### PR TITLE
refactor(talk): reuse realtime launch option picker

### DIFF
--- a/src/gateway/server-methods/talk-shared.ts
+++ b/src/gateway/server-methods/talk-shared.ts
@@ -426,28 +426,7 @@ function withRealtimeBrowserOverrides(
   providerConfig: RealtimeVoiceProviderConfig,
   params: RealtimeVoiceLaunchOptionInput,
 ): RealtimeVoiceProviderConfig {
-  const overrides: RealtimeVoiceProviderConfig = {};
-  const model = normalizeOptionalString(params.model);
-  const voice = normalizeOptionalString(params.voice);
-  const reasoningEffort = normalizeOptionalString(params.reasoningEffort);
-  if (model) {
-    overrides.model = model;
-  }
-  if (voice) {
-    overrides.voice = voice;
-  }
-  if (typeof params.vadThreshold === "number" && Number.isFinite(params.vadThreshold)) {
-    overrides.vadThreshold = params.vadThreshold;
-  }
-  if (typeof params.silenceDurationMs === "number" && Number.isFinite(params.silenceDurationMs)) {
-    overrides.silenceDurationMs = params.silenceDurationMs;
-  }
-  if (typeof params.prefixPaddingMs === "number" && Number.isFinite(params.prefixPaddingMs)) {
-    overrides.prefixPaddingMs = params.prefixPaddingMs;
-  }
-  if (reasoningEffort) {
-    overrides.reasoningEffort = reasoningEffort;
-  }
+  const overrides = pickRealtimeVoiceLaunchOptions(params);
   return Object.keys(overrides).length > 0 ? { ...providerConfig, ...overrides } : providerConfig;
 }
 

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -1891,9 +1891,10 @@ describe("talk.session unified handlers", () => {
       createBridge: vi.fn(),
     };
     mocks.listRealtimeVoiceProviders.mockReturnValue([provider] as never);
+    const providerConfig = { apiKey: "openai-key" };
     mocks.resolveConfiguredRealtimeVoiceProvider.mockReturnValue({
       provider,
-      providerConfig: { apiKey: "openai-key" },
+      providerConfig,
     });
     mocks.createTalkRealtimeRelaySession.mockReturnValue({
       provider: "openai",
@@ -1976,6 +1977,8 @@ describe("talk.session unified handlers", () => {
       model: "gpt-realtime",
       voice: "alloy",
     });
+    expect(relayCreateInput.providerConfig).not.toBe(providerConfig);
+    expect(providerConfig).toEqual({ apiKey: "openai-key" });
     expect(relayCreateInput.instructions).toContain(
       "Additional realtime instructions:\nSpeak warmly.",
     );
@@ -2155,9 +2158,10 @@ describe("talk.session unified handlers", () => {
       isConfigured: () => true,
       createBridge: vi.fn(),
     };
+    const providerConfig = {};
     mocks.resolveConfiguredRealtimeVoiceProvider.mockReturnValue({
       provider,
-      providerConfig: {},
+      providerConfig,
     });
     mocks.createTalkRealtimeRelaySession.mockReturnValue({
       provider: "openai",
@@ -2211,6 +2215,8 @@ describe("talk.session unified handlers", () => {
         assertCommitAllowed: expect.any(Function),
       }),
     );
+    const relayCreateInput = mocks.createTalkRealtimeRelaySession.mock.calls[0]?.[0];
+    expect(relayCreateInput?.providerConfig).toBe(providerConfig);
     expectRespondOk(respond, { relaySessionId: "relay-talk-owner" });
   });
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled. This is a same-repository branch.

</details>

## What Problem This Solves

Talk browser overrides duplicate the launch-option normalization already used in the same owner. Keeping two copies makes future changes liable to diverge. This is an internal cleanup, not a newly claimed user-facing bug fix.

Production LOC: +1/−22 (net −21). Tests: +8/−2 (net +6). Whole change: −15 lines.

## Why This Change Was Made

Reuse the existing private picker, preserving normalization, finite-number handling, field order, and precedence. Empty overrides still return the original provider-config object; nonempty overrides still create a fresh object without mutating it. Two existing handler cases now characterize those identity and nonmutation contracts.

Prepared Talk targets, canonical session keys, store selection, lifecycle guards, provider APIs, and configuration defaults are unchanged.

## User Impact

No intended user-visible change. Talk configuration and speech-provider selection retain their existing behavior.

## Evidence

- Current composed source: four whole Talk suites passed all 162 cases, followed by all six consult-history sibling cases. Earlier characterization and paired proof are retained separately, not presented as a current whole-suite baseline.
- The normal selected changed checks passed all 29 ordered stages, and the default build passed all 14 stages.
- A configured Linux run exercised the built Gateway through the canonical source QA client with synthetic providers: nine Talk behavior calls, two identity diagnostics, and 12 fixture events. No external vendor calls or agent turns were made.
- That operator command still exited 1: its strict listener-observation check rejected `lsof` mount-stat warnings. The behavior results were retained; a separately reviewed, same-lease cleanup verified the exact known processes/groups and listener absent, removed only the owned scratch directory, and stopped the lease. This is not a claim that the original operator passed or that stopping destroyed the VM.
- Current-source precommit and separate exact-commit Codex reviews completed with no P0 findings. Hosted exact-head CI and native landing remain pending.

Retained compiler-cache attribution is not independent transform-equivalence proof. The synthetic operator does not establish live-vendor or media-quality behavior.
