### PR TITLE
refactor(ui): unify mock preview state and request handling

### DIFF
--- a/scripts/control-ui-mock-background-tasks.ts
+++ b/scripts/control-ui-mock-background-tasks.ts
@@ -77,50 +77,42 @@ export function buildBackgroundTasksMock(baseTime: number) {
     finishedTask(5, now),
   ];
   return {
-    "chat.history": {
-      cases: [
-        {
-          match: { sessionKey: taskSessionKey },
-          response: {
-            messages: [
-              historyMessage(
-                "user",
-                "Map the run-status indicator code and report the active execution path.",
-                baseTime + 40 * 60_000,
-              ),
-              historyMessage(
-                "assistant",
-                "Tracing task events from the gateway through the chat background-tasks rail.",
-                baseTime + 40 * 60_000 + 8_000,
-              ),
-            ],
-            sessionId: "control-ui-mock-task-session",
-            thinkingLevel: null,
-          },
-        },
-        {
-          match: { sessionKey: secondTaskSessionKey },
-          response: {
-            messages: [
-              historyMessage(
-                "user",
-                "Audit the gateway task-event scope guards.",
-                baseTime + 41 * 60_000,
-              ),
-              historyMessage(
-                "assistant",
-                "Comparing requester, owner, and child-session event routing.",
-                baseTime + 41 * 60_000 + 6_000,
-              ),
-            ],
-            sessionId: "control-ui-mock-task-session-2",
-            thinkingLevel: null,
-          },
-        },
-      ],
+    sessionTranscripts: {
+      [taskSessionKey]: {
+        messages: [
+          historyMessage(
+            "user",
+            "Map the run-status indicator code and report the active execution path.",
+            baseTime + 40 * 60_000,
+          ),
+          historyMessage(
+            "assistant",
+            "Tracing task events from the gateway through the chat background-tasks rail.",
+            baseTime + 40 * 60_000 + 8_000,
+          ),
+        ],
+        thinkingLevel: null,
+      },
+      [secondTaskSessionKey]: {
+        messages: [
+          historyMessage(
+            "user",
+            "Audit the gateway task-event scope guards.",
+            baseTime + 41 * 60_000,
+          ),
+          historyMessage(
+            "assistant",
+            "Comparing requester, owner, and child-session event routing.",
+            baseTime + 41 * 60_000 + 6_000,
+          ),
+        ],
+        thinkingLevel: null,
+      },
     },
-    // One live subagent task exercises the rail, collapsed badge, and running-task status row.
-    "tasks.list": { tasks },
-    "tasks.get": { cases: tasks.map(taskDetailCase) },
+    methodResponses: {
+      // One live subagent task exercises the rail, collapsed badge, and running-task status row.
+      "tasks.list": { tasks },
+      "tasks.get": { cases: tasks.map(taskDetailCase) },
+    },
   };
 }

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -5,10 +5,7 @@ import { fileURLToPath } from "node:url";
 import qrcode from "qrcode";
 import { createServer, type Plugin, type ViteDevServer } from "vite";
 import type {
-  RequestFrame,
   SystemAgentChatHistoryResult,
-  SystemAgentChatQuestion,
-  SystemAgentChatResult,
   SystemChangesListResult,
   UserProfile,
 } from "../packages/gateway-protocol/src/index.js";
@@ -48,6 +45,7 @@ import {
   buildPluginInspectMock,
   buildPluginSetEnabledMock,
 } from "./control-ui-mock-plugins.ts";
+import { createControlUiPreviewInitScript } from "./control-ui-mock-preview.ts";
 import { buildSkillWorkshopMocks } from "./control-ui-mock-skill-workshop.js";
 
 type CliOptions = {
@@ -92,7 +90,6 @@ const MOCK_ACTOR_MIRA: SessionActorFixture = {
 const MOCK_SESSION_OWNERS: readonly SessionActorFixture[] = [MOCK_ACTOR_PETER, MOCK_ACTOR_MIRA];
 
 const SESSION_PAGE_SIZE = 50;
-const TOTAL_MOCK_SESSIONS = 650;
 const TOTAL_TELEGRAM_SESSIONS = 180;
 const ATTENTION_FIXTURE_EXPIRES_AT = Date.parse("2099-01-01T00:00:00.000Z");
 const NARRATION_DEMO_SESSION_KEY = "agent:main:sidebar-narration-demo";
@@ -100,8 +97,6 @@ const NARRATION_DEMO_RUN_ID = "mock-sidebar-narration-run";
 const OBSERVER_DEMO_SESSION_KEY = "agent:main:session-observer-demo";
 const OBSERVER_DEMO_RUN_ID = "mock-session-observer-run";
 const PLAN_DEMO_RUN_ID = "mock-plan-run";
-const CUSTODIAN_CHAT_REPLY_DELAY_MS = 600;
-const CHAT_SEND_REPLY_DELAY_MS = 200;
 type UpdateFixture = {
   available: UpdateAvailable;
   runResponse: unknown;
@@ -395,8 +390,8 @@ function sessionRow(
   const { model, modelProvider, ...extra } = options;
   return createControlUiSessionRow(key, label, updatedAt, {
     contextTokens: 200_000,
-    model: (model as string | undefined) ?? "gpt-5.6-luna",
-    modelProvider: (modelProvider as string | undefined) ?? "openai",
+    model: model ?? "gpt-5.6-luna",
+    modelProvider: modelProvider ?? "openai",
     ...extra,
   });
 }
@@ -1290,7 +1285,7 @@ function buildScrollableChatHistory(baseTime: number): unknown[] {
   const messages: unknown[] = [
     chatHistoryMessage(
       "assistant",
-      `Mock Control UI is running with ${TOTAL_MOCK_SESSIONS} sessions. Open the chat picker, search for "telegram" or "claude", then use Load more repeatedly.`,
+      'Mock Control UI is running. Open the chat picker, search for "telegram" or "claude", then use Load more repeatedly.',
       baseTime,
     ),
   ];
@@ -1725,6 +1720,7 @@ async function createChatPickerScenario(
       activeRunIds: [PLAN_DEMO_RUN_ID],
       childSessions: ["agent:main:lisbon-trip", ...swarmChildRows.map((row) => row.key)],
       hasActiveRun: true,
+      status: "running",
       totalTokens: 170_000,
       totalTokensFresh: true,
       ...(fixture === "goal" ? { goal: activeGoal } : {}),
@@ -1947,12 +1943,6 @@ async function createChatPickerScenario(
       : fixture === "code-fences"
         ? buildCodeFenceChatHistory(baseTime)
         : buildScrollableChatHistory(baseTime);
-  const planSessionInfo = {
-    activeRunIds: [PLAN_DEMO_RUN_ID],
-    hasActiveRun: true,
-    key: "agent:main:main",
-    ...(fixture === "goal" ? { goal: activeGoal } : {}),
-  };
   const planInFlightRun = {
     runId: PLAN_DEMO_RUN_ID,
     text: "",
@@ -1967,13 +1957,7 @@ async function createChatPickerScenario(
       ],
     },
   };
-  const planChatHistory = {
-    messages: historyMessages,
-    sessionId: "session:agent:main:main",
-    sessionInfo: planSessionInfo,
-    inFlightRun: planInFlightRun,
-    thinkingLevel: null,
-  };
+  const backgroundTasks = buildBackgroundTasksMock(baseTime);
   const custodianHistory = {
     turns: [
       {
@@ -2104,6 +2088,11 @@ async function createChatPickerScenario(
     // so people-aware UI (People sort, Person grouping) is exercisable here.
     hasMultipleSessionSharingIdentities: true,
     historyMessages,
+    sessionGroups: ["Research"],
+    sessionTranscripts: {
+      ...backgroundTasks.sessionTranscripts,
+      "agent:main:main": { messages: historyMessages, inFlightRun: planInFlightRun },
+    },
     // Lights up the footer facepile and who's-online roster; the email-only
     // entry keeps the roster's no-display-name row exercised.
     presenceUsers: [
@@ -2147,36 +2136,8 @@ async function createChatPickerScenario(
       },
     ],
     methodResponses: {
-      ...buildBackgroundTasksMock(baseTime),
+      ...backgroundTasks.methodResponses,
       ...cronMocks,
-      "chat.history": {
-        cases: [{ match: { sessionKey: "agent:main:main" }, response: planChatHistory }],
-      },
-      "chat.startup": {
-        cases: [
-          {
-            match: { sessionKey: "agent:main:main" },
-            response: {
-              ...planChatHistory,
-              agentsList: {
-                agents: [
-                  {
-                    id: "main",
-                    identity: { name: "Molty" },
-                    name: "Molty",
-                    workspace: "/Users/peter/Projects/openclaw",
-                    workspaceGit: true,
-                  },
-                ],
-                defaultId: "main",
-                mainKey: "main",
-                scope: "agent",
-              },
-              metadata: { models: modelProviders.models },
-            },
-          },
-        ],
-      },
       "progressCard.get": { card: null },
       "users.self": { profile: selfProfile },
       // Talk settings page pickers: realtime catalog with the model/voice
@@ -2233,9 +2194,6 @@ async function createChatPickerScenario(
           ],
         },
       },
-      // Custom session group catalog so the sidebar's category zone (and its
-      // drag-reordering against built-in sections) is exercised in the mock.
-      "sessions.groups.list": { groups: [{ name: "Research", position: 0 }] },
       // Coding session catalogs so the sidebar's catalog sections (header
       // right-click menu, hide/restore preference) are exercised in the mock.
       // Ids must match registered plugin catalogs (`claude`, `codex`) or the
@@ -3091,7 +3049,13 @@ async function createChatPickerScenario(
       ],
     },
     sessionArchiveFiltering: true,
-    sessions: [...sessions, ...archivedSessions, mainChildRow, taxChildRow],
+    sessions: [
+      ...sessions,
+      ...archivedSessions,
+      ...telegramSessions,
+      ...claudeSessions,
+      taxChildRow,
+    ],
     sessionKey: fixture === "workboard" ? workboardMocks.sessionKey : "agent:main:main",
     workspace: "/Users/peter/Projects/openclaw",
     workspaceGit: true,
@@ -3102,178 +3066,12 @@ function escapeScriptContent(script: string): string {
   return script.replaceAll("</script", "<\\/script");
 }
 
-/** Adds the stateful mock surfaces the generic scenario fixture cannot express. */
-function installControlUiStatefulMocks(
-  custodianReplyDelayMs: number,
-  chatReplyDelayMs: number,
-): void {
-  type MockGatewayControls = {
-    deferNext: (method: string) => void;
-    emit: (event: string, payload: unknown) => void;
-    resolveDeferred: (method: string, payload: unknown) => void;
-  };
-  type MockWindow = Window & {
-    __OPENCLAW_NATIVE_CONTROL_AUTH__?: { gatewayUrl: string };
-    openclawControlUiE2eGateway?: MockGatewayControls;
-  };
-
-  const mockWindow = window as MockWindow;
-  // The WebSocket mock does not intercept HTTP. Bind startup to this preview
-  // before Vite's default Gateway URL can send synthetic avatars to port 18789.
-  const gatewayUrl = new URL(window.location.origin);
-  gatewayUrl.protocol = gatewayUrl.protocol === "https:" ? "wss:" : "ws:";
-  mockWindow["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = { gatewayUrl: gatewayUrl.origin };
-
-  const gateway = mockWindow.openclawControlUiE2eGateway;
-  const MockWebSocket = window.WebSocket;
-  if (!gateway || !MockWebSocket) {
-    return;
-  }
-  const sendDescriptor = Object.getOwnPropertyDescriptor(MockWebSocket.prototype, "send");
-  const originalSend = sendDescriptor?.value as WebSocket["send"] | undefined;
-  if (typeof originalSend !== "function") {
-    return;
-  }
-  const sendOriginal = (socket: WebSocket, data: Parameters<WebSocket["send"]>[0]): void => {
-    Reflect.apply(originalSend, socket, [data]);
-  };
-  const sessionTurns = new Map<string, number>();
-  MockWebSocket.prototype.send = function (data): void {
-    let frame: RequestFrame | null = null;
-    if (typeof data === "string") {
-      try {
-        frame = JSON.parse(data) as RequestFrame;
-      } catch {
-        frame = null;
-      }
-    }
-    if (frame?.type !== "req") {
-      sendOriginal(this, data);
-      return;
-    }
-
-    if (frame.method === "chat.send") {
-      const params =
-        frame.params && typeof frame.params === "object"
-          ? (frame.params as {
-              idempotencyKey?: unknown;
-              message?: unknown;
-              sessionKey?: unknown;
-            })
-          : {};
-      const runId =
-        typeof params.idempotencyKey === "string" && params.idempotencyKey.trim()
-          ? params.idempotencyKey
-          : "control-ui-mock-run";
-      const sessionKey =
-        typeof params.sessionKey === "string" && params.sessionKey.trim()
-          ? params.sessionKey
-          : "agent:main:main";
-      const message = typeof params.message === "string" ? params.message.trim() : "";
-      gateway.deferNext("chat.send");
-      sendOriginal(this, data);
-      window.setTimeout(() => {
-        gateway.resolveDeferred("chat.send", { runId, status: "started" });
-        window.setTimeout(
-          () =>
-            gateway.emit("chat", {
-              message: {
-                content: [{ text: `Mock reply: ${message || "message received"}`, type: "text" }],
-                role: "assistant",
-                timestamp: Date.now(),
-              },
-              runId,
-              seq: 1,
-              sessionKey,
-              state: "final",
-            }),
-          0,
-        );
-      }, chatReplyDelayMs);
-      return;
-    }
-
-    if (frame.method !== "openclaw.chat") {
-      sendOriginal(this, data);
-      return;
-    }
-
-    const params =
-      frame.params && typeof frame.params === "object"
-        ? (frame.params as { message?: unknown; sessionId?: unknown })
-        : {};
-    const sessionId =
-      typeof params.sessionId === "string" && params.sessionId.trim()
-        ? params.sessionId
-        : "control-ui-custodian-mock";
-    const message = typeof params.message === "string" ? params.message : undefined;
-    const turn = sessionTurns.get(sessionId) ?? 0;
-    sessionTurns.set(sessionId, turn + 1);
-    const channelQuestion = {
-      id: "mock-channel-choice",
-      header: "Channel setup",
-      question: "Which channel would you like to work on?",
-      options: [
-        {
-          label: "WhatsApp",
-          reply: "help me connect WhatsApp",
-          description: "Review linking and account status.",
-          recommended: true,
-        },
-        {
-          label: "Telegram",
-          reply: "help me connect Telegram",
-          description: "Review the bot token and delivery status.",
-        },
-        {
-          label: "Discord",
-          reply: "help me connect Discord",
-          description: "Review the bot and server connection.",
-        },
-      ],
-      isOther: true,
-    } satisfies SystemAgentChatQuestion;
-    const response: SystemAgentChatResult = message
-      ? message.toLowerCase().includes("channel")
-        ? {
-            sessionId,
-            reply: "I can help with that.\n\nChoose a channel to continue.",
-            action: "none",
-            question: channelQuestion,
-          }
-        : {
-            sessionId,
-            reply: `I checked the mock system. Everything looks healthy.\n\nThat was demo turn ${turn}.`,
-            action: "none",
-          }
-      : {
-          sessionId,
-          reply:
-            "Hi — I’m OpenClaw, your system caretaker.\n\nAsk me about setup, channels, or recent changes.",
-          action: "none",
-        };
-
-    // Defer before forwarding so the generic gateway records the request but
-    // cannot race its normal immediate response against this stateful reply.
-    gateway.deferNext("openclaw.chat");
-    sendOriginal(this, data);
-    window.setTimeout(
-      () => gateway.resolveDeferred("openclaw.chat", response),
-      message === undefined ? 0 : custodianReplyDelayMs,
-    );
-  };
-}
-
-function createStatefulMockInitScript(): string {
-  return `(() => { const __name = (target) => target; (${installControlUiStatefulMocks.toString()})(${CUSTODIAN_CHAT_REPLY_DELAY_MS}, ${CHAT_SEND_REPLY_DELAY_MS}); })();`;
-}
-
 function createMockGatewayPlugin(
   scenario: ControlUiMockGatewayScenario,
   fixture?: CliOptions["fixture"],
 ): Plugin {
   const initScript = escapeScriptContent(createControlUiMockGatewayInitScript(scenario));
-  const statefulInitScript = escapeScriptContent(createStatefulMockInitScript());
+  const statefulInitScript = escapeScriptContent(createControlUiPreviewInitScript());
   const bootstrapBody = JSON.stringify(createControlUiMockBootstrapConfig(scenario));
   const attachmentThemeToggle =
     fixture === "attachments"

--- a/scripts/control-ui-mock-preview.ts
+++ b/scripts/control-ui-mock-preview.ts
@@ -1,0 +1,115 @@
+import type {
+  SystemAgentChatQuestion,
+  SystemAgentChatResult,
+} from "../packages/gateway-protocol/src/index.js";
+import type { ControlUiMockGateway } from "../ui/src/test-helpers/control-ui-e2e.ts";
+
+// Serialized into the preview page; runtime dependencies must stay inside this function.
+function installControlUiPreview(): void {
+  const previewWindow = window as Window & {
+    __OPENCLAW_NATIVE_CONTROL_AUTH__?: { gatewayUrl: string };
+    openclawControlUiE2eGateway?: ControlUiMockGateway;
+  };
+  // The WebSocket mock does not intercept HTTP. Select this origin before
+  // application startup can send synthetic resources to the operator Gateway.
+  const gatewayUrl = new URL(window.location.origin);
+  gatewayUrl.protocol = gatewayUrl.protocol === "https:" ? "wss:" : "ws:";
+  previewWindow["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = { gatewayUrl: gatewayUrl.origin };
+
+  const gateway = previewWindow.openclawControlUiE2eGateway;
+  if (!gateway) {
+    throw new Error("Preview Gateway must be installed before its request handlers");
+  }
+
+  gateway.setRequestHandler("chat.send", ({ params, respond, emit }) => {
+    const input = params && typeof params === "object" ? (params as Record<string, unknown>) : {};
+    const runId =
+      typeof input.idempotencyKey === "string" && input.idempotencyKey.trim()
+        ? input.idempotencyKey
+        : "control-ui-mock-run";
+    const sessionKey =
+      typeof input.sessionKey === "string" && input.sessionKey.trim()
+        ? input.sessionKey
+        : "agent:main:main";
+    const message = typeof input.message === "string" ? input.message.trim() : "";
+    window.setTimeout(() => {
+      respond({ runId, status: "started" });
+      // The client must observe admission before the final event for this run.
+      window.setTimeout(
+        () =>
+          emit("chat", {
+            message: {
+              content: [{ text: `Mock reply: ${message || "message received"}`, type: "text" }],
+              role: "assistant",
+              timestamp: Date.now(),
+            },
+            runId,
+            seq: 1,
+            sessionKey,
+            state: "final",
+          }),
+        0,
+      );
+    }, 200);
+  });
+
+  const sessionTurns = new Map<string, number>();
+  const channelQuestion = {
+    id: "mock-channel-choice",
+    header: "Channel setup",
+    question: "Which channel would you like to work on?",
+    options: [
+      {
+        label: "WhatsApp",
+        reply: "help me connect WhatsApp",
+        description: "Review linking and account status.",
+        recommended: true,
+      },
+      {
+        label: "Telegram",
+        reply: "help me connect Telegram",
+        description: "Review the bot token and delivery status.",
+      },
+      {
+        label: "Discord",
+        reply: "help me connect Discord",
+        description: "Review the bot and server connection.",
+      },
+    ],
+    isOther: true,
+  } satisfies SystemAgentChatQuestion;
+  gateway.setRequestHandler("openclaw.chat", ({ params, respond }) => {
+    const input = params && typeof params === "object" ? (params as Record<string, unknown>) : {};
+    const sessionId =
+      typeof input.sessionId === "string" && input.sessionId.trim()
+        ? input.sessionId
+        : "control-ui-custodian-mock";
+    const message = typeof input.message === "string" ? input.message : undefined;
+    const turn = sessionTurns.get(sessionId) ?? 0;
+    sessionTurns.set(sessionId, turn + 1);
+    const response: SystemAgentChatResult = message
+      ? message.toLowerCase().includes("channel")
+        ? {
+            sessionId,
+            reply: "I can help with that.\n\nChoose a channel to continue.",
+            action: "none",
+            question: channelQuestion,
+          }
+        : {
+            sessionId,
+            reply: `I checked the mock system. Everything looks healthy.\n\nThat was demo turn ${turn}.`,
+            action: "none",
+          }
+      : {
+          sessionId,
+          reply:
+            "Hi — I’m OpenClaw, your system caretaker.\n\nAsk me about setup, channels, or recent changes.",
+          action: "none",
+        };
+    window.setTimeout(() => respond(response), message === undefined ? 0 : 600);
+  });
+}
+
+export function createControlUiPreviewInitScript(): string {
+  return `(() => { const __name = (target) => target; (${installControlUiPreview.toString()})(); })();`;
+}

--- a/ui/src/e2e/board-fixture.e2e.test.ts
+++ b/ui/src/e2e/board-fixture.e2e.test.ts
@@ -7,6 +7,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import { chromium, type Browser, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ApplicationRuntime } from "../app/bootstrap.ts";
 import {
   canRunPlaywrightChromium,
   resolvePlaywrightChromiumExecutablePath,
@@ -155,6 +156,22 @@ async function readMenuColors(page: Page): Promise<{ background: string; foregro
 let browser: Browser;
 let fixtureServer: FixtureServer;
 
+async function requestPreviewGateway(
+  page: Page,
+  requests: Array<{ method: string; params?: unknown }>,
+): Promise<unknown[]> {
+  return page.evaluate((batch) => {
+    const app = document.querySelector<HTMLElement & { runtime?: ApplicationRuntime }>(
+      "openclaw-app",
+    );
+    const client = app?.runtime?.context.gateway.snapshot.client;
+    if (!client) {
+      throw new Error("Preview Gateway client is unavailable");
+    }
+    return Promise.all(batch.map(({ method, params }) => client.request(method, params)));
+  }, requests);
+}
+
 describeStandaloneMockServer("standalone Control UI mock server", () => {
   beforeAll(async () => {
     fixtureServer = await startFixtureServer();
@@ -164,6 +181,132 @@ describeStandaloneMockServer("standalone Control UI mock server", () => {
   afterAll(async () => {
     await browser?.close();
     await stopFixtureServer(fixtureServer);
+  });
+
+  it("correlates concurrent caretaker replies with their original requests", async () => {
+    const page = await browser.newPage();
+    try {
+      await page.goto(new URL("/chat", fixtureServer.url).toString());
+      await page.getByRole("textbox", { name: "Message Molty" }).waitFor();
+      const replies = await requestPreviewGateway(page, [
+        { method: "openclaw.chat", params: { sessionId: "delayed", message: "hello" } },
+        { method: "openclaw.chat", params: { sessionId: "welcome" } },
+      ]);
+      expect(replies).toMatchObject([
+        { sessionId: "delayed", reply: expect.stringContaining("demo turn 0") },
+        { sessionId: "welcome", reply: expect.stringContaining("system caretaker") },
+      ]);
+    } finally {
+      await page.close();
+    }
+  });
+
+  it("keeps renamed preview groups authoritative across reads and reloads", async () => {
+    const page = await browser.newPage();
+    try {
+      await page.goto(new URL("/chat", fixtureServer.url).toString());
+      await page.getByRole("textbox", { name: "Message Molty" }).waitFor();
+      await requestPreviewGateway(page, [
+        { method: "sessions.groups.rename", params: { name: "Research", to: "Reviewed" } },
+      ]);
+      for (const reload of [false, true]) {
+        if (reload) {
+          await page.reload();
+          await page.getByRole("textbox", { name: "Message Molty" }).waitFor();
+        }
+        expect(await requestPreviewGateway(page, [{ method: "sessions.groups.list" }])).toEqual([
+          { groups: [{ name: "Reviewed", position: 0 }], sectionOrder: [] },
+        ]);
+      }
+    } finally {
+      await page.close();
+    }
+  });
+
+  it("serves background-task transcripts through both chat entry points", async () => {
+    const page = await browser.newPage();
+    try {
+      await page.goto(new URL("/chat", fixtureServer.url).toString());
+      await page.getByRole("textbox", { name: "Message Molty" }).waitFor();
+      const sessionKey = "agent:openclaw-mock:subagent:mock-task-1";
+      const [description] = (await requestPreviewGateway(page, [
+        { method: "sessions.describe", params: { key: sessionKey } },
+      ])) as Array<{ session: { sessionId: string } }>;
+      const replies = await requestPreviewGateway(
+        page,
+        ["chat.history", "chat.startup"].map((method) => ({
+          method,
+          params: { sessionKey },
+        })),
+      );
+      for (const reply of replies) {
+        expect(reply).toMatchObject({
+          sessionId: description!.session.sessionId,
+          messages: [
+            { role: "user", content: [{ text: expect.stringContaining("Map the run-status") }] },
+            {
+              role: "assistant",
+              content: [{ text: expect.stringContaining("Tracing task events") }],
+            },
+          ],
+        });
+      }
+    } finally {
+      await page.close();
+    }
+  });
+
+  it("keeps the main preview run active when hydrating canonical session metadata", async () => {
+    const page = await browser.newPage();
+    try {
+      await page.goto(new URL("/chat", fixtureServer.url).toString());
+      await page.getByRole("textbox", { name: "Message Molty" }).waitFor();
+      expect(
+        await requestPreviewGateway(page, [
+          { method: "chat.startup", params: { sessionKey: "agent:main:main" } },
+        ]),
+      ).toMatchObject([
+        {
+          sessionInfo: { hasActiveRun: true, status: "running", activeRunIds: ["mock-plan-run"] },
+          inFlightRun: { runId: "mock-plan-run" },
+        },
+      ]);
+      await page.getByRole("button", { name: "Stop generating" }).waitFor();
+    } finally {
+      await page.close();
+    }
+  });
+
+  it("keeps generated search-session metadata in the canonical fixture catalog", async () => {
+    const page = await browser.newPage();
+    try {
+      await page.goto(new URL("/chat", fixtureServer.url).toString());
+      await page.getByRole("textbox", { name: "Message Molty" }).waitFor();
+      const replies = await requestPreviewGateway(
+        page,
+        ["telegram", "claude"].map((search) => ({
+          method: "sessions.list",
+          params: { search },
+        })),
+      );
+      expect(replies).toMatchObject([
+        {
+          sessions: expect.arrayContaining([
+            expect.objectContaining({ label: "Telegram investigation 001", model: "gpt-5.6-luna" }),
+          ]),
+        },
+        {
+          sessions: expect.arrayContaining([
+            expect.objectContaining({
+              label: "Model search result 001",
+              model: "claude-sonnet-4-6",
+            }),
+          ]),
+        },
+      ]);
+    } finally {
+      await page.close();
+    }
   });
 
   it("keeps synthetic avatar requests on the preview origin across reloads", async () => {

--- a/ui/src/lib/identity-avatar-loader.ts
+++ b/ui/src/lib/identity-avatar-loader.ts
@@ -34,23 +34,18 @@ function clearIdentityAvatarCache(): void {
 // the owning Gateway or credential context changes.
 registerAvatarGatewayReset(clearIdentityAvatarCache);
 
-function trimIdentityAvatarCache(protectedEntry?: CachedIdentityAvatar): void {
-  while (identityAvatarCache.size > IDENTITY_AVATAR_CACHE_MAX_ENTRIES) {
-    let evicted = false;
-    for (const [key, entry] of identityAvatarCache) {
-      // Pending consumers still need their eventual blob. Only completed LRU
-      // entries may be evicted; the request currently resolving stays valid.
-      if (!entry.blobUrl || !entry.loaded || entry === protectedEntry) {
-        continue;
-      }
-      identityAvatarCache.delete(key);
-      URL.revokeObjectURL(entry.blobUrl);
-      evicted = true;
+function trimIdentityAvatarCache(): void {
+  for (const [key, entry] of identityAvatarCache) {
+    if (identityAvatarCache.size <= IDENTITY_AVATAR_CACHE_MAX_ENTRIES) {
       break;
     }
-    if (!evicted) {
-      break;
+    // Pending consumers still need their eventual blob. Only settled images
+    // may be evicted, in the Map's LRU order.
+    if (!entry.blobUrl || !entry.loaded) {
+      continue;
     }
+    identityAvatarCache.delete(key);
+    URL.revokeObjectURL(entry.blobUrl);
   }
 }
 
@@ -96,7 +91,7 @@ function loadIdentityAvatar(url: string): string | Promise<string | null> {
         return null;
       }
       entry.blobUrl = blobUrl;
-      trimIdentityAvatarCache(entry);
+      trimIdentityAvatarCache();
       return blobUrl;
     } catch {
       return null;
@@ -108,7 +103,7 @@ function loadIdentityAvatar(url: string): string | Promise<string | null> {
     }
   })();
   identityAvatarCache.set(url, entry);
-  trimIdentityAvatarCache(entry);
+  trimIdentityAvatarCache();
   return entry.promise;
 }
 
@@ -121,9 +116,7 @@ export function resolveAvatarImageUrl(value: string): string | Promise<string | 
   }
   // Connected same-origin routes need the loader too: it resolves a missing
   // avatar before Lit can reconcile an <img> error back over its initials.
-  const pageOrigin = globalThis.location?.origin;
-  const crossOrigin = pageOrigin ? new URL(trusted, pageOrigin).origin !== pageOrigin : false;
-  return origin || authHeader || crossOrigin ? loadIdentityAvatar(trusted) : trusted;
+  return origin || authHeader ? loadIdentityAvatar(trusted) : trusted;
 }
 
 /** A blob stays live until its image has finished loading or definitively failed. */

--- a/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
@@ -2,7 +2,11 @@
 // Exercises the serialized mock gateway exactly as a page would: the init
 // script installs MockWebSocket on window, and requests flow over it.
 import { describe, expect } from "vitest";
-import { createControlUiMockGatewayInitScript } from "./control-ui-e2e.ts";
+import {
+  createControlUiMockGatewayInitScript,
+  type ControlUiMockGateway,
+  type ControlUiMockRequestHandler,
+} from "./control-ui-e2e.ts";
 import { mockGatewayTest as it } from "./mock-gateway-page.test-support.ts";
 
 type ResponseFrame = {
@@ -23,6 +27,49 @@ function waitForMockCycle(): Promise<void> {
     setTimeout(resolve, 300);
   });
 }
+
+it("keeps handler responses and events on the requesting socket", async ({ gatewayPage }) => {
+  const { window, execute } = gatewayPage;
+  execute(createControlUiMockGatewayInitScript());
+  const gateway = (window as Window & { openclawControlUiE2eGateway?: ControlUiMockGateway })
+    .openclawControlUiE2eGateway;
+  if (!gateway) {
+    throw new Error("Mock Gateway was not installed");
+  }
+  const pending: Parameters<ControlUiMockRequestHandler>[0][] = [];
+  gateway.setRequestHandler("health", (request) => pending.push(request));
+  const sockets = [
+    new window.WebSocket("ws://mock/first"),
+    new window.WebSocket("ws://mock/second"),
+  ];
+  const frames: ResponseFrame[][] = [[], []];
+  for (const [index, socket] of sockets.entries()) {
+    socket.addEventListener("message", (event: MessageEvent) => {
+      const frame = JSON.parse(String(event.data)) as ResponseFrame;
+      if (frame.event !== "connect.challenge") {
+        frames[index]!.push(frame);
+      }
+    });
+  }
+  await flushMockTimers();
+  for (const [index, socket] of sockets.entries()) {
+    socket.send(
+      JSON.stringify({ type: "req", id: String(index), method: "health", params: { index } }),
+    );
+  }
+  await flushMockTimers();
+  expect(pending.map((request) => request.params)).toEqual([{ index: 0 }, { index: 1 }]);
+  for (const request of pending.toReversed()) {
+    request.respond(request.params);
+    request.emit("checked", request.params);
+  }
+  for (const index of [0, 1]) {
+    expect(frames[index]).toMatchObject([
+      { type: "res", id: String(index), ok: true, payload: { index } },
+      { type: "event", event: "checked", payload: { index } },
+    ]);
+  }
+});
 
 describe("mock gateway stateful config", () => {
   it("takes existing mock sockets offline without closing their replacement", async ({

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -337,6 +337,15 @@ export type ControlUiMockGatewayScenario = {
   /** Simulate a legacy Gateway that predates the advertised method catalog. */
   omitFeatureMethods?: boolean;
   historyMessages?: unknown[];
+  /** Canonical per-session transcripts, shared by history and startup reads. */
+  sessionTranscripts?: Record<
+    string,
+    {
+      messages: unknown[];
+      thinkingLevel?: string | null;
+      inFlightRun?: ControlUiMockGatewayScenario["inFlightRun"];
+    }
+  >;
   maxPayload?: number;
   /** Static payloads, parameter-matched cases, or call-ordered sequences. */
   methodResponses?: Record<string, unknown>;
@@ -959,6 +968,7 @@ function normalizeScenario(
     featureMethods: scenario.featureMethods ?? [...defaultControlUiFeatureMethods],
     omitFeatureMethods: scenario.omitFeatureMethods ?? false,
     historyMessages: scenario.historyMessages ?? [],
+    sessionTranscripts: scenario.sessionTranscripts ?? {},
     maxPayload: scenario.maxPayload ?? DEFAULT_MOCK_MAX_PAYLOAD_BYTES,
     mainSessionKey,
     methodResponses: scenario.methodResponses ?? {},
@@ -1034,6 +1044,45 @@ export function createControlUiMockGatewayInitScript(
   return `${json5BrowserSource}\n;(() => { const __name = (target) => target; (${installControlUiMockGateway.toString()})(${JSON.stringify(input)}, globalThis.JSON5.parse, ${createControlUiSessionFixtures.toString()}); })();`;
 }
 
+export type ControlUiMockRequestHandler = (request: {
+  params: unknown;
+  respond: (payload: unknown) => void;
+  emit: (event: string, payload: unknown) => void;
+}) => void;
+
+export type ControlUiMockGateway = {
+  closeLatest: (code?: number, reason?: string) => void;
+  deliverLatest: (frame: unknown) => void;
+  deferNext: (method: string, match?: Record<string, unknown>) => void;
+  emit: (event: string, payload?: unknown) => void;
+  findRequests: (method?: string) => MockGatewayRequest[];
+  rejectDeferred: (
+    method: string,
+    error?: { code?: string; message?: string; details?: unknown; retryable?: boolean },
+  ) => void;
+  requests: MockGatewayRequest[];
+  resolveDeferred: (method: string, payload?: unknown) => void;
+  suspendLatest: () => void;
+  setOnline: (online: boolean) => void;
+  setGatewayBootId: (bootId: string) => void;
+  setServerBuildId: (buildId: string) => void;
+  setOperatorScopes: (scopes: string[]) => void;
+  setHistoryMessages: (messages: unknown[]) => void;
+  setMethodResponse: (method: string, payload: unknown) => void;
+  setRequestHandler: (method: string, handler: ControlUiMockRequestHandler) => void;
+  setSessionSharingPolicy: (policy: {
+    allowedSessionVisibilities: Array<"shared" | "read-only" | "suggest" | "draft">;
+    hasMultipleSessionSharingIdentities: boolean;
+  }) => void;
+  socketCount: () => number;
+  socketStates: () => Array<{ readyState: number; state: string; url: string }>;
+  socketUrls: () => string[];
+};
+type MockGatewayWindow = Window & {
+  __OPENCLAW_CONTROL_UI_BASE_PATH__?: string;
+  openclawControlUiE2eGateway?: ControlUiMockGateway;
+};
+
 function installControlUiMockGateway(
   input: {
     protocolVersion: number;
@@ -1043,14 +1092,12 @@ function installControlUiMockGateway(
   createSessions: typeof createControlUiSessionFixtures,
 ) {
   const NativeWebSocket = window.WebSocket;
-  type BrowserRequest = { id: string; method: string; params?: unknown };
   type BrowserFrame = {
     id?: unknown;
     method?: unknown;
     params?: unknown;
     type?: unknown;
   };
-  type BrowserScenario = NormalizedControlUiMockGatewayScenario;
   type BrowserMethodResponseCase = {
     match?: Record<string, unknown>;
     response?: unknown;
@@ -1083,39 +1130,8 @@ function installControlUiMockGateway(
     buffer: string;
     seq: number;
   };
-  type ExposedGateway = {
-    closeLatest: (code?: number, reason?: string) => void;
-    deliverLatest: (frame: unknown) => void;
-    deferNext: (method: string, match?: Record<string, unknown>) => void;
-    emit: (event: string, payload?: unknown) => void;
-    findRequests: (method?: string) => BrowserRequest[];
-    rejectDeferred: (
-      method: string,
-      error?: { code?: string; message?: string; details?: unknown; retryable?: boolean },
-    ) => void;
-    requests: BrowserRequest[];
-    resolveDeferred: (method: string, payload?: unknown) => void;
-    suspendLatest: () => void;
-    setOnline: (online: boolean) => void;
-    setGatewayBootId: (bootId: string) => void;
-    setServerBuildId: (buildId: string) => void;
-    setOperatorScopes: (scopes: string[]) => void;
-    setHistoryMessages: (messages: unknown[]) => void;
-    setMethodResponse: (method: string, payload: unknown) => void;
-    setSessionSharingPolicy: (policy: {
-      allowedSessionVisibilities: Array<"shared" | "read-only" | "suggest" | "draft">;
-      hasMultipleSessionSharingIdentities: boolean;
-    }) => void;
-    socketCount: () => number;
-    socketStates: () => Array<{ readyState: number; state: string; url: string }>;
-    socketUrls: () => string[];
-  };
-  type WindowWithGateway = Window & {
-    __OPENCLAW_CONTROL_UI_BASE_PATH__?: string;
-    openclawControlUiE2eGateway?: ExposedGateway;
-  };
 
-  const scenario: BrowserScenario = input.scenario;
+  const scenario = input.scenario;
   const serverBuildIdStateKey = "openclaw.control-ui-e2e.serverBuildId";
   let serverBuildId = scenario.serverBuildId;
   let gatewayBootId =
@@ -1126,7 +1142,7 @@ function installControlUiMockGateway(
   } catch {
     // The scenario value remains authoritative when browser storage is unavailable.
   }
-  (window as unknown as WindowWithGateway)["__OPENCLAW_CONTROL_UI_BASE_PATH__"] = scenario.basePath;
+  (window as MockGatewayWindow)["__OPENCLAW_CONTROL_UI_BASE_PATH__"] = scenario.basePath;
   const protocolVersion = input.protocolVersion;
   const methodResponseOverridesStorageKey = "openclaw.control-ui-e2e.method-responses.v1";
   const methodResponseOverrides: Record<string, unknown> = {};
@@ -1143,7 +1159,8 @@ function installControlUiMockGateway(
   const deferredMethods: DeferredMethod[] = scenario.deferredMethods.map((method) => ({ method }));
   const heldMethods = new Set(scenario.heldMethods);
   const deferredResponses: DeferredResponse[] = [];
-  const requests: BrowserRequest[] = [];
+  const requests: MockGatewayRequest[] = [];
+  const requestHandlers = new Map<string, ControlUiMockRequestHandler>();
   const methodResponseSequenceIndexes = new Map<string, number>();
   const sessions = createSessions({
     rows: scenario.sessions,
@@ -1857,6 +1874,7 @@ function installControlUiMockGateway(
           ...(info || override ? { sessionInfo: { ...info, ...override } } : {}),
           thinkingLevel: null,
           ...(scenario.inFlightRun ? { inFlightRun: scenario.inFlightRun } : {}),
+          ...scenario.sessionTranscripts[row.key],
           ...(method === "chat.startup"
             ? {
                 metadata: { models: scenario.models },
@@ -2238,12 +2256,8 @@ function installControlUiMockGateway(
         deferredResponses.push({ id, method, params: frame.params, socket: this });
         return;
       }
-      window.setTimeout(() => {
-        const payload = commitSessionResponse(
-          method,
-          frame.params,
-          buildResponse(method, frame.params),
-        );
+      const respond = (response: unknown) => {
+        const payload = commitSessionResponse(method, frame.params, response);
         const mockError =
           isRecord(payload) && isRecord(payload["__mockError"]) ? payload["__mockError"] : null;
         this.deliver(
@@ -2279,6 +2293,20 @@ function installControlUiMockGateway(
             type: "event",
           });
         }
+      };
+      window.setTimeout(() => {
+        const handler = requestHandlers.get(method);
+        if (handler) {
+          // Delayed fixtures retain this request and socket, even when another
+          // request for the same method finishes first.
+          handler({
+            params: frame.params,
+            respond,
+            emit: (event, payload) => this.deliver({ event, payload, seq: ++seq, type: "event" }),
+          });
+        } else {
+          respond(buildResponse(method, frame.params));
+        }
       }, 0);
     }
 
@@ -2297,7 +2325,7 @@ function installControlUiMockGateway(
     }
   }
 
-  const exposed: ExposedGateway = {
+  const exposed: ControlUiMockGateway = {
     closeLatest(code, reason) {
       MockWebSocket.latest?.close(code ?? 1006, reason ?? "mock close");
     },
@@ -2395,6 +2423,9 @@ function installControlUiMockGateway(
     setOperatorScopes(scopes) {
       scenario.operatorScopes = [...scopes];
     },
+    setRequestHandler(method, handler) {
+      requestHandlers.set(method, handler);
+    },
     setMethodResponse(method, payload) {
       if (method === "sessions.list" && isRecord(payload) && Array.isArray(payload.sessions)) {
         sessions.replaceListSnapshot(payload.sessions);
@@ -2444,7 +2475,7 @@ function installControlUiMockGateway(
     },
   };
 
-  (window as unknown as WindowWithGateway).openclawControlUiE2eGateway = exposed;
+  (window as MockGatewayWindow).openclawControlUiE2eGateway = exposed;
   const RoutedWebSocket = function (url: string | URL, protocols?: string | string[]) {
     const resolvedUrl = String(url);
     // Vite's dev client must keep its real socket: the mock would fake the
@@ -2503,13 +2534,7 @@ function createMockGatewayControls(
   const emitGatewayEvent = async (event: string, payload?: unknown) => {
     await page.evaluate(
       ({ eventName, eventPayload }) => {
-        const gateway = (
-          window as Window & {
-            openclawControlUiE2eGateway?: {
-              emit: (event: string, payload?: unknown) => void;
-            };
-          }
-        ).openclawControlUiE2eGateway;
+        const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
         if (!gateway) {
           throw new Error("Mock Gateway is not installed");
         }
@@ -2521,13 +2546,7 @@ function createMockGatewayControls(
 
   const deliverLatest = async (frame: unknown) => {
     await page.evaluate((payload) => {
-      const gateway = (
-        window as Window & {
-          openclawControlUiE2eGateway?: {
-            deliverLatest: (frame: unknown) => void;
-          };
-        }
-      ).openclawControlUiE2eGateway;
+      const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
       if (!gateway) {
         throw new Error("Mock Gateway is not installed");
       }
@@ -2537,13 +2556,7 @@ function createMockGatewayControls(
 
   const getRequests = async (method?: string) =>
     page.evaluate((targetMethod) => {
-      const gateway = (
-        window as Window & {
-          openclawControlUiE2eGateway?: {
-            findRequests: (method?: string) => MockGatewayRequest[];
-          };
-        }
-      ).openclawControlUiE2eGateway;
+      const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
       return gateway?.findRequests(targetMethod) ?? [];
     }, method);
 
@@ -2551,13 +2564,7 @@ function createMockGatewayControls(
     async closeLatest(code, reason) {
       await page.evaluate(
         ({ closeCode, closeReason }) => {
-          const gateway = (
-            window as Window & {
-              openclawControlUiE2eGateway?: {
-                closeLatest: (code?: number, reason?: string) => void;
-              };
-            }
-          ).openclawControlUiE2eGateway;
+          const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
           if (!gateway) {
             throw new Error("Mock Gateway is not installed");
           }
@@ -2570,13 +2577,7 @@ function createMockGatewayControls(
     async deferNext(method, match) {
       await page.evaluate(
         ({ targetMethod, requestMatch }) => {
-          const gateway = (
-            window as Window & {
-              openclawControlUiE2eGateway?: {
-                deferNext: (method: string, match?: Record<string, unknown>) => void;
-              };
-            }
-          ).openclawControlUiE2eGateway;
+          const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
           if (!gateway) {
             throw new Error("Mock Gateway is not installed");
           }
@@ -2601,46 +2602,20 @@ function createMockGatewayControls(
     getRequests,
     async getSocketCount() {
       return await page.evaluate(() => {
-        const gateway = (
-          window as Window & {
-            openclawControlUiE2eGateway?: {
-              socketCount: () => number;
-            };
-          }
-        ).openclawControlUiE2eGateway;
+        const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
         return gateway?.socketCount() ?? 0;
       });
     },
     async getSocketUrls() {
       return await page.evaluate(() => {
-        const gateway = (
-          window as Window & {
-            openclawControlUiE2eGateway?: {
-              socketUrls: () => string[];
-            };
-          }
-        ).openclawControlUiE2eGateway;
+        const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
         return gateway?.socketUrls() ?? [];
       });
     },
     async rejectDeferred(method, error) {
       await page.evaluate(
         ({ targetMethod, responseError }) => {
-          const gateway = (
-            window as Window & {
-              openclawControlUiE2eGateway?: {
-                rejectDeferred: (
-                  method: string,
-                  error?: {
-                    code?: string;
-                    message?: string;
-                    details?: unknown;
-                    retryable?: boolean;
-                  },
-                ) => void;
-              };
-            }
-          ).openclawControlUiE2eGateway;
+          const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
           if (!gateway) {
             throw new Error("Mock Gateway is not installed");
           }
@@ -2652,13 +2627,7 @@ function createMockGatewayControls(
     async resolveDeferred(method, payload) {
       await page.evaluate(
         ({ targetMethod, responsePayload }) => {
-          const gateway = (
-            window as Window & {
-              openclawControlUiE2eGateway?: {
-                resolveDeferred: (method: string, payload?: unknown) => void;
-              };
-            }
-          ).openclawControlUiE2eGateway;
+          const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
           if (!gateway) {
             throw new Error("Mock Gateway is not installed");
           }
@@ -2669,11 +2638,7 @@ function createMockGatewayControls(
     },
     async suspendLatest() {
       await page.evaluate(() => {
-        const gateway = (
-          window as Window & {
-            openclawControlUiE2eGateway?: { suspendLatest: () => void };
-          }
-        ).openclawControlUiE2eGateway;
+        const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
         if (!gateway) {
           throw new Error("Mock Gateway is not installed");
         }
@@ -2682,13 +2647,7 @@ function createMockGatewayControls(
     },
     async setOnline(online) {
       await page.evaluate((nextOnline) => {
-        const gateway = (
-          window as Window & {
-            openclawControlUiE2eGateway?: {
-              setOnline: (online: boolean) => void;
-            };
-          }
-        ).openclawControlUiE2eGateway;
+        const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
         if (!gateway) {
           throw new Error("Mock Gateway is not installed");
         }
@@ -2697,13 +2656,7 @@ function createMockGatewayControls(
     },
     async setGatewayBootId(bootId) {
       await page.evaluate((nextBootId) => {
-        const gateway = (
-          window as Window & {
-            openclawControlUiE2eGateway?: {
-              setGatewayBootId: (bootId: string) => void;
-            };
-          }
-        ).openclawControlUiE2eGateway;
+        const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
         if (!gateway) {
           throw new Error("Mock Gateway is not installed");
         }
@@ -2712,13 +2665,7 @@ function createMockGatewayControls(
     },
     async setServerBuildId(buildId) {
       await page.evaluate((nextBuildId) => {
-        const gateway = (
-          window as Window & {
-            openclawControlUiE2eGateway?: {
-              setServerBuildId: (buildId: string) => void;
-            };
-          }
-        ).openclawControlUiE2eGateway;
+        const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
         if (!gateway) {
           throw new Error("Mock Gateway is not installed");
         }
@@ -2727,13 +2674,7 @@ function createMockGatewayControls(
     },
     async setOperatorScopes(scopes) {
       await page.evaluate((nextScopes) => {
-        const gateway = (
-          window as Window & {
-            openclawControlUiE2eGateway?: {
-              setOperatorScopes: (scopes: string[]) => void;
-            };
-          }
-        ).openclawControlUiE2eGateway;
+        const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
         if (!gateway) {
           throw new Error("Mock Gateway is not installed");
         }
@@ -2742,13 +2683,7 @@ function createMockGatewayControls(
     },
     async setHistoryMessages(messages) {
       await page.evaluate((nextMessages) => {
-        const gateway = (
-          window as Window & {
-            openclawControlUiE2eGateway?: {
-              setHistoryMessages: (messages: unknown[]) => void;
-            };
-          }
-        ).openclawControlUiE2eGateway;
+        const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
         if (!gateway) {
           throw new Error("Mock Gateway is not installed");
         }
@@ -2758,13 +2693,7 @@ function createMockGatewayControls(
     async setMethodResponse(method, payload) {
       await page.evaluate(
         ({ targetMethod, responsePayload }) => {
-          const gateway = (
-            window as Window & {
-              openclawControlUiE2eGateway?: {
-                setMethodResponse: (method: string, payload: unknown) => void;
-              };
-            }
-          ).openclawControlUiE2eGateway;
+          const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
           if (!gateway) {
             throw new Error("Mock Gateway is not installed");
           }
@@ -2775,13 +2704,7 @@ function createMockGatewayControls(
     },
     async setSessionSharingPolicy(policy) {
       await page.evaluate((nextPolicy) => {
-        const gateway = (
-          window as Window & {
-            openclawControlUiE2eGateway?: {
-              setSessionSharingPolicy: (policy: typeof nextPolicy) => void;
-            };
-          }
-        ).openclawControlUiE2eGateway;
+        const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
         if (!gateway) {
           throw new Error("Mock Gateway is not installed");
         }
@@ -2795,13 +2718,7 @@ function createMockGatewayControls(
         try {
           await page.waitForFunction(
             ({ targetMethod, priorCount }) => {
-              const gateway = (
-                window as Window & {
-                  openclawControlUiE2eGateway?: {
-                    requests: MockGatewayRequest[];
-                  };
-                }
-              ).openclawControlUiE2eGateway;
+              const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
               const matching =
                 gateway?.requests.filter((request) => request.method === targetMethod) ?? [];
               return matching.length > (priorCount ?? 0);


### PR DESCRIPTION
Related: #134686

## What Problem This Solves

Fixes inconsistent behavior in the standalone Control UI mock preview: concurrent caretaker requests could receive each other's replies, renamed groups returned after reload, background-task transcripts were hidden by the main transcript override, and generated search results lost their session metadata.

## Why This Change Was Made

The preview installed a second WebSocket dispatcher and resolved delayed replies by method name. It also declared overlapping copies of state already owned by the shared mock Gateway. The shared dispatcher now supplies callbacks bound to the requesting socket and request ID; the standalone initializer only registers its two interactive handlers and selects the preview origin before startup.

Groups, session identity, and session metadata now come from the existing fixture stores. Per-session transcripts feed both history and startup; explicit method-response cases and sequences remain available for deliberate wire fault injection. The main demo row explicitly remains running. This removes the prototype patch, duplicate parsing, overlapping transcript/group responses, duplicate session row, and repeated browser-control type declarations.

The production avatar loader also uses one LRU scan and removes a redundant origin check. Its trust rules, authentication, lazy loading, pending consumers, and blob lifetime are preserved.

## User Impact

Developers can use the synthetic preview with consistent replies, persistent group edits, and the correct task/search data. Preview HTTP resources stay on the preview origin, including after reload. Normal production avatar behavior is unchanged; no operator Gateway, operator credentials, or operator state was used for proof.

Production: +12/-19 lines (net -7). Preview tooling and test support: +264/-442 (net -178). Tests: +191/-1. No dependencies, configuration, persistence schema, or protocol changes.

## Evidence

- All four original fixture/request regressions failed before repair; focused red/green checks also cover canonical transcript identity and the active main run.
- 12 standalone Playwright tests pass, including cold-load/reload avatar origin isolation, both transcript entry points, concurrent caretaker replies, search metadata, group persistence, and chat replies.
- 126 focused avatar, bootstrap, session, deferral, and shared-dispatch tests pass. The dispatcher regression resolves two sockets' requests in reverse order and checks both response and event ownership.
- Full changed-file gate and final replay, production UI build (including sidecar and bundle-budget checks), and independent review passed.
- Synthetic browser recording exercised group rename/reload, stopping the demo run, and sending a message. All 2,484 HTTP requests stayed on the preview origin. Any off-origin attempt would fail the capture; none occurred.

Before: renaming Research to Reviewed leaves both groups after reload.

![Before: stale Research group returns after rename and reload](https://github.com/user-attachments/assets/9386236e-9a59-4e84-b78c-a275ab1ac027)

After: the renamed group is authoritative after reload, with the demo run still active.

![After: Reviewed remains authoritative after reload](https://github.com/user-attachments/assets/5071deca-05a3-4930-936f-d0bc9f9f84aa)
