### PR TITLE
fix(browser): prevent gateway crash on sessionless worker attach

### DIFF
--- a/extensions/browser/src/browser/pw-session-cdp-transport.ts
+++ b/extensions/browser/src/browser/pw-session-cdp-transport.ts
@@ -147,9 +147,9 @@ export async function connectOverCdpTransport(
     const releaseContextlessTarget = (params: Record<string, unknown>) => {
       const sessionId = readStringField(params, "sessionId");
       if (!sessionId) {
-        // A root attach without a session cannot be resumed or detached. Consume
-        // only the malformed event so Playwright never reaches its browserContextId
-        // assertion while the shared browser transport remains usable.
+        // A root attach without a session cannot use the session command path.
+        // Consume only that malformed event so Playwright cannot crash before the
+        // shared browser transport handles the next valid message.
         return;
       }
       // Chrome dispatches session and root commands independently. Wait for the

--- a/extensions/browser/src/browser/pw-session-cdp-transport.ts
+++ b/extensions/browser/src/browser/pw-session-cdp-transport.ts
@@ -147,9 +147,9 @@ export async function connectOverCdpTransport(
     const releaseContextlessTarget = (params: Record<string, unknown>) => {
       const sessionId = readStringField(params, "sessionId");
       if (!sessionId) {
-        // A root attach without a session cannot be resumed or detached. Forwarding
-        // it would reach Playwright's browserContextId assertion, so fail closed.
-        closeTransportSocket();
+        // A root attach without a session cannot be resumed or detached. Consume
+        // only the malformed event so Playwright never reaches its browserContextId
+        // assertion while the shared browser transport remains usable.
         return;
       }
       // Chrome dispatches session and root commands independently. Wait for the

--- a/extensions/browser/src/browser/pw-session-cdp-transport.ts
+++ b/extensions/browser/src/browser/pw-session-cdp-transport.ts
@@ -13,7 +13,9 @@ const FIRST_INTERNAL_COMMAND_ID = -10_000;
 
 // Playwright's browser-root handler requires browserContextId for non-browser targets.
 // Release only those root targets; nested sessions belong to Playwright's frame handler.
-function contextlessTargetSession(message: Record<string, unknown>): string | undefined {
+function contextlessTargetParams(
+  message: Record<string, unknown>,
+): Record<string, unknown> | undefined {
   if (readStringField(message, "method") !== "Target.attachedToTarget") {
     return undefined;
   }
@@ -26,7 +28,7 @@ function contextlessTargetSession(message: Record<string, unknown>): string | un
   ) {
     return undefined;
   }
-  return readStringField(params, "sessionId");
+  return params ?? {};
 }
 
 type CdpTransportOptions = {
@@ -142,7 +144,14 @@ export async function connectOverCdpTransport(
       wire.send({ id, method, ...(params ? { params } : {}), sessionId });
       return id;
     };
-    const releaseContextlessTarget = (sessionId: string) => {
+    const releaseContextlessTarget = (params: Record<string, unknown>) => {
+      const sessionId = readStringField(params, "sessionId");
+      if (!sessionId) {
+        // A root attach without a session cannot be resumed or detached. Forwarding
+        // it would reach Playwright's browserContextId assertion, so fail closed.
+        closeTransportSocket();
+        return;
+      }
       // Chrome dispatches session and root commands independently. Wait for the
       // resume response before detach so the hidden target cannot stay paused.
       const resumeId = sendInternalCommand("Runtime.runIfWaitingForDebugger", undefined, sessionId);
@@ -218,9 +227,9 @@ export async function connectOverCdpTransport(
             }
             return;
           }
-          const contextlessSessionId = contextlessTargetSession(parsed);
-          if (contextlessSessionId) {
-            releaseContextlessTarget(contextlessSessionId);
+          const contextlessParams = contextlessTargetParams(parsed);
+          if (contextlessParams) {
+            releaseContextlessTarget(contextlessParams);
             return;
           }
           scheduleMessage(parsed);

--- a/extensions/browser/src/browser/pw-session.pinned-transport.test.ts
+++ b/extensions/browser/src/browser/pw-session.pinned-transport.test.ts
@@ -291,6 +291,46 @@ describe("pw-session Playwright CDP transport", () => {
     });
   });
 
+  it("closes a root contextless target that has no session id", async () => {
+    const commands: object[] = [];
+    const closeWire = vi.fn();
+    const wire: import("playwright-core").ConnectOverCDPTransport = {
+      send: (message) => commands.push(message),
+      close: closeWire,
+    };
+    const browser = makeBrowser("A", "https://example.com");
+    connectOverCdpSpy.mockImplementationOnce((async (value: unknown) => {
+      const transport = value as import("playwright-core").ConnectOverCDPTransport;
+      const delivered: object[] = [];
+      let closed = false;
+      Object.assign(transport, {
+        onmessage: (message: object) => delivered.push(message),
+        onclose: () => {
+          closed = true;
+        },
+      });
+      wire.onmessage?.({
+        method: "Target.attachedToTarget",
+        params: {
+          targetInfo: { targetId: "sessionless-worker", type: "service_worker" },
+          waitingForDebugger: true,
+        },
+      });
+      expect(commands).toEqual([]);
+      expect(delivered).toEqual([]);
+      expect(closeWire).toHaveBeenCalledOnce();
+      expect(closed).toBe(false);
+      wire.onclose?.("cleanup acknowledged");
+      await vi.waitFor(() => expect(closed).toBe(true));
+      return browser.browser;
+    }) as never);
+    await connectOverCdpTransport("http://127.0.0.1:18799", {
+      timeout: 1000,
+      headers: {},
+      preparedTransport: wire,
+    });
+  });
+
   it("connects guarded Playwright CDP through the pinned WebSocket transport", async () => {
     const server = new WebSocketServer({ port: 0, host: "127.0.0.1" });
     await new Promise<void>((resolve) => {

--- a/extensions/browser/src/browser/pw-session.pinned-transport.test.ts
+++ b/extensions/browser/src/browser/pw-session.pinned-transport.test.ts
@@ -291,7 +291,7 @@ describe("pw-session Playwright CDP transport", () => {
     });
   });
 
-  it("closes a root contextless target that has no session id", async () => {
+  it("suppresses a root contextless target that has no session id without closing", async () => {
     const commands: object[] = [];
     const closeWire = vi.fn();
     const wire: import("playwright-core").ConnectOverCDPTransport = {
@@ -302,12 +302,9 @@ describe("pw-session Playwright CDP transport", () => {
     connectOverCdpSpy.mockImplementationOnce((async (value: unknown) => {
       const transport = value as import("playwright-core").ConnectOverCDPTransport;
       const delivered: object[] = [];
-      let closed = false;
       Object.assign(transport, {
         onmessage: (message: object) => delivered.push(message),
-        onclose: () => {
-          closed = true;
-        },
+        onclose: vi.fn(),
       });
       wire.onmessage?.({
         method: "Target.attachedToTarget",
@@ -316,12 +313,11 @@ describe("pw-session Playwright CDP transport", () => {
           waitingForDebugger: true,
         },
       });
+      const followup = { id: 42, result: { ok: true } };
+      wire.onmessage?.(followup);
       expect(commands).toEqual([]);
-      expect(delivered).toEqual([]);
-      expect(closeWire).toHaveBeenCalledOnce();
-      expect(closed).toBe(false);
-      wire.onclose?.("cleanup acknowledged");
-      await vi.waitFor(() => expect(closed).toBe(true));
+      await vi.waitFor(() => expect(delivered).toEqual([followup]));
+      expect(closeWire).not.toHaveBeenCalled();
       return browser.browser;
     }) as never);
     await connectOverCdpTransport("http://127.0.0.1:18799", {


### PR DESCRIPTION
Closes #134851

## What Problem This Solves

A root `Target.attachedToTarget` event for a non-browser target without `params.sessionId` bypassed the worker-target guard. Playwright then reached its fatal `browserContextId` assertion and terminated the Gateway process.

## Root cause

The transport used the optional cleanup session ID as both the target classification result and cleanup handle. A missing session made a matching malformed root event look unhandled, so the transport forwarded it to Playwright.

## Fix

- Classify root contextless targets independently from the optional cleanup session.
- Keep resume-then-detach cleanup for valid session-bearing targets.
- Consume only the malformed sessionless event and keep the shared transport usable.
- Cover the missing-session case and a following valid CDP response at the owner boundary.

## Evidence

- Current main `4adab7342dd8ad3ba4311f5e0f9ff725c02fc3c7`: real Chromium and Playwright 1.62.1 reproduced the fatal `browserContextId` assertion after the injected sessionless worker attach.
- Exact head `93b7810b7256dac103bf6edd64bbe62327f77ad4`: an isolated secretless Linux container ran the source Gateway and `openclaw browser snapshot --format ai --selector body` through a byte-preserving CDP proxy.
- The setup, injected action, and anti-cheat snapshots all exited 0.
- The Gateway stayed alive.
- The same persistent CDP connection carried the injected action, 64 later responses, and the anti-cheat snapshot.
- Formatting and `git diff --check` passed.

## Merge-risk resolution

- The injected event violates Playwright's required CDP payload type. Natural Chromium incidence remains unknown; this change intentionally adds a narrow transport-boundary quarantine for that observed malformed shape.
- Production changes are +15/-6, net +9. The growth separates target classification from the optional cleanup handle and keeps the existing valid cleanup state machine unchanged.

## Provenance

PR #132419 added the session-bearing guard but carried forward the pre-existing sessionless forwarding path. This PR completes that owner-boundary repair.
