### PR TITLE
fix: restore Ask OpenClaw connections and preserve conversation recovery

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -870,7 +870,11 @@ through OpenClaw.
 
 By default, the plugin starts OpenClaw's managed Codex binary locally with
 stdio transport. Set `appServer.command` only to intentionally run a
-different executable. Codex classifies WebSocket transport as experimental
+different executable. Verified setup accepts a native Codex executable or the
+official `@openai/codex` npm entrypoint, including its installed symlink or
+Windows npm launcher. Arbitrary wrapper scripts cannot be verified because
+their native target is unknown; select the native executable or official npm
+launcher instead. Codex classifies WebSocket transport as experimental
 and unsupported; use it only for non-production testing against an app-server
 already running elsewhere:
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -188,6 +188,8 @@ When your connection is bound to an authenticated Gateway profile, theme, theme 
 
 Open **Settings → Ask OpenClaw** to talk to the system setup and repair agent. Toggle it from anywhere with the lobster button in the sidebar footer or the **Ask OpenClaw** command-palette action. The full page and dockable panel share one machine-wide conversation whose durable history lives on the Gateway. Closing the UI never cancels a turn; reopening Ask OpenClaw shows the completed conversation. The panel docks on the right or bottom, remembers its placement and size in the browser profile, and hides itself while the full page is open.
 
+If no AI provider is configured, Ask OpenClaw offers **Connect an AI provider**. If a configured runtime fails to start or verify, the conversation stays visible with the actual error and **Retry**. Sending stays disabled until verification succeeds. Retry checks the runtime without resending your earlier message or clearing your draft.
+
 Each chat message carries the Control UI page you are currently viewing as an untrusted ambient hint, so requests like "configure this channel" or "why is this page empty?" resolve against the page you are looking at.
 
 Guided channel setup, workspace skills setup, web-search provider setup, and local Gateway setup run as hosted wizards inside the chat. Wizard questions stay in the conversation, secret steps mask input in the browser, and successful config-backed flows are audited and re-validated. If a chosen web-search provider needs a plugin install and that install fails, setup stops and reports the failure instead of pretending the provider is configured.

--- a/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
@@ -8,6 +8,7 @@ import {
   createCodexRuntimePlanFixture,
   createParams as createSharedParams,
   runCodexAppServerAttempt as runSharedCodexAppServerAttempt,
+  seedRunSessionOwnerForTest,
   setupRunAttemptTestHooks,
   tempDir,
   threadStartResult,
@@ -113,8 +114,14 @@ const DISABLED_CODEX_WEB_SEARCH_THREAD_CONFIG_FINGERPRINT = JSON.stringify({
 });
 const APP_SERVER_START_WAIT = { interval: 1, timeout: 5_000 } as const;
 
-function writeCodexAppServerBinding(...args: Parameters<typeof writeRawCodexAppServerBinding>) {
+async function writeCodexAppServerBinding(
+  ...args: Parameters<typeof writeRawCodexAppServerBinding>
+) {
   const [sessionFile, binding, lookup] = args;
+  await seedRunSessionOwnerForTest(
+    AUTH_PROFILE_RUNTIME_CONTRACT.sessionId,
+    AUTH_PROFILE_RUNTIME_CONTRACT.sessionKey,
+  );
   return writeRawCodexAppServerBinding(
     sessionFile,
     {

--- a/extensions/codex/src/app-server/managed-binary.test.ts
+++ b/extensions/codex/src/app-server/managed-binary.test.ts
@@ -65,6 +65,27 @@ describe("managed Codex app-server binary", () => {
     ).toBe(MACOS_DESKTOP_CHATGPT_APP_SERVER_COMMAND);
   });
 
+  it.each([true, false])(
+    "uses embedded vendor binaries only when the platform package is absent (present=%s)",
+    (platformPackagePresent) => {
+      const packageRoot = "/repo/node_modules/@openai/codex";
+      const embedded = `${packageRoot}/vendor/aarch64-apple-darwin/bin/codex`;
+      expect(
+        resolveManagedCodexNativeCommand(`${packageRoot}/bin/codex.js`, {
+          platform: "darwin",
+          arch: "arm64",
+          resolvePackageJson: (name) =>
+            name === "@openai/codex"
+              ? `${packageRoot}/package.json`
+              : platformPackagePresent
+                ? "/repo/node_modules/@openai/codex-darwin-arm64/package.json"
+                : undefined,
+          pathExists: (candidate) => candidate === embedded,
+        }),
+      ).toBe(platformPackagePresent ? undefined : embedded);
+    },
+  );
+
   it("leaves explicit command overrides unchanged without probing managed paths", async () => {
     const explicitOptions = startOptions("config");
     const pathExists = vi.fn(async () => false);

--- a/extensions/codex/src/app-server/managed-binary.ts
+++ b/extensions/codex/src/app-server/managed-binary.ts
@@ -85,23 +85,35 @@ export function resolveManagedCodexNativeCommand(
   }
   const resolvePackageJson = options.resolvePackageJson ?? resolvePackageJsonFromRoot;
   const pathExists = options.pathExists ?? existsSync;
-  for (const packageName of [target.packageName, MANAGED_CODEX_APP_SERVER_PACKAGE]) {
-    const packageJsonPath = resolvePackageJson(packageName, packageRoot);
-    if (!packageJsonPath) {
-      continue;
-    }
-    const candidate = path.join(
-      path.dirname(packageJsonPath),
-      "vendor",
-      target.triple,
-      "bin",
-      platform === "win32" ? "codex.exe" : "codex",
-    );
-    if (pathExists(candidate)) {
-      return candidate;
-    }
+  // The npm entrypoint selects the platform package before checking its binary.
+  // An incomplete platform package must not attest a different embedded executable.
+  const packageJsonPath =
+    resolvePackageJson(target.packageName, packageRoot) ??
+    resolvePackageJson(MANAGED_CODEX_APP_SERVER_PACKAGE, packageRoot);
+  if (!packageJsonPath) {
+    return undefined;
   }
-  return undefined;
+  const candidate = path.join(
+    path.dirname(packageJsonPath),
+    "vendor",
+    target.triple,
+    "bin",
+    platform === "win32" ? "codex.exe" : "codex",
+  );
+  return pathExists(candidate) ? candidate : undefined;
+}
+
+/** Recognizes only the official npm entrypoint, not arbitrary configured wrappers. */
+export function resolvePackagedCodexNativeCommand(entrypoint: string): string | undefined {
+  const packageRoot = path.dirname(path.dirname(entrypoint));
+  if (
+    path.basename(packageRoot) !== "codex" ||
+    path.basename(path.dirname(packageRoot)) !== "@openai" ||
+    path.relative(packageRoot, entrypoint) !== path.join("bin", "codex.js")
+  ) {
+    return undefined;
+  }
+  return resolveManagedCodexNativeCommand(entrypoint);
 }
 
 /** Returns whether a command is one of the standard macOS desktop app executables. */

--- a/extensions/codex/src/app-server/run-attempt-connection.ts
+++ b/extensions/codex/src/app-server/run-attempt-connection.ts
@@ -178,13 +178,9 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
     : undefined;
   const isInactiveThreadBootstrapBinding = (binding: CodexAppServerThreadBinding | undefined) =>
     !activeContextEngine && binding?.contextEngine?.projection?.mode === "thread_bootstrap";
-  // The public runner carries a resolved store target. Its durable row must
-  // authorize a stable-key fence before an old generation can read its binding.
-  if (
-    bindingIdentity.kind === "session" &&
-    bindingIdentity.sessionKey &&
-    (params.sessionTarget?.storePath || params.config?.session?.store)
-  ) {
+  // Only a durable session row authorizes stable-key ownership. Caller-owned
+  // transcripts omit a store target, so classify them against the default store too.
+  if (bindingIdentity.kind === "session" && bindingIdentity.sessionKey) {
     const authority = resolveCodexRunSessionBindingAuthority({
       identity: bindingIdentity,
       config: params.config,

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -17,6 +17,12 @@ import { clearInternalHooks, resetGlobalHookRunner } from "openclaw/plugin-sdk/h
 import { clearMemoryPluginState } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { clearPluginCommands } from "openclaw/plugin-sdk/plugin-runtime";
 import { createAgentHarnessHostCapabilitiesForTest } from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
+  deleteSessionEntry,
+  resolveStorePath,
+  upsertSessionEntry,
+} from "openclaw/plugin-sdk/session-store-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { afterEach, beforeEach, expect, vi } from "vitest";
 import { defaultCodexAppInventoryCache } from "./app-inventory-cache.js";
@@ -103,6 +109,7 @@ vi.mock("openclaw/plugin-sdk/exec-approvals-runtime", async (importOriginal) => 
 });
 
 export let tempDir: string;
+const seededSessionOwnersForTest: Array<Parameters<typeof deleteSessionEntry>[0]> = [];
 let codexAppServerClientFactoryForTest: CodexAppServerClientFactory | undefined;
 const multiplexedTestClients = new WeakSet<CodexAppServerClient>();
 export const fastWait = { interval: 1, timeout: 5_000 } as const;
@@ -301,6 +308,17 @@ export function createParams(
 
 export function createTestParams(): EmbeddedRunAttemptParams {
   return createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace"));
+}
+
+/** Models the core owner required for a reusable stable-key Codex binding. */
+export async function seedRunSessionOwnerForTest(sessionId: string, sessionKey: string) {
+  const scope = {
+    agentId: "main",
+    sessionKey,
+    storePath: resolveStorePath(undefined, { agentId: "main" }),
+  };
+  await upsertSessionEntry({ ...scope, entry: { sessionId, updatedAt: Date.now() } });
+  seededSessionOwnersForTest.push({ ...scope, expectedSessionId: sessionId });
 }
 
 /** Replaces the lightweight default with the admitted host boundary used in production. */
@@ -693,6 +711,9 @@ export function setupRunAttemptTestHooks(): void {
     vi.stubEnv("CODEX_API_KEY", "");
     vi.stubEnv("OPENAI_API_KEY", "");
     tempDir = await fs.mkdtemp(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-codex-run-"));
+    // createParams models an ordinary durable session; seeded native bindings
+    // must have the same authoritative core owner as a real resumed conversation.
+    await seedRunSessionOwnerForTest("session-1", "agent:main:session-1");
   });
 
   afterEach(async () => {
@@ -719,6 +740,10 @@ export function setupRunAttemptTestHooks(): void {
     vi.useRealTimers();
     vi.unstubAllEnvs();
     await sandboxExecServerRegistry.closeAll();
+    for (const owner of seededSessionOwnersForTest.splice(0)) {
+      await deleteSessionEntry(owner);
+    }
+    closeOpenClawAgentDatabasesForTest();
     await fs.rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
   });
 }

--- a/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
@@ -12,6 +12,7 @@ import {
   mockClientRuntimeMethods,
   multiplexCodexTestClientHandlers,
   runCodexAppServerAttempt,
+  seedRunSessionOwnerForTest,
   setupRunAttemptTestHooks,
   tempDir,
   threadStartResult,
@@ -188,6 +189,9 @@ describe("Codex app-server main thread cleanup", () => {
       a: path.join(tempDir, "session-a.jsonl"),
       b: path.join(tempDir, "session-b.jsonl"),
     };
+    for (const label of ["a", "b"]) {
+      await seedRunSessionOwnerForTest(`session-${label}`, `agent:main:session-${label}`);
+    }
     const harness = createClientHarness();
     const clientStarted = createDeferred<void>();
     vi.spyOn(CodexAppServerClient, "start").mockImplementation(async () => {
@@ -301,6 +305,10 @@ describe("Codex app-server main thread cleanup", () => {
       path.join(tempDir, "concurrent-second-workspace"),
       "agent:main:telegram:topic:second",
     );
+    firstParams.sessionId = "session-first";
+    secondParams.sessionId = "session-second";
+    await seedRunSessionOwnerForTest(firstParams.sessionId, firstParams.sessionKey!);
+    await seedRunSessionOwnerForTest(secondParams.sessionId, secondParams.sessionKey!);
     firstParams.timeoutMs = 100;
     secondParams.timeoutMs = 100;
 
@@ -472,7 +480,8 @@ describe("Codex app-server main thread cleanup", () => {
 
     const result = await run;
     expect(readAttemptTerminal(result)).toMatchObject({ aborted: false, timedOut: false });
-    await expect(readCodexAppServerBinding(sessionFile)).resolves.toMatchObject({
+    const physicalIdentity = sessionBindingIdentity({ agentId: "main", sessionId: "session-1" });
+    await expect(testCodexAppServerBindingStore.read(physicalIdentity)).resolves.toMatchObject({
       threadId: "thread-1",
       clientId: harness.client.getInstanceId(),
     });
@@ -480,7 +489,7 @@ describe("Codex app-server main thread cleanup", () => {
     const requestStart = harness.writes.length;
     const retirement = retireCodexAppServerSessionGeneration({
       bindingStore: testCodexAppServerBindingStore,
-      identity: sessionBindingIdentity({ agentId: "main", sessionId: "session-1", sessionKey }),
+      identity: physicalIdentity,
       mode: "retire",
     });
     const unsubscribe = await waitForHarnessRequest(harness, "thread/unsubscribe", requestStart);
@@ -540,7 +549,11 @@ describe("Codex app-server main thread cleanup", () => {
       { threadId: "thread-1" },
       { timeoutMs: 5_000 },
     );
-    await expect(readCodexAppServerBinding(sessionFile)).resolves.toBeUndefined();
+    await expect(
+      testCodexAppServerBindingStore.read(
+        sessionBindingIdentity({ agentId: "main", sessionId: "session-1" }),
+      ),
+    ).resolves.toBeUndefined();
   });
 
   it.each([
@@ -847,7 +860,11 @@ describe("Codex app-server main thread cleanup", () => {
     expect(turnStartError).toBeInstanceOf(Error);
     expect(turnStartError).toMatchObject({ message: "turn start exploded" });
     expect(contaminated.stdinDestroyed).toBe(false);
-    await expect(readCodexAppServerBinding(sessionFile)).resolves.toBeUndefined();
+    await expect(
+      testCodexAppServerBindingStore.read(
+        sessionBindingIdentity({ agentId: "main", sessionId: "session-1" }),
+      ),
+    ).resolves.toBeUndefined();
 
     const replacementRun = runCodexAppServerAttempt(
       createParams(sessionFile, workspaceDir, sessionKey),

--- a/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts
@@ -454,6 +454,8 @@ describe("Codex app-server main thread cleanup", () => {
     const sessionFile = path.join(tempDir, "incognito-session.jsonl");
     const workspaceDir = path.join(tempDir, "incognito-workspace");
     const sessionKey = "agent:main:dashboard:incognito-live-thread";
+    // Dashboard incognito sessions keep an authoritative row in process-held SQLite.
+    await seedRunSessionOwnerForTest("session-1", sessionKey);
     const harness = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start").mockResolvedValueOnce(harness.client);
     const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir, sessionKey), {
@@ -480,8 +482,7 @@ describe("Codex app-server main thread cleanup", () => {
 
     const result = await run;
     expect(readAttemptTerminal(result)).toMatchObject({ aborted: false, timedOut: false });
-    const physicalIdentity = sessionBindingIdentity({ agentId: "main", sessionId: "session-1" });
-    await expect(testCodexAppServerBindingStore.read(physicalIdentity)).resolves.toMatchObject({
+    await expect(readCodexAppServerBinding(sessionFile)).resolves.toMatchObject({
       threadId: "thread-1",
       clientId: harness.client.getInstanceId(),
     });
@@ -489,7 +490,7 @@ describe("Codex app-server main thread cleanup", () => {
     const requestStart = harness.writes.length;
     const retirement = retireCodexAppServerSessionGeneration({
       bindingStore: testCodexAppServerBindingStore,
-      identity: physicalIdentity,
+      identity: sessionBindingIdentity({ agentId: "main", sessionId: "session-1", sessionKey }),
       mode: "retire",
     });
     const unsubscribe = await waitForHarnessRequest(harness, "thread/unsubscribe", requestStart);
@@ -511,6 +512,7 @@ describe("Codex app-server main thread cleanup", () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const sessionKey = "agent:main:dashboard:incognito-failed-turn";
+    await seedRunSessionOwnerForTest("session-1", sessionKey);
     const requests: Array<{ method: string; params: unknown }> = [];
     const request = vi.fn(async (method: string, params?: unknown) => {
       requests.push({ method, params });
@@ -549,11 +551,7 @@ describe("Codex app-server main thread cleanup", () => {
       { threadId: "thread-1" },
       { timeoutMs: 5_000 },
     );
-    await expect(
-      testCodexAppServerBindingStore.read(
-        sessionBindingIdentity({ agentId: "main", sessionId: "session-1" }),
-      ),
-    ).resolves.toBeUndefined();
+    await expect(readCodexAppServerBinding(sessionFile)).resolves.toBeUndefined();
   });
 
   it.each([
@@ -671,6 +669,7 @@ describe("Codex app-server main thread cleanup", () => {
       const sessionFile = path.join(tempDir, "cancelled-session.jsonl");
       const workspaceDir = path.join(tempDir, "cancelled-workspace");
       const sessionKey = "agent:main:dashboard:incognito-cancelled-turn";
+      await seedRunSessionOwnerForTest("session-1", sessionKey);
       const harness = createClientHarness();
       const abort = new AbortController();
       const close = vi.spyOn(harness.client, "close");
@@ -818,6 +817,7 @@ describe("Codex app-server main thread cleanup", () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const sessionKey = "agent:main:dashboard:incognito-failed-unsubscribe";
+    await seedRunSessionOwnerForTest("session-1", sessionKey);
     const contaminated = createClientHarness();
     const replacement = createClientHarness();
     const startClient = vi
@@ -860,11 +860,7 @@ describe("Codex app-server main thread cleanup", () => {
     expect(turnStartError).toBeInstanceOf(Error);
     expect(turnStartError).toMatchObject({ message: "turn start exploded" });
     expect(contaminated.stdinDestroyed).toBe(false);
-    await expect(
-      testCodexAppServerBindingStore.read(
-        sessionBindingIdentity({ agentId: "main", sessionId: "session-1" }),
-      ),
-    ).resolves.toBeUndefined();
+    await expect(readCodexAppServerBinding(sessionFile)).resolves.toBeUndefined();
 
     const replacementRun = runCodexAppServerAttempt(
       createParams(sessionFile, workspaceDir, sessionKey),

--- a/extensions/codex/src/app-server/run-attempt.steering.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.steering.test.ts
@@ -18,13 +18,17 @@ import {
   mockClientRuntimeMethods,
   queueActiveRunMessageForTest,
   runCodexAppServerAttempt,
+  seedRunSessionOwnerForTest,
   setCodexAppServerClientFactoryForTest,
   setupRunAttemptTestHooks,
   tempDir,
   threadStartResult,
   turnStartResult,
 } from "./run-attempt-test-harness.js";
-import { readCodexAppServerBinding } from "./session-binding.test-helpers.js";
+import {
+  readCodexAppServerBinding,
+  testCodexAppServerBindingStore,
+} from "./session-binding.test-helpers.js";
 
 const activeRunRegistrationMocks = vi.hoisted(() => ({
   cancelPendingAgentQuestionForSession: vi.fn(),
@@ -150,6 +154,8 @@ describe("runCodexAppServerAttempt steering", () => {
       const params = createSteeringParams();
       if (incognito) {
         params.sessionKey = `agent:main:dashboard:incognito-${params.sessionId}`;
+      } else {
+        await seedRunSessionOwnerForTest(params.sessionId, params.sessionKey!);
       }
       const onAttemptAbort = vi.fn();
       params.onAttemptAbort = onAttemptAbort;
@@ -244,7 +250,14 @@ describe("runCodexAppServerAttempt steering", () => {
           method: "turn/interrupt",
           params: { threadId: "thread-1", turnId: "turn-1" },
         });
-        expect(await readCodexAppServerBinding(params.sessionFile)).toMatchObject({
+        const binding = incognito
+          ? await testCodexAppServerBindingStore.read({
+              kind: "session",
+              agentId: "main",
+              sessionId: params.sessionId,
+            })
+          : await readCodexAppServerBinding(params.sessionFile);
+        expect(binding).toMatchObject({
           threadId: "thread-1",
         });
         if (incognito) {

--- a/extensions/codex/src/app-server/run-attempt.steering.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.steering.test.ts
@@ -25,10 +25,7 @@ import {
   threadStartResult,
   turnStartResult,
 } from "./run-attempt-test-harness.js";
-import {
-  readCodexAppServerBinding,
-  testCodexAppServerBindingStore,
-} from "./session-binding.test-helpers.js";
+import { readCodexAppServerBinding } from "./session-binding.test-helpers.js";
 
 const activeRunRegistrationMocks = vi.hoisted(() => ({
   cancelPendingAgentQuestionForSession: vi.fn(),
@@ -154,9 +151,8 @@ describe("runCodexAppServerAttempt steering", () => {
       const params = createSteeringParams();
       if (incognito) {
         params.sessionKey = `agent:main:dashboard:incognito-${params.sessionId}`;
-      } else {
-        await seedRunSessionOwnerForTest(params.sessionId, params.sessionKey!);
       }
+      await seedRunSessionOwnerForTest(params.sessionId, params.sessionKey!);
       const onAttemptAbort = vi.fn();
       params.onAttemptAbort = onAttemptAbort;
       const onAgentEvent = vi.fn();
@@ -250,14 +246,7 @@ describe("runCodexAppServerAttempt steering", () => {
           method: "turn/interrupt",
           params: { threadId: "thread-1", turnId: "turn-1" },
         });
-        const binding = incognito
-          ? await testCodexAppServerBindingStore.read({
-              kind: "session",
-              agentId: "main",
-              sessionId: params.sessionId,
-            })
-          : await readCodexAppServerBinding(params.sessionFile);
-        expect(binding).toMatchObject({
+        expect(await readCodexAppServerBinding(params.sessionFile)).toMatchObject({
           threadId: "thread-1",
         });
         if (incognito) {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -22,7 +22,7 @@ import { MESSAGE_TOOL_DELIVERY_HINTS } from "openclaw/plugin-sdk/message-tool-de
 import { registerPluginCommand } from "openclaw/plugin-sdk/plugin-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { GPT5_BEHAVIOR_CONTRACT as CODEX_GPT5_BEHAVIOR_CONTRACT } from "openclaw/plugin-sdk/provider-model-shared";
-import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { resolveStorePath, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import {
   appendSessionTranscriptMessageByIdentity,
   readSessionTranscriptEvents,
@@ -7137,89 +7137,108 @@ describe("runCodexAppServerAttempt", () => {
     });
   });
 
-  it("starts sequential ephemeral generations that share a stable session key", async () => {
-    const { sessionFile, workspaceDir } = createRunPaths();
-    const sessionKey = "agent:main:ephemeral-helper";
-    const storePath = path.join(tempDir, "ephemeral-sessions.json");
-    let generation = 0;
-    const harness = createStartedThreadHarness(async (method) => {
-      if (method === "thread/start") {
-        generation += 1;
-        return threadStartResult(`thread-ephemeral-${generation}`);
-      }
-      if (method === "turn/start") {
-        return turnStartResult(`turn-ephemeral-${generation}`);
-      }
-      return undefined;
-    });
-
-    for (const [index, sessionId] of ["session-ephemeral-1", "session-ephemeral-2"].entries()) {
-      const params = createParams(sessionFile, workspaceDir);
-      params.sessionId = sessionId;
-      params.sessionKey = sessionKey;
-      params.sessionTarget = { agentId: "main", sessionId, sessionKey, storePath };
-      params.config = { ...params.config, session: { store: storePath } };
-
-      const run = runCodexAppServerAttempt(params);
-      let startupError: unknown;
-      void run.catch((error: unknown) => {
-        startupError = error;
-      });
-      const expectedGeneration = index + 1;
-      await vi.waitFor(() => {
-        if (startupError) {
-          throw startupError instanceof Error
-            ? startupError
-            : new Error("Codex attempt failed.", { cause: startupError });
+  it.each(["default", "config", "target"] as const)(
+    "starts sequential ephemeral generations with the %s session store",
+    async (storeSelection) => {
+      const { sessionFile, workspaceDir } = createRunPaths();
+      const sessionKey = "agent:main:ephemeral-helper";
+      vi.stubEnv("OPENCLAW_STATE_DIR", path.join(tempDir, "ephemeral-state"));
+      const storePath = path.join(tempDir, "ephemeral-sessions.json");
+      let generation = 0;
+      const harness = createStartedThreadHarness(async (method) => {
+        if (method === "thread/start") {
+          generation += 1;
+          return threadStartResult(`thread-ephemeral-${generation}`);
         }
-        expect(harness.requests.filter((request) => request.method === "turn/start")).toHaveLength(
-          expectedGeneration,
-        );
-      }, fastWait);
-      const threadId = `thread-ephemeral-${expectedGeneration}`;
-      const turnId = `turn-ephemeral-${expectedGeneration}`;
-      await harness.completeTurn({ threadId, turnId });
-      await expect(run).resolves.toBeDefined();
-    }
-    expect(harness.requests.filter((request) => request.method === "thread/start")).toHaveLength(2);
-  });
+        if (method === "turn/start") {
+          return turnStartResult(`turn-ephemeral-${generation}`);
+        }
+        return undefined;
+      });
 
-  it("rejects a run whose physical generation mismatches its durable session row", async () => {
-    const { sessionFile, workspaceDir } = createRunPaths();
-    const sessionKey = "agent:main:durable-generation";
-    const durableSessionId = "session-durable-current";
-    const storePath = path.join(tempDir, "durable-sessions.json");
-    registerCodexTestSessionIdentity(sessionFile, durableSessionId, sessionKey);
-    await writeCodexAppServerBinding(sessionFile, {
-      threadId: "thread-durable-current",
-      cwd: workspaceDir,
-    });
-    await upsertSessionEntry({
-      agentId: "main",
-      storePath,
-      sessionKey,
-      entry: { sessionId: durableSessionId, updatedAt: Date.now() },
-    });
-    const params = createParams(sessionFile, workspaceDir);
-    params.sessionId = "session-durable-stale";
-    params.sessionKey = sessionKey;
-    params.sessionTarget = {
-      agentId: "main",
-      sessionId: params.sessionId,
-      sessionKey,
-      storePath,
-    };
-    params.config = { ...params.config, session: { store: storePath } };
-    const clientFactory = vi.fn(async () => {
-      throw new Error("client must not start");
-    });
+      for (const [index, sessionId] of ["session-ephemeral-1", "session-ephemeral-2"].entries()) {
+        const params = createParams(sessionFile, workspaceDir);
+        params.sessionId = sessionId;
+        params.sessionKey = sessionKey;
+        if (storeSelection === "target") {
+          params.sessionTarget = { agentId: "main", sessionId, sessionKey, storePath };
+        } else if (storeSelection === "config") {
+          params.config = { ...params.config, session: { store: storePath } };
+        }
 
-    await expect(runCodexAppServerAttempt(params, { clientFactory })).rejects.toMatchObject({
-      name: "AgentHarnessSessionSupersededError",
-      message: "Codex session generation is no longer current: session-durable-stale",
-    });
-    expect(clientFactory).not.toHaveBeenCalled();
-  });
+        const run = runCodexAppServerAttempt(params);
+        let startupError: unknown;
+        void run.catch((error: unknown) => {
+          startupError = error;
+        });
+        const expectedGeneration = index + 1;
+        await vi.waitFor(() => {
+          if (startupError) {
+            throw startupError instanceof Error
+              ? startupError
+              : new Error("Codex attempt failed.", { cause: startupError });
+          }
+          expect(
+            harness.requests.filter((request) => request.method === "turn/start"),
+          ).toHaveLength(expectedGeneration);
+        }, fastWait);
+        const threadId = `thread-ephemeral-${expectedGeneration}`;
+        const turnId = `turn-ephemeral-${expectedGeneration}`;
+        await harness.completeTurn({ threadId, turnId });
+        await expect(run).resolves.toBeDefined();
+      }
+      expect(harness.requests.filter((request) => request.method === "thread/start")).toHaveLength(
+        2,
+      );
+    },
+  );
+
+  it.each(["default", "config", "target"] as const)(
+    "rejects a superseded generation in the %s session store",
+    async (storeSelection) => {
+      const { sessionFile, workspaceDir } = createRunPaths();
+      const sessionKey = "agent:main:durable-generation";
+      const durableSessionId = "session-durable-current";
+      vi.stubEnv("OPENCLAW_STATE_DIR", path.join(tempDir, "durable-state"));
+      const storePath =
+        storeSelection === "default"
+          ? resolveStorePath(undefined, { agentId: "main" })
+          : path.join(tempDir, "durable-sessions.json");
+      registerCodexTestSessionIdentity(sessionFile, durableSessionId, sessionKey);
+      await writeCodexAppServerBinding(sessionFile, {
+        threadId: "thread-durable-current",
+        cwd: workspaceDir,
+      });
+      await upsertSessionEntry({
+        agentId: "main",
+        storePath,
+        sessionKey,
+        entry: { sessionId: durableSessionId, updatedAt: Date.now() },
+      });
+      const params = createParams(sessionFile, workspaceDir);
+      params.sessionId = "session-durable-stale";
+      params.sessionKey = sessionKey;
+      if (storeSelection === "target") {
+        params.sessionTarget = {
+          agentId: "main",
+          sessionId: params.sessionId,
+          sessionKey,
+          storePath,
+        };
+      } else if (storeSelection === "config") {
+        params.config = { ...params.config, session: { store: storePath } };
+      }
+      const clientFactory = vi.fn(async () => {
+        throw new Error("client must not start");
+      });
+
+      await expect(runCodexAppServerAttempt(params, { clientFactory })).rejects.toMatchObject({
+        name: "AgentHarnessSessionSupersededError",
+        message: "Codex session generation is no longer current: session-durable-stale",
+      });
+      expect(clientFactory).not.toHaveBeenCalled();
+    },
+  );
 
   it("does not inherit a bound local provider for explicit native OpenAI resumed runs", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();

--- a/extensions/codex/src/app-server/runtime-artifact.test.ts
+++ b/extensions/codex/src/app-server/runtime-artifact.test.ts
@@ -58,6 +58,45 @@ async function captureBinding(params: {
   return { binding, client };
 }
 
+async function createNpmLauncherFixture(root: string) {
+  const packageRoot = path.join(root, "node_modules", "@openai", "codex");
+  const launcher = path.join(packageRoot, "bin", "codex.js");
+  const platform = process.platform === "darwin" ? "darwin" : "linux";
+  const arch = process.arch === "arm64" ? "arm64" : "x64";
+  const triple = `${arch === "arm64" ? "aarch64" : "x86_64"}-${platform === "darwin" ? "apple-darwin" : "unknown-linux-musl"}`;
+  const nativePackage = path.join(
+    packageRoot,
+    "node_modules",
+    "@openai",
+    `codex-${platform}-${arch}`,
+  );
+  const native = path.join(nativePackage, "vendor", triple, "bin", "codex");
+  const binDir = path.join(root, "bin");
+  await Promise.all([
+    fs.mkdir(path.dirname(launcher), { recursive: true }),
+    fs.mkdir(path.dirname(native), { recursive: true }),
+    fs.mkdir(binDir),
+  ]);
+  await Promise.all([
+    fs.writeFile(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "@openai/codex", bin: { codex: "bin/codex.js" } }),
+    ),
+    fs.writeFile(
+      path.join(nativePackage, "package.json"),
+      JSON.stringify({ name: `@openai/codex-${platform}-${arch}` }),
+    ),
+    fs.writeFile(launcher, "#!/usr/bin/env node\n"),
+    fs.writeFile(native, "native-v1"),
+    fs.writeFile(path.join(binDir, "node"), "node-v1"),
+  ]);
+  await fs.chmod(launcher, 0o755);
+  await fs.chmod(path.join(binDir, "node"), 0o755);
+  const command = path.join(binDir, "codex");
+  await fs.symlink(launcher, command);
+  return { command, native, binDir };
+}
+
 describe("Codex app-server runtime artifact", () => {
   it("binds a native executable and its adjacent code-mode host", async () => {
     await withTempDir("openclaw-codex-runtime-artifact-", async (root) => {
@@ -75,6 +114,31 @@ describe("Codex app-server runtime artifact", () => {
     });
   });
 
+  it.runIf(process.platform === "darwin" || process.platform === "linux").each([
+    ["config", "absolute"],
+    ["env", "path"],
+    ["config", "relative"],
+  ] as const)(
+    "binds the official npm launcher selected by %s via %s",
+    async (source, selection) => {
+      await withTempDir("openclaw-codex-npm-artifact-", async (root) => {
+        const { command, native, binDir } = await createNpmLauncherFixture(root);
+        const options = startOptions(
+          selection === "path" ? "codex" : selection === "relative" ? "bin/codex" : command,
+          {
+            commandSource: source,
+            cwd: root,
+            env: { PATH: binDir },
+          },
+        );
+        const { binding } = await captureBinding({ options });
+        await expect(validateCodexAppServerRuntimeArtifact(binding)).resolves.toBe(true);
+        await fs.writeFile(native, "native-v2");
+        await expect(validateCodexAppServerRuntimeArtifact(binding)).resolves.toBe(false);
+      });
+    },
+  );
+
   it("attests the sanitized environment when the host injects a runtime loader path", async () => {
     await withTempDir("openclaw-codex-runtime-sanitized-env-", async (root) => {
       const command = path.join(root, "codex");
@@ -88,6 +152,23 @@ describe("Codex app-server runtime artifact", () => {
       });
     });
   });
+
+  it
+    .runIf(process.platform !== "win32")
+    .each(["custom.js", "node_modules/.bin/custom", "node_modules/@openai/codex/bin/custom.js"])(
+    "rejects an unrecognized configured script at %s",
+    async (relativePath) => {
+      await withTempDir("openclaw-codex-custom-artifact-", async (root) => {
+        await createNpmLauncherFixture(root);
+        const command = path.join(root, relativePath);
+        await fs.mkdir(path.dirname(command), { recursive: true });
+        await fs.writeFile(command, "#!/usr/bin/env node\n");
+        await expect(captureBinding({ options: startOptions(command) })).rejects.toThrow(
+          "cannot attest a custom script launcher",
+        );
+      });
+    },
+  );
 
   it.runIf(process.platform !== "win32")(
     "resolves relative launch paths and shebang targets from the spawn cwd",
@@ -403,6 +484,30 @@ describe("Codex app-server runtime artifact", () => {
         fingerprint,
       }),
     ).resolves.toBe(false);
+  });
+
+  it("binds the native executable behind a Windows forwarder independently of path sort order", async () => {
+    await withTempDir("openclaw-codex-runtime-exe-shim-", async (root) => {
+      const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+      const nativeDir = path.join(root, "z-runtime");
+      const command = path.join(root, "a-launch.cmd");
+      const host = path.join(nativeDir, "codex-code-mode-host.exe");
+      await fs.mkdir(nativeDir);
+      await Promise.all([
+        fs.writeFile(command, '@ECHO off\r\n"%~dp0\\z-runtime\\codex.exe" %*\r\n'),
+        fs.writeFile(path.join(nativeDir, "codex.exe"), "native-v1"),
+        fs.writeFile(host, "host-v1"),
+      ]);
+      try {
+        Object.defineProperty(process, "platform", { ...platform, value: "win32" });
+        const { binding } = await captureBinding({ options: startOptions(command) });
+        await expect(validateCodexAppServerRuntimeArtifact(binding)).resolves.toBe(true);
+        await fs.writeFile(host, "host-v2");
+        await expect(validateCodexAppServerRuntimeArtifact(binding)).resolves.toBe(false);
+      } finally {
+        Object.defineProperty(process, "platform", platform);
+      }
+    });
   });
 
   it("rejects packages beyond the bounded directory depth", async () => {

--- a/extensions/codex/src/app-server/runtime-artifact.ts
+++ b/extensions/codex/src/app-server/runtime-artifact.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/windows-spawn";
 import type { CodexAppServerClient, CodexAppServerRuntimeIdentity } from "./client.js";
 import type { CodexAppServerStartOptions } from "./config.js";
+import { resolvePackagedCodexNativeCommand } from "./managed-binary.js";
 import { resolveCodexAppServerSpawnEnv } from "./transport-stdio.js";
 
 const ARTIFACT_ID_PREFIX = "codex-app-server:v1:";
@@ -561,6 +562,8 @@ async function captureFilesystemDescriptor(params: {
   const spawnCwd = path.resolve(params.startOptions.cwd ?? process.cwd());
   const commandPath = await resolveCommandPath(params.startOptions.command, env, spawnCwd);
   const commandRealPath = await fs.realpath(commandPath);
+  let nativeCommand = params.spawnIdentity.nativeCommand;
+  let nativeCandidate = commandRealPath;
   let invocationPaths: string[];
   if (process.platform === "win32") {
     const program = resolveWindowsSpawnProgram({
@@ -570,11 +573,16 @@ async function captureFilesystemDescriptor(params: {
       execPath: process.execPath,
       packageName: "@openai/codex",
     });
-    if (program.resolution === "node-entrypoint" && !params.spawnIdentity.nativeCommand) {
+    const entrypoint = program.leadingArgv[0];
+    if (program.resolution === "node-entrypoint" && entrypoint && !nativeCommand) {
+      nativeCommand = resolvePackagedCodexNativeCommand(await fs.realpath(entrypoint));
+    }
+    if (program.resolution === "node-entrypoint" && !nativeCommand) {
       throw new Error(
         "Codex runtime cannot attest a custom Node launcher without its native target",
       );
     }
+    nativeCandidate = program.command;
     const invocationCandidates = [commandRealPath, program.command, ...program.leadingArgv];
     invocationPaths = [];
     for (const candidate of invocationCandidates) {
@@ -582,22 +590,21 @@ async function captureFilesystemDescriptor(params: {
       invocationPaths.push(await fs.realpath(resolved));
     }
   } else {
+    nativeCommand ??= resolvePackagedCodexNativeCommand(commandRealPath);
     invocationPaths = await resolvePosixInvocationPaths({
       commandRealPath,
       env,
       cwd: spawnCwd,
-      nativeCommand: params.spawnIdentity.nativeCommand,
+      nativeCommand,
     });
   }
   invocationPaths = [...new Set(invocationPaths)].toSorted(compareArtifactNames);
   if (invocationPaths.length > MAX_ARTIFACT_INVOCATION_PATHS) {
     throw new Error("Codex runtime launcher exceeds the bounded invocation file count");
   }
-  const nativeCandidate = params.spawnIdentity.nativeCommand ?? invocationPaths[0];
-  if (!nativeCandidate) {
-    throw new Error("Codex runtime did not resolve a native executable");
-  }
-  const nativePath = await fs.realpath(await resolveCommandPath(nativeCandidate, env, spawnCwd));
+  const nativePath = await fs.realpath(
+    await resolveCommandPath(nativeCommand ?? nativeCandidate, env, spawnCwd),
+  );
   const packageRoot = await resolvePackageRoot(nativePath);
   const configuredCodeModeHost = readEffectiveSpawnEnvironmentValue(
     env,

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -83,7 +83,8 @@ vi.mock("./auth-bridge.js", () => ({
   resolveCodexAppServerPreparedApiKeyCacheKey: mocks.resolveCodexAppServerPreparedApiKeyCacheKey,
 }));
 
-vi.mock("./managed-binary.js", () => ({
+vi.mock("./managed-binary.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./managed-binary.js")>()),
   isManagedCodexDesktopCommand: mocks.isManagedCodexDesktopCommand,
   resolveManagedCodexAppServerStartOptions: mocks.resolveManagedCodexAppServerStartOptions,
   resolveManagedCodexNativeCommand: mocks.resolveManagedCodexNativeCommand,

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -1075,14 +1075,10 @@ async function startInitializedCodexAppServerClient(params: {
     const runtimeArtifactModule = params.runtimeArtifactMode
       ? await import("./runtime-artifact.js")
       : undefined;
-    const nativeCommandBeforeStart =
-      startOptions.commandSource === "resolved-managed"
-        ? resolveManagedCodexNativeCommand(startOptions.command)
-        : undefined;
     const runtimeArtifactBeforeStart = runtimeArtifactModule
       ? await runtimeArtifactModule.captureCodexAppServerRuntimeArtifactBeforeStart({
           startOptions,
-          spawnIdentity: resolveCodexAppServerSpawnIdentity(startOptions, nativeCommandBeforeStart),
+          spawnIdentity: resolveCodexAppServerSpawnIdentity(startOptions),
           signal: params.runtimeArtifactSignal,
         })
       : undefined;
@@ -1162,14 +1158,10 @@ async function startInitializedCodexAppServerClient(params: {
     let runtimeArtifact: AgentHarnessRuntimeArtifactBinding | undefined;
     try {
       if (runtimeArtifactModule && runtimeArtifactBeforeStart) {
-        const nativeCommand =
-          startOptions.commandSource === "resolved-managed"
-            ? resolveManagedCodexNativeCommand(startOptions.command)
-            : undefined;
         runtimeArtifact = await runtimeArtifactModule.finalizeCodexAppServerRuntimeArtifact({
           before: runtimeArtifactBeforeStart,
           startOptions,
-          spawnIdentity: resolveCodexAppServerSpawnIdentity(startOptions, nativeCommand),
+          spawnIdentity: resolveCodexAppServerSpawnIdentity(startOptions),
           runtimeIdentity: client.getRuntimeIdentity(),
           signal: params.runtimeArtifactSignal,
         });

--- a/src/system-agent/assistant.configured.test.ts
+++ b/src/system-agent/assistant.configured.test.ts
@@ -1,6 +1,8 @@
 // Configured OpenClaw assistant tests cover route-owned, tool-free planning.
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { RunCliAgentParams } from "../agents/cli-runner/types.js";
+import type { RunEmbeddedAgentParams } from "../agents/embedded-agent-runner/run/params.js";
+import { resolveRequestStreamTransportOverrides } from "../agents/embedded-agent-runner/run/runtime-resolution.js";
 import { fingerprintResolvedProviderAuth } from "../agents/execution-auth-binding.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { planSystemAgentCommandWithConfiguredModel } from "./assistant.js";
@@ -404,7 +406,7 @@ describe("OpenClaw configured-model planner", () => {
     );
   });
 
-  it("carries the verified child runtime artifact into planning", async () => {
+  it("keeps the verified child runtime while parsing a JSON plan", async () => {
     const config = {
       agents: {
         list: [
@@ -420,11 +422,11 @@ describe("OpenClaw configured-model planner", () => {
     } satisfies OpenClawConfig;
     const { binding, deps } = await createSystemAgentVerifiedInferenceTestFixture(config);
     useFastVerifiedInference(binding);
-    const runEmbeddedAgent = vi.fn(async () => ({
+    const runEmbeddedAgent = vi.fn(async (_params: RunEmbeddedAgentParams) => ({
       payloads: [{ text: '{"reply":"Ready.","command":"gateway status"}' }],
     }));
 
-    await planSystemAgentCommandWithConfiguredModel({
+    const result = await planSystemAgentCommandWithConfiguredModel({
       input: "is the gateway healthy",
       overview: overview("openai/gpt-5.5"),
       verifiedInference: binding,
@@ -437,6 +439,14 @@ describe("OpenClaw configured-model planner", () => {
       },
     });
 
+    expect(result).toEqual({
+      reply: "Ready.",
+      command: "gateway status",
+      modelLabel: "openai/gpt-5.5",
+    });
+    expect(
+      resolveRequestStreamTransportOverrides(runEmbeddedAgent.mock.calls[0]?.[0]?.streamParams),
+    ).toBeUndefined();
     expect(runEmbeddedAgent).toHaveBeenCalledWith(
       expect.objectContaining({
         agentHarnessRuntimeOverride: "codex",

--- a/src/system-agent/assistant.ts
+++ b/src/system-agent/assistant.ts
@@ -143,6 +143,9 @@ async function runConfiguredSystemAgentText(params: {
   } catch (error) {
     throw new SystemAgentInferenceUnavailableError("planner", [error]);
   }
+  // Provider transport options can select a different runtime. Plugin-owned
+  // inference keeps its verified runtime and uses the JSON prompt/parser contract.
+  const responseFormat = expectedAgentHarnessRuntimeArtifact ? undefined : params.responseFormat;
   const tempDir = await (params.deps?.createTempDir ?? createTempPlannerDir)();
   let text: string | undefined;
   let preparedRunAdmission: ReturnType<typeof prepareSystemAgentRunAdmission> | undefined;
@@ -180,7 +183,7 @@ async function runConfiguredSystemAgentText(params: {
       messageProvider: "openclaw",
       disableTools: true,
       disableTrajectory: true,
-      ...(params.responseFormat ? { streamParams: { responseFormat: params.responseFormat } } : {}),
+      ...(responseFormat ? { streamParams: { responseFormat } } : {}),
       ...(route.authProfileId ? { authProfileId: route.authProfileId } : {}),
     };
     const result =

--- a/ui/src/e2e/inference-setup-gate.e2e.test.ts
+++ b/ui/src/e2e/inference-setup-gate.e2e.test.ts
@@ -127,57 +127,89 @@ suite.define(() => {
     }
   });
 
-  it("distinguishes a configured provider that fails its live check", async () => {
-    const context = await suite.browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1660 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      deferredMethods: ["openclaw.chat"],
-      featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
-      methodResponses: {
-        "agents.list": {
-          agents: [
-            {
-              id: "main",
-              identity: { name: "OpenClaw" },
-              model: { primary: "openai/gpt-5.5" },
-              name: "OpenClaw",
-            },
-          ],
-          defaultId: "main",
-          mainKey: "main",
-          scope: "agent",
+  it.each(["page", "panel"])(
+    "keeps %s history and the runtime error visible until retry succeeds",
+    async (surface) => {
+      const viewport = { height: 900, width: 1660 };
+      const context = await suite.browser.newContext({
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport,
+        ...(process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
+          ? { recordVideo: { dir: proofDir, size: viewport } }
+          : {}),
+      });
+      const page = await context.newPage();
+      const runtimeError =
+        "OpenClaw requires working inference: The configured runtime could not start. Repair the launcher and retry.";
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["openclaw.chat"],
+        featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat", "openclaw.chat.history"],
+        methodResponses: {
+          "openclaw.chat.history": {
+            turns: [
+              {
+                role: "assistant",
+                text: "Your earlier conversation is still here.",
+                at: 1_700_000_101_000,
+              },
+            ],
+          },
         },
-      },
-    });
-
-    try {
-      await page.goto(`${suite.server.baseUrl}custodian`);
-      await gateway.waitForRequest("openclaw.chat");
-      await gateway.rejectDeferred("openclaw.chat", {
-        code: "UNAVAILABLE",
-        details: { code: "system_agent_inference_unavailable" },
-        message: "OpenClaw requires working inference: provider authentication failed",
       });
 
-      await page.getByRole("heading", { name: "Configured AI needs attention" }).waitFor();
-      await expect.poll(() => page.locator(".agent-chat__composer-shell").count()).toBe(0);
-      await expect
-        .poll(() => page.getByRole("button", { name: "Review connection" }).count())
-        .toBe(1);
-      await expect.poll(() => page.getByRole("button", { name: "Retry" }).count()).toBe(1);
-      await captureProof(page, "custodian-provider-unavailable.png");
+      try {
+        await page.goto(`${suite.server.baseUrl}${surface === "page" ? "custodian" : "chat"}`);
+        if (surface === "panel") {
+          await page.locator(".sidebar-issues-button").click();
+          await page.locator(".sidebar-issues-panel__ask").click();
+        }
+        const chat = page.locator("openclaw-custodian-surface");
+        await gateway.waitForRequest("openclaw.chat");
+        await gateway.rejectDeferred("openclaw.chat", {
+          code: "UNAVAILABLE",
+          details: { code: "system_agent_inference_unavailable" },
+          message: runtimeError,
+        });
+        await chat.locator(".custodian__setup-state, .custodian__error").waitFor();
+        await captureProof(page, "01-runtime-error.png");
+        await expect
+          .poll(() => chat.locator(".custodian__error").textContent())
+          .toContain(runtimeError);
+        await chat.getByText("Your earlier conversation is still here.").waitFor();
+        expect(await chat.getByRole("button", { name: "Review connection" }).count()).toBe(0);
+        expect(await chat.locator(".agent-chat__composer-shell").count()).toBe(1);
+        expect(await chat.getByRole("textbox").isDisabled()).toBe(true);
 
-      await page.getByRole("button", { name: "Review connection" }).click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/model-setup");
-      const modelsLink = page.locator('.settings-sidebar__item[href="/settings/model-providers"]');
-      await expect.poll(() => modelsLink.getAttribute("aria-current")).toBe("page");
-    } finally {
-      await context.close();
-    }
-  });
+        await chat.getByRole("button", { name: "Retry", exact: true }).click();
+        const retry = await gateway.waitForRequest("openclaw.chat", { after: 1 });
+        expect(retry.params).not.toHaveProperty("message");
+        expect(await chat.getByRole("textbox").isDisabled()).toBe(true);
+        await gateway.resolveDeferred("openclaw.chat", {
+          sessionId: "runtime-recovered",
+          reply: "Ready to help again.",
+          action: "none",
+        });
+        await chat.getByText("Ready to help again.").waitFor();
+        await expect.poll(() => chat.getByRole("textbox").isEnabled()).toBe(true);
+        expect(await chat.locator(".custodian__error").count()).toBe(0);
+        await captureProof(page, "02-runtime-recovered.png");
+
+        await chat.getByRole("textbox").fill("Check my setup");
+        await chat.getByRole("button", { name: "Send", exact: true }).click();
+        const turn = await gateway.waitForRequest("openclaw.chat", { after: 2 });
+        expect(turn.params).toMatchObject({ message: "Check my setup" });
+        await gateway.resolveDeferred("openclaw.chat", {
+          sessionId: "runtime-recovered",
+          reply: "Your setup is working.",
+          action: "none",
+        });
+        await chat.getByText("Your setup is working.").waitFor();
+        await captureProof(page, "03-user-turn-succeeded.png");
+      } finally {
+        await context.close();
+      }
+    },
+  );
 });

--- a/ui/src/e2e/inference-setup-gate.e2e.test.ts
+++ b/ui/src/e2e/inference-setup-gate.e2e.test.ts
@@ -182,6 +182,8 @@ suite.define(() => {
         expect(await chat.locator(".agent-chat__composer-shell").count()).toBe(1);
         expect(await chat.getByRole("textbox").isDisabled()).toBe(true);
 
+        // Each deferral is consumed by one request, including the failed startup check.
+        await gateway.deferNext("openclaw.chat");
         await chat.getByRole("button", { name: "Retry", exact: true }).click();
         const retry = await gateway.waitForRequest("openclaw.chat", { after: 1 });
         expect(retry.params).not.toHaveProperty("message");
@@ -196,6 +198,7 @@ suite.define(() => {
         expect(await chat.locator(".custodian__error").count()).toBe(0);
         await captureProof(page, "02-runtime-recovered.png");
 
+        await gateway.deferNext("openclaw.chat", { message: "Check my setup" });
         await chat.getByRole("textbox").fill("Check my setup");
         await chat.getByRole("button", { name: "Send", exact: true }).click();
         const turn = await gateway.waitForRequest("openclaw.chat", { after: 2 });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2819,11 +2819,6 @@ export const en: TranslationMap = {
       body: "We couldn't find a provider and model configured for this agent. Choose a supported connection; OpenClaw will test it before enabling chat.",
       action: "Connect an AI provider",
     },
-    connectionFailure: {
-      title: "Configured AI needs attention",
-      body: "OpenClaw found the provider and model selected for this agent, but the live check failed. Your configuration is still intact. Review the credential, model access, or provider status, then verify again.",
-      action: "Review connection",
-    },
     loading: "Checking this Gateway for available AI access…",
     testing: "Testing — asking the selected model for a quick reply…",
     retry: "Retry",

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -451,14 +451,13 @@ describe("custodian page", () => {
     expect(replacementRequest).not.toHaveBeenCalled();
   });
 
-  it("keeps loaded transcript rows when a welcome retry cannot refresh them", async () => {
+  it("keeps loaded transcript rows while retrying the welcome without reloading history", async () => {
     const request = vi
       .fn()
       .mockResolvedValueOnce({
         turns: [{ role: "assistant", text: "Loaded transcript row", at: 1 }],
       })
       .mockRejectedValueOnce(new Error("temporary welcome failure"))
-      .mockRejectedValueOnce(new Error("temporary history failure"))
       .mockResolvedValueOnce({
         sessionId: "engine-session-after-retry",
         reply: "Recovered welcome.",
@@ -474,7 +473,6 @@ describe("custodian page", () => {
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "openclaw.chat.history",
       "openclaw.chat",
-      "openclaw.chat.history",
       "openclaw.chat",
     ]);
     expect(page.textContent).toContain("Loaded transcript row");

--- a/ui/src/pages/custodian/custodian-session-store.test.ts
+++ b/ui/src/pages/custodian/custodian-session-store.test.ts
@@ -418,34 +418,74 @@ describe("CustodianSessionStore", () => {
     expect(store.messages.at(-1)?.text).toBe("Ready.");
   });
 
-  it("blocks messages until inference setup succeeds", async () => {
+  it.each([
+    new GatewayRequestError({
+      code: "UNAVAILABLE",
+      message: "The configured runtime could not start. Repair the launcher and retry.",
+      details: { code: "system_agent_inference_unavailable" },
+    }),
+    new Error("The greeting could not start. Retry after repairing the runtime."),
+  ])(
+    "keeps startup failures in the conversation and blocks sends until verified: %s",
+    async (error) => {
+      const request = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce({
+        sessionId: "shared-session",
+        reply: "Ready.",
+        action: "none",
+      });
+      const { context } = createContext(request);
+      const store = new CustodianSessionStore();
+
+      store.connect(context, "caretaker");
+      await waitForFast(() => expect(store.error).toBe(error.message));
+      expect(store.setupRequired).toBe(false);
+      await expect(store.send("should not send")).resolves.toBe("rejected");
+      expect(request).toHaveBeenCalledOnce();
+
+      store.setInput("Keep my draft");
+      store.retry();
+      await waitForFast(() => expect(store.messages.at(-1)?.text).toBe("Ready."));
+      expect(store.input).toBe("Keep my draft");
+      expect(request.mock.calls[1]?.[1]).not.toHaveProperty("message");
+      expect(store.error).toBeNull();
+    },
+  );
+
+  it("rechecks failed inference without replaying a user turn", async () => {
     const request = vi
       .fn()
+      .mockResolvedValueOnce({
+        sessionId: "shared-session",
+        reply: "Ready.",
+        action: "none",
+      })
       .mockRejectedValueOnce(
         new GatewayRequestError({
           code: "UNAVAILABLE",
-          message: "OpenClaw requires working inference: no configured model",
+          message: "Runtime verification failed.",
           details: { code: "system_agent_inference_unavailable" },
         }),
       )
       .mockResolvedValueOnce({
         sessionId: "shared-session",
-        reply: "Ready.",
+        reply: "Recovered.",
         action: "none",
       });
     const { context } = createContext(request);
     const store = new CustodianSessionStore();
-
     store.connect(context, "caretaker");
-    await waitForFast(() => expect(store.setupRequired).toBe(true));
-    expect(store.setupIssue).toBe("unavailable");
-
-    await expect(store.send("should not send")).resolves.toBe("rejected");
-    expect(request).toHaveBeenCalledOnce();
-
+    await waitForFast(() => expect(store.sending).toBe(false));
+    await store.send("Check this system");
+    expect(store.error).toBe("Runtime verification failed.");
+    expect(store.messages.map((message) => message.text)).toContain("Check this system");
+    await expect(store.send("Do not send yet")).resolves.toBe("rejected");
+    store.setInput("Next question");
     store.retry();
-    await waitForFast(() => expect(store.setupRequired).toBe(false));
-    await waitForFast(() => expect(store.messages.at(-1)?.text).toBe("Ready."));
+    await waitForFast(() => expect(store.messages.at(-1)?.text).toBe("Recovered."));
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(request.mock.calls[2]?.[1]).not.toHaveProperty("message");
+    expect(store.messages.map((message) => message.text)).toContain("Check this system");
+    expect(store.input).toBe("Next question");
   });
 
   it("shows setup before starting chat when the default agent has no model", async () => {
@@ -463,7 +503,6 @@ describe("CustodianSessionStore", () => {
     store.connect(context, "caretaker");
 
     expect(store.setupRequired).toBe(true);
-    expect(store.setupIssue).toBe("missing");
     expect(store.sending).toBe(false);
     expect(request).not.toHaveBeenCalled();
     await expect(store.send("should not send")).resolves.toBe("rejected");

--- a/ui/src/pages/custodian/custodian-session-store.ts
+++ b/ui/src/pages/custodian/custodian-session-store.ts
@@ -44,7 +44,6 @@ const SYSTEM_AGENT_CHAT_TIMEOUT_MS = 190_000;
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
 
 type StoreListener = () => void;
-type CustodianSetupIssue = "missing" | "unavailable";
 
 /** One process-local conversation owner shared by the full page and dock surface. */
 export class CustodianSessionStore {
@@ -58,7 +57,6 @@ export class CustodianSessionStore {
   questionReplyUncertain = false;
   error: string | null = null;
   transcript = new CustodianTranscriptLoader(() => this.emit());
-  setupIssue: CustodianSetupIssue | null = null;
   dismissedQuestions = new Set<string>();
   answeredQuestions = new Set<string>();
   activeClient: GatewayBrowserClient | null = null;
@@ -69,6 +67,7 @@ export class CustodianSessionStore {
   earlierBoundaryAfterId: number | null = null;
   abandonedTurnOutcomeUnknown = false;
 
+  private inferenceState: "unverified" | "ready" = "unverified";
   private context: ApplicationContext | null = null;
   private variant: CustodianSessionVariant = "caretaker";
   private sessionVariant: CustodianSessionVariant | null = null;
@@ -190,7 +189,17 @@ export class CustodianSessionStore {
   }
 
   get setupRequired(): boolean {
-    return this.setupIssue !== null;
+    return this.configuredInferenceState === "required";
+  }
+
+  get canSend(): boolean {
+    return (
+      this.activeClient !== null &&
+      this.chatAvailable &&
+      !this.sending &&
+      this.configuredInferenceState === "ready" &&
+      this.inferenceState === "ready"
+    );
   }
 
   get wizardCancelAvailable(): boolean {
@@ -201,7 +210,7 @@ export class CustodianSessionStore {
     const client = this.activeClient;
     const params = this.retryParams;
     if (client && params && !hasCustodianUserInput(params) && this.chatAvailable && !this.sending) {
-      void this.initializeSession(client, params);
+      void this.initializeSession(client, params, false);
     }
   }
 
@@ -213,7 +222,7 @@ export class CustodianSessionStore {
     // Trim decides emptiness only; sensitive values may carry meaningful whitespace.
     const message = this.sensitive ? text : text.trim();
     const client = this.activeClient;
-    if (!message.trim() || !client || !this.chatAvailable || this.sending || this.setupRequired) {
+    if (!message.trim() || !client || !this.canSend) {
       this.emit();
       return "rejected";
     }
@@ -338,7 +347,7 @@ export class CustodianSessionStore {
     }
     const submission = custodianWizardSubmission(message.step, value);
     const client = this.activeClient;
-    if (!submission || !client || !this.chatAvailable || this.sending || this.setupRequired) {
+    if (!submission || !client || !this.canSend) {
       this.emit();
       return;
     }
@@ -358,10 +367,8 @@ export class CustodianSessionStore {
       !step ||
       !this.wizardInputPending ||
       !client ||
-      !this.chatAvailable ||
-      !this.wizardCancelAvailable ||
-      this.sending ||
-      this.setupRequired
+      !this.canSend ||
+      !this.wizardCancelAvailable
     ) {
       this.emit();
       return;
@@ -457,7 +464,6 @@ export class CustodianSessionStore {
     this.wizardSecretVisible = false;
     this.sensitive = this.wizardInputPending = this.questionReplyUncertain = false;
     this.error = null;
-    this.setupIssue = null;
     this.earlierBoundaryAfterId = this.messages.at(-1)?.id ?? null;
     this.startSession(client, variant, false);
   }
@@ -565,11 +571,7 @@ export class CustodianSessionStore {
     if (configuredInferenceState === "required") {
       this.sessionStarted = false;
       this.clearConversation();
-      this.setupIssue = "missing";
       return;
-    }
-    if (inferenceStateChanged) {
-      this.setupIssue = null;
     }
     if (this.sessionStarted) {
       if (!this.retryParams) {
@@ -588,6 +590,7 @@ export class CustodianSessionStore {
   ): Promise<void> {
     const epoch = this.advanceRequestEpoch();
     this.sending = true;
+    this.inferenceState = "unverified";
     this.error = null;
     this.retryParams = params;
     this.emit();
@@ -634,7 +637,7 @@ export class CustodianSessionStore {
     this.retryParams = null;
     this.error = null;
     this.transcript.reset();
-    this.setupIssue = null;
+    this.inferenceState = "unverified";
     this.input = "";
     [this.wizardValue, this.wizardSecretVisible] = [undefined, false];
     this.sensitive = this.wizardInputPending = this.questionReplyUncertain = false;
@@ -663,9 +666,6 @@ export class CustodianSessionStore {
     let delivery: eventNudgeState.CustodianSendDelivery = "unsent";
     this.sending = true;
     this.error = null;
-    if (hasCustodianUserInput(params)) {
-      this.setupIssue = null;
-    }
     this.retryParams = params;
     this.emit();
     try {
@@ -682,7 +682,7 @@ export class CustodianSessionStore {
       this.sensitive = result.sensitive === true;
       this.wizardInputPending = result.wizardInputPending === true;
       this.retryParams = null;
-      this.setupIssue = null;
+      this.inferenceState = "ready";
       const step = result.step ?? null;
       const question = step ? null : parseCustodianQuestion(result.question);
       if (this.rejoinBarrierPending && !hasCustodianUserInput(params)) {
@@ -728,12 +728,11 @@ export class CustodianSessionStore {
         this.error = custodianErrorMessage(error);
         const details =
           error && typeof error === "object" ? (error as { details?: unknown }).details : undefined;
-        this.setupIssue =
-          readSystemAgentInferenceUnavailableErrorDetails(details) !== undefined
-            ? this.configuredInferenceState === "required"
-              ? "missing"
-              : "unavailable"
-            : null;
+        if (readSystemAgentInferenceUnavailableErrorDetails(details)) {
+          this.inferenceState = "unverified";
+          // Recheck the runtime without replaying a user turn that may have reached the Gateway.
+          this.retryParams = { sessionId: this.sessionId, ...custodianChatParams(this.variant) };
+        }
         const sessionInvalidated = isCustodianSessionInvalidatedError(error);
         if (sessionInvalidated && hasCustodianUserInput(params)) {
           // Retained transcript rows are display context only; the next turn needs a fresh id.

--- a/ui/src/pages/custodian/custodian-surface.ts
+++ b/ui/src/pages/custodian/custodian-surface.ts
@@ -88,12 +88,7 @@ class CustodianSurface extends OpenClawLightDomElement {
 
   override updated(): void {
     const store = this.store;
-    if (
-      store.chatAvailable &&
-      !store.sending &&
-      !store.hasUnresolvedQuestion() &&
-      !store.setupRequired
-    ) {
+    if (store.canSend && !store.hasUnresolvedQuestion()) {
       custodianAlertStore.askIfReady((question) => void store.send(question));
     }
     const transcript = this.querySelector<HTMLElement>(".custodian__messages");
@@ -143,7 +138,6 @@ class CustodianSurface extends OpenClawLightDomElement {
         })
       : nothing;
     if (store.setupRequired) {
-      const unavailable = store.setupIssue === "unavailable";
       return html`
         <section
           class="custodian-surface custodian-surface--setup-required ${this.compact
@@ -153,30 +147,12 @@ class CustodianSurface extends OpenClawLightDomElement {
           ${alertCard}
           <div class="custodian__setup-state" role="alert">
             <openclaw-mascot mood="idle" .size=${this.compact ? 72 : 96}></openclaw-mascot>
-            <h2>
-              ${t(unavailable ? "modelSetup.connectionFailure.title" : "modelSetup.required.title")}
-            </h2>
-            <p>
-              ${t(unavailable ? "modelSetup.connectionFailure.body" : "modelSetup.required.body")}
-            </p>
+            <h2>${t("modelSetup.required.title")}</h2>
+            <p>${t("modelSetup.required.body")}</p>
             <div class="custodian__setup-actions">
               <button class="btn primary" type="button" @click=${() => store.openModelSetup()}>
-                ${t(
-                  unavailable
-                    ? "modelSetup.connectionFailure.action"
-                    : "modelSetup.required.action",
-                )}
+                ${t("modelSetup.required.action")}
               </button>
-              ${store.activeClient && store.chatAvailable && store.canRetry()
-                ? html`<button
-                    class="btn"
-                    type="button"
-                    ?disabled=${store.sending}
-                    @click=${() => store.retry()}
-                  >
-                    ${t("common.retry")}
-                  </button>`
-                : nothing}
             </div>
           </div>
         </section>
@@ -216,12 +192,7 @@ class CustodianSurface extends OpenClawLightDomElement {
           ${!this.onboarding && store.eventNudge && !store.eventNudgePending
             ? eventNudgeState.renderCustodianEventNudge({
                 nudge: store.eventNudge,
-                disabled:
-                  !store.activeClient ||
-                  !store.chatAvailable ||
-                  store.sending ||
-                  store.sensitive ||
-                  store.hasUnresolvedQuestion(),
+                disabled: !store.canSend || store.sensitive || store.hasUnresolvedQuestion(),
                 onSend: () => void store.sendEventNudge(),
                 onDismiss: () => store.dismissEventNudge(),
               })
@@ -235,13 +206,12 @@ class CustodianSurface extends OpenClawLightDomElement {
               boundaryAfterId: store.earlierBoundaryAfterId,
               assistantAvatar,
               showQuestion,
-              questionDisabled:
-                store.sending || !store.chatAvailable || store.answeredQuestions.has(questionKey),
+              questionDisabled: !store.canSend || store.answeredQuestions.has(questionKey),
               onSelect: (label) => store.answerQuestion(message, label),
               onSkip: () => void store.dismissQuestion(message),
               showWizardStep: message === activeWizardMessage,
               wizardValue: store.wizardValue,
-              wizardDisabled: store.sending || !store.chatAvailable,
+              wizardDisabled: !store.canSend,
               wizardSecretVisible: store.wizardSecretVisible,
               onWizardValueChange: (value) => store.setWizardValue(value),
               onWizardAnswer: (value) => store.answerWizardStep(message, value),
@@ -299,10 +269,7 @@ class CustodianSurface extends OpenClawLightDomElement {
                           autocomplete="off"
                           placeholder=${t("custodian.sensitivePlaceholder")}
                           aria-label=${t("custodian.sensitivePlaceholder")}
-                          ?disabled=${!store.activeClient ||
-                          !store.chatAvailable ||
-                          store.sending ||
-                          store.setupRequired}
+                          ?disabled=${!store.canSend}
                           @input=${(event: Event) =>
                             store.setInput((event.target as HTMLInputElement).value)}
                           @keydown=${(event: KeyboardEvent) => this.handleComposerKeydown(event)}
@@ -313,10 +280,7 @@ class CustodianSurface extends OpenClawLightDomElement {
                           autocomplete="on"
                           placeholder=${t("custodian.placeholder")}
                           aria-label=${t("custodian.placeholder")}
-                          ?disabled=${!store.activeClient ||
-                          !store.chatAvailable ||
-                          store.sending ||
-                          store.setupRequired}
+                          ?disabled=${!store.canSend}
                           @input=${(event: Event) =>
                             store.setInput((event.target as HTMLTextAreaElement).value)}
                           @keydown=${(event: KeyboardEvent) => this.handleComposerKeydown(event)}
@@ -327,11 +291,7 @@ class CustodianSurface extends OpenClawLightDomElement {
                       class="chat-send-btn"
                       type="button"
                       aria-label=${t("custodian.send")}
-                      ?disabled=${!store.input.trim() ||
-                      !store.activeClient ||
-                      !store.chatAvailable ||
-                      store.sending ||
-                      store.setupRequired}
+                      ?disabled=${!store.input.trim() || !store.canSend}
                       @click=${() => void store.send()}
                     >
                       ${icons.arrowUp}


### PR DESCRIPTION
Closes #134727

## What Problem This Solves

Ask OpenClaw could reject an explicitly configured official Codex npm launcher, then replace the entire conversation with a generic “Review connection” screen. The actual runtime error and existing history were hidden even though the provider and model were configured. Repairing the launcher and clicking Retry could then appear successful while the next message failed on a stale native session binding.

## Why This Change Was Made

The Codex plugin now attests the native executable selected by the official npm entrypoint, including configured paths, PATH commands, symlinks, and Windows launchers. Arbitrary scripts remain rejected. One resolver follows Codex’s platform-package precedence; Windows attestation tracks the executable rather than whichever invocation path sorts first. Duplicate native-resolution calls are removed.

Ask OpenClaw reserves the setup screen for missing configuration. Runtime failures use the existing inline error and Retry controls, retaining history and drafts. One readiness state gates all send actions; Retry initializes without replaying input or reloading history.

Codex session authority now uses the same durable-row classification for default and explicitly selected stores. Temporary conversations use their own physical session bindings instead of inheriting older stable-key fences; stale durable generations still fail closed. The planner also keeps its verified plugin runtime instead of injecting optional provider transport formatting that selects a different runtime. Its existing JSON prompt/parser remains authoritative; built-in and CLI formatting is preserved.

## User Impact

Explicit official npm installations work. Real inference failures leave the full page and docked panel readable, show the actual error, and allow repair followed by Retry. Sending remains disabled until verification succeeds, and the next user turn works after a Gateway restart.

## Evidence

617 Codex session/harness tests across all 20 shared-fixture consumers passed, along with 219 focused launcher/UI unit tests, 16 planner/parser tests, and all 5 inference setup/recovery browser scenarios. Regression cases failed on pre-fix code for the official launcher, full-page/panel error visibility, sequential default-store generations, and planner transport selection. Full production/UI builds and i18n verification/baseline checks passed.

[Real-flow evidence and captures](https://github.com/openclaw/openclaw/pull/134776#issuecomment-5489076277): an isolated Gateway using official npm Codex 0.151.0 and `openai/gpt-5.6-luna` returned an initial real reply, preserved history during an intentional launcher failure, recovered with an input-free Retry after restart, and returned the next real reply without duplicating input. The normal command owner also completed a real planner turn through the verified Codex runtime and parsed its JSON reply. No production Gateway restart was needed for proof.

Independent Codex review completed with no accepted actionable findings. The first CI run exposed a one-shot mock deferral in the browser fixture; explicit deferral now covers Retry and Send without changing assertions. Session fixtures now model actual durable/in-memory owners and unique physical conversations while retaining auth, concurrency, and cleanup checks. [Final-head CI](https://github.com/openclaw/openclaw/actions/runs/33472157173) passed: 207 successful jobs, 12 intentional skips, no failures.

Production: +86/-122 (net **-36**). Tests/support: +424/-149. Docs: +7/-1.

No new configuration, schema, or protocol surface. The repair reuses existing runtime attestation, session-authority, and inline-error owners.

Dependency contract inspected directly: Codex `codex-cli/bin/codex.js:78–110` selects the platform package before checking its executable, and `:195–198` spawns that executable; `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:62–154` and `turn.rs:152–240` define native thread/turn requests. UI regression provenance is patch-verified in #115716 (`cc6b766079c7`, authored and merged by @vincentkoc). The incomplete explicit-store predicate is patch-verified in #115601 (`fed427a50ede`, authored and merged by @steipete). Launcher rejection predates the available history boundary; its introduction remains unknown.

ClawSweeper’s requested after-fix visual evidence is supplied below and in the linked proof comment.

![Before: a runtime failure replaces the conversation with a generic setup screen](https://github.com/user-attachments/assets/3502e3da-1d96-4eb3-81be-442294a7a1a8)

![After: runtime error and Retry alongside retained conversation](https://github.com/user-attachments/assets/0eb415a3-ccd8-4d9d-9420-0815c9eff058)

![After: the docked panel retains history and shows the runtime error](https://github.com/user-attachments/assets/8643c10a-9052-4610-8ddb-585ef1ee15ea)
