### PR TITLE
fix(release): handle large package inventories

### DIFF
--- a/scripts/release-plan-producer-core.mts
+++ b/scripts/release-plan-producer-core.mts
@@ -222,7 +222,7 @@ function withCandidateSnapshot<T>(
     const tree = execFileSync(
       "git",
       ["ls-tree", "-r", "-z", candidateSha, "--", "package.json", "extensions", "packages"],
-      { cwd: repoRoot },
+      { cwd: repoRoot, maxBuffer: 16 * 1024 * 1024 },
     ).toString("utf8");
     const inventoryPaths: string[] = [];
     for (const entry of tree.split("\0").filter(Boolean)) {


### PR DESCRIPTION
Related: #134868

## What Problem This Solves

Release plan generation failed with `spawnSync git ENOBUFS` once the package inventory exceeded Node's default 1 MiB subprocess buffer. That made an otherwise unrelated PR's CI fail while reading the current repository tree.

## Why This Change Was Made

This PR gives the package-inventory `git ls-tree` call the same explicit 16 MiB buffer already used by adjacent Git reads in the release producer. Large inventories now complete without changing the inventory or release-plan contract.

## User Impact

There is no end-user behavior change. Release and PR validation can continue as the repository's package inventory grows.

## Evidence

**Before: direct base**

The current repository inventory exceeded the default buffer and reproduced the CI failure:

```text
Error: spawnSync git ENOBUFS
stdout bytes captured before failure: 1,048,865
```

Original CI failure: https://github.com/openclaw/openclaw/actions/runs/33475097294/job/99752752534

**After: PR**

```text
node scripts/run-vitest.mjs test/scripts/release-plan-producer.test.ts --run
Test Files  1 passed (1)
Tests       43 passed (43)
```

Additional validation:

```text
node scripts/check-changed.mjs
autoreview --mode local --base origin/main
```

Both completed without findings.
