### PR TITLE
Add Office document extraction support

### DIFF
--- a/extensions/document-extract/document-extractor.test.ts
+++ b/extensions/document-extract/document-extractor.test.ts
@@ -1,4 +1,5 @@
 // Document Extract tests cover document extractor plugin behavior.
+import JSZip from "jszip";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { createEngineMock, openPdfMock, pdfDocument } = vi.hoisted(() => ({
@@ -15,7 +16,12 @@ vi.mock("clawpdf", () => ({
   createEngine: createEngineMock,
 }));
 
-import { createPdfDocumentExtractor } from "./document-extractor.js";
+import {
+  createDocxDocumentExtractor,
+  createPdfDocumentExtractor,
+  createPptxDocumentExtractor,
+  createXlsxDocumentExtractor,
+} from "./document-extractor.js";
 
 function request(overrides = {}) {
   return {
@@ -228,5 +234,132 @@ describe("PDF document extractor", () => {
       expect(onImageExtractionError).toHaveBeenCalledWith(failure);
     }
     expect(pdfDocument.destroy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Office document extractors", () => {
+  async function createDocx(parts: Record<string, string>): Promise<Buffer> {
+    const zip = new JSZip();
+    zip.file("[Content_Types].xml", "<Types/>");
+    for (const [name, content] of Object.entries(parts)) {
+      zip.file(name, content);
+    }
+    return Buffer.from(await zip.generateAsync({ type: "nodebuffer" }));
+  }
+
+  it("declares DOCX support", () => {
+    const extractor = createDocxDocumentExtractor();
+    const { extract, ...descriptor } = extractor;
+    expect(extract).toBeInstanceOf(Function);
+    expect(descriptor).toEqual({
+      id: "docx",
+      label: "DOCX",
+      mimeTypes: ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
+      autoDetectOrder: 20,
+    });
+  });
+
+  it("extracts paragraph and table text from a DOCX package", async () => {
+    const buffer = await createDocx({
+      "word/document.xml": [
+        '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>',
+        "<w:p><w:r><w:t>Hello &amp; welcome</w:t></w:r><w:r><w:tab/><w:t>Debra</w:t></w:r></w:p>",
+        "<w:p><w:r><w:t>Katherine homework</w:t></w:r><w:r><w:br/><w:t>page two</w:t></w:r></w:p>",
+        "<w:tbl><w:tr><w:tc><w:p><w:r><w:t>Name</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>Score</w:t></w:r></w:p></w:tc></w:tr>",
+        "<w:tr><w:tc><w:p><w:r><w:t>Katherine</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>100</w:t></w:r></w:p></w:tc></w:tr></w:tbl>",
+        "</w:body></w:document>",
+      ].join(""),
+    });
+
+    await expect(
+      createDocxDocumentExtractor().extract(
+        request({
+          buffer,
+          mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        }),
+      ),
+    ).resolves.toEqual({
+      text: "Hello & welcome\tDebra\nKatherine homework\npage two\nTable\nName\tScore\nKatherine\t100",
+      images: [],
+    });
+  });
+
+  it("extracts worksheet rows from an XLSX package", async () => {
+    const buffer = await createDocx({
+      "xl/workbook.xml": [
+        '<workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets>',
+        '<sheet name="Meal Plan" r:id="rId1"/>',
+        "</sheets></workbook>",
+      ].join(""),
+      "xl/_rels/workbook.xml.rels":
+        '<Relationships><Relationship Id="rId1" Target="worksheets/sheet1.xml"/></Relationships>',
+      "xl/sharedStrings.xml": [
+        "<sst><si><t>Item</t></si><si><t>Count</t></si><si><t>Muffins</t></si></sst>",
+      ].join(""),
+      "xl/worksheets/sheet1.xml": [
+        "<worksheet><sheetData>",
+        '<row r="1"><c r="A1" t="s"><v>0</v></c><c r="C1" t="s"><v>1</v></c></row>',
+        '<row r="2"><c r="A2" t="s"><v>2</v></c><c r="C2"><v>12</v></c></row>',
+        "</sheetData></worksheet>",
+      ].join(""),
+    });
+
+    await expect(
+      createXlsxDocumentExtractor().extract(
+        request({
+          buffer,
+          mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        }),
+      ),
+    ).resolves.toEqual({
+      text: "Meal Plan\nrow\tvalues\n1\tItem\t\tCount\n2\tMuffins\t\t12",
+      images: [],
+    });
+  });
+
+  it("extracts slide and speaker-note text from a PPTX package", async () => {
+    const drawing = (text: string) =>
+      `<p:sld xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\"><a:p><a:r><a:t>${text}</a:t></a:r></a:p></p:sld>`;
+    const buffer = await createDocx({
+      "ppt/slides/slide1.xml": drawing("Lesson &amp; practice"),
+      "ppt/notesSlides/notesSlide1.xml": drawing("Teacher note"),
+    });
+
+    await expect(
+      createPptxDocumentExtractor().extract(
+        request({
+          buffer,
+          mimeType: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        }),
+      ),
+    ).resolves.toEqual({
+      text: "Slide 1 (ppt/slides/slide1.xml)\nLesson & practice\n\nNotes 1 (ppt/notesSlides/notesSlide1.xml)\nTeacher note",
+      images: [],
+    });
+  });
+
+  it("includes comments, footnotes, endnotes, headers, and footers", async () => {
+    const xml = (text: string) =>
+      `<w:root xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><w:p><w:r><w:t>${text}</w:t></w:r></w:p></w:root>`;
+    const buffer = await createDocx({
+      "word/document.xml": xml("body"),
+      "word/footnotes.xml": xml("footnote"),
+      "word/endnotes.xml": xml("endnote"),
+      "word/comments.xml": xml("comment"),
+      "word/header2.xml": xml("header"),
+      "word/footer1.xml": xml("footer"),
+    });
+
+    await expect(
+      createDocxDocumentExtractor().extract(
+        request({
+          buffer,
+          mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        }),
+      ),
+    ).resolves.toEqual({
+      text: "body\nfootnote\nendnote\ncomment\nfooter\nheader",
+      images: [],
+    });
   });
 });

--- a/extensions/document-extract/document-extractor.ts
+++ b/extensions/document-extract/document-extractor.ts
@@ -1,5 +1,6 @@
-// Document Extract plugin module implements document extractor behavior.
 import type { PdfDocument, PdfEngine, PdfImage } from "clawpdf";
+// Document Extract plugin module implements document extractor behavior.
+import JSZip from "jszip";
 import type {
   DocumentExtractedImage,
   DocumentExtractionRequest,
@@ -9,6 +10,16 @@ import type {
 
 const MAX_EXTRACTED_TEXT_CHARS = 200_000;
 const MAX_RENDER_DIMENSION = 10_000;
+const DOCX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+const XLSX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+const PPTX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+
+const DOCX_TEXT_PARTS = [
+  "word/document.xml",
+  "word/footnotes.xml",
+  "word/endnotes.xml",
+  "word/comments.xml",
+] as const;
 
 let pdfEnginePromise: Promise<PdfEngine> | null = null;
 
@@ -24,6 +35,332 @@ async function loadPdfEngine(): Promise<PdfEngine> {
       });
   }
   return pdfEnginePromise;
+}
+
+function decodeXmlEntities(value: string): string {
+  return value.replace(/&(?:#(x[0-9a-fA-F]+|\d+)|amp|lt|gt|quot|apos);/gu, (entity, numeric) => {
+    if (numeric) {
+      const codePoint =
+        numeric.startsWith("x") || numeric.startsWith("X")
+          ? Number.parseInt(numeric.slice(1), 16)
+          : Number.parseInt(numeric, 10);
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : entity;
+    }
+    switch (entity) {
+      case "&amp;":
+        return "&";
+      case "&lt;":
+        return "<";
+      case "&gt;":
+        return ">";
+      case "&quot;":
+        return '"';
+      case "&apos;":
+        return "'";
+      default:
+        return entity;
+    }
+  });
+}
+
+function normalizeExtractedText(text: string): string {
+  return text
+    .replace(/[ \t]+\n/gu, "\n")
+    .replace(/\n{3,}/gu, "\n\n")
+    .trim();
+}
+
+function clampExtractedText(text: string): string {
+  return text.length > MAX_EXTRACTED_TEXT_CHARS ? text.slice(0, MAX_EXTRACTED_TEXT_CHARS) : text;
+}
+
+function extractParagraphText(xml: string): string[] {
+  const paragraphs: string[] = [];
+  const paragraphMatches = xml.matchAll(/<w:p\b[^>]*>([\s\S]*?)<\/w:p>/gu);
+  for (const match of paragraphMatches) {
+    const paragraphXml = match[1] ?? "";
+    const chunks: string[] = [];
+    const tokenMatches = paragraphXml.matchAll(
+      /<w:t\b[^>]*>([\s\S]*?)<\/w:t>|<w:(?:tab|br|cr)\b[^>]*\/?\s*>/gu,
+    );
+    for (const token of tokenMatches) {
+      const full = token[0];
+      if (/^<w:t(?:\s|>)/u.test(full)) {
+        chunks.push(decodeXmlEntities(token[1] ?? ""));
+      } else if (full.startsWith("<w:tab")) {
+        chunks.push("\t");
+      } else {
+        chunks.push("\n");
+      }
+    }
+    const paragraph = chunks.join("").trimEnd();
+    if (paragraph.trim()) {
+      paragraphs.push(paragraph);
+    }
+  }
+  return paragraphs;
+}
+
+function extractDocxTableText(xml: string): string[] {
+  const tables: string[] = [];
+  for (const tableMatch of xml.matchAll(/<w:tbl\b[^>]*>([\s\S]*?)<\/w:tbl>/gu)) {
+    const rows: string[] = [];
+    for (const rowMatch of (tableMatch[1] ?? "").matchAll(/<w:tr\b[^>]*>([\s\S]*?)<\/w:tr>/gu)) {
+      const cells = Array.from(
+        (rowMatch[1] ?? "").matchAll(/<w:tc\b[^>]*>([\s\S]*?)<\/w:tc>/gu),
+        (cell) =>
+          extractParagraphText(cell[1] ?? "")
+            .join(" ")
+            .trim(),
+      );
+      if (cells.some((cell) => cell.length > 0)) {
+        rows.push(cells.join("\t"));
+      }
+    }
+    if (rows.length > 0) {
+      tables.push(["Table", ...rows].join("\n"));
+    }
+  }
+  return tables;
+}
+
+function extractDocxPartText(xml: string): string[] {
+  const tables = extractDocxTableText(xml);
+  const withoutTables = xml.replace(/<w:tbl\b[^>]*>[\s\S]*?<\/w:tbl>/gu, "");
+  return [...extractParagraphText(withoutTables), ...tables];
+}
+
+async function readZipTextFile(zip: JSZip, name: string): Promise<string | undefined> {
+  const file = zip.file(name);
+  return file ? await file.async("string") : undefined;
+}
+
+async function loadOfficeZip(request: DocumentExtractionRequest, label: string): Promise<JSZip> {
+  try {
+    return await JSZip.loadAsync(request.buffer);
+  } catch (err) {
+    throw new Error(
+      `${label} extraction failed: file is corrupt, encrypted, or not a supported Office OOXML package.`,
+      { cause: err },
+    );
+  }
+}
+
+function numericPathSort(left: { name: string }, right: { name: string }): number {
+  return left.name.localeCompare(right.name, undefined, { numeric: true });
+}
+
+function columnIndexFromCellRef(ref: string | undefined, fallback: number): number {
+  const letters = ref?.match(/^[A-Z]+/iu)?.[0]?.toUpperCase();
+  if (!letters) {
+    return fallback;
+  }
+  let index = 0;
+  for (const char of letters) {
+    index = index * 26 + (char.charCodeAt(0) - 64);
+  }
+  return Math.max(0, index - 1);
+}
+
+function firstXmlAttr(value: string, attr: string): string | undefined {
+  const escaped = attr.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  return value.match(new RegExp(`${escaped}=(["'])(.*?)\\1`, "u"))?.[2];
+}
+
+function stripXmlTags(value: string): string {
+  return value.replace(/<[^>]+>/gu, "");
+}
+
+function extractPlainXmlText(xml: string): string {
+  return normalizeExtractedText(decodeXmlEntities(stripXmlTags(xml)));
+}
+
+async function loadSharedStrings(zip: JSZip): Promise<string[]> {
+  const xml = await readZipTextFile(zip, "xl/sharedStrings.xml");
+  if (!xml) {
+    return [];
+  }
+  return Array.from(
+    xml.matchAll(/<si\b[^>]*>([\s\S]*?)<\/si>/gu),
+    (match) =>
+      extractParagraphText(match[1] ?? "").join("\n") || extractPlainXmlText(match[1] ?? ""),
+  );
+}
+
+function extractWorkbookSheetNames(xml: string | undefined): Map<string, string> {
+  const names = new Map<string, string>();
+  if (!xml) {
+    return names;
+  }
+  for (const match of xml.matchAll(/<sheet\b[^>]*>/gu)) {
+    const tag = match[0];
+    const id = firstXmlAttr(tag, "r:id");
+    const name = firstXmlAttr(tag, "name");
+    if (id && name) {
+      names.set(id, decodeXmlEntities(name));
+    }
+  }
+  return names;
+}
+
+function extractWorkbookRels(xml: string | undefined): Map<string, string> {
+  const rels = new Map<string, string>();
+  if (!xml) {
+    return rels;
+  }
+  for (const match of xml.matchAll(/<Relationship\b[^>]*>/gu)) {
+    const tag = match[0];
+    const id = firstXmlAttr(tag, "Id");
+    const target = firstXmlAttr(tag, "Target");
+    if (id && target) {
+      rels.set(id, target.startsWith("/") ? target.slice(1) : `xl/${target}`);
+    }
+  }
+  return rels;
+}
+
+function extractXlsxCellText(cellXml: string, sharedStrings: readonly string[]): string {
+  const type = firstXmlAttr(cellXml.match(/<c\b[^>]*>/u)?.[0] ?? "", "t");
+  const inline = cellXml.match(/<is\b[^>]*>([\s\S]*?)<\/is>/u)?.[1];
+  if (inline) {
+    return extractPlainXmlText(inline);
+  }
+  const value = decodeXmlEntities(cellXml.match(/<v\b[^>]*>([\s\S]*?)<\/v>/u)?.[1] ?? "");
+  if (type === "s") {
+    const index = Number.parseInt(value, 10);
+    return Number.isFinite(index) ? (sharedStrings[index] ?? "") : "";
+  }
+  if (type === "str") {
+    return value;
+  }
+  if (type === "b") {
+    return value === "1" ? "TRUE" : value === "0" ? "FALSE" : value;
+  }
+  return value;
+}
+
+async function extractXlsxContent(
+  request: DocumentExtractionRequest,
+): Promise<DocumentExtractionResult> {
+  const zip = await loadOfficeZip(request, "XLSX");
+  const sharedStrings = await loadSharedStrings(zip);
+  const sheetNames = extractWorkbookSheetNames(await readZipTextFile(zip, "xl/workbook.xml"));
+  const workbookRels = extractWorkbookRels(
+    await readZipTextFile(zip, "xl/_rels/workbook.xml.rels"),
+  );
+  const sheetFiles = zip.file(/^xl\/worksheets\/sheet\d+\.xml$/u).sort(numericPathSort);
+  const namesByPath = new Map<string, string>();
+  for (const [id, name] of sheetNames) {
+    const target = workbookRels.get(id);
+    if (target) {
+      namesByPath.set(target, name);
+    }
+  }
+
+  const sheets: string[] = [];
+  for (const [sheetIndex, sheetFile] of sheetFiles.entries()) {
+    const xml = await sheetFile.async("string");
+    const rows: string[] = [];
+    for (const rowMatch of xml.matchAll(/<row\b[^>]*>([\s\S]*?)<\/row>/gu)) {
+      const cells: string[] = [];
+      let fallbackColumn = 0;
+      for (const cellMatch of (rowMatch[1] ?? "").matchAll(/<c\b[^>]*>[\s\S]*?<\/c>/gu)) {
+        const cellXml = cellMatch[0];
+        const column = columnIndexFromCellRef(
+          firstXmlAttr(cellXml.match(/<c\b[^>]*>/u)?.[0] ?? "", "r"),
+          fallbackColumn,
+        );
+        while (cells.length < column) {
+          cells.push("");
+        }
+        cells[column] = extractXlsxCellText(cellXml, sharedStrings);
+        fallbackColumn = column + 1;
+      }
+      const trimmed = cells.map((cell) => cell ?? "");
+      while (trimmed.length > 0 && !trimmed.at(-1)) {
+        trimmed.pop();
+      }
+      if (trimmed.some((cell) => cell.trim())) {
+        rows.push(
+          `${firstXmlAttr(rowMatch[0], "r") ?? String(rows.length + 1)}\t${trimmed.join("\t")}`,
+        );
+      }
+    }
+    if (rows.length > 0) {
+      const fallback = `Sheet ${sheetIndex + 1}`;
+      sheets.push(
+        [
+          decodeXmlEntities(namesByPath.get(sheetFile.name) ?? fallback),
+          "row\tvalues",
+          ...rows,
+        ].join("\n"),
+      );
+    }
+  }
+
+  return {
+    text: clampExtractedText(normalizeExtractedText(sheets.join("\n\n"))),
+    images: [],
+  };
+}
+
+function extractDrawingText(xml: string): string[] {
+  return Array.from(xml.matchAll(/<a:p\b[^>]*>([\s\S]*?)<\/a:p>/gu), (match) => {
+    const chunks = Array.from((match[1] ?? "").matchAll(/<a:t\b[^>]*>([\s\S]*?)<\/a:t>/gu), (t) =>
+      decodeXmlEntities(t[1] ?? ""),
+    );
+    return chunks.join("").trim();
+  }).filter(Boolean);
+}
+
+async function extractPptxContent(
+  request: DocumentExtractionRequest,
+): Promise<DocumentExtractionResult> {
+  const zip = await loadOfficeZip(request, "PPTX");
+  const parts = [
+    ...zip.file(/^ppt\/slides\/slide\d+\.xml$/u).sort(numericPathSort),
+    ...zip.file(/^ppt\/notesSlides\/notesSlide\d+\.xml$/u).sort(numericPathSort),
+  ];
+  const sections: string[] = [];
+  for (const file of parts) {
+    const text = extractDrawingText(await file.async("string"));
+    if (text.length > 0) {
+      const isNotes = file.name.includes("/notesSlides/");
+      const number = file.name.match(/(?:slide|notesSlide)(\d+)\.xml$/u)?.[1] ?? "?";
+      const kind = isNotes ? "Notes" : "Slide";
+      sections.push([`${kind} ${number} (${file.name})`, ...text].join("\n"));
+    }
+  }
+  return {
+    text: clampExtractedText(normalizeExtractedText(sections.join("\n\n"))),
+    images: [],
+  };
+}
+
+async function extractDocxContent(
+  request: DocumentExtractionRequest,
+): Promise<DocumentExtractionResult> {
+  const zip = await loadOfficeZip(request, "DOCX");
+  const paragraphs: string[] = [];
+  for (const part of DOCX_TEXT_PARTS) {
+    const xml = await readZipTextFile(zip, part);
+    if (xml) {
+      paragraphs.push(...extractDocxPartText(xml));
+    }
+  }
+
+  const headerFooterFiles = zip
+    .file(/^word\/(?:header|footer)\d+\.xml$/u)
+    .sort((left, right) => left.name.localeCompare(right.name));
+  for (const file of headerFooterFiles) {
+    const xml = await file.async("string");
+    paragraphs.push(...extractDocxPartText(xml));
+  }
+
+  return {
+    text: clampExtractedText(normalizeExtractedText(paragraphs.join("\n"))),
+    images: [],
+  };
 }
 
 function toDocumentImage(image: PdfImage): DocumentExtractedImage {
@@ -136,5 +473,35 @@ export function createPdfDocumentExtractor(): DocumentExtractorPlugin {
     mimeTypes: ["application/pdf"],
     autoDetectOrder: 10,
     extract: extractPdfContent,
+  };
+}
+
+export function createDocxDocumentExtractor(): DocumentExtractorPlugin {
+  return {
+    id: "docx",
+    label: "DOCX",
+    mimeTypes: [DOCX_MIME_TYPE],
+    autoDetectOrder: 20,
+    extract: extractDocxContent,
+  };
+}
+
+export function createXlsxDocumentExtractor(): DocumentExtractorPlugin {
+  return {
+    id: "xlsx",
+    label: "XLSX",
+    mimeTypes: [XLSX_MIME_TYPE],
+    autoDetectOrder: 30,
+    extract: extractXlsxContent,
+  };
+}
+
+export function createPptxDocumentExtractor(): DocumentExtractorPlugin {
+  return {
+    id: "pptx",
+    label: "PPTX",
+    mimeTypes: [PPTX_MIME_TYPE],
+    autoDetectOrder: 40,
+    extract: extractPptxContent,
   };
 }

--- a/extensions/document-extract/index.ts
+++ b/extensions/document-extract/index.ts
@@ -4,7 +4,8 @@ import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 export default definePluginEntry({
   id: "document-extract",
   name: "Document Extraction",
-  description: "Extract text and fallback page images from local document attachments.",
+  description:
+    "Extract text from local PDF and Office document attachments, with fallback page images for PDFs.",
   register() {
     // Runtime is exposed through document-extractor.ts so document hot paths can
     // load only the narrow extractor artifact instead of the full plugin entrypoint.

--- a/extensions/document-extract/openclaw.plugin.json
+++ b/extensions/document-extract/openclaw.plugin.json
@@ -5,9 +5,9 @@
   },
   "enabledByDefault": true,
   "name": "Document Extraction",
-  "description": "Extract text and fallback page images from local document attachments.",
+  "description": "Extract text from local PDF and Office document attachments, with fallback page images for PDFs.",
   "contracts": {
-    "documentExtractors": ["pdf"]
+    "documentExtractors": ["pdf", "docx", "xlsx", "pptx"]
   },
   "configSchema": {
     "type": "object",

--- a/extensions/document-extract/package.json
+++ b/extensions/document-extract/package.json
@@ -5,7 +5,8 @@
   "description": "OpenClaw local document extraction plugin",
   "type": "module",
   "dependencies": {
-    "clawpdf": "0.3.1"
+    "clawpdf": "0.3.1",
+    "jszip": "3.10.1"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -995,6 +995,9 @@ importers:
       clawpdf:
         specifier: 0.3.1
         version: 0.3.1
+      jszip:
+        specifier: 3.10.1
+        version: 3.10.1
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -15,6 +15,7 @@ import { readResponseWithLimit } from "../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { logWarn } from "../logger.js";
+import { extractDocumentContent } from "./document-extractors.runtime.js";
 import { convertHeicToJpeg } from "./media-services.js";
 import { extractPdfContent, type PdfExtractedImage } from "./pdf-extract.js";
 
@@ -115,7 +116,13 @@ export const DEFAULT_INPUT_IMAGE_MIMES = [
   "image/heic",
   "image/heif",
 ];
-/** Default MIME allowlist for input_file text/PDF extraction. */
+/** Word OOXML (.docx) MIME handled by the document-extract plugin. */
+export const DOCX_MIME_TYPE =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+export const XLSX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+export const PPTX_MIME_TYPE =
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+/** Default MIME allowlist for input_file text/PDF/OOXML extraction. */
 const DEFAULT_INPUT_FILE_MIMES = [
   "text/plain",
   "text/markdown",
@@ -123,6 +130,9 @@ const DEFAULT_INPUT_FILE_MIMES = [
   "text/csv",
   "application/json",
   "application/pdf",
+  DOCX_MIME_TYPE,
+  XLSX_MIME_TYPE,
+  PPTX_MIME_TYPE,
 ];
 /** Default decoded-byte cap for input_image payloads. */
 export const DEFAULT_INPUT_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
@@ -481,6 +491,34 @@ export async function extractFileContentFromBuffer(params: {
         },
       }),
     });
+    const text = extracted.text ? clampText(extracted.text, limits.maxChars) : "";
+    return {
+      filename,
+      text,
+      images: extracted.images.length > 0 ? extracted.images : undefined,
+    };
+  }
+
+  if (mimeType === DOCX_MIME_TYPE || mimeType === XLSX_MIME_TYPE || mimeType === PPTX_MIME_TYPE) {
+    const label =
+      mimeType === DOCX_MIME_TYPE ? "DOCX" : mimeType === XLSX_MIME_TYPE ? "XLSX" : "PPTX";
+    const extracted = await withInputFileTimeout({
+      label: `${label} extraction`,
+      timeoutMs: limits.timeoutMs,
+      task: extractDocumentContent({
+        buffer,
+        mimeType,
+        maxPages: limits.pdf.maxPages,
+        maxPixels: limits.pdf.maxPixels,
+        minTextChars: limits.pdf.minTextChars,
+        ...(params.config ? { config: params.config } : {}),
+      }),
+    });
+    if (!extracted) {
+      throw new Error(
+        `${label} extraction disabled or unavailable: enable the document-extract plugin to process Office files.`,
+      );
+    }
     const text = extracted.text ? clampText(extracted.text, limits.maxChars) : "";
     return {
       filename,


### PR DESCRIPTION
## Summary
Refs openclaw/openclaw#35406

- add bundled Office OOXML document extraction for DOCX, XLSX, and PPTX attachments
- route DOCX/XLSX/PPTX through the default `input_file` document-extractor path
- preserve practical document structure: DOCX table rows, XLSX sheet names + row numbers, PPTX slide/notes order
- surface corrupt/encrypted/non-OOXML Office packages as explicit extraction failures instead of silently losing attachments

## Verification
- `node --import ./scripts/tsx.mjs scripts/run-vitest.mjs run extensions/document-extract/document-extractor.test.ts src/media/input-files.extract.test.ts src/media/document-extractors.runtime.test.ts src/media/pdf-extract.test.ts src/media-understanding/file-attachment-outcomes.test.ts src/media-understanding/apply.test.ts src/plugins/bundled-manifest-contract-plugins.test.ts src/plugins/document-extractors.runtime.test.ts src/plugins/capability-summary.test.ts`
- `node --import ./scripts/tsx.mjs scripts/run-vitest.mjs run extensions/document-extract/document-extractor.test.ts`
- `corepack pnpm exec oxfmt --check extensions/document-extract/document-extractor.ts extensions/document-extract/document-extractor.test.ts extensions/document-extract/index.ts extensions/document-extract/openclaw.plugin.json extensions/document-extract/package.json src/media/input-files.ts package.json pnpm-lock.yaml`
- `git diff --check`
