### PR TITLE
refactor(doctor): simplify agent migration traversal

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
@@ -131,9 +131,10 @@ function hasLegacyMemorySearchFlatKeys(value: unknown): boolean {
   );
 }
 
-function getAgentMemorySearchRecord(agent: unknown): Record<string, unknown> | null {
-  const record = getRecord(agent);
-  return getRecord(record?.memorySearch) ?? getRecord(getRecord(record?.memory)?.search);
+function getAgentMemorySearchRecord(
+  agent: Record<string, unknown>,
+): Record<string, unknown> | null {
+  return getRecord(agent.memorySearch) ?? getRecord(getRecord(agent.memory)?.search);
 }
 
 function someAgentEntry(
@@ -285,7 +286,7 @@ const PROFILE_CONFIGURED_TOOL_SECTION_RULES: LegacyConfigRule[] = [
         typeof globalTools?.profile === "string" ? globalTools.profile : undefined;
       const inheritedAlsoAllow = readToolPolicyGrantList(globalTools, "alsoAllow");
       return someAgentEntry(value, (agent) => {
-        const agentTools = getRecord(getRecord(agent)?.tools);
+        const agentTools = getRecord(agent.tools);
         return toolProfileConfiguredSectionsNeedExplicitRepair(
           agentTools,
           inheritedProfile,
@@ -593,7 +594,8 @@ function migrateUnsupportedSandboxBrowserNetworks(
   const defaultBrowser = getSandboxBrowserConfig(defaults);
   const defaultNetworkUnsupported = isUnsupportedSandboxBrowserNetwork(defaultBrowser?.network);
   const defaultBrowserEnabled = defaultBrowser?.enabled === true;
-  const migrateAgentBrowser = (agent: unknown, pathLabel: string): void => {
+  visitAgentEntries(raw, (agent, path) => {
+    const pathLabel = `${path}.sandbox.browser`;
     if (defaultNetworkUnsupported) {
       migrateAgentBrowserInheritedFromUnsupportedDefault({
         agent,
@@ -607,9 +609,7 @@ function migrateUnsupportedSandboxBrowserNetworks(
     if (browser) {
       migrateExplicitUnsupportedSandboxBrowserNetwork(browser, pathLabel, changes);
     }
-  };
-
-  visitAgentEntries(raw, (agent, path) => migrateAgentBrowser(agent, `${path}.sandbox.browser`));
+  });
 
   if (defaultBrowser) {
     migrateExplicitUnsupportedSandboxBrowserNetwork(
@@ -1248,7 +1248,7 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_AGENTS: LegacyConfigMigrationSpec[
         inheritedProfile,
       );
       visitAgentEntries(raw, (agent, path) => {
-        const agentTools = getRecord(getRecord(agent)?.tools);
+        const agentTools = getRecord(agent.tools);
         const configuredGrants = collectEffectiveConfiguredToolSectionGrants(
           globalTools,
           agentTools,

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.codex.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.codex.ts
@@ -155,14 +155,10 @@ function getMergeableLegacyOpenAIModels(params: {
 
 function collectLegacyModelPolicyWildcardPaths(raw: unknown): Map<string, string[]> {
   const pathsByProvider = new Map<string, string[]>();
-  const scopes: Array<{ value: unknown; path: string }> = [];
   visitAgentConfigScopes(getRecord(raw) ?? {}, (agent, path) => {
-    scopes.push({ value: agent.modelPolicy, path: `${path}.modelPolicy` });
-  });
-  for (const scope of scopes) {
-    const allow = getRecord(scope.value)?.allow;
+    const allow = getRecord(agent.modelPolicy)?.allow;
     if (!Array.isArray(allow)) {
-      continue;
+      return;
     }
     for (const [index, entry] of allow.entries()) {
       if (typeof entry !== "string" || !entry.trim().endsWith("/*")) {
@@ -173,10 +169,10 @@ function collectLegacyModelPolicyWildcardPaths(raw: unknown): Map<string, string
         continue;
       }
       const paths = pathsByProvider.get(provider) ?? [];
-      paths.push(`${scope.path}.allow.${index}`);
+      paths.push(`${path}.modelPolicy.allow.${index}`);
       pathsByProvider.set(provider, paths);
     }
-  }
+  });
   return pathsByProvider;
 }
 

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -212,9 +212,9 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS = [
       }
 
       // Default selections and model-map keys stay fixed while params and provider rows migrate.
-      let defaultModelIds: string[] | undefined;
+      let cachedDefaultModelIds: string[] | undefined;
       const getDefaultModelIds = () =>
-        (defaultModelIds ??= [
+        (cachedDefaultModelIds ??= [
           ...vllm.collectVllmModelIdsFromSelection(agentsDefaults?.model),
           ...vllm.collectVllmModelIdsFromAgentModelMap(defaultModels),
         ]);

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -211,13 +211,19 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS = [
         }
       }
 
+      // Default selections and model-map keys stay fixed while params and provider rows migrate.
+      let defaultModelIds: string[] | undefined;
+      const getDefaultModelIds = () =>
+        (defaultModelIds ??= [
+          ...vllm.collectVllmModelIdsFromSelection(agentsDefaults?.model),
+          ...vllm.collectVllmModelIdsFromAgentModelMap(defaultModels),
+        ]);
       const providerParams = getRecord(vllmProvider?.params);
       if (providerParams) {
         const providerLegacyFormat = vllm.getLegacyVllmQwenThinkingFormat(providerParams);
         if (providerLegacyFormat) {
           const providerModelIds = [
-            ...vllm.collectVllmModelIdsFromSelection(agentsDefaults?.model),
-            ...vllm.collectVllmModelIdsFromAgentModelMap(defaultModels),
+            ...getDefaultModelIds(),
             ...vllm.collectVllmModelIdsFromAgentRoster(raw),
           ];
           const targets = vllm.combineVllmModelTargets(
@@ -252,10 +258,7 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS = [
       if (defaultParams) {
         const defaultLegacyFormat = vllm.getLegacyVllmQwenThinkingFormat(defaultParams);
         if (defaultLegacyFormat) {
-          const defaultModelIds = [
-            ...vllm.collectVllmModelIdsFromSelection(agentsDefaults?.model),
-            ...vllm.collectVllmModelIdsFromAgentModelMap(defaultModels),
-          ];
+          const defaultModelIds = getDefaultModelIds();
           const targets =
             defaultModelIds.length > 0
               ? vllm.createVllmModelTargets(raw, defaultModelIds)
@@ -296,12 +299,8 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS = [
           ...vllm.collectVllmModelIdsFromSelection(agentRecord.model),
           ...vllm.collectVllmModelIdsFromAgentModelMap(agentRecord.models),
         ];
-        const inheritedDefaultModelIds = [
-          ...vllm.collectVllmModelIdsFromSelection(agentsDefaults?.model),
-          ...vllm.collectVllmModelIdsFromAgentModelMap(defaultModels),
-        ];
         const agentModelIds =
-          explicitAgentModelIds.length > 0 ? explicitAgentModelIds : inheritedDefaultModelIds;
+          explicitAgentModelIds.length > 0 ? explicitAgentModelIds : getDefaultModelIds();
         const targets =
           agentModelIds.length > 0
             ? vllm.createVllmModelTargets(raw, agentModelIds)

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts
@@ -101,23 +101,22 @@ function migrateFinalLayoutRenames(raw: Record<string, unknown>, changes: string
     }
   }
 
-  const migrateAgentScope = (scope: Record<string, unknown> | null, path: string) => {
+  visitAgentConfigScopes(raw, (scope, path) => {
     moveKey(
-      getRecord(getRecord(scope?.tools)?.exec),
+      getRecord(getRecord(scope.tools)?.exec),
       "timeoutSec",
       "timeoutSeconds",
       `${path}.tools.exec`,
       changes,
     );
     moveKey(
-      getRecord(getRecord(getRecord(scope?.sandbox)?.browser)),
+      getRecord(getRecord(scope.sandbox)?.browser),
       "enableNoVnc",
       "noVncEnabled",
       `${path}.sandbox.browser`,
       changes,
     );
-  };
-  visitAgentConfigScopes(raw, migrateAgentScope);
+  });
   moveKey(
     getRecord(getRecord(raw.tools)?.exec),
     "timeoutSec",


### PR DESCRIPTION
Related: #134758 (Doctor persistence repair), #133984 (upgrade migration reports).

## What Problem This Solves

Maintainer-requested cleanup of the Doctor migration repair. The shared roster walker made several intermediate arrays, callback adapters, and repeated record checks unnecessary. The vLLM migration also reparsed the same inherited model selections for every agent in a fleet.

## Why This Change Was Made

Scan model-policy wildcards directly in the canonical visitor, inline the one-use migration callbacks, and rely on the visitor's existing record validation. Resolve inherited vLLM model IDs lazily once per migration, while continuing to look up mutable provider targets at each scope. Provider/default/agent application order, diagnostics, canonical-entry precedence, and second-run behavior are preserved.

This keeps the current traversal contract. Converting every visitor to a generator solely to remove the TTS buffer would broaden the change and disturb its lazy traversal without a demonstrated benefit.

## User Impact

No configuration or behavior changes. Large fleets avoid repeated parsing of the same default model map during legacy vLLM repair. No new options, schema, dependencies, or runtime compatibility paths.

## Evidence

- The same 323 tests passed before and after across the main migration suite, roster precedence, model policies, retired config, and Doctor's real config-writer persistence tests.
- The tests cover both roster forms, explicit ownership, updater mode, preserved values, inherited model targets, exact migration diagnostics, and an idempotent second repair. Existing regression tests are retained; this behavior-preserving refactor adds no test-only production seams.
- Production diff: +27/-33 (net -6); tests, generated files, and documentation: unchanged.
- Both core and core-test typechecks, formatting, boundary/deprecation/coercion guards, and all three dead-code scans passed. Lint caught a shadowed cache variable; that name is corrected and the targeted type-aware lint rerun passed.
- Fresh independent Codex autoreview of the complete final candidate: scoped-clean at P0; manual and independent source review found no actionable defects.

The previous repair's built-CLI evidence remains in #134758. This follow-up uses focused owner-boundary proof; it does not claim a fresh full npm/systemd WSL upgrade.

## Maintainer Review Follow-through

Read the complete live comment history and the final-head [ClawSweeper review](https://github.com/openclaw/openclaw/pull/134845#issuecomment-5489292555). It identifies no code or security findings. Its remaining risk/rank-up request is to check earlier filtered comments: the earlier acknowledgment and review-start notices contain no additional requirements. Maintainer handling is complete, subject to exact-head CI. No persistent data model or upgrade semantics change; the existing before/after migration and real-writer tests above confirm compatibility.

Final validation: [CI run 33472443723](https://github.com/openclaw/openclaw/actions/runs/33472443723) completed successfully on `2e625836edec75f9eea6a3af7cff8751eca66394`, including the required `openclaw/ci-gate`.
