### PR TITLE
refactor(scripts): share SQLite reliability stderr formatting

### DIFF
--- a/scripts/lib/sqlite-reliability-compaction.ts
+++ b/scripts/lib/sqlite-reliability-compaction.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import type { SnapshotDatabaseIdentity } from "../../src/snapshot/snapshot-provider.js";
 import {
   assertSameCompactionPayload,
+  formatReliabilityStderr,
   type CompactionPayloadProof,
   type ReliabilityReport,
   type ReliabilityStateProof,
@@ -60,11 +61,6 @@ function workerArgs(target: CompactionTarget): string[] {
   throw new Error(`unsupported reliability target role: ${target.identity.role}`);
 }
 
-function formatWorkerStderr(stderr: string): string {
-  const text = stderr.trim();
-  return text ? ` stderr=${JSON.stringify(text)}` : "";
-}
-
 async function waitForWorkerReady(params: {
   child: ChildProcess;
   readStderr: () => string;
@@ -74,7 +70,7 @@ async function waitForWorkerReady(params: {
       cleanup();
       reject(
         new Error(
-          `SQLite compaction worker did not become ready.${formatWorkerStderr(params.readStderr())}`,
+          `SQLite compaction worker did not become ready.${formatReliabilityStderr(params.readStderr())}`,
         ),
       );
     }, 30_000);
@@ -96,7 +92,7 @@ async function waitForWorkerReady(params: {
       cleanup();
       reject(
         new Error(
-          `SQLite compaction worker exited before ready: code=${String(code)} signal=${String(signal)}.${formatWorkerStderr(params.readStderr())}`,
+          `SQLite compaction worker exited before ready: code=${String(code)} signal=${String(signal)}.${formatReliabilityStderr(params.readStderr())}`,
         ),
       );
     };
@@ -153,7 +149,7 @@ async function waitForActiveVacuum(params: {
     }
     if (params.child.exitCode !== null || params.child.signalCode !== null) {
       throw new Error(
-        `SQLite compaction completed before interruption evidence was observed.${formatWorkerStderr(params.readStderr())}`,
+        `SQLite compaction completed before interruption evidence was observed.${formatReliabilityStderr(params.readStderr())}`,
       );
     }
     await delay(2);

--- a/scripts/lib/sqlite-reliability-contract.ts
+++ b/scripts/lib/sqlite-reliability-contract.ts
@@ -43,6 +43,11 @@ export type ReliabilityStateProof = {
   sha256: string;
 };
 
+export function formatReliabilityStderr(stderr: string): string {
+  const text = stderr.trim();
+  return text ? ` stderr=${JSON.stringify(text)}` : "";
+}
+
 export function assertSameCompactionPayload(
   actual: CompactionPayloadProof,
   expected: CompactionPayloadProof,

--- a/scripts/lib/sqlite-reliability-index-repair.ts
+++ b/scripts/lib/sqlite-reliability-index-repair.ts
@@ -9,6 +9,7 @@ import { openNodeSqliteDatabase } from "../../src/infra/node-sqlite.js";
 import { repairCanonicalSqliteIndexes } from "../../src/infra/sqlite-index-schema.js";
 import { assertSqliteIntegrity } from "../../src/infra/sqlite-integrity.js";
 import {
+  formatReliabilityStderr,
   INDEX_REPAIR_INDEX_NAME,
   INDEX_REPAIR_SCHEMA_SQL,
   type IndexRepairJournalMode,
@@ -111,11 +112,6 @@ function prepareIndexRepairDatabase(
   }
 }
 
-function formatWorkerStderr(stderr: string): string {
-  const text = stderr.trim();
-  return text ? ` stderr=${JSON.stringify(text)}` : "";
-}
-
 async function waitForWorkerMessage(params: {
   action?: () => void;
   child: ChildProcess;
@@ -127,7 +123,7 @@ async function waitForWorkerMessage(params: {
       cleanup();
       reject(
         new Error(
-          `SQLite index repair worker did not report ${params.kind}.${formatWorkerStderr(params.readStderr())}`,
+          `SQLite index repair worker did not report ${params.kind}.${formatReliabilityStderr(params.readStderr())}`,
         ),
       );
     }, INDEX_REPAIR_TIMEOUT_MS);
@@ -150,7 +146,7 @@ async function waitForWorkerMessage(params: {
       cleanup();
       reject(
         new Error(
-          `SQLite index repair worker exited before ${params.kind}: code=${String(code)} signal=${String(signal)}.${formatWorkerStderr(params.readStderr())}`,
+          `SQLite index repair worker exited before ${params.kind}: code=${String(code)} signal=${String(signal)}.${formatReliabilityStderr(params.readStderr())}`,
         ),
       );
     };
@@ -183,7 +179,7 @@ async function waitForActiveTransaction(params: {
     }
     if (params.child.exitCode !== null || params.child.signalCode !== null) {
       throw new Error(
-        `SQLite index repair completed before ${params.journalMode} interruption evidence was observed.${formatWorkerStderr(params.readStderr())}`,
+        `SQLite index repair completed before ${params.journalMode} interruption evidence was observed.${formatReliabilityStderr(params.readStderr())}`,
       );
     }
     await delay(2);

--- a/scripts/lib/sqlite-reliability-repository.ts
+++ b/scripts/lib/sqlite-reliability-repository.ts
@@ -10,6 +10,7 @@ import {
 } from "../../src/snapshot/snapshot-provider.js";
 import {
   assertSameCompactionPayload,
+  formatReliabilityStderr,
   type CompactionPayloadProof,
   type ReliabilityReport,
   type ReliabilityStateProof,
@@ -50,11 +51,6 @@ function assertSameState(
   }
 }
 
-function formatWorkerStderr(stderr: string): string {
-  const text = stderr.trim();
-  return text ? ` stderr=${JSON.stringify(text)}` : "";
-}
-
 async function waitForCrashPoint(params: {
   child: ChildProcess;
   crashPoint: RepositoryCrashPoint;
@@ -65,7 +61,7 @@ async function waitForCrashPoint(params: {
       cleanup();
       reject(
         new Error(
-          `SQLite repository worker did not reach ${params.crashPoint}.${formatWorkerStderr(params.readStderr())}`,
+          `SQLite repository worker did not reach ${params.crashPoint}.${formatReliabilityStderr(params.readStderr())}`,
         ),
       );
     }, REPOSITORY_TIMEOUT_MS);
@@ -84,7 +80,7 @@ async function waitForCrashPoint(params: {
       cleanup();
       reject(
         new Error(
-          `SQLite repository worker exited before ${params.crashPoint}: code=${String(code)} signal=${String(signal)}.${formatWorkerStderr(params.readStderr())}`,
+          `SQLite repository worker exited before ${params.crashPoint}: code=${String(code)} signal=${String(signal)}.${formatReliabilityStderr(params.readStderr())}`,
         ),
       );
     };

--- a/scripts/lib/sqlite-reliability-restore.ts
+++ b/scripts/lib/sqlite-reliability-restore.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { createLocalSqliteSnapshotProvider } from "../../src/snapshot/local-repository.js";
 import {
   assertSameCompactionPayload,
+  formatReliabilityStderr,
   type CompactionPayloadProof,
   type ReliabilityReport,
   type ReliabilityStateProof,
@@ -79,11 +80,6 @@ function hasPublicationStaging(scratchPath: string): boolean {
   );
 }
 
-function formatWorkerStderr(stderr: string): string {
-  const text = stderr.trim();
-  return text ? ` stderr=${JSON.stringify(text)}` : "";
-}
-
 async function waitForWorkerReady(params: {
   child: ChildProcess;
   readStderr: () => string;
@@ -93,7 +89,7 @@ async function waitForWorkerReady(params: {
       cleanup();
       reject(
         new Error(
-          `SQLite restore worker did not become ready.${formatWorkerStderr(params.readStderr())}`,
+          `SQLite restore worker did not become ready.${formatReliabilityStderr(params.readStderr())}`,
         ),
       );
     }, 30_000);
@@ -115,7 +111,7 @@ async function waitForWorkerReady(params: {
       cleanup();
       reject(
         new Error(
-          `SQLite restore worker exited before ready: code=${String(code)} signal=${String(signal)}.${formatWorkerStderr(params.readStderr())}`,
+          `SQLite restore worker exited before ready: code=${String(code)} signal=${String(signal)}.${formatReliabilityStderr(params.readStderr())}`,
         ),
       );
     };
@@ -187,7 +183,7 @@ async function waitForCrashPoint(params: {
       cleanup();
       reject(
         new Error(
-          `SQLite restore worker did not reach ${params.crashPoint}.${formatWorkerStderr(params.readStderr())}`,
+          `SQLite restore worker did not reach ${params.crashPoint}.${formatReliabilityStderr(params.readStderr())}`,
         ),
       );
     }, RESTORE_TIMEOUT_MS);
@@ -206,7 +202,7 @@ async function waitForCrashPoint(params: {
       cleanup();
       reject(
         new Error(
-          `SQLite restore worker exited before ${params.crashPoint}: code=${String(code)} signal=${String(signal)}.${formatWorkerStderr(params.readStderr())}`,
+          `SQLite restore worker exited before ${params.crashPoint}: code=${String(code)} signal=${String(signal)}.${formatReliabilityStderr(params.readStderr())}`,
         ),
       );
     };

--- a/scripts/lib/sqlite-reliability-writer.ts
+++ b/scripts/lib/sqlite-reliability-writer.ts
@@ -4,6 +4,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { openNodeSqliteDatabase } from "../../src/infra/node-sqlite.js";
 import {
   COMMITTED_WAL_SENTINEL,
+  formatReliabilityStderr,
   STRESS_TABLE_SQL,
   type ProfileConfig,
 } from "./sqlite-reliability-contract.js";
@@ -92,7 +93,7 @@ export async function waitForWriterMessage<T extends WriterMessage["kind"]>(
       cleanup();
       reject(
         new Error(
-          `SQLite reliability writer timed out waiting for ${kind}.${formatWriterStderr(writer)}`,
+          `SQLite reliability writer timed out waiting for ${kind}.${formatReliabilityStderr(writer.stderr.join(""))}`,
         ),
       );
     }, WRITER_MESSAGE_TIMEOUT_MS);
@@ -116,7 +117,7 @@ export async function waitForWriterMessage<T extends WriterMessage["kind"]>(
       cleanup();
       reject(
         new Error(
-          `SQLite reliability writer exited before ${kind}: code=${String(code)} signal=${String(signal)}.${formatWriterStderr(writer)}`,
+          `SQLite reliability writer exited before ${kind}: code=${String(code)} signal=${String(signal)}.${formatReliabilityStderr(writer.stderr.join(""))}`,
         ),
       );
     };
@@ -131,11 +132,6 @@ export async function waitForWriterMessage<T extends WriterMessage["kind"]>(
     writer.child.on("exit", onExit);
     action?.();
   });
-}
-
-function formatWriterStderr(writer: WriterHandle): string {
-  const text = writer.stderr.join("").trim();
-  return text ? ` stderr=${JSON.stringify(text)}` : "";
 }
 
 export async function stopWriter(writer: WriterHandle): Promise<WriterResultMessage> {

--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parseSqliteReliabilityCli } from "../../scripts/lib/sqlite-reliability-cli.js";
 import {
+  formatReliabilityStderr,
   STRESS_TABLE_SQL,
   type ReliabilityReport,
 } from "../../scripts/lib/sqlite-reliability-contract.js";
@@ -113,6 +114,17 @@ async function waitForChildExit(child: ChildProcess): Promise<{
 }
 
 describe("scripts/bench-sqlite-reliability", () => {
+  it.each([
+    ["whitespace-only stderr", " \n\t ", ""],
+    [
+      "multiline quoted stderr",
+      ' first line\n"quoted"\\path ',
+      ' stderr="first line\\n\\"quoted\\"\\\\path"',
+    ],
+  ])("formats %s", (_name, stderr, expected) => {
+    expect(formatReliabilityStderr(stderr)).toBe(expected);
+  });
+
   it("detects a transient WAL overrun before the file shrinks", async () => {
     const walPath = path.join(
       tempDirs.make("openclaw-sqlite-reliability-test-"),


### PR DESCRIPTION
## What Problem This Solves

Resolves duplicated SQLite reliability diagnostic formatting that had drift risk across compaction, index repair, repository, restore, and writer subprocess failures.

## Why This Change Was Made

Moves the shared trim-and-JSON stderr suffix contract into the existing SQLite reliability contract module. The writer still owns stderr chunk collection, while the publication proof keeps its intentionally different raw diagnostic format.

## User Impact

No user-visible behavior changes. Maintainers get one canonical implementation for subprocess stderr diagnostics while preserving the existing failure text byte-for-byte.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/bench-sqlite-reliability.test.ts` (7 passed, including full smoke/crash proof; repeated after rebase)
- `pnpm check:import-cycles` (0 runtime value cycles)
- `pnpm build` (passed)
- Exact Sol/high autoreview: no accepted or actionable findings; patch correctness 0.98
- `node scripts/check-changed.mjs --dry-run -- <changed files>` completed
- Blacksmith Testbox `tbx_01m1dhx227fzb6f0j482vecxvg`: clean exact-tree changed gate passed; Linux subprocess/SIGKILL reliability suite passed 7/7
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/33468140436
- Tooling: +24/-39, net -15; tests: +12
