### PR TITLE
fix(macos): reveal onboarding failures and restore retry actions

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
@@ -164,8 +164,9 @@ extension OnboardingAISetupModel {
         if status == "cancelled" {
             return .failure(OnboardingAISetupError.activationCancelled)
         }
-        return .failure(OnboardingAISetupError
-            .activationFailed(error ?? "The Gateway did not return a verified model."))
+        return .failure(status == "error"
+            ? OnboardingAISetupError.activationFailed(error ?? "AI setup failed.")
+            : OnboardingAISetupError.activationOutcomeUnavailable)
     }
 
     struct Candidate: Identifiable, Equatable {
@@ -468,6 +469,10 @@ extension OnboardingAISetupModel {
 
     static func activationFailureIsDefinitive(_ error: Error) -> Bool {
         if case OnboardingAISetupError.activationCancelled = error {
+            return true
+        }
+        // A terminal wizard error arrives after its runner and setup admission settle.
+        if case OnboardingAISetupError.activationFailed = error {
             return true
         }
         if let response = error as? GatewayResponseError {

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
@@ -826,6 +826,8 @@ struct OnboardingErrorCard: View {
     var secondaryTitle: String?
     var secondary: (() -> Void)?
 
+    /// Keep retry required so Swift binds a lone trailing closure to the primary
+    /// action instead of the defaulted secondary action.
     init(
         title: String,
         message: String,
@@ -834,7 +836,7 @@ struct OnboardingErrorCard: View {
         retryTitle: String? = nil,
         secondaryTitle: String? = nil,
         secondary: (() -> Void)? = nil,
-        retry: (() -> Void)? = nil)
+        retry: (() -> Void)?)
     {
         self.title = title
         self.message = message

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift
@@ -99,6 +99,7 @@ struct OnboardingAISetupView: View {
     var returnToGatewayAuthentication: () -> Void
     var retryConfiguredGatewayProbe: () -> Void
     @State private var openedProviderAuthURL: URL?
+    @State private var manualEntryRequest = 0
 
     static func gatewayAuthCard(for issue: RemoteGatewayAuthIssue) -> GatewayAuthCard {
         GatewayAuthCard(
@@ -109,6 +110,25 @@ struct OnboardingAISetupView: View {
     }
 
     var body: some View {
+        ScrollViewReader { scroll in
+            ScrollView {
+                self.content
+                    .padding(.vertical, 4)
+                    .padding(.trailing, 12)
+            }
+            .scrollIndicators(.automatic)
+            .onChange(of: self.manualEntryRequest) {
+                withAnimation { scroll.scrollTo("manual-entry", anchor: .top) }
+            }
+            .onChange(of: self.model.manualError) { _, error in
+                if error != nil {
+                    withAnimation { scroll.scrollTo("manual-entry", anchor: .bottom) }
+                }
+            }
+        }
+    }
+
+    private var content: some View {
         VStack(alignment: .leading, spacing: 12) {
             switch self.model.phase {
             case .idle, .detecting:
@@ -492,6 +512,8 @@ struct OnboardingAISetupView: View {
         Button {
             withAnimation(.spring(response: 0.25, dampingFraction: 0.9)) {
                 self.model.showManualEntry = true
+                // The form can already exist below the viewport; every tap must reveal it.
+                self.manualEntryRequest += 1
             }
         } label: {
             HStack(spacing: 10) {
@@ -779,6 +801,7 @@ struct OnboardingAISetupView: View {
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(OnboardingSurface(cornerRadius: 12))
+        .id("manual-entry")
     }
 
     private var manualProviderHelp: String {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift
@@ -30,15 +30,10 @@ extension OnboardingView {
                 .frame(maxWidth: 540)
                 .fixedSize(horizontal: false, vertical: true)
 
-            ScrollView {
-                OnboardingAISetupView(
-                    model: self.aiSetup,
-                    returnToGatewayAuthentication: { self.returnToGatewayAuthentication() },
-                    retryConfiguredGatewayProbe: { self.retryConfiguredGatewayProbe() })
-                    .padding(.vertical, 4)
-                    .padding(.trailing, 12)
-            }
-            .scrollIndicators(.automatic)
+            OnboardingAISetupView(
+                model: self.aiSetup,
+                returnToGatewayAuthentication: { self.returnToGatewayAuthentication() },
+                retryConfiguredGatewayProbe: { self.retryConfiguredGatewayProbe() })
         }
         .padding(.horizontal, 28)
         .padding(.top, 48)

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -1089,7 +1089,8 @@ struct OnboardingAISetupTests {
                     "The Gateway setup request failed. Show details to inspect or copy the error.")
                 #expect(failure.detail == (terminalError
                         ? failureDetail
-                        : "AI setup ended before its result was received. OpenClaw will verify the Gateway before trying again."))
+                        :
+                        "AI setup ended before its result was received. OpenClaw will verify the Gateway before trying again."))
             }
         }
         #expect(!model.exhaustedAutoCandidates)

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -919,11 +919,16 @@ struct OnboardingAISetupTests {
             "openclaw.setup.prepare.start")
     }
 
-    @Test(arguments: ["accept", "decline", "cancel", "error", "retry-cancel"], [false, true])
+    @Test(
+        arguments: ["accept", "decline", "cancel", "error", "error-replaced", "malformed-success", "retry-cancel"],
+        [false, true])
     func `activation consent uses shared wizard`(decision: String, manual: Bool) async throws {
         let recorder = AISetupRequestRecorder()
+        let activationAttempts = AISetupSocketGeneration()
         let cancellationFails = LockIsolated(true)
-        let accepts = ["accept", "error"].contains(decision)
+        let terminalError = decision == "error" || decision == "error-replaced"
+        let accepts = terminalError || ["accept", "malformed-success"].contains(decision)
+        let failureDetail = "AI access was saved, but could not be applied."
         let defaults = try #require(isolatedAISetupDefaults(prefix: "ActivationConsent"))
         let session = makeAISetupRequestSession(
             recorder: recorder,
@@ -938,6 +943,14 @@ struct OnboardingAISetupTests {
                 case "openclaw.setup.activate.start":
                     #expect(request.params["kind"] as? String == (manual ? "api-key" : "codex-cli"))
                     let sessionID = try #require(request.params["sessionId"] as? String)
+                    if activationAttempts.claim() > 0 {
+                        payload = [
+                            "sessionId": sessionID, "done": true, "status": "done",
+                            "modelActivation": ["modelRef": request
+                                .params["modelRef"] as? String ?? "synthetic/manual"],
+                        ]
+                        break
+                    }
                     task.emitReceiveSuccess(.data(wizardStartResponse(id: request.id, sessionID: sessionID)))
                     return
                 case "wizard.next":
@@ -951,8 +964,10 @@ struct OnboardingAISetupTests {
                     case "consent":
                         let accepted = try #require(answer?["value"] as? Bool)
                         #expect(accepted == accepts)
-                        payload = if decision == "error" {
-                            ["done": true, "status": "error", "error": "AI access was saved, but could not be applied."]
+                        payload = if terminalError {
+                            ["done": true, "status": "error", "error": failureDetail]
+                        } else if decision == "malformed-success" {
+                            ["done": true, "status": "done"]
                         } else if accepted {
                             ["done": true, "status": "done", "modelActivation": ["modelRef": "openai/gpt-5.5"]]
                         } else {
@@ -995,6 +1010,8 @@ struct OnboardingAISetupTests {
             })
         let gateway = try makeAISetupGateway(url: #require(URL(string: "ws://example.invalid")), session: session)
         let model = makeAISetupModel(gateway: gateway, defaults: defaults)
+        var handoffs = 0
+        model.onConnected = { handoffs += 1 }
         let activation = Task {
             await model.detectAndAutoConnect()
             if manual {
@@ -1018,6 +1035,13 @@ struct OnboardingAISetupTests {
         }
         #expect(model.authStep.map(wizardStepType) == "confirm")
         #expect(!model.authConfirmation)
+        let originalOwner = try #require(storedActivationOwner(defaults))
+        let replacementOwner = OnboardingSystemAgentResumeStore.ActivationOwner(
+            id: UUID().uuidString,
+            routeFingerprint: originalOwner.routeFingerprint)
+        if decision == "error-replaced" {
+            markPending(defaults, owner: replacementOwner)
+        }
         if decision == "retry-cancel" {
             model.cancelProviderAuth()
             for _ in 0..<400 where model.authError == nil {
@@ -1036,9 +1060,14 @@ struct OnboardingAISetupTests {
         for _ in 0..<400 where model.activeAuthOption != nil {
             try await Task.sleep(nanoseconds: 5_000_000)
         }
+        await activation.value
         await settleQueuedAISetupTasks()
+        let ambiguous = decision == "malformed-success" || decision == "retry-cancel"
         #expect(model.connected == (decision == "accept"))
-        #expect(model.pendingActivationVerification == (decision == "error" || decision == "retry-cancel"))
+        #expect(handoffs == (decision == "accept" ? 1 : 0))
+        #expect(model.pendingActivationVerification == ambiguous)
+        #expect(model.waitingForPendingActivationDeadline == ambiguous)
+        #expect(model.isBusy == ambiguous)
         #expect(model.activeAuthOption == nil)
         if decision != "accept" {
             let failure: OnboardingAISetupModel.Failure
@@ -1058,14 +1087,48 @@ struct OnboardingAISetupTests {
             } else {
                 #expect(failure.summary ==
                     "The Gateway setup request failed. Show details to inspect or copy the error.")
-                #expect(failure.detail == (decision == "error"
-                        ? "AI access was saved, but could not be applied."
+                #expect(failure.detail == (terminalError
+                        ? failureDetail
                         : "AI setup ended before its result was received. OpenClaw will verify the Gateway before trying again."))
             }
         }
+        #expect(!model.exhaustedAutoCandidates)
         let requests = await recorder.snapshot()
         #expect(!requests.methods.contains("openclaw.setup.activate"))
         #expect(requests.methods.filter { $0 == "openclaw.setup.activate.start" }.count == 1)
+        if terminalError {
+            #expect(model.phase == .ready)
+            if decision == "error-replaced" {
+                #expect(storedActivationOwner(defaults) == replacementOwner)
+            } else {
+                #expect(pendingState(defaults) == .none)
+            }
+        } else if ambiguous {
+            #expect(model.phase == .detecting)
+            #expect(storedActivationOwner(defaults) == originalOwner)
+        }
+        guard decision == "error" else { return }
+        // The failed wizard has settled. A new user action may retry immediately,
+        // while the assertion above forbids an automatic switch to the next candidate.
+        try #require(!model.isBusy)
+        if manual {
+            model.manualKey = "corrected-fixture-key"
+            model.submitManualKey()
+        } else {
+            model.userSelect(kind: "codex-cli")
+        }
+        for _ in 0..<400 where !model.connected {
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        #expect(model.connected)
+        #expect(handoffs == 1)
+        #expect(pendingState(defaults) == .completed)
+        #expect(storedActivationOwner(defaults) != originalOwner)
+        let retried = await recorder.snapshot()
+        #expect(retried.methods.filter { $0 == "openclaw.setup.activate.start" }.count == 2)
+        if manual {
+            #expect(retried.apiKeys == ["fixture-key", "corrected-fixture-key"])
+        }
     }
 
     @Test(arguments: ["terminal-reply", "nonterminal-reply", "confirmed-cancel"])

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -180,6 +180,53 @@ struct OnboardingViewSmokeTests {
         #expect(short < preferred)
     }
 
+    @Test(arguments: ["primary", "dual", "passive"])
+    func `error card trailing closure owns its primary action`(_ actions: String) throws {
+        var primaryInvocations = 0
+        var secondaryInvocations = 0
+        let card = switch actions {
+        case "primary":
+            OnboardingErrorCard(
+                title: "Setup failed",
+                message: "Fixture failure",
+                docsSlug: "start/onboarding",
+                retryTitle: "Try again")
+            {
+                primaryInvocations += 1
+            }
+        case "dual":
+            OnboardingErrorCard(
+                title: "Setup failed",
+                message: "Fixture failure",
+                docsSlug: "start/onboarding",
+                retryTitle: "Back to Gateway",
+                secondaryTitle: "Try again",
+                secondary: { secondaryInvocations += 1 },
+                retry: { primaryInvocations += 1 })
+        default:
+            OnboardingErrorCard(
+                title: "Setup failed",
+                message: "Fixture failure",
+                docsSlug: "start/onboarding",
+                retry: nil)
+        }
+
+        if actions == "dual" {
+            let secondary = try #require(card.secondary)
+            secondary()
+        } else {
+            #expect(card.secondary == nil)
+        }
+        if actions == "passive" {
+            #expect(card.retry == nil)
+        } else {
+            let retry = try #require(card.retry)
+            retry()
+        }
+        #expect(primaryInvocations == (actions == "passive" ? 0 : 1))
+        #expect(secondaryInvocations == (actions == "dual" ? 1 : 0))
+    }
+
     @Test func `configured flows end at AI setup and hand off to the dashboard`() {
         // Everything after working inference (memory import, permissions,
         // channels, hatch) belongs to the dashboard custodian onboarding.


### PR DESCRIPTION
## What Problem This Solves

macOS onboarding could leave users unable to recover from setup failures: API Keys did not reveal the entry form, a rejected key remained stuck waiting after the Gateway had already returned a terminal error, and five error-card callers silently lost their Retry button.

## Why This Change Was Made

The activation decoder now distinguishes settled wizard errors from uncertain outcomes. A confirmed error uses the existing attempt-owned cleanup to permit a deliberate retry. Malformed or uncertain outcomes retain the pending lease, and cleanup cannot remove a newer attempt's receipt. A terminal error is not converted to an ordinary unsuccessful candidate result, which would automatically try another account after consent.

The action-owning AI setup view owns one scroll container and reveals the form on every API Keys click and each new manual error. The redundant parent scroll wrapper is removed. The shared error-card initializer makes its final optional retry closure required: under Swift 6, the former pair of defaulted closures bound a lone trailing closure to the secondary action, leaving the primary button without its callback. Repairing the initializer covers all five primary-only callers while preserving explicit dual-action and passive cards.

## User Impact

Failed setup presents a visible recovery action. Users can correct a rejected key and continue through verified inference to chat. Capability consent, uncertain-outcome protection, and activation ownership remain intact. No configuration, storage, dependency, or protocol changes.

## Verification

- Original native production fails the extended 14-case activation matrix with 18 assertion failures; fixed production passes. Coverage includes manual keys and detected accounts, terminal errors, consent/cancellation, malformed success, exact-owner cleanup, replacement-owner preservation, immediate deliberate retry, and no automatic account switching.
- The actual shared-card regression fails before the fix (three cases, two primary-case issues) and passes afterward. It exercises primary-only trailing closures, explicit dual actions, and passive cards against the real initializer.
- [Exact-head native CI](https://github.com/openclaw/openclaw/actions/runs/33476605316/job/99757209108) executed **1,907 app tests in 196 suites** and **1,546 OpenClawKit tests in 119 suites**, all passing on `52f0bdbd4a4cb66e6e354afd86fb4356a377f935`. The 14-case activation and three-case shared-card tests both executed successfully; this is not compilation-only evidence.
- [Required CI](https://github.com/openclaw/openclaw/actions/runs/33476605316) passes, including macOS Node, native localization, security, and `openclaw/ci-gate`.
- Canonical macOS packaging and packaged-worker checks pass. Before/after apps use timestamped OpenClaw Foundation Developer ID signatures. The final installed app's commit identity and deep strict signature were verified in the guest.
- Codex autoreview of the complete final branch is scoped-clean at the configured P0 threshold. Independent owner/caller/sibling review found no actionable source finding. SwiftFormat and whitespace checks pass.

### Final signed-app live pass

The final `52f0bdbd4a4` app completed GUI installation in a freshly restored macOS 26.6 guest. Synthetic invalid OpenAI keys produced HTTP 401 and visible failure details with Connect enabled, rather than the old pending-activation wait. Repeated API Keys clicks revealed the form and error details in a window shortened by 126 points. A controlled read-only Gateway disconnect produced the shared error card with **Try again** visible; restoring the Gateway recovered discovery automatically.

A real OpenAI key then produced `status=200` from the Responses API at **2026-09-01 11:04:30.950 PDT**, followed by the managed Gateway restart and successful inference verification. The UI reached **Inference is ready**. **Talk to my agent** opened chat, and a GUI user prompt returned **MACOS_ONBOARD_FINAL_OK in six seconds**. Quit was confirmed; relaunch created a new app process, did not reopen onboarding, and reopening the dashboard preserved the configured state and the successful conversation.

Coverage boundaries: the manual-key flow did not present a capability-consent decision, so decline/cancel proof is the executed native matrix, not a claimed live click. Immediate reattempt timing is asserted by that matrix; GUI automation delayed the corrected-key submission, so the live pass is not a retry-latency benchmark. The restored Gateway recovered before the intended Try again click, so that click is not counted as proof. An optional second prompt after relaunch was submitted, but its response capture was lost during temporary-artifact cleanup; no second live reply is claimed.

### Before / after

These are inspected screenshots from the actual signed apps. The original temporary PNG files were cleaned up later; the attached, unretouched 2048-pixel image-tool previews were recovered from saved task outputs. No API key value, account identity, or private host information is visible. All seven uploaded attachments were downloaded again and their bytes matched the inspected preview hashes.

| Before | After (`52f0bdbd4a4`) |
| --- | --- |
| API Keys selects a row without revealing its form.<br>![Before: API Keys form remains below the viewport](https://github.com/user-attachments/assets/151755f2-9839-416c-a9de-07c3f17f5f44) | Repeated API Keys reveals the form and error details even in the shortened window.<br>![After: manual key form and error details visible](https://github.com/user-attachments/assets/2650cebb-b562-42b4-8563-cbd612f848a4) |
| A completed HTTP 401 leaves the app waiting for an already-finished test.<br>![Before: terminal error leaves a pending wait](https://github.com/user-attachments/assets/e0b13934-3140-47ed-9b61-dfbcd7220beb) | The failure is visible and Connect is enabled; see the same after capture above. |
| Shared error-card initializer loses the primary retry action on the installation caller.<br>![Before: installation error has no retry button](https://github.com/user-attachments/assets/c43f3207-c779-4506-9339-6da5d0daadc0) | The same shared initializer now exposes Try again on the detection caller. The actual-card matrix covers all callback shapes.<br>![After: detection error exposes Try again](https://github.com/user-attachments/assets/39a57b03-36dd-4e39-8d4f-b53a7859dfc9) |

![Final signed app: inference ready after live OpenAI verification](https://github.com/user-attachments/assets/69b4ed45-c5da-41ab-8584-7faecc32424e)

![Final signed app: successful GUI user chat in six seconds](https://github.com/user-attachments/assets/f48f9fdb-2cd2-428d-b71b-3b7adf3e94ea)

ClawSweeper rank-up disposition: signed failure/reveal/retry-affordance, connection, and chat evidence is attached. Relaunch was observed directly; its screenshot remains local because an unrelated Finder pane is visible. The timing/click/cancellation limits above are explicit rather than inferred from screenshots.

## Scope and Follow-up

Production delta is **+37/-12, net +25**; tests are **+119/-8, net +111**. Maintainer disposition after the fresh 21:29 UTC review: retain the owner-bound net +25. The settled-versus-uncertain distinction and two independently repeatable reveal events are required behavior; replacing terminal errors with candidate failure would switch accounts after consent, while observing only form visibility would miss repeated API Keys clicks. The redundant scroll container is deleted, and the shared initializer fixes all five callers without a second retry mechanism. No fallback path or compatibility shim is added. Existing onboarding documentation already promises verified connection and retry. `CHANGELOG.md` is release-only; this PR carries user-facing release-note context.

History confirms the terminal-error classification regression originated in #134101 on current main and is not in stable `v2026.8.1`. The shared trailing-closure regression from #117904 is reachable in that stable tag.

Follow-up: **Fresh macOS onboarding: queued presence events may wake heartbeat before AI setup**. An earlier baseline showed a historical missing-bearer error before its first user turn; the original timestamp could not be recovered. Source permits a pre-setup presence-event wake, but that link remains unconfirmed. Both baseline and final configured user turns succeeded. The final observed chat did not show that historical error; no speculative credential-forwarding change is included.
