### PR TITLE
fix(cli): bound --target-file reads and preserve file on read errors

### DIFF
--- a/docs/cli/connect.md
+++ b/docs/cli/connect.md
@@ -106,9 +106,12 @@ hosting and exact capacity from this durable consent when it starts.
 - an `oc-pair://<setup-code>` URL;
 - a bare base64url setup code.
 
-`--target-file <path>` reads the target from a private file and removes that file
-after reading it. The dormant installer wrapper uses this handoff to keep the
-single-use target out of child-process arguments.
+`--target-file <path>` accepts a regular file up to 64 KiB. It removes the path
+only after reading a non-empty target. If the file is empty, too large,
+unreadable, or not a regular file, OpenClaw leaves it in place. A symlink is
+allowed; OpenClaw reads its target, removes the symlink after a successful read,
+and keeps the backing file. The dormant installer wrapper uses this handoff to
+keep the single-use target out of child-process arguments.
 
 Join URLs must use HTTPS. Plain HTTP is accepted only for loopback Gateway URLs
 such as `http://127.0.0.1/j/<shortcode>`. Direct setup codes can carry the

--- a/src/cli/connect-cli.test.ts
+++ b/src/cli/connect-cli.test.ts
@@ -1,5 +1,6 @@
 // Connect CLI tests cover accepted targets and handoff to the canonical node runtime.
 import fs from "node:fs/promises";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
@@ -13,7 +14,6 @@ const mocks = vi.hoisted(() => ({
   runNodeHost: vi.fn(),
   runNodeDaemonInstall: vi.fn(),
   fetchWithSsrFGuard: vi.fn(),
-  readRegularFile: vi.fn(),
   loadNodeHostConfig: vi.fn<() => Promise<NodeHostConfig | null>>(async () => null),
   mutateConfigFileWithRetry: vi.fn(),
   runtime: {
@@ -35,11 +35,6 @@ vi.mock("../infra/net/fetch-guard.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../infra/net/fetch-guard.js")>();
   mocks.fetchWithSsrFGuard.mockImplementation(actual.fetchWithSsrFGuard);
   return { fetchWithSsrFGuard: mocks.fetchWithSsrFGuard };
-});
-vi.mock("../infra/regular-file.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../infra/regular-file.js")>();
-  mocks.readRegularFile.mockImplementation(actual.readRegularFile);
-  return { readRegularFile: mocks.readRegularFile };
 });
 vi.mock("../runtime.js", () => ({ defaultRuntime: mocks.runtime }));
 
@@ -181,51 +176,57 @@ describe("connect cli", () => {
     }
   });
 
-  it("does not delete the target file when reading it fails", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-connect-target-fail-"));
+  it.skipIf(process.platform === "win32")(
+    "rejects a socket target without removing it",
+    async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-connect-target-socket-"));
+      const targetFile = path.join(root, "setup-code.sock");
+      const server = net.createServer();
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(targetFile, resolve);
+      });
+      try {
+        await runConnect(["--target-file", targetFile, "--ephemeral"]);
+
+        expect(mocks.runtime.error).toHaveBeenCalledWith(
+          expect.stringContaining("path must be a regular file"),
+        );
+        expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+        expect(mocks.runNodeHost).not.toHaveBeenCalled();
+        const stat = await fs.lstat(targetFile);
+        expect(stat.isSocket()).toBe(true);
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each([
+    {
+      name: "empty",
+      contents: Buffer.alloc(0),
+      message: "Connect target file is empty.",
+    },
+    {
+      name: "oversized",
+      contents: Buffer.alloc(64 * 1024 + 1, 0x61),
+      message: "max 65536 bytes",
+    },
+  ])("rejects an $name target file without removing it", async ({ contents, message }) => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-connect-target-invalid-"));
     const targetFile = path.join(root, "setup-code");
-    await fs.writeFile(targetFile, setupCode(), { mode: 0o600 });
-    mocks.readRegularFile.mockRejectedValueOnce(new Error("permission denied"));
+    await fs.writeFile(targetFile, contents, { mode: 0o600 });
     try {
       await runConnect(["--target-file", targetFile, "--ephemeral"]);
 
+      expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining(message));
       expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
       expect(mocks.runNodeHost).not.toHaveBeenCalled();
-      await expect(fs.stat(targetFile)).resolves.toBeDefined();
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("does not delete an empty target file", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-connect-target-empty-"));
-    const targetFile = path.join(root, "setup-code");
-    await fs.writeFile(targetFile, "");
-    try {
-      await runConnect(["--target-file", targetFile, "--ephemeral"]);
-
-      expect(mocks.runtime.error).toHaveBeenCalledWith("Connect target file is empty.");
-      expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
-      expect(mocks.runNodeHost).not.toHaveBeenCalled();
-      await expect(fs.stat(targetFile)).resolves.toBeDefined();
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
-  });
-
-  it("includes the --target-file flag and size limit in read errors", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-connect-target-err-"));
-    const targetFile = path.join(root, "setup-code");
-    await fs.writeFile(targetFile, setupCode(), { mode: 0o600 });
-    mocks.readRegularFile.mockRejectedValueOnce(new Error("File exceeds 65536 bytes"));
-    try {
-      await runConnect(["--target-file", targetFile]);
-
-      expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining("--target-file"));
-      expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining("65536"));
-      expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
-      expect(mocks.runNodeHost).not.toHaveBeenCalled();
-      await expect(fs.stat(targetFile)).resolves.toBeDefined();
+      await expect(fs.readFile(targetFile)).resolves.toEqual(contents);
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/src/cli/connect-cli.test.ts
+++ b/src/cli/connect-cli.test.ts
@@ -1,10 +1,10 @@
 // Connect CLI tests cover accepted targets and handoff to the canonical node runtime.
 import fs from "node:fs/promises";
 import net from "node:net";
-import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { NodeHostConfig } from "../node-host/config.js";
 import { encodePairingSetupCode } from "../pairing/setup-code.js";
@@ -54,6 +54,8 @@ async function runConnect(args: string[]): Promise<void> {
   registerConnectCli(program);
   await program.parseAsync(["connect", ...args], { from: "user" });
 }
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("connect cli", () => {
   beforeEach(() => {
@@ -161,25 +163,22 @@ describe("connect cli", () => {
   );
 
   it("consumes an environment-managed target file before connecting", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-connect-target-"));
+    const root = tempDirs.make("openclaw-connect-target-");
     const targetFile = path.join(root, "setup-code");
     await fs.writeFile(targetFile, setupCode(), { mode: 0o600 });
-    try {
-      await runConnect(["--target-file", targetFile, "--ephemeral"]);
 
-      expect(mocks.runNodeHost).toHaveBeenCalledWith(
-        expect.objectContaining({ forceWorkerRuns: true }),
-      );
-      await expect(fs.stat(targetFile)).rejects.toMatchObject({ code: "ENOENT" });
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    await runConnect(["--target-file", targetFile, "--ephemeral"]);
+
+    expect(mocks.runNodeHost).toHaveBeenCalledWith(
+      expect.objectContaining({ forceWorkerRuns: true }),
+    );
+    await expect(fs.stat(targetFile)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it.skipIf(process.platform === "win32")(
     "rejects a socket target without removing it",
     async () => {
-      const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-connect-target-socket-"));
+      const root = tempDirs.make("openclaw-connect-target-socket-");
       const targetFile = path.join(root, "setup-code.sock");
       const server = net.createServer();
       await new Promise<void>((resolve, reject) => {
@@ -200,7 +199,6 @@ describe("connect cli", () => {
         await new Promise<void>((resolve, reject) => {
           server.close((error) => (error ? reject(error) : resolve()));
         });
-        await fs.rm(root, { recursive: true, force: true });
       }
     },
   );
@@ -217,40 +215,33 @@ describe("connect cli", () => {
       message: "max 65536 bytes",
     },
   ])("rejects an $name target file without removing it", async ({ contents, message }) => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-connect-target-invalid-"));
+    const root = tempDirs.make("openclaw-connect-target-invalid-");
     const targetFile = path.join(root, "setup-code");
     await fs.writeFile(targetFile, contents, { mode: 0o600 });
-    try {
-      await runConnect(["--target-file", targetFile, "--ephemeral"]);
 
-      expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining(message));
-      expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
-      expect(mocks.runNodeHost).not.toHaveBeenCalled();
-      await expect(fs.readFile(targetFile)).resolves.toEqual(contents);
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    await runConnect(["--target-file", targetFile, "--ephemeral"]);
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining(message));
+    expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.runNodeHost).not.toHaveBeenCalled();
+    await expect(fs.readFile(targetFile)).resolves.toEqual(contents);
   });
 
   it.skipIf(process.platform === "win32")(
     "consumes a symlinked target file and keeps the backing file intact",
     async () => {
-      const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-connect-target-symlink-"));
+      const root = tempDirs.make("openclaw-connect-target-symlink-");
       const targetFile = path.join(root, "setup-code");
       const backingFile = path.join(root, "backing-setup-code");
       await fs.writeFile(backingFile, setupCode(), { mode: 0o600 });
       await fs.symlink(backingFile, targetFile);
-      try {
-        await runConnect(["--target-file", targetFile, "--ephemeral"]);
+      await runConnect(["--target-file", targetFile, "--ephemeral"]);
 
-        expect(mocks.runNodeHost).toHaveBeenCalledWith(
-          expect.objectContaining({ forceWorkerRuns: true }),
-        );
-        await expect(fs.stat(targetFile)).rejects.toMatchObject({ code: "ENOENT" });
-        await expect(fs.stat(backingFile)).resolves.toBeDefined();
-      } finally {
-        await fs.rm(root, { recursive: true, force: true });
-      }
+      expect(mocks.runNodeHost).toHaveBeenCalledWith(
+        expect.objectContaining({ forceWorkerRuns: true }),
+      );
+      await expect(fs.stat(targetFile)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.stat(backingFile)).resolves.toBeDefined();
     },
   );
 

--- a/src/cli/connect-cli.test.ts
+++ b/src/cli/connect-cli.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   runNodeHost: vi.fn(),
   runNodeDaemonInstall: vi.fn(),
   fetchWithSsrFGuard: vi.fn(),
+  readRegularFile: vi.fn(),
   loadNodeHostConfig: vi.fn<() => Promise<NodeHostConfig | null>>(async () => null),
   mutateConfigFileWithRetry: vi.fn(),
   runtime: {
@@ -34,6 +35,11 @@ vi.mock("../infra/net/fetch-guard.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../infra/net/fetch-guard.js")>();
   mocks.fetchWithSsrFGuard.mockImplementation(actual.fetchWithSsrFGuard);
   return { fetchWithSsrFGuard: mocks.fetchWithSsrFGuard };
+});
+vi.mock("../infra/regular-file.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/regular-file.js")>();
+  mocks.readRegularFile.mockImplementation(actual.readRegularFile);
+  return { readRegularFile: mocks.readRegularFile };
 });
 vi.mock("../runtime.js", () => ({ defaultRuntime: mocks.runtime }));
 
@@ -170,6 +176,56 @@ describe("connect cli", () => {
         expect.objectContaining({ forceWorkerRuns: true }),
       );
       await expect(fs.stat(targetFile)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not delete the target file when reading it fails", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-connect-target-fail-"));
+    const targetFile = path.join(root, "setup-code");
+    await fs.writeFile(targetFile, setupCode(), { mode: 0o600 });
+    mocks.readRegularFile.mockRejectedValueOnce(new Error("permission denied"));
+    try {
+      await runConnect(["--target-file", targetFile, "--ephemeral"]);
+
+      expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+      expect(mocks.runNodeHost).not.toHaveBeenCalled();
+      await expect(fs.stat(targetFile)).resolves.toBeDefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not delete an empty target file", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-connect-target-empty-"));
+    const targetFile = path.join(root, "setup-code");
+    await fs.writeFile(targetFile, "");
+    try {
+      await runConnect(["--target-file", targetFile, "--ephemeral"]);
+
+      expect(mocks.runtime.error).toHaveBeenCalledWith("Connect target file is empty.");
+      expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+      expect(mocks.runNodeHost).not.toHaveBeenCalled();
+      await expect(fs.stat(targetFile)).resolves.toBeDefined();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("includes the --target-file flag and size limit in read errors", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-connect-target-err-"));
+    const targetFile = path.join(root, "setup-code");
+    await fs.writeFile(targetFile, setupCode(), { mode: 0o600 });
+    mocks.readRegularFile.mockRejectedValueOnce(new Error("File exceeds 65536 bytes"));
+    try {
+      await runConnect(["--target-file", targetFile]);
+
+      expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining("--target-file"));
+      expect(mocks.runtime.error).toHaveBeenCalledWith(expect.stringContaining("65536"));
+      expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+      expect(mocks.runNodeHost).not.toHaveBeenCalled();
+      await expect(fs.stat(targetFile)).resolves.toBeDefined();
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/src/cli/connect-cli.test.ts
+++ b/src/cli/connect-cli.test.ts
@@ -231,6 +231,28 @@ describe("connect cli", () => {
     }
   });
 
+  it.skipIf(process.platform === "win32")(
+    "consumes a symlinked target file and keeps the backing file intact",
+    async () => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-connect-target-symlink-"));
+      const targetFile = path.join(root, "setup-code");
+      const backingFile = path.join(root, "backing-setup-code");
+      await fs.writeFile(backingFile, setupCode(), { mode: 0o600 });
+      await fs.symlink(backingFile, targetFile);
+      try {
+        await runConnect(["--target-file", targetFile, "--ephemeral"]);
+
+        expect(mocks.runNodeHost).toHaveBeenCalledWith(
+          expect.objectContaining({ forceWorkerRuns: true }),
+        );
+        await expect(fs.stat(targetFile)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(fs.stat(backingFile)).resolves.toBeDefined();
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
   it.each([
     {
       args: ["--ephemeral", "--service"],

--- a/src/cli/connect-cli.ts
+++ b/src/cli/connect-cli.ts
@@ -14,6 +14,7 @@ import { isLoopbackHost } from "../gateway/net.js";
 import { cancelUnreadResponseBody, readResponseWithLimit } from "../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { normalizeHostname } from "../infra/net/hostname.js";
+import { readRegularFile } from "../infra/regular-file.js";
 import { loadNodeHostConfig, type NodeHostGatewayConfig } from "../node-host/config.js";
 import {
   nodeHostCloudflareAccessConfigFromEnv,
@@ -41,6 +42,7 @@ type ConnectCommandOptions = {
 type PairingSetupPayload = ReturnType<typeof decodePairingSetupCode>;
 
 const MAX_JOIN_PAYLOAD_BYTES = 24 * 1024;
+const MAX_TARGET_FILE_BYTES = 64 * 1024;
 const JOIN_FETCH_TIMEOUT_MS = 15_000;
 
 function parseJoinTarget(target: string): URL | null {
@@ -147,19 +149,29 @@ async function resolveConnectTarget(
   if (target) {
     return target;
   }
-  const path = targetFile?.trim();
-  if (!path) {
+  const filePath = targetFile?.trim();
+  if (!filePath) {
     throw new Error("Connect target is required.");
   }
+  let buffer: Buffer;
   try {
-    const value = (await fs.readFile(path, "utf8")).trim();
-    if (!value) {
-      throw new Error("Connect target file is empty.");
-    }
-    return value;
-  } finally {
-    await fs.rm(path, { force: true });
+    ({ buffer } = await readRegularFile({
+      filePath,
+      maxBytes: MAX_TARGET_FILE_BYTES,
+    }));
+  } catch (error) {
+    const cause = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Could not read --target-file ${filePath} (max ${MAX_TARGET_FILE_BYTES} bytes): ${cause}`,
+      { cause: error },
+    );
   }
+  const value = buffer.toString("utf8").trim();
+  if (!value) {
+    throw new Error("Connect target file is empty.");
+  }
+  await fs.rm(filePath, { force: true });
+  return value;
 }
 
 async function runConnectCommand(

--- a/src/cli/connect-cli.ts
+++ b/src/cli/connect-cli.ts
@@ -155,8 +155,12 @@ async function resolveConnectTarget(
   }
   let buffer: Buffer;
   try {
+    // The original fs.readFile behavior followed symlinks in the target path.
+    // Resolve intentional links before the regular-file safety check so
+    // symlinked secret-mount or one-shot target files keep working.
+    const resolvedFilePath = await fs.realpath(filePath);
     ({ buffer } = await readRegularFile({
-      filePath,
+      filePath: resolvedFilePath,
       maxBytes: MAX_TARGET_FILE_BYTES,
     }));
   } catch (error) {


### PR DESCRIPTION
## What Problem This Solves

`openclaw connect --target-file <path>` read the whole path without a limit. It also removed the operator's path in `finally`, including after a read error.

This caused two data-loss and resource risks:

- A FIFO or device could block or produce an unbounded stream.
- An unreadable regular file could fail with `EACCES` and still be deleted.

## Why This Change Was Made

`resolveConnectTarget` now uses the existing `readRegularFile` boundary with a 64 KiB limit. The helper rejects non-regular targets and caps allocation even if a file grows during the read.

The command removes the original path only after it reads a non-empty target. It resolves a symlink before the safety check, then removes the symlink rather than its backing file. This preserves the shipped symlink behavior.

The public connect guide now documents the limit, failure preservation, and symlink behavior.

## User Impact

- FIFO, device, socket, unreadable, empty, and oversized targets stay in place.
- Regular target files are still consumed after a successful non-empty read.
- Symlink target files are still consumed while their backing files stay in place.
- Read errors identify `--target-file` and the 65,536-byte limit.

## Evidence

### Current-main red

Baseline main at reproduction start: `c65cc8e0e5691860289398d288bf758f15fcacc3`.

The real built CLI ran through `pnpm openclaw connect --target-file <path> --ephemeral` on Testbox:

| Input | Exit | Path after command |
| --- | --- | --- |
| FIFO with a finite writer | Invalid pairing target | Removed |
| Mode-`000` regular file | `EACCES` | Removed |

The FIFO case proves the CLI read and removed a non-regular target. The permission case varies the input and proves deletion after a genuine read failure.

The owner-boundary regression cases were also applied without the production fix on the baseline checkout:

```text
node scripts/run-vitest.mjs src/cli/connect-cli.test.ts
Test Files  1 failed (1)
Tests  3 failed | 16 passed (19)
```

### Exact-head green

Candidate head: `e76d5e7e10653e34f041ebeb67ec8e23da2e03e8`.

Candidate tree verified before the remote commands: `5bf2f53c7cee3f2f8ef6752735e2fd5754616052`.

Testbox run: https://github.com/openclaw/openclaw/actions/runs/33501163430

| Input | Exit | Path after command |
| --- | --- | --- |
| FIFO | Rejected as non-regular | Preserved |
| Mode-`000` regular file | `EACCES` | Preserved |
| 65,537-byte regular file | 65,536-byte limit | Preserved |
| Readable regular file | Invalid pairing target after read | Removed |
| Symlink to readable regular file | Invalid pairing target after read | Symlink removed; backing file preserved |

### Tests and checks

- `node scripts/run-vitest.mjs src/cli/connect-cli.test.ts` — 20 passed.
- Remote `pnpm check:changed` — passed after a frozen dependency install.
- `pnpm docs:check-mdx` — passed.
- `pnpm docs:check-links` — 7,208 links checked; 0 broken.
- `pnpm format:docs:check` — passed.
- `git diff --check` — passed.

The regression tests use the real CLI registration and filesystem boundary. They do not mock `readRegularFile`. Direct inspection of `@openclaw/fs-safe@0.5.6` confirmed that `readRegularFile` rejects non-files before opening and uses a bounded handle read when `maxBytes` is set.
