### PR TITLE
fix(release): preserve original attempts in reused validation

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 347792,
-  "reason": "Final automatic update lifecycle ownership and stale hold response fencing measured 347792 B in the canonical isolated production build (+1015 B, 0.29% from the original baseline); fixed 358400 B cap and allowances unchanged",
+  "startupJsGzipBytes": 348433,
+  "reason": "Reconcile merged Control UI changes since the update-lifecycle baseline with CI 33470685955: 348433 B (+641 B, 0.18%); fixed 358400 B cap and existing growth and build-variance allowances retained",
   "updatedAt": "2026-09-01"
 }

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -351,7 +351,12 @@ export function hydrateReusedPlan(plan, evidence) {
       ...child,
       displayTitle: reused.displayTitle,
       result: "success",
-      runAttempt: reused.runAttempt,
+      // Reuse keeps the dispatch origin, so a human rerun still composes earlier jobs.
+      // Verified manifests predating childEvidence only carry the effective attempt.
+      runAttempt:
+        evidence.manifest.childEvidence === undefined
+          ? reused.runAttempt
+          : evidence.manifest.childEvidence[child.key].plannedRunAttempt,
       runId: reused.runId,
       url: reused.url,
       workflowRef: reused.headBranch,

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -2,7 +2,7 @@ import { spawn, spawnSync } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, assert, describe, expect, it } from "vitest";
 import { buildFullReleaseCandidateBinding } from "../../scripts/full-release-candidate-contract.mjs";
 import {
   composeReleaseAttemptJobs,
@@ -18,12 +18,12 @@ import {
   classifyReleaseGhTransportError,
   classifyReleaseSnapshot,
   formatReleaseStateOutcome,
+  hydrateReusedPlan,
   readChild,
   releaseGhRetryDelayMs,
   releaseStateChildEvidence,
   serializeReleaseArtifact,
   selectReleaseStateArtifacts,
-  validateChildBinding,
   validateReleaseExecutionPlanArtifact,
   validateReleaseStateArtifact,
   verifyReleaseStateArtifacts,
@@ -916,35 +916,61 @@ describe("release decision policy", () => {
     });
   });
 
-  it("accepts a monotonically newer attempt for the exact child tuple", () => {
-    const result = validateChildBinding(
-      child("normalCi"),
-      {
-        actor: { login: "github-actions[bot]" },
-        conclusion: "",
-        created_at: "2026-08-21T00:00:00Z",
-        display_title: "normalCi",
-        event: "workflow_dispatch",
-        head_branch: "release-ci/tooling",
-        head_sha: SHA,
-        html_url: "https://example.invalid/runs/101",
-        id: 101,
-        path: ".github/workflows/ci.yml@refs/heads/release-ci/tooling",
-        repository: { full_name: "openclaw/openclaw" },
-        run_attempt: 2,
-        status: "in_progress",
-        updated_at: "2026-08-21T00:01:00Z",
-        triggering_actor: { login: "release-operator" },
-      },
-      {
-        jobs: [],
+  it.each(["fresh", "reused"] as const)(
+    "accepts a human child rerun with retained earlier jobs in a %s plan",
+    async (source) => {
+      const original = child("normalCi");
+      const planned =
+        source === "reused"
+          ? hydrateReusedPlan([original], {
+              children: [
+                {
+                  ...reusedEvidenceChildren()[0],
+                  displayTitle: original.displayTitle,
+                  runAttempt: 2,
+                },
+              ],
+              manifest: { childEvidence: { normalCi: { plannedRunAttempt: 1 } } },
+            })[0]
+          : original;
+      assert(planned, "selected child remains present in the reused plan");
+      const result = await readChild(planned, undefined, undefined, {
+        readRun: async () => ({
+          actor: { login: "github-actions[bot]" },
+          conclusion: "success",
+          display_title: original.displayTitle,
+          event: "workflow_dispatch",
+          head_branch: original.workflowRef,
+          head_sha: SHA,
+          html_url: original.url,
+          id: 101,
+          path: ".github/workflows/ci.yml@refs/heads/release-ci/tooling",
+          repository: { full_name: "openclaw/openclaw" },
+          run_attempt: 2,
+          status: "completed",
+          triggering_actor: { login: "release-operator" },
+        }),
+        readAttemptJobs: async (_runId, attempt) =>
+          attempt === 1
+            ? [
+                { name: "lint", status: "completed", conclusion: "success" },
+                { name: "test", status: "completed", conclusion: "failure" },
+              ]
+            : [{ name: "test", status: "completed", conclusion: "success" }],
+      });
+      expect(result.errors).toEqual([]);
+      expect(result).toMatchObject({
         observedRunAttempts: [1, 2],
-        sha256: "c".repeat(64),
-      },
-    );
-    expect(result.errors).toEqual([]);
-    expect(result).toMatchObject({ plannedRunAttempt: 1, runAttempt: 2 });
-  });
+        plannedRunAttempt: 1,
+        runAttempt: 2,
+        triggeringActor: "release-operator",
+      });
+      expect(result.jobs).toEqual([
+        expect.objectContaining({ name: "lint", acceptedRunAttempt: 1, conclusion: "success" }),
+        expect.objectContaining({ name: "test", acceptedRunAttempt: 2, conclusion: "success" }),
+      ]);
+    },
+  );
 
   it.each([
     "HTTP 503: Server Error",


### PR DESCRIPTION
Changelog-only release validation failed when its successful source validation included a maintainer-triggered CI retry. Reuse replaced the child's original planned attempt with its latest effective attempt, so the provenance check treated that retry as a new, non-bot dispatch and rejected it.

Keep the original planned attempt from the verified source manifest. This preserves both the dispatch identity and successful jobs carried forward from earlier attempts; actor, workflow, SHA, and attempt checks remain intact. Legacy manifests without composite child evidence retain their existing contract.

Validation: the regression reproduces the exact provenance failure before the fix and passes afterward. All 216 release-state tests pass, covering fresh and reused human retries, earlier successful jobs, legacy reuse, and strict evidence validation. The failure was observed in [release validation 33469950542](https://github.com/openclaw/openclaw/actions/runs/33469950542); the underlying [code validation 33465912522](https://github.com/openclaw/openclaw/actions/runs/33465912522) remains successful. This changes release tooling only.

The same CI run exposed a stale Control UI startup baseline after already-merged UI changes: 348433 measured gzip bytes versus the previous 347792-byte baseline. Refresh that generated baseline from the exact CI measurement using the canonical helper. This records 641 bytes of accumulated growth (0.18%) while retaining the fixed 350 KiB ceiling and all growth/variance allowances; no UI runtime changes are included. The frozen release candidate is unchanged.
