### PR TITLE
fix(twilio): consume media stream tokens once

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1343,7 +1343,7 @@ extensions/voice-call/src/realtime-agent-context.ts	1
 extensions/voice-call/src/response-generator.ts	3
 extensions/voice-call/src/runtime.ts	3
 extensions/voice-call/src/tts-provider-voice.ts	1
-extensions/voice-call/src/webhook.ts	10
+extensions/voice-call/src/webhook.ts	9
 extensions/voice-call/src/webhook/realtime-handler.ts	1
 extensions/volcengine/tts.ts	2
 extensions/voyage/embedding-batch.ts	1

--- a/extensions/voice-call/src/media-stream.test.ts
+++ b/extensions/voice-call/src/media-stream.test.ts
@@ -90,6 +90,7 @@ describe("MediaStreamHandler security hardening", () => {
 
     try {
       const ws = await connectWs(server.url);
+      const closed = waitForClose(ws);
       ws.send("{not json");
 
       await vi.waitFor(() => {
@@ -107,8 +108,7 @@ describe("MediaStreamHandler security hardening", () => {
       expect(error).not.toBeInstanceOf(SyntaxError);
       expect((error as Error).cause).toBeInstanceOf(SyntaxError);
 
-      ws.close();
-      await waitForClose(ws);
+      await expect(closed).resolves.toEqual({ code: 1011, reason: "Stream setup failed" });
     } finally {
       errorSpy.mockRestore();
       await server.close();

--- a/extensions/voice-call/src/media-stream.test.ts
+++ b/extensions/voice-call/src/media-stream.test.ts
@@ -115,6 +115,60 @@ describe("MediaStreamHandler security hardening", () => {
     }
   });
 
+  it("closes an active stream with a processing reason when audio forwarding fails", async () => {
+    const closeSession = vi.fn();
+    const onConnect = vi.fn();
+    const onDisconnect = vi.fn();
+    const handler = new MediaStreamHandler({
+      transcriptionProvider: {
+        createSession: () => ({
+          ...createStubSession(),
+          sendAudio: () => {
+            throw new Error("synthetic audio forwarding failure");
+          },
+          close: closeSession,
+        }),
+        id: "openai",
+        label: "OpenAI",
+        isConfigured: () => true,
+      },
+      providerConfig: {},
+      shouldAcceptStream: () => true,
+      onConnect,
+      onDisconnect,
+    });
+    const server = await startWsServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          streamSid: "MZ-processing-failure",
+          start: { callSid: "CA-processing-failure" },
+        }),
+      );
+      await vi.waitFor(() => expect(onConnect).toHaveBeenCalledOnce());
+
+      const closed = waitForClose(ws);
+      ws.send(
+        JSON.stringify({
+          event: "media",
+          streamSid: "MZ-processing-failure",
+          media: { payload: Buffer.from("audio").toString("base64") },
+        }),
+      );
+
+      await expect(closed).resolves.toEqual({ code: 1011, reason: "Stream processing failed" });
+      await vi.waitFor(() => {
+        expect(onDisconnect).toHaveBeenCalledWith("CA-processing-failure", "MZ-processing-failure");
+      });
+      expect(closeSession).toHaveBeenCalledOnce();
+    } finally {
+      await server.close();
+    }
+  });
+
   it("rejects start frames when no stream acceptance validator is configured", async () => {
     const createSession = vi.fn(() => createStubSession());
     const handler = new MediaStreamHandler({

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -335,7 +335,7 @@ export class MediaStreamHandler {
         }
       } catch (error) {
         console.error("[MediaStream] Error processing message:", error);
-        ws.close(1011, "Stream setup failed");
+        ws.close(1011, session ? "Stream processing failed" : "Stream setup failed");
       }
     });
 
@@ -390,8 +390,8 @@ export class MediaStreamHandler {
     }
 
     if (!this.config.shouldAcceptStream({ callId: callSid, streamSid, token: effectiveToken })) {
-      console.warn(`[MediaStream] Rejecting stream for unknown call: ${callSid}`);
-      ws.close(1008, "Unknown call");
+      console.warn(`[MediaStream] Rejecting unauthorized stream for call: ${callSid}`);
+      ws.close(1008, "Unauthorized stream");
       return null;
     }
 

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -335,6 +335,7 @@ export class MediaStreamHandler {
         }
       } catch (error) {
         console.error("[MediaStream] Error processing message:", error);
+        ws.close(1011, "Stream setup failed");
       }
     });
 
@@ -363,7 +364,7 @@ export class MediaStreamHandler {
     message: TwilioMediaMessage,
     streamToken?: string,
   ): StreamSession | null {
-    const streamSid = message.streamSid || "";
+    const streamSid = message.streamSid;
     const callSid = message.start?.callSid || "";
 
     // Prefer token from start message customParameters (set via TwiML <Parameter>),
@@ -371,6 +372,11 @@ export class MediaStreamHandler {
     // URLs but reliably delivers <Parameter> values in customParameters.
     const effectiveToken = message.start?.customParameters?.token ?? streamToken;
 
+    if (typeof streamSid !== "string" || !streamSid.trim()) {
+      console.warn("[MediaStream] Missing streamSid; closing stream");
+      ws.close(1008, "Missing streamSid");
+      return null;
+    }
     console.log(`[MediaStream] Stream started: ${streamSid} (call: ${callSid})`);
     if (!callSid) {
       console.warn("[MediaStream] Missing callSid; closing stream");

--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -388,7 +388,7 @@ describe("TwilioProvider", () => {
     expect(secondBody).not.toContain("hold-queue");
   });
 
-  it("binds a stream token to one live stream and releases it for reconnect", () => {
+  it("consumes each stream token once and mints a replacement for later TwiML", () => {
     const provider = createProvider();
     const inbound = createContext("CallStatus=ringing&Direction=inbound&CallSid=CA-reconnect");
     const firstBody = requireResponseBody(provider.parseWebhookEvent(inbound).providerResponseBody);
@@ -397,19 +397,27 @@ describe("TwilioProvider", () => {
       throw new Error("expected first stream token");
     }
 
-    expect(provider.validateStreamToken("CA-reconnect", firstToken)).toBe(true);
+    expect(provider.consumeStreamToken("CA-reconnect", firstToken)).toBe(true);
     provider.registerCallStream("CA-reconnect", "MZ-first");
-    expect(provider.validateStreamToken("CA-reconnect", firstToken)).toBe(false);
+    expect(provider.consumeStreamToken("CA-reconnect", firstToken)).toBe(false);
 
     provider.unregisterCallStream("CA-reconnect", "MZ-first");
-    expect(provider.validateStreamToken("CA-reconnect", firstToken)).toBe(true);
+    expect(provider.consumeStreamToken("CA-reconnect", firstToken)).toBe(false);
+
+    const reconnectBody = requireResponseBody(
+      provider.parseWebhookEvent(inbound).providerResponseBody,
+    );
+    const reconnectToken = reconnectBody.match(/<Parameter name="token" value="([^"]+)"/u)?.[1];
+    if (!reconnectToken) {
+      throw new Error("expected reconnect stream token");
+    }
+    expect(reconnectToken).not.toBe(firstToken);
+    expect(provider.consumeStreamToken("CA-reconnect", reconnectToken)).toBe(true);
+
     provider.registerCallStream("CA-reconnect", "MZ-reconnect");
+    // A stale predecessor disconnect must not unregister the replacement stream.
     provider.unregisterCallStream("CA-reconnect", "MZ-first");
     expect(provider.hasRegisteredStream("CA-reconnect", "MZ-reconnect")).toBe(true);
-
-    provider.revokeStreamToken("CA-reconnect");
-    provider.unregisterCallStream("CA-reconnect", "MZ-reconnect");
-    expect(provider.validateStreamToken("CA-reconnect", firstToken)).toBe(false);
   });
 
   it("cleans up active inbound call on completed status callback", () => {

--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -388,6 +388,30 @@ describe("TwilioProvider", () => {
     expect(secondBody).not.toContain("hold-queue");
   });
 
+  it("binds a stream token to one live stream and releases it for reconnect", () => {
+    const provider = createProvider();
+    const inbound = createContext("CallStatus=ringing&Direction=inbound&CallSid=CA-reconnect");
+    const firstBody = requireResponseBody(provider.parseWebhookEvent(inbound).providerResponseBody);
+    const firstToken = firstBody.match(/<Parameter name="token" value="([^"]+)"/u)?.[1];
+    if (!firstToken) {
+      throw new Error("expected first stream token");
+    }
+
+    expect(provider.validateStreamToken("CA-reconnect", firstToken)).toBe(true);
+    provider.registerCallStream("CA-reconnect", "MZ-first");
+    expect(provider.validateStreamToken("CA-reconnect", firstToken)).toBe(false);
+
+    provider.unregisterCallStream("CA-reconnect", "MZ-first");
+    expect(provider.validateStreamToken("CA-reconnect", firstToken)).toBe(true);
+    provider.registerCallStream("CA-reconnect", "MZ-reconnect");
+    provider.unregisterCallStream("CA-reconnect", "MZ-first");
+    expect(provider.hasRegisteredStream("CA-reconnect", "MZ-reconnect")).toBe(true);
+
+    provider.revokeStreamToken("CA-reconnect");
+    provider.unregisterCallStream("CA-reconnect", "MZ-reconnect");
+    expect(provider.validateStreamToken("CA-reconnect", firstToken)).toBe(false);
+  });
+
   it("cleans up active inbound call on completed status callback", () => {
     const provider = createProvider();
     const firstInbound = createContext("CallStatus=ringing&Direction=inbound&CallSid=CA411");

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -204,16 +204,15 @@ export class TwilioProvider implements VoiceCallProvider {
     return Boolean(this.mediaStreamHandler && this.getStreamUrl());
   }
 
-  validateStreamToken(callSid: string, token?: string): boolean {
+  consumeStreamToken(callSid: string, token?: string): boolean {
     const expected = this.streamAuthTokens.get(callSid);
     if (!expected || !token || !safeEqualSecret(expected, token)) {
       return false;
     }
-    return !this.hasRegisteredStream(callSid);
-  }
-
-  revokeStreamToken(callSid: string): void {
+    // A rendered TwiML capability admits one WebSocket. Any later Stream must
+    // be created from TwiML carrying a newly minted capability.
     this.streamAuthTokens.delete(callSid);
+    return true;
   }
 
   /**

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -204,12 +204,16 @@ export class TwilioProvider implements VoiceCallProvider {
     return Boolean(this.mediaStreamHandler && this.getStreamUrl());
   }
 
-  isValidStreamToken(callSid: string, token?: string): boolean {
+  validateStreamToken(callSid: string, token?: string): boolean {
     const expected = this.streamAuthTokens.get(callSid);
-    if (!expected || !token) {
+    if (!expected || !token || !safeEqualSecret(expected, token)) {
       return false;
     }
-    return safeEqualSecret(expected, token);
+    return !this.hasRegisteredStream(callSid);
+  }
+
+  revokeStreamToken(callSid: string): void {
+    this.streamAuthTokens.delete(callSid);
   }
 
   /**

--- a/extensions/voice-call/src/webhook.auto-response.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook.auto-response.lifecycle.test.ts
@@ -53,11 +53,8 @@ class SpeechProvider extends FakeProvider {
   override parseWebhookEvent(ctx: WebhookContext) {
     return { events: [JSON.parse(ctx.rawBody) as NormalizedEvent], statusCode: 200 };
   }
-  validateStreamToken(callId: string) {
-    return !this.streamOwner.hasRegisteredStream(callId);
-  }
-  revokeStreamToken(callId: string) {
-    this.streamOwner.revokeStreamToken(callId);
+  consumeStreamToken() {
+    return true;
   }
   registerCallStream(callId: string, streamId: string) {
     this.streamOwner.registerCallStream(callId, streamId);
@@ -281,9 +278,6 @@ describe("automatic phone reply ownership", () => {
       const old = await call.openStream("stream-old");
       old.callbacks.onTranscript?.("old question");
       await responseAt(0);
-      const closed = waitForClose(old.ws);
-      old.ws.close();
-      await closed;
       const replacement = await call.openStream("stream-new");
       replacement.callbacks.onTranscript?.("new question");
       const current = await responseAt(1);
@@ -308,12 +302,12 @@ describe("automatic phone reply ownership", () => {
     const old = await call.openStream("stream-old");
     old.callbacks.onTranscript?.("old question");
     const first = await responseAt(0);
-    const closed = waitForClose(old.ws);
-    old.ws.close();
-    await closed;
     const replacement = await call.openStream("stream-new");
     replacement.callbacks.onTranscript?.("new question");
     const second = await responseAt(1);
+    const closed = waitForClose(old.ws);
+    old.ws.close();
+    await closed;
     await first.finish("obsolete reply");
     await second.finish("replacement reply");
     expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual(["replacement reply"]);

--- a/extensions/voice-call/src/webhook.auto-response.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook.auto-response.lifecycle.test.ts
@@ -53,8 +53,11 @@ class SpeechProvider extends FakeProvider {
   override parseWebhookEvent(ctx: WebhookContext) {
     return { events: [JSON.parse(ctx.rawBody) as NormalizedEvent], statusCode: 200 };
   }
-  isValidStreamToken() {
-    return true;
+  validateStreamToken(callId: string) {
+    return !this.streamOwner.hasRegisteredStream(callId);
+  }
+  revokeStreamToken(callId: string) {
+    this.streamOwner.revokeStreamToken(callId);
   }
   registerCallStream(callId: string, streamId: string) {
     this.streamOwner.registerCallStream(callId, streamId);
@@ -278,6 +281,9 @@ describe("automatic phone reply ownership", () => {
       const old = await call.openStream("stream-old");
       old.callbacks.onTranscript?.("old question");
       await responseAt(0);
+      const closed = waitForClose(old.ws);
+      old.ws.close();
+      await closed;
       const replacement = await call.openStream("stream-new");
       replacement.callbacks.onTranscript?.("new question");
       const current = await responseAt(1);
@@ -302,12 +308,12 @@ describe("automatic phone reply ownership", () => {
     const old = await call.openStream("stream-old");
     old.callbacks.onTranscript?.("old question");
     const first = await responseAt(0);
-    const replacement = await call.openStream("stream-new");
-    replacement.callbacks.onTranscript?.("new question");
-    const second = await responseAt(1);
     const closed = waitForClose(old.ws);
     old.ws.close();
     await closed;
+    const replacement = await call.openStream("stream-new");
+    replacement.callbacks.onTranscript?.("new question");
+    const second = await responseAt(1);
     await first.finish("obsolete reply");
     await second.finish("replacement reply");
     expect(call.provider.playTtsCalls.map((entry) => entry.text)).toEqual(["replacement reply"]);

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -11,10 +11,11 @@ import type { VoiceCallProvider } from "./providers/base.js";
 import { MockProvider } from "./providers/mock.js";
 import { PlivoProvider } from "./providers/plivo.js";
 import { TwilioProvider } from "./providers/twilio.js";
-import type { CallRecord, NormalizedEvent } from "./types.js";
+import type { CallRecord, NormalizedEvent, WebhookContext } from "./types.js";
 import { createWebhookReplayCache, reserveWebhookReplay } from "./webhook-replay.js";
 import { VoiceCallWebhookServer } from "./webhook.js";
 import type { RealtimeCallHandler } from "./webhook/realtime-handler.js";
+import { connectWs, waitForClose } from "./websocket-test-support.js";
 
 const mocks = vi.hoisted(() => {
   const realtimeTranscriptionProvider: RealtimeTranscriptionProviderPlugin = {
@@ -32,6 +33,7 @@ const mocks = vi.hoisted(() => {
   };
 
   return {
+    realtimeTranscriptionProvider,
     generateVoiceResponse: vi.fn(
       async (_params?: {
         onEarlyText?: (text: string) => Promise<boolean>;
@@ -71,7 +73,8 @@ const provider: VoiceCallProvider = {
 type TwilioProviderTestDouble = VoiceCallProvider &
   Pick<
     TwilioProvider,
-    | "isValidStreamToken"
+    | "validateStreamToken"
+    | "revokeStreamToken"
     | "registerCallStream"
     | "unregisterCallStream"
     | "hasRegisteredStream"
@@ -313,7 +316,8 @@ function createTwilioStreamingProvider(
       stopListening: async () => {},
       getCallStatus: async () => ({ status: "in-progress", isTerminal: false }),
     }),
-    isValidStreamToken: () => true,
+    validateStreamToken: () => true,
+    revokeStreamToken: () => {},
     registerCallStream: () => {},
     unregisterCallStream: () => {},
     hasRegisteredStream: () => true,
@@ -432,6 +436,122 @@ describe("VoiceCallWebhookServer realtime transcription provider selection", () 
 });
 
 describe("VoiceCallWebhookServer media stream authorization", () => {
+  it("rejects a parallel Twilio token replay and admits a replacement after disconnect", async () => {
+    const providerCallId = "CA-stream-auth";
+    const call = {
+      ...createCall(Date.now()),
+      provider: "twilio" as const,
+      providerCallId,
+    };
+    const { manager, endCall } = createManager([call]);
+    Object.assign(manager, {
+      getCallByProviderCallId: (callId: string) => (callId === providerCallId ? call : undefined),
+      speakInitialMessage: vi.fn(async () => {}),
+    });
+    const config = createConfig({
+      provider: "twilio",
+      streaming: {
+        ...createConfig().streaming,
+        enabled: true,
+        providers: { openai: { apiKey: "test-key" } }, // pragma: allowlist secret
+      },
+    });
+    const twilio = new TwilioProvider(
+      { accountSid: "AC123", authToken: "test-auth" },
+      {
+        publicUrl: "https://example.test",
+        streamPath: config.streaming.streamPath,
+        skipVerification: true,
+      },
+    );
+    const twimlContext: WebhookContext = {
+      headers: {},
+      rawBody: `CallStatus=ringing&Direction=inbound&CallSid=${providerCallId}`,
+      url: "https://example.test/voice/webhook",
+      method: "POST",
+    };
+    const twiml = twilio.parseWebhookEvent(twimlContext).providerResponseBody ?? "";
+    const token = twiml.match(/<Parameter name="token" value="([^"]+)"/u)?.[1];
+    if (!token) {
+      throw new Error("expected Twilio stream token");
+    }
+
+    const server = new VoiceCallWebhookServer(config, manager, twilio);
+    const sockets = [] as Awaited<ReturnType<typeof connectWs>>[];
+    const createSession = vi
+      .spyOn(mocks.realtimeTranscriptionProvider, "createSession")
+      .mockImplementationOnce(() => {
+        throw new Error("synthetic transcription setup failure");
+      });
+    try {
+      const baseUrl = await server.start();
+      const streamUrl = new URL(config.streaming.streamPath, baseUrl);
+      streamUrl.protocol = "ws:";
+      const start = async (streamSid?: string) => {
+        const ws = await connectWs(streamUrl.toString());
+        sockets.push(ws);
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            streamSid,
+            start: { callSid: providerCallId, customParameters: { token } },
+          }),
+        );
+        return ws;
+      };
+
+      const malformed = await start();
+      await expect(waitForClose(malformed)).resolves.toEqual({
+        code: 1008,
+        reason: "Missing streamSid",
+      });
+      expect(twilio.hasRegisteredStream(providerCallId)).toBe(false);
+
+      const failed = await start("MZ-setup-failure");
+      await expect(waitForClose(failed)).resolves.toEqual({
+        code: 1011,
+        reason: "Stream setup failed",
+      });
+      expect(twilio.hasRegisteredStream(providerCallId)).toBe(false);
+
+      const first = await start("MZ-first");
+      await vi.waitFor(() =>
+        expect(twilio.hasRegisteredStream(providerCallId, "MZ-first")).toBe(true),
+      );
+
+      const replay = await connectWs(streamUrl.toString());
+      sockets.push(replay);
+      const replayClosed = waitForClose(replay);
+      replay.send(
+        JSON.stringify({
+          event: "start",
+          streamSid: "MZ-replay",
+          start: { callSid: providerCallId, customParameters: { token } },
+        }),
+      );
+      await expect(replayClosed).resolves.toEqual({ code: 1008, reason: "Unknown call" });
+
+      const firstClosed = waitForClose(first);
+      first.close(1000);
+      await firstClosed;
+      await vi.waitFor(() => expect(twilio.hasRegisteredStream(providerCallId)).toBe(false));
+
+      await start("MZ-replacement");
+      await vi.waitFor(() =>
+        expect(twilio.hasRegisteredStream(providerCallId, "MZ-replacement")).toBe(true),
+      );
+      expect(endCall).not.toHaveBeenCalled();
+    } finally {
+      for (const ws of sockets) {
+        if (ws.readyState !== ws.CLOSED) {
+          ws.terminate();
+        }
+      }
+      createSession.mockRestore();
+      await server.stop();
+    }
+  });
+
   it.each(["telnyx", "plivo", "mock"] as const)(
     "rejects active provider=%s calls before consulting their call id",
     async (providerName) => {
@@ -2450,7 +2570,8 @@ describe("VoiceCallWebhookServer stream disconnect grace", () => {
       processEvent: vi.fn(),
     } as unknown as CallManager;
 
-    let currentStreamSid: string | null = "MZ-old";
+    let currentStreamSid: string | null = null;
+    const revokeStreamToken = vi.fn();
     const twilioProvider = createTwilioStreamingProvider({
       registerCallStream: (_callSid: string, streamSid: string) => {
         currentStreamSid = streamSid;
@@ -2465,6 +2586,7 @@ describe("VoiceCallWebhookServer stream disconnect grace", () => {
         currentStreamSid = null;
       },
       hasRegisteredStream: () => currentStreamSid !== null,
+      revokeStreamToken,
     });
 
     const config = createConfig({
@@ -2509,6 +2631,7 @@ describe("VoiceCallWebhookServer stream disconnect grace", () => {
     mediaHandler.config.onDisconnect?.("CA-stream-1", "MZ-old");
     await vi.advanceTimersByTimeAsync(2_100);
     expect(endCall).not.toHaveBeenCalled();
+    expect(revokeStreamToken).not.toHaveBeenCalled();
     expect(speakInitialMessage).not.toHaveBeenCalled();
 
     mediaHandler.config.onTranscriptionReady?.("CA-stream-1", "MZ-new");
@@ -2518,6 +2641,8 @@ describe("VoiceCallWebhookServer stream disconnect grace", () => {
     mediaHandler.config.onDisconnect?.("CA-stream-1", "MZ-new");
     mediaHandler.config.onDisconnect?.("CA-stream-1", "MZ-new");
     await vi.advanceTimersByTimeAsync(2_100);
+    expect(revokeStreamToken).toHaveBeenCalledOnce();
+    expect(revokeStreamToken).toHaveBeenCalledWith("CA-stream-1");
     expect(endCall).toHaveBeenCalledTimes(1);
     expect(endCall).toHaveBeenCalledWith(call.callId);
     expect(messages).toContain(

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -73,8 +73,7 @@ const provider: VoiceCallProvider = {
 type TwilioProviderTestDouble = VoiceCallProvider &
   Pick<
     TwilioProvider,
-    | "validateStreamToken"
-    | "revokeStreamToken"
+    | "consumeStreamToken"
     | "registerCallStream"
     | "unregisterCallStream"
     | "hasRegisteredStream"
@@ -316,8 +315,7 @@ function createTwilioStreamingProvider(
       stopListening: async () => {},
       getCallStatus: async () => ({ status: "in-progress", isTerminal: false }),
     }),
-    validateStreamToken: () => true,
-    revokeStreamToken: () => {},
+    consumeStreamToken: () => true,
     registerCallStream: () => {},
     unregisterCallStream: () => {},
     hasRegisteredStream: () => true,
@@ -436,7 +434,7 @@ describe("VoiceCallWebhookServer realtime transcription provider selection", () 
 });
 
 describe("VoiceCallWebhookServer media stream authorization", () => {
-  it("rejects a parallel Twilio token replay and admits a replacement after disconnect", async () => {
+  it("consumes Twilio stream tokens before setup and rejects replay after disconnect", async () => {
     const providerCallId = "CA-stream-auth";
     const call = {
       ...createCall(Date.now()),
@@ -470,13 +468,26 @@ describe("VoiceCallWebhookServer media stream authorization", () => {
       url: "https://example.test/voice/webhook",
       method: "POST",
     };
-    const twiml = twilio.parseWebhookEvent(twimlContext).providerResponseBody ?? "";
-    const token = twiml.match(/<Parameter name="token" value="([^"]+)"/u)?.[1];
-    if (!token) {
-      throw new Error("expected Twilio stream token");
-    }
+    const mintToken = () => {
+      const twiml = twilio.parseWebhookEvent(twimlContext).providerResponseBody ?? "";
+      const token = twiml.match(/<Parameter name="token" value="([^"]+)"/u)?.[1];
+      if (!token) {
+        throw new Error("expected Twilio stream token");
+      }
+      return token;
+    };
+    const initialToken = mintToken();
 
-    const server = new VoiceCallWebhookServer(config, manager, twilio);
+    const { logger, messages } = createCapturingLogger();
+    const server = new VoiceCallWebhookServer(
+      config,
+      manager,
+      twilio,
+      undefined,
+      undefined,
+      undefined,
+      logger,
+    );
     const sockets = [] as Awaited<ReturnType<typeof connectWs>>[];
     const createSession = vi
       .spyOn(mocks.realtimeTranscriptionProvider, "createSession")
@@ -487,7 +498,7 @@ describe("VoiceCallWebhookServer media stream authorization", () => {
       const baseUrl = await server.start();
       const streamUrl = new URL(config.streaming.streamPath, baseUrl);
       streamUrl.protocol = "ws:";
-      const start = async (streamSid?: string) => {
+      const start = async (token: string, streamSid?: string) => {
         const ws = await connectWs(streamUrl.toString());
         sockets.push(ws);
         ws.send(
@@ -500,21 +511,22 @@ describe("VoiceCallWebhookServer media stream authorization", () => {
         return ws;
       };
 
-      const malformed = await start();
+      const malformed = await start(initialToken);
       await expect(waitForClose(malformed)).resolves.toEqual({
         code: 1008,
         reason: "Missing streamSid",
       });
       expect(twilio.hasRegisteredStream(providerCallId)).toBe(false);
 
-      const failed = await start("MZ-setup-failure");
+      const failed = await start(initialToken, "MZ-setup-failure");
       await expect(waitForClose(failed)).resolves.toEqual({
         code: 1011,
         reason: "Stream setup failed",
       });
       expect(twilio.hasRegisteredStream(providerCallId)).toBe(false);
 
-      const first = await start("MZ-first");
+      const firstToken = mintToken();
+      const first = await start(firstToken, "MZ-first");
       await vi.waitFor(() =>
         expect(twilio.hasRegisteredStream(providerCallId, "MZ-first")).toBe(true),
       );
@@ -526,17 +538,28 @@ describe("VoiceCallWebhookServer media stream authorization", () => {
         JSON.stringify({
           event: "start",
           streamSid: "MZ-replay",
-          start: { callSid: providerCallId, customParameters: { token } },
+          start: { callSid: providerCallId, customParameters: { token: firstToken } },
         }),
       );
-      await expect(replayClosed).resolves.toEqual({ code: 1008, reason: "Unknown call" });
+      await expect(replayClosed).resolves.toEqual({ code: 1008, reason: "Unauthorized stream" });
+      expect(messages).toContain(
+        `[voice-call] Rejecting media stream: invalid token for ${providerCallId}`,
+      );
 
       const firstClosed = waitForClose(first);
       first.close(1000);
       await firstClosed;
       await vi.waitFor(() => expect(twilio.hasRegisteredStream(providerCallId)).toBe(false));
 
-      await start("MZ-replacement");
+      const staleReplay = await start(firstToken, "MZ-stale-replay");
+      await expect(waitForClose(staleReplay)).resolves.toEqual({
+        code: 1008,
+        reason: "Unauthorized stream",
+      });
+
+      const replacementToken = mintToken();
+      expect(replacementToken).not.toBe(firstToken);
+      await start(replacementToken, "MZ-replacement");
       await vi.waitFor(() =>
         expect(twilio.hasRegisteredStream(providerCallId, "MZ-replacement")).toBe(true),
       );
@@ -2571,7 +2594,6 @@ describe("VoiceCallWebhookServer stream disconnect grace", () => {
     } as unknown as CallManager;
 
     let currentStreamSid: string | null = null;
-    const revokeStreamToken = vi.fn();
     const twilioProvider = createTwilioStreamingProvider({
       registerCallStream: (_callSid: string, streamSid: string) => {
         currentStreamSid = streamSid;
@@ -2586,7 +2608,6 @@ describe("VoiceCallWebhookServer stream disconnect grace", () => {
         currentStreamSid = null;
       },
       hasRegisteredStream: () => currentStreamSid !== null,
-      revokeStreamToken,
     });
 
     const config = createConfig({
@@ -2631,7 +2652,6 @@ describe("VoiceCallWebhookServer stream disconnect grace", () => {
     mediaHandler.config.onDisconnect?.("CA-stream-1", "MZ-old");
     await vi.advanceTimersByTimeAsync(2_100);
     expect(endCall).not.toHaveBeenCalled();
-    expect(revokeStreamToken).not.toHaveBeenCalled();
     expect(speakInitialMessage).not.toHaveBeenCalled();
 
     mediaHandler.config.onTranscriptionReady?.("CA-stream-1", "MZ-new");
@@ -2641,8 +2661,6 @@ describe("VoiceCallWebhookServer stream disconnect grace", () => {
     mediaHandler.config.onDisconnect?.("CA-stream-1", "MZ-new");
     mediaHandler.config.onDisconnect?.("CA-stream-1", "MZ-new");
     await vi.advanceTimersByTimeAsync(2_100);
-    expect(revokeStreamToken).toHaveBeenCalledOnce();
-    expect(revokeStreamToken).toHaveBeenCalledWith("CA-stream-1");
     expect(endCall).toHaveBeenCalledTimes(1);
     expect(endCall).toHaveBeenCalledWith(call.callId);
     expect(messages).toContain(

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -234,6 +234,9 @@ export class VoiceCallWebhookServer {
       debug: rawDebug ? (msg: string) => rawDebug(`[voice-call] ${msg}`) : undefined,
     };
     this.streamDisconnectGrace = new StreamDisconnectGrace(({ providerCallId }) => {
+      if (this.provider.name === "twilio") {
+        (this.provider as TwilioProvider).revokeStreamToken(providerCallId);
+      }
       const call = this.manager.getCallByProviderCallId(providerCallId);
       if (!call) {
         return;
@@ -413,7 +416,7 @@ export class VoiceCallWebhookServer {
           return false;
         }
         const twilio = this.provider as TwilioProvider;
-        if (!twilio.isValidStreamToken(callId, token)) {
+        if (!twilio.validateStreamToken(callId, token)) {
           this.logger.warn(`Rejecting media stream: invalid token for ${callId}`);
           return false;
         }
@@ -470,9 +473,10 @@ export class VoiceCallWebhookServer {
         if (call) {
           this.manager.invalidateAutoResponse(call);
         }
-
-        // Register stream with provider for TTS routing
+        // Admission and this callback run synchronously around session
+        // construction, so no second start can interleave before this bind.
         if (this.provider.name === "twilio") {
+          // SAFETY: the provider-name guard narrows the configured classic provider.
           (this.provider as TwilioProvider).registerCallStream(callId, streamSid);
         }
       },

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -234,9 +234,6 @@ export class VoiceCallWebhookServer {
       debug: rawDebug ? (msg: string) => rawDebug(`[voice-call] ${msg}`) : undefined,
     };
     this.streamDisconnectGrace = new StreamDisconnectGrace(({ providerCallId }) => {
-      if (this.provider.name === "twilio") {
-        (this.provider as TwilioProvider).revokeStreamToken(providerCallId);
-      }
       const call = this.manager.getCallByProviderCallId(providerCallId);
       if (!call) {
         return;
@@ -416,7 +413,7 @@ export class VoiceCallWebhookServer {
           return false;
         }
         const twilio = this.provider as TwilioProvider;
-        if (!twilio.validateStreamToken(callId, token)) {
+        if (!twilio.consumeStreamToken(callId, token)) {
           this.logger.warn(`Rejecting media stream: invalid token for ${callId}`);
           return false;
         }


### PR DESCRIPTION
## Summary

Prevents a captured Twilio classic media-stream credential from authenticating a second WebSocket, including after the legitimate stream disconnects. Each credential rendered into TwiML is now consumed synchronously before transcription-session creation.

## Changes

- Replace reusable stream-token validation with provider-owned single-use consumption using the existing timing-safe comparison.
- Delete the credential on successful admission before session construction; malformed starts do not consume it, while setup failure does.
- Require any later Twilio `<Stream>` to use a fresh capability minted by a later TwiML render.
- Preserve the generic predecessor/replacement lifecycle ordering so a stale predecessor disconnect cannot unregister a replacement stream.
- Reject missing stream identity before admission and report authorization, setup, and active-stream processing failures with distinct close reasons.
- Add bound HTTP/WebSocket regression coverage for malformed starts, setup failure, parallel replay, replay after disconnect, and later fresh-token admission.
- Add active-session audio failure coverage and clarify the mismatched-StreamSid cleanup invariant.

The bound runtime proof observes a malformed start closing with `1008 Missing streamSid` without consuming the capability, a synchronous transcription setup failure closing with `1011 Stream setup failed` after consuming it, replay closing with `1008 Unauthorized stream` both before and after disconnect, and a later explicitly rendered TwiML capability admitting a replacement stream.

## Validation

- `corepack pnpm test:extension voice-call` — 68 files, 807 tests passed.
- Focused provider/media/webhook/lifecycle run — 4 files, 130 tests passed.
- Pre-fix regression run failed because `consumeStreamToken` did not exist and mid-session failures closed as `Stream setup failed`; both pass after the fix.
- `node scripts/check-changed.mjs` — production/test typechecks and all preceding changed-file gates passed; the final extension lint wrapper was blocked by the unrelated declaration-serialization error in `packages/gateway-protocol/src/schema/protocol-schemas.ts:20`.
- Direct type-aware `oxlint` over all changed voice-call files, targeted formatting, and `git diff --check` — passed.
- `corepack pnpm build` — blocked by the same unrelated `TS7056` declaration-serialization error in `packages/gateway-protocol/src/schema/protocol-schemas.ts:20`.
- Fresh `autoreview --mode uncommitted` — scoped clean, no accepted/actionable findings.

## Notes

- No config, environment variable, schema, persistence, protocol, public SDK, dependency, docs, or generated-artifact change.
- Judged follow-up delta: production -4 lines, tests +74 lines; the assertion baseline ratchet is net zero. The complete PR remains focused on the Twilio stream-authorization owner.
- No carrier-account call was run because Twilio credentials are unavailable in this environment. Twilio's public contract documents one WebSocket per Media Stream, but does not establish that a disconnected bidirectional stream causes a fresh TwiML render or that carrier replacement never overlaps the predecessor. Transparent carrier reconnect therefore remains unproven and requires voice-call owner acceptance before landing.
- The earlier ClawSweeper review covered `bf9fe2dc6e6`; this revision changes the token lifecycle to single-use, restores overlap lifecycle coverage, and corrects diagnostics. That earlier review is not carried forward as exact-head review evidence.
