### PR TITLE
improve(ui): add space before session status icons

### DIFF
--- a/ui/src/e2e/session-management.trailing-state.e2e.test.ts
+++ b/ui/src/e2e/session-management.trailing-state.e2e.test.ts
@@ -152,6 +152,21 @@ suite.define(() => {
       const menu = row.getByRole("button", { name: "Open session menu" });
       await expect.poll(() => state.locator(".session-run-spinner").isVisible()).toBe(true);
       await expect.poll(() => actionOpacity(state)).toBe("1");
+      await page.mouse.move(500, 500);
+      await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+      await captureUiProof(suite, page, "sidebar-session-title-icon-gap.png");
+
+      const [restingNameBounds, restingStateBounds] = await Promise.all([
+        row.locator(".sidebar-recent-session__name").boundingBox(),
+        state.boundingBox(),
+      ]);
+      if (!restingNameBounds || !restingStateBounds) {
+        throw new Error("Expected visible title and trailing state geometry");
+      }
+      expect(restingStateBounds.x - (restingNameBounds.x + restingNameBounds.width)).toBeCloseTo(
+        16,
+        1,
+      );
 
       await row.hover();
       await expect.poll(() => actionOpacity(state)).toBe("1");

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -4502,7 +4502,7 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
 .sidebar-recent-session--single-line .sidebar-recent-session__text {
   flex-direction: row;
   align-items: center;
-  gap: var(--sidebar-row-gap);
+  gap: calc(var(--sidebar-row-gap) + var(--sidebar-row-gap));
 }
 
 /* Basis 0 mirrors the two-line subtitle contract: the title absorbs all


### PR DESCRIPTION
## What Problem This Solves

Resolves a visual crowding problem in the session sidebar where trailing state icons sat only 8px from the session title.

## Why This Change Was Made

The shared single-line session row now uses a 16px title-to-endcap gap, doubling the existing spacing contract for every trailing state that uses that endcap (running, unread, pull request, workboard, presence, and badges). The existing browser E2E now asserts the rendered geometry directly.

## User Impact

Session titles and their trailing status icons have clearer visual separation. Long titles still truncate within the existing row width, and hover actions retain their current layout.

## Evidence

### Before — 8px gap

![Session sidebar before, with the running-state icon 8px from the title](https://github.com/user-attachments/assets/67cdd3b0-ac74-4e9b-9c96-72c8e526290b)

### After — 16px gap

![Session sidebar after, with the running-state icon 16px from the title](https://github.com/user-attachments/assets/dbf77a7e-3823-45fd-a952-6c90fd6fe4ea)

- Baseline regression proof: the new browser assertion reported an 8px rendered gap against the previous CSS while expecting 16px.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs ui/src/e2e/session-management.trailing-state.e2e.test.ts` — 6 tests passed.
- `node scripts/check-changed.mjs -- ui/src/styles/layout.css ui/src/e2e/session-management.trailing-state.e2e.test.ts` — passed.
- Post-rebase sanity: `node scripts/run-vitest.mjs ui/src/e2e/session-management.trailing-state.e2e.test.ts` — 6 tests passed on the pushed head.
