### PR TITLE
test(plugin-sdk): reuse QA facade graphs within suites

### DIFF
--- a/src/plugin-sdk/qa-runner-runtime.test.ts
+++ b/src/plugin-sdk/qa-runner-runtime.test.ts
@@ -3,7 +3,7 @@
  */
 import path from "node:path";
 import type { Command } from "commander";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   cleanupTempDirs,
   expectPrivateQaLabRuntimeSurfaceLoad,
@@ -50,8 +50,11 @@ describe("plugin-sdk qa-runner-runtime", () => {
   const originalPrivateQaCli = process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI;
   const originalBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
 
-  beforeEach(() => {
+  beforeAll(() => {
     vi.resetModules();
+  });
+
+  beforeEach(() => {
     loadPluginManifestRegistryCore.mockReset().mockReturnValue({
       plugins: [],
       diagnostics: [],
@@ -78,6 +81,7 @@ describe("plugin-sdk qa-runner-runtime", () => {
   });
 
   it("stays cold until runner discovery is requested", async () => {
+    vi.resetModules();
     await import("./qa-runner-runtime.js");
 
     expect(loadPluginManifestRegistryCore).not.toHaveBeenCalled();

--- a/src/plugin-sdk/qa-runtime.test.ts
+++ b/src/plugin-sdk/qa-runtime.test.ts
@@ -3,7 +3,7 @@ import { createServer } from "node:net";
  * Tests QA runtime command loading and private CLI gating.
  */
 import { Command } from "commander";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   cleanupTempDirs,
   expectPrivateQaLabRuntimeSurfaceLoad,
@@ -27,8 +27,11 @@ describe("plugin-sdk qa-runtime", () => {
   const originalPrivateQaCli = process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI;
   const originalBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
 
-  beforeEach(() => {
+  beforeAll(() => {
     vi.resetModules();
+  });
+
+  beforeEach(() => {
     loadBundledPluginPublicSurfaceModuleSync.mockReset();
     resolveOpenClawPackageRootSync.mockReset().mockReturnValue(null);
     delete process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI;
@@ -85,6 +88,7 @@ describe("plugin-sdk qa-runtime", () => {
   }
 
   it("stays cold until the runtime seam is used", async () => {
+    vi.resetModules();
     const module = await import("./qa-runtime.js");
 
     expect(loadBundledPluginPublicSurfaceModuleSync).not.toHaveBeenCalled();


### PR DESCRIPTION
## What Problem This Solves

The two QA facade suites reset and reload their owner graphs before all 26 cases even though tested state is held in per-case mocks, environment variables and runtime objects.

## Why This Change Was Made

Reset once per suite and explicitly inside both existing cold-import cases. All original call sites and assertions remain, as do per-case environment, mock, filesystem and global-fetch cleanup. This removes 22 reset calls and 24 ordinary owner graph evaluations.

## User Impact

Test-only. Runtime loading, SDK contracts, timeout arguments and operator behavior are unchanged. No elapsed-time improvement is claimed.

## Evidence

All 29 unit and linked-plugin integration cases pass before and after under the normal non-isolated plugin-sdk project. Temporary top-level loader calls make both cold-import tests fail at the expected unexpected mock invocation; exact production bytes were restored. Real linked-plugin loading, operator-state exclusion, socket checks and health cancellation remain covered.

Full changed checks and Codex autoreview pass. Production +0/-0; tests +12/-4. Reviewed both owners, call-time environment/fetch resolution, fixture cleanup, actual QA Lab callers, sibling integration and the original isolation fix.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugin-sdk/qa-runtime.test.ts src/plugin-sdk/qa-runner-runtime.test.ts src/plugin-sdk/qa-runner-runtime.integration.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base ae91c7aa7726beb3f0d077cae05ddef09fc3d797
```

