### PR TITLE
test(sandbox): reuse SSH upload fixtures and await child startup

### DIFF
--- a/src/agents/sandbox/ssh.spawn-env.test.ts
+++ b/src/agents/sandbox/ssh.spawn-env.test.ts
@@ -6,7 +6,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureFullEnv } from "../../test-utils/env.js";
 import { SANDBOX_COMMAND_MAX_BUFFER_BYTES } from "./constants.js";
 
@@ -90,9 +90,14 @@ describe("ssh subprocess env sanitization", () => {
   const tempDirs: string[] = [];
   let envSnapshot: ReturnType<typeof captureFullEnv>;
 
-  beforeEach(async () => {
-    envSnapshot = captureFullEnv();
+  beforeAll(async () => {
     vi.resetModules();
+    ({ prepareSshSandboxExec, runSshSandboxCommand, uploadDirectoryToSshTarget } =
+      await import("./ssh.js"));
+  });
+
+  beforeEach(() => {
+    envSnapshot = captureFullEnv();
     vi.clearAllMocks();
     spawnCommandMock.mockResolvedValue({
       failed: false,
@@ -101,17 +106,18 @@ describe("ssh subprocess env sanitization", () => {
       stdout: Buffer.alloc(0),
       stderr: Buffer.alloc(0),
     });
-    ({ prepareSshSandboxExec, runSshSandboxCommand, uploadDirectoryToSshTarget } =
-      await import("./ssh.js"));
   });
 
   afterEach(async () => {
-    await Promise.all(
-      tempDirs.splice(0).map(async (dir) => {
-        await fs.rm(dir, { recursive: true, force: true });
-      }),
-    );
-    envSnapshot.restore();
+    try {
+      await Promise.all(
+        tempDirs.splice(0).map(async (dir) => {
+          await fs.rm(dir, { recursive: true, force: true });
+        }),
+      );
+    } finally {
+      envSnapshot.restore();
+    }
   });
 
   it("filters blocked secrets before spawning ssh commands", async () => {

--- a/src/agents/sandbox/ssh.stream-errors.test.ts
+++ b/src/agents/sandbox/ssh.stream-errors.test.ts
@@ -1,10 +1,9 @@
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { PassThrough } from "node:stream";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 
@@ -32,22 +31,19 @@ vi.mock("node:child_process", async () => {
   };
 });
 
-const tempDirs: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterAll);
+let localDir: string;
 
 let uploadDirectoryToSshTarget: typeof import("./ssh.js").uploadDirectoryToSshTarget;
 
-beforeEach(async () => {
+beforeAll(async () => {
   vi.resetModules();
-  vi.clearAllMocks();
   ({ uploadDirectoryToSshTarget } = await import("./ssh.js"));
+  localDir = tempDirs.make("openclaw-ssh-stream-test-");
 });
 
-afterEach(async () => {
-  await Promise.all(
-    tempDirs.splice(0).map(async (dir) => {
-      await fs.rm(dir, { recursive: true, force: true });
-    }),
-  );
+beforeEach(() => {
+  spawnMock.mockReset();
 });
 
 function fakeSession(): import("./ssh.js").SshSandboxSession {
@@ -62,13 +58,13 @@ describe("SSH sandbox stream errors", () => {
   it.each(["tar.stdout", "tar.stderr", "ssh.stdin", "ssh.stdout", "ssh.stderr"] as const)(
     "rejects and terminates both upload children once when %s fails",
     async (stream) => {
-      const localDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ssh-stream-test-"));
-      tempDirs.push(localDir);
       const tar = createMockChildProcess();
       const ssh = createMockChildProcess();
-      spawnMock
-        .mockReturnValueOnce(tar as unknown as ChildProcess)
-        .mockReturnValueOnce(ssh as unknown as ChildProcess);
+      const childrenSpawned = createDeferred();
+      spawnMock.mockReturnValueOnce(tar as unknown as ChildProcess).mockImplementationOnce(() => {
+        childrenSpawned.resolve();
+        return ssh as unknown as ChildProcess;
+      });
       const expected = `${stream} failed`;
       const result = uploadDirectoryToSshTarget({
         session: fakeSession(),
@@ -83,7 +79,12 @@ describe("SSH sandbox stream errors", () => {
           expect(error).toEqual(expect.objectContaining({ message: expected }));
         },
       );
-      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2), { timeout: 10_000 });
+      await withTestTimeout(
+        childrenSpawned.promise,
+        10_000,
+        "tar/ssh upload children did not spawn",
+      );
+      expect(spawnMock).toHaveBeenCalledTimes(2);
       const [childName, streamName] = stream.split(".") as ["tar" | "ssh", keyof MockChildProcess];
       const failedStream = { tar, ssh }[childName][streamName] as PassThrough;
 


### PR DESCRIPTION
## What Problem This Solves

The SSH upload/error suites reload the same owner for every case, allocate five identical read-only source directories, and poll the spawn mock before emitting stream errors. Their cleanup also skips environment restoration if directory removal rejects.

## Why This Change Was Made

Import the stateless owner once per suite, keep one tracked read-only directory for the stream rows, and wait for the second child spawn. The synchronous upload executor finishes installing listeners and piping streams before that waiter resumes. Each row still creates fresh child doubles; the stream mock resets between rows. Environment capture remains per case and restoration now runs in finally.

## User Impact

Test-only: production +0/-0; tests +37/-30 (net +7). On POSIX, 18 module imports/resets become two and five stream roots become one; five polling loops disappear. All original error, environment and security assertions remain, including both peer kills and late-error single termination. The existing 10-second readiness bound remains. No elapsed-time speedup is claimed.

## Evidence

The before/after runs each pass all 74 cases, with identical native names and statuses across the changed suites and SSH helper/backend siblings. Temporary faults prove the five late kill-count oracles and the named 10-second missing-start failure. A real removal followed by an injected cleanup rejection demonstrates the old environment-restoration gap and the candidate fix while preserving the cleanup error. Exact source bytes were restored; subsequent formatting only wrapped expressions.

The initial explicit-config missing-start probe stalled before producing a native result and is excluded. Repeating that probe through the normal test route produced the intended diagnostic, with no unhandled errors or global timeout. The normal suite passed separately.

Full changed-file checks passed. Scoped Codex autoreview returned no findings; broader lead and independent source review found no actionable issue.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/sandbox/ssh.stream-errors.test.ts src/agents/sandbox/ssh.spawn-env.test.ts src/agents/sandbox/ssh.test.ts src/agents/sandbox/ssh-backend.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base 14e26a380d342a595bc1f536a19f4be0935a002e
```

Named follow-ups from source review: spawn-env still retains unconsumed once implementations after an early failed row; stream doubles and upload promises are not universally joined after failed assertions. This change does not claim full settlement of intentionally failed upload fixtures or real SSH/network proof.
