### PR TITLE
perf: reduce memory spikes when reading HTTP response bodies

### DIFF
--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -230,10 +230,7 @@ async function readResponsePrefixFromReader(
   }
 
   return {
-    buffer: Buffer.concat(
-      chunks.map((chunk) => Buffer.from(chunk)),
-      total,
-    ),
+    buffer: Buffer.concat(chunks, total),
     size,
     truncated,
   };


### PR DESCRIPTION
## What Problem This Solves

Downloading a bounded HTTP response temporarily allocated an unnecessary second copy of its entire body. Large media and provider responses therefore caused avoidable memory spikes.

## Why This Change Was Made

Pass the collected `Uint8Array` chunks directly to `Buffer.concat`. Node already accepts these inputs and returns an independently owned Buffer; converting every chunk to a Buffer first only duplicated the copy. The shared response reader remains the single owner of limits, overflow reporting, cancellation, and deadlines.

## User Impact

Response assembly avoids one full-body temporary allocation. A 32 MiB response now avoids 32 MiB of intermediate copied bytes. Returned bytes and existing limits remain identical. Production LOC: +1/-4 (net -3); tests unchanged.

## Evidence

- Existing HTTP request/response suites: 46 tests passed, including byte limits, multi-chunk content, UTF-8 prefixes, cancellation, and idle/overall deadlines (`node scripts/run-vitest.mjs src/infra/http-body.response.test.ts src/infra/http-body.test.ts`).
- Actual `readResponseWithLimit` allocation probe with 512 x 64 KiB chunks: intermediate copied bytes 33,554,432 -> 0; ArrayBuffer delta after the read 67,111,808 -> 33,557,376 bytes. Output content and independent byte ownership both passed. These are isolated owner measurements, not a whole-gateway memory claim.
- Real HTTPS download through the changed reader: Node.js Buffer documentation, HTTP 200, 1,151,240 bytes, byte-for-byte equal to the native response body.
- `node scripts/check-changed.mjs -- src/infra/http-body.ts` passed, including core and core-test typechecks, lint, architecture and lifecycle guards.
- Independent source/dependency review and fresh Codex autoreview found no actionable issues. Node's documented `Buffer.concat` contract accepts `Uint8Array[]`; supported since Node 8, below OpenClaw's runtime floor.
