### PR TITLE
fix(chat): publish retry state for settings failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.
+
 - **macOS AI setup:** show confirmed capability-review cancellation and retry guidance directly instead of a misleading Gateway failure headline. (#134573)
 - **Doctor memory:** keep Matrix migration codecs separate from the live client and avoid loading the ACP runtime when no legacy session records need inspection.
 - **Agent prompts:** keep model-identity guidance conditional so ordinary requests are not mistaken for questions about the current model.

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
@@ -883,12 +883,11 @@ extension OpenClawChatViewModel {
             agentID: command.agentID,
             sessionRoutingContract: command.routingContract)
         {
-            _ = await outbox.markCommandFailedIfPresent(
-                id: command.id,
-                attemptVersion: command.attemptVersion,
+            _ = await self.failOutboxCommand(
+                command,
+                outbox: outbox,
                 retryCount: command.retryCount,
-                lastError: settingsError)
-            self.setOutboxState(.failed(reason: settingsError), forCommandID: command.id)
+                reason: settingsError)
             self.errorText = settingsError
             return .stop
         }
@@ -897,28 +896,26 @@ extension OpenClawChatViewModel {
         {
             let reason = OpenClawChatSQLiteTranscriptCache.outboxSettingsGatewayUpgradeRequiredError
             let message = OpenClawChatSQLiteTranscriptCache.outboxDisplayError(reason)
-            _ = await outbox.markCommandFailedIfPresent(
-                id: command.id,
-                attemptVersion: command.attemptVersion,
+            let update = await self.failOutboxCommand(
+                command,
+                outbox: outbox,
                 retryCount: command.retryCount,
-                lastError: reason)
-            self.setOutboxState(.failed(reason: message), forCommandID: command.id)
+                reason: reason)
             self.errorText = message
-            return .continueFlush
+            return update == .unavailable ? .stop : .continueFlush
         }
         if routeLease.supportsSessionSettingsCAS,
            command.expectedSessionSettings == nil
         {
             let reason = OpenClawChatSQLiteTranscriptCache.outboxSettingsReviewRequiredError
             let message = OpenClawChatSQLiteTranscriptCache.outboxDisplayError(reason)
-            _ = await outbox.markCommandFailedIfPresent(
-                id: command.id,
-                attemptVersion: command.attemptVersion,
+            let update = await self.failOutboxCommand(
+                command,
+                outbox: outbox,
                 retryCount: command.retryCount,
-                lastError: reason)
-            self.setOutboxState(.failed(reason: message), forCommandID: command.id)
+                reason: reason)
             self.errorText = message
-            return .continueFlush
+            return update == .unavailable ? .stop : .continueFlush
         }
         self.setOutboxState(.sending, forCommandID: command.id)
         do {
@@ -1103,23 +1100,11 @@ extension OpenClawChatViewModel {
         _ command: OpenClawChatOutboxCommand,
         outbox: any OpenClawChatCommandOutbox) async -> Bool
     {
-        let storedReason = OpenClawChatSQLiteTranscriptCache.outboxSettingsChangedError
-        let reason = OpenClawChatSQLiteTranscriptCache.outboxDisplayError(storedReason)
-        let update = await outbox.markCommandFailedIfPresent(
-            id: command.id,
-            attemptVersion: command.attemptVersion,
+        await self.failOutboxCommand(
+            command,
+            outbox: outbox,
             retryCount: command.retryCount,
-            lastError: storedReason)
-        guard update != .unavailable else {
-            self.applyTransportHealth(false)
-            return false
-        }
-        if update == .updated {
-            self.setOutboxState(.failed(reason: reason), forCommandID: command.id)
-        } else {
-            self.clearOutboxState(forCommandID: command.id)
-        }
-        return true
+            reason: OpenClawChatSQLiteTranscriptCache.outboxSettingsChangedError) != .unavailable
     }
 
     /// Gateway rejections ("error"/"timeout" send acks) burn a retry attempt

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxSettingsTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxSettingsTests.swift
@@ -47,33 +47,61 @@ struct ChatViewModelOutboxSettingsTests {
         #expect(await transport.state.sentSessionSettings[0] == expectation)
     }
 
-    @Test func `CAS gateway parks a legacy command without a settings expectation`() async throws {
+    @Test(arguments: [false, true])
+    func `settings failures remain retryable before outbox reload`(gatewayRejectsSettings: Bool) async throws {
         let (store, _, databaseDirectory) = try makeOutboxStore()
         defer { try? FileManager.default.removeItem(at: databaseDirectory) }
         #expect(await store.enqueueCommand(outboxTestCommand(
             id: "legacy-settings",
             text: "review before replay",
             createdAt: Date().timeIntervalSince1970,
-            expectedSessionSettings: nil)))
+            expectedSessionSettings: gatewayRejectsSettings
+                ? OpenClawChatSessionSettingsExpectation(permissionMode: nil, toolOverrides: nil)
+                : nil)))
+        let outbox = ScriptedOutbox(base: store)
         let transport = OutboxTestTransport(
-            healthy: true,
+            healthy: false,
             sessions: [outboxSessionEntry(key: "main", thinkingLevels: ["off"])],
             supportsSessionSettingsCAS: true)
-        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+        await transport.state.update { $0.sendSettingsChanged = gatewayRejectsSettings }
+        let vm = await makeOutboxViewModel(transport: transport, outbox: outbox)
 
         await MainActor.run { vm.load() }
-        try await waitUntil("legacy command parked") {
-            await store.loadCommands().first?.status == .failed
+        try await waitUntil("offline bootstrap settled") {
+            await MainActor.run { !vm.isLoading && vm.hasRestoredOutboxMessages }
         }
+        await outbox.holdLoadAfterFailure()
+        await transport.goOnline()
+        await outbox.waitUntilSnapshotCaptured()
 
-        #expect(await transport.state.sentMessages.isEmpty)
-        let failed = try #require(await store.loadCommands().first)
-        #expect(failed.lastError == OpenClawChatSQLiteTranscriptCache.outboxSettingsReviewRequiredError)
-        #expect(OpenClawChatSQLiteTranscriptCache.outboxDisplayError(failed.lastError) ==
-            "Session settings were not captured. Review and retry this message.")
+        do {
+            #expect(await transport.state.sentMessages.isEmpty)
+            let failed = try #require(await store.loadCommands().first)
+            #expect(failed.lastError == (gatewayRejectsSettings
+                    ? OpenClawChatSQLiteTranscriptCache.outboxSettingsChangedError
+                    : OpenClawChatSQLiteTranscriptCache.outboxSettingsReviewRequiredError))
+            if !gatewayRejectsSettings {
+                #expect(OpenClawChatSQLiteTranscriptCache.outboxDisplayError(failed.lastError) ==
+                    "Session settings were not captured. Review and retry this message.")
+            }
+            await transport.state.update { $0.sendSettingsChanged = false }
 
-        let messageID = try #require(await MainActor.run { vm.messages.last?.id })
-        await MainActor.run { vm.retryOutboxMessage(messageID) }
+            // A visible failure must authorize retry before any later reload can supply its version.
+            let messageID = try #require(await MainActor.run {
+                vm.messages.first { vm.outboxState(for: $0.id)?.isFailed == true }?.id
+            })
+            await MainActor.run { vm.retryOutboxMessage(messageID) }
+            try await waitUntil("reviewed settings rebound before reload") {
+                await store.loadCommands().first?.status == .queued
+            }
+        } catch {
+            await outbox.releaseSnapshot()
+            try? await waitUntil("failed proof flush released") {
+                await MainActor.run { !vm.isFlushingOutbox }
+            }
+            throw error
+        }
+        await outbox.releaseSnapshot()
         try await waitUntil("reviewed settings rebound and sent") {
             await transport.state.sentMessages == ["review before replay"]
         }
@@ -82,28 +110,49 @@ struct ChatViewModelOutboxSettingsTests {
         ])
     }
 
-    @Test func `pre CAS gateway parks a fenced command with upgrade guidance`() async throws {
+    @Test(arguments: [OpenClawChatOutboxUpdateResult.updated, .unavailable, .confirmed, .superseded])
+    func `pre CAS parking honors the terminal write result`(
+        terminalResult: OpenClawChatOutboxUpdateResult) async throws
+    {
         let (store, _, databaseDirectory) = try makeOutboxStore()
         defer { try? FileManager.default.removeItem(at: databaseDirectory) }
-        #expect(await store.enqueueCommand(outboxTestCommand(
+        let command = outboxTestCommand(
             id: "pre-cas-settings",
             text: "wait for gateway upgrade",
             createdAt: Date().timeIntervalSince1970,
             expectedSessionSettings: OpenClawChatSessionSettingsExpectation(
                 permissionMode: .guarded,
-                toolOverrides: nil))))
-        let transport = OutboxTestTransport(
-            healthy: true,
-            supportsSessionSettingsCAS: false)
-        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+                toolOverrides: nil))
+        #expect(await store.enqueueCommand(command))
+        let outbox = ScriptedOutbox(base: store)
+        await outbox.setTerminalWriteResult(terminalResult)
+        let transport = OutboxTestTransport(healthy: false, supportsSessionSettingsCAS: false)
+        let vm = await makeOutboxViewModel(transport: transport, outbox: outbox)
 
         await MainActor.run { vm.load() }
-        try await waitUntil("pre-CAS row parked") {
-            await store.loadCommands().first?.status == .failed
+        await transport.goOnline()
+        try await waitUntil("pre-CAS terminal result settled") {
+            let commands = await store.loadCommands()
+            let storedResult = switch terminalResult {
+            case .updated: commands.first?.status == .failed
+            case .unavailable: commands.first?.status == .sending
+            case .confirmed, .missing: commands.isEmpty
+            case .superseded: commands.first?.status == .sending && commands.first?.attemptVersion == command
+                .attemptVersion + 1
+            }
+            return await MainActor.run {
+                storedResult && !vm.isFlushingOutbox && (terminalResult != .unavailable || !vm.healthOK)
+            }
         }
         #expect(await transport.state.sentMessages.isEmpty)
-        #expect(await store.loadCommands().first?.lastError ==
-            OpenClawChatSQLiteTranscriptCache.outboxSettingsGatewayUpgradeRequiredError)
+        if terminalResult == .updated {
+            #expect(await store.loadCommands().first?.lastError ==
+                OpenClawChatSQLiteTranscriptCache.outboxSettingsGatewayUpgradeRequiredError)
+        } else {
+            #expect(await MainActor.run {
+                vm.messages.allSatisfy { vm.outboxState(for: $0.id)?.isFailed != true }
+            })
+        }
     }
 
     @Test func `failed restrictive patch cannot release a later automatic flush`() async throws {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
@@ -87,6 +87,7 @@ actor OutboxTransportState {
     var sendRejects = false
     var sendResponseErrors = false
     var sendRoutingChanged = false
+    var sendSettingsChanged = false
     var historyFails = false
     var sessionListFails = false
     var historyRequestCount = 0
@@ -379,6 +380,13 @@ final class OutboxTestTransport: @unchecked Sendable, OpenClawChatTransport {
                     "reason": AnyCodable(OpenClawChatSessionRoutingContract.changedErrorReason),
                 ])
         }
+        if await self.state.sendSettingsChanged {
+            throw GatewayResponseError(
+                method: "chat.send",
+                code: "INVALID_REQUEST",
+                message: "session settings changed; review and retry",
+                details: ["reason": AnyCodable(OpenClawChatSessionSettingsContract.changedErrorReason)])
+        }
         if await self.state.sendRejects {
             // Gateway responded but refused to start the run.
             return OpenClawChatSendResponse(runId: idempotencyKey, status: "error")
@@ -561,11 +569,12 @@ actor ScriptedOutbox: OpenClawChatCommandOutbox {
     private var loadDelayNanoseconds: UInt64 = 0
     private var enqueueRelease: DeleteGate?
     private var recoveryAvailable = true
-    private var terminalWritesAvailable = true
+    private var terminalWriteResult: OpenClawChatOutboxUpdateResult = .updated
     private var parkingAvailable = true
     private var captured = DeleteGate()
     private var snapshotRelease = DeleteGate()
     private var shouldHoldNextLoad = false
+    private var shouldHoldLoadAfterFailure = false
     private let enqueueStarted = DeleteGate()
     private let recoveryAttempted = DeleteGate()
     private let canceled = DeleteGate()
@@ -589,7 +598,11 @@ actor ScriptedOutbox: OpenClawChatCommandOutbox {
     }
 
     func setTerminalWritesAvailable(_ available: Bool) {
-        self.terminalWritesAvailable = available
+        self.terminalWriteResult = available ? .updated : .unavailable
+    }
+
+    func setTerminalWriteResult(_ result: OpenClawChatOutboxUpdateResult) {
+        self.terminalWriteResult = result
     }
 
     func setParkingAvailable(_ available: Bool) {
@@ -611,6 +624,12 @@ actor ScriptedOutbox: OpenClawChatCommandOutbox {
     func releaseEnqueue() async {
         await self.enqueueRelease?.open()
         self.enqueueRelease = nil
+    }
+
+    func holdLoadAfterFailure() {
+        self.captured = DeleteGate()
+        self.snapshotRelease = DeleteGate()
+        self.shouldHoldLoadAfterFailure = true
     }
 
     func holdNextLoad() {
@@ -703,12 +722,30 @@ actor ScriptedOutbox: OpenClawChatCommandOutbox {
         retryCount: Int,
         lastError: String?) async -> OpenClawChatOutboxUpdateResult
     {
-        guard self.terminalWritesAvailable else { return .unavailable }
-        return await self.base.markCommandFailedIfPresent(
+        switch self.terminalWriteResult {
+        case .unavailable:
+            return .unavailable
+        case .confirmed, .missing:
+            _ = await self.base.confirmCommand(id: id, attemptVersion: attemptVersion)
+            return self.terminalWriteResult
+        case .superseded:
+            _ = await self.base.markCommandQueued(
+                id: id, attemptVersion: attemptVersion, retryCount: retryCount, lastError: nil)
+            _ = await self.base.claimNextCommand()
+            return .superseded
+        case .updated:
+            break
+        }
+        let result = await self.base.markCommandFailedIfPresent(
             id: id,
             attemptVersion: attemptVersion,
             retryCount: retryCount,
             lastError: lastError)
+        if result == .updated, self.shouldHoldLoadAfterFailure {
+            self.shouldHoldLoadAfterFailure = false
+            self.shouldHoldNextLoad = true
+        }
+        return result
     }
 
     func parkQueuedCommands(


### PR DESCRIPTION
## What Problem This Solves

Apple chat could display **Retry Send** after a session-settings failure while clicking it silently did nothing. The failed badge was visible, but the view model had not published the exact failed attempt required by the retry action. A later outbox reload could hide the defect. The investigation began with an intermittent native CI test that also waited for SQLite state instead of visible retry readiness; its exact hosted schedule was not reproduced.

## Why This Change Was Made

Four settings-failure paths bypassed the existing `failOutboxCommand` owner and updated only the badge after writing the failure to SQLite. They now use the canonical helper, which publishes the badge and retry version together, clears stale presentation when the command has already moved on, and stops flushing when the durable write is unavailable. The duplicated settings-specific failure path is removed.

Production changes are +18/-33 (net -15). The SQLite schema, transactions, retry authorization, Gateway protocol, settings comparison, timeouts and concurrency policy are unchanged. The shared fix applies to iOS and macOS chat; it changes no visual layout or localized strings.

## Evidence

- Holding the first post-failure reload reproduces the defect against unchanged production: the public failed state is visible but the public retry action cannot requeue the real SQLite row. Both a legacy missing-settings command and a Gateway settings rejection fail before the fix. The unavailable-write case also fails its health/settlement expectation before the fix.
- With the fix, both public retry actions requeue before the held reload and then deliver through the injected transport with the captured settings. All 61 Outbox and OutboxSettings tests pass, including terminal-write results, stale attempts, cross-view confirmation, unavailable storage and restrictive-mutation siblings.
- The final Swift build, scoped SwiftFormat and production SwiftLint checks pass. The native proof ran through the compiled SwiftPM helper in an audited deny-default OS sandbox with task-only state; negative probes rejected outside-file access, network connections and unapproved executables. This is real view-model/SQLite behavior with an injected transport, not GUI or authenticated Gateway proof. No operator app, preferences, Keychain or Gateway was used.
- The exact interleaving where an already-claimed send observes a pending restrictive mutation failure is covered by source inspection and existing mutation siblings, not a new forced private-waiter hook. The same canonical failure helper owns that path.
- The local changed-plan also selects the broad macOS TypeScript packaging/signing suite. Duplicate execution was held while a separate owned run was active; the full local changed gate is not claimed green. Required exact-head hosted CI remains a landing gate.
