### PR TITLE
test(foundry): coordinate concurrent refreshes without sleeps

### DIFF
--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -2,6 +2,7 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ProviderAuthMethod } from "openclaw/plugin-sdk/core";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { azLoginDeviceCodeWithOptions, execAz, getAccessTokenResultAsync } from "./cli.js";
@@ -247,12 +248,14 @@ function buildFoundryRuntimeAuthContext(
   };
 }
 
-function mockAzureCliToken(params: { accessToken: string; expiresInMs: number; delayMs?: number }) {
+function mockAzureCliToken(params: {
+  accessToken: string;
+  expiresInMs: number;
+  response?: Promise<void>;
+}) {
   execFileMock.mockImplementationOnce(async () => {
-    if (params.delayMs) {
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, params.delayMs);
-      });
+    if (params.response) {
+      await params.response;
     }
     return {
       stdout: JSON.stringify({
@@ -268,12 +271,10 @@ function mockAzureCliTokenRaw(stdout: string) {
   execFileMock.mockResolvedValueOnce({ stdout, stderr: "" });
 }
 
-function mockAzureCliLoginFailure(delayMs?: number) {
+function mockAzureCliLoginFailure(response?: Promise<void>) {
   execFileMock.mockImplementationOnce(async () => {
-    if (delayMs) {
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, delayMs);
-      });
+    if (response) {
+      await response;
     }
     throw Object.assign(new Error("az failed"), { stderr: defaultAzureCliLoginError, stdout: "" });
   });
@@ -611,44 +612,69 @@ describe("microsoft-foundry plugin", () => {
   it("dedupes concurrent Entra token refreshes for the same profile", async () => {
     const provider = registerProvider();
     const prepareRuntimeAuth = requirePrepareRuntimeAuth(provider);
-    mockAzureCliToken({ accessToken: "deduped-token", expiresInMs: 60_000, delayMs: 10 });
+    const tokenResponse = createDeferred<void>();
+    mockAzureCliToken({
+      accessToken: "deduped-token",
+      expiresInMs: 60_000,
+      response: tokenResponse.promise,
+    });
     ensureAuthProfileStoreMock.mockReturnValue(buildEntraProfileStore());
 
     const runtimeContext = buildFoundryRuntimeAuthContext();
+    const pending = [prepareRuntimeAuth(runtimeContext), prepareRuntimeAuth(runtimeContext)];
+    const settled = Promise.allSettled(pending);
+    try {
+      expect(execFileMock).toHaveBeenCalledTimes(1);
+      tokenResponse.resolve();
+      const [first, second] = await Promise.all(pending);
 
-    const [first, second] = await Promise.all([
-      prepareRuntimeAuth(runtimeContext),
-      prepareRuntimeAuth(runtimeContext),
-    ]);
-
-    expect(execFileMock).toHaveBeenCalledTimes(1);
-    expect(requireRuntimeAuthResult(first).apiKey).toBe("deduped-token");
-    expect(requireRuntimeAuthResult(second).apiKey).toBe("deduped-token");
+      expect(execFileMock).toHaveBeenCalledTimes(1);
+      expect(requireRuntimeAuthResult(first).apiKey).toBe("deduped-token");
+      expect(requireRuntimeAuthResult(second).apiKey).toBe("deduped-token");
+    } finally {
+      tokenResponse.resolve();
+      await settled;
+    }
   });
 
   it("clears failed refresh state so later concurrent retries succeed", async () => {
     const provider = registerProvider();
     const prepareRuntimeAuth = requirePrepareRuntimeAuth(provider);
-    mockAzureCliLoginFailure(10);
-    mockAzureCliToken({ accessToken: "recovered-token", expiresInMs: 10 * 60_000, delayMs: 10 });
+    const failedResponse = createDeferred<void>();
+    const recoveryResponse = createDeferred<void>();
+    mockAzureCliLoginFailure(failedResponse.promise);
+    mockAzureCliToken({
+      accessToken: "recovered-token",
+      expiresInMs: 10 * 60_000,
+      response: recoveryResponse.promise,
+    });
     ensureAuthProfileStoreMock.mockReturnValue(buildEntraProfileStore());
 
     const runtimeContext = buildFoundryRuntimeAuthContext();
+    const pending = [prepareRuntimeAuth(runtimeContext), prepareRuntimeAuth(runtimeContext)];
+    let settled = Promise.allSettled(pending);
+    try {
+      expect(execFileMock).toHaveBeenCalledTimes(1);
+      failedResponse.resolve();
+      const failed = await settled;
+      expect(failed.every((result) => result.status === "rejected")).toBe(true);
+      expect(execFileMock).toHaveBeenCalledTimes(1);
 
-    const failed = await Promise.allSettled([
-      prepareRuntimeAuth(runtimeContext),
-      prepareRuntimeAuth(runtimeContext),
-    ]);
-    expect(failed.every((result) => result.status === "rejected")).toBe(true);
-    expect(execFileMock).toHaveBeenCalledTimes(1);
-
-    const [first, second] = await Promise.all([
-      prepareRuntimeAuth(runtimeContext),
-      prepareRuntimeAuth(runtimeContext),
-    ]);
-    expect(execFileMock).toHaveBeenCalledTimes(2);
-    expect(requireRuntimeAuthResult(first).apiKey).toBe("recovered-token");
-    expect(requireRuntimeAuthResult(second).apiKey).toBe("recovered-token");
+      const retries = [prepareRuntimeAuth(runtimeContext), prepareRuntimeAuth(runtimeContext)];
+      pending.push(...retries);
+      settled = Promise.allSettled(pending);
+      expect(execFileMock).toHaveBeenCalledTimes(2);
+      recoveryResponse.resolve();
+      const [first, second] = await Promise.all(retries);
+      expect(execFileMock).toHaveBeenCalledTimes(2);
+      expect(requireRuntimeAuthResult(first).apiKey).toBe("recovered-token");
+      expect(requireRuntimeAuthResult(second).apiKey).toBe("recovered-token");
+    } finally {
+      // Broken dedupe can consume the recovery response in the first pair.
+      failedResponse.resolve();
+      recoveryResponse.resolve();
+      await settled;
+    }
   });
 
   it("refreshes again when a cached token is too close to expiry", async () => {


### PR DESCRIPTION
## What Problem This Solves

Two Foundry concurrency tests use three fixed 10 ms response delays to make concurrent refreshes overlap. Their intended condition is an unresolved Azure CLI response, which a timer expresses indirectly.

## Why This Change Was Made

Hold each mocked response on the existing SDK deferred helper, assert the invocation count before releasing it, and join admitted promises in finally. The failure/recovery case releases both gates during cleanup because broken deduplication can consume the queued recovery response in the first pair.

## User Impact

Test-only: production +0/-0; tests +63/-37 (net +26). All eight original concurrency assertions remain, with three pre-release counts added. The three fixed delays disappear; matched runs do not establish an elapsed-time improvement. Existing process deadlines, provider isolation, profile ownership and mock reset stay intact.

## Evidence

All 117 native case labels and statuses match across the original baseline, current-base baseline and candidate, including onboarding connection and image-generation siblings. Temporary faults independently break in-flight sharing, retain a failed refresh, and return an unexpected successful first response. Each fails at the intended assertion; cleanup releases held responses and joins admitted work without unhandled rejections or a global timeout. Exact production and candidate bytes were restored.

The full changed-file gate and Codex autoreview passed. Lead and independent source reviews found no actionable findings.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/microsoft-foundry/index.test.ts extensions/microsoft-foundry/image-generation-provider.test.ts extensions/microsoft-foundry/onboard.connection.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base 36b18316eb5023ded9bc1669e33f47a9c8424abd
```

Named separate follow-up: the Foundry reference page says native Anthropic Messages is unsupported while the current provider owns that route. This change does not alter the provider or claim live API proof.
