### PR TITLE
fix(release): preserve blockers across child retry job URLs

### DIFF
--- a/.agents/skills/release-openclaw-ci/SKILL.md
+++ b/.agents/skills/release-openclaw-ci/SKILL.md
@@ -200,6 +200,12 @@ until their dependent enforcement changes land.
 
 ## Preflight
 
+Before full matrix dispatch, run both `pnpm ui:i18n:check` and
+`pnpm native:i18n:check` against the frozen trusted target in approved isolation.
+Bind both results to that exact SHA; either generated-locale drift blocks
+dispatch. Keep target execution outside the trusted dispatch helper—do not
+execute an arbitrary target checkout as helper code.
+
 Before full release validation:
 
 ```bash

--- a/scripts/full-release-validation-policy.mjs
+++ b/scripts/full-release-validation-policy.mjs
@@ -1838,7 +1838,21 @@ function verifyStateStructure(state, executionPlan, label) {
   }
 }
 
-function verifyStateTransition(decision, drain) {
+function acceptedJobBlockerAttempt(state, blocker) {
+  const child = state.children[blocker.child];
+  if (blocker.kind !== "job_failure" || !child || child.runId !== blocker.runId) {
+    return undefined;
+  }
+  return child.timing.jobs.find(
+    (job) =>
+      job.name === blocker.job &&
+      job.url === blocker.url &&
+      job.conclusion === blocker.conclusion &&
+      job.status === "completed",
+  )?.acceptedRunAttempt;
+}
+
+function verifyStateTransition(decision, drain, executionPlan) {
   const reuseRecovery =
     ["blocked_complete", "blocked_diagnostics_running"].includes(decision.state) &&
     drain.state === "passed" &&
@@ -1864,6 +1878,12 @@ function verifyStateTransition(decision, drain) {
       drain.blockers.some(
         (candidate) =>
           JSON.stringify(candidate) === JSON.stringify(blocker) ||
+          // A verified newer attempt can replace a job URL while retaining the
+          // same blocker. Both URLs must belong to their accepted job evidence.
+          (executionPlan.attemptEvidenceVersion !== undefined &&
+            JSON.stringify({ ...candidate, url: blocker.url }) === JSON.stringify(blocker) &&
+            acceptedJobBlockerAttempt(drain, candidate) >
+              acceptedJobBlockerAttempt(decision, blocker)) ||
           (blocker.kind === "workflow_failure" &&
             candidate.kind === "job_failure" &&
             ["child", "runId"].every((key) => candidate[key] === blocker[key])),
@@ -1888,7 +1908,7 @@ function verifyReleaseStatePair(planPayload, decisionPayload, drainPayload, expe
   }
   verifyStateStructure(decision, executionPlan, "release decision");
   verifyStateStructure(drain, executionPlan, "diagnostic drain");
-  verifyStateTransition(decision, drain);
+  verifyStateTransition(decision, drain, executionPlan);
   return {
     decision,
     drain,

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -1377,6 +1377,30 @@ describe("release state artifacts", () => {
     };
   }
 
+  function attemptedBlockedArtifact(
+    mode: "decision" | "drain",
+    sealedPlan: ReturnType<typeof executionPlan>,
+    attempts: { runAttempt: number; jobs: Record<string, unknown>[] }[],
+  ) {
+    const runAttempt = attempts.at(-1)!.runAttempt;
+    const composite = composeReleaseAttemptJobs(attempts, {
+      plannedRunAttempt: 1,
+      effectiveRunAttempt: runAttempt,
+    });
+    return artifact(mode, 2, sealedPlan, {
+      compositeJobsSha256: composite.sha256,
+      conclusion: "failure",
+      status: mode === "decision" ? "in_progress" : "completed",
+      dispatchActor: "github-actions[bot]",
+      jobs: composite.jobs,
+      observedRunAttempts: attempts.map((attempt) => attempt.runAttempt),
+      plannedRunAttempt: 1,
+      repository: "openclaw/openclaw",
+      runAttempt,
+      triggeringActor: "release-operator",
+    });
+  }
+
   function stateExpected(maxParentRunAttempt = 2) {
     return {
       maxParentRunAttempt,
@@ -1819,6 +1843,93 @@ describe("release state artifacts", () => {
       decision: { activeRunIds: ["101"], state: "blocked_diagnostics_running" },
       drain: { activeRunIds: [], blockers: [{ job: "test" }, { job: "terminal diagnostic" }] },
     });
+  });
+
+  it("retains a failed logical job when a later attempt replaces its job URL", () => {
+    const sealedPlan = executionPlan(
+      { rerunGroup: "ci" },
+      { attemptEvidenceVersion: 2, candidateRequest: candidateBinding().request },
+    );
+    const retriedJob = { ...FAILED_JOB, url: "https://example.invalid/jobs/retried" };
+    const attempts = [
+      { runAttempt: 1, jobs: [FAILED_JOB] },
+      { runAttempt: 2, jobs: [retriedJob] },
+    ];
+    const decision = attemptedBlockedArtifact("decision", sealedPlan, attempts.slice(0, 1));
+    const drain = attemptedBlockedArtifact("drain", sealedPlan, attempts);
+    expect(selectPair(sealedPlan, decision, drain)).toMatchObject({
+      decision: { state: "blocked_diagnostics_running" },
+      drain: {
+        state: "blocked_complete",
+        blockers: [{ job: "test", url: retriedJob.url }],
+      },
+    });
+    expect(() => verifyReleaseStateArtifacts(sealedPlan, decision, drain, stateExpected())).toThrow(
+      "Full Release Validation state: blocked_complete\n- Blocker: test (failure)",
+    );
+  });
+
+  it.each([
+    "same accepted attempt",
+    "regressed accepted attempt",
+    "retained job in a newer attempt",
+    "blocker URL outside its job evidence",
+    "foreign-run blocker borrowing child job evidence",
+    "historical plan without attempt validation",
+    "renamed job",
+    "changed failure conclusion",
+  ])("rejects replacement blocker URLs with %s", (scenario) => {
+    const sealedPlan = executionPlan(
+      { rerunGroup: "ci" },
+      scenario === "historical plan without attempt validation"
+        ? {}
+        : { attemptEvidenceVersion: 2, candidateRequest: candidateBinding().request },
+    );
+    const first = { runAttempt: 1, jobs: [FAILED_JOB] };
+    const replaced = {
+      ...FAILED_JOB,
+      url: "https://example.invalid/jobs/retried",
+      ...(scenario === "renamed job" ? { name: "different test" } : {}),
+      ...(scenario === "changed failure conclusion" ? { conclusion: "timed_out" } : {}),
+    };
+    const second = {
+      runAttempt: 2,
+      jobs:
+        scenario === "renamed job"
+          ? [{ ...FAILED_JOB, conclusion: "success" }, replaced]
+          : [replaced],
+    };
+    const decision = attemptedBlockedArtifact(
+      "decision",
+      sealedPlan,
+      scenario === "regressed accepted attempt"
+        ? [first, { ...second, jobs: [FAILED_JOB] }]
+        : [first],
+    );
+    const drain = attemptedBlockedArtifact(
+      "drain",
+      sealedPlan,
+      scenario === "same accepted attempt" || scenario === "regressed accepted attempt"
+        ? [{ runAttempt: 1, jobs: [replaced] }]
+        : scenario === "retained job in a newer attempt"
+          ? [
+              { ...first, jobs: [replaced] },
+              { runAttempt: 2, jobs: [{ ...FAILED_JOB, name: "other", conclusion: "success" }] },
+            ]
+          : [first, second],
+    );
+    if (scenario === "blocker URL outside its job evidence") {
+      drain.blockers = drain.blockers.map((blocker) => ({
+        ...blocker,
+        url: "https://example.invalid/jobs/unrelated",
+      }));
+    }
+    if (scenario === "foreign-run blocker borrowing child job evidence") {
+      for (const snapshot of [decision, drain]) {
+        snapshot.blockers.push({ ...snapshot.blockers[0], runId: "999" });
+      }
+    }
+    expect(() => selectPair(sealedPlan, decision, drain)).toThrow("changed or removed");
   });
 
   it("selects a terminal blocked pair when workflow evidence refines to failed jobs", () => {


### PR DESCRIPTION
## What Problem This Solves

A legitimate retry of one full-release child job can allocate new GitHub job URLs for other retained failures. The early Release Decision and final Diagnostic Drain then describe the same failed logical jobs with different URLs, but the transition validator rejects them as removed blockers. This obscures the complete diagnostic result even though source, workflow, run and failure identity are unchanged.

## Why This Change Was Made

Keep exact blocker comparison, with one narrow exception for attempt-aware evidence: both URLs must match their own validated child/run/job/conclusion snapshots, every other blocker field must match, and the accepted job attempt must advance. Same-attempt changes, carried older jobs, foreign-run evidence, renamed jobs and changed conclusions remain rejected. Legacy evidence retains exact comparison.

The publication verifier still requires both states to pass and their complete accepted evidence to agree. This change never converts a failed release into a passing one. Runtime code is unchanged; tooling changes are +22/-2, with regression coverage and a short runbook preflight addition. The runbook now checks both UI and native generated locales on the frozen trusted target before launching the full matrix, without executing arbitrary target code inside the trusted dispatch helper.

## Evidence

- The original validator rejects the retained artifacts from full run 33460145086 after its Android-only retry. Exactly two retained blockers differ only by job URL; the independently composed child attempts match the final artifact.
- The corrected selector accepts those unchanged artifacts as `blocked_complete` and preserves all six blockers. Strict publication still rejects them with their actual failure list. Historical artifacts and the original failed-run receipt were not modified.
- Test-first reproduction fails before the fix. The owner, full-release collector, summary and evidence-validator sibling tests pass: 381 tests. Adversarial cases cover same/regressed attempts, retained old jobs, unbound URLs, foreign-run borrowing, legacy plans, renamed jobs and changed conclusions.
- Independent P0 review is scoped-clean, and the full changed-file gate passes. Required exact-head CI remains a landing gate. No release publication is requested or performed.
