### PR TITLE
perf(gateway): skip unused session snapshot and deletion reads

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
@@ -235,6 +235,9 @@ export function deleteMaterializedSessionStatePlans(
   protectedSessionIds?: ReadonlySet<string>,
   excludedSessionKeys?: ReadonlySet<string>,
 ): SessionLifecycleArchivedTranscript[] {
+  if (plans.length === 0) {
+    return [];
+  }
   const archivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
   const referencedSessionIds = readReferencedSessionIds(database, excludedSessionKeys);
   for (const sessionId of protectedSessionIds ?? []) {
@@ -323,7 +326,6 @@ export async function projectSessionEntryLifecycleMutation(
   const store = readSessionEntryStore(removalDatabase, {
     allowCanonicalRepair: params.allowCanonicalRepair === true,
   });
-  const removedEntries: Array<{ archiveTranscript: boolean; entry: SessionEntry }> = [];
   const removedKeysToArchive = new Set<string>();
   const changedSessionKeys = new Set<string>();
   const projectedRemovals: ProjectedLifecycleMutation["removals"] = [];
@@ -357,13 +359,11 @@ export async function projectSessionEntryLifecycleMutation(
       }
     }
     projectedRemovals.push({
+      // Capture each archive decision before an async builder can change its input.
+      archiveTranscript: removal.archiveRemovedTranscript === true,
       expectedEntry: cloneSessionEntry(entry),
       removal,
       sessionKey,
-    });
-    removedEntries.push({
-      archiveTranscript: removal.archiveRemovedTranscript === true,
-      entry,
     });
     if (removal.archiveRemovedTranscript === true) {
       removedKeysToArchive.add(sessionKey);
@@ -413,6 +413,9 @@ export async function projectSessionEntryLifecycleMutation(
       ...(upsert.resetBoundary ? { resetBoundary: upsert.resetBoundary } : {}),
     });
   }
+  if (projectedRemovals.length === 0) {
+    return { deletePlans: [], removals: projectedRemovals, upsertedEntries };
+  }
   // openclaw-agent-db.ts cache rule: LRU eviction may close idle handles during buildEntry awaits.
   const database = openOpenClawAgentDatabase(databaseOptions);
   const referencedSessionIds = collectProjectedReferencedSessionIds({
@@ -420,7 +423,7 @@ export async function projectSessionEntryLifecycleMutation(
     excludedSessionKeys: changedSessionKeys,
     projectedStore: store,
   });
-  const deletePlans = removedEntries.flatMap(({ archiveTranscript, entry }) =>
+  const deletePlans = projectedRemovals.flatMap(({ archiveTranscript, expectedEntry: entry }) =>
     planSessionStateAfterEntryRemoval({
       archiveDirectory: params.archiveDirectory,
       archiveTranscript,

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-types.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-types.ts
@@ -33,6 +33,7 @@ export type LifecycleArtifactCleanupPlan = {
 export type ProjectedLifecycleMutation = {
   deletePlans: SessionStateDeletePlan[];
   removals: Array<{
+    archiveTranscript: boolean;
     expectedEntry: SessionEntry;
     removal: SessionEntryLifecycleRemoval;
     sessionKey: string;

--- a/src/config/sessions/session-accessor.sqlite-maintenance-writer.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance-writer.test.ts
@@ -9,6 +9,7 @@ import {
   applySessionEntryLifecycleMutation,
   cleanupSessionLifecycleArtifactsCore,
   loadSessionEntry,
+  loadTranscriptEventsSync,
   replaceSessionEntrySync,
   replaceTranscriptEventsSync,
 } from "./session-accessor.js";
@@ -34,6 +35,7 @@ vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => {
+  vi.restoreAllMocks();
   archiveMaterializationHook.beforeMaterialize = undefined;
   closeOpenClawAgentDatabasesForTest();
 });
@@ -57,6 +59,45 @@ function createPlannerStore(entryCount: number) {
   database.db.exec("ANALYZE; PRAGMA analysis_limit = 37;");
   return { database, storePath };
 }
+
+it.each([false, true])(
+  "does not rescan unrelated rows when no lifecycle removal matches (requested: %s)",
+  async (requestRemoval) => {
+    const { storePath } = createPlannerStore(2);
+    const retained = { sessionKey: "agent:main:planner-1", sessionId: "planner-1", storePath };
+    const transcript = [{ type: "session", id: retained.sessionId, content: "retained" }];
+    replaceTranscriptEventsSync(retained, transcript);
+    const parseSpy = vi.spyOn(JSON, "parse");
+    await expect(
+      applySessionEntryLifecycleMutation({
+        storePath,
+        skipMaintenance: true,
+        removals: requestRemoval ? [{ sessionKey: "agent:main:missing" }] : [],
+        upserts: [
+          {
+            sessionKey: "agent:main:planner-0",
+            buildEntry: async ({ currentEntry }) => ({ ...currentEntry!, label: "updated" }),
+          },
+        ],
+      }),
+    ).resolves.toMatchObject({
+      afterCount: 2,
+      removedEntries: 0,
+      archivedTranscriptDirectories: [],
+    });
+
+    // Allow the builder snapshot and before/after counts, but no unused deletion scans.
+    expect(
+      parseSpy.mock.calls.filter(([serialized]) => serialized.includes('"planner-1"')).length,
+    ).toBeLessThanOrEqual(3);
+    parseSpy.mockRestore();
+    expect(loadSessionEntry({ sessionKey: "agent:main:planner-0", storePath })?.label).toBe(
+      "updated",
+    );
+    expect(loadSessionEntry(retained)?.sessionId).toBe(retained.sessionId);
+    expect(loadTranscriptEventsSync(retained)).toEqual(transcript);
+  },
+);
 
 it("releases the store writer before maintenance archive sizing completes", async () => {
   const tempDir = tempDirs.make("openclaw-session-maintenance-writer-");

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -327,7 +327,6 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
               const resolvedSharingTargets = result.sessions.map((session) =>
                 resolveSessionSharingTarget({
                   cfg,
-                  projection: "list",
                   sessionKey: session.key,
                   storeCache: sharingStoreCache,
                   targetDiscoveryCache,

--- a/src/gateway/session-sharing-policy.ts
+++ b/src/gateway/session-sharing-policy.ts
@@ -72,7 +72,6 @@ export function resolveSessionSharingTarget(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   agentId?: string;
-  projection?: "full" | "list";
   storeCache?: GatewaySessionStoreCache;
   targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
 }): SessionSharingTarget | null {
@@ -81,7 +80,8 @@ export function resolveSessionSharingTarget(params: {
     key: params.sessionKey,
     agentId: params.agentId,
     clone: false,
-    ...(params.projection ? { projection: params.projection } : {}),
+    // Authorization rechecks current metadata; prompt snapshots are not part of that binding.
+    projection: "list",
     ...(params.storeCache ? { storeCache: params.storeCache } : {}),
     ...(params.targetDiscoveryCache ? { targetDiscoveryCache: params.targetDiscoveryCache } : {}),
   });

--- a/src/gateway/session-sharing-store-cache.test.ts
+++ b/src/gateway/session-sharing-store-cache.test.ts
@@ -95,12 +95,18 @@ describe("session mutation authorization store caches", () => {
     });
   });
 
-  it("fences a replaced patchMany target with padded identity fields", async () => {
+  it("reuses metadata for padded patchMany targets and fences replacements", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       const sessionKey = "agent:main:padded-batch-target";
+      const prompt = "authorization does not need this prompt snapshot".repeat(512);
       await sessionAccessor.upsertSessionEntryCore(
         { agentId: "main", sessionKey },
-        { sessionId: "session-original", updatedAt: 1, visibility: "shared" },
+        {
+          sessionId: "session-original",
+          updatedAt: 1,
+          visibility: "shared",
+          skillsSnapshot: { prompt, skills: [] },
+        },
       );
       const target = { sessionKey: ` ${sessionKey} `, agentId: " main " };
       const result = resolveSessionMutationAuthorization({
@@ -116,7 +122,10 @@ describe("session mutation authorization store caches", () => {
       expect(result.error).toBeNull();
       expect(result.authorization).toBeDefined();
       const authorization = result.authorization!;
+      const parseSpy = vi.spyOn(JSON, "parse");
       expect(() => authorization.assertTargetCurrent(target)).not.toThrow();
+      expect(parseSpy.mock.calls.some(([serialized]) => serialized.includes(prompt))).toBe(false);
+      parseSpy.mockRestore();
 
       await sessionAccessor.upsertSessionEntryCore(
         { agentId: "main", sessionKey },


### PR DESCRIPTION
## What Problem This Solves

Reduces repeated Gateway work before agent turns. Sharing authorization decoded large prompt snapshots that it never uses, while session updates scanned transcript references even when there was nothing to delete.

Related: #134673.

## Why This Change Was Made

The sharing resolver now always uses the existing metadata projection, removing its optional full-entry path. Current identity, permission, membership, replacement and post-await checks stay in their existing owners; full session descriptions and transcript reads load their own data.

The lifecycle owner skips reference collection for empty effective removals and empty materialized deletion plans. It captures archive decisions on the existing projected-removal record before asynchronous builders, deleting the parallel removed-entry collection. Actual deletions retain reference and snapshot revalidation.

Production LOC: +12/-9 (net +3). Tests: +52/-2 (net +50). The remaining growth is the two empty-work exits and the captured archive decision; the redundant option and parallel collection are removed. No schema, configuration, protocol or provider changes.

## User Impact

Lower local preparation overhead for the measured plain and file-tool turns. This does not establish a consistent end-to-end reply speedup: provider, tool, host and background work produced mixed total timings.

## Evidence

Real OpenAI runs used `openai/gpt-5.6-luna`, low reasoning, unchanged configuration and identical restored session state. Order: candidate A, baseline, candidate B; 84 measured turns, all outliers retained, plus warmups and probes for 128 verified replies/tool outcomes. The baseline was `73f24c23151506cce758c92a0f8a4eb9e35655bb`. All three rounds held the same 8,722 shared package output files fixed and switched only root build output; older measurements were excluded after detecting regenerated package outputs.

| Workload | Baseline prep median | Candidate prep median | Baseline final median | Candidate final median | Baseline Gateway CPU/turn | Candidate Gateway CPU/turn |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Plain | 138.17 ms | 119.64 ms | 997.98 ms | 1023.24 ms | 253.73 ms | 210.05 ms |
| File tool | 130.83 ms | 117.54 ms | 2162.73 ms | 2353.14 ms | 351.35 ms | 309.44 ms |
| Status tool | 123.11 ms | 127.08 ms | 1970.38 ms | 1839.78 ms | 290.15 ms | 314.46 ms |

Candidate medians pool both rounds: plain n=32 and each tool n=12, versus baseline n=16/6/6. Candidate CPU averages equal-size rounds. Preparation is request-to-turn-starting; Gateway CPU excludes the native model-runtime child. The shared host was not idle, so these are workload observations, not a universal latency guarantee.

Separate two-turn counters were identical in both candidate probes: session-record parses fell 1,626 → 1,337 (17.8%); reference reads 6 → 2; projected-reference collections 4 → 2. The latter two counts overlap and must not be added. Session clone and identity-snapshot counts were unchanged.

Regression proof failed on the old code: warm authorization decoded the large prompt; both empty-removal cases decoded an unrelated row five times against a budget of three. The candidate passed while still fencing replacements and retaining sibling rows/transcripts. All 127 focused tests across 12 files passed, covering sharing/revocation, cache freshness, async handle recovery, archive fencing and deletion races. Changed-scope checks and the full build passed. Fresh independent Codex Autoreview returned P0 scoped-clean with no accepted/actionable findings.

Release-note context: reduce unnecessary session snapshot and deletion-reference reads during Gateway turn preparation. Existing operator documentation and settings remain unchanged.

The benchmark results predate a mechanical rebase onto `e4806dc82aa`; `git range-diff` confirms the six-file patch is unchanged. All 127 focused tests and a fresh Codex Autoreview passed again on `a194bfbdadd`. The rebase picks up upstream UI HTML-comment cleanup after the earlier merge build exceeded the startup bundle budget; this PR changes no UI code or budget.

Final landing validation on `a194bfbdadd`: all 127 focused tests, changed-scope checks, the complete local build, and [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33471615801) passed, including `openclaw/ci-gate`. Four additional real OpenAI turns verified two plain replies, a file-tool result and a session-status result on the rebuilt Gateway. These smoke checks are separate from the benchmark samples above. The earlier UI budget failure (63 B, then 61 B on retry) is resolved by the upstream cleanup with the original budget intact.
