### PR TITLE
fix(buzz): retain lowest-id replaceable events on timestamp ties

### DIFF
--- a/extensions/buzz/src/buzz-bus.profile-lifecycle.test.ts
+++ b/extensions/buzz/src/buzz-bus.profile-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { finalizeEvent } from "nostr-tools";
+import { compareEvents, finalizeEvent } from "nostr-tools";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it, vi } from "vitest";
 
@@ -14,6 +14,43 @@ const { PRIVATE_KEY, CHANNEL_ID, startTestBus, signSenderEvent, subscriptionIncl
   useBuzzBusLifecycleFixture();
 
 describe("Buzz profile lifecycle", () => {
+  it("selects the lowest event ID when profiles share a timestamp", async () => {
+    relayMocks.auth.mockResolvedValue("ok");
+    const secretKey = Uint8Array.from(Buffer.from(PRIVATE_KEY, "hex"));
+    const profiles = ["First profile", "Second profile"].map((displayName) =>
+      finalizeEvent(
+        {
+          kind: 0,
+          created_at: 1_700_000_000,
+          content: JSON.stringify({ display_name: displayName }),
+          tags: [],
+        },
+        secretKey,
+      ),
+    );
+    const sortedProfiles = profiles.toSorted(compareEvents);
+    const lowerIdProfile = sortedProfiles[0];
+    const higherIdProfile = sortedProfiles[1];
+    if (!lowerIdProfile || !higherIdProfile) {
+      throw new Error("Expected two signed profile fixtures");
+    }
+    relayMocks.profileEvents = [higherIdProfile, lowerIdProfile];
+
+    const bus = await startTestBus({ profileName: "Configured Agent Name" });
+
+    await vi.waitFor(() =>
+      expect(relayMocks.publish.mock.calls.some(([event]) => event.kind === 10_100)).toBe(true),
+    );
+    const agentProfile = relayMocks.publish.mock.calls
+      .map(([event]) => event)
+      .find((event) => event.kind === 10_100);
+    expect(JSON.parse(agentProfile?.content ?? "{}")).toMatchObject({
+      name: JSON.parse(lowerIdProfile.content).display_name,
+      display_name: JSON.parse(lowerIdProfile.content).display_name,
+    });
+    await bus.close();
+  });
+
   it("isolates message failures from fatal relay failures", async () => {
     relayMocks.auth.mockResolvedValue("ok");
     relayMocks.profileEvents = [

--- a/extensions/buzz/src/buzz-relay.test-harness.ts
+++ b/extensions/buzz/src/buzz-relay.test-harness.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { createServer } from "node:http";
 import {
+  compareEvents,
   finalizeEvent,
   generateSecretKey,
   getPublicKey,
@@ -133,7 +134,7 @@ export async function createBuzzRelayFixture() {
           for (const filter of filters) {
             const matching = snapshot
               .filter((event) => matchesStored(filter, event))
-              .toSorted((a, b) => b.created_at - a.created_at);
+              .toSorted(compareEvents);
             for (const event of matching.slice(0, filter.limit ?? matching.length)) {
               if (!sent.has(event.id)) {
                 send(socket, ["EVENT", value, event]);

--- a/extensions/buzz/src/directory-state.ts
+++ b/extensions/buzz/src/directory-state.ts
@@ -1,6 +1,7 @@
 import type { Event } from "nostr-tools";
 import type { ChannelDirectoryEntry } from "openclaw/plugin-sdk/directory-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { isNewerBuzzRevision } from "./event-order.js";
 import type { BuzzMentionMember } from "./mentions.js";
 import type { BuzzRoomMembership } from "./room-membership.js";
 import { buildBuzzTarget, parseBuzzTarget } from "./target.js";
@@ -55,17 +56,6 @@ function readPreferredString(params: {
     return normalizeBoundedString(params.content[params.primary], params.maxChars);
   }
   return normalizeBoundedString(params.content[params.fallback], params.maxChars);
-}
-
-function isNewerEvent(
-  candidate: { createdAt: number; eventId: string },
-  current: { createdAt: number; eventId: string } | undefined,
-): boolean {
-  return (
-    !current ||
-    candidate.createdAt > current.createdAt ||
-    (candidate.createdAt === current.createdAt && candidate.eventId < current.eventId)
-  );
 }
 
 function fallbackPublicKeyLabel(publicKey: string): string {
@@ -257,7 +247,7 @@ export class BuzzDirectoryState {
     if (
       !profile ||
       !this.#profilePublicKeys.has(profile.publicKey) ||
-      !isNewerEvent(profile, this.#profiles.get(profile.publicKey))
+      !isNewerBuzzRevision(profile, this.#profiles.get(profile.publicKey))
     ) {
       return false;
     }
@@ -270,7 +260,7 @@ export class BuzzDirectoryState {
     if (
       !room ||
       !this.#configuredRoomIds.has(room.roomId) ||
-      !isNewerEvent(room, this.#rooms.get(room.roomId))
+      !isNewerBuzzRevision(room, this.#rooms.get(room.roomId))
     ) {
       return false;
     }

--- a/extensions/buzz/src/event-order.test.ts
+++ b/extensions/buzz/src/event-order.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { isNewerBuzzRevision } from "./event-order.js";
+
+describe("isNewerBuzzRevision", () => {
+  it.each([
+    {
+      name: "missing current",
+      candidate: { createdAt: 10, eventId: "b" },
+      current: undefined,
+      expected: true,
+    },
+    {
+      name: "newer timestamp",
+      candidate: { createdAt: 11, eventId: "b" },
+      current: { createdAt: 10, eventId: "a" },
+      expected: true,
+    },
+    {
+      name: "older timestamp",
+      candidate: { createdAt: 9, eventId: "a" },
+      current: { createdAt: 10, eventId: "b" },
+      expected: false,
+    },
+    {
+      name: "lower ID at equal timestamp",
+      candidate: { createdAt: 10, eventId: "a" },
+      current: { createdAt: 10, eventId: "b" },
+      expected: true,
+    },
+    {
+      name: "higher ID at equal timestamp",
+      candidate: { createdAt: 10, eventId: "b" },
+      current: { createdAt: 10, eventId: "a" },
+      expected: false,
+    },
+    {
+      name: "identical revision",
+      candidate: { createdAt: 10, eventId: "a" },
+      current: { createdAt: 10, eventId: "a" },
+      expected: false,
+    },
+  ])("$name", ({ candidate, current, expected }) => {
+    expect(isNewerBuzzRevision(candidate, current)).toBe(expected);
+  });
+});

--- a/extensions/buzz/src/event-order.ts
+++ b/extensions/buzz/src/event-order.ts
@@ -1,0 +1,17 @@
+type BuzzEventRevision = {
+  createdAt: number;
+  eventId: string;
+};
+
+// NIP-01 retains the lowest event ID when replaceable events share a timestamp.
+// Authorization-sensitive membership paths depend on this exact tie-break.
+export function isNewerBuzzRevision(
+  candidate: BuzzEventRevision,
+  current: BuzzEventRevision | undefined,
+): boolean {
+  return (
+    !current ||
+    candidate.createdAt > current.createdAt ||
+    (candidate.createdAt === current.createdAt && candidate.eventId < current.eventId)
+  );
+}

--- a/extensions/buzz/src/profile.ts
+++ b/extensions/buzz/src/profile.ts
@@ -1,4 +1,4 @@
-import { finalizeEvent, type Event, type Relay } from "nostr-tools";
+import { compareEvents, finalizeEvent, type Event, type Relay } from "nostr-tools";
 import { queryBuzzRelaySnapshot } from "./relay-subscription.js";
 
 const PROFILE_KIND = 0;
@@ -68,7 +68,7 @@ async function queryCurrentProfiles(params: {
     closeMessage: (reason) => `Buzz profile query closed: ${reason}`,
     onEvent: (event) => {
       const current = latestByKind.get(event.kind);
-      if (!current || event.created_at > current.created_at) {
+      if (!current || compareEvents(event, current) < 0) {
         latestByKind.set(event.kind, event);
       }
     },

--- a/extensions/buzz/src/qa/relay-client.ts
+++ b/extensions/buzz/src/qa/relay-client.ts
@@ -1,4 +1,5 @@
 import { finalizeEvent, type Event, type Relay } from "nostr-tools";
+import { isNewerBuzzRevision } from "../event-order.js";
 import {
   buildBuzzMessageTags,
   parseBuzzMessageEvent,
@@ -8,7 +9,6 @@ import { connectAuthenticatedBuzzRelaySession, parseBuzzAuthTag } from "../relay
 import { openBuzzRelaySubscription } from "../relay-subscription.js";
 import {
   BUZZ_ROOM_MEMBERSHIP_KIND,
-  isNewerBuzzRoomMembership,
   parseBuzzRoomMembershipEvent,
   type BuzzRoomMembership,
 } from "../room-membership.js";
@@ -75,10 +75,7 @@ async function loadBuzzQaRoomMembership(params: {
         {
           onevent: (event) => {
             const membership = parseBuzzRoomMembershipEvent(event, params.relayPublicKey);
-            if (
-              membership?.roomId === params.roomId &&
-              isNewerBuzzRoomMembership(membership, latest)
-            ) {
+            if (membership?.roomId === params.roomId && isNewerBuzzRevision(membership, latest)) {
               latest = membership;
             }
           },

--- a/extensions/buzz/src/room-discovery.ts
+++ b/extensions/buzz/src/room-discovery.ts
@@ -1,4 +1,5 @@
 import type { Event, Filter, Relay } from "nostr-tools";
+import { isNewerBuzzRevision } from "./event-order.js";
 import { connectAuthenticatedBuzzRelaySession, parseBuzzAuthTag } from "./relay-auth.js";
 import { queryBuzzRelaySnapshot } from "./relay-subscription.js";
 import { BUZZ_ROOM_MEMBERSHIP_KIND, parseBuzzRoomMembershipEvent } from "./room-membership.js";
@@ -93,9 +94,10 @@ export async function discoverBuzzRoomsOnRelay(params: {
       event.pubkey.toLowerCase() !== params.relayPublicKey ||
       !roomId ||
       !roomIds.includes(roomId) ||
-      (current &&
-        (current.created_at > event.created_at ||
-          (current.created_at === event.created_at && current.id <= event.id)))
+      !isNewerBuzzRevision(
+        { createdAt: event.created_at, eventId: event.id },
+        current ? { createdAt: current.created_at, eventId: current.id } : undefined,
+      )
     ) {
       continue;
     }

--- a/extensions/buzz/src/room-membership-query.ts
+++ b/extensions/buzz/src/room-membership-query.ts
@@ -1,8 +1,8 @@
 import type { Relay } from "nostr-tools";
+import { isNewerBuzzRevision } from "./event-order.js";
 import { queryBuzzRelaySnapshot } from "./relay-subscription.js";
 import {
   BUZZ_ROOM_MEMBERSHIP_KIND,
-  isNewerBuzzRoomMembership,
   parseBuzzRoomMembershipEvent,
   type BuzzRoomMembership,
 } from "./room-membership.js";
@@ -39,7 +39,7 @@ async function queryBuzzRoomMembershipBatch(params: {
       if (
         membership &&
         configuredRooms.has(membership.roomId) &&
-        isNewerBuzzRoomMembership(membership, memberships.get(membership.roomId))
+        isNewerBuzzRevision(membership, memberships.get(membership.roomId))
       ) {
         memberships.set(membership.roomId, membership);
       }
@@ -62,7 +62,7 @@ export async function queryBuzzRoomMemberships(params: {
       channelIds: params.channelIds.slice(index, index + RELAY_QUERY_EVENT_LIMIT),
     });
     for (const [roomId, membership] of batch) {
-      if (isNewerBuzzRoomMembership(membership, memberships.get(roomId))) {
+      if (isNewerBuzzRevision(membership, memberships.get(roomId))) {
         memberships.set(roomId, membership);
       }
     }

--- a/extensions/buzz/src/room-membership-tracker.ts
+++ b/extensions/buzz/src/room-membership-tracker.ts
@@ -1,4 +1,5 @@
 import type { Event, Filter, Relay } from "nostr-tools";
+import { isNewerBuzzRevision } from "./event-order.js";
 import { catchUpBuzzRoomHistory } from "./history-catchup.js";
 import { BUZZ_INBOUND_MESSAGE_KINDS, isBuzzInboundMessageKind } from "./message-event.js";
 import { openBuzzRelaySubscription } from "./relay-subscription.js";
@@ -10,7 +11,6 @@ import { queryBuzzRoomMemberships } from "./room-membership-query.js";
 import {
   BUZZ_ROOM_SYSTEM_KIND,
   BUZZ_ROOM_MEMBERSHIP_KIND,
-  isNewerBuzzRoomMembership,
   parseBuzzRoomMembershipEvent,
   parseBuzzRoomMembershipChangeEvent,
   type BuzzRoomMembership,
@@ -190,7 +190,7 @@ export async function createBuzzRoomMembershipTracker(params: {
       }
       // A live roster may have advanced while this query was in flight.
       const current = memberships.get(channelId);
-      if (current && isNewerBuzzRoomMembership(current, refreshed)) {
+      if (current && isNewerBuzzRevision(current, refreshed)) {
         refreshed = current;
       }
       const pending = pendingMemberships.get(channelId);
@@ -288,7 +288,7 @@ export async function createBuzzRoomMembershipTracker(params: {
       if (
         membership &&
         memberships.has(membership.roomId) &&
-        isNewerBuzzRoomMembership(membership, memberships.get(membership.roomId))
+        isNewerBuzzRevision(membership, memberships.get(membership.roomId))
       ) {
         try {
           replaceMembership(membership);

--- a/extensions/buzz/src/room-membership.ts
+++ b/extensions/buzz/src/room-membership.ts
@@ -63,17 +63,6 @@ export function parseBuzzRoomMembershipEvent(
   };
 }
 
-export function isNewerBuzzRoomMembership(
-  candidate: BuzzRoomMembership,
-  current: BuzzRoomMembership | undefined,
-): boolean {
-  return (
-    !current ||
-    candidate.createdAt > current.createdAt ||
-    (candidate.createdAt === current.createdAt && candidate.eventId < current.eventId)
-  );
-}
-
 export function parseBuzzRoomMembershipChangeEvent(
   event: Event,
   membership: BuzzRoomMembership,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Buzz profile synchronization could select whichever replaceable event arrived first when two signed events shared a timestamp. That disagreed with NIP-01 and could make profile state depend on relay delivery order.

The same ordering rule was also duplicated across room metadata, directory profiles, membership snapshots, discovery, and QA code, making authorization-sensitive membership selection easier to drift.

## Why This Change Was Made

Buzz projection types now use one plugin-private replaceable-event comparator: newer timestamp wins, then the lower event ID wins on ties. Full verified Nostr events use `nostr-tools@2.24.3`'s existing `compareEvents` contract directly.

This stays inside the Buzz plugin. It adds no config, persistence, core, SDK, docs, or compatibility surface.

Upstream contract:

- NIP-01: https://github.com/nostr-protocol/nips/blob/master/01.md
- `nostr-tools.compareEvents`: reverse chronological `created_at`, then lexicographic `id`

## User Impact

Buzz profile, room metadata, and membership state now resolve equal-timestamp replaceable events deterministically according to NIP-01. Relay arrival order can no longer select the wrong profile revision.

## Evidence

- Pre-fix regression: the equal-timestamp profile lifecycle test failed because the higher-ID event supplied the selected profile.
- The signed profile fixture derives lower/higher IDs with upstream `compareEvents` at the shared timestamp, matching the production contract without locale-sensitive ordering.
- Focused Buzz ordering and sibling paths: 34/34 passed.
- Full Buzz plugin suite: 318/318 passed.
- Refreshed-base ordering regressions: 7/7 passed.
- Buzz-only TypeScript check: passed.
- Changed-file Oxlint: passed.
- Formatting and `git diff --check`: passed.
- Sol/high autoreview on the final tightened diff: clean, 0.97.
- `node scripts/check-changed.mjs`: all checks through package patches and test-temp reporting passed; the global extension typecheck then stopped on unrelated shared-install skew where local `grammy@1.45.1` lacks Telegram types required by current `main`. Clean-install CI/Testbox remains the authority for that gate.
- Production LOC: +35/-40, net -5.
- Tests: +83/-1. Test support: +2/-1.
- Direct AWS Crabbox is not needed: this is pure TypeScript ordering with no OS, package-install, service, or external API behavior. The required Blacksmith Linux Testbox prepare gate will provide clean remote proof before landing.
