### PR TITLE
refactor: reduce repeated work during turn preparation

### DIFF
--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -6,6 +6,7 @@ import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js
 import type { OpenClawConfig } from "../../config/config.js";
 import * as mediaStore from "../../media/store.js";
 import * as webMedia from "../../media/web-media.js";
+import * as pluginConfig from "../../plugins/config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
 import { setCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata.test-support.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../../plugins/installed-plugin-index-policy.js";
@@ -159,12 +160,13 @@ function createVideoProviderSnapshot(params: {
   id: string;
   origin: PluginManifestRecord["origin"];
   referenceAudioInputs?: boolean;
+  unrelatedPluginCount?: number;
   workspaceDir?: string;
 }): PluginMetadataSnapshot {
   // Plugin-backed provider snapshots are synthesized here so tool behavior can
   // be tested without loading plugin manifests from disk.
   const policyHash = resolveInstalledPluginIndexPolicyHash(params.config);
-  const plugin: PluginManifestRecord = {
+  const providerPlugin: PluginManifestRecord = {
     id: params.id,
     origin: params.origin,
     rootDir: `/plugins/${params.id}`,
@@ -183,6 +185,17 @@ function createVideoProviderSnapshot(params: {
             [params.id]: { referenceAudioInputs: params.referenceAudioInputs },
           },
   };
+  const plugins = [
+    providerPlugin,
+    ...Array.from({ length: params.unrelatedPluginCount ?? 0 }, (_, index) => ({
+      ...providerPlugin,
+      id: `unrelated-${index}`,
+      rootDir: `/plugins/unrelated-${index}`,
+      source: `/plugins/unrelated-${index}/index.js`,
+      manifestPath: `/plugins/unrelated-${index}/openclaw.plugin.json`,
+      contracts: index % 2 === 0 ? undefined : { videoGenerationProviders: [] },
+    })),
+  ];
   const index: PluginMetadataSnapshot["index"] = {
     version: 1,
     hostContractVersion: "test",
@@ -191,23 +204,21 @@ function createVideoProviderSnapshot(params: {
     policyHash,
     generatedAtMs: 0,
     installRecords: {},
-    plugins: [
-      {
-        pluginId: params.id,
-        manifestPath: plugin.manifestPath,
-        manifestHash: "test",
-        source: plugin.source,
-        rootDir: plugin.rootDir,
-        origin: params.origin,
-        enabled: true,
-        startup: {
-          sidecar: false,
-          memory: false,
-          agentHarnesses: [],
-        },
-        compat: [],
+    plugins: plugins.map((plugin) => ({
+      pluginId: plugin.id,
+      manifestPath: plugin.manifestPath,
+      manifestHash: "test",
+      source: plugin.source,
+      rootDir: plugin.rootDir,
+      origin: params.origin,
+      enabled: true,
+      startup: {
+        sidecar: false,
+        memory: false,
+        agentHarnesses: [],
       },
-    ],
+      compat: [],
+    })),
     diagnostics: [],
   };
   return {
@@ -216,10 +227,10 @@ function createVideoProviderSnapshot(params: {
     index,
     registryIndex: index,
     registryDiagnostics: [],
-    manifestRegistry: { plugins: [plugin], diagnostics: [] },
-    plugins: [plugin],
+    manifestRegistry: { plugins, diagnostics: [] },
+    plugins,
     diagnostics: [],
-    byPluginId: new Map([[plugin.id, plugin]]),
+    byPluginId: new Map(plugins.map((plugin) => [plugin.id, plugin])),
     normalizePluginId: (pluginId) => pluginId,
     owners: {
       channels: new Map(),
@@ -237,8 +248,8 @@ function createVideoProviderSnapshot(params: {
       manifestRegistryMs: 0,
       ownerMapsMs: 0,
       totalMs: 0,
-      indexPluginCount: 1,
-      manifestPluginCount: 1,
+      indexPluginCount: plugins.length,
+      manifestPluginCount: plugins.length,
     },
   };
 }
@@ -469,22 +480,30 @@ describe("createVideoGenerateTool", () => {
       },
     });
     const workspaceDir = "/workspace/external-video";
-    setCurrentPluginMetadataSnapshot(
-      createVideoProviderSnapshot({
-        config,
-        id: "external-video",
-        origin: "workspace",
-        workspaceDir,
-      }),
-      { config, workspaceDir },
-    );
-    expect(getCurrentPluginMetadataSnapshot({ config, workspaceDir })).toBeDefined();
+    const normalize = vi.spyOn(pluginConfig, "normalizePluginsConfig");
+    const normalizationCounts: number[] = [];
+    for (const unrelatedPluginCount of [0, 32]) {
+      setCurrentPluginMetadataSnapshot(
+        createVideoProviderSnapshot({
+          config,
+          id: "external-video",
+          origin: "workspace",
+          unrelatedPluginCount,
+          workspaceDir,
+        }),
+        { config, workspaceDir },
+      );
+      expect(getCurrentPluginMetadataSnapshot({ config, workspaceDir })).toBeDefined();
+      createVideoGenerateTool({ config, workspaceDir });
+      normalize.mockClear();
+      const properties = toolParameterProperties(createVideoGenerateTool({ config, workspaceDir }));
+      normalizationCounts.push(normalize.mock.calls.length);
 
-    const properties = toolParameterProperties(createVideoGenerateTool({ config, workspaceDir }));
-
-    expect(properties.audioRef).toBeUndefined();
-    expect(properties.audioRefs).toBeUndefined();
-    expect(properties.audioRoles).toBeUndefined();
+      expect(properties.audioRef).toBeUndefined();
+      expect(properties.audioRefs).toBeUndefined();
+      expect(properties.audioRoles).toBeUndefined();
+    }
+    expect(normalizationCounts[1]).toBeLessThanOrEqual(normalizationCounts[0]!);
   });
 
   it("exposes reference-audio params for configured audio-capable model overrides", () => {

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -274,6 +274,7 @@ function shouldExposeVideoReferenceAudioParams(params: {
 
   for (const plugin of snapshot.plugins) {
     if (
+      !plugin.contracts?.videoGenerationProviders?.length ||
       !isManifestPluginAvailableForControlPlane({
         snapshot,
         plugin,
@@ -282,8 +283,7 @@ function shouldExposeVideoReferenceAudioParams(params: {
     ) {
       continue;
     }
-    const providerIds = plugin.contracts?.videoGenerationProviders ?? [];
-    for (const providerId of providerIds) {
+    for (const providerId of plugin.contracts.videoGenerationProviders) {
       knownProviderIds.add(providerId);
       const metadata = plugin.videoGenerationProviderMetadata?.[providerId];
       const providerCanUseReferenceAudio = metadata?.referenceAudioInputs === true;

--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -186,14 +186,16 @@ describe("SQLite session entry cache", () => {
       },
     });
 
-    const fullEntry = listSessionEntriesCore({ ...scope, clone: false, projection: "full" })[0]
-      ?.entry;
-    expect(fullEntry).toBeDefined();
-    if (!fullEntry) {
-      throw new Error("missing seeded lazy-list-projection entry");
-    }
     const cloneSpy = vi.spyOn(globalThis, "structuredClone");
     try {
+      const fullEntry = listSessionEntriesCore({
+        agentId: scope.agentId,
+        env: scope.env,
+      })[0]?.entry;
+      expect(fullEntry).toBeDefined();
+      if (!fullEntry) {
+        throw new Error("missing seeded lazy-list-projection entry");
+      }
       parseSessionEntryCalls.mockClear();
       const first = listSessionEntriesCore({
         ...scope,
@@ -221,11 +223,20 @@ describe("SQLite session entry cache", () => {
       expect(cached.entries.get(scope.sessionKey)?.skillsSnapshot).toBeUndefined();
       expect(cached.entries.get(scope.sessionKey)?.systemPromptReport).toBeUndefined();
 
-      const fullAgain = listSessionEntriesCore({ ...scope, clone: false, projection: "full" })[0]
-        ?.entry;
-      expect(fullAgain).toEqual(fullEntry);
+      fullEntry.worktree!.branch = "mutated full read";
+      fullEntry.skillsSnapshot!.prompt = "mutated full prompt";
+      const fullAgain = listSessionEntriesCore({ ...scope, projection: "full" })[0]?.entry;
+      expect(fullAgain?.worktree?.branch).toBe("main");
       expect(fullAgain?.skillsSnapshot?.prompt).toBe(prompt);
       expect(fullAgain?.systemPromptReport?.source).toBe("run");
+      expect(cloneSpy).not.toHaveBeenCalled();
+      expect(first?.worktree?.branch).toBe("main");
+
+      const copiedListEntry = listSessionEntriesCore(scope)[0]?.entry;
+      expect(copiedListEntry?.worktree?.branch).toBe("main");
+      expect(copiedListEntry?.worktree).not.toBe(first?.worktree);
+      copiedListEntry!.worktree!.branch = "mutated list copy";
+      expect(first?.worktree?.branch).toBe("main");
       expect(listSessionEntriesCore({ ...scope, clone: false, projection: "list" })[0]?.entry).toBe(
         first,
       );

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -27,10 +27,7 @@ import type {
   SessionEntryTargetPatchScope,
   SessionTranscriptReadScope,
 } from "./session-accessor.sqlite-contract.js";
-import {
-  readSessionEntryCache,
-  type SessionEntryCacheSnapshot,
-} from "./session-accessor.sqlite-entry-cache.js";
+import { readSessionEntryCache } from "./session-accessor.sqlite-entry-cache.js";
 import {
   assertLifecycleTargetSnapshotUnchanged,
   type SqliteLifecycleTargetSnapshot,
@@ -312,7 +309,16 @@ function listSqliteSessionEntriesFromDatabase(
   scope: SessionEntryListScope,
 ): SessionEntrySummary[] {
   assertCanonicalSqliteSessionKeysCurrent(database);
-  const snapshot = readSessionEntrySnapshot(database, resolved, scope);
+  const projection = scope.projection ?? "full";
+  const cache = !isIncognitoOpenClawAgentSqlitePath(database.path, {
+    agentId: database.agentId,
+    env: resolved.env,
+  });
+  const snapshot = readSessionEntryCache(database, {
+    cache,
+    latest: scope.readConsistency === "latest",
+    projection,
+  });
   return snapshot.keys.flatMap((sessionKey) => {
     if (isInternalSessionEffectsKey(sessionKey)) {
       return [];
@@ -327,28 +333,13 @@ function listSqliteSessionEntriesFromDatabase(
         `non-canonical persisted row resolves to session key ${deliveryCanonicalKey}`,
       );
     }
+    // Full snapshots own their nested values; list snapshots may share cached entries.
     return [
       {
         sessionKey,
-        entry: scope.clone === false ? entry : cloneSessionEntry(entry),
+        entry: projection === "list" && scope.clone !== false ? cloneSessionEntry(entry) : entry,
       },
     ];
-  });
-}
-
-function readSessionEntrySnapshot(
-  database: Pick<OpenClawAgentDatabase, "agentId" | "db" | "path">,
-  resolved: ResolvedSqliteScope,
-  scope: SessionEntryListScope,
-): SessionEntryCacheSnapshot {
-  const cache = !isIncognitoOpenClawAgentSqlitePath(database.path, {
-    agentId: database.agentId,
-    env: resolved.env,
-  });
-  return readSessionEntryCache(database, {
-    cache,
-    latest: scope.readConsistency === "latest",
-    projection: scope.projection ?? "full",
   });
 }
 

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -197,7 +197,7 @@ export function isTestDefaultMemorySlotDisabled(
   return true;
 }
 
-export function resolvePluginActivationState(params: {
+function resolvePluginActivationState(params: {
   id: string;
   origin: PluginOrigin;
   config: NormalizedPluginsConfig;


### PR DESCRIPTION
Related: #134814

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Gateway turn preparation repeats work that does not affect the resulting session data or tool schema: it deep-copies freshly allocated full session entries and evaluates video-provider policy for plugins with no video capability.

## Why This Change Was Made

Return the full session snapshot's owned values directly, retaining defensive copies for cached list entries, and inline the single-use snapshot wrapper. Filter manifests by video capability before evaluating the existing provider policy. Remove an unused activation-helper export exposed by the strengthened regression coverage.

The ownership boundaries stay explicit: SQLite owns fresh full reads; the list cache retains its copy boundary; actual video providers retain their policy checks. Production LOC: +16/-25 (**net -9**). Tests: +77/-47 (**net +30**). No new cache, configuration, dependency, or SQLite schema.

## User Impact

Less repeated work during turn preparation, with unchanged session isolation and video-tool availability. The live runs do **not** establish a reliable wall-clock speedup: host contention varied substantially. This is a measured work reduction and simplification, not a latency guarantee.

## Evidence

- Both regression checks failed before the production changes: a full read made a redundant clone, and adding 32 unrelated manifests increased plugin normalization work. They pass with the patch.
- **160 unique focused tests passed** across Gateway, SQLite session access, video tools, and plugin policy; the 45 video cases also passed a second time.
- Changed-code validation completed across the full and resumed runs. The full run reached a test-fixture shadowed-variable lint error after type and unused-export checks; the fixture was renamed, then scoped lint and every remaining guard passed. Build and diff checks passed.
- **168 real Gateway comparison turns** across baseline/candidate/baseline/candidate: 112 measured, 48 warmups, and 8 separately instrumented diagnostics. Plain, file-tool, and session-status outcomes were validated. Two additional final smoke turns passed.
- In both paired diagnostic repeats, per two plain turns, `cloneSessionEntry` calls fell **296 to 64 (78.4%)** and `normalizePluginsConfig` calls fell **1,422 to 878 (38.3%)**. Session parsing remained **1,337 to 1,337**. These are exact function counts, not reductions in total runtime or all clone calls.
- The same prompts, starting session snapshot, and requested model/effort were used. Measurements cover the Control UI client's Gateway WebSocket flow, not browser rendering. Recorded markers verify the requested model; they do not independently attest the provider's accepted model.
- Fresh Codex Autoreview of the exact five-file patch, repeated after refreshing the base: **P0 scoped-clean**, no findings. Independent owner-boundary and evidence review found no blocker.

Remaining session parsing is a possible follow-up; reducing it would require a separate review of narrower read ownership and is outside this small cleanup.

CI on the initial head exposed the existing release-inventory `spawnSync git ENOBUFS` failure ([failed job](https://github.com/openclaw/openclaw/actions/runs/33477523229/job/99759936470)). Refreshed onto the canonical metadata-enumeration repair already landed in #134824; no additional fix is included in this PR. All **48 release-plan producer tests** now pass locally, including the original failing inventory test, the large-tree regression, and symlink controls. The five-file patch remains byte-for-byte identical; [Hosted CI passed on the refreshed head](https://github.com/openclaw/openclaw/actions/runs/33478713210), including both Windows lanes and the required gate.

ClawSweeper review follow-through: the 06:30 UTC review found no actionable code issues and requested ordinary maintainer review plus exact-head checks. Maintainer review is complete. Its path-based stored-data warning was checked: there is **no SQLite schema, serialized format, or read/write persistence change**, so no migration is required. Fresh-full and cached-list mutation-isolation coverage remains intact.
