### PR TITLE
test(hooks): reuse the Gmail diagnostics module graph

### DIFF
--- a/src/hooks/gmail-setup-utils.test.ts
+++ b/src/hooks/gmail-setup-utils.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SpawnResult } from "../process/exec.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -33,12 +33,12 @@ const noisy = {
 };
 
 beforeEach(() => {
-  vi.resetModules();
   runCommandWithTimeoutMock.mockReset();
 });
 afterEach(() => vi.restoreAllMocks());
 
 async function loadGmailSetupUtils() {
+  vi.resetModules();
   return await import("./gmail-setup-utils.js");
 }
 
@@ -363,20 +363,25 @@ describe("ensureTailscaleEndpoint", () => {
 
 describe("Gmail setup diagnostics and decisions", () => {
   const hasBinaryMock = vi.fn<(bin: string) => boolean>();
+  let configEval: typeof import("../shared/config-eval.js");
+  let utils: typeof import("./gmail-setup-utils.js");
 
-  beforeEach(async () => {
+  beforeAll(async () => {
+    vi.resetModules();
+    configEval = await import("../shared/config-eval.js");
+    utils = await import("./gmail-setup-utils.js");
+  });
+
+  beforeEach(() => {
     // Keep real filesystem probes in the binary-availability cases above.
     hasBinaryMock.mockReset().mockReturnValue(true);
-    vi.spyOn(await import("../shared/config-eval.js"), "hasBinary").mockImplementation(
-      hasBinaryMock,
-    );
+    vi.spyOn(configEval, "hasBinary").mockImplementation(hasBinaryMock);
   });
 
   it.each(["gcloud", "login", "brew", "tailscale status", "tailscale serve"])(
     "%s retains bounded tails from both streams",
     async (boundary) =>
       withEnvAsync({ PATH: "" }, async () => {
-        const utils = await loadGmailSetupUtils();
         runCommandWithTimeoutMock.mockResolvedValue(noisy);
         const run = async () => {
           if (boundary === "login") {
@@ -465,7 +470,7 @@ describe("Gmail setup diagnostics and decisions", () => {
     "retains $reason with code=$code even without output",
     async ({ reason, ...metadata }) =>
       withEnvAsync({ PATH: "" }, async () => {
-        const { runGcloud } = await loadGmailSetupUtils();
+        const { runGcloud } = utils;
         runCommandWithTimeoutMock.mockResolvedValue({ ...success, ...metadata });
         const { message } = await rejection(() => runGcloud(["config", "list"]));
         expect(message).toContain(reason);
@@ -483,7 +488,7 @@ describe("Gmail setup diagnostics and decisions", () => {
   );
 
   it("bounds invalid JSON diagnostics while retaining the parser cause and successful exit metadata", async () => {
-    const { ensureTailscaleEndpoint } = await loadGmailSetupUtils();
+    const { ensureTailscaleEndpoint } = utils;
     runCommandWithTimeoutMock.mockResolvedValue({
       ...noisy,
       code: 0,
@@ -503,7 +508,7 @@ describe("Gmail setup diagnostics and decisions", () => {
 
   it("keeps successful gcloud output untouched", async () =>
     withEnvAsync({ PATH: "" }, async () => {
-      const { runGcloud } = await loadGmailSetupUtils();
+      const { runGcloud } = utils;
       const result = { ...noisy, code: 0 };
       runCommandWithTimeoutMock.mockResolvedValue(result);
       expect(await runGcloud(["config", "list"])).toBe(result);
@@ -514,7 +519,7 @@ describe("Gmail setup diagnostics and decisions", () => {
     { code: 1, stdout: "account@example.com\n", login: true },
   ])("auth list code=$code login=$login", async ({ code, stdout, login }) =>
     withEnvAsync({ PATH: "" }, async () => {
-      const { ensureGcloudAuth } = await loadGmailSetupUtils();
+      const { ensureGcloudAuth } = utils;
       runCommandWithTimeoutMock
         .mockResolvedValueOnce({ ...success, code, stdout })
         .mockResolvedValue(success);
@@ -528,7 +533,7 @@ describe("Gmail setup diagnostics and decisions", () => {
 
   it.each([0, 1])("provisions only according to describe exit code %i", async (code) =>
     withEnvAsync({ PATH: "" }, async () => {
-      const { ensureTopic, ensureSubscription } = await loadGmailSetupUtils();
+      const { ensureTopic, ensureSubscription } = utils;
       runCommandWithTimeoutMock
         .mockResolvedValueOnce({ ...success, code })
         .mockResolvedValue(success);
@@ -567,7 +572,7 @@ describe("Gmail setup diagnostics and decisions", () => {
       expected: "gog still not available after brew install",
     },
   ] as const)("retains dependency guidance: $state", async ({ state, platform, expected }) => {
-    const { ensureDependency } = await loadGmailSetupUtils();
+    const { ensureDependency } = utils;
     hasBinaryMock.mockImplementation(
       (bin: string) =>
         state === "installed" || (state === "post install missing" && bin === "brew"),

--- a/src/hooks/gmail.windows.test.ts
+++ b/src/hooks/gmail.windows.test.ts
@@ -1,6 +1,6 @@
 // Gmail Windows tests cover gog watcher command invocation on Windows.
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { getWindowsInstallRoots } from "../infra/windows-install-roots.js";
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
 
@@ -24,8 +24,6 @@ function expectedTrustedCmdExe(): string {
 }
 
 describe("resolveGogServeInvocation on Windows", () => {
-  beforeEach(() => {});
-
   it("wraps spaced gog .cmd paths in an outer cmd.exe command line", async () => {
     const { resolveGogServeInvocation } = await importGmailWithExecutable(
       "C:\\Program Files\\gog\\gog.cmd",


### PR DESCRIPTION
## What Problem This Solves

The 22 Gmail diagnostics cases rebuild the same module graph despite using stable executable-resolution inputs.

## Why This Change Was Made

Load that group’s owner once and keep its exact config-eval namespace for each restored/reinstalled spy. The nine filesystem, interpreter-cache, inherited-environment and Tailscale cases still load fresh graphs. Per-case process mock resets remain. Remove an empty Windows wrapper setup hook.

## User Impact

Test-only: 21 owner imports/module resets disappear. All 31 setup cases and four integration/Windows sibling cases remain. Production +0/-0; tests +19/-16. No timeouts or assertions are weakened.

## Evidence

35/35 cases pass before and after with identical labels and statuses. Full changed checks and Codex autoreview pass. Original cache-isolation history and installed Vite namespace behavior were inspected. Real local fixture commands remain; no elapsed-time or live Google-service claim.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/hooks/gmail-setup-utils.test.ts src/hooks/gmail-setup.integration.test.ts src/hooks/gmail.windows.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base 84648e8c32b6b729abf2f7732f55095cdf46cae3
```
