### PR TITLE
fix: plugins init scaffolds a toolchain that can resolve older than the host

### DIFF
--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -712,7 +712,7 @@ describe("plugin authoring commands", () => {
         openclaw: ">=2026.5.17",
       },
       devDependencies: {
-        openclaw: "latest",
+        openclaw: `>=${VERSION}`,
         typescript: "^5.9.0",
         vitest: "^3.2.0",
       },
@@ -776,7 +776,7 @@ describe("plugin authoring commands", () => {
       },
       devDependencies: {
         clawhub: "latest",
-        openclaw: "latest",
+        openclaw: `>=${VERSION}`,
         typescript: "^5.9.0",
         vitest: "^3.2.0",
       },

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -501,7 +501,10 @@ function writeToolPluginScaffold(params: { rootDir: string; id: string; name: st
       typebox: "^1.1.38",
     },
     devDependencies: {
-      openclaw: "latest",
+      // Floor the toolchain at the generating host. "latest" lets npm resolve below it
+      // whenever the dist-tag trails the host (betas, source checkouts, a rolled-back tag),
+      // and plugin:build then runs an older CLI that rejects the host's active config.
+      openclaw: `>=${VERSION}`,
       typescript: "^5.9.0",
       vitest: "^3.2.0",
     },
@@ -598,7 +601,8 @@ function writeProviderPluginScaffold(params: { rootDir: string; id: string; name
     },
     devDependencies: {
       clawhub: "latest",
-      openclaw: "latest",
+      // Same floor as the tool-plugin scaffold above.
+      openclaw: `>=${VERSION}`,
       typescript: "^5.9.0",
       vitest: "^3.2.0",
     },


### PR DESCRIPTION
Closes #123335

## What Problem This Solves

Fixes an issue where a plugin project created by `openclaw plugins init` can install a CLI older than the OpenClaw that generated it, so the very first `npm run plugin:build` in the new project fails before it reaches plugin metadata generation. The scaffold looks correct and the failure surfaces as the local CLI rejecting the host's active configuration, which does not point back at the scaffold.

Both scaffolds wrote `devDependencies.openclaw: "latest"`. `latest` is the npm dist-tag, not the host that generated the project, so the two disagree whenever the tag trails the host.

That is a routine condition, not an edge case. Current dist-tags:

```
$ npm view openclaw dist-tags --json
{
  "alpha": "2026.5.19-alpha.1",
  "latest": "2026.8.1",
  "extended-stable": "2026.6.34",
  "beta": "2026.9.1-beta.1"
}
```

`beta` is already ahead of `latest`, so every host on the beta channel scaffolds a project whose toolchain resolves backwards today. Source checkouts and the window around a release or a rolled-back tag do the same — the reporter hit the rollback case on 2026-08-13, with a 2026.7.2 host resolving `latest` to 2026.7.1-2.

## Why This Change Was Made

Floor the scaffold's dev toolchain at the generating host: `openclaw: ` >=${VERSION}` ` in both `writeToolPluginScaffold` and `writeProviderPluginScaffold`. `VERSION` was already imported in this file, and the provider scaffold already pins its peer range the same way, so this reuses an existing convention rather than inventing one.

**Peer ranges are deliberately left alone.** `peerDependencies` describes which hosts the finished plugin supports and is intentionally wider than the toolchain that builds it — the tool scaffold keeps `>=2026.5.17` (`TOOL_PLUGIN_API_RANGE`). Collapsing the two would silently narrow every generated plugin's compatibility, which is not what this issue asks for.

**Trade-off worth a maintainer's call:** `>=${VERSION}` is unsatisfiable if the host's version is not published to npm — the window between a version bump and its publish. That affects maintainers building from an unreleased tree, not users on a released or beta build, and the provider scaffold's `peerDependencies` already has exactly this property on `main` today. If you would rather not widen that surface, the alternatives are pinning the exact host version or falling back to `latest` when the host version is unpublished; say the word and I will switch it.

## User Impact

A project created by `openclaw plugins init` installs a CLI at least as new as the OpenClaw that generated it, so `npm run plugin:build` works on the machine that scaffolded it instead of failing against an older CLI pulled from npm. Plugin authors on beta builds and source checkouts stop hitting a build failure that has nothing to do with their plugin code.

## Evidence

### Real CLI behavior

Built from source, run against an isolated `OPENCLAW_STATE_DIR`, host `OpenClaw 2026.8.1`.

**Before** — base commit `09a71580`:

```
$ node ./openclaw.mjs plugins init demo-tools
Created demo-tools

openclaw-plugin-demo-tools
  peerDependencies: {"openclaw":">=2026.5.17"}
  devDependencies : {"openclaw":"latest","typescript":"^5.9.0","vitest":"^3.2.0"}
```

No lower bound tied to the generating host anywhere in the file.

**After** — this branch, both scaffold types:

```
$ node ./openclaw.mjs plugins init demo-tools
$ node ./openclaw.mjs plugins init demo-provider --type provider

openclaw-plugin-demo-tools
  peerDependencies: {"openclaw":">=2026.5.17"}     <- unchanged, still the wide API range
  devDependencies : {"openclaw":">=2026.8.1","typescript":"^5.9.0","vitest":"^3.2.0"}

openclaw-plugin-demo-provider
  peerDependencies: {"openclaw":">=2026.8.1"}      <- unchanged from main
  devDependencies : {"clawhub":"latest","openclaw":">=2026.8.1","typescript":"^5.9.0","vitest":"^3.2.0"}
```

The generated toolchain now cannot resolve below the host. `clawhub: "latest"` is left as-is; it is a separate package and outside this issue.

### Tests

`src/cli/plugins-authoring-command.test.ts` already asserted the generated `package.json` for both scaffolds; the two `devDependencies.openclaw` expectations move from `"latest"` to `` `>=${VERSION}` ``, which is why they are part of this PR.

```
this branch:  Test Files  1 failed (1)   Tests  1 failed | 24 passed (25)
base 09a71580: Test Files  1 failed (1)   Tests  1 failed | 24 passed (25)
```

Identical. The one failure is pre-existing on the base commit — `keeps validation errors on stderr and sanitizes JSON paths`, unrelated to scaffolding.

`oxfmt` and `oxlint` are clean on both changed files. Validation ran on Node 24.20.0 / pnpm 12.1.0.
