### PR TITLE
fix: models status skips refresh with matching agent directory override

### DIFF
--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -28,7 +28,11 @@ openclaw models set-image <model-or-alias>
 openclaw models scan
 ```
 
-`status`, `list`, and `auth` subcommands accept `--agent <id>` to target a configured agent; `fallbacks`/`image-fallbacks` always use the configured default agent, and `set`, `set-image`, `scan`, `refresh`, and `aliases` reject `--agent` outright because they are global and never agent-scoped. When omitted, `--agent`-aware commands use `OPENCLAW_AGENT_DIR` if set, otherwise the configured default agent.
+`status`, `list`, and `auth` subcommands accept `--agent <id>` to target a configured agent. Without it, model inspection uses `agents.defaults.systemAgent.agentId` when configured, otherwise the sole configured agent. Auth mutations require `--agent <id>` when multiple agents are configured.
+
+For `models status`, `OPENCLAW_AGENT_DIR` overrides the inspected auth directory when `--agent` is omitted. A matching configured `agentDir` retains that agent's ownership during credential refresh. An explicit `--agent <id>` takes precedence over the environment override.
+
+`fallbacks`/`image-fallbacks` manage global defaults. `set`, `set-image`, `scan`, `refresh`, and `aliases` also operate globally and reject `--agent`.
 
 `models set` and `models set-image` require the provider to be declared by an installed plugin or configured under `models.providers`. An unknown provider exits nonzero without changing config. If the provider is known but the model is absent from the local catalog, the command saves the selection and prints a warning because newly released and self-hosted models may not be cataloged yet. `openclaw doctor --json` reports configured unknown providers; add `--severity-min info` to also see active models that the local catalog cannot confirm.
 

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -923,12 +923,10 @@ describe("modelsStatusCommand auth overview", () => {
 
   it("honors OPENCLAW_AGENT_DIR when no --agent override is provided", async () => {
     const localRuntime = createRuntime();
-    mocks.resolveAgentDir.mockClear();
     await withEnvAsync({ OPENCLAW_AGENT_DIR: "/tmp/openclaw-isolated-agent" }, async () => {
       await modelsStatusCommand({ json: true }, localRuntime as never);
     });
 
-    expect(mocks.resolveAgentDir).not.toHaveBeenCalled();
     expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith("/tmp/openclaw-isolated-agent");
     const payload = parseFirstJsonLog(localRuntime);
     expect(payload.agentDir).toBe("/tmp/openclaw-isolated-agent");
@@ -937,7 +935,6 @@ describe("modelsStatusCommand auth overview", () => {
 
   it("honors deprecated PI_CODING_AGENT_DIR when OPENCLAW_AGENT_DIR is unset", async () => {
     const localRuntime = createRuntime();
-    mocks.resolveAgentDir.mockClear();
     await withEnvAsync(
       {
         OPENCLAW_AGENT_DIR: undefined,
@@ -948,7 +945,6 @@ describe("modelsStatusCommand auth overview", () => {
       },
     );
 
-    expect(mocks.resolveAgentDir).not.toHaveBeenCalled();
     expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith("/tmp/openclaw-legacy-agent");
     const payload = parseFirstJsonLog(localRuntime);
     expect(payload.agentDir).toBe("/tmp/openclaw-legacy-agent");

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -923,10 +923,12 @@ describe("modelsStatusCommand auth overview", () => {
 
   it("honors OPENCLAW_AGENT_DIR when no --agent override is provided", async () => {
     const localRuntime = createRuntime();
+    mocks.resolveAgentDir.mockClear();
     await withEnvAsync({ OPENCLAW_AGENT_DIR: "/tmp/openclaw-isolated-agent" }, async () => {
       await modelsStatusCommand({ json: true }, localRuntime as never);
     });
 
+    expectResolveAgentDirCalledFor("main");
     expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith("/tmp/openclaw-isolated-agent");
     const payload = parseFirstJsonLog(localRuntime);
     expect(payload.agentDir).toBe("/tmp/openclaw-isolated-agent");
@@ -935,6 +937,7 @@ describe("modelsStatusCommand auth overview", () => {
 
   it("honors deprecated PI_CODING_AGENT_DIR when OPENCLAW_AGENT_DIR is unset", async () => {
     const localRuntime = createRuntime();
+    mocks.resolveAgentDir.mockClear();
     await withEnvAsync(
       {
         OPENCLAW_AGENT_DIR: undefined,
@@ -945,6 +948,7 @@ describe("modelsStatusCommand auth overview", () => {
       },
     );
 
+    expectResolveAgentDirCalledFor("main");
     expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith("/tmp/openclaw-legacy-agent");
     const payload = parseFirstJsonLog(localRuntime);
     expect(payload.agentDir).toBe("/tmp/openclaw-legacy-agent");

--- a/src/commands/models/shared.auth-store.test.ts
+++ b/src/commands/models/shared.auth-store.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { unregisterResolvedAgentDir } from "../../agents/agent-dir-registry.js";
+import {
+  readPersistedAuthProfileStateRaw,
+  resolveAuthProfileDatabasePath,
+  writePersistedAuthProfileStateRaw,
+} from "../../agents/auth-profiles/sqlite.js";
+import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { resolveModelsTargetAgent } from "./shared.js";
+
+describe("model inspection auth store ownership", () => {
+  it("retains the configured owner when a read override selects the same custom directory", async () => {
+    await withOpenClawTestState({ label: "models-custom-owner" }, async (state) => {
+      const agentId = "helper";
+      const agentDir = state.statePath("agents", agentId);
+      const cfg = {
+        agents: { ownership: "explicit" as const, entries: { [agentId]: { agentDir } } },
+      };
+      openOpenClawAgentDatabase({ agentId, path: resolveAuthProfileDatabasePath(agentDir) });
+      try {
+        const target = resolveModelsTargetAgent(cfg, undefined, {
+          kind: "read",
+          agentDirOverride: agentDir,
+        });
+        const authState = { version: 1, lastGood: { anthropic: "anthropic:local" } };
+
+        writePersistedAuthProfileStateRaw(authState, target.agentDir);
+
+        expect(target).toEqual({ agentId, agentDir });
+        expect(readPersistedAuthProfileStateRaw(agentDir)).toEqual(authState);
+      } finally {
+        unregisterResolvedAgentDir({ agentId, agentDir });
+      }
+    });
+  });
+
+  it("preserves an unrelated override without assigning it the configured agent's ownership", async () => {
+    await withOpenClawTestState({ label: "models-override-owner" }, async (state) => {
+      const agentId = "helper";
+      const agentDir = state.statePath("agents", agentId);
+      const overrideDir = state.statePath("separate-auth");
+      const cfg = {
+        agents: { ownership: "explicit" as const, entries: { [agentId]: { agentDir } } },
+      };
+      openOpenClawAgentDatabase({
+        agentId: "separate-owner",
+        path: resolveAuthProfileDatabasePath(overrideDir),
+      });
+      try {
+        const target = resolveModelsTargetAgent(cfg, undefined, {
+          kind: "read",
+          agentDirOverride: overrideDir,
+        });
+
+        expect(target).toEqual({ agentId, agentDir: overrideDir });
+        expect(() => writePersistedAuthProfileStateRaw({ version: 1 }, target.agentDir)).toThrow(
+          /requested agent custom-/,
+        );
+      } finally {
+        unregisterResolvedAgentDir({ agentId, agentDir });
+      }
+    });
+  });
+});

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -148,7 +148,7 @@ function resolveKnownAgentId(cfg: OpenClawConfig, rawAgentId: string): string {
 
 type ModelsTargetMode = { kind: "read"; agentDirOverride?: string } | { kind: "mutation" };
 
-/** Resolves the selected model-command agent and its profile directory. */
+/** Resolves model-command scope and retains configured auth ownership through read overrides. */
 export function resolveModelsTargetAgent(
   cfg: OpenClawConfig,
   rawAgentId: string | undefined,
@@ -172,8 +172,8 @@ export function resolveModelsTargetAgent(
         resolveSoleAgentId(cfg, { surface: "the model command", hint: "Pass --agent <id>." }));
   const agentId = resolveKnownAgentId(cfg, resolvedAgentId);
   const agentDirOverride = mode.kind === "read" ? mode.agentDirOverride : undefined;
-  const agentDir = agentDirOverride ?? resolveAgentDir(cfg, agentId);
-  return { agentId, agentDir };
+  const agentDir = resolveAgentDir(cfg, agentId);
+  return { agentId, agentDir: agentDirOverride ?? agentDir };
 }
 
 /** Normalized primary/fallback config shape used by text and image defaults. */


### PR DESCRIPTION
Related: #133984

## What Problem This Solves

Fixes an issue where a cold `openclaw models status` call could fail to persist refreshed credentials when `OPENCLAW_AGENT_DIR` named the selected agent's configured custom directory. A later explicit `--agent` call could work, making the failure appear intermittent.

## Why This Change Was Made

Resolve and register the configured directory before applying the existing inspection override. This preserves the known owner before credential synchronization runs. An unrelated override still has to satisfy its own database ownership checks.

## User Impact

The first status call can persist refreshed credentials for the configured agent. CLI documentation now describes explicit, system, and sole-agent selection and the scope of the directory override.

## Evidence

The public built baseline CLI returned valid JSON and exit 0 but retained expired credentials on the cold override path; an independently reseeded explicit-agent control refreshed them. The same harness passes against the combined candidate build: both cold and explicit-agent paths persist refreshed credentials. The isolated source-command proof below independently attributes the change to this patch. The same isolated `modelsStatusCommand` reproduction with real SQLite and a synthetic external CLI credential file fails its fresh-credential assertion before the fix and passes afterward. The explicit-agent control also passes. No live provider credentials or chat transport were used.

The two new real-store regressions pass, including refusal to assign an unrelated override the configured agent's ownership. The status test file also passes all 38 tests. CI exposed two older assertions that prohibited the owner lookup this fix requires. The existing override tests now establish a fresh invocation boundary and positively verify resolution of the configured agent, while retaining directory-selection and JSON-output checks. The actual changed gate passed on the production fix, including production/test typechecks, changed-file lint, and required guards. Independent Codex autoreview found no actionable findings. The earlier optional shared-helper Vitest run was stopped during slow imports and is not reported green. A later local run of the final status assertions reached the existing 900-second no-output limit before assertions; its automatic retry was stopped. That run is incomplete. The current main branch already contains the inventory-buffer and Gateway-test prerequisite repairs needed by CI; final exact-head checks remain required before landing.

Production LOC: +3/-3 (net 0); tests: +67/-2; docs: +5/-1. The original chat `/model` ownership failure from the linked report was not reproduced and is not claimed fixed by this CLI correction.

