### PR TITLE
perf(test): avoid packaging checks for native Swift test edits

### DIFF
--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -132,7 +132,7 @@ const ANDROID_VERSION_SYNC_PATHS = new Set([
   "apps/android/version.json",
 ]);
 const MACOS_APP_CI_PATH_RE =
-  /^(?:apps\/(?:macos|macos-mlx-tts|shared|swabble)\/|Swabble\/|src\/(?:shared\/worker-bundle-hash\.ts|worker\/workspace-rsync-receiver\.ts|gateway\/worker-environments\/workspace-(?:accepted-(?:remote-script|sync)|mutation-remote-script|rsync-path\.test|sync(?:-helpers)?)\.ts)$)/u;
+  /^(?:apps\/(?:macos\/(?!Tests\/.+\.swift$)|(?:macos-mlx-tts|shared|swabble)\/)|Swabble\/|src\/(?:shared\/worker-bundle-hash\.ts|worker\/workspace-rsync-receiver\.ts|gateway\/worker-environments\/workspace-(?:accepted-(?:remote-script|sync)|mutation-remote-script|rsync-path\.test|sync(?:-helpers)?)\.ts)$)/u;
 let corepackPnpmShimDir: string | undefined;
 let corepackPnpmShimCleanupRegistered = false;
 let cachedGeneratedExtensionAssetPaths: Set<string> | undefined;
@@ -163,6 +163,7 @@ function hasAndroidVersionSyncPath(paths: string[]) {
 
 function hasMacosAppCiPath(paths: string[]) {
   // Native-source policy stays local; script and test owners share the CI selector.
+  // Swift test-target sources do not feed the packaged app; native CI still covers them.
   return paths.some((changedPath) => {
     const normalized = normalizeChangedPath(changedPath);
     return MACOS_APP_CI_PATH_RE.test(normalized) || isMacosToolingPath(normalized);

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -2166,6 +2166,8 @@ describe("scripts/changed-lanes", () => {
   it("runs macOS app CI tests for macOS app dependency changes", () => {
     for (const changedPath of [
       "apps/macos/Sources/OpenClawMac/AppDelegate.swift",
+      "apps/macos/Package.swift",
+      "apps/macos/Tests/OpenClawIPCTests/Fixtures/state.json",
       "apps/macos-mlx-tts/Sources/OpenClawMLXTTS/main.swift",
       "apps/shared/OpenClawKit/Sources/OpenClawKit/Client.swift",
       "apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift",
@@ -2194,6 +2196,41 @@ describe("scripts/changed-lanes", () => {
         }),
       );
     }
+  });
+
+  it.each([
+    "apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift",
+    "./apps/macos/Tests/OpenClawIPCTests/RemovedTests.swift",
+    "apps\\macos\\Tests\\OpenClawIPCTests\\Nested\\WorkerTests.swift",
+  ])("keeps Swift test-only changes out of local packaging tests: %s", (changedPath) => {
+    const plan = createChangedCheckPlan(detectChangedLanes([changedPath]), {
+      env: { PATH: "/usr/bin" },
+      platform: "darwin",
+      swiftlintAvailable: true,
+    });
+
+    expect(plan.commands.map((command) => command.args[0])).toContain("lint:apps");
+    expect(plan.commands.map((command) => command.name)).toContain(
+      "native state schema version guard",
+    );
+    expect(plan.commands.map((command) => command.args[0])).not.toContain("test:macos:ci");
+  });
+
+  it("preserves the full changed gate alongside a Swift test change", () => {
+    const fullPlan = createChangedCheckPlan(detectChangedLanes(["pnpm-lock.yaml"]));
+    const mixedPlan = createChangedCheckPlan(
+      detectChangedLanes([
+        "pnpm-lock.yaml",
+        "apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift",
+      ]),
+    );
+    const withoutFormat = (plan: typeof fullPlan) =>
+      plan.commands.filter((command) => command.name !== "format changed files");
+
+    expect(fullPlan.commands.map((command) => command.args[0])).toEqual(
+      expect.arrayContaining(["tsgo:all", "lint"]),
+    );
+    expect(withoutFormat(mixedPlan)).toEqual(withoutFormat(fullPlan));
   });
 
   it("runs macOS CI tests for workspace rsync receiver owners", () => {
@@ -2243,64 +2280,73 @@ describe("scripts/changed-lanes", () => {
     }
   });
 
-  it("runs macOS app CI tests for macOS packaging scripts and owner tests", () => {
-    for (const changedPath of [
-      "scripts/codesign-mac-app.sh",
-      "scripts/create-dmg.sh",
-      "scripts/lib/plistbuddy.sh",
-      "scripts/lib/swift-toolchain.sh",
-      "scripts/mac-elevation-host.sh",
-      "scripts/notarize-mac-artifact.sh",
-      "scripts/package-mac-app.sh",
-      "scripts/package-mac-dist.sh",
-      "scripts/restart-mac.sh",
-      "scripts/stage-mac-node-worker.sh",
-      "scripts/test-macos-native.mts",
-      "test/scripts/macos-native-test-launch.test.ts",
-      "scripts/verify-mac-node-worker.mjs",
-      "scripts/verify-mac-node-worker-fs.mjs",
-      "scripts/materialize-mac-node-worker.py",
-      "scripts/lib/mac-app-bundle.sh",
-      "scripts/lib/mac-native-inventory.py",
-      "scripts/lib/mac-worker-portability.mjs",
-      "scripts/lib/mac-node-worker-proof-state.mjs",
-      "scripts/lib/mac-bundle-mutation.py",
-      "test/helpers/mac-native.ts",
-      "test/helpers/mac-signing.ts",
-      "test/scripts/mac-node-worker.test.ts",
-      "test/scripts/verify-mac-node-worker-fs.test.ts",
-      "test/scripts/restart-mac.test.ts",
-      "test/scripts/mac-elevation-artifact.test-support.ts",
-      "test/scripts/mac-native-fixtures.test-support.ts",
-      "test/scripts/mac-node-worker-materialization.test-support.ts",
-      "test/scripts/codesign-mac-app.test.ts",
-      "test/scripts/create-dmg.test.ts",
-      "test/scripts/mac-elevation-host.test.ts",
-      "test/scripts/notarize-mac-artifact.test.ts",
-      "test/scripts/package-mac-app.test.ts",
-      "test/scripts/package-mac-dist.test.ts",
-    ]) {
-      const result = detectChangedLanes([changedPath]);
-      const plan = createChangedCheckPlan(result, {
-        env: { PATH: "/usr/bin" },
-        platform: "linux",
-        swiftlintAvailable: false,
-      });
+  it.each([false, true])(
+    "runs macOS app CI tests for macOS packaging scripts and owner tests (mixed Swift test: %s)",
+    (includeSwiftTest) => {
+      for (const changedPath of [
+        "scripts/codesign-mac-app.sh",
+        "scripts/create-dmg.sh",
+        "scripts/lib/plistbuddy.sh",
+        "scripts/lib/swift-toolchain.sh",
+        "scripts/mac-elevation-host.sh",
+        "scripts/notarize-mac-artifact.sh",
+        "scripts/package-mac-app.sh",
+        "scripts/package-mac-dist.sh",
+        "scripts/restart-mac.sh",
+        "scripts/stage-mac-node-worker.sh",
+        "scripts/test-macos-native.mts",
+        "test/scripts/macos-native-test-launch.test.ts",
+        "scripts/verify-mac-node-worker.mjs",
+        "scripts/verify-mac-node-worker-fs.mjs",
+        "scripts/materialize-mac-node-worker.py",
+        "scripts/lib/mac-app-bundle.sh",
+        "scripts/lib/mac-native-inventory.py",
+        "scripts/lib/mac-worker-portability.mjs",
+        "scripts/lib/mac-node-worker-proof-state.mjs",
+        "scripts/lib/mac-bundle-mutation.py",
+        "test/helpers/mac-native.ts",
+        "test/helpers/mac-signing.ts",
+        "test/scripts/mac-node-worker.test.ts",
+        "test/scripts/verify-mac-node-worker-fs.test.ts",
+        "test/scripts/restart-mac.test.ts",
+        "test/scripts/mac-elevation-artifact.test-support.ts",
+        "test/scripts/mac-native-fixtures.test-support.ts",
+        "test/scripts/mac-node-worker-materialization.test-support.ts",
+        "test/scripts/codesign-mac-app.test.ts",
+        "test/scripts/create-dmg.test.ts",
+        "test/scripts/mac-elevation-host.test.ts",
+        "test/scripts/notarize-mac-artifact.test.ts",
+        "test/scripts/package-mac-app.test.ts",
+        "test/scripts/package-mac-dist.test.ts",
+      ]) {
+        const result = detectChangedLanes([
+          changedPath,
+          ...(includeSwiftTest
+            ? ["apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift"]
+            : []),
+        ]);
+        const plan = createChangedCheckPlan(result, {
+          env: { PATH: "/usr/bin" },
+          platform: "linux",
+          swiftlintAvailable: false,
+        });
 
-      expectLanes(result.lanes, {
-        scripts: changedPath.endsWith(".mts"),
-        testRoot: changedPath.endsWith(".ts"),
-        tooling: true,
-      });
-      expect(plan.commands.map((command) => command.args[0])).not.toContain("lint:apps");
-      expect(plan.commands).toContainEqual(
-        expect.objectContaining({
-          name: "macOS app CI tests",
-          args: ["test:macos:ci"],
-        }),
-      );
-    }
-  });
+        expectLanes(result.lanes, {
+          scripts: changedPath.endsWith(".mts"),
+          testRoot: changedPath.endsWith(".ts"),
+          tooling: true,
+          apps: includeSwiftTest,
+        });
+        expect(plan.commands.map((command) => command.args[0])).not.toContain("lint:apps");
+        expect(plan.commands).toContainEqual(
+          expect.objectContaining({
+            name: "macOS app CI tests",
+            args: ["test:macos:ci"],
+          }),
+        );
+      }
+    },
+  );
 
   it("routes appcast changes to appcast owner tests", () => {
     const result = detectChangedLanes(["appcast.xml"]);


### PR DESCRIPTION
## What Problem This Solves

Changing a macOS Swift test currently makes local `check:changed` run all 19 TypeScript packaging, signing and installer test files. Those files do not consume Swift test-target sources, so this adds substantial unrelated work to native test repair iterations.

## Why This Change Was Made

Exclude only `apps/macos/Tests/**/*.swift` from the local packaging-test selector. Keep native lint, schema guards and hosted native CI coverage. Production Swift, package manifests, non-Swift test resources and mixed changes that include a packaging owner still select the packaging suite.

The shared CI classifier and workflow are unchanged. Full changed checks and full release verification retain their existing coverage. The repair modifies the existing selection rule rather than introducing another runner or a skip flag.

## Evidence

- Before the fix, all three representative Swift-test exclusions fail; product/resource/mixed/full controls pass.
- The complete 205-test selection owner suite passed on the inherited Vitest 4.1.10 installation; the declared version is 4.1.11. Final focused proof uses pinned Vitest 4.1.11 and covers normalized, nested and deleted Swift test paths, unchanged full-mode selection, and existing CI native/full-scope controls. Every packaging-owner table entry is checked both alone and alongside a Swift test change.
- After correcting task-private dependency links to the verified pinned installation, all 19 selected changed-file checks pass, including scripts/test-root types, lint and formatting. Independent P0–P2 review is scoped-clean. Required exact-head CI remains a landing gate.
- No whole-release timing improvement is claimed from this local selector change. It removes an unnecessary 19-file suite for this specific input class without changing test deadlines, assertions or release gates.
