### PR TITLE
fix(doctor): report shared auth health without a default agent

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -241,6 +241,11 @@ openclaw doctor --lint --skip core/doctor/skills-readiness
 
 `--only` and `--skip` accept full check ids and may be repeated. If an `--only` id is not registered, no check runs for that id; use `checksRun`/`checksSkipped` in the output to confirm a focused gate selects the checks you expect.
 
+To check model credentials, run `openclaw doctor --lint --only core/doctor/auth-profiles --json`.
+This opt-in check inspects shared credentials and each configured agent's local
+auth store, including fleets without a default agent. Shared credential problems
+are reported once; agent-specific cooldowns remain attributed to their local store.
+
 ## Post-upgrade mode
 
 `openclaw doctor --post-upgrade` runs plugin compatibility probes for chaining after a build or upgrade. Findings go to stdout; exit code is 1 if any finding has `level: "error"`. Add `--json` for a machine-readable envelope (`{ probesRun, findings }`), suitable for CI, the community `fork-upgrade` skill, and other post-upgrade smoke tooling. If the installed plugin index is missing or malformed, JSON mode still emits the envelope with a `plugin.index_unavailable` error finding.

--- a/scripts/e2e/lib/plugins/fixtures.sh
+++ b/scripts/e2e/lib/plugins/fixtures.sh
@@ -43,12 +43,13 @@ openclaw_plugins_cleanup_fixture_servers() {
   done
 }
 
+# Use explicit statuses: Bash 5.2 bare returns inside EXIT cleanup reuse the original failure.
 openclaw_plugins_signal_fixture_process() {
   local pid="$1"
   local signal="$2"
   if kill -0 -- "-$pid" >/dev/null 2>&1; then
     kill "-$signal" -- "-$pid" >/dev/null 2>&1 || true
-    return
+    return 0
   fi
   kill "-$signal" "$pid" >/dev/null 2>&1 || true
 }
@@ -66,11 +67,11 @@ openclaw_plugins_stop_fixture_process() {
   interval="$(openclaw_plugins_read_nonnegative_decimal_env OPENCLAW_PLUGINS_FIXTURE_STOP_INTERVAL_SECONDS 0.25)" || return $?
   if declare -F openclaw_e2e_stop_process >/dev/null 2>&1; then
     openclaw_e2e_stop_process "$pid"
-    return
+    return "$?"
   fi
   openclaw_plugins_signal_fixture_process "$pid" TERM
   for _ in $(seq 1 "$attempts"); do
-    ! openclaw_plugins_fixture_process_alive "$pid" && { wait "$pid" >/dev/null 2>&1 || true; return; }
+    ! openclaw_plugins_fixture_process_alive "$pid" && { wait "$pid" >/dev/null 2>&1 || true; return 0; }
     sleep "$interval"
   done
   openclaw_plugins_signal_fixture_process "$pid" KILL

--- a/src/commands/doctor-auth.profile-health.test.ts
+++ b/src/commands/doctor-auth.profile-health.test.ts
@@ -12,10 +12,10 @@ import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
 const authProfileMocks = vi.hoisted(() => ({
-  ensureAuthProfileStore: vi.fn<
+  loadAuthProfileStoreForRuntime: vi.fn<
     (
       agentDir?: string,
-      options?: { allowKeychainPrompt?: boolean; readOnly?: boolean },
+      options?: { allowKeychainPrompt?: boolean; readOnly?: boolean; inheritedAuthDir?: string },
     ) => AuthProfileStore
   >(() => {
     throw new Error("unexpected auth profile load");
@@ -28,7 +28,7 @@ const authProfileMocks = vi.hoisted(() => ({
 
 vi.mock("../agents/auth-profiles.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../agents/auth-profiles.js")>()),
-  ensureAuthProfileStore: authProfileMocks.ensureAuthProfileStore,
+  loadAuthProfileStoreForRuntime: authProfileMocks.loadAuthProfileStoreForRuntime,
   hasAnyAuthProfileStoreSource: authProfileMocks.hasAnyAuthProfileStoreSource,
   hasLocalAuthProfileStoreSource: authProfileMocks.hasLocalAuthProfileStoreSource,
   resolveApiKeyForProfile: authProfileMocks.resolveApiKeyForProfile,
@@ -52,7 +52,7 @@ describe("noteAuthProfileHealth", () => {
   beforeEach(() => {
     tempDir = tempDirs.make("openclaw-doctor-auth-");
     vi.stubEnv("OPENCLAW_STATE_DIR", tempDir);
-    authProfileMocks.ensureAuthProfileStore.mockReset();
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockReset();
     authProfileMocks.hasAnyAuthProfileStoreSource.mockReset();
     authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(false);
     authProfileMocks.hasLocalAuthProfileStoreSource.mockReset();
@@ -97,8 +97,10 @@ describe("noteAuthProfileHealth", () => {
     vi.spyOn(Date, "now").mockReturnValue(now);
     const mainDir = path.join(tempDir, "main-agent");
     writeAuthStore(mainDir);
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
-    authProfileMocks.ensureAuthProfileStore.mockReturnValue(
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+      (agentDir) => agentDir !== undefined,
+    );
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockReturnValue(
       expiredStore("openai:default", now - 60_000),
     );
 
@@ -129,7 +131,7 @@ describe("noteAuthProfileHealth", () => {
     writeConfigMachineState("auth.sharedStore", { location: "state-db" });
     writePersistedAuthProfileStoreRaw({ version: 1, profiles: {} });
     authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
-    authProfileMocks.ensureAuthProfileStore.mockReturnValue(
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockReturnValue(
       expiredStore("openai:default", now - 60_000),
     );
 
@@ -150,8 +152,10 @@ describe("noteAuthProfileHealth", () => {
     const now = 1_700_000_000_000;
     vi.spyOn(Date, "now").mockReturnValue(now);
     const mainDir = path.join(tempDir, "main-agent");
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
-    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+      (agentDir) => agentDir !== undefined,
+    );
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockReturnValue({
       version: 1,
       profiles: {
         "anthropic:static-cli": {
@@ -186,8 +190,10 @@ describe("noteAuthProfileHealth", () => {
     const now = 1_700_000_000_000;
     vi.spyOn(Date, "now").mockReturnValue(now);
     const mainDir = path.join(tempDir, "main-agent");
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
-    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+      (agentDir) => agentDir !== undefined,
+    );
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockReturnValue({
       version: 1,
       profiles: {
         "anthropic:custom-cli": {
@@ -219,9 +225,11 @@ describe("noteAuthProfileHealth", () => {
     vi.spyOn(Date, "now").mockReturnValue(now);
     const mainDir = path.join(tempDir, "main-agent");
     writeAuthStore(mainDir);
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+      (agentDir) => agentDir !== undefined,
+    );
     authProfileMocks.resolveProfileUnusableUntilForDisplay.mockReturnValue(now + 5 * 60_000);
-    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockReturnValue({
       version: 1,
       profiles: {},
       usageStats: {
@@ -263,9 +271,11 @@ describe("noteAuthProfileHealth", () => {
       const now = 1_700_000_000_000;
       vi.spyOn(Date, "now").mockReturnValue(now);
       const mainDir = path.join(tempDir, "main-agent");
-      authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+      authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+        (agentDir) => agentDir !== undefined,
+      );
       authProfileMocks.resolveProfileUnusableUntilForDisplay.mockReturnValue(now + 5 * 60_000);
-      authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+      authProfileMocks.loadAuthProfileStoreForRuntime.mockReturnValue({
         version: 1,
         profiles: {
           "openai:disabled": { type: "api_key", provider: "openai", key: "secret" },
@@ -292,9 +302,11 @@ describe("noteAuthProfileHealth", () => {
     const now = 1_700_000_000_000;
     vi.spyOn(Date, "now").mockReturnValue(now);
     const mainDir = path.join(tempDir, "main-agent");
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+      (agentDir) => agentDir !== undefined,
+    );
     authProfileMocks.resolveProfileUnusableUntilForDisplay.mockReturnValue(now + 5 * 60_000);
-    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockReturnValue({
       version: 1,
       profiles: {
         "openai:expired": {
@@ -332,9 +344,11 @@ describe("noteAuthProfileHealth", () => {
     const now = 1_700_000_000_000;
     vi.spyOn(Date, "now").mockReturnValue(now);
     const mainDir = path.join(tempDir, "main-agent");
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+      (agentDir) => agentDir !== undefined,
+    );
     authProfileMocks.resolveProfileUnusableUntilForDisplay.mockReturnValue(now + 5 * 60_000);
-    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockReturnValue({
       ...expiredStore("openai:expired", now - 60_000),
       usageStats: { "openai:expired": { cooldownUntil: now + 5 * 60_000 } },
     });
@@ -355,9 +369,11 @@ describe("noteAuthProfileHealth", () => {
     const now = 1_700_000_000_000;
     vi.spyOn(Date, "now").mockReturnValue(now);
     const mainDir = path.join(tempDir, "main-agent");
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+      (agentDir) => agentDir !== undefined,
+    );
     authProfileMocks.resolveProfileUnusableUntilForDisplay.mockReturnValue(now + 5 * 60_000);
-    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockReturnValue({
       version: 1,
       profiles: {
         "google-gemini-cli:legacy": {
@@ -395,9 +411,11 @@ describe("noteAuthProfileHealth", () => {
     const now = 1_700_000_000_000;
     vi.spyOn(Date, "now").mockReturnValue(now);
     const mainDir = path.join(tempDir, "main-agent");
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+      (agentDir) => agentDir !== undefined,
+    );
     authProfileMocks.resolveProfileUnusableUntilForDisplay.mockReturnValue(now + 5 * 60_000);
-    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockReturnValue({
       version: 1,
       profiles: {},
       usageStats: { "openai:cooldown": { cooldownUntil: now + 5 * 60_000 } },
@@ -417,8 +435,10 @@ describe("noteAuthProfileHealth", () => {
   it("maps malformed API-key auth profiles to structured findings", async () => {
     const mainDir = path.join(tempDir, "main-agent");
     writeAuthStore(mainDir);
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
-    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+      (agentDir) => agentDir !== undefined,
+    );
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockReturnValue({
       version: 1,
       profiles: {
         "zai:default": {
@@ -455,9 +475,10 @@ describe("noteAuthProfileHealth", () => {
     vi.spyOn(Date, "now").mockReturnValue(now);
     const mainDir = path.join(tempDir, "main-agent");
     const coderDir = path.join(tempDir, "coder-agent");
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
-    authProfileMocks.hasLocalAuthProfileStoreSource.mockReturnValue(true);
-    authProfileMocks.ensureAuthProfileStore.mockImplementation((agentDir) => {
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+      (agentDir) => agentDir !== undefined,
+    );
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockImplementation((agentDir) => {
       if (agentDir === mainDir) {
         return expiredStore("openai:main", now - 60_000);
       }
@@ -494,15 +515,15 @@ describe("noteAuthProfileHealth", () => {
     });
 
     expect(authProfileMocks.hasAnyAuthProfileStoreSource).toHaveBeenCalledOnce();
-    expect(authProfileMocks.ensureAuthProfileStore).not.toHaveBeenCalled();
+    expect(authProfileMocks.loadAuthProfileStoreForRuntime).not.toHaveBeenCalled();
   });
 
   it("checks the configured default agent auth store source", async () => {
     const defaultDir = path.join(tempDir, "custom-default");
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockImplementation(
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
       (agentDir) => agentDir === defaultDir,
     );
-    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockReturnValue({
       version: 1,
       profiles: {},
     });
@@ -517,9 +538,11 @@ describe("noteAuthProfileHealth", () => {
       allowKeychainPrompt: false,
     });
 
-    expect(authProfileMocks.hasAnyAuthProfileStoreSource).toHaveBeenCalledWith(defaultDir);
-    expect(authProfileMocks.ensureAuthProfileStore).toHaveBeenCalledWith(defaultDir, {
+    expect(authProfileMocks.hasLocalAuthProfileStoreSource).toHaveBeenCalledWith(defaultDir);
+    expect(authProfileMocks.loadAuthProfileStoreForRuntime).toHaveBeenCalledWith(defaultDir, {
+      inheritedAuthDir: defaultDir,
       allowKeychainPrompt: false,
+      readOnly: undefined,
     });
   });
 
@@ -530,9 +553,10 @@ describe("noteAuthProfileHealth", () => {
     const coderDir = path.join(tempDir, "coder-agent");
     writeAuthStore(mainDir);
     writeAuthStore(coderDir);
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
-    authProfileMocks.hasLocalAuthProfileStoreSource.mockReturnValue(true);
-    authProfileMocks.ensureAuthProfileStore.mockImplementation((agentDir) => {
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+      (agentDir) => agentDir !== undefined,
+    );
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockImplementation((agentDir) => {
       if (agentDir === mainDir) {
         return expiredStore("openai-codex:main", now - 60_000);
       }
@@ -561,9 +585,9 @@ describe("noteAuthProfileHealth", () => {
     expect(modelAuthCalls).toHaveLength(1);
     const body = String(modelAuthCalls[0]?.[0]);
     expect(body).toContain("openai-codex:coder");
-    expect(body).toContain("(agents: coder)");
+    expect(body).toContain("(stores: Agent coder)");
     expect(body).toContain("openai-codex:main");
-    expect(body).toContain("(agents: main)");
+    expect(body).toContain("(stores: Agent main)");
   });
 
   it("deduplicates model auth diagnostics shared by every agent", async () => {
@@ -573,9 +597,10 @@ describe("noteAuthProfileHealth", () => {
     const coderDir = path.join(tempDir, "coder-agent");
     writeAuthStore(mainDir);
     writeAuthStore(coderDir);
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
-    authProfileMocks.hasLocalAuthProfileStoreSource.mockReturnValue(true);
-    authProfileMocks.ensureAuthProfileStore.mockReturnValue(
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+      (agentDir) => agentDir !== undefined,
+    );
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockReturnValue(
       expiredStore("openai-codex:shared", now - 60_000),
     );
 
@@ -598,7 +623,7 @@ describe("noteAuthProfileHealth", () => {
     expect(modelAuthCalls).toHaveLength(1);
     const body = String(modelAuthCalls[0]?.[0]);
     expect(body.match(/openai-codex:shared/g)).toHaveLength(1);
-    expect(body).not.toContain("(agents:");
+    expect(body).not.toContain("(stores:");
   });
 
   it("offers credential repair while the same profile is cooling down", async () => {
@@ -606,9 +631,11 @@ describe("noteAuthProfileHealth", () => {
     vi.spyOn(Date, "now").mockReturnValue(now);
     const mainDir = path.join(tempDir, "main-agent");
     writeAuthStore(mainDir);
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+      (agentDir) => agentDir !== undefined,
+    );
     authProfileMocks.resolveProfileUnusableUntilForDisplay.mockReturnValue(now + 5 * 60_000);
-    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockReturnValue({
       ...expiredStore("openai-codex:expired", now - 60_000),
       usageStats: { "openai-codex:expired": { cooldownUntil: now + 5 * 60_000 } },
     });
@@ -638,11 +665,10 @@ describe("noteAuthProfileHealth", () => {
     vi.spyOn(Date, "now").mockReturnValue(now);
     const mainDir = path.join(tempDir, "main-agent");
     const coderDir = path.join(tempDir, "coder-agent");
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
     authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
       (agentDir) => agentDir === mainDir,
     );
-    authProfileMocks.ensureAuthProfileStore.mockImplementation((agentDir) => {
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockImplementation((agentDir) => {
       if (agentDir === mainDir) {
         return expiredStore("openai-codex:main", now - 60_000);
       }
@@ -665,9 +691,11 @@ describe("noteAuthProfileHealth", () => {
     });
 
     expect(authProfileMocks.hasLocalAuthProfileStoreSource).toHaveBeenCalledWith(coderDir);
-    expect(authProfileMocks.ensureAuthProfileStore).toHaveBeenCalledOnce();
-    expect(authProfileMocks.ensureAuthProfileStore).toHaveBeenCalledWith(mainDir, {
+    expect(authProfileMocks.loadAuthProfileStoreForRuntime).toHaveBeenCalledOnce();
+    expect(authProfileMocks.loadAuthProfileStoreForRuntime).toHaveBeenCalledWith(mainDir, {
+      inheritedAuthDir: mainDir,
       allowKeychainPrompt: false,
+      readOnly: undefined,
     });
     expect(noteMock).toHaveBeenCalledWith(
       expect.stringContaining("openai-codex:main"),
@@ -678,8 +706,10 @@ describe("noteAuthProfileHealth", () => {
   it("prints malformed API-key profile diagnostics", async () => {
     const agentDir = path.join(tempDir, "main-agent");
     writeAuthStore(agentDir);
-    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
-    authProfileMocks.ensureAuthProfileStore.mockImplementation(
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+      (candidateDir) => candidateDir !== undefined,
+    );
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockImplementation(
       (receivedAgentDir): AuthProfileStore => {
         if (receivedAgentDir === agentDir) {
           return {
@@ -724,7 +754,7 @@ describe("noteAuthProfileHealth", () => {
     authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
       (agentDir) => agentDir === coderDir,
     );
-    authProfileMocks.ensureAuthProfileStore.mockImplementation((agentDir) => {
+    authProfileMocks.loadAuthProfileStoreForRuntime.mockImplementation((agentDir) => {
       if (agentDir === coderDir) {
         return expiredStore("openai-codex:coder", now + 60 * 60_000);
       }
@@ -783,8 +813,10 @@ describe("noteAuthProfileHealth", () => {
       const now = 1_700_000_000_000;
       vi.spyOn(Date, "now").mockReturnValue(now);
       const agentDir = path.join(tempDir, "main-agent");
-      authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
-      authProfileMocks.ensureAuthProfileStore.mockReturnValue(
+      authProfileMocks.hasLocalAuthProfileStoreSource.mockImplementation(
+        (candidateDir) => candidateDir !== undefined,
+      );
+      authProfileMocks.loadAuthProfileStoreForRuntime.mockReturnValue(
         expiredStore(profileId, now - 60_000),
       );
       authProfileMocks.resolveApiKeyForProfile.mockRejectedValue(new Error(message));

--- a/src/commands/doctor-auth.shared-health.test.ts
+++ b/src/commands/doctor-auth.shared-health.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { note } from "../../packages/terminal-core/src/note.js";
+import { resolveSharedAuthStorePath } from "../agents/auth-profiles/path-resolve.js";
+import {
+  resolveAuthProfileDatabasePath,
+  writePersistedAuthProfileStateRaw,
+  writePersistedAuthProfileStoreRaw,
+} from "../agents/auth-profiles/sqlite.js";
+import {
+  loadAuthProfileStoreForRuntime,
+  loadAuthProfileStoreWithoutExternalProfiles,
+  resolvePersistedAuthProfileOwnerAgentDir,
+} from "../agents/auth-profiles/store.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { writeConfigMachineState } from "../state/config-machine-state.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { collectAuthProfileHealthFindings, noteAuthProfileHealth } from "./doctor-auth.js";
+import { createDoctorPrompter } from "./doctor-prompter.js";
+
+vi.mock("../../packages/terminal-core/src/note.js", () => ({ note: vi.fn() }));
+const cliCredentials = vi.hoisted(() => ({ readCodex: vi.fn() }));
+const refreshProfile = vi.hoisted(() => vi.fn(async () => undefined));
+vi.mock("../agents/auth-profiles.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../agents/auth-profiles.js")>()),
+  resolveApiKeyForProfile: refreshProfile,
+}));
+vi.mock("../agents/cli-credentials.js", () => ({
+  readCodexCliCredentialsCached: cliCredentials.readCodex,
+  readMiniMaxCliCredentialsCached: () => null,
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  cliCredentials.readCodex.mockReset();
+});
+
+describe("Doctor shared auth health", () => {
+  it("reports shared OAuth expiry for an explicit fleet without local profiles", async () => {
+    await withOpenClawTestState({ prefix: "openclaw-doctor-shared-health-" }, async (state) => {
+      const cfg: OpenClawConfig = {
+        agents: { ownership: "explicit", entries: { alpha: {}, beta: {} } },
+        plugins: { enabled: false },
+      };
+      await state.writeConfig(cfg);
+      const profileId = "diagnostic-provider:shared";
+      const store = {
+        version: 1,
+        profiles: {
+          [profileId]: {
+            type: "oauth" as const,
+            provider: "diagnostic-provider",
+            access: "synthetic-access",
+            refresh: "synthetic-refresh",
+            expires: Date.now() - 60_000,
+          },
+        },
+      };
+      writeConfigMachineState("auth.sharedStore", { location: "state-db" });
+      writePersistedAuthProfileStoreRaw(store);
+      const sharedPath = resolveSharedAuthStorePath();
+      const prompter = createDoctorPrompter({
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        options: { nonInteractive: true },
+      });
+
+      const findings = await collectAuthProfileHealthFindings({ cfg });
+      await noteAuthProfileHealth({ cfg, prompter, allowKeychainPrompt: false });
+
+      expect.soft(findings).toEqual([
+        expect.objectContaining({
+          target: profileId,
+          path: sharedPath,
+          message: expect.stringContaining("expired"),
+        }),
+      ]);
+      expect
+        .soft(vi.mocked(note).mock.calls)
+        .toEqual([[expect.stringContaining(`${profileId}: expired`), "Model auth"]]);
+      expect(loadAuthProfileStoreWithoutExternalProfiles().profiles).toEqual(store.profiles);
+    });
+  });
+
+  it("keeps inherited-profile recovery guidance local without duplicating shared expiry", async () => {
+    await withOpenClawTestState({ prefix: "openclaw-doctor-auth-owners-" }, async (state) => {
+      const cfg: OpenClawConfig = {
+        agents: { ownership: "explicit", entries: { alpha: {}, beta: {} } },
+        plugins: { enabled: false },
+      };
+      await state.writeConfig(cfg);
+      const profileId = "diagnostic-provider:shared";
+      writeConfigMachineState("auth.sharedStore", { location: "state-db" });
+      writePersistedAuthProfileStoreRaw({
+        version: 1,
+        profiles: {
+          [profileId]: {
+            type: "oauth",
+            provider: "diagnostic-provider",
+            access: "synthetic-access",
+            refresh: "synthetic-refresh",
+            expires: Date.now() - 60_000,
+          },
+        },
+      });
+      const agentDir = state.agentDir("alpha");
+      writePersistedAuthProfileStoreRaw({ version: 1, profiles: {} }, agentDir);
+      writePersistedAuthProfileStateRaw(
+        {
+          version: 1,
+          usageStats: {
+            [profileId]: { cooldownUntil: Date.now() + 600_000, cooldownReason: "session_expired" },
+          },
+        },
+        agentDir,
+      );
+
+      const findings = await collectAuthProfileHealthFindings({ cfg });
+      expect.soft(findings).toEqual([
+        expect.objectContaining({
+          target: profileId,
+          path: resolveSharedAuthStorePath(),
+          message: expect.stringContaining("expired"),
+        }),
+        expect.objectContaining({
+          target: profileId,
+          path: resolveAuthProfileDatabasePath(agentDir),
+          message: expect.stringContaining("cooldown:session_expired"),
+          fixHint:
+            "Re-authenticate with `openclaw models auth login --provider diagnostic-provider --profile-id 'diagnostic-provider:shared'`.",
+        }),
+      ]);
+      await noteAuthProfileHealth({
+        cfg,
+        prompter: createDoctorPrompter({
+          runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+          options: { nonInteractive: true },
+        }),
+        allowKeychainPrompt: false,
+      });
+      expect(vi.mocked(note)).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Re-authenticate with `openclaw models auth login --provider diagnostic-provider --profile-id 'diagnostic-provider:shared'`.",
+        ),
+        "Auth profile cooldowns (Agent alpha)",
+      );
+    });
+  });
+
+  it("preserves external CLI overlays when checking an agent-local auth store", async () => {
+    await withOpenClawTestState({ prefix: "openclaw-doctor-cli-auth-" }, async (state) => {
+      const cfg: OpenClawConfig = {
+        agents: { ownership: "explicit", entries: { alpha: {}, beta: {} } },
+        plugins: { enabled: false },
+      };
+      await state.writeConfig(cfg);
+      writeConfigMachineState("auth.sharedStore", { location: "state-db" });
+      writePersistedAuthProfileStoreRaw(
+        {
+          version: 1,
+          profiles: { "openai:default": { type: "oauth", provider: "openai", expires: 1 } },
+        },
+        state.agentDir("alpha"),
+      );
+      cliCredentials.readCodex.mockReturnValue({
+        type: "oauth",
+        provider: "openai",
+        access: "synthetic-cli-access",
+        refresh: "synthetic-cli-refresh",
+        expires: Date.now() + 7 * 86_400_000,
+      });
+
+      expect(await collectAuthProfileHealthFindings({ cfg })).toEqual([]);
+      expect(cliCredentials.readCodex).toHaveBeenCalledWith(
+        expect.objectContaining({ allowKeychainPrompt: false }),
+      );
+    });
+  });
+
+  it.each([
+    { name: "healthy shared", sharedExpired: false, sameAccount: true, owner: undefined },
+    { name: "expired shared", sharedExpired: true, sameAccount: true, owner: "shared" },
+    { name: "distinct local account", sharedExpired: false, sameAccount: false, owner: "local" },
+  ])("respects canonical OAuth ownership for $name credentials", async (scenario) => {
+    await withOpenClawTestState({ prefix: "openclaw-doctor-oauth-owner-" }, async (state) => {
+      const cfg: OpenClawConfig = {
+        agents: { ownership: "explicit", entries: { alpha: {}, beta: {} } },
+        plugins: { enabled: false },
+      };
+      await state.writeConfig(cfg);
+      writeConfigMachineState("auth.sharedStore", { location: "state-db" });
+      const profileId = "diagnostic-provider:shared";
+      const shared = {
+        type: "oauth" as const,
+        provider: "diagnostic-provider",
+        access: "synthetic-shared-access",
+        refresh: "synthetic-shared-refresh",
+        accountId: "shared-account",
+        expires: Date.now() + (scenario.sharedExpired ? -60_000 : 7 * 86_400_000),
+      };
+      const local = {
+        ...shared,
+        access: "synthetic-old-local-access",
+        refresh: "synthetic-old-local-refresh",
+        accountId: scenario.sameAccount ? shared.accountId : "local-account",
+        expires: Date.now() - 120_000,
+      };
+      const agentDir = state.agentDir("alpha");
+      writePersistedAuthProfileStoreRaw({ version: 1, profiles: { [profileId]: shared } });
+      writePersistedAuthProfileStoreRaw({ version: 1, profiles: { [profileId]: local } }, agentDir);
+
+      expect(loadAuthProfileStoreForRuntime(agentDir).profiles[profileId]).toEqual(local);
+      expect(resolvePersistedAuthProfileOwnerAgentDir({ agentDir, profileId })).toBe(
+        scenario.sameAccount ? undefined : agentDir,
+      );
+      const findings = await collectAuthProfileHealthFindings({ cfg });
+      expect.soft(findings).toEqual(
+        scenario.owner
+          ? [
+              expect.objectContaining({
+                target: profileId,
+                path:
+                  scenario.owner === "shared"
+                    ? resolveSharedAuthStorePath()
+                    : resolveAuthProfileDatabasePath(agentDir),
+                message: expect.stringContaining("expired"),
+              }),
+            ]
+          : [],
+      );
+      const prompter = createDoctorPrompter({
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        options: { nonInteractive: true, repair: true },
+      });
+      await noteAuthProfileHealth({ cfg, prompter, allowKeychainPrompt: false });
+      expect(refreshProfile).toHaveBeenCalledTimes(scenario.owner ? 1 : 0);
+      if (scenario.owner) {
+        expect(refreshProfile).toHaveBeenCalledWith(
+          expect.objectContaining({
+            profileId,
+            agentDir: scenario.owner === "shared" ? undefined : agentDir,
+            forceRefresh: true,
+          }),
+        );
+      }
+    });
+  });
+});

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -1,12 +1,6 @@
 /** Doctor notes for auth profile health, OAuth refresh failures, and legacy Codex config. */
-import path from "node:path";
 import { note } from "../../packages/terminal-core/src/note.js";
-import {
-  listAgentIds,
-  resolveAgentDir,
-  resolveDefaultAgentDir,
-  tryResolveDefaultAgentId,
-} from "../agents/agent-scope.js";
+import { listAgentIds, resolveAgentDir } from "../agents/agent-scope.js";
 import {
   buildAuthHealthSummary,
   DEFAULT_OAUTH_WARN_MS,
@@ -16,8 +10,10 @@ import {
 import {
   type AuthCredentialReasonCode,
   ensureAuthProfileStore,
+  findPersistedAuthProfileCredential,
   hasAnyAuthProfileStoreSource,
   hasLocalAuthProfileStoreSource,
+  loadAuthProfileStoreForRuntime,
   resolveApiKeyForProfile,
   resolveProfileUnusableUntilForDisplay,
 } from "../agents/auth-profiles.js";
@@ -29,9 +25,16 @@ import {
   formatOAuthRefreshFailureLoginCommandMarkdown,
   type OAuthRefreshFailureReason,
 } from "../agents/auth-profiles/oauth-refresh-failure.js";
-import { resolveSharedAuthStoreOwnership } from "../agents/auth-profiles/path-resolve.js";
+import { shouldUseMainOwnerForLocalOAuthCredential } from "../agents/auth-profiles/ownership.js";
+import {
+  resolveSharedAuthStoreOwnership,
+  resolveSharedAuthStorePath,
+} from "../agents/auth-profiles/path-resolve.js";
 import { resolveAuthStorePathForDisplay } from "../agents/auth-profiles/paths.js";
-import { inspectPersistedSharedAuthProfileStoreRaw } from "../agents/auth-profiles/sqlite.js";
+import {
+  inspectPersistedSharedAuthProfileStoreRaw,
+  resolveAuthProfileDatabasePath,
+} from "../agents/auth-profiles/sqlite.js";
 import { buildProviderAuthRecoveryHint } from "../agents/provider-auth-recovery-hint.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding } from "../flows/health-checks.js";
@@ -174,36 +177,28 @@ type AuthIssue = {
 };
 
 type AuthProfileHealthTarget = {
-  agentId: string;
-  agentDir: string;
-  isDefault: boolean;
+  label: string;
+  agentDir?: string;
 };
 
-function formatAgentNoteTitle(title: string, agentId: string, labelAgents: boolean): string {
-  return labelAgents ? `${title} (agent: ${agentId})` : title;
+function formatAuthNoteTitle(
+  title: string,
+  target: AuthProfileHealthTarget,
+  labelStores: boolean,
+): string {
+  return labelStores ? `${title} (${target.label})` : title;
 }
 
 function listAuthProfileHealthTargets(cfg: OpenClawConfig): AuthProfileHealthTarget[] {
-  const defaultAgentId = tryResolveDefaultAgentId(cfg);
   const targets = new Map<string, AuthProfileHealthTarget>();
-  const addTarget = (agentId: string, agentDir: string, isDefault: boolean) => {
-    const key = path.resolve(agentDir);
-    const existing = targets.get(key);
-    if (!existing || isDefault) {
-      targets.set(key, { agentId, agentDir, isDefault: isDefault || existing?.isDefault === true });
-    }
-  };
-
-  if (defaultAgentId) {
-    addTarget(defaultAgentId, resolveDefaultAgentDir(cfg), true);
+  if (hasAnyAuthProfileStoreSource() || Object.keys(cfg.auth?.profiles ?? {}).length > 0) {
+    targets.set(resolveSharedAuthStorePath(), { label: "Shared" });
   }
   for (const agentId of listAgentIds(cfg)) {
-    if (agentId === defaultAgentId) {
-      continue;
-    }
     const agentDir = resolveAgentDir(cfg, agentId);
-    if (hasLocalAuthProfileStoreSource(agentDir)) {
-      addTarget(agentId, agentDir, false);
+    const databasePath = resolveAuthProfileDatabasePath(agentDir);
+    if (!targets.has(databasePath) && hasLocalAuthProfileStoreSource(agentDir)) {
+      targets.set(databasePath, { label: `Agent ${agentId}`, agentDir });
     }
   }
 
@@ -295,7 +290,7 @@ function resolveAuthProfileStorePath(target: AuthProfileHealthTarget): string {
 function authProfileIssueToHealthFinding(params: {
   issue: AuthIssue;
   target: AuthProfileHealthTarget;
-  labelAgents: boolean;
+  labelStores: boolean;
   hint: string | null;
 }): HealthFinding {
   const remaining =
@@ -303,7 +298,7 @@ function authProfileIssueToHealthFinding(params: {
       ? ` (${formatRemainingShort(params.issue.remainingMs)})`
       : "";
   const reason = params.issue.reasonCode ? ` [${params.issue.reasonCode}]` : "";
-  const owner = params.labelAgents ? `Agent ${params.target.agentId} auth profile` : "Auth profile";
+  const owner = params.labelStores ? `${params.target.label} auth profile` : "Auth profile";
   return {
     checkId: AUTH_PROFILES_CHECK_ID,
     severity: "warning",
@@ -319,19 +314,55 @@ function authProfileIssueToHealthFinding(params: {
   };
 }
 
-function authProfileCooldownToHealthFinding(params: {
+type AuthProfileCooldown = {
   profileId: string;
-  target: AuthProfileHealthTarget;
-  labelAgents: boolean;
   kind: string;
   remaining: string;
   hint: string;
-}): HealthFinding {
+};
+
+function collectAuthProfileCooldowns(store: ReturnType<typeof ensureAuthProfileStore>) {
+  const cooldowns: AuthProfileCooldown[] = [];
+  const now = Date.now();
+  for (const profileId of Object.keys(store.usageStats ?? {})) {
+    const until = resolveProfileUnusableUntilForDisplay(store, profileId);
+    if (!until || now >= until) {
+      continue;
+    }
+    const stats = store.usageStats?.[profileId];
+    const disabledActive = typeof stats?.disabledUntil === "number" && now < stats.disabledUntil;
+    const reason = disabledActive ? stats?.disabledReason : stats?.cooldownReason;
+    const displayReason = disabledActive ? reason : (stats?.cooldownClassification ?? reason);
+    cooldowns.push({
+      profileId,
+      kind: `${disabledActive ? "disabled" : "cooldown"}${displayReason ? `:${displayReason}` : ""}`,
+      remaining: formatRemainingShort(until - now),
+      hint: buildAuthProfileUnusableHint({
+        kind: disabledActive ? "disabled" : "cooldown",
+        reason,
+        // Local cooldowns can refer to shared credentials, whose expiry is checked separately.
+        provider:
+          store.profiles[profileId]?.provider ??
+          findPersistedAuthProfileCredential({ profileId })?.provider ??
+          profileId,
+        profileId,
+      }),
+    });
+  }
+  return cooldowns;
+}
+
+function authProfileCooldownToHealthFinding(
+  params: AuthProfileCooldown & {
+    target: AuthProfileHealthTarget;
+    labelStores: boolean;
+  },
+): HealthFinding {
   return {
     checkId: AUTH_PROFILES_CHECK_ID,
     severity: "warning",
-    message: params.labelAgents
-      ? `Agent ${params.target.agentId} auth profile ${params.profileId} is ${params.kind} (${params.remaining}).`
+    message: params.labelStores
+      ? `${params.target.label} auth profile ${params.profileId} is ${params.kind} (${params.remaining}).`
       : `Auth profile ${params.profileId} is ${params.kind} (${params.remaining}).`,
     path: resolveAuthProfileStorePath(params.target),
     target: params.profileId,
@@ -349,53 +380,60 @@ function isAuthProfileHealthIssue(profile: AuthHealthSummary["profiles"][number]
   );
 }
 
+function loadAuthProfileHealth(params: {
+  cfg: OpenClawConfig;
+  target: AuthProfileHealthTarget;
+  allowKeychainPrompt: boolean;
+  readOnly?: boolean;
+}) {
+  // Same-store inheritance keeps local cooldowns and CLI overlays. Credential health follows
+  // canonical OAuth ownership, so stale local copies cannot refresh shared credentials twice.
+  const store = loadAuthProfileStoreForRuntime(params.target.agentDir, {
+    inheritedAuthDir: params.target.agentDir,
+    allowKeychainPrompt: params.allowKeychainPrompt,
+    readOnly: params.readOnly,
+  });
+  const profiles = params.target.agentDir
+    ? Object.fromEntries(
+        Object.entries(store.profiles).filter(
+          ([profileId, local]) =>
+            local.type !== "oauth" ||
+            !shouldUseMainOwnerForLocalOAuthCredential({
+              local,
+              main: findPersistedAuthProfileCredential({ profileId }),
+            }),
+        ),
+      )
+    : store.profiles;
+  return {
+    store,
+    summary: buildAuthHealthSummary({
+      store: { ...store, profiles },
+      cfg: params.cfg,
+      warnAfterMs: DEFAULT_OAUTH_WARN_MS,
+      allowKeychainPrompt: params.allowKeychainPrompt,
+    }),
+  };
+}
+
 async function collectAuthProfileHealthFindingsForTarget(params: {
   cfg: OpenClawConfig;
   allowKeychainPrompt: boolean;
   target: AuthProfileHealthTarget;
-  labelAgents: boolean;
+  labelStores: boolean;
 }): Promise<readonly HealthFinding[]> {
-  const store = ensureAuthProfileStore(params.target.agentDir, {
-    allowKeychainPrompt: params.allowKeychainPrompt,
-    readOnly: true,
-  });
+  const { store, summary } = loadAuthProfileHealth({ ...params, readOnly: true });
   const findings: HealthFinding[] = [];
-  const now = Date.now();
-  for (const profileId of Object.keys(store.usageStats ?? {})) {
-    const until = resolveProfileUnusableUntilForDisplay(store, profileId);
-    if (!until || now >= until) {
-      continue;
-    }
-    const stats = store.usageStats?.[profileId];
-    const remaining = formatRemainingShort(until - now);
-    const disabledActive = typeof stats?.disabledUntil === "number" && now < stats.disabledUntil;
-    const reason = disabledActive ? stats?.disabledReason : stats?.cooldownReason;
-    const displayReason = disabledActive ? reason : (stats?.cooldownClassification ?? reason);
-    const kind = `${disabledActive ? "disabled" : "cooldown"}${displayReason ? `:${displayReason}` : ""}`;
-    const hint = buildAuthProfileUnusableHint({
-      kind: disabledActive ? "disabled" : "cooldown",
-      reason,
-      provider: store.profiles[profileId]?.provider ?? profileId,
-      profileId,
-    });
+  for (const cooldown of collectAuthProfileCooldowns(store)) {
     findings.push(
       authProfileCooldownToHealthFinding({
-        profileId,
+        ...cooldown,
         target: params.target,
-        labelAgents: params.labelAgents,
-        kind,
-        remaining,
-        hint,
+        labelStores: params.labelStores,
       }),
     );
   }
 
-  const summary = buildAuthHealthSummary({
-    store,
-    cfg: params.cfg,
-    warnAfterMs: DEFAULT_OAUTH_WARN_MS,
-    allowKeychainPrompt: params.allowKeychainPrompt,
-  });
   const issues = summary.profiles.filter(isAuthProfileHealthIssue);
   for (const issue of issues) {
     const authIssue: AuthIssue = {
@@ -409,7 +447,7 @@ async function collectAuthProfileHealthFindingsForTarget(params: {
       authProfileIssueToHealthFinding({
         issue: authIssue,
         target: params.target,
-        labelAgents: params.labelAgents,
+        labelStores: params.labelStores,
         hint: await resolveAuthIssueHint(authIssue, params.cfg, store),
       }),
     );
@@ -422,22 +460,16 @@ export async function collectAuthProfileHealthFindings(params: {
   cfg: OpenClawConfig;
   allowKeychainPrompt?: boolean;
 }): Promise<readonly HealthFinding[]> {
-  const configuredProfiles = Object.keys(params.cfg.auth?.profiles ?? {}).length > 0;
-  const targets = listAuthProfileHealthTargets(params.cfg);
-  const activeTargets = targets.filter((target) =>
-    target.isDefault
-      ? hasAnyAuthProfileStoreSource(target.agentDir) || configuredProfiles
-      : hasLocalAuthProfileStoreSource(target.agentDir),
-  );
+  const activeTargets = listAuthProfileHealthTargets(params.cfg);
   const findings: HealthFinding[] = [];
-  const labelAgents = activeTargets.length > 1;
+  const labelStores = activeTargets.length > 1;
   for (const target of activeTargets) {
     findings.push(
       ...(await collectAuthProfileHealthFindingsForTarget({
         cfg: params.cfg,
         allowKeychainPrompt: params.allowKeychainPrompt ?? false,
         target,
-        labelAgents,
+        labelStores,
       })),
     );
   }
@@ -458,48 +490,19 @@ async function noteAuthProfileHealthForTarget(params: {
   prompter: DoctorPrompter;
   allowKeychainPrompt: boolean;
   target: AuthProfileHealthTarget;
-  labelAgents: boolean;
+  labelStores: boolean;
 }): Promise<string[]> {
-  const store = ensureAuthProfileStore(params.target.agentDir, {
-    allowKeychainPrompt: params.allowKeychainPrompt,
-  });
+  let { store, summary } = loadAuthProfileHealth(params);
   const noteTitle = (title: string) =>
-    formatAgentNoteTitle(title, params.target.agentId, params.labelAgents);
-  const unusable = (() => {
-    const now = Date.now();
-    const out: string[] = [];
-    for (const profileId of Object.keys(store.usageStats ?? {})) {
-      const until = resolveProfileUnusableUntilForDisplay(store, profileId);
-      if (!until || now >= until) {
-        continue;
-      }
-      const stats = store.usageStats?.[profileId];
-      const remaining = formatRemainingShort(until - now);
-      const disabledActive = typeof stats?.disabledUntil === "number" && now < stats.disabledUntil;
-      const reason = disabledActive ? stats?.disabledReason : stats?.cooldownReason;
-      const displayReason = disabledActive ? reason : (stats?.cooldownClassification ?? reason);
-      const kind = `${disabledActive ? "disabled" : "cooldown"}${displayReason ? `:${displayReason}` : ""}`;
-      const hint = buildAuthProfileUnusableHint({
-        kind: disabledActive ? "disabled" : "cooldown",
-        reason,
-        provider: store.profiles[profileId]?.provider ?? profileId,
-        profileId,
-      });
-      out.push(`- ${profileId}: ${kind} (${remaining})${hint ? ` — ${hint}` : ""}`);
-    }
-    return out;
-  })();
+    formatAuthNoteTitle(title, params.target, params.labelStores);
+  const unusable = collectAuthProfileCooldowns(store).map(
+    ({ profileId, kind, remaining, hint }) =>
+      `- ${profileId}: ${kind} (${remaining})${hint ? ` — ${hint}` : ""}`,
+  );
 
   if (unusable.length > 0) {
     note(unusable.join("\n"), noteTitle("Auth profile cooldowns"));
   }
-
-  let summary = buildAuthHealthSummary({
-    store,
-    cfg: params.cfg,
-    warnAfterMs: DEFAULT_OAUTH_WARN_MS,
-    allowKeychainPrompt: params.allowKeychainPrompt,
-  });
 
   const findIssues = () => summary.profiles.filter(isAuthProfileHealthIssue);
 
@@ -543,14 +546,7 @@ async function noteAuthProfileHealthForTarget(params: {
     if (errors.length > 0) {
       note(errors.join("\n"), noteTitle("OAuth refresh errors"));
     }
-    summary = buildAuthHealthSummary({
-      store: ensureAuthProfileStore(params.target.agentDir, {
-        allowKeychainPrompt: false,
-      }),
-      cfg: params.cfg,
-      warnAfterMs: DEFAULT_OAUTH_WARN_MS,
-      allowKeychainPrompt: false,
-    });
+    ({ store, summary } = loadAuthProfileHealth({ ...params, allowKeychainPrompt: false }));
     issues = findIssues();
   }
 
@@ -563,35 +559,29 @@ export async function noteAuthProfileHealth(params: {
   prompter: DoctorPrompter;
   allowKeychainPrompt: boolean;
 }): Promise<void> {
-  const configuredProfiles = Object.keys(params.cfg.auth?.profiles ?? {}).length > 0;
-  const targets = listAuthProfileHealthTargets(params.cfg);
-  const activeTargets = targets.filter((target) =>
-    target.isDefault
-      ? hasAnyAuthProfileStoreSource(target.agentDir) || configuredProfiles
-      : hasLocalAuthProfileStoreSource(target.agentDir),
-  );
+  const activeTargets = listAuthProfileHealthTargets(params.cfg);
   if (activeTargets.length === 0) {
     return;
   }
 
-  const labelAgents = activeTargets.length > 1;
-  const agentsByIssueLine = new Map<string, Set<string>>();
+  const labelStores = activeTargets.length > 1;
+  const storesByIssueLine = new Map<string, Set<string>>();
   for (const target of activeTargets) {
-    for (const line of await noteAuthProfileHealthForTarget({ ...params, target, labelAgents })) {
-      const agentIds = agentsByIssueLine.get(line) ?? new Set<string>();
-      agentsByIssueLine.set(line, agentIds.add(target.agentId));
+    for (const line of await noteAuthProfileHealthForTarget({ ...params, target, labelStores })) {
+      const labels = storesByIssueLine.get(line) ?? new Set<string>();
+      storesByIssueLine.set(line, labels.add(target.label));
     }
   }
-  if (agentsByIssueLine.size === 0) {
+  if (storesByIssueLine.size === 0) {
     return;
   }
-  // One aggregated note; a line shared by every checked agent needs no attribution.
-  const lines = [...agentsByIssueLine.entries()]
+  // One aggregated note; a line shared by every checked store needs no attribution.
+  const lines = [...storesByIssueLine.entries()]
     .toSorted(([left], [right]) => left.localeCompare(right))
-    .map(([line, agentIds]) =>
-      agentIds.size === activeTargets.length
+    .map(([line, labels]) =>
+      labels.size === activeTargets.length
         ? line
-        : `${line} (agents: ${[...agentIds].toSorted().join(", ")})`,
+        : `${line} (stores: ${[...labels].toSorted().join(", ")})`,
     );
   note(lines.join("\n"), "Model auth");
 }

--- a/test/scripts/kitchen-sink-rpc-walk.test.ts
+++ b/test/scripts/kitchen-sink-rpc-walk.test.ts
@@ -580,6 +580,7 @@ describe("kitchen-sink RPC gateway teardown", () => {
   });
 
   it("requires /readyz body.ready before accepting gateway readiness", async () => {
+    vi.useFakeTimers();
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-kitchen-rpc-ready-body-"));
     try {
       const logPath = path.join(root, "gateway.log");
@@ -589,13 +590,15 @@ describe("kitchen-sink RPC gateway teardown", () => {
         .mockResolvedValueOnce(new Response('{"ready":false}', { status: 200 }))
         .mockResolvedValueOnce(new Response('{"ready":true}', { status: 200 }));
 
-      await expect(
+      const readiness = expect(
         waitForGatewayReady({ exitCode: null, signalCode: null }, 9, logPath, {
           fetchImpl,
           pollDelayMs: 1,
           timeoutMs: 100,
         }),
       ).resolves.toBeUndefined();
+      await vi.advanceTimersByTimeAsync(1);
+      await readiness;
 
       expect(fetchImpl).toHaveBeenCalledTimes(2);
     } finally {

--- a/test/scripts/write-unified-entry-dts.test.ts
+++ b/test/scripts/write-unified-entry-dts.test.ts
@@ -125,15 +125,6 @@ describe("write-unified-entry-dts", () => {
     expect(treeHashes(path.join(root, "dist"))).toEqual(before);
     expect(treeHashes(cache)).toEqual(cached);
     expectStagingClean(root);
-
-    write("src/contract.d.ts", 'export interface SourceOnly { value: "changed"; }');
-    const changed = runUnifiedBuild(root);
-    expect(changed.status, changed.stdout + changed.stderr).toBe(0);
-    expect(
-      (changed.stdout + changed.stderr).match(/\[tsdown-build\] invocation \d\/\d finished/gu),
-    ).toHaveLength(7);
-    expect(treeHashes(path.join(root, "dist"))).not.toEqual(before);
-    expectStagingClean(root);
   });
 
   it("records successful empty partitions for a bounded plugin selection", () => {


### PR DESCRIPTION
Related: #133984

## What Problem This Solves

Fixes an issue where Doctor could report no authentication problems for an explicit multi-agent fleet even when its shared OAuth profile had expired. Neither agent had local credentials, and there was no ambient default agent, so the shared store was never selected for inspection.

## Why This Change Was Made

Enumerate shared authentication independently of agent ownership, then inspect local stores once by their canonical database path. Both Doctor outputs use that same target list, cooldown projection, and health producer. The existing OAuth ownership rule assigns matching stale local copies to the shared owner, preventing duplicate refresh requests. The existing owner-local loader keeps CLI credential overlays and local cooldowns without repeatedly inspecting or refreshing inherited shared credentials.

## User Impact

Doctor reports expired shared credentials and keeps provider-specific recovery commands for local cooldowns on inherited credentials. It does not select an ambient agent or change authentication routing, persistence, or schema.

## Evidence

The built baseline CLI, using an isolated explicit two-agent fleet and synthetic expired shared OAuth, returned no findings from `doctor --lint --only core/doctor/auth-profiles --json`. The same real-store regression failed in both structured and text Doctor outputs before the fix. The final built candidate reports exactly one shared expiry finding and the expected lint exit 1; the harness exits 0. Three additional public-CLI cases verify healthy shared/stale local, expired shared/stale local, and distinct local accounts. All four cases preserve config and credential payloads and clean temporary state.

All 42 focused tests pass, including shared-only fleets, inherited-profile cooldown recovery hints, CLI credential overlays, and existing source-owner/hint behavior. Source inspection confirms the missed shared-store combination exists in stable v2026.8.1. No live provider login or real credentials were used.

Production LOC: +134/-144 (net -10). No authentication store implementation changed. The broader report that OAuth switched to API billing was not reproduced and is not claimed fixed here.

Real-store controls verify one shared refresh request at the stubbed provider boundary, preserve a distinct local account, and suppress the stale-copy warning when shared credentials are healthy. Runtime authentication and persistent ownership rules are unchanged.

The scoped changed gate passed all 29 stages against baseline `09a71580645f6ee2da22ac22938da04e76c3cfa6`, including production/test typechecks, lint, unused-export scans, and database/runtime guards. The earlier build and auth source hashes match the implementation retained across these rebases.

The auth implementation was rebased onto `09f9cbd2d065895c106fb3d1b59e78ad162f280e`, including the landed release-inventory fix (#134824) and Doctor/Gateway process-test preparation fix (#134812). The production auth module and both auth test files remain byte-identical to the reviewed implementation used for the earlier 42-test and four built-CLI proofs; the auth patch ID is unchanged. The current head is `de2a1f900017b913d00f70f158940bf31b4c5577`.

## CI Follow-up

[The earlier exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33489061479) exposed three unrelated tooling defects, now repaired in the same PR:

- The readiness-body test used a 100ms real-clock budget for two mocked responses. It now advances the existing 1ms poll with fake time, retaining the deadline, false/true response sequence, ready-log canary, and exact two-request assertion. Existing cleanup restores real timers before neighboring tests.
- The unified declaration test repeated a source-invalidation build already covered by the [SDK canonical-partitions case](https://github.com/openclaw/openclaw/blob/de2a1f900017b913d00f70f158940bf31b4c5577/test/scripts/write-plugin-sdk-entry-dts.test.ts). Both writers use the same declaration-cache owner. Removing that final repeated transition saves seven compiler invocations while preserving all six-group, public-type consumer, runtime rebuild, protected-output, byte-restoration, and cleanup checks.
- Bash 5.2 makes a bare return inside EXIT cleanup inherit the original trap status. Explicit success and delegated statuses let fixture cleanup finish and retain the caller's original outcome.

On the rebased candidate, 146 readiness/fixture tests and the two selected real declaration-build cases passed. The retained SDK source-invalidation case took 60.633s and the reduced unified case 34.581s locally; unrelated declaration cases were not rerun. Fifteen direct shell-behavior controls passed across Bash 3.2, 5.2, and 5.3, covering graceful/group cleanup, caller cleanup, original exit status, and delegated success/failure. The first local declaration attempt stopped before compilation because this native PR worktree lacked dependencies; a normal frozen-lockfile install resolved it without dependency or source changes.

The CI follow-up changes test lines by -6 and fixture support by +1 (three explicit return statuses plus one invariant comment). Product auth code remains net -10. The scoped changed gate passed all 14 stages, and independent Codex review found no P0 or P1 findings. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33495606567) passed: 201 successful jobs and 16 skipped.

The latest completed ClawSweeper review (09:19 UTC, before the CI follow-up) found no actionable auth code or security findings and requested successful exact-head CI and maintainer merge handling. CI is now green; the CI follow-up also has a clean independent review and one fresh ClawSweeper re-review request. Its stored-data heuristic is not a persistent-store change: this patch changes Doctor's diagnostic target selection and health projection only, reuses the existing OAuth owner policy, and preserves the full store for existing refresh operations. The four built-CLI controls verified unchanged configuration and credential payloads. No SQLite schema, migration, or authentication-store implementation is changed.
