### PR TITLE
fix(agents): avoid evicting MCP runtimes during requester resolution

### DIFF
--- a/src/agents/agent-bundle-mcp-manager-lifecycle.ts
+++ b/src/agents/agent-bundle-mcp-manager-lifecycle.ts
@@ -208,10 +208,9 @@ export function createSessionMcpRuntimeManagerLifecycle(
       if (nowMs - runtime.lastUsedAt < DEFAULT_SESSION_MCP_RUNTIME_IDLE_TTL_MS) {
         continue;
       }
-      // A requester resolve/install is serialized on this key but runs outside
-      // the runtime lease. Keep its current transport alive until that chain
-      // records the refreshed runtime, rather than racing it with disposal.
-      if (store.requesterWorkChains.has(runtimeKey) || store.createInFlight.has(runtimeKey)) {
+      // Requester work runs outside the runtime lease. Keep its current
+      // transport until the chain records the refreshed runtime.
+      if (store.requesterWorkChains.has(runtimeKey)) {
         continue;
       }
       store.runtimesBySessionId.delete(runtimeKey);
@@ -258,8 +257,12 @@ export function createSessionMcpRuntimeManagerLifecycle(
       .toSorted((a, b) => a.runtime.lastUsedAt - b.runtime.lastUsedAt)
       .slice(0, overflow);
     for (const { runtimeKey, runtime } of evictable) {
-      // Serialize with in-flight work on that key so eviction cannot clobber a
-      // concurrent reuse or install for the same requester.
+      // Do not queue opportunistic eviction behind active requester work: that
+      // would dispose the runtime the work just refreshed.
+      if (store.requesterWorkChains.has(runtimeKey)) {
+        continue;
+      }
+      // Claim the idle key before yielding so later requester work follows disposal.
       await runExclusiveOnRuntimeKey(runtimeKey, async () => {
         const current = store.runtimesBySessionId.get(runtimeKey);
         if (current !== runtime || (current.activeLeases ?? 0) > 0) {

--- a/src/agents/agent-bundle-mcp-manager-lifecycle.ts
+++ b/src/agents/agent-bundle-mcp-manager-lifecycle.ts
@@ -208,6 +208,12 @@ export function createSessionMcpRuntimeManagerLifecycle(
       if (nowMs - runtime.lastUsedAt < DEFAULT_SESSION_MCP_RUNTIME_IDLE_TTL_MS) {
         continue;
       }
+      // A requester resolve/install is serialized on this key but runs outside
+      // the runtime lease. Keep its current transport alive until that chain
+      // records the refreshed runtime, rather than racing it with disposal.
+      if (store.requesterWorkChains.has(runtimeKey) || store.createInFlight.has(runtimeKey)) {
+        continue;
+      }
       store.runtimesBySessionId.delete(runtimeKey);
       store.connectionMetaByRuntimeKey.delete(runtimeKey);
       expired.push(runtime);

--- a/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
+++ b/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
@@ -388,7 +388,7 @@ describe("MCP manager creation ownership", () => {
     await resolutionStarted.promise;
     const competing = manager.getOrCreateRequesterScoped(requesterParams("sender-b"));
     await secondRuntimeCreated.promise;
-    await new Promise<void>(setImmediate);
+    await new Promise<void>((resolve) => setImmediate(resolve));
     releaseResolution.resolve();
 
     expect((await refreshed)?.runtime).toBe(first);

--- a/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
+++ b/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
@@ -400,5 +400,14 @@ describe("MCP manager creation ownership", () => {
     expect(manager.listRuntimeKeys()).toEqual([
       expect.stringContaining('"requesterSenderId":"sender-a"'),
     ]);
+    console.log(
+      JSON.stringify({
+        claim: "competing requester capacity eviction",
+        firstRuntimeDisposed: first.dispose.mock.calls.length > 0,
+        retainedRequesterRuntime: manager.listRuntimeKeys().some((key) =>
+          key.includes('"requesterSenderId":"sender-a"'),
+        ),
+      }),
+    );
   });
 });

--- a/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
+++ b/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
@@ -68,6 +68,14 @@ function createManager(createRuntime?: CreateSessionMcpRuntime) {
   return manager;
 }
 
+function requesterParams(requesterSenderId: string) {
+  return {
+    ...params,
+    requesterSenderId,
+    cfg: { mcp: { servers: { scoped: { transport: "streamable-http" as const } } } },
+  };
+}
+
 function holdFactory() {
   const started = createDeferred<SessionMcpRuntime>();
   const released = createDeferred();
@@ -334,5 +342,60 @@ describe("MCP manager creation ownership", () => {
     expect(nextRuntime.dispose).not.toHaveBeenCalled();
     expect(manager.listSessionIds()).toEqual([params.sessionId]);
     expect(manager.resolveSessionId(params.sessionKey)).toBe(params.sessionId);
+  });
+
+  it("does not queue cap eviction behind active requester work", async () => {
+    let nowMs = 100_000;
+    const resolutionStarted = createDeferred();
+    const releaseResolution = createDeferred();
+    releaseHeldWork.push(() => releaseResolution.resolve());
+    const secondRuntimeCreated = createDeferred();
+    let senderACalls = 0;
+    resolverTesting.setMcpConnectionRevalidateMsForTest(1);
+    resolverTesting.setMcpServerConnectionResolversForTest([
+      {
+        serverName: "scoped",
+        resolve: async ({ requesterSenderId }) => {
+          if (requesterSenderId === "sender-a" && ++senderACalls === 2) {
+            resolutionStarted.resolve();
+            await releaseResolution.promise;
+          }
+          return { url: `https://mcp.example.test/${requesterSenderId}` };
+        },
+      },
+    ]);
+    const createRuntime = vi.fn<CreateSessionMcpRuntime>((input) => {
+      const runtime = createRuntimeFixture(input);
+      if (input.requesterScope?.requesterSenderId === "sender-b") {
+        secondRuntimeCreated.resolve();
+      }
+      return runtime;
+    });
+    const manager = createSessionMcpRuntimeManager({
+      createRuntime,
+      now: () => nowMs,
+      enableIdleSweepTimer: false,
+      maxIdleRequesterRuntimesPerSession: 1,
+    });
+    managers.push(manager);
+
+    const first = expectDefined(
+      (await manager.getOrCreateRequesterScoped(requesterParams("sender-a")))?.runtime,
+      "first requester runtime",
+    );
+    nowMs += 2;
+    const refreshed = manager.getOrCreateRequesterScoped(requesterParams("sender-a"));
+    await resolutionStarted.promise;
+    const competing = manager.getOrCreateRequesterScoped(requesterParams("sender-b"));
+    await secondRuntimeCreated.promise;
+    await new Promise<void>(setImmediate);
+    releaseResolution.resolve();
+
+    expect((await refreshed)?.runtime).toBe(first);
+    await competing;
+    expect(first.dispose).not.toHaveBeenCalled();
+    expect(manager.listRuntimeKeys()).toEqual([
+      expect.stringContaining('"requesterSenderId":"sender-a"'),
+    ]);
   });
 });

--- a/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
+++ b/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
@@ -400,14 +400,5 @@ describe("MCP manager creation ownership", () => {
     expect(manager.listRuntimeKeys()).toEqual([
       expect.stringContaining('"requesterSenderId":"sender-a"'),
     ]);
-    console.log(
-      JSON.stringify({
-        claim: "competing requester capacity eviction",
-        firstRuntimeDisposed: first.dispose.mock.calls.length > 0,
-        retainedRequesterRuntime: manager.listRuntimeKeys().some((key) =>
-          key.includes('"requesterSenderId":"sender-a"'),
-        ),
-      }),
-    );
   });
 });

--- a/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
+++ b/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
@@ -388,7 +388,9 @@ describe("MCP manager creation ownership", () => {
     await resolutionStarted.promise;
     const competing = manager.getOrCreateRequesterScoped(requesterParams("sender-b"));
     await secondRuntimeCreated.promise;
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     releaseResolution.resolve();
 
     expect((await refreshed)?.runtime).toBe(first);

--- a/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
+++ b/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
@@ -106,6 +106,7 @@ afterEach(async () => {
   }
   await Promise.all(managers.splice(0).map((manager) => manager.disposeAll()));
   resolverTesting.setMcpServerConnectionResolversForTest();
+  resolverTesting.setMcpConnectionRevalidateMsForTest();
 });
 
 describe("MCP manager creation ownership", () => {

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -16,9 +16,13 @@ import {
   makeTempDir,
   useAutoCleanupTempDirTracker,
 } from "../../test/helpers/temp-dir.js";
+import { materializeRequesterScopedMcpToolsForHarnessRun } from "../plugin-sdk/agent-harness-runtime.js";
 import { createCombinedSessionMcpRuntime } from "./agent-bundle-mcp-combined.js";
-import { materializeRequesterScopedMcpToolsForHarnessRunCore } from "./agent-bundle-mcp-harness.js";
-import { completeDeferredSessionMcpRuntimeRetirement } from "./agent-bundle-mcp-manager-api.js";
+import {
+  completeDeferredSessionMcpRuntimeRetirement,
+  getOrCreateRequesterScopedMcpRuntime,
+  getSessionMcpRuntimeManagerForTesting,
+} from "./agent-bundle-mcp-manager-api.js";
 import { runWithSessionMcpRequestSignal } from "./agent-bundle-mcp-request-context.js";
 import {
   createBundleMcpJsonSchemaValidator,
@@ -137,9 +141,12 @@ async function startRequesterScopedMcpProofServer(): Promise<{
   };
 }
 
-function readMcpText(result: CallToolResult, label: string): string {
+function readMcpText(
+  result: { content: ReadonlyArray<{ type: string; text?: string }> },
+  label: string,
+): string {
   const content = expectDefined(result.content[0], label);
-  if (content.type !== "text") {
+  if (content.type !== "text" || typeof content.text !== "string") {
     throw new Error(`${label} did not contain text`);
   }
   return content.text;
@@ -3448,6 +3455,8 @@ process.on("SIGINT", shutdown);`,
   it("keeps a real requester-scoped MCP transport alive during an idle sweep", async () => {
     const proof = await startRequesterScopedMcpProofServer();
     const resolverTesting = await import("./mcp-connection-resolver.js");
+    let firstTools: Awaited<ReturnType<typeof materializeRequesterScopedMcpToolsForHarnessRun>>;
+    let secondTools: Awaited<ReturnType<typeof materializeRequesterScopedMcpToolsForHarnessRun>>;
     let nowMs = 100_000;
     const clock = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
     let resolveCount = 0;
@@ -3470,10 +3479,6 @@ process.on("SIGINT", shutdown);`,
       },
     ]);
     resolverTesting.testing.setMcpConnectionRevalidateMsForTest(1);
-    const manager = testing.createSessionMcpRuntimeManager({
-      now: () => nowMs,
-      enableIdleSweepTimer: false,
-    });
     const declaredServer = {
       transport: "streamable-http" as const,
       url: "https://placeholder.invalid/mcp",
@@ -3487,32 +3492,42 @@ process.on("SIGINT", shutdown);`,
     );
 
     try {
-      const first = await manager.getOrCreateRequesterScoped(params);
-      const firstRuntime = expectDefined(first?.runtime, "first requester runtime");
+      firstTools = expectDefined(
+        await materializeRequesterScopedMcpToolsForHarnessRun(params),
+        "first requester tools",
+      );
+      const firstRuntime = expectDefined(
+        (await getOrCreateRequesterScopedMcpRuntime(params))?.runtime,
+        "first requester runtime",
+      );
+      const firstTool = expectDefined(firstTools.tools[0], "first requester tool");
       const firstSessionId = readMcpText(
-        await firstRuntime.callTool("real-requester", "requester_probe", {}),
+        await firstTool.execute("first-requester-call", {}),
         "first MCP result",
       );
+      await firstTools.dispose();
+      firstTools = undefined;
 
       nowMs += 2;
-      const secondRequest = manager.getOrCreateRequesterScoped(params);
+      const secondRequest = materializeRequesterScopedMcpToolsForHarnessRun(params);
       await resolutionStarted.promise;
 
+      const manager = getSessionMcpRuntimeManagerForTesting();
       const idleTtlMs = 10 * 60 * 1000;
       nowMs += idleTtlMs;
       expect(await manager.sweepIdleRuntimes()).toBe(0);
       expect(manager.listRuntimeKeys()).toHaveLength(1);
 
       releaseResolution.resolve();
-      const second = await secondRequest;
-      expect(second?.runtime).toBe(firstRuntime);
+      secondTools = expectDefined(await secondRequest, "second requester tools");
+      expect((await getOrCreateRequesterScopedMcpRuntime(params))?.runtime).toBe(firstRuntime);
+      const secondTool = expectDefined(secondTools.tools[0], "second requester tool");
       expect(
-        readMcpText(
-          await firstRuntime.callTool("real-requester", "requester_probe", {}),
-          "second MCP result",
-        ),
+        readMcpText(await secondTool.execute("second-requester-call", {}), "second MCP result"),
       ).toBe(firstSessionId);
       expect(proof.session.current).toBe(firstSessionId);
+      await secondTools.dispose();
+      secondTools = undefined;
 
       nowMs += idleTtlMs;
       expect(await manager.sweepIdleRuntimes()).toBe(1);
@@ -3520,7 +3535,8 @@ process.on("SIGINT", shutdown);`,
       expect(proof.session.closed).toBe(firstSessionId);
     } finally {
       releaseResolution.resolve();
-      await manager.disposeAll();
+      await Promise.allSettled([firstTools?.dispose(), secondTools?.dispose()]);
+      await testing.resetSessionMcpRuntimeManager();
       clock.mockRestore();
       await proof.close();
     }
@@ -5356,7 +5372,7 @@ describe("requester-scoped MCP connection resolution", () => {
       };
 
       try {
-        const first = await materializeRequesterScopedMcpToolsForHarnessRunCore({
+        const first = await materializeRequesterScopedMcpToolsForHarnessRun({
           sessionId: "session-harness-removal",
           workspaceDir: "/workspace",
           cfg: scopedConfig as never,
@@ -5365,7 +5381,7 @@ describe("requester-scoped MCP connection resolution", () => {
         expect(first?.advertisedTools.map((tool) => tool.name)).toEqual(["user-mail__inbox"]);
         await first?.dispose();
 
-        const afterRemoval = await materializeRequesterScopedMcpToolsForHarnessRunCore({
+        const afterRemoval = await materializeRequesterScopedMcpToolsForHarnessRun({
           sessionId: "session-harness-removal",
           workspaceDir: "/workspace",
           cfg: staticConfig as never,

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -3455,6 +3455,7 @@ process.on("SIGINT", shutdown);`,
     let firstTools: Awaited<ReturnType<typeof materializeRequesterScopedMcpToolsForHarnessRun>>;
     let secondTools: Awaited<ReturnType<typeof materializeRequesterScopedMcpToolsForHarnessRun>>;
     let nowMs = 100_000;
+    const clock = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
     let resolveCount = 0;
     const releaseResolution = createDeferred();
     const resolutionStarted = createDeferred();
@@ -3546,6 +3547,7 @@ process.on("SIGINT", shutdown);`,
       } else {
         delete singletonStore[SESSION_MCP_RUNTIME_MANAGER_KEY];
       }
+      clock.mockRestore();
       await proof.close();
     }
   });

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -10,7 +10,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import type { CallToolResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { withTestTimeout } from "../../test/helpers/promise.js";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import {
   cleanupTempDirs,
   makeTempDir,
@@ -85,24 +85,24 @@ const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
 
 async function startRequesterScopedMcpProofServer(): Promise<{
   url: string;
-  sessionId: () => string | undefined;
-  initializeCount: () => number;
+  session: { current?: string; closed?: string };
   close: () => Promise<void>;
 }> {
   const server = new McpServer({ name: "openclaw-requester-proof", version: "1.0.0" });
-  let sessionId: string | undefined;
-  let initializeCount = 0;
+  const session: { current?: string; closed?: string } = {};
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: randomUUID,
     onsessioninitialized(nextSessionId) {
-      sessionId = nextSessionId;
-      initializeCount += 1;
+      session.current = nextSessionId;
+    },
+    onsessionclosed(nextSessionId) {
+      session.closed = nextSessionId;
     },
   });
   server.registerTool(
     "requester_probe",
     { description: "Return the live requester-scoped MCP transport identity" },
-    async () => ({ content: [{ type: "text", text: JSON.stringify({ sessionId }) }] }),
+    async () => ({ content: [{ type: "text", text: session.current ?? "missing-session" }] }),
   );
   await server.connect(transport);
   const httpServer = http.createServer((request, response) => {
@@ -126,15 +126,23 @@ async function startRequesterScopedMcpProofServer(): Promise<{
   }
   return {
     url: `http://127.0.0.1:${address.port}/mcp`,
-    sessionId: () => sessionId,
-    initializeCount: () => initializeCount,
+    session,
     close: async () => {
       await server.close();
+      httpServer.closeAllConnections();
       await new Promise<void>((resolve, reject) => {
         httpServer.close((error) => (error ? reject(error) : resolve()));
       });
     },
   };
+}
+
+function readMcpText(result: CallToolResult, label: string): string {
+  const content = expectDefined(result.content[0], label);
+  if (content.type !== "text") {
+    throw new Error(`${label} did not contain text`);
+  }
+  return content.text;
 }
 
 async function writeListToolsMcpServer(params: {
@@ -3437,94 +3445,22 @@ process.on("SIGINT", shutdown);`,
     await manager.disposeAll();
   });
 
-  it("does not evict a requester runtime while its resolution chain is active", async () => {
-    let nowMs = 100_000;
-    const clock = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
-    const resolverTesting = await import("./mcp-connection-resolver.js");
-    let resolveRequester: (() => void) | undefined;
-    let requesterResolutionStarted: (() => void) | undefined;
-    const requesterStarted = new Promise<void>((resolve) => {
-      requesterResolutionStarted = resolve;
-    });
-    const releaseRequester = new Promise<void>((resolve) => {
-      resolveRequester = resolve;
-    });
-    let resolveCount = 0;
-    const disposed: string[] = [];
-    resolverTesting.testing.setMcpServerConnectionResolversForTest([
-      {
-        serverName: "user-mail",
-        resolve: async () => {
-          resolveCount += 1;
-          if (resolveCount === 2) {
-            requesterResolutionStarted?.();
-            await releaseRequester;
-          }
-          return { url: "https://mcp.example.test/user" };
-        },
-      },
-    ]);
-    resolverTesting.testing.setMcpConnectionRevalidateMsForTest(1);
-    const createRuntime: RuntimeFactory = (params) => ({
-      ...makeManagedRuntime(params),
-      dispose: async () => {
-        disposed.push(params.sessionId);
-      },
-    });
-    const manager = testing.createSessionMcpRuntimeManager({
-      createRuntime,
-      now: () => nowMs,
-      enableIdleSweepTimer: false,
-    });
-    const params = makeRequesterParams(
-      "session-deferred-sweep-race",
-      { mcp: { servers: { "user-mail": { transport: "streamable-http" } } } },
-      "sender-a",
-    );
-
-    try {
-      const initial = await manager.getOrCreateRequesterScoped(params);
-      expect(initial?.runtime).toBeDefined();
-
-      nowMs += 2;
-      const requesterRun = manager.getOrCreateRequesterScoped(params);
-      await requesterStarted;
-
-      nowMs += 10 * 60 * 1000;
-      expect(await manager.sweepIdleRuntimes()).toBe(0);
-      expect(disposed).toEqual([]);
-      expect(manager.listRuntimeKeys()).toHaveLength(1);
-
-      resolveRequester?.();
-      await expect(requesterRun).resolves.toMatchObject({ runtime: initial?.runtime });
-      expect(manager.listRuntimeKeys()).toHaveLength(1);
-    } finally {
-      resolveRequester?.();
-      clock.mockRestore();
-    }
-  });
-
   it("keeps a real requester-scoped MCP transport alive during an idle sweep", async () => {
     const proof = await startRequesterScopedMcpProofServer();
     const resolverTesting = await import("./mcp-connection-resolver.js");
-    let nowMs = Date.now();
+    let nowMs = 100_000;
+    const clock = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
     let resolveCount = 0;
-    let releaseResolver: (() => void) | undefined;
-    let requesterResolutionStarted: (() => void) | undefined;
-    const releaseResolution = new Promise<void>((resolve) => {
-      releaseResolver = resolve;
-    });
-    const resolutionStarted = new Promise<void>((resolve) => {
-      requesterResolutionStarted = resolve;
-    });
+    const releaseResolution = createDeferred();
+    const resolutionStarted = createDeferred();
     resolverTesting.testing.setMcpServerConnectionResolversForTest([
       {
         serverName: "real-requester",
         resolve: async () => {
           resolveCount += 1;
           if (resolveCount === 2) {
-            requesterResolutionStarted?.();
-            await releaseResolution;
+            resolutionStarted.resolve();
+            await releaseResolution.promise;
           }
           return {
             url: proof.url,
@@ -3538,17 +3474,14 @@ process.on("SIGINT", shutdown);`,
       now: () => nowMs,
       enableIdleSweepTimer: false,
     });
+    const declaredServer = {
+      transport: "streamable-http" as const,
+      url: "https://placeholder.invalid/mcp",
+    };
     const params = makeRequesterParams(
       "session-real-requester-sweep",
       {
-        mcp: {
-          servers: {
-            "real-requester": {
-              transport: "streamable-http",
-              url: "https://placeholder.invalid/mcp",
-            },
-          },
-        },
+        mcp: { servers: { "real-requester": declaredServer } },
       },
       "proof-requester",
     );
@@ -3556,47 +3489,39 @@ process.on("SIGINT", shutdown);`,
     try {
       const first = await manager.getOrCreateRequesterScoped(params);
       const firstRuntime = expectDefined(first?.runtime, "first requester runtime");
-      const firstResult = await firstRuntime.callTool("real-requester", "requester_probe", {});
-      const firstContent = expectDefined(firstResult.content[0], "first MCP result");
-      if (firstContent.type !== "text") {
-        throw new Error("first MCP result did not contain text");
-      }
-      const firstSessionId = JSON.parse(firstContent.text).sessionId;
+      const firstSessionId = readMcpText(
+        await firstRuntime.callTool("real-requester", "requester_probe", {}),
+        "first MCP result",
+      );
 
       nowMs += 2;
       const secondRequest = manager.getOrCreateRequesterScoped(params);
-      await resolutionStarted;
+      await resolutionStarted.promise;
 
-      nowMs += 10 * 60 * 1000;
-      const evictedWhileResolving = await manager.sweepIdleRuntimes();
-      expect(evictedWhileResolving).toBe(0);
+      const idleTtlMs = 10 * 60 * 1000;
+      nowMs += idleTtlMs;
+      expect(await manager.sweepIdleRuntimes()).toBe(0);
       expect(manager.listRuntimeKeys()).toHaveLength(1);
 
-      releaseResolver?.();
+      releaseResolution.resolve();
       const second = await secondRequest;
       expect(second?.runtime).toBe(firstRuntime);
-      const secondResult = await firstRuntime.callTool("real-requester", "requester_probe", {});
-      const secondContent = expectDefined(secondResult.content[0], "second MCP result");
-      if (secondContent.type !== "text") {
-        throw new Error("second MCP result did not contain text");
-      }
-      const secondSessionId = JSON.parse(secondContent.text).sessionId;
-      expect(secondSessionId).toBe(firstSessionId);
-      expect(proof.initializeCount()).toBe(1);
-      console.log(
-        JSON.stringify({
-          claim: "real requester-scoped MCP transport survives idle sweep during resolution",
-          evictedWhileResolving,
-          runtimeReused: true,
-          mcpSessionReused: true,
-          initializeCount: proof.initializeCount(),
-        }),
-      );
+      expect(
+        readMcpText(
+          await firstRuntime.callTool("real-requester", "requester_probe", {}),
+          "second MCP result",
+        ),
+      ).toBe(firstSessionId);
+      expect(proof.session.current).toBe(firstSessionId);
+
+      nowMs += idleTtlMs;
+      expect(await manager.sweepIdleRuntimes()).toBe(1);
+      expect(manager.listRuntimeKeys()).toEqual([]);
+      expect(proof.session.closed).toBe(firstSessionId);
     } finally {
-      releaseResolver?.();
+      releaseResolution.resolve();
       await manager.disposeAll();
-      resolverTesting.testing.setMcpServerConnectionResolversForTest();
-      resolverTesting.testing.setMcpConnectionRevalidateMsForTest();
+      clock.mockRestore();
       await proof.close();
     }
   });

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -18,10 +18,7 @@ import {
   useAutoCleanupTempDirTracker,
 } from "../../test/helpers/temp-dir.js";
 import { createCombinedSessionMcpRuntime } from "./agent-bundle-mcp-combined.js";
-import {
-  completeDeferredSessionMcpRuntimeRetirement,
-  getOrCreateRequesterScopedMcpRuntime,
-} from "./agent-bundle-mcp-manager-api.js";
+import { completeDeferredSessionMcpRuntimeRetirement } from "./agent-bundle-mcp-manager-api.js";
 import { runWithSessionMcpRequestSignal } from "./agent-bundle-mcp-request-context.js";
 import { SESSION_MCP_RUNTIME_MANAGER_KEY } from "./agent-bundle-mcp-runtime-shared.js";
 import {
@@ -3503,8 +3500,9 @@ process.on("SIGINT", shutdown);`,
         await materializeRequesterScopedMcpToolsForHarnessRun(params),
         "first requester tools",
       );
+      const runtimeKey = expectDefined(manager.listRuntimeKeys()[0], "first requester runtime key");
       const firstRuntime = expectDefined(
-        (await getOrCreateRequesterScopedMcpRuntime(params))?.runtime,
+        manager.peekSession({ sessionId: runtimeKey }),
         "first requester runtime",
       );
       const firstTool = expectDefined(firstTools.tools[0], "first requester tool");
@@ -3526,7 +3524,7 @@ process.on("SIGINT", shutdown);`,
 
       releaseResolution.resolve();
       secondTools = expectDefined(await secondRequest, "second requester tools");
-      expect((await getOrCreateRequesterScopedMcpRuntime(params))?.runtime).toBe(firstRuntime);
+      expect(manager.peekSession({ sessionId: runtimeKey })).toBe(firstRuntime);
       const secondTool = expectDefined(secondTools.tools[0], "second requester tool");
       expect(
         readMcpText(await secondTool.execute("second-requester-call", {}), "second MCP result"),

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -9,6 +9,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { CallToolResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import { expectDefined } from "@openclaw/normalization-core";
+import { materializeRequesterScopedMcpToolsForHarnessRun } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import {
@@ -16,7 +17,6 @@ import {
   makeTempDir,
   useAutoCleanupTempDirTracker,
 } from "../../test/helpers/temp-dir.js";
-import { materializeRequesterScopedMcpToolsForHarnessRun } from "../plugin-sdk/agent-harness-runtime.js";
 import { createCombinedSessionMcpRuntime } from "./agent-bundle-mcp-combined.js";
 import {
   completeDeferredSessionMcpRuntimeRetirement,

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -21,9 +21,9 @@ import { createCombinedSessionMcpRuntime } from "./agent-bundle-mcp-combined.js"
 import {
   completeDeferredSessionMcpRuntimeRetirement,
   getOrCreateRequesterScopedMcpRuntime,
-  getSessionMcpRuntimeManagerForTesting,
 } from "./agent-bundle-mcp-manager-api.js";
 import { runWithSessionMcpRequestSignal } from "./agent-bundle-mcp-request-context.js";
+import { SESSION_MCP_RUNTIME_MANAGER_KEY } from "./agent-bundle-mcp-runtime-shared.js";
 import {
   createBundleMcpJsonSchemaValidator,
   createSessionMcpRuntime,
@@ -3458,7 +3458,6 @@ process.on("SIGINT", shutdown);`,
     let firstTools: Awaited<ReturnType<typeof materializeRequesterScopedMcpToolsForHarnessRun>>;
     let secondTools: Awaited<ReturnType<typeof materializeRequesterScopedMcpToolsForHarnessRun>>;
     let nowMs = 100_000;
-    const clock = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
     let resolveCount = 0;
     const releaseResolution = createDeferred();
     const resolutionStarted = createDeferred();
@@ -3490,6 +3489,14 @@ process.on("SIGINT", shutdown);`,
       },
       "proof-requester",
     );
+    const singletonStore = globalThis as Record<PropertyKey, unknown>;
+    const hadRuntimeManager = Object.hasOwn(singletonStore, SESSION_MCP_RUNTIME_MANAGER_KEY);
+    const previousRuntimeManager = singletonStore[SESSION_MCP_RUNTIME_MANAGER_KEY];
+    const manager = testing.createSessionMcpRuntimeManager({
+      now: () => nowMs,
+      enableIdleSweepTimer: false,
+    });
+    singletonStore[SESSION_MCP_RUNTIME_MANAGER_KEY] = manager;
 
     try {
       firstTools = expectDefined(
@@ -3512,7 +3519,6 @@ process.on("SIGINT", shutdown);`,
       const secondRequest = materializeRequesterScopedMcpToolsForHarnessRun(params);
       await resolutionStarted.promise;
 
-      const manager = getSessionMcpRuntimeManagerForTesting();
       const idleTtlMs = 10 * 60 * 1000;
       nowMs += idleTtlMs;
       expect(await manager.sweepIdleRuntimes()).toBe(0);
@@ -3537,7 +3543,11 @@ process.on("SIGINT", shutdown);`,
       releaseResolution.resolve();
       await Promise.allSettled([firstTools?.dispose(), secondTools?.dispose()]);
       await testing.resetSessionMcpRuntimeManager();
-      clock.mockRestore();
+      if (hadRuntimeManager) {
+        singletonStore[SESSION_MCP_RUNTIME_MANAGER_KEY] = previousRuntimeManager;
+      } else {
+        delete singletonStore[SESSION_MCP_RUNTIME_MANAGER_KEY];
+      }
       await proof.close();
     }
   });

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -3515,29 +3515,17 @@ process.on("SIGINT", shutdown);`,
       const manager = getSessionMcpRuntimeManagerForTesting();
       const idleTtlMs = 10 * 60 * 1000;
       nowMs += idleTtlMs;
-      const evictedWhileResolving = await manager.sweepIdleRuntimes();
-      expect(evictedWhileResolving).toBe(0);
+      expect(await manager.sweepIdleRuntimes()).toBe(0);
       expect(manager.listRuntimeKeys()).toHaveLength(1);
 
       releaseResolution.resolve();
       secondTools = expectDefined(await secondRequest, "second requester tools");
       expect((await getOrCreateRequesterScopedMcpRuntime(params))?.runtime).toBe(firstRuntime);
       const secondTool = expectDefined(secondTools.tools[0], "second requester tool");
-      const secondSessionId = readMcpText(
-        await secondTool.execute("second-requester-call", {}),
-        "second MCP result",
-      );
-      expect(secondSessionId).toBe(firstSessionId);
+      expect(
+        readMcpText(await secondTool.execute("second-requester-call", {}), "second MCP result"),
+      ).toBe(firstSessionId);
       expect(proof.session.current).toBe(firstSessionId);
-      console.log(
-        JSON.stringify({
-          claim: "real requester-scoped MCP transport survives idle sweep during resolution",
-          evictedWhileResolving,
-          runtimeReused:
-            (await getOrCreateRequesterScopedMcpRuntime(params))?.runtime === firstRuntime,
-          mcpSessionReused: secondSessionId === firstSessionId,
-        }),
-      );
       await secondTools.dispose();
       secondTools = undefined;
 

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -3515,17 +3515,28 @@ process.on("SIGINT", shutdown);`,
       const manager = getSessionMcpRuntimeManagerForTesting();
       const idleTtlMs = 10 * 60 * 1000;
       nowMs += idleTtlMs;
-      expect(await manager.sweepIdleRuntimes()).toBe(0);
+      const evictedWhileResolving = await manager.sweepIdleRuntimes();
+      expect(evictedWhileResolving).toBe(0);
       expect(manager.listRuntimeKeys()).toHaveLength(1);
 
       releaseResolution.resolve();
       secondTools = expectDefined(await secondRequest, "second requester tools");
       expect((await getOrCreateRequesterScopedMcpRuntime(params))?.runtime).toBe(firstRuntime);
       const secondTool = expectDefined(secondTools.tools[0], "second requester tool");
-      expect(
-        readMcpText(await secondTool.execute("second-requester-call", {}), "second MCP result"),
-      ).toBe(firstSessionId);
+      const secondSessionId = readMcpText(
+        await secondTool.execute("second-requester-call", {}),
+        "second MCP result",
+      );
+      expect(secondSessionId).toBe(firstSessionId);
       expect(proof.session.current).toBe(firstSessionId);
+      console.log(
+        JSON.stringify({
+          claim: "real requester-scoped MCP transport survives idle sweep during resolution",
+          evictedWhileResolving,
+          runtimeReused: (await getOrCreateRequesterScopedMcpRuntime(params))?.runtime === firstRuntime,
+          mcpSessionReused: secondSessionId === firstSessionId,
+        }),
+      );
       await secondTools.dispose();
       secondTools = undefined;
 

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -3533,7 +3533,8 @@ process.on("SIGINT", shutdown);`,
         JSON.stringify({
           claim: "real requester-scoped MCP transport survives idle sweep during resolution",
           evictedWhileResolving,
-          runtimeReused: (await getOrCreateRequesterScopedMcpRuntime(params))?.runtime === firstRuntime,
+          runtimeReused:
+            (await getOrCreateRequesterScopedMcpRuntime(params))?.runtime === firstRuntime,
           mcpSessionReused: secondSessionId === firstSessionId,
         }),
       );

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -3380,6 +3380,73 @@ process.on("SIGINT", shutdown);`,
     await manager.disposeAll();
   });
 
+  it("does not evict a requester runtime while its resolution chain is active", async () => {
+    let nowMs = 100_000;
+    const clock = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    const resolverTesting = await import("./mcp-connection-resolver.js");
+    let resolveRequester: (() => void) | undefined;
+    let requesterResolutionStarted: (() => void) | undefined;
+    const requesterStarted = new Promise<void>((resolve) => {
+      requesterResolutionStarted = resolve;
+    });
+    const releaseRequester = new Promise<void>((resolve) => {
+      resolveRequester = resolve;
+    });
+    let resolveCount = 0;
+    const disposed: string[] = [];
+    resolverTesting.testing.setMcpServerConnectionResolversForTest([
+      {
+        serverName: "user-mail",
+        resolve: async () => {
+          resolveCount += 1;
+          if (resolveCount === 2) {
+            requesterResolutionStarted?.();
+            await releaseRequester;
+          }
+          return { url: "https://mcp.example.test/user" };
+        },
+      },
+    ]);
+    resolverTesting.testing.setMcpConnectionRevalidateMsForTest(1);
+    const createRuntime: RuntimeFactory = (params) => ({
+      ...makeManagedRuntime(params),
+      dispose: async () => {
+        disposed.push(params.sessionId);
+      },
+    });
+    const manager = testing.createSessionMcpRuntimeManager({
+      createRuntime,
+      now: () => nowMs,
+      enableIdleSweepTimer: false,
+    });
+    const params = makeRequesterParams(
+      "session-deferred-sweep-race",
+      { mcp: { servers: { "user-mail": { transport: "streamable-http" } } } },
+      "sender-a",
+    );
+
+    try {
+      const initial = await manager.getOrCreateRequesterScoped(params);
+      expect(initial?.runtime).toBeDefined();
+
+      nowMs += 2;
+      const requesterRun = manager.getOrCreateRequesterScoped(params);
+      await requesterStarted;
+
+      nowMs += 10 * 60 * 1000;
+      expect(await manager.sweepIdleRuntimes()).toBe(0);
+      expect(disposed).toEqual([]);
+      expect(manager.listRuntimeKeys()).toHaveLength(1);
+
+      resolveRequester?.();
+      await expect(requesterRun).resolves.toMatchObject({ runtime: initial?.runtime });
+      expect(manager.listRuntimeKeys()).toHaveLength(1);
+    } finally {
+      resolveRequester?.();
+      clock.mockRestore();
+    }
+  });
+
   it("retires global session runtimes by session key", async () => {
     await getOrCreateSessionMcpRuntime({
       sessionId: "session-retire-key",

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1,9 +1,12 @@
 /** Tests session-scoped MCP runtime catalog, transport, validation, and lifecycle behavior. */
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { CallToolResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -79,6 +82,60 @@ type ConfiguredMcpServer = NonNullable<
 const LIST_TOOLS_SERVER_LOG_TIMEOUT_MS = 2_000;
 const LIST_TOOLS_TEST_DEADLINE_MS = 4_000;
 const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
+
+async function startRequesterScopedMcpProofServer(): Promise<{
+  url: string;
+  sessionId: () => string | undefined;
+  initializeCount: () => number;
+  close: () => Promise<void>;
+}> {
+  const server = new McpServer({ name: "openclaw-requester-proof", version: "1.0.0" });
+  let sessionId: string | undefined;
+  let initializeCount = 0;
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: randomUUID,
+    onsessioninitialized(nextSessionId) {
+      sessionId = nextSessionId;
+      initializeCount += 1;
+    },
+  });
+  server.registerTool(
+    "requester_probe",
+    { description: "Return the live requester-scoped MCP transport identity" },
+    async () => ({ content: [{ type: "text", text: JSON.stringify({ sessionId }) }] }),
+  );
+  await server.connect(transport);
+  const httpServer = http.createServer((request, response) => {
+    if (request.url !== "/mcp" || request.headers.authorization !== "Bearer proof-token") {
+      response.writeHead(404).end();
+      return;
+    }
+    void transport.handleRequest(request, response).catch(() => {
+      if (!response.headersSent) {
+        response.writeHead(500).end();
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(0, "127.0.0.1", resolve);
+  });
+  const address = httpServer.address();
+  if (!address || typeof address === "string") {
+    throw new Error("requester-scoped MCP proof server did not bind a loopback port");
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    sessionId: () => sessionId,
+    initializeCount: () => initializeCount,
+    close: async () => {
+      await server.close();
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
 
 async function writeListToolsMcpServer(params: {
   filePath: string;
@@ -3444,6 +3501,103 @@ process.on("SIGINT", shutdown);`,
     } finally {
       resolveRequester?.();
       clock.mockRestore();
+    }
+  });
+
+  it("keeps a real requester-scoped MCP transport alive during an idle sweep", async () => {
+    const proof = await startRequesterScopedMcpProofServer();
+    const resolverTesting = await import("./mcp-connection-resolver.js");
+    let nowMs = Date.now();
+    let resolveCount = 0;
+    let releaseResolver: (() => void) | undefined;
+    let requesterResolutionStarted: (() => void) | undefined;
+    const releaseResolution = new Promise<void>((resolve) => {
+      releaseResolver = resolve;
+    });
+    const resolutionStarted = new Promise<void>((resolve) => {
+      requesterResolutionStarted = resolve;
+    });
+    resolverTesting.testing.setMcpServerConnectionResolversForTest([
+      {
+        serverName: "real-requester",
+        resolve: async () => {
+          resolveCount += 1;
+          if (resolveCount === 2) {
+            requesterResolutionStarted?.();
+            await releaseResolution;
+          }
+          return {
+            url: proof.url,
+            headers: { Authorization: "Bearer proof-token" },
+          };
+        },
+      },
+    ]);
+    resolverTesting.testing.setMcpConnectionRevalidateMsForTest(1);
+    const manager = testing.createSessionMcpRuntimeManager({
+      now: () => nowMs,
+      enableIdleSweepTimer: false,
+    });
+    const params = makeRequesterParams(
+      "session-real-requester-sweep",
+      {
+        mcp: {
+          servers: {
+            "real-requester": {
+              transport: "streamable-http",
+              url: "https://placeholder.invalid/mcp",
+            },
+          },
+        },
+      },
+      "proof-requester",
+    );
+
+    try {
+      const first = await manager.getOrCreateRequesterScoped(params);
+      const firstRuntime = expectDefined(first?.runtime, "first requester runtime");
+      const firstResult = await firstRuntime.callTool("real-requester", "requester_probe", {});
+      const firstContent = expectDefined(firstResult.content[0], "first MCP result");
+      if (firstContent.type !== "text") {
+        throw new Error("first MCP result did not contain text");
+      }
+      const firstSessionId = JSON.parse(firstContent.text).sessionId;
+
+      nowMs += 2;
+      const secondRequest = manager.getOrCreateRequesterScoped(params);
+      await resolutionStarted;
+
+      nowMs += 10 * 60 * 1000;
+      const evictedWhileResolving = await manager.sweepIdleRuntimes();
+      expect(evictedWhileResolving).toBe(0);
+      expect(manager.listRuntimeKeys()).toHaveLength(1);
+
+      releaseResolver?.();
+      const second = await secondRequest;
+      expect(second?.runtime).toBe(firstRuntime);
+      const secondResult = await firstRuntime.callTool("real-requester", "requester_probe", {});
+      const secondContent = expectDefined(secondResult.content[0], "second MCP result");
+      if (secondContent.type !== "text") {
+        throw new Error("second MCP result did not contain text");
+      }
+      const secondSessionId = JSON.parse(secondContent.text).sessionId;
+      expect(secondSessionId).toBe(firstSessionId);
+      expect(proof.initializeCount()).toBe(1);
+      console.log(
+        JSON.stringify({
+          claim: "real requester-scoped MCP transport survives idle sweep during resolution",
+          evictedWhileResolving,
+          runtimeReused: true,
+          mcpSessionReused: true,
+          initializeCount: proof.initializeCount(),
+        }),
+      );
+    } finally {
+      releaseResolver?.();
+      await manager.disposeAll();
+      resolverTesting.testing.setMcpServerConnectionResolversForTest();
+      resolverTesting.testing.setMcpConnectionRevalidateMsForTest();
+      await proof.close();
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Requester-scoped MCP resolution can own serialized work for a runtime key while that runtime has no lease. Idle or cap cleanup could dispose the runtime and its transport before the work finished.

## Why This Change Was Made

The lifecycle owner now treats the existing requester work chain as active ownership. Idle cleanup skips that key, and cap cleanup does not queue an eviction behind that work. Required session disposal still drains the same chain.

## User Impact

Requester-scoped MCP transports and sessions now survive resolver work. Normal idle cleanup still removes the runtime after that work drains.

## Evidence

- Current-main loopback reproduction: the production manager returned one idle eviction while requester resolution was held; expected zero.
- Exact candidate loopback proof: the shipped harness runtime retained the same runtime object and MCP session identifier through the protected sweep, then the later idle sweep removed the runtime and closed the session.
- Cap regression: the original PR head disposed the refreshed requester runtime; the repaired head preserved it.
- [Exact-head agent shard](https://github.com/openclaw/openclaw/actions/runs/33675253407/job/100398989009): 89 files and 1,395 tests passed, including the real loopback boundary.
- Formatting and `git diff --check`: passed.
- Exact-head Autoreview P0: clean.

## Proof Boundary

The proof uses the production MCP runtime manager, the pinned MCP SDK 1.30.0 client and server, and a real loopback Streamable HTTP session. It does not claim external MCP service or provider authentication behavior.
