### PR TITLE
fix(ui): align Workshop content width

### DIFF
--- a/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
+++ b/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
@@ -75,6 +75,8 @@ const methodResponses = {
 };
 
 type HubGeometry = {
+  contentLeft: number;
+  contentWidth: number;
   height: number;
   left: number;
   title: string;
@@ -104,7 +106,18 @@ async function hubGeometry(page: Page): Promise<HubGeometry> {
   return tabs.evaluate((element) => {
     const rect = element.getBoundingClientRect();
     const title = document.querySelector<HTMLElement>(".content-header .page-title");
+    const workshop = document.querySelector<HTMLElement>(".content--skill-workshop");
+    const contentColumn =
+      workshop && workshop.getClientRects().length > 0
+        ? workshop
+        : document.querySelector<HTMLElement>(".settings-page--wide");
+    if (!contentColumn) {
+      throw new Error("Plugins hub content column did not render");
+    }
+    const contentRect = contentColumn.getBoundingClientRect();
     return {
+      contentLeft: contentRect.left,
+      contentWidth: contentRect.width,
       height: rect.height,
       left: rect.left,
       title: title?.textContent?.trim() ?? "",
@@ -122,6 +135,8 @@ function expectStableGeometry(actual: HubGeometry, expected: HubGeometry) {
   expect(Math.abs(actual.top - expected.top)).toBeLessThanOrEqual(1);
   expect(Math.abs(actual.width - expected.width)).toBeLessThanOrEqual(1);
   expect(Math.abs(actual.height - expected.height)).toBeLessThanOrEqual(1);
+  expect(Math.abs(actual.contentLeft - expected.contentLeft)).toBeLessThanOrEqual(1);
+  expect(Math.abs(actual.contentWidth - expected.contentWidth)).toBeLessThanOrEqual(1);
 }
 
 async function skillsToolbarGeometry(page: Page): Promise<ControlGeometry[]> {
@@ -193,7 +208,9 @@ async function selectHubTab(
 
 suite.define(() => {
   it.each([
-    { label: "desktop", viewport: { height: 960, width: 1440 } },
+    { label: "desktop", viewport: { height: 1053, width: 2048 } },
+    { label: "laptop", viewport: { height: 768, width: 1366 } },
+    { label: "tablet", viewport: { height: 1024, width: 768 } },
     { label: "narrow", viewport: { height: 852, width: 393 } },
   ])(
     "keeps the hub shell fixed through every $label tab transition",
@@ -275,6 +292,7 @@ suite.define(() => {
           pathname: "/skills/workshop",
           routeId: "skill-workshop",
         });
+        await captureScreenshot(page, `${label}-04-workshop-today.png`);
         expectStableGeometry(await hubGeometry(page), installed);
         const workshopShellBottom = await page
           .locator(".plugins-hub-header")
@@ -283,7 +301,6 @@ suite.define(() => {
           .locator(".sw-header-controls")
           .evaluate((element) => element.getBoundingClientRect().top);
         expect(workshopControlsTop).toBeGreaterThanOrEqual(workshopShellBottom);
-        await captureScreenshot(page, `${label}-04-workshop-today.png`);
 
         await page.locator("#skill-workshop-mode-tab-board").click();
         await expect

--- a/ui/src/styles/skill-workshop.css
+++ b/ui/src/styles/skill-workshop.css
@@ -16,7 +16,10 @@
   flex-direction: column;
   flex: 1 1 auto;
   box-sizing: border-box;
+  width: 100%;
+  max-width: 1120px;
   height: 100%;
+  margin-inline: auto;
   min-height: 0;
   overflow: hidden;
   padding-bottom: 16px;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the Workshop tab in the Plugins hub would see its content stretch beyond the shared content width used by Installed, Discover, and Skills on wide screens.

## Why This Change Was Made

The Workshop content root now uses the same centered 1120px maximum width as the other Plugins hub tabs. Existing navigation coverage now asserts the visible content column remains aligned through every tab transition at desktop, laptop, tablet, and narrow mobile sizes.

## User Impact

Workshop now aligns with the Plugins header, tab bar, and sibling tab content instead of spanning the full viewport. Responsive behavior remains unchanged below the shared maximum width.

## Evidence

- Before/after Chromium screenshots:

  **Before — Workshop stretches beyond the Plugins hub content column**

  ![Before: Workshop content spans the wide viewport](https://files.catbox.moe/9jxo0u.png)

  **After — Workshop uses the same centered content width as the other tabs**

  ![After: Workshop content aligns with the Plugins hub content column](https://files.catbox.moe/6o8qig.png)
- Regression proof before the CSS fix: `plugins-hub-navigation.e2e.test.ts` failed on desktop with a 315px content-column offset.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/plugins-hub-navigation.e2e.test.ts` — 4/4 viewport cases pass.
- `node scripts/check-changed.mjs -- ui/src/styles/skill-workshop.css ui/src/e2e/plugins-hub-navigation.e2e.test.ts` — passes.
- `pnpm ui:build` — passes.
- `autoreview --mode uncommitted` — no actionable findings.

Release note: Fixed Workshop content alignment in the Plugins hub on wide screens.
