### PR TITLE
refactor(markdown): share span clipping logic

### DIFF
--- a/packages/markdown-core/src/ir-spans.ts
+++ b/packages/markdown-core/src/ir-spans.ts
@@ -81,46 +81,42 @@ export function createStyleSpan(params: MarkdownStyleSpan): MarkdownStyleSpan {
   return span;
 }
 
+function clipSpans<T extends { start: number; end: number }>(
+  spans: T[],
+  start: number,
+  end: number,
+  copySpan: (span: T) => T,
+): T[] {
+  const clipped: T[] = [];
+  for (const span of spans) {
+    const sliceStart = Math.max(span.start, start);
+    const sliceEnd = Math.min(span.end, end);
+    if (sliceEnd > sliceStart) {
+      const copy = copySpan(span);
+      copy.start = sliceStart - start;
+      copy.end = sliceEnd - start;
+      clipped.push(copy);
+    }
+  }
+  return clipped;
+}
+
 export function clampStyleSpans(
   spans: MarkdownStyleSpan[],
   maxLength: number,
 ): MarkdownStyleSpan[] {
-  const clamped: MarkdownStyleSpan[] = [];
-  for (const span of spans) {
-    const start = Math.max(0, Math.min(span.start, maxLength));
-    const end = Math.max(start, Math.min(span.end, maxLength));
-    if (end > start) {
-      clamped.push(createStyleSpan({ start, end, style: span.style, language: span.language }));
-    }
-  }
-  return clamped;
+  return clipSpans(spans, 0, maxLength, createStyleSpan);
 }
 
 export function clampLinkSpans(spans: MarkdownLinkSpan[], maxLength: number): MarkdownLinkSpan[] {
-  const clamped: MarkdownLinkSpan[] = [];
-  for (const span of spans) {
-    const start = Math.max(0, Math.min(span.start, maxLength));
-    const end = Math.max(start, Math.min(span.end, maxLength));
-    if (end > start) {
-      clamped.push(copyMarkdownLinkSpan(span, { start, end }));
-    }
-  }
-  return clamped;
+  return clipSpans(spans, 0, maxLength, copyMarkdownLinkSpan);
 }
 
 export function clampAnnotationSpans(
   spans: MarkdownAnnotationSpan[],
   maxLength: number,
 ): MarkdownAnnotationSpan[] {
-  const clamped: MarkdownAnnotationSpan[] = [];
-  for (const span of spans) {
-    const start = Math.max(0, Math.min(span.start, maxLength));
-    const end = Math.max(start, Math.min(span.end, maxLength));
-    if (end > start) {
-      clamped.push({ ...span, start, end });
-    }
-  }
-  return clamped;
+  return clipSpans(spans, 0, maxLength, (span) => ({ ...span }));
 }
 
 export function mergeAnnotationSpans(spans: MarkdownAnnotationSpan[]): MarkdownAnnotationSpan[] {
@@ -172,36 +168,12 @@ export function mergeStyleSpans(spans: MarkdownStyleSpan[]): MarkdownStyleSpan[]
   return merged;
 }
 
-function resolveSliceBounds(
-  span: { start: number; end: number },
-  start: number,
-  end: number,
-): { start: number; end: number } | null {
-  const sliceStart = Math.max(span.start, start);
-  const sliceEnd = Math.min(span.end, end);
-  return sliceEnd > sliceStart ? { start: sliceStart, end: sliceEnd } : null;
-}
-
 export function sliceStyleSpans(
   spans: MarkdownStyleSpan[],
   start: number,
   end: number,
 ): MarkdownStyleSpan[] {
-  const sliced: MarkdownStyleSpan[] = [];
-  for (const span of spans) {
-    const bounds = resolveSliceBounds(span, start, end);
-    if (bounds) {
-      sliced.push(
-        createStyleSpan({
-          start: bounds.start - start,
-          end: bounds.end - start,
-          style: span.style,
-          language: span.language,
-        }),
-      );
-    }
-  }
-  return mergeStyleSpans(sliced);
+  return mergeStyleSpans(clipSpans(spans, start, end, createStyleSpan));
 }
 
 export function sliceLinkSpans(
@@ -209,19 +181,7 @@ export function sliceLinkSpans(
   start: number,
   end: number,
 ): MarkdownLinkSpan[] {
-  const sliced: MarkdownLinkSpan[] = [];
-  for (const span of spans) {
-    const bounds = resolveSliceBounds(span, start, end);
-    if (bounds) {
-      sliced.push(
-        copyMarkdownLinkSpan(span, {
-          start: bounds.start - start,
-          end: bounds.end - start,
-        }),
-      );
-    }
-  }
-  return sliced;
+  return clipSpans(spans, start, end, copyMarkdownLinkSpan);
 }
 
 export function sliceAnnotationSpans(
@@ -229,16 +189,5 @@ export function sliceAnnotationSpans(
   start: number,
   end: number,
 ): MarkdownAnnotationSpan[] {
-  const sliced: MarkdownAnnotationSpan[] = [];
-  for (const span of spans) {
-    const bounds = resolveSliceBounds(span, start, end);
-    if (bounds) {
-      sliced.push({
-        ...span,
-        start: bounds.start - start,
-        end: bounds.end - start,
-      });
-    }
-  }
-  return mergeAnnotationSpans(sliced);
+  return mergeAnnotationSpans(clipSpans(spans, start, end, (span) => ({ ...span })));
 }


### PR DESCRIPTION
Clamping and slicing Markdown styles, links and annotations repeated the same intersection and rebasing loops. One private clipping loop now handles those operations while each span type retains its existing copy operation, metadata and merge rules.

This is a one-file, behavior-preserving refactor in `packages/markdown-core/src/ir-spans.ts`: **+26 / −77 production lines, net −51; no test, generated, dependency or configuration changes.** All six public signatures remain unchanged. Fresh copies, numeric bounds, empty and reversed intervals, style-language filtering, annotation metadata, private autolink provenance, overlap/adjacency merging and blockquote boundaries retain their prior behavior.

Validation was repeated on base `9c752338fadf97ba19da1ce9b23058df2dfea843`, including the current Markdown parser and transcript callers:

- The same **85 maintained tests in five files** passed before and after the change: IR, links, assistant transcripts, construct fallbacks and render-aware chunking.
- **114,036 baseline/candidate comparisons** passed using an immutable copy of the original owner, covering the listed value, allocation and provenance contracts.
- All 27 classifier-selected changed-file checks passed across the original run and a continuation, with source and dependency hashes unchanged. The original run completed 16 checks, including both type checks, before its 40-minute overall deadline interrupted the deprecated-API guard. The remaining 11 canonical checks were then run separately; the interrupted run is retained as exit 124, not described as a passing full invocation.
- Fresh independent Codex P2/high review returned scoped-clean with no actionable findings.

The final owner SHA-256 is `08e86c41246347d95e0da9cc3cfe1f9a3b20cad31b3da3fab628a23cb18487c6`; the reviewed patch SHA-256 is `ef8237192fecb27a53f3b19008bd2181f3205e692bba5659b6906b1dae51c240`. The PR makes no performance claim and changes no transport, protocol or persistence behavior. This pure helper is exercised through the real Markdown callers above; there is no external service involved.


Maintainer landing review: the refreshed head `6aac22b8145922328891a2326595e139b00784f4` passed [CI run 33517622620](https://github.com/openclaw/openclaw/actions/runs/33517622620), including all 165 selected jobs and `openclaw/ci-gate`. The complete 14:13 UTC ClawSweeper review has no code finding or separate rank-up move; its remaining request for maintainer handling and exact-head CI is satisfied by this review and the green run.

The canonical clipping helper, type-specific copy operations, private link provenance, merge boundaries, and callers were inspected directly. Local proof includes 85 maintained tests on each side and 114,036 differential comparisons. The initial aggregate local check hit its original deadline after 16 successful checks; all 11 remaining checks subsequently passed on unchanged source and dependencies. The timeout remains recorded and is not represented as a successful aggregate run. Production is −51 lines; tests are unchanged.
