### PR TITLE
fix(workshop): quarantine no longer blocks authoring

### DIFF
--- a/docs/tools/self-learning.md
+++ b/docs/tools/self-learning.md
@@ -293,7 +293,7 @@ result pending regardless of autonomous mode.
 | ------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `skills.workshop.autonomous.mode`          | `"auto"` | Chooses capture behavior; `auto` also enables weekly collection review.                                                  |
 | `skills.workshop.approvalPolicy`           | `"auto"` | Controls prompts for normal agent-initiated lifecycle calls. It never expands the isolated reviewer tool surface.        |
-| `skills.workshop.maxPending`               | `50`     | Caps pending and quarantined proposals per workspace.                                                                    |
+| `skills.workshop.maxPending`               | `50`     | Caps pending proposals per workspace; quarantined proposals remain inspectable without blocking authoring.               |
 | `skills.workshop.maxSkillBytes`            | `40000`  | Caps proposal body size in bytes.                                                                                        |
 | `skills.workshop.allowSymlinkTargetWrites` | `false`  | Allows apply through explicitly trusted workspace skill symlinks. Capture itself does not widen the trusted target list. |
 

--- a/docs/tools/self-learning.md
+++ b/docs/tools/self-learning.md
@@ -297,6 +297,10 @@ result pending regardless of autonomous mode.
 | `skills.workshop.maxSkillBytes`            | `40000`  | Caps proposal body size in bytes.                                                                                        |
 | `skills.workshop.allowSymlinkTargetWrites` | `false`  | Allows apply through explicitly trusted workspace skill symlinks. Capture itself does not widen the trusted target list. |
 
+Changes under `skills.workshop` other than `autonomous.mode` require a Gateway
+restart. The config CLI says so explicitly; use `openclaw gateway restart --safe`
+when automatic reload is disabled.
+
 See [Skills config](/tools/skills-config#workshop-skills-workshop) for ranges and
 the complete `skills.*` schema.
 

--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -2,7 +2,7 @@
 summary: "Create and update workspace skills through Skill Workshop review"
 read_when:
   - You want the agent to create or update a skill from chat
-  - You need to review, apply, reject, or quarantine a generated skill draft
+  - You need to review, apply, reject, quarantine, or archive a generated skill draft
   - You are configuring Skill Workshop approval, autonomy, storage, or limits
   - You want to understand where self-learning proposals are reviewed
 title: "Skill Workshop"
@@ -50,10 +50,14 @@ evaluate      -> pending
 apply         -> applied
 reject        -> rejected
 quarantine    -> quarantined
+archive       -> stale (evidence retained)
 target change -> stale
 ```
 
 Only a `pending` proposal can be revised, applied, rejected, or quarantined.
+Only a `quarantined` proposal can be archived. Archive is a retained terminal
+transition: the record, event history, `PROPOSAL.md`, and support files remain
+available to `list` and `inspect`; no proposal evidence is deleted.
 
 ## Collection review
 
@@ -161,7 +165,7 @@ Revise it to also flag anything marked urgent.
 Apply the morning-catchup proposal.
 ```
 
-Agent-initiated `apply`, `reject`, and `quarantine` run without an additional
+Agent-initiated `apply`, `reject`, `quarantine`, and `archive` run without an additional
 approval prompt by default. Set `skills.workshop.approvalPolicy` to `"pending"`
 to require operator approval before those actions.
 
@@ -169,8 +173,8 @@ When approval is required, the prompt identifies the proposal id and target
 skill, and shows the proposal description, support-file count, and body size.
 Approval requests are bounded to finish before the agent tool watchdog. If no
 decision arrives before the prompt expires, the lifecycle action does not run:
-the proposal stays pending and unchanged. Decide later in the Skill Workshop UI or run
-`openclaw skills workshop apply|reject|quarantine <proposal-id>`. Agents should
+the proposal stays unchanged. Decide later in the Skill Workshop UI or run
+`openclaw skills workshop apply|reject|quarantine|archive <proposal-id>`. Agents should
 not retry an expired lifecycle action in a loop.
 
 ## CLI
@@ -199,6 +203,7 @@ openclaw skills workshop evaluate <proposal-id>
 openclaw skills workshop apply <proposal-id>
 openclaw skills workshop reject <proposal-id> --reason "Duplicate"
 openclaw skills workshop quarantine <proposal-id> --reason "Needs security review"
+openclaw skills workshop archive <proposal-id> --reason "Superseded; evidence retained"
 ```
 
 Every subcommand takes `--agent <id>` (target workspace; defaults to
@@ -278,25 +283,25 @@ and paths outside the standard support folders.
 ## Agent tool
 
 The model uses `skill_workshop` with one required `action`:
-`create | read | prepare_patch | patch | update | revise | list | inspect | evaluate | apply | reject | quarantine | history | restore_collection`.
+`create | read | prepare_patch | patch | update | revise | list | inspect | evaluate | apply | reject | quarantine | archive | history | restore_collection`.
 Other parameters apply depending on the action:
 
-| Parameter                  | Used by                                                          | Notes                                                                 |
-| -------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `name`                     | `create`, `inspect`, `revise`                                    | Required for `create`; resolves a pending proposal by name otherwise  |
-| `description`              | `create`, `update`, `revise`                                     | Max 160 bytes                                                         |
-| `skill_name`               | `read`, `prepare_patch`, `patch`, `update`                       | Existing skill name or key                                            |
-| `old_string`               | `prepare_patch`, `patch`                                         | Exact current text; prepare it when the complete skill cannot be read |
-| `new_string`               | `patch`                                                          | Replacement for the exact current text                                |
-| `proposal_content`         | `create`, `update`, `revise`                                     | Required for create/update; omit on revise to preserve the body       |
-| `support_files`            | `create`, `update`, `revise`                                     | Array of `{ path, content }`                                          |
-| `goal`, `evidence`         | `create`, `update`, `revise`                                     | Free-text context                                                     |
-| `proposal_id`              | `inspect`, `revise`, `evaluate`, `apply`, `reject`, `quarantine` | Target proposal                                                       |
-| `artifact_path`            | `inspect`                                                        | `PROPOSAL.md` or one listed support-file path                         |
-| `expected_revision_hash`   | `evaluate`, `apply`, `reject`, `quarantine`                      | Rejects a stale orchestration step                                    |
-| `correlation_id`           | `evaluate`, `revise`, `apply`, `reject`, `quarantine`            | External run or experiment correlation                                |
-| `reason`                   | `apply`, `reject`, `quarantine`                                  | Optional                                                              |
-| `query`, `status`, `limit` | `list`                                                           | Filter/paginate; `limit` max 50, default 20                           |
+| Parameter                  | Used by                                                                     | Notes                                                                 |
+| -------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `name`                     | `create`, `inspect`, `revise`                                               | Required for `create`; resolves a pending proposal by name otherwise  |
+| `description`              | `create`, `update`, `revise`                                                | Max 160 bytes                                                         |
+| `skill_name`               | `read`, `prepare_patch`, `patch`, `update`                                  | Existing skill name or key                                            |
+| `old_string`               | `prepare_patch`, `patch`                                                    | Exact current text; prepare it when the complete skill cannot be read |
+| `new_string`               | `patch`                                                                     | Replacement for the exact current text                                |
+| `proposal_content`         | `create`, `update`, `revise`                                                | Required for create/update; omit on revise to preserve the body       |
+| `support_files`            | `create`, `update`, `revise`                                                | Array of `{ path, content }`                                          |
+| `goal`, `evidence`         | `create`, `update`, `revise`                                                | Free-text context                                                     |
+| `proposal_id`              | `inspect`, `revise`, `evaluate`, `apply`, `reject`, `quarantine`, `archive` | Target proposal                                                       |
+| `artifact_path`            | `inspect`                                                                   | `PROPOSAL.md` or one listed support-file path                         |
+| `expected_revision_hash`   | `evaluate`, `apply`, `reject`, `quarantine`, `archive`                      | Rejects a stale orchestration step                                    |
+| `correlation_id`           | `evaluate`, `revise`, `apply`, `reject`, `quarantine`, `archive`            | External run or experiment correlation                                |
+| `reason`                   | `apply`, `reject`, `quarantine`, `archive`                                  | Optional                                                              |
+| `query`, `status`, `limit` | `list`                                                                      | Filter/paginate; `limit` max 50, default 20                           |
 
 Only one prepared patch span may be active per skill. A second
 `prepare_patch` is rejected until a `patch` attempt consumes or invalidates the
@@ -391,7 +396,7 @@ the proposal threshold, and troubleshooting.
 | -------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `autonomous.mode`          | `"auto"` | `"off"` disables autonomous capture, `"propose"` creates pending captures, and `"auto"` applies captures and runs weekly cleanup that can rewrite or drop Workshop-owned skills. |
 | `allowSymlinkTargetWrites` | `false`  | Lets apply write through workspace skill symlinks whose real target is listed in `skills.load.allowSymlinkTargets`.                                                              |
-| `approvalPolicy`           | `"auto"` | `"auto"` skips an additional prompt for agent-initiated `apply`, `reject`, or `quarantine` (the agent still has to call the action). `"pending"` requires approval.              |
+| `approvalPolicy`           | `"auto"` | `"auto"` skips an additional prompt for agent-initiated `apply`, `reject`, `quarantine`, or `archive` (the agent still has to call the action). `"pending"` requires approval.   |
 | `maxPending`               | `50`     | Caps pending proposals per workspace (1-200). Quarantined proposals remain available for triage without blocking authoring.                                                      |
 | `maxSkillBytes`            | `40000`  | Caps manual and foreground proposal body size in bytes (1024-200000). Autonomous results have a 10,000-character cap.                                                            |
 
@@ -513,6 +518,7 @@ proposals remain listed with a previous-workspace marker instead of disappearing
 | `Support file paths must be under one of...`   | Move support files under `assets/`, `examples/`, `references/`, `scripts/`, or `templates/`.                                                                                                                |
 | Proposal does not show in list                 | Check the selected `--agent` workspace and `OPENCLAW_STATE_DIR`.                                                                                                                                            |
 | `pending proposal limit reached`               | Run `openclaw skills workshop list`, then apply, reject, or quarantine one pending proposal. Quarantined proposals do not consume the pending limit.                                                        |
+| Quarantined proposal is obsolete               | Run `openclaw skills workshop archive <proposal-id> --reason "..."`. The proposal becomes retained `stale` evidence and remains inspectable.                                                                |
 | Agent cannot call `skill_workshop`             | Check the active tool policy and run mode. `coding` includes the tool; restrictive `tools.allow` policies must list it explicitly, and sandboxed runs must use a normal host-side agent session or the CLI. |
 
 ### Tool-policy diagnostic

--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -392,7 +392,7 @@ the proposal threshold, and troubleshooting.
 | `autonomous.mode`          | `"auto"` | `"off"` disables autonomous capture, `"propose"` creates pending captures, and `"auto"` applies captures and runs weekly cleanup that can rewrite or drop Workshop-owned skills. |
 | `allowSymlinkTargetWrites` | `false`  | Lets apply write through workspace skill symlinks whose real target is listed in `skills.load.allowSymlinkTargets`.                                                              |
 | `approvalPolicy`           | `"auto"` | `"auto"` skips an additional prompt for agent-initiated `apply`, `reject`, or `quarantine` (the agent still has to call the action). `"pending"` requires approval.              |
-| `maxPending`               | `50`     | Caps pending and quarantined proposals per workspace (1-200).                                                                                                                    |
+| `maxPending`               | `50`     | Caps pending proposals per workspace (1-200). Quarantined proposals remain available for triage without blocking authoring.                                                      |
 | `maxSkillBytes`            | `40000`  | Caps manual and foreground proposal body size in bytes (1024-200000). Autonomous results have a 10,000-character cap.                                                            |
 
 In `propose` and `auto` modes, an isolated run of the selected model decides whether the
@@ -492,14 +492,14 @@ proposals remain listed with a previous-workspace marker instead of disappearing
 
 ## Limits
 
-| Limit                           | Value                                                                        |
-| ------------------------------- | ---------------------------------------------------------------------------- |
-| Description                     | 160 bytes                                                                    |
-| Proposal body                   | `skills.workshop.maxSkillBytes` (default 40,000; hard ceiling 200,000 bytes) |
-| Autonomous `SKILL.md`           | 10,000 characters, or strictly shorter when already over the cap             |
-| Support files                   | 64 per proposal                                                              |
-| Support file size               | 256 KiB each, 2 MiB total                                                    |
-| Pending + quarantined proposals | `skills.workshop.maxPending` per workspace (default 50)                      |
+| Limit                 | Value                                                                        |
+| --------------------- | ---------------------------------------------------------------------------- |
+| Description           | 160 bytes                                                                    |
+| Proposal body         | `skills.workshop.maxSkillBytes` (default 40,000; hard ceiling 200,000 bytes) |
+| Autonomous `SKILL.md` | 10,000 characters, or strictly shorter when already over the cap             |
+| Support files         | 64 per proposal                                                              |
+| Support file size     | 256 KiB each, 2 MiB total                                                    |
+| Pending proposals     | `skills.workshop.maxPending` per workspace (default 50)                      |
 
 ## Troubleshooting
 
@@ -512,6 +512,7 @@ proposals remain listed with a previous-workspace marker instead of disappearing
 | `untrusted symlink target`                     | Configure `skills.load.allowSymlinkTargets` and enable `skills.workshop.allowSymlinkTargetWrites` only for intentional shared skill roots.                                                                  |
 | `Support file paths must be under one of...`   | Move support files under `assets/`, `examples/`, `references/`, `scripts/`, or `templates/`.                                                                                                                |
 | Proposal does not show in list                 | Check the selected `--agent` workspace and `OPENCLAW_STATE_DIR`.                                                                                                                                            |
+| `pending proposal limit reached`               | Run `openclaw skills workshop list`, then apply, reject, or quarantine one pending proposal. Quarantined proposals do not consume the pending limit.                                                        |
 | Agent cannot call `skill_workshop`             | Check the active tool policy and run mode. `coding` includes the tool; restrictive `tools.allow` policies must list it explicitly, and sandboxed runs must use a normal host-side agent session or the CLI. |
 
 ### Tool-policy diagnostic

--- a/docs/tools/skills-config.md
+++ b/docs/tools/skills-config.md
@@ -374,7 +374,7 @@ See [Self-learning](/tools/self-learning) for eligibility, privacy, cost,
 proposal-only permissions, and troubleshooting.
 
 <ParamField path="skills.workshop.approvalPolicy" type='"pending" | "auto"' default='"auto"'>
-  `auto` allows agent-initiated apply, reject, or quarantine without an
+  `auto` allows agent-initiated apply, reject, quarantine, or archive without an
   additional approval prompt. `pending` requires operator approval.
 </ParamField>
 
@@ -390,6 +390,14 @@ proposal-only permissions, and troubleshooting.
   Quarantined proposals remain inspectable but do not consume this authoring
   budget.
 </ParamField>
+
+Except for `skills.workshop.autonomous.mode`, Workshop configuration is captured
+when Gateway runs are constructed. Supported config writes therefore report
+`Restart the gateway to apply`; they never claim the file-only value is live.
+With automatic reload disabled, run `openclaw gateway restart --safe`. Compare
+`configRevisionHash` and `appliedConfigHash` from
+`openclaw gateway call config.get --params '{}' --json`: equality confirms the
+running Gateway has applied the authored revision.
 
 <ParamField path="skills.workshop.maxSkillBytes" type="number" default="40000">
   Maximum proposal body size in bytes (allowed range: 1024-200000). Proposal

--- a/docs/tools/skills-config.md
+++ b/docs/tools/skills-config.md
@@ -386,8 +386,9 @@ proposal-only permissions, and troubleshooting.
 </ParamField>
 
 <ParamField path="skills.workshop.maxPending" type="number" default="50">
-  Maximum pending and quarantined proposals retained per workspace (allowed
-  range: 1-200).
+  Maximum pending proposals retained per workspace (allowed range: 1-200).
+  Quarantined proposals remain inspectable but do not consume this authoring
+  budget.
 </ParamField>
 
 <ParamField path="skills.workshop.maxSkillBytes" type="number" default="40000">

--- a/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
+++ b/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
@@ -769,7 +769,7 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
       kind: "veto",
       deniedReason: "plugin-approval",
       reason:
-        "The Skill Workshop approval request expired without a decision. This lifecycle call left the proposal unchanged and pending; check its current status in case another operator acted on it. Decide in the Skill Workshop UI or run `openclaw skills workshop apply|reject|quarantine <id>`. Do not retry this tool call in a loop.",
+        "The Skill Workshop approval request expired without a decision. This lifecycle call left the proposal unchanged and pending; check its current status in case another operator acted on it. Decide in the Skill Workshop UI or run `openclaw skills workshop apply|reject|quarantine|archive <id>`. Do not retry this tool call in a loop.",
     });
   });
 

--- a/src/agents/tools/skill-workshop-tool-helpers.ts
+++ b/src/agents/tools/skill-workshop-tool-helpers.ts
@@ -5,6 +5,7 @@ import {
 } from "../../skills/workshop/frontmatter.js";
 import { prepareSkillProposalDraft } from "../../skills/workshop/proposal-draft.js";
 import {
+  archiveSkillProposal,
   inspectSkillProposal,
   resolvePendingSkillProposal,
 } from "../../skills/workshop/service.js";
@@ -46,6 +47,27 @@ export function assertAutonomousSkillSize(
 
 export function skillWorkshopAgentEventActor(agentId?: string) {
   return { type: "agent" as const, ...(agentId ? { id: agentId } : {}) };
+}
+
+export async function executeSkillWorkshopArchive(params: {
+  workspaceDir: string;
+  agentId?: string;
+  env?: NodeJS.ProcessEnv;
+  toolParams: Record<string, unknown>;
+}) {
+  const archived = await archiveSkillProposal({
+    workspaceDir: params.workspaceDir,
+    agentId: params.agentId,
+    eventActor: skillWorkshopAgentEventActor(params.agentId),
+    env: params.env,
+    proposalId: readLifecycleProposalIdParam(params.toolParams),
+    expectedRevisionHash: readToolStringParam(params.toolParams, "expected_revision_hash"),
+    correlationId: readToolStringParam(params.toolParams, "correlation_id"),
+    reason: readToolStringParam(params.toolParams, "reason"),
+  });
+  return actionResult(archived, {
+    contentText: `Archived skill proposal ${archived.id}; evidence retained.`,
+  });
 }
 
 export function proposalReviewPhase(

--- a/src/agents/tools/skill-workshop-tool-schema.ts
+++ b/src/agents/tools/skill-workshop-tool-schema.ts
@@ -21,6 +21,7 @@ export const SKILL_WORKSHOP_ACTIONS = [
   "apply",
   "reject",
   "quarantine",
+  "archive",
   "history",
   "restore_collection",
   "complete",
@@ -59,13 +60,13 @@ export function buildSkillWorkshopToolSchema(collectionOnly: boolean, proposalRe
             ? "inspect = read the exact operator-reviewed proposal; revise = update only that proposal with the run-bound expected revision hash."
             : collectionOnly
               ? SKILL_COLLECTION_ACTION_DESCRIPTION
-              : "create = new skill; read = existing live skill when complete content fits; prepare_patch = authorize one exact non-empty span and return bounded context, with only one prepared span active per skill; patch = targeted find-and-replace after read or prepare_patch; update = full-body rewrite; history = show up to 20 recent collection review outcomes and drop reasons; restore_collection = restore the collection backup retained by the last cleanup; revise = existing pending proposal; list/inspect discover pending proposals (not filesystem search); evaluate runs plugin evaluators for the exact draft; apply/reject/quarantine are explicit lifecycle actions; complete = finish an internal review when available.",
+              : "create = new skill; read = existing live skill when complete content fits; prepare_patch = authorize one exact non-empty span and return bounded context, with only one prepared span active per skill; patch = targeted find-and-replace after read or prepare_patch; update = full-body rewrite; history = show up to 20 recent collection review outcomes and drop reasons; restore_collection = restore the collection backup retained by the last cleanup; revise = existing pending proposal; list/inspect discover proposals (not filesystem search); evaluate runs plugin evaluators for the exact draft; apply/reject/quarantine/archive are explicit lifecycle actions; archive retains quarantined evidence in the stale terminal state; complete = finish an internal review when available.",
         },
       ),
       proposal_id: Type.Optional(
         Type.String({
           description:
-            "Existing proposal id for action=inspect, action=revise, action=evaluate, action=apply, action=reject, or action=quarantine.",
+            "Existing proposal id for action=inspect, action=revise, action=evaluate, action=apply, action=reject, action=quarantine, or action=archive.",
         }),
       ),
       artifact_path: Type.Optional(
@@ -142,13 +143,14 @@ export function buildSkillWorkshopToolSchema(collectionOnly: boolean, proposalRe
       evidence: Type.Optional(Type.String({ description: "Short evidence or notes." })),
       reason: Type.Optional(
         Type.String({
-          description: "Optional reason for action=apply, action=reject, or action=quarantine.",
+          description:
+            "Optional reason for action=apply, action=reject, action=quarantine, or action=archive.",
         }),
       ),
       expected_revision_hash: Type.Optional(
         Type.String({
           description:
-            "Optional exact recorded proposal revision hash for revise/evaluate/apply/reject/quarantine. The action fails if the stored proposal record changed. Revise, evaluate, and apply verify proposal artifacts. Reject and quarantine run interrupted-apply recovery first, then use only the stored record.",
+            "Optional exact recorded proposal revision hash for revise/evaluate/apply/reject/quarantine/archive. The action fails if the stored proposal record changed. Revise, evaluate, and apply verify proposal artifacts. Reject and quarantine run interrupted-apply recovery first, then use only the stored record. Archive uses only the stored quarantined record after lifecycle reconciliation.",
         }),
       ),
       correlation_id: Type.Optional(

--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -398,6 +398,7 @@ describe("skill_workshop tool", () => {
       "apply",
       "reject",
       "quarantine",
+      "archive",
       "history",
       "restore_collection",
       "complete",
@@ -887,6 +888,23 @@ describe("skill_workshop tool", () => {
       skillKey: "quarantined-skill",
       scanState: "quarantined",
     });
+    const archiveResult = await tool.execute("call-7", {
+      action: "archive",
+      proposal_id: quarantinedId,
+      reason: "superseded; evidence retained",
+    });
+    expect((archiveResult.content[0] as { text: string }).text).toContain(
+      `Archived skill proposal ${quarantinedId}; evidence retained.`,
+    );
+    expect(archiveResult.details).toMatchObject({
+      id: quarantinedId,
+      status: "stale",
+      kind: "create",
+      skillKey: "quarantined-skill",
+    });
+    await expect(
+      tool.execute("call-8", { action: "inspect", proposal_id: quarantinedId }),
+    ).resolves.toMatchObject({ details: { id: quarantinedId, status: "stale" } });
     await expect(
       fs.access(path.join(workspaceDir, "skills", "quarantined-skill", "SKILL.md")),
     ).rejects.toThrow();

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -54,6 +54,7 @@ import {
   assertAutonomousSkillSize,
   beginProposalReviewMutation,
   completeProposalReview,
+  executeSkillWorkshopArchive,
   proposalMutationText,
   proposalResult,
   proposalReviewPhase,
@@ -444,6 +445,15 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
         });
         return actionResult(quarantined, {
           contentText: `Quarantined skill proposal ${quarantined.id}.`,
+        });
+      }
+
+      if (action === "archive") {
+        return await executeSkillWorkshopArchive({
+          workspaceDir: options.workspaceDir,
+          agentId: options.agentId,
+          env: options.env,
+          toolParams: params,
         });
       }
 

--- a/src/cli/config-cli.integration.test.ts
+++ b/src/cli/config-cli.integration.test.ts
@@ -222,6 +222,53 @@ describe("config cli integration", () => {
     );
   });
 
+  it("writes Workshop limits with an explicit Gateway restart requirement", async () => {
+    await withConfigFileHarness(
+      "openclaw-config-cli-workshop-restart-",
+      "{ skills: { workshop: { maxPending: 50 } } }\n",
+      async ({ configPath }) => {
+        const output = createTestRuntime();
+
+        await runConfigSet({
+          path: "skills.workshop.maxPending",
+          value: "51",
+          cliOptions: {},
+          runtime: output.runtime,
+        });
+
+        expect(JSON5.parse(fs.readFileSync(configPath, "utf8"))).toMatchObject({
+          skills: { workshop: { maxPending: 51 } },
+        });
+        expect(output.errors).toStrictEqual([]);
+        expect(output.logs).toStrictEqual([
+          "Updated skills.workshop.maxPending. Restart the gateway to apply.",
+        ]);
+      },
+    );
+  });
+
+  it.each([
+    ["skills.workshop.maxPending", "201"],
+    ["skills.workshop.maxSkillBytes", "1023"],
+    ["skills.workshop.maxSkillBytes", "200001"],
+  ])("rejects out-of-contract Workshop value %s=%s", async (configPath, value) => {
+    await withConfigFileHarness(
+      "openclaw-config-cli-workshop-bounds-",
+      "{ skills: { workshop: { maxPending: 50, maxSkillBytes: 40000 } } }\n",
+      async ({ configPath: filePath }) => {
+        const before = fs.readFileSync(filePath, "utf8");
+        const output = createTestRuntime();
+
+        await expect(
+          runConfigSet({ path: configPath, value, cliOptions: {}, runtime: output.runtime }),
+        ).rejects.toThrow("__exit__:1");
+
+        expect(fs.readFileSync(filePath, "utf8")).toBe(before);
+        expect(output.errors.join("\n")).toContain("Config validation failed");
+      },
+    );
+  });
+
   it("accepts plugin hook conversation-access policy via config set", async () => {
     await withConfigFileHarness(
       "openclaw-config-cli-plugin-hooks-",

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -48,6 +48,7 @@ import {
 } from "../skills/workshop/curator.js";
 import {
   applySkillProposal,
+  archiveSkillProposal,
   inspectSkillProposal,
   listSkillProposals,
   proposeCreateSkill,
@@ -1177,6 +1178,13 @@ export function registerSkillsCli(program: Command) {
       "Quarantined",
       quarantineSkillProposal,
     ],
+    [
+      "archive",
+      "Archive a quarantined skill proposal while retaining its evidence",
+      "Reason for archival or expiry",
+      "Archived",
+      archiveSkillProposal,
+    ],
   ] as const) {
     workshop
       .command(name)
@@ -1195,10 +1203,10 @@ export function registerSkillsCli(program: Command) {
             command,
             async ({ agentId, workspaceDir }) => {
               const reviewed =
-                name === "reject"
+                name === "reject" || name === "archive"
                   ? await inspectSkillProposal(proposalId, { agentId, workspaceDir })
                   : undefined;
-              if (name === "reject" && !reviewed) {
+              if ((name === "reject" || name === "archive") && !reviewed) {
                 throw new Error(`Skill proposal not found: ${proposalId}`);
               }
               return action({

--- a/src/cli/skills-cli.workshop.test.ts
+++ b/src/cli/skills-cli.workshop.test.ts
@@ -278,6 +278,46 @@ describe("skills workshop cli", () => {
     ).resolves.toContain("Use current conditions");
   });
 
+  it("archives a quarantined proposal while retaining CLI inspection", async () => {
+    const draftPath = path.join(mocks.workspaceDir, "archive-proposal.md");
+    await fs.writeFile(draftPath, "# Superseded Draft\n\nRetain this evidence.\n", "utf8");
+
+    await runCommand([
+      "skills",
+      "workshop",
+      "propose-create",
+      "--name",
+      "Superseded Draft",
+      "--description",
+      "Superseded proposal evidence",
+      "--proposal",
+      draftPath,
+    ]);
+    const proposalId = mocks.runtimeStdout.at(-1);
+    await runCommand([
+      "skills",
+      "workshop",
+      "quarantine",
+      proposalId!,
+      "--reason",
+      "newer revision is active",
+    ]);
+    await runCommand([
+      "skills",
+      "workshop",
+      "archive",
+      proposalId!,
+      "--reason",
+      "superseded; evidence retained",
+    ]);
+
+    expect(mocks.runtimeStdout.at(-1)).toBe(`Archived ${proposalId}`);
+    await runCommand(["skills", "workshop", "list"]);
+    expect(mocks.runtimeStdout.at(-1)).toContain(`${proposalId}  stale  create`);
+    await runCommand(["skills", "workshop", "inspect", proposalId!]);
+    expect(mocks.runtimeStdout.at(-1)).toContain("Retain this evidence.");
+  });
+
   it("lists and inspects an agent proposal after its workspace changes", async () => {
     const firstWorkspaceDir = mocks.workspaceDir;
     const draftPath = path.join(firstWorkspaceDir, "proposal-draft.md");

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -67,7 +67,7 @@ export type SkillsWorkshopConfig = {
   allowSymlinkTargetWrites?: boolean;
   /** Whether proposal lifecycle actions need explicit approval. */
   approvalPolicy?: "pending" | "auto";
-  /** Maximum pending/quarantined proposals retained per workspace. */
+  /** Maximum pending proposals retained per workspace. */
   maxPending?: number;
   /** Maximum generated skill proposal size in bytes. */
   maxSkillBytes?: number;

--- a/src/config/zod-schema.root-shape.ts
+++ b/src/config/zod-schema.root-shape.ts
@@ -475,8 +475,8 @@ export const OpenClawSchemaShape = {
             .optional(),
           approvalPolicy: z.union([z.literal("pending"), z.literal("auto")]).optional(),
           allowSymlinkTargetWrites: z.boolean().optional(),
-          maxPending: z.number().int().min(1).optional(),
-          maxSkillBytes: z.number().int().min(1).optional(),
+          maxPending: z.number().int().min(1).max(200).optional(),
+          maxSkillBytes: z.number().int().min(1024).max(200_000).optional(),
         })
         .optional(),
       entries: z.record(z.string(), SkillEntrySchema).optional(),

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -140,6 +140,10 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     kind: "hot",
     actions: ["reconcile-skill-review-jobs"],
   },
+  // Workshop tool instances capture these values when their run is constructed.
+  // Never claim a file-only Workshop edit is active in the running Gateway.
+  // The longer autonomous.mode rule above remains hot-reloadable.
+  { prefix: "skills.workshop", kind: "restart" },
   { prefix: "cron", kind: "hot", actions: ["restart-cron"] },
   // The dedicated Apps listener and origin are created once during Gateway
   // startup; disposing MCP runtimes cannot move or create that HTTP server.

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -475,6 +475,23 @@ describe("buildGatewayReloadPlan", () => {
   });
 
   it.each([
+    "skills.workshop.maxPending",
+    "skills.workshop.maxSkillBytes",
+    "skills.workshop.approvalPolicy",
+    "skills.workshop.allowSymlinkTargetWrites",
+  ])("requires a gateway restart when %s changes", (path) => {
+    const plan = buildGatewayReloadPlan([path]);
+
+    expect(plan).toMatchObject({
+      restartGateway: true,
+      restartReasons: [path],
+      hotReasons: [],
+      noopPaths: [],
+    });
+    expect(isNoopGatewayReloadPlan(plan)).toBe(false);
+  });
+
+  it.each([
     { path: "agents.entries", restartHeartbeat: true },
     { path: "agents.ownership", restartHeartbeat: false },
     { path: "agents.defaults.sessionStore", restartHeartbeat: false },

--- a/src/skills/workshop/policy.ts
+++ b/src/skills/workshop/policy.ts
@@ -20,13 +20,19 @@ const SKILL_WORKSHOP_LIFECYCLE_ACTIONS = new Set([
   "apply",
   "reject",
   "quarantine",
+  "archive",
   "restore_collection",
 ]);
 // Codex dynamic tools have a 90s watchdog. Approval RPCs reserve another 10s
 // for Gateway cleanup, leaving 10s for proposal lookup and tool-call overhead.
 const SKILL_WORKSHOP_APPROVAL_TIMEOUT_MS = 70_000;
 
-type SkillWorkshopLifecycleAction = "apply" | "reject" | "quarantine" | "restore_collection";
+type SkillWorkshopLifecycleAction =
+  | "apply"
+  | "reject"
+  | "quarantine"
+  | "archive"
+  | "restore_collection";
 
 // Lifecycle actions mutate proposals or live skills and therefore require approval checks.
 function readLifecycleAction(params: unknown): SkillWorkshopLifecycleAction | undefined {
@@ -62,6 +68,13 @@ function lifecycleApprovalText(action: SkillWorkshopLifecycleAction): {
       description:
         "Replace current workspace skills with the previous collection backup. Later skill changes may be removed.",
       severity: "warning",
+    };
+  }
+  if (action === "archive") {
+    return {
+      title: "Archive quarantined skill proposal",
+      description: "Archive a quarantined proposal while retaining its evidence.",
+      severity: "info",
     };
   }
   return {
@@ -164,10 +177,11 @@ function lifecycleApprovalTimeoutReason(params: {
     ].join(" ");
   }
   const proposal = params.proposalId ? `Proposal ${params.proposalId}` : "the proposal";
+  const unchangedState = params.action === "archive" ? "quarantined" : "pending";
   return [
     "The Skill Workshop approval request expired without a decision.",
-    `This lifecycle call left ${proposal} unchanged and pending; check its current status in case another operator acted on it.`,
-    "Decide in the Skill Workshop UI or run `openclaw skills workshop apply|reject|quarantine <id>`.",
+    `This lifecycle call left ${proposal} unchanged and ${unchangedState}; check its current status in case another operator acted on it.`,
+    "Decide in the Skill Workshop UI or run `openclaw skills workshop apply|reject|quarantine|archive <id>`.",
     "Do not retry this tool call in a loop.",
   ].join(" ");
 }

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -19,8 +19,10 @@ import { applyAutonomousSkillProposal } from "./autonomous-apply.js";
 import { renderProposalMarkdown, stripProposalFrontmatterForSkill } from "./frontmatter.js";
 import {
   applySkillProposal,
+  archiveSkillProposal,
   getSkillProposalRunProgress,
   inspectSkillProposal,
+  listSkillProposalEvents,
   listSkillProposals,
   proposeCreateSkill,
   proposeUpdateSkill,
@@ -1055,6 +1057,48 @@ describe("skill workshop proposals", () => {
         reason: "already applied",
       }),
     ).rejects.toThrow("Only pending proposals can be rejected");
+  });
+
+  it("archives a quarantined proposal as stale while retaining its evidence bundle", async () => {
+    const workspaceDir = await makeWorkspace();
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Archived Draft",
+      description: "Superseded quarantined proposal",
+      content: "# Archived draft\n",
+    });
+    await quarantineSkillProposal({
+      workspaceDir,
+      proposalId: proposal.record.id,
+      reason: "newer revision is active",
+    });
+
+    const archived = await archiveSkillProposal({
+      workspaceDir,
+      proposalId: proposal.record.id,
+      reason: "expired after 30 days",
+    });
+
+    expect(archived).toMatchObject({
+      status: "stale",
+      statusReason: "newer revision is active",
+    });
+    expect(archived.staleAt).toBeTruthy();
+    const inspected = await inspectSkillProposal(proposal.record.id);
+    expect(inspected?.record.status).toBe("stale");
+    expect(inspected?.content).toContain("Archived draft");
+    expect(
+      listSkillProposalEvents({ workspaceDir, proposalId: proposal.record.id }).events.at(-1),
+    ).toMatchObject({
+      type: "stale",
+      payload: {
+        archiveReason: "expired after 30 days",
+        quarantineReason: "newer revision is active",
+      },
+    });
+    await expect(
+      archiveSkillProposal({ workspaceDir, proposalId: proposal.record.id }),
+    ).rejects.toThrow("Only quarantined proposals can be archived");
   });
 
   it("reconciles a create apply interrupted after the live skill write", async () => {

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -1633,6 +1633,33 @@ describe("skill workshop proposals", () => {
     ).rejects.toThrow("proposal content is too large");
   });
 
+  it("does not let quarantined proposals consume the pending authoring budget", async () => {
+    const workspaceDir = await makeWorkspace();
+    const limitedConfig = { skills: { workshop: { maxPending: 1 } } };
+    const quarantined = await proposeCreateSkill({
+      workspaceDir,
+      config: limitedConfig,
+      name: "Quarantined Limited",
+      description: "Terminal quarantine must not block later authoring",
+      content: "# Quarantined Limited\n",
+    });
+    await quarantineSkillProposal({
+      workspaceDir,
+      proposalId: quarantined.record.id,
+      reason: "Needs separate operator review",
+    });
+
+    await expect(
+      proposeCreateSkill({
+        workspaceDir,
+        config: limitedConfig,
+        name: "Authoring Still Available",
+        description: "Create while quarantine is full",
+        content: "# Authoring Still Available\n",
+      }),
+    ).resolves.toMatchObject({ record: { status: "pending" } });
+  });
+
   it("bounds proposal descriptions before writing proposal state", async () => {
     const workspaceDir = await makeWorkspace();
     await expect(

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -28,6 +28,7 @@ import {
   normalizeProposalOrigin,
 } from "./service-propose.js";
 import { readRequiredProposal } from "./service-query.js";
+import { commitQuarantinedSkillProposalTransition } from "./store-sqlite-transition.js";
 import {
   hashSkillProposalContent,
   readSkillProposalRecord,
@@ -225,6 +226,91 @@ export async function quarantineSkillProposal(
   input: SkillProposalActionInput,
 ): Promise<SkillProposalRecord> {
   return await markProposal(input, "quarantined");
+}
+
+/**
+ * Move a quarantined proposal into the retained terminal state.
+ *
+ * The proposal record, event history, and evidence bundle stay in place. This
+ * is deliberately a lifecycle transition rather than a filesystem cleanup so
+ * operators can still list and inspect the archived evidence.
+ */
+export async function archiveSkillProposal(
+  input: SkillProposalActionInput,
+): Promise<SkillProposalRecord> {
+  const scope = {
+    ...(input.agentId ? { agentId: input.agentId } : {}),
+    workspaceDir: input.workspaceDir,
+  };
+  const initial = await readSkillProposalRecord(
+    input.proposalId,
+    proposalStoreOptions(input.env),
+    scope,
+    input.config ? { config: input.config } : undefined,
+  );
+  if (!initial) {
+    throw new Error(`Skill proposal not found: ${input.proposalId}`);
+  }
+  const result = await withSkillProposalTargetLock(
+    initial,
+    async () => {
+      const current = await readSkillProposalRecord(
+        input.proposalId,
+        proposalStoreOptions(input.env),
+        scope,
+        { reconcile: false },
+      );
+      if (!current) {
+        throw new Error(`Skill proposal not found: ${input.proposalId}`);
+      }
+      if (current.status !== "quarantined") {
+        throw new Error(
+          `Only quarantined proposals can be archived. Current status: ${current.status}.`,
+        );
+      }
+      assertExpectedRevisionHash(hashSkillProposalRevision(current), input.expectedRevisionHash);
+      const now = new Date().toISOString();
+      const archiveReason = normalizeOptionalString(input.reason);
+      const record: SkillProposalRecord = {
+        ...current,
+        status: "stale",
+        updatedAt: now,
+        staleAt: now,
+      };
+      const proposedEvent = createSkillProposalEvent({
+        record,
+        type: "stale",
+        actor: input.eventActor,
+        ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+        payload: {
+          archiveReason: archiveReason ?? "archived",
+          quarantineReason: current.statusReason ?? null,
+        },
+        occurredAt: now,
+      });
+      const commit = commitQuarantinedSkillProposalTransition({
+        expected: current,
+        record,
+        event: proposedEvent,
+        store: proposalStoreOptions(input.env),
+        operationLabel: "skill-workshop.proposal.archive",
+      });
+      if (commit.state === "conflict") {
+        throw new Error("Skill proposal changed before archive commit.");
+      }
+      return { record, event: commit.event };
+    },
+    proposalStoreOptions(input.env),
+  );
+  if (result.event) {
+    await dispatchSkillProposalChanged({
+      event: result.event,
+      record: result.record,
+      workspaceDir: input.workspaceDir,
+      ...(input.agentId ? { agentId: input.agentId } : {}),
+    });
+  }
+  return result.record;
 }
 
 export async function applySkillProposal(

--- a/src/skills/workshop/store-sqlite-transition.ts
+++ b/src/skills/workshop/store-sqlite-transition.ts
@@ -26,14 +26,19 @@ export type PendingSkillProposalTransitionCommit =
   | { state: "committed"; event: SkillProposalEvent }
   | { state: "conflict"; current?: SkillProposalRecord };
 
-export function commitPendingSkillProposalTransition(params: {
+type SkillProposalTransitionParams = {
   expected: SkillProposalRecord;
+  expectedStatus: "pending" | "quarantined";
   record: SkillProposalRecord;
   event: NewSkillProposalEvent;
   store?: SkillWorkshopStoreOptions;
   operationLabel: string;
   invalidateRollback?: boolean;
-}): PendingSkillProposalTransitionCommit {
+};
+
+function commitSkillProposalTransition(
+  params: SkillProposalTransitionParams,
+): PendingSkillProposalTransitionCommit {
   ensureSkillWorkshopSchema(params.store);
   return runOpenClawStateWriteTransaction(
     ({ db }) => {
@@ -49,7 +54,7 @@ export function commitPendingSkillProposalTransition(params: {
       if (
         !current ||
         !currentRecord ||
-        currentRecord.status !== "pending" ||
+        currentRecord.status !== params.expectedStatus ||
         current.record_json !== JSON.stringify(params.expected)
       ) {
         return {
@@ -74,6 +79,27 @@ export function commitPendingSkillProposalTransition(params: {
     databaseOptions(params.store),
     { operationLabel: params.operationLabel },
   );
+}
+
+export function commitPendingSkillProposalTransition(params: {
+  expected: SkillProposalRecord;
+  record: SkillProposalRecord;
+  event: NewSkillProposalEvent;
+  store?: SkillWorkshopStoreOptions;
+  operationLabel: string;
+  invalidateRollback?: boolean;
+}): PendingSkillProposalTransitionCommit {
+  return commitSkillProposalTransition({ ...params, expectedStatus: "pending" });
+}
+
+export function commitQuarantinedSkillProposalTransition(params: {
+  expected: SkillProposalRecord;
+  record: SkillProposalRecord;
+  event: NewSkillProposalEvent;
+  store?: SkillWorkshopStoreOptions;
+  operationLabel: string;
+}): PendingSkillProposalTransitionCommit {
+  return commitSkillProposalTransition({ ...params, expectedStatus: "quarantined" });
 }
 
 export function readCommittedSkillProposalTransition(params: {

--- a/src/skills/workshop/store.ts
+++ b/src/skills/workshop/store.ts
@@ -267,10 +267,18 @@ export async function writeSkillProposal(params: {
             .selectFrom("skill_workshop_proposals")
             .select((eb) => eb.fn.countAll<number>().as("count"))
             .where("workspace_dir", "=", path.resolve(params.workspaceDir))
-            .where("status", "in", ["pending", "quarantined"]),
+            .where("status", "=", "pending"),
         );
-        if ((count?.count ?? 0) >= params.maxPending) {
-          throw new Error(`Skill Workshop pending proposal limit reached (${params.maxPending}).`);
+        const pending = count?.count ?? 0;
+        if (pending >= params.maxPending) {
+          throw new Error(
+            `Skill Workshop pending proposal limit reached (${pending}/${params.maxPending} pending). ` +
+              `Run \`openclaw skills workshop list\`, then resolve one with ` +
+              `\`openclaw skills workshop apply <proposal-id>\`, ` +
+              `\`openclaw skills workshop reject <proposal-id>\`, or ` +
+              `\`openclaw skills workshop quarantine <proposal-id>\`. ` +
+              `Quarantined proposals do not count toward this limit.`,
+          );
         }
         insertProposal(db, {
           record: params.record,


### PR DESCRIPTION
Closes #134955

## What Problem This Solves

Fixes an issue where users could no longer author a Skill Workshop proposal when a workspace had reached `maxPending` entirely through quarantined proposals, even with no pending review queue.

## Why This Change Was Made

The existing serialized, workspace-scoped write boundary remains intact, but the cap now counts only pending proposals. A genuinely full pending queue still fails loudly and names the existing list/apply/reject/quarantine commands; quarantine remains visible for separate lifecycle governance.

## User Impact

Agents can keep authoring while quarantined proposals await triage. Operators still get a bounded pending queue and an actionable error if that real pending queue is full.

## Evidence

- Red first: the new regression failed on the previous predicate with `Skill Workshop pending proposal limit reached (1)`.
- Green: `pnpm test src/skills/workshop/service.test.ts` — 50/50 passed.
- `pnpm check:changed` — passed.
- `pnpm build` — passed.
- Fresh read-only review corrected the error commands and the remaining contradictory docs before this head.

The available `autoreview` skill was not installed in this environment; the evidence above plus an independent exact-head reviewer were used as the fallback review lane.
