### PR TITLE
refactor(browser): share tab id validation

### DIFF
--- a/extensions/browser/chrome-extension/modules/popup-background.js
+++ b/extensions/browser/chrome-extension/modules/popup-background.js
@@ -5,10 +5,7 @@ import {
   parsePairingString,
 } from "./relay-core.js";
 import { isTabSelected } from "./relay-tab-groups.js";
-
-function isValidTabId(value) {
-  return Number.isSafeInteger(value) && value >= 0;
-}
+import { isValidTabId } from "./tab-eligibility.js";
 
 function errorResponse(sendResponse, error) {
   sendResponse({ ok: false, error: error instanceof Error ? error.message : String(error) });

--- a/extensions/browser/chrome-extension/modules/tab-access.js
+++ b/extensions/browser/chrome-extension/modules/tab-access.js
@@ -2,13 +2,9 @@ import { ACCESS_MODE_ALL, ACCESS_MODE_SELECTED, OPENCLAW_TAB_GROUP_TITLE } from 
 import { addTabToOpenClawGroup } from "./relay-tab-groups.js";
 import { TAB_SCOPED_COMMANDS } from "./tab-access-command-scope.js";
 import { createTabDocumentProvenance } from "./tab-document-provenance.js";
-import { effectiveTabUrl, tabEligibility } from "./tab-eligibility.js";
+import { effectiveTabUrl, isValidTabId, tabEligibility } from "./tab-eligibility.js";
 
 const DENIED_TAB_IDS_KEY = "deniedTabIdsV1";
-
-function isValidTabId(value) {
-  return Number.isSafeInteger(value) && value >= 0;
-}
 
 function initialBlankDocument(tab) {
   return tab.url === "about:blank" || (!tab.url && tab.pendingUrl === "about:blank");

--- a/extensions/browser/chrome-extension/modules/tab-eligibility.d.ts
+++ b/extensions/browser/chrome-extension/modules/tab-eligibility.d.ts
@@ -18,6 +18,8 @@ export type TabEligibilityResult =
   | { eligible: true; reason: null }
   | { eligible: false; reason: TabEligibilityReason };
 
+export function isValidTabId(value: unknown): value is number;
+
 export function effectiveTabUrl(tab: BrowserTabSnapshot | null | undefined): string | undefined;
 
 export function tabEligibility(

--- a/extensions/browser/chrome-extension/modules/tab-eligibility.js
+++ b/extensions/browser/chrome-extension/modules/tab-eligibility.js
@@ -1,4 +1,4 @@
-function isValidTabId(value) {
+export function isValidTabId(value) {
   return Number.isSafeInteger(value) && value >= 0;
 }
 


### PR DESCRIPTION
## What Problem This Solves

The browser extension maintained identical tab ID validation helpers in `tab-access.js` and `popup-background.js`, while `tab-eligibility.js` already owned the same validation policy.

## Why This Change Was Made

Export the existing validator from the eligibility owner, declare its type guard, and reuse it from both callers. This removes the two duplicate policy copies without changing accepted tab IDs.

- Architectural owner: `tab-eligibility.js`
- Removed paths: two local `isValidTabId` implementations
- Production delta: +5/-10, net -5
- Tests/docs/manifests/packages/changelog: unchanged

## User Impact

No behavior change. Tab access and popup requests continue accepting only non-negative safe integer tab IDs, now through one canonical implementation.

## Evidence

- Focused browser extension tests: 3 files, 71/71 passed
- `pnpm check:import-cycles`: 0 runtime value cycles
- `pnpm check:changed`: passed
- `pnpm build`: passed; 147 public SDK subpaths and 63 plugins verified
- Sol/high branch autoreview: clean, patch correctness 0.99
- Full local browser extension suite: 3615 passed, 26 skipped; one macOS-only `127.0.0.2` bind attempt failed with `EADDRNOTAVAIL`
- Direct AWS Crabbox Linux proof: `run_a0666ec385dd`, lease `cbx_8d0d8d89dbf9`, `c7a.8xlarge`
- Remote command: `pnpm install --frozen-lockfile && pnpm test:e2e:browser-extension`
- Remote result: exit 0; Chromium E2E 1/1 passed in 52.23s
- Crabbox proof: https://crabbox.openclaw.ai/portal/runs/run_a0666ec385dd

## Overlap Check

- https://github.com/openclaw/openclaw/pull/130731 remains a broad release branch and does not implement this dedupe.
- https://github.com/openclaw/openclaw/pull/120887 remains unrelated agent read-page work and does not implement this dedupe.
