### PR TITLE
fix(codex): preserve configured MCP on native fallback

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -457,8 +457,9 @@ for the current Codex rules.
 
 For an ordinary policy-restricted turn, OpenClaw disables Codex native Code
 Mode, removes environment selections, disables and verifies inherited and
-configured MCP servers, disables native hook relays, and filters OpenClaw
-dynamic tools through the effective policy. The bounded workspace `AGENTS.md`
+native configured MCP servers, and disables native hook relays. Static configured
+MCP tools that pass the effective policy move to OpenClaw's dynamic surface for
+that turn. Other OpenClaw dynamic tools use the same policy. The bounded workspace `AGENTS.md`
 snapshot still reaches the model as thread-level developer instructions because
 project instructions are context, not tool authority.
 

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -169,6 +169,8 @@ export async function startCodexAttemptThread(params: {
   nativeHookRelayGeneration?: string;
   nativeHookRelayRequired?: boolean;
   bundleMcpThreadConfig: CodexBundleMcpThreadConfig;
+  /** Static configured MCP is present on the dynamic surface, so native MCP stays absent. */
+  configuredMcpDynamicSurface?: boolean;
   /** OpenClaw owns configured MCP dynamically for this scheduled turn. */
   configuredMcpOwnershipVersion?: 1;
   nativeToolSurfaceEnabled: boolean;
@@ -212,7 +214,7 @@ export async function startCodexAttemptThread(params: {
       },
       operation: async () => {
         const threadConfig = mergeCodexThreadConfigs(
-          params.configuredMcpOwnershipVersion === 1
+          params.configuredMcpDynamicSurface
             ? undefined
             : (params.bundleMcpThreadConfig?.configPatch as JsonObject | undefined),
         );
@@ -492,17 +494,14 @@ export async function startCodexAttemptThread(params: {
                 nativeCodeModeEnabled: params.nativeToolSurfaceEnabled,
                 nativeProviderWebSearchSupport: params.nativeProviderWebSearchSupport,
                 nativeCodeModeOnlyEnabled: params.appServer.codeModeOnly,
-                userMcpServersEnabled:
-                  params.configuredMcpOwnershipVersion === 1
-                    ? false
-                    : params.nativeToolSurfaceEnabled,
-                mcpServersFingerprint:
-                  params.configuredMcpOwnershipVersion === 1
-                    ? undefined
-                    : params.bundleMcpThreadConfig.fingerprint,
+                userMcpServersEnabled: params.configuredMcpDynamicSurface
+                  ? false
+                  : params.nativeToolSurfaceEnabled,
+                mcpServersFingerprint: params.configuredMcpDynamicSurface
+                  ? undefined
+                  : params.bundleMcpThreadConfig.fingerprint,
                 mcpServersFingerprintEvaluated:
-                  params.configuredMcpOwnershipVersion === 1 ||
-                  params.bundleMcpThreadConfig.evaluated,
+                  params.configuredMcpDynamicSurface || params.bundleMcpThreadConfig.evaluated,
                 configuredMcpOwnershipVersion: params.configuredMcpOwnershipVersion,
                 environmentSelection: startupEnvironmentSelection,
                 appServerRuntimeFingerprint,

--- a/extensions/codex/src/app-server/canonical-fork.test-support.ts
+++ b/extensions/codex/src/app-server/canonical-fork.test-support.ts
@@ -340,7 +340,7 @@ export async function createCanonicalForkFixture(params: {
           startup?.releaseSharedClientLease();
           runAbortController.abort();
           await preparedTools.scopedMcpTools?.dispose();
-          await preparedTools.scheduledConfiguredMcp?.dispose();
+          await preparedTools.configuredMcp?.dispose();
           for (const cleanup of preparedTools.runCleanups) {
             await cleanup("fixture complete");
           }

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -17,9 +17,11 @@ import {
 } from "./elicitation-response.js";
 import type { CodexActiveMcpToolCall } from "./event-projector-native-tool-lifecycle.js";
 import {
+  requestPluginApproval,
   requestPluginApprovalOutcome,
   sanitizeCodexApprovalVisibleText,
   truncateCodexApprovalDisplayText as truncateDisplayText,
+  type AppServerApprovalOutcome,
   type ExecApprovalDecision,
   type PluginApprovalOutcome,
 } from "./plugin-approval-roundtrip.js";

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -17,14 +17,11 @@ import {
 } from "./elicitation-response.js";
 import type { CodexActiveMcpToolCall } from "./event-projector-native-tool-lifecycle.js";
 import {
-  approvalRequestExplicitlyUnavailable,
-  mapExecDecisionToOutcome,
-  requestPluginApproval,
+  requestPluginApprovalOutcome,
   sanitizeCodexApprovalVisibleText,
   truncateCodexApprovalDisplayText as truncateDisplayText,
-  type AppServerApprovalOutcome,
   type ExecApprovalDecision,
-  waitForPluginApprovalDecision,
+  type PluginApprovalOutcome,
 } from "./plugin-approval-roundtrip.js";
 import type {
   CodexAppPolicyContextEntry,
@@ -48,7 +45,7 @@ type BridgeableApprovalElicitation = {
   allowedDecisions?: ExecApprovalDecision[];
 };
 
-type ElicitationApprovalOutcome = AppServerApprovalOutcome | "timed-out";
+type ElicitationApprovalOutcome = PluginApprovalOutcome;
 type CodexApprovalElicitationResult =
   | { kind: "not-mine" }
   | { kind: "handled"; response: CodexElicitationResponse };
@@ -209,10 +206,11 @@ export async function routeCodexAppServerElicitationRequest(params: {
   }
 
   const outcome = await requestPluginApprovalOutcome({
-    paramsForRun: params.paramsForRun,
+    hostCapabilities: params.paramsForRun.hostCapabilities,
     title: approvalPrompt.title,
     description: approvalPrompt.description,
     allowedDecisions: approvalPrompt.allowedDecisions,
+    toolName: "codex_mcp_tool_approval",
     ...persistence,
     signal: params.signal,
   });
@@ -419,10 +417,11 @@ async function buildPluginPolicyElicitationResponse(params: {
       return response;
     }
     const outcome = await requestPluginApprovalOutcome({
-      paramsForRun: params.paramsForRun,
+      hostCapabilities: params.paramsForRun.hostCapabilities,
       title: approvalPrompt.title,
       description: approvalPrompt.description,
       allowedDecisions: allowedPluginPolicyApprovalDecisions(mode, approvalPrompt),
+      toolName: "codex_mcp_tool_approval",
       signal: params.signal,
     });
     return buildElicitationResponse(approvalPrompt, outcome);
@@ -769,59 +768,6 @@ function sanitizeDisplayText(value: string): string {
   });
   const escaped = sanitized ? formatCodexDisplayText(sanitized) : "";
   return clipped && escaped ? `${escaped}...` : escaped;
-}
-
-async function requestPluginApprovalOutcome(params: {
-  paramsForRun: EmbeddedRunAttemptParams;
-  title: string;
-  description: string;
-  allowedDecisions?: ExecApprovalDecision[];
-  mcpTool?: { server: string; tool: string };
-  toolCallId?: string;
-  isMcpToolApprovalActive?: () => boolean;
-  signal?: AbortSignal;
-}): Promise<ElicitationApprovalOutcome> {
-  try {
-    const requestResult = await requestPluginApproval({
-      hostCapabilities: params.paramsForRun.hostCapabilities,
-      signal: params.signal,
-      title: params.title,
-      description: params.description,
-      severity: "warning",
-      toolName: "codex_mcp_tool_approval",
-      allowedDecisions: params.allowedDecisions,
-      mcpTool: params.mcpTool,
-      toolCallId: params.toolCallId,
-      isMcpToolApprovalActive: params.isMcpToolApprovalActive,
-    });
-
-    const approvalId = requestResult?.id;
-    if (!approvalId) {
-      return "unavailable";
-    }
-
-    const approvalResult = approvalRequestExplicitlyUnavailable(requestResult)
-      ? undefined
-      : await waitForPluginApprovalDecision({
-          hostCapabilities: params.paramsForRun.hostCapabilities,
-          approvalId,
-          signal: params.signal,
-        });
-    if (params.signal?.aborted) {
-      return "cancelled";
-    }
-    if (approvalResult?.terminalReason === "timeout") {
-      return "timed-out";
-    }
-    const decision = approvalResult?.decision;
-    return mapExecDecisionToOutcome(
-      decision === "allow-always" && params.allowedDecisions?.includes("allow-always") === false
-        ? "allow-once"
-        : decision,
-    );
-  } catch {
-    return params.signal?.aborted ? "cancelled" : "denied";
-  }
 }
 
 function buildElicitationResponse(

--- a/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
+++ b/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
@@ -53,6 +53,8 @@ export type AppServerApprovalOutcome =
   | "unavailable"
   | "cancelled";
 
+export type PluginApprovalOutcome = AppServerApprovalOutcome | "timed-out";
+
 type ApprovalRequestResult = {
   id?: string;
   decision?: ExecApprovalDecision | null;
@@ -159,6 +161,51 @@ export function mapExecDecisionToOutcome(
       return "denied";
     default:
       return "unavailable";
+  }
+}
+
+/** Runs one complete host approval request and maps transport failures to a closed outcome. */
+export async function requestPluginApprovalOutcome(params: {
+  hostCapabilities: AgentHarnessHostCapabilities;
+  signal?: AbortSignal;
+  title: string;
+  description: string;
+  allowedDecisions?: ExecApprovalDecision[];
+  toolName: string;
+  toolCallId?: string;
+  mcpTool?: { server: string; tool: string };
+  isMcpToolApprovalActive?: () => boolean;
+}): Promise<PluginApprovalOutcome> {
+  try {
+    const requestResult = await requestPluginApproval({
+      ...params,
+      severity: "warning",
+    });
+    const approvalId = requestResult?.id;
+    if (!approvalId) {
+      return "unavailable";
+    }
+    const approvalResult = approvalRequestExplicitlyUnavailable(requestResult)
+      ? undefined
+      : await waitForPluginApprovalDecision({
+          hostCapabilities: params.hostCapabilities,
+          approvalId,
+          signal: params.signal,
+        });
+    if (params.signal?.aborted) {
+      return "cancelled";
+    }
+    if (approvalResult?.terminalReason === "timeout") {
+      return "timed-out";
+    }
+    const decision = approvalResult?.decision;
+    return mapExecDecisionToOutcome(
+      decision === "allow-always" && params.allowedDecisions?.includes("allow-always") === false
+        ? "allow-once"
+        : decision,
+    );
+  } catch {
+    return params.signal?.aborted ? "cancelled" : "denied";
   }
 }
 

--- a/extensions/codex/src/app-server/run-attempt-cleanup.ts
+++ b/extensions/codex/src/app-server/run-attempt-cleanup.ts
@@ -195,8 +195,8 @@ export async function cleanupCodexAttempt(
     await runCleanupStep("codex-scoped-mcp-dispose", () =>
       prompt.context.attemptTools.scopedMcpTools?.dispose(),
     );
-    await runCleanupStep("codex-scheduled-mcp-dispose", () =>
-      prompt.context.attemptTools.scheduledConfiguredMcp?.dispose(),
+    await runCleanupStep("codex-configured-mcp-dispose", () =>
+      prompt.context.attemptTools.configuredMcp?.dispose(),
     );
     await runCleanupStep("codex-abort-listener-remove", () => {
       runAbortController.signal.removeEventListener("abort", abortListener);

--- a/extensions/codex/src/app-server/run-attempt-runtime.ts
+++ b/extensions/codex/src/app-server/run-attempt-runtime.ts
@@ -184,7 +184,7 @@ export async function prepareCodexAttemptRuntime(connection: CodexAttemptConnect
     params.trigger === "cron" &&
     params.scheduledToolPolicy !== undefined &&
     Array.isArray(params.toolsAllow);
-  const ownsScheduledConfiguredMcpSurface =
+  const scheduledConfiguredMcpSurface =
     authenticatedScheduledMode &&
     (bundleMcpThreadConfig.staticServerNames.length > 0 ||
       mutable.startupBinding?.configuredMcpOwnershipVersion === 1);
@@ -224,6 +224,11 @@ export async function prepareCodexAttemptRuntime(connection: CodexAttemptConnect
     sandbox,
     { agentId: policyAgentId, runtimeSessionKey: sandboxSessionKey, sandboxExecServerEnabled },
   );
+  const configuredMcpSurface = scheduledConfiguredMcpSurface
+    ? "scheduled"
+    : !nativeToolSurfaceEnabled && bundleMcpThreadConfig.staticServerNames.length > 0
+      ? "transient"
+      : undefined;
   preDynamicStartupStages.mark("native-tool-surface");
   const nativeProviderWebSearchSupport =
     resolveCodexWebSearchPlan({
@@ -282,7 +287,7 @@ export async function prepareCodexAttemptRuntime(connection: CodexAttemptConnect
     bundleMcpThreadConfig,
     bundleManifestRegistry,
     authenticatedScheduledMode,
-    ownsScheduledConfiguredMcpSurface,
+    configuredMcpSurface,
     canResolveScheduledConfiguredMcpCreatorAuthority:
       mayResolveScheduledConfiguredMcpCreatorAuthority,
     codexMcpToolOverrides,

--- a/extensions/codex/src/app-server/run-attempt-start.ts
+++ b/extensions/codex/src/app-server/run-attempt-start.ts
@@ -53,7 +53,7 @@ export async function startCodexAttemptRuntime(resources: CodexAttemptResources)
   const { toolBridge, toolState } = attemptTools;
   const developerInstructions = joinPresentSections(
     turnState.promptBuild.developerInstructions,
-    attemptTools.scheduledConfiguredMcp?.diagnosticNotice,
+    attemptTools.configuredMcp?.diagnosticNotice,
   );
   const {
     params,
@@ -130,6 +130,7 @@ export async function startCodexAttemptRuntime(resources: CodexAttemptResources)
             Boolean(connection.sandboxSessionKey) &&
             loopDetectionEnabled)),
       bundleMcpThreadConfig,
+      configuredMcpDynamicSurface: attemptTools.configuredMcp !== undefined,
       configuredMcpOwnershipVersion: attemptTools.configuredMcpOwnershipVersion,
       nativeToolSurfaceEnabled,
       nativeProviderWebSearchSupport,
@@ -232,7 +233,7 @@ export async function startCodexAttemptRuntime(resources: CodexAttemptResources)
       cwd: effectiveCwd,
       developerInstructions: joinPresentSections(
         buildRenderedCodexDeveloperInstructions(),
-        attemptTools.scheduledConfiguredMcp?.diagnosticNotice,
+        attemptTools.configuredMcp?.diagnosticNotice,
       ),
       prompt: turnState.codexTurnPromptText,
       tools: toolBridge.availableSpecs,

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -7,7 +7,8 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   captureFinalCodexCronCreatorToolAllowlist,
-  materializeStaticMcpToolsForScheduledHarnessRun,
+  formatMcpCodexApprovalRemedy,
+  materializeStaticMcpToolsForHarnessRun,
 } from "openclaw/plugin-sdk/codex-mcp-projection";
 import { resolveCodexPluginsPolicy, shouldAutoApproveCodexAppServerApprovals } from "./config.js";
 import {
@@ -26,6 +27,10 @@ import {
 } from "./dynamic-tools.js";
 import { hasCodexNativeToolCatalog, loadCodexNativeToolCatalog } from "./native-tool-catalog.js";
 import { CodexCompactionPlanState } from "./plan-compaction-state.js";
+import {
+  requestPluginApprovalOutcome,
+  type ExecApprovalDecision,
+} from "./plugin-approval-roundtrip.js";
 import type { CodexDynamicToolSpec } from "./protocol.js";
 import { emitCodexAppServerEvent } from "./run-attempt-lifecycle.js";
 import type { CodexAttemptRuntime } from "./run-attempt-runtime.js";
@@ -53,7 +58,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     hookChannelId,
     codexMcpToolOverrides,
     authenticatedScheduledMode,
-    ownsScheduledConfiguredMcpSurface,
+    configuredMcpSurface,
     canResolveScheduledConfiguredMcpCreatorAuthority,
   } = runtime;
   const {
@@ -368,10 +373,11 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     ...(params.memberRoleIds?.length ? { roleIds: [...params.memberRoleIds] } : {}),
   };
   const hasRequester = Object.keys(requester).length > 0;
-  const scheduledConfiguredMcp = ownsScheduledConfiguredMcpSurface
-    ? await materializeStaticMcpToolsForScheduledHarnessRun({
+  const configuredMcp = configuredMcpSurface
+    ? await materializeStaticMcpToolsForHarnessRun({
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
+        agentId: sessionAgentId,
         workspaceDir: effectiveWorkspace,
         agentDir: policyContext.agentDir,
         cfg: params.config,
@@ -382,6 +388,33 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
         autoApproveCodexAppServerApprovals: shouldAutoApproveCodexAppServerApprovals(
           connection.appServer,
         ),
+        projectedMcpServers: bundleMcpThreadConfig.configPatch?.mcp_servers,
+        ...(configuredMcpSurface === "transient"
+          ? {
+              requestInteractiveCodexApproval: async (approval) => {
+                const allowedDecisions: ExecApprovalDecision[] =
+                  approval.mode === "prompt"
+                    ? ["allow-once", "deny"]
+                    : ["allow-once", "allow-always", "deny"];
+                const outcome = await requestPluginApprovalOutcome({
+                  hostCapabilities: params.hostCapabilities,
+                  signal: approval.signal,
+                  title: `Run MCP tool ${approval.serverName}/${approval.toolName}`,
+                  description: `Codex approval mode "${approval.mode}" requires an operator decision before this MCP tool runs. ${formatMcpCodexApprovalRemedy(approval.serverName)}`,
+                  allowedDecisions,
+                  toolName: approval.safeToolName,
+                  toolCallId: approval.toolCallId,
+                  mcpTool: { server: approval.serverName, tool: approval.toolName },
+                  isMcpToolApprovalActive: approval.isActive,
+                });
+                if (outcome !== "approved-once" && outcome !== "approved-session") {
+                  throw new Error(
+                    `${approval.serverName}/${approval.toolName}: interactive Codex approval (${approval.mode}) was not granted: ${outcome}`,
+                  );
+                }
+              },
+            }
+          : {}),
         policyContext,
         warn: (message) => embeddedAgentLog.warn(message),
       })
@@ -404,7 +437,10 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
           requesterSenderId: params.senderId,
           agentAccountId: params.agentAccountId,
           messageChannel: params.messageChannel ?? params.messageProvider,
-          reservedToolNames,
+          reservedToolNames: [
+            ...reservedToolNames,
+            ...(configuredMcp?.tools.map((tool) => tool.name) ?? []),
+          ],
           toolsAllow: params.toolsAllow,
           policyContext,
           warn: (message) => embeddedAgentLog.warn(message),
@@ -413,11 +449,11 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     // MCP tools exactly like every other dynamic tool. Filter both lists with the
     // same rule so execution and advertised specs stay name-aligned.
     const scopedExecutable = filterCodexDynamicTools(
-      scheduledConfiguredMcp?.tools ?? scopedMcpTools?.tools ?? [],
+      [...(configuredMcp?.tools ?? []), ...(scopedMcpTools?.tools ?? [])],
       pluginConfig,
     );
     const scopedAdvertised = filterCodexDynamicTools(
-      scheduledConfiguredMcp?.tools ?? scopedMcpTools?.advertisedTools ?? [],
+      [...(configuredMcp?.tools ?? []), ...(scopedMcpTools?.advertisedTools ?? [])],
       pluginConfig,
     );
     const toolsWithScopedMcp =
@@ -534,12 +570,11 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
           });
         }
         const authorityRuntimeId = `cron-authority:${params.runId}`;
-        let materialized: Awaited<
-          ReturnType<typeof materializeStaticMcpToolsForScheduledHarnessRun>
-        >;
+        let materialized: Awaited<ReturnType<typeof materializeStaticMcpToolsForHarnessRun>>;
         try {
-          materialized = await materializeStaticMcpToolsForScheduledHarnessRun({
+          materialized = await materializeStaticMcpToolsForHarnessRun({
             sessionId: authorityRuntimeId,
+            agentId: sessionAgentId,
             workspaceDir: effectiveWorkspace,
             agentDir: policyContext.agentDir,
             cfg: params.config,
@@ -550,6 +585,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
             autoApproveCodexAppServerApprovals: shouldAutoApproveCodexAppServerApprovals(
               connection.appServer,
             ),
+            projectedMcpServers: bundleMcpThreadConfig.configPatch?.mcp_servers,
             policyContext,
             warn: (message) => embeddedAgentLog.warn(message),
             retireSessionRuntimeAfterDispose: true,
@@ -596,8 +632,9 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
       tools: toolsWithScopedMcp,
       registeredTools: registeredWithScopedMcp,
       scopedMcpTools,
-      scheduledConfiguredMcp,
-      configuredMcpOwnershipVersion: ownsScheduledConfiguredMcpSurface ? (1 as const) : undefined,
+      configuredMcp,
+      configuredMcpOwnershipVersion:
+        configuredMcpSurface === "scheduled" ? (1 as const) : undefined,
       cronCreatorToolAllowlist,
       cronCreatorToolAllowlistCaptureRef,
       scheduledAppAuthoritySourceRef,
@@ -617,7 +654,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     // Materialized runtimes are attempt-owned only after this function returns.
     // Dispose here when filtering, schema projection, or bridge setup fails first.
     await scopedMcpTools?.dispose();
-    await scheduledConfiguredMcp?.dispose();
+    await configuredMcp?.dispose();
     throw error;
   }
 }

--- a/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
@@ -24,6 +24,8 @@ const mcpMocks = vi.hoisted(() => ({
   staticFacade: vi.fn(),
   threadConfigFacade: vi.fn(),
   requesterCalls: 0,
+  requesterCollisionTool: false,
+  requesterDispose: vi.fn(async () => undefined),
   requesterParams: [] as Array<Record<string, unknown>>,
   staticDiagnosticNotice: undefined as string | undefined,
   staticFailure: undefined as Error | undefined,
@@ -41,8 +43,24 @@ vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
       ...args: Parameters<typeof actual.materializeRequesterScopedMcpToolsForHarnessRun>
     ) => {
       mcpMocks.requesterCalls += 1;
-      mcpMocks.requesterParams.push(args[0] as Record<string, unknown>);
-      return undefined;
+      const params = args[0] as Record<string, unknown>;
+      mcpMocks.requesterParams.push(params);
+      if (!mcpMocks.requesterCollisionTool) {
+        return undefined;
+      }
+      const reserved = new Set(params.reservedToolNames as string[] | undefined);
+      const name = reserved.has("fake__show") ? "fake__show_2" : "fake__show";
+      const tool = {
+        name,
+        description: "Requester-scoped MCP collision fixture.",
+        parameters: { type: "object", properties: {} },
+        execute: vi.fn(async () => ({ content: [{ type: "text" as const, text: "scoped" }] })),
+      };
+      return {
+        tools: [tool],
+        advertisedTools: [tool],
+        dispose: mcpMocks.requesterDispose,
+      };
     },
     loadCodexBundleMcpThreadConfig: async (
       ...args: Parameters<typeof actual.loadCodexBundleMcpThreadConfig>
@@ -87,7 +105,7 @@ vi.mock("openclaw/plugin-sdk/codex-mcp-projection", async (importOriginal) => {
       mcpMocks.authorityResolvers.push(params.resolve);
       return actual.runWithCronCreatorAuthorityCapabilityResolver(params as never);
     },
-    materializeStaticMcpToolsForScheduledHarnessRun: async (params: Record<string, unknown>) => {
+    materializeStaticMcpToolsForHarnessRun: async (params: Record<string, unknown>) => {
       mcpMocks.staticCalls.push(params);
       mcpMocks.staticFacade(params);
       if (mcpMocks.staticFailure) {
@@ -178,12 +196,14 @@ beforeEach(() => {
   mcpMocks.staticCalls.length = 0;
   mcpMocks.staticToolExecutes.length = 0;
   mcpMocks.requesterCalls = 0;
+  mcpMocks.requesterCollisionTool = false;
   mcpMocks.requesterParams.length = 0;
   mcpMocks.threadConfigCalls.length = 0;
   mcpMocks.staticDiagnosticNotice = undefined;
   mcpMocks.staticFailure = undefined;
   mcpMocks.staticFailureGate = undefined;
   mcpMocks.dispose.mockClear();
+  mcpMocks.requesterDispose.mockClear();
   mcpMocks.captureFacade.mockClear();
   mcpMocks.staticFacade.mockClear();
   mcpMocks.threadConfigFacade.mockClear();
@@ -546,26 +566,86 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
     },
   );
 
-  it("captures a restricted ordinary turn without inventing intentionally disabled native MCP", async () => {
+  it("keeps configured and requester MCP unique when the native surface is unavailable", async () => {
     const sessionFile = path.join(tempDir, "session-native-mcp-restricted.jsonl");
     const params = createParams(sessionFile, path.join(tempDir, "workspace-native-mcp-restricted"));
     configureFakeMcp(params);
+    params.config!.mcp!.servers!.fake!.codex = { defaultToolsApprovalMode: "auto" };
     params.toolsAllow = ["cron", "fake__show"];
+    mcpMocks.requesterCollisionTool = true;
+    const requestApproval = vi.fn(async (request: { isMcpToolApprovalActive?: () => boolean }) => {
+      expect(request.isMcpToolApprovalActive?.()).toBe(true);
+      return { id: "plugin:mcp-dynamic" };
+    });
+    const waitForApproval = vi.fn(async () => ({
+      decision: "allow-always" as const,
+      terminalReason: "user" as const,
+    }));
+    params.hostCapabilities = Object.freeze({
+      ...params.hostCapabilities,
+      requestApproval,
+      waitForApproval,
+    });
 
     const harness = createStartedThreadHarness();
     const run = runCodexAppServerAttempt(params);
     await harness.waitForMethod("turn/start");
+    const threadStart = harness.requests.find((request) => request.method === "thread/start")
+      ?.params as { config?: Record<string, unknown>; dynamicTools?: unknown } | undefined;
+    const dynamicTools = JSON.stringify(threadStart?.dynamicTools ?? []);
+    expect(mcpMocks.staticCalls).toHaveLength(1);
+    expect(mcpMocks.staticCalls[0]).toMatchObject({
+      agentId: "main",
+      projectedMcpServers: expect.objectContaining({ fake: expect.any(Object) }),
+      requestInteractiveCodexApproval: expect.any(Function),
+    });
+    expect(threadStart?.config).not.toHaveProperty("mcp_servers");
+    expect(dynamicTools.match(/fake__show"/gu)).toHaveLength(1);
+    expect(dynamicTools.match(/fake__show_2"/gu)).toHaveLength(1);
+
+    const requestInteractiveCodexApproval = mcpMocks.staticCalls[0]!
+      .requestInteractiveCodexApproval as (params: {
+      safeToolName: string;
+      toolCallId: string;
+      serverName: string;
+      toolName: string;
+      mode: "auto";
+      isActive: () => boolean;
+    }) => Promise<void>;
+    await requestInteractiveCodexApproval({
+      safeToolName: "fake__show",
+      toolCallId: "call-fake-show",
+      serverName: "fake",
+      toolName: "show",
+      mode: "auto",
+      isActive: () => true,
+    });
+    expect(requestApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedDecisions: ["allow-once", "allow-always", "deny"],
+        mcpTool: { server: "fake", tool: "show" },
+        toolCallId: "call-fake-show",
+      }),
+    );
+    expect(waitForApproval).toHaveBeenCalledOnce();
+
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await expect(run).resolves.toBeDefined();
 
     expect(harness.requests.map((request) => request.method)).not.toContain("mcpServerStatus/list");
-    expect(mcpMocks.staticCalls).toHaveLength(0);
     expect(mcpMocks.captureCalls).toHaveLength(1);
-    expect(mcpMocks.captureCalls[0]!.storedNames).not.toContain("fake__show");
+    expect(mcpMocks.captureCalls[0]!.storedNames).toEqual(
+      expect.arrayContaining(["fake__show", "fake__show_2"]),
+    );
+    expect(new Set(mcpMocks.captureCalls[0]!.storedNames).size).toBe(
+      mcpMocks.captureCalls[0]!.storedNames.length,
+    );
     expect(mcpMocks.captureCalls[0]!.provenance).toEqual({
       version: 1,
       source: "final-executable-surface",
     });
+    expect(mcpMocks.dispose).toHaveBeenCalledOnce();
+    expect(mcpMocks.requesterDispose).toHaveBeenCalledOnce();
   });
 
   it("withholds final provenance when a sender-attributed turn cannot snapshot native MCP", async () => {

--- a/src/agents/agent-bundle-mcp-harness.test.ts
+++ b/src/agents/agent-bundle-mcp-harness.test.ts
@@ -92,7 +92,7 @@ vi.mock("./mcp-oauth.js", async (importOriginal) => {
 
 import {
   materializeRequesterScopedMcpToolsForHarnessRunCore,
-  materializeStaticMcpToolsForScheduledHarnessRunCore,
+  materializeStaticMcpToolsForHarnessRunCore,
 } from "./agent-bundle-mcp-harness.js";
 import { createRequesterMcpConnect } from "./agent-bundle-mcp-requester-connect.js";
 
@@ -202,14 +202,14 @@ beforeEach(() => {
   startAuthorization.mockReset();
 });
 
-describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
+describe("materializeStaticMcpToolsForHarnessRunCore", () => {
   it("materializes static tools without carrying requester identity and applies the stored cap", async () => {
     const runtime = makeRuntime({ sessionId: "scheduled", requesterSenderId: "unused" });
     delete runtime.requesterScope;
     runtime.peekCatalog()!.servers["user-mail"]!.codexApprovalMode = "approve";
     mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
 
-    const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
+    const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled",
       workspaceDir: "/workspace",
       toolsAllow: ["user-mail__inbox"],
@@ -231,7 +231,7 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
     delete runtime.requesterScope;
     mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
 
-    const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
+    const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled-denied",
       workspaceDir: "/workspace",
       toolsAllow: ["read"],
@@ -239,6 +239,72 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
 
     expect(result?.tools).toEqual([]);
     await result?.dispose();
+  });
+
+  it("gates interactive configured MCP before the original executor", async () => {
+    const runtime = makeRuntime({ sessionId: "interactive", requesterSenderId: "unused" });
+    delete runtime.requesterScope;
+    const callTool = vi.spyOn(runtime, "callTool");
+    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    let active: (() => boolean) | undefined;
+    const requestInteractiveCodexApproval = vi.fn(async (request) => {
+      active = request.isActive;
+      if (request.toolCallId === "denied") {
+        throw new Error("operator denied");
+      }
+    });
+
+    const result = await materializeStaticMcpToolsForHarnessRunCore({
+      sessionId: "interactive",
+      workspaceDir: "/workspace",
+      toolsAllow: ["user-mail__inbox"],
+      requestInteractiveCodexApproval,
+    });
+    const tool = result.tools[0]!;
+
+    await expect(tool.execute("denied", { folder: "private" })).rejects.toThrow("operator denied");
+    expect(callTool).not.toHaveBeenCalled();
+
+    await expect(tool.execute("allowed", { folder: "team" })).resolves.toBeDefined();
+    expect(callTool).toHaveBeenCalledOnce();
+    expect(callTool).toHaveBeenCalledWith("user-mail", "inbox", { folder: "team" });
+    expect(requestInteractiveCodexApproval).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        safeToolName: "user-mail__inbox",
+        toolCallId: "allowed",
+        serverName: "user-mail",
+        toolName: "inbox",
+        mode: "auto",
+      }),
+    );
+    expect(active?.()).toBe(false);
+    await result.dispose();
+  });
+
+  it.each([
+    { name: "full permission", mode: undefined, grant: false, approvalCalls: 0 },
+    { name: "explicit prompt", mode: "prompt" as const, grant: false, approvalCalls: 1 },
+    { name: "durable grant", mode: "auto" as const, grant: true, approvalCalls: 0 },
+  ])("preserves $name on the interactive surface", async ({ mode, grant, approvalCalls }) => {
+    const runtime = makeRuntime({ sessionId: "interactive-policy", requesterSenderId: "unused" });
+    delete runtime.requesterScope;
+    runtime.peekCatalog()!.servers["user-mail"]!.codexApprovalMode = mode;
+    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    const requestInteractiveCodexApproval = vi.fn(async () => undefined);
+
+    const result = await materializeStaticMcpToolsForHarnessRunCore({
+      sessionId: "interactive-policy",
+      workspaceDir: "/workspace",
+      toolsAllow: ["user-mail__inbox"],
+      autoApproveCodexAppServerApprovals: true,
+      projectedMcpServers: grant
+        ? { "user-mail": { tools: { inbox: { approval_mode: "approve" } } } }
+        : undefined,
+      requestInteractiveCodexApproval,
+    });
+    await expect(result.tools[0]!.execute("call", {})).resolves.toBeDefined();
+    expect(requestInteractiveCodexApproval).toHaveBeenCalledTimes(approvalCalls);
+    await result.dispose();
   });
 
   it("binds persistent app views to the same finite scheduled cap", async () => {
@@ -279,7 +345,7 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
     const callTool = vi.spyOn(runtime, "callTool");
     mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
 
-    const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
+    const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled-app",
       sessionKey: "agent:main:main",
       agentId: "main",
@@ -352,13 +418,15 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
     });
     const callTool = vi.spyOn(runtime, "callTool");
     mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    const requestInteractiveCodexApproval = vi.fn(async () => undefined);
 
-    const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
+    const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled-app-approval",
       sessionKey: "agent:main:main",
       agentId: "main",
       workspaceDir: "/workspace",
       toolsAllow: ["*"],
+      requestInteractiveCodexApproval,
     });
     const callResult = await result.tools[0]!.execute("call-app", {});
     const viewId = (callResult.details as { mcpAppPreview?: { mcpApp?: { viewId?: string } } })
@@ -380,6 +448,7 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
       ),
     ).resolves.toBeDefined();
     expect(callTool).toHaveBeenCalledTimes(2);
+    expect(requestInteractiveCodexApproval).not.toHaveBeenCalled();
     await result.dispose();
   });
 
@@ -419,7 +488,7 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
     });
     mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
 
-    const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
+    const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled-app-yolo",
       sessionKey: "agent:main:main",
       agentId: "main",
@@ -444,7 +513,7 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
     runtime.getCatalog = async () => emptyCatalog;
     mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
 
-    const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
+    const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled-empty",
       workspaceDir: "/workspace",
       toolsAllow: ["*"],
@@ -475,7 +544,7 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
     runtime.getCatalog = async () => failedCatalog;
     mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
 
-    const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
+    const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled-diagnostic",
       workspaceDir: "/workspace",
       toolsAllow: ["*"],
@@ -494,7 +563,7 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
     mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
     const callTool = vi.spyOn(runtime, "callTool");
 
-    const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
+    const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled-prompt",
       workspaceDir: "/workspace",
       toolsAllow: ["user-mail__inbox"],
@@ -521,7 +590,7 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
     mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
     const callTool = vi.spyOn(runtime, "callTool");
 
-    const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
+    const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled-yolo",
       workspaceDir: "/workspace",
       toolsAllow: ["user-mail__inbox"],
@@ -553,7 +622,7 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
     mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
     const callTool = vi.spyOn(runtime, "callTool");
 
-    const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
+    const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: `scheduled-${mode}`,
       workspaceDir: "/workspace",
       toolsAllow: ["user-mail__inbox"],
@@ -570,7 +639,7 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
     mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
     const callTool = vi.spyOn(runtime, "callTool");
 
-    const result = await materializeStaticMcpToolsForScheduledHarnessRunCore({
+    const result = await materializeStaticMcpToolsForHarnessRunCore({
       sessionId: "scheduled-unknown",
       workspaceDir: "/workspace",
       toolsAllow: ["user-mail__inbox"],

--- a/src/agents/agent-bundle-mcp-harness.ts
+++ b/src/agents/agent-bundle-mcp-harness.ts
@@ -2,7 +2,7 @@
 import type { SessionToolOverrides } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
-import { getPluginToolMeta } from "../plugins/tool-metadata.js";
+import { getPluginToolMeta, setPluginToolMeta } from "../plugins/tool-metadata.js";
 import {
   getAdvertisedScopedMcpCatalog,
   getOrCreateRequesterScopedMcpRuntime,
@@ -16,6 +16,7 @@ import {
 } from "./agent-bundle-mcp-materialize.js";
 import { mergeMcpConnectCatalog } from "./agent-bundle-mcp-requester-connect.js";
 import type { McpToolCatalog, RequesterMcpConnect } from "./agent-bundle-mcp-types.js";
+import type { CodexMcpServersConfig } from "./codex-mcp-config.types.js";
 import {
   resolveConversationCapabilityProfile,
   type ConversationCapabilityProfileParams,
@@ -26,6 +27,7 @@ import { applyEmbeddedAttemptToolsAllow } from "./embedded-agent-runner/run/atte
 import {
   formatMcpCodexApprovalRemedy,
   requiresMcpCodexToolApproval,
+  resolveProjectedMcpCodexToolApprovalMode,
 } from "./mcp-codex-tool-approval.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -40,15 +42,18 @@ type RequesterScopedHarnessMcpTools = {
   dispose: () => Promise<void>;
 };
 
-type ScheduledStaticHarnessMcpTools = {
-  /** Final executable static MCP tools for this scheduled turn. */
+type StaticHarnessMcpTools = {
+  /** Final executable static MCP tools for this turn. */
   tools: AnyAgentTool[];
   /** Bounded model/operator warning when configured servers or final policy were incomplete. */
   diagnosticNotice?: string;
   dispose: () => Promise<void>;
 };
 
-function formatScheduledMcpDiagnosticNotice(messages: readonly string[]): string | undefined {
+function formatConfiguredMcpDiagnosticNotice(
+  messages: readonly string[],
+  runLabel: "this scheduled run" | "this run",
+): string | undefined {
   const bounded = [...new Set(messages)]
     .map((message) => message.replaceAll(/\s+/g, " ").trim().slice(0, 180))
     .filter(Boolean)
@@ -57,31 +62,90 @@ function formatScheduledMcpDiagnosticNotice(messages: readonly string[]): string
     return undefined;
   }
   return (
-    `Configured MCP is incomplete for this scheduled run: ${bounded.join("; ")}. ` +
+    `Configured MCP is incomplete for ${runLabel}: ${bounded.join("; ")}. ` +
     "Do not claim MCP-backed work succeeded; report this blocker to the operator."
   );
 }
 
-function filterScheduledCodexApproval(
+type InteractiveConfiguredMcpApprovalRequest = {
+  signal?: AbortSignal;
+  safeToolName: string;
+  toolCallId: string;
+  serverName: string;
+  toolName: string;
+  mode: "auto" | "prompt";
+  isActive: () => boolean;
+};
+
+function applyConfiguredMcpApproval(
   tools: readonly AnyAgentTool[],
-  autoApprove: boolean,
-  onOmitted?: (message: string) => void,
+  options: {
+    fullPermission: boolean;
+    projectedMcpServers?: CodexMcpServersConfig;
+    requestApproval?: (params: InteractiveConfiguredMcpApprovalRequest) => Promise<void>;
+    onOmitted?: (message: string) => void;
+  },
 ): AnyAgentTool[] {
-  return tools.filter((tool) => {
+  return tools.flatMap((tool) => {
     const mcp = getPluginToolMeta(tool)?.mcp;
+    if (mcp?.operation !== "tool") {
+      return [tool];
+    }
+    const projectedMode = resolveProjectedMcpCodexToolApprovalMode(
+      mcp.serverName,
+      {},
+      options.projectedMcpServers?.[mcp.serverName],
+      mcp.toolName,
+    );
+    const mode = projectedMode ?? mcp.codexApproval?.mode;
     if (
-      mcp?.operation !== "tool" ||
       !requiresMcpCodexToolApproval({
         ...mcp.codexApproval,
-        fullPermission: autoApprove,
+        mode,
+        fullPermission: options.fullPermission,
       })
     ) {
-      return true;
+      return [tool];
     }
-    onOmitted?.(
-      `${mcp.serverName}/${mcp.toolName}: requires interactive Codex approval (${mcp.codexApproval?.mode ?? "auto"}); ${formatMcpCodexApprovalRemedy(mcp.serverName)}`,
-    );
-    return false;
+    const approvalMode = mode === "prompt" ? "prompt" : "auto";
+    const requestApproval = options.requestApproval;
+    if (!requestApproval) {
+      options.onOmitted?.(
+        `${mcp.serverName}/${mcp.toolName}: requires interactive Codex approval (${approvalMode}); ${formatMcpCodexApprovalRemedy(mcp.serverName)}`,
+      );
+      return [];
+    }
+    const meta = getPluginToolMeta(tool)!;
+    const execute = tool.execute;
+    const guarded = {
+      ...tool,
+      execute: async (
+        toolCallId: string,
+        params: unknown,
+        signal?: AbortSignal,
+        onUpdate?: Parameters<AnyAgentTool["execute"]>[3],
+      ) => {
+        // Dynamic tools bypass Codex's native MCP gate. Keep the exact call live
+        // while host approval is pending, then run its original executor once.
+        let active = true;
+        try {
+          await requestApproval({
+            signal,
+            safeToolName: tool.name,
+            toolCallId,
+            serverName: mcp.serverName,
+            toolName: mcp.toolName,
+            mode: approvalMode,
+            isActive: () => active,
+          });
+          return await execute(toolCallId, params, signal, onUpdate);
+        } finally {
+          active = false;
+        }
+      },
+    } satisfies AnyAgentTool;
+    setPluginToolMeta(guarded, meta);
+    return [guarded];
   });
 }
 
@@ -166,10 +230,10 @@ function buildCatalogTools(
 }
 
 /**
- * Materialize only static configured MCP for an authenticated scheduled turn.
+ * Materialize static configured MCP for a Codex harness turn.
  * No requester identity is accepted here, so requester resolvers stay unreachable.
  */
-export async function materializeStaticMcpToolsForScheduledHarnessRunCore(
+export async function materializeStaticMcpToolsForHarnessRunCore(
   params: Omit<
     MaterializeRequesterScopedMcpToolsForHarnessRunParams,
     "requesterSenderId" | "agentAccountId" | "messageChannel"
@@ -177,10 +241,16 @@ export async function materializeStaticMcpToolsForScheduledHarnessRunCore(
     toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
     /** Exact established Codex yolo predicate; no other profile bypasses approval metadata. */
     autoApproveCodexAppServerApprovals?: boolean;
+    /** Prepared native projection carries exact persisted per-tool approval grants. */
+    projectedMcpServers?: CodexMcpServersConfig;
+    /** Interactive turns request approval before the original MCP executor runs. */
+    requestInteractiveCodexApproval?: (
+      params: InteractiveConfiguredMcpApprovalRequest,
+    ) => Promise<void>;
     /** Mutation-only probes retire their isolated runtime after the snapshot. */
     retireSessionRuntimeAfterDispose?: boolean;
   },
-): Promise<ScheduledStaticHarnessMcpTools> {
+): Promise<StaticHarnessMcpTools> {
   const runtime = await getOrCreateSessionMcpRuntime({
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
@@ -219,26 +289,42 @@ export async function materializeStaticMcpToolsForScheduledHarnessRunCore(
         params.warn?.(message);
       },
     };
-    const allowed = filterScheduledCodexApproval(
-      applyHarnessToolPolicy(liveRuntime.tools, policyParams),
-      params.autoApproveCodexAppServerApprovals === true,
-      (message) => policyWarnings.push(message),
-    );
+    const fullPermission = params.autoApproveCodexAppServerApprovals === true;
+    const policyTools = applyHarnessToolPolicy(liveRuntime.tools, policyParams);
+    const projectedApproval = params.projectedMcpServers
+      ? { projectedMcpServers: params.projectedMcpServers }
+      : {};
+    const allowed = applyConfiguredMcpApproval(policyTools, {
+      fullPermission,
+      ...projectedApproval,
+      ...(params.requestInteractiveCodexApproval
+        ? { requestApproval: params.requestInteractiveCodexApproval }
+        : {}),
+      onOmitted: (message) => policyWarnings.push(message),
+    });
     // App views outlive this attempt, so bind their callable surface to the
     // same complete catalog and final policy before any model tool can mint one.
     liveRuntime.restrictAppTools?.(
-      filterScheduledCodexApproval(
+      applyConfiguredMcpApproval(
         applyHarnessToolPolicy(liveRuntime.appTools ?? liveRuntime.tools, policyParams),
-        params.autoApproveCodexAppServerApprovals === true,
-        (message) => policyWarnings.push(message),
+        {
+          fullPermission,
+          ...projectedApproval,
+          ...(params.requestInteractiveCodexApproval
+            ? {}
+            : { onOmitted: (message: string) => policyWarnings.push(message) }),
+        },
       ),
     );
-    const diagnosticNotice = formatScheduledMcpDiagnosticNotice([
-      ...(liveRuntime.diagnostics ?? []).map(
-        (diagnostic) => `${diagnostic.serverName}: ${diagnostic.message}`,
-      ),
-      ...policyWarnings,
-    ]);
+    const diagnosticNotice = formatConfiguredMcpDiagnosticNotice(
+      [
+        ...(liveRuntime.diagnostics ?? []).map(
+          (diagnostic) => `${diagnostic.serverName}: ${diagnostic.message}`,
+        ),
+        ...policyWarnings,
+      ],
+      params.requestInteractiveCodexApproval ? "this run" : "this scheduled run",
+    );
     let disposed = false;
     return {
       tools: allowed,

--- a/src/agents/mcp-codex-tool-approval.test.ts
+++ b/src/agents/mcp-codex-tool-approval.test.ts
@@ -34,6 +34,14 @@ describe("Codex MCP tool approval projection", () => {
         url: "http://127.0.0.1:18789/mcp",
       }),
     ).toBe("approve");
+    expect(
+      resolveProjectedMcpCodexToolApprovalMode(
+        "example",
+        {},
+        { tools: { write: { approval_mode: "approve" } } },
+        "write",
+      ),
+    ).toBe("approve");
   });
 
   it.each([

--- a/src/agents/mcp-codex-tool-approval.ts
+++ b/src/agents/mcp-codex-tool-approval.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { McpCodexToolApprovalMode, McpServerConfig } from "../config/types.mcp.js";
 
 export type McpCodexToolAnnotations = {
@@ -28,12 +29,17 @@ export function resolveProjectedMcpCodexToolApprovalMode(
   serverName: string,
   server: McpServerConfig,
   projectedServer?: Record<string, unknown>,
+  toolName?: string,
 ): McpCodexToolApprovalMode | undefined {
   const codex =
     server.codex && typeof server.codex === "object" && !Array.isArray(server.codex)
       ? (server.codex as Record<string, unknown>)
       : {};
+  const projectedTools = isRecord(projectedServer?.tools) ? projectedServer.tools : undefined;
+  const projectedTool =
+    toolName && isRecord(projectedTools?.[toolName]) ? projectedTools[toolName] : undefined;
   return (
+    normalizeApprovalMode(projectedTool?.approval_mode) ??
     normalizeApprovalMode(codex.defaultToolsApprovalMode) ??
     normalizeApprovalMode(codex.default_tools_approval_mode) ??
     normalizeApprovalMode(projectedServer?.default_tools_approval_mode) ??

--- a/src/plugin-sdk/codex-mcp-projection.ts
+++ b/src/plugin-sdk/codex-mcp-projection.ts
@@ -57,13 +57,13 @@ export {
   runWithCronCreatorAuthorityResolver,
 } from "../agents/cron-creator-authority-context.js";
 
-/** Materialize static configured MCP under a scheduled Codex authority envelope. */
-export async function materializeStaticMcpToolsForScheduledHarnessRun(
+/** Materialize static configured MCP under the Codex harness authority envelope. */
+export async function materializeStaticMcpToolsForHarnessRun(
   params: Parameters<
-    typeof import("../agents/agent-bundle-mcp-harness.js").materializeStaticMcpToolsForScheduledHarnessRunCore
+    typeof import("../agents/agent-bundle-mcp-harness.js").materializeStaticMcpToolsForHarnessRunCore
   >[0],
 ) {
-  const { materializeStaticMcpToolsForScheduledHarnessRunCore: materialize } =
+  const { materializeStaticMcpToolsForHarnessRunCore: materialize } =
     await import("../agents/agent-bundle-mcp-harness.js");
   return materialize(params);
 }


### PR DESCRIPTION
## What Problem This Solves

Configured static MCP tools disappeared from Codex turns when OpenClaw disabled Codex's native tool surface. The native `mcp_servers` projection was absent, while the dynamic producer materialized configured MCP only for scheduled runs. Operators saw a healthy configured server, but the model saw no tool and no useful failure.

## Root cause

The Codex attempt runtime had two independent decisions:

- disable native MCP for a restricted or OpenClaw-node execution policy
- give configured static MCP dynamic ownership only to scheduled runs

An ordinary native-off turn therefore had no owner for configured MCP.

## Fix

- Give configured MCP one explicit owner: native on normal turns, dynamic on scheduled or native-off turns.
- Keep transient native-off ownership from rotating the persistent Codex thread binding.
- Use one configured-MCP materializer for scheduled and interactive turns.
- Preserve explicit `prompt`, per-tool projected approval, and durable OpenClaw grants.
- Bind interactive approval to the exact server, tool, call ID, and live attempt before the original MCP executor runs once.
- Exclude approval-requiring MCP App tools from persistent app views because that call boundary does not own the same approval roundtrip.
- Reserve configured and requester-scoped MCP names against each other, then compose both lists once.
- Share the host approval roundtrip with native Codex elicitation instead of keeping a second implementation.

## Evidence

The same isolated production Gateway flow used `openai/gpt-5.6-sol`, forced the Codex harness, set `tools.exec.host="node"`, configured one static MCP server, and requested one hidden fixture value through `openclaw agent`.

| Revision | Harness | MCP calls | Result |
| --- | --- | ---: | --- |
| current main `04bad80b953d` | `codex` (`forced_plugin`) | 0 | `fixture__lookup_note is unavailable.` |
| candidate `48397e587cca` (Sol) | `codex` (`forced_plugin`) | 1 | exact hidden value returned |
| exact head `c909e68d223` (Luna) | `codex` (`forced_plugin`) | 1 | exact hidden value returned |

The hidden value was generated after the builds, never appeared in the prompt, and remained private to the fixture. The exact-head `dist/` was built on Testbox, downloaded by hash, and used unchanged for the final isolated Gateway replay. All Gateways and both Testbox leases were stopped after proof. Public Testbox runs: [initial red/green](https://github.com/openclaw/openclaw/actions/runs/33642214216), [exact-head build](https://github.com/openclaw/openclaw/actions/runs/33651230642).

## Codex contract checked

Direct inspection of `openai/codex@da23e131e68b171909407f469da1b2f72d9c4f4a` confirmed:

- [`thread/start` owns stable config and experimental dynamic tools](https://github.com/openai/codex/blob/da23e131e68b171909407f469da1b2f72d9c4f4a/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L100-L144).
- [missing experimental capability rejects the request](https://github.com/openai/codex/blob/da23e131e68b171909407f469da1b2f72d9c4f4a/codex-rs/app-server/src/message_processor.rs#L891-L894).
- [native MCP registers before dynamic tools](https://github.com/openai/codex/blob/da23e131e68b171909407f469da1b2f72d9c4f4a/codex-rs/core/src/tools/spec_plan.rs#L170-L191), and [duplicate external names keep the first owner](https://github.com/openai/codex/blob/da23e131e68b171909407f469da1b2f72d9c4f4a/codex-rs/core/src/tools/registry.rs#L372-L382).
- [dynamic client failure becomes a failed tool response](https://github.com/openai/codex/blob/da23e131e68b171909407f469da1b2f72d9c4f4a/codex-rs/app-server/src/dynamic_tools.rs#L18-L33); Codex does not retry through native MCP.
- [native MCP asks for approval before approved execution](https://github.com/openai/codex/blob/da23e131e68b171909407f469da1b2f72d9c4f4a/codex-rs/core/src/mcp_tool_call.rs#L244-L265).

## Validation

- Current-main regression: expected one static materialization, received zero.
- Candidate focused and sibling tests: 201 passed; the CI import repair then passed 107 focused tests.
- Production Gateway red/green: passed.
- Clean Linux candidate and baseline builds: passed.
- Formatting and Oxlint: passed.
- Plugin SDK export and surface checks: passed.
- Max-lines, assertion-safety, coercion, deprecated-API, temp-path, conflict-marker, and docs-list guards: passed.
- Local type-check and build were not run because this host forbids them; CI owns those gates.

## Diff audit

<!-- proof-rechecked: c909e68d22379ea924f960a0ac92303a67f8e6ae -->

- Production: `+258/-129` (net `+129`).
- Tests: `+176/-19` (net `+157`).
- Test support: `+1/-1`.
- Docs: `+3/-2`.

The positive production delta creates the missing dynamic owner and closure-bound approval boundary. The change replaces the scheduled-only materializer and removes the duplicate 61-line approval implementation; it does not add a second MCP or fallback stack.
