### PR TITLE
fix(ci): provision Go for docs i18n Testbox

### DIFF
--- a/.github/actions/prepare-testbox-shell/action.yml
+++ b/.github/actions/prepare-testbox-shell/action.yml
@@ -1,9 +1,12 @@
 name: Prepare Testbox shell
-description: Pin the checked-out base ref and expose the setup-node toolchain to Testbox.
+description: Pin the checked-out base ref and expose the prepared toolchains to Testbox.
 
 inputs:
   base-ref:
     description: Event base for pull requests, or ref to treat as origin/main for manual runs; defaults to HEAD.
+    required: false
+  go-version:
+    description: Go version to install and expose to Testbox; empty skips Go setup.
     required: false
 
 runs:
@@ -50,3 +53,24 @@ runs:
         exec /usr/local/bin/corepack pnpm "$@"
         PNPM
         sudo chmod 0755 /usr/local/bin/pnpm
+
+    - name: Setup Go environment
+      if: inputs.go-version != ''
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        go-version: ${{ inputs.go-version }}
+        cache: false
+
+    - name: Expose Go tools
+      if: inputs.go-version != ''
+      shell: bash
+      env:
+        TESTBOX_GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        set -euo pipefail
+
+        test "$(go env GOVERSION)" = "go${TESTBOX_GO_VERSION}"
+        go_root="$(go env GOROOT)"
+        for tool in go gofmt; do
+          sudo ln -sf "$go_root/bin/$tool" "/usr/local/bin/$tool"
+        done

--- a/.github/workflows/ci-check-arm-testbox.yml
+++ b/.github/workflows/ci-check-arm-testbox.yml
@@ -66,6 +66,7 @@ jobs:
         uses: ./.github/actions/prepare-testbox-shell
         with:
           base-ref: ${{ github.event.pull_request.base.sha || 'refs/remotes/origin/main' }}
+          go-version: "1.27.0"
 
       - name: Hydrate Testbox provider env helper
         shell: bash

--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -61,6 +61,7 @@ jobs:
         uses: ./.github/actions/prepare-testbox-shell
         with:
           base-ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || 'HEAD' }}
+          go-version: "1.27.0"
 
       - name: Hydrate Testbox provider env helper
         shell: bash

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -7041,20 +7041,23 @@ server.listen(0, "127.0.0.1", () => {
         ".github/workflows/ci-check-testbox.yml",
         "1",
         "${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || 'HEAD' }}",
+        "1.27.0",
       ],
       [
         ".github/workflows/ci-check-arm-testbox.yml",
         "0",
         "${{ github.event.pull_request.base.sha || 'refs/remotes/origin/main' }}",
+        "1.27.0",
       ],
       [
         ".github/workflows/ci-build-artifacts-testbox.yml",
         "0",
         "${{ github.event.pull_request.base.sha || 'refs/remotes/origin/main' }}",
+        undefined,
       ],
     ] as const;
 
-    for (const [workflowPath, dispatchFetchDepth, baseRef] of workflowPaths) {
+    for (const [workflowPath, dispatchFetchDepth, baseRef, goVersion] of workflowPaths) {
       const workflow = parse(readFileSync(workflowPath, "utf8"));
       const job = Object.values(workflow.jobs)[0] as { steps: WorkflowStep[] };
       const checkoutStep = job.steps.find((step) => step.name === "Checkout");
@@ -7077,6 +7080,7 @@ server.listen(0, "127.0.0.1", () => {
       }
       expect(prepareStep?.uses, workflowPath).toBe("./.github/actions/prepare-testbox-shell");
       expect(prepareStep?.with?.["base-ref"], workflowPath).toBe(baseRef);
+      expect(prepareStep?.with?.["go-version"], workflowPath).toBe(goVersion);
       const ensureBaseStep = job.steps.find(
         (step: WorkflowStep) => step.name === "Ensure Testbox base commit",
       );
@@ -7087,7 +7091,34 @@ server.listen(0, "127.0.0.1", () => {
     }
 
     const action = parse(readFileSync(".github/actions/prepare-testbox-shell/action.yml", "utf8"));
-    const run = action.runs.steps[0].run as string;
+    expect(action.inputs["go-version"]).toMatchObject({ required: false });
+    const setupGo = expectDefined(
+      action.runs.steps.find((step: WorkflowStep) => step.uses === SETUP_GO_V6),
+      "Testbox Go setup",
+    );
+    expect(setupGo).toMatchObject({
+      if: "inputs.go-version != ''",
+      with: {
+        cache: false,
+        "go-version": "${{ inputs.go-version }}",
+      },
+    });
+    const exposeGo = expectDefined(
+      action.runs.steps.find((step: WorkflowStep) => step.name === "Expose Go tools"),
+      "Testbox Go exposure",
+    );
+    expect(exposeGo.if).toBe("inputs.go-version != ''");
+    expect(exposeGo.run).toContain('test "$(go env GOVERSION)" = "go${TESTBOX_GO_VERSION}"');
+    expect(exposeGo.run).toContain('go_root="$(go env GOROOT)"');
+    expect(exposeGo.run).toContain("for tool in go gofmt; do");
+    expect(exposeGo.run).toContain('"/usr/local/bin/$tool"');
+    const prepare = expectDefined(
+      action.runs.steps.find(
+        (step: WorkflowStep) => step.name === "Pin Testbox base and Node tools",
+      ),
+      "Testbox base preparation",
+    );
+    const run = prepare.run as string;
     expect(run).toContain('base_ref="${TESTBOX_BASE_REF:-HEAD}"');
     expect(run).toContain('git rev-parse --verify "${base_ref}^{commit}"');
     expect(run).toContain('git update-ref refs/remotes/origin/main "$base_sha"');

--- a/test/scripts/docs-i18n.test.ts
+++ b/test/scripts/docs-i18n.test.ts
@@ -24,7 +24,11 @@ describe.skipIf(!hasGoToolchain)("docs-i18n Go module", () => {
       encoding: "utf8",
       // Go's default read-only module directories prevent recursive teardown.
       // Keep this build's writable module cache inside the suite-owned root.
-      env: { ...process.env, GOMODCACHE: path.join(tempDir, "gomodcache") },
+      env: {
+        ...process.env,
+        GOMODCACHE: path.join(tempDir, "gomodcache"),
+        GOTOOLCHAIN: "local",
+      },
     });
     if (result.error || result.status !== 0) {
       throw result.error ?? new Error(result.stderr || result.stdout || "failed to build Go tests");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the docs-i18n Testbox shard could fail strict temporary-directory cleanup with `EACCES`. Testbox hydration did not provide the workflow-owned Go 1.27 toolchain, so Go's automatic toolchain selection could place downloaded toolchain files inside the suite-owned module cache with permissions that recursive teardown could not remove.

Current `main` reproduced the failure in `test/scripts/docs-i18n.test.ts:36` on Linux Testbox: https://github.com/openclaw/openclaw/actions/runs/33464692199.

An initial exact-head CI run then exposed the existing base-preparation contract: all 12 cases in `test/scripts/testbox-base.test.ts` failed because optional Go setup had displaced the executable shell preparation from `action.runs.steps[0]`. The final action keeps base preparation first and runs optional Go setup afterward.

## Why This Change Was Made

The shared Testbox shell action now accepts an optional Go version, preserves the base preparation command as step 0, installs the pinned toolchain afterward with the existing official `actions/setup-go` revision, verifies the exact version, and exposes `go` and `gofmt` from the resolved `GOROOT`. The x64 and ARM check workflows opt into Go 1.27; the build-artifact Testbox intentionally does not.

The docs-i18n fixture also sets `GOTOOLCHAIN=local` beside its private writable `GOMODCACHE`, preventing an implicit toolchain download from escaping the hydration contract. The existing `-modcacherw`, four partitions, and strict recursive teardown remain unchanged.

## User Impact

No application runtime behavior changes. Maintainer Testbox validation now runs the docs-i18n shard with the same pinned Go toolchain as normal CI on both x64 and ARM.

Production app LOC: +0/-0 | CI/action tooling: +27/-1 | Tests: +38/-3

## Evidence

- Pre-fix current-main Linux Testbox reproduced `EACCES` removing the docs-i18n temporary root: https://github.com/openclaw/openclaw/actions/runs/33464692199.
- Initial exact-head CI run 33466922824, job 99728692026, deterministically failed all 12 base-preparation cases with `Missing Testbox preparation command`; the repaired owner action restores the executable preparation command at step 0.
- Local focused command passed 213 tests with 6 skips, including all 12 base-preparation cases: `node scripts/run-vitest.mjs test/scripts/testbox-base.test.ts test/scripts/docs-i18n.test.ts test/scripts/ci-workflow-guards.test.ts`. The four Go cases skipped locally because this host has no Go toolchain.
- Repaired-head x64 Blacksmith Testbox passed exact Go `go1.27.0`, all four docs-i18n partitions, all 12 base-preparation cases, strict removable `TMPDIR`, `pnpm check:workflows`, and `git diff --check origin/main...HEAD` at `d1f41b86d8529e56a1b003d6a31189045f6ee4c0`: lease `tbx_01m1dh76raghjyemwa0g61z89f`, https://github.com/openclaw/openclaw/actions/runs/33467442040.
- Repaired-head ARM Blacksmith Testbox passed the same exact toolchain, all four partitions, all 12 base-preparation cases, and strict teardown contract: lease `tbx_01m1dh76rs1hp7emgk52p9whpa`, https://github.com/openclaw/openclaw/actions/runs/33467442278.
- Local `pnpm check:workflows` reached the repository check but the machine's configured Python index only exposed `pre-commit` through 4.3.0, below the repository pin 4.6.2. The exact command passed in the clean repaired-head x64 Testbox above.
- `node_modules/.bin/oxfmt --write` on all five files and local `git diff --check` passed.
- Exact pinned Sol autoreview returned scoped-clean with no accepted or actionable findings.
- The official `actions/setup-go` action source at `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e` declares Node 24 execution, `go-version`, optional architecture defaulting to the runner architecture, and cache control; tag `v7.0.0` resolves to that commit.
- Codex source gate inspected directly at `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`; no Codex CLI/runtime contract is involved in this CI hydration change.
