### PR TITLE
fix(macos): bind exec approval fixtures to the canonical cwd owner

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/ExecAllowlistTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecAllowlistTests.swift
@@ -41,8 +41,8 @@ struct ExecAllowlistTests {
     }
 
     private static func cwdBoundArgPattern(_ argv: [String], cwd: String) -> String {
-        // Canonicalization is the production owner's policy; a local copy silently desynchronizes
-        // whenever that policy changes, and only under symlinked roots such as /tmp.
+        // Use the approval cwd identity: Foundation folds existing /private paths back to their
+        // aliases, so a local copy of this normalization changes the bytes these fixtures hash.
         let normalizedCwd = ExecCommandResolution.canonicalApprovalCwd(cwd)
         let arguments = Array(argv.dropFirst())
         let argvSubject = "\(arguments.count)\0" + arguments
@@ -316,11 +316,16 @@ struct ExecAllowlistTests {
     }
 
     @Test func `cwd bound hash matches the shared cross platform vector`() {
-        #expect(
-            Self.cwdBoundArgPattern(
-                ["/usr/bin/printf", "hello world", ""],
-                cwd: "/workspace") ==
-                "sha256:cwd-argv:v1:2b4f4aed226aa1fd771c852b8f74e4c162d440aafaf60bfef19746f3b2ee5890")
+        let argv = ["/usr/bin/printf", "hello world", ""]
+        let vector = "sha256:cwd-argv:v1:2b4f4aed226aa1fd771c852b8f74e4c162d440aafaf60bfef19746f3b2ee5890"
+        #expect(Self.cwdBoundArgPattern(argv, cwd: "/workspace") == vector)
+        // src/infra/exec-approvals-allow-always.test.ts pins the same literal through its own
+        // builder; the app must reach it through production, not only through this fixture.
+        let patterns = ExecCommandResolution.resolveAllowAlwaysPatterns(
+            command: argv,
+            cwd: "/workspace",
+            env: ["PATH": "/usr/bin:/bin"])
+        #expect(patterns.first?.argPattern == vector)
     }
 
     @Test func `cwd bound patterns give a symlinked working directory one identity`() throws {

--- a/apps/macos/Tests/OpenClawIPCTests/ExecAllowlistTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecAllowlistTests.swift
@@ -41,7 +41,9 @@ struct ExecAllowlistTests {
     }
 
     private static func cwdBoundArgPattern(_ argv: [String], cwd: String) -> String {
-        let normalizedCwd = URL(fileURLWithPath: cwd).standardizedFileURL.resolvingSymlinksInPath().path
+        // Canonicalization is the production owner's policy; a local copy silently desynchronizes
+        // whenever that policy changes, and only under symlinked roots such as /tmp.
+        let normalizedCwd = ExecCommandResolution.canonicalApprovalCwd(cwd)
         let arguments = Array(argv.dropFirst())
         let argvSubject = "\(arguments.count)\0" + arguments
             .map { "\($0.data(using: .utf8)?.count ?? 0)\0\($0)\0" }
@@ -319,6 +321,31 @@ struct ExecAllowlistTests {
                 ["/usr/bin/printf", "hello world", ""],
                 cwd: "/workspace") ==
                 "sha256:cwd-argv:v1:2b4f4aed226aa1fd771c852b8f74e4c162d440aafaf60bfef19746f3b2ee5890")
+    }
+
+    @Test func `cwd bound patterns give a symlinked working directory one identity`() throws {
+        let fm = FileManager()
+        // macOS reaches one directory through /tmp and /private/tmp, and Foundation folds the real
+        // path back to the link. Approval identity must stay the realpath for either spelling.
+        let name = "oc-exec-cwd-\(UUID().uuidString)"
+        let realDirectory = "/private/tmp/\(name)"
+        let linkedDirectory = "/tmp/\(name)"
+        try fm.createDirectory(atPath: realDirectory, withIntermediateDirectories: false)
+        defer { try? fm.removeItem(atPath: realDirectory) }
+        try #require(fm.fileExists(atPath: linkedDirectory))
+
+        #expect(ExecCommandResolution.canonicalApprovalCwd(linkedDirectory) == realDirectory)
+        #expect(ExecCommandResolution.canonicalApprovalCwd(realDirectory) == realDirectory)
+
+        let command = ["/usr/bin/printf", "safe_marker"]
+        let env = ["PATH": "/usr/bin:/bin"]
+        let viaLink = ExecCommandResolution.resolveAllowAlwaysPatterns(
+            command: command, cwd: linkedDirectory, env: env)
+        let viaReal = ExecCommandResolution.resolveAllowAlwaysPatterns(
+            command: command, cwd: realDirectory, env: env)
+        let linkedPattern = try #require(viaLink.first?.argPattern)
+        #expect(linkedPattern == viaReal.first?.argPattern)
+        #expect(linkedPattern == Self.cwdBoundArgPattern(command, cwd: linkedDirectory))
     }
 
     @Test func `arg pattern does not discard redirect shaped direct argv literal`() {


### PR DESCRIPTION
## What Problem This Solves

`ExecAllowlistTests` fails deterministically on any machine whose checkout lives under `/tmp`, `/private/tmp`, `/var/tmp`, or `/private/var/tmp`:

```
Test "allow always patterns preserve generated sh lc raw payload binding" recorded an issue
at ExecAllowlistTests.swift:1089:9: Expectation failed:
patterns.first?.argPattern == Self.cwdBoundArgPattern(["/usr/bin/printf", "safe_marker"],
                                                      cwd: FileManager.default.currentDirectoryPath)
```

The cwd-bound approval hash has one canonical owner, `ExecCommandResolution.canonicalApprovalCwd`. #129636 introduced it, and at that point the fixture in `ExecAllowlistTests` carried a byte-identical copy of the same normalization, so the two agreed. #131717 then hardened production from Foundation path resolution to POSIX `realpath()`, with an inline comment naming the exact hazard — *"Foundation can fold /private/tmp back to the /tmp symlink. Identity needs POSIX realpath."* — but left the deleted implementation behind in the test helper.

Foundation strips `/private` whenever the shortened path exists, in both directions: `/private/var/tmp` normalizes to `/var/tmp`, and `/tmp` normalizes to `/tmp`, while `realpath` returns `/private/var/tmp` and `/private/tmp`. Every other call site in the suite passes a synthetic path such as `/workspace`, where the two implementations agree because `realpath` fails and production falls back to the same lexical form. Exactly one test passes the real process working directory, and that is the one that breaks. GitHub runners check out under `/Users/runner/work`, which is unaffected, so CI has never seen it.

## Why This Change Was Made

Re-syncing the copy would leave the same defect one commit away, so the duplicated policy is deleted instead: the fixture asks the production owner to canonicalize, exactly like the matcher, the evaluator, and the store already do.

Two pieces of coverage back that up:

- A new test pins the invariant on production's side — one directory reached as `/tmp/<uuid>` and `/private/tmp/<uuid>` must produce one approval identity. It fails on the pre-fix helper for the right reason, deterministically, regardless of where the checkout lives.
- The existing shared cross-platform digest vector previously only exercised the fixture. `src/infra/exec-approvals-allow-always.test.ts` pins the same literal through its production builder; the Swift vector now asserts it through `resolveAllowAlwaysPatterns` as well, so the app-side production path is held to the cross-language contract directly.

## User Impact

None at runtime. Test-only change; production LOC delta is 0. The practical effect is that the macOS suite stops reporting a phantom approval-hash failure for maintainers and agents working in worktrees under `/tmp`, which is the layout this repository's own guidance asks for.

## Evidence

Root cause: incomplete repair in d65e712b280 (#131717), which changed the canonical cwd normalization and left a fossil of the removed implementation in `ExecAllowlistTests.swift:43`.
Architectural owner: `ExecCommandResolution.canonicalApprovalCwd` (`apps/macos/Sources/OpenClaw/ExecCommandResolution.swift:25`).
Removed path: the duplicated Foundation normalization in the test fixture.
Production LOC delta: 0. Tests: +33 / −8.

Normalization divergence measured on macOS 27 (arm64):

```
/tmp             foundation=/tmp            realpath=/private/tmp        match=false
/private/var/tmp foundation=/var/tmp        realpath=/private/var/tmp    match=false
/var/tmp         foundation=/var/tmp        realpath=/private/var/tmp    match=false
/Users           foundation=/Users          realpath=/Users              match=true
```

Failing reproduction, checkout at `/private/tmp/oc-retest-main`, before the fix:

```
swift test --package-path apps/macos --build-system native --skip-build --filter ExecAllowlistTests
Test run with 62 tests in 1 suite failed after 0.245 seconds with 1 issue.
```

New test against the pre-fix helper (deterministic, independent of checkout location):

```
Test "cwd bound patterns give a symlinked working directory one identity" recorded an issue
at ExecAllowlistTests.swift:346:9: Expectation failed:
linkedPattern == Self.cwdBoundArgPattern(command, cwd: linkedDirectory)
Test run with 1 test in 1 suite failed after 0.009 seconds with 1 issue.
```

After the fix:

```
swift test ... --filter ExecAllowlistTests
Test run with 63 tests in 1 suite passed after 0.148 seconds.

swift test ... --filter Exec
Test run with 222 tests in 20 suites passed after 11.586 seconds.
```

Formatting and lint: `swiftformat --lint --config config/swiftformat` reports `0/1 files require formatting`. `swiftlint --config config/swiftlint.yml` reports only the pre-existing `type_body_length` warning on this file (1028 counted lines before, 1048 after; warning threshold 800, error threshold 1200).

Independent review: a full-context review pass read `ExecCommandResolution`, `ExecAllowlistMatcher`, `ExecApprovalsStore`, `ExecApprovalEvaluation`, `ExecApprovals`, `ExecHostExecutor`, the TypeScript counterparts, and the history of each. It found no other fossil sharing this invariant, confirmed the remaining Foundation calls in the neighbourhood serve different identities (executable identity, skill-bin identity, state-directory keys, socket lifecycle) and must not be mechanically converted, and confirmed no TypeScript change is required. Its two non-blocking suggestions — the corrected comment wording and reaching the shared vector through production — are both applied in this PR.

Not fixed here, recorded as follow-ups:

- `ExecAllowlistTests` is at 1048 counted lines against a 1200-line SwiftLint error threshold and should be split by concern.
- `ShellExecutorTimeoutTests` is flaky by construction on current `main`, unrelated to this change: its fixtures must fork, exec `/bin/sh`, and publish a pid file inside a 100 ms executor timeout, and the assertion reads that file afterwards. Measured `/bin/sh` spawn-to-pid-write latency on this host is p50 40 ms, p90 67 ms, max 88 ms, and the suite failed 2 of 4 runs on clean `origin/main`. Every observed failure was the missing pid file; `waitUntilGone` never returned false, so the executor's kill-and-reap behaviour itself is sound. Being fixed separately.
