### PR TITLE
refactor(scripts): share spawn output coercion

### DIFF
--- a/scripts/format-docs.mts
+++ b/scripts/format-docs.mts
@@ -8,7 +8,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { resolveRepoToolBinPath } from "./lib/local-check-runtime.mts";
 import { repairMintlifyAccordionIndentation } from "./lib/mintlify-accordion.mjs";
-import { outputTail } from "./lib/output-tail.mts";
+import { outputTail, spawnOutputText } from "./lib/output-tail.mts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import { buildCmdExeCommandLine, resolveWindowsCmdExePath } from "./windows-cmd-helpers.mjs";
 const ROOT = resolveRepoRoot(import.meta.url);
@@ -39,16 +39,6 @@ type OxfmtParams = {
 };
 type FormatDocsParams = OxfmtParams & { check?: boolean; root?: string };
 type CommandInvocation = { args: string[]; command: string };
-
-function outputText(value: unknown) {
-  if (typeof value === "string") {
-    return value;
-  }
-  if (Buffer.isBuffer(value)) {
-    return value.toString("utf8");
-  }
-  return "";
-}
 
 function commandFailureMessage(
   label: string,
@@ -99,7 +89,7 @@ export function docsFiles(root = ROOT, deps: FormatDeps = {}) {
       }),
     );
   }
-  return outputText(result.stdout)
+  return spawnOutputText(result.stdout)
     .split("\n")
     .filter(Boolean)
     .filter((relativePath) => (deps.existsSync ?? fs.existsSync)(path.join(root, relativePath)));

--- a/scripts/lib/output-tail.mts
+++ b/scripts/lib/output-tail.mts
@@ -1,6 +1,6 @@
 // Keeps child-process diagnostic tails byte-bounded without splitting UTF-8 characters.
 
-function outputText(value: string | Buffer | null | undefined): string {
+export function spawnOutputText(value: string | Buffer | null | undefined): string {
   if (typeof value === "string") {
     return value;
   }
@@ -19,7 +19,7 @@ function decodeUtf8Tail(buffer: Buffer): string {
 }
 
 export function outputTail(value: string | Buffer | null | undefined, maxBytes: number): string {
-  const text = outputText(value).trim();
+  const text = spawnOutputText(value).trim();
   if (!text) {
     return "";
   }


### PR DESCRIPTION
## What Problem This Solves

The docs formatter duplicated the child-process output coercion already owned by `scripts/lib/output-tail.mts`. The copies could drift on string, Buffer, or empty output handling.

This is part of the maintainer-requested function-duplication cleanup.

## Why This Change Was Made

- Exports the repository-private `spawnOutputText` helper from the existing process-output owner.
- Reuses it from `scripts/format-docs.mts`.
- Deletes the formatter-local duplicate.
- Keeps the import direct: no barrel, public SDK seam, compatibility alias, or new file.

The behavior is unchanged: strings pass through, Buffers decode as UTF-8, other runtime values become an empty string, and only `outputTail` trims and applies the byte bound.

## User Impact

No user-visible behavior change. The docs tooling now has one canonical process-output coercion path.

## Evidence

- Refreshed signed head: `35cef3ec27fe0d8c89c7c2a17db8068ed4844983`.
- The mechanical refresh onto current `main` preserved patch ID `609366e796a389ba0d5d7e9982d2d0fed01bb45f`.
- Open-PR overlap sweep found no other open PR for `spawnOutputText` or `output-tail`.
- Patch-identical focused proof: `node scripts/run-vitest.mjs test/scripts/format-docs.test.ts` passed 8/8.
- Patch-identical docs proof: `pnpm format:docs:check` found 738 files clean.
- Patch-identical direct runtime contract probe covered string whitespace, UTF-8 Buffer decoding, null, undefined, non-output values, and `outputTail` trimming.
- Patch-identical scripts oxlint passed.
- Refreshed-head `git diff --check`, focused oxfmt, signature verification, exact two-file diff, and changed-gate dry-run passed.
- Sol/high autoreview was clean at 0.99 confidence; no rerun was needed because the patch content did not change.
- Exact-head CI run https://github.com/openclaw/openclaw/actions/runs/33474000069 completed green.
- `build-artifacts` measured startup JavaScript at `348,187 B` gzip against the `349,009 B` enforcement limit.
- No new test: direct helper coverage would couple tests to a private refactor; existing formatter and UTF-8 tail behavior coverage remains.
- `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 134821` passed at 05:42:46 UTC. The native gate reused the exact-head hosted proof (`hosted_exact_or_recent_parent`), so no separate Testbox lease was allocated.

## ClawSweeper Rank-up Moves

The durable ClawSweeper review from September 1, 2026 at 05:12 UTC applies to this mechanical refresh under the repository's <12h rule because the patch ID is unchanged.

1. **Resolve merge risk (P1): satisfied.** #134820 landed the repository-wide Control UI baseline correction. The refreshed exact-head build passed at `348,187 B` gzip, below the `349,009 B` enforcement limit.
2. **Complete next step (P2): satisfied.** Exact-head CI is complete and green for `35cef3ec27fe0d8c89c7c2a17db8068ed4844983`.

Production LOC: `+0/-0`  
Tooling LOC: `+4/-14` (net `-10`)  
Tests: `+0/-0`
