### PR TITLE
fix(plugins): preserve plugin load errors across retries

### DIFF
--- a/src/plugins/native-module-require.test.ts
+++ b/src/plugins/native-module-require.test.ts
@@ -47,7 +47,8 @@ describe("tryNativeRequireJavaScriptModule", () => {
   });
 
   it("declines an in-flight ESM require race for source-transform fallback", () => {
-    const modulePath = "/plugins/discord/dist/index.js";
+    const modulePath = path.join(tempDirs.make("openclaw-native-require-"), "plugin.cjs");
+    fs.writeFileSync(modulePath, "module.exports = {};\n", "utf8");
     const error = Object.assign(new Error("ESM is still loading"), {
       code: "ERR_REQUIRE_ESM_RACE_CONDITION",
     });
@@ -245,6 +246,89 @@ console.log("native path + file URL load/cache reload; missing target/dependency
     expect(result.stdout.trim()).toBe(
       "native path + file URL load/cache reload; missing target/dependency controls passed",
     );
+  });
+
+  it("retains terminal ESM failures across eviction and alias changes until a new path loads", async () => {
+    const dir = tempDirs.make("openclaw-native-failed-generation-");
+    const ownerPath = path.join(dir, "native-require.mjs");
+    await build({
+      entryPoints: [path.resolve("src/plugins/native-module-require.ts")],
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      outfile: ownerPath,
+      logLevel: "silent",
+    });
+    const probePath = path.join(dir, "probe.mjs");
+    fs.writeFileSync(
+      probePath,
+      `import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { clearPluginModuleRequireCache as clear, tryNativeRequireJavaScriptModule as load } from ${JSON.stringify(pathToFileURL(ownerPath).href)};
+const dir = ${JSON.stringify(dir)};
+const brokenPath = path.join(dir, "broken.mjs");
+const missingApi = path.join(dir, "missing-api.mjs");
+const currentApi = path.join(dir, "current-api.mjs");
+fs.writeFileSync(missingApi, "export const existing = 1;\\n");
+fs.writeFileSync(currentApi, "export const required = 2;\\n");
+const pluginSource = 'import { required } from "fixture-api"; export const value = required;\\n';
+fs.writeFileSync(brokenPath, pluginSource);
+const aliasDir = path.join(dir, "alias");
+fs.symlinkSync(dir, aliasDir, process.platform === "win32" ? "junction" : "dir");
+const options = { allowWindows: true, aliasMap: { "fixture-api": missingApi } };
+let initial;
+assert.throws(() => load(brokenPath, options), error => {
+  initial = error;
+  return error instanceof SyntaxError;
+});
+for (const target of [brokenPath, pathToFileURL(brokenPath).href, "./broken.mjs", path.join(aliasDir, "broken.mjs")]) {
+  clear(brokenPath, { dependencyRoot: dir });
+  assert.throws(() => load(target, {
+    ...options,
+    aliasMap: { "fixture-api": currentApi },
+    fallbackOnNativeError: true,
+  }), error => error === initial);
+}
+const newPath = path.join(dir, "new-generation.mjs");
+fs.writeFileSync(newPath, pluginSource);
+const repaired = load(newPath, { ...options, aliasMap: { "fixture-api": currentApi } });
+assert.equal(repaired.ok, true);
+assert.equal(repaired.moduleExport.value, 2);
+const retryPath = path.join(dir, "retry.cjs");
+fs.writeFileSync(retryPath, 'if (!globalThis.__pluginDependencyReady) throw new Error("dependency not ready"); module.exports = { ready: true };\\n');
+assert.throws(() => load(retryPath, { allowWindows: true }), /dependency not ready/);
+globalThis.__pluginDependencyReady = true;
+const retried = load(path.join(aliasDir, "retry.cjs"), { allowWindows: true });
+assert.equal(retried.ok, true);
+assert.equal(retried.moduleExport.ready, true);
+delete globalThis.__pluginDependencyReady;
+clear(retryPath);
+fs.writeFileSync(retryPath, 'throw Object.assign(new Error("fresh race"), { code: "ERR_REQUIRE_ESM_RACE_CONDITION" });\\n');
+assert.deepEqual(load(retryPath, { allowWindows: true }), { ok: false });
+const aliasRequest = path.join(dir, "alias-request.cjs");
+const aliasFirst = path.join(dir, "alias-first.cjs");
+const aliasSecond = path.join(dir, "alias-second.cjs");
+fs.writeFileSync(aliasFirst, 'module.exports = "first";\\n');
+fs.writeFileSync(aliasSecond, 'module.exports = "second";\\n');
+assert.deepEqual(load(aliasRequest, {
+  allowWindows: true,
+  aliasMap: { [aliasRequest]: aliasFirst, [aliasFirst]: aliasSecond },
+}), { ok: true, moduleExport: "first" });
+console.log("terminal error retained; new generation recovered");
+`,
+    );
+    // tsx changes named-import linking, so this contract needs an unhooked Node process.
+    const result = spawnSync(process.execPath, [probePath], {
+      cwd: process.cwd(),
+      env: { ...process.env, NODE_OPTIONS: "" },
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout.trim()).toBe("terminal error retained; new generation recovered");
   });
 
   it("clears local dependencies loaded by a native JavaScript module", () => {

--- a/src/plugins/native-module-require.ts
+++ b/src/plugins/native-module-require.ts
@@ -6,6 +6,9 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { isPathInside } from "../infra/path-guards.js";
 
 const nodeRequire = createRequire(import.meta.url);
+// Failed ESM jobs survive require-cache eviction. Preserve an observed terminal error
+// if a retry hits that job, rather than transforming its rejected graph through Jiti.
+const nativeModuleLoadFailures = new Map<string, unknown>();
 type ResolveFilename = (
   request: string,
   parent: NodeJS.Module | undefined,
@@ -75,11 +78,27 @@ export function tryNativeRequireJavaScriptModule(
   if (!isJavaScriptModulePath(modulePath)) {
     return { ok: false };
   }
+  let resolvedPath = modulePath;
   try {
-    return { ok: true, moduleExport: requireWithOptionalAliases(modulePath, options.aliasMap) };
+    const moduleExport = withNativeRequireAliases(options.aliasMap, () => {
+      // A process-wide require retains evicted graphs through its parent's children.
+      // Keep that parent scoped to this load so retired graphs can be collected.
+      const require = createRequire(import.meta.url);
+      resolvedPath = require.resolve(modulePath);
+      // Requiring the resolved target could apply a second alias to the same request.
+      return require(modulePath);
+    });
+    nativeModuleLoadFailures.delete(resolvedPath);
+    return { ok: true, moduleExport };
   } catch (error) {
     const code =
       error && typeof error === "object" ? (error as { code?: unknown }).code : undefined;
+    if (
+      nativeModuleLoadFailures.has(resolvedPath) &&
+      (code === "ERR_REQUIRE_ESM_RACE_CONDITION" || code === "ERR_INTERNAL_ASSERTION")
+    ) {
+      throw nativeModuleLoadFailures.get(resolvedPath);
+    }
     if (
       isSourceTransformFallbackError(error, modulePath) ||
       options.fallbackOnNativeError ||
@@ -88,6 +107,7 @@ export function tryNativeRequireJavaScriptModule(
     ) {
       return { ok: false };
     }
+    nativeModuleLoadFailures.set(resolvedPath, error);
     throw error;
   }
 }
@@ -144,15 +164,6 @@ function clearRequireCacheSubtree(
     }
   }
   delete nodeRequire.cache[resolvedPath];
-}
-
-function requireWithOptionalAliases(
-  modulePath: string,
-  aliasMap: Record<string, string> | ((specifier: string) => string | undefined) | undefined,
-): unknown {
-  // A process-wide require retains evicted modules through its synthetic parent's children.
-  // Keep that parent scoped to this load so retired graphs can be collected.
-  return withNativeRequireAliases(aliasMap, () => createRequire(import.meta.url)(modulePath));
 }
 
 /** Runs a native require block with temporary CJS/ESM alias hooks and restores both afterward. */


### PR DESCRIPTION
Related: #133828, #133984.

## What Problem This Solves

Fixes an issue where operators retrying failed plugin inspection or activation could lose the original missing-export diagnostic or see an invalid plugin accepted as loaded. The failure can recur after disposing a plugin cache, making the result depend on earlier load attempts in the same process.

## Why This Change Was Made

Node retains a failed ESM job: a later require reports `ERR_INTERNAL_ASSERTION` on Node 22.23.2 or `ERR_REQUIRE_ESM_RACE_CONDITION` on Node 24.20.0. OpenClaw treats the latter as a source-transform fallback, allowing Jiti to return a plugin whose missing imported binding is undefined.

Preserve the observed terminal failure at the native require owner when a retry encounters that cached job. Native retries remain authoritative, and success clears the remembered error, so transient CommonJS failures recover. Resolve the native target inside the existing alias scope while requiring the original request, preserving alias semantics. The single-use require wrapper is absorbed into that owner. Node's ESM job outlives OpenClaw's generation cache, so failure ownership must survive that cache's disposal.

Production delta: **+21/-10 (net +11)**. Test delta: **+85/-1 (net +84)**. The added state records Node-owned failure provenance; the redundant wrapper is removed. No config/default, migration, store, dependency, or SDK surface changes.

## User Impact

Plugin retries retain the useful original error and cannot silently accept the rejected module graph through fallback. A compatible plugin at a new generation path still loads. The original missing-export failure requires a compatible package; the retired SDK export is not restored.

## Evidence

- The new regression fails against the pre-fix owner at the second load: the expected terminal exception is missing.
- The focused native owner, plugin module-cache, WhatsApp runtime-boundary, and SDK entry-contract suites pass: **56 tests in four files**. After correcting the existing first-time race fixture to use a real native path, the final owner-file rerun passes **15/15**.
- Plain Node **22.23.2** and **24.20.0** probes preserve the original SyntaxError through a repeated load and a new PluginCache/alias variant after eviction, with **zero Jiti fallbacks**. A repaired plugin at a new generation path loads natively. Sibling controls cover relative paths, file URLs, symlinks, chained aliases, transient CommonJS recovery, and the original first-time race fallback.
- A combined integration build using `node --import tsx scripts/build-all.mts full` passed in **502.3 seconds**, including all 50 native control-plane modules, SDK declarations/export guard, and UI. Its native loader source is byte-identical to this change. The isolated tests and Node probes above validate this patch separately from the other changes included in that integration build.
- The actual two-file `check:changed` run passed formatting, core and core-test typechecks, preceding ratchets/ownership/dependency guards, and the script/production unused-export scans (zero entries). **The local gate is incomplete:** the full-tree Knip scan hit its unchanged 600-second timeout. No limit was increased or check skipped; downstream gate steps were not reached. Hosted checks on the PR's exact commit must pass before landing.

### Real package recovery check

An isolated profile installed the published `@openclaw/discord@2026.6.6` package against the current built host and reproduced the missing `privateFileStore` export with runtime status `error`. Standalone Doctor removed that unretained managed npm package because it shadowed the source build's bundled Discord. `update repair --yes --json --accept-capabilities` then completed with `status: ok` and `restart: false`; final runtime inspection loaded bundled Discord 2026.8.1 with no diagnostics.

This verifies unretained-shadow cleanup and convergence in the built source layout. The repair had no npm update to perform after Doctor removed the stale record, so it is not evidence for an npm upgrade or an intentionally retained generation. The managed package install completed in 8m51s. No Gateway/service, channel connection, or real message was started; channel delivery was not exercised. Product timeouts were unchanged.
