### PR TITLE
perf(gateway): streamline doctor imports and schema construction

### DIFF
--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -532,7 +532,7 @@ For local media read policy, import `getAgentScopedMediaLocalRoots(...)` or
     | Pending delivery queue drain | `openclaw/plugin-sdk/delivery-queue-runtime` |
     | Channel activity telemetry | `openclaw/plugin-sdk/channel-activity-runtime` |
     | In-memory and persistent-backed dedupe caches | `openclaw/plugin-sdk/dedupe-runtime` |
-    | Safe local-file/media paths, regular-file checks, and symlink-parent checks | `openclaw/plugin-sdk/file-access-runtime` |
+    | Safe local-file/media paths, regular-file checks, and symlink-parent checks | `openclaw/plugin-sdk/security-runtime` |
     | Dispatcher-aware fetch | `openclaw/plugin-sdk/runtime-fetch` |
     | Proxy and guarded fetch helpers | `openclaw/plugin-sdk/fetch-runtime` |
     | SSRF dispatcher policy types | `openclaw/plugin-sdk/ssrf-dispatcher` |

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -532,7 +532,7 @@ For local media read policy, import `getAgentScopedMediaLocalRoots(...)` or
     | Pending delivery queue drain | `openclaw/plugin-sdk/delivery-queue-runtime` |
     | Channel activity telemetry | `openclaw/plugin-sdk/channel-activity-runtime` |
     | In-memory and persistent-backed dedupe caches | `openclaw/plugin-sdk/dedupe-runtime` |
-    | Safe local-file/media path helpers | `openclaw/plugin-sdk/file-access-runtime` |
+    | Safe local-file/media paths, regular-file checks, and symlink-parent checks | `openclaw/plugin-sdk/file-access-runtime` |
     | Dispatcher-aware fetch | `openclaw/plugin-sdk/runtime-fetch` |
     | Proxy and guarded fetch helpers | `openclaw/plugin-sdk/fetch-runtime` |
     | SSRF dispatcher policy types | `openclaw/plugin-sdk/ssrf-dispatcher` |

--- a/extensions/imessage/src/state-migrations.ts
+++ b/extensions/imessage/src/state-migrations.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { ChannelLegacyStateMigrationPlan } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { fileExists } from "openclaw/plugin-sdk/security-runtime";
+import { fileExists } from "openclaw/plugin-sdk/file-access-runtime";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { asFiniteNumber, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {

--- a/extensions/nextcloud-talk/src/doctor.ts
+++ b/extensions/nextcloud-talk/src/doctor.ts
@@ -2,8 +2,8 @@
 import os from "node:os";
 import path from "node:path";
 import type { ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract";
+import { fileExists } from "openclaw/plugin-sdk/file-access-runtime";
 import { migratePersistentDedupeLegacyJsonFile } from "openclaw/plugin-sdk/persistent-dedupe";
-import { fileExists } from "openclaw/plugin-sdk/security-runtime";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { listNextcloudTalkAccountIds, resolveNextcloudTalkAccount } from "./accounts.js";
 import { probeNextcloudTalkBotResponseFeature } from "./bot-preflight.js";

--- a/extensions/telegram/src/state-migrations.ts
+++ b/extensions/telegram/src/state-migrations.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { listAgentIds } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { ChannelLegacyStateMigrationPlan } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { fileExists } from "openclaw/plugin-sdk/security-runtime";
+import { fileExists } from "openclaw/plugin-sdk/file-access-runtime";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-paths";
 import { isRecord, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveTelegramAccountOwnerAgentId } from "./account-owner.js";

--- a/extensions/whatsapp/setup-entry.test.ts
+++ b/extensions/whatsapp/setup-entry.test.ts
@@ -1,14 +1,8 @@
 // Whatsapp tests cover setup entry plugin behavior.
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-import { buildLegacyMigrationPreview } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { describe, expect, it, vi } from "vitest";
-import { stateMigrations } from "./doctor-contract-api.js";
 import * as legacySessionSurfaceApi from "./legacy-session-surface-api.js";
 import setupEntry from "./setup-entry.js";
 import * as setupPluginApi from "./setup-plugin-api.js";
-import { detectWhatsAppLegacyStateMigrations } from "./src/state-migrations.js";
 
 vi.mock("baileys", () => {
   throw new Error("setup plugin load must not load Baileys");
@@ -52,76 +46,6 @@ describe("whatsapp setup entry", () => {
     ]);
     expect(legacySessionSurface.canonicalizeLegacySessionKey).toBeTypeOf("function");
     expect(legacySessionSurface.isLegacyGroupSessionKey).toBeTypeOf("function");
-  });
-
-  it("plans migration for every Baileys auth category while preserving other shared-root files", async () => {
-    const oauthDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wa-legacy-migration-"));
-    const authFiles = [
-      "creds.json",
-      "creds.json.bak",
-      "pre-key-1.json",
-      "session-contact.json",
-      "sender-key-group.json",
-      "sender-key-memory-group.json",
-      "app-state-sync-key-contact.json",
-      "app-state-sync-version-contact.json",
-      "lid-mapping-15551234567.json",
-      "device-list-15551234567.json",
-      "tctoken-15551234567.json",
-      "identity-key-15551234567.json",
-    ];
-
-    try {
-      for (const file of [...authFiles, "oauth.json", "google-oauth.json", "notes.txt"]) {
-        fs.writeFileSync(path.join(oauthDir, file), "{}", "utf-8");
-      }
-      fs.mkdirSync(path.join(oauthDir, "nested"));
-      fs.writeFileSync(path.join(oauthDir, "nested", "session-keep.json"), "{}", "utf-8");
-      fs.symlinkSync(path.join(oauthDir, "notes.txt"), path.join(oauthDir, "session-linked.json"));
-
-      const migrations = detectWhatsAppLegacyStateMigrations({ oauthDir });
-
-      expect(migrations.map((migration) => path.basename(migration.sourcePath)).toSorted()).toEqual(
-        authFiles.toSorted(),
-      );
-      expect(
-        migrations
-          .map((migration) => ({
-            kind: migration.kind,
-            label: migration.label,
-            sourcePath: migration.sourcePath,
-            targetPath: migration.targetPath,
-            namespace: null,
-          }))
-          .toSorted((left, right) => left.sourcePath.localeCompare(right.sourcePath)),
-      ).toEqual(
-        authFiles
-          .map((fileName) => ({
-            kind: "move",
-            label: `WhatsApp auth ${fileName}`,
-            sourcePath: path.join(oauthDir, fileName),
-            targetPath: path.join(oauthDir, "whatsapp", "default", fileName),
-            namespace: null,
-          }))
-          .toSorted((left, right) => left.sourcePath.localeCompare(right.sourcePath)),
-      );
-      await expect(
-        stateMigrations[0]?.detectLegacyState({
-          config: {},
-          env: {},
-          oauthDir,
-          stateDir: oauthDir,
-          context: { openPluginStateKeyedStore: vi.fn() } as never,
-        }),
-      ).resolves.toEqual({ preview: migrations.map(buildLegacyMigrationPreview) });
-      for (const migration of migrations) {
-        expect(migration.targetPath).toBe(
-          path.join(oauthDir, "whatsapp", "default", path.basename(migration.sourcePath)),
-        );
-      }
-    } finally {
-      fs.rmSync(oauthDir, { recursive: true, force: true });
-    }
   });
 
   it("loads the delegated setup wizard without importing runtime dependencies", async () => {

--- a/extensions/whatsapp/src/creds-files.ts
+++ b/extensions/whatsapp/src/creds-files.ts
@@ -8,7 +8,7 @@ import {
   readRegularFileSync,
   statRegularFile,
   statRegularFileSync,
-} from "openclaw/plugin-sdk/security-runtime";
+} from "openclaw/plugin-sdk/file-access-runtime";
 
 // The legacy OAuth root is shared; keep its exact WhatsApp namespaces aligned
 // with Baileys without importing the provider into setup discovery.

--- a/extensions/whatsapp/src/state-migrations.test.ts
+++ b/extensions/whatsapp/src/state-migrations.test.ts
@@ -1,0 +1,95 @@
+// Doctor migration detection must stay independent of the broad security runtime.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { buildLegacyMigrationPreview } from "openclaw/plugin-sdk/runtime-doctor-migrations";
+import { describe, expect, it, vi } from "vitest";
+import { stateMigrations } from "../doctor-contract-api.js";
+import { detectWhatsAppLegacyStateMigrations } from "./state-migrations.js";
+
+vi.mock("openclaw/plugin-sdk/security-runtime", () => {
+  throw new Error("Doctor migration detection must not load the broad security runtime");
+});
+
+describe("WhatsApp legacy state migrations", () => {
+  it("plans migration for every Baileys auth category while preserving other shared-root files", async () => {
+    const oauthDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wa-legacy-migration-"));
+    const authFiles = [
+      "creds.json",
+      "creds.json.bak",
+      "pre-key-1.json",
+      "session-contact.json",
+      "sender-key-group.json",
+      "sender-key-memory-group.json",
+      "app-state-sync-key-contact.json",
+      "app-state-sync-version-contact.json",
+      "lid-mapping-15551234567.json",
+      "device-list-15551234567.json",
+      "tctoken-15551234567.json",
+      "identity-key-15551234567.json",
+    ];
+
+    try {
+      for (const file of [
+        ...authFiles,
+        "session-existing.json",
+        "oauth.json",
+        "google-oauth.json",
+        "notes.txt",
+      ]) {
+        fs.writeFileSync(path.join(oauthDir, file), "{}", "utf-8");
+      }
+      fs.mkdirSync(path.join(oauthDir, "nested"));
+      fs.writeFileSync(path.join(oauthDir, "nested", "session-keep.json"), "{}", "utf-8");
+      fs.symlinkSync(path.join(oauthDir, "notes.txt"), path.join(oauthDir, "session-linked.json"));
+      const targetDir = path.join(oauthDir, "whatsapp", "default");
+      fs.mkdirSync(targetDir, { recursive: true });
+      fs.writeFileSync(path.join(targetDir, "session-existing.json"), "{}", "utf-8");
+      fs.symlinkSync(path.join(oauthDir, "notes.txt"), path.join(targetDir, "creds.json.bak"));
+      fs.mkdirSync(path.join(targetDir, "pre-key-1.json"));
+
+      const migrations = detectWhatsAppLegacyStateMigrations({ oauthDir });
+
+      expect(migrations.map((migration) => path.basename(migration.sourcePath)).toSorted()).toEqual(
+        authFiles.toSorted(),
+      );
+      expect(
+        migrations
+          .map((migration) => ({
+            kind: migration.kind,
+            label: migration.label,
+            sourcePath: migration.sourcePath,
+            targetPath: migration.targetPath,
+            namespace: null,
+          }))
+          .toSorted((left, right) => left.sourcePath.localeCompare(right.sourcePath)),
+      ).toEqual(
+        authFiles
+          .map((fileName) => ({
+            kind: "move",
+            label: `WhatsApp auth ${fileName}`,
+            sourcePath: path.join(oauthDir, fileName),
+            targetPath: path.join(oauthDir, "whatsapp", "default", fileName),
+            namespace: null,
+          }))
+          .toSorted((left, right) => left.sourcePath.localeCompare(right.sourcePath)),
+      );
+      await expect(
+        stateMigrations[0]?.detectLegacyState({
+          config: {},
+          env: {},
+          oauthDir,
+          stateDir: oauthDir,
+          context: { openPluginStateKeyedStore: vi.fn() },
+        }),
+      ).resolves.toEqual({ preview: migrations.map(buildLegacyMigrationPreview) });
+      for (const migration of migrations) {
+        expect(migration.targetPath).toBe(
+          path.join(oauthDir, "whatsapp", "default", path.basename(migration.sourcePath)),
+        );
+      }
+    } finally {
+      fs.rmSync(oauthDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/whatsapp/src/state-migrations.ts
+++ b/extensions/whatsapp/src/state-migrations.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import type { ChannelLegacyStateMigrationPlan } from "openclaw/plugin-sdk/channel-contract";
-import { fileExists } from "openclaw/plugin-sdk/security-runtime";
+import { fileExists } from "openclaw/plugin-sdk/file-access-runtime";
 import { isWhatsAppBaileysAuthFileName } from "./creds-files.js";
 
 export function detectWhatsAppLegacyStateMigrations(params: {

--- a/src/config/schema.tags.ts
+++ b/src/config/schema.tags.ts
@@ -2,28 +2,8 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { ConfigUiHint, ConfigUiHints } from "../shared/config-ui-hints-types.js";
 
-/** Stable config UI tag vocabulary used for filtering and grouping schema hints. */
-const CONFIG_TAGS = [
-  "security",
-  "auth",
-  "network",
-  "access",
-  "privacy",
-  "observability",
-  "performance",
-  "reliability",
-  "storage",
-  "models",
-  "media",
-  "automation",
-  "channels",
-  "tools",
-  "advanced",
-] as const;
-
-type ConfigTag = (typeof CONFIG_TAGS)[number];
-
-const TAG_PRIORITY: Record<ConfigTag, number> = {
+/** Stable config UI tag vocabulary and display order. */
+const TAG_PRIORITY = {
   security: 0,
   auth: 1,
   access: 2,
@@ -40,6 +20,8 @@ const TAG_PRIORITY: Record<ConfigTag, number> = {
   tools: 13,
   advanced: 14,
 };
+
+type ConfigTag = keyof typeof TAG_PRIORITY;
 
 const TAG_OVERRIDES: Record<string, ConfigTag[]> = {
   worktreeRoot: ["storage", "advanced"],
@@ -115,26 +97,17 @@ const MEDIA_PATH_PATTERN = /(tools\.media\.|^audio\.|^talk\.|image|video|stt|tts
 const AUTOMATION_PATH_PATTERN = /(cron|heartbeat|schedule|onstart|watchdebounce)/i;
 const AUTH_KEYWORD_PATTERN = /(token|password|secret|api[_.-]?key|credential|oauth)/i;
 
-function normalizeTag(tag: string): ConfigTag | null {
-  const normalized = normalizeLowercaseStringOrEmpty(tag) as ConfigTag;
-  return CONFIG_TAGS.includes(normalized) ? normalized : null;
-}
-
-function normalizeTags(tags: ReadonlyArray<string>): string[] {
-  const out = new Set<ConfigTag>();
+function normalizeTags(known: Set<ConfigTag>, tags: ReadonlyArray<string>): string[] {
   const custom = new Set<string>();
   for (const tag of tags) {
-    const known = normalizeTag(tag);
-    if (known) {
-      out.add(known);
-    } else {
-      const normalized = normalizeLowercaseStringOrEmpty(tag);
-      if (normalized) {
-        custom.add(normalized);
-      }
+    const normalized = normalizeLowercaseStringOrEmpty(tag);
+    if (Object.hasOwn(TAG_PRIORITY, normalized)) {
+      known.add(normalized as ConfigTag);
+    } else if (normalized) {
+      custom.add(normalized);
     }
   }
-  return [...[...out].toSorted((a, b) => TAG_PRIORITY[a] - TAG_PRIORITY[b]), ...custom];
+  return [...[...known].toSorted((a, b) => TAG_PRIORITY[a] - TAG_PRIORITY[b]), ...custom];
 }
 
 function patternToRegExp(pattern: string): RegExp {
@@ -153,14 +126,14 @@ function addTags(set: Set<ConfigTag>, tags: ReadonlyArray<ConfigTag>): void {
 }
 
 /** Derive known config UI tags from a schema path and optional hint metadata. */
-function deriveTagsForPath(path: string, hint?: ConfigUiHint): ConfigTag[] {
-  const lowerPath = normalizeLowercaseStringOrEmpty(path);
+function deriveTagsForPath(path: string, hint?: ConfigUiHint): Set<ConfigTag> {
   const override =
     TAG_OVERRIDES[path] ?? WILDCARD_TAG_OVERRIDES.find(({ pattern }) => pattern.test(path))?.tags;
   if (override) {
-    return override;
+    return new Set(override);
   }
 
+  const lowerPath = normalizeLowercaseStringOrEmpty(path);
   const tags = new Set<ConfigTag>();
   for (const rule of PREFIX_RULES) {
     if (lowerPath.startsWith(rule.prefix)) {
@@ -194,7 +167,7 @@ function deriveTagsForPath(path: string, hint?: ConfigUiHint): ConfigTag[] {
     tags.add("advanced");
   }
 
-  return [...tags];
+  return tags;
 }
 
 /** Return hints with derived known tags merged ahead of any existing custom tags. */
@@ -204,7 +177,7 @@ export function applyDerivedTags(hints: ConfigUiHints): ConfigUiHints {
     const existingTags = Array.isArray(hint?.tags) ? hint.tags : [];
     const derivedTags = deriveTagsForPath(path, hint);
     // Preserve unknown tags after known tags so external/custom UI tags survive normalization.
-    const tags = normalizeTags([...derivedTags, ...existingTags]);
+    const tags = normalizeTags(derivedTags, existingTags);
     next[path] = { ...hint, tags };
   }
   return next;

--- a/src/config/schema.tiers.ts
+++ b/src/config/schema.tiers.ts
@@ -257,7 +257,9 @@ function isNumericSchema(schema: ConfigJsonSchemaObject): boolean {
 
 function mergeTierHint(hints: ConfigUiHints, path: string, advanced: boolean): void {
   const current = hints[path];
-  hints[path] = current ? { ...current, advanced } : { advanced };
+  if (current?.advanced !== advanced) {
+    hints[path] = current ? { ...current, advanced } : { advanced };
+  }
 }
 
 function visitSchemaNodes<T>(

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -395,13 +395,13 @@ function applyHeartbeatTargetHints(
   return next;
 }
 
-function applyExtensionSchemas(
+/** Mutate a caller-owned schema; cached inputs must be cloned before merging. */
+function mergeExtensionSchemas(
   schema: ConfigSchema,
   channels: ChannelUiMetadata[],
   plugins?: PluginUiMetadata[],
 ): ConfigSchema {
-  const next = cloneSchema(schema);
-  const root = asSchemaObject(next);
+  const root = asSchemaObject(schema);
   const pluginsNode = asSchemaObject(root?.properties?.plugins);
   const entriesNode = asSchemaObject(pluginsNode?.properties?.entries);
   const entryBase = asSchemaObject(entriesNode?.additionalProperties);
@@ -439,7 +439,7 @@ function applyExtensionSchemas(
 
   const channelsNode = asSchemaObject(root?.properties?.channels);
   if (!channelsNode) {
-    return next;
+    return schema;
   }
   const channelProps = channelsNode.properties ?? {};
   channelsNode.properties = channelProps;
@@ -457,7 +457,7 @@ function applyExtensionSchemas(
     }
   }
 
-  return next;
+  return schema;
 }
 
 let cachedBase: ConfigSchemaResponse | null = null;
@@ -557,7 +557,7 @@ function buildBaseConfigSchema(): ConfigSchemaResponse {
       collectExtensionHintKeys(mergedWithoutSensitiveHints, [], bundledChannels),
     ),
   );
-  const mergedSchema = applyExtensionSchemas(generated.schema, bundledChannels);
+  const mergedSchema = mergeExtensionSchemas(generated.schema, bundledChannels);
   const next = {
     ...generated,
     schema: mergedSchema,
@@ -603,7 +603,7 @@ export function buildConfigSchemaCore(params?: {
       extensionHintKeys,
     ),
   );
-  const mergedSchema = applyExtensionSchemas(base.schema, channels, plugins);
+  const mergedSchema = mergeExtensionSchemas(cloneSchema(base.schema), channels, plugins);
   const merged = {
     ...base,
     schema: mergedSchema,

--- a/src/plugin-sdk/file-access-runtime.ts
+++ b/src/plugin-sdk/file-access-runtime.ts
@@ -1,12 +1,27 @@
 // Safe local-file helpers for plugin runtime media and bridge code.
+import { statRegularFileSync as inspectRegularFileSync } from "../infra/fs-safe.js";
+
+/** Return whether a path resolves to a regular file, treating filesystem errors as missing. */
+export function fileExists(filePath: string): boolean {
+  try {
+    return !inspectRegularFileSync(filePath).missing;
+  } catch {
+    return false;
+  }
+}
 
 export {
   canonicalPathFromExistingAncestor,
   readFileWithinRoot,
   readLocalFileFromRoots,
+  readRegularFile,
+  readRegularFileSync,
   root,
+  statRegularFile,
+  statRegularFileSync,
   writeFileWithinRoot,
 } from "../infra/fs-safe.js";
+export { assertNoSymlinkParents, assertNoSymlinkParentsSync } from "../infra/fs-safe-advanced.js";
 export {
   ensureDurableDirectory,
   syncDirectory,

--- a/src/plugin-sdk/fs-safe-compat.test.ts
+++ b/src/plugin-sdk/fs-safe-compat.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { loadSecretFileSync as loadSecretFileSyncFromCore } from "openclaw/plugin-sdk/core";
 import {
+  fileExists,
   readFileWithinRoot,
   removePathWithinRoot,
   writeFileWithinRoot,
@@ -13,10 +14,32 @@ import {
   loadSecretFileSync,
   type SecretFileReadResult,
 } from "openclaw/plugin-sdk/secret-file-runtime";
+import { fileExists as fileExistsFromSecurity } from "openclaw/plugin-sdk/security-runtime";
 import { describe, expect, it } from "vitest";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 
 describe("plugin SDK fs-safe compatibility exports", () => {
+  it.each([
+    { subpath: "file-access-runtime", exists: fileExists },
+    { subpath: "security-runtime", exists: fileExistsFromSecurity },
+  ])("keeps $subpath file checks limited to regular files", async ({ exists }) => {
+    await withTestDir({ prefix: "openclaw-sdk-file-exists-" }, async (root) => {
+      const filePath = path.join(root, "file.txt");
+      const symlinkPath = path.join(root, "linked.txt");
+      fs.writeFileSync(filePath, "content");
+      fs.symlinkSync(filePath, symlinkPath);
+
+      for (const [candidate, expected] of [
+        [filePath, true],
+        [path.join(root, "missing.txt"), false],
+        [root, false],
+        [symlinkPath, false],
+      ] as const) {
+        expect(exists(candidate), candidate).toBe(expected);
+      }
+    });
+  });
+
   it("keeps deprecated secret-file result helpers on public SDK subpaths", async () => {
     await withTestDir({ prefix: "openclaw-sdk-secret-compat-" }, async (root) => {
       const secretPath = path.join(root, "token.txt");

--- a/src/plugin-sdk/security-runtime.ts
+++ b/src/plugin-sdk/security-runtime.ts
@@ -1,15 +1,14 @@
 /** Public security runtime helpers for plugin-side trust boundaries. */
 
-import { statRegularFileSync as inspectRegularFileSync } from "../infra/fs-safe.js";
-
-/** Return whether a path resolves to a regular file, treating filesystem errors as missing. */
-export function fileExists(filePath: string): boolean {
-  try {
-    return !inspectRegularFileSync(filePath).missing;
-  } catch {
-    return false;
-  }
-}
+export {
+  assertNoSymlinkParents,
+  assertNoSymlinkParentsSync,
+  fileExists,
+  readRegularFile,
+  readRegularFileSync,
+  statRegularFile,
+  statRegularFileSync,
+} from "./file-access-runtime.js";
 
 export {
   buildChannelMetadata,
@@ -39,12 +38,8 @@ export {
   openLocalFileSafely,
   pathExists,
   pathExistsSync,
-  readRegularFile,
   resolveLocalPathFromRootsSync,
-  readRegularFileSync,
   root,
-  statRegularFile,
-  statRegularFileSync,
   writeExternalFileWithinRoot,
   withTimeout,
 } from "../infra/fs-safe.js";
@@ -70,7 +65,6 @@ export { sanitizeUntrustedFileName } from "../infra/fs-safe-advanced.js";
 export { privateFileStoreSync } from "../infra/private-file-store.js";
 export { movePathWithCopyFallback, replaceFileAtomic } from "../infra/replace-file.js";
 
-export { assertNoSymlinkParents, assertNoSymlinkParentsSync } from "../infra/fs-safe-advanced.js";
 export { ensurePortAvailable } from "../infra/ports.js";
 
 export {

--- a/ui/src/components/github-link-hovercard.test.ts
+++ b/ui/src/components/github-link-hovercard.test.ts
@@ -224,7 +224,10 @@ describe("openclaw-github-link-hovercard-provider", () => {
       updatedAt: "2026-07-05T09:55:00Z",
     });
     const href = "https://github.com/openclaw/openclaw/pull/99816";
-    const { anchor, provider } = createLink(href, "#99816");
+    const { anchor, provider } = createLink(
+      "HTTPS://GITHUB.COM:443/openclaw/openclaw/pull/99816",
+      "#99816",
+    );
     provider.client = { request } as unknown as GatewayBrowserClient;
 
     await hover(anchor);
@@ -431,6 +434,9 @@ describe("openclaw-github-link-hovercard-provider", () => {
   it.each([
     "http://github.com/openclaw/openclaw/issues/99815",
     "https://user:password@github.com/openclaw/openclaw/issues/99815",
+    "https://github.com:8443/openclaw/openclaw/issues/99815",
+    "https://github.com.example.com/openclaw/openclaw/issues/99815",
+    "blob:https://github.com/issues/99815",
     "https://example.com/openclaw/openclaw/issues/99815",
     "javascript:alert(1)",
   ])("does not preview an untrusted item URL: %s", async (href) => {

--- a/ui/src/components/github-link-target.ts
+++ b/ui/src/components/github-link-target.ts
@@ -1,4 +1,4 @@
-const GITHUB_HOST = "github.com";
+const GITHUB_URL_PREFIX = "https://github.com/";
 
 export const GITHUB_HOVERCARD_OPEN_DELAY_MS = 250;
 
@@ -38,14 +38,13 @@ export function parseGitHubItemPath(url: URL): GitHubItemTarget | null {
 export function parseGitHubLinkTarget(href: string): GitHubLinkTarget | null {
   let url: URL;
   try {
-    url = new URL(href, globalThis.location?.href ?? "http://localhost/");
+    // Anchors resolve relative links; the stream scanner supplies absolute URLs.
+    url = new URL(href);
   } catch {
     return null;
   }
-  if (url.protocol !== "https:" || url.hostname.toLowerCase() !== GITHUB_HOST) {
-    return null;
-  }
-  if (url.username || url.password || (url.port && url.port !== "443")) {
+  // Match the parsed URL so credentials, ports, and lookalike hosts cannot pass.
+  if (!url.href.startsWith(GITHUB_URL_PREFIX)) {
     return null;
   }
   const target = parseGitHubItemPath(url);
@@ -53,7 +52,7 @@ export function parseGitHubLinkTarget(href: string): GitHubLinkTarget | null {
 }
 
 export function gitHubProfileUrl(login: string): string {
-  return `https://${GITHUB_HOST}/${encodeURIComponent(login)}`;
+  return `${GITHUB_URL_PREFIX}${encodeURIComponent(login)}`;
 }
 
 export function githubLinkAnchorFromEvent(event: Event): HTMLAnchorElement | null {
@@ -66,8 +65,4 @@ export function githubLinkAnchorFromEvent(event: Event): HTMLAnchorElement | nul
     }
   }
   return null;
-}
-
-export function isGitHubPullRequestLink(href: string): boolean {
-  return parseGitHubLinkTarget(href)?.kind === "pull";
 }

--- a/ui/src/pages/chat/chat-pull-request-refresh.ts
+++ b/ui/src/pages/chat/chat-pull-request-refresh.ts
@@ -1,4 +1,4 @@
-import { isGitHubPullRequestLink } from "../../components/github-link-target.ts";
+import { parseGitHubLinkTarget } from "../../components/github-link-target.ts";
 import type { ChatEventPayload } from "./chat-gateway.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 
@@ -11,7 +11,7 @@ export function pullRequestLinksIn(text: unknown): string[] {
   const links: string[] = [];
   for (const match of text.matchAll(GITHUB_URL_CANDIDATE)) {
     const href = match[0].replace(/[.,;:!?]+$/u, "");
-    if (isGitHubPullRequestLink(href)) {
+    if (parseGitHubLinkTarget(href)?.kind === "pull") {
       links.push(href);
     }
   }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can update this branch.

</details>

## What Problem This Solves

Dev Gateway startup waits for plugin Doctor contracts and configuration schema construction before the dashboard is ready. Real Gateway profiling found avoidable module loading and repeated schema allocations in those paths. This change reduces that work while preserving schema output, migration behavior, file-safety checks, history limits, and saved reading positions.

## Why This Change Was Made

Five startup imports across WhatsApp, iMessage, Telegram, and Nextcloud Talk now use the existing private `file-access-runtime` facade. That facade owns the unchanged `fileExists` implementation and exposes six existing regular-file/symlink-parent helpers. The typed public `security-runtime` facade re-exports the same seven bindings shipped in v2026.8.1. External plugins keep that public entrypoint; the SDK migration guide now recommends it correctly.

Schema construction derives tags once from one priority vocabulary, reuses unchanged intermediate tier hints, and merges into caller-owned schema input. Cached schema is cloned at its owner, and final public hint records remain fresh. This removes duplicate copying and normalization without introducing a cache or changing schema policy.

The eager GitHub-link parser validates the canonical parsed URL once, leaves relative-link resolution to browser anchors, and removes a one-use PR predicate wrapper. Credential-bearing URLs, alternate ports, lookalike hosts, and blob URLs remain rejected. This simplification also addresses the startup bundle budget failure exposed during integration.

The final diff spans **17 files: production −21 lines, tests +48 after accounting for the moved migration case, and documentation net 0**. It contains no release-script changes.

## User Impact

Gateway startup and initial dashboard configuration loading do less CPU work. Existing external SDK types and file-validation behavior remain intact; bundled startup avoids loading the broader security dependency graph for simple file checks.

Release-note context: reduce Gateway startup and configuration-loading work by narrowing plugin file-check imports and removing redundant schema allocations.

## Evidence

Measured against [main at bacc13444eaf](https://github.com/openclaw/openclaw/commit/bacc13444eaf37a3709999c4cbf81c8334b056fa) using an isolated Linux source/dev Gateway, normal plugin startup and dashboard authentication, Node 24.19.0, and Chromium 151.0.7922.34. Unprofiled timings used ABBABAAB order with **four fresh Gateway/browser runs per version**; CPU profiles were collected separately.

| Measurement | Before | After | Change |
| --- | ---: | ---: | ---: |
| Median Gateway readiness | 4,064.3 ms | 3,325.9 ms | −18.2% |
| Doctor contract loading, sampled inclusive CPU | 1,149.6 ms | 611.9 ms | −46.8% |
| Schema construction, sampled inclusive CPU | 334.5 ms | 299.6 ms | −10.4% |

The synthetic fixture had 3,000 rich messages and 375 completed tool pairs. The UI loaded 800 messages, prepended 1,000, switched sessions, and restored its reading position: correct counts, zero anchor drift, no browser errors, and no RPC on saved return. Providers were not called. Source, frozen dependency, fixture, and build identities were checked.

These fixed-baseline measurements cover the source/dev Gateway, not published-package performance or the final rebase. Browser timings remain exploratory: prepend first paint was effectively flat and long-task totals did not improve. The measured UI builds also differed by 40 generated initializer bytes outside the gated startup graph despite identical embedded metadata. No general scrolling speedup is claimed.

[Clean Linux validation](https://github.com/openclaw/openclaw/actions/runs/33462104310) passed **255 tests across 17 files**, with zero skips, covering schema/redaction, SDK file access, Doctor contracts, and all four affected plugins. The WhatsApp import-boundary regression failed on the original broad import. Nine complete schema/hint/lookup/redaction captures—16,164,353 bytes—matched except for `generatedAt`. Formatting, scoped lint, full `pnpm build`, and the SDK export check passed. Built import/RSS checks passed for all four plugins; those establish importability, not memory savings.

[Separate UI validation](https://github.com/openclaw/openclaw/actions/runs/33471302006) passed **138 tests** across hovercard, native-link-routing, and chat-state, with zero skips. Local parity covered 3,600 absolute URLs and four profile URLs. Every UI performance budget passed: startup JavaScript gzip was **348,324 bytes against the unchanged 348,368-byte limit**. The complete 35,953-file manifest and frozen inputs were verified. Embedded metadata recorded `main`, `dirty: true`, and `167e99dd077f`; this is an absolute candidate budget pass, not a strict code-only size comparison or final-head CI proof. Both proof leases were stopped.

The [fresh CI artifact](https://github.com/openclaw/openclaw/actions/runs/33489632896/artifacts/9793396741) passed an external packed-declaration NodeNext/strict TypeScript 6.0.3 consumer: all seven public helpers were non-`any`, callable, and rejected invalid numeric arguments, with zero diagnostics. Its 62 declaration files and 152 relative edges stay within the package; the private flat facade declaration is absent. The artifact build source is GitHub merge commit `a61416b1a58be938c50531267235034fba3acd0d`, containing the reviewed PR head; checkout logs and embedded metadata agree, and all 17 PR paths match that source.

The archive used npm's package-file inventory with scripts disabled and unchanged `files`/`exports` rules. `workspace:*` dependency metadata remains unchanged; no dependencies were installed. `skipLibCheck` is enabled with explicit non-`any` and callability checks. This proves the declaration boundary, not installation, external dependency types, or full pnpm release packaging. The downloaded artifact digest and all retained declaration hashes were verified.

The accepted [ClawSweeper SDK documentation finding](https://github.com/openclaw/openclaw/pull/134807#issuecomment-5488949767) and its Rank-up move are addressed by the public entrypoint correction. The declaration-import concern did not reproduce in the packed consumer: the canonical builder bundles private helpers into public declarations. The stored-data heuristic does not apply to configuration UI hint tags; no SQLite schema or persistence behavior changes. The latest requested main refresh, exact-head CI, and packaged consumer Rank-up proof are complete.

Current candidate is `1e8ae0191dcbaf080728416e5e74f8340e6b8741`, rebased onto [main fd6bb2296993](https://github.com/openclaw/openclaw/commit/fd6bb2296993b12c27df4b48a6a525784842b2ff). Main already contains the release-inventory overflow repair from [#134824](https://github.com/openclaw/openclaw/pull/134824) and canonical Doctor runtime-prebuild fixture repair from [#134812](https://github.com/openclaw/openclaw/pull/134812); duplicate #135023 was closed. Earlier CI also encountered a dependency-download reset. No readiness timeout or assertion was relaxed here. **[Current-head CI](https://github.com/openclaw/openclaw/actions/runs/33489632896) passed on attempt 1. Fresh managed Codex review completed with no accepted findings at the requested P0 threshold, and the refreshed SDK consumer proof passed.** The [Doctor shard](https://github.com/openclaw/openclaw/actions/runs/33489632896/job/99798608590) passed all 11 process cases and all 310 tests across 12 files, with zero skips; the readiness case took 2.843 seconds after the canonical 35.6-second runtime prebuild. Earlier canceled/stale-dependency changed-check attempts do not establish a full pass.

Initial-history captures from the measured synthetic flow; layout is unchanged:

| Before | After |
| --- | --- |
| ![Before: synthetic history loaded](https://github.com/user-attachments/assets/f907b79c-99ee-4ce2-adb6-4de2fca1019a) | ![After: synthetic history loaded](https://github.com/user-attachments/assets/32b29a77-422b-456f-b2f6-2d1448feb924) |

Named adjacent follow-ups: channel object-schema merging retains nested metadata differently from sibling branches; `sensitive: false` with `url-secret` has inconsistent redaction/restoration behavior; general source synchronization omitted 18 tracked files before the task-specific transfer was repaired. These pre-existing ownership/tooling issues remain outside this refactor.
