### PR TITLE
fix(auth): recover interrupted shared credential migrations

### DIFF
--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -1284,7 +1284,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         ? hasAuthProfileState(coerceAuthProfileState(canonicalStore))
         : false;
       for (const receipt of sourceReceipts) {
-        if (receipt.targetTable === "auth_profile_store") {
+        if (receipt.targetTable !== "auth_profile_state") {
           receipt.expectedProfileSha256 = expectedProfileSha256;
         }
         if (

--- a/src/commands/doctor-auth-shared-receipt.test.ts
+++ b/src/commands/doctor-auth-shared-receipt.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import { afterEach, expect, it, vi } from "vitest";
+import { loadPersistedSharedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
+import { deletePersistedAuthProfileStoreRaw } from "../agents/auth-profiles/sqlite.js";
+import { writeConfigMachineState } from "../state/config-machine-state.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { maybeMigrateAuthProfileJsonStoresToSqlite } from "./doctor-auth-flat-profiles.js";
+
+let state: OpenClawTestState;
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  await state?.cleanup();
+});
+
+it.each([
+  ["legacy-main", "auth-profiles.json"],
+  ["legacy-main", "auth.json"],
+  ["state-db", "auth-profiles.json"],
+  ["state-db", "auth.json"],
+] as const)("recovers %s credentials after interrupted %s archival", async (location, filename) => {
+  state = await createOpenClawTestState({ layout: "state-only" });
+  if (location === "state-db") {
+    writeConfigMachineState("auth.sharedStore", { location }, { env: state.env });
+  }
+  const credential = { type: "api_key", provider: "openai", key: "synthetic-migration-key" };
+  const source = await state.writeJson(
+    `agents/main/agent/${filename}`,
+    filename === "auth-profiles.json"
+      ? { version: 1, profiles: { "openai:default": credential } }
+      : { openai: credential },
+  );
+  const sourceBytes = fs.readFileSync(source);
+  const migrate = () =>
+    maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      prompter: { confirmAutoFix: async () => true },
+      env: state.env,
+    });
+  const rename = fs.renameSync;
+  const interruptedRename = vi.spyOn(fs, "renameSync").mockImplementation((from, to) => {
+    rename(from, to);
+    if (String(from) === source) {
+      throw new Error("simulated interruption after archive rename");
+    }
+  });
+  const interrupted = await migrate();
+  interruptedRename.mockRestore();
+  expect(interrupted.warnings).toEqual([
+    expect.stringContaining("simulated interruption after archive rename"),
+  ]);
+  expect(fs.existsSync(source)).toBe(false);
+  const db = openOpenClawStateDatabase({ env: state.env }).db;
+  expect(
+    db.prepare("SELECT status FROM migration_sources WHERE source_path = ?").get(source),
+  ).toEqual({ status: "imported" });
+
+  // Model a lost destination after the import commit but before terminal completion.
+  deletePersistedAuthProfileStoreRaw(location === "legacy-main" ? state.agentDir() : undefined);
+  expect(loadPersistedSharedAuthProfileStore(state.env)?.profiles ?? {}).toEqual({});
+  const repaired = await migrate();
+
+  expect(repaired.warnings).toEqual([]);
+  expect(loadPersistedSharedAuthProfileStore(state.env)?.profiles).toEqual({
+    "openai:default": credential,
+  });
+  expect(repaired.changes).toContain("Reset an interrupted auth migration receipt for retry.");
+  const receipt = db
+    .prepare("SELECT status, report_json FROM migration_sources WHERE source_path = ?")
+    .get(source) as { status: string; report_json: string };
+  expect(receipt.status).toBe("completed");
+  expect(fs.readFileSync(JSON.parse(receipt.report_json).archivePath)).toEqual(sourceBytes);
+  expect((await migrate()).changes).toEqual([]);
+});


### PR DESCRIPTION
Related: #134608 — credential migration deadlock reported by @erameson. This PR addresses the shared-receipt verification hole; the issue remains open for completed-receipt recovery policy.

## What Problem This Solves

Fixes an issue where operators retrying an interrupted shared credential migration could receive a completed migration receipt even though the canonical credential store was empty. Doctor could archive the legacy source without restoring the missing credentials.

## Why This Change Was Made

Shared credential receipts use `auth_profile_stores`, but the producer only attached expected credential fingerprints to singular `auth_profile_store` receipts. The existing verifier skips credential checks without those fingerprints. Both credential destinations now receive them, so the existing verification, verified-archive recovery, retry, and completion flow handles the interruption correctly. State-only receipts retain their existing state verification.

**Scope boundary:** recovery of already-corrupted **completed** receipts remains **NEEDS-MAINTAINER-DECISION**. This PR does not replay completed receipts or repair historical receipts that lack fingerprints. It preserves the existing boundary against resurrecting deleted credentials. The original report's damaged artifacts were lost during rollback, so this reproducible producer defect is not claimed to explain every observation in that incident.

## User Impact

New shared credential imports verify their destination before completion. If archival is interrupted and the destination is subsequently lost, another `doctor --fix` restores the verified archived credentials instead of finalizing an empty store. Repeated repair remains idempotent. This restores the documented [Doctor migration contract](https://docs.openclaw.ai/cli/doctor).

Production LOC: **+1/-1, net 0**. Tests: **+84/-0**. No new configuration, environment, schema, protocol, dependency, or public API surface. Thanks @erameson for the report and follow-up evidence.

## Evidence

The four-case regression uses the real migration producer, interrupts after the real archive rename, removes the canonical destination, and retries. It covers `auth-profiles.json` and `auth.json` against both legacy-main and shared-state destinations. Before the fix: **2 shared-state cases failed** on missing canonical profiles; **2 legacy-main cases passed**. After the fix: **90 focused tests passed**; the rebased-head rerun is recorded below.

```sh
node scripts/run-vitest.mjs src/commands/doctor-auth-shared-receipt.test.ts src/commands/doctor-auth-migration-receipts.test.ts src/commands/doctor-auth-flat-profiles.test.ts src/commands/doctor-auth-migration-inherited-oauth.test.ts src/infra/state-migrations.shared-auth-store.test.ts
```

Rebased head `df4920a05f16c68b7649d9880fd6502104f4736d`: **90 tests passed across five files**, both Vitest shards exited 0. This includes all four new regression cases.

The full changed-file check passed for this exact patch before the mechanical rebase:

```sh
node scripts/check-changed.mjs -- src/commands/doctor-auth-flat-profiles.ts src/commands/doctor-auth-shared-receipt.test.ts
```

`git range-diff` confirms the patch is unchanged; the migration producer, receipt verifier, auth storage owners, and relocation owner were unchanged in the rebase. Independent Codex review: branch review passed with no accepted/actionable findings.

<details>
<summary>Real CLI fault-injection proof</summary>

Built from `61404b6c2a91871b2a4f5819ca98b06a90077796` plus this exact patch. A disposable fixture used a fake home, scrubbed child environment, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, and the existing external service-repair policy. No operator state or managed gateway was used. All credentials were synthetic; no credential values were printed.

The fixture selected the existing shared state-DB owner and wrote a legacy `agents/main/agent/auth-profiles.json`. A Node preloader called the real `fs.renameSync` and exited 86 immediately after the source was archived, before receipt completion. The fixture then deleted only its own canonical `authProfiles.store` row to model destination loss.

The CLI lines below are child commands under that isolated environment:

```text
$ node openclaw.mjs doctor --fix --non-interactive --no-workspace-suggestions
bootstrap exit: 0

$ node --import /tmp/codex-auth-mig-fault.mjs openclaw.mjs doctor --fix --non-interactive --no-workspace-suggestions
interrupted exit: 86
receipt: status=imported, removed_source=0
legacy source: archived
fixture canonical destination: removed

$ node openclaw.mjs doctor --fix --non-interactive --no-workspace-suggestions
recovery exit: 0
canonical profile ids: ["openai:default"]
receipt: status=completed, removed_source=1

$ node openclaw.mjs doctor --fix --non-interactive --no-workspace-suggestions
repeat exit: 0

$ node openclaw.mjs models auth list --provider openai --json
exit: 0
recovered profile: openai:default, type=api_key
AUTH_ARCHIVE_RECOVERY_PASS
```

Build limitation: the initial full `pnpm build` compiled runtime/plugins but hit the unchanged 120-second native-require probe timeout. A focused `node scripts/runtime-postbuild.mjs` retry passed all 50 control-plane modules and all 12 postbuild phases. The live CLI then completed the proof above. No timeout or gate was weakened; exact-head CI is required before landing.

</details>
