### PR TITLE
fix(ios): restore dependency resolution with WebRTC 152

### DIFF
--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -17,7 +17,7 @@ packages:
     path: ../swabble
   WebRTC:
     url: https://github.com/stasel/WebRTC.git
-    exactVersion: 151.0.0
+    exactVersion: 152.0.0
 
 schemes:
   OpenClaw:


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where iOS builds fail during Swift package resolution after the upstream WebRTC 151.0.0 publication changed and its binary download disappeared. Previously trusted 151 installations can reject the changed fingerprint; fresh resolution reaches the deleted artifact.

## Why This Change Was Made

Advance the iOS dependency to the separately versioned [WebRTC 152 release](https://github.com/stasel/WebRTC/releases/tag/152.0.0), retaining normal source-fingerprint and artifact-checksum verification. No trust records, checksums, caches, or verification policies are overridden.

This intentionally takes the M152 milestone update. The apparent smaller 151.0.1 replacement still references the deleted 151.0.0 binary URL in its [package manifest](https://github.com/stasel/WebRTC/blob/151.0.1/Package.swift); changing only the package version to 151.0.1 does not repair that fetch. M152's actual consumer APIs and native transport behavior were validated below.

The Swift package audit covered all five package manifests, both committed lockfiles, and the iOS XcodeGen project: 33 external packages. Other versioned packages already match their observed stable releases. Retain the existing Peekaboo and MLX Audio revisions because their tagged releases predate the AXorcist packaging and progressive Fish streaming/cancellation fixes we consume. Unchanged macOS and MLX graphs and lockfiles remain unchanged.

## User Impact

Developers can resolve and build the iOS app normally. The iOS 18 minimum is unchanged. One manifest line changes, with zero net production or test LOC growth and no UI changes.

## Evidence

- Strict SwiftPM resolution selected 152.0.0 at `1d04692697cb642bfebf6ad2dd99fe52649c3d6d`. The downloaded 44,701,370-byte archive matches the [immutable manifest](https://github.com/stasel/WebRTC/blob/1d04692697cb642bfebf6ad2dd99fe52649c3d6d/Package.swift) SHA256 `115cb9944248a3302c0c8af17462e2576a28ccc7adef9f6a1fe66ee75d9e1cc8`; required device/simulator slices and unchanged bundled license verified.
- Compared all 93 existing simulator headers: none removed. Seventeen of 18 headers directly used by Talk are identical; the remaining readonly-property annotation change affects a property Talk does not read.
- Actual iOS simulator app build and six existing transcript/ordering/license tests passed. A temporary XCTest exercised the real M152 peer pair through offer/answer, ICE, DTLS/SCTP data-channel request/reply, channel closure, and peer closure; passed in 0.812s. Production source matched the exact PR head; those three proof simulators were deleted and the existing 151 trust record stayed unchanged.
- The temporary smoke initially expected channel callbacks after peer shutdown. A diagnostic rerun and upstream shutdown source isolated that invalid fixture assumption. Closing the channel while peers remain alive, then closing peers, passed with the same 15-second bounds; no app code or timeout was changed. Original failed results were preserved.
- [Exact-head CI 33480832663](https://github.com/openclaw/openclaw/actions/runs/33480832663) passed, including [iOS build](https://github.com/openclaw/openclaw/actions/runs/33480832663/job/99770035067), iPhone/iPad screenshot checks, and the required CI gate.
- Independent Codex autoreview passed through P2 with no actionable findings; whitespace validation passed.

This proves simulator build/load and local native transport behavior. It does not claim physical microphone/speaker, live-provider call, reproducible-binary, or binary-equivalence proof. The separate Talk cancellation repair is not part of this dependency-only PR.

ClawSweeper rank-up moves addressed: M152 scope is explicit above; strict resolution and exact-head native/CI evidence are complete. Its suggested 151.0.1 alternative was checked directly and rejected because the manifest still targets the 404 asset.
