### PR TITLE
refactor(status): share terminal report context

### DIFF
--- a/src/commands/status-all/report-lines.test.ts
+++ b/src/commands/status-all/report-lines.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it, vi } from "vitest";
 import type { ProgressReporter } from "../../cli/progress.js";
 import { buildStatusAllReportLines } from "./report-lines.js";
 
-const diagnosisSpy = vi.hoisted(() => vi.fn(async () => {}));
+const diagnosisSpy = vi.hoisted(() =>
+  vi.fn(async ({ lines }: { lines: string[]; secretDiagnostics: string[] }) => {
+    await Promise.resolve();
+    lines.push("diagnosis body", "");
+  }),
+);
 
 vi.mock("./diagnosis.js", () => ({
   appendStatusAllDiagnosis: diagnosisSpy,
@@ -34,7 +39,14 @@ describe("buildStatusAllReportLines", () => {
             detail: "connected",
           },
         ],
-        details: [],
+        details: [
+          {
+            title: "Discord accounts",
+            columns: ["Account", "Status", "Notes"],
+            rows: [{ Account: "default", Status: "OK", Notes: "ready" }],
+          },
+          { title: "Empty accounts", columns: ["Account", "Status"], rows: [] },
+        ],
       },
       channelIssues: [{ channel: "discord", message: `${"x".repeat(89)}🚀tail` }],
       agentStatus: {
@@ -96,10 +108,22 @@ describe("buildStatusAllReportLines", () => {
       output.indexOf("OpenClaw status --all"),
     );
     expect(output).not.toContain(String.fromCharCode(0xd83d));
+    expect(
+      lines.filter((line) =>
+        /^(Overview|Channels|Discord accounts|Empty accounts|Agents|Diagnosis \(read-only\))$/.test(
+          line,
+        ),
+      ),
+    ).toEqual([
+      "Overview",
+      "Channels",
+      "Discord accounts",
+      "Empty accounts",
+      "Agents",
+      "Diagnosis (read-only)",
+    ]);
+    expect(lines.slice(-4)).toEqual(["", "Diagnosis (read-only)", "diagnosis body", ""]);
     expect(diagnosisSpy).toHaveBeenCalledOnce();
-    const [diagnosisOptions] = diagnosisSpy.mock.calls[0] as unknown as [
-      { secretDiagnostics?: unknown[] },
-    ];
-    expect(diagnosisOptions?.secretDiagnostics).toEqual([]);
+    expect(diagnosisSpy).toHaveBeenCalledWith(expect.objectContaining({ secretDiagnostics: [] }));
   });
 });

--- a/src/commands/status-all/report-lines.ts
+++ b/src/commands/status-all/report-lines.ts
@@ -85,20 +85,18 @@ export async function buildStatusAllReportLines(params: {
   appendStatusReportSections({
     lines,
     heading,
+    width: tableWidth,
+    renderTable,
     sections: [
       {
         kind: "table",
         title: "Overview",
-        width: tableWidth,
-        renderTable,
         columns: [...statusOverviewTableColumns],
         rows: params.overviewRows,
       },
       {
         kind: "table",
         title: "Channels",
-        width: tableWidth,
-        renderTable,
         // The status-all report has more horizontal space than compact status output.
         columns: statusChannelsTableColumns.map((column) =>
           column.key === "Detail" ? Object.assign({}, column, { minWidth: 28 }) : column,
@@ -115,16 +113,12 @@ export async function buildStatusAllReportLines(params: {
       },
       ...buildStatusChannelDetailSections({
         details: params.channels.details,
-        width: tableWidth,
-        renderTable,
         ok,
         warn,
       }),
       {
         kind: "table",
         title: "Agents",
-        width: tableWidth,
-        renderTable,
         columns: [...statusAgentsTableColumns],
         rows: buildStatusAgentTableRows({
           agentStatus: params.agentStatus,

--- a/src/commands/status-all/report-tables.test.ts
+++ b/src/commands/status-all/report-tables.test.ts
@@ -52,7 +52,6 @@ describe("status-all report tables", () => {
   });
 
   it("builds colored detail table sections", () => {
-    const renderTable = ({ rows }: { rows: unknown[] }) => `rows:${rows.length}`;
     const [section] = buildStatusChannelDetailSections({
       details: [
         {
@@ -61,8 +60,6 @@ describe("status-all report tables", () => {
           rows: [{ Channel: "quietchat", Status: "WARN", Notes: "setup" }],
         },
       ],
-      width: 120,
-      renderTable,
       ok: (value) => `ok(${value})`,
       warn: (value) => `warn(${value})`,
     });
@@ -70,8 +67,6 @@ describe("status-all report tables", () => {
     expect(section).toEqual({
       kind: "table",
       title: "Channel detail",
-      width: 120,
-      renderTable,
       columns: [
         { key: "Channel", header: "Channel", flex: false, minWidth: 10 },
         { key: "Status", header: "Status", flex: false, minWidth: 10 },

--- a/src/commands/status-all/report-tables.ts
+++ b/src/commands/status-all/report-tables.ts
@@ -1,7 +1,6 @@
 // Table row helpers for status report sections.
 // These functions keep terminal styling decisions out of the scan/data layer.
 
-import type { RenderTableOptions } from "../../../packages/terminal-core/src/table.js";
 import { formatTimeAgo } from "./format.js";
 import type { StatusReportSection } from "./text-report.js";
 
@@ -58,16 +57,12 @@ export function buildStatusAgentTableRows(params: {
 /** Converts per-channel account detail rows into renderable table sections. */
 export function buildStatusChannelDetailSections(params: {
   details: ChannelDetailLike[];
-  width: number;
-  renderTable: (input: RenderTableOptions) => string;
   ok: (text: string) => string;
   warn: (text: string) => string;
 }): StatusReportSection[] {
   return params.details.map((detail) => ({
     kind: "table" as const,
     title: detail.title,
-    width: params.width,
-    renderTable: params.renderTable,
     columns: detail.columns.map((column) => ({
       key: column,
       header: column,

--- a/src/commands/status-all/text-report.test.ts
+++ b/src/commands/status-all/text-report.test.ts
@@ -9,6 +9,8 @@ describe("appendStatusReportSections", () => {
     appendStatusReportSections({
       lines,
       heading: (text) => `# ${text}`,
+      width: 120,
+      renderTable: ({ width, rows }) => `  table:${width}:${rows.length} \n\t`,
       sections: [
         {
           kind: "raw",
@@ -22,11 +24,9 @@ describe("appendStatusReportSections", () => {
         {
           kind: "table",
           title: "Health",
-          width: 120,
-          renderTable: ({ rows }) => `table:${rows.length}`,
           columns: [{ key: "Item", header: "Item" }],
           rows: [{ Item: "Gateway" }],
-          trailer: "trailer",
+          trailer: "trailer  ",
         },
         {
           kind: "lines",
@@ -46,8 +46,62 @@ describe("appendStatusReportSections", () => {
       "overview body",
       "",
       "# Health",
-      "table:1",
-      "trailer",
+      "  table:120:1",
+      "trailer  ",
     ]);
   });
+
+  it.each([{ initial: [] }, { initial: ["# Start"] }, { initial: ["# Start", ""] }])(
+    "keeps empty sections unless explicitly skipped after $initial",
+    ({ initial }) => {
+      const lines = [...initial];
+      appendStatusReportSections({
+        lines,
+        heading: (text) => `# ${text}`,
+        width: 80,
+        renderTable: ({ width, rows }) => `table:${width}:${rows.length}\n`,
+        sections: [
+          { kind: "raw", body: [], skipIfEmpty: true },
+          { kind: "lines", title: "Skipped", body: [], skipIfEmpty: true },
+          {
+            kind: "table",
+            title: "Skipped table",
+            columns: [],
+            rows: [],
+            skipIfEmpty: true,
+            trailer: "skipped trailer",
+          },
+          { kind: "lines", title: "Empty lines", body: [] },
+          { kind: "raw", body: [] },
+          {
+            kind: "table",
+            title: "Empty table",
+            columns: [],
+            rows: [],
+            trailer: "empty trailer",
+          },
+          {
+            kind: "table",
+            title: "More rows",
+            columns: [{ key: "Item", header: "Item" }],
+            rows: [{ Item: "Gateway" }],
+            skipIfEmpty: true,
+            trailer: "",
+          },
+        ],
+      });
+      expect(lines).toEqual([
+        ...initial,
+        ...(initial.length ? [""] : []),
+        "# Empty lines",
+        "",
+        "# Empty table",
+        "table:80:0",
+        "empty trailer",
+        "",
+        "# More rows",
+        "table:80:1",
+      ]);
+    },
+  );
 });

--- a/src/commands/status-all/text-report.ts
+++ b/src/commands/status-all/text-report.ts
@@ -16,8 +16,6 @@ export type StatusReportSection =
   | {
       kind: "table";
       title: string;
-      width: number;
-      renderTable: TableRenderer;
       columns: readonly TableColumn[];
       rows: Array<Record<string, string>>;
       trailer?: string | null;
@@ -41,75 +39,41 @@ export function appendStatusSectionHeading(params: {
   params.lines.push(params.heading(params.title));
 }
 
-function appendStatusLinesSection(params: {
-  lines: string[];
-  heading: HeadingFn;
-  title: string;
-  body: string[];
-}) {
-  appendStatusSectionHeading(params);
-  params.lines.push(...params.body);
-}
-
-function appendStatusTableSection<Row extends Record<string, string>>(params: {
-  lines: string[];
-  heading: HeadingFn;
-  title: string;
-  width: number;
-  renderTable: (input: { width: number; columns: TableColumn[]; rows: Row[] }) => string;
-  columns: readonly TableColumn[];
-  rows: Row[];
-}) {
-  appendStatusSectionHeading(params);
-  params.lines.push(
-    params
-      .renderTable({
-        width: params.width,
-        columns: [...params.columns],
-        rows: params.rows,
-      })
-      .trimEnd(),
-  );
-}
-
-/** Appends all non-empty report sections in display order. */
+/** Appends report sections in display order, honoring explicit empty-section skipping. */
 export function appendStatusReportSections(params: {
   lines: string[];
   heading: HeadingFn;
+  width: number;
+  renderTable: TableRenderer;
   sections: StatusReportSection[];
 }) {
   for (const section of params.sections) {
+    const content = section.kind === "table" ? section.rows : section.body;
+    if (section.skipIfEmpty && content.length === 0) {
+      continue;
+    }
     if (section.kind === "raw") {
-      if (section.skipIfEmpty && section.body.length === 0) {
-        continue;
-      }
       params.lines.push(...section.body);
       continue;
     }
-    if (section.kind === "lines") {
-      if (section.skipIfEmpty && section.body.length === 0) {
-        continue;
-      }
-      appendStatusLinesSection({
-        lines: params.lines,
-        heading: params.heading,
-        title: section.title,
-        body: section.body,
-      });
-      continue;
-    }
-    if (section.skipIfEmpty && section.rows.length === 0) {
-      continue;
-    }
-    appendStatusTableSection({
+    appendStatusSectionHeading({
       lines: params.lines,
       heading: params.heading,
       title: section.title,
-      width: section.width,
-      renderTable: section.renderTable,
-      columns: section.columns,
-      rows: section.rows,
     });
+    if (section.kind === "lines") {
+      params.lines.push(...section.body);
+      continue;
+    }
+    params.lines.push(
+      params
+        .renderTable({
+          width: params.width,
+          columns: [...section.columns],
+          rows: section.rows,
+        })
+        .trimEnd(),
+    );
     if (section.trailer) {
       params.lines.push(section.trailer);
     }

--- a/src/commands/status.command-report.ts
+++ b/src/commands/status.command-report.ts
@@ -37,12 +37,12 @@ export async function buildStatusCommandReportLines(params: {
   appendStatusReportSections({
     lines,
     heading: params.heading,
+    width: params.width,
+    renderTable: params.renderTable,
     sections: [
       {
         kind: "table",
         title: "Overview",
-        width: params.width,
-        renderTable: params.renderTable,
         columns: [...statusOverviewTableColumns],
         rows: params.overviewRows,
       },
@@ -95,8 +95,6 @@ export async function buildStatusCommandReportLines(params: {
         : {
             kind: "table",
             title: "Channels",
-            width: params.width,
-            renderTable: params.renderTable,
             columns: [...params.channelsColumns],
             rows: params.channelsRows,
           },
@@ -109,16 +107,12 @@ export async function buildStatusCommandReportLines(params: {
         : {
             kind: "table",
             title: "Sessions",
-            width: params.width,
-            renderTable: params.renderTable,
             columns: [...params.sessionsColumns],
             rows: params.sessionsRows,
           },
       {
         kind: "table",
         title: "System events",
-        width: params.width,
-        renderTable: params.renderTable,
         columns: [{ key: "Event", header: "Event", flex: true, minWidth: 24 }],
         rows: params.systemEventsRows ?? [],
         trailer: params.systemEventsTrailer,
@@ -127,8 +121,6 @@ export async function buildStatusCommandReportLines(params: {
       {
         kind: "table",
         title: "Health",
-        width: params.width,
-        renderTable: params.renderTable,
         columns: [...(params.healthColumns ?? [])],
         rows: params.healthRows ?? [],
         skipIfEmpty: true,


### PR DESCRIPTION
## What Problem This Solves

Removes repeated terminal-report setup in normal and detailed status output while preserving the reports operators see.

## Why This Change Was Made

The report owner prepares terminal styling and rendering context once and passes it through the existing report renderers. This removes duplicated setup and lookup paths without changing status collection, diagnosis, ordering or JSON output.

## User Impact

No intended behavior change. Production code decreases by 55 lines; focused test coverage adds 73 lines. This changes presentation plumbing only.

## Evidence

All 18 focused status-report tests pass. An external baseline/candidate corpus compared 20,736 mixed-section compositions and 768 compact reports byte-for-byte, including ANSI and terminal-width cases. Detailed status rendering and asynchronous Diagnosis handoff are covered by the focused integration tests. Selected type, format, lint, dead-export, runtime-sidecar and architecture checks pass. Independent P2 review and deslop found no actionable issue. Rebase onto current main preserved all seven touched files exactly.

## Review follow-through

The latest ClawSweeper review found no actionable issue. Exact-head [CI 33480804343](https://github.com/openclaw/openclaw/actions/runs/33480804343), including the required CI gate, is successful. Maintainer review confirms the shared section renderer is the existing owner for both report builders.
