### PR TITLE
docs: clarify disabled plugin reinstall behavior

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -198,6 +198,8 @@ third-party packages, and non-npm sources are not rewritten.
   <Accordion title="--force confirmation and reinstall vs update">
     `--force` confirms a non-ClawHub source without prompting. It does not bypass `security.installPolicy` or remaining install safety checks. When the plugin or hook pack is already installed, it also reuses the existing target and overwrites it in place. Use it after reviewing an arbitrary npm, local, archive, git, or marketplace source, or when intentionally reinstalling the same id. For routine upgrades of an already tracked npm plugin, prefer `openclaw plugins update <id-or-npm-spec>`.
 
+    Reinstalling preserves an authored `plugins.entries.<id>.enabled: false`. `--force` does not approve capabilities: when no valid prior acceptance can be reused, review and accept them before the install commits. Use `openclaw plugins enable <id>` to activate the plugin afterward. See [Capability consent](/plugins/manage-plugins#capability-consent).
+
     If you run `plugins install` for a plugin id that is already installed, OpenClaw stops and points you at `plugins update <id-or-npm-spec>` for a normal upgrade, or at `plugins install <package> --force` when you genuinely want to overwrite the current install from a different source. Arbitrary sources still show the interactive provenance warning; noninteractive installs must pass `--force` after review. Trusted ClawHub and OpenClaw-catalog sources do not need it. With `--link`, `--force` confirms the source but does not change the linked-path install mode.
 
   </Accordion>

--- a/docs/plugins/manage-plugins.md
+++ b/docs/plugins/manage-plugins.md
@@ -126,8 +126,9 @@ enabled plugins require fresh consent when the new artifact declares additional
 capabilities; unchanged or narrower
 surfaces can refresh an existing valid acceptance. Updating a disabled
 plugin preserves disablement and defers any required consent until enablement.
-Reinstalling through `plugins install` activates the plugin and must satisfy
-consent before activation.
+Reinstalling through `plugins install` also preserves an authored `enabled: false`,
+but requires consent before committing the install when no valid acceptance can
+be reused. Run `openclaw plugins enable <plugin-id>` to activate it afterward.
 
 Already-enabled third-party legacy installations remain usable without an initial review;
 disabling and re-enabling them requires consent. Setup rechecks consent when

--- a/scripts/e2e/lib/plugin-update/consent-scenario.mjs
+++ b/scripts/e2e/lib/plugin-update/consent-scenario.mjs
@@ -8,15 +8,20 @@ import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fixtureCapabilityConsentArgs } from "../package-compat.mjs";
+import { readPluginInstallIndex } from "../plugin-index-sqlite.mjs";
 import { observePostCoreCommand } from "./process-observer.mjs";
 
+// Without a core tarball, run only the plugin reinstall boundary against the supplied CLI.
 export async function runConsentScenario(entry, coreTarball) {
-  assert(entry && coreTarball, "expected installed entry and canonical core tarball");
-  const coreHash = createHash("sha256");
-  for await (const chunk of fs.createReadStream(coreTarball)) {
-    coreHash.update(chunk);
+  assert(entry, "expected CLI entry");
+  let coreTarballSha256;
+  if (coreTarball) {
+    const coreHash = createHash("sha256");
+    for await (const chunk of fs.createReadStream(coreTarball)) {
+      coreHash.update(chunk);
+    }
+    coreTarballSha256 = coreHash.digest("hex");
   }
-  const coreTarballSha256 = coreHash.digest("hex");
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-update-consent-"));
   const pluginId = "update-consent-fixture";
   const packageName = `@acme/${pluginId}`;
@@ -147,16 +152,19 @@ export async function runConsentScenario(entry, coreTarball) {
     process.env.npm_config_registry = process.env.NPM_CONFIG_REGISTRY;
   }
 
-  async function snapshot(label, version) {
+  async function snapshot(label, version, enabled = true) {
     const report = JSON.parse(
       (await cli(label, ["plugins", "inspect", pluginId, "--runtime", "--json"])).output,
     );
-    assert.equal(report.plugin.status, "loaded");
+    assert.equal(report.plugin.status, enabled ? "loaded" : "disabled");
+    assert.equal(report.plugin.enabled, enabled);
+    const config = JSON.parse(fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH, "utf8"));
+    assert.equal(config.plugins.entries[pluginId].enabled, enabled);
     const record = report.install;
     assert.equal(record.version, `${version}.0.0`);
     assert.deepEqual(
       report.tools.flatMap((tool) => tool.names).toSorted(),
-      expectedSurface(version).tools,
+      enabled ? expectedSurface(version).tools : [],
     );
     const surface = expectedSurface(version);
     assert.deepEqual(record.acceptedSurface, surface);
@@ -169,8 +177,11 @@ export async function runConsentScenario(entry, coreTarball) {
     assert(record.acceptedSurfaceAt);
     const bytes = fs.readFileSync(path.join(record.installPath, "index.js"), "utf8");
     assert.equal(bytes, artifacts.get(version).code);
+    const pkg = JSON.parse(fs.readFileSync(path.join(record.installPath, "package.json"), "utf8"));
+    assert.equal(pkg.version, `${version}.0.0`);
     snapshots.push({
       label,
+      enabled,
       record,
       payloadSha256: createHash("sha256").update(bytes).digest("hex"),
     });
@@ -221,13 +232,57 @@ export async function runConsentScenario(entry, coreTarball) {
           }),
         );
         fs.writeFileSync(path.join(dir, "index.js"), code);
-        const tarball = path.join(root, `fixture-${version}.tgz`);
-        execFileSync("tar", ["-czf", tarball, "-C", path.dirname(dir), "package"]);
+        const filename = execFileSync("npm", ["pack", "--pack-destination", root, "--silent"], {
+          cwd: dir,
+          encoding: "utf8",
+        }).trim();
+        const tarball = path.join(root, filename);
         artifacts.set(version, {
           tarball,
           code,
           integrity: `sha512-${createHash("sha512").update(fs.readFileSync(tarball)).digest("base64")}`,
         });
+      }
+      const reinstall = (version) => [
+        "plugins",
+        "install",
+        `npm-pack:${artifacts.get(version).tarball}`,
+        "--force",
+      ];
+      await cli("reinstall-initial", [...reinstall(1), "--accept-capabilities"]);
+      await snapshot("reinstall-initial-state", 1);
+      await cli("disable", ["plugins", "disable", pluginId]);
+      await cli("reinstall-unchanged", reinstall(1));
+      const disabled = await snapshot("reinstall-unchanged-disabled", 1, false);
+      const configBefore = fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH, "utf8");
+      const indexBefore = readPluginInstallIndex();
+      assert.deepEqual(indexBefore.installRecords[pluginId], disabled.record);
+      const rejected = await cli("reinstall-widened-denied", reinstall(2), { allowFailure: true });
+      assert.equal(rejected.code, 1, `${rejected.output}\n${rejected.diagnostic}`);
+      assert.match(rejected.output + rejected.diagnostic, /requires capability consent/i);
+      assert.equal(fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH, "utf8"), configBefore);
+      assert.deepEqual(readPluginInstallIndex(), indexBefore);
+      assert.deepEqual(await snapshot("reinstall-denied-preserved", 1, false), disabled);
+      await cli("reinstall-widened-accepted", [...reinstall(2), "--accept-capabilities"]);
+      const acceptedDisabled = await snapshot("reinstall-accepted-disabled", 2, false);
+      assert.deepEqual(readPluginInstallIndex().installRecords[pluginId], acceptedDisabled.record);
+      await cli("reinstall-enable", ["plugins", "enable", pluginId]);
+      assert.deepEqual(await snapshot("reinstall-enabled", 2), acceptedDisabled);
+      const reinstallAssertions = [
+        "unchanged forced reinstall reuses acceptance and preserves authored disablement",
+        "widened forced reinstall without consent preserves config, package, and SQLite index",
+        "accepted forced reinstall replaces package and acceptance while remaining disabled",
+        "explicit enable activates the reviewed replacement",
+      ];
+      if (!coreTarball) {
+        console.log(
+          JSON.stringify(
+            { status: "passed", root, assertions: reinstallAssertions, runs, snapshots },
+            null,
+            2,
+          ),
+        );
+        return;
       }
       await serve(1);
       await cli("initial-install", [
@@ -319,6 +374,7 @@ export async function runConsentScenario(entry, coreTarball) {
             root,
             coreTarballSha256,
             assertions: [
+              ...reinstallAssertions,
               "no-consent preserves old payload and record",
               "repair accepts exact surface and integrity",
               "acceptance grants no future widening",

--- a/src/plugins/capability-consent.test.ts
+++ b/src/plugins/capability-consent.test.ts
@@ -505,7 +505,7 @@ describe("plugin capability consent", () => {
     },
   );
 
-  it("requires consent when reinstalling a previously disabled plugin will enable it", async () => {
+  it("rejects reinstall without capability consent even when the plugin is disabled", async () => {
     const rootDir = createArtifactFixture({
       "package.json": { openclaw: { extensions: ["./index.js"] } },
       "index.js": "export {};",

--- a/src/plugins/capability-consent.ts
+++ b/src/plugins/capability-consent.ts
@@ -273,7 +273,7 @@ async function resolvePluginArtifactCapabilityConsent(params: {
       resolveAcceptedSurfaceCurrent(params.previousRecord, params.previousDeclared) &&
       resolvePluginInstallRecordIntegrity(params.previousRecord) !== undefined;
     acceptanceCurrent = !hasWidening && priorAcceptanceCurrent;
-    // Reinstalls preserve authored disablement but still require consent before commit.
+    // Reinstalls preserve authored disablement; required consent still precedes commit.
     // Only update-only flows defer it in preparePluginUpdateCapabilityConsent.
   }
   const acknowledgment =
@@ -329,7 +329,7 @@ export function createManagedPluginArtifactConsentHandler(params: {
   beforePersistentEffect?: () => void | Promise<void>;
   previousRecords?: Record<string, PluginInstallRecord>;
   previousPluginOwners?: ReadonlyMap<string, string>;
-  /** Update-only flows preserve disablement; ordinary installs activate the package. */
+  /** Update-only flows may defer consent while every known package entry is disabled. */
   updatingPluginIds?: readonly string[];
 }): {
   onBeforePluginArtifactCommit: PluginInstallArtifactConsentHandler;

--- a/src/plugins/capability-consent.ts
+++ b/src/plugins/capability-consent.ts
@@ -273,8 +273,8 @@ async function resolvePluginArtifactCapabilityConsent(params: {
       resolveAcceptedSurfaceCurrent(params.previousRecord, params.previousDeclared) &&
       resolvePluginInstallRecordIntegrity(params.previousRecord) !== undefined;
     acceptanceCurrent = !hasWidening && priorAcceptanceCurrent;
-    // Managed installs activate the package, even when its previous version was disabled.
-    // Update-only flows preserve disablement in preparePluginUpdateCapabilityConsent instead.
+    // Reinstalls preserve authored disablement but still require consent before commit.
+    // Only update-only flows defer it in preparePluginUpdateCapabilityConsent.
   }
   const acknowledgment =
     official || !params.enabled || acceptanceCurrent


### PR DESCRIPTION
Closes #134867

## What Problem This Solves

Resolves a documentation mismatch where operators were told that reinstalling a plugin with `plugins install` activates it, although the supported install flow preserves an authored `plugins.entries.<id>.enabled: false`.

The capability-consent comment and one test name repeated that activation claim. Existing unit coverage did not exercise disabled-plugin reinstall through the real CLI.

## Why This Change Was Made

Document the two independent boundaries already present in shipped behavior: install persistence preserves authored disablement; artifact consent controls whether a replacement may commit. An unchanged, integrity-bound acceptance can be reused. For third-party artifacts requiring fresh review, `--force` permits replacement but does not approve capabilities or activate a disabled plugin.

Correct the two docs pages, comment, and test name, and extend the existing CLI consent scenario with npm-packed artifacts, config persistence, SQLite install records, and runtime inspection. There is no application executable change or new production seam.

The initial landing CI failed the old source-Gateway readiness case twice. Main supplied the canonical test-owner repair in [#134812](https://github.com/openclaw/openclaw/pull/134812), commit [113805d6a517](https://github.com/openclaw/openclaw/commit/113805d6a517c27b7c2521be58c2e1fd84093ba0). This branch was rebased onto `7fd30e6bb5747014b8b9eb132971828b33bd115f`, retaining main's shared built-CLI fixture and omitting the redundant local CI repair commit `c11db7532b1`. The PR is back to its original five-file scope; it does not claim main's startup or test-owner improvements.

## User Impact

Operators can expect explicit disablement to survive reinstall. A widened third-party artifact without consent is rejected before replacement; accepting that artifact still leaves the plugin disabled. Use `openclaw plugins enable <plugin-id>` to activate it afterward. Existing first-party consent exemptions remain as documented on main.

Executable application LOC: **+0/-0**. Application comment: **+3/-3**; docs: **+5/-2**; tests/support: **+67/-11 (net +56)**, including a test-name-only change. No CI tooling, activation policy, configuration/default, or storage/schema change is included.

## Evidence

Current head is `d5eba6e5bfdb8f487f8cdb02d06c05cb3106b25f`. Its only changes since green `c65f5d512d461d202063d81dd82bf736b99245d8` are two comments clarifying install consent and update-only deferral, including the inherited JSDoc. Executable code, tests and docs are unchanged. Fresh full-candidate managed Codex autoreview was scoped-clean at P0, and focused formatting/diff checks passed. [Exact d5 CI 33491964272, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33491964272) passed, including required `openclaw/ci-gate`; the native watcher finished GREEN with exit 0. No retry was needed.

Substantive proof below was run on `c65f5d512d461d202063d81dd82bf736b99245d8`, tree `aa4e740110395705006c13f4c961f53bb5660e2b`, using Node 24.20.0, and is reused with that explicit comment-only provenance:

- `pnpm build qaRuntime` passed in 6m 22.1s. Build provenance records the exact head, tree, and CLI file hash.
- `node scripts/run-vitest.mjs src/plugins/capability-consent.test.ts src/plugins/install-persistence.enablement.test.ts src/plugins/update.test.ts src/plugins/update-channel.consent.test.ts` passed **221 tests across four files**.
- `node scripts/e2e/lib/plugin-update/probe.mjs consent "$PWD/dist/index.js"` passed **12 real CLI commands and five snapshots** with a fresh synthetic home/state/config and isolated npm cache/config. Unchanged forced reinstall reused acceptance and remained disabled; widened reinstall without consent exited 1 and preserved config bytes, package payload, and the full SQLite index; accepted widening replaced payload and acceptance while remaining disabled; explicit enable activated that reviewed package.
- `node scripts/run-vitest.mjs src/commands/doctor-config-preflight.process.test.ts` ran all **11 cases in the original file/order**: **8 passed, 3 failed locally**. Main's canonical cron migration/readiness case passed in **12.199s**, with the original 30-second readiness and 45-second test budgets. The three unchanged source Doctor cases hit `spawnSync ETIMEDOUT`: v17 additive repair (60s), legacy approvals/config repair (45s), and invalid-config exit (60s). No retry, timeout, assertion, or environment change was made. The exact-head hosted Linux proof below supplies the remaining original-order proof; this local aggregate remains failed.
- Five-file formatting, targeted script lint, and diff checks passed. The fresh changed gate passed all 32 planned commands: `node scripts/check-changed.mjs --base 7fd30e6bb5747014b8b9eb132971828b33bd115f -- docs/cli/plugins.md docs/plugins/manage-plugins.md scripts/e2e/lib/plugin-update/consent-scenario.mjs src/plugins/capability-consent.test.ts src/plugins/capability-consent.ts`.
- Fresh managed Codex autoreview was **scoped-clean at its configured P0 threshold**, with no accepted/actionable findings in that scope. The reconciled diff preserves the original correction; range-diff differences are surrounding main context.

The earlier [CI run 33473927375](https://github.com/openclaw/openclaw/actions/runs/33473927375) failed the old source-Gateway case in attempts 1 and 2. Historical proof of the omitted local CI repair is not presented as proof of main's different implementation. [Exact-head CI run 33490027813, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33490027813) passed on `c65f5d512d461d202063d81dd82bf736b99245d8`; required `openclaw/ci-gate` is `SUCCESS`. Its [Doctor-owning job](https://github.com/openclaw/openclaw/actions/runs/33490027813/job/99799265652), `checks-node-compact-small-1`, passed all **11 Doctor process cases in original order** on Linux/Node 24.19.0, including the canonical Gateway case in **3.554s**. The three locally timed-out source cases passed there as well. No CI retry was needed for this reconciled head.

The behavior and inaccurate activation claim were present in stable `v2026.8.1`. This is characterization and documentation repair, not a red-to-green application-runtime claim.

Proof gap: the broader Docker/core-tarball update and post-core subprocess portion was not rerun for this docs/test correction. No clean-machine packaging or official-source trust proof is claimed. ClawSweeper requested retaining canonical main/removing the duplicate repair and obtaining fresh exact-head CI. The duplicate repair remains omitted. CI was green at c65 and is now green at exact d5 after the two-comment follow-up. ClawSweeper automatically reviewed c65 at 2026-09-01 09:07 UTC with no introduced correctness findings. The completed review remains under 12 hours old and covers the comment-only follow-up; its CI rank-up is satisfied by green exact d5 checks. `pnpm docs:list` also passed locally, addressing the reviewer environment's read-only Corepack-cache limitation. No redundant re-review was requested.

