### PR TITLE
fix(copilot): authenticate azure byok proxy requests

### DIFF
--- a/extensions/copilot/src/byok-proxy.test.ts
+++ b/extensions/copilot/src/byok-proxy.test.ts
@@ -15,6 +15,16 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
   fetchWithSsrFGuard: ssrfRuntimeMock.fetchWithSsrFGuard,
 }));
 
+function getProxyCredentialHeader(headers: Record<string, string>): [string, string] {
+  return expectDefined(
+    Object.entries(headers).find(
+      ([name, value]) =>
+        /^x-openclaw-copilot-byok-[a-f0-9]{24}$/.test(name) && /^[a-f0-9]{24}$/.test(value),
+    ),
+    "proxy credential header",
+  );
+}
+
 describe("createCopilotByokProxy", () => {
   afterEach(() => {
     ssrfRuntimeMock.fetchWithSsrFGuard.mockReset();
@@ -331,11 +341,11 @@ describe("createCopilotByokProxy", () => {
     const proxy = await createCopilotByokProxy(resolvedProvider);
     expect(proxy?.provider.provider?.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
     const sdkHeaders = expectDefined(proxy?.provider.provider?.headers, "Azure SDK headers");
+    const [proxyCredentialHeader] = getProxyCredentialHeader(sdkHeaders);
     expect(sdkHeaders).toMatchObject({
+      "X-OpenClaw-Copilot-Byok-Proxy-Token": "configured-value",
       "X-Trace": "test",
-      "x-openclaw-copilot-byok-proxy-token": expect.stringMatching(/^[a-f0-9]{24}$/),
     });
-    expect(sdkHeaders).not.toHaveProperty("X-OpenClaw-Copilot-Byok-Proxy-Token");
 
     try {
       const response = await fetch(
@@ -357,6 +367,7 @@ describe("createCopilotByokProxy", () => {
             headers: expect.objectContaining({
               "accept-encoding": "identity",
               "api-key": "azure-key",
+              "x-openclaw-copilot-byok-proxy-token": "configured-value",
               "x-trace": "test",
             }),
           }),
@@ -365,7 +376,7 @@ describe("createCopilotByokProxy", () => {
       const call = ssrfRuntimeMock.fetchWithSsrFGuard.mock.calls[0]?.[0] as
         | { init?: { headers?: Record<string, string> } }
         | undefined;
-      expect(call?.init?.headers).not.toHaveProperty("x-openclaw-copilot-byok-proxy-token");
+      expect(call?.init?.headers).not.toHaveProperty(proxyCredentialHeader);
     } finally {
       await proxy?.close();
     }
@@ -386,6 +397,8 @@ describe("createCopilotByokProxy", () => {
         },
       }),
     );
+    const sdkHeaders = expectDefined(proxy?.provider.provider?.headers, "Azure SDK headers");
+    const [proxyCredentialHeader] = getProxyCredentialHeader(sdkHeaders);
 
     try {
       const status = await new Promise<number>((resolve, reject) => {
@@ -414,7 +427,7 @@ describe("createCopilotByokProxy", () => {
         `${proxy?.provider.provider?.baseUrl}/openai/v1/responses`,
         {
           method: "POST",
-          headers: { "x-openclaw-copilot-byok-proxy-token": "wrong" },
+          headers: { [proxyCredentialHeader]: "wrong" },
           body: JSON.stringify({ model: "deployment-gpt" }),
         },
       );

--- a/extensions/copilot/src/byok-proxy.test.ts
+++ b/extensions/copilot/src/byok-proxy.test.ts
@@ -1,3 +1,4 @@
+import { request as httpRequest } from "node:http";
 // Copilot BYOK proxy tests verify SDK-local transport is guarded outbound fetch.
 import { expectDefined } from "@openclaw/normalization-core";
 import type { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -319,19 +320,29 @@ describe("createCopilotByokProxy", () => {
         api: "azure-openai-responses",
         id: "deployment-gpt",
         baseUrl: "https://example.openai.azure.com/openai/v1",
+        headers: {
+          "X-OpenClaw-Copilot-Byok-Proxy-Token": "configured-value",
+          "X-Trace": "test",
+        },
       },
       resolvedApiKey: "azure-key",
     });
 
     const proxy = await createCopilotByokProxy(resolvedProvider);
     expect(proxy?.provider.provider?.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    const sdkHeaders = expectDefined(proxy?.provider.provider?.headers, "Azure SDK headers");
+    expect(sdkHeaders).toMatchObject({
+      "X-Trace": "test",
+      "x-openclaw-copilot-byok-proxy-token": expect.stringMatching(/^[a-f0-9]{24}$/),
+    });
+    expect(sdkHeaders).not.toHaveProperty("X-OpenClaw-Copilot-Byok-Proxy-Token");
 
     try {
       const response = await fetch(
         `${proxy?.provider.provider?.baseUrl}/openai/v1/responses?trace=request`,
         {
           method: "POST",
-          headers: { "api-key": "azure-key" },
+          headers: { ...sdkHeaders, "api-key": "azure-key" },
           body: JSON.stringify({ model: "deployment-gpt" }),
         },
       );
@@ -346,10 +357,69 @@ describe("createCopilotByokProxy", () => {
             headers: expect.objectContaining({
               "accept-encoding": "identity",
               "api-key": "azure-key",
+              "x-trace": "test",
             }),
           }),
         }),
       );
+      const call = ssrfRuntimeMock.fetchWithSsrFGuard.mock.calls[0]?.[0] as
+        | { init?: { headers?: Record<string, string> } }
+        | undefined;
+      expect(call?.init?.headers).not.toHaveProperty("x-openclaw-copilot-byok-proxy-token");
+    } finally {
+      await proxy?.close();
+    }
+  });
+
+  it("rejects nonce-less Azure SDK paths before reading the request body", async () => {
+    ssrfRuntimeMock.fetchWithSsrFGuard.mockResolvedValue({
+      response: new Response("unexpected", { status: 200 }),
+      release: vi.fn(async () => undefined),
+    });
+    const proxy = await createCopilotByokProxy(
+      resolveCopilotProvider({
+        model: {
+          provider: "custom-azure",
+          api: "azure-openai-responses",
+          id: "deployment-gpt",
+          baseUrl: "https://example.openai.azure.com/openai/v1",
+        },
+      }),
+    );
+
+    try {
+      const status = await new Promise<number>((resolve, reject) => {
+        const client = httpRequest(
+          `${proxy?.provider.provider?.baseUrl}/openai/v1/responses`,
+          { method: "POST", headers: { "content-length": "1048576" } },
+          (response) => {
+            clearTimeout(timeout);
+            response.resume();
+            resolve(response.statusCode ?? 0);
+          },
+        );
+        const timeout = setTimeout(() => {
+          client.destroy();
+          reject(new Error("proxy waited for the unauthenticated request body"));
+        }, 1_000);
+        client.on("error", (error) => {
+          clearTimeout(timeout);
+          reject(error);
+        });
+        client.flushHeaders();
+      });
+
+      expect(status).toBe(404);
+      const wrongCredential = await fetch(
+        `${proxy?.provider.provider?.baseUrl}/openai/v1/responses`,
+        {
+          method: "POST",
+          headers: { "x-openclaw-copilot-byok-proxy-token": "wrong" },
+          body: JSON.stringify({ model: "deployment-gpt" }),
+        },
+      );
+      expect(wrongCredential.status).toBe(404);
+      expect(ssrfRuntimeMock.fetchWithSsrFGuard).not.toHaveBeenCalled();
     } finally {
       await proxy?.close();
     }
@@ -372,10 +442,12 @@ describe("createCopilotByokProxy", () => {
     });
 
     const proxy = await createCopilotByokProxy(resolvedProvider);
+    const sdkHeaders = expectDefined(proxy?.provider.provider?.headers, "Azure SDK headers");
 
     try {
       const response = await fetch(`${proxy?.provider.provider?.baseUrl}/openai/v1/responses`, {
         method: "POST",
+        headers: sdkHeaders,
         body: JSON.stringify({ model: "deployment-gpt" }),
       });
 

--- a/extensions/copilot/src/byok-proxy.ts
+++ b/extensions/copilot/src/byok-proxy.ts
@@ -1,5 +1,5 @@
 // Copilot BYOK transport proxy keeps OpenClaw in charge of outbound network policy.
-import { randomBytes } from "node:crypto";
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -8,6 +8,7 @@ import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { ResolvedCopilotProvider } from "./provider-bridge.js";
 
 const LOOPBACK_HOST = "127.0.0.1";
+const PROXY_CREDENTIAL_HEADER = "x-openclaw-copilot-byok-proxy-token";
 
 type CopilotByokProxyHandle = {
   close: () => Promise<void>;
@@ -32,6 +33,8 @@ export async function createCopilotByokProxy(
   const nonce = randomBytes(12).toString("hex");
   const targetPathPrefix = trimTrailingSlash(targetBaseUrl.pathname);
   const proxyPathPrefix = `/${nonce}${targetPathPrefix}`;
+  // Azure rebuilds nonce-less /openai paths, so carry the same per-proxy secret
+  // in an SDK provider header and validate it before accepting request bytes.
   const acceptsAzureSdkPaths = providerConfig.type === "azure";
   const upstreamBearerAuthorization = resolveUpstreamBearerAuthorization(providerConfig);
   const activeFetches = new Set<AbortController>();
@@ -40,6 +43,7 @@ export async function createCopilotByokProxy(
       acceptsAzureSdkPaths,
       activeFetches,
       proxyPathPrefix,
+      proxyCredential: nonce,
       targetBaseUrl,
       targetPathPrefix,
       upstreamBearerAuthorization,
@@ -69,6 +73,9 @@ export async function createCopilotByokProxy(
       provider: {
         ...providerConfig,
         baseUrl: sdkBaseUrl,
+        ...(acceptsAzureSdkPaths
+          ? { headers: buildSdkProviderHeaders(providerConfig.headers, nonce) }
+          : {}),
       },
     },
     close: async () => {
@@ -92,6 +99,7 @@ async function handleProxyRequest(
     acceptsAzureSdkPaths: boolean;
     activeFetches: Set<AbortController>;
     proxyPathPrefix: string;
+    proxyCredential: string;
     targetBaseUrl: URL;
     targetPathPrefix: string;
     upstreamBearerAuthorization: string | undefined;
@@ -108,9 +116,9 @@ async function handleProxyRequest(
     }
   });
   try {
-    const canInjectBearerAuthorization = isNonceProtectedProxyRequest(req, params.proxyPathPrefix);
+    const isNonceProtected = isNonceProtectedProxyRequest(req, params.proxyPathPrefix);
     const url = resolveTargetUrl(req, params);
-    if (!url) {
+    if (!url || (!isNonceProtected && !hasValidProxyCredential(req, params.proxyCredential))) {
       res.writeHead(404);
       res.end("Not found");
       return;
@@ -121,7 +129,7 @@ async function handleProxyRequest(
       init: {
         method: req.method,
         headers: buildProxyRequestHeaders(req.headers, {
-          upstreamBearerAuthorization: canInjectBearerAuthorization
+          upstreamBearerAuthorization: isNonceProtected
             ? params.upstreamBearerAuthorization
             : undefined,
         }),
@@ -210,6 +218,18 @@ function isNonceProtectedProxyRequest(req: IncomingMessage, proxyPathPrefix: str
   );
 }
 
+function hasValidProxyCredential(req: IncomingMessage, expected: string): boolean {
+  const received = req.headers[PROXY_CREDENTIAL_HEADER];
+  if (typeof received !== "string") {
+    return false;
+  }
+  const receivedBytes = Buffer.from(received);
+  const expectedBytes = Buffer.from(expected);
+  return (
+    receivedBytes.length === expectedBytes.length && timingSafeEqual(receivedBytes, expectedBytes)
+  );
+}
+
 async function readBody(req: IncomingMessage): Promise<Buffer<ArrayBuffer> | undefined> {
   const chunks: Buffer[] = [];
   for await (const chunk of req) {
@@ -221,7 +241,11 @@ async function readBody(req: IncomingMessage): Promise<Buffer<ArrayBuffer> | und
 function normalizeProxyRequestHeaders(headers: IncomingMessage["headers"]): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [key, value] of Object.entries(headers)) {
-    if (isHopByHopHeader(key) || key.toLowerCase() === "accept-encoding") {
+    if (
+      isHopByHopHeader(key) ||
+      key.toLowerCase() === "accept-encoding" ||
+      key.toLowerCase() === PROXY_CREDENTIAL_HEADER
+    ) {
       continue;
     }
     const normalized = normalizeHeaderValue(value);
@@ -230,6 +254,17 @@ function normalizeProxyRequestHeaders(headers: IncomingMessage["headers"]): Reco
     }
   }
   out["accept-encoding"] = "identity";
+  return out;
+}
+
+function buildSdkProviderHeaders(
+  headers: ProviderConfig["headers"],
+  proxyCredential: string,
+): Record<string, string> {
+  const out = Object.fromEntries(
+    Object.entries(headers ?? {}).filter(([key]) => key.toLowerCase() !== PROXY_CREDENTIAL_HEADER),
+  );
+  out[PROXY_CREDENTIAL_HEADER] = proxyCredential;
   return out;
 }
 

--- a/extensions/copilot/src/byok-proxy.ts
+++ b/extensions/copilot/src/byok-proxy.ts
@@ -8,7 +8,7 @@ import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { ResolvedCopilotProvider } from "./provider-bridge.js";
 
 const LOOPBACK_HOST = "127.0.0.1";
-const PROXY_CREDENTIAL_HEADER = "x-openclaw-copilot-byok-proxy-token";
+const PROXY_CREDENTIAL_HEADER_PREFIX = "x-openclaw-copilot-byok-";
 
 type CopilotByokProxyHandle = {
   close: () => Promise<void>;
@@ -36,6 +36,9 @@ export async function createCopilotByokProxy(
   // Azure rebuilds nonce-less /openai paths, so carry the same per-proxy secret
   // in an SDK provider header and validate it before accepting request bytes.
   const acceptsAzureSdkPaths = providerConfig.type === "azure";
+  const proxyCredentialHeader = acceptsAzureSdkPaths
+    ? createProxyCredentialHeaderName(providerConfig.headers)
+    : undefined;
   const upstreamBearerAuthorization = resolveUpstreamBearerAuthorization(providerConfig);
   const activeFetches = new Set<AbortController>();
   const server = createServer((req, res) => {
@@ -44,6 +47,7 @@ export async function createCopilotByokProxy(
       activeFetches,
       proxyPathPrefix,
       proxyCredential: nonce,
+      proxyCredentialHeader,
       targetBaseUrl,
       targetPathPrefix,
       upstreamBearerAuthorization,
@@ -73,8 +77,14 @@ export async function createCopilotByokProxy(
       provider: {
         ...providerConfig,
         baseUrl: sdkBaseUrl,
-        ...(acceptsAzureSdkPaths
-          ? { headers: buildSdkProviderHeaders(providerConfig.headers, nonce) }
+        ...(proxyCredentialHeader
+          ? {
+              headers: buildSdkProviderHeaders(
+                providerConfig.headers,
+                proxyCredentialHeader,
+                nonce,
+              ),
+            }
           : {}),
       },
     },
@@ -100,6 +110,7 @@ async function handleProxyRequest(
     activeFetches: Set<AbortController>;
     proxyPathPrefix: string;
     proxyCredential: string;
+    proxyCredentialHeader: string | undefined;
     targetBaseUrl: URL;
     targetPathPrefix: string;
     upstreamBearerAuthorization: string | undefined;
@@ -118,7 +129,12 @@ async function handleProxyRequest(
   try {
     const isNonceProtected = isNonceProtectedProxyRequest(req, params.proxyPathPrefix);
     const url = resolveTargetUrl(req, params);
-    if (!url || (!isNonceProtected && !hasValidProxyCredential(req, params.proxyCredential))) {
+    if (
+      !url ||
+      (!isNonceProtected &&
+        (!params.proxyCredentialHeader ||
+          !hasValidProxyCredential(req, params.proxyCredentialHeader, params.proxyCredential)))
+    ) {
       res.writeHead(404);
       res.end("Not found");
       return;
@@ -132,6 +148,7 @@ async function handleProxyRequest(
           upstreamBearerAuthorization: isNonceProtected
             ? params.upstreamBearerAuthorization
             : undefined,
+          proxyCredentialHeader: params.proxyCredentialHeader,
         }),
         signal: upstreamAbort.signal,
         ...(body ? { body } : {}),
@@ -218,8 +235,12 @@ function isNonceProtectedProxyRequest(req: IncomingMessage, proxyPathPrefix: str
   );
 }
 
-function hasValidProxyCredential(req: IncomingMessage, expected: string): boolean {
-  const received = req.headers[PROXY_CREDENTIAL_HEADER];
+function hasValidProxyCredential(
+  req: IncomingMessage,
+  headerName: string,
+  expected: string,
+): boolean {
+  const received = req.headers[headerName];
   if (typeof received !== "string") {
     return false;
   }
@@ -238,13 +259,16 @@ async function readBody(req: IncomingMessage): Promise<Buffer<ArrayBuffer> | und
   return chunks.length > 0 ? Buffer.concat(chunks) : undefined;
 }
 
-function normalizeProxyRequestHeaders(headers: IncomingMessage["headers"]): Record<string, string> {
+function normalizeProxyRequestHeaders(
+  headers: IncomingMessage["headers"],
+  proxyCredentialHeader: string | undefined,
+): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [key, value] of Object.entries(headers)) {
     if (
       isHopByHopHeader(key) ||
       key.toLowerCase() === "accept-encoding" ||
-      key.toLowerCase() === PROXY_CREDENTIAL_HEADER
+      key.toLowerCase() === proxyCredentialHeader
     ) {
       continue;
     }
@@ -259,20 +283,29 @@ function normalizeProxyRequestHeaders(headers: IncomingMessage["headers"]): Reco
 
 function buildSdkProviderHeaders(
   headers: ProviderConfig["headers"],
+  proxyCredentialHeader: string,
   proxyCredential: string,
 ): Record<string, string> {
-  const out = Object.fromEntries(
-    Object.entries(headers ?? {}).filter(([key]) => key.toLowerCase() !== PROXY_CREDENTIAL_HEADER),
-  );
-  out[PROXY_CREDENTIAL_HEADER] = proxyCredential;
-  return out;
+  return { ...headers, [proxyCredentialHeader]: proxyCredential };
+}
+
+function createProxyCredentialHeaderName(headers: ProviderConfig["headers"]): string {
+  for (;;) {
+    const name = `${PROXY_CREDENTIAL_HEADER_PREFIX}${randomBytes(12).toString("hex")}`;
+    if (!headers || !hasHeader(headers, name)) {
+      return name;
+    }
+  }
 }
 
 function buildProxyRequestHeaders(
   headers: IncomingMessage["headers"],
-  params: { upstreamBearerAuthorization: string | undefined },
+  params: {
+    proxyCredentialHeader: string | undefined;
+    upstreamBearerAuthorization: string | undefined;
+  },
 ): Record<string, string> {
-  const out = normalizeProxyRequestHeaders(headers);
+  const out = normalizeProxyRequestHeaders(headers, params.proxyCredentialHeader);
   if (params.upstreamBearerAuthorization && !hasHeader(out, "authorization")) {
     // The SDK declares bearerToken as Authorization auth, but some BYOK
     // adapter paths can omit it before reaching our loopback proxy. The proxy


### PR DESCRIPTION
## Summary

- Authenticate native Azure Copilot BYOK loopback requests with an ephemeral per-proxy credential.
- Preserve the existing nonce-prefixed transport behavior for non-Azure providers and every configured provider header.

## Changes

- Generate a fresh, collision-checked internal header name and credential for each Azure proxy.
- Reject missing or invalid credentials before consuming request body bytes.
- Compare credentials in constant time and return the same response as an invalid route.
- Strip only the generated internal header before the guarded upstream request; configured headers remain untouched, including the former fixed internal-header name.

## Validation

- `corepack pnpm build`
- `corepack pnpm check:test-types`
- `corepack pnpm exec oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/copilot`
- `corepack pnpm exec vitest run extensions/copilot` (22 files, 617 tests)
- Real Copilot SDK v1.0.11 native Azure session generated `POST /openai/v1/responses` and forwarded the injected provider header.
- Final-boundary proof used the real bundled native runtime in isolated `empty` mode, the production proxy, and a mocked guarded fetch boundary. The authenticated SDK request reached guarded fetch once; the nearest unauthenticated direct request returned 404 without another guarded call; the generated credential was absent upstream:

```json
{"directUnauthenticated":{"guardedFetchCallsAfter":1,"status":404},"nativeAzureSdk":{"credentialHeadersInProviderConfig":1,"guardedFetchCalls":1,"internalCredentialForwardedUpstream":false,"method":"POST","upstreamPath":"/openai/v1/responses"}}
```

- Structured Codex autoreview: clean, no actionable P0 findings.

## Notes

- No config, environment, public API, protocol, persistence, dependency, or request-size contract changes.
- Production delta: +76/-8 lines; test delta: +86/-1 lines.
- Exact-head ClawSweeper re-review found no actionable defects and marked the supplied proof sufficient; ordinary maintainer/security-boundary review remains.
- CI source, type, lint, security, boundary, and changed-extension checks passed. `build-artifacts` alone failed the unrelated Control UI startup-gzip ratchet (348448 B, then 348410 B on rerun, versus 348368 B); this PR has no UI or build-surface changes.
