### PR TITLE
fix(plugins): exempt verified first-party plugins from capability consent

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -157,6 +157,13 @@ already tracked install do not require it. `--force` does not bypass
 install safety checks.
 </Warning>
 
+Bundled plugins and verified first-party catalog plugins do not require
+`--accept-capabilities` for install, enable, update, or Doctor repair. Local
+copies and unverified sources still require capability consent even when their
+package name matches an official plugin. This exemption does not grant OAuth,
+operating-system, or runtime tool permissions. See
+[capability consent](/plugins/manage-plugins#capability-consent).
+
 `plugins search` queries ClawHub for installable `code-plugin` and
 `bundle-plugin` packages (not skills; use `openclaw skills search` for those).
 Default `--limit` is 20, capped at 100. It only reads the remote catalog: no

--- a/docs/plugins/manage-plugins.md
+++ b/docs/plugins/manage-plugins.md
@@ -101,12 +101,22 @@ are enabled by default; others require `enable` after install.
 
 ## Capability consent
 
-OpenClaw asks you to review an external plugin's declared capabilities before
+OpenClaw asks you to review a third-party plugin's declared capabilities before
 installing or enabling it. The consent screen identifies the plugin, its
 version and source, artifact integrity, and available trust information. It
 also lists declared channels, providers, tools, hooks, MCP servers, CLI
 commands and backends, skills, and dangerous configuration flags, along with
 the operator grants that apply to hooks, model access, and subagents.
+
+Bundled plugins and verified first-party plugins from OpenClaw's official
+catalog do not require this capability review during install, enable, update,
+or Doctor repair. For separately installed first-party plugins, OpenClaw checks
+the actual package identity against its catalog and verified npm source record
+or official-channel record from `https://clawhub.ai`. A matching plugin id or
+package name alone is insufficient: local copies, archives, git installs,
+custom ClawHub registries, and conflicting source records still require review.
+This exemption does not grant OAuth access, operating-system permissions, or
+runtime tool approvals, and does not create an operator acceptance record.
 
 The review token hashes the exact declared capability surface, not the plugin's
 executable files. Acceptance separately records installer-provided artifact
@@ -119,7 +129,7 @@ plugin preserves disablement and defers any required consent until enablement.
 Reinstalling through `plugins install` activates the plugin and must satisfy
 consent before activation.
 
-Already-enabled legacy installations remain usable without an initial review;
+Already-enabled third-party legacy installations remain usable without an initial review;
 disabling and re-enabling them requires consent. Setup rechecks consent when
 saving its final config, so a plugin update during login cannot activate a
 replacement with unaccepted capabilities.
@@ -147,7 +157,7 @@ openclaw plugins update <plugin-id> --accept-capabilities
 openclaw plugins enable <plugin-id> --accept-capabilities
 ```
 
-Doctor uses the same review before installing or adopting a replacement plugin.
+Doctor uses the same source checks and review before installing or adopting a replacement plugin.
 `doctor --fix` and `--yes` do not approve capabilities automatically. For
 noninteractive repair, review and install the plugin with the explicit flag
 above, then rerun doctor.
@@ -162,8 +172,7 @@ with `--accept-capabilities`:
 /plugins enable <plugin-id> --accept-capabilities
 ```
 
-Bundled plugins are exempt because they ship with the OpenClaw release rather
-than arriving as separately installed artifacts. Plugins discovered directly
+Plugins discovered directly
 in a workspace or through `plugins.load.paths`, without a managed install
 record, cannot persist capability acceptance. Their details in the Control UI
 still show declared capabilities.

--- a/src/auto-reply/reply/commands-plugins.test.ts
+++ b/src/auto-reply/reply/commands-plugins.test.ts
@@ -2,7 +2,7 @@
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { PluginCapabilityConsentReview } from "../../plugins/capability-consent.js";
+import type { PluginCapabilityConsentReview } from "../../plugins/capability-summary.js";
 import { recordInstalledPluginIndexInstallOwner } from "../../plugins/installed-plugin-index-install-owner.js";
 import { ManagedPluginLifecycleError } from "../../plugins/management-lifecycle-error.js";
 import { createInstalledPluginIndexSnapshot } from "../../plugins/status.test-fixtures.js";

--- a/src/cli/plugin-capability-consent.ts
+++ b/src/cli/plugin-capability-consent.ts
@@ -4,10 +4,8 @@ import {
 } from "../../packages/gateway-protocol/src/schema/plugin-declared-surface-groups.js";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
-import type {
-  PluginCapabilityConsentHandler,
-  PluginCapabilityConsentReview,
-} from "../plugins/capability-consent.js";
+import type { PluginCapabilityConsentHandler } from "../plugins/capability-consent.js";
+import type { PluginCapabilityConsentReview } from "../plugins/capability-summary.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { promptYesNo } from "./prompt.js";
 

--- a/src/cli/plugins-cli.policy.test.ts
+++ b/src/cli/plugins-cli.policy.test.ts
@@ -188,7 +188,7 @@ describe("plugins cli policy mutations", () => {
       await runPluginsCommand(commandArgs);
 
       const { resolvePluginArtifactDeclaredSurface } =
-        await import("../plugins/capability-consent.js");
+        await import("../plugins/capability-artifact.js");
       const { computeDeclaredSurfaceHash } = await import("../plugins/capability-summary.js");
       if (expectsConsent) {
         const acceptedRecord =

--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ClawHubTrustErrorCode } from "../infra/clawhub-install-trust.js";
 import { resolveRegistryUpdateChannel } from "../infra/update-channels.js";
-import type { PluginCapabilityConsentReview } from "../plugins/capability-consent.js";
+import type { PluginCapabilityConsentReview } from "../plugins/capability-summary.js";
 import {
   attachPluginInstallOwnerMigrations,
   resolvePluginInstallTransactionSink,

--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -2,7 +2,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileCredential } from "../agents/auth-profiles/types.js";
-import { buildPluginCapabilityConsentReview } from "../plugins/capability-consent.js";
+import { buildPluginCapabilityConsentReview } from "../plugins/capability-summary.js";
 import * as pluginEnable from "../plugins/enable.js";
 import { metadataSnapshot } from "../plugins/management-service.test-helpers.js";
 import {

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -7,10 +7,8 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { writeChannelPairingStateSnapshot } from "../pairing/pairing-store-sqlite.test-helpers.js";
-import {
-  buildPluginCapabilityConsentReview,
-  type PluginCapabilityConsentHandler,
-} from "../plugins/capability-consent.js";
+import type { PluginCapabilityConsentHandler } from "../plugins/capability-consent.js";
+import { buildPluginCapabilityConsentReview } from "../plugins/capability-summary.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";

--- a/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
@@ -459,6 +459,8 @@ async function adoptExistingNpmPackage(params: {
         params.candidate.pluginId,
         {
           source: "npm",
+          // Adoption discovers local bytes; only a registry reinstall can establish official trust.
+          sourcePath: params.packagePath,
           spec: resolveNpmInstallRecordSpec({
             requestedSpec: params.npmRecordSpec,
             resolution: npmResolution,

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -7,6 +7,7 @@ import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../../../packages/gateway
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig, PluginsConfig } from "../../../config/types.js";
 import { resolveRegistryUpdateChannel } from "../../../infra/update-channels.js";
+import { resolvePluginArtifactDeclaredSurface } from "../../../plugins/capability-artifact.js";
 import type { PluginCapabilityConsentHandler } from "../../../plugins/capability-consent.js";
 import { computeDeclaredSurfaceHash } from "../../../plugins/capability-summary.js";
 import {
@@ -15,6 +16,7 @@ import {
 } from "../../../plugins/install-channel-specs.js";
 import type { PluginInstallArtifactConsentHandler } from "../../../plugins/install-types.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../../../plugins/installed-plugin-index-policy.js";
+import { isTrustedOfficialPluginInstallRecord } from "../../../plugins/official-external-install-records.js";
 import type { BundledProviderPolicySurface } from "../../../plugins/provider-policy-surface.js";
 import { createColdPluginFixture } from "../../../plugins/test-helpers/cold-plugin-fixtures.js";
 import { VERSION } from "../../../version.js";
@@ -378,9 +380,9 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         installPath: installDir,
         ...(previousState === "accepted"
           ? {
-              acceptedSurface: actual.resolvePluginArtifactDeclaredSurface(installDir),
+              acceptedSurface: resolvePluginArtifactDeclaredSurface(installDir),
               acceptedSurfaceHash: computeDeclaredSurfaceHash(
-                actual.resolvePluginArtifactDeclaredSurface(installDir),
+                resolvePluginArtifactDeclaredSurface(installDir),
               ),
               acceptedSurfaceAt: "2026-01-01T00:00:00.000Z",
               acceptedSurfaceIntegrity: "sha512-previous",
@@ -545,15 +547,19 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       );
       const root = tempDirs.make("openclaw-doctor-consent-");
       const npmRoot = path.join(root, "npm");
+      const packageName = source === "adopt" ? "@openclaw/matrix" : "@example/matrix";
+      if (source === "adopt") {
+        useManifestCatalogResolvers();
+      }
       const artifactDir =
         source === "adopt"
-          ? path.join(npmRoot, "node_modules", "@example", "matrix")
+          ? path.join(npmRoot, "node_modules", ...packageName.split("/"))
           : path.join(root, "artifact");
       fs.mkdirSync(artifactDir, { recursive: true });
       const fixture = createColdPluginFixture({
         rootDir: artifactDir,
         pluginId: "matrix",
-        packageName: "@example/matrix",
+        packageName,
         manifest: { contracts: { tools: ["matrix.write"] } },
       });
       mocks.resolveDefaultPluginNpmDir.mockReturnValue(npmRoot);
@@ -565,8 +571,8 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           meta: { label: "Matrix" },
           install:
             source === "clawhub"
-              ? { clawhubSpec: "clawhub:@example/matrix@1.0.0" }
-              : { npmSpec: "@example/matrix@1.0.0", defaultChoice: "npm" },
+              ? { clawhubSpec: `clawhub:${packageName}@1.0.0` }
+              : { npmSpec: `${packageName}@1.0.0`, defaultChoice: "npm" },
         },
       ]);
       let committed = false;
@@ -582,13 +588,13 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         return {
           ...successfulInstall({
             pluginId: "matrix",
-            npmSpec: "@example/matrix",
+            npmSpec: packageName,
             version: "1.0.0",
             targetDir: artifactDir,
           }),
           clawhub: {
             source: "clawhub",
-            clawhubPackage: "@example/matrix",
+            clawhubPackage: packageName,
             integrity: "sha256-matrix",
           },
         };
@@ -628,6 +634,16 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           acceptedSurfaceHash: expect.stringMatching(/^[a-f\d]{64}$/),
           acceptedSurfaceAt: expect.any(String),
         });
+        if (source === "adopt") {
+          expect(result.records.matrix?.sourcePath).toBe(artifactDir);
+          expect(
+            isTrustedOfficialPluginInstallRecord({
+              pluginId: "matrix",
+              packageName,
+              record: expectDefined(result.records.matrix, "adopted install record"),
+            }),
+          ).toBe(false);
+        }
         expect(mocks.writePersistedInstalledPluginIndexInstallRecords).toHaveBeenCalledWith(
           result.records,
           expect.any(Object),

--- a/src/gateway/server-methods/system-agent-setup-resolution.test.ts
+++ b/src/gateway/server-methods/system-agent-setup-resolution.test.ts
@@ -8,7 +8,7 @@ import type {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { WizardNextResultSchema } from "../../../packages/gateway-protocol/src/schema/wizard.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { buildPluginCapabilityConsentReview } from "../../plugins/capability-consent.js";
+import { buildPluginCapabilityConsentReview } from "../../plugins/capability-summary.js";
 import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
 import { createPluginCapabilityConsentPrompter } from "../../wizard/plugin-capability-consent.js";
 import { WizardSession } from "../../wizard/session.js";

--- a/src/plugins/capability-artifact.ts
+++ b/src/plugins/capability-artifact.ts
@@ -1,0 +1,155 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginAcceptedDeclaredSurface } from "../config/types.plugins.js";
+import { isRootFileMissingFailure } from "../infra/boundary-file-read.js";
+import {
+  resolvePathViaExistingAncestorSync,
+  resolveRootPathSync,
+  safeRealpathSync,
+} from "../infra/boundary-path.js";
+import { readRootJsonObjectSync } from "../infra/json-files.js";
+import { isPathInside } from "../infra/path-guards.js";
+import { resolveUserPath } from "../utils.js";
+import { buildPluginCapabilitySummary, mergePluginDeclaredSurfaces } from "./capability-summary.js";
+import { discoverConfiguredPluginLoadPaths } from "./discovery.js";
+import { loadPluginManifestRegistryCore } from "./manifest-registry.js";
+import { resolvePackageExtensionEntries } from "./package-manifest.js";
+import { createPluginCache, withPluginCache } from "./plugin-cache.js";
+
+type PluginArtifactInspectionContext = {
+  config?: OpenClawConfig;
+  currentArtifactDir?: string;
+};
+
+function resolvePluginArtifactManifests(
+  rootDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+  context: PluginArtifactInspectionContext = {},
+) {
+  const artifactRoot = fs.realpathSync(resolveUserPath(rootDir, env));
+  const packageManifest = readRootJsonObjectSync({
+    rootDir: artifactRoot,
+    rootRealPath: artifactRoot,
+    relativePath: "package.json",
+    boundaryLabel: "plugin artifact directory",
+    rejectHardlinks: true,
+  });
+  if (!packageManifest.ok) {
+    if (packageManifest.reason !== "open" || !isRootFileMissingFailure(packageManifest.failure)) {
+      throw new Error(`Unable to inspect the plugin artifact package manifest: ${artifactRoot}`);
+    }
+  } else {
+    const extensions = resolvePackageExtensionEntries(packageManifest.value);
+    if (extensions.status === "invalid") {
+      throw new Error(extensions.error);
+    }
+    if (extensions.status === "empty") {
+      throw new Error("package.json openclaw.extensions is empty");
+    }
+  }
+
+  const currentRoot = path.resolve(resolveUserPath(context.currentArtifactDir ?? rootDir, env));
+  const currentCanonicalRoot = resolvePathViaExistingAncestorSync(currentRoot);
+  const loadPaths: string[] = [];
+  for (const configuredPath of context.config?.plugins?.load?.paths ?? []) {
+    const source = path.resolve(resolveUserPath(configuredPath, env));
+    const canonicalSource = resolvePathViaExistingAncestorSync(source);
+    if (
+      !isPathInside(currentRoot, source) &&
+      !isPathInside(currentCanonicalRoot, canonicalSource)
+    ) {
+      continue;
+    }
+    const current = resolveRootPathSync({
+      absolutePath: source,
+      rootPath: currentRoot,
+      rootCanonicalPath: currentCanonicalRoot,
+      boundaryLabel: "installed plugin artifact directory",
+    });
+    const lexicalRoot = isPathInside(currentRoot, source) ? currentRoot : currentCanonicalRoot;
+    const relativePath = isPathInside(lexicalRoot, source)
+      ? path.relative(lexicalRoot, source)
+      : path.relative(
+          currentCanonicalRoot,
+          current.kind === "directory"
+            ? current.canonicalPath
+            : path.join(
+                resolvePathViaExistingAncestorSync(path.dirname(source)),
+                path.basename(source),
+              ),
+        );
+    const staged = resolveRootPathSync({
+      absolutePath: path.join(artifactRoot, relativePath),
+      rootPath: artifactRoot,
+      rootCanonicalPath: artifactRoot,
+      boundaryLabel: "staged plugin artifact directory",
+    });
+    // A file symlink uses its lexical parent's manifest, not the target file's parent.
+    loadPaths.push(staged.absolutePath);
+  }
+  // Explicit paths keep runtime precedence; ordinary package entries all use their root manifest.
+  loadPaths.push(artifactRoot);
+  const packageDiscovery = discoverConfiguredPluginLoadPaths({
+    loadPaths: [artifactRoot],
+    env,
+    deduplicate: true,
+  });
+  const packageSources = new Set(
+    packageDiscovery.candidates.map(
+      (candidate) => safeRealpathSync(candidate.source) ?? candidate.source,
+    ),
+  );
+  const discovery =
+    loadPaths.length === 1
+      ? packageDiscovery
+      : discoverConfiguredPluginLoadPaths({ loadPaths, env, deduplicate: true });
+  const registry = loadPluginManifestRegistryCore({
+    config: { plugins: { load: { paths: loadPaths } } },
+    env,
+    installRecords: {},
+    discovery: {
+      // Only physical package entries inherit managed ownership, including configured overrides.
+      candidates: discovery.candidates.filter((candidate) =>
+        packageSources.has(safeRealpathSync(candidate.source) ?? candidate.source),
+      ),
+      diagnostics: packageDiscovery.diagnostics,
+    },
+  });
+  const error = registry.diagnostics.find((diagnostic) => diagnostic.level === "error");
+  if (error || registry.plugins.length === 0) {
+    throw new Error(
+      error?.message ?? `Plugin artifact has no valid plugin manifest: ${artifactRoot}`,
+    );
+  }
+  return registry.plugins;
+}
+
+export function inspectPluginCapabilityArtifact(
+  rootDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+  context: PluginArtifactInspectionContext = {},
+) {
+  // Consent inspects the current artifact, including after an approval callback yields.
+  // Runtime or earlier review facts must never authorize replacement bytes.
+  return withPluginCache(createPluginCache(), () => {
+    const manifests = resolvePluginArtifactManifests(rootDir, env, context);
+    return {
+      manifest: manifests[0],
+      declared: mergePluginDeclaredSurfaces(
+        manifests.map(
+          (manifest) => buildPluginCapabilitySummary({ manifest, origin: "global" }).declared,
+        ),
+      ),
+    };
+  });
+}
+
+/** Read only validated manifest surfaces belonging to the actual artifact on disk. */
+export function resolvePluginArtifactDeclaredSurface(
+  rootDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+  context: PluginArtifactInspectionContext = {},
+): PluginAcceptedDeclaredSurface {
+  return inspectPluginCapabilityArtifact(rootDir, env, context).declared;
+}

--- a/src/plugins/capability-consent.test.ts
+++ b/src/plugins/capability-consent.test.ts
@@ -5,15 +5,12 @@ import type {
   PluginAcceptedDeclaredSurface,
   PluginInstallRecord,
 } from "../config/types.plugins.js";
-import {
-  buildPluginCapabilityConsentReview,
-  createManagedPluginArtifactConsentHandler,
-  diffDeclaredSurfaceWidening,
-  resolvePluginArtifactDeclaredSurface,
-} from "./capability-consent.js";
+import { resolvePluginArtifactDeclaredSurface } from "./capability-artifact.js";
+import { createManagedPluginArtifactConsentHandler } from "./capability-consent.js";
 import {
   buildPluginCapabilitySummary,
   computeDeclaredSurfaceHash,
+  diffDeclaredSurfaceWidening,
   mergePluginDeclaredSurfaces,
   resolveAcceptedSurfaceCurrent,
   resolvePluginInstallRecordIntegrity,
@@ -394,23 +391,33 @@ describe("plugin capability consent", () => {
     expect(resolveAcceptedSurfaceCurrent(installRecord, surface)).toBe(current);
   });
 
-  it("redacts source credentials before a capability review reaches a prompt or pending inspection", () => {
+  it("redacts source credentials before a capability review reaches a prompt or pending inspection", async () => {
     const url = new URL("https://example.invalid/plugins/demo.git");
     url.username = "fixture-user";
     url.password = "fixture-password";
     url.searchParams.set("token", "fixture-token");
     const record: PluginInstallRecord = { source: "git", spec: `git:${url.href}` };
 
-    const review = buildPluginCapabilityConsentReview({
-      pluginId: "plugin",
-      manifest: {},
+    let reviewSpec: string | undefined;
+    const consent = createManagedPluginArtifactConsentHandler({
       config: {},
-      record,
+      source: record.source,
+      spec: record.spec,
+      onCapabilityConsent: async (review) => {
+        reviewSpec = review.source?.spec;
+        return { reviewToken: review.reviewToken };
+      },
+    });
+    await consent.onBeforePluginArtifactCommit({
+      pluginId: "plugin",
+      mode: "install",
+      stagedArtifactDir: createArtifactFixture({
+        "index.js": "export {};",
+        "openclaw.plugin.json": { id: "plugin", configSchema: { type: "object" } },
+      }),
     });
 
-    expect(review.source?.spec).toBe(
-      "git:https://***:***@example.invalid/plugins/demo.git?token=***",
-    );
+    expect(reviewSpec).toBe("git:https://***:***@example.invalid/plugins/demo.git?token=***");
     expect(record.spec).toBe(`git:${url.href}`);
   });
 

--- a/src/plugins/capability-consent.ts
+++ b/src/plugins/capability-consent.ts
@@ -1,35 +1,25 @@
-import fs from "node:fs";
 import path from "node:path";
-import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
-import { PLUGIN_DECLARED_SURFACE_GROUPS } from "../../packages/gateway-protocol/src/schema/plugin-declared-surface-groups.js";
-import type {
-  PluginInstallTrust,
-  PluginsInspectResult,
-} from "../../packages/gateway-protocol/src/schema/plugins.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type {
   PluginAcceptedDeclaredSurface,
   PluginInstallRecord,
 } from "../config/types.plugins.js";
-import { isRootFileMissingFailure } from "../infra/boundary-file-read.js";
-import {
-  resolvePathViaExistingAncestorSync,
-  resolveRootPathSync,
-  safeRealpathSync,
-} from "../infra/boundary-path.js";
-import { readRootJsonObjectSync } from "../infra/json-files.js";
-import { isPathInside } from "../infra/path-guards.js";
 import { resolveUserPath } from "../utils.js";
 import {
-  buildPluginCapabilitySummary,
+  inspectPluginCapabilityArtifact,
+  resolvePluginArtifactDeclaredSurface,
+} from "./capability-artifact.js";
+import {
+  buildPluginCapabilityConsentReview,
   computeDeclaredSurfaceHash,
-  mergePluginDeclaredSurfaces,
+  diffDeclaredSurfaceWidening,
   resolveAcceptedSurfaceCurrent,
   resolvePluginInstallRecordIntegrity,
   resolvePluginPackageDeclaredSurface,
+  type PluginCapabilityConsentReview,
 } from "./capability-summary.js";
+import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import { resolvePluginControlPlaneWorkspace } from "./control-plane-workspace.js";
-import { discoverConfiguredPluginLoadPaths } from "./discovery.js";
 import type {
   PluginInstallArtifactConsentHandler,
   PluginInstallArtifactConsentRequest,
@@ -42,12 +32,9 @@ import {
   loadInstalledPluginIndexInstallRecords,
   writePersistedInstalledPluginIndexInstallRecordsWithLease,
 } from "./installed-plugin-index-records.js";
-import type { InstalledPluginInstallRecordInfo } from "./installed-plugin-index-types.js";
 import { resolveInstalledPluginPackageOwnership } from "./installed-plugin-package-ownership.js";
 import { ManagedPluginLifecycleError } from "./management-lifecycle-error.js";
-import { loadPluginManifestRegistryCore } from "./manifest-registry.js";
-import { resolvePackageExtensionEntries } from "./package-manifest.js";
-import { createPluginCache, withPluginCache } from "./plugin-cache.js";
+import { isTrustedOfficialPluginInstallRecord } from "./official-external-install-records.js";
 import { withPluginLifecycleLease } from "./plugin-lifecycle-lease.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import {
@@ -55,167 +42,7 @@ import {
   type PluginMetadataSnapshot,
 } from "./plugin-metadata-snapshot.js";
 
-type PluginArtifactInspectionContext = {
-  config?: OpenClawConfig;
-  currentArtifactDir?: string;
-};
-
-function resolvePluginArtifactManifests(
-  rootDir: string,
-  env: NodeJS.ProcessEnv = process.env,
-  context: PluginArtifactInspectionContext = {},
-) {
-  const artifactRoot = fs.realpathSync(resolveUserPath(rootDir, env));
-  const packageManifest = readRootJsonObjectSync({
-    rootDir: artifactRoot,
-    rootRealPath: artifactRoot,
-    relativePath: "package.json",
-    boundaryLabel: "plugin artifact directory",
-    rejectHardlinks: true,
-  });
-  if (!packageManifest.ok) {
-    if (packageManifest.reason !== "open" || !isRootFileMissingFailure(packageManifest.failure)) {
-      throw new Error(`Unable to inspect the plugin artifact package manifest: ${artifactRoot}`);
-    }
-  } else {
-    const extensions = resolvePackageExtensionEntries(packageManifest.value);
-    if (extensions.status === "invalid") {
-      throw new Error(extensions.error);
-    }
-    if (extensions.status === "empty") {
-      throw new Error("package.json openclaw.extensions is empty");
-    }
-  }
-
-  const currentRoot = path.resolve(resolveUserPath(context.currentArtifactDir ?? rootDir, env));
-  const currentCanonicalRoot = resolvePathViaExistingAncestorSync(currentRoot);
-  const loadPaths: string[] = [];
-  for (const configuredPath of context.config?.plugins?.load?.paths ?? []) {
-    const source = path.resolve(resolveUserPath(configuredPath, env));
-    const canonicalSource = resolvePathViaExistingAncestorSync(source);
-    if (
-      !isPathInside(currentRoot, source) &&
-      !isPathInside(currentCanonicalRoot, canonicalSource)
-    ) {
-      continue;
-    }
-    const current = resolveRootPathSync({
-      absolutePath: source,
-      rootPath: currentRoot,
-      rootCanonicalPath: currentCanonicalRoot,
-      boundaryLabel: "installed plugin artifact directory",
-    });
-    const lexicalRoot = isPathInside(currentRoot, source) ? currentRoot : currentCanonicalRoot;
-    const relativePath = isPathInside(lexicalRoot, source)
-      ? path.relative(lexicalRoot, source)
-      : path.relative(
-          currentCanonicalRoot,
-          current.kind === "directory"
-            ? current.canonicalPath
-            : path.join(
-                resolvePathViaExistingAncestorSync(path.dirname(source)),
-                path.basename(source),
-              ),
-        );
-    const staged = resolveRootPathSync({
-      absolutePath: path.join(artifactRoot, relativePath),
-      rootPath: artifactRoot,
-      rootCanonicalPath: artifactRoot,
-      boundaryLabel: "staged plugin artifact directory",
-    });
-    // A file symlink uses its lexical parent's manifest, not the target file's parent.
-    loadPaths.push(staged.absolutePath);
-  }
-  // Explicit paths keep runtime precedence; ordinary package entries all use their root manifest.
-  loadPaths.push(artifactRoot);
-  const packageDiscovery = discoverConfiguredPluginLoadPaths({
-    loadPaths: [artifactRoot],
-    env,
-    deduplicate: true,
-  });
-  const packageSources = new Set(
-    packageDiscovery.candidates.map(
-      (candidate) => safeRealpathSync(candidate.source) ?? candidate.source,
-    ),
-  );
-  const discovery =
-    loadPaths.length === 1
-      ? packageDiscovery
-      : discoverConfiguredPluginLoadPaths({ loadPaths, env, deduplicate: true });
-  const registry = loadPluginManifestRegistryCore({
-    config: { plugins: { load: { paths: loadPaths } } },
-    env,
-    installRecords: {},
-    discovery: {
-      // Only physical package entries inherit managed ownership, including configured overrides.
-      candidates: discovery.candidates.filter((candidate) =>
-        packageSources.has(safeRealpathSync(candidate.source) ?? candidate.source),
-      ),
-      diagnostics: packageDiscovery.diagnostics,
-    },
-  });
-  const error = registry.diagnostics.find((diagnostic) => diagnostic.level === "error");
-  if (error || registry.plugins.length === 0) {
-    throw new Error(
-      error?.message ?? `Plugin artifact has no valid plugin manifest: ${artifactRoot}`,
-    );
-  }
-  return registry.plugins;
-}
-
-function inspectPluginArtifact(
-  rootDir: string,
-  env: NodeJS.ProcessEnv = process.env,
-  context: PluginArtifactInspectionContext = {},
-) {
-  // Consent inspects the current artifact, including after an approval callback yields.
-  // Runtime or earlier review facts must never authorize replacement bytes.
-  return withPluginCache(createPluginCache(), () => {
-    const manifests = resolvePluginArtifactManifests(rootDir, env, context);
-    return {
-      manifest: manifests[0],
-      declared: mergePluginDeclaredSurfaces(
-        manifests.map(
-          (manifest) => buildPluginCapabilitySummary({ manifest, origin: "global" }).declared,
-        ),
-      ),
-    };
-  });
-}
-
-/** Read only validated manifest surfaces belonging to the actual artifact on disk. */
-export function resolvePluginArtifactDeclaredSurface(
-  rootDir: string,
-  env: NodeJS.ProcessEnv = process.env,
-  context: PluginArtifactInspectionContext = {},
-): PluginAcceptedDeclaredSurface {
-  return inspectPluginArtifact(rootDir, env, context).declared;
-}
-
-export function diffDeclaredSurfaceWidening(
-  previous: PluginAcceptedDeclaredSurface,
-  next: PluginAcceptedDeclaredSurface,
-): { widened: Partial<PluginAcceptedDeclaredSurface>; hasWidening: boolean } {
-  const widened: Partial<PluginAcceptedDeclaredSurface> = {};
-  for (const group of PLUGIN_DECLARED_SURFACE_GROUPS) {
-    const previousValues = new Set(previous[group]);
-    const added = next[group].filter((value) => !previousValues.has(value)).toSorted();
-    if (added.length > 0) {
-      widened[group] = added;
-    }
-  }
-  return { widened, hasWidening: Object.keys(widened).length > 0 };
-}
-
 export type PluginCapabilityConsentAcknowledgment = { reviewToken: string };
-
-export type PluginCapabilityConsentReview = Omit<PluginsInspectResult, "ok" | "plugin"> & {
-  pluginId: string;
-  name: string;
-  version?: string;
-  widened?: Partial<PluginAcceptedDeclaredSurface>;
-  acceptedAt?: string;
-};
 
 export type PluginCapabilityConsentHandler = (
   review: PluginCapabilityConsentReview,
@@ -260,24 +87,6 @@ export function resolvePendingPluginCapabilityReview(
   return pendingPluginCapabilityReviews.get(pluginId);
 }
 
-export function resolvePluginInstallRecordTrust(
-  record: InstalledPluginInstallRecordInfo | undefined,
-): PluginInstallTrust | undefined {
-  if (!record?.clawhubTrustDisposition) {
-    return undefined;
-  }
-  return {
-    disposition: record.clawhubTrustDisposition,
-    ...(record.clawhubTrustReasons ? { reasons: [...record.clawhubTrustReasons] } : {}),
-    ...(record.clawhubTrustCheckedAt ? { checkedAt: record.clawhubTrustCheckedAt } : {}),
-    ...(record.clawhubTrustAcknowledgedAt
-      ? { acknowledgedAt: record.clawhubTrustAcknowledgedAt }
-      : {}),
-    ...(record.clawhubTrustPending !== undefined ? { pending: record.clawhubTrustPending } : {}),
-    ...(record.clawhubTrustStale !== undefined ? { stale: record.clawhubTrustStale } : {}),
-  };
-}
-
 function acceptManagedPluginDeclaredSurface<T extends PluginInstallRecord>(
   record: T,
   declared: PluginAcceptedDeclaredSurface,
@@ -294,56 +103,6 @@ function acceptManagedPluginDeclaredSurface<T extends PluginInstallRecord>(
     accepted.acceptedSurfaceIntegrity = integrity;
   }
   return accepted;
-}
-
-export function buildPluginCapabilityConsentReview(params: {
-  pluginId: string;
-  manifest: Parameters<typeof buildPluginCapabilitySummary>[0]["manifest"] & {
-    name?: string;
-    version?: string;
-  };
-  record: PluginInstallRecord;
-  config: OpenClawConfig;
-  declared?: PluginAcceptedDeclaredSurface;
-  previousDeclared?: PluginAcceptedDeclaredSurface;
-  widened?: Partial<PluginAcceptedDeclaredSurface>;
-}): PluginCapabilityConsentReview {
-  const { pluginId, manifest, record } = params;
-  const summary = buildPluginCapabilitySummary({
-    manifest,
-    origin: "global",
-    entryConfig: params.config.plugins?.entries?.[pluginId],
-  });
-  const declared = params.declared ?? summary.declared;
-  const spec = record.resolvedSpec ?? record.spec;
-  const packageName = record.clawhubPackage ?? record.resolvedName;
-  const previousDeclared = params.previousDeclared ?? record.acceptedSurface;
-  const widened =
-    params.widened ??
-    (previousDeclared
-      ? diffDeclaredSurfaceWidening(previousDeclared, declared).widened
-      : undefined);
-  const trust = resolvePluginInstallRecordTrust(record);
-  return {
-    pluginId,
-    name: manifest.name ?? pluginId,
-    ...((manifest.version ?? record.version)
-      ? { version: manifest.version ?? record.version }
-      : {}),
-    ...summary,
-    declared,
-    reviewToken: computeDeclaredSurfaceHash(declared),
-    source: {
-      kind: record.source,
-      // Keep operational specs in install records; prompts and RPCs receive display-safe copies.
-      ...(spec ? { spec: redactSensitiveUrlLikeString(spec) } : {}),
-      ...(packageName ? { packageName } : {}),
-      ...resolvePluginInstallRecordIntegrity(record),
-    },
-    ...(trust ? { trust } : {}),
-    ...(widened && Object.keys(widened).length > 0 ? { widened } : {}),
-    ...(record.acceptedSurfaceAt ? { acceptedAt: record.acceptedSurfaceAt } : {}),
-  };
 }
 
 function throwManagedPluginCapabilityConsentRequired(review: PluginCapabilityConsentReview): never {
@@ -410,6 +169,10 @@ export async function resolvePluginCapabilityConsent(params: {
     if (!manifest) {
       throw new ManagedPluginLifecycleError(`Plugin "${pluginId}" has no installed manifest.`);
     }
+    if (manifest.trustedOfficialInstall) {
+      pendingPluginCapabilityReviews.delete(pluginId);
+      return;
+    }
     const declared = resolvePluginPackageDeclaredSurface(ownership.value, metadata.byPluginId);
     if (!declared) {
       throw new ManagedPluginLifecycleError(
@@ -468,6 +231,7 @@ async function resolvePluginArtifactCapabilityConsent(params: {
   config: OpenClawConfig;
   pluginId: string;
   record: PluginInstallRecord;
+  sourceRecord?: PluginInstallRecord;
   artifactDir: string;
   currentArtifactDir?: string;
   env?: NodeJS.ProcessEnv;
@@ -477,17 +241,26 @@ async function resolvePluginArtifactCapabilityConsent(params: {
   previousDeclared?: PluginAcceptedDeclaredSurface;
   previousRecord?: PluginInstallRecord;
   mode?: "install" | "update";
-}): Promise<PluginAcceptedDeclaredSurface> {
+  enabled: boolean;
+}): Promise<PluginAcceptedDeclaredSurface | undefined> {
   const artifactContext = { config: params.config, currentArtifactDir: params.currentArtifactDir };
-  const { declared, manifest } = inspectPluginArtifact(
+  const { declared, manifest } = inspectPluginCapabilityArtifact(
     params.artifactDir,
     params.env,
     artifactContext,
   );
+  const isOfficialArtifact = (artifactManifest: typeof manifest) =>
+    params.sourceRecord !== undefined &&
+    isTrustedOfficialPluginInstallRecord({
+      pluginId: params.pluginId,
+      packageName: artifactManifest?.packageName,
+      record: params.sourceRecord,
+    });
+  const official = isOfficialArtifact(manifest);
   const review = buildPluginCapabilityConsentReview({
     pluginId: params.pluginId,
     manifest: manifest ?? { name: params.pluginId },
-    record: params.record,
+    record: params.sourceRecord ?? params.record,
     config: params.config,
     declared,
     ...(params.previousDeclared ? { previousDeclared: params.previousDeclared } : {}),
@@ -503,22 +276,27 @@ async function resolvePluginArtifactCapabilityConsent(params: {
     // Managed installs activate the package, even when its previous version was disabled.
     // Update-only flows preserve disablement in preparePluginUpdateCapabilityConsent instead.
   }
-  const acknowledgment = acceptanceCurrent
-    ? { reviewToken: review.reviewToken }
-    : (params.acknowledgeCapabilities ?? (await params.onCapabilityConsent?.(review)));
+  const acknowledgment =
+    official || !params.enabled || acceptanceCurrent
+      ? { reviewToken: review.reviewToken }
+      : (params.acknowledgeCapabilities ?? (await params.onCapabilityConsent?.(review)));
   // Review and staged-package rollback remain cancellable. Lock only when
   // accepting this artifact, then recheck its bytes after the callback yields.
   if (acknowledgment) {
     await params.beforePersistentEffect?.();
   }
   // Interactive consent yields; re-read the final stage so a replaced artifact cannot inherit it.
-  const { declared: finalDeclared, manifest: finalManifest } = inspectPluginArtifact(
+  const { declared: finalDeclared, manifest: finalManifest } = inspectPluginCapabilityArtifact(
     params.artifactDir,
     params.env,
     artifactContext,
   );
   const finalToken = computeDeclaredSurfaceHash(finalDeclared);
-  if (!acknowledgment || acknowledgment.reviewToken !== finalToken) {
+  if (
+    !acknowledgment ||
+    acknowledgment.reviewToken !== finalToken ||
+    (official && !isOfficialArtifact(finalManifest))
+  ) {
     const finalReview =
       finalToken === review.reviewToken
         ? review
@@ -527,7 +305,7 @@ async function resolvePluginArtifactCapabilityConsent(params: {
             manifest: finalManifest ?? {
               name: params.pluginId,
             },
-            record: params.record,
+            record: params.sourceRecord ?? params.record,
             config: params.config,
             declared: finalDeclared,
             ...(params.previousDeclared ? { previousDeclared: params.previousDeclared } : {}),
@@ -535,7 +313,8 @@ async function resolvePluginArtifactCapabilityConsent(params: {
     return throwManagedPluginCapabilityConsentRequired(finalReview);
   }
   pendingPluginCapabilityReviews.delete(params.pluginId);
-  return finalDeclared;
+  // First-party provenance authorizes the artifact; it is not operator acceptance.
+  return !official && (params.enabled || acceptanceCurrent) ? finalDeclared : undefined;
 }
 
 /** Bind artifact consent to verified staged bytes and carry acceptance into the record commit. */
@@ -550,6 +329,8 @@ export function createManagedPluginArtifactConsentHandler(params: {
   beforePersistentEffect?: () => void | Promise<void>;
   previousRecords?: Record<string, PluginInstallRecord>;
   previousPluginOwners?: ReadonlyMap<string, string>;
+  /** Update-only flows preserve disablement; ordinary installs activate the package. */
+  updatingPluginIds?: readonly string[];
 }): {
   onBeforePluginArtifactCommit: PluginInstallArtifactConsentHandler;
   applyAcceptedSurface: <T extends PluginInstallRecord>(pluginId: string, record: T) => T;
@@ -570,11 +351,13 @@ export function createManagedPluginArtifactConsentHandler(params: {
       }
     }
   }
-  const pendingAcceptedSurfaces = new Map<string, PluginAcceptedDeclaredSurface>();
+  const pendingAcceptedSurfaces = new Map<string, PluginAcceptedDeclaredSurface | undefined>();
   return {
     onBeforePluginArtifactCommit: async (
       artifact: PluginInstallArtifactConsentRequest,
     ): Promise<void> => {
+      // A fallback stage cannot inherit an earlier artifact's acceptance or exemption.
+      pendingAcceptedSurfaces.clear();
       const matchingOwners = Object.entries(params.previousRecords ?? {}).filter(
         ([installOwner, record]) =>
           installOwner === artifact.pluginId ||
@@ -605,23 +388,35 @@ export function createManagedPluginArtifactConsentHandler(params: {
           ...(params.spec ? { spec: params.spec } : {}),
           ...(params.expectedIntegrity ? { integrity: params.expectedIntegrity } : {}),
         },
+        sourceRecord: artifact.sourceRecord,
         acknowledgeCapabilities: params.acknowledgeCapabilities,
         onCapabilityConsent: params.onCapabilityConsent,
         beforePersistentEffect: params.beforePersistentEffect,
         ...(previousRecord ? { previousRecord } : {}),
         ...(previousDeclared ? { previousDeclared } : {}),
         mode: artifact.mode,
+        enabled:
+          !params.updatingPluginIds?.length ||
+          params.updatingPluginIds.some(
+            (id) =>
+              resolveEffectiveEnableState({
+                id,
+                origin: "global",
+                config: normalizePluginsConfig(params.config.plugins),
+                rootConfig: params.config,
+              }).enabled,
+          ),
       });
       pendingAcceptedSurfaces.set(artifact.pluginId, declared);
     },
     applyAcceptedSurface: (pluginId, record) => {
       const declared = pendingAcceptedSurfaces.get(pluginId);
-      if (!declared) {
+      if (!pendingAcceptedSurfaces.has(pluginId)) {
         throw new ManagedPluginLifecycleError(
           `Plugin "${pluginId}" did not expose its verified artifact for capability review.`,
         );
       }
-      return acceptManagedPluginDeclaredSurface(record, declared);
+      return declared ? acceptManagedPluginDeclaredSurface(record, declared) : record;
     },
   };
 }

--- a/src/plugins/capability-summary.ts
+++ b/src/plugins/capability-summary.ts
@@ -1,12 +1,16 @@
 // Inventory needs capability facts without artifact inspection or lifecycle writes.
 import { createHash } from "node:crypto";
+import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { PLUGIN_DECLARED_SURFACE_GROUPS } from "../../packages/gateway-protocol/src/schema/plugin-declared-surface-groups.js";
 import type {
   PluginDeclaredSurface,
   PluginHookGrant,
   PluginInspectSource,
   PluginOperatorGrants,
+  PluginInstallTrust,
+  PluginsInspectResult,
 } from "../../packages/gateway-protocol/src/schema/plugins.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type {
   PluginAcceptedDeclaredSurface,
   PluginEntryConfig,
@@ -16,6 +20,7 @@ import {
   resolveConversationAccessAllowed,
   resolvePromptInjectionAllowed,
 } from "./hook-policy-decisions.js";
+import type { InstalledPluginInstallRecordInfo } from "./installed-plugin-index-types.js";
 import type { InstalledPluginPackageOwnership } from "./installed-plugin-package-ownership.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginManifestContracts } from "./manifest-types.js";
@@ -68,6 +73,21 @@ type PluginCapabilityManifest = {
   skills?: readonly string[];
   configContracts?: PluginManifestRecord["configContracts"];
 };
+
+export function diffDeclaredSurfaceWidening(
+  previous: PluginAcceptedDeclaredSurface,
+  next: PluginAcceptedDeclaredSurface,
+): { widened: Partial<PluginAcceptedDeclaredSurface>; hasWidening: boolean } {
+  const widened: Partial<PluginAcceptedDeclaredSurface> = {};
+  for (const group of PLUGIN_DECLARED_SURFACE_GROUPS) {
+    const previousValues = new Set(previous[group]);
+    const added = next[group].filter((value) => !previousValues.has(value)).toSorted();
+    if (added.length > 0) {
+      widened[group] = added;
+    }
+  }
+  return { widened, hasWidening: Object.keys(widened).length > 0 };
+}
 
 export function mergePluginDeclaredSurfaces(
   surfaces: Iterable<PluginDeclaredSurface>,
@@ -243,5 +263,81 @@ export function buildPluginCapabilitySummary(params: {
           }
         : {}),
     },
+  };
+}
+
+export type PluginCapabilityConsentReview = Omit<PluginsInspectResult, "ok" | "plugin"> & {
+  pluginId: string;
+  name: string;
+  version?: string;
+  widened?: Partial<PluginAcceptedDeclaredSurface>;
+  acceptedAt?: string;
+};
+
+export function resolvePluginInstallRecordTrust(
+  record: InstalledPluginInstallRecordInfo | undefined,
+): PluginInstallTrust | undefined {
+  if (!record?.clawhubTrustDisposition) {
+    return undefined;
+  }
+  return {
+    disposition: record.clawhubTrustDisposition,
+    ...(record.clawhubTrustReasons ? { reasons: [...record.clawhubTrustReasons] } : {}),
+    ...(record.clawhubTrustCheckedAt ? { checkedAt: record.clawhubTrustCheckedAt } : {}),
+    ...(record.clawhubTrustAcknowledgedAt
+      ? { acknowledgedAt: record.clawhubTrustAcknowledgedAt }
+      : {}),
+    ...(record.clawhubTrustPending !== undefined ? { pending: record.clawhubTrustPending } : {}),
+    ...(record.clawhubTrustStale !== undefined ? { stale: record.clawhubTrustStale } : {}),
+  };
+}
+
+export function buildPluginCapabilityConsentReview(params: {
+  pluginId: string;
+  manifest: Parameters<typeof buildPluginCapabilitySummary>[0]["manifest"] & {
+    name?: string;
+    version?: string;
+  };
+  record: PluginInstallRecord;
+  config: OpenClawConfig;
+  declared?: PluginAcceptedDeclaredSurface;
+  previousDeclared?: PluginAcceptedDeclaredSurface;
+  widened?: Partial<PluginAcceptedDeclaredSurface>;
+}): PluginCapabilityConsentReview {
+  const { pluginId, manifest, record } = params;
+  const summary = buildPluginCapabilitySummary({
+    manifest,
+    origin: "global",
+    entryConfig: params.config.plugins?.entries?.[pluginId],
+  });
+  const declared = params.declared ?? summary.declared;
+  const spec = record.resolvedSpec ?? record.spec;
+  const packageName = record.clawhubPackage ?? record.resolvedName;
+  const previousDeclared = params.previousDeclared ?? record.acceptedSurface;
+  const widened =
+    params.widened ??
+    (previousDeclared
+      ? diffDeclaredSurfaceWidening(previousDeclared, declared).widened
+      : undefined);
+  const trust = resolvePluginInstallRecordTrust(record);
+  return {
+    pluginId,
+    name: manifest.name ?? pluginId,
+    ...((manifest.version ?? record.version)
+      ? { version: manifest.version ?? record.version }
+      : {}),
+    ...summary,
+    declared,
+    reviewToken: computeDeclaredSurfaceHash(declared),
+    source: {
+      kind: record.source,
+      // Keep operational specs in install records; prompts and RPCs receive display-safe copies.
+      ...(spec ? { spec: redactSensitiveUrlLikeString(spec) } : {}),
+      ...(packageName ? { packageName } : {}),
+      ...resolvePluginInstallRecordIntegrity(record),
+    },
+    ...(trust ? { trust } : {}),
+    ...(widened && Object.keys(widened).length > 0 ? { widened } : {}),
+    ...(record.acceptedSurfaceAt ? { acceptedAt: record.acceptedSurfaceAt } : {}),
   };
 }

--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -7,6 +7,7 @@ import { Readable } from "node:stream";
 import JSZip from "jszip";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createZipCentralDirectoryArchive } from "../test-utils/zip-central-directory-fixture.js";
+import type { PluginInstallArtifactConsentHandler } from "./install-types.js";
 
 const parseClawHubPluginSpecMock = vi.fn();
 const fetchClawHubPackageDetailMock = vi.fn();
@@ -538,6 +539,49 @@ describe("installPluginFromClawHub", () => {
     expect(installPluginFromArchiveMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { baseUrl: "https://clawhub.ai", channel: "official" },
+    { baseUrl: "https://clawhub.ai", channel: "community" },
+    { baseUrl: "https://plugins.example.test", channel: "official" },
+  ])(
+    "passes verified source facts to consent for $baseUrl/$channel",
+    async ({ baseUrl, channel }) => {
+      if (channel === "community") {
+        mockCommunityClawHubPackageDetail();
+      }
+      const onBeforePluginArtifactCommit = vi.fn();
+      installPluginFromArchiveMock.mockImplementationOnce(
+        async (params: { onBeforePluginArtifactCommit: PluginInstallArtifactConsentHandler }) => {
+          await params.onBeforePluginArtifactCommit({
+            pluginId: "demo",
+            stagedArtifactDir: "/tmp/openclaw/plugins/demo",
+            mode: "install",
+          });
+          return { ok: true, pluginId: "demo", targetDir: "/tmp/openclaw/plugins/demo" };
+        },
+      );
+      const result = await installPluginFromClawHub({
+        spec: "clawhub:demo",
+        baseUrl,
+        onBeforePluginArtifactCommit,
+      });
+      expect(result.ok).toBe(true);
+      expect(onBeforePluginArtifactCommit).toHaveBeenCalledWith({
+        pluginId: "demo",
+        stagedArtifactDir: "/tmp/openclaw/plugins/demo",
+        mode: "install",
+        sourceRecord: {
+          source: "clawhub",
+          spec: "clawhub:demo",
+          clawhubUrl: baseUrl,
+          clawhubPackage: "demo",
+          clawhubChannel: channel,
+          integrity: DEMO_ARCHIVE_INTEGRITY,
+        },
+      });
+    },
+  );
+
   it("accepts a matching catalog archive integrity pin", async () => {
     const result = await installPluginFromClawHub({
       spec: "clawhub:demo",
@@ -550,10 +594,12 @@ describe("installPluginFromClawHub", () => {
 
   it("rejects a catalog archive integrity mismatch before extraction", async () => {
     const expectedIntegrity = `sha256-${Buffer.from("1".repeat(64), "hex").toString("base64")}`;
+    const onBeforePluginArtifactCommit = vi.fn();
 
     const result = await installPluginFromClawHub({
       spec: "clawhub:demo",
       expectedIntegrity,
+      onBeforePluginArtifactCommit,
     });
 
     expectInstallFailureFields(
@@ -562,6 +608,7 @@ describe("installPluginFromClawHub", () => {
       `ClawHub archive integrity mismatch for "demo@2026.3.22": expected ${expectedIntegrity}, got ${DEMO_ARCHIVE_INTEGRITY}.`,
     );
     expect(installPluginFromArchiveMock).not.toHaveBeenCalled();
+    expect(onBeforePluginArtifactCommit).not.toHaveBeenCalled();
     expect(archiveCleanupMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -1468,7 +1468,20 @@ export async function installPluginFromClawHub(
         timeoutMs: params.timeoutMs,
         dryRun: params.dryRun,
         expectedPluginId: runtimeIdResolution.expectedPluginId,
-        onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
+        onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit
+          ? (artifact) =>
+              params.onBeforePluginArtifactCommit!({
+                ...artifact,
+                sourceRecord: {
+                  source: "clawhub",
+                  spec: params.spec,
+                  clawhubUrl: clawhubRegistry,
+                  clawhubPackage: canonicalPackageName,
+                  clawhubChannel: detail.package!.channel,
+                  integrity: archive.integrity,
+                },
+              })
+          : undefined,
         installPolicyRequest: {
           kind: "plugin-archive",
           requestedSpecifier: params.spec,

--- a/src/plugins/install-managed-npm.ts
+++ b/src/plugins/install-managed-npm.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
+  buildNpmResolutionFields,
   formatNpmCommandFailureOutput,
   type NpmIntegrityDrift,
   type NpmSpecResolution,
@@ -577,6 +578,15 @@ export async function installPluginFromManagedNpmRoot(
       ...(policyMode === "update" ? { currentArtifactDir: installRoot } : {}),
       stagedArtifactDir: installRoot,
       mode: policyMode,
+      ...(params.installPolicyRequest.source?.kind === "npm"
+        ? {
+            sourceRecord: {
+              source: "npm" as const,
+              spec: params.displaySpec,
+              ...buildNpmResolutionFields(params.npmResolution),
+            },
+          }
+        : {}),
     });
     return {
       ...result,

--- a/src/plugins/install-record-commit.sqlite.test.ts
+++ b/src/plugins/install-record-commit.sqlite.test.ts
@@ -8,10 +8,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
-import {
-  resolvePluginArtifactDeclaredSurface,
-  resolvePluginCapabilityConsent,
-} from "./capability-consent.js";
+import { resolvePluginArtifactDeclaredSurface } from "./capability-artifact.js";
+import { resolvePluginCapabilityConsent } from "./capability-consent.js";
 import { computeDeclaredSurfaceHash } from "./capability-summary.js";
 import { enablePluginWithCapabilityConsent } from "./enable.js";
 import { commitConfigWriteWithPendingPluginInstalls } from "./install-record-commit.js";

--- a/src/plugins/install-types.ts
+++ b/src/plugins/install-types.ts
@@ -1,3 +1,4 @@
+import type { PluginInstallRecord } from "../config/types.plugins.js";
 import type { NpmIntegrityDrift, NpmSpecResolution } from "../infra/install-source-utils.js";
 import type { InstallPolicySource } from "../security/install-policy.js";
 import type { PluginInstallArtifactInspection } from "./install-artifact-inspection.js";
@@ -79,6 +80,8 @@ export type PluginInstallArtifactConsentRequest = {
   currentArtifactDir?: string;
   stagedArtifactDir: string;
   mode: "install" | "update";
+  /** Source facts supplied by the installer after validating the staged artifact. */
+  sourceRecord?: PluginInstallRecord;
 };
 
 export type PluginInstallArtifactConsentHandler = (

--- a/src/plugins/management-service.capability-consent.test.ts
+++ b/src/plugins/management-service.capability-consent.test.ts
@@ -2,9 +2,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { resolvePluginArtifactDeclaredSurface } from "./capability-artifact.js";
 import {
   createManagedPluginArtifactConsentHandler,
-  resolvePluginArtifactDeclaredSurface,
   resolvePluginCapabilityConsent,
   type PluginCapabilityConsentHandler,
 } from "./capability-consent.js";
@@ -17,6 +17,7 @@ import {
   metadataSnapshot,
 } from "./management-service.test-helpers.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import { collectPluginCapabilityConsentDiagnostics } from "./status-snapshot.js";
 import { createColdPluginFixture } from "./test-helpers/cold-plugin-fixtures.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
@@ -85,8 +86,12 @@ vi.mock("./official-external-plugin-catalog.js", async (importOriginal) => ({
     mocks.officialCatalog(...args),
 }));
 
-const { clearManagedPluginOfficialCatalogCache, inspectManagedPlugin, setManagedPluginEnabled } =
-  await import("./management-service.js");
+const {
+  clearManagedPluginOfficialCatalogCache,
+  inspectManagedPlugin,
+  listManagedPlugins,
+  setManagedPluginEnabled,
+} = await import("./management-service.js");
 
 const trackedArtifactDirs: string[] = [];
 
@@ -168,6 +173,165 @@ describe("managed plugin capability consent", () => {
       resolvePluginCapabilityConsent({ config: {}, env: {}, pluginId: "workboard" }),
     ).resolves.toBeUndefined();
     expect(mocks.writeRecords).not.toHaveBeenCalled();
+  });
+
+  function officialArtifact() {
+    const rootDir = makeTrackedTempDir("official-capability-consent", trackedArtifactDirs);
+    createColdPluginFixture({
+      rootDir,
+      pluginId: "diffs",
+      packageName: "@openclaw/diffs",
+      manifest: { providers: [], channels: [], channelConfigs: {}, providerAuthChoices: [] },
+    });
+    return rootDir;
+  }
+
+  const officialSources: PluginInstallRecord[] = [
+    {
+      source: "npm",
+      spec: "@openclaw/diffs@1.0.0",
+      resolvedName: "@openclaw/diffs",
+      resolvedSpec: "@openclaw/diffs@1.0.0",
+      integrity: "sha512-official-artifact",
+    },
+    {
+      source: "clawhub",
+      spec: "clawhub:@openclaw/diffs@1.0.0",
+      clawhubPackage: "@openclaw/diffs",
+      clawhubUrl: "https://clawhub.ai",
+      clawhubChannel: "official",
+      integrity: "sha256-official-artifact",
+    },
+  ];
+
+  it.each(officialSources)(
+    "installs verified official $source artifacts without recording operator acceptance",
+    async (sourceRecord) => {
+      const rootDir = officialArtifact();
+      const onCapabilityConsent = vi.fn<PluginCapabilityConsentHandler>();
+      const handler = createManagedPluginArtifactConsentHandler({
+        config: {},
+        source: sourceRecord.source,
+        spec: sourceRecord.spec,
+        onCapabilityConsent,
+      });
+      await expect(
+        handler.onBeforePluginArtifactCommit({
+          pluginId: "diffs",
+          stagedArtifactDir: rootDir,
+          mode: "install",
+          sourceRecord,
+        }),
+      ).resolves.toBeUndefined();
+      expect(onCapabilityConsent).not.toHaveBeenCalled();
+      expect(handler.applyAcceptedSurface("diffs", sourceRecord)).toEqual(sourceRecord);
+    },
+  );
+
+  it.each([
+    { name: "unverified catalog name", sourceRecord: undefined },
+    {
+      name: "local npm archive",
+      sourceRecord: { ...officialSources[0]!, artifactKind: "npm-pack" as const },
+    },
+    {
+      name: "conflicting registry identity",
+      sourceRecord: { ...officialSources[0]!, resolvedName: "@vendor/diffs" },
+    },
+    {
+      name: "custom ClawHub server",
+      sourceRecord: { ...officialSources[1]!, clawhubUrl: "https://plugins.example" },
+    },
+    {
+      name: "community ClawHub release",
+      sourceRecord: { ...officialSources[1]!, clawhubChannel: "community" as const },
+    },
+  ])("requires review for $name", async ({ sourceRecord }) => {
+    const handler = createManagedPluginArtifactConsentHandler({
+      config: {},
+      source: sourceRecord?.source ?? "npm",
+      spec: sourceRecord?.spec ?? "@openclaw/diffs",
+    });
+    await expect(
+      handler.onBeforePluginArtifactCommit({
+        pluginId: "diffs",
+        stagedArtifactDir: officialArtifact(),
+        mode: "install",
+        sourceRecord,
+      }),
+    ).rejects.toMatchObject({ capabilityConsent: { pluginId: "diffs" } });
+  });
+
+  it("rechecks first-party package identity after the commit guard yields", async () => {
+    const rootDir = officialArtifact();
+    const handler = createManagedPluginArtifactConsentHandler({
+      config: {},
+      source: "npm",
+      beforePersistentEffect: async () => {
+        const packagePath = path.join(rootDir, "package.json");
+        const manifest = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+        fs.writeFileSync(packagePath, JSON.stringify({ ...manifest, name: "@vendor/diffs" }));
+      },
+    });
+    await expect(
+      handler.onBeforePluginArtifactCommit({
+        pluginId: "diffs",
+        stagedArtifactDir: rootDir,
+        mode: "install",
+        sourceRecord: officialSources[0],
+      }),
+    ).rejects.toMatchObject({ capabilityConsent: { pluginId: "diffs" } });
+  });
+
+  it("does not carry a first-party exemption into an unverified fallback stage", async () => {
+    const rootDir = officialArtifact();
+    const handler = createManagedPluginArtifactConsentHandler({ config: {}, source: "npm" });
+    const artifact = { pluginId: "diffs", stagedArtifactDir: rootDir, mode: "install" as const };
+    await handler.onBeforePluginArtifactCommit({ ...artifact, sourceRecord: officialSources[0] });
+    await expect(handler.onBeforePluginArtifactCommit(artifact)).rejects.toMatchObject({
+      capabilityConsent: { pluginId: "diffs" },
+    });
+    expect(() => handler.applyAcceptedSurface("diffs", officialSources[0]!)).toThrow(
+      "did not expose its verified artifact",
+    );
+  });
+
+  it("enables and reports a verified official install without legacy acceptance", async () => {
+    const rootDir = officialArtifact();
+    const record = { ...officialSources[0]!, installPath: rootDir };
+    const config = {
+      plugins: { load: { paths: [rootDir] }, entries: { diffs: { enabled: true } } },
+    };
+    const env = {
+      HOME: rootDir,
+      OPENCLAW_STATE_DIR: path.join(rootDir, "state"),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_DISABLE_BUNDLED_SOURCE_OVERLAYS: "1",
+    };
+    const { index, manifestRegistry } = loadInstalledPluginIndexWithDiscovery({
+      config,
+      env,
+      installRecords: { diffs: record },
+    });
+    const byPluginId = new Map(manifestRegistry.plugins.map((manifest) => [manifest.id, manifest]));
+    const metadata = {
+      index,
+      byPluginId,
+      plugins: manifestRegistry.plugins,
+      diagnostics: manifestRegistry.diagnostics,
+      normalizePluginId: (pluginId: string) => pluginId,
+    };
+    mocks.records = { diffs: record };
+    mocks.metadata.mockReturnValue(metadata);
+    await expect(
+      resolvePluginCapabilityConsent({ config, env, pluginId: "diffs" }),
+    ).resolves.toBeUndefined();
+    expect(mocks.writeRecords).not.toHaveBeenCalled();
+    expect(collectPluginCapabilityConsentDiagnostics({ index, manifests: byPluginId })).toEqual([]);
+    const catalog = await listManagedPlugins({ config, env });
+    expect(catalog.diagnostics).not.toContainEqual(
+      expect.objectContaining({ message: expect.stringContaining("requires capability consent") }),
+    );
   });
 
   it("rejects enabling an unaccepted plugin with only its reviewed-surface challenge", async () => {

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -32,7 +32,6 @@ import {
   prepareManagedPluginArtifactConsentHandler,
   resolvePendingPluginCapabilityReview,
   resolvePluginCapabilityConsent,
-  resolvePluginInstallRecordTrust,
   type PluginCapabilityConsentAcknowledgment,
   type PluginCapabilityConsentHandler,
 } from "./capability-consent.js";
@@ -42,6 +41,7 @@ import {
   formatPluginCapabilityConsentRequired,
   resolveAcceptedSurfaceCurrent,
   resolvePluginInstallRecordIntegrity,
+  resolvePluginInstallRecordTrust,
   resolvePluginPackageDeclaredSurface,
 } from "./capability-summary.js";
 import { CLAWHUB_INSTALL_ERROR_CODE, isUnavailableClawHubTarget } from "./clawhub-error-codes.js";
@@ -926,7 +926,13 @@ export const listManagedPlugins = withManagedPluginCache(
       const ownership = resolveInstalledPluginPackageOwnership(metadata.index, record.pluginId);
       const installOwner = ownership.ok ? ownership.value.installOwner : undefined;
       const installRecord = installOwner ? metadata.index.installRecords[installOwner] : undefined;
-      if (enabled && record.origin !== "bundled" && ownership.ok && installRecord) {
+      if (
+        enabled &&
+        record.origin !== "bundled" &&
+        !manifest?.trustedOfficialInstall &&
+        ownership.ok &&
+        installRecord
+      ) {
         const declared = resolvePluginPackageDeclaredSurface(ownership.value, metadata.byPluginId);
         if (!declared || !resolveAcceptedSurfaceCurrent(installRecord, declared)) {
           capabilityConsentDiagnostics.push({

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -977,6 +977,18 @@ describe("loadPluginManifestRegistry", () => {
 
   it.each([
     {
+      name: "conflicting npm requested identity",
+      overrides: { spec: "@vendor/diffs" },
+    },
+    {
+      name: "conflicting npm resolved identity",
+      overrides: { resolvedName: "@vendor/diffs" },
+    },
+    {
+      name: "missing npm identity",
+      overrides: { spec: undefined, resolvedName: undefined, resolvedSpec: undefined },
+    },
+    {
       name: "npm-pack archive metadata",
       overrides: {
         sourcePath: "/tmp/diffs.tgz",
@@ -1165,7 +1177,7 @@ describe("loadPluginManifestRegistry", () => {
     expect(registry.plugins[0]?.trustedOfficialInstall).toBeUndefined();
   });
 
-  it("preserves legacy spec-only records for catalog-backed ClawHub installs", () => {
+  it("does not trust legacy ClawHub records without source authority", () => {
     const dir = makeTempDir();
     writeManifest(dir, { id: "diagnostics-otel", configSchema: { type: "object" } });
 
@@ -1188,7 +1200,7 @@ describe("loadPluginManifestRegistry", () => {
       ],
     });
 
-    expect(registry.plugins[0]?.trustedOfficialInstall).toBe(true);
+    expect(registry.plugins[0]?.trustedOfficialInstall).toBeUndefined();
   });
 
   it("marks official diagnostics-otel config paths trusted when the install record matches", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -45,12 +45,10 @@ import {
   normalizeManifestChannelCommandDefaults,
 } from "./manifest.js";
 import { checkMinHostVersion } from "./min-host-version.js";
-import { resolveTrustedSourceLinkedOfficialClawHubInstall } from "./official-external-install-records.js";
+import { isTrustedOfficialPluginInstallRecord } from "./official-external-install-records.js";
 import {
   getOfficialExternalPluginCatalogEntryForPackage,
   getOfficialExternalPluginCatalogManifest,
-  resolveOfficialExternalPluginId,
-  resolveOfficialExternalPluginInstall,
 } from "./official-external-plugin-catalog.js";
 import { satisfiesPluginApiRange, resolvePackagePluginApiRange } from "./package-compat.js";
 import { isPathInside } from "./path-safety.js";
@@ -713,17 +711,6 @@ function matchesInstalledPluginRecord(params: {
   );
 }
 
-function npmSpecMatchesPackage(value: string | undefined, packageName: string): boolean {
-  const normalized = value?.trim();
-  if (!normalized) {
-    return false;
-  }
-  if (normalized === packageName) {
-    return true;
-  }
-  return normalized.startsWith(`${packageName}@`);
-}
-
 function isTrustedOfficialPluginInstall(params: {
   pluginId: string;
   candidate: PluginCandidate;
@@ -748,42 +735,15 @@ function isTrustedOfficialPluginInstall(params: {
   if (!packageName) {
     return false;
   }
-  const catalogEntry = getOfficialExternalPluginCatalogEntryForPackage(packageName);
-  if (!catalogEntry || resolveOfficialExternalPluginId(catalogEntry) !== installOwner) {
-    return false;
-  }
-  const officialInstall = resolveOfficialExternalPluginInstall(catalogEntry);
   const installRecord = params.installRecords[installOwner];
-  if (!installRecord) {
-    return false;
-  }
-  const officialClawHubInstall =
-    installRecord.source === "clawhub"
-      ? resolveTrustedSourceLinkedOfficialClawHubInstall({
-          pluginId: installOwner,
-          record: installRecord,
-        })
-      : undefined;
-  // Local npm-pack archives also persist source="npm". Only registry installs
-  // may inherit catalog trust; local artifacts and source links stay untrusted.
-  if (
-    installRecord.source === "npm" &&
-    installRecord.artifactKind === undefined &&
-    installRecord.sourcePath === undefined &&
-    officialInstall?.npmSpec === packageName &&
-    [
-      installRecord.resolvedName,
-      installRecord.spec,
-      installRecord.resolvedSpec,
-      params.candidate.packageName,
-    ].some((value) => npmSpecMatchesPackage(value, packageName))
-  ) {
-    return true;
-  }
-  if (installRecord.source === "clawhub" && officialClawHubInstall) {
-    return true;
-  }
-  return false;
+  return Boolean(
+    installRecord &&
+    isTrustedOfficialPluginInstallRecord({
+      pluginId: installOwner,
+      packageName,
+      record: installRecord,
+    }),
+  );
 }
 
 function resolveDuplicatePrecedenceRank(params: {

--- a/src/plugins/official-external-install-records.test.ts
+++ b/src/plugins/official-external-install-records.test.ts
@@ -1,9 +1,109 @@
 import { describe, expect, it } from "vitest";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
 import {
+  isTrustedOfficialPluginInstallRecord,
   resolveTrustedSourceLinkedOfficialClawHubInstall,
   resolveTrustedSourceLinkedOfficialNpmInstall,
   resolveTrustedSourceLinkedOfficialNpmSpec,
 } from "./official-external-install-records.js";
+
+describe("official plugin install trust", () => {
+  const packageName = "@openclaw/fish-audio-speech";
+  const npmRecord: PluginInstallRecord = {
+    source: "npm",
+    spec: `${packageName}@2026.7.2`,
+    resolvedName: packageName,
+    resolvedSpec: `${packageName}@2026.7.2`,
+  };
+
+  it.each(["fish-audio-speech", "fish-audio"])(
+    "binds canonical and declared legacy id %s to the actual official package",
+    (pluginId) => {
+      expect(
+        isTrustedOfficialPluginInstallRecord({ pluginId, packageName, record: npmRecord }),
+      ).toBe(true);
+    },
+  );
+
+  it.each([
+    { pluginId: "fish-audio-speech", packageName: undefined },
+    { pluginId: "unrelated-plugin", packageName },
+    { pluginId: "fish-audio-speech", packageName: "@vendor/fish-audio-speech" },
+    { pluginId: "unlisted", packageName: "@openclaw/unlisted" },
+  ])("rejects an unbound catalog identity $pluginId / $packageName", (identity) => {
+    expect(isTrustedOfficialPluginInstallRecord({ ...identity, record: npmRecord })).toBe(false);
+  });
+
+  it.each([
+    { spec: "@vendor/fish-audio-speech" },
+    { resolvedName: "@vendor/fish-audio-speech" },
+    { resolvedSpec: "@vendor/fish-audio-speech@1.0.0" },
+    { clawhubPackage: "@vendor/fish-audio-speech" },
+    { spec: "file:/tmp/official.tgz" },
+    { resolvedName: `${packageName}@2026.7.2` },
+    { spec: undefined, resolvedName: undefined, resolvedSpec: undefined },
+    { artifactKind: "npm-pack" },
+    { sourcePath: "/tmp/official" },
+    { source: "path" },
+  ] satisfies Partial<PluginInstallRecord>[])(
+    "rejects unsupported npm provenance %j",
+    (override) => {
+      expect(
+        isTrustedOfficialPluginInstallRecord({
+          pluginId: "fish-audio-speech",
+          packageName,
+          record: { ...npmRecord, ...override },
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it.each([
+    { spec: undefined, resolvedSpec: undefined },
+    { spec: undefined, resolvedName: undefined },
+  ])("accepts consistent legacy npm resolution evidence %j", (override) => {
+    expect(
+      isTrustedOfficialPluginInstallRecord({
+        pluginId: "fish-audio-speech",
+        packageName,
+        record: { ...npmRecord, ...override },
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    { name: "default official host", overrides: {}, trusted: true },
+    { name: "missing authority", overrides: { clawhubUrl: undefined }, trusted: false },
+    { name: "custom host", overrides: { clawhubUrl: "https://example.invalid" }, trusted: false },
+    { name: "community channel", overrides: { clawhubChannel: "community" }, trusted: false },
+    { name: "conflicting resolution", overrides: { resolvedName: "@vendor/acpx" }, trusted: false },
+    {
+      name: "resolved identity alone",
+      overrides: { spec: undefined, clawhubPackage: undefined },
+      trusted: false,
+    },
+  ] satisfies Array<{
+    name: string;
+    overrides: Partial<PluginInstallRecord>;
+    trusted: boolean;
+  }>)("requires current ClawHub authority: $name", ({ overrides, trusted }) => {
+    expect(
+      isTrustedOfficialPluginInstallRecord({
+        pluginId: "acpx",
+        packageName: "@openclaw/acpx",
+        record: {
+          source: "clawhub",
+          spec: "clawhub:@openclaw/acpx",
+          clawhubPackage: "@openclaw/acpx",
+          clawhubUrl: "https://clawhub.ai",
+          clawhubChannel: "official",
+          resolvedName: "@openclaw/acpx",
+          ...overrides,
+        },
+      }),
+    ).toBe(trusted);
+  });
+});
 
 describe("trusted official npm install records", () => {
   it("resolves an exact canonical catalog package", () => {

--- a/src/plugins/official-external-install-records.ts
+++ b/src/plugins/official-external-install-records.ts
@@ -107,11 +107,7 @@ function isOfficialClawHubInstallRecord(record: PluginInstallRecord): boolean {
 export function resolveTrustedOfficialClawHubPackageName(
   record: PluginInstallRecord,
 ): string | undefined {
-  if (
-    record.source !== "clawhub" ||
-    record.clawhubChannel !== "official" ||
-    (record.clawhubUrl ?? "").trim().replace(/\/+$/, "") !== "https://clawhub.ai"
-  ) {
+  if (!isOfficialClawHubInstallRecord(record)) {
     return undefined;
   }
   const packageNames = resolveRecordedClawHubPackageNames(record);
@@ -119,6 +115,44 @@ export function resolveTrustedOfficialClawHubPackageName(
     return undefined;
   }
   return packageNames[0];
+}
+
+/** Binds official trust to the actual package and consistent recorded source identity. */
+export function isTrustedOfficialPluginInstallRecord(params: {
+  pluginId: string;
+  packageName?: string;
+  record: PluginInstallRecord;
+}): boolean {
+  const packageName = params.packageName?.trim();
+  const entry = packageName
+    ? getOfficialExternalPluginCatalogEntryForPackage(packageName)
+    : undefined;
+  if (
+    !entry ||
+    (resolveOfficialExternalPluginId(entry) !== params.pluginId &&
+      !resolveOfficialExternalPluginLegacyIds(entry).includes(params.pluginId))
+  ) {
+    return false;
+  }
+  const install = resolveOfficialExternalPluginInstall(entry);
+  const record = params.record;
+  if (record.source === "npm") {
+    // Local npm-pack archives also persist source="npm". Catalog identity alone
+    // cannot turn a local artifact or conflicting source record into official trust.
+    return (
+      record.artifactKind === undefined &&
+      record.sourcePath === undefined &&
+      resolveNpmSpecPackageName(install?.npmSpec) === packageName &&
+      resolveUnanimousRecordedNpmPackageName(record) === packageName &&
+      (record.clawhubPackage === undefined ||
+        resolveExactNpmPackageName(record.clawhubPackage) === packageName)
+    );
+  }
+  return (
+    Boolean(install?.clawhubSpec || install?.npmSpec) &&
+    (record.clawhubPackage !== undefined || record.spec !== undefined) &&
+    resolveTrustedOfficialClawHubPackageName(record) === packageName
+  );
 }
 
 function hasTrustedClawHubSourceAuthority(

--- a/src/plugins/status-snapshot.ts
+++ b/src/plugins/status-snapshot.ts
@@ -77,7 +77,11 @@ export function collectPluginCapabilityConsentDiagnostics(params: {
   }
   const currentAcceptanceByOwner = new Map<string, boolean>();
   for (const plugin of params.index.plugins) {
-    if (!plugin.enabled || plugin.origin === "bundled") {
+    if (
+      !plugin.enabled ||
+      plugin.origin === "bundled" ||
+      params.manifests.get(plugin.pluginId)?.trustedOfficialInstall
+    ) {
       continue;
     }
     const installOwner = resolveInstalledPluginIndexInstallOwner(plugin);

--- a/src/plugins/update-capability-consent.ts
+++ b/src/plugins/update-capability-consent.ts
@@ -1,24 +1,10 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type {
-  PluginAcceptedDeclaredSurface,
-  PluginInstallRecord,
-} from "../config/types.plugins.js";
-import { readInstalledPackageManifest } from "../infra/package-update-utils.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
 import {
-  buildPluginCapabilityConsentReview,
-  diffDeclaredSurfaceWidening,
-  resolvePluginArtifactDeclaredSurface,
+  createManagedPluginArtifactConsentHandler,
   type PluginCapabilityConsentHandler,
 } from "./capability-consent.js";
-import {
-  computeDeclaredSurfaceHash,
-  resolveAcceptedSurfaceCurrent,
-  resolvePluginInstallRecordIntegrity,
-} from "./capability-summary.js";
-import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import type { PluginInstallArtifactConsentHandler } from "./install-types.js";
-import { ManagedPluginLifecycleError } from "./management-lifecycle-error.js";
-import { loadPluginManifest } from "./manifest.js";
 
 export function preparePluginUpdateCapabilityConsent(params: {
   config: OpenClawConfig;
@@ -33,158 +19,29 @@ export function preparePluginUpdateCapabilityConsent(params: {
   onBeforePluginArtifactCommit: PluginInstallArtifactConsentHandler;
   acceptInstallRecord: <T extends PluginInstallRecord>(record: T) => T;
 } {
-  let previousDeclared: PluginAcceptedDeclaredSurface | undefined;
-  try {
-    // Capture the installed artifact before npm can mutate its managed root;
-    // comparing against stored self-declarations lets malicious updates hide widening.
-    previousDeclared = resolvePluginArtifactDeclaredSurface(params.installPath, process.env, {
-      config: params.config,
-    });
-  } catch {
-    // An unverifiable old payload cannot authorize its replacement; review the full stage.
-  }
-
-  let acceptedSurface: PluginAcceptedDeclaredSurface | undefined;
-  let artifactReviewed = false;
+  const consent = createManagedPluginArtifactConsentHandler({
+    config: params.config,
+    source: params.record.source,
+    spec: params.record.spec,
+    expectedIntegrity: params.expectedIntegrity,
+    previousRecords: {
+      [params.pluginId]: { ...params.record, installPath: params.installPath },
+    },
+    updatingPluginIds: params.packagePluginIds ?? [],
+    onCapabilityConsent: params.onCapabilityConsent,
+    beforePersistentEffect: params.beforePersistentEffect,
+  });
+  let reviewedPluginId = params.pluginId;
   return {
-    onBeforePluginArtifactCommit: async ({ stagedArtifactDir }) => {
-      // Fallback attempts must not inherit an earlier stage's review or acceptance.
-      acceptedSurface = undefined;
-      artifactReviewed = false;
-      const artifactContext = {
-        config: params.config,
-        // npm can stage a new generation; configured paths still refer to the recorded install.
+    onBeforePluginArtifactCommit: async (artifact) => {
+      reviewedPluginId = artifact.pluginId;
+      await consent.onBeforePluginArtifactCommit({
+        ...artifact,
+        // New npm generations still inherit configured paths from the old package root.
         currentArtifactDir: params.installPath,
-      };
-      const declared = resolvePluginArtifactDeclaredSurface(
-        stagedArtifactDir,
-        process.env,
-        artifactContext,
-      );
-      artifactReviewed = true;
-      const { widened, hasWidening } = previousDeclared
-        ? diffDeclaredSurfaceWidening(previousDeclared, declared)
-        : { widened: undefined, hasWidening: false };
-      const priorAcceptanceCurrent =
-        previousDeclared !== undefined &&
-        resolveAcceptedSurfaceCurrent(params.record, previousDeclared);
-      const priorIntegrity = resolvePluginInstallRecordIntegrity(params.record);
-      // Unknown package ownership must not let a disabled owner hide an enabled sibling.
-      const enabled =
-        !params.packagePluginIds?.length ||
-        params.packagePluginIds.some(
-          (ownedPluginId) =>
-            resolveEffectiveEnableState({
-              id: ownedPluginId,
-              origin: "global",
-              config: normalizePluginsConfig(params.config.plugins),
-              rootConfig: params.config,
-            }).enabled,
-        );
-
-      const requiresAcceptance =
-        !previousDeclared || hasWidening || !priorAcceptanceCurrent || !priorIntegrity;
-      if (requiresAcceptance && enabled) {
-        const loadedManifest = loadPluginManifest(stagedArtifactDir);
-        const packageManifest = readInstalledPackageManifest(stagedArtifactDir);
-        const packageName =
-          typeof packageManifest?.name === "string" ? packageManifest.name : undefined;
-        const packageVersion =
-          typeof packageManifest?.version === "string" ? packageManifest.version : undefined;
-        const manifest = {
-          ...(loadedManifest.ok ? loadedManifest.manifest : {}),
-          name:
-            (loadedManifest.ok ? loadedManifest.manifest.name : undefined) ??
-            packageName ??
-            params.pluginId,
-          version:
-            (loadedManifest.ok ? loadedManifest.manifest.version : undefined) ?? packageVersion,
-        };
-        const {
-          integrity: _previousIntegrity,
-          npmIntegrity: _previousNpmIntegrity,
-          clawpackSha256: _previousClawpackIntegrity,
-          gitCommit: _previousGitCommit,
-          acceptedSurface: _previousAcceptedSurface,
-          acceptedSurfaceHash: _previousAcceptedSurfaceHash,
-          acceptedSurfaceAt: _previousAcceptedSurfaceAt,
-          acceptedSurfaceIntegrity: _previousAcceptedSurfaceIntegrity,
-          ...previousRecordWithoutIntegrity
-        } = params.record;
-        const review = buildPluginCapabilityConsentReview({
-          config: params.config,
-          pluginId: params.pluginId,
-          record: {
-            ...previousRecordWithoutIntegrity,
-            ...(params.expectedIntegrity ? { integrity: params.expectedIntegrity } : {}),
-          },
-          manifest,
-          declared,
-          widened,
-        });
-        const acknowledgment = await params.onCapabilityConsent?.(review);
-        if (acknowledgment) {
-          await params.beforePersistentEffect?.();
-        }
-        // The prompt can yield while staged files change; bind approval to the final artifact.
-        const finalDeclared = resolvePluginArtifactDeclaredSurface(
-          stagedArtifactDir,
-          process.env,
-          artifactContext,
-        );
-        if (acknowledgment?.reviewToken !== computeDeclaredSurfaceHash(finalDeclared)) {
-          throw new ManagedPluginLifecycleError(
-            `Plugin "${params.pluginId}" requires capability consent; rerun with --accept-capabilities.`,
-            {
-              capabilityConsent: {
-                pluginId: params.pluginId,
-                reviewToken: computeDeclaredSurfaceHash(finalDeclared),
-                ...(previousDeclared
-                  ? {
-                      widened: diffDeclaredSurfaceWidening(previousDeclared, finalDeclared).widened,
-                    }
-                  : {}),
-              },
-            },
-          );
-        }
-        acceptedSurface = finalDeclared;
-        return;
-      }
-      if (!hasWidening && priorAcceptanceCurrent && priorIntegrity) {
-        acceptedSurface = declared;
-      }
-      // Reused acceptance still publishes a package. Keep the same commit
-      // guard, and reject staged-byte drift across its await.
-      await params.beforePersistentEffect?.();
-      const finalDeclared = resolvePluginArtifactDeclaredSurface(
-        stagedArtifactDir,
-        process.env,
-        artifactContext,
-      );
-      if (computeDeclaredSurfaceHash(finalDeclared) !== computeDeclaredSurfaceHash(declared)) {
-        throw new ManagedPluginLifecycleError(
-          `Plugin "${params.pluginId}" changed during its update commit; retry the update.`,
-        );
-      }
+        mode: "update",
+      });
     },
-    acceptInstallRecord: (record) => {
-      if (!artifactReviewed) {
-        throw new Error(
-          `Plugin "${params.pluginId}" update did not review the staged artifact capabilities.`,
-        );
-      }
-      if (!acceptedSurface) {
-        return record;
-      }
-      const integrity = resolvePluginInstallRecordIntegrity(record)?.integrity;
-      return {
-        ...record,
-        acceptedSurface,
-        acceptedSurfaceHash: computeDeclaredSurfaceHash(acceptedSurface),
-        acceptedSurfaceAt: new Date().toISOString(),
-        ...(integrity ? { acceptedSurfaceIntegrity: integrity } : {}),
-      };
-    },
+    acceptInstallRecord: (record) => consent.applyAcceptedSurface(reviewedPluginId, record),
   };
 }

--- a/src/plugins/update-channel.consent.test.ts
+++ b/src/plugins/update-channel.consent.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolvePluginArtifactDeclaredSurface } from "./capability-consent.js";
+import { resolvePluginArtifactDeclaredSurface } from "./capability-artifact.js";
 import { computeDeclaredSurfaceHash } from "./capability-summary.js";
 import type { PluginInstallArtifactConsentHandler } from "./install-types.js";
 import { makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import type { OpenClawConfig } from "../config/config.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { withEnvAsync } from "../test-utils/env.js";
-import { resolvePluginArtifactDeclaredSurface } from "./capability-consent.js";
+import { resolvePluginArtifactDeclaredSurface } from "./capability-artifact.js";
 import { computeDeclaredSurfaceHash } from "./capability-summary.js";
 import { makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
@@ -156,8 +156,6 @@ vi.mock("./package-entry-resolution.js", async (importOriginal) => {
     },
   };
 });
-
-vi.resetModules();
 
 const { syncPluginsForUpdateChannel, updateNpmInstalledPlugins } = await import("./update.js");
 
@@ -1147,7 +1145,7 @@ describe("updateNpmInstalledPlugins", () => {
         packagePluginIds: { [pluginId]: [rootPluginId, `${pluginId}-addon`] },
       });
       if (omitStageReview) {
-        await expect(pendingUpdate).rejects.toThrow("did not review the staged artifact");
+        await expect(pendingUpdate).rejects.toThrow("did not expose its verified artifact");
         return;
       }
       if (review === "throw" || review === "throw-undefined") {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where installing, re-enabling, updating, or repairing an official first-party plugin such as Codex could require blanket capability consent even though OpenClaw already ships or distributes that plugin. Noninteractive setup and Doctor could stop at a consent prompt on the normal first-party path.

## Why This Change Was Made

Use one catalog-backed source-identity check for installed metadata and verified staged artifacts. npm supplies its validated resolution; ClawHub supplies the actual registry and release channel after artifact verification. The actual package and every populated source identity must agree with the official catalog. Installed trust remains bound to the tracked installation path.

Install and update now share the staged consent owner, removing the duplicated update review flow. Artifact inspection and pure review presentation have separate owners; their implementations move unchanged and callers use those owners directly. Each retry or fallback owns fresh provenance; the commit guard rechecks staged capabilities and first-party identity after awaited work. Third-party widening, missing prior artifacts, disabled updates, omitted review callbacks, and cancellation retain their existing protections.

Doctor adoption records the local source path instead of allowing untracked local bytes to become a trusted registry install. Registry replacement can establish fresh provenance normally. Production delta: **424 added / 491 removed (net −67)**; tests: **385 added / 45 removed (net +340)**. No new configuration, environment variables, schema, or persisted acceptance fields.

## User Impact

Bundled and verified first-party catalog plugins can install, enable, update, and repair without `--accept-capabilities`. This exemption does not fabricate operator acceptance or grant OAuth, OS, or runtime tool permissions. Third-party plugins, local copies (including the genuine package installed through `npm-pack:`), custom ClawHub registries, and conflicting source records still require consent. Legacy ClawHub records missing registry/channel authority do not receive the exemption; the existing catalog repair/update routing remains available.

CLI and plugin-management documentation describe the same policy. Related: #134172.

## Evidence

- Before-fix live baseline: genuine published `npm:@openclaw/codex@2026.8.1`, closed stdin, no acceptance flag: capability-consent failure; synthetic config unchanged.
- **630 passing focused tests across nine files**, including staged and installed first-party exemption, invalid source identities, fallback isolation, commit-time mutation, third-party update preservation, ClawHub authority propagation, onboarding, and Doctor.
- Manifest source-conflict and Doctor local-adoption regressions failed before their producer fixes and passed afterward.
- Independent Codex autoreview: no accepted/actionable findings at the repository's default P0 threshold. Direct owner/sibling review also completed.
- Runtime permission boundary inspected directly in upstream Codex `codex-rs/app-server/README.md:1888–1940` at `e017e93aceafb2fe04bed1c926e448a5fb4f913d`; this change does not modify runtime approvals.
- Live first-party flows passed with closed stdin and no acceptance flag: genuine npm Codex 2026.8.1 install; legacy enable after removing acceptance fields; genuine 2026.7.1 → 2026.8.1 update; official ClawHub 2026.8.1 install. All had global installed origin, no fabricated acceptance fields, and no cold consent diagnostics.
- Real packaged-core `doctor --fix --non-interactive` installed missing Codex from npm and preserved the authored runtime selection. The raw development checkout was excluded from this proof because its bundled Codex build can satisfy Doctor without an install.
- Third-party, spoofed id, and local official-name controls required consent for install and re-enable, and succeeded only with explicit acceptance. The identical registry-integrity-matching Codex tarball installed through `npm-pack:` retained this boundary. Public uninstall with `--keep-files` followed by Doctor refused untracked retained bytes, left the payload unchanged, and created no install record.
- Final production/test typegraphs, scoped lint, production/full-tree dead-export scans, schema/storage guards, and runtime import-cycle checks passed. The owner split preserves the moved function bodies byte-for-byte.
- Live execution: [full package/source matrix](https://github.com/openclaw/openclaw/actions/runs/33474114347), [rebuilt packaged smoke](https://github.com/openclaw/openclaw/actions/runs/33477014968). Artifact publication was unavailable from the configured broker; sanitized receipts and source-hash manifests were collected locally.
- After the final owner split: 344 focused local cases passed; Linux independently passed the 219-case consent/update suite and all 15 gateway setup-resolution cases. The final canonical package was rebuilt and installed into a fresh prefix; all eight smoke commands passed and all 30 source hashes matched before/after. The combined macOS runner needed interruption during shutdown after its 344 cases passed, and a broader macOS gateway attempt stalled in preparation; Linux completed the same gateway file successfully in 20.40 seconds.
