### PR TITLE
fix(macos): run bundle copy off the main thread during self-install

### DIFF
--- a/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
+++ b/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
@@ -302,7 +302,16 @@ enum ApplicationRelocator {
                         destination: destination,
                         replacing: replacing,
                         fileManager: fileManager)
-                    _ = relaunchAndTerminate(at: destination)
+                    let disposition = relaunchAndTerminate(at: destination)
+                    // relaunchAndTerminate returns .continueLaunch only when it
+                    // could not spawn the relaunch helper (it already showed the
+                    // "open it manually" alert). Since we returned .installing and
+                    // the caller skipped menu bar, dock, and gateway startup,
+                    // continuing would leave a headless LSUIElement process.
+                    // Terminate instead of resuming a full transient session.
+                    if case .continueLaunch = disposition {
+                        AppDelegate.requestTermination()
+                    }
                 } catch {
                     if let unsafeError = error as? UnsafeCopyDestinationError {
                         self.logger.error(
@@ -313,6 +322,12 @@ enum ApplicationRelocator {
                     }
                     showFailure(
                         "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.")
+                    // Install failed (disk full, permissions, etc.). The caller
+                    // returned .installing and never started the status item or
+                    // dock icon. Leaving the process alive would create an
+                    // invisible LSUIElement ghost the user cannot Cmd-Tab to.
+                    // Terminate after the alert is dismissed.
+                    AppDelegate.requestTermination()
                 }
             }
             return .installing
@@ -1048,11 +1063,15 @@ extension ApplicationRelocator {
         do {
             if replacing {
                 let backupName = ".\(destination.lastPathComponent).backup-\(UUID().uuidString)"
+                let backupURL = parent.appendingPathComponent(backupName)
                 _ = try fileManager.replaceItemAt(
                     destination,
                     withItemAt: staging,
                     backupItemName: backupName)
-                try? fileManager.removeItem(at: parent.appendingPathComponent(backupName))
+                // The backup is the previous installed bundle (potentially
+                // multi-GB). Remove it off the main thread to avoid a second
+                // main-thread stall right after the copy finishes.
+                Task.detached { try? FileManager().removeItem(at: backupURL) }
             } else {
                 try fileManager.moveItem(at: staging, to: destination)
             }

--- a/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
+++ b/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
@@ -1054,9 +1054,11 @@ extension ApplicationRelocator {
                 try FileManager().copyItem(at: source, to: staging)
             }.value
         } catch {
-            // Remove a partial copy off the main thread so a multi-gigabyte
-            // deletion cannot re-block the caller.
-            Task.detached { try? FileManager().removeItem(at: staging) }
+            // Remove a partial copy off the main thread. Await the deletion so
+            // it actually completes before the process exits (the app quits
+            // ~2 s after a failure alert, which would abandon a fire-and-forget
+            // multi-GB cleanup).
+            try? await Task.detached { try? FileManager().removeItem(at: staging) }.value
             throw error
         }
 
@@ -1069,15 +1071,16 @@ extension ApplicationRelocator {
                     withItemAt: staging,
                     backupItemName: backupName)
                 // The backup is the previous installed bundle (potentially
-                // multi-GB). Remove it off the main thread to avoid a second
-                // main-thread stall right after the copy finishes.
-                Task.detached { try? FileManager().removeItem(at: backupURL) }
+                // multi-GB). Remove it off the main thread and await completion
+                // so the relaunch that follows does not abandon a large leftover.
+                try? await Task.detached { try? FileManager().removeItem(at: backupURL) }.value
             } else {
                 try fileManager.moveItem(at: staging, to: destination)
             }
         } catch {
-            // replace/move failed while staging still exists. Clean up off-main.
-            Task.detached { try? FileManager().removeItem(at: staging) }
+            // replace/move failed while staging still exists. Clean up off-main
+            // and await it before surfacing the error.
+            try? await Task.detached { try? FileManager().removeItem(at: staging) }.value
             throw error
         }
     }

--- a/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
+++ b/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
@@ -45,6 +45,10 @@ enum ApplicationRelocator {
 
     enum LaunchDisposition: Equatable, Sendable {
         case continueLaunch(startUpdater: Bool)
+        /// A self-install is running in the background. The caller must not start
+        /// gateway, menu, onboarding, or other services from the transient bundle;
+        /// the app will relaunch from the installed location once the copy finishes.
+        case installing
         case terminating
     }
 
@@ -281,10 +285,17 @@ enum ApplicationRelocator {
             guard confirmInstall(replacing: replacing) else {
                 return .continueLaunch(startUpdater: false)
             }
-            // Perform the bundle copy asynchronously so the main thread can finish
-            // launching and present UI. A synchronous multi-gigabyte copy here makes
-            // the app appear hung and unresponsive to SIGTERM (see issue #134736).
+            // Perform the bundle copy asynchronously so the main thread stays
+            // responsive (a multi-gigabyte copy on the main thread blocks
+            // applicationDidFinishLaunching and makes the process unkillable by
+            // SIGTERM — see issue #134736). Return .installing so the caller
+            // does not start gateway, menu, onboarding, or CLI services from the
+            // transient bundle; the app relaunches from the installed copy once
+            // the copy completes.
+            let progressWindow = makeInstallProgressWindow(replacing: replacing)
+            progressWindow.makeKeyAndOrderFront(nil)
             Task { @MainActor in
+                defer { progressWindow.close() }
                 do {
                     try await install(
                         source: environment.bundleURL,
@@ -293,12 +304,18 @@ enum ApplicationRelocator {
                         fileManager: fileManager)
                     _ = relaunchAndTerminate(at: destination)
                 } catch {
-                    self.logger.error("Could not install app: \(error.localizedDescription, privacy: .public)")
+                    if let unsafeError = error as? UnsafeCopyDestinationError {
+                        self.logger.error(
+                            "Refusing unsafe copy: source=\(unsafeError.source.path, privacy: .public), "
+                            + "staging=\(unsafeError.staging.path, privacy: .public)")
+                    } else {
+                        self.logger.error("Could not install app: \(error.localizedDescription, privacy: .public)")
+                    }
                     showFailure(
                         "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.")
                 }
             }
-            return .continueLaunch(startUpdater: false)
+            return .installing
         case .cannotInstall:
             let message =
                 "OpenClaw is running from a temporary location. " +
@@ -1003,12 +1020,12 @@ extension ApplicationRelocator {
         let parent = destination.deletingLastPathComponent()
         try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
         let staging = parent.appendingPathComponent(".\(destination.lastPathComponent).installing-\(UUID().uuidString)")
-        defer { try? fileManager.removeItem(at: staging) }
 
-        // Guard against a staging directory that resolves inside the source bundle.
-        // Without this check, copyItem can recursively descend into its own output
-        // and write without bound — observed as ~2 GB of disk writes in 40 s when
-        // the app is launched under App Translocation.
+        // Defensive guard: refuse to copy when the staging directory resolves
+        // inside the source bundle. Production destinations (/Applications,
+        // ~/Applications) are never nested inside a translocated/Downloads
+        // source, so this is belt-and-suspenders rather than the reported
+        // failure path (the 2 GB / 40 s write is the large bundle copy itself).
         guard !isPath(staging, nestedIn: source) else {
             throw UnsafeCopyDestinationError(source: source, staging: staging)
         }
@@ -1017,25 +1034,39 @@ extension ApplicationRelocator {
         // blocks applicationDidFinishLaunching, prevents any UI from appearing,
         // and leaves the process unresponsive to SIGTERM because the main thread
         // is stuck in a kernel write(). Run the copy on a background queue.
-        try await Task.detached(priority: .userInitiated) {
-            try FileManager.default.copyItem(at: source, to: staging)
-        }.value
+        do {
+            try await Task.detached(priority: .userInitiated) {
+                try FileManager().copyItem(at: source, to: staging)
+            }.value
+        } catch {
+            // Remove a partial copy off the main thread so a multi-gigabyte
+            // deletion cannot re-block the caller.
+            Task.detached { try? FileManager().removeItem(at: staging) }
+            throw error
+        }
 
-        if replacing {
-            let backupName = ".\(destination.lastPathComponent).backup-\(UUID().uuidString)"
-            _ = try fileManager.replaceItemAt(
-                destination,
-                withItemAt: staging,
-                backupItemName: backupName)
-            try? fileManager.removeItem(at: parent.appendingPathComponent(backupName))
-        } else {
-            try fileManager.moveItem(at: staging, to: destination)
+        do {
+            if replacing {
+                let backupName = ".\(destination.lastPathComponent).backup-\(UUID().uuidString)"
+                _ = try fileManager.replaceItemAt(
+                    destination,
+                    withItemAt: staging,
+                    backupItemName: backupName)
+                try? fileManager.removeItem(at: parent.appendingPathComponent(backupName))
+            } else {
+                try fileManager.moveItem(at: staging, to: destination)
+            }
+        } catch {
+            // replace/move failed while staging still exists. Clean up off-main.
+            Task.detached { try? FileManager().removeItem(at: staging) }
+            throw error
         }
     }
 
-    /// Returns true when `nested` resolves to the same path as `root` or lies
-    /// inside its directory tree. Uses standardized file URLs so that symlinks,
-    /// relative segments, and trailing slashes cannot bypass the check.
+    /// Returns true when `nested` is the same path as `root` or lies inside its
+    /// directory tree. Uses standardizedFileURL, which collapses `.` / `..` and
+    /// extra slashes but does **not** resolve symlinks. This is a lightweight
+    /// structural check, not a security boundary.
     static func isPath(_ nested: URL, nestedIn root: URL) -> Bool {
         let nestedPath = nested.standardizedFileURL.path
         let rootPath = root.standardizedFileURL.path
@@ -1413,6 +1444,45 @@ extension ApplicationRelocator {
         alert.alertStyle = .warning
         alert.addButton(withTitle: "OK")
         alert.runModal()
+    }
+
+    /// A small non-modal window shown while the app copies itself to Applications.
+    /// It stays on screen during the background copy and is closed by the caller
+    /// (in a `defer`) once the install succeeds or fails.
+    private static func makeInstallProgressWindow(replacing: Bool) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 120),
+            styleMask: [.titled, .fullSizeContentView],
+            backing: .buffered,
+            defer: false)
+        window.title = "OpenClaw"
+        window.level = .floating
+        window.isReleasedWhenClosed = false
+        window.center()
+
+        let container = NSView(frame: window.contentLayoutRect)
+        container.autoresizingMask = [.width, .height]
+
+        let spinner = NSProgressIndicator(frame: NSRect(x: 20, y: 40, width: 32, height: 32))
+        spinner.style = .spinning
+        spinner.controlSize = .regular
+        spinner.startAnimation(nil)
+        spinner.autoresizingMask = [.maxXMargin, .maxYMargin]
+        container.addSubview(spinner)
+
+        let text = NSTextField(frame: NSRect(x: 64, y: 44, width: 280, height: 32))
+        text.stringValue = replacing
+            ? "Replacing OpenClaw in Applications…"
+            : "Copying OpenClaw to Applications…"
+        text.isBezeled = false
+        text.isEditable = false
+        text.drawsBackground = false
+        text.font = .systemFont(ofSize: 13)
+        text.autoresizingMask = [.width, .maxYMargin]
+        container.addSubview(text)
+
+        window.contentView = container
+        return window
     }
 
     private static func compareBuild(_ lhs: String, _ rhs: String) -> ComparisonResult {

--- a/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
+++ b/apps/macos/Sources/OpenClaw/ApplicationRelocator.swift
@@ -281,19 +281,24 @@ enum ApplicationRelocator {
             guard confirmInstall(replacing: replacing) else {
                 return .continueLaunch(startUpdater: false)
             }
-            do {
-                try install(
-                    source: environment.bundleURL,
-                    destination: destination,
-                    replacing: replacing,
-                    fileManager: fileManager)
-                return relaunchAndTerminate(at: destination)
-            } catch {
-                self.logger.error("Could not install app: \(error.localizedDescription, privacy: .public)")
-                showFailure(
-                    "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.")
-                return .continueLaunch(startUpdater: false)
+            // Perform the bundle copy asynchronously so the main thread can finish
+            // launching and present UI. A synchronous multi-gigabyte copy here makes
+            // the app appear hung and unresponsive to SIGTERM (see issue #134736).
+            Task { @MainActor in
+                do {
+                    try await install(
+                        source: environment.bundleURL,
+                        destination: destination,
+                        replacing: replacing,
+                        fileManager: fileManager)
+                    _ = relaunchAndTerminate(at: destination)
+                } catch {
+                    self.logger.error("Could not install app: \(error.localizedDescription, privacy: .public)")
+                    showFailure(
+                        "OpenClaw couldn’t be installed in Applications. Move it there manually, then open that copy.")
+                }
             }
+            return .continueLaunch(startUpdater: false)
         case .cannotInstall:
             let message =
                 "OpenClaw is running from a temporary location. " +
@@ -983,17 +988,38 @@ extension ApplicationRelocator {
         return fileManager.isWritableFile(atPath: ancestor.path)
     }
 
+    /// Error thrown when the requested copy would recurse into the source bundle.
+    struct UnsafeCopyDestinationError: Error, Equatable, Sendable {
+        let source: URL
+        let staging: URL
+    }
+
     private static func install(
         source: URL,
         destination: URL,
         replacing: Bool,
-        fileManager: FileManager) throws
+        fileManager: FileManager) async throws
     {
         let parent = destination.deletingLastPathComponent()
         try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
         let staging = parent.appendingPathComponent(".\(destination.lastPathComponent).installing-\(UUID().uuidString)")
         defer { try? fileManager.removeItem(at: staging) }
-        try fileManager.copyItem(at: source, to: staging)
+
+        // Guard against a staging directory that resolves inside the source bundle.
+        // Without this check, copyItem can recursively descend into its own output
+        // and write without bound — observed as ~2 GB of disk writes in 40 s when
+        // the app is launched under App Translocation.
+        guard !isPath(staging, nestedIn: source) else {
+            throw UnsafeCopyDestinationError(source: source, staging: staging)
+        }
+
+        // The bundle can exceed 2 GB. Copying it synchronously on the main thread
+        // blocks applicationDidFinishLaunching, prevents any UI from appearing,
+        // and leaves the process unresponsive to SIGTERM because the main thread
+        // is stuck in a kernel write(). Run the copy on a background queue.
+        try await Task.detached(priority: .userInitiated) {
+            try FileManager.default.copyItem(at: source, to: staging)
+        }.value
 
         if replacing {
             let backupName = ".\(destination.lastPathComponent).backup-\(UUID().uuidString)"
@@ -1005,6 +1031,15 @@ extension ApplicationRelocator {
         } else {
             try fileManager.moveItem(at: staging, to: destination)
         }
+    }
+
+    /// Returns true when `nested` resolves to the same path as `root` or lies
+    /// inside its directory tree. Uses standardized file URLs so that symlinks,
+    /// relative segments, and trailing slashes cannot bypass the check.
+    static func isPath(_ nested: URL, nestedIn root: URL) -> Bool {
+        let nestedPath = nested.standardizedFileURL.path
+        let rootPath = root.standardizedFileURL.path
+        return isInside(nestedPath, root: rootPath)
     }
 
     private static func confirmInstall(replacing: Bool) -> Bool {

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -297,7 +297,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let launchPlan = AppLaunchRuntimePlan.current
         if !AppProfile.current.isActive, !launchPlan.isElevationHost {
             switch ApplicationRelocator.handleLaunch() {
-            case .terminating:
+            case .terminating, .installing:
+                // .terminating: the app is handing off to an installed copy.
+                // .installing: a self-install is running in the background and
+                // the app will relaunch from the installed location. In both
+                // cases we must not start gateway, menu, onboarding, or CLI
+                // services from the transient bundle.
                 return
             case let .continueLaunch(startUpdater):
                 if startUpdater, launchPlan.allowsUpdater {

--- a/apps/macos/Tests/OpenClawIPCTests/ApplicationRelocatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ApplicationRelocatorTests.swift
@@ -478,6 +478,44 @@ struct ApplicationRelocatorTests {
     }
 
     @Test
+    func `nested path detection rejects staging inside source bundle`() {
+        let source = URL(fileURLWithPath: "/private/var/folders/x/AppTranslocation/y/d/OpenClaw.app")
+
+        // Staging directory that resolves inside the source bundle must be rejected.
+        let stagingInside = source.deletingLastPathComponent()
+            .appendingPathComponent(".OpenClaw.app.installing-abc")
+        // This staging path is a sibling of the source, not nested — should be safe.
+        let stagingSibling = URL(fileURLWithPath: "/Applications/.OpenClaw.app.installing-abc")
+
+        #expect(ApplicationRelocator.isPath(stagingInside, nestedIn: source) == true)
+        #expect(ApplicationRelocator.isPath(stagingSibling, nestedIn: source) == false)
+    }
+
+    @Test
+    func `nested path detection handles identical paths and relative segments`() {
+        let root = URL(fileURLWithPath: "/Applications/OpenClaw.app")
+
+        // Identical path counts as nested.
+        #expect(ApplicationRelocator.isPath(root, nestedIn: root) == true)
+        // Direct child.
+        #expect(ApplicationRelocator.isPath(
+            root.appendingPathComponent("Contents"),
+            nestedIn: root) == true)
+        // Sibling is not nested.
+        #expect(ApplicationRelocator.isPath(
+            URL(fileURLWithPath: "/Applications/Safari.app"),
+            nestedIn: root) == false)
+        // ".." segments are resolved before comparison.
+        #expect(ApplicationRelocator.isPath(
+            URL(fileURLWithPath: "/Applications/OpenClaw.app/Contents/../Contents/MacOS"),
+            nestedIn: root) == true)
+        // A path that escapes via ".." is not nested.
+        #expect(ApplicationRelocator.isPath(
+            URL(fileURLWithPath: "/Applications/OpenClaw.app/../Safari.app"),
+            nestedIn: root) == false)
+    }
+
+    @Test
     func `launch at login hydration does not persist the current bundle path`() {
         #expect(!AppState.shouldPersistLaunchAtLoginChange(
             isInitializing: false,

--- a/apps/macos/Tests/OpenClawIPCTests/ApplicationRelocatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ApplicationRelocatorTests.swift
@@ -481,14 +481,17 @@ struct ApplicationRelocatorTests {
     func `nested path detection rejects staging inside source bundle`() {
         let source = URL(fileURLWithPath: "/private/var/folders/x/AppTranslocation/y/d/OpenClaw.app")
 
-        // Staging directory that resolves inside the source bundle must be rejected.
-        let stagingInside = source.deletingLastPathComponent()
+        // A staging path that is genuinely inside the source bundle.
+        let stagingInside = source.appendingPathComponent(".OpenClaw.app.installing-abc")
+        // A staging path that is a sibling of the source .app — not nested.
+        let stagingSibling = source.deletingLastPathComponent()
             .appendingPathComponent(".OpenClaw.app.installing-abc")
-        // This staging path is a sibling of the source, not nested — should be safe.
-        let stagingSibling = URL(fileURLWithPath: "/Applications/.OpenClaw.app.installing-abc")
+        // A staging path in a completely different location.
+        let stagingElsewhere = URL(fileURLWithPath: "/Applications/.OpenClaw.app.installing-abc")
 
         #expect(ApplicationRelocator.isPath(stagingInside, nestedIn: source) == true)
         #expect(ApplicationRelocator.isPath(stagingSibling, nestedIn: source) == false)
+        #expect(ApplicationRelocator.isPath(stagingElsewhere, nestedIn: source) == false)
     }
 
     @Test
@@ -501,11 +504,15 @@ struct ApplicationRelocatorTests {
         #expect(ApplicationRelocator.isPath(
             root.appendingPathComponent("Contents"),
             nestedIn: root) == true)
+        // Grandchild.
+        #expect(ApplicationRelocator.isPath(
+            root.appendingPathComponent("Contents/MacOS/OpenClaw"),
+            nestedIn: root) == true)
         // Sibling is not nested.
         #expect(ApplicationRelocator.isPath(
             URL(fileURLWithPath: "/Applications/Safari.app"),
             nestedIn: root) == false)
-        // ".." segments are resolved before comparison.
+        // ".." segments are collapsed before comparison.
         #expect(ApplicationRelocator.isPath(
             URL(fileURLWithPath: "/Applications/OpenClaw.app/Contents/../Contents/MacOS"),
             nestedIn: root) == true)
@@ -513,6 +520,13 @@ struct ApplicationRelocatorTests {
         #expect(ApplicationRelocator.isPath(
             URL(fileURLWithPath: "/Applications/OpenClaw.app/../Safari.app"),
             nestedIn: root) == false)
+        // /var and /private/var are different literal strings; standardizedFileURL
+        // does not resolve this symlink, so they are treated as distinct paths.
+        // This documents the known limitation, not a bypass of production logic
+        // (production staging paths are always absolute and explicit).
+        #expect(ApplicationRelocator.isPath(
+            URL(fileURLWithPath: "/var/OpenClaw.app/Contents"),
+            nestedIn: URL(fileURLWithPath: "/private/var/OpenClaw.app")) == false)
     }
 
     @Test


### PR DESCRIPTION
## Problem

When OpenClaw is launched under **App Translocation** (the `com.apple.quarantine` xattr is still present on `/Applications/OpenClaw.app`), `handleLaunch()` falls into the `.offerInstall` path and calls `install()` **synchronously on the main thread**.

`copyItem()` on a 2 GB+ bundle blocks `applicationDidFinishLaunching` for minutes:
- No menu bar icon appears, no window opens
- CPU sits at 200–286 % continuously
- The process **cannot be terminated with SIGTERM** because the main thread is stuck in a kernel `write()` syscall — only `kill -9` works
- macOS generates a diagnostic report showing ~2.1 GB written in 40 s

Root cause and stack trace are documented in #134736.

## Changes

1. **`install()` is now `async`** — the actual `copyItem` runs in a `Task.detached(priority: .userInitiated)` so the main thread can finish launching and present UI. The subsequent `replaceItemAt` / `moveItem` remain on the main actor.

2. **Path-nesting guard** — before copying, `install()` verifies that the staging directory does not resolve inside the source bundle. This prevents a recursive copy loop (staging inside source → copyItem descends into its own output → unbounded disk writes).

3. **`handleLaunch()` `.offerInstall` branch** starts the install as a background `Task { @MainActor }` and returns `.continueLaunch(startUpdater: false)` immediately, instead of blocking the caller.

4. **Unit tests** for `isPath(_:nestedIn:)` covering identical paths, direct children, siblings, and `..` segment resolution.

## Testing

- Added `ApplicationRelocatorTests` cases for the nesting guard.
- Manual verification: after removing the quarantine attribute (`xattr -dr com.apple.quarantine`), the app launches normally — this PR prevents the hang when the attribute is present.

## Risk

- The `.offerInstall` flow no longer blocks `applicationDidFinishLaunching`. The app UI appears first, then the background copy completes and `relaunchAndTerminate` restarts the app from the installed location. This is a behavior change but strictly an improvement (previously the app appeared completely frozen).
- `FileManager.default.copyItem` is documented as thread-safe; the detached task uses the default instance rather than the passed-in `fileManager` to avoid Sendable concerns.
- The path guard is a pure addition; it only rejects configurations that would already be unsafe.

Fixes #134736