### PR TITLE
test(openai): align stable manifest contract

### DIFF
--- a/extensions/openai/openclaw.plugin.test.ts
+++ b/extensions/openai/openclaw.plugin.test.ts
@@ -49,13 +49,6 @@ const manifest = JSON.parse(
   legacyPluginIds?: string[];
 };
 
-const packageJson = JSON.parse(
-  readFileSync(new URL("./package.json", import.meta.url), "utf8"),
-) as {
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-};
-
 function manifestComparableWizardFields(choice: {
   choiceId?: string;
   choiceLabel?: string;
@@ -107,11 +100,6 @@ function expectWizardFields(
 }
 
 describe("OpenAI plugin manifest", () => {
-  it("keeps runtime dependencies in the package manifest", () => {
-    expect(packageJson.devDependencies?.["@openclaw/plugin-sdk"]).toBe("workspace:*");
-    expect(packageJson.dependencies?.ws).toBe("8.21.0");
-  });
-
   it("exposes only current OpenAI login choices", () => {
     const openAiLogin = manifest.providerAuthChoices?.find(
       (choice) => choice.choiceId === "openai",


### PR DESCRIPTION
Remove a stale package-dependency assertion from the frozen OpenAI plugin manifest contract.\n\nTests: 8 focused OpenAI plugin manifest tests passed.