### PR TITLE
test(macos): synchronize pending disable coverage

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
@@ -321,9 +321,7 @@ extension GatewayLaunchAgentManager {
         #if DEBUG
         if self.testingInterceptDaemonCommands {
             self.testingDaemonCommandCalls.append(args)
-            if self.testingDaemonCommandDelayNanoseconds > 0 {
-                try? await Task.sleep(nanoseconds: self.testingDaemonCommandDelayNanoseconds)
-            }
+            await self.testingDaemonCommandHook?(args)
             let payload = if args.first == "status" {
                 if self.testingDaemonStatusPayloads.isEmpty {
                     self.testingDaemonStatusPayload ?? "{\"ok\":true}"
@@ -392,14 +390,18 @@ extension GatewayLaunchAgentManager {
     private nonisolated(unsafe) static var testingDaemonCommandCalls: [[String]] = []
     private nonisolated(unsafe) static var testingDaemonStatusPayload: String?
     private nonisolated(unsafe) static var testingDaemonStatusPayloads: [String] = []
-    private nonisolated(unsafe) static var testingDaemonCommandDelayNanoseconds: UInt64 = 0
+    private nonisolated(unsafe) static var testingDaemonCommandHook: (@Sendable ([String]) async -> Void)?
 
     static func setTestingDisableLaunchAgentMarkerURL(_ url: URL?) {
         self.testingDisableLaunchAgentMarkerURL = url
     }
 
-    static func setTestingInterceptDaemonCommands(_ intercept: Bool) {
+    static func setTestingInterceptDaemonCommands(
+        _ intercept: Bool,
+        beforeReturning hook: (@Sendable ([String]) async -> Void)? = nil)
+    {
         self.testingInterceptDaemonCommands = intercept
+        self.testingDaemonCommandHook = hook
     }
 
     static func setTestingDaemonStatusPayload(_ payload: String?) {
@@ -410,10 +412,6 @@ extension GatewayLaunchAgentManager {
     static func setTestingDaemonStatusPayloads(_ payloads: [String]) {
         self.testingDaemonStatusPayload = nil
         self.testingDaemonStatusPayloads = payloads
-    }
-
-    static func setTestingDaemonCommandDelayNanoseconds(_ nanoseconds: UInt64) {
-        self.testingDaemonCommandDelayNanoseconds = nanoseconds
     }
 
     static func clearTestingDaemonCommandCalls() {

--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -188,6 +188,7 @@ final class GatewayProcessManager {
     private var gatewayStartTaskGeneration: UInt64?
     #if DEBUG
     private var testingConnection: GatewayConnection?
+    private var testingLaunchAgentDisableWaitHook: (() -> Void)?
     private var testingSkipControlChannelRefresh = false
     private var testingControlChannelRefreshForces: [Bool] = []
     #endif
@@ -303,6 +304,9 @@ final class GatewayProcessManager {
         // A stop may already be uninstalling launchd. Wait until it finishes so a newer start's
         // attach/install is ordered last; loop because another stop can supersede it while waiting.
         while let disableTask = self.launchAgentDisableTask {
+            #if DEBUG
+            self.testingLaunchAgentDisableWaitHook?()
+            #endif
             await disableTask.value
         }
     }
@@ -1209,6 +1213,10 @@ extension GatewayProcessManager {
 
 #if DEBUG
 extension GatewayProcessManager {
+    func _testSetLaunchAgentDisableWaitHook(_ hook: (() -> Void)?) {
+        self.testingLaunchAgentDisableWaitHook = hook
+    }
+
     func setTestingConnection(_ connection: GatewayConnection?) {
         self.testingConnection = connection
     }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -105,25 +105,29 @@ struct GatewayProcessManagerTests {
         statusPayload: String? = nil,
         statusPayloads: [String]? = nil,
         commandDelayNanoseconds: UInt64 = 0,
+        commandHook: (@Sendable ([String]) async -> Void)? = nil,
         _ body: () async throws -> T) async throws -> T
     {
         let marker = FileManager.default.temporaryDirectory
             .appendingPathComponent("openclaw-launchagent-marker-\(UUID().uuidString)")
         return try await self.withGatewayConfig(mode: mode, port: port, homeDirectory: homeDirectory) {
             GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(marker)
-            GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true)
+            GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true) { arguments in
+                if commandDelayNanoseconds > 0 {
+                    try? await Task.sleep(nanoseconds: commandDelayNanoseconds)
+                }
+                await commandHook?(arguments)
+            }
             if let statusPayloads {
                 GatewayLaunchAgentManager.setTestingDaemonStatusPayloads(statusPayloads)
             } else {
                 GatewayLaunchAgentManager.setTestingDaemonStatusPayload(statusPayload)
             }
-            GatewayLaunchAgentManager.setTestingDaemonCommandDelayNanoseconds(commandDelayNanoseconds)
             GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
             defer {
                 GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(nil)
                 GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
                 GatewayLaunchAgentManager.setTestingDaemonStatusPayload(nil)
-                GatewayLaunchAgentManager.setTestingDaemonCommandDelayNanoseconds(0)
                 GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
                 self.manager.setTestingDesiredActive(false)
                 self.manager._testClearLaunchAgentReadinessFailure()
@@ -423,31 +427,54 @@ struct GatewayProcessManagerTests {
     @Test func `restart waits for disable before attaching`() async throws {
         let port = 19099
         let url = try #require(URL(string: "ws://example.invalid"))
-        let (_, connection, manager) = self.makeGatewayReadinessFixture(url: url) {
-            self.gatewayTask(healthSucceedsAfter: 0)
+        let finishDisable = AsyncTestGate()
+        let events = AsyncStream<String>.makeStream()
+        defer {
+            finishDisable.open()
+            events.continuation.finish()
+        }
+        let (session, connection, manager) = self.makeGatewayReadinessFixture(url: url) {
+            events.continuation.yield("attach")
+            return self.gatewayTask(healthSucceedsAfter: 0)
         }
         let descriptor = self.gatewayDescriptor(pid: 4242)
 
-        try await self.withLaunchAgentEnvironment(commandDelayNanoseconds: 100_000_000) {
+        try await self.withLaunchAgentEnvironment(commandHook: { arguments in
+            guard arguments == ["uninstall"] else { return }
+            events.continuation.yield("disable-started")
+            await finishDisable.wait()
+            events.continuation.yield("disable-finished")
+        }) {
             manager.setTestingDesiredActive(true)
             await PortGuardian.shared.setTestingDescriptor(descriptor, forPort: port)
             defer {
                 manager.setTestingDesiredActive(false)
+                manager._testSetLaunchAgentDisableWaitHook(nil)
+            }
+            manager._testSetLaunchAgentDisableWaitHook {
+                events.continuation.yield("disable-wait")
             }
 
+            var iterator = events.stream.makeAsyncIterator()
             manager.stop()
-            await self.waitForCondition {
-                GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot()
-                    .contains(where: { $0.first == "uninstall" })
-            }
+            #expect(await iterator.next() == "disable-started")
             manager._testBeginGatewayStartGeneration()
 
-            let startedAt = Date()
-            let attached = await manager._testAttachExistingGatewayAfterPendingDisable(port: port)
-            let elapsed = Date().timeIntervalSince(startedAt)
+            let attachment = Task { @MainActor in
+                return await manager._testAttachExistingGatewayAfterPendingDisable(port: port)
+            }
+            // Either the owner registers its wait or a broken restart admits a socket first.
+            #expect(await iterator.next() == "disable-wait")
+            #expect(session.snapshotMakeCount() == 0)
+            finishDisable.open()
+            let attached = await attachment.value
+            manager._testSetLaunchAgentDisableWaitHook(nil)
+            events.continuation.finish()
+            var order: [String] = []
+            while let event = await iterator.next() { order.append(event) }
 
             #expect(attached)
-            #expect(elapsed >= 0.05)
+            #expect(order == ["disable-finished", "attach"])
             #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot()
                 .filter { $0.first == "uninstall" }.count == 1)
             guard case .attachedExisting = manager.status else {
@@ -621,7 +648,7 @@ struct GatewayProcessManagerTests {
             #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot()
                 .contains(where: { $0.first == "status" }))
 
-            GatewayLaunchAgentManager.setTestingDaemonCommandDelayNanoseconds(0)
+            GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true)
             manager.stop()
             manager._testBeginGatewayStartGeneration()
             await manager._testFinishLaunchAgentReadinessFailure(


### PR DESCRIPTION
## Summary

- replace only the macOS stabilization portion of https://github.com/openclaw/openclaw/pull/134710
- preserve Peter Steinberger's authorship while moving the work to a maintainer-owned branch
- replace the clock-based restart assertion with deterministic disable/wait/attach ordering
- keep production behavior unchanged; all source changes are DEBUG-only test support

## Proof

- exact test passes:
  ```sh
  swift test --package-path apps/macos --filter 'OpenClawIPCTests.GatewayProcessManagerTests/`restart waits for disable before attaching`()'
  ```
- temporary removed-wait mutant failed the same test with three expected signals:
  missing `disable-wait`, one premature session snapshot, and missing `attach` after `disable-finished`
- mutant was not committed; the production file was restored byte-for-byte from the staged index
- `./scripts/format-swift.sh macos`
- `./scripts/lint-swift.sh macos`

## Scope

- application production: `+0/-0`
- DEBUG test support: `+15/-9`
- tests: `+42/-15`
- files: `GatewayLaunchAgentManager.swift`, `GatewayProcessManager.swift`, `GatewayProcessManagerTests.swift`

## Overlap

- https://github.com/openclaw/openclaw/pull/131682 and https://github.com/openclaw/openclaw/pull/133215 remain open and do not change the pending-disable synchronization symbols
- this PR does not include the CI changes from https://github.com/openclaw/openclaw/pull/134710

Original contributor: Peter Steinberger.
