### PR TITLE
fix(line): tell the agent it has the buttons LINE renders

### DIFF
--- a/extensions/line/src/channel.rich-messages.test.ts
+++ b/extensions/line/src/channel.rich-messages.test.ts
@@ -11,22 +11,6 @@ import {
 } from "./rich-messages.js";
 import type { LineRichCard } from "./types.js";
 
-describe("LINE agent prompt capabilities", () => {
-  const cfg = {
-    channels: { line: { enabled: true, channelAccessToken: "token", channelSecret: "secret" } },
-  } as never;
-
-  it("tells the agent it has the buttons the renderer produces", () => {
-    const advertised = linePlugin.agentPrompt?.messageToolCapabilities?.({ cfg });
-    const renders = lineOutboundAdapter.presentationCapabilities?.buttons === true;
-
-    // The prompt and the renderer answer the same question; a channel that says
-    // no here loses the button hint and is told to set a config key it has not got.
-    expect(renders).toBe(true);
-    expect(advertised).toContain("inlineButtons");
-  });
-});
-
 function resolveChannelDataSchema() {
   const discovery = lineMessageActions.describeMessageTool({
     cfg: {

--- a/extensions/line/src/channel.rich-messages.test.ts
+++ b/extensions/line/src/channel.rich-messages.test.ts
@@ -11,6 +11,22 @@ import {
 } from "./rich-messages.js";
 import type { LineRichCard } from "./types.js";
 
+describe("LINE agent prompt capabilities", () => {
+  const cfg = {
+    channels: { line: { enabled: true, channelAccessToken: "token", channelSecret: "secret" } },
+  } as never;
+
+  it("tells the agent it has the buttons the renderer produces", () => {
+    const advertised = linePlugin.agentPrompt?.messageToolCapabilities?.({ cfg });
+    const renders = lineOutboundAdapter.presentationCapabilities?.buttons === true;
+
+    // The prompt and the renderer answer the same question; a channel that says
+    // no here loses the button hint and is told to set a config key it has not got.
+    expect(renders).toBe(true);
+    expect(advertised).toContain("inlineButtons");
+  });
+});
+
 function resolveChannelDataSchema() {
   const discovery = lineMessageActions.describeMessageTool({
     cfg: {

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -120,10 +120,7 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = createChatChannelP
       defaultTopLevelPlacement: "current",
     },
     agentPrompt: {
-      // LINE renders presentation buttons on every account and has no switch to
-      // turn them off, so the prompt must offer them. Without this the agent is
-      // told inline buttons are off and to ask for a channels.line.capabilities
-      // key the strict account schema rejects.
+      // LINE always renders native buttons; it has no capability opt-in setting.
       messageToolCapabilities: () => ["inlineButtons"],
       messageToolHints: () => [
         "",

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -120,6 +120,11 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = createChatChannelP
       defaultTopLevelPlacement: "current",
     },
     agentPrompt: {
+      // LINE renders presentation buttons on every account and has no switch to
+      // turn them off, so the prompt must offer them. Without this the agent is
+      // told inline buttons are off and to ask for a channels.line.capabilities
+      // key the strict account schema rejects.
+      messageToolCapabilities: () => ["inlineButtons"],
       messageToolHints: () => [
         "",
         "### LINE structured output",

--- a/src/agents/channel-tools.line.test.ts
+++ b/src/agents/channel-tools.line.test.ts
@@ -1,0 +1,43 @@
+// Compose LINE's public plugin contract with the canonical runtime prompt.
+import { expect, it } from "vitest";
+import type { ChannelPlugin } from "../channels/plugins/types.public.js";
+import { loadBundledPluginPublicSurface } from "../plugin-sdk/test-helpers/public-surface-loader.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { resolveChannelMessageToolHints } from "./channel-tools.js";
+import { collectRuntimeChannelCapabilities } from "./runtime-capabilities.js";
+import { buildAgentSystemPrompt } from "./system-prompt.js";
+
+it("offers LINE buttons without prescribing an unsupported config setting", async () => {
+  const { linePlugin } = await loadBundledPluginPublicSurface<{ linePlugin: ChannelPlugin }>({
+    pluginId: "line",
+    artifactBasename: "api.js",
+  });
+  const snapshot = captureActivePluginRegistrySnapshot();
+  try {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "line", source: "test", plugin: linePlugin }]),
+    );
+    const channel = { cfg: {}, channel: "line" };
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw-line-prompt",
+      toolNames: ["message"],
+      runtimeInfo: {
+        channel: "line",
+        capabilities: collectRuntimeChannelCapabilities(channel),
+      },
+      messageToolHints: resolveChannelMessageToolHints(channel),
+    });
+
+    expect(prompt).toContain("Inline buttons: `send` with `presentation=");
+    expect(prompt).toContain("LINE maps them to Flex controls or quick replies");
+    expect(prompt).not.toContain("Inline buttons OFF for line");
+    expect(prompt).not.toContain("line.capabilities.inlineButtons");
+  } finally {
+    restoreActivePluginRegistrySnapshot(snapshot);
+  }
+});


### PR DESCRIPTION
## What Problem This Solves

LINE already renders portable buttons as Flex controls or quick replies, but its prompt capability declaration omitted `inlineButtons`. This made the shared agent prompt describe buttons as disabled and suggest an unsupported setting. Declare the existing capability at the LINE plugin owner, shorten the explanatory comment, and replace the declaration-only assertion with a regression that composes the public plugin, runtime collectors, and real system prompt.

## Why This Change Was Made

The final PR adds 2 production lines and 43 test lines. It introduces no setting and leaves the generic collector unchanged. Native execution-approval wording was independently fixed on main and is outside this repair; the linked issue's broader cross-channel questions remain separate.

## User Impact

LINE agents receive guidance for the inline buttons the plugin already supports.

## Evidence

Validation passed: the new regression fails against the pre-fix owner; 22 focused tests, the full build, and full changed-file gates pass on trusted main with the identical capability change and public-loader test. The loader and collectors are byte-identical to this PR's base. The contributor checkout was not executed locally; exact-head hosted CI is tracked separately for `995ff5508f3c9af72ae88de55c24a20f8521f183`.

A real ephemeral Gateway accepted a correctly signed synthetic LINE webhook, sent the corrected prompt to the mock provider, and delivered a reply through a synthetic LINE HTTP API:

```json
{"passed":true,"gateway":"real ephemeral Gateway","channelApi":"synthetic LINE HTTP","authenticatedLine":false,"webhookHttpStatus":200,"durableAcceptance":true,"modelRequests":1,"inlineButtonsGuidancePresent":true,"unsupportedSettingGuidanceAbsent":true,"lineReplyCount":1,"gatewayTemporaryStateRemoved":true}
```

ClawSweeper's comment-condensation rank-up is addressed. Fresh independent P0 review is clean. The final head follows the contributor directly; no unrelated main integration is included. Thanks @edenfunf.


Maintainer-reviewed head: `995ff5508f3c9af72ae88de55c24a20f8521f183`. Contributor credit is preserved.
