### PR TITLE
fix(ui): pinned sessions show a filled neutral pin

### DIFF
--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import type { Locator } from "playwright";
 import { expect, it } from "vitest";
 import {
   waitForControlUiGatewayReady,
@@ -22,6 +23,19 @@ import {
 } from "./session-management.test-support.ts";
 
 const suite = createSessionManagementE2eSuite();
+
+function sessionActionPresentation(button: Locator) {
+  return button.evaluate((element) => {
+    const icon = element.querySelector("svg");
+    if (!icon) {
+      throw new Error("expected session action icon");
+    }
+    return {
+      color: getComputedStyle(element).color,
+      fill: getComputedStyle(icon).fill,
+    };
+  });
+}
 
 suite.define(() => {
   it("expands and manages child sessions inline before opening a child chat", async () => {
@@ -600,8 +614,9 @@ suite.define(() => {
     }
   });
 
-  it("does not duplicate the active chat when its only session is pinned", async () => {
+  it("keeps the only pinned chat unique and presents its pin state", async () => {
     const context = await suite.browser.newContext({
+      colorScheme: "dark",
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
@@ -629,6 +644,26 @@ suite.define(() => {
         .toEqual(["Pinned only"]);
       await expect.poll(() => chatsGroup.locator(".sidebar-recent-session").count()).toBe(0);
       await expect.poll(() => page.locator(".sidebar-recent-session--active").count()).toBe(1);
+      const pin = pinnedEntry.getByRole("button", { name: "Unpin session" });
+      const menu = pinnedEntry.getByRole("button", { name: "Open session menu" });
+      await pinnedEntry.hover();
+      await captureUiProof(suite, page, "pinned-session-icon.png");
+      const revealedPin = await sessionActionPresentation(pin);
+      const revealedMenu = await sessionActionPresentation(menu);
+      expect(revealedPin.color).toBe(revealedMenu.color);
+      expect(revealedPin.fill).toBe(revealedPin.color);
+
+      await pin.hover();
+      await expect
+        .poll(async () => (await sessionActionPresentation(pin)).color)
+        .not.toBe(revealedPin.color);
+      await expect
+        .poll(async () => {
+          const hoveredPin = await sessionActionPresentation(pin);
+          return hoveredPin.fill === hoveredPin.color;
+        })
+        .toBe(true);
+
       // The empty Threads section only materializes after dragstart. Move the
       // real pointer first so Playwright does not wait for a hidden target.
       const pinnedRow = pinnedEntry.locator(".sidebar-recent-session");

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5919,8 +5919,8 @@ td.data-table-key-col {
   }
 }
 
-.session-row-host--pinned .session-action--pin {
-  color: var(--accent);
+.session-row-host--pinned .session-action--pin svg {
+  fill: currentColor;
 }
 
 .session-run-spinner {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where pinned sessions used the same outline pin as unpinned sessions and recolored it red, making the pinned state unclear and visually inconsistent with the neighboring ellipsis action.

## Why This Change Was Made

Pinned rows now fill the existing pin glyph with its inherited action color. Removing the pinned-only accent override keeps the pin and ellipsis on the same muted resting color and preserves the shared hover treatment.

## User Impact

Pinned sessions show a filled pin. The icon no longer appears as a red outline and behaves like the other session-row actions on hover.

## Evidence

### Before

Red outline pin:

![Before: pinned session with a red outline pin](https://github.com/user-attachments/assets/054a604a-037c-4037-853b-0933790a1c83)

### After

Filled pin using the same neutral color as the ellipsis:

![After: pinned session with a filled neutral pin](https://github.com/user-attachments/assets/e30cc673-8cfe-4bcc-b69a-14b7c187cddf)

Validation:

- Regression test fails against the old rule (`rgb(255, 92, 92)` pin versus `rgb(139, 139, 148)` ellipsis) and passes with the fix.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.sidebar.e2e.test.ts` — 10/10 passed, including touch controls.
- `node scripts/check-changed.mjs -- ui/src/e2e/session-management.sidebar.e2e.test.ts ui/src/styles/components.css` — passed.
- Autoreview — scoped clean, no accepted/actionable findings (0.99 correctness confidence).

Production LOC: +2/-2 (net 0). Tests: +36/-1.
