### PR TITLE
fix(plugins): preserve channel settings during uninstall

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -424,7 +424,9 @@ openclaw plugins uninstall <id> --force
 
 `uninstall` prints a preview of what will be removed. Multi-entry packages name the package owner and every affected child before prompting. Pass `--force` to skip the confirmation prompt (useful for scripts and non-interactive runs); without it, uninstall requires an interactive TTY. `--dry-run` prints the same preview and exits without prompting or changing anything.
 
-If OpenClaw cannot prove exactly one package owner and a complete child list, lifecycle mutations fail closed without changing package files, config, or the installed index. Run `openclaw plugins registry --refresh`, inspect `openclaw plugins doctor`, and use `openclaw doctor --fix` for repairable legacy index state. If ownership is still ambiguous, reinstall the package before retrying update or uninstall.
+If a tracked package has no discovered plugin entries, uninstall can remove its exact install record and same-owner policy, including owner-keyed channel config that no other discovered plugin claims. This recovery is allowed only when no other install record shares its package path and no discovered plugin matches its id or recorded paths. Unrelated policy remains unchanged. Registry refresh rebuilds discovery metadata; it does not remove these orphan install records.
+
+Discovered packages with missing, ambiguous, or conflicting ownership still fail closed without changing package files, config, or the installed index. Run `openclaw plugins registry --refresh`, inspect `openclaw plugins doctor`, and use `openclaw doctor --fix` for repairable legacy index state. If ownership is still ambiguous, reinstall the package before retrying update or uninstall.
 
 <Note>
 `--keep-config` is supported as a deprecated alias for `--keep-files`.
@@ -442,6 +444,8 @@ openclaw plugins update openclaw-codex-app-server --acknowledge-install-policy-w
 ```
 
 Updates apply to tracked plugin installs in the managed plugin index and tracked hook-pack installs in shared SQLite state. They reuse the source that the user already chose when installing the plugin, so they do not require a second source acknowledgement.
+
+`update --all` reports and skips orphaned path-source install records so remaining plugins can update. Remove an orphan record with `openclaw plugins uninstall <id>` when its files are no longer needed.
 
 <AccordionGroup>
   <Accordion title="Resolving plugin id vs npm spec">

--- a/src/cli/plugins-cli.uninstall.test.ts
+++ b/src/cli/plugins-cli.uninstall.test.ts
@@ -5,6 +5,7 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { persistClawPackageRef } from "../claws/provenance.js";
 import type { ClawAddPlan } from "../claws/types.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { recordInstalledPluginIndexInstallOwner } from "../plugins/installed-plugin-index-install-owner.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
   applyPluginUninstallDirectoryRemovalMock,
@@ -87,7 +88,7 @@ function expectLatestUninstallPlanParams(expected: {
   expect(params.pluginId).toBe(expected.pluginId);
   expect(params.deleteFiles).toBe(expected.deleteFiles);
   if ("channelIds" in expected) {
-    expect(params.channelIds).toBe(expected.channelIds);
+    expect(params.channelIds).toEqual(expected.channelIds);
   }
 }
 
@@ -718,73 +719,133 @@ describe("plugins cli uninstall", () => {
     }
   });
 
-  it("removes installed channel config when plugin code is absent from the current registry", async () => {
-    const installRecords = {
-      alpha: {
-        source: "npm",
-        spec: "alpha@1.0.0",
-        installPath: ALPHA_INSTALL_PATH,
-      },
-    } as const;
-    const baseConfig = {
-      plugins: {
-        entries: {
-          alpha: { enabled: true },
+  it.each([false, true])(
+    "preserves another channel owner during orphan uninstall: %s",
+    async (claimed) => {
+      const pluginId = "orphan-channel-plugin";
+      const installRecords = {
+        [pluginId]: {
+          source: "path",
+          sourcePath: "/tmp/missing-orphan-channel-source",
+          installPath: "/tmp/missing-orphan-channel-install",
         },
-        installs: installRecords,
-      },
-      channels: {
-        alpha: {
-          enabled: true,
+      } as const;
+      const baseConfig = {
+        channels: {
+          [pluginId]: { enabled: true },
+          discord: { enabled: true },
         },
-        discord: {
-          enabled: true,
-        },
-      },
-    } as OpenClawConfig;
-    const nextConfig = {
-      channels: {
-        discord: {
-          enabled: true,
-        },
-      },
-    } as OpenClawConfig;
-
-    pluginCliConfigMock.mockReturnValue(baseConfig);
-    setInstalledPluginIndexInstallRecords(installRecords);
-    buildPluginSnapshotReportMock.mockReturnValue({
-      plugins: [],
-      diagnostics: [],
-    });
-    const actualUninstall =
-      await vi.importActual<typeof import("../plugins/uninstall.js")>("../plugins/uninstall.js");
-    planPluginUninstallMock.mockImplementation((params) =>
-      actualUninstall.planPluginUninstall(
-        params as Parameters<typeof actualUninstall.planPluginUninstall>[0],
-      ),
-    );
-    const installedIndexModule = await import("../plugins/installed-plugin-index.js");
-    const indexSpy = vi
-      .spyOn(installedIndexModule, "loadInstalledPluginIndex")
-      .mockReturnValue(
-        createTestInstalledPluginIndex({ policyHash: "orphan-channel", installRecords }),
-      );
-    try {
-      await runPluginsCommand(["plugins", "uninstall", "alpha", "--force", "--keep-files"]);
-
-      expectLatestUninstallPlanParams({
-        pluginId: "alpha",
-        channelIds: undefined,
-        deleteFiles: false,
+      } as OpenClawConfig;
+      pluginCliConfigMock.mockReturnValue(baseConfig);
+      setInstalledPluginIndexInstallRecords(installRecords);
+      buildPluginSnapshotReportMock.mockReturnValue({
+        plugins: [],
+        diagnostics: [],
       });
-      expectInstallRecordsWrittenWithLease({}, nextConfig);
-      expect(configWriteMock).toHaveBeenCalledWith(nextConfig);
-      expectRuntimeLogIncludes("channel config (channels.alpha)");
-      expect(pluginsCliRuntimeLogs.at(-2)).toContain('Uninstalled plugin "alpha"');
-    } finally {
-      indexSpy.mockRestore();
-    }
-  });
+      const actualUninstall =
+        await vi.importActual<typeof import("../plugins/uninstall.js")>("../plugins/uninstall.js");
+      planPluginUninstallMock.mockImplementation((params) =>
+        actualUninstall.planPluginUninstall(
+          params as Parameters<typeof actualUninstall.planPluginUninstall>[0],
+        ),
+      );
+      const installedIndexModule = await import("../plugins/installed-plugin-index.js");
+      const indexSpy = vi.spyOn(installedIndexModule, "loadInstalledPluginIndex").mockReturnValue(
+        createTestInstalledPluginIndex({
+          policyHash: "orphan-channel",
+          installRecords,
+          plugins: claimed
+            ? [
+                {
+                  pluginId: "bridge",
+                  rootDir: "/tmp/bridge",
+                  manifestPath: "/tmp/bridge/openclaw.plugin.json",
+                  manifestHash: "bridge",
+                  origin: "global",
+                  enabled: true,
+                  startup: { sidecar: false, memory: false, agentHarnesses: [] },
+                  packageChannel: { id: pluginId },
+                  compat: [],
+                },
+              ]
+            : [],
+        }),
+      );
+      try {
+        await runPluginsCommand(["plugins", "uninstall", pluginId, "--force", "--keep-files"]);
+
+        expectLatestUninstallPlanParams({
+          pluginId,
+          channelIds: claimed ? [] : undefined,
+          deleteFiles: false,
+        });
+        expectInstallRecordsWrittenWithLease(
+          {},
+          {
+            channels: {
+              ...(claimed ? { [pluginId]: { enabled: true } } : {}),
+              discord: { enabled: true },
+            },
+          },
+        );
+      } finally {
+        indexSpy.mockRestore();
+      }
+    },
+  );
+
+  it.each(["pack", "pack/one"])(
+    "cleans declared singleton channels through %s",
+    async (requestedId) => {
+      const installPath = "/tmp/singleton-pack";
+      const installRecords = {
+        pack: { source: "path", sourcePath: installPath, installPath },
+      } as const;
+      pluginCliConfigMock.mockReturnValue({
+        channels: { chat: { enabled: true }, "pack/one": { enabled: true } },
+      } as OpenClawConfig);
+      setInstalledPluginIndexInstallRecords(installRecords);
+      buildPluginSnapshotReportMock.mockReturnValue({
+        plugins: [{ id: "pack/one", name: "One", status: "loaded", channelIds: ["chat"] }],
+        diagnostics: [],
+      });
+      const actualUninstall =
+        await vi.importActual<typeof import("../plugins/uninstall.js")>("../plugins/uninstall.js");
+      planPluginUninstallMock.mockImplementation((params) =>
+        actualUninstall.planPluginUninstall(
+          params as Parameters<typeof actualUninstall.planPluginUninstall>[0],
+        ),
+      );
+      const installedIndexModule = await import("../plugins/installed-plugin-index.js");
+      const indexSpy = vi.spyOn(installedIndexModule, "loadInstalledPluginIndex").mockReturnValue(
+        createTestInstalledPluginIndex({
+          policyHash: "singleton",
+          installRecords,
+          plugins: [
+            recordInstalledPluginIndexInstallOwner(
+              {
+                pluginId: "pack/one",
+                rootDir: installPath,
+                manifestPath: `${installPath}/openclaw.plugin.json`,
+                manifestHash: "one",
+                origin: "global" as const,
+                enabled: true,
+                startup: { sidecar: false, memory: false, agentHarnesses: [] },
+                compat: [],
+              },
+              "pack",
+            ),
+          ],
+        }),
+      );
+      try {
+        await runPluginsCommand(["plugins", "uninstall", requestedId, "--force", "--keep-files"]);
+        expectInstallRecordsWrittenWithLease({}, { channels: { "pack/one": { enabled: true } } });
+      } finally {
+        indexSpy.mockRestore();
+      }
+    },
+  );
 
   it("exits when uninstall target is not managed by plugin install records", async () => {
     pluginCliConfigMock.mockReturnValue({

--- a/src/cli/plugins-uninstall-command.ts
+++ b/src/cli/plugins-uninstall-command.ts
@@ -65,6 +65,8 @@ async function runPluginUninstallCommandUnlocked(
   }
 
   const { loadInstalledPluginIndex } = await import("../plugins/installed-plugin-index.js");
+  const { createInstalledPluginIndexScopeLookup } =
+    await import("../plugins/installed-plugin-index-scope-lookup.js");
   const { resolveInstalledPluginLifecycleOwnership } =
     await import("../plugins/installed-plugin-package-ownership.js");
   const {
@@ -142,7 +144,7 @@ async function runPluginUninstallCommandUnlocked(
   let channelIds: string[] | undefined;
   if (ownedPluginIds.length === 1 && ownedPluginIds[0] === requestedPluginId) {
     channelIds = plugin?.channelIds;
-  } else if (ownedPluginIds.length > 1) {
+  } else if (ownedPluginIds.length > 0) {
     channelIds = [
       ...new Set(
         ownedPluginIds.flatMap(
@@ -150,6 +152,11 @@ async function runPluginUninstallCommandUnlocked(
         ),
       ),
     ];
+  } else if (
+    createInstalledPluginIndexScopeLookup(installedIndex).hasChannelContributionOwners([pluginId])
+  ) {
+    // An orphan's owner-key fallback cannot remove another discovered plugin's channel policy.
+    channelIds = [];
   }
   const initialPlan = planPluginUninstall(
     recordPluginPackageUninstallPlan(

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -92,6 +92,7 @@ import {
   withPluginInstallRecords,
   withoutPluginInstallRecords,
 } from "./installed-plugin-index-records.js";
+import { createInstalledPluginIndexScopeLookup } from "./installed-plugin-index-scope-lookup.js";
 import { isInstalledPluginEnabled } from "./installed-plugin-index.js";
 import {
   resolveInstalledPluginLifecycleOwnership,
@@ -2069,7 +2070,12 @@ export async function uninstallManagedPlugin(params: {
     const channelIds =
       ownedManifests.length > 0
         ? uniqueStrings(ownedManifests.flatMap((manifest) => manifest.channels))
-        : undefined;
+        : ownership.value.kind === "orphan" &&
+            createInstalledPluginIndexScopeLookup(metadata.index).hasChannelContributionOwners([
+              installOwner,
+            ])
+          ? []
+          : undefined;
     const extensionsDir = resolveDefaultPluginExtensionsDir(env);
     const initialPlan = planPluginUninstall(
       recordPluginPackageUninstallPlan(

--- a/src/plugins/management-service.uninstall-ownership.test.ts
+++ b/src/plugins/management-service.uninstall-ownership.test.ts
@@ -201,44 +201,64 @@ describe("plugin management uninstall channel ownership", () => {
     expect(mocks.commitRecords).not.toHaveBeenCalled();
   });
 
-  it("removes an exact orphan owner record with no discovered plugin code", async () => {
-    const pluginId = "orphaned-plugin";
-    const installRecord = {
-      source: "path",
-      sourcePath: "/tmp/missing-orphan-source",
-      installPath: "/tmp/missing-orphan-install",
-    } as const;
-    mocks.readConfig.mockResolvedValue({
-      snapshot: {
-        valid: true,
-        parsed: {},
-        path: "/tmp/openclaw.json",
-        sourceConfig: { plugins: { entries: { [pluginId]: { enabled: true } } } },
-        hash: "base-hash",
-      },
-      writeOptions: { expectedConfigPath: "/tmp/openclaw.json" },
-    });
-    mocks.installRecords.mockResolvedValue({ [pluginId]: installRecord });
-    mocks.metadata.mockReturnValue({
-      index: {
-        plugins: [],
-        installRecords: { [pluginId]: installRecord },
-      },
-      byPluginId: new Map(),
-      normalizePluginId: (rawPluginId: string) => rawPluginId,
-    });
+  it.each([false, true])(
+    "preserves another channel owner during managed orphan uninstall: %s",
+    async (claimed) => {
+      const pluginId = "orphaned-plugin";
+      const installRecord = {
+        source: "path",
+        sourcePath: "/tmp/missing-orphan-source",
+        installPath: "/tmp/missing-orphan-install",
+      } as const;
+      mocks.readConfig.mockResolvedValue({
+        snapshot: {
+          valid: true,
+          parsed: {},
+          path: "/tmp/openclaw.json",
+          sourceConfig: {
+            plugins: { entries: { [pluginId]: { enabled: true } } },
+            channels: { [pluginId]: { enabled: true }, unknown: { enabled: true } },
+          },
+          hash: "base-hash",
+        },
+        writeOptions: { expectedConfigPath: "/tmp/openclaw.json" },
+      });
+      mocks.installRecords.mockResolvedValue({ [pluginId]: installRecord });
+      mocks.metadata.mockReturnValue({
+        index: {
+          plugins: claimed
+            ? [
+                {
+                  pluginId: "bridge",
+                  rootDir: "/tmp/bridge",
+                  startup: { agentHarnesses: [] },
+                  contributions: { channels: [pluginId] },
+                },
+              ]
+            : [],
+          installRecords: { [pluginId]: installRecord },
+        },
+        byPluginId: new Map(),
+        normalizePluginId: (rawPluginId: string) => rawPluginId,
+      });
 
-    const result = await uninstallManagedPlugin({ pluginId, env: {} });
+      const result = await uninstallManagedPlugin({ pluginId, env: {} });
 
-    expect(mocks.commitRecords).toHaveBeenCalledWith(
-      expect.objectContaining({
-        nextConfig: {},
-        nextInstallRecords: {},
-      }),
-    );
-    expect(result.pluginId).toBe(pluginId);
-    expect(result.removed).toContain("install record");
-  });
+      expect(mocks.commitRecords).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nextConfig: {
+            channels: {
+              ...(claimed ? { [pluginId]: { enabled: true } } : {}),
+              unknown: { enabled: true },
+            },
+          },
+          nextInstallRecords: {},
+        }),
+      );
+      expect(result.pluginId).toBe(pluginId);
+      expect(result.removed).toContain("install record");
+    },
+  );
 
   it("resolves a child request to one package owner and removes every sibling policy", async () => {
     const installPath = "/tmp/openclaw-managed-linked-pack";


### PR DESCRIPTION
Related: #134321. Follow-up to #134590; thanks @MoerAI for the orphan-install recovery fix.

## What Problem This Solves

Fixes an issue where users uninstalling an orphaned plugin could lose a channel configuration owned by another installed plugin when the channel key matched the orphan's install owner. Uninstalling a package by its owner ID also left the declared channel configuration behind when only one differently named runtime child remained.

## Why This Change Was Made

The uninstall entry points now reuse the installed-plugin index's channel ownership lookup before applying the orphan owner-key cleanup fallback. CLI package-owner selection collects declared channels for one or more discovered children, matching child-ID selection. This keeps exact-orphan recovery and strict package/replacement ownership validation intact. The CLI docs describe the recovery boundary, including preserving channels claimed by another discovered plugin.

Production changes are +15/-2 lines (net +13): the existing ownership lookup is needed at both uninstall entry points, while the singleton repair broadens the existing aggregation branch. Tests are +180/-99 (net +81); docs are +5/-1. No new configuration, default, persistence schema, or migration surface.

## User Impact

Removing a missing plugin clears its own durable install record and policy without deleting another plugin's channel settings. Removing a package through either its owner or remaining child ID clears the child's declared channel settings consistently.

## Evidence

On baseline `a0868f477a8ec13269e59c0ea821c3814f03d3f6`, the added coverage reproduced two CLI failures and the managed-uninstall channel ownership failure. With this patch, all 21 CLI uninstall tests and 10 managed uninstall tests pass on Linux.

Focused commands:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/plugins-cli.uninstall.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/management-service.uninstall-ownership.test.ts
```

Independent Codex source review found no concrete P0/P1/P2 defects. The required autoreview passed its configured scope. The proof covers owner and child selectors, claimed and unclaimed orphan channel keys, unrelated channels, managed uninstall, conflicting orphan paths, and the existing fail-closed ownership tests.

`check-changed` and the full `pnpm build` also passed. The compiled CLI passed 21 synthetic Linux checks: install a package, change it to one valid renamed runtime child under the existing durable owner, refresh the registry, and uninstall through both owner and child selectors; each removes the declared `chat` settings and preserves another plugin's channels. A second sequence installs an orphan candidate and a channel-owning bridge, deletes the orphan files, runs update-all → registry refresh → update-all → uninstall, and verifies the orphan record is removed while the bridge's same-named channel survives. All temporary fixture state was removed.

The initial CLI fixture attempts stopped at invalid package setup or an overly specific preview assertion before exercising the final sequence; the corrected valid-metadata fixture passed without product changes. The original #134590 was merged independently while this review was in progress; this PR repairs the two remaining cleanup cases on main.
