### PR TITLE
refactor(terminal): consolidate table style metadata

### DIFF
--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -78,129 +78,43 @@ const C1_ST = "\u009c";
 const BEL = "\u0007";
 
 type AnsiToken = { kind: "ansi"; value: string; width: number } | { kind: "char"; value: string };
-type SgrCategory =
-  | "background"
-  | "blink"
-  | "conceal"
-  | "font"
-  | "foreground"
-  | "frame"
-  | "ideogram"
-  | "intensity"
-  | "inverse"
-  | "italic"
-  | "overline"
-  | "proportional"
-  | "script"
-  | "strike"
-  | "underline"
-  | "underlineColor";
 
-const SGR_CATEGORY_ORDER: readonly SgrCategory[] = [
-  "font",
-  "intensity",
-  "italic",
-  "underline",
-  "underlineColor",
-  "blink",
-  "inverse",
-  "conceal",
-  "strike",
-  "proportional",
-  "frame",
-  "overline",
-  "ideogram",
-  "script",
-  "foreground",
-  "background",
-];
+// Keep this order when closing and reopening styles at cell wrap boundaries.
+const SGR_CATEGORIES = [
+  { category: "font", reset: 10, codes: [11, 12, 13, 14, 15, 16, 17, 18, 19] },
+  { category: "intensity", reset: 22, codes: [1, 2] },
+  { category: "italic", reset: 23, codes: [3, 20] },
+  { category: "underline", reset: 24, codes: [4, 21] },
+  { category: "underlineColor", reset: 59, codes: [] },
+  { category: "blink", reset: 25, codes: [5, 6] },
+  { category: "inverse", reset: 27, codes: [7] },
+  { category: "conceal", reset: 28, codes: [8] },
+  { category: "strike", reset: 29, codes: [9] },
+  { category: "proportional", reset: 50, codes: [26] },
+  { category: "frame", reset: 54, codes: [51, 52] },
+  { category: "overline", reset: 55, codes: [53] },
+  { category: "ideogram", reset: 65, codes: [60, 61, 62, 63, 64] },
+  { category: "script", reset: 75, codes: [73, 74] },
+  {
+    category: "foreground",
+    reset: 39,
+    codes: [30, 31, 32, 33, 34, 35, 36, 37, 90, 91, 92, 93, 94, 95, 96, 97],
+  },
+  {
+    category: "background",
+    reset: 49,
+    codes: [40, 41, 42, 43, 44, 45, 46, 47, 100, 101, 102, 103, 104, 105, 106, 107],
+  },
+] as const;
 
-const SGR_RESET_CATEGORIES = new Map<number, SgrCategory>([
-  [10, "font"],
-  [22, "intensity"],
-  [23, "italic"],
-  [24, "underline"],
-  [25, "blink"],
-  [27, "inverse"],
-  [28, "conceal"],
-  [29, "strike"],
-  [39, "foreground"],
-  [49, "background"],
-  [50, "proportional"],
-  [54, "frame"],
-  [55, "overline"],
-  [59, "underlineColor"],
-  [65, "ideogram"],
-  [75, "script"],
-]);
+type SgrCategory = (typeof SGR_CATEGORIES)[number]["category"];
 
-const SGR_CATEGORY_RESETS = new Map<SgrCategory, number>([
-  ["font", 10],
-  ["intensity", 22],
-  ["italic", 23],
-  ["underline", 24],
-  ["blink", 25],
-  ["inverse", 27],
-  ["conceal", 28],
-  ["strike", 29],
-  ["foreground", 39],
-  ["background", 49],
-  ["proportional", 50],
-  ["frame", 54],
-  ["overline", 55],
-  ["underlineColor", 59],
-  ["ideogram", 65],
-  ["script", 75],
-]);
-
-function simpleSgrCategory(param: number): SgrCategory | undefined {
-  if (param === 1 || param === 2) {
-    return "intensity";
-  }
-  if (param >= 11 && param <= 19) {
-    return "font";
-  }
-  if (param === 3 || param === 20) {
-    return "italic";
-  }
-  if (param === 4 || param === 21) {
-    return "underline";
-  }
-  if (param === 5 || param === 6) {
-    return "blink";
-  }
-  if (param === 7) {
-    return "inverse";
-  }
-  if (param === 8) {
-    return "conceal";
-  }
-  if (param === 9) {
-    return "strike";
-  }
-  if (param === 26) {
-    return "proportional";
-  }
-  if ((param >= 30 && param <= 37) || (param >= 90 && param <= 97)) {
-    return "foreground";
-  }
-  if ((param >= 40 && param <= 47) || (param >= 100 && param <= 107)) {
-    return "background";
-  }
-  if (param === 51 || param === 52) {
-    return "frame";
-  }
-  if (param === 53) {
-    return "overline";
-  }
-  if (param >= 60 && param <= 64) {
-    return "ideogram";
-  }
-  if (param === 73 || param === 74) {
-    return "script";
-  }
-  return undefined;
-}
+const SGR_RESET_CATEGORIES = new Map<number, SgrCategory>(
+  SGR_CATEGORIES.map(({ category, reset }) => [reset, category]),
+);
+const SGR_SIMPLE_CATEGORIES = new Map<number, SgrCategory>(
+  SGR_CATEGORIES.flatMap(({ category, codes }) => codes.map((code) => [code, category] as const)),
+);
 
 function extendedSgrCategory(param: number): SgrCategory | undefined {
   if (param === 38) {
@@ -251,7 +165,7 @@ function applySgrSequence(active: Map<SgrCategory, string>, value: string): void
     const field = fields[index] ?? "";
     if (field.includes(":")) {
       const param = Number(field.slice(0, field.indexOf(":")));
-      const category = extendedSgrCategory(param) ?? simpleSgrCategory(param);
+      const category = extendedSgrCategory(param) ?? SGR_SIMPLE_CATEGORIES.get(param);
       if (category) {
         active.set(category, sgrSequence(sequence.introducer, field));
       }
@@ -286,7 +200,7 @@ function applySgrSequence(active: Map<SgrCategory, string>, value: string): void
       continue;
     }
 
-    const category = simpleSgrCategory(param);
+    const category = SGR_SIMPLE_CATEGORIES.get(param);
     if (category) {
       active.set(category, sgrSequence(sequence.introducer, String(param)));
     }
@@ -302,13 +216,10 @@ function activeSgrAfter(tokens: readonly AnsiToken[]): ActiveSgr[] {
       applySgrSequence(active, token.value);
     }
   }
-  return SGR_CATEGORY_ORDER.flatMap((category) => {
+  return SGR_CATEGORIES.flatMap(({ category, reset }) => {
     const open = active.get(category);
     const parsed = open ? parseSgrSequence(open) : undefined;
-    const reset = SGR_CATEGORY_RESETS.get(category);
-    return open && parsed && reset !== undefined
-      ? [{ close: sgrSequence(parsed.introducer, String(reset)), open }]
-      : [];
+    return open && parsed ? [{ close: sgrSequence(parsed.introducer, String(reset)), open }] : [];
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of terminal table styling. The same 16 style categories were represented separately in a type union, ordering list, two reset maps, and activation-code branches.

## Why This Change Was Made

One ordered category definition now owns simple activation codes, resets, and wrap-boundary ordering. The existing parser still owns extended color operands, ANSI introducers, and colon forms; wrapping and hyperlink handling retain their existing paths.

## User Impact

No functionality or terminal output changes. Wrapped cells retain the same style resets and continuation sequences.

## Evidence

- Production: +41/-130, net **89 lines deleted**. Tests, generated files and public exports unchanged; no moves counted.
- All **67 existing terminal table tests passed before and after** via `node scripts/run-vitest.mjs packages/terminal-core/src/table.test.ts`.
- **3,516 real table renders matched byte-for-byte**, covering codes 0–127, simple/colon forms, selective/full resets, extended RGB/indexed/incomplete operands, ESC/C1 introducers, Unicode, CRLF, OSC links, widths and border modes. Both corpora contain 1,589,709 bytes with SHA-256 `6da743a1554d96fb05facb9d92506ece3bd8dcf44e842fdc5ec92d2608fb7df0`.
- Core and core-test types, changed-file lint/format, all three dead-export scans and repository architecture guards passed. The runtime-sidecar guard initially needed worktree-local dependencies; a frozen install resolved that setup issue, and the remaining guards passed.
- Diff-scoped deslop completed. Fresh independent Codex autoreview through P2 is clean.

The change is internal to the table renderer. Its callers, public options, parsing grammar and output contracts remain unchanged.

The initial CI failure was the main-branch release inventory buffer limit, fixed by #134824. After rebasing without changing the renderer bytes, exact-head CI [33478627844](https://github.com/openclaw/openclaw/actions/runs/33478627844) passed, including `openclaw/ci-gate`. A fresh independent P2 review on the rebased head also found no actionable issue. This resolves the latest ClawSweeper CI concern.
