### PR TITLE
test: remove redundant provider catalog setup

### DIFF
--- a/extensions/huggingface/models.proxy.test.ts
+++ b/extensions/huggingface/models.proxy.test.ts
@@ -10,28 +10,13 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
 
 import { discoverHuggingfaceModels } from "./models.js";
 
-const ORIGINAL_VITEST = process.env.VITEST;
-const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
-
-function restoreEnv(key: "VITEST" | "NODE_ENV", value: string | undefined) {
-  if (value === undefined) {
-    delete process.env[key];
-  } else {
-    process.env[key] = value;
-  }
-}
-
 afterEach(() => {
-  restoreEnv("VITEST", ORIGINAL_VITEST);
-  restoreEnv("NODE_ENV", ORIGINAL_NODE_ENV);
   fetchWithSsrFGuardMock.mockReset();
   vi.restoreAllMocks();
 });
 
 describe("Hugging Face model discovery proxy policy", () => {
   it("allows the guarded official catalog request to use an eligible HTTP proxy", async () => {
-    process.env.VITEST = "false";
-    process.env.NODE_ENV = "development";
     const response = new Response("unavailable", { status: 503 });
     const release = vi.fn(async () => undefined);
     fetchWithSsrFGuardMock.mockResolvedValue({ response, release });

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -101,7 +101,6 @@ const catalogResponses = new Map<
 >();
 
 afterEach(() => {
-  vi.useRealTimers();
   clearLiveCatalogCacheForTests();
   ssrfRuntimeMocks.fetchWithSsrFGuard.mockReset();
   ssrfRuntimeMocks.ssrfPolicyFromHttpBaseUrlAllowedHostname.mockClear();
@@ -576,37 +575,6 @@ describe("nvidia provider catalog", () => {
     await buildLiveNvidiaProvider();
 
     expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(2);
-  });
-
-  it("skips featured catalog cache when ttl expiry overflows", async () => {
-    vi.setSystemTime(new Date(8_640_000_000_000_000));
-    mockFeaturedCatalogResponse({
-      "featured-models": [
-        {
-          model: "minimaxai/minimax-m3",
-          "model-name": "Minimax M3",
-          context: 196608,
-          "max-output": 8192,
-        },
-      ],
-    });
-    mockFeaturedCatalogResponse({
-      "featured-models": [
-        {
-          model: "z-ai/glm-5.2",
-          "model-name": "GLM 5.2",
-          context: 202752,
-          "max-output": 8192,
-        },
-      ],
-    });
-
-    const first = await buildLiveNvidiaProvider();
-    const second = await buildLiveNvidiaProvider();
-
-    expect(first.models.map((model) => model.id)).toEqual(["minimaxai/minimax-m3"]);
-    expect(second.models.map((model) => model.id)).toEqual(["z-ai/glm-5.2"]);
-    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(4);
   });
 
   it("does not cache successful featured catalog responses with no usable rows", async () => {


### PR DESCRIPTION
## What Problem This Solves

Two provider test suites retain coverage or setup that moved to shared owners: NVIDIA repeats the shared catalog cache's overflowing-expiry case, and Hugging Face still changes runner environment flags after discovery stopped reading them.

## Why This Change Was Made

Remove NVIDIA's duplicate overflow case and its now-unused clock teardown. Keep the shared max-Date/positive-TTL regression and NVIDIA's own cache eligibility, repeated-builder, retry, catalog and onboarding coverage. Remove only the obsolete environment capture, mutation and restoration from Hugging Face's proxy test; its real discovery call, guarded URL, response and release assertions stay unchanged.

## User Impact

Production code and behavior are unchanged. The patch removes 47 test lines and one redundant case without removing a runtime export or changing authentication, discovery, fallback or proxy policy.

## Evidence

The ordinary seven-suite group passed 72 cases before and 71 after. Every surviving per-file case name, order and result is preserved; parallel cross-file completion order differs. All 15 Hugging Face cases and all 21 shared catalog cases remain. All 52 relevant source contexts match between the paired proof base and publication base.

Independent source and raw-log review confirmed the shared overflow regression, retained NVIDIA wiring coverage, and the historical removal of Hugging Face's runner-environment branch. This is controlled test proof, not a live vendor request or a performance measurement. All normal changed checks passed, including extension test types, dead-export scans, lint and repository guards. Managed Codex review was scoped-clean at its selected P0 scope, and independent review found no lost provider contract.
