### PR TITLE
test(plugins): coordinate property probes without sleeps

### DIFF
--- a/src/plugins/provider-self-hosted-discovery.test.ts
+++ b/src/plugins/provider-self-hosted-discovery.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import { discoverOpenAICompatibleLocalModels } from "./provider-self-hosted-discovery.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
@@ -136,6 +137,10 @@ describe("discoverOpenAICompatibleLocalModels raw discovery", () => {
       id: `model-${index}`,
       status: { value: "loaded" },
     }));
+    const started = createDeferred();
+    const release = createDeferred();
+    const now = vi.spyOn(Date, "now").mockReturnValue(0);
+    let active = 0;
     fetchWithSsrFGuardMock.mockImplementation(async ({ url }: { url: string }) => {
       if (url.endsWith("/health")) {
         return guarded(new Response(null, { status: 200 }));
@@ -143,13 +148,15 @@ describe("discoverOpenAICompatibleLocalModels raw discovery", () => {
       if (url.endsWith("/models")) {
         return guarded(new Response(JSON.stringify({ data: models })));
       }
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 20);
-      });
+      active += 1;
+      if (active === 8) {
+        started.resolve();
+      }
+      await release.promise;
       return guarded(new Response(JSON.stringify({ n_ctx: 8192 })));
     });
 
-    const result = await discoverOpenAICompatibleLocalModels({
+    const resultPromise = discoverOpenAICompatibleLocalModels({
       baseUrl: "http://127.0.0.1:8080/v1",
       label: "llama-server",
       healthPath: "/health",
@@ -159,10 +166,22 @@ describe("discoverOpenAICompatibleLocalModels raw discovery", () => {
       rawResult: true,
     });
 
-    expect(result.kind === "success" ? result.rows : []).toHaveLength(17);
-    expect(
-      fetchWithSsrFGuardMock.mock.calls.filter(([call]) => call.url.includes("/props?")).length,
-    ).toBe(8);
+    try {
+      await withTestTimeout(started.promise, 1_000, "initial eight property probes did not start");
+      // Expire the budget only after the first wave starts, independent of runner load.
+      now.mockReturnValue(20);
+      release.resolve();
+      const result = await withTestTimeout(resultPromise, 1_000, "discovery did not finish");
+
+      expect(result.kind === "success" ? result.rows : []).toHaveLength(17);
+      expect(
+        fetchWithSsrFGuardMock.mock.calls.filter(([call]) => call.url.includes("/props?")).length,
+      ).toBe(8);
+    } finally {
+      release.resolve();
+      now.mockRestore();
+      await withTestTimeout(resultPromise, 1_000, "property probes did not settle during cleanup");
+    }
   });
 
   it("bounds concurrent property probes and keeps results associated by model", async () => {
@@ -170,6 +189,8 @@ describe("discoverOpenAICompatibleLocalModels raw discovery", () => {
       id: `model-${index}`,
       status: { value: "loaded" },
     }));
+    const started = models.map(() => createDeferred());
+    const releases = models.map(() => createDeferred());
     let active = 0;
     let maxActive = 0;
     fetchWithSsrFGuardMock.mockImplementation(async ({ url }: { url: string }) => {
@@ -183,14 +204,13 @@ describe("discoverOpenAICompatibleLocalModels raw discovery", () => {
       const index = Number(modelId?.replace("model-", ""));
       active += 1;
       maxActive = Math.max(maxActive, active);
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 10 - index);
-      });
+      started[index]!.resolve();
+      await releases[index]!.promise;
       active -= 1;
       return guarded(new Response(JSON.stringify({ n_ctx: 8_000 + index })));
     });
 
-    const result = await discoverOpenAICompatibleLocalModels({
+    const resultPromise = discoverOpenAICompatibleLocalModels({
       baseUrl: "http://127.0.0.1:8080/v1",
       label: "llama-server",
       healthPath: "/health",
@@ -199,10 +219,40 @@ describe("discoverOpenAICompatibleLocalModels raw discovery", () => {
       rawResult: true,
     });
 
-    expect(maxActive).toBe(8);
-    expect(result.kind === "success" ? result.rows.map((row) => row.props?.n_ctx) : []).toEqual(
-      models.map((_, index) => 8_000 + index),
-    );
+    try {
+      await withTestTimeout(
+        started[7]!.promise,
+        1_000,
+        "initial eight property probes did not start",
+      );
+      // Finish later models first so completion order cannot stand in for model identity.
+      releases[7]!.resolve();
+      await withTestTimeout(
+        started[8]!.promise,
+        1_000,
+        "model-8 probe did not start after model-7",
+      );
+      releases[6]!.resolve();
+      await withTestTimeout(
+        started[9]!.promise,
+        1_000,
+        "model-9 probe did not start after model-6",
+      );
+      for (const release of releases.toReversed()) {
+        release.resolve();
+      }
+      const result = await withTestTimeout(resultPromise, 1_000, "discovery did not finish");
+
+      expect(maxActive).toBe(8);
+      expect(result.kind === "success" ? result.rows.map((row) => row.props?.n_ctx) : []).toEqual(
+        models.map((_, index) => 8_000 + index),
+      );
+    } finally {
+      for (const release of releases) {
+        release.resolve();
+      }
+      await withTestTimeout(resultPromise, 1_000, "property probes did not settle during cleanup");
+    }
   });
 
   it("caps property probes at 200 models", async () => {


### PR DESCRIPTION
## What Problem This Solves

Two property-probe tests coordinate work with 18 artificial request-delay timers. The shared-deadline case also assumes the runner can start eight probes within ten milliseconds.

## Why This Change Was Made

Use the existing deferred and bounded-wait helpers to observe request starts and release completions explicitly. Advance a scoped deadline clock only after the first wave starts; complete later models first to preserve the result-association check. Every gate is released and the owner is joined during cleanup, including failed assertions.

## User Impact

Test-only: no provider, concurrency limit, timeout argument or response-processing change. All seven labels and original assertions remain. Eighteen artificial sleep timers are removed; no elapsed-time improvement is claimed.

## Evidence

All 50 raw-discovery and setup cases pass before and after in the normal non-isolated plugins project. Sensitivity probes also passed: temporarily disabling deadline skipping fails at 17 versus 8 probes; temporarily raising concurrency to nine fails at a peak of 9 versus 8. Original production bytes were restored after each probe.

Full changed checks and Codex autoreview pass. Production +0/-0; tests +66/-16, with growth for causal coordination and failure cleanup. Source review covered the scheduler, installed p-limit implementation, body/deadline cleanup, SDK and llama-cpp callers, sibling suites and the original discovery-limit history.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/provider-self-hosted-discovery.test.ts src/plugins/provider-self-hosted-setup.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base a005070acf6
```

