### PR TITLE
test(video): require SSRF denial in transport cases

### DIFF
--- a/extensions/deepinfra/video-generation-provider.transport.test.ts
+++ b/extensions/deepinfra/video-generation-provider.transport.test.ts
@@ -244,7 +244,12 @@ describe("deepinfra video generation provider transport", () => {
           baseUrl: `${baseUrl}/v1/openai`,
           request,
         }),
-      ).rejects.toThrow();
+      ).rejects.toThrow(
+        expect.objectContaining({
+          name: "SsrFBlockedError",
+          message: expect.stringContaining("private/internal/special-use IP address"),
+        }),
+      );
       expect(requests).toHaveLength(0);
     });
   });

--- a/extensions/xai/video-generation-provider.transport.test.ts
+++ b/extensions/xai/video-generation-provider.transport.test.ts
@@ -201,7 +201,12 @@ describe("xai video generation provider transport", () => {
             },
           } as never,
         }),
-      ).rejects.toThrow();
+      ).rejects.toThrow(
+        expect.objectContaining({
+          name: "SsrFBlockedError",
+          message: expect.stringContaining("private/internal/special-use IP address"),
+        }),
+      );
 
       expect(server.requests).toHaveLength(0);
     },


### PR DESCRIPTION
## What Problem This Solves

Resolves a coverage hole where the DeepInfra and xAI video private-network rejection cases could pass on an unrelated pre-transport failure. A generic `rejects.toThrow()` plus zero upstream requests does not establish that the SSRF guard denied the request.

This is a maintainer-requested, bounded coverage follow-up—not a fix for the separate DeepInfra operation-deadline timeout. [CI run 33419303058, attempt 1, job 99577833447](https://github.com/openclaw/openclaw/actions/runs/33419303058/job/99577833447) failed at the first POST's remaining-budget evaluation. Why its negative cases passed remains unknown.

## Why This Change Was Made

Extend the existing default-policy and explicit-false cases to require both the documented `SsrFBlockedError` identity and the private/internal/special-use IP denial reason. The [SDK documents this error](https://docs.openclaw.ai/plugins/sdk-subpaths); `src/infra/net/ssrf.ts` produces the denial and the guarded HTTP path rethrows it unchanged.

Keep the proof at the real provider transport boundary rather than adding duplicate tests, mocked transport, or a production seam. Matching the error's name and reason avoids constructor-identity coupling across the suites' existing module resets. Local HTTP servers, zero-request assertions, auth setup, real clocks, and every deadline are unchanged.

## User Impact

No runtime behavior changes. Developers get a failure instead of a false-positive security test when another error prevents the request from reaching the SSRF guard.

Production LOC: **+0/-0**. Tests: **+12/-2** across exactly two existing files. No new tests, dependencies, configuration, or production exports.

## Evidence

Clean Linux proof used **Blacksmith Testbox** `tbx_01m1dppjs1xcp7xnc3eczv0x2v`, [session run 33473362777](https://github.com/openclaw/openclaw/actions/runs/33473362777), Node 24.19.0 and Vitest 4.1.11. The materialized candidate tree was `82f3784cd5e541c910be62b40398b749b53f1471`; exact candidate bytes were verified before and after the temporary fault injection. The lease was stopped and its terminal state verified.

| Proof variant | Observed result |
| --- | --- |
| Unmodified candidate, both complete transport files | 7 passed |
| Existing negative cases with the old generic matcher and a one-shot ordinary `Error` injected through the existing auth mock | All 4 passed, including zero-request assertions |
| Same injected error with the tightened matcher | All 4 failed at the intended asymmetric-matcher assertion; verbose output showed the ordinary deadline-shaped error rather than SSRF denial |
| Exact candidate restored, both transport files plus both provider unit suites and xAI TTS SSRF transport siblings | 43 passed, 0 skipped, 0 errors |

The fault was synthetic and pre-transport; it was removed completely. It proves rejection discrimination in the actual cases, not real deadline exhaustion or the cause of the historical CI negatives. Negative-only runs deliberately filtered the three positive cases; the final five-file run had no skips. An initial scratch collector stopped because native JSON omitted the received-error diff; the collector was corrected to use verbose evidence and the entire ordered sequence was rerun successfully without changing source behavior or test settings.

Final focused command:

```sh
node scripts/run-vitest.mjs extensions/deepinfra/video-generation-provider.transport.test.ts extensions/xai/video-generation-provider.transport.test.ts extensions/deepinfra/video-generation-provider.test.ts extensions/xai/video-generation-provider.test.ts extensions/xai/tts.ssrf-transport.test.ts --reporter=verbose --reporter=json
```

Mutation selection used the same wrapper with `-t 'blocks .*loopback'`, running each tightened-mutant file separately so fail-fast routing could not hide either provider.

Also passed: full changed-scope checks for the two files, including extension-test typecheck, targeted lint, formatting, guards, and dead-export scans; `git diff --check`; fresh Codex autoreview, scoped-clean at P0.

Earlier local attempts were blocked before test bodies: xAI's unchanged provider-import hook timed out twice, and DeepInfra stalled in compiled-worker setup. Those are not counted as passing proof; the clean Linux runs above close the actual provider-case proof gap.
