### PR TITLE
fix: /acp close resumes the closed session after restart

### DIFF
--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1965,6 +1965,7 @@ describe("/acp command", () => {
       sessionKey: defaultAcpSessionKey,
       reason: "manual-close",
       allowBackendUnavailable: true,
+      discardPersistentState: true,
       clearMeta: true,
     });
     expectMockCallFields(hoisted.sessionBindingUnbindMock, {

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -508,6 +508,7 @@ export async function handleAcpCloseAction(
           agentId,
           reason: "manual-close",
           allowBackendUnavailable: true,
+          discardPersistentState: true,
           clearMeta: true,
         });
         runtimeNotice = closed.runtimeNotice ? ` (${closed.runtimeNotice})` : "";


### PR DESCRIPTION
## What Problem This Solves

`/acp close` cleared ACP session metadata but did not request removal of the persistent ACPX session state. A later turn could therefore resume the closed session, including after a gateway restart, instead of creating a fresh session.

## Why This Change Was Made

The close-session manager already owns a `discardPersistentState` path that clears the runtime handle and asks the ACP runtime to prepare a fresh session. The command handler was not opting into that existing lifecycle contract.

This change passes `discardPersistentState: true` from `/acp close` and updates the command regression coverage. It does not add another cleanup path, configuration surface, or storage mechanism.

## User Impact

After `/acp close`, the next ACP turn starts a fresh session rather than resuming the previously closed ACPX session.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-acp.test.ts` — passed.
- `pnpm exec prettier --check src/auto-reply/reply/commands-acp/lifecycle.ts src/auto-reply/reply/commands-acp.test.ts` — passed.
- The regression assertion now requires `/acp close` to call `closeSession` with `discardPersistentState: true`.

Closes #107487
