### PR TITLE
fix(doctor): preserve per-agent memory search during upgrades

### DIFF
--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -202,6 +202,8 @@ describe("doctor invalid config process exit", () => {
     const stateDir = path.join(root, "state");
     const configPath = path.join(stateDir, "openclaw.json");
     const approvalsPath = path.join(stateDir, "exec-approvals.json");
+    const knowledgePath = path.join(root, "knowledge");
+    const legacyIndexPath = path.join(root, "legacy-memory.sqlite");
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       HOME: root,
@@ -224,7 +226,22 @@ describe("doctor invalid config process exit", () => {
           list: [
             {
               id: "jup",
-              memorySearch: { enabled: true },
+              memorySearch: {
+                enabled: true,
+                provider: "auto",
+                sources: ["memory", "sessions"],
+                extraPaths: [knowledgePath],
+                experimental: { sessionMemory: true },
+                store: { path: legacyIndexPath, vector: { enabled: false } },
+                query: { maxResults: 8 },
+              },
+              memory: {
+                search: {
+                  enabled: false,
+                  experimental: { sessionMemory: false },
+                  query: { minScore: 0.25 },
+                },
+              },
               tools: { message: { allowCrossContextSend: true } },
             },
           ],
@@ -277,6 +294,20 @@ describe("doctor invalid config process exit", () => {
     expect(output).toContain("Exec approvals updated: removed 1 older generated approval");
     expect(output).toContain("Doctor complete.");
     expect(output).not.toContain("Building Control UI assets");
+    expect(output).toContain("Merged agents.entries.jup.memorySearch");
+
+    const repairedConfig = JSON.parse(fs.readFileSync(configPath, "utf8")) as OpenClawConfig;
+    expect(repairedConfig.agents).not.toHaveProperty("list");
+    expect(repairedConfig.agents?.entries?.jup).not.toHaveProperty("memorySearch");
+    expect(repairedConfig.agents?.entries?.jup?.memory?.search).toEqual({
+      enabled: false,
+      provider: "openai",
+      sources: ["memory", "sessions"],
+      extraPaths: [knowledgePath],
+      experimental: { sessionMemory: false },
+      store: { vector: { enabled: false } },
+      query: { minScore: 0.25, maxResults: 8 },
+    });
 
     expect(fs.existsSync(approvalsPath)).toBe(false);
     const database = new DatabaseSync(path.join(stateDir, "state", "openclaw.sqlite"), {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
@@ -20,6 +20,7 @@ import {
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
 import { isBlockedObjectKey } from "../../../infra/prototype-keys.js";
+import { visitAgentConfigScopes } from "./legacy-config-record-shared.js";
 import {
   modelEntryWithRuntimePolicy,
   selectedCanonicalModelRefsForRuntimePolicy,
@@ -50,12 +51,11 @@ const AGENT_MEMORY_SEARCH_OWNER_RULES: LegacyConfigRule[] = [
     path: ["agents", "defaults", "memorySearch"],
     message: 'agents.defaults.memorySearch moved to memory.search. Run "openclaw doctor --fix".',
   },
-  {
-    path: ["agents", "list"],
-    message:
-      'agents.list[].memorySearch moved to agents.list[].memory.search. Run "openclaw doctor --fix".',
-    match: (value) => someAgentList(value, (agent) => agent.memorySearch !== undefined),
-  },
+  ...agentMemorySearchRules(
+    (scope) =>
+      `${scope}.memorySearch moved to ${scope}.memory.search. Run "openclaw doctor --fix".`,
+    (agent) => agent.memorySearch !== undefined,
+  ),
 ];
 
 const LEGACY_MEMORY_SEARCH_AUTO_PROVIDER_RULES: LegacyConfigRule[] = [
@@ -71,15 +71,11 @@ const LEGACY_MEMORY_SEARCH_AUTO_PROVIDER_RULES: LegacyConfigRule[] = [
       'memory.search.provider = "auto" is legacy; use "openai" explicitly. Run "openclaw doctor --fix".',
     match: isLegacyMemorySearchAutoProvider,
   },
-  {
-    path: ["agents", "list"],
-    message:
-      'agents.list[].memorySearch.provider = "auto" is legacy; use "openai" explicitly. Run "openclaw doctor --fix".',
-    match: (value) =>
-      someAgentList(value, (agent) =>
-        isLegacyMemorySearchAutoProvider(getAgentMemorySearchRecord(agent)?.provider),
-      ),
-  },
+  ...agentMemorySearchRules(
+    (scope) =>
+      `${scope}.memorySearch.provider = "auto" is legacy; use "openai" explicitly. Run "openclaw doctor --fix".`,
+    (agent) => isLegacyMemorySearchAutoProvider(getAgentMemorySearchRecord(agent)?.provider),
+  ),
 ];
 
 const LEGACY_MEMORY_SEARCH_STORE_PATH_RULES: LegacyConfigRule[] = [
@@ -93,13 +89,11 @@ const LEGACY_MEMORY_SEARCH_STORE_PATH_RULES: LegacyConfigRule[] = [
     message:
       'memory.search.store.path is legacy; memory indexes now live in each agent database. Run "openclaw doctor --fix".',
   },
-  {
-    path: ["agents", "list"],
-    message:
-      'agents.list[].memorySearch.store.path is legacy; memory indexes now live in each agent database. Run "openclaw doctor --fix".',
-    match: (value) =>
-      someAgentList(value, (agent) => hasMemorySearchStorePath(getAgentMemorySearchRecord(agent))),
-  },
+  ...agentMemorySearchRules(
+    (scope) =>
+      `${scope}.memorySearch.store.path is legacy; memory indexes now live in each agent database. Run "openclaw doctor --fix".`,
+    (agent) => hasMemorySearchStorePath(getAgentMemorySearchRecord(agent)),
+  ),
 ];
 
 const LEGACY_MEMORY_SEARCH_FLAT_KEY_RULES: LegacyConfigRule[] = [
@@ -109,16 +103,28 @@ const LEGACY_MEMORY_SEARCH_FLAT_KEY_RULES: LegacyConfigRule[] = [
       'memory.search uses legacy flat chunkSize, chunkOverlap, or maxResults fields. Run "openclaw doctor --fix".',
     match: hasLegacyMemorySearchFlatKeys,
   },
-  {
-    path: ["agents", "list"],
-    message:
-      'agents.list[].memorySearch uses legacy flat chunkSize, chunkOverlap, or maxResults fields. Run "openclaw doctor --fix".',
-    match: (value) =>
-      someAgentList(value, (agent) =>
-        hasLegacyMemorySearchFlatKeys(getAgentMemorySearchRecord(agent)),
-      ),
-  },
+  ...agentMemorySearchRules(
+    (scope) =>
+      `${scope}.memorySearch uses legacy flat chunkSize, chunkOverlap, or maxResults fields. Run "openclaw doctor --fix".`,
+    (agent) => hasLegacyMemorySearchFlatKeys(getAgentMemorySearchRecord(agent)),
+  ),
 ];
+
+function agentMemorySearchRules(
+  message: (scope: string) => string,
+  predicate: (agent: Record<string, unknown>) => boolean,
+): LegacyConfigRule[] {
+  return (
+    [
+      ["entries", "agents.entries.*", someAgentEntries],
+      ["list", "agents.list[]", someAgentList],
+    ] as const
+  ).map(([key, scope, match]) => ({
+    path: ["agents", key],
+    message: message(scope),
+    match: (value) => match(value, predicate),
+  }));
+}
 
 function hasLegacyMemorySearchFlatKeys(value: unknown): boolean {
   const memorySearch = getRecord(value);
@@ -145,6 +151,20 @@ function someAgentList(
       const agent = getRecord(entry);
       return agent !== null && predicate(agent);
     })
+  );
+}
+
+function someAgentEntries(
+  value: unknown,
+  predicate: (agent: Record<string, unknown>) => boolean,
+): boolean {
+  const entries = getRecord(value);
+  return Boolean(
+    entries &&
+    Object.values(entries).some((entry) => {
+      const agent = getRecord(entry);
+      return agent !== null && predicate(agent);
+    }),
   );
 }
 
@@ -531,17 +551,16 @@ function migrateCanonicalMemorySearches(
   agentPathStyle: "dot" | "brackets" = "dot",
 ): void {
   migrateMemorySearch(getRecord(getRecord(raw.memory)?.search), "memory.search", changes);
-  const agents = getRecord(raw.agents);
-  if (!Array.isArray(agents?.list)) {
-    return;
-  }
-  for (const [index, agent] of agents.list.entries()) {
-    const pathLabel =
-      agentPathStyle === "brackets"
-        ? `agents.list[${index}].memory.search`
-        : `agents.list.${index}.memory.search`;
-    migrateMemorySearch(getRecord(getRecord(getRecord(agent)?.memory)?.search), pathLabel, changes);
-  }
+  visitAgentConfigScopes(
+    raw,
+    (agent, pathLabel) =>
+      migrateMemorySearch(
+        getRecord(getRecord(agent.memory)?.search),
+        `${pathLabel}.memory.search`,
+        changes,
+      ),
+    { includeDefaults: false, listPathStyle: agentPathStyle === "dot" ? "dots" : "brackets" },
+  );
 }
 
 function migrateLegacySandboxPerSession(
@@ -1445,27 +1464,27 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_AGENTS: LegacyConfigMigrationSpec[
         );
       }
 
-      if (!Array.isArray(agents?.list)) {
-        return;
-      }
-      for (const [index, rawAgent] of agents.list.entries()) {
-        const agent = getRecord(rawAgent);
-        const legacy = getRecord(agent?.memorySearch);
-        if (!agent || !legacy) {
-          continue;
-        }
-        const agentMemory = ensureRecord(agent, "memory");
-        const existing = getRecord(agentMemory.search);
-        const target = structuredClone(existing ?? {});
-        mergeMissing(target, legacy);
-        agentMemory.search = target;
-        delete agent.memorySearch;
-        changes.push(
-          existing
-            ? `Merged agents.list.${index}.memorySearch → agents.list.${index}.memory.search (kept explicit memory.search values).`
-            : `Moved agents.list.${index}.memorySearch → agents.list.${index}.memory.search.`,
-        );
-      }
+      visitAgentConfigScopes(
+        raw,
+        (agent, pathLabel) => {
+          const legacy = getRecord(agent.memorySearch);
+          if (!legacy) {
+            return;
+          }
+          const agentMemory = ensureRecord(agent, "memory");
+          const existing = getRecord(agentMemory.search);
+          const target = structuredClone(existing ?? {});
+          mergeMissing(target, legacy);
+          agentMemory.search = target;
+          delete agent.memorySearch;
+          changes.push(
+            existing
+              ? `Merged ${pathLabel}.memorySearch → ${pathLabel}.memory.search (kept explicit memory.search values).`
+              : `Moved ${pathLabel}.memorySearch → ${pathLabel}.memory.search.`,
+          );
+        },
+        { includeDefaults: false, listPathStyle: "dots" },
+      );
     },
   }),
   defineLegacyConfigMigration({

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.config-tranche.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.config-tranche.ts
@@ -1,31 +1,7 @@
 // Config-tranche migrations move legacy aliases before canonical validation.
 import { ensureRecord, getRecord } from "../../../config/legacy.shared.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../../routing/account-id.js";
-import { deleteRetiredPath } from "./legacy-config-record-shared.js";
-
-function visitAgentEntries(
-  raw: Record<string, unknown>,
-  visitor: (entry: Record<string, unknown>, path: string) => void,
-): void {
-  const agents = getRecord(raw.agents);
-  const entries = getRecord(agents?.entries);
-  if (entries) {
-    for (const [agentId, value] of Object.entries(entries)) {
-      const entry = getRecord(value);
-      if (entry) {
-        visitor(entry, `agents.entries.${agentId}`);
-      }
-    }
-  }
-  if (Array.isArray(agents?.list)) {
-    agents.list.forEach((value, index) => {
-      const entry = getRecord(value);
-      if (entry) {
-        visitor(entry, `agents.list[${index}]`);
-      }
-    });
-  }
-}
+import { deleteRetiredPath, visitAgentConfigScopes } from "./legacy-config-record-shared.js";
 
 function stripRetiredPresentationPrefs(raw: Record<string, unknown>, changes: string[]): void {
   const prefs = getRecord(getRecord(raw.ui)?.prefs);
@@ -72,13 +48,17 @@ function stripRetiredAgentConfig(raw: Record<string, unknown>, changes: string[]
     stripContextLimits(defaults);
   }
   let removedTypingOverride = false;
-  visitAgentEntries(raw, (entry) => {
-    if (Object.hasOwn(entry, "typingIntervalSeconds")) {
-      delete entry.typingIntervalSeconds;
-      removedTypingOverride = true;
-    }
-    stripContextLimits(entry);
-  });
+  visitAgentConfigScopes(
+    raw,
+    (entry) => {
+      if (Object.hasOwn(entry, "typingIntervalSeconds")) {
+        delete entry.typingIntervalSeconds;
+        removedTypingOverride = true;
+      }
+      stripContextLimits(entry);
+    },
+    { includeDefaults: false },
+  );
   if (removedTypingOverride) {
     changes.push(
       "Removed per-agent typingIntervalSeconds overrides; agents.defaults.typingIntervalSeconds now applies to every agent.",

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.retired-memory-qmd.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.retired-memory-qmd.ts
@@ -8,8 +8,7 @@ import {
 } from "../../../config/legacy.shared.js";
 import { normalizeConfiguredMemoryExtraPaths } from "../../../memory-host-sdk/host/config-utils.js";
 import type { MemoryExtraPath } from "../../../memory-host-sdk/host/types.js";
-import { visitAgentConfigScopes } from "./legacy-config-migrations.runtime.tier-eval.js";
-import { deleteRetiredPath } from "./legacy-config-record-shared.js";
+import { deleteRetiredPath, visitAgentConfigScopes } from "./legacy-config-record-shared.js";
 
 const rule = (
   path: string[],

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.tier-eval.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.tier-eval.ts
@@ -1,6 +1,10 @@
 // Tier-eval config compatibility migration and its scoped traversal helpers.
 import { ensureRecord, getRecord } from "../../../config/legacy.shared.js";
-import { deleteRetiredPath, visitChannelEntries } from "./legacy-config-record-shared.js";
+import {
+  deleteRetiredPath,
+  visitAgentConfigScopes,
+  visitChannelEntries,
+} from "./legacy-config-record-shared.js";
 
 const TIER_EVAL_RETIRED_ROOT_PATHS = [
   ["cloudWorkers", "profiles", "*", "lifetime"],
@@ -42,34 +46,6 @@ const TIER_EVAL_RETIRED_AGENT_PATHS = [
   ["heartbeat", "skipWhenBusy"],
   ["heartbeat", "suppressToolErrorWarnings"],
 ] as const;
-
-export function visitAgentConfigScopes(
-  raw: Record<string, unknown>,
-  visitor: (scope: Record<string, unknown>, path: string) => void,
-): void {
-  const agents = getRecord(raw.agents);
-  const defaults = getRecord(agents?.defaults);
-  if (defaults) {
-    visitor(defaults, "agents.defaults");
-  }
-  const entries = getRecord(agents?.entries);
-  if (entries) {
-    for (const [agentId, value] of Object.entries(entries)) {
-      const entry = getRecord(value);
-      if (entry) {
-        visitor(entry, `agents.entries.${agentId}`);
-      }
-    }
-  }
-  if (Array.isArray(agents?.list)) {
-    agents.list.forEach((value, index) => {
-      const entry = getRecord(value);
-      if (entry) {
-        visitor(entry, `agents.list[${index}]`);
-      }
-    });
-  }
-}
 
 type LegacyExecPolicy = {
   security: "deny" | "allowlist" | "full";

--- a/src/commands/doctor/shared/legacy-config-record-shared.ts
+++ b/src/commands/doctor/shared/legacy-config-record-shared.ts
@@ -48,6 +48,38 @@ export function deleteRetiredPath(owner: unknown, path: readonly string[], index
   return true;
 }
 
+/** Visit agent defaults and both persisted roster shapes in config order. */
+export function visitAgentConfigScopes(
+  raw: JsonRecord,
+  visitor: (scope: JsonRecord, path: string) => void,
+  options: { includeDefaults?: boolean; listPathStyle?: "brackets" | "dots" } = {},
+): void {
+  const agents = raw.agents;
+  if (!isRecord(agents)) {
+    return;
+  }
+  if (options.includeDefaults !== false && isRecord(agents.defaults)) {
+    visitor(agents.defaults, "agents.defaults");
+  }
+  if (isRecord(agents.entries)) {
+    for (const [agentId, value] of Object.entries(agents.entries)) {
+      if (isRecord(value)) {
+        visitor(value, `agents.entries.${agentId}`);
+      }
+    }
+  }
+  if (!Array.isArray(agents.list)) {
+    return;
+  }
+  agents.list.forEach((value, index) => {
+    if (isRecord(value)) {
+      const path =
+        options.listPathStyle === "dots" ? `agents.list.${index}` : `agents.list[${index}]`;
+      visitor(value, path);
+    }
+  });
+}
+
 /** Visit a channel root followed by its object-shaped accounts in config order. */
 export function visitChannelEntries(
   raw: JsonRecord,


### PR DESCRIPTION
Closes #134256

Reported by @vdruts.

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --fix` after an upgrade could silently lose every per-agent memory-search override when Doctor converted `agents.list` to keyed `agents.entries` first. This removed settings such as `extraPaths`, `sources`, `experimental.sessionMemory`, and `enabled`.

## Why This Change Was Made

Doctor now visits both keyed agent entries and legacy list entries at the migration owner. It moves `memorySearch` before unknown-key cleanup, preserves explicit canonical values, and applies the existing provider, nested-field, and retired-path migrations to the moved data.

The shared agent-scope traversal replaces two duplicate traversal implementations. The regression was introduced by #112678, which moved roster normalization before the older list-only migration from #111527.

## User Impact

Per-agent memory-search settings now survive `openclaw doctor --fix` and remain attached to the correct agent. Operators no longer lose per-agent retrieval paths silently during this upgrade path.

## Evidence

- Red on current-main baseline `8abb80073c8648e85d11a0e9bd22b09d1d2bfac2`: [Testbox run 33466170600](https://github.com/openclaw/openclaw/actions/runs/33466170600) removed the legacy block and retained only the pre-existing canonical field.
- Green on exact head `983df6b6ddf33ffad80f32874966ffeeaf0a803f`: [Testbox run 33467597600](https://github.com/openclaw/openclaw/actions/runs/33467597600) ran the real CLI, preserved supported fields and canonical precedence, verified the authored input, and produced byte-identical config on a second Doctor run.
- Regression proof: the strengthened Doctor process test fails on the baseline and passes on the head.
- `node scripts/run-vitest.mjs src/commands/doctor-config-preflight.process.test.ts` — 10 passed.
- `node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts src/commands/doctor/shared/legacy-config-migrations.runtime.retired.memory-qmd.test.ts src/commands/doctor/shared/legacy-config-migrations.runtime.retired.test.ts` — 294 passed.
- Focused format, Oxlint, Doctor registry, coercion helper, max-lines, assertion safety, import-cycle, temp-directory, conflict-marker, and dead-export checks passed.
- Autoreview on the exact local diff: clean, no actionable P0 findings.

Agent task: https://chatgpt.com/codex/tasks/01a040d7-aa3d-7433-83eb-de7f49979443
