### PR TITLE
test(agents): await ask_user RPC startup without polling

### DIFF
--- a/src/agents/tools/ask-user-tool.test.ts
+++ b/src/agents/tools/ask-user-tool.test.ts
@@ -1,5 +1,6 @@
 import { Value } from "typebox/value";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
 import { ReplyDispatchDeliveryError } from "../../auto-reply/reply/reply-dispatch-outcome.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
 import { steerActiveSessionWithOptionalDeliveryWait } from "../embedded-agent-runner/run/attempt-queue-message.js";
@@ -43,8 +44,26 @@ function gatewayStub(
     extra?: { signal?: AbortSignal },
   ) => Promise<unknown>,
 ) {
-  const mock = vi.fn(implementation);
-  return { mock, call: mock as unknown as GatewayCall };
+  const started = {
+    "question.request": createDeferred(),
+    "question.waitAnswer": createDeferred(),
+  };
+  const mock = vi.fn((...args: Parameters<typeof implementation>) => {
+    const response = implementation(...args);
+    const [method] = args;
+    // Callback setup has completed, but the owner's later prompt-delivery phase
+    // is not implied by starting either RPC.
+    if (method === "question.request" || method === "question.waitAnswer") {
+      started[method].resolve();
+    }
+    return response;
+  });
+  return {
+    mock,
+    call: mock as unknown as GatewayCall,
+    waitForCall: (method: keyof typeof started) =>
+      withTestTimeout(started[method].promise, 1_000, `ask_user did not start ${method}`),
+  };
 }
 
 function requestedQuestionId(mock: ReturnType<typeof gatewayStub>["mock"]): string {
@@ -277,11 +296,13 @@ describe("ask_user prompt delivery", () => {
     await vi.waitFor(() =>
       expect(gateway.mock.mock.calls.some(([method]) => method === "question.request")).toBe(true),
     );
-    let readyQuestions: unknown;
-    void waitForAskUserPromptReady(reservation.questionId).then((value) => {
-      readyQuestions = value;
-    });
-    await vi.waitFor(() => expect(readyQuestions).toEqual(questions));
+    await expect(
+      withTestTimeout(
+        waitForAskUserPromptReady(reservation.questionId),
+        1_000,
+        "ask_user prompt readiness did not reach the subscriber module",
+      ),
+    ).resolves.toEqual(questions);
 
     settleAskUserPromptDelivery(reservation.questionId);
     finishWait?.({
@@ -390,7 +411,8 @@ describe("ask_user execution", () => {
       gatewayCall: gateway.call,
     });
     const first = tool.execute("call-first", validArgs);
-    await vi.waitFor(() => expect(finishWait).toBeTypeOf("function"));
+    await gateway.waitForCall("question.waitAnswer");
+    expect(finishWait).toBeTypeOf("function");
 
     await expect(tool.execute("call-second", validArgs)).rejects.toThrow(
       "already has a pending question",
@@ -418,9 +440,8 @@ describe("ask_user execution", () => {
       sessionKey: "agent:main:abort",
       gatewayCall: gateway.call,
     }).execute("call-abort", validArgs, controller.signal);
-    await vi.waitFor(() =>
-      expect(gateway.mock.mock.calls.some((call) => call[0] === "question.waitAnswer")).toBe(true),
-    );
+    await gateway.waitForCall("question.waitAnswer");
+    expect(gateway.mock.mock.calls.some((call) => call[0] === "question.waitAnswer")).toBe(true);
     const questionId = requestedQuestionId(gateway.mock);
 
     controller.abort(new Error("stop"));
@@ -449,9 +470,8 @@ describe("ask_user execution", () => {
       sessionKey: "agent:main:register-abort",
       gatewayCall: gateway.call,
     }).execute("call-register-abort", validArgs, controller.signal);
-    await vi.waitFor(() =>
-      expect(gateway.mock.mock.calls.some((call) => call[0] === "question.request")).toBe(true),
-    );
+    await gateway.waitForCall("question.request");
+    expect(gateway.mock.mock.calls.some((call) => call[0] === "question.request")).toBe(true);
     const questionId = requestedQuestionId(gateway.mock);
 
     controller.abort(new Error("stop"));
@@ -492,7 +512,8 @@ describe("ask_user execution", () => {
       validArgs,
       controller.signal,
     );
-    await vi.waitFor(() => expect(finishRegistration).toBeTypeOf("function"));
+    await gateway.waitForCall("question.request");
+    expect(finishRegistration).toBeTypeOf("function");
 
     controller.abort(new Error("stop before registration completed"));
     finishRegistration?.({ id: reservation.questionId });
@@ -533,7 +554,8 @@ describe("ask_user execution", () => {
       "call-register-image",
       validArgs,
     );
-    await vi.waitFor(() => expect(finishRegistration).toBeTypeOf("function"));
+    await gateway.waitForCall("question.request");
+    expect(finishRegistration).toBeTypeOf("function");
     const questionId = requestedQuestionId(gateway.mock);
     const steer = vi.fn(async () => undefined);
     const images = [{ type: "image" as const, data: "pixels", mimeType: "image/png" }];
@@ -758,7 +780,8 @@ describe("ask_user execution", () => {
       sessionKey: "agent:main:claim",
       gatewayCall: gateway.call,
     }).execute("call-claim", validArgs);
-    await vi.waitFor(() => expect(finishWait).toBeTypeOf("function"));
+    await gateway.waitForCall("question.waitAnswer");
+    expect(finishWait).toBeTypeOf("function");
     const questionId = requestedQuestionId(gateway.mock);
     const steer = vi.fn(async () => undefined);
     const activeSession = { steer, subscribe: vi.fn(() => () => undefined) };
@@ -824,7 +847,8 @@ describe("ask_user execution", () => {
       `call-${suffix}`,
       validArgs,
     );
-    await vi.waitFor(() => expect(finishWait).toBeTypeOf("function"));
+    await gateway.waitForCall("question.waitAnswer");
+    expect(finishWait).toBeTypeOf("function");
     const questionId = requestedQuestionId(gateway.mock);
     const steer = vi.fn(async () => undefined);
     const images = [{ type: "image" as const, data: "pixels", mimeType: "image/png" }];
@@ -888,7 +912,8 @@ describe("ask_user execution", () => {
       "call-resolve-loss",
       validArgs,
     );
-    await vi.waitFor(() => expect(finishWait).toBeTypeOf("function"));
+    await gateway.waitForCall("question.waitAnswer");
+    expect(finishWait).toBeTypeOf("function");
     const steer = vi.fn(async () => undefined);
     const persistApproved = vi.fn(async () => undefined);
 
@@ -930,7 +955,8 @@ describe("ask_user execution", () => {
       sessionKey: "agent:main:terminal-race",
       gatewayCall: gateway.call,
     }).execute("call-terminal-race", validArgs);
-    await vi.waitFor(() => expect(finishWait).toBeTypeOf("function"));
+    await gateway.waitForCall("question.waitAnswer");
+    expect(finishWait).toBeTypeOf("function");
     const steer = vi.fn(async () => undefined);
 
     await steerActiveSessionWithOptionalDeliveryWait(


### PR DESCRIPTION
## What Problem This Solves

The ask_user tests poll for registration or answer callbacks even though those fixtures already own the moment their synchronous setup finishes. Another poll watches an existing prompt-readiness promise indirectly through a temporary variable.

## Why This Change Was Made

Give each gateway stub bounded request/answer start signals. Invoke the original callback first, then signal that its resolver or abort listener is installed, and return its exact Promise. Await the existing prompt-readiness promise directly for the cross-module equality check.

RPC startup does not establish the later prompt-delivery phase. The four delivery-phase polls, intentional split-module reset and canonical per-case registry cleanup remain.

## User Impact

Test-only: production +0/-0; tests +46/-20 (net +26). Ten polling sites across eleven expanded case executions disappear. All 32 ask_user cases and 79 source expect calls remain, including the exact registration-abort and cancellation assertions. Every replacement wait keeps the original one-second failure bound. No elapsed-time speedup is claimed.

## Evidence

The normal before/after runs each pass 65/65: 32 ask_user cases and 33 secrets-tool siblings, with identical native names and statuses. Source comparison confirms 78 matcher expressions are identical; the remaining question-equality assertion directly awaits the same readiness promise.

A temporary fault suppressing only the request-start signal produces the sole expected registration-abort failure: `ask_user did not start question.request`, through the existing one-second helper. The other 31 cases skip, with no unhandled error or global timeout. Exact source bytes were restored, and the managed runner's group, leader and output completion were verified. The fault occurs before the case aborts its controller, so this proves the failure bound; the separate passing run proves its later abort and cancellation assertions.

The Gateway-question harness also passes 11/11. Full changed-file checks and scoped Codex autoreview pass; broader lead and independent review found no actionable issue. The initial lint check identified two redundant type arguments. Removing them leaves identical runtime code, and the full gate and review passed afterward.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/tools/ask-user-tool.test.ts src/agents/tools/secrets-tool.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/harness/gateway-question.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base eaaa6da895f625a2421853587c3ef21286325b7c
```

Named follow-up: replace the four remaining delivery-phase polls only when a true prompt-ready observation is available. Registry and claim cleanup does not establish that every execute Promise joined; the intentionally faulted registration remains pending when its start gate times out. This change makes no full asynchronous settlement or live Gateway proof claim.
