### PR TITLE
refactor(cli): consolidate hook requirement reports

### DIFF
--- a/src/cli/hooks-cli.format.ts
+++ b/src/cli/hooks-cli.format.ts
@@ -1,6 +1,4 @@
 // Renders the `openclaw hooks` list, info, and check reports.
-// Kept apart from command wiring so each surface stays readable and under the file-size cap.
-
 import {
   decorativeEmoji,
   decorativePrefix,
@@ -67,36 +65,32 @@ function formatHookSource(hook: HookStatusEntry): string {
   return `plugin:${hook.pluginId ?? "unknown"}`;
 }
 
-export function formatHookMissingSummary(hook: HookStatusEntry, itemLimit?: number): string {
+const HOOK_REQUIREMENT_GROUPS = [
+  ["bins", "Binaries"],
+  ["anyBins", "Any binary"],
+  ["env", "Environment"],
+  ["config", "Config"],
+  ["os", "OS"],
+] as const;
+
+function formatHookMissingRequirements(hook: HookStatusEntry, itemLimit?: number): string[] {
   const formatEntries = (entries: string[]) =>
     itemLimit === undefined
       ? entries.join(", ")
       : summarizeStringEntries({ entries, limit: itemLimit });
-  const missing: string[] = [];
+  return HOOK_REQUIREMENT_GROUPS.filter(([key]) => hook.missing[key].length > 0).map(
+    ([key]) => `${key}: ${formatEntries(hook.missing[key])}`,
+  );
+}
+
+export function formatHookMissingSummary(hook: HookStatusEntry, itemLimit?: number): string {
+  const missing = formatHookMissingRequirements(hook, itemLimit);
   if (hook.enabledByConfig && hook.blockedReason && hook.blockedReason !== "missing requirements") {
-    missing.push(hook.blockedReason);
-  }
-  if (hook.missing.bins.length > 0) {
-    missing.push(`bins: ${formatEntries(hook.missing.bins)}`);
-  }
-  if (hook.missing.anyBins.length > 0) {
-    missing.push(`anyBins: ${formatEntries(hook.missing.anyBins)}`);
-  }
-  if (hook.missing.env.length > 0) {
-    missing.push(`env: ${formatEntries(hook.missing.env)}`);
-  }
-  if (hook.missing.config.length > 0) {
-    missing.push(`config: ${formatEntries(hook.missing.config)}`);
-  }
-  if (hook.missing.os.length > 0) {
-    missing.push(`os: ${formatEntries(hook.missing.os)}`);
+    missing.unshift(hook.blockedReason);
   }
   return missing.join("; ");
 }
 
-/**
- * Format the hooks list output
- */
 export function formatHooksList(report: HookStatusReport, opts: HooksListOptions): string {
   const hooks = opts.eligible ? report.hooks.filter((h) => h.loadable) : report.hooks;
 
@@ -170,9 +164,6 @@ export function formatHooksList(report: HookStatusReport, opts: HooksListOptions
   return lines.join("\n");
 }
 
-/**
- * Format detailed info for a single hook
- */
 export function formatHookInfo(
   hook: HookStatusEntry | undefined,
   hookName: string,
@@ -211,7 +202,6 @@ export function formatHookInfo(
   lines.push(hook.description);
   lines.push("");
 
-  // Details
   lines.push(theme.heading("Details:"));
   if (hook.managedByPlugin) {
     lines.push(`${theme.muted("  Source:")} ${hook.source} (${hook.pluginId ?? "unknown"})`);
@@ -240,63 +230,42 @@ export function formatHookInfo(
     lines.push(`${theme.muted("  Blocked reason:")} ${hook.blockedReason}`);
   }
 
-  // Requirements
-  const hasRequirements =
-    hook.requirements.bins.length > 0 ||
-    hook.requirements.anyBins.length > 0 ||
-    hook.requirements.env.length > 0 ||
-    hook.requirements.config.length > 0 ||
-    hook.requirements.os.length > 0;
+  const requirementGroups = HOOK_REQUIREMENT_GROUPS.filter(
+    ([key]) => hook.requirements[key].length > 0,
+  );
 
-  if (hasRequirements) {
+  if (requirementGroups.length > 0) {
     lines.push("");
     lines.push(theme.heading("Requirements:"));
-    if (hook.requirements.bins.length > 0) {
-      const binsStatus = hook.requirements.bins.map((bin) => {
-        const missing = hook.missing.bins.includes(bin);
-        return missing ? theme.error(`✗ ${bin}`) : theme.success(`✓ ${bin}`);
-      });
-      lines.push(`${theme.muted("  Binaries:")} ${binsStatus.join(", ")}`);
-    }
-    if (hook.requirements.anyBins.length > 0) {
-      const anyBinsStatus =
-        hook.missing.anyBins.length > 0
-          ? theme.error(`✗ (any of: ${hook.requirements.anyBins.join(", ")})`)
-          : theme.success(`✓ (any of: ${hook.requirements.anyBins.join(", ")})`);
-      lines.push(`${theme.muted("  Any binary:")} ${anyBinsStatus}`);
-    }
-    if (hook.requirements.env.length > 0) {
-      const envStatus = hook.requirements.env.map((env) => {
-        const missing = hook.missing.env.includes(env);
-        return missing ? theme.error(`✗ ${env}`) : theme.success(`✓ ${env}`);
-      });
-      lines.push(`${theme.muted("  Environment:")} ${envStatus.join(", ")}`);
-    }
-    if (hook.requirements.config.length > 0) {
-      const configStatus = hook.configChecks.map((check) => {
-        return check.satisfied ? theme.success(`✓ ${check.path}`) : theme.error(`✗ ${check.path}`);
-      });
-      lines.push(`${theme.muted("  Config:")} ${configStatus.join(", ")}`);
-    }
-    if (hook.requirements.os.length > 0) {
-      const osStatus =
-        hook.missing.os.length > 0
-          ? theme.error(`✗ (${hook.requirements.os.join(", ")})`)
-          : theme.success(`✓ (${hook.requirements.os.join(", ")})`);
-      lines.push(`${theme.muted("  OS:")} ${osStatus}`);
+    const formatStatus = (value: string, satisfied: boolean) =>
+      satisfied ? theme.success(`✓ ${value}`) : theme.error(`✗ ${value}`);
+    for (const [key, label] of requirementGroups) {
+      const required = hook.requirements[key];
+      const missing = hook.missing[key];
+      let requirementStatus: string;
+      if (key === "anyBins" || key === "os") {
+        const prefix = key === "anyBins" ? "any of: " : "";
+        requirementStatus = formatStatus(`(${prefix}${required.join(", ")})`, missing.length === 0);
+      } else if (key === "config") {
+        requirementStatus = hook.configChecks
+          .map((check) => formatStatus(check.path, check.satisfied))
+          .join(", ");
+      } else {
+        requirementStatus = required
+          .map((value) => formatStatus(value, !missing.includes(value)))
+          .join(", ");
+      }
+      lines.push(`${theme.muted(`  ${label}:`)} ${requirementStatus}`);
     }
   }
 
   return lines.join("\n");
 }
 
-/**
- * Format check output
- */
 export function formatHooksCheck(report: HookStatusReport, opts: HooksCheckOptions): string {
+  const eligible = report.hooks.filter((h) => h.loadable);
+  const notEligible = report.hooks.filter((h) => !h.loadable);
   if (opts.json) {
-    const eligible = report.hooks.filter((h) => h.loadable);
-    const notEligible = report.hooks.filter((h) => !h.loadable);
     return JSON.stringify(
       {
         total: report.hooks.length,
@@ -316,9 +285,6 @@ export function formatHooksCheck(report: HookStatusReport, opts: HooksCheckOptio
     );
   }
 
-  const eligible = report.hooks.filter((h) => h.loadable);
-  const notEligible = report.hooks.filter((h) => !h.loadable);
-
   const lines: string[] = [];
   lines.push(theme.heading("Hooks Status"));
   lines.push("");
@@ -330,24 +296,9 @@ export function formatHooksCheck(report: HookStatusReport, opts: HooksCheckOptio
     lines.push("");
     lines.push(theme.heading("Hooks not ready:"));
     for (const hook of notEligible) {
-      const reasons = [];
+      const reasons = formatHookMissingRequirements(hook);
       if (hook.blockedReason && hook.blockedReason !== "missing requirements") {
-        reasons.push(hook.blockedReason);
-      }
-      if (hook.missing.bins.length > 0) {
-        reasons.push(`bins: ${hook.missing.bins.join(", ")}`);
-      }
-      if (hook.missing.anyBins.length > 0) {
-        reasons.push(`anyBins: ${hook.missing.anyBins.join(", ")}`);
-      }
-      if (hook.missing.env.length > 0) {
-        reasons.push(`env: ${hook.missing.env.join(", ")}`);
-      }
-      if (hook.missing.config.length > 0) {
-        reasons.push(`config: ${hook.missing.config.join(", ")}`);
-      }
-      if (hook.missing.os.length > 0) {
-        reasons.push(`os: ${hook.missing.os.join(", ")}`);
+        reasons.unshift(hook.blockedReason);
       }
       const emoji = hook.emoji ?? decorativeEmoji("🔗");
       lines.push(`  ${emoji ? `${emoji} ` : ""}${hook.name} - ${reasons.join("; ")}`);


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of the `openclaw hooks` reports. List, check, and info maintained repeated requirement-group branches, making the same reporting policy harder to keep consistent.

## Why This Change Was Made

One ordered requirement-group definition now drives missing-requirement summaries and detailed status rendering. The formatter retains the existing differences between list and check policy reasons, aggregate binary/OS requirements, and config checks. This follows the existing skills-report pattern without introducing a shared public API.

## User Impact

Text, ANSI styling, JSON fields, ordering, and bounded enable-error hints remain identical.

## Evidence

- Production: +44/-93 lines, net **49 lines deleted**; tests and generated files unchanged.
- Existing hook CLI and hook-status suites: **154 tests passed before and after** (`node scripts/run-vitest.mjs src/cli/hooks-cli.test.ts src/cli/hooks-cli.toggle.test.ts src/hooks/hooks-status.test.ts`).
- A temporary differential corpus compared **14,080 byte-identical outputs** across requirement-group masks, missing states, enablement, blocked reasons, text/JSON reports, emoji presence, and summary limits, with ANSI colors enabled.
- Independent Codex autoreview through P2: no actionable findings. Diff-scoped deslop completed.
- All selected changed-file checks passed, including architecture guards, core and core-test types, dead-export scans, type-aware lint, and formatting. A shadowed local variable was corrected; the output corpus passed again on final source.
- Initial hosted CI exposed current-main release inventory `ENOBUFS`. That cause is fixed on main by #134824. This branch now includes that main baseline; the duplicate incidental repair was removed. The reviewed formatter bytes remain unchanged after rebase. A fresh exact-head hosted run is required before landing, addressing ClawSweeper's Rank-up move.

Hook discovery, policy, configuration, and command execution retain their existing owners.

Hosted CI run 33478544531, attempt 2 is now green on ffeb0a4d819780acbc95213fa0b462230ca2063f. The initial unrelated MCP descendant-test failure was investigated before one unchanged-head diagnostic retry. A separately reproduced inherited-stdout cleanup leak remains follow-up work; this PR changes no transport code. The latest ClawSweeper review has no functional finding, and its CI-completion rank-up move is satisfied.
