### PR TITLE
test(proxy): align absolute-form request targets

### DIFF
--- a/src/infra/net/proxy/external-proxy.e2e.test.ts
+++ b/src/infra/net/proxy/external-proxy.e2e.test.ts
@@ -500,8 +500,10 @@ describe("SSRF external proxy routing", () => {
     expect(child.stdout).toContain('"body":"from loopback target"');
     expect(seenConnectTargets).toContain(`127.0.0.1:${wsTargetPort}`);
     expect(seenConnectTargets).toContain(`127.0.0.1:${httpsLikeTargetPort}`);
-    expect(seenConnectTargets).toContain(`127.0.0.1:${targetPort}`);
-    expect(seenConnectTargets).toContain(`127.0.0.1:${globalFetchTargetPort}`);
+    expect(seenConnectTargets).toContain(`http://127.0.0.1:${targetPort}/private-metadata`);
+    expect(seenConnectTargets).toContain(
+      `http://127.0.0.1:${globalFetchTargetPort}/global-fetch-metadata`,
+    );
     expect(seenConnectTargets).toContain(`http://127.0.0.1:${targetPort}/node-http-metadata`);
     expect(seenConnectTargets).toContain(`http://127.0.0.1:${targetPort}/explicit-agent`);
     expect(seenConnectTargets).not.toContain(`127.0.0.1:${gatewayBypassWsTargetPort}`);


### PR DESCRIPTION
Align the proxy E2E fixture with the actual absolute-form HTTP request targets used by the stable runtime.\n\nTests: 2 focused proxy E2E tests passed.