### PR TITLE
refactor(migrate-hermes): share env reference normalization

### DIFF
--- a/extensions/migrate-hermes/config-env.ts
+++ b/extensions/migrate-hermes/config-env.ts
@@ -3,7 +3,7 @@ import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 export const MCP_ENV_REFERENCE_RE = /\$\{([^}]+)\}/gu;
 
-function normalizeHermesEnvReferenceName(value: string): string | undefined {
+export function normalizeHermesEnvReferenceName(value: string): string | undefined {
   const trimmed = value.trim();
   const name = trimmed.startsWith("env:") ? trimmed.slice("env:".length).trim() : trimmed;
   return name || undefined;

--- a/extensions/migrate-hermes/config-provider-contract.ts
+++ b/extensions/migrate-hermes/config-provider-contract.ts
@@ -4,6 +4,7 @@ import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-co
 import {
   MCP_ENV_REFERENCE_RE,
   mcpValueHasEnvReferences,
+  normalizeHermesEnvReferenceName,
   resolveMcpEnvReferences,
 } from "./config-env.js";
 import { childRecord } from "./helpers.js";
@@ -262,12 +263,6 @@ export function readEnvReference(value: unknown): string | undefined {
   const raw = normalizeOptionalString(value);
   const match = raw?.match(/^\$\{([^}]+)\}$/u);
   return match ? normalizeHermesEnvReferenceName(match[1] ?? "") : undefined;
-}
-
-function normalizeHermesEnvReferenceName(value: string): string | undefined {
-  const trimmed = value.trim();
-  const name = trimmed.startsWith("env:") ? trimmed.slice("env:".length).trim() : trimmed;
-  return name || undefined;
 }
 
 export function readProviderApiKeyEnv(raw: Record<string, unknown>): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

Hermes provider and MCP migration paths maintained identical environment-reference normalization logic in two places, allowing behavior to drift inside one plugin.

## Why This Change Was Made

The MCP config module now owns the existing normalization helper, and the provider contract imports it through its existing private dependency edge. This removes the duplicate without adding an SDK surface, compatibility path, or behavior change.

## User Impact

No user-visible behavior changes. Hermes environment references continue to normalize identically while the plugin has one canonical implementation.

## Evidence

- `node scripts/run-vitest.mjs extensions/migrate-hermes/config.test.ts` - 27 passed
- `pnpm test:extension migrate-hermes` - 137 passed
- `pnpm check:import-cycles` - 0 runtime value cycles
- `pnpm check:changed` - passed
- Sol/high autoreview - scoped clean, 0.99 confidence
- Production LOC: +2/-7, net -5
- Tests: +0/-0
