### PR TITLE
fix(packaging): preserve package markers and clean up smoke layouts

### DIFF
--- a/scripts/openclaw-postpack.mjs
+++ b/scripts/openclaw-postpack.mjs
@@ -15,13 +15,13 @@ import { restorePackageManifest } from "./package-manifest.mjs";
 export async function restorePrepackArtifacts(cwd = process.cwd()) {
   await restorePackageChangelog(cwd);
   await restorePackageManifest(cwd);
-  // Release the lifecycle receipt only after every other source mutation settles.
-  await restorePackageDocsMap(cwd);
   await Promise.all(
     [PACKAGE_LIFECYCLE_PENDING_RELATIVE_PATH, LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH].map(
       (relativePath) => rm(path.join(cwd, relativePath), { force: true }),
     ),
   );
+  // Release the lifecycle receipt only after every other source mutation settles.
+  await restorePackageDocsMap(cwd);
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/openclaw-prepack.ts
+++ b/scripts/openclaw-prepack.ts
@@ -276,12 +276,12 @@ async function writeDistInventory(): Promise<void> {
 
 export async function preparePrepackArtifacts(env: NodeJS.ProcessEnv = process.env): Promise<void> {
   ensurePreparedArtifacts();
-  await writeDistInventory();
   runBuildSmoke();
   // The docs-map receipt serializes source-mutating pack lifecycles before the
   // changelog is touched, so concurrent packs cannot restore each other's files.
   await preparePackageDocsMap(process.cwd());
   try {
+    await writeDistInventory();
     await preparePackageManifest(process.cwd());
     await preparePackageChangelog(process.cwd(), {
       allowUnreleased: resolvePrepackAllowUnreleasedChangelog(env),

--- a/scripts/package-openclaw-for-docker.mts
+++ b/scripts/package-openclaw-for-docker.mts
@@ -884,13 +884,13 @@ async function restorePackageSourceArtifacts(
 ) {
   await restoreChangelog(sourceDir);
   await restoreManifest(sourceDir);
-  // Release the lifecycle receipt only after every other source mutation settles.
-  await restoreDocsMap(sourceDir);
   await Promise.all(
     [PACKAGE_LIFECYCLE_PENDING_RELATIVE_PATH, LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH].map(
       (relativePath) => fs.rm(path.join(sourceDir, relativePath), { force: true }),
     ),
   );
+  // Release the lifecycle receipt only after every other source mutation settles.
+  await restoreDocsMap(sourceDir);
 }
 
 async function loadSourcePackageLifecycle(
@@ -984,6 +984,9 @@ export async function packOpenClawPackageForDocker(
     }
   };
   try {
+    console.error("==> Writing OpenClaw package inventory");
+    await writePackageInventoryForDocker(sourcePath, packageOptions.runImpl ?? run);
+
     await prepareManifest(sourcePath);
     await prepareChangelog(sourcePath);
   } catch (error) {
@@ -1151,9 +1154,6 @@ async function main() {
   if (!options.skipBuild) {
     await buildPackageArtifacts(sourceDir, { bundlePlugins: options.bundlePlugins });
   }
-
-  console.error("==> Writing OpenClaw package inventory");
-  await writePackageInventoryForDocker(sourceDir);
 
   const tarball = await packOpenClawPackageForDocker(sourceDir, outputDir, {
     bundlePlugins: options.bundlePlugins,

--- a/scripts/test-built-bundled-channel-entry-smoke.mts
+++ b/scripts/test-built-bundled-channel-entry-smoke.mts
@@ -55,18 +55,13 @@ function packageRootLooksInstalled(root: string) {
   return root.replaceAll("\\", "/").endsWith("/node_modules/openclaw");
 }
 
-function smokeInInstalledLayoutIfNeeded() {
-  if (process.env[installedLayoutEnv] === "1" || packageRootLooksInstalled(packageRoot)) {
-    return;
-  }
-
+function smokeInInstalledLayout() {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-smoke-"));
   const nodeModulesRoot = path.join(tempRoot, "node_modules");
   const installedPackageRoot = path.join(nodeModulesRoot, "openclaw");
-  fs.mkdirSync(nodeModulesRoot, { recursive: true });
-  fs.symlinkSync(packageRoot, installedPackageRoot, "dir");
-
   try {
+    fs.mkdirSync(nodeModulesRoot, { recursive: true });
+    fs.symlinkSync(packageRoot, installedPackageRoot, "dir");
     const result = spawnSync(
       process.execPath,
       [
@@ -80,13 +75,16 @@ function smokeInInstalledLayoutIfNeeded() {
         stdio: "inherit",
       },
     );
-    process.exit(result.status ?? 1);
+    return result.status ?? 1;
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
 }
 
-smokeInInstalledLayoutIfNeeded();
+if (process.env[installedLayoutEnv] !== "1" && !packageRootLooksInstalled(packageRoot)) {
+  // Let the layout owner's finally run before terminating this process.
+  process.exit(smokeInInstalledLayout());
+}
 
 async function importBuiltModule(absolutePath: string): Promise<unknown> {
   const imported: unknown = await import(pathToFileURL(absolutePath).href);

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -5,12 +5,16 @@ import { once } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import * as tar from "tar";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV } from "../../../../scripts/lib/bundled-plugin-build-entries.mjs";
 import { writePackageDistInventoryForPublish } from "../../../../scripts/lib/package-dist-inventory.ts";
+import {
+  preparePackageDocsMap,
+  restorePackageDocsMap,
+} from "../../../../scripts/package-docs-map.mjs";
 import {
   preparePackageManifest,
   restorePackageManifest,
@@ -25,6 +29,7 @@ import {
   writePackageInventoryForDocker,
 } from "../../../../scripts/package-openclaw-for-docker.mts";
 import { withEnvAsync } from "../../../../src/test-utils/env.js";
+import { createDeferred } from "../../../helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
 
 const skipBundledAiRuntime = async (): Promise<() => Promise<void>> => async () => {};
@@ -38,14 +43,39 @@ const skipDocsMapLifecycle = {
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const tsxImport = import.meta.resolve("tsx");
 
+function createPackageSourceFixture(prefix: string) {
+  const sourceDir = tempDirs.make(prefix);
+  fs.mkdirSync(path.join(sourceDir, "scripts"));
+  fs.mkdirSync(path.join(sourceDir, "node_modules"));
+  // The inventory child runs from this fixture; inherit its source owner's workspace aliases.
+  fs.writeFileSync(
+    path.join(sourceDir, "tsconfig.json"),
+    JSON.stringify({ extends: path.resolve("tsconfig.json") }),
+  );
+  // Run the canonical inventory producer against this fixture's files.
+  // Only tsx is linked; AI staging must retain its own writable node_modules tree.
+  const inventoryUrl = pathToFileURL(path.resolve("scripts/lib/package-dist-inventory.ts")).href;
+  fs.writeFileSync(
+    path.join(sourceDir, "scripts/write-package-dist-inventory.ts"),
+    `import(${JSON.stringify(inventoryUrl)}).then(({ writePackageDistInventoryForPublish }) => writePackageDistInventoryForPublish(process.cwd()));\n`,
+  );
+  fs.symlinkSync(
+    path.dirname(fileURLToPath(import.meta.resolve("tsx/package.json"))),
+    path.join(sourceDir, "node_modules/tsx"),
+    "junction",
+  );
+  return sourceDir;
+}
+
 function createSelectedPluginPackageFixture() {
-  const sourceDir = tempDirs.make("openclaw-selected-plugin-source-");
+  const sourceDir = createPackageSourceFixture("openclaw-selected-plugin-source-");
   const outputDir = tempDirs.make("openclaw-selected-plugin-output-");
   const packageJson = {
     name: "openclaw",
     version: "2026.8.1",
     files: [
       "dist",
+      ".openclaw-lifecycle-pending",
       "!dist/extensions/demo/**",
       "!dist/extensions/other/**",
       "!dist/extensions/*/node_modules/**",
@@ -150,9 +180,7 @@ async function waitForExit(
 describe("package-openclaw-for-docker", () => {
   it("packs explicitly selected plugin runtime and dependencies without changing the ordinary package", async () => {
     const { sourceDir, outputDir, files } = createSelectedPluginPackageFixture();
-    await writePackageDistInventoryForPublish(sourceDir);
     const inventoryPath = path.join(sourceDir, "dist/postinstall-inventory.json");
-    const originalInventory = fs.readFileSync(inventoryPath, "utf8");
     const options = {
       ...skipDocsMapLifecycle,
       prepareChangelog: async () => {},
@@ -165,6 +193,9 @@ describe("package-openclaw-for-docker", () => {
     const extractDir = tempDirs.make("openclaw-selected-plugin-extract-");
     await tar.x({ file: selected, cwd: extractDir });
     const packedRoot = path.join(extractDir, "package");
+    expect(fs.readFileSync(path.join(packedRoot, ".openclaw-lifecycle-pending"), "utf8")).toBe(
+      "pending\n",
+    );
     expect(fs.existsSync(path.join(packedRoot, "dist/extensions/demo/index.js"))).toBe(true);
     expect(fs.existsSync(path.join(packedRoot, "dist/shared-runtime.js"))).toBe(true);
     expect(fs.existsSync(path.join(packedRoot, "dist/extensions/other/index.js"))).toBe(false);
@@ -181,11 +212,13 @@ describe("package-openclaw-for-docker", () => {
     expect(fs.readFileSync(path.join(sourceDir, "package.json"), "utf8")).toBe(
       files["package.json"],
     );
-    expect(fs.readFileSync(inventoryPath, "utf8")).toBe(originalInventory);
+    expect(JSON.parse(fs.readFileSync(inventoryPath, "utf8"))).toEqual(["dist/shared-runtime.js"]);
+    expect(fs.existsSync(path.join(sourceDir, ".openclaw-lifecycle-pending"))).toBe(false);
 
     const ordinary = await packOpenClawPackageForDocker(sourceDir, outputDir, options);
     const ordinaryEntries: string[] = [];
     await tar.t({ file: ordinary, onentry: (entry) => ordinaryEntries.push(entry.path) });
+    expect(ordinaryEntries).toContain("package/.openclaw-lifecycle-pending");
     expect(ordinaryEntries.some((entry) => entry.startsWith("package/dist/extensions/demo/"))).toBe(
       false,
     );
@@ -448,7 +481,11 @@ describe("package-openclaw-for-docker", () => {
       expect(fs.readFileSync(path.join(sourceDir, "package.json"), "utf8")).toBe(
         files["package.json"],
       );
-      expect(fs.existsSync(path.join(sourceDir, "dist/postinstall-inventory.json"))).toBe(false);
+      expect(
+        JSON.parse(
+          fs.readFileSync(path.join(sourceDir, "dist/postinstall-inventory.json"), "utf8"),
+        ),
+      ).toEqual(["dist/shared-runtime.js"]);
     },
   );
 
@@ -470,7 +507,9 @@ describe("package-openclaw-for-docker", () => {
     expect(fs.readFileSync(path.join(sourceDir, "package.json"), "utf8")).toBe(
       files["package.json"],
     );
-    expect(fs.existsSync(path.join(sourceDir, "dist/postinstall-inventory.json"))).toBe(false);
+    expect(
+      JSON.parse(fs.readFileSync(path.join(sourceDir, "dist/postinstall-inventory.json"), "utf8")),
+    ).toEqual(["dist/shared-runtime.js"]);
     expect(fs.existsSync(path.join(sourceDir, "dist/openclaw-install-guard"))).toBe(false);
     expect(fs.existsSync(path.join(sourceDir, ".openclaw-lifecycle-pending"))).toBe(false);
   });
@@ -567,6 +606,7 @@ describe("package-openclaw-for-docker", () => {
     );
     fs.writeFileSync(path.join(sourceDir, "node_modules", "tsx", "loader.mjs"), "export {};\n");
     fs.writeFileSync(path.join(sourceDir, "dist", "entry.js"), "export {};\n");
+    fs.writeFileSync(path.join(sourceDir, "dist", "not-in-frozen-inventory.js"), "export {};\n");
     fs.writeFileSync(
       path.join(sourceDir, "scripts", "write-package-dist-inventory.ts"),
       [
@@ -585,10 +625,7 @@ describe("package-openclaw-for-docker", () => {
             .href,
           path.join(sourceDir, "scripts", "write-package-dist-inventory.ts"),
         ]);
-        fs.writeFileSync(
-          path.join(sourceDir, "dist", "postinstall-inventory.json"),
-          JSON.stringify(["dist/entry.js"]),
-        );
+        await runCommandForTest(command, args, cwd);
       },
     );
 
@@ -717,7 +754,7 @@ describe("package-openclaw-for-docker", () => {
   });
 
   it("omits stale hashed dist output when frozen sources expose only their own build", async () => {
-    const sourceDir = tempDirs.make("openclaw-package-clean-dist-source-");
+    const sourceDir = createPackageSourceFixture("openclaw-package-clean-dist-source-");
     const outputDir = tempDirs.make("openclaw-package-clean-dist-output-");
     const stalePath = path.join(sourceDir, "dist", "runtime-OLDHASH.js");
     fs.mkdirSync(path.dirname(stalePath));
@@ -758,7 +795,7 @@ describe("package-openclaw-for-docker", () => {
   it.skipIf(process.platform === "win32")(
     "reports the final artifact after normalizing owner-only packed modes",
     async () => {
-      const sourceDir = tempDirs.make("openclaw-package-modes-source-");
+      const sourceDir = createPackageSourceFixture("openclaw-package-modes-source-");
       const outputDir = tempDirs.make("openclaw-package-modes-output-");
       const distDir = path.join(sourceDir, "dist");
       // A restrictive-umask build host leaves owner-only sources on disk;
@@ -1004,7 +1041,7 @@ describe("package-openclaw-for-docker", () => {
   });
 
   it("reuses the source manifest lifecycle for ignore-scripts package artifacts", async () => {
-    const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docker-manifest-source-"));
+    const sourceDir = createPackageSourceFixture("openclaw-docker-manifest-source-");
     const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docker-manifest-output-"));
     const scriptsDir = path.join(sourceDir, "scripts");
     const packageJsonPath = path.join(sourceDir, "package.json");
@@ -1023,7 +1060,7 @@ describe("package-openclaw-for-docker", () => {
     const aiPackageJsonPath = path.join(sourceDir, "packages", "ai", "package.json");
     const originalAiPackageJson =
       '{"name":"@openclaw/ai","devDependencies":{"@openclaw/normalization-core":"workspace:*"}}\n';
-    fs.mkdirSync(scriptsDir);
+    fs.mkdirSync(scriptsDir, { recursive: true });
     fs.mkdirSync(path.dirname(aiPackageJsonPath), { recursive: true });
     fs.copyFileSync(
       path.join(process.cwd(), "scripts", "package-manifest.mjs"),
@@ -1136,8 +1173,10 @@ describe("package-openclaw-for-docker", () => {
   });
 
   it("trims and restores the changelog around ignore-scripts package artifacts", async () => {
+    const outputDir = tempDirs.make("openclaw-package-output-");
+    const sourceDir = createPackageSourceFixture("openclaw-package-source-");
     const calls: string[] = [];
-    const tarball = await packOpenClawPackageForDocker("/repo", "/out", {
+    const tarball = await packOpenClawPackageForDocker(sourceDir, outputDir, {
       ...skipTarballModeNormalization,
       prepareBundledAiRuntime: skipBundledAiRuntime,
       prepareChangelog: async (cwd: string) => {
@@ -1158,13 +1197,13 @@ describe("package-openclaw-for-docker", () => {
       },
     });
 
-    expect(tarball).toBe(path.join("/out", "openclaw-2026.5.28.tgz"));
+    expect(tarball).toBe(path.join(outputDir, "openclaw-2026.5.28.tgz"));
     expect(calls).toEqual([
-      "prepare-docs:/repo",
-      "prepare:/repo",
-      "npm:pack --silent --ignore-scripts --pack-destination /out --json=false:/repo",
-      "restore-changelog:/repo",
-      "restore-docs:/repo",
+      `prepare-docs:${sourceDir}`,
+      `prepare:${sourceDir}`,
+      `npm:pack --silent --ignore-scripts --pack-destination ${outputDir} --json=false:${sourceDir}`,
+      `restore-changelog:${sourceDir}`,
+      `restore-docs:${sourceDir}`,
     ]);
   });
 
@@ -1184,12 +1223,98 @@ describe("package-openclaw-for-docker", () => {
     expect(calls).toEqual(["prepare-docs"]);
   });
 
+  it.each([false, true])(
+    "preserves the next package's marker after a failed=%s owner releases its receipt",
+    async (firstFails) => {
+      const { sourceDir, outputDir, files } = createSelectedPluginPackageFixture();
+      const secondOutput = tempDirs.make("openclaw-next-package-");
+      const rejectedOutput = tempDirs.make("openclaw-rejected-package-");
+      fs.mkdirSync(path.join(sourceDir, "docs"));
+      fs.writeFileSync(path.join(sourceDir, "docs/page.md"), "# Package docs\n");
+      const sourceChangelog =
+        "# Changelog\n\n## 2026.8.1\n- Current package notes with enough detail.\n";
+      fs.writeFileSync(path.join(sourceDir, "CHANGELOG.md"), sourceChangelog);
+      await writePackageDistInventoryForPublish(sourceDir);
+      const markerPath = path.join(sourceDir, ".openclaw-lifecycle-pending");
+      const receiptPath = path.join(sourceDir, ".artifacts/package-docs-map/receipt.json");
+      const lifecycle = {
+        ...skipTarballModeNormalization,
+        prepareDocsMap: preparePackageDocsMap,
+        restoreDocsMap: restorePackageDocsMap,
+        prepareManifest: preparePackageManifest,
+        restoreManifest: restorePackageManifest,
+      };
+      const ready = createDeferred<void>();
+      const finishSecond = createDeferred<void>();
+      let second: Promise<string> | undefined;
+      let markerAtCapture: string | undefined;
+      const firstError = new Error("first pack failed");
+      const first = packOpenClawPackageForDocker(sourceDir, outputDir, {
+        ...lifecycle,
+        runCaptureImpl: async () => {
+          const receipt = fs.readFileSync(receiptPath, "utf8");
+          const marker = fs.readFileSync(markerPath, "utf8");
+          await expect(
+            packOpenClawPackageForDocker(sourceDir, rejectedOutput, lifecycle),
+          ).rejects.toMatchObject({ code: "PACKAGE_DOCS_MAP_ACTIVE" });
+          expect(fs.readFileSync(receiptPath, "utf8")).toBe(receipt);
+          expect(fs.readFileSync(markerPath, "utf8")).toBe(marker);
+          if (firstFails) {
+            throw firstError;
+          }
+          fs.writeFileSync(path.join(outputDir, "openclaw-2026.8.1.tgz"), "package");
+          return "openclaw-2026.8.1.tgz\n";
+        },
+        restoreDocsMap: async (cwd) => {
+          await restorePackageDocsMap(cwd);
+          second = packOpenClawPackageForDocker(sourceDir, secondOutput, {
+            ...lifecycle,
+            runCaptureImpl: async () => {
+              markerAtCapture = fs.readFileSync(markerPath, "utf8");
+              ready.resolve();
+              await finishSecond.promise;
+              fs.writeFileSync(path.join(secondOutput, "openclaw-2026.8.1.tgz"), "package");
+              return "openclaw-2026.8.1.tgz\n";
+            },
+          });
+          void second.catch(ready.reject);
+          await ready.promise;
+        },
+      }).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+
+      let markerAfterFirst: string | undefined;
+      const firstResult = await first;
+      try {
+        markerAfterFirst = fs.existsSync(markerPath)
+          ? fs.readFileSync(markerPath, "utf8")
+          : undefined;
+      } finally {
+        finishSecond.resolve();
+        await second;
+      }
+      expect(firstResult).toBe(firstFails ? firstError : undefined);
+      expect(second).toBeDefined();
+      expect(markerAtCapture).toBe("pending\n");
+      expect(markerAfterFirst).toBe("pending\n");
+      expect(fs.existsSync(markerPath)).toBe(false);
+      expect(fs.existsSync(receiptPath)).toBe(false);
+      expect(fs.readFileSync(path.join(sourceDir, "package.json"), "utf8")).toBe(
+        files["package.json"],
+      );
+      expect(fs.readFileSync(path.join(sourceDir, "CHANGELOG.md"), "utf8")).toBe(sourceChangelog);
+    },
+  );
+
   it("keeps the docs-map lock when changelog restoration fails", async () => {
+    const sourceDir = createPackageSourceFixture("openclaw-package-source-");
     const outputDir = tempDirs.make("openclaw-package-restore-order-");
     const calls: string[] = [];
 
     await expect(
-      packOpenClawPackageForDocker("/repo", outputDir, {
+      packOpenClawPackageForDocker(sourceDir, outputDir, {
         prepareBundledAiRuntime: skipBundledAiRuntime,
         prepareChangelog: async () => {},
         prepareDocsMap: async () => {},
@@ -1212,7 +1337,7 @@ describe("package-openclaw-for-docker", () => {
   });
 
   it("packages Unreleased notes for explicitly non-publish stable artifacts", async () => {
-    const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-unreleased-package-"));
+    const sourceDir = createPackageSourceFixture("openclaw-unreleased-package-");
     const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-unreleased-output-"));
     const sourceChangelog = [
       "# Changelog",
@@ -1232,7 +1357,7 @@ describe("package-openclaw-for-docker", () => {
     fs.writeFileSync(path.join(sourceDir, "CHANGELOG.md"), sourceChangelog);
     fs.mkdirSync(path.join(sourceDir, "docs"));
     fs.writeFileSync(path.join(sourceDir, "docs", "page.md"), "# Package page\n");
-    fs.mkdirSync(path.join(sourceDir, "scripts"));
+    fs.mkdirSync(path.join(sourceDir, "scripts"), { recursive: true });
     fs.copyFileSync(
       path.join(process.cwd(), "scripts", "package-docs-map.mjs"),
       path.join(sourceDir, "scripts", "package-docs-map.mjs"),
@@ -1269,8 +1394,8 @@ describe("package-openclaw-for-docker", () => {
     }
   });
 
-  it("keeps a frozen pre-map source package byte-owned by that ref", async () => {
-    const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-frozen-package-"));
+  it("keeps the docs surface of a pre-map source package unchanged", async () => {
+    const sourceDir = createPackageSourceFixture("openclaw-frozen-package-");
     const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-frozen-output-"));
     const docsDir = path.join(sourceDir, "docs");
     fs.mkdirSync(docsDir);
@@ -1307,12 +1432,13 @@ describe("package-openclaw-for-docker", () => {
   });
 
   it("uses pnpm pack when requested", async () => {
+    const sourceDir = createPackageSourceFixture("openclaw-package-source-");
     const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pnpm-pack-"));
     const calls: string[] = [];
     const packedPath = path.join(outputDir, "openclaw-2026.5.28.tgz");
 
     try {
-      const tarball = await packOpenClawPackageForDocker("/repo", outputDir, {
+      const tarball = await packOpenClawPackageForDocker(sourceDir, outputDir, {
         ...skipDocsMapLifecycle,
         ...skipTarballModeNormalization,
         pnpmPack: true,
@@ -1328,7 +1454,7 @@ describe("package-openclaw-for-docker", () => {
 
       expect(tarball).toBe(packedPath);
       expect(calls).toEqual([
-        `pnpm:pack --silent --config.ignore-scripts=true --pack-destination ${outputDir}:/repo`,
+        `pnpm:pack --silent --config.ignore-scripts=true --pack-destination ${outputDir}:${sourceDir}`,
       ]);
     } finally {
       fs.rmSync(outputDir, { force: true, recursive: true });
@@ -1336,7 +1462,7 @@ describe("package-openclaw-for-docker", () => {
   });
 
   it("normalizes npm 12 pack metadata for renamed package artifacts", async () => {
-    const sourceDir = tempDirs.make("openclaw-docker-pack-source-");
+    const sourceDir = createPackageSourceFixture("openclaw-docker-pack-source-");
     const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docker-pack-json-"));
     const packJsonPath = path.join(outputDir, "pack.json");
     const npmPackOutput = JSON.stringify({
@@ -1402,6 +1528,7 @@ describe("package-openclaw-for-docker", () => {
   });
 
   it("cleans receipts without obscuring runner and parse failures", async () => {
+    const sourceDir = createPackageSourceFixture("openclaw-package-source-");
     const originalRm = fs.promises.rm.bind(fs.promises);
     for (const failure of ["runner", "parse"] as const) {
       for (const cleanupFails of [false, true]) {
@@ -1415,7 +1542,7 @@ describe("package-openclaw-for-docker", () => {
           return await originalRm(target, options);
         });
         try {
-          const packPromise = packOpenClawPackageForDocker("/repo", outputDir, {
+          const packPromise = packOpenClawPackageForDocker(sourceDir, outputDir, {
             ...skipDocsMapLifecycle,
             ...skipTarballModeNormalization,
             packJsonPath: path.join(outputDir, "pack.json"),
@@ -1459,6 +1586,8 @@ describe("package-openclaw-for-docker", () => {
   });
 
   it("rejects path-like npm pack stdout before resolving Docker package tarballs", async () => {
+    const outputDir = tempDirs.make("openclaw-package-output-");
+    const sourceDir = createPackageSourceFixture("openclaw-package-source-");
     for (const filename of [
       "../openclaw-2026.6.17.tgz",
       "/tmp/openclaw-2026.6.17.tgz",
@@ -1468,7 +1597,7 @@ describe("package-openclaw-for-docker", () => {
       "openclaw-C:evil.tgz",
     ]) {
       await expect(
-        packOpenClawPackageForDocker("/repo", "/out", {
+        packOpenClawPackageForDocker(sourceDir, outputDir, {
           ...skipDocsMapLifecycle,
           prepareBundledAiRuntime: skipBundledAiRuntime,
           prepareChangelog: async () => {},
@@ -1480,6 +1609,7 @@ describe("package-openclaw-for-docker", () => {
   });
 
   it("ignores unsafe output directory tarball names when npm stdout is not usable", async () => {
+    const sourceDir = createPackageSourceFixture("openclaw-package-source-");
     const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docker-pack-"));
     try {
       if (process.platform === "win32") {
@@ -1491,7 +1621,7 @@ describe("package-openclaw-for-docker", () => {
         fs.writeFileSync(path.join(outputDir, String.raw`openclaw-nested\evil.tgz`), "");
       }
       await expect(
-        packOpenClawPackageForDocker("/repo", outputDir, {
+        packOpenClawPackageForDocker(sourceDir, outputDir, {
           ...skipDocsMapLifecycle,
           prepareBundledAiRuntime: skipBundledAiRuntime,
           prepareChangelog: async () => {},
@@ -1501,7 +1631,7 @@ describe("package-openclaw-for-docker", () => {
       ).rejects.toThrow("missing packed OpenClaw tarball");
 
       await expect(
-        packOpenClawPackageForDocker("/repo", outputDir, {
+        packOpenClawPackageForDocker(sourceDir, outputDir, {
           ...skipDocsMapLifecycle,
           ...skipTarballModeNormalization,
           prepareBundledAiRuntime: skipBundledAiRuntime,
@@ -1519,12 +1649,13 @@ describe("package-openclaw-for-docker", () => {
   });
 
   it("ignores stale package tarballs before fallback scanning npm output", async () => {
+    const sourceDir = createPackageSourceFixture("openclaw-package-source-");
     const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docker-pack-stale-"));
     try {
       fs.writeFileSync(path.join(outputDir, "openclaw-9999.1.1.tgz"), "stale");
 
       await expect(
-        packOpenClawPackageForDocker("/repo", outputDir, {
+        packOpenClawPackageForDocker(sourceDir, outputDir, {
           ...skipDocsMapLifecycle,
           ...skipTarballModeNormalization,
           prepareBundledAiRuntime: skipBundledAiRuntime,
@@ -1547,10 +1678,12 @@ describe("package-openclaw-for-docker", () => {
   });
 
   it("restores the changelog when ignore-scripts packaging fails", async () => {
+    const outputDir = tempDirs.make("openclaw-package-output-");
+    const sourceDir = createPackageSourceFixture("openclaw-package-source-");
     const calls: string[] = [];
 
     await expect(
-      packOpenClawPackageForDocker("/repo", "/out", {
+      packOpenClawPackageForDocker(sourceDir, outputDir, {
         ...skipDocsMapLifecycle,
         prepareBundledAiRuntime: async () => {
           calls.push("embed");
@@ -1571,7 +1704,13 @@ describe("package-openclaw-for-docker", () => {
       }),
     ).rejects.toThrow("pack failed");
 
-    expect(calls).toEqual(["prepare:/repo", "embed", "pack", "cleanup", "restore-changelog:/repo"]);
+    expect(calls).toEqual([
+      `prepare:${sourceDir}`,
+      "embed",
+      "pack",
+      "cleanup",
+      `restore-changelog:${sourceDir}`,
+    ]);
   });
 
   it("clamps oversized command timers before scheduling", async () => {
@@ -1772,6 +1911,7 @@ describe("package-openclaw-for-docker", () => {
     if (process.platform === "win32") {
       return;
     }
+    const sourceDir = createPackageSourceFixture("openclaw-package-source-");
     const tempDir = tempDirs.make("openclaw-package-receipt-signal-");
     const markerPath = path.join(tempDir, "restored");
     const scriptUrl = pathToFileURL(path.resolve("scripts/package-openclaw-for-docker.mts")).href;
@@ -1781,7 +1921,7 @@ const readFile = fs.promises.readFile.bind(fs.promises);
 fs.promises.readFile = async (...args) => { if (String(args[0]).endsWith("/pack.json")) { process.kill(process.pid, "SIGTERM"); await new Promise((resolve) => setTimeout(resolve, 50)); } return await readFile(...args); };
 const { packOpenClawPackageForDocker } = await import(${JSON.stringify(scriptUrl)});
 try {
-  await packOpenClawPackageForDocker("/repo", ${JSON.stringify(tempDir)}, { packJsonPath: "result.json", normalizeTarballModes: async () => {}, prepareBundledAiRuntime: async () => async () => {}, prepareChangelog: async () => {}, prepareDocsMap: async () => {}, prepareManifest: async () => {}, restoreChangelog: async () => {}, restoreDocsMap: async () => { fs.writeFileSync(${JSON.stringify(markerPath)}, "done"); }, restoreManifest: async () => {}, runCaptureImpl: async (_command, _args, _cwd, options) => { if (options.stdoutFilePath) fs.writeFileSync(options.stdoutFilePath, '[{"filename":"openclaw-2026.5.28.tgz"}]'); fs.writeFileSync(${JSON.stringify(path.join(tempDir, "openclaw-2026.5.28.tgz"))}, "package"); return "openclaw-2026.5.28.tgz\\n"; } });
+  await packOpenClawPackageForDocker(${JSON.stringify(sourceDir)}, ${JSON.stringify(tempDir)}, { packJsonPath: "result.json", normalizeTarballModes: async () => {}, prepareBundledAiRuntime: async () => async () => {}, prepareChangelog: async () => {}, prepareDocsMap: async () => {}, prepareManifest: async () => {}, restoreChangelog: async () => {}, restoreDocsMap: async () => { fs.writeFileSync(${JSON.stringify(markerPath)}, "done"); }, restoreManifest: async () => {}, runCaptureImpl: async (_command, _args, _cwd, options) => { if (options.stdoutFilePath) fs.writeFileSync(options.stdoutFilePath, '[{"filename":"openclaw-2026.5.28.tgz"}]'); fs.writeFileSync(${JSON.stringify(path.join(tempDir, "openclaw-2026.5.28.tgz"))}, "package"); return "openclaw-2026.5.28.tgz\\n"; } });
 } catch (error) { process.exit(error.exitCode ?? 1); }
 `;
     const runner = spawn(process.execPath, ["--input-type=module", "-e", runnerScript]);

--- a/test/openclaw-prepack.test.ts
+++ b/test/openclaw-prepack.test.ts
@@ -6,11 +6,14 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import * as tar from "tar";
 import { afterEach, describe, expect, it } from "vitest";
+import { restorePrepackArtifacts } from "../scripts/openclaw-postpack.mjs";
 import {
   collectPreparedPrepackErrors,
   collectSourcePackWorkspaceDependencyErrors,
@@ -20,6 +23,7 @@ import {
   resolvePrepackCommandTimeoutMs,
   runPrepackCommand,
 } from "../scripts/openclaw-prepack.ts";
+import { preparePackageDocsMap } from "../scripts/package-docs-map.mjs";
 import { useAutoCleanupTempDirTracker } from "./helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -40,7 +44,7 @@ const standaloneBundledChannelSmokeFiles = [
   "scripts/process-warning-filter.mts",
 ];
 
-function runStandaloneBundledChannelSmoke(entrySource: string) {
+function createBundledChannelSmokeFixture(entrySource: string, prepared = false) {
   const rootDir = tempDirs.make("openclaw-prepack-standalone-smoke-");
   for (const relativePath of standaloneBundledChannelSmokeFiles) {
     const destination = path.join(rootDir, relativePath);
@@ -48,7 +52,7 @@ function runStandaloneBundledChannelSmoke(entrySource: string) {
     copyFileSync(path.join(process.cwd(), relativePath), destination);
   }
 
-  const packageRoot = path.join(rootDir, "package");
+  const packageRoot = prepared ? rootDir : path.join(rootDir, "package");
   const extensionRoot = path.join(packageRoot, "dist", "extensions", "fixture-channel");
   mkdirSync(extensionRoot, { recursive: true });
   writeFileSync(path.join(packageRoot, "package.json"), '{"files":[]}\n');
@@ -60,6 +64,12 @@ function runStandaloneBundledChannelSmoke(entrySource: string) {
     })}\n`,
   );
   writeFileSync(path.join(extensionRoot, "index.js"), entrySource);
+
+  return { rootDir, packageRoot };
+}
+
+function runStandaloneBundledChannelSmoke(entrySource: string) {
+  const { rootDir, packageRoot } = createBundledChannelSmokeFixture(entrySource);
 
   return spawnSync(
     process.execPath,
@@ -101,6 +111,87 @@ describe("standalone bundled channel smoke", () => {
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("AssertionError");
   });
+});
+
+describe("prepared prepack ownership", () => {
+  it.each([
+    { invalid: false, incumbent: true },
+    { invalid: true, incumbent: false },
+    { invalid: true, incumbent: true },
+  ])(
+    "does not mutate source when smoke is invalid=$invalid and incumbent=$incumbent",
+    async ({ invalid, incumbent }) => {
+      const { rootDir } = createBundledChannelSmokeFixture(
+        invalid
+          ? "export default [];\n"
+          : 'export default { kind: "bundled-channel-entry", loadChannelPlugin() { return { id: "fixture-channel" }; } };\n',
+        true,
+      );
+      mkdirSync(path.join(rootDir, "node_modules"));
+      symlinkSync(
+        path.dirname(fileURLToPath(import.meta.resolve("tsx/package.json"))),
+        path.join(rootDir, "node_modules/tsx"),
+        "junction",
+      );
+      mkdirSync(path.join(rootDir, "docs"));
+      mkdirSync(path.join(rootDir, "dist/control-ui/assets"), { recursive: true });
+      const sourceFiles = {
+        "package.json":
+          '{"name":"openclaw","version":"2026.8.1","type":"module","files":["dist"]}\n',
+        "CHANGELOG.md": "# Changelog\n\n## 2026.8.1\n- Current release notes with enough detail.\n",
+        "docs/page.md": "# Package docs\n",
+        "dist/index.js": "export {};\n",
+        "dist/control-ui/index.html": "<!doctype html>\n",
+        "dist/control-ui/assets/fixture.js.br": "prepared asset fixture\n",
+        "dist/control-ui/assets/fixture.js.gz": "prepared asset fixture\n",
+      };
+      for (const [name, contents] of Object.entries(sourceFiles)) {
+        writeFileSync(path.join(rootDir, name), contents);
+      }
+      if (incumbent) {
+        await preparePackageDocsMap(rootDir);
+      }
+      const receiptPath = path.join(rootDir, ".artifacts/package-docs-map/receipt.json");
+      const receipt = incumbent ? readFileSync(receiptPath, "utf8") : undefined;
+      const ownerUrl = pathToFileURL(path.resolve("scripts/openclaw-prepack.ts")).href;
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--import",
+          import.meta.resolve("tsx"),
+          "--input-type=module",
+          "--eval",
+          `import { preparePrepackArtifacts } from ${JSON.stringify(ownerUrl)}; await preparePrepackArtifacts();`,
+        ],
+        {
+          cwd: rootDir,
+          encoding: "utf8",
+          timeout: 30_000,
+          stdio: ["ignore", "pipe", "pipe"],
+          env: {
+            ...process.env,
+            // The package fixture still imports the real owner's workspace source.
+            TSX_TSCONFIG_PATH: path.resolve("tsconfig.json"),
+          },
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.signal).toBeNull();
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(invalid ? "AssertionError" : "PACKAGE_DOCS_MAP_ACTIVE");
+      expect(existsSync(path.join(rootDir, ".openclaw-lifecycle-pending"))).toBe(false);
+      expect(existsSync(path.join(rootDir, "dist/postinstall-inventory.json"))).toBe(false);
+      for (const [name, contents] of Object.entries(sourceFiles)) {
+        expect(readFileSync(path.join(rootDir, name), "utf8")).toBe(contents);
+      }
+      if (incumbent) {
+        expect(readFileSync(receiptPath, "utf8")).toBe(receipt);
+        await restorePrepackArtifacts(rootDir);
+      }
+      expect(existsSync(receiptPath)).toBe(false);
+    },
+  );
 });
 
 describe("collectSourcePackWorkspaceDependencyErrors", () => {

--- a/test/openclaw-prepack.test.ts
+++ b/test/openclaw-prepack.test.ts
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  renameSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -68,10 +69,34 @@ function createBundledChannelSmokeFixture(entrySource: string, prepared = false)
   return { rootDir, packageRoot };
 }
 
-function runStandaloneBundledChannelSmoke(entrySource: string) {
-  const { rootDir, packageRoot } = createBundledChannelSmokeFixture(entrySource);
+type BundledChannelSmokeLayout = "source" | "installed-env" | "installed-path";
 
-  return spawnSync(
+function runStandaloneBundledChannelSmoke(entrySource: string, layout: BundledChannelSmokeLayout) {
+  const fixture = createBundledChannelSmokeFixture(entrySource);
+  const { rootDir } = fixture;
+  let { packageRoot } = fixture;
+  if (layout === "installed-path") {
+    const installedRoot = path.join(rootDir, "node_modules", "openclaw");
+    mkdirSync(path.dirname(installedRoot), { recursive: true });
+    renameSync(packageRoot, installedRoot);
+    packageRoot = installedRoot;
+  }
+  const temporaryRoot = path.join(rootDir, "smoke-temp");
+  mkdirSync(temporaryRoot);
+  const sentinelPath = path.join(temporaryRoot, "unrelated.txt");
+  writeFileSync(sentinelPath, "preserve caller-owned temporary sibling\n");
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    TMPDIR: temporaryRoot,
+    TMP: temporaryRoot,
+    TEMP: temporaryRoot,
+  };
+  delete env.OPENCLAW_BUNDLED_CHANNEL_SMOKE_INSTALLED_LAYOUT;
+  if (layout === "installed-env") {
+    env.OPENCLAW_BUNDLED_CHANNEL_SMOKE_INSTALLED_LAYOUT = "1";
+  }
+
+  const result = spawnSync(
     process.execPath,
     [
       path.join(rootDir, "scripts", "test-built-bundled-channel-entry-smoke.mts"),
@@ -81,36 +106,54 @@ function runStandaloneBundledChannelSmoke(entrySource: string) {
     {
       cwd: rootDir,
       encoding: "utf8",
-      env: {
-        ...process.env,
-        OPENCLAW_BUNDLED_CHANNEL_SMOKE_INSTALLED_LAYOUT: "1",
-      },
+      env,
       stdio: ["ignore", "pipe", "pipe"],
     },
   );
+  return {
+    result,
+    temporaryEntries: readdirSync(temporaryRoot).toSorted(),
+    sentinel: readFileSync(sentinelPath, "utf8"),
+    entrySource: readFileSync(
+      path.join(packageRoot, "dist", "extensions", "fixture-channel", "index.js"),
+      "utf8",
+    ),
+  };
 }
 
 describe("standalone bundled channel smoke", () => {
-  it("runs without workspace packages linked at the root", () => {
-    const result = runStandaloneBundledChannelSmoke(`
-      export default {
-        kind: "bundled-channel-entry",
-        loadChannelPlugin() {
-          return { id: "fixture-channel" };
-        },
-      };
-    `);
-
-    expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain("channel=1");
-  });
-
-  it("rejects a non-record channel entry default export", () => {
-    const result = runStandaloneBundledChannelSmoke("export default [];\n");
-
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("AssertionError");
-  });
+  const layouts = ["source", "installed-env", "installed-path"] as const;
+  it.each(
+    layouts.flatMap((layout) => [
+      { layout, invalid: false },
+      { layout, invalid: true },
+    ]),
+  )(
+    "preserves the result and releases its layout for $layout with invalid=$invalid",
+    ({ layout, invalid }) => {
+      const entrySource = invalid
+        ? "export default [];\n"
+        : `export default {
+            kind: "bundled-channel-entry",
+            loadChannelPlugin() { return { id: "fixture-channel" }; },
+          };\n`;
+      const observed = runStandaloneBundledChannelSmoke(entrySource, layout);
+      const { result } = observed;
+      expect(result.error).toBeUndefined();
+      expect(result.signal).toBeNull();
+      expect(result.status, result.stderr).toBe(invalid ? 1 : 0);
+      if (invalid) {
+        expect(result.stderr).toContain("AssertionError");
+        expect(result.stdout).not.toContain("[build-smoke]");
+      } else {
+        expect(result.stdout).toContain("channel=1");
+        expect(result.stdout.match(/\[build-smoke\]/gu)).toHaveLength(1);
+      }
+      expect(observed.entrySource).toBe(entrySource);
+      expect(observed.sentinel).toBe("preserve caller-owned temporary sibling\n");
+      expect(observed.temporaryEntries).toEqual(["unrelated.txt"]);
+    },
+  );
 });
 
 describe("prepared prepack ownership", () => {

--- a/test/scripts/package-docs-map.test.ts
+++ b/test/scripts/package-docs-map.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { renderDocsHeadingMap } from "../../scripts/docs-list.js";
@@ -123,4 +123,28 @@ describe("package docs map", () => {
     expect(existsSync(changelogBackupPath)).toBe(false);
     expect(existsSync(receiptPath)).toBe(false);
   });
+
+  it.each([".openclaw-lifecycle-pending", "dist/openclaw-install-guard"])(
+    "retains the lifecycle lock when %s cannot be removed",
+    async (relativePath) => {
+      const root = makePackageRoot();
+      const markerPath = path.join(root, relativePath);
+      const receiptPath = path.join(root, ".artifacts/package-docs-map/receipt.json");
+      await preparePackageDocsMap(root);
+      await preparePackageChangelog(root);
+      mkdirSync(markerPath, { recursive: true });
+      writeFileSync(path.join(markerPath, "retain"), "filesystem fault fixture\n");
+
+      await expect(restorePrepackArtifacts(root)).rejects.toMatchObject({ code: "ERR_FS_EISDIR" });
+      expect(existsSync(receiptPath)).toBe(true);
+      await expect(preparePackageDocsMap(root)).rejects.toMatchObject({
+        code: "PACKAGE_DOCS_MAP_ACTIVE",
+      });
+
+      rmSync(markerPath, { recursive: true });
+      await restorePrepackArtifacts(root);
+      expect(existsSync(receiptPath)).toBe(false);
+      expect(readFileSync(path.join(root, "CHANGELOG.md"), "utf8")).toBe(sourceChangelog);
+    },
+  );
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers building overlapping packages could produce a tarball without `.openclaw-lifecycle-pending`, causing the canonical package checker to reject it. A rejected prepack attempt could write lifecycle artifacts before acquiring the packaging receipt. Source-layout channel smoke checks also left temporary layouts behind after both success and failure.

## Why This Change Was Made

Keep marker production and cleanup within the existing receipt owner's lifetime: acquire the receipt before writing the inventory, and remove the markers before releasing it. Smoke validation remains before receipt acquisition. Its temporary-layout owner now covers setup and returns the child status through `finally`; the CLI exits only after cleanup. Installed-layout selection, diagnostics and child exit behavior stay unchanged.

These fixes remove lifecycle ordering mistakes without new locks, retries, storage, configuration or consumer fallbacks. The final seven-file change has production LOC +16/−18 (net −2); tests/support net +298. The related marker-placement, receipt-acquisition and inventory work in #130538, #133908, #133980 and #134417 retains its existing responsibilities. The documentation design in #117477 is not adopted here.

## User Impact

Overlapping package jobs preserve the next owner's marker through successful and failed handoffs. Cleanup failures retain the receipt, preventing another package from starting while the previous owner's artifacts remain. Source-layout smoke checks remove their own temporary layout while preserving unrelated temporary files and the child's success or failure result.

## Evidence

- Linux package construction used independent baseline/fixed checkouts, normal frozen installs/builds and Node 24.19.0/pnpm 12.1.0: all eight lifecycle scenarios failed before and passed after. The baseline second overlapping tarball lacked the marker and failed the checker; first/sequential controls passed. All three fixed tarballs contained the marker and passed. [Recorded workflow](https://github.com/openclaw/openclaw/actions/runs/33439927536). This proves package construction/checker behavior, not an installed CLI or byte-for-byte reproducible builds; generated declaration names differed across revisions without an inferred cause or equivalence.
- Original maintained regressions exposed eleven owner/postcondition failures. Original-scope owner runs passed 80 cases in total with three existing Windows-only skips on macOS: Docker 54/3, prepack 18 and docs-map 8. Earlier fixture-resolution failures are retained; correcting the source configuration preserved assertions. Subsequent changes only formatted tests and used the existing typed promise helper with the same native API and scheduling. Managed Codex review found no findings within its default P0 scope.
- The original six-path canonical gate passed all 16 checks. Its wrapper then exited 125 after a 20-second Git-status postflight timeout. A later read-only audit matched the original source/dependency/tool/link and protected-checkout snapshots and confirmed closure. The original contemporaneous postflight remains incomplete; the later audit does not erase that timing gap.
- The smoke cleanup addendum reproduced two source-layout cleanup failures and four installed-layout controls through the real owner. The maintained six-case regression likewise failed only the two cleanup assertions before the fix, then passed all six afterward. It checks child exit/diagnostics, unchanged package bytes, preserved unrelated temporary siblings and absence of leaked layouts. The baseline evidence parser subsequently failed; actual native JSON and logs retain the two intended failures. Later filesystem checks preserve that temporal gap and do not claim complete clean/untracked status. After mechanical formatting, a separate managed P0–P2 review found no actionable findings, and the canonical two-path gate passed all 16 selected checks, including script/root type checks and script lint. All recorded original process instances were independently confirmed absent; an unrelated reused PID in the gate closure was not signaled.
- Earlier [Windows CI](https://github.com/openclaw/openclaw/actions/runs/33471585565/job/99742355800) ran the merge commit `ec2b6f99b33828b0e25a275a32d59bb6fb6222b6` (PR head `1df4510` plus base `0ccc900`) with Node 22.23.2/pnpm 12.1.0. Its packaging cases passed, but the durable gateway/cron process-identity test failed to observe shutdown before its deadline. Preparing the isolated Windows diagnostic checkout did not complete; the diagnostic test has not run. That historical failure is not dismissed as a harmless flake. Updated-head CI is now green as recorded below; the attempted separate Windows probe failed during source synchronization before executing tests and its lease was stopped.

- [CI run 33481573191, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33481573191) passed at exact PR head `4a6e815990f6809ffc70a740a798bc821a030345`: 126 successful jobs and 15 skipped, including both formerly failing compact Node jobs and `openclaw/ci-gate`. The first attempt failed in unchanged gateway participant-callback and responsive UI bootstrap tests. A diagnostic of the original gateway group at the actual tested merge `055ed660bef5509afe530f523cfd2eb621d0c5f1` passed 1,953 tests across 114 files and observed the callback once before finalization; it did not reproduce or explain the historical Linux failure. One failed-job CI rerun then passed, without changing source, assertions, timeouts, or test environment settings. Investigating those two historical failures remains follow-up work; no unrelated speculative repair is included. This addresses the latest ClawSweeper request for completed exact-head CI without claiming that a rerun establishes the original root cause.
- A fresh managed P0–P2 review of the complete seven-file branch found no actionable findings. The four production owners remain unchanged on current main outside this repair; receipt ownership is still the correct boundary.

Introduction provenance is unknown. The package defect was reproduced at `ca0bdb8db3fe6defc861022e38452b515ea953bb`; the smoke leak was reproduced at `1df4510509df9da38c747db279d2636fd26d219d` before the cleanup commit.

Fixes #134834
