### PR TITLE
fix(test): print failure trailer for string process.exitCode

### DIFF
--- a/scripts/lib/failed-trailer.mts
+++ b/scripts/lib/failed-trailer.mts
@@ -1,11 +1,27 @@
 // Keeps wrapper failures visible even when preceding diagnostics are truncated.
+function resolveFailedExitCode(
+  exitCode: number | string | null | undefined,
+): number | undefined {
+  if (typeof exitCode === "number" && Number.isFinite(exitCode) && exitCode !== 0) {
+    return exitCode;
+  }
+  if (typeof exitCode === "string" && exitCode.trim() !== "") {
+    const parsed = Number(exitCode);
+    if (Number.isFinite(parsed) && parsed !== 0) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
 export function writeFailedTrailer(
   tool: string,
   exitCode: number | string | null | undefined,
   log: (value: unknown) => void = console.error,
 ): void {
-  if (typeof exitCode === "number" && exitCode !== 0) {
-    log(`[${tool}] FAILED (exit ${exitCode})`);
+  const resolved = resolveFailedExitCode(exitCode);
+  if (resolved !== undefined) {
+    log(`[${tool}] FAILED (exit ${resolved})`);
   }
 }
 

--- a/test/scripts/failed-trailer.test.ts
+++ b/test/scripts/failed-trailer.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { runWithFailedTrailer, writeFailedTrailer } from "../../scripts/lib/failed-trailer.mts";
+
+describe("writeFailedTrailer", () => {
+  it("prints a trailer for numeric nonzero exit codes", () => {
+    const lines: unknown[] = [];
+    writeFailedTrailer("test", 1, (line) => lines.push(line));
+    expect(lines).toEqual(["[test] FAILED (exit 1)"]);
+  });
+
+  it("prints a trailer for string nonzero exit codes", () => {
+    const lines: unknown[] = [];
+    writeFailedTrailer("vitest", "1", (line) => lines.push(line));
+    expect(lines).toEqual(["[vitest] FAILED (exit 1)"]);
+  });
+
+  it("skips trailers for zero and unset codes", () => {
+    const lines: unknown[] = [];
+    writeFailedTrailer("test", 0, (line) => lines.push(line));
+    writeFailedTrailer("test", "0", (line) => lines.push(line));
+    writeFailedTrailer("test", undefined, (line) => lines.push(line));
+    expect(lines).toEqual([]);
+  });
+});
+
+describe("runWithFailedTrailer", () => {
+  it("reports a string process.exitCode set by the inner run", async () => {
+    const prior = process.exitCode;
+    const lines: unknown[] = [];
+    try {
+      process.exitCode = "2";
+      await runWithFailedTrailer("lint", () => {}, (line) => lines.push(line));
+      expect(lines).toEqual(["[lint] FAILED (exit 2)"]);
+    } finally {
+      process.exitCode = prior;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
`writeFailedTrailer` ignored string `process.exitCode` values Node allows, so some failing wrappers skipped the final `[tool] FAILED` line.

## Test plan
- `node scripts/run-vitest.mjs test/scripts/failed-trailer.test.ts`