### PR TITLE
fix(node-host): preserve native Claude login for blank credentials

### DIFF
--- a/src/node-host/invoke-agent-cli-claude-handler.ts
+++ b/src/node-host/invoke-agent-cli-claude-handler.ts
@@ -94,7 +94,12 @@ function prepareClaudeNodeSecretInput(params: {
   ]) {
     delete params.childEnv[key];
   }
-  const source = Buffer.from(params.requestEnv?.[selected.requestEnv] ?? "", "utf8");
+  const value = params.requestEnv?.[selected.requestEnv]?.trim();
+  // An empty descriptor suppresses Claude's healthy native login.
+  if (!value) {
+    return { cleanup: () => {} };
+  }
+  const source = Buffer.from(value, "utf8");
   params.childEnv[selected.descriptorEnv] = "3";
   return {
     secretInput: {

--- a/src/node-host/invoke-agent-cli-claude.test.ts
+++ b/src/node-host/invoke-agent-cli-claude.test.ts
@@ -279,72 +279,92 @@ describe("Claude CLI node command", () => {
     },
   );
 
-  it("converts forwarded OAuth into a child-only descriptor after approval", async () => {
-    const executable = await executableScript(`
+  it.each([
+    { rawEnv: "CLAUDE_CODE_OAUTH_TOKEN", value: "selected-node-oauth" },
+    { rawEnv: "ANTHROPIC_API_KEY", value: "selected-node-api-key" },
+    { rawEnv: "CLAUDE_CODE_OAUTH_TOKEN", value: "" },
+    { rawEnv: "ANTHROPIC_API_KEY", value: "" },
+    { rawEnv: "CLAUDE_CODE_OAUTH_TOKEN", value: " \t " },
+    { rawEnv: "ANTHROPIC_API_KEY", value: " \t " },
+  ])(
+    "forwards only nonblank $rawEnv through a child-only descriptor ($value)",
+    async ({ rawEnv, value }) => {
+      const executable = await executableScript(`
 const fs = require("node:fs");
-const secret = fs.readFileSync(3, "utf8");
+const descriptor = process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR ?? process.env.CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR;
+const secret = descriptor ? fs.readFileSync(Number(descriptor), "utf8") : "native-login";
 process.stdout.write(JSON.stringify({
   type: "result",
   result: secret,
-  descriptor: process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR,
-  rawPresent: Object.hasOwn(process.env, "CLAUDE_CODE_OAUTH_TOKEN"),
+  descriptor: descriptor ?? null,
+  rawPresent: Object.hasOwn(process.env, "CLAUDE_CODE_OAUTH_TOKEN") || Object.hasOwn(process.env, "ANTHROPIC_API_KEY"),
   scrubPresent: Object.hasOwn(process.env, "CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"),
 }) + "\\n");`);
-    const calls: Array<{ method: string; params: unknown }> = [];
-    const handleSystemRun = vi.fn(
-      async (options: {
-        params: { command: string[]; env?: Record<string, string>; timeoutMs?: number };
-        runCommand: (
-          argv: string[],
-          cwd: string | undefined,
-          env: Record<string, string> | undefined,
-          timeoutMs: number | undefined,
-        ) => Promise<unknown>;
-        sendInvokeResult: (result: unknown) => Promise<void>;
-      }) => {
-        await options.runCommand(
-          options.params.command,
-          undefined,
-          {
-            ...process.env,
-            ...options.params.env,
-            CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1",
-          } as Record<string, string>,
-          options.params.timeoutMs,
-        );
-        await options.sendInvokeResult({ ok: true });
-      },
-    );
-    await handleInvoke(
-      frame({
-        argv: ["-p"],
-        env: { CLAUDE_CODE_OAUTH_TOKEN: "selected-node-oauth" },
-        clearEnv: ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"],
-        idleTimeoutMs: 1_000,
-        timeoutMs: 5_000,
-      }),
-      client(calls),
-      { current: async () => [] },
-      undefined,
-      { claudePath: executable, handleSystemRun: handleSystemRun as never },
-    );
+      const calls: Array<{ method: string; params: unknown }> = [];
+      const handleSystemRun = vi.fn(
+        async (options: {
+          params: { command: string[]; env?: Record<string, string>; timeoutMs?: number };
+          runCommand: (
+            argv: string[],
+            cwd: string | undefined,
+            env: Record<string, string> | undefined,
+            timeoutMs: number | undefined,
+          ) => Promise<unknown>;
+          sendInvokeResult: (result: unknown) => Promise<void>;
+        }) => {
+          await options.runCommand(
+            options.params.command,
+            undefined,
+            {
+              ...process.env,
+              ...options.params.env,
+              CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1",
+              CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR: "8",
+              CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR: "9",
+            } as Record<string, string>,
+            options.params.timeoutMs,
+          );
+          await options.sendInvokeResult({ ok: true });
+        },
+      );
+      await handleInvoke(
+        frame({
+          argv: ["-p"],
+          env: { [rawEnv]: value },
+          clearEnv: [
+            "ANTHROPIC_API_KEY",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR",
+            "CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR",
+          ],
+          idleTimeoutMs: 1_000,
+          timeoutMs: 5_000,
+        }),
+        client(calls),
+        { current: async () => [] },
+        undefined,
+        { claudePath: executable, handleSystemRun: handleSystemRun as never },
+      );
 
-    const progress = calls
-      .filter((call) => call.method === "node.invoke.progress")
-      .map((call) => (call.params as { chunk: string }).chunk)
-      .join("");
-    expect(progress).toContain('"result":"selected-node-oauth"');
-    expect(progress).toContain('"descriptor":"3"');
-    expect(progress).toContain('"rawPresent":false');
-    expect(progress).toContain('"scrubPresent":false');
-    expect(calls).toContainEqual({
-      method: "node.invoke.result",
-      params: expect.objectContaining({
-        ok: true,
-        payloadJSON: expect.stringContaining('"exitCode":0'),
-      }),
-    });
-  });
+      const progress = calls
+        .filter((call) => call.method === "node.invoke.progress")
+        .map((call) => (call.params as { chunk: string }).chunk)
+        .join("");
+      expect(JSON.parse(progress)).toMatchObject({
+        result: value.trim() || "native-login",
+        descriptor: value.trim() ? "3" : null,
+      });
+      expect(progress).toContain('"rawPresent":false');
+      expect(progress).toContain('"scrubPresent":false');
+      expect(calls).toContainEqual({
+        method: "node.invoke.result",
+        params: expect.objectContaining({
+          ok: true,
+          payloadJSON: expect.stringContaining('"exitCode":0'),
+        }),
+      });
+    },
+  );
 
   it("preserves node-native Claude auth when no profile credential is forwarded", async () => {
     const executable = await executableScript(`


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Claude runs on a paired node fail authentication when a forwarded OAuth token or API key is empty. Declaring an empty credential descriptor prevents Claude Code from using its native login. Related: #126753; thanks to @rockytanf for the descriptor A/B diagnosis.

## Why This Change Was Made

The node-host preparation boundary now trims selected credentials and omits both the descriptor environment variable and private secret input when no credential remains. Selected-auth environment scrubbing still happens first; requests without a selected profile continue preserving node-native authentication. The Anthropic plugin already enforces the same nonblank-input contract.

The producer sweep covered the plugin backend, gateway-to-node serialization, node-host preparation, supervisor child/relay adapters, and Agent SDK spawner. Only the node-host producer selected empty material by key presence. No configuration, schema, protocol, or public API changes.

## User Impact

Paired-node Claude runs with empty or whitespace-only forwarded credentials can use Claude Code's native login again. Nonempty OAuth and API-key credentials still travel through the private one-shot descriptor rather than the child environment.

Release-note context: restore native Claude authentication for blank node-host credential handoffs; related #126753, reported by @rockytanf.

## Evidence

- Before the fix: `node scripts/run-vitest.mjs src/node-host/invoke-agent-cli-claude.test.ts -t 'forwards only nonblank'` failed all four empty/whitespace cases for OAuth and API keys. Real child processes observed descriptor `"3"` with empty/whitespace bytes. Both nonempty cases passed.
- After the fix: `node scripts/run-vitest.mjs src/node-host/invoke-agent-cli-claude.test.ts src/process/spawn-secret-input.test.ts` passed all 41 tests, including native-env preservation, both credential types, inherited-descriptor clearing, pipe delivery and cleanup, cancellation, and output limits.
- Real Claude Code 2.1.236 probe, isolated temporary HOME/config, empty OAuth env, fd 3 opened from `/dev/null`: `claude -p ping --bare` exited 1 with `Not logged in · Please run /login`. The equivalent shell command is `CLAUDE_CONFIG_DIR="$(mktemp -d)" CLAUDE_CODE_OAUTH_TOKEN='' CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR=3 claude -p ping --bare 3</dev/null`.
- Native-login success cannot be demonstrated on this host: after removing auth overrides, `claude auth status --json` reports `loggedIn: false`, `authMethod: none`. The authenticated A/B contract is recorded in #126753: valid fd token succeeds; bogus token gives an invalid-token error; only empty fd gives the reported login failure. The repaired node-host test proves omission of the descriptor, rather than claiming an authenticated model turn.

Production delta: +6/-1 (net +5); tests: +79/-59 (net +20). The small production growth keeps credential scrubbing before the empty-value return; moving the early return ahead of scrubbing would leave whitespace credentials in the child environment. No transport fallback or additional abstraction was added.

The real dispatcher probe (`node --import ./scripts/tsx.mjs /tmp/claude-fd3-live.mts`) used an isolated state/config directory and the normal node-host command dispatcher. A probe wrapper printed descriptor presence, then exec'd the installed real Claude binary. Observed:

```text
descriptor declared: false
Not logged in · Please run /login
node.invoke.result: ok=true, exitCode=1, stderrTail="", truncated=false
```

`pnpm build` passed, including runtime postbuild and Control UI budgets. Both local and committed-branch autoreview completed with no accepted/actionable findings.

<details>
<summary>Reproducible live dispatcher probe</summary>

Save as `/tmp/claude-fd3-live.mts`, then run the command above from the repository root.

```typescript
import fs from 'node:fs/promises';
import os from 'node:os';
import path from 'node:path';
const root = process.cwd();
const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openclaw-fd3-live-'));
process.env.OPENCLAW_STATE_DIR = stateDir;
process.env.CLAUDE_CONFIG_DIR = path.join(stateDir, 'claude');
await fs.mkdir(process.env.CLAUDE_CONFIG_DIR);
const wrapper = path.join(stateDir, 'claude-probe');
await fs.writeFile(wrapper, `#!/bin/sh
if [ -n "$CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR$CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR" ]; then
  printf 'descriptor declared: true\\n'
else
  printf 'descriptor declared: false\\n'
fi
exec /opt/homebrew/bin/claude "$@"
`, {mode:0o700});
for (const key of ['ANTHROPIC_API_KEY','ANTHROPIC_AUTH_TOKEN','CLAUDE_CODE_OAUTH_TOKEN','CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR','CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR']) delete process.env[key];
const { handleInvoke } = await import(`${root}/src/node-host/invoke.ts`);
const { setRuntimeConfigSnapshot } = await import(`${root}/src/config/runtime-snapshot.ts`);
setRuntimeConfigSnapshot({});
try {
 await handleInvoke({
  id:'fd3-live',nodeId:'synthetic-node',command:'agent.cli.claude.run.v1',
  paramsJSON:JSON.stringify({argv:['-p','--bare'],stdin:'Reply with pong',env:{CLAUDE_CODE_OAUTH_TOKEN:''},clearEnv:['ANTHROPIC_API_KEY','CLAUDE_CODE_OAUTH_TOKEN','CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR','CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR'],idleTimeoutMs:60000,timeoutMs:90000}),
 }, {request:async(method,params)=>{if(method==='node.invoke.progress') process.stdout.write(params.chunk);else if(method==='node.invoke.result') console.log(JSON.stringify({method,...params}));return {}; }}, {current:async()=>[]}, undefined, {claudePath:wrapper});
} finally { await fs.rm(stateDir,{recursive:true,force:true}); }
```
</details>

The complete local changed-file gate also passed: `node scripts/check-changed.mjs -- src/node-host/invoke-agent-cli-claude-handler.ts src/node-host/invoke-agent-cli-claude.test.ts` (exit 0). Exact-head CI run [33478893819](https://github.com/openclaw/openclaw/actions/runs/33478893819) is green. Latest ClawSweeper comment is an acknowledgement only; no Rank-up moves have been published.
