### PR TITLE
fix(ui): simplify pull request hovercard stats

### DIFF
--- a/ui/src/components/github-link-hovercard.runtime.ts
+++ b/ui/src/components/github-link-hovercard.runtime.ts
@@ -10,7 +10,6 @@ import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../lib/external-link
 import { formatRelativeTimestamp } from "../lib/format.ts";
 import {
   GITHUB_HOVERCARD_OPEN_DELAY_MS,
-  gitHubFilesChangedUrl,
   githubLinkAnchorFromEvent,
   gitHubProfileUrl,
   parseGitHubLinkTarget,
@@ -87,7 +86,6 @@ function parsePreviewResponse(target: GitHubLinkTarget, value: unknown): GitHubP
     ...target,
     additions: asFiniteNumber(value.additions),
     avatarDataUrl: safeAvatarDataUrl(value.avatarDataUrl),
-    changedFiles: asFiniteNumber(value.changedFiles),
     closedAt: readNonBlankString(value.closedAt),
     coAuthorCount: asFiniteNumber(value.coAuthorCount),
     coAuthors: parseCoAuthors(value.coAuthors),
@@ -291,19 +289,9 @@ function renderPreview(card: HTMLDivElement, preview: GitHubPreview): void {
   const metrics = document.createElement("span");
   metrics.className = "github-link-hovercard__metrics";
   if (preview.kind === "pull") {
+    metrics.classList.add("github-link-hovercard__metrics--diff");
     appendMetric(metrics, "github-link-hovercard__metric--additions", `+${preview.additions ?? 0}`);
     appendMetric(metrics, "github-link-hovercard__metric--deletions", `−${preview.deletions ?? 0}`);
-    const files = preview.changedFiles ?? 0;
-    // The diff-size chip's natural next step is the files-changed view; issues
-    // have no such view, so their comment count stays plain text.
-    appendCardLink(
-      metrics,
-      "github-link-hovercard__metric github-link-hovercard__metric--files",
-      gitHubFilesChangedUrl(preview),
-      t(files === 1 ? "githubPreview.file" : "githubPreview.files", {
-        count: String(files),
-      }),
-    );
   } else {
     const comments = preview.comments ?? 0;
     appendMetric(

--- a/ui/src/components/github-link-hovercard.test.ts
+++ b/ui/src/components/github-link-hovercard.test.ts
@@ -238,7 +238,7 @@ describe("openclaw-github-link-hovercard-provider", () => {
     expect(card?.textContent).toContain("steipete");
     expect(card?.textContent).toContain("+101");
     expect(card?.textContent).toContain("−12");
-    expect(card?.textContent).toContain("3 files");
+    expect(card?.textContent).not.toContain("3 files");
     expect(card?.textContent).toContain("5m ago");
     expect(anchor.href).toBe(href);
     // A card that owns a link is an interactive popover, never an ARIA tooltip.
@@ -249,20 +249,25 @@ describe("openclaw-github-link-hovercard-provider", () => {
     expect(anchor.getAttribute("aria-haspopup")).toBe("dialog");
     expect(anchor.getAttribute("aria-expanded")).toBe("true");
     expect(anchor.getAttribute("aria-controls")).toBe(card?.id);
-    // Title, repo reference, author and the files chip are all real links, which
-    // is what makes the card a popover rather than a tooltip.
+    // Title, repo reference, and author are real links, which is what makes the
+    // card a popover rather than a tooltip.
     const cardLink = (selector: string) =>
       card?.querySelector<HTMLAnchorElement>(`.github-link-hovercard__${selector}`);
     expect(cardLink("title")?.getAttribute("href")).toBe(href);
     expect(cardLink("repo")?.getAttribute("href")).toBe(href);
     expect(cardLink("author")?.getAttribute("href")).toBe("https://github.com/steipete");
-    expect(cardLink("metric--files")?.getAttribute("href")).toBe(`${href}/files`);
-    for (const selector of ["title", "repo", "author", "metric--files"]) {
+    expect(card?.querySelector(".github-link-hovercard__metric--files")).toBeNull();
+    for (const selector of ["title", "repo", "author"]) {
       expect(cardLink(selector)?.target).toBe("_blank");
       expect(cardLink(selector)?.rel.split(/\s+/)).toEqual(
         expect.arrayContaining(["noopener", "noreferrer"]),
       );
     }
+    const diffMetrics = card?.querySelector(".github-link-hovercard__metrics--diff");
+    expect(diffMetrics?.children).toHaveLength(2);
+    expect([...(diffMetrics?.children ?? [])].every((metric) => metric.tagName === "SPAN")).toBe(
+      true,
+    );
     expect(request).toHaveBeenCalledWith(
       "controlUi.githubPreview",
       {

--- a/ui/src/components/github-link-target.ts
+++ b/ui/src/components/github-link-target.ts
@@ -56,13 +56,6 @@ export function gitHubProfileUrl(login: string): string {
   return `https://${GITHUB_HOST}/${encodeURIComponent(login)}`;
 }
 
-// Build from parsed parts because the source href may already carry its own
-// sub-path, query, or comment fragment.
-export function gitHubFilesChangedUrl(target: GitHubItemTarget): string {
-  const repoPath = `${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}`;
-  return `https://${GITHUB_HOST}/${repoPath}/pull/${target.number}/files`;
-}
-
 export function githubLinkAnchorFromEvent(event: Event): HTMLAnchorElement | null {
   for (const candidate of event.composedPath()) {
     if (candidate instanceof HTMLAnchorElement) {

--- a/ui/src/e2e/github-link-hovercard.e2e.test.ts
+++ b/ui/src/e2e/github-link-hovercard.e2e.test.ts
@@ -312,7 +312,8 @@ describeControlUiE2e("GitHub link hover cards", () => {
     await expectText(card, "openclaw/openclaw #99816");
     await expectText(card, "+101");
     await expectText(card, "−12");
-    await expectText(card, "3 files");
+    expect(await card.getByText("3 files", { exact: true }).count()).toBe(0);
+    expect(await card.locator(".github-link-hovercard__metric--files").count()).toBe(0);
     await page.clock.runFor(300);
     await captureArtifact(page, "github-hovercard-title-tooltip");
     await expect.poll(() => page.locator("openclaw-tooltip[open]").count()).toBe(0);
@@ -466,7 +467,7 @@ describeControlUiE2e("GitHub link hover cards", () => {
 
     // The title owns the card's only underline; the other links stay quiet even
     // under the pointer, so the card keeps reading as a preview and not a menu.
-    for (const quiet of ["repo", "author", "metric--files"]) {
+    for (const quiet of ["repo", "author"]) {
       const link = card.locator(`.github-link-hovercard__${quiet}`);
       await link.hover();
       expect(await link.evaluate((el) => getComputedStyle(el).textDecorationLine)).toBe("none");
@@ -483,14 +484,6 @@ describeControlUiE2e("GitHub link hover cards", () => {
     const popup = await popupPromise;
     await popup.waitForLoadState("domcontentloaded");
     expect(popup.url()).toBe("https://github.com/openclaw/openclaw/pull/99816");
-
-    // The diff-size chip is the card's deep link into the files-changed view.
-    const filesPopupPromise = page.waitForEvent("popup");
-    await card.locator(".github-link-hovercard__metric--files").click();
-    const filesPopup = await filesPopupPromise;
-    await filesPopup.waitForLoadState("domcontentloaded");
-    expect(filesPopup.url()).toBe("https://github.com/openclaw/openclaw/pull/99816/files");
-    await filesPopup.close();
 
     // The click focused the title link inside the card; leaving the card still
     // dismisses it with no click-outside required (github-link-hovercard.runtime.ts

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1291,8 +1291,8 @@ openclaw-session-progress-hovercard-provider {
   box-shadow: 0 0 0 3px color-mix(in srgb, currentColor 14%, transparent);
 }
 
-/* The repo reference, author and files chip are links too, but the title owns
-   the card's only underline; the rest stay text until hovered or focused. */
+/* The repo reference and author are links too, but the title owns the card's
+   only underline; the rest stay text until hovered or focused. */
 .github-link-hovercard__repo {
   min-width: 0;
   color: inherit;
@@ -1394,6 +1394,11 @@ openclaw-session-progress-hovercard-provider {
   gap: 6px;
 }
 
+.github-link-hovercard__metrics--diff .github-link-hovercard__metric {
+  padding: 0;
+  background: none;
+}
+
 .github-link-hovercard__metric {
   padding: 4px 8px;
   border-radius: var(--radius-sm);
@@ -1403,17 +1408,6 @@ openclaw-session-progress-hovercard-provider {
   font-size: var(--control-ui-text-sm);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
-}
-
-.github-link-hovercard__metric--files {
-  text-decoration: none;
-}
-
-.github-link-hovercard__metric--files:hover,
-.github-link-hovercard__metric--files:focus-visible {
-  background: var(--bg-muted);
-  color: var(--text-strong);
-  text-decoration: none;
 }
 
 .github-link-hovercard__metric--additions {
@@ -1490,6 +1484,10 @@ openclaw-session-progress-hovercard-provider {
     align-items: flex-start;
     flex-direction: column;
     gap: 10px;
+  }
+
+  .github-link-hovercard__metrics--diff {
+    align-self: flex-end;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Pull request hovercards showed a redundant changed-file count and boxed every diff statistic, making the footer visually heavier than intended.

## Why This Change Was Made

Pull request previews now omit the changed-file count and render additions/deletions as unboxed text at the bottom-right. Issue comment metrics remain unchanged. The obsolete files-changed deep-link helper was removed.

## User Impact

Pull request previews are cleaner: users see only additions and deletions, aligned at the bottom-right, without a changed-file badge.

## Evidence

- Before/after Control UI proof at 1366×768; responsive verification at 390×844, 768×1024, and 1440×900.
- `node scripts/run-vitest.mjs ui/src/components/github-link-hovercard.test.ts` — 18 passed.
- `OPENCLAW_UI_E2E_ARTIFACT_DIR=.artifacts/pr-hovercard-proof/e2e pnpm test:ui:e2e -- ui/src/e2e/github-link-hovercard.e2e.test.ts` — 7 passed.
- `pnpm check:changed` — passed.
- Scoped autoreview — clean.

Before/after screenshots: https://github.com/openclaw/openclaw/pull/134791#issuecomment-5488842151
