### PR TITLE
refactor(test): centralize Vitest include selection

### DIFF
--- a/test/vitest/vitest.boundary.config.ts
+++ b/test/vitest/vitest.boundary.config.ts
@@ -5,12 +5,6 @@ import { resolveVitestIsolation } from "./vitest.scoped-config.ts";
 import { nonIsolatedRunnerPath, sharedVitestConfig } from "./vitest.shared.config.ts";
 import { boundaryTestFiles } from "./vitest.unit-paths.mjs";
 
-function loadBoundaryIncludePatternsFromEnv(
-  env: Record<string, string | undefined> = process.env,
-): string[] | null {
-  return loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
-}
-
 export function createBoundaryVitestConfig(
   env: Record<string, string | undefined> = process.env,
   argv: string[] = process.argv,
@@ -24,7 +18,10 @@ export function createBoundaryVitestConfig(
       name: "boundary",
       isolate,
       ...(isolate ? { runner: undefined } : { runner: nonIsolatedRunnerPath }),
-      include: loadBoundaryIncludePatternsFromEnv(env) ?? cliIncludePatterns ?? boundaryTestFiles,
+      include:
+        loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env) ??
+        cliIncludePatterns ??
+        boundaryTestFiles,
       ...(cliIncludePatterns?.length === 0 ? { passWithNoTests: true } : {}),
       // Boundary workers still need the shared isolated HOME/bootstrap. Only
       // per-file module isolation is disabled here.

--- a/test/vitest/vitest.channels.config.ts
+++ b/test/vitest/vitest.channels.config.ts
@@ -1,16 +1,9 @@
 // Vitest channels config wires the channels test shard.
 import { coreChannelTestInclude } from "./vitest.channel-paths.mjs";
-import { loadPatternListFromEnv } from "./vitest.pattern-file.ts";
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
-export function loadIncludePatternsFromEnv(
-  env: Record<string, string | undefined> = process.env,
-): string[] | null {
-  return loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
-}
-
 export function createChannelsVitestConfig(env?: Record<string, string | undefined>) {
-  return createScopedVitestConfig(loadIncludePatternsFromEnv(env) ?? coreChannelTestInclude, {
+  return createScopedVitestConfig(coreChannelTestInclude, {
     env,
     exclude: ["src/gateway/**", "src/channels/plugins/contracts/**"],
     name: "channels",

--- a/test/vitest/vitest.contracts-shared.ts
+++ b/test/vitest/vitest.contracts-shared.ts
@@ -25,12 +25,6 @@ const baseTest = sharedVitestConfig.test ?? {};
 
 export const pluginContractPatterns = ["src/plugins/contracts/**/*.test.ts"];
 
-function loadContractsIncludePatternsFromEnv(
-  env: Record<string, string | undefined> = process.env,
-): string[] | null {
-  return loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
-}
-
 export function createContractsVitestConfig(
   includePatterns: string[],
   env: Record<string, string | undefined> = process.env,
@@ -40,7 +34,7 @@ export function createContractsVitestConfig(
   const cliIncludePatterns = narrowIncludePatternsForCli(includePatterns, argv);
   const envIncludePatterns = intersectIncludePatterns(
     includePatterns,
-    loadContractsIncludePatternsFromEnv(env),
+    loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env),
   );
   return defineConfig({
     ...base,

--- a/test/vitest/vitest.extension-config.ts
+++ b/test/vitest/vitest.extension-config.ts
@@ -1,6 +1,5 @@
 // Vitest extension config helpers keep extension shard defaults aligned.
 import type { ViteUserConfig } from "vitest/config";
-import { loadPatternListFromEnv } from "./vitest.pattern-file.ts";
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
 type ExtensionVitestConfigOptions = {
@@ -16,8 +15,7 @@ export function createExtensionVitestConfig(
   options: ExtensionVitestConfigOptions = {},
 ): ViteUserConfig {
   return createScopedVitestConfig(
-    loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env) ??
-      testRoots.map((root) => `${root}/**/*.test.ts`),
+    testRoots.map((root) => `${root}/**/*.test.ts`),
     {
       dir: "extensions",
       env,

--- a/test/vitest/vitest.extensions.config.ts
+++ b/test/vitest/vitest.extensions.config.ts
@@ -24,7 +24,6 @@ import { telegramExtensionTestRoots } from "./vitest.extension-telegram-paths.mj
 import { voiceCallExtensionTestRoots } from "./vitest.extension-voice-call-paths.mjs";
 import { whatsAppExtensionTestRoots } from "./vitest.extension-whatsapp-paths.mjs";
 import { zaloExtensionTestRoots } from "./vitest.extension-zalo-paths.mjs";
-import { loadPatternListFromEnv } from "./vitest.pattern-file.ts";
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
 export const extensionCatchAllExcludedTestRoots = [
@@ -51,16 +50,10 @@ export const extensionCatchAllExcludedTestRoots = [
   zaloExtensionTestRoots,
 ].flat();
 
-export function loadIncludePatternsFromEnv(
-  env: Record<string, string | undefined> = process.env,
-): string[] | null {
-  return loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
-}
-
 export function createExtensionsVitestConfig(
   env: Record<string, string | undefined> = process.env,
 ) {
-  return createScopedVitestConfig(loadIncludePatternsFromEnv(env) ?? [BUNDLED_PLUGIN_TEST_GLOB], {
+  return createScopedVitestConfig([BUNDLED_PLUGIN_TEST_GLOB], {
     dir: "extensions",
     env,
     name: "extensions",

--- a/test/vitest/vitest.tooling.config.ts
+++ b/test/vitest/vitest.tooling.config.ts
@@ -1,28 +1,18 @@
 // Vitest tooling config wires the tooling test shard.
-import { loadPatternListFromEnv } from "./vitest.pattern-file.ts";
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 import { toolingDockerTestFiles } from "./vitest.tooling-docker.config.ts";
 import { toolingIsolatedTestFiles } from "./vitest.tooling-isolated-paths.mjs";
 import { boundaryTestFiles } from "./vitest.unit-paths.mjs";
 
-export function loadIncludePatternsFromEnv(
-  env: Record<string, string | undefined> = process.env,
-): string[] | null {
-  return loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
-}
-
 export function createToolingVitestConfig(env?: Record<string, string | undefined>) {
-  return createScopedVitestConfig(
-    loadIncludePatternsFromEnv(env) ?? ["test/**/*.test.ts", "src/scripts/**/*.test.ts"],
-    {
-      env,
-      exclude: [...boundaryTestFiles, ...toolingDockerTestFiles, ...toolingIsolatedTestFiles],
-      fileParallelism: false,
-      includeOpenClawRuntimeSetup: false,
-      name: "tooling",
-      passWithNoTests: true,
-    },
-  );
+  return createScopedVitestConfig(["test/**/*.test.ts", "src/scripts/**/*.test.ts"], {
+    env,
+    exclude: [...boundaryTestFiles, ...toolingDockerTestFiles, ...toolingIsolatedTestFiles],
+    fileParallelism: false,
+    includeOpenClawRuntimeSetup: false,
+    name: "tooling",
+    passWithNoTests: true,
+  });
 }
 
 export default createToolingVitestConfig();

--- a/test/vitest/vitest.unit.config.ts
+++ b/test/vitest/vitest.unit.config.ts
@@ -24,12 +24,6 @@ import {
 const sharedTest = sharedVitestConfig.test ?? {};
 const exclude = sharedTest.exclude ?? [];
 
-export function loadIncludePatternsFromEnv(
-  env: Record<string, string | undefined> = process.env,
-): string[] | null {
-  return loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
-}
-
 export function loadExtraExcludePatternsFromEnv(
   env: Record<string, string | undefined> = process.env,
 ): string[] {
@@ -114,7 +108,7 @@ export function createUnitVitestConfigWithOptions(
 ) {
   const isolate = resolveVitestIsolation(env);
   const argv = options.argv ?? process.argv;
-  const envIncludePatterns = loadIncludePatternsFromEnv(env);
+  const envIncludePatterns = loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
   const defaultIncludePatterns = options.includePatterns ?? unitTestIncludePatterns;
   const cliIncludePatterns = narrowIncludePatternsForCli(defaultIncludePatterns, argv);
   const unitFastTestFiles = getUnitFastTestFiles(envIncludePatterns ?? cliIncludePatterns);


### PR DESCRIPTION
## What Problem This Solves

Vitest project configs redundantly read `OPENCLAW_VITEST_INCLUDE_FILE` before delegating to the shared scoped-config owner. That duplicates selection policy and makes several lanes read the same include file twice.

## Why This Change Was Made

This removes the seven reviewed forwarding wrappers and lets the existing `loadPatternListFromEnv` and `createScopedVitestConfig` owners select include files once. It adds no helper, config surface, test, SDK seam, or behavior change.

## User Impact

No runtime user-visible change. Test maintainers get one canonical include-file selection path while preserving explicit empty lists, ordering, errors, CLI precedence, scoped paths, coverage behavior, and `passWithNoTests`.

## Evidence

- Focused local Vitest proof: 555 tests passed across the boundary, unit, scoped-config, project-routing, unit-fast, shard-runner, and test-project owners.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- Exact Codex autoreview with `gpt-5.6-sol` at high reasoning: scoped clean, 0.99 correctness.
- Blacksmith Testbox `tbx_01m1djk3re0j9my4hgdz2adezk`: six real lane producers passed 83 tests, the explicit unit include-file producer passed 23 tests, and the clean `check:changed` gate passed. Run: https://github.com/openclaw/openclaw/actions/runs/33468869746
- Blacksmith Testbox `tbx_01m1dk1v54jwkh4mvy053256tg`: clean `pnpm build` passed end to end. Run: https://github.com/openclaw/openclaw/actions/runs/33469369162
- Local aggregate `check:changed` and build reached unrelated stale shared-install failures; the clean Testbox runs above passed those exact validation surfaces.
- Test-infrastructure LOC: +17/-58, net -41. Production LOC: 0. Test LOC: 0.
