### PR TITLE
fix(voice-call): stream diagnostic logs with backpressure

### DIFF
--- a/docs/cli/voicecall.md
+++ b/docs/cli/voicecall.md
@@ -171,8 +171,13 @@ openclaw voicecall status --call-id <id>
 
 ### `tail`
 
-Tail the voice-call JSONL log. Prints the last `--since` lines on start, then
-streams new lines as they are written.
+Tail persisted voice-call records from SQLite: print the last `--since` records
+initially, then only new snapshots (`--since 0` starts with new snapshots only).
+With an existing custom `--file`
+whose basename is not `calls.jsonl`, prints the last `--since` nonempty complete
+lines on start, then streams new complete lines. Partial lines wait for a newline;
+file replacement or observed truncation starts a fresh stream. Slow output pipes
+pause reading instead of accumulating the rest of the log in memory.
 
 | Flag            | Default                    | Description                    |
 | --------------- | -------------------------- | ------------------------------ |
@@ -182,8 +187,15 @@ streams new lines as they are written.
 
 ### `latency`
 
-Summarize turn-latency and listen-wait metrics from `calls.jsonl`. Output is
-JSON with `recordsScanned`, `turnLatency`, and `listenWait` summaries.
+Summarize turn-latency and listen-wait metrics from SQLite or an existing custom
+log selected with `--file`. Output is JSON with `recordsScanned`, `turnLatency`,
+and `listenWait` summaries.
+
+Custom logs are scanned incrementally without a byte cap on requested history.
+`latency` selects the last N nonempty records, skips malformed JSON, and accepts
+a final JSON record without a newline. It parses one selected record at a time;
+memory still scales with the largest selected JSON record and the requested
+number of metric samples.
 
 | Flag            | Default                    | Description                          |
 | --------------- | -------------------------- | ------------------------------------ |

--- a/docs/cli/voicecall.md
+++ b/docs/cli/voicecall.md
@@ -52,8 +52,8 @@ openclaw voicecall expose   [--mode <m>] [--path <p>] [--port <port>] [--serve-p
 | `dtmf`     | Send DTMF digits to an active call.                             |
 | `end`      | Hang up an active call.                                         |
 | `status`   | Inspect active calls (or one by `--call-id`).                   |
-| `tail`     | Tail `calls.jsonl` (useful during provider tests).              |
-| `latency`  | Summarize turn-latency metrics from `calls.jsonl`.              |
+| `tail`     | Tail persisted call records or an explicit custom JSONL log.    |
+| `latency`  | Summarize turn latency from call history or a custom JSONL log. |
 | `expose`   | Toggle Tailscale serve/funnel for the webhook endpoint.         |
 
 ## Setup and smoke

--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -832,8 +832,9 @@ delegate to the Gateway-owned voice-call runtime so the CLI does not bind a
 second webhook server. If no Gateway is reachable, the commands fall back to
 a standalone CLI runtime.
 
-`latency` reads `calls.jsonl` from the default voice-call storage path. Use
-`--file <path>` to point at a different log and `--last <n>` to limit
+`latency` reads persisted call records from SQLite by default. Use
+`--file <path>` to read an existing custom JSONL log (with a basename other than
+`calls.jsonl`) and `--last <n>` to limit
 analysis to the last N records (default 200). Output includes min/max/avg,
 p50, and p95 for turn latency and listen-wait times.
 

--- a/extensions/voice-call/src/cli-call-log.test.ts
+++ b/extensions/voice-call/src/cli-call-log.test.ts
@@ -1,0 +1,217 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { tempWorkspace } from "openclaw/plugin-sdk/temp-path";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+
+const { sleepMock, historyMock } = vi.hoisted(() => ({
+  sleepMock: vi.fn(),
+  historyMock: vi.fn(),
+}));
+vi.mock("../api.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../api.js")>()),
+  sleep: sleepMock,
+}));
+vi.mock("./manager/store.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./manager/store.js")>()),
+  getCallHistoryFromStore: historyMock,
+}));
+
+import { registerVoiceCallLogs } from "./cli-call-log.js";
+
+describe("voice-call diagnostic stream ownership", () => {
+  let workspace: Awaited<ReturnType<typeof tempWorkspace>>;
+  let file: string;
+  let output: Buffer[];
+  let stdout: MockInstance<typeof process.stdout.write>;
+  const stopped = new Error("diagnostic test finished");
+
+  beforeEach(async () => {
+    workspace = await tempWorkspace({ rootDir: os.tmpdir(), prefix: "voice-call-log-" });
+    file = await workspace.write("diagnostics.jsonl", "");
+    output = [];
+    sleepMock.mockReset().mockRejectedValue(stopped);
+    historyMock.mockReset().mockResolvedValue([]);
+    stdout = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      output.push(Buffer.isBuffer(chunk) ? Buffer.from(chunk) : Buffer.from(String(chunk)));
+      return true;
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await workspace.cleanup();
+  });
+
+  function command(...args: string[]) {
+    const program = new Command();
+    registerVoiceCallLogs({ root: program, defaultFile: file, ensureHistoryStateRuntime() {} });
+    return program.parseAsync(args, { from: "user" });
+  }
+
+  function text() {
+    return Buffer.concat(output).toString("utf8");
+  }
+
+  it.each(["tail", "latency"])(
+    "preserves requested %s history beyond one megabyte without reading the whole file",
+    async (mode) => {
+      const records = [120, 240, 360].map((latency) =>
+        JSON.stringify({ metadata: { lastTurnLatencyMs: latency }, padding: "x".repeat(600_000) }),
+      );
+      fs.writeFileSync(file, `${records.join("\n")}\n`);
+      const readFile = vi.spyOn(fs, "readFileSync");
+      if (mode === "tail") {
+        await expect(command("tail", "--since", "3")).rejects.toBe(stopped);
+        expect(text()).toBe(`${records.join("\n")}\n`);
+      } else {
+        await command("latency", "--last", "3");
+        expect(JSON.parse(text())).toMatchObject({
+          recordsScanned: 3,
+          turnLatency: { count: 3, avgMs: 240, minMs: 120, maxMs: 360 },
+        });
+      }
+      expect(readFile.mock.calls.filter(([target]) => target === file)).toEqual([]);
+    },
+  );
+
+  it("bounds follow reads while retaining every record and the unfinished suffix", async () => {
+    const records = Array.from({ length: 2048 }, (_, seq) =>
+      JSON.stringify({ seq, text: "é".repeat(512) }),
+    );
+    const read = vi.spyOn(fs, "readSync");
+    sleepMock
+      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(async () => {
+        fs.appendFileSync(file, `${records.join("\n")}\n{"seq":2048`);
+      })
+      .mockImplementationOnce(async () => {
+        fs.appendFileSync(file, "}\n");
+      });
+    await expect(command("tail", "--since", "0")).rejects.toBe(stopped);
+    expect(text()).toBe(`${records.join("\n")}\n{"seq":2048}\n`);
+    const requested = read.mock.calls.map(([, buffer]) => buffer.byteLength);
+    expect(requested.length).toBeGreaterThan(0);
+    expect(requested.every((length) => length <= 64 * 1024)).toBe(true);
+  });
+
+  it("does not join a pending record to a larger replacement file", async () => {
+    fs.writeFileSync(file, '{"seq":0}\n{"retired":');
+    const replacement = `${JSON.stringify({ seq: 1, text: "fresh".repeat(64) })}\n`;
+    sleepMock.mockImplementationOnce(async () => {
+      const next = await workspace.write("replacement.jsonl", replacement);
+      fs.renameSync(next, file);
+    });
+    await expect(command("tail", "--since", "1")).rejects.toBe(stopped);
+    expect(text()).toBe(`{"seq":0}\n${replacement}`);
+  });
+
+  it("stops producing until stdout drains", async () => {
+    fs.writeFileSync(file, '{"seq":0}\n{"seq":1}\n');
+    const blocked = createDeferred<void>();
+    let rejectWrites = true;
+    stdout.mockImplementation((chunk) => {
+      output.push(Buffer.isBuffer(chunk) ? Buffer.from(chunk) : Buffer.from(String(chunk)));
+      if (rejectWrites) {
+        blocked.resolve();
+        return false;
+      }
+      return true;
+    });
+    const running = command("tail", "--since", "2").catch((error: unknown) => error);
+    await blocked.promise;
+    try {
+      expect(text()).not.toContain('"seq":1');
+      expect(sleepMock).not.toHaveBeenCalled();
+    } finally {
+      rejectWrites = false;
+      process.stdout.emit("drain");
+      expect(await running).toBe(stopped);
+    }
+    expect(text()).toBe('{"seq":0}\n{"seq":1}\n');
+  });
+
+  it("streams a large record across polls without breaking UTF-8 or dropping its prefix", async () => {
+    const record = JSON.stringify({ text: "é".repeat(700_000) });
+    const bytes = Buffer.from(record);
+    fs.writeFileSync(file, bytes.subarray(0, 600_001));
+    sleepMock.mockImplementationOnce(async () => {
+      fs.appendFileSync(file, Buffer.concat([bytes.subarray(600_001), Buffer.from("\n")]));
+    });
+    const read = vi.spyOn(fs, "readSync");
+    await expect(command("tail", "--since", "0")).rejects.toBe(stopped);
+    expect(Buffer.concat(output)).toEqual(Buffer.concat([bytes, Buffer.from("\n")]));
+    expect(read.mock.calls.every(([, buffer]) => buffer.byteLength <= 64 * 1024)).toBe(true);
+  });
+
+  it("keeps latency record selection, envelopes, malformed JSON and final EOF semantics", async () => {
+    fs.writeFileSync(
+      file,
+      [
+        '{"metadata":{"lastTurnLatencyMs":900}}',
+        "",
+        '{"call":{"metadata":{"lastTurnLatencyMs":100,"lastTurnListenWaitMs":20}}}',
+        "invalid JSON",
+        "null",
+        '{"metadata":{"lastTurnLatencyMs":300,"lastTurnLatencyMs":200}}',
+      ].join("\n"),
+    );
+    await command("latency", "--last", "4");
+    expect(JSON.parse(text())).toMatchObject({
+      recordsScanned: 2,
+      turnLatency: { count: 2, minMs: 100, maxMs: 200, avgMs: 150 },
+      listenWait: { count: 1, avgMs: 20 },
+    });
+  });
+
+  it("closes the active descriptor and stops when blocked stdout fails", async () => {
+    fs.writeFileSync(file, '{"seq":0}\n');
+    const drainListeners = process.stdout.listenerCount("drain");
+    const blocked = createDeferred<void>();
+    const failed = new Error("output pipe failed");
+    stdout.mockImplementation(() => {
+      blocked.resolve();
+      return false;
+    });
+    const open = vi.spyOn(fs, "openSync");
+    const running = command("tail", "--since", "1").catch((error: unknown) => error);
+    await blocked.promise;
+    const index = open.mock.calls.findIndex(([target]) => target === file);
+    const opened = open.mock.results[index];
+    if (opened?.type !== "return") {
+      throw new Error("diagnostic command did not open its log");
+    }
+    const fd = opened.value;
+    expect(fs.fstatSync(fd).isFile()).toBe(true);
+    process.stdout.emit("error", failed);
+    expect(await running).toBe(failed);
+    expect(() => fs.fstatSync(fd)).toThrow();
+    expect(sleepMock).not.toHaveBeenCalled();
+    expect(process.stdout.listenerCount("drain")).toBe(drainListeners);
+  });
+
+  it("deduplicates retained SQLite snapshots without retaining retired history forever", async () => {
+    file = path.join(workspace.dir, "calls.jsonl");
+    const first = { callId: "first", state: "completed" };
+    const second = { callId: "second", state: "completed" };
+    historyMock
+      .mockResolvedValueOnce([first])
+      .mockResolvedValueOnce([first, second])
+      .mockResolvedValueOnce([second])
+      .mockResolvedValueOnce([first])
+      .mockResolvedValueOnce([first]);
+    sleepMock
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+    await expect(command("tail", "--since", "1")).rejects.toBe(stopped);
+    expect(
+      text()
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+    ).toEqual([first, second, first]);
+  });
+});

--- a/extensions/voice-call/src/cli-call-log.ts
+++ b/extensions/voice-call/src/cli-call-log.ts
@@ -1,12 +1,109 @@
 // Voice Call plugin module implements cli call log commands.
+import { once } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
-import { StringDecoder } from "node:string_decoder";
 import type { Command } from "commander";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sleep } from "../api.js";
-import { parseCliInteger, writeCliJson, writeCliLine } from "./cli-command-io.js";
-import { getCallHistoryFromStore } from "./manager/store.js";
+import { parseCliInteger, writeCliJson } from "./cli-command-io.js";
+import { getCallHistoryFromStore, MAX_CALL_RECORD_EVENTS } from "./manager/store.js";
+
+const READ_BYTES = 64 * 1024;
+type LogLine = { fd: number; start: number; end: number };
+
+async function writeLogChunk(chunk: string | Buffer): Promise<void> {
+  if (!process.stdout.write(chunk)) {
+    await once(process.stdout, "drain");
+  }
+}
+
+function* readLogLine({ fd, start, end }: LogLine): Generator<Buffer> {
+  for (let offset = start; offset < end;) {
+    const chunk = Buffer.alloc(Math.min(READ_BYTES, end - offset));
+    const bytesRead = fs.readSync(fd, chunk, 0, chunk.length, offset);
+    if (!bytesRead) {
+      throw new Error("Voice-call log was truncated while reading a record");
+    }
+    offset += bytesRead;
+    yield chunk.subarray(0, bytesRead);
+  }
+}
+
+async function* readLogLines(file: string, last: number, pollMs?: number): AsyncGenerator<LogLine> {
+  let initial = true;
+  let offset = 0;
+  let lineStart = 0;
+  let previous: fs.Stats | undefined;
+  const buffer = Buffer.alloc(READ_BYTES);
+  for (;;) {
+    let fd: number;
+    try {
+      fd = fs.openSync(file, "r");
+    } catch (error) {
+      if (initial || pollMs === undefined || !isRecord(error) || error.code !== "ENOENT") {
+        throw error;
+      }
+      // Rotation may temporarily remove the path; retain the old cursor until its replacement opens.
+      await sleep(pollMs);
+      continue;
+    }
+    try {
+      const stat = fs.fstatSync(fd);
+      if (
+        previous &&
+        (stat.ino !== previous.ino || stat.dev !== previous.dev || stat.size < previous.size)
+      ) {
+        offset = lineStart = 0;
+      }
+      previous = stat;
+      // Retain positions, not record contents. A partial record can span any number of polls.
+      const selected: LogLine[] = [];
+      let count = 0;
+      while (offset < stat.size) {
+        const length = Math.min(buffer.length, stat.size - offset);
+        const bytesRead = fs.readSync(fd, buffer, 0, length, offset);
+        if (!bytesRead) {
+          break;
+        }
+        const start = offset;
+        offset += bytesRead;
+        for (
+          let index = buffer.indexOf(10);
+          index >= 0 && index < bytesRead;
+          index = buffer.indexOf(10, index + 1)
+        ) {
+          const line = { fd, start: lineStart, end: start + index };
+          lineStart = line.end + 1;
+          if (line.end > line.start) {
+            if (!initial) {
+              yield line;
+            } else if (last > 0) {
+              selected[count++ % last] = line;
+            }
+          }
+        }
+        // Check copytruncate against the observed size before retrying a short follow read.
+        if (!initial && bytesRead < length) {
+          break;
+        }
+      }
+      if (pollMs === undefined && lineStart < offset) {
+        selected[count++ % last] = { fd, start: lineStart, end: offset };
+      }
+      // The next overwrite slot is the oldest retained line.
+      yield* selected.splice(last === 0 ? 0 : count % last);
+      yield* selected;
+    } finally {
+      // The descriptor also closes if the consumer fails while waiting for stdout.
+      fs.closeSync(fd);
+    }
+    initial = false;
+    if (pollMs === undefined) {
+      return;
+    }
+    await sleep(pollMs);
+  }
+}
 
 function percentile(values: number[], p: number): number {
   if (values.length === 0) {
@@ -44,11 +141,13 @@ function summarizeSeries(values: number[]): {
   };
 }
 
-function writeVoiceCallLatencySummary(calls: unknown[]) {
+async function writeVoiceCallLatencySummary(calls: Iterable<unknown> | AsyncIterable<unknown>) {
+  let recordsScanned = 0;
   const turnLatencyMs: number[] = [];
   const listenWaitMs: number[] = [];
 
-  for (const call of calls) {
+  for await (const call of calls) {
+    recordsScanned++;
     const metadata = isRecord(call) && isRecord(call.metadata) ? call.metadata : undefined;
     const latency = metadata?.lastTurnLatencyMs;
     const listenWait = metadata?.lastTurnListenWaitMs;
@@ -61,7 +160,7 @@ function writeVoiceCallLatencySummary(calls: unknown[]) {
   }
 
   writeCliJson({
-    recordsScanned: calls.length,
+    recordsScanned,
     turnLatency: summarizeSeries(turnLatencyMs),
     listenWait: summarizeSeries(listenWaitMs),
   });
@@ -74,7 +173,7 @@ export function registerVoiceCallLogs(params: {
 }): void {
   params.root
     .command("tail")
-    .description("Tail voice-call JSONL logs (prints new lines; useful during provider tests)")
+    .description("Tail persisted voice-call records or a custom JSONL log")
     .option("--file <path>", "Path to calls.jsonl", params.defaultFile)
     .option("--since <n>", "Print last N lines first", "25")
     .option("--poll <ms>", "Poll interval in ms", "250")
@@ -83,85 +182,39 @@ export function registerVoiceCallLogs(params: {
       const since = parseCliInteger(options.since, "--since", { min: 0 });
       const pollMs = parseCliInteger(options.poll, "--poll", { min: 50 });
 
-      const tailSqliteHistory = async (initialLimit: number): Promise<never> => {
-        params.ensureHistoryStateRuntime();
-        const seen = new Set<string>();
-        const printCall = (call: unknown): void => {
-          const line = JSON.stringify(call);
-          if (!seen.has(line)) {
-            seen.add(line);
-            writeCliLine(line);
-          }
-        };
-        if (initialLimit > 0) {
-          for (const call of await getCallHistoryFromStore(path.dirname(file), initialLimit)) {
-            printCall(call);
-          }
-        }
-        for (;;) {
-          try {
-            for (const call of await getCallHistoryFromStore(path.dirname(file), 1000)) {
-              printCall(call);
-            }
-          } catch {
-            // ignore and retry
-          }
-          await sleep(pollMs);
-        }
-      };
-
       if (fs.existsSync(file) && path.basename(file) !== "calls.jsonl") {
-        const initial = fs.readFileSync(file);
-        let decoder = new StringDecoder("utf8");
-        const initialLines = decoder.write(initial).split("\n");
-        let pendingLine = initialLines.pop() ?? "";
-        const lines = initialLines.filter(Boolean);
-        for (const line of lines.slice(Math.max(0, lines.length - since))) {
-          writeCliLine(line);
-        }
-
-        let offset = initial.length;
-        let lastObservedSize = initial.length;
-        for (;;) {
-          try {
-            const stat = fs.statSync(file);
-            // A short read can leave the cursor behind the observed file size;
-            // compare observed sizes so copytruncate also clears buffered text.
-            if (stat.size < lastObservedSize) {
-              offset = 0;
-              decoder = new StringDecoder("utf8");
-              pendingLine = "";
-            }
-            lastObservedSize = stat.size;
-            if (stat.size > offset) {
-              const fd = fs.openSync(file, "r");
-              try {
-                const buf = Buffer.alloc(stat.size - offset);
-                const bytesRead = fs.readSync(fd, buf, 0, buf.length, offset);
-                offset += bytesRead;
-                const text = decoder.write(buf.subarray(0, bytesRead));
-                const completeLines = `${pendingLine}${text}`.split("\n");
-                pendingLine = completeLines.pop() ?? "";
-                for (const line of completeLines.filter(Boolean)) {
-                  writeCliLine(line);
-                }
-              } finally {
-                fs.closeSync(fd);
-              }
-            }
-          } catch {
-            // ignore and retry
+        for await (const line of readLogLines(file, since, pollMs)) {
+          for (const chunk of readLogLine(line)) {
+            await writeLogChunk(chunk);
           }
-          await sleep(pollMs);
+          await writeLogChunk("\n");
         }
       } else {
-        await tailSqliteHistory(since);
+        params.ensureHistoryStateRuntime();
+        let initial = true;
+        let seen = new Set<string>();
+        for (;;) {
+          const lines = (
+            await getCallHistoryFromStore(path.dirname(file), MAX_CALL_RECORD_EVENTS)
+          ).map((call) => JSON.stringify(call));
+          for (const line of initial ? lines.slice(Math.max(0, lines.length - since)) : lines) {
+            if (!seen.has(line)) {
+              await writeLogChunk(`${line}\n`);
+              seen.add(line);
+            }
+          }
+          // Prime from all retained history, but print only --since initially.
+          // Later snapshots retire dedup entries with their store records.
+          seen = new Set(lines);
+          initial = false;
+          await sleep(pollMs);
+        }
       }
     });
 
   params.root
     .command("latency")
-    .description("Summarize turn latency metrics from voice-call JSONL logs")
+    .description("Summarize turn latency metrics from voice-call history or a custom JSONL log")
     .option("--file <path>", "Path to calls.jsonl", params.defaultFile)
     .option("--last <n>", "Analyze last N records", "200")
     .action(async (options: { file: string; last?: string }) => {
@@ -169,24 +222,27 @@ export function registerVoiceCallLogs(params: {
       const last = parseCliInteger(options.last, "--last", { min: 1 });
 
       if (fs.existsSync(file) && path.basename(file) !== "calls.jsonl") {
-        const content = fs.readFileSync(file, "utf8");
-        const calls = content
-          .split("\n")
-          .filter(Boolean)
-          .slice(-last)
-          .map((line) => {
+        async function* readCalls() {
+          for await (const line of readLogLines(file, last)) {
             try {
-              const parsed: unknown = JSON.parse(line);
-              return (isRecord(parsed) ? parsed.call : undefined) ?? parsed;
-            } catch {
-              return null;
+              const parsed: unknown = JSON.parse(
+                Buffer.concat([...readLogLine(line)]).toString("utf8"),
+              );
+              const call = (isRecord(parsed) ? parsed.call : undefined) ?? parsed;
+              if (call !== null) {
+                yield call;
+              }
+            } catch (error) {
+              if (!(error instanceof SyntaxError)) {
+                throw error;
+              }
             }
-          })
-          .filter((call) => call !== null);
-        writeVoiceCallLatencySummary(calls);
+          }
+        }
+        await writeVoiceCallLatencySummary(readCalls());
       } else {
         params.ensureHistoryStateRuntime();
-        writeVoiceCallLatencySummary(await getCallHistoryFromStore(path.dirname(file), last));
+        await writeVoiceCallLatencySummary(await getCallHistoryFromStore(path.dirname(file), last));
       }
     });
 }

--- a/extensions/voice-call/src/manager/store.test.ts
+++ b/extensions/voice-call/src/manager/store.test.ts
@@ -1,12 +1,14 @@
 // Voice Call tests cover store plugin behavior.
 import fs from "node:fs";
 import path from "node:path";
+import { Command } from "commander";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerVoiceCallLogs } from "../cli-call-log.js";
 import {
   createTestStorePath,
   makePersistedCall,
@@ -21,6 +23,12 @@ import {
   loadActiveCallsFromStore,
   persistCallRecord,
 } from "./store.js";
+
+const { sleepMock } = vi.hoisted(() => ({ sleepMock: vi.fn() }));
+vi.mock("../../api.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../api.js")>()),
+  sleep: sleepMock,
+}));
 
 const MANAGER_REPLAY_KEY_LIMIT = 10_000;
 
@@ -52,6 +60,49 @@ describe("voice-call call record store", () => {
   afterEach(() => {
     vi.useRealTimers();
     resetPluginStateStoreForTests();
+  });
+
+  it.each([0, 1])("honors SQLite tail --since %s before following new snapshots", async (since) => {
+    const storePath = createTestStorePath();
+    const calls = ["first", "second", "third"].map((callId) =>
+      CallRecordSchema.parse(makePersistedCall({ callId })),
+    );
+    const added = CallRecordSchema.parse(makePersistedCall({ callId: "new" }));
+    for (const call of calls) {
+      persistCallRecord(storePath, call);
+    }
+    const stopped = new Error("SQLite tail test finished");
+    sleepMock
+      .mockReset()
+      .mockRejectedValue(stopped)
+      .mockImplementationOnce(async () => {
+        persistCallRecord(storePath, added);
+      });
+    let output = "";
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      output += String(chunk);
+      return true;
+    });
+    const program = new Command();
+    registerVoiceCallLogs({
+      root: program,
+      defaultFile: path.join(storePath, "calls.jsonl"),
+      ensureHistoryStateRuntime: installStateRuntime,
+    });
+    try {
+      await expect(
+        program.parseAsync(["tail", "--since", String(since)], { from: "user" }),
+      ).rejects.toBe(stopped);
+      expect(
+        output
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line).callId),
+      ).toEqual(since === 0 ? ["new"] : ["third", "new"]);
+    } finally {
+      stdout.mockRestore();
+      fs.rmSync(storePath, { recursive: true, force: true });
+    }
   });
 
   it("does not import legacy JSONL records at runtime", async () => {


### PR DESCRIPTION
## What Problem This Solves

Replaces #111759 with a shared streaming implementation for Voice Call diagnostics. Custom JSONL tailing and latency analysis currently read whole files or appended regions into memory, and tailing keeps writing when stdout is blocked. SQLite tailing also retains every serialized snapshot for the process lifetime and unexpectedly backfills old history after `--since 0` or `--since 1`.

## Why This Change Was Made

One descriptor/range reader now owns complete-line framing, initial history selection, partial records, file replacement, observed truncation, and descriptor cleanup. Tail reads and writes 64 KiB chunks and awaits stdout drain. Latency parses selected records individually, preserving requested history, normal JSON semantics, malformed-record skipping, and a final unterminated JSON record. No arbitrary byte window or record-size cap is introduced.

The SQLite tail loop primes deduplication from the existing retained history while printing only the requested initial records, then replaces the seen set with each retained snapshot. This changes ephemeral CLI state only: no schema, persistence, retention, configuration, dependency, or SDK change.

## User Impact

Slow consumers no longer cause the CLI to queue the rest of a large append, rotation starts a fresh stream, and `--since 0` follows new snapshots without replaying old history. Documentation now distinguishes the default SQLite store from explicit custom JSONL diagnostics. Thanks @sunlit-deng for the original work and report.

## Evidence

- Failure-first owner tests reproduced whole-file reads, append-sized allocations, replacement corruption, ignored output backpressure, and lifetime deduplication. Real-store/registered-command regressions separately reproduced the incorrect `--since 0` and `--since 1` startup behavior.
- Final owner/store cohort: 19 passed; unchanged CLI sibling cohort: 22 passed. Existing short-read, copytruncate, partial-startup and UTF-8 controls remain unchanged and pass.
- Actual registered CLI with a real paused stdout pipe: the same 8,481,706-byte append produced exactly 8,481,717 output bytes before and after. Queued stdout fell from 4,242,477 to 66,207 bytes. Exact output hashes matched, source stayed unchanged during each run, and all owned processes and fixture state were cleaned up. This pressure proof preceded the final type-safe ring iteration cleanup; final-source history ordering was then checked separately. This is synthetic local CLI proof, not a carrier call or measured OOM.
- Codex autoreview: no actionable findings at the default blocking threshold. The full changed-file gate passed on the final source, including production and test types, lint, and all selected architecture guards. A final real registered-CLI probe also verified exact UTF-8 output and history order for wrapped and non-wrapped requested history, with complete child cleanup.

Production +144/-88 (net +56), tests +268, docs net +13. The shared reader removes duplicate whole-file/append decoding and nested tail wrappers; the remaining growth owns bounded range reads, file identity, and output backpressure. The original proposal added 214 production lines.

Latency memory still scales with the largest selected JSON record plus requested metric samples. Concurrent in-place rewrites are not atomic snapshots: inode replacement and observed shrink reset the stream, but an undetected same-inode truncate/regrow between polls cannot be inferred.
