### PR TITLE
fix(ai): preserve Responses stream output

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -785,6 +785,48 @@ describe("convertResponsesMessages", () => {
 });
 
 describe("processResponsesStream", () => {
+  it("keeps text deltas when content_part.added is omitted", async () => {
+    const output = createAssistantOutput();
+    const stream = new AssistantMessageEventStream();
+
+    await processResponsesStream(
+      responseEvents([
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: {
+            type: "message",
+            role: "assistant",
+            id: "msg_without_part",
+            content: [],
+            status: "in_progress",
+          },
+        },
+        { type: "response.output_text.delta", output_index: 0, content_index: 0, delta: "KOVA_" },
+        {
+          type: "response.output_text.delta",
+          output_index: 0,
+          content_index: 0,
+          delta: "AGENT_OK",
+        },
+        {
+          type: "response.completed",
+          response: {
+            id: "resp_without_part",
+            status: "completed",
+            output: [],
+          },
+        },
+      ]),
+      output,
+      stream,
+      nativeOpenAIModel,
+    );
+
+    expect(output.content).toEqual([{ type: "text", text: "KOVA_AGENT_OK" }]);
+    expect(output.stopReason).toBe("stop");
+  });
+
   it("aborts the Responses request signal when the first SSE event never arrives", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -801,8 +801,11 @@ export async function processResponsesStream<TApi extends Api>(
       }
     } else if (event.type === "response.output_text.delta") {
       if (currentItem?.type === "message") {
-        if (!currentItem.content || currentItem.content.length === 0) {
-          continue;
+        currentItem.content = currentItem.content || [];
+        if (currentItem.content.length === 0) {
+          // Some compatible Responses servers begin text deltas immediately
+          // after output_item.added without a content_part.added event.
+          currentItem.content.push({ type: "output_text", text: "", annotations: [] });
         }
         const lastPart = currentItem.content[currentItem.content.length - 1];
         if (isResponsesTextContentPartType(lastPart?.type)) {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -4230,10 +4230,12 @@ async function runEmbeddedAgentInternal(
               durationMs: Date.now() - started,
               agentMeta,
               aborted,
-              systemPromptReport: attempt.systemPromptReport,
-              finalPromptText: attempt.finalPromptText,
+              // Keep terminal text ahead of large diagnostic reports so truncated
+              // harness output still exposes the user-visible result.
               finalAssistantVisibleText,
               finalAssistantRawText,
+              systemPromptReport: attempt.systemPromptReport,
+              finalPromptText: attempt.finalPromptText,
               replayInvalid,
               livenessState,
               agentHarnessResultClassification: attempt.agentHarnessResultClassification,


### PR DESCRIPTION
Accept text deltas without content-part events and keep terminal assistant fields ahead of the large prompt report so compatibility consumers retain the final reply.\n\nTests: 35 focused OpenAI Responses tests passed; the release Kova scenarios previously proved the terminal path end to end.