### PR TITLE
test(inworld): consolidate duplicate transport coverage

### DIFF
--- a/extensions/inworld/tts.test.ts
+++ b/extensions/inworld/tts.test.ts
@@ -1,4 +1,3 @@
-// Inworld tests cover tts plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 
@@ -47,61 +46,19 @@ function readRequestBody(request: GuardRequest): string {
   return body;
 }
 
-const guardedSuccessReleaseCases = [
-  {
-    name: "listInworldVoices",
-    run: async () => {
-      const { release } = queueGuardedResponse(
-        new Response(JSON.stringify({ voices: [] }), { status: 200 }),
-      );
-
-      await listInworldVoices({ apiKey: "test-key" });
-      return release;
-    },
-  },
-  {
-    name: "inworldTTS",
-    run: async () => {
-      const chunk = Buffer.from("audio").toString("base64");
-      const { release } = queueGuardedResponse(
-        new Response(JSON.stringify({ result: { audioContent: chunk } }), { status: 200 }),
-      );
-
-      await inworldTTS({ text: "test", apiKey: "test-key" });
-      return release;
-    },
-  },
-];
+afterEach(() => {
+  fetchWithSsrFGuardMock.mockReset();
+  vi.restoreAllMocks();
+});
 
 afterAll(() => {
   vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
   vi.resetModules();
 });
 
-describe("Inworld guarded dispatcher lifecycle", () => {
-  afterEach(() => {
-    fetchWithSsrFGuardMock.mockReset();
-    vi.restoreAllMocks();
-  });
-
-  it.each(guardedSuccessReleaseCases)(
-    "$name releases the guarded dispatcher after success",
-    async ({ run }) => {
-      const release = await run();
-
-      expect(release).toHaveBeenCalledTimes(1);
-    },
-  );
-});
-
 describe("listInworldVoices", () => {
-  afterEach(() => {
-    fetchWithSsrFGuardMock.mockReset();
-    vi.restoreAllMocks();
-  });
-
   it("maps Inworld voice metadata into speech voice options", async () => {
-    queueGuardedResponse(
+    const { release } = queueGuardedResponse(
       new Response(
         JSON.stringify({
           voices: [
@@ -151,6 +108,7 @@ describe("listInworldVoices", () => {
     expect(request.policy).toEqual({ hostnameAllowlist: ["api.inworld.ai"] });
     const headers = new Headers(request.init?.headers);
     expect(headers.get("authorization")).toBe("Basic test-key");
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("throws on API errors with response body", async () => {
@@ -212,11 +170,6 @@ describe("listInworldVoices", () => {
 });
 
 describe("inworldTTS", () => {
-  afterEach(() => {
-    fetchWithSsrFGuardMock.mockReset();
-    vi.restoreAllMocks();
-  });
-
   it("concatenates base64 audio chunks from streaming response", async () => {
     const chunk1 = Buffer.from("audio-chunk-1").toString("base64");
     const chunk2 = Buffer.from("audio-chunk-2").toString("base64");
@@ -225,7 +178,7 @@ describe("inworldTTS", () => {
       JSON.stringify({ result: { audioContent: chunk2 } }),
     ].join("\n");
 
-    queueGuardedResponse(new Response(body, { status: 200 }));
+    const { release } = queueGuardedResponse(new Response(body, { status: 200 }));
 
     const buffer = await inworldTTS({
       text: "Hello world",
@@ -235,6 +188,7 @@ describe("inworldTTS", () => {
     expect(buffer).toEqual(
       Buffer.concat([Buffer.from("audio-chunk-1"), Buffer.from("audio-chunk-2")]),
     );
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("rejects malformed base64 audio chunks", async () => {
@@ -247,11 +201,12 @@ describe("inworldTTS", () => {
   });
 
   it("throws on HTTP errors with response body", async () => {
-    queueGuardedResponse(new Response("bad request body", { status: 400 }));
+    const { release } = queueGuardedResponse(new Response("bad request body", { status: 400 }));
 
     await expect(inworldTTS({ text: "test", apiKey: "test-key" })).rejects.toThrow(
       "Inworld TTS API error (400): bad request body",
     );
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("keeps truncated HTTP error bodies UTF-16 safe", async () => {
@@ -367,15 +322,6 @@ describe("inworldTTS", () => {
     const buffer = await inworldTTS({ text: "test", apiKey: "test-key" });
     expect(buffer).toEqual(Buffer.from("audio"));
   });
-
-  it("releases the guarded dispatcher after failure", async () => {
-    const { release } = queueGuardedResponse(new Response("fail", { status: 500 }));
-
-    await expect(inworldTTS({ text: "test", apiKey: "test-key" })).rejects.toThrow(
-      "Inworld TTS API error (500): fail",
-    );
-    expect(release).toHaveBeenCalledTimes(1);
-  });
 });
 
 describe("Inworld response read bounding", () => {
@@ -416,19 +362,6 @@ describe("Inworld response read bounding", () => {
     expect(state.cancelled).toBe(true);
   });
 
-  it("happy-path: a normal multi-line NDJSON audio payload still decodes unchanged", async () => {
-    const part1 = Buffer.from("hello-").toString("base64");
-    const part2 = Buffer.from("world").toString("base64");
-    const body = [
-      JSON.stringify({ result: { audioContent: part1 } }),
-      JSON.stringify({ result: { audioContent: part2 } }),
-    ].join("\n");
-    queueGuardedResponse(new Response(body, { status: 200 }));
-
-    const audio = await inworldTTS({ text: "test", apiKey: "test-key" });
-    expect(audio.toString("utf8")).toBe("hello-world");
-  });
-
   it("edge: an under-cap ~1 MiB audio payload is read intact, not truncated", async () => {
     const payload = "x".repeat(MiB);
     const encoded = Buffer.from(payload).toString("base64");
@@ -449,13 +382,6 @@ describe("Inworld response read bounding", () => {
 
     await expect(inworldTTS({ text: "test", apiKey: "test-key" })).rejects.toThrow(
       /Inworld TTS decoded audio too large: 16777217 bytes \(limit: 16777216 bytes\)/,
-    );
-  });
-
-  it("regression: a malformed NDJSON line under the cap still throws a bounded parse error", async () => {
-    queueGuardedResponse(new Response("this-is-not-json", { status: 200 }));
-    await expect(inworldTTS({ text: "test", apiKey: "test-key" })).rejects.toThrow(
-      /Inworld TTS stream parse error/,
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves

The Inworld suite repeats five transport executions that exercise the same success, non-OK response and malformed-line paths as stronger existing cases.

## Why This Change Was Made

Move all three dispatcher-release assertions onto the existing voice-mapping, exact two-chunk Buffer and HTTP-error cases. Delete the redundant decoding and generic parse-error replays. One file-owned afterEach resets the same guard mock and restores spies, including the bounding cases.

## User Impact

Test-only: production +0/-0; tests +10/-84 (net -74). Five guarded Responses and owner calls are removed. The 32 MiB stream cap, 16 MiB audio/voice caps, 1 MiB integrity fixture, 64 KiB hostile error, Unicode-safe exact error and malformed-base64 coverage remain. No elapsed-time improvement is claimed.

## Evidence

Native proof passes 45/45 before and 40/40 after, including all 13 speech-provider cases and the real-guard voice-timeout sibling. Every retained case label/status matches. The deleted cases map as follows:

| Removed execution | Retained coverage |
| --- | --- |
| Voice success-release replay | Rich voice metadata mapping plus exact-one release |
| TTS success-release replay | Exact two-chunk Buffer concatenation plus exact-one release |
| Standalone 500/release replay | Full 400 status/body substring assertion plus exact-one release; oversized error retains 500 coverage |
| Two-line decoding replay | Exact two-chunk Buffer comparison |
| Generic malformed-line prefix replay | Exact bounded Unicode-safe parse error |

A temporary omission of TTS dispatcher release makes both retained TTS release assertions fail with zero calls; the selected voice case still passes. Exact source bytes were restored. This retains the original immediate-spy oracle, not a new delayed-release claim. Full changed-file checks and Codex autoreview passed; independent source review found no actionable findings.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/inworld/tts.test.ts extensions/inworld/speech-provider.test.ts extensions/inworld/voices-timeout.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base 7d508d2a890
```
