### PR TITLE
feat(ui): render Mermaid diagrams in chat

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -697,8 +697,10 @@ flowchart LR
 ```
 ````
 
-Choose **Diagram** or **Source** to switch views, **Copy source** to copy the
-Mermaid text, or **Expand diagram** to open the image viewer with zoom controls.
+Open the **Diagram options** menu in the top-right corner to switch between the
+diagram and source or choose **Expand diagram** for the image viewer with zoom.
+The copy button appears on hover or keyboard focus and stays visible on touch
+screens. It copies the original Mermaid text.
 Diagram colors and fonts follow the current UI theme.
 
 An unfinished streaming fence stays readable as code. Rendering starts when the

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -684,6 +684,29 @@ Chat error banners, including cloud runner failures, show short messages in full
   </Accordion>
 </AccordionGroup>
 
+### Mermaid diagrams
+
+Use a `mermaid` fenced code block in chat. The Control UI renders it as a diagram
+automatically:
+
+````markdown
+```mermaid
+flowchart LR
+  Gateway --> Worker
+  Worker --> State
+```
+````
+
+Choose **Diagram** or **Source** to switch views, **Copy source** to copy the
+Mermaid text, or **Expand diagram** to open the image viewer with zoom controls.
+Diagram colors and fonts follow the current UI theme.
+
+An unfinished streaming fence stays readable as code. Rendering starts when the
+closing fence arrives or the response finishes. Invalid or overly complex
+diagrams keep their source visible with an error; correct the syntax or simplify
+the diagram. Diagram source cannot run scripts or click handlers, load external
+images, or add custom CSS to the Control UI.
+
 ## Connection loss and reconnect
 
 Once a session is established, a dropped Gateway connection does not log you out. The dashboard

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2615,6 +2615,9 @@ importers:
       markdown-it-task-lists:
         specifier: 2.1.1
         version: 2.1.1
+      mermaid:
+        specifier: 11.17.1
+        version: 11.17.1
       remend:
         specifier: 1.3.0
         version: 1.3.0
@@ -2687,6 +2690,9 @@ packages:
     resolution: {integrity: sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.232':
     resolution: {integrity: sha512-+/4PX+dwmQAjlOlooocwa3kClulZfMo133xQH3LYDlK7D5bzze16lwlDGPVAYGEarpvXg7G5JK8QjfWAJ2HYbg==}
@@ -3037,6 +3043,9 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
@@ -3050,6 +3059,9 @@ packages:
 
   '@cacheable/utils@2.5.0':
     resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@clack/core@1.4.3':
     resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
@@ -3594,6 +3606,12 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -3898,6 +3916,9 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@mermaid-js/parser@1.2.1':
+    resolution: {integrity: sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==}
 
   '@microsoft/mxc-sdk@0.7.0':
     resolution: {integrity: sha512-EWhz2pKkcPluZHAOI1yneV+JK0NO/3hdh7nABBb0x4PjyUWMeSWPTBAjtIu+BhtMYOqlaijSPZMZ0Hs/J4ZL4A==}
@@ -5165,6 +5186,99 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.1':
+    resolution: {integrity: sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.4':
+    resolution: {integrity: sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.2.0':
+    resolution: {integrity: sha512-kVd74ta9eof3eJOvbNd1vGKS/XERRyQbT26Og63hIsvDO84cjD5gEOhsXf26w3FSoNlPVz84DOFcKv/oou+fMw==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -5191,6 +5305,9 @@ packages:
 
   '@types/express@5.0.6':
     resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
@@ -5397,6 +5514,9 @@ packages:
 
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@urbit/aura@3.0.0':
     resolution: {integrity: sha512-N8/FHc/lmlMDCumMuTXyRHCxlov5KZY6unmJ9QR2GOw+OpROZMBsXYGwE+ZMtvN21ql9+Xb8KhGNBj08IrG3Wg==}
@@ -6007,6 +6127,14 @@ packages:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
     engines: {node: '>=22.12.0'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   composed-offset-position@0.0.6:
     resolution: {integrity: sha512-Q7dLompI6lUwd7LWyIcP66r4WcS9u7AL2h8HaeipiRfCRPLMWqRx8fYsjb4OHi6UQFifO7XtNC2IlEJ1ozIFxw==}
     peerDependencies:
@@ -6041,6 +6169,12 @@ packages:
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
+
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
   cosmiconfig@9.0.2:
     resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
@@ -6099,6 +6233,162 @@ packages:
   curve25519-js@0.0.4:
     resolution: {integrity: sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.1:
+    resolution: {integrity: sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -6109,6 +6399,9 @@ packages:
 
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
+  dayjs@1.11.23:
+    resolution: {integrity: sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==}
 
   debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
@@ -6159,6 +6452,9 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -6316,6 +6612,9 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.51.0:
+    resolution: {integrity: sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==}
+
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
 
@@ -6444,6 +6743,9 @@ packages:
   fast-xml-parser@5.11.0:
     resolution: {integrity: sha512-9IGxMqvqLOnqP+Egi1nqDHKv5k8aZ7r9n558enxcucmyVGEBNPAU+MOg/8jPIS7rO7sSq4gFm1/nHtiaubMruw==}
     hasBin: true
+
+  fastdom@1.0.12:
+    resolution: {integrity: sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -6646,6 +6948,9 @@ packages:
     resolution: {integrity: sha512-/8Qw+iisrUdOMk+p2mjEHouMm/BBdBEN1DHh16wiTpRUZkxDG3PxexdjCvR+wvK3LWPdrEvnQbdrwpU954sPhg==}
     engines: {node: ^12.20.0 || >=14.13.1}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
@@ -6817,6 +7122,13 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ip-address@10.5.0:
     resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
@@ -7068,8 +7380,15 @@ packages:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -7085,6 +7404,12 @@ packages:
   kysely@0.29.5:
     resolution: {integrity: sha512-ooa+eSbBNPTo3MycPEuW5jdrxQdQwdtB3LC3h43FiXQbIry5tR0C5lDG7eealK0E4D7XjrnOP5DIUg/LyjRMYQ==}
     engines: {node: '>=22.0.0'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   leac@0.7.0:
     resolution: {integrity: sha512-qMrZeyEekgdRQ9o6a4NAB2EQZrv827GJdn1vnapwSJ90hWRB4TzUSunvacPkxQ2TnNqHNI1/zSt0hlo0crG8Jw==}
@@ -7234,6 +7559,9 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -7354,6 +7682,11 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   marked@18.0.10:
     resolution: {integrity: sha512-FJeH4bRpYoXiggcgriCGItKCSv3xkngJc4QCZ/rkQCogU3VYaLxYJoZl8Nw/b4+x7iij/pd+09mZ6A1dXzpL0A==}
     engines: {node: '>= 20'}
@@ -7446,6 +7779,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid@11.17.1:
+    resolution: {integrity: sha512-G1BP6qU4BRwEGk2SdsxgDk1cSuApimT32Nkb52YRSv+856FrmB8qo28BaNk9Ee8Fvuon3OxpXDJ4L6cD5AykXg==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -7852,6 +8188,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
@@ -7894,6 +8233,9 @@ packages:
 
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -7973,6 +8315,12 @@ packages:
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss-lit@1.4.1:
     resolution: {integrity: sha512-n3eVDvF7uyMEcxDVVBrOisB7MhkE1btqfQRALZZCeCFURn7sRoElzQa7/KfHeLhoSrkwBPLmZx0mCnoxHDI9lA==}
@@ -8237,6 +8585,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown-plugin-dts@0.28.2:
     resolution: {integrity: sha512-U0Ng45ZaESZ7rJtQtgCWkJYCpMgH42yIj3xv9HGAsh/dJ8XBhjI4lcqh4NOWx8+CAxoY2HWg8VYINML2yE9A5A==}
     engines: {node: ^22.18.0 || ^24.11.0 || >=26.0.0}
@@ -8261,6 +8612,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -8271,6 +8625,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -8486,6 +8843,9 @@ packages:
   streamx@2.28.0:
     resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
 
+  strictdom@1.0.1:
+    resolution: {integrity: sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -8538,6 +8898,9 @@ packages:
     resolution: {integrity: sha512-xVQwyiuxALUBNB2fBe0tmNemg9KqLtdj3T64mioFDar79B2cU8LIyz+3KL6LdiHs9NkeNfwxpKSaIVOY8f112g==}
     engines: {node: '>=20.19.0'}
     hasBin: true
+
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -8693,6 +9056,10 @@ packages:
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   ts-simple-type@2.0.0-next.0:
     resolution: {integrity: sha512-A+hLX83gS+yH6DtzNAhzZbPfU+D9D8lHlTSd7GeoMRBjOt3GRylDqLTYbdmjA4biWvq2xSfpqfIDj2l0OA/BVg==}
@@ -9245,6 +9612,11 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.8.0
+      tinyexec: 1.3.0
+
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.232':
     optional: true
 
@@ -9789,6 +10161,8 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
+  '@braintree/sanitize-url@7.1.2': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -9810,6 +10184,8 @@ snapshots:
     dependencies:
       hashery: 1.5.1
       keyv: 5.6.0
+
+  '@chevrotain/types@11.1.2': {}
 
   '@clack/core@1.4.3':
     dependencies:
@@ -10435,6 +10811,14 @@ snapshots:
     dependencies:
       hono: 4.13.3
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.4':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
@@ -10774,6 +11158,10 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@mermaid-js/parser@1.2.1':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@microsoft/mxc-sdk@0.7.0':
     dependencies:
@@ -11993,6 +12381,123 @@ snapshots:
     dependencies:
       '@types/node': 26.2.0
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.1':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.4': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.2.0':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.1
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.2.0
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -12025,6 +12530,8 @@ snapshots:
       '@types/body-parser': 1.19.6
       '@types/express-serve-static-core': 5.1.3
       '@types/serve-static': 2.2.0
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.5':
     dependencies:
@@ -12217,6 +12724,11 @@ snapshots:
       '@ubjs/node-win32-x64-msvc': 0.31.0-3
 
   '@ungap/structured-clone@1.3.3': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@urbit/aura@3.0.0': {}
 
@@ -12807,6 +13319,10 @@ snapshots:
 
   commander@15.0.0: {}
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   composed-offset-position@0.0.6(@floating-ui/utils@0.2.12):
     dependencies:
       '@floating-ui/utils': 0.2.12
@@ -12829,6 +13345,14 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
 
   cosmiconfig@9.0.2(typescript@6.0.3):
     dependencies:
@@ -12879,6 +13403,190 @@ snapshots:
 
   curve25519-js@0.0.4: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.1):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.1
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.1):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.1
+
+  cytoscape@3.34.1: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
   data-uri-to-buffer@4.0.1: {}
 
   data-urls@7.0.0(@noble/hashes@2.3.0):
@@ -12889,6 +13597,8 @@ snapshots:
       - '@noble/hashes'
 
   date-fns@4.4.0: {}
+
+  dayjs@1.11.23: {}
 
   debug@4.4.0(supports-color@10.2.2):
     dependencies:
@@ -12924,6 +13634,10 @@ snapshots:
   define-lazy-prop@3.0.0: {}
 
   defu@6.1.7: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -13058,6 +13772,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.4
+
+  es-toolkit@1.51.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -13264,6 +13980,10 @@ snapshots:
       path-expression-matcher: 1.6.2
       strnum: 2.4.2
       xml-naming: 0.3.0
+
+  fastdom@1.0.12:
+    dependencies:
+      strictdom: 1.0.1
 
   fastest-levenshtein@1.0.16: {}
 
@@ -13507,6 +14227,8 @@ snapshots:
       - encoding
       - supports-color
 
+  hachure-fill@0.5.2: {}
+
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
@@ -13734,6 +14456,10 @@ snapshots:
   ini@1.3.8: {}
 
   inline-style-parser@0.2.7: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   ip-address@10.5.0: {}
 
@@ -13976,9 +14702,15 @@ snapshots:
 
   jwt-decode@4.0.0: {}
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   keyv@5.6.0:
     dependencies:
       '@keyv/serialize': 1.1.1
+
+  khroma@2.1.0: {}
 
   kind-of@6.0.3: {}
 
@@ -14003,6 +14735,10 @@ snapshots:
       '@koromix/koffi-win32-x64': 3.1.6
 
   kysely@0.29.5: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   leac@0.7.0: {}
 
@@ -14142,6 +14878,8 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
+  lodash-es@4.18.1: {}
+
   lodash.camelcase@4.3.0: {}
 
   lodash.clonedeep@4.5.0: {}
@@ -14272,6 +15010,8 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@11.2.0: {}
+
+  marked@16.4.2: {}
 
   marked@18.0.10: {}
 
@@ -14441,6 +15181,31 @@ snapshots:
   merge-descriptors@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  mermaid@11.17.1:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.4
+      '@mermaid-js/parser': 1.2.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.1
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.1)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.1)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.23
+      dompurify: 3.4.14
+      es-toolkit: 1.51.0
+      fastdom: 1.0.12
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.2
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -14991,6 +15756,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-manager-detector@1.8.0: {}
+
   pako@1.0.11: {}
 
   pako@2.2.0: {}
@@ -15038,6 +15805,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   partial-json@0.1.7: {}
+
+  path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
 
@@ -15115,6 +15884,13 @@ snapshots:
   pngjs@5.0.0: {}
 
   pngjs@7.0.0: {}
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss-lit@1.4.1(jiti@2.7.0)(postcss@8.5.26)(supports-color@10.2.2)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
@@ -15366,6 +16142,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  robust-predicates@3.0.3: {}
+
   rolldown-plugin-dts@0.28.2(@typescript/native-preview@7.0.0-dev.20260707.2)(rolldown@1.2.5)(typescript@6.0.3):
     dependencies:
       dts-resolver: 3.0.0
@@ -15402,6 +16180,13 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.5
       '@rolldown/binding-win32-x64-msvc': 1.2.5
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   router@2.2.0(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -15417,6 +16202,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   safe-buffer@5.1.2: {}
 
@@ -15653,6 +16440,8 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  strictdom@1.0.1: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -15745,6 +16534,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  stylis@4.4.0: {}
 
   supports-color@10.2.2: {}
 
@@ -15893,6 +16684,8 @@ snapshots:
   trough@2.2.0: {}
 
   ts-algebra@2.0.0: {}
+
+  ts-dedent@2.3.0: {}
 
   ts-simple-type@2.0.0-next.0: {}
 

--- a/scripts/check-control-ui-performance.mts
+++ b/scripts/check-control-ui-performance.mts
@@ -21,6 +21,10 @@ const DEFAULT_STARTUP_BUDGET_BASELINE_PATH = path.resolve(
 // may accumulate. The fixed startup JS ceiling bounds that cumulative creep.
 const CONTROL_UI_STARTUP_JS_GZIP_TOLERANCE_BYTES = 512;
 const CONTROL_UI_STARTUP_JS_GZIP_BUILD_VARIANCE_BYTES = 64;
+// The opaque Mermaid sandbox loads one self-contained classic script only when
+// a diagram is viewed. Keep its size visible without relaxing ordinary chunks.
+const MERMAID_RENDERER_ASSET = /^assets\/mermaid\.min-[\w-]+\.js$/u;
+const MERMAID_RENDERER_GZIP_BYTES = 960 * KIB;
 
 // Small, explicit headroom over the optimized baseline. Budget changes should
 // accompany an intentional loading or chunking decision.
@@ -125,8 +129,10 @@ export function collectControlUiPerformanceMetrics(distDir: string) {
     return asset;
   });
   const jsAssets = assets.filter((asset) => asset.type === "js");
+  const mermaidRenderer = jsAssets.filter((asset) => MERMAID_RENDERER_ASSET.test(asset.file));
+  const ordinaryJsAssets = jsAssets.filter((asset) => !MERMAID_RENDERER_ASSET.test(asset.file));
   const cssAssets = assets.filter((asset) => asset.type === "css");
-  if (jsAssets.length === 0 || cssAssets.length === 0 || startup.length === 0) {
+  if (ordinaryJsAssets.length === 0 || cssAssets.length === 0 || startup.length === 0) {
     throw new Error("Control UI performance check found an incomplete production bundle");
   }
   return {
@@ -141,9 +147,10 @@ export function collectControlUiPerformanceMetrics(distDir: string) {
       css: summarizeAssets(cssAssets),
     },
     largest: {
-      js: largestAsset(jsAssets),
+      js: largestAsset(ordinaryJsAssets),
       css: largestAsset(cssAssets),
     },
+    mermaidRenderer,
   };
 }
 
@@ -166,6 +173,19 @@ export function evaluateControlUiPerformanceBudgets(
     ["startup CSS gzip", metrics.startup.css.gzipBytes, budgets.startupCssGzipBytes, "bytes"],
     ["largest JS gzip", metrics.largest.js.gzipBytes, budgets.largestJsGzipBytes, "bytes"],
     ["largest CSS gzip", metrics.largest.css.gzipBytes, budgets.largestCssGzipBytes, "bytes"],
+    ["isolated Mermaid JS assets", metrics.mermaidRenderer.length, 1, "count"],
+    [
+      "isolated Mermaid JS gzip",
+      summarizeAssets(metrics.mermaidRenderer).gzipBytes,
+      MERMAID_RENDERER_GZIP_BYTES,
+      "bytes",
+    ],
+    [
+      "startup Mermaid JS assets",
+      metrics.startup.assets.filter((asset) => MERMAID_RENDERER_ASSET.test(asset.file)).length,
+      0,
+      "count",
+    ],
   ];
   const violations = checks.flatMap(([metric, actual, limit, unit]) =>
     actual > limit ? [{ metric, actual, limit, unit }] : [],
@@ -265,11 +285,16 @@ export function formatControlUiPerformanceReport(
   }
   lines.push(
     `  startup CSS: ${formatAssetSummary(metrics.startup.css)} (limits: ${formatRequestCount(budgets.startupCssRequests)}, ${formatControlUiPerformanceBytes(budgets.startupCssGzipBytes)} gzip)`,
-    `  largest JS: ${metrics.largest.js.file}, ${formatControlUiPerformanceBytes(metrics.largest.js.gzipBytes)} gzip (limit: ${formatControlUiPerformanceBytes(budgets.largestJsGzipBytes)})`,
+    `  largest ordinary JS: ${metrics.largest.js.file}, ${formatControlUiPerformanceBytes(metrics.largest.js.gzipBytes)} gzip (limit: ${formatControlUiPerformanceBytes(budgets.largestJsGzipBytes)})`,
     `  largest CSS: ${metrics.largest.css.file}, ${formatControlUiPerformanceBytes(metrics.largest.css.gzipBytes)} gzip (limit: ${formatControlUiPerformanceBytes(budgets.largestCssGzipBytes)})`,
     `  all JS: ${formatAssetSummary(metrics.total.js)}`,
     `  all CSS: ${formatAssetSummary(metrics.total.css)}`,
   );
+  if (metrics.mermaidRenderer.length > 0) {
+    lines.push(
+      `  isolated Mermaid JS: ${formatAssetSummary(summarizeAssets(metrics.mermaidRenderer))} (limits: 1 deferred asset, ${formatControlUiPerformanceBytes(MERMAID_RENDERER_GZIP_BYTES)} gzip; forbidden at startup)`,
+    );
+  }
   if (
     startupBudgetBaseline &&
     metrics.startup.js.gzipBytes + STARTUP_JS_BASELINE_RATCHET_BYTES <

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -113,7 +113,7 @@ const RELEASE_BRANCH_RE = /^release\/\d{4}\.\d+\.\d+$/;
 class ControlUiGeneratedArtifactsMixedError extends Error {}
 class NativeGeneratedArtifactsMixedError extends Error {}
 const CHROMIUM_UI_TEST_SCOPE_RE =
-  /^(ui\/|extensions\/browser\/chrome-extension\/|test\/vitest\/vitest\.(?:shared|ui-e2e)\.config\.ts$|scripts\/ensure-playwright-chromium\.mts$|package\.json$|\.github\/workflows\/ci\.yml$)/;
+  /^(ui\/|extensions\/browser\/chrome-extension\/|test\/vitest\/vitest\.(?:(?:shared|ui-e2e|ui-browser)\.config\.ts|ui-paths\.mjs)$|scripts\/ensure-playwright-chromium\.mts$|package\.json$|\.github\/workflows\/ci\.yml$)/;
 const NATIVE_I18N_SCOPE_RE =
   /^(?:apps\/\.i18n\/|apps\/android\/(?:app\/src\/(?:main|play|thirdParty)\/|wear\/src\/main\/)|apps\/ios\/|apps\/macos\/Sources\/|apps\/shared\/OpenClawKit\/Sources\/|scripts\/(?:android-app-i18n|apple-app-i18n|native-(?:app-i18n|i18n-locales))\.ts$|test\/scripts\/(?:android-app-i18n|apple-app-i18n|native-app-i18n)\.test\.ts$|\.github\/workflows\/(?:ci|native-app-locale-refresh)\.yml$)/;
 // Android base resources are co-owned: source PRs edit their English content,

--- a/scripts/lib/ci-changed-node-test-plan.mts
+++ b/scripts/lib/ci-changed-node-test-plan.mts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
+import { isUiBrowserTestFile } from "../../test/vitest/vitest.ui-paths.mjs";
 import { detectChangedLanes } from "../changed-lanes.mts";
 import {
   buildVitestRunPlans,
@@ -545,10 +546,14 @@ export function createChangedNodeTestShards(
   // suite scans the checked-out tree and never consumes the built dist.
   const shards = [
     ...createChangedExtensionConfigShardsForPaths(livePaths, cwd),
-    ...createChangedTargetShards(targets, {
-      checkName: "checks-node-changed",
-      shardName: "changed",
-    }),
+    // Native browser files run in checks-ui, including precise changed-file plans.
+    ...createChangedTargetShards(
+      targets.filter((target) => !isUiBrowserTestFile(target)),
+      {
+        checkName: "checks-node-changed",
+        shardName: "changed",
+      },
+    ),
     ...(hasBuildArtifactAffectingChange(changedPaths) ? [] : [createBoundaryShard()]),
   ];
   return shards.length > 0 ? shards : null;

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -16,6 +16,7 @@ import {
 import { fullSuiteVitestShards } from "../../test/vitest/vitest.test-shards.mjs";
 import { toolingIsolatedTestFiles } from "../../test/vitest/vitest.tooling-isolated-paths.mjs";
 import { uiIsolatedTestFiles } from "../../test/vitest/vitest.ui-isolated-paths.mjs";
+import { isUiBrowserTestFile } from "../../test/vitest/vitest.ui-paths.mjs";
 import {
   getUnitFastIsolatedTestFiles,
   getUnitFastTestFiles,
@@ -160,7 +161,11 @@ const EXCLUDED_FULL_SUITE_SHARDS = new Set([
   "test/vitest/vitest.full-extensions.config.ts",
 ]);
 
-const EXCLUDED_PROJECT_CONFIGS = new Set(["test/vitest/vitest.channels.config.ts"]);
+const EXCLUDED_PROJECT_CONFIGS = new Set([
+  "test/vitest/vitest.channels.config.ts",
+  // checks-ui owns the Chromium project; Node stripes retain Node-driven Playwright tests.
+  "test/vitest/vitest.ui-browser.config.ts",
+]);
 const DEFAULT_NODE_TEST_RUNNER = "blacksmith-8vcpu-ubuntu-2404";
 const BUNDLED_NODE_TEST_RUNNER = "blacksmith-4vcpu-ubuntu-2404";
 // Startup-core transforms the broad gateway graph before its assertions run.
@@ -1647,7 +1652,10 @@ function createCoreRuntimeMediaUiSplitShards(): NodeTestSplitShard[] {
   const unitFastFiles = new Set(getUnitFastTestFiles());
   const isolatedUiFiles = new Set(uiIsolatedTestFiles);
   const files = listTestFiles("ui/src").filter(
-    (file) => isStripeEligibleTestFile(file, unitFastFiles) && !isolatedUiFiles.has(file),
+    (file) =>
+      isStripeEligibleTestFile(file, unitFastFiles) &&
+      !isolatedUiFiles.has(file) &&
+      !isUiBrowserTestFile(file),
   );
   return [
     ...createStripedSplitShards({

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -9,7 +9,7 @@ import {
   embeddedAgentVitestProjectOwners,
 } from "../test/vitest/vitest.agents-paths.mjs";
 import { toolingIsolatedTestFiles } from "../test/vitest/vitest.tooling-isolated-paths.mjs";
-import { isUiTestTarget } from "../test/vitest/vitest.ui-paths.mjs";
+import { isUiBrowserTestFile, isUiTestTarget } from "../test/vitest/vitest.ui-paths.mjs";
 import { boundaryTestFiles } from "../test/vitest/vitest.unit-paths.mjs";
 import { parsePermissiveBooleanToken } from "./lib/arg-utils.mts";
 import { resolveExtensionTestConfig } from "./lib/extension-test-plan.mts";
@@ -76,6 +76,7 @@ export const DEFAULT_EXTRA_LONG_RUNNING_VITEST_NO_OUTPUT_TIMEOUT_MS = 2_400_000;
 const VITEST_NO_OUTPUT_TIMEOUT_ENV_KEY = "OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS";
 const VITEST_NO_OUTPUT_HEARTBEAT_ENV_KEY = "OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS";
 const UI_VITEST_CONFIG = "test/vitest/vitest.ui.config.ts";
+const UI_BROWSER_VITEST_CONFIG = "test/vitest/vitest.ui-browser.config.ts";
 const TOOLING_DOCKER_VITEST_CONFIG = "test/vitest/vitest.tooling-docker.config.ts";
 const TOOLING_VITEST_CONFIG = "test/vitest/vitest.tooling.config.ts";
 const GATEWAY_CORE_VITEST_CONFIG = "test/vitest/vitest.gateway-core.config.ts";
@@ -985,6 +986,9 @@ export function resolveImplicitVitestArgs(argv: string[], cwd = process.cwd()): 
     resolved.splice(separatorIndex < 0 ? resolved.length : separatorIndex, 0, "--isolate");
     return resolved;
   }
+  if (collectExplicitDirectoryTargetArgs(argv, cwd).length > 0) {
+    return argv;
+  }
   const testTargets = argv
     .filter((arg) => !arg.startsWith("-") && arg.endsWith(".test.ts"))
     .map((arg) => toRepoRelativeArg(arg, cwd));
@@ -994,7 +998,17 @@ export function resolveImplicitVitestArgs(argv: string[], cwd = process.cwd()): 
   if (testTargets.length > 0 && testTargets.every(isToolingTestTarget)) {
     return withImplicitVitestConfig(argv, TOOLING_VITEST_CONFIG);
   }
-  if (testTargets.length > 0 && testTargets.every(isUiTestTarget)) {
+  // Glob selectors can span both browser owners; the root project matrix partitions them.
+  if (testTargets.some((target) => /[*?[\]{}]|[@+!]\(/u.test(target))) {
+    return argv;
+  }
+  if (testTargets.length > 0 && testTargets.every(isUiBrowserTestFile)) {
+    return withImplicitVitestConfig(argv, UI_BROWSER_VITEST_CONFIG);
+  }
+  if (
+    testTargets.length > 0 &&
+    testTargets.every((target) => isUiTestTarget(target) && !isUiBrowserTestFile(target))
+  ) {
     return withImplicitVitestConfig(argv, UI_VITEST_CONFIG);
   }
   return argv;

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -75,6 +75,7 @@ import {
   isUiIsolatedTestFile,
   uiIsolatedTestFiles,
 } from "../test/vitest/vitest.ui-isolated-paths.mjs";
+import { isUiBrowserTestFile } from "../test/vitest/vitest.ui-paths.mjs";
 import {
   getUnitFastIsolatedTestFiles,
   getUnitFastTestFiles,
@@ -455,6 +456,7 @@ const FULL_SUITE_UNIT_FAST_TEST_TARGET_CHUNK_SIZE = 70;
 const TUI_VITEST_CONFIG = "test/vitest/vitest.tui.config.ts";
 const TUI_PTY_VITEST_CONFIG = "test/vitest/vitest.tui-pty.config.ts";
 const UI_VITEST_CONFIG = "test/vitest/vitest.ui.config.ts";
+const UI_BROWSER_VITEST_CONFIG = "test/vitest/vitest.ui-browser.config.ts";
 const UI_E2E_VITEST_CONFIG = "test/vitest/vitest.ui-e2e.config.ts";
 const UI_ISOLATED_VITEST_CONFIG = "test/vitest/vitest.ui-isolated.config.ts";
 const UTILS_VITEST_CONFIG = "test/vitest/vitest.utils.config.ts";
@@ -523,6 +525,7 @@ const VITEST_CONFIG_BY_KIND: Record<string, string> = {
   plugin: PLUGINS_VITEST_CONFIG,
   ui: UI_VITEST_CONFIG,
   uiIsolated: UI_ISOLATED_VITEST_CONFIG,
+  uiBrowser: UI_BROWSER_VITEST_CONFIG,
   uiE2e: UI_E2E_VITEST_CONFIG,
   unitSrc: UNIT_SRC_VITEST_CONFIG,
   unitSecurity: UNIT_SECURITY_VITEST_CONFIG,
@@ -1277,6 +1280,13 @@ function expandExplicitSourceTestTargets(targetArgs: string[], cwd: string) {
   const forceFullImportGraph = sourceTargetCount > EXPLICIT_SOURCE_FULL_IMPORT_GRAPH_THRESHOLD;
   return targetArgs.flatMap((targetArg) => {
     const relative = toRepoRelativeTarget(targetArg, cwd);
+    if (isPathAtOrUnder(relative, "ui") && isGlobTarget(relative)) {
+      // Expand mixed browser globs before assigning files to their disjoint runners.
+      const targets = listExplicitTestTargetFilesForCwd(cwd).filter(
+        (file) => isTestFileTarget(file) && path.matchesGlob(file, relative),
+      );
+      return targets.length > 0 ? targets : [targetArg];
+    }
     const prefixTargets = resolveExplicitTestPrefixTargets(targetArg, cwd);
     if (prefixTargets) {
       return prefixTargets;
@@ -3426,6 +3436,9 @@ function classifyTarget(arg: string, cwd: string) {
   if (isUiIsolatedTestFile(relative)) {
     return "uiIsolated";
   }
+  if (isUiBrowserTestFile(relative)) {
+    return "uiBrowser";
+  }
   if (isPathAtOrUnder(relative, "ui")) {
     return "ui";
   }
@@ -3787,6 +3800,16 @@ export function buildVitestRunPlans(
   const changedTargetArgs =
     targetArgs.length === 0 ? resolveChangedTargetArgs(args, cwd, listChangedPaths, options) : null;
   const requestedTargetArgs = changedTargetArgs ?? targetArgs;
+  if (
+    watchMode &&
+    requestedTargetArgs.some(
+      (target) => isPathAtOrUnder(toRepoRelativeTarget(target, cwd), "ui") && isGlobTarget(target),
+    )
+  ) {
+    throw new Error(
+      "watch mode with UI glob targets is not supported; use a literal test path, directory, or dedicated UI suite",
+    );
+  }
   const activeTargetArgs = expandBroadToolingScriptTargets(
     expandExplicitSourceTestTargets(requestedTargetArgs, cwd),
     cwd,
@@ -3884,6 +3907,25 @@ export function buildVitestRunPlans(
     groupedTargets.set("toolingIsolated", current);
   }
   const uiTargets = groupedTargets.get("ui") ?? [];
+  const broadUiTargets = uiTargets.filter(
+    (targetArg) => !isTestFileTarget(toRepoRelativeTarget(targetArg, cwd)),
+  );
+  if (broadUiTargets.length > 0) {
+    const browserTargets = listExplicitTestTargetFilesForCwd(cwd).filter(
+      (file) =>
+        isUiBrowserTestFile(file) &&
+        broadUiTargets.some(
+          (targetArg) =>
+            shouldUseWholeConfigTarget("ui", targetArg, cwd) ||
+            includePatternMatchesAnyFile(toScopedIncludePattern(targetArg, cwd), [file]),
+        ),
+    );
+    if (browserTargets.length > 0) {
+      groupedTargets.set("uiBrowser", [
+        ...new Set([...(groupedTargets.get("uiBrowser") ?? []), ...browserTargets]),
+      ]);
+    }
+  }
   const impliedUiIsolatedTargets = uiIsolatedTestFiles.filter((file) =>
     uiTargets.some((targetArg) =>
       includePatternMatchesAnyFile(toScopedIncludePattern(targetArg, cwd), [file]),

--- a/src/scripts/ci-changed-scope.control-ui.test.ts
+++ b/src/scripts/ci-changed-scope.control-ui.test.ts
@@ -27,9 +27,11 @@ it("runs Chromium UI tests for browser copilot extension changes", () => {
   );
 });
 
-it.each(["package.json", ".github/workflows/ci.yml"])(
-  "runs Chromium UI tests when %s can change the browser copilot CI route",
-  (changedPath) => {
-    expect(detectChangedScope([changedPath]).runUiTests).toBe(true);
-  },
-);
+it.each([
+  "package.json",
+  ".github/workflows/ci.yml",
+  "test/vitest/vitest.ui-paths.mjs",
+  "test/vitest/vitest.ui-browser.config.ts",
+])("runs Chromium UI tests when %s can change the browser copilot CI route", (changedPath) => {
+  expect(detectChangedScope([changedPath]).runUiTests).toBe(true);
+});

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -97,6 +97,15 @@ it.each([
 });
 
 describe("CI changed Node test plan", () => {
+  it("leaves native Chromium tests to checks-ui while retaining changed Node-driven tests", () => {
+    const browser = "ui/src/components/markdown-mermaid.runtime.browser.test.ts";
+    const node = "ui/src/components/form-controls.browser.test.ts";
+    const shards = createChangedNodeTestShards([browser, node]);
+    expect(shards).not.toBeNull();
+    const targets = shards?.flatMap((shard) => shard.targets ?? []);
+    expect(targets).toContain(node);
+    expect(targets).not.toContain(browser);
+  });
   it.each([
     "extensions/copilot/index.ts",
     "extensions/copilot/harness.ts",

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -119,6 +119,18 @@ function listAllToolingTestFiles(): string[] {
 }
 
 describe("scripts/lib/ci-node-test-plan.mts", () => {
+  it("keeps Chromium files in the UI CI owner and Node-driven Playwright files in Node stripes", () => {
+    const shards = createNodeTestShards();
+    const uiStripes = shards.filter((shard) =>
+      shard.shardName.startsWith("core-runtime-media-ui-"),
+    );
+    const files = uiStripes.flatMap((shard) => shard.includePatterns ?? []);
+    expect(files).toContain("ui/src/components/form-controls.browser.test.ts");
+    expect(files).not.toContain("ui/src/components/markdown-mermaid.runtime.browser.test.ts");
+    expect(shards.flatMap((shard) => shard.configs)).not.toContain(
+      "test/vitest/vitest.ui-browser.config.ts",
+    );
+  });
   it.each(["github", "hybrid"])("keeps oversized sparse groups nonempty on %s", (runnerBackend) => {
     const native = createNodeTestShards({ includeReleaseOnlyPluginShards: false });
     const targets = [1, 2].map((count) =>

--- a/test/scripts/control-ui-performance.test.ts
+++ b/test/scripts/control-ui-performance.test.ts
@@ -105,6 +105,7 @@ function createMetrics(startupJsGzipBytes: number) {
         brotliBytes: 12,
       },
     },
+    mermaidRenderer: [],
   };
 }
 
@@ -199,6 +200,70 @@ describe("Control UI performance budgets", () => {
     );
   });
 
+  it.each([
+    { name: "accepts the capped deferred renderer", gzipBytes: 960 * 1024, violations: [] },
+    {
+      name: "rejects renderer growth above its cap",
+      gzipBytes: 960 * 1024 + 1,
+      violations: ["isolated Mermaid JS gzip"],
+    },
+    {
+      name: "rejects duplicate renderer artifacts",
+      gzipBytes: 200_000,
+      duplicate: true,
+      violations: ["isolated Mermaid JS assets"],
+    },
+    {
+      name: "rejects the renderer in startup preloads",
+      gzipBytes: 200_000,
+      startup: true,
+      violations: ["startup Mermaid JS assets"],
+    },
+    {
+      name: "retains the ordinary chunk cap beside the renderer",
+      gzipBytes: 200_000,
+      ordinaryGzipBytes: 215 * 1024 + 1,
+      violations: ["largest JS gzip"],
+    },
+    {
+      name: "does not exempt similarly named chunks",
+      gzipBytes: 960 * 1024,
+      rendererName: "mermaid-extra-a.js",
+      violations: ["largest JS gzip"],
+    },
+  ])("$name", ({ gzipBytes, duplicate, startup, ordinaryGzipBytes, rendererName, violations }) => {
+    const { distDir, writeAsset } = createDistFixture();
+    fs.writeFileSync(
+      path.join(distDir, "index.html"),
+      '<script type="module" src="./assets/index-a.js"></script>\n' +
+        '<link rel="stylesheet" href="./assets/index-c.css">\n' +
+        (startup ? '<link rel="modulepreload" href="./assets/mermaid.min-a.js">\n' : ""),
+    );
+    writeAsset("index-a.js", { rawBytes: 100, gzipBytes: 40, brotliBytes: 30 });
+    writeAsset("lazy-b.js", {
+      rawBytes: 200,
+      gzipBytes: ordinaryGzipBytes ?? 70,
+      brotliBytes: 55,
+    });
+    writeAsset("index-c.css", { rawBytes: 50, gzipBytes: 15, brotliBytes: 12 });
+    writeAsset(rendererName ?? "mermaid.min-a.js", { rawBytes: 200, gzipBytes, brotliBytes: 100 });
+    if (duplicate) {
+      writeAsset("mermaid.min-b.js", { rawBytes: 200, gzipBytes, brotliBytes: 100 });
+    }
+
+    const metrics = collectControlUiPerformanceMetrics(distDir);
+    expect(evaluateControlUiPerformanceBudgets(metrics).map((entry) => entry.metric)).toEqual(
+      violations,
+    );
+    expect(metrics.total.js.gzipBytes).toBe(
+      40 + (ordinaryGzipBytes ?? 70) + gzipBytes * (duplicate ? 2 : 1),
+    );
+    if (!rendererName) {
+      expect(metrics.largest.js.file).toBe("assets/lazy-b.js");
+      expect(formatControlUiPerformanceReport(metrics)).toContain("isolated Mermaid JS:");
+    }
+  });
+
   it("includes exact bytes when rounded violation values collide", () => {
     const metrics = {
       schemaVersion: 1 as const,
@@ -227,6 +292,7 @@ describe("Control UI performance budgets", () => {
           brotliBytes: 12,
         },
       },
+      mermaidRenderer: [],
     } satisfies ReturnType<typeof collectControlUiPerformanceMetrics>;
     const budgets = {
       startupJsRequests: 1,

--- a/test/scripts/run-vitest.test.ts
+++ b/test/scripts/run-vitest.test.ts
@@ -613,6 +613,27 @@ describe("scripts/run-vitest", () => {
     ]);
   });
 
+  it.each([
+    [
+      ["ui/src/components/markdown-mermaid.runtime.browser.test.ts"],
+      "test/vitest/vitest.ui-browser.config.ts",
+    ],
+    [["ui/src/components/form-controls.browser.test.ts"], "test/vitest/vitest.ui.config.ts"],
+    [
+      [
+        "ui/src/components/markdown-mermaid.runtime.browser.test.ts",
+        "ui/src/components/form-controls.browser.test.ts",
+      ],
+      null,
+    ],
+    [["ui/src/**/*.browser.test.ts"], null],
+    [["ui/src/components", "ui/src/pages/chat/chat-message-markdown.browser.test.ts"], null],
+  ])("preserves browser ownership for implicit targets %j", (targets, config) => {
+    expect(resolveImplicitVitestArgs(["run", ...targets])).toEqual(
+      config ? ["run", "--config", config, ...targets] : ["run", ...targets],
+    );
+  });
+
   it("allows opting back into Maglev explicitly", () => {
     expect(
       resolveVitestNodeArgs({

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -554,7 +554,9 @@ describe("scripts/test-projects changed-target routing", () => {
     ]) {
       const plan = resolveChangedTestTargetPlan([file]);
       expect(plan.mode).toBe("targets");
-      if (plan.mode !== "targets") throw new Error(`Missing recovery test owner: ${file}`);
+      if (plan.mode !== "targets") {
+        throw new Error(`Missing recovery test owner: ${file}`);
+      }
       expect(plan.targets).toContain("test/scripts/upgrade-survivor-recovery-cleanup.test.ts");
     }
   });
@@ -904,7 +906,9 @@ describe("scripts/test-projects changed-target routing", () => {
       (cwd) => {
         const targets = resolveChangedTestTargetPlan([changedPath], { cwd }).targets;
 
-        for (const exactTarget of exactTargets) expect(targets).toContain(exactTarget);
+        for (const exactTarget of exactTargets) {
+          expect(targets).toContain(exactTarget);
+        }
         expect(targets).toContain("test/scripts/direct-workflow-reference.test.ts");
         expect(targets).toContain("test/scripts/ci-workflow-guards.test.ts");
       },
@@ -3047,14 +3051,16 @@ describe("scripts/test-projects changed-target routing", () => {
       "ui/src/test-helpers/lit-warnings.setup.ts",
     ]);
 
-    expect(plans).toEqual([
-      {
-        config: "test/vitest/vitest.ui.config.ts",
-        forwardedArgs: [],
-        includePatterns: null,
-        watchMode: false,
-      },
-    ]);
+    expect(plans[0]).toEqual({
+      config: "test/vitest/vitest.ui.config.ts",
+      forwardedArgs: [],
+      includePatterns: null,
+      watchMode: false,
+    });
+    expect(plans[1]?.config).toBe("test/vitest/vitest.ui-browser.config.ts");
+    expect(plans[1]?.includePatterns).toContain(
+      "ui/src/components/markdown-mermaid.runtime.browser.test.ts",
+    );
   });
 
   it("keeps mixed Control UI root and source changes in the UI lane", () => {
@@ -3067,6 +3073,7 @@ describe("scripts/test-projects changed-target routing", () => {
     expect(plans.map((plan) => plan.config)).toEqual([
       "test/vitest/vitest.ui.config.ts",
       "test/vitest/vitest.ui-isolated.config.ts",
+      "test/vitest/vitest.ui-browser.config.ts",
     ]);
   });
 
@@ -3095,20 +3102,71 @@ describe("scripts/test-projects changed-target routing", () => {
     });
   });
 
-  it("adds the isolated project for broad ui targets", () => {
+  it("adds the isolated and Chromium projects for broad ui targets", () => {
     const plans = buildVitestRunPlans(["ui/src"]);
 
     expect(plans.map((plan) => plan.config)).toEqual([
       "test/vitest/vitest.ui.config.ts",
       "test/vitest/vitest.ui-isolated.config.ts",
+      "test/vitest/vitest.ui-browser.config.ts",
     ]);
     expect(plans[1]?.includePatterns).toContain("ui/src/pages/workboard/view.test.ts");
+    expect(plans[2]?.includePatterns).toContain(
+      "ui/src/components/markdown-mermaid.runtime.browser.test.ts",
+    );
+  });
+
+  it.each([
+    [
+      "ui/src/components/markdown-mermaid.runtime.browser.test.ts",
+      "test/vitest/vitest.ui-browser.config.ts",
+    ],
+    ["ui/src/components/form-controls.browser.test.ts", "test/vitest/vitest.ui.config.ts"],
+  ])("routes the browser test %s to its execution owner", (file, config) => {
+    expectSingleVitestRunPlan(buildVitestRunPlans([file]), { config, includePatterns: [file] });
+  });
+
+  it.each([
+    ["ui/src/**/*.browser.test.ts"],
+    [
+      "ui/src/components/*.browser.test.ts",
+      "ui/src/pages/chat",
+      "ui/src/styles/cursor-policy.browser.test.ts",
+    ],
+  ])("retains both browser owners for mixed selectors %j", (...targets) => {
+    const plans = buildVitestRunPlans(targets);
+    const native = plans.find((plan) => plan.config === "test/vitest/vitest.ui-browser.config.ts");
+    const node = plans.find((plan) => plan.config === "test/vitest/vitest.ui.config.ts");
+    expect(native?.includePatterns).toContain(
+      "ui/src/components/markdown-mermaid.runtime.browser.test.ts",
+    );
+    expect(
+      node?.includePatterns === null ||
+        node?.includePatterns?.includes("ui/src/components/form-controls.browser.test.ts"),
+    ).toBe(true);
+    expect(node?.includePatterns ?? []).not.toContain(
+      "ui/src/components/markdown-mermaid.runtime.browser.test.ts",
+    );
+    expect(native?.includePatterns).not.toContain(
+      "ui/src/components/form-controls.browser.test.ts",
+    );
+    if (targets.length === 1) {
+      expect(plans.flatMap((plan) => plan.includePatterns ?? []).toSorted()).toEqual(
+        fs.globSync(targets[0]!).toSorted(),
+      );
+    }
   });
 
   it("rejects broad ui watch targets that cross shared and isolated projects", () => {
     expect(() => buildVitestRunPlans(["--watch", "ui/src"])).toThrow(
       "watch mode with mixed test suites is not supported",
     );
+  });
+
+  it("rejects UI glob watch before freezing the current matching files", () => {
+    expect(() =>
+      buildVitestRunPlans(["--watch", "ui/src/components/markdown-*.browser.test.ts"]),
+    ).toThrow("use a literal test path, directory, or dedicated UI suite");
   });
 
   it("keeps explicit non-renderer ui test targets scoped", () => {

--- a/test/vitest-projects-config.test-support.ts
+++ b/test/vitest-projects-config.test-support.ts
@@ -11,6 +11,7 @@ type VitestTestConfig = {
 };
 
 type VitestConfig = {
+  root?: string;
   test?: VitestTestConfig;
 };
 
@@ -54,8 +55,9 @@ async function listFullSuiteTestFileMatches(): Promise<Map<string, string[]>> {
   const matches = new Map<string, string[]>();
   const configPaths = [...new Set(fullSuiteVitestShards.flatMap((shard) => shard.projects))];
   for (const configPath of configPaths) {
-    const testConfig = (await loadRawVitestConfig(configPath)).test ?? {};
-    const dir = testConfig.dir ? path.resolve(process.cwd(), testConfig.dir) : process.cwd();
+    const config = await loadRawVitestConfig(configPath);
+    const testConfig = config.test ?? {};
+    const dir = path.resolve(config.root ?? process.cwd(), testConfig.dir ?? ".");
     const exclude = (testConfig.exclude ?? []).map((pattern) =>
       path.isAbsolute(pattern) ? toRepoPath(path.relative(dir, pattern)) : toRepoPath(pattern),
     );

--- a/test/vitest-projects-config.test.ts
+++ b/test/vitest-projects-config.test.ts
@@ -411,6 +411,19 @@ describe("projects vitest config", () => {
     expect(requireWebOptimizer(testConfig).enabled).toBe(true);
   });
 
+  it("registers the package Chromium owner in root and full runtime runs", async () => {
+    const configPath = "test/vitest/vitest.ui-browser.config.ts";
+    expect(rootVitestProjects).toContain(configPath);
+    expect(
+      fullSuiteVitestShards.find((shard) => shard.name === "core-runtime")?.projects,
+    ).toContain(configPath);
+    const { createUiBrowserVitestConfig } = await import("./vitest/vitest.ui-browser.config.ts");
+    const browser = createUiBrowserVitestConfig();
+    expect(normalizeConfigPath(browser.root)).toBe("ui");
+    expect(requireTestConfig(browser).browser?.enabled).toBe(true);
+    expect(requireTestConfig(browser).runner).toBeUndefined();
+  });
+
   it("keeps root-matrix unit-fast files on the cross-file cleanup runner", () => {
     const testConfig = requireTestConfig(unitFastRootConfig);
     expect(testConfig.isolate).toBe(false);

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -1137,7 +1137,17 @@ describe("scoped vitest configs", () => {
   it("normalizes ui include patterns relative to the scoped dir", () => {
     const testConfig = requireTestConfig(defaultUiConfig);
     expect(testConfig.dir).toBe(process.cwd());
-    expect(testConfig.include).toEqual(["ui/src/**/*.test.ts"]);
+    expect(testConfig.include?.every((pattern) => pattern.startsWith("ui/src/"))).toBe(true);
+    for (const [file, included] of [
+      ["ui/src/pages/chat/chat-view.test.ts", true],
+      ["ui/src/components/form-controls.browser.test.ts", true],
+      ["ui/src/components/markdown-mermaid.runtime.browser.test.ts", false],
+    ] as const) {
+      expect(
+        testConfig.include?.some((pattern) => path.matchesGlob(file, pattern)),
+        file,
+      ).toBe(included);
+    }
     expect(testConfig.exclude).toContain("ui/src/**/*.e2e.test.ts");
   });
 

--- a/test/vitest-ui-package-config.test.ts
+++ b/test/vitest-ui-package-config.test.ts
@@ -8,6 +8,7 @@ import uiNodeConfig from "../ui/vitest.node.config.ts";
 import { useAutoCleanupTempDirTracker } from "./helpers/temp-dir.js";
 import { normalizeConfigPath } from "./helpers/vitest-config-paths.js";
 import { loadVitestExperimentalConfig } from "./vitest/vitest.performance-config.ts";
+import { createUiVitestConfig } from "./vitest/vitest.ui.config.ts";
 
 type ExpectedTestConfig = {
   experimental?: ReturnType<typeof loadVitestExperimentalConfig>["experimental"];
@@ -68,12 +69,60 @@ describe("ui package vitest config", () => {
     ]);
   });
 
+  it("keeps native Chromium files out of root jsdom without dropping Node-driven Playwright files", async () => {
+    const includeFile = path.join(tempDirs.make("ui-node-selection-"), "include.json");
+    writeFileSync(includeFile, JSON.stringify(["ui/src/**/*.test.ts"]));
+    vi.stubEnv("OPENCLAW_VITEST_INCLUDE_FILE", includeFile);
+    vi.resetModules();
+    const config = (await import("../ui/vitest.config.ts")).default;
+    const uiRoot = path.join(process.cwd(), "ui");
+    const projects = (requireTestConfig(config).projects ?? []).map(requireTestConfig);
+    const browser = projects.find((project) => project.browser?.enabled);
+    const node = projects.find((project) => project.name === "unit-node");
+    const root = requireTestConfig(createUiVitestConfig());
+    const nativeFiles = globSync(browser?.include ?? [], {
+      cwd: uiRoot,
+      exclude: browser?.exclude,
+    }).map((file) => `ui/${file}`);
+    const nodeFiles = globSync(node?.include ?? [], {
+      cwd: uiRoot,
+      exclude: node?.exclude,
+    })
+      .filter((file) => file.endsWith(".browser.test.ts"))
+      .map((file) => `ui/${file}`);
+    const rootFiles = globSync(root.include ?? [], { exclude: root.exclude });
+    expect(nativeFiles).toContain("ui/src/components/markdown-mermaid.runtime.browser.test.ts");
+    expect(nodeFiles).toContain("ui/src/components/form-controls.browser.test.ts");
+    expect(rootFiles.filter((file) => nativeFiles.includes(file))).toEqual([]);
+    expect(rootFiles).toEqual(expect.arrayContaining(nodeFiles));
+    expect([...nativeFiles, ...nodeFiles].toSorted()).toEqual(
+      globSync("ui/src/**/*.browser.test.ts").toSorted(),
+    );
+    writeFileSync(includeFile, JSON.stringify([...nativeFiles, ...nodeFiles]));
+    const scopedRoot = requireTestConfig(
+      createUiVitestConfig({ OPENCLAW_VITEST_INCLUDE_FILE: includeFile }),
+    );
+    expect(globSync(scopedRoot.include ?? [], { exclude: scopedRoot.exclude }).toSorted()).toEqual(
+      nodeFiles.toSorted(),
+    );
+  });
+
   it.each([
     [
       ["ui/src/pages/chat/chat-view.test.ts", "ui/src/pages/chat/chat-pane-lifecycle.test.ts"],
       ["ui/src/pages/chat/chat-pane-lifecycle.test.ts", "ui/src/pages/chat/chat-view.test.ts"],
     ],
     [["src/pages/chat/chat-view.test.ts"], []],
+    [
+      [
+        "ui/src/components/markdown-mermaid.runtime.browser.test.ts",
+        "ui/src/components/form-controls.browser.test.ts",
+      ],
+      [
+        "ui/src/components/form-controls.browser.test.ts",
+        "ui/src/components/markdown-mermaid.runtime.browser.test.ts",
+      ],
+    ],
     [[], []],
   ])("intersects a repository include list with every project: %j", async (requested, expected) => {
     const includeFile = path.join(tempDirs.make("ui-package-selection-"), "include.json");

--- a/test/vitest/vitest.config.ts
+++ b/test/vitest/vitest.config.ts
@@ -56,6 +56,7 @@ const rootVitestProjects = [
   "test/vitest/vitest.tooling.config.ts",
   "test/vitest/vitest.tui.config.ts",
   "test/vitest/vitest.ui.config.ts",
+  "test/vitest/vitest.ui-browser.config.ts",
   "test/vitest/vitest.utils.config.ts",
   "test/vitest/vitest.wizard.config.ts",
   "test/vitest/vitest.channels.config.ts",

--- a/test/vitest/vitest.test-shards.mjs
+++ b/test/vitest/vitest.test-shards.mjs
@@ -96,6 +96,7 @@ export const fullSuiteVitestShards = [
       "test/vitest/vitest.tui.config.ts",
       "test/vitest/vitest.tui-pty.config.ts",
       "test/vitest/vitest.ui.config.ts",
+      "test/vitest/vitest.ui-browser.config.ts",
       "test/vitest/vitest.ui-isolated.config.ts",
       "test/vitest/vitest.utils.config.ts",
       "test/vitest/vitest.wizard.config.ts",

--- a/test/vitest/vitest.ui-browser.config.ts
+++ b/test/vitest/vitest.ui-browser.config.ts
@@ -1,0 +1,5 @@
+// Root and package runs share the same Chromium project and workspace aliases.
+import { createUiBrowserVitestConfig } from "../../ui/vitest.config.ts";
+
+export { createUiBrowserVitestConfig };
+export default createUiBrowserVitestConfig();

--- a/test/vitest/vitest.ui-paths.d.mts
+++ b/test/vitest/vitest.ui-paths.d.mts
@@ -1,0 +1,3 @@
+export const uiNodeDrivenBrowserTestFiles: string[];
+export function isUiBrowserTestFile(relative: string): boolean;
+export function isUiTestTarget(relative: string): boolean;

--- a/test/vitest/vitest.ui-paths.mjs
+++ b/test/vitest/vitest.ui-paths.mjs
@@ -1,4 +1,29 @@
-// Test routing predicate for Control UI tests.
+// These files launch Playwright from Node; all other .browser tests run in Chromium.
+export const uiNodeDrivenBrowserTestFiles = [
+  "ui/src/pages/chat/chat-responsive.browser.test.ts",
+  "ui/src/pages/chat/chat-working-indicator.browser.test.ts",
+  "ui/src/pages/chat/chat-composer-undo-redo.browser.test.ts",
+  "ui/src/pages/chat/components/chat-swarm-progress.browser.test.ts",
+  "ui/src/components/form-controls.browser.test.ts",
+  "ui/src/components/sidebar-footer-layout.browser.test.ts",
+  "ui/src/pages/sessions/view.browser.test.ts",
+  "ui/src/styles/corner-shape.browser.test.ts",
+  "ui/src/styles/cursor-policy.browser.test.ts",
+  "ui/src/styles/chat-file-link-presentation.browser.test.ts",
+  "ui/src/styles/chat-github-link-presentation.browser.test.ts",
+  "ui/src/styles/shimmer.browser.test.ts",
+  "ui/src/styles/sr-only.browser.test.ts",
+];
+
+export function isUiBrowserTestFile(relative) {
+  return (
+    isUiTestTarget(relative) &&
+    !/[*?[\]{}]|[@+!]\(/u.test(relative) &&
+    relative.endsWith(".browser.test.ts") &&
+    !uiNodeDrivenBrowserTestFiles.includes(relative)
+  );
+}
+
 export function isUiTestTarget(relative) {
   return (
     relative.startsWith("ui/src/") &&

--- a/test/vitest/vitest.ui.config.ts
+++ b/test/vitest/vitest.ui.config.ts
@@ -4,13 +4,11 @@ import { controlUiLocaleModulesPlugin } from "../../ui/config/control-ui-locales
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 import { jsdomOptimizedDeps } from "./vitest.shared.config.ts";
 import { uiIsolatedTestFiles } from "./vitest.ui-isolated-paths.mjs";
+import { uiNodeDrivenBrowserTestFiles } from "./vitest.ui-paths.mjs";
 
 // Explicit nameable return type: inference reaches vite-internal names (TS4058/TS4082).
-export function createUiVitestConfig(
-  env?: Record<string, string | undefined>,
-  options?: { includePatterns?: string[]; name?: string },
-): ViteUserConfig {
-  const includePatterns = options?.includePatterns ?? ["ui/src/**/*.test.ts"];
+export function createUiVitestConfig(env?: Record<string, string | undefined>): ViteUserConfig {
+  const includePatterns = ["ui/src/**/!(*.browser).test.ts", ...uiNodeDrivenBrowserTestFiles];
   // Isolated files must never enter the shared module graph, including scoped runs.
   const exclude = ["ui/src/**/*.e2e.test.ts", ...uiIsolatedTestFiles];
   const config = createScopedVitestConfig(includePatterns, {
@@ -20,8 +18,9 @@ export function createUiVitestConfig(
     exclude,
     excludeUnitFastTests: false,
     includeOpenClawRuntimeSetup: false,
+    intersectIncludeFile: true,
     isolate: false,
-    name: options?.name ?? "ui",
+    name: "ui",
     setupFiles: ["ui/src/test-helpers/lit-warnings.setup.ts"],
     useNonIsolatedRunner: true,
   });

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,6 +43,7 @@
     "lit": "3.3.3",
     "markdown-it": "15.0.0",
     "markdown-it-task-lists": "2.1.1",
+    "mermaid": "11.17.1",
     "remend": "1.3.0",
     "zod": "4.4.3"
   },

--- a/ui/src/components/markdown-code-blocks.ts
+++ b/ui/src/components/markdown-code-blocks.ts
@@ -208,6 +208,26 @@ class MarkdownCodeBlocksDirective extends AsyncDirective {
   }
 
   private scan(root: Element): void {
+    if (root.querySelector(".markdown-mermaid pre code")) {
+      void import("./markdown-mermaid.ts").then(
+        ({ mountMermaidBlocks }) => {
+          if (
+            this.isConnected &&
+            this.root === root &&
+            root.isConnected &&
+            mountMermaidBlocks(root)
+          ) {
+            this.scheduleScan();
+          }
+        },
+        () => {
+          for (const block of root.querySelectorAll(".markdown-mermaid")) {
+            block.classList.remove("markdown-mermaid");
+            block.prepend(t("chat.mermaid.error"));
+          }
+        },
+      );
+    }
     for (const node of this.observedNodes) {
       if (!root.contains(node)) {
         this.resizeObserver?.unobserve(node);

--- a/ui/src/components/markdown-details.test.ts
+++ b/ui/src/components/markdown-details.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { toSanitizedMarkdownHtml, toStreamingMarkdownHtml } from "./markdown.ts";
+import { toSanitizedMarkdownHtml, toStreamingMarkdownParts } from "./markdown.ts";
 
 function htmlFragment(html: string): DocumentFragment {
   return document.createRange().createContextualFragment(html);
@@ -117,9 +117,9 @@ describe("model-authored details blocks", () => {
   });
 
   it("keeps an unterminated details block in the repaired streaming tail", () => {
-    const html = toStreamingMarkdownHtml(
+    const html = toStreamingMarkdownParts(
       "Intro\n\n<details open>\n<summary>More</summary>\n\n**partial body",
-    );
+    ).join("");
     const fragment = htmlFragment(html);
     const details = fragment.querySelector("details");
 
@@ -133,7 +133,7 @@ describe("model-authored details blocks", () => {
   });
 
   it("repairs an unterminated summary while streaming", () => {
-    const html = toStreamingMarkdownHtml("<details>\n<summary>Still arriving");
+    const html = toStreamingMarkdownParts("<details>\n<summary>Still arriving").join("");
     const fragment = htmlFragment(html);
 
     expect(fragment.querySelector("details summary")?.textContent).toBe("Still arriving");
@@ -141,9 +141,9 @@ describe("model-authored details blocks", () => {
   });
 
   it("keeps completed code fences inside an open details streaming tail", () => {
-    const html = toStreamingMarkdownHtml(
+    const html = toStreamingMarkdownParts(
       "<details>\n<summary>Logs</summary>\n\n~~~ts\nconst value = 1;\n~~~\n\nstill streaming",
-    );
+    ).join("");
     const fragment = htmlFragment(html);
     const details = fragment.querySelector("details");
 
@@ -153,9 +153,9 @@ describe("model-authored details blocks", () => {
   });
 
   it("repairs prose after a closed fence and details block without a blank line", () => {
-    const html = toStreamingMarkdownHtml(
+    const html = toStreamingMarkdownParts(
       "<details>\n<summary>Logs</summary>\n\n```ts\nconst value = 1;\n```\n</details>\ncontinuing **now",
-    );
+    ).join("");
     const fragment = htmlFragment(html);
 
     expect(fragment.querySelector("details code.language-ts")?.textContent).toContain(
@@ -165,9 +165,9 @@ describe("model-authored details blocks", () => {
   });
 
   it("repairs an unterminated summary after a closed fence and details block", () => {
-    const html = toStreamingMarkdownHtml(
+    const html = toStreamingMarkdownParts(
       "<details>\n<summary>Logs</summary>\n\n```ts\nconst value = 1;\n```\n</details>\n<details>\n<summary>Still arriving",
-    );
+    ).join("");
     const details = htmlFragment(html).querySelectorAll("details");
 
     expect(details).toHaveLength(2);
@@ -176,9 +176,9 @@ describe("model-authored details blocks", () => {
   });
 
   it("stabilizes a completed details block before the live markdown tail", () => {
-    const html = toStreamingMarkdownHtml(
+    const html = toStreamingMarkdownParts(
       "<details><summary>Done</summary>fixed</details>\n\ncontinuing **now",
-    );
+    ).join("");
     const fragment = htmlFragment(html);
 
     expect(fragment.querySelector("details summary")?.textContent).toBe("Done");
@@ -187,9 +187,9 @@ describe("model-authored details blocks", () => {
   });
 
   it("keeps a closed disclosure and its continuation in the same list item", () => {
-    const html = toStreamingMarkdownHtml(
+    const html = toStreamingMarkdownParts(
       "- <details>\n  <summary>Logs</summary>\n\n  body\n  </details>\n  continuing **now",
-    );
+    ).join("");
     const fragment = htmlFragment(html);
     const listItem = fragment.querySelector("li");
 
@@ -350,9 +350,9 @@ describe("details line-start contract", () => {
 
   it("keeps an open streaming details block intact across inline code", () => {
     const code = "`literal </details> marker`";
-    const html = toStreamingMarkdownHtml(
+    const html = toStreamingMarkdownParts(
       `<details>\n<summary>Example</summary>\n${code}\n\nstill inside`,
-    );
+    ).join("");
     const fragment = htmlFragment(html);
     const details = fragment.querySelector("details");
 
@@ -385,7 +385,7 @@ describe("details line-start contract", () => {
   });
 
   it("does not repair disclosure-shaped indented code while streaming", () => {
-    const html = toStreamingMarkdownHtml("before\n\n    <details>\n    <summary>literal");
+    const html = toStreamingMarkdownParts("before\n\n    <details>\n    <summary>literal").join("");
     const code = htmlFragment(html).querySelector("code");
 
     expect(code?.textContent).toBe("<details>\n<summary>literal\n");
@@ -393,9 +393,9 @@ describe("details line-start contract", () => {
   });
 
   it("keeps streaming details intact across an inline prose close tag", () => {
-    const html = toStreamingMarkdownHtml(
+    const html = toStreamingMarkdownParts(
       "<details>\n<summary>A</summary>\nliteral </details> text\n\nstill inside",
-    );
+    ).join("");
     const fragment = htmlFragment(html);
     const details = fragment.querySelector("details");
 
@@ -408,7 +408,7 @@ describe("details line-start contract", () => {
     ["list item", "- <details>\n  <summary>A</summary>\n\n  still inside"],
     ["blockquote", "> <details>\n> <summary>A</summary>\n>\n> still inside"],
   ])("keeps streaming details intact inside a %s container", (_name, markdown) => {
-    const html = toStreamingMarkdownHtml(markdown);
+    const html = toStreamingMarkdownParts(markdown).join("");
     const details = htmlFragment(html).querySelector("details");
 
     expect(details?.querySelector("summary")?.textContent).toBe("A");
@@ -417,9 +417,9 @@ describe("details line-start contract", () => {
   });
 
   it("keeps streaming details intact on a wide list continuation indent", () => {
-    const html = toStreamingMarkdownHtml(
+    const html = toStreamingMarkdownParts(
       "1.  item\n    <details>\n    <summary>A</summary>\n\n    still inside",
-    );
+    ).join("");
     const details = htmlFragment(html).querySelector("details");
 
     expect(details?.querySelector("summary")?.textContent).toBe("A");

--- a/ui/src/components/markdown-links.test.ts
+++ b/ui/src/components/markdown-links.test.ts
@@ -1,7 +1,7 @@
 // Control UI tests cover markdown link rendering: autolinking, file links, and link marks.
 import { describe, expect, it, vi } from "vitest";
 import { shortestFileLabels } from "./file-kind.ts";
-import { toSanitizedMarkdownHtml, toStreamingMarkdownHtml } from "./markdown.ts";
+import { toSanitizedMarkdownHtml, toStreamingMarkdownParts } from "./markdown.ts";
 
 function htmlFragment(html: string): HTMLElement {
   const container = document.createElement("div");
@@ -599,9 +599,9 @@ describe("toSanitizedMarkdownHtml links", () => {
 
     it("stays deterministic across streaming tail renders", () => {
       const options = { sessionLinks: true } as const;
-      const first = htmlFragment(toStreamingMarkdownHtml(`Open ${sessionKey}`, options));
+      const first = htmlFragment(toStreamingMarkdownParts(`Open ${sessionKey}`, options).join(""));
       const extended = htmlFragment(
-        toStreamingMarkdownHtml(`Open ${sessionKey} and continue`, options),
+        toStreamingMarkdownParts(`Open ${sessionKey} and continue`, options).join(""),
       );
       expect(first.querySelector<HTMLAnchorElement>("a")?.dataset.sessionKey).toBe(sessionKey);
       expect(extended.querySelector<HTMLAnchorElement>("a")?.dataset.sessionKey).toBe(sessionKey);

--- a/ui/src/components/markdown-mermaid-frame.runtime.js
+++ b/ui/src/components/markdown-mermaid-frame.runtime.js
@@ -48,7 +48,7 @@
     window.removeEventListener("message", initialize);
     const port = event.ports[0];
     let busy = false;
-    port.onmessage = async ({ data: { id, source, config, maxSvgLength, maxSvgElements } }) => {
+    const render = async ({ data: { id, source, config, maxSvgLength, maxSvgElements } }) => {
       if (busy) {
         return;
       }
@@ -109,6 +109,8 @@
         busy = false;
       }
     };
+    port.addEventListener("message", (message) => void render(message));
+    port.start();
     port.postMessage({ type: "ready" });
   };
   window.addEventListener("message", initialize);

--- a/ui/src/components/markdown-mermaid-frame.runtime.js
+++ b/ui/src/components/markdown-mermaid-frame.runtime.js
@@ -1,0 +1,115 @@
+// A classic script is required here: opaque sandbox frames cannot import
+// same-origin ES modules without relaxing the Gateway's asset CORS policy.
+(() => {
+  const mermaid = globalThis.mermaid;
+  const properties = [
+    "fill",
+    "fill-opacity",
+    "fill-rule",
+    "stroke",
+    "stroke-width",
+    "stroke-opacity",
+    "stroke-linecap",
+    "stroke-linejoin",
+    "stroke-dasharray",
+    "stroke-dashoffset",
+    "opacity",
+    "font-family",
+    "font-size",
+    "font-weight",
+    "font-style",
+    "text-anchor",
+    "dominant-baseline",
+    "alignment-baseline",
+    "baseline-shift",
+    "text-decoration",
+    "letter-spacing",
+    "word-spacing",
+    "visibility",
+    "display",
+  ];
+  // Both application scripts are already loaded. Diagram input can now cause
+  // no script, image, stylesheet, font, fetch, or nested-frame network requests.
+  const policy = document.createElement("meta");
+  policy.httpEquiv = "Content-Security-Policy";
+  policy.content =
+    "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'";
+  document.head.append(policy);
+  mermaid.initialize({ startOnLoad: false });
+
+  const initialize = (event) => {
+    if (
+      event.source !== parent ||
+      event.data?.type !== "openclaw:mermaid-init" ||
+      !event.ports[0]
+    ) {
+      return;
+    }
+    window.removeEventListener("message", initialize);
+    const port = event.ports[0];
+    let busy = false;
+    port.onmessage = async ({ data: { id, source, config, maxSvgLength, maxSvgElements } }) => {
+      if (busy) {
+        return;
+      }
+      busy = true;
+      const container = document.createElement("div");
+      document.body.replaceChildren(container);
+      try {
+        // Lock every supported configuration root, including future defaults.
+        // The source may describe diagrams, but cannot change host policy.
+        config.secure = [
+          ...new Set([
+            ...Object.keys(mermaid.mermaidAPI.defaultConfig),
+            ...Object.keys(config),
+            ...config.secure,
+          ]),
+        ];
+        mermaid.initialize(config);
+        const { svg } = await mermaid.render(`mermaid-${id}`, source, container);
+        if (svg.length > maxSvgLength) {
+          throw new Error("Mermaid diagram output is too large.");
+        }
+        container.innerHTML = svg;
+        const root = container.querySelector("svg");
+        if (!root) {
+          throw new Error("Mermaid returned an invalid diagram.");
+        }
+        const elements = [root, ...root.querySelectorAll("*")];
+        if (elements.length > maxSvgElements) {
+          throw new Error("Mermaid diagram contains too many elements.");
+        }
+        // Freeze browser-computed presentation before removing CSS. The parent
+        // can then discard all CSS without parsing untrusted style expressions.
+        const styles = elements.map((element) => {
+          const computed = getComputedStyle(element);
+          return properties.map((property) => [property, computed.getPropertyValue(property)]);
+        });
+        elements.forEach((element, index) => {
+          for (const [property, value] of styles[index]) {
+            if (value) {
+              element.setAttribute(property, value);
+            }
+          }
+          element.removeAttribute("style");
+        });
+        root.querySelectorAll("style").forEach((style) => style.remove());
+        const result = new XMLSerializer().serializeToString(root);
+        if (result.length > maxSvgLength) {
+          throw new Error("Mermaid diagram output is too large.");
+        }
+        port.postMessage({ id, svg: result });
+      } catch (error) {
+        port.postMessage({
+          id,
+          error: String(error instanceof Error ? error.message : error).slice(0, 1_000),
+        });
+      } finally {
+        document.body.replaceChildren();
+        busy = false;
+      }
+    };
+    port.postMessage({ type: "ready" });
+  };
+  window.addEventListener("message", initialize);
+})();

--- a/ui/src/components/markdown-mermaid.runtime.browser.test.ts
+++ b/ui/src/components/markdown-mermaid.runtime.browser.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { renderMermaidSvg, type MermaidTheme } from "./markdown-mermaid.runtime.ts";
+
+const theme: MermaidTheme = {
+  background: "#18181b",
+  foreground: "#fafafa",
+  muted: "#a1a1aa",
+  border: "#52525b",
+  accent: "#f97316",
+  fontFamily: "Arial, sans-serif",
+  darkMode: true,
+};
+
+function parseSvg(svg: string): Element {
+  return new DOMParser().parseFromString(svg, "image/svg+xml").documentElement;
+}
+
+afterEach(() => {
+  window.dispatchEvent(new PageTransitionEvent("pagehide"));
+});
+
+describe("Mermaid rendering boundary", () => {
+  it("renders multiline flowchart labels and both directions as a passive SVG image", async () => {
+    const source = `flowchart LR
+G["Gateway: channels, admission,<br/>approvals and lifecycle"]
+W["Bounded warm executors:<br/>session loops and runtime processing"]
+S["Canonical state owner:<br/>ordered, fenced commits"]
+G <-->|Commands and compact events| W
+W --> S
+G --> S`;
+    const svg = await renderMermaidSvg(source, theme);
+    const root = parseSvg(svg);
+    expect(root.localName).toBe("svg");
+    expect(root.textContent).toContain("Gateway:");
+    expect(root.textContent).toContain("lifecycle");
+    expect(root.textContent).toContain("Commands");
+    expect(root.querySelector("[marker-start]")).not.toBeNull();
+    expect(root.querySelector("[marker-end]")).not.toBeNull();
+    expect(
+      root.querySelector("style,script,a,image,foreignObject,animate,set,[style],[href]"),
+    ).toBeNull();
+    document.body.append(root);
+    try {
+      const gateway = root.querySelector('g[id*="-flowchart-G-"]')!;
+      const box = gateway.querySelector("rect")!.getBoundingClientRect();
+      const label = gateway.querySelector("text")!.getBoundingClientRect();
+      expect(box.height).toBeGreaterThan(0);
+      expect(Math.abs(label.top + label.bottom - box.top - box.bottom)).toBeLessThan(
+        box.height * 0.2,
+      );
+    } finally {
+      root.remove();
+    }
+    const frame = document.querySelector<HTMLIFrameElement>(
+      "iframe[sandbox='allow-scripts'][srcdoc]",
+    );
+    expect(frame).not.toBeNull();
+    expect(frame?.contentDocument).toBeNull();
+    const url = URL.createObjectURL(new Blob([svg], { type: "image/svg+xml" }));
+    try {
+      const image = new Image();
+      image.src = url;
+      await image.decode();
+      expect(image.naturalWidth).toBeGreaterThan(0);
+      expect(image.naturalHeight).toBeGreaterThan(0);
+      const canvas = document.createElement("canvas");
+      canvas.width = 200;
+      canvas.height = 100;
+      const context = canvas.getContext("2d")!;
+      context.drawImage(image, 0, 0, 200, 100);
+      // Exclude antialiasing at fractional SVG viewport edges. The interior
+      // must not let the underlying chat show through expanded labels.
+      const pixels = context.getImageData(1, 1, 198, 98).data;
+      expect(pixels.every((value, index) => index % 4 !== 3 || value === 255)).toBe(true);
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  });
+
+  it("keeps concurrent diagram themes independent in the warm renderer", async () => {
+    const secondTheme = { ...theme, background: "#ffffff", foreground: "#202020", darkMode: false };
+    const results = await Promise.all([
+      renderMermaidSvg("flowchart LR\nA[First] --> B[Diagram]", theme),
+      renderMermaidSvg("flowchart LR\nA[Second] --> B[Diagram]", secondTheme),
+    ]);
+    for (const [index, currentTheme] of [theme, secondTheme].entries()) {
+      const root = parseSvg(results[index]!);
+      const fills = Array.from(root.querySelectorAll("[fill]"), (element) =>
+        element.getAttribute("fill"),
+      );
+      expect(fills).toContain(currentTheme.background);
+      expect(fills).toContain(currentTheme.foreground);
+    }
+  });
+
+  it.each([
+    ["sequence", "sequenceDiagram\nAlice->>Bob: Hello\nBob-->>Alice: Ready", "Alice"],
+    ["class", "classDiagram\nVehicle <|-- Car\nVehicle : +move()", "Vehicle"],
+    ["state", "stateDiagram-v2\n[*] --> Ready\nReady --> Running\nRunning --> [*]", "Running"],
+  ])("preserves %s diagram content in the passive image", async (_name, source, label) => {
+    const root = parseSvg(await renderMermaidSvg(source, theme));
+    expect(root.textContent).toContain(label);
+    expect(root.querySelector("path,rect,line,polygon")).not.toBeNull();
+    expect(root.querySelector("style,script,a,image,foreignObject,[style],[href]")).toBeNull();
+  });
+
+  it("enforces host source and edge limits despite source configuration, then recovers", async () => {
+    await expect(renderMermaidSvg("x".repeat(20_001), theme)).rejects.toThrow(/characters/u);
+    const source = `%%{init: {"maxEdges": 1000}}%%\nflowchart LR\n${Array.from({ length: 201 }, (_, index) => `A${index} --> A${index + 1}`).join("\n")}`;
+    await expect(renderMermaidSvg(source, theme)).rejects.toThrow(/edge/iu);
+    await expect(renderMermaidSvg("flowchart LR\nA -->", theme)).rejects.toThrow();
+    const recovered = parseSvg(
+      await renderMermaidSvg("flowchart LR\nA[Recovered] --> B[Ready]", theme),
+    );
+    expect(recovered.textContent).toContain("Recovered");
+  });
+
+  it("blocks image decoding inside Mermaid before the SVG reaches the host", async () => {
+    const image = btoa(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10"/></svg>',
+    );
+    const source = `flowchart LR\nA@{ img: "data:image/svg+xml;base64,${image}", label: "Image" }`;
+    await expect(renderMermaidSvg(source, theme)).rejects.toThrow();
+  });
+
+  it("keeps source links and CSS inside the sandbox and preserves safe diagram styles", async () => {
+    const config = {
+      securityLevel: "loose",
+      htmlLabels: true,
+      themeCSS:
+        '@import url("https://example.invalid/mermaid.css"); body { opacity: 0 !important; }',
+      dompurifyConfig: { ADD_TAGS: ["script", "image"], ADD_ATTR: ["onload"] },
+    };
+    const source = `%%{init: ${JSON.stringify(config)}}%%
+flowchart LR
+A[Styled] --> B[Link]
+classDef default fill:#ffaa00,color:#112233;
+click A "javascript:alert(1)"
+click B "https://example.invalid/mermaid-link"`;
+    const opacity = getComputedStyle(document.body).opacity;
+    const svg = await renderMermaidSvg(source, theme);
+    const root = parseSvg(svg);
+    expect(root.textContent).toContain("Styled");
+    expect(root.querySelector('[fill="#ffaa00"]')).not.toBeNull();
+    expect(
+      root.querySelector("style,script,a,image,foreignObject,[style],[href],[onload]"),
+    ).toBeNull();
+    expect(svg).not.toContain("example.invalid");
+    expect(svg).not.toContain("javascript:");
+    expect(getComputedStyle(document.body).opacity).toBe(opacity);
+
+    // Class diagrams accept CSS functions; flowchart classDef grammar rejects them.
+    const remote = await renderMermaidSvg(
+      "classDiagram\nclass Remote:::remote\nclassDef remote fill:url(https://example.invalid/mermaid-paint.svg#paint)",
+      theme,
+    );
+    expect(parseSvg(remote).textContent).toContain("Remote");
+    expect(remote).not.toContain("example.invalid");
+  });
+});

--- a/ui/src/components/markdown-mermaid.runtime.ts
+++ b/ui/src/components/markdown-mermaid.runtime.ts
@@ -1,0 +1,353 @@
+import { asRecord } from "@openclaw/normalization-core/record-coerce";
+import createDOMPurify from "dompurify";
+import type { MermaidConfig } from "mermaid";
+import mermaidScriptUrl from "mermaid/dist/mermaid.min.js?url";
+import frameScriptUrl from "./markdown-mermaid-frame.runtime.js?url&no-inline";
+import { escapeMarkdownHtml } from "./markdown-text.ts";
+
+export type MermaidTheme = {
+  background: string;
+  foreground: string;
+  muted: string;
+  border: string;
+  accent: string;
+  fontFamily: string;
+  darkMode: boolean;
+};
+
+const MAX_SOURCE_LENGTH = 20_000;
+const MAX_EDGES = 200;
+const MAX_SVG_LENGTH = 1_000_000;
+const MAX_SVG_ELEMENTS = 5_000;
+const RENDER_TIMEOUT_MS = 15_000;
+const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+const LOCAL_REFERENCE = /^url\(["']?(#[^\s"'()]+)["']?\)$/u;
+const SVG_TAGS = [
+  "svg",
+  "g",
+  "defs",
+  "marker",
+  "path",
+  "rect",
+  "circle",
+  "ellipse",
+  "polygon",
+  "polyline",
+  "line",
+  "text",
+  "tspan",
+  "title",
+  "desc",
+  "clipPath",
+  "mask",
+  "linearGradient",
+  "radialGradient",
+  "stop",
+  "pattern",
+];
+const SVG_ATTRIBUTES = [
+  "id",
+  "xmlns",
+  "viewBox",
+  "width",
+  "height",
+  "x",
+  "y",
+  "dx",
+  "dy",
+  "x1",
+  "y1",
+  "x2",
+  "y2",
+  "cx",
+  "cy",
+  "r",
+  "rx",
+  "ry",
+  "d",
+  "points",
+  "transform",
+  "preserveAspectRatio",
+  "fill",
+  "fill-opacity",
+  "fill-rule",
+  "stroke",
+  "stroke-width",
+  "stroke-opacity",
+  "stroke-linecap",
+  "stroke-linejoin",
+  "stroke-dasharray",
+  "stroke-dashoffset",
+  "opacity",
+  "font-family",
+  "font-size",
+  "font-weight",
+  "font-style",
+  "text-anchor",
+  "dominant-baseline",
+  "alignment-baseline",
+  "baseline-shift",
+  "text-decoration",
+  "letter-spacing",
+  "word-spacing",
+  "visibility",
+  "display",
+  "markerWidth",
+  "markerHeight",
+  "refX",
+  "refY",
+  "orient",
+  "markerUnits",
+  "marker-start",
+  "marker-mid",
+  "marker-end",
+  "clip-path",
+  "mask",
+  "gradientUnits",
+  "gradientTransform",
+  "offset",
+  "stop-color",
+  "stop-opacity",
+  "patternUnits",
+  "patternContentUnits",
+  "patternTransform",
+  "role",
+];
+
+type MermaidFrame = {
+  frame: HTMLIFrameElement;
+  ready: Promise<void>;
+  render: (source: string, config: MermaidConfig) => Promise<string>;
+  dispose: (error: Error) => void;
+};
+
+let renderer: MermaidFrame | undefined;
+let renderQueue = Promise.resolve();
+
+function sanitizeMermaidSvg(source: string, backgroundColor: string): string {
+  if (source.length > MAX_SVG_LENGTH) {
+    throw new Error("Mermaid diagram output is too large.");
+  }
+  // This instance must not inherit the generic Markdown sanitizer's link hooks.
+  const purifier = createDOMPurify(window);
+  const fragment = purifier.sanitize(source, {
+    ALLOWED_TAGS: SVG_TAGS,
+    ALLOWED_ATTR: SVG_ATTRIBUTES,
+    ALLOW_DATA_ATTR: false,
+    ALLOW_ARIA_ATTR: true,
+    RETURN_DOM_FRAGMENT: true,
+  });
+  const svg = fragment.firstElementChild;
+  if (fragment.childElementCount !== 1 || !(svg instanceof SVGSVGElement)) {
+    throw new Error("Mermaid returned an invalid diagram.");
+  }
+  const elements = [svg, ...svg.querySelectorAll("*")];
+  if (elements.length > MAX_SVG_ELEMENTS) {
+    throw new Error("Mermaid diagram contains too many elements.");
+  }
+  const colorParser = document.createElement("canvas").getContext("2d");
+  if (!colorParser) {
+    throw new Error("Mermaid diagram colors could not be prepared.");
+  }
+  for (const element of elements) {
+    for (const attribute of ["marker-start", "marker-mid", "marker-end", "clip-path", "mask"]) {
+      const value = element.getAttribute(attribute);
+      if (value && value !== "none" && !LOCAL_REFERENCE.test(value)) {
+        element.removeAttribute(attribute);
+      }
+    }
+    for (const attribute of ["fill", "stroke", "stop-color"]) {
+      const value = element.getAttribute(attribute);
+      if (!value || value === "none" || LOCAL_REFERENCE.test(value)) {
+        continue;
+      }
+      // Canvas accepts CSS colors, never paint URLs or unresolved CSS variables.
+      colorParser.fillStyle = "#000000";
+      colorParser.fillStyle = value;
+      element.setAttribute(attribute, String(colorParser.fillStyle));
+    }
+  }
+  svg.setAttribute("xmlns", SVG_NAMESPACE);
+  // The image also opens over the lightbox backdrop. Paint its own theme
+  // background so labels and edges stay readable outside the chat card.
+  const background = document.createElementNS(SVG_NAMESPACE, "rect");
+  const bounds = svg.viewBox.baseVal;
+  background.setAttribute("x", String(bounds.x));
+  background.setAttribute("y", String(bounds.y));
+  background.setAttribute("width", "100%");
+  background.setAttribute("height", "100%");
+  colorParser.fillStyle = backgroundColor;
+  background.setAttribute("fill", String(colorParser.fillStyle));
+  svg.prepend(background);
+  return new XMLSerializer().serializeToString(svg);
+}
+
+function createMermaidFrame(): MermaidFrame {
+  const frame = document.createElement("iframe");
+  const channel = new MessageChannel();
+  let readyResolve: () => void;
+  let readyReject: (error: Error) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    readyResolve = resolve;
+    readyReject = reject;
+  });
+  let pending:
+    | {
+        id: number;
+        resolve: (svg: string) => void;
+        reject: (error: Error) => void;
+      }
+    | undefined;
+  let nextId = 0;
+  let initialized = false;
+  let loaded = false;
+  let disposed = false;
+  let timeout: number;
+  const instance: MermaidFrame = {
+    frame,
+    ready,
+    dispose(error) {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      window.clearTimeout(timeout);
+      channel.port1.close();
+      channel.port2.close();
+      frame.remove();
+      readyReject(error);
+      pending?.reject(error);
+      pending = undefined;
+      if (renderer === instance) {
+        renderer = undefined;
+      }
+    },
+    render(source, config) {
+      if (disposed || !frame.isConnected) {
+        return Promise.reject(new Error("Mermaid renderer is unavailable."));
+      }
+      return new Promise((resolve, reject) => {
+        const id = ++nextId;
+        pending = { id, resolve, reject };
+        timeout = window.setTimeout(
+          () => instance.dispose(new Error("Mermaid diagram rendering timed out.")),
+          RENDER_TIMEOUT_MS,
+        );
+        channel.port1.postMessage({
+          id,
+          source,
+          config,
+          maxSvgLength: MAX_SVG_LENGTH,
+          maxSvgElements: MAX_SVG_ELEMENTS,
+        });
+      });
+    },
+  };
+  channel.port1.onmessage = (event: MessageEvent<unknown>) => {
+    if (disposed || !frame.isConnected) {
+      return;
+    }
+    const result = asRecord(event.data);
+    if (!initialized && result.type === "ready") {
+      initialized = true;
+      window.clearTimeout(timeout);
+      readyResolve();
+      return;
+    }
+    const request = pending;
+    if (!initialized || !request || result.id !== request.id) {
+      return;
+    }
+    pending = undefined;
+    window.clearTimeout(timeout);
+    if (typeof result.error === "string") {
+      request.reject(new Error(result.error.slice(0, 1_000)));
+    } else if (typeof result.svg === "string" && result.svg.length <= MAX_SVG_LENGTH) {
+      request.resolve(result.svg);
+    } else {
+      request.reject(new Error("Mermaid returned an invalid diagram."));
+    }
+  };
+  frame.addEventListener("load", () => {
+    if (loaded) {
+      instance.dispose(new Error("Mermaid renderer navigated unexpectedly."));
+      return;
+    }
+    loaded = true;
+    // The frame has an opaque origin. Only this exact window receives the port;
+    // all subsequent diagram data travels on that private channel.
+    frame.contentWindow?.postMessage({ type: "openclaw:mermaid-init" }, "*", [channel.port2]);
+  });
+  frame.setAttribute("sandbox", "allow-scripts");
+  frame.setAttribute("aria-hidden", "true");
+  frame.tabIndex = -1;
+  frame.inert = true;
+  frame.referrerPolicy = "no-referrer";
+  frame.style.cssText =
+    "position:fixed;left:-10000px;top:0;width:1024px;height:768px;border:0;visibility:hidden;pointer-events:none";
+  const scripts = [mermaidScriptUrl, frameScriptUrl].map((url) => new URL(url, location.href).href);
+  const policy = `default-src 'none'; script-src ${scripts.join(" ")}; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'`;
+  frame.srcdoc = `<!doctype html><html><head><meta http-equiv="Content-Security-Policy" content="${escapeMarkdownHtml(policy)}">${scripts.map((url) => `<script src="${escapeMarkdownHtml(url)}"></script>`).join("")}</head><body></body></html>`;
+  timeout = window.setTimeout(
+    () => instance.dispose(new Error("Mermaid renderer could not be loaded.")),
+    RENDER_TIMEOUT_MS,
+  );
+  document.body.append(frame);
+  return instance;
+}
+
+export function renderMermaidSvg(source: string, theme: MermaidTheme): Promise<string> {
+  if (!source.trim() || source.length > MAX_SOURCE_LENGTH) {
+    return Promise.reject(
+      new Error(`Mermaid diagrams must contain 1–${MAX_SOURCE_LENGTH} characters.`),
+    );
+  }
+  // Mermaid's initialization and rendering share global config. Keep them in
+  // one serialized owner, including after a failed render or a theme change.
+  const result = renderQueue.then(async () => {
+    if (renderer && !renderer.frame.isConnected) {
+      renderer.dispose(new Error("Mermaid renderer was removed."));
+    }
+    renderer ??= createMermaidFrame();
+    const active = renderer;
+    try {
+      await active.ready;
+      const config: MermaidConfig = {
+        startOnLoad: false,
+        securityLevel: "strict",
+        secure: ["dompurifyConfig"],
+        htmlLabels: false,
+        suppressErrorRendering: true,
+        maxTextSize: MAX_SOURCE_LENGTH,
+        maxEdges: MAX_EDGES,
+        arrowMarkerAbsolute: false,
+        theme: "base",
+        themeCSS: "",
+        fontFamily: theme.fontFamily,
+        themeVariables: {
+          darkMode: theme.darkMode,
+          background: theme.background,
+          primaryColor: theme.background,
+          primaryTextColor: theme.foreground,
+          primaryBorderColor: theme.border,
+          lineColor: theme.muted,
+          secondaryColor: theme.accent,
+          tertiaryColor: theme.background,
+          textColor: theme.foreground,
+          edgeLabelBackground: theme.background,
+        },
+      };
+      return sanitizeMermaidSvg(await active.render(source, config), theme.background);
+    } catch (error) {
+      active.dispose(error instanceof Error ? error : new Error(String(error)));
+      throw error;
+    }
+  });
+  renderQueue = result.then(
+    () => {},
+    () => {},
+  );
+  return result;
+}
+
+window.addEventListener("pagehide", () => renderer?.dispose(new Error("Mermaid renderer closed.")));

--- a/ui/src/components/markdown-mermaid.runtime.ts
+++ b/ui/src/components/markdown-mermaid.runtime.ts
@@ -164,7 +164,7 @@ function sanitizeMermaidSvg(source: string, backgroundColor: string): string {
       // Canvas accepts CSS colors, never paint URLs or unresolved CSS variables.
       colorParser.fillStyle = "#000000";
       colorParser.fillStyle = value;
-      element.setAttribute(attribute, String(colorParser.fillStyle));
+      element.setAttribute(attribute, colorParser.fillStyle);
     }
   }
   svg.setAttribute("xmlns", SVG_NAMESPACE);
@@ -177,7 +177,7 @@ function sanitizeMermaidSvg(source: string, backgroundColor: string): string {
   background.setAttribute("width", "100%");
   background.setAttribute("height", "100%");
   colorParser.fillStyle = backgroundColor;
-  background.setAttribute("fill", String(colorParser.fillStyle));
+  background.setAttribute("fill", colorParser.fillStyle);
   svg.prepend(background);
   return new XMLSerializer().serializeToString(svg);
 }
@@ -243,7 +243,7 @@ function createMermaidFrame(): MermaidFrame {
       });
     },
   };
-  channel.port1.onmessage = (event: MessageEvent<unknown>) => {
+  channel.port1.addEventListener("message", (event: MessageEvent<unknown>) => {
     if (disposed || !frame.isConnected) {
       return;
     }
@@ -267,7 +267,8 @@ function createMermaidFrame(): MermaidFrame {
     } else {
       request.reject(new Error("Mermaid returned an invalid diagram."));
     }
-  };
+  });
+  channel.port1.start();
   frame.addEventListener("load", () => {
     if (loaded) {
       instance.dispose(new Error("Mermaid renderer navigated unexpectedly."));

--- a/ui/src/components/markdown-mermaid.test.ts
+++ b/ui/src/components/markdown-mermaid.test.ts
@@ -1,0 +1,263 @@
+/* @vitest-environment jsdom */
+
+import { html, nothing, render } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { copyToClipboard } from "../lib/clipboard.ts";
+import { renderMermaidSvg } from "./markdown-mermaid.runtime.ts";
+import { mountMermaidBlocks } from "./markdown-mermaid.ts";
+import { toSanitizedMarkdownHtml } from "./markdown.ts";
+
+vi.mock("./markdown-mermaid.runtime.ts", () => ({ renderMermaidSvg: vi.fn() }));
+vi.mock("../lib/clipboard.ts", () => ({ copyToClipboard: vi.fn() }));
+
+type MermaidElement = HTMLElementTagNameMap["openclaw-mermaid"];
+const svg = '<svg xmlns="http://www.w3.org/2000/svg"><text>Rendered diagram</text></svg>';
+const renderSvg = vi.mocked(renderMermaidSvg);
+const copySource = vi.mocked(copyToClipboard);
+const containers = new Set<HTMLElement>();
+let sourceSequence = 0;
+let originalThemeMode: string | null;
+let originalStyle: string | null;
+let createObjectURL: ReturnType<typeof vi.fn<(blob: Blob | MediaSource) => string>>;
+let revokeObjectURL: ReturnType<typeof vi.fn<(url: string) => void>>;
+
+function source(label: string): string {
+  return `flowchart LR\n  A["${label} ${++sourceSequence}"] --> B\n`;
+}
+
+async function mount(...sources: string[]) {
+  const container = document.body.appendChild(document.createElement("div"));
+  containers.add(container);
+  const markdown = sources.map((value) => `\`\`\`mermaid\n${value}\`\`\``).join("\n\n");
+  render(html`${unsafeHTML(toSanitizedMarkdownHtml(markdown))}`, container);
+  mountMermaidBlocks(container);
+  const elements = [...container.querySelectorAll("openclaw-mermaid")];
+  expect(elements).toHaveLength(sources.length);
+  await Promise.all(elements.map((element) => element.updateComplete));
+  return { container, elements };
+}
+
+function button(element: MermaidElement, label: string): HTMLButtonElement {
+  const match = [...(element.shadowRoot?.querySelectorAll("button") ?? [])].find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
+  if (!match) {
+    throw new Error(`Missing Mermaid action: ${label}`);
+  }
+  return match;
+}
+
+function imageSource(element: MermaidElement): string | null | undefined {
+  return element.shadowRoot?.querySelector("img")?.getAttribute("src");
+}
+
+async function waitForImage(element: MermaidElement): Promise<string> {
+  await vi.waitFor(() => expect(imageSource(element)).toMatch(/^blob:mermaid-/u));
+  return imageSource(element)!;
+}
+
+beforeEach(() => {
+  renderSvg.mockReset().mockResolvedValue(svg);
+  copySource.mockReset().mockResolvedValue(true);
+  let urlSequence = 0;
+  createObjectURL = vi.fn(() => `blob:mermaid-${++urlSequence}`);
+  revokeObjectURL = vi.fn();
+  const NativeURL = URL;
+  vi.stubGlobal(
+    "URL",
+    class extends NativeURL {
+      static override createObjectURL = createObjectURL;
+      static override revokeObjectURL = revokeObjectURL;
+    },
+  );
+  const root = document.documentElement;
+  originalThemeMode = root.getAttribute("data-theme-mode");
+  originalStyle = root.getAttribute("style");
+  root.dataset.themeMode = "light";
+  for (const property of ["--card", "--text", "--muted", "--border", "--accent"]) {
+    root.style.setProperty(property, "#123456");
+  }
+});
+
+afterEach(() => {
+  for (const container of containers) {
+    render(nothing, container);
+    container.remove();
+  }
+  containers.clear();
+  for (const [attribute, value] of [
+    ["data-theme-mode", originalThemeMode],
+    ["style", originalStyle],
+  ] as const) {
+    if (value === null) {
+      document.documentElement.removeAttribute(attribute);
+    } else {
+      document.documentElement.setAttribute(attribute, value);
+    }
+  }
+  vi.unstubAllGlobals();
+});
+
+describe("Mermaid Markdown presentation", () => {
+  it("preserves the exact source when switching views and copying", async () => {
+    const original = source("x < y & z <script>alert(1)</script>");
+    const {
+      elements: [element],
+    } = await mount(original);
+    const imageUrl = await waitForImage(element!);
+
+    expect(renderSvg).toHaveBeenCalledWith(original, expect.objectContaining({ darkMode: false }));
+    expect(button(element!, "Expand diagram").disabled).toBe(false);
+    button(element!, "Source").click();
+    await element!.updateComplete;
+    expect(element!.shadowRoot?.querySelector("code")?.textContent).toBe(original);
+    expect(element!.shadowRoot?.querySelector("script, img")).toBeNull();
+    button(element!, "Copy source").click();
+    await vi.waitFor(() => expect(button(element!, "Copied!")).toBeDefined());
+    expect(copySource).toHaveBeenCalledExactlyOnceWith(original);
+
+    button(element!, "Diagram").click();
+    await element!.updateComplete;
+    expect(imageSource(element!)).toBe(imageUrl);
+    expect(renderSvg).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["layout", "image"])(
+    "keeps %s failures readable and copyable outside an image",
+    async (failure) => {
+      if (failure === "layout") {
+        renderSvg.mockRejectedValueOnce(new Error("<script>internal parser detail</script>"));
+      }
+      const original = source("Invalid diagram");
+      const {
+        elements: [element],
+      } = await mount(original);
+      if (failure === "image") {
+        await waitForImage(element!);
+        element!.shadowRoot?.querySelector("img")?.dispatchEvent(new Event("error"));
+      }
+
+      await vi.waitFor(() =>
+        expect(element!.shadowRoot?.querySelector('[role="status"]')?.textContent).toContain(
+          "Check the source or simplify the diagram",
+        ),
+      );
+      expect(element!.shadowRoot?.querySelector("code")?.textContent).toBe(original);
+      expect(element!.shadowRoot?.querySelector("img, script")).toBeNull();
+      expect(element!.shadowRoot?.textContent).not.toContain("internal parser detail");
+      expect(button(element!, "Expand diagram").disabled).toBe(true);
+      button(element!, "Copy source").click();
+      await vi.waitFor(() => expect(copySource).toHaveBeenCalledExactlyOnceWith(original));
+      if (failure === "image") {
+        expect(revokeObjectURL).toHaveBeenCalledExactlyOnceWith("blob:mermaid-1");
+      } else {
+        expect(createObjectURL).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it.each([
+    { change: "source", oldOutcome: "success" },
+    { change: "source", oldOutcome: "failure" },
+    { change: "theme", oldOutcome: "success" },
+    { change: "theme", oldOutcome: "failure" },
+  ])("ignores a stale $oldOutcome after a $change change", async ({ change, oldOutcome }) => {
+    const old = createDeferred<string>();
+    const current = createDeferred<string>();
+    renderSvg.mockReturnValueOnce(old.promise).mockReturnValueOnce(current.promise);
+    const {
+      elements: [element],
+    } = await mount(source("Old diagram"));
+    expect(renderSvg).toHaveBeenCalledTimes(1);
+    if (change === "source") {
+      element!.source = source("Current diagram");
+    } else {
+      document.documentElement.dataset.themeMode = "dark";
+    }
+    await vi.waitFor(() => expect(renderSvg).toHaveBeenCalledTimes(2));
+    if (change === "theme") {
+      expect(renderSvg.mock.calls[1]?.[1].darkMode).toBe(true);
+    }
+    current.resolve(svg);
+    const imageUrl = await waitForImage(element!);
+    if (oldOutcome === "success") {
+      old.resolve(svg);
+    } else {
+      old.reject(new Error("Stale failure"));
+    }
+    await old.promise.catch(() => {});
+    await element!.updateComplete;
+
+    expect(imageSource(element!)).toBe(imageUrl);
+    expect(element!.shadowRoot?.querySelector('[role="status"]')).toBeNull();
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])(
+    "releases URLs across reconnect with disconnect before render=%s",
+    async (disconnectBeforeRender) => {
+      const pending = createDeferred<string>();
+      renderSvg.mockReturnValueOnce(pending.promise);
+      const {
+        container,
+        elements: [element],
+      } = await mount(source("Reconnected diagram"));
+      if (!disconnectBeforeRender) {
+        pending.resolve(svg);
+        await waitForImage(element!);
+      }
+      element!.remove();
+      if (disconnectBeforeRender) {
+        pending.resolve(svg);
+        await pending.promise;
+        expect(createObjectURL).not.toHaveBeenCalled();
+      } else {
+        expect(revokeObjectURL).toHaveBeenCalledExactlyOnceWith("blob:mermaid-1");
+      }
+
+      container.append(element!);
+      const reconnectedUrl = disconnectBeforeRender ? "blob:mermaid-1" : "blob:mermaid-2";
+      await vi.waitFor(() => expect(imageSource(element!)).toBe(reconnectedUrl));
+      expect(renderSvg).toHaveBeenCalledTimes(1);
+      expect(createObjectURL).toHaveBeenCalledTimes(disconnectBeforeRender ? 1 : 2);
+      element!.remove();
+      expect(revokeObjectURL).toHaveBeenCalledWith(reconnectedUrl);
+      expect(revokeObjectURL).toHaveBeenCalledTimes(createObjectURL.mock.calls.length);
+    },
+  );
+
+  it("shares concurrent layout work while each displayed diagram owns its URL", async () => {
+    const pending = createDeferred<string>();
+    renderSvg.mockReturnValueOnce(pending.promise);
+    const original = source("Shared layout");
+    const { elements } = await mount(original, original);
+    expect(renderSvg).toHaveBeenCalledTimes(1);
+    pending.resolve(svg);
+    const [firstUrl, secondUrl] = await Promise.all(elements.map(waitForImage));
+    expect(firstUrl).not.toBe(secondUrl);
+
+    elements[0]!.remove();
+    expect(revokeObjectURL).toHaveBeenCalledExactlyOnceWith(firstUrl);
+    expect(imageSource(elements[1]!)).toBe(secondUrl);
+    expect(revokeObjectURL).not.toHaveBeenCalledWith(secondUrl);
+  });
+
+  it("evicts older layouts under sustained use without revoking visible images", async () => {
+    const sources = Array.from({ length: 20 }, (_, index) => source(`Diagram ${index}`));
+    const { elements } = await mount(...sources);
+    const originalUrls = await Promise.all(elements.map(waitForImage));
+    expect(renderSvg).toHaveBeenCalledTimes(sources.length);
+
+    const recent = await mount(sources.at(-1)!);
+    await waitForImage(recent.elements[0]!);
+    expect(renderSvg).toHaveBeenCalledTimes(sources.length);
+    const oldest = await mount(sources[0]!);
+    await waitForImage(oldest.elements[0]!);
+    expect(renderSvg).toHaveBeenCalledTimes(sources.length + 1);
+    expect(elements.map(imageSource)).toEqual(originalUrls);
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/markdown-mermaid.test.ts
+++ b/ui/src/components/markdown-mermaid.test.ts
@@ -39,9 +39,13 @@ async function mount(...sources: string[]) {
   return { container, elements };
 }
 
-function button(element: MermaidElement, label: string): HTMLButtonElement {
-  const match = [...(element.shadowRoot?.querySelectorAll("button") ?? [])].find(
-    (candidate) => candidate.textContent?.trim() === label,
+function action(element: MermaidElement, label: string) {
+  const controls = element.shadowRoot?.querySelectorAll<
+    HTMLButtonElement | HTMLElementTagNameMap["wa-dropdown-item"]
+  >("button, wa-dropdown-item");
+  const match = [...(controls ?? [])].find(
+    (candidate) =>
+      (candidate.getAttribute("aria-label") ?? candidate.textContent?.trim()) === label,
   );
   if (!match) {
     throw new Error(`Missing Mermaid action: ${label}`);
@@ -101,7 +105,8 @@ afterEach(() => {
 });
 
 describe("Mermaid Markdown presentation", () => {
-  it("preserves the exact source when switching views and copying", async () => {
+  it.each([true, false])("preserves source and reports copy success=%s", async (copied) => {
+    copySource.mockResolvedValueOnce(copied);
     const original = source("x < y & z <script>alert(1)</script>");
     const {
       elements: [element],
@@ -109,16 +114,18 @@ describe("Mermaid Markdown presentation", () => {
     const imageUrl = await waitForImage(element!);
 
     expect(renderSvg).toHaveBeenCalledWith(original, expect.objectContaining({ darkMode: false }));
-    expect(button(element!, "Expand diagram").disabled).toBe(false);
-    button(element!, "Source").click();
+    expect(action(element!, "Expand diagram").disabled).toBe(false);
+    action(element!, "Show source").click();
     await element!.updateComplete;
     expect(element!.shadowRoot?.querySelector("code")?.textContent).toBe(original);
     expect(element!.shadowRoot?.querySelector("script, img")).toBeNull();
-    button(element!, "Copy source").click();
-    await vi.waitFor(() => expect(button(element!, "Copied!")).toBeDefined());
+    action(element!, "Copy source").click();
+    await vi.waitFor(() =>
+      expect(action(element!, copied ? "Copied!" : "Copy failed")).toBeDefined(),
+    );
     expect(copySource).toHaveBeenCalledExactlyOnceWith(original);
 
-    button(element!, "Diagram").click();
+    action(element!, "Show diagram").click();
     await element!.updateComplete;
     expect(imageSource(element!)).toBe(imageUrl);
     expect(renderSvg).toHaveBeenCalledTimes(1);
@@ -147,8 +154,8 @@ describe("Mermaid Markdown presentation", () => {
       expect(element!.shadowRoot?.querySelector("code")?.textContent).toBe(original);
       expect(element!.shadowRoot?.querySelector("img, script")).toBeNull();
       expect(element!.shadowRoot?.textContent).not.toContain("internal parser detail");
-      expect(button(element!, "Expand diagram").disabled).toBe(true);
-      button(element!, "Copy source").click();
+      expect(action(element!, "Expand diagram").disabled).toBe(true);
+      action(element!, "Copy source").click();
       await vi.waitFor(() => expect(copySource).toHaveBeenCalledExactlyOnceWith(original));
       if (failure === "image") {
         expect(revokeObjectURL).toHaveBeenCalledExactlyOnceWith("blob:mermaid-1");

--- a/ui/src/components/markdown-mermaid.ts
+++ b/ui/src/components/markdown-mermaid.ts
@@ -240,7 +240,7 @@ class OpenClawMermaid extends OpenClawLitElement {
           ${t("chat.mermaid.source")}
         </button>
         <span class="spacer"></span>
-        <button type="button" @click=${this.copySource}>
+        <button type="button" @click=${() => void this.copySource()}>
           ${t(
             this.copyResult === undefined
               ? "chat.mermaid.copySource"

--- a/ui/src/components/markdown-mermaid.ts
+++ b/ui/src/components/markdown-mermaid.ts
@@ -4,8 +4,10 @@ import { t } from "../i18n/index.ts";
 import { copyToClipboard } from "../lib/clipboard.ts";
 import { resolveThemeColor } from "../lib/theme-color.ts";
 import { OpenClawLitElement } from "../lit/openclaw-element.ts";
+import { icons } from "./icons.ts";
 import { renderMermaidSvg, type MermaidTheme } from "./markdown-mermaid.runtime.ts";
 import "./image-lightbox.ts";
+import "./web-awesome.ts";
 
 const CACHE_LIMIT = 16;
 const diagrams = new Map<string, Promise<string>>();
@@ -60,6 +62,7 @@ class OpenClawMermaid extends OpenClawLitElement {
   static override styles = css`
     :host {
       display: block;
+      position: relative;
       min-width: 0;
       margin: 12px 0;
       border: 1px solid var(--border);
@@ -69,30 +72,31 @@ class OpenClawMermaid extends OpenClawLitElement {
       color: var(--text);
       font-family: var(--font-body);
     }
-    .toolbar {
+    .actions {
+      position: absolute;
+      inset-block-start: 6px;
+      inset-inline-end: 6px;
+      z-index: 1;
       display: flex;
       align-items: center;
-      flex-wrap: wrap;
-      gap: 4px;
-      padding: 6px 8px;
-      border-bottom: 1px solid var(--border);
-    }
-    .spacer {
-      flex: 1;
+      gap: 2px;
     }
     button {
-      padding: 5px 8px;
-      min-height: 32px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      padding: 0;
       border: 0;
       border-radius: var(--radius-sm, 6px);
       background: transparent;
       color: var(--muted);
       font: inherit;
-      font-size: 12px;
       cursor: default;
     }
     button:hover,
-    button[aria-pressed="true"] {
+    button[aria-expanded="true"] {
       background: var(--bg-hover);
       color: var(--text);
     }
@@ -100,12 +104,49 @@ class OpenClawMermaid extends OpenClawLitElement {
       outline: 2px solid var(--accent);
       outline-offset: -2px;
     }
-    button:disabled {
-      opacity: 0.5;
+    button svg {
+      width: 15px;
+      height: 15px;
+    }
+    .copy-button {
+      opacity: 0;
+      pointer-events: none;
+    }
+    :host(:hover) .copy-button,
+    :host(:focus-within) .copy-button {
+      opacity: 1;
+      pointer-events: auto;
+    }
+    .copy-feedback {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+      clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    wa-dropdown::part(menu) {
+      min-width: 160px;
+      padding: var(--menu-padding);
+      border: 1px solid var(--overlay-border);
+      border-radius: var(--menu-radius);
+      background: var(--bg-elevated);
+      box-shadow: var(--overlay-shadow);
+    }
+    wa-dropdown-item {
+      min-height: var(--menu-item-height);
+      padding: 0 8px;
+      border-radius: var(--menu-item-radius);
+      color: var(--text);
+      font: 12px var(--font-body);
       cursor: default;
     }
+    wa-dropdown-item:hover,
+    wa-dropdown-item:focus-visible {
+      background: var(--bg-hover);
+    }
     .preview {
-      padding: 16px;
+      padding: 36px 16px 16px;
       overflow: auto;
     }
     img {
@@ -116,7 +157,7 @@ class OpenClawMermaid extends OpenClawLitElement {
     }
     pre {
       margin: 0;
-      padding: 16px;
+      padding: 36px 16px 16px;
       overflow: auto;
       max-height: 480px;
       font: 12px/1.6 var(--font-mono, monospace);
@@ -124,16 +165,23 @@ class OpenClawMermaid extends OpenClawLitElement {
     }
     .status {
       margin: 0;
-      padding: 12px 16px;
+      padding: 36px 16px 12px;
       font-size: 12px;
       color: var(--muted);
     }
-    @media (max-width: 640px) {
+    @media (hover: none), (pointer: coarse) {
       button {
-        min-height: 40px;
+        width: 36px;
+        height: 36px;
       }
-      .preview {
-        padding: 8px;
+      .copy-button {
+        opacity: 1;
+        pointer-events: auto;
+      }
+      .preview,
+      pre,
+      .status {
+        padding-top: 44px;
       }
     }
   `;
@@ -219,46 +267,65 @@ class OpenClawMermaid extends OpenClawLitElement {
 
   override render() {
     const sourceVisible = this.showSource || this.failed;
+    const copyLabel = t(
+      this.copyResult === undefined
+        ? "chat.mermaid.copySource"
+        : this.copyResult
+          ? "common.copied"
+          : "common.copyFailed",
+    );
     return html`
-      <div class="toolbar" role="group" aria-label=${t("chat.mermaid.title")}>
+      <div class="actions">
         <button
+          class="copy-button"
           type="button"
-          aria-pressed=${!this.showSource}
-          @click=${() => {
-            this.showSource = false;
-          }}
+          aria-label=${copyLabel}
+          title=${copyLabel}
+          @click=${() => void this.copySource()}
         >
-          ${t("chat.mermaid.diagram")}
-        </button>
-        <button
-          type="button"
-          aria-pressed=${this.showSource}
-          @click=${() => {
-            this.showSource = true;
-          }}
-        >
-          ${t("chat.mermaid.source")}
-        </button>
-        <span class="spacer"></span>
-        <button type="button" @click=${() => void this.copySource()}>
-          ${t(
-            this.copyResult === undefined
-              ? "chat.mermaid.copySource"
+          <span aria-hidden="true"
+            >${this.copyResult === undefined
+              ? icons.copy
               : this.copyResult
-                ? "common.copied"
-                : "common.copyFailed",
-          )}
+                ? icons.check
+                : icons.x}</span
+          >
         </button>
-        <button
-          type="button"
-          ?disabled=${!this.imageUrl}
-          @click=${() => {
-            this.expanded = true;
+        <wa-dropdown
+          placement="bottom-end"
+          size="s"
+          .distance=${4}
+          aria-label=${t("chat.mermaid.options")}
+          @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+            const action = event.detail.item.value;
+            if (action === "expand") {
+              this.expanded = true;
+            } else if (action === "source" || action === "diagram") {
+              this.showSource = action === "source";
+            }
           }}
         >
-          ${t("chat.mermaid.expand")}
-        </button>
+          <button
+            slot="trigger"
+            type="button"
+            aria-label=${t("chat.mermaid.options")}
+            title=${t("chat.mermaid.options")}
+          >
+            <span aria-hidden="true">${icons.moreHorizontal}</span>
+          </button>
+          <wa-dropdown-item
+            value=${sourceVisible ? "diagram" : "source"}
+            ?disabled=${sourceVisible && !this.imageUrl}
+            >${t(sourceVisible ? "chat.mermaid.diagram" : "chat.mermaid.source")}</wa-dropdown-item
+          >
+          <wa-dropdown-item value="expand" ?disabled=${!this.imageUrl}
+            >${t("chat.mermaid.expand")}</wa-dropdown-item
+          >
+        </wa-dropdown>
       </div>
+      <span class="copy-feedback" aria-live="polite"
+        >${this.copyResult === undefined ? nothing : copyLabel}</span
+      >
       ${this.failed
         ? html`<p class="status" role="status">${t("chat.mermaid.error")}</p>`
         : this.pending && !this.imageUrl

--- a/ui/src/components/markdown-mermaid.ts
+++ b/ui/src/components/markdown-mermaid.ts
@@ -160,7 +160,7 @@ class OpenClawMermaid extends OpenClawLitElement {
       padding: 36px 16px 16px;
       overflow: auto;
       max-height: 480px;
-      font: 12px/1.6 var(--font-mono, monospace);
+      font: 12px/1.6 var(--mono);
       tab-size: 2;
     }
     .status {

--- a/ui/src/components/markdown-mermaid.ts
+++ b/ui/src/components/markdown-mermaid.ts
@@ -1,0 +1,317 @@
+import { css, html, nothing, type PropertyValues } from "lit";
+import { property, state } from "lit/decorators.js";
+import { t } from "../i18n/index.ts";
+import { copyToClipboard } from "../lib/clipboard.ts";
+import { resolveThemeColor } from "../lib/theme-color.ts";
+import { OpenClawLitElement } from "../lit/openclaw-element.ts";
+import { renderMermaidSvg, type MermaidTheme } from "./markdown-mermaid.runtime.ts";
+import "./image-lightbox.ts";
+
+const CACHE_LIMIT = 16;
+const diagrams = new Map<string, Promise<string>>();
+
+function currentTheme(): MermaidTheme {
+  const root = document.documentElement;
+  const styles = getComputedStyle(root);
+  const darkMode = root.dataset.themeMode === "dark";
+  return {
+    background: resolveThemeColor(styles, "--card") || (darkMode ? "#181818" : "#ffffff"),
+    foreground: resolveThemeColor(styles, "--text") || (darkMode ? "#eeeeee" : "#171717"),
+    muted: resolveThemeColor(styles, "--muted") || "#888888",
+    border: resolveThemeColor(styles, "--border-hover") || "#888888",
+    accent: resolveThemeColor(styles, "--accent") || "#888888",
+    fontFamily: styles.getPropertyValue("--font-body").trim() || "system-ui, sans-serif",
+    darkMode,
+  };
+}
+
+function cachedDiagram(key: string, source: string, theme: MermaidTheme): Promise<string> {
+  let result = diagrams.get(key);
+  if (result) {
+    diagrams.delete(key);
+  } else {
+    result = renderMermaidSvg(source, theme);
+    void result.catch(() => {
+      if (diagrams.get(key) === result) {
+        diagrams.delete(key);
+      }
+    });
+  }
+  diagrams.set(key, result);
+  if (diagrams.size > CACHE_LIMIT) {
+    diagrams.delete(diagrams.keys().next().value!);
+  }
+  return result;
+}
+
+class OpenClawMermaid extends OpenClawLitElement {
+  @property({ attribute: false }) source = "";
+  @state() private imageUrl = "";
+  @state() private showSource = false;
+  @state() private expanded = false;
+  @state() private pending = false;
+  @state() private failed = false;
+  @state() private copyResult: boolean | undefined;
+  private renderKey = "";
+  private generation = 0;
+  private copyAttempt = 0;
+  private readonly themeObserver = new MutationObserver(() => void this.renderDiagram());
+
+  static override styles = css`
+    :host {
+      display: block;
+      min-width: 0;
+      margin: 12px 0;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md, 10px);
+      overflow: hidden;
+      background: var(--card);
+      color: var(--text);
+      font-family: var(--font-body);
+    }
+    .toolbar {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 4px;
+      padding: 6px 8px;
+      border-bottom: 1px solid var(--border);
+    }
+    .spacer {
+      flex: 1;
+    }
+    button {
+      padding: 5px 8px;
+      min-height: 32px;
+      border: 0;
+      border-radius: var(--radius-sm, 6px);
+      background: transparent;
+      color: var(--muted);
+      font: inherit;
+      font-size: 12px;
+      cursor: default;
+    }
+    button:hover,
+    button[aria-pressed="true"] {
+      background: var(--bg-hover);
+      color: var(--text);
+    }
+    button:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: -2px;
+    }
+    button:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+    .preview {
+      padding: 16px;
+      overflow: auto;
+    }
+    img {
+      display: block;
+      width: 100%;
+      max-height: 480px;
+      object-fit: contain;
+    }
+    pre {
+      margin: 0;
+      padding: 16px;
+      overflow: auto;
+      max-height: 480px;
+      font: 12px/1.6 var(--font-mono, monospace);
+      tab-size: 2;
+    }
+    .status {
+      margin: 0;
+      padding: 12px 16px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+    @media (max-width: 640px) {
+      button {
+        min-height: 40px;
+      }
+      .preview {
+        padding: 8px;
+      }
+    }
+  `;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme", "data-theme-mode", "style"],
+    });
+    if (this.hasUpdated) {
+      void this.renderDiagram();
+    }
+  }
+
+  override disconnectedCallback() {
+    this.themeObserver.disconnect();
+    this.generation += 1;
+    this.copyAttempt += 1;
+    this.renderKey = "";
+    this.expanded = false;
+    this.releaseImage();
+    super.disconnectedCallback();
+  }
+
+  protected override updated(changed: PropertyValues<this>) {
+    if (changed.has("source")) {
+      this.copyResult = undefined;
+      this.copyAttempt += 1;
+      this.releaseImage();
+      void this.renderDiagram();
+    }
+  }
+
+  private releaseImage() {
+    if (this.imageUrl) {
+      URL.revokeObjectURL(this.imageUrl);
+      this.imageUrl = "";
+    }
+  }
+
+  private async renderDiagram() {
+    if (!this.isConnected) {
+      return;
+    }
+    const theme = currentTheme();
+    const key = JSON.stringify([this.source, theme]);
+    if (key === this.renderKey) {
+      return;
+    }
+    this.renderKey = key;
+    const generation = ++this.generation;
+    this.pending = true;
+    this.failed = false;
+    try {
+      const svg = await cachedDiagram(key, this.source, theme);
+      // Remounts, edits and theme switches can overtake asynchronous layout.
+      // Only the current connected owner may acquire a new blob URL.
+      if (!this.isConnected || generation !== this.generation) {
+        return;
+      }
+      this.releaseImage();
+      this.imageUrl = URL.createObjectURL(new Blob([svg], { type: "image/svg+xml" }));
+    } catch {
+      if (this.isConnected && generation === this.generation) {
+        this.releaseImage();
+        this.failed = true;
+      }
+    } finally {
+      if (this.isConnected && generation === this.generation) {
+        this.pending = false;
+      }
+    }
+  }
+
+  private async copySource() {
+    const attempt = ++this.copyAttempt;
+    const copied = await copyToClipboard(this.source);
+    if (this.isConnected && attempt === this.copyAttempt) {
+      this.copyResult = copied;
+    }
+  }
+
+  override render() {
+    const sourceVisible = this.showSource || this.failed;
+    return html`
+      <div class="toolbar" role="group" aria-label=${t("chat.mermaid.title")}>
+        <button
+          type="button"
+          aria-pressed=${!this.showSource}
+          @click=${() => {
+            this.showSource = false;
+          }}
+        >
+          ${t("chat.mermaid.diagram")}
+        </button>
+        <button
+          type="button"
+          aria-pressed=${this.showSource}
+          @click=${() => {
+            this.showSource = true;
+          }}
+        >
+          ${t("chat.mermaid.source")}
+        </button>
+        <span class="spacer"></span>
+        <button type="button" @click=${this.copySource}>
+          ${t(
+            this.copyResult === undefined
+              ? "chat.mermaid.copySource"
+              : this.copyResult
+                ? "common.copied"
+                : "common.copyFailed",
+          )}
+        </button>
+        <button
+          type="button"
+          ?disabled=${!this.imageUrl}
+          @click=${() => {
+            this.expanded = true;
+          }}
+        >
+          ${t("chat.mermaid.expand")}
+        </button>
+      </div>
+      ${this.failed
+        ? html`<p class="status" role="status">${t("chat.mermaid.error")}</p>`
+        : this.pending && !this.imageUrl
+          ? html`<p class="status" role="status">${t("chat.mermaid.rendering")}</p>`
+          : nothing}
+      ${sourceVisible
+        ? html`<pre><code>${this.source}</code></pre>`
+        : this.imageUrl
+          ? html`<div class="preview">
+              <img
+                src=${this.imageUrl}
+                alt=${t("chat.mermaid.title")}
+                @error=${() => {
+                  this.failed = true;
+                  this.releaseImage();
+                }}
+              />
+            </div>`
+          : nothing}
+      ${this.expanded && this.imageUrl
+        ? html`<openclaw-image-lightbox
+            src=${this.imageUrl}
+            .imageTitle=${t("chat.mermaid.title")}
+            @image-lightbox-close=${() => {
+              this.expanded = false;
+            }}
+          ></openclaw-image-lightbox>`
+        : nothing}
+    `;
+  }
+}
+
+if (!customElements.get("openclaw-mermaid")) {
+  customElements.define("openclaw-mermaid", OpenClawMermaid);
+}
+
+export function mountMermaidBlocks(root: Element): boolean {
+  let mounted = false;
+  for (const block of root.querySelectorAll(".markdown-mermaid")) {
+    const code = block.querySelector("pre code");
+    if (!code) {
+      continue;
+    }
+    const diagram = document.createElement("openclaw-mermaid");
+    diagram.source = code.textContent ?? "";
+    block.replaceChildren(diagram);
+    mounted = true;
+  }
+  return mounted;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "openclaw-mermaid": OpenClawMermaid;
+  }
+}

--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -666,12 +666,18 @@ export function createMarkdownParser(): MarkdownItParser {
     const language = token.info.trim().split(/\s+/)[0] || "";
     // An unfinished fence consumes the remaining input; only container closers can
     // follow it. Invalid fence-looking prose must not de-highlight an earlier block.
-    const streamingOpenFence = env?.streamingOpenFence === true;
-    return renderMarkdownCodeBlock(token.content, language, env, {
+    const openFence =
+      env?.streamingOpenFence === true &&
+      tokens.findLastIndex(({ nesting }) => nesting !== -1) === index;
+    const code = renderMarkdownCodeBlock(token.content, language, env, {
       copyText: markdownCodeBlockCopyText(token.content),
-      highlight:
-        !streamingOpenFence || tokens.findLastIndex(({ nesting }) => nesting !== -1) !== index,
+      highlight: !openFence,
     });
+    // Keep source readable until the host mounts the lazy renderer. Incomplete
+    // streamed fences stay code so partial syntax never starts diagram layout.
+    return language.toLowerCase() === "mermaid" && !openFence
+      ? `<div class="markdown-mermaid">${code}</div>`
+      : code;
   };
   // Override indented code blocks (code_block) with the same treatment as fence
   markdownParser.renderer.rules.code_block = (tokens, index, _options, env) => {

--- a/ui/src/components/markdown-streaming-highlight.test.ts
+++ b/ui/src/components/markdown-streaming-highlight.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { toSanitizedMarkdownHtml, toStreamingMarkdownHtml } from "./markdown.ts";
+import { toSanitizedMarkdownHtml, toStreamingMarkdownParts } from "./markdown.ts";
 
 function htmlFragment(html: string): HTMLElement {
   const container = document.createElement("div");
@@ -7,9 +7,40 @@ function htmlFragment(html: string): HTMLElement {
   return container;
 }
 
-describe("toStreamingMarkdownHtml code fences", () => {
+describe("toStreamingMarkdownParts code fences", () => {
+  it.each([
+    { name: "an unfinished fence", markdown: "```mermaid\nflowchart LR\nA --> B", diagrams: 0 },
+    {
+      name: "a finished response",
+      markdown: "```mermaid\nflowchart LR\nA --> B",
+      final: true,
+      diagrams: 1,
+    },
+    { name: "a closed fence", markdown: "```mermaid\nflowchart LR\nA --> B\n```", diagrams: 1 },
+    { name: "a tilde fence", markdown: "~~~Mermaid\nflowchart LR\nA --> B\n~~~", diagrams: 1 },
+    { name: "a shell fence", markdown: "```bash\nflowchart LR\nA --> B\n```", diagrams: 0 },
+    {
+      name: "an authored HTML marker",
+      markdown: '<div class="markdown-mermaid"><pre><code>flowchart LR</code></pre></div>',
+      diagrams: 0,
+    },
+    {
+      name: "closed then open fences",
+      markdown: "```mermaid\nflowchart LR\nA --> B\n```\n\n```mermaid\nflowchart LR\nC --> D",
+      diagrams: 1,
+    },
+  ])("only mounts complete Mermaid source: $name", ({ markdown, diagrams, final }) => {
+    const fragment = htmlFragment(
+      final ? toSanitizedMarkdownHtml(markdown) : toStreamingMarkdownParts(markdown).join(""),
+    );
+    expect(fragment.querySelectorAll(".markdown-mermaid")).toHaveLength(diagrams);
+    for (const diagram of fragment.querySelectorAll(".markdown-mermaid")) {
+      expect(diagram.querySelector("pre code")?.textContent).toContain("flowchart LR");
+    }
+  });
+
   it("streams an open code fence without syntax highlighting", () => {
-    const html = toStreamingMarkdownHtml("Intro\n\n```ts\nconst x = 1 < 2");
+    const html = toStreamingMarkdownParts("Intro\n\n```ts\nconst x = 1 < 2").join("");
     const fragment = htmlFragment(html);
     const code = fragment.querySelector("code.language-ts");
 
@@ -21,9 +52,9 @@ describe("toStreamingMarkdownHtml code fences", () => {
   });
 
   it("highlights only completed fences inside an open details block", () => {
-    const html = toStreamingMarkdownHtml(
+    const html = toStreamingMarkdownParts(
       "<details>\n<summary>Logs</summary>\n\n```ts\nconst closed = 1;\n```\n\n```ts\nconst open = 2;",
-    );
+    ).join("");
     const code = htmlFragment(html).querySelectorAll("details code.language-ts");
 
     expect(code).toHaveLength(2);
@@ -34,9 +65,9 @@ describe("toStreamingMarkdownHtml code fences", () => {
   });
 
   it("keeps a completed fence highlighted when a later backtick fence has invalid info", () => {
-    const html = toStreamingMarkdownHtml(
+    const html = toStreamingMarkdownParts(
       "- ```ts\n  const closed = 1;\n  ```\n\n  ```bad`info\n  trailing text",
-    );
+    ).join("");
     const code = htmlFragment(html).querySelector("code.language-ts");
 
     expect(code?.textContent).toContain("const closed = 1;");
@@ -44,7 +75,7 @@ describe("toStreamingMarkdownHtml code fences", () => {
   });
 
   it("streams an open list code fence through blank lines", () => {
-    const html = toStreamingMarkdownHtml("- ```ts\n  const x = 1;\n\n  const y = 2;");
+    const html = toStreamingMarkdownParts("- ```ts\n  const x = 1;\n\n  const y = 2;").join("");
     const fragment = htmlFragment(html);
     const code = fragment.querySelector("li code");
 
@@ -57,7 +88,9 @@ describe("toStreamingMarkdownHtml code fences", () => {
   it("keeps completed tilde-fence code out of the remend tail", () => {
     // remend only understands ``` fences; a closed ~~~ block must land in the
     // stable prefix so its raw markers are never "completed" as inline markdown.
-    const html = toStreamingMarkdownHtml('~~~ts\nconst s = "**open";\n~~~\ncontinuing **bold');
+    const html = toStreamingMarkdownParts(
+      '~~~ts\nconst s = "**open";\n~~~\ncontinuing **bold',
+    ).join("");
     const fragment = htmlFragment(html);
 
     expect(fragment.querySelector("code")?.textContent).toContain('const s = "**open";');
@@ -66,7 +99,7 @@ describe("toStreamingMarkdownHtml code fences", () => {
   });
 
   it("streams an open blockquote code fence through blank lines", () => {
-    const html = toStreamingMarkdownHtml("> ```ts\n> const x = 1;\n>\n> const y = 2;");
+    const html = toStreamingMarkdownParts("> ```ts\n> const x = 1;\n>\n> const y = 2;").join("");
     const fragment = htmlFragment(html);
     const code = fragment.querySelector("blockquote code");
 
@@ -78,7 +111,7 @@ describe("toStreamingMarkdownHtml code fences", () => {
 
   it("renders a completed code fence once the closing fence arrives", () => {
     const markdown = "```ts\nconst x = 1;\n```";
-    const html = toStreamingMarkdownHtml(markdown);
+    const html = toStreamingMarkdownParts(markdown).join("");
 
     expect(html).toContain('<code class="hljs language-ts"');
     expect(html).toContain("const x = 1;");

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -4,7 +4,7 @@ import { i18n } from "../i18n/index.ts";
 import { handleMarkdownCodeBlockClick } from "./markdown-code-blocks.ts";
 import * as markdownDetails from "./markdown-details.ts";
 import { splitStableStreamingMarkdown } from "./markdown-streaming.ts";
-import { toSanitizedMarkdownHtml, toStreamingMarkdownHtml } from "./markdown.ts";
+import { toSanitizedMarkdownHtml, toStreamingMarkdownParts } from "./markdown.ts";
 
 function htmlFragment(html: string): HTMLElement {
   const container = document.createElement("div");
@@ -865,7 +865,7 @@ PY
   });
 });
 
-describe("toStreamingMarkdownHtml", () => {
+describe("toStreamingMarkdownParts", () => {
   it("does not rescan completed disclosures in appended prefixes", () => {
     const prefixes: string[] = [];
     let prefix = "<details><summary>Done</summary></details>\n\n";
@@ -926,8 +926,8 @@ describe("toStreamingMarkdownHtml", () => {
           expect(splitIncrementally(prefix, `split-parity-${key}`)).toEqual(
             splitStableStreamingMarkdown(prefix),
           );
-          expect(toStreamingMarkdownHtml(prefix, {}, `html-parity-${key}`)).toBe(
-            toStreamingMarkdownHtml(prefix),
+          expect(toStreamingMarkdownParts(prefix, {}, `html-parity-${key}`).join("")).toBe(
+            toStreamingMarkdownParts(prefix).join(""),
           );
           if (end >= markdown.length) {
             break;
@@ -969,10 +969,10 @@ describe("toStreamingMarkdownHtml", () => {
     const partial = "Intro\n\ncitevery-long-partial-citation-marker";
     const completed = `${partial}\n\n\`\`\`ts\nconst answer = 42;`;
 
-    toStreamingMarkdownHtml(partial, {}, "citation-prefix-replacement");
+    toStreamingMarkdownParts(partial, {}, "citation-prefix-replacement");
 
-    expect(toStreamingMarkdownHtml(completed, {}, "citation-prefix-replacement")).toBe(
-      toStreamingMarkdownHtml(completed),
+    expect(toStreamingMarkdownParts(completed, {}, "citation-prefix-replacement").join("")).toBe(
+      toStreamingMarkdownParts(completed).join(""),
     );
   });
 
@@ -980,7 +980,9 @@ describe("toStreamingMarkdownHtml", () => {
     "keeps details inside a loose %s list continuation while streaming",
     (item) => {
       const markdown = `${item}\n\n    <details>\n    <summary>Logs</summary>\n\n    still inside`;
-      const fragment = htmlFragment(toStreamingMarkdownHtml(markdown, {}, `loose-list:${item}`));
+      const fragment = htmlFragment(
+        toStreamingMarkdownParts(markdown, {}, `loose-list:${item}`).join(""),
+      );
       const details = fragment.querySelector("li details");
 
       expect(details?.querySelector("summary")?.textContent).toBe("Logs");
@@ -997,23 +999,23 @@ describe("toStreamingMarkdownHtml", () => {
     for (const end of [139_500, 140_050, 141_000, text.length]) {
       const prefix = text.slice(0, end);
 
-      expect(toStreamingMarkdownHtml(prefix, {}, "truncated-stream-parity")).toBe(
-        toStreamingMarkdownHtml(prefix),
+      expect(toStreamingMarkdownParts(prefix, {}, "truncated-stream-parity").join("")).toBe(
+        toStreamingMarkdownParts(prefix).join(""),
       );
     }
   });
 
   it("marks a completed transcript-role header in the streaming tail", () => {
-    const html = toStreamingMarkdownHtml("user[Thu 2026-07-02] question", {
+    const html = toStreamingMarkdownParts("user[Thu 2026-07-02] question", {
       assistantTranscriptRoleHeaders: true,
-    });
+    }).join("");
 
     expect(html).toContain('class="assistant-transcript-role"');
   });
 
   it("renders streaming raw block art without collapsing quiet-zone spaces", () => {
     const blockArt = "  ▀▀▀▀  \n  ▄▄▄▄  \n  ████  ";
-    const html = toStreamingMarkdownHtml(blockArt);
+    const html = toStreamingMarkdownParts(blockArt).join("");
     const fragment = htmlFragment(html);
     const code = fragment.querySelector("pre code.markdown-block-art");
 
@@ -1024,7 +1026,7 @@ describe("toStreamingMarkdownHtml", () => {
   it("truncates oversized streaming raw block art before rendering", () => {
     const line = "  ▀▀▀▀  ";
     const blockArt = Array.from({ length: 20_000 }, () => line).join("\n");
-    const html = toStreamingMarkdownHtml(blockArt);
+    const html = toStreamingMarkdownParts(blockArt).join("");
     const fragment = htmlFragment(html);
     const code = fragment.querySelector("pre code.markdown-block-art");
 
@@ -1044,7 +1046,7 @@ describe("toStreamingMarkdownHtml", () => {
     await i18n.setLocale("pt-BR");
     try {
       const blockArt = Array.from({ length: 20_000 }, () => "  ▀▀▀▀  ").join("\n");
-      const fragment = htmlFragment(toStreamingMarkdownHtml(blockArt));
+      const fragment = htmlFragment(toStreamingMarkdownParts(blockArt).join(""));
       expect(fragment.textContent).toContain("… truncado");
       expect(fragment.textContent).toContain("exibindo os primeiros 140000");
     } finally {
@@ -1053,7 +1055,7 @@ describe("toStreamingMarkdownHtml", () => {
   });
 
   it("renders completed block prefixes as markdown and closes the streaming tail", () => {
-    const html = toStreamingMarkdownHtml("## Done\n\nworking **tail");
+    const html = toStreamingMarkdownParts("## Done\n\nworking **tail").join("");
 
     expect(html).toBe("<h2>Done</h2>\n<p>working <strong>tail</strong></p>\n");
   });
@@ -1069,29 +1071,29 @@ describe("toStreamingMarkdownHtml", () => {
     ["tab-indented list continuation", "Intro\n\n  - one\n\n\tcontinuation"],
     ["list continuation before a root heading", "- one\n\n  continuation\n# Heading"],
   ])("preserves whole-document Markdown semantics for %s", (_kind, input) => {
-    expect(toStreamingMarkdownHtml(input)).toBe(toSanitizedMarkdownHtml(input));
+    expect(toStreamingMarkdownParts(input).join("")).toBe(toSanitizedMarkdownHtml(input));
   });
 
   it("uses Unicode separators as stable markdown boundaries", () => {
-    const html = toStreamingMarkdownHtml("## Done\u2028\u2028working **tail");
+    const html = toStreamingMarkdownParts("## Done\u2028\u2028working **tail").join("");
 
     expect(html).toBe("<h2>Done</h2>\n<p>working <strong>tail</strong></p>\n");
   });
 
   it("renders a single open paragraph as markdown with closed formatting", () => {
-    const html = toStreamingMarkdownHtml("**still streaming");
+    const html = toStreamingMarkdownParts("**still streaming").join("");
 
     expect(html).toBe("<p><strong>still streaming</strong></p>\n");
   });
 
   it("renders half-written links as text only while streaming", () => {
-    const html = toStreamingMarkdownHtml("see [Streamdown](https://strea");
+    const html = toStreamingMarkdownParts("see [Streamdown](https://strea").join("");
 
     expect(html).toBe("<p>see Streamdown</p>\n");
   });
 
   it("streams tables as markdown before the closing row arrives", () => {
-    const html = toStreamingMarkdownHtml("| left | right |\n| --- | --- |\n| 1 | 2");
+    const html = toStreamingMarkdownParts("| left | right |\n| --- | --- |\n| 1 | 2").join("");
     const fragment = htmlFragment(html);
 
     expect(fragment.querySelector("table")).not.toBeNull();
@@ -1100,7 +1102,7 @@ describe("toStreamingMarkdownHtml", () => {
   });
 
   it("leaves dollar amounts alone while streaming", () => {
-    const html = toStreamingMarkdownHtml("prices are $$50 and");
+    const html = toStreamingMarkdownParts("prices are $$50 and").join("");
 
     expect(html).toBe("<p>prices are $$50 and</p>\n");
   });

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -572,22 +572,22 @@ function toEscapedPlainTextHtml(value: string, options: MarkdownRenderEnv): stri
   );
 }
 
-export function toStreamingMarkdownHtml(
+export function toStreamingMarkdownParts(
   markdownLocal: string,
   options: MarkdownRenderOptions = {},
   streamKey?: string,
-): string {
+): [stableHtml: string, tailHtml: string] {
   const renderOptions = normalizeMarkdownRenderOptions(options);
   const rawInput = normalizeMarkdownLineBreaks(
     stripUnsupportedCitationControlMarkers(markdownLocal),
   );
   if (isMarkdownBlockArtText(rawInput)) {
-    return renderSanitizedMarkdown(rawInput, renderOptions);
+    return ["", renderSanitizedMarkdown(rawInput, renderOptions)];
   }
 
   const trimmedInput = rawInput.trim();
   if (!trimmedInput) {
-    return "";
+    return ["", ""];
   }
   const truncated = truncateText(trimmedInput, MARKDOWN_CHAR_LIMIT);
   const input = appendMarkdownTruncationNotice(truncated);
@@ -601,7 +601,7 @@ export function toStreamingMarkdownHtml(
   const streamingTail = input.slice(boundary);
   const stableHtml = boundary > 0 ? toSanitizedMarkdownHtml(stableMarkdown, options) : "";
   if (!streamingTail.trim()) {
-    return stableHtml;
+    return [stableHtml, ""];
   }
   const tailHtml =
     tailRepairStart === null
@@ -610,5 +610,5 @@ export function toStreamingMarkdownHtml(
           repairStreamingMarkdownTail(streamingTail, tailRepairStart - boundary),
           renderOptions,
         );
-  return `${stableHtml}${tailHtml}`;
+  return [stableHtml, tailHtml];
 }

--- a/ui/src/components/terminal/terminal-theme.ts
+++ b/ui/src/components/terminal/terminal-theme.ts
@@ -3,6 +3,7 @@ import type {
   CreateGhosttyTerminalOptions,
   TerminalDefaultColors,
 } from "@openclaw/libterminal/browser";
+import { resolveThemeColor } from "../../lib/theme-color.ts";
 
 type TerminalTheme = NonNullable<
   NonNullable<CreateGhosttyTerminalOptions["terminalOptions"]>["theme"]
@@ -53,33 +54,12 @@ const LIGHT_ANSI = {
   brightWhite: "#0a0c10",
 } as const;
 
-function resolveTerminalColor(styles: CSSStyleDeclaration, property: string): string {
-  const value = styles.getPropertyValue(property).trim();
-  if (!value || /^#[\da-f]{6}$/iu.test(value)) {
-    return value.toLowerCase();
-  }
-  const canvas = document.createElement("canvas");
-  canvas.width = canvas.height = 1;
-  const context = canvas.getContext("2d");
-  if (!context) {
-    return value;
-  }
-  // Custom themes may use modern color functions, while OSC 10-12 accepts
-  // only concrete #rrggbb colors; reading a painted pixel resolves both.
-  context.fillStyle = value;
-  context.fillRect(0, 0, 1, 1);
-  return `#${Array.from(context.getImageData(0, 0, 1, 1).data)
-    .slice(0, 3)
-    .map((channel) => channel.toString(16).padStart(2, "0"))
-    .join("")}`;
-}
-
 export function terminalDynamicColors(): TerminalDefaultColors {
   const styles = getComputedStyle(document.documentElement);
   return {
-    background: resolveTerminalColor(styles, "--bg"),
-    cursor: resolveTerminalColor(styles, "--accent"),
-    foreground: resolveTerminalColor(styles, "--text"),
+    background: resolveThemeColor(styles, "--bg"),
+    cursor: resolveThemeColor(styles, "--accent"),
+    foreground: resolveThemeColor(styles, "--text"),
   };
 }
 

--- a/ui/src/components/web-awesome.test.ts
+++ b/ui/src/components/web-awesome.test.ts
@@ -8,8 +8,9 @@ import {
 } from "./web-awesome.ts";
 
 type DropdownElement = HTMLElement & { readonly updateComplete: Promise<unknown> };
+const domRoots = ["light", "shadow"] as const;
 
-async function createDropdown(label?: string) {
+async function createDropdown(label?: string, domRoot: (typeof domRoots)[number] = "light") {
   const dropdown = document.createElement("wa-dropdown") as DropdownElement;
   if (label) {
     dropdown.setAttribute("aria-label", label);
@@ -20,7 +21,11 @@ async function createDropdown(label?: string) {
   const item = document.createElement("wa-dropdown-item");
   item.textContent = "Open";
   dropdown.append(trigger, item);
-  document.body.append(dropdown);
+  const root =
+    domRoot === "shadow"
+      ? document.body.appendChild(document.createElement("div")).attachShadow({ mode: "open" })
+      : document.body;
+  root.append(dropdown);
   await dropdown.updateComplete;
   dropdown.dispatchEvent(new CustomEvent("wa-show", { bubbles: true, composed: true }));
   return { dropdown, trigger };
@@ -29,8 +34,8 @@ async function createDropdown(label?: string) {
 afterEach(() => document.body.replaceChildren());
 
 describe("Web Awesome adapters", () => {
-  it("copies an explicit dropdown label to the menu", async () => {
-    const { dropdown } = await createDropdown("Message actions");
+  it.each(domRoots)("syncs an explicit menu label only while open in %s DOM", async (domRoot) => {
+    const { dropdown } = await createDropdown("Message actions", domRoot);
 
     expect(dropdown.shadowRoot?.querySelector('[part="menu"]')?.getAttribute("aria-label")).toBe(
       "Message actions",
@@ -40,6 +45,12 @@ describe("Web Awesome adapters", () => {
     await new Promise((resolve) => {
       setTimeout(resolve, 0);
     });
+    expect(dropdown.shadowRoot?.querySelector('[part="menu"]')?.getAttribute("aria-label")).toBe(
+      "Updated actions",
+    );
+    dropdown.dispatchEvent(new Event("wa-after-hide", { bubbles: true, composed: true }));
+    dropdown.setAttribute("aria-label", "Closed actions");
+    await Promise.resolve();
     expect(dropdown.shadowRoot?.querySelector('[part="menu"]')?.getAttribute("aria-label")).toBe(
       "Updated actions",
     );
@@ -53,8 +64,8 @@ describe("Web Awesome adapters", () => {
     );
   });
 
-  it("removes closing dropdown menus from native Tab order before their animation", async () => {
-    const { dropdown } = await createDropdown();
+  it.each(domRoots)("makes closing menus inert and restores them in %s DOM", async (domRoot) => {
+    const { dropdown } = await createDropdown(undefined, domRoot);
     const menu = dropdown.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
     expect(menu?.hasAttribute("inert")).toBe(false);
 

--- a/ui/src/components/web-awesome.ts
+++ b/ui/src/components/web-awesome.ts
@@ -71,7 +71,8 @@ function labelDropdownMenu(dropdown: HTMLElement) {
 const dropdownLabelObservers = new WeakMap<HTMLElement, MutationObserver>();
 
 function startDropdownLabelSync(event: Event) {
-  const dropdown = event.target;
+  // Document listeners otherwise see the containing component's shadow host.
+  const dropdown = event.composedPath()[0];
   if (!(dropdown instanceof HTMLElement) || dropdown.localName !== "wa-dropdown") {
     return;
   }
@@ -96,7 +97,7 @@ function startDropdownLabelSync(event: Event) {
 }
 
 function disableClosingDropdownMenu(event: Event) {
-  const dropdown = event.target;
+  const dropdown = event.composedPath()[0];
   if (!(dropdown instanceof HTMLElement) || dropdown.localName !== "wa-dropdown") {
     return;
   }
@@ -115,7 +116,7 @@ function disableClosingDropdownMenu(event: Event) {
 }
 
 function stopDropdownLabelSync(event: Event) {
-  const dropdown = event.target;
+  const dropdown = event.composedPath()[0];
   if (!(dropdown instanceof HTMLElement) || dropdown.localName !== "wa-dropdown") {
     return;
   }

--- a/ui/src/css.d.ts
+++ b/ui/src/css.d.ts
@@ -1,2 +1,12 @@
 // Control UI type declarations define css contracts.
 declare module "*.css";
+
+declare module "*?url" {
+  const url: string;
+  export default url;
+}
+
+declare module "*?url&no-inline" {
+  const url: string;
+  export default url;
+}

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5727,6 +5727,15 @@ export const en: TranslationMap = {
     markdown: {
       truncated: "… truncated ({total} chars, showing first {shown}).",
     },
+    mermaid: {
+      title: "Mermaid diagram",
+      diagram: "Diagram",
+      source: "Source",
+      copySource: "Copy source",
+      expand: "Expand diagram",
+      rendering: "Rendering diagram…",
+      error: "This diagram could not be rendered. Check the source or simplify the diagram.",
+    },
     codeBlock: {
       languageFallback: "Code",
       hiddenLine: "1 hidden line",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5729,8 +5729,9 @@ export const en: TranslationMap = {
     },
     mermaid: {
       title: "Mermaid diagram",
-      diagram: "Diagram",
-      source: "Source",
+      options: "Diagram options",
+      diagram: "Show diagram",
+      source: "Show source",
       copySource: "Copy source",
       expand: "Expand diagram",
       rendering: "Rendering diagram…",

--- a/ui/src/lib/theme-color.ts
+++ b/ui/src/lib/theme-color.ts
@@ -1,0 +1,21 @@
+/** Resolve theme colors for consumers that require concrete RGB values. */
+export function resolveThemeColor(styles: CSSStyleDeclaration, property: string): string {
+  const value = styles.getPropertyValue(property).trim();
+  if (!value || /^#[\da-f]{6}$/iu.test(value)) {
+    return value.toLowerCase();
+  }
+  const canvas = document.createElement("canvas");
+  canvas.width = canvas.height = 1;
+  const context = canvas.getContext("2d");
+  if (!context) {
+    return value;
+  }
+  // Custom themes use modern color functions; terminal OSC colors and Mermaid
+  // require concrete #rrggbb values. A painted pixel resolves either syntax.
+  context.fillStyle = value;
+  context.fillRect(0, 0, 1, 1);
+  return `#${Array.from(context.getImageData(0, 0, 1, 1).data)
+    .slice(0, 3)
+    .map((channel) => channel.toString(16).padStart(2, "0"))
+    .join("")}`;
+}

--- a/ui/src/pages/chat/components/chat-message-markdown.test.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.test.ts
@@ -4,6 +4,7 @@
 // transcript mutation actions.
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
+import { handleMarkdownCodeBlockClick } from "../../../components/markdown-code-blocks.ts";
 import { persistedMessageEntryId } from "../chat-thread-items.ts";
 import { renderMessageMarkdown, resolveMessageActionDetails } from "./chat-message-markdown.ts";
 
@@ -144,5 +145,60 @@ describe("user message disclosure", () => {
     for (const line of markdown.split("\n").filter(Boolean)) {
       expect(container.textContent).toContain(line);
     }
+  });
+});
+
+describe("streaming message Markdown", () => {
+  it("retains completed fence controls while the following paragraph streams", () => {
+    const container = document.createElement("div");
+    const prefix = "```ts\nconst answer = 42;\n```\n\n";
+    const renderTail = (tail: string) =>
+      render(
+        renderMessageMarkdown(
+          prefix + tail,
+          "retained-fence",
+          { role: "assistant", isStreaming: true },
+          { codeBlockInteraction: "interactive" },
+        ),
+        container,
+      );
+    container.addEventListener("click", handleMarkdownCodeBlockClick);
+    renderTail("The answer");
+    const code = container.querySelector("code");
+    const wrapper = container.querySelector(".code-block-wrapper");
+    expect(code).not.toBeNull();
+    container.querySelector<HTMLButtonElement>(".code-block-wrap")?.click();
+    expect(wrapper?.classList.contains("is-wrapped")).toBe(true);
+
+    renderTail("The answer is ready.");
+
+    expect(container.querySelector("code")).toBe(code);
+    expect(container.querySelector(".code-block-wrapper")?.classList.contains("is-wrapped")).toBe(
+      true,
+    );
+    expect(container.querySelector(".chat-text > p")?.textContent).toBe("The answer is ready.");
+    container.removeEventListener("click", handleMarkdownCodeBlockClick);
+  });
+
+  it.each([
+    { markdown: "Intro\n\nTail", owner: ".chat-text > p:last-child" },
+    { markdown: "Intro\n\n", owner: ".chat-text > p" },
+    { markdown: "Intro\n\n```ts\nconst answer = 42;\n```", owner: ".chat-text" },
+  ])("keeps the duplicate count on the terminal owner for $markdown", ({ markdown, owner }) => {
+    const container = document.createElement("div");
+    render(
+      renderMessageMarkdown(
+        markdown,
+        "streaming-duplicate",
+        { role: "assistant", isStreaming: true },
+        {},
+        { count: 3, label: "Three identical messages" },
+      ),
+      container,
+    );
+
+    expect(container.querySelectorAll(".chat-duplicate-count")).toHaveLength(1);
+    expect(container.querySelector(`${owner} > .chat-duplicate-count`)?.textContent).toBe("×3");
+    expect(container.querySelector("code .chat-duplicate-count")).toBeNull();
   });
 });

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -7,7 +7,7 @@ import { CHAT_PENDING_INPUT_MESSAGE_PREFIX } from "../../../../../packages/gatew
 import { renderCopyAsMarkdownButton } from "../../../components/copy-button.ts";
 import { icons } from "../../../components/icons.ts";
 import type { MarkdownRenderOptions } from "../../../components/markdown-render-options.ts";
-import { toSanitizedMarkdownHtml, toStreamingMarkdownHtml } from "../../../components/markdown.ts";
+import { toSanitizedMarkdownHtml, toStreamingMarkdownParts } from "../../../components/markdown.ts";
 import { t } from "../../../i18n/index.ts";
 import type { NormalizedMessage } from "../../../lib/chat/chat-types.ts";
 import {
@@ -333,13 +333,17 @@ function renderMarkdownText(
   duplicateSuffix?: DuplicateSuffix,
   streamKey?: string,
 ) {
-  const rendered = isStreaming
-    ? toStreamingMarkdownHtml(markdown, markdownRenderOptions, streamKey)
-    : toSanitizedMarkdownHtml(markdown, markdownRenderOptions);
-  const content = duplicateSuffix ? appendDuplicateSuffix(rendered, duplicateSuffix) : rendered;
-  return html`
-    <div class="chat-text" dir="${detectTextDirection(markdown)}">${unsafeHTML(content)}</div>
-  `;
+  const parts: [string, string] = isStreaming
+    ? toStreamingMarkdownParts(markdown, markdownRenderOptions, streamKey)
+    : [toSanitizedMarkdownHtml(markdown, markdownRenderOptions), ""];
+  if (duplicateSuffix) {
+    const terminalPart = parts[1].trim() ? 1 : 0;
+    parts[terminalPart] = appendDuplicateSuffix(parts[terminalPart], duplicateSuffix);
+  }
+  // Separate Lit parts preserve completed code controls and diagrams while the
+  // streaming tail changes; the Markdown splitter still owns container boundaries.
+  const content = parts.map((part) => unsafeHTML(part));
+  return html` <div class="chat-text" dir="${detectTextDirection(markdown)}">${content}</div> `;
 }
 
 function appendDuplicateSuffix(rendered: string, suffix: DuplicateSuffix): string {

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -35,8 +35,10 @@ const markdownRenderMock = vi.fn(
   (value: string, _options?: { codeBlockChrome?: "copy" | "none"; fileLinks?: boolean }) => value,
 );
 const streamingMarkdownRenderMock = vi.fn(
-  (value: string, _options?: { codeBlockChrome?: "copy" | "none"; fileLinks?: boolean }) =>
-    `<div class="streaming-markdown">${value}</div>`,
+  (
+    value: string,
+    _options?: { codeBlockChrome?: "copy" | "none"; fileLinks?: boolean },
+  ): [string, string] => ["", `<div class="streaming-markdown">${value}</div>`],
 );
 
 function getSafeLocalStorageMock(): Storage {
@@ -88,7 +90,7 @@ function pointerClick(element: Element) {
 beforeEach(() => {
   vi.spyOn(localStorageModule, "getSafeLocalStorage").mockImplementation(getSafeLocalStorageMock);
   vi.spyOn(markdown, "toSanitizedMarkdownHtml").mockImplementation(markdownRenderMock);
-  vi.spyOn(markdown, "toStreamingMarkdownHtml").mockImplementation(streamingMarkdownRenderMock);
+  vi.spyOn(markdown, "toStreamingMarkdownParts").mockImplementation(streamingMarkdownRenderMock);
   vi.spyOn(chatAvatar, "renderChatAvatar").mockImplementation(renderChatAvatarMock);
 });
 

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { playwright } from "@vitest/browser-playwright";
 import { chromium } from "playwright";
-import { defineConfig, defineProject } from "vitest/config";
+import { defineConfig, defineProject, type ViteUserConfig } from "vitest/config";
 import {
   intersectIncludePatterns,
   loadPatternListFromEnv,
@@ -19,6 +19,7 @@ import {
   sharedVitestConfig,
 } from "../test/vitest/vitest.shared.config.ts";
 import { uiIsolatedTestFiles } from "../test/vitest/vitest.ui-isolated-paths.mjs";
+import { uiNodeDrivenBrowserTestFiles } from "../test/vitest/vitest.ui-paths.mjs";
 import { controlUiLocaleModulesPlugin } from "./config/control-ui-locales.ts";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -97,11 +98,10 @@ const workspaceSourceAliases = [
     replacement: path.resolve(repoRoot, "packages/net-policy/src/index.ts"),
   },
 ];
-const requestedIncludes = loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE");
-function includeUiTests(patterns: string[]): string[] {
+function includeUiTests(patterns: string[], env = process.env): string[] {
   const selected = intersectIncludePatterns(
     patterns.map((pattern) => `ui/${pattern}`),
-    requestedIncludes,
+    loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env),
   );
   return selected ? relativizeScopedPatterns(selected, "ui") : patterns;
 }
@@ -115,22 +115,7 @@ const sharedUiTestConfig = {
   testTimeout: 60_000,
   hookTimeout: 60_000,
 } as const;
-const nodeDrivenBrowserLayoutTests = [
-  "src/ui/chat/sidebar-session-picker.browser.test.ts",
-  "src/pages/chat/chat-responsive.browser.test.ts",
-  "src/pages/chat/chat-working-indicator.browser.test.ts",
-  "src/pages/chat/chat-composer-undo-redo.browser.test.ts",
-  "src/pages/chat/components/chat-swarm-progress.browser.test.ts",
-  "src/components/form-controls.browser.test.ts",
-  "src/components/sidebar-footer-layout.browser.test.ts",
-  "src/pages/sessions/view.browser.test.ts",
-  "src/styles/corner-shape.browser.test.ts",
-  "src/styles/cursor-policy.browser.test.ts",
-  "src/styles/chat-file-link-presentation.browser.test.ts",
-  "src/styles/chat-github-link-presentation.browser.test.ts",
-  "src/styles/shimmer.browser.test.ts",
-  "src/styles/sr-only.browser.test.ts",
-] as const;
+const nodeDrivenBrowserLayoutTests = relativizeScopedPatterns(uiNodeDrivenBrowserTestFiles, "ui");
 const mockRegistryUnitTests = [
   ...uiIsolatedTestFiles.map((testFile) => testFile.slice("ui/".length)),
   "src/components/mcp-app-view.test.ts",
@@ -168,6 +153,32 @@ function resolveChromiumLaunchOptions(): { executablePath: string } | undefined 
 }
 
 const chromiumLaunchOptions = resolveChromiumLaunchOptions();
+
+export function createUiBrowserVitestConfig(env = process.env): ViteUserConfig {
+  return defineProject({
+    root: here,
+    plugins: [controlUiLocaleModulesPlugin()],
+    resolve: {
+      alias: workspaceSourceAliases,
+    },
+    test: {
+      ...sharedUiTestConfig,
+      name: "browser",
+      // No cleanup runner: it imports node:fs and repo server modules, which
+      // cannot load in browser mode. Browser files own their own teardown.
+      include: includeUiTests(["src/**/*.browser.test.ts"], env),
+      exclude: [...nodeDrivenBrowserLayoutTests],
+      setupFiles: ["./src/test-helpers/lit-warnings.setup.ts"],
+      browser: {
+        enabled: true,
+        provider: playwright(chromiumLaunchOptions ? { launchOptions: chromiumLaunchOptions } : {}),
+        instances: [{ browser: "chromium", name: "chromium" }],
+        headless: true,
+        ui: false,
+      },
+    },
+  });
+}
 
 export default defineConfig({
   root: here,
@@ -239,30 +250,7 @@ export default defineConfig({
           setupFiles: ["./src/test-helpers/lit-warnings.setup.ts"],
         },
       }),
-      defineProject({
-        plugins: [controlUiLocaleModulesPlugin()],
-        resolve: {
-          alias: workspaceSourceAliases,
-        },
-        test: {
-          ...sharedUiTestConfig,
-          name: "browser",
-          // No cleanup runner: it imports node:fs and repo server modules, which
-          // cannot load in browser mode. Browser files own their own teardown.
-          include: includeUiTests(["src/**/*.browser.test.ts"]),
-          exclude: [...nodeDrivenBrowserLayoutTests],
-          setupFiles: ["./src/test-helpers/lit-warnings.setup.ts"],
-          browser: {
-            enabled: true,
-            provider: playwright(
-              chromiumLaunchOptions ? { launchOptions: chromiumLaunchOptions } : {},
-            ),
-            instances: [{ browser: "chromium", name: "chromium" }],
-            headless: true,
-            ui: false,
-          },
-        },
-      }),
+      createUiBrowserVitestConfig(),
     ],
   },
 });


### PR DESCRIPTION
## What Problem This Solves

Mermaid code blocks in Control UI chat currently remain source code. Architecture diagrams such as Gateway ↔ executors → canonical state cannot be read visually in the conversation.

## Why This Change Was Made

Completed `mermaid` fences now use the maintained Mermaid renderer, loaded on demand, with one lifecycle owner for rendering, theme changes, cached results, and cleanup. Layout runs in an opaque sandbox with a restrictive content security policy; the UI displays sanitized, passive SVG images and preserves the original Markdown source.

The renderer is a 953.1 KiB gzip deferred asset. Its explicit 960 KiB budget rejects startup inclusion or duplicates while preserving the existing startup and ordinary-chunk limits. Conversations without diagrams do not load Mermaid.

## User Impact

Diagrams have a small top-right options menu for showing the source or expanding with zoom. The copy button appears on hover or keyboard focus and stays visible on touch screens. Colors follow the UI theme, including an opaque background for readable expanded images. Incomplete streaming fences remain code; completed diagrams retain their DOM while the ordinary streaming tail changes. Invalid or excessive input shows an error with readable source.

Diagrams are static: links and click handlers are inactive, and diagrams that require image loading show their source with an error.

No Gateway configuration or persistence changes are required. The Control UI documentation includes the supported fence syntax and controls.

## Evidence

The feature suites passed 552 UI, Chromium, and performance-budget cases across the initial runs; the compact controls passed 22 component/dropdown cases. The runner repair passed 43 focused cases, including actual mixed dispatch of native Chromium rendering and Node-driven Playwright tests, with no skipped cases in that dispatch. All 27 stages of the changed gate passed on the frozen runner-repair sources, including typechecks, lint, styles, architecture/dependency guards, and dead-export scans. These runs preceded the final rebase and scoped-config assertion repair; the refreshed commit's CI status is recorded below.

The final one-file repair in `test/vitest-scoped-config.test.ts` replaces the stale blanket UI-glob assertion with executable ownership checks: ordinary UI and Node-driven Playwright files are included, while native Chromium Mermaid files are excluded from the Node project. The stale assertion failed before the repair; afterward, all 109 owner/sibling tests across two files and all 14 selected changed-gate stages passed. A negative check restoring the old blanket inclusion also fails the repaired assertion, confirming it detects the browser-ownership regression. This repair changes no production code.

The full production build passed before the final mechanical rebase. A fresh production UI build from `d80681bfec5` passes the performance check: startup JavaScript is 348,253 B gzip against the inherited 349,244 B enforcement limit. Mermaid remains one deferred 953.1 KiB gzip asset and is absent from startup. This PR changes no startup baseline, growth allowance, or hard ceiling.

Live proof uses Chromium against an isolated, built Gateway and persisted synthetic assistant messages through the actual session/history flow, without a model-provider call. Four bounded checkpoints passed against the fresh `d80681bfec5` production UI: persisted diagram/exact copy, source/menu round trip, expansion/decode/close, and SHA-256 verification of 68 served JavaScript/CSS assets against the build. There were zero page errors. This run served UI build `2026.8.1-d80681bfec5d-2026-09-01T07-46-58.453Z` through the retained full Gateway build `2026.8.1-46ca25391148-2026-09-01T06-55-34.770Z`; only the UI was rebuilt for the runner/font repair. The Gateway's real CSP remains unchanged, and the existing lightbox/icon console entries are classified below. The diagram and menu appearance is unchanged from the attached screenshots.

The renderer stress run rendered the first diagram in 872 ms and 33 diagrams in 1.234 s; eight identical diagrams shared one layout. Source/copy, expansion/zoom/close, dark/light themes, 390 px mobile layout, and persisted-history reload passed. Hostile CSS/image/configuration inputs produced zero trap requests and zero page errors. The 21,000-character and 201-edge cases were rejected; the 200-edge case reached the output bound, showed exact source in 588 ms, and recovered with a valid diagram.

The compact-controls production build was live-tested through the same real Gateway flow: copy is hidden at desktop idle and visible on hover/focus; keyboard copy preserves exact bytes; the named menu supports Escape focus return and outside dismissal; eight repeated source/diagram round trips, expansion/zoom/close, dark/light themes, persisted reload, and a 390 px touch viewport all pass. Touch controls remain visible, the menu stays inside the viewport, and no page errors occurred. The source view computes the canonical 12 px monospace font. The shared dropdown adapter now handles menu labeling and closing correctly through component shadow roots.

**Before — Mermaid remains a code block:**

![Before: Mermaid source in Control UI chat](https://github.com/user-attachments/assets/1e236adb-f7f3-45d7-9e1b-584f4b5700ec)

**After — rendered diagram with compact corner controls:**

![Rendered Mermaid diagram with compact controls](https://github.com/user-attachments/assets/d627effd-fb41-4d91-b728-cc4458a83d41)

**Diagram options:**

![Compact source and expansion menu](https://github.com/user-attachments/assets/dee164d2-4813-490d-9ed5-11b6a1bbcebf)

<details>
<summary>Hover copy, touch controls, and expanded light theme</summary>

![Copy source appears on hover](https://github.com/user-attachments/assets/b99ac055-77dd-474f-be08-4af36b92075a)

![Copy and menu remain visible on touch screens](https://github.com/user-attachments/assets/2ba2811d-0e31-4ef2-ad60-134e73b4fee5)

![Expanded Mermaid diagram in the light theme](https://github.com/user-attachments/assets/37f1fd69-22fe-43dd-9e3e-68d7f1135ecf)

</details>

The browser tests cover flowchart, sequence, class, and state output; hostile links/CSS/configuration, resource blocking, malformed input and recovery; source and edge bounds; and raster readability. Component tests cover theme/source races, unmount cleanup, cache sharing/eviction, copy failure, and image failure. Streaming DOM preservation, expanded-image opacity, and text centering each fail against their preceding implementations.

The timeout is a watchdog, not preemption of synchronous Mermaid layout. Source is capped at 20,000 characters, flowcharts at 200 edges, and generated SVG at one million UTF-16 code units and 5,000 elements. Final live proof includes a case at the flowchart edge limit and recovery after rejected input.

Judged LOC: UI production +952/-45 (net +907); performance tooling +28/-3 (net +25); test infrastructure +151/-60 (net +91); tests/support +863/-87 (net +776); docs +25; dependency manifest +1 and lockfile +793. Production growth owns the sandbox, safe SVG conversion, diagram lifecycle, and compact controls. The previous single-string streaming API is removed, the existing theme-color resolver is shared, and test discovery has one browser-ownership policy.

CI exposed two additional defects that are repaired here: the Mermaid source view referenced an undefined font token, and root Node test selection collected native Chromium tests in jsdom. The source view now uses the canonical `--mono` token. A shared test ownership policy keeps native browser tests in the existing Chromium project while preserving Node-driven Playwright tests. Explicit files, mixed selectors, directory/full runs, and both CI planners use that ownership boundary; no tests are skipped to hide the timeout. The stale nonexistent Node-browser entry and unused root UI include override are removed.

Known shared-viewer follow-up: expanding a Blob image logs a CSP-blocked MIME-probe fetch from `ui/src/components/image-lightbox.ts:605`; the image itself loads and zooms normally, and the unsafe Open-original action remains absent. This existing shared lightbox behavior is unchanged here. The follow-up is to avoid the disallowed probe while preserving its MIME safety check; the Gateway CSP remains unchanged. The other observed console entries are the documented missing-workspace-icon 404/folder fallback for the synthetic session, not failed Mermaid assets.

[CI run 33482621262 on d80681bfec5](https://github.com/openclaw/openclaw/actions/runs/33482621262) failed the stale scoped-config assertion repaired above and the steady-composer budget (`hostUpdates = 2`, limit `1`). All five unchanged runtime-budget tests subsequently passed in their original file order, with no skips, against the freshly built `d80681bfec5` production UI. A separate diagnostic using retained prior UI assets injected a synthetic window-focus/catalog interleaving and recorded two pane update requests from the microphone catalog owner with zero DOM mutations. That proves a competing background producer, not the exact origin of the CI failure. No UI code, test assertion, or render budget was changed in response.

Named follow-up if the composer-budget failure recurs: attribute background catalog/session updates separately in the steady-composer performance test while preserving the ordinary-typing budget.

The final branch refresh is `96db6ceaa3253104d437df1af655b426d77584fe`, rebased onto `2ec1bb44f6cd0af2523def910f5a5f7c8d4d8b08`. The only conflict was an equivalent cache-warm test assertion already fixed on main; range-diff confirms the other patches are unchanged. All five targeted planner integration cases pass on the complete 36,071-file source tree and matching Git index, including main's compiler-fixture resource routing. The renderer, chat components, English locale, UI test configuration, performance checker, manifest and lockfile are byte-identical to reviewed `11d2`. A subsequent automatic merge with main `a084c652c62` is clean; its shared Markdown link-boundary extraction preserves the previous predicates and does not affect fence rendering.

[Previous full CI run 33485127778](https://github.com/openclaw/openclaw/actions/runs/33485127778) passed on `11d2`, including both previously failing jobs.

**Final CI: passed** on `96db6ceaa3253104d437df1af655b426d77584fe` — [run 33488542309](https://github.com/openclaw/openclaw/actions/runs/33488542309).

The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/134913#issuecomment-5489822536), reviewed at 08:28 UTC on `11d2`, identifies no actionable code findings. Its two Rank-up moves are addressed by the branch refresh/integration verification above and the dependency review. Direct inspection of Mermaid 11.17.1’s packaged source confirms directive sanitization/secure-key removal (`src/config.ts:131`), render/configuration and error handling (`src/mermaidAPI.ts:463`), serialized public rendering (`src/mermaid.ts:409`), and flowchart edge/callback enforcement (`src/diagrams/flowchart/flowDb.ts:283`, `:500`). These dependency paths are inside the locked Mermaid package. OpenClaw additionally serializes initialization with rendering, locks every configuration root, omits returned event binders, and applies its own passive-SVG allowlist. The inspected classic bundle has SHA-256 `b7a4cda9e88e187d4e1f279b8a14a3df651edd8dc704b9b56ed8e84659735570`.

The lockfile audit confirms one UI importer addition and 106 new registry package records/snapshots (Mermaid plus 105 reachable transitive dependencies), all with SHA-512 integrity. Existing package/snapshot records, package-manager settings, and unrelated importers are unchanged. The installed Mermaid manifest matches the pinned version and its 22 dependency names/ranges, declares MIT and the upstream `mermaid-js/mermaid` repository, and has no install or prepare lifecycle hooks.
