### PR TITLE
test(channels): drive ingress poll windows with scoped clocks

### DIFF
--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -9,16 +9,14 @@ import {
   runWithGatewayIndependentRootWorkContinuation,
 } from "../../process/gateway-work-admission.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { sleep } from "../../utils/sleep.js";
 import { createChannelIngressError } from "./ingress-errors.js";
 import {
   CHANNEL_INGRESS_RETENTION_DEFAULTS,
   createChannelIngressMonitor,
-  type ChannelIngressMonitorDeliveryResult,
   type ChannelIngressMonitorLifecycle,
+  type CreateChannelIngressMonitorOptions,
 } from "./ingress-monitor.js";
 import { createChannelIngressQueue, type ChannelIngressQueue } from "./ingress-queue.js";
-import type { IngressRetryPolicyConfig } from "./ingress-retry-policy.js";
 import {
   ChannelIngressUnavailableError,
   isChannelIngressUnavailableError,
@@ -26,6 +24,7 @@ import {
 
 type RawEvent = { id: string; lane: string; text: string };
 type StoredEvent = { version: 1; rawEvent: string };
+type MonitorOptions = CreateChannelIngressMonitorOptions<RawEvent, string, StoredEvent, unknown>;
 
 class PermanentIngressError extends Error {}
 
@@ -43,36 +42,12 @@ async function withQueue<T>(
 }
 
 function createMonitor(
-  queue: ChannelIngressQueue<StoredEvent> | (() => ChannelIngressQueue<StoredEvent>),
-  deliver: (
-    raw: RawEvent,
-    lifecycle: ChannelIngressMonitorLifecycle,
-  ) =>
-    | Promise<ChannelIngressMonitorDeliveryResult | void>
-    | ChannelIngressMonitorDeliveryResult
-    | void,
+  queue: MonitorOptions["queue"],
+  deliver: MonitorOptions["deliver"],
   activityOrMonitorOptions?:
-    | ((active: boolean) => void)
-    | {
-        admissionMode?: "durable-after-stop";
-        deferredClaims?: "wait-on-stop" | "settle-on-abort" | "manual";
-        inspect?: (raw: RawEvent) => { eventId: string; laneKey: string } | null;
-        retention?:
-          | "standard"
-          | Partial<{
-              pruneIntervalMs: number;
-              completedTtlMs: number;
-              completedMaxEntries: number;
-              failedTtlMs: number;
-              failedMaxEntries: number;
-            }>;
-        now?: () => number;
-        waitForDeliveryIdleBeforeRepump?: boolean;
-        waitForDeliveryIdleOnStop?: boolean;
-        retryPolicy?: IngressRetryPolicyConfig;
-        deferredLaneOccupancy?: "hold" | "release";
-        runPumpTask?: (work: () => Promise<void>) => Promise<void>;
-      },
+    | MonitorOptions["onActivityChange"]
+    | (Partial<Omit<MonitorOptions, "queue" | "deliver" | "payload" | "drain">> &
+        Pick<NonNullable<MonitorOptions["drain"]>, "retryPolicy" | "deferredLaneOccupancy">),
   onError?: (error: unknown) => void,
   abortSignal?: AbortSignal,
   pollIntervalMs = 10,
@@ -191,11 +166,20 @@ describe("channel ingress monitor", () => {
         retention: { pruneIntervalMs: 0, completedMaxEntries: 10 },
       });
 
-      monitor.start();
-      await sleep(65);
-      await monitor.stop();
+      vi.useFakeTimers();
+      try {
+        monitor.start();
+        await vi.advanceTimersByTimeAsync(65);
+        await monitor.stop();
 
-      expect(prune).not.toHaveBeenCalled();
+        expect(prune).not.toHaveBeenCalled();
+      } finally {
+        try {
+          await monitor.stop();
+        } finally {
+          vi.useRealTimers();
+        }
+      }
     });
   });
 
@@ -1057,35 +1041,50 @@ describe("channel ingress monitor", () => {
     const onError = vi.fn();
     const monitor = createMonitor(queueFactory, vi.fn(), undefined, onError, undefined, 1);
 
-    // The typed rethrow is the gateway's only way to tell dead inbound apart from
-    // an ordinary channel crash; the denial stays reachable as the cause.
-    const startError = (() => {
-      try {
-        monitor.start();
-        return expect.unreachable("start must fail while the durable queue is denied");
-      } catch (error) {
-        return error;
-      }
-    })();
-    expect(startError).toBeInstanceOf(ChannelIngressUnavailableError);
-    expect((startError as Error).cause).toBe(denial);
-    expect(isChannelIngressUnavailableError(startError)).toBe(true);
-    // A channel plugin is free to wrap the start failure in its own error.
-    expect(
-      isChannelIngressUnavailableError(new Error("slack start failed", { cause: startError })),
-    ).toBe(true);
-    expect(isChannelIngressUnavailableError(denial)).toBe(false);
-    expect(monitor.isRunning()).toBe(false);
-    // An armed poll timer would have retried the denied factory many times over this window.
-    await sleep(25);
-    expect(queueFactory).toHaveBeenCalledOnce();
-    expect(onError).not.toHaveBeenCalled();
+    vi.useFakeTimers();
+    try {
+      // The typed rethrow is the gateway's only way to tell dead inbound apart from
+      // an ordinary channel crash; the denial stays reachable as the cause.
+      const startError = (() => {
+        try {
+          monitor.start();
+          return expect.unreachable("start must fail while the durable queue is denied");
+        } catch (error) {
+          return error;
+        }
+      })();
+      expect(startError).toBeInstanceOf(ChannelIngressUnavailableError);
+      expect((startError as Error).cause).toBe(denial);
+      expect(isChannelIngressUnavailableError(startError)).toBe(true);
+      // A channel plugin is free to wrap the start failure in its own error.
+      expect(
+        isChannelIngressUnavailableError(new Error("slack start failed", { cause: startError })),
+      ).toBe(true);
+      expect(isChannelIngressUnavailableError(denial)).toBe(false);
+      expect(monitor.isRunning()).toBe(false);
+      // An armed poll timer would have retried the denied factory many times over this window.
+      await vi.advanceTimersByTimeAsync(25);
+      expect(queueFactory).toHaveBeenCalledOnce();
+      expect(onError).not.toHaveBeenCalled();
 
-    // Accepted transport input still fails closed rather than being silently dropped.
-    await expect(monitor.admit({ id: "event-denied", lane: "a", text: "hello" })).rejects.toBe(
-      denial,
-    );
-    await monitor.stop();
+      // Accepted transport input still fails closed rather than being silently dropped.
+      const admissionAssertion = expect(
+        monitor.admit({ id: "event-denied", lane: "a", text: "hello" }),
+      ).rejects.toBe(denial);
+      const timerRun = vi.runAllTimersAsync();
+      // A failed assertion can settle first; join the clock driver before restoring timers.
+      try {
+        await Promise.all([admissionAssertion, timerRun]);
+      } finally {
+        await timerRun;
+      }
+    } finally {
+      try {
+        await monitor.stop();
+      } finally {
+        vi.useRealTimers();
+      }
+    }
   });
 
   it("can defer delivery-idle waiting to a channel-owned shutdown grace", async () => {


### PR DESCRIPTION
## What Problem This Solves

Two ingress-monitor cases wait on real time to observe idle polling and a denied queue's retry window, even though they assert timer callbacks and error identity.

## Why This Change Was Made

Use scoped fake clocks in those two cases, retaining the actual queue and monitor owners. Always stop the monitor and restore the clock. Join the asynchronous timer driver even when the admission assertion fails, so cleanup cannot race clock restoration.

## User Impact

Test-only. All 32 cases and existing assertions remain; the other 30 cases keep real timers. The change virtualizes 90 ms of explicit polling waits and 400 ms of existing retry delays. These are scheduled-work counts, not measured elapsed savings. Production +0/-0; tests +62/-63 (net -1).

## Evidence

32/32 pass before and after with identical native case labels and results. Removing the idle-prune guard fails the original no-prune assertion; restoring the old denied-start ordering fails its typed synchronous-start assertion. An intentionally wrong denial identity fails normally, without a global timeout or unhandled error. Exact source bytes were restored before the passing run.

These two cases test callback and no-spin behavior. They do not test retention age against a fake Date.now. The final normal full channels project passes 1,274/1,274. Full changed checks, Codex autoreview and independent source review pass. The gate caught a promise-finally lint issue and the file line limit; the final edit uses an explicit awaited cleanup block and reuses the monitor owner's option types, without changing the fixture runtime body or other case arguments.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/channels/message/ingress-monitor.test.ts --config test/vitest/vitest.channels.config.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs --config test/vitest/vitest.channels.config.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base 167a934d1ee
```

