### PR TITLE
fix(docker): resolve plugins by public id

### DIFF
--- a/scripts/lib/docker-plugin-selection.mjs
+++ b/scripts/lib/docker-plugin-selection.mjs
@@ -1,0 +1,133 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { collectRootPackageExcludedExtensionDirs } from "./root-package-bundled-plugin-excludes.mjs";
+
+const PLUGIN_ID_RE = /^[a-z0-9][a-z0-9-]*$/u;
+
+function readManifest(pluginDir) {
+  const manifestPath = path.join(pluginDir, "openclaw.plugin.json");
+  if (!fs.existsSync(manifestPath)) {
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+}
+
+function collectPluginIdentities(extensionsRoot) {
+  return fs
+    .readdirSync(extensionsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const pluginDir = path.join(extensionsRoot, entry.name);
+      const hasPackageJson = fs.existsSync(path.join(pluginDir, "package.json"));
+      const manifest = readManifest(pluginDir);
+      const manifestId =
+        typeof manifest?.id === "string" && manifest.id.length > 0 ? manifest.id : null;
+      return {
+        dirName: entry.name,
+        manifestId,
+        providers: manifest?.providers ?? [],
+        known: hasPackageJson || manifestId !== null,
+      };
+    })
+    .filter((entry) => entry.known)
+    .toSorted((left, right) => left.dirName.localeCompare(right.dirName));
+}
+
+/** Resolve public Docker selections to the source directories used by build and prune steps. */
+export function resolveDockerPluginSelection(params) {
+  const selection = typeof params.selection === "string" ? params.selection : "";
+  const selectedIds = new Set(
+    selection
+      .split(/[\s,]+/u)
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  );
+  const plugins = collectPluginIdentities(params.extensionsRoot);
+  const resolvedDirs = new Set();
+  const providers = new Set(params.providers ?? []);
+  for (const plugin of plugins) {
+    if (plugin.providers.some((provider) => providers.has(provider))) {
+      resolvedDirs.add(plugin.dirName);
+    }
+  }
+
+  for (const selectedId of selectedIds) {
+    if (!PLUGIN_ID_RE.test(selectedId)) {
+      throw new Error(`invalid OPENCLAW_EXTENSIONS plugin id: ${selectedId}`);
+    }
+    const matches = plugins.filter(
+      (plugin) => plugin.dirName === selectedId || plugin.manifestId === selectedId,
+    );
+    if (matches.length === 0) {
+      throw new Error(`unknown OPENCLAW_EXTENSIONS plugin id: ${selectedId}`);
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        `ambiguous OPENCLAW_EXTENSIONS plugin id: ${selectedId} (${matches
+          .map((plugin) => plugin.dirName)
+          .join(", ")})`,
+      );
+    }
+    resolvedDirs.add(matches[0].dirName);
+  }
+
+  return [...resolvedDirs].toSorted((left, right) => left.localeCompare(right));
+}
+
+function collectRequiredBundledPluginDirs(params) {
+  const excluded = collectRootPackageExcludedExtensionDirs({
+    cwd: path.dirname(params.rootPackagePath),
+  });
+  return collectPluginIdentities(params.extensionsRoot)
+    .filter(({ dirName }) => {
+      if (excluded.has(dirName)) {
+        return false;
+      }
+      const packageJsonPath = path.join(params.extensionsRoot, dirName, "package.json");
+      if (!fs.existsSync(packageJsonPath)) {
+        return false;
+      }
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+      return Object.keys(packageJson.dependencies ?? {}).length > 0;
+    })
+    .map(({ dirName }) => dirName);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  try {
+    const params = {
+      extensionsRoot: process.argv[2],
+      selection: process.argv[3] ?? "",
+    };
+    let resolved = resolveDockerPluginSelection(params);
+    if (process.argv[4] === "--required-bundled") {
+      resolved = [
+        ...new Set([
+          ...resolved,
+          ...collectRequiredBundledPluginDirs({ ...params, rootPackagePath: process.argv[5] }),
+        ]),
+      ].toSorted((left, right) => left.localeCompare(right));
+    } else if (process.argv[4] === "--required-platform-packages") {
+      resolved = [
+        ...new Set(
+          resolved.flatMap((dirName) => {
+            const packageJsonPath = path.join(params.extensionsRoot, dirName, "package.json");
+            if (!fs.existsSync(packageJsonPath)) {
+              return [];
+            }
+            const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+            return packageJson.openclaw?.install?.requiredPlatformPackages ?? [];
+          }),
+        ),
+      ].toSorted((left, right) => left.localeCompare(right));
+    }
+    if (resolved.length > 0) {
+      process.stdout.write(`${resolved.join("\n")}\n`);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`ERROR: ${message}`);
+    process.exitCode = 1;
+  }
+}

--- a/test/scripts/docker-plugin-selection.test.ts
+++ b/test/scripts/docker-plugin-selection.test.ts
@@ -1,0 +1,62 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const repoRoot = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const selectorScript = path.join(repoRoot, "scripts/lib/docker-plugin-selection.mjs");
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function writePlugin(extensionsRoot: string, dirName: string, manifestId?: string) {
+  const pluginDir = path.join(extensionsRoot, dirName);
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(path.join(pluginDir, "package.json"), `${JSON.stringify({ name: dirName })}\n`);
+  if (manifestId) {
+    fs.writeFileSync(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      `${JSON.stringify({ id: manifestId })}\n`,
+    );
+  }
+}
+
+function runSelector(extensionsRoot: string, selection: string) {
+  return spawnSync(process.execPath, [selectorScript, extensionsRoot, selection], {
+    encoding: "utf8",
+  });
+}
+
+describe("Docker plugin selection", () => {
+  it("resolves manifest ids and source directory names deterministically", () => {
+    const extensionsRoot = tempDirs.make("openclaw-docker-plugin-selection-");
+    writePlugin(extensionsRoot, "source-only");
+    writePlugin(extensionsRoot, "provider-source", "provider-id");
+
+    const result = runSelector(
+      extensionsRoot,
+      "source-only,provider-id provider-source,provider-id",
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("provider-source\nsource-only\n");
+  });
+
+  it("fails closed for unknown, invalid, and ambiguous ids", () => {
+    const extensionsRoot = tempDirs.make("openclaw-docker-plugin-selection-errors-");
+    writePlugin(extensionsRoot, "shared");
+    writePlugin(extensionsRoot, "other-source", "shared");
+
+    for (const [selection, message] of [
+      ["missing-plugin", "unknown OPENCLAW_EXTENSIONS plugin id: missing-plugin"],
+      ["../invalid", "invalid OPENCLAW_EXTENSIONS plugin id: ../invalid"],
+      ["shared", "ambiguous OPENCLAW_EXTENSIONS plugin id: shared"],
+    ] as const) {
+      const result = runSelector(extensionsRoot, selection);
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain(message);
+    }
+  });
+});


### PR DESCRIPTION
Add fail-closed Docker plugin selection by manifest id or source directory, including deterministic deduplication and ambiguity rejection.\n\nTests: 2 focused selector tests passed.