### PR TITLE
docs: explain recovery from Homebrew op path changes

### DIFF
--- a/docs/gateway/1password.md
+++ b/docs/gateway/1password.md
@@ -3,6 +3,7 @@ summary: "Use the 1Password plugin, bundled skill, or official MCP with OpenClaw
 read_when:
   - You want API keys out of openclaw.json and inside 1Password
   - You run the Gateway headless and need service account auth for op
+  - A Homebrew upgrade broke a manual 1Password exec provider
   - You want agents to read, inject, or maintain secrets with 1Password
 title: "1Password"
 ---
@@ -137,3 +138,41 @@ One-time passcodes are filled by 1Password on the same page; never relay verific
 - A reference is rejected: include the vault explicitly and use stable vault,
   item, section, and field IDs when names are long or contain unsupported
   1Password reference characters.
+
+### Homebrew command symlinks
+
+If a manual exec provider reports `command must not be a symlink` for
+`/opt/homebrew/bin/op` or `/usr/local/bin/op`, use the
+[plugin setup flow](/gateway/1password#resolve-config-secrets-with-the-plugin). Manual exec
+providers require a non-symlink command. Resolving the Homebrew link to a
+versioned `Caskroom` path works only while that version remains installed;
+a later package upgrade or cleanup can remove it.
+
+The plugin resolves `op` from the Gateway process's `PATH` for each resolver
+request, then checks the real executable and its parent directories before
+passing the service-account token. An existing `CLAW_1PASSWORD_OP` override
+can name the stable absolute Homebrew link and receives the same checks.
+The plugin follows a replacement link after an upgrade without storing its
+versioned target in `openclaw.json`. Group- or other-writable executables still
+fail, as do parent directories that let another user replace the checked path.
+
+Before migrating, map every existing credential target to the exact 1Password
+reference its old command reads. A manual provider may put that reference in
+`args` and use an unrelated SecretRef `id`; copying that id into the plugin
+would select a different secret or fail. Choose an unused provider alias with
+`--provider-alias <alias>` if `onepassword` already names a manual provider:
+replacing that provider would also change unlisted references that use its alias.
+Create the plugin token file as shown above, then generate a plan with explicit
+mappings, for example:
+
+```bash
+openclaw onepassword secretref setup \
+  --target 'models.providers.anthropic.apiKey=op://Automation/Anthropic/credential' \
+  --target 'models.providers.openai.apiKey=op://Automation/OpenAI/credential' \
+  --plan-out ./openclaw-1password-secrets-plan.json
+```
+
+Inspect the plan's provider alias and every target before using the status,
+dry-run, apply, audit, and reload commands above. Remove an old manual provider
+only after all references to it have moved; include auth-profile and channel
+credentials in that check.


### PR DESCRIPTION
## What Problem This Solves

Fixes missing recovery guidance for operators whose manual 1Password exec provider rejects a Homebrew `op` symlink or points at a versioned executable removed by an upgrade.

## Why This Change Was Made

Document the existing 1Password plugin setup flow, which resolves and validates the current executable for each request. The migration instructions preserve exact credential-to-item mappings and explain how to avoid provider-alias collisions.

## User Impact

Operators can move from a brittle versioned command path to the supported plugin integration while retaining executable and parent-directory trust checks.

## Evidence

Synthetic process proofs verified manual symlink rejection, successful canonical execution, and failure after the pinned version was removed. The real plugin resolver followed replacement Homebrew symlinks through both PATH and an absolute override, then refused unsafe executable and parent replacements without executing them.

The built CLI setup command generated both exact target mappings under an unused provider alias and left the original config unchanged. No real 1Password credentials or Homebrew installation were used. Docs indexing, formatting, and diff checks pass. An optional unchanged op-path sibling test import was canceled after prolonged filesystem reads; the completed resolver and command proofs are retained.

Docs only: +39 lines; no production or test changes.
