### PR TITLE
fix(infra): expire stale presence after clock rollback

### DIFF
--- a/src/gateway/server/client-presence.test.ts
+++ b/src/gateway/server/client-presence.test.ts
@@ -62,10 +62,12 @@ describe("live person presence timing", () => {
 
   const clients = new GatewayClientRegistry();
   const sockets: ReturnType<typeof attachGatewayWsForTest>["socket"][] = [];
+  let nextTestTime = new Date("2040-01-01T00:00:00Z").getTime();
 
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2040-01-01T00:00:00Z"));
+    vi.setSystemTime(nextTestTime);
+    nextTestTime += 24 * 60 * 60 * 1000;
     attachMessageHandler.mockClear();
   });
   afterEach(() => {

--- a/src/infra/system-presence.test.ts
+++ b/src/infra/system-presence.test.ts
@@ -1,5 +1,6 @@
 // Covers in-memory system presence merging and expiry behavior.
 import { randomUUID } from "node:crypto";
+import os from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   listSystemPresence,
@@ -8,12 +9,26 @@ import {
   upsertPresence,
 } from "./system-presence.js";
 
+function useFakePerformanceClock() {
+  vi.useFakeTimers();
+  vi.spyOn(os, "uptime").mockReturnValue(0);
+}
+
+function useFakeSuspendClock() {
+  const clock = { monotonic: performance.now(), uptime: os.uptime() };
+  vi.useFakeTimers();
+  vi.spyOn(performance, "now").mockImplementation(() => clock.monotonic);
+  vi.spyOn(os, "uptime").mockImplementation(() => clock.uptime);
+  return clock;
+}
+
 describe("system-presence", () => {
   afterEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(Date.now() + 5 * 60 * 1000 + 1);
     listSystemPresence();
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("dedupes entries across sources by case-insensitive instanceId key", () => {
@@ -94,7 +109,7 @@ describe("system-presence", () => {
   });
 
   it("parses node presence text and normalizes the update key", () => {
-    vi.useFakeTimers();
+    useFakePerformanceClock();
     vi.setSystemTime(new Date("2026-05-11T04:00:00.000Z"));
     const update = updateSystemPresence({
       text: "Node: Relay-Host (10.0.0.9) · app 2.1.0 · last input 7s ago · mode ui · reason beacon",
@@ -153,7 +168,7 @@ describe("system-presence", () => {
   });
 
   it("keeps connection-owned presence alive when its heartbeat is acknowledged", () => {
-    vi.useFakeTimers();
+    useFakePerformanceClock();
     vi.setSystemTime(Date.now());
 
     const connectionId = randomUUID();
@@ -172,7 +187,7 @@ describe("system-presence", () => {
   });
 
   it("prunes stale non-self entries after TTL", () => {
-    vi.useFakeTimers();
+    useFakePerformanceClock();
     vi.setSystemTime(Date.now());
 
     const deviceId = randomUUID();
@@ -193,7 +208,7 @@ describe("system-presence", () => {
   });
 
   it("keeps the gateway when the clock jumps forward during expiry pruning", () => {
-    vi.useFakeTimers();
+    useFakePerformanceClock();
     const now = Date.now();
     const self = listSystemPresence().find((entry) => entry.reason === "self");
     expect(self?.instanceId).toBeDefined();
@@ -218,7 +233,7 @@ describe("system-presence", () => {
   }
 
   it("counts the gateway within the capacity limit when peers have tied timestamps", () => {
-    vi.useFakeTimers();
+    useFakePerformanceClock();
     vi.setSystemTime(Date.now() + 24 * 60 * 60 * 1000);
     const self = listSystemPresence().find((entry) => entry.reason === "self");
     expect(self?.instanceId).toBeDefined();
@@ -235,7 +250,7 @@ describe("system-presence", () => {
   it.each(["connection", "beacon"] as const)(
     "keeps the genuine gateway row when a %s uses its hostname key",
     (source) => {
-      vi.useFakeTimers();
+      useFakePerformanceClock();
       vi.setSystemTime(Date.now() + 24 * 60 * 60 * 1000);
       const self = listSystemPresence().find((entry) => entry.reason === "self");
       if (!self?.host || !self.instanceId) {
@@ -265,4 +280,221 @@ describe("system-presence", () => {
       expect(bounded.some((entry) => entry.text === forged.text)).toBe(false);
     },
   );
+
+  it("prunes stale non-self entries after a forward wall-clock jump", () => {
+    useFakePerformanceClock();
+    const initialTime = Date.now() + 24 * 60 * 60 * 1000;
+    vi.setSystemTime(initialTime);
+
+    const deviceId = randomUUID();
+    upsertPresence(deviceId, {
+      deviceId,
+      host: "suspended-stale-host",
+      mode: "ui",
+      reason: "connect",
+    });
+
+    vi.setSystemTime(initialTime + 5 * 60 * 1000 + 1);
+
+    expect(listSystemPresence().map((entry) => entry.deviceId)).not.toContain(deviceId);
+  });
+
+  it("preserves freshness across clock rollback without extending the TTL", () => {
+    useFakePerformanceClock();
+    const initialTime = Date.now();
+    vi.setSystemTime(initialTime);
+
+    const deviceId = randomUUID();
+    upsertPresence(deviceId, {
+      deviceId,
+      host: "rollback-stale-host",
+      mode: "ui",
+      reason: "connect",
+    });
+
+    vi.setSystemTime(initialTime - 60 * 60 * 1000);
+
+    expect(listSystemPresence().map((entry) => entry.deviceId)).toContain(deviceId);
+
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    const entries = listSystemPresence();
+    expect(entries.map((entry) => entry.deviceId)).not.toContain(deviceId);
+    expect(entries.map((entry) => entry.reason)).toContain("self");
+  });
+
+  it("keeps a rolled-clock refresh fresh when wall time recovers", () => {
+    useFakePerformanceClock();
+    const initialTime = Date.now();
+    vi.setSystemTime(initialTime);
+
+    const deviceId = randomUUID();
+    upsertPresence(deviceId, {
+      deviceId,
+      host: "rollback-refresh-host",
+      mode: "ui",
+      reason: "connect",
+    });
+
+    const rolledTime = initialTime - 60 * 60 * 1000;
+    vi.setSystemTime(rolledTime);
+    expect(touchPresence(deviceId)).toBe(true);
+    expect(listSystemPresence().find((entry) => entry.deviceId === deviceId)?.ts).toBe(rolledTime);
+
+    vi.advanceTimersByTime(1000);
+    vi.setSystemTime(initialTime);
+
+    expect(listSystemPresence().map((entry) => entry.deviceId)).toContain(deviceId);
+
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    expect(listSystemPresence().map((entry) => entry.deviceId)).not.toContain(deviceId);
+  });
+
+  it("keeps presence created during rollback fresh when wall time recovers", () => {
+    useFakePerformanceClock();
+    const initialTime = Date.now();
+    vi.setSystemTime(initialTime);
+    listSystemPresence();
+
+    const deviceId = randomUUID();
+    const rolledTime = initialTime - 60 * 60 * 1000;
+    vi.setSystemTime(rolledTime);
+    upsertPresence(deviceId, {
+      deviceId,
+      host: "rollback-created-host",
+      mode: "ui",
+      reason: "connect",
+    });
+
+    vi.advanceTimersByTime(60 * 1000);
+    vi.setSystemTime(initialTime + 60 * 1000);
+
+    const recovered = listSystemPresence().find((entry) => entry.deviceId === deviceId);
+    expect(recovered?.ts).toBe(rolledTime);
+
+    vi.advanceTimersByTime(4 * 60 * 1000 + 1);
+
+    expect(listSystemPresence().map((entry) => entry.deviceId)).not.toContain(deviceId);
+  });
+
+  it("expires presence suspended while the wall clock remains rolled back", () => {
+    const clock = useFakeSuspendClock();
+    const initialTime = Date.now();
+    vi.setSystemTime(initialTime);
+    listSystemPresence();
+
+    const deviceId = randomUUID();
+    const rolledTime = initialTime - 60 * 60 * 1000;
+    vi.setSystemTime(rolledTime);
+    upsertPresence(deviceId, {
+      deviceId,
+      host: "rollback-suspended-host",
+      mode: "ui",
+      reason: "connect",
+    });
+
+    clock.uptime += 5 * 60 + 0.001;
+    vi.setSystemTime(rolledTime + 5 * 60 * 1000 + 1);
+
+    expect(listSystemPresence().map((entry) => entry.deviceId)).not.toContain(deviceId);
+  });
+
+  it("gives a suspended rollback refresh a full TTL through recovery", () => {
+    const clock = useFakeSuspendClock();
+    const initialTime = Date.now();
+    vi.setSystemTime(initialTime);
+    listSystemPresence();
+
+    const deviceId = randomUUID();
+    const rolledTime = initialTime - 60 * 60 * 1000;
+    vi.setSystemTime(rolledTime);
+    upsertPresence(deviceId, {
+      deviceId,
+      host: "rollback-suspended-refresh-host",
+      mode: "ui",
+      reason: "connect",
+    });
+
+    clock.uptime += 60;
+    vi.setSystemTime(rolledTime + 60 * 1000);
+    expect(touchPresence(deviceId)).toBe(true);
+    vi.setSystemTime(initialTime + 60 * 1000);
+
+    expect(listSystemPresence().map((entry) => entry.deviceId)).toContain(deviceId);
+    clock.monotonic += 4 * 60 * 1000 + 1;
+    clock.uptime += 4 * 60 + 0.001;
+    vi.advanceTimersByTime(4 * 60 * 1000 + 1);
+    expect(listSystemPresence().map((entry) => entry.deviceId)).toContain(deviceId);
+    clock.monotonic += 60 * 1000;
+    clock.uptime += 60;
+    vi.advanceTimersByTime(60 * 1000);
+    expect(listSystemPresence().map((entry) => entry.deviceId)).not.toContain(deviceId);
+  });
+
+  it("advances logical freshness across repeated rolled-clock refreshes", () => {
+    useFakePerformanceClock();
+    const initialTime = Date.now();
+    vi.setSystemTime(initialTime);
+
+    const deviceId = randomUUID();
+    upsertPresence(deviceId, {
+      deviceId,
+      host: "rollback-repeated-refresh-host",
+      mode: "ui",
+      reason: "connect",
+    });
+
+    const rolledTime = initialTime - 60 * 60 * 1000;
+    vi.setSystemTime(rolledTime);
+    for (let minute = 1; minute <= 6; minute += 1) {
+      vi.advanceTimersByTime(60 * 1000);
+      expect(touchPresence(deviceId)).toBe(true);
+    }
+    expect(listSystemPresence().find((entry) => entry.deviceId === deviceId)?.ts).toBe(
+      rolledTime + 6 * 60 * 1000,
+    );
+
+    vi.setSystemTime(initialTime + 6 * 60 * 1000);
+
+    expect(listSystemPresence().map((entry) => entry.deviceId)).toContain(deviceId);
+
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    expect(listSystemPresence().map((entry) => entry.deviceId)).not.toContain(deviceId);
+  });
+
+  it("evicts pre-rollback presence before fresh rolled-clock entries", () => {
+    useFakePerformanceClock();
+    const initialTime = Date.now() + 24 * 60 * 60 * 1000;
+    vi.setSystemTime(initialTime);
+    listSystemPresence();
+
+    const staleDeviceId = `rollback-old-${randomUUID()}`;
+    upsertPresence(staleDeviceId, {
+      deviceId: staleDeviceId,
+      host: "rollback-old-host",
+      mode: "ui",
+      reason: "connect",
+    });
+
+    vi.setSystemTime(initialTime - 60 * 60 * 1000);
+    vi.advanceTimersByTime(1);
+    listSystemPresence();
+
+    const freshPrefix = `rollback-fresh-${randomUUID()}-`;
+    for (let index = 0; index < 200; index += 1) {
+      upsertPresence(`${freshPrefix}${index}`, {
+        deviceId: `${freshPrefix}${index}`,
+        host: `rollback-fresh-host-${index}`,
+        mode: "ui",
+        reason: "connect",
+      });
+    }
+
+    const entries = listSystemPresence();
+    expect(entries.map((entry) => entry.deviceId)).not.toContain(staleDeviceId);
+    expect(entries.filter((entry) => entry.deviceId?.startsWith(freshPrefix))).toHaveLength(199);
+    expect(entries.map((entry) => entry.reason)).toContain("self");
+  });
 });

--- a/src/infra/system-presence.test.ts
+++ b/src/infra/system-presence.test.ts
@@ -283,7 +283,7 @@ describe("system-presence", () => {
 
   it("prunes stale non-self entries after a forward wall-clock jump", () => {
     useFakePerformanceClock();
-    const initialTime = Date.now() + 24 * 60 * 60 * 1000;
+    const initialTime = Date.now() + 48 * 60 * 60 * 1000;
     vi.setSystemTime(initialTime);
 
     const deviceId = randomUUID();
@@ -323,60 +323,48 @@ describe("system-presence", () => {
     expect(entries.map((entry) => entry.reason)).toContain("self");
   });
 
-  it("keeps a rolled-clock refresh fresh when wall time recovers", () => {
-    useFakePerformanceClock();
-    const initialTime = Date.now();
-    vi.setSystemTime(initialTime);
+  it.each(["created", "refreshed"] as const)(
+    "keeps presence %s during rollback fresh when wall time recovers",
+    (action) => {
+      useFakePerformanceClock();
+      const initialTime = Date.now();
+      const forwardTime = initialTime + 24 * 60 * 60 * 1000;
+      vi.setSystemTime(forwardTime);
+      listSystemPresence();
 
-    const deviceId = randomUUID();
-    upsertPresence(deviceId, {
-      deviceId,
-      host: "rollback-refresh-host",
-      mode: "ui",
-      reason: "connect",
-    });
+      const deviceId = randomUUID();
+      const rolledTime = initialTime - 60 * 60 * 1000;
+      if (action === "refreshed") {
+        upsertPresence(deviceId, {
+          deviceId,
+          host: "rollback-refresh-host",
+          mode: "ui",
+          reason: "connect",
+        });
+      }
+      vi.setSystemTime(rolledTime);
+      if (action === "created") {
+        upsertPresence(deviceId, {
+          deviceId,
+          host: "rollback-created-host",
+          mode: "ui",
+          reason: "connect",
+        });
+      } else {
+        expect(touchPresence(deviceId)).toBe(true);
+      }
 
-    const rolledTime = initialTime - 60 * 60 * 1000;
-    vi.setSystemTime(rolledTime);
-    expect(touchPresence(deviceId)).toBe(true);
-    expect(listSystemPresence().find((entry) => entry.deviceId === deviceId)?.ts).toBe(rolledTime);
+      vi.advanceTimersByTime(60 * 1000);
+      vi.setSystemTime(forwardTime + 60 * 1000);
 
-    vi.advanceTimersByTime(1000);
-    vi.setSystemTime(initialTime);
+      const recovered = listSystemPresence().find((entry) => entry.deviceId === deviceId);
+      expect(recovered?.ts).toBe(rolledTime);
 
-    expect(listSystemPresence().map((entry) => entry.deviceId)).toContain(deviceId);
+      vi.advanceTimersByTime(4 * 60 * 1000 + 1);
 
-    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
-
-    expect(listSystemPresence().map((entry) => entry.deviceId)).not.toContain(deviceId);
-  });
-
-  it("keeps presence created during rollback fresh when wall time recovers", () => {
-    useFakePerformanceClock();
-    const initialTime = Date.now();
-    vi.setSystemTime(initialTime);
-    listSystemPresence();
-
-    const deviceId = randomUUID();
-    const rolledTime = initialTime - 60 * 60 * 1000;
-    vi.setSystemTime(rolledTime);
-    upsertPresence(deviceId, {
-      deviceId,
-      host: "rollback-created-host",
-      mode: "ui",
-      reason: "connect",
-    });
-
-    vi.advanceTimersByTime(60 * 1000);
-    vi.setSystemTime(initialTime + 60 * 1000);
-
-    const recovered = listSystemPresence().find((entry) => entry.deviceId === deviceId);
-    expect(recovered?.ts).toBe(rolledTime);
-
-    vi.advanceTimersByTime(4 * 60 * 1000 + 1);
-
-    expect(listSystemPresence().map((entry) => entry.deviceId)).not.toContain(deviceId);
-  });
+      expect(listSystemPresence().map((entry) => entry.deviceId)).not.toContain(deviceId);
+    },
+  );
 
   it("expires presence suspended while the wall clock remains rolled back", () => {
     const clock = useFakeSuspendClock();
@@ -394,96 +382,38 @@ describe("system-presence", () => {
       reason: "connect",
     });
 
-    clock.uptime += 5 * 60 + 0.001;
-    vi.setSystemTime(rolledTime + 5 * 60 * 1000 + 1);
+    clock.uptime += 5 * 60 + 1;
 
     expect(listSystemPresence().map((entry) => entry.deviceId)).not.toContain(deviceId);
   });
 
-  it("gives a suspended rollback refresh a full TTL through recovery", () => {
+  it("evicts stale presence before a peer refreshed during suspend and rollback", () => {
     const clock = useFakeSuspendClock();
-    const initialTime = Date.now();
-    vi.setSystemTime(initialTime);
-    listSystemPresence();
-
-    const deviceId = randomUUID();
-    const rolledTime = initialTime - 60 * 60 * 1000;
-    vi.setSystemTime(rolledTime);
-    upsertPresence(deviceId, {
-      deviceId,
-      host: "rollback-suspended-refresh-host",
-      mode: "ui",
-      reason: "connect",
-    });
-
-    clock.uptime += 60;
-    vi.setSystemTime(rolledTime + 60 * 1000);
-    expect(touchPresence(deviceId)).toBe(true);
-    vi.setSystemTime(initialTime + 60 * 1000);
-
-    expect(listSystemPresence().map((entry) => entry.deviceId)).toContain(deviceId);
-    clock.monotonic += 4 * 60 * 1000 + 1;
-    clock.uptime += 4 * 60 + 0.001;
-    vi.advanceTimersByTime(4 * 60 * 1000 + 1);
-    expect(listSystemPresence().map((entry) => entry.deviceId)).toContain(deviceId);
-    clock.monotonic += 60 * 1000;
-    clock.uptime += 60;
-    vi.advanceTimersByTime(60 * 1000);
-    expect(listSystemPresence().map((entry) => entry.deviceId)).not.toContain(deviceId);
-  });
-
-  it("advances logical freshness across repeated rolled-clock refreshes", () => {
-    useFakePerformanceClock();
-    const initialTime = Date.now();
-    vi.setSystemTime(initialTime);
-
-    const deviceId = randomUUID();
-    upsertPresence(deviceId, {
-      deviceId,
-      host: "rollback-repeated-refresh-host",
-      mode: "ui",
-      reason: "connect",
-    });
-
-    const rolledTime = initialTime - 60 * 60 * 1000;
-    vi.setSystemTime(rolledTime);
-    for (let minute = 1; minute <= 6; minute += 1) {
-      vi.advanceTimersByTime(60 * 1000);
-      expect(touchPresence(deviceId)).toBe(true);
-    }
-    expect(listSystemPresence().find((entry) => entry.deviceId === deviceId)?.ts).toBe(
-      rolledTime + 6 * 60 * 1000,
-    );
-
-    vi.setSystemTime(initialTime + 6 * 60 * 1000);
-
-    expect(listSystemPresence().map((entry) => entry.deviceId)).toContain(deviceId);
-
-    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
-
-    expect(listSystemPresence().map((entry) => entry.deviceId)).not.toContain(deviceId);
-  });
-
-  it("evicts pre-rollback presence before fresh rolled-clock entries", () => {
-    useFakePerformanceClock();
     const initialTime = Date.now() + 24 * 60 * 60 * 1000;
     vi.setSystemTime(initialTime);
     listSystemPresence();
 
-    const staleDeviceId = `rollback-old-${randomUUID()}`;
+    const refreshedDeviceId = `rollback-refreshed-${randomUUID()}`;
+    upsertPresence(refreshedDeviceId, {
+      deviceId: refreshedDeviceId,
+      host: "rollback-refreshed-host",
+      mode: "ui",
+      reason: "connect",
+    });
+    const staleDeviceId = `rollback-stale-${randomUUID()}`;
     upsertPresence(staleDeviceId, {
       deviceId: staleDeviceId,
-      host: "rollback-old-host",
+      host: "rollback-stale-host",
       mode: "ui",
       reason: "connect",
     });
 
     vi.setSystemTime(initialTime - 60 * 60 * 1000);
-    vi.advanceTimersByTime(1);
-    listSystemPresence();
+    clock.uptime += 1;
+    expect(touchPresence(refreshedDeviceId)).toBe(true);
 
     const freshPrefix = `rollback-fresh-${randomUUID()}-`;
-    for (let index = 0; index < 200; index += 1) {
+    for (let index = 0; index < 198; index += 1) {
       upsertPresence(`${freshPrefix}${index}`, {
         deviceId: `${freshPrefix}${index}`,
         host: `rollback-fresh-host-${index}`,
@@ -494,7 +424,8 @@ describe("system-presence", () => {
 
     const entries = listSystemPresence();
     expect(entries.map((entry) => entry.deviceId)).not.toContain(staleDeviceId);
-    expect(entries.filter((entry) => entry.deviceId?.startsWith(freshPrefix))).toHaveLength(199);
+    expect(entries.map((entry) => entry.deviceId)).toContain(refreshedDeviceId);
+    expect(entries.filter((entry) => entry.deviceId?.startsWith(freshPrefix))).toHaveLength(198);
     expect(entries.map((entry) => entry.reason)).toContain("self");
   });
 });

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -46,33 +46,37 @@ type SystemPresenceUpdate = {
   changedKeys: (keyof SystemPresence)[];
 };
 
+type StoredPresence = {
+  presence: SystemPresence;
+  freshness: number;
+};
+
 // The gateway owns a private key; caller-supplied string identities remain peers.
 const SELF_KEY = Symbol("system-presence-self");
-const entries = new Map<string | symbol, SystemPresence>();
-const freshnessAt = new WeakMap<SystemPresence, { monotonic: number; wall: number }>();
+const entries = new Map<string | symbol, StoredPresence>();
 const TTL_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_ENTRIES = 200;
 const SELF_INSTANCE_ID = randomUUID();
 const uptimeOrigin = os.uptime() * 1000 - performance.now();
+let freshnessTime = Date.now();
+let freshnessSample = continuousTimeNow();
 
-function freshnessNow(): number {
-  // System uptime includes suspend without following wall-clock adjustments.
+function continuousTimeNow(): number {
+  // Uptime covers suspend on platforms where the high-resolution clock pauses.
   return Math.max(performance.now(), os.uptime() * 1000 - uptimeOrigin);
 }
 
+function freshnessNow(): number {
+  const sample = continuousTimeNow();
+  const elapsed = Math.max(0, sample - freshnessSample);
+  freshnessSample = sample;
+  // Preserve forward-clock expiry while continuous elapsed keeps rollback and suspend moving.
+  freshnessTime = Math.max(Date.now(), freshnessTime + elapsed);
+  return freshnessTime;
+}
+
 function setPresence(key: string | symbol, presence: SystemPresence) {
-  const previous = entries.get(key);
-  const monotonic = freshnessNow();
-  const previousFreshness = previous ? freshnessAt.get(previous) : undefined;
-  // Keep logical wall freshness monotonic across rollback/recovery while public ts follows heartbeat time.
-  const wall = Math.max(
-    presence.ts,
-    previousFreshness
-      ? previousFreshness.wall + Math.max(0, monotonic - previousFreshness.monotonic)
-      : performance.timeOrigin + monotonic,
-  );
-  entries.set(key, presence);
-  freshnessAt.set(presence, { monotonic, wall });
+  entries.set(key, { presence, freshness: freshnessNow() });
 }
 
 function normalizePresenceKey(key: string | undefined): string | undefined {
@@ -142,7 +146,7 @@ function initSelfPresence() {
 }
 
 function touchSelfPresence() {
-  const existing = entries.get(SELF_KEY);
+  const existing = entries.get(SELF_KEY)?.presence;
   if (existing) {
     setPresence(SELF_KEY, { ...existing, ts: Date.now() });
   } else {
@@ -230,7 +234,7 @@ export function updateSystemPresence(payload: SystemPresencePayload): SystemPres
     truncateUtf16Safe(parsed.text, 64) ||
     normalizeLowercaseStringOrEmpty(os.hostname());
   const hadExisting = entries.has(key);
-  const existing = entries.get(key) ?? ({} as SystemPresence);
+  const existing = entries.get(key)?.presence ?? ({} as SystemPresence);
   const merged: SystemPresence = {
     ...existing,
     ...parsed,
@@ -277,7 +281,7 @@ export function updateSystemPresence(payload: SystemPresencePayload): SystemPres
 
 export function upsertPresence(key: string, presence: Partial<SystemPresence>) {
   const normalizedKey = normalizePresenceKey(key) ?? normalizeLowercaseStringOrEmpty(os.hostname());
-  const existing = entries.get(normalizedKey) ?? ({} as SystemPresence);
+  const existing = entries.get(normalizedKey)?.presence ?? ({} as SystemPresence);
   const roles = mergeStringList(existing.roles, presence.roles);
   const scopes = mergeStringList(existing.scopes, presence.scopes);
   const merged: SystemPresence = {
@@ -302,7 +306,7 @@ export function touchPresence(key: string): boolean {
   if (!normalizedKey) {
     return false;
   }
-  const existing = entries.get(normalizedKey);
+  const existing = entries.get(normalizedKey)?.presence;
   if (!existing) {
     return false;
   }
@@ -312,33 +316,21 @@ export function touchPresence(key: string): boolean {
 
 export function listSystemPresence(): SystemPresence[] {
   touchSelfPresence();
-  const wallNow = Date.now();
-  const monotonicNow = freshnessNow();
-  for (const [k, v] of entries) {
-    const freshness = freshnessAt.get(v);
-    // Wall time covers forward jumps; continuous time covers rollback and suspend.
-    if (
-      k !== SELF_KEY &&
-      (freshness === undefined ||
-        wallNow - freshness.wall > TTL_MS ||
-        monotonicNow - freshness.monotonic > TTL_MS)
-    ) {
-      entries.delete(k);
+  const now = freshnessNow();
+  for (const [key, entry] of entries) {
+    if (key !== SELF_KEY && now - entry.freshness > TTL_MS) {
+      entries.delete(key);
     }
   }
-  // Enforce max size by the same monotonic freshness used for expiry.
+  // Expiry and capacity share one freshness order even when public timestamps roll back.
   if (entries.size > MAX_ENTRIES) {
     const sorted = [...entries.entries()]
       .filter(([key]) => key !== SELF_KEY)
-      .toSorted(
-        (a, b) =>
-          (freshnessAt.get(a[1])?.monotonic ?? Number.NEGATIVE_INFINITY) -
-          (freshnessAt.get(b[1])?.monotonic ?? Number.NEGATIVE_INFINITY),
-      );
+      .toSorted((a, b) => a[1].freshness - b[1].freshness);
     const toDrop = entries.size - MAX_ENTRIES;
     for (const [key] of sorted.slice(0, toDrop)) {
       entries.delete(key);
     }
   }
-  return [...entries.values()].toSorted((a, b) => b.ts - a.ts);
+  return [...entries.values()].map((entry) => entry.presence).toSorted((a, b) => b.ts - a.ts);
 }

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -49,9 +49,31 @@ type SystemPresenceUpdate = {
 // The gateway owns a private key; caller-supplied string identities remain peers.
 const SELF_KEY = Symbol("system-presence-self");
 const entries = new Map<string | symbol, SystemPresence>();
+const freshnessAt = new WeakMap<SystemPresence, { monotonic: number; wall: number }>();
 const TTL_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_ENTRIES = 200;
 const SELF_INSTANCE_ID = randomUUID();
+const uptimeOrigin = os.uptime() * 1000 - performance.now();
+
+function freshnessNow(): number {
+  // System uptime includes suspend without following wall-clock adjustments.
+  return Math.max(performance.now(), os.uptime() * 1000 - uptimeOrigin);
+}
+
+function setPresence(key: string | symbol, presence: SystemPresence) {
+  const previous = entries.get(key);
+  const monotonic = freshnessNow();
+  const previousFreshness = previous ? freshnessAt.get(previous) : undefined;
+  // Keep logical wall freshness monotonic across rollback/recovery while public ts follows heartbeat time.
+  const wall = Math.max(
+    presence.ts,
+    previousFreshness
+      ? previousFreshness.wall + Math.max(0, monotonic - previousFreshness.monotonic)
+      : performance.timeOrigin + monotonic,
+  );
+  entries.set(key, presence);
+  freshnessAt.set(presence, { monotonic, wall });
+}
 
 function normalizePresenceKey(key: string | undefined): string | undefined {
   return normalizeOptionalLowercaseString(key);
@@ -116,13 +138,13 @@ function initSelfPresence() {
     text,
     ts: Date.now(),
   };
-  entries.set(SELF_KEY, selfEntry);
+  setPresence(SELF_KEY, selfEntry);
 }
 
 function touchSelfPresence() {
   const existing = entries.get(SELF_KEY);
   if (existing) {
-    entries.set(SELF_KEY, { ...existing, ts: Date.now() });
+    setPresence(SELF_KEY, { ...existing, ts: Date.now() });
   } else {
     initSelfPresence();
   }
@@ -231,7 +253,7 @@ export function updateSystemPresence(payload: SystemPresencePayload): SystemPres
     text: payload.text || parsed.text || existing.text,
     ts: Date.now(),
   };
-  entries.set(key, merged);
+  setPresence(key, merged);
   const trackKeys = ["host", "ip", "version", "mode", "reason"] as const;
   type TrackKey = (typeof trackKeys)[number];
   const changes: Partial<Pick<SystemPresence, TrackKey>> = {};
@@ -271,7 +293,7 @@ export function upsertPresence(key: string, presence: Partial<SystemPresence>) {
         presence.mode ?? existing.mode ?? "unknown"
       }`,
   };
-  entries.set(normalizedKey, merged);
+  setPresence(normalizedKey, merged);
 }
 
 /** Renews an existing connection-owned presence row without recreating expired metadata. */
@@ -284,24 +306,35 @@ export function touchPresence(key: string): boolean {
   if (!existing) {
     return false;
   }
-  entries.set(normalizedKey, { ...existing, ts: Date.now() });
+  setPresence(normalizedKey, { ...existing, ts: Date.now() });
   return true;
 }
 
 export function listSystemPresence(): SystemPresence[] {
   touchSelfPresence();
-  // prune expired
-  const now = Date.now();
+  const wallNow = Date.now();
+  const monotonicNow = freshnessNow();
   for (const [k, v] of entries) {
-    if (k !== SELF_KEY && now - v.ts > TTL_MS) {
+    const freshness = freshnessAt.get(v);
+    // Wall time covers forward jumps; continuous time covers rollback and suspend.
+    if (
+      k !== SELF_KEY &&
+      (freshness === undefined ||
+        wallNow - freshness.wall > TTL_MS ||
+        monotonicNow - freshness.monotonic > TTL_MS)
+    ) {
       entries.delete(k);
     }
   }
-  // enforce max size (LRU by ts)
+  // Enforce max size by the same monotonic freshness used for expiry.
   if (entries.size > MAX_ENTRIES) {
     const sorted = [...entries.entries()]
       .filter(([key]) => key !== SELF_KEY)
-      .toSorted((a, b) => a[1].ts - b[1].ts);
+      .toSorted(
+        (a, b) =>
+          (freshnessAt.get(a[1])?.monotonic ?? Number.NEGATIVE_INFINITY) -
+          (freshnessAt.get(b[1])?.monotonic ?? Number.NEGATIVE_INFINITY),
+      );
     const toDrop = entries.size - MAX_ENTRIES;
     for (const [key] of sorted.slice(0, toDrop)) {
       entries.delete(key);


### PR DESCRIPTION
## What Problem This Solves

Gateway presence used the public wall-clock heartbeat timestamp for expiry and capacity order. If the host clock moved backward, stale remote users or devices could remain online until wall time caught up.

## Why This Change Was Made

`src/infra/system-presence.ts` owns every presence write, five-minute expiry, and the 200-row bound. It now stamps each stored row with one private logical freshness clock.

The owner clock advances from forward wall movement or continuous elapsed time. Continuous time combines the high-resolution process clock with aligned system uptime, so rollback and suspend do not pause expiry. The public `ts` field remains the actual wall-clock heartbeat timestamp.

This replaces the earlier per-entry dual-clock implementation. That implementation could delete a fresh row created during rollback when wall time recovered after an earlier forward step.

## User Impact

Stale remote presence expires after five minutes through clock rollback and suspend. Fresh rows keep their full TTL through recovery. Capacity pressure removes the least-fresh peer first.

## Evidence

- Current-main baseline `9ca9c1106e2784bf6aca5543ef089269fd3752e8`: rollback expiry, suspend expiry, and rollback capacity tests fail with stale rows retained.
- Contributor head `6176af7bb2c084afe0a367551e30088fe64c56d6`: a row created during rollback expires immediately after recovery if the owner saw an earlier forward step.
- Corrected head `73122ec45c5cf1f311e82e28f26e6871cc649f97`: presence owner tests pass 23/23, including three consecutive full-order runs.
- Corrected head: Gateway producer and consumer tests pass 35/35 across WebSocket presence, `system-event`, snapshots, broadcasts, and audience projection.
- Targeted Oxlint, Oxfmt, `git diff --check`, and two pre-commit P0 reviews pass.
- The prior real loopback Gateway proof remains available in [run 33575093579](https://github.com/lzhan011/openclaw/actions/runs/33575093579) and its [artifact](https://github.com/lzhan011/openclaw/actions/runs/33575093579/artifacts/9826473707). It is bound to predecessor `6176af7b`; the corrected head relies on focused owner/caller proof plus exact-head hosted CI because this host cannot build OpenClaw safely.

## Scope and Risk

- Production: `+43/-18` (net `+25`).
- Tests: `+173/-7` (net `+166`).
- No API, configuration, environment variable, dependency, protocol, SQLite, persistence, or migration change.
- Public presence fields and `ts` serialization are unchanged.
- The production growth is the owner clock and co-located freshness record needed to preserve forward-step, rollback, suspend, expiry, and eviction invariants with one ordering source.

## Alternatives Considered

- Changing public `ts` was rejected because the protocol, Control UI, and macOS app consume it as epoch wall time.
- Consumer-side filtering was rejected because RPC, snapshots, broadcasts, and typing checks would diverge.
- Per-entry logical wall clocks were rejected because a new row cannot inherit an owner-wide observed clock epoch.
