### PR TITLE
fix(doctor): leave legacy transcript checks to migration

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2492,7 +2492,7 @@ src/commands/doctor-skill-workshop-sqlite.ts	1
 src/commands/doctor-skills.ts	1
 src/commands/doctor-sqlite-compact.ts	3
 src/commands/doctor-sqlite-maintenance-lock.ts	2
-src/commands/doctor-state-integrity.ts	2
+src/commands/doctor-state-integrity.ts	1
 src/commands/doctor-state-sqlite-compact.ts	1
 src/commands/doctor-telegram-general-topic-conversations.ts	2
 src/commands/doctor-tools-md-migration.ts	5

--- a/src/commands/doctor-session-transcripts.test.ts
+++ b/src/commands/doctor-session-transcripts.test.ts
@@ -603,8 +603,8 @@ describe("doctor session transcript repair", () => {
         archivedTranscriptFiles: 0,
         archivedUnreferencedJsonlFiles: 0,
         importedTranscriptEvents: 0,
-        issues: 0,
-        legacyEntries: 0,
+        issues: 1,
+        legacyEntries: 1,
         sqliteEntries: 0,
         unreferencedJsonlFiles: 0,
         validatedTranscriptEvents: 0,
@@ -634,6 +634,12 @@ describe("doctor session transcript repair", () => {
       env,
       maintenanceAuthority: undefined,
     });
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Inspect with "openclaw doctor --session-sqlite dry-run --session-sqlite-all-agents".',
+      ),
+      "Session SQLite",
+    );
   });
 
   it("reports post-session plugin changes and actionable ownership warnings", async () => {

--- a/src/commands/doctor-session-transcripts.ts
+++ b/src/commands/doctor-session-transcripts.ts
@@ -429,7 +429,9 @@ async function noteSessionSqliteMigrationHealth(params: {
     );
   }
   if (report.totals.issues > 0) {
-    lines.push(`- Found ${report.totals.issues} session SQLite issue(s).`);
+    lines.push(
+      `- Found ${report.totals.issues} session SQLite issue(s). Inspect with "${formatCliCommand("openclaw doctor --session-sqlite dry-run --session-sqlite-all-agents", params.env)}".`,
+    );
   }
   if (!params.shouldRepair) {
     lines.push(

--- a/src/commands/doctor-state-integrity-format.ts
+++ b/src/commands/doctor-state-integrity-format.ts
@@ -1,11 +1,3 @@
-import path from "node:path";
-
 export function countLabel(count: number, singular: string, plural = `${singular}s`): string {
   return `${count} ${count === 1 ? singular : plural}`;
-}
-
-export function formatFilePreview(paths: string[], limit = 3): string {
-  const names = paths.slice(0, limit).map((filePath) => path.basename(filePath));
-  const remaining = paths.length - names.length;
-  return remaining > 0 ? `${names.join(", ")}, and ${remaining} more` : names.join(", ");
 }

--- a/src/commands/doctor-state-integrity.transcripts.test.ts
+++ b/src/commands/doctor-state-integrity.transcripts.test.ts
@@ -33,8 +33,6 @@ import {
   hasRepairPromptMessage,
   noteMock,
   noteStateIntegrity,
-  repairPromptCalls,
-  runStateIntegrityText,
   setupSessionState,
   stateIntegrityText,
   writeSessionStore,
@@ -93,64 +91,25 @@ describe("doctor transcript and heartbeat session repairs", () => {
     fs.rmSync(tempHome, { recursive: true, force: true });
   });
 
-  it("detects orphan transcripts and offers archival remediation", async () => {
-    const cfg: OpenClawConfig = { agents: { entries: { alpha: {}, beta: {} } } };
-    const sessionsDirs = ["alpha", "beta"].map((agentId) => {
-      setupSessionState(cfg, process.env, process.env.HOME ?? "", agentId);
-      const sessionsDir = resolveSessionTranscriptsDirForAgent(
-        agentId,
-        process.env,
-        () => tempHome,
-      );
-      fs.writeFileSync(path.join(sessionsDir, `orphan-${agentId}.jsonl`), '{"type":"session"}\n');
-      return sessionsDir;
-    });
-    const confirmRuntimeRepair = vi.fn(async (params: { message: string }) =>
-      params.message.includes("This only renames them to *.deleted.<timestamp>."),
-    );
-    await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
-    expect(stateIntegrityText()).toContain(
-      "These .jsonl files are no longer referenced by sessions.json",
-    );
-    expect(stateIntegrityText()).toContain("Examples: orphan-alpha.jsonl");
-    expect(stateIntegrityText()).toContain("Examples: orphan-beta.jsonl");
-    const archivePrompts = repairPromptCalls(confirmRuntimeRepair).filter((prompt) =>
-      prompt.message?.includes("This only renames them to *.deleted.<timestamp>."),
-    );
-    expect(archivePrompts).toHaveLength(2);
-    expect(archivePrompts.every((prompt) => prompt.requiresInteractiveConfirmation)).toBe(true);
-    for (const [index, sessionsDir] of sessionsDirs.entries()) {
-      const agentId = index === 0 ? "alpha" : "beta";
-      expect(
-        fs
-          .readdirSync(sessionsDir)
-          .some((name) => name.startsWith(`orphan-${agentId}.jsonl.deleted.`)),
-      ).toBe(true);
-    }
-  });
-
-  it("uses SQLite session rows for transcript integrity without orphan false positives", async () => {
+  it("leaves legacy transcript diagnostics to the SQLite migration owner", async () => {
     const cfg: OpenClawConfig = {};
-    setupSessionState(cfg, process.env, process.env.HOME ?? "");
-    const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId: "main" });
-    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
-    const transcriptPath = path.join(sessionsDir, "sqlite-live-session.jsonl");
-    fs.writeFileSync(transcriptPath, '{"type":"session"}\n');
-    await upsertSessionEntryCore(
-      { agentId: "main", sessionKey: "agent:main:main", storePath },
-      {
-        sessionFile: transcriptPath,
-        sessionId: "sqlite-live-session",
+    writeSessionStore(cfg, {
+      "agent:main:main:heartbeat": {
+        heartbeatIsolatedBaseSessionKey: "agent:main:main",
+        sessionId: "latest-heartbeat-wake",
         updatedAt: Date.now(),
       },
-    );
+    });
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    const displacedTranscript = path.join(sessionsDir, "displaced-heartbeat-wake.jsonl");
+    fs.writeFileSync(displacedTranscript, '{"type":"session"}\n');
     const confirmRuntimeRepair = vi.fn(async () => false);
 
     await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
 
-    expect(stateIntegrityText()).not.toContain("orphan transcript file");
     expect(stateIntegrityText()).not.toContain("recent sessions are missing transcripts");
-    expect(fs.existsSync(transcriptPath)).toBe(true);
+    expect(stateIntegrityText()).not.toContain("orphan transcript file");
+    expect(fs.existsSync(displacedTranscript)).toBe(true);
     expect(confirmRuntimeRepair).not.toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining("Archive 1 orphan") }),
     );
@@ -189,138 +148,6 @@ describe("doctor transcript and heartbeat session repairs", () => {
       expect(stateIntegrityText()).not.toContain("Main session transcript missing");
     },
   );
-
-  it("does not auto-archive orphan transcripts from non-interactive repair mode", async () => {
-    const cfg: OpenClawConfig = {};
-    setupSessionState(cfg, process.env, process.env.HOME ?? "");
-    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
-    fs.writeFileSync(path.join(sessionsDir, "orphan-session.jsonl"), '{"type":"session"}\n');
-    const confirmRuntimeRepair = vi.fn(
-      async (params: { initialValue?: boolean; requiresInteractiveConfirmation?: boolean }) =>
-        params.requiresInteractiveConfirmation !== true,
-    );
-    await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
-
-    const archivePrompt = repairPromptCalls(confirmRuntimeRepair).find(
-      (prompt) => prompt.requiresInteractiveConfirmation === true,
-    );
-    expect(archivePrompt?.initialValue).toBe(false);
-    const files = fs.readdirSync(sessionsDir);
-    expect(files).toContain("orphan-session.jsonl");
-    const archivedOrphanTranscripts = files.filter((name) =>
-      name.startsWith("orphan-session.jsonl.deleted."),
-    );
-    expect(archivedOrphanTranscripts).toStrictEqual([]);
-  });
-
-  it.skipIf(process.platform === "win32")(
-    "does not archive referenced transcripts when the state dir path resolves through a symlink",
-    async () => {
-      const cfg: OpenClawConfig = {};
-      const originalHome = tempHome;
-      const symlinkHome = path.join(
-        path.dirname(originalHome),
-        `${path.basename(originalHome)}-link`,
-      );
-      fs.symlinkSync(originalHome, symlinkHome, "dir");
-      try {
-        const symlinkStateDir = path.join(symlinkHome, ".openclaw");
-        setTestEnvValue("HOME", symlinkHome);
-        setTestEnvValue("OPENCLAW_HOME", symlinkHome);
-        setTestEnvValue("OPENCLAW_STATE_DIR", symlinkStateDir);
-
-        setupSessionState(cfg, process.env, symlinkHome);
-        const sessionsDir = resolveSessionTranscriptsDirForAgent(
-          "main",
-          process.env,
-          () => symlinkHome,
-        );
-        const transcriptPath = path.join(sessionsDir, "linked-session.jsonl");
-        fs.writeFileSync(transcriptPath, '{"type":"session"}\n');
-        writeSessionStore(cfg, {
-          "agent:main:main": {
-            sessionId: "linked-session",
-            updatedAt: Date.now(),
-          },
-        });
-
-        const confirmRuntimeRepair = vi.fn(async (params: { message: string }) =>
-          params.message.includes("This only renames them to *.deleted.<timestamp>."),
-        );
-        await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
-
-        expect(fs.existsSync(transcriptPath)).toBe(true);
-        expect(fs.readdirSync(sessionsDir).filter((name) => name.includes(".deleted."))).toEqual(
-          [],
-        );
-        expect(stateIntegrityText()).not.toContain("These .jsonl files are no longer referenced");
-      } finally {
-        fs.rmSync(symlinkHome, { force: true, recursive: true });
-      }
-    },
-  );
-
-  it("prints openclaw-only verification hints when recent sessions are missing transcripts", async () => {
-    const cfg: OpenClawConfig = { agents: { entries: { alpha: {}, beta: {} } } };
-    for (const agentId of ["alpha", "beta"]) {
-      writeSessionStore(
-        cfg,
-        {
-          [`agent:${agentId}:missing`]: {
-            sessionId: `missing-${agentId}`,
-            updatedAt: Date.now(),
-          },
-        },
-        agentId,
-      );
-      const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId });
-      await upsertSessionEntryCore(
-        { agentId, sessionKey: `agent:${agentId}:sqlite`, storePath },
-        { sessionId: `sqlite-${agentId}`, updatedAt: Date.now() },
-      );
-    }
-    const text = await runStateIntegrityText(cfg);
-    expect(text.match(/recent sessions are missing transcripts/g)).toHaveLength(2);
-    expect(text).toContain(path.join("agents", "alpha", "agent", "openclaw-agent.sqlite"));
-    expect(text).toContain(path.join("agents", "beta", "agent", "openclaw-agent.sqlite"));
-    expect(text).toMatch(
-      /openclaw sessions cleanup --store ".*openclaw-agent\.sqlite" --dry-run --fix-missing/,
-    );
-    expect(text).not.toMatch(
-      /openclaw sessions cleanup --store ".*openclaw-agent\.sqlite" --dry-run(?! --fix-missing)/,
-    );
-    expect(text).toMatch(
-      /openclaw sessions cleanup --store ".*openclaw-agent\.sqlite" --enforce --fix-missing/,
-    );
-    expect(text).not.toContain("--active");
-    expect(text).not.toContain(" ls ");
-  });
-
-  it("preserves a non-main compatibility owner for a fixed legacy store", async () => {
-    const storePath = path.join(tempHome, "fixed-store", "sessions.json");
-    const cfg: OpenClawConfig = {
-      agents: {
-        defaults: { sessionStore: { agentId: "ops" } },
-        entries: { main: {}, ops: {} },
-      },
-      session: { store: storePath },
-    };
-    writeSessionStore(
-      cfg,
-      {
-        "agent:ops:missing": {
-          sessionId: "missing-ops",
-          updatedAt: Date.now(),
-        },
-      },
-      "ops",
-    );
-    const text = await runStateIntegrityText(cfg);
-    const sqliteStorePath = path.join(path.dirname(storePath), "openclaw-agent.sqlite");
-    expect(text).toContain("1/1 recent sessions are missing transcripts");
-    expect(text).toContain(sqliteStorePath);
-    expect(text).not.toContain(path.join(path.dirname(storePath), "openclaw-agent.ops.sqlite"));
-  });
 
   it("moves a non-default SQLite heartbeat main session without recreating sessions.json", async () => {
     const cfg: OpenClawConfig = { agents: { entries: { main: {}, ops: {} } } };
@@ -801,17 +628,5 @@ describe("doctor transcript and heartbeat session repairs", () => {
       closeOpenClawStateDatabaseForTest();
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
-  });
-
-  it("ignores slash-routing sessions for recent missing transcript warnings", async () => {
-    const cfg: OpenClawConfig = {};
-    writeSessionStore(cfg, {
-      "agent:main:telegram:slash:6790081233": {
-        sessionId: "missing-slash-transcript",
-        updatedAt: Date.now(),
-      },
-    });
-    const text = await runStateIntegrityText(cfg);
-    expect(text).not.toContain("recent sessions are missing transcripts");
   });
 });

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -27,11 +27,6 @@ import {
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveSessionStoreCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
 import { resolveOAuthDir, resolveStateDir } from "../config/paths.js";
-import {
-  formatSessionArchiveTimestamp,
-  isPrimarySessionTranscriptFileName,
-} from "../config/sessions/artifacts.js";
-import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import { resolveCanonicalMainSessionKey } from "../config/sessions/main-session-key.js";
 import {
   resolveSessionFilePathCore,
@@ -59,7 +54,6 @@ import {
 } from "../infra/state-migrations.legacy-session-store.js";
 import { listConfiguredChannelIdsForReadOnlyScope } from "../plugins/channel-plugin-ids.js";
 import { normalizeAgentId } from "../routing/session-key.js";
-import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { shortenHomePath } from "../utils.js";
 import { repairHeartbeatPoisonedMainSession } from "./doctor-heartbeat-main-session-repair.js";
 import { describeHeartbeatSessionTargetIssues } from "./doctor-heartbeat-session-target.js";
@@ -72,7 +66,7 @@ import {
   createPluginSessionStateDoctorScanner,
   runPluginSessionStateDoctorRepairs,
 } from "./doctor-session-state-providers.js";
-import { countLabel, formatFilePreview } from "./doctor-state-integrity-format.js";
+import { countLabel } from "./doctor-state-integrity-format.js";
 
 const STATE_INTEGRITY_CHECK_ID = "core/doctor/state-integrity";
 
@@ -164,10 +158,6 @@ function tryResolveNativeRealPath(targetPath: string): string | null {
   } catch {
     return null;
   }
-}
-
-function resolveComparableTranscriptPath(filePath: string): string {
-  return tryResolveNativeRealPath(filePath) ?? path.resolve(filePath);
 }
 
 function areComparablePathsEqual(leftPath: string, rightPath: string): boolean {
@@ -737,15 +727,6 @@ function hasPairingPolicy(value: unknown): boolean {
     }
   }
   return false;
-}
-
-function isSlashRoutingSessionKey(sessionKey: string): boolean {
-  const raw = normalizeOptionalLowercaseString(sessionKey);
-  if (!raw) {
-    return false;
-  }
-  const scoped = parseAgentSessionKey(raw)?.rest ?? raw;
-  return /^[^:]+:slash:[^:]+(?:$|:)/.test(scoped);
 }
 
 function shouldRequireOAuthDir(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
@@ -1320,9 +1301,7 @@ export async function noteStateIntegrity(
     inspectLegacyStore: boolean,
   ) => {
     const { agentId, storePath } = target;
-    const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId, env, homedir);
     const absoluteStorePath = path.resolve(storePath);
-    const displaySessionsDir = shortenHomePath(sessionsDir);
 
     const sqliteStorePath = resolveSqliteTargetFromSessionStorePath(absoluteStorePath, {
       agentId,
@@ -1339,10 +1318,10 @@ export async function noteStateIntegrity(
       (candidate): candidate is [string, SessionEntry] =>
         candidate[1] != null && typeof candidate[1] === "object",
     );
-    const legacyOrder = new Map(legacyEntries.map(([sessionKey], index) => [sessionKey, index]));
+    const legacySessionKeys = new Set(legacyEntries.map(([sessionKey]) => sessionKey));
     const sqliteSessionKeys = new Set<string>();
     const isSessionKeyOccupied = (sessionKey: string) =>
-      sqliteSessionKeys.has(sessionKey) || legacyOrder.has(sessionKey);
+      sqliteSessionKeys.has(sessionKey) || legacySessionKeys.has(sessionKey);
     const mainKey = resolveCanonicalMainSessionKey({
       agentId,
       mainKey: cfg.session?.mainKey,
@@ -1353,21 +1332,7 @@ export async function noteStateIntegrity(
     const sqlitePluginStateScanner = createPluginSessionStateDoctorScanner({ agentId, cfg, env });
     const legacyPluginStateScanner = createPluginSessionStateDoctorScanner({ agentId, cfg, env });
     let mainEntry: SessionEntry | undefined;
-    let sqliteNewKeyIndex = 0;
-    const recent: Array<{ entry: SessionEntry; order: number; sessionKey: string }> = [];
-    const addRecent = (sessionKey: string, entry: SessionEntry, order: number) => {
-      recent.push({ entry, order, sessionKey });
-      recent.sort((left, right) => {
-        const leftUpdated = typeof left.entry.updatedAt === "number" ? left.entry.updatedAt : 0;
-        const rightUpdated = typeof right.entry.updatedAt === "number" ? right.entry.updatedAt : 0;
-        return rightUpdated - leftUpdated || left.order - right.order;
-      });
-      if (recent.length > 5) {
-        recent.pop();
-      }
-    };
-    const inspectMergedEntry = (sessionKey: string, entry: SessionEntry, order: number) => {
-      addRecent(sessionKey, entry, order);
+    const inspectMergedEntry = (sessionKey: string, entry: SessionEntry) => {
       if (sessionKey === mainKey) {
         mainEntry = entry;
       }
@@ -1383,22 +1348,19 @@ export async function noteStateIntegrity(
       ({ entry, sessionKey }) => {
         sqliteSessionKeys.add(sessionKey);
         sqlitePluginStateScanner.scanEntry(sessionKey, entry);
-        const order = legacyOrder.get(sessionKey) ?? legacyEntries.length + sqliteNewKeyIndex++;
-        inspectMergedEntry(sessionKey, entry, order);
+        inspectMergedEntry(sessionKey, entry);
         const recovery = inspectMainSessionRecoveryEntry(sessionKey, entry);
         if (recovery) {
           mainRecoveryWedged.push(recovery);
         }
       },
     );
-    let mergedEntryCount = sqliteEntryCount;
     for (const [sessionKey, entry] of legacyEntries) {
       if (sqliteSessionKeys.has(sessionKey)) {
         continue;
       }
       legacyPluginStateScanner.scanEntry(sessionKey, entry);
-      inspectMergedEntry(sessionKey, entry, legacyOrder.get(sessionKey) ?? mergedEntryCount);
-      mergedEntryCount += 1;
+      inspectMergedEntry(sessionKey, entry);
     }
     const sessionPathOpts = resolveSessionFilePathOptions({ agentId, storePath });
     await noteMainSessionRecoveryIntegrity({
@@ -1409,36 +1371,9 @@ export async function noteStateIntegrity(
       confirmRepair: (params) => prompter.confirmRuntimeRepair(params),
       countLabel,
     });
-    if (mergedEntryCount > 0) {
-      const recentTranscriptCandidates = recent
-        .map(({ entry, sessionKey }) => [sessionKey, entry] as const)
-        .filter(([key]) => !isSlashRoutingSessionKey(key));
-      const missing = recentTranscriptCandidates.filter(([key, entry]) => {
-        if (sqliteSessionKeys.has(key)) {
-          return false;
-        }
-        const sessionId = entry.sessionId;
-        if (!sessionId) {
-          return false;
-        }
-        const legacySessionFile = (entry as SessionEntry & { sessionFile?: string }).sessionFile;
-        if (parseSqliteSessionFileMarker(legacySessionFile)) {
-          return false;
-        }
-        const transcriptPath = resolveSessionFilePathCore(sessionId, entry, sessionPathOpts);
-        return !existsFile(transcriptPath);
-      });
-      if (missing.length > 0) {
-        warnings.push(
-          [
-            `- ${missing.length}/${recentTranscriptCandidates.length} recent sessions are missing transcripts.`,
-            `  Verify sessions in store: ${formatCliCommand(`openclaw sessions --store "${sqliteStorePath}"`)}`,
-            `  Preview cleanup impact: ${formatCliCommand(`openclaw sessions cleanup --store "${sqliteStorePath}" --dry-run --fix-missing`)}`,
-            `  Prune missing entries: ${formatCliCommand(`openclaw sessions cleanup --store "${sqliteStorePath}" --enforce --fix-missing`)}`,
-          ].join("\n"),
-        );
-      }
-
+    // Session SQLite migration owns legacy transcript validation and archival.
+    // Repeating it here turns healthy pending imports into integrity warnings.
+    if (sqliteEntryCount > 0 || legacyEntries.length > 0) {
       if (wedgedSubagentSessions.length > 0) {
         const wedgedCount = countLabel(wedgedSubagentSessions.length, "wedged subagent session");
         warnings.push(
@@ -1561,70 +1496,6 @@ export async function noteStateIntegrity(
           if (lineCount <= 1) {
             warnings.push(
               `- Main session transcript has only ${lineCount} line. Session history may not be appending.`,
-            );
-          }
-        }
-      }
-    }
-
-    // SQLite transcript ownership is repaired by the import/migration workflow.
-    // Never offer generic file archival against a live canonical session store.
-    if (sqliteEntryCount === 0 && inspectLegacyStore && existsDir(sessionsDir)) {
-      const referencedTranscriptPaths = new Set<string>();
-      for (const [, entry] of legacyEntries) {
-        if (!entry?.sessionId) {
-          continue;
-        }
-        try {
-          referencedTranscriptPaths.add(
-            resolveComparableTranscriptPath(
-              resolveSessionFilePathCore(entry.sessionId, entry, sessionPathOpts),
-            ),
-          );
-        } catch {
-          // ignore invalid legacy paths
-        }
-      }
-      const sessionDirEntries = fs.readdirSync(sessionsDir, { withFileTypes: true });
-      const orphanTranscriptPaths = sessionDirEntries
-        .filter((entry) => entry.isFile() && isPrimarySessionTranscriptFileName(entry.name))
-        .map((entry) => path.join(sessionsDir, entry.name))
-        .filter(
-          (filePath) => !referencedTranscriptPaths.has(resolveComparableTranscriptPath(filePath)),
-        );
-      if (orphanTranscriptPaths.length > 0) {
-        const orphanCount = countLabel(orphanTranscriptPaths.length, "orphan transcript file");
-        const orphanPreview = formatFilePreview(orphanTranscriptPaths);
-        warnings.push(
-          [
-            `- Found ${orphanCount} in ${displaySessionsDir}.`,
-            "  These .jsonl files are no longer referenced by sessions.json, so they are not part of any active session history.",
-            "  Doctor can archive them safely by renaming each file to *.deleted.<timestamp>.",
-            `  Examples: ${orphanPreview}`,
-          ].join("\n"),
-        );
-        const archiveOrphans = await prompter.confirmRuntimeRepair({
-          message: `Archive ${orphanCount} in ${displaySessionsDir}? This only renames them to *.deleted.<timestamp>.`,
-          initialValue: false,
-          requiresInteractiveConfirmation: true,
-        });
-        if (archiveOrphans) {
-          let archived = 0;
-          const archivedAt = formatSessionArchiveTimestamp();
-          for (const orphanPath of orphanTranscriptPaths) {
-            const archivedPath = `${orphanPath}.deleted.${archivedAt}`;
-            try {
-              fs.renameSync(orphanPath, archivedPath);
-              archived += 1;
-            } catch (err) {
-              warnings.push(
-                `- Failed to archive orphan transcript ${shortenHomePath(orphanPath)}: ${String(err)}`,
-              );
-            }
-          }
-          if (archived > 0) {
-            changes.push(
-              `- Archived ${countLabel(archived, "orphan transcript file")} in ${displaySessionsDir} as .deleted timestamped backups.`,
             );
           }
         }


### PR DESCRIPTION
Fixes #131770. Replaces #132464 while preserving @LiuwqGit's contribution credit.

## What Problem This Solves

`openclaw doctor` reported healthy pending legacy isolated-heartbeat migration data as both missing-transcript and orphan-transcript corruption. The same Doctor run had already identified that data for the Session SQLite migration.

## Why This Change Was Made

Session SQLite migration is the existing owner of legacy JSON/JSONL validation, import, and archival. State integrity repeated those checks later with weaker context, which created false positives and a second archival path.

This repair removes the duplicate state-integrity path and its obsolete tests. It keeps session-row, plugin-state, and main-session recovery checks in state integrity. It also points real migration issues to the detailed `doctor --session-sqlite dry-run --session-sqlite-all-agents` command.

## User Impact

Doctor stays quiet for healthy isolated heartbeat migration churn. A real missing direct-session transcript still produces a Session SQLite issue and a concrete inspection command.

## Evidence

- Current-main red at `c1f527d2c06082b9b7b88572bbf039ad22aadf7a`: the real `openclaw doctor --non-interactive` command reported `1/1 recent sessions are missing transcripts` and `Found 2 orphan transcript files` for one isolated heartbeat row and two displaced heartbeat JSONL files.
- Exact-head green: the same real Doctor flow reports neither false-positive warning.
- Anti-cheat: a direct-session row with an explicit missing transcript still reports `transcript_missing`; regular Doctor now points to the detailed dry-run command.
- Focused tests: 63 Doctor/state-integrity tests passed; 2 Session SQLite migration controls passed.
- Local gates: formatting, Oxlint, max-lines, assertion safety, dead-code exports, database-first, deprecation, coercion, runtime-sidecar, and import-cycle checks passed.
- Host policy forbids local TypeScript typecheck and build; continuous integration owns those gates.

Production LOC: +12/-147. Tests and ratchets: +20/-199.
