### PR TITLE
test(realtime): reuse canonical terminal fixture promise helpers

### DIFF
--- a/extensions/openai/realtime-voice-terminal-outcomes.test.ts
+++ b/extensions/openai/realtime-voice-terminal-outcomes.test.ts
@@ -1,6 +1,8 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { RealtimeVoiceResponseOutcome } from "openclaw/plugin-sdk/realtime-voice";
+import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { describe, expect, it } from "vitest";
 import type WebSocket from "ws";
 import { WebSocketServer } from "ws";
@@ -15,28 +17,6 @@ type CapturedOutcome = {
   connected: boolean;
 };
 
-function signal() {
-  let resolve = () => {};
-  const promise = new Promise<void>((done) => {
-    resolve = done;
-  });
-  return { promise, resolve };
-}
-
-async function waitFor(promise: Promise<void>, label: string): Promise<void> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  try {
-    await Promise.race([
-      promise,
-      new Promise<never>((_, reject) => {
-        timeout = setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), 2_000);
-      }),
-    ]);
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
 async function capture(
   terminalEvent: Record<string, unknown>,
   options: { completeFollowup?: boolean; queueFollowup?: boolean; throwCallback?: boolean } = {},
@@ -49,10 +29,10 @@ async function capture(
     tools: [],
     connected: false,
   };
-  const responseCreated = signal();
-  const terminalProcessed = signal();
-  const followupCreated = signal();
-  const followupCompleted = signal();
+  const responseCreated = createDeferred<void>();
+  const terminalProcessed = createDeferred<void>();
+  const followupCreated = createDeferred<void>();
+  const followupCompleted = createDeferred<void>();
   const server = createServer();
   const sockets = new Set<WebSocket>();
   const wss = new WebSocketServer({ noServer: true, maxPayload: 1024 * 1024 });
@@ -122,17 +102,25 @@ async function capture(
       throw new Error("expected a connected fixture socket");
     }
     socket.send(JSON.stringify({ type: "response.created", response: { id: "response_1" } }));
-    await waitFor(responseCreated.promise, "response.created");
+    await withTimeout(responseCreated.promise, 2_000, {
+      message: "timed out waiting for response.created",
+    });
     if (options.queueFollowup) {
       bridge.sendUserMessage?.("Continue after the terminal response.");
     }
     socket.send(JSON.stringify(terminalEvent));
-    await waitFor(terminalProcessed.promise, "terminal response");
+    await withTimeout(terminalProcessed.promise, 2_000, {
+      message: "timed out waiting for terminal response",
+    });
     if (options.queueFollowup) {
-      await waitFor(followupCreated.promise, "queued response.create");
+      await withTimeout(followupCreated.promise, 2_000, {
+        message: "timed out waiting for queued response.create",
+      });
     }
     if (options.completeFollowup) {
-      await waitFor(followupCompleted.promise, "completed follow-up");
+      await withTimeout(followupCompleted.promise, 2_000, {
+        message: "timed out waiting for completed follow-up",
+      });
     }
     captured.connected = bridge.isConnected();
     return captured;

--- a/extensions/xai/realtime-voice-terminal-outcomes.test.ts
+++ b/extensions/xai/realtime-voice-terminal-outcomes.test.ts
@@ -1,6 +1,8 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { RealtimeVoiceResponseOutcome } from "openclaw/plugin-sdk/realtime-voice";
+import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { describe, expect, it } from "vitest";
 import type WebSocket from "ws";
 import { WebSocketServer } from "ws";
@@ -20,38 +22,15 @@ type CaptureRealtimeOutcomeOptions = {
   throwOnResponseDone?: boolean;
 };
 
-async function waitForFixtureEvent(promise: Promise<void>, label: string): Promise<void> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  try {
-    await Promise.race([
-      promise,
-      new Promise<never>((_, reject) => {
-        timeout = setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), 2_000);
-      }),
-    ]);
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
 async function captureRealtimeOutcome(
   eventInput: Record<string, unknown> | Record<string, unknown>[],
   options: CaptureRealtimeOutcomeOptions = {},
 ): Promise<RealtimeOutcome> {
   const events = Array.isArray(eventInput) ? eventInput : [eventInput];
   const outcome: RealtimeOutcome = { errors: [], outcomes: [], transcripts: [], tools: [] };
-  let markServerEventHandled: () => void = () => {};
-  const serverEventHandled = new Promise<void>((resolve) => {
-    markServerEventHandled = resolve;
-  });
-  let markResponseCreatedHandled: () => void = () => {};
-  const responseCreatedHandled = new Promise<void>((resolve) => {
-    markResponseCreatedHandled = resolve;
-  });
-  let markQueuedResponseCompleted: () => void = () => {};
-  const queuedResponseCompleted = new Promise<void>((resolve) => {
-    markQueuedResponseCompleted = resolve;
-  });
+  const serverEventHandled = createDeferred<void>();
+  const responseCreatedHandled = createDeferred<void>();
+  const queuedResponseCompleted = createDeferred<void>();
   const server = createServer();
   const sockets = new Set<WebSocket>();
   let queuedTurnTriggered = false;
@@ -75,7 +54,7 @@ async function captureRealtimeOutcome(
               }),
             );
           }
-          markServerEventHandled();
+          serverEventHandled.resolve();
           return;
         }
         if (
@@ -114,7 +93,7 @@ async function captureRealtimeOutcome(
     onResponseDone: (responseOutcome) => {
       outcome.outcomes.push(responseOutcome);
       if (responseOutcome.responseId === "response_2") {
-        markQueuedResponseCompleted();
+        queuedResponseCompleted.resolve();
       }
       if (options.throwOnResponseDone && responseOutcome.responseId === "response_1") {
         throw new Error("consumer callback failed");
@@ -124,11 +103,11 @@ async function captureRealtimeOutcome(
     onToolCall: (tool) => outcome.tools.push(tool),
     onEvent: (observed) => {
       if (observed.direction === "server" && observed.type === "response.created") {
-        markResponseCreatedHandled();
+        responseCreatedHandled.resolve();
       }
       if (observed.direction === "server" && observed.type === events.at(-1)?.type) {
         if (!options.queuedUserMessage) {
-          markServerEventHandled();
+          serverEventHandled.resolve();
         }
       }
     },
@@ -137,14 +116,20 @@ async function captureRealtimeOutcome(
   try {
     await bridge.connect();
     if (options.queuedUserMessage) {
-      await waitForFixtureEvent(responseCreatedHandled, "response.created");
+      await withTimeout(responseCreatedHandled.promise, 2_000, {
+        message: "timed out waiting for response.created",
+      });
       bridge.sendUserMessage?.(options.queuedUserMessage);
-      await waitForFixtureEvent(serverEventHandled, "the queued response.create");
+      await withTimeout(serverEventHandled.promise, 2_000, {
+        message: "timed out waiting for the queued response.create",
+      });
       if (options.completeQueuedResponse) {
-        await waitForFixtureEvent(queuedResponseCompleted, "the completed queued response");
+        await withTimeout(queuedResponseCompleted.promise, 2_000, {
+          message: "timed out waiting for the completed queued response",
+        });
       }
     } else {
-      await serverEventHandled;
+      await serverEventHandled.promise;
     }
     return outcome;
   } finally {


### PR DESCRIPTION
## What Problem This Solves

The OpenAI and xAI real-socket terminal fixtures carry local deferred and timeout implementations already provided by the public plugin SDK.

## Why This Change Was Made

Reuse the canonical helpers and explicitly type all seven completion signals as void. Preserve each event producer, the OpenAI terminal microtask, the seven existing two-second diagnostics and the fixture teardown sequence.

## User Impact

Test-only: production +0/-0; tests +37/-64 (net -27). Both complete describe bodies remain byte-identical: eight OpenAI cases and nineteen xAI cases, with all original assertions and payloads. The removed timeout copies already cleared their timers; no new timer-leak fix, removed socket startup or elapsed-time speedup is claimed.

## Evidence

Source and dependency review confirms the helper contracts and retained fixture boundaries. Parser-only checks preserve the 8/19 expanded case counts, 11/12 source expect calls, seven explicit void-deferred sites and all seven two-second diagnostics.

Normal before/after pass 8/8 OpenAI and 19/19 xAI, with identical ordered native identities/statuses including repeated truncated labels. The OpenAI terminal/bridge-events sibling run passes 25/25. Suppressing only the OpenAI terminal completion signal produces the sole selected failure, 'timed out waiting for terminal response', through the existing two-second helper; seven cases skip, with no unhandled/global timeout. The saved post-close observation records a disconnected bridge, one closed tracked socket, zero ws clients and no HTTP listener after the actual completed event/outcome. This covers only that normal-setup, suppressed-signal path. Exact source restoration and managed runner group/leader/output completion were recorded and the restored source hashes match. Full changed-file gate exit 0 is confirmed. Scoped Codex autoreview returned no findings at its requested review threshold. This does not establish complete asynchronous settlement, setup-failure cleanup, a bound for the xAI nonqueued wait, hosted CI, or landing. No elapsed-time speedup is claimed.

The selected completed-only tool assertion is unchanged but is not reached under this fault; the normal passing run supplies that behavior proof.

```sh
node scripts/run-vitest.mjs extensions/openai/realtime-voice-terminal-outcomes.test.ts
node scripts/run-vitest.mjs extensions/xai/realtime-voice-terminal-outcomes.test.ts
node scripts/run-vitest.mjs extensions/openai/realtime-voice-terminal-outcomes.test.ts extensions/openai/realtime-voice-bridge-events.test.ts
```

Named follow-ups remain: setup precedes the fixture try/finally, and the xAI ordinary nonqueued completion wait remains unbounded. This change does not repair or prove setup-failure cleanup, and an outer test timeout must not be treated as proof that the unbounded path enters cleanup.
