### PR TITLE
fix(release): harden 7.33 Kova validation

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -65,7 +65,8 @@ env:
   OCM_VERSION: v0.2.15
   OCM_LINUX_X64_SHA256: b849b8de5d77e97e0df9319703254ae95e29d7f26a7552ea79bf173ff110ea0a
   KOVA_REPOSITORY: openclaw/Kova
-  KOVA_ARCHIVE_SHA256: 8cb2f4dd90e1bd5a5615d5d14f7766136057c4c5e66d399b5efb4d59a50dee7e
+  KOVA_TRUSTED_LIVE_REF: 24c26969e57d4d49f9d1a5071af85dd3d79daa2d
+  KOVA_ARCHIVE_SHA256: 3b0d49b28c3e73a9022ab704d9c884bab092b7fae1f27167e36bf787b774701d
   PERFORMANCE_MODEL_ID: gpt-5.5
   KOVA_SCENARIO_TIMEOUT_MS: "300000"
 
@@ -235,15 +236,22 @@ jobs:
           tar -xzf "$ocm_archive" -C "${RUNNER_TEMP}/ocm-install"
           install -m 0755 "${RUNNER_TEMP}/ocm-install/ocm" "$HOME/.local/bin/ocm"
 
-          kova_archive="${RUNNER_TEMP}/kova-${KOVA_REF}.tar.gz"
-          mkdir -p "$KOVA_SRC"
-          curl -fsSL --proto '=https' --tlsv1.2 \
-            --max-time 180 \
-            --retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused \
-            -o "$kova_archive" \
-            "https://codeload.github.com/${KOVA_REPOSITORY}/tar.gz/${KOVA_REF}"
-          echo "${KOVA_ARCHIVE_SHA256}  ${kova_archive}" | sha256sum -c -
-          tar -xzf "$kova_archive" --strip-components=1 -C "$KOVA_SRC"
+          if [[ "$KOVA_REF" == "$KOVA_TRUSTED_LIVE_REF" ]]; then
+            kova_archive="${RUNNER_TEMP}/kova-${KOVA_REF}.tar.gz"
+            mkdir -p "$KOVA_SRC"
+            curl -fsSL --proto '=https' --tlsv1.2 \
+              --max-time 180 \
+              --retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused \
+              -o "$kova_archive" \
+              "https://codeload.github.com/${KOVA_REPOSITORY}/tar.gz/${KOVA_REF}"
+            echo "${KOVA_ARCHIVE_SHA256}  ${kova_archive}" | sha256sum -c -
+            tar -xzf "$kova_archive" --strip-components=1 -C "$KOVA_SRC"
+          else
+            git init -b main "$KOVA_SRC"
+            git -C "$KOVA_SRC" remote add origin "https://github.com/${KOVA_REPOSITORY}.git"
+            git -C "$KOVA_SRC" fetch --filter=blob:none --depth 1 origin "$KOVA_REF"
+            git -C "$KOVA_SRC" checkout --detach FETCH_HEAD
+          fi
           npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund
           node - "$KOVA_SRC" <<'NODE'
           const fs = require("node:fs");

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -134,6 +134,10 @@ jobs:
             run_lane=false
             reason="live_openai_candidate input is false"
           fi
+          if [[ "$LANE_ID" == "live-openai-candidate" && "$run_lane" == "true" && "$KOVA_REF" != "$KOVA_TRUSTED_LIVE_REF" ]]; then
+            echo "::error::The live OpenAI lane only executes the checksum-verified Kova default. Omit kova_ref or update the pinned workflow defaults after review."
+            exit 1
+          fi
           echo "run=$run_lane" >> "$GITHUB_OUTPUT"
           if [[ "$run_lane" != "true" ]]; then
             echo "Skipping ${LANE_ID}: ${reason}" >> "$GITHUB_STEP_SUMMARY"
@@ -354,8 +358,8 @@ jobs:
         id: kova
         if: steps.lane.outputs.run == 'true'
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
+          OPENAI_API_KEY: ${{ matrix.live == 'true' && secrets.OPENAI_API_KEY || '' }}
+          OPENAI_BASE_URL: ${{ matrix.live == 'true' && secrets.OPENAI_BASE_URL || '' }}
           CLAWGRIT_REPORTS_TOKEN_PRESENT: ${{ steps.clawgrit.outputs.present || 'false' }}
         shell: bash
         run: |

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -238,6 +238,13 @@ jobs:
           git -C "$KOVA_SRC" remote add origin "https://github.com/${KOVA_REPOSITORY}.git"
           git -C "$KOVA_SRC" fetch --filter=blob:none --depth 1 origin "$KOVA_REF"
           git -C "$KOVA_SRC" checkout --detach FETCH_HEAD
+          npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund
+          node - "$KOVA_SRC" <<'NODE'
+          const root = process.argv[2];
+          for (const dependency of ["mock-ai-provider", "zod"]) {
+            require.resolve(dependency, { paths: [root] });
+          }
+          NODE
           cat > "$HOME/.local/bin/kova" <<EOF
           #!/usr/bin/env bash
           export KOVA_HOME="${KOVA_HOME}"

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -240,10 +240,27 @@ jobs:
           git -C "$KOVA_SRC" checkout --detach FETCH_HEAD
           npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund
           node - "$KOVA_SRC" <<'NODE'
+          const fs = require("node:fs");
+          const path = require("node:path");
+
           const root = process.argv[2];
-          for (const dependency of ["mock-ai-provider", "zod"]) {
-            require.resolve(dependency, { paths: [root] });
+          const packageJsonPath = require.resolve("mock-ai-provider/package.json", {
+            paths: [root],
+          });
+          const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+          const bin =
+            typeof packageJson.bin === "string"
+              ? packageJson.bin
+              : packageJson.bin?.["mock-ai-provider"];
+          if (typeof bin !== "string" || bin.length === 0) {
+            throw new Error("mock-ai-provider does not declare its CLI entrypoint");
           }
+          fs.accessSync(path.resolve(path.dirname(packageJsonPath), bin), fs.constants.R_OK);
+          fs.accessSync(
+            path.join(root, "node_modules", ".bin", "mock-ai-provider"),
+            fs.constants.X_OK,
+          );
+          require.resolve("zod", { paths: [root] });
           NODE
           cat > "$HOME/.local/bin/kova" <<EOF
           #!/usr/bin/env bash

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -275,7 +275,6 @@ jobs:
           const files = [
             "support/configure-openclaw-mock-auth.mjs",
             "support/configure-openclaw-live-auth.mjs",
-            "support/mock-openai-server.mjs",
             "states/mock-openai-provider.json"
           ];
           for (const rel of files) {

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -234,10 +234,14 @@ jobs:
           tar -xzf "$ocm_archive" -C "${RUNNER_TEMP}/ocm-install"
           install -m 0755 "${RUNNER_TEMP}/ocm-install/ocm" "$HOME/.local/bin/ocm"
 
-          git init -b main "$KOVA_SRC"
-          git -C "$KOVA_SRC" remote add origin "https://github.com/${KOVA_REPOSITORY}.git"
-          git -C "$KOVA_SRC" fetch --filter=blob:none --depth 1 origin "$KOVA_REF"
-          git -C "$KOVA_SRC" checkout --detach FETCH_HEAD
+          kova_archive="${RUNNER_TEMP}/kova-${KOVA_REF}.tar.gz"
+          mkdir -p "$KOVA_SRC"
+          curl -fsSL --proto '=https' --tlsv1.2 \
+            --max-time 180 \
+            --retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused \
+            -o "$kova_archive" \
+            "https://codeload.github.com/${KOVA_REPOSITORY}/tar.gz/${KOVA_REF}"
+          tar -xzf "$kova_archive" --strip-components=1 -C "$KOVA_SRC"
           npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund
           node - "$KOVA_SRC" <<'NODE'
           const fs = require("node:fs");

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -383,11 +383,7 @@ jobs:
           status=${PIPESTATUS[0]}
           set -e
 
-          report_json="$(find "$REPORT_DIR" -maxdepth 1 -type f -name '*.json' -print | sort | tail -n 1)"
-          if [[ -z "$report_json" ]]; then
-            echo "Kova did not write a JSON report." >&2
-            exit 1
-          fi
+          report_json="$(node "$PERFORMANCE_HELPER_DIR/scripts/lib/kova-report-selector.mjs" --report-dir "$REPORT_DIR")"
           report_md="${report_json%.json}.md"
           effective_status="$status"
           if [[ "$FAIL_ON_REGRESSION" == "true" && "$status" != "0" ]]; then
@@ -449,8 +445,8 @@ jobs:
         run: |
           set -euo pipefail
           missing=0
-          if ! find "$REPORT_DIR" -maxdepth 1 -type f -name '*.json' -size +0c -print -quit | grep -q .; then
-            echo "::error::Kova JSON report is missing for ${LANE_ID}."
+          if ! node "$PERFORMANCE_HELPER_DIR/scripts/lib/kova-report-selector.mjs" --report-dir "$REPORT_DIR" >/dev/null; then
+            echo "::error::Exactly one full Kova JSON report is required for ${LANE_ID}."
             missing=1
           fi
           if [[ ! -s "$BUNDLE_DIR/bundle.json" ]]; then

--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -65,6 +65,7 @@ env:
   OCM_VERSION: v0.2.15
   OCM_LINUX_X64_SHA256: b849b8de5d77e97e0df9319703254ae95e29d7f26a7552ea79bf173ff110ea0a
   KOVA_REPOSITORY: openclaw/Kova
+  KOVA_ARCHIVE_SHA256: 8cb2f4dd90e1bd5a5615d5d14f7766136057c4c5e66d399b5efb4d59a50dee7e
   PERFORMANCE_MODEL_ID: gpt-5.5
   KOVA_SCENARIO_TIMEOUT_MS: "300000"
 
@@ -241,6 +242,7 @@ jobs:
             --retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused \
             -o "$kova_archive" \
             "https://codeload.github.com/${KOVA_REPOSITORY}/tar.gz/${KOVA_REF}"
+          echo "${KOVA_ARCHIVE_SHA256}  ${kova_archive}" | sha256sum -c -
           tar -xzf "$kova_archive" --strip-components=1 -C "$KOVA_SRC"
           npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund
           node - "$KOVA_SRC" <<'NODE'

--- a/scripts/lib/kova-report-selector.mjs
+++ b/scripts/lib/kova-report-selector.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import { readdirSync, realpathSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function check(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+export function selectKovaReport(reportDir) {
+  const root = realpathSync(reportDir);
+  const reports = readdirSync(root, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isFile() && entry.name.endsWith(".json") && !entry.name.endsWith(".summary.json"),
+    )
+    .map((entry) => path.join(root, entry.name));
+
+  check(
+    reports.length === 1,
+    `expected exactly one full Kova JSON report; found ${reports.length}`,
+  );
+  check(statSync(reports[0]).size > 0, "full Kova JSON report is empty");
+  return reports[0];
+}
+
+function runCli(argv) {
+  check(argv.length === 2 && argv[0] === "--report-dir", "usage: --report-dir <directory>");
+  console.log(selectKovaReport(argv[1]));
+}
+
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  try {
+    runCli(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -1185,6 +1185,7 @@ const TOOLING_SOURCE_TEST_TARGETS = new Map([
   ["scripts/lib/live-docker-stage.sh", ["test/scripts/live-docker-stage.test.ts"]],
   ["scripts/lib/local-heavy-check-runtime.mjs", ["test/scripts/local-heavy-check-runtime.test.ts"]],
   ["scripts/lib/kova-report-gate.mjs", ["test/scripts/kova-report-gate.test.ts"]],
+  ["scripts/lib/kova-report-selector.mjs", ["test/scripts/kova-report-selector.test.ts"]],
   ["scripts/lib/managed-child-process.mjs", ["test/scripts/managed-child-process.test.ts"]],
   [
     "scripts/lib/windows-taskkill.mjs",

--- a/test/scripts/kova-report-selector.test.ts
+++ b/test/scripts/kova-report-selector.test.ts
@@ -1,0 +1,63 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { selectKovaReport } from "../../scripts/lib/kova-report-selector.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempRoots = useAutoCleanupTempDirTracker(afterEach);
+const SCRIPT_PATH = "scripts/lib/kova-report-selector.mjs";
+
+function reportDir() {
+  const root = tempRoots.make("openclaw-kova-report-selector-");
+  const dir = join(root, "reports");
+  mkdirSync(dir);
+  return dir;
+}
+
+describe("Kova report selector", () => {
+  it("selects the full report when Kova also writes its summary", () => {
+    const dir = reportDir();
+    const report = join(dir, "kova-run-release.json");
+    writeFileSync(report, '{"schemaVersion":"kova.report.v1"}\n');
+    writeFileSync(
+      join(dir, "kova-run-release.summary.json"),
+      '{"schemaVersion":"kova.report.summary.v1"}\n',
+    );
+
+    expect(selectKovaReport(dir)).toBe(report);
+    const cli = spawnSync(process.execPath, [SCRIPT_PATH, "--report-dir", dir], {
+      encoding: "utf8",
+    });
+    expect(cli).toMatchObject({ status: 0, stderr: "", stdout: `${report}\n` });
+  });
+
+  it("fails closed without a full report", () => {
+    const dir = reportDir();
+    writeFileSync(
+      join(dir, "kova-run-release.summary.json"),
+      '{"schemaVersion":"kova.report.summary.v1"}\n',
+    );
+
+    expect(() => selectKovaReport(dir)).toThrow(
+      "expected exactly one full Kova JSON report; found 0",
+    );
+  });
+
+  it("fails closed with multiple full reports", () => {
+    const dir = reportDir();
+    writeFileSync(join(dir, "kova-run-a.json"), "{}\n");
+    writeFileSync(join(dir, "kova-run-b.json"), "{}\n");
+
+    expect(() => selectKovaReport(dir)).toThrow(
+      "expected exactly one full Kova JSON report; found 2",
+    );
+  });
+
+  it("rejects an empty full report", () => {
+    const dir = reportDir();
+    writeFileSync(join(dir, "kova-run-release.json"), "");
+
+    expect(() => selectKovaReport(dir)).toThrow("full Kova JSON report is empty");
+  });
+});

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -141,6 +141,14 @@ describe("OpenClaw performance workflow", () => {
     const install = findStep("Install OCM and Kova");
 
     expect(install.run).toContain(
+      "https://codeload.github.com/${KOVA_REPOSITORY}/tar.gz/${KOVA_REF}",
+    );
+    expect(install.run).toContain(
+      "--retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused",
+    );
+    expect(install.run).toContain('tar -xzf "$kova_archive" --strip-components=1');
+    expect(install.run).not.toContain('git -C "$KOVA_SRC" fetch');
+    expect(install.run).toContain(
       'npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund',
     );
     expect(install.run).toContain('require.resolve("mock-ai-provider/package.json", {');

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -143,11 +143,12 @@ describe("OpenClaw performance workflow", () => {
     expect(install.run).toContain(
       "https://codeload.github.com/${KOVA_REPOSITORY}/tar.gz/${KOVA_REF}",
     );
+    expect(install.run).toContain('if [[ "$KOVA_REF" == "$KOVA_TRUSTED_LIVE_REF" ]]');
     expect(install.run).toContain(
       "--retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused",
     );
     expect(readWorkflow().env?.KOVA_ARCHIVE_SHA256).toBe(
-      "8cb2f4dd90e1bd5a5615d5d14f7766136057c4c5e66d399b5efb4d59a50dee7e",
+      "3b0d49b28c3e73a9022ab704d9c884bab092b7fae1f27167e36bf787b774701d",
     );
     expect(install.run).toContain(
       'echo "${KOVA_ARCHIVE_SHA256}  ${kova_archive}" | sha256sum -c -',
@@ -156,7 +157,9 @@ describe("OpenClaw performance workflow", () => {
     expect(
       install.run.indexOf('echo "${KOVA_ARCHIVE_SHA256}  ${kova_archive}" | sha256sum -c -'),
     ).toBeLessThan(install.run.indexOf('tar -xzf "$kova_archive" --strip-components=1'));
-    expect(install.run).not.toContain('git -C "$KOVA_SRC" fetch');
+    expect(install.run).toContain(
+      'git -C "$KOVA_SRC" fetch --filter=blob:none --depth 1 origin "$KOVA_REF"',
+    );
     expect(install.run).toContain(
       'npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund',
     );

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -172,15 +172,21 @@ describe("OpenClaw performance workflow", () => {
   });
 
   it("fails selected live Kova lanes when live auth is missing", () => {
+    const decideLane = findStep("Decide lane");
     const configureAuth = findStep("Configure live OpenAI auth");
     const runKova = findStep("Run Kova");
 
+    expect(decideLane.run).toContain('"$KOVA_REF" != "$KOVA_TRUSTED_LIVE_REF"');
+    expect(decideLane.run).toContain("only executes the checksum-verified Kova default");
     expect(configureAuth.if).toContain("matrix.live == 'true'");
     expect(configureAuth.env?.OPENAI_API_KEY).toBe("${{ secrets.OPENAI_API_KEY }}");
     expect(configureAuth.run).toContain('if [[ -z "${OPENAI_API_KEY:-}" ]]; then');
     expect(configureAuth.run).toContain("cannot run without live evidence");
     expect(configureAuth.run).toContain("exit 1");
     expect(configureAuth.run).not.toContain("will be skipped");
+    expect(runKova.env?.OPENAI_API_KEY).toBe(
+      "${{ matrix.live == 'true' && secrets.OPENAI_API_KEY || '' }}",
+    );
     expect(runKova.run).not.toContain('echo "skipped=true" >> "$GITHUB_OUTPUT"');
   });
 

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -134,8 +134,12 @@ describe("OpenClaw performance workflow", () => {
     expect(install.run).toContain(
       'npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund',
     );
-    expect(install.run).toContain('for (const dependency of ["mock-ai-provider", "zod"])');
-    expect(install.run).toContain("require.resolve(dependency, { paths: [root] })");
+    expect(install.run).toContain('require.resolve("mock-ai-provider/package.json", {');
+    expect(install.run).toContain('packageJson.bin?.["mock-ai-provider"]');
+    expect(install.run).toContain('path.join(root, "node_modules", ".bin", "mock-ai-provider")');
+    expect(install.run).toContain("fs.constants.X_OK");
+    expect(install.run).toContain('require.resolve("zod", { paths: [root] })');
+    expect(install.run).not.toContain('require.resolve("mock-ai-provider",');
   });
 
   it("fails selected live Kova lanes when live auth is missing", () => {

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -113,6 +113,15 @@ describe("OpenClaw performance workflow", () => {
     expect(runKova.run).not.toContain("report.summary?.statuses ?? {}");
   });
 
+  it("selects the full Kova report instead of its summary", () => {
+    const runKova = findStep("Run Kova");
+    const validate = findStep("Validate Kova evidence");
+
+    expect(runKova.run).toContain('kova-report-selector.mjs" --report-dir "$REPORT_DIR"');
+    expect(validate.run).toContain('kova-report-selector.mjs" --report-dir "$REPORT_DIR"');
+    expect(runKova.run).not.toContain("tail -n 1");
+  });
+
   it("installs local workspace packages beside the OCM root tarball", () => {
     const configure = findStep("Configure OCM local workspace dependencies");
 
@@ -161,7 +170,7 @@ describe("OpenClaw performance workflow", () => {
 
     expect(validateEvidence.if).toContain("always()");
     expect(validateEvidence.if).toContain("steps.lane.outputs.run == 'true'");
-    expect(validateEvidence.run).toContain('"$REPORT_DIR" -maxdepth 1 -type f -name');
+    expect(validateEvidence.run).toContain('kova-report-selector.mjs" --report-dir "$REPORT_DIR"');
     expect(validateEvidence.run).toContain('"$BUNDLE_DIR/bundle.json"');
     expect(validateEvidence.run).toContain('"$SUMMARY_DIR/${LANE_ID}.md"');
     expect(validateEvidence.run).toContain("exit 1");

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -146,7 +146,16 @@ describe("OpenClaw performance workflow", () => {
     expect(install.run).toContain(
       "--retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused",
     );
+    expect(readWorkflow().env?.KOVA_ARCHIVE_SHA256).toBe(
+      "8cb2f4dd90e1bd5a5615d5d14f7766136057c4c5e66d399b5efb4d59a50dee7e",
+    );
+    expect(install.run).toContain(
+      'echo "${KOVA_ARCHIVE_SHA256}  ${kova_archive}" | sha256sum -c -',
+    );
     expect(install.run).toContain('tar -xzf "$kova_archive" --strip-components=1');
+    expect(
+      install.run.indexOf('echo "${KOVA_ARCHIVE_SHA256}  ${kova_archive}" | sha256sum -c -'),
+    ).toBeLessThan(install.run.indexOf('tar -xzf "$kova_archive" --strip-components=1'));
     expect(install.run).not.toContain('git -C "$KOVA_SRC" fetch');
     expect(install.run).toContain(
       'npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund',

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -52,6 +52,15 @@ describe("OpenClaw performance workflow", () => {
     expect(workflow).toContain(`inputs.kova_ref || '${kovaRef}'`);
   });
 
+  it("rewrites only Kova files that own the performance model pin", () => {
+    const pinModel = findStep("Pin Kova OpenAI model to GPT 5.5").run ?? "";
+
+    expect(pinModel).toContain('"support/configure-openclaw-mock-auth.mjs"');
+    expect(pinModel).toContain('"support/configure-openclaw-live-auth.mjs"');
+    expect(pinModel).toContain('"states/mock-openai-provider.json"');
+    expect(pinModel).not.toContain('"support/mock-openai-server.mjs"');
+  });
+
   it("resolves dispatch target refs before checkout", () => {
     const resolveTarget = findStep("Resolve OpenClaw target ref");
     const checkout = findStep("Checkout OpenClaw");

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -128,6 +128,16 @@ describe("OpenClaw performance workflow", () => {
     );
   });
 
+  it("installs Kova runtime dependencies before invoking its CLI", () => {
+    const install = findStep("Install OCM and Kova");
+
+    expect(install.run).toContain(
+      'npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund',
+    );
+    expect(install.run).toContain('for (const dependency of ["mock-ai-provider", "zod"])');
+    expect(install.run).toContain("require.resolve(dependency, { paths: [root] })");
+  });
+
   it("fails selected live Kova lanes when live auth is missing", () => {
     const configureAuth = findStep("Configure live OpenAI auth");
     const runKova = findStep("Run Kova");


### PR DESCRIPTION
Restore Kova dependency setup, select full reports, and fetch the pinned default archive with retries plus SHA-256 verification while preserving secretless custom refs.\n\nTests: 16 focused performance workflow and report-selector assertions passed.