### PR TITLE
feat(approvals): persist external verification attempts

### DIFF
--- a/src/gateway/operator-approval-authorization.ts
+++ b/src/gateway/operator-approval-authorization.ts
@@ -21,6 +21,19 @@ function normalizeIdentities(values: readonly string[] | null | undefined): stri
   return [...normalized];
 }
 
+/** Whether one device identity satisfies an approval's optional reviewer binding. */
+export function isOperatorApprovalReviewerAuthorized(params: {
+  reviewerDeviceId?: string | null;
+  reviewerDeviceIds?: readonly string[] | null;
+}): boolean {
+  const reviewerDeviceIds = normalizeIdentities(params.reviewerDeviceIds);
+  if (reviewerDeviceIds.length === 0) {
+    return true;
+  }
+  const reviewerDeviceId = normalizeIdentity(params.reviewerDeviceId);
+  return Boolean(reviewerDeviceId && reviewerDeviceIds.includes(reviewerDeviceId));
+}
+
 /** Whether a client may inspect safe approval projections. */
 export function canReviewOperatorApproval(client: GatewayClient | null): boolean {
   const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
@@ -64,10 +77,13 @@ export function canAccessOperatorApproval(params: {
     return true;
   }
 
-  const clientDeviceId = normalizeIdentity(params.client?.connect?.device?.id);
-  const reviewerDeviceIds = normalizeIdentities(params.binding.reviewerDeviceIds);
-  if (reviewerDeviceIds.length > 0) {
-    return Boolean(clientDeviceId && reviewerDeviceIds.includes(clientDeviceId));
+  if (
+    !isOperatorApprovalReviewerAuthorized({
+      reviewerDeviceId: params.client?.connect?.device?.id,
+      reviewerDeviceIds: params.binding.reviewerDeviceIds,
+    })
+  ) {
+    return false;
   }
 
   // No explicit reviewer binding: the operator.approvals scope tier is the

--- a/src/gateway/operator-approval-store.ts
+++ b/src/gateway/operator-approval-store.ts
@@ -424,6 +424,22 @@ function hasValidLifecycleTuple(params: {
   );
 }
 
+function presentationAllowsDecision(
+  presentation: ApprovalPresentation,
+  decision: OperatorApprovalDecision,
+): boolean {
+  if (Array.prototype.includes.call(presentation.allowedDecisions, decision)) {
+    return true;
+  }
+  // External allow decisions are intentionally absent from the generic resolver surface.
+  // Only the plugin-bound completion transaction may authorize one.
+  return (
+    presentation.kind === "plugin" &&
+    (decision === "allow-once" || decision === "allow-always") &&
+    presentation.externalResolution?.decisions.includes(decision) === true
+  );
+}
+
 function decodeOperatorApprovalRow(row: OperatorApprovalRow): OperatorApprovalRecord | null {
   const presentation = parseApprovalPresentation(row.presentation_json);
   const reviewerDeviceIds = parseStringArray(row.reviewer_device_ids_json);
@@ -468,8 +484,7 @@ function decodeOperatorApprovalRow(row: OperatorApprovalRow): OperatorApprovalRe
     row.resolution_ref !==
       buildApprovalResolutionRef({ approvalId: row.approval_id, approvalKind: kind }) ||
     !hasValidLifecycleTuple({ row, status, decision, terminalReason, resolverKind }) ||
-    (status === "allowed" &&
-      (!decision || !Array.prototype.includes.call(presentation.allowedDecisions, decision)))
+    (status === "allowed" && (!decision || !presentationAllowsDecision(presentation, decision)))
   ) {
     return null;
   }

--- a/src/gateway/plugin-external-verification-store.test.ts
+++ b/src/gateway/plugin-external-verification-store.test.ts
@@ -1,0 +1,755 @@
+import fs from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import {
+  closeOrphanedOperatorApprovals,
+  forceDenyOperatorApproval,
+  getOperatorApprovalDetailed,
+  insertOperatorApproval,
+  resolveOperatorApproval,
+} from "./operator-approval-store.js";
+import {
+  completeExternalVerificationAttempt,
+  failExternalVerificationAttempt,
+  getExternalVerificationAttemptSnapshot,
+  getExternalVerificationNativeActionState,
+  startExternalVerificationAttempt,
+} from "./plugin-external-verification-store.js";
+
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    cleanup();
+  });
+});
+
+function createDatabaseOptions(): OpenClawStateDatabaseOptions {
+  const stateDir = fs.realpathSync(tempDirs.make("openclaw-external-verification-"));
+  return { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
+}
+
+function insertExternalApproval(params: {
+  databaseOptions: OpenClawStateDatabaseOptions;
+  id?: string;
+  reviewerDeviceIds?: string[];
+  runId?: string | null;
+  runtimeEpoch?: string;
+  expiresAtMs?: number;
+}) {
+  const id = params.id ?? "plugin:approval-1";
+  return insertOperatorApproval({
+    approval: {
+      id,
+      kind: "plugin",
+      presentation: {
+        kind: "plugin",
+        title: "World verification",
+        description: "Verify personhood before continuing.",
+        severity: "warning",
+        pluginId: "agentkit",
+        toolName: "dangerous-tool",
+        agentId: "main",
+        allowedDecisions: ["deny"],
+        externalResolution: {
+          label: "Verify with World",
+          decisions: ["allow-once", "allow-always"],
+        },
+      },
+      source: {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "session-1",
+        runId: params.runId === undefined ? "run-1" : params.runId,
+        toolCallId: "call-1",
+        toolName: "dangerous-tool",
+      },
+      runtimeEpoch: params.runtimeEpoch ?? "epoch-1",
+      createdAtMs: 1_000,
+      expiresAtMs: params.expiresAtMs ?? 10_000,
+      reviewerDeviceIds: params.reviewerDeviceIds,
+    },
+    databaseOptions: params.databaseOptions,
+  });
+}
+
+function getApproval(id: string, databaseOptions: OpenClawStateDatabaseOptions, nowMs = 2_000) {
+  const result = getOperatorApprovalDetailed({ id, nowMs, databaseOptions });
+  return result.outcome === "found" ? result.record : null;
+}
+
+describe("plugin external verification store", () => {
+  it("starts one host-bound attempt and replays the same interaction without replacement", () => {
+    const databaseOptions = createDatabaseOptions();
+    expect(insertExternalApproval({ databaseOptions })).toMatchObject({ outcome: "inserted" });
+
+    const first = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    expect(first).toMatchObject({
+      outcome: "started",
+      attempt: {
+        context: {
+          approvalId: "plugin:approval-1",
+          pluginId: "agentkit",
+          runId: "run-1",
+          toolName: "dangerous-tool",
+          toolCallId: "call-1",
+          sessionId: "session-1",
+          decision: "allow-once",
+        },
+      },
+    });
+
+    expect(
+      startExternalVerificationAttempt({
+        approvalId: "plugin:approval-1",
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_001,
+        databaseOptions,
+      }),
+    ).toEqual({ outcome: "replay", attempt: first.outcome === "started" ? first.attempt : null });
+  });
+
+  it("reports expiry before replaying an active interaction", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions, expiresAtMs: 2_050 });
+    const request = {
+      approvalId: "plugin:approval-1",
+      decision: "allow-once" as const,
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      databaseOptions,
+    };
+    const started = startExternalVerificationAttempt({ ...request, nowMs: 2_000 });
+    if (started.outcome !== "started") {
+      throw new Error("expected active attempt");
+    }
+
+    expect(startExternalVerificationAttempt({ ...request, nowMs: 2_100 })).toEqual({
+      outcome: "approval-expired",
+    });
+    expect(getApproval("plugin:approval-1", databaseOptions, 2_000)).toMatchObject({
+      status: "pending",
+    });
+    expect(
+      getExternalVerificationAttemptSnapshot({
+        attemptId: started.attempt.id,
+        pluginId: "agentkit",
+        databaseOptions,
+      }),
+    ).not.toHaveProperty("outcome");
+  });
+
+  it("replays a superseded interaction instead of reviving its stale decision", () => {
+    const databaseOptions = createDatabaseOptions();
+    expect(insertExternalApproval({ databaseOptions })).toMatchObject({ outcome: "inserted" });
+
+    const first = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    expect(first.outcome).toBe("started");
+    if (first.outcome !== "started") {
+      throw new Error("expected the first external verification attempt to start");
+    }
+
+    const stronger = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-always",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_001,
+      databaseOptions,
+    });
+    expect(stronger).toMatchObject({
+      outcome: "started",
+      attempt: { context: { decision: "allow-always" } },
+    });
+    if (stronger.outcome !== "started") {
+      throw new Error("expected the stronger external verification attempt to start");
+    }
+
+    const staleReplay = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_002,
+      databaseOptions,
+    });
+    expect(staleReplay).toEqual({
+      outcome: "replay",
+      attempt: {
+        ...first.attempt,
+        endedAtMs: 2_001,
+        outcome: "cancelled",
+        terminalSource: "reviewer-retry",
+      },
+    });
+    expect(
+      getExternalVerificationAttemptSnapshot({
+        attemptId: first.attempt.id,
+        pluginId: "agentkit",
+        databaseOptions,
+      }),
+    ).toMatchObject({
+      outcome: "cancelled",
+      terminalSource: "reviewer-retry",
+    });
+    const activeAttempt = getExternalVerificationAttemptSnapshot({
+      attemptId: stronger.attempt.id,
+      pluginId: "agentkit",
+      databaseOptions,
+    });
+    expect(activeAttempt).toMatchObject({ context: { decision: "allow-always" } });
+    expect(activeAttempt).not.toHaveProperty("outcome");
+    expect(
+      startExternalVerificationAttempt({
+        approvalId: "plugin:approval-1",
+        decision: "allow-always",
+        interactionId: "a".repeat(64),
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_003,
+        databaseOptions,
+      }),
+    ).toEqual({ outcome: "replay", attempt: stronger.attempt });
+  });
+
+  it("enforces the approval reviewer binding before starting or replaying an attempt", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({
+      databaseOptions,
+      reviewerDeviceIds: ["device-authorized"],
+    });
+    const request = {
+      approvalId: "plugin:approval-1",
+      decision: "allow-once" as const,
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    };
+    expect(
+      startExternalVerificationAttempt({
+        ...request,
+        reviewerDeviceId: "device-other",
+      }),
+    ).toEqual({ outcome: "reviewer-unauthorized" });
+    expect(
+      startExternalVerificationAttempt({
+        ...request,
+        reviewerDeviceId: "device-authorized",
+      }),
+    ).toMatchObject({ outcome: "started" });
+    expect(startExternalVerificationAttempt(request)).toEqual({
+      outcome: "reviewer-unauthorized",
+    });
+  });
+
+  it("treats a new reviewer interaction as an explicit retry and closes only the active attempt", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions });
+    const first = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    const second = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-always",
+      interactionId: "b".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_100,
+      databaseOptions,
+    });
+    expect(second).toMatchObject({
+      outcome: "started",
+      attempt: { context: { decision: "allow-always" } },
+    });
+    if (first.outcome !== "started") {
+      throw new Error("expected first attempt");
+    }
+    expect(
+      completeExternalVerificationAttempt({
+        attemptId: first.attempt.id,
+        pluginId: "agentkit",
+        outcome: "succeeded",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_200,
+        databaseOptions,
+      }),
+    ).toMatchObject({
+      outcome: "replay",
+      applied: false,
+      attempt: { outcome: "cancelled", terminalSource: "reviewer-retry" },
+    });
+  });
+
+  it("requires a core-issued native retry generation to replace the exact active attempt", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions });
+    const common = {
+      approvalId: "plugin:approval-1",
+      decision: "allow-once" as const,
+      runtimeEpoch: "epoch-1",
+      databaseOptions,
+    };
+    expect(getExternalVerificationNativeActionState({ ...common, nowMs: 2_000 })).toEqual({
+      outcome: "ready",
+      action: { intent: "start", expectedAttemptId: null },
+    });
+
+    const first = startExternalVerificationAttempt({
+      ...common,
+      interactionId: "a".repeat(64),
+      nativeAction: { intent: "start", expectedAttemptId: null },
+      nowMs: 2_001,
+    });
+    expect(first.outcome).toBe("started");
+    if (first.outcome !== "started") {
+      throw new Error("expected native start attempt");
+    }
+    expect(
+      startExternalVerificationAttempt({
+        ...common,
+        interactionId: "a".repeat(64),
+        nativeAction: { intent: "start", expectedAttemptId: null },
+        nowMs: 2_002,
+      }),
+    ).toEqual({ outcome: "replay", attempt: first.attempt });
+    expect(
+      startExternalVerificationAttempt({
+        ...common,
+        interactionId: "b".repeat(64),
+        nativeAction: { intent: "start", expectedAttemptId: null },
+        nowMs: 2_003,
+      }),
+    ).toEqual({ outcome: "stale-action", attempt: first.attempt });
+
+    const retryAction = {
+      intent: "retry" as const,
+      expectedAttemptId: first.attempt.id,
+    };
+    expect(getExternalVerificationNativeActionState({ ...common, nowMs: 2_004 })).toEqual({
+      outcome: "ready",
+      action: retryAction,
+    });
+    const retry = startExternalVerificationAttempt({
+      ...common,
+      interactionId: "c".repeat(64),
+      nativeAction: retryAction,
+      nowMs: 2_005,
+    });
+    expect(retry.outcome).toBe("started");
+    if (retry.outcome !== "started") {
+      throw new Error("expected native retry attempt");
+    }
+    expect(
+      startExternalVerificationAttempt({
+        ...common,
+        interactionId: "a".repeat(64),
+        nativeAction: { intent: "start", expectedAttemptId: null },
+        nowMs: 2_006,
+      }),
+    ).toEqual({ outcome: "stale-action", attempt: retry.attempt });
+    expect(
+      startExternalVerificationAttempt({
+        ...common,
+        interactionId: "d".repeat(64),
+        nativeAction: retryAction,
+        nowMs: 2_007,
+      }),
+    ).toEqual({ outcome: "stale-action", attempt: retry.attempt });
+    expect(
+      getExternalVerificationAttemptSnapshot({
+        attemptId: first.attempt.id,
+        pluginId: "agentkit",
+        databaseOptions,
+      }),
+    ).toMatchObject({ outcome: "cancelled", terminalSource: "reviewer-retry" });
+
+    failExternalVerificationAttempt({
+      attemptId: retry.attempt.id,
+      pluginId: "agentkit",
+      nowMs: 2_008,
+      errorClass: "proof-rejected",
+      databaseOptions,
+    });
+    expect(getExternalVerificationNativeActionState({ ...common, nowMs: 2_009 })).toEqual({
+      outcome: "ready",
+      action: { intent: "start", expectedAttemptId: retry.attempt.id },
+    });
+  });
+
+  it("does not expose a stronger attempt through a stale weaker native action", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions });
+    const common = {
+      approvalId: "plugin:approval-1",
+      runtimeEpoch: "epoch-1",
+      databaseOptions,
+    };
+    const weakerAction = { intent: "start" as const, expectedAttemptId: null };
+    const weaker = startExternalVerificationAttempt({
+      ...common,
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      nativeAction: weakerAction,
+      nowMs: 2_000,
+    });
+    if (weaker.outcome !== "started") {
+      throw new Error("expected weaker native attempt");
+    }
+    const stronger = startExternalVerificationAttempt({
+      ...common,
+      decision: "allow-always",
+      interactionId: "b".repeat(64),
+      nowMs: 2_001,
+    });
+    if (stronger.outcome !== "started") {
+      throw new Error("expected stronger replacement attempt");
+    }
+
+    expect(
+      startExternalVerificationAttempt({
+        ...common,
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        nativeAction: weakerAction,
+        nowMs: 2_002,
+      }),
+    ).toEqual({ outcome: "stale-action" });
+    expect(
+      startExternalVerificationAttempt({
+        ...common,
+        decision: "allow-once",
+        interactionId: "c".repeat(64),
+        nativeAction: weakerAction,
+        nowMs: 2_003,
+      }),
+    ).toEqual({ outcome: "stale-action" });
+    expect(
+      getExternalVerificationAttemptSnapshot({
+        attemptId: stronger.attempt.id,
+        pluginId: "agentkit",
+        databaseOptions,
+      }),
+    ).toMatchObject({ context: { decision: "allow-always" } });
+  });
+
+  it("keeps failure pending, then atomically records a stable grant on success", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions });
+    const failed = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    if (failed.outcome !== "started") {
+      throw new Error("expected failed attempt fixture");
+    }
+    expect(
+      completeExternalVerificationAttempt({
+        attemptId: failed.attempt.id,
+        pluginId: "agentkit",
+        outcome: "failed",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_100,
+        databaseOptions,
+      }),
+    ).toMatchObject({ outcome: "completed", applied: false, attempt: { outcome: "failed" } });
+    expect(getApproval("plugin:approval-1", databaseOptions)).toMatchObject({ status: "pending" });
+
+    const successful = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-always",
+      interactionId: "b".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_200,
+      databaseOptions,
+    });
+    if (successful.outcome !== "started") {
+      throw new Error("expected successful attempt fixture");
+    }
+    const completed = completeExternalVerificationAttempt({
+      attemptId: successful.attempt.id,
+      pluginId: "agentkit",
+      outcome: "succeeded",
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_300,
+      databaseOptions,
+    });
+    expect(completed).toMatchObject({
+      outcome: "completed",
+      applied: true,
+      attempt: { outcome: "succeeded" },
+      grantAuthorization: {
+        approvalId: "plugin:approval-1",
+        attemptId: successful.attempt.id,
+        decision: "allow-always",
+      },
+    });
+    expect(getApproval("plugin:approval-1", databaseOptions)).toMatchObject({
+      status: "allowed",
+      decision: "allow-always",
+      resolver: { kind: "runtime", id: "plugin:agentkit" },
+    });
+    expect(
+      completeExternalVerificationAttempt({
+        attemptId: successful.attempt.id,
+        pluginId: "agentkit",
+        outcome: "succeeded",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_400,
+        databaseOptions,
+      }),
+    ).toEqual({ ...completed, outcome: "replay", applied: false });
+  });
+
+  it("does not issue reusable grant authorization for allow-once", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions });
+    const started = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    if (started.outcome !== "started") {
+      throw new Error("expected allow-once attempt");
+    }
+
+    const completed = completeExternalVerificationAttempt({
+      attemptId: started.attempt.id,
+      pluginId: "agentkit",
+      outcome: "succeeded",
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_100,
+      databaseOptions,
+    });
+
+    expect(completed).toMatchObject({ outcome: "completed", applied: true });
+    expect(completed).not.toHaveProperty("grantAuthorization");
+  });
+
+  it("never grants after denial wins and rejects caller-selected plugin ownership", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions });
+    const started = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    if (started.outcome !== "started") {
+      throw new Error("expected attempt");
+    }
+    expect(
+      completeExternalVerificationAttempt({
+        attemptId: started.attempt.id,
+        pluginId: "different-plugin",
+        outcome: "succeeded",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_050,
+        databaseOptions,
+      }),
+    ).toEqual({ outcome: "attempt-not-found" });
+    expect(
+      resolveOperatorApproval({
+        id: "plugin:approval-1",
+        decision: "deny",
+        resolver: { kind: "channel", id: "telegram:owner" },
+        expectedKind: "plugin",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_100,
+        databaseOptions,
+      }),
+    ).toMatchObject({ outcome: "resolved", record: { status: "denied" } });
+    expect(
+      completeExternalVerificationAttempt({
+        attemptId: started.attempt.id,
+        pluginId: "agentkit",
+        outcome: "succeeded",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_200,
+        databaseOptions,
+      }),
+    ).toMatchObject({
+      outcome: "replay",
+      applied: false,
+      attempt: { outcome: "cancelled", terminalSource: "user" },
+    });
+  });
+
+  it("reports an expired approval to the runtime before a late success can authorize a grant", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions, expiresAtMs: 2_050 });
+    const started = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-always",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    if (started.outcome !== "started") {
+      throw new Error("expected expiring attempt");
+    }
+
+    const completion = completeExternalVerificationAttempt({
+      attemptId: started.attempt.id,
+      pluginId: "agentkit",
+      outcome: "succeeded",
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_100,
+      databaseOptions,
+    });
+
+    expect(completion).toMatchObject({
+      outcome: "approval-expired",
+      approvalId: "plugin:approval-1",
+    });
+    expect(completion).not.toHaveProperty("grantAuthorization");
+    expect(getApproval("plugin:approval-1", databaseOptions, 2_000)).toMatchObject({
+      status: "pending",
+    });
+    expect(
+      getExternalVerificationAttemptSnapshot({
+        attemptId: started.attempt.id,
+        pluginId: "agentkit",
+        databaseOptions,
+      }),
+    ).not.toHaveProperty("outcome");
+  });
+
+  it("records run cancellation as terminal before replaying a late completion", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions });
+    const started = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-always",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    if (started.outcome !== "started") {
+      throw new Error("expected run-bound attempt");
+    }
+    expect(
+      forceDenyOperatorApproval({
+        id: "plugin:approval-1",
+        status: "cancelled",
+        reason: "run-aborted",
+        resolver: { kind: "system", id: null },
+        expectedKind: "plugin",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_100,
+        databaseOptions,
+      }),
+    ).toMatchObject({ outcome: "denied", record: { status: "cancelled" } });
+
+    const completion = completeExternalVerificationAttempt({
+      attemptId: started.attempt.id,
+      pluginId: "agentkit",
+      outcome: "succeeded",
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_200,
+      databaseOptions,
+    });
+    expect(completion).toMatchObject({
+      outcome: "replay",
+      applied: false,
+      attempt: { outcome: "cancelled", terminalSource: "run-aborted" },
+    });
+    expect(completion).not.toHaveProperty("grantAuthorization");
+  });
+
+  it("fails closed without a run binding and reconciles active attempts on restart", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions, id: "plugin:no-run", runId: null });
+    expect(
+      startExternalVerificationAttempt({
+        approvalId: "plugin:no-run",
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_000,
+        databaseOptions,
+      }),
+    ).toEqual({ outcome: "run-unavailable" });
+
+    insertExternalApproval({ databaseOptions, id: "plugin:restart" });
+    const started = startExternalVerificationAttempt({
+      approvalId: "plugin:restart",
+      decision: "allow-once",
+      interactionId: "b".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    if (started.outcome !== "started") {
+      throw new Error("expected restart attempt");
+    }
+    expect(
+      closeOrphanedOperatorApprovals({
+        runtimeEpoch: "epoch-2",
+        nowMs: 2_100,
+        databaseOptions,
+      }),
+    ).toMatchObject({ affected: 2 });
+    expect(
+      completeExternalVerificationAttempt({
+        attemptId: started.attempt.id,
+        pluginId: "agentkit",
+        outcome: "succeeded",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_200,
+        databaseOptions,
+      }),
+    ).toMatchObject({
+      outcome: "replay",
+      applied: false,
+      attempt: { outcome: "cancelled", terminalSource: "gateway-restart" },
+    });
+    expect(
+      completeExternalVerificationAttempt({
+        attemptId: started.attempt.id,
+        pluginId: "agentkit",
+        outcome: "succeeded",
+        runtimeEpoch: "epoch-2",
+        nowMs: 2_300,
+        databaseOptions,
+      }),
+    ).toMatchObject({
+      outcome: "replay",
+      applied: false,
+      attempt: { outcome: "cancelled", terminalSource: "gateway-restart" },
+    });
+  });
+});

--- a/src/gateway/plugin-external-verification-store.ts
+++ b/src/gateway/plugin-external-verification-store.ts
@@ -1,0 +1,737 @@
+// Durable, proof-free attempt ledger and atomic external approval completion.
+import { createHash, randomUUID } from "node:crypto";
+import { sql, type Selectable } from "kysely";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import type {
+  PluginExternalVerificationAttemptSnapshot,
+  PluginExternalVerificationGrantAuthorization,
+} from "../plugins/external-verification-approval-types.js";
+import { ensurePluginExternalVerificationSchema } from "../state/openclaw-state-db-schema-additive.js";
+import type {
+  DB as OpenClawStateKyselyDatabase,
+  OperatorApprovals,
+  PluginExternalVerificationAttempts,
+} from "../state/openclaw-state-db.generated.js";
+import {
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabase,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import { isOperatorApprovalReviewerAuthorized } from "./operator-approval-authorization.js";
+
+type ExternalAttemptRow = Selectable<PluginExternalVerificationAttempts>;
+type OperatorApprovalRow = Selectable<OperatorApprovals>;
+type ExternalVerificationDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "operator_approvals" | "plugin_external_verification_attempts"
+>;
+
+type ExternalVerificationUnavailableOutcome =
+  | "approval-expired"
+  | "approval-not-found"
+  | "approval-not-pending"
+  | "decision-unavailable"
+  | "owner-unavailable"
+  | "reviewer-unauthorized"
+  | "run-unavailable";
+
+type NativeExternalVerificationAction = {
+  intent: "start" | "retry";
+  expectedAttemptId: string | null;
+};
+
+type StartExternalVerificationResult =
+  | {
+      outcome: "started" | "replay";
+      attempt: PluginExternalVerificationAttemptSnapshot;
+    }
+  | {
+      outcome: "stale-action";
+      attempt?: PluginExternalVerificationAttemptSnapshot;
+    }
+  | {
+      outcome: ExternalVerificationUnavailableOutcome;
+    };
+
+export type ExternalVerificationNativeActionState =
+  | {
+      outcome: "ready";
+      action: NativeExternalVerificationAction;
+    }
+  | {
+      outcome: ExternalVerificationUnavailableOutcome;
+    };
+
+type CompleteExternalVerificationStoreResult =
+  | {
+      outcome: "completed" | "replay";
+      applied: boolean;
+      approvalId: string;
+      attempt: PluginExternalVerificationAttemptSnapshot;
+      grantAuthorization?: PluginExternalVerificationGrantAuthorization;
+    }
+  | { outcome: "approval-expired"; approvalId: string }
+  | { outcome: "attempt-not-found" };
+
+export function getExternalVerificationAttemptSnapshot(params: {
+  attemptId: string;
+  pluginId: string;
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): PluginExternalVerificationAttemptSnapshot | null {
+  return runOpenClawStateWriteTransaction((database) => {
+    ensurePluginExternalVerificationSchema(database.db);
+    const attempt = selectAttempt(database, params.attemptId);
+    if (!attempt || attempt.plugin_id !== params.pluginId) {
+      return null;
+    }
+    return decodeAttempt(attempt);
+  }, params.databaseOptions);
+}
+
+type ExternalResolutionProjection = {
+  label: string;
+  decisions: Array<"allow-once" | "allow-always">;
+};
+
+function readExternalResolution(row: OperatorApprovalRow): ExternalResolutionProjection | null {
+  try {
+    const presentation: unknown = JSON.parse(row.presentation_json);
+    if (typeof presentation !== "object" || presentation === null || Array.isArray(presentation)) {
+      return null;
+    }
+    // SAFETY: isRecord(presentation) was checked by the caller guard above.
+    const record = presentation as Record<string, unknown>;
+    const external = record.externalResolution;
+    if (typeof external !== "object" || external === null || Array.isArray(external)) {
+      return null;
+    }
+    // SAFETY: isRecord(external) was checked immediately above.
+    const externalRecord = external as Record<string, unknown>;
+    const label = typeof externalRecord.label === "string" ? externalRecord.label.trim() : "";
+    const rawDecisions = externalRecord.decisions;
+    if (
+      !label ||
+      !Array.isArray(rawDecisions) ||
+      rawDecisions.length < 1 ||
+      rawDecisions.length > 2 ||
+      rawDecisions.some((decision) => decision !== "allow-once" && decision !== "allow-always")
+    ) {
+      return null;
+    }
+    return {
+      label,
+      // SAFETY: the filter above kept only allow-once/allow-always literals.
+      decisions: rawDecisions as Array<"allow-once" | "allow-always">,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readReviewerDeviceIds(row: OperatorApprovalRow): string[] | null {
+  try {
+    const value: unknown = JSON.parse(row.reviewer_device_ids_json);
+    return Array.isArray(value) && value.every((entry) => typeof entry === "string") ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function decodeAttempt(row: ExternalAttemptRow): PluginExternalVerificationAttemptSnapshot {
+  const decision = row.decision === "allow-always" ? "allow-always" : "allow-once";
+  const outcome =
+    row.outcome === "succeeded" ||
+    row.outcome === "failed" ||
+    row.outcome === "cancelled" ||
+    row.outcome === "timed-out"
+      ? row.outcome
+      : undefined;
+  return {
+    id: row.attempt_id,
+    context: {
+      approvalId: row.approval_id,
+      pluginId: row.plugin_id,
+      runId: row.run_id,
+      toolName: row.tool_name,
+      ...(row.tool_call_id ? { toolCallId: row.tool_call_id } : {}),
+      ...(row.agent_id ? { agentId: row.agent_id } : {}),
+      ...(row.session_key ? { sessionKey: row.session_key } : {}),
+      ...(row.session_id ? { sessionId: row.session_id } : {}),
+      decision,
+      label: row.label,
+      expiresAtMs: row.expires_at_ms,
+    },
+    createdAtMs: row.created_at_ms,
+    ...(row.ended_at_ms === null ? {} : { endedAtMs: row.ended_at_ms }),
+    ...(outcome ? { outcome } : {}),
+    ...(row.error_class ? { errorClass: row.error_class } : {}),
+    ...(row.terminal_source ? { terminalSource: row.terminal_source } : {}),
+  };
+}
+
+function decodeAttemptForDecision(
+  row: ExternalAttemptRow | undefined,
+  decision: "allow-once" | "allow-always",
+): PluginExternalVerificationAttemptSnapshot | undefined {
+  return row?.decision === decision ? decodeAttempt(row) : undefined;
+}
+
+function buildGrantAuthorization(
+  row: ExternalAttemptRow,
+): PluginExternalVerificationGrantAuthorization | undefined {
+  if (
+    row.outcome !== "succeeded" ||
+    row.decision !== "allow-always" ||
+    !row.grant_authorization_id ||
+    row.grant_issued_at_ms === null
+  ) {
+    return undefined;
+  }
+  return {
+    id: row.grant_authorization_id,
+    issuedAtMs: row.grant_issued_at_ms,
+    approvalId: row.approval_id,
+    attemptId: row.attempt_id,
+    decision: row.decision === "allow-always" ? "allow-always" : "allow-once",
+  };
+}
+
+function stableGrantAuthorizationId(attemptId: string): string {
+  return createHash("sha256").update(`external-verification:${attemptId}`).digest("base64url");
+}
+
+function bindInteractionIdToDecision(
+  interactionId: string,
+  decision: "allow-once" | "allow-always",
+): string {
+  return createHash("sha256")
+    .update(`external-verification-interaction:${interactionId}:${decision}`)
+    .digest("hex");
+}
+
+function selectAttempt(
+  database: OpenClawStateDatabase,
+  attemptId: string,
+): ExternalAttemptRow | undefined {
+  const stateDb = getNodeSqliteKysely<ExternalVerificationDatabase>(database.db);
+  return executeSqliteQueryTakeFirstSync(
+    database.db,
+    stateDb
+      .selectFrom("plugin_external_verification_attempts")
+      .selectAll()
+      .where("attempt_id", "=", attemptId),
+  );
+}
+
+function selectLatestAttempt(
+  database: OpenClawStateDatabase,
+  approvalId: string,
+): ExternalAttemptRow | undefined {
+  const stateDb = getNodeSqliteKysely<ExternalVerificationDatabase>(database.db);
+  return executeSqliteQueryTakeFirstSync(
+    database.db,
+    stateDb
+      .selectFrom("plugin_external_verification_attempts")
+      .selectAll()
+      .where("approval_id", "=", approvalId)
+      .orderBy(sql<number>`rowid`, "desc"),
+  );
+}
+
+function selectActiveAttempt(
+  database: OpenClawStateDatabase,
+  approvalId: string,
+): ExternalAttemptRow | undefined {
+  const stateDb = getNodeSqliteKysely<ExternalVerificationDatabase>(database.db);
+  return executeSqliteQueryTakeFirstSync(
+    database.db,
+    stateDb
+      .selectFrom("plugin_external_verification_attempts")
+      .selectAll()
+      .where("approval_id", "=", approvalId)
+      .where("ended_at_ms", "is", null),
+  );
+}
+
+function selectExternalApproval(params: {
+  database: OpenClawStateDatabase;
+  approvalId: string;
+  reviewerDeviceId?: string;
+  runtimeEpoch: string;
+}):
+  | { outcome: "ready"; approval: OperatorApprovalRow }
+  | { outcome: "approval-not-found" | "reviewer-unauthorized" } {
+  const stateDb = getNodeSqliteKysely<ExternalVerificationDatabase>(params.database.db);
+  const approval = executeSqliteQueryTakeFirstSync(
+    params.database.db,
+    stateDb
+      .selectFrom("operator_approvals")
+      .selectAll()
+      .where("approval_id", "=", params.approvalId),
+  );
+  if (!approval || approval.kind !== "plugin" || approval.runtime_epoch !== params.runtimeEpoch) {
+    return { outcome: "approval-not-found" };
+  }
+  const reviewerDeviceIds = readReviewerDeviceIds(approval);
+  if (
+    !reviewerDeviceIds ||
+    !isOperatorApprovalReviewerAuthorized({
+      reviewerDeviceId: params.reviewerDeviceId,
+      reviewerDeviceIds,
+    })
+  ) {
+    return { outcome: "reviewer-unauthorized" };
+  }
+  return { outcome: "ready", approval };
+}
+
+function validatePendingExternalApproval(params: {
+  database: OpenClawStateDatabase;
+  approval: OperatorApprovalRow;
+  decision: "allow-once" | "allow-always";
+  nowMs: number;
+}):
+  | {
+      outcome: "ready";
+      external: ExternalResolutionProjection;
+      pluginId: string;
+      runId: string;
+      toolName: string;
+    }
+  | { outcome: Exclude<ExternalVerificationUnavailableOutcome, "reviewer-unauthorized"> } {
+  const { approval } = params;
+  if (approval.status !== "pending") {
+    return { outcome: "approval-not-pending" };
+  }
+  if (approval.expires_at_ms <= params.nowMs) {
+    return { outcome: "approval-expired" };
+  }
+  const external = readExternalResolution(approval);
+  if (!external?.decisions.includes(params.decision)) {
+    return { outcome: "decision-unavailable" };
+  }
+  const pluginId = (() => {
+    try {
+      // SAFETY: presentation_json is host-written canonical presentation state.
+      const presentation = JSON.parse(approval.presentation_json) as {
+        pluginId?: unknown;
+      };
+      return typeof presentation.pluginId === "string" ? presentation.pluginId.trim() : "";
+    } catch {
+      return "";
+    }
+  })();
+  if (!pluginId) {
+    return { outcome: "owner-unavailable" };
+  }
+  const runId = approval.source_run_id?.trim() ?? "";
+  if (!runId) {
+    return { outcome: "run-unavailable" };
+  }
+  const toolName = approval.source_tool_name?.trim() ?? "";
+  if (!toolName) {
+    return { outcome: "approval-not-found" };
+  }
+  return { outcome: "ready", external, pluginId, runId, toolName };
+}
+
+/** Read the exact attempt generation a native approval action must bind. */
+export function getExternalVerificationNativeActionState(params: {
+  approvalId: string;
+  decision: "allow-once" | "allow-always";
+  reviewerDeviceId?: string;
+  runtimeEpoch: string;
+  nowMs?: number;
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): ExternalVerificationNativeActionState {
+  return runOpenClawStateWriteTransaction((database) => {
+    ensurePluginExternalVerificationSchema(database.db);
+    const selected = selectExternalApproval({ database, ...params });
+    if (selected.outcome !== "ready") {
+      return selected;
+    }
+    const validated = validatePendingExternalApproval({
+      database,
+      approval: selected.approval,
+      decision: params.decision,
+      nowMs: params.nowMs ?? Date.now(),
+    });
+    if (validated.outcome !== "ready") {
+      return validated;
+    }
+    const active = selectActiveAttempt(database, selected.approval.approval_id);
+    if (active) {
+      return {
+        outcome: "ready",
+        action: { intent: "retry", expectedAttemptId: active.attempt_id },
+      };
+    }
+    return {
+      outcome: "ready",
+      action: {
+        intent: "start",
+        expectedAttemptId:
+          selectLatestAttempt(database, selected.approval.approval_id)?.attempt_id ?? null,
+      },
+    };
+  }, params.databaseOptions);
+}
+
+/** Start or replay one reviewer interaction, replacing only an active prior attempt. */
+export function startExternalVerificationAttempt(params: {
+  approvalId: string;
+  decision: "allow-once" | "allow-always";
+  interactionId: string;
+  reviewerDeviceId?: string;
+  nativeAction?: NativeExternalVerificationAction;
+  runtimeEpoch: string;
+  nowMs?: number;
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): StartExternalVerificationResult {
+  return runOpenClawStateWriteTransaction((database) => {
+    ensurePluginExternalVerificationSchema(database.db);
+    const nowMs = params.nowMs ?? Date.now();
+    // Decision is part of the idempotency key: each authenticated interaction/decision
+    // pair starts once, so stale redelivery cannot revive superseded reviewer intent.
+    const interactionId = bindInteractionIdToDecision(params.interactionId, params.decision);
+    const selected = selectExternalApproval({ database, ...params });
+    if (selected.outcome !== "ready") {
+      return selected;
+    }
+    const approval = selected.approval;
+    const stateDb = getNodeSqliteKysely<ExternalVerificationDatabase>(database.db);
+    // The manager owns terminal lifecycle publication and in-memory cancellation.
+    // Report due state before replay so the runtime can expire through that owner.
+    if (approval.status === "pending" && approval.expires_at_ms <= nowMs) {
+      return { outcome: "approval-expired" };
+    }
+    const replay = executeSqliteQueryTakeFirstSync(
+      database.db,
+      stateDb
+        .selectFrom("plugin_external_verification_attempts")
+        .selectAll()
+        .where("approval_id", "=", approval.approval_id)
+        .where("interaction_id", "=", interactionId),
+    );
+    if (replay) {
+      if (params.nativeAction) {
+        const latest = selectLatestAttempt(database, approval.approval_id);
+        if (latest?.attempt_id !== replay.attempt_id) {
+          const attempt = decodeAttemptForDecision(latest, params.decision);
+          return {
+            outcome: "stale-action",
+            ...(attempt ? { attempt } : {}),
+          };
+        }
+      }
+      return { outcome: "replay", attempt: decodeAttempt(replay) };
+    }
+    const validated = validatePendingExternalApproval({
+      database,
+      approval,
+      decision: params.decision,
+      nowMs,
+    });
+    if (validated.outcome !== "ready") {
+      return validated;
+    }
+    if (params.nativeAction) {
+      const active = selectActiveAttempt(database, approval.approval_id);
+      const latest = selectLatestAttempt(database, approval.approval_id);
+      const actionMatches =
+        params.nativeAction.intent === "retry"
+          ? Boolean(
+              active &&
+              latest?.attempt_id === active.attempt_id &&
+              active.attempt_id === params.nativeAction.expectedAttemptId,
+            )
+          : !active && (latest?.attempt_id ?? null) === params.nativeAction.expectedAttemptId;
+      if (!actionMatches) {
+        const attempt = decodeAttemptForDecision(latest, params.decision);
+        return {
+          outcome: "stale-action",
+          ...(attempt ? { attempt } : {}),
+        };
+      }
+    }
+    executeSqliteQuerySync(
+      database.db,
+      stateDb
+        .updateTable("plugin_external_verification_attempts")
+        .set({
+          ended_at_ms: nowMs,
+          outcome: "cancelled",
+          terminal_source: "reviewer-retry",
+          completion_applied: 0,
+        })
+        .where("approval_id", "=", approval.approval_id)
+        .where("ended_at_ms", "is", null),
+    );
+    const attemptId = `external:${randomUUID()}`;
+    executeSqliteQuerySync(
+      database.db,
+      stateDb.insertInto("plugin_external_verification_attempts").values({
+        attempt_id: attemptId,
+        approval_id: approval.approval_id,
+        plugin_id: validated.pluginId,
+        run_id: validated.runId,
+        tool_name: validated.toolName,
+        tool_call_id: approval.source_tool_call_id,
+        agent_id: approval.source_agent_id,
+        session_key: approval.source_session_key,
+        session_id: approval.source_session_id,
+        interaction_id: interactionId,
+        decision: params.decision,
+        label: validated.external.label,
+        created_at_ms: nowMs,
+        expires_at_ms: approval.expires_at_ms,
+        ended_at_ms: null,
+        outcome: null,
+        error_class: null,
+        terminal_source: null,
+        completion_applied: null,
+        grant_authorization_id: null,
+        grant_issued_at_ms: null,
+        resolver_plugin_id: null,
+        runtime_epoch: params.runtimeEpoch,
+      }),
+    );
+    const attempt = selectAttempt(database, attemptId);
+    if (!attempt) {
+      throw new Error("external verification attempt was not readable after insert");
+    }
+    return { outcome: "started", attempt: decodeAttempt(attempt) };
+  }, params.databaseOptions);
+}
+
+function endExternalVerificationAttempt(params: {
+  attemptId: string;
+  pluginId: string;
+  outcome: "failed" | "cancelled";
+  errorClass?: string;
+  terminalSource: "verifier-error" | "verifier-retired";
+  nowMs?: number;
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): void {
+  runOpenClawStateWriteTransaction((database) => {
+    ensurePluginExternalVerificationSchema(database.db);
+    const stateDb = getNodeSqliteKysely<ExternalVerificationDatabase>(database.db);
+    executeSqliteQuerySync(
+      database.db,
+      stateDb
+        .updateTable("plugin_external_verification_attempts")
+        .set({
+          ended_at_ms: params.nowMs ?? Date.now(),
+          outcome: params.outcome,
+          error_class: params.errorClass ?? null,
+          terminal_source: params.terminalSource,
+          completion_applied: 0,
+        })
+        .where("attempt_id", "=", params.attemptId)
+        .where("plugin_id", "=", params.pluginId)
+        .where("ended_at_ms", "is", null),
+    );
+  }, params.databaseOptions);
+}
+
+/** Mark a verifier dispatch failure without resolving the owning approval. */
+export function failExternalVerificationAttempt(params: {
+  attemptId: string;
+  pluginId: string;
+  errorClass: string;
+  nowMs?: number;
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): void {
+  endExternalVerificationAttempt({
+    ...params,
+    outcome: "failed",
+    terminalSource: "verifier-error",
+  });
+}
+
+/** Cancel an attempt whose owning verifier instance is no longer live. */
+export function cancelRetiredExternalVerificationAttempt(params: {
+  attemptId: string;
+  pluginId: string;
+  nowMs?: number;
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): void {
+  endExternalVerificationAttempt({
+    ...params,
+    outcome: "cancelled",
+    terminalSource: "verifier-retired",
+  });
+}
+
+/** Complete an attempt and atomically authorize the canonical approval on success. */
+export function completeExternalVerificationAttempt(params: {
+  attemptId: string;
+  pluginId: string;
+  outcome: "succeeded" | "failed";
+  runtimeEpoch: string;
+  nowMs?: number;
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): CompleteExternalVerificationStoreResult {
+  return runOpenClawStateWriteTransaction((database) => {
+    ensurePluginExternalVerificationSchema(database.db);
+    const nowMs = params.nowMs ?? Date.now();
+    const stateDb = getNodeSqliteKysely<ExternalVerificationDatabase>(database.db);
+    let attempt = selectAttempt(database, params.attemptId);
+    if (!attempt || attempt.plugin_id !== params.pluginId) {
+      return { outcome: "attempt-not-found" };
+    }
+    if (attempt.ended_at_ms !== null) {
+      return {
+        outcome: "replay",
+        applied: false,
+        approvalId: attempt.approval_id,
+        attempt: decodeAttempt(attempt),
+        ...(buildGrantAuthorization(attempt)
+          ? { grantAuthorization: buildGrantAuthorization(attempt) }
+          : {}),
+      };
+    }
+    if (attempt.runtime_epoch !== params.runtimeEpoch) {
+      return { outcome: "attempt-not-found" };
+    }
+    if (params.outcome === "failed") {
+      executeSqliteQuerySync(
+        database.db,
+        stateDb
+          .updateTable("plugin_external_verification_attempts")
+          .set({
+            ended_at_ms: nowMs,
+            outcome: "failed",
+            terminal_source: "plugin-completion",
+            completion_applied: 0,
+          })
+          .where("attempt_id", "=", params.attemptId)
+          .where("ended_at_ms", "is", null),
+      );
+      attempt = selectAttempt(database, params.attemptId)!;
+      return {
+        outcome: "completed",
+        applied: false,
+        approvalId: attempt.approval_id,
+        attempt: decodeAttempt(attempt),
+      };
+    }
+    const approval = executeSqliteQueryTakeFirstSync(
+      database.db,
+      stateDb
+        .selectFrom("operator_approvals")
+        .selectAll()
+        .where("approval_id", "=", attempt.approval_id),
+    );
+    const matchesApproval =
+      approval?.kind === "plugin" &&
+      approval.runtime_epoch === params.runtimeEpoch &&
+      approval.status === "pending" &&
+      approval.source_run_id === attempt.run_id;
+    if (matchesApproval && approval.expires_at_ms <= nowMs) {
+      return { outcome: "approval-expired", approvalId: attempt.approval_id };
+    }
+    if (!matchesApproval) {
+      executeSqliteQuerySync(
+        database.db,
+        stateDb
+          .updateTable("plugin_external_verification_attempts")
+          .set({
+            ended_at_ms: nowMs,
+            outcome: "cancelled",
+            terminal_source: "approval-unavailable",
+            completion_applied: 0,
+          })
+          .where("attempt_id", "=", params.attemptId)
+          .where("ended_at_ms", "is", null),
+      );
+      attempt = selectAttempt(database, params.attemptId)!;
+      return {
+        outcome: "completed",
+        applied: false,
+        approvalId: attempt.approval_id,
+        attempt: decodeAttempt(attempt),
+      };
+    }
+    const external = readExternalResolution(approval);
+    if (
+      approval.presentation_json.length === 0 ||
+      !external?.decisions.includes(
+        attempt.decision === "allow-always" ? "allow-always" : "allow-once",
+      )
+    ) {
+      executeSqliteQuerySync(
+        database.db,
+        stateDb
+          .updateTable("plugin_external_verification_attempts")
+          .set({
+            ended_at_ms: nowMs,
+            outcome: "cancelled",
+            terminal_source: "decision-unavailable",
+            completion_applied: 0,
+          })
+          .where("attempt_id", "=", params.attemptId)
+          .where("ended_at_ms", "is", null),
+      );
+      attempt = selectAttempt(database, params.attemptId)!;
+      return {
+        outcome: "completed",
+        applied: false,
+        approvalId: attempt.approval_id,
+        attempt: decodeAttempt(attempt),
+      };
+    }
+    const reusable = attempt.decision === "allow-always";
+    const grantAuthorizationId = reusable ? stableGrantAuthorizationId(attempt.attempt_id) : null;
+    executeSqliteQuerySync(
+      database.db,
+      stateDb
+        .updateTable("plugin_external_verification_attempts")
+        .set({
+          ended_at_ms: nowMs,
+          outcome: "succeeded",
+          terminal_source: "plugin-completion",
+          completion_applied: 1,
+          grant_authorization_id: grantAuthorizationId,
+          grant_issued_at_ms: reusable ? nowMs : null,
+          resolver_plugin_id: params.pluginId,
+        })
+        .where("attempt_id", "=", params.attemptId)
+        .where("ended_at_ms", "is", null),
+    );
+    const approvalUpdate = executeSqliteQuerySync(
+      database.db,
+      stateDb
+        .updateTable("operator_approvals")
+        .set({
+          status: "allowed",
+          decision: attempt.decision,
+          terminal_reason: "user",
+          resolved_at_ms: nowMs,
+          resolver_kind: "runtime",
+          resolver_id: `plugin:${params.pluginId}`,
+          updated_at_ms: nowMs,
+        })
+        .where("approval_id", "=", attempt.approval_id)
+        .where("status", "=", "pending")
+        .where("runtime_epoch", "=", params.runtimeEpoch)
+        .where("expires_at_ms", ">", nowMs),
+    );
+    if (approvalUpdate.numAffectedRows !== 1n) {
+      throw new Error("external verification lost approval authorization after validation");
+    }
+    attempt = selectAttempt(database, params.attemptId)!;
+    const grantAuthorization = buildGrantAuthorization(attempt);
+    return {
+      outcome: "completed",
+      applied: true,
+      approvalId: attempt.approval_id,
+      attempt: decodeAttempt(attempt),
+      ...(grantAuthorization ? { grantAuthorization } : {}),
+    };
+  }, params.databaseOptions);
+}

--- a/src/plugins/external-verification-approval-types.ts
+++ b/src/plugins/external-verification-approval-types.ts
@@ -1,0 +1,87 @@
+import type {
+  ApprovalAllowDecision,
+  ApprovalSnapshot,
+} from "../../packages/gateway-protocol/src/index.js";
+import type { PluginStateEntry } from "../plugin-state/plugin-state-store.types.js";
+
+/** Plugin-owned reviewer choices that require an external verification ceremony. */
+export type PluginExternalResolution = {
+  label: string;
+  decisions?: readonly ApprovalAllowDecision[];
+};
+
+/** Host-derived approval context that verifier challenges must bind. */
+export type PluginExternalVerificationContext = Readonly<{
+  approvalId: string;
+  pluginId: string;
+  runId: string;
+  toolName: string;
+  toolCallId?: string;
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  decision: ApprovalAllowDecision;
+  label: string;
+  expiresAtMs: number;
+}>;
+
+/** Immutable context for one host-authenticated external verification attempt. */
+export type PluginExternalVerificationAttempt = Readonly<{
+  id: string;
+  context: PluginExternalVerificationContext;
+  createdAtMs: number;
+  signal: AbortSignal;
+  present: (params: { message: string }) => Promise<void>;
+}>;
+
+/** Persisted, proof-free attempt projection returned by completion calls. */
+export type PluginExternalVerificationAttemptSnapshot = Omit<
+  PluginExternalVerificationAttempt,
+  "present" | "signal"
+> & {
+  endedAtMs?: number;
+  outcome?: "succeeded" | "failed" | "cancelled" | "timed-out";
+  errorClass?: string;
+  terminalSource?: string;
+};
+
+/** Stable host authorization emitted only when external verification wins the approval race. */
+export type PluginExternalVerificationGrantAuthorization = {
+  id: string;
+  issuedAtMs: number;
+  approvalId: string;
+  attemptId: string;
+  decision: ApprovalAllowDecision;
+};
+
+/** Idempotent completion result derived entirely from host-owned attempt state. */
+export type PluginExternalVerificationCompletionResult = {
+  applied: boolean;
+  approval: ApprovalSnapshot;
+  attempt: PluginExternalVerificationAttemptSnapshot;
+  grantAuthorization?: PluginExternalVerificationGrantAuthorization;
+};
+
+export type PluginExternalVerificationHandler = (
+  attempt: PluginExternalVerificationAttempt,
+) => Promise<void> | void;
+
+/** Durable grant storage that preserves prior authorizations and tombstones. */
+export type PluginExternalVerificationGrantStore<T> = {
+  registerIfAbsent: (key: string, value: T) => boolean;
+  lookup: (key: string) => T | undefined;
+  entries: () => PluginStateEntry<T>[];
+  update: (key: string, updateValue: (current: T | undefined) => T | undefined) => boolean;
+};
+
+export type OpenClawPluginApprovalsApi = {
+  /** Register this plugin's single verifier for host-authenticated approval attempts. */
+  onExternalVerification: (handler: PluginExternalVerificationHandler) => void;
+  /** Complete an attempt owned by this plugin; plugin and approval identity are host-derived. */
+  completeExternalVerification: (params: {
+    attemptId: string;
+    outcome: "succeeded" | "failed";
+  }) => Promise<PluginExternalVerificationCompletionResult>;
+  /** Open bounded plugin-owned storage for stable grant authorizations and tombstones. */
+  openGrantStore: <T>() => PluginExternalVerificationGrantStore<T>;
+};

--- a/src/state/openclaw-state-db-contract.ts
+++ b/src/state/openclaw-state-db-contract.ts
@@ -57,6 +57,7 @@ export const LAZY_ADDITIVE_STATE_TABLES = [
   ...FIRST_USE_STATE_TABLES,
   "agent_provenance",
   "cron_run_receipts",
+  "plugin_external_verification_attempts",
   "config_revision_keys",
   "secret_store_entries",
   "projects",
@@ -71,8 +72,19 @@ export const LAZY_ADDITIVE_STATE_TABLES = [
   "worker_environment_ssh_fallback_ports",
   "worker_session_placement_moves",
 ] as const;
+// Triggers that reference a lazy table must leave the projected runtime
+// schema with it: SQLite validates trigger bodies at fire time, so a dangling
+// trigger breaks the first ordinary write that fires it on an upgraded
+// database. The owning first-use ensure installs table, indexes, and trigger
+// together.
+export const LAZY_ADDITIVE_STATE_TRIGGERS = [
+  "trg_operator_approval_closes_external_verification",
+] as const;
 export const LAZY_ADDITIVE_STATE_INDEXES = [
   ...FIRST_USE_STATE_INDEXES,
+  "idx_plugin_external_verification_active_approval",
+  "idx_plugin_external_verification_run_active",
+  "idx_plugin_external_verification_approval_created",
   "idx_cron_run_receipts_active_job",
   "idx_cron_run_receipts_job_history",
   "idx_github_publication_requests_pending",

--- a/src/state/openclaw-state-db-schema-additive.ts
+++ b/src/state/openclaw-state-db-schema-additive.ts
@@ -79,6 +79,33 @@ export function ensureDevicePairingJoinCodeSchema(database: DatabaseSync): void 
   ); // sqlite-allow-raw -- Canonical additive DDL only.
 }
 
+const PLUGIN_EXTERNAL_VERIFICATION_SCHEMA_START =
+  "CREATE TABLE IF NOT EXISTS plugin_external_verification_attempts (";
+const PLUGIN_EXTERNAL_VERIFICATION_SCHEMA_END =
+  "WHERE approval_id = NEW.approval_id AND ended_at_ms IS NULL;\nEND;";
+
+/**
+ * Lazily install the additive external verification attempt ledger (table,
+ * indexes, and the operator-approval closing trigger) on first feature use.
+ * Registered in LAZY_ADDITIVE_STATE_TABLES so pre-feature databases stay valid.
+ */
+export function ensurePluginExternalVerificationSchema(database: DatabaseSync): void {
+  const start = OPENCLAW_STATE_SCHEMA_SQL.indexOf(PLUGIN_EXTERNAL_VERIFICATION_SCHEMA_START);
+  const endMarkerStart = OPENCLAW_STATE_SCHEMA_SQL.indexOf(
+    PLUGIN_EXTERNAL_VERIFICATION_SCHEMA_END,
+    start,
+  );
+  if (start < 0 || endMarkerStart < start) {
+    throw new Error("OpenClaw plugin external verification schema marker is missing.");
+  }
+  database.exec(
+    OPENCLAW_STATE_SCHEMA_SQL.slice(
+      start,
+      endMarkerStart + PLUGIN_EXTERNAL_VERIFICATION_SCHEMA_END.length,
+    ),
+  ); // sqlite-allow-raw -- Canonical additive DDL only.
+}
+
 /** Lazily installs the Gateway's installation-local config revision key owner. */
 export function ensureConfigRevisionKeySchema(database: DatabaseSync): void {
   const start = OPENCLAW_STATE_SCHEMA_SQL.indexOf(CONFIG_REVISION_KEY_SCHEMA_START);

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -1041,6 +1041,32 @@ export interface PluginBlobEntries {
   plugin_id: string;
 }
 
+export interface PluginExternalVerificationAttempts {
+  agent_id: string | null;
+  approval_id: string;
+  attempt_id: string;
+  completion_applied: number | null;
+  created_at_ms: number;
+  decision: string;
+  ended_at_ms: number | null;
+  error_class: string | null;
+  expires_at_ms: number;
+  grant_authorization_id: string | null;
+  grant_issued_at_ms: number | null;
+  interaction_id: string;
+  label: string;
+  outcome: string | null;
+  plugin_id: string;
+  resolver_plugin_id: string | null;
+  run_id: string;
+  runtime_epoch: string;
+  session_id: string | null;
+  session_key: string | null;
+  terminal_source: string | null;
+  tool_call_id: string | null;
+  tool_name: string;
+}
+
 export interface PluginStateEntries {
   created_at: number;
   entry_key: string;
@@ -1674,6 +1700,7 @@ export interface DB {
   outbound_message_progress: OutboundMessageProgress;
   plugin_binding_approvals: PluginBindingApprovals;
   plugin_blob_entries: PluginBlobEntries;
+  plugin_external_verification_attempts: PluginExternalVerificationAttempts;
   plugin_state_entries: PluginStateEntries;
   projects: Projects;
   sandbox_registry_entries: SandboxRegistryEntries;

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -63,7 +63,10 @@ import {
   withOpenClawStateStartupMigrationCheckpointDatabase,
 } from "./openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
-import { getOpenClawStateRuntimeSchema } from "./openclaw-state-schema-compatibility.js";
+import {
+  getOpenClawStateRuntimeSchema,
+  OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
+} from "./openclaw-state-schema-compatibility.js";
 import { STATE_SCHEMA_10_TO_9_DOWNGRADE_SQL } from "./openclaw-state-schema-v10-retirement.test-support.js";
 import { STATE_SCHEMA_11_TO_10_TABLES_SQL } from "./openclaw-state-schema-v11-retirement.test-support.js";
 import { STATE_SCHEMA_12_TO_11_DOWNGRADE_SQL } from "./openclaw-state-schema-v12-foldin.test-support.js";
@@ -149,6 +152,13 @@ function markStateDatabaseAsPreviousAppVersion(database: DatabaseSync): void {
   database
     .prepare("UPDATE schema_meta SET app_version = ? WHERE meta_key = 'primary'")
     .run("2026.7.0");
+}
+
+function markStateDatabaseAsV5(database: DatabaseSync): void {
+  database.exec(`
+    PRAGMA user_version = 5;
+    UPDATE schema_meta SET schema_version = 5 WHERE meta_key = 'primary';
+  `);
 }
 
 function createInitialStateSchemaShape() {
@@ -4742,6 +4752,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         currentSchema.db,
         "previous v9 reader",
         getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: false }),
+        OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
       ),
     ).not.toThrow();
     closeOpenClawStateDatabaseForTest();
@@ -6209,28 +6220,40 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         )
         .get() as { sql: string }
     ).sql;
+    // This fixture models the shipped two-kind schema, which predates external
+    // verification attempts and their operator-approval trigger.
+    legacyDb.exec(`
+      DROP TRIGGER trg_operator_approval_closes_external_verification;
+      DROP TABLE plugin_external_verification_attempts;
+    `);
     legacyDb.exec("ALTER TABLE operator_approvals RENAME TO operator_approvals_current");
     legacyDb.exec(currentSql.replace("'exec', 'plugin', 'system-agent'", "'exec', 'plugin'"));
     legacyDb.exec("DROP TABLE operator_approvals_current");
+    markStateDatabaseAsV5(legacyDb);
     legacyDb.close();
 
     expect(detectOpenClawStateDatabaseSchemaMigrations(options)).toContainEqual({
       kind: "operator-approvals-system-agent",
       path: databasePath,
     });
-    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
-      changes: [
-        "Migrated shared state operator approvals → OpenClaw system changes",
-        expect.stringMatching(/^Rebuilt canonical shared-state SQLite indexes \(\d+\)$/u),
-      ],
-      warnings: [],
-    });
+    const repaired = repairOpenClawStateDatabaseSchema(options);
+    expect(repaired.warnings).toEqual([]);
+    expect(repaired.changes).toContain(
+      "Migrated shared state operator approvals → OpenClaw system changes",
+    );
 
     const reopened = openOpenClawStateDatabase(options);
     const migratedSql = reopened.db
       .prepare("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 'operator_approvals'")
       .get() as { sql: string };
     expect(migratedSql.sql).toContain("'system-agent'");
+    expect(
+      reopened.db
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'plugin_external_verification_attempts'",
+        )
+        .get(),
+    ).toEqual({ name: "plugin_external_verification_attempts" });
   });
 
   it("does not recursively recommend doctor when operator approval repair refuses a shape", () => {

--- a/src/state/openclaw-state-schema-compatibility.test.ts
+++ b/src/state/openclaw-state-schema-compatibility.test.ts
@@ -2,6 +2,35 @@ import { describe, expect, it } from "vitest";
 import { getOpenClawStateRuntimeSchema } from "./openclaw-state-schema-compatibility.js";
 
 describe("OpenClaw state runtime schema projection", () => {
+  it("lets a previous reader accept a database carrying the lazy attempts trigger", async () => {
+    const { DatabaseSync } = await import("node:sqlite");
+    const { assertSqliteSchemaContains } = await import("../infra/sqlite-schema-contract.js");
+    const { OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY } =
+      await import("./openclaw-state-schema-compatibility.js");
+    const db = new DatabaseSync(":memory:");
+    // A current database that has installed the external-verification feature:
+    // the attempts table plus the close trigger on the core approvals table.
+    db.exec(getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: true }));
+    expect(
+      db
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'trigger' AND name = 'trg_operator_approval_closes_external_verification'",
+        )
+        .get(),
+    ).toEqual({ name: "trg_operator_approval_closes_external_verification" });
+    // A previous reader (predating the feature: attempts table projected out)
+    // must accept the trigger's presence rather than reject it as noncanonical.
+    expect(() =>
+      assertSqliteSchemaContains(
+        db,
+        "previous reader",
+        getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: false }),
+        OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
+      ),
+    ).not.toThrow();
+    db.close();
+  });
+
   it("omits lazy additive tables and their unique indexes before first use", () => {
     const schema = getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: false });
 
@@ -17,5 +46,45 @@ describe("OpenClaw state runtime schema projection", () => {
     expect(schema).not.toContain("CREATE TABLE IF NOT EXISTS github_publication_requests");
     expect(schema).not.toContain("idx_github_publication_requests_pending");
     expect(schema).not.toContain("CREATE TABLE IF NOT EXISTS config_revision_keys");
+    // The trigger references the lazy attempts table in its body; SQLite only
+    // validates that at fire time, so a projected schema keeping the trigger
+    // would break the first ordinary approval resolution on an upgraded
+    // database that has never used external verification.
+    expect(schema).not.toContain("plugin_external_verification_attempts");
+    expect(schema).not.toContain("trg_operator_approval_closes_external_verification");
+  });
+
+  it("keeps the attempts ledger trigger with its table when lazy tables are included", () => {
+    const schema = getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: true });
+    expect(schema).toContain("CREATE TABLE IF NOT EXISTS plugin_external_verification_attempts");
+    expect(schema).toContain(
+      "CREATE TRIGGER IF NOT EXISTS trg_operator_approval_closes_external_verification",
+    );
+  });
+
+  it("resolves an ordinary approval on a database opened without the lazy ledger", async () => {
+    const { DatabaseSync } = await import("node:sqlite");
+    const db = new DatabaseSync(":memory:");
+    db.exec(getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: false }));
+    db.exec(`
+      INSERT INTO operator_approvals (
+        approval_id, resolution_ref, kind, status, presentation_json,
+        reviewer_device_ids_json, audience_session_keys_json, runtime_epoch,
+        created_at_ms, expires_at_ms, updated_at_ms
+      ) VALUES (
+        'plugin:upgrade-probe', '${"A".repeat(43)}', 'plugin', 'pending', '{}',
+        '[]', '[]', 'epoch-1',
+        1, 10000, 1
+      );
+    `);
+    // Fires any terminal-transition trigger left in the projected schema.
+    db.exec(
+      "UPDATE operator_approvals SET status = 'denied', decision = 'deny', terminal_reason = 'user', resolver_kind = 'runtime', resolved_at_ms = 2, updated_at_ms = 2 WHERE approval_id = 'plugin:upgrade-probe';",
+    );
+    const row = db
+      .prepare("SELECT status FROM operator_approvals WHERE approval_id = 'plugin:upgrade-probe'")
+      .get() as { status: string };
+    expect(row.status).toBe("denied");
+    db.close();
   });
 });

--- a/src/state/openclaw-state-schema-compatibility.ts
+++ b/src/state/openclaw-state-schema-compatibility.ts
@@ -13,6 +13,7 @@ import {
   FIRST_USE_STATE_TABLES,
   LAZY_ADDITIVE_STATE_INDEXES,
   LAZY_ADDITIVE_STATE_TABLES,
+  LAZY_ADDITIVE_STATE_TRIGGERS,
 } from "./openclaw-state-db-contract.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
 
@@ -70,6 +71,18 @@ export function getOpenClawStateRuntimeSchema(options: {
     }
     schema = `${schema.slice(0, start)}${schema.slice(end + endMarker.length)}`;
   }
+  const omittedTriggers = options.includeVersionLazyAdditiveTables
+    ? []
+    : LAZY_ADDITIVE_STATE_TRIGGERS;
+  for (const triggerName of omittedTriggers) {
+    const start = schema.indexOf(`CREATE TRIGGER IF NOT EXISTS ${triggerName}`);
+    const endMarker = "\nEND;";
+    const end = start >= 0 ? schema.indexOf(endMarker, start) : -1;
+    if (start < 0 || end < 0) {
+      throw new Error(`lazy additive state schema trigger is missing for ${triggerName}`);
+    }
+    schema = `${schema.slice(0, start)}${schema.slice(end + endMarker.length)}`;
+  }
   for (const indexName of omittedIndexes) {
     const plainStart = schema.indexOf(`CREATE INDEX IF NOT EXISTS ${indexName}`);
     const uniqueStart = schema.indexOf(`CREATE UNIQUE INDEX IF NOT EXISTS ${indexName}`);
@@ -109,11 +122,46 @@ export const STATE_PERSISTENT_SCHEMA_COMPATIBILITY: SqliteSchemaCompatibility = 
   },
 };
 
+/**
+ * The external-verification close trigger lives on the core operator_approvals
+ * table but belongs to the lazy plugin_external_verification_attempts feature.
+ * A previous reader that predates the feature (attempts table absent) sees the
+ * trigger as unexpected; a current reader (table present) requires it. Register
+ * it as an optional canonical trigger group keyed to the lazy table so both
+ * readers validate. The SQL is derived from the canonical schema and normalized
+ * to SQLite's stored form (no IF NOT EXISTS, no trailing semicolon) so it
+ * cannot drift from the shipped trigger.
+ */
+const EXTERNAL_VERIFICATION_CLOSE_TRIGGER_NAME =
+  "trg_operator_approval_closes_external_verification";
+
+function canonicalExternalVerificationCloseTrigger(): { name: string; sql: string } {
+  const start = OPENCLAW_STATE_SCHEMA_SQL.indexOf(
+    `CREATE TRIGGER IF NOT EXISTS ${EXTERNAL_VERIFICATION_CLOSE_TRIGGER_NAME}`,
+  );
+  const endMarker = "\nEND;";
+  const end = start >= 0 ? OPENCLAW_STATE_SCHEMA_SQL.indexOf(endMarker, start) : -1;
+  if (start < 0 || end < 0) {
+    throw new Error("external verification close trigger is missing from the canonical schema");
+  }
+  const stored = OPENCLAW_STATE_SCHEMA_SQL.slice(start, end + endMarker.length)
+    .replace("CREATE TRIGGER IF NOT EXISTS ", "CREATE TRIGGER ")
+    .replace(/;$/u, "");
+  return { name: EXTERNAL_VERIFICATION_CLOSE_TRIGGER_NAME, sql: stored };
+}
+
+const EXTERNAL_VERIFICATION_OPTIONAL_TRIGGER_GROUP = {
+  tableName: "operator_approvals",
+  optionalWhenTableMissing: "plugin_external_verification_attempts",
+  triggers: [canonicalExternalVerificationCloseTrigger()],
+} as const;
+
 export const OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY: SqliteSchemaCompatibility = {
   ...STATE_PERSISTENT_SCHEMA_COMPATIBILITY,
   allowedMissingTables: [...LAZY_ADDITIVE_STATE_TABLES, ...CLAW_STARTUP_ADDITIVE_STATE_TABLES],
   allowedMissingIndexes: CLAW_READONLY_OPTIONAL_STATE_INDEXES,
   allowedMissingColumns: CLAW_LAZY_ADDITIVE_STATE_COLUMNS,
+  optionalCanonicalTriggerGroups: [EXTERNAL_VERIFICATION_OPTIONAL_TRIGGER_GROUP],
 };
 
 /** Identify schema differences that the writable shared-state cold open repairs. */

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -540,6 +540,101 @@ CREATE INDEX IF NOT EXISTS idx_operator_approvals_runtime_pending
   ON operator_approvals(runtime_epoch, approval_id)
   WHERE status = 'pending';
 
+-- External verifier attempts are append-only, proof-free audit records. The
+-- canonical approval row remains the authorization source of truth.
+CREATE TABLE IF NOT EXISTS plugin_external_verification_attempts (
+  attempt_id TEXT NOT NULL PRIMARY KEY CHECK (length(attempt_id) > 0),
+  approval_id TEXT NOT NULL,
+  plugin_id TEXT NOT NULL CHECK (length(plugin_id) > 0),
+  run_id TEXT NOT NULL CHECK (length(run_id) > 0),
+  tool_name TEXT NOT NULL CHECK (length(tool_name) > 0),
+  tool_call_id TEXT,
+  agent_id TEXT,
+  session_key TEXT,
+  session_id TEXT,
+  interaction_id TEXT NOT NULL CHECK (length(interaction_id) = 64),
+  decision TEXT NOT NULL CHECK (decision IN ('allow-once', 'allow-always')),
+  label TEXT NOT NULL CHECK (length(label) BETWEEN 1 AND 80),
+  created_at_ms INTEGER NOT NULL,
+  expires_at_ms INTEGER NOT NULL,
+  ended_at_ms INTEGER,
+  outcome TEXT CHECK (outcome IN ('succeeded', 'failed', 'cancelled', 'timed-out')),
+  error_class TEXT CHECK (error_class IS NULL OR length(error_class) BETWEEN 1 AND 64),
+  terminal_source TEXT,
+  completion_applied INTEGER CHECK (completion_applied IN (0, 1)),
+  grant_authorization_id TEXT,
+  grant_issued_at_ms INTEGER,
+  resolver_plugin_id TEXT,
+  runtime_epoch TEXT NOT NULL,
+  FOREIGN KEY (approval_id) REFERENCES operator_approvals(approval_id) ON DELETE CASCADE,
+  UNIQUE (approval_id, interaction_id),
+  CHECK (expires_at_ms >= created_at_ms),
+  CHECK (
+    (
+      ended_at_ms IS NULL
+      AND outcome IS NULL
+      AND error_class IS NULL
+      AND terminal_source IS NULL
+      AND completion_applied IS NULL
+      AND grant_authorization_id IS NULL
+      AND grant_issued_at_ms IS NULL
+      AND resolver_plugin_id IS NULL
+    )
+    OR (
+      ended_at_ms IS NOT NULL
+      AND outcome IS NOT NULL
+      AND completion_applied IS NOT NULL
+      AND ended_at_ms >= created_at_ms
+    )
+  ),
+  CHECK (
+    (
+      outcome = 'succeeded'
+      AND resolver_plugin_id IS NOT NULL
+      AND (
+        (
+          decision = 'allow-always'
+          AND grant_authorization_id IS NOT NULL
+          AND grant_issued_at_ms IS NOT NULL
+        )
+        OR (
+          decision = 'allow-once'
+          AND grant_authorization_id IS NULL
+          AND grant_issued_at_ms IS NULL
+        )
+      )
+    )
+    OR (outcome IS NULL OR outcome != 'succeeded')
+  )
+) STRICT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_plugin_external_verification_active_approval
+  ON plugin_external_verification_attempts(approval_id)
+  WHERE ended_at_ms IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_plugin_external_verification_run_active
+  ON plugin_external_verification_attempts(run_id, created_at_ms)
+  WHERE ended_at_ms IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_plugin_external_verification_approval_created
+  ON plugin_external_verification_attempts(approval_id, created_at_ms DESC);
+
+-- Every terminal approval transition closes its active verifier attempt in the
+-- same SQLite transaction. External success ends the attempt before allowing
+-- the approval, so this trigger only handles denial/expiry/cancellation races.
+CREATE TRIGGER IF NOT EXISTS trg_operator_approval_closes_external_verification
+AFTER UPDATE OF status ON operator_approvals
+WHEN OLD.status = 'pending' AND NEW.status != 'pending'
+BEGIN
+  UPDATE plugin_external_verification_attempts
+  SET
+    ended_at_ms = NEW.resolved_at_ms,
+    outcome = CASE WHEN NEW.status = 'expired' THEN 'timed-out' ELSE 'cancelled' END,
+    terminal_source = NEW.terminal_reason,
+    completion_applied = 0
+  WHERE approval_id = NEW.approval_id AND ended_at_ms IS NULL;
+END;
+
 CREATE TABLE IF NOT EXISTS operator_approval_execution_identities (
   approval_id TEXT NOT NULL PRIMARY KEY
     REFERENCES operator_approvals(approval_id) ON DELETE CASCADE,


### PR DESCRIPTION
## What Problem This Solves

External HITL plugins need durable, host-owned attempt state so a World-style verification ceremony can gate a protected tool call with auditable, first-answer-wins resolution. The contract landed in #113517; this is the state slice of the follow-up series from the accepted design RFC (openclaw/rfcs#15) and tracker #82336.

## Why This Change Was Made

Adds the proof-free `plugin_external_verification_attempts` ledger as a same-version additive SQLite table with a one-time idempotent first-use ensure, registered in `LAZY_ADDITIVE_STATE_TABLES` per the database-schema doctrine (downgraded readers stay safe; fold into the next natural version bump). The owning store implements attempt start with immutable presentation per retry generation, interaction replay, first-answer-wins completion that atomically authorizes the canonical approval row, and grant authorization issuance for allow-always. Reviewer authorization for the external resolution path and the plugin-facing attempt/grant types ride here as the store's contract dependencies.

No new plugin-facing capability is exposed by this slice; the SDK surface follows separately.

## User Impact

None yet — the table is created lazily on first feature use and nothing calls the store until the runtime slice lands. No migration, no schema version change, no behavior change for existing installs.

## Evidence

- Store suite (13) and shared-state DB suite green on this branch; full `check:changed` green.
- The only local failures are the two `setAuthorizer` ownership tests, which fail identically on virgin `main` under Node 22 (API requires newer Node).
- Durable behavior (restart reconciliation, expiry, fail-closed run binding) covered in `plugin-external-verification-store.test.ts`.
- End-to-end proof of the full series on a 2.0 gateway with production World App ceremonies (verify-once, verify-and-trust, deny, expiry, run-abort) is recorded in tracker #82336 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Real behavior proof (added after ClawSweeper review)

**Owner-boundary, exact head (`b535ee8`), real SQLite — not mocks:**
- `plugin-external-verification-store.test.ts` (13) opens real `node:sqlite` databases and exercises attempt start/replay, first-answer-wins completion atomically flipping the canonical approval, and grant issuance.
- `openclaw-state-schema-compatibility.test.ts` (3) covers the trigger-projection fix ClawSweeper flagged: it asserts the lazy attempts trigger is omitted with its table, kept when the table is included, and — the regression for the reported upgrade failure — that an ordinary approval resolves on a database opened without the lazy ledger (the exact "dangling trigger breaks ordinary resolution on an upgraded DB" scenario), failing on pre-fix code.

**Composition, exact assembled head (`777b392` = this store + the dependent SDK/runtime/TUI/coverage slices), real gateway:** the `agentkit` gateway E2E (`test:openclaw-hitl`, human + delegation modes, both exit 0) runs a real built OpenClaw gateway with the real `before_tool_call` hook; only the World transport is mocked. The store code in this PR is byte-identical to the store in that head. Redacted trace excerpt:

```
[gateway] http server listening (2 plugins: agentkit, memory-core)
[plugins] agentkit: stored session grant <redacted> for exec
[plugins] agentkit: allowed exec via verified session grant <redacted>
```

**Live human ceremony:** the full series was verified end-to-end with a physical World App on 2026.8.1 (verify-once, verify-and-trust, deny, expiry, run-abort), recorded on tracker #82336.

**Why this slice has no in-branch production caller:** it is the state/store slice of a deliberately sliced series; its caller is the runtime slice (#134899). The store *is* the production owner and is proven at its own boundary above.
