### PR TITLE
fix(ci): native Windows Testbox rejects its session SSH key

### DIFF
--- a/.github/workflows/windows-blacksmith-testbox.yml
+++ b/.github/workflows/windows-blacksmith-testbox.yml
@@ -29,6 +29,7 @@ jobs:
         shell: pwsh
     steps:
       - name: Begin Testbox
+        id: begin_testbox
         shell: bash
         env:
           TESTBOX_ID: ${{ inputs.testbox_id }}
@@ -139,6 +140,21 @@ jobs:
           chmod 700 ~/.ssh
           chmod 600 ~/.ssh/authorized_keys
 
+          bash_path="$BASH"
+          [[ "$bash_path" = /* ]] || bash_path="$PWD/$bash_path"
+          printf 'bash_os=%s\nbash_identity=%s\nbash_home=%s\nbash_path=%s\n' \
+            "$(uname -s)" "$(id -un)" "$HOME" "$bash_path"
+          if key_info="$(ssh-keygen -E sha256 -lf "$state/ssh_public_key" 2>/dev/null)"; then
+            awk '$2 ~ /^SHA256:[A-Za-z0-9+\/]+$/ { print "testbox_key_fingerprint=" $2 }' <<<"$key_info"
+          else
+            echo "testbox_key_fingerprint=unavailable"
+          fi
+          if command -v cygpath >/dev/null 2>&1 && installed_key_path="$(cygpath -aw "$HOME/.ssh/authorized_keys" 2>/dev/null)"; then
+            printf 'installed_key_path=%s\n' "$installed_key_path" >> "$GITHUB_OUTPUT"
+          else
+            echo "bash_installed_key_windows_path=unavailable"
+          fi
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -146,13 +162,82 @@ jobs:
           submodules: false
 
       - name: Prepare Windows shell
+        env:
+          BASH_INSTALLED_KEY_PATH: ${{ steps.begin_testbox.outputs.installed_key_path }}
         run: |
           $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $false
           Write-Host "runner=$env:RUNNER_NAME"
           Write-Host "machine=$env:COMPUTERNAME"
+          Write-Host ("windows_identity=" + [Security.Principal.WindowsIdentity]::GetCurrent().Name)
+          Write-Host "windows_userprofile=$env:USERPROFILE"
           Write-Host ("os=" + [System.Environment]::OSVersion.VersionString)
+          Write-Host ("architecture=" + [Runtime.InteropServices.RuntimeInformation]::OSArchitecture)
           Write-Host ("powershell=" + $PSVersionTable.PSVersion.ToString())
-          git --version
+          $gitVersion = & git --version 2>$null
+          if ($LASTEXITCODE -ne 0) { throw "git version unavailable" }
+          Write-Host "git=$gitVersion"
+
+          $service = Get-CimInstance Win32_Service -Filter "Name='sshd'"
+          $sshd = "$env:WINDIR\System32\OpenSSH\sshd.exe"
+          $serviceArguments = $false
+          if ($service) {
+            Write-Host "sshd_service_identity=$($service.StartName) sshd_service_state=$($service.State)"
+            $sshd = $null
+            if ($service.PathName -match '^\s*(?:"([^"]+\.exe)"|(.+?\.exe))\s*(.*)$') {
+              $sshd = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+              $serviceArguments = -not [string]::IsNullOrWhiteSpace($Matches[3])
+            }
+          } else { Write-Host "sshd_service=unavailable" }
+          $sshdAvailable = $sshd -and (Test-Path -LiteralPath $sshd -PathType Leaf)
+          Write-Host "sshd_executable=$sshd available=$sshdAvailable service_arguments_present=$serviceArguments"
+          foreach ($user in @('runner', 'runneradmin')) {
+            $account = Get-CimInstance Win32_UserAccount -Filter "LocalAccount=True AND Name='$user'"
+            if ($account) { Write-Host "account=$user enabled=$(-not $account.Disabled)" }
+            else { Write-Host "account=$user unavailable" }
+            # User-only context; do not invent connection addresses or replay service arguments.
+            if (-not $sshdAvailable -or $serviceArguments) {
+              Write-Host "sshd_config_user=$user unavailable (executable or service arguments)"
+              continue
+            }
+            $effectiveConfig = & $sshd -T -C "user=$user" 2>$null
+            $configExit = $LASTEXITCODE
+            Write-Host "sshd_config_user=$user context=user-only exit=$configExit"
+            if ($configExit -eq 0) {
+              $effectiveConfig | Where-Object {
+                $_ -match '^(port|authorizedkeysfile|pubkeyauthentication|authenticationmethods|allowusers|denyusers|strictmodes)\s'
+              } | ForEach-Object { Write-Host "sshd_config_user=$user $_" }
+            } else { Write-Host "sshd_config_user=$user unavailable" }
+          }
+
+          $keygen = "$env:WINDIR\System32\OpenSSH\ssh-keygen.exe"
+          $keyFiles = @('C:\ProgramData\ssh\administrators_authorized_keys', 'C:\Users\runneradmin\.ssh\authorized_keys', $env:BASH_INSTALLED_KEY_PATH)
+          foreach ($keyFile in ($keyFiles | Select-Object -Unique)) {
+            if (-not $keyFile -or -not (Test-Path -LiteralPath $keyFile -PathType Leaf)) {
+              Write-Host "public_key_file=$keyFile unavailable"
+              continue
+            }
+            Write-Host "public_key_file=$keyFile"
+            if (Test-Path -LiteralPath $keygen -PathType Leaf) {
+              $keyInfo = & $keygen -E sha256 -lf $keyFile 2>$null
+              $keyExit = $LASTEXITCODE
+              Write-Host "fingerprint_exit=$keyExit"
+              if ($keyExit -eq 0) {
+                foreach ($line in $keyInfo) {
+                  if ($line -match '^\d+\s+(SHA256:[A-Za-z0-9+/]+)\s') { Write-Host "fingerprint=$($Matches[1])" }
+                }
+              } else { Write-Host "fingerprint=unavailable" }
+            } else { Write-Host "fingerprint=unavailable (ssh-keygen missing)" }
+            try {
+              $acl = Get-Acl -LiteralPath $keyFile
+              Write-Host "owner_sid=$($acl.GetOwner([Security.Principal.SecurityIdentifier]).Value)"
+              foreach ($rule in $acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier])) {
+                Write-Host "acl_sid=$($rule.IdentityReference.Value) rights=$($rule.FileSystemRights) type=$($rule.AccessControlType) inherited=$($rule.IsInherited)"
+              }
+            } catch { Write-Host "acl=unavailable" }
+          }
+          # A failed diagnostic process must not become the step's implicit exit status.
+          exit 0
 
       - name: Run Testbox
         if: always()

--- a/.github/workflows/windows-blacksmith-testbox.yml
+++ b/.github/workflows/windows-blacksmith-testbox.yml
@@ -70,6 +70,15 @@ jobs:
           fi
           runner_ssh_port="${BLACKSMITH_SSH_PORT:-22}"
 
+          echo "$TESTBOX_ID" > "$state/testbox_id"
+          echo "$installation_model_id" > "$state/installation_model_id"
+          echo "$auth_token" > "$state/auth_token"
+          echo "$api_url" > "$state/api_url"
+          echo "$runner_host" > "$state/runner_host"
+          echo "$runner_ssh_port" > "$state/runner_ssh_port"
+          echo "$GITHUB_WORKSPACE" > "$state/working_directory"
+          echo "$GITHUB_RUN_ID" > "$state/adopted_run_id"
+
           hydrating_body="$RUNNER_TEMP/testbox-hydrating.json"
           hydrating_response="$RUNNER_TEMP/testbox-hydrating.response"
           jq -n \
@@ -104,20 +113,10 @@ jobs:
           echo "phone_home_hydrating_curl=${hydrating_curl_status}"
           echo "phone_home_hydrating_http=${hydrating_http_code}"
           if (( hydrating_curl_status != 0 )) || [[ ! "$hydrating_http_code" =~ ^2 ]]; then
-            echo "Blacksmith phone-home hydrating failed; response body:" >&2
-            cat "$hydrating_response" >&2 || true
+            echo "Blacksmith phone-home hydrating failed." >&2
             exit 1
           fi
           response="$(cat "$hydrating_response")"
-
-          echo "$TESTBOX_ID" > "$state/testbox_id"
-          echo "$installation_model_id" > "$state/installation_model_id"
-          echo "$auth_token" > "$state/auth_token"
-          echo "$api_url" > "$state/api_url"
-          echo "$runner_host" > "$state/runner_host"
-          echo "$runner_ssh_port" > "$state/runner_ssh_port"
-          echo "$GITHUB_WORKSPACE" > "$state/working_directory"
-          echo "$GITHUB_RUN_ID" > "$state/adopted_run_id"
 
           if [ -n "$response" ] && echo "$response" | jq -e . >/dev/null 2>&1; then
             echo "$response" | jq -r '.ssh_public_key // empty' > "$state/ssh_public_key"
@@ -132,28 +131,12 @@ jobs:
 
           ssh_public_key="$(cat "$state/ssh_public_key" 2>/dev/null || true)"
           if [ -z "$ssh_public_key" ]; then
-            echo "Blacksmith phone-home did not return an SSH public key; testbox cannot accept CLI connections." >&2
+            echo "Blacksmith phone-home did not return an SSH public key; testbox cannot accept native SSH connections." >&2
             exit 1
           fi
-          mkdir -p ~/.ssh
-          printf '%s\n' "$ssh_public_key" >> ~/.ssh/authorized_keys
-          chmod 700 ~/.ssh
-          chmod 600 ~/.ssh/authorized_keys
-
-          bash_path="$BASH"
-          [[ "$bash_path" = /* ]] || bash_path="$PWD/$bash_path"
-          printf 'bash_os=%s\nbash_identity=%s\nbash_home=%s\nbash_path=%s\n' \
-            "$(uname -s)" "$(id -un)" "$HOME" "$bash_path"
-          if key_info="$(ssh-keygen -E sha256 -lf "$state/ssh_public_key" 2>/dev/null)"; then
-            awk '$2 ~ /^SHA256:[A-Za-z0-9+\/]+$/ { print "testbox_key_fingerprint=" $2 }' <<<"$key_info"
-          else
-            echo "testbox_key_fingerprint=unavailable"
-          fi
-          if command -v cygpath >/dev/null 2>&1 && installed_key_path="$(cygpath -aw "$HOME/.ssh/authorized_keys" 2>/dev/null)"; then
-            printf 'installed_key_path=%s\n' "$installed_key_path" >> "$GITHUB_OUTPUT"
-          else
-            echo "bash_installed_key_windows_path=unavailable"
-          fi
+          public_key_path="$(cygpath -aw "$state/ssh_public_key")"
+          printf 'public_key_path=%s\n' "$public_key_path" >> "$GITHUB_OUTPUT"
+          printf 'bash_os=%s\nbash_user=%s\n' "$(uname -s)" "$(id -un)"
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -161,87 +144,72 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      - name: Prepare Windows shell
+      - name: Prepare Windows SSH
+        id: prepare_windows
         env:
-          BASH_INSTALLED_KEY_PATH: ${{ steps.begin_testbox.outputs.installed_key_path }}
+          TESTBOX_PUBLIC_KEY_PATH: ${{ steps.begin_testbox.outputs.public_key_path }}
         run: |
           $ErrorActionPreference = "Stop"
           $PSNativeCommandUseErrorActionPreference = $false
-          Write-Host "runner=$env:RUNNER_NAME"
-          Write-Host "machine=$env:COMPUTERNAME"
-          Write-Host ("windows_identity=" + [Security.Principal.WindowsIdentity]::GetCurrent().Name)
-          Write-Host "windows_userprofile=$env:USERPROFILE"
-          Write-Host ("os=" + [System.Environment]::OSVersion.VersionString)
+          $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+          $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+          if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+            throw "Native Windows SSH preparation requires an elevated administrator."
+          }
+          $nativeUser = [Environment]::UserName
+          Write-Host "windows_user=$nativeUser"
+          Write-Host ("os=" + [Environment]::OSVersion.VersionString)
           Write-Host ("architecture=" + [Runtime.InteropServices.RuntimeInformation]::OSArchitecture)
           Write-Host ("powershell=" + $PSVersionTable.PSVersion.ToString())
-          $gitVersion = & git --version 2>$null
-          if ($LASTEXITCODE -ne 0) { throw "git version unavailable" }
-          Write-Host "git=$gitVersion"
 
-          $service = Get-CimInstance Win32_Service -Filter "Name='sshd'"
+          # Only the stock native OpenSSH service and administrator key-file contract are supported.
           $sshd = "$env:WINDIR\System32\OpenSSH\sshd.exe"
-          $serviceArguments = $false
-          if ($service) {
-            Write-Host "sshd_service_identity=$($service.StartName) sshd_service_state=$($service.State)"
-            $sshd = $null
-            if ($service.PathName -match '^\s*(?:"([^"]+\.exe)"|(.+?\.exe))\s*(.*)$') {
-              $sshd = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
-              $serviceArguments = -not [string]::IsNullOrWhiteSpace($Matches[3])
-            }
-          } else { Write-Host "sshd_service=unavailable" }
-          $sshdAvailable = $sshd -and (Test-Path -LiteralPath $sshd -PathType Leaf)
-          Write-Host "sshd_executable=$sshd available=$sshdAvailable service_arguments_present=$serviceArguments"
-          foreach ($user in @('runner', 'runneradmin')) {
-            $account = Get-CimInstance Win32_UserAccount -Filter "LocalAccount=True AND Name='$user'"
-            if ($account) { Write-Host "account=$user enabled=$(-not $account.Disabled)" }
-            else { Write-Host "account=$user unavailable" }
-            # User-only context; do not invent connection addresses or replay service arguments.
-            if (-not $sshdAvailable -or $serviceArguments) {
-              Write-Host "sshd_config_user=$user unavailable (executable or service arguments)"
-              continue
-            }
-            $effectiveConfig = & $sshd -T -C "user=$user" 2>$null
-            $configExit = $LASTEXITCODE
-            Write-Host "sshd_config_user=$user context=user-only exit=$configExit"
-            if ($configExit -eq 0) {
-              $effectiveConfig | Where-Object {
-                $_ -match '^(port|authorizedkeysfile|pubkeyauthentication|authenticationmethods|allowusers|denyusers|strictmodes)\s'
-              } | ForEach-Object { Write-Host "sshd_config_user=$user $_" }
-            } else { Write-Host "sshd_config_user=$user unavailable" }
+          $keygen = "$env:WINDIR\System32\OpenSSH\ssh-keygen.exe"
+          $service = Get-CimInstance Win32_Service -Filter "Name='sshd'"
+          if (-not $service -or $service.State -ne "Running" -or $service.StartName -ne "LocalSystem" -or
+              $service.PathName.Trim().Trim('"') -ine $sshd) {
+            throw "Expected the running stock LocalSystem Windows OpenSSH service without arguments."
+          }
+          $effectiveConfig = & $sshd -T -C "user=$nativeUser" 2>&1
+          if ($LASTEXITCODE -ne 0) { throw "Could not inspect native Windows OpenSSH configuration." }
+          $keySetting = @($effectiveConfig | Where-Object { $_ -match '^authorizedkeysfile\s' })
+          if ($keySetting.Count -ne 1 -or $keySetting[0] -cne 'authorizedkeysfile __PROGRAMDATA__/ssh/administrators_authorized_keys') {
+            throw "Expected the stock administrator AuthorizedKeysFile for the native Windows user."
+          }
+          $authorizedKeys = Join-Path $env:ProgramData 'ssh\administrators_authorized_keys'
+          if (-not (Test-Path -LiteralPath $authorizedKeys -PathType Leaf)) {
+            throw "Expected the provider's existing administrator authorized keys file."
           }
 
-          $keygen = "$env:WINDIR\System32\OpenSSH\ssh-keygen.exe"
-          $keyFiles = @('C:\ProgramData\ssh\administrators_authorized_keys', 'C:\Users\runneradmin\.ssh\authorized_keys', $env:BASH_INSTALLED_KEY_PATH)
-          foreach ($keyFile in ($keyFiles | Select-Object -Unique)) {
-            if (-not $keyFile -or -not (Test-Path -LiteralPath $keyFile -PathType Leaf)) {
-              Write-Host "public_key_file=$keyFile unavailable"
-              continue
-            }
-            Write-Host "public_key_file=$keyFile"
-            if (Test-Path -LiteralPath $keygen -PathType Leaf) {
-              $keyInfo = & $keygen -E sha256 -lf $keyFile 2>$null
-              $keyExit = $LASTEXITCODE
-              Write-Host "fingerprint_exit=$keyExit"
-              if ($keyExit -eq 0) {
-                foreach ($line in $keyInfo) {
-                  if ($line -match '^\d+\s+(SHA256:[A-Za-z0-9+/]+)\s') { Write-Host "fingerprint=$($Matches[1])" }
-                }
-              } else { Write-Host "fingerprint=unavailable" }
-            } else { Write-Host "fingerprint=unavailable (ssh-keygen missing)" }
-            try {
-              $acl = Get-Acl -LiteralPath $keyFile
-              Write-Host "owner_sid=$($acl.GetOwner([Security.Principal.SecurityIdentifier]).Value)"
-              foreach ($rule in $acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier])) {
-                Write-Host "acl_sid=$($rule.IdentityReference.Value) rights=$($rule.FileSystemRights) type=$($rule.AccessControlType) inherited=$($rule.IsInherited)"
-              }
-            } catch { Write-Host "acl=unavailable" }
+          $keyInfo = @(& $keygen -E sha256 -lf $env:TESTBOX_PUBLIC_KEY_PATH 2>&1)
+          if ($LASTEXITCODE -ne 0 -or $keyInfo.Count -ne 1 -or
+              $keyInfo[0] -notmatch '^\d+\s+(SHA256:[A-Za-z0-9+/]+)\s') {
+            throw "Testbox did not provide one valid SSH public key."
           }
-          # A failed diagnostic process must not become the step's implicit exit status.
-          exit 0
+          $fingerprint = $Matches[1]
+          $publicKey = [IO.File]::ReadAllText($env:TESTBOX_PUBLIC_KEY_PATH).Trim()
+          if ($publicKey -match '[\r\n]') { throw "Expected a single-line Testbox SSH public key." }
+
+          # Windows OpenSSH requires only SYSTEM and Administrators; SIDs avoid localized names.
+          $acl = [Security.AccessControl.FileSecurity]::new()
+          $acl.SetOwner([Security.Principal.SecurityIdentifier]::new('S-1-5-32-544'))
+          $acl.SetAccessRuleProtection($true, $false)
+          foreach ($sid in @('S-1-5-18', 'S-1-5-32-544')) {
+            $acl.AddAccessRule([Security.AccessControl.FileSystemAccessRule]::new(
+              [Security.Principal.SecurityIdentifier]::new($sid), "FullControl", "Allow"))
+          }
+          Set-Acl -LiteralPath $authorizedKeys -AclObject $acl
+          # Preserve provider keys byte-for-byte, including a final line without a newline.
+          [IO.File]::AppendAllText($authorizedKeys, "`r`n$publicKey`r`n", [Text.UTF8Encoding]::new($false))
+          Write-Host "authorized_keys=$authorizedKeys testbox_key_fingerprint=$fingerprint"
+          "ssh_user=$nativeUser" >> $env:GITHUB_OUTPUT
 
       - name: Run Testbox
         if: always()
         shell: bash
+        env:
+          JOB_STATUS: ${{ job.status }}
+          NATIVE_SSH_USER: ${{ steps.prepare_windows.outputs.ssh_user }}
         run: |
           set -euo pipefail
 
@@ -263,11 +231,15 @@ jobs:
             exit 1
           fi
 
-          ready_body="$RUNNER_TEMP/testbox-ready.json"
+          phone_home_status="ready"
+          if [ "$JOB_STATUS" != "success" ]; then
+            phone_home_status="hydration_failed"
+          fi
+          final_body="$RUNNER_TEMP/testbox-final.json"
           jq -n \
             --arg testbox_id "$testbox_id" \
             --argjson installation_model_id "$installation_model_id" \
-            --arg status "ready" \
+            --arg status "$phone_home_status" \
             --arg ip_address "$runner_host" \
             --arg ssh_port "$runner_ssh_port" \
             --arg working_directory "$working_directory" \
@@ -281,22 +253,26 @@ jobs:
               working_directory: $working_directory,
               adopted_run_id: $adopted_run_id,
               metadata: {}
-            }' > "$ready_body"
+            }' > "$final_body"
 
           # curl can expose a 2xx status before a response-body timeout, so preserve its exit code.
-          ready_curl_status=0
+          final_curl_status=0
           http_code="$(curl -sS -L --post302 --post303 \
             --connect-timeout 10 --max-time 30 \
-            -o "$RUNNER_TEMP/testbox-ready.response" -w '%{http_code}' \
+            -o "$RUNNER_TEMP/testbox-final.response" -w '%{http_code}' \
             -X POST "${api_url}/api/testbox/phone-home" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${auth_token}" \
-            --data-binary @"$ready_body")" || ready_curl_status=$?
-          echo "phone_home_ready_curl=${ready_curl_status}"
-          echo "phone_home_ready_http=${http_code}"
-          if (( ready_curl_status != 0 )) || [[ ! "$http_code" =~ ^2 ]]; then
-            echo "Blacksmith phone-home ready failed; response body:" >&2
-            cat "$RUNNER_TEMP/testbox-ready.response" >&2 || true
+            --data-binary @"$final_body")" || final_curl_status=$?
+          echo "phone_home_${phone_home_status}_curl=${final_curl_status}"
+          echo "phone_home_${phone_home_status}_http=${http_code}"
+          if (( final_curl_status != 0 )) || [[ ! "$http_code" =~ ^2 ]]; then
+            echo "Blacksmith phone-home ${phone_home_status} failed." >&2
+            exit 1
+          fi
+
+          if [ "$phone_home_status" != "ready" ]; then
+            echo "Testbox setup failed; reported hydration_failed." >&2
             exit 1
           fi
 
@@ -307,8 +283,10 @@ jobs:
           echo "  SSH port:           ${runner_ssh_port}"
           echo "  Working directory:  ${working_directory}"
           echo "  Run ID:             ${adopted_run_id}"
-          echo "  SSH:                ssh -p ${runner_ssh_port} runner@${runner_host}"
+          echo "  SSH:                ssh -p ${runner_ssh_port} ${NATIVE_SSH_USER}@${runner_host}"
           echo "============================================"
+
+          echo "Native SSH inspection only: Blacksmith CLI 0.4.57 still targets runner and has no username override; supported sync/run remains blocked."
 
           # Blacksmith advertises a forwarded port; native sockets use sshd's local listeners.
           runner_ssh_local_ports="$(pwsh -NoProfile -NonInteractive -Command '

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -79,6 +79,14 @@ owning its prepared environment. Direct providers use
 requested proof requires another environment; capacity or hydration failure
 does not make a different provider equivalent.
 
+The direct `.github/workflows/windows-blacksmith-testbox.yml` workflow runs
+native Windows. The wrapper's Blacksmith adapter supports Linux only; explicit
+`--provider blacksmith-testbox` prevents automatic Azure routing but does not
+enable Windows support. Blacksmith CLI 0.4.57 targets `runner` and has no native
+username override, so supported CLI sync/run on this Windows image remains
+blocked. Native SSH inspection with the per-Testbox key is not CLI end-to-end
+proof.
+
 The wrapper checks an executable sibling `../crabbox/bin/crabbox`, then `PATH`,
 then the sibling of the Git common checkout. Verify the selected binary and
 its source rather than trusting a directory name. If it needs repair or is

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -206,6 +206,10 @@ syntax natively without the Node loader. Only their runtime imports change.
 Existing package build entry paths and Vitest source parents stay unchanged. Other
 Worker-thread entries and arbitrary source CLI fixtures remain outside this declared set.
 
+The session-title retention test declares its title-reader and session-utils roots
+in this same generation. Each fresh heap-measurement child runs their JavaScript
+without spending its execution deadline on TypeScript imports.
+
 Preparation is lazy across both projects and shards. Config imports, listing
 tests, and tiny tests that do not import these declarations do not load the
 subprocess compiler or compile workers. A shard that needs a declaration requests the

--- a/scripts/lib/vitest-worker-artifacts.mts
+++ b/scripts/lib/vitest-worker-artifacts.mts
@@ -12,6 +12,8 @@ export const vitestWorkerDeclarationEntries = {
   ...runtimeProcessDeclarationEntries,
   "agents/command/cli-compaction-runtime.test-support":
     "src/agents/command/cli-compaction-runtime.test-support.ts",
+  "gateway/session-title-retention.test-support":
+    "src/gateway/session-title-retention.test-support.ts",
   "tui/tui-pty-runtime-test-support": "src/tui/tui-pty-runtime-test-support.ts",
 };
 

--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { cliCompactionBackendEntrypoints } from "../../src/agents/command/cli-compaction-runtime.test-support.ts";
+import { sessionTitleRetentionEntrypoints } from "../../src/gateway/session-title-retention.test-support.ts";
 import { tuiPtyRuntimeEntrypoints } from "../../src/tui/tui-pty-runtime-test-support.ts";
 import { runtimeProcessBuildEntries } from "./runtime-process-build-entries.mts";
 
@@ -7,13 +8,11 @@ import { runtimeProcessBuildEntries } from "./runtime-process-build-entries.mts"
 export const vitestWorkerBuildEntries = {
   ...runtimeProcessBuildEntries,
   ...Object.fromEntries(
-    cliCompactionBackendEntrypoints.map((entry) => [
-      entry.distWorkerPath.replace(/\.js$/u, ""),
-      fileURLToPath(new URL(`./${entry.sourceWorkerName}.ts`, entry.currentModuleUrl)),
-    ]),
-  ),
-  ...Object.fromEntries(
-    Object.values(tuiPtyRuntimeEntrypoints).map((entry) => [
+    [
+      ...cliCompactionBackendEntrypoints,
+      ...Object.values(tuiPtyRuntimeEntrypoints),
+      ...Object.values(sessionTitleRetentionEntrypoints),
+    ].map((entry) => [
       entry.distWorkerPath.replace(/\.js$/u, ""),
       fileURLToPath(new URL(`./${entry.sourceWorkerName}.ts`, entry.currentModuleUrl)),
     ]),

--- a/src/gateway/session-title-retention.test-support.ts
+++ b/src/gateway/session-title-retention.test-support.ts
@@ -1,0 +1,15 @@
+// Compile both runtime roots before the retention child's bounded heap measurement.
+const currentModuleUrl = import.meta.url;
+
+export const sessionTitleRetentionEntrypoints = {
+  titleReader: {
+    currentModuleUrl,
+    sourceWorkerName: "session-transcript-title-reader",
+    distWorkerPath: "gateway/session-transcript-title-reader.js",
+  },
+  sessionUtils: {
+    currentModuleUrl,
+    sourceWorkerName: "session-utils-core",
+    distWorkerPath: "gateway/session-utils-core.js",
+  },
+} as const;

--- a/src/gateway/session-transcript-title-reader.retention.test.ts
+++ b/src/gateway/session-transcript-title-reader.retention.test.ts
@@ -5,11 +5,13 @@ import {
   persistSessionTranscriptTurn,
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
+import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
 import { cleanupSessionStateForTest } from "../test-utils/session-state-cleanup.js";
+import { sessionTitleRetentionEntrypoints } from "./session-title-retention.test-support.js";
 
 let state: OpenClawTestState;
 let storePath: string;
@@ -52,19 +54,19 @@ afterAll(async () => {
 test.each(["scalar", "batch"])(
   "releases transcript payloads after caching %s title fields",
   (mode) => {
-    const moduleUrl = (relative: string) => new URL(relative, import.meta.url).href;
+    const titleReaderUrl = resolveRuntimeWorkerUrl(sessionTitleRetentionEntrypoints.titleReader);
+    const sessionUtilsUrl = resolveRuntimeWorkerUrl(sessionTitleRetentionEntrypoints.sessionUtils);
     const result = spawnSync(
       process.execPath,
       [
         "--expose-gc",
-        "--import",
-        "tsx",
+        ...resolveRuntimeWorkerArgv(titleReaderUrl).slice(0, -1),
         "--input-type=module",
         "--eval",
         `
           import { setImmediate as yieldTurn } from "node:timers/promises";
-          import { readSessionTitleFieldsFromTranscript, readSessionTitleFieldsFromTranscriptBatch } from ${JSON.stringify(moduleUrl("./session-transcript-title-reader.ts"))};
-          import { deriveSessionTitle } from ${JSON.stringify(moduleUrl("./session-utils-core.ts"))};
+          import { readSessionTitleFieldsFromTranscript, readSessionTitleFieldsFromTranscriptBatch } from ${JSON.stringify(titleReaderUrl.href)};
+          import { deriveSessionTitle } from ${JSON.stringify(sessionUtilsUrl.href)};
 
           async function heapUsed() {
             await yieldTurn();
@@ -99,7 +101,7 @@ test.each(["scalar", "batch"])(
       ],
       { cwd: process.cwd(), env: state.env, encoding: "utf8", timeout: 20_000 },
     );
-    expect(result.error).toBeUndefined();
+    expect(result.error, result.stderr + result.stdout).toBeUndefined();
     expect(result.status, result.stderr).toBe(0);
     const output = JSON.parse(result.stdout) as {
       retainedBytes: number;

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -7838,18 +7838,52 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
 
   it("fails Windows Testbox setup when Blacksmith phone-home is not accepted", () => {
     const workflow = readFileSync(".github/workflows/windows-blacksmith-testbox.yml", "utf8");
+    const job = parse(workflow).jobs.windows;
+    const prepare = job.steps.find((step: WorkflowStep) => step.name === "Prepare Windows SSH");
+    const finalize = job.steps.find((step: WorkflowStep) => step.name === "Run Testbox").run;
+
+    // Windows administrators use the effective ProgramData file and native ACLs.
+    // The native handshake is the behavioral proof; this guards workflow wiring.
+    expect(prepare?.env).toEqual({
+      TESTBOX_PUBLIC_KEY_PATH: "${{ steps.begin_testbox.outputs.public_key_path }}",
+    });
+    const nativeSetup = prepare?.run ?? "";
+    expect(nativeSetup).toContain("WindowsPrincipal");
+    expect(nativeSetup).toContain("System32\\OpenSSH\\sshd.exe");
+    expect(nativeSetup).toContain('-T -C "user=$nativeUser"');
+    expect(nativeSetup).toContain(
+      "authorizedkeysfile __PROGRAMDATA__/ssh/administrators_authorized_keys",
+    );
+    expect(nativeSetup).toContain("System32\\OpenSSH\\ssh-keygen.exe");
+    expect(nativeSetup).toContain("-E sha256 -lf $env:TESTBOX_PUBLIC_KEY_PATH");
+    expect(nativeSetup).toContain("[IO.File]::AppendAllText($authorizedKeys,");
+    expect(nativeSetup).toContain("S-1-5-18");
+    expect(nativeSetup).toContain("S-1-5-32-544");
+    expect(nativeSetup).toContain("SetAccessRuleProtection($true, $false)");
+    expect(nativeSetup).toContain('"FullControl", "Allow"');
+    expect(nativeSetup).toContain("Set-Acl -LiteralPath $authorizedKeys");
+    expect(workflow).not.toContain(">> ~/.ssh/authorized_keys");
+
+    expect(finalize).toMatch(
+      /if \[ "\$JOB_STATUS" != "success" \]; then\s+phone_home_status="hydration_failed"/u,
+    );
+    expect(finalize).toContain('--arg status "$phone_home_status"');
+    expect(finalize.match(/\/api\/testbox\/phone-home/gu)).toHaveLength(1);
+    expect(finalize.slice(0, finalize.indexOf('echo "Testbox ready!"'))).toMatch(
+      /if \[ "\$phone_home_status" != "ready" \]; then[^]*?exit 1\s+fi/u,
+    );
 
     expect(workflow.match(/--connect-timeout 10 --max-time 30/gu)).toHaveLength(2);
     expect(workflow).toContain('echo "phone_home_hydrating_curl=${hydrating_curl_status}"');
     expect(workflow).toContain('echo "phone_home_hydrating_http=${hydrating_http_code}"');
-    expect(workflow).toContain('echo "phone_home_ready_curl=${ready_curl_status}"');
-    expect(workflow).toContain('echo "phone_home_ready_http=${http_code}"');
+    expect(workflow).toContain('echo "phone_home_${phone_home_status}_curl=${final_curl_status}"');
+    expect(workflow).toContain('echo "phone_home_${phone_home_status}_http=${http_code}"');
     expect(workflow).toContain('jq -e \'type == "number"\' <<<"$installation_model_id"');
     expect(workflow).toContain('--arg testbox_id "$TESTBOX_ID"');
     expect(workflow).toContain('--arg testbox_id "$testbox_id"');
     expect(workflow).toContain('--argjson installation_model_id "$installation_model_id"');
     expect(workflow).toContain('--data-binary @"$hydrating_body"');
-    expect(workflow).toContain('--data-binary @"$ready_body"');
+    expect(workflow).toContain('--data-binary @"$final_body"');
     const hydratingFailureBlock = workflow.slice(
       workflow.indexOf(
         'if (( hydrating_curl_status != 0 )) || [[ ! "$hydrating_http_code" =~ ^2 ]]; then',
@@ -7858,26 +7892,26 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     );
     const missingSshKeyFailureBlock = workflow.slice(
       workflow.indexOf('if [ -z "$ssh_public_key" ]; then'),
-      workflow.indexOf("mkdir -p ~/.ssh"),
+      workflow.indexOf('public_key_path="$(cygpath'),
     );
-    const readyFailureBlock = workflow.slice(
-      workflow.indexOf('if (( ready_curl_status != 0 )) || [[ ! "$http_code" =~ ^2 ]]; then'),
+    const finalFailureBlock = workflow.slice(
+      workflow.indexOf('if (( final_curl_status != 0 )) || [[ ! "$http_code" =~ ^2 ]]; then'),
       workflow.indexOf('echo "============================================"'),
     );
 
     expect(workflow).toContain(')" || hydrating_curl_status=$?');
-    expect(workflow).toContain(')" || ready_curl_status=$?');
+    expect(workflow).toContain(')" || final_curl_status=$?');
     expect(hydratingFailureBlock).toContain("exit 1");
     expect(missingSshKeyFailureBlock).toContain("exit 1");
-    expect(readyFailureBlock).toContain("exit 1");
+    expect(finalFailureBlock).toContain("exit 1");
     expect(workflow).toContain(
-      "Blacksmith phone-home did not return an SSH public key; testbox cannot accept CLI connections.",
+      "Blacksmith phone-home did not return an SSH public key; testbox cannot accept native SSH connections.",
     );
     expect(workflow).not.toContain(
-      'phone_home_ready_http=${http_code}"\n\n          echo "============================================"',
+      'phone_home_${phone_home_status}_http=${http_code}"\n\n          echo "============================================"',
     );
     expect(workflow).not.toContain('\\"testbox_id\\": \\"${TESTBOX_ID}\\"');
-    expect(workflow).not.toContain('cat > "$ready_body" <<JSON');
+    expect(workflow).not.toContain('cat > "$final_body" <<JSON');
     expect(workflow).not.toContain('"testbox_id": "${testbox_id}"');
   });
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -5366,6 +5366,11 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
       "github.event_name == 'workflow_dispatch' && always()",
     );
     expect(runWindowsTestboxStep.if).toBe("always()");
+    expect(runWindowsTestboxStep.env?.JOB_STATUS).toBe("${{ job.status }}");
+    expect(runWindowsTestboxStep.env?.NATIVE_SSH_USER).toBe(
+      "${{ steps.prepare_windows.outputs.ssh_user }}",
+    );
+    expect(runWindowsTestboxStep.run).toContain("${NATIVE_SSH_USER}@${runner_host}");
     expect(runTestboxStep["continue-on-error"]).toBeUndefined();
   });
 


### PR DESCRIPTION
Closes #134823 — native Windows Testbox rejects the per-session SSH key installed by its workflow.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled. This is a same-repository maintainer-editable branch.

</details>

## What Problem This Solves

The native Windows Blacksmith Testbox workflow reported ready but installed its lease key in a home-directory file that the running Windows OpenSSH administrator account did not use. Even the correct native account could not authenticate. The finalizer also advertised readiness after setup failure.

This repairs the **OpenClaw workflow half only**. Blacksmith CLI 0.4.57 still selects the absent `runner` account and has no supported native-username override; supported CLI synchronization and remote command execution remain blocked.

## Why This Change Was Made

Native PowerShell verifies the stock running daemon and its effective `%ProgramData%/ssh/administrators_authorized_keys` contract, validates and appends the lease key without overwriting provider keys, and installs SYSTEM/Administrators-only ACL entries using SIDs. The ineffective Bash home-file/chmod path and temporary diagnostic dump are removed.

One checked finalizer carries the recorded job outcome: `ready` after successful preparation, `hydration_failed` otherwise. Failed setup exits before the ready banner and keepalive; successful setup prints the actual native SSH user. No account alias, vendor binary patch, authentication relaxation, or provider switch is introduced.

The candidate also retains main's independently landed idle repair from #134927: after the CLI-limitation notice, it discovers the running daemon's **local listener ports** and checks exact established local endpoints. It does not restore the old externally forwarded-port comparison.

## User Impact

Maintainers can authenticate with the exact per-Testbox key and inspect native Windows through PowerShell. Setup failures no longer masquerade as readiness, and active SSH keeps the composed workflow alive beyond its configured idle interval. The [testing guide](https://docs.openclaw.ai/reference/test#crabbox-repository-setup) documents the native SSH/vendor CLI boundary.

Native SSH proof is **not CLI end-to-end or synchronization proof**. There are no application-runtime, dependency-graph, schema, migration, configuration-option, test-budget, timeout, or assertion changes.

## Evidence

### Fresh composed workflow proof

Exact candidate: `71f172b7a9bd1857da2b1068c7431112dada31ad`, merge base `d1c9e4880b2238aac0582d1db1558d3cea998f69`. Workflow SHA-256: `8ab4e7ee37f34c1d837f9797d39760aa4ffa2f3d08ff0c6f8f22cb12c050456f`.

Provider **blacksmith-testbox**, native Windows runner, one fresh lease `tbx_01m1e3j7v4sqxhtqyn68ck8mwm`: [run 33490559574 / job 99800790521](https://github.com/openclaw/openclaw/actions/runs/33490559574/job/99800790521). Allocated directly from this branch with a **3-minute** idle timeout; no Azure, Linux, WSL, operator host, or stopped lease was substituted.

Public-key-only SSH used this lease's generated key, with agent/default identities and password fallback disabled. The server identified itself as Windows OpenSSH 9.5 and accepted the exact lease key. The native command verified:

- Windows NT 10.0.26100, X64, `runneradmin`, and PowerShell 7.4.11 at `C:\Program Files\PowerShell\7\pwsh.exe`.
- Exact candidate HEAD and workflow hash above.
- Effective administrator authorized-key file; only SYSTEM and Administrators FullControl Allow entries, no inheritance.
- `runner` remains absent; sshd's actual local listener is port 22.
- Normal command completion, **exit 0 after 240.16 seconds** (09:10:47–09:14:47 UTC on September 1).

At 185.15 seconds the native command still observed its established local SSH connection. At **190.00 seconds**, a forced-fresh exact-job GitHub read independently confirmed both the job and **Run Testbox** step were `in_progress`, while SSH was still running. This verifies the composed monitor beyond the 180-second idle interval, not merely connection survival during runner teardown grace. The peer's previously recorded short-marker/false-forwarded-port negative controls remain separate inherited evidence; no broader duplicate suite was claimed.

The first transport attempt authenticated but hit Windows' command-line length limit before the diagnostic payload ran. The same diagnostic then ran through a short encoded PowerShell launcher with script input on stdin, on the same lease. No workflow or source edits were made during proof.

Cleanup: the provider lease is `completed`, its status has no IP, and its owned local key cache is absent. The lingering Actions keepalive was cancelled only **after** successful native proof. Native command exit 0 is the proof; a cancelled whole workflow is not described as a successful whole-job run. Private keys, tokens, and endpoint details are not published. Setup-failure finalization has static guard coverage; the fresh native lease proves the successful setup and active-SSH path, not a deliberately failed hydration run.

### Exact-head CI and fresh review

[CI run 33489655903](https://github.com/openclaw/openclaw/actions/runs/33489655903) completed **success** for `71f172b7a9bd1857da2b1068c7431112dada31ad`; required [openclaw/ci-gate 99800946234](https://github.com/openclaw/openclaw/actions/runs/33489655903/job/99800946234) passed. The repository's exact-head watcher returned `GREEN`.

The retention tests passed scalar then batch in [large-5 / job 99798185036](https://github.com/openclaw/openclaw/actions/runs/33489655903/job/99798185036): **3,084 ms / 2,139 ms**. The current inventory case passed in [large-29 / job 99798188731](https://github.com/openclaw/openclaw/actions/runs/33489655903/job/99798188731). [Build job 99798183036](https://github.com/openclaw/openclaw/actions/runs/33489655903/job/99798183036) passed with startup gzip **348,114 bytes**, below even the original 348,368-byte limit; current main's actual enforcement was 349,244 bytes. This PR changes no budget.

Fresh isolated Codex autoreview of the complete composed candidate against its actual `d1c9e488…` merge base completed **scoped-clean at P0/P1**, with no actionable findings. This is a new review of `71f172b7…`, not a claim that the older review ran on these workflow bytes.

Fresh focused proof passed **10 tests in 3 files**, with 455 unrelated cases unselected:

```bash
node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts test/scripts/package-acceptance-workflow.test.ts test/scripts/windows-blacksmith-testbox.test.ts -t 'fails Windows Testbox setup|finalizes dispatched Testbox delegation|native Windows Testbox idle monitor' --reporter=dot
node --import tsx scripts/check-workflows.mts
git diff --check d1c9e4880b2238aac0582d1db1558d3cea998f69...HEAD
```

Full workflow sanity passed: actionlint, zizmor, CI Git-owner generation, composite-input checks, and conflict-marker checks. Native review artifacts were regenerated for this head and validated through `scripts/pr`.

### Historical reproduction and bounded CI repair

The original unchanged workflow blob `8eed835c89a83b4a6bc119d394519a22a3398526` failed authentication in [baseline run 33452905609](https://github.com/openclaw/openclaw/actions/runs/33452905609). [Native diagnostic run 33462647568](https://github.com/openclaw/openclaw/actions/runs/33462647568) proved that the lease key was in the home file but absent from the daemon's effective administrator file; the correct native account still failed. [Repair run 33468205108](https://github.com/openclaw/openclaw/actions/runs/33468205108) at `3182541…` accepted the lease key and executed native PowerShell with restricted ACLs. Its different historical workflow hash is not used as fresh composed-head proof. All historical leases/key caches were cleaned. Old local temporary raw receipts are no longer available; surviving review records and public CI preserve the history, while the fresh run above is the current proof.

The retention harness previously spent its 20-second child deadline loading raw TypeScript runtime imports. It now declares the title-reader/session-utils roots through the existing compiled-worker owner and uses the existing runtime URL/argument resolver. Fixtures, separate fresh children, scalar-before-batch order, source/watch behavior, 128 large prompts, named-title and lone-surrogate assertions, three GCs, the **8 MiB heap limit**, and **20s/30s deadlines** remain unchanged. Repeated build-map construction is consolidated; no application cache or persistence semantics change.

Historical phase probes measured source imports at 15.65s/19.58s, versus compiled children at 2.60s/1.93s with preparation outside the deadline. Restoring the actual pre-copy retention behavior made both children exit normally but fail the unchanged heap assertion at 36,013,464/34,445,576 retained bytes. The final uninstrumented 75-test owner/lifecycle/transform suite and classified changed-file checks passed. These are historical measurements, not newly recreated raw logs; the retention files are byte-identical to the prior green head `51dd042…`, and fresh exact-head CI passed above.

Earlier integration blockers were resolved by already-landed canonical main fixes: #134758 removes emitted UI developer comments without a budget change; #134824 narrows release inventory enumeration to package directories and exact metadata without increasing the buffer. Neither repair is duplicated in this PR. #134914 is not a prerequisite. The independent idle fix #134927 is inherited and verified in the fresh composition.

### Contracts, scope, and review follow-through

The implementation follows [Microsoft's administrator key-file/ACL contract](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh-server-configuration#authorizedkeysfile) and the directly inspected [pinned Testbox finalizer contract](https://github.com/useblacksmith/run-testbox/blob/3f60ff9ceb2c10c3feefa87dc0c6490cffae059d/action.yml#L37). Home-file chmod would leave the wrong owner path; a native account alias would conceal the vendor boundary; longer retention deadlines would hide test preparation inside measurement.

Eight intended files: workflow **+96/-33 (net +63)**; tests/support/test tooling **+81/-24 (net +57)**; docs **+12**; application-production code **0**. Workflow growth provides the required native daemon/file/ACL and explicit failure-outcome contracts. No dependency, lockfile, budget, schema, or runtime changes are included.

ClawSweeper's latest before-merge and rank-up requests are addressed by the exact composed workflow/hash proof and completed exact-head CI above. The newer local-listener monitor is preserved, upstream contracts were directly inspected, and this remains the maintainer-owned candidate for #134823. The existing re-review request covers the harness change; this mechanical integration does not add another request. The remaining vendor CLI native-user/synchronization gap is explicit and outside this workflow-half repair.

### Landing closeout

Landed through the native prepare/merge workflow as [e6ae941d8b2ec927f4ba0291ed034ac2906e6552](https://github.com/openclaw/openclaw/commit/e6ae941d8b2ec927f4ba0291ed034ac2906e6552). Post-merge verification reconstructed the merge tree from the actual parent plus approved head and matched it exactly; the landed workflow SHA-256 remains `8ab4e7ee37f34c1d837f9797d39760aa4ffa2f3d08ff0c6f8f22cb12c050456f`, with only the eight intended files in the squash delta.

The final ClawSweeper review at 09:31 UTC found no actionable patch defect and accepted the exact-head native proof. Its remaining provider-image availability risk is accepted within the approved scope: if the stock Windows service, effective key-file path, or restricted ACL contract changes, setup deliberately fails visibly instead of advertising a ready but inaccessible Testbox. No fallback to the ineffective home file or fabricated account alias is added. The native workflow merge request is complete; the vendor CLI account-selection/sync limitation remains unresolved.
