### PR TITLE
fix: avoid duplicate Git work during concurrent session starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway session diffs:** share concurrent empty-tree Git preparation within each repository, avoiding duplicate subprocesses during simultaneous session starts while keeping later reads fresh.
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.
 
 - **macOS AI setup:** show confirmed capability-review cancellation and retry guidance directly instead of a misleading Gateway failure headline. (#134573)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway session diffs:** share concurrent empty-tree Git preparation within each repository, avoiding duplicate subprocesses during simultaneous session starts while keeping later reads fresh.
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.
 
 - **macOS AI setup:** show confirmed capability-review cancellation and retry guidance directly instead of a misleading Gateway failure headline. (#134573)

--- a/src/sessions/session-diff-revisions.test.ts
+++ b/src/sessions/session-diff-revisions.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runGit, type GitResult } from "../agents/worktrees/git.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { resolveSessionDiffEmptyTree } from "./session-diff-revisions.js";
+
+vi.mock("../agents/worktrees/git.js", () => ({ runGit: vi.fn() }));
+
+function gitResult(stdout: string, code = 0): GitResult {
+  return {
+    stdout,
+    code,
+    stderr: "",
+    signal: null,
+    killed: false,
+    termination: "exit",
+    timeoutMs: 120_000,
+  };
+}
+
+describe("empty-tree preparation", () => {
+  beforeEach(() => {
+    vi.mocked(runGit).mockReset();
+  });
+
+  it("shares concurrent Git work per repository without retaining settled results", async () => {
+    const first = createDeferredCore<GitResult>();
+    const other = createDeferredCore<GitResult>();
+    vi.mocked(runGit).mockImplementation((root) =>
+      root === "first" ? first.promise : other.promise,
+    );
+
+    const pending = Array.from({ length: 32 }, () => resolveSessionDiffEmptyTree("first"));
+    const otherPending = resolveSessionDiffEmptyTree("other");
+    first.resolve(gitResult("first-tree\n"));
+    other.resolve(gitResult("other-tree\n"));
+
+    expect(await Promise.all(pending)).toEqual(
+      Array.from({ length: 32 }, () => ({ base: "first-tree" })),
+    );
+    await expect(otherPending).resolves.toEqual({ base: "other-tree" });
+    expect(runGit).toHaveBeenCalledTimes(2);
+
+    vi.mocked(runGit).mockResolvedValue(gitResult("replacement-tree\n"));
+    await expect(resolveSessionDiffEmptyTree("first")).resolves.toEqual({
+      base: "replacement-tree",
+    });
+    expect(runGit).toHaveBeenCalledTimes(3);
+  });
+
+  it.each(["exit", "reject"])(
+    "releases shared %s failures before a later request",
+    async (failure) => {
+      const command = createDeferredCore<GitResult>();
+      vi.mocked(runGit).mockReturnValue(command.promise);
+      const pending = Array.from({ length: 8 }, () => resolveSessionDiffEmptyTree("failed"));
+      if (failure === "reject") {
+        command.reject(new Error("Git unavailable"));
+      } else {
+        command.resolve(gitResult("", 128));
+      }
+      expect(await Promise.all(pending)).toEqual(Array.from({ length: 8 }, () => null));
+      expect(runGit).toHaveBeenCalledOnce();
+
+      vi.mocked(runGit).mockResolvedValue(gitResult("recovered-tree\n"));
+      await expect(resolveSessionDiffEmptyTree("failed")).resolves.toEqual({
+        base: "recovered-tree",
+      });
+      expect(runGit).toHaveBeenCalledTimes(2);
+    },
+  );
+});

--- a/src/sessions/session-diff-revisions.ts
+++ b/src/sessions/session-diff-revisions.ts
@@ -1,5 +1,8 @@
 import type { SessionsDiffResult } from "../../packages/gateway-protocol/src/index.js";
 import { runGit } from "../agents/worktrees/git.js";
+import { getOrCreatePromise } from "../shared/lazy-promise.js";
+
+const emptyTreesInFlight = new Map<string, Promise<string>>();
 
 type GitOutput = (
   cwd: string,
@@ -51,8 +54,17 @@ export async function resolveSessionDiffEmptyTree(
   root: string,
 ): Promise<{ base: string; baseRef?: string } | null> {
   try {
-    const result = await runGit(root, ["hash-object", "-t", "tree", "--stdin"], { input: "" });
-    const emptyTree = result.code === 0 ? result.stdout.trim() : "";
+    // Concurrent starts share this immutable hash, never HEAD or file contents.
+    // Evict on settlement so a replaced repository or failed command is read afresh.
+    const emptyTree = await getOrCreatePromise(
+      emptyTreesInFlight,
+      root,
+      async () => {
+        const result = await runGit(root, ["hash-object", "-t", "tree", "--stdin"], { input: "" });
+        return result.code === 0 ? result.stdout.trim() : "";
+      },
+      { evictOnSettled: true },
+    );
     return emptyTree ? { base: emptyTree } : null;
   } catch {
     return null;


### PR DESCRIPTION
## What Problem This Solves

Concurrent session starts in one workspace each run the same Git empty-tree calculation while capturing their diff baselines. Under a burst, those duplicate subprocesses add avoidable work to Gateway preparation.

## Why This Change Was Made

The revision owner now shares only overlapping empty-tree requests for the same repository through the existing promise helper. Every success or failure evicts the operation immediately; later requests ask Git again, and callers receive separate result objects. Mutable HEAD, branch, file and session-baseline state remain independent.

Computing the hash in core would introduce a repository-format discovery contract. Sharing the whole baseline would cross mutable-file and session-start ownership. This change keeps Git authoritative and adds no persistent cache, dependency, configuration, timeout or schema change.

Production: +14/-2 (net +12), required to own and release the concurrent operation. Tests: +71. No generated release metadata changes. No duplicate baseline path is retained. Historical introduction of the repeated work is not attributed.

## User Impact

Simultaneous starts avoid duplicate empty-tree subprocesses without changing diff contents or retaining results across repository changes. Residual event-loop saturation remains a separate follow-up; this PR does not claim to eliminate all stalls.

## Evidence

- All three new owner regressions fail before the change and pass afterward; 60 focused and sibling tests pass, including real Git diff/RPC behavior and durable capture races.
- An independent actual-Git probe observes 64 to 1 subprocesses for both SHA-1 and SHA-256 repositories, correct hashes, unchanged object stores, fresh later calls and failure recovery.
- Full local changed checks pass. An initial test-only TypeScript failure was corrected by using the existing deferred helper; production and assertions did not change. Managed Codex review is scoped-clean at its default P0 scope.
- Exact-source Linux Gateway pairs use four CPUs, Node 24.19.0, isolated HOME/state/loopback ports, the stock sourcePerformance build and unchanged 2000 ms limits. All six runs pass every budget with zero operation failures and zero plugin metadata scans.

| 64-turn order | Source | Mixed workload | History p99 / max |
| --- | --- | ---: | ---: |
| Before then after | Before | 19.02 s | 1566 / 1644 ms |
| Before then after | After | 15.80 s | 1526 / 1542 ms |
| After then before | After | 16.65 s | 1267 / 1358 ms |
| After then before | Before | 20.10 s | 1499 / 1510 ms |

These are small mixed-load observations, not a general throughput guarantee: background embedding counts vary, the 32-turn workload interval increases from 10.48 to 11.71 seconds, and readiness remains mostly degraded at median event-loop utilization 1. Every expected model response completed. Original parameters retain 48 seed sessions, 128 updates across four clients, three history clients with bursts of five, six subscribers, a visible observer, 100 ms cadence and 1000 ms mock stream delay. Both sources and build outputs stayed unchanged; temporary state and the owned worker were cleaned up.

The refreshed head is based on the canonical release-inventory repair in #134824. The first hosted run failed only because the previous release-plan producer exceeded the default Git output buffer; that failure is retained, and no failed run was retried. The upstream fix narrows the Git inventory without raising the buffer. All 48 release-plan tests and the three Git regressions pass on the refreshed source; the Gateway implementation and test afterimages are unchanged.

The refreshed local `pnpm ui:build` also passes: startup JavaScript is 347,927 bytes, below even the older 348,368-byte enforcement limit. This PR changes no budget. Exact-head hosted CI and the normal native prepare/merge gates are still required; benchmark runtime builds do not replace them.

Latest ClawSweeper review and rank-up request addressed: removed the normal-PR CHANGELOG.md entry under the current release-generation policy. Release context remains in this body; implementation and regression tests are unchanged. Exact-head hosted validation is refreshed for the final source.
