### PR TITLE
fix(gateway): reject model selections without an activatable harness

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -186,6 +186,13 @@ allowlist replaces the shared default, including `[]` to allow any model.
 Policy permission does not supply provider credentials or guarantee that the
 selected model is available to its runtime.
 
+Before saving a model selection, these Gateway methods check that any required
+embedded harness has an installed, activatable plugin. A missing or disabled
+plugin rejects the change and preserves the previous session selection and
+configured default. Install and enable the named harness plugin, restart the
+Gateway, then select the model again. This check does not start the runtime or
+verify provider credentials.
+
 Choose the model when you create a session whenever possible. The Control UI's
 **New Chat** composer includes the model picker for this reason: a fresh session
 gives the selected model a clean conversation boundary.

--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -296,7 +296,7 @@ export function resolveSelectedAgentHarnessRuntime(
 }
 
 // Returns whether a selection needs a plugin-owned harness in its prepared generation.
-function requiresAgentHarnessPluginSelection(
+export function requiresAgentHarnessPluginSelection(
   selection: AgentHarnessPluginSelection,
   config?: OpenClawConfig,
 ): boolean {

--- a/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
@@ -5,6 +5,8 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import type { AgentConfig } from "../../config/types.agents.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import {
   createOpenClawTestState,
@@ -12,55 +14,19 @@ import {
 } from "../../test-utils/openclaw-test-state.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
-const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
-  policyHash: "sticky-model-test-empty-plugin-policy",
-  index: {
-    version: 1,
-    hostContractVersion: "test",
-    compatRegistryVersion: "test",
-    migrationVersion: 1,
-    policyHash: "sticky-model-test-empty-plugin-policy",
-    generatedAtMs: 0,
-    installRecords: {},
-    plugins: [],
-    diagnostics: [],
-  },
-  registryDiagnostics: [],
-  manifestRegistry: { plugins: [], diagnostics: [] },
-  plugins: [],
-  diagnostics: [],
-  byPluginId: new Map(),
-  normalizePluginId: (pluginId: string) => pluginId,
-  owners: {
-    channels: new Map(),
-    channelConfigs: new Map(),
-    providers: new Map(),
-    modelCatalogProviders: new Map(),
-    cliBackends: new Map(),
-    setupProviders: new Map(),
-    commandAliases: new Map(),
-    contracts: new Map(),
-    modelIdNormalizationPolicies: new Map(),
-  },
-  metrics: {
-    registrySnapshotMs: 0,
-    manifestRegistryMs: 0,
-    ownerMapsMs: 0,
-    totalMs: 0,
-    indexPluginCount: 0,
-    manifestPluginCount: 0,
-  },
+const pluginMetadata = vi.hoisted(() => ({
+  snapshot: undefined as PluginMetadataSnapshot | undefined,
 }));
 
 vi.mock("../../plugins/current-plugin-metadata-snapshot.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../plugins/current-plugin-metadata-snapshot.js")>()),
-  getCurrentPluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
+  getCurrentPluginMetadataSnapshot: () => pluginMetadata.snapshot,
 }));
 
 vi.mock("../../plugins/plugin-metadata-snapshot.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../plugins/plugin-metadata-snapshot.js")>()),
-  loadPluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
-  resolvePluginMetadataSnapshot: () => emptyPluginMetadataSnapshot,
+  loadPluginMetadataSnapshot: () => pluginMetadata.snapshot,
+  resolvePluginMetadataSnapshot: () => pluginMetadata.snapshot,
 }));
 
 vi.mock("../../plugins/provider-thinking.js", () => ({
@@ -154,6 +120,11 @@ async function patchSession(
 
 beforeAll(async () => {
   openClawTestState = await createOpenClawTestState({ scenario: "minimal" });
+  // Sticky selections still pass real harness admission; this fixture supplies
+  // the installed owner required by its OpenAI route without loading runtime code.
+  pluginMetadata.snapshot = createPluginMetadataSnapshotFixture({
+    plugins: [{ id: "codex", activation: { onAgentHarnesses: ["codex"] } }],
+  });
 });
 
 beforeEach(() => {

--- a/src/gateway/server.sessions.agent-model-catalog.test.ts
+++ b/src/gateway/server.sessions.agent-model-catalog.test.ts
@@ -1,6 +1,12 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
 import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import {
+  createColdPluginFixture,
+  isColdPluginRuntimeLoaded,
+} from "../plugins/test-helpers/cold-plugin-fixtures.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import type { PrepareGatewaySessionLifecycle } from "./session-lifecycle-preparation.js";
 import { writeSessionStore } from "./test-helpers.js";
@@ -37,16 +43,21 @@ type ModelSelectionCase = {
   agentAllow?: string[];
   globalAlias?: string;
   agentAlias?: string;
+  agentRuntime?: string;
+  harness?: "enabled" | "disabled" | "denied";
+  codexDenied?: boolean;
   model: string;
   expectedModel: string;
   denied?: boolean;
+  error?: string;
 };
 
 function configureAgentModels(
   scenario: Pick<
     ModelSelectionCase,
-    "globalAllow" | "agentAllow" | "globalAlias" | "agentAlias"
+    "globalAllow" | "agentAllow" | "globalAlias" | "agentAlias" | "agentRuntime"
   > & { subagentModel?: string },
+  runtimeModel = workRef,
 ) {
   testState.agentConfig = {
     model: { primary: "synthetic/base" },
@@ -65,13 +76,50 @@ function configureAgentModels(
         id: "work",
         subagents: scenario.subagentModel ? { model: scenario.subagentModel } : undefined,
         ...(scenario.agentAllow ? { modelPolicy: { allow: scenario.agentAllow } } : {}),
-        models: scenario.agentAlias ? { [workRef]: { alias: scenario.agentAlias } } : {},
+        models: {
+          [workRef]: scenario.agentAlias ? { alias: scenario.agentAlias } : {},
+          ...(scenario.agentRuntime
+            ? { [runtimeModel]: { agentRuntime: { id: scenario.agentRuntime } } }
+            : {}),
+        },
       },
     ],
   };
 }
 
 const cases: ModelSelectionCase[] = [
+  {
+    label: "rejects configured Codex selection when its harness is denied",
+    globalAllow: [],
+    agentRuntime: "codex",
+    codexDenied: true,
+    model: "openai/gpt-5.4",
+    expectedModel: "openai/gpt-5.4",
+    denied: true,
+    error:
+      'Model openai/gpt-5.4 requires agent harness "codex", but no enabled plugin provides it. Install and enable its plugin, restart the Gateway, then select the model again.',
+  },
+  {
+    label: "preserves the session when the selected model requires an unavailable harness",
+    globalAllow: [],
+    agentRuntime: "missing-harness",
+    model: workRef,
+    expectedModel: workRef,
+    denied: true,
+    error:
+      'Model work-provider/work-only requires agent harness "missing-harness", but no enabled plugin provides it. Install and enable its plugin, restart the Gateway, then select the model again.',
+  },
+  ...(["enabled", "disabled", "denied"] as const).map((harness) => ({
+    label: `checks an installed ${harness} harness without loading its runtime`,
+    globalAllow: [],
+    agentRuntime: "fixture-harness",
+    harness,
+    model: workRef,
+    expectedModel: workRef,
+    denied: harness !== "enabled",
+    error:
+      'Model work-provider/work-only requires agent harness "fixture-harness", but no enabled plugin provides it. Install and enable its plugin, restart the Gateway, then select the model again.',
+  })),
   {
     label: "loads the explicit agent model catalog",
     explicitAgent: true,
@@ -158,8 +206,30 @@ const cases: ModelSelectionCase[] = [
 
 describe.each(["sessions.create", "sessions.patch"] as const)("%s", (method) => {
   test.each(cases)("$label", async (scenario) => {
-    const { workStorePath } = await createSelectedGlobalSessionStore();
-    configureAgentModels(scenario);
+    const { dir, workStorePath } = await createSelectedGlobalSessionStore();
+    configureAgentModels(scenario, scenario.expectedModel);
+    let fixture: ReturnType<typeof createColdPluginFixture> | undefined;
+    if (scenario.harness) {
+      const rootDir = await fs.mkdtemp(path.join(dir, "harness-"));
+      fixture = createColdPluginFixture({
+        rootDir,
+        pluginId: "fixture-harness",
+        manifest: { activation: { onAgentHarnesses: ["fixture-harness"] } },
+      });
+      const { writeConfigFile } = await getGatewayConfigModule();
+      await writeConfigFile({
+        plugins: {
+          load: { paths: [rootDir] },
+          ...(scenario.harness === "denied"
+            ? {}
+            : { entries: { "fixture-harness": { enabled: scenario.harness !== "disabled" } } }),
+          ...(scenario.harness === "denied" ? { deny: ["fixture-harness"] } : {}),
+        },
+      });
+    } else if (scenario.codexDenied) {
+      const { writeConfigFile } = await getGatewayConfigModule();
+      await writeConfigFile({ plugins: { deny: ["codex"] } });
+    }
     const key = "agent:work:dashboard:catalog-owner";
     const access = { agentId: "work", sessionKey: key, storePath: workStorePath };
     if (method === "sessions.patch") {
@@ -177,6 +247,8 @@ describe.each(["sessions.create", "sessions.patch"] as const)("%s", (method) => 
       });
     }
     const before = loadSessionEntry(access);
+    const { readConfigFileSnapshot } = await getGatewayConfigModule();
+    const beforeConfig = await readConfigFileSnapshot();
     const loadGatewayModelCatalog = createAgentModelCatalogLoader();
     const result = await directSessionReq<{ entry?: SessionEntry }>(
       method,
@@ -186,17 +258,24 @@ describe.each(["sessions.create", "sessions.patch"] as const)("%s", (method) => 
         model: scenario.model,
         label: "Updated label",
       },
-      { context: { loadGatewayModelCatalog } },
+      {
+        context: { loadGatewayModelCatalog },
+        ...(scenario.error ? { client: { connect: { scopes: ["operator.admin"] } } as never } : {}),
+      },
     );
 
     expect(loadGatewayModelCatalog).toHaveBeenCalledWith({ agentId: "work" });
+    if (fixture) {
+      expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
+    }
     if (scenario.denied) {
       expect.soft(result.ok).toBe(false);
       expect.soft(result.error).toMatchObject({
         code: "INVALID_REQUEST",
-        message: `model not allowed: ${scenario.expectedModel}`,
+        message: scenario.error ?? `model not allowed: ${scenario.expectedModel}`,
       });
       expect(loadSessionEntry(access)).toEqual(before);
+      expect((await readConfigFileSnapshot()).config).toEqual(beforeConfig.config);
       return;
     }
     expect(result.ok, result.error?.message).toBe(true);

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -8,7 +8,15 @@ import {
   type SessionsPatchParams,
 } from "../../packages/gateway-protocol/src/index.js";
 import { readAcpSessionMetaForEntry } from "../acp/runtime/session-meta.js";
-import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
+import {
+  requiresAgentHarnessPluginSelection,
+  resolveAgentHarnessOwnerPluginIds,
+} from "../agents/harness/runtime-plugin-load-plan.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import {
@@ -468,22 +476,11 @@ export async function projectSessionsPatchEntry(params: {
       : undefined;
     delete next.modelFallback;
     const raw = patch.model;
+    let selection:
+      | { provider: string; model: string; profile?: string; isDefault: boolean }
+      | undefined;
     if (raw === null) {
-      applyModelOverrideWithAuthProfileCompatibility({
-        cfg,
-        agentDir: resolveAgentDir(cfg, sessionAgentId),
-        entry: next,
-        currentProvider: next.providerOverride ?? next.modelProvider ?? resolvedDefault.provider,
-        selection: {
-          provider: resolvedDefault.provider,
-          model: resolvedDefault.model,
-          isDefault: true,
-        },
-        ...(params.providerAuthMetadataSnapshot
-          ? { metadataSnapshot: params.providerAuthMetadataSnapshot }
-          : {}),
-      });
-      delete next.liveModelSwitchPending;
+      selection = { ...resolvedDefault, isDefault: true };
     } else if (raw !== undefined) {
       const trimmed = normalizeOptionalString(raw) ?? "";
       if (!trimmed) {
@@ -511,22 +508,49 @@ export async function projectSessionsPatchEntry(params: {
       if (!resolved.ok) {
         return invalid(resolved.error);
       }
+      selection = resolved;
+    }
+    if (selection) {
+      // Catalog membership does not guarantee an activatable harness. Reject before
+      // committing the session so sticky defaults cannot retain an unusable selection.
+      const harnessSelection = {
+        provider: selection.provider,
+        modelId: selection.model,
+        runtime: resolveThinkingRuntime(selection.provider, selection.model, next),
+        agentId: sessionAgentId,
+      };
+      if (
+        !readAcpSessionMetaForEntry({
+          sessionKey: storeKey,
+          agentId: sessionAgentId,
+          entry: next,
+        }) &&
+        requiresAgentHarnessPluginSelection(harnessSelection, cfg) &&
+        resolveAgentHarnessOwnerPluginIds({
+          ...harnessSelection,
+          config: cfg,
+          workspaceDir: resolveAgentWorkspaceDir(cfg, sessionAgentId),
+        }).length === 0
+      ) {
+        return invalid(
+          `Model ${selection.provider}/${selection.model} requires agent harness "${harnessSelection.runtime}", but no enabled plugin provides it. Install and enable its plugin, restart the Gateway, then select the model again.`,
+        );
+      }
       applyModelOverrideWithAuthProfileCompatibility({
         cfg,
         agentDir: resolveAgentDir(cfg, sessionAgentId),
         entry: next,
         currentProvider: next.providerOverride ?? next.modelProvider ?? resolvedDefault.provider,
-        selection: {
-          provider: resolved.provider,
-          model: resolved.model,
-          isDefault: resolved.isDefault,
-        },
-        profileOverride: resolved.profile,
+        selection,
+        profileOverride: selection.profile,
         ...(params.providerAuthMetadataSnapshot
           ? { metadataSnapshot: params.providerAuthMetadataSnapshot }
           : {}),
-        markLiveSwitchPending: true,
+        markLiveSwitchPending: raw !== null,
       });
+      if (raw === null) {
+        delete next.liveModelSwitchPending;
+      }
     }
     if (agentModelFallback) {
       next.modelFallback = agentModelFallback;


### PR DESCRIPTION
Fixes #134305. Reported by @goslingmanagment. Related: #134468 adds execution-time recovery diagnostics for already-broken configurations.

## What Problem This Solves

The Control UI could save a model whose required embedded harness had no installed, activatable plugin owner. `sessions.patch` committed the model and other patch fields, then sticky persistence could replace the configured default. `sessions.create` likewise accepted an unusable model. The next turn failed before inference.

This remains reproducible on main `61404b6c2a9`. Merged #134463 (`84e81339c2c3`) pairs the full model catalog with native-auth evidence; it does not validate harness ownership before saving a session selection.

## Why This Change Was Made

Validate harness ownership in the shared `sessions.create` / `sessions.patch` projection before committing any patch fields or publishing sticky defaults. Reuse the canonical runtime policy, manifest activation planner, and Gateway metadata snapshot. Installed lazy owners remain selectable without importing their runtime; missing, disabled, denied, or untrusted owners are rejected.

Explicit selections and null/default resets now share one application step. Installation and capability consent stay with setup. ACP and CLI backends retain their existing selection owners.

The maintainer decision requested by ClawSweeper is resolved: reject an unavailable harness before saving, preserve the previous selection, and explain recovery. Exact-head CI remains a landing requirement.

## User Impact

An unavailable selection returns actionable guidance and preserves the previous model, other session fields, and configured default. The model-selection docs describe the check and recovery. This restores the intended Gateway picker behavior for the 2026.8.1 regression reported in #134305; it does not authenticate providers or certify later runtime initialization.

Production: +48/-24, net +24. Tests: +97/-47, net +50. Docs: +7. The production growth adds the missing admission boundary while removing duplicate model-application code. No configuration option, protocol version, dependency, public API, or SQLite schema was added.

Named follow-up — **apply harness admission to `/model` directives**: `src/auto-reply/reply/model-runtime-normalization.ts:89-102` can accept a cataloged selection without checking its harness owner, and `src/auto-reply/reply/directive-handling.impl.ts:489` persists it. This PR protects Gateway session selection; it does not claim every model-selection surface is covered.

## Evidence

The original regression failed both real Gateway handlers before the fix: patch saved the unavailable model and another field, while create admitted an unusable row. The refreshed focused run passed **118 tests**: 35 session-handler, 19 sticky-selection, 35 harness-owner, 23 registry, and 6 usage cases. Coverage includes missing owners, explicit Codex denial, enabled/disabled/denied generic harnesses, agent/global policy, aliases, and unchanged session/config after rejection. Cold fixture runtimes throw if imported, proving selection remains lazy.

The sticky-selection fixture now supplies the installed Codex owner required by its OpenAI route through the shared metadata fixture builder. This preserves real activation-policy checks and removes 29 test lines.

**Actual Gateway RPC proof:** both PRs were applied over main `61404b6c2a9` and exercised together using a built Gateway, authenticated WebSocket RPC, synthetic config marked `lastTouchedVersion: "2026.7.1-2"`, a fresh `OPENCLAW_STATE_DIR`, and a random loopback port excluding 18789. The drivers stop their own Gateway afterward. No external provider inference or operator state was used.

```sh
node /tmp/harness-live-missing.mjs baseline-missing-stable
node /tmp/harness-live-missing.mjs candidate-missing
node /tmp/harness-live-proof.mjs candidate-disabled
```

Each driver first creates `agent:main:harness-proof` with `synthetic/working` and label `Before selection`, then sends:

```json
{"method":"sessions.patch","params":{"key":"agent:main:harness-proof","model":"openai/gpt-5.6-sol","label":"Should not persist"}}
{"method":"sessions.create","params":{"key":"agent:main:unavailable-create","model":"openai/gpt-5.6-sol"}}
```

| Observation | Main baseline | Candidate: missing owner | Candidate: plugins disabled |
| --- | --- | --- | --- |
| Patch / create | Both accepted | Both `INVALID_REQUEST` | Both `INVALID_REQUEST` |
| Existing session label | `Should not persist` | `Before selection` | `Before selection` |
| Config unchanged after rejection | `false` | `true` | `true` |
| Configured default afterward | `openai/gpt-5.6-sol` | `synthetic/working` | `synthetic/working` |

The missing-owner response was:

```text
Model openai/gpt-5.6-sol requires agent harness "missing-harness", but no enabled plugin provides it. Install and enable its plugin, restart the Gateway, then select the model again.
```

The disabled-plugin case returned the same guidance naming `codex`. A separate configured agent already using the broken model received `chat.send`; the Gateway emitted visible `chat` error events containing `reason=owner-plugin-not-activatable`. The disabled case also named owner `codex` and the `plugins disabled` blocker. These paired runs verify selection rejection and the companion execution diagnostic. The first event exposed a truncation issue in the companion PR. The final rebuilt rerun now includes the complete Doctor command in the first implicit-Codex chat error. `/health` and `/readyz` remained HTTP 200 in these runs; this PR does not change their meaning.

Direct dependency inspection covered Codex's `codex-rs/app-server/src/request_processors/catalog_processor.rs:242-295` and `account_processor.rs:1034-1090`: catalog listing and auth status are separate from OpenClaw plugin-host availability.

Final validation:

- Full required validation is green in exact-head [CI run 33479490035](https://github.com/openclaw/openclaw/actions/runs/33479490035). Local focused commands were `node scripts/run-vitest.mjs src/agents/harness/runtime-plugin.test.ts src/agents/runtime-plugins.test.ts src/plugins/provider-runtime.usage-harness.test.ts src/gateway/server.sessions.agent-model-catalog.test.ts src/gateway/server-methods/sessions-mutations.sticky-model.test.ts` (118 passed), then the final harness-owner suite (35 passed). The combined `pnpm build` passed in 22m2s. Additional `node scripts/check-changed.mjs --base 61404b6c2a91871b2a4f5819ca98b06a90077796 -- <the 11 changed files>` is still running and is not claimed as completed proof.
- Final rebuilt Gateway rerun passed: `node /tmp/harness-live-missing.mjs final-missing` (port 57540) and `node /tmp/harness-live-implicit.mjs final-implicit` (port 57551). Both rejected patch/create and preserved state. The implicit Codex fixture has no explicit runtime override; its first chat error includes the complete `openclaw doctor --fix` command and the disabled-plugin reason. The missing-harness first event contains complete enable/reinstall/restart guidance.
- Required branch autoreview passed on `b34390d4cf76fadb569d5673dcec9402aadd46f9`: `.agents/skills/autoreview/scripts/autoreview --mode branch --base aadafdc198c062d61c0c4dc182d311232df6df03 --max-priority P2`; scoped-clean with no accepted/actionable P0–P2 findings.
- Exact reviewed head: `b34390d4cf76fadb569d5673dcec9402aadd46f9`. `node scripts/watch-pr-ci.mjs 134837 b34390d4cf76fadb569d5673dcec9402aadd46f9` returned `GREEN`. Latest ClawSweeper comment has no `Rank-up moves:` section; its before-merge requests are resolved by the explicitly authorized early-rejection decision, the shared projection boundary, and green exact-head CI. Native prepare/merge remains the required landing path.

The upgrade-shaped fixture also passed: `node /tmp/harness-live-legacy-doctor.mjs final-legacy-doctor` ran `doctor --fix --non-interactive` against actual v2026.7.1-2 `agents.list` and legacy `openai-codex` references before starting the Gateway. Doctor exited 0, migrated the route to `openai`, then both selections rejected with the harness reason, state stayed unchanged, and the first broken-turn error retained `openclaw doctor --fix`.

### Before / After

These original screenshots show the real Control UI with **mock-Gateway responses**. They are rendering evidence, distinct from the actual Gateway RPC proof above.

Before: the unavailable model remains selected and sending fails.

![Before: unavailable model persists](https://github.com/user-attachments/assets/121732a5-a9d7-4437-9424-c11411a6b9de)

After: recovery guidance appears and the previous model remains selected.

![After: recovery guidance and previous model retained](https://github.com/user-attachments/assets/30e0c258-8f98-403e-8498-4816f568b664)
