### PR TITLE
fix(pr): recover merges invoked from another checkout

### DIFF
--- a/scripts/pr-lib/process-group-runner.mjs
+++ b/scripts/pr-lib/process-group-runner.mjs
@@ -21,9 +21,9 @@ if (process.platform === "win32") {
 }
 
 const repoRoot = resolve(repoRootArg);
-const invocationCwd = process.cwd();
 // The supervisor must not retain a cwd inside a worktree the operation may
-// delete; only the child keeps the caller's original cwd.
+// delete. Start the child in this same owner so early Git/gh reads use the
+// repository selected by the wrapper, before any PR worktree is entered.
 process.chdir(repoRoot);
 const lockScript = fileURLToPath(new URL("./operation-lock.sh", import.meta.url));
 const lockSnapshotDir = mkdtempSync(join(tmpdir(), "openclaw-pr-lock-release-"));
@@ -208,7 +208,7 @@ const gitConfigParameters = [
   .join(" ");
 
 const child = spawn(script, args, {
-  cwd: invocationCwd,
+  cwd: repoRoot,
   detached: true,
   env: {
     ...process.env,

--- a/scripts/pr-lib/review.sh
+++ b/scripts/pr-lib/review.sh
@@ -307,13 +307,10 @@ review_tests() {
 
 review_init() {
   local pr="$1"
-  local root json pr_url
-  root=$(repo_root) || return 1
+  local json pr_url
   # Metadata reads are read-only, so fetching before the side-effect marker keeps a
-  # transient GitHub failure inside the lock's auto-release window. Command substitution
-  # is already a subshell, so this cd gives gh its repo context without moving the
-  # caller - enter_worktree still reports the real invocation cwd.
-  json=$(cd "$root" && pr_meta_json "$pr") || return 1
+  # transient GitHub failure inside the lock's auto-release window.
+  json=$(pr_meta_json "$pr") || return 1
 
   enter_worktree "$pr" true || return 1
   write_pr_meta_files "$json"

--- a/test/scripts/pr-cross-checkout.test.ts
+++ b/test/scripts/pr-cross-checkout.test.ts
@@ -1,0 +1,235 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import { delimiter, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+import { copyPrWrapperSources } from "./pr-wrapper.test-support.js";
+
+const temps = useAutoCleanupTempDirTracker(afterEach);
+const outcomeRef = "refs/openclaw/pr-merge-outcomes/123";
+const lockRef = "refs/openclaw/pr-operation-locks/123";
+const describePosix = process.platform === "win32" ? describe.skip : describe;
+
+function fixture() {
+  const root = realpathSync(temps.make("pr-cross-checkout-"));
+  const owner = join(root, "owner");
+  const caller = join(root, "caller");
+  const bin = join(root, "bin");
+  for (const dir of [owner, caller, bin]) mkdirSync(dir);
+  const env = {
+    HOME: root,
+    TMPDIR: root,
+    PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_ALLOW_PROTOCOL: "file",
+  };
+  const git = (repo: string, args: string[], input?: string) =>
+    execFileSync("git", ["-C", repo, ...args], {
+      env,
+      input,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  for (const repo of [owner, caller]) {
+    git(repo, ["init", "-q", "-b", "main"]);
+    git(repo, ["config", "user.name", "Fixture"]);
+    git(repo, ["config", "user.email", "fixture@example.invalid"]);
+    git(repo, ["config", "core.hooksPath", "/dev/null"]);
+    git(repo, ["config", "commit.gpgsign", "false"]);
+    git(repo, ["commit", "--allow-empty", "-qm", "Base"]);
+  }
+  copyPrWrapperSources(owner);
+  const base = git(owner, ["rev-parse", "HEAD"]);
+  const blob = git(owner, ["hash-object", "-w", "--stdin"], "reviewed change\n");
+  const tree = git(owner, ["mktree"], `100644 blob ${blob}\towner.txt\n`);
+  const head = git(owner, ["commit-tree", tree, "-p", base], "Source\n");
+  const landed = git(owner, ["commit-tree", tree, "-p", base], "Landed\n");
+  git(owner, ["update-ref", "refs/heads/main", landed]);
+  git(owner, ["remote", "add", "origin", owner]);
+  const worktree = join(owner, ".worktrees/pr-123");
+  git(owner, ["worktree", "add", "-q", "--detach", worktree, head]);
+  mkdirSync(join(worktree, ".local"));
+  const capture = join(worktree, ".local/merge-output.log");
+  writeFileSync(capture, "retained capture\n");
+  const repo = { id: 123, nameWithOwner: "fixture/repo", url: "https://github.com/fixture/repo" };
+  const record = {
+    version: 1,
+    repo,
+    pr: 123,
+    prId: "fixture-pr",
+    base: "main",
+    head,
+    main: base,
+    method: "squash",
+    route: "immediate",
+    attempt: "11111111-2222-4333-8444-555555555555",
+    phase: "intent",
+    accepted: true,
+    landed: null,
+  };
+  const recordBlob = git(owner, ["hash-object", "-w", "--stdin"], JSON.stringify(record));
+  const recordTree = git(owner, ["mktree"], `100644 blob ${recordBlob}\toutcome.json\n`);
+  const intent = git(owner, ["commit-tree", recordTree, "-p", head, "-p", base], "Intent\n");
+  git(owner, ["update-ref", outcomeRef, intent]);
+  const response = {
+    data: {
+      repository: {
+        ...repo,
+        ref: { target: { oid: landed } },
+        pullRequest: {
+          id: record.prId,
+          number: 123,
+          url: `${repo.url}/pull/123`,
+          state: "MERGED",
+          headRefOid: head,
+          baseRefName: "main",
+          isDraft: false,
+          mergeCommit: { oid: landed },
+          autoMergeRequest: null,
+          isInMergeQueue: false,
+          isMergeQueueEnabled: false,
+          mergeable: "UNKNOWN",
+          mergeStateStatus: "UNKNOWN",
+        },
+      },
+    },
+  };
+  const calls = join(root, "calls.log");
+  const gh = join(bin, "gh");
+  writeFileSync(
+    gh,
+    `#!/bin/sh
+printf '%s\\t%s\\n' "$(git rev-parse --show-toplevel)" "$*" >> '${calls}'
+case "$1 $2" in
+  "repo view") printf '%s\\n' '${JSON.stringify(repo)}' ;;
+  "api graphql") printf '%s\\n' '${JSON.stringify(response)}' ;;
+  "pr view")
+    if [ "$(git rev-parse --show-toplevel)" = '${owner}' ]; then
+      printf '%s\\n' '{"baseRefName":"owner-release","headRefOid":""}'
+    else
+      printf '%s\\n' '{"baseRefName":"caller-release","headRefOid":""}'
+    fi ;;
+  *) echo "Unexpected GitHub operation: $*" >&2; exit 99 ;;
+esac
+`,
+  );
+  chmodSync(gh, 0o755);
+  const run = (cwd = caller, args = ["merge-run", "123"]) => {
+    const result = spawnSync(join(owner, "scripts/pr"), args, {
+      cwd,
+      env,
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    return { ...result, output: result.stdout + result.stderr };
+  };
+  const readCalls = () => readFileSync(calls, "utf8").trim().split("\n");
+  return {
+    root,
+    owner,
+    caller,
+    worktree,
+    capture,
+    head,
+    landed,
+    intent,
+    record,
+    git,
+    run,
+    readCalls,
+  };
+}
+
+describePosix("native PR wrapper repository ownership", () => {
+  it.each(["foreign", "foreign with outcome", "linked", "non-Git"])(
+    "reconciles the owner's accepted intent from a %s caller without redispatch or cleanup",
+    (location) => {
+      const f = fixture();
+      let cwd = f.caller;
+      if (location === "foreign with outcome") {
+        // A same-number record in another clone must never become recovery authority.
+        f.git(f.caller, ["update-ref", outcomeRef, f.git(f.caller, ["rev-parse", "HEAD"])]);
+      } else if (location === "linked") {
+        cwd = f.worktree;
+      } else if (location === "non-Git") {
+        cwd = f.root;
+      }
+      const callerRefs = f.git(f.caller, ["show-ref"]);
+      const result = f.run(cwd);
+
+      expect(result.status, result.output).toBe(0);
+      expect(result.output).toContain(`MERGED exact attempted head ${f.head} as ${f.landed}`);
+      expect(result.output).toContain("completion pending");
+      expect(JSON.parse(f.git(f.owner, ["show", `${outcomeRef}:outcome.json`]))).toEqual({
+        ...f.record,
+        phase: "merged",
+        landed: f.landed,
+      });
+      f.git(f.owner, ["merge-base", "--is-ancestor", f.intent, outcomeRef]);
+      expect(readFileSync(f.capture, "utf8")).toBe("retained capture\n");
+      expect(f.git(f.caller, ["show-ref"])).toBe(callerRefs);
+      expect(f.git(f.owner, ["for-each-ref", "--format=%(refname)", lockRef])).toBe("");
+      expect(f.readCalls()).toHaveLength(3);
+      expect(f.readCalls().every((call) => call.startsWith(`${f.owner}\t`))).toBe(true);
+      expect(f.readCalls().some((call) => call.includes("pr merge") || call.includes("POST"))).toBe(
+        false,
+      );
+    },
+  );
+
+  it("reconciles from another clone after the disposable worktree is gone", () => {
+    const f = fixture();
+    f.git(f.owner, ["worktree", "remove", "--force", f.worktree]);
+    const result = f.run();
+    expect(result.status, result.output).toBe(0);
+    expect(result.output).toContain("completion pending");
+    expect(existsSync(f.worktree)).toBe(false);
+    expect(f.git(f.caller, ["for-each-ref", "--format=%(refname)", "refs/openclaw"])).toBe("");
+  });
+
+  it("rejects corrupt owner evidence even when the caller has a valid retained intent", () => {
+    const f = fixture();
+    f.git(f.caller, ["fetch", f.owner, `${outcomeRef}:${outcomeRef}`]);
+    f.git(f.owner, ["update-ref", outcomeRef, f.head]);
+    const result = f.run();
+    expect(result.status, result.output).toBe(1);
+    expect(result.output).toContain("corrupt or mismatched retained record");
+    expect(f.git(f.owner, ["rev-parse", outcomeRef])).toBe(f.head);
+    expect(f.git(f.caller, ["rev-parse", outcomeRef])).toBe(f.intent);
+    expect(readFileSync(f.capture, "utf8")).toBe("retained capture\n");
+    expect(f.readCalls()).toEqual([`${f.owner}\trepo view --json id,nameWithOwner,url`]);
+  });
+
+  it.each(["prepare-run", "merge-recover", "ci-dispatch", "review-init"])(
+    "uses owner repository metadata for early %s validation",
+    (command) => {
+      const f = fixture();
+      const result = f.run(f.caller, [
+        command,
+        "123",
+        ...(command === "merge-recover" ? [f.intent, "--confirmed-operator-recovery"] : []),
+      ]);
+      expect(result.status, result.output).toBe(1);
+      expect(result.output).toContain(
+        command === "ci-dispatch"
+          ? "missing remote headRefName/headRefOid metadata"
+          : command === "review-init"
+            ? "did not include a head SHA"
+            : "targets owner-release",
+      );
+      expect(f.readCalls()).toHaveLength(1);
+      expect(f.readCalls()[0]).toContain(`${f.owner}\tpr view 123 --json `);
+      expect(f.git(f.owner, ["rev-parse", outcomeRef])).toBe(f.intent);
+      expect(f.git(f.owner, ["for-each-ref", "--format=%(refname)", lockRef])).toBe("");
+      expect(f.git(f.caller, ["for-each-ref", "--format=%(refname)", "refs/openclaw"])).toBe("");
+    },
+  );
+});

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -1911,10 +1911,10 @@ describePosix("scripts/pr per-PR operation lock", () => {
       if (failure === "merge") {
         expect(result.status, output).toBe(1);
         expect(output).toContain("fixture merge failed");
-        expect(events).toBe(`invocation\t${worktreeDir}\n`);
+        expect(events).toBe(`invocation\t${repoDir}\n`);
       } else {
         const completedEvents =
-          command === "gc" ? "removed\n" : `invocation\t${worktreeDir}\nmerged\ncomment\nremoved\n`;
+          command === "gc" ? "removed\n" : `invocation\t${repoDir}\nmerged\ncomment\nremoved\n`;
         expect(events, output).toBe(completedEvents + (failure === "none" ? "released\n" : ""));
         expect(readFileSync(releaseCwd, "utf8").trim(), output).toBe(repoDir);
         expect(result.status, output).toBe(failure === "none" ? 0 : 1);


### PR DESCRIPTION
Closes #134701

## What Problem This Solves

Fixes an issue where maintainers invoking an absolute native PR wrapper from another clone would receive a false missing-outcome error during merge recovery. Related: #134311 (already-merged Chutes/Cerebras pricing work that exposed the wrapper defect).

## Why This Change Was Made

Start the supervised command in the canonical repository already selected by the wrapper, so early Git/GitHub reads, retained outcomes, operation locks, and worktree placement share one owner. Remove the redundant `review-init` metadata context switch. Recovery still runs before disposable worktree entry and retains every existing uncertainty guard.

A merge-only `git -C` patch would leave early prepare checks and CI dispatch inconsistent; entering the PR worktree before recovery would break recovery after that worktree has been removed. No path override, duplicated state, new fallback, or schema change is introduced.

## User Impact

Maintainers can reconcile a retained merge from another clone or a non-Git directory using the owner's absolute wrapper path. Early prepare/recovery checks and CI-dispatch metadata use that same repository. No bot/runtime behavior changes.

## Evidence

Before editing, a native two-repository reproduction failed from A with `prior merge output exists without an outcome record`, while the same command from B reconciled its accepted intent. Only synthetic refs, captures, and worktrees were used; the original pricing PR recovery state remains untouched.

New native-entrypoint tests cover independent clones, a conflicting caller outcome, linked callers, non-Git callers, missing disposable worktrees, corrupt owner evidence, and early prepare/recovery/review/CI-dispatch reads. They verify retained ancestry, unchanged captures/caller refs, no redispatch or completion POST, and process-lock release.

The focused wrapper run passed: **8 files, 416 tests passed, 1 Linux-only zombie-process test skipped on macOS** (cross-checkout, operation-lock, merge-outcome, wrapper trust, metadata, main-refresh, worktree evidence, and containment). All ten new boundary cases passed.

The changed-files gate passed on Testbox ([run 33464205264](https://github.com/openclaw/openclaw/actions/runs/33464205264)), including repository guards, formatting, root test typechecking, coercion checks, and scripts lint. Isolated Codex autoreview reported no accepted/actionable findings at its default blocking priority.

Production: +6/-9 lines (net -3). Tests: +237/-2 lines, including ten new native-boundary cases. No dependencies, configuration, persisted record format, or merge admission rules change.

Proof boundary: these tests execute the real native wrapper, process supervisor, Git refs, and worktrees with synthetic data; GitHub responses are stubbed. They do not replay or mutate any real pricing-PR recovery state.
