### PR TITLE
fix(models): show newly authenticated providers after a config reload

### DIFF
--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -48,6 +48,8 @@ export function resolvePreparedModelRuntimeOwnerBySnapshot(
   return ownersBySnapshot.get(snapshot);
 }
 
+// Sole permitted writer of `owner.snapshot`. The map keys on snapshot identity, so any
+// assignment that bypasses this leaves the owner unreachable from the snapshot readers hold.
 function publishPreparedModelRuntimeOwnerSnapshot(
   owner: PreparedModelRuntimeOwner,
   snapshot: PreparedModelRuntimeSnapshot,
@@ -261,8 +263,12 @@ export function advancePreparedModelRuntimeOwnerConfig(
   owner.input = { ...owner.input, config };
   if (owner.snapshot) {
     // Existing leases retain their immutable snapshot. New readers receive the same prepared
-    // generation with only its planner-approved, model-neutral config stamp advanced.
-    owner.snapshot = stampPreparedModelRuntimeSnapshotConfig(owner.snapshot, config);
+    // generation with only its planner-approved, model-neutral config stamp advanced. The stamp
+    // mints a new snapshot identity, so it has to move the owner's snapshot index with it.
+    publishPreparedModelRuntimeOwnerSnapshot(
+      owner,
+      stampPreparedModelRuntimeSnapshotConfig(owner.snapshot, config),
+    );
   }
 }
 

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -14,6 +14,7 @@ import {
 import { loadPreparedModelCatalogOwnerSnapshot } from "./prepared-model-catalog.js";
 import {
   acquireAgentRunPreparedModelRuntime,
+  advancePreparedModelRuntimeConfig,
   loadPublishedGatewayReplyDispatchRuntime,
   prepareModelRuntimeSnapshot,
   refreshStalePreparedModelRuntimeCatalog,
@@ -809,6 +810,51 @@ describe("prepared model runtime reload auth adoption", () => {
       configBuild.resolve({ agentDir: state.agentDir("default"), wrote: false });
       await Promise.allSettled([authWaiter, reload]);
     }
+  });
+
+  it("keeps a stale catalog reachable after a model-neutral config stamp advance", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const model = {
+      provider: "catalog-refresh-fixture",
+      id: "authenticated-model",
+      name: "Authenticated model",
+      api: "openai-completions" as const,
+    };
+    mocks.runPreparedModelCatalogWorker.mockResolvedValue({
+      entries: [model],
+      routeVariants: [model],
+    });
+    const input = {
+      agentId: "default",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
+      config: {},
+    };
+    await refreshPreparedModelRuntimeSnapshots(input.config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+    await prepareModelRuntimeSnapshot(input);
+
+    mocks.mutationListener?.({
+      agentDir: input.agentDir,
+      affectsInheritedStores: false,
+      profileSetChanged: true,
+    });
+    await prepareModelRuntimeSnapshot(input);
+
+    // A model-neutral runtime config commit re-stamps every published owner in place. The stamp
+    // mints a new snapshot identity, which must stay resolvable back to the owner holding the
+    // stale flag; otherwise the next explicit browse silently serves the pre-mutation catalog.
+    advancePreparedModelRuntimeConfig({});
+
+    const advanced = await prepareModelRuntimeSnapshot(input);
+    mocks.runPreparedModelCatalogWorker.mockClear();
+    await expect(refreshStalePreparedModelRuntimeCatalog(advanced)).resolves.toMatchObject({
+      entries: [model],
+    });
+    expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
+    await expect(refreshStalePreparedModelRuntimeCatalog(advanced)).resolves.toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Related: #134361

## What Problem This Solves

Fixes an issue where an operator who runs `models auth login` and then triggers any ordinary gateway config reload is still shown the pre-login model catalog in `/models` and `models.list`. The catalog is marked stale by the auth change, but the refresh that is supposed to consume that flag on the next explicit browse silently does not run, so the newly authenticated provider's models never appear until the gateway restarts.

This is the exact failure #134361 shipped to fix; it comes back whenever a model-neutral runtime-config commit lands between the login and the browse.

## Why This Change Was Made

#134361 added `ownersBySnapshot`, a `WeakMap` from a published snapshot to its owner, so `refreshStalePreparedModelRuntimeCatalog` can find the owner holding `catalogStale` without scanning every owner. `publishPreparedModelRuntimeOwnerSnapshot` is its only writer.

`advancePreparedModelRuntimeOwnerConfig` assigns `owner.snapshot` directly, bypassing that writer:

```ts
owner.snapshot = stampPreparedModelRuntimeSnapshotConfig(owner.snapshot, config);
```

`stampPreparedModelRuntimeSnapshotConfig` returns `Object.freeze({ ...snapshot, config })`, a new object identity, in exactly the case that reaches this line. The map keeps pointing at the retired snapshot, the snapshot readers now receive is absent from it, and the lookup returns `undefined`. `catalogStale` is untouched by the advance, so the flag stays set while the code that consumes it can no longer resolve its owner.

Both callers are live gateway paths: `advancePreparedModelRuntimeConfig` runs from `gateway/server-reload-managed.ts` on every model-neutral runtime-config commit, and `updateOwnersForScopedRefresh` advances every owner outside a scoped refresh.

The fix routes that assignment through the writer, and the writer now carries a comment stating it is the only permitted assignment site, so a future `owner.snapshot =` elsewhere is visibly out of contract. It is behaviour-preserving for every path that does not take a config advance: the previous owner scan read `owner.snapshot` at call time, which is what the map now reflects.

## User Impact

After authenticating a new provider, an explicit model browse refreshes the catalog as intended even if a config reload happened in between. Nothing else changes: the refresh still runs only on an explicit read that opts in, and owners that never take a config advance behave exactly as before.

## Evidence

Regression test added to `src/agents/prepared-model-runtime.reload-auth.test.ts`: publish, apply a `profileSetChanged` auth mutation, advance the config stamp in place, then refresh from the snapshot readers now hold.

The measurement that motivated it, counting `runPreparedModelCatalogWorker` invocations across two arms that differ only by the `advancePreparedModelRuntimeConfig({})` call:

| | without config advance | with config advance |
| --- | --- | --- |
| `main` | worker x1, `["authenticated-model"]` | worker x0, `undefined` |
| this branch | worker x1, `["authenticated-model"]` | worker x1, `["authenticated-model"]` |

End to end through `loadPreparedModelCatalogOwnerSnapshot({ readOnly: true, refreshFullCatalog: true })` the same split shows up as reaching `materializeRequestedModelCatalog` versus returning `entries: []` without ever attempting the refresh.

The new test is load-bearing. Reverting only the `prepared-model-runtime.owner.ts` change and rerunning the file:

```
Tests  1 failed | 15 passed (16)
x keeps a stale catalog reachable after a model-neutral config stamp advance
```

With the change applied, all 16 pass:

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts \
  src/agents/prepared-model-runtime.reload-auth.test.ts
Test Files  1 passed (1)
     Tests  16 passed (16)
```

Local gates, all clean against `origin/main`:

```
oxlint -c .oxlintrc.json <changed files>          exit 0
oxfmt --check <changed files>                     All matched files use the correct format.
check-max-lines-ratchet.mts --base origin/main    max-lines ratchet OK: 873 grandfathered suppressions.
check-assertion-safety-ratchet.mts --base origin/main
                                                  assertion SAFETY ratchet OK: 4130 files, 12735 grandfathered assertions.
check-deadcode-exports.mts                        Knip production unused-export scan passed with 0 entries.
```
