### PR TITLE
fix(config): redact pre-migration snapshots in responses

### DIFF
--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -50,13 +50,14 @@ function expectGatewayAuthFieldValue(
 }
 
 describe("redactConfigSnapshot", () => {
-  it("does not expose internal plugin metadata snapshot fields", () => {
+  it.each([true, false])("does not expose internal plugin metadata (valid=%s)", (valid) => {
     const snapshot = {
       ...makeSnapshot({
         plugins: {
           allow: ["demo"],
         },
       }),
+      valid,
       pluginMetadataSnapshot: {
         manifestRegistry: {
           plugins: [
@@ -75,6 +76,57 @@ describe("redactConfigSnapshot", () => {
 
     expect("pluginMetadataSnapshot" in result).toBe(false);
   });
+
+  it.each([true, false])(
+    "redacts pre-migration credentials without mutating source (valid=%s)",
+    (valid) => {
+      const source = makeSnapshot({
+        channels: { discord: { token: "synthetic-discord-token" } },
+        models: {
+          providers: {
+            inline: { apiKey: "synthetic-provider-key", models: [] },
+            referenced: {
+              apiKey: { source: "env", provider: "default", id: "SYNTHETIC_PROVIDER_KEY" },
+              models: [],
+            },
+          },
+        },
+      });
+      const snapshot = {
+        ...makeSnapshot({}),
+        valid,
+        sourceConfigBeforeMigrations: source.sourceConfig,
+      };
+      const before = structuredClone(snapshot);
+
+      const result = redactConfigSnapshot(snapshot, mainSchemaHints);
+
+      expect(snapshot).toEqual(before);
+      expect(result.sourceConfigBeforeMigrations).toEqual(
+        valid
+          ? {
+              channels: { discord: { token: REDACTED_SENTINEL } },
+              models: {
+                providers: {
+                  inline: { apiKey: REDACTED_SENTINEL, models: [] },
+                  referenced: {
+                    apiKey: { source: "env", provider: "default", id: REDACTED_SENTINEL },
+                    models: [],
+                  },
+                },
+              },
+            }
+          : {},
+      );
+      for (const secret of [
+        "synthetic-discord-token",
+        "synthetic-provider-key",
+        "SYNTHETIC_PROVIDER_KEY",
+      ]) {
+        expect(JSON.stringify(result)).not.toContain(secret);
+      }
+    },
+  );
 
   it("redacts common secret field patterns across config sections", () => {
     const snapshot = makeSnapshot({

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -325,18 +325,20 @@ export function redactConfigSnapshot(
   snapshot: ConfigFileSnapshot,
   uiHints?: ConfigUiHints,
 ): ConfigFileSnapshot {
+  const { pluginMetadataSnapshot: _pluginMetadataSnapshot, ...publicSnapshot } =
+    snapshot as typeof snapshot & {
+      pluginMetadataSnapshot?: unknown;
+    };
   if (!snapshot.valid) {
-    // This is bad. We could try to redact the raw string using known key names,
-    // but then we would not be able to restore them, and would trash the user's
-    // credentials. Less than ideal---we should never delete important data.
-    // On the other hand, we cannot hand out "raw" if we're not sure we have
-    // properly redacted all sensitive data. Handing out a partially or, worse,
-    // unredacted config string would be bad.
-    // Therefore, the only safe route is to reject handling out broken configs.
+    // Invalid config cannot safely round-trip through redaction and restoration.
+    // Withhold every config projection so diagnostics cannot expose credentials.
     const redactedConfig = {} as ConfigFileSnapshot["config"];
     const redactedResolved = {} as ConfigFileSnapshot["resolved"];
     return {
-      ...snapshot,
+      ...publicSnapshot,
+      sourceConfigBeforeMigrations: snapshot.sourceConfigBeforeMigrations
+        ? redactedResolved
+        : undefined,
       sourceConfig: redactedResolved,
       runtimeConfig: redactedConfig,
       config: redactedConfig,
@@ -345,9 +347,6 @@ export function redactConfigSnapshot(
       resolved: redactedResolved,
     };
   }
-  // else: snapshot.config must be valid and populated, as that is what
-  // readConfigFileSnapshot() does when it creates the snapshot.
-
   const redactedConfig = redactObject(snapshot.config, uiHints);
   const redactedParsed = snapshot.parsed ? redactObject(snapshot.parsed, uiHints) : snapshot.parsed;
   let redactedRaw = snapshot.raw ? redactRawText(snapshot.raw, snapshot.config, uiHints) : null;
@@ -366,13 +365,9 @@ export function redactConfigSnapshot(
   }
   // Also redact the resolved config (contains values after ${ENV} substitution)
   const redactedResolved = redactConfigObject(snapshot.resolved, uiHints);
-  const { pluginMetadataSnapshot: _pluginMetadataSnapshot, ...publicSnapshot } =
-    snapshot as typeof snapshot & {
-      pluginMetadataSnapshot?: unknown;
-    };
-
   return {
     ...publicSnapshot,
+    sourceConfigBeforeMigrations: redactObject(snapshot.sourceConfigBeforeMigrations, uiHints),
     sourceConfig: redactedResolved,
     runtimeConfig: redactedConfig,
     config: redactedConfig,


### PR DESCRIPTION
Related: #134169. Thanks @joemc1470 for the persisted-versus-active comparison that exposed this response gap.

## What Problem This Solves

Fixes an issue where users inspecting Gateway `config.get` responses could receive inline credentials and SecretRef identifiers through `sourceConfigBeforeMigrations`, even though the other config projections were redacted. Invalid snapshots also retained this credential-bearing field and internal plugin metadata.

The issue's follow-up explicitly confirms that on-disk credentials were intact. Redacted RPC output is not evidence that migration changed the live credentials; this PR repairs the independently reproduced disclosure at the response boundary.

## Why This Change Was Made

The shared snapshot redactor now redacts the pre-migration projection for valid configs and withholds it for invalid configs, consistently with the existing sibling projections. Internal plugin metadata is excluded before either branch. The diagnostic field remains available, and the source snapshot and persistence/migration inputs remain unchanged.

The field was added in 82d1a03f2559d15ceb829b855dd16ee193009573 (#112678) without corresponding response redaction; the same gap exists in v2026.8.1. No configuration option, SQLite schema, dependency, or protocol change.

## User Impact

Config diagnostics protect credentials across all config projections, including when validation fails. Existing migration and credential restoration behavior is preserved. The original Discord connection symptom remains unproven by the RPC comparison and is not claimed fixed here.

Release-note context: protect pre-migration config diagnostics from credential disclosure; reported by @joemc1470 in #134169.

## Evidence

- Before the fix, the regression run failed in three intended cases: valid and invalid pre-migration credential disclosure, and invalid-snapshot plugin metadata disclosure. The existing metadata test was extended; no new production test seam.
- After the fix: 114 tests passed across `redact-snapshot.test.ts`, `redact-snapshot.restore.test.ts`, `redact-snapshot.schema.test.ts`, and `gateway/config-get-response.test.ts`.
- `pnpm build` and `check-changed` passed (type checks, lint, dead-code scans, and repository guards). Local and committed-branch Codex autoreview passed with no accepted/actionable findings at the configured P0 threshold; manual owner-boundary review also found no actionable issue.
- Refreshed onto main `d7c32f5846d`; `git range-diff` confirms the patch is byte-identical to tested/reviewed head `68420293c6e`. The proof above was run on that pre-rebase head; [exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33480276699) for `1055ebea8e495ca1279cbeb90c8ee03b16258fe0`.
- Production: +11/-16, net **−5**. Tests: +53/-1, net **+52**.

Commands:

```sh
node scripts/run-vitest.mjs src/config/redact-snapshot.test.ts
node scripts/run-vitest.mjs src/config/redact-snapshot.test.ts src/config/redact-snapshot.restore.test.ts src/config/redact-snapshot.schema.test.ts src/gateway/config-get-response.test.ts
pnpm build
node scripts/check-changed.mjs -- src/config/redact-snapshot.ts src/config/redact-snapshot.test.ts
.agents/skills/autoreview/scripts/autoreview --mode branch
```

Live CLI proof used a fresh temporary home/state directory, an OS-assigned free loopback port (62318), a `meta.lastTouchedVersion: "2026.7.1-2"` fixture with `agents.list`/`default: true`, and synthetic gateway, disabled Discord, and custom-provider credentials. Only the isolated process received these environment settings:

```sh
OPENCLAW_HOME="$FIXTURE/home" OPENCLAW_STATE_DIR="$FIXTURE/state-a" \
OPENCLAW_CONFIG_PATH="$FIXTURE/state-a/openclaw.json" OPENCLAW_GATEWAY_PORT=62318 \
node openclaw.mjs doctor --fix --non-interactive
# doctor exit: 0
# secret values byte-identical: true
# redaction sentinel persisted: false
# legacy roster migrated: true
```

Doctor reported `Moved agents.list to keyed agents.entries`, removed the retired default marker, and wrote the isolated config and backup. The comparisons inspected the three credential values without printing them.

With the same isolated environment, a task-owned Gateway was started and queried:

```sh
node openclaw.mjs gateway run --port 62318 --bind loopback
node openclaw.mjs gateway call config.get --json
# config.get exit: 0
# config.get exposes fixture credentials: false
# pre-migration projection redacted: true
# config bytes unchanged after RPC: true
```

The temporary Gateway was stopped after the check. No operator Gateway or home-state directory was used. This is real local doctor/RPC proof; it does not claim live Discord authentication with a real bot token.
