### PR TITLE
refactor(memory-wiki): share person-page classification

### DIFF
--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -65,6 +65,7 @@ import {
   WIKI_RELATED_START_MARKER,
 } from "./markdown.js";
 import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
+import { isPersonLikePage } from "./person-page.js";
 import { readMemoryWikiSourceSyncState } from "./source-sync-state.js";
 import { activateExistingMemoryWikiVault, initializeMemoryWikiVault } from "./vault.js";
 import { buildMemoryWikiOverview, projectMemoryWikiOverviewItem } from "./wiki-overview.js";
@@ -508,18 +509,6 @@ function formatListPreview(values: readonly string[], maxItems = 3): string | nu
 
 function formatMaybeDetail(label: string, value: string | null | undefined): string | null {
   return value ? `${label} ${value}` : null;
-}
-
-function isPersonLikePage(page: WikiPageSummary): boolean {
-  const entityType = normalizeLowercaseStringOrEmpty(page.entityType);
-  const pageType = normalizeLowercaseStringOrEmpty(page.pageType);
-  return (
-    Boolean(page.personCard) ||
-    entityType === "person" ||
-    entityType === "maintainer" ||
-    pageType === "person" ||
-    pageType === "maintainer"
-  );
 }
 
 function formatPersonDirectoryLine(

--- a/extensions/memory-wiki/src/person-page.ts
+++ b/extensions/memory-wiki/src/person-page.ts
@@ -1,0 +1,16 @@
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { WikiPageSummary } from "./markdown.js";
+
+export function isPersonLikePage(
+  page: Pick<WikiPageSummary, "entityType" | "pageType" | "personCard">,
+): boolean {
+  const entityType = normalizeLowercaseStringOrEmpty(page.entityType);
+  const pageType = normalizeLowercaseStringOrEmpty(page.pageType);
+  return (
+    Boolean(page.personCard) ||
+    entityType === "person" ||
+    entityType === "maintainer" ||
+    pageType === "person" ||
+    pageType === "maintainer"
+  );
+}

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -28,6 +28,7 @@ import {
   type WikiClaim,
   type WikiPageSummary,
 } from "./markdown.js";
+import { isPersonLikePage } from "./person-page.js";
 import { initializeMemoryWikiVault } from "./vault.js";
 
 const QUERY_DIRS = ["entities", "concepts", "sources", "syntheses", "reports"] as const;
@@ -567,20 +568,6 @@ function hasRouteQuestionMatch(values: readonly string[], queryLower: string): b
   return hasAnyQueryMatch(values, queryLower, buildRouteQuestionTokens(queryLower));
 }
 
-function isPersonLikeSummary(
-  page: Pick<WikiPageSummary, "entityType" | "pageType" | "personCard">,
-): boolean {
-  const entityType = normalizeLowercaseStringOrEmpty(page.entityType);
-  const pageType = normalizeLowercaseStringOrEmpty(page.pageType);
-  return (
-    Boolean(page.personCard) ||
-    entityType === "person" ||
-    entityType === "maintainer" ||
-    pageType === "person" ||
-    pageType === "maintainer"
-  );
-}
-
 function scorePageSearchModeBoost(params: {
   page: QueryableWikiPage;
   matchingClaims: readonly WikiClaim[];
@@ -593,7 +580,7 @@ function scorePageSearchModeBoost(params: {
     case "auto":
       return 0;
     case "find-person": {
-      let score = isPersonLikeSummary(page) ? 24 : -4;
+      let score = isPersonLikePage(page) ? 24 : -4;
       if (
         hasAnyQueryMatch(
           [
@@ -613,7 +600,7 @@ function scorePageSearchModeBoost(params: {
       return score;
     }
     case "route-question": {
-      let score = isPersonLikeSummary(page) ? 14 : 0;
+      let score = isPersonLikePage(page) ? 14 : 0;
       if (hasRouteQuestionMatch(buildPageRouteQuestionFields(page), queryLower)) {
         score += 32;
       }
@@ -664,7 +651,7 @@ function scoreDigestSearchModeBoost(params: {
     case "auto":
       return 0;
     case "find-person": {
-      let score = isPersonLikeSummary(page) ? 24 : -4;
+      let score = isPersonLikePage(page) ? 24 : -4;
       if (
         hasAnyQueryMatch(
           [
@@ -684,7 +671,7 @@ function scoreDigestSearchModeBoost(params: {
       return score;
     }
     case "route-question": {
-      let score = isPersonLikeSummary(page) ? 14 : 0;
+      let score = isPersonLikePage(page) ? 14 : 0;
       if (hasRouteQuestionMatch(buildDigestRouteQuestionFields(page), queryLower)) {
         score += 32;
       }


### PR DESCRIPTION
## What Problem This Solves

Memory Wiki classified person-like pages in two separate private predicates. Compile-time directory generation and live/compiled query ranking could drift even though they own the same person, maintainer, and person-card invariant.

## Why This Change Was Made

Moves that invariant into one plugin-private `isPersonLikePage` helper and deletes both local copies. The helper stays inside Memory Wiki with direct imports only; it adds no barrel, core, Plugin SDK, config, persistence, or public API surface.

Classification behavior is unchanged:

- a present `personCard` qualifies
- normalized `entityType` or `pageType` equal to `person` qualifies
- normalized `entityType` or `pageType` equal to `maintainer` qualifies

The dedicated module owns cross-cutting page classification. `markdown.ts` remains the parser owner, and `compiled-cache.ts` remains the persistence owner.

## User Impact

No user-visible behavior changes. Compile dashboards, live queries, and compiled-digest queries now share one canonical person-page classification rule.

## Evidence

- Focused owner proof: 4 files, 131 tests passed.
- Full plugin proof: `pnpm test:extension memory-wiki`, 42 files and 489 tests passed.
- Memory Wiki package typecheck passed.
- Direct lint and formatting passed for all three changed files.
- Changed-scope guards passed through plugin boundaries; the local repo-wide extension typecheck and dead-code wrapper were blocked by unrelated stale Telegram/UI artifacts in the shared install. Exact-head CI and Testbox will provide clean dependency proof.
- Sol/high autoreview: clean, confidence 0.99.
- Current and shipped `v2026.8.1` behavior was verified equivalent.
- Open PRs #105550, #113746, #116374, #129191, and #129897 touch `query.ts`; none changes the removed predicate. #129191 has only nearby import conflict risk.

Production LOC, raw diff: `+22/-30` (net `-8`). Four call-site renames account for `+4/-4`; canonical logic and imports are `+18/-26` (net `-8`). Tests: `+0/-0`.

Before landing, run `OPENCLAW_TESTBOX=1 scripts/pr prepare-run <PR>`, then the native merge verification and squash flow. If the known branch-independent Control UI gzip failure reproduces, record the exact job and wait for its separate repair without changing UI assets or budgets here.
