### PR TITLE
fix(worker): close owned state before removing runtime directory

### DIFF
--- a/src/worker/worker-runtime-environment.test.ts
+++ b/src/worker/worker-runtime-environment.test.ts
@@ -1,0 +1,35 @@
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, it } from "vitest";
+import {
+  closeOpenClawStateDatabaseByPath,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { createWorkerRuntimeEnvironment } from "./worker.runtime.js";
+
+it("closes the worker state database before removing its directory without closing other state", async () => {
+  const unrelatedRoot = await mkdtemp(path.join(tmpdir(), "openclaw-worker-unrelated-"));
+  const unrelated = openOpenClawStateDatabase({
+    path: path.join(unrelatedRoot, "openclaw.sqlite"),
+  });
+  const environment = await createWorkerRuntimeEnvironment("worker-state-cleanup");
+  const owned = openOpenClawStateDatabase();
+  try {
+    expect(owned.db.isOpen).toBe(true);
+    expect(unrelated.db.isOpen).toBe(true);
+
+    await environment.close();
+
+    expect(owned.db.isOpen).toBe(false);
+    expect(unrelated.db.isOpen).toBe(true);
+    expect(unrelated.db.prepare("SELECT 1 AS value").get()).toEqual({ value: 1 });
+    await expect(stat(environment.stateDir)).rejects.toMatchObject({ code: "ENOENT" });
+    await environment.close();
+  } finally {
+    closeOpenClawStateDatabaseByPath(owned.path);
+    closeOpenClawStateDatabaseByPath(unrelated.path);
+    await rm(environment.stateDir, { recursive: true, force: true });
+    await rm(unrelatedRoot, { recursive: true, force: true });
+  }
+});

--- a/src/worker/worker.runtime.ts
+++ b/src/worker/worker.runtime.ts
@@ -10,6 +10,8 @@ import type { ComputerContextEpoch } from "../agents/tools/computer-tool.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
+import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db-cache.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import type { WorkerBrowserRuntime } from "./browser-runtime.js";
 import { buildWorkerConnectParams, type WorkerLaunchDescriptor } from "./launch-descriptor.js";
 import {
@@ -79,6 +81,10 @@ export async function createWorkerRuntimeEnvironment(sessionId: string) {
         supervisor.cancelScope(scopeKey, "manual-cancel");
         await supervisor.waitForScope?.(scopeKey);
         await waitForExecScope(scopeKey);
+        // Exec finalizers can open state; release its handle before Windows removes the file.
+        closeOpenClawStateDatabaseByPath(
+          resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: stateDir }),
+        );
         // Process completion writes its task outcome into this environment's state.
         // Restore the ambient directory only after those callbacks have settled.
         if (previousStateDir === undefined) {


### PR DESCRIPTION
A real Windows session-host turn completed its exec and computer tools and reconciled its workspace, then the physical worker exited 1 while deleting its temporary state. The native launch journal recorded the completed turn separately from the failed process. Its error was EBUSY unlinking the worker's state/openclaw.sqlite.

The runtime environment owned the temporary directory but never released the process-cached SQLite handle. POSIX unlink hid this lifecycle leak; Windows correctly refused to remove the open file. The same owner now drains its existing process/exec scopes, closes only the database at its canonical owned path, restores ambient configuration, and removes the directory. It reuses the existing exact-path database closer and path resolver; unrelated database handles stay open.

No schema, persistence design, API, configuration, timeout, retry or error suppression changes. Production adds six lines (two imports, one ownership comment and one existing-owner call); there is no duplicate cleanup path to delete. The regression adds 35 lines.

Validation completed:

- Real Windows Server 2022 / Node 24.20.0 failure captured after an actual OpenClaw worker turn. exec reported win32 and its remote workspace; computer returned the correct Notepad image; the marker file reconciled. Physical process cleanup then failed with EBUSY.
- New regression uses an actual cached DatabaseSync: it fails on original code because the owned handle remains open, then passes with this fix. It also proves an unrelated database remains usable, the temporary directory disappears, and repeated close is safe.
- 149 tests across five worker runtime/command/supervisor/lifetime suites passed, including foreground and hidden-background finalization, retained processes and managed EOF cleanup. The first broader run used an overlong task artifact TMPDIR and hit 61 Unix socket listen EINVAL setup failures; the same source and test arguments passed with a short task-owned TMPDIR. No assertions, deadlines or runner isolation changed.
- Core production types, the canonical other-core-test type shard, type-aware scoped lint and formatting passed. Managed Codex P0 review found no actionable findings.

Live after-fix verification now passed on the same Windows node. The canonical full runtime and UI build delivered worker bundle `b568982432674f81b18e5f6a200909969d83c48d312eba3c068dffbb5f52f0e5` through the normal Gateway installer. Both installed worker files independently matched the producer hashes. The real model turn executed Node in the placed Windows workspace, wrote its unique marker, used computer screenshot, and correctly identified the synthetic Notepad text. The marker reconciled to the Gateway worktree.

Thirteen native samples observed the worker as a child of the unchanged node in interactive session 1 with its slot occupied. The turn and physical launch then both completed; the supervisor's completed classification requires exit 0 with no signal. Independent checks found the worker gone and its exact reported temporary directory and SQLite file absent. Normal reclaim completed, the node returned to one available slot, and a final native snapshot found no worker descendants. This is native lifecycle proof, not a separately instrumented OS exit event or native computer-close acknowledgement.

The full runtime/UI build passed, but the optional npm package-metadata dry run timed out at its unchanged five-minute limit before tarball-integrity validation. This proof uses the fully built Gateway and its canonical worker-bundle transfer, not an unverified npm installation. The combined live build includes the separately reviewed desktop handoff patch from https://github.com/openclaw/openclaw/pull/134903; this PR contains only the two worker cleanup files. The source owner is unchanged between the tested baseline and PR base. Release-note context is retained here because the repository reserves CHANGELOG.md changes for release preparation.

CI integration: the original head’s sole substantive failure was the release-plan publisher inventory exceeding the default Git output buffer (run 33480733027, small-44 job 99769844996). Main fixed that producer in #134824. This candidate incorporates that fix and preserves both worker files byte-for-byte; it introduces no second inventory workaround. ClawSweeper found no code defect. Its automatic stored-data-model classification does not apply: this change closes an existing handle for ephemeral environment cleanup, with no schema, migration or persistence-policy change.

The refreshed candidate passed all 149 worker/supervisor tests again, six release-inventory regressions, and the full canonical changed-file gate (production/test types, lint and owner guards). Fresh managed Codex review found no actionable findings. Both worker files remain byte-identical to the live-verified candidate. Commit `7ff84494ba1870467c8bf0752c54accc6ecdfea4` is pushed; exact-head PR checks remain required before native landing.
