### PR TITLE
test(whatsapp): own auth fixture cleanup and remove duplicate cases

### DIFF
--- a/extensions/whatsapp/src/auth-store.test.ts
+++ b/extensions/whatsapp/src/auth-store.test.ts
@@ -2,7 +2,8 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getWebAuthAgeMs,
   hasWebCredsSync,
@@ -40,24 +41,19 @@ vi.mock("./auth-store.runtime.js", () => ({
   resolveOAuthDir: () => hoisted.oauthDir,
 }));
 
-function createTempAuthDir(prefix: string) {
-  return fsSync.mkdtempSync(
-    path.join((process.env.TMPDIR ?? "/tmp").replace(/\/+$/, ""), `${prefix}-`),
-  );
-}
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function withOwnedOAuthAuthDir<T>(
   prefix: string,
   run: (authDir: string) => Promise<T>,
 ): Promise<T> {
   const previousOAuthDir = hoisted.oauthDir;
-  const oauthDir = createTempAuthDir(`${prefix}-oauth`);
+  const oauthDir = tempDirs.make(`${prefix}-oauth-`);
   const authDir = path.join(oauthDir, "whatsapp", "default");
   fsSync.mkdirSync(authDir, { recursive: true });
   hoisted.oauthDir = oauthDir;
   return run(authDir).finally(() => {
     hoisted.oauthDir = previousOAuthDir;
-    fsSync.rmSync(oauthDir, { recursive: true, force: true });
   });
 }
 
@@ -67,7 +63,7 @@ describe("auth-store", () => {
   });
 
   it("does not restore creds from backup on ordinary reads", async () => {
-    const authDir = createTempAuthDir("openclaw-wa-auth-read");
+    const authDir = tempDirs.make("openclaw-wa-auth-read-");
     const credsPath = path.join(authDir, "creds.json");
     const backupPath = path.join(authDir, "creds.json.bak");
     fsSync.writeFileSync(backupPath, JSON.stringify({ me: { id: "123@s.whatsapp.net" } }), "utf-8");
@@ -77,7 +73,7 @@ describe("auth-store", () => {
   });
 
   it("restores malformed creds from a valid backup", async () => {
-    const authDir = createTempAuthDir("openclaw-wa-auth-restore");
+    const authDir = tempDirs.make("openclaw-wa-auth-restore-");
     const credsPath = path.join(authDir, "creds.json");
     fsSync.writeFileSync(credsPath, "{x", "utf-8");
     fsSync.writeFileSync(
@@ -93,7 +89,7 @@ describe("auth-store", () => {
   });
 
   it("revalidates setup ownership immediately before restoring backup credentials", async () => {
-    const authDir = createTempAuthDir("openclaw-wa-auth-guarded-restore");
+    const authDir = tempDirs.make("openclaw-wa-auth-guarded-restore-");
     const credsPath = path.join(authDir, "creds.json");
     const guardError = new Error("verified inference route changed");
     fsSync.writeFileSync(credsPath, "{x", "utf-8");
@@ -114,7 +110,7 @@ describe("auth-store", () => {
   });
 
   it("leaves malformed creds unchanged when the backup is malformed", async () => {
-    const authDir = createTempAuthDir("openclaw-wa-auth-malformed-backup");
+    const authDir = tempDirs.make("openclaw-wa-auth-malformed-backup-");
     const credsPath = path.join(authDir, "creds.json");
     fsSync.writeFileSync(credsPath, "{x", "utf-8");
     fsSync.writeFileSync(path.join(authDir, "creds.json.bak"), "{y", "utf-8");
@@ -124,7 +120,7 @@ describe("auth-store", () => {
   });
 
   it("preserves valid large creds instead of treating them as corrupt", async () => {
-    const authDir = createTempAuthDir("openclaw-wa-auth-large-creds");
+    const authDir = tempDirs.make("openclaw-wa-auth-large-creds-");
     const credsPath = path.join(authDir, "creds.json");
     const largeCreds = JSON.stringify({
       me: { id: "15551234567@s.whatsapp.net" },
@@ -147,7 +143,7 @@ describe("auth-store", () => {
   });
 
   it("refuses to restore creds from a symlinked backup path", async () => {
-    const authDir = createTempAuthDir("openclaw-wa-auth-restore-symlink");
+    const authDir = tempDirs.make("openclaw-wa-auth-restore-symlink-");
     const targetPath = path.join(authDir, "backup-target.json");
     const backupPath = path.join(authDir, "creds.json.bak");
     const credsPath = path.join(authDir, "creds.json");
@@ -162,7 +158,7 @@ describe("auth-store", () => {
   it.runIf(process.platform !== "win32")(
     "does not restore backup over a symlinked creds path",
     async () => {
-      const authDir = createTempAuthDir("openclaw-wa-auth-restore-target-symlink");
+      const authDir = tempDirs.make("openclaw-wa-auth-restore-target-symlink-");
       const targetPath = path.join(authDir, "target-creds.json");
       const credsPath = path.join(authDir, "creds.json");
       const backupPath = path.join(authDir, "creds.json.bak");
@@ -181,7 +177,7 @@ describe("auth-store", () => {
   );
 
   it("reports linked auth state and snapshot from the shared read helper", async () => {
-    const authDir = createTempAuthDir("openclaw-wa-auth-linked");
+    const authDir = tempDirs.make("openclaw-wa-auth-linked-");
     fsSync.writeFileSync(
       path.join(authDir, "creds.json"),
       JSON.stringify({ me: { id: "15551234567@s.whatsapp.net" } }),
@@ -206,7 +202,7 @@ describe("auth-store", () => {
   it.runIf(process.platform !== "win32")(
     "treats symlinked creds as missing across auth readers",
     async () => {
-      const authDir = createTempAuthDir("openclaw-wa-auth-symlink-read");
+      const authDir = tempDirs.make("openclaw-wa-auth-symlink-read-");
       const targetPath = path.join(authDir, "target-creds.json");
       const credsPath = path.join(authDir, "creds.json");
       fsSync.writeFileSync(
@@ -240,7 +236,7 @@ describe("auth-store", () => {
   it.runIf(process.platform !== "win32")(
     "treats creds under a symlinked auth directory as missing",
     async () => {
-      const rootDir = createTempAuthDir("openclaw-wa-auth-symlink-parent");
+      const rootDir = tempDirs.make("openclaw-wa-auth-symlink-parent-");
       const targetAuthDir = path.join(rootDir, "target-auth");
       const authDir = path.join(rootDir, "linked-auth");
       fsSync.mkdirSync(targetAuthDir);
@@ -262,7 +258,7 @@ describe("auth-store", () => {
   );
 
   it("reports unstable auth state when the shared barrier read times out", async () => {
-    const authDir = createTempAuthDir("openclaw-wa-auth-unstable-state");
+    const authDir = tempDirs.make("openclaw-wa-auth-unstable-state-");
     fsSync.writeFileSync(
       path.join(authDir, "creds.json"),
       JSON.stringify({ me: { id: "15551234567@s.whatsapp.net" } }),
@@ -319,12 +315,11 @@ describe("auth-store", () => {
   });
 
   it("does not delete the whole legacy auth root when targeted cleanup fails", async () => {
-    const authDir = createTempAuthDir("openclaw-wa-auth-legacy-failure");
+    const authDir = tempDirs.make("openclaw-wa-auth-legacy-failure-");
     const previousOAuthDir = hoisted.oauthDir;
     fsSync.writeFileSync(path.join(authDir, "creds.json"), "{}", "utf-8");
     fsSync.writeFileSync(path.join(authDir, "oauth.json"), '{"token":true}', "utf-8");
     fsSync.writeFileSync(path.join(authDir, "session-abc.json"), "{}", "utf-8");
-    hoisted.oauthDir = authDir;
     const originalRm = fs.rm;
     const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
       if (String(target).endsWith("creds.json")) {
@@ -339,6 +334,7 @@ describe("auth-store", () => {
     };
 
     try {
+      hoisted.oauthDir = authDir;
       await expect(
         logoutWeb({ authDir, isLegacyAuthDir: true, runtime: runtime as never }),
       ).rejects.toThrow("EACCES");
@@ -347,12 +343,11 @@ describe("auth-store", () => {
     } finally {
       hoisted.oauthDir = previousOAuthDir;
       rmSpy.mockRestore();
-      fsSync.rmSync(authDir, { recursive: true, force: true });
     }
   });
 
   it("clears every Baileys auth category from the shared legacy root without touching other files", async () => {
-    const authDir = createTempAuthDir("openclaw-wa-auth-legacy-categories");
+    const authDir = tempDirs.make("openclaw-wa-auth-legacy-categories-");
     const previousOAuthDir = hoisted.oauthDir;
     const authFiles = [
       "creds.json",
@@ -397,109 +392,11 @@ describe("auth-store", () => {
       );
     } finally {
       hoisted.oauthDir = previousOAuthDir;
-      fsSync.rmSync(authDir, { recursive: true, force: true });
-    }
-  });
-
-  it("clears auth state even when directory enumeration fails", async () => {
-    await withOwnedOAuthAuthDir("openclaw-wa-auth-readdir", async (authDir) => {
-      fsSync.writeFileSync(path.join(authDir, "creds.json"), "{}", "utf-8");
-      const readdirSpy = vi
-        .spyOn(fs, "readdir")
-        .mockRejectedValueOnce(Object.assign(new Error("EACCES"), { code: "EACCES" }));
-      const runtime = {
-        log: vi.fn(),
-        error: vi.fn(),
-        exit: vi.fn(),
-      };
-
-      await expect(logoutWeb({ authDir, runtime: runtime as never })).resolves.toBe(true);
-      expect(fsSync.existsSync(authDir)).toBe(false);
-      readdirSpy.mockRestore();
-    });
-  });
-
-  it("does not delete custom auth directories outside the OpenClaw auth root", async () => {
-    const authDir = createTempAuthDir("openclaw-wa-auth-custom");
-    const nestedDir = path.join(authDir, "nested");
-    fsSync.mkdirSync(nestedDir);
-    fsSync.writeFileSync(path.join(authDir, "creds.json"), "{}", "utf-8");
-    fsSync.writeFileSync(path.join(authDir, "notes.txt"), "keep me", "utf-8");
-    fsSync.writeFileSync(path.join(nestedDir, "session-abc.json"), "keep me", "utf-8");
-    const runtime = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn(),
-    };
-
-    await expect(logoutWeb({ authDir, runtime: runtime as never })).resolves.toBe(false);
-    expect(fsSync.existsSync(authDir)).toBe(true);
-    expect(fsSync.existsSync(path.join(authDir, "creds.json"))).toBe(true);
-    expect(fsSync.existsSync(path.join(authDir, "notes.txt"))).toBe(true);
-    expect(fsSync.existsSync(path.join(nestedDir, "session-abc.json"))).toBe(true);
-  });
-
-  it("does not clear auth files through a symlinked owned auth directory", async () => {
-    const previousOAuthDir = hoisted.oauthDir;
-    const oauthDir = createTempAuthDir("openclaw-wa-auth-symlink-oauth");
-    const externalDir = createTempAuthDir("openclaw-wa-auth-symlink-target");
-    const authDir = path.join(oauthDir, "whatsapp", "default");
-    try {
-      fsSync.mkdirSync(path.dirname(authDir), { recursive: true });
-      fsSync.writeFileSync(path.join(externalDir, "creds.json"), "{}", "utf-8");
-      fsSync.writeFileSync(path.join(externalDir, "notes.txt"), "keep me", "utf-8");
-      fsSync.symlinkSync(externalDir, authDir, "dir");
-      hoisted.oauthDir = oauthDir;
-      const runtime = {
-        log: vi.fn(),
-        error: vi.fn(),
-        exit: vi.fn(),
-      };
-
-      await expect(logoutWeb({ authDir, runtime: runtime as never })).resolves.toBe(false);
-      expect(fsSync.existsSync(authDir)).toBe(true);
-      expect(fsSync.existsSync(path.join(externalDir, "creds.json"))).toBe(true);
-      expect(fsSync.existsSync(path.join(externalDir, "notes.txt"))).toBe(true);
-    } finally {
-      hoisted.oauthDir = previousOAuthDir;
-      fsSync.rmSync(oauthDir, { recursive: true, force: true });
-      fsSync.rmSync(externalDir, { recursive: true, force: true });
-    }
-  });
-
-  it("does not clear auth files through an intermediate symlink in the owned auth tree", async () => {
-    const previousOAuthDir = hoisted.oauthDir;
-    const oauthDir = createTempAuthDir("openclaw-wa-auth-symlink-parent-oauth");
-    const externalRoot = createTempAuthDir("openclaw-wa-auth-symlink-parent-target");
-    const externalAuthDir = path.join(externalRoot, "default");
-    const linkedParent = path.join(oauthDir, "whatsapp", "linked");
-    const authDir = path.join(linkedParent, "default");
-    try {
-      fsSync.mkdirSync(path.dirname(linkedParent), { recursive: true });
-      fsSync.mkdirSync(externalAuthDir, { recursive: true });
-      fsSync.writeFileSync(path.join(externalAuthDir, "creds.json"), "{}", "utf-8");
-      fsSync.writeFileSync(path.join(externalAuthDir, "notes.txt"), "keep me", "utf-8");
-      fsSync.symlinkSync(externalRoot, linkedParent, "dir");
-      hoisted.oauthDir = oauthDir;
-      const runtime = {
-        log: vi.fn(),
-        error: vi.fn(),
-        exit: vi.fn(),
-      };
-
-      await expect(logoutWeb({ authDir, runtime: runtime as never })).resolves.toBe(false);
-      expect(fsSync.existsSync(authDir)).toBe(true);
-      expect(fsSync.existsSync(path.join(externalAuthDir, "creds.json"))).toBe(true);
-      expect(fsSync.existsSync(path.join(externalAuthDir, "notes.txt"))).toBe(true);
-    } finally {
-      hoisted.oauthDir = previousOAuthDir;
-      fsSync.rmSync(oauthDir, { recursive: true, force: true });
-      fsSync.rmSync(externalRoot, { recursive: true, force: true });
     }
   });
 
   it("does not delete unrelated non-empty directories on logout", async () => {
-    const authDir = createTempAuthDir("openclaw-wa-auth-unrelated");
+    const authDir = tempDirs.make("openclaw-wa-auth-unrelated-");
     fsSync.writeFileSync(path.join(authDir, "notes.txt"), "keep me", "utf-8");
     const runtime = {
       log: vi.fn(),


### PR DESCRIPTION
## What Problem This Solves

Auth-store tests allocate private directories without consistent per-case cleanup and repeat logout boundaries already covered through the real logout fixture.

## Why This Change Was Made

Use the existing test-env temp tracker, retaining finally-owned OAuth overrides and spy restoration. Delete three duplicate logout boundary cases: outside-root, direct symlink and intermediate symlink protection remain in the unchanged logout suite with its real OAuth and credential barrier setup. Remove the directory-enumeration fault case after proving its readdir spy is never called; the actual successful removal behavior remains covered.

## User Impact

Test-only. Six of 22 temp allocations disappear, and twelve retained roots gain explicit per-case cleanup. The outer test process already cleans its namespace on exit; this makes fixture lifetime explicit and shorter. Production +0/-0; tests +19/-122 (net -103). Private roots, all other assertions, deadlines and platform skips remain.

## Evidence

30/30 cases pass before and 26/26 after. The native result map contains exactly the four intended deletions and preserves every retained case name and result. Logout source bytes are unchanged. Adding a diagnostic call-count assertion to the dormant readdir spy failed with zero calls after the original result/removal assertions passed; the original bytes were restored before applying the cleanup. Full changed checks and Codex autoreview pass.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/whatsapp/src/auth-store.test.ts extensions/whatsapp/src/logout.test.ts extensions/whatsapp/src/creds-persistence.test.ts extensions/whatsapp/src/auth-store.lazy-dir.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base 2b6b1e2a8b8
```

