### PR TITLE
test(mac): skip discarded native fixture copies

### DIFF
--- a/test/scripts/verify-mac-node-worker-fs.test.ts
+++ b/test/scripts/verify-mac-node-worker-fs.test.ts
@@ -40,8 +40,8 @@ describe.skipIf(process.platform !== "darwin")("Mac worker bundled filesystem pr
     for (const bundle of bundles) {
       await bundle[Symbol.asyncDispose]();
     }
-    // Seed genuine assets even before the producer repair lands; negative fixtures
-    // must remove them explicitly rather than depend on today's build omission.
+    // Keep the template populated even if the producer omits assets; each probe
+    // selects its native path independently.
     fs.cpSync(path.join(dependency, "dist/native"), path.join(compiled, "dist/native"), {
       recursive: true,
     });
@@ -52,8 +52,10 @@ describe.skipIf(process.platform !== "darwin")("Mac worker bundled filesystem pr
     const directory = fixtures.make("openclaw-worker-fs-proof-");
     const runtime = path.join(directory, "runtime");
     const packageRoot = path.join(runtime, "lib/node_modules/openclaw");
-    fs.cpSync(compiled, packageRoot, { recursive: true });
-    fs.rmSync(path.join(packageRoot, "dist/native"), { recursive: true });
+    fs.cpSync(compiled, packageRoot, {
+      recursive: true,
+      filter: (source) => source !== path.join(compiled, "dist/native"),
+    });
     const home = path.join(directory, "home");
     fs.mkdirSync(home);
     const dependencyRoot = path.join(packageRoot, "node_modules/@openclaw/fs-safe");
@@ -170,7 +172,7 @@ registerHooks({
 
   it("accepts completed SDK write/create bytes and exactly the bundled native cache path", () => {
     const { packageRoot, home, native } = fixture();
-    // Disposable fixture only: the build's native-asset producer is a separate repair.
+    // This probe supplies the bundled payload; the other probes choose missing or misplaced paths.
     fs.cpSync(path.join(dependency, "dist/native"), path.join(packageRoot, "dist/native"), {
       recursive: true,
     });


### PR DESCRIPTION
## What Problem This Solves

Four Mac worker filesystem fixtures copy the compiled native payload and immediately remove it before selecting their own missing or misplaced payload.

## Why This Change Was Made

Exclude that exact source directory from the copy. Keep genuine assets in the compiled template and leave each test responsible for its selected native path. Update stale fixture comments to describe current ownership.

## User Impact

Test-only: four discarded native-tree copies and four removal traversals disappear. The installed seven-file payload totals 16,233,360 bytes, avoiding 64,933,440 logical requested copy bytes across the fixtures. This is not measured physical I/O or elapsed savings. Production +0/-0; tests +7/-5.

## Evidence

All four cases pass before and after on macOS, including real compiled SDK write/create bytes, exact native cache paths, omitted payload and misplaced-library rejection. Full changed checks, including the required macOS Node CI tests, and Codex autoreview pass. Assertions, compiler inputs, dependencies and deadlines are unchanged.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/verify-mac-node-worker-fs.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base a514fc0497fba619979f9617450f1b3a41e1237a
```
