### PR TITLE
fix(ui): retain desktop viewer through control handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Desktop control:** keep the current viewer connected until its replacement authenticates when switching control modes, preventing Windows desktop disconnects, and cancel stale connection attempts when the panel closes.
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.
 
 - **macOS AI setup:** show confirmed capability-review cancellation and retry guidance directly instead of a misleading Gateway failure headline. (#134573)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Desktop control:** keep the current viewer connected until its replacement authenticates when switching control modes, preventing Windows desktop disconnects, and cancel stale connection attempts when the panel closes.
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.
 
 - **macOS AI setup:** show confirmed capability-review cancellation and retry guidance directly instead of a misleading Gateway failure headline. (#134573)

--- a/src/agents/code-mode.bridge.lifecycle.test.ts
+++ b/src/agents/code-mode.bridge.lifecycle.test.ts
@@ -22,6 +22,7 @@ import {
   resultDetails,
   runUntilCompleted,
   testing,
+  waitUntilCompleted,
 } from "./code-mode.test-support.js";
 import { buildEmbeddedRunPayloads } from "./embedded-agent-runner/run/payloads.js";
 import { emitAssistantTextDeltaAndEnd } from "./embedded-agent-subscribe.e2e-harness.js";
@@ -437,12 +438,10 @@ describe("Code Mode subscribed bridge lifecycle", () => {
         );
         expect(suspended).toMatchObject({ status: "waiting", reason: "yield" });
 
-        const completed = resultDetails(
-          await expectDefined(harness.tools[1], "Code Mode wait test invariant").execute(
-            `code-wait-stage-${stage}`,
-            { runId: suspended.runId },
-          ),
-        );
+        const completed = await waitUntilCompleted({
+          details: suspended,
+          waitTool: expectDefined(harness.tools[1], "Code Mode wait test invariant"),
+        });
         expect(completed).toMatchObject({ status: "completed", value: { finished: true } });
         expect(countActiveToolExecutions(harness.runId)).toBe(0);
       }

--- a/ui/src/components/desktop/desktop-client.test.ts
+++ b/ui/src/components/desktop/desktop-client.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import { DesktopClient } from "./desktop-client.ts";
 
 type RfbConstructor = NonNullable<ConstructorParameters<typeof DesktopClient>[0]>;
@@ -36,6 +37,44 @@ function createFakeRfb() {
 }
 
 describe("DesktopClient", () => {
+  it.each([false, true])(
+    "opens a socket after the RFB loader only while the operation remains current (%s)",
+    async (remainsCurrent) => {
+      const { Rfb, instances } = createFakeRfb();
+      const loaded = createDeferred<RfbConstructor>();
+      const createSocket = vi.fn((url: string) => new FakeSocket(url) as unknown as WebSocket);
+      const client = new DesktopClient(undefined, createSocket, () => loaded.promise);
+      let current = true;
+      const pending = client.connect({
+        wsUrl: "ws://control.example.test/desktop/observe",
+        viewOnly: false,
+        target: document.createElement("div"),
+        isCurrent: () => current,
+      });
+      const result = pending.then(
+        (handle) => ({ handle, error: undefined }),
+        (error: unknown) => ({ handle: undefined, error }),
+      );
+      try {
+        expect(createSocket).not.toHaveBeenCalled();
+        current = remainsCurrent;
+        loaded.resolve(Rfb);
+        const outcome = await result;
+        expect(createSocket).toHaveBeenCalledTimes(remainsCurrent ? 1 : 0);
+        if (remainsCurrent) {
+          expect(outcome.error).toBeUndefined();
+          expect(instances).toHaveLength(1);
+        } else {
+          expect(outcome.error).toMatchObject({ name: "AbortError" });
+          expect(instances).toHaveLength(0);
+        }
+      } finally {
+        loaded.resolve(Rfb);
+        (await result).handle?.disconnect();
+      }
+    },
+  );
+
   it.each([
     ["http://control.example.test/chat", "ws://control.example.test/desktop/observe?token=abc"],
     ["https://control.example.test/chat", "wss://control.example.test/desktop/observe?token=abc"],
@@ -51,6 +90,7 @@ describe("DesktopClient", () => {
 
     await client.connect({
       gatewayUrl,
+      isCurrent: () => true,
       wsUrl: "/desktop/observe?token=abc",
       credentials: { password: "secret" },
       viewOnly: true,
@@ -74,6 +114,7 @@ describe("DesktopClient", () => {
 
     const handle = await client.connect({
       gatewayUrl: "ws://control.example.test",
+      isCurrent: () => true,
       wsUrl: "/desktop/observe",
       credentials: { username: "operator", password: "secret" },
       background: "rgb(8, 8, 8)",
@@ -100,6 +141,8 @@ describe("DesktopClient", () => {
       ["k", "m", "Backspace"],
     );
 
+    handle.disableInput();
+    expect(instances[0]?.viewOnly).toBe(true);
     handle.disconnect();
     expect(instances[0]?.disconnect).toHaveBeenCalledOnce();
   });
@@ -112,6 +155,7 @@ describe("DesktopClient", () => {
 
     await client.connect({
       wsUrl: "ws://control.example.test/desktop/observe",
+      isCurrent: () => true,
       viewOnly: true,
       target: document.createElement("div"),
       onDisconnect,

--- a/ui/src/components/desktop/desktop-client.ts
+++ b/ui/src/components/desktop/desktop-client.ts
@@ -12,6 +12,7 @@ type DesktopConnectOptions = {
   background?: string;
   credentials?: { username?: string; password?: string };
   gatewayUrl?: string;
+  isCurrent: () => boolean;
   onConnect?: () => void;
   onDisconnect?: (detail: DesktopDisconnectDetail) => void;
   onSecurityFailure?: (detail: DesktopSecurityFailureDetail) => void;
@@ -23,6 +24,7 @@ type DesktopConnectOptions = {
 
 export type DesktopConnectionHandle = {
   disconnect(): void;
+  disableInput(): void;
   sendBackspace?(): void;
   sendKeyboardEvent?(event: KeyboardEvent): void;
   sendText?(text: string): void;
@@ -82,6 +84,10 @@ export class DesktopClient {
   async connect(options: DesktopConnectOptions): Promise<DesktopConnectionHandle> {
     const Rfb = this.rfbConstructor ?? (await this.loadRfb());
     const wsUrl = resolveDesktopWebSocketUrl(options.wsUrl, options.gatewayUrl);
+    // The socket claims control before RFB authentication; canceled lazy loads must not open it.
+    if (!options.isCurrent()) {
+      throw new DOMException("Desktop connection is no longer current", "AbortError");
+    }
     const socket = this.createWebSocket(wsUrl);
     let closeDetail: DesktopDisconnectDetail = {};
     socket.addEventListener("close", (event) => {
@@ -123,6 +129,9 @@ export class DesktopClient {
       });
     return {
       disconnect: () => rfb.disconnect(),
+      disableInput: () => {
+        rfb.viewOnly = true;
+      },
       setScaleViewport: (enabled) => {
         rfb.scaleViewport = enabled;
       },

--- a/ui/src/components/desktop/desktop-panel-connection.ts
+++ b/ui/src/components/desktop/desktop-panel-connection.ts
@@ -1,4 +1,5 @@
 import type { DesktopObserveResult, WorkerDesktopAppId } from "@openclaw/gateway-protocol";
+import type { DesktopConnectionHandle } from "./desktop-client.ts";
 
 export type DesktopAppId = WorkerDesktopAppId;
 export type DesktopCredentials = { username?: string; password?: string };
@@ -13,3 +14,46 @@ export type PendingDesktopConnection = {
 export type ObservedDesktopConnection = PendingDesktopConnection & {
   observed: DesktopObserveResult;
 };
+
+/** Keeps a same-source viewer alive until its replacement finishes RFB authentication. */
+export class DesktopConnectionHandoff {
+  private current: DesktopConnectionHandle | null = null;
+  private retained: DesktopConnectionHandle | null = null;
+  private connected = false;
+
+  get handle(): DesktopConnectionHandle | null {
+    return this.connected ? this.current : null;
+  }
+
+  begin(retainViewer: boolean): void {
+    const retained = retainViewer ? (this.connected ? this.current : this.retained) : null;
+    const current = this.current;
+    const previous = this.retained;
+    this.current = null;
+    this.retained = retained;
+    this.connected = false;
+    if (current !== retained) {
+      current?.disconnect();
+    }
+    if (previous !== retained) {
+      previous?.disconnect();
+    }
+    retained?.disableInput();
+  }
+
+  attach(handle: DesktopConnectionHandle): void {
+    this.current = handle;
+  }
+
+  markConnected(): void {
+    // A returned handle or observe result is not the RFB authentication boundary.
+    this.connected = true;
+    const retained = this.retained;
+    this.retained = null;
+    retained?.disconnect();
+  }
+
+  disconnect(): void {
+    this.begin(false);
+  }
+}

--- a/ui/src/components/desktop/desktop-panel.test.ts
+++ b/ui/src/components/desktop/desktop-panel.test.ts
@@ -5,15 +5,15 @@ import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient, GatewayEventListener } from "../../api/gateway.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
+import type { DesktopClient, DesktopConnectionHandle } from "./desktop-client.ts";
 import "./desktop-panel.ts";
 
 type DesktopPanelElement = HTMLElement & {
   available: boolean;
   documentMode: boolean;
+  documentControl: boolean;
   client: GatewayBrowserClient | null;
-  desktopClientFactory: () => {
-    connect(options: { onConnect: () => void }): Promise<{ disconnect(): void }>;
-  };
+  desktopClientFactory: () => Pick<DesktopClient, "connect">;
   embedded: boolean;
   handleToggleRequest(event: Event): void;
   presented: boolean;
@@ -83,9 +83,9 @@ describe("embedded desktop panel presentation", () => {
       };
     });
     const disconnect = vi.fn();
-    const connect = vi.fn(async (options: { onConnect: () => void }) => {
-      options.onConnect();
-      return { disconnect };
+    const connect = vi.fn(async (options: Parameters<DesktopClient["connect"]>[0]) => {
+      options.onConnect?.();
+      return { disconnect, disableInput: vi.fn() };
     });
     const panel = createPanel();
     panel.client = { gatewayUrl: "ws://gateway.test", request } as unknown as GatewayBrowserClient;
@@ -153,9 +153,9 @@ describe("embedded desktop panel presentation", () => {
       };
     });
     const disconnect = vi.fn();
-    const connect = vi.fn(async (options: { onConnect: () => void }) => {
-      options.onConnect();
-      return { disconnect };
+    const connect = vi.fn(async (options: Parameters<DesktopClient["connect"]>[0]) => {
+      options.onConnect?.();
+      return { disconnect, disableInput: vi.fn() };
     });
     const panel = createPanel();
     panel.client = {
@@ -222,6 +222,198 @@ describe("embedded desktop panel presentation", () => {
     expect(unsubscribe).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    { initialControl: false, handleTiming: "before" },
+    { initialControl: false, handleTiming: "after" },
+    { initialControl: true, handleTiming: "before" },
+    { initialControl: true, handleTiming: "after" },
+  ] as const)(
+    "retains control=$initialControl until RFB connects with the handle $handleTiming the callback",
+    async ({ initialControl, handleTiming }) => {
+      const observe = createDeferred<unknown>();
+      const replacement = createDeferred<DesktopConnectionHandle>();
+      const previous = { disconnect: vi.fn(), disableInput: vi.fn(), sendKeyboardEvent: vi.fn() };
+      const next = { disconnect: vi.fn(), disableInput: vi.fn(), sendKeyboardEvent: vi.fn() };
+      let pending: Parameters<DesktopClient["connect"]>[0] | undefined;
+      const request = vi.fn(async (method: string, params?: { control?: boolean }) => {
+        if (method === "environments.list") {
+          return { environments: [desktopEnvironment] };
+        }
+        if (params?.control !== initialControl) {
+          return observe.promise;
+        }
+        return { transport: "rfb", wsPath: "/view", control: initialControl };
+      });
+      const connect = vi.fn(async (options: Parameters<DesktopClient["connect"]>[0]) => {
+        if (options.viewOnly !== !initialControl) {
+          pending = options;
+          return replacement.promise;
+        }
+        options.onConnect?.();
+        return previous;
+      });
+      const panel = createPanel();
+      panel.client = {
+        gatewayUrl: "ws://gateway.test",
+        request,
+      } as unknown as GatewayBrowserClient;
+      panel.available = true;
+      panel.documentMode = true;
+      panel.documentControl = initialControl;
+      panel.embedded = true;
+      panel.presented = true;
+      panel.requestedSource = desktopEnvironment.id;
+      panel.desktopClientFactory = () => ({ connect });
+      document.body.append(panel);
+      try {
+        await waitForFast(() => expect(connect).toHaveBeenCalledOnce());
+        await settleTasks();
+        const toggle = panel.renderRoot.querySelector<HTMLButtonElement>(
+          `button[aria-label="${initialControl ? "Switch to view only" : "Take control"}"]`,
+        );
+        if (!toggle) {
+          throw new Error("expected the desktop control toggle");
+        }
+        toggle.click();
+        await waitForFast(() =>
+          expect(
+            request.mock.calls.filter(([method]) => method === "desktop.observe"),
+          ).toHaveLength(2),
+        );
+        expect(previous.disconnect).not.toHaveBeenCalled();
+        expect(previous.disableInput).toHaveBeenCalledOnce();
+        observe.resolve({ transport: "rfb", wsPath: "/control", control: !initialControl });
+        await waitForFast(() => expect(connect).toHaveBeenCalledTimes(2));
+        if (handleTiming === "before") {
+          replacement.resolve(next);
+          await settleTasks();
+        }
+        expect(previous.disconnect).not.toHaveBeenCalled();
+        const input =
+          panel.renderRoot.querySelector<HTMLTextAreaElement>(".desktop-keyboard-input");
+        if (!input) {
+          throw new Error("expected the mobile keyboard input");
+        }
+        const sendKey = () =>
+          input.dispatchEvent(
+            new KeyboardEvent("keydown", { key: "x", code: "KeyX", bubbles: true }),
+          );
+        sendKey();
+        expect(previous.sendKeyboardEvent).not.toHaveBeenCalled();
+        expect(next.sendKeyboardEvent).not.toHaveBeenCalled();
+        if (!pending?.onConnect) {
+          throw new Error("replacement must expose the RFB connected callback");
+        }
+        pending.onConnect();
+        expect(previous.disconnect).toHaveBeenCalledOnce();
+        replacement.resolve(next);
+        await settleTasks();
+        expect(next.disconnect).not.toHaveBeenCalled();
+        sendKey();
+        expect(next.sendKeyboardEvent).toHaveBeenCalledTimes(initialControl ? 0 : 1);
+        expect(previous.sendKeyboardEvent).not.toHaveBeenCalled();
+        panel.remove();
+        expect(next.disconnect).toHaveBeenCalledOnce();
+      } finally {
+        observe.resolve({ transport: "rfb", wsPath: "/control", control: !initialControl });
+        replacement.resolve(next);
+        panel.remove();
+        await settleTasks();
+      }
+    },
+  );
+
+  it.each([
+    "observe failure",
+    "credentials",
+    "security failure",
+    "transport failure",
+    "hide",
+    "source change",
+    "unmount",
+  ] as const)("releases the retained viewer and pending replacement on %s", async (outcome) => {
+    const observe = createDeferred<unknown>();
+    const previous = { disconnect: vi.fn(), disableInput: vi.fn() };
+    const next = { disconnect: vi.fn(), disableInput: vi.fn() };
+    let pending: Parameters<DesktopClient["connect"]>[0] | undefined;
+    const request = vi.fn(async (method: string, params?: { control?: boolean }) => {
+      if (method === "environments.list") {
+        return { environments: [desktopEnvironment] };
+      }
+      return params?.control
+        ? observe.promise
+        : { transport: "rfb", wsPath: "/view", control: false };
+    });
+    const connect = vi.fn(async (options: Parameters<DesktopClient["connect"]>[0]) => {
+      if (!options.viewOnly) {
+        pending = options;
+        return next;
+      }
+      options.onConnect?.();
+      return previous;
+    });
+    const panel = createPanel();
+    panel.client = { gatewayUrl: "ws://gateway.test", request } as unknown as GatewayBrowserClient;
+    panel.available = true;
+    panel.embedded = true;
+    panel.presented = true;
+    panel.requestedSource = desktopEnvironment.id;
+    panel.desktopClientFactory = () => ({ connect });
+    document.body.append(panel);
+    try {
+      await waitForFast(() => expect(connect).toHaveBeenCalledOnce());
+      await settleTasks();
+      panel.renderRoot.querySelector<HTMLButtonElement>(".desktop-stage__take-control")?.click();
+      await waitForFast(() =>
+        expect(request.mock.calls.filter(([method]) => method === "desktop.observe")).toHaveLength(
+          2,
+        ),
+      );
+      expect(previous.disconnect).not.toHaveBeenCalled();
+      if (outcome === "observe failure" || outcome === "credentials") {
+        observe.reject(
+          outcome === "credentials"
+            ? { details: { code: "DESKTOP_CREDENTIALS_REQUIRED", auth: "vnc-password" } }
+            : new Error("observer capacity reached"),
+        );
+      } else {
+        observe.resolve({ transport: "rfb", wsPath: "/control", control: true });
+        await waitForFast(() => expect(connect).toHaveBeenCalledTimes(2));
+        await settleTasks();
+        expect(previous.disconnect).not.toHaveBeenCalled();
+        expect(pending?.isCurrent()).toBe(true);
+        if (outcome === "security failure") {
+          pending?.onSecurityFailure?.({ reason: "authentication rejected" });
+          pending?.onDisconnect?.({ code: 1008, reason: "authentication rejected" });
+        } else if (outcome === "transport failure") {
+          pending?.onDisconnect?.({ code: 1000, reason: "desktop stream closed" });
+        } else if (outcome === "hide") {
+          panel.presented = false;
+        } else if (outcome === "source change") {
+          panel.requestedSource = null;
+        } else {
+          panel.remove();
+        }
+      }
+      await settleTasks();
+      expect(previous.disconnect).toHaveBeenCalledOnce();
+      if (pending) {
+        expect(pending.isCurrent()).toBe(false);
+        expect(next.disconnect).toHaveBeenCalledOnce();
+        pending.onConnect?.();
+        await settleTasks();
+        expect(previous.disconnect).toHaveBeenCalledOnce();
+        expect(next.disconnect).toHaveBeenCalledOnce();
+      } else {
+        expect(next.disconnect).not.toHaveBeenCalled();
+      }
+    } finally {
+      observe.resolve({ transport: "rfb", wsPath: "/control", control: true });
+      panel.remove();
+      await settleTasks();
+    }
+  });
+
   it("keeps a hidden embedded mount dormant even when the standalone dock was open", async () => {
     localStorage.setItem(
       "openclaw.desktopPanel",
@@ -261,9 +453,9 @@ describe("embedded desktop panel presentation", () => {
       };
     });
     const disconnect = vi.fn();
-    const connect = vi.fn(async (options: { onConnect: () => void }) => {
-      options.onConnect();
-      return { disconnect };
+    const connect = vi.fn(async (options: Parameters<DesktopClient["connect"]>[0]) => {
+      options.onConnect?.();
+      return { disconnect, disableInput: vi.fn() };
     });
     const panel = createPanel();
     panel.client = { gatewayUrl: "ws://gateway.test", request } as unknown as GatewayBrowserClient;
@@ -312,7 +504,7 @@ describe("embedded desktop panel presentation", () => {
       }
       return observe;
     });
-    const connect = vi.fn(async () => ({ disconnect: vi.fn() }));
+    const connect = vi.fn(async () => ({ disconnect: vi.fn(), disableInput: vi.fn() }));
     const panel = createPanel();
     panel.client = { gatewayUrl: "ws://gateway.test", request } as unknown as GatewayBrowserClient;
     panel.available = true;

--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -16,16 +16,17 @@ import {
   DESKTOP_PANEL_TOGGLE_EVENT,
   type DesktopPanelToggleDetail,
 } from "../panel-toggle-contract.ts";
-import { DesktopClient, type DesktopConnectionHandle } from "./desktop-client.ts";
+import { DesktopClient } from "./desktop-client.ts";
 import { resolveDesktopDocumentInventoryTarget } from "./desktop-document-inventory.ts";
 import { renderDesktopDocumentView } from "./desktop-document-view.ts";
 import { openDesktopFocus } from "./desktop-focus-window.ts";
 import { DesktopMobileKeyboard } from "./desktop-mobile-keyboard.ts";
-import type {
-  DesktopAppId,
-  DesktopCredentials,
-  ObservedDesktopConnection,
-  PendingDesktopConnection,
+import {
+  DesktopConnectionHandoff,
+  type DesktopAppId,
+  type DesktopCredentials,
+  type ObservedDesktopConnection,
+  type PendingDesktopConnection,
 } from "./desktop-panel-connection.ts";
 import { desktopCredentialRequirement } from "./desktop-panel-credentials.ts";
 import { DesktopPanelFullscreenController } from "./desktop-panel-fullscreen-controller.ts";
@@ -77,7 +78,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
   @state() private desktopApps: DesktopAppId[] = [];
   @state() private scaleViewport = true;
 
-  private connection: DesktopConnectionHandle | null = null;
+  private readonly connection = new DesktopConnectionHandoff();
   private credentials: DesktopCredentials | undefined;
   private credentialAuth: "vnc-password" | "ard-account" | undefined;
   private pendingConnection: PendingDesktopConnection | null = null;
@@ -95,7 +96,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     },
   );
   private readonly mobileKeyboard = new DesktopMobileKeyboard({
-    connection: () => this.connection,
+    connection: () => this.connection.handle,
     controlling: () => this.controlling,
     input: () => this.shadowRoot?.querySelector<HTMLTextAreaElement>(".desktop-keyboard-input"),
   });
@@ -245,12 +246,10 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     this.disconnectedReason = null;
   }
 
-  private disconnectConnection(): void {
+  private disconnectConnection(retainViewer = false): void {
     this.operationId += 1;
     this.pendingConnection = null;
-    const connection = this.connection;
-    this.connection = null;
-    connection?.disconnect();
+    this.connection.begin(retainViewer);
     this.mobileKeyboard.reset();
   }
 
@@ -358,16 +357,11 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       this.credentials = undefined;
       this.credentialAuth = undefined;
     }
-    this.desktopApps = [
-      ...(this.environments.find((environment) => environment.id === environmentId)?.worker
-        ?.desktopApps ?? []),
-    ];
-    this.disconnectConnection();
+    const environment = this.environments.find((candidate) => candidate.id === environmentId);
+    this.desktopApps = [...(environment?.worker?.desktopApps ?? [])];
+    this.disconnectConnection(this.environmentId === environmentId);
     const operationId = this.operationId;
-    const environment = this.environments.find((candidate) => candidate.id === environmentId) ?? {
-      id: environmentId,
-    };
-    const source = desktopSourceForEnvironment(environment);
+    const source = desktopSourceForEnvironment(environment ?? { id: environmentId });
     this.environmentId = environmentId;
     this.source = source;
     this.controlling = control;
@@ -407,6 +401,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
         observed.preauthenticated !== true &&
         !credentials?.password
       ) {
+        this.connection.disconnect();
         this.credentialAuth = "vnc-password";
         this.pendingConnection = { environmentId, control, observed, operationId };
         this.state = "credentials";
@@ -422,6 +417,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     } catch (error) {
       const requiredAuth = desktopCredentialRequirement(error);
       if (requiredAuth && operationId === this.operationId) {
+        this.connection.disconnect();
         this.credentialAuth = requiredAuth;
         this.pendingConnection = { environmentId, control, operationId };
         this.state = "credentials";
@@ -453,6 +449,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       const background = getComputedStyle(target).backgroundColor;
       const connection = await desktopClient.connect({
         background,
+        isCurrent: () => pending.operationId === this.operationId,
         wsUrl: pending.observed.wsPath,
         gatewayUrl: client.gatewayUrl,
         credentials,
@@ -461,6 +458,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
         target,
         onConnect: () => {
           if (pending.operationId === this.operationId) {
+            this.connection.markConnected();
             this.state = "connected";
           }
         },
@@ -471,9 +469,9 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
         },
         onSecurityFailure: (detail) => {
           if (pending.operationId === this.operationId) {
-            this.errorText = t("desktop.errors.securityFailed", {
-              reason: formatUiExternalText(detail.reason, t("desktop.unknownReason")),
-            });
+            const reason = formatUiExternalText(detail.reason, t("desktop.unknownReason"));
+            this.errorText = t("desktop.errors.securityFailed", { reason });
+            this.failConnection(pending.operationId, new Error(reason));
           }
         },
       });
@@ -481,7 +479,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
         connection.disconnect();
         return;
       }
-      this.connection = connection;
+      this.connection.attach(connection);
     } catch (error) {
       this.failConnection(pending.operationId, error);
     }
@@ -491,6 +489,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     if (operationId !== this.operationId) {
       return;
     }
+    this.disconnectConnection();
     this.state = "disconnected";
     this.disconnectedReason = formatUiError(error);
     this.clearLaunchState();
@@ -528,7 +527,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
   }
 
   private handleDesktopDisconnect(environmentId: string, code?: number, reason?: string): void {
-    this.connection = null;
+    this.disconnectConnection();
     this.clearLaunchState();
     if (code === 1008 && this.credentialAuth === "ard-account") {
       this.credentials = this.credentials?.username
@@ -674,7 +673,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
         onKeyboardInput: (event) => this.mobileKeyboard.handleInput(event),
         onScaleToggle: () => {
           this.scaleViewport = !this.scaleViewport;
-          this.connection?.setScaleViewport?.(this.scaleViewport);
+          this.connection.handle?.setScaleViewport?.(this.scaleViewport);
         },
         onClose: () => this.onDocumentClose?.(),
       });

--- a/ui/src/e2e/desktop-document-mode.e2e.test.ts
+++ b/ui/src/e2e/desktop-document-mode.e2e.test.ts
@@ -42,6 +42,7 @@ async function installDesktopClientFake(panel: import("playwright").Locator) {
         desktopClientFactory: () => {
           connect(options: FakeDesktopConnectOptions): Promise<{
             disconnect(): void;
+            disableInput(): void;
             sendBackspace(): void;
             sendKeyboardEvent(event: KeyboardEvent): void;
             sendText(text: string): void;
@@ -61,6 +62,9 @@ async function installDesktopClientFake(panel: import("playwright").Locator) {
         options.target.replaceChildren(remote);
         options.onConnect?.();
         return {
+          disableInput() {
+            element.dataset.viewOnly = "true";
+          },
           disconnect() {
             remote.remove();
           },

--- a/ui/src/e2e/desktop-panel-fullscreen.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel-fullscreen.e2e.test.ts
@@ -249,7 +249,11 @@ suite.define(() => {
             .poll(async () => (await gateway.getRequests("desktop.observe")).length)
             .toBe(2);
           expect(await page.evaluate(() => document.fullscreenElement !== null)).toBe(true);
-          await panel.locator(".desktop-surface canvas").waitFor();
+          // The authenticated handoff keeps both canvases until the replacement connects.
+          await expect
+            .poll(() => screenHandle?.evaluate((element) => element.isConnected))
+            .toBe(false);
+          await screen.waitFor();
           await expect
             .poll(() => panel.getByRole("button", { name: "Take control", exact: true }).count())
             .toBe(0);

--- a/ui/src/e2e/desktop-panel.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel.e2e.test.ts
@@ -798,13 +798,14 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}activity`);
       // The production DesktopClient still owns noVNC; only the RFB endpoint
       // is scripted here so this CI test remains deterministic.
-      await installScriptedRfbServer(page);
+      const rfb = await installScriptedRfbServer(page, { disconnectAfterLastPeer: true });
 
       await openDirectDesktop(page, "worker-desktop-1");
       const panel = page.locator("openclaw-desktop-panel");
       await panel.locator("section[aria-label='Desktop']").waitFor();
       const canvas = panel.locator(".desktop-surface canvas");
       await canvas.waitFor();
+      await expect.poll(rfb.events).toEqual(["authenticated:1"]);
       const canvasHandle = await canvas.elementHandle();
       await panel.getByRole("button", { name: "Enter fullscreen", exact: true }).click();
       await expect.poll(() => page.evaluate(() => document.fullscreenElement !== null)).toBe(true);
@@ -824,7 +825,9 @@ suite.define(() => {
         source: { kind: "environment", environmentId: "worker-desktop-1" },
         control: true,
       });
-      await panel.locator(".desktop-surface canvas").waitFor();
+      await expect.poll(rfb.events).toEqual(["authenticated:1", "authenticated:2", "closed:1"]);
+      await expect.poll(() => panel.locator(".desktop-surface canvas").count()).toBe(1);
+      expect(await panel.getByRole("status", { name: "Connecting to desktop…" }).count()).toBe(0);
       expect(await takeControl.count()).toBe(0);
       expect(await page.evaluate(() => document.fullscreenElement !== null)).toBe(true);
       await panel.getByRole("button", { name: "Exit fullscreen", exact: true }).click();

--- a/ui/src/e2e/desktop-rfb-test-support.ts
+++ b/ui/src/e2e/desktop-rfb-test-support.ts
@@ -8,6 +8,7 @@ export async function installDesktopClientFake(panel: Locator): Promise<void> {
         desktopClientFactory: () => {
           connect(options: { credentials?: { username?: string; password?: string } }): Promise<{
             disconnect(): void;
+            disableInput(): void;
           }>;
         };
       }
@@ -16,6 +17,7 @@ export async function installDesktopClientFake(panel: Locator): Promise<void> {
         element.dataset.connectCount = String(Number(element.dataset.connectCount ?? "0") + 1);
         element.dataset.usedCredentials = options.credentials?.password ? "true" : "false";
         return {
+          disableInput() {},
           disconnect() {
             element.dataset.disconnectCount = String(
               Number(element.dataset.disconnectCount ?? "0") + 1,
@@ -28,10 +30,16 @@ export async function installDesktopClientFake(panel: Locator): Promise<void> {
 }
 
 /** Install the scripted RFB 3.8 endpoint used by Desktop's canonical noVNC E2E. */
-export async function installScriptedRfbServer(page: Page): Promise<void> {
-  await page.evaluate(() => {
+export async function installScriptedRfbServer(
+  page: Page,
+  options: { disconnectAfterLastPeer?: boolean } = {},
+) {
+  await page.evaluate(({ disconnectAfterLastPeer }) => {
     const GatewaySocket = window.WebSocket;
     const sockets = new Set<FakeRfbSocket>();
+    const events: string[] = [];
+    let nextId = 0;
+    let desktopTeardown = false;
     class FakeRfbSocket extends EventTarget {
       binaryType = "arraybuffer";
       protocol = "";
@@ -41,8 +49,12 @@ export async function installScriptedRfbServer(page: Page): Promise<void> {
       onopen: ((event: Event) => void) | null = null;
       onclose: ((event: CloseEvent) => void) | null = null;
       private handshake = 0;
+      private readonly id: number;
+      authenticated = false;
       constructor() {
         super();
+        nextId += 1;
+        this.id = nextId;
         sockets.add(this);
         setTimeout(() => {
           if (this.readyState !== 0) {
@@ -69,6 +81,12 @@ export async function installScriptedRfbServer(page: Page): Promise<void> {
         } else if (this.handshake === 2) {
           this.deliver(new Uint8Array([0, 0, 0, 0]));
         } else if (this.handshake === 3) {
+          if (desktopTeardown) {
+            this.close(1000, "desktop stream closed");
+            return;
+          }
+          this.authenticated = true;
+          events.push(`authenticated:${this.id}`);
           const name = new TextEncoder().encode("scripted-desktop");
           const init = new Uint8Array(24 + name.length);
           const view = new DataView(init.buffer);
@@ -90,6 +108,15 @@ export async function installScriptedRfbServer(page: Page): Promise<void> {
         }
         this.readyState = 3;
         sockets.delete(this);
+        events.push(`closed:${this.id}`);
+        if (
+          disconnectAfterLastPeer &&
+          this.authenticated &&
+          ![...sockets].some((socket) => socket.authenticated)
+        ) {
+          // Model an old native desktop teardown crossing the replacement handshake.
+          desktopTeardown = true;
+        }
         const event = new CloseEvent("close", { code, reason });
         this.onclose?.(event);
         this.dispatchEvent(new CloseEvent("close", { code, reason }));
@@ -115,5 +142,16 @@ export async function installScriptedRfbServer(page: Page): Promise<void> {
         socket.close(1006, reason);
       }
     };
-  });
+    (window as typeof window & { desktopRfbEvents?: () => string[] }).desktopRfbEvents = () => [
+      ...events,
+    ];
+  }, options);
+  return {
+    events: () =>
+      page.evaluate(
+        () =>
+          (window as typeof window & { desktopRfbEvents?: () => string[] }).desktopRfbEvents?.() ??
+          [],
+      ),
+  };
 }


### PR DESCRIPTION
Switching a Windows desktop from view-only to control could close the only authenticated VNC viewer before its replacement authenticated. On the real TightVNC 2.8.85 host this disconnected the replacement twice; retaining a second authenticated viewer made the same transition succeed.

The existing desktop connection owner now retains at most one same-source viewer, disables its input immediately, and retires it when noVNC reports an authenticated connection. Observe RPC completion and a returned client handle are not that boundary. Failure, credential prompting, source changes, hidden panels and unmount release both connections. A canceled lazy noVNC load also checks the existing operation identity before opening a control WebSocket.

This replaces the nullable-handle lifecycle; Gateway authentication, controller arbitration, observer caps and view-only filtering are unchanged. There are no new dependencies, configuration, timeouts, retries or compatibility paths. Production delta is +79/-27 (net +52): bounded overlapping connection ownership and explicit input/readiness transfer require state that the old single-handle owner could not express. Duplicate environment lookup was removed. Desktop tests/support are +304/-19; the Code Mode CI fixture follow-up is +5/-6. Release-note context stays here; the release-owned root changelog has no PR delta.

Validation:

- Captured pre-fix failures in real noVNC E2E, panel lifecycle tests and canceled lazy-load coverage; all pass with the fix. The E2E asserts authenticated old → authenticated replacement → old closed.
- 22 unit tests, 35 Desktop browser tests, UI production/test types, scoped lint, keyless i18n verification and canonical UI build passed. Managed Codex P0 review found no actionable findings.
- Live Windows Server 2022/TightVNC 2.8.85: sole-viewer Take control passed, both directions passed in the focus view, six additional alternating transitions passed, and leaving during handoff followed by a fresh control connection passed. Keyboard input after handoff reached Notepad.
- Native TightVNC had exactly one established viewer after handoffs and zero after the sole viewer closed. Switching to view-only blocked a subsequent keypress, so retaining the predecessor did not retain input or leak a viewer.
- A real OpenClaw worker turn placed on the same Windows device executed Node in its remote workspace, wrote a marker reconciled through the normal workspace owner, and called computer screenshot. The retrieved image independently showed the text entered through WebVNC. The turn completed; the separate Windows worker cleanup defect is repaired and live-verified in #134911, not changed by this UI PR.
- Live Gateway/node package is d1111d9eb5d4 plus this exact UI candidate. Served entry and desktop chunk hashes were verified. The eight desktop files remain byte-identical to the tested candidate after integration onto main 0449cd137717. Exact PR CI is additional integration evidence.

The TightVNC source supports a last-client teardown race: it clears/deletes the old desktop while a replacement can be authenticating, and an old IPC close can disconnect clients. The internal callback race was not instrumented; the live failure/control comparison and real-noVNC ordering regression are the direct repair evidence. macOS ARD authentication remains Gateway-owned; this is not a claim of live macOS GUI proof.

Before (sole-viewer Take control):

![Windows desktop disconnected during control handoff](https://github.com/user-attachments/assets/a402b2d9-0d9a-4e46-9e3b-ce608c65c1b8)

After (same panel remains connected):

![Windows desktop connected after control handoff](https://github.com/user-attachments/assets/cfe90b9d-85a3-4391-96cf-0a301f365d74)

CI follow-up and integration:

- The first CI run exposed an existing release-plan inventory overflow: the full Git tree exceeded Node’s default 1 MiB output buffer. Main already landed the canonical metadata-only enumeration repair in #134824; this PR integrates that main revision rather than carrying a second fix. Its large-tree, four symlink, and current publisher-inventory regressions passed (6 tests).
- An existing Code Mode lifecycle fixture assumed one wait must be terminal despite the runtime’s per-call budget. It now uses the existing bounded helper to resume the same run; the two executions, exactly-once lifecycle and cleanup assertions are unchanged. No runtime budget, timeout, action replay or production behavior changed. Fresh managed Codex P0 review and canonical changed-file checks passed.
- Both complete agent files passed (30 tests), including the unchanged acquired/borrowed/empty transport table. The prior acquired-transport timeout in the 85-file CI shard remains unexplained; the focused pass does not replace that original evidence. The prior integration run is [33480747319](https://github.com/openclaw/openclaw/actions/runs/33480747319); its fullscreen handoff timing failure is repaired below.

- The integrated CI run exposed one additional fullscreen test race: it queried a strict single canvas after the observation RPC acknowledged, while the intended authenticated handoff still held both canvases. The existing test now waits for retirement of the original canvas (owned by replacement noVNC connect) before its single visible-canvas assertion. Fullscreen identity, geometry and control assertions remain. All three complete Desktop E2E files passed again (35 tests), and canonical changed-file checks passed. Production bytes are unchanged.

Fresh managed Codex review of the complete candidate found no actionable findings. The final test repair is commit `e5af1515ecb4782403b95ac9cfc5d105c3303c5b`; GitHub branch state confirms it is pushed. Exact-head PR checks remain required before native landing.
