### PR TITLE
fix(release): restore evidence reuse and reconcile advisory ranges

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -584,6 +584,7 @@ jobs:
             scripts/lib/managed-child-process.mts
             scripts/lib/windows-taskkill.mjs
             scripts/lib/release-version.mjs
+            .github/actions/setup-pnpm-store-cache/ensure-node.sh
           sparse-checkout-cone-mode: false
           fetch-depth: 1
           persist-credentials: false
@@ -601,6 +602,14 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
           submodules: false
+
+      - name: Setup Node.js
+        env:
+          REQUESTED_NODE_VERSION: "24.x"
+        run: |
+          set -euo pipefail
+          source workflow/.github/actions/setup-pnpm-store-cache/ensure-node.sh
+          openclaw_ensure_node "$REQUESTED_NODE_VERSION"
 
       - name: Find reusable validation evidence
         id: find

--- a/scripts/dependency-vulnerability-gate.mts
+++ b/scripts/dependency-vulnerability-gate.mts
@@ -392,6 +392,7 @@ export function renderDependencyVulnerabilityGateMarkdownReport(
     `- Package versions mapped to upstream repositories: ${report.coverage.upstream.mappedPackageVersions}/${report.coverage.upstream.packageVersions}`,
     `- Repositories fully read: ${report.coverage.upstream.checkedRepositories}/${report.coverage.upstream.repositories}`,
     `- Coverage issues: ${report.coverage.upstream.issues.length}`,
+    `- GitHub-reviewed range reconciliations: ${report.coverage.upstream.reconciliations.length} (raw ranges retained in JSON coverage evidence)`,
     "",
     "An empty source response is not comprehensive vulnerability clearance. Unsupported or incomplete upstream checks are not evidence that a package is unaffected.",
     "",

--- a/scripts/lib/upstream-repository-advisories.mts
+++ b/scripts/lib/upstream-repository-advisories.mts
@@ -33,6 +33,13 @@ type CoverageReason =
 type CoverageIssue = { subject: string; reason: CoverageReason };
 type PackageVersions = Record<string, string[]>;
 type RepositoryPackages = Map<string, Set<string>>;
+type AdvisoryReconciliation = {
+  id: string;
+  packageName: string;
+  repositoryRange: string;
+  reviewedRanges: string[];
+  matchedVersions: string[];
+};
 type JsonResponse = { data: unknown; link: string | null };
 
 export type PublishedRepositoryAdvisory = {
@@ -212,6 +219,39 @@ function collectRepositoryMatches(
       });
     }
   }
+}
+
+function reviewedPackageRanges(data: unknown, advisory: PublishedRepositoryAdvisory) {
+  if (
+    !isRecord(data) ||
+    data.ghsa_id !== advisory.id ||
+    data.withdrawn_at !== null ||
+    typeof data.published_at !== "string" ||
+    !Number.isFinite(Date.parse(data.published_at)) ||
+    typeof data.github_reviewed_at !== "string" ||
+    !Number.isFinite(Date.parse(data.github_reviewed_at)) ||
+    !Array.isArray(data.vulnerabilities)
+  ) {
+    return null;
+  }
+  const ranges: semver.Comparator[][] = [];
+  for (const vulnerability of data.vulnerabilities) {
+    if (!isRecord(vulnerability) || !isRecord(vulnerability.package)) {
+      return null;
+    }
+    if (
+      vulnerability.package.ecosystem !== "npm" ||
+      vulnerability.package.name !== advisory.packageName
+    ) {
+      continue;
+    }
+    const range = githubRange(vulnerability.vulnerable_version_range);
+    if (!range) {
+      return null;
+    }
+    ranges.push(range);
+  }
+  return ranges.length > 0 ? ranges : null;
 }
 
 export async function fetchPublishedRepositoryAdvisories({
@@ -414,13 +454,52 @@ export async function fetchPublishedRepositoryAdvisories({
       }),
   });
 
+  const reconciliations: AdvisoryReconciliation[] = [];
+  const reconciled = await runTasksWithConcurrency({
+    limit: CONCURRENCY,
+    throwOnError: true,
+    tasks: advisories.map((advisory) => async () => {
+      // Repository ranges can remain stale after GitHub reviews the same GHSA.
+      // Only exact reviewed package ranges may replace them; missing proof retains the blocker.
+      const response = await request(`${GITHUB_API}/advisories/${advisory.id}`, "github");
+      const ranges = response.ok ? reviewedPackageRanges(response.value.data, advisory) : null;
+      if (!ranges) {
+        issues.push({
+          subject: `${advisory.packageName}#${advisory.id}`,
+          reason: response.ok ? "invalid-advisory" : response.error,
+        });
+        return advisory;
+      }
+      const reviewedRanges = ranges.map((range) => range.map((bound) => bound.value).join(" "));
+      const matchedVersions = [...new Set(payload[advisory.packageName] ?? [])]
+        .filter((version) => ranges.some((range) => range.every((bound) => bound.test(version))))
+        .toSorted();
+      reconciliations.push({
+        id: advisory.id,
+        packageName: advisory.packageName,
+        repositoryRange: advisory.vulnerable_versions,
+        reviewedRanges,
+        matchedVersions,
+      });
+      return matchedVersions.length > 0
+        ? { ...advisory, vulnerable_versions: reviewedRanges.join(" || "), matchedVersions }
+        : null;
+    }),
+  });
+
   return {
-    advisories: advisories.toSorted(
-      (left, right) =>
-        left.packageName.localeCompare(right.packageName) || left.id.localeCompare(right.id),
-    ),
+    advisories: reconciled.results
+      .filter((entry): entry is PublishedRepositoryAdvisory => entry !== null)
+      .toSorted(
+        (left, right) =>
+          left.packageName.localeCompare(right.packageName) || left.id.localeCompare(right.id),
+      ),
     coverage: {
       source: "github-public-repository-advisories" as const,
+      reconciliations: reconciliations.toSorted(
+        (left, right) =>
+          left.packageName.localeCompare(right.packageName) || left.id.localeCompare(right.id),
+      ),
       status: issues.length === 0 ? ("checked" as const) : ("partial" as const),
       packageVersions: entries.length,
       mappedPackageVersions,

--- a/test/scripts/full-release-validation-continuation-workflow.test.ts
+++ b/test/scripts/full-release-validation-continuation-workflow.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 
@@ -71,6 +71,26 @@ describe("full release metadata checkouts", () => {
         ]),
       ).toBe("");
       if (job === "evidence_reuse") {
+        const setup = step(job, "Setup Node.js");
+        const steps = workflow.jobs[job]!.steps;
+        expect(steps.indexOf(setup)).toBeLessThan(
+          steps.indexOf(step(job, "Find reusable validation evidence")),
+        );
+        expect(setup.env).toMatchObject({ REQUESTED_NODE_VERSION: "24.x" });
+        execFileSync("bash", ["-c", String(setup.run)], {
+          cwd: root,
+          encoding: "utf8",
+          timeout: 10_000,
+          env: {
+            ...process.env,
+            ...(setup.env as Record<string, string>),
+            // Keep this sparse-file proof offline on every supported test runtime.
+            REQUESTED_NODE_VERSION: process.versions.node,
+            PATH: `${dirname(process.execPath)}${delimiter}${process.env.PATH ?? ""}`,
+            NODE_OPTIONS: "",
+            GITHUB_PATH: join(root, "github-path"),
+          },
+        });
         expect(
           runNode(
             [join(root, "workflow/scripts/release-preflight.mjs"), "--macos-versions-only"],

--- a/test/scripts/upstream-repository-advisories.test.ts
+++ b/test/scripts/upstream-repository-advisories.test.ts
@@ -14,8 +14,10 @@ function vulnerability(range: unknown, name: unknown = "fixture", ecosystem = "n
   return { package: { ecosystem, name }, vulnerable_version_range: range };
 }
 
+const publishedRows = new Map<string, Record<string, unknown>>();
+
 function advisory(range: unknown = "< 2.0.0", fields: Record<string, unknown> = {}) {
-  return {
+  const row = {
     ghsa_id: ADVISORY_ID,
     state: "published",
     withdrawn_at: null,
@@ -24,6 +26,8 @@ function advisory(range: unknown = "< 2.0.0", fields: Record<string, unknown> = 
     vulnerabilities: [vulnerability(range)],
     ...fields,
   };
+  if (!publishedRows.has(row.ghsa_id)) publishedRows.set(row.ghsa_id, row);
+  return row;
 }
 
 function manifest(url: URL, repository: unknown = `git+https://github.com/${REPOSITORY}.git`) {
@@ -36,6 +40,7 @@ function createSourceFetch(
     manifest?: Handler;
     repository?: Handler;
     page?: Handler;
+    reviewed?: Handler;
   } = {},
 ) {
   const calls: Array<{ url: URL; init: RequestInit | undefined }> = [];
@@ -47,6 +52,16 @@ function createSourceFetch(
     }
     if (url.origin !== "https://api.github.com") {
       throw new Error(`Unexpected request origin: ${url.origin}`);
+    }
+    if (url.pathname.startsWith("/advisories/")) {
+      if (handlers.reviewed) return handlers.reviewed(url, init);
+      const row = publishedRows.get(url.pathname.split("/").at(-1) ?? "");
+      return Response.json({
+        ...row,
+        published_at: "2026-08-01T00:00:00Z",
+        github_reviewed_at: "2026-08-02T00:00:00Z",
+        withdrawn_at: null,
+      });
     }
     if (url.pathname.endsWith("/security-advisories")) {
       return handlers.page ? handlers.page(url, init) : Response.json([]);
@@ -63,6 +78,7 @@ function scan(fetchImpl: typeof fetch, payload: Record<string, string[]> = { fix
 }
 
 beforeEach(() => {
+  publishedRows.clear();
   vi.stubEnv("GH_TOKEN", undefined);
 });
 
@@ -99,6 +115,8 @@ describe("published upstream repository advisories", () => {
       "/fixture/1.0.0",
       "/repos/fixture/packages",
       "/repos/fixture/packages/security-advisories",
+      `/advisories/${ADVISORY_ID}`,
+      `/advisories/${ADVISORY_ID}`,
     ]);
     expect(report.advisories).toMatchObject([
       { packageName: "@scope/leaf", matchedVersions: ["1.2.3"] },
@@ -112,6 +130,112 @@ describe("published upstream repository advisories", () => {
       checkedRepositories: 1,
       issues: [],
     });
+  });
+
+  it.each([
+    {
+      name: "fast-xml-builder",
+      id: "GHSA-45c6-75p6-83cc",
+      raw: "> 1.1.5",
+      reviewed: "= 1.1.5",
+      version: "1.3.1",
+    },
+    {
+      name: "fast-xml-parser",
+      id: "GHSA-8r6m-32jq-jx6q",
+      raw: ">= 5.9.3",
+      reviewed: ">= 5.9.3, < 5.10.1",
+      version: "5.11.0",
+    },
+    {
+      name: "hono",
+      id: "GHSA-m732-5p4w-x69g",
+      raw: "> 1.1.0",
+      reviewed: ">= 1.1.0, < 4.10.2",
+      version: "4.13.3",
+    },
+    {
+      name: "hono",
+      id: "GHSA-xh87-mx6m-69f3",
+      raw: ">= 4.12.0",
+      reviewed: ">= 4.12.0, < 4.12.2",
+      version: "4.13.3",
+    },
+  ])(
+    "reconciles the published $id range without losing raw evidence",
+    async ({ name, id, raw, reviewed, version }) => {
+      const source = createSourceFetch({
+        page: () =>
+          Response.json([
+            advisory(raw, { ghsa_id: id, vulnerabilities: [vulnerability(raw, name)] }),
+          ]),
+        reviewed: () =>
+          Response.json({
+            ghsa_id: id,
+            published_at: "2026-08-01T00:00:00Z",
+            github_reviewed_at: "2026-08-02T00:00:00Z",
+            withdrawn_at: null,
+            vulnerabilities: [vulnerability(reviewed, name)],
+          }),
+      });
+      const report = await scan(source.fetchImpl, { [name]: [version] });
+      expect(report.advisories).toEqual([]);
+      expect(report.coverage).toMatchObject({
+        status: "checked",
+        reconciliations: [
+          {
+            id,
+            packageName: name,
+            repositoryRange: raw.replaceAll(" ", ""),
+            reviewedRanges: [
+              reviewed
+                .replaceAll(", ", " ")
+                .replace(/([<>=]) /g, "$1")
+                .replace(/^=/, ""),
+            ],
+            matchedVersions: [],
+          },
+        ],
+      });
+    },
+  );
+
+  it.each([
+    { name: "unavailable", response: null },
+    { name: "wrong identity", response: { ghsa_id: "GHSA-5555-6666-7777" } },
+    { name: "unreviewed", response: { github_reviewed_at: null } },
+    { name: "unpublished", response: { published_at: null } },
+    { name: "withdrawn", response: { withdrawn_at: "2026-08-03T00:00:00Z" } },
+    { name: "wrong package", response: { vulnerabilities: [vulnerability("< 1.0.0", "another")] } },
+    {
+      name: "wrong ecosystem",
+      response: { vulnerabilities: [vulnerability("< 1.0.0", "fixture", "pip")] },
+    },
+    {
+      name: "malformed sibling",
+      response: { vulnerabilities: [vulnerability("< 1.0.0"), vulnerability("unknown")] },
+    },
+  ])("retains the raw blocker when reviewed evidence is $name", async ({ response }) => {
+    const source = createSourceFetch({
+      page: () => Response.json([advisory()]),
+      reviewed: () =>
+        response === null
+          ? new Response(null, { status: 503 })
+          : Response.json({
+              ghsa_id: ADVISORY_ID,
+              published_at: "2026-08-01T00:00:00Z",
+              github_reviewed_at: "2026-08-02T00:00:00Z",
+              withdrawn_at: null,
+              vulnerabilities: [vulnerability("< 1.0.0")],
+              ...response,
+            }),
+    });
+    const report = await scan(source.fetchImpl);
+    expect(report.advisories).toMatchObject([{ id: ADVISORY_ID, matchedVersions: ["1.0.0"] }]);
+    expect(report.coverage.status).toBe("partial");
+    expect(report.coverage.issues).toContainEqual(
+      expect.objectContaining({ subject: `fixture#${ADVISORY_ID}` }),
+    );
   });
 
   it("sends the token only to fixed GitHub requests and refuses redirects on every request", async () => {
@@ -346,7 +470,9 @@ describe("published upstream repository advisories", () => {
     expect(report.advisories).toMatchObject([{ id: ADVISORY_ID, matchedVersions: ["1.0.0"] }]);
     expect(report.coverage).toMatchObject({
       status: "partial",
-      issues: [{ subject: `fixture#${ADVISORY_ID}`, reason: "invalid-range" }],
+      issues: expect.arrayContaining([
+        { subject: `fixture#${ADVISORY_ID}`, reason: "invalid-range" },
+      ]),
     });
   });
 
@@ -509,15 +635,10 @@ describe("published upstream repository advisories", () => {
       expect(requestedTimeouts.at(-1)).toBe(deadline === "run" ? 5 : 15_000);
       expect(cancel).toHaveBeenCalledTimes(deadline === "run" ? 1 : 0);
       expect(report.advisories).toHaveLength(1);
-      expect(report.coverage).toMatchObject({
-        status: "partial",
-        checkedRepositories: 0,
-        issues: [
-          {
-            subject: REPOSITORY,
-            reason: deadline === "run" ? "budget-exhausted" : "request-failed",
-          },
-        ],
+      expect(report.coverage).toMatchObject({ status: "partial", checkedRepositories: 0 });
+      expect(report.coverage.issues).toContainEqual({
+        subject: REPOSITORY,
+        reason: deadline === "run" ? "budget-exhausted" : "request-failed",
       });
     },
   );


### PR DESCRIPTION
## What Problem This Solves

Resolves two release-validation failures: the sparse evidence-reuse job inherited Node 20 on Blacksmith and unnecessarily launched full validation after failing to load its metadata probe; the dependency scanner treated stale upstream repository advisory ranges as current even when GitHub's reviewed record for the same advisory and package contained corrected ranges.

## Why This Change Was Made

Provision Node 24 through the existing lightweight bootstrap before evidence discovery. Reconcile repository matches only against a published, nonwithdrawn, GitHub-reviewed record with the exact GHSA and npm package identity. Missing or invalid reviewed evidence retains the raw blocker. Reports retain the original ranges and disclose each reconciliation; severity policy, dependency versions, and validation requirements are unchanged.

## User Impact

Maintainers can reuse valid release evidence and distinguish corrected advisory metadata from affected dependency versions. This change does not alter Gateway behavior or exempt vulnerabilities.

## Evidence

- 145 focused tests pass across sparse workflow execution, runtime bootstrap, release preflight, upstream advisories, and dependency gate policy. The runtime regression fails before the fix.
- Node 20 import failure reproduced in [Full Release Validation](https://github.com/openclaw/openclaw/actions/runs/33472165135/job/99744011328).
- Corrected ranges verified against GitHub-reviewed records: [fast-xml-builder](https://github.com/advisories/GHSA-45c6-75p6-83cc), [fast-xml-parser](https://github.com/advisories/GHSA-8r6m-32jq-jx6q), [Hono JWT](https://github.com/advisories/GHSA-m732-5p4w-x69g), and [Hono ALB](https://github.com/advisories/GHSA-xh87-mx6m-69f3). Exact installed package source independently retains their upstream fixes.
- Independent P0–P2 reviews passed for both repairs and the combined diff. A live scanner replay clears all four stale HIGH matches, retains vulnerable Sharp/js-yaml versions, excludes patched versions, and retains raw findings for five unavailable reviewed records. Hosted CI is required before landing.

Tooling delta: +93/-4 lines; tests: +153/-12. The added scanner code enforces matching reviewed provenance and preserves raw evidence without advisory-specific exceptions.
