### PR TITLE
Keep quiet Slack previews on the latest preamble

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1526,7 +1526,8 @@ The default scope (`"group-mentions"`) does not fire ack reactions in direct mes
 - `partial` (default): replace preview text with the latest partial output.
 - `block`: append chunked preview updates.
 - `progress`: show progress status text while generating, then send final text.
-- `streaming.preview.toolProgress`: when draft preview is active, route tool/progress updates into the same edited preview message (default: `true`). Set `false` to keep separate tool/progress messages.
+- `streaming.preview.toolProgress`: when draft preview is active, route tool/progress updates into the same edited preview message (default: `true`). Set `false` to hide interim tool and plan updates.
+- `streaming.progress.toolProgress`: set `false` to keep progress drafts on authored preambles instead of tool-status lines and plan checklists. Pair with `commentary: true`, `label: false`, and `maxLines: 1` to show only the latest preamble until the final reply replaces it.
 - `streaming.preview.commandText` / `streaming.progress.commandText`: set to `status` to keep compact tool-progress lines while hiding raw command/exec text (default: `raw`).
 
 Hide raw command/exec text while keeping compact progress lines:

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -429,6 +429,10 @@ export function createSlackProgressRuntime(runtimeParams: {
   };
 
   const pushPlanProgress = async (steps?: AgentPlanStep[], explanation?: string) => {
+    // A plan is tool progress, not a replacement for the model's latest preamble.
+    if (!previewToolProgressEnabled) {
+      return;
+    }
     if (streamMode === "status_final") {
       await progressDraft.pushPlanProgress(steps, { explanation });
       return;

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -3904,7 +3904,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     );
   });
 
-  it("keeps the full latest preamble and turns the same Slack message into the final answer", async () => {
+  it("keeps only authored preambles before replacing the draft with the final answer", async () => {
     const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
@@ -3916,16 +3916,53 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       "I found the earlier decision and am checking the owner, the current rollout, and the original feedback before deciding what would actually be useful here.";
     mockedReplyOptionEvents = [
       {
+        kind: "plan",
+        phase: "update",
+        steps: [
+          { step: "Inspect", status: "in_progress" },
+          { step: "Patch", status: "pending" },
+          { step: "Verify", status: "pending" },
+        ],
+      },
+      {
         kind: "item",
         itemKind: "preamble",
         itemId: "preamble-1",
         progressText: firstPreamble,
       },
       {
+        kind: "tool_start",
+        itemId: "tool-1",
+        name: "bash",
+        phase: "start",
+        args: { command: "pnpm test" },
+      },
+      { kind: "reasoning", text: "Considering the next step." },
+      {
+        kind: "plan",
+        phase: "update",
+        explanation: "Running the checklist.",
+        steps: [{ step: "Patch", status: "in_progress" }],
+      },
+      {
         kind: "item",
         itemKind: "preamble",
         itemId: "preamble-2",
         progressText: latestPreamble,
+      },
+      {
+        kind: "command_output",
+        itemId: "tool-1",
+        name: "bash",
+        phase: "end",
+        title: "pnpm test",
+        exitCode: 1,
+      },
+      {
+        kind: "plan",
+        phase: "update",
+        explanation: "Finishing the checklist.",
+        steps: [{ step: "Verify", status: "completed" }],
       },
     ];
 
@@ -3946,8 +3983,10 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       }),
     );
 
-    expect(draftStream.update).toHaveBeenCalledWith(`_${firstPreamble}_`);
-    expect(draftStream.update).toHaveBeenLastCalledWith(`_${latestPreamble}_`);
+    expect(draftStream.update.mock.calls.flat()).toEqual([
+      `_${firstPreamble}_`,
+      `_${latestPreamble}_`,
+    ]);
     expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
     expectMockCallArgFields(finalizeSlackPreviewEditMock, 0, "progress final edit", {
       channelId: "C123",


### PR DESCRIPTION
Backports the quiet-preview fix in https://github.com/openclaw/openclaw/pull/134716 to `sjf_openclaw_2026-07-31`.

Plan updates bypassed Slack's existing tool-progress opt-out, so a generated checklist could replace the agent's latest preamble. Treat plans as tool progress and leave the preamble in place until the next preamble or final answer.

This release line already uses the compact preview path, so only the plan gate, matching dispatch regression, and documentation apply here. It does not need the newer card-style handling from main. The regression reproduces the three-step counter before the patch and checks that plans and tool events no longer overwrite either authored preamble, with final replacement preserved.

The upstream PR is merged as `af485df6faa124ba62353cfd4f1a615b4603ecb2`; this backport was prepared from its original fix commit `39de8f7bd5bdba95e49e2b03f081fa48bbcea953`. No dependency, protocol, configuration-schema, or persisted-state changes.
