### PR TITLE
fix(status): show delivery queue warnings in detailed reports

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2572,7 +2572,6 @@ src/commands/sessions-compact.ts	1
 src/commands/sessions-lifecycle.ts	3
 src/commands/setup.ts	1
 src/commands/status-all/channels.ts	2
-src/commands/status-all/diagnosis.ts	1
 src/commands/status-all/gateway.ts	1
 src/commands/status.command.ts	1
 src/commands/status.scan.bootstrap-shared.ts	1

--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -31,6 +31,11 @@ Channels without a probe, such as WhatsApp, report lifecycle health instead.
 In the Health table, `healthy` is `OK`; degraded lifecycle states and failed
 probes remain `WARN`. A lifecycle `OK` does not mean a live probe ran.
 
+`--deep` and `--all` also show delivery queue warnings for dead-lettered messages
+and pressured inbound lanes. These warnings include pending, claimed, and blocked
+message counts even when a channel connection is healthy. See
+[Queue warnings](/gateway/health#queue-warnings).
+
 Plain `openclaw status` stays on the fast read-only path and marks memory as
 `not checked` instead of unavailable when it skips memory inspection. Heavy
 security audit, plugin compatibility, and memory-vector probes are left to

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayClientRequestError } from "../../packages/gateway-client/src/index.js";
 import { retainGatewayResponsePayload } from "../../packages/gateway-client/src/protocol-request.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { GatewayTransportError } from "../gateway/transport-error.js";
 import {
   GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE,
   GATEWAY_HEALTH_CREDENTIALS_REQUIRED_TITLE,
@@ -12,7 +13,6 @@ import {
 
 const callGateway = vi.hoisted(() => vi.fn());
 const isGatewayCredentialsRequiredError = vi.hoisted(() => vi.fn(() => false));
-const isGatewayTransportError = vi.hoisted(() => vi.fn((_value: unknown) => false));
 const isGatewaySecretRefUnavailableError = vi.hoisted(() => vi.fn(() => false));
 const probeGatewayStatus = vi.hoisted(() => vi.fn());
 const note = vi.hoisted(() => vi.fn());
@@ -32,7 +32,6 @@ vi.mock("../gateway/call.js", () => ({
   })),
   callGateway,
   isGatewayCredentialsRequiredError,
-  isGatewayTransportError,
 }));
 
 vi.mock("../gateway/credentials.js", () => ({
@@ -60,8 +59,6 @@ describe("checkGatewayHealth", () => {
     callGateway.mockReset();
     isGatewayCredentialsRequiredError.mockReset();
     isGatewayCredentialsRequiredError.mockReturnValue(false);
-    isGatewayTransportError.mockReset();
-    isGatewayTransportError.mockReturnValue(false);
     isGatewaySecretRefUnavailableError.mockReset();
     isGatewaySecretRefUnavailableError.mockReturnValue(false);
     probeGatewayStatus.mockReset();
@@ -313,15 +310,17 @@ describe("checkGatewayHealth", () => {
   });
 
   it("reports a typed close without depending on gateway error wording", async () => {
-    const error = Object.assign(
-      new Error("transport closed: \u001B]52;c;YXR0YWNr\u0007protocol version mismatch"),
-      {
-        kind: "closed",
-        code: 1008,
+    const error = new GatewayTransportError({
+      message: "transport closed: \u001B]52;c;YXR0YWNr\u0007protocol version mismatch",
+      kind: "closed",
+      code: 1008,
+      connectionDetails: {
+        url: TEST_GATEWAY_URL,
+        urlSource: "local loopback",
+        message: `Gateway target: ${TEST_GATEWAY_URL}`,
       },
-    );
+    });
     callGateway.mockRejectedValueOnce(error);
-    isGatewayTransportError.mockImplementation((value) => value === error);
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
 
     await checkGatewayHealth({ runtime: runtime as never, cfg, timeoutMs: 3000 });

--- a/src/commands/health-format.test.ts
+++ b/src/commands/health-format.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { ChannelAccountHealthSummary, HealthSummary } from "../gateway/health/types.js";
-import { formatGatewayClosedDiagnostic, formatHealthChannelLines } from "./health-format.js";
+import {
+  formatDeliveryQueueHealthLine,
+  formatGatewayClosedDiagnostic,
+  formatHealthChannelLines,
+} from "./health-format.js";
 
 describe("formatGatewayClosedDiagnostic", () => {
   it("formats a coded gateway transport close", () => {
@@ -28,7 +32,11 @@ describe("formatGatewayClosedDiagnostic", () => {
 });
 
 const createHealthSummary = (
-  params: Pick<HealthSummary, "channels" | "channelOrder" | "channelLabels">,
+  params: Pick<HealthSummary, "channels" | "channelOrder" | "channelLabels"> = {
+    channels: {},
+    channelOrder: [],
+    channelLabels: {},
+  },
 ): HealthSummary => ({
   ok: true,
   ts: 0,
@@ -325,5 +333,86 @@ describe("formatHealthChannelLines", () => {
     expect(formatHealthChannelLines(summary)).toContain(
       "iMessage: failed (unknown) - imsg cannot access ~/Library/Messages/chat.db. Grant Full Disk Access to the Gateway/launcher process and restart Gateway.",
     );
+  });
+});
+
+describe("formatDeliveryQueueHealthLine", () => {
+  it("summarizes dead-lettered delivery queue entries with the oldest age", () => {
+    const summary = createHealthSummary();
+    summary.deliveryQueues = {
+      failed: [
+        { queueName: "outbound", count: 3, oldestFailedAt: 90_000 },
+        { queueName: "session", count: 1 },
+      ],
+    };
+
+    expect(formatDeliveryQueueHealthLine(summary, 7_290_000)).toBe(
+      "Delivery queue: warning (dead-lettered entries — outbound: 3, session: 1; oldest 2h ago)",
+    );
+  });
+
+  it("summarizes dead-lettered ingress entries per channel account", () => {
+    const summary = createHealthSummary();
+    summary.deliveryQueues = {
+      failed: [],
+      ingressFailed: [
+        { channelId: "line", accountId: "default", count: 1, oldestFailedAt: 90_000 },
+        { channelId: "telegram", accountId: "ops", count: 2 },
+      ],
+    };
+
+    expect(formatDeliveryQueueHealthLine(summary, 7_290_000)).toBe(
+      "Delivery queue: warning (dead-lettered entries — inbound line/default: 1, inbound telegram/ops: 2; oldest 2h ago)",
+    );
+  });
+
+  it("summarizes ingress pressure per channel account", () => {
+    const summary = createHealthSummary();
+    summary.deliveryQueues = {
+      failed: [],
+      ingressPressure: [
+        {
+          channelId: "telegram",
+          accountId: "ops",
+          laneCount: 1,
+          pendingCount: 56,
+          claimedCount: 0,
+          blockedCount: 55,
+          oldestReceivedAt: 90_000,
+        },
+      ],
+    };
+
+    expect(formatDeliveryQueueHealthLine(summary, 7_290_000)).toBe(
+      "Delivery queue: warning (ingress pressure — inbound telegram/ops: 1 pressured lane, 56 pending, 0 claimed, 55 blocked; oldest 2h ago)",
+    );
+  });
+
+  it("summarizes dead letters and ingress pressure together", () => {
+    const summary = createHealthSummary();
+    summary.deliveryQueues = {
+      failed: [{ queueName: "outbound", count: 2, oldestFailedAt: 90_000 }],
+      ingressPressure: [
+        {
+          channelId: "line",
+          accountId: "default",
+          laneCount: 2,
+          pendingCount: 3,
+          claimedCount: 1,
+          blockedCount: 2,
+          oldestReceivedAt: 3_690_000,
+        },
+      ],
+    };
+
+    expect(formatDeliveryQueueHealthLine(summary, 7_290_000)).toBe(
+      "Delivery queue: warning (dead-lettered entries — outbound: 2; oldest 2h ago; ingress pressure — inbound line/default: 2 pressured lanes, 3 pending, 1 claimed, 2 blocked; oldest 1h ago)",
+    );
+  });
+
+  it("returns null when no dead-lettered entries are reported", () => {
+    const summary = createHealthSummary();
+
+    expect(formatDeliveryQueueHealthLine(summary)).toBeNull();
   });
 });

--- a/src/commands/health-format.ts
+++ b/src/commands/health-format.ts
@@ -1,10 +1,11 @@
-/** Formatting helpers for `openclaw health` failures and channel summaries. */
+/** Shared CLI formatting for gateway health failures, channels, and delivery queues. */
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { colorize, isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatChannelStatusState } from "../channels/plugins/status-state.js";
-import { isGatewayTransportError } from "../gateway/call.js";
 import type { ChannelAccountHealthSummary, HealthSummary } from "../gateway/health/types.js";
+import { isGatewayTransportError } from "../gateway/transport-error.js";
+import { formatDurationHuman } from "../infra/format-time/format-duration.js";
 
 export function formatGatewayClosedDiagnostic(err: unknown): string | undefined {
   if (!isGatewayTransportError(err) || err.kind !== "closed" || err.code === undefined) {
@@ -282,3 +283,43 @@ export const formatHealthChannelLines = (
   }
   return lines;
 };
+
+/** Formats dead-lettered and pressured delivery queue entries for text health output. */
+export function formatDeliveryQueueHealthLine(
+  summary: HealthSummary,
+  now = Date.now(),
+): string | null {
+  const failed = summary.deliveryQueues?.failed ?? [];
+  const ingressFailed = summary.deliveryQueues?.ingressFailed ?? [];
+  const ingressPressure = summary.deliveryQueues?.ingressPressure ?? [];
+  const warnings: string[] = [];
+  const deadLetterCounts = [
+    ...failed.map((queue) => `${queue.queueName}: ${queue.count}`),
+    ...ingressFailed.map(
+      (queue) => `inbound ${queue.channelId}/${queue.accountId}: ${queue.count}`,
+    ),
+  ].join(", ");
+  const oldest = [...failed, ...ingressFailed]
+    .map((queue) => queue.oldestFailedAt)
+    .filter((value): value is number => typeof value === "number");
+  const oldestNote =
+    oldest.length > 0 ? `; oldest ${formatDurationHuman(now - Math.min(...oldest))} ago` : "";
+  if (deadLetterCounts) {
+    warnings.push(`dead-lettered entries — ${deadLetterCounts}${oldestNote}`);
+  }
+  if (ingressPressure.length > 0) {
+    const pressureCounts = ingressPressure
+      .map(
+        (queue) =>
+          `inbound ${queue.channelId}/${queue.accountId}: ${queue.laneCount} pressured ${
+            queue.laneCount === 1 ? "lane" : "lanes"
+          }, ${queue.pendingCount} pending, ${queue.claimedCount} claimed, ${queue.blockedCount} blocked`,
+      )
+      .join(", ");
+    const oldestPressure = Math.min(...ingressPressure.map((queue) => queue.oldestReceivedAt));
+    warnings.push(
+      `ingress pressure — ${pressureCounts}; oldest ${formatDurationHuman(now - oldestPressure)} ago`,
+    );
+  }
+  return warnings.length > 0 ? `Delivery queue: warning (${warnings.join("; ")})` : null;
+}

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -18,7 +18,6 @@ import type { HealthSummary } from "./health.js";
 import {
   formatConfigReloadHealthLine,
   formatContextEngineHealthLine,
-  formatDeliveryQueueHealthLine,
   healthCommand,
   healthCommandNonExiting,
 } from "./health.js";
@@ -911,87 +910,6 @@ describe("formatContextEngineHealthLine", () => {
     expect(formatContextEngineHealthLine(summary)).toBe(
       "Context engine: warning (1 quarantined; downgraded to legacy: lossless-claw)",
     );
-  });
-});
-
-describe("formatDeliveryQueueHealthLine", () => {
-  it("summarizes dead-lettered delivery queue entries with the oldest age", () => {
-    const summary = createHealthSummary();
-    summary.deliveryQueues = {
-      failed: [
-        { queueName: "outbound", count: 3, oldestFailedAt: 90_000 },
-        { queueName: "session", count: 1 },
-      ],
-    };
-
-    expect(formatDeliveryQueueHealthLine(summary, 7_290_000)).toBe(
-      "Delivery queue: warning (dead-lettered entries — outbound: 3, session: 1; oldest 2h ago)",
-    );
-  });
-
-  it("summarizes dead-lettered ingress entries per channel account", () => {
-    const summary = createHealthSummary();
-    summary.deliveryQueues = {
-      failed: [],
-      ingressFailed: [
-        { channelId: "line", accountId: "default", count: 1, oldestFailedAt: 90_000 },
-        { channelId: "telegram", accountId: "ops", count: 2 },
-      ],
-    };
-
-    expect(formatDeliveryQueueHealthLine(summary, 7_290_000)).toBe(
-      "Delivery queue: warning (dead-lettered entries — inbound line/default: 1, inbound telegram/ops: 2; oldest 2h ago)",
-    );
-  });
-
-  it("summarizes ingress pressure per channel account", () => {
-    const summary = createHealthSummary();
-    summary.deliveryQueues = {
-      failed: [],
-      ingressPressure: [
-        {
-          channelId: "telegram",
-          accountId: "ops",
-          laneCount: 1,
-          pendingCount: 56,
-          claimedCount: 0,
-          blockedCount: 55,
-          oldestReceivedAt: 90_000,
-        },
-      ],
-    };
-
-    expect(formatDeliveryQueueHealthLine(summary, 7_290_000)).toBe(
-      "Delivery queue: warning (ingress pressure — inbound telegram/ops: 1 pressured lane, 56 pending, 0 claimed, 55 blocked; oldest 2h ago)",
-    );
-  });
-
-  it("summarizes dead letters and ingress pressure together", () => {
-    const summary = createHealthSummary();
-    summary.deliveryQueues = {
-      failed: [{ queueName: "outbound", count: 2, oldestFailedAt: 90_000 }],
-      ingressPressure: [
-        {
-          channelId: "line",
-          accountId: "default",
-          laneCount: 2,
-          pendingCount: 3,
-          claimedCount: 1,
-          blockedCount: 2,
-          oldestReceivedAt: 3_690_000,
-        },
-      ],
-    };
-
-    expect(formatDeliveryQueueHealthLine(summary, 7_290_000)).toBe(
-      "Delivery queue: warning (dead-lettered entries — outbound: 2; oldest 2h ago; ingress pressure — inbound line/default: 2 pressured lanes, 3 pending, 1 claimed, 2 blocked; oldest 1h ago)",
-    );
-  });
-
-  it("returns null when no dead-lettered entries are reported", () => {
-    const summary = createHealthSummary();
-
-    expect(formatDeliveryQueueHealthLine(summary)).toBeNull();
   });
 });
 

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -26,10 +26,7 @@ import type { HealthSummary } from "../gateway/health/types.js";
 import { info } from "../globals.js";
 import { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import {
-  formatDurationCompact,
-  formatDurationHuman,
-} from "../infra/format-time/format-duration.js";
+import { formatDurationCompact } from "../infra/format-time/format-duration.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { buildChannelAccountBindings, resolvePreferredAccountId } from "../routing/bindings.js";
 import { ExitError, type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
@@ -41,7 +38,7 @@ import {
   gatewayProbeResultSawGateway,
   gatewayProbeResultWasRateLimited,
 } from "./gateway-health-auth-diagnostic.js";
-import { formatHealthChannelLines } from "./health-format.js";
+import { formatDeliveryQueueHealthLine, formatHealthChannelLines } from "./health-format.js";
 import { logGatewayConnectionDetails } from "./status.gateway-connection.js";
 export { formatHealthChannelLines } from "./health-format.js";
 export type { HealthSummary } from "../gateway/health/types.js";
@@ -180,46 +177,6 @@ export function formatContextEngineHealthLine(summary: HealthSummary): string | 
   }
   const engines = quarantined.map((entry) => entry.engineId).join(", ");
   return `Context engine: warning (${quarantined.length} quarantined; downgraded to legacy: ${engines})`;
-}
-
-/** Formats dead-lettered and pressured delivery queue entries for text health output. */
-export function formatDeliveryQueueHealthLine(
-  summary: HealthSummary,
-  now = Date.now(),
-): string | null {
-  const failed = summary.deliveryQueues?.failed ?? [];
-  const ingressFailed = summary.deliveryQueues?.ingressFailed ?? [];
-  const ingressPressure = summary.deliveryQueues?.ingressPressure ?? [];
-  const warnings: string[] = [];
-  const deadLetterCounts = [
-    ...failed.map((queue) => `${queue.queueName}: ${queue.count}`),
-    ...ingressFailed.map(
-      (queue) => `inbound ${queue.channelId}/${queue.accountId}: ${queue.count}`,
-    ),
-  ].join(", ");
-  const oldest = [...failed, ...ingressFailed]
-    .map((queue) => queue.oldestFailedAt)
-    .filter((value): value is number => typeof value === "number");
-  const oldestNote =
-    oldest.length > 0 ? `; oldest ${formatDurationHuman(now - Math.min(...oldest))} ago` : "";
-  if (deadLetterCounts) {
-    warnings.push(`dead-lettered entries — ${deadLetterCounts}${oldestNote}`);
-  }
-  if (ingressPressure.length > 0) {
-    const pressureCounts = ingressPressure
-      .map(
-        (queue) =>
-          `inbound ${queue.channelId}/${queue.accountId}: ${queue.laneCount} pressured ${
-            queue.laneCount === 1 ? "lane" : "lanes"
-          }, ${queue.pendingCount} pending, ${queue.claimedCount} claimed, ${queue.blockedCount} blocked`,
-      )
-      .join(", ");
-    const oldestPressure = Math.min(...ingressPressure.map((queue) => queue.oldestReceivedAt));
-    warnings.push(
-      `ingress pressure — ${pressureCounts}; oldest ${formatDurationHuman(now - oldestPressure)} ago`,
-    );
-  }
-  return warnings.length > 0 ? `Delivery queue: warning (${warnings.join("; ")})` : null;
 }
 
 /** Formats config hot-reload watcher degradation for text health output. */

--- a/src/commands/status-all/diagnosis.test.ts
+++ b/src/commands/status-all/diagnosis.test.ts
@@ -106,6 +106,56 @@ describe("status-all diagnosis port checks", () => {
     gatewayMocks.summarizeLogTail.mockImplementation((lines: string[]) => lines);
   });
 
+  it("retains queue warnings from a successful gateway health snapshot", async () => {
+    const params = createBaseParams([]);
+    params.health = {
+      ok: true,
+      ts: 0,
+      durationMs: 42,
+      heartbeatSeconds: 60,
+      defaultAgentId: "main",
+      agents: [],
+      sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+      deliveryQueues: {
+        failed: [{ queueName: "outbound", count: 2 }],
+        ingressPressure: [
+          {
+            channelId: "telegram",
+            accountId: "ops",
+            laneCount: 1,
+            pendingCount: 2,
+            claimedCount: 0,
+            blockedCount: 1,
+            oldestReceivedAt: Date.now(),
+          },
+        ],
+      },
+    };
+
+    await appendStatusAllDiagnosis(params);
+
+    const output = params.lines.join("\n");
+    expect(output).toContain("Delivery queue: warning");
+    expect(output).toContain("outbound: 2");
+    expect(output).toContain(
+      "inbound telegram/ops: 1 pressured lane, 2 pending, 0 claimed, 1 blocked",
+    );
+  });
+
+  it("keeps a failed health request visible in the complete report", async () => {
+    const params = createBaseParams([]);
+    params.health = { error: "health request timed out" };
+
+    await appendStatusAllDiagnosis(params);
+
+    const output = params.lines.join("\n");
+    expect(output).toContain("Gateway health:\n  health request timed out");
+    expect(output).toContain("Pasteable debug report. Auth tokens redacted.");
+  });
+
   it("labels OpenClaw Tailscale exposure separately from daemon state", async () => {
     const params = createBaseParams([]);
     params.tailscale.backendState = "Running";

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -26,7 +26,11 @@ import {
   formatPluginCompatibilityNotice,
   type PluginCompatibilityNotice,
 } from "../../plugins/status.js";
-import type { StatusGatewayDiagnosticsResult } from "../status-runtime-shared.ts";
+import { formatDeliveryQueueHealthLine } from "../health-format.js";
+import type {
+  resolveStatusGatewayHealthSafe,
+  StatusGatewayDiagnosticsResult,
+} from "../status-runtime-shared.ts";
 import {
   formatUpdateRestartActionLines,
   formatUpdateRestartStatusValue,
@@ -164,7 +168,7 @@ export async function appendStatusAllDiagnosis(params: {
   exporterDiagnostics: StatusGatewayDiagnosticsResult | null;
   agentStatus?: AgentStatusLike;
   gatewayReachable: boolean;
-  health: unknown;
+  health: Awaited<ReturnType<typeof resolveStatusGatewayHealthSafe>> | null | undefined;
   nodeOnlyGateway: NodeOnlyGatewayInfo | null;
 }) {
   const { lines, muted, ok, warn, fail } = params;
@@ -501,31 +505,19 @@ export async function appendStatusAllDiagnosis(params: {
     );
   }
 
-  const healthErr = (() => {
-    if (!params.health || typeof params.health !== "object") {
-      return "";
+  if (params.health) {
+    if ("error" in params.health) {
+      if (params.health.error) {
+        lines.push("");
+        lines.push(muted("Gateway health:"));
+        lines.push(`  ${muted(redactStatusSecrets(params.health.error))}`);
+      }
+    } else {
+      const deliveryQueueLine = formatDeliveryQueueHealthLine(params.health);
+      if (deliveryQueueLine) {
+        emitCheck(redactStatusSecrets(deliveryQueueLine), "warn");
+      }
     }
-    const record = params.health as Record<string, unknown>;
-    if (!("error" in record)) {
-      return "";
-    }
-    const value = record.error;
-    if (!value) {
-      return "";
-    }
-    if (typeof value === "string") {
-      return value;
-    }
-    try {
-      return JSON.stringify(value, null, 2);
-    } catch {
-      return "[unserializable error]";
-    }
-  })();
-  if (healthErr) {
-    lines.push("");
-    lines.push(muted("Gateway health:"));
-    lines.push(`  ${muted(redactStatusSecrets(healthErr))}`);
   }
 
   lines.push("");

--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -391,6 +391,50 @@ describe("status.command-sections", () => {
     });
   });
 
+  it("shows blocked ingress even when the channel connection is healthy", () => {
+    const rows = buildStatusHealthRows({
+      health: {
+        ok: true,
+        ts: 0,
+        durationMs: 42,
+        heartbeatSeconds: 60,
+        defaultAgentId: "main",
+        agents: [],
+        sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
+        channels: {},
+        channelOrder: [],
+        channelLabels: {},
+        deliveryQueues: {
+          failed: [],
+          ingressPressure: [
+            {
+              channelId: "telegram",
+              accountId: "ops",
+              laneCount: 1,
+              pendingCount: 2,
+              claimedCount: 0,
+              blockedCount: 1,
+              oldestReceivedAt: Date.now(),
+            },
+          ],
+        },
+      },
+      formatHealthChannelLines: () => ["Telegram: healthy"],
+      ok: (value) => `ok(${value})`,
+      warn: (value) => `warn(${value})`,
+      muted: (value) => `muted(${value})`,
+    });
+
+    expect(rows).toContainEqual({ Item: "Telegram", Status: "ok(OK)", Detail: "healthy" });
+    expect(rows).toContainEqual({
+      Item: "Delivery queue",
+      Status: "warn(WARN)",
+      Detail: expect.stringContaining(
+        "inbound telegram/ops: 1 pressured lane, 2 pending, 0 claimed, 1 blocked",
+      ),
+    });
+  });
+
   it("adds degraded event-loop health to status rows", () => {
     const rows = buildStatusHealthRows({
       health: {

--- a/src/commands/status.command-sections.ts
+++ b/src/commands/status.command-sections.ts
@@ -13,6 +13,7 @@ import { formatDurationCompact } from "../infra/format-time/format-duration.js";
 import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
 import type { Tone } from "../memory-host-sdk/status.js";
 import type { SessionStatus, StatusSummary } from "../status/types.js";
+import { formatDeliveryQueueHealthLine } from "./health-format.js";
 import type { HealthSummary } from "./health.js";
 import type { AgentLocalStatus } from "./status.agent-local.js";
 import type { MemoryStatusSnapshot, MemoryPluginStatus } from "./status.scan.shared.js";
@@ -268,7 +269,7 @@ export function buildStatusSecurityAuditLines(params: {
   return lines;
 }
 
-/** Builds health table rows from gateway health and channel health text. */
+/** Builds gateway, channel, and delivery queue health table rows. */
 export function buildStatusHealthRows(params: {
   health: HealthSummary;
   formatHealthChannelLines: (summary: HealthSummary, opts: { accountMode: "all" }) => string[];
@@ -290,7 +291,12 @@ export function buildStatusHealthRows(params: {
       Detail: formatEventLoopHealthDetail(params.health.eventLoop),
     });
   }
-  for (const line of params.formatHealthChannelLines(params.health, { accountMode: "all" })) {
+  const healthLines = params.formatHealthChannelLines(params.health, { accountMode: "all" });
+  const deliveryQueueLine = formatDeliveryQueueHealthLine(params.health);
+  if (deliveryQueueLine) {
+    healthLines.push(deliveryQueueLine);
+  }
+  for (const line of healthLines) {
     const colon = line.indexOf(":");
     if (colon === -1) {
       continue;
@@ -298,7 +304,7 @@ export function buildStatusHealthRows(params: {
     const item = line.slice(0, colon).trim();
     const detail = line.slice(colon + 1).trim();
     const normalized = normalizeLowercaseStringOrEmpty(detail);
-    // Channel health format is string-based; classify known prefixes into table status chips.
+    // Shared health text uses known prefixes to classify table status chips.
     const status =
       normalized === "healthy" || normalized.startsWith("ok") || normalized.startsWith("configured")
         ? params.ok("OK")


### PR DESCRIPTION
Related: #133984

## What Problem This Solves

Fixes an issue where `status --deep` and `status --all` could show a reachable Gateway and healthy channel while omitting an inbound delivery backlog already present in Gateway health.

## Why This Change Was Made

Move the existing delivery-queue formatter into the shared health-format module and use it on all three detailed diagnostic surfaces. Keep the formatter's transport-error dependency light and type the actual health response instead of serializing unknown error shapes.

## User Impact

Detailed status reports show pressured ingress lanes and dead-lettered deliveries alongside channel connectivity. Ordinary status gains no extra probe. Queue ordering, retries, retention, and repair behavior remain unchanged.

## Evidence

A real isolated baseline Gateway exposed one pressured lane, two pending messages, and one blocked message through health and deep JSON. All five CLI commands exited successfully, but deep/all text omitted the warning. The identical renderer diagnostic failed three assertions before the fix and passed all four afterward. Candidate replay of the same five commands passes: deep/all text now contains the warning and counts, health/deep JSON retain the same pressure, and Gateway shutdown exits 0. The replay uses the combined candidate build; the isolated renderer diagnostic attributes the output correction to this patch.

All 112 focused health/status tests pass. Gateway cleanup completed without remaining task processes. The pressure fixture uses synthetic local state; no Telegram or other channel message was sent.

Production LOC: net -4 after discounting the formatter move. Tests: net +100, including five existing formatter cases moved with their owner; docs: +5. The existing eight-attempt and 24-hour ingress policy is intentional and unchanged; this fixes visibility rather than the unconfirmed producer of the reported stalled turn.

Independent Codex autoreview found no actionable findings. The refactor also removes the obsolete one-assertion allowance from the assertion-safety baseline. The actual changed gate passed all 30 selected checks, including core and core-test types, core and tooling lint, import cycles, and remaining guards.

The first hosted CI run exposed an old Doctor test that forced the transport-error guard to accept an ordinary error. The fixture now constructs the real `GatewayTransportError`, removes the obsolete facade mock, and keeps the sanitized diagnostic assertion. This correction changes tests only. Formatting, typed lint, core-test types, all 35 formatter tests, and a direct real-error/formatter diagnostic pass; independent Codex review is clean. The full local Doctor run reached the runner's existing no-output limit before assertions and is recorded as incomplete. Hosted CI on `e55f374` subsequently passed the corrected Doctor case, its restart sibling, and the entire Doctor group (5 files, 171 tests).

The latest ClawSweeper review has no code findings and asks for completed exact-head CI and ordinary maintainer handling. Its automated stored-data-model warning does not apply: `diagnosis.ts` only projects an existing `HealthSummary` into report text. This PR has no schema, stored-state, migration, retention, or recovery change.

The prior remaining hosted failure was the shared release-inventory `git ls-tree` output overflow. This branch is rebased onto the canonical repair in #134824 (`eaaa6da`); both PR commits remain patch-identical. Full CI on rebased head `f6b824f8b4d` passed: 222 successful checks, one neutral result, 45 skips, and none pending or failing. This satisfies the latest ClawSweeper rank-up request for green exact-head CI. No status or health assertion failed on the corrected pre-rebase head.
