### PR TITLE
fix(ui): avoid flashes when switching cold sessions

### DIFF
--- a/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
@@ -3,6 +3,7 @@ import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import {
   chatSessionListResponse,
+  controlUiSessionUrl,
   createChatFlowE2eSuite,
   installMockGateway,
 } from "./chat-flow.test-support.ts";
@@ -21,6 +22,112 @@ async function captureHistoryIssuanceProof(page: Page, name: string): Promise<vo
 }
 
 suite.define(() => {
+  it("switches immediately but shows a skeleton only for slow history", async () => {
+    const context = await suite.newBrowserContext({
+      ...createControlUiE2eContextOptions(),
+      reducedMotion: "reduce",
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["chat.startup", "chat.history"],
+      sessionKey: "agent:main:session-a",
+      historyMessages: [{ role: "assistant", content: "Previous conversation." }],
+      sessionTranscripts: {
+        "agent:main:session-b": {
+          messages: [{ role: "assistant", content: "Destination conversation." }],
+        },
+      },
+      methodResponses: { "sessions.list": chatSessionListResponse() },
+    });
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:session-a"));
+      await gateway.waitForRequest("chat.startup");
+      const loader = page.locator(
+        ".chat-pane-cache__pane--visible .chat-thread openclaw-panel-loading-skeleton",
+      );
+      await loader.waitFor({ state: "attached" });
+      expect(await loader.evaluate((node) => getComputedStyle(node).visibility)).toBe("hidden");
+      await gateway.resolveDeferred("chat.startup");
+      const previous = page.locator(".chat-thread").getByText("Previous conversation.");
+      await previous.waitFor({ state: "visible" });
+      expect(await loader.count()).toBe(0);
+      await gateway.deferNext("chat.startup");
+      const [revealDelay] = await Promise.all([
+        page.evaluate(
+          () =>
+            new Promise<{ delay: number; previousVisible: boolean }>((resolve) => {
+              const started = performance.now();
+              let animationStart: number | undefined;
+              let previousVisible = false;
+              const sample = () => {
+                const skeleton = document.querySelector(
+                  ".chat-pane-cache__pane--visible .chat-thread openclaw-panel-loading-skeleton",
+                );
+                if (skeleton) {
+                  const startTime = skeleton.getAnimations()[0]?.startTime;
+                  if (typeof startTime === "number") {
+                    animationStart = startTime;
+                  }
+                  previousVisible ||= [...document.querySelectorAll("openclaw-chat-pane")].some(
+                    (pane) =>
+                      getComputedStyle(pane).opacity !== "0" &&
+                      pane.getAttribute("aria-hidden") === "false" &&
+                      Boolean(pane.textContent?.includes("Previous conversation.")),
+                  );
+                  if (getComputedStyle(skeleton).visibility === "visible") {
+                    // Use the animation clock: the first sampled frame may arrive late on CI.
+                    const now = document.timeline.currentTime;
+                    resolve({
+                      delay:
+                        typeof now === "number" && animationStart !== undefined
+                          ? now - animationStart
+                          : 0,
+                      previousVisible,
+                    });
+                    return;
+                  }
+                }
+                if (performance.now() - started > 3_000) {
+                  resolve({ delay: -1, previousVisible });
+                  return;
+                }
+                requestAnimationFrame(sample);
+              };
+              sample();
+            }),
+        ),
+        page
+          .locator('[data-session-key="agent:main:session-b"] a.sidebar-recent-session__link')
+          .click(),
+      ]);
+      expect(revealDelay.delay).toBeGreaterThanOrEqual(480);
+      expect(revealDelay.previousVisible).toBe(false);
+      expect(revealDelay.delay).toBeLessThan(1_000);
+      expect(
+        await page
+          .locator(".chat-pane-cache__pane--visible")
+          .getByText("Previous conversation.")
+          .count(),
+      ).toBe(0);
+      await gateway.resolveDeferred("chat.startup");
+      await page
+        .locator(".chat-thread")
+        .getByText("Destination conversation.")
+        .waitFor({ state: "visible" });
+      await page
+        .locator('[data-session-key="agent:main:session-a"] a.sidebar-recent-session__link')
+        .click();
+      await previous.waitFor({ state: "visible" });
+      expect(
+        await page
+          .locator(".chat-pane-cache__pane--visible openclaw-panel-loading-skeleton")
+          .count(),
+      ).toBe(0);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it.each(["named", "short"] as const)(
     "retains deferred history across %s chat canonicalization",
     async (reference) => {

--- a/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
@@ -72,7 +72,7 @@ suite.define(() => {
                     (pane) =>
                       getComputedStyle(pane).opacity !== "0" &&
                       pane.getAttribute("aria-hidden") === "false" &&
-                      Boolean(pane.textContent?.includes("Previous conversation.")),
+                      pane.textContent.includes("Previous conversation."),
                   );
                   if (getComputedStyle(skeleton).visibility === "visible") {
                     // Use the animation clock: the first sampled frame may arrive late on CI.

--- a/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
@@ -49,6 +49,9 @@ suite.define(() => {
       expect(await loader.evaluate((node) => getComputedStyle(node).visibility)).toBe("hidden");
       const opacity = await loader.evaluate(async (node) => {
         const animation = node.getAnimations()[0];
+        if (!animation) {
+          throw new Error("The loading skeleton has no reveal animation");
+        }
         await animation.ready;
         animation.pause();
         return [499, 575, 650].map((time) => {
@@ -65,6 +68,7 @@ suite.define(() => {
       await previous.waitFor({ state: "visible" });
       expect(await loader.count()).toBe(0);
       await page.emulateMedia({ reducedMotion: "reduce" });
+      await page.waitForFunction(() => matchMedia("(prefers-reduced-motion: reduce)").matches);
       await gateway.deferNext("chat.startup");
       const [revealDelay] = await Promise.all([
         page.evaluate(
@@ -117,7 +121,13 @@ suite.define(() => {
       expect(revealDelay.delay).toBeGreaterThanOrEqual(480);
       expect(revealDelay.previousVisible).toBe(false);
       expect(revealDelay.delay).toBeLessThan(1_000);
-      expect(await loader.evaluate((node) => getComputedStyle(node).opacity)).toBe("1");
+      expect(
+        await loader.evaluate((node) => ({
+          opacity: getComputedStyle(node).opacity,
+          duration: getComputedStyle(node).animationDuration,
+          reduced: matchMedia("(prefers-reduced-motion: reduce)").matches,
+        })),
+      ).toEqual({ opacity: "1", duration: "1e-05s", reduced: true });
       expect(
         await page
           .locator(".chat-pane-cache__pane--visible")

--- a/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
@@ -25,7 +25,7 @@ suite.define(() => {
   it("switches immediately but shows a skeleton only for slow history", async () => {
     const context = await suite.newBrowserContext({
       ...createControlUiE2eContextOptions(),
-      reducedMotion: "reduce",
+      reducedMotion: "no-preference",
     });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -47,10 +47,24 @@ suite.define(() => {
       );
       await loader.waitFor({ state: "attached" });
       expect(await loader.evaluate((node) => getComputedStyle(node).visibility)).toBe("hidden");
+      const opacity = await loader.evaluate(async (node) => {
+        const animation = node.getAnimations()[0];
+        await animation.ready;
+        animation.pause();
+        return [499, 575, 650].map((time) => {
+          animation.currentTime = time;
+          return Number(getComputedStyle(node).opacity);
+        });
+      });
+      expect(opacity[0]).toBe(0);
+      expect(opacity[1]).toBeGreaterThan(0);
+      expect(opacity[1]).toBeLessThan(1);
+      expect(opacity[2]).toBe(1);
       await gateway.resolveDeferred("chat.startup");
       const previous = page.locator(".chat-thread").getByText("Previous conversation.");
       await previous.waitFor({ state: "visible" });
       expect(await loader.count()).toBe(0);
+      await page.emulateMedia({ reducedMotion: "reduce" });
       await gateway.deferNext("chat.startup");
       const [revealDelay] = await Promise.all([
         page.evaluate(
@@ -103,6 +117,7 @@ suite.define(() => {
       expect(revealDelay.delay).toBeGreaterThanOrEqual(480);
       expect(revealDelay.previousVisible).toBe(false);
       expect(revealDelay.delay).toBeLessThan(1_000);
+      expect(await loader.evaluate((node) => getComputedStyle(node).opacity)).toBe("1");
       expect(
         await page
           .locator(".chat-pane-cache__pane--visible")

--- a/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
@@ -49,7 +49,7 @@ suite.define(() => {
       const frames = await loader.evaluate(async (node) => {
         // Restart the CSS animation for clock samples even if CI reached this node after completion.
         node.style.animationName = "none";
-        getComputedStyle(node).animationName;
+        void getComputedStyle(node).animationName;
         node.style.animationName = "";
         const animation = node.getAnimations()[0];
         if (!animation) {

--- a/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
@@ -46,8 +46,7 @@ suite.define(() => {
         ".chat-pane-cache__pane--visible .chat-thread openclaw-panel-loading-skeleton",
       );
       await loader.waitFor({ state: "attached" });
-      expect(await loader.evaluate((node) => getComputedStyle(node).visibility)).toBe("hidden");
-      const opacity = await loader.evaluate(async (node) => {
+      const frames = await loader.evaluate(async (node) => {
         const animation = node.getAnimations()[0];
         if (!animation) {
           throw new Error("The loading skeleton has no reveal animation");
@@ -56,13 +55,14 @@ suite.define(() => {
         animation.pause();
         return [499, 575, 650].map((time) => {
           animation.currentTime = time;
-          return Number(getComputedStyle(node).opacity);
+          const style = getComputedStyle(node);
+          return { opacity: Number(style.opacity), visibility: style.visibility };
         });
       });
-      expect(opacity[0]).toBe(0);
-      expect(opacity[1]).toBeGreaterThan(0);
-      expect(opacity[1]).toBeLessThan(1);
-      expect(opacity[2]).toBe(1);
+      expect(frames[0]).toEqual({ opacity: 0, visibility: "hidden" });
+      expect(frames[1]?.opacity).toBeGreaterThan(0);
+      expect(frames[1]?.opacity).toBeLessThan(1);
+      expect(frames[2]).toEqual({ opacity: 1, visibility: "visible" });
       await gateway.resolveDeferred("chat.startup");
       const previous = page.locator(".chat-thread").getByText("Previous conversation.");
       await previous.waitFor({ state: "visible" });

--- a/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
@@ -47,6 +47,10 @@ suite.define(() => {
       );
       await loader.waitFor({ state: "attached" });
       const frames = await loader.evaluate(async (node) => {
+        // Restart the CSS animation for clock samples even if CI reached this node after completion.
+        node.style.animationName = "none";
+        getComputedStyle(node).animationName;
+        node.style.animationName = "";
         const animation = node.getAnimations()[0];
         if (!animation) {
           throw new Error("The loading skeleton has no reveal animation");

--- a/ui/src/styles/chat/message-layout.css
+++ b/ui/src/styles/chat/message-layout.css
@@ -245,15 +245,17 @@
 /* Keep the destination responsive without flashing a loader on fast history.
    Removing the skeleton when content arrives also cancels its pending reveal. */
 .chat-thread-inner > openclaw-panel-loading-skeleton {
-  animation: chat-skeleton-reveal 0s 500ms backwards;
+  animation: chat-skeleton-reveal 150ms ease-out 500ms backwards;
 }
 
 @keyframes chat-skeleton-reveal {
   from {
     visibility: hidden;
+    opacity: 0;
   }
   to {
     visibility: visible;
+    opacity: 1;
   }
 }
 

--- a/ui/src/styles/chat/message-layout.css
+++ b/ui/src/styles/chat/message-layout.css
@@ -242,6 +242,21 @@
   margin-top: 0 !important;
 }
 
+/* Keep the destination responsive without flashing a loader on fast history.
+   Removing the skeleton when content arrives also cancels its pending reveal. */
+.chat-thread-inner > openclaw-panel-loading-skeleton {
+  animation: chat-skeleton-reveal 0s 500ms backwards;
+}
+
+@keyframes chat-skeleton-reveal {
+  from {
+    visibility: hidden;
+  }
+  to {
+    visibility: visible;
+  }
+}
+
 .chat-thread-inner {
   /* Shared gutter plus the responsive side inset that used to be
      .chat-thread's horizontal padding (moved off the scroll container so


### PR DESCRIPTION
## What Problem This Solves

Avoids flashing a loading skeleton when conversation history loads quickly, and softens its appearance on slower loads.

## Why This Change Was Made

Switch to the destination immediately. Delay the existing skeleton by **500 ms**, then **fade it in over 150 ms**. If history arrives sooner, the skeleton disappears without flashing. Reduced-motion users keep the delay without a perceptible fade.

This replaces the earlier retained-conversation implementation. No retained old transcript, dimming, JavaScript timer, readiness API, or skeleton redesign. Main’s warm cache and loading/error behavior stay unchanged.

## User Impact

- Session selection and header update immediately.
- Fast loads show the conversation directly.
- Slow loads show the existing skeleton with a brief fade after 500 ms.
- Cached sessions still switch instantly.

## Evidence

**Two files; one added browser journey.** The former large transition patch is no longer part of this PR.

| Scope | Files | Added | Removed |
|---|---:|---:|---:|
| Production CSS | 1 | 17 | 0 |
| Browser test | 1 | 136 | 0 |
| Total | 2 | 153 | 0 |

Current fade recording, normal playback speed:

https://github.com/user-attachments/assets/03ae2c10-14b0-44e8-bb42-5594383f08ea

Matched main/PR comparison of the initial 500 ms delay (recorded before adding the fade; main left, PR right):

https://github.com/user-attachments/assets/033b828f-5c72-4499-aea3-869e92d2f8ff

- Fade regression failed before the CSS change; all six history journeys pass on the final revision.
- Existing browser journey checks hidden state before 500 ms, partial opacity during the fade, full opacity afterward, reduced-motion delay without fade, removal of old content, fast completion, and cached return.
- Independent focused review: no actionable findings, including the final test correction.
- Current head: `d6db656d0abdd7c95bcf2363ee2f9d831a255826`. [Fresh exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34313993360). Merge preparation exposed and repaired a wall-clock race in the test. The test now samples visibility and opacity on the existing CSS animation clock; production CSS is unchanged. Six history and eleven current-main catalog browser journeys pass locally. Type-aware lint passes after making the computed-style flush explicit.
- Independent source/cascade review found no actionable issues; that reviewer did not independently rerun browser tests. No new merge-readiness review is claimed by this status update.
- No live Gateway changes or deployment.

Worked on by:
- @jesse-merhi

## Merge authorization

Jesse explicitly waived fresh code-review on 2026-09-09 and authorized merging. His +1 reaction is present. Fresh exact-head CI passed; the prior focused independent review reported no actionable findings. The native merge artifacts record the waiver rather than claiming a fresh native/cold review.

ClawSweeper’s remaining note was inability to access the recording, not a code finding. The implementation coordinator inspected the capture, and the merge coordinator re-inspected the extracted fade frames: destination header/composer remain present while the initially blank transcript gains the skeleton. Timing and reduced-motion are covered by the browser test. Maintainer authorization above accepts this evidence; no new feature or test changes are required.

