### PR TITLE
fix: reduce retained Gateway and Activity memory

### DIFF
--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -16,6 +16,7 @@ import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-run
 import { configureMemoryCoreDreamingState } from "./src/dreaming-state.js";
 import { registerShortTermPromotionDreaming } from "./src/dreaming.js";
 import { buildMemoryFlushPlan } from "./src/flush-plan.js";
+import "./src/memory/background-context.js";
 import {
   buildMemoryPromptSection,
   MEMORY_GET_TOOL_CONTRACT,

--- a/extensions/memory-core/src/memory/background-context.ts
+++ b/extensions/memory-core/src/memory/background-context.ts
@@ -1,0 +1,6 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+// The plugin entry loads this before Gateway turns are admitted, while managers
+// load lazily. Background resources must not retain the turn that opens a
+// manager or publishes a transcript update.
+export const runInMemoryBackgroundContext = AsyncLocalStorage.snapshot();

--- a/extensions/memory-core/src/memory/manager-session-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-ops.ts
@@ -22,6 +22,7 @@ import {
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-paths";
 import { listMemorySessionTombstones } from "../memory-entry-origins.js";
+import { runInMemoryBackgroundContext } from "./background-context.js";
 import { shouldSyncSessionsForReindex } from "./manager-session-reindex.js";
 import {
   isMemorySessionIndexable,
@@ -131,21 +132,23 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
     if (!this.sources.has("sessions") || this.sessionUnsubscribe) {
       return;
     }
-    this.sessionUnsubscribe = this.subscribeSessionTranscriptUpdates((update) => {
-      if (this.closed) {
-        return;
-      }
-      const target = this.resolveSessionTranscriptUpdateSyncTarget(update);
-      if (target) {
-        this.scheduleSessionDirty(target);
-        return;
-      }
-      if (update.sessionFile) {
-        void this.scheduleCorpusSessionFileDirty(update.sessionFile).catch((err: unknown) => {
-          log.warn(`memory session corpus update failed: ${String(err)}`);
-        });
-      }
-    });
+    this.sessionUnsubscribe = this.subscribeSessionTranscriptUpdates((update) =>
+      runInMemoryBackgroundContext(() => {
+        if (this.closed) {
+          return;
+        }
+        const target = this.resolveSessionTranscriptUpdateSyncTarget(update);
+        if (target) {
+          this.scheduleSessionDirty(target);
+          return;
+        }
+        if (update.sessionFile) {
+          void this.scheduleCorpusSessionFileDirty(update.sessionFile).catch((err: unknown) => {
+            log.warn(`memory session corpus update failed: ${String(err)}`);
+          });
+        }
+      }),
+    );
   }
 
   protected subscribeSessionTranscriptUpdates(

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test-support.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test-support.ts
@@ -1,8 +1,10 @@
 // Shared harness and fixtures for manager sync-ops startup catch-up tests.
+import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import type {
-  OpenClawConfig,
-  ResolvedMemorySearchConfig,
+import {
+  resolveStateDir,
+  type OpenClawConfig,
+  type ResolvedMemorySearchConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
   MEMORY_CHUNKING_VERSION,
@@ -133,6 +135,7 @@ export class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
     },
     provider: "none",
     store: {
+      databasePath: path.join(resolveStateDir(), "memory-index.sqlite"),
       fts: {
         tokenizer: "unicode61",
       },

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -1,4 +1,5 @@
 // Memory Core tests cover manager sync ops.startup-catchup plugin behavior.
+import { AsyncLocalStorage } from "node:async_hooks";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -647,18 +648,38 @@ describe("session startup catch-up", () => {
     vi.useFakeTimers();
     const session = await writeSqliteSession();
     const harness = new SessionStartupCatchupHarness([], true, true);
-    harness.startTranscriptListener();
+    const turnContext = new AsyncLocalStorage<string>();
+    const pendingInputContext = new AsyncLocalStorage<string>();
+    turnContext.run("opening turn", () => harness.startTranscriptListener());
+    const timerContexts: Array<{ turn?: string; pendingInput?: string }> = [];
+    const originalSetTimeout = globalThis.setTimeout;
+    const timerObserver = vi.spyOn(globalThis, "setTimeout").mockImplementation((...args) => {
+      if (args[1] === 5000) {
+        timerContexts.push({
+          turn: turnContext.getStore(),
+          pendingInput: pendingInputContext.getStore(),
+        });
+      }
+      return originalSetTimeout(...args);
+    });
 
     try {
-      await appendSessionTranscriptMessageByIdentity({
-        agentId: "main",
-        sessionId: session.sessionId,
-        sessionKey: session.sessionKey,
-        storePath: session.storePath,
-        cwd: stateDir,
-        message: { role: "assistant", content: "persisted listener update" },
-      });
-      await publishSessionTranscriptUpdateByIdentity(session);
+      await turnContext.run("later turn", () =>
+        pendingInputContext.run("later input", async () => {
+          await appendSessionTranscriptMessageByIdentity({
+            agentId: "main",
+            sessionId: session.sessionId,
+            sessionKey: session.sessionKey,
+            storePath: session.storePath,
+            cwd: stateDir,
+            message: { role: "assistant", content: "persisted listener update" },
+          });
+          await publishSessionTranscriptUpdateByIdentity(session);
+          expect(turnContext.getStore()).toBe("later turn");
+          expect(pendingInputContext.getStore()).toBe("later input");
+        }),
+      );
+      expect(timerContexts).toEqual([{ turn: undefined, pendingInput: undefined }]);
 
       await vi.advanceTimersByTimeAsync(6000);
       await harness.waitForSessionSync();
@@ -669,6 +690,7 @@ describe("session startup catch-up", () => {
       ]);
     } finally {
       harness.stopTranscriptListener();
+      timerObserver.mockRestore();
     }
   });
 

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -19,6 +19,7 @@ import {
   type MemorySyncParams,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
+import { runInMemoryBackgroundContext } from "./background-context.js";
 import type { MemoryCoreAcquireLocalService } from "./embedding-local-service.js";
 import type { EmbeddingProvider, EmbeddingProviderRequest } from "./embeddings.js";
 import { awaitPendingManagerWork } from "./manager-async-state.js";
@@ -235,11 +236,6 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
         (initialIndexIdentity.status === "missing" && this.sources.has("memory"));
       const transient =
         params.purpose === "status" || params.purpose === "cli" || params.purpose === "maintenance";
-      if (!transient) {
-        this.ensureWatcher();
-        this.ensureSessionListener();
-        this.ensureIntervalSync();
-      }
       const invalidatedSources = new Set(
         (
           this.db
@@ -266,7 +262,12 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       }
       this.batch = this.resolveBatchConfig();
       if (!transient) {
-        this.ensureSessionStartupCatchup();
+        runInMemoryBackgroundContext(() => {
+          this.ensureWatcher();
+          this.ensureSessionListener();
+          this.ensureIntervalSync();
+          this.ensureSessionStartupCatchup();
+        });
       }
     } catch (err) {
       closeMemoryDatabase(this.db);

--- a/extensions/memory-core/src/memory/manager.watcher-filesystem.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-filesystem.test.ts
@@ -1,10 +1,13 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import nativeFs from "node:fs";
 import fs from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import { MEMORY_INDEX_CHUNKS_TABLE } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { createOpenClawTestState } from "openclaw/plugin-sdk/test-state";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   configureMemoryCoreDreamingStateForTests,
   resetMemoryCoreDreamingStateForTests,
@@ -21,6 +24,30 @@ describe("memory watchers on the real filesystem", () => {
     async (operation) => {
       const state = await createOpenClawTestState({ label: "memory-watch-filesystem" });
       const initialWatchers = activeFilesystemWatchers();
+      const turnContext = new AsyncLocalStorage<string>();
+      const pendingInputContext = new AsyncLocalStorage<string>();
+      const watcherContexts: Array<{ turn?: string; pendingInput?: string }> = [];
+      const timerContexts: typeof watcherContexts = [];
+      const originalWatch = nativeFs.watch;
+      const watchObserver = vi.spyOn(nativeFs, "watch").mockImplementation((...args) => {
+        watcherContexts.push({
+          turn: turnContext.getStore(),
+          pendingInput: pendingInputContext.getStore(),
+        });
+        return originalWatch(...args);
+      });
+      syncBuiltinESMExports();
+      const originalSetTimeout = globalThis.setTimeout;
+      const timerObserver = vi.spyOn(globalThis, "setTimeout").mockImplementation((...args) => {
+        // Observe the real startup pressure check and filesystem debounce timers.
+        if (args[1] === 10_000 || args[1] === 1500) {
+          timerContexts.push({
+            turn: turnContext.getStore(),
+            pendingInput: pendingInputContext.getStore(),
+          });
+        }
+        return originalSetTimeout(...args);
+      });
       let manager: MemoryIndexManager | null = null;
       let index: DatabaseSync | undefined;
       try {
@@ -42,7 +69,14 @@ describe("memory watchers on the real filesystem", () => {
             },
           },
         };
-        manager = await MemoryIndexManager.get({ cfg, agentId: "main" });
+        manager = await turnContext.run("opening turn", () =>
+          pendingInputContext.run("accepted input", async () => {
+            const opened = await MemoryIndexManager.get({ cfg, agentId: "main" });
+            expect(turnContext.getStore()).toBe("opening turn");
+            expect(pendingInputContext.getStore()).toBe("accepted input");
+            return opened;
+          }),
+        );
         if (!manager) {
           throw new Error("memory manager unavailable");
         }
@@ -93,6 +127,11 @@ describe("memory watchers on the real filesystem", () => {
         ]);
         expect(await activeManager.search("Amethyst")).toEqual([]);
         expect(await activeManager.search("Cobalt")).toEqual([]);
+        expect(watcherContexts.length).toBeGreaterThan(0);
+        expect(timerContexts.length).toBeGreaterThan(0);
+        for (const context of [...watcherContexts, ...timerContexts]) {
+          expect(context).toEqual({ turn: undefined, pendingInput: undefined });
+        }
 
         index.close();
         index = undefined;
@@ -101,6 +140,9 @@ describe("memory watchers on the real filesystem", () => {
       } finally {
         index?.close();
         await manager?.close();
+        timerObserver.mockRestore();
+        watchObserver.mockRestore();
+        syncBuiltinESMExports();
         resetMemoryCoreDreamingStateForTests();
         await state.cleanup();
       }

--- a/src/agents/agent-bundle-mcp-manager-lifecycle.ts
+++ b/src/agents/agent-bundle-mcp-manager-lifecycle.ts
@@ -1,4 +1,5 @@
 /** Session MCP runtime manager lifecycle: maps, idle sweep, dispose, advertised catalog. */
+import { AsyncLocalStorage } from "node:async_hooks";
 import { logWarn } from "../logger.js";
 import {
   DEFAULT_SESSION_MCP_RUNTIME_IDLE_TTL_MS,
@@ -13,6 +14,10 @@ import type {
   RequesterScopedMcpRuntimeHandle,
   SessionMcpRuntime,
 } from "./agent-bundle-mcp-types.js";
+
+// Gateway shutdown preparation and CLI command imports load this before turns.
+// The process-owned sweep must not retain its first requesting turn.
+const runInMcpManagerContext = AsyncLocalStorage.snapshot();
 
 type ManagerCreateInFlight = {
   promise: Promise<SessionMcpRuntime>;
@@ -279,7 +284,9 @@ export function createSessionMcpRuntimeManagerLifecycle(
     if (!store.enableIdleSweepTimer || store.idleSweepIntervalMs <= 0 || store.idleSweepTimer) {
       return;
     }
-    store.idleSweepTimer = setInterval(queueIdleSweep, store.idleSweepIntervalMs);
+    store.idleSweepTimer = runInMcpManagerContext(() =>
+      setInterval(queueIdleSweep, store.idleSweepIntervalMs),
+    );
     store.idleSweepTimer.unref?.();
   };
 

--- a/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
+++ b/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
@@ -1,8 +1,12 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { createSessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.js";
-import type { CreateSessionMcpRuntime } from "./agent-bundle-mcp-runtime-shared.js";
+import {
+  SESSION_MCP_RUNTIME_SWEEP_INTERVAL_MS,
+  type CreateSessionMcpRuntime,
+} from "./agent-bundle-mcp-runtime-shared.js";
 import type { SessionMcpRuntime, SessionMcpRuntimeManager } from "./agent-bundle-mcp-types.js";
 import { testing as resolverTesting } from "./mcp-connection-resolver.js";
 
@@ -108,6 +112,63 @@ describe("MCP manager creation ownership", () => {
 
     expect(manager.listRuntimeKeys()).toEqual([]);
   });
+
+  it.each(["static", "requester"] as const)(
+    "keeps the native idle timer outside %s requesting turns across disposal",
+    async (entrypoint) => {
+      const turnContext = new AsyncLocalStorage<string>();
+      const pendingInputContext = new AsyncLocalStorage<string>();
+      const readContext = () => ({
+        turn: turnContext.getStore(),
+        pendingInput: pendingInputContext.getStore(),
+      });
+      const timerContexts: ReturnType<typeof readContext>[] = [];
+      const factoryContexts: ReturnType<typeof readContext>[] = [];
+      const nativeSetInterval = globalThis.setInterval;
+      const intervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation((...args) => {
+        if (args[1] === SESSION_MCP_RUNTIME_SWEEP_INTERVAL_MS) {
+          timerContexts.push(readContext());
+        }
+        return nativeSetInterval(...args);
+      });
+      const manager = createSessionMcpRuntimeManager({
+        createRuntime(input) {
+          factoryContexts.push(readContext());
+          return createRuntimeFixture(input);
+        },
+      });
+      managers.push(manager);
+      resolverTesting.setMcpServerConnectionResolversForTest([
+        { serverName: "scoped", resolve: async () => ({ url: "https://mcp.example.test/scoped" }) },
+      ]);
+
+      try {
+        for (const turn of ["first turn", "later turn"]) {
+          const pendingInput = `${turn} input`;
+          await turnContext.run(turn, () =>
+            pendingInputContext.run(pendingInput, async () => {
+              if (entrypoint === "static") {
+                await manager.getOrCreate(params);
+              } else {
+                await manager.getOrCreateRequesterScoped({
+                  ...params,
+                  requesterSenderId: "sender",
+                  cfg: { mcp: { servers: { scoped: { transport: "streamable-http" } } } },
+                });
+              }
+              expect(readContext()).toEqual({ turn, pendingInput });
+            }),
+          );
+          expect(factoryContexts.splice(0)).toEqual([{ turn, pendingInput }]);
+          expect(timerContexts.splice(0)).toEqual([{ turn: undefined, pendingInput: undefined }]);
+          await manager.disposeAll();
+        }
+      } finally {
+        await manager.disposeAll();
+        intervalSpy.mockRestore();
+      }
+    },
+  );
 
   it.each(["session", "all"] as const)(
     "drains late creation during %s disposal without publishing or clearing a successor",

--- a/src/auto-reply/reply/commands-diagnostics.test.ts
+++ b/src/auto-reply/reply/commands-diagnostics.test.ts
@@ -1,12 +1,16 @@
 // Tests diagnostics command output and runtime diagnostic toggles.
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import * as sessionAccessor from "../../config/sessions/session-accessor.js";
 import { clearPluginCommands, registerPluginCommand } from "../../plugins/commands.js";
 import { createPluginRegistry } from "../../plugins/registry.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
 import { createBundledPluginRecord } from "../../plugins/status.test-fixtures.js";
 import type { OpenClawPluginCommandDefinition, PluginCommandContext } from "../../plugins/types.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 
 type PluginCommandHandler = OpenClawPluginCommandDefinition["handler"];
@@ -480,6 +484,56 @@ describe("diagnostics command", () => {
     expect(requireExecCall(execCalls).defaults.approvalWarningText).toContain(
       "OpenAI Codex harness:",
     );
+  });
+
+  it("loads diagnostics inventory after authorization when the reply view contains one row", async () => {
+    await withOpenClawTestState({ label: "diagnostics-session-inventory" }, async (state) => {
+      const storePath = path.join(state.sessionsDir("main"), "sessions.json");
+      const sessionKey = "agent:main:whatsapp:direct:user-1";
+      const otherKey = "agent:main:discord:channel:123";
+      const current = { sessionId: "active-session", updatedAt: Date.now() };
+      await upsertSessionEntryCore({ agentId: "main", sessionKey, storePath }, current);
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey: otherKey, storePath },
+        {
+          sessionId: "other-session",
+          updatedAt: Date.now(),
+          agentHarnessId: "codex",
+          delivery: normalizeSessionDeliveryState({ context: { channel: "discord" } }),
+          skillsSnapshot: { prompt: "unrelated diagnostics prompt ".repeat(4096), skills: [] },
+        },
+      );
+      const { calls } = registerCodexDiagnosticsCommandForTest(async () => null);
+      const { handleDiagnosticsCommand } = createDiagnosticsHandlerForTest();
+      const params = buildDiagnosticsParams("/diagnostics", {
+        agentId: "main",
+        sessionKey,
+        sessionEntry: current,
+        sessionStore: { [sessionKey]: current },
+        storePath,
+      });
+      const reads = vi.spyOn(sessionAccessor, "listSessionEntriesReadOnly");
+      try {
+        await handleDiagnosticsCommand(
+          { ...params, command: { ...params.command, senderIsOwner: false } },
+          true,
+        );
+        expect(reads).not.toHaveBeenCalled();
+        expect(calls).toHaveLength(0);
+        await handleDiagnosticsCommand(params, true);
+        expect(requireDiagnosticsSessions(calls[0])).toEqual([
+          expect.objectContaining({ sessionKey, sessionId: "active-session" }),
+          expect.objectContaining({
+            sessionKey: otherKey,
+            sessionId: "other-session",
+            agentHarnessId: "codex",
+            channel: "discord",
+          }),
+        ]);
+      } finally {
+        reads.mockRestore();
+      }
+    });
   });
 
   it("omits the Codex section for ordinary sessions without Codex targets", async () => {

--- a/src/auto-reply/reply/commands-diagnostics.ts
+++ b/src/auto-reply/reply/commands-diagnostics.ts
@@ -4,6 +4,7 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { createExecTool } from "../../agents/bash-tools.js";
 import type { ExecToolDetails } from "../../agents/bash-tools.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { listSessionEntriesReadOnly } from "../../config/sessions/session-accessor.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { ExecApprovalRequest } from "../../infra/exec-approvals.js";
@@ -105,13 +106,30 @@ async function handleDiagnosticsCommandWithDeps(
   if (nonOwner) {
     return nonOwner;
   }
+  // Inventory belongs to this authorized command, not every reply's retained
+  // session view. Metadata preserves Codex target discovery without prompt snapshots.
+  const commandParams = params.storePath
+    ? {
+        ...params,
+        sessionStore: {
+          ...Object.fromEntries(
+            listSessionEntriesReadOnly({
+              agentId: params.agentId,
+              storePath: params.storePath,
+              projection: "list",
+            }).map(({ sessionKey, entry }) => [sessionKey, entry]),
+          ),
+          ...params.sessionStore,
+        },
+      }
+    : params;
   if (isCodexDiagnosticsConfirmationAction(args)) {
-    const codexResult = await executeCodexDiagnosticsAddon(params, args);
+    const codexResult = await executeCodexDiagnosticsAddon(commandParams, args);
     const reply = codexResult
       ? rewriteCodexDiagnosticsResult(codexResult)
       : { text: "No Codex diagnostics confirmation handler is available for this session." };
-    if (params.isGroup) {
-      return await deliverGroupDiagnosticsReplyPrivately(deps, params, reply);
+    if (commandParams.isGroup) {
+      return await deliverGroupDiagnosticsReplyPrivately(deps, commandParams, reply);
     }
     return {
       shouldContinue: false,
@@ -119,15 +137,15 @@ async function handleDiagnosticsCommandWithDeps(
     };
   }
 
-  if (params.isGroup) {
-    const privateTarget = (await deps.resolvePrivateDiagnosticsTargets(params))[0];
+  if (commandParams.isGroup) {
+    const privateTarget = (await deps.resolvePrivateDiagnosticsTargets(commandParams))[0];
     if (!privateTarget) {
       return {
         shouldContinue: false,
         reply: { text: DIAGNOSTICS_PRIVATE_ROUTE_UNAVAILABLE },
       };
     }
-    const privateReply = await buildDiagnosticsReply(deps, params, args, {
+    const privateReply = await buildDiagnosticsReply(deps, commandParams, args, {
       diagnosticsPrivateRouted: true,
       privateApprovalTarget: privateTarget,
     });
@@ -137,10 +155,15 @@ async function handleDiagnosticsCommandWithDeps(
         reply: { text: DIAGNOSTICS_PRIVATE_ROUTE_ACK },
       };
     }
-    return await deliverGroupDiagnosticsReplyPrivately(deps, params, privateReply, privateTarget);
+    return await deliverGroupDiagnosticsReplyPrivately(
+      deps,
+      commandParams,
+      privateReply,
+      privateTarget,
+    );
   }
 
-  const reply = await buildDiagnosticsReply(deps, params, args);
+  const reply = await buildDiagnosticsReply(deps, commandParams, args);
   return reply ? { shouldContinue: false, reply } : { shouldContinue: false };
 }
 

--- a/src/auto-reply/reply/get-reply-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-fast-path.ts
@@ -5,14 +5,12 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeChatType } from "../../channels/chat-type.js";
+import { resolveSessionParentSessionKey } from "../../channels/plugins/session-conversation.js";
 import { normalizeAnyChannelId } from "../../channels/registry.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
 import { resolveResetPreservedSelection } from "../../config/sessions/reset-preserved-selection.js";
-import {
-  loadSessionEntry,
-  listSessionEntriesCore,
-} from "../../config/sessions/session-accessor.js";
+import { loadReplySessionInitializationSnapshot } from "../../config/sessions/session-accessor.js";
 import { buildSessionCreationStamp } from "../../config/sessions/session-entry-provenance.js";
 import { resolveSessionKey } from "../../config/sessions/session-key.js";
 import {
@@ -191,13 +189,26 @@ export function initFastReplySessionState(params: {
     agentId,
   });
   const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId });
-  const sessionStore: Record<string, SessionEntry> = Object.fromEntries(
-    listSessionEntriesCore({ storePath }).map(({ sessionKey: entryKey, entry }) => [
-      entryKey,
-      entry,
-    ]),
-  );
-  const existingEntry = loadSessionEntry({ storePath, sessionKey });
+  const relatedSessionKeys = [
+    ctx.ParentSessionKey,
+    ctx.ModelParentSessionKey,
+    ctx.CommandTargetSessionKey,
+    resolveSessionParentSessionKey(sessionKey),
+  ].filter((key): key is string => typeof key === "string");
+  const snapshot = loadReplySessionInitializationSnapshot({
+    agentId,
+    storePath,
+    sessionKey,
+    relatedSessionKeys,
+  });
+  const existingEntry = snapshot.currentEntry;
+  const sessionStore: Record<string, SessionEntry> = {};
+  for (const key of [...relatedSessionKeys, existingEntry?.parentSessionKey]) {
+    const entry = key ? snapshot.readEntry(key) : undefined;
+    if (key && entry) {
+      sessionStore[key] = entry;
+    }
+  }
   const commandSource = ctx.commandText ?? "";
   const normalizedChatType = normalizeChatType(ctx.ChatType);
   const isGroup = normalizedChatType != null && normalizedChatType !== "direct";

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -216,6 +216,36 @@ describe("resolveReplySessionPreprocessingState", () => {
     });
   }
 
+  it("resolves key-less preprocessing using the configured agent and main key", async () => {
+    const storePath = await createStorePath("openclaw-keyless-preprocessing-");
+    const configuredSessionKey = "agent:ops:work";
+    await upsertSessionEntryCore(
+      { agentId: "ops", sessionKey: configuredSessionKey, storePath },
+      { sessionId: "keyless-preprocessing", updatedAt: Date.now() },
+    );
+
+    expect(
+      resolveReplySessionPreprocessingState({
+        cfg: {
+          agents: { list: [{ id: "ops", default: true }] },
+          session: { store: storePath, mainKey: "work" },
+        },
+        ctx: finalizeInboundContext({
+          Body: "Please inspect https://example.org/sample",
+          From: "synthetic-sender",
+          To: "bot",
+          ChatType: "direct",
+          Provider: "webchat",
+          Surface: "webchat",
+        }),
+      }),
+    ).toMatchObject({
+      sessionKey: configuredSessionKey,
+      storePath,
+      sessionEntry: { sessionId: "keyless-preprocessing" },
+    });
+  });
+
   it("returns the valid durable harness owner lock before preprocessing", async () => {
     const storePath = await createStorePath("openclaw-media-preflight-valid-");
     await writeSessionStoreFast(storePath, {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -11,6 +11,7 @@ import { clearAllCliSessions, getCliSessionBinding } from "../../agents/cli-sess
 import { resetRegisteredAgentHarnessSessions } from "../../agents/harness/registry.js";
 import { cleanupBrowserSessionsForLifecycleEnd } from "../../browser-lifecycle-cleanup.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
+import { resolveSessionParentSessionKey } from "../../channels/plugins/session-conversation.js";
 import { conversationRouteContextFromMsgContext } from "../../config/sessions/conversation-route-context.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
 import {
@@ -363,6 +364,7 @@ export function resolveReplySessionPreprocessingState(
       params.cfg.session?.scope ?? "per-sender",
       attemptContext.sessionCtxForState,
       normalizeMainKey(params.cfg.session?.mainKey),
+      attemptContext.agentId,
     ),
   });
   const sessionEntry = loadReplySessionInitializationSnapshot({
@@ -584,10 +586,18 @@ async function initSessionStateAttemptLocked(
   // mtime granularity may miss rapid writes) can cause incorrect sessionId
   // generation, leading to orphaned transcript files. See #17971.
   const sessionStoreLoadStartMs = ingressTimingEnabled ? Date.now() : 0;
+  const relatedSessionKeys = [
+    buildAgentMainSessionKey({ agentId, mainKey }),
+    ctx.ParentSessionKey,
+    ctx.ModelParentSessionKey,
+    ctx.CommandTargetSessionKey,
+    resolveSessionParentSessionKey(sessionKey),
+  ].filter((key): key is string => typeof key === "string");
   const initializationSnapshot = loadReplySessionInitializationSnapshot({
     agentId,
     storePath,
     sessionKey,
+    relatedSessionKeys,
   });
   if (ingressTimingEnabled) {
     log.info(
@@ -1015,6 +1025,7 @@ async function initSessionStateAttemptLocked(
     agentId,
     archivePreviousTranscript: false,
     expectedRevision: initializationSnapshot.revision,
+    relatedSessionKeys,
     maintenanceConfig,
     onArchiveError: (error, sourcePath) => {
       log.warn(

--- a/src/config/sessions/session-accessor.entry-mutation.ts
+++ b/src/config/sessions/session-accessor.entry-mutation.ts
@@ -214,11 +214,7 @@ export function mergeConcurrentReplySessionMetadata(params: {
   return merged;
 }
 
-export function createReplySessionInitializationRevision(params: {
-  entry: SessionEntry | undefined;
-  storePath: string;
-}): string {
-  const { entry } = params;
+export function createReplySessionInitializationRevision(entry: SessionEntry | undefined): string {
   if (!entry) {
     return JSON.stringify(null);
   }
@@ -226,15 +222,6 @@ export function createReplySessionInitializationRevision(params: {
   // activity/context writes are merged below; comparing them here would reject
   // before the merge can preserve the concurrent metadata.
   return JSON.stringify({ sessionId: entry.sessionId });
-}
-
-export function resolveInitializedReplySessionEntry(params: {
-  agentId: string;
-  currentEntry?: SessionEntry;
-  sessionEntry: SessionEntry;
-  storePath: string;
-}): SessionEntry {
-  return params.sessionEntry;
 }
 
 /** Updates an existing entry only; returns null when the session is absent. */

--- a/src/config/sessions/session-accessor.lifecycle-types.ts
+++ b/src/config/sessions/session-accessor.lifecycle-types.ts
@@ -156,7 +156,6 @@ export type SessionEntryLifecycleUpsert = {
       buildEntry: (context: {
         currentEntry?: SessionEntry;
         sessionKey: string;
-        store: Record<string, SessionEntry>;
       }) => Promise<SessionEntry | null | undefined> | SessionEntry | null | undefined;
       entry?: never;
     }

--- a/src/config/sessions/session-accessor.reply-init-selection.test.ts
+++ b/src/config/sessions/session-accessor.reply-init-selection.test.ts
@@ -1,0 +1,153 @@
+import path from "node:path";
+import { expect, it, vi } from "vitest";
+import * as sqliteQueries from "../../infra/kysely-sync.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import {
+  applySessionEntryLifecycleMutation,
+  commitReplySessionInitialization,
+  loadReplySessionInitializationSnapshot,
+  loadSessionEntry,
+  upsertSessionEntryCore,
+} from "./session-accessor.js";
+import type { SessionEntry } from "./types.js";
+
+it("retains only declared reply rows and their stored model parent at each snapshot", async () => {
+  await withOpenClawTestState({ label: "reply-row-selection" }, async (state) => {
+    const sessionKey = "agent:main:reply";
+    const parentKey = "agent:main:matrix:group:!Parent:example.org";
+    const storedParentKey = "agent:main:stored-parent";
+    const unrelatedKey = "agent:main:matrix:group:!parent:example.org";
+    const relatedSessionKeys = [
+      "agent:main:main",
+      parentKey,
+      "agent:main:model-parent",
+      "agent:main:command-target",
+      "agent:main:missing",
+    ];
+    const storePath = path.join(state.sessionsDir("main"), "sessions.json");
+    const scope = { agentId: "main", sessionKey, storePath, relatedSessionKeys };
+    const now = Date.now();
+    const current = { sessionId: "reply", updatedAt: now, parentSessionKey: storedParentKey };
+    const unrelated = {
+      sessionId: "unrelated",
+      updatedAt: now,
+      skillsSnapshot: { prompt: "unrelated prompt ".repeat(4096), skills: [] },
+    };
+    for (const [key, entry] of [
+      [sessionKey, current],
+      [storedParentKey, { sessionId: "stored-parent", updatedAt: now }],
+      [unrelatedKey, unrelated],
+      ...relatedSessionKeys
+        .slice(0, -1)
+        .map((relatedKey, index) => [
+          relatedKey,
+          { sessionId: `related-${index}`, updatedAt: now, label: "before snapshot" },
+        ]),
+    ] as Array<[string, SessionEntry]>) {
+      await upsertSessionEntryCore({ ...scope, sessionKey: key }, entry);
+    }
+
+    const persistedCurrent = loadSessionEntry(scope)!;
+    const persistedUnrelated = loadSessionEntry({ ...scope, sessionKey: unrelatedKey });
+    const snapshot = loadReplySessionInitializationSnapshot(scope);
+    expect(snapshot.currentEntry).toEqual(persistedCurrent);
+    expect(snapshot.readEntry(storedParentKey)?.sessionId).toBe("stored-parent");
+    expect(snapshot.readEntry(unrelatedKey)).toBeUndefined();
+    expect(snapshot.readEntry("agent:main:missing")).toBeUndefined();
+
+    const parentScope = { ...scope, sessionKey: parentKey };
+    const parent = snapshot.readEntry(parentKey)!;
+    await upsertSessionEntryCore(parentScope, { ...parent, label: "before commit" });
+    expect(snapshot.readEntry(parentKey)?.label).toBe("before snapshot");
+
+    const committed = await commitReplySessionInitialization({
+      ...scope,
+      activeSessionKey: sessionKey,
+      archivePreviousTranscript: false,
+      expectedRevision: snapshot.revision,
+      sessionEntry: persistedCurrent,
+      prepareSessionEntry: async ({ readEntry, sessionEntry }) => {
+        expect(readEntry(parentKey)?.label).toBe("before commit");
+        await upsertSessionEntryCore(parentScope, { ...parent, label: "after commit snapshot" });
+        expect(readEntry(parentKey)?.label).toBe("before commit");
+        return sessionEntry;
+      },
+    });
+    expect(committed.ok).toBe(true);
+    if (!committed.ok) {
+      throw new Error("reply initialization unexpectedly conflicted");
+    }
+    expect(Object.keys(committed.sessionStoreView).toSorted()).toEqual(
+      [sessionKey, storedParentKey, ...relatedSessionKeys.slice(0, -1)].toSorted(),
+    );
+    expect(committed.sessionStoreView[parentKey]?.label).toBe("before commit");
+    expect(loadSessionEntry(parentScope)?.label).toBe("after commit snapshot");
+    expect(loadSessionEntry({ ...scope, sessionKey: unrelatedKey })).toEqual(persistedUnrelated);
+  });
+});
+
+it.each(["upsert", "removal"] as const)(
+  "projects a lifecycle %s without acquiring unrelated prompt payloads",
+  async (operation) => {
+    await withOpenClawTestState({ label: `lifecycle-selected-${operation}` }, async (state) => {
+      const scope = {
+        agentId: "main",
+        sessionKey: "agent:main:selected",
+        storePath: path.join(state.sessionsDir("main"), "sessions.json"),
+      };
+      const current = { sessionId: "selected", updatedAt: Date.now(), label: "original" };
+      const unrelatedScope = { ...scope, sessionKey: "agent:main:unrelated" };
+      const prompt = "unrelated lifecycle prompt ".repeat(4096);
+      await upsertSessionEntryCore(scope, current);
+      await upsertSessionEntryCore(unrelatedScope, {
+        sessionId: "unrelated",
+        updatedAt: Date.now(),
+        skillsSnapshot: { prompt, skills: [] },
+      });
+      // The connection's one-time canonical check is separate from per-mutation projection.
+      const persistedCurrent = loadSessionEntry(scope)!;
+      const iterate = sqliteQueries.iterateSqliteQuerySync;
+      let acquiredPromptRows = 0;
+      const reads = vi.spyOn(sqliteQueries, "iterateSqliteQuerySync").mockImplementation(function* <
+        Row,
+      >(...args: Parameters<typeof sqliteQueries.iterateSqliteQuerySync<Row>>) {
+        for (const row of iterate<Row>(...args)) {
+          if (
+            row !== null &&
+            typeof row === "object" &&
+            "entry_json" in row &&
+            typeof row.entry_json === "string" &&
+            row.entry_json.includes(prompt)
+          ) {
+            acquiredPromptRows += 1;
+          }
+          yield row;
+        }
+      });
+      try {
+        await applySessionEntryLifecycleMutation({
+          ...scope,
+          skipMaintenance: true,
+          ...(operation === "removal"
+            ? { removals: [{ sessionKey: scope.sessionKey, expectedEntry: persistedCurrent }] }
+            : {
+                upserts: [
+                  {
+                    sessionKey: scope.sessionKey,
+                    buildEntry: ({ currentEntry }) => {
+                      expect(currentEntry).toEqual(persistedCurrent);
+                      return { ...currentEntry!, label: "updated" };
+                    },
+                  },
+                ],
+              }),
+        });
+      } finally {
+        reads.mockRestore();
+      }
+      expect(acquiredPromptRows).toBe(0);
+      expect(loadSessionEntry(unrelatedScope)?.skillsSnapshot?.prompt).toBe(prompt);
+      expect(loadSessionEntry(scope)?.label).toBe(operation === "removal" ? undefined : "updated");
+    });
+  },
+);

--- a/src/config/sessions/session-accessor.reset.ts
+++ b/src/config/sessions/session-accessor.reset.ts
@@ -1,35 +1,35 @@
+import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
 import {
   isIncognitoSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../../routing/session-key.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { ConversationRouteContext } from "./conversation-route-context.js";
 import {
   cloneSessionEntries,
   mergeConcurrentReplySessionMetadata,
   createReplySessionInitializationRevision,
-  resolveInitializedReplySessionEntry,
 } from "./session-accessor.entry-mutation.js";
-import {
-  listSessionEntriesCore,
-  listSessionEntriesReadOnly,
-  loadSessionEntry,
-  resolveSessionEntryFromStore,
-} from "./session-accessor.entry.js";
+import { loadSessionEntry, resolveSessionEntryFromStore } from "./session-accessor.entry.js";
 import {
   SessionEntryLifecycleUpsertConflictError,
   type SessionEntryLifecycleUpsert,
 } from "./session-accessor.lifecycle-types.js";
 import { applySessionEntryLifecycleMutation } from "./session-accessor.lifecycle.js";
+import { readExactSessionEntryRow } from "./session-accessor.sqlite-entry-store.js";
+import { resolveSqliteScope, toDatabaseOptions } from "./session-accessor.sqlite-scope.js";
 import type {
   SessionLifecycleTranscriptInfo,
   ReplySessionInitializationSnapshot,
   ReplySessionInitializationCommitContext,
   ReplySessionInitializationCommitResult,
 } from "./session-accessor.types.js";
+import { assertCanonicalSqliteSessionKeysCurrent } from "./session-canonical-key.js";
 import type { SessionResetBoundaryRequest } from "./session-reset-boundary-event.js";
 import { resolveSessionStorePathForScope } from "./session-store-path.js";
+import { normalizeStoreSessionKey } from "./store-entry.js";
 import type {
   ResolvedSessionMaintenanceConfig,
   SessionMaintenanceWarning,
@@ -96,51 +96,78 @@ export async function persistSessionResetLifecycle(params: {
   return { replayedMessages: 0 };
 }
 
-/** Loads the reply-session initialization rows without exposing a mutable store. */
-export function loadReplySessionInitializationSnapshot(params: {
+type ReplySessionInitializationSelection = {
   agentId: string;
   storePath: string;
   sessionKey: string;
-}): ReplySessionInitializationSnapshot {
+  relatedSessionKeys?: readonly string[];
+};
+
+function loadReplySessionInitializationEntries(
+  params: ReplySessionInitializationSelection,
+): Record<string, SessionEntry> {
   assertSessionInitializationAgentScope(params.agentId, params.sessionKey);
-  const storePath = resolveSessionStorePathForScope(params);
-  const store = Object.fromEntries(
-    listSessionEntriesReadOnly({ agentId: params.agentId, storePath }).map(
-      ({ sessionKey, entry }) => [sessionKey, entry],
-    ),
+  const result = withOpenClawAgentDatabaseReadOnly(
+    (database) =>
+      runSqliteDeferredTransactionSync(database.db, () => {
+        assertCanonicalSqliteSessionKeysCurrent(database);
+        const entries: Record<string, SessionEntry> = {};
+        const currentKey = normalizeStoreSessionKey(params.sessionKey);
+        const keys = new Set([currentKey, ...(params.relatedSessionKeys ?? [])]);
+        // Related rows must share the current row's snapshot, including its stored
+        // model parent. Lazy reads after preparation could inherit a different generation.
+        for (const key of keys) {
+          const sessionKey = normalizeStoreSessionKey(key);
+          if (!sessionKey || entries[sessionKey]) {
+            continue;
+          }
+          const entry = readExactSessionEntryRow(database, sessionKey)?.entry;
+          if (entry) {
+            entries[sessionKey] = entry;
+            if (sessionKey === currentKey && entry.parentSessionKey) {
+              keys.add(entry.parentSessionKey);
+            }
+          }
+        }
+        return entries;
+      }),
+    toDatabaseOptions(resolveSqliteScope(params)),
   );
+  return result.found ? result.value : {};
+}
+
+/** Loads the declared reply-session rows without exposing a mutable store. */
+export function loadReplySessionInitializationSnapshot(
+  params: ReplySessionInitializationSelection,
+): ReplySessionInitializationSnapshot {
+  const storePath = resolveSessionStorePathForScope(params);
+  const store = loadReplySessionInitializationEntries({ ...params, storePath });
   const resolved = resolveSessionEntryFromStore({ store, sessionKey: params.sessionKey });
   const currentEntry = resolved.existing ? { ...resolved.existing } : undefined;
-  const entries = cloneSessionEntries(store);
   return {
     ...(currentEntry ? { currentEntry } : {}),
     readEntry: (sessionKey) => {
-      const entry = resolveSessionEntryFromStore({ store: entries, sessionKey }).existing;
+      const entry = resolveSessionEntryFromStore({ store, sessionKey }).existing;
       return entry ? { ...entry } : undefined;
     },
-    revision: createReplySessionInitializationRevision({
-      entry: currentEntry,
-      storePath,
-    }),
+    revision: createReplySessionInitializationRevision(currentEntry),
   };
 }
 
 function createStaleReplySessionInitializationResult(
   currentEntry: SessionEntry | undefined,
-  storePath: string,
 ): ReplySessionInitializationCommitResult {
   return {
     ok: false,
     ...(currentEntry ? { currentEntry } : {}),
     reason: "stale-snapshot",
-    revision: createReplySessionInitializationRevision({ entry: currentEntry, storePath }),
+    revision: createReplySessionInitializationRevision(currentEntry),
   };
 }
 
 /**
  * Persists one reply-session initialization result and archives the previous
- * transcript after metadata commits. SQLite adapters map the guarded write to a
- * transaction and keep archive failure warning-only, matching file storage.
+ * transcript after metadata commits, keeping archive failure warning-only.
  */
 export async function commitReplySessionInitialization(params: {
   activeSessionKey: string;
@@ -164,6 +191,7 @@ export async function commitReplySessionInitialization(params: {
   retiredEntry?: SessionEntryRetirement;
   sessionEntry: SessionEntry;
   sessionKey: string;
+  relatedSessionKeys?: readonly string[];
   snapshotEntry?: SessionEntry;
   storePath: string;
 }): Promise<ReplySessionInitializationCommitResult> {
@@ -172,39 +200,25 @@ export async function commitReplySessionInitialization(params: {
     sessionKey: params.sessionKey,
     storePath: params.storePath,
   });
-  const store = Object.fromEntries(
-    listSessionEntriesCore({ agentId: params.agentId, storePath }).map(({ sessionKey, entry }) => [
-      sessionKey,
-      entry,
-    ]),
-  );
+  const store = loadReplySessionInitializationEntries({ ...params, storePath });
   const resolved = resolveSessionEntryFromStore({ store, sessionKey: params.sessionKey });
   const currentEntry = resolved.existing ? { ...resolved.existing } : undefined;
-  const revision = createReplySessionInitializationRevision({
-    entry: currentEntry,
-    storePath,
-  });
+  const revision = createReplySessionInitializationRevision(currentEntry);
   if (revision !== params.expectedRevision) {
-    return createStaleReplySessionInitializationResult(currentEntry, storePath);
+    return createStaleReplySessionInitializationResult(currentEntry);
   }
 
   const readEntry = (sessionKey: string) => {
     const entry = resolveSessionEntryFromStore({ store, sessionKey }).existing;
     return entry ? { ...entry } : undefined;
   };
-  const preparedSessionEntry = params.prepareSessionEntry
+  const sessionEntry = params.prepareSessionEntry
     ? await params.prepareSessionEntry({
         ...(currentEntry ? { currentEntry } : {}),
         readEntry,
         sessionEntry: params.sessionEntry,
       })
     : params.sessionEntry;
-  const sessionEntry = resolveInitializedReplySessionEntry({
-    agentId: params.agentId,
-    ...(currentEntry ? { currentEntry } : {}),
-    sessionEntry: preparedSessionEntry,
-    storePath,
-  });
   let staleCommit: SessionEntry | null | undefined;
   let committedSessionEntry = sessionEntry;
   let beforeEntryMutationDone = false;
@@ -213,16 +227,8 @@ export async function commitReplySessionInitialization(params: {
       sessionKey: resolved.normalizedKey,
       ...(params.routeContext !== undefined ? { routeContext: params.routeContext } : {}),
       ...(params.resetBoundary ? { resetBoundary: params.resetBoundary } : {}),
-      buildEntry: async ({ store: currentStore }) => {
-        const commitResolved = resolveSessionEntryFromStore({
-          store: currentStore,
-          sessionKey: params.sessionKey,
-        });
-        const commitEntry = commitResolved.existing;
-        const commitRevision = createReplySessionInitializationRevision({
-          entry: commitEntry,
-          storePath,
-        });
+      buildEntry: async ({ currentEntry: commitEntry }) => {
+        const commitRevision = createReplySessionInitializationRevision(commitEntry);
         if (commitRevision !== params.expectedRevision) {
           staleCommit = commitEntry ? { ...commitEntry } : null;
           return null;
@@ -278,11 +284,10 @@ export async function commitReplySessionInitialization(params: {
         sessionKey: error.sessionKey,
         storePath,
       }),
-      storePath,
     );
   }
   if (staleCommit !== undefined) {
-    return createStaleReplySessionInitializationResult(staleCommit ?? undefined, storePath);
+    return createStaleReplySessionInitializationResult(staleCommit ?? undefined);
   }
   store[resolved.normalizedKey] = committedSessionEntry;
   if (params.retiredEntry) {

--- a/src/config/sessions/session-accessor.sqlite-deletion.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-deletion.test.ts
@@ -154,46 +154,112 @@ describe("session deletion and native owner state", () => {
   const read = (key = sessionKey) =>
     loadSessionEntry({ sessionKey: key, storePath, readConsistency: "latest" });
 
-  it("does not materialize surviving prompts when deleting a node with no windows", async () => {
-    const reclaimedKey = "agent:main:reclaimed-node";
-    const survivorKey = "agent:main:untouched-node";
-    const entry = { sessionId: "reclaimed-session", updatedAt: Date.now() };
-    await replaceSessionEntry({ sessionKey: reclaimedKey, storePath }, entry);
-    await replaceSessionEntry(
-      { sessionKey: survivorKey, storePath },
-      {
-        sessionId: "untouched-session",
-        updatedAt: entry.updatedAt,
-        skillsSnapshot: { prompt: "saved skill prompt", skills: [] },
-      },
-    );
-    const scope = {
-      agentId: "main",
-      path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
-    };
-    const database = openOpenClawAgentDatabase(scope);
-    database.db.prepare("DELETE FROM session_windows WHERE session_key = ?").run(reclaimedKey);
-    const queries = vi.spyOn(sqliteQueries, "executeSqliteQuerySync");
-    try {
-      await withSqliteSessionDeletions(scope, [{ sessionKey: reclaimedKey, entry }], async () => {
-        runSqliteSessionDeletionTransaction((current) => {
-          deleteSessionEntryRows(current, reclaimedKey);
-        }, scope);
-      });
-      const rows = queries.mock.results.flatMap((result) =>
-        result.type === "return" ? result.value.rows : [],
-      );
-      expect(rows).not.toContainEqual(
-        expect.objectContaining({ session_key: survivorKey, entry_json: expect.any(String) }),
-      );
-    } finally {
-      queries.mockRestore();
-    }
-    expect(loadSessionEntry({ sessionKey: reclaimedKey, storePath })).toBeUndefined();
-    expect(loadSessionEntry({ sessionKey: survivorKey, storePath })?.skillsSnapshot?.prompt).toBe(
-      "saved skill prompt",
-    );
-  });
+  it.each(["no windows", "a shared window", "a placeholder successor"] as const)(
+    "does not materialize surviving prompts when deleting a node with %s",
+    async (scenario) => {
+      const reclaimedKey = "agent:main:reclaimed-node";
+      const survivorKeys = ["agent:main:survivor-a", "agent:main:survivor-b"] as const;
+      const entry = { sessionId: "reclaimed-session", updatedAt: Date.now() };
+      const retainedEvent = { type: "session", id: entry.sessionId, content: "retained history" };
+      await replaceSessionEntry({ sessionKey: reclaimedKey, storePath }, entry);
+      for (const survivorKey of survivorKeys.toReversed()) {
+        await replaceSessionEntry(
+          { sessionKey: survivorKey, storePath },
+          {
+            sessionId: `${survivorKey}-session`,
+            previousSessionId: entry.sessionId,
+            updatedAt: entry.updatedAt,
+            skillsSnapshot: { prompt: "saved skill prompt".repeat(4096), skills: [] },
+            systemPromptReport: {
+              source: "run",
+              generatedAt: entry.updatedAt,
+              systemPrompt: { chars: 1, projectContextChars: 0, nonProjectContextChars: 1 },
+              injectedWorkspaceFiles: [],
+              skills: { promptChars: 0, entries: [{ name: "saved-report-skill", blockChars: 0 }] },
+              tools: { listChars: 0, schemaChars: 0, entries: [] },
+            },
+          },
+        );
+      }
+      const scope = {
+        agentId: "main",
+        path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
+      };
+      const database = openOpenClawAgentDatabase(scope);
+      if (scenario === "no windows") {
+        database.db.prepare("DELETE FROM session_windows WHERE session_key = ?").run(reclaimedKey);
+      } else {
+        replaceTranscriptEventsSync(
+          { sessionKey: reclaimedKey, sessionId: entry.sessionId, storePath },
+          [retainedEvent],
+        );
+        if (scenario === "a placeholder successor") {
+          database.db
+            .prepare(
+              "UPDATE session_nodes SET current_session_id = ?, entry_json = '{}', entry_valid = -1 WHERE session_key = ?",
+            )
+            .run(entry.sessionId, survivorKeys[0]);
+        }
+      }
+      const readSurvivors = () =>
+        database.db
+          .prepare(
+            "SELECT session_key, current_session_id, entry_json, entry_valid FROM session_nodes WHERE session_key != ? ORDER BY session_key",
+          )
+          .all(reclaimedKey);
+      const survivorsBefore = readSurvivors();
+      const queries = vi.spyOn(sqliteQueries, "executeSqliteQuerySync");
+      try {
+        await withSqliteSessionDeletions(scope, [{ sessionKey: reclaimedKey, entry }], async () => {
+          runSqliteSessionDeletionTransaction((current) => {
+            deleteSessionEntryRows(current, reclaimedKey, {
+              deleteOwnedWindows: scenario === "a shared window",
+            });
+          }, scope);
+        });
+        const rows = queries.mock.results.flatMap((result) =>
+          result.type === "return" ? result.value.rows : [],
+        );
+        if (scenario === "no windows") {
+          for (const survivorKey of survivorKeys) {
+            expect(rows).not.toContainEqual(
+              expect.objectContaining({ session_key: survivorKey, entry_json: expect.any(String) }),
+            );
+          }
+        }
+        for (const payload of ["saved skill prompt", "saved-report-skill"]) {
+          expect(
+            rows.filter(
+              (row) =>
+                typeof row === "object" &&
+                row !== null &&
+                "entry_json" in row &&
+                typeof row.entry_json === "string" &&
+                row.entry_json.includes(payload),
+            ).length,
+          ).toBe(0);
+        }
+      } finally {
+        queries.mockRestore();
+      }
+      expect(loadSessionEntry({ sessionKey: reclaimedKey, storePath })).toBeUndefined();
+      expect(readSurvivors()).toEqual(survivorsBefore);
+      if (scenario !== "no windows") {
+        expect(
+          database.db
+            .prepare("SELECT session_key FROM session_windows WHERE session_id = ?")
+            .get(entry.sessionId),
+        ).toEqual({ session_key: survivorKeys[0] });
+        await expect(
+          loadTranscriptEvents({
+            sessionKey: survivorKeys[0],
+            sessionId: entry.sessionId,
+            storePath,
+          }),
+        ).resolves.toEqual([retainedEvent]);
+      }
+    },
+  );
 
   it("patches a case-distinct Matrix room without preparing its admitted sibling for deletion", async () => {
     const mixedKey = "agent:main:matrix:channel:!RoomAbC:example.org";

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -213,15 +213,19 @@ export function readExactSessionEntryRowValidated(
 
 export function readSessionEntryStore(
   database: OpenClawAgentDatabase,
-  options: { allowCanonicalRepair?: boolean } = {},
+  options: { allowCanonicalRepair?: boolean; sessionKeys?: readonly string[] } = {},
 ): Record<string, SessionEntry> {
   if (options.allowCanonicalRepair !== true) {
     assertCanonicalSqliteSessionKeysCurrent(database);
   }
+  if (options.sessionKeys?.length === 0) {
+    return {};
+  }
   const db = getSessionKysely(database.db);
+  const query = db.selectFrom("session_nodes").selectAll().orderBy("session_key");
   const rows = iterateSqliteQuerySync(
     database.db,
-    db.selectFrom("session_nodes").selectAll().orderBy("session_key"),
+    options.sessionKeys ? query.where("session_key", "in", options.sessionKeys) : query,
   );
   const store: Record<string, SessionEntry> = {};
   for (const row of rows) {
@@ -331,15 +335,15 @@ export function deleteSessionEntryRows(
     database.db,
     db.selectFrom("session_windows").select("session_id").where("session_key", "=", sessionKey),
   ).rows;
-  // Maintenance may have reclaimed every window already. Only scan surviving
-  // prompts when a retained window needs an owner; otherwise each deletion reads the whole store.
+  // Skip the survivor scan when maintenance reclaimed every window. Otherwise, project
+  // reference metadata before acquiring rows to avoid loading unrelated saved prompts.
   const survivingNodes =
     windows.length > 0
       ? executeSqliteQuerySync(
           database.db,
           db
             .selectFrom("session_nodes")
-            .select(["current_session_id", "entry_json", "session_key"])
+            .select(["current_session_id", sessionEntryMetadataJson, "session_key"])
             .where("session_key", "!=", sessionKey)
             .orderBy("session_key", "asc"),
         ).rows

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
@@ -325,6 +325,12 @@ export async function projectSessionEntryLifecycleMutation(
   const removalDatabase = openOpenClawAgentDatabase(databaseOptions);
   const store = readSessionEntryStore(removalDatabase, {
     allowCanonicalRepair: params.allowCanonicalRepair === true,
+    sessionKeys: [
+      ...params.removals.map((removal) =>
+        removal.exactStoredKey ? removal.sessionKey : removal.sessionKey.trim(),
+      ),
+      ...params.upserts.map((upsert) => upsert.sessionKey.trim()),
+    ],
   });
   const removedKeysToArchive = new Set<string>();
   const changedSessionKeys = new Set<string>();
@@ -397,7 +403,6 @@ export async function projectSessionEntryLifecycleMutation(
         : await upsert.buildEntry({
             currentEntry: expectedEntry ? cloneSessionEntry(expectedEntry) : undefined,
             sessionKey,
-            store,
           });
     if (!entry) {
       continue;

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -568,14 +568,14 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
       upserts: [
         {
           sessionKey: isolatedSessionKey,
-          buildEntry: ({ store }) => {
+          buildEntry: ({ currentEntry }) => {
             const cronSession = resolveCronSession({
               cfg,
               sessionKey: isolatedSessionKey,
               agentId,
               nowMs: startedAt,
               forceNew: true,
-              store,
+              store: currentEntry ? { [isolatedSessionKey]: currentEntry } : {},
             });
             const nextEntry = {
               ...cronSession.sessionEntry,

--- a/src/infra/net/pinned-dispatcher-pool.test.ts
+++ b/src/infra/net/pinned-dispatcher-pool.test.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { Dispatcher } from "undici";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { hasProviderTransportDispatcherPool } from "../../agents/provider-runtime-lifecycle.js";
@@ -126,6 +127,56 @@ describe("PinnedDispatcherPool", () => {
 
     await pool.closeAll();
   });
+
+  it.each(["expiry", "retirement", "shutdown"] as const)(
+    "keeps request contexts out of pool-owned %s cleanup",
+    async (reason) => {
+      const requestScope = new AsyncLocalStorage<object>();
+      const sessionScope = new AsyncLocalStorage<object>();
+      const request = {};
+      const session = {};
+      const closed = createDeferredCore<[object | undefined, object | undefined]>();
+      const close = vi.fn(async () => {
+        closed.resolve([requestScope.getStore(), sessionScope.getStore()]);
+      });
+      let pool: PinnedDispatcherPool | undefined;
+      try {
+        await requestScope.run(request, () =>
+          sessionScope.run(session, async () => {
+            pool = new PinnedDispatcherPool({ maxEntries: 1, idleTtlMs: 5 });
+            const lease = pool.acquire({
+              key: "origin-a/pin-a",
+              groupKey: "origin-a",
+              createDispatcher: () => {
+                expect(requestScope.getStore()).toBe(request);
+                expect(sessionScope.getStore()).toBe(session);
+                return { close } as unknown as Dispatcher;
+              },
+            });
+            expect(lease).toBeDefined();
+            if (reason === "retirement") {
+              pool.acquire({
+                key: "origin-a/pin-b",
+                groupKey: "origin-a",
+                createDispatcher: () => createDispatcher().dispatcher,
+              });
+            }
+            if (reason === "shutdown") {
+              await pool.closeAll();
+            } else {
+              await lease!.release();
+            }
+            expect(requestScope.getStore()).toBe(request);
+            expect(sessionScope.getStore()).toBe(session);
+          }),
+        );
+        expect(await closed.promise).toEqual([undefined, undefined]);
+        expect(close).toHaveBeenCalledOnce();
+      } finally {
+        await pool?.closeAll();
+      }
+    },
+  );
 
   it("fences a closed generation from later acquisition", async () => {
     const pool = new PinnedDispatcherPool({ maxEntries: 1, idleTtlMs: 60_000 });

--- a/src/infra/net/pinned-dispatcher-pool.ts
+++ b/src/infra/net/pinned-dispatcher-pool.ts
@@ -1,5 +1,10 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { Dispatcher } from "undici";
 import { closeDispatcher } from "./ssrf.js";
+
+// Gateway startup imports this module before admitting requests. Pool timers and
+// cleanup must keep that context instead of retaining the last request's stores.
+const runInDispatcherPoolContext = AsyncLocalStorage.snapshot();
 
 export type PinnedDispatcherLease = {
   dispatcher: Dispatcher;
@@ -126,7 +131,9 @@ export class PinnedDispatcherPool {
           await this.startClose(entry);
           return;
         }
-        entry.idleTimer = setTimeout(() => this.retireEntry(entry), this.idleTtlMs);
+        entry.idleTimer = runInDispatcherPoolContext(() =>
+          setTimeout(() => this.retireEntry(entry), this.idleTtlMs),
+        );
         entry.idleTimer.unref?.();
       },
     };
@@ -146,13 +153,11 @@ export class PinnedDispatcherPool {
   }
 
   private startClose(entry: PinnedDispatcherPoolEntry): Promise<void> {
-    if (entry.closePromise) {
-      return entry.closePromise;
-    }
-    const closePromise = closeDispatcher(entry.dispatcher).finally(() => {
-      this.ownedEntries.delete(entry);
-    });
-    entry.closePromise = closePromise;
-    return closePromise;
+    entry.closePromise ??= runInDispatcherPoolContext(() =>
+      closeDispatcher(entry.dispatcher).finally(() => {
+        this.ownedEntries.delete(entry);
+      }),
+    );
+    return entry.closePromise;
   }
 }

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -1,4 +1,5 @@
 // Covers SQLite WAL maintenance configuration.
+import { AsyncLocalStorage, createHook } from "node:async_hooks";
 import childProcess, { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -8,6 +9,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 import {
   configureSqliteConnectionPragmas,
@@ -541,26 +543,63 @@ describe("sqlite WAL maintenance", () => {
     expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
   });
 
-  it("runs lightweight periodic PASSIVE checkpoints and TRUNCATE on close", () => {
-    vi.useFakeTimers();
+  it("runs periodic maintenance outside request contexts and TRUNCATE on close", async () => {
+    const requestScope = new AsyncLocalStorage<object>();
+    const sessionScope = new AsyncLocalStorage<object>();
+    const request = {};
+    const session = {};
+    const timerContexts: Array<[object | undefined, object | undefined]> = [];
+    const periodic = createDeferredCore<[object | undefined, object | undefined]>();
+    const hook = createHook({
+      init(_asyncId, type) {
+        if (type === "Timeout") {
+          timerContexts.push([requestScope.getStore(), sessionScope.getStore()]);
+        }
+      },
+    });
     const db = createMockDb();
     vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    vi.mocked(db["exec"]).mockImplementation((sql) => {
+      if (sql === "PRAGMA incremental_vacuum(512);") {
+        periodic.resolve([requestScope.getStore(), sessionScope.getStore()]);
+      }
+    });
+    let maintenance: ReturnType<typeof configureSqliteWalMaintenance> | undefined;
+    try {
+      await requestScope.run(request, () =>
+        sessionScope.run(session, async () => {
+          hook.enable();
+          try {
+            maintenance = configureSqliteWalMaintenance(db, { checkpointIntervalMs: 5 });
+          } finally {
+            hook.disable();
+          }
+          expect(requestScope.getStore()).toBe(request);
+          expect(sessionScope.getStore()).toBe(session);
+          // The native resource must be detached at allocation, not only when its callback runs.
+          expect(timerContexts).toEqual([[undefined, undefined]]);
+          expect(db["exec"]).toHaveBeenCalledTimes(3);
 
-    const maintenance = configureSqliteWalMaintenance(db, { checkpointIntervalMs: 100 });
-    // journal_mode=WAL, wal_autocheckpoint, journal_size_limit.
-    expect(db["exec"]).toHaveBeenCalledTimes(3);
+          expect(await periodic.promise).toEqual([undefined, undefined]);
+          expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA wal_checkpoint(PASSIVE);");
+          expect(db["exec"]).toHaveBeenNthCalledWith(4, "PRAGMA incremental_vacuum(512);");
+          expect(maintenance.close()).toBe(true);
+          expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA wal_checkpoint(TRUNCATE);");
+          expect(requestScope.getStore()).toBe(request);
+          expect(sessionScope.getStore()).toBe(session);
 
-    vi.advanceTimersByTime(100);
-    expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA wal_checkpoint(PASSIVE);");
-    expect(db["exec"]).toHaveBeenNthCalledWith(4, "PRAGMA incremental_vacuum(512);");
-    expect(db["exec"]).toHaveBeenCalledTimes(4);
-
-    expect(maintenance.close()).toBe(true);
-    expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA wal_checkpoint(TRUNCATE);");
-    expect(db["exec"]).toHaveBeenCalledTimes(4);
-
-    vi.advanceTimersByTime(200);
-    expect(db["exec"]).toHaveBeenCalledTimes(4);
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 10);
+          });
+          expect(db["exec"]).toHaveBeenCalledTimes(4);
+        }),
+      );
+    } finally {
+      hook.disable();
+      maintenance?.close();
+      requestScope.disable();
+      sessionScope.disable();
+    }
   });
 
   it.runIf(process.platform === "linux").each([

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -1,4 +1,5 @@
 // Configures SQLite WAL and related pragmas for local stores.
+import { AsyncLocalStorage } from "node:async_hooks";
 import fs, { type BigIntStats } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
@@ -40,6 +41,10 @@ const SQLITE_WAL_SPLIT_BRAIN_FATAL_MESSAGE =
   "SQLite WAL sidecar identity mismatch; terminating without SQLite cleanup";
 
 const log = createSubsystemLogger("infra/sqlite-wal");
+
+// Gateway bootstrap loads the database owner before admitting turns. Long-lived
+// maintenance timers must not retain the context of a turn that opens a database.
+const runInSqliteMaintenanceContext = AsyncLocalStorage.snapshot();
 
 type IntervalHandle = ReturnType<typeof setInterval> & {
   unref?: () => void;
@@ -644,34 +649,37 @@ export function configureSqliteWalMaintenance(
 
   let timer: IntervalHandle | null = null;
   if (timerIntervalMs > 0) {
-    timer = setInterval(() => {
-      if (tripwireDatabasePath && splitBrainDetectionEnabled) {
-        let splitBrain: SqliteWalSplitBrainEvent | undefined;
-        try {
-          splitBrain = detectSqliteWalSplitBrain(tripwireDatabasePath);
-        } catch (error) {
-          splitBrainDetectionEnabled = false;
-          if (!splitBrainDetectionWarningLogged) {
-            splitBrainDetectionWarningLogged = true;
-            log.warn("SQLite WAL split-brain detection disabled", {
-              databaseLabel: options.databaseLabel,
-              databasePath: tripwireDatabasePath,
-              error: error instanceof Error ? error.message : String(error),
-            });
+    timer = runInSqliteMaintenanceContext(
+      () =>
+        setInterval(() => {
+          if (tripwireDatabasePath && splitBrainDetectionEnabled) {
+            let splitBrain: SqliteWalSplitBrainEvent | undefined;
+            try {
+              splitBrain = detectSqliteWalSplitBrain(tripwireDatabasePath);
+            } catch (error) {
+              splitBrainDetectionEnabled = false;
+              if (!splitBrainDetectionWarningLogged) {
+                splitBrainDetectionWarningLogged = true;
+                log.warn("SQLite WAL split-brain detection disabled", {
+                  databaseLabel: options.databaseLabel,
+                  databasePath: tripwireDatabasePath,
+                  error: error instanceof Error ? error.message : String(error),
+                });
+              }
+            }
+            if (splitBrain) {
+              invalidated = true;
+              if (timer) {
+                clearInterval(timer);
+                timer = null;
+              }
+              terminateForSqliteWalSplitBrain(splitBrain, options.databaseLabel);
+            }
           }
-        }
-        if (splitBrain) {
-          invalidated = true;
-          if (timer) {
-            clearInterval(timer);
-            timer = null;
-          }
-          terminateForSqliteWalSplitBrain(splitBrain, options.databaseLabel);
-        }
-      }
-      runCheckpoint(periodicCheckpointMode);
-      runIncrementalVacuum();
-    }, timerIntervalMs) as IntervalHandle;
+          runCheckpoint(periodicCheckpointMode);
+          runIncrementalVacuum();
+        }, timerIntervalMs) as IntervalHandle,
+    );
     timer.unref?.();
   }
 

--- a/src/skills/runtime/refresh.missing-root.integration.test.ts
+++ b/src/skills/runtime/refresh.missing-root.integration.test.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import nativeFs from "node:fs";
 import fs from "node:fs/promises";
 import { syncBuiltinESMExports } from "node:module";
@@ -15,8 +16,15 @@ it("refreshes skills created beneath an initially missing project skills root", 
   const workspaceDir = path.join(root, "workspace");
   await fs.mkdir(path.join(workspaceDir, "skills", "existing"), { recursive: true });
   const registeredPaths = new Set<string>();
+  const turnContext = new AsyncLocalStorage<string>();
+  const pendingInputContext = new AsyncLocalStorage<string>();
+  const inheritedContexts: Array<{ turn?: string; pendingInput?: string }> = [];
   const originalWatch = nativeFs.watch;
   const watchObserver = vi.spyOn(nativeFs, "watch").mockImplementation((...args) => {
+    inheritedContexts.push({
+      turn: turnContext.getStore(),
+      pendingInput: pendingInputContext.getStore(),
+    });
     const watcher = originalWatch(...args);
     registeredPaths.add(path.resolve(String(args[0])));
     return watcher;
@@ -31,7 +39,13 @@ it("refreshes skills created beneath an initially missing project skills root", 
     }
   });
   try {
-    ensureSkillsWatcher({ workspaceDir });
+    turnContext.run("active turn", () => {
+      pendingInputContext.run("accepted input", () => {
+        ensureSkillsWatcher({ workspaceDir });
+        expect(turnContext.getStore()).toBe("active turn");
+        expect(pendingInputContext.getStore()).toBe("accepted input");
+      });
+    });
     const existingSkill = path.join(workspaceDir, "skills", "existing", "SKILL.md");
     // Chokidar readiness can precede missing-parent registration, and parent
     // registration does not await child watches. Observe both native watches
@@ -53,6 +67,10 @@ it("refreshes skills created beneath an initially missing project skills root", 
       },
       { timeout: 3_000 },
     );
+    expect(inheritedContexts.length).toBeGreaterThan(0);
+    for (const context of inheritedContexts) {
+      expect(context).toEqual({ turn: undefined, pendingInput: undefined });
+    }
   } finally {
     unregister();
     await closeSkillsWatchers();

--- a/src/skills/runtime/refresh.ts
+++ b/src/skills/runtime/refresh.ts
@@ -1,4 +1,5 @@
 // Skill runtime refresh helpers reload active skill state and notify subscribers.
+import { AsyncLocalStorage } from "node:async_hooks";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -53,6 +54,9 @@ type FileStabilitySnapshot = {
 };
 
 const log = createSubsystemLogger("gateway/skills");
+// Gateway startup imports this owner before serving turns. Shared watcher handles,
+// including later rebuilds, must inherit that lifetime rather than the triggering turn.
+const runInSkillsWatcherContext = AsyncLocalStorage.snapshot();
 const GROUPED_SKILLS_WATCH_DEPTH = 6;
 const CONFIGURED_ROOT_WATCH_DEPTH = 2;
 const MAX_SYMLINK_WATCH_TARGETS_PER_ROOT = 100;
@@ -503,23 +507,25 @@ function createSkillsPathWatcher(target: WatchTarget): SkillsPathWatchState {
   // Chokidar's missing-root fallback retains only the final basename, so it
   // misses creation through multiple absent parents. Watch the existing prefix
   // and restrict traversal to the logical root and its ancestor chain.
-  const watcher = chokidar.watch(target.watchRoot, {
-    ignoreInitial: true,
-    followSymlinks: false,
-    usePolling,
-    // Skill root precedence and grouped discovery use the same bounded depth,
-    // so watcher invalidation must observe that whole decision surface.
-    depth:
-      target.depth +
-      path.relative(target.watchRoot, target.path).split(path.sep).filter(Boolean).length,
-    awaitWriteFinish: {
-      stabilityThreshold: SKILLS_WATCH_DEBOUNCE_MS,
-      pollInterval: 100,
-    },
-    ignored: (watchPath, stats) =>
-      (!isPathInside(target.path, watchPath) && !isPathInside(watchPath, target.path)) ||
-      shouldIgnoreSkillsWatchPath(watchPath, stats, { usePolling }),
-  });
+  const watcher = runInSkillsWatcherContext(() =>
+    chokidar.watch(target.watchRoot, {
+      ignoreInitial: true,
+      followSymlinks: false,
+      usePolling,
+      // Skill root precedence and grouped discovery use the same bounded depth,
+      // so watcher invalidation must observe that whole decision surface.
+      depth:
+        target.depth +
+        path.relative(target.watchRoot, target.path).split(path.sep).filter(Boolean).length,
+      awaitWriteFinish: {
+        stabilityThreshold: SKILLS_WATCH_DEBOUNCE_MS,
+        pollInterval: 100,
+      },
+      ignored: (watchPath, stats) =>
+        (!isPathInside(target.path, watchPath) && !isPathInside(watchPath, target.path)) ||
+        shouldIgnoreSkillsWatchPath(watchPath, stats, { usePolling }),
+    }),
+  );
 
   const state: SkillsPathWatchState = {
     watcher,

--- a/ui/src/pages/activity/tool-activity.test.ts
+++ b/ui/src/pages/activity/tool-activity.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import { parseActivityEvent, updateToolActivity, type ActivityEntry } from "./tool-activity.ts";
 
@@ -24,6 +25,14 @@ function buildResultPreview(result: unknown): string {
 }
 
 describe("activity model output preview redaction", () => {
+  it.each([
+    ["short UTF-16 text", "\ud800 visible 🦞 text", "\ud800 visible 🦞 text"],
+    ["a surrogate pair at the cap", "a".repeat(1_999) + "🦞tail", "a".repeat(1_999)],
+    ["a lone surrogate inside the cap", "\ud800" + "a".repeat(2_100), "\ud800" + "a".repeat(1_999)],
+  ])("preserves %s", (_label, source, expected) => {
+    expect(buildResultPreview({ text: source })).toBe(expected);
+  });
+
   it("redacts dotted API key assignments emitted by tool output", () => {
     const preview = buildResultPreview({
       text: [
@@ -51,6 +60,69 @@ describe("activity model output preview redaction", () => {
     expect(preview).not.toContain("visible secret");
     expect(preview).not.toContain("keep hidden");
   });
+});
+
+describe("activity preview retention", () => {
+  it.each(["tool", "answer_candidate"])(
+    "releases large %s payloads while retaining their previews",
+    (kind) => {
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--expose-gc",
+          "--import",
+          "tsx",
+          "--input-type=module",
+          "--eval",
+          `
+            import { setImmediate as yieldTurn } from "node:timers/promises";
+            import { updateToolActivity } from ${JSON.stringify(new URL("./tool-activity.ts", import.meta.url).href)};
+            let entries = [];
+            async function heapUsed() {
+              await yieldTurn();
+              globalThis.gc();
+              await yieldTurn();
+              globalThis.gc();
+              return process.memoryUsage().heapUsed;
+            }
+            function append(index, size) {
+              const text = JSON.parse(JSON.stringify("Synthetic " + index + ": " + "x".repeat(size)));
+              entries = updateToolActivity(entries, {
+                stream: ${JSON.stringify(kind === "tool" ? "tool" : "item")},
+                runId: "run-" + index, ts: index, receivedAt: index,
+                data: ${JSON.stringify(kind)} === "tool"
+                  ? { toolCallId: "tool-" + index, name: "read", phase: "result", result: { text } }
+                  : { kind: "answer_candidate", itemId: "answer-" + index, status: "selected", progressText: text },
+              });
+            }
+            append(0, 5_000);
+            entries = [];
+            const before = await heapUsed();
+            for (let index = 0; index < 64; index++) append(index, 512 * 1024);
+            const retainedBytes = (await heapUsed()) - before;
+            // Serialize only after measuring: consuming a slice can flatten it.
+            process.stdout.write(JSON.stringify({ retainedBytes, previews: entries.map((entry) => ({ text: entry.outputPreview, truncated: entry.outputTruncated })) }));
+          `,
+        ],
+        { cwd: process.cwd(), encoding: "utf8", timeout: 20_000 },
+      );
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(0);
+      const output = JSON.parse(result.stdout) as {
+        retainedBytes: number;
+        previews: { text: string; truncated: boolean }[];
+      };
+      expect(output.previews).toEqual(
+        Array.from({ length: 64 }, (_, index) => ({
+          text: (`Synthetic ${index}: ` + "x".repeat(2_000)).slice(0, 2_000),
+          truncated: true,
+        })),
+      );
+      // The discarded source bodies total 32 MiB; previews need only 128 KiB.
+      expect(output.retainedBytes).toBeLessThan(8 * 1024 * 1024);
+    },
+    30_000,
+  );
 });
 
 describe("answer candidate activity", () => {

--- a/ui/src/pages/activity/tool-activity.ts
+++ b/ui/src/pages/activity/tool-activity.ts
@@ -119,7 +119,9 @@ function buildOutputPreview(value: unknown): { text?: string; truncated: boolean
   }
   const redacted = redactToolPayloadText(raw);
   const truncated = truncateText(redacted, ACTIVITY_OUTPUT_PREVIEW_LIMIT);
-  return { text: truncated.text, truncated: truncated.truncated };
+  // A sliced preview can retain the whole output after the raw event is evicted.
+  // Copy its characters here so the bounded Activity entry owns only its preview.
+  return { text: Array.from(truncated.text).join(""), truncated: truncated.truncated };
 }
 
 function countArgumentFields(value: unknown): number {


### PR DESCRIPTION
Related: #91588 (long-running Gateway memory growth)

## What Problem This Solves

Fixes an issue where operators with large saved-session histories would see Gateway memory grow during ordinary CLI and Web UI conversations. Activity could also retain a large tool result long after its raw event left the feed, despite displaying only a short preview.

## Why This Change Was Made

Single-session lookups and reply initialization acquired every saved prompt, then request closures carried those inventories into background resource lifetimes. The repair reads the current session and declared relatives in one SQLite snapshot, projects lifecycle writes and deletion references before acquiring prompt payloads, and gives shared watchers, dispatcher cleanup, MCP idle sweeps, and SQLite maintenance timers their own startup context. Authorized diagnostics explicitly obtains the metadata inventory it needs. Activity owns a copy of its bounded preview.

The same pass fixes key-less reply preprocessing, which omitted the configured agent ID when deriving the session key. Request authorization and transport acquisition stay in the caller's context; only owner-managed background work changes context. SQLite schema, maintenance timing, retention policy, configuration, and visible Activity contents remain unchanged.

Current-head integration preserves #134814 (metadata-only authorization and unused deletion-scan removal), which landed during this pass. Its sharing-policy and cache-test changes remain identical to main; selected lifecycle reads retain its captured archive decisions. The current candidate is `184c9c303fa` on main `2a920ab94d3`. Main also independently landed #134935’s exact-row Gateway lookups and #134812’s Doctor readiness-fixture repair. Those implementations remain unchanged, and this PR drops its duplicate lookup and fixture changes. The remaining 30-file patch has the same stable patch ID as the corresponding files in the previously tested memory commit. The base also includes #134824’s release-inventory repair.

## User Impact

CLI and Web UI conversations retain substantially less memory when many sessions have saved prompts. Session lists, parent inheritance, diagnostics discovery, reset/delete cleanup, memory indexing, and Activity output remain functional.

## Evidence

Measurements below are from original candidate `d1b4d9cccef9383c9ded24a2ed56b5cd7152a0bf`, against freshly pulled main `38f80876377c15c3150a8c1e0b1922a87815b606`, using Node 24.19.0, an isolated built Gateway, the actual CLI and Control UI, and a deterministic local OpenAI-compatible provider. The corpus contains 1,998 sessions with 64 KiB saved prompts. This is a controlled stress workload, not a multi-day production soak.

| Measurement | Baseline | Candidate | Reduction |
| --- | ---: | ---: | ---: |
| Main heap after GC | 703.82 MB | 313.37 MB | 55.5% |
| Process RSS after GC | 1318.81 MB | 830.36 MB | 37.0% |
| Workload peak RSS | 3504.31 MB | 2460.60 MB | 29.8% |
| Retained saved-prompt copies | 5,994 (392.92 MB) | 0 | 100% |

Final integrated runtime proof (`184c9c303fa`): the complete build passed and all nine workload stages passed, with 310.99 MB post-GC heap, 834.42 MB RSS, 2285.55 MB workload peak RSS, **zero retained saved fixture prompts**, and zero browser errors. Reset retained the session ID, rotated its lifecycle, cleared saved skills, preserved the model override, and deletion changed 1,998 rows to 1,997; repeated deletion returned false and an unrelated row stayed byte-identical. The final `/readyz` response was ready with no failing checks or event-loop degradation. Source/tree/diff and built-file hashes bind this replay to the exact pushed commit.

The earlier integrated build (`300b7781d554`) also passed all nine stages, with 313.20 MB heap, 836.83 MB RSS, and zero retained saved fixture prompts. These integration figures include newer main changes and are not a separate attribution of their gains to this PR. Historical integration suites passed 289 tests, then another 108 tests with seven Linux-only cases skipped locally.

The workload covers prepared/full/refreshed model catalogs, three CLI agent turns, 500 distinct paginated session keys, 20 reconnect/subscription cycles, 20 status/list cycles, Web UI paging/sidebar expansion/reloads, and an actual composer reply. Reset and deletion additionally verify lifecycle rotation, repeated deletion, and preservation of an unrelated session. Browser errors: zero.

Allocation and owner probes independently show reply-snapshot retention falling from 132.25 MB to 0.12 MB; commit retention from 135.95 MB to 8.94 MB; and deletion survivor payload acquisition from 131.19 MB to 0.16 MB, with transcript ownership and unrelated persisted rows preserved. The final main-isolate heap snapshot contains zero saved fixture prompts, versus 5,994 retained copies on the baseline. The Activity browser stress case retains 0.65 MB instead of 17.35 MB after 100 large results and eviction of all raw result events; the same 100 rows and 200,000 preview characters remain visible.

The catalog grew from 230 to 266 models during the test window, so no cold-catalog performance improvement is claimed. Whole-process RSS includes Workers and allocator behavior; heap figures are post-GC main-isolate measurements. The pool idle timer was bounded at 60 seconds. Watchers and repeating MCP/SQLite maintenance timers retained completed turns until their owners closed; the periodic timers now start in their owner context. This PR does not claim to resolve every multi-day/custom-plugin report in #91588.

Regression tests fail on the original sources and pass with the repairs, including actual native timers/watchers under two async contexts, related-row snapshot consistency across an await, shared-window deletion, writable/read-only lookup visibility, diagnostics inventory, key-less ingress, and both Activity payload branches. Focused and sibling lifecycle, authorization, heartbeat, transport, and UI suites pass. Full build, formatting, core/test/UI/plugin type checks, lint, dead-export and boundary guards passed. The final MCP/WAL suites passed 170 tests (seven Linux-only tests skipped on macOS). A fresh independent Codex review found no actionable P0 issues. One build attempt correctly stopped on a changing dependency-resolution namespace; the unchanged-source retry passed. A Promise-executor lint finding in the new test was corrected and the suite/lint rerun passed.

The base includes #134824's release-inventory repair: it selects package metadata from the immutable Git tree before collecting it, preventing unrelated source growth from overflowing Node's 1 MiB buffer. This resolves the `ENOBUFS` encountered in [CI](https://github.com/openclaw/openclaw/actions/runs/33475586579/job/99754176091), with a large-tree regression and root/core/plugin manifest and README symlink coverage. The memory PR preserves that implementation unchanged.

ClawSweeper follow-through: its September 1, 09:02 UTC review covers exact head `184c9c303fa` and finds no actionable introduced defect. The maintainer accepts the bounded lifecycle change and net 84 production lines with the selected-session, related-parent/command-target, shared-window deletion, concurrency, and native-lifetime regressions retained and passing. The complete build, 180-test focused run, changed-scope checks, live reset/delete and zero-retainer replay, and exact-head CI supply the requested integration proof. Its SQLite-table and serialized-state warnings are not applicable: `sqlite-wal.ts` only changes the async context used to allocate its existing maintenance timer, and the entry-mutation change removes unused revision plumbing. No DDL, schema, stored row format, checkpoint mode, maintenance interval, or persistence policy changes.

Production: +257/-173 (net +84); tests and test support: +686/-75 (net +611). The added production code establishes selected-row snapshot acquisition and explicit background lifetime ownership; obsolete whole-inventory paths, the no-op initialization helper, and unused revision plumbing are removed from these flows. A preexisting test fixture now keeps its reindex lock inside temporary state. Named follow-ups: forced maintenance still hydrates full entries, and the UI full-message expansion cache has no payload-byte cap; neither is claimed fixed here.

Latest candidate validation: fresh independent Codex P0 review is clean; the exact-head full build and all nine live stages pass, and [full CI run 33486488004](https://github.com/openclaw/openclaw/actions/runs/33486488004) is green. The final focused integration run passed 180 tests across 14 files, with seven Linux-only cases skipped on macOS, including all 11 Doctor process cases. `check:changed` passed formatting, dependency and source-boundary guards, Doctor closure tests, core/test/UI/plugin typechecks, lint, unused-export scans, schema/storage guards, import-cycle checks, and webhook/pairing guards. Earlier measured results above remain tied to their stated revisions. The Doctor CI timeout is repaired by main #134812’s canonical pre-worker runtime build; its original readiness deadline and migration assertions remain intact.

Before and after Activity: identical visible content, bounded retained storage.

![Activity before](https://github.com/user-attachments/assets/16f60b11-56d7-4598-820b-cb301b8dd6b0)

![Activity after](https://github.com/user-attachments/assets/8788b161-8f64-4383-99b3-461bb11e0a48)

Actual rebuilt Gateway Web UI reply on final head `184c9c303fa`:

https://github.com/user-attachments/assets/9e98d166-51af-486a-8df3-503d409952ad
