### PR TITLE
feat(approvals): run the external verification attempt lifecycle

### DIFF
--- a/packages/gateway-protocol/src/plugin-approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/plugin-approvals-validators.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { validatePluginApprovalRequestParams } from "./index.js";
+import type {
+  PluginApprovalExternalPrepareParams,
+  PluginApprovalExternalPrepareResult,
+  PluginApprovalExternalStartResult,
+} from "./schema/plugin-approvals.js";
 
 const nullableMetadataFields = [
   "pluginId",
@@ -19,6 +24,18 @@ const nullableMetadataFields = [
 ] as const;
 
 describe("plugin approval protocol validators", () => {
+  it("keeps external action wire enums closed in the public types", () => {
+    expectTypeOf<PluginApprovalExternalPrepareParams["decision"]>().toEqualTypeOf<
+      "allow-once" | "allow-always"
+    >();
+    expectTypeOf<PluginApprovalExternalPrepareResult["intent"]>().toEqualTypeOf<
+      "start" | "retry"
+    >();
+    expectTypeOf<PluginApprovalExternalStartResult["outcome"]>().toEqualTypeOf<
+      "started" | "replay" | "stale-action"
+    >();
+  });
+
   it("validates bounded reviewer-only detail independently from the description", () => {
     const request = {
       title: "Apply workspace skill proposal",

--- a/packages/gateway-protocol/src/schema/plugin-approvals.ts
+++ b/packages/gateway-protocol/src/schema/plugin-approvals.ts
@@ -15,6 +15,15 @@ import { NonEmptyString } from "./primitives.js";
 const MAX_PLUGIN_APPROVAL_TIMEOUT_MS = 600_000;
 const PLUGIN_APPROVAL_TITLE_MAX_LENGTH = 80;
 const PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH = 512;
+const PLUGIN_APPROVAL_EXTERNAL_ACTION_TOKEN_MAX_LENGTH = 256;
+
+// Native generators require a flat string enum; the explicit static type keeps
+// protocol callers on the same closed literal set enforced by the wire schema.
+function flatStringEnum<const Values extends readonly string[]>(values: Values) {
+  return Type.Unsafe<Values[number]>({ type: "string", enum: [...values] });
+}
+
+const PluginApprovalExternalDecisionSchema = flatStringEnum(["allow-once", "allow-always"]);
 
 type SingleTypeSchema = TSchema & { type: string; enum?: readonly (string | null)[] };
 
@@ -92,7 +101,50 @@ export const PluginApprovalResolveParamsSchema = closedObject({
   reviewer: Type.Optional(ApprovalChannelReviewerSchema),
 });
 
+/** Native reviewer request for the current core-issued external action generation. */
+export const PluginApprovalExternalPrepareParamsSchema = closedObject({
+  id: NonEmptyString,
+  decision: PluginApprovalExternalDecisionSchema,
+});
+
+/** Core-issued opaque action generation rendered by a native approval client. */
+export const PluginApprovalExternalPrepareResultSchema = closedObject({
+  intent: flatStringEnum(["start", "retry"]),
+  actionToken: Type.String({
+    minLength: 1,
+    maxLength: PLUGIN_APPROVAL_EXTERNAL_ACTION_TOKEN_MAX_LENGTH,
+  }),
+});
+
+/** Native reviewer dispatch of a previously prepared external action generation. */
+export const PluginApprovalExternalStartParamsSchema = closedObject({
+  id: NonEmptyString,
+  decision: PluginApprovalExternalDecisionSchema,
+  actionToken: Type.String({
+    minLength: 1,
+    maxLength: PLUGIN_APPROVAL_EXTERNAL_ACTION_TOKEN_MAX_LENGTH,
+  }),
+});
+
+/** Challenge text returned through the approval control lane. */
+export const PluginApprovalExternalStartResultSchema = closedObject({
+  outcome: flatStringEnum(["started", "replay", "stale-action"]),
+  presentations: Type.Array(Type.String({ minLength: 1, maxLength: 8_192 }), { maxItems: 8 }),
+});
+
 // Owner-local wire types derived directly from local schema consts so the
 // public plugin-sdk declaration graph never pulls in the ProtocolSchemas registry.
 export type PluginApprovalRequestParams = Static<typeof PluginApprovalRequestParamsSchema>;
 export type PluginApprovalResolveParams = Static<typeof PluginApprovalResolveParamsSchema>;
+export type PluginApprovalExternalPrepareParams = Static<
+  typeof PluginApprovalExternalPrepareParamsSchema
+>;
+export type PluginApprovalExternalPrepareResult = Static<
+  typeof PluginApprovalExternalPrepareResultSchema
+>;
+export type PluginApprovalExternalStartParams = Static<
+  typeof PluginApprovalExternalStartParamsSchema
+>;
+export type PluginApprovalExternalStartResult = Static<
+  typeof PluginApprovalExternalStartResultSchema
+>;

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-plugins-lifecycle.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-plugins-lifecycle.ts
@@ -9,6 +9,10 @@ import * as plugins from "./plugins.js";
 export const PluginLifecycleProtocolSchemas = {
   CapabilityConsentErrorDetails: plugins.CapabilityConsentErrorDetailsSchema,
   HooksStatusParams: hooks.HooksStatusParamsSchema,
+  PluginApprovalExternalPrepareParams: pluginApprovals.PluginApprovalExternalPrepareParamsSchema,
+  PluginApprovalExternalPrepareResult: pluginApprovals.PluginApprovalExternalPrepareResultSchema,
+  PluginApprovalExternalStartParams: pluginApprovals.PluginApprovalExternalStartParamsSchema,
+  PluginApprovalExternalStartResult: pluginApprovals.PluginApprovalExternalStartResultSchema,
   PluginApprovalRequestParams: pluginApprovals.PluginApprovalRequestParamsSchema,
   PluginApprovalResolveParams: pluginApprovals.PluginApprovalResolveParamsSchema,
   PluginCatalogClawHubInstall: plugins.PluginCatalogClawHubInstallSchema,

--- a/packages/gateway-protocol/src/validator-registry.ts
+++ b/packages/gateway-protocol/src/validator-registry.ts
@@ -493,6 +493,12 @@ export const validateQuestionWaitAnswerParams = compile(S.QuestionWaitAnswerPara
 export const validateQuestionResolveParams = compile(S.QuestionResolveParamsSchema);
 export const validateQuestionGetParams = compile(S.QuestionGetParamsSchema);
 export const validateQuestionListParams = compile(S.QuestionListParamsSchema);
+export const validatePluginApprovalExternalPrepareParams = compile(
+  S.PluginApprovalExternalPrepareParamsSchema,
+);
+export const validatePluginApprovalExternalStartParams = compile(
+  S.PluginApprovalExternalStartParamsSchema,
+);
 export const validatePluginApprovalRequestParams = compile(S.PluginApprovalRequestParamsSchema);
 export const validatePluginApprovalResolveParams = compile(S.PluginApprovalResolveParamsSchema);
 export const validateCapabilityConsentErrorDetails = compile(S.CapabilityConsentErrorDetailsSchema);

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -351,7 +351,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: browser-safe Date timestamp validation and UTF-16 truncation primitives.
       // +3: capability catalog descriptors, entry factories, and native host context.
       // +2: canonical paragraph grouping and UTF-16 boundaries for channel-owned chunking.
-      4433,
+      // +7: plugin-owned external verification approval API and contracts.
+      4440,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -473,7 +474,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +4: defineFeatureContract, createFeatureClient, defineFeaturePlugin, defineControlUiPlugin.
       // +2: browser-safe Date timestamp validation and UTF-16 truncation primitives.
       // +2: canonical paragraph grouping and UTF-16 boundaries for channel-owned chunking.
-      2618,
+      // +1: plugin-owned external verification handler contract.
+      2619,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(
@@ -492,7 +494,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       //     (voice-call/matrix runtime-doctor repair names, WhatsApp ack policy,
       //     Slack progress-draft render) so installed plugins survive upgrade (#124041 class).
       // -18: retire the expired August compatibility exports and messaging-targets subpath.
-      1134,
+      // +1: external verification approval shape carried by the plugin API contract.
+      1135,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/agent-tools.before-tool-call.approval.ts
+++ b/src/agents/agent-tools.before-tool-call.approval.ts
@@ -17,6 +17,7 @@ import { resolveCanonicalPluginApprovalRequestAllowedDecisions } from "../infra/
 import {
   DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS,
   MAX_PLUGIN_APPROVAL_TIMEOUT_MS,
+  normalizePluginExternalResolution,
 } from "../infra/plugin-approvals.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { cloneHookIsolationValue } from "../plugins/hook-isolation.js";
@@ -208,10 +209,26 @@ async function requestPluginToolApproval(params: {
   const approval = params.approval;
   const timeoutMs = resolvePluginToolApprovalTimeoutMs(approval);
   const gatewayTimeoutMs = resolvePluginToolApprovalGatewayTimeoutMs(timeoutMs);
-  const allowedDecisions = resolveCanonicalPluginApprovalRequestAllowedDecisions(approval);
   let gatewayApprovalPhase: "none" | "request" | "wait" = "none";
   try {
-    const embeddedApprovalBroker = isEmbeddedMode() ? getEmbeddedPluginApprovalBroker() : null;
+    const externalResolution = normalizePluginExternalResolution(approval.externalResolution);
+    const gatewayAllowedDecisions = resolveCanonicalPluginApprovalRequestAllowedDecisions(approval);
+    const allowedDecisions = externalResolution
+      ? [...(externalResolution.decisions ?? ["allow-once"]), "deny"]
+      : gatewayAllowedDecisions;
+    if (externalResolution && !params.ctx?.runId?.trim()) {
+      notifyPluginApprovalResolution(approval, PluginApprovalResolutions.CANCELLED);
+      return {
+        blocked: true,
+        kind: "failure",
+        disposition: "failed",
+        deniedReason: "plugin-approval",
+        reason: "External verification approval requires a host-derived run id",
+        params: params.baseParams,
+      };
+    }
+    const embeddedApprovalBroker =
+      !externalResolution && isEmbeddedMode() ? getEmbeddedPluginApprovalBroker() : null;
     if (embeddedApprovalBroker) {
       const result = await embeddedApprovalBroker.request({
         request: {
@@ -301,11 +318,16 @@ async function requestPluginToolApproval(params: {
             description: approval.description,
             ...(approval.scope ? { scope: approval.scope } : {}),
             severity: approval.severity,
-            allowedDecisions: approval.allowedDecisions,
+            allowedDecisions: externalResolution
+              ? gatewayAllowedDecisions
+              : approval.allowedDecisions,
+            ...(externalResolution ? { externalResolution } : {}),
             toolName: params.toolName,
             toolCallId: params.toolCallId,
             agentId: params.ctx?.agentId,
             sessionKey: params.ctx?.sessionKey,
+            sessionId: params.ctx?.sessionId,
+            runId: params.ctx?.runId,
             ...(params.ctx?.approvalReviewerDeviceId
               ? { approvalReviewerDeviceIds: [params.ctx.approvalReviewerDeviceId] }
               : {}),

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -2965,6 +2965,33 @@ describe("before_tool_call requireApproval handling", () => {
     expect(result).toHaveProperty("reason", "Plugin approval required (gateway unavailable)");
   });
 
+  it("fails closed when a plugin returns invalid external verification metadata", async () => {
+    const onResolution = vi.fn();
+    hookRunner.runBeforeToolCall.mockResolvedValue({
+      requireApproval: {
+        title: "Invalid external verification",
+        description: "Must remain blocked",
+        externalResolution: { label: " " },
+        onResolution,
+      },
+    });
+
+    const result = await runBeforeToolCallHook({
+      toolName: "bash",
+      params: {},
+      ctx: { agentId: "main", sessionKey: "main", runId: "run-1" },
+    });
+
+    expect(result).toMatchObject({
+      blocked: true,
+      kind: "failure",
+      deniedReason: "plugin-approval",
+      reason: "Plugin approval required (gateway unavailable)",
+    });
+    expect(mockCallGateway).not.toHaveBeenCalled();
+    expect(onResolution).toHaveBeenCalledWith(PluginApprovalResolutions.CANCELLED);
+  });
+
   it.each([
     [
       "surfaces validation rejections",

--- a/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
+++ b/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
@@ -218,12 +218,18 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
         agentId: undefined,
         allowedDecisions: undefined,
         description: "Test approval request",
+        runId: undefined,
+        sessionId: undefined,
         sessionKey: undefined,
         severity: "info",
         timeoutMs: 120_000,
         title: "Needs approval",
         toolCallId: "call-1",
         toolName: "exec",
+        turnSourceAccountId: undefined,
+        turnSourceChannel: undefined,
+        turnSourceThreadId: undefined,
+        turnSourceTo: undefined,
         twoPhase: true,
       },
       { expectFinal: false },
@@ -525,6 +531,82 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
     expect(approvalCall.request.timeoutMs).toBe(5_000);
     expect(approvalCall.request.twoPhase).toBe(true);
     expect(approvalCall.options.expectFinal).toBe(false);
+  });
+
+  it("routes external verification through the host even in embedded mode", async () => {
+    setEmbeddedMode(true);
+    const broker = new EmbeddedPluginApprovalBroker();
+    setEmbeddedPluginApprovalBroker(broker);
+    runBeforeToolCallMock.mockResolvedValue({
+      requireApproval: {
+        pluginId: "agentkit",
+        title: "World verification",
+        description: "Verify personhood before continuing.",
+        externalResolution: {
+          label: "Verify with World",
+          decisions: ["allow-once", "allow-always"],
+        },
+      },
+    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:external-1", status: "accepted" })
+      .mockResolvedValueOnce({
+        id: "plugin:external-1",
+        decision: PluginApprovalResolutions.ALLOW_ALWAYS,
+      });
+
+    const result = await runBeforeToolCallHook({
+      toolName: "dangerous-tool",
+      params: { action: "execute" },
+      toolCallId: "call-external",
+      ctx: {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "session-1",
+        runId: "run-1",
+      },
+    });
+
+    expect(result).toMatchObject({
+      blocked: false,
+      approvalResolution: PluginApprovalResolutions.ALLOW_ALWAYS,
+    });
+    const approvalCall = requireApprovalRequestCall("external verification approval request");
+    expect(approvalCall.request).toMatchObject({
+      toolName: "dangerous-tool",
+      toolCallId: "call-external",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedDecisions: ["deny"],
+      externalResolution: {
+        label: "Verify with World",
+        decisions: ["allow-once", "allow-always"],
+      },
+    });
+  });
+
+  it("fails closed before dispatch when external verification has no run binding", async () => {
+    runBeforeToolCallMock.mockResolvedValue({
+      requireApproval: {
+        pluginId: "agentkit",
+        title: "World verification",
+        description: "Verify personhood before continuing.",
+        externalResolution: { label: "Verify with World" },
+      },
+    });
+
+    const result = await runBeforeToolCallHook({
+      toolName: "dangerous-tool",
+      params: {},
+      ctx: { agentId: "main", sessionKey: "agent:main:main" },
+    });
+
+    expect(result).toMatchObject({
+      blocked: true,
+      deniedReason: "plugin-approval",
+      reason: expect.stringContaining("requires a host-derived run id"),
+    });
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
   });
 
   it("preserves hook params override after an approval allow decision", async () => {

--- a/src/auto-reply/reply/commands-approve.test.ts
+++ b/src/auto-reply/reply/commands-approve.test.ts
@@ -17,9 +17,19 @@ import { handleApproveCommand } from "./commands-approve.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
 const resolveApprovalOverGatewayMock = vi.hoisted(() => vi.fn());
+const startExternalVerificationForReviewerMock = vi.hoisted(() => vi.fn());
+const routeReplyMock = vi.hoisted(() => vi.fn(async () => ({ ok: true })));
 
 vi.mock("../../infra/approval-gateway-resolver.js", () => ({
   resolveApprovalOverGateway: resolveApprovalOverGatewayMock,
+}));
+
+vi.mock("../../gateway/plugin-external-verification-runtime.js", () => ({
+  startExternalVerificationForReviewer: startExternalVerificationForReviewerMock,
+}));
+
+vi.mock("./route-reply.js", () => ({
+  routeReply: routeReplyMock,
 }));
 
 vi.mock("../../globals.js", () => ({
@@ -129,6 +139,9 @@ function buildApproveParams(
     SenderId?: string;
     GatewayClientScopes?: string[];
     AccountId?: string;
+    ApprovalReviewerDeviceId?: string;
+    MessageSid?: string;
+    OriginatingTo?: string;
   },
 ): HandleCommandsParams {
   const provider = ctxOverrides?.Provider ?? "whatsapp";
@@ -141,6 +154,9 @@ function buildApproveParams(
       SenderId: ctxOverrides?.SenderId,
       GatewayClientScopes: ctxOverrides?.GatewayClientScopes,
       AccountId: ctxOverrides?.AccountId,
+      ApprovalReviewerDeviceId: ctxOverrides?.ApprovalReviewerDeviceId,
+      MessageSid: ctxOverrides?.MessageSid,
+      OriginatingTo: ctxOverrides?.OriginatingTo,
     },
     command: {
       commandBodyNormalized,
@@ -221,6 +237,101 @@ describe("handleApproveCommand", () => {
     );
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply?.text).toContain("Usage: /approve");
+  });
+
+  it("starts the plugin-bound external verifier without submitting a generic allow", async () => {
+    startExternalVerificationForReviewerMock.mockImplementation(
+      async (request: { present: (message: string) => Promise<void> }) => {
+        await request.present("Open the World verifier.");
+        return {
+          id: "external:attempt-1",
+          approvalId: "plugin:approval-1",
+          pluginId: "agentkit",
+          runId: "run-1",
+          toolName: "dangerous-tool",
+          decision: "allow-once",
+          label: "Verify with World",
+          createdAtMs: 1,
+          expiresAtMs: 2,
+        };
+      },
+    );
+    const result = await handleApproveCommand(
+      buildApproveParams(
+        "/approve plugin:approval-1 external allow-once",
+        {
+          commands: { text: true },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+        } as OpenClawConfig,
+        {
+          ApprovalReviewerDeviceId: "device-tui-reviewer",
+          SenderId: "owner",
+          MessageSid: "message-1",
+          OriginatingTo: "owner",
+        },
+      ),
+      true,
+    );
+
+    expect(result).toEqual({ shouldContinue: false });
+    expect(resolveApprovalOverGatewayMock).not.toHaveBeenCalled();
+    expect(startExternalVerificationForReviewerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        approvalId: "plugin:approval-1",
+        decision: "allow-once",
+        interactionId: expect.stringMatching(/^[a-f0-9]{64}$/),
+        reviewerDeviceId: "device-tui-reviewer",
+      }),
+    );
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { text: "Open the World verifier." },
+        channel: "whatsapp",
+        to: "owner",
+        mirror: false,
+      }),
+    );
+  });
+
+  it("fails closed when an external command has no stable message identity", async () => {
+    const result = await handleApproveCommand(
+      buildApproveParams(
+        "/approve plugin:approval-1 external allow-once",
+        {
+          commands: { text: true },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+        } as OpenClawConfig,
+        { SenderId: "owner", OriginatingTo: "owner" },
+      ),
+      true,
+    );
+    expect(result?.reply?.text).toContain("stable authenticated message route");
+    expect(startExternalVerificationForReviewerMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "/approve plugin:approval-1 external deny",
+    "/approve plugin:approval-1 external allow-once extra",
+  ])("rejects malformed external verification syntax: %s", async (command) => {
+    const result = await handleApproveCommand(
+      buildApproveParams(
+        command,
+        {
+          commands: { text: true },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+        } as OpenClawConfig,
+        {
+          SenderId: "owner",
+          MessageSid: "message-1",
+          OriginatingTo: "owner",
+        },
+      ),
+      true,
+    );
+
+    expect(result?.reply?.text).toContain("Usage: /approve");
+    expect(startExternalVerificationForReviewerMock).not.toHaveBeenCalled();
+    expect(resolveApprovalOverGatewayMock).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { expectDefined } from "@openclaw/normalization-core";
 // Implements approval commands for pending tool and execution requests.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
@@ -5,15 +6,19 @@ import {
   getChannelPlugin,
   resolveChannelApprovalCapability,
 } from "../../channels/plugins/index.js";
+import { startExternalVerificationForReviewer } from "../../gateway/plugin-external-verification-runtime.js";
 import { logVerbose } from "../../globals.js";
 import { isApprovalNotFoundError } from "../../infra/approval-errors.js";
 import { resolveApprovalOverGateway } from "../../infra/approval-gateway-resolver.js";
 import type { ChannelApprovalKind } from "../../infra/approval-types.js";
 import { resolveApprovalCommandAuthorization } from "../../infra/channel-approval-auth.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import type { OriginatingChannelType } from "../templating.js";
 import { resolveChannelAccountId } from "./channel-context.js";
 import { requireGatewayClientScope } from "./command-gates.js";
+import { readCommandDeliveryTarget, readCommandMessageThreadId } from "./commands-private-route.js";
 import type { CommandHandler } from "./commands-types.js";
+import { routeReply } from "./route-reply.js";
 
 const COMMAND_REGEX = /^\/?approve(?:\s|$)/i;
 const FOREIGN_COMMAND_MENTION_REGEX = /^\/approve@([^\s]+)(?:\s|$)/i;
@@ -33,6 +38,12 @@ const DECISION_ALIASES: Record<string, "allow-once" | "allow-always" | "deny"> =
 
 type ParsedApproveCommand =
   | { ok: true; id: string; decision: "allow-once" | "allow-always" | "deny" }
+  | {
+      ok: true;
+      id: string;
+      decision: "allow-once" | "allow-always";
+      resolver: "external";
+    }
   | { ok: false; error: string };
 
 const APPROVE_USAGE_TEXT =
@@ -58,6 +69,20 @@ function parseApproveCommand(raw: string): ParsedApproveCommand | null {
 
   const first = normalizeLowercaseStringOrEmpty(tokens[0]);
   const second = normalizeLowercaseStringOrEmpty(tokens[1]);
+  const third = normalizeLowercaseStringOrEmpty(tokens[2]);
+
+  if (
+    tokens.length === 3 &&
+    second === "external" &&
+    (third === "allow-once" || third === "allow-always")
+  ) {
+    return {
+      ok: true,
+      id: expectDefined(tokens[0], "tokens entry at 0"),
+      decision: third,
+      resolver: "external",
+    };
+  }
 
   if (DECISION_ALIASES[first]) {
     return {
@@ -76,7 +101,8 @@ function parseApproveCommand(raw: string): ParsedApproveCommand | null {
   return { ok: false, error: APPROVE_USAGE_TEXT };
 }
 
-type ApproveCommandParams = Pick<Parameters<CommandHandler>[0], "cfg" | "command" | "ctx">;
+type ApproveCommandParams = Pick<Parameters<CommandHandler>[0], "cfg" | "command" | "ctx"> &
+  Partial<Pick<Parameters<CommandHandler>[0], "sessionKey">>;
 
 function buildResolvedByLabel(params: ApproveCommandParams): string {
   const channel = params.command.channel;
@@ -86,6 +112,32 @@ function buildResolvedByLabel(params: ApproveCommandParams): string {
 
 function formatApprovalSubmitError(error: unknown): string {
   return formatErrorMessage(error);
+}
+
+function buildExternalInteractionId(
+  params: ApproveCommandParams,
+  accountId: string | undefined,
+): string | null {
+  const messageId =
+    params.ctx.MessageSidFull?.trim() ||
+    params.ctx.MessageSid?.trim() ||
+    params.ctx.MessageSidFirst?.trim() ||
+    params.ctx.MessageSidLast?.trim();
+  if (!messageId) {
+    return null;
+  }
+  return createHash("sha256")
+    .update(
+      JSON.stringify([
+        params.command.channel,
+        accountId ?? "",
+        params.command.senderId ?? "",
+        readCommandDeliveryTarget(params) ?? "",
+        readCommandMessageThreadId(params) ?? "",
+        messageId,
+      ]),
+    )
+    .digest("hex");
 }
 
 type ApproveCommandBehavior =
@@ -235,6 +287,69 @@ export async function handleApproveCommandFromContext(
         }),
       },
     };
+  }
+
+  if ("resolver" in parsed && parsed.resolver === "external") {
+    if (!methods.includes("plugin")) {
+      return {
+        shouldContinue: false,
+        reply: {
+          text: resolveApprovalAuthorizationError({
+            execAuthorization: execApprovalAuthorization,
+            pluginAuthorization: pluginApprovalAuthorization,
+          }),
+        },
+      };
+    }
+    const interactionId = buildExternalInteractionId(params, effectiveAccountId);
+    const target = readCommandDeliveryTarget(params);
+    if (!interactionId || !target) {
+      return {
+        shouldContinue: false,
+        reply: { text: "❌ External verification requires a stable authenticated message route." },
+      };
+    }
+    try {
+      const attempt = await startExternalVerificationForReviewer({
+        approvalId: parsed.id,
+        decision: parsed.decision,
+        interactionId,
+        reviewerDeviceId: params.ctx.ApprovalReviewerDeviceId,
+        present: async (message) => {
+          const delivery = await routeReply({
+            payload: { text: message },
+            // SAFETY: command contexts only originate from registered channels.
+            channel: params.command.channel as OriginatingChannelType,
+            to: target,
+            accountId: effectiveAccountId,
+            threadId: readCommandMessageThreadId(params),
+            cfg: params.cfg,
+            sessionKey: params.sessionKey,
+            mirror: false,
+            replyKind: "final",
+          });
+          if (!delivery.ok) {
+            throw new Error("external verification presentation could not be delivered");
+          }
+        },
+      });
+      if (attempt.outcome) {
+        return {
+          shouldContinue: false,
+          reply: {
+            text: `External verification attempt already ${attempt.outcome}. ID: ${attempt.id}`,
+          },
+        };
+      }
+      return { shouldContinue: false };
+    } catch (error) {
+      return {
+        shouldContinue: false,
+        reply: {
+          text: `❌ Failed to start external verification: ${formatApprovalSubmitError(error)}`,
+        },
+      };
+    }
   }
 
   for (const [index, method] of methods.entries()) {

--- a/src/auto-reply/reply/commands-private-route.ts
+++ b/src/auto-reply/reply/commands-private-route.ts
@@ -115,7 +115,9 @@ export async function deliverPrivateCommandReply(params: {
 }
 
 /** Reads the command message thread id from command context. */
-export function readCommandMessageThreadId(params: HandleCommandsParams): string | undefined {
+export function readCommandMessageThreadId(
+  params: Pick<HandleCommandsParams, "ctx" | "command">,
+): string | undefined {
   return typeof params.ctx.MessageThreadId === "string" ||
     typeof params.ctx.MessageThreadId === "number"
     ? String(params.ctx.MessageThreadId)
@@ -123,7 +125,9 @@ export function readCommandMessageThreadId(params: HandleCommandsParams): string
 }
 
 /** Reads the best delivery target for command route resolution. */
-export function readCommandDeliveryTarget(params: HandleCommandsParams): string | undefined {
+export function readCommandDeliveryTarget(
+  params: Pick<HandleCommandsParams, "ctx" | "command">,
+): string | undefined {
   return (
     normalizeOptionalString(params.ctx.OriginatingTo) ??
     normalizeOptionalString(params.command.to) ??

--- a/src/auto-reply/reply/fast-approve.ts
+++ b/src/auto-reply/reply/fast-approve.ts
@@ -31,7 +31,7 @@ export async function tryFastApproveFromMessage(params: {
     commandAuthorized: params.ctx.CommandAuthorized,
   });
   const result = await handleApproveCommandFromContext(
-    { cfg: params.cfg, ctx: params.ctx, command },
+    { cfg: params.cfg, ctx: params.ctx, command, sessionKey: params.sessionKey },
     shouldHandleTextCommands({
       cfg: params.cfg,
       surface: command.surface,

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -462,7 +462,7 @@ export class ExecApprovalManager<
 
   /** Settle one durable terminal transition and report whether this manager published it. */
   reconcileDurableTerminal(record: OperatorApprovalRecord): boolean {
-    return this.settleLocalFromStore(record);
+    return this.settleLocalFromStore(record, undefined, record.resolver?.id ?? null);
   }
 
   /** Reconciles durable truth with an existing waiter without rehydrating its request. */

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -86,6 +86,8 @@ const CORE_GATEWAY_METHOD_SPECS = [
   ["question.get", null, "operator.questions", "2026.7"],
   ["question.list", null, "operator.questions", "2026.7"],
   ["plugin.approval.list", null, "operator.approvals", "<=2026.7"],
+  ["plugin.approval.external.prepare", null, "operator.approvals", "2026.8"],
+  ["plugin.approval.external.start", null, "operator.approvals", "2026.8"],
   ["plugin.approval.request", null, "operator.approvals", "<=2026.7"],
   ["plugin.approval.waitDecision", null, "operator.approvals", "<=2026.7"],
   ["plugin.approval.resolve", null, "operator.approvals", "<=2026.7"],

--- a/src/gateway/operator-approval-authorization.ts
+++ b/src/gateway/operator-approval-authorization.ts
@@ -21,6 +21,19 @@ function normalizeIdentities(values: readonly string[] | null | undefined): stri
   return [...normalized];
 }
 
+/** Whether one device identity satisfies an approval's optional reviewer binding. */
+export function isOperatorApprovalReviewerAuthorized(params: {
+  reviewerDeviceId?: string | null;
+  reviewerDeviceIds?: readonly string[] | null;
+}): boolean {
+  const reviewerDeviceIds = normalizeIdentities(params.reviewerDeviceIds);
+  if (reviewerDeviceIds.length === 0) {
+    return true;
+  }
+  const reviewerDeviceId = normalizeIdentity(params.reviewerDeviceId);
+  return Boolean(reviewerDeviceId && reviewerDeviceIds.includes(reviewerDeviceId));
+}
+
 /** Whether a client may inspect safe approval projections. */
 export function canReviewOperatorApproval(client: GatewayClient | null): boolean {
   const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
@@ -64,10 +77,13 @@ export function canAccessOperatorApproval(params: {
     return true;
   }
 
-  const clientDeviceId = normalizeIdentity(params.client?.connect?.device?.id);
-  const reviewerDeviceIds = normalizeIdentities(params.binding.reviewerDeviceIds);
-  if (reviewerDeviceIds.length > 0) {
-    return Boolean(clientDeviceId && reviewerDeviceIds.includes(clientDeviceId));
+  if (
+    !isOperatorApprovalReviewerAuthorized({
+      reviewerDeviceId: params.client?.connect?.device?.id,
+      reviewerDeviceIds: params.binding.reviewerDeviceIds,
+    })
+  ) {
+    return false;
   }
 
   // No explicit reviewer binding: the operator.approvals scope tier is the

--- a/src/gateway/operator-approval-store.ts
+++ b/src/gateway/operator-approval-store.ts
@@ -424,6 +424,22 @@ function hasValidLifecycleTuple(params: {
   );
 }
 
+function presentationAllowsDecision(
+  presentation: ApprovalPresentation,
+  decision: OperatorApprovalDecision,
+): boolean {
+  if (Array.prototype.includes.call(presentation.allowedDecisions, decision)) {
+    return true;
+  }
+  // External allow decisions are intentionally absent from the generic resolver surface.
+  // Only the plugin-bound completion transaction may authorize one.
+  return (
+    presentation.kind === "plugin" &&
+    (decision === "allow-once" || decision === "allow-always") &&
+    presentation.externalResolution?.decisions.includes(decision) === true
+  );
+}
+
 function decodeOperatorApprovalRow(row: OperatorApprovalRow): OperatorApprovalRecord | null {
   const presentation = parseApprovalPresentation(row.presentation_json);
   const reviewerDeviceIds = parseStringArray(row.reviewer_device_ids_json);
@@ -468,8 +484,7 @@ function decodeOperatorApprovalRow(row: OperatorApprovalRow): OperatorApprovalRe
     row.resolution_ref !==
       buildApprovalResolutionRef({ approvalId: row.approval_id, approvalKind: kind }) ||
     !hasValidLifecycleTuple({ row, status, decision, terminalReason, resolverKind }) ||
-    (status === "allowed" &&
-      (!decision || !Array.prototype.includes.call(presentation.allowedDecisions, decision)))
+    (status === "allowed" && (!decision || !presentationAllowsDecision(presentation, decision)))
   ) {
     return null;
   }

--- a/src/gateway/plugin-external-verification-runtime.native-actions.test.ts
+++ b/src/gateway/plugin-external-verification-runtime.native-actions.test.ts
@@ -1,0 +1,420 @@
+import fs from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resolveCanonicalPluginApprovalRequestAllowedDecisions } from "../infra/plugin-approval-canonical-decisions.js";
+import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
+import type { PluginExternalVerificationAttempt } from "../plugins/external-verification-approval-types.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { markPluginRegistryRetired } from "../plugins/registry-lifecycle.js";
+import type { PluginExternalApprovalVerifierRegistration } from "../plugins/registry-types.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import { ExecApprovalManager } from "./exec-approval-manager.js";
+import { getOperatorApprovalDetailed } from "./operator-approval-store.js";
+import { PluginExternalVerificationRuntime } from "./plugin-external-verification-runtime.js";
+
+let runtime: PluginExternalVerificationRuntime | null = null;
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+  afterEach(() => {
+    runtime?.shutdown();
+    runtime = null;
+    closeOpenClawStateDatabaseForTest();
+    vi.restoreAllMocks();
+    cleanup();
+  });
+});
+
+function createDatabaseOptions(): OpenClawStateDatabaseOptions {
+  const stateDir = fs.realpathSync(tempDirs.make("openclaw-external-runtime-"));
+  return { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
+}
+
+function createHarness(
+  handler: (attempt: PluginExternalVerificationAttempt) => void | Promise<void>,
+  options?: {
+    publishResolution?: ConstructorParameters<
+      typeof PluginExternalVerificationRuntime
+    >[0]["publishResolution"];
+    resolveVerifier?: ConstructorParameters<
+      typeof PluginExternalVerificationRuntime
+    >[0]["resolveVerifier"];
+  },
+) {
+  const databaseOptions = createDatabaseOptions();
+  const runtimeEpoch = "runtime-external";
+  const owner = {};
+  const verifier: PluginExternalApprovalVerifierRegistration = {
+    pluginId: "agentkit",
+    pluginName: "AgentKit",
+    owner,
+    handler,
+    source: "/plugins/agentkit/index.js",
+  };
+  const verifierRegistry = createEmptyPluginRegistry();
+  verifierRegistry.externalApprovalVerifiers.push(verifier);
+  let activeVerifier: PluginExternalApprovalVerifierRegistration | null = verifier;
+  const manager = new ExecApprovalManager<PluginApprovalRequestPayload>({
+    approvalKind: "plugin",
+    persistence: { runtimeEpoch, databaseOptions },
+    resolveAllowedDecisions: resolveCanonicalPluginApprovalRequestAllowedDecisions,
+    onLifecycle: (event) => runtime?.onApprovalLifecycle(event),
+  });
+  runtime = new PluginExternalVerificationRuntime({
+    manager,
+    runtimeEpoch,
+    databaseOptions,
+    ...(options?.publishResolution ? { publishResolution: options.publishResolution } : {}),
+    resolveVerifier:
+      options?.resolveVerifier ??
+      ((pluginId) => (pluginId === verifier.pluginId ? activeVerifier : null)),
+  });
+  const request: PluginApprovalRequestPayload = {
+    pluginId: "agentkit",
+    title: "World verification",
+    description: "Verify personhood before continuing.",
+    toolName: "dangerous-tool",
+    toolCallId: "call-1",
+    agentId: "main",
+    sessionKey: "agent:main:main",
+    sessionId: "session-1",
+    runId: "run-1",
+    externalResolution: {
+      label: "Verify with World",
+      decisions: ["allow-once", "allow-always"],
+    },
+  };
+  const record = manager.create(request, 60_000, "plugin:runtime-approval");
+  const decision = manager.register(record, 60_000);
+  return {
+    databaseOptions,
+    decision,
+    manager,
+    owner,
+    retireVerifier: () => {
+      activeVerifier = null;
+      markPluginRegistryRetired(verifierRegistry);
+    },
+    setVerifier: (next: PluginExternalApprovalVerifierRegistration | null) => {
+      activeVerifier = next;
+    },
+  };
+}
+
+function readApproval(databaseOptions: OpenClawStateDatabaseOptions) {
+  const lookup = getOperatorApprovalDetailed({
+    id: "plugin:runtime-approval",
+    databaseOptions,
+  });
+  return lookup.outcome === "found" ? lookup.record : null;
+}
+
+describe("PluginExternalVerificationRuntime native actions", () => {
+  it("issues stable native action generations and rejects stale retry replacement", async () => {
+    const handler = vi.fn(async (attempt: PluginExternalVerificationAttempt) => {
+      await attempt.present({ message: `Verify attempt ${attempt.id}.` });
+    });
+    createHarness(handler);
+
+    const firstAction = runtime!.prepareNativeAction({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+    });
+    expect(
+      runtime!.prepareNativeAction({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+      }),
+    ).toEqual(firstAction);
+    expect(firstAction.intent).toBe("start");
+
+    const first = await runtime!.dispatchNativeAction({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      token: firstAction.token,
+    });
+    const replay = await runtime!.dispatchNativeAction({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      token: firstAction.token,
+    });
+    expect(replay).toEqual({ ...first, outcome: "replay" });
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    await expect(
+      runtime!.dispatchNativeAction({
+        approvalId: "plugin:other",
+        decision: "allow-once",
+        token: firstAction.token,
+      }),
+    ).rejects.toThrow("external verification action is invalid");
+    await expect(
+      runtime!.dispatchNativeAction({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-always",
+        token: firstAction.token,
+      }),
+    ).rejects.toThrow("external verification action is invalid");
+
+    const retryAction = runtime!.prepareNativeAction({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+    });
+    expect(retryAction.intent).toBe("retry");
+    expect(retryAction.token).not.toBe(firstAction.token);
+
+    const newer = await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      interactionId: "f".repeat(64),
+      present: async () => undefined,
+    });
+    await expect(
+      runtime!.dispatchNativeAction({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        token: firstAction.token,
+      }),
+    ).resolves.toMatchObject({
+      outcome: "stale-action",
+      attempt: { id: newer.id },
+      presentations: [`Verify attempt ${newer.id}.`],
+    });
+    const staleRetry = await runtime!.dispatchNativeAction({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      token: retryAction.token,
+    });
+    expect(staleRetry).toMatchObject({
+      outcome: "stale-action",
+      attempt: { id: newer.id },
+      presentations: [`Verify attempt ${newer.id}.`],
+    });
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it("binds native action tokens and presentation replay to one reviewer device", async () => {
+    const handler = vi.fn(async (attempt: PluginExternalVerificationAttempt) => {
+      await attempt.present({ message: `Verify attempt ${attempt.id}.` });
+    });
+    createHarness(handler);
+
+    const deviceAAction = runtime!.prepareNativeAction({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      reviewerDeviceId: "device-a",
+    });
+    expect(
+      runtime!.prepareNativeAction({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        reviewerDeviceId: "device-a",
+      }),
+    ).toEqual(deviceAAction);
+    const deviceBAction = runtime!.prepareNativeAction({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      reviewerDeviceId: "device-b",
+    });
+    expect(deviceBAction.token).not.toBe(deviceAAction.token);
+
+    await expect(
+      runtime!.dispatchNativeAction({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        reviewerDeviceId: "device-b",
+        token: deviceAAction.token,
+      }),
+    ).rejects.toThrow("external verification action is invalid");
+
+    const started = await runtime!.dispatchNativeAction({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      reviewerDeviceId: "device-a",
+      token: deviceAAction.token,
+    });
+    await expect(
+      runtime!.dispatchNativeAction({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        reviewerDeviceId: "device-b",
+        token: deviceBAction.token,
+      }),
+    ).resolves.toMatchObject({
+      outcome: "stale-action",
+      attempt: { id: started.attempt.id },
+      presentations: [],
+    });
+    await expect(
+      runtime!.dispatchNativeAction({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        reviewerDeviceId: "device-a",
+        token: deviceAAction.token,
+      }),
+    ).resolves.toEqual({ ...started, outcome: "replay" });
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a stale weaker native action after a stronger attempt starts", async () => {
+    const handler = vi.fn(async (attempt: PluginExternalVerificationAttempt) => {
+      await attempt.present({ message: `Verify attempt ${attempt.id}.` });
+    });
+    const { databaseOptions } = createHarness(handler);
+    const weakerAction = runtime!.prepareNativeAction({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+    });
+    await runtime!.dispatchNativeAction({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      token: weakerAction.token,
+    });
+    const stronger = await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-always",
+      interactionId: "f".repeat(64),
+      present: async () => undefined,
+    });
+
+    await expect(
+      runtime!.dispatchNativeAction({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        token: weakerAction.token,
+      }),
+    ).rejects.toThrow("external verification action is stale; prepare a fresh action");
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(readApproval(databaseOptions)).toMatchObject({ status: "pending" });
+    expect(stronger.context.decision).toBe("allow-always");
+  });
+
+  it("coalesces concurrent native dispatches until every presentation is ready", async () => {
+    let releaseSetup = () => {};
+    const setupGate = new Promise<void>((resolve) => {
+      releaseSetup = resolve;
+    });
+    let signalFirstPresentation = () => {};
+    const firstPresentation = new Promise<void>((resolve) => {
+      signalFirstPresentation = resolve;
+    });
+    const handler = vi.fn(async (attempt: PluginExternalVerificationAttempt) => {
+      await attempt.present({ message: "First reviewer instruction." });
+      signalFirstPresentation();
+      await setupGate;
+      await attempt.present({ message: "Second reviewer instruction." });
+    });
+    createHarness(handler);
+    const action = runtime!.prepareNativeAction({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+    });
+
+    const firstDispatch = runtime!.dispatchNativeAction({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      token: action.token,
+    });
+    await firstPresentation;
+    let replaySettled = false;
+    const replayDispatch = runtime!
+      .dispatchNativeAction({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        token: action.token,
+      })
+      .finally(() => {
+        replaySettled = true;
+      });
+    await Promise.resolve();
+    expect(replaySettled).toBe(false);
+
+    releaseSetup();
+    const [first, replay] = await Promise.all([firstDispatch, replayDispatch]);
+    expect(first).toMatchObject({
+      outcome: "started",
+      presentations: ["First reviewer instruction.", "Second reviewer instruction."],
+    });
+    expect(replay).toEqual({ ...first, outcome: "replay" });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays a native setup failure without reporting an empty success", async () => {
+    let invocation = 0;
+    const handler = vi.fn(() => {
+      invocation += 1;
+      throw new Error(`setup failed ${invocation}`);
+    });
+    const { databaseOptions } = createHarness(handler);
+    const action = runtime!.prepareNativeAction({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+    });
+    const dispatch = () =>
+      runtime!.dispatchNativeAction({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        token: action.token,
+      });
+
+    await expect(dispatch()).rejects.toThrow("setup failed 1");
+    await expect(dispatch()).resolves.toMatchObject({
+      outcome: "replay",
+      presentations: [],
+      attempt: {
+        outcome: "failed",
+        terminalSource: "verifier-error",
+      },
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(readApproval(databaseOptions)).toMatchObject({ status: "pending" });
+
+    const retry = runtime!.prepareNativeAction({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+    });
+    expect(retry.token).not.toBe(action.token);
+    await expect(
+      runtime!.dispatchNativeAction({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        token: retry.token,
+      }),
+    ).rejects.toThrow("setup failed 2");
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates a prepared native action when the registered verifier instance changes", async () => {
+    const handler = vi.fn(async (attempt: PluginExternalVerificationAttempt) => {
+      await attempt.present({ message: "Verify this attempt." });
+    });
+    const { setVerifier } = createHarness(handler);
+    const prepared = runtime!.prepareNativeAction({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+    });
+    setVerifier({
+      pluginId: "agentkit",
+      pluginName: "Replacement AgentKit",
+      owner: {},
+      handler,
+      source: "/plugins/agentkit/replacement.js",
+    });
+
+    await expect(
+      runtime!.dispatchNativeAction({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        token: prepared.token,
+      }),
+    ).rejects.toThrow("external verification action is invalid");
+    expect(handler).not.toHaveBeenCalled();
+    expect(
+      runtime!.prepareNativeAction({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+      }).token,
+    ).not.toBe(prepared.token);
+  });
+});

--- a/src/gateway/plugin-external-verification-runtime.test.ts
+++ b/src/gateway/plugin-external-verification-runtime.test.ts
@@ -1,0 +1,787 @@
+import fs from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resolveCanonicalPluginApprovalRequestAllowedDecisions } from "../infra/plugin-approval-canonical-decisions.js";
+import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
+import { completeExternalVerificationForPlugin } from "../plugins/external-verification-approval-runtime-state.js";
+import type { PluginExternalVerificationAttempt } from "../plugins/external-verification-approval-types.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { markPluginRegistryRetired } from "../plugins/registry-lifecycle.js";
+import type { PluginExternalApprovalVerifierRegistration } from "../plugins/registry-types.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import { ExecApprovalManager } from "./exec-approval-manager.js";
+import { getOperatorApprovalDetailed } from "./operator-approval-store.js";
+import { PluginExternalVerificationRuntime } from "./plugin-external-verification-runtime.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
+
+let runtime: PluginExternalVerificationRuntime | null = null;
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+  afterEach(() => {
+    runtime?.shutdown();
+    runtime = null;
+    closeOpenClawStateDatabaseForTest();
+    vi.restoreAllMocks();
+    cleanup();
+  });
+});
+
+function createDatabaseOptions(): OpenClawStateDatabaseOptions {
+  const stateDir = fs.realpathSync(tempDirs.make("openclaw-external-runtime-"));
+  return { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
+}
+
+function createHarness(
+  handler: (attempt: PluginExternalVerificationAttempt) => void | Promise<void>,
+  options?: {
+    publishResolution?: ConstructorParameters<
+      typeof PluginExternalVerificationRuntime
+    >[0]["publishResolution"];
+    resolveVerifier?: ConstructorParameters<
+      typeof PluginExternalVerificationRuntime
+    >[0]["resolveVerifier"];
+  },
+) {
+  const databaseOptions = createDatabaseOptions();
+  const runtimeEpoch = "runtime-external";
+  const owner = {};
+  const verifier: PluginExternalApprovalVerifierRegistration = {
+    pluginId: "agentkit",
+    pluginName: "AgentKit",
+    owner,
+    handler,
+    source: "/plugins/agentkit/index.js",
+  };
+  const verifierRegistry = createEmptyPluginRegistry();
+  verifierRegistry.externalApprovalVerifiers.push(verifier);
+  let activeVerifier: PluginExternalApprovalVerifierRegistration | null = verifier;
+  const manager = new ExecApprovalManager<PluginApprovalRequestPayload>({
+    approvalKind: "plugin",
+    persistence: { runtimeEpoch, databaseOptions },
+    resolveAllowedDecisions: resolveCanonicalPluginApprovalRequestAllowedDecisions,
+    onLifecycle: (event) => runtime?.onApprovalLifecycle(event),
+  });
+  runtime = new PluginExternalVerificationRuntime({
+    manager,
+    runtimeEpoch,
+    databaseOptions,
+    ...(options?.publishResolution ? { publishResolution: options.publishResolution } : {}),
+    resolveVerifier:
+      options?.resolveVerifier ??
+      ((pluginId) => (pluginId === verifier.pluginId ? activeVerifier : null)),
+  });
+  const request: PluginApprovalRequestPayload = {
+    pluginId: "agentkit",
+    title: "World verification",
+    description: "Verify personhood before continuing.",
+    toolName: "dangerous-tool",
+    toolCallId: "call-1",
+    agentId: "main",
+    sessionKey: "agent:main:main",
+    sessionId: "session-1",
+    runId: "run-1",
+    externalResolution: {
+      label: "Verify with World",
+      decisions: ["allow-once", "allow-always"],
+    },
+  };
+  const record = manager.create(request, 60_000, "plugin:runtime-approval");
+  const decision = manager.register(record, 60_000);
+  return {
+    databaseOptions,
+    decision,
+    manager,
+    owner,
+    retireVerifier: () => {
+      activeVerifier = null;
+      markPluginRegistryRetired(verifierRegistry);
+    },
+    setVerifier: (next: PluginExternalApprovalVerifierRegistration | null) => {
+      activeVerifier = next;
+    },
+  };
+}
+
+function readApproval(databaseOptions: OpenClawStateDatabaseOptions) {
+  const lookup = getOperatorApprovalDetailed({
+    id: "plugin:runtime-approval",
+    databaseOptions,
+  });
+  return lookup.outcome === "found" ? lookup.record : null;
+}
+
+describe("PluginExternalVerificationRuntime", () => {
+  it("dispatches one immutable attempt and replays the same reviewer interaction", async () => {
+    const attempts: PluginExternalVerificationAttempt[] = [];
+    const handler = vi.fn(async (attempt: PluginExternalVerificationAttempt) => {
+      attempts.push(attempt);
+      await attempt.present({ message: "Open the verifier and complete the World proof." });
+    });
+    const { owner, decision } = createHarness(handler);
+    const firstPresent = vi.fn(async () => undefined);
+    const replayPresent = vi.fn(async () => undefined);
+
+    const first = await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-always",
+      interactionId: "a".repeat(64),
+      present: firstPresent,
+    });
+    const replay = await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-always",
+      interactionId: "a".repeat(64),
+      present: replayPresent,
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(firstPresent).toHaveBeenCalledWith("Open the verifier and complete the World proof.");
+    expect(replayPresent).toHaveBeenCalledWith("Open the verifier and complete the World proof.");
+    expect(replay).toEqual(first);
+    expect(attempts[0]).toMatchObject({
+      context: {
+        approvalId: "plugin:runtime-approval",
+        pluginId: "agentkit",
+        runId: "run-1",
+        toolName: "dangerous-tool",
+        toolCallId: "call-1",
+        sessionId: "session-1",
+        decision: "allow-always",
+      },
+    });
+    expect(Object.isFrozen(attempts[0])).toBe(true);
+    expect(Object.isFrozen(attempts[0]?.context)).toBe(true);
+
+    const completed = await runtime!.complete(owner, "agentkit", {
+      attemptId: first.id,
+      outcome: "succeeded",
+    });
+    expect(completed).toMatchObject({
+      applied: true,
+      attempt: { id: first.id, outcome: "succeeded" },
+      approval: { status: "allowed", decision: "allow-always" },
+      grantAuthorization: { approvalId: "plugin:runtime-approval", attemptId: first.id },
+    });
+    await expect(
+      runtime!.complete(owner, "agentkit", {
+        attemptId: first.id,
+        outcome: "succeeded",
+      }),
+    ).resolves.toEqual({ ...completed, applied: false });
+    await expect(decision).resolves.toBe("allow-always");
+  });
+
+  it("expires through the manager before replaying a delayed reviewer interaction", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    let attempt: PluginExternalVerificationAttempt | undefined;
+    const { databaseOptions, decision } = createHarness(async (value) => {
+      attempt = value;
+      await value.present({ message: "Verify now." });
+    });
+    const firstPresent = vi.fn(async () => undefined);
+    await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      present: firstPresent,
+    });
+    now.mockReturnValue(61_000);
+    const replayPresent = vi.fn(async () => undefined);
+
+    await expect(
+      runtime!.start({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        present: replayPresent,
+      }),
+    ).resolves.toMatchObject({
+      outcome: "timed-out",
+      terminalSource: "timeout",
+    });
+
+    expect(firstPresent).toHaveBeenCalledOnce();
+    expect(replayPresent).not.toHaveBeenCalled();
+    expect(attempt?.signal.aborted).toBe(true);
+    expect(readApproval(databaseOptions)).toMatchObject({
+      status: "expired",
+      terminalReason: "timeout",
+    });
+    await expect(decision).resolves.toBeNull();
+  });
+
+  it("expires through the manager when a verifier completes after the deadline", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    let attempt: PluginExternalVerificationAttempt | undefined;
+    const { databaseOptions, owner, decision } = createHarness(async (value) => {
+      attempt = value;
+      await value.present({ message: "Verify now." });
+    });
+    const started = await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-always",
+      interactionId: "a".repeat(64),
+      present: async () => undefined,
+    });
+    now.mockReturnValue(61_000);
+
+    await expect(
+      runtime!.complete(owner, "agentkit", {
+        attemptId: started.id,
+        outcome: "succeeded",
+      }),
+    ).resolves.toMatchObject({
+      applied: false,
+      approval: { status: "expired" },
+      attempt: { outcome: "timed-out", terminalSource: "timeout" },
+    });
+    expect(attempt?.signal.aborted).toBe(true);
+    expect(readApproval(databaseOptions)).toMatchObject({
+      status: "expired",
+      terminalReason: "timeout",
+    });
+    await expect(decision).resolves.toBeNull();
+  });
+
+  it("keeps the approval pending when the verifier fails before presenting instructions", async () => {
+    const { databaseOptions } = createHarness(() => undefined);
+
+    await expect(
+      runtime!.start({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        present: async () => undefined,
+      }),
+    ).rejects.toThrow("returned without presenting reviewer instructions");
+    expect(readApproval(databaseOptions)).toMatchObject({ status: "pending" });
+  });
+
+  it("returns a durable setup failure without replaying its closed presentation", async () => {
+    const handler = vi.fn(async (attempt: PluginExternalVerificationAttempt) => {
+      await attempt.present({ message: "Verify this request." });
+      throw new Error("setup failed");
+    });
+    createHarness(handler);
+
+    await expect(
+      runtime!.start({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        present: async () => undefined,
+      }),
+    ).rejects.toThrow("external verifier failed: setup failed");
+    const replayPresent = vi.fn(async () => undefined);
+    await expect(
+      runtime!.start({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        present: replayPresent,
+      }),
+    ).resolves.toMatchObject({
+      outcome: "failed",
+      terminalSource: "verifier-error",
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(replayPresent).not.toHaveBeenCalled();
+  });
+
+  it("durably fails an attempt when verifier lookup throws", async () => {
+    createHarness(() => undefined, {
+      resolveVerifier: () => {
+        const error = new Error("registry unavailable");
+        Object.defineProperty(error, "name", { value: 42 });
+        throw error;
+      },
+    });
+
+    await expect(
+      runtime!.start({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        present: async () => undefined,
+      }),
+    ).rejects.toThrow("external verifier lookup failed: registry unavailable");
+    await expect(
+      runtime!.start({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        present: async () => undefined,
+      }),
+    ).resolves.toMatchObject({
+      errorClass: "unknown-error",
+      outcome: "failed",
+      terminalSource: "verifier-error",
+    });
+  });
+
+  it("does not count reviewer instructions when delivery fails and the verifier swallows it", async () => {
+    const { databaseOptions } = createHarness(async (attempt) => {
+      try {
+        await attempt.present({ message: "Verify now." });
+      } catch {}
+    });
+
+    await expect(
+      runtime!.start({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        present: async () => {
+          throw new Error("delivery failed");
+        },
+      }),
+    ).rejects.toThrow("returned without presenting reviewer instructions");
+    expect(readApproval(databaseOptions)).toMatchObject({ status: "pending" });
+  });
+
+  it("bounds concurrent reviewer presentations to the native response contract", async () => {
+    const { databaseOptions } = createHarness(async (attempt) => {
+      await Promise.all(
+        Array.from({ length: 9 }, (_, index) =>
+          attempt.present({ message: `Reviewer message ${index + 1}.` }),
+        ),
+      );
+    });
+
+    await expect(
+      runtime!.start({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        present: async () => undefined,
+      }),
+    ).rejects.toThrow("may present at most 8 reviewer messages");
+    expect(readApproval(databaseOptions)).toMatchObject({ status: "pending" });
+  });
+
+  it("rejects completion from a stale plugin instance", async () => {
+    const { owner, databaseOptions } = createHarness(async (attempt) => {
+      await attempt.present({ message: "Verify now." });
+    });
+    const started = await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-always",
+      interactionId: "a".repeat(64),
+      present: async () => undefined,
+    });
+
+    await expect(
+      runtime!.complete({}, "agentkit", {
+        attemptId: started.id,
+        outcome: "succeeded",
+      }),
+    ).rejects.toThrow("not found for this plugin instance");
+    expect(readApproval(databaseOptions)).toMatchObject({ status: "pending" });
+
+    await expect(
+      runtime!.complete(owner, "agentkit", {
+        attemptId: started.id,
+        outcome: "failed",
+      }),
+    ).resolves.toMatchObject({ applied: false, attempt: { outcome: "failed" } });
+  });
+
+  it("revokes presentation and aborts the attempt when its verifier registry retires", async () => {
+    let attempt: PluginExternalVerificationAttempt | undefined;
+    const { retireVerifier } = createHarness(async (value) => {
+      attempt = value;
+      await value.present({ message: "Verify now." });
+    });
+    const started = await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      present: async () => undefined,
+    });
+
+    retireVerifier();
+
+    expect(attempt?.signal.aborted).toBe(true);
+    await expect(attempt?.present({ message: "stale verifier output" })).rejects.toThrow(
+      "verifier-retired",
+    );
+    await expect(
+      runtime!.start({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        present: async () => undefined,
+      }),
+    ).resolves.toMatchObject({
+      id: started.id,
+      outcome: "cancelled",
+      terminalSource: "verifier-retired",
+    });
+  });
+
+  it("revokes the prior attempt before a retry reports a missing verifier", async () => {
+    let attempt: PluginExternalVerificationAttempt | undefined;
+    const { setVerifier } = createHarness(async (value) => {
+      attempt = value;
+      await value.present({ message: "Verify now." });
+    });
+    await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      present: async () => undefined,
+    });
+    setVerifier(null);
+
+    await expect(
+      runtime!.start({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        interactionId: "b".repeat(64),
+        present: async () => undefined,
+      }),
+    ).rejects.toThrow("has no active external verifier");
+    expect(attempt?.signal.aborted).toBe(true);
+    await expect(attempt?.present({ message: "stale retry output" })).rejects.toThrow(
+      "reviewer-retry",
+    );
+  });
+
+  it("rejects completion before the verifier presents reviewer instructions", async () => {
+    let earlyCompletion: Promise<unknown> | undefined;
+    const harness = createHarness(async (attempt) => {
+      earlyCompletion = runtime!.complete(owner, "agentkit", {
+        attemptId: attempt.id,
+        outcome: "succeeded",
+      });
+      await expect(earlyCompletion).rejects.toThrow("before reviewer presentation finishes");
+      await attempt.present({ message: "Verify now." });
+    });
+    const owner = harness.owner;
+
+    const started = await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      present: async () => undefined,
+    });
+
+    await expect(earlyCompletion).rejects.toThrow("before reviewer presentation finishes");
+    expect(readApproval(harness.databaseOptions)).toMatchObject({ status: "pending" });
+    await expect(
+      runtime!.complete(owner, "agentkit", {
+        attemptId: started.id,
+        outcome: "succeeded",
+      }),
+    ).resolves.toMatchObject({ applied: true });
+  });
+
+  it("accepts an immediately resolved verifier after presentation", async () => {
+    let completion: Promise<unknown> | undefined;
+    const harness = createHarness(async (attempt) => {
+      await attempt.present({ message: "Verify now." });
+      completion = runtime!.complete(owner, "agentkit", {
+        attemptId: attempt.id,
+        outcome: "succeeded",
+      });
+      await expect(completion).resolves.toMatchObject({ applied: true });
+    });
+    const owner = harness.owner;
+
+    const started = await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      present: async () => undefined,
+    });
+
+    await expect(completion).resolves.toMatchObject({ applied: true });
+    expect(started).toMatchObject({ outcome: "succeeded", terminalSource: "plugin-completion" });
+    expect(readApproval(harness.databaseOptions)).toMatchObject({
+      status: "allowed",
+      decision: "allow-once",
+    });
+  });
+
+  it("cancels the canonical approval and aborts the handler on graceful shutdown", async () => {
+    let signal: AbortSignal | undefined;
+    let abortCompletion: ReturnType<typeof completeExternalVerificationForPlugin> | undefined;
+    const harness = createHarness(async (attempt) => {
+      signal = attempt.signal;
+      attempt.signal.addEventListener(
+        "abort",
+        () => {
+          abortCompletion = completeExternalVerificationForPlugin(owner, "agentkit", {
+            attemptId: attempt.id,
+            outcome: "succeeded",
+          });
+        },
+        { once: true },
+      );
+      await attempt.present({ message: "Verify now." });
+    });
+    const owner = harness.owner;
+    await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      present: async () => undefined,
+    });
+
+    runtime!.shutdown();
+    runtime = null;
+
+    expect(signal?.aborted).toBe(true);
+    expect(readApproval(harness.databaseOptions)).toMatchObject({
+      status: "cancelled",
+      terminalReason: "gateway-restart",
+    });
+    await expect(abortCompletion).resolves.toMatchObject({
+      applied: false,
+      approval: { status: "cancelled" },
+      attempt: { outcome: "cancelled" },
+    });
+    await expect(harness.decision).resolves.toBeNull();
+  });
+
+  it("aborts retry and run-cancelled attempts and permanently closes presentation", async () => {
+    const attempts: PluginExternalVerificationAttempt[] = [];
+    const { manager, owner, decision } = createHarness(async (attempt) => {
+      attempts.push(attempt);
+      await attempt.present({ message: "Verify now." });
+    });
+    await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      present: async () => undefined,
+    });
+    const second = await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-always",
+      interactionId: "b".repeat(64),
+      present: async () => undefined,
+    });
+
+    expect(attempts[0]?.signal.aborted).toBe(true);
+    await expect(attempts[0]?.present({ message: "stale retry output" })).rejects.toThrow(
+      "reviewer-retry",
+    );
+    expect(
+      manager.forceDenyDetailed(
+        "plugin:runtime-approval",
+        "run-aborted",
+        { kind: "system", id: null },
+        "cancelled",
+      ),
+    ).toMatchObject({ outcome: "denied", record: { status: "cancelled" } });
+    expect(attempts[1]?.signal.aborted).toBe(true);
+    await expect(attempts[1]?.present({ message: "stale cancelled output" })).rejects.toThrow(
+      "run-aborted",
+    );
+    await expect(
+      runtime!.complete(owner, "agentkit", {
+        attemptId: second.id,
+        outcome: "succeeded",
+      }),
+    ).resolves.toMatchObject({
+      applied: false,
+      attempt: { outcome: "cancelled", terminalSource: "run-aborted" },
+    });
+    await expect(decision).resolves.toBeNull();
+  });
+
+  it.each([
+    {
+      name: "normal denial",
+      decision: "deny",
+      terminalSource: "user",
+      terminate: (manager: ExecApprovalManager<PluginApprovalRequestPayload>) =>
+        manager.resolveDetailed(
+          "plugin:runtime-approval",
+          "deny",
+          { kind: "channel", id: "telegram:owner" },
+          "telegram:owner",
+        ),
+    },
+    {
+      name: "expiry",
+      decision: null,
+      terminalSource: "timeout",
+      terminate: (manager: ExecApprovalManager<PluginApprovalRequestPayload>) =>
+        manager.expire("plugin:runtime-approval"),
+    },
+  ])(
+    "aborts and closes presentation after $name",
+    async ({ decision: expectedDecision, terminalSource, terminate }) => {
+      let attempt: PluginExternalVerificationAttempt | undefined;
+      const { manager, decision } = createHarness(async (value) => {
+        attempt = value;
+        await value.present({ message: "Verify now." });
+      });
+      await runtime!.start({
+        approvalId: "plugin:runtime-approval",
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        present: async () => undefined,
+      });
+
+      terminate(manager);
+
+      expect(attempt?.signal.aborted).toBe(true);
+      await expect(attempt?.present({ message: "stale terminal output" })).rejects.toThrow(
+        terminalSource,
+      );
+      await expect(decision).resolves.toBe(expectedDecision);
+    },
+  );
+
+  it("keeps a winning grant when completion commits before a later run cancellation", async () => {
+    const { manager, owner, decision } = createHarness(async (attempt) => {
+      await attempt.present({ message: "Verify now." });
+    });
+    const started = await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-always",
+      interactionId: "a".repeat(64),
+      present: async () => undefined,
+    });
+    const completed = await runtime!.complete(owner, "agentkit", {
+      attemptId: started.id,
+      outcome: "succeeded",
+    });
+
+    expect(completed).toMatchObject({
+      applied: true,
+      approval: { status: "allowed", decision: "allow-always" },
+      grantAuthorization: { attemptId: started.id, decision: "allow-always" },
+    });
+    expect(
+      manager.forceDenyDetailed(
+        "plugin:runtime-approval",
+        "run-aborted",
+        { kind: "system", id: null },
+        "cancelled",
+      ),
+    ).toMatchObject({ outcome: "already-terminal", record: { status: "allowed" } });
+    await expect(
+      runtime!.complete(owner, "agentkit", {
+        attemptId: started.id,
+        outcome: "succeeded",
+      }),
+    ).resolves.toEqual({ ...completed, applied: false });
+    await expect(decision).resolves.toBe("allow-always");
+  });
+
+  it("returns durable grant authorization when post-commit publication fails", async () => {
+    const publishResolution = vi.fn(async () => {
+      throw new Error("push unavailable");
+    });
+    const { owner, decision, databaseOptions } = createHarness(
+      async (attempt) => {
+        await attempt.present({ message: "Verify now." });
+      },
+      { publishResolution },
+    );
+    const logError = vi.fn();
+    runtime!.attachContext({
+      getRuntimeConfig: () => ({}),
+      logGateway: { error: logError },
+    } as unknown as GatewayRequestContext);
+    const started = await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-always",
+      interactionId: "a".repeat(64),
+      present: async () => undefined,
+    });
+
+    await expect(
+      runtime!.complete(owner, "agentkit", {
+        attemptId: started.id,
+        outcome: "succeeded",
+      }),
+    ).resolves.toMatchObject({
+      applied: true,
+      approval: { status: "allowed", decision: "allow-always" },
+      grantAuthorization: { attemptId: started.id, decision: "allow-always" },
+    });
+    expect(publishResolution).toHaveBeenCalledTimes(1);
+    expect(publishResolution).toHaveBeenCalledWith(
+      expect.objectContaining({
+        liveRecord: expect.objectContaining({ resolvedBy: "plugin:agentkit" }),
+      }),
+    );
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining("publication failed after durable completion: push unavailable"),
+    );
+    expect(readApproval(databaseOptions)).toMatchObject({
+      status: "allowed",
+      decision: "allow-always",
+    });
+    await expect(decision).resolves.toBe("allow-always");
+  });
+
+  it("cancels only run A when concurrent approvals share one session", async () => {
+    const attemptsByRun = new Map<string, PluginExternalVerificationAttempt>();
+    const { manager, owner, decision } = createHarness(async (attempt) => {
+      attemptsByRun.set(attempt.context.runId, attempt);
+      await attempt.present({ message: `Verify ${attempt.context.runId}.` });
+    });
+    const secondRequest: PluginApprovalRequestPayload = {
+      pluginId: "agentkit",
+      title: "Second World verification",
+      description: "Verify personhood before continuing.",
+      toolName: "dangerous-tool",
+      toolCallId: "call-2",
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      sessionId: "session-1",
+      runId: "run-2",
+      externalResolution: {
+        label: "Verify with World",
+        decisions: ["allow-once"],
+      },
+    };
+    const secondRecord = manager.create(secondRequest, 60_000, "plugin:runtime-approval-2");
+    const secondDecision = manager.register(secondRecord, 60_000);
+    const first = await runtime!.start({
+      approvalId: "plugin:runtime-approval",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      present: async () => undefined,
+    });
+    const second = await runtime!.start({
+      approvalId: "plugin:runtime-approval-2",
+      decision: "allow-once",
+      interactionId: "b".repeat(64),
+      present: async () => undefined,
+    });
+
+    expect(
+      manager.forceDenyDetailed(
+        "plugin:runtime-approval",
+        "run-aborted",
+        { kind: "system", id: null },
+        "cancelled",
+      ),
+    ).toMatchObject({ outcome: "denied" });
+    expect(attemptsByRun.get("run-1")?.signal.aborted).toBe(true);
+    expect(attemptsByRun.get("run-2")?.signal.aborted).toBe(false);
+    await expect(
+      runtime!.complete(owner, "agentkit", {
+        attemptId: second.id,
+        outcome: "succeeded",
+      }),
+    ).resolves.toMatchObject({ applied: true, approval: { status: "allowed" } });
+    await expect(
+      runtime!.complete(owner, "agentkit", {
+        attemptId: first.id,
+        outcome: "succeeded",
+      }),
+    ).resolves.toMatchObject({ applied: false, attempt: { outcome: "cancelled" } });
+    await expect(decision).resolves.toBeNull();
+    await expect(secondDecision).resolves.toBe("allow-once");
+  });
+});

--- a/src/gateway/plugin-external-verification-runtime.ts
+++ b/src/gateway/plugin-external-verification-runtime.ts
@@ -1,0 +1,690 @@
+// Gateway-lifetime dispatcher for plugin-bound external approval verification.
+import { createHash, randomUUID } from "node:crypto";
+import { formatErrorMessage } from "../infra/errors.js";
+import type { ExecApprovalForwarder } from "../infra/exec-approval-forwarder.js";
+import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
+import {
+  clearExternalVerificationCompletionRuntime,
+  setExternalVerificationCompletionRuntime,
+} from "../plugins/external-verification-approval-runtime-state.js";
+import type {
+  PluginExternalVerificationAttempt,
+  PluginExternalVerificationAttemptSnapshot,
+  PluginExternalVerificationCompletionResult,
+} from "../plugins/external-verification-approval-types.js";
+import { getPluginExternalApprovalVerifier } from "../plugins/hook-runner-global-state.js";
+import { onPluginRegistryLifecycleChange } from "../plugins/registry-lifecycle.js";
+import type { PluginExternalApprovalVerifierRegistration } from "../plugins/registry-types.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import { normalizeControlUiBasePath } from "./control-ui-shared.js";
+import type {
+  ExecApprovalManager,
+  OperatorApprovalLifecycleEvent,
+} from "./exec-approval-manager.js";
+import {
+  getOperatorApprovalDetailed,
+  type OperatorApprovalRecord,
+} from "./operator-approval-store.js";
+import {
+  cancelRetiredExternalVerificationAttempt,
+  completeExternalVerificationAttempt,
+  failExternalVerificationAttempt,
+  getExternalVerificationAttemptSnapshot,
+  getExternalVerificationNativeActionState,
+  startExternalVerificationAttempt,
+} from "./plugin-external-verification-store.js";
+import {
+  publishAppliedApprovalResolution,
+  type PluginApprovalIosPushDelivery,
+} from "./server-methods/approval-publication.js";
+import { buildApprovalSnapshot } from "./server-methods/approval.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
+
+const MAX_EXTERNAL_VERIFICATION_PRESENTATION_LENGTH = 8_192;
+const MAX_EXTERNAL_VERIFICATION_PRESENTATIONS = 8;
+const EXTERNAL_VERIFICATION_ERROR_CLASS_PATTERN = /^[A-Za-z][A-Za-z0-9._:-]{0,63}$/u;
+
+type PresentExternalVerification = (message: string) => Promise<void>;
+
+type LiveAttempt = {
+  approvalId: string;
+  controller: AbortController;
+  presentations: string[];
+  pluginId: string;
+  ready: boolean;
+  reviewerDeviceId?: string;
+  verifierOwner: object;
+};
+
+type AttemptSetup = {
+  approvalId: string;
+  presentations: string[];
+  reviewerDeviceId?: string;
+  promise: Promise<{
+    outcome: "started";
+    attempt: PluginExternalVerificationAttemptSnapshot;
+  }>;
+};
+
+type NativeAction = {
+  approvalId: string;
+  decision: "allow-once" | "allow-always";
+  expectedAttemptId: string | null;
+  interactionId: string;
+  intent: "start" | "retry";
+  pluginId: string;
+  reviewerDeviceId?: string;
+  token: string;
+  verifierOwner: object;
+};
+
+export type PreparedExternalVerificationNativeAction = Pick<NativeAction, "intent" | "token">;
+
+export type ExternalVerificationNativeDispatchResult = {
+  outcome: "started" | "replay" | "stale-action";
+  attempt: PluginExternalVerificationAttemptSnapshot;
+  presentations: string[];
+};
+
+type ExternalVerificationRuntimeState = {
+  active: PluginExternalVerificationRuntime | null;
+};
+
+const runtimeStateKey = Symbol.for("openclaw.plugin-external-verification-runtime");
+
+function getRuntimeState(): ExternalVerificationRuntimeState {
+  return resolveGlobalSingleton<ExternalVerificationRuntimeState>(runtimeStateKey, () => ({
+    active: null,
+  }));
+}
+
+function requireApprovalRecord(
+  approvalId: string,
+  databaseOptions?: OpenClawStateDatabaseOptions,
+): OperatorApprovalRecord {
+  const lookup = getOperatorApprovalDetailed({ id: approvalId, databaseOptions });
+  if (lookup.outcome !== "found") {
+    throw new Error("external verification approval is no longer available");
+  }
+  return lookup.record;
+}
+
+function snapshotAttemptWithRecord(
+  attempt: PluginExternalVerificationAttemptSnapshot,
+  record: OperatorApprovalRecord,
+): PluginExternalVerificationAttemptSnapshot {
+  return Object.freeze({
+    ...attempt,
+    context: Object.freeze({
+      ...attempt.context,
+      toolName: record.source.toolName ?? attempt.context.toolName,
+      ...(record.source.toolCallId ? { toolCallId: record.source.toolCallId } : {}),
+      ...(record.source.agentId ? { agentId: record.source.agentId } : {}),
+      ...(record.source.sessionKey ? { sessionKey: record.source.sessionKey } : {}),
+      ...(record.source.sessionId ? { sessionId: record.source.sessionId } : {}),
+    }),
+  });
+}
+
+function classifyExternalVerificationError(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return "unknown-error";
+  }
+  try {
+    const rawName: unknown = error.name;
+    const name = typeof rawName === "string" ? rawName.trim() : "";
+    return EXTERNAL_VERIFICATION_ERROR_CLASS_PATTERN.test(name) ? name : "unknown-error";
+  } catch {
+    return "unknown-error";
+  }
+}
+
+export class PluginExternalVerificationRuntime {
+  private readonly attemptSetups = new Map<string, AttemptSetup>();
+  private context: GatewayRequestContext | null = null;
+  private readonly liveAttempts = new Map<string, LiveAttempt>();
+  private readonly nativeActionsByGeneration = new Map<string, NativeAction>();
+  private readonly nativeActionsByToken = new Map<string, NativeAction>();
+  private readonly verifierOwnerIds = new WeakMap<object, string>();
+  private readonly stopRegistryLifecycleListener: () => void;
+
+  constructor(
+    private readonly params: {
+      manager: ExecApprovalManager<PluginApprovalRequestPayload>;
+      runtimeEpoch: string;
+      forwarder?: ExecApprovalForwarder;
+      iosPushDelivery?: PluginApprovalIosPushDelivery;
+      databaseOptions?: OpenClawStateDatabaseOptions;
+      publishResolution?: typeof publishAppliedApprovalResolution;
+      resolveVerifier?: (pluginId: string) => PluginExternalApprovalVerifierRegistration | null;
+    },
+  ) {
+    getRuntimeState().active = this;
+    setExternalVerificationCompletionRuntime(this, (owner, pluginId, completion) =>
+      this.complete(owner, pluginId, completion),
+    );
+    this.stopRegistryLifecycleListener = onPluginRegistryLifecycleChange(() =>
+      this.revokeRetiredVerifierAttempts(),
+    );
+  }
+
+  attachContext(context: GatewayRequestContext): void {
+    this.context = context;
+  }
+
+  onApprovalLifecycle(event: OperatorApprovalLifecycleEvent): void {
+    if (event.phase !== "terminal" || event.record.kind !== "plugin") {
+      return;
+    }
+    this.abortApprovalAttempts(event.record.id, event.record.terminalReason ?? "approval-terminal");
+    this.clearApprovalAttemptSetups(event.record.id);
+    this.clearApprovalNativeActions(event.record.id);
+  }
+
+  private abortApprovalAttempts(approvalId: string, reason: string, exceptId?: string): void {
+    for (const [attemptId, live] of this.liveAttempts) {
+      if (live.approvalId !== approvalId || attemptId === exceptId) {
+        continue;
+      }
+      live.controller.abort(new Error(`external verification cancelled: ${reason}`));
+      this.liveAttempts.delete(attemptId);
+    }
+  }
+
+  private clearApprovalNativeActions(approvalId: string): void {
+    for (const [generation, action] of this.nativeActionsByGeneration) {
+      if (action.approvalId !== approvalId) {
+        continue;
+      }
+      this.nativeActionsByGeneration.delete(generation);
+      this.nativeActionsByToken.delete(action.token);
+    }
+  }
+
+  private clearApprovalAttemptSetups(approvalId: string): void {
+    for (const [attemptId, setup] of this.attemptSetups) {
+      if (setup.approvalId === approvalId) {
+        this.attemptSetups.delete(attemptId);
+      }
+    }
+  }
+
+  private resolveVerifier(pluginId: string): PluginExternalApprovalVerifierRegistration | null {
+    return (this.params.resolveVerifier ?? getPluginExternalApprovalVerifier)(pluginId);
+  }
+
+  private getVerifierOwnerId(owner: object): string {
+    const existing = this.verifierOwnerIds.get(owner);
+    if (existing) {
+      return existing;
+    }
+    const id = randomUUID();
+    this.verifierOwnerIds.set(owner, id);
+    return id;
+  }
+
+  private revokeRetiredVerifierAttempts(): void {
+    for (const [attemptId, live] of this.liveAttempts) {
+      let verifier: PluginExternalApprovalVerifierRegistration | null = null;
+      try {
+        verifier = this.resolveVerifier(live.pluginId);
+      } catch {
+        // Registry transitions must revoke the capability even if composition is unavailable.
+      }
+      if (verifier?.owner === live.verifierOwner) {
+        continue;
+      }
+      cancelRetiredExternalVerificationAttempt({
+        attemptId,
+        pluginId: live.pluginId,
+        databaseOptions: this.params.databaseOptions,
+      });
+      live.controller.abort(new Error("external verification cancelled: verifier-retired"));
+      this.liveAttempts.delete(attemptId);
+    }
+    for (const [generation, action] of this.nativeActionsByGeneration) {
+      let currentOwner: object | undefined;
+      try {
+        currentOwner = this.resolveVerifier(action.pluginId)?.owner;
+      } catch {
+        // A failed registry composition cannot preserve an issued capability.
+      }
+      if (currentOwner === action.verifierOwner) {
+        continue;
+      }
+      this.nativeActionsByGeneration.delete(generation);
+      this.nativeActionsByToken.delete(action.token);
+    }
+  }
+
+  async start(params: {
+    approvalId: string;
+    decision: "allow-once" | "allow-always";
+    interactionId: string;
+    reviewerDeviceId?: string;
+    present: PresentExternalVerification;
+  }): Promise<PluginExternalVerificationAttemptSnapshot> {
+    return (
+      await this.startDetailed({
+        ...params,
+      })
+    ).attempt;
+  }
+
+  private async startDetailed(params: {
+    approvalId: string;
+    decision: "allow-once" | "allow-always";
+    interactionId: string;
+    reviewerDeviceId?: string;
+    nativeAction?: {
+      intent: "start" | "retry";
+      expectedAttemptId: string | null;
+    };
+    present: PresentExternalVerification;
+  }): Promise<{
+    outcome: "started" | "replay" | "stale-action";
+    attempt: PluginExternalVerificationAttemptSnapshot;
+  }> {
+    const storeParams = {
+      approvalId: params.approvalId,
+      decision: params.decision,
+      interactionId: params.interactionId,
+      reviewerDeviceId: params.reviewerDeviceId,
+      nativeAction: params.nativeAction,
+      runtimeEpoch: this.params.runtimeEpoch,
+      databaseOptions: this.params.databaseOptions,
+    };
+    let started = startExternalVerificationAttempt(storeParams);
+    if (started.outcome === "approval-expired") {
+      this.params.manager.expire(params.approvalId);
+      started = startExternalVerificationAttempt(storeParams);
+    }
+    if (
+      started.outcome !== "started" &&
+      started.outcome !== "replay" &&
+      started.outcome !== "stale-action"
+    ) {
+      throw new Error(`external verification unavailable: ${started.outcome}`);
+    }
+    if (!started.attempt) {
+      throw new Error("external verification action is stale; prepare a fresh action");
+    }
+    const record = requireApprovalRecord(params.approvalId, this.params.databaseOptions);
+    const attemptSnapshot = snapshotAttemptWithRecord(started.attempt, record);
+    if (started.outcome === "replay" || started.outcome === "stale-action") {
+      const setup = this.attemptSetups.get(attemptSnapshot.id);
+      // Setup failure is already durable. Replay must return that terminal
+      // attempt instead of rethrowing the first delivery's transient error.
+      await setup?.promise.catch(() => undefined);
+      const current = getExternalVerificationAttemptSnapshot({
+        attemptId: attemptSnapshot.id,
+        pluginId: attemptSnapshot.context.pluginId,
+        databaseOptions: this.params.databaseOptions,
+      });
+      const replaySnapshot = current ? snapshotAttemptWithRecord(current, record) : attemptSnapshot;
+      const live = this.liveAttempts.get(attemptSnapshot.id);
+      const presentations =
+        setup && setup.reviewerDeviceId === params.reviewerDeviceId
+          ? setup.presentations
+          : live && live.reviewerDeviceId === params.reviewerDeviceId
+            ? live.presentations
+            : [];
+      if (!replaySnapshot.outcome) {
+        for (const presentation of presentations) {
+          await params.present(presentation);
+        }
+      }
+      return {
+        outcome: started.outcome,
+        attempt: replaySnapshot,
+      };
+    }
+    // The store has already cancelled an older attempt. Revoke its in-memory
+    // presentation capability even when the replacement verifier is unavailable.
+    this.clearApprovalAttemptSetups(attemptSnapshot.context.approvalId);
+    this.abortApprovalAttempts(attemptSnapshot.context.approvalId, "reviewer-retry");
+    let verifier: PluginExternalApprovalVerifierRegistration | null;
+    try {
+      verifier = this.resolveVerifier(attemptSnapshot.context.pluginId);
+    } catch (error) {
+      failExternalVerificationAttempt({
+        attemptId: attemptSnapshot.id,
+        pluginId: attemptSnapshot.context.pluginId,
+        errorClass: classifyExternalVerificationError(error),
+        databaseOptions: this.params.databaseOptions,
+      });
+      throw new Error(`external verifier lookup failed: ${formatErrorMessage(error)}`, {
+        cause: error,
+      });
+    }
+    if (!verifier) {
+      failExternalVerificationAttempt({
+        attemptId: attemptSnapshot.id,
+        pluginId: attemptSnapshot.context.pluginId,
+        errorClass: "verifier-unavailable",
+        databaseOptions: this.params.databaseOptions,
+      });
+      throw new Error(
+        `plugin '${attemptSnapshot.context.pluginId}' has no active external verifier`,
+      );
+    }
+    const controller = new AbortController();
+    let presentationCount = 0;
+    const present = async ({ message }: { message: string }): Promise<void> => {
+      if (controller.signal.aborted) {
+        throw controller.signal.reason;
+      }
+      if (this.resolveVerifier(attemptSnapshot.context.pluginId)?.owner !== verifier.owner) {
+        controller.abort(new Error("external verification cancelled: verifier-retired"));
+        this.liveAttempts.delete(attemptSnapshot.id);
+        throw controller.signal.reason;
+      }
+      const normalized = message.trim();
+      if (!normalized || normalized.length > MAX_EXTERNAL_VERIFICATION_PRESENTATION_LENGTH) {
+        throw new Error(
+          `external verification presentation must be 1-${MAX_EXTERNAL_VERIFICATION_PRESENTATION_LENGTH} characters`,
+        );
+      }
+      const live = this.liveAttempts.get(attemptSnapshot.id);
+      if (!live) {
+        throw new Error("external verifier was retired during presentation");
+      }
+      if (live.presentations.length >= MAX_EXTERNAL_VERIFICATION_PRESENTATIONS) {
+        throw new Error(
+          `external verification may present at most ${MAX_EXTERNAL_VERIFICATION_PRESENTATIONS} reviewer messages`,
+        );
+      }
+      live.presentations.push(normalized);
+      await params.present(normalized);
+      presentationCount += 1;
+      live.ready = true;
+    };
+    const attempt: PluginExternalVerificationAttempt = Object.freeze({
+      ...attemptSnapshot,
+      context: Object.freeze({ ...attemptSnapshot.context }),
+      signal: controller.signal,
+      present,
+    });
+    this.liveAttempts.set(attempt.id, {
+      approvalId: attempt.context.approvalId,
+      controller,
+      presentations: [],
+      pluginId: attempt.context.pluginId,
+      ready: false,
+      reviewerDeviceId: params.reviewerDeviceId,
+      verifierOwner: verifier.owner,
+    });
+    const readPluginCompletion = (): PluginExternalVerificationAttemptSnapshot | null => {
+      const completed = getExternalVerificationAttemptSnapshot({
+        attemptId: attempt.id,
+        pluginId: attempt.context.pluginId,
+        databaseOptions: this.params.databaseOptions,
+      });
+      if (completed?.terminalSource !== "plugin-completion") {
+        return null;
+      }
+      return snapshotAttemptWithRecord(
+        completed,
+        requireApprovalRecord(attempt.context.approvalId, this.params.databaseOptions),
+      );
+    };
+    const setupPromise: AttemptSetup["promise"] = Promise.resolve().then(async () => {
+      try {
+        await verifier.handler(attempt);
+        if (presentationCount === 0) {
+          throw new Error("external verifier returned without presenting reviewer instructions");
+        }
+        const live = this.liveAttempts.get(attempt.id);
+        if (!live) {
+          const completed = readPluginCompletion();
+          if (completed) {
+            return { outcome: "started", attempt: completed };
+          }
+          throw new Error("external verifier was retired during setup");
+        }
+        return { outcome: "started", attempt: attemptSnapshot };
+      } catch (error) {
+        const completed = readPluginCompletion();
+        if (completed) {
+          return { outcome: "started", attempt: completed };
+        }
+        failExternalVerificationAttempt({
+          attemptId: attempt.id,
+          pluginId: attempt.context.pluginId,
+          errorClass: classifyExternalVerificationError(error),
+          databaseOptions: this.params.databaseOptions,
+        });
+        controller.abort(error);
+        this.liveAttempts.delete(attempt.id);
+        throw new Error(`external verifier failed: ${formatErrorMessage(error)}`, { cause: error });
+      }
+    });
+    this.attemptSetups.set(attempt.id, {
+      approvalId: attempt.context.approvalId,
+      presentations: this.liveAttempts.get(attempt.id)?.presentations ?? [],
+      reviewerDeviceId: params.reviewerDeviceId,
+      promise: setupPromise,
+    });
+    return await setupPromise;
+  }
+
+  prepareNativeAction(params: {
+    approvalId: string;
+    decision: "allow-once" | "allow-always";
+    reviewerDeviceId?: string;
+  }): PreparedExternalVerificationNativeAction {
+    const storeParams = {
+      ...params,
+      runtimeEpoch: this.params.runtimeEpoch,
+      databaseOptions: this.params.databaseOptions,
+    };
+    let state = getExternalVerificationNativeActionState(storeParams);
+    if (state.outcome === "approval-expired") {
+      this.params.manager.expire(params.approvalId);
+      state = getExternalVerificationNativeActionState(storeParams);
+    }
+    if (state.outcome !== "ready") {
+      throw new Error(`external verification unavailable: ${state.outcome}`);
+    }
+    const record = requireApprovalRecord(params.approvalId, this.params.databaseOptions);
+    const pluginId =
+      record.presentation.kind === "plugin" ? record.presentation.pluginId?.trim() : "";
+    const verifier = pluginId ? this.resolveVerifier(pluginId) : null;
+    if (!pluginId || !verifier) {
+      throw new Error("external verification verifier is not available");
+    }
+    const generation = JSON.stringify([
+      params.approvalId,
+      params.decision,
+      state.action.intent,
+      state.action.expectedAttemptId,
+      this.getVerifierOwnerId(verifier.owner),
+      params.reviewerDeviceId ?? null,
+    ]);
+    const existing = this.nativeActionsByGeneration.get(generation);
+    if (existing) {
+      return { intent: existing.intent, token: existing.token };
+    }
+    const token = `external-action:${randomUUID()}`;
+    const action: NativeAction = {
+      approvalId: params.approvalId,
+      decision: params.decision,
+      expectedAttemptId: state.action.expectedAttemptId,
+      interactionId: createHash("sha256").update(token).digest("hex"),
+      intent: state.action.intent,
+      pluginId,
+      reviewerDeviceId: params.reviewerDeviceId,
+      token,
+      verifierOwner: verifier.owner,
+    };
+    this.nativeActionsByGeneration.set(generation, action);
+    this.nativeActionsByToken.set(token, action);
+    return { intent: action.intent, token };
+  }
+
+  async dispatchNativeAction(params: {
+    approvalId: string;
+    decision: "allow-once" | "allow-always";
+    reviewerDeviceId?: string;
+    token: string;
+  }): Promise<ExternalVerificationNativeDispatchResult> {
+    const action = this.nativeActionsByToken.get(params.token);
+    if (
+      !action ||
+      action.approvalId !== params.approvalId ||
+      action.decision !== params.decision ||
+      action.reviewerDeviceId !== params.reviewerDeviceId ||
+      this.resolveVerifier(action.pluginId)?.owner !== action.verifierOwner
+    ) {
+      throw new Error("external verification action is invalid");
+    }
+    const presentations: string[] = [];
+    const dispatched = await this.startDetailed({
+      approvalId: action.approvalId,
+      decision: action.decision,
+      interactionId: action.interactionId,
+      reviewerDeviceId: action.reviewerDeviceId,
+      nativeAction: {
+        intent: action.intent,
+        expectedAttemptId: action.expectedAttemptId,
+      },
+      present: async (message) => {
+        presentations.push(message);
+      },
+    });
+    return {
+      outcome: dispatched.outcome,
+      attempt: dispatched.attempt,
+      presentations,
+    };
+  }
+
+  async complete(
+    owner: object,
+    pluginId: string,
+    completion: { attemptId: string; outcome: "succeeded" | "failed" },
+  ): Promise<PluginExternalVerificationCompletionResult> {
+    const verifier = this.resolveVerifier(pluginId);
+    if (!verifier || verifier.owner !== owner) {
+      throw new Error("external verification attempt not found for this plugin instance");
+    }
+    const live = this.liveAttempts.get(completion.attemptId);
+    if (live && !live.ready) {
+      throw new Error(
+        "external verification cannot complete before reviewer presentation finishes",
+      );
+    }
+    if (
+      !live &&
+      !getExternalVerificationAttemptSnapshot({
+        attemptId: completion.attemptId,
+        pluginId,
+        databaseOptions: this.params.databaseOptions,
+      })?.outcome
+    ) {
+      throw new Error("external verification attempt is not active in this runtime");
+    }
+    const storeParams = {
+      attemptId: completion.attemptId,
+      pluginId,
+      outcome: completion.outcome,
+      runtimeEpoch: this.params.runtimeEpoch,
+      databaseOptions: this.params.databaseOptions,
+    };
+    let stored = completeExternalVerificationAttempt(storeParams);
+    if (stored.outcome === "approval-expired") {
+      this.params.manager.expire(stored.approvalId);
+      stored = completeExternalVerificationAttempt(storeParams);
+    }
+    if (stored.outcome === "approval-expired") {
+      throw new Error("external verification approval expiry could not be reconciled");
+    }
+    if (stored.outcome === "attempt-not-found") {
+      throw new Error("external verification attempt not found for this plugin");
+    }
+    const record = requireApprovalRecord(stored.approvalId, this.params.databaseOptions);
+    const controlUiBasePath = normalizeControlUiBasePath(
+      this.context?.getRuntimeConfig().gateway?.controlUi?.basePath,
+    );
+    const approval = buildApprovalSnapshot(record, controlUiBasePath);
+    if (!approval) {
+      throw new Error("external verification approval projection is unavailable");
+    }
+    if (stored.applied) {
+      const liveRecord = this.params.manager.getLiveSnapshot(record.id) ?? undefined;
+      this.params.manager.reconcileDurableTerminal(record);
+      if (liveRecord && this.context) {
+        try {
+          await (this.params.publishResolution ?? publishAppliedApprovalResolution)({
+            record,
+            liveRecord,
+            context: this.context,
+            forwarder: this.params.forwarder,
+            pluginIosPushDelivery: this.params.iosPushDelivery,
+          });
+        } catch (error) {
+          this.context.logGateway?.error?.(
+            `plugin approvals: external verification publication failed after durable completion: ${formatErrorMessage(error)}`,
+          );
+        }
+      }
+    }
+    const completedLiveAttempt = this.liveAttempts.get(stored.attempt.id);
+    if (completedLiveAttempt) {
+      completedLiveAttempt.controller.abort(
+        new Error(
+          `external verification ${completion.outcome === "succeeded" ? "completed" : "failed"}`,
+        ),
+      );
+      this.liveAttempts.delete(stored.attempt.id);
+    }
+    return {
+      applied: stored.applied,
+      approval,
+      attempt: snapshotAttemptWithRecord(stored.attempt, record),
+      ...(stored.grantAuthorization ? { grantAuthorization: stored.grantAuthorization } : {}),
+    };
+  }
+
+  shutdown(): void {
+    if (getRuntimeState().active === this) {
+      getRuntimeState().active = null;
+    }
+    this.stopRegistryLifecycleListener();
+    const approvalIds = new Set([...this.liveAttempts.values()].map((live) => live.approvalId));
+    for (const approvalId of approvalIds) {
+      this.params.manager.forceDenyDetailed(
+        approvalId,
+        "gateway-restart",
+        { kind: "system", id: null },
+        "cancelled",
+        null,
+      );
+    }
+    // Terminal state must commit before plugin abort listeners run; otherwise
+    // a synchronous listener could allow the action during shutdown.
+    for (const live of this.liveAttempts.values()) {
+      live.controller.abort(new Error("external verification cancelled: gateway-restart"));
+    }
+    clearExternalVerificationCompletionRuntime(this);
+    this.liveAttempts.clear();
+    this.attemptSetups.clear();
+    this.nativeActionsByGeneration.clear();
+    this.nativeActionsByToken.clear();
+  }
+}
+
+export async function startExternalVerificationForReviewer(params: {
+  approvalId: string;
+  decision: "allow-once" | "allow-always";
+  interactionId: string;
+  reviewerDeviceId?: string;
+  present: PresentExternalVerification;
+}): Promise<PluginExternalVerificationAttemptSnapshot> {
+  const runtime = getRuntimeState().active;
+  if (!runtime) {
+    throw new Error("external verification approval runtime is not available");
+  }
+  return await runtime.start(params);
+}

--- a/src/gateway/plugin-external-verification-store.test.ts
+++ b/src/gateway/plugin-external-verification-store.test.ts
@@ -1,0 +1,755 @@
+import fs from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import {
+  closeOrphanedOperatorApprovals,
+  forceDenyOperatorApproval,
+  getOperatorApprovalDetailed,
+  insertOperatorApproval,
+  resolveOperatorApproval,
+} from "./operator-approval-store.js";
+import {
+  completeExternalVerificationAttempt,
+  failExternalVerificationAttempt,
+  getExternalVerificationAttemptSnapshot,
+  getExternalVerificationNativeActionState,
+  startExternalVerificationAttempt,
+} from "./plugin-external-verification-store.js";
+
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    cleanup();
+  });
+});
+
+function createDatabaseOptions(): OpenClawStateDatabaseOptions {
+  const stateDir = fs.realpathSync(tempDirs.make("openclaw-external-verification-"));
+  return { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
+}
+
+function insertExternalApproval(params: {
+  databaseOptions: OpenClawStateDatabaseOptions;
+  id?: string;
+  reviewerDeviceIds?: string[];
+  runId?: string | null;
+  runtimeEpoch?: string;
+  expiresAtMs?: number;
+}) {
+  const id = params.id ?? "plugin:approval-1";
+  return insertOperatorApproval({
+    approval: {
+      id,
+      kind: "plugin",
+      presentation: {
+        kind: "plugin",
+        title: "World verification",
+        description: "Verify personhood before continuing.",
+        severity: "warning",
+        pluginId: "agentkit",
+        toolName: "dangerous-tool",
+        agentId: "main",
+        allowedDecisions: ["deny"],
+        externalResolution: {
+          label: "Verify with World",
+          decisions: ["allow-once", "allow-always"],
+        },
+      },
+      source: {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "session-1",
+        runId: params.runId === undefined ? "run-1" : params.runId,
+        toolCallId: "call-1",
+        toolName: "dangerous-tool",
+      },
+      runtimeEpoch: params.runtimeEpoch ?? "epoch-1",
+      createdAtMs: 1_000,
+      expiresAtMs: params.expiresAtMs ?? 10_000,
+      reviewerDeviceIds: params.reviewerDeviceIds,
+    },
+    databaseOptions: params.databaseOptions,
+  });
+}
+
+function getApproval(id: string, databaseOptions: OpenClawStateDatabaseOptions, nowMs = 2_000) {
+  const result = getOperatorApprovalDetailed({ id, nowMs, databaseOptions });
+  return result.outcome === "found" ? result.record : null;
+}
+
+describe("plugin external verification store", () => {
+  it("starts one host-bound attempt and replays the same interaction without replacement", () => {
+    const databaseOptions = createDatabaseOptions();
+    expect(insertExternalApproval({ databaseOptions })).toMatchObject({ outcome: "inserted" });
+
+    const first = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    expect(first).toMatchObject({
+      outcome: "started",
+      attempt: {
+        context: {
+          approvalId: "plugin:approval-1",
+          pluginId: "agentkit",
+          runId: "run-1",
+          toolName: "dangerous-tool",
+          toolCallId: "call-1",
+          sessionId: "session-1",
+          decision: "allow-once",
+        },
+      },
+    });
+
+    expect(
+      startExternalVerificationAttempt({
+        approvalId: "plugin:approval-1",
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_001,
+        databaseOptions,
+      }),
+    ).toEqual({ outcome: "replay", attempt: first.outcome === "started" ? first.attempt : null });
+  });
+
+  it("reports expiry before replaying an active interaction", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions, expiresAtMs: 2_050 });
+    const request = {
+      approvalId: "plugin:approval-1",
+      decision: "allow-once" as const,
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      databaseOptions,
+    };
+    const started = startExternalVerificationAttempt({ ...request, nowMs: 2_000 });
+    if (started.outcome !== "started") {
+      throw new Error("expected active attempt");
+    }
+
+    expect(startExternalVerificationAttempt({ ...request, nowMs: 2_100 })).toEqual({
+      outcome: "approval-expired",
+    });
+    expect(getApproval("plugin:approval-1", databaseOptions, 2_000)).toMatchObject({
+      status: "pending",
+    });
+    expect(
+      getExternalVerificationAttemptSnapshot({
+        attemptId: started.attempt.id,
+        pluginId: "agentkit",
+        databaseOptions,
+      }),
+    ).not.toHaveProperty("outcome");
+  });
+
+  it("replays a superseded interaction instead of reviving its stale decision", () => {
+    const databaseOptions = createDatabaseOptions();
+    expect(insertExternalApproval({ databaseOptions })).toMatchObject({ outcome: "inserted" });
+
+    const first = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    expect(first.outcome).toBe("started");
+    if (first.outcome !== "started") {
+      throw new Error("expected the first external verification attempt to start");
+    }
+
+    const stronger = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-always",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_001,
+      databaseOptions,
+    });
+    expect(stronger).toMatchObject({
+      outcome: "started",
+      attempt: { context: { decision: "allow-always" } },
+    });
+    if (stronger.outcome !== "started") {
+      throw new Error("expected the stronger external verification attempt to start");
+    }
+
+    const staleReplay = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_002,
+      databaseOptions,
+    });
+    expect(staleReplay).toEqual({
+      outcome: "replay",
+      attempt: {
+        ...first.attempt,
+        endedAtMs: 2_001,
+        outcome: "cancelled",
+        terminalSource: "reviewer-retry",
+      },
+    });
+    expect(
+      getExternalVerificationAttemptSnapshot({
+        attemptId: first.attempt.id,
+        pluginId: "agentkit",
+        databaseOptions,
+      }),
+    ).toMatchObject({
+      outcome: "cancelled",
+      terminalSource: "reviewer-retry",
+    });
+    const activeAttempt = getExternalVerificationAttemptSnapshot({
+      attemptId: stronger.attempt.id,
+      pluginId: "agentkit",
+      databaseOptions,
+    });
+    expect(activeAttempt).toMatchObject({ context: { decision: "allow-always" } });
+    expect(activeAttempt).not.toHaveProperty("outcome");
+    expect(
+      startExternalVerificationAttempt({
+        approvalId: "plugin:approval-1",
+        decision: "allow-always",
+        interactionId: "a".repeat(64),
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_003,
+        databaseOptions,
+      }),
+    ).toEqual({ outcome: "replay", attempt: stronger.attempt });
+  });
+
+  it("enforces the approval reviewer binding before starting or replaying an attempt", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({
+      databaseOptions,
+      reviewerDeviceIds: ["device-authorized"],
+    });
+    const request = {
+      approvalId: "plugin:approval-1",
+      decision: "allow-once" as const,
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    };
+    expect(
+      startExternalVerificationAttempt({
+        ...request,
+        reviewerDeviceId: "device-other",
+      }),
+    ).toEqual({ outcome: "reviewer-unauthorized" });
+    expect(
+      startExternalVerificationAttempt({
+        ...request,
+        reviewerDeviceId: "device-authorized",
+      }),
+    ).toMatchObject({ outcome: "started" });
+    expect(startExternalVerificationAttempt(request)).toEqual({
+      outcome: "reviewer-unauthorized",
+    });
+  });
+
+  it("treats a new reviewer interaction as an explicit retry and closes only the active attempt", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions });
+    const first = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    const second = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-always",
+      interactionId: "b".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_100,
+      databaseOptions,
+    });
+    expect(second).toMatchObject({
+      outcome: "started",
+      attempt: { context: { decision: "allow-always" } },
+    });
+    if (first.outcome !== "started") {
+      throw new Error("expected first attempt");
+    }
+    expect(
+      completeExternalVerificationAttempt({
+        attemptId: first.attempt.id,
+        pluginId: "agentkit",
+        outcome: "succeeded",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_200,
+        databaseOptions,
+      }),
+    ).toMatchObject({
+      outcome: "replay",
+      applied: false,
+      attempt: { outcome: "cancelled", terminalSource: "reviewer-retry" },
+    });
+  });
+
+  it("requires a core-issued native retry generation to replace the exact active attempt", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions });
+    const common = {
+      approvalId: "plugin:approval-1",
+      decision: "allow-once" as const,
+      runtimeEpoch: "epoch-1",
+      databaseOptions,
+    };
+    expect(getExternalVerificationNativeActionState({ ...common, nowMs: 2_000 })).toEqual({
+      outcome: "ready",
+      action: { intent: "start", expectedAttemptId: null },
+    });
+
+    const first = startExternalVerificationAttempt({
+      ...common,
+      interactionId: "a".repeat(64),
+      nativeAction: { intent: "start", expectedAttemptId: null },
+      nowMs: 2_001,
+    });
+    expect(first.outcome).toBe("started");
+    if (first.outcome !== "started") {
+      throw new Error("expected native start attempt");
+    }
+    expect(
+      startExternalVerificationAttempt({
+        ...common,
+        interactionId: "a".repeat(64),
+        nativeAction: { intent: "start", expectedAttemptId: null },
+        nowMs: 2_002,
+      }),
+    ).toEqual({ outcome: "replay", attempt: first.attempt });
+    expect(
+      startExternalVerificationAttempt({
+        ...common,
+        interactionId: "b".repeat(64),
+        nativeAction: { intent: "start", expectedAttemptId: null },
+        nowMs: 2_003,
+      }),
+    ).toEqual({ outcome: "stale-action", attempt: first.attempt });
+
+    const retryAction = {
+      intent: "retry" as const,
+      expectedAttemptId: first.attempt.id,
+    };
+    expect(getExternalVerificationNativeActionState({ ...common, nowMs: 2_004 })).toEqual({
+      outcome: "ready",
+      action: retryAction,
+    });
+    const retry = startExternalVerificationAttempt({
+      ...common,
+      interactionId: "c".repeat(64),
+      nativeAction: retryAction,
+      nowMs: 2_005,
+    });
+    expect(retry.outcome).toBe("started");
+    if (retry.outcome !== "started") {
+      throw new Error("expected native retry attempt");
+    }
+    expect(
+      startExternalVerificationAttempt({
+        ...common,
+        interactionId: "a".repeat(64),
+        nativeAction: { intent: "start", expectedAttemptId: null },
+        nowMs: 2_006,
+      }),
+    ).toEqual({ outcome: "stale-action", attempt: retry.attempt });
+    expect(
+      startExternalVerificationAttempt({
+        ...common,
+        interactionId: "d".repeat(64),
+        nativeAction: retryAction,
+        nowMs: 2_007,
+      }),
+    ).toEqual({ outcome: "stale-action", attempt: retry.attempt });
+    expect(
+      getExternalVerificationAttemptSnapshot({
+        attemptId: first.attempt.id,
+        pluginId: "agentkit",
+        databaseOptions,
+      }),
+    ).toMatchObject({ outcome: "cancelled", terminalSource: "reviewer-retry" });
+
+    failExternalVerificationAttempt({
+      attemptId: retry.attempt.id,
+      pluginId: "agentkit",
+      nowMs: 2_008,
+      errorClass: "proof-rejected",
+      databaseOptions,
+    });
+    expect(getExternalVerificationNativeActionState({ ...common, nowMs: 2_009 })).toEqual({
+      outcome: "ready",
+      action: { intent: "start", expectedAttemptId: retry.attempt.id },
+    });
+  });
+
+  it("does not expose a stronger attempt through a stale weaker native action", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions });
+    const common = {
+      approvalId: "plugin:approval-1",
+      runtimeEpoch: "epoch-1",
+      databaseOptions,
+    };
+    const weakerAction = { intent: "start" as const, expectedAttemptId: null };
+    const weaker = startExternalVerificationAttempt({
+      ...common,
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      nativeAction: weakerAction,
+      nowMs: 2_000,
+    });
+    if (weaker.outcome !== "started") {
+      throw new Error("expected weaker native attempt");
+    }
+    const stronger = startExternalVerificationAttempt({
+      ...common,
+      decision: "allow-always",
+      interactionId: "b".repeat(64),
+      nowMs: 2_001,
+    });
+    if (stronger.outcome !== "started") {
+      throw new Error("expected stronger replacement attempt");
+    }
+
+    expect(
+      startExternalVerificationAttempt({
+        ...common,
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        nativeAction: weakerAction,
+        nowMs: 2_002,
+      }),
+    ).toEqual({ outcome: "stale-action" });
+    expect(
+      startExternalVerificationAttempt({
+        ...common,
+        decision: "allow-once",
+        interactionId: "c".repeat(64),
+        nativeAction: weakerAction,
+        nowMs: 2_003,
+      }),
+    ).toEqual({ outcome: "stale-action" });
+    expect(
+      getExternalVerificationAttemptSnapshot({
+        attemptId: stronger.attempt.id,
+        pluginId: "agentkit",
+        databaseOptions,
+      }),
+    ).toMatchObject({ context: { decision: "allow-always" } });
+  });
+
+  it("keeps failure pending, then atomically records a stable grant on success", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions });
+    const failed = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    if (failed.outcome !== "started") {
+      throw new Error("expected failed attempt fixture");
+    }
+    expect(
+      completeExternalVerificationAttempt({
+        attemptId: failed.attempt.id,
+        pluginId: "agentkit",
+        outcome: "failed",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_100,
+        databaseOptions,
+      }),
+    ).toMatchObject({ outcome: "completed", applied: false, attempt: { outcome: "failed" } });
+    expect(getApproval("plugin:approval-1", databaseOptions)).toMatchObject({ status: "pending" });
+
+    const successful = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-always",
+      interactionId: "b".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_200,
+      databaseOptions,
+    });
+    if (successful.outcome !== "started") {
+      throw new Error("expected successful attempt fixture");
+    }
+    const completed = completeExternalVerificationAttempt({
+      attemptId: successful.attempt.id,
+      pluginId: "agentkit",
+      outcome: "succeeded",
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_300,
+      databaseOptions,
+    });
+    expect(completed).toMatchObject({
+      outcome: "completed",
+      applied: true,
+      attempt: { outcome: "succeeded" },
+      grantAuthorization: {
+        approvalId: "plugin:approval-1",
+        attemptId: successful.attempt.id,
+        decision: "allow-always",
+      },
+    });
+    expect(getApproval("plugin:approval-1", databaseOptions)).toMatchObject({
+      status: "allowed",
+      decision: "allow-always",
+      resolver: { kind: "runtime", id: "plugin:agentkit" },
+    });
+    expect(
+      completeExternalVerificationAttempt({
+        attemptId: successful.attempt.id,
+        pluginId: "agentkit",
+        outcome: "succeeded",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_400,
+        databaseOptions,
+      }),
+    ).toEqual({ ...completed, outcome: "replay", applied: false });
+  });
+
+  it("does not issue reusable grant authorization for allow-once", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions });
+    const started = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    if (started.outcome !== "started") {
+      throw new Error("expected allow-once attempt");
+    }
+
+    const completed = completeExternalVerificationAttempt({
+      attemptId: started.attempt.id,
+      pluginId: "agentkit",
+      outcome: "succeeded",
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_100,
+      databaseOptions,
+    });
+
+    expect(completed).toMatchObject({ outcome: "completed", applied: true });
+    expect(completed).not.toHaveProperty("grantAuthorization");
+  });
+
+  it("never grants after denial wins and rejects caller-selected plugin ownership", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions });
+    const started = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-once",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    if (started.outcome !== "started") {
+      throw new Error("expected attempt");
+    }
+    expect(
+      completeExternalVerificationAttempt({
+        attemptId: started.attempt.id,
+        pluginId: "different-plugin",
+        outcome: "succeeded",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_050,
+        databaseOptions,
+      }),
+    ).toEqual({ outcome: "attempt-not-found" });
+    expect(
+      resolveOperatorApproval({
+        id: "plugin:approval-1",
+        decision: "deny",
+        resolver: { kind: "channel", id: "telegram:owner" },
+        expectedKind: "plugin",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_100,
+        databaseOptions,
+      }),
+    ).toMatchObject({ outcome: "resolved", record: { status: "denied" } });
+    expect(
+      completeExternalVerificationAttempt({
+        attemptId: started.attempt.id,
+        pluginId: "agentkit",
+        outcome: "succeeded",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_200,
+        databaseOptions,
+      }),
+    ).toMatchObject({
+      outcome: "replay",
+      applied: false,
+      attempt: { outcome: "cancelled", terminalSource: "user" },
+    });
+  });
+
+  it("reports an expired approval to the runtime before a late success can authorize a grant", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions, expiresAtMs: 2_050 });
+    const started = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-always",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    if (started.outcome !== "started") {
+      throw new Error("expected expiring attempt");
+    }
+
+    const completion = completeExternalVerificationAttempt({
+      attemptId: started.attempt.id,
+      pluginId: "agentkit",
+      outcome: "succeeded",
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_100,
+      databaseOptions,
+    });
+
+    expect(completion).toMatchObject({
+      outcome: "approval-expired",
+      approvalId: "plugin:approval-1",
+    });
+    expect(completion).not.toHaveProperty("grantAuthorization");
+    expect(getApproval("plugin:approval-1", databaseOptions, 2_000)).toMatchObject({
+      status: "pending",
+    });
+    expect(
+      getExternalVerificationAttemptSnapshot({
+        attemptId: started.attempt.id,
+        pluginId: "agentkit",
+        databaseOptions,
+      }),
+    ).not.toHaveProperty("outcome");
+  });
+
+  it("records run cancellation as terminal before replaying a late completion", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions });
+    const started = startExternalVerificationAttempt({
+      approvalId: "plugin:approval-1",
+      decision: "allow-always",
+      interactionId: "a".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    if (started.outcome !== "started") {
+      throw new Error("expected run-bound attempt");
+    }
+    expect(
+      forceDenyOperatorApproval({
+        id: "plugin:approval-1",
+        status: "cancelled",
+        reason: "run-aborted",
+        resolver: { kind: "system", id: null },
+        expectedKind: "plugin",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_100,
+        databaseOptions,
+      }),
+    ).toMatchObject({ outcome: "denied", record: { status: "cancelled" } });
+
+    const completion = completeExternalVerificationAttempt({
+      attemptId: started.attempt.id,
+      pluginId: "agentkit",
+      outcome: "succeeded",
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_200,
+      databaseOptions,
+    });
+    expect(completion).toMatchObject({
+      outcome: "replay",
+      applied: false,
+      attempt: { outcome: "cancelled", terminalSource: "run-aborted" },
+    });
+    expect(completion).not.toHaveProperty("grantAuthorization");
+  });
+
+  it("fails closed without a run binding and reconciles active attempts on restart", () => {
+    const databaseOptions = createDatabaseOptions();
+    insertExternalApproval({ databaseOptions, id: "plugin:no-run", runId: null });
+    expect(
+      startExternalVerificationAttempt({
+        approvalId: "plugin:no-run",
+        decision: "allow-once",
+        interactionId: "a".repeat(64),
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_000,
+        databaseOptions,
+      }),
+    ).toEqual({ outcome: "run-unavailable" });
+
+    insertExternalApproval({ databaseOptions, id: "plugin:restart" });
+    const started = startExternalVerificationAttempt({
+      approvalId: "plugin:restart",
+      decision: "allow-once",
+      interactionId: "b".repeat(64),
+      runtimeEpoch: "epoch-1",
+      nowMs: 2_000,
+      databaseOptions,
+    });
+    if (started.outcome !== "started") {
+      throw new Error("expected restart attempt");
+    }
+    expect(
+      closeOrphanedOperatorApprovals({
+        runtimeEpoch: "epoch-2",
+        nowMs: 2_100,
+        databaseOptions,
+      }),
+    ).toMatchObject({ affected: 2 });
+    expect(
+      completeExternalVerificationAttempt({
+        attemptId: started.attempt.id,
+        pluginId: "agentkit",
+        outcome: "succeeded",
+        runtimeEpoch: "epoch-1",
+        nowMs: 2_200,
+        databaseOptions,
+      }),
+    ).toMatchObject({
+      outcome: "replay",
+      applied: false,
+      attempt: { outcome: "cancelled", terminalSource: "gateway-restart" },
+    });
+    expect(
+      completeExternalVerificationAttempt({
+        attemptId: started.attempt.id,
+        pluginId: "agentkit",
+        outcome: "succeeded",
+        runtimeEpoch: "epoch-2",
+        nowMs: 2_300,
+        databaseOptions,
+      }),
+    ).toMatchObject({
+      outcome: "replay",
+      applied: false,
+      attempt: { outcome: "cancelled", terminalSource: "gateway-restart" },
+    });
+  });
+});

--- a/src/gateway/plugin-external-verification-store.ts
+++ b/src/gateway/plugin-external-verification-store.ts
@@ -1,0 +1,737 @@
+// Durable, proof-free attempt ledger and atomic external approval completion.
+import { createHash, randomUUID } from "node:crypto";
+import { sql, type Selectable } from "kysely";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import type {
+  PluginExternalVerificationAttemptSnapshot,
+  PluginExternalVerificationGrantAuthorization,
+} from "../plugins/external-verification-approval-types.js";
+import { ensurePluginExternalVerificationSchema } from "../state/openclaw-state-db-schema-additive.js";
+import type {
+  DB as OpenClawStateKyselyDatabase,
+  OperatorApprovals,
+  PluginExternalVerificationAttempts,
+} from "../state/openclaw-state-db.generated.js";
+import {
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabase,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import { isOperatorApprovalReviewerAuthorized } from "./operator-approval-authorization.js";
+
+type ExternalAttemptRow = Selectable<PluginExternalVerificationAttempts>;
+type OperatorApprovalRow = Selectable<OperatorApprovals>;
+type ExternalVerificationDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "operator_approvals" | "plugin_external_verification_attempts"
+>;
+
+type ExternalVerificationUnavailableOutcome =
+  | "approval-expired"
+  | "approval-not-found"
+  | "approval-not-pending"
+  | "decision-unavailable"
+  | "owner-unavailable"
+  | "reviewer-unauthorized"
+  | "run-unavailable";
+
+type NativeExternalVerificationAction = {
+  intent: "start" | "retry";
+  expectedAttemptId: string | null;
+};
+
+type StartExternalVerificationResult =
+  | {
+      outcome: "started" | "replay";
+      attempt: PluginExternalVerificationAttemptSnapshot;
+    }
+  | {
+      outcome: "stale-action";
+      attempt?: PluginExternalVerificationAttemptSnapshot;
+    }
+  | {
+      outcome: ExternalVerificationUnavailableOutcome;
+    };
+
+export type ExternalVerificationNativeActionState =
+  | {
+      outcome: "ready";
+      action: NativeExternalVerificationAction;
+    }
+  | {
+      outcome: ExternalVerificationUnavailableOutcome;
+    };
+
+type CompleteExternalVerificationStoreResult =
+  | {
+      outcome: "completed" | "replay";
+      applied: boolean;
+      approvalId: string;
+      attempt: PluginExternalVerificationAttemptSnapshot;
+      grantAuthorization?: PluginExternalVerificationGrantAuthorization;
+    }
+  | { outcome: "approval-expired"; approvalId: string }
+  | { outcome: "attempt-not-found" };
+
+export function getExternalVerificationAttemptSnapshot(params: {
+  attemptId: string;
+  pluginId: string;
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): PluginExternalVerificationAttemptSnapshot | null {
+  return runOpenClawStateWriteTransaction((database) => {
+    ensurePluginExternalVerificationSchema(database.db);
+    const attempt = selectAttempt(database, params.attemptId);
+    if (!attempt || attempt.plugin_id !== params.pluginId) {
+      return null;
+    }
+    return decodeAttempt(attempt);
+  }, params.databaseOptions);
+}
+
+type ExternalResolutionProjection = {
+  label: string;
+  decisions: Array<"allow-once" | "allow-always">;
+};
+
+function readExternalResolution(row: OperatorApprovalRow): ExternalResolutionProjection | null {
+  try {
+    const presentation: unknown = JSON.parse(row.presentation_json);
+    if (typeof presentation !== "object" || presentation === null || Array.isArray(presentation)) {
+      return null;
+    }
+    // SAFETY: isRecord(presentation) was checked by the caller guard above.
+    const record = presentation as Record<string, unknown>;
+    const external = record.externalResolution;
+    if (typeof external !== "object" || external === null || Array.isArray(external)) {
+      return null;
+    }
+    // SAFETY: isRecord(external) was checked immediately above.
+    const externalRecord = external as Record<string, unknown>;
+    const label = typeof externalRecord.label === "string" ? externalRecord.label.trim() : "";
+    const rawDecisions = externalRecord.decisions;
+    if (
+      !label ||
+      !Array.isArray(rawDecisions) ||
+      rawDecisions.length < 1 ||
+      rawDecisions.length > 2 ||
+      rawDecisions.some((decision) => decision !== "allow-once" && decision !== "allow-always")
+    ) {
+      return null;
+    }
+    return {
+      label,
+      // SAFETY: the filter above kept only allow-once/allow-always literals.
+      decisions: rawDecisions as Array<"allow-once" | "allow-always">,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readReviewerDeviceIds(row: OperatorApprovalRow): string[] | null {
+  try {
+    const value: unknown = JSON.parse(row.reviewer_device_ids_json);
+    return Array.isArray(value) && value.every((entry) => typeof entry === "string") ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function decodeAttempt(row: ExternalAttemptRow): PluginExternalVerificationAttemptSnapshot {
+  const decision = row.decision === "allow-always" ? "allow-always" : "allow-once";
+  const outcome =
+    row.outcome === "succeeded" ||
+    row.outcome === "failed" ||
+    row.outcome === "cancelled" ||
+    row.outcome === "timed-out"
+      ? row.outcome
+      : undefined;
+  return {
+    id: row.attempt_id,
+    context: {
+      approvalId: row.approval_id,
+      pluginId: row.plugin_id,
+      runId: row.run_id,
+      toolName: row.tool_name,
+      ...(row.tool_call_id ? { toolCallId: row.tool_call_id } : {}),
+      ...(row.agent_id ? { agentId: row.agent_id } : {}),
+      ...(row.session_key ? { sessionKey: row.session_key } : {}),
+      ...(row.session_id ? { sessionId: row.session_id } : {}),
+      decision,
+      label: row.label,
+      expiresAtMs: row.expires_at_ms,
+    },
+    createdAtMs: row.created_at_ms,
+    ...(row.ended_at_ms === null ? {} : { endedAtMs: row.ended_at_ms }),
+    ...(outcome ? { outcome } : {}),
+    ...(row.error_class ? { errorClass: row.error_class } : {}),
+    ...(row.terminal_source ? { terminalSource: row.terminal_source } : {}),
+  };
+}
+
+function decodeAttemptForDecision(
+  row: ExternalAttemptRow | undefined,
+  decision: "allow-once" | "allow-always",
+): PluginExternalVerificationAttemptSnapshot | undefined {
+  return row?.decision === decision ? decodeAttempt(row) : undefined;
+}
+
+function buildGrantAuthorization(
+  row: ExternalAttemptRow,
+): PluginExternalVerificationGrantAuthorization | undefined {
+  if (
+    row.outcome !== "succeeded" ||
+    row.decision !== "allow-always" ||
+    !row.grant_authorization_id ||
+    row.grant_issued_at_ms === null
+  ) {
+    return undefined;
+  }
+  return {
+    id: row.grant_authorization_id,
+    issuedAtMs: row.grant_issued_at_ms,
+    approvalId: row.approval_id,
+    attemptId: row.attempt_id,
+    decision: row.decision === "allow-always" ? "allow-always" : "allow-once",
+  };
+}
+
+function stableGrantAuthorizationId(attemptId: string): string {
+  return createHash("sha256").update(`external-verification:${attemptId}`).digest("base64url");
+}
+
+function bindInteractionIdToDecision(
+  interactionId: string,
+  decision: "allow-once" | "allow-always",
+): string {
+  return createHash("sha256")
+    .update(`external-verification-interaction:${interactionId}:${decision}`)
+    .digest("hex");
+}
+
+function selectAttempt(
+  database: OpenClawStateDatabase,
+  attemptId: string,
+): ExternalAttemptRow | undefined {
+  const stateDb = getNodeSqliteKysely<ExternalVerificationDatabase>(database.db);
+  return executeSqliteQueryTakeFirstSync(
+    database.db,
+    stateDb
+      .selectFrom("plugin_external_verification_attempts")
+      .selectAll()
+      .where("attempt_id", "=", attemptId),
+  );
+}
+
+function selectLatestAttempt(
+  database: OpenClawStateDatabase,
+  approvalId: string,
+): ExternalAttemptRow | undefined {
+  const stateDb = getNodeSqliteKysely<ExternalVerificationDatabase>(database.db);
+  return executeSqliteQueryTakeFirstSync(
+    database.db,
+    stateDb
+      .selectFrom("plugin_external_verification_attempts")
+      .selectAll()
+      .where("approval_id", "=", approvalId)
+      .orderBy(sql<number>`rowid`, "desc"),
+  );
+}
+
+function selectActiveAttempt(
+  database: OpenClawStateDatabase,
+  approvalId: string,
+): ExternalAttemptRow | undefined {
+  const stateDb = getNodeSqliteKysely<ExternalVerificationDatabase>(database.db);
+  return executeSqliteQueryTakeFirstSync(
+    database.db,
+    stateDb
+      .selectFrom("plugin_external_verification_attempts")
+      .selectAll()
+      .where("approval_id", "=", approvalId)
+      .where("ended_at_ms", "is", null),
+  );
+}
+
+function selectExternalApproval(params: {
+  database: OpenClawStateDatabase;
+  approvalId: string;
+  reviewerDeviceId?: string;
+  runtimeEpoch: string;
+}):
+  | { outcome: "ready"; approval: OperatorApprovalRow }
+  | { outcome: "approval-not-found" | "reviewer-unauthorized" } {
+  const stateDb = getNodeSqliteKysely<ExternalVerificationDatabase>(params.database.db);
+  const approval = executeSqliteQueryTakeFirstSync(
+    params.database.db,
+    stateDb
+      .selectFrom("operator_approvals")
+      .selectAll()
+      .where("approval_id", "=", params.approvalId),
+  );
+  if (!approval || approval.kind !== "plugin" || approval.runtime_epoch !== params.runtimeEpoch) {
+    return { outcome: "approval-not-found" };
+  }
+  const reviewerDeviceIds = readReviewerDeviceIds(approval);
+  if (
+    !reviewerDeviceIds ||
+    !isOperatorApprovalReviewerAuthorized({
+      reviewerDeviceId: params.reviewerDeviceId,
+      reviewerDeviceIds,
+    })
+  ) {
+    return { outcome: "reviewer-unauthorized" };
+  }
+  return { outcome: "ready", approval };
+}
+
+function validatePendingExternalApproval(params: {
+  database: OpenClawStateDatabase;
+  approval: OperatorApprovalRow;
+  decision: "allow-once" | "allow-always";
+  nowMs: number;
+}):
+  | {
+      outcome: "ready";
+      external: ExternalResolutionProjection;
+      pluginId: string;
+      runId: string;
+      toolName: string;
+    }
+  | { outcome: Exclude<ExternalVerificationUnavailableOutcome, "reviewer-unauthorized"> } {
+  const { approval } = params;
+  if (approval.status !== "pending") {
+    return { outcome: "approval-not-pending" };
+  }
+  if (approval.expires_at_ms <= params.nowMs) {
+    return { outcome: "approval-expired" };
+  }
+  const external = readExternalResolution(approval);
+  if (!external?.decisions.includes(params.decision)) {
+    return { outcome: "decision-unavailable" };
+  }
+  const pluginId = (() => {
+    try {
+      // SAFETY: presentation_json is host-written canonical presentation state.
+      const presentation = JSON.parse(approval.presentation_json) as {
+        pluginId?: unknown;
+      };
+      return typeof presentation.pluginId === "string" ? presentation.pluginId.trim() : "";
+    } catch {
+      return "";
+    }
+  })();
+  if (!pluginId) {
+    return { outcome: "owner-unavailable" };
+  }
+  const runId = approval.source_run_id?.trim() ?? "";
+  if (!runId) {
+    return { outcome: "run-unavailable" };
+  }
+  const toolName = approval.source_tool_name?.trim() ?? "";
+  if (!toolName) {
+    return { outcome: "approval-not-found" };
+  }
+  return { outcome: "ready", external, pluginId, runId, toolName };
+}
+
+/** Read the exact attempt generation a native approval action must bind. */
+export function getExternalVerificationNativeActionState(params: {
+  approvalId: string;
+  decision: "allow-once" | "allow-always";
+  reviewerDeviceId?: string;
+  runtimeEpoch: string;
+  nowMs?: number;
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): ExternalVerificationNativeActionState {
+  return runOpenClawStateWriteTransaction((database) => {
+    ensurePluginExternalVerificationSchema(database.db);
+    const selected = selectExternalApproval({ database, ...params });
+    if (selected.outcome !== "ready") {
+      return selected;
+    }
+    const validated = validatePendingExternalApproval({
+      database,
+      approval: selected.approval,
+      decision: params.decision,
+      nowMs: params.nowMs ?? Date.now(),
+    });
+    if (validated.outcome !== "ready") {
+      return validated;
+    }
+    const active = selectActiveAttempt(database, selected.approval.approval_id);
+    if (active) {
+      return {
+        outcome: "ready",
+        action: { intent: "retry", expectedAttemptId: active.attempt_id },
+      };
+    }
+    return {
+      outcome: "ready",
+      action: {
+        intent: "start",
+        expectedAttemptId:
+          selectLatestAttempt(database, selected.approval.approval_id)?.attempt_id ?? null,
+      },
+    };
+  }, params.databaseOptions);
+}
+
+/** Start or replay one reviewer interaction, replacing only an active prior attempt. */
+export function startExternalVerificationAttempt(params: {
+  approvalId: string;
+  decision: "allow-once" | "allow-always";
+  interactionId: string;
+  reviewerDeviceId?: string;
+  nativeAction?: NativeExternalVerificationAction;
+  runtimeEpoch: string;
+  nowMs?: number;
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): StartExternalVerificationResult {
+  return runOpenClawStateWriteTransaction((database) => {
+    ensurePluginExternalVerificationSchema(database.db);
+    const nowMs = params.nowMs ?? Date.now();
+    // Decision is part of the idempotency key: each authenticated interaction/decision
+    // pair starts once, so stale redelivery cannot revive superseded reviewer intent.
+    const interactionId = bindInteractionIdToDecision(params.interactionId, params.decision);
+    const selected = selectExternalApproval({ database, ...params });
+    if (selected.outcome !== "ready") {
+      return selected;
+    }
+    const approval = selected.approval;
+    const stateDb = getNodeSqliteKysely<ExternalVerificationDatabase>(database.db);
+    // The manager owns terminal lifecycle publication and in-memory cancellation.
+    // Report due state before replay so the runtime can expire through that owner.
+    if (approval.status === "pending" && approval.expires_at_ms <= nowMs) {
+      return { outcome: "approval-expired" };
+    }
+    const replay = executeSqliteQueryTakeFirstSync(
+      database.db,
+      stateDb
+        .selectFrom("plugin_external_verification_attempts")
+        .selectAll()
+        .where("approval_id", "=", approval.approval_id)
+        .where("interaction_id", "=", interactionId),
+    );
+    if (replay) {
+      if (params.nativeAction) {
+        const latest = selectLatestAttempt(database, approval.approval_id);
+        if (latest?.attempt_id !== replay.attempt_id) {
+          const attempt = decodeAttemptForDecision(latest, params.decision);
+          return {
+            outcome: "stale-action",
+            ...(attempt ? { attempt } : {}),
+          };
+        }
+      }
+      return { outcome: "replay", attempt: decodeAttempt(replay) };
+    }
+    const validated = validatePendingExternalApproval({
+      database,
+      approval,
+      decision: params.decision,
+      nowMs,
+    });
+    if (validated.outcome !== "ready") {
+      return validated;
+    }
+    if (params.nativeAction) {
+      const active = selectActiveAttempt(database, approval.approval_id);
+      const latest = selectLatestAttempt(database, approval.approval_id);
+      const actionMatches =
+        params.nativeAction.intent === "retry"
+          ? Boolean(
+              active &&
+              latest?.attempt_id === active.attempt_id &&
+              active.attempt_id === params.nativeAction.expectedAttemptId,
+            )
+          : !active && (latest?.attempt_id ?? null) === params.nativeAction.expectedAttemptId;
+      if (!actionMatches) {
+        const attempt = decodeAttemptForDecision(latest, params.decision);
+        return {
+          outcome: "stale-action",
+          ...(attempt ? { attempt } : {}),
+        };
+      }
+    }
+    executeSqliteQuerySync(
+      database.db,
+      stateDb
+        .updateTable("plugin_external_verification_attempts")
+        .set({
+          ended_at_ms: nowMs,
+          outcome: "cancelled",
+          terminal_source: "reviewer-retry",
+          completion_applied: 0,
+        })
+        .where("approval_id", "=", approval.approval_id)
+        .where("ended_at_ms", "is", null),
+    );
+    const attemptId = `external:${randomUUID()}`;
+    executeSqliteQuerySync(
+      database.db,
+      stateDb.insertInto("plugin_external_verification_attempts").values({
+        attempt_id: attemptId,
+        approval_id: approval.approval_id,
+        plugin_id: validated.pluginId,
+        run_id: validated.runId,
+        tool_name: validated.toolName,
+        tool_call_id: approval.source_tool_call_id,
+        agent_id: approval.source_agent_id,
+        session_key: approval.source_session_key,
+        session_id: approval.source_session_id,
+        interaction_id: interactionId,
+        decision: params.decision,
+        label: validated.external.label,
+        created_at_ms: nowMs,
+        expires_at_ms: approval.expires_at_ms,
+        ended_at_ms: null,
+        outcome: null,
+        error_class: null,
+        terminal_source: null,
+        completion_applied: null,
+        grant_authorization_id: null,
+        grant_issued_at_ms: null,
+        resolver_plugin_id: null,
+        runtime_epoch: params.runtimeEpoch,
+      }),
+    );
+    const attempt = selectAttempt(database, attemptId);
+    if (!attempt) {
+      throw new Error("external verification attempt was not readable after insert");
+    }
+    return { outcome: "started", attempt: decodeAttempt(attempt) };
+  }, params.databaseOptions);
+}
+
+function endExternalVerificationAttempt(params: {
+  attemptId: string;
+  pluginId: string;
+  outcome: "failed" | "cancelled";
+  errorClass?: string;
+  terminalSource: "verifier-error" | "verifier-retired";
+  nowMs?: number;
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): void {
+  runOpenClawStateWriteTransaction((database) => {
+    ensurePluginExternalVerificationSchema(database.db);
+    const stateDb = getNodeSqliteKysely<ExternalVerificationDatabase>(database.db);
+    executeSqliteQuerySync(
+      database.db,
+      stateDb
+        .updateTable("plugin_external_verification_attempts")
+        .set({
+          ended_at_ms: params.nowMs ?? Date.now(),
+          outcome: params.outcome,
+          error_class: params.errorClass ?? null,
+          terminal_source: params.terminalSource,
+          completion_applied: 0,
+        })
+        .where("attempt_id", "=", params.attemptId)
+        .where("plugin_id", "=", params.pluginId)
+        .where("ended_at_ms", "is", null),
+    );
+  }, params.databaseOptions);
+}
+
+/** Mark a verifier dispatch failure without resolving the owning approval. */
+export function failExternalVerificationAttempt(params: {
+  attemptId: string;
+  pluginId: string;
+  errorClass: string;
+  nowMs?: number;
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): void {
+  endExternalVerificationAttempt({
+    ...params,
+    outcome: "failed",
+    terminalSource: "verifier-error",
+  });
+}
+
+/** Cancel an attempt whose owning verifier instance is no longer live. */
+export function cancelRetiredExternalVerificationAttempt(params: {
+  attemptId: string;
+  pluginId: string;
+  nowMs?: number;
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): void {
+  endExternalVerificationAttempt({
+    ...params,
+    outcome: "cancelled",
+    terminalSource: "verifier-retired",
+  });
+}
+
+/** Complete an attempt and atomically authorize the canonical approval on success. */
+export function completeExternalVerificationAttempt(params: {
+  attemptId: string;
+  pluginId: string;
+  outcome: "succeeded" | "failed";
+  runtimeEpoch: string;
+  nowMs?: number;
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): CompleteExternalVerificationStoreResult {
+  return runOpenClawStateWriteTransaction((database) => {
+    ensurePluginExternalVerificationSchema(database.db);
+    const nowMs = params.nowMs ?? Date.now();
+    const stateDb = getNodeSqliteKysely<ExternalVerificationDatabase>(database.db);
+    let attempt = selectAttempt(database, params.attemptId);
+    if (!attempt || attempt.plugin_id !== params.pluginId) {
+      return { outcome: "attempt-not-found" };
+    }
+    if (attempt.ended_at_ms !== null) {
+      return {
+        outcome: "replay",
+        applied: false,
+        approvalId: attempt.approval_id,
+        attempt: decodeAttempt(attempt),
+        ...(buildGrantAuthorization(attempt)
+          ? { grantAuthorization: buildGrantAuthorization(attempt) }
+          : {}),
+      };
+    }
+    if (attempt.runtime_epoch !== params.runtimeEpoch) {
+      return { outcome: "attempt-not-found" };
+    }
+    if (params.outcome === "failed") {
+      executeSqliteQuerySync(
+        database.db,
+        stateDb
+          .updateTable("plugin_external_verification_attempts")
+          .set({
+            ended_at_ms: nowMs,
+            outcome: "failed",
+            terminal_source: "plugin-completion",
+            completion_applied: 0,
+          })
+          .where("attempt_id", "=", params.attemptId)
+          .where("ended_at_ms", "is", null),
+      );
+      attempt = selectAttempt(database, params.attemptId)!;
+      return {
+        outcome: "completed",
+        applied: false,
+        approvalId: attempt.approval_id,
+        attempt: decodeAttempt(attempt),
+      };
+    }
+    const approval = executeSqliteQueryTakeFirstSync(
+      database.db,
+      stateDb
+        .selectFrom("operator_approvals")
+        .selectAll()
+        .where("approval_id", "=", attempt.approval_id),
+    );
+    const matchesApproval =
+      approval?.kind === "plugin" &&
+      approval.runtime_epoch === params.runtimeEpoch &&
+      approval.status === "pending" &&
+      approval.source_run_id === attempt.run_id;
+    if (matchesApproval && approval.expires_at_ms <= nowMs) {
+      return { outcome: "approval-expired", approvalId: attempt.approval_id };
+    }
+    if (!matchesApproval) {
+      executeSqliteQuerySync(
+        database.db,
+        stateDb
+          .updateTable("plugin_external_verification_attempts")
+          .set({
+            ended_at_ms: nowMs,
+            outcome: "cancelled",
+            terminal_source: "approval-unavailable",
+            completion_applied: 0,
+          })
+          .where("attempt_id", "=", params.attemptId)
+          .where("ended_at_ms", "is", null),
+      );
+      attempt = selectAttempt(database, params.attemptId)!;
+      return {
+        outcome: "completed",
+        applied: false,
+        approvalId: attempt.approval_id,
+        attempt: decodeAttempt(attempt),
+      };
+    }
+    const external = readExternalResolution(approval);
+    if (
+      approval.presentation_json.length === 0 ||
+      !external?.decisions.includes(
+        attempt.decision === "allow-always" ? "allow-always" : "allow-once",
+      )
+    ) {
+      executeSqliteQuerySync(
+        database.db,
+        stateDb
+          .updateTable("plugin_external_verification_attempts")
+          .set({
+            ended_at_ms: nowMs,
+            outcome: "cancelled",
+            terminal_source: "decision-unavailable",
+            completion_applied: 0,
+          })
+          .where("attempt_id", "=", params.attemptId)
+          .where("ended_at_ms", "is", null),
+      );
+      attempt = selectAttempt(database, params.attemptId)!;
+      return {
+        outcome: "completed",
+        applied: false,
+        approvalId: attempt.approval_id,
+        attempt: decodeAttempt(attempt),
+      };
+    }
+    const reusable = attempt.decision === "allow-always";
+    const grantAuthorizationId = reusable ? stableGrantAuthorizationId(attempt.attempt_id) : null;
+    executeSqliteQuerySync(
+      database.db,
+      stateDb
+        .updateTable("plugin_external_verification_attempts")
+        .set({
+          ended_at_ms: nowMs,
+          outcome: "succeeded",
+          terminal_source: "plugin-completion",
+          completion_applied: 1,
+          grant_authorization_id: grantAuthorizationId,
+          grant_issued_at_ms: reusable ? nowMs : null,
+          resolver_plugin_id: params.pluginId,
+        })
+        .where("attempt_id", "=", params.attemptId)
+        .where("ended_at_ms", "is", null),
+    );
+    const approvalUpdate = executeSqliteQuerySync(
+      database.db,
+      stateDb
+        .updateTable("operator_approvals")
+        .set({
+          status: "allowed",
+          decision: attempt.decision,
+          terminal_reason: "user",
+          resolved_at_ms: nowMs,
+          resolver_kind: "runtime",
+          resolver_id: `plugin:${params.pluginId}`,
+          updated_at_ms: nowMs,
+        })
+        .where("approval_id", "=", attempt.approval_id)
+        .where("status", "=", "pending")
+        .where("runtime_epoch", "=", params.runtimeEpoch)
+        .where("expires_at_ms", ">", nowMs),
+    );
+    if (approvalUpdate.numAffectedRows !== 1n) {
+      throw new Error("external verification lost approval authorization after validation");
+    }
+    attempt = selectAttempt(database, params.attemptId)!;
+    const grantAuthorization = buildGrantAuthorization(attempt);
+    return {
+      outcome: "completed",
+      applied: true,
+      approvalId: attempt.approval_id,
+      attempt: decodeAttempt(attempt),
+      ...(grantAuthorization ? { grantAuthorization } : {}),
+    };
+  }, params.databaseOptions);
+}

--- a/src/gateway/server-aux-handlers.ts
+++ b/src/gateway/server-aux-handlers.ts
@@ -46,6 +46,7 @@ import {
   closeOrphanedOperatorApprovals,
   pruneTerminalOperatorApprovals,
 } from "./operator-approval-store.js";
+import { PluginExternalVerificationRuntime } from "./plugin-external-verification-runtime.js";
 import { QuestionManager } from "./question-manager.js";
 import { publishAppliedApprovalResolution } from "./server-methods/approval-publication.js";
 import {
@@ -104,6 +105,7 @@ export function createGatewayAuxHandlers(
   const presentationWork = new AsyncWorkScope();
   const trackPresentationWork = (run: () => Promise<void>): Promise<void> =>
     presentationWork.track(() => runWithRetainedGatewayRootWork(run));
+  let externalVerificationRuntime: PluginExternalVerificationRuntime | null = null;
   const createApprovalManager = <TPayload extends ApprovalPayload>(
     approvalKind: "exec" | "plugin" | "system-agent",
     resolveAllowedDecisions: (request: TPayload) => readonly ExecApprovalDecision[],
@@ -120,7 +122,10 @@ export function createGatewayAuxHandlers(
       ...(params.resolveGrantDefaultExpiresAtMs
         ? { resolveStandingGrantExpiresAtMs: params.resolveGrantDefaultExpiresAtMs }
         : {}),
-      onLifecycle: params.onApprovalLifecycle,
+      onLifecycle: (event) => {
+        params.onApprovalLifecycle?.(event);
+        externalVerificationRuntime?.onApprovalLifecycle(event);
+      },
       // Timeout expiry is gateway-clock truth: publish the terminal like a
       // resolve so reviewer surfaces need not infer it from their own clocks.
       onExpired: (record, liveRecord) =>
@@ -228,6 +233,12 @@ export function createGatewayAuxHandlers(
   );
   const approvalManagers = [execApprovalManager, pluginApprovalManager, systemAgentApprovalManager];
   const pluginApprovalIosPushDelivery = createPluginApprovalIosPushDelivery({ log: params.log });
+  externalVerificationRuntime = new PluginExternalVerificationRuntime({
+    manager: pluginApprovalManager,
+    runtimeEpoch: approvalPersistence.runtimeEpoch,
+    forwarder: execApprovalForwarder,
+    iosPushDelivery: pluginApprovalIosPushDelivery,
+  });
   type PendingAuthorityPublication = {
     kind: ChannelApprovalKind;
     record: Parameters<typeof publishAppliedApprovalResolution>[0]["record"];
@@ -353,6 +364,7 @@ export function createGatewayAuxHandlers(
         createPluginApprovalHandlers(pluginApprovalManager, {
           forwarder: execApprovalForwarder,
           iosPushDelivery: pluginApprovalIosPushDelivery,
+          externalVerificationRuntime,
         }),
       ),
     { cacheRejections: true },
@@ -442,6 +454,7 @@ export function createGatewayAuxHandlers(
 
   return {
     execApprovalManager,
+    externalVerificationRuntime,
     cancelRunBoundApprovals,
     forwardPluginApprovalRequest: execApprovalForwarder.handlePluginApprovalRequested,
     approvalWebPushDelivery,
@@ -471,6 +484,14 @@ export function createGatewayAuxHandlers(
         loadExecApprovalHandlers,
       ),
       "plugin.approval.list": createLazyHandler("plugin.approval.list", loadPluginApprovalHandlers),
+      "plugin.approval.external.prepare": createLazyHandler(
+        "plugin.approval.external.prepare",
+        loadPluginApprovalHandlers,
+      ),
+      "plugin.approval.external.start": createLazyHandler(
+        "plugin.approval.external.start",
+        loadPluginApprovalHandlers,
+      ),
       "plugin.approval.request": createLazyHandler(
         "plugin.approval.request",
         loadPluginApprovalHandlers,

--- a/src/gateway/server-aux-methods.ts
+++ b/src/gateway/server-aux-methods.ts
@@ -10,6 +10,8 @@ export const GATEWAY_AUX_METHODS = [
   "exec.approval.grants.list",
   "exec.approval.grants.revoke",
   "plugin.approval.list",
+  "plugin.approval.external.prepare",
+  "plugin.approval.external.start",
   "plugin.approval.request",
   "plugin.approval.waitDecision",
   "plugin.approval.resolve",

--- a/src/gateway/server-core-runtime.ts
+++ b/src/gateway/server-core-runtime.ts
@@ -285,6 +285,7 @@ export async function startGatewayCoreRuntime(input: {
 
   const {
     execApprovalManager,
+    externalVerificationRuntime,
     questionManager,
     cancelRunBoundApprovals,
     forwardPluginApprovalRequest,
@@ -348,6 +349,11 @@ export async function startGatewayCoreRuntime(input: {
     stop: async () => {
       requestLifetime.removeEventListener("abort", beginCloseApprovalObservers);
       await stopOperatorInteractions();
+    },
+  });
+  kernel.addGatewayLifetimeSidecar({
+    stop: async () => {
+      externalVerificationRuntime.shutdown();
     },
   });
   approvalManagersForReplay.set("exec", execApprovalManager);
@@ -638,6 +644,7 @@ export async function startGatewayCoreRuntime(input: {
     sessionObserver,
     approvalSessionEvents,
     execApprovalManager,
+    externalVerificationRuntime,
     questionManager,
     cancelRunBoundApprovals,
     forwardPluginApprovalRequest,

--- a/src/gateway/server-kernel-request-runtime.ts
+++ b/src/gateway/server-kernel-request-runtime.ts
@@ -47,6 +47,7 @@ export async function prepareGatewayKernelRequestRuntime(params: {
     placementStandingGrants,
     systemAgentApprovalManager,
     bindApprovalPublicationContext,
+    externalVerificationRuntime,
     validateAgentRuntimeApprovalAuthority,
     approvalSessionEvents,
     startupTrace,
@@ -249,6 +250,7 @@ export async function prepareGatewayKernelRequestRuntime(params: {
   });
   gatewayRequestContext.requestEntryLifetime = runtime.requestEntryLifetime;
   bindApprovalPublicationContext(gatewayRequestContext);
+  externalVerificationRuntime.attachContext(gatewayRequestContext);
   await attachInitialGatewayLifetimeSidecars({
     chatMetadataLifecycle,
     gatewayRequestContext,

--- a/src/gateway/server-methods/approval.test.ts
+++ b/src/gateway/server-methods/approval.test.ts
@@ -905,6 +905,10 @@ describe("unified approval handlers", () => {
       id: "completed-run-approval",
       request: { runId: "run-completed", toolCallId: "tool-completed" },
     });
+    const plugin = registerPlugin(managers.plugin, {
+      id: "aborted-run-plugin-approval",
+      request: { runId: "run-active", toolCallId: "plugin-tool-active" },
+    });
     const context = createContext();
     const publish = vi.fn();
 
@@ -913,11 +917,21 @@ describe("unified approval handlers", () => {
         runId: "run-active",
         manager: managers.exec,
         publish,
-      }),
-    ).toBe(1);
+      }) +
+        cancelUnboundRunApprovals({
+          runId: "run-active",
+          manager: managers.plugin,
+          publish,
+        }),
+    ).toBe(2);
 
     await expect(aborted.decision).resolves.toBeNull();
+    await expect(plugin.decision).resolves.toBeNull();
     expect(managers.exec.getSnapshot(aborted.record.id)).toMatchObject({
+      status: "cancelled",
+      terminalReason: "run-aborted",
+    });
+    expect(managers.plugin.getSnapshot(plugin.record.id)).toMatchObject({
       status: "cancelled",
       terminalReason: "run-aborted",
     });

--- a/src/gateway/server-methods/approval.ts
+++ b/src/gateway/server-methods/approval.ts
@@ -57,7 +57,7 @@ type CreateApprovalHandlersParams = {
   databaseOptions?: OpenClawStateDatabaseOptions;
 };
 
-function buildApprovalSnapshot(
+export function buildApprovalSnapshot(
   record: OperatorApprovalRecord,
   controlUiBasePath: string,
 ): ApprovalSnapshot | null {

--- a/src/gateway/server-methods/plugin-approval.external-resolution.test.ts
+++ b/src/gateway/server-methods/plugin-approval.external-resolution.test.ts
@@ -1,0 +1,256 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginApprovalRequestPayload } from "../../infra/plugin-approvals.js";
+import type { ExecApprovalManager } from "../exec-approval-manager.js";
+import { createTestApprovalManager } from "../exec-approval-manager.test-support.js";
+import { createPluginApprovalHandlers } from "./plugin-approval.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+
+function createClient(approvalRuntime = false): GatewayRequestHandlerOptions["client"] {
+  return {
+    connId: "conn-test-client",
+    connect: {
+      client: {
+        id: "test-client",
+        displayName: "Test Client",
+      },
+    },
+    ...(approvalRuntime ? { internal: { approvalRuntime: true } } : {}),
+  } as unknown as GatewayRequestHandlerOptions["client"];
+}
+
+function createApprovalContext(
+  hasAbortMarker: (runId: string) => boolean = () => false,
+): GatewayRequestHandlerOptions["context"] {
+  return {
+    broadcast: vi.fn(),
+    logGateway: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+    hasExecApprovalClients: () => true,
+    chatRunState: { hasAbortMarker },
+  } as unknown as GatewayRequestHandlerOptions["context"];
+}
+
+function createOptions(
+  method: string,
+  params: Record<string, unknown>,
+  overrides: Partial<GatewayRequestHandlerOptions> = {},
+): GatewayRequestHandlerOptions {
+  return {
+    req: { method, params, id: "req-1" },
+    params,
+    client: createClient(),
+    isWebchatConnect: () => false,
+    respond: vi.fn(),
+    context: createApprovalContext(),
+    ...overrides,
+  } as unknown as GatewayRequestHandlerOptions;
+}
+
+type MockCallSource = {
+  mock: {
+    calls: ArrayLike<ReadonlyArray<unknown>>;
+  };
+};
+
+function responseCall(source: unknown, index = 0) {
+  const call = (source as MockCallSource).mock.calls[index];
+  if (!call) {
+    throw new Error(`Expected response call ${index}`);
+  }
+  return {
+    ok: call[0],
+    result: call[1],
+    error: call[2] as Record<string, unknown> | undefined,
+  };
+}
+
+async function waitForAcceptedApproval(respond: unknown): Promise<string> {
+  let approvalId: string | undefined;
+  await vi.waitFor(() => {
+    const calls = Array.from((respond as MockCallSource).mock.calls);
+    const accepted = calls.find((call) => {
+      const result = call[1];
+      return (
+        typeof result === "object" &&
+        result !== null &&
+        "status" in result &&
+        (result as { status?: unknown }).status === "accepted"
+      );
+    });
+    const result = accepted?.[1] as { id?: unknown } | undefined;
+    expect(result?.id).toBeTypeOf("string");
+    approvalId = result?.id as string;
+  });
+  return expectDefined(approvalId, "accepted approval id");
+}
+
+describe("plugin external approval resolution", () => {
+  let manager: ExecApprovalManager<PluginApprovalRequestPayload>;
+
+  beforeEach((testContext) => {
+    manager = createTestApprovalManager<PluginApprovalRequestPayload>(testContext, {
+      approvalKind: "plugin",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects externalResolution from ordinary Gateway callers", async () => {
+    const handlers = createPluginApprovalHandlers(manager);
+    const opts = createOptions("plugin.approval.request", {
+      title: "T",
+      description: "D",
+      externalResolution: { label: "Verify with World" },
+    });
+
+    await expectDefined(
+      handlers["plugin.approval.request"],
+      'handlers["plugin.approval.request"] test invariant',
+    )(opts);
+
+    expect(responseCall(opts.respond).ok).toBe(false);
+    expect(responseCall(opts.respond).error?.message).toContain("unexpected property");
+  });
+
+  it("accepts host-bound verification only for the internal approval runtime", async () => {
+    const handlers = createPluginApprovalHandlers(manager);
+    const respond = vi.fn();
+    const opts = createOptions(
+      "plugin.approval.request",
+      {
+        pluginId: "agentkit",
+        title: "T",
+        description: "D",
+        toolName: "dangerous-tool",
+        allowedDecisions: ["deny"],
+        externalResolution: {
+          label: "Verify with World",
+          decisions: ["allow-once", "allow-always"],
+        },
+        runId: "run-1",
+        sessionId: "session-1",
+        twoPhase: true,
+      },
+      { client: createClient(true), respond },
+    );
+    const handlerPromise = expectDefined(
+      handlers["plugin.approval.request"],
+      'handlers["plugin.approval.request"] test invariant',
+    )(opts);
+    const approvalId = await waitForAcceptedApproval(respond);
+
+    expect(manager.getSnapshot(approvalId)?.request).toMatchObject({
+      pluginId: "agentkit",
+      toolName: "dangerous-tool",
+      runId: "run-1",
+      sessionId: "session-1",
+      allowedDecisions: ["deny"],
+      externalResolution: {
+        label: "Verify with World",
+        decisions: ["allow-once", "allow-always"],
+      },
+    });
+
+    const genericAllow = createOptions("plugin.approval.resolve", {
+      id: approvalId,
+      decision: "allow-once",
+    });
+    await expectDefined(
+      handlers["plugin.approval.resolve"],
+      'handlers["plugin.approval.resolve"] test invariant',
+    )(genericAllow);
+
+    expect(responseCall(genericAllow.respond).ok).toBe(false);
+    expect(responseCall(genericAllow.respond).error).toMatchObject({
+      details: { allowedDecisions: ["deny"] },
+    });
+    expect(manager.getSnapshot(approvalId)?.resolvedAtMs).toBeUndefined();
+    manager.resolve(approvalId, "deny");
+    await handlerPromise;
+  });
+
+  it("rejects missing host bindings and overlapping generic allow decisions", async () => {
+    const handlers = createPluginApprovalHandlers(manager);
+    const invalidRequests = [
+      {
+        pluginId: "agentkit",
+        title: "T",
+        description: "D",
+        toolName: "dangerous-tool",
+        allowedDecisions: ["deny"],
+        externalResolution: { label: "Verify with World" },
+      },
+      {
+        title: "T",
+        description: "D",
+        toolName: "dangerous-tool",
+        runId: "run-1",
+        externalResolution: { label: "Verify with World" },
+      },
+      {
+        pluginId: "agentkit",
+        title: "T",
+        description: "D",
+        runId: "run-1",
+        externalResolution: { label: "Verify with World" },
+      },
+      {
+        pluginId: "agentkit",
+        title: "T",
+        description: "D",
+        toolName: "dangerous-tool",
+        allowedDecisions: ["allow-once", "deny"],
+        externalResolution: { label: "Verify with World" },
+        runId: "run-1",
+      },
+    ];
+
+    for (const request of invalidRequests) {
+      const opts = createOptions("plugin.approval.request", request, {
+        client: createClient(true),
+      });
+      await expectDefined(
+        handlers["plugin.approval.request"],
+        'handlers["plugin.approval.request"] test invariant',
+      )(opts);
+      expect(responseCall(opts.respond).ok).toBe(false);
+    }
+  });
+
+  it("rejects verification after the owning run was aborted", async () => {
+    const handlers = createPluginApprovalHandlers(manager);
+    const context = createApprovalContext((runId) => runId === "run-aborted");
+    const opts = createOptions(
+      "plugin.approval.request",
+      {
+        pluginId: "agentkit",
+        title: "T",
+        description: "D",
+        toolName: "dangerous-tool",
+        allowedDecisions: ["deny"],
+        externalResolution: { label: "Verify with World" },
+        runId: "run-aborted",
+        twoPhase: true,
+      },
+      {
+        client: createClient(true),
+        context,
+      },
+    );
+
+    await expectDefined(
+      handlers["plugin.approval.request"],
+      'handlers["plugin.approval.request"] test invariant',
+    )(opts);
+
+    expect(responseCall(opts.respond).ok).toBe(false);
+    expect(responseCall(opts.respond).error).toMatchObject({
+      message: "approval run already aborted",
+      details: { reason: "PLUGIN_APPROVAL_RUN_ABORTED" },
+    });
+    expect(manager.listPendingRecords()).toEqual([]);
+    expect(context.broadcast).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-methods/plugin-approval.external.test.ts
+++ b/src/gateway/server-methods/plugin-approval.external.test.ts
@@ -1,0 +1,277 @@
+// External verification surface of the plugin approval handlers: native
+// prepare/start actions, method registration/classification, and param
+// validation. Split out of plugin-approval.test.ts to keep that file within
+// the max-lines budget; helpers mirror the ones there (same shapes).
+
+import { expectDefined } from "@openclaw/normalization-core";
+import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
+import { afterEach, beforeEach, describe, expect, it, vi, type TestContext } from "vitest";
+import type { PluginApprovalRequestPayload } from "../../infra/plugin-approvals.js";
+import type { ExecApprovalManager } from "../exec-approval-manager.js";
+import { createTestApprovalManager } from "../exec-approval-manager.test-support.js";
+import { isGatewayMethodClassified } from "../method-scopes.js";
+import type { PluginExternalVerificationRuntime } from "../plugin-external-verification-runtime.js";
+import { listGatewayMethods } from "../server-methods-list.js";
+import { createPluginApprovalHandlers } from "./plugin-approval.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+
+function createManager(testContext: TestContext) {
+  return createTestApprovalManager<PluginApprovalRequestPayload>(testContext, {
+    approvalKind: "plugin",
+  });
+}
+
+function createLogGatewayMock() {
+  return { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
+}
+
+function createApprovalContext(): GatewayRequestHandlerOptions["context"] {
+  return {
+    broadcast: vi.fn(),
+    logGateway: createLogGatewayMock(),
+    hasExecApprovalClients: () => true,
+  } as unknown as GatewayRequestHandlerOptions["context"];
+}
+
+function createClient(
+  params: { deviceId?: string; scopes?: string[] } = {},
+): GatewayRequestHandlerOptions["client"] {
+  const connect: Record<string, unknown> = {
+    client: { id: "test-client", displayName: "Test Client" },
+  };
+  if (params.deviceId) {
+    connect.device = { id: params.deviceId };
+  }
+  if (params.scopes) {
+    connect.scopes = params.scopes;
+  }
+  return {
+    connId: "conn-test-client",
+    connect,
+  } as unknown as GatewayRequestHandlerOptions["client"];
+}
+
+function createMockOptions(
+  method: string,
+  params: Record<string, unknown>,
+  overrides?: Partial<GatewayRequestHandlerOptions>,
+): GatewayRequestHandlerOptions {
+  return {
+    req: { method, params, id: "req-1" },
+    params,
+    client: createClient(),
+    isWebchatConnect: () => false,
+    respond: vi.fn(),
+    context: createApprovalContext(),
+    ...overrides,
+  } as unknown as GatewayRequestHandlerOptions;
+}
+
+type MockCallSource = { mock: { calls: ArrayLike<ReadonlyArray<unknown>> } };
+
+const requireRecord = createRequireRecord("object", "expected-label");
+
+function mockCall(source: unknown, index: number, label: string) {
+  const call = (source as MockCallSource).mock.calls[index];
+  if (!call) {
+    throw new Error(`Expected ${label}`);
+  }
+  return call;
+}
+
+function responseCall(source: unknown, index = 0) {
+  const call = mockCall(source, index, `response call ${index}`);
+  return { ok: call[0], result: call[1], error: call[2] };
+}
+
+function responseError(source: unknown, index = 0) {
+  return requireRecord(responseCall(source, index).error, `response error ${index}`);
+}
+
+function expectResponseRejected(source: unknown, index = 0) {
+  expect(responseCall(source, index).ok).toBe(false);
+  return responseError(source, index);
+}
+
+const externalMethods = [
+  "plugin.approval.external.prepare",
+  "plugin.approval.external.start",
+] as const;
+
+describe("plugin approval external verification handlers", () => {
+  let manager: ExecApprovalManager<PluginApprovalRequestPayload>;
+
+  beforeEach((testContext) => {
+    manager = createManager(testContext);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lists and classifies the external verification methods", () => {
+    for (const method of externalMethods) {
+      expect(listGatewayMethods()).toContain(method);
+      expect(isGatewayMethodClassified(method)).toBe(true);
+    }
+  });
+
+  it("returns handlers for every plugin approval method", () => {
+    const handlers = createPluginApprovalHandlers(manager);
+    expect(Object.keys(handlers).toSorted()).toEqual([
+      "plugin.approval.external.prepare",
+      "plugin.approval.external.start",
+      "plugin.approval.list",
+      "plugin.approval.request",
+      "plugin.approval.resolve",
+      "plugin.approval.waitDecision",
+    ]);
+  });
+
+  describe("native external verification actions", () => {
+    it("prepares and starts an action for an authorized paired reviewer", async () => {
+      const prepareNativeAction = vi.fn().mockReturnValue({
+        intent: "start",
+        token: "external-action:test",
+      });
+      const dispatchNativeAction = vi.fn().mockResolvedValue({
+        outcome: "started",
+        presentations: ["Scan challenge"],
+      });
+      const externalVerificationRuntime = {
+        prepareNativeAction,
+        dispatchNativeAction,
+      } as unknown as PluginExternalVerificationRuntime;
+      const handlers = createPluginApprovalHandlers(manager, {
+        externalVerificationRuntime,
+      });
+      const client = createClient({
+        deviceId: "device-reviewer",
+        scopes: ["operator.approvals"],
+      });
+      const prepareRespond = vi.fn();
+      await expectDefined(
+        handlers["plugin.approval.external.prepare"],
+        "prepare handler test invariant",
+      )(
+        createMockOptions(
+          "plugin.approval.external.prepare",
+          { id: "plugin:approval-1", decision: "allow-once" },
+          { client, respond: prepareRespond },
+        ),
+      );
+      expect(prepareRespond).toHaveBeenCalledWith(
+        true,
+        { intent: "start", actionToken: "external-action:test" },
+        undefined,
+      );
+      expect(prepareNativeAction).toHaveBeenCalledWith({
+        approvalId: "plugin:approval-1",
+        decision: "allow-once",
+        reviewerDeviceId: "device-reviewer",
+      });
+
+      const startRespond = vi.fn();
+      await expectDefined(
+        handlers["plugin.approval.external.start"],
+        "start handler test invariant",
+      )(
+        createMockOptions(
+          "plugin.approval.external.start",
+          {
+            id: "plugin:approval-1",
+            decision: "allow-once",
+            actionToken: "external-action:test",
+          },
+          { client, respond: startRespond },
+        ),
+      );
+      expect(startRespond).toHaveBeenCalledWith(
+        true,
+        { outcome: "started", presentations: ["Scan challenge"] },
+        undefined,
+      );
+      expect(dispatchNativeAction).toHaveBeenCalledWith({
+        approvalId: "plugin:approval-1",
+        decision: "allow-once",
+        reviewerDeviceId: "device-reviewer",
+        token: "external-action:test",
+      });
+    });
+
+    it("rejects a native replay whose verifier attempt already failed", async () => {
+      const handlers = createPluginApprovalHandlers(manager, {
+        externalVerificationRuntime: {
+          dispatchNativeAction: vi.fn().mockResolvedValue({
+            outcome: "replay",
+            presentations: [],
+            attempt: { outcome: "failed" },
+          }),
+        } as unknown as PluginExternalVerificationRuntime,
+      });
+      const respond = vi.fn();
+      await expectDefined(
+        handlers["plugin.approval.external.start"],
+        "start handler test invariant",
+      )(
+        createMockOptions(
+          "plugin.approval.external.start",
+          {
+            id: "plugin:approval-1",
+            decision: "allow-once",
+            actionToken: "external-action:test",
+          },
+          {
+            client: createClient({
+              deviceId: "device-reviewer",
+              scopes: ["operator.approvals"],
+            }),
+            respond,
+          },
+        ),
+      );
+
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          message: "external verification attempt failed",
+        }),
+      );
+    });
+
+    it("rejects an approval-scoped client without a paired reviewer device", async () => {
+      const prepareNativeAction = vi.fn();
+      const handlers = createPluginApprovalHandlers(manager, {
+        externalVerificationRuntime: {
+          prepareNativeAction,
+        } as unknown as PluginExternalVerificationRuntime,
+      });
+      const respond = vi.fn();
+      await expectDefined(
+        handlers["plugin.approval.external.prepare"],
+        "prepare handler test invariant",
+      )(
+        createMockOptions(
+          "plugin.approval.external.prepare",
+          { id: "plugin:approval-1", decision: "allow-once" },
+          {
+            client: createClient({ scopes: ["operator.approvals"] }),
+            respond,
+          },
+        ),
+      );
+      expect(responseCall(respond).ok).toBe(false);
+      expect(responseError(respond).message).toContain("authorized approval reviewer");
+      expect(prepareNativeAction).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each(externalMethods)("%s rejects invalid params", async (method) => {
+    const handlers = createPluginApprovalHandlers(manager);
+    const opts = createMockOptions(method, {});
+    await expectDefined(handlers[method], "handlers[method] test invariant")(opts);
+    expect(responseCall(opts.respond).result).toBeUndefined();
+    expect(expectResponseRejected(opts.respond).code).toBeTypeOf("string");
+  });
+});

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -262,16 +262,6 @@ describe("createPluginApprovalHandlers", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns handlers for every plugin approval method", () => {
-    const handlers = createPluginApprovalHandlers(manager);
-    expect(Object.keys(handlers).toSorted()).toEqual([
-      "plugin.approval.list",
-      "plugin.approval.request",
-      "plugin.approval.resolve",
-      "plugin.approval.waitDecision",
-    ]);
-  });
-
   describe("invalid params", () => {
     it.each(invalidParamMethodCases)("$method rejects invalid params", async ({ method }) => {
       const handlers = createPluginApprovalHandlers(manager);

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -4,10 +4,14 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import {
   ErrorCodes,
   errorShape,
+  formatValidationErrors,
+  validatePluginApprovalExternalPrepareParams,
+  validatePluginApprovalExternalStartParams,
   validatePluginApprovalRequestParams,
   validatePluginApprovalResolveParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { sanitizeApprovalScope, type ApprovalScope } from "../../infra/approval-scope.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
 import {
   exceedsApprovalTextLimit,
@@ -22,12 +26,15 @@ import type {
   PluginApprovalResolved,
 } from "../../infra/plugin-approvals.js";
 import {
+  normalizePluginExternalResolution,
   PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH,
   PLUGIN_APPROVAL_TITLE_MAX_LENGTH,
   resolvePluginApprovalTimeoutMs,
   truncatePluginApprovalDetail,
 } from "../../infra/plugin-approvals.js";
 import type { ExecApprovalManager } from "../exec-approval-manager.js";
+import { canReviewOperatorApproval } from "../operator-approval-authorization.js";
+import type { PluginExternalVerificationRuntime } from "../plugin-external-verification-runtime.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { resolveStoredSessionKeyForAgentStore } from "../session-store-key.js";
 import { runApprovalRequestDeliveries } from "./approval-request-delivery.js";
@@ -43,7 +50,6 @@ import {
   resolveApprovalDecisionParams,
 } from "./approval-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
-import { assertValidParams } from "./validation.js";
 
 type PluginApprovalIosPushDelivery = {
   handleRequested?: (
@@ -59,7 +65,11 @@ type PluginApprovalIosPushDelivery = {
 /** Create plugin approval handlers backed by the shared approval manager. */
 export function createPluginApprovalHandlers(
   manager: ExecApprovalManager<PluginApprovalRequestPayload>,
-  opts?: { forwarder?: ExecApprovalForwarder; iosPushDelivery?: PluginApprovalIosPushDelivery },
+  opts?: {
+    forwarder?: ExecApprovalForwarder;
+    iosPushDelivery?: PluginApprovalIosPushDelivery;
+    externalVerificationRuntime?: PluginExternalVerificationRuntime;
+  },
 ): GatewayRequestHandlers {
   return {
     "plugin.approval.list": async ({ respond, client, context }) => {
@@ -74,18 +84,144 @@ export function createPluginApprovalHandlers(
         undefined,
       );
     },
-    "plugin.approval.request": async ({ params, client, respond, context }) => {
-      if (
-        !assertValidParams(
-          params,
-          validatePluginApprovalRequestParams,
-          "plugin.approval.request",
-          respond,
-        )
-      ) {
+    "plugin.approval.external.prepare": async ({ params, respond, client }) => {
+      if (!validatePluginApprovalExternalPrepareParams(params)) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `invalid plugin.approval.external.prepare params: ${formatValidationErrors(
+              validatePluginApprovalExternalPrepareParams.errors,
+            )}`,
+          ),
+        );
+        return;
+      }
+      if (!canReviewOperatorApproval(client)) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.FORBIDDEN,
+            "external verification actions require an authorized approval reviewer",
+          ),
+        );
         return;
       }
       const p = params as {
+        id: string;
+        decision: "allow-once" | "allow-always";
+      };
+      try {
+        const prepared = opts?.externalVerificationRuntime?.prepareNativeAction({
+          approvalId: p.id,
+          decision: p.decision,
+          reviewerDeviceId: client?.connect.device?.id,
+        });
+        if (!prepared) {
+          throw new Error("external verification approval runtime is not available");
+        }
+        respond(true, { intent: prepared.intent, actionToken: prepared.token }, undefined);
+      } catch (error) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, formatErrorMessage(error)),
+        );
+      }
+    },
+    "plugin.approval.external.start": async ({ params, respond, client }) => {
+      if (!validatePluginApprovalExternalStartParams(params)) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `invalid plugin.approval.external.start params: ${formatValidationErrors(
+              validatePluginApprovalExternalStartParams.errors,
+            )}`,
+          ),
+        );
+        return;
+      }
+      if (!canReviewOperatorApproval(client)) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.FORBIDDEN,
+            "external verification actions require an authorized approval reviewer",
+          ),
+        );
+        return;
+      }
+      const p = params as {
+        id: string;
+        decision: "allow-once" | "allow-always";
+        actionToken: string;
+      };
+      try {
+        const dispatched = await opts?.externalVerificationRuntime?.dispatchNativeAction({
+          approvalId: p.id,
+          decision: p.decision,
+          reviewerDeviceId: client?.connect.device?.id,
+          token: p.actionToken,
+        });
+        if (!dispatched) {
+          throw new Error("external verification approval runtime is not available");
+        }
+        const attemptOutcome = dispatched.attempt?.outcome;
+        if (
+          attemptOutcome === "failed" ||
+          attemptOutcome === "cancelled" ||
+          attemptOutcome === "timed-out"
+        ) {
+          throw new Error(`external verification attempt ${attemptOutcome}`);
+        }
+        respond(
+          true,
+          { outcome: dispatched.outcome, presentations: dispatched.presentations },
+          undefined,
+        );
+      } catch (error) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, formatErrorMessage(error)),
+        );
+      }
+    },
+    "plugin.approval.request": async ({ params, client, respond, context }) => {
+      const internalRequest =
+        client?.internal?.approvalRuntime === true &&
+        typeof params === "object" &&
+        params !== null &&
+        !Array.isArray(params);
+      // SAFETY: internalRequest already proved params is a non-array object.
+      const rawParams = internalRequest ? (params as Record<string, unknown>) : null;
+      const publicParams = rawParams
+        ? Object.fromEntries(
+            Object.entries(rawParams).filter(
+              ([key]) => key !== "externalResolution" && key !== "runId" && key !== "sessionId",
+            ),
+          )
+        : params;
+      if (!validatePluginApprovalRequestParams(publicParams)) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `invalid plugin.approval.request params: ${formatValidationErrors(
+              validatePluginApprovalRequestParams.errors,
+            )}`,
+          ),
+        );
+        return;
+      }
+      // SAFETY: validatePluginApprovalRequestParams accepted publicParams above.
+      const p = publicParams as {
         pluginId?: string | null;
         title: string;
         description: string;
@@ -106,9 +242,72 @@ export function createPluginApprovalHandlers(
         timeoutMs?: number;
         twoPhase?: boolean;
       };
+      let externalResolution: PluginApprovalRequestPayload["externalResolution"];
+      try {
+        externalResolution = internalRequest
+          ? normalizePluginExternalResolution(
+              // SAFETY: normalizePluginExternalResolution validates or throws on this shape.
+              rawParams?.externalResolution as PluginApprovalRequestPayload["externalResolution"],
+            )
+          : null;
+      } catch (error) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, `invalid external verification: ${String(error)}`),
+        );
+        return;
+      }
+      const runId = internalRequest
+        ? normalizeOptionalString(rawParams?.runId as string | undefined) // SAFETY: normalizeOptionalString rejects every non-string value.
+        : null;
+      const pluginId = normalizeOptionalString(p.pluginId ?? undefined);
+      const toolName = normalizeOptionalString(p.toolName ?? undefined);
+      const trustedAgentRuntime = client?.internal?.agentRuntimeIdentity;
+      // Ownership for external verification is host-derived: the signed agent
+      // runtime identity owner wins; an explicit payload pluginId only reaches
+      // here from trusted in-process approval-runtime clients.
+      const externalOwnerPluginId = trustedAgentRuntime?.approvalOwnerPluginId ?? pluginId;
+      if (externalResolution && !runId) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "external verification requires a host-derived run id",
+          ),
+        );
+        return;
+      }
+      if (externalResolution && (!externalOwnerPluginId || !toolName)) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "external verification requires host-derived plugin and tool ownership",
+          ),
+        );
+        return;
+      }
+      if (
+        externalResolution &&
+        p.allowedDecisions?.some(
+          (decision) => decision === "allow-once" || decision === "allow-always",
+        )
+      ) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "generic and external allow decisions cannot overlap",
+          ),
+        );
+        return;
+      }
       const twoPhase = p.twoPhase === true;
       const timeoutMs = resolvePluginApprovalTimeoutMs(p.timeoutMs);
-      const trustedAgentRuntime = client?.internal?.agentRuntimeIdentity;
 
       if (
         trustedAgentRuntime &&
@@ -198,14 +397,17 @@ export function createPluginApprovalHandlers(
           rawDetail === null
             ? null
             : truncatePluginApprovalDetail(sanitizeExecApprovalWarningText(rawDetail)),
+        // SAFETY: schema validation constrained severity to the closed union above.
         severity: (p.severity as PluginApprovalRequestPayload["severity"]) ?? null,
         toolName: sanitizeMeta(p.toolName),
         toolCallId: p.toolCallId ?? null,
         ...(trustedAgentRuntime && p.mcpTool ? { mcpTool: { ...p.mcpTool } } : {}),
+        ...(externalResolution ? { externalResolution } : {}),
         ...(Array.isArray(p.allowedDecisions)
           ? {
               allowedDecisions: resolveCanonicalPluginApprovalRequestAllowedDecisions({
                 allowedDecisions: p.allowedDecisions,
+                externalResolution,
               }),
             }
           : {}),
@@ -213,7 +415,10 @@ export function createPluginApprovalHandlers(
           trustedAgentRuntime?.agentId ??
           (sessionOwner?.ok ? sessionOwner.agentId : sanitizeMeta(p.agentId)),
         sessionKey,
-        runId: trustedAgentRuntime?.operationalRunInstance.runId ?? null,
+        sessionId: internalRequest
+          ? normalizeOptionalString(rawParams?.sessionId as string | undefined) // SAFETY: normalizeOptionalString rejects every non-string value.
+          : null,
+        runId: trustedAgentRuntime?.operationalRunInstance.runId ?? runId,
         turnSourceChannel: trustedAgentRuntime
           ? normalizeTrimmedString(trustedAgentRuntime.turnSourceChannel)
           : normalizeTrimmedString(p.turnSourceChannel),
@@ -227,6 +432,19 @@ export function createPluginApprovalHandlers(
           ? (trustedAgentRuntime.turnSourceThreadId ?? null)
           : (p.turnSourceThreadId ?? null),
       };
+
+      // The abort owner records its tombstone before sweeping approvals. Keep
+      // this check adjacent to creation so an already-aborted run cannot park.
+      if (runId && context.chatRunState.hasAbortMarker(runId)) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "approval run already aborted", {
+            details: { reason: "PLUGIN_APPROVAL_RUN_ABORTED" },
+          }),
+        );
+        return;
+      }
 
       // Always server-generate the ID — never accept plugin-provided IDs.
       // Kind-prefix so /approve routing can distinguish plugin vs exec IDs deterministically.

--- a/src/infra/approval-presentation.ts
+++ b/src/infra/approval-presentation.ts
@@ -18,12 +18,11 @@ import type { ExecApprovalRequestPayload } from "./exec-approvals.js";
 import {
   PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH,
   PLUGIN_APPROVAL_TITLE_MAX_LENGTH,
+  normalizePluginExternalResolution,
   truncatePluginApprovalDetail,
   type PluginApprovalRequestPayload,
 } from "./plugin-approvals.js";
 import type { SystemAgentApprovalRequestPayload } from "./system-agent-approvals.js";
-
-const PLUGIN_EXTERNAL_RESOLUTION_LABEL_MAX_LENGTH = 80;
 
 function normalizeDecisionList(decisions: readonly ApprovalDecision[]): ApprovalDecision[] {
   const result: ApprovalDecision[] = [];
@@ -41,29 +40,6 @@ function normalizeDecisionList(decisions: readonly ApprovalDecision[]): Approval
 function sanitizeOptionalSingleLine(value: unknown): string | null {
   const normalized = normalizeOptionalString(value);
   return normalized ? sanitizeExecApprovalDisplayText(normalized) : null;
-}
-
-function normalizePluginExternalResolution(
-  value: PluginApprovalRequestPayload["externalResolution"],
-): NonNullable<PluginApprovalRequestPayload["externalResolution"]> | null {
-  if (!value) {
-    return null;
-  }
-  const rawLabel = value.label?.trim();
-  const label = rawLabel ? sanitizeExecApprovalDisplayText(rawLabel) : "";
-  if (!label || exceedsApprovalTextLimit(label, PLUGIN_EXTERNAL_RESOLUTION_LABEL_MAX_LENGTH)) {
-    throw new Error("invalid external approval label");
-  }
-  const decisions = value.decisions ?? ["allow-once"];
-  if (
-    decisions.length < 1 ||
-    decisions.length > 2 ||
-    decisions.some((decision) => decision !== "allow-once" && decision !== "allow-always") ||
-    new Set(decisions).size !== decisions.length
-  ) {
-    throw new Error("invalid external approval decisions");
-  }
-  return { label, decisions: [...decisions] };
 }
 
 function buildExecApprovalPresentation(params: {
@@ -127,13 +103,13 @@ function buildPluginApprovalPresentation(params: {
   const detail = rawDetail
     ? truncatePluginApprovalDetail(sanitizeExecApprovalWarningText(rawDetail))
     : null;
-  const scope = request.scope ? sanitizeApprovalScope(request.scope) : null;
   let externalResolution: ReturnType<typeof normalizePluginExternalResolution>;
   try {
     externalResolution = normalizePluginExternalResolution(request.externalResolution);
   } catch {
     return null;
   }
+  const scope = request.scope ? sanitizeApprovalScope(request.scope) : null;
   return {
     kind: "plugin",
     title,

--- a/src/infra/approval-view-model.test.ts
+++ b/src/infra/approval-view-model.test.ts
@@ -140,6 +140,32 @@ describe("buildPendingApprovalView", () => {
     ]);
   });
 
+  it("keeps external verification off generic native actions", () => {
+    const request: PluginApprovalRequest = {
+      id: "plugin:external-approval",
+      createdAtMs: 1,
+      expiresAtMs: 2,
+      request: {
+        title: "World verification",
+        description: "Verify personhood before continuing.",
+        pluginId: "agentkit",
+        externalResolution: {
+          label: "Verify with World",
+          decisions: ["allow-once", "allow-always"],
+        },
+      },
+    };
+
+    const view = buildPendingApprovalView(request);
+
+    expect(view.actions).toEqual([
+      expect.objectContaining({
+        command: "/approve plugin:external-approval deny",
+        action: expect.objectContaining({ type: "approval", decision: "deny" }),
+      }),
+    ]);
+  });
+
   it.each([
     { request: {} },
     { request: { command: "echo hi", title: "Ambiguous", description: "Ambiguous" } },

--- a/src/infra/plugin-approval-canonical-decisions.ts
+++ b/src/infra/plugin-approval-canonical-decisions.ts
@@ -5,7 +5,11 @@ import { resolvePluginApprovalRequestAllowedDecisions } from "./plugin-approvals
 /** Add the fail-closed deny verdict to the normalized plugin decision set. */
 export function resolveCanonicalPluginApprovalRequestAllowedDecisions(params?: {
   allowedDecisions?: readonly ExecApprovalDecision[] | readonly string[] | null;
+  externalResolution?: unknown;
 }): readonly ExecApprovalDecision[] {
+  if (params?.externalResolution) {
+    return ["deny"];
+  }
   const allowedDecisions = resolvePluginApprovalRequestAllowedDecisions(params);
   return allowedDecisions.includes("deny") ? allowedDecisions : [...allowedDecisions, "deny"];
 }

--- a/src/infra/plugin-approvals.test.ts
+++ b/src/infra/plugin-approvals.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPluginApprovalRequestMessage,
+  type PluginApprovalRequest,
+} from "./plugin-approvals.js";
+
+describe("plugin external approval presentation", () => {
+  it("emits the accepted text fallback without a generic allow command", () => {
+    const request: PluginApprovalRequest = {
+      id: "plugin:external-1",
+      createdAtMs: 1_000,
+      expiresAtMs: 61_000,
+      request: {
+        title: "World verification",
+        description: "Verify personhood before continuing.",
+        pluginId: "agentkit",
+        toolName: "dangerous-tool",
+        agentId: "main",
+        externalResolution: {
+          label: "Verify with World",
+          decisions: ["allow-once", "allow-always"],
+        },
+      },
+    };
+
+    expect(buildPluginApprovalRequestMessage(request, 1_000)).toContain(
+      [
+        "Verify with World",
+        "Verify once: /approve plugin:external-1 external allow-once",
+        "Verify and trust for session: /approve plugin:external-1 external allow-always",
+        "Deny: /approve plugin:external-1 deny",
+      ].join("\n"),
+    );
+    expect(buildPluginApprovalRequestMessage(request, 1_000)).not.toContain(
+      "/approve plugin:external-1 allow-once",
+    );
+  });
+});

--- a/src/infra/plugin-approvals.ts
+++ b/src/infra/plugin-approvals.ts
@@ -1,6 +1,8 @@
 // Defines plugin approval request/resolution payloads and actions.
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { PluginExternalResolution } from "../plugins/external-verification-approval-types.js";
 import { summarizeApprovalScope, type ApprovalScope } from "./approval-scope.js";
+import { sanitizeExecApprovalDisplayText } from "./exec-approval-text-sanitize.js";
 import type { ExecApprovalDecision } from "./exec-approvals.js";
 
 // Plugin approval types and renderers mirror exec approval decisions while
@@ -45,13 +47,11 @@ export type PluginApprovalRequestPayload = {
   mcpTool?: { server: string; tool: string };
   allowedDecisions?: readonly ExecApprovalDecision[] | null;
   /** Trusted in-process metadata; public Gateway callers cannot submit this field. */
-  externalResolution?: {
-    label: string;
-    decisions?: readonly ("allow-once" | "allow-always")[];
-  } | null;
+  externalResolution?: PluginExternalResolution | null;
   actions?: readonly PluginApprovalActionView[] | null;
   agentId?: string | null;
   sessionKey?: string | null;
+  sessionId?: string | null;
   /** Host-derived source run; never accepted from plugin approval RPC params. */
   runId?: string | null;
   /** Host-derived grant binding; never accepted from plugin approval RPC params. */
@@ -86,6 +86,7 @@ export const MAX_PLUGIN_APPROVAL_TIMEOUT_MS = 600_000;
 export const PLUGIN_APPROVAL_TITLE_MAX_LENGTH = 80;
 export const PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH = 512;
 export const PLUGIN_APPROVAL_DETAIL_MAX_LENGTH = 16_384;
+const PLUGIN_EXTERNAL_RESOLUTION_LABEL_MAX_LENGTH = 80;
 const PLUGIN_APPROVAL_DETAIL_TRUNCATION_SUFFIX = "…[truncated]";
 export const DEFAULT_PLUGIN_APPROVAL_DECISIONS = [
   "allow-once",
@@ -152,6 +153,30 @@ export function resolvePluginApprovalRequestAllowedDecisions(params?: {
   return explicit.length > 0 ? explicit : DEFAULT_PLUGIN_APPROVAL_DECISIONS;
 }
 
+/** Normalize the bounded external route shared by creation and presentation paths. */
+export function normalizePluginExternalResolution(
+  value: PluginExternalResolution | null | undefined,
+): PluginExternalResolution | null {
+  if (!value) {
+    return null;
+  }
+  const rawLabel = value.label?.trim();
+  const label = rawLabel ? sanitizeExecApprovalDisplayText(rawLabel) : "";
+  if (!label || Array.from(label).length > PLUGIN_EXTERNAL_RESOLUTION_LABEL_MAX_LENGTH) {
+    throw new Error("invalid external approval label");
+  }
+  const decisions = value.decisions ?? ["allow-once"];
+  if (
+    decisions.length < 1 ||
+    decisions.length > 2 ||
+    decisions.some((decision) => decision !== "allow-once" && decision !== "allow-always") ||
+    new Set(decisions).size !== decisions.length
+  ) {
+    throw new Error("external decisions must be unique allow-once/allow-always values");
+  }
+  return { label, decisions: [...decisions] };
+}
+
 /** Build the pending plugin approval message. */
 export function buildPluginApprovalRequestMessage(
   request: PluginApprovalRequest,
@@ -179,6 +204,18 @@ export function buildPluginApprovalRequestMessage(
   lines.push(`ID: ${request.id}`);
   const expiresIn = Math.max(0, Math.round((request.expiresAtMs - nowMsValue) / 1000));
   lines.push(`Expires in: ${expiresIn}s`);
+  const externalResolution = normalizePluginExternalResolution(request.request.externalResolution);
+  if (externalResolution) {
+    lines.push(externalResolution.label);
+    if (externalResolution.decisions?.includes("allow-once")) {
+      lines.push(`Verify once: /approve ${request.id} external allow-once`);
+    }
+    if (externalResolution.decisions?.includes("allow-always")) {
+      lines.push(`Verify and trust for session: /approve ${request.id} external allow-always`);
+    }
+    lines.push(`Deny: /approve ${request.id} deny`);
+    return lines.join("\n");
+  }
   lines.push(
     `Reply with: /approve ${request.id} ${resolvePluginApprovalRequestAllowedDecisions(
       request.request,

--- a/src/plugin-sdk/plugin-entry.ts
+++ b/src/plugin-sdk/plugin-entry.ts
@@ -12,6 +12,14 @@ export type {
 } from "../plugins/capability-catalog-context.types.js";
 export type { PluginCapabilityCatalog } from "../plugins/capability-catalog.types.js";
 export type { OpenClawConfig } from "../config/types.openclaw.js";
+export type {
+  PluginExternalResolution,
+  PluginExternalVerificationAttempt,
+  PluginExternalVerificationCompletionResult,
+  PluginExternalVerificationContext,
+  PluginExternalVerificationGrantAuthorization,
+  PluginExternalVerificationGrantStore,
+} from "../plugins/external-verification-approval-types.js";
 
 export type {
   AgentHarness,

--- a/src/plugin-sdk/plugin-test-api.ts
+++ b/src/plugin-sdk/plugin-test-api.ts
@@ -19,6 +19,15 @@ export function createTestPluginApi(api: TestPluginApiInput = {}): OpenClawPlugi
     config: {},
     runtime: {} as OpenClawPluginApi["runtime"],
     logger: { info() {}, warn() {}, error() {}, debug() {} },
+    approvals: {
+      onExternalVerification() {},
+      completeExternalVerification: async () => {
+        throw new Error("external verification approval runtime is not available in tests");
+      },
+      openGrantStore: () => {
+        throw new Error("external verification grant storage is not available in tests");
+      },
+    },
     registerTool() {},
     registerHook() {},
     registerHttpRoute() {},

--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -21,6 +21,15 @@ type BuildPluginApiParams = {
 };
 
 const noops = {
+  approvals: {
+    onExternalVerification: () => {},
+    completeExternalVerification: async () => {
+      throw new Error("external verification approval runtime is not available");
+    },
+    openGrantStore: () => {
+      throw new Error("external verification grant storage is unavailable during plugin discovery");
+    },
+  },
   registerTool: () => {},
   registerHook: () => {},
   registerHttpRoute: () => {},
@@ -137,6 +146,7 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
     pluginConfig: params.pluginConfig,
     runtime: params.runtime,
     logger: params.logger,
+    approvals: handlers.approvals ?? noops.approvals,
     registerTool: handlers.registerTool ?? noops.registerTool,
     registerHook: handlers.registerHook ?? noops.registerHook,
     registerHttpRoute: handlers.registerHttpRoute ?? noops.registerHttpRoute,

--- a/src/plugins/external-verification-approval-runtime-state.ts
+++ b/src/plugins/external-verification-approval-runtime-state.ts
@@ -1,0 +1,55 @@
+// Process-local bridge from the plugin-bound facade to the active Gateway owner.
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import type { PluginExternalVerificationCompletionResult } from "./external-verification-approval-types.js";
+
+type CompletionHandler = (
+  owner: object,
+  pluginId: string,
+  completion: { attemptId: string; outcome: "succeeded" | "failed" },
+) => Promise<PluginExternalVerificationCompletionResult>;
+
+type CompletionRuntimeState = {
+  owner: object | null;
+  handler: CompletionHandler | null;
+};
+
+const completionRuntimeStateKey = Symbol.for(
+  "openclaw.plugin-external-verification-completion-runtime",
+);
+
+function getCompletionRuntimeState(): CompletionRuntimeState {
+  return resolveGlobalSingleton<CompletionRuntimeState>(completionRuntimeStateKey, () => ({
+    owner: null,
+    handler: null,
+  }));
+}
+
+export function setExternalVerificationCompletionRuntime(
+  owner: object,
+  handler: CompletionHandler,
+): void {
+  const state = getCompletionRuntimeState();
+  state.owner = owner;
+  state.handler = handler;
+}
+
+export function clearExternalVerificationCompletionRuntime(owner: object): void {
+  const state = getCompletionRuntimeState();
+  if (state.owner !== owner) {
+    return;
+  }
+  state.owner = null;
+  state.handler = null;
+}
+
+export async function completeExternalVerificationForPlugin(
+  owner: object,
+  pluginId: string,
+  completion: { attemptId: string; outcome: "succeeded" | "failed" },
+): Promise<PluginExternalVerificationCompletionResult> {
+  const handler = getCompletionRuntimeState().handler;
+  if (!handler) {
+    throw new Error("external verification approval runtime is not available");
+  }
+  return await handler(owner, pluginId, completion);
+}

--- a/src/plugins/external-verification-approval-types.ts
+++ b/src/plugins/external-verification-approval-types.ts
@@ -1,0 +1,87 @@
+import type {
+  ApprovalAllowDecision,
+  ApprovalSnapshot,
+} from "../../packages/gateway-protocol/src/index.js";
+import type { PluginStateEntry } from "../plugin-state/plugin-state-store.types.js";
+
+/** Plugin-owned reviewer choices that require an external verification ceremony. */
+export type PluginExternalResolution = {
+  label: string;
+  decisions?: readonly ApprovalAllowDecision[];
+};
+
+/** Host-derived approval context that verifier challenges must bind. */
+export type PluginExternalVerificationContext = Readonly<{
+  approvalId: string;
+  pluginId: string;
+  runId: string;
+  toolName: string;
+  toolCallId?: string;
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  decision: ApprovalAllowDecision;
+  label: string;
+  expiresAtMs: number;
+}>;
+
+/** Immutable context for one host-authenticated external verification attempt. */
+export type PluginExternalVerificationAttempt = Readonly<{
+  id: string;
+  context: PluginExternalVerificationContext;
+  createdAtMs: number;
+  signal: AbortSignal;
+  present: (params: { message: string }) => Promise<void>;
+}>;
+
+/** Persisted, proof-free attempt projection returned by completion calls. */
+export type PluginExternalVerificationAttemptSnapshot = Omit<
+  PluginExternalVerificationAttempt,
+  "present" | "signal"
+> & {
+  endedAtMs?: number;
+  outcome?: "succeeded" | "failed" | "cancelled" | "timed-out";
+  errorClass?: string;
+  terminalSource?: string;
+};
+
+/** Stable host authorization emitted only when external verification wins the approval race. */
+export type PluginExternalVerificationGrantAuthorization = {
+  id: string;
+  issuedAtMs: number;
+  approvalId: string;
+  attemptId: string;
+  decision: ApprovalAllowDecision;
+};
+
+/** Idempotent completion result derived entirely from host-owned attempt state. */
+export type PluginExternalVerificationCompletionResult = {
+  applied: boolean;
+  approval: ApprovalSnapshot;
+  attempt: PluginExternalVerificationAttemptSnapshot;
+  grantAuthorization?: PluginExternalVerificationGrantAuthorization;
+};
+
+export type PluginExternalVerificationHandler = (
+  attempt: PluginExternalVerificationAttempt,
+) => Promise<void> | void;
+
+/** Durable grant storage that preserves prior authorizations and tombstones. */
+export type PluginExternalVerificationGrantStore<T> = {
+  registerIfAbsent: (key: string, value: T) => boolean;
+  lookup: (key: string) => T | undefined;
+  entries: () => PluginStateEntry<T>[];
+  update: (key: string, updateValue: (current: T | undefined) => T | undefined) => boolean;
+};
+
+export type OpenClawPluginApprovalsApi = {
+  /** Register this plugin's single verifier for host-authenticated approval attempts. */
+  onExternalVerification: (handler: PluginExternalVerificationHandler) => void;
+  /** Complete an attempt owned by this plugin; plugin and approval identity are host-derived. */
+  completeExternalVerification: (params: {
+    attemptId: string;
+    outcome: "succeeded" | "failed";
+  }) => Promise<PluginExternalVerificationCompletionResult>;
+  /** Open bounded plugin-owned storage for stable grant authorizations and tombstones. */
+  openGrantStore: <T>() => PluginExternalVerificationGrantStore<T>;
+};

--- a/src/plugins/hook-before-tool-call-result.ts
+++ b/src/plugins/hook-before-tool-call-result.ts
@@ -1,4 +1,5 @@
 import type { ApprovalScope } from "../infra/approval-scope.js";
+import type { PluginExternalResolution } from "./external-verification-approval-types.js";
 
 export const PluginApprovalResolutions = {
   ALLOW_ONCE: "allow-once",
@@ -11,25 +12,41 @@ export const PluginApprovalResolutions = {
 export type PluginApprovalResolution =
   (typeof PluginApprovalResolutions)[keyof typeof PluginApprovalResolutions];
 
+type PluginHookApprovalRequest = {
+  title: string;
+  description: string;
+  scope?: ApprovalScope;
+  severity?: "info" | "warning" | "critical";
+  timeoutMs?: number;
+  /**
+   * @deprecated Unresolved approvals always deny; retained for plugin API
+   * compatibility. The field will be removed after one deprecation release train.
+   */
+  timeoutBehavior?: "allow" | "deny";
+  /** Override timeout text and return the timeout as a blocked tool result. */
+  timeoutReason?: string;
+  allowedDecisions?: Array<"allow-once" | "allow-always" | "deny">;
+  /**
+   * @deprecated Ignored. The host stamps the live plugin owner and will remove
+   * this field after one deprecation release train.
+   */
+  pluginId?: string;
+  /** Plugin-owned allow path. Core still owns denial and the final approval ledger. */
+  externalResolution?: PluginExternalResolution;
+  onResolution?: (decision: PluginApprovalResolution) => Promise<void> | void;
+};
+
 export type PluginHookBeforeToolCallResult = {
   params?: Record<string, unknown>;
   block?: boolean;
   blockReason?: string;
-  requireApproval?: {
-    title: string;
-    description: string;
-    scope?: ApprovalScope;
-    severity?: "info" | "warning" | "critical";
-    timeoutMs?: number;
-    /**
-     * @deprecated Unresolved approvals always deny; retained for plugin API
-     * compatibility. The field will be removed after one deprecation release train.
-     */
-    timeoutBehavior?: "allow" | "deny";
-    /** Override timeout text and return the timeout as a blocked tool result. */
-    timeoutReason?: string;
-    allowedDecisions?: Array<"allow-once" | "allow-always" | "deny">;
-    pluginId?: string;
-    onResolution?: (decision: PluginApprovalResolution) => Promise<void> | void;
-  };
+  requireApproval?: PluginHookApprovalRequest;
+};
+
+/** Internal merger result with an owner stamped from the live registration. */
+export type PluginHostBeforeToolCallResult = Omit<
+  PluginHookBeforeToolCallResult,
+  "requireApproval"
+> & {
+  requireApproval?: PluginHookApprovalRequest & { pluginId?: string };
 };

--- a/src/plugins/hook-runner-global-state.ts
+++ b/src/plugins/hook-runner-global-state.ts
@@ -4,6 +4,7 @@ import type { GlobalHookRunnerRegistry } from "./hook-registry.types.js";
 import type { HookRunner } from "./hooks.js";
 import { isPluginRegistryRetired } from "./registry-lifecycle.js";
 import type {
+  PluginExternalApprovalVerifierRegistration,
   PluginRegistry,
   PluginTrustedToolPolicyRegistryRegistration,
 } from "./registry-types.js";
@@ -13,6 +14,7 @@ import { getPluginRuntimeGenerationRegistry } from "./runtime/generation-scope.j
 
 type TrustedPolicyHookRunnerRegistry = GlobalHookRunnerRegistry & {
   trustedToolPolicies?: PluginTrustedToolPolicyRegistryRegistration[];
+  externalApprovalVerifiers?: PluginExternalApprovalVerifierRegistration[];
 };
 
 type HookRunnerGlobalState = {
@@ -94,6 +96,18 @@ function overlayHookRegistries(
     const rightRank = right.origin === "bundled" ? 0 : 1;
     return leftRank - rightRank;
   });
+  // External approval verifiers follow the same overlay contract: a source
+  // that carries a verifier for a plugin replaces the base entry for that
+  // plugin only, keeping one live owner per plugin id.
+  const overlayExternalVerifierPluginIds = new Set(
+    (overlayRegistry.externalApprovalVerifiers ?? []).map((entry) => entry.pluginId),
+  );
+  const externalApprovalVerifiers = [
+    ...(baseRegistry.externalApprovalVerifiers ?? []).filter(
+      (entry) => !overlayExternalVerifierPluginIds.has(entry.pluginId),
+    ),
+    ...(overlayRegistry.externalApprovalVerifiers ?? []),
+  ];
   return {
     hooks: [
       ...baseRegistry.hooks.flatMap((hook) => {
@@ -117,6 +131,7 @@ function overlayHookRegistries(
       ...overlayRegistry.plugins,
     ],
     trustedToolPolicies,
+    externalApprovalVerifiers,
   };
 }
 
@@ -149,6 +164,9 @@ export function createLiveHookRegistryFacade(
     get trustedToolPolicies() {
       return resolveHookRegistry(state)?.trustedToolPolicies ?? [];
     },
+    get externalApprovalVerifiers() {
+      return resolveHookRegistry(state)?.externalApprovalVerifiers ?? [];
+    },
   };
 }
 
@@ -157,4 +175,15 @@ export function getGlobalHookRunnerRegistry(): TrustedPolicyHookRunnerRegistry |
   return resolveHookRegistry(hookRunnerGlobalState)
     ? createLiveHookRegistryFacade(hookRunnerGlobalState)
     : null;
+}
+
+/** Resolve the verifier owned by the same live plugin registry selected for hook dispatch. */
+export function getPluginExternalApprovalVerifier(
+  pluginId: string,
+): PluginExternalApprovalVerifierRegistration | null {
+  return (
+    getGlobalHookRunnerRegistry()?.externalApprovalVerifiers?.find(
+      (registration) => registration.pluginId === pluginId,
+    ) ?? null
+  );
 }

--- a/src/plugins/hooks.before-tool-call.test.ts
+++ b/src/plugins/hooks.before-tool-call.test.ts
@@ -158,6 +158,34 @@ describe("before_tool_call hook merger — requireApproval", () => {
     expectRequireApprovalResult(result, { requireApproval: expectedApproval });
   });
 
+  it("preserves external resolution while stamping its live plugin owner", async () => {
+    const result = await runBeforeToolCallWithHooks(registry, [
+      {
+        pluginId: "agentkit",
+        result: {
+          requireApproval: {
+            title: "World verification",
+            description: "Verify personhood before continuing.",
+            externalResolution: {
+              label: "Verify with World",
+              decisions: ["allow-once", "allow-always"],
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(result?.requireApproval).toEqual({
+      title: "World verification",
+      description: "Verify personhood before continuing.",
+      pluginId: "agentkit",
+      externalResolution: {
+        label: "Verify with World",
+        decisions: ["allow-once", "allow-always"],
+      },
+    });
+  });
+
   it("merges block and requireApproval from different plugins", async () => {
     const result = await runBeforeToolCallWithHooks(registry, [
       {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -24,6 +24,10 @@ import { formatHookErrorForLog } from "../hooks/fire-and-forget.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { projectModelContextMessages } from "../shared/model-context-message.js";
 import { concatOptionalTextSegments } from "../shared/text/join-segments.js";
+import type {
+  PluginHookBeforeToolCallResult,
+  PluginHostBeforeToolCallResult,
+} from "./hook-before-tool-call-result.js";
 import {
   type GateHookResult,
   type InputGateDecision,
@@ -60,7 +64,6 @@ import type {
   PluginHookInboundClaimEvent,
   PluginHookInboundClaimResult,
   PluginHookBeforeToolCallEvent,
-  PluginHookBeforeToolCallResult,
   PluginAgentTurnPrepareEvent,
   PluginAgentTurnPrepareResult,
   PluginHeartbeatPromptContributionEvent,
@@ -1448,8 +1451,8 @@ export function createHookRunner(
       assertAuthority: () => boolean | void;
       markOwnerDecision?: () => void;
     }>,
-  ): Promise<PluginHookBeforeToolCallResult | undefined> {
-    return runModifyingHook<"before_tool_call", PluginHookBeforeToolCallResult>(
+  ): Promise<PluginHostBeforeToolCallResult | undefined> {
+    return runModifyingHook<"before_tool_call", PluginHostBeforeToolCallResult>(
       "before_tool_call",
       event,
       ctx,

--- a/src/plugins/plugin-api.types.ts
+++ b/src/plugins/plugin-api.types.ts
@@ -24,6 +24,7 @@ import type {
 import type { CliBackendPlugin, PluginTextTransforms } from "./cli-backend.types.js";
 import type { CodexAppServerExtensionFactory } from "./codex-app-server-extension-types.js";
 import type { PluginConversationBindingResolvedEvent } from "./conversation-binding.types.js";
+import type { OpenClawPluginApprovalsApi } from "./external-verification-approval-types.js";
 import type {
   PluginHookHandlerMap,
   PluginHookName,
@@ -205,6 +206,8 @@ export type OpenClawPluginApi = {
   runContext: OpenClawPluginRunContextApi;
   /** Grouped facade for plugin-owned lifecycle cleanup hooks. */
   lifecycle: OpenClawPluginLifecycleApi;
+  /** Plugin-bound external approval verification capability. */
+  approvals: OpenClawPluginApprovalsApi;
   registerTool: (
     tool: AnyAgentTool | OpenClawPluginToolFactory,
     opts?: OpenClawPluginToolOptions,

--- a/src/plugins/registry-api.ts
+++ b/src/plugins/registry-api.ts
@@ -1,10 +1,13 @@
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { createPluginStateSyncKeyedStore } from "../plugin-state/plugin-state-store.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { resolveUserPath } from "../utils.js";
 import { emitPluginAgentEvent } from "./agent-event-emission.js";
 import { buildPluginApi } from "./api-builder.js";
+import { completeExternalVerificationForPlugin } from "./external-verification-approval-runtime-state.js";
+import type { PluginExternalVerificationGrantStore } from "./external-verification-approval-types.js";
 import {
   clearPluginRunContext,
   getPluginRunContext,
@@ -14,7 +17,11 @@ import {
   schedulePluginSessionTurn,
   unschedulePluginSessionTurnsByTag,
 } from "./host-hook-scheduled-turns.js";
-import { isPluginRegistryActivated, isPluginRegistryRetired } from "./registry-lifecycle.js";
+import {
+  capturePluginLifecycleAuthority,
+  isPluginRegistryActivated,
+  isPluginRegistryRetired,
+} from "./registry-lifecycle.js";
 import type { PluginRegistrars } from "./registry-registrars.js";
 import type { PluginRuntimeResolver } from "./registry-runtime.js";
 import {
@@ -24,7 +31,33 @@ import {
   type PluginSideEffectGuard,
 } from "./registry-state.js";
 import type { PluginRecord } from "./registry-types.js";
+import { getActivePluginRegistry } from "./runtime.js";
 import type { OpenClawPluginApi, PluginLogger, PluginRegistrationMode } from "./types.js";
+
+const EXTERNAL_APPROVAL_GRANT_STORE_NAMESPACE = "external-approval-grants";
+const EXTERNAL_APPROVAL_GRANT_STORE_MAX_ENTRIES = 5_000;
+
+function openExternalApprovalGrantStore<T>(params: {
+  assertActive: () => void;
+  pluginId: string;
+}): PluginExternalVerificationGrantStore<T> {
+  params.assertActive();
+  const store = createPluginStateSyncKeyedStore<T>(params.pluginId, {
+    namespace: EXTERNAL_APPROVAL_GRANT_STORE_NAMESPACE,
+    maxEntries: EXTERNAL_APPROVAL_GRANT_STORE_MAX_ENTRIES,
+    overflowPolicy: "reject-new",
+  });
+  const withActiveOwner = <R>(operation: () => R): R => {
+    params.assertActive();
+    return operation();
+  };
+  return {
+    registerIfAbsent: (key, value) => withActiveOwner(() => store.registerIfAbsent(key, value)),
+    lookup: (key) => withActiveOwner(() => store.lookup(key)),
+    entries: () => withActiveOwner(() => store.entries()),
+    update: (key, updateValue) => withActiveOwner(() => store.update?.(key, updateValue) ?? false),
+  };
+}
 
 // Registration exposes these async operations without loading session storage or delivery.
 const loadAttachments = createLazyRuntimeModule(() => import("./host-hook-attachments.js"));
@@ -145,6 +178,7 @@ export function createPluginApiFactory(
   ): OpenClawPluginApi => {
     const registrationMode = params.registrationMode ?? "full";
     const registrationCapabilities = resolvePluginRegistrationCapabilities(registrationMode);
+    const externalApprovalOwner = {};
     setPluginRuntimeRecord(record);
     const sideEffectGuard = createPluginSideEffectGuard(record.id);
     const isLoadedRecordInRegistry = () =>
@@ -164,6 +198,27 @@ export function createPluginApiFactory(
       !isPluginRegistryRetired(registry) &&
       (isActivatingLoadedRecord() ||
         (isPluginRegistryActivated(registry) && isLoadedRecordInRegistry()));
+    const assertExternalApprovalGrantStoreOwnerActive = () => {
+      // Grant metadata is authorization-adjacent durable state: only a live,
+      // loaded owner generation may touch it. Prepared runs execute their hooks
+      // in a scoped (non-Gateway) registry generation that is intentionally not
+      // globally activated, so gate on canonical lifecycle authority: it accepts
+      // such a scoped run generation with a loaded record (plus the in-flight
+      // activation case) while still refusing a retired, revoked, unloaded, or
+      // side-effect-deactivated owner — e.g. a discovery/inventory scan that
+      // never loaded the record into a live run must not persist grants.
+      const gatewayRegistry = getActivePluginRegistry();
+      const isOwnerCurrent = capturePluginLifecycleAuthority(registry, record, {
+        scopedRuntime: registry !== gatewayRegistry,
+      });
+      const ownerLive =
+        isActivatingLoadedRecord() || (isOwnerCurrent !== undefined && isOwnerCurrent());
+      if (!sideEffectGuard.active || isPluginRegistryRetired(registry) || !ownerLive) {
+        throw new Error(
+          `plugin '${record.id}' external approval grant store owner is no longer active`,
+        );
+      }
+    };
     return buildPluginApi({
       id: record.id,
       name: record.name,
@@ -180,6 +235,41 @@ export function createPluginApiFactory(
       handlers: {
         ...(registrationCapabilities.capabilityHandlers
           ? {
+              // Any mode that can register hooks can execute them during a run
+              // (prepared-run generations load in discovery/tool-discovery mode);
+              // without the real approvals surface those hooks fail closed at
+              // verification time. The registry side-effect guard still fences
+              // grant-store use to the registry's active lifecycle.
+              approvals: {
+                onExternalVerification: (handler) => {
+                  if (
+                    registry.externalApprovalVerifiers.some((entry) => entry.pluginId === record.id)
+                  ) {
+                    throw new Error(
+                      `plugin '${record.id}' registered more than one external verifier`,
+                    );
+                  }
+                  registry.externalApprovalVerifiers.push({
+                    pluginId: record.id,
+                    pluginName: record.name,
+                    owner: externalApprovalOwner,
+                    handler,
+                    source: record.source,
+                    rootDir: record.rootDir,
+                  });
+                },
+                completeExternalVerification: (completion) =>
+                  completeExternalVerificationForPlugin(
+                    externalApprovalOwner,
+                    record.id,
+                    completion,
+                  ),
+                openGrantStore: () =>
+                  openExternalApprovalGrantStore({
+                    assertActive: assertExternalApprovalGrantStoreOwnerActive,
+                    pluginId: record.id,
+                  }),
+              },
               registerTool: (tool, opts) => registerTool(record, tool, opts),
               registerHook: (events, handler, opts) =>
                 registerHook(record, events, handler, opts, params.config, params.pluginConfig),

--- a/src/plugins/registry-empty.ts
+++ b/src/plugins/registry-empty.ts
@@ -69,6 +69,7 @@ export function createEmptyPluginRegistry(): PluginRegistry {
     sessionSchedulerJobs: [],
     sessionActions: [],
     conversationBindingResolvedHandlers: [],
+    externalApprovalVerifiers: [],
     diagnostics: [],
   };
 }

--- a/src/plugins/registry-lifecycle.ts
+++ b/src/plugins/registry-lifecycle.ts
@@ -23,6 +23,20 @@ const { retiredRegistries, activatedRegistries, registryEpochs, recordEpochs, re
 export type PluginRegistryLifecycleEpoch = object;
 type PluginRecordLifecycleEpoch = object;
 
+const lifecycleListeners = new Set<() => void>();
+
+function notifyPluginRegistryLifecycleListeners(): void {
+  for (const listener of lifecycleListeners) {
+    listener();
+  }
+}
+
+/** Observe activation edges that can replace runtime-owned plugin capabilities. */
+export function onPluginRegistryLifecycleChange(listener: () => void): () => void {
+  lifecycleListeners.add(listener);
+  return () => lifecycleListeners.delete(listener);
+}
+
 /** Marks a registry retired so late runtime calls can reject stale plugin state. */
 export function markPluginRegistryRetired(registry: PluginRegistry | null | undefined): void {
   if (registry) {
@@ -31,6 +45,7 @@ export function markPluginRegistryRetired(registry: PluginRegistry | null | unde
     // Retired registrations cannot be reused and retain their Gateway/cache generation.
     // Release every cache key now, including keys that will never be looked up again.
     pluginLoaderCacheState.deleteValue(registry);
+    notifyPluginRegistryLifecycleListeners();
   }
 }
 
@@ -42,6 +57,7 @@ export function markPluginRegistryActive(registry: PluginRegistry | null | undef
     // Every activation owns a fresh opaque generation. A retired closure cannot
     // regain authority merely because the same registry object becomes active.
     registryEpochs.set(registry, Object.freeze({}));
+    notifyPluginRegistryLifecycleListeners();
   }
 }
 

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -16,6 +16,7 @@ import type { CodexAppServerExtensionFactory } from "./codex-app-server-extensio
 import type { PluginCompatCode } from "./compat/registry.js";
 import type { PluginActivationSource } from "./config-state.js";
 import type { EmbeddingProviderAdapter } from "./embedding-provider-types.js";
+import type { PluginExternalVerificationHandler } from "./external-verification-approval-types.js";
 import type {
   PluginAgentEventSubscriptionRegistration,
   PluginControlUiDescriptor,
@@ -461,6 +462,15 @@ type PluginConversationBindingResolvedHandlerRegistration = {
   rootDir?: string;
 };
 
+export type PluginExternalApprovalVerifierRegistration = {
+  pluginId: string;
+  pluginName?: string;
+  owner: object;
+  handler: PluginExternalVerificationHandler;
+  source: string;
+  rootDir?: string;
+};
+
 export type PluginRecord = {
   id: string;
   name: string;
@@ -596,6 +606,7 @@ export type PluginRegistry = {
   sessionSchedulerJobs: PluginSessionSchedulerJobRegistryRegistration[];
   sessionActions: PluginSessionActionRegistryRegistration[];
   conversationBindingResolvedHandlers: PluginConversationBindingResolvedHandlerRegistration[];
+  externalApprovalVerifiers: PluginExternalApprovalVerifierRegistration[];
   diagnostics: PluginDiagnostic[];
 };
 

--- a/src/plugins/registry.runtime-config.test.ts
+++ b/src/plugins/registry.runtime-config.test.ts
@@ -3,9 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { resolveUserPath } from "../utils.js";
+import { getPluginExternalApprovalVerifier } from "./hook-runner-global-state.js";
 import { createLazyPluginRuntime } from "./loader-module-runtime.js";
 import { createPluginRecord } from "./loader-records.js";
+import { markPluginRegistryRetired } from "./registry-lifecycle.js";
 import { createPluginRegistry } from "./registry.js";
 import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
 import { createPluginRuntime } from "./runtime/index.js";
@@ -21,6 +24,14 @@ function createTestRegistry(runtime: PluginRuntime) {
     },
     runtime,
     activateGlobalSideEffects: false,
+  });
+}
+
+function createActivatingTestRegistry(runtime: PluginRuntime) {
+  return createPluginRegistry({
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    runtime,
+    activateGlobalSideEffects: true,
   });
 }
 
@@ -615,5 +626,173 @@ describe("plugin registry runtime config scope", () => {
         initialEntry: { ...initialEntry, cliBackendId: "opencode" } as never,
       }),
     ).rejects.toThrow("requires exactly one runtime owner");
+  });
+
+  it("registers exactly one external verifier for a fully activated plugin", () => {
+    const pluginRegistry = createTestRegistry(createPluginRuntime());
+    const record = createPluginRecord({
+      id: "approval-owner",
+      name: "Approval Owner",
+      source: "/plugins/approval-owner/index.js",
+      origin: "global",
+      enabled: true,
+      configSchema: false,
+    });
+    const api = pluginRegistry.createApi(record, {
+      config: {} as OpenClawConfig,
+      registrationMode: "full",
+    });
+    const handler = vi.fn();
+
+    api.approvals.onExternalVerification(handler);
+
+    expect(pluginRegistry.registry.externalApprovalVerifiers).toEqual([
+      expect.objectContaining({
+        pluginId: "approval-owner",
+        pluginName: "Approval Owner",
+        handler,
+      }),
+    ]);
+    expect(() => api.approvals.onExternalVerification(vi.fn())).toThrow(
+      "registered more than one external verifier",
+    );
+  });
+
+  it("provides bounded plugin-scoped grant storage without broad external state access", async () => {
+    await withOpenClawTestState({ label: "external-approval-grants", applyEnv: true }, async () => {
+      const pluginRegistry = createActivatingTestRegistry(createPluginRuntime());
+      const record = createPluginRecord({
+        id: "external-approval-owner",
+        source: "/plugins/external-approval-owner/index.js",
+        origin: "global",
+        enabled: true,
+        configSchema: false,
+      });
+      const api = pluginRegistry.createApi(record, {
+        config: {} as OpenClawConfig,
+        registrationMode: "full",
+      });
+
+      expect(() =>
+        api.runtime.state.openSyncKeyedStore({
+          namespace: "unrestricted",
+          maxEntries: 10,
+        }),
+      ).toThrow("openSyncKeyedStore is only available for trusted plugins");
+
+      const grants = api.approvals.openGrantStore<{ status: "active" | "revoked" }>();
+      expect(grants.registerIfAbsent("grant-1", { status: "active" })).toBe(true);
+      expect(grants.registerIfAbsent("grant-1", { status: "active" })).toBe(false);
+      expect(grants.update("grant-1", (current) => ({ ...current, status: "revoked" }))).toBe(true);
+      expect(grants.lookup("grant-1")).toEqual({ status: "revoked" });
+      expect(grants.entries()).toEqual([
+        expect.objectContaining({
+          key: "grant-1",
+          value: { status: "revoked" },
+        }),
+      ]);
+      expect(api.approvals.openGrantStore().lookup("grant-1")).toEqual({
+        status: "revoked",
+      });
+      expect(grants).not.toHaveProperty("delete");
+      expect(grants).not.toHaveProperty("clear");
+    });
+  });
+
+  it("rejects grant storage writes from a never-activated discovery registry", async () => {
+    await withOpenClawTestState(
+      { label: "external-approval-discovery-grants", applyEnv: true },
+      async () => {
+        const pluginRegistry = createTestRegistry(createPluginRuntime());
+        const record = createPluginRecord({
+          id: "discovery-approval-owner",
+          source: "/plugins/discovery-approval-owner/index.js",
+          origin: "global",
+          enabled: true,
+          configSchema: false,
+        });
+        const api = pluginRegistry.createApi(record, {
+          config: {} as OpenClawConfig,
+          registrationMode: "discovery",
+        });
+
+        // Verifier registration is allowed during discovery; durable grant
+        // metadata is authorization-adjacent and requires the activated owner,
+        // so opening the store is refused before any write can reach SQLite.
+        api.approvals.onExternalVerification(vi.fn());
+        expect(() => api.approvals.openGrantStore<{ status: "active" }>()).toThrow(
+          "external approval grant store owner is no longer active",
+        );
+      },
+    );
+  });
+
+  it("revokes external approval grant storage when its plugin registry retires", async () => {
+    await withOpenClawTestState(
+      { label: "external-approval-retired-grants", applyEnv: true },
+      async () => {
+        const pluginRegistry = createActivatingTestRegistry(createPluginRuntime());
+        const record = createPluginRecord({
+          id: "retired-approval-owner",
+          source: "/plugins/retired-approval-owner/index.js",
+          origin: "global",
+          enabled: true,
+          configSchema: false,
+        });
+        const api = pluginRegistry.createApi(record, {
+          config: {} as OpenClawConfig,
+          registrationMode: "full",
+        });
+        const grants = api.approvals.openGrantStore<{ status: "active" | "revoked" }>();
+        expect(grants.registerIfAbsent("grant-1", { status: "active" })).toBe(true);
+
+        markPluginRegistryRetired(pluginRegistry.registry);
+
+        const ownerRetired = "external approval grant store owner is no longer active";
+        expect(() => grants.lookup("grant-1")).toThrow(ownerRetired);
+        expect(() => grants.entries()).toThrow(ownerRetired);
+        expect(() => grants.registerIfAbsent("grant-2", { status: "active" })).toThrow(
+          ownerRetired,
+        );
+        expect(() => grants.update("grant-1", () => ({ status: "revoked" }))).toThrow(ownerRetired);
+        expect(() => api.approvals.openGrantStore()).toThrow(ownerRetired);
+
+        const replacementRegistry = createActivatingTestRegistry(createPluginRuntime());
+        const replacementApi = replacementRegistry.createApi(record, {
+          config: {} as OpenClawConfig,
+          registrationMode: "full",
+        });
+        const replacementGrants = replacementApi.approvals.openGrantStore<{
+          status: "active" | "revoked";
+        }>();
+        expect(replacementGrants.lookup("grant-1")).toEqual({ status: "active" });
+      },
+    );
+  });
+
+  it("records a discovery-mode verifier in its own registry without global activation", () => {
+    const pluginRegistry = createTestRegistry(createPluginRuntime());
+    const record = createPluginRecord({
+      id: "approval-discovery",
+      source: "/plugins/approval-discovery/index.js",
+      origin: "global",
+      enabled: true,
+      configSchema: false,
+    });
+    const api = pluginRegistry.createApi(record, {
+      config: {} as OpenClawConfig,
+      registrationMode: "discovery",
+    });
+
+    api.approvals.onExternalVerification(vi.fn());
+
+    // Prepared-run generations load plugins in discovery mode and execute
+    // their hooks, so the verifier must live in the loaded registry itself;
+    // liveness is owned by that registry's lifecycle, never by load mode.
+    expect(
+      pluginRegistry.registry.externalApprovalVerifiers.map((entry) => entry.pluginId),
+    ).toEqual(["approval-discovery"]);
+    // A scan that is never activated leaks nothing into global resolution.
+    expect(getPluginExternalApprovalVerifier("approval-discovery")).toBeNull();
   });
 });

--- a/src/plugins/trusted-tool-policy.ts
+++ b/src/plugins/trusted-tool-policy.ts
@@ -2,9 +2,9 @@
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isPlainObject } from "../utils.js";
+import type { PluginHostBeforeToolCallResult } from "./hook-before-tool-call-result.js";
 import type {
   PluginHookBeforeToolCallEvent,
-  PluginHookBeforeToolCallResult,
   PluginHookToolContext,
   PluginHookToolInputKind,
   PluginHookToolKind,
@@ -164,7 +164,7 @@ function trustedPolicyDefaultBlockReason(registration: TrustedPolicyRegistration
 function trustedPolicyFailureResult(
   registration: TrustedPolicyRegistration,
   detail: string,
-): PluginHookBeforeToolCallResult {
+): PluginHostBeforeToolCallResult {
   return {
     block: true,
     blockReason: `${trustedPolicyDefaultBlockReason(registration)}: ${detail}`,
@@ -231,11 +231,11 @@ export async function runTrustedToolPolicies(
       | undefined;
     registry?: TrustedToolPolicyRegistry;
   },
-): Promise<PluginHookBeforeToolCallResult | undefined> {
+): Promise<PluginHostBeforeToolCallResult | undefined> {
   const policies = copyTrustedPolicyRegistrations(options?.registry ?? getActivePluginRegistry());
   let adjustedParams = event.params;
   let hasAdjustedParams = false;
-  let approval: PluginHookBeforeToolCallResult["requireApproval"];
+  let approval: PluginHostBeforeToolCallResult["requireApproval"];
   const sessionExtensionStateCache = new Map<string, Record<string, PluginJsonValue> | undefined>();
   let resolvedSessionConfig: OpenClawConfig | undefined = options?.config;
   let didResolveSessionConfig = Boolean(options?.config);
@@ -365,7 +365,10 @@ export async function runTrustedToolPolicies(
         );
       }
       if ("requireApproval" in decision && decision.requireApproval && !approval) {
-        approval = decision.requireApproval;
+        approval = {
+          ...decision.requireApproval,
+          pluginId: trustedPolicyDiagnosticPluginId(registration),
+        };
       }
     } catch {
       ctx.abortSignal?.throwIfAborted();

--- a/src/state/openclaw-state-db-contract.ts
+++ b/src/state/openclaw-state-db-contract.ts
@@ -57,6 +57,7 @@ export const LAZY_ADDITIVE_STATE_TABLES = [
   ...FIRST_USE_STATE_TABLES,
   "agent_provenance",
   "cron_run_receipts",
+  "plugin_external_verification_attempts",
   "config_revision_keys",
   "secret_store_entries",
   "projects",
@@ -71,8 +72,19 @@ export const LAZY_ADDITIVE_STATE_TABLES = [
   "worker_environment_ssh_fallback_ports",
   "worker_session_placement_moves",
 ] as const;
+// Triggers that reference a lazy table must leave the projected runtime
+// schema with it: SQLite validates trigger bodies at fire time, so a dangling
+// trigger breaks the first ordinary write that fires it on an upgraded
+// database. The owning first-use ensure installs table, indexes, and trigger
+// together.
+export const LAZY_ADDITIVE_STATE_TRIGGERS = [
+  "trg_operator_approval_closes_external_verification",
+] as const;
 export const LAZY_ADDITIVE_STATE_INDEXES = [
   ...FIRST_USE_STATE_INDEXES,
+  "idx_plugin_external_verification_active_approval",
+  "idx_plugin_external_verification_run_active",
+  "idx_plugin_external_verification_approval_created",
   "idx_cron_run_receipts_active_job",
   "idx_cron_run_receipts_job_history",
   "idx_github_publication_requests_pending",

--- a/src/state/openclaw-state-db-schema-additive.ts
+++ b/src/state/openclaw-state-db-schema-additive.ts
@@ -79,6 +79,33 @@ export function ensureDevicePairingJoinCodeSchema(database: DatabaseSync): void 
   ); // sqlite-allow-raw -- Canonical additive DDL only.
 }
 
+const PLUGIN_EXTERNAL_VERIFICATION_SCHEMA_START =
+  "CREATE TABLE IF NOT EXISTS plugin_external_verification_attempts (";
+const PLUGIN_EXTERNAL_VERIFICATION_SCHEMA_END =
+  "WHERE approval_id = NEW.approval_id AND ended_at_ms IS NULL;\nEND;";
+
+/**
+ * Lazily install the additive external verification attempt ledger (table,
+ * indexes, and the operator-approval closing trigger) on first feature use.
+ * Registered in LAZY_ADDITIVE_STATE_TABLES so pre-feature databases stay valid.
+ */
+export function ensurePluginExternalVerificationSchema(database: DatabaseSync): void {
+  const start = OPENCLAW_STATE_SCHEMA_SQL.indexOf(PLUGIN_EXTERNAL_VERIFICATION_SCHEMA_START);
+  const endMarkerStart = OPENCLAW_STATE_SCHEMA_SQL.indexOf(
+    PLUGIN_EXTERNAL_VERIFICATION_SCHEMA_END,
+    start,
+  );
+  if (start < 0 || endMarkerStart < start) {
+    throw new Error("OpenClaw plugin external verification schema marker is missing.");
+  }
+  database.exec(
+    OPENCLAW_STATE_SCHEMA_SQL.slice(
+      start,
+      endMarkerStart + PLUGIN_EXTERNAL_VERIFICATION_SCHEMA_END.length,
+    ),
+  ); // sqlite-allow-raw -- Canonical additive DDL only.
+}
+
 /** Lazily installs the Gateway's installation-local config revision key owner. */
 export function ensureConfigRevisionKeySchema(database: DatabaseSync): void {
   const start = OPENCLAW_STATE_SCHEMA_SQL.indexOf(CONFIG_REVISION_KEY_SCHEMA_START);

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -1041,6 +1041,32 @@ export interface PluginBlobEntries {
   plugin_id: string;
 }
 
+export interface PluginExternalVerificationAttempts {
+  agent_id: string | null;
+  approval_id: string;
+  attempt_id: string;
+  completion_applied: number | null;
+  created_at_ms: number;
+  decision: string;
+  ended_at_ms: number | null;
+  error_class: string | null;
+  expires_at_ms: number;
+  grant_authorization_id: string | null;
+  grant_issued_at_ms: number | null;
+  interaction_id: string;
+  label: string;
+  outcome: string | null;
+  plugin_id: string;
+  resolver_plugin_id: string | null;
+  run_id: string;
+  runtime_epoch: string;
+  session_id: string | null;
+  session_key: string | null;
+  terminal_source: string | null;
+  tool_call_id: string | null;
+  tool_name: string;
+}
+
 export interface PluginStateEntries {
   created_at: number;
   entry_key: string;
@@ -1674,6 +1700,7 @@ export interface DB {
   outbound_message_progress: OutboundMessageProgress;
   plugin_binding_approvals: PluginBindingApprovals;
   plugin_blob_entries: PluginBlobEntries;
+  plugin_external_verification_attempts: PluginExternalVerificationAttempts;
   plugin_state_entries: PluginStateEntries;
   projects: Projects;
   sandbox_registry_entries: SandboxRegistryEntries;

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -63,7 +63,10 @@ import {
   withOpenClawStateStartupMigrationCheckpointDatabase,
 } from "./openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
-import { getOpenClawStateRuntimeSchema } from "./openclaw-state-schema-compatibility.js";
+import {
+  getOpenClawStateRuntimeSchema,
+  OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
+} from "./openclaw-state-schema-compatibility.js";
 import { STATE_SCHEMA_10_TO_9_DOWNGRADE_SQL } from "./openclaw-state-schema-v10-retirement.test-support.js";
 import { STATE_SCHEMA_11_TO_10_TABLES_SQL } from "./openclaw-state-schema-v11-retirement.test-support.js";
 import { STATE_SCHEMA_12_TO_11_DOWNGRADE_SQL } from "./openclaw-state-schema-v12-foldin.test-support.js";
@@ -149,6 +152,13 @@ function markStateDatabaseAsPreviousAppVersion(database: DatabaseSync): void {
   database
     .prepare("UPDATE schema_meta SET app_version = ? WHERE meta_key = 'primary'")
     .run("2026.7.0");
+}
+
+function markStateDatabaseAsV5(database: DatabaseSync): void {
+  database.exec(`
+    PRAGMA user_version = 5;
+    UPDATE schema_meta SET schema_version = 5 WHERE meta_key = 'primary';
+  `);
 }
 
 function createInitialStateSchemaShape() {
@@ -4742,6 +4752,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         currentSchema.db,
         "previous v9 reader",
         getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: false }),
+        OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
       ),
     ).not.toThrow();
     closeOpenClawStateDatabaseForTest();
@@ -6209,28 +6220,40 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         )
         .get() as { sql: string }
     ).sql;
+    // This fixture models the shipped two-kind schema, which predates external
+    // verification attempts and their operator-approval trigger.
+    legacyDb.exec(`
+      DROP TRIGGER trg_operator_approval_closes_external_verification;
+      DROP TABLE plugin_external_verification_attempts;
+    `);
     legacyDb.exec("ALTER TABLE operator_approvals RENAME TO operator_approvals_current");
     legacyDb.exec(currentSql.replace("'exec', 'plugin', 'system-agent'", "'exec', 'plugin'"));
     legacyDb.exec("DROP TABLE operator_approvals_current");
+    markStateDatabaseAsV5(legacyDb);
     legacyDb.close();
 
     expect(detectOpenClawStateDatabaseSchemaMigrations(options)).toContainEqual({
       kind: "operator-approvals-system-agent",
       path: databasePath,
     });
-    expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
-      changes: [
-        "Migrated shared state operator approvals → OpenClaw system changes",
-        expect.stringMatching(/^Rebuilt canonical shared-state SQLite indexes \(\d+\)$/u),
-      ],
-      warnings: [],
-    });
+    const repaired = repairOpenClawStateDatabaseSchema(options);
+    expect(repaired.warnings).toEqual([]);
+    expect(repaired.changes).toContain(
+      "Migrated shared state operator approvals → OpenClaw system changes",
+    );
 
     const reopened = openOpenClawStateDatabase(options);
     const migratedSql = reopened.db
       .prepare("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 'operator_approvals'")
       .get() as { sql: string };
     expect(migratedSql.sql).toContain("'system-agent'");
+    expect(
+      reopened.db
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'plugin_external_verification_attempts'",
+        )
+        .get(),
+    ).toEqual({ name: "plugin_external_verification_attempts" });
   });
 
   it("does not recursively recommend doctor when operator approval repair refuses a shape", () => {

--- a/src/state/openclaw-state-schema-compatibility.test.ts
+++ b/src/state/openclaw-state-schema-compatibility.test.ts
@@ -2,6 +2,35 @@ import { describe, expect, it } from "vitest";
 import { getOpenClawStateRuntimeSchema } from "./openclaw-state-schema-compatibility.js";
 
 describe("OpenClaw state runtime schema projection", () => {
+  it("lets a previous reader accept a database carrying the lazy attempts trigger", async () => {
+    const { DatabaseSync } = await import("node:sqlite");
+    const { assertSqliteSchemaContains } = await import("../infra/sqlite-schema-contract.js");
+    const { OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY } =
+      await import("./openclaw-state-schema-compatibility.js");
+    const db = new DatabaseSync(":memory:");
+    // A current database that has installed the external-verification feature:
+    // the attempts table plus the close trigger on the core approvals table.
+    db.exec(getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: true }));
+    expect(
+      db
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'trigger' AND name = 'trg_operator_approval_closes_external_verification'",
+        )
+        .get(),
+    ).toEqual({ name: "trg_operator_approval_closes_external_verification" });
+    // A previous reader (predating the feature: attempts table projected out)
+    // must accept the trigger's presence rather than reject it as noncanonical.
+    expect(() =>
+      assertSqliteSchemaContains(
+        db,
+        "previous reader",
+        getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: false }),
+        OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
+      ),
+    ).not.toThrow();
+    db.close();
+  });
+
   it("omits lazy additive tables and their unique indexes before first use", () => {
     const schema = getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: false });
 
@@ -17,5 +46,45 @@ describe("OpenClaw state runtime schema projection", () => {
     expect(schema).not.toContain("CREATE TABLE IF NOT EXISTS github_publication_requests");
     expect(schema).not.toContain("idx_github_publication_requests_pending");
     expect(schema).not.toContain("CREATE TABLE IF NOT EXISTS config_revision_keys");
+    // The trigger references the lazy attempts table in its body; SQLite only
+    // validates that at fire time, so a projected schema keeping the trigger
+    // would break the first ordinary approval resolution on an upgraded
+    // database that has never used external verification.
+    expect(schema).not.toContain("plugin_external_verification_attempts");
+    expect(schema).not.toContain("trg_operator_approval_closes_external_verification");
+  });
+
+  it("keeps the attempts ledger trigger with its table when lazy tables are included", () => {
+    const schema = getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: true });
+    expect(schema).toContain("CREATE TABLE IF NOT EXISTS plugin_external_verification_attempts");
+    expect(schema).toContain(
+      "CREATE TRIGGER IF NOT EXISTS trg_operator_approval_closes_external_verification",
+    );
+  });
+
+  it("resolves an ordinary approval on a database opened without the lazy ledger", async () => {
+    const { DatabaseSync } = await import("node:sqlite");
+    const db = new DatabaseSync(":memory:");
+    db.exec(getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: false }));
+    db.exec(`
+      INSERT INTO operator_approvals (
+        approval_id, resolution_ref, kind, status, presentation_json,
+        reviewer_device_ids_json, audience_session_keys_json, runtime_epoch,
+        created_at_ms, expires_at_ms, updated_at_ms
+      ) VALUES (
+        'plugin:upgrade-probe', '${"A".repeat(43)}', 'plugin', 'pending', '{}',
+        '[]', '[]', 'epoch-1',
+        1, 10000, 1
+      );
+    `);
+    // Fires any terminal-transition trigger left in the projected schema.
+    db.exec(
+      "UPDATE operator_approvals SET status = 'denied', decision = 'deny', terminal_reason = 'user', resolver_kind = 'runtime', resolved_at_ms = 2, updated_at_ms = 2 WHERE approval_id = 'plugin:upgrade-probe';",
+    );
+    const row = db
+      .prepare("SELECT status FROM operator_approvals WHERE approval_id = 'plugin:upgrade-probe'")
+      .get() as { status: string };
+    expect(row.status).toBe("denied");
+    db.close();
   });
 });

--- a/src/state/openclaw-state-schema-compatibility.ts
+++ b/src/state/openclaw-state-schema-compatibility.ts
@@ -13,6 +13,7 @@ import {
   FIRST_USE_STATE_TABLES,
   LAZY_ADDITIVE_STATE_INDEXES,
   LAZY_ADDITIVE_STATE_TABLES,
+  LAZY_ADDITIVE_STATE_TRIGGERS,
 } from "./openclaw-state-db-contract.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
 
@@ -70,6 +71,18 @@ export function getOpenClawStateRuntimeSchema(options: {
     }
     schema = `${schema.slice(0, start)}${schema.slice(end + endMarker.length)}`;
   }
+  const omittedTriggers = options.includeVersionLazyAdditiveTables
+    ? []
+    : LAZY_ADDITIVE_STATE_TRIGGERS;
+  for (const triggerName of omittedTriggers) {
+    const start = schema.indexOf(`CREATE TRIGGER IF NOT EXISTS ${triggerName}`);
+    const endMarker = "\nEND;";
+    const end = start >= 0 ? schema.indexOf(endMarker, start) : -1;
+    if (start < 0 || end < 0) {
+      throw new Error(`lazy additive state schema trigger is missing for ${triggerName}`);
+    }
+    schema = `${schema.slice(0, start)}${schema.slice(end + endMarker.length)}`;
+  }
   for (const indexName of omittedIndexes) {
     const plainStart = schema.indexOf(`CREATE INDEX IF NOT EXISTS ${indexName}`);
     const uniqueStart = schema.indexOf(`CREATE UNIQUE INDEX IF NOT EXISTS ${indexName}`);
@@ -109,11 +122,46 @@ export const STATE_PERSISTENT_SCHEMA_COMPATIBILITY: SqliteSchemaCompatibility = 
   },
 };
 
+/**
+ * The external-verification close trigger lives on the core operator_approvals
+ * table but belongs to the lazy plugin_external_verification_attempts feature.
+ * A previous reader that predates the feature (attempts table absent) sees the
+ * trigger as unexpected; a current reader (table present) requires it. Register
+ * it as an optional canonical trigger group keyed to the lazy table so both
+ * readers validate. The SQL is derived from the canonical schema and normalized
+ * to SQLite's stored form (no IF NOT EXISTS, no trailing semicolon) so it
+ * cannot drift from the shipped trigger.
+ */
+const EXTERNAL_VERIFICATION_CLOSE_TRIGGER_NAME =
+  "trg_operator_approval_closes_external_verification";
+
+function canonicalExternalVerificationCloseTrigger(): { name: string; sql: string } {
+  const start = OPENCLAW_STATE_SCHEMA_SQL.indexOf(
+    `CREATE TRIGGER IF NOT EXISTS ${EXTERNAL_VERIFICATION_CLOSE_TRIGGER_NAME}`,
+  );
+  const endMarker = "\nEND;";
+  const end = start >= 0 ? OPENCLAW_STATE_SCHEMA_SQL.indexOf(endMarker, start) : -1;
+  if (start < 0 || end < 0) {
+    throw new Error("external verification close trigger is missing from the canonical schema");
+  }
+  const stored = OPENCLAW_STATE_SCHEMA_SQL.slice(start, end + endMarker.length)
+    .replace("CREATE TRIGGER IF NOT EXISTS ", "CREATE TRIGGER ")
+    .replace(/;$/u, "");
+  return { name: EXTERNAL_VERIFICATION_CLOSE_TRIGGER_NAME, sql: stored };
+}
+
+const EXTERNAL_VERIFICATION_OPTIONAL_TRIGGER_GROUP = {
+  tableName: "operator_approvals",
+  optionalWhenTableMissing: "plugin_external_verification_attempts",
+  triggers: [canonicalExternalVerificationCloseTrigger()],
+} as const;
+
 export const OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY: SqliteSchemaCompatibility = {
   ...STATE_PERSISTENT_SCHEMA_COMPATIBILITY,
   allowedMissingTables: [...LAZY_ADDITIVE_STATE_TABLES, ...CLAW_STARTUP_ADDITIVE_STATE_TABLES],
   allowedMissingIndexes: CLAW_READONLY_OPTIONAL_STATE_INDEXES,
   allowedMissingColumns: CLAW_LAZY_ADDITIVE_STATE_COLUMNS,
+  optionalCanonicalTriggerGroups: [EXTERNAL_VERIFICATION_OPTIONAL_TRIGGER_GROUP],
 };
 
 /** Identify schema differences that the writable shared-state cold open repairs. */

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -540,6 +540,101 @@ CREATE INDEX IF NOT EXISTS idx_operator_approvals_runtime_pending
   ON operator_approvals(runtime_epoch, approval_id)
   WHERE status = 'pending';
 
+-- External verifier attempts are append-only, proof-free audit records. The
+-- canonical approval row remains the authorization source of truth.
+CREATE TABLE IF NOT EXISTS plugin_external_verification_attempts (
+  attempt_id TEXT NOT NULL PRIMARY KEY CHECK (length(attempt_id) > 0),
+  approval_id TEXT NOT NULL,
+  plugin_id TEXT NOT NULL CHECK (length(plugin_id) > 0),
+  run_id TEXT NOT NULL CHECK (length(run_id) > 0),
+  tool_name TEXT NOT NULL CHECK (length(tool_name) > 0),
+  tool_call_id TEXT,
+  agent_id TEXT,
+  session_key TEXT,
+  session_id TEXT,
+  interaction_id TEXT NOT NULL CHECK (length(interaction_id) = 64),
+  decision TEXT NOT NULL CHECK (decision IN ('allow-once', 'allow-always')),
+  label TEXT NOT NULL CHECK (length(label) BETWEEN 1 AND 80),
+  created_at_ms INTEGER NOT NULL,
+  expires_at_ms INTEGER NOT NULL,
+  ended_at_ms INTEGER,
+  outcome TEXT CHECK (outcome IN ('succeeded', 'failed', 'cancelled', 'timed-out')),
+  error_class TEXT CHECK (error_class IS NULL OR length(error_class) BETWEEN 1 AND 64),
+  terminal_source TEXT,
+  completion_applied INTEGER CHECK (completion_applied IN (0, 1)),
+  grant_authorization_id TEXT,
+  grant_issued_at_ms INTEGER,
+  resolver_plugin_id TEXT,
+  runtime_epoch TEXT NOT NULL,
+  FOREIGN KEY (approval_id) REFERENCES operator_approvals(approval_id) ON DELETE CASCADE,
+  UNIQUE (approval_id, interaction_id),
+  CHECK (expires_at_ms >= created_at_ms),
+  CHECK (
+    (
+      ended_at_ms IS NULL
+      AND outcome IS NULL
+      AND error_class IS NULL
+      AND terminal_source IS NULL
+      AND completion_applied IS NULL
+      AND grant_authorization_id IS NULL
+      AND grant_issued_at_ms IS NULL
+      AND resolver_plugin_id IS NULL
+    )
+    OR (
+      ended_at_ms IS NOT NULL
+      AND outcome IS NOT NULL
+      AND completion_applied IS NOT NULL
+      AND ended_at_ms >= created_at_ms
+    )
+  ),
+  CHECK (
+    (
+      outcome = 'succeeded'
+      AND resolver_plugin_id IS NOT NULL
+      AND (
+        (
+          decision = 'allow-always'
+          AND grant_authorization_id IS NOT NULL
+          AND grant_issued_at_ms IS NOT NULL
+        )
+        OR (
+          decision = 'allow-once'
+          AND grant_authorization_id IS NULL
+          AND grant_issued_at_ms IS NULL
+        )
+      )
+    )
+    OR (outcome IS NULL OR outcome != 'succeeded')
+  )
+) STRICT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_plugin_external_verification_active_approval
+  ON plugin_external_verification_attempts(approval_id)
+  WHERE ended_at_ms IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_plugin_external_verification_run_active
+  ON plugin_external_verification_attempts(run_id, created_at_ms)
+  WHERE ended_at_ms IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_plugin_external_verification_approval_created
+  ON plugin_external_verification_attempts(approval_id, created_at_ms DESC);
+
+-- Every terminal approval transition closes its active verifier attempt in the
+-- same SQLite transaction. External success ends the attempt before allowing
+-- the approval, so this trigger only handles denial/expiry/cancellation races.
+CREATE TRIGGER IF NOT EXISTS trg_operator_approval_closes_external_verification
+AFTER UPDATE OF status ON operator_approvals
+WHEN OLD.status = 'pending' AND NEW.status != 'pending'
+BEGIN
+  UPDATE plugin_external_verification_attempts
+  SET
+    ended_at_ms = NEW.resolved_at_ms,
+    outcome = CASE WHEN NEW.status = 'expired' THEN 'timed-out' ELSE 'cancelled' END,
+    terminal_source = NEW.terminal_reason,
+    completion_applied = 0
+  WHERE approval_id = NEW.approval_id AND ended_at_ms IS NULL;
+END;
+
 CREATE TABLE IF NOT EXISTS operator_approval_execution_identities (
   approval_id TEXT NOT NULL PRIMARY KEY
     REFERENCES operator_approvals(approval_id) ON DELETE CASCADE,


### PR DESCRIPTION
## What Problem This Solves

The behavior half of the accepted external verification contract (#113517, openclaw/rfcs#15, tracker #82336): a plugin-owned verification ceremony actually gating a protected tool call, with OpenClaw retaining approval identity, reviewer authorization, timeout, denial, cancellation, retry generations, and the final decision.

## Why This Change Was Made

Runtime slice. Implements the attempt runtime (immutable setup and presentation per generation, reviewer interaction replay, native action tokens returning current state when stale), the `plugin.approval.external.prepare`/`start` gateway methods with reviewer authorization, first-answer-wins completion wired to the durable store, startup/shutdown reconciliation (pending attempts fail closed on gateway restart), approval-ownership derivation from the signed agent runtime identity (public payloads never carry `pluginId`; `externalResolution`/`runId`/`sessionId` accepted only from internal approval-runtime callers), and run-end settlement of external approvals alongside exec approvals.

Draft, stacked: the first two commits are #134897 (state) and #134898 (SDK); review the final commit. Implements only the accepted contract in #82336's body — the previously dropped asks (arbitrary approval actions, `keepPendingWithoutRoute`, `chat.inject` cards, admin helpers) remain out.

## User Impact

With a verifier plugin installed, protected tool calls block on a host-owned approval that only the plugin's external ceremony (or deny) can resolve; generic resolution stays deny-only. Without such a plugin: no change.

## Evidence

- Runtime suite (26), plugin-approval methods (44), approval methods (18), presentation/payload suites (66), embedded-mode hook suite (27) — green on this branch; `check:changed` green.
- Live proof on a 2026.8.1 gateway with production World App: verify-once resumed exactly the gated call; deny prevented it; stale retry required a fresh ceremony; expiry and run-abort failed closed (evidence trail in #82336).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Real behavior proof + P1 resolution (after ClawSweeper review)

**P1 "advertised external command not wired" — fixed.** The `/approve <id> external allow-once|allow-always` parser now lives in this runtime slice (moved from the TUI slice, since the canonical text command is contract-level and this slice advertises it). Exact-head coverage in `commands-approve.test.ts`: the external command routes to the plugin-bound verifier start (not a generic allow), and fails closed when there is no stable message identity.

**Owner-boundary, exact head:** runtime suite (26), plugin-approval methods (44), approval methods (18), presentation/payload suites, embedded-mode hook suite — green.

**Composition, real gateway:** `agentkit` gateway E2E (`test:openclaw-hitl`, human + delegation, both exit 0) against the assembled head drives prepare/start/complete/grant through a real built gateway (only World transport mocked). Redacted trace:

```
[gateway] http server listening (2 plugins: agentkit, memory-core)
[plugins] agentkit: stored session grant <redacted> for exec
[plugins] agentkit: allowed exec via verified session grant <redacted>
```

**Live human ceremony:** physical World App on 2026.8.1 (tracker #82336).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
