### PR TITLE
fix(tts): keep terminal command replies text-only

### DIFF
--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -864,6 +864,10 @@ channel that supports conversion.
 
 When `tts.auto` is enabled, OpenClaw:
 
+- Keeps terminal slash and plugin command replies text-only, including with
+  `auto: "always"`. Explicit speech requests such as `/tts audio` and `/tts latest`
+  still send audio. Commands that continue into an assistant run keep the normal
+  auto-TTS behavior for the assistant's answer.
 - Skips TTS if the reply already contains structured media.
 - Skips very short replies (under 10 chars).
 - Summarizes long replies when summaries are enabled, using

--- a/src/tts/tts-payload.ts
+++ b/src/tts/tts-payload.ts
@@ -128,7 +128,7 @@ export async function maybeApplyTtsToPayloadCore(
   });
   const ttsMetadata = getReplyPayloadMetadata(params.payload);
   const explicitTts = ttsMetadata?.ttsExplicit === true;
-  if (autoMode === "off" && !explicitTts) {
+  if (!explicitTts && (autoMode === "off" || ttsMetadata?.commandReply)) {
     return params.payload;
   }
   const activeProvider = resolveTtsProvider(config, prefsPath);

--- a/src/tts/tts-runtime-fallbacks.test.ts
+++ b/src/tts/tts-runtime-fallbacks.test.ts
@@ -1,7 +1,10 @@
 import { rmSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { setReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
+import {
+  markCommandReplyForDelivery,
+  setReplyPayloadMetadata,
+} from "../auto-reply/reply-payload.js";
 import { createReplyDispatcher } from "../auto-reply/reply/reply-dispatcher.js";
 import { routeReply } from "../auto-reply/reply/route-reply.js";
 import * as bundledChannelPlugins from "../channels/plugins/bundled.js";
@@ -99,6 +102,49 @@ describe("TTS runtime provider fallback and delivery behavior", () => {
     transcodeAudioBufferMock.mockClear();
     routedPayloads.length = 0;
     installSpeechProviders([createMockSpeechProvider()]);
+  });
+
+  it.each(["always", "inbound", "tagged"])(
+    "keeps terminal command replies text-only with %s auto-TTS",
+    async (ttsAuto) => {
+      const payload = { text: "The requested command is complete." };
+      markCommandReplyForDelivery(payload);
+      const result = await maybeApplyTtsToPayloadCore(
+        {
+          payload,
+          cfg: createTtsConfig("openclaw-command-auto-tts"),
+          channel: "slack",
+          kind: "final",
+          inboundAudio: true,
+          ttsAuto,
+        },
+        async () => "/unused.ogg",
+      );
+
+      expect(result).toBe(payload);
+      expect(synthesizeMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("preserves explicit speech requests on command-owned replies", async () => {
+    const payload = setReplyPayloadMetadata(
+      { text: "Requested spoken response." },
+      { ttsExplicit: true },
+    );
+    markCommandReplyForDelivery(payload);
+    const result = await maybeApplyTtsToPayloadCore(
+      {
+        payload,
+        cfg: createTtsConfig("openclaw-command-explicit-tts"),
+        channel: "slack",
+        kind: "final",
+        ttsAuto: "off",
+      },
+      async () => "/requested.ogg",
+    );
+
+    expect(result).toMatchObject({ text: payload.text, mediaUrl: "/requested.ogg" });
+    expect(requireFirstSynthesisRequest("explicit command speech").text).toBe(payload.text);
   });
 
   it("synthesizes persisted TTS facts after the visible text has been stripped", async () => {


### PR DESCRIPTION
Closes #82582.

## What Problem This Solves

With automatic TTS enabled, terminal slash and plugin command replies can be synthesized as speech, including command status and control output. The delivery layer already records that these are command-owned replies, but the speech owner ignores that fact.

## Why This Change Was Made

The existing automatic-TTS gate now reads the canonical `commandReply` metadata and keeps those terminal replies text-only. Explicit `ttsExplicit` speech requests still bypass the automatic gate. This is one changed production line, with no slash-text heuristic, configuration option, or new metadata path.

## User Impact

`auto: "always"` no longer reads terminal command output aloud. Ordinary assistant answers, commands that continue into an assistant run, and explicit `/tts audio` and `/tts latest` requests retain their speech behavior.

## Evidence

- Failure-first owner regression: `always` and `inbound` command replies incorrectly invoked synthesis before the fix; the controls and repaired cases pass. Full existing TTS fallback/delivery cohort: 45 passed.
- Real built Gateway with the canonical QA channel transport and synthetic HTTP model/speech services: all eight cases passed on a clean Linux install. Text/native terminal commands made zero model and speech calls; ordinary assistant answers, both command continuations, and unknown-slash input synthesized; explicit audio/latest commands synthesized. Every audio attachment matched the fixture WAV bytes. Gateway process stopped and cleanup reported no errors.
- Codex autoreview completed with no actionable findings at the default blocking threshold.
- The complete changed-file gate passed on the matching clean Linux installation, including production/test typechecks, lint and all structural guards. The local attempt exposed stale installed `pako` versus the declared dependency; no type workaround or dependency declaration was added. The first remote attempt compared an unrelated hydrated base; the successful run explicitly used the verified candidate base. The Testbox lease is stopped.

Production delta: zero (one line replaced); tests +46; documentation +4. This does not change command authorization, routing, provider behavior, or persisted TTS preferences. The end-to-end proof uses mock channel/provider services, not a live external messaging account or paid speech request.
