### PR TITLE
feat(plugin-sdk): expose the external verification approvals surface

### DIFF
--- a/packages/gateway-protocol/src/plugin-approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/plugin-approvals-validators.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { validatePluginApprovalRequestParams } from "./index.js";
+import type {
+  PluginApprovalExternalPrepareParams,
+  PluginApprovalExternalPrepareResult,
+  PluginApprovalExternalStartResult,
+} from "./schema/plugin-approvals.js";
 
 const nullableMetadataFields = [
   "pluginId",
@@ -19,6 +24,18 @@ const nullableMetadataFields = [
 ] as const;
 
 describe("plugin approval protocol validators", () => {
+  it("keeps external action wire enums closed in the public types", () => {
+    expectTypeOf<PluginApprovalExternalPrepareParams["decision"]>().toEqualTypeOf<
+      "allow-once" | "allow-always"
+    >();
+    expectTypeOf<PluginApprovalExternalPrepareResult["intent"]>().toEqualTypeOf<
+      "start" | "retry"
+    >();
+    expectTypeOf<PluginApprovalExternalStartResult["outcome"]>().toEqualTypeOf<
+      "started" | "replay" | "stale-action"
+    >();
+  });
+
   it("validates bounded reviewer-only detail independently from the description", () => {
     const request = {
       title: "Apply workspace skill proposal",

--- a/packages/gateway-protocol/src/schema/plugin-approvals.ts
+++ b/packages/gateway-protocol/src/schema/plugin-approvals.ts
@@ -15,6 +15,15 @@ import { NonEmptyString } from "./primitives.js";
 const MAX_PLUGIN_APPROVAL_TIMEOUT_MS = 600_000;
 const PLUGIN_APPROVAL_TITLE_MAX_LENGTH = 80;
 const PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH = 512;
+const PLUGIN_APPROVAL_EXTERNAL_ACTION_TOKEN_MAX_LENGTH = 256;
+
+// Native generators require a flat string enum; the explicit static type keeps
+// protocol callers on the same closed literal set enforced by the wire schema.
+function flatStringEnum<const Values extends readonly string[]>(values: Values) {
+  return Type.Unsafe<Values[number]>({ type: "string", enum: [...values] });
+}
+
+const PluginApprovalExternalDecisionSchema = flatStringEnum(["allow-once", "allow-always"]);
 
 type SingleTypeSchema = TSchema & { type: string; enum?: readonly (string | null)[] };
 
@@ -92,7 +101,50 @@ export const PluginApprovalResolveParamsSchema = closedObject({
   reviewer: Type.Optional(ApprovalChannelReviewerSchema),
 });
 
+/** Native reviewer request for the current core-issued external action generation. */
+export const PluginApprovalExternalPrepareParamsSchema = closedObject({
+  id: NonEmptyString,
+  decision: PluginApprovalExternalDecisionSchema,
+});
+
+/** Core-issued opaque action generation rendered by a native approval client. */
+export const PluginApprovalExternalPrepareResultSchema = closedObject({
+  intent: flatStringEnum(["start", "retry"]),
+  actionToken: Type.String({
+    minLength: 1,
+    maxLength: PLUGIN_APPROVAL_EXTERNAL_ACTION_TOKEN_MAX_LENGTH,
+  }),
+});
+
+/** Native reviewer dispatch of a previously prepared external action generation. */
+export const PluginApprovalExternalStartParamsSchema = closedObject({
+  id: NonEmptyString,
+  decision: PluginApprovalExternalDecisionSchema,
+  actionToken: Type.String({
+    minLength: 1,
+    maxLength: PLUGIN_APPROVAL_EXTERNAL_ACTION_TOKEN_MAX_LENGTH,
+  }),
+});
+
+/** Challenge text returned through the approval control lane. */
+export const PluginApprovalExternalStartResultSchema = closedObject({
+  outcome: flatStringEnum(["started", "replay", "stale-action"]),
+  presentations: Type.Array(Type.String({ minLength: 1, maxLength: 8_192 }), { maxItems: 8 }),
+});
+
 // Owner-local wire types derived directly from local schema consts so the
 // public plugin-sdk declaration graph never pulls in the ProtocolSchemas registry.
 export type PluginApprovalRequestParams = Static<typeof PluginApprovalRequestParamsSchema>;
 export type PluginApprovalResolveParams = Static<typeof PluginApprovalResolveParamsSchema>;
+export type PluginApprovalExternalPrepareParams = Static<
+  typeof PluginApprovalExternalPrepareParamsSchema
+>;
+export type PluginApprovalExternalPrepareResult = Static<
+  typeof PluginApprovalExternalPrepareResultSchema
+>;
+export type PluginApprovalExternalStartParams = Static<
+  typeof PluginApprovalExternalStartParamsSchema
+>;
+export type PluginApprovalExternalStartResult = Static<
+  typeof PluginApprovalExternalStartResultSchema
+>;

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-plugins-lifecycle.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-plugins-lifecycle.ts
@@ -9,6 +9,10 @@ import * as plugins from "./plugins.js";
 export const PluginLifecycleProtocolSchemas = {
   CapabilityConsentErrorDetails: plugins.CapabilityConsentErrorDetailsSchema,
   HooksStatusParams: hooks.HooksStatusParamsSchema,
+  PluginApprovalExternalPrepareParams: pluginApprovals.PluginApprovalExternalPrepareParamsSchema,
+  PluginApprovalExternalPrepareResult: pluginApprovals.PluginApprovalExternalPrepareResultSchema,
+  PluginApprovalExternalStartParams: pluginApprovals.PluginApprovalExternalStartParamsSchema,
+  PluginApprovalExternalStartResult: pluginApprovals.PluginApprovalExternalStartResultSchema,
   PluginApprovalRequestParams: pluginApprovals.PluginApprovalRequestParamsSchema,
   PluginApprovalResolveParams: pluginApprovals.PluginApprovalResolveParamsSchema,
   PluginCatalogClawHubInstall: plugins.PluginCatalogClawHubInstallSchema,

--- a/packages/gateway-protocol/src/validator-registry.ts
+++ b/packages/gateway-protocol/src/validator-registry.ts
@@ -493,6 +493,12 @@ export const validateQuestionWaitAnswerParams = compile(S.QuestionWaitAnswerPara
 export const validateQuestionResolveParams = compile(S.QuestionResolveParamsSchema);
 export const validateQuestionGetParams = compile(S.QuestionGetParamsSchema);
 export const validateQuestionListParams = compile(S.QuestionListParamsSchema);
+export const validatePluginApprovalExternalPrepareParams = compile(
+  S.PluginApprovalExternalPrepareParamsSchema,
+);
+export const validatePluginApprovalExternalStartParams = compile(
+  S.PluginApprovalExternalStartParamsSchema,
+);
 export const validatePluginApprovalRequestParams = compile(S.PluginApprovalRequestParamsSchema);
 export const validatePluginApprovalResolveParams = compile(S.PluginApprovalResolveParamsSchema);
 export const validateCapabilityConsentErrorDetails = compile(S.CapabilityConsentErrorDetailsSchema);

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -351,7 +351,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: browser-safe Date timestamp validation and UTF-16 truncation primitives.
       // +3: capability catalog descriptors, entry factories, and native host context.
       // +2: canonical paragraph grouping and UTF-16 boundaries for channel-owned chunking.
-      4433,
+      // +6: external verification approvals surface (types, runtime state, verifier contracts) for plugin-owned HITL.
+      4439,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/plugin-sdk/plugin-entry.ts
+++ b/src/plugin-sdk/plugin-entry.ts
@@ -12,6 +12,14 @@ export type {
 } from "../plugins/capability-catalog-context.types.js";
 export type { PluginCapabilityCatalog } from "../plugins/capability-catalog.types.js";
 export type { OpenClawConfig } from "../config/types.openclaw.js";
+export type {
+  PluginExternalResolution,
+  PluginExternalVerificationAttempt,
+  PluginExternalVerificationCompletionResult,
+  PluginExternalVerificationContext,
+  PluginExternalVerificationGrantAuthorization,
+  PluginExternalVerificationGrantStore,
+} from "../plugins/external-verification-approval-types.js";
 
 export type {
   AgentHarness,

--- a/src/plugin-sdk/plugin-test-api.ts
+++ b/src/plugin-sdk/plugin-test-api.ts
@@ -19,6 +19,15 @@ export function createTestPluginApi(api: TestPluginApiInput = {}): OpenClawPlugi
     config: {},
     runtime: {} as OpenClawPluginApi["runtime"],
     logger: { info() {}, warn() {}, error() {}, debug() {} },
+    approvals: {
+      onExternalVerification() {},
+      completeExternalVerification: async () => {
+        throw new Error("external verification approval runtime is not available in tests");
+      },
+      openGrantStore: () => {
+        throw new Error("external verification grant storage is not available in tests");
+      },
+    },
     registerTool() {},
     registerHook() {},
     registerHttpRoute() {},

--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -21,6 +21,15 @@ type BuildPluginApiParams = {
 };
 
 const noops = {
+  approvals: {
+    onExternalVerification: () => {},
+    completeExternalVerification: async () => {
+      throw new Error("external verification approval runtime is not available");
+    },
+    openGrantStore: () => {
+      throw new Error("external verification grant storage is unavailable during plugin discovery");
+    },
+  },
   registerTool: () => {},
   registerHook: () => {},
   registerHttpRoute: () => {},
@@ -137,6 +146,7 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
     pluginConfig: params.pluginConfig,
     runtime: params.runtime,
     logger: params.logger,
+    approvals: handlers.approvals ?? noops.approvals,
     registerTool: handlers.registerTool ?? noops.registerTool,
     registerHook: handlers.registerHook ?? noops.registerHook,
     registerHttpRoute: handlers.registerHttpRoute ?? noops.registerHttpRoute,

--- a/src/plugins/external-verification-approval-runtime-state.ts
+++ b/src/plugins/external-verification-approval-runtime-state.ts
@@ -1,0 +1,55 @@
+// Process-local bridge from the plugin-bound facade to the active Gateway owner.
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import type { PluginExternalVerificationCompletionResult } from "./external-verification-approval-types.js";
+
+type CompletionHandler = (
+  owner: object,
+  pluginId: string,
+  completion: { attemptId: string; outcome: "succeeded" | "failed" },
+) => Promise<PluginExternalVerificationCompletionResult>;
+
+type CompletionRuntimeState = {
+  owner: object | null;
+  handler: CompletionHandler | null;
+};
+
+const completionRuntimeStateKey = Symbol.for(
+  "openclaw.plugin-external-verification-completion-runtime",
+);
+
+function getCompletionRuntimeState(): CompletionRuntimeState {
+  return resolveGlobalSingleton<CompletionRuntimeState>(completionRuntimeStateKey, () => ({
+    owner: null,
+    handler: null,
+  }));
+}
+
+export function setExternalVerificationCompletionRuntime(
+  owner: object,
+  handler: CompletionHandler,
+): void {
+  const state = getCompletionRuntimeState();
+  state.owner = owner;
+  state.handler = handler;
+}
+
+export function clearExternalVerificationCompletionRuntime(owner: object): void {
+  const state = getCompletionRuntimeState();
+  if (state.owner !== owner) {
+    return;
+  }
+  state.owner = null;
+  state.handler = null;
+}
+
+export async function completeExternalVerificationForPlugin(
+  owner: object,
+  pluginId: string,
+  completion: { attemptId: string; outcome: "succeeded" | "failed" },
+): Promise<PluginExternalVerificationCompletionResult> {
+  const handler = getCompletionRuntimeState().handler;
+  if (!handler) {
+    throw new Error("external verification approval runtime is not available");
+  }
+  return await handler(owner, pluginId, completion);
+}

--- a/src/plugins/external-verification-approval-types.ts
+++ b/src/plugins/external-verification-approval-types.ts
@@ -1,0 +1,87 @@
+import type {
+  ApprovalAllowDecision,
+  ApprovalSnapshot,
+} from "../../packages/gateway-protocol/src/index.js";
+import type { PluginStateEntry } from "../plugin-state/plugin-state-store.types.js";
+
+/** Plugin-owned reviewer choices that require an external verification ceremony. */
+export type PluginExternalResolution = {
+  label: string;
+  decisions?: readonly ApprovalAllowDecision[];
+};
+
+/** Host-derived approval context that verifier challenges must bind. */
+export type PluginExternalVerificationContext = Readonly<{
+  approvalId: string;
+  pluginId: string;
+  runId: string;
+  toolName: string;
+  toolCallId?: string;
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  decision: ApprovalAllowDecision;
+  label: string;
+  expiresAtMs: number;
+}>;
+
+/** Immutable context for one host-authenticated external verification attempt. */
+export type PluginExternalVerificationAttempt = Readonly<{
+  id: string;
+  context: PluginExternalVerificationContext;
+  createdAtMs: number;
+  signal: AbortSignal;
+  present: (params: { message: string }) => Promise<void>;
+}>;
+
+/** Persisted, proof-free attempt projection returned by completion calls. */
+export type PluginExternalVerificationAttemptSnapshot = Omit<
+  PluginExternalVerificationAttempt,
+  "present" | "signal"
+> & {
+  endedAtMs?: number;
+  outcome?: "succeeded" | "failed" | "cancelled" | "timed-out";
+  errorClass?: string;
+  terminalSource?: string;
+};
+
+/** Stable host authorization emitted only when external verification wins the approval race. */
+export type PluginExternalVerificationGrantAuthorization = {
+  id: string;
+  issuedAtMs: number;
+  approvalId: string;
+  attemptId: string;
+  decision: ApprovalAllowDecision;
+};
+
+/** Idempotent completion result derived entirely from host-owned attempt state. */
+export type PluginExternalVerificationCompletionResult = {
+  applied: boolean;
+  approval: ApprovalSnapshot;
+  attempt: PluginExternalVerificationAttemptSnapshot;
+  grantAuthorization?: PluginExternalVerificationGrantAuthorization;
+};
+
+export type PluginExternalVerificationHandler = (
+  attempt: PluginExternalVerificationAttempt,
+) => Promise<void> | void;
+
+/** Durable grant storage that preserves prior authorizations and tombstones. */
+export type PluginExternalVerificationGrantStore<T> = {
+  registerIfAbsent: (key: string, value: T) => boolean;
+  lookup: (key: string) => T | undefined;
+  entries: () => PluginStateEntry<T>[];
+  update: (key: string, updateValue: (current: T | undefined) => T | undefined) => boolean;
+};
+
+export type OpenClawPluginApprovalsApi = {
+  /** Register this plugin's single verifier for host-authenticated approval attempts. */
+  onExternalVerification: (handler: PluginExternalVerificationHandler) => void;
+  /** Complete an attempt owned by this plugin; plugin and approval identity are host-derived. */
+  completeExternalVerification: (params: {
+    attemptId: string;
+    outcome: "succeeded" | "failed";
+  }) => Promise<PluginExternalVerificationCompletionResult>;
+  /** Open bounded plugin-owned storage for stable grant authorizations and tombstones. */
+  openGrantStore: <T>() => PluginExternalVerificationGrantStore<T>;
+};

--- a/src/plugins/hook-before-tool-call-result.ts
+++ b/src/plugins/hook-before-tool-call-result.ts
@@ -1,4 +1,5 @@
 import type { ApprovalScope } from "../infra/approval-scope.js";
+import type { PluginExternalResolution } from "./external-verification-approval-types.js";
 
 export const PluginApprovalResolutions = {
   ALLOW_ONCE: "allow-once",
@@ -11,25 +12,41 @@ export const PluginApprovalResolutions = {
 export type PluginApprovalResolution =
   (typeof PluginApprovalResolutions)[keyof typeof PluginApprovalResolutions];
 
+type PluginHookApprovalRequest = {
+  title: string;
+  description: string;
+  scope?: ApprovalScope;
+  severity?: "info" | "warning" | "critical";
+  timeoutMs?: number;
+  /**
+   * @deprecated Unresolved approvals always deny; retained for plugin API
+   * compatibility. The field will be removed after one deprecation release train.
+   */
+  timeoutBehavior?: "allow" | "deny";
+  /** Override timeout text and return the timeout as a blocked tool result. */
+  timeoutReason?: string;
+  allowedDecisions?: Array<"allow-once" | "allow-always" | "deny">;
+  /**
+   * @deprecated Ignored. The host stamps the live plugin owner and will remove
+   * this field after one deprecation release train.
+   */
+  pluginId?: string;
+  /** Plugin-owned allow path. Core still owns denial and the final approval ledger. */
+  externalResolution?: PluginExternalResolution;
+  onResolution?: (decision: PluginApprovalResolution) => Promise<void> | void;
+};
+
 export type PluginHookBeforeToolCallResult = {
   params?: Record<string, unknown>;
   block?: boolean;
   blockReason?: string;
-  requireApproval?: {
-    title: string;
-    description: string;
-    scope?: ApprovalScope;
-    severity?: "info" | "warning" | "critical";
-    timeoutMs?: number;
-    /**
-     * @deprecated Unresolved approvals always deny; retained for plugin API
-     * compatibility. The field will be removed after one deprecation release train.
-     */
-    timeoutBehavior?: "allow" | "deny";
-    /** Override timeout text and return the timeout as a blocked tool result. */
-    timeoutReason?: string;
-    allowedDecisions?: Array<"allow-once" | "allow-always" | "deny">;
-    pluginId?: string;
-    onResolution?: (decision: PluginApprovalResolution) => Promise<void> | void;
-  };
+  requireApproval?: PluginHookApprovalRequest;
+};
+
+/** Internal merger result with an owner stamped from the live registration. */
+export type PluginHostBeforeToolCallResult = Omit<
+  PluginHookBeforeToolCallResult,
+  "requireApproval"
+> & {
+  requireApproval?: PluginHookApprovalRequest & { pluginId?: string };
 };

--- a/src/plugins/hook-runner-global-state.ts
+++ b/src/plugins/hook-runner-global-state.ts
@@ -4,6 +4,7 @@ import type { GlobalHookRunnerRegistry } from "./hook-registry.types.js";
 import type { HookRunner } from "./hooks.js";
 import { isPluginRegistryRetired } from "./registry-lifecycle.js";
 import type {
+  PluginExternalApprovalVerifierRegistration,
   PluginRegistry,
   PluginTrustedToolPolicyRegistryRegistration,
 } from "./registry-types.js";
@@ -13,6 +14,7 @@ import { getPluginRuntimeGenerationRegistry } from "./runtime/generation-scope.j
 
 type TrustedPolicyHookRunnerRegistry = GlobalHookRunnerRegistry & {
   trustedToolPolicies?: PluginTrustedToolPolicyRegistryRegistration[];
+  externalApprovalVerifiers?: PluginExternalApprovalVerifierRegistration[];
 };
 
 type HookRunnerGlobalState = {
@@ -94,6 +96,18 @@ function overlayHookRegistries(
     const rightRank = right.origin === "bundled" ? 0 : 1;
     return leftRank - rightRank;
   });
+  // External approval verifiers follow the same overlay contract: a source
+  // that carries a verifier for a plugin replaces the base entry for that
+  // plugin only, keeping one live owner per plugin id.
+  const overlayExternalVerifierPluginIds = new Set(
+    (overlayRegistry.externalApprovalVerifiers ?? []).map((entry) => entry.pluginId),
+  );
+  const externalApprovalVerifiers = [
+    ...(baseRegistry.externalApprovalVerifiers ?? []).filter(
+      (entry) => !overlayExternalVerifierPluginIds.has(entry.pluginId),
+    ),
+    ...(overlayRegistry.externalApprovalVerifiers ?? []),
+  ];
   return {
     hooks: [
       ...baseRegistry.hooks.flatMap((hook) => {
@@ -117,6 +131,7 @@ function overlayHookRegistries(
       ...overlayRegistry.plugins,
     ],
     trustedToolPolicies,
+    externalApprovalVerifiers,
   };
 }
 
@@ -149,6 +164,9 @@ export function createLiveHookRegistryFacade(
     get trustedToolPolicies() {
       return resolveHookRegistry(state)?.trustedToolPolicies ?? [];
     },
+    get externalApprovalVerifiers() {
+      return resolveHookRegistry(state)?.externalApprovalVerifiers ?? [];
+    },
   };
 }
 
@@ -157,4 +175,15 @@ export function getGlobalHookRunnerRegistry(): TrustedPolicyHookRunnerRegistry |
   return resolveHookRegistry(hookRunnerGlobalState)
     ? createLiveHookRegistryFacade(hookRunnerGlobalState)
     : null;
+}
+
+/** Resolve the verifier owned by the same live plugin registry selected for hook dispatch. */
+export function getPluginExternalApprovalVerifier(
+  pluginId: string,
+): PluginExternalApprovalVerifierRegistration | null {
+  return (
+    getGlobalHookRunnerRegistry()?.externalApprovalVerifiers?.find(
+      (registration) => registration.pluginId === pluginId,
+    ) ?? null
+  );
 }

--- a/src/plugins/hooks.before-tool-call.test.ts
+++ b/src/plugins/hooks.before-tool-call.test.ts
@@ -158,6 +158,34 @@ describe("before_tool_call hook merger — requireApproval", () => {
     expectRequireApprovalResult(result, { requireApproval: expectedApproval });
   });
 
+  it("preserves external resolution while stamping its live plugin owner", async () => {
+    const result = await runBeforeToolCallWithHooks(registry, [
+      {
+        pluginId: "agentkit",
+        result: {
+          requireApproval: {
+            title: "World verification",
+            description: "Verify personhood before continuing.",
+            externalResolution: {
+              label: "Verify with World",
+              decisions: ["allow-once", "allow-always"],
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(result?.requireApproval).toEqual({
+      title: "World verification",
+      description: "Verify personhood before continuing.",
+      pluginId: "agentkit",
+      externalResolution: {
+        label: "Verify with World",
+        decisions: ["allow-once", "allow-always"],
+      },
+    });
+  });
+
   it("merges block and requireApproval from different plugins", async () => {
     const result = await runBeforeToolCallWithHooks(registry, [
       {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -24,6 +24,10 @@ import { formatHookErrorForLog } from "../hooks/fire-and-forget.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { projectModelContextMessages } from "../shared/model-context-message.js";
 import { concatOptionalTextSegments } from "../shared/text/join-segments.js";
+import type {
+  PluginHookBeforeToolCallResult,
+  PluginHostBeforeToolCallResult,
+} from "./hook-before-tool-call-result.js";
 import {
   type GateHookResult,
   type InputGateDecision,
@@ -60,7 +64,6 @@ import type {
   PluginHookInboundClaimEvent,
   PluginHookInboundClaimResult,
   PluginHookBeforeToolCallEvent,
-  PluginHookBeforeToolCallResult,
   PluginAgentTurnPrepareEvent,
   PluginAgentTurnPrepareResult,
   PluginHeartbeatPromptContributionEvent,
@@ -1448,8 +1451,8 @@ export function createHookRunner(
       assertAuthority: () => boolean | void;
       markOwnerDecision?: () => void;
     }>,
-  ): Promise<PluginHookBeforeToolCallResult | undefined> {
-    return runModifyingHook<"before_tool_call", PluginHookBeforeToolCallResult>(
+  ): Promise<PluginHostBeforeToolCallResult | undefined> {
+    return runModifyingHook<"before_tool_call", PluginHostBeforeToolCallResult>(
       "before_tool_call",
       event,
       ctx,

--- a/src/plugins/plugin-api.types.ts
+++ b/src/plugins/plugin-api.types.ts
@@ -24,6 +24,7 @@ import type {
 import type { CliBackendPlugin, PluginTextTransforms } from "./cli-backend.types.js";
 import type { CodexAppServerExtensionFactory } from "./codex-app-server-extension-types.js";
 import type { PluginConversationBindingResolvedEvent } from "./conversation-binding.types.js";
+import type { OpenClawPluginApprovalsApi } from "./external-verification-approval-types.js";
 import type {
   PluginHookHandlerMap,
   PluginHookName,
@@ -205,6 +206,8 @@ export type OpenClawPluginApi = {
   runContext: OpenClawPluginRunContextApi;
   /** Grouped facade for plugin-owned lifecycle cleanup hooks. */
   lifecycle: OpenClawPluginLifecycleApi;
+  /** Plugin-bound external approval verification capability. */
+  approvals: OpenClawPluginApprovalsApi;
   registerTool: (
     tool: AnyAgentTool | OpenClawPluginToolFactory,
     opts?: OpenClawPluginToolOptions,

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -1,10 +1,13 @@
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { createPluginStateSyncKeyedStore } from "../plugin-state/plugin-state-store.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { resolveUserPath } from "../utils.js";
 import { emitPluginAgentEvent } from "./agent-event-emission.js";
 import { buildPluginApi } from "./api-builder.js";
+import { completeExternalVerificationForPlugin } from "./external-verification-approval-runtime-state.js";
+import type { PluginExternalVerificationGrantStore } from "./external-verification-approval-types.js";
 import {
   clearPluginRunContext,
   getPluginRunContext,
@@ -14,7 +17,11 @@ import {
   schedulePluginSessionTurn,
   unschedulePluginSessionTurnsByTag,
 } from "./host-hook-scheduled-turns.js";
-import { isPluginRegistryActivated, isPluginRegistryRetired } from "./registry-lifecycle.js";
+import {
+  capturePluginLifecycleAuthority,
+  isPluginRegistryActivated,
+  isPluginRegistryRetired,
+} from "./registry-lifecycle.js";
 import type { PluginRegistrars } from "./registry-registrars.js";
 import type { PluginRuntimeResolver } from "./registry-runtime.js";
 import {
@@ -24,7 +31,33 @@ import {
   type PluginSideEffectGuard,
 } from "./registry-state.js";
 import type { PluginRecord } from "./registry-types.js";
+import { getActivePluginRegistry } from "./runtime.js";
 import type { OpenClawPluginApi, PluginLogger, PluginRegistrationMode } from "./types.js";
+
+const EXTERNAL_APPROVAL_GRANT_STORE_NAMESPACE = "external-approval-grants";
+const EXTERNAL_APPROVAL_GRANT_STORE_MAX_ENTRIES = 5_000;
+
+function openExternalApprovalGrantStore<T>(params: {
+  assertActive: () => void;
+  pluginId: string;
+}): PluginExternalVerificationGrantStore<T> {
+  params.assertActive();
+  const store = createPluginStateSyncKeyedStore<T>(params.pluginId, {
+    namespace: EXTERNAL_APPROVAL_GRANT_STORE_NAMESPACE,
+    maxEntries: EXTERNAL_APPROVAL_GRANT_STORE_MAX_ENTRIES,
+    overflowPolicy: "reject-new",
+  });
+  const withActiveOwner = <R>(operation: () => R): R => {
+    params.assertActive();
+    return operation();
+  };
+  return {
+    registerIfAbsent: (key, value) => withActiveOwner(() => store.registerIfAbsent(key, value)),
+    lookup: (key) => withActiveOwner(() => store.lookup(key)),
+    entries: () => withActiveOwner(() => store.entries()),
+    update: (key, updateValue) => withActiveOwner(() => store.update?.(key, updateValue) ?? false),
+  };
+}
 
 // Registration exposes these async operations without loading session storage or delivery.
 const loadAttachments = createLazyRuntimeModule(() => import("./host-hook-attachments.js"));
@@ -145,6 +178,7 @@ export function createPluginApiFactory(
   ): OpenClawPluginApi => {
     const registrationMode = params.registrationMode ?? "full";
     const registrationCapabilities = resolvePluginRegistrationCapabilities(registrationMode);
+    const externalApprovalOwner = {};
     setPluginRuntimeRecord(record);
     const sideEffectGuard = createPluginSideEffectGuard(record.id);
     const isLoadedRecordInRegistry = () =>
@@ -164,6 +198,27 @@ export function createPluginApiFactory(
       !isPluginRegistryRetired(registry) &&
       (isActivatingLoadedRecord() ||
         (isPluginRegistryActivated(registry) && isLoadedRecordInRegistry()));
+    const assertExternalApprovalGrantStoreOwnerActive = () => {
+      // Grant metadata is authorization-adjacent durable state: only a live,
+      // loaded owner generation may touch it. Prepared runs execute their hooks
+      // in a scoped (non-Gateway) registry generation that is intentionally not
+      // globally activated, so gate on canonical lifecycle authority: it accepts
+      // such a scoped run generation with a loaded record (plus the in-flight
+      // activation case) while still refusing a retired, revoked, unloaded, or
+      // side-effect-deactivated owner — e.g. a discovery/inventory scan that
+      // never loaded the record into a live run must not persist grants.
+      const gatewayRegistry = getActivePluginRegistry();
+      const isOwnerCurrent = capturePluginLifecycleAuthority(registry, record, {
+        scopedRuntime: registry !== gatewayRegistry,
+      });
+      const ownerLive =
+        isActivatingLoadedRecord() || (isOwnerCurrent !== undefined && isOwnerCurrent());
+      if (!sideEffectGuard.active || isPluginRegistryRetired(registry) || !ownerLive) {
+        throw new Error(
+          `plugin '${record.id}' external approval grant store owner is no longer active`,
+        );
+      }
+    };
     return buildPluginApi({
       id: record.id,
       name: record.name,
@@ -180,6 +235,41 @@ export function createPluginApiFactory(
       handlers: {
         ...(registrationCapabilities.capabilityHandlers
           ? {
+              // Any mode that can register hooks can execute them during a run
+              // (prepared-run generations load in discovery/tool-discovery mode);
+              // without the real approvals surface those hooks fail closed at
+              // verification time. The registry side-effect guard still fences
+              // grant-store use to the registry's active lifecycle.
+              approvals: {
+                onExternalVerification: (handler) => {
+                  if (
+                    registry.externalApprovalVerifiers.some((entry) => entry.pluginId === record.id)
+                  ) {
+                    throw new Error(
+                      `plugin '${record.id}' registered more than one external verifier`,
+                    );
+                  }
+                  registry.externalApprovalVerifiers.push({
+                    pluginId: record.id,
+                    pluginName: record.name,
+                    owner: externalApprovalOwner,
+                    handler,
+                    source: record.source,
+                    rootDir: record.rootDir,
+                  });
+                },
+                completeExternalVerification: (completion) =>
+                  completeExternalVerificationForPlugin(
+                    externalApprovalOwner,
+                    record.id,
+                    completion,
+                  ),
+                openGrantStore: () =>
+                  openExternalApprovalGrantStore({
+                    assertActive: assertExternalApprovalGrantStoreOwnerActive,
+                    pluginId: record.id,
+                  }),
+              },
               registerTool: (tool, opts) => registerTool(record, tool, opts),
               registerHook: (events, handler, opts) =>
                 registerHook(record, events, handler, opts, params.config, params.pluginConfig),

--- a/src/plugins/registry-empty.ts
+++ b/src/plugins/registry-empty.ts
@@ -69,6 +69,7 @@ export function createEmptyPluginRegistry(): PluginRegistry {
     sessionSchedulerJobs: [],
     sessionActions: [],
     conversationBindingResolvedHandlers: [],
+    externalApprovalVerifiers: [],
     diagnostics: [],
   };
 }

--- a/src/plugins/registry-lifecycle.ts
+++ b/src/plugins/registry-lifecycle.ts
@@ -23,6 +23,20 @@ const { retiredRegistries, activatedRegistries, registryEpochs, recordEpochs, re
 export type PluginRegistryLifecycleEpoch = object;
 type PluginRecordLifecycleEpoch = object;
 
+const lifecycleListeners = new Set<() => void>();
+
+function notifyPluginRegistryLifecycleListeners(): void {
+  for (const listener of lifecycleListeners) {
+    listener();
+  }
+}
+
+/** Observe activation edges that can replace runtime-owned plugin capabilities. */
+export function onPluginRegistryLifecycleChange(listener: () => void): () => void {
+  lifecycleListeners.add(listener);
+  return () => lifecycleListeners.delete(listener);
+}
+
 /** Marks a registry retired so late runtime calls can reject stale plugin state. */
 export function markPluginRegistryRetired(registry: PluginRegistry | null | undefined): void {
   if (registry) {
@@ -31,6 +45,7 @@ export function markPluginRegistryRetired(registry: PluginRegistry | null | unde
     // Retired registrations cannot be reused and retain their Gateway/cache generation.
     // Release every cache key now, including keys that will never be looked up again.
     pluginLoaderCacheState.deleteValue(registry);
+    notifyPluginRegistryLifecycleListeners();
   }
 }
 
@@ -42,6 +57,7 @@ export function markPluginRegistryActive(registry: PluginRegistry | null | undef
     // Every activation owns a fresh opaque generation. A retired closure cannot
     // regain authority merely because the same registry object becomes active.
     registryEpochs.set(registry, Object.freeze({}));
+    notifyPluginRegistryLifecycleListeners();
   }
 }
 

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -16,6 +16,7 @@ import type { CodexAppServerExtensionFactory } from "./codex-app-server-extensio
 import type { PluginCompatCode } from "./compat/registry.js";
 import type { PluginActivationSource } from "./config-state.js";
 import type { EmbeddingProviderAdapter } from "./embedding-provider-types.js";
+import type { PluginExternalVerificationHandler } from "./external-verification-approval-types.js";
 import type {
   PluginAgentEventSubscriptionRegistration,
   PluginControlUiDescriptor,
@@ -461,6 +462,15 @@ type PluginConversationBindingResolvedHandlerRegistration = {
   rootDir?: string;
 };
 
+export type PluginExternalApprovalVerifierRegistration = {
+  pluginId: string;
+  pluginName?: string;
+  owner: object;
+  handler: PluginExternalVerificationHandler;
+  source: string;
+  rootDir?: string;
+};
+
 export type PluginRecord = {
   id: string;
   name: string;
@@ -596,6 +606,7 @@ export type PluginRegistry = {
   sessionSchedulerJobs: PluginSessionSchedulerJobRegistryRegistration[];
   sessionActions: PluginSessionActionRegistryRegistration[];
   conversationBindingResolvedHandlers: PluginConversationBindingResolvedHandlerRegistration[];
+  externalApprovalVerifiers: PluginExternalApprovalVerifierRegistration[];
   diagnostics: PluginDiagnostic[];
 };
 

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -3,9 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { resolveUserPath } from "../utils.js";
+import { getPluginExternalApprovalVerifier } from "./hook-runner-global-state.js";
 import { createLazyPluginRuntime } from "./loader-module-runtime.js";
 import { createPluginRecord } from "./loader-records.js";
+import { markPluginRegistryRetired } from "./registry-lifecycle.js";
 import { createPluginRegistry } from "./registry.js";
 import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
 import { createPluginRuntime } from "./runtime/index.js";
@@ -21,6 +24,14 @@ function createTestRegistry(runtime: PluginRuntime) {
     },
     runtime,
     activateGlobalSideEffects: false,
+  });
+}
+
+function createActivatingTestRegistry(runtime: PluginRuntime) {
+  return createPluginRegistry({
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    runtime,
+    activateGlobalSideEffects: true,
   });
 }
 
@@ -615,5 +626,173 @@ describe("plugin registry runtime config scope", () => {
         initialEntry: { ...initialEntry, cliBackendId: "opencode" } as never,
       }),
     ).rejects.toThrow("requires exactly one runtime owner");
+  });
+
+  it("registers exactly one external verifier for a fully activated plugin", () => {
+    const pluginRegistry = createTestRegistry(createPluginRuntime());
+    const record = createPluginRecord({
+      id: "approval-owner",
+      name: "Approval Owner",
+      source: "/plugins/approval-owner/index.js",
+      origin: "global",
+      enabled: true,
+      configSchema: false,
+    });
+    const api = pluginRegistry.createApi(record, {
+      config: {} as OpenClawConfig,
+      registrationMode: "full",
+    });
+    const handler = vi.fn();
+
+    api.approvals.onExternalVerification(handler);
+
+    expect(pluginRegistry.registry.externalApprovalVerifiers).toEqual([
+      expect.objectContaining({
+        pluginId: "approval-owner",
+        pluginName: "Approval Owner",
+        handler,
+      }),
+    ]);
+    expect(() => api.approvals.onExternalVerification(vi.fn())).toThrow(
+      "registered more than one external verifier",
+    );
+  });
+
+  it("provides bounded plugin-scoped grant storage without broad external state access", async () => {
+    await withOpenClawTestState({ label: "external-approval-grants", applyEnv: true }, async () => {
+      const pluginRegistry = createActivatingTestRegistry(createPluginRuntime());
+      const record = createPluginRecord({
+        id: "external-approval-owner",
+        source: "/plugins/external-approval-owner/index.js",
+        origin: "global",
+        enabled: true,
+        configSchema: false,
+      });
+      const api = pluginRegistry.createApi(record, {
+        config: {} as OpenClawConfig,
+        registrationMode: "full",
+      });
+
+      expect(() =>
+        api.runtime.state.openSyncKeyedStore({
+          namespace: "unrestricted",
+          maxEntries: 10,
+        }),
+      ).toThrow("openSyncKeyedStore is only available for trusted plugins");
+
+      const grants = api.approvals.openGrantStore<{ status: "active" | "revoked" }>();
+      expect(grants.registerIfAbsent("grant-1", { status: "active" })).toBe(true);
+      expect(grants.registerIfAbsent("grant-1", { status: "active" })).toBe(false);
+      expect(grants.update("grant-1", (current) => ({ ...current, status: "revoked" }))).toBe(true);
+      expect(grants.lookup("grant-1")).toEqual({ status: "revoked" });
+      expect(grants.entries()).toEqual([
+        expect.objectContaining({
+          key: "grant-1",
+          value: { status: "revoked" },
+        }),
+      ]);
+      expect(api.approvals.openGrantStore().lookup("grant-1")).toEqual({
+        status: "revoked",
+      });
+      expect(grants).not.toHaveProperty("delete");
+      expect(grants).not.toHaveProperty("clear");
+    });
+  });
+
+  it("rejects grant storage writes from a never-activated discovery registry", async () => {
+    await withOpenClawTestState(
+      { label: "external-approval-discovery-grants", applyEnv: true },
+      async () => {
+        const pluginRegistry = createTestRegistry(createPluginRuntime());
+        const record = createPluginRecord({
+          id: "discovery-approval-owner",
+          source: "/plugins/discovery-approval-owner/index.js",
+          origin: "global",
+          enabled: true,
+          configSchema: false,
+        });
+        const api = pluginRegistry.createApi(record, {
+          config: {} as OpenClawConfig,
+          registrationMode: "discovery",
+        });
+
+        // Verifier registration is allowed during discovery; durable grant
+        // metadata is authorization-adjacent and requires the activated owner,
+        // so opening the store is refused before any write can reach SQLite.
+        api.approvals.onExternalVerification(vi.fn());
+        expect(() => api.approvals.openGrantStore<{ status: "active" }>()).toThrow(
+          "external approval grant store owner is no longer active",
+        );
+      },
+    );
+  });
+
+  it("revokes external approval grant storage when its plugin registry retires", async () => {
+    await withOpenClawTestState(
+      { label: "external-approval-retired-grants", applyEnv: true },
+      async () => {
+        const pluginRegistry = createActivatingTestRegistry(createPluginRuntime());
+        const record = createPluginRecord({
+          id: "retired-approval-owner",
+          source: "/plugins/retired-approval-owner/index.js",
+          origin: "global",
+          enabled: true,
+          configSchema: false,
+        });
+        const api = pluginRegistry.createApi(record, {
+          config: {} as OpenClawConfig,
+          registrationMode: "full",
+        });
+        const grants = api.approvals.openGrantStore<{ status: "active" | "revoked" }>();
+        expect(grants.registerIfAbsent("grant-1", { status: "active" })).toBe(true);
+
+        markPluginRegistryRetired(pluginRegistry.registry);
+
+        const ownerRetired = "external approval grant store owner is no longer active";
+        expect(() => grants.lookup("grant-1")).toThrow(ownerRetired);
+        expect(() => grants.entries()).toThrow(ownerRetired);
+        expect(() => grants.registerIfAbsent("grant-2", { status: "active" })).toThrow(
+          ownerRetired,
+        );
+        expect(() => grants.update("grant-1", () => ({ status: "revoked" }))).toThrow(ownerRetired);
+        expect(() => api.approvals.openGrantStore()).toThrow(ownerRetired);
+
+        const replacementRegistry = createActivatingTestRegistry(createPluginRuntime());
+        const replacementApi = replacementRegistry.createApi(record, {
+          config: {} as OpenClawConfig,
+          registrationMode: "full",
+        });
+        const replacementGrants = replacementApi.approvals.openGrantStore<{
+          status: "active" | "revoked";
+        }>();
+        expect(replacementGrants.lookup("grant-1")).toEqual({ status: "active" });
+      },
+    );
+  });
+
+  it("records a discovery-mode verifier in its own registry without global activation", () => {
+    const pluginRegistry = createTestRegistry(createPluginRuntime());
+    const record = createPluginRecord({
+      id: "approval-discovery",
+      source: "/plugins/approval-discovery/index.js",
+      origin: "global",
+      enabled: true,
+      configSchema: false,
+    });
+    const api = pluginRegistry.createApi(record, {
+      config: {} as OpenClawConfig,
+      registrationMode: "discovery",
+    });
+
+    api.approvals.onExternalVerification(vi.fn());
+
+    // Prepared-run generations load plugins in discovery mode and execute
+    // their hooks, so the verifier must live in the loaded registry itself;
+    // liveness is owned by that registry's lifecycle, never by load mode.
+    expect(
+      pluginRegistry.registry.externalApprovalVerifiers.map((entry) => entry.pluginId),
+    ).toEqual(["approval-discovery"]);
+    // A scan that is never activated leaks nothing into global resolution.
+    expect(getPluginExternalApprovalVerifier("approval-discovery")).toBeNull();
   });
 });

--- a/src/plugins/trusted-tool-policy.ts
+++ b/src/plugins/trusted-tool-policy.ts
@@ -2,9 +2,9 @@
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isPlainObject } from "../utils.js";
+import type { PluginHostBeforeToolCallResult } from "./hook-before-tool-call-result.js";
 import type {
   PluginHookBeforeToolCallEvent,
-  PluginHookBeforeToolCallResult,
   PluginHookToolContext,
   PluginHookToolInputKind,
   PluginHookToolKind,
@@ -164,7 +164,7 @@ function trustedPolicyDefaultBlockReason(registration: TrustedPolicyRegistration
 function trustedPolicyFailureResult(
   registration: TrustedPolicyRegistration,
   detail: string,
-): PluginHookBeforeToolCallResult {
+): PluginHostBeforeToolCallResult {
   return {
     block: true,
     blockReason: `${trustedPolicyDefaultBlockReason(registration)}: ${detail}`,
@@ -231,11 +231,11 @@ export async function runTrustedToolPolicies(
       | undefined;
     registry?: TrustedToolPolicyRegistry;
   },
-): Promise<PluginHookBeforeToolCallResult | undefined> {
+): Promise<PluginHostBeforeToolCallResult | undefined> {
   const policies = copyTrustedPolicyRegistrations(options?.registry ?? getActivePluginRegistry());
   let adjustedParams = event.params;
   let hasAdjustedParams = false;
-  let approval: PluginHookBeforeToolCallResult["requireApproval"];
+  let approval: PluginHostBeforeToolCallResult["requireApproval"];
   const sessionExtensionStateCache = new Map<string, Record<string, PluginJsonValue> | undefined>();
   let resolvedSessionConfig: OpenClawConfig | undefined = options?.config;
   let didResolveSessionConfig = Boolean(options?.config);
@@ -365,7 +365,10 @@ export async function runTrustedToolPolicies(
         );
       }
       if ("requireApproval" in decision && decision.requireApproval && !approval) {
-        approval = decision.requireApproval;
+        approval = {
+          ...decision.requireApproval,
+          pluginId: trustedPolicyDiagnosticPluginId(registration),
+        };
       }
     } catch {
       ctx.abortSignal?.throwIfAborted();


### PR DESCRIPTION
## What Problem This Solves

Plugins implementing the external verification contract from #113517 need the SDK seam the accepted RFC (openclaw/rfcs#15) defines: register exactly one verifier, complete only their own host-bound attempts, and persist host-authorized grant metadata. Tracker: #82336. SDK slice of the series; state/store slice is the companion.

## Why This Change Was Made

Adds `api.approvals` (`onExternalVerification` / `completeExternalVerification` / `openGrantStore`), the `plugin.approval.external.prepare`/`start` RPC schemas and validators, host-stamped `PluginHostBeforeToolCallResult` with `externalResolution` hook plumbing, and the verifier overlay contract for composed hook registries.

One deliberate 2.0 interaction: prepared-run generation registries load plugins in discovery mode and execute their hooks, so the approvals surface is served to every hook-capable registration mode. Verifier liveness is owned by the registry lifecycle, never by load mode — a never-activated discovery scan leaks nothing into global resolution (regression-tested both ways).

## User Impact

None on its own — no runtime consumes the RPC schemas until the runtime slice. Plugins compiled against the SDK gain the typed approvals surface. Surface budgets updated with accounted deltas (+7 exports / +1 function / +1 deprecated / +1 infra-runtime).

## Evidence

- Full `check:changed`, `plugin-sdk:surface:check`, and assertion-safety ratchet green on this branch.
- `registry.runtime-config` suite updated for the restated discovery invariant (20/20); plugins test tree green (4,569 passed, 2 pre-existing env-only failures unrelated to this surface).
- Companion reference plugin (Guardiola31337/openclaw-agentkit#2) builds and passes its gateway E2E against this surface unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Real behavior proof (added after ClawSweeper review)

**Authority chain, exact head (`a14a3b5`) — directly answers the finding.** ClawSweeper asked for proof that "an active verifier can write successfully while discovery and retired owners are rejected before persistence." `registry.runtime-config.test.ts` (21) now asserts exactly that chain, and the grant-store fence was tightened to require the activated, loaded owner (not merely non-retired):
- **active owner succeeds** — an activating loaded record opens the grant store and `registerIfAbsent` persists.
- **discovery rejected before persistence** — a never-activated discovery registry: verifier registration is allowed, but `openGrantStore()` throws `external approval grant store owner is no longer active` before any SQLite write.
- **retired rejected** — after `markPluginRegistryRetired`, every store operation and re-open throws.
- **discovery verifier isolation** — a discovery scan records its verifier in its own registry but leaks nothing into global resolution.

This closes the security finding: durable grant metadata can no longer be written from an unactivated discovery load.

**Composition, exact assembled head (`777b392`), real gateway:** the `agentkit` gateway E2E (`test:openclaw-hitl`, human + delegation, both exit 0) drives this SDK surface — `api.approvals.onExternalVerification`, `completeExternalVerification`, `openGrantStore` — through a real gateway; only World transport is mocked. Redacted trace shows the grant store in use:

```
[plugins] agentkit: stored session grant <redacted> for exec
[plugins] agentkit: allowed exec via verified session grant <redacted>
```

**Live human ceremony:** full series verified with a physical World App on 2026.8.1 (tracker #82336).

**No in-branch production caller** is by slicing design; the caller is the runtime slice (#134899). The SDK surface is proven at its own authority boundary above.
