### PR TITLE
perf: reduce CodeMode latency and session lookup work

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1709,7 +1709,7 @@ src/agents/cli-runner/execute.ts	3
 src/agents/cli-runner/prepare.ts	5
 src/agents/cli-runner/session-history.ts	3
 src/agents/code-mode-namespaces.ts	5
-src/agents/code-mode-runtime.ts	4
+src/agents/code-mode-runtime.ts	2
 src/agents/code-mode-script-syntax.ts	1
 src/agents/code-mode-worker.ts	2
 src/agents/code-mode.ts	2

--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -42,8 +42,15 @@ identically-named `exec`/`wait` tools.
 In OpenClaw code mode, `command` is a JavaScript or TypeScript alias for
 `code`, not a shell command. For shell or file operations, call the appropriate
 async tool global from guest JavaScript. Recognizable shell
-commands are rejected before the QuickJS worker starts with actionable
+commands are rejected before guest execution with actionable
 `invalid_input` guidance.
+
+Source validation, TypeScript compilation, and guest execution run in a bounded
+pool of worker threads that scales with available CPU cores. Workers stay warm
+between calls; each execution or resume gets an isolated QuickJS VM. Tool
+permissions, approvals, and session ownership remain with the Gateway. Queued
+work shares the execution deadline, and cancellation stops an active worker
+before the call settles.
 
 ## What it does
 

--- a/src/agents/clawrouter-catalog-discovery.e2e.test.ts
+++ b/src/agents/clawrouter-catalog-discovery.e2e.test.ts
@@ -119,7 +119,6 @@ describe("ClawRouter cold prepared catalog", () => {
     });
     const result = await runPreparedModelCatalogWorkerRequest(value, {
       kind: "catalog",
-      requestId: 1,
     });
     expect(result.status).toBe("ok");
     if (result.status !== "ok" || result.kind !== "catalog") {

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -7,7 +7,6 @@ import {
   createCodeModeCatalogProjection,
   type CodeModeCatalogProjection,
 } from "./code-mode-catalog.js";
-import { awaitCodeModeDeadline } from "./code-mode-deadline.js";
 import { CodeModeOutputState } from "./code-mode-json.js";
 import {
   createCodeModeNamespaceRuntime,
@@ -20,7 +19,6 @@ import {
   codeModeFailureMessage,
   createCodeModeApiFilesForRun,
   enforceSnapshotPayloadLimits,
-  prepareSource,
   toToolSearchConfig,
   type CodeModeConfig,
   type CodeModeLanguage,
@@ -53,7 +51,7 @@ import {
   type CodeModeBridgeDispatchState,
   type CodeModeRunOwner,
 } from "./code-mode-state.js";
-import { normalizeCodeModeWorkerResult, runCodeModeWorker } from "./code-mode-worker.js";
+import { runCodeModeWorker } from "./code-mode-worker.js";
 import type { AgentToolUpdateCallback } from "./runtime/index.js";
 import { resolveSwarmConfig } from "./subagents/swarm/swarm-config.js";
 import type { ToolResultBudget } from "./tool-result-limits.js";
@@ -104,32 +102,24 @@ export async function runCodeModeExec(params: {
   const signal = owner.bindCall(params.signal);
   const output = new CodeModeOutputState(config.maxOutputBytes, params.resultBudget);
   try {
-    const source = await awaitCodeModeDeadline({
-      operation: () => prepareSource({ code: params.code, language: params.language, config }),
-      remainingMs: deadlineMs - Date.now(),
-      signal,
-      createTimeoutError: () => new Error("interrupted"),
-      createAbortError: () => new Error("code mode execution aborted"),
-    });
     const remainingMs = deadlineMs - Date.now();
     if (remainingMs <= 0) {
       throw new Error("interrupted");
     }
-    const result = normalizeCodeModeWorkerResult(
-      await runCodeModeWorker(
-        {
-          kind: "exec",
-          source,
-          config: { ...config, timeoutMs: remainingMs },
-          catalog: catalogProjection.guestBindings,
-          apiFiles,
-          namespaces: namespaceRuntime.descriptors,
-          swarmEnabled,
-        },
-        remainingMs + CODE_MODE_WORKER_WATCHDOG_GRACE_MS,
-        undefined,
-        signal,
-      ),
+    const result = await runCodeModeWorker(
+      {
+        kind: "exec",
+        source: params.code,
+        language: params.language,
+        config: { ...config, timeoutMs: remainingMs },
+        catalog: catalogProjection.guestBindings,
+        apiFiles,
+        namespaces: namespaceRuntime.descriptors,
+        swarmEnabled,
+      },
+      remainingMs + CODE_MODE_WORKER_WATCHDOG_GRACE_MS,
+      undefined,
+      signal,
     );
     output.append(result.output);
     return await settleCodeModeResult({
@@ -390,22 +380,20 @@ async function settleCodeModeResult(params: {
       // The resumed guest inherits only the remaining shared budget as its
       // QuickJS interrupt deadline; the extra host margin is watchdog grace,
       // not extra guest run time.
-      result = normalizeCodeModeWorkerResult(
-        await runCodeModeWorker(
-          {
-            kind: "resume",
-            snapshotBytes: result.snapshotBytes,
-            config: {
-              ...params.config,
-              timeoutMs: resumeBudgetMs,
-            },
-            settledRequests,
-            pendingRequests: pending.map(({ id, method, args }) => ({ id, method, args })),
+      result = await runCodeModeWorker(
+        {
+          kind: "resume",
+          snapshotBytes: result.snapshotBytes,
+          config: {
+            ...params.config,
+            timeoutMs: resumeBudgetMs,
           },
-          resumeBudgetMs + CODE_MODE_WORKER_WATCHDOG_GRACE_MS,
-          undefined,
-          params.signal,
-        ),
+          settledRequests,
+          pendingRequests: pending.map(({ id, method, args }) => ({ id, method, args })),
+        },
+        resumeBudgetMs + CODE_MODE_WORKER_WATCHDOG_GRACE_MS,
+        undefined,
+        params.signal,
       );
       output.append(result.output);
       if (result.status === "waiting") {
@@ -613,22 +601,20 @@ export async function runWait(params: {
     releaseActiveRunSlot = reserveActiveRunSlot(state.runId);
     // The resumed guest inherits only the remaining shared budget as its QuickJS
     // interrupt deadline; the extra host margin is watchdog grace only.
-    const result = normalizeCodeModeWorkerResult(
-      await runCodeModeWorker(
-        {
-          kind: "resume",
-          snapshotBytes: state.snapshotBytes,
-          config: {
-            ...state.config,
-            timeoutMs: resumeBudgetMs,
-          },
-          settledRequests,
-          pendingRequests: pending.map(({ id, method, args }) => ({ id, method, args })),
+    const result = await runCodeModeWorker(
+      {
+        kind: "resume",
+        snapshotBytes: state.snapshotBytes,
+        config: {
+          ...state.config,
+          timeoutMs: resumeBudgetMs,
         },
-        resumeBudgetMs + CODE_MODE_WORKER_WATCHDOG_GRACE_MS,
-        undefined,
-        signal,
-      ),
+        settledRequests,
+        pendingRequests: pending.map(({ id, method, args }) => ({ id, method, args })),
+      },
+      resumeBudgetMs + CODE_MODE_WORKER_WATCHDOG_GRACE_MS,
+      undefined,
+      signal,
     );
     state.output.append(result.output);
     return await settleCodeModeResult({

--- a/src/agents/code-mode-headless.test.ts
+++ b/src/agents/code-mode-headless.test.ts
@@ -1,15 +1,7 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-const loadCodeModeTypeScriptRuntime = vi.hoisted(() =>
-  vi.fn<() => Promise<typeof import("typescript")>>(),
-);
-
-vi.mock("./code-mode-typescript-runtime.js", () => ({
-  loadCodeModeTypeScriptRuntime,
-}));
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import type { CodeModeNamespaceDescriptor } from "./code-mode-namespaces.js";
-import { prepareSource } from "./code-mode-runtime.js";
+import { prepareSource } from "./code-mode-source.js";
 import { runCodeModeScriptHeadless, type CodeModeHeadlessResult } from "./code-mode.js";
 import { createHeadlessCodeModeHarness, testing } from "./code-mode.test-support.js";
 import { jsonResult, type AnyAgentTool } from "./tools/common.js";
@@ -41,13 +33,8 @@ function expectFailed(result: CodeModeHeadlessResult) {
 }
 
 describe("headless Code Mode", () => {
-  beforeEach(async () => {
-    loadCodeModeTypeScriptRuntime.mockResolvedValue(await import("typescript"));
-  });
-
   afterEach(() => {
     vi.useRealTimers();
-    loadCodeModeTypeScriptRuntime.mockReset();
     expect(testing.activeRuns.size).toBe(0);
     testing.activeRuns.clear();
     testing.resumingRunIds.clear();
@@ -905,46 +892,6 @@ describe("headless Code Mode", () => {
       resumed: true,
     });
     expect(result.toolCallCount).toBe(0);
-  });
-
-  it("times out an unfinished headless TypeScript runtime load", async () => {
-    loadCodeModeTypeScriptRuntime.mockReturnValue(new Promise(() => {}));
-
-    const result = expectFailed(
-      await runCodeModeScriptHeadless({
-        ctx: createHeadlessCodeModeHarness(),
-        language: "typescript",
-        code: "return 42;",
-        wallClockMs: 25,
-      }),
-    );
-
-    expect(result).toMatchObject({
-      code: "timeout",
-      error: "code mode headless wall-clock timeout exceeded",
-      output: [],
-      toolCallCount: 0,
-    });
-  });
-
-  it("aborts an unfinished headless TypeScript runtime load", async () => {
-    loadCodeModeTypeScriptRuntime.mockReturnValue(new Promise(() => {}));
-    const controller = new AbortController();
-    const resultPromise = runCodeModeScriptHeadless({
-      ctx: createHeadlessCodeModeHarness(),
-      language: "typescript",
-      code: "return 42;",
-      signal: controller.signal,
-    });
-
-    controller.abort();
-
-    expect(expectFailed(await resultPromise)).toMatchObject({
-      code: "aborted",
-      error: "code mode execution aborted",
-      output: [],
-      toolCallCount: 0,
-    });
   });
 
   it("keeps worker-leg wall-clock expiry classified as timeout", async () => {

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -18,7 +18,6 @@ import {
   codeModeFailureMessage,
   createCodeModeApiFilesForRun,
   enforceSnapshotPayloadLimits,
-  prepareSource,
   readPositiveInteger,
   resolveCodeModeHeadlessConfig,
   toToolSearchConfig,
@@ -41,7 +40,6 @@ import {
 import {
   CodeModeHeadlessAbortError,
   CodeModeHeadlessTimeoutError,
-  normalizeCodeModeWorkerResult,
   runCodeModeWorker,
 } from "./code-mode-worker.js";
 import { ToolSearchRuntime } from "./tool-search-runtime.js";
@@ -107,13 +105,17 @@ async function runHeadlessWorkerLeg(params: {
   signal: AbortSignal;
 }): Promise<CodeModeWorkerResult> {
   const remainingMs = remainingHeadlessMs(params.deadline);
-  const timeoutMs = Math.max(1, Math.min(params.config.timeoutMs, remainingMs));
+  const executionTimeoutMs = Math.max(1, Math.min(params.config.timeoutMs, remainingMs));
+  // Initial source preparation uses the wall-clock allowance; the guest keeps
+  // its separate CPU budget after compilation. Resumes need no preparation.
+  const timeoutMs = params.input.kind === "exec" ? remainingMs : executionTimeoutMs;
   // Let the headless abort scope own the wall-clock deadline. Capping the host
   // watchdog to the same deadline makes its internal timeout message race the scope.
   const workerTimeoutMs = timeoutMs + CODE_MODE_WORKER_WATCHDOG_GRACE_MS;
   return await runCodeModeWorker(
     {
       ...params.input,
+      executionTimeoutMs,
       config: { ...params.config, timeoutMs },
     },
     workerTimeoutMs,
@@ -233,13 +235,6 @@ export async function runCodeModeScriptHeadless(params: {
     const bridgeDispatch = createCodeModeBridgeDispatchState();
     const namespaceCatalog = runtime.namespaceEntries();
     const namespaceRuntime = createCodeModeNamespaceRuntime(namespaceCatalog);
-    const preparedSource = await awaitCodeModeDeadline({
-      operation: () => prepareSource({ code: params.code, language: params.language, config }),
-      remainingMs: remainingHeadlessMs(deadline),
-      signal: abortScope.signal,
-      createTimeoutError: () => new CodeModeHeadlessTimeoutError(),
-      createAbortError: headlessAbortError,
-    });
     const namespaces = mergeHeadlessNamespaces(
       namespaceRuntime.descriptors,
       params.extraNamespaces ?? [],
@@ -247,23 +242,22 @@ export async function runCodeModeScriptHeadless(params: {
     const catalogProjection = createCodeModeCatalogProjection(runtime.all({ includeMcp: false }), {
       reservedNames: namespaces.map((descriptor) => descriptor.globalName),
     });
-    const source = `${headlessNamespaceFreezePrelude(namespaces)}${preparedSource}`;
     const parentToolCallId = `headless:${randomUUID()}`;
-    let result = normalizeCodeModeWorkerResult(
-      await runHeadlessWorkerLeg({
-        input: {
-          kind: "exec",
-          source,
-          catalog: catalogProjection.guestBindings,
-          apiFiles: createCodeModeApiFilesForRun(namespaceRuntime, swarmEnabled),
-          namespaces,
-          swarmEnabled,
-        },
-        config,
-        deadline,
-        signal: abortScope.signal,
-      }),
-    );
+    let result = await runHeadlessWorkerLeg({
+      input: {
+        kind: "exec",
+        source: params.code,
+        language: params.language,
+        prelude: headlessNamespaceFreezePrelude(namespaces),
+        catalog: catalogProjection.guestBindings,
+        apiFiles: createCodeModeApiFilesForRun(namespaceRuntime, swarmEnabled),
+        namespaces,
+        swarmEnabled,
+      },
+      config,
+      deadline,
+      signal: abortScope.signal,
+    });
 
     while (true) {
       output.append(result.output);
@@ -343,19 +337,17 @@ export async function runCodeModeScriptHeadless(params: {
       });
       const settledRequests = settledBridgeRequestsInCompletionOrder(pending);
       pending = pending.filter((entry) => !entry.settled);
-      result = normalizeCodeModeWorkerResult(
-        await runHeadlessWorkerLeg({
-          input: {
-            kind: "resume",
-            snapshotBytes: result.snapshotBytes,
-            settledRequests,
-            pendingRequests: pending.map(({ id, method, args }) => ({ id, method, args })),
-          },
-          config,
-          deadline,
-          signal: abortScope.signal,
-        }),
-      );
+      result = await runHeadlessWorkerLeg({
+        input: {
+          kind: "resume",
+          snapshotBytes: result.snapshotBytes,
+          settledRequests,
+          pendingRequests: pending.map(({ id, method, args }) => ({ id, method, args })),
+        },
+        config,
+        deadline,
+        signal: abortScope.signal,
+      });
     }
   } catch (error) {
     const timedOut = error instanceof CodeModeHeadlessTimeoutError;

--- a/src/agents/code-mode-runtime.test.ts
+++ b/src/agents/code-mode-runtime.test.ts
@@ -4,12 +4,9 @@ import {
   captureCodeModeValue,
   CodeModeOutputState,
 } from "./code-mode-json.js";
-import {
-  isCodeModeEngagedForModel,
-  prepareSource,
-  resolveCodeModeConfig,
-} from "./code-mode-runtime.js";
+import { isCodeModeEngagedForModel, resolveCodeModeConfig } from "./code-mode-runtime.js";
 import { parseCodeModeScriptSyntax } from "./code-mode-script-syntax.js";
+import { prepareSource } from "./code-mode-source.js";
 
 const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
 

--- a/src/agents/code-mode-runtime.ts
+++ b/src/agents/code-mode-runtime.ts
@@ -1,7 +1,6 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueValues } from "@openclaw/normalization-core/string-normalization";
-import { parse, tokenizer } from "acorn";
 import { normalizeAgentModelRefForConfig } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -10,16 +9,12 @@ import { clampNumber } from "../utils.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
 import type { CodeModeOutputSource } from "./code-mode-json.js";
 import type { CodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
-import {
-  buildCodeModeScriptParseSource,
-  parseCodeModeScriptSyntax,
-} from "./code-mode-script-syntax.js";
-import {
-  CODE_MODE_SHELL_SOURCE_ERROR,
-  isShellLikeCodeModeSource,
-} from "./code-mode-shell-source.js";
-import { loadCodeModeTypeScriptRuntime } from "./code-mode-typescript-runtime.js";
-import type { CodeModeFailurePhase, CodeModeWorkerThreadResult } from "./code-mode-worker-types.js";
+import type {
+  CodeModeConfig as CodeModeWorkerConfig,
+  CodeModeFailurePhase,
+  CodeModeLanguage,
+  CodeModeWorkerThreadResult,
+} from "./code-mode-worker-types.js";
 import type { ToolSearchConfig, ToolSearchToolContext } from "./tool-search.js";
 import { asToolParamsRecord, ToolInputError } from "./tools/common.js";
 
@@ -39,20 +34,14 @@ export const MAX_HEADLESS_WALL_CLOCK_MS = 900_000;
 export const DEFAULT_HEADLESS_TOOL_CALLS = 5;
 export const MAX_HEADLESS_TOOL_CALLS = 200;
 
-export type CodeModeLanguage = "javascript" | "typescript";
+export type { CodeModeLanguage } from "./code-mode-worker-types.js";
 
 /** Resolved Code Mode runtime limits and visible language options. */
-export type CodeModeConfig = {
+export type CodeModeConfig = CodeModeWorkerConfig & {
   /** Effective activation policy; "auto" follows the model catalog flag. */
   enabled: boolean | "auto";
   runtime: "quickjs-wasi";
   mode: "only";
-  languages: CodeModeLanguage[];
-  timeoutMs: number;
-  memoryLimitBytes: number;
-  maxOutputBytes: number;
-  maxSnapshotBytes: number;
-  maxPendingToolCalls: number;
   snapshotTtlSeconds: number;
   searchDefaultLimit: number;
   maxSearchLimit: number;
@@ -327,259 +316,6 @@ export function readRunId(args: unknown): string {
     throw new ToolInputError("runId must be a non-empty string.");
   }
   return runId.trim();
-}
-
-function maskCodeLiteralsAndComments(
-  code: string,
-  typescriptRuntime?: typeof import("typescript"),
-): string {
-  let masked = code.split("");
-  const maskRange = (start: number, end: number, offset = 0) => {
-    for (
-      let index = Math.max(start - offset, 0);
-      index < Math.min(end - offset, masked.length);
-      index += 1
-    ) {
-      if (masked[index] !== "\n" && masked[index] !== "\r") {
-        masked[index] = " ";
-      }
-    }
-  };
-
-  try {
-    const wrapped = buildCodeModeScriptParseSource(code);
-    parse(wrapped.source, {
-      ecmaVersion: "latest",
-      onComment: (_isBlock, _text, start, end) => maskRange(start, end, wrapped.codeOffset),
-      onToken: (token) => {
-        // Parse in the real async guest context: standalone tokenization can
-        // mistake executable division for a regex after contextual keywords.
-        if (
-          token.type.label === "string" ||
-          token.type.label === "regexp" ||
-          token.type.label === "template"
-        ) {
-          maskRange(token.start, token.end, wrapped.codeOffset);
-        }
-      },
-    });
-    return masked.join("");
-  } catch {
-    // Parser and tokenizer offsets are UTF-16 code units, not Unicode points.
-    masked = code.split("");
-    if (typescriptRuntime) {
-      try {
-        const sourceFile = typescriptRuntime.createSourceFile(
-          "code-mode.ts",
-          code,
-          typescriptRuntime.ScriptTarget.ES2022,
-          true,
-          typescriptRuntime.ScriptKind.TS,
-        );
-        const visit = (node: import("typescript").Node) => {
-          typescriptRuntime.forEachLeadingCommentRange(code, node.getFullStart(), (start, end) =>
-            maskRange(start, end),
-          );
-          typescriptRuntime.forEachTrailingCommentRange(code, node.getEnd(), (start, end) =>
-            maskRange(start, end),
-          );
-          if (
-            typescriptRuntime.isStringLiteralLike(node) ||
-            typescriptRuntime.isRegularExpressionLiteral(node) ||
-            typescriptRuntime.isTemplateHead(node) ||
-            typescriptRuntime.isTemplateMiddle(node) ||
-            typescriptRuntime.isTemplateTail(node)
-          ) {
-            maskRange(node.getStart(sourceFile), node.getEnd());
-          }
-          typescriptRuntime.forEachChild(node, visit);
-        };
-        visit(sourceFile);
-        return masked.join("");
-      } catch {
-        // A failed TypeScript parse must never expose a partially masked scan.
-        return code;
-      }
-    }
-
-    // Malformed JavaScript needs a conservative lexical pass: never trust a
-    // context-free regexp token to hide executable module access.
-    try {
-      for (const token of tokenizer(code, {
-        ecmaVersion: "latest",
-        onComment: (_isBlock, _text, start, end) => maskRange(start, end),
-      })) {
-        if (token.type.label === "string" || token.type.label === "template") {
-          maskRange(token.start, token.end);
-        }
-      }
-      return masked.join("");
-    } catch {
-      // Never inspect partially masked input after a tokenizer failure.
-      return code;
-    }
-  }
-}
-
-function isModuleLoaderCallee(callee: import("acorn").Expression | import("acorn").Super): boolean {
-  if (callee.type === "ParenthesizedExpression") {
-    return isModuleLoaderCallee(callee.expression);
-  }
-  if (callee.type === "ChainExpression") {
-    return isModuleLoaderCallee(callee.expression);
-  }
-  if (callee.type === "SequenceExpression") {
-    const expression = callee.expressions[callee.expressions.length - 1];
-    return expression !== undefined && isModuleLoaderCallee(expression);
-  }
-  return callee.type === "Identifier" && callee.name === "require";
-}
-
-function containsModuleAccess(node: import("acorn").AnyNode): boolean {
-  if (
-    node.type === "ImportDeclaration" ||
-    node.type === "ImportExpression" ||
-    (node.type === "MetaProperty" && node.meta.name === "import") ||
-    (node.type === "CallExpression" && isModuleLoaderCallee(node.callee))
-  ) {
-    return true;
-  }
-
-  for (const value of Object.values(node)) {
-    if (Array.isArray(value)) {
-      for (const child of value) {
-        if (
-          child !== null &&
-          typeof child === "object" &&
-          "type" in child &&
-          typeof child.type === "string" &&
-          containsModuleAccess(child as import("acorn").AnyNode)
-        ) {
-          return true;
-        }
-      }
-      continue;
-    }
-    if (
-      value !== null &&
-      typeof value === "object" &&
-      "type" in value &&
-      typeof value.type === "string" &&
-      containsModuleAccess(value as import("acorn").AnyNode)
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function typeScriptContainsModuleAccess(code: string, ts: typeof import("typescript")): boolean {
-  const source = ts.createSourceFile(
-    "code-mode.ts",
-    code,
-    ts.ScriptTarget.ES2022,
-    true,
-    ts.ScriptKind.TS,
-  );
-
-  const isLoaderCallee = (expression: import("typescript").Expression): boolean => {
-    if (ts.isParenthesizedExpression(expression)) {
-      return isLoaderCallee(expression.expression);
-    }
-    if (
-      ts.isBinaryExpression(expression) &&
-      expression.operatorToken.kind === ts.SyntaxKind.CommaToken
-    ) {
-      return isLoaderCallee(expression.right);
-    }
-    return ts.isIdentifier(expression) && expression.text === "require";
-  };
-
-  const visit = (node: import("typescript").Node): boolean => {
-    if (
-      ts.isImportDeclaration(node) ||
-      ts.isImportEqualsDeclaration(node) ||
-      (ts.isMetaProperty(node) && node.keywordToken === ts.SyntaxKind.ImportKeyword) ||
-      (ts.isCallExpression(node) &&
-        (node.expression.kind === ts.SyntaxKind.ImportKeyword || isLoaderCallee(node.expression)))
-    ) {
-      return true;
-    }
-    return ts.forEachChild(node, (child) => (visit(child) ? true : undefined)) === true;
-  };
-
-  return visit(source);
-}
-
-function rejectsModuleAccess(
-  code: string,
-  typescriptRuntime?: typeof import("typescript"),
-): boolean {
-  const parsed = parseCodeModeScriptSyntax(code);
-  if (parsed.ok) {
-    // The WASI guest has no host module loader. Only executable module syntax
-    // belongs in this early check; ordinary guest methods are not capabilities.
-    return containsModuleAccess(parsed.program);
-  }
-  if (typescriptRuntime) {
-    try {
-      return typeScriptContainsModuleAccess(code, typescriptRuntime);
-    } catch {
-      // Keep malformed input on the conservative lexical fallback.
-    }
-  }
-  const source = maskCodeLiteralsAndComments(code, typescriptRuntime);
-  return /\bimport\b\s*(?:\.|\(|["'`{*]|\w)|\brequire\b\s*\(/u.test(source);
-}
-
-export async function prepareSource(input: {
-  code: string;
-  language?: CodeModeLanguage;
-  config: CodeModeConfig;
-}): Promise<string> {
-  const language = input.language ?? "javascript";
-  if (!input.config.languages.includes(language)) {
-    throw new ToolInputError(`code mode ${language} input is disabled.`);
-  }
-  if (language === "javascript") {
-    if (rejectsModuleAccess(input.code)) {
-      throw new ToolInputError("code mode module access is disabled.");
-    }
-    if (isShellLikeCodeModeSource(input.code)) {
-      throw new ToolInputError(CODE_MODE_SHELL_SOURCE_ERROR);
-    }
-    return input.code;
-  }
-  const ts = await loadCodeModeTypeScriptRuntime();
-  if (rejectsModuleAccess(input.code, ts)) {
-    throw new ToolInputError("code mode module access is disabled.");
-  }
-  const transformed = ts.transpileModule(input.code, {
-    compilerOptions: {
-      target: ts.ScriptTarget.ES2022,
-      module: ts.ModuleKind.ESNext,
-      importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
-      sourceMap: false,
-    },
-    reportDiagnostics: true,
-  });
-  const diagnostics = transformed.diagnostics ?? [];
-  if (diagnostics.some((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error)) {
-    const message = diagnostics
-      .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))
-      .join("\n");
-    throw new ToolInputError(`typescript transform failed: ${message}`);
-  }
-  if (rejectsModuleAccess(transformed.outputText, ts)) {
-    throw new ToolInputError("code mode module access is disabled.");
-  }
-  if (
-    isShellLikeCodeModeSource(input.code, transformed.outputText) ||
-    isShellLikeCodeModeSource(transformed.outputText)
-  ) {
-    throw new ToolInputError(CODE_MODE_SHELL_SOURCE_ERROR);
-  }
-  return transformed.outputText;
 }
 
 export function createCodeModeApiFilesForRun(

--- a/src/agents/code-mode-source.ts
+++ b/src/agents/code-mode-source.ts
@@ -1,0 +1,268 @@
+/** Validate and transpile guest source in the execution worker. */
+import { parse, tokenizer } from "acorn";
+import {
+  buildCodeModeScriptParseSource,
+  parseCodeModeScriptSyntax,
+} from "./code-mode-script-syntax.js";
+import {
+  CODE_MODE_SHELL_SOURCE_ERROR,
+  isShellLikeCodeModeSource,
+} from "./code-mode-shell-source.js";
+import { loadCodeModeTypeScriptRuntime } from "./code-mode-typescript-runtime.js";
+import type { CodeModeConfig, CodeModeLanguage } from "./code-mode-worker-types.js";
+import { ToolInputError } from "./tool-input-error.js";
+
+function maskCodeLiteralsAndComments(
+  code: string,
+  typescriptRuntime?: typeof import("typescript"),
+): string {
+  let masked = code.split("");
+  const maskRange = (start: number, end: number, offset = 0) => {
+    for (
+      let index = Math.max(start - offset, 0);
+      index < Math.min(end - offset, masked.length);
+      index += 1
+    ) {
+      if (masked[index] !== "\n" && masked[index] !== "\r") {
+        masked[index] = " ";
+      }
+    }
+  };
+
+  try {
+    const wrapped = buildCodeModeScriptParseSource(code);
+    parse(wrapped.source, {
+      ecmaVersion: "latest",
+      onComment: (_isBlock, _text, start, end) => maskRange(start, end, wrapped.codeOffset),
+      onToken: (token) => {
+        // Parse in the real async guest context: standalone tokenization can
+        // mistake executable division for a regex after contextual keywords.
+        if (
+          token.type.label === "string" ||
+          token.type.label === "regexp" ||
+          token.type.label === "template"
+        ) {
+          maskRange(token.start, token.end, wrapped.codeOffset);
+        }
+      },
+    });
+    return masked.join("");
+  } catch {
+    // Parser and tokenizer offsets are UTF-16 code units, not Unicode points.
+    masked = code.split("");
+    if (typescriptRuntime) {
+      try {
+        const sourceFile = typescriptRuntime.createSourceFile(
+          "code-mode.ts",
+          code,
+          typescriptRuntime.ScriptTarget.ES2022,
+          true,
+          typescriptRuntime.ScriptKind.TS,
+        );
+        const visit = (node: import("typescript").Node) => {
+          typescriptRuntime.forEachLeadingCommentRange(code, node.getFullStart(), (start, end) =>
+            maskRange(start, end),
+          );
+          typescriptRuntime.forEachTrailingCommentRange(code, node.getEnd(), (start, end) =>
+            maskRange(start, end),
+          );
+          if (
+            typescriptRuntime.isStringLiteralLike(node) ||
+            typescriptRuntime.isRegularExpressionLiteral(node) ||
+            typescriptRuntime.isTemplateHead(node) ||
+            typescriptRuntime.isTemplateMiddle(node) ||
+            typescriptRuntime.isTemplateTail(node)
+          ) {
+            maskRange(node.getStart(sourceFile), node.getEnd());
+          }
+          typescriptRuntime.forEachChild(node, visit);
+        };
+        visit(sourceFile);
+        return masked.join("");
+      } catch {
+        // A failed TypeScript parse must never expose a partially masked scan.
+        return code;
+      }
+    }
+
+    // Malformed JavaScript needs a conservative lexical pass: never trust a
+    // context-free regexp token to hide executable module access.
+    try {
+      for (const token of tokenizer(code, {
+        ecmaVersion: "latest",
+        onComment: (_isBlock, _text, start, end) => maskRange(start, end),
+      })) {
+        if (token.type.label === "string" || token.type.label === "template") {
+          maskRange(token.start, token.end);
+        }
+      }
+      return masked.join("");
+    } catch {
+      // Never inspect partially masked input after a tokenizer failure.
+      return code;
+    }
+  }
+}
+
+function isModuleLoaderCallee(callee: import("acorn").Expression | import("acorn").Super): boolean {
+  if (callee.type === "ParenthesizedExpression") {
+    return isModuleLoaderCallee(callee.expression);
+  }
+  if (callee.type === "ChainExpression") {
+    return isModuleLoaderCallee(callee.expression);
+  }
+  if (callee.type === "SequenceExpression") {
+    const expression = callee.expressions[callee.expressions.length - 1];
+    return expression !== undefined && isModuleLoaderCallee(expression);
+  }
+  return callee.type === "Identifier" && callee.name === "require";
+}
+
+function containsModuleAccess(node: import("acorn").AnyNode): boolean {
+  if (
+    node.type === "ImportDeclaration" ||
+    node.type === "ImportExpression" ||
+    (node.type === "MetaProperty" && node.meta.name === "import") ||
+    (node.type === "CallExpression" && isModuleLoaderCallee(node.callee))
+  ) {
+    return true;
+  }
+
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        if (
+          child !== null &&
+          typeof child === "object" &&
+          "type" in child &&
+          typeof child.type === "string" &&
+          // SAFETY: Children are taken directly from Acorn's parsed AST.
+          containsModuleAccess(child as import("acorn").AnyNode)
+        ) {
+          return true;
+        }
+      }
+      continue;
+    }
+    if (
+      value !== null &&
+      typeof value === "object" &&
+      "type" in value &&
+      typeof value.type === "string" &&
+      // SAFETY: Child fields are taken directly from Acorn's parsed AST.
+      containsModuleAccess(value as import("acorn").AnyNode)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function typeScriptContainsModuleAccess(code: string, ts: typeof import("typescript")): boolean {
+  const source = ts.createSourceFile(
+    "code-mode.ts",
+    code,
+    ts.ScriptTarget.ES2022,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  const isLoaderCallee = (expression: import("typescript").Expression): boolean => {
+    if (ts.isParenthesizedExpression(expression)) {
+      return isLoaderCallee(expression.expression);
+    }
+    if (
+      ts.isBinaryExpression(expression) &&
+      expression.operatorToken.kind === ts.SyntaxKind.CommaToken
+    ) {
+      return isLoaderCallee(expression.right);
+    }
+    return ts.isIdentifier(expression) && expression.text === "require";
+  };
+
+  const visit = (node: import("typescript").Node): boolean => {
+    if (
+      ts.isImportDeclaration(node) ||
+      ts.isImportEqualsDeclaration(node) ||
+      (ts.isMetaProperty(node) && node.keywordToken === ts.SyntaxKind.ImportKeyword) ||
+      (ts.isCallExpression(node) &&
+        (node.expression.kind === ts.SyntaxKind.ImportKeyword || isLoaderCallee(node.expression)))
+    ) {
+      return true;
+    }
+    return ts.forEachChild(node, (child) => (visit(child) ? true : undefined)) === true;
+  };
+
+  return visit(source);
+}
+
+function rejectsModuleAccess(
+  code: string,
+  typescriptRuntime?: typeof import("typescript"),
+): boolean {
+  const parsed = parseCodeModeScriptSyntax(code);
+  if (parsed.ok) {
+    // The WASI guest has no host module loader. Only executable module syntax
+    // belongs in this early check; ordinary guest methods are not capabilities.
+    return containsModuleAccess(parsed.program);
+  }
+  if (typescriptRuntime) {
+    try {
+      return typeScriptContainsModuleAccess(code, typescriptRuntime);
+    } catch {
+      // Keep malformed input on the conservative lexical fallback.
+    }
+  }
+  const source = maskCodeLiteralsAndComments(code, typescriptRuntime);
+  return /\bimport\b\s*(?:\.|\(|["'`{*]|\w)|\brequire\b\s*\(/u.test(source);
+}
+
+export async function prepareSource(input: {
+  code: string;
+  language?: CodeModeLanguage;
+  config: Pick<CodeModeConfig, "languages">;
+}): Promise<string> {
+  const language = input.language ?? "javascript";
+  if (!input.config.languages.includes(language)) {
+    throw new ToolInputError(`code mode ${language} input is disabled.`);
+  }
+  if (language === "javascript") {
+    if (rejectsModuleAccess(input.code)) {
+      throw new ToolInputError("code mode module access is disabled.");
+    }
+    if (isShellLikeCodeModeSource(input.code)) {
+      throw new ToolInputError(CODE_MODE_SHELL_SOURCE_ERROR);
+    }
+    return input.code;
+  }
+  const ts = await loadCodeModeTypeScriptRuntime();
+  if (rejectsModuleAccess(input.code, ts)) {
+    throw new ToolInputError("code mode module access is disabled.");
+  }
+  const transformed = ts.transpileModule(input.code, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.ESNext,
+      importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
+      sourceMap: false,
+    },
+    reportDiagnostics: true,
+  });
+  const diagnostics = transformed.diagnostics ?? [];
+  if (diagnostics.some((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error)) {
+    const message = diagnostics
+      .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))
+      .join("\n");
+    throw new ToolInputError(`typescript transform failed: ${message}`);
+  }
+  if (rejectsModuleAccess(transformed.outputText, ts)) {
+    throw new ToolInputError("code mode module access is disabled.");
+  }
+  if (
+    isShellLikeCodeModeSource(input.code, transformed.outputText) ||
+    isShellLikeCodeModeSource(transformed.outputText)
+  ) {
+    throw new ToolInputError(CODE_MODE_SHELL_SOURCE_ERROR);
+  }
+  return transformed.outputText;
+}

--- a/src/agents/code-mode-worker-lifecycle.test.ts
+++ b/src/agents/code-mode-worker-lifecycle.test.ts
@@ -75,6 +75,36 @@ afterEach(() => {
 });
 
 describe("Code Mode worker lifecycle", () => {
+  it("isolates guest globals, bridge failures, and cancellations across warm executions", async () => {
+    const config = resolveCodeModeConfig({
+      tools: { codeMode: { enabled: true, maxPendingToolCalls: 1 } },
+    } as never);
+    const execute = (source: string) =>
+      runCodeModeWorker({ kind: "exec", source, config, catalog: [] }, 10_000);
+
+    expect(
+      await execute(
+        "globalThis.previousRun = true; setTimeout(() => {}, 1); setTimeout(() => {}, 2);",
+      ),
+    ).toMatchObject({ status: "failed", code: "invalid_input" });
+    const cancelled = await execute(
+      'const timer = setTimeout(() => {}, 1); clearTimeout(timer); await yield_control("pause");',
+    );
+    expect(cancelled).toMatchObject({
+      status: "waiting",
+      canceledRequestIds: ["bridge:sleep:1"],
+    });
+    expect(await execute('await yield_control("next session");')).toMatchObject({
+      status: "waiting",
+      canceledRequestIds: [],
+      pendingRequests: [{ id: "bridge:yield:1", method: "yield" }],
+    });
+    expect(await execute("return typeof globalThis.previousRun;")).toMatchObject({
+      status: "completed",
+      value: { kind: "complete", json: '"undefined"' },
+    });
+  });
+
   it.each(["exec", "resume"] as const)(
     "terminates a real CPU-active %s worker when its catalog closes",
     async (phase) => {
@@ -149,8 +179,10 @@ describe("Code Mode worker lifecycle", () => {
       await executing.promise;
       clearToolSearchCatalog(h.ctx);
       expect(resultDetails(await execution)).toMatchObject({ status: "failed", code: "aborted" });
-      expect(terminate).toHaveBeenCalledOnce();
-      const worker = terminate.mock.contexts[0];
+      // Changing the runtime entry also retires idle warm workers. The active
+      // CPU worker is the last termination, and must stop before abort settles.
+      expect(terminate).toHaveBeenCalled();
+      const worker = terminate.mock.contexts.at(-1);
       if (!(worker instanceof Worker)) {
         throw new Error("Expected a terminated real worker");
       }
@@ -279,12 +311,15 @@ describe("Code Mode worker lifecycle", () => {
     const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
     const workerUrl = new URL(
       `data:text/javascript,${encodeURIComponent(`
-        import { parentPort, workerData } from "node:worker_threads";
-        parentPort.postMessage({
-          status: "completed",
-          value: { kind: "complete", json: JSON.stringify(workerData.wasmModule instanceof WebAssembly.Module) },
-          output: { count: 0, source: { kind: "complete", json: "[]" } },
-        });
+        import { parentPort } from "node:worker_threads";
+        parentPort.on("message", ({ input }) => parentPort.postMessage({
+          status: "ok",
+          value: {
+            status: "completed",
+            value: { kind: "complete", json: JSON.stringify(input.wasmModule instanceof WebAssembly.Module) },
+            output: { count: 0, source: { kind: "complete", json: "[]" } },
+          },
+        }));
       `)}`,
     );
 

--- a/src/agents/code-mode-worker-types.ts
+++ b/src/agents/code-mode-worker-types.ts
@@ -16,7 +16,10 @@ type CodeModeBridgeMethod =
   | "sleep"
   | "swarmNote";
 
+export type CodeModeLanguage = "javascript" | "typescript";
+
 export type CodeModeConfig = {
+  languages: CodeModeLanguage[];
   timeoutMs: number;
   memoryLimitBytes: number;
   maxOutputBytes: number;
@@ -49,6 +52,9 @@ type CodeModeWorkerInput =
   | {
       kind: "exec";
       source: string;
+      language?: CodeModeLanguage;
+      prelude?: string;
+      executionTimeoutMs?: number;
       config: CodeModeConfig;
       catalog: unknown[];
       apiFiles?: CodeModeApiVirtualFile[];

--- a/src/agents/code-mode-worker.ts
+++ b/src/agents/code-mode-worker.ts
@@ -1,9 +1,9 @@
 import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
-import { Worker } from "node:worker_threads";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import { WorkerTaskError, WorkerTaskPool } from "../infra/worker-task-pool.js";
 import { EMPTY_CODE_MODE_OUTPUT } from "./code-mode-json.js";
 import type { CodeModeFailureCode, CodeModeWorkerResult } from "./code-mode-runtime.js";
 
@@ -61,8 +61,16 @@ export function normalizeCodeModeTimeoutResult<
   return result;
 }
 
-export function normalizeCodeModeWorkerResult(result: CodeModeWorkerResult): CodeModeWorkerResult {
-  return normalizeCodeModeTimeoutResult(result);
+let sharedPool: { url: string; pool: WorkerTaskPool<unknown, unknown> } | undefined;
+
+function getCodeModePool(url: URL): WorkerTaskPool<unknown, unknown> {
+  if (sharedPool?.url !== url.href) {
+    // A runtime entry change retires its old workers; ordinary runs reuse the
+    // process-stable entry while each request still creates an isolated VM.
+    void sharedPool?.pool.close();
+    sharedPool = { url: url.href, pool: new WorkerTaskPool({ workerUrl: url }) };
+  }
+  return sharedPool.pool;
 }
 
 export async function runCodeModeWorker(
@@ -71,110 +79,63 @@ export async function runCodeModeWorker(
   workerUrl?: URL,
   signal?: AbortSignal,
 ): Promise<CodeModeWorkerResult> {
-  const resolvedWorkerUrl = workerUrl ?? codeModeWorkerUrl();
-  const sourceWorkerExecArgv = resolvedWorkerUrl.pathname.endsWith(".ts")
-    ? ["--import", "tsx"]
-    : undefined;
-  let worker: Worker | undefined;
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  let onAbort: (() => void) | undefined;
+  const pool = workerUrl
+    ? new WorkerTaskPool<unknown, unknown>({ workerUrl, maxWorkers: 1 })
+    : getCodeModePool(codeModeWorkerUrl());
+  const startedAt = performance.now();
   try {
-    return await new Promise<CodeModeWorkerResult>((resolve) => {
-      let settled = false;
-      const finish = (result: CodeModeWorkerResult) => {
-        if (settled) {
-          return;
+    const message = await pool.run(
+      async () => {
+        const wasmModule = await getQuickJsWasmModule();
+        if (!isRecord(workerData)) {
+          return workerData;
         }
-        settled = true;
-        resolve(result);
-      };
-      timer = setTimeout(() => {
-        finish({
-          status: "failed",
-          error: "code mode worker timeout exceeded",
-          code: "timeout",
-          failurePhase: "host",
-          bridgeDispatchStarted: false,
-          output: EMPTY_CODE_MODE_OUTPUT,
-        });
-      }, timeoutMs);
-      onAbort = () => {
-        const abortReason = signal?.reason;
-        finish({
-          status: "failed",
-          error:
-            abortReason instanceof CodeModeHeadlessTimeoutError
-              ? "code mode timeout exceeded"
-              : "code mode execution aborted",
-          code: abortReason instanceof CodeModeHeadlessTimeoutError ? "timeout" : "aborted",
-          failurePhase: "host",
-          bridgeDispatchStarted: false,
-          output: EMPTY_CODE_MODE_OUTPUT,
-        });
-      };
-      signal?.addEventListener("abort", onAbort, { once: true });
-      if (signal?.aborted) {
-        onAbort();
-        return;
-      }
-
-      // Compilation is part of the same execution deadline. A timed-out or
-      // aborted initialization must never create a worker after settlement.
-      void getQuickJsWasmModule().then(
-        (wasmModule) => {
-          if (settled) {
-            return;
-          }
-          try {
-            worker = new Worker(resolvedWorkerUrl, {
-              workerData: isRecord(workerData) ? { ...workerData, wasmModule } : workerData,
-              execArgv: sourceWorkerExecArgv,
-            });
-          } catch (error) {
-            finish(failedCodeModeWorkerResult(error, "runtime_unavailable"));
-            return;
-          }
-
-          worker.once("message", (message: unknown) => {
-            const result = isRecord(message)
-              ? (message as CodeModeWorkerResult)
-              : ({
-                  status: "failed",
-                  error: "invalid code mode worker response",
-                  code: "internal_error",
-                  failurePhase: "host",
-                  bridgeDispatchStarted: false,
-                  output: EMPTY_CODE_MODE_OUTPUT,
-                } satisfies CodeModeWorkerResult);
-            finish(normalizeCodeModeWorkerResult(result));
-          });
-          worker.once("error", (error) => {
-            finish(failedCodeModeWorkerResult(error, "runtime_unavailable"));
-          });
-          worker.once("exit", (code) => {
-            // A clean exit without a response is still unavailable; `finish`
-            // prevents normal message-then-exit from replacing a real result.
-            finish(
-              failedCodeModeWorkerResult(
-                new Error(`code mode worker exited with code ${code} before returning a result`),
-                "runtime_unavailable",
-              ),
-            );
-          });
-        },
-        (error: unknown) => {
-          finish(failedCodeModeWorkerResult(error, "runtime_unavailable"));
-        },
+        const config = isRecord(workerData.config) ? workerData.config : undefined;
+        return {
+          ...workerData,
+          wasmModule,
+          // Queueing and initialization consume the same guest budget as
+          // parsing and execution; admission must not restart the deadline.
+          ...(config && typeof config.timeoutMs === "number"
+            ? {
+                config: {
+                  ...config,
+                  timeoutMs: Math.max(0, config.timeoutMs - (performance.now() - startedAt)),
+                },
+              }
+            : {}),
+        };
+      },
+      {
+        timeoutMs,
+        signal,
+        // A committed resume consumes this snapshot. Failure already closes
+        // the run, so transferring ownership avoids copying its entire heap.
+        transferList: (input) =>
+          isRecord(input) && input.snapshotBytes instanceof Uint8Array
+            ? [input.snapshotBytes.buffer as ArrayBuffer] // SAFETY: QuickJS allocates a dedicated ArrayBuffer.
+            : [],
+      },
+    );
+    return isRecord(message)
+      ? normalizeCodeModeTimeoutResult(message as CodeModeWorkerResult)
+      : failedCodeModeWorkerResult("invalid code mode worker response", "internal_error");
+  } catch (error) {
+    if (signal?.aborted) {
+      return failedCodeModeWorkerResult(
+        signal.reason instanceof CodeModeHeadlessTimeoutError
+          ? "code mode timeout exceeded"
+          : "code mode execution aborted",
+        signal.reason instanceof CodeModeHeadlessTimeoutError ? "timeout" : "aborted",
       );
-    });
+    }
+    return error instanceof WorkerTaskError && error.code === "timeout"
+      ? failedCodeModeWorkerResult("code mode worker timeout exceeded", "timeout")
+      : failedCodeModeWorkerResult(error, "runtime_unavailable");
   } finally {
-    if (timer) {
-      clearTimeout(timer);
+    if (workerUrl) {
+      await pool.close();
     }
-    if (onAbort) {
-      signal?.removeEventListener("abort", onAbort);
-    }
-    await worker?.terminate();
   }
 }
 

--- a/src/agents/code-mode.guest-source.test.ts
+++ b/src/agents/code-mode.guest-source.test.ts
@@ -2,7 +2,8 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { prepareSource, resolveCodeModeConfig } from "./code-mode-runtime.js";
+import { resolveCodeModeConfig } from "./code-mode-runtime.js";
+import { prepareSource } from "./code-mode-source.js";
 import { applyCodeModeCatalog } from "./code-mode.js";
 import {
   resetCodeModeTestState,

--- a/src/agents/code-mode.limits.test.ts
+++ b/src/agents/code-mode.limits.test.ts
@@ -403,7 +403,7 @@ describe("Code Mode runtime and output limits", () => {
       codeModeFailureCode(new Error("interrupted", { cause: new Error("worker stopped") })),
     ).toBe("timeout");
     expect(
-      testing.normalizeCodeModeWorkerResult({
+      testing.normalizeCodeModeTimeoutResult({
         status: "failed",
         code: "timeout",
         error: "interrupted",
@@ -417,7 +417,7 @@ describe("Code Mode runtime and output limits", () => {
     });
 
     expect(
-      testing.normalizeCodeModeWorkerResult({
+      testing.normalizeCodeModeTimeoutResult({
         status: "failed",
         code: "internal_error",
         error: "interrupted",
@@ -491,7 +491,7 @@ describe("Code Mode runtime and output limits", () => {
     expect(result).toMatchObject({
       status: "failed",
       code: "runtime_unavailable",
-      error: "code mode worker exited with code 0 before returning a result",
+      error: expect.stringContaining("worker exited with code 0"),
     });
   });
 

--- a/src/agents/code-mode.test-support.ts
+++ b/src/agents/code-mode.test-support.ts
@@ -9,7 +9,7 @@ import {
   removeExpiredRuns,
   resumingRunIds,
 } from "./code-mode-state.js";
-import { normalizeCodeModeWorkerResult, runCodeModeWorker } from "./code-mode-worker.js";
+import { normalizeCodeModeTimeoutResult, runCodeModeWorker } from "./code-mode-worker.js";
 import { createCodeModeTools } from "./code-mode.js";
 import {
   createToolSearchCatalogRef,
@@ -24,7 +24,7 @@ export const testing = {
   resumingRunIds,
   codeModeReplayIdForToolCall,
   removeExpiredRuns,
-  normalizeCodeModeWorkerResult,
+  normalizeCodeModeTimeoutResult,
   runCodeModeWorker,
   resolveCodeModeHeadlessConfig,
 };

--- a/src/agents/code-mode.typescript.test.ts
+++ b/src/agents/code-mode.typescript.test.ts
@@ -1,16 +1,20 @@
 /** Tests Code Mode TypeScript execution. */
 
+import { writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { BroadcastChannel, Worker } from "node:worker_threads";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-const loadCodeModeTypeScriptRuntime = vi.hoisted(() =>
-  vi.fn<() => Promise<typeof import("typescript")>>(),
-);
-
-vi.mock("./code-mode-typescript-runtime.js", () => ({
-  loadCodeModeTypeScriptRuntime,
-}));
-import { applyCodeModeCatalog, runCodeModeScriptHeadless } from "./code-mode.js";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import * as workerUrls from "../infra/runtime-worker-url.js";
+import {
+  applyCodeModeCatalog,
+  createCodeModeTools,
+  runCodeModeScriptHeadless,
+} from "./code-mode.js";
 import {
   resetCodeModeTestState,
   pluginTool,
@@ -19,17 +23,47 @@ import {
   runUntilCompleted,
   testing,
 } from "./code-mode.test-support.js";
-import { registerHeadlessToolSearchCatalog } from "./tool-search.js";
+import { clearToolSearchCatalog, registerHeadlessToolSearchCatalog } from "./tool-search.js";
+
+async function observeTypeScriptPreparation(source: string) {
+  const tempDirs = useAutoCleanupTempDirTracker(onTestFinished);
+  const dir = tempDirs.make("code-mode-typescript-load-");
+  const channelName = `typescript-load-${crypto.randomUUID()}`;
+  const channel = new BroadcastChannel(channelName);
+  onTestFinished(() => channel.close());
+  const loading = createDeferred();
+  channel.addEventListener("message", () => loading.resolve(), { once: true });
+  await writeFile(
+    path.join(dir, "observed-typescript.mjs"),
+    `import { BroadcastChannel } from "node:worker_threads";
+     new BroadcastChannel(${JSON.stringify(channelName)}).postMessage("loading");
+     ${source}`,
+  );
+  const workerPath = path.join(dir, "observed-worker.ts");
+  await writeFile(path.join(dir, "package.json"), '{"type":"module"}');
+  // Observe the real worker's lazy import; parent-isolate mocks cannot prove this boundary.
+  await writeFile(
+    workerPath,
+    `import { registerHooks } from "node:module";
+     registerHooks({ resolve(specifier, context, nextResolve) {
+       return specifier === "typescript"
+         ? { url: new URL("./observed-typescript.mjs", import.meta.url).href, shortCircuit: true }
+         : nextResolve(specifier, context);
+     }});
+     await import(${JSON.stringify(new URL("./code-mode.worker.ts", import.meta.url).href)});`,
+  );
+  const resolveWorker = vi
+    .spyOn(workerUrls, "resolveRuntimeWorkerUrl")
+    .mockReturnValue(pathToFileURL(workerPath));
+  onTestFinished(() => resolveWorker.mockRestore());
+  const terminate = vi.spyOn(Worker.prototype, "terminate");
+  onTestFinished(() => terminate.mockRestore());
+  return { loading: loading.promise, terminate };
+}
 
 describe("Code Mode TypeScript execution", () => {
-  beforeEach(async () => {
-    vi.useRealTimers();
-    loadCodeModeTypeScriptRuntime.mockResolvedValue(await import("typescript"));
-  });
-
   afterEach(() => {
     vi.useRealTimers();
-    loadCodeModeTypeScriptRuntime.mockReset();
     resetCodeModeTestState();
   });
 
@@ -116,100 +150,109 @@ describe("Code Mode TypeScript execution", () => {
     expect(testing.activeRuns.size).toBe(0);
   });
 
-  it.each([-1, 1])(
-    "keeps the headless budget when TypeScript preparation shifts the wall clock by %i",
-    async (clockDirection) => {
-      const typescriptRuntime = await import("typescript");
-      const initialWallClockMs = Date.now();
-      let wallClockJumpMs = 0;
-      const wallClock = vi
-        .spyOn(Date, "now")
-        .mockImplementation(() => initialWallClockMs + wallClockJumpMs);
-      try {
-        loadCodeModeTypeScriptRuntime.mockImplementation(async () => {
-          wallClockJumpMs = clockDirection * 60_000;
-          return typescriptRuntime;
-        });
-        const { ctx, catalogRef } = createCodeModeHarness();
-        registerHeadlessToolSearchCatalog({ catalogRef, tools: [] });
-
-        const result = await runCodeModeScriptHeadless({
-          ctx,
-          language: "typescript",
-          code: "const value: number = 42; return value;",
-          wallClockMs: 30_000,
-        });
-
-        expect(result).toMatchObject({ status: "completed", value: 42 });
-        expect(loadCodeModeTypeScriptRuntime).toHaveBeenCalledOnce();
-      } finally {
-        wallClock.mockRestore();
+  it.each(
+    (["exec", "headless"] as const).flatMap((mode) =>
+      (["aborted", "timeout"] as const).map((outcome) => ({ mode, outcome })),
+    ),
+  )(
+    "stops $mode source preparation on $outcome before any tool dispatch",
+    async ({ mode, outcome }) => {
+      const { loading, terminate } = await observeTypeScriptPreparation(
+        "await new Promise(() => {});",
+      );
+      const h = createCodeModeHarness();
+      const tool = pluginTool("fake_noop", "Noop");
+      onTestFinished(() => clearToolSearchCatalog(h.ctx));
+      (h.config as { tools: { codeMode: unknown } }).tools.codeMode = {
+        enabled: true,
+        timeoutMs: 1_000,
+      };
+      // Controls capture limits once; construct them after applying this execution's budget.
+      const codeModeTools = createCodeModeTools(h.ctx);
+      if (mode === "headless") {
+        registerHeadlessToolSearchCatalog({ catalogRef: h.catalogRef, tools: [tool] });
+      } else {
+        applyCodeModeCatalog({ ...h.ctx, tools: [...codeModeTools, tool] });
       }
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const controller = new AbortController();
+      const code = "await fake_noop({}); return 42;";
+      const execution =
+        mode === "headless"
+          ? runCodeModeScriptHeadless({
+              ctx: h.ctx,
+              code,
+              language: "typescript",
+              wallClockMs: 1_000,
+              signal: controller.signal,
+            })
+          : expectDefined(codeModeTools[0], "Code Mode exec test invariant")
+              .execute("typescript-load", { code, language: "typescript" }, controller.signal)
+              .then(resultDetails);
+      onTestFinished(async () => {
+        controller.abort();
+        await execution;
+      });
+      await Promise.race([
+        loading,
+        execution.then((result) => {
+          throw new Error(`Code Mode settled before source preparation: ${JSON.stringify(result)}`);
+        }),
+      ]);
+      if (outcome === "aborted") {
+        controller.abort();
+      } else {
+        await vi.advanceTimersByTimeAsync(3_000);
+      }
+      expect(await execution).toMatchObject({ status: "failed", code: outcome, output: [] });
+      expect(tool.execute).not.toHaveBeenCalled();
+      expect(terminate).toHaveBeenCalled();
+      const worker = terminate.mock.contexts.at(-1);
+      expect(worker).toBeInstanceOf(Worker);
+      expect((worker as Worker).threadId).toBe(-1);
+      expect(testing.activeRuns.size).toBe(0);
     },
   );
 
-  it("times out an unfinished TypeScript runtime load without starting a worker", async () => {
-    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
-    (config as { tools: { codeMode: unknown } }).tools.codeMode = {
-      enabled: true,
-      timeoutMs: 100,
-    };
-    applyCodeModeCatalog({
-      tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
-      config,
-      sessionId: "session-code-mode",
-      sessionKey: "agent:main:main",
-      runId: "run-code-mode",
-      catalogRef,
-    });
-    loadCodeModeTypeScriptRuntime.mockReturnValue(new Promise(() => {}));
-
-    const result = resultDetails(
-      await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
-        "code-call-typescript-load-timeout",
-        { code: "return 42;", language: "typescript" },
-      ),
-    );
-
-    expect(result).toMatchObject({
-      status: "failed",
-      code: "timeout",
-      error: "code mode timeout exceeded",
-      failurePhase: "host",
-      bridgeDispatchStarted: false,
-      output: [],
-    });
-    expect(testing.activeRuns.size).toBe(0);
-  });
-
-  it("aborts an unfinished TypeScript runtime load without starting a worker", async () => {
-    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
-    applyCodeModeCatalog({
-      tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
-      config,
-      sessionId: "session-code-mode",
-      sessionKey: "agent:main:main",
-      runId: "run-code-mode",
-      catalogRef,
-    });
-    loadCodeModeTypeScriptRuntime.mockReturnValue(new Promise(() => {}));
-    const controller = new AbortController();
-    const resultPromise = expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
-      "code-call-typescript-load-abort",
-      { code: "return 42;", language: "typescript" },
-      controller.signal,
-    );
-
-    controller.abort();
-
-    expect(resultDetails(await resultPromise)).toMatchObject({
-      status: "failed",
-      code: "aborted",
-      error: "code mode execution aborted",
-      failurePhase: "host",
-      bridgeDispatchStarted: false,
-      output: [],
-    });
-    expect(testing.activeRuns.size).toBe(0);
-  });
+  it.each([
+    {
+      name: "short guest",
+      code: "const value: number = 42; return value;",
+      expected: { status: "completed", value: 42 },
+    },
+    {
+      name: "CPU-bound guest",
+      code: "while (true) {}",
+      expected: { status: "failed", code: "timeout" },
+    },
+  ])(
+    "keeps headless preparation outside the guest budget for a $name",
+    async ({ code, expected }) => {
+      const typescriptUrl = pathToFileURL(createRequire(import.meta.url).resolve("typescript"));
+      const { loading } = await observeTypeScriptPreparation(`
+      export * from ${JSON.stringify(typescriptUrl.href)};
+      const now = performance.now.bind(performance);
+      Object.defineProperty(performance, "now", { value: () => now() + 2_000 });
+    `);
+      const h = createCodeModeHarness();
+      registerHeadlessToolSearchCatalog({ catalogRef: h.catalogRef, tools: [] });
+      onTestFinished(() => clearToolSearchCatalog(h.ctx));
+      const controller = new AbortController();
+      const execution = runCodeModeScriptHeadless({
+        ctx: h.ctx,
+        code,
+        language: "typescript",
+        overrides: { timeoutMs: 100 },
+        wallClockMs: 10_000,
+        signal: controller.signal,
+      });
+      onTestFinished(async () => {
+        controller.abort();
+        await execution;
+      });
+      const [, result] = await Promise.all([loading, execution]);
+      expect(result).toMatchObject({ ...expected, toolCallCount: 0 });
+    },
+    15_000,
+  );
 });

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -1,9 +1,9 @@
 /**
  * QuickJS worker for Code Mode guest execution and suspended VM snapshots.
  */
-import { parentPort, workerData } from "node:worker_threads";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { EvalFlags, JSException, QuickJS, type JSValueHandle } from "quickjs-wasi";
+import { serveWorkerTasks } from "../infra/worker-task-pool.js";
 import { CODE_MODE_CONTROLLER_SOURCE } from "./code-mode-controller-source.js";
 import {
   boundCodeModeError,
@@ -13,8 +13,10 @@ import {
   toCodeModeJsonSafe as toJsonSafe,
 } from "./code-mode-json.js";
 import type { CodeModeApiVirtualFile } from "./code-mode-namespaces.js";
+import { prepareSource } from "./code-mode-source.js";
 import type {
   CodeModeConfig,
+  CodeModeLanguage,
   CodeModeNamespaceDescriptor,
   CodeModeWorkerPayload,
   CodeModeVmResult as CodeModeWorkerResult,
@@ -22,6 +24,7 @@ import type {
   PendingBridgeRequest,
   SettledBridgeRequest,
 } from "./code-mode-worker-types.js";
+import { ToolInputError } from "./tool-input-error.js";
 class CodeModeWorkerFailure extends Error {
   readonly code: Extract<CodeModeWorkerResult, { status: "failed" }>["code"];
 
@@ -41,9 +44,13 @@ type VmRun = {
   didTimeout: () => boolean;
 };
 
-// Each worker handles exactly one exec/resume payload, so bridge state is run-scoped.
-const canceledBridgeRequestIds: string[] = [];
-let bridgeAdmissionFailure: CodeModeWorkerFailure | undefined;
+// Workers are reusable; every VM owns its own bridge state, including failures
+// and cancellations, so a later session cannot inherit a previous run's state.
+type BridgeState = {
+  pendingRequests: PendingBridgeRequest[];
+  canceledRequestIds: string[];
+  admissionFailure?: CodeModeWorkerFailure;
+};
 
 // QuickJS error stacks are backtrace frames only ("    at file:line:col"), with
 // no leading "Name: message" header like V8. Returning .stack alone therefore
@@ -87,7 +94,7 @@ function trackPromiseRejection(
 
 function createHostRequestHandler(params: {
   vm: QuickJS;
-  pendingRequests: PendingBridgeRequest[];
+  bridge: BridgeState;
   config: CodeModeConfig;
 }): (
   this: JSValueHandle,
@@ -96,12 +103,12 @@ function createHostRequestHandler(params: {
   bridgeId?: JSValueHandle,
 ) => JSValueHandle {
   return (methodHandle, argsHandle, bridgeIdHandle) => {
-    if (params.pendingRequests.length >= params.config.maxPendingToolCalls) {
-      bridgeAdmissionFailure ??= new CodeModeWorkerFailure(
+    if (params.bridge.pendingRequests.length >= params.config.maxPendingToolCalls) {
+      params.bridge.admissionFailure ??= new CodeModeWorkerFailure(
         "invalid_input",
         "too many pending code mode tool calls",
       );
-      throw bridgeAdmissionFailure;
+      throw params.bridge.admissionFailure;
     }
     const method = methodHandle.toString();
     if (
@@ -132,12 +139,12 @@ function createHostRequestHandler(params: {
     if (!id?.startsWith(`bridge:${method}:`) || !/^bridge:[A-Za-z]+:[1-9]\d*$/u.test(id)) {
       throw new Error("invalid code mode bridge id");
     }
-    if (params.pendingRequests.some((request) => request.id === id)) {
+    if (params.bridge.pendingRequests.some((request) => request.id === id)) {
       throw new Error("duplicate code mode bridge id");
     }
     // The guest receives only an opaque id. Host-side tool execution and policy
     // happen after the worker returns a waiting snapshot.
-    params.pendingRequests.push({
+    params.bridge.pendingRequests.push({
       id,
       method,
       args: Array.isArray(args) ? args : [],
@@ -148,106 +155,69 @@ function createHostRequestHandler(params: {
 
 function createHostCancelRequestHandler(params: {
   vm: QuickJS;
-  pendingRequests: PendingBridgeRequest[];
+  bridge: BridgeState;
 }): (this: JSValueHandle, id: JSValueHandle) => JSValueHandle {
   return (idHandle) => {
     const id = idHandle.toString();
-    const index = params.pendingRequests.findIndex((request) => request.id === id);
+    const index = params.bridge.pendingRequests.findIndex((request) => request.id === id);
     if (index >= 0) {
       // Return the cancellation to the parent owner as well as removing it
       // locally; restored requests may already have a live host operation.
-      params.pendingRequests.splice(index, 1);
-      canceledBridgeRequestIds.push(id);
+      params.bridge.pendingRequests.splice(index, 1);
+      params.bridge.canceledRequestIds.push(id);
     }
     return params.vm.undefined;
   };
 }
 
-async function createVm(params: {
-  wasmModule: WebAssembly.Module;
-  catalog: unknown[];
-  apiFiles: CodeModeApiVirtualFile[];
-  namespaces: CodeModeNamespaceDescriptor[];
-  swarmEnabled: boolean;
-  config: CodeModeConfig;
-  pendingRequests: PendingBridgeRequest[];
-}): Promise<VmRun> {
+async function createVm(input: CodeModeWorkerPayload, bridge: BridgeState): Promise<VmRun> {
   const startedAt = performance.now();
   let timedOut = false;
-  const deadlineReached = () => performance.now() - startedAt >= params.config.timeoutMs;
-  const vm = await QuickJS.create({
-    wasm: params.wasmModule,
-    memoryLimit: params.config.memoryLimitBytes,
+  const deadlineReached = () => performance.now() - startedAt >= input.config.timeoutMs;
+  const options = {
+    wasm: input.wasmModule,
+    memoryLimit: input.config.memoryLimitBytes,
     timezoneOffset: 0,
     onUnhandledRejection: trackPromiseRejection,
     interruptHandler: () => {
       timedOut = deadlineReached();
       return timedOut;
     },
-  });
-  vm.hostToHandle(params.catalog).consume((handle) =>
-    vm.global.setProp("__openclawCatalog", handle),
-  );
-  vm.hostToHandle(params.namespaces).consume((handle) =>
-    vm.global.setProp("__openclawNamespaces", handle),
-  );
-  vm.hostToHandle(params.apiFiles).consume((handle) =>
-    vm.global.setProp("__openclawApiFiles", handle),
-  );
-  vm.hostToHandle(params.swarmEnabled).consume((handle) =>
-    vm.global.setProp("__openclawSwarmEnabled", handle),
-  );
-  vm.newFunction(
-    "__openclawHostRequest",
-    createHostRequestHandler({
-      vm,
-      pendingRequests: params.pendingRequests,
-      config: params.config,
-    }),
-  ).consume((hostRequest) => vm.global.setProp("__openclawHostRequest", hostRequest));
-  vm.newFunction(
-    "__openclawHostCancelRequest",
-    createHostCancelRequestHandler({ vm, pendingRequests: params.pendingRequests }),
-  ).consume((hostCancelRequest) =>
-    vm.global.setProp("__openclawHostCancelRequest", hostCancelRequest),
-  );
-  vm.evalCode(CODE_MODE_CONTROLLER_SOURCE, "openclaw-code-mode:controller.js").dispose();
-  return { vm, didTimeout: () => timedOut || deadlineReached() };
-}
-
-async function restoreVm(params: {
-  wasmModule: WebAssembly.Module;
-  snapshotBytes: Uint8Array;
-  config: CodeModeConfig;
-  pendingRequests: PendingBridgeRequest[];
-}): Promise<VmRun> {
-  const startedAt = performance.now();
-  let timedOut = false;
-  const deadlineReached = () => performance.now() - startedAt >= params.config.timeoutMs;
-  const snapshot = QuickJS.deserializeSnapshot(params.snapshotBytes);
-  const vm = await QuickJS.restore(snapshot, {
-    wasm: params.wasmModule,
-    memoryLimit: params.config.memoryLimitBytes,
-    timezoneOffset: 0,
-    onUnhandledRejection: trackPromiseRejection,
-    interruptHandler: () => {
-      timedOut = deadlineReached();
-      return timedOut;
-    },
-  });
-  vm.registerHostCallback(
-    "__openclawHostRequest",
-    createHostRequestHandler({
-      vm,
-      pendingRequests: params.pendingRequests,
-      config: params.config,
-    }),
-  );
-  vm.registerHostCallback(
-    "__openclawHostCancelRequest",
-    createHostCancelRequestHandler({ vm, pendingRequests: params.pendingRequests }),
-  );
-  return { vm, didTimeout: () => timedOut || deadlineReached() };
+  };
+  const vm =
+    input.kind === "resume"
+      ? await QuickJS.restore(QuickJS.deserializeSnapshot(input.snapshotBytes), options)
+      : await QuickJS.create(options);
+  try {
+    const callbacks = [
+      ["__openclawHostRequest", createHostRequestHandler({ vm, bridge, config: input.config })],
+      ["__openclawHostCancelRequest", createHostCancelRequestHandler({ vm, bridge })],
+    ] as const;
+    for (const [name, callback] of callbacks) {
+      if (input.kind === "resume") {
+        // The snapshot owns the original function identities. Rebind callbacks
+        // by name without recreating globals the controller deliberately hides.
+        vm.registerHostCallback(name, callback);
+      } else {
+        vm.newFunction(name, callback).consume((handle) => vm.global.setProp(name, handle));
+      }
+    }
+    if (input.kind === "exec") {
+      for (const [name, value] of [
+        ["__openclawCatalog", input.catalog],
+        ["__openclawNamespaces", input.namespaces],
+        ["__openclawApiFiles", input.apiFiles ?? []],
+        ["__openclawSwarmEnabled", input.swarmEnabled === true],
+      ] as const) {
+        vm.hostToHandle(value).consume((handle) => vm.global.setProp(name, handle));
+      }
+      vm.evalCode(CODE_MODE_CONTROLLER_SOURCE, "openclaw-code-mode:controller.js").dispose();
+    }
+    return { vm, didTimeout: () => timedOut || deadlineReached() };
+  } catch (error) {
+    vm.dispose();
+    throw error;
+  }
 }
 
 function takeOutput(vm: QuickJS): unknown[] {
@@ -358,7 +328,7 @@ function serializeCompletedCatalogHandles(vm: QuickJS, value: JSValueHandle): un
 
 function waitingResult(params: {
   vm: QuickJS;
-  pendingRequests: PendingBridgeRequest[];
+  bridge: BridgeState;
   settlementMode: Extract<CodeModeWorkerResult, { status: "waiting" }>["settlementMode"];
   output: unknown[];
   config: CodeModeConfig;
@@ -370,8 +340,8 @@ function waitingResult(params: {
   return {
     status: "waiting",
     snapshotBytes,
-    pendingRequests: params.pendingRequests,
-    canceledRequestIds: canceledBridgeRequestIds,
+    pendingRequests: params.bridge.pendingRequests,
+    canceledRequestIds: params.bridge.canceledRequestIds,
     settlementMode: params.settlementMode,
     output: params.output,
   };
@@ -380,7 +350,7 @@ function waitingResult(params: {
 async function runVmExecution(params: {
   vm: QuickJS;
   didTimeout: () => boolean;
-  pendingRequests: PendingBridgeRequest[];
+  bridge: BridgeState;
   config: CodeModeConfig;
   prepare: () => void;
 }): Promise<CodeModeWorkerResult> {
@@ -388,23 +358,23 @@ async function runVmExecution(params: {
   try {
     params.prepare();
     params.vm.executePendingJobs();
-    if (bridgeAdmissionFailure) {
-      throw bridgeAdmissionFailure;
+    if (params.bridge.admissionFailure) {
+      throw params.bridge.admissionFailure;
     }
     output = takeOutput(params.vm);
     const resultHandle = params.vm.global.getProp("__openclawResult");
     try {
       const promisePending = resultHandle.isPromise && resultHandle.promiseState === 0;
-      if (promisePending && params.pendingRequests.length === 0) {
+      if (promisePending && params.bridge.pendingRequests.length === 0) {
         throw new Error("code mode promise is pending without host work");
       }
-      const requiredPendingRequestIds = params.pendingRequests.map((request) => request.id);
+      const requiredPendingRequestIds = params.bridge.pendingRequests.map((request) => request.id);
       if (promisePending || requiredPendingRequestIds.length > 0) {
         // Native await does not expose Promise ownership. Every dispatched
         // call remains required, including detached calls and race branches.
         return waitingResult({
           vm: params.vm,
-          pendingRequests: params.pendingRequests,
+          bridge: params.bridge,
           settlementMode: promisePending
             ? { kind: "awaiting" }
             : { kind: "draining", requiredRequestIds: requiredPendingRequestIds },
@@ -435,48 +405,42 @@ async function runVmExecution(params: {
   }
 }
 
-async function runExec(input: Extract<CodeModeWorkerPayload, { kind: "exec" }>) {
-  const pendingRequests: PendingBridgeRequest[] = [];
-  const { vm, didTimeout } = await createVm({
-    wasmModule: input.wasmModule,
-    catalog: input.catalog,
-    apiFiles: input.apiFiles ?? [],
-    namespaces: input.namespaces,
-    swarmEnabled: input.swarmEnabled === true,
-    config: input.config,
-    pendingRequests,
-  });
+async function run(input: CodeModeWorkerPayload): Promise<CodeModeWorkerResult> {
+  const startedAt = performance.now();
+  const source =
+    input.kind === "exec"
+      ? await prepareSource({ code: input.source, language: input.language, config: input.config })
+      : "";
+  const config = {
+    ...input.config,
+    timeoutMs: Math.min(
+      input.config.timeoutMs - (performance.now() - startedAt),
+      input.kind === "exec" ? (input.executionTimeoutMs ?? Infinity) : Infinity,
+    ),
+  };
+  if (config.timeoutMs <= 0) {
+    throw new CodeModeWorkerFailure("timeout", "code mode timeout exceeded");
+  }
+  // Restored promises retain bridge IDs; unresolved siblings are not redispatched.
+  const bridge: BridgeState = {
+    pendingRequests: input.kind === "resume" ? [...(input.pendingRequests ?? [])] : [],
+    canceledRequestIds: [],
+  };
+  const { vm, didTimeout } = await createVm({ ...input, config }, bridge);
   return runVmExecution({
     vm,
     didTimeout,
-    pendingRequests,
-    config: input.config,
+    bridge,
+    config,
     prepare: () => {
-      vm.evalCode(
-        buildUserSource(input.source),
-        "openclaw-code-mode:user.js",
-        EvalFlags.ASYNC,
-      ).dispose();
-    },
-  });
-}
-
-async function runResume(input: Extract<CodeModeWorkerPayload, { kind: "resume" }>) {
-  // Restored promises keep their original bridge ids; do not redispatch calls
-  // that are still running when a faster sibling resumes this snapshot.
-  const pendingRequests: PendingBridgeRequest[] = [...(input.pendingRequests ?? [])];
-  const { vm, didTimeout } = await restoreVm({
-    wasmModule: input.wasmModule,
-    snapshotBytes: input.snapshotBytes,
-    config: input.config,
-    pendingRequests,
-  });
-  return runVmExecution({
-    vm,
-    didTimeout,
-    pendingRequests,
-    config: input.config,
-    prepare: () => {
+      if (input.kind === "exec") {
+        vm.evalCode(
+          buildUserSource(`${input.prelude ?? ""}${source}`),
+          "openclaw-code-mode:user.js",
+          EvalFlags.ASYNC,
+        ).dispose();
+        return;
+      }
       vm.global.getProp("__openclawSettleBridge").consume((settle) => {
         for (const request of input.settledRequests) {
           const id = vm.newString(request.id);
@@ -503,8 +467,7 @@ function isQuickJsWasmModule(value: unknown): value is WebAssembly.Module {
   return Object.prototype.toString.call(value) === "[object WebAssembly.Module]";
 }
 
-async function main(): Promise<CodeModeWorkerThreadResult> {
-  const input = workerData as unknown;
+async function main(input: unknown): Promise<CodeModeWorkerThreadResult> {
   if (!isRecord(input) || !isRecord(input.config) || !isQuickJsWasmModule(input.wasmModule)) {
     return {
       ...failedWorkerResult("invalid_input", "invalid code mode worker input"),
@@ -513,12 +476,19 @@ async function main(): Promise<CodeModeWorkerThreadResult> {
   }
   const config = input.config as CodeModeConfig;
   try {
+    if (config.timeoutMs <= 0) {
+      throw new CodeModeWorkerFailure("timeout", "code mode timeout exceeded");
+    }
     if (input.kind === "exec" && typeof input.source === "string") {
       return captureWorkerResult(
-        await runExec({
+        await run({
           kind: "exec",
           wasmModule: input.wasmModule,
           source: input.source,
+          language: input.language as CodeModeLanguage | undefined,
+          prelude: typeof input.prelude === "string" ? input.prelude : undefined,
+          executionTimeoutMs:
+            typeof input.executionTimeoutMs === "number" ? input.executionTimeoutMs : undefined,
           config,
           catalog: Array.isArray(input.catalog) ? input.catalog : [],
           apiFiles: Array.isArray(input.apiFiles)
@@ -534,7 +504,7 @@ async function main(): Promise<CodeModeWorkerThreadResult> {
     }
     if (input.kind === "resume" && input.snapshotBytes instanceof Uint8Array) {
       return captureWorkerResult(
-        await runResume({
+        await run({
           kind: "resume",
           wasmModule: input.wasmModule,
           snapshotBytes: input.snapshotBytes,
@@ -559,7 +529,9 @@ async function main(): Promise<CodeModeWorkerThreadResult> {
       ? "timeout"
       : error instanceof CodeModeWorkerFailure
         ? error.code
-        : "internal_error";
+        : error instanceof ToolInputError
+          ? "invalid_input"
+          : "internal_error";
     return captureWorkerResult(
       failedWorkerResult(code, timedOut ? "code mode timeout exceeded" : errorMessage(error)),
       config,
@@ -567,8 +539,8 @@ async function main(): Promise<CodeModeWorkerThreadResult> {
   }
 }
 
-if (parentPort) {
-  Reflect.apply(Reflect.get(parentPort, "postMessage") as (message: unknown) => void, parentPort, [
-    await main(),
-  ]);
-}
+serveWorkerTasks(main, {
+  transferList: (result) =>
+    // SAFETY: QuickJS.serializeSnapshot allocates a dedicated, transferable ArrayBuffer.
+    result.status === "waiting" ? [result.snapshotBytes.buffer as ArrayBuffer] : [],
+});

--- a/src/agents/compaction-planning-worker-runtime.ts
+++ b/src/agents/compaction-planning-worker-runtime.ts
@@ -1,10 +1,8 @@
-import { Worker } from "node:worker_threads";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
-import { toErrorObject } from "../infra/errors.js";
 import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import { WorkerTaskError, WorkerTaskPool } from "../infra/worker-task-pool.js";
 import type {
   CompactionPlanningWorkerInput,
-  CompactionPlanningWorkerResult,
   CompactionPlanningWorkerValue,
 } from "./compaction-planning.worker.js";
 
@@ -20,98 +18,44 @@ export class CompactionPlanningWorkerError extends Error {
   }
 }
 
-function compactionPlanningWorkerUrl(): URL {
-  return resolveRuntimeWorkerUrl({
+const planningPool = new WorkerTaskPool<
+  CompactionPlanningWorkerInput,
+  CompactionPlanningWorkerValue
+>({
+  workerUrl: resolveRuntimeWorkerUrl({
     currentModuleUrl: import.meta.url,
     sourceWorkerName: "compaction-planning.worker",
     distWorkerPath: "agents/compaction-planning.worker.js",
-  });
-}
+  }),
+});
 
-export function runCompactionPlanningWorker(params: {
+export async function runCompactionPlanningWorker(params: {
   input: CompactionPlanningWorkerInput;
   signal?: AbortSignal;
   timeoutMs?: number;
   workerUrl?: URL;
 }): Promise<CompactionPlanningWorkerValue> {
-  const abortError = () =>
-    toErrorObject(
-      params.signal?.reason ?? new Error("compaction planning aborted"),
-      "Non-Error rejection",
-    );
-  if (params.signal?.aborted) {
-    return Promise.reject(abortError());
-  }
-
-  const workerUrl = params.workerUrl ?? compactionPlanningWorkerUrl();
-  const sourceWorkerExecArgv = workerUrl.pathname.endsWith(".ts") ? ["--import", "tsx"] : undefined;
-  let worker: Worker;
+  const pool = params.workerUrl
+    ? new WorkerTaskPool<CompactionPlanningWorkerInput, CompactionPlanningWorkerValue>({
+        workerUrl: params.workerUrl,
+      })
+    : planningPool;
   try {
-    worker = new Worker(workerUrl, {
-      workerData: params.input,
-      execArgv: sourceWorkerExecArgv,
+    return await pool.run(params.input, {
+      timeoutMs: resolveTimerTimeoutMs(params.timeoutMs, COMPACTION_PLANNING_WORKER_TIMEOUT_MS),
+      signal: params.signal,
     });
   } catch (error) {
-    return Promise.reject(
-      new CompactionPlanningWorkerError(
-        error instanceof Error ? error.message : String(error),
-        "unavailable",
-      ),
-    );
-  }
-
-  worker.unref?.();
-
-  return new Promise<CompactionPlanningWorkerValue>((resolve, reject) => {
-    let settled = false;
-    const timeout = setTimeout(
-      () =>
-        fail(new CompactionPlanningWorkerError("compaction planning worker timed out", "timeout")),
-      resolveTimerTimeoutMs(params.timeoutMs, COMPACTION_PLANNING_WORKER_TIMEOUT_MS),
-    );
-    const abort = () => fail(abortError());
-
-    const settle = (finish: () => void, terminate: boolean) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeout);
-      params.signal?.removeEventListener("abort", abort);
-      worker.removeAllListeners();
-      if (terminate) {
-        void worker.terminate();
-      }
-      finish();
-    };
-    const fail = (error: Error, terminate = true) => settle(() => reject(error), terminate);
-
-    params.signal?.addEventListener("abort", abort, { once: true });
-
-    worker.once("message", (message: CompactionPlanningWorkerResult) => {
-      settle(() => {
-        if (message.status === "ok") {
-          resolve(message.value);
-          return;
-        }
-        reject(new CompactionPlanningWorkerError(message.error, "failed"));
-      }, false);
-    });
-    worker.once("error", (error) => {
-      const message = error instanceof Error ? error.message : String(error);
-      fail(new CompactionPlanningWorkerError(message, "unavailable"));
-    });
-    worker.once("exit", (code) => {
-      if (code === 0) {
-        return;
-      }
-      fail(
-        new CompactionPlanningWorkerError(
-          `compaction planning worker exited with code ${code}`,
-          "unavailable",
-        ),
-        false,
+    if (error instanceof WorkerTaskError && error !== params.signal?.reason) {
+      throw new CompactionPlanningWorkerError(
+        error.code === "timeout" ? "compaction planning worker timed out" : error.message,
+        error.code,
       );
-    });
-  });
+    }
+    throw error;
+  } finally {
+    if (params.workerUrl) {
+      await pool.close();
+    }
+  }
 }

--- a/src/agents/compaction-planning-worker.test.ts
+++ b/src/agents/compaction-planning-worker.test.ts
@@ -16,7 +16,10 @@ import {
   computeAdaptiveChunkRatioWithWorker,
 } from "./compaction-planning-worker.js";
 import { buildSummaryChunks, estimateMessagesTokens } from "./compaction-planning.js";
-import { runCompactionPlanningWorkerInput } from "./compaction-planning.worker.js";
+import {
+  type CompactionPlanningWorkerInput,
+  runCompactionPlanningWorkerInput,
+} from "./compaction-planning.worker.js";
 import { summarizeInStages } from "./compaction.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures.js";
@@ -72,7 +75,7 @@ describe("compaction planning worker", () => {
     });
   });
 
-  it("rejects invalid and retired worker input", () => {
+  it("rejects invalid and retired worker input", async () => {
     for (const input of [
       { kind: "summaryChunks" },
       {
@@ -84,9 +87,15 @@ describe("compaction planning worker", () => {
         maxHistoryShare: 0.5,
       },
     ]) {
-      expect(runCompactionPlanningWorkerInput(input)).toEqual({
-        status: "failed",
-        error: "invalid compaction planning worker input",
+      await expect(
+        runCompactionPlanningWorker({
+          // SAFETY: Exercise the worker's runtime validation with malformed protocol input.
+          input: input as CompactionPlanningWorkerInput,
+        }),
+      ).rejects.toMatchObject({
+        name: "CompactionPlanningWorkerError",
+        code: "failed",
+        message: "invalid compaction planning worker input",
       });
     }
   });
@@ -372,17 +381,12 @@ describe("compaction planning worker", () => {
   }, 45_000);
 
   it("plans summary chunks for worker input", () => {
-    const result = runCompactionPlanningWorkerInput({
+    const value = runCompactionPlanningWorkerInput({
       kind: "summaryChunks",
       messages: [makeMessage(1), makeMessage(2), makeMessage(3)],
       maxChunkTokens: 1200,
     });
 
-    expect(result.status).toBe("ok");
-    if (result.status !== "ok") {
-      return;
-    }
-    const value = result.value;
     expect(value.kind).toBe("summaryChunks");
     if (value.kind !== "summaryChunks") {
       return;
@@ -397,8 +401,7 @@ describe("compaction planning worker", () => {
     { kind: "adaptiveChunkRatio", messages: [makeMessage(1)], contextWindow: 1200 },
   ])("plans $kind for worker input", (input) => {
     expect(runCompactionPlanningWorkerInput(input)).toMatchObject({
-      status: "ok",
-      value: { kind: input.kind },
+      kind: input.kind,
     });
   });
 
@@ -437,13 +440,13 @@ describe("compaction planning worker", () => {
   it("clamps oversized worker timeouts before scheduling", async () => {
     const workerUrl = createSyntheticWorkerUrl(`
       import { parentPort } from "node:worker_threads";
-      parentPort.postMessage({
+      parentPort.on("message", () => parentPort.postMessage({
         status: "ok",
         value: {
           kind: "summaryChunks",
-          chunks: [],
+          chunkIndexes: [],
         },
-      });
+      }));
     `);
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
@@ -485,13 +488,13 @@ describe("compaction planning worker", () => {
     // winning this race proves the worker path yielded control.
     const workerUrl = createSyntheticWorkerUrl(`
       import { parentPort } from "node:worker_threads";
-      parentPort.postMessage({
+      parentPort.on("message", () => parentPort.postMessage({
         status: "ok",
         value: {
           kind: "stageSplit",
           mode: "single",
         },
-      });
+      }));
     `);
     const timer = new Promise<"timer">((resolve) => {
       setTimeout(() => resolve("timer"), 0);

--- a/src/agents/compaction-planning.worker.ts
+++ b/src/agents/compaction-planning.worker.ts
@@ -1,7 +1,7 @@
 /**
  * Worker-thread entrypoint for serializable compaction planning requests.
  */
-import { parentPort, workerData } from "node:worker_threads";
+import { serveWorkerTasks } from "../infra/worker-task-pool.js";
 import {
   buildOversizedFallbackPlan,
   buildStageSplitPlan,
@@ -38,17 +38,6 @@ export type CompactionPlanningWorkerValue =
       ratio: number;
     };
 
-/** Serializable success/failure envelope posted by the worker. */
-export type CompactionPlanningWorkerResult =
-  | {
-      status: "ok";
-      value: CompactionPlanningWorkerValue;
-    }
-  | {
-      status: "failed";
-      error: string;
-    };
-
 function isWorkerInput(value: unknown): value is CompactionPlanningWorkerInput {
   if (!value || typeof value !== "object" || !("kind" in value)) {
     return false;
@@ -81,9 +70,11 @@ function createMessageIndexer(source: AgentMessage[]): (selected: AgentMessage[]
     });
 }
 
-function planCompactionWorkerInput(
-  input: CompactionPlanningWorkerInput,
-): CompactionPlanningWorkerValue {
+/** Run one compaction planning request and return a serializable value. */
+export function runCompactionPlanningWorkerInput(input: unknown): CompactionPlanningWorkerValue {
+  if (!isWorkerInput(input)) {
+    throw new Error("invalid compaction planning worker input");
+  }
   switch (input.kind) {
     case "summaryChunks":
       return {
@@ -117,22 +108,4 @@ function planCompactionWorkerInput(
   throw new Error("unsupported compaction planning worker input");
 }
 
-/** Run one compaction planning request and return a serializable result. */
-export function runCompactionPlanningWorkerInput(input: unknown): CompactionPlanningWorkerResult {
-  if (!isWorkerInput(input)) {
-    return { status: "failed", error: "invalid compaction planning worker input" };
-  }
-
-  try {
-    return { status: "ok", value: planCompactionWorkerInput(input) };
-  } catch (error) {
-    return { status: "failed", error: error instanceof Error ? error.message : String(error) };
-  }
-}
-
-if (parentPort) {
-  // Worker-thread mode: process the single workerData payload and post one result.
-  const sendToParent: (message: CompactionPlanningWorkerResult) => void =
-    parentPort.postMessage.bind(parentPort);
-  sendToParent(runCompactionPlanningWorkerInput(workerData));
-}
+serveWorkerTasks(runCompactionPlanningWorkerInput);

--- a/src/agents/model-provider-auth-state.ts
+++ b/src/agents/model-provider-auth-state.ts
@@ -15,13 +15,6 @@ export type ProviderAuthWarmSnapshot = {
   }>;
 };
 
-type ProviderAuthWarmWorkerHandle = {
-  worker: {
-    terminate: () => unknown;
-  };
-  cancelled: boolean;
-};
-
 // One entry per configured agent, keyed by agentId. Populated by the provider
 // auth warm path; consulted by hasAuthForModelProvider on every model-listing call.
 let currentProviderAuthStates: ReadonlyMap<string, PreparedProviderAuthState> | null = null;
@@ -29,7 +22,7 @@ let currentProviderAuthStates: ReadonlyMap<string, PreparedProviderAuthState> | 
 // Generation counter guards against an in-flight warm publishing stale state
 // after a subsequent warm or clear has invalidated it.
 let currentProviderAuthStateGeneration = 0;
-let currentProviderAuthWarmWorker: ProviderAuthWarmWorkerHandle | undefined;
+let currentProviderAuthWarmWorker: AbortController | undefined;
 
 export function getCurrentProviderAuthStates(): ReadonlyMap<
   string,
@@ -47,11 +40,11 @@ export function isCurrentProviderAuthStateGeneration(generation: number): boolea
   return generation === currentProviderAuthStateGeneration;
 }
 
-export function setCurrentProviderAuthWarmWorker(handle: ProviderAuthWarmWorkerHandle): void {
+export function setCurrentProviderAuthWarmWorker(handle: AbortController): void {
   currentProviderAuthWarmWorker = handle;
 }
 
-export function clearCurrentProviderAuthWarmWorker(handle: ProviderAuthWarmWorkerHandle): void {
+export function clearCurrentProviderAuthWarmWorker(handle: AbortController): void {
   if (currentProviderAuthWarmWorker === handle) {
     currentProviderAuthWarmWorker = undefined;
   }
@@ -62,9 +55,8 @@ export function cancelCurrentProviderAuthWarmWorker(): void {
   if (!current) {
     return;
   }
-  current.cancelled = true;
   currentProviderAuthWarmWorker = undefined;
-  void current.worker.terminate();
+  current.abort();
 }
 
 export function clearCurrentProviderAuthState(): void {

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -728,20 +728,23 @@ describe("prepared provider auth state", () => {
       workerPath,
       `
         import fs from "node:fs";
-        import { parentPort, workerData } from "node:worker_threads";
-        setTimeout(() => {
-          fs.writeFileSync(workerData.cfg.markerPath, "finished");
+        import { parentPort } from "node:worker_threads";
+        parentPort.on("message", ({ input }) => setTimeout(() => {
+          fs.writeFileSync(input.cfg.markerPath, "finished");
           parentPort.postMessage({
             status: "ok",
-            snapshot: {
-              agents: [{
-                agentId: "default",
-                configFingerprint: "fingerprint",
-                providers: [["openai", true]]
-              }]
+            value: {
+              status: "ok",
+              snapshot: {
+                agents: [{
+                  agentId: "default",
+                  configFingerprint: "fingerprint",
+                  providers: [["openai", true]]
+                }]
+              }
             }
           });
-        }, 200);
+        }, 200));
       `,
     );
     let cancelled = false;

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -3,11 +3,10 @@
  * keeps per-agent auth snapshots process-current so model listing can avoid
  * repeated env/profile/plugin discovery on hot paths.
  */
-import { Worker } from "node:worker_threads";
 import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { toErrorObject } from "../infra/errors.js";
 import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import { WorkerTaskError, WorkerTaskPool } from "../infra/worker-task-pool.js";
 import {
   listAgentIds,
   resolveAgentDir,
@@ -50,7 +49,7 @@ import {
 import { normalizeProviderId } from "./model-selection.js";
 import { resolveDefaultAgentWorkspaceDir } from "./workspace.js";
 
-type ProviderAuthWarmWorkerResult =
+export type ProviderAuthWarmWorkerResult =
   | {
       status: "ok";
       snapshot: ProviderAuthWarmSnapshot;
@@ -70,15 +69,20 @@ type ProviderAuthWarmRuntimeAuthLookup = {
   lookup: RuntimeProviderAuthLookup;
 };
 
-type ProviderAuthWarmWorkerRunner = (params: {
+export type ProviderAuthWarmWorkerInput = {
   cfg: OpenClawConfig;
   runtimeAuthStores?: ProviderAuthWarmRuntimeAuthStore[];
   runtimeAuthLookups?: ProviderAuthWarmRuntimeAuthLookup[];
   omitFalseProviderAuth?: boolean;
-  timeoutMs: number;
-  isCancelled: () => boolean;
-  workerUrl?: URL;
-}) => Promise<ProviderAuthWarmSnapshot>;
+};
+
+type ProviderAuthWarmWorkerRunner = (
+  params: ProviderAuthWarmWorkerInput & {
+    timeoutMs: number;
+    isCancelled: () => boolean;
+    workerUrl?: URL;
+  },
+) => Promise<ProviderAuthWarmSnapshot>;
 
 const PROVIDER_AUTH_WARM_WORKER_TIMEOUT_MS = 120_000;
 const PROVIDER_AUTH_WARM_CANCEL_POLL_MS = 25;
@@ -585,15 +589,7 @@ function collectProviderAuthWarmRuntimeAuthLookups(cfg: OpenClawConfig): {
   return { entries, omitFalseProviderAuth };
 }
 
-function runProviderAuthWarmWorker(params: {
-  cfg: OpenClawConfig;
-  runtimeAuthStores?: ProviderAuthWarmRuntimeAuthStore[];
-  runtimeAuthLookups?: ProviderAuthWarmRuntimeAuthLookup[];
-  omitFalseProviderAuth?: boolean;
-  timeoutMs: number;
-  isCancelled: () => boolean;
-  workerUrl?: URL;
-}): Promise<ProviderAuthWarmSnapshot> {
+const runProviderAuthWarmWorker: ProviderAuthWarmWorkerRunner = async (params) => {
   const workerUrl =
     params.workerUrl ??
     resolveRuntimeWorkerUrl({
@@ -601,101 +597,60 @@ function runProviderAuthWarmWorker(params: {
       sourceWorkerName: "model-provider-auth.worker",
       distWorkerPath: "agents/model-provider-auth.worker.js",
     });
-  const sourceWorkerExecArgv = workerUrl.pathname.endsWith(".ts") ? ["--import", "tsx"] : undefined;
-  const worker = new Worker(workerUrl, {
-    workerData: {
-      cfg: params.cfg,
-      ...(params.runtimeAuthStores?.length ? { runtimeAuthStores: params.runtimeAuthStores } : {}),
-      ...(params.runtimeAuthLookups?.length
-        ? { runtimeAuthLookups: params.runtimeAuthLookups }
-        : {}),
-      ...(params.omitFalseProviderAuth ? { omitFalseProviderAuth: true } : {}),
-    },
-    execArgv: sourceWorkerExecArgv,
+  // Auth preparation owns process-local catalog caches, so each warm generation gets its own pool.
+  const pool = new WorkerTaskPool<ProviderAuthWarmWorkerInput, ProviderAuthWarmWorkerResult>({
+    workerUrl,
+    maxWorkers: 1,
   });
-  worker.unref?.();
-  const handle = {
-    worker,
-    cancelled: false,
-  };
+  const handle = new AbortController();
   setCurrentProviderAuthWarmWorker(handle);
-  return new Promise<ProviderAuthWarmSnapshot>((resolve, reject) => {
-    let settled = false;
-    const finish = (complete: () => void) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearCurrentProviderAuthWarmWorker(handle);
-      if (timer) {
-        clearTimeout(timer);
-      }
-      if (cancelTimer) {
-        clearInterval(cancelTimer);
-      }
-      complete();
-    };
-    const cancelWorker = () => {
-      handle.cancelled = true;
-      void worker.terminate();
-      finish(() => resolve({ agents: [] }));
-    };
-    const timer: ReturnType<typeof setTimeout> | undefined = setTimeout(() => {
-      handle.cancelled = true;
-      void worker.terminate();
-      finish(() => reject(new Error("provider auth warm worker timed out")));
-    }, params.timeoutMs);
-    timer.unref?.();
-    const cancelTimer: ReturnType<typeof setInterval> | undefined = setInterval(() => {
-      if (params.isCancelled()) {
-        cancelWorker();
-      }
-    }, PROVIDER_AUTH_WARM_CANCEL_POLL_MS);
-    cancelTimer.unref?.();
-    worker.once("message", (message: unknown) => {
-      void worker.terminate();
-      finish(() => {
-        if (handle.cancelled) {
-          resolve({ agents: [] });
-          return;
-        }
-        if (!isProviderAuthWarmWorkerResult(message)) {
-          reject(new Error("invalid provider auth warm worker response"));
-          return;
-        }
-        if (message.status === "failed") {
-          reject(new Error(message.error));
-          return;
-        }
-        resolve(message.snapshot);
-      });
-    });
-    worker.once("error", (error) => {
-      finish(() => {
-        if (handle.cancelled) {
-          resolve({ agents: [] });
-          return;
-        }
-        reject(toErrorObject(error, "Non-Error rejection"));
-      });
-    });
-    worker.once("exit", (code) => {
-      if (settled || code === 0) {
-        return;
-      }
-      finish(() => {
-        if (handle.cancelled) {
-          resolve({ agents: [] });
-          return;
-        }
-        reject(new Error(`provider auth warm worker exited with code ${code}`));
-      });
-    });
+  const cancelTimer = setInterval(() => {
     if (params.isCancelled()) {
-      cancelWorker();
+      handle.abort();
     }
-  });
-}
+  }, PROVIDER_AUTH_WARM_CANCEL_POLL_MS);
+  cancelTimer.unref();
+  try {
+    if (params.isCancelled()) {
+      handle.abort();
+    }
+    const message = await pool.run(
+      {
+        cfg: params.cfg,
+        ...(params.runtimeAuthStores?.length
+          ? { runtimeAuthStores: params.runtimeAuthStores }
+          : {}),
+        ...(params.runtimeAuthLookups?.length
+          ? { runtimeAuthLookups: params.runtimeAuthLookups }
+          : {}),
+        ...(params.omitFalseProviderAuth ? { omitFalseProviderAuth: true } : {}),
+      },
+      { timeoutMs: params.timeoutMs, signal: handle.signal },
+    );
+    if (handle.signal.aborted || params.isCancelled()) {
+      return { agents: [] };
+    }
+    if (!isProviderAuthWarmWorkerResult(message)) {
+      throw new Error("invalid provider auth warm worker response");
+    }
+    if (message.status === "failed") {
+      throw new Error(message.error);
+    }
+    return message.snapshot;
+  } catch (error) {
+    if (handle.signal.aborted) {
+      return { agents: [] };
+    }
+    if (error instanceof WorkerTaskError && error.code === "timeout") {
+      throw new Error("provider auth warm worker timed out", { cause: error });
+    }
+    throw error;
+  } finally {
+    clearInterval(cancelTimer);
+    clearCurrentProviderAuthWarmWorker(handle);
+    await pool.close();
+  }
+};
 
 /** Warms process-current provider auth state in a worker thread. */
 export async function warmCurrentProviderAuthStateOffMainThread(

--- a/src/agents/model-provider-auth.worker.ts
+++ b/src/agents/model-provider-auth.worker.ts
@@ -1,40 +1,13 @@
 /**
  * Worker entrypoint for warming provider auth state off the main thread.
  */
-import { parentPort, workerData } from "node:worker_threads";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { replaceRuntimeAuthProfileStoreSnapshots, type AuthProfileStore } from "./auth-profiles.js";
-import type { RuntimeProviderAuthLookup } from "./model-auth.js";
-import { buildCurrentProviderAuthStateSnapshot } from "./model-provider-auth.js";
-
-/**
- * Worker entrypoint for warming provider auth state without blocking the foreground
- * model-selection path.
- */
-type ProviderAuthWarmRuntimeAuthStore = {
-  agentDir?: string;
-  store: AuthProfileStore;
-};
-
-type ProviderAuthWarmWorkerInput = {
-  cfg: OpenClawConfig;
-  runtimeAuthStores?: ProviderAuthWarmRuntimeAuthStore[];
-  runtimeAuthLookups?: Array<{
-    agentId: string;
-    lookup: RuntimeProviderAuthLookup;
-  }>;
-  omitFalseProviderAuth?: boolean;
-};
-
-type ProviderAuthWarmWorkerResult =
-  | {
-      status: "ok";
-      snapshot: Awaited<ReturnType<typeof buildCurrentProviderAuthStateSnapshot>>;
-    }
-  | {
-      status: "failed";
-      error: string;
-    };
+import { serveWorkerTasks } from "../infra/worker-task-pool.js";
+import { replaceRuntimeAuthProfileStoreSnapshots } from "./auth-profiles.js";
+import {
+  buildCurrentProviderAuthStateSnapshot,
+  type ProviderAuthWarmWorkerInput,
+  type ProviderAuthWarmWorkerResult,
+} from "./model-provider-auth.js";
 
 function isWorkerInput(value: unknown): value is ProviderAuthWarmWorkerInput {
   if (!value || typeof value !== "object") {
@@ -84,8 +57,4 @@ export async function runProviderAuthWarmWorkerInput(
   }
 }
 
-if (parentPort) {
-  const sendToParent: (message: ProviderAuthWarmWorkerResult) => void =
-    parentPort.postMessage.bind(parentPort);
-  sendToParent(await runProviderAuthWarmWorkerInput(workerData));
-}
+serveWorkerTasks(runProviderAuthWarmWorkerInput);

--- a/src/agents/prepared-model-catalog-worker.secrets.test.ts
+++ b/src/agents/prepared-model-catalog-worker.secrets.test.ts
@@ -306,7 +306,6 @@ module.exports = {
         );
         const result = await runPreparedModelCatalogWorkerRequest(serialized, {
           kind: "catalog",
-          requestId: 1,
         });
         expect(result.status).toBe("ok");
         const runtimeFacts = getConfigResolutionFacts(serialized.input.config);

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -1,12 +1,11 @@
 /** Runs complete model-catalog discovery outside the Gateway event loop. */
-import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
-import { Worker } from "node:worker_threads";
 import {
   getConfigResolutionFacts,
   serializeConfigResolutionFacts,
 } from "../config/resolution-facts.js";
 import { projectConfigOntoRuntimeSourceSnapshot } from "../config/runtime-source-projection.js";
+import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import { WorkerTaskPool } from "../infra/worker-task-pool.js";
 import { resolveInstalledManifestRegistryIndexFingerprint } from "../plugins/manifest-registry-installed.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { PreparedAgentCredentialModes } from "./agent-auth-credential-modes.js";
@@ -38,14 +37,6 @@ export type PreparedModelCatalogWorkerInput = Readonly<{
 }>;
 
 export type PreparedModelWorkerRequest =
-  | Readonly<{ requestId: number; kind: "catalog" }>
-  | Readonly<{
-      requestId: number;
-      kind: "auth-refresh";
-      profileIds?: readonly string[];
-      providerIds: readonly string[];
-    }>;
-type PreparedModelWorkerRequestInput =
   | Readonly<{ kind: "catalog" }>
   | Readonly<{
       kind: "auth-refresh";
@@ -56,7 +47,6 @@ type PreparedModelWorkerRequestInput =
 export type PreparedModelWorkerResult =
   | Readonly<{
       status: "ok";
-      requestId: number;
       kind: "catalog";
       generationFingerprint: string;
       snapshot: ModelCatalogSnapshot;
@@ -65,13 +55,12 @@ export type PreparedModelWorkerResult =
     }>
   | Readonly<{
       status: "ok";
-      requestId: number;
       kind: "auth-refresh";
       generationFingerprint: string;
       authStore: AuthProfileStore;
       authModes: PreparedAgentCredentialModes;
     }>
-  | Readonly<{ status: "failed"; requestId: number; error: string }>;
+  | Readonly<{ status: "failed"; error: string }>;
 
 // Cold source/plugin loading can take well over a minute. Three minutes preserves exact full-view
 // discovery while bounding a wedged provider; expiry rejects and never returns partial results.
@@ -166,19 +155,6 @@ export function createPreparedModelCatalogWorkerInput(params: {
   };
 }
 
-function resolvePreparedModelCatalogWorkerUrl(currentModuleUrl = import.meta.url): URL {
-  const currentPath = fileURLToPath(currentModuleUrl);
-  const normalized = currentPath.replaceAll(path.sep, "/");
-  const distMarker = "/dist/";
-  const distIndex = normalized.lastIndexOf(distMarker);
-  if (distIndex >= 0) {
-    const distRoot = currentPath.slice(0, distIndex + distMarker.length);
-    return pathToFileURL(path.join(distRoot, "agents", "prepared-model-catalog.worker.js"));
-  }
-  const extension = path.extname(currentPath) || ".js";
-  return new URL(`./prepared-model-catalog.worker${extension}`, currentModuleUrl);
-}
-
 type PreparedModelCatalogWorker = Readonly<{
   loadAuth: (scope: PreparedModelRuntimeAuthScope) => Promise<PreparedModelRuntimeAuth>;
   loadCatalog: () => Promise<ModelCatalogSnapshot>;
@@ -192,125 +168,71 @@ export function createPreparedModelCatalogWorker(params: {
     new PreparedModelRuntimePublicationSupersededError(
       `prepared model runtime catalog generation was superseded for ${params.input.input.agentDir}`,
     );
-  let worker: Worker | undefined;
   let generationPoll: NodeJS.Timeout | undefined;
-  let terminalError: Error | undefined;
-  let nextRequestId = 1;
-  const pending = new Map<
-    number,
-    {
-      timeout: NodeJS.Timeout;
-      resolve: (message: Extract<PreparedModelWorkerResult, { status: "ok" }>) => void;
-      reject: (error: Error) => void;
-    }
-  >();
-
-  const rejectPending = (error: Error) => {
-    for (const request of pending.values()) {
-      clearTimeout(request.timeout);
-      request.reject(error);
-    }
-    pending.clear();
-  };
-  const stop = (error: Error) => {
-    terminalError ??= error;
-    if (generationPoll) {
-      clearInterval(generationPoll);
-      generationPoll = undefined;
-    }
-    const active = worker;
-    worker = undefined;
-    active?.removeAllListeners();
-    rejectPending(error);
-    if (active) {
-      void active.terminate();
-    }
-  };
-  const ensureWorker = (): Worker => {
-    if (terminalError) {
-      throw terminalError;
-    }
+  const assertCurrent = () => {
     if (!params.isCurrent()) {
-      const error = superseded();
-      stop(error);
-      throw error;
+      throw superseded();
     }
-    if (worker) {
-      return worker;
-    }
-    const workerUrl = resolvePreparedModelCatalogWorkerUrl();
-    const active = new Worker(workerUrl, {
+  };
+  const pool = new WorkerTaskPool<PreparedModelWorkerRequest, PreparedModelWorkerResult>({
+    workerUrl: resolveRuntimeWorkerUrl({
+      currentModuleUrl: import.meta.url,
+      sourceWorkerName: "prepared-model-catalog.worker",
+      distWorkerPath: "agents/prepared-model-catalog.worker.js",
+    }),
+    maxWorkers: 1,
+    // Recreating this worker would import changed plugin code under the old generation.
+    // Only the lifecycle owner may retire it; crashes close the generation permanently.
+    idleTimeoutMs: 0,
+    restartOnError: false,
+    workerOptions: {
       workerData: params.input,
-      ...(workerUrl.pathname.endsWith(".ts") ? { execArgv: ["--import", "tsx"] } : {}),
       // Establish state/config environment before worker module initialization reads process.env.
       env: { ...process.env, ...params.input.input.env },
-    });
-    active.unref();
-    active.on("message", (message: PreparedModelWorkerResult) => {
-      const request = pending.get(message.requestId);
-      if (!request) {
-        return;
+    },
+    validateResult: (message) => {
+      assertCurrent();
+      if (
+        message.status === "ok" &&
+        message.generationFingerprint !== params.input.generationFingerprint
+      ) {
+        throw new Error("prepared model catalog worker returned a stale generation");
       }
-      pending.delete(message.requestId);
-      clearTimeout(request.timeout);
-      if (!params.isCurrent()) {
-        const error = superseded();
-        request.reject(error);
-        stop(error);
-      } else if (message.status === "failed") {
-        request.reject(new Error(message.error));
-      } else if (message.generationFingerprint !== params.input.generationFingerprint) {
-        const error = new Error("prepared model catalog worker returned a stale generation");
-        request.reject(error);
-        stop(error);
-      } else {
-        request.resolve(message);
-      }
-    });
-    active.once("error", (error) =>
-      stop(error instanceof Error ? error : new Error(String(error))),
-    );
-    active.once("exit", (code) => {
-      if (worker === active) {
-        stop(
-          new Error(
-            `prepared model catalog worker exited with code ${code} before its generation retired`,
-          ),
-        );
-      }
-    });
-    worker = active;
-    generationPoll = setInterval(() => {
-      if (!params.isCurrent()) {
-        stop(superseded());
-      }
-    }, PREPARED_MODEL_CATALOG_WORKER_GENERATION_POLL_MS);
-    generationPoll.unref();
-    return active;
+    },
+  });
+  const stop = (error: Error) => {
+    clearInterval(generationPoll);
+    generationPoll = undefined;
+    return pool.close(error);
   };
-  const request = (
-    value: PreparedModelWorkerRequestInput,
+  const request = async (
+    value: PreparedModelWorkerRequest,
   ): Promise<Extract<PreparedModelWorkerResult, { status: "ok" }>> => {
-    let active: Worker;
+    let message: PreparedModelWorkerResult;
     try {
-      active = ensureWorker();
+      assertCurrent();
+      generationPoll ??= setInterval(() => {
+        if (!params.isCurrent()) {
+          void stop(superseded());
+        }
+      }, PREPARED_MODEL_CATALOG_WORKER_GENERATION_POLL_MS);
+      generationPoll.unref();
+      message = await pool.run(
+        () => {
+          assertCurrent();
+          return value;
+        },
+        { timeoutMs: PREPARED_MODEL_CATALOG_WORKER_TIMEOUT_MS },
+      );
+      assertCurrent();
     } catch (error) {
-      return Promise.reject(error instanceof Error ? error : new Error(String(error)));
+      await stop(error instanceof Error ? error : new Error(String(error)));
+      throw error;
     }
-    const requestId = nextRequestId++;
-    return new Promise<Extract<PreparedModelWorkerResult, { status: "ok" }>>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        stop(new Error("prepared model catalog worker timed out"));
-      }, PREPARED_MODEL_CATALOG_WORKER_TIMEOUT_MS);
-      timeout.unref();
-      pending.set(requestId, { timeout, resolve, reject });
-      active.postMessage({ ...value, requestId } satisfies PreparedModelWorkerRequest, []);
-    }).then((message) => {
-      if (!params.isCurrent()) {
-        throw superseded();
-      }
-      return message;
-    });
+    if (message.status === "failed") {
+      throw new Error(message.error);
+    }
+    return message;
   };
 
   return {

--- a/src/agents/prepared-model-catalog.worker.ts
+++ b/src/agents/prepared-model-catalog.worker.ts
@@ -6,6 +6,7 @@ import {
   restoreConfigResolutionFacts,
 } from "../config/resolution-facts.js";
 import { setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
+import { serveWorkerTasks } from "../infra/worker-task-pool.js";
 import { restorePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
@@ -143,7 +144,6 @@ export async function runPreparedModelCatalogWorkerRequest(
       });
       return {
         status: "ok",
-        requestId: request.requestId,
         kind: "auth-refresh",
         generationFingerprint: value.generationFingerprint,
         authStore,
@@ -221,7 +221,6 @@ export async function runPreparedModelCatalogWorkerRequest(
     );
     return {
       status: "ok",
-      requestId: request.requestId,
       kind: "catalog",
       generationFingerprint: value.generationFingerprint,
       snapshot: facts.modelCatalog,
@@ -231,21 +230,19 @@ export async function runPreparedModelCatalogWorkerRequest(
   } catch (error) {
     return {
       status: "failed",
-      requestId: request.requestId,
       error: error instanceof Error ? error.message : String(error),
     };
   }
 }
 
 if (parentPort) {
-  const send: (message: PreparedModelWorkerResult) => void =
-    parentPort.postMessage.bind(parentPort);
   const value = workerData as PreparedModelCatalogWorkerInput;
-  const preparedGeneration = prepareWorkerGeneration(value);
-  let queue = Promise.resolve();
-  parentPort.on("message", (request: PreparedModelWorkerRequest) => {
-    queue = queue.then(async () => {
-      send(await runPreparedModelCatalogWorkerRequest(value, request, preparedGeneration));
-    });
-  });
+  let preparedGeneration: ReturnType<typeof prepareWorkerGeneration> | undefined;
+  serveWorkerTasks((request: PreparedModelWorkerRequest) =>
+    runPreparedModelCatalogWorkerRequest(
+      value,
+      request,
+      (preparedGeneration ??= prepareWorkerGeneration(value)),
+    ),
+  );
 }

--- a/src/agents/prepared-model-catalog.worker.ts
+++ b/src/agents/prepared-model-catalog.worker.ts
@@ -1,6 +1,7 @@
 /** Worker-thread entrypoint for complete model-catalog discovery. */
 import { parentPort, workerData } from "node:worker_threads";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   copyConfigResolutionFacts,
   restoreConfigResolutionFacts,
@@ -235,14 +236,30 @@ export async function runPreparedModelCatalogWorkerRequest(
   }
 }
 
+function isWorkerRequest(value: unknown): value is PreparedModelWorkerRequest {
+  return (
+    isRecord(value) &&
+    (value.kind === "catalog" ||
+      (value.kind === "auth-refresh" &&
+        Array.isArray(value.providerIds) &&
+        value.providerIds.every((providerId) => typeof providerId === "string") &&
+        (value.profileIds === undefined ||
+          (Array.isArray(value.profileIds) &&
+            value.profileIds.every((profileId) => typeof profileId === "string")))))
+  );
+}
+
 if (parentPort) {
   const value = workerData as PreparedModelCatalogWorkerInput;
   let preparedGeneration: ReturnType<typeof prepareWorkerGeneration> | undefined;
-  serveWorkerTasks((request: PreparedModelWorkerRequest) =>
-    runPreparedModelCatalogWorkerRequest(
+  serveWorkerTasks((request) => {
+    if (!isWorkerRequest(request)) {
+      throw new Error("invalid prepared model catalog worker request");
+    }
+    return runPreparedModelCatalogWorkerRequest(
       value,
       request,
       (preparedGeneration ??= prepareWorkerGeneration(value)),
-    ),
-  );
+    );
+  });
 }

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -12,6 +12,7 @@ import {
   listSessionChildEntriesReadOnly,
   listSessionEntriesCore as listAccessorSessionEntries,
   listSessionEntriesReadOnly as listAccessorSessionEntriesReadOnly,
+  loadExactSessionEntry,
   loadExactSessionEntryReadOnly,
   type SessionEntryListScope,
 } from "../config/sessions/session-accessor.js";
@@ -193,7 +194,7 @@ function loadGatewaySessionLookupStore(
 ): Record<string, SessionEntry> {
   const cache = options.cache;
   const cacheKey = cache
-    ? `${storePath}\u0000${agentId ?? ""}\u0000${clone === false ? "0" : "1"}\u0000${options.readOnly ? "1" : "0"}\u0000${options.projection ?? "full"}\u0000${options.exactKeys?.join("\u0001") ?? ""}`
+    ? `${storePath}\u0000${agentId ?? ""}\u0000${clone === false ? "0" : "1"}\u0000${options.readOnly}\u0000${options.projection ?? "full"}\u0000${options.exactKeys?.join("\u0001") ?? ""}`
     : "";
   if (cache) {
     const cached = cache.get(cacheKey);
@@ -219,14 +220,23 @@ function loadGatewaySessionLookupStoreUncached(
   try {
     if (options.exactKeys) {
       const store: Record<string, SessionEntry> = {};
+      // Borrowed listing views and probes never create stores; ordinary owned reads may.
+      const loadExact =
+        options.readOnly === false && clone !== false
+          ? loadExactSessionEntry
+          : loadExactSessionEntryReadOnly;
       for (const sessionKey of options.exactKeys) {
-        const match = loadExactSessionEntryReadOnly({
+        const match = loadExact({
           ...(agentId ? { agentId } : {}),
           clone: false,
           sessionKey,
           storePath,
         });
         if (match) {
+          if (options.projection === "list") {
+            delete match.entry.skillsSnapshot;
+            delete match.entry.systemPromptReport;
+          }
           store[match.sessionKey] = match.entry;
         }
       }
@@ -291,7 +301,7 @@ function resolveGatewaySessionStoreLookup(params: {
   }
   const loadStore = (target: SessionStoreTarget) =>
     loadGatewaySessionLookupStore(target.storePath, params.clone, target.agentId, {
-      readOnly: params.readOnly || !configured,
+      readOnly: configured ? params.readOnly : true,
       ...(params.exactRead ? { exactKeys: scanTargets } : {}),
       ...(params.projection ? { projection: params.projection } : {}),
       ...(params.storeCache ? { cache: params.storeCache } : {}),

--- a/src/gateway/session-utils-store.ts
+++ b/src/gateway/session-utils-store.ts
@@ -29,6 +29,7 @@ import {
   type SessionEntry,
   type SessionScope,
 } from "../config/sessions.js";
+import { isInternalSessionEffectsKey } from "../config/sessions/internal-session-key.js";
 import type { SessionEntryListScope } from "../config/sessions/session-accessor.js";
 import { canonicalSessionKeyMigrationRequiredError } from "../config/sessions/session-canonical-key.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -150,19 +151,22 @@ function loadSessionEntryWithMode(
   const target = resolveGatewaySessionStoreTargetWithStore({
     cfg,
     key,
+    exactRead: true,
+    readOnly,
     projection: opts?.projection,
     ...(opts?.clone === false ? { clone: false } : {}),
     ...(opts?.agentId ? { agentId: opts.agentId } : {}),
-    ...(readOnly
-      ? {
-          exactRead: true,
-          readOnly: true,
-          ...(opts?.includeStoreChildEntries ? { includeStoreChildEntries: true } : {}),
-        }
-      : {}),
+    ...(opts?.includeStoreChildEntries ? { includeStoreChildEntries: true } : {}),
   });
   const storePath = target.storePath;
   const store = target.store;
+  if (!readOnly) {
+    for (const storeKey of target.storeKeys) {
+      if (isInternalSessionEffectsKey(storeKey)) {
+        delete store[storeKey];
+      }
+    }
+  }
   const canonicalMatch = resolveCanonicalSessionStoreMatchFromStoreKeys(store, target.storeKeys);
   const legacyKey = canonicalMatch?.key !== target.canonicalKey ? canonicalMatch?.key : undefined;
   const entry =

--- a/src/gateway/session-utils.single-row-cache.test.ts
+++ b/src/gateway/session-utils.single-row-cache.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests fresh child state in exact session-row Gateway projections.
  */
+import { existsSync } from "node:fs";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -12,6 +13,7 @@ import {
   updateSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import { resetPluginRuntimeStateForTest } from "../plugins/runtime.js";
+import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 
 const subagentRegistryReadMock = vi.hoisted(() => {
@@ -217,61 +219,100 @@ describe("single gateway session row child projections", () => {
     vi.clearAllMocks();
   });
 
-  test("preserves session selection and hidden effects across metadata and full reads", async () => {
+  test.each([undefined, false])(
+    "reads only the selected session while preserving projections and hidden effects (clone: %s)",
+    async (clone) => {
+      await withSingleRowCacheStore(
+        "openclaw-single-row-hidden-effects-",
+        "/tmp/openclaw-single-row-hidden-effects",
+        async ({ now, storePath }) => {
+          const hidden = resolveInternalSessionEffectsIdentity({
+            agentId: MAIN_AGENT_ID,
+            runId: "suppressed-effects",
+          });
+          const sessionKey = "agent:main:main";
+          const visible: SessionEntry = {
+            ...parentSession("visible-session", now),
+            skillsSnapshot: { prompt: "saved skill prompt", skills: [] },
+            systemPromptReport: {
+              source: "run",
+              generatedAt: now,
+              systemPrompt: { chars: 1, projectContextChars: 0, nonProjectContextChars: 1 },
+              injectedWorkspaceFiles: [],
+              skills: { promptChars: 0, entries: [] },
+              tools: { listChars: 0, schemaChars: 0, entries: [] },
+            },
+          };
+          await seedSessionEntries(storePath, {
+            [sessionKey]: visible,
+            [hidden.sessionKey]: parentSession(hidden.sessionId, now),
+            ...Object.fromEntries(
+              Array.from({ length: 24 }, (_, index) => [
+                `agent:main:unrelated-${index}`,
+                { ...visible, sessionId: `unrelated-session-${index}` },
+              ]),
+            ),
+          });
+
+          // The canonical store scan belongs to handle admission, before repeated row lookups.
+          expect(loadExactSessionEntryReadOnly({ sessionKey, storePath })?.entry.sessionId).toBe(
+            visible.sessionId,
+          );
+          const parse = vi.spyOn(JSON, "parse");
+          try {
+            const metadata = loadSessionEntry("main", {
+              agentId: MAIN_AGENT_ID,
+              clone,
+              projection: "list",
+            });
+            expect(metadata).toMatchObject({
+              agentId: MAIN_AGENT_ID,
+              canonicalKey: sessionKey,
+              storePath,
+              entry: parentSession(visible.sessionId, now),
+            });
+            expect(metadata.entry?.skillsSnapshot).toBeUndefined();
+            expect(metadata.entry?.systemPromptReport).toBeUndefined();
+            expect(loadSessionEntry("main", { agentId: MAIN_AGENT_ID, clone })).toMatchObject({
+              agentId: metadata.agentId,
+              canonicalKey: metadata.canonicalKey,
+              storePath: metadata.storePath,
+              entry: visible,
+            });
+
+            expect(loadSessionEntry(hidden.sessionKey, { clone }).entry).toBeUndefined();
+            expect(
+              loadSessionEntry(hidden.sessionKey, { clone, projection: "list" }).entry,
+            ).toBeUndefined();
+            expect(loadGatewaySessionEntryReadOnly(hidden.sessionKey).entry?.sessionId).toBe(
+              hidden.sessionId,
+            );
+            expect(loadExactSessionEntryReadOnly({ ...hidden, storePath })?.entry.sessionId).toBe(
+              hidden.sessionId,
+            );
+            expect(
+              parse.mock.calls.filter(
+                ([value]) => typeof value === "string" && value.includes("unrelated-session-"),
+              ),
+            ).toHaveLength(0);
+          } finally {
+            parse.mockRestore();
+          }
+        },
+      );
+    },
+  );
+
+  test("preserves missing-store behavior for borrowed and owned entry lookups", async () => {
     await withSingleRowCacheStore(
-      "openclaw-single-row-hidden-effects-",
-      "/tmp/openclaw-single-row-hidden-effects",
-      async ({ now, storePath }) => {
-        const hidden = resolveInternalSessionEffectsIdentity({
-          agentId: MAIN_AGENT_ID,
-          runId: "suppressed-effects",
-        });
-        const sessionKey = "agent:main:main";
-        const visible: SessionEntry = {
-          ...parentSession("visible-session", now),
-          skillsSnapshot: { prompt: "saved skill prompt", skills: [] },
-          systemPromptReport: {
-            source: "run",
-            generatedAt: now,
-            systemPrompt: { chars: 1, projectContextChars: 0, nonProjectContextChars: 1 },
-            injectedWorkspaceFiles: [],
-            skills: { promptChars: 0, entries: [] },
-            tools: { listChars: 0, schemaChars: 0, entries: [] },
-          },
-        };
-        await seedSessionEntries(storePath, {
-          [sessionKey]: visible,
-          [hidden.sessionKey]: parentSession(hidden.sessionId, now),
-        });
-
-        const metadata = loadSessionEntry("main", {
-          agentId: MAIN_AGENT_ID,
-          clone: false,
-          projection: "list",
-        });
-        expect(metadata).toMatchObject({
-          agentId: MAIN_AGENT_ID,
-          canonicalKey: sessionKey,
-          storePath,
-          entry: parentSession(visible.sessionId, now),
-        });
-        expect(metadata.entry?.skillsSnapshot).toBeUndefined();
-        expect(metadata.entry?.systemPromptReport).toBeUndefined();
-        expect(loadSessionEntry("main", { agentId: MAIN_AGENT_ID, clone: false })).toMatchObject({
-          agentId: metadata.agentId,
-          canonicalKey: metadata.canonicalKey,
-          storePath: metadata.storePath,
-          entry: visible,
-        });
-
-        expect(loadSessionEntry(hidden.sessionKey).entry).toBeUndefined();
-        expect(loadSessionEntry(hidden.sessionKey, { projection: "list" }).entry).toBeUndefined();
-        expect(loadGatewaySessionEntryReadOnly(hidden.sessionKey).entry?.sessionId).toBe(
-          hidden.sessionId,
-        );
-        expect(loadExactSessionEntryReadOnly({ ...hidden, storePath })?.entry.sessionId).toBe(
-          hidden.sessionId,
-        );
+      "openclaw-single-row-missing-store-",
+      "/tmp/openclaw-single-row-missing-store",
+      async () => {
+        const databasePath = resolveOpenClawAgentSqlitePath({ agentId: MAIN_AGENT_ID });
+        expect(loadSessionEntry("main", { clone: false }).entry).toBeUndefined();
+        expect(existsSync(databasePath)).toBe(false);
+        expect(loadSessionEntry("main").entry).toBeUndefined();
+        expect(existsSync(databasePath)).toBe(true);
       },
     );
   });

--- a/src/infra/worker-task-pool.test-fixture.ts
+++ b/src/infra/worker-task-pool.test-fixture.ts
@@ -1,0 +1,36 @@
+import { threadId } from "node:worker_threads";
+import { serveWorkerTasks } from "./worker-task-pool.js";
+
+export type PoolFixtureInput = {
+  label: string;
+  counters?: SharedArrayBuffer;
+  wait?: boolean;
+  exitCode?: number;
+  buffer?: ArrayBuffer;
+};
+export type PoolFixtureResult = {
+  label: string;
+  threadId: number;
+  buffer?: ArrayBuffer;
+  previousBufferBytes?: number;
+};
+
+let previousBuffer: ArrayBuffer | undefined;
+serveWorkerTasks<PoolFixtureInput, PoolFixtureResult>(
+  (input) => {
+    if (input.exitCode !== undefined) {
+      process.exit(input.exitCode);
+    }
+    if (input.counters) {
+      const counters = new Int32Array(input.counters);
+      Atomics.add(counters, 0, 1);
+      if (input.wait) {
+        Atomics.wait(counters, 1, 0);
+      }
+    }
+    const previousBufferBytes = previousBuffer?.byteLength;
+    previousBuffer = input.buffer;
+    return { label: input.label, threadId, buffer: input.buffer, previousBufferBytes };
+  },
+  { transferList: (value) => (value.buffer ? [value.buffer] : []) },
+);

--- a/src/infra/worker-task-pool.test-support.ts
+++ b/src/infra/worker-task-pool.test-support.ts
@@ -1,4 +1,6 @@
+import assert from "node:assert/strict";
 import { threadId } from "node:worker_threads";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { serveWorkerTasks } from "./worker-task-pool.js";
 
 export type PoolFixtureInput = {
@@ -16,12 +18,16 @@ export type PoolFixtureResult = {
 };
 
 let previousBuffer: ArrayBuffer | undefined;
-serveWorkerTasks<PoolFixtureInput, PoolFixtureResult>(
+serveWorkerTasks<PoolFixtureResult>(
   (input) => {
+    assert.ok(isRecord(input));
+    assert.ok(typeof input.label === "string");
     if (input.exitCode !== undefined) {
+      assert.ok(typeof input.exitCode === "number");
       process.exit(input.exitCode);
     }
     if (input.counters) {
+      assert.ok(input.counters instanceof SharedArrayBuffer);
       const counters = new Int32Array(input.counters);
       Atomics.add(counters, 0, 1);
       if (input.wait) {
@@ -29,6 +35,7 @@ serveWorkerTasks<PoolFixtureInput, PoolFixtureResult>(
       }
     }
     const previousBufferBytes = previousBuffer?.byteLength;
+    assert.ok(input.buffer === undefined || input.buffer instanceof ArrayBuffer);
     previousBuffer = input.buffer;
     return { label: input.label, threadId, buffer: input.buffer, previousBufferBytes };
   },

--- a/src/infra/worker-task-pool.test.ts
+++ b/src/infra/worker-task-pool.test.ts
@@ -1,0 +1,199 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { channel } from "node:diagnostics_channel";
+import { promisify } from "node:util";
+import { Worker } from "node:worker_threads";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WorkerTaskPool } from "./worker-task-pool.js";
+import type { PoolFixtureInput, PoolFixtureResult } from "./worker-task-pool.test-fixture.js";
+
+const workerUrl = new URL("./worker-task-pool.test-fixture.ts", import.meta.url);
+const pools: WorkerTaskPool<PoolFixtureInput, PoolFixtureResult>[] = [];
+const workers: Worker[] = [];
+const workerChannel = channel("worker_threads");
+const trackWorker = (message: unknown) => workers.push((message as { worker: Worker }).worker);
+
+function createPool(
+  options: ConstructorParameters<typeof WorkerTaskPool<PoolFixtureInput, PoolFixtureResult>>[0] = {
+    workerUrl,
+  },
+) {
+  const pool = new WorkerTaskPool<PoolFixtureInput, PoolFixtureResult>({
+    maxWorkers: 1,
+    ...options,
+  });
+  pools.push(pool);
+  return pool;
+}
+
+beforeEach(() => workerChannel.subscribe(trackWorker));
+afterEach(async () => {
+  await Promise.all(pools.splice(0).map((pool) => pool.close()));
+  workerChannel.unsubscribe(trackWorker);
+  for (const worker of workers.splice(0)) {
+    expect(worker.threadId).toBe(-1);
+  }
+});
+
+describe("worker task pool", () => {
+  it("bounds parallel execution and reuses warm workers for queued requests", async () => {
+    const pool = createPool({ workerUrl, maxWorkers: 2 });
+    const counters = new SharedArrayBuffer(8);
+    const view = new Int32Array(counters);
+    const completion = Promise.all(
+      ["first", "second", "third"].map((label) =>
+        pool.run({ label, counters, wait: true }, { timeoutMs: 10_000 }),
+      ),
+    );
+    void completion.catch(() => {});
+    try {
+      await expect.poll(() => Atomics.load(view, 0)).toBe(2);
+      expect(workers).toHaveLength(2);
+      Atomics.store(view, 1, 1);
+      Atomics.notify(view, 1);
+      const results = await completion;
+      expect(results.map((result) => result.label)).toEqual(["first", "second", "third"]);
+      expect(new Set(results.map((result) => result.threadId)).size).toBe(2);
+      expect(Atomics.load(view, 0)).toBe(3);
+      expect((await pool.run({ label: "warm" }, { timeoutMs: 10_000 })).threadId).toBe(
+        results[0]?.threadId,
+      );
+      expect(workers).toHaveLength(2);
+    } finally {
+      Atomics.store(view, 1, 1);
+      Atomics.notify(view, 1);
+      await Promise.allSettled([completion]);
+    }
+  });
+
+  it("expires queued work and never launches cancelled asynchronous preparation", async () => {
+    const pool = createPool();
+    const counters = new SharedArrayBuffer(8);
+    const view = new Int32Array(counters);
+    const controller = new AbortController();
+    const reason = new Error("cancel prepared task");
+    let prepared!: (input: PoolFixtureInput) => void;
+    const preparing = pool.run(
+      () =>
+        new Promise<PoolFixtureInput>((resolve) => {
+          prepared = resolve;
+        }),
+      { timeoutMs: 10_000, signal: controller.signal },
+    );
+    const rejected = expect(preparing).rejects.toBe(reason);
+    const queuedFactory = vi.fn(() => ({ label: "expired", counters }));
+    await expect(pool.run(queuedFactory, { timeoutMs: 10 })).rejects.toMatchObject({
+      code: "timeout",
+    });
+    expect(queuedFactory).not.toHaveBeenCalled();
+    controller.abort(reason);
+    await rejected;
+    prepared({ label: "abandoned", counters });
+    await expect(
+      pool.run({ label: "current", counters }, { timeoutMs: 10_000 }),
+    ).resolves.toMatchObject({ label: "current" });
+    expect(Atomics.load(view, 0)).toBe(1);
+    expect(workers).toHaveLength(1);
+  });
+
+  it("terminates only the cancelled worker before admitting its replacement", async () => {
+    const pool = createPool();
+    const counters = new SharedArrayBuffer(8);
+    const controller = new AbortController();
+    const reason = new Error("cancel execution");
+    const active = pool.run(
+      { label: "cancelled", counters, wait: true },
+      { timeoutMs: 10_000, signal: controller.signal },
+    );
+    const rejected = expect(active).rejects.toBe(reason);
+    await expect.poll(() => Atomics.load(new Int32Array(counters), 0)).toBe(1);
+    const cancelledWorker = workers[0];
+    const replacement = pool.run({ label: "replacement" }, { timeoutMs: 10_000 });
+    controller.abort(reason);
+    await rejected;
+    expect(cancelledWorker?.threadId).toBe(-1);
+    await expect(replacement).resolves.toMatchObject({ label: "replacement" });
+    expect(workers).toHaveLength(2);
+  });
+
+  it.each([0, 1])(
+    "rejects exit code %i before a response and recovers capacity",
+    async (exitCode) => {
+      const pool = createPool();
+      await expect(
+        pool.run({ label: "exit", exitCode }, { timeoutMs: 10_000 }),
+      ).rejects.toMatchObject({ code: "unavailable" });
+      await expect(pool.run({ label: "next" }, { timeoutMs: 10_000 })).resolves.toMatchObject({
+        label: "next",
+      });
+      expect(workers).toHaveLength(2);
+    },
+  );
+
+  it("closes a generation before a rejected result can dispatch its successor", async () => {
+    const reason = new Error("generation superseded");
+    const pool = createPool({
+      workerUrl,
+      restartOnError: false,
+      validateResult: () => {
+        throw reason;
+      },
+    });
+    const first = pool.run({ label: "stale" }, { timeoutMs: 10_000 });
+    const nextFactory = vi.fn(() => ({ label: "forbidden" }));
+    const next = pool.run(nextFactory, { timeoutMs: 10_000 });
+    await Promise.all([expect(first).rejects.toBe(reason), expect(next).rejects.toBe(reason)]);
+    await expect(pool.run({ label: "closed" }, { timeoutMs: 10_000 })).rejects.toBe(reason);
+    expect(nextFactory).not.toHaveBeenCalled();
+    expect(workers).toHaveLength(1);
+    expect(workers[0]?.threadId).toBe(-1);
+  });
+
+  it("does not recreate an idle generation worker after it crashes", async () => {
+    const pool = createPool({ workerUrl, restartOnError: false, idleTimeoutMs: 0 });
+    await pool.run({ label: "generation" }, { timeoutMs: 10_000 });
+    const worker = workers[0];
+    assert.ok(worker);
+    await worker.terminate();
+    await expect(pool.run({ label: "forbidden" }, { timeoutMs: 10_000 })).rejects.toMatchObject({
+      code: "unavailable",
+    });
+    expect(workers).toHaveLength(1);
+  });
+
+  it("retires idle compute workers and transfers uniquely owned buffers in both directions", async () => {
+    const pool = createPool({ workerUrl, idleTimeoutMs: 20 });
+    const buffer = new ArrayBuffer(4);
+    new Uint8Array(buffer)[0] = 42;
+    const result = await pool.run(
+      { label: "transfer", buffer },
+      { timeoutMs: 10_000, transferList: (input) => [input.buffer!] },
+    );
+    expect(buffer.byteLength).toBe(0);
+    expect(new Uint8Array(result.buffer!)[0]).toBe(42);
+    expect((await pool.run({ label: "inspect" }, { timeoutMs: 10_000 })).previousBufferBytes).toBe(
+      0,
+    );
+    await expect.poll(() => workers[0]?.threadId).toBe(-1);
+    const next = await pool.run({ label: "new worker" }, { timeoutMs: 10_000 });
+    expect(next.threadId).not.toBe(result.threadId);
+  });
+
+  it("lets a headless process exit while warm workers are idle", async () => {
+    const moduleUrl = new URL("./worker-task-pool.ts", import.meta.url);
+    const { stdout } = await promisify(execFile)(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "--input-type=module",
+        "-e",
+        `import { WorkerTaskPool } from ${JSON.stringify(moduleUrl.href)};
+       const pool = new WorkerTaskPool({ workerUrl: new URL(${JSON.stringify(workerUrl.href)}) });
+       console.log((await pool.run({ label: "finished" }, { timeoutMs: 10000 })).label);`,
+      ],
+      { timeout: 15_000 },
+    );
+    expect(stdout.trim()).toBe("finished");
+  }, 20_000);
+});

--- a/src/infra/worker-task-pool.test.ts
+++ b/src/infra/worker-task-pool.test.ts
@@ -5,9 +5,9 @@ import { promisify } from "node:util";
 import { Worker } from "node:worker_threads";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkerTaskPool } from "./worker-task-pool.js";
-import type { PoolFixtureInput, PoolFixtureResult } from "./worker-task-pool.test-fixture.js";
+import type { PoolFixtureInput, PoolFixtureResult } from "./worker-task-pool.test-support.js";
 
-const workerUrl = new URL("./worker-task-pool.test-fixture.ts", import.meta.url);
+const workerUrl = new URL("./worker-task-pool.test-support.ts", import.meta.url);
 const pools: WorkerTaskPool<PoolFixtureInput, PoolFixtureResult>[] = [];
 const workers: Worker[] = [];
 const workerChannel = channel("worker_threads");

--- a/src/infra/worker-task-pool.ts
+++ b/src/infra/worker-task-pool.ts
@@ -1,0 +1,285 @@
+import { availableParallelism } from "node:os";
+import { parentPort, Worker, type Transferable, type WorkerOptions } from "node:worker_threads";
+import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
+import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+
+type WorkerTaskInput<Input> = Input | (() => Input | Promise<Input>);
+type WorkerTaskOptions<Input> = {
+  timeoutMs: number;
+  signal?: AbortSignal;
+  transferList?: (input: Input) => readonly Transferable[];
+};
+type WorkerReply<Output> = { status: "ok"; value: Output } | { status: "failed"; error: string };
+type Task<Input, Output> = {
+  input: WorkerTaskInput<Input>;
+  options: WorkerTaskOptions<Input>;
+  resolve: (value: Output) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+  abort: () => void;
+  done: boolean;
+  slot?: Slot<Input, Output>;
+};
+type Slot<Input, Output> = {
+  worker?: Worker;
+  task?: Task<Input, Output>;
+  idleTimer?: NodeJS.Timeout;
+  retiring?: Promise<void>;
+};
+
+export class WorkerTaskError extends Error {
+  constructor(
+    message: string,
+    readonly code: "unavailable" | "timeout" | "failed",
+  ) {
+    super(message);
+    this.name = "WorkerTaskError";
+  }
+}
+
+/** Bounded execution workers; each worker accepts one task at a time. */
+export class WorkerTaskPool<Input, Output> {
+  private readonly slots = new Set<Slot<Input, Output>>();
+  private readonly queue: Task<Input, Output>[] = [];
+  private readonly maxWorkers: number;
+  private closedError?: Error;
+
+  constructor(
+    private readonly options: {
+      workerUrl: URL;
+      workerOptions?: Omit<WorkerOptions, "eval">;
+      maxWorkers?: number;
+      idleTimeoutMs?: number;
+      restartOnError?: boolean;
+      validateResult?: (value: Output) => void;
+    },
+  ) {
+    this.maxWorkers = options.maxWorkers ?? availableParallelism();
+  }
+
+  run(input: WorkerTaskInput<Input>, options: WorkerTaskOptions<Input>): Promise<Output> {
+    if (this.closedError) {
+      return Promise.reject(this.closedError);
+    }
+    return new Promise<Output>((resolve, reject) => {
+      const abort = () =>
+        this.cancel(task, toErrorObject(options.signal?.reason, "worker task aborted"));
+      const task: Task<Input, Output> = {
+        input,
+        options,
+        resolve,
+        reject,
+        abort,
+        done: false,
+        // Queueing and asynchronous preparation consume the same budget as execution.
+        timer: setTimeout(
+          () => this.cancel(task, new WorkerTaskError("worker task timed out", "timeout")),
+          resolveTimerTimeoutMs(options.timeoutMs, 60_000),
+        ),
+      };
+      options.signal?.addEventListener("abort", abort, { once: true });
+      this.queue.push(task);
+      if (options.signal?.aborted) {
+        abort();
+      } else {
+        this.dispatch();
+      }
+    });
+  }
+
+  close(
+    error: Error = new WorkerTaskError("worker task pool closed", "unavailable"),
+  ): Promise<void> {
+    this.closedError ??= error;
+    for (const task of this.queue.splice(0)) {
+      this.finish(task, this.closedError);
+    }
+    for (const slot of this.slots) {
+      if (slot.task) {
+        this.finish(slot.task, this.closedError, undefined, true);
+      }
+    }
+    return Promise.all([...this.slots].map((slot) => this.retire(slot))).then(() => undefined);
+  }
+
+  private dispatch(): void {
+    while (!this.closedError && this.queue.length) {
+      let slot = [...this.slots].find((entry) => !entry.task && !entry.retiring);
+      if (!slot) {
+        if (this.slots.size >= this.maxWorkers) {
+          return;
+        }
+        slot = {};
+        this.slots.add(slot);
+      }
+      clearTimeout(slot.idleTimer);
+      const task = this.queue.shift()!;
+      slot.task = task;
+      task.slot = slot;
+      slot.worker?.ref();
+      void this.start(slot, task);
+    }
+  }
+
+  private async start(slot: Slot<Input, Output>, task: Task<Input, Output>): Promise<void> {
+    let input: Input;
+    try {
+      input =
+        typeof task.input === "function"
+          ? await (task.input as () => Input | Promise<Input>)() // SAFETY: Callable inputs are factories.
+          : task.input;
+    } catch (error) {
+      this.fail(slot, toErrorObject(error, "worker task preparation failed"));
+      return;
+    }
+    // A cancelled preparation may finish later, but it must never create or feed a worker.
+    if (task.done) {
+      return;
+    }
+    try {
+      if (!slot.worker) {
+        const worker = new Worker(this.options.workerUrl, {
+          execArgv: this.options.workerUrl.pathname.endsWith(".ts") ? ["--import", "tsx"] : [],
+          ...this.options.workerOptions,
+        });
+        slot.worker = worker;
+        worker.on("message", (message: unknown) => this.receive(slot, message));
+        worker.on("error", (error) =>
+          this.fail(slot, new WorkerTaskError(String(error), "unavailable")),
+        );
+        worker.on("messageerror", (error) =>
+          this.fail(slot, new WorkerTaskError(String(error), "unavailable")),
+        );
+        worker.once("exit", (code) =>
+          this.fail(slot, new WorkerTaskError(`worker exited with code ${code}`, "unavailable")),
+        );
+      }
+      const transferList = task.options.transferList?.(input);
+      if (!task.done) {
+        slot.worker.postMessage({ input }, transferList);
+      }
+    } catch (error) {
+      this.fail(slot, new WorkerTaskError(String(error), "unavailable"));
+    }
+  }
+
+  private receive(slot: Slot<Input, Output>, message: unknown): void {
+    if (slot.retiring) {
+      return;
+    }
+    const task = slot.task;
+    if (!task || !isRecord(message) || (message.status !== "ok" && message.status !== "failed")) {
+      this.fail(slot, new WorkerTaskError("invalid worker task response", "unavailable"));
+      return;
+    }
+    // SAFETY: The private worker entry owns Output; the transport discriminant is checked above.
+    const reply = message as WorkerReply<Output>;
+    if (reply.status === "failed") {
+      this.finish(task, new WorkerTaskError(reply.error, "failed"));
+      return;
+    }
+    try {
+      // The owner must accept its lifecycle-bound result before a successor can execute.
+      this.options.validateResult?.(reply.value);
+    } catch (error) {
+      this.fail(slot, toErrorObject(error, "worker result validation failed"));
+      return;
+    }
+    this.finish(task, undefined, reply.value);
+  }
+
+  private cancel(task: Task<Input, Output>, error: Error): void {
+    if (task.done) {
+      return;
+    }
+    if (task.slot) {
+      this.fail(task.slot, error);
+    } else {
+      this.finish(task, error);
+    }
+  }
+
+  private fail(slot: Slot<Input, Output>, error: Error): void {
+    if (slot.retiring) {
+      return;
+    }
+    if (this.options.restartOnError === false) {
+      void this.close(error);
+    } else if (slot.task) {
+      this.finish(slot.task, error, undefined, true);
+    } else {
+      void this.retire(slot);
+    }
+  }
+
+  private finish(task: Task<Input, Output>, error?: Error, value?: Output, retire = false): void {
+    if (task.done) {
+      return;
+    }
+    task.done = true;
+    clearTimeout(task.timer);
+    task.options.signal?.removeEventListener("abort", task.abort);
+    const queuedIndex = this.queue.indexOf(task);
+    if (queuedIndex !== -1) {
+      this.queue.splice(queuedIndex, 1);
+    }
+    // SAFETY: Only a validated successful reply reaches finish without an error and supplies Output.
+    const complete = () => (error ? task.reject(error) : task.resolve(value as Output));
+    const slot = task.slot;
+    if (slot) {
+      slot.task = undefined;
+      if (retire) {
+        // Keep the slot reserved and the caller pending until its execution actually stops.
+        void this.retire(slot).then(complete);
+        return;
+      }
+      slot.worker?.unref();
+      const idleMs = this.options.idleTimeoutMs ?? 60_000;
+      if (idleMs > 0) {
+        slot.idleTimer = setTimeout(() => void this.retire(slot), idleMs);
+        slot.idleTimer.unref();
+      }
+    }
+    complete();
+    this.dispatch();
+  }
+
+  private retire(slot: Slot<Input, Output>): Promise<void> {
+    clearTimeout(slot.idleTimer);
+    // Retain error listeners until exit: termination can race a worker startup error.
+    return (slot.retiring ??= (slot.worker?.terminate() ?? Promise.resolve()).then(() => {
+      slot.worker?.removeAllListeners();
+      this.slots.delete(slot);
+      this.dispatch();
+    }));
+  }
+}
+
+/** Pool dispatch is serial per worker; handlers finish cleanup before returning their result. */
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- The handler owns the private input type.
+export function serveWorkerTasks<Input, Output>(
+  handler: (input: Input) => Output | Promise<Output>,
+  options: { transferList?: (value: Output) => Transferable[] } = {},
+): void {
+  const port = parentPort;
+  if (!port) {
+    return;
+  }
+  port.on("message", ({ input }: { input: Input }) => {
+    void Promise.resolve()
+      .then(() => handler(input))
+      .then((value) =>
+        port.postMessage(
+          { status: "ok", value } satisfies WorkerReply<Output>,
+          options.transferList?.(value) ?? [],
+        ),
+      )
+      .catch((error: unknown) =>
+        port.postMessage({
+          status: "failed",
+          error: error instanceof Error ? error.message : String(error),
+        } satisfies WorkerReply<Output>),
+      );
+  });
+}

--- a/src/infra/worker-task-pool.ts
+++ b/src/infra/worker-task-pool.ts
@@ -257,16 +257,15 @@ export class WorkerTaskPool<Input, Output> {
 }
 
 /** Pool dispatch is serial per worker; handlers finish cleanup before returning their result. */
-// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- The handler owns the private input type.
-export function serveWorkerTasks<Input, Output>(
-  handler: (input: Input) => Output | Promise<Output>,
+export function serveWorkerTasks<Output>(
+  handler: (input: unknown) => Output | Promise<Output>,
   options: { transferList?: (value: Output) => Transferable[] } = {},
 ): void {
   const port = parentPort;
   if (!port) {
     return;
   }
-  port.on("message", ({ input }: { input: Input }) => {
+  port.on("message", ({ input }: { input: unknown }) => {
     void Promise.resolve()
       .then(() => handler(input))
       .then((value) =>


### PR DESCRIPTION
## What Problem This Solves

Repeated CodeMode executions pay for fresh Node workers and TypeScript initialization on every execution/resume, while ordinary single-session Gateway reads decode unrelated session rows. Those costs consume CPU and delay concurrent work on large machines.

This is a maintainer-requested performance refactor. It replaces duplicated worker lifecycle code with one bounded execution owner and removes unnecessary work from single-session reads.

## Why This Change Was Made

CodeMode and compaction reuse lazily created workers; TypeScript preparation runs in the worker, snapshots transfer ownership, and every CodeMode execution/resume still creates or restores an isolated QuickJS VM. Queueing and preparation consume the original deadline, and cancellation waits for actual worker termination before releasing capacity. Catalog workers stay bound to their immutable generation; auth warming remains disposable. Host tools, approvals and session orchestration retain their existing authority owners.

Single-session lookups use the existing exact SQLite row accessor, preserving hidden-session visibility and borrowed-read behavior. No configuration, dependency, protocol or database schema changes.

Production LOC: **+1, 036 / -1, 048, net -12**. Tests and test support: +576 / -266, net +310. Documentation: +7; assertion ratchet: net zero. The removed paths are per-task worker startup/termination plumbing, duplicate catalog request bookkeeping and main-thread TypeScript preparation.

## User Impact

CodeMode becomes substantially faster after workers are warm, with less worker startup CPU and main-thread blocking. Sessions retain their existing orchestration and tool-authorization behavior; this does not move entire session loops to workers or claim a measured general Gateway throughput improvement.

Warm workers retain more memory. In the measured 16-way TypeScript workload, process RSS after the warm batch rose from approximately 910 MiB to 2,338 MiB. Workers retire after 60 idle seconds, but a sustained follow-up still recorded approximately 2,569 MiB RSS after every worker retired and a diagnostic parent GC. The source audit found no concrete retained per-execution VM/snapshot owner; native-memory attribution and long-term plateau remain unproven. This tradeoff was disclosed before the maintainer requested landing.

## Evidence

Three alternating baseline/candidate packaged runs on Node 24.19.0, with the same installed dependencies and complete matching 148-plugin build inventories. Each process verified all 190 real host-tool bridge calls and independent context markers. The host also ran unrelated jobs, so these are observed sample medians rather than a dedicated-host capacity claim.

| TypeScript workload | Before | After |
| --- | ---: | ---: |
| First script, five host-tool bridges | 329.7 ms | 210.0 ms |
| Five warm sequential scripts | 927.3 ms | 60.1 ms |
| Sixteen warm concurrent scripts | 297.8 ms | 38.0 ms |
| Worker starts across the 190-call workload | 228 | 16 |

The warm concurrent workload used about 85% less CPU time; the first-script main-thread timer overrun fell from 127.2 ms to 1.4 ms. A longer 1,790-call run stayed at 16 workers and all retired after the idle deadline; the memory limitation above remains.

Validation completed before publication:

- Canonical focused suites covering real worker reuse, queue and active cancellation, termination ordering, early exit, transfers, generation fencing, TypeScript budgets, headless cancellation, compaction, catalog and auth: 191 passing tests across 10 files. The shared-pool suite was rerun after final test type fixes: 9/9 passed.
- Gateway session/cache suites: 239 passed. The before-fix regression decoded 72 unrelated rows; the candidate decoded zero for both normal and borrowed reads.
- ClawRouter prepared-catalog E2E: both cold discovery cases passed, with and without sibling catalog state.
- `node scripts/check-changed.mjs --base HEAD`: passed, including core/test types, formatting, lint, architectural guards, dead exports and runtime import cycles.
- `node --import ./scripts/tsx.mjs scripts/build-all.mts sourcePerformance`: passed, including packaged worker entries. Full build reached the UI gzip budget and failed on unchanged UI code: 348,450 bytes against 348,368. All 1,537 source modules in that closure matched the baseline; clearing only the dirty build flag still exceeded the budget. No UI budget was relaxed.
- Real packaged Gateway mock-provider flow at 32 concurrent turns: both revisions completed 32 turns, 128 patches and 96 provider requests. Build-profile and host-load confounders prevent a causal Gateway speedup claim.
- Fresh Codex autoreview found no actionable P0 findings. Independent source review covered lifecycle, cancellation, deadline accounting, VM isolation, snapshot ownership and current-main catalog integration.

The first hosted CI run caught a test fixture filename outside the existing test-support convention and a new lint suppression. The correction renames the fixture and makes the shared transport accept unknown input; the catalog worker owns request validation. No lint/dead-code allowlists or budgets were increased. The same run also hit the independently reproduced Doctor readiness-fixture timeout. Its existing repair landed in #134812 as `113805d6a517c27b7c2521be58c2e1fd84093ba0`: the canonical prepared-runtime fixture and explicit prerequisite retain the original deadlines and migration assertions. The next merge-candidate CI run includes that upstream repair; this PR does not duplicate or take credit for it. Correction verification passed: 43 tests across five files, the complete changed-file gate run, and fresh Codex P0 review with no findings. Hosted [CI 33481377907](https://github.com/openclaw/openclaw/actions/runs/33481377907) completed successfully on exact corrected head `c998a9ed9c410e273ce5ef292602ca88982d05a9`: 197 successful jobs, 16 skipped and 0 failures. Remaining follow-ups are sustained native-memory attribution and exported-source plugin discovery when an enclosing Git worktree reports an empty tracked-file list. The historical UI failure above remains recorded; current main includes separate UI-budget repairs.

A separate current-main follow-up found during integration reading needs reproduction: `advancePreparedModelRuntimeOwnerConfig` stamps a new snapshot without updating `ownersBySnapshot`, which may leave a subsequent explicit stale-catalog refresh unable to resolve its owner. This preexists the worker refactor and is outside its patch.

## Review response and capacity decision

ClawSweeper's September 1 review identifies the same memory tradeoff reported above and explicitly offers maintainer acceptance as an alternative to adding a new process-wide ceiling. The maintainer requested landing after receiving those measurements. This PR takes that documented tradeoff: each reusable compute pool has a finite CPU-count ceiling, but the pools do not share a process-wide worker or memory budget. Larger CPU counts can retain more warm workers and consume substantially more memory. Sixty-second retirement proves worker lifecycle completion, not operating-system RSS reclamation or a proven long-term memory plateau.

The rank-up suggestion to add a process-wide ceiling is intentionally deferred; it requires separate capacity-policy and workload evidence. No claim of safe capacity at arbitrary core counts is made. The reported stored-data-model flags do not correspond to a schema change: the pool is in-process worker state, and session reads use an existing exact-row accessor without DDL, migration, or changed persistence semantics.
