### PR TITLE
fix: cancel narration requests when their turn ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Progress narration:** cancel utility-model requests when a turn ends or is replaced, and prevent stopped turns from starting late requests.
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.
 
 - **macOS AI setup:** show confirmed capability-review cancellation and retry guidance directly instead of a misleading Gateway failure headline. (#134573)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Progress narration:** cancel utility-model requests when a turn ends or is replaced, and prevent stopped turns from starting late requests.
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.
 
 - **macOS AI setup:** show confirmed capability-review cancellation and retry guidance directly instead of a misleading Gateway failure headline. (#134573)

--- a/docs/concepts/progress-drafts.md
+++ b/docs/concepts/progress-drafts.md
@@ -320,6 +320,9 @@ would render — never raw command output or tool results. With
 `commandText: "status"`, narration input also omits exec/bash command text,
 matching what the draft shows.
 
+Narration belongs to the current turn. Ending or replacing that turn cancels its
+pending utility-model request and prevents late results from updating the draft.
+
 ### Line limits
 
 Limit how many lines stay visible (default 8):

--- a/src/auto-reply/reply/progress-narrator-model.test.ts
+++ b/src/auto-reply/reply/progress-narrator-model.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { generateNarrationWithUtilityModel } from "./progress-narrator-model.js";
+
+const complete = vi.hoisted(() => vi.fn());
+vi.mock("../../agents/simple-completion-runtime.js", () => ({
+  completeWithPreparedSimpleCompletionModel: complete,
+  prepareSimpleCompletionModelForAgent: vi.fn(),
+}));
+
+const prepared: Parameters<typeof generateNarrationWithUtilityModel>[0]["prepared"] = {
+  selection: { provider: "openai", modelId: "gpt-test", agentDir: "/unused-narration-test" },
+  model: {
+    provider: "openai",
+    id: "gpt-test",
+    name: "Narration test",
+    api: "openai-responses",
+    baseUrl: "https://example.invalid/v1",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 8192,
+    maxTokens: 4096,
+  },
+  auth: { apiKey: "synthetic", source: "test", mode: "api-key" },
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  complete.mockReset();
+  complete.mockResolvedValue({
+    stopReason: "stop",
+    content: [{ type: "text", text: "Working on the request." }],
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("progress narration completion cancellation", () => {
+  it.each([false, true])(
+    "does not dispatch an already aborted request: aborted=%s",
+    async (aborted) => {
+      const controller = new AbortController();
+      if (aborted) {
+        controller.abort();
+      }
+
+      const result = await generateNarrationWithUtilityModel({
+        cfg: {},
+        prepared,
+        input: {
+          userMessage: "Inspect the fixture",
+          activityNotes: ["Tool read"],
+          previousText: "",
+        },
+        abortSignal: controller.signal,
+      });
+
+      expect(complete).toHaveBeenCalledTimes(aborted ? 0 : 1);
+      expect(result.text).toBe(aborted ? null : "Working on the request.");
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+});

--- a/src/auto-reply/reply/progress-narrator-model.ts
+++ b/src/auto-reply/reply/progress-narrator-model.ts
@@ -89,9 +89,11 @@ export async function generateNarrationWithUtilityModel(params: {
 }): Promise<{ text: string | null; error?: string }> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), NARRATION_TIMEOUT_MS);
-  const onOuterAbort = () => controller.abort();
-  params.abortSignal?.addEventListener("abort", onOuterAbort, { once: true });
+  const signal = params.abortSignal
+    ? AbortSignal.any([params.abortSignal, controller.signal])
+    : controller.signal;
   try {
+    signal.throwIfAborted();
     const result = await completeWithPreparedSimpleCompletionModel({
       model: params.prepared.model,
       auth: params.prepared.auth,
@@ -109,7 +111,7 @@ export async function generateNarrationWithUtilityModel(params: {
       options: {
         maxTokens: Math.min(NARRATION_MAX_TOKENS, Math.floor(params.prepared.model.maxTokens)),
         temperature: 0.3,
-        signal: controller.signal,
+        signal,
       },
     });
     if (result.stopReason === "error") {
@@ -128,6 +130,5 @@ export async function generateNarrationWithUtilityModel(params: {
     return { text: null, error: String(err) };
   } finally {
     clearTimeout(timeout);
-    params.abortSignal?.removeEventListener("abort", onOuterAbort);
   }
 }

--- a/src/auto-reply/reply/progress-narrator.test.ts
+++ b/src/auto-reply/reply/progress-narrator.test.ts
@@ -1,5 +1,6 @@
 // Progress narrator tests cover trigger policy, gating, and reply-option wiring.
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { PROGRESS_STATUS_PREAMBLE_FRESH_MS } from "../../channels/progress-draft-compositor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { GetReplyOptions } from "../get-reply-options.types.js";
@@ -8,6 +9,12 @@ import type { ProgressNarrationInput } from "./progress-narrator-model.js";
 
 const narratorWarnSpy = vi.hoisted(() => vi.fn());
 const narrationModelMocks = vi.hoisted(() => ({
+  prepared: {
+    selection: { provider: "openai", modelId: "gpt-5.5-mini" },
+    model: {},
+    auth: {},
+  },
+  prepare: vi.fn(),
   generate: vi.fn(),
 }));
 vi.mock("../../logging/subsystem.js", async (importOriginal) => {
@@ -25,14 +32,16 @@ vi.mock("./progress-narrator-model.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./progress-narrator-model.js")>();
   return {
     ...actual,
-    prepareNarrationModel: vi.fn(async () => ({
-      selection: { provider: "openai", modelId: "gpt-5.5-mini" },
-      model: {},
-      auth: {},
-    })),
+    prepareNarrationModel: narrationModelMocks.prepare,
     generateNarrationWithUtilityModel: vi.fn(
-      async ({ input }: { input: ProgressNarrationInput }) => ({
-        text: await narrationModelMocks.generate(input),
+      async ({
+        input,
+        abortSignal,
+      }: {
+        input: ProgressNarrationInput;
+        abortSignal?: AbortSignal;
+      }) => ({
+        text: await narrationModelMocks.generate(input, abortSignal),
       }),
     ),
   };
@@ -55,19 +64,18 @@ async function flushNarrations() {
 
 function createNarratorHarness(params?: {
   texts?: Array<string | null>;
-  generate?: (input: ProgressNarrationInput) => Promise<string | null>;
+  generate?: (input: ProgressNarrationInput, signal?: AbortSignal) => Promise<string | null>;
+  abortSignal?: AbortSignal;
   now?: () => number;
   hideCommandText?: boolean;
   isProgressDraftVisible?: () => boolean;
-  setTimeoutFn?: typeof setTimeout;
-  clearTimeoutFn?: typeof clearTimeout;
 }) {
   const inputs: ProgressNarrationInput[] = [];
   const texts = params?.texts ?? ["Working on the request."];
-  const generate = vi.fn(async (input: ProgressNarrationInput) => {
+  const generate = vi.fn(async (input: ProgressNarrationInput, signal?: AbortSignal) => {
     inputs.push(input);
     return params?.generate
-      ? await params.generate(input)
+      ? await params.generate(input, signal)
       : (texts[Math.min(inputs.length - 1, texts.length - 1)] ?? null);
   });
   const onUpdate = vi.fn();
@@ -84,6 +92,7 @@ function createNarratorHarness(params?: {
     userMessage: "change the default model",
     opts: {
       onNarrationUpdate: onUpdate,
+      abortSignal: params?.abortSignal,
       onToolStart: vi.fn(),
       onCommandOutput: vi.fn(),
       onItemEvent: vi.fn(),
@@ -120,8 +129,13 @@ function createNarratorHarness(params?: {
   return { narrator, generate, onUpdate, inputs };
 }
 
+beforeEach(() => {
+  narrationModelMocks.prepare.mockResolvedValue(narrationModelMocks.prepared);
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
+  narrationModelMocks.prepare.mockReset();
   narrationModelMocks.generate.mockReset();
 });
 
@@ -154,8 +168,6 @@ describe("progress narration through reply options", () => {
       let visible = false;
       const { narrator, generate, inputs } = createNarratorHarness({
         isProgressDraftVisible: () => visible,
-        setTimeoutFn: setTimeout,
-        clearTimeoutFn: clearTimeout,
       });
 
       narrator.noteToolStart({ name: "exec", phase: "start", args: { command: "first" } });
@@ -180,8 +192,6 @@ describe("progress narration through reply options", () => {
     try {
       const { narrator, generate } = createNarratorHarness({
         isProgressDraftVisible: () => false,
-        setTimeoutFn: setTimeout,
-        clearTimeoutFn: clearTimeout,
       });
 
       narrator.noteToolStart({ name: "exec", phase: "start" });
@@ -206,8 +216,6 @@ describe("progress narration through reply options", () => {
       const { narrator, generate } = createNarratorHarness({
         texts: ["Running a command.", "The command failed."],
         isProgressDraftVisible: () => visible,
-        setTimeoutFn: setTimeout,
-        clearTimeoutFn: clearTimeout,
       });
 
       narrator.noteToolStart({ name: "exec", phase: "start" });
@@ -232,8 +240,6 @@ describe("progress narration through reply options", () => {
       let visible = false;
       const { narrator, generate, inputs } = createNarratorHarness({
         isProgressDraftVisible: () => visible,
-        setTimeoutFn: setTimeout,
-        clearTimeoutFn: clearTimeout,
       });
 
       narrator.noteItemEvent({ kind: "preamble", progressText: "Primary turn work." });
@@ -255,19 +261,81 @@ describe("progress narration through reply options", () => {
   });
 
   it("drops a utility-model result that settles after the turn stops", async () => {
-    let resolveGeneration: ((text: string) => void) | undefined;
+    const started = createDeferred();
+    const generation = createDeferred<string>();
     const { narrator, onUpdate } = createNarratorHarness({
-      generate: () =>
-        new Promise<string>((resolve) => {
-          resolveGeneration = resolve;
-        }),
+      generate: () => {
+        started.resolve();
+        return generation.promise;
+      },
     });
 
     narrator.noteToolStart({ name: "exec", phase: "start" });
+    await started.promise;
     narrator.stopTurn();
-    resolveGeneration?.("Stale status.");
+    generation.resolve("Stale status.");
     await flushNarrations();
 
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])(
+    "does not start a stopped turn after preparation with replacement=%s",
+    async (replaceBeforePrepared) => {
+      const preparation = createDeferred<typeof narrationModelMocks.prepared>();
+      narrationModelMocks.prepare.mockReturnValueOnce(preparation.promise);
+      const { narrator, generate, onUpdate, inputs } = createNarratorHarness();
+      const beginReplacement = () => {
+        narrator.beginTurn();
+        narrator.noteToolStart({ name: "read", phase: "start" });
+      };
+
+      narrator.noteToolStart({ name: "exec", phase: "start" });
+      expect(narrationModelMocks.prepare).toHaveBeenCalledOnce();
+      narrator.stopTurn();
+      if (replaceBeforePrepared) {
+        beginReplacement();
+      }
+      preparation.resolve(narrationModelMocks.prepared);
+      await flushNarrations();
+
+      if (!replaceBeforePrepared) {
+        expect(generate).not.toHaveBeenCalled();
+        expect(onUpdate).not.toHaveBeenCalled();
+        beginReplacement();
+        await flushNarrations();
+      }
+      expect(narrationModelMocks.prepare).toHaveBeenCalledOnce();
+      expect(generate).toHaveBeenCalledOnce();
+      expect(inputs[0]?.userMessage).toBe("");
+      expect(inputs[0]?.activityNotes).toEqual(["Tool read"]);
+      expect(onUpdate).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("cancels active narration at final without aborting its caller", async () => {
+    const outer = new AbortController();
+    const started = createDeferred<AbortSignal | undefined>();
+    const generation = createDeferred<string>();
+    const { narrator, onUpdate } = createNarratorHarness({
+      abortSignal: outer.signal,
+      generate: (_input, signal) => {
+        started.resolve(signal);
+        return generation.promise;
+      },
+    });
+
+    narrator.noteToolStart({ name: "exec", phase: "start" });
+    const signal = await started.promise;
+    try {
+      expect(signal?.aborted).toBe(false);
+      narrator.stopTurn();
+      expect(signal?.aborted).toBe(true);
+      expect(outer.signal.aborted).toBe(false);
+    } finally {
+      generation.resolve("Stale status.");
+      await flushNarrations();
+    }
     expect(onUpdate).not.toHaveBeenCalled();
   });
 
@@ -277,8 +345,6 @@ describe("progress narration through reply options", () => {
       let nowMs = 0;
       const { narrator, generate, inputs } = createNarratorHarness({
         now: () => nowMs,
-        setTimeoutFn: setTimeout,
-        clearTimeoutFn: clearTimeout,
       });
 
       narrator.noteItemEvent({
@@ -303,10 +369,7 @@ describe("progress narration through reply options", () => {
   it("does not let silent or directive-only preambles suppress narration", async () => {
     vi.useFakeTimers();
     try {
-      const { narrator, generate, inputs } = createNarratorHarness({
-        setTimeoutFn: setTimeout,
-        clearTimeoutFn: clearTimeout,
-      });
+      const { narrator, generate, inputs } = createNarratorHarness();
 
       narrator.noteItemEvent({ kind: "preamble", progressText: "[[reply_to_current]]" });
       narrator.noteItemEvent({

--- a/src/auto-reply/reply/progress-narrator.ts
+++ b/src/auto-reply/reply/progress-narrator.ts
@@ -58,15 +58,7 @@ function createProgressNarrator(params: {
   abortSignal?: AbortSignal;
   /** Mirror of the channel's commandText: "status" policy for narration input. */
   hideCommandText?: boolean;
-  /** Test seam: replaces the utility-model completion. */
-  generate?: (input: ProgressNarrationInput) => Promise<string | null>;
-  now?: () => number;
-  setTimeoutFn?: typeof setTimeout;
-  clearTimeoutFn?: typeof clearTimeout;
 }) {
-  const now = params.now ?? Date.now;
-  const setTimeoutFn = params.setTimeoutFn ?? setTimeout;
-  const clearTimeoutFn = params.clearTimeoutFn ?? clearTimeout;
   let activity = createSessionActivityNoteState();
   let disabled = false;
   let inFlight = false;
@@ -83,21 +75,22 @@ function createProgressNarrator(params: {
   let visibilityRetryCount = 0;
   let retryTimer: ReturnType<typeof setTimeout> | undefined;
   let retryImmediate = false;
-  let turnGeneration = 0;
-  let turnActive = true;
+  // Each turn owns cancellation; replacing it fences old continuations without
+  // discarding the prepared model shared by queued turns.
+  let turnController = new AbortController();
   let userMessage = params.userMessage ?? "";
 
   const clearRetryTimer = () => {
     if (retryTimer !== undefined) {
-      clearTimeoutFn(retryTimer);
+      clearTimeout(retryTimer);
       retryTimer = undefined;
     }
     retryImmediate = false;
   };
 
   const resetTurnState = () => {
-    turnGeneration += 1;
-    turnActive = true;
+    turnController.abort();
+    turnController = new AbortController();
     // Queued turns reuse the narrator lifecycle but not the primary request.
     // Empty context is safer than describing follow-up work with stale intent.
     userMessage = "";
@@ -117,11 +110,7 @@ function createProgressNarrator(params: {
   };
 
   const stopTurn = () => {
-    if (!turnActive) {
-      return;
-    }
-    turnGeneration += 1;
-    turnActive = false;
+    turnController.abort();
     inFlight = false;
     pendingImmediate = false;
     clearRetryTimer();
@@ -144,33 +133,32 @@ function createProgressNarrator(params: {
     });
   }
 
-  const generate =
-    params.generate ??
-    (async (input: ProgressNarrationInput) => {
-      preparedPromise ??= prepareNarrationModel({ cfg: params.cfg, agentId: params.agentId });
-      const prepared = await preparedPromise;
-      if (!prepared) {
-        disableNarration();
-        return null;
-      }
-      const { provider, modelId, profileId } = prepared.selection;
-      utilityModelLabel = `${provider}/${modelId}${profileId ? ` via ${profileId}` : ""}`;
-      const outcome = await generateNarrationWithUtilityModel({
-        cfg: params.cfg,
-        prepared,
-        input,
-        abortSignal: params.abortSignal,
-      });
-      lastFailure = outcome.error;
-      return outcome.text;
+  const generate = async (input: ProgressNarrationInput, abortSignal: AbortSignal) => {
+    preparedPromise ??= prepareNarrationModel({ cfg: params.cfg, agentId: params.agentId });
+    const prepared = await preparedPromise;
+    if (abortSignal.aborted) {
+      return null;
+    }
+    if (!prepared) {
+      disableNarration();
+      return null;
+    }
+    const { provider, modelId, profileId } = prepared.selection;
+    utilityModelLabel = `${provider}/${modelId}${profileId ? ` via ${profileId}` : ""}`;
+    return await generateNarrationWithUtilityModel({
+      cfg: params.cfg,
+      prepared,
+      input,
+      abortSignal,
     });
+  };
 
   const recordEvent = (
     stream: AgentEventStream,
     data: Record<string, unknown>,
     options?: { immediate?: boolean; flushAssistant?: boolean },
   ): void => {
-    if (!turnActive || disabled || params.abortSignal?.aborted) {
+    if (turnController.signal.aborted || disabled || params.abortSignal?.aborted) {
       return;
     }
     visibilityRetryCount = 0;
@@ -179,7 +167,7 @@ function createProgressNarrator(params: {
       runId: "progress-narrator",
       seq: sequenceBefore + 1,
       stream,
-      ts: now(),
+      ts: Date.now(),
       data,
     };
     noteSessionActivityEvent(activity, event, NARRATION_NOTE_MAX_CHARS);
@@ -203,21 +191,21 @@ function createProgressNarrator(params: {
     if (newNotes >= MIN_EVENTS_PER_NARRATION) {
       return true;
     }
-    return now() - lastRunAt >= MIN_INTERVAL_MS;
+    return Date.now() - lastRunAt >= MIN_INTERVAL_MS;
   };
 
   // Skips retain note bookkeeping; one replaceable timer rechecks the active gate.
   const scheduleRetry = (delayMs: number, immediate: boolean) => {
     retryImmediate ||= immediate;
     if (retryTimer !== undefined) {
-      clearTimeoutFn(retryTimer);
+      clearTimeout(retryTimer);
       retryTimer = undefined;
     }
-    if (!turnActive || disabled || params.abortSignal?.aborted) {
+    if (turnController.signal.aborted || disabled || params.abortSignal?.aborted) {
       retryImmediate = false;
       return;
     }
-    retryTimer = setTimeoutFn(
+    retryTimer = setTimeout(
       () => {
         retryTimer = undefined;
         const rerunImmediate = retryImmediate;
@@ -229,7 +217,7 @@ function createProgressNarrator(params: {
   };
 
   function maybeRun(immediate: boolean) {
-    if (!turnActive || disabled || params.abortSignal?.aborted) {
+    if (turnController.signal.aborted || disabled || params.abortSignal?.aborted) {
       clearRetryTimer();
       return;
     }
@@ -240,7 +228,7 @@ function createProgressNarrator(params: {
       }
       return;
     }
-    const preambleAge = lastPreambleAt === undefined ? undefined : now() - lastPreambleAt;
+    const preambleAge = lastPreambleAt === undefined ? undefined : Date.now() - lastPreambleAt;
     if (preambleAge !== undefined && preambleAge < PROGRESS_STATUS_PREAMBLE_FRESH_MS) {
       scheduleRetry(
         PROGRESS_STATUS_PREAMBLE_FRESH_MS - preambleAge + PREAMBLE_RETRY_EPSILON_MS,
@@ -262,10 +250,10 @@ function createProgressNarrator(params: {
     }
     visibilityRetryCount = 0;
     inFlight = true;
-    const runGeneration = turnGeneration;
+    const runSignal = turnController.signal;
     narrationCount += 1;
     noteSequenceAtLastRun = activity.noteSequence;
-    lastRunAt = now();
+    lastRunAt = Date.now();
     const input: ProgressNarrationInput = {
       userMessage,
       activityNotes: activity.notes.map((note) => note.text),
@@ -273,11 +261,12 @@ function createProgressNarrator(params: {
     };
     void (async () => {
       try {
-        const raw = await generate(input);
-        if (!turnActive || runGeneration !== turnGeneration) {
+        const outcome = await generate(input, runSignal);
+        if (runSignal.aborted) {
           return;
         }
-        const text = raw ? normalizeNarrationText(raw) : "";
+        lastFailure = outcome?.error;
+        const text = outcome?.text ? normalizeNarrationText(outcome.text) : "";
         if (!text) {
           consecutiveFailures += 1;
           if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
@@ -302,7 +291,7 @@ function createProgressNarrator(params: {
       } catch (err) {
         logVerbose(`progress-narrator: update failed: ${String(err)}`);
       } finally {
-        if (runGeneration === turnGeneration) {
+        if (!runSignal.aborted) {
           inFlight = false;
           const rerunImmediate = pendingImmediate;
           pendingImmediate = false;
@@ -368,7 +357,7 @@ function createProgressNarrator(params: {
         if (!preambleText) {
           return;
         }
-        lastPreambleAt = now();
+        lastPreambleAt = Date.now();
         recordEvent("assistant", { text: preambleText }, { flushAssistant: true });
         return;
       }


### PR DESCRIPTION
## What Problem This Solves

Ending a turn could leave its progress-narration model request running. If the turn ended while the utility model was still being prepared, the old continuation could even start a request afterward. Existing stale-result checks hid the text but did not stop the work.

## Why This Change Was Made

Each narration turn now owns an AbortController. Stopping or replacing the turn cancels its completion and fences continuations after preparation, while queued turns keep sharing the prepared model. The completion adapter composes turn cancellation with its existing timeout and rejects an already-aborted request before dispatch.

This replaces the separate active flag and generation counter and removes unused private test-injection options. Production **+46/−56, net −10**; tests **+162/−33, net +129**. No public configuration, provider selection, timeout budget, persistence, schema or protocol changes.

## User Impact

Progress narration stops consuming a model request after its turn ends, and a replacement turn reports only its own activity. This is a separate lifecycle defect found during Gateway profiling: the `deliver:false` concurrency benchmark does not enter this channel-narration path, so this PR does not claim to repair that benchmark's saturation.

## Evidence

- Four regression cases fail on the original source: stopping during preparation, replacing a stopped turn during preparation, cancelling an active completion, and rejecting an already-aborted completion. All **28 focused cases pass** after the fix. The existing late-result case now waits for the completion to start, and passes on both revisions.
- **83 sibling cases pass**, covering Discord draft/final delivery, Gateway observer/preparation, and prepared simple completions.
- An isolated loopback HTTP server exercised the real narrator, model preparation and OpenAI-compatible streaming transport without module mocks. Stopping the turn closed the held HTTP stream in **502.8 ms**; no stale update appeared; a replacement request produced only its new activity; pre-aborted generation sent no additional request. Exactly two requests were observed, and the server, process and temporary HOME were cleaned up.
- Managed Codex P0 review and direct owner/caller review found no actionable defect. The complete changed-code gate passed in 2,002.1 seconds, and the default build passed in 835.2 seconds with the reviewed source unchanged. The operator documentation describes cancellation at turn closure; release-generated CHANGELOG.md remains unchanged.

Current exact head `92a308a929b9742a25a0976b6de1b5bd7df8a14f` also passed clean Linux validation on Node 24.19.0: 28 focused cases, the original ordered 83-case sibling batch, the full changed-file gate (1,130.1 seconds), and the default build (324.9 seconds). All 35,973 tracked source entries and the five reviewed afterimages were verified unchanged before and after. The built Control UI is 348,199 bytes of startup JavaScript gzip and passes the committed performance budgets. Synthetic HOME/state cleanup and the downloaded evidence bundle SHA256 were verified. [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/33487264604).

Commands: `node scripts/run-vitest.mjs src/auto-reply/reply/progress-narrator.test.ts src/auto-reply/reply/progress-narrator-model.test.ts --maxWorkers=1 --reporter=verbose`; `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.process.draft-final.test.ts src/gateway/session-observer-preparation.test.ts src/gateway/session-observer.test.ts src/agents/simple-completion-execution.test.ts --maxWorkers=1 --reporter=verbose`; `node scripts/check-changed.mjs -- docs/concepts/progress-drafts.md src/auto-reply/reply/progress-narrator-model.test.ts src/auto-reply/reply/progress-narrator-model.ts src/auto-reply/reply/progress-narrator.test.ts src/auto-reply/reply/progress-narrator.ts`; `pnpm build`; `node --import ./scripts/tsx.mjs scripts/check-control-ui-performance.mts --json`.

The earlier local refresh passed 28 focused and 43 Gateway/simple-completion cases, but Discord stopped in its unchanged 180-second import setup hook before running its 40 cases. That failure is retained; the exact-source Linux run above passes all 40. No timeout, assertion, or performance budget was increased. Required exact-head [PR CI](https://github.com/openclaw/openclaw/actions/runs/33490027479) passed on the same head: 198 successful jobs and 16 intentional skips, including the required `openclaw/ci-gate`. The repository-native hosted prepare and merge gates remain mandatory. The completed ClawSweeper review has no code finding; its validation and ready-state next steps are satisfied.

No authenticated Discord roundtrip was run: the local QA credential broker variables are unavailable, and the existing manual hosted entry point starts all channel lanes rather than this bounded narration scenario. The existing mock progress scenario also lacks an explicit utility model, so it would not prove this path unchanged. The HTTP transport proof and Discord regression suites above are not represented as a live Discord send.
