### PR TITLE
test(media): share Rastermill metadata setup

### DIFF
--- a/src/media/image-ops.rastermill-adapter.test.ts
+++ b/src/media/image-ops.rastermill-adapter.test.ts
@@ -1,142 +1,169 @@
 // Raster image adapter tests cover image operation integration with RasterMill.
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ImageProbe } from "rastermill";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("image ops Rastermill adapter", () => {
-  beforeEach(() => {
-    vi.resetModules();
-  });
-
-  afterEach(() => {
-    vi.doUnmock("rastermill");
-    vi.doUnmock("@silvia-odwyer/photon-node");
-    vi.doUnmock("../infra/resolve-system-bin.js");
-    vi.resetModules();
-  });
-
-  it("does not load Photon for Rastermill-backed operations", async () => {
-    const actualRastermill = await vi.importActual<typeof import("rastermill")>("rastermill");
-    const encode = vi.fn(async () => ({ data: Buffer.from("jpeg") }));
-    const photonModuleFactory = vi.fn(() => {
-      throw new Error("Photon loaded eagerly");
+  describe("cold processor initialization", () => {
+    beforeEach(() => {
+      vi.resetModules();
     });
 
-    vi.doMock("@silvia-odwyer/photon-node", photonModuleFactory);
-    vi.doMock("rastermill", () => ({
-      ...actualRastermill,
-      createRastermill: vi.fn(() => ({ encode })),
-      readImageMetadataFromHeader: vi.fn(() => ({ width: 1, height: 1 })),
-      readImageProbeFromHeader: vi.fn(() => ({ width: 1, height: 1, format: "jpeg" })),
-    }));
+    afterEach(() => {
+      vi.doUnmock("rastermill");
+      vi.doUnmock("@silvia-odwyer/photon-node");
+      vi.doUnmock("../infra/resolve-system-bin.js");
+      vi.resetModules();
+    });
 
-    const { resizeToJpeg } = await import("./image-ops.js");
+    it("does not load Photon for Rastermill-backed operations", async () => {
+      const actualRastermill = await vi.importActual<typeof import("rastermill")>("rastermill");
+      const encode = vi.fn(async () => ({ data: Buffer.from("jpeg") }));
+      const photonModuleFactory = vi.fn(() => {
+        throw new Error("Photon loaded eagerly");
+      });
 
-    await expect(
-      resizeToJpeg({ buffer: Buffer.from("input"), maxSide: 1, quality: 80 }),
-    ).resolves.toEqual(Buffer.from("jpeg"));
-    expect(photonModuleFactory).not.toHaveBeenCalled();
+      vi.doMock("@silvia-odwyer/photon-node", photonModuleFactory);
+      vi.doMock("rastermill", () => ({
+        ...actualRastermill,
+        createRastermill: vi.fn(() => ({ encode })),
+        readImageMetadataFromHeader: vi.fn(() => ({ width: 1, height: 1 })),
+        readImageProbeFromHeader: vi.fn(() => ({ width: 1, height: 1, format: "jpeg" })),
+      }));
+
+      const { resizeToJpeg } = await import("./image-ops.js");
+
+      await expect(
+        resizeToJpeg({ buffer: Buffer.from("input"), maxSide: 1, quality: 80 }),
+      ).resolves.toEqual(Buffer.from("jpeg"));
+      expect(photonModuleFactory).not.toHaveBeenCalled();
+    });
+
+    it("configures Rastermill with OpenClaw limits, temp root, and command resolution", async () => {
+      const actualRastermill = await vi.importActual<typeof import("rastermill")>("rastermill");
+      const encode = vi.fn(async () => ({ data: Buffer.from("jpeg") }));
+      const createRastermill = vi.fn((_options: unknown) => ({ encode }));
+      const resolveSystemBin = vi.fn(() => "/usr/bin/tool");
+
+      vi.doMock("rastermill", () => ({
+        ...actualRastermill,
+        createRastermill,
+        readImageMetadataFromHeader: vi.fn(() => ({ width: 1, height: 1 })),
+        readImageProbeFromHeader: vi.fn(() => ({ width: 1, height: 1, format: "png" })),
+      }));
+      vi.doMock("../infra/resolve-system-bin.js", () => ({
+        resolveSystemBin,
+      }));
+
+      const { resizeToJpeg, MAX_IMAGE_INPUT_PIXELS } = await import("./image-ops.js");
+
+      await expect(
+        resizeToJpeg({ buffer: Buffer.from("input"), maxSide: 1, quality: 80 }),
+      ).resolves.toEqual(Buffer.from("jpeg"));
+
+      expect(createRastermill).toHaveBeenCalledWith({
+        execution: "auto",
+        limits: {
+          inputPixels: MAX_IMAGE_INPUT_PIXELS,
+          outputPixels: MAX_IMAGE_INPUT_PIXELS,
+        },
+        temp: expect.objectContaining({
+          prefix: "openclaw-img-",
+        }),
+        commandResolver: expect.any(Function),
+      });
+      const options = createRastermill.mock.calls[0]?.[0] as {
+        commandResolver: (command: string) => string | null;
+        env?: unknown;
+      };
+      expect(options.env).toBeUndefined();
+      expect(options.commandResolver("powershell")).toBe("/usr/bin/tool");
+      expect(resolveSystemBin).toHaveBeenLastCalledWith("powershell", { trust: "strict" });
+    });
+
+    it("exposes Rastermill unavailable errors through the SDK alias", async () => {
+      const actualRastermill = await vi.importActual<typeof import("rastermill")>("rastermill");
+      const unavailableError = new actualRastermill.RastermillUnavailableError(
+        "encode",
+        "Image processor unavailable",
+        [new Error("missing backend")],
+      );
+      const createRastermill = vi.fn(() => ({
+        encode: vi.fn(async () => {
+          throw unavailableError;
+        }),
+      }));
+
+      vi.doMock("rastermill", () => ({
+        ...actualRastermill,
+        createRastermill,
+        readImageMetadataFromHeader: vi.fn(() => ({ width: 1, height: 1 })),
+        readImageProbeFromHeader: vi.fn(() => ({ width: 1, height: 1, format: "png" })),
+      }));
+
+      const { isImageProcessorUnavailableError, resizeToJpeg } = await import("./image-ops.js");
+
+      await expect(
+        resizeToJpeg({ buffer: Buffer.from("input"), maxSide: 1, quality: 80 }).then(
+          () => false,
+          (error: unknown) => isImageProcessorUnavailableError(error),
+        ),
+      ).resolves.toBe(true);
+    });
   });
 
-  it("configures Rastermill with OpenClaw limits, temp root, and command resolution", async () => {
-    const actualRastermill = await vi.importActual<typeof import("rastermill")>("rastermill");
-    const encode = vi.fn(async () => ({ data: Buffer.from("jpeg") }));
-    const createRastermill = vi.fn((_options: unknown) => ({ encode }));
-    const resolveSystemBin = vi.fn(() => "/usr/bin/tool");
+  describe("display metadata", () => {
+    const probe = vi.fn<() => Promise<ImageProbe | null>>();
+    const readProbe = vi.fn<() => ImageProbe | null>();
+    let imageOps: typeof import("./image-ops.js");
 
-    vi.doMock("rastermill", () => ({
-      ...actualRastermill,
-      createRastermill,
-      readImageMetadataFromHeader: vi.fn(() => ({ width: 1, height: 1 })),
-      readImageProbeFromHeader: vi.fn(() => ({ width: 1, height: 1, format: "png" })),
-    }));
-    vi.doMock("../infra/resolve-system-bin.js", () => ({
-      resolveSystemBin,
-    }));
+    beforeAll(async () => {
+      vi.resetModules();
+      const actualRastermill = await vi.importActual<typeof import("rastermill")>("rastermill");
+      vi.doMock("rastermill", () => ({
+        ...actualRastermill,
+        createRastermill: vi.fn(() => ({ probe })),
+        readImageProbeFromHeader: readProbe,
+      }));
+      imageOps = await import("./image-ops.js");
+    });
 
-    const { resizeToJpeg, MAX_IMAGE_INPUT_PIXELS } = await import("./image-ops.js");
+    beforeEach(() => {
+      probe.mockReset();
+      readProbe.mockReset();
+    });
 
-    await expect(
-      resizeToJpeg({ buffer: Buffer.from("input"), maxSide: 1, quality: 80 }),
-    ).resolves.toEqual(Buffer.from("jpeg"));
+    afterAll(() => {
+      vi.doUnmock("rastermill");
+      vi.resetModules();
+    });
 
-    expect(createRastermill).toHaveBeenCalledWith({
-      execution: "auto",
-      limits: {
-        inputPixels: MAX_IMAGE_INPUT_PIXELS,
-        outputPixels: MAX_IMAGE_INPUT_PIXELS,
+    it.each([
+      { orientation: null, expected: { width: 640, height: 480 } },
+      { orientation: 1, expected: { width: 640, height: 480 } },
+      { orientation: 4, expected: { width: 640, height: 480 } },
+      { orientation: 5, expected: { width: 480, height: 640 } },
+      { orientation: 6, expected: { width: 480, height: 640 } },
+      { orientation: 7, expected: { width: 480, height: 640 } },
+      { orientation: 8, expected: { width: 480, height: 640 } },
+    ] as const)(
+      "reports display dimensions for EXIF orientation $orientation",
+      async (testCase) => {
+        const imageProbe = {
+          width: 640,
+          height: 480,
+          format: "jpeg" as const,
+          hasAlpha: false,
+          orientation: testCase.orientation,
+          bytes: 24,
+        };
+        probe.mockResolvedValue(imageProbe);
+        readProbe.mockReturnValue(imageProbe);
+        const image = Buffer.from("image");
+
+        expect(imageOps.readImageMetadataFromHeader(image)).toEqual(testCase.expected);
+        await expect(imageOps.getImageMetadata(image)).resolves.toEqual(testCase.expected);
+        expect(imageOps.readImageProbeFromHeader(image)).toEqual(imageProbe);
       },
-      temp: expect.objectContaining({
-        prefix: "openclaw-img-",
-      }),
-      commandResolver: expect.any(Function),
-    });
-    const options = createRastermill.mock.calls[0]?.[0] as {
-      commandResolver: (command: string) => string | null;
-      env?: unknown;
-    };
-    expect(options.env).toBeUndefined();
-    expect(options.commandResolver("powershell")).toBe("/usr/bin/tool");
-    expect(resolveSystemBin).toHaveBeenLastCalledWith("powershell", { trust: "strict" });
-  });
-
-  it.each([
-    { orientation: null, expected: { width: 640, height: 480 } },
-    { orientation: 1, expected: { width: 640, height: 480 } },
-    { orientation: 4, expected: { width: 640, height: 480 } },
-    { orientation: 5, expected: { width: 480, height: 640 } },
-    { orientation: 6, expected: { width: 480, height: 640 } },
-    { orientation: 7, expected: { width: 480, height: 640 } },
-    { orientation: 8, expected: { width: 480, height: 640 } },
-  ] as const)("reports display dimensions for EXIF orientation $orientation", async (testCase) => {
-    const actualRastermill = await vi.importActual<typeof import("rastermill")>("rastermill");
-    const probe = {
-      width: 640,
-      height: 480,
-      format: "jpeg" as const,
-      hasAlpha: false,
-      orientation: testCase.orientation,
-      bytes: 24,
-    };
-    vi.doMock("rastermill", () => ({
-      ...actualRastermill,
-      createRastermill: vi.fn(() => ({ probe: vi.fn(async () => probe) })),
-      readImageProbeFromHeader: vi.fn(() => probe),
-    }));
-    const { getImageMetadata, readImageMetadataFromHeader, readImageProbeFromHeader } =
-      await import("./image-ops.js");
-    const image = Buffer.from("image");
-
-    expect(readImageMetadataFromHeader(image)).toEqual(testCase.expected);
-    await expect(getImageMetadata(image)).resolves.toEqual(testCase.expected);
-    expect(readImageProbeFromHeader(image)).toEqual(probe);
-  });
-
-  it("exposes Rastermill unavailable errors through the SDK alias", async () => {
-    const actualRastermill = await vi.importActual<typeof import("rastermill")>("rastermill");
-    const unavailableError = new actualRastermill.RastermillUnavailableError(
-      "encode",
-      "Image processor unavailable",
-      [new Error("missing backend")],
     );
-    const createRastermill = vi.fn(() => ({
-      encode: vi.fn(async () => {
-        throw unavailableError;
-      }),
-    }));
-
-    vi.doMock("rastermill", () => ({
-      ...actualRastermill,
-      createRastermill,
-      readImageMetadataFromHeader: vi.fn(() => ({ width: 1, height: 1 })),
-      readImageProbeFromHeader: vi.fn(() => ({ width: 1, height: 1, format: "png" })),
-    }));
-
-    const { isImageProcessorUnavailableError, resizeToJpeg } = await import("./image-ops.js");
-
-    await expect(
-      resizeToJpeg({ buffer: Buffer.from("input"), maxSide: 1, quality: 80 }).then(
-        () => false,
-        (error: unknown) => isImageProcessorUnavailableError(error),
-      ),
-    ).resolves.toBe(true);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Seven EXIF metadata cases repeatedly import the same Rastermill adapter and reset its module graph even though only their probe result changes.

## Why This Change Was Made

Give those seven independently reported cases one suite setup, with fresh probe mock state per row. Keep the three cold processor cases in their own per-case reset/unmock scope, preserving the historical cross-file isolation repair and actual-package partial mocks.

## User Impact

Test-only: no image behavior change. Adapter/package imports drop from ten to four and module resets from twenty to eight. No elapsed-time gain is claimed. All ten cases and 29 expanded assertions remain, including both metadata paths, raw probe identity, lazy Photon loading, processor options and unavailable-error identity.

## Evidence

The full current media project passes before and after: 485 passed, nine existing skipped across 27 files. All original adapter labels remain; the unavailable-error case moves before metadata to keep cold setup together. Full changed checks and Codex autoreview pass.

Source review covered the adapter, sanitizer caller and siblings, lazy/temp/command owners, installed Rastermill 0.3.2 probe/EXIF contracts, and historical isolation/display-axis fixes. Production +0/-0; tests +153/-126, primarily nesting/moving existing cases.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs --config test/vitest/vitest.media.config.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base 9597f653c438302523f6ea1b6dfa80f0b1fb92cb
```

