### PR TITLE
test(infra): scope Windows encoding module resets

### DIFF
--- a/src/infra/windows-encoding.test.ts
+++ b/src/infra/windows-encoding.test.ts
@@ -1,7 +1,7 @@
 // Covers Windows command-output code page parsing and decoding.
 
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 
 const spawnSyncMock = vi.hoisted(() => vi.fn());
 const queryWindowsRegistryValueMock = vi.hoisted(() => vi.fn((): string | null => null));
@@ -36,8 +36,11 @@ const UTF16_OUTPUT_CASES = [
 ] as const;
 
 describe("windows output encoding", () => {
-  afterEach(() => {
+  afterAll(() => {
     vi.resetModules();
+  });
+
+  afterEach(() => {
     vi.restoreAllMocks();
     spawnSyncMock.mockReset();
     queryWindowsRegistryValueMock.mockReset();


### PR DESCRIPTION
## What Problem This Solves

The Windows encoding suite clears the module graph after all 26 cases, including decoder-only cases that use already imported functions and fresh decoder instances.

## Why This Change Was Made

Keep all 27 explicit resets used to create fresh OEM/console/system cache probes, and move the final cleanup reset to suite teardown. Per-case mock and platform-spy restoration stays unchanged. Every test body and assertion remains intact.

## User Impact

Test-only: 25 redundant module-graph sweeps are removed, from 53 explicit resets to 28. No runtime encoding change or elapsed-time gain is claimed.

## Evidence

All 54 encoding, install-root and launcher cases pass before and after in the normal isolated infra project. This retains 26 encoding cases, all 23 OEM mappings, cached failed-probe checks, exact subprocess timeout options, UTF-16/BOM/chunk boundaries and independent decoder state. Full changed checks and Codex autoreview pass.

Source review covered the decoder, registry/install-root callee, launcher and process-output callers, selected siblings and the original cached-probe/OEM fixes. Production +0/-0; tests +5/-2. Local proof uses the existing platform fixtures; no native Windows run is claimed.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/infra/windows-encoding.test.ts src/infra/windows-install-roots.test.ts src/infra/windows-launcher-encoding.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base c1f527d2c06082b9b7b88572bbf039ad22aadf7a
```

