### PR TITLE
fix(voice-call): stop reporting host cancellation as tool failure

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1345,7 +1345,7 @@ extensions/voice-call/src/response-generator.ts	3
 extensions/voice-call/src/runtime.ts	3
 extensions/voice-call/src/tts-provider-voice.ts	1
 extensions/voice-call/src/webhook.ts	10
-extensions/voice-call/src/webhook/realtime-handler.ts	3
+extensions/voice-call/src/webhook/realtime-handler.ts	1
 extensions/volcengine/tts.ts	2
 extensions/voyage/embedding-batch.ts	1
 extensions/vydra/shared.ts	2

--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -352,6 +352,10 @@ close and the inactivity backstop remain independent of it.
 | `substantive` | Answer simple conversational glue directly and consult before facts, memory, tools, or context. |
 | `always`      | Consult before every substantive answer.                                                        |
 
+When a host tool run reports cancellation, the realtime model receives a
+cancelled result and the phone call stays open. Timeouts and other tool failures
+remain errors; ending the phone session suppresses pending consult results.
+
 ### Agent voice context
 
 Enable `realtime.agentContext` when the voice bridge should sound like the

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -15,7 +15,7 @@ import type { CallManager } from "../manager.js";
 import type { CallRecord, NormalizedEvent } from "../types.js";
 import { connectWs, startUpgradeWsServer, waitForClose } from "../websocket-test-support.js";
 import { RealtimeAudioPacer } from "./realtime-audio-pacer.js";
-import { RealtimeCallHandler } from "./realtime-handler.js";
+import { RealtimeCallHandler, type ToolHandlerContext } from "./realtime-handler.js";
 import { StreamDisconnectGrace } from "./stream-disconnect-grace.js";
 
 const realtimeVoiceHarnessTestHooks = vi.hoisted(() => ({
@@ -1754,6 +1754,138 @@ describe("RealtimeCallHandler path routing", () => {
     } finally {
       await server.close();
     }
+  });
+
+  describe.each(["forced", "native", "general"] as const)("%s host tool outcomes", (path) => {
+    const cancelled = { status: "cancelled", message: "Cancelled the active OpenClaw run." };
+    it.each([
+      { label: "AbortSignal cancellation", error: AbortSignal.abort().reason, result: cancelled },
+      {
+        label: "named AbortError",
+        error: Object.assign(new Error("Host run stopped"), { name: "AbortError" }),
+        result: cancelled,
+      },
+      {
+        label: "standard abort message",
+        error: new Error("This operation was aborted"),
+        result: cancelled,
+      },
+      {
+        label: "TimeoutError",
+        error: new DOMException("Host run timed out", "TimeoutError"),
+        result: { error: "Host run timed out" },
+      },
+      {
+        label: "ordinary error mentioning abort",
+        error: new Error("Operation aborted"),
+        result: { error: "Operation aborted" },
+      },
+      { label: "successful answer", result: { text: "The deployment is healthy." } },
+      { label: "returned cancellation", result: { text: "", canceled: true } },
+      { label: "returned timeout", result: { text: "The run timed out.", timedOut: true } },
+    ])("projects $label once per provider call while the phone stays open", async (outcome) => {
+      let callbacks: RealtimeBridgeRequest | undefined;
+      const submitToolResult = vi.fn();
+      const sendUserMessage = vi.fn();
+      const closeBridge = vi.fn();
+      const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+        callbacks = request;
+        return makeBridge({
+          supportsToolResultContinuation: true,
+          submitToolResult,
+          sendUserMessage,
+          close: closeBridge,
+        });
+      });
+      const call = makeCallRecord("CA-host-outcome");
+      const handler = makeHandler(
+        { consultPolicy: path === "forced" ? "always" : "auto" },
+        {
+          manager: { getCallByProviderCallId: vi.fn(() => call) },
+          realtimeProvider: makeRealtimeProvider(createBridge),
+        },
+      );
+      const pending = createDeferred<unknown>();
+      const hostTool = vi.fn(
+        (_args: unknown, _callId: string, _context: ToolHandlerContext) => pending.promise,
+      );
+      const name = path === "general" ? "custom_lookup" : "openclaw_agent_consult";
+      handler.registerToolHandler(name, hostTool);
+      const server = await startRealtimeServer(handler);
+      const ws = await connectWs(server.url);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      try {
+        ws.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-host", callSid: call.providerCallId },
+          }),
+        );
+        await waitForRealtimeTest(() => expect(createBridge).toHaveBeenCalledOnce());
+        const provider = expectDefined(callbacks, "provider callbacks");
+        vi.useFakeTimers();
+        const question = "Check the deployment.";
+        if (path === "forced") {
+          provider.onTranscript?.("user", question, true);
+          await vi.advanceTimersByTimeAsync(200);
+          expect(hostTool).toHaveBeenCalledOnce();
+        }
+        const callIds = path === "general" ? ["host-tool"] : ["host-tool", "shared-host-tool"];
+        for (const callId of callIds) {
+          provider.onToolCall?.({ itemId: callId, callId, name, args: { question } });
+        }
+        await vi.advanceTimersByTimeAsync(0);
+        expect(hostTool).toHaveBeenCalledOnce();
+        expect(hostTool.mock.calls[0]?.[2].abortSignal?.aborted).toBe(
+          path === "general" ? undefined : false,
+        );
+
+        if ("error" in outcome) {
+          pending.reject(outcome.error);
+        } else {
+          pending.resolve(outcome.result);
+        }
+        await vi.advanceTimersByTimeAsync(0);
+
+        const finals = submitToolResult.mock.calls.filter(
+          (submission) => !submission[2]?.willContinue,
+        );
+        expect(finals).toEqual(callIds.map((callId) => [callId, outcome.result, undefined]));
+        const terminalEvents = recentTalkEvents(call).filter((event) =>
+          ["tool.result", "tool.error"].includes(event.type),
+        );
+        expect(terminalEvents.map((event) => event.type)).toEqual(
+          callIds.map(() => ("error" in outcome.result ? "tool.error" : "tool.result")),
+        );
+        if (path === "forced") {
+          const failures = warn.mock.calls.filter(([message]) =>
+            String(message).includes("realtime forced agent consult failed"),
+          );
+          expect(failures).toHaveLength("error" in outcome.result ? 1 : 0);
+          if (outcome.result === cancelled) {
+            expect(log).toHaveBeenCalledWith(
+              expect.stringContaining("realtime forced agent consult cancelled"),
+            );
+          }
+        }
+        expect(sendUserMessage).not.toHaveBeenCalled();
+        expect(closeBridge).not.toHaveBeenCalled();
+        expect(ws.readyState).toBe(WebSocket.OPEN);
+        expect(hostTool.mock.calls[0]?.[2].abortSignal?.aborted).toBe(
+          path === "general" ? undefined : false,
+        );
+      } finally {
+        warn.mockRestore();
+        log.mockRestore();
+        pending.resolve(undefined);
+        vi.useRealTimers();
+        ws.terminate();
+        await handler.close();
+        await server.close();
+      }
+    });
   });
 
   it("terminally satisfies a late native call for a cancelled forced consult", async () => {

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1758,7 +1758,7 @@ describe("RealtimeCallHandler path routing", () => {
 
   describe.each(["forced", "native", "general"] as const)("%s host tool outcomes", (path) => {
     const cancelled = { status: "cancelled", message: "Cancelled the active OpenClaw run." };
-    it.each([
+    const outcomes = [
       { label: "AbortSignal cancellation", error: AbortSignal.abort().reason, result: cancelled },
       {
         label: "named AbortError",
@@ -1783,7 +1783,15 @@ describe("RealtimeCallHandler path routing", () => {
       { label: "successful answer", result: { text: "The deployment is healthy." } },
       { label: "returned cancellation", result: { text: "", canceled: true } },
       { label: "returned timeout", result: { text: "The run timed out.", timedOut: true } },
-    ])("projects $label once per provider call while the phone stays open", async (outcome) => {
+    ];
+    it.each(
+      outcomes.flatMap((outcome) => [
+        { ...outcome, synchronous: false },
+        ...(path === "general" && "error" in outcome
+          ? [{ ...outcome, synchronous: true, label: `synchronous ${outcome.label}` }]
+          : []),
+      ]),
+    )("projects $label once per provider call while the phone stays open", async (outcome) => {
       let callbacks: RealtimeBridgeRequest | undefined;
       const submitToolResult = vi.fn();
       const sendUserMessage = vi.fn();
@@ -1806,9 +1814,12 @@ describe("RealtimeCallHandler path routing", () => {
         },
       );
       const pending = createDeferred<unknown>();
-      const hostTool = vi.fn(
-        (_args: unknown, _callId: string, _context: ToolHandlerContext) => pending.promise,
-      );
+      const hostTool = vi.fn((_args: unknown, _callId: string, _context: ToolHandlerContext) => {
+        if (outcome.synchronous && "error" in outcome) {
+          throw outcome.error;
+        }
+        return pending.promise;
+      });
       const name = path === "general" ? "custom_lookup" : "openclaw_agent_consult";
       handler.registerToolHandler(name, hostTool);
       const server = await startRealtimeServer(handler);
@@ -1842,7 +1853,7 @@ describe("RealtimeCallHandler path routing", () => {
           path === "general" ? undefined : false,
         );
 
-        if ("error" in outcome) {
+        if ("error" in outcome && !outcome.synchronous) {
           pending.reject(outcome.error);
         } else {
           pending.resolve(outcome.result);

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1785,13 +1785,14 @@ describe("RealtimeCallHandler path routing", () => {
       { label: "returned timeout", result: { text: "The run timed out.", timedOut: true } },
     ];
     it.each(
-      outcomes.flatMap((outcome) => [
-        { ...outcome, synchronous: false },
-        ...(path === "general" && "error" in outcome
-          ? [{ ...outcome, synchronous: true, label: `synchronous ${outcome.label}` }]
-          : []),
-      ]),
-    )("projects $label once per provider call while the phone stays open", async (outcome) => {
+      outcomes.flatMap((outcome) => {
+        const asynchronous = { outcome, synchronous: false, label: outcome.label };
+        return path === "general" && "error" in outcome
+          ? [asynchronous, { outcome, synchronous: true, label: `synchronous ${outcome.label}` }]
+          : [asynchronous];
+      }),
+    )("projects $label once per provider call while the phone stays open", async (testCase) => {
+      const { outcome, synchronous } = testCase;
       let callbacks: RealtimeBridgeRequest | undefined;
       const submitToolResult = vi.fn();
       const sendUserMessage = vi.fn();
@@ -1815,7 +1816,7 @@ describe("RealtimeCallHandler path routing", () => {
       );
       const pending = createDeferred<unknown>();
       const hostTool = vi.fn((_args: unknown, _callId: string, _context: ToolHandlerContext) => {
-        if (outcome.synchronous && "error" in outcome) {
+        if (synchronous && "error" in outcome) {
           throw outcome.error;
         }
         return pending.promise;
@@ -1853,7 +1854,7 @@ describe("RealtimeCallHandler path routing", () => {
           path === "general" ? undefined : false,
         );
 
-        if ("error" in outcome && !outcome.synchronous) {
+        if ("error" in outcome && !synchronous) {
           pending.reject(outcome.error);
         } else {
           pending.resolve(outcome.result);

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import {
   buildRealtimeVoiceAgentConsultWorkingResponse,
+  buildRealtimeVoiceAgentErrorProviderResult,
   calculateMulawRms,
   createRealtimeVoiceSessionHarness,
   createSpeechThresholdGate,
@@ -1676,8 +1677,11 @@ export class RealtimeCallHandler {
       );
     } catch (error) {
       if (!state.cancelled) {
-        console.warn(
-          `[voice-call] realtime forced agent consult failed callId=${params.callId} providerCallId=${params.callSid} error=${formatErrorMessage(error)}`,
+        const result = buildRealtimeVoiceAgentErrorProviderResult(error);
+        const failed = "error" in result;
+        const report = failed ? console.warn : console.log;
+        report(
+          `[voice-call] realtime forced agent consult ${failed ? "failed" : "cancelled"} callId=${params.callId} providerCallId=${params.callSid}${failed ? ` error=${result.error}` : ""}`,
         );
       }
     } finally {
@@ -1899,9 +1903,9 @@ export class RealtimeCallHandler {
           return;
         }
         forcedConsult.sendSpeechPrompt = false;
-        const result = await forcedConsult.promise.catch((error: unknown) => ({
-          error: formatErrorMessage(error),
-        }));
+        const result = await forcedConsult.promise.catch(
+          buildRealtimeVoiceAgentErrorProviderResult,
+        );
         if (
           forcedConsult.cancelled ||
           forcedConsult.owner !== bridge ||
@@ -1975,9 +1979,7 @@ export class RealtimeCallHandler {
             ? { error: `Tool "${name}" not available` }
             : await handler(handlerArgs, callId, context);
         } catch (error) {
-          return {
-            error: formatErrorMessage(error),
-          };
+          return buildRealtimeVoiceAgentErrorProviderResult(error);
         }
       })().then(completeConsult);
       try {
@@ -1986,10 +1988,7 @@ export class RealtimeCallHandler {
           return;
         }
         const result = outcome.result;
-        const status =
-          result && typeof result === "object" && !Array.isArray(result) && "error" in result
-            ? "error"
-            : "ok";
+        const status = hasResultError(result) ? "error" : "ok";
         const error =
           status === "error" && result && typeof result === "object" && !Array.isArray(result)
             ? formatErrorMessage((result as { error?: unknown }).error ?? "unknown")
@@ -2018,19 +2017,10 @@ export class RealtimeCallHandler {
     const context = {
       partialUserTranscript: this.resolveUserTranscriptContext(callId, userTranscriptOwner),
     };
-    const handlerArgs =
-      name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME
-        ? withFallbackConsultQuestion(args, context.partialUserTranscript)
-        : args;
     const result = !handler
       ? { error: `Tool "${name}" not available` }
-      : await handler(handlerArgs, callId, context).catch((error: unknown) => ({
-          error: formatErrorMessage(error),
-        }));
-    const status =
-      result && typeof result === "object" && !Array.isArray(result) && "error" in result
-        ? "error"
-        : "ok";
+      : await handler(args, callId, context).catch(buildRealtimeVoiceAgentErrorProviderResult);
+    const status = hasResultError(result) ? "error" : "ok";
     const error =
       status === "error" && result && typeof result === "object" && !Array.isArray(result)
         ? formatErrorMessage((result as { error?: unknown }).error ?? "unknown")
@@ -2039,9 +2029,6 @@ export class RealtimeCallHandler {
       `[voice-call] realtime tool call completed callId=${callId} tool=${name} status=${status} elapsedMs=${Date.now() - startedAt}${error ? ` error=${error}` : ""}`,
     );
     await submitFinalToolResult(result);
-    if (name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME && status === "ok") {
-      this.consumePartialUserTranscript(callId, userTranscriptOwner, context.partialUserTranscript);
-    }
   }
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -1829,9 +1829,9 @@ export class RealtimeCallHandler {
     }
     const handler = this.toolHandlers.get(name);
     const startedAt = Date.now();
-    const hasResultError = (result: unknown): boolean => {
-      return Boolean(
-        result && typeof result === "object" && !Array.isArray(result) && "error" in result,
+    const hasResultError = (result: unknown): result is { error: unknown } => {
+      return (
+        result !== null && typeof result === "object" && !Array.isArray(result) && "error" in result
       );
     };
     const emitFinalToolEvent = (result: unknown): void => {
@@ -1988,16 +1988,13 @@ export class RealtimeCallHandler {
           return;
         }
         const result = outcome.result;
-        const status = hasResultError(result) ? "error" : "ok";
-        const error =
-          status === "error" && result && typeof result === "object" && !Array.isArray(result)
-            ? formatErrorMessage((result as { error?: unknown }).error ?? "unknown")
-            : undefined;
+        const failed = hasResultError(result);
+        const error = failed ? formatErrorMessage(result.error ?? "unknown") : undefined;
         console.log(
-          `[voice-call] realtime tool call completed callId=${callId} tool=${name} status=${status} elapsedMs=${Date.now() - startedAt}${error ? ` error=${error}` : ""}`,
+          `[voice-call] realtime tool call completed callId=${callId} tool=${name} status=${failed ? "error" : "ok"} elapsedMs=${Date.now() - startedAt}${error ? ` error=${error}` : ""}`,
         );
         await submitFinalToolResult(result);
-        if (status === "ok") {
+        if (!failed) {
           this.consumePartialUserTranscript(
             callId,
             userTranscriptOwner,
@@ -2017,16 +2014,19 @@ export class RealtimeCallHandler {
     const context = {
       partialUserTranscript: this.resolveUserTranscriptContext(callId, userTranscriptOwner),
     };
-    const result = !handler
-      ? { error: `Tool "${name}" not available` }
-      : await handler(args, callId, context).catch(buildRealtimeVoiceAgentErrorProviderResult);
-    const status = hasResultError(result) ? "error" : "ok";
-    const error =
-      status === "error" && result && typeof result === "object" && !Array.isArray(result)
-        ? formatErrorMessage((result as { error?: unknown }).error ?? "unknown")
-        : undefined;
+    let result: unknown;
+    try {
+      result = !handler
+        ? { error: `Tool "${name}" not available` }
+        : await handler(args, callId, context);
+    } catch (error) {
+      result = buildRealtimeVoiceAgentErrorProviderResult(error);
+    }
+    const error = hasResultError(result)
+      ? formatErrorMessage(result.error ?? "unknown")
+      : undefined;
     console.log(
-      `[voice-call] realtime tool call completed callId=${callId} tool=${name} status=${status} elapsedMs=${Date.now() - startedAt}${error ? ` error=${error}` : ""}`,
+      `[voice-call] realtime tool call completed callId=${callId} tool=${name} status=${error === undefined ? "ok" : "error"} elapsedMs=${Date.now() - startedAt}${error ? ` error=${error}` : ""}`,
     );
     await submitFinalToolResult(result);
   }

--- a/src/agents/compaction.summarize-fallback.test.ts
+++ b/src/agents/compaction.summarize-fallback.test.ts
@@ -4,6 +4,7 @@ import type { ExtensionContext } from "openclaw/plugin-sdk/agent-sessions";
 import type { UserMessage } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CompactionError } from "../../packages/agent-core/src/harness/types.js";
+import { isAbortError } from "../infra/abort-signal.js";
 import { summarizeWithFallback } from "./compaction.test-support.js";
 
 const agentSessionMocks = vi.hoisted(() => ({
@@ -57,30 +58,43 @@ describe("summarizeWithFallback", () => {
     vi.useRealTimers();
   });
 
-  it("throws CompactionError when all summarization attempts fail", async () => {
-    const messages: AgentMessage[] = [
-      {
-        role: "user",
-        content: "hello",
-        timestamp: 1,
-      } satisfies UserMessage,
-    ];
+  it.each([
+    { error: new Error("Summarization failed: fetch failed"), attempts: 1 },
+    { error: new DOMException("This operation was aborted", "AbortError"), attempts: 3 },
+  ])(
+    "throws CompactionError after $attempts failed attempts: $error.name",
+    async ({ error, attempts }) => {
+      agentSessionMocks.generateSummary.mockRejectedValue(error);
+      const signal = new AbortController().signal;
+      const messages: AgentMessage[] = [
+        {
+          role: "user",
+          content: "hello",
+          timestamp: 1,
+        } satisfies UserMessage,
+      ];
 
-    const result = expect(
-      summarizeWithFallback({
-        messages,
-        model: testModel,
-        apiKey: "test-key", // pragma: allowlist secret
-        signal: new AbortController().signal,
-        reserveTokens: 1000,
-        maxChunkTokens: 50_000,
-        contextWindow: 200_000,
-      }),
-    ).rejects.toThrow("All summarization attempts failed for 1 messages");
-    await finishAssertionWithTimers(result);
-    // "fetch failed" is timeout-classed now, so summarizeChunks does not retry it.
-    expect(agentSessionMocks.generateSummary).toHaveBeenCalledTimes(1);
-  });
+      const result = expect(
+        summarizeWithFallback({
+          messages,
+          model: testModel,
+          apiKey: "test-key", // pragma: allowlist secret
+          signal,
+          reserveTokens: 1000,
+          maxChunkTokens: 50_000,
+          contextWindow: 200_000,
+        }).catch((failure: unknown) => {
+          expect(failure).toBeInstanceOf(CompactionError);
+          expect(isAbortError(failure)).toBe(false);
+          throw failure;
+        }),
+      ).rejects.toThrow("All summarization attempts failed for 1 messages");
+      await finishAssertionWithTimers(result);
+      // "fetch failed" is timeout-classed now, so summarizeChunks does not retry it.
+      expect(agentSessionMocks.generateSummary).toHaveBeenCalledTimes(attempts);
+      expect(signal.aborted).toBe(false);
+    },
+  );
 
   it("retries provider-side AbortError and returns a real summary when caller signal is not aborted", async () => {
     // Reproduce the undici AbortError("This operation was aborted") shape thrown

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -1,5 +1,7 @@
 // Coverage for assistant failover decisions and auth-profile rotation.
 import { describe, expect, it, vi } from "vitest";
+import { projectProviderError } from "../../../../packages/ai/src/utils/provider-error.js";
+import { buildRealtimeVoiceAgentErrorProviderResult } from "../../../talk/agent-run-control.js";
 import { formatBillingErrorMessage } from "../../embedded-agent-helpers.js";
 import { FailoverError } from "../../failover-error.js";
 import { handleAssistantFailover, isShortWindowRateLimitMessage } from "./assistant-failover.js";
@@ -518,6 +520,49 @@ describe("handleAssistantFailover", () => {
   });
 
   describe("surface_error branch (openclaw#70124)", () => {
+    it.each([
+      Object.assign(new Error("This operation was aborted"), { name: "AbortError" }),
+      Object.assign(new Error("The operation timed out"), { name: "TimeoutError" }),
+      new Error("provider connection failed"),
+    ])(
+      "keeps provider $name failures visible to realtime voice with an active caller",
+      async (error) => {
+        const signal = new AbortController().signal;
+        const projected = projectProviderError(error, signal);
+        expect(projected.stopReason).toBe("error");
+        const outcome = await handleAssistantFailover(
+          makeParams({
+            initialDecision: { action: "surface_error", reason: null },
+            failoverReason: null,
+            billingFailure: false,
+            lastAssistant: {
+              role: "assistant",
+              api: "openai-completions",
+              provider: "openai",
+              model: "test-model",
+              content: [],
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              timestamp: 0,
+              ...projected,
+            },
+          }),
+        );
+        const failure = expectThrownFailoverError(outcome);
+        expect(failure.rawError).toBe(error.message);
+        expect(buildRealtimeVoiceAgentErrorProviderResult(failure)).toEqual({
+          error: failure.message,
+        });
+        expect(signal.aborted).toBe(false);
+      },
+    );
+
     it("logs the incremented count after a successful transient retry", async () => {
       let transientRetryCount = 0;
       const logAssistantFailoverDecision = vi.fn();

--- a/src/plugin-sdk/realtime-voice.ts
+++ b/src/plugin-sdk/realtime-voice.ts
@@ -157,6 +157,7 @@ export {
 export {
   buildRealtimeVoiceAgentCancelProviderResult,
   buildRealtimeVoiceAgentControlSpeechMessage,
+  buildRealtimeVoiceAgentErrorProviderResult,
   classifyRealtimeVoiceAgentControlText,
   controlRealtimeVoiceAgentRun,
   normalizeRealtimeVoiceAgentControlMode,

--- a/src/talk/agent-run-control-shared.ts
+++ b/src/talk/agent-run-control-shared.ts
@@ -9,6 +9,8 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { isAbortError } from "../infra/abort-signal.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import type { RealtimeVoiceTool } from "./provider-types.js";
 import type { TalkEvent } from "./talk-events.js";
 
@@ -289,6 +291,15 @@ export function buildRealtimeVoiceAgentCancelProviderResult(
     status: "cancelled",
     message,
   };
+}
+
+/** Host cancellation can settle a tool while its voice session remains open. */
+export function buildRealtimeVoiceAgentErrorProviderResult(
+  error: unknown,
+): RealtimeVoiceAgentControlProviderResult | { error: string } {
+  return isAbortError(error)
+    ? buildRealtimeVoiceAgentCancelProviderResult()
+    : { error: formatErrorMessage(error) };
 }
 
 /** Wrap follow-up text so an active run treats it as deferred context. */

--- a/src/talk/agent-run-control-shared.ts
+++ b/src/talk/agent-run-control-shared.ts
@@ -9,8 +9,6 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { isAbortError } from "../infra/abort-signal.js";
-import { formatErrorMessage } from "../infra/errors.js";
 import type { RealtimeVoiceTool } from "./provider-types.js";
 import type { TalkEvent } from "./talk-events.js";
 
@@ -291,15 +289,6 @@ export function buildRealtimeVoiceAgentCancelProviderResult(
     status: "cancelled",
     message,
   };
-}
-
-/** Host cancellation can settle a tool while its voice session remains open. */
-export function buildRealtimeVoiceAgentErrorProviderResult(
-  error: unknown,
-): RealtimeVoiceAgentControlProviderResult | { error: string } {
-  return isAbortError(error)
-    ? buildRealtimeVoiceAgentCancelProviderResult()
-    : { error: formatErrorMessage(error) };
 }
 
 /** Wrap follow-up text so an active run treats it as deferred context. */

--- a/src/talk/agent-run-control.ts
+++ b/src/talk/agent-run-control.ts
@@ -8,12 +8,15 @@ import type {
   ActiveEmbeddedRunOwner,
   EmbeddedAgentQueueMessageOutcome,
 } from "../agents/embedded-agent-runner/runs.js";
+import { isAbortError } from "../infra/abort-signal.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import {
   buildRealtimeVoiceAgentCancelProviderResult,
   buildRealtimeVoiceAgentFollowupSteeringText,
   formatRealtimeVoiceAgentQueueRejection,
   formatRealtimeVoiceAgentStatus,
   resolveRealtimeVoiceAgentControlIntent,
+  type RealtimeVoiceAgentControlProviderResult,
   type RealtimeVoiceAgentControlResult,
   type RealtimeVoiceAgentRunActivity,
 } from "./agent-run-control-shared.js";
@@ -22,7 +25,6 @@ import type { TalkEvent } from "./talk-events.js";
 export {
   buildRealtimeVoiceAgentCancelProviderResult,
   buildRealtimeVoiceAgentControlSpeechMessage,
-  buildRealtimeVoiceAgentErrorProviderResult,
   classifyRealtimeVoiceAgentControlText,
   normalizeRealtimeVoiceAgentControlMode,
   parseRealtimeVoiceAgentControlToolArgs,
@@ -36,6 +38,15 @@ export {
   type RealtimeVoiceAgentControlProviderResult,
   type RealtimeVoiceAgentControlResult,
 } from "./agent-run-control-shared.js";
+
+/** Host error projection needs server-side redaction, outside browser-shared contracts. */
+export function buildRealtimeVoiceAgentErrorProviderResult(
+  error: unknown,
+): RealtimeVoiceAgentControlProviderResult | { error: string } {
+  return isAbortError(error)
+    ? buildRealtimeVoiceAgentCancelProviderResult()
+    : { error: formatErrorMessage(error) };
+}
 
 type RealtimeVoiceAgentControlDeps = {
   abortEmbeddedAgentRun: (sessionId: string) => boolean;

--- a/src/talk/agent-run-control.ts
+++ b/src/talk/agent-run-control.ts
@@ -22,6 +22,7 @@ import type { TalkEvent } from "./talk-events.js";
 export {
   buildRealtimeVoiceAgentCancelProviderResult,
   buildRealtimeVoiceAgentControlSpeechMessage,
+  buildRealtimeVoiceAgentErrorProviderResult,
   classifyRealtimeVoiceAgentControlText,
   normalizeRealtimeVoiceAgentControlMode,
   parseRealtimeVoiceAgentControlToolArgs,


### PR DESCRIPTION
Closes #134883 — realtime phone calls report independent host cancellation as failure.

Related: #133844 and native Talk PR #134003. Native Talk and Discord voice cancellation are separate work; neither is changed or closed here.

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch; maintainers can update it.

</details>

## What Problem This Solves

Callers could receive a tool failure instead of cancellation when host agent work was cancelled while the phone session stayed open. Standalone forced-consult diagnostics also called that cancellation a failure. The general-tool invocation had a second gap: attaching `.catch` to its returned promise missed synchronous throws, leaving the provider without a terminal tool result.

Existing phone teardown coverage did not exercise independent host cancellation: phone-owned teardown correctly retires delivery before aborting pending work.

## Why This Change Was Made

The forced join, native consult, and general-tool paths now use one Talk runtime rejection projector: the canonical abort classifier plus the existing cancelled payload. Forced-consult diagnostics use the same classification. The general invocation catches synchronous throws and rejected promises with an explicit local `try`/`await`/`catch`; forced/native scheduling and ownership are unchanged.

The projector belongs in the server runtime adapter, not the browser-shared message/policy module, because ordinary error formatting needs server-side redaction. The browser-shared module remains unchanged. A real local type predicate removes repeated object guards and casts; unreachable general-path consult handling is removed. The assertion-safety baseline shrinks from three entries to one for this handler.

Production LOC is **+42/-42 (net zero)**; tests **+227/-24 (net +203)**; docs **+4/-0**. No configuration, dependency, schema, provider wire contract, cancellation authority, suppression baseline, or compatibility machinery is added.

## User Impact

Independent host cancellation produces the existing cancelled result without ending the phone call or emitting a false tool failure. Timeouts and ordinary failures remain errors; fulfilled results pass through unchanged. Synchronous general-tool failures now also settle once instead of silently omitting a result. Teardown-before-abort, supersession, native/forced deduplication, continuation, and once-only terminal settlement remain covered.

The [Voice Call guide](https://docs.openclaw.ai/plugins/voice-call#tool-policy) documents the distinction.

## Evidence

- Original handler/WebSocket reproduction: **9 cancellation cases failed before the repair**, while **15 failure/timeout/fulfilled controls passed**. Three standalone forced-consult diagnostic cases separately reproduced false failure logging.
- New synchronous reproduction in that same real handler/loopback WebSocket fixture: **5 cases failed before invocation repair**, with **8 asynchronous/fulfilled controls passing**. Each failed because no terminal provider result was delivered.
- Final focused retry: **201 tests passed across eight files**, including all **29 forced/native/general outcome cases**, provider-failure normalization, compaction exhaustion, and lifecycle/settlement coverage. One earlier attempt timed out in the unchanged real-runtime dynamic import; the identical command passed on retry with no assertion or timeout changes.
- Fresh isolated Codex autoreview of the full branch candidate, including the cleanup and final test-only lint correction: **scoped-clean at P0/P1**, with source integrity verified. The reviewer did not run tests; execution proof is reported separately above.
- Prior full build, Control UI build, and hosted build-artifacts jobs passed the server/browser boundary repair. This final invocation/type-predicate cleanup adds no import or package topology change.
- The implicated baseline handler is byte-identical to stable `v2026.8.1`; introduction provenance remains unknown and is not attributed to the native Talk follow-up.

### Provider-abort review disposition

The active-caller controls exercise real `projectProviderError` → `handleAssistantFailover` → voice projection: provider `AbortError`, `TimeoutError`, and ordinary connection failure remain error results. The compaction control proves exhausted provider aborts become `CompactionError` after three attempts, not host cancellation.

This follows the actual owners: provider adapters and the lazy provider registry project failures with their own request signal; assistant failure handling surfaces `FailoverError`. Active-caller compaction retries raw provider aborts and wraps exhaustion. Requiring the **phone** signal to abort would reinstate #134883 because that signal does not own independent host-run cancellation. The requested provider-failure controls are added; the suggested phone-signal gate is intentionally not applied. This is evidence for these reachable paths, not a claim about arbitrary third-party code. ClawSweeper accepted this evidence and withdrew the old P1. Its [10:09 UTC exact-head review](https://github.com/openclaw/openclaw/pull/134924#issuecomment-5489924394) reports no correctness/security findings; its remaining exact-head CI request is now satisfied.

### Proof boundary

The WebSocket/handler proof uses synthetic carrier/provider edges; it is not a live phone or provider API test. Live calls, credential hydration, production-state copies, and service operations were expressly prohibited and were not performed. No external API contract changes. Combined integration with unfinished native Talk or Discord work is not claimed.

Current head: `a017d117da898a6fa3387016c635ab2b21347cd7`. The complete eight-file changed gate passed, including lint, all four type lanes, dead-export checks, and architecture/owner guards. The final phone rerun passed 93 tests; after the test-table lint correction, focused lint and all 29 outcome cases passed again. Fresh full-candidate autoreview is scoped-clean at P0/P1.

[Exact-head hosted CI run 33495278268](https://github.com/openclaw/openclaw/actions/runs/33495278268), **attempt 2, passed**, including `openclaw/ci-gate`. Attempt 1 failed the unrelated Active Memory fixture during Gateway startup with `AUTH_TOKEN_MISMATCH`, before recall/main requests. That shard had passed on the production-identical predecessor; one bounded same-head failed-jobs retry passed without code, timeout, authentication, or assertion changes. **Named follow-up:** investigate intermittent Active Memory fixture isolation/auth readiness if this recurs; its root cause is not established or claimed fixed here.

The previous head's run 33492809174 failed test-table spread lint, corrected by the test-only follow-up. The branch includes already-landed release-inventory fix #134824; older merge-snapshot runs are historical, not final-head proof. Native review artifacts validated and hosted-evidence preparation completed successfully for this exact head; no rebase or additional push was needed. Ready for the maintainer’s separate merge decision.
