### PR TITLE
fix(ui): prevent overlapping text in collapsed user messages

### DIFF
--- a/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
+++ b/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
@@ -1,3 +1,4 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import {
@@ -74,11 +75,12 @@ suite.define(() => {
       const toggle = bubble.getByRole("button", { name: "Show more" });
 
       expect(await toggle.getAttribute("aria-expanded")).toBe("false");
-      expect(await content.evaluate((element) => getComputedStyle(element).webkitLineClamp)).toBe(
-        "5",
-      );
-      expect(await content.textContent()).toContain(text.slice(-18));
+      const lineHeight = await content
+        .locator(".chat-text")
+        .evaluate((element) => Number.parseFloat(getComputedStyle(element).lineHeight));
+      expect((await content.textContent())?.trim()).toBe(text);
       const collapsedHeight = await content.evaluate((element) => element.clientHeight);
+      expect(collapsedHeight).toBeLessThanOrEqual(5 * lineHeight + 1);
       expect(await content.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(
         true,
       );
@@ -91,9 +93,6 @@ suite.define(() => {
       await toggle.click();
       const collapse = bubble.getByRole("button", { name: "Show less" });
       expect(await collapse.getAttribute("aria-expanded")).toBe("true");
-      expect(await content.evaluate((element) => getComputedStyle(element).webkitLineClamp)).toBe(
-        "none",
-      );
       expect(await content.evaluate((element) => element.clientHeight)).toBeGreaterThan(
         collapsedHeight,
       );
@@ -101,4 +100,166 @@ suite.define(() => {
       await suite.closeBrowserContext(context);
     }
   });
+
+  it.each([
+    { name: "desktop", width: 1280, height: 900 },
+    { name: "mobile", width: 390, height: 844 },
+  ])(
+    "keeps collapsed paragraphs readable after reload and browser reveal ($name)",
+    async (viewport) => {
+      const paragraphs = [
+        ...Array.from(
+          { length: 8 },
+          (_, index) =>
+            `Background paragraph ${index + 1}. Please review the synthetic project notes and summarize the next steps. Keep the explanation clear enough for someone reading the conversation later.`,
+        ),
+        ...["First", "Second"].map((label) =>
+          [
+            `${label} request:`,
+            "<review_request>",
+            "<input>Read the sample notes and explain the next step,",
+            "then describe the expected result.</input>",
+            "<context>The sample is ready for review.</context>",
+            "</review_request>",
+          ].join("\n"),
+        ),
+        "Final prompt tail: the complete request remains available.",
+      ];
+      const context = await suite.newBrowserContext({
+        locale: "en-US",
+        colorScheme: "light",
+        serviceWorkers: "block",
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const page = await context.newPage();
+      await installMockGateway(page, {
+        historyMessages: [
+          { role: "user", content: paragraphs.join("\n\n"), timestamp: 1 },
+          { role: "user", content: "Short follow-up request.", timestamp: 2 },
+          { role: "assistant", content: "The sample review is complete.", timestamp: 3 },
+        ],
+      });
+
+      try {
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const bubble = page.locator(".chat-group.user .chat-bubble").first();
+        const toggle = bubble.getByRole("button", { name: "Show more", exact: true });
+        await toggle.waitFor({ state: "visible" });
+        await page.reload();
+        await toggle.waitFor({ state: "visible" });
+        const content = bubble.locator(".chat-message-disclosure__content");
+        const markdown = content.locator(".chat-text");
+        const lineHeight = await markdown.evaluate((element) =>
+          Number.parseFloat(getComputedStyle(element).lineHeight),
+        );
+        expect(await content.evaluate((element) => element.scrollTop)).toBe(0);
+        expect(await markdown.locator("p").allTextContents()).toEqual(paragraphs);
+
+        // Browser descendant reveal can scroll an overflow-hidden preview without expanding it.
+        const revealedParagraph = markdown.locator("p").nth(9);
+        await revealedParagraph.scrollIntoViewIfNeeded();
+        const geometry = await revealedParagraph.evaluate((paragraph) => {
+          const clip = paragraph.closest(".chat-message-disclosure__content");
+          if (!clip) {
+            throw new Error("Missing user message preview");
+          }
+          const clipRect = clip.getBoundingClientRect();
+          const paragraphRect = paragraph.getBoundingClientRect();
+          // Read individual text nodes so BR boxes and duplicate element fragments are excluded.
+          const walker = document.createTreeWalker(paragraph, NodeFilter.SHOW_TEXT);
+          const lines: Array<{ top: number; bottom: number }> = [];
+          for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+            if (!node.textContent?.trim()) {
+              continue;
+            }
+            const range = document.createRange();
+            range.selectNodeContents(node);
+            for (const rect of range.getClientRects()) {
+              if (rect.width > 0 && rect.height > 0) {
+                lines.push({ top: rect.top, bottom: rect.bottom });
+              }
+            }
+          }
+          return {
+            scrollTop: clip.scrollTop,
+            clip: { top: clipRect.top, bottom: clipRect.bottom },
+            paragraph: { top: paragraphRect.top, bottom: paragraphRect.bottom },
+            lines,
+          };
+        });
+        if (captureUiProofEnabled) {
+          const artifactDir = path.join(suite.artifactDir, "user-bubble-clamp");
+          await page.screenshot({ path: path.join(artifactDir, `${viewport.name}-revealed.png`) });
+          await writeFile(
+            path.join(artifactDir, `${viewport.name}-geometry.json`),
+            `${JSON.stringify(geometry, null, 2)}\n`,
+          );
+        }
+        expect(await toggle.getAttribute("aria-expanded")).toBe("false");
+        expect(geometry.scrollTop).toBeGreaterThan(0);
+        expect(
+          geometry.lines.filter(
+            (line) => line.top >= geometry.clip.top && line.bottom <= geometry.clip.bottom,
+          ).length,
+        ).toBeGreaterThan(0);
+        expect(geometry.lines.length).toBeGreaterThanOrEqual(6);
+        for (const line of geometry.lines) {
+          expect(line.top, "text starts within its own paragraph").toBeGreaterThanOrEqual(
+            geometry.paragraph.top - 1,
+          );
+          expect(
+            line.bottom,
+            "text ends within its own paragraph without overlapping the next",
+          ).toBeLessThanOrEqual(geometry.paragraph.bottom + 1);
+        }
+        const collapsedHeight = await content.evaluate((element) => element.clientHeight);
+        expect(collapsedHeight).toBeLessThanOrEqual(5 * lineHeight + 1);
+
+        await toggle.click();
+        const collapse = bubble.getByRole("button", { name: "Show less", exact: true });
+        expect(await collapse.getAttribute("aria-expanded")).toBe("true");
+        expect(await content.evaluate((element) => element.clientHeight)).toBeGreaterThan(
+          collapsedHeight,
+        );
+        expect(
+          await content.evaluate((element) => element.scrollHeight - element.clientHeight),
+        ).toBeLessThanOrEqual(1);
+        const tail = markdown.locator("p").last();
+        await tail.scrollIntoViewIfNeeded();
+        expect(await tail.textContent()).toBe(paragraphs.at(-1));
+        if (captureUiProofEnabled) {
+          await page.screenshot({
+            path: path.join(
+              suite.artifactDir,
+              "user-bubble-clamp",
+              `${viewport.name}-expanded-tail.png`,
+            ),
+          });
+        }
+        await collapse.click();
+        expect(await toggle.getAttribute("aria-expanded")).toBe("false");
+        expect(await content.evaluate((element) => element.clientHeight)).toBeLessThanOrEqual(
+          5 * lineHeight + 1,
+        );
+        const siblings = page.locator(".chat-group .chat-bubble");
+        expect(await siblings.nth(1).textContent()).toContain("Short follow-up request.");
+        expect(await siblings.nth(2).textContent()).toContain("The sample review is complete.");
+        const boxes = await siblings.evaluateAll((elements) =>
+          elements.map((element) => {
+            const rect = element.getBoundingClientRect();
+            return { top: rect.top, bottom: rect.bottom };
+          }),
+        );
+        expect(boxes).toHaveLength(3);
+        for (const [index, box] of boxes.entries()) {
+          const previous = boxes[index - 1];
+          if (previous) {
+            expect(previous.bottom).toBeLessThanOrEqual(box.top + 1);
+          }
+        }
+      } finally {
+        await suite.closeBrowserContext(context);
+      }
+    },
+  );
 });

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -39,10 +39,10 @@
 }
 
 .chat-message-disclosure:not(.is-expanded) .chat-message-disclosure__content {
-  display: -webkit-box;
+  /* Legacy line clamp compresses hidden blocks that browser descendant reveal can
+     expose as overlapping text. Clip the natural Markdown layout instead. */
+  max-height: calc(var(--chat-text-size) * 1.5 * 5);
   overflow: hidden;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 5;
 }
 
 .chat-message-disclosure__toggle {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where text in long, collapsed Control UI user messages can overlap when a browser reveals a later paragraph inside the preview. The failure was reproduced independently with synthetic history and a browser `scrollIntoViewIfNeeded` operation after reload.

Reload alone was clean in the isolated reproductions. The trigger is revealing content inside the collapsed preview. The exact historical payload and browser version from the original report were not retained; the regression demonstrates the same visual bug class with a synthetic fixture.

## Why This Change Was Made

The legacy five-line clamp compresses later Markdown paragraph boxes, while `overflow: hidden` still permits browser-driven internal scrolling. Revealing those paragraphs exposes text that overlaps neighboring paragraphs. A bounded five-chat-line-height preview preserves the full natural Markdown layout instead, reusing the existing overflow observer, chevron, and expansion path.

This removes the legacy box/clamp declarations without adding another renderer, measurement path, dependency, or configuration option. Production LOC is +3/-3 (net zero). Tests are +168/-7. No Gateway, provider, protocol, or persistent-state changes are included.

## User Impact

Long user prompts remain readable when browser reveal operations bring later text into view. The compact preview, complete expanded prompt, short user messages, assistant messages, and adjacent transcript positioning remain covered.

## Evidence

- Failing-first desktop (1280×900) and mobile (390×844) regressions reproduce the overlap on the original CSS. Text-line bottoms exceed their paragraph boxes: 181px versus 163px on desktop, and 180.3125px versus 162.3125px on mobile.
- After the CSS repair, 15 tests passed across user-bubble disclosure, transcript disclosure anchoring, and Markdown alignment. A final four-test disclosure rerun passed after a type-safe adjustment to the adjacent-bubble assertions.
- Scoped `check:changed`, formatting, and `git diff --check` passed. Independent blocking-priority review found no actionable findings.
- Attached before/after captures were inspected in full and contain only synthetic fixture data. They come from real isolated Chromium pages rendering the built Control UI against the repository's mocked Gateway transport, with no application DOM/state injection.

Focused behavior proof:

```bash
OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts ui/src/e2e/chat-markdown-alignment.e2e.test.ts
```

Scoped checks:

```bash
node scripts/check-changed.mjs -- ui/src/styles/chat/text.css ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
```

One initial local cold-build attempt hit the runner's 300-second no-output watchdog during global setup, before assertions. The completed proof used the existing build-inactivity allowance shown above; no product timeout or test assertion deadline was changed. That build-progress issue is a separate tooling follow-up.

Browser proof covers isolated Chromium at desktop and mobile viewport sizes. Other browser engines and physical mobile devices were not tested. The focused patch, disclosure owner, direct renderer callers, Markdown path, virtualizer, test files, and mocked Gateway harness are unchanged on the selected current-main base; hosted CI validates the published head.

![Desktop before: browser reveal exposes overlapping collapsed paragraphs](https://github.com/user-attachments/assets/7ff8e3e3-b2a9-4dd1-904e-7e5e354f1dcd)

![Desktop after: revealed paragraphs retain natural readable layout](https://github.com/user-attachments/assets/cd4e2cc0-b46a-47ce-aaa8-bbf383a53028)

![Mobile before: revealed collapsed text overlaps](https://github.com/user-attachments/assets/2cdd544d-2f48-49b7-a91e-d94d84e8c9f5)

![Mobile after: revealed text remains readable within the compact preview](https://github.com/user-attachments/assets/1bb15e6b-c788-47cb-bb3e-f3b28d680ca1)