### PR TITLE
test(perf): consolidate startup parser CLI coverage

### DIFF
--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -15,7 +15,7 @@ describe("bench-cli-startup", () => {
 
     const result = spawnSync(
       process.execPath,
-      ["--import", "tsx", "scripts/bench-cli-startup.ts", "--wat"],
+      ["--import", "tsx", "scripts/bench-cli-startup.ts", "--wat", "--help"],
       {
         cwd: join(__dirname, "../.."),
         encoding: "utf8",
@@ -32,21 +32,6 @@ describe("bench-cli-startup", () => {
   it("rejects short flag values before running benchmarks", () => {
     expect(() => testing.validateCliArgs(["--output", "-h"])).toThrow("--output requires a value");
     expect(() => testing.validateCliArgs(["--case", "-h"])).toThrow("--case requires a value");
-
-    const result = spawnSync(
-      process.execPath,
-      ["--import", "tsx", "scripts/bench-cli-startup.ts", "--output", "-h"],
-      {
-        cwd: join(__dirname, "../.."),
-        encoding: "utf8",
-      },
-    );
-
-    expect(result.status).toBe(1);
-    expect(result.stdout).toBe("");
-    expect(result.stderr.trim()).toBe("--output requires a value");
-    expect(result.stderr).not.toContain("Node.js");
-    expect(result.stderr).not.toContain("\n    at ");
   });
 
   it("rejects duplicate benchmark cases before running benchmarks", () => {
@@ -70,29 +55,6 @@ describe("bench-cli-startup", () => {
     expect(() => testing.validateCliArgs(["--output", "one.json", "--output", "two.json"])).toThrow(
       "--output was provided more than once",
     );
-
-    const result = spawnSync(
-      process.execPath,
-      [
-        "--import",
-        "tsx",
-        "scripts/bench-cli-startup.ts",
-        "--output",
-        "one.json",
-        "--output",
-        "two.json",
-      ],
-      {
-        cwd: join(__dirname, "../.."),
-        encoding: "utf8",
-      },
-    );
-
-    expect(result.status).toBe(1);
-    expect(result.stdout).toBe("");
-    expect(result.stderr.trim()).toBe("--output was provided more than once");
-    expect(result.stderr).not.toContain("Node.js");
-    expect(result.stderr).not.toContain("\n    at ");
   });
 
   it.runIf(process.platform !== "win32")(


### PR DESCRIPTION
## What Problem This Solves

The startup benchmark tests launch Node/tsx repeatedly to exercise the same CLI rejection renderer after directly checking each validator rule.

## Why This Change Was Made

Remove two duplicate launches while retaining the exact short-value and duplicate-output parser assertions. Add `--help` to the existing unknown-option CLI case so it also verifies that validation runs before the help shortcut. Real repeated-case, private-output and child process-group timeout tests remain.

## User Impact

Test-only. All 16 benchmark cases and 14 memory sibling cases remain; production +0/-0, tests +1/-39. No timeout or elapsed-time claim changes.

## Evidence

All 30 cases pass before and after with identical labels/statuses. Temporarily moving validation after the help return makes the retained CLI case fail on exit status (0 versus 1); restoring the exact owner bytes makes it pass again. Full changed checks and Codex autoreview pass. Independent source review and the original validator regressions confirm that the removed launches add no distinct parser coverage.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/bench-cli-startup.test.ts test/scripts/check-cli-startup-memory.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base fed0215c58b36c43bab83515e9d7be06189a5e4c
```
