### PR TITLE
fix(ios): omit deep-link URLs from logs

### DIFF
--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -10032,8 +10032,7 @@ extension NodeAppModel {
     private func handleAgentDeepLink(_ link: AgentDeepLink, originalURL: URL) async {
         let message = link.message.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !message.isEmpty else { return }
-        self.deepLinkLogger.info(
-            "agent deep link messageChars=\(message.count) url=\(originalURL.absoluteString, privacy: .public)")
+        self.deepLinkLogger.info("agent deep link messageChars=\(message.count, privacy: .public)")
 
         if message.count > IOSDeepLinkAgentPolicy.maxMessageChars {
             self.recordShareEvent("Rejected: message too large (\(message.count) chars).")

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -7575,6 +7575,16 @@ private final class TimingOutDeviceStatusService: DeviceStatusServicing {
         #expect(appModel.lastShareEventText.contains("gateway not connected"))
     }
 
+    @Test func `agent deep link logging excludes the original URL`() throws {
+        let source = try String(contentsOf: Self.nodeAppModelSourceURL(), encoding: .utf8)
+        let start = try #require(source.range(of: "private func handleAgentDeepLink("))
+        let end = try #require(
+            source.range(of: "private func effectiveAgentDeepLinkForPrompt(", range: start.upperBound..<source.endIndex))
+        let handler = String(source[start.lowerBound..<end.lowerBound])
+
+        #expect(!handler.contains("originalURL.absoluteString, privacy: .public"))
+    }
+
     @Test @MainActor func `handle deep link records oversized message rejection`() async throws {
         let appModel = NodeAppModel()
         let msg = String(repeating: "a", count: 20001)
@@ -7725,5 +7735,12 @@ private final class TimingOutDeviceStatusService: DeviceStatusServicing {
         await #expect(throws: Error.self) {
             try await appModel.sendVoiceTranscript(text: "hello", sessionKey: "main")
         }
+    }
+
+    private static func nodeAppModelSourceURL() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Model/NodeAppModel.swift")
     }
 }


### PR DESCRIPTION
## Summary

### What Problem This Solves

iOS agent deep-link diagnostics included the complete incoming URL. This change keeps useful diagnostic metadata without recording request contents or query values.

## Changes

### Why This Change Was Made

The full URL is unnecessary for diagnosing the route and can contain private request data. The logging owner now emits only the bounded message character count.

### User Impact

Agent deep-link parsing, confirmation, delivery, and submission behavior are unchanged. Local confirmation still presents the incoming URL to the device user when approval is required.

- Remove the original URL from the iOS agent deep-link info log.
- Add a regression guard to the existing focused iOS lifecycle test suite.

## Validation

### Evidence

- Pre-fix source assertion reproduced the public original-URL interpolation.
- Post-fix source assertion confirms the interpolation is absent.
- node scripts/check-changed.mjs
- git diff --check
- Structured autoreview: clean, no actionable findings.
- [Exact-head iOS CI](https://github.com/openclaw/openclaw/actions/runs/33466646812) passed on 202a4ca738ddfabe2829f73af556bcc06e3774c1: Swift lint, Debug and Release builds, focused iOS lifecycle simulator tests, Apple Watch simulator tests, native checks, and iPhone/iPad screenshot shards.
- Direct unified-log capture was infeasible because the local Linux host has no Apple runtime and the configured remote CLI was unavailable; the regression is enforced in the simulator-executed focused suite.

## Notes

- No config, protocol, persistence, or public API changes.
- Production code delta: net -1 line.
- AI-assisted implementation and review.