### PR TITLE
fix(deepinfra): refresh estimates from native pricing

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -292,12 +292,15 @@ Its scheduled workflow checks OpenClaw's default-branch plugin manifests and
 public pricing sources every four hours; every catalog content change is
 preserved as a public commit. Provider-owned policies select complete price
 schedules, including context tiers, without mixing rates from different sources.
-Declared native sources read the public Cerebras, Chutes, OpenCode, and Venice
+Declared native sources read the public Cerebras, Chutes, DeepInfra, OpenCode, and Venice
 catalogs, so connected installations can receive advertised price changes without
 a new OpenClaw release. When a valid native feed no longer supplies a model's
 price, publication preserves the model metadata without an estimate; it does not
 infer retirement or substitute another source's rate. Explicit user costs still
-win.
+win. DeepInfra uses its agent projection for model metadata and its native
+`/models/list` feed for prices, including numeric discounts. Qualified schedules
+that cannot be represented as unconditional token costs stay unknown; models
+remain available. See [DeepInfra price estimates](/providers/deepinfra#price-estimates).
 
 Run `openclaw models refresh` for an immediate metadata and pricing check, or
 disable every hosted catalog request with `models.catalogRefresh.enabled:

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -1299,6 +1299,7 @@ Provider fields:
 | ------------ | ----------------- | ----------------------------------------------------------------------------------------------- |
 | `cerebras`   | `false \| object` | Explicit mapping to the public Cerebras `/public/v1/models` catalog. Never enabled implicitly.  |
 | `chutes`     | `false \| object` | Explicit mapping to the public Chutes `/v1/models` catalog. Never enabled implicitly.           |
+| `deepinfra`  | `false \| object` | Explicit mapping to the public DeepInfra `/models/list` catalog. Never enabled implicitly.      |
 | `external`   | `boolean`         | Set `false` for local/self-hosted providers that should never use published external pricing.   |
 | `openCode`   | `false \| object` | Explicit mapping to the public `models.opencode.ai/api.json` catalog. Never enabled implicitly. |
 | `openRouter` | `false \| object` | OpenRouter publication-key mapping. `false` disables OpenRouter matching for this provider.     |
@@ -1335,9 +1336,16 @@ For authoritative native source mappings, use:
 
 The publisher fetches a fixed public endpoint without credentials only when its
 source is declared, and publishes native prices only in explicitly mapped owner
-namespaces. Cerebras and Chutes use the same shape with their respective source
+namespaces. Cerebras, Chutes, and DeepInfra use the same shape with their respective source
 and provider IDs. Lightweight plugin-owned `pricing-api.ts` artifacts share
 payload parsing with runtime discovery without importing provider runtimes.
+
+DeepInfra's top-level array uses `model_name` identity. Its numeric discount and
+cached-input ratio apply to native cents-per-token prices. Pricing prose,
+nonempty tables, scheduled expiry, and undocumented generic cache-write rates
+are validated but omitted as unsupported schedules. Priority/flex and explicit
+cache-retention multipliers do not change standard costs. Its agent projection
+continues to own runtime metadata; the pricing feed does not discover chat models.
 
 An opted-in native source owns the complete provider schedule, including missing
 prices: generic sources cannot fill its gaps. A successful feed with no price for

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -418,13 +418,23 @@ catalog, API-key auth, and dynamic model resolution.
 
     Official plugins use the private, pure
     `openclaw/plugin-sdk/model-catalog-pricing` runtime subpath. It exposes
-    `normalizeModelPricingCatalog(rows, normalizePricing, readPricing?)` for
+    `normalizeModelPricingCatalog(rows, normalizePricing, options?)` for
     provider-owned pricing feeds. It returns a map of complete costs: absent
     prices are omitted, while malformed declared prices, invalid or duplicate
     model IDs, and a feed with no usable prices return `undefined`. Supply the
-    provider's unit conversion and optional price-field selector; the default
-    selector reads `model.pricing`. No auth, discovery, or runtime loader is
-    imported.
+    provider's unit conversion. Options can select `readModelId(model)` (default
+    `model.id`), `readPricing(model)` (default `model.pricing`), and
+    `isSupportedPricing(rawPricing)` (default `true`). Declared prices are
+    normalized and validated before unsupported schedules are omitted; duplicate
+    IDs are rejected even on unpriced or unsupported rows. Non-token domains
+    can return `undefined` from `readPricing`. No auth, discovery, or runtime
+    loader is imported.
+
+    DeepInfra's `pricing-api.ts` uses these selectors for its native array and
+    `model_name` identities. Release plugins using the options contract (including
+    DeepInfra and Venice) with a matching host, and coordinate their plugin API
+    and minimum-host floors at release time. The private subpath is not an
+    independently versioned third-party compatibility API.
 
     This subpath also exposes `normalizeOpenRouterModelPricing(pricing)` for
     native OpenRouter pricing objects. It converts per-token rates and static

--- a/docs/providers/deepinfra.md
+++ b/docs/providers/deepinfra.md
@@ -91,6 +91,39 @@ deepinfra/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B
 ...and many more
 ```
 
+## Price estimates
+
+Chat discovery keeps model membership, order, tags, and limits from DeepInfra's
+agent projection. Prices come separately from the anonymous native
+[`/models/list`](https://docs.deepinfra.com/api-reference/models/models-list)
+catalog. The plugin converts cents per token to USD per million tokens, applies
+the advertised numeric discount once, and uses the native cached-input ratio.
+Both requests share the existing five-minute live-catalog cache and run
+concurrently only for configured chat discovery. Image and video discovery do
+not request chat prices.
+
+Schedules qualified by pricing prose, a nonempty pricing table, or a scheduled
+discount expiry remain unknown; OpenClaw does not guess context tiers or parse
+promotion dates. A declared generic cache-write rate also remains unsupported
+because its numeric semantics are not documented. Explicit 5-minute/1-hour
+retention and priority/flex rates are separate contracts and are not included in
+standard estimates. See DeepInfra's [prompt caching](https://docs.deepinfra.com/chat/prompt-caching)
+and [cache retention](https://docs.deepinfra.com/chat/prompt-cache-retention) docs.
+
+Missing, malformed, or unavailable native prices never restore the projection's
+flat prices. Models remain selectable; the required runtime zero-cost placeholder
+means unknown, not verified free billing. If metadata discovery fails, OpenClaw
+keeps bundled model metadata and applies any available native prices. The complete
+bundled fallback, including prices, is used only when both sources fail or live
+discovery is skipped. Onboarding adds the model alias without pinning provider
+prices, and explicitly configured model costs remain authoritative.
+
+Hosted publication uses the same native parser. It preserves metadata without
+cost for unsupported or absent schedules, retains declared zero prices, and
+leaves the previous hosted catalog intact if the native feed fails validation.
+The existing [hosted catalog refresh and Gateway restart lifecycle](/concepts/models#hosted-catalog-updates)
+is unchanged.
+
 ## Notes
 
 - Model refs are `deepinfra/<provider>/<model>` (for example `deepinfra/Qwen/Qwen3-Max`).

--- a/extensions/deepinfra/index.test.ts
+++ b/extensions/deepinfra/index.test.ts
@@ -5,7 +5,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import deepinfraPlugin from "./index.js";
 import { DEEPINFRA_MODEL_CATALOG } from "./provider-models.js";
 
@@ -56,6 +56,30 @@ function jsonResponse(payload: unknown, init: ResponseInit = {}): Response {
     ...init,
   });
 }
+
+function mockDiscoveryFetch(id = "profile/live-model") {
+  return vi.fn(async (url: string) => {
+    if (url === DEEPINFRA_MODELS_URL) {
+      return jsonResponse({ data: [makeAgentModelEntry(id)] });
+    }
+    expect(url).toBe("https://api.deepinfra.com/models/list");
+    return jsonResponse([
+      {
+        model_name: id,
+        pricing: {
+          type: "tokens",
+          cents_per_input_token: 0.0004,
+          cents_per_output_token: 0.0008,
+        },
+      },
+    ]);
+  });
+}
+
+afterEach(() => {
+  clearLiveCatalogCacheForTests();
+  vi.restoreAllMocks();
+});
 
 async function withLiveDiscoveryTestEnv(
   mockFetch: ReturnType<typeof vi.fn>,
@@ -130,9 +154,7 @@ describe("deepinfra augmentModelCatalog", () => {
 
   it("uses config-backed API keys to enable live model catalog augmentation", async () => {
     clearLiveCatalogCacheForTests();
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValue(jsonResponse({ data: [makeAgentModelEntry("config/live-model")] }));
+    const mockFetch = mockDiscoveryFetch("config/live-model");
     const provider = await registerSingleProviderPlugin(deepinfraPlugin);
 
     await withLiveDiscoveryTestEnv(mockFetch, async () => {
@@ -151,16 +173,14 @@ describe("deepinfra augmentModelCatalog", () => {
           },
         } as never)) ?? [];
 
-      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(entries.map((entry) => entry.id)).toContain("config/live-model");
     });
   });
 
   it("still runs live discovery when ctx.entries includes custom DeepInfra rows", async () => {
     clearLiveCatalogCacheForTests();
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValue(jsonResponse({ data: [makeAgentModelEntry("custom/live-model")] }));
+    const mockFetch = mockDiscoveryFetch("custom/live-model");
     const provider = await registerSingleProviderPlugin(deepinfraPlugin);
 
     const seededDeepInfraCount = DEEPINFRA_MODEL_CATALOG.length + 5;
@@ -191,7 +211,7 @@ describe("deepinfra augmentModelCatalog", () => {
           },
         } as never)) ?? [];
 
-      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(entries[0]).toEqual({
         provider: "deepinfra",
         id: "zai-org/GLM-5.1",
@@ -236,7 +256,7 @@ describe("deepinfra capability registration", () => {
 
   it("uses profile-resolved API keys for live text catalog discovery", async () => {
     clearLiveCatalogCacheForTests();
-    const mockFetch = vi.fn().mockResolvedValue(jsonResponse({ data: [makeAgentModelEntry()] }));
+    const mockFetch = mockDiscoveryFetch();
     const captured = createCapturedPluginRegistration();
     deepinfraPlugin.register(captured.api);
     const provider = captured.providers[0];
@@ -251,8 +271,16 @@ describe("deepinfra capability registration", () => {
         throw new Error("expected single-provider DeepInfra catalog result");
       }
 
-      expect(mockFetch).toHaveBeenCalledOnce();
-      expect(mockFetch.mock.calls[0]?.[0]).toBe(DEEPINFRA_MODELS_URL);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls.map(([url]) => url)).toEqual(
+        expect.arrayContaining([DEEPINFRA_MODELS_URL, "https://api.deepinfra.com/models/list"]),
+      );
+      expect(result.provider.models[0]?.cost).toEqual({
+        input: 4,
+        output: 8,
+        cacheRead: 0,
+        cacheWrite: 0,
+      });
       expect(result?.provider.apiKey).toBe("profile-key");
       expect(result.provider.models.map((model) => model.id)).toEqual([
         "profile/live-model",

--- a/extensions/deepinfra/onboard.test.ts
+++ b/extensions/deepinfra/onboard.test.ts
@@ -1,7 +1,4 @@
 // Deepinfra tests cover onboard plugin behavior.
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import * as providerAuth from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   type OpenClawConfig,
@@ -10,7 +7,11 @@ import {
 import { captureEnv } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { applyDeepInfraConfig } from "./onboard.js";
-import { DEEPINFRA_BASE_URL, DEEPINFRA_DEFAULT_MODEL_REF } from "./provider-models.js";
+import {
+  DEEPINFRA_BASE_URL,
+  DEEPINFRA_DEFAULT_MODEL_REF,
+  DEEPINFRA_MODEL_CATALOG,
+} from "./provider-models.js";
 
 const { resolveEnvApiKey } = providerAuth;
 
@@ -28,6 +29,27 @@ describe("DeepInfra provider config", () => {
   });
 
   describe("applyDeepInfraConfig", () => {
+    it.each([
+      { label: "custom", cost: { input: 7, output: 8, cacheRead: 0.7, cacheWrite: 0.8 } },
+      { label: "zero", cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
+    ])(
+      "preserves authored $label costs and alias-only setup without pinning a catalog",
+      ({ cost }) => {
+        const ref = "deepinfra/fixture/authored";
+        const model = { ...DEEPINFRA_MODEL_CATALOG[0]!, id: "fixture/authored", cost };
+        const config: OpenClawConfig = {
+          models: { providers: { deepinfra: { baseUrl: DEEPINFRA_BASE_URL, models: [model] } } },
+          agents: {
+            defaults: { model: { primary: ref }, models: { [ref]: { alias: "Authored" } } },
+          },
+        };
+        const result = applyDeepInfraConfig(config, ref);
+        expect(result.models).toEqual(config.models);
+        expect(result.agents?.defaults).toEqual(config.agents?.defaults);
+        expect(applyDeepInfraConfig({}).models?.providers?.deepinfra).toBeUndefined();
+      },
+    );
+
     it("sets the provided model ref as the primary default", () => {
       const result = applyDeepInfraConfig(emptyCfg, DEEPINFRA_DEFAULT_MODEL_REF);
       expect(resolveAgentModelPrimaryValue(result.agents?.defaults?.model)).toBe(
@@ -90,41 +112,6 @@ describe("DeepInfra provider config", () => {
       try {
         const result = resolveEnvApiKey("deepinfra");
         expect(result).toBeNull();
-      } finally {
-        envSnapshot.restore();
-      }
-    });
-
-    it("resolves the deepinfra api key via resolveApiKeyForProvider", async () => {
-      const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
-      const envSnapshot = captureEnv(["DEEPINFRA_API_KEY"]);
-      process.env.DEEPINFRA_API_KEY = "deepinfra-provider-test-key";
-
-      const spy = vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-        apiKey: "deepinfra-provider-test-key",
-        source: "env: DEEPINFRA_API_KEY",
-        mode: "api-key",
-      });
-
-      try {
-        const auth = await providerAuth.resolveApiKeyForProvider({
-          provider: "deepinfra",
-          agentDir,
-        });
-
-        expect(spy.mock.calls).toEqual([
-          [
-            {
-              provider: "deepinfra",
-              agentDir,
-            },
-          ],
-        ]);
-        expect(auth).toEqual({
-          apiKey: "deepinfra-provider-test-key",
-          source: "env: DEEPINFRA_API_KEY",
-          mode: "api-key",
-        });
       } finally {
         envSnapshot.restore();
       }

--- a/extensions/deepinfra/openclaw.plugin.json
+++ b/extensions/deepinfra/openclaw.plugin.json
@@ -81,9 +81,9 @@
             "contextWindow": 1048576,
             "maxTokens": 1048576,
             "cost": {
-              "input": 0.93,
-              "output": 3,
-              "cacheRead": 0.18,
+              "input": 0.4875,
+              "output": 1.56,
+              "cacheRead": 0.091000001625,
               "cacheWrite": 0
             },
             "compat": {
@@ -116,9 +116,9 @@
             "contextWindow": 262144,
             "maxTokens": 262144,
             "cost": {
-              "input": 0.74,
-              "output": 3.5,
-              "cacheRead": 0.15,
+              "input": 0.68,
+              "output": 3.4,
+              "cacheRead": 0.136,
               "cacheWrite": 0
             },
             "compat": {
@@ -225,9 +225,9 @@
             "contextWindow": 262144,
             "maxTokens": 262144,
             "cost": {
-              "input": 0.1,
+              "input": 0.09,
               "output": 0.3,
-              "cacheRead": 0.02,
+              "cacheRead": 0.0199999998,
               "cacheWrite": 0
             },
             "compat": {
@@ -258,6 +258,11 @@
     },
     "discovery": {
       "deepinfra": "refreshable"
+    }
+  },
+  "modelPricing": {
+    "providers": {
+      "deepinfra": { "deepinfra": { "provider": "deepinfra" } }
     }
   },
   "providerAuthChoices": [

--- a/extensions/deepinfra/pricing-api.test.ts
+++ b/extensions/deepinfra/pricing-api.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { parseDeepInfraPricingCatalog } from "./pricing-api.js";
+
+const pricing = {
+  type: "tokens",
+  cents_per_input_token: 0.0002,
+  cents_per_output_token: 0.001,
+  rate_per_input_token_cached: 0.25,
+};
+const paid = { model_name: "fixture/paid", pricing };
+const base = { input: 2, output: 10, cacheRead: 0.5, cacheWrite: 0 };
+
+describe("native DeepInfra pricing contract", () => {
+  it("converts cents/token and cache ratios, applying a nullable discount once", () => {
+    const result = parseDeepInfraPricingCatalog([
+      paid,
+      {
+        model_name: "fixture/discounted",
+        pricing: { ...pricing, discount: 0.5, discount_ends_at: null },
+      },
+      { model_name: "fixture/free", pricing: { ...pricing, discount: 1 } },
+      {
+        model_name: "fixture/nullable",
+        pricing: {
+          ...pricing,
+          discount: null,
+          full: null,
+          table: null,
+          rate_per_input_token_cached: null,
+          rate_per_input_token_cache_write: null,
+        },
+      },
+      { model_name: "fixture/unknown" },
+      { model_name: "fixture/image", pricing: { type: "image_units", cents_per_image_unit: 3 } },
+    ]);
+    expect(result).toEqual(
+      new Map([
+        ["fixture/paid", base],
+        ["fixture/discounted", { input: 1, output: 5, cacheRead: 0.25, cacheWrite: 0 }],
+        ["fixture/free", { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }],
+        ["fixture/nullable", { input: 2, output: 10, cacheRead: 0, cacheWrite: 0 }],
+      ]),
+    );
+    expect(
+      parseDeepInfraPricingCatalog([
+        {
+          model_name: "fixture/zero",
+          pricing: {
+            ...pricing,
+            cents_per_input_token: 0,
+            cents_per_output_token: 0,
+          },
+        },
+      ])?.get("fixture/zero"),
+    ).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+  });
+
+  it("does not graft service tiers or explicit retention onto standard token costs", () => {
+    expect(
+      parseDeepInfraPricingCatalog([
+        {
+          ...paid,
+          pricing: {
+            ...pricing,
+            full: "",
+            table: {},
+            rate_per_service_tier_priority: 1.5,
+            rate_per_service_tier_flex: 0.8,
+            rate_per_explicit_cache_write_token: { "5m": 1.25, "1h": 2 },
+            explicit_cache_granularity_tokens: 8192,
+          },
+        },
+      ])?.get(paid.model_name),
+    ).toEqual(base);
+  });
+
+  it.each([
+    { full: "Different rates above a context threshold" },
+    { full: "Promotion ends on a calendar date" },
+    { table: { columns: ["context"], rows: [[1000]] } },
+    { discount_ends_at: 1 },
+    { discount_ends_at: 9_000_000_000 },
+    { rate_per_input_token_cache_write: 1.25 },
+  ])("validates then omits unsupported schedules: %j", (qualification) => {
+    const qualified = {
+      model_name: "fixture/qualified",
+      pricing: { ...pricing, ...qualification },
+    };
+    expect(parseDeepInfraPricingCatalog([paid, qualified])).toEqual(
+      new Map([[paid.model_name, base]]),
+    );
+    expect(parseDeepInfraPricingCatalog([qualified])).toBeUndefined();
+    expect(
+      parseDeepInfraPricingCatalog([
+        paid,
+        {
+          ...qualified,
+          pricing: {
+            ...qualified.pricing,
+            cents_per_output_token: "bad",
+          },
+        },
+      ]),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    { type: 5 },
+    { cents_per_input_token: -1 },
+    { cents_per_output_token: undefined },
+    { cents_per_input_token: "0.0002" },
+    { cents_per_output_token: Infinity },
+    { cents_per_input_token: 1e308 },
+    { discount: "0.5" },
+    { discount: -0.1 },
+    { discount: 1.1 },
+    { discount_ends_at: "123" },
+    { discount_ends_at: 1.5 },
+    { full: {} },
+    { table: [] },
+    { rate_per_input_token_cached: "0.25" },
+    { rate_per_input_token_cached: -1 },
+    { rate_per_input_token_cache_write: "1.25" },
+    { rate_per_service_tier_priority: -1 },
+    { rate_per_service_tier_flex: "0.8" },
+    { rate_per_explicit_cache_write_token: [] },
+    { rate_per_explicit_cache_write_token: { "5m": "1.25" } },
+    { explicit_cache_granularity_tokens: 0 },
+  ])("rejects malformed declared token pricing without retaining partial rates: %j", (invalid) => {
+    expect(
+      parseDeepInfraPricingCatalog([
+        paid,
+        {
+          model_name: "fixture/bad",
+          pricing: {
+            ...pricing,
+            ...invalid,
+          },
+        },
+      ]),
+    ).toBeUndefined();
+  });
+
+  it.each(
+    [
+      { data: [paid] },
+      [],
+      [null],
+      [{ id: "fixture/foreign-identity", pricing }],
+      [paid, { model_name: " " }],
+      [paid, { model_name: paid.model_name }],
+      [paid, { ...paid, pricing: { ...pricing, full: "Qualified" } }],
+      [paid, { model_name: "fixture/bad", pricing: null }],
+      [{ model_name: "fixture/unpriced" }],
+      [{ model_name: "fixture/image", pricing: { type: "image_units" } }],
+    ].map((payload) => ({ payload })),
+  )("rejects malformed, duplicate or unusable feeds: $payload", ({ payload }) => {
+    expect(parseDeepInfraPricingCatalog(payload)).toBeUndefined();
+  });
+});

--- a/extensions/deepinfra/pricing-api.ts
+++ b/extensions/deepinfra/pricing-api.ts
@@ -1,0 +1,80 @@
+import { normalizeModelPricingCatalog } from "openclaw/plugin-sdk/model-catalog-pricing";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  asFiniteNumberInRange,
+  asOptionalRecord,
+  asPositiveSafeInteger,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+
+function normalizeDeepInfraTokenPricing(value: unknown): ModelDefinitionConfig["cost"] | undefined {
+  const row = asOptionalRecord(value);
+  if (!row || (row.type !== undefined && row.type !== "tokens")) {
+    return undefined;
+  }
+  const discount = asFiniteNumberInRange(row.discount ?? 0, { min: 0, max: 1 });
+  const inputCents = asFiniteNumberInRange(row.cents_per_input_token, { min: 0 });
+  const outputCents = asFiniteNumberInRange(row.cents_per_output_token, { min: 0 });
+  const cacheRatio = asFiniteNumberInRange(row.rate_per_input_token_cached ?? 0, { min: 0 });
+  const table = row.table == null ? undefined : asOptionalRecord(row.table);
+  const explicitWrites = row.rate_per_explicit_cache_write_token;
+  const writeRates = explicitWrites == null ? undefined : asOptionalRecord(explicitWrites);
+  if (
+    discount === undefined ||
+    inputCents === undefined ||
+    outputCents === undefined ||
+    cacheRatio === undefined ||
+    (row.full != null && typeof row.full !== "string") ||
+    (row.table != null && !table) ||
+    (row.discount_ends_at != null && !Number.isSafeInteger(row.discount_ends_at)) ||
+    [
+      "rate_per_input_token_cache_write",
+      "rate_per_service_tier_priority",
+      "rate_per_service_tier_flex",
+    ].some(
+      (key) => row[key] != null && asFiniteNumberInRange(row[key], { min: 0 }) === undefined,
+    ) ||
+    (explicitWrites != null &&
+      (!writeRates ||
+        Object.values(writeRates).some(
+          (rate) => asFiniteNumberInRange(rate, { min: 0 }) === undefined,
+        ))) ||
+    (row.explicit_cache_granularity_tokens != null &&
+      asPositiveSafeInteger(row.explicit_cache_granularity_tokens) === undefined)
+  ) {
+    return undefined;
+  }
+  // Native cents/token become USD/M; the documented discount applies once to all charges.
+  // DeepInfra's public pricing renderer multiplies cached input by this input-price ratio.
+  const input = inputCents * 10_000 * (1 - discount);
+  const output = outputCents * 10_000 * (1 - discount);
+  const cacheRead = input * cacheRatio;
+  return [input, output, cacheRead].every(Number.isFinite)
+    ? { input, output, cacheRead, cacheWrite: 0 }
+    : undefined;
+}
+
+/** Pure native price owner shared by hosted publication and chat discovery. */
+export function parseDeepInfraPricingCatalog(payload: unknown) {
+  return normalizeModelPricingCatalog(payload, normalizeDeepInfraTokenPricing, {
+    readModelId: (model) => model.model_name,
+    readPricing: (model) => {
+      const pricing = asOptionalRecord(model.pricing);
+      // Other native domains (images, time, embeddings) are not malformed chat token prices.
+      return typeof pricing?.type === "string" && pricing.type !== "tokens"
+        ? undefined
+        : model.pricing;
+    },
+    isSupportedPricing: (value) => {
+      const row = asOptionalRecord(value);
+      // Prose, tables, and expiry cannot establish an unconditional schedule. Retention and
+      // service-tier multipliers are separate contracts; generic cache-write semantics remain undocumented.
+      return (
+        row !== undefined &&
+        !row.full &&
+        Object.keys(asOptionalRecord(row.table) ?? {}).length === 0 &&
+        row.discount_ends_at == null &&
+        row.rate_per_input_token_cache_write == null
+      );
+    },
+  });
+}

--- a/extensions/deepinfra/provider-models.pricing.test.ts
+++ b/extensions/deepinfra/provider-models.pricing.test.ts
@@ -1,0 +1,187 @@
+import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEEPINFRA_MODEL_CATALOG, discoverDeepInfraModels } from "./provider-models.js";
+
+const DEEPINFRA_MODELS_URL =
+  "https://api.deepinfra.com/v1/openai/models?sort_by=openclaw&filter=with_meta";
+const jsonResponse = Response.json.bind(Response);
+
+function makeAgentModelEntry({ id }: { id: string }) {
+  return {
+    id,
+    metadata: {
+      tags: ["chat", "vlm", "reasoning"],
+      context_length: 131072,
+      max_tokens: 65536,
+      pricing: { input_tokens: 3, output_tokens: 15, cache_read_tokens: 0.3 },
+    },
+  };
+}
+
+beforeEach(() => clearLiveCatalogCacheForTests());
+afterEach(() => {
+  clearLiveCatalogCacheForTests();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function withFetchPathTest(mockFetch: ReturnType<typeof vi.fn>, run: () => Promise<void>) {
+  vi.stubEnv("NODE_ENV", undefined);
+  vi.stubEnv("VITEST", undefined);
+  vi.stubGlobal("fetch", mockFetch);
+  await run();
+}
+
+describe("DeepInfra native runtime prices", () => {
+  it("keeps native prices with static metadata when metadata discovery fails", async () => {
+    const seedId = DEEPINFRA_MODEL_CATALOG[0]!.id;
+    const nativeCost = { input: 1, output: 5, cacheRead: 0.2, cacheWrite: 0 };
+    const mockFetch = vi.fn(async (url: string) => {
+      if (url === DEEPINFRA_MODELS_URL) {
+        return new Response("unavailable", { status: 503 });
+      }
+      expect(url).toBe("https://api.deepinfra.com/models/list");
+      return jsonResponse(
+        [seedId, "fixture/price-only"].map((model_name) => ({
+          model_name,
+          pricing: {
+            type: "tokens",
+            cents_per_input_token: 0.0002,
+            cents_per_output_token: 0.001,
+            discount: 0.5,
+            rate_per_input_token_cached: 0.2,
+          },
+        })),
+      );
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const offline = await discoverDeepInfraModels({ hasApiKey: false });
+      expect(mockFetch).not.toHaveBeenCalled();
+      const models = await discoverDeepInfraModels({ hasApiKey: true });
+      expect(models.map((model) => model.id)).toEqual(offline.map((model) => model.id));
+      expect(models[0]?.cost).toEqual(nativeCost);
+      for (const [index, model] of models.entries()) {
+        expect(model).toEqual({
+          ...offline[index],
+          cost: index === 0 ? nativeCost : { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        });
+      }
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it.each(["unavailable", "malformed", "absent"])(
+    "keeps metadata with unknown costs when native pricing is %s and recovers without refetching metadata",
+    async (failure) => {
+      let nativeCalls = 0;
+      const mockFetch = vi.fn(async (url: string) => {
+        if (url === DEEPINFRA_MODELS_URL) {
+          return jsonResponse({ data: [makeAgentModelEntry({ id: "fixture/recovered" })] });
+        }
+        expect(url).toBe("https://api.deepinfra.com/models/list");
+        nativeCalls++;
+        if (nativeCalls === 1) {
+          if (failure === "unavailable") {
+            return new Response("unavailable", { status: 503 });
+          }
+          if (failure === "absent") {
+            return jsonResponse([]);
+          }
+          return jsonResponse([
+            {
+              model_name: "fixture/recovered",
+              pricing: {
+                type: "tokens",
+                cents_per_input_token: -1,
+                cents_per_output_token: 0.001,
+              },
+            },
+          ]);
+        }
+        return jsonResponse([
+          {
+            model_name: "fixture/recovered",
+            pricing: {
+              type: "tokens",
+              cents_per_input_token: 0.0002,
+              cents_per_output_token: 0.001,
+            },
+          },
+        ]);
+      });
+      await withFetchPathTest(mockFetch, async () => {
+        const unknown = await discoverDeepInfraModels({ hasApiKey: true });
+        expect(unknown[0]).toMatchObject({
+          id: "fixture/recovered",
+          contextWindow: 131072,
+          maxTokens: 65536,
+        });
+        expect(
+          unknown.every((model) => Object.values(model.cost).every((rate) => rate === 0)),
+        ).toBe(true);
+        const recovered = await discoverDeepInfraModels({ hasApiKey: true });
+        expect(recovered[0]?.cost).toEqual({ input: 2, output: 10, cacheRead: 0, cacheWrite: 0 });
+        expect(recovered.map((model) => model.id)).toEqual(unknown.map((model) => model.id));
+        expect(await discoverDeepInfraModels({ hasApiKey: true })).toEqual(recovered);
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+      });
+    },
+  );
+
+  it("uses native DeepInfra discounts and omits qualified prices without changing metadata", async () => {
+    const nativePricing = {
+      type: "tokens",
+      cents_per_input_token: 0.0002,
+      cents_per_output_token: 0.001,
+      rate_per_input_token_cached: 0.2,
+      discount: 0.5,
+      discount_ends_at: null,
+    };
+    const mockFetch = vi.fn(async (url: string, _init?: RequestInit) => {
+      if (url === DEEPINFRA_MODELS_URL) {
+        return jsonResponse({
+          data: ["fixture/paid", "fixture/qualified", "fixture/absent"].map((id) =>
+            makeAgentModelEntry({ id }),
+          ),
+        });
+      }
+      expect(url).toBe("https://api.deepinfra.com/models/list");
+      return jsonResponse([
+        { model_name: "fixture/paid", pricing: nativePricing },
+        {
+          model_name: "fixture/qualified",
+          pricing: { ...nativePricing, full: "Higher rates above a context threshold" },
+        },
+        { model_name: DEEPINFRA_MODEL_CATALOG[0]!.id, pricing: nativePricing },
+      ]);
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverDeepInfraModels({ hasApiKey: true });
+      expect(models.slice(0, 3).map((model) => model.id)).toEqual([
+        "fixture/paid",
+        "fixture/qualified",
+        "fixture/absent",
+      ]);
+      expect(models[0]).toMatchObject({
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: 131072,
+        maxTokens: 65536,
+        cost: { input: 1, output: 5, cacheRead: 0.2, cacheWrite: 0 },
+      });
+      for (const model of models) {
+        expect(model.cost).toEqual(
+          model.id === "fixture/paid" || model.id === DEEPINFRA_MODEL_CATALOG[0]!.id
+            ? { input: 1, output: 5, cacheRead: 0.2, cacheWrite: 0 }
+            : { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        );
+      }
+      expect(await discoverDeepInfraModels({ hasApiKey: true })).toEqual(models);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      for (const [, init] of mockFetch.mock.calls) {
+        expect(new Headers(init?.headers).has("authorization")).toBe(false);
+      }
+    });
+  });
+});

--- a/extensions/deepinfra/provider-models.proxy.test.ts
+++ b/extensions/deepinfra/provider-models.proxy.test.ts
@@ -1,4 +1,5 @@
-// DeepInfra proxy tests cover the live model discovery transport policy.
+// DeepInfra proxy tests cover both public transports and their resource ownership.
+import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
@@ -10,42 +11,60 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
 
 import { discoverDeepInfraModels } from "./provider-models.js";
 
-const ORIGINAL_VITEST = process.env.VITEST;
-const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
-
-function restoreEnv(key: "VITEST" | "NODE_ENV", value: string | undefined) {
-  if (value === undefined) {
-    delete process.env[key];
-  } else {
-    process.env[key] = value;
-  }
-}
-
 afterEach(() => {
-  restoreEnv("VITEST", ORIGINAL_VITEST);
-  restoreEnv("NODE_ENV", ORIGINAL_NODE_ENV);
+  clearLiveCatalogCacheForTests();
   fetchWithSsrFGuardMock.mockReset();
   vi.restoreAllMocks();
 });
 
 describe("DeepInfra model discovery proxy policy", () => {
-  it("allows the guarded official catalog request to use an eligible HTTP proxy", async () => {
-    delete process.env.VITEST;
-    process.env.NODE_ENV = "development";
-    const release = vi.fn(async () => undefined);
-    fetchWithSsrFGuardMock.mockResolvedValue({
-      response: new Response("unavailable", { status: 503 }),
-      release,
-    });
-
-    await discoverDeepInfraModels({ hasApiKey: true });
-
-    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        mode: "trusted_env_proxy",
-        url: "https://api.deepinfra.com/v1/openai/models?sort_by=openclaw&filter=with_meta",
-      }),
-    );
-    expect(release).toHaveBeenCalledOnce();
-  });
+  it.each(["success", "malformed", "unavailable"])(
+    "pairs both anonymous guarded requests with release on %s",
+    async (scenario) => {
+      const releases: ReturnType<typeof vi.fn>[] = [];
+      fetchWithSsrFGuardMock.mockImplementation(async ({ url }) => {
+        const release = vi.fn(async () => undefined);
+        releases.push(release);
+        const body = url.endsWith("/models/list")
+          ? [
+              {
+                model_name: "fixture/chat",
+                pricing: {
+                  type: "tokens",
+                  cents_per_input_token: 0.0002,
+                  cents_per_output_token: 0.001,
+                },
+              },
+            ]
+          : { data: [{ id: "fixture/chat", metadata: { tags: ["chat"] } }] };
+        return {
+          finalUrl: url,
+          response:
+            scenario === "unavailable"
+              ? new Response("unavailable", { status: 503 })
+              : scenario === "malformed"
+                ? new Response("not JSON")
+                : Response.json(body),
+          release,
+        };
+      });
+      await discoverDeepInfraModels({ hasApiKey: true, env: {} });
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
+      expect(new Set(fetchWithSsrFGuardMock.mock.calls.map(([request]) => request.url))).toEqual(
+        new Set([
+          "https://api.deepinfra.com/models/list",
+          "https://api.deepinfra.com/v1/openai/models?sort_by=openclaw&filter=with_meta",
+        ]),
+      );
+      for (const [request] of fetchWithSsrFGuardMock.mock.calls) {
+        expect(request.mode).toBe("trusted_env_proxy");
+        expect(new Headers(request.init.headers).has("authorization")).toBe(false);
+        expect(request.timeoutMs).toBeLessThanOrEqual(5000);
+      }
+      expect(releases).toHaveLength(2);
+      for (const release of releases) {
+        expect(release).toHaveBeenCalledOnce();
+      }
+    },
+  );
 });

--- a/extensions/deepinfra/provider-models.test.ts
+++ b/extensions/deepinfra/provider-models.test.ts
@@ -1,6 +1,6 @@
 import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 // Deepinfra tests cover provider models plugin behavior.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const isProviderApiKeyConfiguredMock = vi.hoisted(() => vi.fn<(p: unknown) => boolean>());
 vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
@@ -61,7 +61,14 @@ function expectedStaticChatCatalog() {
 
 function expectedLiveChatCatalog(liveModels: ReturnType<typeof expectedStaticChatCatalog>) {
   const liveIds = new Set(liveModels.map((model) => model.id));
-  return [...liveModels, ...expectedStaticChatCatalog().filter((model) => !liveIds.has(model.id))];
+  return [
+    ...liveModels,
+    ...expectedStaticChatCatalog()
+      .filter((model) => !liveIds.has(model.id))
+      .map((model) =>
+        Object.assign(model, { cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } }),
+      ),
+  ];
 }
 
 async function withFetchPathTest(
@@ -69,40 +76,42 @@ async function withFetchPathTest(
   envOverrides: Record<string, string | undefined>,
   runAssertions: () => Promise<void>,
 ) {
-  const env = { ...process.env };
-  delete process.env.NODE_ENV;
-  delete process.env.VITEST;
+  vi.stubEnv("NODE_ENV", undefined);
+  vi.stubEnv("VITEST", undefined);
   for (const [key, value] of Object.entries(envOverrides)) {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      Reflect.set(process.env, key, value);
-    }
+    vi.stubEnv(key, value);
   }
   vi.stubGlobal("fetch", mockFetch);
-
   try {
     await runAssertions();
   } finally {
-    for (const key of Object.keys(envOverrides)) {
-      if (env[key] === undefined) {
-        delete process.env[key];
-      } else {
-        Reflect.set(process.env, key, env[key]);
-      }
-    }
-    if (env.NODE_ENV !== undefined) {
-      process.env.NODE_ENV = env.NODE_ENV;
-    }
-    if (env.VITEST !== undefined) {
-      process.env.VITEST = env.VITEST;
-    }
+    vi.unstubAllEnvs();
     vi.unstubAllGlobals();
   }
 }
 
-function requireFirstFetchCall(mockFetch: ReturnType<typeof vi.fn>): [unknown, unknown] {
-  const [call] = mockFetch.mock.calls;
+afterEach(() => {
+  clearLiveCatalogCacheForTests();
+  vi.restoreAllMocks();
+});
+
+function mockProjectionFetch(projection: () => Promise<Response> | Response) {
+  return vi.fn(async (url: string) => {
+    if (url === "https://api.deepinfra.com/models/list") {
+      return jsonResponse([
+        {
+          model_name: "fixture/native-only",
+          pricing: { type: "tokens", cents_per_input_token: 0.0002, cents_per_output_token: 0.001 },
+        },
+      ]);
+    }
+    expect(url).toBe(DEEPINFRA_MODELS_URL);
+    return projection();
+  });
+}
+
+function requireMetadataFetchCall(mockFetch: ReturnType<typeof vi.fn>): [unknown, unknown] {
+  const call = mockFetch.mock.calls.find(([url]) => url === DEEPINFRA_MODELS_URL);
   if (!call) {
     throw new Error("expected DeepInfra models fetch call");
   }
@@ -143,14 +152,6 @@ describe("buildDeepInfraModelDefinition", () => {
     for (const model of deepseekModels) {
       expect(model.compat?.thinkingFormat).toBe("deepseek");
     }
-  });
-});
-
-describe("DEEPINFRA_MODELS_URL", () => {
-  it("points at /v1/openai/models with the openclaw sort + filter=with_meta gate", () => {
-    expect(DEEPINFRA_MODELS_URL).toBe(
-      "https://api.deepinfra.com/v1/openai/models?sort_by=openclaw&filter=with_meta",
-    );
   });
 });
 
@@ -234,12 +235,14 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
   });
 
   it("fetches the openclaw-projection endpoint and parses chat-surface entries when an API key is configured", async () => {
-    const mockFetch = vi.fn().mockResolvedValue(jsonResponse({ data: [makeAgentModelEntry()] }));
+    const mockFetch = mockProjectionFetch(
+      vi.fn().mockResolvedValue(jsonResponse({ data: [makeAgentModelEntry()] })),
+    );
 
     await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: "sk-test" }, async () => {
       const models = await discoverDeepInfraModels();
-      expect(mockFetch).toHaveBeenCalledOnce();
-      const [fetchUrl, fetchInit] = requireFirstFetchCall(mockFetch);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const [fetchUrl, fetchInit] = requireMetadataFetchCall(mockFetch);
       const fetchSignal = Reflect.get(fetchInit ?? {}, "signal");
       const fetchHeaders = Reflect.get(fetchInit ?? {}, "headers");
       expect(fetchUrl).toBe(DEEPINFRA_MODELS_URL);
@@ -255,7 +258,7 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
             input: ["text", "image"],
             contextWindow: 131072,
             maxTokens: 65536,
-            cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
             compat: { supportsUsageInStreaming: true },
           },
         ]),
@@ -306,7 +309,7 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
         },
       }),
     ];
-    const mockFetch = vi.fn().mockResolvedValue(jsonResponse({ data: rows }));
+    const mockFetch = mockProjectionFetch(vi.fn().mockResolvedValue(jsonResponse({ data: rows })));
     DEEPINFRA_MODEL_CATALOG.push(DEEPINFRA_MODEL_CATALOG[0]!);
 
     try {
@@ -320,7 +323,7 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
             input: ["text"],
             contextWindow: 96000,
             maxTokens: 4096,
-            cost: { input: 4, output: 8, cacheRead: 0.4, cacheWrite: 0 },
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
             compat: {
               codeMode: "capable",
               supportsUsageInStreaming: true,
@@ -333,7 +336,7 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
             input: ["text", "image"],
             contextWindow: 192000,
             maxTokens: 16384,
-            cost: { input: 0.2, output: 1.15, cacheRead: 0, cacheWrite: 0 },
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
           },
           { id: "deepseek-ai/DeepSeek-V3.2", reasoning: false },
           { id: "unlisted/no-reasoning", reasoning: false },
@@ -347,18 +350,20 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
   });
 
   it("skips entries with no metadata or no surface tag, and deduplicates ids", async () => {
-    const mockFetch = vi.fn().mockResolvedValue(
-      jsonResponse({
-        data: [
-          { id: "BAAI/bge-m3", object: "model", metadata: null },
-          makeAgentModelEntry({
-            id: "untagged/model",
-            metadata: { context_length: 1, max_tokens: 1, pricing: {}, tags: [] },
-          }),
-          makeAgentModelEntry(),
-          makeAgentModelEntry(),
-        ],
-      }),
+    const mockFetch = mockProjectionFetch(
+      vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: [
+            { id: "BAAI/bge-m3", object: "model", metadata: null },
+            makeAgentModelEntry({
+              id: "untagged/model",
+              metadata: { context_length: 1, max_tokens: 1, pricing: {}, tags: [] },
+            }),
+            makeAgentModelEntry(),
+            makeAgentModelEntry(),
+          ],
+        }),
+      ),
     );
 
     await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: "sk-test" }, async () => {
@@ -372,7 +377,7 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
             input: ["text", "image"],
             contextWindow: 131072,
             maxTokens: 65536,
-            cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
             compat: { supportsUsageInStreaming: true },
           },
         ]).map((model) => model.id),
@@ -386,21 +391,24 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
     await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: undefined }, async () => {
       const models = await discoverDeepInfraModels();
       expect(mockFetch).not.toHaveBeenCalled();
-      expect(models.map((m) => m.id)).toEqual(expectedStaticChatCatalog().map((model) => model.id));
+      expect(models).toEqual(expectedStaticChatCatalog());
     });
   });
 
-  it("falls back to the static catalog on network errors", async () => {
+  it("falls back to the complete static catalog when both sources fail", async () => {
     const mockFetch = vi.fn().mockRejectedValue(new Error("network error"));
 
     await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: "sk-test" }, async () => {
       const models = await discoverDeepInfraModels();
-      expect(models.map((m) => m.id)).toEqual(expectedStaticChatCatalog().map((model) => model.id));
+      expect(models).toEqual(expectedStaticChatCatalog());
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
   });
 
   it("falls back to the static catalog on non-2xx HTTP responses", async () => {
-    const mockFetch = vi.fn().mockResolvedValue(new Response("", { status: 503 }));
+    const mockFetch = mockProjectionFetch(
+      vi.fn().mockResolvedValue(new Response("", { status: 503 })),
+    );
 
     await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: "sk-test" }, async () => {
       const models = await discoverDeepInfraModels();
@@ -409,12 +417,14 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
   });
 
   it("falls back without caching malformed successful model list payloads", async () => {
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValueOnce(jsonResponse({ data: {} }))
-      .mockResolvedValueOnce(
-        jsonResponse({ data: [makeAgentModelEntry({ id: "recovered/model" })] }),
-      );
+    const mockFetch = mockProjectionFetch(
+      vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse({ data: {} }))
+        .mockResolvedValueOnce(
+          jsonResponse({ data: [makeAgentModelEntry({ id: "recovered/model" })] }),
+        ),
+    );
 
     await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: "sk-test" }, async () => {
       expect((await discoverDeepInfraModels()).map((m) => m.id)).toEqual(
@@ -429,20 +439,24 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
             input: ["text", "image"],
             contextWindow: 131072,
             maxTokens: 65536,
-            cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
             compat: { supportsUsageInStreaming: true },
           },
         ]).map((model) => model.id),
       );
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
     });
   });
 
   it("caches successful discovery responses only", async () => {
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValueOnce(jsonResponse({ data: [makeAgentModelEntry({ id: "first/model" })] }))
-      .mockResolvedValueOnce(jsonResponse({ data: [makeAgentModelEntry({ id: "second/model" })] }));
+    const mockFetch = mockProjectionFetch(
+      vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse({ data: [makeAgentModelEntry({ id: "first/model" })] }))
+        .mockResolvedValueOnce(
+          jsonResponse({ data: [makeAgentModelEntry({ id: "second/model" })] }),
+        ),
+    );
 
     await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: "sk-test" }, async () => {
       const expectedIds = expectedLiveChatCatalog([
@@ -453,23 +467,25 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
           input: ["text", "image"],
           contextWindow: 131072,
           maxTokens: 65536,
-          cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
           compat: { supportsUsageInStreaming: true },
         },
       ]).map((model) => model.id);
       expect((await discoverDeepInfraModels()).map((m) => m.id)).toEqual(expectedIds);
       expect((await discoverDeepInfraModels()).map((m) => m.id)).toEqual(expectedIds);
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
   });
 
   it("does not cache successful responses that produce no live catalog rows", async () => {
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValueOnce(jsonResponse({ data: [] }))
-      .mockResolvedValueOnce(
-        jsonResponse({ data: [makeAgentModelEntry({ id: "recovered/model" })] }),
-      );
+    const mockFetch = mockProjectionFetch(
+      vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse({ data: [] }))
+        .mockResolvedValueOnce(
+          jsonResponse({ data: [makeAgentModelEntry({ id: "recovered/model" })] }),
+        ),
+    );
 
     await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: "sk-test" }, async () => {
       expect((await discoverDeepInfraModels()).map((m) => m.id)).toEqual(
@@ -484,12 +500,12 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
             input: ["text", "image"],
             contextWindow: 131072,
             maxTokens: 65536,
-            cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
             compat: { supportsUsageInStreaming: true },
           },
         ]).map((model) => model.id),
       );
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
     });
   });
 });
@@ -559,6 +575,7 @@ describe("discoverDeepInfraSurfaces (per-surface bucketing)", () => {
     await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: "sk-test" }, async () => {
       const catalog = await discoverDeepInfraSurfaces();
       expect(catalog.live).toBe(true);
+      expect(mockFetch).toHaveBeenCalledOnce();
       expect(catalog.chat.map((m) => m.id)).toEqual(["anthropic/claude-sonnet-4-6"]);
       expect(catalog.vlm.map((m) => m.id)).toEqual(["anthropic/claude-sonnet-4-6"]);
       expect(catalog.embed.map((m) => m.id)).toEqual(["BAAI/bge-m3"]);

--- a/extensions/deepinfra/provider-models.ts
+++ b/extensions/deepinfra/provider-models.ts
@@ -3,16 +3,21 @@
 import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import {
+  fetchLiveProviderModelRows,
   getCachedLiveProviderModelRows,
   LiveModelCatalogHttpError,
 } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
-import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import {
+  buildManifestModelProviderConfig,
+  getCachedLiveCatalogValue,
+} from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { asPositiveSafeInteger } from "openclaw/plugin-sdk/string-coerce-runtime";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
+import { parseDeepInfraPricingCatalog } from "./pricing-api.js";
 
 const log = createSubsystemLogger("deepinfra-models");
 
@@ -23,6 +28,7 @@ const DEEPINFRA_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
 
 export const DEEPINFRA_BASE_URL = DEEPINFRA_MANIFEST_PROVIDER.baseUrl;
 const DEEPINFRA_MODELS_URL = `${DEEPINFRA_BASE_URL}/models?sort_by=openclaw&filter=with_meta`;
+const DEEPINFRA_PRICING_URL = "https://api.deepinfra.com/models/list";
 
 const DEEPINFRA_DEFAULT_MODEL_ID = "deepseek-ai/DeepSeek-V4-Flash";
 export const DEEPINFRA_DEFAULT_MODEL_REF = `deepinfra/${DEEPINFRA_DEFAULT_MODEL_ID}`;
@@ -34,6 +40,12 @@ export const DEEPINFRA_MODEL_CATALOG: ModelDefinitionConfig[] = DEEPINFRA_MANIFE
 
 const DISCOVERY_TIMEOUT_MS = 5000;
 const DISCOVERY_CACHE_TTL_MS = 5 * 60 * 1000;
+
+type DeepInfraDiscoveryOptions = {
+  hasApiKey?: boolean;
+  env?: NodeJS.ProcessEnv;
+  agentDir?: string;
+};
 
 type DeepInfraAuthConfig = {
   secrets?: { defaults?: { env?: string; file?: string; exec?: string } };
@@ -358,11 +370,13 @@ export function buildDeepInfraModelDefinition(model: ModelDefinitionConfig): Mod
   };
 }
 
-function chatSurfaceModelToModelDefinition(model: DeepInfraSurfaceModel): ModelDefinitionConfig {
+function chatSurfaceModelToModelDefinition(
+  model: DeepInfraSurfaceModel,
+): Omit<ModelDefinitionConfig, "cost"> {
   const manifestModel = DEEPINFRA_MODEL_CATALOG.find((entry) => entry.id === model.id);
   const input: Array<"text" | "image"> = model.tags.includes("vlm") ? ["text", "image"] : ["text"];
   const reasoning = model.tags.includes("reasoning") || model.tags.includes("reasoning_effort");
-  return buildDeepInfraModelDefinition({
+  return {
     id: model.id,
     name: model.name,
     reasoning: manifestModel?.reasoning ?? reasoning,
@@ -370,13 +384,7 @@ function chatSurfaceModelToModelDefinition(model: DeepInfraSurfaceModel): ModelD
     ...(manifestModel?.compat ? { compat: manifestModel.compat } : {}),
     contextWindow: model.contextWindow ?? DEEPINFRA_DEFAULT_CONTEXT_WINDOW,
     maxTokens: model.maxTokens ?? DEEPINFRA_DEFAULT_MAX_TOKENS,
-    cost: {
-      input: model.pricing.input_tokens ?? 0,
-      output: model.pricing.output_tokens ?? 0,
-      cacheRead: model.pricing.cache_read_tokens ?? 0,
-      cacheWrite: 0,
-    },
-  });
+  };
 }
 
 // Gate dynamic discovery on key presence: pre-auth keeps the picker tight and
@@ -406,23 +414,22 @@ export function hasDeepInfraApiKey(options?: {
   return isProviderApiKeyConfigured({ provider: "deepinfra", agentDir: options?.agentDir });
 }
 
-// Discover the per-surface catalog. Falls back to the static manifest when
-// no key, fetch fails, or running under Vitest. 5-minute cache on success.
-export async function discoverDeepInfraSurfaces(options?: {
-  hasApiKey?: boolean;
-  env?: NodeJS.ProcessEnv;
-  agentDir?: string;
-}): Promise<DeepInfraDiscoveredCatalog> {
+function canDiscoverDeepInfra(options?: DeepInfraDiscoveryOptions): boolean {
   const env = options?.env ?? process.env;
   if (env.NODE_ENV === "test" || env.VITEST) {
-    return manifestFallbackCatalog();
+    return false;
   }
+  return options?.hasApiKey ?? hasDeepInfraApiKey({ env, agentDir: options?.agentDir });
+}
 
-  const hasKey = options?.hasApiKey ?? hasDeepInfraApiKey({ env, agentDir: options?.agentDir });
-  if (!hasKey) {
-    return manifestFallbackCatalog();
-  }
+// Keep pre-auth and tests offline; successful discovery shares the five-minute live catalog cache.
+export async function discoverDeepInfraSurfaces(
+  options?: DeepInfraDiscoveryOptions,
+): Promise<DeepInfraDiscoveredCatalog> {
+  return canDiscoverDeepInfra(options) ? loadDeepInfraSurfaces() : manifestFallbackCatalog();
+}
 
+async function loadDeepInfraSurfaces(): Promise<DeepInfraDiscoveredCatalog> {
   try {
     const data = await getCachedLiveProviderModelRows({
       providerId: "deepinfra",
@@ -462,30 +469,79 @@ export async function discoverDeepInfraSurfaces(options?: {
   }
 }
 
-// Chat-only shim for callers that haven't migrated to the per-surface catalog
-// (provider-catalog.ts, augmentModelCatalog).
-export async function discoverDeepInfraModels(options?: {
-  hasApiKey?: boolean;
-  env?: NodeJS.ProcessEnv;
-  agentDir?: string;
-}): Promise<ModelDefinitionConfig[]> {
-  const catalog = await discoverDeepInfraSurfaces(options);
-  if (!catalog.live) {
-    // Keep manifest-owned chat compatibility metadata intact. The generic
-    // surface projection intentionally carries only cross-surface fields.
+async function discoverDeepInfraPricing() {
+  try {
+    return await getCachedLiveCatalogValue({
+      keyParts: ["deepinfra", "native-pricing", DEEPINFRA_PRICING_URL],
+      ttlMs: DISCOVERY_CACHE_TTL_MS,
+      load: async () => {
+        const rows = await fetchLiveProviderModelRows({
+          providerId: "deepinfra",
+          endpoint: DEEPINFRA_PRICING_URL,
+          timeoutMs: DISCOVERY_TIMEOUT_MS,
+          buildRequestHeaders: () => ({ Accept: "application/json" }),
+          auditContext: "deepinfra-pricing-discovery",
+          fetchGuard: (params) => fetchWithSsrFGuard(withTrustedEnvProxyGuardedFetchMode(params)),
+          readRows: (body) => {
+            if (!Array.isArray(body)) {
+              throw new Error("Native DeepInfra pricing response must be an array");
+            }
+            return body;
+          },
+        });
+        const prices = parseDeepInfraPricingCatalog(rows);
+        if (!prices) {
+          throw new Error("Native DeepInfra pricing is malformed or has no usable schedules");
+        }
+        return prices;
+      },
+    });
+  } catch (error) {
+    log.warn(
+      `Native pricing unavailable: ${String(error)}. Keeping model metadata with unknown estimates; retry discovery or configure explicit model costs.`,
+    );
+    return undefined;
+  }
+}
+
+export async function discoverDeepInfraModels(
+  options?: DeepInfraDiscoveryOptions,
+): Promise<ModelDefinitionConfig[]> {
+  if (!canDiscoverDeepInfra(options)) {
+    return DEEPINFRA_MODEL_CATALOG.map(buildDeepInfraModelDefinition);
+  }
+  // Resolve auth once and load independent public facts concurrently within the discovery deadline.
+  // Media-only discovery continues to use just the agent projection.
+  const [catalog, prices] = await Promise.all([
+    loadDeepInfraSurfaces(),
+    discoverDeepInfraPricing(),
+  ]);
+  if (!catalog.live && !prices) {
     return DEEPINFRA_MODEL_CATALOG.map(buildDeepInfraModelDefinition);
   }
   const chatModels = catalog.chat.length > 0 ? catalog.chat : [...catalog.chat, ...catalog.vlm];
-  if (chatModels.length === 0) {
-    // True empty (no manifest entries either) — keep behavior stable.
-    return DEEPINFRA_MODEL_CATALOG.map(buildDeepInfraModelDefinition);
-  }
-  const liveModels = chatModels.map(chatSurfaceModelToModelDefinition);
+  // Static surface rows omit chat compatibility metadata; keep the complete
+  // manifest seeds when metadata fails, then attach any available native prices.
+  const liveModels = catalog.live ? chatModels.map(chatSurfaceModelToModelDefinition) : [];
   const seen = new Set(liveModels.map((model) => model.id));
   const manifestModels = DEEPINFRA_MODEL_CATALOG.filter((model) => {
     const unseen = !seen.has(model.id);
     seen.add(model.id);
     return unseen;
-  }).map(buildDeepInfraModelDefinition);
-  return [...liveModels, ...manifestModels];
+  });
+  const models = [...liveModels, ...manifestModels];
+  const unknownPrices = models.filter((model) => !prices?.has(model.id)).length;
+  if (prices && unknownPrices > 0) {
+    log.warn(
+      `Native pricing unavailable or qualified for ${unknownPrices} models; keeping metadata with unknown estimates. Configure explicit model costs if needed.`,
+    );
+  }
+  // Price appended seeds too: a missing projection row must not revive stale bundled costs.
+  // Runtime requires zeros for unknown prices; this is not evidence of free billing.
+  return models.map((model) =>
+    buildDeepInfraModelDefinition({
+      ...model,
+      cost: prices?.get(model.id) ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    }),
+  );
 }

--- a/extensions/venice/pricing-api.ts
+++ b/extensions/venice/pricing-api.ts
@@ -68,9 +68,8 @@ export function parseVeniceModelPricing(value: unknown): ModelDefinitionConfig["
 export function parseVenicePricingCatalog(
   payload: unknown,
 ): Map<string, ModelDefinitionConfig["cost"]> | undefined {
-  return normalizeModelPricingCatalog(
-    asOptionalRecord(payload)?.data,
-    parseVeniceModelPricing,
-    (model) => (model.type === "text" ? asOptionalRecord(model.model_spec)?.pricing : undefined),
-  );
+  return normalizeModelPricingCatalog(asOptionalRecord(payload)?.data, parseVeniceModelPricing, {
+    readPricing: (model) =>
+      model.type === "text" ? asOptionalRecord(model.model_spec)?.pricing : undefined,
+  });
 }

--- a/packages/model-catalog-core/src/model-catalog-pricing.test.ts
+++ b/packages/model-catalog-core/src/model-catalog-pricing.test.ts
@@ -48,6 +48,29 @@ describe("model pricing source policy", () => {
 describe("native pricing catalogs", () => {
   const paid = { id: "paid", pricing: { input: 2, output: 10 } };
 
+  it("uses the selected identity and validates prices before filtering unsupported schedules", () => {
+    const options = {
+      readModelId: (row: Record<string, unknown>) => row.model_name,
+      readPricing: (row: Record<string, unknown>) => row.cost,
+      isSupportedPricing: (value: unknown) => !Object.hasOwn(value as object, "qualified"),
+    };
+    const native = { id: "ignored", model_name: " paid ", cost: paid.pricing };
+    const qualified = { model_name: "qualified", cost: { ...paid.pricing, qualified: true } };
+    expect(
+      normalizeModelPricingCatalog([native, qualified], normalizeUpstreamModelPricing, options),
+    ).toEqual(new Map([["paid", BASE_COST]]));
+    for (const rows of [
+      [qualified],
+      [native, { ...qualified, model_name: "paid" }],
+      [native, { model_name: "paid" }],
+      [native, { ...qualified, cost: { input: -1, output: 10, qualified: true } }],
+    ]) {
+      expect(
+        normalizeModelPricingCatalog(rows, normalizeUpstreamModelPricing, options),
+      ).toBeUndefined();
+    }
+  });
+
   it("keeps declared free prices distinct from missing prices", () => {
     expect(
       normalizeModelPricingCatalog(

--- a/packages/model-catalog-core/src/model-catalog-pricing.ts
+++ b/packages/model-catalog-core/src/model-catalog-pricing.ts
@@ -38,6 +38,12 @@ export const MODEL_PRICING_SOURCES = [
     url: "https://api.cerebras.ai/public/v1/models",
     authoritative: true,
   },
+  {
+    id: "deepinfra",
+    label: "DeepInfra",
+    url: "https://api.deepinfra.com/models/list",
+    authoritative: true,
+  },
   { id: "openRouter", label: "OpenRouter", url: OPENROUTER_MODELS_URL, authoritative: false },
   { id: "liteLLM", label: "LiteLLM", url: LITELLM_PRICING_URL, authoritative: false },
 ] as const;
@@ -90,7 +96,15 @@ export function normalizeModelPricingProvider(value: unknown): ModelPricingProvi
 export function normalizeModelPricingCatalog(
   rows: unknown,
   normalizePricing: (value: unknown) => CompleteModelCost | undefined,
-  readPricing: (model: Record<string, unknown>) => unknown = (model) => model.pricing,
+  {
+    readModelId = (model) => model.id,
+    readPricing = (model) => model.pricing,
+    isSupportedPricing = () => true,
+  }: {
+    readModelId?: (model: Record<string, unknown>) => unknown;
+    readPricing?: (model: Record<string, unknown>) => unknown;
+    isSupportedPricing?: (pricing: unknown) => boolean;
+  } = {},
 ): Map<string, CompleteModelCost> | undefined {
   if (!Array.isArray(rows)) {
     return undefined;
@@ -99,7 +113,7 @@ export function normalizeModelPricingCatalog(
   const ids = new Set<string>();
   for (const value of rows) {
     const model = asOptionalRecord(value);
-    const id = normalizeOptionalString(model?.id);
+    const id = model && normalizeOptionalString(readModelId(model));
     if (!model || !id || ids.has(id)) {
       return undefined;
     }
@@ -112,7 +126,10 @@ export function normalizeModelPricingCatalog(
     if (!pricing) {
       return undefined;
     }
-    prices.set(id, pricing);
+    // Validate declared rates even when their qualifications cannot be represented.
+    if (isSupportedPricing(rawPricing)) {
+      prices.set(id, pricing);
+    }
   }
   // An empty price feed cannot establish that every previously known price disappeared.
   return prices.size > 0 ? prices : undefined;

--- a/scripts/publish-model-catalog.mts
+++ b/scripts/publish-model-catalog.mts
@@ -16,6 +16,7 @@ import { parseStrictFiniteNumber } from "@openclaw/normalization-core/number-coe
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { parseCerebrasPricingCatalog } from "../extensions/cerebras/pricing-api.js";
 import { parseChutesPricingCatalog } from "../extensions/chutes/pricing-api.js";
+import { parseDeepInfraPricingCatalog } from "../extensions/deepinfra/pricing-api.js";
 import { parseVenicePricingCatalog } from "../extensions/venice/pricing-api.js";
 import type {
   RemoteModelCatalogBundle,
@@ -55,6 +56,7 @@ const defaultRootDir = resolveRepoRoot(import.meta.url);
 const NATIVE_CATALOG_PARSERS = {
   cerebras: parseCerebrasPricingCatalog,
   chutes: parseChutesPricingCatalog,
+  deepinfra: parseDeepInfraPricingCatalog,
   venice: parseVenicePricingCatalog,
 } satisfies Record<
   Exclude<Extract<PricingSource, { authoritative: true }>["id"], "openCode">,
@@ -381,19 +383,29 @@ async function readJsonResponse(response: Response, source: string) {
   } catch {
     throw new Error(`${source} response is malformed JSON`);
   }
-  if (!isRecord(payload)) {
-    throw new Error(`${source} response is not a JSON object`);
-  }
   return payload;
 }
 
 function parsePricingCatalog(
   source: PricingSource,
-  body: Record<string, unknown>,
+  body: unknown,
   policies: PricingPolicies,
 ): LoadedPricingSource {
   const catalog: PricingCatalog = new Map();
   const aliases: string[][] = [];
+  if (source.authoritative && source.id !== "openCode") {
+    const prices = NATIVE_CATALOG_PARSERS[source.id](body);
+    if (!prices) {
+      throw new Error(`${source.label} pricing response is malformed`);
+    }
+    for (const [id, pricing] of prices) {
+      catalog.set(`${source.id}/${id}`, pricing);
+    }
+    return { ...source, catalog, aliases };
+  }
+  if (!isRecord(body)) {
+    throw new Error(`${source.label} response is not a JSON object`);
+  }
   if (source.id === "openCode") {
     for (const [providerId] of policies) {
       const policy = sourcePolicy(policies, providerId, source);
@@ -408,25 +420,15 @@ function parsePricingCatalog(
       const rows = Object.entries(provider.models).map(([id, model]) =>
         isRecord(model) && model.id === id ? model : undefined,
       );
-      const prices = normalizeModelPricingCatalog(
-        rows,
-        normalizeUpstreamModelPricing,
-        (model) => model.cost,
-      );
+      const prices = normalizeModelPricingCatalog(rows, normalizeUpstreamModelPricing, {
+        readPricing: (model) => model.cost,
+      });
       if (!prices) {
         throw new Error(`${source.label} pricing malformed for provider ${upstreamId}`);
       }
       for (const [id, pricing] of prices) {
         catalog.set(`${upstreamId}/${id}`, pricing);
       }
-    }
-  } else if (source.authoritative) {
-    const prices = NATIVE_CATALOG_PARSERS[source.id](body);
-    if (!prices) {
-      throw new Error(`${source.label} pricing response is malformed`);
-    }
-    for (const [id, pricing] of prices) {
-      catalog.set(`${source.id}/${id}`, pricing);
     }
   } else if (source.id === "openRouter") {
     for (const row of Array.isArray(body.data) ? body.data : []) {

--- a/test/scripts/publish-model-catalog.test.ts
+++ b/test/scripts/publish-model-catalog.test.ts
@@ -81,7 +81,7 @@ function writeFixtureManifest(root: string, pluginId: string, providers: Record<
   );
 }
 
-function nativeManifests(source: "OpenCode" | "Venice" | "Chutes" | "Cerebras") {
+function nativeManifests(source: "OpenCode" | "Venice" | "Chutes" | "Cerebras" | "DeepInfra") {
   const provider = source.toLowerCase();
   const sourceId = source === "OpenCode" ? "openCode" : provider;
   return [
@@ -145,6 +145,144 @@ const NATIVE_SOURCES = [
 ] as const;
 
 describe("publish model catalog", () => {
+  it("publishes native DeepInfra array prices with discounts rather than generic rates", async () => {
+    const manifests = nativeManifests("DeepInfra");
+    const bundle = await assembleModelCatalogBundle({
+      manifests,
+      generatedAt: Date.now(),
+      sourceCommit: "fixture",
+    });
+    const provider = bundle.providers.deepinfra!;
+    for (const id of ["qualified", "absent", "free"]) {
+      provider.models.push({
+        ...provider.models[0]!,
+        id,
+        name: `Fixture ${id}`,
+        contextWindow: 123456,
+      });
+    }
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+      expect(new Headers(init?.headers).has("authorization")).toBe(false);
+      const url = requestUrl(input);
+      if (url === "https://api.deepinfra.com/models/list") {
+        return Response.json([
+          {
+            model_name: "priced-fixture",
+            pricing: {
+              type: "tokens",
+              cents_per_input_token: 0.0002,
+              cents_per_output_token: 0.001,
+              discount: 0.5,
+              rate_per_input_token_cached: 0.2,
+            },
+          },
+          {
+            model_name: "qualified",
+            pricing: {
+              type: "tokens",
+              cents_per_input_token: 0.0002,
+              cents_per_output_token: 0.001,
+              full: "Higher rates at long context",
+            },
+          },
+          ...["free", "standalone-free", "foreign/hidden"].map((model_name) => ({
+            model_name,
+            pricing: { type: "tokens", cents_per_input_token: 0, cents_per_output_token: 0 },
+          })),
+        ]);
+      }
+      if (url === OPENROUTER_MODELS_URL) {
+        return Response.json({
+          data: ["priced-fixture", "qualified", "absent", "absent-unbundled"].map((id) => ({
+            id: `deepinfra/${id}`,
+            pricing: { prompt: "1", completion: "1" },
+          })),
+        });
+      }
+      expect(url).toBe(LITELLM_PRICING_URL);
+      return Response.json({
+        absent: {
+          litellm_provider: "deepinfra",
+          input_cost_per_token: 1,
+          output_cost_per_token: 1,
+        },
+      });
+    });
+    await enrichModelCatalogPricing({ bundle, manifests, fetchImpl });
+    expect(bundle.providers.deepinfra?.models[0]?.cost).toEqual({
+      input: 1,
+      output: 5,
+      cacheRead: 0.2,
+      cacheWrite: 0,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    for (const id of ["qualified", "absent"]) {
+      const model = bundle.providers.deepinfra?.models.find((row) => row.id === id);
+      expect(model).toMatchObject({ name: `Fixture ${id}`, contextWindow: 123456 });
+      expect(model?.cost).toBeUndefined();
+    }
+    for (const id of ["priced-fixture", "qualified", "absent", "absent-unbundled"]) {
+      expect(bundle.pricing).not.toHaveProperty(`deepinfra/${id}`);
+    }
+    expect(bundle.pricing).not.toHaveProperty("absent");
+    expect(bundle.pricing).not.toHaveProperty("foreign/hidden");
+    expect(bundle.providers).not.toHaveProperty("foreign");
+    const params = publishedPricingParams(bundle, "deepinfra");
+    for (const model of ["free", "standalone-free"]) {
+      expect(bundle.pricing?.[`deepinfra/${model}`]).toEqual({ input: 0, output: 0 });
+      expect(resolveModelCostConfig({ ...params, model })).toEqual({
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      });
+    }
+    expect(resolveModelCostConfig({ ...params, model: "qualified" })).toBeUndefined();
+  });
+
+  it.each(["outage", "object response", "malformed qualified price"])(
+    "rejects DeepInfra %s before mutating the previous bundle",
+    async (scenario) => {
+      const manifests = nativeManifests("DeepInfra");
+      const bundle = await assembleModelCatalogBundle({
+        manifests,
+        generatedAt: Date.now(),
+        sourceCommit: "fixture",
+      });
+      const previous = serializeModelCatalogBundle(bundle);
+      await expect(
+        enrichModelCatalogPricing({
+          bundle,
+          manifests,
+          fetchImpl: async (input) => {
+            const url = requestUrl(input);
+            if (url === "https://api.deepinfra.com/models/list") {
+              if (scenario === "outage") {
+                return new Response("unavailable", { status: 503 });
+              }
+              if (scenario === "object response") {
+                return Response.json({ data: [] });
+              }
+              return Response.json([
+                {
+                  model_name: "fixture/bad",
+                  pricing: {
+                    type: "tokens",
+                    cents_per_input_token: -1,
+                    cents_per_output_token: 0.001,
+                    full: "Qualified",
+                  },
+                },
+              ]);
+            }
+            return Response.json(url === OPENROUTER_MODELS_URL ? { data: [] } : {});
+          },
+        }),
+      ).rejects.toThrow("DeepInfra pricing");
+      expect(serializeModelCatalogBundle(bundle)).toBe(previous);
+    },
+  );
+
   it("assembles and validates fixture manifests at the 200-model floor", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-publish-catalog-"));
     tempDirs.push(root);
@@ -813,6 +951,10 @@ describe("publish model catalog", () => {
 
   it.each([
     { source: "OpenCode", scenario: "unreachable" },
+    ...["unreachable", "malformed body", "invalid price"].map((scenario) => ({
+      source: "DeepInfra",
+      scenario,
+    })),
     ...["unreachable", "malformed body", "missing model", "invalid price"].map((scenario) => ({
       source: "Venice",
       scenario,
@@ -842,6 +984,16 @@ for (const manifest of manifests) {
 globalThis.fetch = async (url) => {
   if (${JSON.stringify(source)} === "OpenCode") throw new Error("fixture outage");
   if (url === ${JSON.stringify(OPENCODE_PRICING_URL)}) return Response.json(openCode);
+  if (${JSON.stringify(source)} === "DeepInfra") {
+    if (url === "https://api.deepinfra.com/models/list") {
+      if (${JSON.stringify(scenario)} === "unreachable") throw new Error("fixture outage");
+      if (${JSON.stringify(scenario)} === "malformed body") return Response.json({ data: [] });
+      return Response.json([{ model_name: "fixture/bad", pricing: { type: "tokens", cents_per_input_token: -1, cents_per_output_token: 0.001, full: "Qualified" } }]);
+    }
+    if (url === "https://llm.chutes.ai/v1/models") return Response.json({ data: [{ id: "fixture/chat", pricing: { prompt: 2, completion: 10 } }] });
+    if (url === "https://api.cerebras.ai/public/v1/models") return Response.json({ data: [{ id: "fixture/chat", pricing: { prompt: "0.000002", completion: "0.00001" } }] });
+    if (url === ${JSON.stringify(VENICE_PRICING_URL)}) return Response.json({ data: [{ id: "fixture/chat", type: "text", model_spec: { pricing: { input: { usd: 2 }, output: { usd: 10 } } } }] });
+  }
   if (url === ${JSON.stringify(VENICE_PRICING_URL)}) {
     if (${JSON.stringify(scenario)} === "unreachable") throw new Error("fixture outage");
     if (${JSON.stringify(scenario)} === "malformed body") return Response.json({});


### PR DESCRIPTION
Closes #134709 (DeepInfra estimates ignore native discounts and schedule qualifications).

<details>
<summary>Additional instructions</summary>

This branch is in `openclaw/openclaw`; maintainers with repository write access can take it over.

</details>

## What Problem This Solves

Fixes an issue where users viewing DeepInfra estimates could receive undiscounted or stale prices, or a lower-band headline rate presented as an unconditional schedule. Live discovery copied a simplified model projection that carries discounts separately and omits native pricing qualifications. Hosted publication had no DeepInfra-native source, and appended offline seed rows could restore stale rates.

The anonymous pre-fix runtime reproduction returned 107 models with four input/output mismatches—three ignored discounts and an appended stale seed—and eight positive flat prices for qualified native schedules. This affects estimates, not provider billing or model availability.

## Why This Change Was Made

Keep metadata and prices with their respective owners. DeepInfra's existing agent projection still controls model membership/order, capabilities and limits. A pure plugin-owned parser reads the native `/models/list` array for pricing, converts cents/token into USD per million, applies the advertised numeric discount exactly once, and interprets the cached-input ratio. Publication and configured chat discovery share that parser; no duplicate cache, store, polling loop or request-time usage lookup was added.

The shared catalog validator now accepts identity, price and support selectors rather than duplicating its integrity loop for `model_name` records. It validates declared prices before omitting unsupported schedules, still rejects duplicate identities including unpriced rows, and preserves real declared zero prices. Source parsers own root-shape validation, allowing DeepInfra arrays without weakening the object contracts of existing feeds. OpenCode and Venice callers migrate directly to the private options contract; Chutes/Cerebras keep the default selectors.

Pricing prose, nonempty tables, scheduled expiry and undocumented generic cache-write rates are not flattened into guesses. Priority/flex and explicit cache-retention prices remain separate from standard token estimates. Native omissions cannot be filled by generic vendors or old projection prices. Source failure or malformed native pricing preserves the previous hosted artifact.

## User Impact

Configured DeepInfra chat discovery refreshes standard advertised prices through the existing five-minute cache. Metadata and pricing requests run concurrently, without Authorization headers; pre-auth/test-suppressed and image/video-only discovery do not add a native price request. Model defaults, IDs, statuses, curated reasoning and compatibility remain unchanged. Three existing offline seed costs were refreshed.

Models remain selectable when their prices are absent, qualified or temporarily unavailable. Runtime retains its existing required unknown-zero placeholder and emits a diagnostic; this is not evidence of free billing. If only metadata fails, complete bundled model metadata still receives available native prices. The complete priced offline fallback is retained only when both sources fail or discovery is skipped. Price-only IDs never add models.

Explicit operator prices—including zero, partial and tiered overrides—continue to win. Onboarding stays alias-only and does not pin generated prices. Hosted activation follows the existing four-hour publication, six-hour conditional client refresh and next-restart lifecycle; no operator Gateway was changed.

Release boundary: DeepInfra and Venice must use a host that supports the private pricing options contract. Standard coordinated release preparation raises existing `compat.pluginApi` floors to the selected supporting host version. Independent plugin publication against an older unsupported host floor is not an acceptable release path. This PR does not bump versions or publish software.

## Evidence

- Captured the real anonymous pre-fix discovery failure before production edits. Deterministic publisher/runtime regressions also failed on the intended price assertions. Their initial wrappers needed interruption after reporting the assertions; those are not claimed as clean RED exits.
- The complete owner/sibling selection passed: **310 tests across 15 files** covering shared pricing integrity, publication, DeepInfra, Chutes/Cerebras/Venice, proxy cleanup, caching, auth suppression, non-chat catalogs and final model-config override merging.
- Parent review found the asymmetric metadata-failure/native-success gap. A new regression exited normally RED, then **30 tests across three files** passed after the production-LOC-neutral repair. Native-only IDs, complete seed metadata, both-failed fallback and no-auth siblings are covered.
- All selected changed-check obligations passed after focused fixture lint repairs. The original aggregate invocation stopped at those lint findings; affected-file reruns and every remaining selected lane completed successfully. All six TypeScript lanes, core/plugin/script lint, doctor contracts, SDK/boundary guards, dead exports and zero runtime import cycles were checked. Final follow-up lint/types/format checks passed.
- Independent live candidate publication at **2026-09-01 04:11 UTC** checked **832 normalized rates across 208 standard native schedules**, three discounted rows and eight qualified omissions. Exactly one anonymous DeepInfra source request was made. Candidate size was **1,920,291 bytes**, below the unchanged 4 MiB client cap.
- The same real guarded runtime reproduction passed at **04:13 UTC**, then again on final candidate `f9bd60aacbf6413f9d329abad1c1a79f3c5fd400` at **05:50 UTC**: **107 models, 99 matching standard schedules, zero input/output mismatches, zero qualified positive flat prices**. All requests lacked Authorization. The independent oracle accounts for the additional native GET in that probe.
- Final extension-test typecheck passed: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`.
- Final isolated Codex autoreview of the complete pricing candidate: scoped-clean at P0, with no accepted/actionable findings at that threshold. Its patch remains identical after the mechanical conflict rebase. A separate fresh frozen review of the temporary two-file CI repair was also scoped-clean; that is historical evidence for the now-superseded patch, not a review claim about upstream's implementation.
- Full `pnpm build` of pricing candidate `f9bd60aacbf6413f9d329abad1c1a79f3c5fd400` passed in **19m 11.5s**, including the native plugin control-plane load checks, all 147 public SDK subpaths and Control UI size gates. It left the reviewed source unchanged. Dependency `eval` and browser externalization warnings were emitted; no ineffective dynamic-import warning was emitted. This preceded the bounded release-tooling repair below.
- [Initial exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33475255851) exposed an existing release-inventory acquisition defect: recursive `git ls-tree` output crossed Node's default 1 MiB synchronous buffer. Our bounded repair passed a real-Git RED/GREEN regression, 62 tests and fresh review. While the next CI ran, [release-verification performance PR #134824](https://github.com/openclaw/openclaw/pull/134824) independently landed the same owner fix and caused a real merge conflict. The rebase onto `eaaa6da895f625a2421853587c3ef21286325b7c` retained main's implementation and dropped our duplicate commit. Both inventory files remain byte-identical to main; no buffer/timeout increase or release-tooling delta remains here. Fresh upstream owner/sibling proof passed **63 tests** (101 unrelated cases intentionally excluded), and real-Git comparison retained all 273 metadata paths/modes/object IDs with a 23,358-byte listing plus success/rejection cleanup.
- Rebased pricing head `9a0263d001f281e725be9d094c2eade9ded54a62` passed the full **311-test / 15-file** pricing selection, proportional formatting/lint/types, and another real anonymous runtime probe at **06:40 UTC**: 107 models, 99 matching schedules, zero mismatches or qualified positive flat prices. Range-diff proves the original pricing patch unchanged; the only inherited docs change is main's unrelated provider-auth paragraph. [New exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33479821732) is the landing candidate's run; old-head failures are not relabeled or rerun as new-head proof.
- The [compatibility/rank-up response](https://github.com/openclaw/openclaw/pull/134893#issuecomment-5489724656) records coordinated-release ownership and a synthetic real alignment/installer-gate check: both affected plugins reject the older host after their floors are aligned. No actual package version was changed.

Commands for the owner/sibling test selection:

```bash
node scripts/run-vitest.mjs packages/model-catalog-core/src/model-catalog-pricing.test.ts extensions/deepinfra/pricing-api.test.ts extensions/deepinfra/provider-models.pricing.test.ts extensions/deepinfra/provider-models.test.ts extensions/deepinfra/provider-models.proxy.test.ts extensions/deepinfra/onboard.test.ts extensions/deepinfra/index.test.ts extensions/deepinfra/surface-model-catalogs.test.ts extensions/deepinfra/cache-wrapper.test.ts extensions/deepinfra/provider.contract.test.ts extensions/venice/models.test.ts extensions/chutes/models.test.ts extensions/cerebras/onboard.test.ts test/scripts/publish-model-catalog.test.ts src/agents/models-config.model-input-presence.test.ts
```

Asymmetric-failure RED and GREEN:

```bash
node scripts/run-vitest.mjs extensions/deepinfra/provider-models.pricing.test.ts -t 'keeps native prices with static metadata'
```

```bash
node scripts/run-vitest.mjs extensions/deepinfra/provider-models.pricing.test.ts extensions/deepinfra/provider-models.test.ts extensions/deepinfra/provider-models.proxy.test.ts
```

Task-local live probes (retained locally, not product files):

```bash
node --import tsx .artifacts/native-pricing-campaign/verify-deepinfra-publication.mts
```

```bash
node --import tsx .artifacts/native-pricing-campaign/verify-deepinfra-runtime-pricing.mts lead-deepinfra-runtime-after.json
```

Final production/tooling/manifest LOC: **+231/-72 (net +159)**. Tests: **+738/-165 (net +573)**. Docs: **+61/-7 (net +54)**, across **18 files**. Growth adds the native schema parser and independent pricing fact acquisition; the old projection-price consumer was deleted. The temporary CI repair was dropped during the required conflict rebase because main independently landed the same owner fix; no duplicate release-tooling change remains in this PR. Cleanup removes the dead URL self-comparison and self-mocked auth test with its leaked temporary directory. No baseline, budget, dependency, storage schema, protocol or permission changes.

Proof limits: no real provider credentials, paid inference, invoices, subscription-charge verification, channel sends or operator Gateway changes. HTTP metadata and normalized estimates are verified, not a paid conversation. Generic cache-write semantics remain unsupported; no 5-minute/1-hour rule was invented. Hosted publication will be verified after merge through the existing catalog workflow.

Sources: [native model schema](https://docs.deepinfra.com/api-reference/models/models-list), [public native catalog](https://api.deepinfra.com/models/list), [official cached-price renderer](https://deepinfra.com/_next/static/chunks/9425-60fe6bcb8718db61.js), [prompt caching](https://docs.deepinfra.com/chat/prompt-caching), [retention semantics](https://docs.deepinfra.com/chat/prompt-cache-retention), [hosted refresh lifecycle](https://docs.openclaw.ai/concepts/models#hosted-catalog-updates). Builds on the [Chutes/Cerebras native pricing foundation](https://github.com/openclaw/openclaw/pull/134311).
