### PR TITLE
fix(voice-call): report missing agent ownership during setup

### DIFF
--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -49,7 +49,8 @@ Gateway, then restart the Gateway to load it.
   <Step title="Configure provider and webhook">
     Set config under `plugins.entries.voice-call.config` (see
     [Configuration](#configuration) below). At minimum: `provider`, provider
-    credentials, `fromNumber`, and a publicly reachable webhook URL.
+    credentials, `fromNumber`, and a publicly reachable webhook URL. With
+    multiple agents, also set `agentId` to the agent that should own calls.
 
     For an inbound Twilio number, set its **Voice webhook** to the public Voice
     Call webhook URL with method `POST`. Set the number-level **Status
@@ -63,8 +64,8 @@ Gateway, then restart the Gateway to load it.
     openclaw voicecall setup --json
     ```
 
-    Checks plugin enablement, provider credentials, webhook exposure, and
-    that only one audio mode (`streaming` or `realtime`) is active.
+    Checks plugin enablement, provider credentials, webhook exposure, agent
+    ownership, and that only one audio mode (`streaming` or `realtime`) is active.
 
   </Step>
   <Step title="Smoke test">
@@ -171,6 +172,20 @@ Voice-call credentials accept SecretRefs. `plugins.entries.voice-call.config.twi
 }
 ```
 
+### Choose the call owner
+
+With one configured agent, Voice Call uses that agent automatically. With
+multiple agents, set `plugins.entries.voice-call.config.agentId` to the intended
+response and session owner. `main` is an ordinary agent ID, not a fallback for
+a multi-agent fleet. Per-number routes may choose different agents for inbound
+calls, but do not replace the plugin's startup owner.
+
+If startup reports that Voice Call has no explicit owner, list your agents with
+`openclaw agents list`, set the existing `agentId` field, and rerun
+`openclaw voicecall setup`. Restart the Gateway after updating its configuration.
+Existing legacy default-agent selection is preserved; new multi-agent setups
+should use an explicit owner. See [Agent configuration](/gateway/config-agents).
+
 ### Config reference
 
 Top-level keys under `plugins.entries.voice-call.config` not shown above:
@@ -189,7 +204,7 @@ Top-level keys under `plugins.entries.voice-call.config` not shown above:
 | `outbound.notifyHangupDelaySec` | `3`          | Seconds to wait after TTS before auto-hangup in notify mode.                                       |
 | `skipSignatureVerification`     | `false`      | Local testing only; never enable in production.                                                    |
 | `store`                         | unset        | Overrides the default `$OPENCLAW_STATE_DIR/voice-calls` path (normally `~/.openclaw/voice-calls`). |
-| `agentId`                       | `"main"`     | Agent used for response generation and session storage.                                            |
+| `agentId`                       | sole agent   | Agent used for response generation and session storage. Set explicitly with multiple agents.       |
 | `responseModel`                 | unset        | Overrides the default model for classic (non-realtime) responses.                                  |
 | `responseSystemPrompt`          | generated    | Custom system prompt for classic responses.                                                        |
 | `responseTimeoutMs`             | `30000`      | Timeout for classic response generation (ms).                                                      |

--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -274,7 +274,7 @@ describe("voice-call plugin", () => {
     expect(entry.configSchema).not.toHaveProperty("uiHints");
     expect(manifest.uiHints?.agentId).toEqual({
       label: "Response Agent ID",
-      help: 'Agent workspace used for voice response generation. Defaults to "main".',
+      help: expect.any(String),
       advanced: true,
     });
     expect(manifest.configSchema?.properties?.agentId).toEqual({

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -551,6 +551,7 @@ export default definePluginEntry({
         registerVoiceCallCli({
           program,
           config,
+          coreConfig: api.config,
           ensureRuntime,
           stateRuntime: api.runtime.state,
           logger: api.logger,

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -242,7 +242,7 @@
     },
     "agentId": {
       "label": "Response Agent ID",
-      "help": "Agent workspace used for voice response generation. Defaults to \"main\".",
+      "help": "Agent used for voice responses and session storage. Defaults to the sole configured agent; set explicitly for a multi-agent fleet.",
       "advanced": true
     },
     "sessionScope": {

--- a/extensions/voice-call/src/cli.test.ts
+++ b/extensions/voice-call/src/cli.test.ts
@@ -43,6 +43,7 @@ vi.mock("./webhook/tailscale.js", async (importOriginal) => ({
 }));
 
 import { registerVoiceCallCli } from "./cli.js";
+import { createVoiceCallBaseConfig } from "./test-fixtures.js";
 
 function captureStdout() {
   let output = "";
@@ -109,11 +110,45 @@ describe("voice-call CLI status fallback", () => {
     registerVoiceCallCli({
       program,
       config: config as never,
+      coreConfig: {},
       ensureRuntime,
       logger: { info() {}, warn() {}, error() {}, debug() {} } as never,
     });
     return program;
   }
+
+  it("reports an ambiguous phone-call owner during setup without starting telephony", async () => {
+    const ensureRuntime = vi.fn();
+    const program = new Command();
+    registerVoiceCallCli({
+      program,
+      config: createVoiceCallBaseConfig(),
+      coreConfig: {
+        agents: { ownership: "explicit", entries: { operator: {}, support: {} } },
+      },
+      ensureRuntime,
+      logger: { info() {}, warn() {}, error() {} },
+    });
+    const capturer = captureStdout();
+    try {
+      await program.parseAsync(["voicecall", "setup", "--json"], { from: "user" });
+    } finally {
+      capturer.restore();
+    }
+    expect(JSON.parse(capturer.output())).toMatchObject({
+      ok: false,
+      checks: expect.arrayContaining([
+        {
+          id: "agent-owner",
+          ok: false,
+          message: expect.stringContaining(
+            "Set plugins.entries.voice-call.config.agentId to a configured agent ID.",
+          ),
+        },
+      ]),
+    });
+    expect(ensureRuntime).not.toHaveBeenCalled();
+  });
 
   async function runStatusWithUnavailableGateway(params: {
     persisted?: unknown;
@@ -129,6 +164,7 @@ describe("voice-call CLI status fallback", () => {
     registerVoiceCallCli({
       program,
       config: {} as never,
+      coreConfig: {},
       ensureRuntime,
       stateRuntime: {} as never,
       logger: { info() {}, warn() {}, error() {}, debug() {} } as never,

--- a/extensions/voice-call/src/cli.ts
+++ b/extensions/voice-call/src/cli.ts
@@ -1,6 +1,8 @@
 // Voice Call plugin module implements cli behavior.
 import path from "node:path";
 import type { Command } from "commander";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { MAX_TCP_PORT } from "openclaw/plugin-sdk/number-runtime";
 import {
   isRecord,
@@ -23,6 +25,7 @@ import {
   type VoiceCallConfig,
 } from "./config.js";
 import { findCallInStore, loadActiveCallsFromStore } from "./manager/store.js";
+import { resolveVoiceCallAgentId } from "./resolve-call-agent-id.js";
 import { setVoiceCallStateRuntime, type VoiceCallStateRuntime } from "./runtime-state.js";
 import type { VoiceCallRuntime } from "./runtime.js";
 import { resolveDefaultVoiceCallStoreDir } from "./store-path.js";
@@ -66,7 +69,7 @@ function resolveDefaultStorePath(config: VoiceCallConfig): string {
   return path.join(base, "calls.jsonl");
 }
 
-function buildSetupStatus(config: VoiceCallConfig): SetupStatus {
+function buildSetupStatus(config: VoiceCallConfig, coreConfig: OpenClawConfig): SetupStatus {
   const validation = validateProviderConfig(config);
   const webhookExposure = resolveWebhookExposureStatus(config);
   const checks: SetupCheck[] = [
@@ -109,6 +112,12 @@ function buildSetupStatus(config: VoiceCallConfig): SetupStatus {
               : "Notify/conversation calls use normal TTS/STT flow",
     },
   ];
+  try {
+    const agentId = resolveVoiceCallAgentId(config, coreConfig);
+    checks.push({ id: "agent-owner", ok: true, message: `Response agent: ${agentId}` });
+  } catch (error) {
+    checks.push({ id: "agent-owner", ok: false, message: formatErrorMessage(error) });
+  }
   return {
     ok: checks.every((check) => check.ok),
     checks,
@@ -125,11 +134,12 @@ function writeSetupStatus(status: SetupStatus): void {
 export function registerVoiceCallCli(params: {
   program: Command;
   config: VoiceCallConfig;
+  coreConfig: OpenClawConfig;
   ensureRuntime: () => Promise<VoiceCallRuntime>;
   stateRuntime?: VoiceCallStateRuntime["state"];
   logger: Logger;
 }) {
-  const { program, config, ensureRuntime, stateRuntime } = params;
+  const { program, config, coreConfig, ensureRuntime, stateRuntime } = params;
   const ensureHistoryStateRuntime = (): void => {
     if (stateRuntime) {
       setVoiceCallStateRuntime({ state: stateRuntime });
@@ -145,7 +155,7 @@ export function registerVoiceCallCli(params: {
     .description("Show Voice Call provider and webhook setup status")
     .option("--json", "Print machine-readable JSON")
     .action((options: { json?: boolean }) => {
-      const status = buildSetupStatus(config);
+      const status = buildSetupStatus(config, coreConfig);
       if (options.json) {
         writeCliJson(status);
         return;
@@ -173,7 +183,7 @@ export function registerVoiceCallCli(params: {
         yes?: boolean;
         json?: boolean;
       }) => {
-        const setup = buildSetupStatus(config);
+        const setup = buildSetupStatus(config, coreConfig);
         if (!setup.ok) {
           if (options.json) {
             writeCliJson({ ok: false, setup });

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -475,7 +475,7 @@ export const VoiceCallConfigSchema = z
     /** Store path for call logs */
     store: z.string().optional(),
 
-    /** Agent ID to use for voice response generation. Defaults to "main". */
+    /** Response/session owner. Required when multiple agents have no legacy owner. */
     agentId: z.string().min(1).optional(),
 
     /** Optional model override for generating voice responses. */

--- a/extensions/voice-call/src/resolve-call-agent-id.ts
+++ b/extensions/voice-call/src/resolve-call-agent-id.ts
@@ -1,6 +1,21 @@
+import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-scope-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import type { VoiceCallConfig } from "./config.js";
 import type { CallRecord } from "./types.js";
+
+/** Setup and startup must resolve the same owner before provisioning telephony. */
+export function resolveVoiceCallAgentId(
+  config: Pick<VoiceCallConfig, "agentId">,
+  coreConfig: OpenClawConfig,
+): string {
+  return config.agentId
+    ? normalizeAgentId(config.agentId)
+    : resolveDefaultAgentId(coreConfig, {
+        surface: "Voice Call",
+        hint: "Set plugins.entries.voice-call.config.agentId to a configured agent ID.",
+      });
+}
 
 /** Keep one agent owner for the full call, including legacy stored records. */
 export function resolveCallAgentId(

--- a/extensions/voice-call/src/runtime.test.ts
+++ b/extensions/voice-call/src/runtime.test.ts
@@ -269,6 +269,44 @@ describe("createVoiceCallRuntime lifecycle", () => {
     mocks.cleanupTailscaleExposure.mockResolvedValue(undefined);
   });
 
+  it("explains the missing phone-call owner before provisioning a runtime", async () => {
+    await expect(
+      createVoiceCallRuntime({
+        config: createBaseConfig(),
+        coreConfig: {
+          agents: { ownership: "explicit", entries: { operator: {}, support: {} } },
+        },
+        agentRuntime: {} as never,
+      }),
+    ).rejects.toThrow("Set plugins.entries.voice-call.config.agentId to a configured agent ID.");
+    expect(mocks.webhookCtorArgs).toHaveLength(0);
+    expect(mocks.managerInitialize).not.toHaveBeenCalled();
+    expect(mocks.startTunnel).not.toHaveBeenCalled();
+  });
+
+  it.each<{ name: string; coreConfig: OpenClawConfig; agentId?: string }>([
+    { name: "sole named agent", coreConfig: { agents: { entries: { operator: {} } } } },
+    {
+      name: "explicit fleet owner",
+      coreConfig: {
+        agents: { ownership: "explicit", entries: { operator: {}, support: {} } },
+      },
+      agentId: "OPERATOR",
+    },
+    {
+      name: "legacy default owner",
+      coreConfig: { agents: { list: [{ id: "support" }, { id: "operator", default: true }] } },
+    },
+  ])("preserves the $name for phone-call startup", async ({ coreConfig, agentId }) => {
+    const runtime = await createVoiceCallRuntime({
+      config: { ...createBaseConfig(), agentId },
+      coreConfig,
+      agentRuntime: {} as never,
+    });
+    expect(runtime.config.agentId).toBe("operator");
+    await runtime.stop();
+  });
+
   it("cleans up tunnel, tailscale, and webhook server when init fails after start", async () => {
     const config = createBaseConfig();
     config.tunnel.provider = "tailscale-funnel";

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -1,5 +1,5 @@
 // Voice Call plugin module implements runtime behavior.
-import { listAgentIds, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-scope-runtime";
+import { listAgentIds } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { isLoopbackHost } from "openclaw/plugin-sdk/gateway-runtime";
@@ -29,7 +29,7 @@ import type { TwilioProvider } from "./providers/twilio.js";
 import { buildRealtimeVoiceInstructions } from "./realtime-agent-context.js";
 import { resolveVoiceCallRealtimeTools } from "./realtime-call-control.js";
 import { resolveRealtimeFastContextConsult } from "./realtime-fast-context.js";
-import { resolveCallAgentId } from "./resolve-call-agent-id.js";
+import { resolveCallAgentId, resolveVoiceCallAgentId } from "./resolve-call-agent-id.js";
 import { resolveVoiceResponseModel } from "./response-model.js";
 import { setVoiceCallStateRuntime, type VoiceCallStateRuntime } from "./runtime-state.js";
 import type { TelephonyTtsRuntime } from "./telephony-tts.js";
@@ -308,10 +308,7 @@ export async function createVoiceCallRuntime(params: {
 
   const cfg = fullConfig ?? (coreConfig as OpenClawConfig);
   const unresolvedConfig = resolveVoiceCallConfig(rawConfig);
-  const configuredAgentId = unresolvedConfig.agentId
-    ? normalizeAgentId(unresolvedConfig.agentId)
-    : resolveDefaultAgentId(cfg);
-  const config = { ...unresolvedConfig, agentId: configuredAgentId };
+  const config = { ...unresolvedConfig, agentId: resolveVoiceCallAgentId(unresolvedConfig, cfg) };
 
   if (!config.enabled) {
     throw new Error("Voice call disabled. Enable the plugin entry in config.");


### PR DESCRIPTION
Closes #132619.

## What Problem This Solves

Fixes an issue where operators configuring Voice Call with multiple agents were told that its response agent defaults to `main`, saw a successful `voicecall setup` result, and then received a generic owner-selection error when the Gateway started the plugin.

## Why This Change Was Made

Setup, smoke checks, and runtime startup now share the plugin's existing owner resolver. Ambiguous fleets receive the exact `plugins.entries.voice-call.config.agentId` hint before telephony resources are provisioned. The manifest and documentation describe the sole-agent default and explicit multi-agent selection accurately.

This preserves existing owner selection, normalization, and legacy default-marker behavior. It adds no configuration field, fallback, migration, storage change, or automatic owner assignment. Explicit unknown IDs remain a separate existing validation concern; this change does not introduce stricter startup validation.

## User Impact

Operators can identify and correct missing Voice Call ownership during setup instead of discovering it after Gateway startup. A sole named agent continues to work automatically, and explicit or legacy owners retain their existing behavior. Thanks @felixboenkost-droid for the report.

## Evidence

- Failure-first regressions: an explicit two-agent setup incorrectly returned `ok: true`; runtime startup returned the generic `this operation` hint. Both regressions fail before the fix and pass after it.
- Focused plugin registration, runtime, and CLI suite: 95 tests passed. Includes sole named, normalized explicit, and legacy default-owner controls.
- Isolated actual plugin registration → service startup → Gateway health proof: all five cases passed, including preserved unknown-explicit behavior. The ambiguous case recorded the exact configuration hint in `plugins.errors` without creating call storage or binding a webhook. Successful cases returned HTTP 200 from their real loopback mock-provider webhook, listed zero calls, and released their listener on stop. No external carrier, model calls, or operator state were used.
- Final Codex autoreview completed with no actionable findings through P2. The complete changed-file gate passed, including production/test types, lint, all three dead-export scans, database/sidecar guards, and runtime import-cycle checks.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33466719578) passed on `64ae1ab1337b3729a627339cd8788e9394c68e93`.

Production delta: +23 lines; tests +74; documentation +15. Growth is the shared setup/runtime owner boundary and the new observable setup check; the former runtime-only resolution branch is removed. No new SDK or persistence surface.
