### PR TITLE
test(agents): reuse the native extension loader owner

### DIFF
--- a/src/agents/sessions/extensions/loader.native-js.test.ts
+++ b/src/agents/sessions/extensions/loader.native-js.test.ts
@@ -28,30 +28,26 @@ vi.mock("jiti/static", () => ({
 }));
 
 const tempDirs: string[] = [];
-let preloadedClearExtensionCache: typeof import("./loader.js").clearExtensionCache;
-let preloadedLoadExtensionsCached: typeof import("./loader.js").loadExtensionsCached;
+let clearExtensionCache: typeof import("./loader.js").clearExtensionCache;
+let loadExtensionsCached: typeof import("./loader.js").loadExtensionsCached;
 
 beforeAll(async () => {
-  ({
-    clearExtensionCache: preloadedClearExtensionCache,
-    loadExtensionsCached: preloadedLoadExtensionsCached,
-  } = await import("./loader.js"));
+  vi.resetModules();
+  ({ clearExtensionCache, loadExtensionsCached } = await import("./loader.js"));
 });
 
 beforeEach(() => {
-  vi.resetModules();
-  preloadedClearExtensionCache();
   jitiCalls.imports.length = 0;
   jitiCalls.options.length = 0;
 });
 
 afterEach(async () => {
+  clearExtensionCache();
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
 });
 
 describe("loadExtensionsCached native JavaScript path", () => {
   it("loads compiled JavaScript extensions without creating a jiti loader", async () => {
-    const loadExtensionsCached = preloadedLoadExtensionsCached;
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.mjs");
@@ -79,7 +75,6 @@ export default async function extension(api) {
   it("reloads native JavaScript extensions when the file changes without stat-key drift", async () => {
     // Explicit reload clears the factory cache. Native imports still need a
     // fresh URL so same-size, same-mtime edits are observed.
-    const { clearExtensionCache, loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.cjs");
@@ -118,7 +113,6 @@ module.exports = async function(api) {
   });
 
   it("loads transpiled CommonJS default exports through the native path", async () => {
-    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.cjs");
@@ -143,7 +137,6 @@ exports.default = async function(api) {
   });
 
   it("keeps CommonJS-shaped .js extensions on jiti", async () => {
-    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     await writeFile(join(dir, "package.json"), '{"type":"module"}\n');
@@ -169,7 +162,6 @@ module.exports = async function(api) {
   });
 
   it("keeps plain ESM .js extensions on jiti", async () => {
-    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.js");
@@ -196,7 +188,6 @@ export default async function extension(api) {
   it("keeps SDK-alias JavaScript extensions on one shared jiti loader", async () => {
     // SDK aliases need jiti's virtual resolution, but one shared loader keeps
     // multi-extension imports consistent and cheap.
-    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const firstPath = join(dir, "first.js");
@@ -222,7 +213,6 @@ module.exports = async function(api) {
   });
 
   it("keeps TypeBox-alias JavaScript extensions on jiti", async () => {
-    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.js");
@@ -250,7 +240,6 @@ module.exports = async function(api) {
   it("keeps multi-file JavaScript extensions on jiti for graph-wide aliases", async () => {
     // Alias detection walks relative helper files; a clean entrypoint can still
     // need jiti when its dependency graph imports SDK/TypeBox aliases.
-    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.js");
@@ -277,7 +266,6 @@ module.exports = async function(api) {
   });
 
   it("keeps ESM re-export JavaScript extensions on jiti for graph-wide aliases", async () => {
-    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     await writeFile(join(dir, "package.json"), '{"type":"module"}\n');
@@ -305,7 +293,6 @@ export default async function extension(api) {
   });
 
   it("keeps minified ESM relative imports on jiti for graph-wide aliases", async () => {
-    const { loadExtensionsCached } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.mjs");


### PR DESCRIPTION
## What Problem This Solves

The native extension tests clear one preloaded owner's cache but reload a different owner graph in nine cases. That repeats module and SDK/native-resolver setup.

## Why This Change Was Made

Share one owner graph and clear its actual factory cache after each case, before removing the temporary directories. Keep the initial module reset, fresh per-load runtime/transformer context, and all per-case Jiti trace cleanup. Ten owner imports and resets become one each.

## User Impact

Test-only. All ten case labels and 43 assertions remain, including same-size, same-timestamp native reloads. Production +0/-0; tests +5/-18.

## Evidence

All 17 selected native, Bun, real-Jiti and resource-loader cases pass before and after under the normal agents-support project, with identical labels/statuses. Removing the explicit cache clear makes the retained native reload assertion fail; the exact test bytes were restored.

Full changed checks, the complete build and Codex autoreview pass.

Measured wall seconds were 128.39 before and 14.81 after; maximum RSS was 1,716,518,912 and 1,813,856,256 bytes. Host load and worker preparation differed substantially, so these are raw observations, not an attributable speedup or memory improvement.

Reviewed the cache owner, actual resource-loader caller, per-load transformer context, aliases/native resolver, installed Jiti entrypoints and original cache/import history. All fixture source, timeout arguments and production code remain unchanged.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/sessions/extensions/loader.native-js.test.ts src/agents/sessions/extensions/loader.bun-virtual-modules.test.ts src/agents/sessions/extensions/loader.test.ts src/agents/sessions/resource-loader.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base 742801a82ae
pnpm build
```
