### PR TITLE
fix(maintainers): require completed ClawSweeper review

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -100,6 +100,8 @@ const repositoryScriptEntries = [
   "scripts/protocol-gen.ts!",
   "scripts/pr-gates-lock.mts!",
   "scripts/pr-lib/ci-dispatch.mjs!",
+  // merge.sh invokes this native review-authority parser by path.
+  "scripts/pr-lib/clawsweeper-review-gate.mjs!",
   "scripts/pr-lib/review-artifacts.mjs!",
   "scripts/pr-lib/process-group-runner.mjs!",
   "scripts/pre-commit/filter-staged-files.mjs!",

--- a/scripts/pr-lib/clawsweeper-review-gate.mjs
+++ b/scripts/pr-lib/clawsweeper-review-gate.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const [prValue, headSha] = process.argv.slice(2);
+const pr = Number(prValue);
+
+function fail(message, code = 1) {
+  console.error(`ClawSweeper review gate failed: ${message}`);
+  process.exit(code);
+}
+
+if (!Number.isInteger(pr) || pr < 1 || !/^[0-9a-f]{40}$/.test(headSha ?? "")) {
+  fail("usage: clawsweeper-review-gate.mjs <PR> <head-sha>", 2);
+}
+
+let pages;
+try {
+  pages = JSON.parse(readFileSync(0, "utf8"));
+} catch {
+  fail("GitHub returned invalid issue-comment JSON.");
+}
+if (!Array.isArray(pages) || !pages.every(Array.isArray)) {
+  fail("GitHub returned invalid issue-comment pages.");
+}
+const versionPrefix = "<!-- clawsweeper-review-version ";
+const identityPrefix = "<!-- clawsweeper-review item=";
+const completionTail =
+  /<!-- clawsweeper-review-version item=(?<item>[1-9]\d*) reviewed_at=(?<reviewedAt>[\w./:@-]+) sha=(?<reviewedSha>[\w./:@-]+) source_revision=(?<sourceRevision>[0-9a-f]{64}) lease_owner=(?<leaseOwner>[\w./:@-]+) lease_comment_id=(?<leaseCommentValue>[\w./:@-]+) v=(?<version>[\w./:@-]+) -->\s*<!-- clawsweeper-review item=(?<identityItem>[1-9]\d*) -->\s*$/;
+const completions = [];
+
+for (const comment of pages.flat()) {
+  const body = comment?.body;
+  if (
+    typeof body !== "string" ||
+    (!body.includes(versionPrefix) && !body.includes(identityPrefix))
+  ) {
+    continue;
+  }
+  if (
+    comment?.user?.login !== "clawsweeper[bot]" ||
+    comment?.user?.type !== "Bot" ||
+    comment?.user?.id !== 274271284
+  ) {
+    continue;
+  }
+  if (body.split(versionPrefix).length !== 2 || body.split(identityPrefix).length !== 2) {
+    fail("trusted review comment contains duplicate completion markers.");
+  }
+  const fields = body.match(completionTail)?.groups;
+  if (!fields) {
+    fail("trusted review completion markers are malformed or not trailing.");
+  }
+  const reviewedMs = Date.parse(fields.reviewedAt);
+  const leaseCommentId = Number(fields.leaseCommentValue);
+  if (
+    fields.item !== String(pr) ||
+    fields.identityItem !== fields.item ||
+    fields.version !== "1" ||
+    !/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d{3})?Z$/.test(fields.reviewedAt) ||
+    !Number.isFinite(reviewedMs) ||
+    !/^[0-9a-f]{40}$/.test(fields.reviewedSha) ||
+    fields.sourceRevision === "unknown" ||
+    fields.leaseOwner === "unknown" ||
+    !Number.isSafeInteger(leaseCommentId) ||
+    leaseCommentId < 1 ||
+    !Number.isSafeInteger(comment.id) ||
+    comment.id < 1
+  ) {
+    fail("trusted review-version field values are invalid.");
+  }
+  const age = Date.now() - reviewedMs;
+  if (age < -5 * 60_000) {
+    fail("trusted review completion is materially future-dated.");
+  }
+  if (age >= 12 * 60 * 60_000) {
+    continue;
+  }
+  const evidence = {
+    commentId: comment.id,
+    reviewedAt: fields.reviewedAt,
+    reviewedSha: fields.reviewedSha,
+    sourceRevision: fields.sourceRevision,
+    leaseOwner: fields.leaseOwner,
+    leaseCommentId,
+  };
+  completions.push({ evidence, reviewedMs, signature: JSON.stringify(fields) });
+}
+
+if (completions.length === 0) {
+  fail("completed review is missing or expired.");
+}
+completions.sort(
+  (a, b) => b.reviewedMs - a.reviewedMs || b.evidence.commentId - a.evidence.commentId,
+);
+const newest = completions.filter(
+  (candidate) => candidate.reviewedMs === completions[0].reviewedMs,
+);
+if (new Set(newest.map((candidate) => candidate.signature)).size !== 1) {
+  fail("newest trusted completion markers conflict.");
+}
+const selected = newest[0].evidence;
+if (selected.reviewedSha !== headSha) {
+  console.error(
+    `ClawSweeper review gate warning: reviewed SHA ${selected.reviewedSha} differs from current head ${headSha}; review is under 12 hours old.`,
+  );
+}
+process.stdout.write(`${JSON.stringify(selected)}\n`);

--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -89,6 +89,39 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/crabbox-merge-bypass.sh"
 # shellcheck source=scripts/pr-lib/merge-outcome.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/merge-outcome.sh"
 
+fetch_clawsweeper_review_comments() {
+  local pr="$1" repo_name="$2" repo_host="$3"
+  if ! CLAWSWEEPER_REVIEW_COMMENTS=$(gh_plain api --hostname "$repo_host" --paginate --slurp \
+    "repos/$repo_name/issues/$pr/comments?per_page=100" \
+    -H 'Cache-Control: max-age=0'); then
+    echo "ClawSweeper review gate failed: unable to read current issue comments." >&2
+    return 1
+  fi
+}
+
+validate_clawsweeper_review_comments() {
+  local pr="$1" head_sha="$2" evidence
+  if ! evidence=$(printf '%s\n' "$CLAWSWEEPER_REVIEW_COMMENTS" |
+    node "$script_parent_dir/pr-lib/clawsweeper-review-gate.mjs" "$pr" "$head_sha"); then
+    unset CLAWSWEEPER_REVIEW_COMMENTS
+    return 1
+  fi
+  unset CLAWSWEEPER_REVIEW_COMMENTS
+  CLAWSWEEPER_REVIEW_EVIDENCE="$evidence"
+  echo "ClawSweeper completed review: comment $(printf '%s\n' "$evidence" | jq -r .commentId), reviewed $(printf '%s\n' "$evidence" | jq -r .reviewedAt)"
+}
+
+require_clawsweeper_review() {
+  local pr="$1" head_sha="$2" repo_name="${3:-}" repo_host="${4:-}" repo_json
+  if [ -z "$repo_name" ] || [ -z "$repo_host" ]; then
+    repo_json=$(gh_plain repo view --json nameWithOwner,url) || return 1
+    repo_name=$(printf '%s\n' "$repo_json" | jq -er '.nameWithOwner | select(type == "string" and length > 0)') || return 1
+    repo_host=$(printf '%s\n' "$repo_json" | jq -er '.url | capture("^https://(?<host>[^/]+)/").host') || return 1
+  fi
+  fetch_clawsweeper_review_comments "$pr" "$repo_name" "$repo_host" || return 1
+  validate_clawsweeper_review_comments "$pr" "$head_sha"
+}
+
 mainline_drift_requires_sync() {
   local mainline_base="$1"
   local prepared_head_sha="$2"
@@ -193,6 +226,8 @@ merge_verify() {
     exit 1
   fi
 
+  require_clawsweeper_review "$pr" "$pr_head_sha" \
+    "${MERGE_REPO_NAME:-}" "${MERGE_REPO_HOST:-}" || return 1
   mark_pr_operation_side_effects_started || return 1
   if [ "${GATES_MODE:-}" = "hosted_exact_or_recent_parent" ]; then
     # The stamp selects the owner, not proof. Revalidate before skipping the
@@ -568,12 +603,20 @@ merge_run() {
       merge_outcome_stop "main changed during final admin admission"; return 1;
     }
   fi
+  fetch_clawsweeper_review_comments "$pr" "$MERGE_REPO_NAME" "$MERGE_REPO_HOST" || return 1
+  if ! merge_outcome_stable "$pr"; then
+    unset CLAWSWEEPER_REVIEW_COMMENTS
+    return 1
+  fi
+  validate_clawsweeper_review_comments "$pr" "$PREP_HEAD_SHA" || return 1
   local intent attempt
   attempt=$(node -e 'process.stdout.write(require("node:crypto").randomUUID())') || return 1
   intent=$(printf '%s\n' "$MERGE_OBSERVATION" | jq -c --argjson repo "$MERGE_REPO" \
-    --arg method "$merge_method" --arg route "$route" --arg attempt "$attempt" '
+    --arg method "$merge_method" --arg route "$route" --arg attempt "$attempt" \
+    --argjson review "$CLAWSWEEPER_REVIEW_EVIDENCE" '
     {version:1,repo:$repo,pr:.pr.number,prId:.pr.id,base:.pr.baseRefName,head:.pr.headRefOid,
-     main:.main,method:$method,route:$route,attempt:$attempt,phase:"intent",accepted:false,landed:null}
+     main:.main,method:$method,route:$route,attempt:$attempt,phase:"intent",accepted:false,landed:null,
+     clawsweeperReview:$review}
   ') || return 1
   if [ -n "$recovery_oid" ]; then
     # This records a new operator decision, not proof that the prior request failed.

--- a/test/scripts/clawsweeper-review-gate.test.ts
+++ b/test/scripts/clawsweeper-review-gate.test.ts
@@ -1,0 +1,115 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const helper = join(process.cwd(), "scripts/pr-lib/clawsweeper-review-gate.mjs");
+const head = "a".repeat(40);
+const ago = (milliseconds: number) => new Date(Date.now() - milliseconds).toISOString();
+
+function reviewComment({
+  id = 1,
+  reviewedAt = ago(60 * 60_000),
+  sha = head,
+  sourceRevision = "b".repeat(64),
+  leaseOwner = "github-run-1",
+  leaseCommentId = "1",
+  attributes = "",
+  suffix = "",
+  user = { id: 274271284, login: "clawsweeper[bot]", type: "Bot" },
+} = {}) {
+  return {
+    id,
+    user,
+    body: `Review text.
+
+<!-- clawsweeper-review-version item=123 reviewed_at=${reviewedAt} sha=${sha} source_revision=${sourceRevision} lease_owner=${leaseOwner} lease_comment_id=${leaseCommentId} v=1${attributes} -->
+
+<!-- clawsweeper-review item=123 -->${suffix}`,
+  };
+}
+
+function run(comments: unknown[]) {
+  return spawnSync(process.execPath, [helper, "123", head], {
+    encoding: "utf8",
+    input: JSON.stringify([comments]),
+  });
+}
+
+describe("ClawSweeper review completion gate", () => {
+  it("accepts the trusted trailing v1 marker pair", () => {
+    const result = run([reviewComment()]);
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      commentId: 1,
+      reviewedSha: head,
+      sourceRevision: "b".repeat(64),
+    });
+  });
+
+  it.each([
+    [
+      "ack-only",
+      [{ id: 1, body: "<!-- clawsweeper-pr-ack:opened item=123 -->", user: reviewComment().user }],
+    ],
+    [
+      "spoofed author",
+      [reviewComment({ user: { id: 1, login: "clawsweeper[bot]", type: "Bot" } })],
+    ],
+    ["non-trailing marker", [reviewComment({ suffix: "\nmore text" })]],
+    ["duplicate attribute", [reviewComment({ attributes: " sha=" + head })]],
+    ["malformed source revision", [reviewComment({ sourceRevision: "not-a-revision" })]],
+    ["missing lease", [reviewComment({ leaseOwner: "unknown" })]],
+    ["expired boundary", [reviewComment({ reviewedAt: ago(12 * 60 * 60_000) })]],
+    ["future dated", [reviewComment({ reviewedAt: ago(-6 * 60_000) })]],
+  ])("rejects %s evidence", (_name, comments) => {
+    const result = run(comments);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("ClawSweeper review gate failed:");
+  });
+
+  it("selects the newest valid completion and ignores a queued refresh", () => {
+    const newer = reviewComment({
+      id: 2,
+      reviewedAt: ago(30 * 60_000),
+      sourceRevision: "c".repeat(64),
+      leaseCommentId: "2",
+    });
+    const queued = {
+      id: 3,
+      body: "<!-- clawsweeper-command-status:123:re_review:queued -->\nRe-review queued.",
+      user: reviewComment().user,
+    };
+    const result = run([reviewComment(), newer, queued]);
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      commentId: 2,
+      sourceRevision: "c".repeat(64),
+    });
+  });
+
+  it("rejects conflicting newest completion evidence", () => {
+    const reviewedAt = ago(60 * 60_000);
+    const result = run([
+      reviewComment({ reviewedAt }),
+      reviewComment({ id: 2, reviewedAt, sha: "c".repeat(40), leaseCommentId: "2" }),
+    ]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("newest trusted completion markers conflict");
+  });
+
+  it("accepts a recent SHA mismatch with a warning", () => {
+    const reviewedSha = "c".repeat(40);
+    const result = run([reviewComment({ sha: reviewedSha })]);
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain(
+      `reviewed SHA ${reviewedSha} differs from current head ${head}`,
+    );
+    expect(JSON.parse(result.stdout).reviewedSha).toBe(reviewedSha);
+  });
+
+  it("accepts distinct lease and durable review comment identities", () => {
+    const result = run([reviewComment({ id: 2, leaseCommentId: "1" })]);
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({ commentId: 2, leaseCommentId: 1 });
+  });
+});

--- a/test/scripts/pr-crabbox-merge-bypass.test.ts
+++ b/test/scripts/pr-crabbox-merge-bypass.test.ts
@@ -13,6 +13,7 @@ import { delimiter, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { formatCrabboxGateCheckSummary } from "../../scripts/pr-lib/crabbox-gate-contract.mjs";
 import { validateCrabboxMergeBypass } from "../../scripts/pr-lib/crabbox-merge-bypass.mjs";
+import { validClawsweeperReviewCommentPages } from "./pr-review-artifact-fixture.js";
 
 const baseSha = "b".repeat(40);
 const headSha = "a".repeat(40);
@@ -330,6 +331,7 @@ function runProtectedShell(
   mkdirSync(join(root, ".local"));
   writeFileSync(join(root, "calls.jsonl"), "");
   const evidence = input();
+  const reviewComments = validClawsweeperReviewCommentPages(131091, headSha);
   evidence.membership.role = role;
   evidence.membership.state = state;
   writeFileSync(join(root, "input.json"), JSON.stringify(evidence));
@@ -344,6 +346,7 @@ const save = () => fs.writeFileSync("input.json", JSON.stringify(value));
 const fail = (message, code = 19) => { console.error(message); process.exit(code); };
 const out = (data) => console.log(typeof data === "string" ? data : JSON.stringify(data));
 const repo = {id:123,nameWithOwner:"openclaw/openclaw",url:"https://github.com/openclaw/openclaw"};
+const reviewComments = ${JSON.stringify(reviewComments)};
 const pr = {id:"fixture-pr",number:131091,url:repo.url+"/pull/131091",state:"OPEN",isDraft:false,
   headRefOid:value.headSha,headRefName:"topic",baseRefName:"main",baseRefOid:"${baseSha}",
   isCrossRepository:false,mergeable:"MERGEABLE",mergeStateStatus:"BLOCKED",mergeCommit:null,
@@ -369,11 +372,12 @@ else if (endpoint === "graphql" && args.includes("query=query { viewer { login }
   const mutable = endpoint.startsWith("orgs/") ||
     (!process.env.FAKE_DISPATCH && !/\\/compare\\/|\\/commits\\/[a-f0-9]{40}$/u.test(endpoint));
   if (mutable && !args.some((arg,i) => ["-H", "--header"].includes(arg) && args[i+1] === "Cache-Control: max-age=0")) fail("missing live header", 18);
-  if (endpoint.includes("/check-runs?") || endpoint.includes("/jobs?")) {
+  if (endpoint.includes("/check-runs?") || endpoint.includes("/jobs?") || endpoint.includes("/issues/131091/comments?")) {
     if (!args.includes("--paginate") || !args.includes("--slurp")) fail("missing pagination");
   }
   const prefix = "repos/openclaw/openclaw/";
   if (endpoint === prefix + "pulls/131091") out(value.pullRequest);
+  else if (endpoint === prefix + "issues/131091/comments?per_page=100") out(reviewComments);
   else if (endpoint === prefix + "commits/" + value.headSha + "/check-runs?filter=latest&per_page=100") out(value.checkRuns.check_runs.map(check => ({check_runs:[check]})));
   else if (endpoint === prefix + "actions/workflows/pr-crabbox-gate-publisher.yml/runs") out({workflow_runs:value.dispatched ? [{...value.publisherRun,html_url:repo.url+"/actions/runs/8001",display_title:"PR Crabbox gate #131091 / "+value.headSha}] : []});
   else if (endpoint === prefix + "actions/runs/8001") out({...value.publisherRun,html_url:repo.url+"/actions/runs/8001"});

--- a/test/scripts/pr-main-refresh.test-support.ts
+++ b/test/scripts/pr-main-refresh.test-support.ts
@@ -219,6 +219,15 @@ export function createMainRefreshFixture(directory: string) {
       | "scheduled-failure"
       | "api-error",
     requiredChecks: "pass" as "pass" | "fail" | "pending" | "api-error",
+    reviewComments: [
+      {
+        id: 1,
+        body: `<!-- clawsweeper-review-version item=42 reviewed_at=${new Date().toISOString()} sha=${head} source_revision=${"b".repeat(64)} lease_owner=github-run-1 lease_comment_id=1 v=1 -->
+
+<!-- clawsweeper-review item=42 -->`,
+        user: { id: 274271284, login: "clawsweeper[bot]", type: "Bot" },
+      },
+    ],
   };
   writeFileSync(controlFile, JSON.stringify(control));
   writeFileSync(eventsFile, "");
@@ -384,8 +393,13 @@ if (args[0] === 'pr' && args[1] === 'view') {
   } else if (endpoint === 'repos/fixture/repo/collaborators/fixture/permission') {
     if (control.authorPermission === 'error') process.exit(1);
     value = { permission: control.authorPermission };
-  } else if (endpoint === 'repos/fixture/repo/issues/42/comments' && args.includes('POST')) {
-    value = { html_url: 'https://example.invalid/pr/42#completion' };
+  } else if (endpoint.startsWith('repos/fixture/repo/issues/42/comments')) {
+    if (args.includes('POST')) {
+      value = { html_url: 'https://example.invalid/pr/42#completion' };
+    } else {
+      event({ kind: 'review-comments' });
+      value = [control.reviewComments];
+    }
   } else if (endpoint === 'repos/fixture/repo/pulls/42') {
     let baseSha = control.metadata.baseRefOid;
     if (control.remoteOnlyBase) {

--- a/test/scripts/pr-merge-hosted.test.ts
+++ b/test/scripts/pr-merge-hosted.test.ts
@@ -164,6 +164,16 @@ describePosix("native hosted merge handoff", () => {
         (event) => event.kind === "gh" && event.args?.[0] === "pr" && event.args[1] === "merge",
       );
     expect(mergeCalls).toHaveLength(1);
+    const events = f.events().slice(before);
+    const reviewReads = events
+      .map((event, index) => ({ event, index }))
+      .filter(({ event }) => event.kind === "review-comments");
+    expect(reviewReads).toHaveLength(2);
+    expect(reviewReads[1]?.index).toBeLessThan(
+      events.findIndex(
+        (event) => event.kind === "gh" && event.args?.[0] === "pr" && event.args[1] === "merge",
+      ),
+    );
     expect(mergeCalls[0]?.args).toEqual([
       "pr",
       "merge",

--- a/test/scripts/pr-merge-outcome.test.ts
+++ b/test/scripts/pr-merge-outcome.test.ts
@@ -132,6 +132,22 @@ function fixture(sourceMessage?: string, sourceVersions: Array<[string, string?]
     calls: [] as string[][],
     mutations: 0,
     mergeBody: null as string | null,
+    issueComments: [
+      {
+        id: 1,
+        body: `<!-- clawsweeper-review-version item=123 reviewed_at=${new Date().toISOString()} sha=${head} source_revision=${"b".repeat(64)} lease_owner=github-run-1 lease_comment_id=1 v=1 -->
+
+<!-- clawsweeper-review item=123 -->`,
+        user: { id: 274271284, login: "clawsweeper[bot]", type: "Bot" },
+      },
+    ],
+    issueCommentsAfterFirst: null as null | Array<{
+      id: number;
+      body: string;
+      user: { id: number; login: string; type: string };
+    }>,
+    issueCommentReads: 0,
+    issueCommentsErrorAt: 0,
     comments: [] as { body: string; html_url: string }[],
     posts: 0,
     invalid: false,
@@ -252,7 +268,11 @@ else if(args[0]==="pr"&&args[1]==="view") {
     out(url);
   } else {
     if(!args.includes("Cache-Control: max-age=0")) fail("missing live comment header");
-    out([s.comments]);
+    s.issueCommentReads++;
+    if(s.issueCommentReads===s.issueCommentsErrorAt) fail("comment API unavailable");
+    if(s.issueCommentReads>1&&s.issueCommentsAfterFirst) s.issueComments=s.issueCommentsAfterFirst;
+    save();
+    out([[...s.issueComments,...s.comments]]);
   }
 } else if(args.some(x=>x.includes("/commits/"))) {
   if(s.audit) fail("audit unavailable");
@@ -666,11 +686,11 @@ describePosix("native merge outcome with real Git and supervised lock recovery",
   it("reconciles a merged receipt without waiting for terminal mergeability", () => {
     const f = fixture();
     const unknown = { pr: { mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" } };
-    f.save({ ...f.state(), observations: [{}, {}, unknown, unknown] });
+    f.save({ ...f.state(), observations: [{}, {}, {}, unknown, unknown] });
     const run = f.run();
     expect(run.status, run.output).toBe(0);
     expect(f.record().phase).toBe("complete");
-    expect(f.state().reads).toBe(4);
+    expect(f.state().reads).toBe(5);
     expect(f.state().settlementSleeps).toEqual([]);
     expect(f.state().mutations).toBe(1);
     expect(f.state().posts).toBe(1);
@@ -1457,6 +1477,99 @@ describePosix("native merge outcome with real Git and supervised lock recovery",
       expect(() => f.record()).toThrow();
     },
   );
+  it("blocks ack-only ClawSweeper evidence before intent", () => {
+    const f = fixture();
+    f.save({
+      ...f.state(),
+      issueComments: [
+        {
+          id: 1,
+          body: "<!-- clawsweeper-pr-ack:opened item=123 -->",
+          user: { id: 274271284, login: "clawsweeper[bot]", type: "Bot" },
+        },
+      ],
+    });
+
+    const run = f.run();
+
+    expect(run.status, run.output).toBe(1);
+    expect(f.state().mutations).toBe(0);
+    expect(() => f.record()).toThrow();
+  });
+  it.each([
+    {
+      name: "removed",
+      comments: [
+        {
+          id: 2,
+          body: "<!-- clawsweeper-pr-ack:opened item=123 -->",
+          user: { id: 274271284, login: "clawsweeper[bot]", type: "Bot" },
+        },
+      ],
+    },
+    {
+      name: "expired",
+      comments: [
+        {
+          id: 2,
+          body: `<!-- clawsweeper-review-version item=123 reviewed_at=${new Date(Date.now() - 13 * 60 * 60_000).toISOString()} sha=${"a".repeat(40)} source_revision=${"c".repeat(64)} lease_owner=github-run-2 lease_comment_id=2 v=1 -->
+
+<!-- clawsweeper-review item=123 -->`,
+          user: { id: 274271284, login: "clawsweeper[bot]", type: "Bot" },
+        },
+      ],
+    },
+  ])("revalidates $name review evidence immediately before intent", ({ comments }) => {
+    const f = fixture();
+    f.save({ ...f.state(), issueCommentsAfterFirst: comments });
+
+    const run = f.run();
+
+    expect(run.status, run.output).toBe(1);
+    expect(f.state().issueCommentReads).toBe(2);
+    expect(f.state().mutations).toBe(0);
+    expect(() => f.record()).toThrow();
+  });
+
+  it("fails closed when the final review comment read is unavailable", () => {
+    const f = fixture();
+    f.save({ ...f.state(), issueCommentsErrorAt: 2 });
+
+    const run = f.run();
+
+    expect(run.status, run.output).toBe(1);
+    expect(run.output).toContain("unable to read current issue comments");
+    expect(f.state().mutations).toBe(0);
+    expect(() => f.record()).toThrow();
+  });
+
+  it("retains evidence from a newer completion observed at final admission", () => {
+    const f = fixture();
+    const reviewedAt = new Date(Date.now() + 1_000).toISOString();
+    f.save({
+      ...f.state(),
+      issueCommentsAfterFirst: [
+        ...f.state().issueComments,
+        {
+          id: 2,
+          body: `<!-- clawsweeper-review-version item=123 reviewed_at=${reviewedAt} sha=${f.head} source_revision=${"c".repeat(64)} lease_owner=github-run-2 lease_comment_id=2 v=1 -->
+
+<!-- clawsweeper-review item=123 -->`,
+          user: { id: 274271284, login: "clawsweeper[bot]", type: "Bot" },
+        },
+      ],
+    });
+
+    const run = f.run();
+
+    expect(run.status, run.output).toBe(0);
+    expect(f.record().clawsweeperReview).toMatchObject({
+      commentId: 2,
+      reviewedAt,
+      reviewedSha: f.head,
+      sourceRevision: "c".repeat(64),
+    });
+  });
   it("does not delete an advanced remote branch and reports cleanup pending", () => {
     const f = fixture();
     f.save({ ...f.state(), cleanup: "advanced" });

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -27,7 +27,11 @@ import { pathToFileURL } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
-import { validReview, writeReviewArtifacts } from "./pr-review-artifact-fixture.js";
+import {
+  validClawsweeperReviewCommentPages,
+  validReview,
+  writeReviewArtifacts,
+} from "./pr-review-artifact-fixture.js";
 import { copyPrWrapperSources } from "./pr-wrapper.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -1825,6 +1829,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
         git("commit", "-qm", "test: canonical wrapper drift");
       }
       const canonicalHead = git("rev-parse", "HEAD");
+      const reviewComments = JSON.stringify(validClawsweeperReviewCommentPages(42, preparedHead));
       const localDir = join(worktreeDir, ".local");
       mkdirSync(localDir);
       for (const artifact of ["review.md", "pr-meta.env", "pr-meta.json", "prep.md"]) {
@@ -1852,6 +1857,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
         '    printf "invocation\\t%s\\n" "$PWD" >> "$OPENCLAW_TEST_LIFECYCLE"',
         `    printf '%s\\n' '{"id":"fixture-repo","url":"https://github.com/fixture/repo","nameWithOwner":"fixture/repo"}' ;;`,
         '  "repo view "*) printf "fixture/repo\\n" ;;',
+        `  "api --hostname github.com --paginate --slurp repos/fixture/repo/issues/42/comments?per_page=100 -H Cache-Control: max-age=0") printf '%s\\n' ${JSON.stringify(reviewComments)} ;;`,
         '  "api --hostname github.com --method POST repos/fixture/repo/issues/42/comments "*)',
         '    printf "comment\\n" >> "$OPENCLAW_TEST_LIFECYCLE"',
         '    printf "https://example.invalid/comment\\n" ;;',

--- a/test/scripts/pr-review-artifact-fixture.ts
+++ b/test/scripts/pr-review-artifact-fixture.ts
@@ -4,6 +4,24 @@ import { join } from "node:path";
 export const REVIEWED_PR = 42;
 export const REVIEWED_HEAD = "b".repeat(40);
 
+export function validClawsweeperReviewCommentPages(pr: number, headSha: string) {
+  const commentId = 9002;
+  const reviewedAt = new Date(Date.now() - 60_000).toISOString();
+  return [
+    [
+      {
+        id: commentId,
+        user: { id: 274271284, login: "clawsweeper[bot]", type: "Bot" },
+        body: [
+          `<!-- clawsweeper-review-version item=${pr} reviewed_at=${reviewedAt} sha=${headSha} source_revision=${"c".repeat(64)} lease_owner=github-run-fixture lease_comment_id=${commentId - 1} v=1 -->`,
+          "",
+          `<!-- clawsweeper-review item=${pr} -->`,
+        ].join("\n"),
+      },
+    ],
+  ];
+}
+
 export function validReview(headSha = REVIEWED_HEAD) {
   return {
     pr: { number: REVIEWED_PR, headSha },

--- a/test/scripts/pr-review-artifact-validation.test.ts
+++ b/test/scripts/pr-review-artifact-validation.test.ts
@@ -6,6 +6,7 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 import {
   REVIEWED_PR,
   REVIEWED_HEAD,
+  validClawsweeperReviewCommentPages,
   validReview,
   writeReviewArtifacts,
   type ReviewArtifactFixtureOptions,
@@ -133,6 +134,7 @@ function runMergeVerification(
     "invalid-json": "printf '%s\\n' 'not valid JSON'",
     "invalid-row": `printf '%s\\n' '["malformed required row"]'`,
   }[checks];
+  const reviewComments = JSON.stringify(validClawsweeperReviewCommentPages(42, head));
 
   return spawnSync(
     "bash",
@@ -149,8 +151,10 @@ function runMergeVerification(
         `refresh_main_snapshot() { PR_MAIN_SHA=${"b".repeat(40)}; }`,
         "mark_pr_operation_side_effects_started() { :; }",
         "git() { :; }",
-        "node() { :; }",
-        `gh_plain() { case "$*" in *"--json name,bucket,state"*) ${checksResponse};; *"--json state,isDraft,headRefOid"*) printf '%s\\n' '{"isDraft":false,"headRefOid":"${head}"}';; *) return 0;; esac; }`,
+        'node() { case "$1" in */watch-pr-ci.mjs) return 0;; *) command node "$@";; esac; }',
+        "MERGE_REPO_NAME=fixture/repo",
+        "MERGE_REPO_HOST=github.com",
+        `gh_plain() { case "$*" in *"issues/42/comments?per_page=100"*) printf '%s\\n' ${JSON.stringify(reviewComments)};; *"--json name,bucket,state"*) ${checksResponse};; *"--json state,isDraft,headRefOid"*) printf '%s\\n' '{"isDraft":false,"headRefOid":"${head}"}';; *) return 0;; esac; }`,
         "merge_verify 42 || exit 1",
       ].join("\n"),
       "pr-merge-verification",

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -218,6 +218,19 @@ describe("scripts/pr wrappers", () => {
     expect(script).toContain("only support PRs targeting main");
   });
 
+  it("packages the dependency-free ClawSweeper review gate with the native wrapper", () => {
+    const fixture = makeMismatchedWrapperRepo();
+    try {
+      const helper = join(fixture.canonical, "scripts/pr-lib/clawsweeper-review-gate.mjs");
+      expect(readScript(helper)).not.toMatch(/from ["'](?!node:)/);
+      expect(existsSync(join(fixture.linked, "scripts/pr-lib/clawsweeper-review-gate.mjs"))).toBe(
+        true,
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   itPosix("preserves the caller's gh route environment through startup", () => {
     const fixture = makeMismatchedWrapperRepo();
     try {


### PR DESCRIPTION
## Summary

- require a current durable ClawSweeper completion marker before merge verification proceeds
- fetch and revalidate the marker again immediately before merge intent creation
- retain the selected review evidence in the merge intent for audit and recovery

Follow-up to #134861.

## Root cause

Native merge admission had no authority check for a completed ClawSweeper review. An acknowledgement-only comment therefore left the landing path open.

The architectural owner is `scripts/pr-lib/merge.sh`. The repair adds a dependency-free parser for the exact v1 marker contract and makes that evidence part of both early verification and final admission.

## Validation

- Pre-fix reproduction: the ack-only scenario returned status 0, performed one merge mutation, and completed a merge receipt.
- Post-fix parser matrix: 13/13 passed.
- Post-fix merge revalidation/API/zero-mutation cases: 6/6 passed.
- Hosted ordering: 17/17 passed.
- CI fixture repair: cleanup 5/5, required-check assertions 6/6, admin membership assertions 3/3.
- Combined parser/tooling regression run: 222 tests passed.
- `pnpm check:script-erasability`
- `pnpm check:changed`
- Production and full-tree Knip unused-file scans: 0 entries.
- Live parser proof against an existing trusted completed marker.
- Exact high-reasoning review: clean, correctness confidence 0.93.

## Scope

Production: +153/-2 lines. Test and test support: +306/-9 lines. Tooling config: +2/-0 lines.

The positive production delta is the new merge authority itself: strict marker parsing, trusted immutable bot identity, pagination/no-cache reads, two admission checks, and retained evidence. There was no existing authority to refactor or remove; the parser was reduced to the fixed sibling v1 contract and has no external dependencies. It enforces the sibling's 64-character lowercase hexadecimal source revision and keeps the durable review comment identity distinct from the carried lease comment identity.

Sibling coverage includes parser rejection/selection, merge outcome final revalidation and API failure, hosted dispatch ordering, and extracted-wrapper packaging. No changelog entry: maintainer process repairs are excluded by repository policy.
