### PR TITLE
fix(ci): keep native Windows Testbox alive during SSH

### DIFF
--- a/.github/workflows/windows-blacksmith-testbox.yml
+++ b/.github/workflows/windows-blacksmith-testbox.yml
@@ -225,6 +225,19 @@ jobs:
           echo "  SSH:                ssh -p ${runner_ssh_port} runner@${runner_host}"
           echo "============================================"
 
+          # Blacksmith advertises a forwarded port; native sockets use sshd's local listeners.
+          runner_ssh_local_ports="$(pwsh -NoProfile -NonInteractive -Command '
+            $ErrorActionPreference = "Stop"
+            $service = Get-CimInstance Win32_Service -Filter "Name = `"sshd`""
+            if ($service.State -ne "Running" -or $service.ProcessId -eq 0) {
+              throw "Cannot monitor activity without the running Windows SSH service."
+            }
+            $ports = @(Get-NetTCPConnection -State Listen -OwningProcess $service.ProcessId |
+              Select-Object -ExpandProperty LocalPort -Unique)
+            if ($ports.Count -eq 0) { throw "No local Windows SSH listener found." }
+            [Console]::Write(($ports -join "|"))
+          ')"
+
           last_activity="$(date +%s)"
           idle_timeout_seconds=$(( idle_timeout * 60 ))
 
@@ -232,7 +245,12 @@ jobs:
             sleep 30
             now="$(date +%s)"
 
-            if netstat -na 2>/dev/null | grep ":${runner_ssh_port}" | grep -q ESTABLISHED; then
+            connections="$(netstat -na)"
+            # Match the local endpoint exactly; consume all rows to avoid pipefail/SIGPIPE races.
+            if awk -v ports="$runner_ssh_local_ports" '
+              $1 == "TCP" && $2 ~ (":(" ports ")$") && $4 ~ /^ESTABLISHED\r?$/ { active = 1 }
+              END { exit !active }
+            ' <<< "$connections"; then
               last_activity="$now"
             elif [ -f ~/.testbox-last-activity ]; then
               file_mtime="$(stat -c %Y ~/.testbox-last-activity 2>/dev/null || stat -f %m ~/.testbox-last-activity)"

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -123,6 +123,12 @@ lease ID, and reuse it with `run --id <tbx_id>`. Stop the owned lease with
   `--script*`, `--env-helper`, capture/download flags, and `--stop-after` are not
   a substitute for the delegated Testbox workflow.
 
+The native Windows Testbox idle monitor uses the running `sshd` service's local
+listener ports, not Blacksmith's externally forwarded SSH port. Established SSH
+connections keep the job alive; the `~/.testbox-last-activity` modification time
+covers short commands between the 30-second polls. Once neither indicates recent
+activity, the configured idle timeout still ends the job.
+
 The shared skill's command placeholders map to the focused commands in this
 guide. Its trusted bootstrap is `scripts/crabbox-untrusted-bootstrap.sh`; the
 untrusted path above invokes the installed trusted CLI, never the PR's wrapper.

--- a/test/scripts/windows-blacksmith-testbox.test.ts
+++ b/test/scripts/windows-blacksmith-testbox.test.ts
@@ -1,0 +1,129 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createTempDir } = createScriptTestHarness();
+const workflow = parse(
+  fs.readFileSync(".github/workflows/windows-blacksmith-testbox.yml", "utf8"),
+) as {
+  jobs: { windows: { steps: { name: string; run?: string }[] } };
+};
+const run = workflow.jobs.windows.steps.find((step) => step.name === "Run Testbox")?.run;
+if (!run) {
+  throw new Error("Missing Windows Testbox run step");
+}
+// Execute the actual monitor after its ready banner, without contacting Blacksmith.
+const banner = 'echo "============================================"';
+const monitor = run.slice(run.lastIndexOf(banner) + banner.length);
+
+function runMonitor(options: {
+  rows?: string;
+  ports?: string;
+  activeUntil?: number;
+  marker?: { observedAt: number; modifiedAt: number };
+  discoveryExit?: number;
+  netstatExit?: number;
+}) {
+  const dir = createTempDir("openclaw-windows-idle-");
+  fs.writeFileSync(path.join(dir, "connections"), options.rows ?? "");
+  const markerSeed = path.join(dir, "marker-seed");
+  fs.writeFileSync(markerSeed, "");
+  const markerTime = options.marker?.modifiedAt ?? 1000;
+  fs.utimesSync(markerSeed, markerTime, markerTime);
+  return spawnSync(
+    "bash",
+    [
+      "-euo",
+      "pipefail",
+      "-c",
+      `
+clock=1000
+runner_ssh_port=64004
+idle_timeout=1
+trap 'printf "monitor_clock=%s\\n" "$clock"' EXIT
+date() { printf '%s\\n' "$clock"; }
+sleep() {
+  clock=$((clock + 30))
+  if [ "$clock" = "$MARKER_AT" ]; then cp -p "$HOME/marker-seed" "$HOME/.testbox-last-activity"; fi
+  if [ "$clock" -gt 1300 ]; then return 90; fi
+}
+pwsh() { printf '%s' "$LOCAL_PORTS"; return "$DISCOVERY_EXIT"; }
+netstat() {
+  if [ "$clock" -le "$ACTIVE_UNTIL" ]; then command cat "$HOME/connections"; fi
+  return "$NETSTAT_EXIT"
+}
+${monitor}`,
+    ],
+    {
+      encoding: "utf8",
+      timeout: 5000,
+      env: {
+        ...process.env,
+        HOME: dir,
+        LOCAL_PORTS: options.ports ?? "22",
+        ACTIVE_UNTIL: String(options.activeUntil ?? 1090),
+        MARKER_AT: String(options.marker?.observedAt ?? 0),
+        DISCOVERY_EXIT: String(options.discoveryExit ?? 0),
+        NETSTAT_EXIT: String(options.netstatExit ?? 0),
+      },
+    },
+  );
+}
+
+describe.skipIf(process.platform === "win32")("native Windows Testbox idle monitor", () => {
+  it.each([
+    { name: "IPv4", ports: "22", local: "172.16.0.2:22" },
+    { name: "IPv6", ports: "22", local: "[2001:db8::1]:22" },
+    { name: "a second non-default listener", ports: "2201|2202", local: "172.16.0.2:2202" },
+  ])("keeps $name SSH active, then expires after disconnect", ({ ports, local }) => {
+    const result = runMonitor({
+      ports,
+      rows: `  TCP    ${local}    192.0.2.1:51000    ESTABLISHED\r\n`,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("monitor_clock=1150");
+    expect(result.stdout).toContain("Idle timeout reached (1 minutes). Shutting down.");
+  });
+
+  it("does not count listeners, foreign ports, port prefixes, or closed connections as activity", () => {
+    const result = runMonitor({
+      rows: [
+        "  TCP    0.0.0.0:22       0.0.0.0:0           LISTENING",
+        "  TCP    172.16.0.2:2222  192.0.2.1:51000     ESTABLISHED",
+        "  TCP    172.16.0.2:51000 192.0.2.1:64004     ESTABLISHED",
+        "  TCP    172.16.0.2:51001 192.0.2.1:22        ESTABLISHED",
+        "  TCP    [2001:db8::1]:22 [2001:db8::2]:51000 TIME_WAIT",
+        "",
+      ].join("\r\n"),
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("monitor_clock=1060");
+  });
+
+  it.each([
+    { name: "a command between polls", modifiedAt: 1015, expectedClock: 1090 },
+    { name: "an old command", modifiedAt: 970, expectedClock: 1060 },
+  ])(
+    "uses the marker mtime for $name without keeping the lease alive forever",
+    ({ modifiedAt, expectedClock }) => {
+      const result = runMonitor({ marker: { observedAt: 1030, modifiedAt } });
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain(`monitor_clock=${expectedClock}`);
+    },
+  );
+
+  it.each([
+    { name: "listener discovery", discoveryExit: 7, expectedExit: 7 },
+    { name: "connection enumeration", netstatExit: 9, expectedExit: 9 },
+  ])(
+    "reports $name failures instead of classifying them as idle",
+    ({ expectedExit, ...options }) => {
+      const result = runMonitor(options);
+      expect(result.status, result.stderr).toBe(expectedExit);
+      expect(result.stdout).not.toContain("Idle timeout reached");
+    },
+  );
+});


### PR DESCRIPTION
Closes #134919 — native Windows Testbox can expire while its SSH command is still active.

Related: #134718 / #134725 track the separate Linux idle-monitor repair; #134823 / #134828 track native Windows SSH key installation. This PR does not change those branches or the dependency-refresh PR #133772.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed. This is a same-repository maintainer-editable branch.

</details>

## What Problem This Solves

Fixes an issue where maintainers running a native Windows Testbox command would have its idle monitor expire while SSH was still connected when Blacksmith forwarded an external port to a different Windows-local daemon port. Short commands must also continue extending the idle budget through the activity marker, without keeping a disconnected lease alive forever.

## Why This Change Was Made

The monitor now derives the running Windows `sshd` service's actual listener ports and matches only exact local `ESTABLISHED` TCP endpoints. This removes the external-port/whole-row grep, avoids short-circuit pipeline failures, and propagates socket-discovery errors instead of misclassifying them as idle. The external port remains unchanged in Blacksmith phone-home metadata and connection instructions.

The existing idle budget, 30-second poll, marker mtime behavior, and normal timeout exit remain unchanged. No dependency, new operator option, alternate provider, account alias, or authentication relaxation is added. Listener ownership is resolved once for the job's fixed SSH endpoint, just as the Linux sibling's cleanup distinguishes external and local ports.

## User Impact

Native Windows Testbox SSH sessions and long commands no longer expire merely because the client-facing port differs from the daemon's local listener. Commands that finish between polls retain their marker-based extension, and genuinely idle monitors still shut down.

This repairs **only the native Windows idle monitor**. The independent native key-installation repair is #134828, and Blacksmith CLI 0.4.57 still selects the absent `runner` account with no supported username override. This PR does not claim supported Blacksmith CLI synchronization/run end-to-end functionality.

## Evidence

### Native Windows before/after

Provider: **blacksmith-testbox**, requested/observed runner `blacksmith-16vcpu-windows-2025`; fresh task-owned lease `tbx_01m1dqd430bkgpmbv7vveh5tmt`; [run 33474143765](https://github.com/openclaw/openclaw/actions/runs/33474143765), [job 99749777503](https://github.com/openclaw/openclaw/actions/runs/33474143765/job/99749777503).

The lease was provisioned from the already-published authentication repair at `3182541eca014b9e99b55c213a8f8d7d1eaa2871`, without editing its branch or reusing another lane's lease. Explicit native `runneradmin` SSH used only that lease's ephemeral key and a task-local known-hosts file. Runtime observations: Windows NT 10.0.26100.0, PowerShell 7.4.11, native `sshd` service PID 2128, IPv4/IPv6 local listeners **22**, external forwarded port **64004**.

Before editing, one native established SSH connection was present with no marker, but the original predicate returned `idle`. The original idle loop was verified byte-identical between the baseline and the authentication provisioning revision.

The exact baseline and candidate monitor bodies were then extracted from the workflow and executed under the native user with real sockets, real timestamps, a one-minute test budget, and the unchanged 30-second poll. An owned native Scheduled Task kept the monitors independent of the client so disconnect and short-command behavior were observable. The candidate was task-local uploaded proof input; the GitHub workflow checkout was not rewritten. This is **native execution of the exact candidate monitor**, not a claim of a hosted candidate-workflow run or supported CLI sync/run.

| Observation | Baseline | Candidate |
| --- | --- | --- |
| SSH held open for 95 seconds | Monitor expired at 60 seconds while connected | Monitor remained alive |
| Short native command between polls | Existing marker behavior retained in regression coverage | Actual user marker refreshed, then SSH disconnected |
| Idle after that marker | — | Normal exit 72 seconds after marker mtime |

```text
established_on_native_listener=1
forwarded_port=64004
legacy_detector=idle
held_connection_start=1788241704
baseline_monitor_end=1788241764
held_connection_end=1788241799
short_command_marker=1788241814
candidate_monitor_end=1788241886
candidate_local_ports=22
expired_after_marker_seconds=72
native_idle_lifecycle=passed
native_cleanup=task_absent,processes_absent,marker_removed,root_removed
```

Candidate monitor SHA-256: `34dd50b21a5447446df05d2524d9f46be6667081c9ddb9b13a713090ca850aac`; complete candidate workflow SHA-256: `df80a42659d9e3bfac53daad9c8dae3d72ffd9575616e0078fdf76e6b22e905c`. These were rechecked after formatting. No private keys, tokens, real operator state, or secret-bearing captures are included.

All native proof resources and the local ephemeral key cache were removed. Provider status is `completed`. Normal then force cancellation cleaned up the lingering owned Actions keepalive; both run and job were independently verified `completed/cancelled` at `2026-09-01T05:57:29Z`. Cancellation is cleanup after successful native commands, not a successful whole-workflow verdict.

### Regression and local validation

The new suite executes the workflow's actual Bash monitor with boundary doubles for native discovery, socket observations, and time. It covers IPv4, IPv6, multiple/non-default local listeners, disconnect expiry, listening/foreign-port/prefix/closed-socket false positives, fresh and old marker mtimes, and observation failures. Real PowerShell discovery and native timer behavior are covered by the native comparison above.

Pre-fix: **6 failed, 2 passed**. After repair: **8 passed**. Including existing phone-home and sibling finalization/cleanup guards: **10 passed across 3 files**, with unrelated cases intentionally unselected.

```bash
node scripts/run-vitest.mjs test/scripts/windows-blacksmith-testbox.test.ts test/scripts/ci-workflow-guards.test.ts test/scripts/package-acceptance-workflow.test.ts -t 'native Windows Testbox idle monitor|fails Windows Testbox setup|finalizes dispatched Testbox delegation' --reporter=dot
```

```bash
node scripts/check-changed.mjs -- .github/workflows/windows-blacksmith-testbox.yml docs/reference/test.md test/scripts/windows-blacksmith-testbox.test.ts
```

```bash
node --import tsx scripts/check-workflows.mts
```

Passed again after rebasing to `1d54f21d0368200bc826a44cd641e6cdf61f3055`: focused behavior tests, changed-file formatting, test-root typechecking, script lint, classified guards, workflow sanity (actionlint/zizmor), and `git diff --check`. Fresh pre-commit and exact-head pre-land isolated Codex autoreviews were scoped-clean at the default P0 threshold. [Exact-head pull-request CI run 33478259546](https://github.com/openclaw/openclaw/actions/runs/33478259546) completed successfully at `183b7bf299b5d1da51a31ef382cc4341de5afb4d`, with the required Actions-owned `openclaw/ci-gate` successful. The canonical watcher returned `GREEN` after API quota recovery; no CI rerun was needed. Native maintainer preparation/merge guards remain mandatory.

One local workflow-bootstrap attempt selected macOS system Python 3.9 through a login shell, which cannot install the existing `pre-commit==4.6.2` pin (`requires_python >=3.10`). The normal documented invocation used the installed Python 3.13 environment and passed. No dependency pin, package, or repository code was changed for that orchestration error.

### Ownership, contracts, and size

- [Microsoft Get-NetTCPConnection](https://learn.microsoft.com/en-us/powershell/module/nettcpip/get-nettcpconnection?view=windowsserver2025-ps) defines local-port, state, and owning-process facts; [Win32_Service](https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-service) supplies the running service PID. Both were read and the query was executed natively.
- [Pinned Testbox action](https://github.com/useblacksmith/run-testbox/blob/3f60ff9ceb2c10c3feefa87dc0c6490cffae059d/action.yml) owns the hybrid SSH/marker activity contract. OpenClaw's Linux workflow already uses daemon-local ports for its separate SSH cleanup.
- Hardcoding port 22 would merely fit this image; using only the activity marker would still expire long foreground commands. The listener-derived exact-local-endpoint repair belongs in the Windows monitor, not in wrapper retries or longer timeouts.
- Tooling/production: **+19/-1 (net +18)**. Tests: **+129/-0**. Docs: **+6**. Growth is the native listener ownership query and explicit observation-error propagation; there is no new production helper or test-only seam.

Raw-parent comparison verified that `18db16471bddfb4a61ca66fb09ed8f1a7fae7f21` introduced the inline forwarded-port lookup relative to `20ade148be981865349b3e38aaa5450f439b593f`. Later established-state filtering retained the same boundary mistake; shallow history was not treated as introduction proof.
