### PR TITLE
fix(cli): reject a blank --session-id or --session-key instead of ignoring it

### DIFF
--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -10,7 +10,7 @@ title: "Agent"
 
 Run one agent turn through the Gateway. The explicit `--local` flag is the only embedded execution path.
 
-Pass at least one session selector: `--to`, `--session-key`, `--session-id`, or `--agent`.
+Pass at least one session selector: `--to`, `--session-key`, `--session-id`, or `--agent`. Explicitly blank or whitespace-only selector values are rejected before local or Gateway dispatch, even when another selector supplies a valid target. Omit an unused selector instead of passing an empty value.
 
 A completed turn exits `0`. Error, timeout, and cancellation outcomes exit `1`, after any text or JSON result is written. A received `SIGINT` or `SIGTERM` instead preserves the signal-specific exit status described below.
 

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -373,6 +373,24 @@ describe("agentCliCommand", () => {
     expect(agentCommand).not.toHaveBeenCalled();
   });
 
+  it("rejects a blank session id before selecting a local or Gateway target", async () => {
+    await expect(
+      agentCliCommand({ message: "hi", agent: "ops", sessionId: "" }, runtime),
+    ).rejects.toThrow("--session-id must not be blank");
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(agentCommand).not.toHaveBeenCalled();
+  });
+
+  it("rejects a whitespace-only session key before selecting a local or Gateway target", async () => {
+    await expect(
+      agentCliCommand({ message: "hi", agent: "ops", sessionKey: "   " }, runtime),
+    ).rejects.toThrow("--session-key must not be blank");
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(agentCommand).not.toHaveBeenCalled();
+  });
+
   it("clamps oversized gateway timeout seconds at the command boundary", async () => {
     await withTempStore(async () => {
       mockGatewaySuccessReply();

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -364,32 +364,31 @@ describe("agentCliCommand", () => {
     expect(zeroTimeoutGatewayRequestMs).toBe(2_147_000_000);
   });
 
-  it("rejects a blank agent before selecting a local or Gateway target", async () => {
-    await expect(agentCliCommand({ message: "hi", agent: "" }, runtime)).rejects.toThrow(
-      "--agent must not be blank",
-    );
-
-    expect(callGateway).not.toHaveBeenCalled();
-    expect(agentCommand).not.toHaveBeenCalled();
-  });
-
-  it("rejects a blank session id before selecting a local or Gateway target", async () => {
-    await expect(
-      agentCliCommand({ message: "hi", agent: "ops", sessionId: "" }, runtime),
-    ).rejects.toThrow("--session-id must not be blank");
-
-    expect(callGateway).not.toHaveBeenCalled();
-    expect(agentCommand).not.toHaveBeenCalled();
-  });
-
-  it("rejects a whitespace-only session key before selecting a local or Gateway target", async () => {
-    await expect(
-      agentCliCommand({ message: "hi", agent: "ops", sessionKey: "   " }, runtime),
-    ).rejects.toThrow("--session-key must not be blank");
-
-    expect(callGateway).not.toHaveBeenCalled();
-    expect(agentCommand).not.toHaveBeenCalled();
-  });
+  it.each([
+    ["agent", "--agent"],
+    ["sessionId", "--session-id"],
+    ["sessionKey", "--session-key"],
+    ["to", "--to"],
+  ] as const)(
+    "rejects blank %s selectors before local or Gateway dispatch",
+    async (option, flag) => {
+      await withTempStore(async () => {
+        mockGatewaySuccessReply();
+        for (const local of [false, true]) {
+          for (const value of ["", "   "]) {
+            await expect(
+              agentCliCommand(
+                { message: "hi", to: "agent:main:explicit-target", local, [option]: value },
+                runtime,
+              ),
+            ).rejects.toThrow(`${flag} must not be blank`);
+          }
+        }
+        expect(callGateway).not.toHaveBeenCalled();
+        expect(agentCommand).not.toHaveBeenCalled();
+      });
+    },
+  );
 
   it("clamps oversized gateway timeout seconds at the command boundary", async () => {
     await withTempStore(async () => {

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -1235,6 +1235,16 @@ export async function agentCliCommand(
   if (opts.agent !== undefined && !opts.agent.trim()) {
     throw new Error("--agent must not be blank");
   }
+  // Same reason as --agent above. Downstream, a blank session selector is
+  // trimmed away and reads as "no explicit target" (see hasExplicitSessionTarget
+  // in normalizeSessionKeyOptsForDispatch), so the turn silently lands in the
+  // agent's default session instead of the one the caller named.
+  if (opts.sessionId !== undefined && !opts.sessionId.trim()) {
+    throw new Error("--session-id must not be blank");
+  }
+  if (opts.sessionKey !== undefined && !opts.sessionKey.trim()) {
+    throw new Error("--session-key must not be blank");
+  }
   protectJsonStdout(opts);
   const messageOpts = await resolveAgentMessageOpts(opts);
   // `/compact` cannot run as a plain CLI agent turn: the slash-command handler

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -1232,18 +1232,16 @@ export async function agentCliCommand(
   runtime: RuntimeEnv,
   deps?: AgentCliDeps,
 ) {
-  if (opts.agent !== undefined && !opts.agent.trim()) {
-    throw new Error("--agent must not be blank");
-  }
-  // Same reason as --agent above. Downstream, a blank session selector is
-  // trimmed away and reads as "no explicit target" (see hasExplicitSessionTarget
-  // in normalizeSessionKeyOptsForDispatch), so the turn silently lands in the
-  // agent's default session instead of the one the caller named.
-  if (opts.sessionId !== undefined && !opts.sessionId.trim()) {
-    throw new Error("--session-id must not be blank");
-  }
-  if (opts.sessionKey !== undefined && !opts.sessionKey.trim()) {
-    throw new Error("--session-key must not be blank");
+  // A present blank selector must not become an omitted target during normalization.
+  for (const [flag, value] of [
+    ["--agent", opts.agent],
+    ["--session-id", opts.sessionId],
+    ["--session-key", opts.sessionKey],
+    ["--to", opts.to],
+  ]) {
+    if (value !== undefined && !value.trim()) {
+      throw new Error(`${flag} must not be blank`);
+    }
   }
   protectJsonStdout(opts);
   const messageOpts = await resolveAgentMessageOpts(opts);


### PR DESCRIPTION
## What Problem This Solves

`openclaw agent --agent ops --session-id "$SESSION_ID" --message hi` can send a turn to the agent's main session when the variable is empty. Session normalization treats blank strings as omission. The same issue affects `--session-key` and the recipient selector `--to`.

## Why This Change Was Made

Validate all four documented selectors at the shared CLI command boundary, before message loading, session normalization, Gateway dispatch, or embedded startup. One loop extends the existing unconditional `--agent` blank check; it replaces duplicated per-selector guards. Gateway protocol and internal session normalization contracts remain unchanged.

The maintainer pass includes `--to` because it has the same observed failure: a present blank recipient completes a turn in the main session. The CLI reference documents the rule and tells scripts to omit unused selectors.

## User Impact

Explicitly empty or whitespace-only selector values now fail with the flag-specific `must not be blank` error. This is intentional even when another selector supplies a valid target, matching the existing blank-`--agent` behavior. Omitted flags retain normal routing, and valid session IDs, session keys, and recipients keep their selected targets. No new configuration option, protocol field, or storage behavior is introduced.

## Evidence

Independent maintainer proof uses trusted main plus the authored repair, Node 24, the real built CLI, isolated local Gateway/state directories, and the existing QA Lab mock provider. The actual OpenClaw runtime completes each positive control; no live provider credentials or external channels are used.

- Before the fix, the extended owner regression fails for all three newly covered selectors: 3 failures, 120 passing cases, and 1 platform skip. Afterward, all 123 cases pass with the same platform skip. The table covers empty/whitespace input, local/Gateway dispatch, and a valid alternate target; existing tests retain accepted selector, ownership, timeout, signal, JSON, and message-file coverage.
- Before the fix, 28 actual CLI invocations produce 24 completed turns and the 4 existing blank-agent rejections. Blank ID/key/recipient values reach the mock provider and report `agent:ops:main`; a blank selector beside `--to agent:ops:alternate` reports the alternate session.
- After the fix, the same 28 invocations produce 20 flag-specific blank rejections with zero additional mock-provider requests, plus 8 completed valid/omitted turns. Response metadata confirms the main, explicit session-key, explicit session-ID, and recipient targets in both Gateway and `--local` flows.
- The canonical `qaRuntime` rebuild passes. Every owned Gateway/mock process terminates, its port closes, and temporary state is removed after both runs.

The complete changed gate passed, including production/test types, all three dead-export scans, lint, and repository boundary guards. The complete three-file native candidate passed the independent P0 review with no findings. Published-head CI remains pending.

Production delta is +8 lines: one invariant comment and the canonical selector loop replacing the old single-selector guard. Tests are +17 net lines by expanding the existing test, and documentation is net-neutral. The additional bindings are the CLI boundary's explicit presence checks; no second normalization flow is added.

Thanks @marmar9615-cloud for identifying the blank session-selector defect.


Maintainer-reviewed head: `44c2b21183eb6a48d29d0575e00124bbd5bf8b87`. Contributor credit is preserved.
