### PR TITLE
fix(macos): keep worker packaging on the destination volume

### DIFF
--- a/scripts/stage-mac-node-worker.sh
+++ b/scripts/stage-mac-node-worker.sh
@@ -13,7 +13,9 @@ case "${OPENCLAW_MAC_SIGNING_VARIANT:-standard}" in
   elevation-host) runtime_name=elevation ;;
   *) echo "ERROR: Unknown Mac signing variant" >&2; exit 1 ;;
 esac
-STAGE="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-mac-worker.XXXXXX")"
+# Keep provisioning and the completed runtime moves on the destination volume.
+mkdir -p "$(dirname "$DESTINATION")"
+STAGE="$(cd "$(dirname "$DESTINATION")" && mktemp -d "$PWD/.openclaw-mac-worker.XXXXXX")"
 trap 'rm -rf "$STAGE"' EXIT
 mkdir -p "$STAGE/home" "$STAGE/package"
 

--- a/test/scripts/mac-node-worker-materialization.test-support.ts
+++ b/test/scripts/mac-node-worker-materialization.test-support.ts
@@ -198,7 +198,7 @@ install_openclaw() { :; }
     destination,
     calls,
     tmp,
-    run(variant: string) {
+    run(variant: string, tempRoot = tmp) {
       return spawnSync(
         "/bin/bash",
         [path.join(scripts, "stage-mac-node-worker.sh"), destination, "arm64", "x86_64"],
@@ -206,7 +206,7 @@ install_openclaw() { :; }
           encoding: "utf8",
           env: {
             HOME: root,
-            TMPDIR: tmp,
+            TMPDIR: tempRoot,
             PATH: `${path.dirname(process.execPath)}:${systemPath}`,
             OPENCLAW_MAC_SIGNING_VARIANT: variant,
           },
@@ -219,11 +219,11 @@ install_openclaw() { :; }
 export function registerMacWorkerMaterializationTests() {
   describe.skipIf(process.platform !== "darwin")("elevation worker materialization", () => {
     const it = createMacScriptTest();
-    it("preserves standard and derived elevation payloads through shared verification", () => {
+    it("provisions beside the destination when system temp is unavailable", () => {
       for (const variant of ["standard", "elevation-host"]) {
         const fixture = stagingFixture();
         const before = snapshot(path.join(fixture.root, "canonical"));
-        const result = fixture.run(variant);
+        const result = fixture.run(variant, path.join(fixture.tmp, "unavailable"));
         expect(result.status, result.stderr).toBe(0);
         expect(snapshot(path.join(fixture.root, "canonical"))).toEqual(before);
         const calls = readFileSync(fixture.calls, "utf8").trim().split("\n");
@@ -234,6 +234,9 @@ export function registerMacWorkerMaterializationTests() {
           expect(node).toBe(`${runtime}/bin/node`);
           expect(runtime).toContain(`/${arch}/${variant === "standard" ? "runtime" : "elevation"}`);
           expect(expected).toBe(path.join(fixture.root, "dist/build-info.json"));
+          const scratch = path.resolve(runtime!, "../..");
+          expect(path.dirname(scratch)).toBe(path.dirname(fixture.destination));
+          expect(existsSync(scratch)).toBe(false);
           expect(snapshot(path.join(fixture.destination, arch))).toEqual(
             snapshot(path.join(fixture.root, "canonical", arch)).filter(
               (entry) => variant === "standard" || entry.path !== "foreign.node",
@@ -263,7 +266,11 @@ export function registerMacWorkerMaterializationTests() {
         const before = existsSync(fixture.destination) ? snapshot(fixture.destination) : [];
         const result = fixture.run(variant);
         expect(result.status, result.stderr).toBe(failure === "verification" ? 42 : 1);
-        expect(readFileSync(fixture.calls, "utf8").trim().split("\n")).toHaveLength(2);
+        const calls = readFileSync(fixture.calls, "utf8").trim().split("\n");
+        expect(calls).toHaveLength(2);
+        for (const call of calls) {
+          expect(existsSync(path.resolve(call.split("|")[1]!, "../.."))).toBe(false);
+        }
         expect(existsSync(path.join(fixture.destination, "arm64"))).toBe(false);
         expect(existsSync(fixture.destination) ? snapshot(fixture.destination) : []).toEqual(
           before,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS app packaging can stall or fail on system temporary storage even when the destination volume has sufficient space and performs well. The worker pack failed twice at the existing 300-second extraction limit while the app was being built on another volume.

## Why This Change Was Made

The worker materialization owner now creates its private staging directory beside the destination. Extraction, installation, verification and final moves stay on that volume. It creates only the parent before validation; existing destination contents and the contract that failed verification leaves no destination are preserved.

The app caller owns an unpublished Resources directory, which the package inventory excludes as part of the staged `.app`. The existing EXIT trap removes temporary staging before signing. No timeout, package selection, credential isolation, signing, configuration or validation gate changes. Production/tooling +3/-1; test support +12/-5.

## User Impact

Build-time reliability only; no runtime or public configuration change.

## Evidence

- Before: two canonical package extraction failures at 300 seconds. A controlled 1,024-file extraction of the same archive took 2.190 seconds on the destination volume and 52.050 seconds on system storage in reversed execution order; every file hash matched. This establishes the observed volume effect, not disk fullness as the sole cause.
- After: the canonical app build passed worker package normalization, integrity and import-graph checks with unchanged limits; strict extraction completed in 2.240 seconds. The full canonical arm64 app build then exited 0 in 11m22s. Native worker load/readiness checks passed before and after real Developer ID signing, and the final deep/strict signature audit passed. This is build and worker proof; no GUI/TCC or AWS Mac runtime proof is claimed.
- The real staging regression fails before the fix when ambient temporary storage is unavailable, then passes for standard and elevation variants. All six existing verification/occupied/symlink failure cases pass with prior contents and temporary-directory cleanup preserved.
- Bash syntax and formatting pass. Fresh managed Codex review is scoped-clean at P0.

The latest ClawSweeper review found no correctness or security issue. Its remaining macOS-validation condition is satisfied by exact-head `macos-node`, `macos-swift` and the required CI gate, all successful. The two extra production lines are needed to create the destination parent before allocating private staging; validation still precedes final destination publication.
