### PR TITLE
fix: preserve workspaces when upgrading legacy agent lists

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -278,9 +278,10 @@ Dream Diary details.
 
 The dreaming system has two related review lanes:
 
-- **Live dreaming** works from the short-term dreaming store under
-  `memory/.dreams/` and is what the normal deep phase uses to decide what
-  graduates into `MEMORY.md`.
+- **Live dreaming** works from short-term dreaming state in SQLite plugin
+  storage and is what the normal deep phase uses to decide what graduates into
+  `MEMORY.md`. Doctor owns migration of legacy dreaming JSON state from
+  `memory/.dreams/`; run `openclaw doctor --fix` before using that old state.
 - **Grounded backfill** reads historical `memory/YYYY-MM-DD.md` notes as
   standalone day files and writes structured review output into `DREAMS.md`.
 

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -240,6 +240,13 @@ both keyed `agents.entries` and older `agents.list` rosters, including with
 `--fix --non-interactive`. Existing bindings and per-surface owners remain
 unchanged; Doctor does not choose an agent for unowned surfaces.
 
+When migrating a legacy `agents.list` roster without a default marker, Doctor
+also pins the first agent's inherited workspace to `agents.entries.<id>.workspace`. Its customized instructions
+and historical `memory/` notes remain in their original directory. Explicit
+workspaces stay authoritative. If an earlier upgrade already left two edited
+workspaces, select the intended per-agent workspace and reconcile their contents
+from your backups; Doctor does not merge directories.
+
 ## Multiple accounts / phone numbers
 
 Channels that support multiple accounts (e.g. WhatsApp) use `accountId` to identify each login. Each `accountId` routes to its own agent, so one server can host multiple phone numbers without mixing sessions.

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1798,6 +1798,7 @@ describe("doctor config flow", () => {
   it("stamps explicit ownership when Doctor migrates a markerless multi-agent list", async () => {
     const rawConfig = {
       agents: {
+        defaults: { workspace: "/srv/legacy-shared" },
         list: [{ id: "ops" }, { id: "research", model: "openai/research" }],
       },
     };
@@ -1814,9 +1815,10 @@ describe("doctor config flow", () => {
       ["agents", "ownership"],
     ]);
     expect(result.cfg.agents).toEqual({
+      defaults: { workspace: "/srv/legacy-shared" },
       ownership: "explicit",
       entries: {
-        ops: {},
+        ops: { workspace: "/srv/legacy-shared" },
         research: { model: "openai/research" },
       },
     });

--- a/src/commands/doctor-config-flow.workspace-persistence.test.ts
+++ b/src/commands/doctor-config-flow.workspace-persistence.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveAgentWorkspaceDir } from "../agents/agent-scope-config.js";
 import { readConfigFileSnapshot } from "../config/config.js";
 import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
 import { makeCronJob } from "../cron/delivery.test-helpers.js";
@@ -151,6 +152,71 @@ describe("Doctor workspace persistence", () => {
             false,
           );
         });
+      });
+    },
+  );
+
+  it.each([
+    { kind: "shared", legacyId: "main" },
+    { kind: "implicit", legacyId: "main" },
+    { kind: "shared", legacyId: " Main " },
+    { kind: "implicit", legacyId: " Main " },
+  ])(
+    "preserves the markerless $legacyId agent's $kind workspace through Doctor persistence",
+    async ({ kind, legacyId }) => {
+      await withTempHome(async (home) => {
+        await withEnvOverride(
+          { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1", OPENCLAW_WORKSPACE_DIR: undefined },
+          async () => {
+            const workspace = path.join(
+              home,
+              kind === "shared" ? "shared-workspace" : ".openclaw/workspace",
+            );
+            await fs.mkdir(path.join(workspace, "memory"), { recursive: true });
+            const originals = {
+              "AGENTS.md": "# Existing agent\n\nKeep the original workspace.\n",
+              "SOUL.md": "# Existing character\n",
+              "IDENTITY.md": "# Original identity\n",
+              "USER.md": "# Original preferences\n",
+              "MEMORY.md": "# Original durable memory\n",
+              "memory/2026-07-01.md": "Historical memory remains in this workspace.\n",
+            };
+            for (const [name, content] of Object.entries(originals)) {
+              await fs.writeFile(path.join(workspace, name), content);
+            }
+            const configPath = await writeOpenClawConfig(home, {
+              agents: {
+                ...(kind === "shared" ? { defaults: { workspace } } : {}),
+                list: [{ id: legacyId }, { id: "other" }],
+              },
+              gateway: { mode: "local" },
+              plugins: { enabled: false },
+            });
+            const before = await readConfigFileSnapshot();
+            expect(before.valid).toBe(false);
+            if (legacyId === "main") {
+              expect(resolveAgentWorkspaceDir(before.sourceConfig, "main")).toBe(workspace);
+            } else {
+              expect(before.sourceConfig.agents?.list?.[0]?.id).toBe(legacyId);
+            }
+
+            const ctx = await prepareDoctorContext(configPath);
+            await runInitialConfigWriteHealth(ctx);
+            const saved = await readConfigFileSnapshot();
+            expect(saved.valid).toBe(true);
+            expect(saved.config.agents?.ownership).toBe("explicit");
+            expect(saved.config.agents?.entries?.main?.workspace).toBe(workspace);
+            expect(saved.config.agents?.defaults?.systemAgent).toBeUndefined();
+            expect(saved.config.bindings).toBeUndefined();
+            expect(resolveAgentWorkspaceDir(saved.config, "main")).toBe(workspace);
+            for (const [name, content] of Object.entries(originals)) {
+              expect(await fs.readFile(path.join(workspace, name), "utf8")).toBe(content);
+            }
+            expect((await prepareDoctorContext(configPath)).configResult.shouldWriteConfig).toBe(
+              false,
+            );
+          },
+        );
       });
     },
   );

--- a/src/commands/doctor/shared/legacy-config-migrate.e2e.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.e2e.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { resolveMemorySearchConfig } from "../../../agents/memory-search.js";
+import { resolveDefaultAgentWorkspaceDir } from "../../../agents/workspace-default.js";
 import { validateConfigObjectRaw } from "../../../config/validation.js";
 import { applyLegacyDoctorMigrations } from "./legacy-config-compat.js";
 import { migrateLegacyConfig } from "./legacy-config-migrate.js";
@@ -15,7 +16,12 @@ describe("legacy config migration end to end", () => {
       },
     });
     expect(duplicate.next).toEqual({
-      agents: { entries: { main: { name: "first" }, "main-2": { name: "second" } } },
+      agents: {
+        entries: {
+          main: { name: "first", workspace: resolveDefaultAgentWorkspaceDir() },
+          "main-2": { name: "second" },
+        },
+      },
     });
     expect(applyLegacyDoctorMigrations(duplicate.next)).toEqual({ next: null, changes: [] });
 

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.entries.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.entries.ts
@@ -1,4 +1,5 @@
 import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
+import { resolveLegacyFirstAgentWorkspacePin } from "../../../config/legacy.default-agent-roles.js";
 import {
   defineLegacyConfigMigration,
   getRecord,
@@ -16,6 +17,7 @@ function migrateAgentEntries(raw: Record<string, unknown>, changes: string[]): v
     return;
   }
   const entries: Record<string, unknown> = {};
+  const orderedEntries: Record<string, unknown>[] = [];
   for (const [index, value] of agents.list.entries()) {
     const entry = getRecord(value);
     if (!entry) {
@@ -34,6 +36,7 @@ function migrateAgentEntries(raw: Record<string, unknown>, changes: string[]): v
       suffix += 1;
     }
     const { id: _id, ...config } = entry;
+    orderedEntries.push(config);
     Object.defineProperty(entries, key, {
       configurable: true,
       enumerable: true,
@@ -43,6 +46,10 @@ function migrateAgentEntries(raw: Record<string, unknown>, changes: string[]): v
     if (key !== requestedId) {
       changes.push(`Moved duplicate agents.list id "${requestedId}" to agents.entries.${key}.`);
     }
+  }
+  const workspace = resolveLegacyFirstAgentWorkspacePin(agents, orderedEntries);
+  if (workspace !== undefined) {
+    orderedEntries[0]!.workspace = workspace;
   }
   agents.entries = entries;
   delete agents.list;

--- a/src/config/io.context.ts
+++ b/src/config/io.context.ts
@@ -134,7 +134,10 @@ export function createConfigIoContext(options: ConfigIoFactoryOptions = {}): Con
     const contextBudgetConfig = migrateLegacyContextBudgetConfig(
       resolution.resolvedConfigRaw,
     ).config;
-    return coerceConfig(migratePersistedImplicitMainRoster(contextBudgetConfig).config);
+    return coerceConfig(
+      migratePersistedImplicitMainRoster(contextBudgetConfig, { env, homedir: deps.homedir })
+        .config,
+    );
   }
 
   function prepareRecoveryBackupCandidate(

--- a/src/config/io.load.ts
+++ b/src/config/io.load.ts
@@ -63,7 +63,10 @@ export function loadConfigFromContext(
     const contextBudgetMigration = migrateLegacyContextBudgetConfig(
       readResolution.resolvedConfigRaw,
     );
-    const rosterMigration = migratePersistedImplicitMainRoster(contextBudgetMigration.config);
+    const rosterMigration = migratePersistedImplicitMainRoster(contextBudgetMigration.config, {
+      env: deps.env,
+      homedir: deps.homedir,
+    });
     const effectiveConfigRaw = rosterMigration.config;
     const validationConfigRaw = effectiveConfigRaw;
     const snapshotRaw = raw;

--- a/src/config/io.snapshot.ts
+++ b/src/config/io.snapshot.ts
@@ -198,7 +198,10 @@ export async function readConfigFileSnapshotInternal(
     const contextBudgetMigration = migrateLegacyContextBudgetConfig(
       readResolution.resolvedConfigRaw,
     );
-    const rosterMigration = migratePersistedImplicitMainRoster(contextBudgetMigration.config);
+    const rosterMigration = migratePersistedImplicitMainRoster(contextBudgetMigration.config, {
+      env: deps.env,
+      homedir: deps.homedir,
+    });
     envVarWarnings.push(
       ...contextBudgetMigration.changes,
       ...contextBudgetMigration.warnings,

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import chokidar from "chokidar";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { createModelVisibilityPolicy } from "../agents/model-visibility-policy.js";
-import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace-default.js";
 import { startGatewayConfigReloader } from "../gateway/config-reload.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
@@ -1078,7 +1077,7 @@ describe("config io write", () => {
         params: { transport: "sse", openaiWsWarmup: false },
       });
       expect(persisted.agents?.entries).toEqual({
-        main: { workspace: resolveDefaultAgentWorkspaceDir() },
+        main: { workspace: path.join(home, ".openclaw", "workspace") },
         ops: {},
       });
     },

--- a/src/config/io.write-topology.ts
+++ b/src/config/io.write-topology.ts
@@ -24,13 +24,14 @@ export function prepareConfigWriteTopology(
     options: Pick<ConfigWriteOptions, "explicitSetPaths" | "explicitSetValueSource">;
     unsetPaths: readonly (readonly string[])[];
     env: NodeJS.ProcessEnv;
+    homedir?: () => string;
   },
 ) {
-  const { snapshot, options, unsetPaths, env, pluginMetadataSnapshot } = params;
+  const { snapshot, options, unsetPaths, env, homedir, pluginMetadataSnapshot } = params;
   let nextConfig = params.nextConfig;
   const sourceRosterMigration = migratePersistedImplicitMainRoster(
     snapshot.sourceConfigBeforeMigrations ?? snapshot.parsed,
-    { env },
+    { env, homedir },
   );
   const retainedLegacyDefaultAgentId = sourceRosterMigration.retainedLegacyDefaultAgentId;
   const previousEntries = listAgentEntries(snapshot.config);
@@ -60,7 +61,8 @@ export function prepareConfigWriteTopology(
     if (nextEntries.some((entry) => entry.default === true)) {
       // This writer owns role transitions; retire only the submitted roster marker.
       nextConfig = coerceConfig(
-        migratePersistedImplicitMainRoster(nextConfig, { materializeRoles: false, env }).config,
+        migratePersistedImplicitMainRoster(nextConfig, { materializeRoles: false, env, homedir })
+          .config,
       );
     }
     nextConfig = {
@@ -106,7 +108,7 @@ export function prepareConfigWriteTopology(
         ownerAgentId,
         env,
         pluginMetadataSnapshot?.manifestRegistry.plugins,
-        { materializeSessionStore: sameFixedSessionStore, materializeWorkspace: true },
+        { materializeSessionStore: sameFixedSessionStore, materializeWorkspace: true, homedir },
       )
     : { config: nextConfig, insertedPaths: [] };
   nextConfig = ownershipMaterialization.config;

--- a/src/config/io.write-topology.ts
+++ b/src/config/io.write-topology.ts
@@ -30,6 +30,7 @@ export function prepareConfigWriteTopology(
   let nextConfig = params.nextConfig;
   const sourceRosterMigration = migratePersistedImplicitMainRoster(
     snapshot.sourceConfigBeforeMigrations ?? snapshot.parsed,
+    { env },
   );
   const retainedLegacyDefaultAgentId = sourceRosterMigration.retainedLegacyDefaultAgentId;
   const previousEntries = listAgentEntries(snapshot.config);
@@ -59,7 +60,7 @@ export function prepareConfigWriteTopology(
     if (nextEntries.some((entry) => entry.default === true)) {
       // This writer owns role transitions; retire only the submitted roster marker.
       nextConfig = coerceConfig(
-        migratePersistedImplicitMainRoster(nextConfig, { materializeRoles: false }).config,
+        migratePersistedImplicitMainRoster(nextConfig, { materializeRoles: false, env }).config,
       );
     }
     nextConfig = {

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -128,6 +128,7 @@ export async function writeConfigFileFromContext(
     options,
     unsetPaths,
     env: deps.env,
+    homedir: deps.homedir,
   });
   const cronOwnerRefusal = cronOwner
     ? await prepareCronOwnerWriteRefusal(snapshot.config, {

--- a/src/config/legacy.default-agent-roles.ts
+++ b/src/config/legacy.default-agent-roles.ts
@@ -93,6 +93,7 @@ export function materializeLegacyDefaultAgentRoles(
   options: {
     ambientChannelIds?: readonly string[];
     env?: NodeJS.ProcessEnv;
+    homedir?: () => string;
     materializeSessionStore?: boolean;
     materializeWorkspace?: boolean;
   } = {},

--- a/src/config/legacy.default-agent-roles.ts
+++ b/src/config/legacy.default-agent-roles.ts
@@ -54,6 +54,39 @@ function listUnboundAmbientChannelIds(
     .filter((channelId) => !bindings.some((binding) => isChannelWideBinding(binding, channelId)));
 }
 
+/** Preserve a legacy workspace locator without assigning any runtime ownership. */
+function resolveLegacyAgentWorkspacePin(
+  defaultWorkspace: unknown,
+  entry: { workspace?: unknown },
+  options: { env?: NodeJS.ProcessEnv; homedir?: () => string } = {},
+): string | undefined {
+  const needsPin =
+    !Object.hasOwn(entry, "workspace") ||
+    (typeof entry.workspace === "string" && entry.workspace.trim().length === 0);
+  return needsPin
+    ? (normalizeOptionalString(defaultWorkspace) ??
+        resolveDefaultAgentWorkspaceDir(options.env, options.homedir))
+    : undefined;
+}
+
+export function resolveLegacyFirstAgentWorkspacePin(
+  agents: Record<string, unknown>,
+  entries: readonly Record<string, unknown>[],
+  options: { env?: NodeJS.ProcessEnv; homedir?: () => string } = {},
+): string | undefined {
+  // Shipped markerless lists gave their first agent the shared workspace. Keep
+  // source array order here; integer-like keys reorder after conversion to entries.
+  return agents.ownership === undefined &&
+    entries.length > 1 &&
+    entries.every((entry) => !Object.hasOwn(entry, "default") || entry.default === false)
+    ? resolveLegacyAgentWorkspacePin(
+        isRecord(agents.defaults) ? agents.defaults.workspace : undefined,
+        entries[0]!,
+        options,
+      )
+    : undefined;
+}
+
 export function materializeLegacyDefaultAgentRoles(
   cfg: OpenClawConfig,
   legacyDefaultAgentId: string,
@@ -73,17 +106,11 @@ export function materializeLegacyDefaultAgentRoles(
       (candidate) => normalizeAgentId(candidate) === agentId,
     );
     const entry = entryKey ? entries[entryKey] : undefined;
-    const workspaceNeedsPin =
-      entry !== undefined &&
-      (!Object.hasOwn(entry, "workspace") ||
-        (typeof entry.workspace === "string" && entry.workspace.trim().length === 0));
-    if (entryKey && entry && workspaceNeedsPin) {
-      entries[entryKey] = {
-        ...entry,
-        workspace:
-          normalizeOptionalString(next.agents?.defaults?.workspace) ??
-          resolveDefaultAgentWorkspaceDir(options.env),
-      };
+    const workspace = entry
+      ? resolveLegacyAgentWorkspacePin(next.agents?.defaults?.workspace, entry, options)
+      : undefined;
+    if (entryKey && entry && workspace !== undefined) {
+      entries[entryKey] = { ...entry, workspace };
       next = { ...next, agents: { ...next.agents, entries } };
       insertedPaths.push(["agents", "entries", entryKey, "workspace"]);
     }

--- a/src/config/legacy.roster.test.ts
+++ b/src/config/legacy.roster.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 import { configIncludeOwnsAgentRoster } from "./agent-roster-provenance.js";
-import { readConfigFileSnapshot, resetConfigRuntimeState } from "./config.js";
+import { createConfigIO, readConfigFileSnapshot, resetConfigRuntimeState } from "./config.js";
 import { migratePersistedImplicitMainRoster } from "./legacy.js";
 import { validateConfigObjectRaw } from "./validation.js";
 
@@ -262,16 +262,102 @@ describe("persisted implicit-main roster migration", () => {
     });
   });
 
+  it.each(["env", "homedir"])(
+    "uses the config reader's %s when pinning a legacy workspace",
+    async (source) => {
+      await withTempHome(async (home) => {
+        const selectedHome = path.join(home, "selected-home");
+        const configPath = path.join(selectedHome, ".openclaw", "openclaw.json");
+        await fs.mkdir(path.dirname(configPath), { recursive: true });
+        await fs.writeFile(
+          configPath,
+          JSON.stringify({ agents: { list: [{ id: "first" }, { id: "other" }] } }),
+        );
+        const io = createConfigIO({
+          configPath,
+          env: source === "env" ? { HOME: selectedHome } : {},
+          homedir: () => selectedHome,
+          observe: false,
+          pluginValidation: "core-only",
+        });
+        const snapshot = await io.readConfigFileSnapshot();
+        expect(snapshot.valid).toBe(false);
+        expect(snapshot.sourceConfig.agents?.entries?.first?.workspace).toBe(
+          path.join(selectedHome, ".openclaw", "workspace"),
+        );
+        expect(JSON.parse(await fs.readFile(configPath, "utf8"))).toEqual({
+          agents: { list: [{ id: "first" }, { id: "other" }] },
+        });
+      });
+    },
+  );
+
+  it.each([
+    {
+      agents: { ownership: "explicit", list: [{ id: "main" }, { id: "other" }] },
+      expectedWorkspace: undefined,
+    },
+    { agents: { entries: { main: {}, other: {} } }, expectedWorkspace: undefined },
+    {
+      agents: { list: [{ id: "main", workspace: "/srv/selected" }, { id: "other" }] },
+      expectedWorkspace: "/srv/selected",
+    },
+  ])(
+    "preserves authored workspace decisions and keyed rosters",
+    ({ agents, expectedWorkspace }) => {
+      const migrated = migratePersistedImplicitMainRoster({
+        agents: { defaults: { workspace: "/srv/shared" }, ...agents },
+      });
+      const cfg = migrated.config as {
+        agents: { entries: Record<string, { workspace?: string }> };
+      };
+      expect(cfg.agents.entries.main?.workspace).toBe(expectedWorkspace);
+      expect(migrated.retainedLegacyDefaultAgentId).toBeUndefined();
+    },
+  );
+
+  it.each(["home", "state", "profile", "workspace"])(
+    "pins a markerless legacy workspace using the supplied %s environment",
+    (kind) => {
+      const home = path.resolve("workspace-migration-home");
+      const env = {
+        HOME: home,
+        ...(kind === "state" ? { OPENCLAW_STATE_DIR: path.join(home, "state") } : {}),
+        ...(kind === "profile" ? { OPENCLAW_PROFILE: "work" } : {}),
+        ...(kind === "workspace" ? { OPENCLAW_WORKSPACE_DIR: path.join(home, "selected") } : {}),
+      };
+      const expected =
+        kind === "state"
+          ? path.join(home, "state", "workspace")
+          : kind === "profile"
+            ? path.join(home, ".openclaw-work", "workspace")
+            : kind === "workspace"
+              ? path.join(home, "selected")
+              : path.join(home, ".openclaw", "workspace");
+      const raw = { agents: { list: [{ id: "first" }, { id: "other" }] } };
+      const options = { materializeWorkspace: false, env };
+      const migrated = migratePersistedImplicitMainRoster(raw, options);
+      expect(migrated.config).toMatchObject({
+        agents: { entries: { first: { workspace: expected }, other: {} } },
+      });
+      expect(migrated.retainedLegacyDefaultAgentId).toBeUndefined();
+      expect(raw).toEqual({ agents: { list: [{ id: "first" }, { id: "other" }] } });
+    },
+  );
+
   it("preserves original list order for markerless numeric ids without inventing an owner", () => {
     const migrated = migratePersistedImplicitMainRoster({
-      agents: { list: [{ id: "10" }, { id: "2" }] },
+      agents: {
+        defaults: { workspace: "/srv/fleet" },
+        list: [{ id: "10" }, { id: "2" }],
+      },
     });
     expect(migrated.changed).toBe(true);
     expect(migrated.config).toMatchObject({
       agents: {
         entries: {
           "2": {},
-          "10": {},
+          "10": { workspace: "/srv/fleet" },
         },
       },
     });

--- a/src/config/legacy.roster.test.ts
+++ b/src/config/legacy.roster.test.ts
@@ -262,17 +262,25 @@ describe("persisted implicit-main roster migration", () => {
     });
   });
 
-  it.each(["env", "homedir"])(
-    "uses the config reader's %s when pinning a legacy workspace",
-    async (source) => {
+  it.each([
+    ["env", false],
+    ["homedir", false],
+    ["env", true],
+    ["homedir", true],
+  ] as const)(
+    "uses config IO's %s when reading and persisting a legacy workspace (marked: %s)",
+    async (source, marked) => {
       await withTempHome(async (home) => {
         const selectedHome = path.join(home, "selected-home");
         const configPath = path.join(selectedHome, ".openclaw", "openclaw.json");
         await fs.mkdir(path.dirname(configPath), { recursive: true });
-        await fs.writeFile(
-          configPath,
-          JSON.stringify({ agents: { list: [{ id: "first" }, { id: "other" }] } }),
-        );
+        const raw = {
+          agents: {
+            list: [{ id: "first", ...(marked ? { default: true } : {}) }, { id: "other" }],
+          },
+          plugins: { enabled: false },
+        };
+        await fs.writeFile(configPath, JSON.stringify(raw));
         const io = createConfigIO({
           configPath,
           env: source === "env" ? { HOME: selectedHome } : {},
@@ -281,13 +289,32 @@ describe("persisted implicit-main roster migration", () => {
           pluginValidation: "core-only",
         });
         const snapshot = await io.readConfigFileSnapshot();
-        expect(snapshot.valid).toBe(false);
+        const workspace = path.join(selectedHome, ".openclaw", "workspace");
         expect(snapshot.sourceConfig.agents?.entries?.first?.workspace).toBe(
-          path.join(selectedHome, ".openclaw", "workspace"),
+          marked ? undefined : workspace,
         );
-        expect(JSON.parse(await fs.readFile(configPath, "utf8"))).toEqual({
-          agents: { list: [{ id: "first" }, { id: "other" }] },
+        expect(JSON.parse(await fs.readFile(configPath, "utf8"))).toEqual(raw);
+        const next = structuredClone(snapshot.sourceConfig);
+        next.agents = {
+          ...next.agents,
+          ownership: "explicit",
+          entries: {
+            ...next.agents?.entries,
+            first: { ...next.agents?.entries?.first, name: "first-updated" },
+          },
+        };
+        await io.writeConfigFile(next, {
+          skipPluginValidation: true,
+          explicitSetPaths: [
+            ["agents", "entries"],
+            ["agents", "ownership"],
+          ],
         });
+        const saved = JSON.parse(await fs.readFile(configPath, "utf8"));
+        expect(saved.agents.entries.first.workspace).toBe(workspace);
+        expect(
+          (await io.readConfigFileSnapshot()).sourceConfig.agents?.entries?.first?.workspace,
+        ).toBe(workspace);
       });
     },
   );

--- a/src/config/legacy.roster.ts
+++ b/src/config/legacy.roster.ts
@@ -4,7 +4,10 @@ import {
   retainLegacyDefaultAgentId,
   tryGetLegacyDefaultAgentId,
 } from "./legacy.default-agent-owner.js";
-import { materializeLegacyDefaultAgentRoles } from "./legacy.default-agent-roles.js";
+import {
+  materializeLegacyDefaultAgentRoles,
+  resolveLegacyFirstAgentWorkspacePin,
+} from "./legacy.default-agent-roles.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
 type MigrationResult = {
@@ -18,7 +21,7 @@ type MigrationResult = {
 /** Converts a valid legacy roster without applying ownership or runtime migrations. */
 export function parseLegacyAgentRoster(
   value: unknown,
-): { entries: Record<string, unknown>; order: string[] } | undefined {
+): { entries: Record<string, Record<string, unknown>>; order: string[] } | undefined {
   if (!Array.isArray(value)) {
     return undefined;
   }
@@ -44,7 +47,12 @@ export function parseLegacyAgentRoster(
 
 export function migratePersistedImplicitMainRoster(
   raw: unknown,
-  options: { materializeWorkspace?: boolean; materializeRoles?: boolean } = {},
+  options: {
+    materializeWorkspace?: boolean;
+    materializeRoles?: boolean;
+    env?: NodeJS.ProcessEnv;
+    homedir?: () => string;
+  } = {},
 ): MigrationResult {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
     return { config: raw, changed: false, diagnostics: [] };
@@ -61,14 +69,14 @@ export function migratePersistedImplicitMainRoster(
       ? (root.agents as Record<string, unknown>)
       : {};
   let convertedLegacyList = false;
-  let legacyRosterOrder: string[] | undefined;
+  let legacyRoster: ReturnType<typeof parseLegacyAgentRoster>;
   let rosterProperty = readAgentRosterProperty({ ...root, agents });
   if (rosterProperty?.kind === "list") {
     const roster = parseLegacyAgentRoster(rosterProperty.value);
     if (!roster) {
       return { config: raw, changed: false, diagnostics: [] };
     }
-    legacyRosterOrder = roster.order;
+    legacyRoster = roster;
     const { list: _list, ...rest } = agents;
     agents = { ...rest, entries: roster.entries };
     convertedLegacyList = true;
@@ -100,7 +108,7 @@ export function migratePersistedImplicitMainRoster(
   }
   const roster = entries as Record<string, unknown>;
   const validIds =
-    legacyRosterOrder ??
+    legacyRoster?.order ??
     Object.entries(roster).flatMap(([id, entry]) =>
       entry && typeof entry === "object" && !Array.isArray(entry) ? [id] : [],
     );
@@ -126,6 +134,23 @@ export function migratePersistedImplicitMainRoster(
   let insertedPaths: string[][] = [];
   const diagnostics = convertedLegacyList ? ["Moved agents.list to keyed agents.entries."] : [];
   let changed = convertedLegacyList;
+  if (legacyRoster && !legacyDefaultAgentId) {
+    const firstId = legacyRoster.order[0]!;
+    const entry = legacyRoster.entries[firstId]!;
+    const workspace = resolveLegacyFirstAgentWorkspacePin(
+      agents,
+      legacyRoster.order.map((id) => legacyRoster.entries[id]!),
+      options,
+    );
+    if (workspace !== undefined) {
+      nextRoot = {
+        ...nextRoot,
+        agents: { ...agents, entries: { ...roster, [firstId]: { ...entry, workspace } } },
+      };
+      insertedPaths.push(["agents", "entries", firstId, "workspace"]);
+      diagnostics.push("Preserved the first legacy agent's existing workspace.");
+    }
+  }
   if (legacyDefaultAgentId && options.materializeRoles !== false) {
     const materialized = materializeLegacyDefaultAgentRoles(
       nextRoot as OpenClawConfig,

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -175,7 +175,11 @@ export function materializeLegacyAgentOwnershipForActiveChannelsResult(
   legacyDefaultAgentId: string,
   env?: NodeJS.ProcessEnv,
   manifestRecords?: PluginManifestRegistry["plugins"],
-  options?: { materializeSessionStore?: boolean; materializeWorkspace?: boolean },
+  options?: {
+    materializeSessionStore?: boolean;
+    materializeWorkspace?: boolean;
+    homedir?: () => string;
+  },
 ): ReturnType<typeof materializeLegacyDefaultAgentRoles> {
   const ambientChannelIds = listChannelIdsForOwnershipMigration({
     config,
@@ -185,6 +189,7 @@ export function materializeLegacyAgentOwnershipForActiveChannelsResult(
   const materialized = materializeLegacyDefaultAgentRoles(config, legacyDefaultAgentId, {
     ambientChannelIds,
     env,
+    homedir: options?.homedir,
     materializeSessionStore: options?.materializeSessionStore,
     materializeWorkspace: options?.materializeWorkspace,
   });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -136,7 +136,9 @@ function validateConfigObjectWithPluginMode(
   applyDefaults: boolean,
 ): ValidateConfigWithPluginsResult {
   const contextBudgetConfig = migrateLegacyContextBudgetConfig(raw).config;
-  const migrated = migratePersistedImplicitMainRoster(contextBudgetConfig).config as OpenClawConfig;
+  const migrated = migratePersistedImplicitMainRoster(contextBudgetConfig, {
+    env: params?.env,
+  }).config as OpenClawConfig;
   let manifestRegistry = params?.pluginMetadataSnapshot?.manifestRegistry;
   const result = validateConfigObjectWithPluginsBase(migrated, {
     applyDefaults,


### PR DESCRIPTION
Related: #133984

## What Problem This Solves

Users upgrading a markerless multi-agent `agents.list` roster could find their customized instructions and memory missing. Conversion changed the first agent's effective workspace from the existing shared directory to a new per-agent directory, while the original files remained on disk.

## Why This Change Was Made

Preserve the workspace locator shipped in 2026.7 before converting the roster. The strict config reader and Doctor's existing ID-normalization path share one migration policy and retain source array order, including numeric IDs. Config reads and writes carry their existing environment and home resolver through the canonical workspace materializer.

The writer correction also fixes the marked-default sibling: with an injected home resolver and no `HOME`, a roster write previously pinned the process account's workspace. Forwarding the existing ConfigIO dependency repairs that boundary without a second resolver or runtime fallback.

## User Impact

The first agent keeps using its original instructions and memory after markerless-list migration. Authored workspace paths and explicit ownership remain authoritative. Migration does not assign ambient routing ownership or move or merge files. The guide explains how to reconcile directories already edited after an earlier upgrade and corrects the description of live dreaming-state storage.

## Evidence

The baseline built CLI at `09a71580645f6ee2da22ac22938da04e76c3cfa6` completed `doctor --fix --non-interactive` but persisted explicit ownership without the first agent's workspace. The regression fixtures also failed for supplied HOME/state/profile/workspace paths, numeric source order, and historical IDs requiring Doctor normalization.

A native macOS CLI/Gateway replay verified the original 12 frozen source-file hashes. Doctor preserved the workspace, migrated the legacy setup file, and kept all six instruction/memory files byte-identical. The first provider request contained the original AGENTS, SOUL, IDENTITY, USER, and MEMORY content. Two agents completed actual Gateway turns against a local scripted provider, each including its own workspace marker and excluding the other's. Both listeners closed, the Gateway exited 0, and the temporary profile was removed. This is real CLI/Gateway/migration behavior with synthetic provider responses; authenticated external model/channel delivery and daily-note retrieval were not exercised.

The workspace-focused suite passed **54/54 tests**: 38 roster tests and 16 Doctor persistence tests, including four controls recently added on main. The existing ConfigIO test now covers environment/home-resolver × markerless/marked inputs through read, write, and reload. Before the writer correction, three matrix cases passed and only marked-default plus injected-home failed. The review's proposed markerless failure did not reproduce; the confirmed marked-default sibling is repaired. All four now retain the selected workspace on disk. The separate stale Doctor-flow expectation was corrected and its **67-test suite passed**.

The corrective head's hosted config-write shard exposed a stale expectation in the existing provider-parameter test: its ConfigIO supplies a fixture home, but the expected workspace used the process home. The expectation now uses the fixture home and retains the complete roster and provider-parameter assertions. The same whole-file run fails on unfixed main `f99d9620017f` (**128 pass, 1 fail**) and passes on the fixed candidate (**129/129**, wrapper exit 0). The test-only correction passed independent P0/P1 review; production source was unchanged.

The latest ClawSweeper review also found a stale full-object expectation in the direct Doctor duplicate-ID migration test. The unchanged `8c48f4b` baseline produced **7 passes and 1 failure** because the first migrated entry now correctly retains its inherited workspace. The expectation now uses the default-workspace resolver while preserving complete object equality, deterministic duplicate IDs, canonical-entry precedence, and idempotence. The combined roster, Doctor persistence, and direct migration suites passed **62/62 tests** (38 + 16 + 8), wrapper exit 0 in 185.83s. The test-only correction passed independent P0/P1 review with no findings, and production source hashes were unchanged. An audit of the other direct migration callers found no additional stale full-roster expectations. This resolves the preceding review’s duplicate-ID finding and requested migration and persistence coverage.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/config/legacy.roster.test.ts \
  src/commands/doctor-config-flow.workspace-persistence.test.ts \
  src/commands/doctor/shared/legacy-config-migrate.e2e.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/config/io.write-config.test.ts
node scripts/check-changed.mjs --base 09a71580645f6ee2da22ac22938da04e76c3cfa6
```

The original full changed-file gate and independent Codex review passed. The final homedir correction passed independent P0/P1 review, focused tests, core production/test typechecks, targeted formatting and typed lint, and coercion/deprecated-API guards. Its resumed local aggregate was stopped during the redundant full-tree unused-export scan; that aggregate is incomplete. Hosted [CI run 33493727882](https://github.com/openclaw/openclaw/actions/runs/33493727882) completed successfully for `8c48f4b47f9e10402992cf396478e36b2fad657b` (199 successful jobs, 16 skipped). The final test-only corrective head `d62f2ab12ab82491206d4d1d941771789e3f4eac` passed hosted [CI run 33497367994](https://github.com/openclaw/openclaw/actions/runs/33497367994): **201 successful jobs, 16 skipped**. Its complete PR rollup has **228 successful checks, 48 skipped, and one neutral**, with no pending or failing checks.

The [final ClawSweeper review](https://github.com/openclaw/openclaw/pull/134892#issuecomment-5489605024) covers `d62f2ab` and finds no remaining correctness or security defect. Maintainer decision: accept the shared migration rule that preserves the shipped first-agent workspace while retaining explicit workspace and ownership choices. The requested exact-head CI is green.

Production LOC: **+105/-25 (net +80)**; tests: **+193/-7 (net +186)**; docs: **+11/-3**. Production growth records the existing locator at both migration owners and forwards the existing ConfigIO resolution context. The shared helper replaces the former inline workspace-pin branch. No new config option, SQLite schema, persistent-store design, or runtime legacy reader is introduced.
