### PR TITLE
refactor: remove duplicated Claude model checks

### DIFF
--- a/src/plugin-sdk/provider-model-shared.test.ts
+++ b/src/plugin-sdk/provider-model-shared.test.ts
@@ -77,7 +77,6 @@ describe("Claude model contracts", () => {
     ["Anthropic API", { id: "claude-opus-5" }, "claude-opus-5"],
     ["Anthropic alias", { id: "opus" }, "claude-opus-5"],
     ["Anthropic version alias", { id: "opus-5" }, "claude-opus-5"],
-    ["Claude CLI", { id: "claude-opus-5" }, "claude-opus-5"],
     ["Vertex AI", { id: "claude-opus-5@20260701" }, "claude-opus-5@20260701"],
     ["Amazon Bedrock", { id: "global.anthropic.claude-opus-5" }, "claude-opus-5"],
     [
@@ -139,7 +138,7 @@ describe("Claude model contracts", () => {
 
 describe("modelCostsEqual", () => {
   it("matches complete flat rates and rejects missing or stale metadata", () => {
-    expect(modelCostsEqual(EXPECTED_COST, EXPECTED_COST)).toBe(true);
+    expect(modelCostsEqual({ ...EXPECTED_COST }, EXPECTED_COST)).toBe(true);
     expect(modelCostsEqual(undefined, EXPECTED_COST)).toBe(false);
     expect(modelCostsEqual({ ...EXPECTED_COST, output: 15 }, EXPECTED_COST)).toBe(false);
   });

--- a/src/plugins/provider-claude-thinking.ts
+++ b/src/plugins/provider-claude-thinking.ts
@@ -45,16 +45,13 @@ export function resolveClaudeThinkingProfile(
   if (resolveClaudeFable5ModelIdentity(ref) || resolveClaudeMythos5ModelIdentity(ref)) {
     return CLAUDE_FABLE_5_THINKING_PROFILE;
   }
+  // Before the generic xhigh branch: Opus 5 defaults thinking on ("high"),
+  // unlike Opus 4.7/4.8 whose omitted-thinking default is off.
   if (resolveClaudeOpus5ModelIdentity(ref)) {
     return CLAUDE_OPUS_5_THINKING_PROFILE;
   }
   if (resolveClaudeSonnet5ModelIdentity(ref)) {
     return CLAUDE_SONNET_5_THINKING_PROFILE;
-  }
-  // Before the generic xhigh branch: Opus 5 defaults thinking on ("high"),
-  // unlike Opus 4.7/4.8 whose omitted-thinking default is off.
-  if (resolveClaudeOpus5ModelIdentity(ref)) {
-    return CLAUDE_OPUS_5_THINKING_PROFILE;
   }
   if (requiresClaudeMandatoryAdaptiveThinking(ref)) {
     return {


### PR DESCRIPTION
## What Problem This Solves

Claude model coverage repeats an identical identity-table invocation, while its thinking-profile owner repeats an unreachable Opus check. The nearby cost-comparison test also compares an object with itself, so it would accept an incorrect identity-only comparator.

## Why This Change Was Made

Remove the duplicate table row and second Opus branch, preserving the existing ordering explanation above the retained branch. Strengthen the existing cost assertion with an equal, separately allocated object. Distinct model aliases, provider identity formats, default thinking levels, and actual Anthropic API/CLI policy coverage remain.

## User Impact

Production behavior is unchanged. The removed table row never invokes the CLI: its unused label is the only difference from the retained Anthropic API row. Production is +2/-5 and tests are +1/-2. No public export, option, provider route, or compatibility contract changes.

## Evidence

The original SDK, shared thinking, and Anthropic policy suites passed all 135 cases. With a temporary identity-only comparator, the original cost case passed; the strengthened case failed at the positive equality assertion. The correct production comparator was restored exactly before the normal after run. This demonstrates a better test oracle, not a current production defect.

The normal after run passed all 134 cases (42 SDK, 77 shared thinking, 15 Anthropic policy). Every surviving case kept its name and execution order. An independent audit verified the two afterimages, restored comparator, and raw control/test logs. All 34 changed checks passed, including core/plugin typechecks, lint, SDK boundaries, unused exports and architecture guards. The mandatory managed Codex review completed clean in its selected P0 scope; the independent full coverage audit found no gap. The normal `pnpm build` also passed with the reviewed source unchanged. Exact-head hosted CI 33471894232 has now completed successfully. Native landing remains pending.

The completed review reported that its partial clone could not retrieve current-main blobs or live comments after a DNS failure. The maintainer has read that full review and independently compared the 27 owner, caller, sibling, dependency and test-context files on main 36b18316eb50. All 26 other files match the proven baseline exactly; the sole package.json delta splits unrelated macOS CI scripts, leaving the tested commands and all dependencies unchanged. The two candidate afterimages and full patch remain unchanged. This closes that reviewer-environment gap without a source refresh or an additional test run.

The normal native main capture e92637ab84fc also matches all 136 qualified source and native-tooling entries. Native artifact validation explicitly records the unchanged branch outcomes exercised by the retained owner and sibling suites.
