### PR TITLE
fix(anthropic): retain Claude subprocess failure diagnostics

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -400,6 +400,13 @@ Claude CLI backends scale this cap with the resolved Claude context window inste
 
 ## Troubleshooting
 
+When a local Claude Agent SDK subprocess fails, its run error includes a bounded,
+redacted stderr diagnostic when available. Check the run error or `openclaw logs`
+for the underlying launch, permission, or runtime failure. Successful turns do not
+forward stderr into logs, and diagnostics from earlier warm turns are discarded.
+Oversized incomplete lines are omitted so truncation cannot expose credential
+fragments. Native stdout and MCP input are not included in these diagnostics.
+
 | Symptom               | Fix                                                                                            |
 | --------------------- | ---------------------------------------------------------------------------------------------- |
 | CLI not found         | Put the CLI on the gateway service's `PATH`, or update the owning plugin's registered command. |

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -403,9 +403,13 @@ Claude CLI backends scale this cap with the resolved Claude context window inste
 When a local Claude Agent SDK subprocess fails, its run error includes a bounded,
 redacted stderr diagnostic when available. Check the run error or `openclaw logs`
 for the underlying launch, permission, or runtime failure. Successful turns do not
-forward stderr into logs, and diagnostics from earlier warm turns are discarded.
+forward stderr into logs. Each live process has its own diagnostic buffer. Since
+stderr has no turn identifiers, a warm process's failure can include earlier turns;
+the error labels that output as process-wide rather than attributing it to the failing turn.
 Oversized incomplete lines are omitted so truncation cannot expose credential
 fragments. Native stdout and MCP input are not included in these diagnostics.
+Stderr is supplemental display text only; it does not change the native error's
+retry, authentication, timeout, or fallback classification.
 
 | Symptom               | Fix                                                                                            |
 | --------------------- | ---------------------------------------------------------------------------------------------- |

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -55,6 +55,17 @@ Provider and channel execution paths must use the active runtime config snapshot
 
 ## Reusable runtime utilities
 
+Use `attachErrorDiagnostic(error, text)` from `openclaw/plugin-sdk/error-runtime`
+to attach supplemental operator diagnostics to a thrown error without changing
+its identity, message, or failure classification. Mask opaque credentials first;
+the helper also redacts recognized secrets and retains at most 2,048 characters.
+`formatErrorMessageForDisplay(error)` includes the nearest attached diagnostic
+through nested causes and aggregates. Use it only at terminal display boundaries,
+never for retry or authentication decisions. Agent lifecycle errors and terminal
+CLI logs render these diagnostics automatically; successful runs remain quiet.
+Native RPC error messages retain their original text; `agent.wait` renders the
+supplemental diagnostic at its terminal result boundary.
+
 Channel plugins must admit authenticated agent turns through their injected
 `api.runtime.agent.runCommandFromIngress(options, runtime)` capability. The host
 accepts owner authority only from the exact active, trusted plugin registered for

--- a/extensions/anthropic/agent-sdk-process.test.ts
+++ b/extensions/anthropic/agent-sdk-process.test.ts
@@ -4,16 +4,21 @@ import path from "node:path";
 import type {
   CliBackendExecuteContext,
   CliBackendLiveSessionHandle,
+  CliBackendPreparedExecution,
 } from "openclaw/plugin-sdk/cli-backend";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ClaudeAgentSdkSecretInput } from "./agent-sdk-process.js";
 import { executeClaudeAgentSdk } from "./agent-sdk.runtime.js";
+import { buildAnthropicCliBackend } from "./cli-backend.js";
 
 const roots: string[] = [];
 const sessions = new Set<CliBackendLiveSessionHandle>();
 
 const PROTOCOL_CHILD = `
   import { createInterface } from "node:readline";
-  import { writeSync } from "node:fs";
+  import { readFileSync, writeSync } from "node:fs";
+  const credential = process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR
+    ? readFileSync(3, "utf8") : "";
   const send = (message) => process.stdout.write(JSON.stringify(message) + "\\n");
   createInterface({ input: process.stdin }).on("line", (line) => {
     const message = JSON.parse(line);
@@ -25,7 +30,8 @@ const PROTOCOL_CHILD = `
       const text = message.message.content;
       if (text === "fail silently") process.exit(1);
       if (text === "fail noisily") {
-        writeSync(2, "PermissionError: current turn failed\\n");
+        writeSync(2, "PermissionError: current turn failed " + credential + "\\n");
+        writeSync(2, "process environment: " + process.env.OPENCLAW_MCP_TOKEN + "\\n");
         process.exit(1);
       }
       if (text === "success with stderr") writeSync(2, "previous turn diagnostic\\n");
@@ -71,9 +77,10 @@ async function contextForChild(source: string): Promise<CliBackendExecuteContext
 async function collect(
   context: CliBackendExecuteContext,
   secretInput?: Parameters<typeof executeClaudeAgentSdk>[1],
+  execute = executeClaudeAgentSdk,
 ) {
   const events: Record<string, unknown>[] = [];
-  for await (const event of executeClaudeAgentSdk(context, secretInput)) {
+  for await (const event of execute(context, secretInput)) {
     events.push(event);
   }
   return events;
@@ -172,10 +179,34 @@ describe("Claude subprocess diagnostics through the real Agent SDK", () => {
     expect(stderr).not.toHaveBeenCalled();
   });
 
-  it.each(["fail silently", "fail noisily"])(
-    "isolates a warm successful turn's stderr from the next turn: %s",
+  it.each(["fail silently", "fail noisily", "close idle"])(
+    "isolates a managed-auth warm turn after credential cleanup: %s",
     async (prompt) => {
       const context = await contextForChild(PROTOCOL_CHILD);
+      const credential = "opaque-warm-credential-fixture";
+      const processGrant = "opaque-first-process-grant-fixture";
+      const backend = buildAnthropicCliBackend();
+      const prepare = async () => {
+        // The descriptor is a provider-private field, outside the public SDK result type.
+        const prepared = (await backend.prepareExecution?.({
+          workspaceDir: context.cwd,
+          provider: "claude-cli",
+          modelId: context.modelId,
+          executionMode: "agent",
+          authCredential: { type: "token", token: credential },
+        } as Parameters<NonNullable<typeof backend.prepareExecution>>[0])) as
+          | (CliBackendPreparedExecution & { secretInput?: ClaudeAgentSdkSecretInput })
+          | undefined;
+        if (!prepared?.execute || !prepared.secretInput || !prepared.cleanup) {
+          throw new Error("Expected a managed Claude SDK execution.");
+        }
+        return {
+          ...prepared,
+          execute: prepared.execute,
+          secretInput: prepared.secretInput,
+          cleanup: prepared.cleanup,
+        };
+      };
       let current: CliBackendLiveSessionHandle | undefined;
       context.liveSession = {
         fingerprint: "synthetic-process-policy",
@@ -192,18 +223,55 @@ describe("Claude subprocess diagnostics through the real Agent SDK", () => {
         },
       };
       const stderr = vi.spyOn(process.stderr, "write");
-      await expect(collect({ ...context, prompt: "success with stderr" })).resolves.toContainEqual(
-        expect.objectContaining({ result: "ok" }),
-      );
+      const first = await prepare();
+      const buffers: Buffer[] = [];
+      const createData = first.secretInput.createData;
+      vi.spyOn(first.secretInput, "createData").mockImplementation(() => {
+        const bytes = createData();
+        buffers.push(bytes);
+        return bytes;
+      });
+      await expect(
+        collect(
+          {
+            ...context,
+            env: { ...context.env, ...first.env, OPENCLAW_MCP_TOKEN: processGrant },
+            prompt: "success with stderr",
+          },
+          undefined,
+          first.execute,
+        ),
+      ).resolves.toContainEqual(expect.objectContaining({ result: "ok" }));
+      await first.cleanup();
+      expect(() => first.secretInput.createData()).toThrow("no longer available");
       expect(current?.isIdle()).toBe(true);
-      const error = await collect({ ...context, prompt, useResume: true }).catch(
-        (failure: unknown) => failure,
-      );
-      expect(String(error)).toContain("exited with code 1");
-      expect(String(error)).not.toContain("previous turn diagnostic");
-      expect(String(error).includes("PermissionError: current turn failed")).toBe(
-        prompt === "fail noisily",
-      );
+      if (prompt === "close idle") {
+        const closing = current;
+        closing?.close("idle");
+        await closing?.waitForExit();
+      } else {
+        const second = await prepare();
+        const error = await collect(
+          {
+            ...context,
+            env: { ...context.env, ...second.env, OPENCLAW_MCP_TOKEN: "opaque-next-grant-fixture" },
+            prompt,
+            useResume: true,
+          },
+          undefined,
+          second.execute,
+        ).catch((failure: unknown) => failure);
+        await second.cleanup();
+        expect(String(error)).toContain("exited with code 1");
+        expect(String(error)).not.toContain("previous turn diagnostic");
+        expect(String(error)).not.toContain(credential);
+        expect(String(error)).not.toContain(processGrant);
+        expect(String(error).includes("PermissionError: current turn failed")).toBe(
+          prompt === "fail noisily",
+        );
+      }
+      expect(buffers.length).toBeGreaterThan(0);
+      expect(buffers.every((bytes) => bytes.every((byte) => byte === 0))).toBe(true);
       expect(stderr).not.toHaveBeenCalled();
     },
   );

--- a/extensions/anthropic/agent-sdk-process.test.ts
+++ b/extensions/anthropic/agent-sdk-process.test.ts
@@ -6,6 +6,7 @@ import type {
   CliBackendLiveSessionHandle,
   CliBackendPreparedExecution,
 } from "openclaw/plugin-sdk/cli-backend";
+import { formatErrorMessageForDisplay } from "openclaw/plugin-sdk/error-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ClaudeAgentSdkSecretInput } from "./agent-sdk-process.js";
 import { executeClaudeAgentSdk } from "./agent-sdk.runtime.js";
@@ -20,6 +21,7 @@ const PROTOCOL_CHILD = `
   const credential = process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR
     ? readFileSync(3, "utf8") : "";
   const send = (message) => process.stdout.write(JSON.stringify(message) + "\\n");
+  let delayedDiagnostic = "";
   createInterface({ input: process.stdin }).on("line", (line) => {
     const message = JSON.parse(line);
     if (message.type === "control_request") {
@@ -28,13 +30,20 @@ const PROTOCOL_CHILD = `
       } });
     } else if (message.type === "user") {
       const text = message.message.content;
+      if (delayedDiagnostic) {
+        writeSync(2, delayedDiagnostic);
+        delayedDiagnostic = "";
+      }
       if (text === "fail silently") process.exit(1);
-      if (text === "fail noisily") {
+      if (text === "fail noisily" || text === "exit without result") {
         writeSync(2, "PermissionError: current turn failed " + credential + "\\n");
         writeSync(2, "process environment: " + process.env.OPENCLAW_MCP_TOKEN + "\\n");
-        process.exit(1);
+        process.exit(text === "exit without result" ? 0 : 1);
       }
       if (text === "success with stderr") writeSync(2, "previous turn diagnostic\\n");
+      if (text === "success with delayed stderr") {
+        delayedDiagnostic = "previous turn diagnostic " + credential + "\\n";
+      }
       send({ type: "result", subtype: "success", is_error: false, result: "ok",
         session_id: "synthetic-session", duration_ms: 1, duration_api_ms: 1,
         num_turns: 1, total_cost_usd: 0, usage: {}, modelUsage: {}, permission_denials: [],
@@ -86,6 +95,25 @@ async function collect(
   return events;
 }
 
+function attachLiveSession(context: CliBackendExecuteContext) {
+  let current: CliBackendLiveSessionHandle | undefined;
+  context.liveSession = {
+    fingerprint: "synthetic-process-policy",
+    current: () => current,
+    register: (handle) => {
+      current = handle;
+      sessions.add(handle);
+    },
+    activate: () => {},
+    remove: (handle) => {
+      if (current === handle) {
+        current = undefined;
+      }
+    },
+  };
+  return () => current;
+}
+
 describe("Claude subprocess diagnostics through the real Agent SDK", () => {
   it("drains pipe-sized stderr and reports a bounded redacted fatal diagnostic", async () => {
     const secret = "sk-ant-api03-synthetic-diagnostic-credential-123456789";
@@ -99,12 +127,13 @@ describe("Claude subprocess diagnostics through the real Agent SDK", () => {
     `);
     const error = await collect(context).catch((failure: unknown) => failure);
     expect(error).toBeInstanceOf(Error);
-    expect(String(error)).toContain("exited with code 1");
-    expect(String(error)).toContain("PermissionError: [Errno 1]");
-    expect(String(error)).toContain("'/bin/ps' 🦞");
-    expect(String(error)).not.toContain(secret);
-    expect(String(error)).not.toContain("discarded noise");
-    expect(String(error).length).toBeLessThan(2_200);
+    expect((error as Error).message).toBe("Claude Code process exited with code 1");
+    expect(formatErrorMessageForDisplay(error)).toContain("exited with code 1");
+    expect(formatErrorMessageForDisplay(error)).toContain("PermissionError: [Errno 1]");
+    expect(formatErrorMessageForDisplay(error)).toContain("'/bin/ps' 🦞");
+    expect(formatErrorMessageForDisplay(error)).not.toContain(secret);
+    expect(formatErrorMessageForDisplay(error)).not.toContain("discarded noise");
+    expect(formatErrorMessageForDisplay(error).length).toBeLessThan(2_200);
   });
 
   it("preserves a silent child's exit error without inventing stderr", async () => {
@@ -135,15 +164,15 @@ describe("Claude subprocess diagnostics through the real Agent SDK", () => {
       },
     });
     const error = await running.catch((failure: unknown) => failure);
-    expect(String(error)).toContain("PermissionError: denied resource 3");
-    expect(String(error)).toContain("[REDACTED]");
+    expect(formatErrorMessageForDisplay(error)).toContain("PermissionError: denied resource 3");
+    expect(formatErrorMessageForDisplay(error)).toContain("[REDACTED]");
     for (const privateText of [
       credential,
       grant,
       "native stdout must stay private",
       context.prompt,
     ]) {
-      expect(String(error)).not.toContain(privateText);
+      expect(formatErrorMessageForDisplay(error)).not.toContain(privateText);
     }
     expect(buffers.length).toBeGreaterThan(0);
     expect(buffers.every((bytes) => bytes.every((byte) => byte === 0))).toBe(true);
@@ -160,7 +189,8 @@ describe("Claude subprocess diagnostics through the real Agent SDK", () => {
       process.exit(1);
     `);
     try {
-      await expect(collect(context)).rejects.toThrow("PermissionError: parent exited");
+      const error = await collect(context).catch((failure: unknown) => failure);
+      expect(formatErrorMessageForDisplay(error)).toContain("PermissionError: parent exited");
       const pid = Number(await readFile(path.join(context.cwd, "descendant.pid"), "utf8"));
       expect(() => process.kill(pid, 0)).not.toThrow();
     } finally {
@@ -179,9 +209,30 @@ describe("Claude subprocess diagnostics through the real Agent SDK", () => {
     expect(stderr).not.toHaveBeenCalled();
   });
 
-  it.each(["fail silently", "fail noisily", "close idle"])(
-    "isolates a managed-auth warm turn after credential cleanup: %s",
-    async (prompt) => {
+  it("keeps diagnostics isolated between live processes", async () => {
+    const warm = await contextForChild(PROTOCOL_CHILD);
+    attachLiveSession(warm);
+    await collect({ ...warm, prompt: "success with stderr" });
+    const other = await contextForChild("process.exit(1);");
+    attachLiveSession(other);
+    await expect(collect(other)).rejects.toThrow(/^Claude Code process exited with code 1$/);
+    const error = await collect({ ...warm, prompt: "fail silently" }).catch(
+      (failure: unknown) => failure,
+    );
+    expect(formatErrorMessageForDisplay(error)).toContain(
+      "stderr (process-wide; may include earlier turns): previous turn diagnostic",
+    );
+  });
+
+  it.each([
+    { firstPrompt: "success with stderr", prompt: "fail silently" },
+    { firstPrompt: "success with stderr", prompt: "fail noisily" },
+    { firstPrompt: "success with stderr", prompt: "close idle" },
+    { firstPrompt: "success with delayed stderr", prompt: "fail silently" },
+    { firstPrompt: "success with stderr", prompt: "exit without result" },
+  ])(
+    "retains process diagnostics after credential cleanup: $firstPrompt then $prompt",
+    async ({ firstPrompt, prompt }) => {
       const context = await contextForChild(PROTOCOL_CHILD);
       const credential = "opaque-warm-credential-fixture";
       const processGrant = "opaque-first-process-grant-fixture";
@@ -207,21 +258,7 @@ describe("Claude subprocess diagnostics through the real Agent SDK", () => {
           cleanup: prepared.cleanup,
         };
       };
-      let current: CliBackendLiveSessionHandle | undefined;
-      context.liveSession = {
-        fingerprint: "synthetic-process-policy",
-        current: () => current,
-        register: (handle) => {
-          current = handle;
-          sessions.add(handle);
-        },
-        activate: () => {},
-        remove: (handle) => {
-          if (current === handle) {
-            current = undefined;
-          }
-        },
-      };
+      const current = attachLiveSession(context);
       const stderr = vi.spyOn(process.stderr, "write");
       const first = await prepare();
       const buffers: Buffer[] = [];
@@ -236,7 +273,7 @@ describe("Claude subprocess diagnostics through the real Agent SDK", () => {
           {
             ...context,
             env: { ...context.env, ...first.env, OPENCLAW_MCP_TOKEN: processGrant },
-            prompt: "success with stderr",
+            prompt: firstPrompt,
           },
           undefined,
           first.execute,
@@ -244,9 +281,9 @@ describe("Claude subprocess diagnostics through the real Agent SDK", () => {
       ).resolves.toContainEqual(expect.objectContaining({ result: "ok" }));
       await first.cleanup();
       expect(() => first.secretInput.createData()).toThrow("no longer available");
-      expect(current?.isIdle()).toBe(true);
+      expect(current()?.isIdle()).toBe(true);
       if (prompt === "close idle") {
-        const closing = current;
+        const closing = current();
         closing?.close("idle");
         await closing?.waitForExit();
       } else {
@@ -262,13 +299,20 @@ describe("Claude subprocess diagnostics through the real Agent SDK", () => {
           second.execute,
         ).catch((failure: unknown) => failure);
         await second.cleanup();
-        expect(String(error)).toContain("exited with code 1");
-        expect(String(error)).not.toContain("previous turn diagnostic");
-        expect(String(error)).not.toContain(credential);
-        expect(String(error)).not.toContain(processGrant);
-        expect(String(error).includes("PermissionError: current turn failed")).toBe(
-          prompt === "fail noisily",
+        expect(formatErrorMessageForDisplay(error)).toContain(
+          prompt === "exit without result"
+            ? "live session exited unexpectedly"
+            : "exited with code 1",
         );
+        expect(formatErrorMessageForDisplay(error)).toContain(
+          "stderr (process-wide; may include earlier turns):",
+        );
+        expect(formatErrorMessageForDisplay(error)).toContain("previous turn diagnostic");
+        expect(formatErrorMessageForDisplay(error)).not.toContain(credential);
+        expect(formatErrorMessageForDisplay(error)).not.toContain(processGrant);
+        expect(
+          formatErrorMessageForDisplay(error).includes("PermissionError: current turn failed"),
+        ).toBe(prompt === "fail noisily" || prompt === "exit without result");
       }
       expect(buffers.length).toBeGreaterThan(0);
       expect(buffers.every((bytes) => bytes.every((byte) => byte === 0))).toBe(true);

--- a/extensions/anthropic/agent-sdk-process.test.ts
+++ b/extensions/anthropic/agent-sdk-process.test.ts
@@ -68,9 +68,12 @@ async function contextForChild(source: string): Promise<CliBackendExecuteContext
   };
 }
 
-async function collect(context: CliBackendExecuteContext) {
+async function collect(
+  context: CliBackendExecuteContext,
+  secretInput?: Parameters<typeof executeClaudeAgentSdk>[1],
+) {
   const events: Record<string, unknown>[] = [];
-  for await (const event of executeClaudeAgentSdk(context)) {
+  for await (const event of executeClaudeAgentSdk(context, secretInput)) {
     events.push(event);
   }
   return events;
@@ -87,7 +90,7 @@ describe("Claude subprocess diagnostics through the real Agent SDK", () => {
       writeSync(2, "PermissionError: [Errno 1] Operation not permitted: '/bin/ps' 🦞");
       process.exit(1);
     `);
-    const error = await collect(context).catch((error: unknown) => error);
+    const error = await collect(context).catch((failure: unknown) => failure);
     expect(error).toBeInstanceOf(Error);
     expect(String(error)).toContain("exited with code 1");
     expect(String(error)).toContain("PermissionError: [Errno 1]");
@@ -116,19 +119,15 @@ describe("Claude subprocess diagnostics through the real Agent SDK", () => {
     context.env.OPENCLAW_MCP_TOKEN = grant;
     context.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR = "3";
     const buffers: Buffer[] = [];
-    const running = (async () => {
-      for await (const _event of executeClaudeAgentSdk(context, {
-        fd: 3,
-        createData: () => {
-          const bytes = Buffer.from(credential);
-          buffers.push(bytes);
-          return bytes;
-        },
-      })) {
-        /* consume the real SDK stream */
-      }
-    })();
-    const error = await running.catch((error: unknown) => error);
+    const running = collect(context, {
+      fd: 3,
+      createData: () => {
+        const bytes = Buffer.from(credential);
+        buffers.push(bytes);
+        return bytes;
+      },
+    });
+    const error = await running.catch((failure: unknown) => failure);
     expect(String(error)).toContain("PermissionError: denied resource 3");
     expect(String(error)).toContain("[REDACTED]");
     for (const privateText of [
@@ -187,7 +186,9 @@ describe("Claude subprocess diagnostics through the real Agent SDK", () => {
         },
         activate: () => {},
         remove: (handle) => {
-          if (current === handle) current = undefined;
+          if (current === handle) {
+            current = undefined;
+          }
         },
       };
       const stderr = vi.spyOn(process.stderr, "write");
@@ -196,7 +197,7 @@ describe("Claude subprocess diagnostics through the real Agent SDK", () => {
       );
       expect(current?.isIdle()).toBe(true);
       const error = await collect({ ...context, prompt, useResume: true }).catch(
-        (error: unknown) => error,
+        (failure: unknown) => failure,
       );
       expect(String(error)).toContain("exited with code 1");
       expect(String(error)).not.toContain("previous turn diagnostic");

--- a/extensions/anthropic/agent-sdk-process.ts
+++ b/extensions/anthropic/agent-sdk-process.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { setImmediate as settleIo } from "node:timers/promises";
 import type { SpawnOptions, SpawnedProcess } from "@anthropic-ai/claude-agent-sdk";
 import type { CliBackendExecuteContext } from "openclaw/plugin-sdk/cli-backend";
+import { attachErrorDiagnostic } from "openclaw/plugin-sdk/error-runtime";
 import { redactSensitiveFieldValue, redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
 import {
   killProcessTree,
@@ -51,7 +51,7 @@ function spawnClaudeAgentSdkProcess(
   return child;
 }
 
-/** Owns one process's stderr, retaining diagnostics only for its active admitted turn. */
+/** Owns one process's stderr; the SDK does not tag stderr with turn identities. */
 export function createClaudeAgentSdkProcessOwner(
   currentContext: () => CliBackendExecuteContext | undefined,
   secretInput?: ClaudeAgentSdkSecretInput,
@@ -61,10 +61,9 @@ export function createClaudeAgentSdkProcessOwner(
   let environment: SpawnOptions["env"] = {};
   let child: ChildProcessWithoutNullStreams | undefined;
   let drained: Promise<void> | undefined;
-  let owner: CliBackendExecuteContext | undefined;
+  let disposed = false;
   let tail = "";
   let dropPartialLine = false;
-  let atLineBoundary = true;
   const observeStderr = (process: ChildProcessWithoutNullStreams) => {
     child = process;
     drained = new Promise<void>((resolve) => {
@@ -74,15 +73,7 @@ export function createClaudeAgentSdkProcessOwner(
     process.stderr.on("error", () => {}); // A failed diagnostic pipe must not crash the Gateway.
     process.stderr.on("data", (chunk: string) => {
       let text = chunk;
-      const context = currentContext();
-      if (context !== owner) {
-        owner = context;
-        tail = "";
-        // Never attach the suffix of an idle/previous turn's credential line to a new turn.
-        dropPartialLine = !atLineBoundary;
-      }
-      atLineBoundary = text.endsWith("\n");
-      if (!owner) {
+      if (disposed) {
         return;
       }
       if (dropPartialLine) {
@@ -105,20 +96,18 @@ export function createClaudeAgentSdkProcessOwner(
   };
   return {
     [Symbol.dispose]() {
+      disposed = true;
       credential?.fill(0);
       environment = {};
       tail = "";
-      owner = undefined;
     },
-    // stdout/stderr are independent pipes. Drain this poll cycle before releasing a warm turn.
-    settleStderr: () => settleIo(),
     spawn: (options: SpawnOptions) => {
       environment = options.env;
       return spawnClaudeAgentSdkProcess(options, secretInput, observeStderr);
     },
     async withDiagnostics(error: unknown): Promise<unknown> {
       const context = currentContext();
-      if (!context || context.abortSignal?.aborted) {
+      if (disposed || !context || context.abortSignal?.aborted) {
         return error;
       }
       // Custom SDK spawners report exit before stderr EOF. Descendants may keep the pipe open.
@@ -135,7 +124,7 @@ export function createClaudeAgentSdkProcessOwner(
           clearTimeout(timer);
         }
       }
-      if (owner !== context || currentContext() !== context || context.abortSignal?.aborted) {
+      if (disposed || currentContext() !== context || context.abortSignal?.aborted) {
         return error;
       }
       let diagnostic = tail;
@@ -164,12 +153,14 @@ export function createClaudeAgentSdkProcessOwner(
         redactSensitiveText(diagnostic, { mode: "tools" }),
         -STDERR_PREVIEW_CHARS,
       ).trim();
-      return diagnostic
-        ? new Error(
-            `${error instanceof Error ? error.message : String(error)}\nstderr: ${diagnostic}`,
-            { cause: error },
-          )
-        : error;
+      if (diagnostic && error instanceof Error) {
+        // Independent pipes cannot attribute warm stderr to a turn or classify its failure.
+        attachErrorDiagnostic(
+          error,
+          `stderr (process-wide; may include earlier turns): ${diagnostic}`,
+        );
+      }
+      return error;
     },
   };
 }

--- a/extensions/anthropic/agent-sdk-process.ts
+++ b/extensions/anthropic/agent-sdk-process.ts
@@ -56,6 +56,9 @@ export function createClaudeAgentSdkProcessOwner(
   currentContext: () => CliBackendExecuteContext | undefined,
   secretInput?: ClaudeAgentSdkSecretInput,
 ) {
+  // Prepared credentials are destroyed after each turn; a warm child outlives that preparation.
+  const credential = secretInput?.createData();
+  let environment: SpawnOptions["env"] = {};
   let child: ChildProcessWithoutNullStreams | undefined;
   let drained: Promise<void> | undefined;
   let owner: CliBackendExecuteContext | undefined;
@@ -101,10 +104,18 @@ export function createClaudeAgentSdkProcessOwner(
     });
   };
   return {
+    [Symbol.dispose]() {
+      credential?.fill(0);
+      environment = {};
+      tail = "";
+      owner = undefined;
+    },
     // stdout/stderr are independent pipes. Drain this poll cycle before releasing a warm turn.
     settleStderr: () => settleIo(),
-    spawn: (options: SpawnOptions) =>
-      spawnClaudeAgentSdkProcess(options, secretInput, observeStderr),
+    spawn: (options: SpawnOptions) => {
+      environment = options.env;
+      return spawnClaudeAgentSdkProcess(options, secretInput, observeStderr);
+    },
     async withDiagnostics(error: unknown): Promise<unknown> {
       const context = currentContext();
       if (!context || context.abortSignal?.aborted) {
@@ -129,32 +140,30 @@ export function createClaudeAgentSdkProcessOwner(
       }
       let diagnostic = tail;
       // Known opaque credentials need exact-value masking as well as pattern redaction.
-      const credential = secretInput?.createData();
-      try {
-        const secrets = Object.entries(context.env)
-          .filter(
-            ([name, value]) => redactSensitiveFieldValue(name, value, { mode: "tools" }) !== value,
-          )
-          .map(([, value]) => value);
-        if (credential) {
-          secrets.push(credential.toString("utf8"));
-        }
-        for (const secret of secrets.filter(Boolean)) {
-          for (const value of [
-            secret,
-            encodeURIComponent(secret),
-            JSON.stringify(secret).slice(1, -1),
-          ]) {
-            diagnostic = diagnostic.replaceAll(value, "[REDACTED]");
-          }
-        }
-        diagnostic = sliceUtf16Safe(
-          redactSensitiveText(diagnostic, { mode: "tools" }),
-          -STDERR_PREVIEW_CHARS,
-        ).trim();
-      } finally {
-        credential?.fill(0);
+      // Warm turns can mint new grants while the child retains its original environment.
+      const secrets = [environment, context.env].flatMap((env) =>
+        Object.entries(env).flatMap(([name, value]) =>
+          value && redactSensitiveFieldValue(name, value, { mode: "tools" }) !== value
+            ? [value]
+            : [],
+        ),
+      );
+      if (credential) {
+        secrets.push(credential.toString("utf8"));
       }
+      for (const secret of secrets.filter(Boolean)) {
+        for (const value of [
+          secret,
+          encodeURIComponent(secret),
+          JSON.stringify(secret).slice(1, -1),
+        ]) {
+          diagnostic = diagnostic.replaceAll(value, "[REDACTED]");
+        }
+      }
+      diagnostic = sliceUtf16Safe(
+        redactSensitiveText(diagnostic, { mode: "tools" }),
+        -STDERR_PREVIEW_CHARS,
+      ).trim();
       return diagnostic
         ? new Error(
             `${error instanceof Error ? error.message : String(error)}\nstderr: ${diagnostic}`,

--- a/extensions/anthropic/agent-sdk-process.ts
+++ b/extensions/anthropic/agent-sdk-process.ts
@@ -64,10 +64,13 @@ export function createClaudeAgentSdkProcessOwner(
   let atLineBoundary = true;
   const observeStderr = (process: ChildProcessWithoutNullStreams) => {
     child = process;
-    drained = new Promise<void>((resolve) => process.stderr.once("close", resolve));
+    drained = new Promise<void>((resolve) => {
+      process.stderr.once("close", resolve);
+    });
     process.stderr.setEncoding("utf8");
     process.stderr.on("error", () => {}); // A failed diagnostic pipe must not crash the Gateway.
-    process.stderr.on("data", (text: string) => {
+    process.stderr.on("data", (chunk: string) => {
+      let text = chunk;
       const context = currentContext();
       if (context !== owner) {
         owner = context;

--- a/extensions/anthropic/agent-sdk-process.ts
+++ b/extensions/anthropic/agent-sdk-process.ts
@@ -1,0 +1,163 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { setImmediate as settleIo } from "node:timers/promises";
+import type { SpawnOptions, SpawnedProcess } from "@anthropic-ai/claude-agent-sdk";
+import type { CliBackendExecuteContext } from "openclaw/plugin-sdk/cli-backend";
+import { redactSensitiveFieldValue, redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
+import {
+  killProcessTree,
+  prepareSecretInputStdio,
+  type SpawnStdioEntry,
+} from "openclaw/plugin-sdk/process-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+
+export type ClaudeAgentSdkSecretInput = { fd: 3; createData: () => Buffer };
+
+const STDERR_CAPTURE_CHARS = 8_192;
+const STDERR_PREVIEW_CHARS = 2_000;
+const STDERR_DRAIN_GRACE_MS = 200;
+
+function spawnClaudeAgentSdkProcess(
+  options: SpawnOptions,
+  secretInput: ClaudeAgentSdkSecretInput | undefined,
+  observeStderr: (child: ChildProcessWithoutNullStreams) => void,
+): SpawnedProcess {
+  const stdio: ["pipe", "pipe", "pipe", ...SpawnStdioEntry[]] = ["pipe", "pipe", "pipe"];
+  using secretDelivery = prepareSecretInputStdio(stdio, secretInput);
+  const child = spawn(options.command, options.args, {
+    cwd: options.cwd,
+    detached: process.platform !== "win32",
+    env: options.env,
+    signal: options.signal,
+    stdio,
+    windowsHide: true,
+  }) as ChildProcessWithoutNullStreams; // SAFETY: stdio[0..2] are pipes.
+  // The SDK only drains stderr for its built-in spawner; unread custom pipes
+  // fill at 64 KiB and deadlock credential-backed Claude processes.
+  observeStderr(child);
+  const killChild = child.kill.bind(child);
+  child.kill = (signal?: NodeJS.Signals | number) => {
+    if (!child.pid || (signal !== undefined && signal !== "SIGTERM" && signal !== "SIGKILL")) {
+      return killChild(signal);
+    }
+    // Windows must enumerate descendants before the root disappears; POSIX
+    // children own a detached group so cancellation never reaches the host.
+    killProcessTree(child.pid, {
+      detached: process.platform !== "win32",
+      ...(signal === "SIGKILL" ? { force: true } : {}),
+    });
+    return true;
+  };
+  void secretDelivery?.deliverTo(child).catch(() => child.kill());
+  return child;
+}
+
+/** Owns one process's stderr, retaining diagnostics only for its active admitted turn. */
+export function createClaudeAgentSdkProcessOwner(
+  currentContext: () => CliBackendExecuteContext | undefined,
+  secretInput?: ClaudeAgentSdkSecretInput,
+) {
+  let child: ChildProcessWithoutNullStreams | undefined;
+  let drained: Promise<void> | undefined;
+  let owner: CliBackendExecuteContext | undefined;
+  let tail = "";
+  let dropPartialLine = false;
+  let atLineBoundary = true;
+  const observeStderr = (process: ChildProcessWithoutNullStreams) => {
+    child = process;
+    drained = new Promise<void>((resolve) => process.stderr.once("close", resolve));
+    process.stderr.setEncoding("utf8");
+    process.stderr.on("error", () => {}); // A failed diagnostic pipe must not crash the Gateway.
+    process.stderr.on("data", (text: string) => {
+      const context = currentContext();
+      if (context !== owner) {
+        owner = context;
+        tail = "";
+        // Never attach the suffix of an idle/previous turn's credential line to a new turn.
+        dropPartialLine = !atLineBoundary;
+      }
+      atLineBoundary = text.endsWith("\n");
+      if (!owner) {
+        return;
+      }
+      if (dropPartialLine) {
+        const newline = text.indexOf("\n");
+        if (newline < 0) {
+          return;
+        }
+        text = text.slice(newline + 1);
+        dropPartialLine = false;
+      }
+      tail += text;
+      if (tail.length > STDERR_CAPTURE_CHARS) {
+        const bounded = sliceUtf16Safe(tail, -STDERR_CAPTURE_CHARS);
+        const newline = bounded.indexOf("\n");
+        // Drop a clipped line in full: its missing prefix may identify a credential.
+        tail = newline < 0 ? "" : bounded.slice(newline + 1);
+        dropPartialLine = newline < 0;
+      }
+    });
+  };
+  return {
+    // stdout/stderr are independent pipes. Drain this poll cycle before releasing a warm turn.
+    settleStderr: () => settleIo(),
+    spawn: (options: SpawnOptions) =>
+      spawnClaudeAgentSdkProcess(options, secretInput, observeStderr),
+    async withDiagnostics(error: unknown): Promise<unknown> {
+      const context = currentContext();
+      if (!context || context.abortSignal?.aborted) {
+        return error;
+      }
+      // Custom SDK spawners report exit before stderr EOF. Descendants may keep the pipe open.
+      if (child && (child.exitCode !== null || child.signalCode !== null)) {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        try {
+          await Promise.race([
+            drained,
+            new Promise<void>((resolve) => {
+              timer = setTimeout(resolve, STDERR_DRAIN_GRACE_MS);
+            }),
+          ]);
+        } finally {
+          clearTimeout(timer);
+        }
+      }
+      if (owner !== context || currentContext() !== context || context.abortSignal?.aborted) {
+        return error;
+      }
+      let diagnostic = tail;
+      // Known opaque credentials need exact-value masking as well as pattern redaction.
+      const credential = secretInput?.createData();
+      try {
+        const secrets = Object.entries(context.env)
+          .filter(
+            ([name, value]) => redactSensitiveFieldValue(name, value, { mode: "tools" }) !== value,
+          )
+          .map(([, value]) => value);
+        if (credential) {
+          secrets.push(credential.toString("utf8"));
+        }
+        for (const secret of secrets.filter(Boolean)) {
+          for (const value of [
+            secret,
+            encodeURIComponent(secret),
+            JSON.stringify(secret).slice(1, -1),
+          ]) {
+            diagnostic = diagnostic.replaceAll(value, "[REDACTED]");
+          }
+        }
+        diagnostic = sliceUtf16Safe(
+          redactSensitiveText(diagnostic, { mode: "tools" }),
+          -STDERR_PREVIEW_CHARS,
+        ).trim();
+      } finally {
+        credential?.fill(0);
+      }
+      return diagnostic
+        ? new Error(
+            `${error instanceof Error ? error.message : String(error)}\nstderr: ${diagnostic}`,
+            { cause: error },
+          )
+        : error;
+    },
+  };
+}

--- a/extensions/anthropic/agent-sdk.process.test.ts
+++ b/extensions/anthropic/agent-sdk.process.test.ts
@@ -1,0 +1,209 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type {
+  CliBackendExecuteContext,
+  CliBackendLiveSessionHandle,
+} from "openclaw/plugin-sdk/cli-backend";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { executeClaudeAgentSdk } from "./agent-sdk.runtime.js";
+
+const roots: string[] = [];
+const sessions = new Set<CliBackendLiveSessionHandle>();
+
+const PROTOCOL_CHILD = `
+  import { createInterface } from "node:readline";
+  import { writeSync } from "node:fs";
+  const send = (message) => process.stdout.write(JSON.stringify(message) + "\\n");
+  createInterface({ input: process.stdin }).on("line", (line) => {
+    const message = JSON.parse(line);
+    if (message.type === "control_request") {
+      send({ type: "control_response", response: {
+        subtype: "success", request_id: message.request_id, response: {},
+      } });
+    } else if (message.type === "user") {
+      const text = message.message.content;
+      if (text === "fail silently") process.exit(1);
+      if (text === "fail noisily") {
+        writeSync(2, "PermissionError: current turn failed\\n");
+        process.exit(1);
+      }
+      if (text === "success with stderr") writeSync(2, "previous turn diagnostic\\n");
+      send({ type: "result", subtype: "success", is_error: false, result: "ok",
+        session_id: "synthetic-session", duration_ms: 1, duration_api_ms: 1,
+        num_turns: 1, total_cost_usd: 0, usage: {}, modelUsage: {}, permission_denials: [],
+      });
+    }
+  });
+`;
+
+afterEach(async () => {
+  for (const session of sessions) {
+    session.close("restart");
+    await session.waitForExit();
+  }
+  sessions.clear();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  vi.restoreAllMocks();
+});
+
+async function contextForChild(source: string): Promise<CliBackendExecuteContext> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "openclaw-claude-stderr-"));
+  roots.push(root);
+  const command = path.join(root, "claude.mjs");
+  await writeFile(command, source);
+  return {
+    command,
+    args: [],
+    cwd: root,
+    env: { PATH: process.env.PATH ?? "", HOME: root, CLAUDE_CONFIG_DIR: root },
+    prompt: "Synthetic subprocess diagnostic probe.",
+    systemPrompt: "Synthetic subprocess diagnostic probe.",
+    modelId: "claude-sonnet-4-6",
+    useResume: false,
+    timeoutMs: 10_000,
+    abortSignal: AbortSignal.timeout(10_000),
+    requestToolPermission: async () => ({ behavior: "deny", message: "No tools in this probe." }),
+    requestUserInput: async () => ({ status: "cancelled", message: "No input in this probe." }),
+  };
+}
+
+async function collect(context: CliBackendExecuteContext) {
+  const events: Record<string, unknown>[] = [];
+  for await (const event of executeClaudeAgentSdk(context)) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe("Claude subprocess diagnostics through the real Agent SDK", () => {
+  it("drains pipe-sized stderr and reports a bounded redacted fatal diagnostic", async () => {
+    const secret = "sk-ant-api03-synthetic-diagnostic-credential-123456789";
+    const context = await contextForChild(`
+      import { writeSync } from "node:fs";
+      writeSync(2, "discarded noise".repeat(100_000) + "\\n");
+      writeSync(2, "Authorization: Bear");
+      writeSync(2, "er ${secret}\\n");
+      writeSync(2, "PermissionError: [Errno 1] Operation not permitted: '/bin/ps' 🦞");
+      process.exit(1);
+    `);
+    const error = await collect(context).catch((error: unknown) => error);
+    expect(error).toBeInstanceOf(Error);
+    expect(String(error)).toContain("exited with code 1");
+    expect(String(error)).toContain("PermissionError: [Errno 1]");
+    expect(String(error)).toContain("'/bin/ps' 🦞");
+    expect(String(error)).not.toContain(secret);
+    expect(String(error)).not.toContain("discarded noise");
+    expect(String(error).length).toBeLessThan(2_200);
+  });
+
+  it("preserves a silent child's exit error without inventing stderr", async () => {
+    const context = await contextForChild("process.exit(1);");
+    await expect(collect(context)).rejects.toThrow(/^Claude Code process exited with code 1$/);
+  });
+
+  it("masks opaque descriptor and environment credentials without copying native stdout", async () => {
+    const context = await contextForChild(`
+      import { readFileSync, writeSync } from "node:fs";
+      writeSync(1, "native stdout must stay private\\n");
+      writeSync(2, "credential: " + readFileSync(3, "utf8") + "\\n");
+      writeSync(2, "environment: " + process.env.OPENCLAW_MCP_TOKEN + "\\n");
+      writeSync(2, "PermissionError: denied resource 3\\n");
+      process.exit(1);
+    `);
+    const credential = "opaque-descriptor-fixture-value";
+    const grant = "opaque-mcp-fixture-value";
+    context.env.OPENCLAW_MCP_TOKEN = grant;
+    context.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR = "3";
+    const buffers: Buffer[] = [];
+    const running = (async () => {
+      for await (const _event of executeClaudeAgentSdk(context, {
+        fd: 3,
+        createData: () => {
+          const bytes = Buffer.from(credential);
+          buffers.push(bytes);
+          return bytes;
+        },
+      })) {
+        /* consume the real SDK stream */
+      }
+    })();
+    const error = await running.catch((error: unknown) => error);
+    expect(String(error)).toContain("PermissionError: denied resource 3");
+    expect(String(error)).toContain("[REDACTED]");
+    for (const privateText of [
+      credential,
+      grant,
+      "native stdout must stay private",
+      context.prompt,
+    ]) {
+      expect(String(error)).not.toContain(privateText);
+    }
+    expect(buffers.length).toBeGreaterThan(0);
+    expect(buffers.every((bytes) => bytes.every((byte) => byte === 0))).toBe(true);
+  });
+
+  it("reports failure while a descendant still holds stderr open", async () => {
+    const context = await contextForChild(`
+      import { spawn } from "node:child_process";
+      import { writeFileSync, writeSync } from "node:fs";
+      const descendant = spawn(process.execPath, ["-e", "setTimeout(() => {}, 10000)"],
+        { stdio: ["ignore", "ignore", 2] });
+      writeFileSync("descendant.pid", String(descendant.pid));
+      writeSync(2, "PermissionError: parent exited\\n");
+      process.exit(1);
+    `);
+    try {
+      await expect(collect(context)).rejects.toThrow("PermissionError: parent exited");
+      const pid = Number(await readFile(path.join(context.cwd, "descendant.pid"), "utf8"));
+      expect(() => process.kill(pid, 0)).not.toThrow();
+    } finally {
+      const pid = Number(await readFile(path.join(context.cwd, "descendant.pid"), "utf8"));
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {}
+    }
+  });
+
+  it.each(["success", "success with stderr"])("keeps %s quiet", async (prompt) => {
+    const context = await contextForChild(PROTOCOL_CHILD);
+    const stderr = vi.spyOn(process.stderr, "write");
+    const events = await collect({ ...context, prompt });
+    expect(events).toContainEqual(expect.objectContaining({ type: "result", result: "ok" }));
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  it.each(["fail silently", "fail noisily"])(
+    "isolates a warm successful turn's stderr from the next turn: %s",
+    async (prompt) => {
+      const context = await contextForChild(PROTOCOL_CHILD);
+      let current: CliBackendLiveSessionHandle | undefined;
+      context.liveSession = {
+        fingerprint: "synthetic-process-policy",
+        current: () => current,
+        register: (handle) => {
+          current = handle;
+          sessions.add(handle);
+        },
+        activate: () => {},
+        remove: (handle) => {
+          if (current === handle) current = undefined;
+        },
+      };
+      const stderr = vi.spyOn(process.stderr, "write");
+      await expect(collect({ ...context, prompt: "success with stderr" })).resolves.toContainEqual(
+        expect.objectContaining({ result: "ok" }),
+      );
+      expect(current?.isIdle()).toBe(true);
+      const error = await collect({ ...context, prompt, useResume: true }).catch(
+        (error: unknown) => error,
+      );
+      expect(String(error)).toContain("exited with code 1");
+      expect(String(error)).not.toContain("previous turn diagnostic");
+      expect(String(error).includes("PermissionError: current turn failed")).toBe(
+        prompt === "fail noisily",
+      );
+      expect(stderr).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/extensions/anthropic/agent-sdk.runtime.ts
+++ b/extensions/anthropic/agent-sdk.runtime.ts
@@ -431,6 +431,8 @@ function closeClaudeAgentSdkSession(
 
   const turn = session.currentTurn;
   session.currentTurn = undefined;
+  // Descendants can retain stderr after exit; session closure owns redaction-material cleanup.
+  session.process?.[Symbol.dispose]();
   if (turn) {
     turn.error =
       error instanceof Error ? error : new Error("Claude Agent SDK live session closed.");
@@ -643,7 +645,7 @@ export async function* executeClaudeAgentSdk(
     controller,
     userInput: createClaudeAgentSdkUserInputAuthorizer(context),
   };
-  const processOwner = createClaudeAgentSdkProcessOwner(() => activeTurn?.context, secretInput);
+  using processOwner = createClaudeAgentSdkProcessOwner(() => activeTurn?.context, secretInput);
   let sawTerminalResult = false;
   const abort = () => controller.abort();
   context.abortSignal?.addEventListener("abort", abort, { once: true });

--- a/extensions/anthropic/agent-sdk.runtime.ts
+++ b/extensions/anthropic/agent-sdk.runtime.ts
@@ -498,14 +498,10 @@ async function consumeClaudeAgentSdkSession(
 ): Promise<void> {
   try {
     for await (const message of query) {
-      if (message.type === "result") {
-        await session.process?.settleStderr();
-      }
       acceptClaudeAgentSdkMessage(session, { ...message });
     }
     if (!session.closed) {
-      const error = new Error("Claude Agent SDK live session exited unexpectedly.");
-      session.handle.close("abort", error);
+      throw new Error("Claude Agent SDK live session exited unexpectedly.");
     }
   } catch (error) {
     if (!session.closed) {

--- a/extensions/anthropic/agent-sdk.runtime.ts
+++ b/extensions/anthropic/agent-sdk.runtime.ts
@@ -1,12 +1,9 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { PassThrough } from "node:stream";
 import type {
   Options as ClaudeAgentSdkOptions,
   PermissionResult as ClaudeAgentSdkPermissionResult,
   Query as ClaudeAgentSdkQuery,
-  SpawnOptions as ClaudeAgentSdkSpawnOptions,
-  SpawnedProcess as ClaudeAgentSdkSpawnedProcess,
 } from "@anthropic-ai/claude-agent-sdk";
 import type {
   CliBackendExecuteContext,
@@ -14,12 +11,11 @@ import type {
   CliBackendLiveSessionCloseReason,
   CliBackendLiveSessionHandle,
 } from "openclaw/plugin-sdk/cli-backend";
-import {
-  killProcessTree,
-  prepareSecretInputStdio,
-  type SpawnStdioEntry,
-} from "openclaw/plugin-sdk/process-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  createClaudeAgentSdkProcessOwner,
+  type ClaudeAgentSdkSecretInput,
+} from "./agent-sdk-process.js";
 import {
   createClaudeAgentSdkUserMessage,
   splitClaudeToolNames,
@@ -75,11 +71,6 @@ const CLAUDE_VARIADIC_VALUE_FLAGS = new Set([
 const CLAUDE_LIVE_IDLE_TIMEOUT_MS = 10 * 60 * 1_000;
 const RESULT_HOLDING_BACKGROUND_TASK_TYPES = new Set(["local_agent", "local_workflow"]);
 
-type ClaudeAgentSdkSecretInput = {
-  fd: 3;
-  createData: () => Buffer;
-};
-
 type ClaudeAgentSdkTurn = {
   context: CliBackendExecuteContext;
   controller: AbortController;
@@ -99,6 +90,7 @@ type ClaudeAgentSdkSession = {
   prompts: PassThrough;
   currentTurn?: ClaudeAgentSdkLiveTurn;
   query?: ClaudeAgentSdkQuery;
+  process?: ReturnType<typeof createClaudeAgentSdkProcessOwner>;
   idleTimer?: ReturnType<typeof setTimeout>;
   hasResultHoldingBackgroundTasks: boolean;
   closed: boolean;
@@ -107,40 +99,6 @@ type ClaudeAgentSdkSession = {
 };
 
 const claudeAgentSdkSessions = new WeakMap<CliBackendLiveSessionHandle, ClaudeAgentSdkSession>();
-
-function spawnClaudeAgentSdkProcess(
-  options: ClaudeAgentSdkSpawnOptions,
-  secretInput?: ClaudeAgentSdkSecretInput,
-): ClaudeAgentSdkSpawnedProcess {
-  const stdio: ["pipe", "pipe", "pipe", ...SpawnStdioEntry[]] = ["pipe", "pipe", "pipe"];
-  using secretDelivery = prepareSecretInputStdio(stdio, secretInput);
-  const child = spawn(options.command, options.args, {
-    cwd: options.cwd,
-    detached: process.platform !== "win32",
-    env: options.env,
-    signal: options.signal,
-    stdio,
-    windowsHide: true,
-  }) as ChildProcessWithoutNullStreams; // SAFETY: stdio[0..2] are pipes.
-  // The SDK only drains stderr for its built-in spawner; unread custom pipes
-  // fill at 64 KiB and deadlock credential-backed Claude processes.
-  child.stderr.resume();
-  const killChild = child.kill.bind(child);
-  child.kill = (signal?: NodeJS.Signals | number) => {
-    if (!child.pid || (signal !== undefined && signal !== "SIGTERM" && signal !== "SIGKILL")) {
-      return killChild(signal);
-    }
-    // Windows must enumerate descendants before the root disappears; POSIX
-    // children own a detached group so cancellation never reaches the host.
-    killProcessTree(child.pid, {
-      detached: process.platform !== "win32",
-      ...(signal === "SIGKILL" ? { force: true } : {}),
-    });
-    return true;
-  };
-  void secretDelivery?.deliverTo(child).catch(() => child.kill());
-  return child;
-}
 
 async function authorizeClaudeAgentSdkTool(params: {
   currentTurn: () => ClaudeAgentSdkTurn | undefined;
@@ -182,7 +140,7 @@ function resolveClaudeAgentSdkOptions(
   context: CliBackendExecuteContext,
   abortController: AbortController,
   currentTurn: () => ClaudeAgentSdkTurn | undefined,
-  secretInput?: ClaudeAgentSdkSecretInput,
+  processOwner: ReturnType<typeof createClaudeAgentSdkProcessOwner>,
 ): ClaudeAgentSdkOptions {
   const options: ClaudeAgentSdkOptions = {
     abortController,
@@ -193,7 +151,7 @@ function resolveClaudeAgentSdkOptions(
     pathToClaudeCodeExecutable: context.command,
     permissionMode: "default",
     settingSources: ["user"],
-    spawnClaudeCodeProcess: (spawnOptions) => spawnClaudeAgentSdkProcess(spawnOptions, secretInput),
+    spawnClaudeCodeProcess: processOwner.spawn,
     systemPrompt: {
       type: "preset",
       preset: "claude_code",
@@ -538,6 +496,9 @@ async function consumeClaudeAgentSdkSession(
 ): Promise<void> {
   try {
     for await (const message of query) {
+      if (message.type === "result") {
+        await session.process?.settleStderr();
+      }
       acceptClaudeAgentSdkMessage(session, { ...message });
     }
     if (!session.closed) {
@@ -546,7 +507,7 @@ async function consumeClaudeAgentSdkSession(
     }
   } catch (error) {
     if (!session.closed) {
-      session.handle.close("abort", error);
+      session.handle.close("abort", await session.process?.withDiagnostics(error));
     }
   } finally {
     session.resolveExit();
@@ -628,11 +589,15 @@ async function* executeClaudeAgentSdkLiveTurn(
     capability.activate(session.handle);
 
     if (!session.query) {
+      session.process = createClaudeAgentSdkProcessOwner(
+        () => session.currentTurn?.context,
+        secretInput,
+      );
       const options = resolveClaudeAgentSdkOptions(
         context,
         session.controller,
         () => session.currentTurn,
-        secretInput,
+        session.process,
       );
       session.query = query({ prompt: session.prompts, options });
       void consumeClaudeAgentSdkSession(session, session.query);
@@ -678,6 +643,7 @@ export async function* executeClaudeAgentSdk(
     controller,
     userInput: createClaudeAgentSdkUserInputAuthorizer(context),
   };
+  const processOwner = createClaudeAgentSdkProcessOwner(() => activeTurn?.context, secretInput);
   let sawTerminalResult = false;
   const abort = () => controller.abort();
   context.abortSignal?.addEventListener("abort", abort, { once: true });
@@ -688,7 +654,7 @@ export async function* executeClaudeAgentSdk(
       context,
       controller,
       () => activeTurn,
-      secretInput,
+      processOwner,
     );
     for await (const message of query({ prompt: context.prompt, options })) {
       if (message.type === "result") {
@@ -699,6 +665,8 @@ export async function* executeClaudeAgentSdk(
     if (!sawTerminalResult && !controller.signal.aborted) {
       throw new Error("Claude Agent SDK exited without a terminal result.");
     }
+  } catch (error) {
+    throw await processOwner.withDiagnostics(error);
   } finally {
     activeTurn = undefined;
     if (!controller.signal.aborted) {

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -331,7 +331,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: canonical diagnostic flag checker through its focused subpath.
       // +3: typed system-agent approval request, payload, and resolution contracts for channel plugins.
       // +2: focused provider-auth routes for shipped auth ordering and provider-map lookup.
-      4359,
+      // +2: bounded display-only error diagnostic attachment and rendering.
+      4361,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -439,7 +440,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: canonical diagnostic flag checker through its focused subpath.
       // +1: shared approval expiry formatter for native channel prompts.
       // +2: focused provider-auth routes for shipped auth ordering and provider-map lookup.
-      2594,
+      // +2: bounded display-only error diagnostic attachment and rendering.
+      2596,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/cli-runner/cli-run-recovery.ts
+++ b/src/agents/cli-runner/cli-run-recovery.ts
@@ -1,4 +1,4 @@
-import { formatErrorMessage } from "../../infra/errors.js";
+import { formatErrorMessageForDisplay } from "../../infra/error-diagnostics.js";
 import { isCliSessionInvalidatingFailoverReason } from "../cli-session.js";
 import type { EmbeddedAgentRunResult } from "../embedded-agent-runner.js";
 import { type FailoverError, isFailoverError } from "../failover-error.js";
@@ -74,7 +74,7 @@ export async function runCliRecovery<TAttempt>(params: {
   const failTerminal = async (error: unknown): Promise<never> => {
     // Record only after every eligible recovery path is exhausted.
     cliBackendLog.warn(
-      `cli terminal failure: provider=${runParams.provider} model=${context.modelId} durationMs=${Date.now() - context.started} runId=${runParams.runId} error=${formatErrorMessage(error)}`,
+      `cli terminal failure: provider=${runParams.provider} model=${context.modelId} durationMs=${Date.now() - context.started} runId=${runParams.runId} error=${formatErrorMessageForDisplay(error)}`,
     );
     await params.onTerminalFailure(error);
     throw error;

--- a/src/agents/command/lifecycle.test.ts
+++ b/src/agents/command/lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { attachErrorDiagnostic } from "../../infra/error-diagnostics.js";
 import { buildAgentRunTerminalOutcome } from "../agent-run-terminal-outcome.js";
 import { FailoverError } from "../failover-error.js";
 import { renderFailoverCodeUserCopy } from "../failover/user-copy.js";
@@ -171,12 +172,71 @@ describe("createAgentCommandLifecycle", () => {
     },
   );
 
+  it.each([
+    ["basic", "plain"],
+    ["post-turn", "plain"],
+    ["post-turn", "timeout"],
+    ["post-turn", "abort"],
+  ] as const)(
+    "displays diagnostics on %s errors while retaining native %s facts",
+    (source, kind) => {
+      emitAgentEvent.mockClear();
+      const controller = new AbortController();
+      if (kind === "abort") {
+        controller.abort();
+      }
+      const lifecycle = createAgentCommandLifecycle({
+        runId: "diagnostic-terminal-owner",
+        lifecycleGeneration: () => "test-generation",
+        startedAt: 100,
+        abortSignal: controller.signal,
+        state: {
+          currentTurnUserMessagePersisted: true,
+          lifecycleFinishing: false,
+          lifecycleEnded: false,
+        },
+      });
+      const error = attachErrorDiagnostic(
+        kind === "timeout"
+          ? new FailoverError("watchdog stopped the child", { reason: "timeout" })
+          : new Error("child exited with code 1"),
+        "stderr: an earlier request timed out and was aborted",
+      );
+
+      if (source === "basic") {
+        lifecycle.emitBasicError(error);
+      } else {
+        lifecycle.emitPostTurnError(error, {
+          metadata: {},
+          outcome: buildAgentRunTerminalOutcome({ status: "error", stopReason: "error" }),
+        });
+      }
+
+      expect(emitAgentEvent).toHaveBeenCalledOnce();
+      const event = emitAgentEvent.mock.calls[0]?.[0];
+      expect(event.data.error).toContain(error.message);
+      expect(event.data.error).toContain("an earlier request timed out and was aborted");
+      if (kind === "timeout") {
+        expect(event.data).toMatchObject({ stopReason: "timeout", timeoutPhase: "provider" });
+        expect(event.data).not.toHaveProperty("aborted");
+      } else if (kind === "abort") {
+        expect(event.data).toMatchObject({ aborted: true, stopReason: "aborted" });
+        expect(event.data).not.toHaveProperty("timeoutPhase");
+      } else {
+        for (const field of ["aborted", "stopReason", "timeoutPhase"]) {
+          expect(event.data).not.toHaveProperty(field);
+        }
+      }
+    },
+  );
+
   it.each(["basic", "post-turn"] as const)(
     "publishes bounded selected-profile recovery from %s lifecycle errors",
     (source) => {
       emitAgentEvent.mockClear();
       const profileId = "openai:private-profile";
       const rawCause = `Codex app-server auth profile "${profileId}" was not found`;
+      const secret = ["sk", "abcdefghijklmnopqrstuv"].join("-");
       const lifecycle = createAgentCommandLifecycle({
         runId: "missing-selected-profile",
         lifecycleGeneration: () => "test-generation",
@@ -193,6 +253,10 @@ describe("createAgentCommandLifecycle", () => {
         profileId,
         cause: new Error(rawCause),
       });
+      attachErrorDiagnostic(
+        error,
+        `stderr: credential staging failed. Authorization: Bearer ${secret}`,
+      );
 
       if (source === "basic") {
         lifecycle.emitBasicError(error);
@@ -204,11 +268,13 @@ describe("createAgentCommandLifecycle", () => {
       }
 
       const event = emitAgentEvent.mock.calls[0]?.[0];
-      expect(event.data.error).toBe(
+      expect(event.data.error).toContain(
         renderFailoverCodeUserCopy("selected_auth_profile_unavailable"),
       );
+      expect(event.data.error).toContain("stderr: credential staging failed.");
       expect(JSON.stringify(event)).not.toContain(profileId);
       expect(JSON.stringify(event)).not.toContain(rawCause);
+      expect(JSON.stringify(event)).not.toContain(secret);
     },
   );
 

--- a/src/agents/command/lifecycle.ts
+++ b/src/agents/command/lifecycle.ts
@@ -1,4 +1,5 @@
 import { emitAgentEvent } from "../../infra/agent-events.js";
+import { formatErrorMessageForDisplay } from "../../infra/error-diagnostics.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { normalizeAgentRunTerminalDeliverySnapshot } from "../agent-run-terminal-delivery.js";
@@ -18,7 +19,7 @@ import type { AgentAttemptResult } from "./runtime-loaders.js";
 const log = createSubsystemLogger("agents/agent-command");
 
 const formatLifecycleError = (error: unknown): string =>
-  renderFailoverCodeUserCopy(getFailoverErrorCode(error)) ?? formatErrorMessage(error);
+  formatErrorMessageForDisplay(error, renderFailoverCodeUserCopy(getFailoverErrorCode(error)));
 
 function resolveTerminalLogLevel(
   outcome: AgentRunTerminalOutcome,

--- a/src/agents/failover-error.diagnostics.test.ts
+++ b/src/agents/failover-error.diagnostics.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { diagnosticErrorFailureKind } from "../infra/diagnostic-error-metadata.js";
+import { attachErrorDiagnostic, formatErrorMessageForDisplay } from "../infra/error-diagnostics.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import {
+  coerceToFailoverError,
+  hasProviderRequestSizeCeiling,
+  isTimeoutError,
+} from "./failover-error.js";
+import { isLikelyContextOverflowError } from "./failover/classify.js";
+
+// Provider hooks do not classify these native process-exit fixtures.
+vi.mock("../plugins/provider-hook-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/provider-hook-runtime.js")>();
+  return {
+    ...actual,
+    resolveProviderHookPlugin: () => undefined,
+    resolveProviderPluginsForHooks: () => [],
+  };
+});
+
+describe("failover diagnostic isolation", () => {
+  it.each([
+    "Rate limit exceeded",
+    "Authentication failed: invalid_api_key",
+    "Request timed out; operation was aborted",
+    "INVALID_ARGUMENT: input exceeds the maximum number of tokens",
+    "413 Request too large on tokens per minute (TPM): Limit 8000, Requested 8098",
+  ])("keeps supplemental process diagnostics out of failure policy: %s", (diagnostic) => {
+    const native = Object.freeze(new Error("Claude Code process exited with code 1"));
+    const error = attachErrorDiagnostic(native, diagnostic);
+
+    expect(error).toBe(native);
+    expect(formatErrorMessageForDisplay(error)).toContain(diagnostic);
+    for (const candidate of [error, new Error("Plugin execution failed", { cause: error })]) {
+      expect(coerceToFailoverError(candidate)).toBeNull();
+      expect(isTimeoutError(candidate)).toBe(false);
+      expect(diagnosticErrorFailureKind(candidate)).toBeUndefined();
+      expect(hasProviderRequestSizeCeiling(candidate)).toBe(false);
+      expect(isLikelyContextOverflowError(formatErrorMessage(candidate))).toBe(false);
+      expect(formatErrorMessage(candidate)).not.toContain(diagnostic);
+    }
+    expect(
+      hasProviderRequestSizeCeiling(new AggregateError([{ error }], "Plugin execution failed")),
+    ).toBe(false);
+  });
+});

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -4,6 +4,8 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import { createAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
+import { attachErrorDiagnostic, formatErrorMessageForDisplay } from "../infra/error-diagnostics.js";
+import { getFailoverErrorCode } from "./failover/error.js";
 
 // Classification here is message/status table behavior. Provider-attributed
 // structured signals (e.g. moonshot + 429) otherwise cross the plugin-consult
@@ -621,7 +623,10 @@ describe("failover-error", () => {
   });
 
   it("classifies a structured prompt error independently of its wording", () => {
-    const promptError = Object.assign(new Error("quota exhausted"), { status: 429 as const });
+    const promptError = attachErrorDiagnostic(
+      Object.assign(new Error("quota exhausted"), { status: 429 as const }),
+      "stderr: authentication failed during an earlier request",
+    );
     const failoverError = coerceToFailoverError(promptError, {
       provider: "openai",
       model: "gpt-5.4",
@@ -630,6 +635,10 @@ describe("failover-error", () => {
     expect(failoverError?.reason).toBe("rate_limit");
     expect(failoverError?.status).toBe(429);
     expect(failoverError?.message).toBe("quota exhausted");
+    expect(failoverError?.rawError).toBe("quota exhausted");
+    expect(formatErrorMessageForDisplay(failoverError)).toContain(
+      "authentication failed during an earlier request",
+    );
   });
 
   it("lets wrapped causes override parent context-overflow classifications", () => {
@@ -655,26 +664,49 @@ describe("failover-error", () => {
     expect(err?.authMode).toBe("oauth");
   });
 
-  it("enriches an existing FailoverError with the active auth mode", () => {
-    const original = new FailoverError("credit balance too low", {
-      reason: "billing",
+  it("preserves typed failure facts and diagnostics when adding the active auth mode", () => {
+    const cause = Object.assign(new Error("socket closed"), { code: "ECONNRESET" });
+    const facts = {
+      reason: "timeout",
       provider: "anthropic",
-      model: "claude-opus-4-6",
+      model: "sonnet-4.6",
       profileId: "anthropic:default",
-      status: 402,
-    });
+      status: 408,
+      rawError: "request timed out",
+      authProfileFailure: { allInCooldown: false },
+      sessionId: "diagnostic-session",
+      lane: "answer",
+      cause,
+      suspend: false,
+      cliTimeout: {
+        mode: "no-output",
+        timeoutSeconds: 30,
+        observedActivity: true,
+        activeToolCount: 1,
+        backgroundTaskCount: 0,
+      },
+      attempts: [{ provider: "anthropic", model: "sonnet-4.6", reason: "timeout" }],
+      soonestCooldownExpiry: null,
+    } satisfies ConstructorParameters<typeof FailoverError>[1];
+    const original = new FailoverError("request timed out", facts);
+    attachErrorDiagnostic(original, "stderr: Rate limit exceeded during an earlier request");
 
     const err = coerceToFailoverError(original, { authMode: "token" });
 
     expect(err).not.toBe(original);
     expect(err).toMatchObject({
-      reason: "billing",
-      provider: "anthropic",
-      model: "claude-opus-4-6",
-      profileId: "anthropic:default",
+      ...facts,
       authMode: "token",
-      status: 402,
     });
+    expect(err?.cause).toBe(cause);
+    expect(err?.message).toBe("request timed out");
+    expect(getFailoverErrorCode(err)).toBeUndefined();
+    expect(findCliTimeoutError(err)).toBe(err);
+    expect(err?.requestSizeCeiling).toBe(false);
+    expect(formatErrorMessageForDisplay(err)).toContain(
+      "Rate limit exceeded during an earlier request",
+    );
+    expect(original.authMode).toBeUndefined();
   });
 
   it("preserves raw provider error text for diagnostic logs", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -6,6 +6,7 @@
 import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
 import { formatCliCommand } from "../cli/command-format.js";
 import { isAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
+import { copyErrorDiagnostic } from "../infra/error-diagnostics.js";
 import { collectErrorGraphCandidates, formatErrorMessage, readErrorName } from "../infra/errors.js";
 import { failoverReasonFromClassification } from "./failover/classification-rules.js";
 import {
@@ -638,7 +639,7 @@ export function coerceToFailoverError(
   if (isFailoverError(err)) {
     if (context?.authMode && !err.authMode) {
       const message = typeof err.message === "string" ? err.message : String(err);
-      return new FailoverError(message, {
+      const enriched = new FailoverError(message, {
         reason: err.reason,
         provider: err.provider,
         model: err.model,
@@ -656,6 +657,8 @@ export function coerceToFailoverError(
         attempts: err.attempts,
         soonestCooldownExpiry: err.soonestCooldownExpiry,
       });
+      copyErrorDiagnostic(err, enriched);
+      return enriched;
     }
     return err;
   }

--- a/src/agents/models-config.model-input-presence.test.ts
+++ b/src/agents/models-config.model-input-presence.test.ts
@@ -80,6 +80,8 @@ describe("models config input presence", () => {
         discoveryAuthConfig: cfg,
         sourceConfigForSecrets,
         agentDir: "/tmp/openclaw-model-input-presence",
+        // Model-ID policies are part of this prepared merge fixture, not ambient discovery.
+        pluginMetadataSnapshot: createPluginMetadataSnapshotFixture(),
         env: { AWS_PROFILE: "default" },
         existingRaw: "",
         existingParsed: {},

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -15,7 +15,6 @@ vi.mock("../gateway/call.js", () => ({
 }));
 
 import {
-  isRecoverableAgentWaitError,
   readLatestAssistantReply,
   readLatestAssistantReplySnapshot,
   waitForAgentRun,
@@ -296,8 +295,49 @@ describe("waitForAgentRun", () => {
     expect(result).toEqual({
       status: "error",
       error: "gateway closed (1006): transport close",
+      retryableTransportError: true,
     });
-    expect(isRecoverableAgentWaitError(result.error)).toBe(true);
+  });
+
+  it.each([
+    "ECONNRESET",
+    "ECONNREFUSED",
+    "ETIMEDOUT",
+    "EPIPE",
+    "EHOSTUNREACH",
+    "ENETUNREACH",
+    "EAI_AGAIN",
+    "UND_ERR_SOCKET",
+  ])("records %s recovery only when the wait RPC rejects", async (code) => {
+    const error = `connect ${code} 127.0.0.1:443`;
+    callGatewayMock.mockResolvedValueOnce({
+      status: "error",
+      error,
+      retryableTransportError: true,
+    });
+    const terminal = await waitForAgentRun({ runId: "run-terminal", timeoutMs: 500 });
+    expect(terminal).toMatchObject({ status: "error", error });
+    expect(terminal).not.toHaveProperty("retryableTransportError");
+
+    callGatewayMock.mockRejectedValueOnce(new Error(error));
+    await expect(waitForAgentRun({ runId: "run-disconnected", timeoutMs: 500 })).resolves.toEqual({
+      status: "error",
+      error,
+      retryableTransportError: true,
+    });
+  });
+
+  it.each([
+    undefined,
+    "",
+    "gateway timeout",
+    "gateway request timeout for agent.wait",
+    "ENOENT: no such file",
+    "getaddrinfo ENOTFOUND gateway.example.com",
+  ])("does not mark a nonrecoverable rejected wait RPC: %s", async (error) => {
+    callGatewayMock.mockRejectedValueOnce(new Error(error));
+    const result = await waitForAgentRun({ runId: "run-unrecoverable", timeoutMs: 500 });
+    expect(result).not.toHaveProperty("retryableTransportError");
   });
 
   it("preserves pending agent.wait status", async () => {
@@ -873,31 +913,5 @@ describe("waitForAgentRunsToDrain", () => {
     } finally {
       vi.useRealTimers();
     }
-  });
-});
-
-describe("isRecoverableAgentWaitError", () => {
-  it.each([
-    "ECONNRESET",
-    "ECONNREFUSED",
-    "ETIMEDOUT",
-    "EPIPE",
-    "EHOSTUNREACH",
-    "ENETUNREACH",
-    "EAI_AGAIN",
-    "UND_ERR_SOCKET",
-  ])("recovers from %s connection failures", (code) => {
-    expect(isRecoverableAgentWaitError(`connect ${code} 127.0.0.1:443`)).toBe(true);
-  });
-
-  it.each([
-    undefined,
-    "",
-    "gateway timeout",
-    "gateway request timeout for agent.wait",
-    "ENOENT: no such file",
-    "getaddrinfo ENOTFOUND gateway.example.com",
-  ])("does not recover from %s", (error) => {
-    expect(isRecoverableAgentWaitError(error)).toBe(false);
   });
 });

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -126,7 +126,7 @@ const RECOVERABLE_AGENT_WAIT_ERROR_PATTERNS: readonly RegExp[] = [
 ];
 
 /** Return true for transient gateway/transport failures that callers may retry. */
-export function isRecoverableAgentWaitError(error: string | undefined): boolean {
+function isRecoverableAgentWaitError(error: string | undefined): boolean {
   const message = error?.trim();
   if (!message) {
     return false;
@@ -390,6 +390,7 @@ export async function waitForAgentRun(params: {
           ? "timeout"
           : "error",
       error,
+      ...(isRecoverableAgentWaitError(error) ? { retryableTransportError: true as const } : {}),
     };
   }
 }

--- a/src/agents/run-wait.types.ts
+++ b/src/agents/run-wait.types.ts
@@ -5,6 +5,8 @@ import type { AgentRunTimeoutPhase } from "./run-timeout-attribution.js";
 export type AgentWaitResult = {
   status: "ok" | "timeout" | "error" | "pending";
   error?: string;
+  /** Set locally when the wait RPC fails; terminal run text is never retry evidence. */
+  retryableTransportError?: true;
   startedAt?: number;
   endedAt?: number;
   stopReason?: string;

--- a/src/agents/subagents/registry/subagent-registry-run-wait.ts
+++ b/src/agents/subagents/registry/subagent-registry-run-wait.ts
@@ -7,7 +7,7 @@ import { isFastTestRuntimeEnv } from "../../../infra/env.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import type { DetachedTaskFindResult } from "../../../tasks/detached-task-runtime-contract.js";
 import { buildAgentRunTerminalOutcomeFromWaitResult } from "../../agent-run-terminal-outcome.js";
-import { isRecoverableAgentWaitError, waitForAgentRun } from "../../run-wait.js";
+import { waitForAgentRun } from "../../run-wait.js";
 import {
   type SubagentRunOutcome,
   withSubagentOutcomeTiming,
@@ -307,7 +307,7 @@ export class SubagentWaitManager {
         }
         return;
       }
-      if (waitStatus === "error" && !waitAborted && isRecoverableAgentWaitError(wait.error)) {
+      if (waitStatus === "error" && !waitAborted && wait.retryableTransportError) {
         scheduleWaitRetry(entry, "subagent wait interrupted; scheduling recovery", wait.error);
         return;
       }

--- a/src/agents/subagents/registry/subagent-registry.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.test.ts
@@ -3750,6 +3750,22 @@ describe("subagent registry seam flow", () => {
       label: "blocked wait announce",
     },
     {
+      name: "announces terminal failures whose diagnostics resemble transport errors",
+      runId: "run-diagnostic-transport-wait",
+      task: "report failed child",
+      wait: {
+        status: "error",
+        error: "child exited with code 1\nstderr: socket hang up",
+        livenessState: undefined,
+      },
+      expectedOutcome: {
+        status: "error",
+        error: "child exited with code 1\nstderr: socket hang up",
+      },
+      expectedReason: "subagent-error",
+      label: "diagnostic transport wait announce",
+    },
+    {
       name: "announces provider hard timeout wait snapshots as timeouts despite blocked metadata",
       runId: "run-blocked-hard-timeout-wait",
       task: "provider timeout wait",

--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -398,12 +398,18 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
   });
 
-  it("notifies the requester when delayed target delivery fails after acceptance", async () => {
-    vi.mocked(waitForAgentRun).mockResolvedValueOnce({
+  it.each([
+    {
       status: "timeout",
       error: "target run failed after delivery acceptance",
       pendingError: true,
-    });
+    },
+    {
+      status: "error",
+      error: "target run failed after delivery acceptance\nstderr: socket hang up",
+    },
+  ] as const)("notifies the requester when accepted delivery ends with $status", async (wait) => {
+    vi.mocked(waitForAgentRun).mockResolvedValueOnce(wait);
 
     await runSessionsSendA2AFlow({
       targetSessionKey: "agent:worker:discord:group:dev",
@@ -485,6 +491,7 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     vi.mocked(waitForAgentRun).mockResolvedValueOnce({
       status: "error",
       error: "gateway closed (1006)",
+      retryableTransportError: true,
     });
 
     await runSessionsSendA2AFlow({

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -14,7 +14,6 @@ import {
   type AgentWaitResult,
   type AssistantReplySnapshot,
   hasUpdatedAssistantReplySnapshot,
-  isRecoverableAgentWaitError,
   readLatestAssistantReplySnapshot,
   waitForAgentRun,
 } from "../run-wait.js";
@@ -52,7 +51,7 @@ function sameOwnedSession(params: {
 }
 function isDeliveryFailureWait(wait: AgentWaitResult): boolean {
   return (
-    (wait.status === "error" && !isRecoverableAgentWaitError(wait.error)) ||
+    (wait.status === "error" && !wait.retryableTransportError) ||
     (wait.status === "timeout" && wait.pendingError === true)
   );
 }

--- a/src/gateway/agent-turn/agent-job.ts
+++ b/src/gateway/agent-turn/agent-job.ts
@@ -25,6 +25,7 @@ import {
   type AgentRunTerminalReplySnapshot,
 } from "../../agents/agent-run-terminal-reply.js";
 import { onAgentEvent } from "../../infra/agent-events.js";
+import { formatErrorMessageForDisplay } from "../../infra/error-diagnostics.js";
 import { isNonTerminalAgentRunStatus } from "../../shared/agent-run-status.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import { setSafeTimeout } from "../../utils/timer-delay.js";
@@ -418,16 +419,21 @@ function parseDedupeObservation(entry: DedupeEntry): DedupeObservation {
     readNonBlankString(payload?.stopReason) ?? readNonBlankString(resultMeta?.stopReason);
   const livenessState =
     readNonBlankString(payload?.livenessState) ?? readNonBlankString(resultMeta?.livenessState);
+  const errorMessage =
+    typeof payload?.error === "string"
+      ? payload.error
+      : typeof payload?.summary === "string"
+        ? payload.summary
+        : entry.error?.message;
   const terminalOutcome = buildAgentRunTerminalOutcome({
     status: terminalStatus,
     startedAt,
     endedAt,
+    // RPC errors stay native for retry policy; agent.wait is an operator-facing projection.
     error:
-      typeof payload?.error === "string"
-        ? payload.error
-        : typeof payload?.summary === "string"
-          ? payload.summary
-          : entry.error?.message,
+      errorMessage === undefined
+        ? undefined
+        : formatErrorMessageForDisplay(entry.error, errorMessage),
     stopReason,
     livenessState,
     timeoutPhase: payload?.timeoutPhase ?? resultMeta?.timeoutPhase,

--- a/src/gateway/agent-turn/agent-run-dispatch.ts
+++ b/src/gateway/agent-turn/agent-run-dispatch.ts
@@ -24,7 +24,7 @@ import { readAgentRunTerminalOutcome } from "../../channels/turn/agent-run-termi
 import { agentCommandFromGatewayIngress } from "../../commands/agent.js";
 import { isAbortError } from "../../infra/abort-signal.js";
 import { clearAgentRunContext } from "../../infra/agent-run-registry.js";
-import { formatErrorMessageWithCode, readErrorName } from "../../infra/errors.js";
+import { readErrorName } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
 import { createRunningTaskRun } from "../../tasks/detached-task-runtime.js";
 import { bindTaskFlowExecution } from "../../tasks/task-flow-registry.store.sqlite.js";
@@ -33,6 +33,7 @@ import { bindTaskRunExecution } from "../../tasks/task-registry.store.sqlite.js"
 import type { TaskRecord } from "../../tasks/task-registry.types.js";
 import { normalizeDeliveryContext } from "../../utils/delivery-context.shared.js";
 import type { ChatAbortControllerEntry } from "../chat-abort.js";
+import { errorShapeFromError } from "../error-shape.js";
 import {
   tryFinalizeTrackedAgentTask,
   type GatewayAgentTaskTrackingMode,
@@ -355,7 +356,8 @@ export function dispatchAgentRunFromGateway(params: {
     })
     .catch(async (err: unknown) => {
       const aborted = isGatewayAgentAbortRejection(err, params.abortController.signal);
-      const renderedErr = formatErrorMessageWithCode(err);
+      const error = errorShapeFromError(ErrorCodes.UNAVAILABLE, err);
+      const renderedErr = error.message;
       const stopReason = aborted
         ? resolveGatewayAgentAbortStopReason(params.abortController.signal)
         : isAbortError(err)
@@ -377,7 +379,6 @@ export function dispatchAgentRunFromGateway(params: {
           log: params.context.logGateway,
         });
       }
-      const error = errorShape(ErrorCodes.UNAVAILABLE, renderedErr);
       Object.defineProperty(error, "cause", { value: err });
       const payload = {
         runId: params.runId,

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -1,4 +1,4 @@
-import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { getAdmittedRunDelegatedAuthority } from "../../agents/admitted-run-context.js";
 import {
   attachAgentCommandAdmissionFacts,
@@ -23,7 +23,6 @@ import {
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isAbortError } from "../../infra/abort-signal.js";
-import { formatErrorMessageWithCode } from "../../infra/errors.js";
 import type { MediaFact } from "../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import { bindGatewayContextResolver } from "../../plugins/runtime/gateway-request-scope.js";
@@ -33,6 +32,7 @@ import {
   type InputProvenance,
 } from "../../sessions/input-provenance.js";
 import { discardPreparedInboundMedia } from "../chat-attachments.js";
+import { errorShapeFromError } from "../error-shape.js";
 import { getGatewayLocalUserIngress } from "../local-user-ingress.js";
 import type { AgentRunRequest } from "../server-methods/agent-request-types.js";
 import { createAgentRunModelSelectionHandler } from "../server-methods/agent-run-model-selection.js";
@@ -496,8 +496,8 @@ export function startAgentRunExecution(params: {
         await finishUndispatchedAbort();
         return;
       }
-      const renderedErr = formatErrorMessageWithCode(err);
-      const error = errorShape(ErrorCodes.UNAVAILABLE, renderedErr);
+      const error = errorShapeFromError(ErrorCodes.UNAVAILABLE, err);
+      const renderedErr = error.message;
       const payload = {
         runId: params.runId,
         status: "error" as const,

--- a/src/gateway/error-shape.ts
+++ b/src/gateway/error-shape.ts
@@ -1,4 +1,5 @@
 import { errorShape } from "../../packages/gateway-protocol/src/index.js";
+import { copyErrorDiagnostic } from "../infra/error-diagnostics.js";
 import { formatErrorMessageWithCode } from "../infra/errors.js";
 
 /** Builds a wire error from an unknown failure without diagnostic class names. */
@@ -7,5 +8,7 @@ export function errorShapeFromError(
   error: unknown,
   opts?: Parameters<typeof errorShape>[2],
 ) {
-  return errorShape(code, formatErrorMessageWithCode(error), opts);
+  const shape = errorShape(code, formatErrorMessageWithCode(error), opts);
+  copyErrorDiagnostic(error, shape);
+  return shape;
 }

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -12,6 +12,7 @@ import {
   resetSubagentRegistryForTests,
 } from "../../agents/subagents/registry/subagent-registry.test-helpers.js";
 import { recordAgentRunTerminalOutcome } from "../../channels/turn/agent-run-terminal-outcome.js";
+import { attachErrorDiagnostic } from "../../infra/error-diagnostics.js";
 import { getDetachedTaskLifecycleRuntime } from "../../tasks/detached-task-runtime.js";
 import {
   findTaskByRunId,
@@ -1468,45 +1469,58 @@ describe("gateway agent handler", () => {
     });
   });
 
-  it("emits provider failure messages without the internal error class name", async () => {
-    const message =
-      "The selected model was not found by the provider. Check the model id or choose a different model.";
-    mocks.agentCommand.mockRejectedValueOnce(
-      new FailoverError(message, {
+  it.each([false, true])(
+    "emits provider failures and optional diagnostics without class names: %s",
+    async (withDiagnostic) => {
+      const message =
+        "The selected model was not found by the provider. Check the model id or choose a different model.";
+      const failure = new FailoverError(message, {
         reason: "model_not_found",
         provider: "ollama",
         model: "definitely-not-a-real-model:latest",
-      }),
-    );
-    const context = makeContext();
-    const respond = vi.fn();
-    const runId = "agent-run-model-not-found";
+      });
+      const diagnostic = "stderr: earlier request timed out; Rate limit exceeded";
+      if (withDiagnostic) {
+        attachErrorDiagnostic(failure, diagnostic);
+      }
+      const displayed = withDiagnostic ? `${message}\n${diagnostic}` : message;
+      mocks.agentCommand.mockRejectedValueOnce(failure);
+      const context = makeContext();
+      const respond = vi.fn();
+      const runId = "agent-run-model-not-found";
 
-    dispatchAgentRunFromGateway({
-      ingressOpts: {
-        message: "hi",
-        sessionKey: "agent:badmodel:main",
-        allowModelOverride: false,
-      },
-      runId,
-      dedupeKeys: [`agent:${runId}`],
-      abortController: new AbortController(),
-      cleanupAbortController: vi.fn(),
-      io: createAgentTurnIo(respond),
-      context,
-      taskTrackingMode: "none",
-    });
+      dispatchAgentRunFromGateway({
+        ingressOpts: {
+          message: "hi",
+          sessionKey: "agent:badmodel:main",
+          allowModelOverride: false,
+        },
+        runId,
+        dedupeKeys: [`agent:${runId}`],
+        abortController: new AbortController(),
+        cleanupAbortController: vi.fn(),
+        io: createAgentTurnIo(respond),
+        context,
+        taskTrackingMode: "none",
+      });
 
-    await waitForAssertion(() => {
-      expect(respond).toHaveBeenCalledWith(
-        false,
-        { runId, status: "error", summary: message },
-        expect.objectContaining({ code: ErrorCodes.UNAVAILABLE, message }),
-        { runId, error: message },
-      );
-      expect(context.dedupe.get(`agent:${runId}`)?.error?.message).toBe(message);
-    });
-  });
+      await waitForAssertion(() => {
+        expect(respond).toHaveBeenCalledWith(
+          false,
+          { runId, status: "error", summary: message },
+          expect.objectContaining({ code: ErrorCodes.UNAVAILABLE, message }),
+          { runId, error: message },
+        );
+        expect(context.dedupe.get(`agent:${runId}`)?.error?.message).toBe(message);
+        expect(failure.message).toBe(message);
+        expect(failure.reason).toBe("model_not_found");
+      });
+      await expect(waitForAgentJob({ runId, timeoutMs: 0 })).resolves.toMatchObject({
+        status: "error",
+        error: displayed,
+      });
+    },
+  );
 
   it("does not overwrite operator-cancelled async gateway agent tasks after late completion", async () => {
     await withTestDir({ prefix: "openclaw-gateway-agent-task-cancelled-" }, async (root) => {

--- a/src/infra/error-diagnostics.ts
+++ b/src/infra/error-diagnostics.ts
@@ -1,0 +1,45 @@
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { redactSensitiveText } from "../logging/redact.js";
+import { collectNestedErrorCandidates } from "./error-graph-internal.js";
+import { formatErrorMessage } from "./errors.js";
+
+// Supplemental process output is display-only: message/cause/code feed retry and auth policy.
+// Weak ownership also preserves frozen errors without retaining completed runs.
+const diagnostics = new WeakMap<object, string>();
+
+/** Attach operator diagnostics; callers must mask opaque credentials before attachment. */
+export function attachErrorDiagnostic<T extends object>(error: T, diagnostic: string): T {
+  diagnostics.set(
+    error,
+    sliceUtf16Safe(redactSensitiveText(diagnostic, { mode: "tools" }), 0, 2_048).trim(),
+  );
+  return error;
+}
+
+function findErrorDiagnostic(error: unknown): string | undefined {
+  for (const candidate of collectNestedErrorCandidates(error)) {
+    const diagnostic =
+      candidate && typeof candidate === "object" ? diagnostics.get(candidate) : undefined;
+    if (diagnostic) {
+      return diagnostic;
+    }
+  }
+  return undefined;
+}
+
+/** Preserve display metadata when an owner must clone a typed failure. */
+export function copyErrorDiagnostic(source: unknown, target: object): void {
+  const diagnostic = findErrorDiagnostic(source);
+  if (diagnostic) {
+    diagnostics.set(target, diagnostic);
+  }
+}
+
+/** Terminal display only. Never classify this text or use it to decide retries. */
+export function formatErrorMessageForDisplay(
+  error: unknown,
+  message = formatErrorMessage(error),
+): string {
+  const diagnostic = findErrorDiagnostic(error);
+  return diagnostic ? `${message}\n${diagnostic}` : message;
+}

--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -1,5 +1,6 @@
 // Tests shared infra error formatting helpers.
 import { describe, expect, it } from "vitest";
+import { attachErrorDiagnostic, formatErrorMessageForDisplay } from "./error-diagnostics.js";
 import { collectNestedErrorCandidates, extractErrorCodeOrErrno } from "./error-graph-internal.js";
 import {
   collectErrorGraphCandidates,
@@ -21,6 +22,33 @@ function createCircularObject() {
 }
 
 describe("error helpers", () => {
+  it("keeps bounded redacted diagnostics off frozen errors and follows wrapper graphs", () => {
+    const error = Object.freeze(new Error("native failure"));
+    const secret = "sk-abcdefghijklmnopqrstuv";
+    const before = Object.getOwnPropertyDescriptors(error);
+    expect(
+      attachErrorDiagnostic(error, `Authorization: Bearer ${secret}\n${"x".repeat(4_000)}`),
+    ).toBe(error);
+    const wrapper = new AggregateError([{ cause: error }], "outer failure");
+    const display = formatErrorMessageForDisplay(wrapper);
+    expect(display).toContain("Authorization: Bearer");
+    expect(display).not.toContain(secret);
+    expect(display.length).toBeLessThanOrEqual("outer failure\n".length + 2_048);
+    expect(formatErrorMessage(wrapper)).toBe("outer failure");
+    expect(Object.getOwnPropertyDescriptors(error)).toEqual(before);
+    expect(formatErrorMessageForDisplay(new Error("unrelated failure"))).toBe("unrelated failure");
+  });
+
+  it("renders one nearest diagnostic even through cyclic aggregate causes", () => {
+    const first = attachErrorDiagnostic(new Error("first"), "first diagnostic");
+    const second = attachErrorDiagnostic(new Error("second"), "second diagnostic");
+    const aggregate = new AggregateError([first, second], "outer");
+    first.cause = aggregate;
+    expect(formatErrorMessageForDisplay(aggregate)).toBe("outer\nfirst diagnostic");
+    attachErrorDiagnostic(aggregate, "outer diagnostic");
+    expect(formatErrorMessageForDisplay(aggregate)).toBe("outer\nouter diagnostic");
+  });
+
   it.each([
     { value: { code: "EADDRINUSE" }, expected: "EADDRINUSE" },
     { value: { code: 429 }, expected: "429" },

--- a/src/plugin-sdk/error-runtime.ts
+++ b/src/plugin-sdk/error-runtime.ts
@@ -24,6 +24,7 @@ export {
   readErrorName,
   toErrorObject,
 } from "../infra/errors.js";
+export { attachErrorDiagnostic, formatErrorMessageForDisplay } from "../infra/error-diagnostics.js";
 export {
   coerceErrorMessage,
   toStringifiedError,


### PR DESCRIPTION
Closes #134690

## What Problem This Solves

Fixes an issue where failed local Claude runs reported only `Claude Code process exited with code 1`, even when the child explained its launch or runtime failure on stderr.

## Why This Change Was Made

The Claude Agent SDK collects stderr only for its built-in spawner. OpenClaw's custom spawner drained the pipe to prevent deadlock but discarded the diagnostics. One Anthropic process owner now continuously drains and retains an 8,192-character tail, masks known credentials, and supplies a bounded diagnostic preview. The exit drain waits at most 200 ms when descendants keep the pipe open. The previous drain-only spawner is removed.

Stderr is process-wide: independent stdout/stderr pipes provide no reliable warm-turn attribution. The display labels that explicitly, and separate processes have separate buffers. Original FD3 credentials and the original process environment remain available for exact-value masking after per-turn preparation cleanup; disposal zeroes the private buffer and clears retained text/environment. Clipped lines are dropped, canonical redaction is forced, and native stdout/MCP input are never diagnostic sources. Success remains quiet.

Supplemental text is attached privately to the original error, preserving its identity, native message, typed fields and failure policy. Only terminal logs, lifecycle display and the server-owned `agent.wait` projection render it. RPC errors retain their native messages. Wait consumers use a transport-retry fact recorded at the actual RPC catch, so an earlier stderr line cannot change authentication, fallback, timeout, announce retry or completion decisions. No new wire fields, configuration, schema or dependencies. The existing SDK source limits account explicitly for the two new generic error helpers; no generated artifact or environment override changes the guard.

Production and tooling: +274/−78 (net +196); tests: +626/−78 (net +548); docs: +22. The added production code owns bounded process capture, credential lifetime and display-only metadata. Reusing the SDK collector is impossible for a custom spawner; appending stderr to ordinary error messages changes existing failure classifiers. The shared diagnostic owner avoids separate ad hoc error wrappers at each terminal sink.

## User Impact

Operators get actionable redacted diagnostics from `agent.wait` and `openclaw logs`, including unexpected clean exits before a warm turn returns a result. The process-wide label warns that earlier warm-turn output can be present.

## Evidence

- The original installed-SDK/real-child PermissionError test failed without retained stderr; the silent-child control passed. Subsequent warm controls reproduced credential-factory disposal and the original MCP bearer escaping after grant rotation before those fixes.
- A child deliberately emitted first-turn stderr only after the next prompt. That disproved the previous per-turn/event-loop attribution; the final owner and documentation use process scope. A separate Gateway/child control reproduced missing diagnostics on code-0 exit without a terminal result.
- Supplemental rate-limit text demonstrably reclassified a local exit before the metadata repair. Real boundary tests protect native error identity/classification, typed auth/timeout metadata, frozen errors, nested causes, aggregate bounds, redaction, and quiet success.
- Transport-shaped terminal diagnostics previously suppressed an A2A failure notification and triggered subagent wait recovery. The RPC-catch fact and consumer regressions distinguish a failed wait connection from a completed failed run.
- 190 SDK/error/failover/lifecycle cases, 122 wait/job/A2A cases, two Gateway projection cases and two selected subagent announcement/transport controls passed. The new terminal-diagnostic announcement case was rerun with a shorter filter after the first selection skipped its abbreviated test name; the actual case passed.
- The normal full build and fresh complete Codex review (P0 threshold) passed. All 43 planned changed-check stages are covered: 28 unchanged stages passed in [Testbox run 33492316142](https://github.com/openclaw/openclaw/actions/runs/33492316142), then all 15 remaining canonical lint/guards passed locally after the test-only repair. The normal two-file changed gate passed on [Testbox run 33494617966](https://github.com/openclaw/openclaw/actions/runs/33494617966), including the affected agents test graph and zero lint warnings/errors. Both leases stopped and temporary worktrees/registrations/processes were removed. Passed production checks were retained because every production afterimage remained unchanged; this does not claim the earlier failed wrapper exited successfully.
- Final packaged Gateway → installed SDK → native synthetic-child proof passed for both code 1 (run fb58d388-d650-4280-93e6-a2c939dc9be5) and code 0 without a result (run 2a7ed15a-dbd0-4599-bf1d-a92c9b67bc2f). Each reused one warm process, drained 228,386 stderr bytes, retained the delayed earlier-turn and PermissionError diagnostics in agent.wait and logs, masked FD3/original MCP credentials, and preserved native error/timeout/abort facts. Both Gateway/child process sets exited and ports closed.

The retained two-line catalog fixture correction is test-only: three prepared input-presence cases use the existing plugin metadata fixture instead of ambient full discovery; all 13 assertions remain. Its previously failing shard passed in [run 33477031468](https://github.com/openclaw/openclaw/actions/runs/33477031468). That run exposed the separate release-inventory overflow later fixed on main in #134824; the mechanical refresh passed [run 33484509592](https://github.com/openclaw/openclaw/actions/runs/33484509592). The final repair requires fresh exact-head CI before landing. The first final changed gate reached the SDK surface check and correctly rejected the two unaccounted exports; the source-owned limits now document exactly those two helpers, and all 10 existing SDK surface tests pass. The next run passed all 28 pre-lint stages, including every core/plugin/test/script type graph, then found a test file above its line limit and an Error-instance spread. The five existing diagnostic-policy cases now live in a focused sibling file, the assertion uses explicit plain facts, and all 80 failover cases still pass. No production code changed during this lint repair. A later current-main integration encountered only the shared SDK export-budget lines from #134670: the final accounting preserves main and adds the same two diagnostic helpers (4,361 public exports / 2,596 callable exports). The surface check, all 10 surface tests and scoped lint passed; all 27 other diagnostics afterimages remain byte-identical to the sealed runtime proof.

Dependency inspection: Claude Agent SDK `0.3.241`, `sdk.d.ts` stderr/SpawnedProcess/SpawnOptions and `sdk.mjs` ProcessTransport spawn, exit and message-reading paths. Its private built-in collector is process-wide and bypassed by custom spawners. Direct Codex sibling source inspected at `sdk/typescript/src/exec.ts:200–232` and `codex-rs/exec/src/lib.rs:275–290`; no Codex runtime/protocol behavior is changed.

Named follow-up: replay-safe warm recovery/MCP grant transfer. A failure before second-turn progress can become `session_expired` in `src/agents/cli-runner/execute-plugin.ts`, then fail fresh-retry MCP grant transfer in `src/agents/cli-runner/prepare.ts`. That separate defect was reproduced; the Gateway diagnostic proof emits second-turn progress and does not claim to repair this recovery path. Personal skill-library work is separate.

<details>
<summary>Build and changed-gate commands</summary>

```sh
pnpm build
node scripts/check-changed.mjs --base origin/main -- \
  scripts/plugin-sdk-surface-report.mts \
  docs/gateway/cli-backends.md \
  docs/plugins/sdk-runtime.md \
  extensions/anthropic/agent-sdk-process.test.ts \
  extensions/anthropic/agent-sdk-process.ts \
  extensions/anthropic/agent-sdk.runtime.ts \
  src/agents/cli-runner/cli-run-recovery.ts \
  src/agents/command/lifecycle.test.ts \
  src/agents/command/lifecycle.ts \
  src/agents/failover-error.test.ts \
  src/agents/failover-error.ts \
  src/agents/models-config.model-input-presence.test.ts \
  src/agents/run-wait.test.ts \
  src/agents/run-wait.ts \
  src/agents/run-wait.types.ts \
  src/agents/subagents/registry/subagent-registry-run-wait.ts \
  src/agents/subagents/registry/subagent-registry.test.ts \
  src/agents/tools/sessions-send-tool.a2a.test.ts \
  src/agents/tools/sessions-send-tool.a2a.ts \
  src/gateway/agent-turn/agent-job.ts \
  src/gateway/agent-turn/agent-run-dispatch.ts \
  src/gateway/agent-turn/agent-run-execution-phase.ts \
  src/gateway/error-shape.ts \
  src/gateway/server-methods/agent.sessions-and-models.test-utils.ts \
  src/infra/error-diagnostics.ts \
  src/infra/errors.test.ts \
  src/plugin-sdk/error-runtime.ts
```

```sh
node scripts/check-changed.mjs --base origin/main -- src/agents/failover-error.test.ts src/agents/failover-error.diagnostics.test.ts
```

The remaining lint/guard commands were taken unchanged from the canonical changed-check plan; package aliases were executed through their declared Node commands to avoid dependency reconciliation in the linked checkout.

</details>
