### PR TITLE
fix(plugins): trust managed host peer links

### DIFF
--- a/src/plugins/install-security-scan.runtime.test.ts
+++ b/src/plugins/install-security-scan.runtime.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const runInstallPolicyMock = vi.fn();
 const findBlockedManifestDependenciesMock = vi.fn();
@@ -41,7 +44,14 @@ const {
   evaluateSkillInstallPolicyRuntime,
   preflightPluginNpmInstallPolicyRuntime,
   scanBundleInstallSourceRuntime,
+  scanInstalledPackageDependencyTreeRuntime,
 } = await import("./install-security-scan.runtime.js");
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
+});
 
 function expectOnlyOperatorPolicyRan() {
   expect(runInstallPolicyMock).toHaveBeenCalledTimes(1);
@@ -53,17 +63,17 @@ function expectOnlyOperatorPolicyRan() {
   expect(getGlobalHookRunnerMock).not.toHaveBeenCalled();
 }
 
-describe("install security scan official bypass", () => {
-  beforeEach(() => {
-    runInstallPolicyMock.mockReset();
-    findBlockedManifestDependenciesMock.mockReset();
-    findBlockedNodeModulesDirectoryMock.mockReset();
-    findBlockedNodeModulesFileAliasMock.mockReset();
-    findBlockedPackageDirectoryInPathMock.mockReset();
-    findBlockedPackageFileAliasInPathMock.mockReset();
-    getGlobalHookRunnerMock.mockReset();
-  });
+beforeEach(() => {
+  runInstallPolicyMock.mockReset();
+  findBlockedManifestDependenciesMock.mockReset();
+  findBlockedNodeModulesDirectoryMock.mockReset();
+  findBlockedNodeModulesFileAliasMock.mockReset();
+  findBlockedPackageDirectoryInPathMock.mockReset();
+  findBlockedPackageFileAliasInPathMock.mockReset();
+  getGlobalHookRunnerMock.mockReset();
+});
 
+describe("install security scan official bypass", () => {
   it("bypasses plugin install friction for bundled OpenClaw sources", async () => {
     const result = await scanBundleInstallSourceRuntime({
       logger: {},
@@ -172,5 +182,66 @@ describe("install security scan official bypass", () => {
       },
     });
     expect(runInstallPolicyMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("installed dependency tree scan", () => {
+  it("accepts a managed host link declared as a runtime dependency", async () => {
+    findBlockedManifestDependenciesMock.mockReturnValue([]);
+    const npmRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-install-scan-"));
+    tempDirs.push(npmRoot);
+    const packageDir = path.join(npmRoot, "node_modules", "runtime-plugin");
+    const hostLink = path.join(packageDir, "node_modules", "openclaw");
+    await fs.mkdir(path.dirname(hostLink), { recursive: true });
+    await fs.writeFile(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "runtime-plugin",
+        dependencies: { openclaw: "2026.7.1" },
+      }),
+      "utf8",
+    );
+    await fs.symlink(process.cwd(), hostLink, "junction");
+
+    const result = await scanInstalledPackageDependencyTreeRuntime({
+      allowManagedNpmRootPackagePeerSymlinks: true,
+      dependencyScanRootDir: npmRoot,
+      logger: {},
+      packageDir,
+      pluginId: "runtime-plugin",
+    });
+
+    expect(result).toBeUndefined();
+    expect(runInstallPolicyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an openclaw dependency symlink that does not target the trusted host", async () => {
+    findBlockedManifestDependenciesMock.mockReturnValue([]);
+    const npmRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-install-scan-"));
+    const outsideRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-install-outside-"));
+    tempDirs.push(npmRoot, outsideRoot);
+    const packageDir = path.join(npmRoot, "node_modules", "runtime-plugin");
+    const hostLink = path.join(packageDir, "node_modules", "openclaw");
+    await fs.mkdir(path.dirname(hostLink), { recursive: true });
+    await fs.writeFile(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "runtime-plugin",
+        dependencies: { openclaw: "2026.7.1" },
+      }),
+      "utf8",
+    );
+    await fs.writeFile(path.join(outsideRoot, "package.json"), '{"name":"openclaw"}', "utf8");
+    await fs.symlink(outsideRoot, hostLink, "junction");
+
+    await expect(
+      scanInstalledPackageDependencyTreeRuntime({
+        allowManagedNpmRootPackagePeerSymlinks: true,
+        dependencyScanRootDir: npmRoot,
+        logger: {},
+        packageDir,
+        pluginId: "runtime-plugin",
+      }),
+    ).rejects.toThrow("installed dependency scan found package outside install root");
   });
 });

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -362,9 +362,11 @@ function collectManifestRuntimeDependencyNames(manifest: PackageManifest): strin
 }
 
 async function resolveInstalledPackageScanRoot(params: {
+  allowManagedNpmRootPackagePeerSymlinks?: boolean;
   boundaryRealPath: string;
   dependencyName: string;
   packageDir: string;
+  trustedHostOpenClawRootRealPath: string | null;
 }): Promise<InstalledPackageScanRoot | undefined> {
   const packageDir = path.join(params.packageDir, "node_modules", params.dependencyName);
   let stats: Awaited<ReturnType<typeof fs.stat>>;
@@ -382,6 +384,16 @@ async function resolveInstalledPackageScanRoot(params: {
 
   const realPath = await fs.realpath(packageDir).catch(() => path.resolve(packageDir));
   if (!isSamePathOrInside(params.boundaryRealPath, realPath)) {
+    if (
+      params.allowManagedNpmRootPackagePeerSymlinks === true &&
+      params.dependencyName === "openclaw" &&
+      isTrustedHostOpenClawPath({
+        resolvedTargetPath: realPath,
+        trustedHostOpenClawRootRealPath: params.trustedHostOpenClawRootRealPath,
+      })
+    ) {
+      return undefined;
+    }
     throw new Error(
       `installed dependency scan found package outside install root at ${packageDir}`,
     );
@@ -391,12 +403,14 @@ async function resolveInstalledPackageScanRoot(params: {
 
 async function collectInstalledPackageScanRoots(params: {
   additionalPackageDirs?: string[];
+  allowManagedNpmRootPackagePeerSymlinks?: boolean;
   dependencyScanRootDir?: string;
   packageDir: string;
 }): Promise<string[]> {
   const limits = resolvePackageManifestTraversalLimits();
   const boundaryDir = params.dependencyScanRootDir ?? params.packageDir;
   const boundaryRealPath = await fs.realpath(boundaryDir).catch(() => path.resolve(boundaryDir));
+  const trustedHostOpenClawRootRealPath = await resolveTrustedHostOpenClawRootRealPath();
   const packageRealPath = await fs
     .realpath(params.packageDir)
     .catch(() => path.resolve(params.packageDir));
@@ -444,17 +458,21 @@ async function collectInstalledPackageScanRoots(params: {
     }
     for (const dependencyName of collectManifestRuntimeDependencyNames(manifest)) {
       const nestedCandidate = await resolveInstalledPackageScanRoot({
+        allowManagedNpmRootPackagePeerSymlinks: params.allowManagedNpmRootPackagePeerSymlinks,
         boundaryRealPath,
         dependencyName,
         packageDir: current.packageDir,
+        trustedHostOpenClawRootRealPath,
       });
       const candidate =
         nestedCandidate ??
         (params.dependencyScanRootDir
           ? await resolveInstalledPackageScanRoot({
+              allowManagedNpmRootPackagePeerSymlinks: params.allowManagedNpmRootPackagePeerSymlinks,
               boundaryRealPath,
               dependencyName,
               packageDir: params.dependencyScanRootDir,
+              trustedHostOpenClawRootRealPath,
             })
           : undefined);
       if (candidate && !visitedRealPaths.has(candidate.realPath)) {
@@ -1114,6 +1132,7 @@ export async function scanInstalledPackageDependencyTreeRuntime(params: {
       ? { additionalPackageDirs: params.additionalPackageDirs }
       : {}),
     dependencyScanRootDir: params.dependencyScanRootDir,
+    allowManagedNpmRootPackagePeerSymlinks: params.allowManagedNpmRootPackagePeerSymlinks,
     packageDir: params.packageDir,
   });
   const manifestScanRoots = await collectNonOverlappingPackageScanRoots(scanRoots);


### PR DESCRIPTION
Complete the managed-peer allowance in installed dependency-root traversal while retaining negative security coverage for unmanaged links.\n\nTests: 8 focused install security-scan tests passed.