### PR TITLE
fix(doctor): identify blocked workspace migration cleanup

### DIFF
--- a/src/agents/workspace-legacy-state.ts
+++ b/src/agents/workspace-legacy-state.ts
@@ -114,35 +114,37 @@ function pathOrClaimExists(filePath: string): boolean {
   );
 }
 
-function siblingPathIsOwnedMarker(filePath: string): boolean {
-  let stat: fs.Stats;
+/** Share presence-only sibling ownership checks between runtime and Doctor. */
+export function legacyWorkspaceSiblingAttestationMayExist(filePath: string): boolean {
   try {
-    stat = fs.lstatSync(filePath);
-  } catch {
-    return false;
-  }
-  if (!stat.isFile()) {
-    return false;
-  }
-  try {
+    const before = fs.lstatSync(filePath);
+    if (!before.isFile()) {
+      return false;
+    }
     const noFollow = typeof fs.constants.O_NOFOLLOW === "number" ? fs.constants.O_NOFOLLOW : 0;
-    const fd = fs.openSync(filePath, fs.constants.O_RDONLY | noFollow);
+    let fd: number;
     try {
-      const buffer = Buffer.alloc(
-        Math.min(stat.size, LEGACY_WORKSPACE_ATTESTATION_HEADER.length + 1),
-      );
-      const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
-      return (
-        buffer.subarray(0, bytesRead).toString("utf8") ===
-        `${LEGACY_WORKSPACE_ATTESTATION_HEADER}\n`
-      );
+      fd = fs.openSync(filePath, fs.constants.O_RDONLY | noFollow);
+    } catch {
+      // An unreadable regular file could be an owned marker. Doctor must surface it.
+      return true;
+    }
+    try {
+      const opened = fs.fstatSync(fd);
+      if (!opened.isFile() || opened.dev !== before.dev || opened.ino !== before.ino) {
+        return true;
+      }
+      const expected = Buffer.from(`${LEGACY_WORKSPACE_ATTESTATION_HEADER}\n`, "utf8");
+      const bytes = Buffer.alloc(expected.length);
+      const read = fs.readSync(fd, bytes, 0, bytes.length, 0);
+      return read === expected.length && bytes.equals(expected);
+    } catch {
+      return true;
     } finally {
       fs.closeSync(fd);
     }
   } catch {
-    // A regular file at the exact retired path is ambiguous when it cannot be
-    // inspected. Doctor owns the safe decision; runtime must not assume absence.
-    return true;
+    return false;
   }
 }
 
@@ -152,8 +154,9 @@ function hasUnmigratedWorkspaceSources(sources: LegacyWorkspaceSourcePaths): boo
     sources.stateDirAttestationPaths.some(pathOrClaimExists) ||
     sources.siblingAttestationPaths.some(
       (sourcePath) =>
-        siblingPathIsOwnedMarker(`${sourcePath}${WORKSPACE_DOCTOR_CLAIM_SUFFIX}`) ||
-        siblingPathIsOwnedMarker(sourcePath),
+        legacyWorkspaceSiblingAttestationMayExist(
+          `${sourcePath}${WORKSPACE_DOCTOR_CLAIM_SUFFIX}`,
+        ) || legacyWorkspaceSiblingAttestationMayExist(sourcePath),
     )
   );
 }

--- a/src/agents/workspace-state-store.ts
+++ b/src/agents/workspace-state-store.ts
@@ -330,7 +330,6 @@ export function readWorkspaceStateSnapshot(
   });
   if (
     initial.resolution.missingAliasKeys.length === 0 ||
-    options.readOnly ||
     (!initial.snapshot.setupExists && !initial.snapshot.attestation)
   ) {
     return initial.snapshot;

--- a/src/infra/state-migrations.workspace-setup-store.ts
+++ b/src/infra/state-migrations.workspace-setup-store.ts
@@ -504,6 +504,23 @@ export function importAndRecordReceipt(params: {
         }
       } else {
         const parsedAttestation = params.parsed.value;
+        const insertGeneratedHashes = () => {
+          const hashes = [...parsedAttestation.generatedHashes.entries()].toSorted(([a], [b]) =>
+            a.localeCompare(b),
+          );
+          if (hashes.length > 0) {
+            executeSqliteQuerySync(
+              db,
+              kysely.insertInto("workspace_generated_bootstrap_hashes").values(
+                hashes.map(([filename, sha256]) => ({
+                  workspace_key: params.source.workspaceKey,
+                  filename,
+                  sha256,
+                })),
+              ),
+            );
+          }
+        };
         const incomingFingerprint = attestationFingerprint({
           attestedAtMs: parsedAttestation.attestedAtMs,
           generatedHashes: parsedAttestation.generatedHashes,
@@ -549,21 +566,7 @@ export function importAndRecordReceipt(params: {
                 .deleteFrom("workspace_generated_bootstrap_hashes")
                 .where("workspace_key", "=", params.source.workspaceKey),
             );
-            const replacementHashes = [...parsedAttestation.generatedHashes.entries()].toSorted(
-              ([left], [right]) => left.localeCompare(right),
-            );
-            if (replacementHashes.length > 0) {
-              executeSqliteQuerySync(
-                db,
-                kysely.insertInto("workspace_generated_bootstrap_hashes").values(
-                  replacementHashes.map(([filename, sha256]) => ({
-                    workspace_key: params.source.workspaceKey,
-                    filename,
-                    sha256,
-                  })),
-                ),
-              );
-            }
+            insertGeneratedHashes();
           };
           const equivalent =
             existing.attested_at_ms === parsedAttestation.attestedAtMs &&
@@ -621,21 +624,7 @@ export function importAndRecordReceipt(params: {
                 }),
               ),
           );
-          const hashes = [...parsedAttestation.generatedHashes.entries()].toSorted(([a], [b]) =>
-            a.localeCompare(b),
-          );
-          if (hashes.length > 0) {
-            executeSqliteQuerySync(
-              db,
-              kysely.insertInto("workspace_generated_bootstrap_hashes").values(
-                hashes.map(([filename, sha256]) => ({
-                  workspace_key: params.source.workspaceKey,
-                  filename,
-                  sha256,
-                })),
-              ),
-            );
-          }
+          insertGeneratedHashes();
           imported = true;
           resolution = "inserted";
           verifiedFingerprint = incomingFingerprint;

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -898,11 +898,9 @@ describe("legacy workspace Doctor migration", () => {
     const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
     const setupPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
     const seededAt = "2026-07-15T00:00:00.000Z";
-    await fsp.writeFile(
-      setupPath,
-      JSON.stringify({ version: 1, bootstrapSeededAt: seededAt }),
-      "utf8",
-    );
+    const setupSource = JSON.stringify({ version: 1, bootstrapSeededAt: seededAt });
+    const claimPath = `${setupPath}.doctor-importing`;
+    await fsp.writeFile(setupPath, setupSource, "utf8");
     const first = await migrateLegacyWorkspaceState({
       detected: detect(context),
       env: context.env,
@@ -912,13 +910,21 @@ describe("legacy workspace Doctor migration", () => {
       },
     });
     expect(first.warnings[0]).toContain("legacy cleanup failed");
-    expect(fs.existsSync(`${setupPath}.doctor-importing`)).toBe(true);
+    expect(first.warnings[0]).toContain(setupPath);
+    expect(fs.existsSync(claimPath)).toBe(true);
     const db = openOpenClawStateDatabase({ env: context.env }).db;
 
+    await fsp.writeFile(claimPath, "{invalid", "utf8");
+    const unreadable = await migrate(context);
+    expect(unreadable.warnings[0]).toContain(setupPath);
+    expect(unreadable.warnings[0]).toContain("invalid JSON");
+    expect(await fsp.readFile(claimPath, "utf8")).toBe("{invalid");
+
+    await fsp.writeFile(claimPath, setupSource, "utf8");
     const retry = await migrate(context);
 
     expect(retry.warnings).toEqual([]);
-    expect(fs.existsSync(`${setupPath}.doctor-importing`)).toBe(false);
+    expect(fs.existsSync(claimPath)).toBe(false);
     expect(
       db
         .prepare("SELECT bootstrap_seeded_at FROM workspace_setup_state WHERE workspace_key = ?")
@@ -931,9 +937,7 @@ describe("legacy workspace Doctor migration", () => {
         )
         .get(path.join(identity.workspacePath, "openclaw-workspace-state.json")),
     ).toEqual({
-      source_sha256: createHash("sha256")
-        .update(JSON.stringify({ version: 1, bootstrapSeededAt: seededAt }))
-        .digest("hex"),
+      source_sha256: createHash("sha256").update(setupSource).digest("hex"),
       removed_source: 1,
     });
   });

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -7,10 +7,10 @@ import { TextDecoder } from "node:util";
 import { root, type Root } from "@openclaw/fs-safe";
 import {
   LEGACY_WORKSPACE_ATTESTATION_DIRNAME,
-  LEGACY_WORKSPACE_ATTESTATION_HEADER,
   LEGACY_WORKSPACE_ATTESTATION_MAX_BYTES,
   LEGACY_WORKSPACE_STATE_CURRENT_FILENAME,
   WORKSPACE_DOCTOR_CLAIM_SUFFIX,
+  legacyWorkspaceSiblingAttestationMayExist,
   resolveLegacyWorkspaceSourcePaths,
 } from "../agents/workspace-legacy-state.js";
 import { listWorkspaceStateDirs } from "../agents/workspace-state-dirs.js";
@@ -35,7 +35,6 @@ import {
   canonicalCoversParsedSource,
   importAndRecordReceipt,
   parseSource,
-  type ParsedSource,
   type SourceSnapshot,
 } from "./state-migrations.workspace-setup-store.js";
 import type {
@@ -157,39 +156,6 @@ function createLegacySource(
   return { ...params, rootDir, relativePath, sourcePath };
 }
 
-function siblingAttestationNeedsDoctor(filePath: string): boolean {
-  try {
-    const before = fs.lstatSync(filePath);
-    if (!before.isFile()) {
-      return false;
-    }
-    const noFollow = typeof fs.constants.O_NOFOLLOW === "number" ? fs.constants.O_NOFOLLOW : 0;
-    let fd: number;
-    try {
-      fd = fs.openSync(filePath, fs.constants.O_RDONLY | noFollow);
-    } catch {
-      // An unreadable regular file could be an owned marker. Doctor must surface it.
-      return true;
-    }
-    try {
-      const opened = fs.fstatSync(fd);
-      if (!opened.isFile() || opened.dev !== before.dev || opened.ino !== before.ino) {
-        return true;
-      }
-      const expected = Buffer.from(`${LEGACY_WORKSPACE_ATTESTATION_HEADER}\n`, "utf8");
-      const bytes = Buffer.alloc(expected.length);
-      const read = fs.readSync(fd, bytes, 0, bytes.length, 0);
-      return read === expected.length && bytes.equals(expected);
-    } catch {
-      return true;
-    } finally {
-      fs.closeSync(fd);
-    }
-  } catch {
-    return false;
-  }
-}
-
 function listOrphanAttestationSources(params: {
   stateDir: string;
   homedir: () => string;
@@ -285,7 +251,7 @@ function addLegacyWorkspaceSources(params: {
   for (const [index, sourcePath] of paths.siblingAttestationPaths.entries()) {
     if (
       !pathMayExistSync(`${sourcePath}${CLAIM_SUFFIX}`) &&
-      !siblingAttestationNeedsDoctor(sourcePath)
+      !legacyWorkspaceSiblingAttestationMayExist(sourcePath)
     ) {
       continue;
     }
@@ -446,7 +412,7 @@ async function cleanupReceiptSource(params: {
     return {
       changes: [],
       warnings: [
-        `Workspace state is in SQLite, but legacy cleanup failed: ${formatErrorMessage(error)}`,
+        `Workspace state is in SQLite, but legacy cleanup failed at ${params.source.sourcePath}: ${formatErrorMessage(error)}`,
       ],
     };
   }
@@ -508,32 +474,28 @@ async function migrateOneSource(params: {
     return { changes: [], warnings: [] };
   }
 
-  let snapshot: SourceSnapshot;
-  let parsed: ParsedSource | undefined;
-  let discardEmptyAttestation: boolean;
-  let claimedByThisRun = false;
+  let operation = `reading legacy workspace state at ${params.source.sourcePath}`;
+  let claimAttempted = false;
+  let imported: ReturnType<typeof importAndRecordReceipt> | undefined;
   try {
-    snapshot = await sourceClaim.read(!hasSource);
+    let snapshot = await sourceClaim.read(!hasSource);
     // Empty reserved hashed markers have no importable state. The runtime gate is
     // presence-only, so leaving them in place blocks agent turns forever.
     // Nonempty, linked, sibling, and unreadable sources stay fail-closed.
-    discardEmptyAttestation =
+    const discardEmptyAttestation =
       params.source.kind === "attestation" &&
       path.basename(path.dirname(params.source.sourcePath)) ===
         LEGACY_WORKSPACE_ATTESTATION_DIRNAME &&
       snapshot.size === 0;
-    if (!discardEmptyAttestation) {
-      parsed = parseSource(params.source, snapshot);
-    }
-  } catch (error) {
-    return {
-      changes: [],
-      warnings: [formatLegacyWorkspaceReadWarning(params.source, error)],
-    };
-  }
+    const parsed = discardEmptyAttestation ? undefined : parseSource(params.source, snapshot);
+    operation = discardEmptyAttestation
+      ? `discarding empty reserved workspace attestation at ${params.source.sourcePath}`
+      : "migrating legacy workspace state";
 
-  if (hasSource) {
-    try {
+    if (hasSource) {
+      // A failed claim may already have renamed the source; restore it on any
+      // pre-import failure, but retain committed imports for receipt-based retry.
+      claimAttempted = true;
       snapshot = await sourceClaim.claim({
         snapshot,
         beforeClaim: () => {
@@ -542,46 +504,19 @@ async function migrateOneSource(params: {
         },
         mismatchMessage: "legacy workspace source changed before Doctor could claim it",
       });
-      claimedByThisRun = true;
-    } catch (error) {
-      const restoreError = await sourceClaim.restore();
-      return {
-        changes: [],
-        warnings: [
-          `Failed ${discardEmptyAttestation ? `discarding empty reserved workspace attestation at ${params.source.sourcePath}` : "migrating legacy workspace state"}: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`,
-        ],
-      };
     }
-  }
 
-  let imported:
-    | { parsed: ParsedSource; receipt: ReturnType<typeof importAndRecordReceipt> }
-    | undefined;
-  if (parsed) {
-    try {
+    if (parsed) {
       assertConfiguredWorkspaceIdentity(params.source);
-      imported = {
+      imported = importAndRecordReceipt({
+        source: params.source,
+        snapshot,
         parsed,
-        receipt: importAndRecordReceipt({
-          source: params.source,
-          snapshot,
-          parsed,
-          env: params.env,
-          replaceRemovedReceipt: receipt?.removedSource === true,
-        }),
-      };
-    } catch (error) {
-      const restoreError = claimedByThisRun ? await sourceClaim.restore() : null;
-      return {
-        changes: [],
-        warnings: [
-          `Failed migrating legacy workspace state: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`,
-        ],
-      };
+        env: params.env,
+        replaceRemovedReceipt: receipt?.removedSource === true,
+      });
     }
-  }
 
-  try {
     if (await sourceClaim.exists()) {
       throw new Error("legacy workspace source reappeared during import");
     }
@@ -592,22 +527,22 @@ async function migrateOneSource(params: {
     assertConfiguredWorkspaceIdentity(params.source);
     await sourceClaim.remove({ removeSource: params.removeSource, skipSourceCheck: true });
     if (imported) {
-      markLegacyMigrationSourceRemoved(imported.receipt.sourceKey, params.env);
+      markLegacyMigrationSourceRemoved(imported.sourceKey, params.env);
     }
   } catch (error) {
-    if (discardEmptyAttestation) {
-      const restoreError = claimedByThisRun ? await sourceClaim.restore() : null;
+    if (imported) {
       return {
         changes: [],
         warnings: [
-          `Failed discarding empty reserved workspace attestation at ${params.source.sourcePath}: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`,
+          `Workspace state is in SQLite, but legacy cleanup failed at ${params.source.sourcePath}: ${formatErrorMessage(error)}`,
         ],
       };
     }
+    const restoreError = claimAttempted ? await sourceClaim.restore() : null;
     return {
       changes: [],
       warnings: [
-        `Workspace state is in SQLite, but legacy cleanup failed: ${formatErrorMessage(error)}`,
+        `Failed ${operation}: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`,
       ],
     };
   }
@@ -618,13 +553,10 @@ async function migrateOneSource(params: {
       warnings: [],
     };
   }
-  const label =
-    imported.parsed.kind === "setup" ? "workspace setup state" : "workspace attestation";
+  const label = params.source.kind === "setup" ? "workspace setup state" : "workspace attestation";
   return {
     changes: [
-      imported.receipt.imported
-        ? `Migrated ${label} to SQLite.`
-        : `Verified canonical SQLite ${label}.`,
+      imported.imported ? `Migrated ${label} to SQLite.` : `Verified canonical SQLite ${label}.`,
     ],
     warnings: [],
     notices: ["Removed retired workspace state after verified SQLite import."],


### PR DESCRIPTION
Related: #134641, #134445.

## What Problem This Solves

Fixes an issue where users retrying `openclaw doctor --fix` after a workspace import would receive a cleanup warning without the path of the file still blocking startup. A damaged `.doctor-importing` claim reproduces this even when the imported workspace state is already safely in SQLite.

## Why This Change Was Made

Doctor now names the source in both initial post-import cleanup failures and receipt-backed retry failures. This follow-up also consolidates sibling-marker detection between Doctor and runtime, flattens migration into one read/claim/import/cleanup flow, shares the generated-hash insertion operation, and removes an unreachable read-only condition.

The migration owner still restores failed pre-import claims and retains committed imports for receipt-based cleanup. File identity, snapshot, symlink/hardlink, canonical-state verification, and transaction ordering remain enforced. No schema, configuration, or persistence contract changes. Production: 76 additions / 153 deletions, net **−77 lines**; tests: 14 additions / 10 deletions, net **+4 lines**.

## User Impact

Operators can identify the file that needs attention when cleanup cannot finish. Empty reserved markers continue to clear through Doctor, valid workspace state and customized workspace files remain intact, and malformed nonempty sources remain available for recovery. This completes the diagnostic path requirement already documented in the workspace guide and flagged in the original PR review.

## Evidence

- Real published `openclaw@2026.8.1` CLI reproduced the original loop in isolated homes: empty reserved markers and interrupted empty claims survived Doctor, and subsequent agent startup failed with the same migration-required error.
- The built candidate CLI removed both empty variants. The real Gateway then returned HTTP 200 from `/readyz` with `ready: true`, and `health --json` exited 0 with `ok: true` and no plugin errors. All test-owned Gateway processes were stopped.
- Valid setup/attestation import retained milestone timestamps and customized `AGENTS.md` content. Nonempty malformed sources were retained byte-for-byte and Doctor reported failure.
- A receipt-backed malformed claim reproduced the missing-path warning before the change; the final built CLI reports the exact source path while preserving the claim and customized workspace content.
- The extended existing cleanup-retry test failed before the diagnostic change and passes after it, including a damaged claim, restoration of its original bytes, and a successful cleanup-only retry. All **99 focused tests across five files** pass, covering setup migration, recreated sources, sandbox safety, runtime legacy guards, and canonical state storage.
- Core typechecking and changed-file structural guards passed. The aggregate local check stopped at core-test typechecking because the shared installed dependencies resolve `pako@1.0.11` while this checkout pins `3.0.1`; no dependency files were modified. Hosted CI verifies a clean dependency installation.

This is real CLI/Gateway proof with isolated local state and a built candidate, not a successful model-response test or a hermetic candidate package-install test. Agent startup cleared the migration gate and then reached the clean fixture's unavailable harness configuration.
