### PR TITLE
docs(release): check production UI build before full validation

### DIFF
--- a/.agents/skills/release-openclaw-ci/SKILL.md
+++ b/.agents/skills/release-openclaw-ci/SKILL.md
@@ -206,6 +206,13 @@ Bind both results to that exact SHA; either generated-locale drift blocks
 dispatch. Keep target execution outside the trusted dispatch helper—do not
 execute an arbitrary target checkout as helper code.
 
+Before expensive full validation, also run `pnpm ui:build` on the same frozen
+trusted target with its frozen dependencies in approved isolation, outside the
+trusted dispatch helper. Record the target SHA with the successful production
+build, precompressed-asset verification, and startup/largest-asset budget results;
+any failure blocks fanout. Do not substitute a dev server or raise budgets to admit
+the target.
+
 Before full release validation:
 
 ```bash


### PR DESCRIPTION
Full release validation can fan out expensive test lanes before discovering that the production Control UI bundle violates an existing asset budget. In run 33471134664, the same startup-size failure blocked Docker assets, candidate preparation, and downstream build lanes.

Require the canonical production UI build in the operator preflight, alongside the existing strict locale checks. Bind its build, precompressed-asset verification, and startup/largest-asset budget results to the frozen target and dependencies. Keep target execution in approved isolation outside the trusted dispatch helper, and keep all budgets unchanged.

Validation: exact-file formatting and diff checks passed; scoped Codex review found no actionable P0 issues. The canonical build owner already invokes both asset validators and propagates failure. This is a seven-line documentation change with no executable or test changes and no claim of a measured full-run speedup.
