### PR TITLE
refactor(diagnostics): remove duplicate metric inventory

### DIFF
--- a/extensions/diagnostics-otel/src/service-metrics.ts
+++ b/extensions/diagnostics-otel/src/service-metrics.ts
@@ -19,332 +19,264 @@ export function createDiagnosticsMetrics(
   const createHistogram = (name: `openclaw.${string}`, options?: MetricOptions) =>
     meter.createHistogram(resolveMetricName(name), options);
 
-  const tokensCounter = createCounter("openclaw.tokens", {
-    unit: "1",
-    description: "Token usage by type",
-  });
-  const genAiTokenUsageHistogram = meter.createHistogram("gen_ai.client.token.usage", {
-    unit: "{token}",
-    description: "Number of input and output tokens used by GenAI client operations",
-    advice: {
-      explicitBucketBoundaries: GEN_AI_TOKEN_USAGE_BUCKETS,
-    },
-  });
-  const genAiOperationDurationHistogram = meter.createHistogram(
-    "gen_ai.client.operation.duration",
-    {
+  return {
+    tokensCounter: createCounter("openclaw.tokens", {
+      unit: "1",
+      description: "Token usage by type",
+    }),
+    genAiTokenUsageHistogram: meter.createHistogram("gen_ai.client.token.usage", {
+      unit: "{token}",
+      description: "Number of input and output tokens used by GenAI client operations",
+      advice: {
+        explicitBucketBoundaries: GEN_AI_TOKEN_USAGE_BUCKETS,
+      },
+    }),
+    genAiOperationDurationHistogram: meter.createHistogram("gen_ai.client.operation.duration", {
       unit: "s",
       description: "GenAI client operation duration",
       advice: {
         explicitBucketBoundaries: GEN_AI_OPERATION_DURATION_BUCKETS,
       },
-    },
-  );
-  const costCounter = createCounter("openclaw.cost.usd", {
-    unit: "1",
-    description: "Estimated model cost (USD)",
-  });
-  const durationHistogram = createHistogram("openclaw.run.duration_ms", {
-    unit: "ms",
-    description: "Agent run duration",
-    advice: { explicitBucketBoundaries: AGENT_DURATION_MS_BUCKETS },
-  });
-  const harnessDurationHistogram = createHistogram("openclaw.harness.duration_ms", {
-    unit: "ms",
-    description: "Agent harness lifecycle duration",
-    advice: { explicitBucketBoundaries: AGENT_DURATION_MS_BUCKETS },
-  });
-  const contextHistogram = createHistogram("openclaw.context.tokens", {
-    unit: "1",
-    description: "Context window size and usage",
-    advice: { explicitBucketBoundaries: CONTEXT_TOKENS_BUCKETS },
-  });
-  const webhookReceivedCounter = createCounter("openclaw.webhook.received", {
-    unit: "1",
-    description: "Webhook requests received",
-  });
-  const webhookErrorCounter = createCounter("openclaw.webhook.error", {
-    unit: "1",
-    description: "Webhook processing errors",
-  });
-  const webhookDurationHistogram = createHistogram("openclaw.webhook.duration_ms", {
-    unit: "ms",
-    description: "Webhook processing duration",
-  });
-  const messageQueuedCounter = createCounter("openclaw.message.queued", {
-    unit: "1",
-    description: "Messages queued for processing",
-  });
-  const messageReceivedCounter = createCounter("openclaw.message.received", {
-    unit: "1",
-    description: "Inbound messages received",
-  });
-  const messageDispatchStartedCounter = createCounter("openclaw.message.dispatch.started", {
-    unit: "1",
-    description: "Inbound message dispatch attempts started",
-  });
-  const messageDispatchCompletedCounter = createCounter("openclaw.message.dispatch.completed", {
-    unit: "1",
-    description: "Inbound message dispatch attempts completed",
-  });
-  const messageDispatchDurationHistogram = createHistogram(
-    "openclaw.message.dispatch.duration_ms",
-    {
+    }),
+    costCounter: createCounter("openclaw.cost.usd", {
+      unit: "1",
+      description: "Estimated model cost (USD)",
+    }),
+    durationHistogram: createHistogram("openclaw.run.duration_ms", {
+      unit: "ms",
+      description: "Agent run duration",
+      advice: { explicitBucketBoundaries: AGENT_DURATION_MS_BUCKETS },
+    }),
+    harnessDurationHistogram: createHistogram("openclaw.harness.duration_ms", {
+      unit: "ms",
+      description: "Agent harness lifecycle duration",
+      advice: { explicitBucketBoundaries: AGENT_DURATION_MS_BUCKETS },
+    }),
+    contextHistogram: createHistogram("openclaw.context.tokens", {
+      unit: "1",
+      description: "Context window size and usage",
+      advice: { explicitBucketBoundaries: CONTEXT_TOKENS_BUCKETS },
+    }),
+    webhookReceivedCounter: createCounter("openclaw.webhook.received", {
+      unit: "1",
+      description: "Webhook requests received",
+    }),
+    webhookErrorCounter: createCounter("openclaw.webhook.error", {
+      unit: "1",
+      description: "Webhook processing errors",
+    }),
+    webhookDurationHistogram: createHistogram("openclaw.webhook.duration_ms", {
+      unit: "ms",
+      description: "Webhook processing duration",
+    }),
+    messageQueuedCounter: createCounter("openclaw.message.queued", {
+      unit: "1",
+      description: "Messages queued for processing",
+    }),
+    messageReceivedCounter: createCounter("openclaw.message.received", {
+      unit: "1",
+      description: "Inbound messages received",
+    }),
+    messageDispatchStartedCounter: createCounter("openclaw.message.dispatch.started", {
+      unit: "1",
+      description: "Inbound message dispatch attempts started",
+    }),
+    messageDispatchCompletedCounter: createCounter("openclaw.message.dispatch.completed", {
+      unit: "1",
+      description: "Inbound message dispatch attempts completed",
+    }),
+    messageDispatchDurationHistogram: createHistogram("openclaw.message.dispatch.duration_ms", {
       unit: "ms",
       description: "Inbound message dispatch duration",
-    },
-  );
-  const messageProcessedCounter = createCounter("openclaw.message.processed", {
-    unit: "1",
-    description: "Messages processed by outcome",
-  });
-  const messageDurationHistogram = createHistogram("openclaw.message.duration_ms", {
-    unit: "ms",
-    description: "Message processing duration",
-  });
-  const messageDeliveryStartedCounter = createCounter("openclaw.message.delivery.started", {
-    unit: "1",
-    description: "Outbound message delivery attempts started",
-  });
-  const messageDeliveryDurationHistogram = createHistogram(
-    "openclaw.message.delivery.duration_ms",
-    {
+    }),
+    messageProcessedCounter: createCounter("openclaw.message.processed", {
+      unit: "1",
+      description: "Messages processed by outcome",
+    }),
+    messageDurationHistogram: createHistogram("openclaw.message.duration_ms", {
+      unit: "ms",
+      description: "Message processing duration",
+    }),
+    messageDeliveryStartedCounter: createCounter("openclaw.message.delivery.started", {
+      unit: "1",
+      description: "Outbound message delivery attempts started",
+    }),
+    messageDeliveryDurationHistogram: createHistogram("openclaw.message.delivery.duration_ms", {
       unit: "ms",
       description: "Outbound message delivery duration",
-    },
-  );
-  const queueDepthHistogram = createHistogram("openclaw.queue.depth", {
-    unit: "1",
-    description: "Queue depth on enqueue/dequeue",
-  });
-  const queueWaitHistogram = createHistogram("openclaw.queue.wait_ms", {
-    unit: "ms",
-    description: "Queue wait time before execution",
-  });
-  const laneEnqueueCounter = createCounter("openclaw.queue.lane.enqueue", {
-    unit: "1",
-    description: "Command queue lane enqueue events",
-  });
-  const laneDequeueCounter = createCounter("openclaw.queue.lane.dequeue", {
-    unit: "1",
-    description: "Command queue lane dequeue events",
-  });
-  const sessionStateCounter = createCounter("openclaw.session.state", {
-    unit: "1",
-    description: "Session state transitions",
-  });
-  const sessionTurnCreatedCounter = createCounter("openclaw.session.turn.created", {
-    unit: "1",
-    description: "Agent session turns created",
-  });
-  const sessionStuckCounter = createCounter("openclaw.session.stuck", {
-    unit: "1",
-    description: "Sessions stuck in processing",
-  });
-  const sessionStuckAgeHistogram = createHistogram("openclaw.session.stuck_age_ms", {
-    unit: "ms",
-    description: "Age of stuck sessions",
-  });
-  const sessionRecoveryRequestedCounter = createCounter("openclaw.session.recovery.requested", {
-    unit: "1",
-    description: "Session recovery attempts requested",
-  });
-  const sessionRecoveryCompletedCounter = createCounter("openclaw.session.recovery.completed", {
-    unit: "1",
-    description: "Session recovery attempts completed",
-  });
-  const sessionRecoveryAgeHistogram = createHistogram("openclaw.session.recovery.age_ms", {
-    unit: "ms",
-    description: "Age of sessions selected for recovery",
-  });
-  const talkEventCounter = createCounter("openclaw.talk.event", {
-    unit: "1",
-    description: "Talk events emitted by type",
-  });
-  const talkEventDurationHistogram = createHistogram("openclaw.talk.event.duration_ms", {
-    unit: "ms",
-    description: "Talk event duration when reported",
-  });
-  const talkAudioBytesHistogram = createHistogram("openclaw.talk.audio.bytes", {
-    unit: "By",
-    description: "Talk audio frame byte lengths",
-  });
-  const runAttemptCounter = createCounter("openclaw.run.attempt", {
-    unit: "1",
-    description: "Run attempts",
-  });
-  const toolLoopCounter = createCounter("openclaw.tool.loop", {
-    unit: "1",
-    description: "Detected repetitive tool-call loop events",
-  });
-  const skillUsedCounter = createCounter("openclaw.skill.used", {
-    unit: "1",
-    description: "Skills used by agent runs",
-  });
-  const modelCallDurationHistogram = createHistogram("openclaw.model_call.duration_ms", {
-    unit: "ms",
-    description: "Model call duration",
-  });
-  const modelCallRequestBytesHistogram = createHistogram("openclaw.model_call.request_bytes", {
-    unit: "By",
-    description: "UTF-8 byte size of sanitized model request payloads",
-  });
-  const modelCallResponseBytesHistogram = createHistogram("openclaw.model_call.response_bytes", {
-    unit: "By",
-    description: "UTF-8 byte size of bounded streamed model response payloads",
-  });
-  const modelCallTimeToFirstByteHistogram = createHistogram(
-    "openclaw.model_call.time_to_first_byte_ms",
-    {
-      unit: "ms",
-      description: "Elapsed time before the first streamed model response event",
-    },
-  );
-  const modelFailoverCounter = createCounter("openclaw.model.failover", {
-    unit: "1",
-    description: "Model failovers by source, destination, lane, and reason",
-  });
-  const toolExecutionDurationHistogram = createHistogram("openclaw.tool.execution.duration_ms", {
-    unit: "ms",
-    description: "Tool execution duration",
-  });
-  const toolExecutionBlockedCounter = createCounter("openclaw.tool.execution.blocked", {
-    unit: "1",
-    description: "Tool executions blocked by policy or sandbox diagnostics",
-  });
-  const execProcessDurationHistogram = createHistogram("openclaw.exec.duration_ms", {
-    unit: "ms",
-    description: "Exec process duration",
-  });
-  const memoryRssHistogram = createHistogram("openclaw.memory.rss_bytes", {
-    unit: "By",
-    description: "Resident set size reported by diagnostic memory samples",
-  });
-  const memoryHeapUsedHistogram = createHistogram("openclaw.memory.heap_used_bytes", {
-    unit: "By",
-    description: "Heap used bytes reported by diagnostic memory samples",
-  });
-  const memoryHeapTotalHistogram = createHistogram("openclaw.memory.heap_total_bytes", {
-    unit: "By",
-    description: "Heap total bytes reported by diagnostic memory samples",
-  });
-  const memoryExternalHistogram = createHistogram("openclaw.memory.external_bytes", {
-    unit: "By",
-    description: "External memory bytes reported by diagnostic memory samples",
-  });
-  const memoryArrayBuffersHistogram = createHistogram("openclaw.memory.array_buffers_bytes", {
-    unit: "By",
-    description: "ArrayBuffer bytes reported by diagnostic memory samples",
-  });
-  const memoryPressureCounter = createCounter("openclaw.memory.pressure", {
-    unit: "1",
-    description: "Diagnostic memory pressure events",
-  });
-  const asyncQueueDroppedCounter = createCounter("openclaw.diagnostic.async_queue.dropped", {
-    unit: "1",
-    description: "Async diagnostic queue drops by dropped event class",
-  });
-  const payloadLargeCounter = createCounter("openclaw.payload.large", {
-    unit: "1",
-    description: "Oversized payload diagnostics by surface and action",
-  });
-  const payloadLargeBytesHistogram = createHistogram("openclaw.payload.large_bytes", {
-    unit: "By",
-    description: "Oversized payload byte sizes by surface and action",
-  });
-  const livenessWarningCounter = createCounter("openclaw.liveness.warning", {
-    unit: "1",
-    description: "Diagnostic liveness warning events",
-  });
-  const livenessEventLoopDelayP99Histogram = createHistogram(
-    "openclaw.liveness.event_loop_delay_p99_ms",
-    {
-      unit: "ms",
-      description: "P99 event-loop delay reported by diagnostic liveness warnings",
-    },
-  );
-  const livenessEventLoopDelayMaxHistogram = createHistogram(
-    "openclaw.liveness.event_loop_delay_max_ms",
-    {
-      unit: "ms",
-      description: "Maximum event-loop delay reported by diagnostic liveness warnings",
-    },
-  );
-  const livenessEventLoopUtilizationHistogram = createHistogram(
-    "openclaw.liveness.event_loop_utilization",
-    {
+    }),
+    queueDepthHistogram: createHistogram("openclaw.queue.depth", {
       unit: "1",
-      description: "Event-loop utilization reported by diagnostic liveness warnings",
-    },
-  );
-  const livenessCpuCoreRatioHistogram = createHistogram("openclaw.liveness.cpu_core_ratio", {
-    unit: "1",
-    description: "CPU core ratio reported by diagnostic liveness warnings",
-  });
-  const telemetryExporterCounter = createCounter("openclaw.telemetry.exporter.events", {
-    unit: "1",
-    description: "Diagnostic telemetry exporter lifecycle and failure events",
-  });
-  return {
-    tokensCounter,
-    genAiTokenUsageHistogram,
-    genAiOperationDurationHistogram,
-    costCounter,
-    durationHistogram,
-    harnessDurationHistogram,
-    contextHistogram,
-    webhookReceivedCounter,
-    webhookErrorCounter,
-    webhookDurationHistogram,
-    messageQueuedCounter,
-    messageReceivedCounter,
-    messageDispatchStartedCounter,
-    messageDispatchCompletedCounter,
-    messageDispatchDurationHistogram,
-    messageProcessedCounter,
-    messageDurationHistogram,
-    messageDeliveryStartedCounter,
-    messageDeliveryDurationHistogram,
-    queueDepthHistogram,
-    queueWaitHistogram,
-    laneEnqueueCounter,
-    laneDequeueCounter,
-    sessionStateCounter,
-    sessionTurnCreatedCounter,
-    sessionStuckCounter,
-    sessionStuckAgeHistogram,
-    sessionRecoveryRequestedCounter,
-    sessionRecoveryCompletedCounter,
-    sessionRecoveryAgeHistogram,
-    talkEventCounter,
-    talkEventDurationHistogram,
-    talkAudioBytesHistogram,
-    runAttemptCounter,
-    toolLoopCounter,
-    skillUsedCounter,
-    modelCallDurationHistogram,
-    modelCallRequestBytesHistogram,
-    modelCallResponseBytesHistogram,
-    modelCallTimeToFirstByteHistogram,
-    modelFailoverCounter,
-    toolExecutionDurationHistogram,
-    toolExecutionBlockedCounter,
-    execProcessDurationHistogram,
-    memoryRssHistogram,
-    memoryHeapUsedHistogram,
-    memoryHeapTotalHistogram,
-    memoryExternalHistogram,
-    memoryArrayBuffersHistogram,
-    memoryPressureCounter,
-    asyncQueueDroppedCounter,
-    payloadLargeCounter,
-    payloadLargeBytesHistogram,
-    livenessWarningCounter,
-    livenessEventLoopDelayP99Histogram,
-    livenessEventLoopDelayMaxHistogram,
-    livenessEventLoopUtilizationHistogram,
-    livenessCpuCoreRatioHistogram,
-    telemetryExporterCounter,
+      description: "Queue depth on enqueue/dequeue",
+    }),
+    queueWaitHistogram: createHistogram("openclaw.queue.wait_ms", {
+      unit: "ms",
+      description: "Queue wait time before execution",
+    }),
+    laneEnqueueCounter: createCounter("openclaw.queue.lane.enqueue", {
+      unit: "1",
+      description: "Command queue lane enqueue events",
+    }),
+    laneDequeueCounter: createCounter("openclaw.queue.lane.dequeue", {
+      unit: "1",
+      description: "Command queue lane dequeue events",
+    }),
+    sessionStateCounter: createCounter("openclaw.session.state", {
+      unit: "1",
+      description: "Session state transitions",
+    }),
+    sessionTurnCreatedCounter: createCounter("openclaw.session.turn.created", {
+      unit: "1",
+      description: "Agent session turns created",
+    }),
+    sessionStuckCounter: createCounter("openclaw.session.stuck", {
+      unit: "1",
+      description: "Sessions stuck in processing",
+    }),
+    sessionStuckAgeHistogram: createHistogram("openclaw.session.stuck_age_ms", {
+      unit: "ms",
+      description: "Age of stuck sessions",
+    }),
+    sessionRecoveryRequestedCounter: createCounter("openclaw.session.recovery.requested", {
+      unit: "1",
+      description: "Session recovery attempts requested",
+    }),
+    sessionRecoveryCompletedCounter: createCounter("openclaw.session.recovery.completed", {
+      unit: "1",
+      description: "Session recovery attempts completed",
+    }),
+    sessionRecoveryAgeHistogram: createHistogram("openclaw.session.recovery.age_ms", {
+      unit: "ms",
+      description: "Age of sessions selected for recovery",
+    }),
+    talkEventCounter: createCounter("openclaw.talk.event", {
+      unit: "1",
+      description: "Talk events emitted by type",
+    }),
+    talkEventDurationHistogram: createHistogram("openclaw.talk.event.duration_ms", {
+      unit: "ms",
+      description: "Talk event duration when reported",
+    }),
+    talkAudioBytesHistogram: createHistogram("openclaw.talk.audio.bytes", {
+      unit: "By",
+      description: "Talk audio frame byte lengths",
+    }),
+    runAttemptCounter: createCounter("openclaw.run.attempt", {
+      unit: "1",
+      description: "Run attempts",
+    }),
+    toolLoopCounter: createCounter("openclaw.tool.loop", {
+      unit: "1",
+      description: "Detected repetitive tool-call loop events",
+    }),
+    skillUsedCounter: createCounter("openclaw.skill.used", {
+      unit: "1",
+      description: "Skills used by agent runs",
+    }),
+    modelCallDurationHistogram: createHistogram("openclaw.model_call.duration_ms", {
+      unit: "ms",
+      description: "Model call duration",
+    }),
+    modelCallRequestBytesHistogram: createHistogram("openclaw.model_call.request_bytes", {
+      unit: "By",
+      description: "UTF-8 byte size of sanitized model request payloads",
+    }),
+    modelCallResponseBytesHistogram: createHistogram("openclaw.model_call.response_bytes", {
+      unit: "By",
+      description: "UTF-8 byte size of bounded streamed model response payloads",
+    }),
+    modelCallTimeToFirstByteHistogram: createHistogram(
+      "openclaw.model_call.time_to_first_byte_ms",
+      {
+        unit: "ms",
+        description: "Elapsed time before the first streamed model response event",
+      },
+    ),
+    modelFailoverCounter: createCounter("openclaw.model.failover", {
+      unit: "1",
+      description: "Model failovers by source, destination, lane, and reason",
+    }),
+    toolExecutionDurationHistogram: createHistogram("openclaw.tool.execution.duration_ms", {
+      unit: "ms",
+      description: "Tool execution duration",
+    }),
+    toolExecutionBlockedCounter: createCounter("openclaw.tool.execution.blocked", {
+      unit: "1",
+      description: "Tool executions blocked by policy or sandbox diagnostics",
+    }),
+    execProcessDurationHistogram: createHistogram("openclaw.exec.duration_ms", {
+      unit: "ms",
+      description: "Exec process duration",
+    }),
+    memoryRssHistogram: createHistogram("openclaw.memory.rss_bytes", {
+      unit: "By",
+      description: "Resident set size reported by diagnostic memory samples",
+    }),
+    memoryHeapUsedHistogram: createHistogram("openclaw.memory.heap_used_bytes", {
+      unit: "By",
+      description: "Heap used bytes reported by diagnostic memory samples",
+    }),
+    memoryHeapTotalHistogram: createHistogram("openclaw.memory.heap_total_bytes", {
+      unit: "By",
+      description: "Heap total bytes reported by diagnostic memory samples",
+    }),
+    memoryExternalHistogram: createHistogram("openclaw.memory.external_bytes", {
+      unit: "By",
+      description: "External memory bytes reported by diagnostic memory samples",
+    }),
+    memoryArrayBuffersHistogram: createHistogram("openclaw.memory.array_buffers_bytes", {
+      unit: "By",
+      description: "ArrayBuffer bytes reported by diagnostic memory samples",
+    }),
+    memoryPressureCounter: createCounter("openclaw.memory.pressure", {
+      unit: "1",
+      description: "Diagnostic memory pressure events",
+    }),
+    asyncQueueDroppedCounter: createCounter("openclaw.diagnostic.async_queue.dropped", {
+      unit: "1",
+      description: "Async diagnostic queue drops by dropped event class",
+    }),
+    payloadLargeCounter: createCounter("openclaw.payload.large", {
+      unit: "1",
+      description: "Oversized payload diagnostics by surface and action",
+    }),
+    payloadLargeBytesHistogram: createHistogram("openclaw.payload.large_bytes", {
+      unit: "By",
+      description: "Oversized payload byte sizes by surface and action",
+    }),
+    livenessWarningCounter: createCounter("openclaw.liveness.warning", {
+      unit: "1",
+      description: "Diagnostic liveness warning events",
+    }),
+    livenessEventLoopDelayP99Histogram: createHistogram(
+      "openclaw.liveness.event_loop_delay_p99_ms",
+      {
+        unit: "ms",
+        description: "P99 event-loop delay reported by diagnostic liveness warnings",
+      },
+    ),
+    livenessEventLoopDelayMaxHistogram: createHistogram(
+      "openclaw.liveness.event_loop_delay_max_ms",
+      {
+        unit: "ms",
+        description: "Maximum event-loop delay reported by diagnostic liveness warnings",
+      },
+    ),
+    livenessEventLoopUtilizationHistogram: createHistogram(
+      "openclaw.liveness.event_loop_utilization",
+      {
+        unit: "1",
+        description: "Event-loop utilization reported by diagnostic liveness warnings",
+      },
+    ),
+    livenessCpuCoreRatioHistogram: createHistogram("openclaw.liveness.cpu_core_ratio", {
+      unit: "1",
+      description: "CPU core ratio reported by diagnostic liveness warnings",
+    }),
+    telemetryExporterCounter: createCounter("openclaw.telemetry.exporter.events", {
+      unit: "1",
+      description: "Diagnostic telemetry exporter lifecycle and failure events",
+    }),
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Removes a duplicated metric inventory from the diagnostics plugin while preserving exported telemetry.

## Why This Change Was Made

The metric factory returns its instruments directly. The same meter calls run in the same order with unchanged names, descriptions, units and boundaries; the returned object retains its keys and instrument identities. Consumers and the OpenTelemetry dependency contract remain unchanged.

## User Impact

No intended behavior change. Production code decreases by 68 physical lines (+245/−313), including 59 lines of actual repeated inventory removal after discounting formatting. No test, dependency or configuration change.

## Evidence

All 288 baseline/candidate tests pass, including 94 cases exercising real OTLP HTTP/protobuf export. Differential proof covers four prefixes, all 59 ordered instrument initializers, 236 paired synchronous failure cases, and identical inferred declarations. Installed OpenTelemetry meter types and runtime implementation were inspected directly. All selected checks, independent P2 review and deslop pass. Rebase onto current main preserved the factory bytes exactly.

## Review follow-through

The remaining CI rank-up move is complete: exact-head [CI 33480805405](https://github.com/openclaw/openclaw/actions/runs/33480805405), including the required CI gate, is successful. The dependency inspection unavailable to ClawSweeper was completed locally against installed `@opentelemetry/api` 1.9.1 (`build/src/metrics/Meter.d.ts`) and `@opentelemetry/sdk-metrics` 2.10.0 (`build/src/Meter.js` and `build/src/state/MeterSharedState.js`). Counter/histogram creation still constructs the same descriptor, registers the same metric storage and returns the same instrument handle in source order. The real OTLP export and synchronous-failure comparisons above exercise that contract. Maintainer review accepts this behavior-preserving cleanup for landing through the normal required gates.
