### PR TITLE
fix(memory): honor bounded embedding provider cooldowns

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1526,7 +1526,6 @@ packages/memory-host-sdk/src/host/memory-schema-migration.ts	1
 packages/memory-host-sdk/src/host/memory-schema-recall.ts	1
 packages/memory-host-sdk/src/host/memory-schema.ts	7
 packages/memory-host-sdk/src/host/multimodal.ts	1
-packages/memory-host-sdk/src/host/post-json.ts	1
 packages/memory-host-sdk/src/host/read-file.ts	1
 packages/memory-host-sdk/src/host/read-retry.ts	4
 packages/memory-host-sdk/src/host/session-files.ts	9

--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -93,6 +93,16 @@ both groups without reindexing their retained transcripts. Ordinary retained,
 reset, and deleted user-session archives remain eligible until explicitly
 targeted.
 
+When an embedding provider rate-limits indexing, each embedding operation gets
+up to five attempts. Retries honor valid provider cooldown hints, capped at
+60 seconds per wait. Other transient errors keep the shorter three-attempt
+budget. Permanent quota errors without a cooldown hint stop that operation.
+The verbose output shows each retry wait.
+
+Interactive `memory_search` keeps three attempts and at most eight seconds of
+total retry sleep within the agent tool's 15-second deadline. A cancelled caller
+interrupts its retry wait.
+
 If status reports an index identity warning after changing embedding settings,
 check the affected agent's provider, model, sources, and extra paths, then rebuild:
 

--- a/extensions/google/embedding-provider.test.ts
+++ b/extensions/google/embedding-provider.test.ts
@@ -342,6 +342,41 @@ describe("Gemini embedding provider", () => {
     );
   });
 
+  it("preserves structured Gemini cooldowns on failed embedding responses", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 429,
+              status: "RESOURCE_EXHAUSTED",
+              details: [
+                {
+                  "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                  retryDelay: "1.500000001s",
+                },
+              ],
+            },
+          }),
+          { status: 429, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "test-key" },
+      model: "gemini-embedding-001",
+      fallback: "none",
+    });
+
+    await expect(provider.embed("test query", { inputType: "query" })).rejects.toMatchObject({
+      status: 429,
+      retryAfterMs: 1501,
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
   it("rejects wrong single embedding vector shapes", async () => {
     installFetchMock(() => ({ embedding: { values: [1, "bad"] } }));
 

--- a/extensions/google/embedding-provider.test.ts
+++ b/extensions/google/embedding-provider.test.ts
@@ -418,6 +418,82 @@ describe("Gemini embedding provider", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
+  it("decodes RetryInfo past core's 500-char errorBody truncation", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 429,
+              status: "RESOURCE_EXHAUSTED",
+              // Padding pushes the RetryInfo detail well past core's 500-char
+              // ProviderHttpError.errorBody preview, matching real ~1KB+ Gemini bodies.
+              message: "quota exceeded ".repeat(40),
+              details: [
+                {
+                  "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                  retryDelay: "5s",
+                },
+              ],
+            },
+          }),
+          { status: 429, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "test-key" },
+      model: "gemini-embedding-001",
+      fallback: "none",
+    });
+
+    await expect(provider.embed("test query", { inputType: "query" })).rejects.toMatchObject({
+      status: 429,
+      retryAfterMs: 5000,
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to the errorBody-based parse when the clone read fails", async () => {
+    const fetchMock = vi.fn(async () => {
+      const response = new Response(
+        JSON.stringify({
+          error: {
+            code: 429,
+            status: "RESOURCE_EXHAUSTED",
+            details: [
+              {
+                "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                retryDelay: "1.500000001s",
+              },
+            ],
+          },
+        }),
+        { status: 429, headers: { "Content-Type": "application/json" } },
+      );
+      response.clone = () => {
+        throw new Error("clone unsupported");
+      };
+      return response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "test-key" },
+      model: "gemini-embedding-001",
+      fallback: "none",
+    });
+
+    await expect(provider.embed("test query", { inputType: "query" })).rejects.toMatchObject({
+      status: 429,
+      retryAfterMs: 1501,
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
   it.each([
     ["negative RetryInfo", "-1s"],
     ["malformed RetryInfo", "NaNs"],

--- a/extensions/google/embedding-provider.test.ts
+++ b/extensions/google/embedding-provider.test.ts
@@ -377,6 +377,87 @@ describe("Gemini embedding provider", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
+  it("keeps the larger RetryInfo or Retry-After cooldown on failed embedding responses", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 429,
+              status: "RESOURCE_EXHAUSTED",
+              details: [
+                {
+                  "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                  retryDelay: "21.549315790s",
+                },
+              ],
+            },
+          }),
+          {
+            status: 429,
+            headers: {
+              "Content-Type": "application/json",
+              "Retry-After": "30",
+            },
+          },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "test-key" },
+      model: "gemini-embedding-001",
+      fallback: "none",
+    });
+
+    await expect(provider.embed("test query", { inputType: "query" })).rejects.toMatchObject({
+      status: 429,
+      retryAfterMs: 30_000,
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["negative RetryInfo", "-1s"],
+    ["malformed RetryInfo", "NaNs"],
+    ["over-precise RetryInfo", "1.0000000001s"],
+    ["unsafe RetryInfo", "9007199254741s"],
+  ])("ignores %s cooldown hints", async (_label, retryDelay) => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 429,
+              status: "RESOURCE_EXHAUSTED",
+              details: [
+                {
+                  "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                  retryDelay,
+                },
+              ],
+            },
+          }),
+          { status: 429, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "test-key" },
+      model: "gemini-embedding-001",
+      fallback: "none",
+    });
+
+    await expect(provider.embed("test query", { inputType: "query" })).rejects.toMatchObject({
+      status: 429,
+      retryAfterMs: undefined,
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
   it("rejects wrong single embedding vector shapes", async () => {
     installFetchMock(() => ({ embedding: { values: [1, "bad"] } }));
 

--- a/extensions/google/embedding-provider.test.ts
+++ b/extensions/google/embedding-provider.test.ts
@@ -1,5 +1,6 @@
 // Google tests cover embedding provider plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 
 vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", async (importOriginal) => {
   const actual =
@@ -340,6 +341,297 @@ describe("Gemini embedding provider", () => {
     await expect(provider.embed("test query", { inputType: "query" })).rejects.toThrow(
       "gemini embeddings failed: malformed JSON response",
     );
+  });
+
+  it("preserves structured Gemini cooldowns on failed embedding responses", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 429,
+              status: "RESOURCE_EXHAUSTED",
+              details: [
+                {
+                  "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                  retryDelay: "1.500000001s",
+                },
+              ],
+            },
+          }),
+          { status: 429, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "test-key" },
+      model: "gemini-embedding-001",
+      fallback: "none",
+    });
+
+    await expect(provider.embed("test query", { inputType: "query" })).rejects.toMatchObject({
+      status: 429,
+      retryAfterMs: 1501,
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the larger RetryInfo or Retry-After cooldown on failed embedding responses", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 429,
+              status: "RESOURCE_EXHAUSTED",
+              details: [
+                {
+                  "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                  retryDelay: "21.549315790s",
+                },
+              ],
+            },
+          }),
+          {
+            status: 429,
+            headers: {
+              "Content-Type": "application/json",
+              "Retry-After": "30",
+            },
+          },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "test-key" },
+      model: "gemini-embedding-001",
+      fallback: "none",
+    });
+
+    await expect(provider.embed("test query", { inputType: "query" })).rejects.toMatchObject({
+      status: 429,
+      retryAfterMs: 30_000,
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("decodes RetryInfo beyond the error preview while redacting reflected credentials", async () => {
+    const credential = "tiny-reflected-value";
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 429,
+              status: "RESOURCE_EXHAUSTED",
+              // Padding pushes the RetryInfo detail well past core's 500-char
+              // ProviderHttpError.errorBody preview, matching real ~1KB+ Gemini bodies.
+              message: `echo ${credential} ${"quota exceeded ".repeat(40)}`,
+              details: [
+                {
+                  "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                  retryDelay: "5s",
+                },
+              ],
+            },
+          }),
+          { status: 429, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: credential },
+      model: "gemini-embedding-001",
+      fallback: "none",
+    });
+
+    await expect(provider.embed("test query", { inputType: "query" })).rejects.toMatchObject({
+      status: 429,
+      retryAfterMs: 5000,
+      message: expect.not.stringContaining(credential),
+      errorBody: expect.not.stringContaining(credential),
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to the errorBody-based parse when the clone read fails", async () => {
+    const fetchMock = vi.fn(async () => {
+      const response = new Response(
+        JSON.stringify({
+          error: {
+            code: 429,
+            status: "RESOURCE_EXHAUSTED",
+            details: [
+              {
+                "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                retryDelay: "1.500000001s",
+              },
+            ],
+          },
+        }),
+        { status: 429, headers: { "Content-Type": "application/json" } },
+      );
+      response.clone = () => {
+        throw new Error("clone unsupported");
+      };
+      return response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "test-key" },
+      model: "gemini-embedding-001",
+      fallback: "none",
+    });
+
+    await expect(provider.embed("test query", { inputType: "query" })).rejects.toMatchObject({
+      status: 429,
+      retryAfterMs: 1501,
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it.each(["original normalization", "cloned body read"] as const)(
+    "releases both Google error response branches when cancelled during %s",
+    async (phase) => {
+      const readStarted = createDeferred();
+      const cancellationReleased = createDeferred();
+      const bodyControllerReady = createDeferred<ReadableStreamDefaultController<Uint8Array>>();
+      const cancel = vi.fn(async () => await cancellationReleased.promise);
+      const clones: Response[] = [];
+      class ObservedErrorResponse extends Response {
+        override clone(): Response {
+          const clone = super.clone();
+          clones.push(clone);
+          return clone;
+        }
+      }
+      const response = new ObservedErrorResponse(
+        new ReadableStream<Uint8Array>(
+          {
+            start(controller) {
+              bodyControllerReady.resolve(controller);
+            },
+            pull() {
+              readStarted.resolve();
+            },
+            cancel,
+          },
+          { highWaterMark: 0 },
+        ),
+        { status: 429, headers: { "Retry-After": "30" } },
+      );
+      const bodyController = await bodyControllerReady.promise;
+      const fetchMock = vi.fn(async () => response);
+      vi.stubGlobal("fetch", fetchMock);
+      const { provider } = await createGeminiEmbeddingProvider({
+        config: {},
+        provider: "gemini",
+        remote: { apiKey: "test-key" },
+        model: "gemini-embedding-001",
+        fallback: "none",
+      });
+      const controller = new AbortController();
+      const reason = new Error("caller stopped memory lookup");
+      if (phase === "cloned body read") {
+        vi.useFakeTimers();
+      }
+      const result = provider
+        .embed("test query", { inputType: "query", signal: controller.signal })
+        .then(
+          (value) => value,
+          (error: unknown) => error,
+        );
+
+      try {
+        await readStarted.promise;
+        expect(clones).toHaveLength(1);
+        const clone = clones[0];
+        if (!clone) {
+          throw new Error("expected the provider's response clone");
+        }
+        if (phase === "cloned body read") {
+          await vi.advanceTimersByTimeAsync(10_000);
+          expect(response.body?.locked).toBe(false);
+          expect(clone.body?.locked).toBe(true);
+          vi.useRealTimers();
+        } else {
+          expect(response.body?.locked).toBe(true);
+          expect(clone.bodyUsed).toBe(false);
+        }
+
+        controller.abort(reason);
+
+        await expect(
+          withTestTimeout(result, 1_000, "Google body abort did not settle"),
+        ).resolves.toBe(reason);
+        expect(cancel).toHaveBeenCalledOnce();
+        expect(response.body?.locked).toBe(false);
+        expect(clone.body?.locked).toBe(false);
+        expect(clone.bodyUsed).toBe(true);
+        expect(fetchMock).toHaveBeenCalledOnce();
+      } finally {
+        vi.useRealTimers();
+        controller.abort(reason);
+        bodyController.error(new Error("Google response fixture disposed"));
+        cancellationReleased.resolve();
+        await Promise.all(
+          [response, ...clones].map(async (branch) => {
+            if (!branch.body?.locked) {
+              await branch.body?.cancel().catch(() => undefined);
+            }
+          }),
+        );
+        await withTestTimeout(result, 1_000, "Google body cleanup did not settle");
+      }
+    },
+  );
+
+  it.each([
+    ["negative RetryInfo", "-1s"],
+    ["malformed RetryInfo", "NaNs"],
+    ["over-precise RetryInfo", "1.0000000001s"],
+    ["unsafe RetryInfo", "9007199254741s"],
+  ])("ignores %s cooldown hints", async (_label, retryDelay) => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 429,
+              status: "RESOURCE_EXHAUSTED",
+              details: [
+                {
+                  "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                  retryDelay,
+                },
+              ],
+            },
+          }),
+          { status: 429, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "test-key" },
+      model: "gemini-embedding-001",
+      fallback: "none",
+    });
+
+    await expect(provider.embed("test query", { inputType: "query" })).rejects.toMatchObject({
+      status: 429,
+      retryAfterMs: undefined,
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it("rejects wrong single embedding vector shapes", async () => {

--- a/extensions/google/embedding-provider.test.ts
+++ b/extensions/google/embedding-provider.test.ts
@@ -1,6 +1,7 @@
 // Google tests cover embedding provider plugin behavior.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { withTimeout } from "openclaw/plugin-sdk/time-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 
 vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", async (importOriginal) => {
   const actual =
@@ -501,8 +502,8 @@ describe("Gemini embedding provider", () => {
   it.each(["original normalization", "cloned body read"] as const)(
     "releases both Google error response branches when cancelled during %s",
     async (phase) => {
-      const readStarted = createDeferred();
-      const cancellationReleased = createDeferred();
+      const readStarted = createDeferred<void>();
+      const cancellationReleased = createDeferred<void>();
       const bodyControllerReady = createDeferred<ReadableStreamDefaultController<Uint8Array>>();
       const cancel = vi.fn(async () => await cancellationReleased.promise);
       const clones: Response[] = [];
@@ -570,7 +571,7 @@ describe("Gemini embedding provider", () => {
         controller.abort(reason);
 
         await expect(
-          withTestTimeout(result, 1_000, "Google body abort did not settle"),
+          withTimeout(result, 1_000, { message: "Google body abort did not settle" }),
         ).resolves.toBe(reason);
         expect(cancel).toHaveBeenCalledOnce();
         expect(response.body?.locked).toBe(false);
@@ -589,7 +590,7 @@ describe("Gemini embedding provider", () => {
             }
           }),
         );
-        await withTestTimeout(result, 1_000, "Google body cleanup did not settle");
+        await withTimeout(result, 1_000, { message: "Google body cleanup did not settle" });
       }
     },
   );

--- a/extensions/google/embedding-provider.ts
+++ b/extensions/google/embedding-provider.ts
@@ -55,6 +55,8 @@ type GeminiTaskType = NonNullable<MemoryEmbeddingProviderCreateOptions["taskType
 const GEMINI_EMBEDDING_2_MODELS = new Set(["gemini-embedding-2", "gemini-embedding-2-preview"]);
 
 const GEMINI_EMBEDDING_2_DEFAULT_DIMENSIONS = 3072;
+const GOOGLE_RETRY_INFO_TYPE = "type.googleapis.com/google.rpc.RetryInfo";
+const GOOGLE_RETRY_DELAY_RE = /^(\d+)(?:\.(\d{1,9}))?s$/u;
 const GEMINI_EMBEDDING_2_TASK_PREFIXES: Record<GeminiTaskType, string> = {
   RETRIEVAL_QUERY: "task: search result | query:",
   RETRIEVAL_DOCUMENT: "title: none | text:",
@@ -207,6 +209,35 @@ function normalizeGeminiModel(model: string): string {
   return withoutPrefix;
 }
 
+function extractGoogleRetryInfoDelayMs(errorBody: unknown): number | undefined {
+  if (typeof errorBody !== "string" || !errorBody) {
+    return undefined;
+  }
+  try {
+    const details = asOptionalRecord(asOptionalRecord(JSON.parse(errorBody))?.error)?.details;
+    if (!Array.isArray(details)) {
+      return undefined;
+    }
+    let retryAfterMs: number | undefined;
+    for (const rawDetail of details) {
+      const detail = asOptionalRecord(rawDetail);
+      const retryDelay = normalizeOptionalString(detail?.retryDelay);
+      const match = retryDelay ? GOOGLE_RETRY_DELAY_RE.exec(retryDelay) : undefined;
+      if (normalizeOptionalString(detail?.["@type"]) !== GOOGLE_RETRY_INFO_TYPE || !match) {
+        continue;
+      }
+      const delayMs =
+        Number(match[1]) * 1000 + (match[2] ? Math.ceil(Number(`0.${match[2]}`) * 1000) : 0);
+      if (Number.isSafeInteger(delayMs) && delayMs >= 0) {
+        retryAfterMs = Math.max(retryAfterMs ?? delayMs, delayMs);
+      }
+    }
+    return retryAfterMs;
+  } catch {
+    return undefined;
+  }
+}
+
 export function sanitizeGeminiEmbedding(values: number[], expectedDimensions?: number): number[] {
   if (expectedDimensions != null && values.length !== expectedDimensions) {
     throw unexpectedGeminiEmbeddingDimensions(expectedDimensions, values.length);
@@ -241,7 +272,21 @@ async function fetchGeminiEmbeddingPayload(params: {
         },
         onResponse: async (res) => {
           if (!res.ok) {
-            throw await createProviderHttpError(res, "gemini embeddings failed");
+            const error = await createProviderHttpError(res, "gemini embeddings failed");
+            const fields = asOptionalRecord(error);
+            const retryAfterMs = extractGoogleRetryInfoDelayMs(fields?.errorBody);
+            if (retryAfterMs !== undefined) {
+              // Google-owned enrichment of its own thrown error: core keeps
+              // retryAfterMs vendor-agnostic (header-only), so the RetryInfo
+              // merge happens here at the provider boundary.
+              Object.assign(error, {
+                retryAfterMs: Math.max(
+                  retryAfterMs,
+                  typeof fields?.retryAfterMs === "number" ? fields.retryAfterMs : 0,
+                ),
+              });
+            }
+            throw error;
           }
           return await readProviderJsonObjectResponse(res, "gemini embeddings failed");
         },

--- a/extensions/google/embedding-provider.ts
+++ b/extensions/google/embedding-provider.ts
@@ -21,6 +21,7 @@ import {
   createProviderHttpError,
   providerOperationRetryConfig,
   readProviderJsonObjectResponse,
+  readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
 import type { SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
@@ -57,6 +58,9 @@ const GEMINI_EMBEDDING_2_MODELS = new Set(["gemini-embedding-2", "gemini-embeddi
 const GEMINI_EMBEDDING_2_DEFAULT_DIMENSIONS = 3072;
 const GOOGLE_RETRY_INFO_TYPE = "type.googleapis.com/google.rpc.RetryInfo";
 const GOOGLE_RETRY_DELAY_RE = /^(\d+)(?:\.(\d{1,9}))?s$/u;
+// Mirrors core's own error-body read limit (extractProviderErrorInfo in
+// provider-http-errors.ts) so the clone read below stays bounded like core's.
+const GOOGLE_RETRY_INFO_BODY_LIMIT_BYTES = 16 * 1024;
 const GEMINI_EMBEDDING_2_TASK_PREFIXES: Record<GeminiTaskType, string> = {
   RETRIEVAL_QUERY: "task: search result | query:",
   RETRIEVAL_DOCUMENT: "title: none | text:",
@@ -209,6 +213,13 @@ function normalizeGeminiModel(model: string): string {
   return withoutPrefix;
 }
 
+/**
+ * Parses the delay hint from a `google.rpc.RetryInfo` detail inside a Gemini error
+ * body. Callers should prefer a full (bounded) body read over the 500-char
+ * `ProviderHttpError.errorBody` preview: real Gemini 429 payloads run ~1KB+ with
+ * the RetryInfo detail near the end of `error.details`, so the truncated preview
+ * regularly cuts the hint away.
+ */
 function extractGoogleRetryInfoDelayMs(errorBody: unknown): number | undefined {
   if (typeof errorBody !== "string" || !errorBody) {
     return undefined;
@@ -272,9 +283,29 @@ async function fetchGeminiEmbeddingPayload(params: {
         },
         onResponse: async (res) => {
           if (!res.ok) {
+            // Clone before createProviderHttpError consumes the body: core truncates
+            // ProviderHttpError.errorBody to 500 chars, which regularly cuts off the
+            // RetryInfo detail near the end of real (~1KB+) Gemini 429 bodies.
+            let errorBodyClone: Response | undefined;
+            try {
+              errorBodyClone = res.clone();
+            } catch {
+              errorBodyClone = undefined;
+            }
             const error = await createProviderHttpError(res, "gemini embeddings failed");
             const fields = asOptionalRecord(error);
-            const retryAfterMs = extractGoogleRetryInfoDelayMs(fields?.errorBody);
+            let retryInfoSource: unknown = fields?.errorBody;
+            if (errorBodyClone) {
+              try {
+                retryInfoSource = await readResponseTextLimited(
+                  errorBodyClone,
+                  GOOGLE_RETRY_INFO_BODY_LIMIT_BYTES,
+                );
+              } catch {
+                retryInfoSource = fields?.errorBody;
+              }
+            }
+            const retryAfterMs = extractGoogleRetryInfoDelayMs(retryInfoSource);
             if (retryAfterMs !== undefined) {
               // Google-owned enrichment of its own thrown error: core keeps
               // retryAfterMs vendor-agnostic (header-only), so the RetryInfo

--- a/extensions/google/embedding-provider.ts
+++ b/extensions/google/embedding-provider.ts
@@ -21,6 +21,7 @@ import {
   createProviderHttpError,
   providerOperationRetryConfig,
   readProviderJsonObjectResponse,
+  readProviderResponseErrorText,
 } from "openclaw/plugin-sdk/provider-http";
 import type { SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
@@ -55,6 +56,11 @@ type GeminiTaskType = NonNullable<MemoryEmbeddingProviderCreateOptions["taskType
 const GEMINI_EMBEDDING_2_MODELS = new Set(["gemini-embedding-2", "gemini-embedding-2-preview"]);
 
 const GEMINI_EMBEDDING_2_DEFAULT_DIMENSIONS = 3072;
+const GOOGLE_RETRY_INFO_TYPE = "type.googleapis.com/google.rpc.RetryInfo";
+const GOOGLE_RETRY_DELAY_RE = /^(\d+)(?:\.(\d{1,9}))?s$/u;
+// Mirrors core's own error-body read limit (extractProviderErrorInfo in
+// provider-http-errors.ts) so the clone read below stays bounded like core's.
+const GOOGLE_RETRY_INFO_BODY_LIMIT_BYTES = 16 * 1024;
 const GEMINI_EMBEDDING_2_TASK_PREFIXES: Record<GeminiTaskType, string> = {
   RETRIEVAL_QUERY: "task: search result | query:",
   RETRIEVAL_DOCUMENT: "title: none | text:",
@@ -207,6 +213,42 @@ function normalizeGeminiModel(model: string): string {
   return withoutPrefix;
 }
 
+/**
+ * Parses the delay hint from a `google.rpc.RetryInfo` detail inside a Gemini error
+ * body. Callers should prefer a full (bounded) body read over the 500-char
+ * `ProviderHttpError.errorBody` preview: real Gemini 429 payloads run ~1KB+ with
+ * the RetryInfo detail near the end of `error.details`, so the truncated preview
+ * regularly cuts the hint away.
+ */
+function extractGoogleRetryInfoDelayMs(errorBody: unknown): number | undefined {
+  if (typeof errorBody !== "string" || !errorBody) {
+    return undefined;
+  }
+  try {
+    const details = asOptionalRecord(asOptionalRecord(JSON.parse(errorBody))?.error)?.details;
+    if (!Array.isArray(details)) {
+      return undefined;
+    }
+    let retryAfterMs: number | undefined;
+    for (const rawDetail of details) {
+      const detail = asOptionalRecord(rawDetail);
+      const retryDelay = normalizeOptionalString(detail?.retryDelay);
+      const match = retryDelay ? GOOGLE_RETRY_DELAY_RE.exec(retryDelay) : undefined;
+      if (normalizeOptionalString(detail?.["@type"]) !== GOOGLE_RETRY_INFO_TYPE || !match) {
+        continue;
+      }
+      const delayMs =
+        Number(match[1]) * 1000 + (match[2] ? Math.ceil(Number(`0.${match[2]}`) * 1000) : 0);
+      if (Number.isSafeInteger(delayMs) && delayMs >= 0) {
+        retryAfterMs = Math.max(retryAfterMs ?? delayMs, delayMs);
+      }
+    }
+    return retryAfterMs;
+  } catch {
+    return undefined;
+  }
+}
+
 export function sanitizeGeminiEmbedding(values: number[], expectedDimensions?: number): number[] {
   if (expectedDimensions != null && values.length !== expectedDimensions) {
     throw unexpectedGeminiEmbeddingDimensions(expectedDimensions, values.length);
@@ -241,7 +283,44 @@ async function fetchGeminiEmbeddingPayload(params: {
         },
         onResponse: async (res) => {
           if (!res.ok) {
-            throw await createProviderHttpError(res, "gemini embeddings failed");
+            // Clone before createProviderHttpError consumes the body: core truncates
+            // ProviderHttpError.errorBody to 500 chars, which regularly cuts off the
+            // RetryInfo detail near the end of real (~1KB+) Gemini 429 bodies.
+            let errorBodyClone: Response | undefined;
+            try {
+              errorBodyClone = res.clone();
+            } catch {
+              errorBodyClone = undefined;
+            }
+            try {
+              const error = await createProviderHttpError(res, "gemini embeddings failed", {
+                requestHeaders: headers,
+                signal: params.signal,
+              });
+              let retryInfoSource: unknown = error.errorBody;
+              if (errorBodyClone) {
+                try {
+                  retryInfoSource = await readProviderResponseErrorText(
+                    errorBodyClone,
+                    GOOGLE_RETRY_INFO_BODY_LIMIT_BYTES,
+                    headers,
+                    params.signal,
+                  );
+                } catch {
+                  params.signal?.throwIfAborted();
+                  retryInfoSource = error.errorBody;
+                }
+              }
+              params.signal?.throwIfAborted();
+              const retryAfterMs = extractGoogleRetryInfoDelayMs(retryInfoSource);
+              if (retryAfterMs !== undefined) {
+                error.retryAfterMs = Math.max(retryAfterMs, error.retryAfterMs ?? 0);
+              }
+              throw error;
+            } finally {
+              // An early exit while reading the original must also release its tee.
+              void errorBodyClone?.body?.cancel().catch(() => undefined);
+            }
           }
           return await readProviderJsonObjectResponse(res, "gemini embeddings failed");
         },

--- a/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
@@ -48,22 +48,28 @@ function createEmbeddingBatchRetryHarness(embedBatch: EmbeddingProvider["embedBa
 describe("memory embedding query retry cancellation", () => {
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("cancels provider backoff immediately without sending a second request", async () => {
     vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const controller = new AbortController();
     const abortReason = new Error("memory search was cancelled");
-    const embedQuery = vi
-      .fn<EmbeddingProvider["embed"]>()
-      .mockRejectedValue(new Error("TypeError: fetch failed"));
-    const manager = createEmbeddingQueryRetryHarness(embedQuery);
+    const embedQuery = vi.fn<EmbeddingProvider["embed"]>().mockRejectedValue(
+      Object.assign(new Error("gemini embeddings failed (429)"), {
+        status: 429,
+        retryAfterMs: 60_000,
+      }),
+    );
+    const manager = createEmbeddingQueryRetryHarness(embedQuery, 10_000);
 
     const pending = manager.embedQueryWithRetry("search terms", controller.signal);
     await vi.advanceTimersByTimeAsync(0);
 
     expect(embedQuery).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(1);
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 60_000);
 
     controller.abort(abortReason);
 

--- a/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
@@ -1,3 +1,4 @@
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { EmbeddingProvider } from "./embeddings.js";
 import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
@@ -53,7 +54,6 @@ describe("memory embedding query retry cancellation", () => {
 
   it("cancels provider backoff immediately without sending a second request", async () => {
     vi.useFakeTimers();
-    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const controller = new AbortController();
     const abortReason = new Error("memory search was cancelled");
     const embedQuery = vi.fn<EmbeddingProvider["embed"]>().mockRejectedValue(
@@ -63,13 +63,25 @@ describe("memory embedding query retry cancellation", () => {
       }),
     );
     const manager = createEmbeddingQueryRetryHarness(embedQuery, 10_000);
+    const waitForRetrySpy = vi.spyOn(
+      manager as unknown as {
+        waitForEmbeddingRetry: (
+          delayMs: number,
+          action: string,
+          signal?: AbortSignal,
+        ) => Promise<void>;
+      },
+      "waitForEmbeddingRetry",
+    );
 
     const pending = manager.embedQueryWithRetry("search terms", controller.signal);
     await vi.advanceTimersByTimeAsync(0);
 
     expect(embedQuery).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(1);
-    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 60_000);
+    const firstDelayMs = waitForRetrySpy.mock.calls[0]?.[0];
+    expect(firstDelayMs).toBeGreaterThanOrEqual(6400);
+    expect(firstDelayMs).toBeLessThanOrEqual(8000);
 
     controller.abort(abortReason);
 
@@ -95,6 +107,33 @@ describe("memory embedding query retry cancellation", () => {
       cause: abortReason,
     });
     expect(embedQuery).not.toHaveBeenCalled();
+  });
+
+  it("reaches caller fallback within the memory_search deadline after a hinted 429", async () => {
+    vi.useFakeTimers();
+    const waits: number[] = [];
+    const embedQuery = vi.fn<EmbeddingProvider["embed"]>().mockRejectedValue(
+      Object.assign(new Error("gemini embeddings failed (429)"), {
+        status: 429,
+        retryAfterMs: 60_000,
+      }),
+    );
+    const manager = Object.assign(createEmbeddingQueryRetryHarness(embedQuery), {
+      waitForEmbeddingRetry: async (delayMs: number, _action: string, signal?: AbortSignal) => {
+        waits.push(delayMs);
+        await sleepWithAbort(delayMs, signal);
+      },
+    }) as EmbeddingQueryRetryHarness;
+    const fallback = vi.fn(async () => [0, 1, 0, 0]);
+
+    const pending = manager.embedQueryWithRetry("search terms").catch(fallback);
+    await vi.runAllTimersAsync();
+
+    await expect(pending).resolves.toEqual([0, 1, 0, 0]);
+    expect(embedQuery).toHaveBeenCalledTimes(3);
+    expect(fallback).toHaveBeenCalledOnce();
+    expect(waits.every((delayMs) => delayMs <= 8_000)).toBe(true);
+    expect(waits.reduce((total, delayMs) => total + delayMs, 0)).toBeLessThan(15_000);
   });
 
   it("retries provider success that arrives after each embedding deadline", async () => {

--- a/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
@@ -3,6 +3,7 @@ import {
   createMemorySearchDeadlineControl,
   type MemorySearchDeadlineControl,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { EmbeddingProvider, EmbeddingProviderRuntime } from "./embeddings.js";
 import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
@@ -62,6 +63,7 @@ function createEmbeddingBatchRetryHarness(embedBatch: EmbeddingProvider["embedBa
 describe("memory embedding query retry cancellation", () => {
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("waits for an already-active readiness phase before arming its query deadline", async () => {
@@ -101,16 +103,32 @@ describe("memory embedding query retry cancellation", () => {
     vi.useFakeTimers();
     const controller = new AbortController();
     const abortReason = new Error("memory search was cancelled");
-    const embedQuery = vi
-      .fn<EmbeddingProvider["embed"]>()
-      .mockRejectedValue(new Error("TypeError: fetch failed"));
-    const manager = createEmbeddingQueryRetryHarness(embedQuery);
+    const embedQuery = vi.fn<EmbeddingProvider["embed"]>().mockRejectedValue(
+      Object.assign(new Error("gemini embeddings failed (429)"), {
+        status: 429,
+        retryAfterMs: 60_000,
+      }),
+    );
+    const manager = createEmbeddingQueryRetryHarness(embedQuery, 10_000);
+    const waitForRetrySpy = vi.spyOn(
+      manager as unknown as {
+        waitForEmbeddingRetry: (
+          delayMs: number,
+          action: string,
+          signal?: AbortSignal,
+        ) => Promise<void>;
+      },
+      "waitForEmbeddingRetry",
+    );
 
     const pending = manager.embedQueryWithRetry("search terms", controller.signal);
     await vi.advanceTimersByTimeAsync(0);
 
     expect(embedQuery).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(1);
+    const firstDelayMs = waitForRetrySpy.mock.calls[0]?.[0];
+    expect(firstDelayMs).toBeGreaterThanOrEqual(6400);
+    expect(firstDelayMs).toBeLessThanOrEqual(8000);
 
     controller.abort(abortReason);
 
@@ -136,6 +154,33 @@ describe("memory embedding query retry cancellation", () => {
       cause: abortReason,
     });
     expect(embedQuery).not.toHaveBeenCalled();
+  });
+
+  it("reaches caller fallback within the memory_search deadline after a hinted 429", async () => {
+    vi.useFakeTimers();
+    const waits: number[] = [];
+    const embedQuery = vi.fn<EmbeddingProvider["embed"]>().mockRejectedValue(
+      Object.assign(new Error("gemini embeddings failed (429)"), {
+        status: 429,
+        retryAfterMs: 60_000,
+      }),
+    );
+    const manager = Object.assign(createEmbeddingQueryRetryHarness(embedQuery), {
+      waitForEmbeddingRetry: async (delayMs: number, _action: string, signal?: AbortSignal) => {
+        waits.push(delayMs);
+        await sleepWithAbort(delayMs, signal);
+      },
+    }) as EmbeddingQueryRetryHarness;
+    const fallback = vi.fn(async () => [0, 1, 0, 0]);
+
+    const pending = manager.embedQueryWithRetry("search terms").catch(fallback);
+    await vi.runAllTimersAsync();
+
+    await expect(pending).resolves.toEqual([0, 1, 0, 0]);
+    expect(embedQuery).toHaveBeenCalledTimes(3);
+    expect(fallback).toHaveBeenCalledOnce();
+    expect(waits.every((delayMs) => delayMs <= 8_000)).toBe(true);
+    expect(waits.reduce((total, delayMs) => total + delayMs, 0)).toBeLessThan(15_000);
   });
 
   it("retries provider success that arrives after each embedding deadline", async () => {

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -53,9 +53,7 @@ import {
   buildMemoryEmbeddingBatches,
   buildTextEmbeddingInputs,
   filterNonEmptyMemoryChunks,
-  isRetryableMemoryEmbeddingError,
   isSplittableMemoryEmbeddingBatchError,
-  resolveMemoryEmbeddingRetryDelay,
   runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
 } from "./manager-embedding-policy.js";
@@ -80,9 +78,6 @@ const FTS_TABLE = MEMORY_INDEX_FTS_TABLE;
 const EMBEDDING_CACHE_TABLE = MEMORY_EMBEDDING_CACHE_TABLE;
 const EMBEDDING_BATCH_MAX_TOKENS = 8000;
 const EMBEDDING_INDEX_CONCURRENCY = 4;
-const EMBEDDING_RETRY_MAX_ATTEMPTS = 3;
-const EMBEDDING_RETRY_BASE_DELAY_MS = 500;
-const EMBEDDING_RETRY_MAX_DELAY_MS = 8000;
 const EMBEDDING_QUERY_TIMEOUT_REMOTE_MS = 60_000;
 const EMBEDDING_QUERY_TIMEOUT_LOCAL_MS = 5 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_REMOTE_MS = 2 * 60_000;
@@ -643,7 +638,6 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
               }
               return result;
             },
-            isRetryable: isRetryableMemoryEmbeddingError,
             isSplittable: isSplittableMemoryEmbeddingBatchError,
             waitForRetry: async (delayMs) => {
               await this.waitForEmbeddingRetry(
@@ -651,8 +645,6 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
                 structured ? "retrying structured batch" : "retrying",
               );
             },
-            maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
-            baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
             onSplit: ({ itemCount, splitAt }) => {
               log.warn(
                 `memory embeddings ${label} failed; splitting ${itemCount} inputs into ${splitAt} + ${itemCount - splitAt}`,
@@ -681,13 +673,8 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     action: string,
     signal?: AbortSignal,
   ): Promise<void> {
-    const waitMs = resolveMemoryEmbeddingRetryDelay(
-      delayMs,
-      Math.random(),
-      EMBEDDING_RETRY_MAX_DELAY_MS,
-    );
-    log.warn(`memory embeddings retryable error; ${action} in ${waitMs}ms`);
-    await sleepWithAbort(waitMs, signal);
+    log.warn(`memory embeddings retryable error; ${action} in ${delayMs}ms`);
+    await sleepWithAbort(delayMs, signal);
   }
 
   private resolveEmbeddingTimeout(
@@ -733,12 +720,9 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
               });
             },
             signal,
-            isRetryable: isRetryableMemoryEmbeddingError,
             waitForRetry: async (delayMs) => {
               await this.waitForEmbeddingRetry(delayMs, "retrying query", signal);
             },
-            maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
-            baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
           }),
       );
     } catch (err) {

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -613,6 +613,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         provider,
         async () =>
           await runMemoryEmbeddingBatchRetryWithSplit({
+            profile: "index",
             items: params.items,
             run: async (batchItems) => {
               const timeoutMs = this.resolveEmbeddingTimeout(
@@ -707,6 +708,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         provider,
         async () =>
           await runMemoryEmbeddingRetryLoop({
+            profile: "query",
             run: async () => {
               signal?.throwIfAborted();
               const timeoutMs = this.resolveEmbeddingTimeout("query", provider, providerRuntime);

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -49,9 +49,7 @@ import {
   buildMemoryEmbeddingBatches,
   buildTextEmbeddingInputs,
   filterNonEmptyMemoryChunks,
-  isRetryableMemoryEmbeddingError,
   isSplittableMemoryEmbeddingBatchError,
-  resolveMemoryEmbeddingRetryDelay,
   runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
 } from "./manager-embedding-policy.js";
@@ -76,9 +74,6 @@ const EMBEDDING_CACHE_TABLE = MEMORY_EMBEDDING_CACHE_TABLE;
 const EMBEDDING_CACHE_PRUNE_BATCH_SIZE = 100;
 const EMBEDDING_BATCH_MAX_TOKENS = 8000;
 const EMBEDDING_INDEX_CONCURRENCY = 4;
-const EMBEDDING_RETRY_MAX_ATTEMPTS = 3;
-const EMBEDDING_RETRY_BASE_DELAY_MS = 500;
-const EMBEDDING_RETRY_MAX_DELAY_MS = 8000;
 const EMBEDDING_QUERY_TIMEOUT_REMOTE_MS = 60_000;
 const EMBEDDING_QUERY_TIMEOUT_LOCAL_MS = 5 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_REMOTE_MS = 2 * 60_000;
@@ -534,6 +529,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         provider,
         async () =>
           await runMemoryEmbeddingBatchRetryWithSplit({
+            profile: "index",
             items: inputs,
             run: async (batchItems) => {
               const timeoutMs = this.resolveEmbeddingTimeout(
@@ -560,7 +556,6 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
               }
               return result;
             },
-            isRetryable: isRetryableMemoryEmbeddingError,
             isSplittable: isSplittableMemoryEmbeddingBatchError,
             waitForRetry: async (delayMs) => {
               await this.waitForEmbeddingRetry(
@@ -568,8 +563,6 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
                 structured ? "retrying structured batch" : "retrying",
               );
             },
-            maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
-            baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
             onSplit: ({ itemCount, splitAt }) => {
               log.warn(
                 `memory embeddings ${label} failed; splitting ${itemCount} inputs into ${splitAt} + ${itemCount - splitAt}`,
@@ -598,13 +591,8 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     action: string,
     signal?: AbortSignal,
   ): Promise<void> {
-    const waitMs = resolveMemoryEmbeddingRetryDelay(
-      delayMs,
-      Math.random(),
-      EMBEDDING_RETRY_MAX_DELAY_MS,
-    );
-    log.warn(`memory embeddings retryable error; ${action} in ${waitMs}ms`);
-    await sleepWithAbort(waitMs, signal);
+    log.warn(`memory embeddings retryable error; ${action} in ${delayMs}ms`);
+    await sleepWithAbort(delayMs, signal);
   }
 
   private resolveEmbeddingTimeout(
@@ -638,6 +626,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         provider,
         async () =>
           await runMemoryEmbeddingRetryLoop({
+            profile: "query",
             run: async () => {
               signal?.throwIfAborted();
               const timeoutMs = this.resolveEmbeddingTimeout("query", provider, providerRuntime);
@@ -658,12 +647,9 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
               });
             },
             signal,
-            isRetryable: isRetryableMemoryEmbeddingError,
             waitForRetry: async (delayMs) => {
               await this.waitForEmbeddingRetry(delayMs, "retrying query", signal);
             },
-            maxAttempts: EMBEDDING_RETRY_MAX_ATTEMPTS,
-            baseDelayMs: EMBEDDING_RETRY_BASE_DELAY_MS,
           }),
       );
     } catch (err) {

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -19,12 +19,16 @@ function expectDelayBetween(delayMs: number | undefined, min: number, max: numbe
  * a permanent error stops after one call, a retryable one runs to its
  * class's exhaustion count (3 for transient, 5 for rate-limit).
  */
-async function probeRetryAttempts(message: string): Promise<number> {
+async function probeRetryAttempts(
+  message: string,
+  profile: "index" | "query" = "index",
+): Promise<number> {
   const run = vi.fn(async () => {
     throw new Error(message);
   });
   try {
     await runMemoryEmbeddingRetryLoop({
+      profile,
       run,
       waitForRetry: async () => {},
     });
@@ -113,6 +117,7 @@ describe("memory embedding policy", () => {
     const waits: number[] = [];
 
     const result = await runMemoryEmbeddingRetryLoop({
+      profile: "index",
       run,
       waitForRetry: async (delayMs) => {
         waits.push(delayMs);
@@ -133,6 +138,7 @@ describe("memory embedding policy", () => {
 
     await expect(
       runMemoryEmbeddingRetryLoop({
+        profile: "index",
         run,
         waitForRetry: async (delayMs) => void waits.push(delayMs),
       }),
@@ -151,27 +157,55 @@ describe("memory embedding policy", () => {
   });
 
   it.each([
-    ["valid", 30_000, 30_000, 36_000],
-    ["hostile", Number.MAX_SAFE_INTEGER, 48_000, 60_000],
-  ])("honors and caps a $name structured cooldown", async (_name, retryAfterMs, min, max) => {
-    const run = vi
-      .fn<() => Promise<string>>()
-      .mockRejectedValueOnce(
-        Object.assign(new Error("gemini embeddings failed (429)"), {
-          status: 429,
-          retryAfterMs,
+    ["index", "valid", 30_000, 30_000, 36_000],
+    ["index", "hostile", Number.MAX_SAFE_INTEGER, 48_000, 60_000],
+    ["query", "hostile", 60_000, 6400, 8000],
+  ] as const)(
+    "honors and caps a $profile $name structured cooldown",
+    async (profile, _name, retryAfterMs, min, max) => {
+      const run = vi
+        .fn<() => Promise<string>>()
+        .mockRejectedValueOnce(
+          Object.assign(new Error("gemini embeddings failed (429)"), {
+            status: 429,
+            retryAfterMs,
+          }),
+        )
+        .mockResolvedValueOnce("ok");
+      const waits: number[] = [];
+
+      await expect(
+        runMemoryEmbeddingRetryLoop({
+          profile,
+          run,
+          waitForRetry: async (delayMs) => void waits.push(delayMs),
         }),
-      )
-      .mockResolvedValueOnce("ok");
+      ).resolves.toBe("ok");
+      expectDelayBetween(waits[0], min, max);
+    },
+  );
+
+  it("keeps query-path hostile cooldown waits within the interactive retry budget", async () => {
     const waits: number[] = [];
+    const run = vi.fn(async () => {
+      throw Object.assign(new Error("gemini embeddings failed (429)"), {
+        status: 429,
+        retryAfterMs: 60_000,
+      });
+    });
 
     await expect(
       runMemoryEmbeddingRetryLoop({
+        profile: "query",
         run,
         waitForRetry: async (delayMs) => void waits.push(delayMs),
       }),
-    ).resolves.toBe("ok");
-    expectDelayBetween(waits[0], min, max);
+    ).rejects.toThrow("429");
+
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(waits).toHaveLength(2);
+    expect(waits.every((delayMs) => delayMs <= 8000)).toBe(true);
+    expect(waits.reduce((total, delayMs) => total + delayMs, 0)).toBe(8000);
   });
 
   it("fails fast for typed daily quota exhaustion without a cooldown", async () => {
@@ -186,6 +220,7 @@ describe("memory embedding policy", () => {
 
     await expect(
       runMemoryEmbeddingRetryLoop({
+        profile: "index",
         run,
         waitForRetry,
       }),
@@ -202,6 +237,7 @@ describe("memory embedding policy", () => {
 
     await expect(
       runMemoryEmbeddingRetryLoop({
+        profile: "index",
         run,
         waitForRetry: async (delayMs) => void waits.push(delayMs),
       }),
@@ -222,6 +258,7 @@ describe("memory embedding policy", () => {
 
     await expect(
       runMemoryEmbeddingRetryLoop({
+        profile: "index",
         run,
         waitForRetry,
         signal: controller.signal,
@@ -245,6 +282,7 @@ describe("memory embedding policy", () => {
       });
 
       const pending = runMemoryEmbeddingRetryLoop({
+        profile: "index",
         run,
         waitForRetry,
         signal: controller.signal,
@@ -277,6 +315,7 @@ describe("memory embedding policy", () => {
 
     await expect(
       runMemoryEmbeddingRetryLoop({
+        profile: "index",
         run,
         waitForRetry,
       }),
@@ -286,65 +325,91 @@ describe("memory embedding policy", () => {
     expect(waitForRetry).not.toHaveBeenCalled();
   });
 
-  const RETRY_BOUNDARY_FIXTURES: Array<{ label: string; message: string; expectedCalls: number }> =
-    [
-      // Transient transport/service errors retry up to the short 3-attempt budget.
-      {
-        label: "fetch failed transport error",
-        message: "TypeError: fetch failed | other side closed",
-        expectedCalls: 3,
-      },
-      { label: "undici socket error", message: "undici error: UND_ERR_SOCKET", expectedCalls: 3 },
-      { label: "ECONNRESET read error", message: "read ECONNRESET", expectedCalls: 3 },
-      { label: "socket hang up", message: "socket hang up", expectedCalls: 3 },
-      { label: "ECONNREFUSED", message: "ECONNREFUSED", expectedCalls: 3 },
-      { label: "EHOSTUNREACH", message: "EHOSTUNREACH", expectedCalls: 3 },
-      {
-        label: "embedding batch timeout",
-        message: "memory embeddings batch timed out",
-        expectedCalls: 3,
-      },
-      { label: "5xx service error", message: "HTTP 503: service unavailable", expectedCalls: 3 },
-      // Permanent errors never retry.
-      {
-        label: "worker terminated by user",
-        message: "worker terminated by user",
-        expectedCalls: 1,
-      },
-      {
-        label: "embedding validation failure",
-        message: "embedding validation failed",
-        expectedCalls: 1,
-      },
-      {
-        label: "splittable item-limit error (max/got)",
-        message:
-          "Embeddings API input limit exceeded: max 10, got 33. Request id: fixture-000597000",
-        expectedCalls: 1,
-      },
-      {
-        label: "splittable item-limit error (max input length)",
-        message: "embeddings max input length is 16",
-        expectedCalls: 1,
-      },
-      {
-        label: "HTTP 400 client error",
-        message: "HTTP 400: request id fixture-000597000",
-        expectedCalls: 1,
-      },
-      {
-        label: "431 request headers too large",
-        message: "431 request_headers_too_large",
-        expectedCalls: 1,
-      },
-      // Rate-limit errors retry up to the long 5-attempt budget.
-      { label: "HTTP 429 rate limit", message: "HTTP 429: rate limit", expectedCalls: 5 },
-    ];
+  const RETRY_BOUNDARY_FIXTURES: Array<{
+    label: string;
+    profile?: "index" | "query";
+    message: string;
+    expectedCalls: number;
+  }> = [
+    // Transient transport/service errors retry up to the short 3-attempt budget.
+    {
+      label: "fetch failed transport error",
+      message: "TypeError: fetch failed | other side closed",
+      expectedCalls: 3,
+    },
+    { label: "undici socket error", message: "undici error: UND_ERR_SOCKET", expectedCalls: 3 },
+    { label: "ECONNRESET read error", message: "read ECONNRESET", expectedCalls: 3 },
+    { label: "socket hang up", message: "socket hang up", expectedCalls: 3 },
+    { label: "ECONNREFUSED", message: "ECONNREFUSED", expectedCalls: 3 },
+    { label: "EHOSTUNREACH", message: "EHOSTUNREACH", expectedCalls: 3 },
+    {
+      label: "embedding batch timeout",
+      message: "memory embeddings batch timed out",
+      expectedCalls: 3,
+    },
+    { label: "5xx service error", message: "HTTP 503: service unavailable", expectedCalls: 3 },
+    // Permanent errors never retry.
+    {
+      label: "worker terminated by user",
+      message: "worker terminated by user",
+      expectedCalls: 1,
+    },
+    {
+      label: "embedding validation failure",
+      message: "embedding validation failed",
+      expectedCalls: 1,
+    },
+    {
+      label: "splittable item-limit error (max/got)",
+      message: "Embeddings API input limit exceeded: max 10, got 33. Request id: fixture-000597000",
+      expectedCalls: 1,
+    },
+    {
+      label: "splittable item-limit error (max input length)",
+      message: "embeddings max input length is 16",
+      expectedCalls: 1,
+    },
+    {
+      label: "HTTP 400 client error",
+      message: "HTTP 400: request id fixture-000597000",
+      expectedCalls: 1,
+    },
+    {
+      label: "431 request headers too large",
+      message: "431 request_headers_too_large",
+      expectedCalls: 1,
+    },
+    // Rate-limit errors retry up to the long 5-attempt budget.
+    {
+      label: "HTTP 429 rate limit (index)",
+      profile: "index",
+      message: "HTTP 429: rate limit",
+      expectedCalls: 5,
+    },
+    {
+      label: "HTTP 429 rate limit (query)",
+      profile: "query",
+      message: "HTTP 429: rate limit",
+      expectedCalls: 3,
+    },
+    {
+      label: "HTTP 503 transient error (query)",
+      profile: "query",
+      message: "HTTP 503: service unavailable",
+      expectedCalls: 3,
+    },
+    {
+      label: "HTTP 400 permanent error (query)",
+      profile: "query",
+      message: "HTTP 400: invalid input",
+      expectedCalls: 1,
+    },
+  ];
 
   it.each(RETRY_BOUNDARY_FIXTURES)(
     "retries $label for $expectedCalls total attempt(s)",
-    async ({ message, expectedCalls }) => {
-      expect(await probeRetryAttempts(message)).toBe(expectedCalls);
+    async ({ profile, message, expectedCalls }) => {
+      expect(await probeRetryAttempts(message, profile)).toBe(expectedCalls);
     },
   );
 
@@ -393,6 +458,7 @@ describe("memory embedding policy", () => {
     });
 
     const result = await runMemoryEmbeddingBatchRetryWithSplit({
+      profile: "index",
       items: ["a", "b", "c", "d"],
       run,
       isSplittable: isSplittableMemoryEmbeddingBatchError,
@@ -412,6 +478,7 @@ describe("memory embedding policy", () => {
     const waits: number[] = [];
 
     const result = await runMemoryEmbeddingRetryLoop({
+      profile: "index",
       run: async () => {
         calls += 1;
         if (calls === 1) {
@@ -437,6 +504,7 @@ describe("memory embedding policy", () => {
 
     await expect(
       runMemoryEmbeddingRetryLoop({
+        profile: "index",
         run,
         waitForRetry: async (delayMs) => {
           waits.push(delayMs);
@@ -460,6 +528,7 @@ describe("memory embedding policy", () => {
     });
 
     const result = await runMemoryEmbeddingBatchRetryWithSplit({
+      profile: "index",
       items: ["a", "b", "c", "d"],
       run,
       isSplittable: isSplittableMemoryEmbeddingBatchError,
@@ -489,6 +558,7 @@ describe("memory embedding policy", () => {
 
     await expect(
       runMemoryEmbeddingBatchRetryWithSplit({
+        profile: "index",
         items: ["a", "b"],
         run,
         isSplittable: isSplittableMemoryEmbeddingBatchError,
@@ -505,6 +575,7 @@ describe("memory embedding policy", () => {
 
     await expect(
       runMemoryEmbeddingBatchRetryWithSplit({
+        profile: "index",
         items: ["a", "b"],
         run,
         isSplittable: isSplittableMemoryEmbeddingBatchError,

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -4,12 +4,35 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildMemoryEmbeddingBatches,
   filterNonEmptyMemoryChunks,
-  isRetryableMemoryEmbeddingError,
   isSplittableMemoryEmbeddingBatchError,
-  resolveMemoryEmbeddingRetryDelay,
   runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
 } from "./manager-embedding-policy.js";
+
+function expectDelayBetween(delayMs: number | undefined, min: number, max: number): void {
+  expect(delayMs).toBeGreaterThanOrEqual(min);
+  expect(delayMs).toBeLessThanOrEqual(max);
+}
+
+/**
+ * Probes the frozen retry-class boundary through the public retry loop:
+ * a permanent error stops after one call, a retryable one runs to its
+ * class's exhaustion count (3 for transient, 5 for rate-limit).
+ */
+async function probeRetryAttempts(message: string): Promise<number> {
+  const run = vi.fn(async () => {
+    throw new Error(message);
+  });
+  try {
+    await runMemoryEmbeddingRetryLoop({
+      run,
+      waitForRetry: async () => {},
+    });
+  } catch {
+    // Expected: the loop always rejects since `run` never succeeds.
+  }
+  return run.mock.calls.length;
+}
 
 function chunk(text: string) {
   return {
@@ -91,17 +114,101 @@ describe("memory embedding policy", () => {
 
     const result = await runMemoryEmbeddingRetryLoop({
       run,
-      isRetryable: isRetryableMemoryEmbeddingError,
       waitForRetry: async (delayMs) => {
         waits.push(delayMs);
       },
-      maxAttempts: 3,
-      baseDelayMs: 500,
     });
 
     expect(result).toBe("ok");
     expect(run).toHaveBeenCalledTimes(3);
-    expect(waits).toEqual([500, 1000]);
+    expectDelayBetween(waits[0], 4000, 6000);
+    expectDelayBetween(waits[1], 800, 1200);
+  });
+
+  it("uses the bounded long retry budget for a bare 429", async () => {
+    const run = vi.fn(async () => {
+      throw Object.assign(new Error("gemini embeddings failed (429)"), { status: 429 });
+    });
+    const waits: number[] = [];
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        run,
+        waitForRetry: async (delayMs) => void waits.push(delayMs),
+      }),
+    ).rejects.toThrow("429");
+
+    expect(run).toHaveBeenCalledTimes(5);
+    expect(waits).toHaveLength(4);
+    for (const [index, range] of [
+      [4000, 6000],
+      [8000, 12_000],
+      [16_000, 24_000],
+      [32_000, 48_000],
+    ].entries()) {
+      expectDelayBetween(waits[index], range[0] ?? 0, range[1] ?? 0);
+    }
+  });
+
+  it.each([
+    ["valid", 30_000, 30_000, 36_000],
+    ["hostile", Number.MAX_SAFE_INTEGER, 48_000, 60_000],
+  ])("honors and caps a $name structured cooldown", async (_name, retryAfterMs, min, max) => {
+    const run = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("gemini embeddings failed (429)"), {
+          status: 429,
+          retryAfterMs,
+        }),
+      )
+      .mockResolvedValueOnce("ok");
+    const waits: number[] = [];
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        run,
+        waitForRetry: async (delayMs) => void waits.push(delayMs),
+      }),
+    ).resolves.toBe("ok");
+    expectDelayBetween(waits[0], min, max);
+  });
+
+  it("fails fast for typed daily quota exhaustion without a cooldown", async () => {
+    const quotaError = Object.assign(new Error("Too many tokens per day"), {
+      status: 429,
+      errorCode: "quota_exceeded",
+    });
+    const run = vi.fn(async () => {
+      throw quotaError;
+    });
+    const waitForRetry = vi.fn(async () => {});
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        run,
+        waitForRetry,
+      }),
+    ).rejects.toBe(quotaError);
+    expect(run).toHaveBeenCalledOnce();
+    expect(waitForRetry).not.toHaveBeenCalled();
+  });
+
+  it("keeps 5xx failures on the short retry budget", async () => {
+    const run = vi.fn(async () => {
+      throw Object.assign(new Error("gemini embeddings failed"), { status: 503 });
+    });
+    const waits: number[] = [];
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        run,
+        waitForRetry: async (delayMs) => void waits.push(delayMs),
+      }),
+    ).rejects.toThrow("gemini embeddings failed");
+    expect(run).toHaveBeenCalledTimes(3);
+    expectDelayBetween(waits[0], 400, 600);
+    expectDelayBetween(waits[1], 800, 1200);
   });
 
   it("stops retrying after the caller signal aborts, even for retryable-looking errors", async () => {
@@ -116,10 +223,7 @@ describe("memory embedding policy", () => {
     await expect(
       runMemoryEmbeddingRetryLoop({
         run,
-        isRetryable: isRetryableMemoryEmbeddingError,
         waitForRetry,
-        maxAttempts: 3,
-        baseDelayMs: 500,
         signal: controller.signal,
       }),
     ).rejects.toThrow("memory embeddings query timed out after 60s");
@@ -142,16 +246,13 @@ describe("memory embedding policy", () => {
 
       const pending = runMemoryEmbeddingRetryLoop({
         run,
-        isRetryable: isRetryableMemoryEmbeddingError,
         waitForRetry,
-        maxAttempts: 3,
-        baseDelayMs: 500,
         signal: controller.signal,
       });
       await vi.advanceTimersByTimeAsync(0);
 
       expect(run).toHaveBeenCalledOnce();
-      expect(waitForRetry).toHaveBeenCalledWith(500);
+      expectDelayBetween(waitForRetry.mock.calls[0]?.[0], 400, 600);
       expect(vi.getTimerCount()).toBe(1);
 
       controller.abort(abortReason);
@@ -177,10 +278,7 @@ describe("memory embedding policy", () => {
     await expect(
       runMemoryEmbeddingRetryLoop({
         run,
-        isRetryable: isRetryableMemoryEmbeddingError,
         waitForRetry,
-        maxAttempts: 3,
-        baseDelayMs: 500,
       }),
     ).rejects.toBe(permanentError);
 
@@ -188,7 +286,69 @@ describe("memory embedding policy", () => {
     expect(waitForRetry).not.toHaveBeenCalled();
   });
 
-  it("retries transient socket/network embedding errors", () => {
+  const RETRY_BOUNDARY_FIXTURES: Array<{ label: string; message: string; expectedCalls: number }> =
+    [
+      // Transient transport/service errors retry up to the short 3-attempt budget.
+      {
+        label: "fetch failed transport error",
+        message: "TypeError: fetch failed | other side closed",
+        expectedCalls: 3,
+      },
+      { label: "undici socket error", message: "undici error: UND_ERR_SOCKET", expectedCalls: 3 },
+      { label: "ECONNRESET read error", message: "read ECONNRESET", expectedCalls: 3 },
+      { label: "socket hang up", message: "socket hang up", expectedCalls: 3 },
+      { label: "ECONNREFUSED", message: "ECONNREFUSED", expectedCalls: 3 },
+      { label: "EHOSTUNREACH", message: "EHOSTUNREACH", expectedCalls: 3 },
+      {
+        label: "embedding batch timeout",
+        message: "memory embeddings batch timed out",
+        expectedCalls: 3,
+      },
+      { label: "5xx service error", message: "HTTP 503: service unavailable", expectedCalls: 3 },
+      // Permanent errors never retry.
+      {
+        label: "worker terminated by user",
+        message: "worker terminated by user",
+        expectedCalls: 1,
+      },
+      {
+        label: "embedding validation failure",
+        message: "embedding validation failed",
+        expectedCalls: 1,
+      },
+      {
+        label: "splittable item-limit error (max/got)",
+        message:
+          "Embeddings API input limit exceeded: max 10, got 33. Request id: fixture-000597000",
+        expectedCalls: 1,
+      },
+      {
+        label: "splittable item-limit error (max input length)",
+        message: "embeddings max input length is 16",
+        expectedCalls: 1,
+      },
+      {
+        label: "HTTP 400 client error",
+        message: "HTTP 400: request id fixture-000597000",
+        expectedCalls: 1,
+      },
+      {
+        label: "431 request headers too large",
+        message: "431 request_headers_too_large",
+        expectedCalls: 1,
+      },
+      // Rate-limit errors retry up to the long 5-attempt budget.
+      { label: "HTTP 429 rate limit", message: "HTTP 429: rate limit", expectedCalls: 5 },
+    ];
+
+  it.each(RETRY_BOUNDARY_FIXTURES)(
+    "retries $label for $expectedCalls total attempt(s)",
+    async ({ message, expectedCalls }) => {
+      expect(await probeRetryAttempts(message)).toBe(expectedCalls);
+    },
+  );
+
+  it("identifies splittable transport errors", () => {
     const splittableMessages = [
       "TypeError: fetch failed | other side closed",
       "undici error: UND_ERR_SOCKET",
@@ -197,17 +357,11 @@ describe("memory embedding policy", () => {
     ];
 
     for (const message of splittableMessages) {
-      expect(isRetryableMemoryEmbeddingError(message)).toBe(true);
       expect(isSplittableMemoryEmbeddingBatchError(message)).toBe(true);
     }
-    expect(isRetryableMemoryEmbeddingError("ECONNREFUSED")).toBe(true);
     expect(isSplittableMemoryEmbeddingBatchError("ECONNREFUSED")).toBe(false);
-    expect(isRetryableMemoryEmbeddingError("EHOSTUNREACH")).toBe(true);
     expect(isSplittableMemoryEmbeddingBatchError("EHOSTUNREACH")).toBe(false);
-    expect(isRetryableMemoryEmbeddingError("memory embeddings batch timed out")).toBe(true);
     expect(isSplittableMemoryEmbeddingBatchError("memory embeddings batch timed out")).toBe(false);
-    expect(isRetryableMemoryEmbeddingError("worker terminated by user")).toBe(false);
-    expect(isRetryableMemoryEmbeddingError("embedding validation failed")).toBe(false);
   });
 
   it("recognizes only provider errors with an explicit numeric embedding item limit", () => {
@@ -216,7 +370,6 @@ describe("memory embedding policy", () => {
       "embeddings max input length is 16",
     ]) {
       expect(isSplittableMemoryEmbeddingBatchError(message)).toBe(true);
-      expect(isRetryableMemoryEmbeddingError(message)).toBe(false);
     }
 
     for (const message of [
@@ -227,9 +380,6 @@ describe("memory embedding policy", () => {
     ]) {
       expect(isSplittableMemoryEmbeddingBatchError(message)).toBe(false);
     }
-    expect(isRetryableMemoryEmbeddingError("HTTP 400: request id fixture-000597000")).toBe(false);
-    expect(isRetryableMemoryEmbeddingError("HTTP 429: rate limit")).toBe(true);
-    expect(isRetryableMemoryEmbeddingError("HTTP 503: service unavailable")).toBe(true);
   });
 
   it("splits OpenAI 431 oversized embedding batches without retrying the same request", async () => {
@@ -245,16 +395,12 @@ describe("memory embedding policy", () => {
     const result = await runMemoryEmbeddingBatchRetryWithSplit({
       items: ["a", "b", "c", "d"],
       run,
-      isRetryable: isRetryableMemoryEmbeddingError,
       isSplittable: isSplittableMemoryEmbeddingBatchError,
       waitForRetry: async () => {},
-      maxAttempts: 3,
-      baseDelayMs: 500,
     });
 
     expect(result).toEqual([[97], [98], [99], [100]]);
     expect(run.mock.calls.map(([items]) => items.length)).toEqual([4, 2, 1, 1, 2, 1, 1]);
-    expect(isRetryableMemoryEmbeddingError("431 request_headers_too_large")).toBe(false);
     expect(isSplittableMemoryEmbeddingBatchError("431 request_headers_too_large")).toBe(true);
     expect(isSplittableMemoryEmbeddingBatchError("embedding validation failed at item 4312")).toBe(
       false,
@@ -273,20 +419,17 @@ describe("memory embedding policy", () => {
         }
         return "ok";
       },
-      isRetryable: isRetryableMemoryEmbeddingError,
       waitForRetry: async (delayMs) => {
         waits.push(delayMs);
       },
-      maxAttempts: 3,
-      baseDelayMs: 500,
     });
 
     expect(result).toBe("ok");
     expect(calls).toBe(2);
-    expect(waits).toEqual([500]);
+    expectDelayBetween(waits[0], 4000, 6000);
   });
 
-  it("stops after the configured maximum attempts", async () => {
+  it("stops after the transient attempt budget", async () => {
     const run = vi.fn(async () => {
       throw new Error("TypeError: fetch failed | other side closed");
     });
@@ -295,17 +438,15 @@ describe("memory embedding policy", () => {
     await expect(
       runMemoryEmbeddingRetryLoop({
         run,
-        isRetryable: isRetryableMemoryEmbeddingError,
         waitForRetry: async (delayMs) => {
           waits.push(delayMs);
         },
-        maxAttempts: 3,
-        baseDelayMs: 500,
       }),
     ).rejects.toThrow("fetch failed");
 
     expect(run).toHaveBeenCalledTimes(3);
-    expect(waits).toEqual([500, 1000]);
+    expectDelayBetween(waits[0], 400, 600);
+    expectDelayBetween(waits[1], 800, 1200);
   });
 
   it("splits transport-failed batches after retries are exhausted", async () => {
@@ -321,21 +462,23 @@ describe("memory embedding policy", () => {
     const result = await runMemoryEmbeddingBatchRetryWithSplit({
       items: ["a", "b", "c", "d"],
       run,
-      isRetryable: isRetryableMemoryEmbeddingError,
       isSplittable: isSplittableMemoryEmbeddingBatchError,
       waitForRetry: async (delayMs) => {
         waits.push(delayMs);
       },
-      maxAttempts: 2,
-      baseDelayMs: 500,
       onSplit: ({ itemCount, splitAt }) => {
         splits.push(`${itemCount}:${splitAt}`);
       },
     });
 
     expect(result).toEqual([[97], [98], [99], [100]]);
-    expect(run.mock.calls.map(([items]) => items.length)).toEqual([4, 4, 2, 2, 1, 1, 2, 2, 1, 1]);
-    expect(waits).toEqual([500, 500, 500]);
+    expect(run.mock.calls.map(([items]) => items.length)).toEqual([
+      4, 4, 4, 2, 2, 2, 1, 1, 2, 2, 2, 1, 1,
+    ]);
+    expect(waits).toHaveLength(6);
+    for (const [index, wait] of waits.entries()) {
+      expectDelayBetween(wait, index % 2 === 0 ? 400 : 800, index % 2 === 0 ? 600 : 1200);
+    }
     expect(splits).toEqual(["4:2", "2:1", "2:1"]);
   });
 
@@ -348,14 +491,11 @@ describe("memory embedding policy", () => {
       runMemoryEmbeddingBatchRetryWithSplit({
         items: ["a", "b"],
         run,
-        isRetryable: isRetryableMemoryEmbeddingError,
         isSplittable: isSplittableMemoryEmbeddingBatchError,
         waitForRetry: async () => {},
-        maxAttempts: 1,
-        baseDelayMs: 500,
       }),
     ).rejects.toThrow("429 rate limit");
-    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledTimes(5);
   });
 
   it("does not split whole-endpoint transport outages", async () => {
@@ -367,19 +507,10 @@ describe("memory embedding policy", () => {
       runMemoryEmbeddingBatchRetryWithSplit({
         items: ["a", "b"],
         run,
-        isRetryable: isRetryableMemoryEmbeddingError,
         isSplittable: isSplittableMemoryEmbeddingBatchError,
         waitForRetry: async () => {},
-        maxAttempts: 2,
-        baseDelayMs: 500,
       }),
     ).rejects.toThrow("ECONNREFUSED");
-    expect(run).toHaveBeenCalledTimes(2);
-  });
-
-  it("caps retry jittered delays", () => {
-    expect(resolveMemoryEmbeddingRetryDelay(500, 0, 8000)).toBe(500);
-    expect(resolveMemoryEmbeddingRetryDelay(500, 1, 8000)).toBe(600);
-    expect(resolveMemoryEmbeddingRetryDelay(10_000, 1, 8000)).toBe(8000);
+    expect(run).toHaveBeenCalledTimes(3);
   });
 });

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -4,12 +4,39 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildMemoryEmbeddingBatches,
   filterNonEmptyMemoryChunks,
-  isRetryableMemoryEmbeddingError,
   isSplittableMemoryEmbeddingBatchError,
-  resolveMemoryEmbeddingRetryDelay,
   runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
 } from "./manager-embedding-policy.js";
+
+function expectDelayBetween(delayMs: number | undefined, min: number, max: number): void {
+  expect(delayMs).toBeGreaterThanOrEqual(min);
+  expect(delayMs).toBeLessThanOrEqual(max);
+}
+
+/**
+ * Probes the frozen retry-class boundary through the public retry loop:
+ * a permanent error stops after one call, a retryable one runs to its
+ * class's exhaustion count (3 for transient, 5 for rate-limit).
+ */
+async function probeRetryAttempts(
+  message: string,
+  profile: "index" | "query" = "index",
+): Promise<number> {
+  const run = vi.fn(async () => {
+    throw new Error(message);
+  });
+  try {
+    await runMemoryEmbeddingRetryLoop({
+      profile,
+      run,
+      waitForRetry: async () => {},
+    });
+  } catch {
+    // Expected: the loop always rejects since `run` never succeeds.
+  }
+  return run.mock.calls.length;
+}
 
 function chunk(text: string) {
   return {
@@ -90,19 +117,146 @@ describe("memory embedding policy", () => {
     const waits: number[] = [];
 
     const result = await runMemoryEmbeddingRetryLoop({
+      profile: "index",
       run,
-      isRetryable: isRetryableMemoryEmbeddingError,
       waitForRetry: async (delayMs) => {
         waits.push(delayMs);
       },
-      maxAttempts: 3,
-      baseDelayMs: 500,
     });
 
     expect(result).toBe("ok");
     expect(run).toHaveBeenCalledTimes(3);
-    expect(waits).toEqual([500, 1000]);
+    expectDelayBetween(waits[0], 4000, 6000);
+    expectDelayBetween(waits[1], 800, 1200);
   });
+
+  it("uses the bounded long retry budget for a bare 429", async () => {
+    const run = vi.fn(async () => {
+      throw Object.assign(new Error("gemini embeddings failed (429)"), { status: 429 });
+    });
+    const waits: number[] = [];
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        profile: "index",
+        run,
+        waitForRetry: async (delayMs) => void waits.push(delayMs),
+      }),
+    ).rejects.toThrow("429");
+
+    expect(run).toHaveBeenCalledTimes(5);
+    expect(waits).toHaveLength(4);
+    for (const [index, range] of [
+      [4000, 6000],
+      [8000, 12_000],
+      [16_000, 24_000],
+      [32_000, 48_000],
+    ].entries()) {
+      expectDelayBetween(waits[index], range[0] ?? 0, range[1] ?? 0);
+    }
+  });
+
+  it.each([
+    ["index", "valid", 30_000, 30_000, 36_000],
+    ["index", "hostile", Number.MAX_SAFE_INTEGER, 48_000, 60_000],
+    ["query", "hostile", 60_000, 6400, 8000],
+  ] as const)(
+    "honors and caps a $profile $name structured cooldown",
+    async (profile, _name, retryAfterMs, min, max) => {
+      const run = vi
+        .fn<() => Promise<string>>()
+        .mockRejectedValueOnce(
+          Object.assign(new Error("gemini embeddings failed (429)"), {
+            status: 429,
+            retryAfterMs,
+          }),
+        )
+        .mockResolvedValueOnce("ok");
+      const waits: number[] = [];
+
+      await expect(
+        runMemoryEmbeddingRetryLoop({
+          profile,
+          run,
+          waitForRetry: async (delayMs) => void waits.push(delayMs),
+        }),
+      ).resolves.toBe("ok");
+      expectDelayBetween(waits[0], min, max);
+    },
+  );
+
+  it("keeps query-path hostile cooldown waits within the interactive retry budget", async () => {
+    const waits: number[] = [];
+    const run = vi.fn(async () => {
+      throw Object.assign(new Error("gemini embeddings failed (429)"), {
+        status: 429,
+        retryAfterMs: 60_000,
+      });
+    });
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        profile: "query",
+        run,
+        waitForRetry: async (delayMs) => void waits.push(delayMs),
+      }),
+    ).rejects.toThrow("429");
+
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(waits).toHaveLength(2);
+    expect(waits.every((delayMs) => delayMs <= 8000)).toBe(true);
+    expect(waits.reduce((total, delayMs) => total + delayMs, 0)).toBe(8000);
+  });
+
+  it.each([
+    { errorCode: "quota_exceeded" },
+    { code: "insufficient_quota" },
+    { errorType: "insufficient_quota" },
+    { errorCode: "insufficient_quota", errorType: "rate_limit_error" },
+  ])("fails fast for structured permanent quota without a cooldown: %j", async (fields) => {
+    const quotaError = Object.assign(new Error("Too many tokens per day"), {
+      status: 429,
+      ...fields,
+    });
+    const run = vi.fn(async () => {
+      throw quotaError;
+    });
+    const waitForRetry = vi.fn(async () => {});
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        profile: "index",
+        run,
+        waitForRetry,
+      }),
+    ).rejects.toBe(quotaError);
+    expect(run).toHaveBeenCalledOnce();
+    expect(waitForRetry).not.toHaveBeenCalled();
+  });
+
+  it.each(["index", "query"] as const)(
+    "keeps %s 5xx failures on the short retry budget",
+    async (profile) => {
+      const run = vi.fn(async () => {
+        throw Object.assign(new Error("gemini embeddings failed: upstream rate limit"), {
+          status: 503,
+          retryAfterMs: 60_000,
+        });
+      });
+      const waits: number[] = [];
+
+      await expect(
+        runMemoryEmbeddingRetryLoop({
+          profile,
+          run,
+          waitForRetry: async (delayMs) => void waits.push(delayMs),
+        }),
+      ).rejects.toThrow("gemini embeddings failed");
+      expect(run).toHaveBeenCalledTimes(3);
+      expectDelayBetween(waits[0], 400, 600);
+      expectDelayBetween(waits[1], 800, 1200);
+    },
+  );
 
   it("stops retrying after the caller signal aborts, even for retryable-looking errors", async () => {
     const controller = new AbortController();
@@ -115,11 +269,9 @@ describe("memory embedding policy", () => {
 
     await expect(
       runMemoryEmbeddingRetryLoop({
+        profile: "index",
         run,
-        isRetryable: isRetryableMemoryEmbeddingError,
         waitForRetry,
-        maxAttempts: 3,
-        baseDelayMs: 500,
         signal: controller.signal,
       }),
     ).rejects.toThrow("memory embeddings query timed out after 60s");
@@ -141,17 +293,15 @@ describe("memory embedding policy", () => {
       });
 
       const pending = runMemoryEmbeddingRetryLoop({
+        profile: "index",
         run,
-        isRetryable: isRetryableMemoryEmbeddingError,
         waitForRetry,
-        maxAttempts: 3,
-        baseDelayMs: 500,
         signal: controller.signal,
       });
       await vi.advanceTimersByTimeAsync(0);
 
       expect(run).toHaveBeenCalledOnce();
-      expect(waitForRetry).toHaveBeenCalledWith(500);
+      expectDelayBetween(waitForRetry.mock.calls[0]?.[0], 400, 600);
       expect(vi.getTimerCount()).toBe(1);
 
       controller.abort(abortReason);
@@ -176,11 +326,9 @@ describe("memory embedding policy", () => {
 
     await expect(
       runMemoryEmbeddingRetryLoop({
+        profile: "index",
         run,
-        isRetryable: isRetryableMemoryEmbeddingError,
         waitForRetry,
-        maxAttempts: 3,
-        baseDelayMs: 500,
       }),
     ).rejects.toBe(permanentError);
 
@@ -188,7 +336,95 @@ describe("memory embedding policy", () => {
     expect(waitForRetry).not.toHaveBeenCalled();
   });
 
-  it("retries transient socket/network embedding errors", () => {
+  const RETRY_BOUNDARY_FIXTURES: Array<{
+    label: string;
+    profile?: "index" | "query";
+    message: string;
+    expectedCalls: number;
+  }> = [
+    // Transient transport/service errors retry up to the short 3-attempt budget.
+    {
+      label: "fetch failed transport error",
+      message: "TypeError: fetch failed | other side closed",
+      expectedCalls: 3,
+    },
+    { label: "undici socket error", message: "undici error: UND_ERR_SOCKET", expectedCalls: 3 },
+    { label: "ECONNRESET read error", message: "read ECONNRESET", expectedCalls: 3 },
+    { label: "socket hang up", message: "socket hang up", expectedCalls: 3 },
+    { label: "ECONNREFUSED", message: "ECONNREFUSED", expectedCalls: 3 },
+    { label: "EHOSTUNREACH", message: "EHOSTUNREACH", expectedCalls: 3 },
+    {
+      label: "embedding batch timeout",
+      message: "memory embeddings batch timed out",
+      expectedCalls: 3,
+    },
+    { label: "5xx service error", message: "HTTP 503: service unavailable", expectedCalls: 3 },
+    // Permanent errors never retry.
+    {
+      label: "worker terminated by user",
+      message: "worker terminated by user",
+      expectedCalls: 1,
+    },
+    {
+      label: "embedding validation failure",
+      message: "embedding validation failed",
+      expectedCalls: 1,
+    },
+    {
+      label: "splittable item-limit error (max/got)",
+      message: "Embeddings API input limit exceeded: max 10, got 33. Request id: fixture-000597000",
+      expectedCalls: 1,
+    },
+    {
+      label: "splittable item-limit error (max input length)",
+      message: "embeddings max input length is 16",
+      expectedCalls: 1,
+    },
+    {
+      label: "HTTP 400 client error",
+      message: "HTTP 400: request id fixture-000597000",
+      expectedCalls: 1,
+    },
+    {
+      label: "431 request headers too large",
+      message: "431 request_headers_too_large",
+      expectedCalls: 1,
+    },
+    // Rate-limit errors retry up to the long 5-attempt budget.
+    {
+      label: "HTTP 429 rate limit (index)",
+      profile: "index",
+      message: "HTTP 429: rate limit",
+      expectedCalls: 5,
+    },
+    {
+      label: "HTTP 429 rate limit (query)",
+      profile: "query",
+      message: "HTTP 429: rate limit",
+      expectedCalls: 3,
+    },
+    {
+      label: "HTTP 503 transient error (query)",
+      profile: "query",
+      message: "HTTP 503: service unavailable",
+      expectedCalls: 3,
+    },
+    {
+      label: "HTTP 400 permanent error (query)",
+      profile: "query",
+      message: "HTTP 400: invalid input",
+      expectedCalls: 1,
+    },
+  ];
+
+  it.each(RETRY_BOUNDARY_FIXTURES)(
+    "retries $label for $expectedCalls total attempt(s)",
+    async ({ profile, message, expectedCalls }) => {
+      expect(await probeRetryAttempts(message, profile)).toBe(expectedCalls);
+    },
+  );
+
+  it("identifies splittable transport errors", () => {
     const splittableMessages = [
       "TypeError: fetch failed | other side closed",
       "undici error: UND_ERR_SOCKET",
@@ -197,17 +433,11 @@ describe("memory embedding policy", () => {
     ];
 
     for (const message of splittableMessages) {
-      expect(isRetryableMemoryEmbeddingError(message)).toBe(true);
       expect(isSplittableMemoryEmbeddingBatchError(message)).toBe(true);
     }
-    expect(isRetryableMemoryEmbeddingError("ECONNREFUSED")).toBe(true);
     expect(isSplittableMemoryEmbeddingBatchError("ECONNREFUSED")).toBe(false);
-    expect(isRetryableMemoryEmbeddingError("EHOSTUNREACH")).toBe(true);
     expect(isSplittableMemoryEmbeddingBatchError("EHOSTUNREACH")).toBe(false);
-    expect(isRetryableMemoryEmbeddingError("memory embeddings batch timed out")).toBe(true);
     expect(isSplittableMemoryEmbeddingBatchError("memory embeddings batch timed out")).toBe(false);
-    expect(isRetryableMemoryEmbeddingError("worker terminated by user")).toBe(false);
-    expect(isRetryableMemoryEmbeddingError("embedding validation failed")).toBe(false);
   });
 
   it("recognizes only provider errors with an explicit numeric embedding item limit", () => {
@@ -217,7 +447,6 @@ describe("memory embedding policy", () => {
       'HTTP 400: {"error":{"message":"<400> InternalError.Algo.InvalidParameter: Value error, batch size is invalid, it should not be larger than 10.: input.contents","type":"InvalidParameter","code":"InvalidParameter"}}',
     ]) {
       expect(isSplittableMemoryEmbeddingBatchError(message)).toBe(true);
-      expect(isRetryableMemoryEmbeddingError(message)).toBe(false);
     }
 
     for (const message of [
@@ -232,9 +461,6 @@ describe("memory embedding policy", () => {
     ]) {
       expect(isSplittableMemoryEmbeddingBatchError(message)).toBe(false);
     }
-    expect(isRetryableMemoryEmbeddingError("HTTP 400: request id fixture-000597000")).toBe(false);
-    expect(isRetryableMemoryEmbeddingError("HTTP 429: rate limit")).toBe(true);
-    expect(isRetryableMemoryEmbeddingError("HTTP 503: service unavailable")).toBe(true);
   });
 
   it("splits OpenAI 431 oversized embedding batches without retrying the same request", async () => {
@@ -248,18 +474,15 @@ describe("memory embedding policy", () => {
     });
 
     const result = await runMemoryEmbeddingBatchRetryWithSplit({
+      profile: "index",
       items: ["a", "b", "c", "d"],
       run,
-      isRetryable: isRetryableMemoryEmbeddingError,
       isSplittable: isSplittableMemoryEmbeddingBatchError,
       waitForRetry: async () => {},
-      maxAttempts: 3,
-      baseDelayMs: 500,
     });
 
     expect(result).toEqual([[97], [98], [99], [100]]);
     expect(run.mock.calls.map(([items]) => items.length)).toEqual([4, 2, 1, 1, 2, 1, 1]);
-    expect(isRetryableMemoryEmbeddingError("431 request_headers_too_large")).toBe(false);
     expect(isSplittableMemoryEmbeddingBatchError("431 request_headers_too_large")).toBe(true);
     expect(isSplittableMemoryEmbeddingBatchError("embedding validation failed at item 4312")).toBe(
       false,
@@ -271,6 +494,7 @@ describe("memory embedding policy", () => {
     const waits: number[] = [];
 
     const result = await runMemoryEmbeddingRetryLoop({
+      profile: "index",
       run: async () => {
         calls += 1;
         if (calls === 1) {
@@ -278,20 +502,17 @@ describe("memory embedding policy", () => {
         }
         return "ok";
       },
-      isRetryable: isRetryableMemoryEmbeddingError,
       waitForRetry: async (delayMs) => {
         waits.push(delayMs);
       },
-      maxAttempts: 3,
-      baseDelayMs: 500,
     });
 
     expect(result).toBe("ok");
     expect(calls).toBe(2);
-    expect(waits).toEqual([500]);
+    expectDelayBetween(waits[0], 4000, 6000);
   });
 
-  it("stops after the configured maximum attempts", async () => {
+  it("stops after the transient attempt budget", async () => {
     const run = vi.fn(async () => {
       throw new Error("TypeError: fetch failed | other side closed");
     });
@@ -299,18 +520,17 @@ describe("memory embedding policy", () => {
 
     await expect(
       runMemoryEmbeddingRetryLoop({
+        profile: "index",
         run,
-        isRetryable: isRetryableMemoryEmbeddingError,
         waitForRetry: async (delayMs) => {
           waits.push(delayMs);
         },
-        maxAttempts: 3,
-        baseDelayMs: 500,
       }),
     ).rejects.toThrow("fetch failed");
 
     expect(run).toHaveBeenCalledTimes(3);
-    expect(waits).toEqual([500, 1000]);
+    expectDelayBetween(waits[0], 400, 600);
+    expectDelayBetween(waits[1], 800, 1200);
   });
 
   it("splits transport-failed batches after retries are exhausted", async () => {
@@ -324,23 +544,26 @@ describe("memory embedding policy", () => {
     });
 
     const result = await runMemoryEmbeddingBatchRetryWithSplit({
+      profile: "index",
       items: ["a", "b", "c", "d"],
       run,
-      isRetryable: isRetryableMemoryEmbeddingError,
       isSplittable: isSplittableMemoryEmbeddingBatchError,
       waitForRetry: async (delayMs) => {
         waits.push(delayMs);
       },
-      maxAttempts: 2,
-      baseDelayMs: 500,
       onSplit: ({ itemCount, splitAt }) => {
         splits.push(`${itemCount}:${splitAt}`);
       },
     });
 
     expect(result).toEqual([[97], [98], [99], [100]]);
-    expect(run.mock.calls.map(([items]) => items.length)).toEqual([4, 4, 2, 2, 1, 1, 2, 2, 1, 1]);
-    expect(waits).toEqual([500, 500, 500]);
+    expect(run.mock.calls.map(([items]) => items.length)).toEqual([
+      4, 4, 4, 2, 2, 2, 1, 1, 2, 2, 2, 1, 1,
+    ]);
+    expect(waits).toHaveLength(6);
+    for (const [index, wait] of waits.entries()) {
+      expectDelayBetween(wait, index % 2 === 0 ? 400 : 800, index % 2 === 0 ? 600 : 1200);
+    }
     expect(splits).toEqual(["4:2", "2:1", "2:1"]);
   });
 
@@ -351,16 +574,14 @@ describe("memory embedding policy", () => {
 
     await expect(
       runMemoryEmbeddingBatchRetryWithSplit({
+        profile: "index",
         items: ["a", "b"],
         run,
-        isRetryable: isRetryableMemoryEmbeddingError,
         isSplittable: isSplittableMemoryEmbeddingBatchError,
         waitForRetry: async () => {},
-        maxAttempts: 1,
-        baseDelayMs: 500,
       }),
     ).rejects.toThrow("429 rate limit");
-    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledTimes(5);
   });
 
   it("does not split whole-endpoint transport outages", async () => {
@@ -370,21 +591,13 @@ describe("memory embedding policy", () => {
 
     await expect(
       runMemoryEmbeddingBatchRetryWithSplit({
+        profile: "index",
         items: ["a", "b"],
         run,
-        isRetryable: isRetryableMemoryEmbeddingError,
         isSplittable: isSplittableMemoryEmbeddingBatchError,
         waitForRetry: async () => {},
-        maxAttempts: 2,
-        baseDelayMs: 500,
       }),
     ).rejects.toThrow("ECONNREFUSED");
-    expect(run).toHaveBeenCalledTimes(2);
-  });
-
-  it("caps retry jittered delays", () => {
-    expect(resolveMemoryEmbeddingRetryDelay(500, 0, 8000)).toBe(500);
-    expect(resolveMemoryEmbeddingRetryDelay(500, 1, 8000)).toBe(600);
-    expect(resolveMemoryEmbeddingRetryDelay(10_000, 1, 8000)).toBe(8000);
+    expect(run).toHaveBeenCalledTimes(3);
   });
 });

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -6,6 +6,10 @@ import {
   type EmbeddingInput,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
+import {
+  asOptionalRecord,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 
 type MemoryEmbeddingChunk = {
   text: string;
@@ -59,88 +63,73 @@ const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
 const SPLITTABLE_MEMORY_EMBEDDING_BATCH_ERROR_RE =
   /(request_headers_too_large|request header fields too large|other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted)|\bembeddings (?:api input limit exceeded:\s*max\s+\d+\s*,\s*got\s+\d+|max input length is\s+\d+)\b)/i;
 
-const MEMORY_EMBEDDING_RETRY_POLICY = {
-  transient: { attempts: 3, baseDelayMs: 500, maxDelayMs: 8000 },
-  rateLimit: { attempts: 5, baseDelayMs: 5000, maxDelayMs: 60_000 },
+const SHORT_MEMORY_EMBEDDING_RETRY_BUDGET = {
+  attempts: 3,
+  baseDelayMs: 500,
+  maxDelayMs: 8000,
 } as const;
+const MEMORY_EMBEDDING_RETRY_PROFILES = {
+  index: {
+    transient: SHORT_MEMORY_EMBEDDING_RETRY_BUDGET,
+    rateLimit: { attempts: 5, baseDelayMs: 5000, maxDelayMs: 60_000 },
+    maxTotalWaitMs: Number.POSITIVE_INFINITY,
+  },
+  query: {
+    transient: SHORT_MEMORY_EMBEDDING_RETRY_BUDGET,
+    rateLimit: SHORT_MEMORY_EMBEDDING_RETRY_BUDGET,
+    maxTotalWaitMs: 8000,
+  },
+} as const;
+export type MemoryEmbeddingRetryProfileName = keyof typeof MEMORY_EMBEDDING_RETRY_PROFILES;
 
 export function isSplittableMemoryEmbeddingBatchError(message: string): boolean {
   return SPLITTABLE_MEMORY_EMBEDDING_BATCH_ERROR_RE.test(message);
 }
 
-type MemoryEmbeddingRetryClass = "permanent" | "rate-limit" | "transient";
-
-function readErrorField(error: unknown, field: string): unknown {
-  if (error === null || (typeof error !== "object" && typeof error !== "function")) {
-    return undefined;
-  }
-  try {
-    return Reflect.get(error, field);
-  } catch {
-    return undefined;
-  }
-}
-
 function readMemoryEmbeddingRetryAfterMs(error: unknown): number | undefined {
-  const value = readErrorField(error, "retryAfterMs");
+  const value = asOptionalRecord(error)?.retryAfterMs;
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
 }
 
-function readMemoryEmbeddingStatus(error: unknown): number | undefined {
-  for (const field of ["status", "statusCode"]) {
-    const value = readErrorField(error, field);
-    if (typeof value === "number" && Number.isInteger(value)) {
-      return value;
-    }
-  }
-  return undefined;
-}
-
-function readMemoryEmbeddingErrorCode(error: unknown): string | undefined {
-  for (const field of ["errorCode", "code"]) {
-    const value = readErrorField(error, field);
-    if (typeof value === "string" && value.trim()) {
-      return value.trim().toLowerCase();
-    }
-  }
-  return undefined;
-}
-
-function classifyMemoryEmbeddingRetryError(error: unknown): MemoryEmbeddingRetryClass {
+function resolveMemoryEmbeddingRetryBudget(
+  profile: (typeof MEMORY_EMBEDDING_RETRY_PROFILES)[MemoryEmbeddingRetryProfileName],
+  error: unknown,
+) {
+  const fields = asOptionalRecord(error);
   const message = formatErrorMessage(error);
   const retryAfterMs = readMemoryEmbeddingRetryAfterMs(error);
-  const status = readMemoryEmbeddingStatus(error);
-  if (readMemoryEmbeddingErrorCode(error) === "quota_exceeded" && retryAfterMs === undefined) {
-    return "permanent";
+  const status = [fields?.status, fields?.statusCode].find(
+    (value): value is number => typeof value === "number" && Number.isInteger(value),
+  );
+  const code = normalizeOptionalString(fields?.errorCode) ?? normalizeOptionalString(fields?.code);
+  if (code?.toLowerCase() === "quota_exceeded" && retryAfterMs === undefined) {
+    return undefined;
   }
   if (status === 429 || RATE_LIMITED_MEMORY_EMBEDDING_ERROR_RE.test(message)) {
-    return "rate-limit";
+    return profile.rateLimit;
   }
-  if (RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message)) {
-    return "transient";
-  }
-  if (isSplittableMemoryEmbeddingBatchError(message)) {
-    return "permanent";
-  }
-  return (status !== undefined && status >= 500 && status <= 599) ||
-    RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE.test(message)
-    ? "transient"
-    : "permanent";
+  return RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message) ||
+    (!isSplittableMemoryEmbeddingBatchError(message) &&
+      ((status !== undefined && status >= 500 && status <= 599) ||
+        RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE.test(message)))
+    ? profile.transient
+    : undefined;
 }
 
 export async function runMemoryEmbeddingRetryLoop<T>(params: {
+  profile: MemoryEmbeddingRetryProfileName;
   run: () => Promise<T>;
   waitForRetry: (delayMs: number) => Promise<void>;
   /** Caller-owned cancellation; an aborted caller stops the retry loop. */
   signal?: AbortSignal;
 }): Promise<T> {
-  const transient = MEMORY_EMBEDDING_RETRY_POLICY.transient;
-  const rateLimit = MEMORY_EMBEDDING_RETRY_POLICY.rateLimit;
+  const profile = MEMORY_EMBEDDING_RETRY_PROFILES[params.profile];
+  let remainingWaitMs = profile.maxTotalWaitMs;
   return await retryAsync(params.run, {
-    attempts: rateLimit.attempts,
-    minDelayMs: transient.baseDelayMs,
-    maxDelayMs: rateLimit.maxDelayMs,
-    retryAfterMaxDelayMs: rateLimit.maxDelayMs,
+    attempts: profile.rateLimit.attempts,
+    minDelayMs: profile.transient.baseDelayMs,
+    maxDelayMs: profile.rateLimit.maxDelayMs,
+    retryAfterMaxDelayMs: profile.rateLimit.maxDelayMs,
     jitter: 0.2,
     // Caller cancellation wins even when its timeout resembles a retryable
     // provider error; otherwise abandoned searches start another request.
@@ -148,26 +137,32 @@ export async function runMemoryEmbeddingRetryLoop<T>(params: {
       if (params.signal?.aborted) {
         return false;
       }
-      const retryClass = classifyMemoryEmbeddingRetryError(err);
-      if (retryClass === "permanent") {
-        return false;
-      }
-      return attempt < (retryClass === "rate-limit" ? rateLimit.attempts : transient.attempts);
+      const retryBudget = resolveMemoryEmbeddingRetryBudget(profile, err);
+      return retryBudget !== undefined && attempt < retryBudget.attempts;
     },
     delayMs: ({ attempt, err }) => {
-      const policy =
-        classifyMemoryEmbeddingRetryError(err) === "rate-limit" ? rateLimit : transient;
-      return Math.min(policy.maxDelayMs, policy.baseDelayMs * 2 ** (attempt - 1));
+      const retryBudget = resolveMemoryEmbeddingRetryBudget(profile, err);
+      return retryBudget
+        ? Math.min(retryBudget.maxDelayMs, retryBudget.baseDelayMs * 2 ** (attempt - 1))
+        : 0;
     },
+    // The query profile shares one short budget for both classes, so this gate
+    // also admits hints on transient errors there — accepted: every honored
+    // hint stays under the profile's per-wait cap and cumulative wait ceiling.
     retryAfterMs: (err) =>
-      classifyMemoryEmbeddingRetryError(err) === "rate-limit"
+      resolveMemoryEmbeddingRetryBudget(profile, err) === profile.rateLimit
         ? readMemoryEmbeddingRetryAfterMs(err)
         : undefined,
-    sleep: params.waitForRetry,
+    sleep: async (delayMs) => {
+      const boundedDelayMs = Math.min(delayMs, remainingWaitMs);
+      remainingWaitMs -= boundedDelayMs;
+      await params.waitForRetry(boundedDelayMs);
+    },
   });
 }
 
 export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(params: {
+  profile: MemoryEmbeddingRetryProfileName;
   items: TInput[];
   run: (items: TInput[]) => Promise<TOutput[]>;
   isSplittable: (message: string) => boolean;
@@ -176,6 +171,7 @@ export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(par
 }): Promise<TOutput[]> {
   try {
     return await runMemoryEmbeddingRetryLoop({
+      profile: params.profile,
       run: async () => await params.run(params.items),
       waitForRetry: params.waitForRetry,
     });

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -48,8 +48,10 @@ export function buildMemoryEmbeddingBatches<T extends MemoryEmbeddingChunk>(
   return batches;
 }
 
-const RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE =
-  /(rate[_ ]limit|too many requests|\b(?:429|5\d\d)\b|resource has been exhausted|cloudflare|tokens per day)/i;
+const RATE_LIMITED_MEMORY_EMBEDDING_ERROR_RE =
+  /(rate[_ ]limit|too many requests|\b429\b|resource has been exhausted|tokens per day)/i;
+
+const RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE = /\b5\d\d\b|cloudflare/i;
 
 const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
   /(fetch failed|other side closed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|UND_ERR_|socket hang up|socket terminated|network error|read ECONN|timed out|connection (?:reset|refused|aborted|timed out)|EHOSTUNREACH|ENETUNREACH|ECONNABORTED|EAI_AGAIN)/i;
@@ -57,42 +59,110 @@ const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
 const SPLITTABLE_MEMORY_EMBEDDING_BATCH_ERROR_RE =
   /(request_headers_too_large|request header fields too large|other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted)|\bembeddings (?:api input limit exceeded:\s*max\s+\d+\s*,\s*got\s+\d+|max input length is\s+\d+)\b)/i;
 
+const MEMORY_EMBEDDING_RETRY_POLICY = {
+  transient: { attempts: 3, baseDelayMs: 500, maxDelayMs: 8000 },
+  rateLimit: { attempts: 5, baseDelayMs: 5000, maxDelayMs: 60_000 },
+} as const;
+
 export function isSplittableMemoryEmbeddingBatchError(message: string): boolean {
   return SPLITTABLE_MEMORY_EMBEDDING_BATCH_ERROR_RE.test(message);
 }
 
-export function isRetryableMemoryEmbeddingError(message: string): boolean {
-  return (
-    RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message) ||
-    (!isSplittableMemoryEmbeddingBatchError(message) &&
-      RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE.test(message))
-  );
+type MemoryEmbeddingRetryClass = "permanent" | "rate-limit" | "transient";
+
+function readErrorField(error: unknown, field: string): unknown {
+  if (error === null || (typeof error !== "object" && typeof error !== "function")) {
+    return undefined;
+  }
+  try {
+    return Reflect.get(error, field);
+  } catch {
+    return undefined;
+  }
 }
 
-export function resolveMemoryEmbeddingRetryDelay(
-  delayMs: number,
-  randomValue: number,
-  maxDelayMs: number,
-): number {
-  return Math.min(maxDelayMs, Math.round(delayMs * (1 + randomValue * 0.2)));
+function readMemoryEmbeddingRetryAfterMs(error: unknown): number | undefined {
+  const value = readErrorField(error, "retryAfterMs");
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function readMemoryEmbeddingStatus(error: unknown): number | undefined {
+  for (const field of ["status", "statusCode"]) {
+    const value = readErrorField(error, field);
+    if (typeof value === "number" && Number.isInteger(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function readMemoryEmbeddingErrorCode(error: unknown): string | undefined {
+  for (const field of ["errorCode", "code"]) {
+    const value = readErrorField(error, field);
+    if (typeof value === "string" && value.trim()) {
+      return value.trim().toLowerCase();
+    }
+  }
+  return undefined;
+}
+
+function classifyMemoryEmbeddingRetryError(error: unknown): MemoryEmbeddingRetryClass {
+  const message = formatErrorMessage(error);
+  const retryAfterMs = readMemoryEmbeddingRetryAfterMs(error);
+  const status = readMemoryEmbeddingStatus(error);
+  if (readMemoryEmbeddingErrorCode(error) === "quota_exceeded" && retryAfterMs === undefined) {
+    return "permanent";
+  }
+  if (status === 429 || RATE_LIMITED_MEMORY_EMBEDDING_ERROR_RE.test(message)) {
+    return "rate-limit";
+  }
+  if (RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message)) {
+    return "transient";
+  }
+  if (isSplittableMemoryEmbeddingBatchError(message)) {
+    return "permanent";
+  }
+  return (status !== undefined && status >= 500 && status <= 599) ||
+    RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE.test(message)
+    ? "transient"
+    : "permanent";
 }
 
 export async function runMemoryEmbeddingRetryLoop<T>(params: {
   run: () => Promise<T>;
-  isRetryable: (message: string) => boolean;
   waitForRetry: (delayMs: number) => Promise<void>;
-  maxAttempts: number;
-  baseDelayMs: number;
   /** Caller-owned cancellation; an aborted caller stops the retry loop. */
   signal?: AbortSignal;
 }): Promise<T> {
+  const transient = MEMORY_EMBEDDING_RETRY_POLICY.transient;
+  const rateLimit = MEMORY_EMBEDDING_RETRY_POLICY.rateLimit;
   return await retryAsync(params.run, {
-    attempts: params.maxAttempts,
-    minDelayMs: params.baseDelayMs,
-    maxDelayMs: Number.MAX_SAFE_INTEGER,
+    attempts: rateLimit.attempts,
+    minDelayMs: transient.baseDelayMs,
+    maxDelayMs: rateLimit.maxDelayMs,
+    retryAfterMaxDelayMs: rateLimit.maxDelayMs,
+    jitter: 0.2,
     // Caller cancellation wins even when its timeout resembles a retryable
     // provider error; otherwise abandoned searches start another request.
-    shouldRetry: (err) => !params.signal?.aborted && params.isRetryable(formatErrorMessage(err)),
+    shouldRetry: (err, attempt) => {
+      if (params.signal?.aborted) {
+        return false;
+      }
+      const retryClass = classifyMemoryEmbeddingRetryError(err);
+      if (retryClass === "permanent") {
+        return false;
+      }
+      return attempt < (retryClass === "rate-limit" ? rateLimit.attempts : transient.attempts);
+    },
+    delayMs: ({ attempt, err }) => {
+      const policy =
+        classifyMemoryEmbeddingRetryError(err) === "rate-limit" ? rateLimit : transient;
+      return Math.min(policy.maxDelayMs, policy.baseDelayMs * 2 ** (attempt - 1));
+    },
+    retryAfterMs: (err) =>
+      classifyMemoryEmbeddingRetryError(err) === "rate-limit"
+        ? readMemoryEmbeddingRetryAfterMs(err)
+        : undefined,
     sleep: params.waitForRetry,
   });
 }
@@ -100,20 +170,14 @@ export async function runMemoryEmbeddingRetryLoop<T>(params: {
 export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(params: {
   items: TInput[];
   run: (items: TInput[]) => Promise<TOutput[]>;
-  isRetryable: (message: string) => boolean;
   isSplittable: (message: string) => boolean;
   waitForRetry: (delayMs: number) => Promise<void>;
-  maxAttempts: number;
-  baseDelayMs: number;
   onSplit?: (info: { itemCount: number; splitAt: number; message: string }) => void;
 }): Promise<TOutput[]> {
   try {
     return await runMemoryEmbeddingRetryLoop({
       run: async () => await params.run(params.items),
-      isRetryable: params.isRetryable,
       waitForRetry: params.waitForRetry,
-      maxAttempts: params.maxAttempts,
-      baseDelayMs: params.baseDelayMs,
     });
   } catch (err) {
     const message = formatErrorMessage(err);

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -6,6 +6,10 @@ import {
   type EmbeddingInput,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
+import {
+  asOptionalRecord,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 
 type MemoryEmbeddingChunk = {
   text: string;
@@ -48,8 +52,10 @@ export function buildMemoryEmbeddingBatches<T extends MemoryEmbeddingChunk>(
   return batches;
 }
 
-const RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE =
-  /(rate[_ ]limit|too many requests|\b(?:429|5\d\d)\b|resource has been exhausted|cloudflare|tokens per day)/i;
+const RATE_LIMITED_MEMORY_EMBEDDING_ERROR_RE =
+  /(rate[_ ]limit|too many requests|\b429\b|resource has been exhausted|tokens per day)/i;
+
+const RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE = /\b5\d\d\b|cloudflare/i;
 
 const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
   /(fetch failed|other side closed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|UND_ERR_|socket hang up|socket terminated|network error|read ECONN|timed out|connection (?:reset|refused|aborted|timed out)|EHOSTUNREACH|ENETUNREACH|ECONNABORTED|EAI_AGAIN)/i;
@@ -57,63 +63,128 @@ const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
 const SPLITTABLE_MEMORY_EMBEDDING_BATCH_ERROR_RE =
   /(request_headers_too_large|request header fields too large|other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted)|\bembeddings (?:api input limit exceeded:\s*max\s+\d+\s*,\s*got\s+\d+|max input length is\s+\d+)\b|\bbatch size is invalid,?\s+it should not be larger than\s+\d+\b)/i;
 
+const SHORT_MEMORY_EMBEDDING_RETRY_BUDGET = {
+  attempts: 3,
+  baseDelayMs: 500,
+  maxDelayMs: 8000,
+} as const;
+const MEMORY_EMBEDDING_RETRY_PROFILES = {
+  index: {
+    transient: SHORT_MEMORY_EMBEDDING_RETRY_BUDGET,
+    rateLimit: { attempts: 5, baseDelayMs: 5000, maxDelayMs: 60_000 },
+    maxTotalWaitMs: Number.POSITIVE_INFINITY,
+  },
+  query: {
+    transient: SHORT_MEMORY_EMBEDDING_RETRY_BUDGET,
+    rateLimit: SHORT_MEMORY_EMBEDDING_RETRY_BUDGET,
+    maxTotalWaitMs: 8000,
+  },
+} as const;
+export type MemoryEmbeddingRetryProfileName = keyof typeof MEMORY_EMBEDDING_RETRY_PROFILES;
+
+type MemoryEmbeddingRetryBudget = {
+  attempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  retryAfterMs?: number;
+};
+
 export function isSplittableMemoryEmbeddingBatchError(message: string): boolean {
   return SPLITTABLE_MEMORY_EMBEDDING_BATCH_ERROR_RE.test(message);
 }
 
-export function isRetryableMemoryEmbeddingError(message: string): boolean {
-  return (
-    RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message) ||
-    (!isSplittableMemoryEmbeddingBatchError(message) &&
-      RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE.test(message))
-  );
+function readMemoryEmbeddingRetryAfterMs(error: unknown): number | undefined {
+  const value = asOptionalRecord(error)?.retryAfterMs;
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
 }
 
-export function resolveMemoryEmbeddingRetryDelay(
-  delayMs: number,
-  randomValue: number,
-  maxDelayMs: number,
-): number {
-  return Math.min(maxDelayMs, Math.round(delayMs * (1 + randomValue * 0.2)));
+function resolveMemoryEmbeddingRetryBudget(
+  profile: (typeof MEMORY_EMBEDDING_RETRY_PROFILES)[MemoryEmbeddingRetryProfileName],
+  error: unknown,
+): MemoryEmbeddingRetryBudget | undefined {
+  const fields = asOptionalRecord(error);
+  const message = formatErrorMessage(error);
+  const retryAfterMs = readMemoryEmbeddingRetryAfterMs(error);
+  const status = [fields?.status, fields?.statusCode].find(
+    (value): value is number => typeof value === "number" && Number.isInteger(value),
+  );
+  const permanentQuota = [fields?.errorCode, fields?.code, fields?.errorType].some((value) => {
+    const code = normalizeOptionalString(value)?.toLowerCase();
+    return code === "quota_exceeded" || code === "insufficient_quota";
+  });
+  if (permanentQuota && retryAfterMs === undefined) {
+    return undefined;
+  }
+  if (status === 429) {
+    return { ...profile.rateLimit, retryAfterMs };
+  }
+  if (status !== undefined) {
+    return status >= 500 && status <= 599 ? profile.transient : undefined;
+  }
+  if (RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message)) {
+    return profile.transient;
+  }
+  if (isSplittableMemoryEmbeddingBatchError(message)) {
+    return undefined;
+  }
+  if (RATE_LIMITED_MEMORY_EMBEDDING_ERROR_RE.test(message)) {
+    return { ...profile.rateLimit, retryAfterMs };
+  }
+  return RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE.test(message) ? profile.transient : undefined;
 }
 
 export async function runMemoryEmbeddingRetryLoop<T>(params: {
+  profile: MemoryEmbeddingRetryProfileName;
   run: () => Promise<T>;
-  isRetryable: (message: string) => boolean;
   waitForRetry: (delayMs: number) => Promise<void>;
-  maxAttempts: number;
-  baseDelayMs: number;
   /** Caller-owned cancellation; an aborted caller stops the retry loop. */
   signal?: AbortSignal;
 }): Promise<T> {
+  const profile = MEMORY_EMBEDDING_RETRY_PROFILES[params.profile];
+  let remainingWaitMs = profile.maxTotalWaitMs;
   return await retryAsync(params.run, {
-    attempts: params.maxAttempts,
-    minDelayMs: params.baseDelayMs,
-    maxDelayMs: Number.MAX_SAFE_INTEGER,
+    attempts: profile.rateLimit.attempts,
+    minDelayMs: profile.transient.baseDelayMs,
+    maxDelayMs: profile.rateLimit.maxDelayMs,
+    retryAfterMaxDelayMs: profile.rateLimit.maxDelayMs,
+    jitter: 0.2,
     // Caller cancellation wins even when its timeout resembles a retryable
     // provider error; otherwise abandoned searches start another request.
-    shouldRetry: (err) => !params.signal?.aborted && params.isRetryable(formatErrorMessage(err)),
-    sleep: params.waitForRetry,
+    shouldRetry: (err, attempt) => {
+      if (params.signal?.aborted) {
+        return false;
+      }
+      const retryBudget = resolveMemoryEmbeddingRetryBudget(profile, err);
+      return retryBudget !== undefined && attempt < retryBudget.attempts;
+    },
+    delayMs: ({ attempt, err }) => {
+      const retryBudget = resolveMemoryEmbeddingRetryBudget(profile, err);
+      return retryBudget
+        ? Math.min(retryBudget.maxDelayMs, retryBudget.baseDelayMs * 2 ** (attempt - 1))
+        : 0;
+    },
+    retryAfterMs: (err) => resolveMemoryEmbeddingRetryBudget(profile, err)?.retryAfterMs,
+    sleep: async (delayMs) => {
+      const boundedDelayMs = Math.min(delayMs, remainingWaitMs);
+      remainingWaitMs -= boundedDelayMs;
+      await params.waitForRetry(boundedDelayMs);
+    },
   });
 }
 
 export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(params: {
+  profile: MemoryEmbeddingRetryProfileName;
   items: TInput[];
   run: (items: TInput[]) => Promise<TOutput[]>;
-  isRetryable: (message: string) => boolean;
   isSplittable: (message: string) => boolean;
   waitForRetry: (delayMs: number) => Promise<void>;
-  maxAttempts: number;
-  baseDelayMs: number;
   onSplit?: (info: { itemCount: number; splitAt: number; message: string }) => void;
 }): Promise<TOutput[]> {
   try {
     return await runMemoryEmbeddingRetryLoop({
+      profile: params.profile,
       run: async () => await params.run(params.items),
-      isRetryable: params.isRetryable,
       waitForRetry: params.waitForRetry,
-      maxAttempts: params.maxAttempts,
-      baseDelayMs: params.baseDelayMs,
     });
   } catch (err) {
     const message = formatErrorMessage(err);

--- a/extensions/openai/embedding-provider.test.ts
+++ b/extensions/openai/embedding-provider.test.ts
@@ -345,7 +345,7 @@ describe("OpenAI embedding provider HTTP contract", () => {
         if (mode === "first request failure") {
           server.requests[0]?.response.writeHead(503).end("fixture rejected");
           await expect(outcome).resolves.toMatchObject({
-            error: { message: expect.stringContaining("openai embeddings failed: 503") },
+            error: { message: expect.stringContaining("openai embeddings failed (503)") },
           });
           // Promise.all rejects early; it must not cancel the still-running sibling.
           expect(server.requests[1]?.closed).toBe(false);

--- a/packages/memory-host-sdk/src/host/batch-http.test.ts
+++ b/packages/memory-host-sdk/src/host/batch-http.test.ts
@@ -1,114 +1,87 @@
 // Memory Host SDK tests cover batch http behavior.
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRetryRunner } from "@openclaw/retry";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { postJsonWithRetry } from "./batch-http.js";
+import { withRemoteHttpResponse } from "./remote-http.js";
 
-vi.mock("./post-json.js", () => ({
-  postJson: vi.fn(),
+vi.mock("./remote-http.js", () => ({
+  withRemoteHttpResponse: vi.fn(),
 }));
 
-type RetryOptions = {
-  attempts: number;
-  minDelayMs: number;
-  maxDelayMs: number;
-  shouldRetry: (err: unknown) => boolean;
-};
-
-type PostJsonParams = {
-  url?: unknown;
-  headers?: unknown;
-  body?: unknown;
-  errorPrefix?: unknown;
-  attachStatus?: unknown;
-};
-
-function requirePostJsonParams(
-  postJsonMock: ReturnType<typeof vi.mocked<typeof import("./post-json.js").postJson>>,
-): PostJsonParams {
-  const [call] = postJsonMock.mock.calls;
-  if (!call) {
-    throw new Error("expected postJson call");
-  }
-  const [params] = call;
-  if (typeof params !== "object" || params === null || Array.isArray(params)) {
-    throw new Error("expected postJson params to be an object");
-  }
-  return params;
-}
-
-function requireFirstRetryOptions(retryAsyncMock: ReturnType<typeof vi.fn>): RetryOptions {
-  const call = retryAsyncMock.mock.calls[0];
-  const options = call?.[1] as RetryOptions | undefined;
-  if (!options) {
-    throw new Error("expected retry options");
-  }
-  return options;
-}
+const remoteHttpMock = vi.mocked(withRemoteHttpResponse);
 
 describe("postJsonWithRetry", () => {
-  let postJsonMock: ReturnType<typeof vi.mocked<typeof import("./post-json.js").postJson>>;
-  let postJsonWithRetry: typeof import("./batch-http.js").postJsonWithRetry;
-  let retryAsyncMock: ReturnType<typeof vi.fn>;
-
-  beforeAll(async () => {
-    ({ postJsonWithRetry } = await import("./batch-http.js"));
-    const postJsonModule = await import("./post-json.js");
-    postJsonMock = vi.mocked(postJsonModule.postJson);
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
-    retryAsyncMock = vi.fn(async (run: () => Promise<unknown>) => await run());
   });
 
-  it("posts JSON and returns parsed response payload", async () => {
-    postJsonMock.mockImplementationOnce(async (params) => {
-      return await params.parse({ ok: true, ids: [1, 2] });
-    });
+  it("returns the batch payload after a transient failure", async () => {
+    remoteHttpMock
+      .mockImplementationOnce(async (params) =>
+        params.onResponse(new Response("busy", { status: 503 })),
+      )
+      .mockImplementationOnce(async (params) =>
+        params.onResponse(Response.json({ ok: true, ids: [1, 2] })),
+      );
+    const waits: number[] = [];
 
-    const result = await postJsonWithRetry<{ ok: boolean; ids: number[] }>({
-      url: "https://memory.example/v1/batch",
-      headers: { Authorization: "Bearer test" },
-      body: { chunks: ["a", "b"] },
-      errorPrefix: "memory batch failed",
-      retryImpl: retryAsyncMock as typeof import("@openclaw/retry").retryAsync,
-    });
+    await expect(
+      postJsonWithRetry({
+        url: "https://memory.example/v1/batch",
+        headers: {},
+        body: { chunks: ["a", "b"] },
+        errorPrefix: "memory batch failed",
+        retryImpl: createRetryRunner({
+          random: () => 0.5,
+          sleep: async (delayMs) => void waits.push(delayMs),
+        }),
+      }),
+    ).resolves.toEqual({ ok: true, ids: [1, 2] });
 
-    expect(result).toEqual({ ok: true, ids: [1, 2] });
-    const postJsonParams = requirePostJsonParams(postJsonMock);
-    expect(postJsonParams.url).toBe("https://memory.example/v1/batch");
-    expect(postJsonParams.headers).toEqual({ Authorization: "Bearer test" });
-    expect(postJsonParams.body).toEqual({ chunks: ["a", "b"] });
-    expect(postJsonParams.errorPrefix).toBe("memory batch failed");
-    expect(postJsonParams.attachStatus).toBe(true);
-
-    const retryOptions = requireFirstRetryOptions(retryAsyncMock);
-    expect(retryOptions.attempts).toBe(3);
-    expect(retryOptions.minDelayMs).toBe(300);
-    expect(retryOptions.maxDelayMs).toBe(2000);
-    expect(retryOptions.shouldRetry({ status: 429 })).toBe(true);
-    expect(retryOptions.shouldRetry({ status: 503 })).toBe(true);
-    expect(retryOptions.shouldRetry({ status: 400 })).toBe(false);
+    expect(remoteHttpMock).toHaveBeenCalledTimes(2);
+    expect(waits).toEqual([300]);
   });
 
-  it("attaches status to non-ok errors", async () => {
-    postJsonMock.mockRejectedValueOnce(
-      Object.assign(new Error("memory batch failed: 503 backend down"), { status: 503 }),
+  it.each([429, 503])("keeps HTTP %s on the existing short batch retry budget", async (status) => {
+    remoteHttpMock.mockImplementation(async (params) =>
+      params.onResponse(new Response("retry later", { status, headers: { "Retry-After": "60" } })),
     );
+    const waits: number[] = [];
 
-    let error: unknown;
-    try {
-      await postJsonWithRetry({
+    await expect(
+      postJsonWithRetry({
+        url: "https://memory.example/v1/batch",
+        headers: {},
+        body: { chunks: ["a"] },
+        errorPrefix: "memory batch failed",
+        retryImpl: createRetryRunner({
+          random: () => 0.5,
+          sleep: async (delayMs) => void waits.push(delayMs),
+        }),
+      }),
+    ).rejects.toMatchObject({ status, retryAfterMs: 60_000 });
+
+    expect(remoteHttpMock).toHaveBeenCalledTimes(3);
+    expect(waits).toEqual([300, 600]);
+  });
+
+  it("does not retry rejected batch input", async () => {
+    remoteHttpMock.mockImplementationOnce(async (params) =>
+      params.onResponse(new Response("invalid input", { status: 400 })),
+    );
+    const sleep = vi.fn(async () => {});
+
+    await expect(
+      postJsonWithRetry({
         url: "https://memory.example/v1/batch",
         headers: {},
         body: { chunks: [] },
         errorPrefix: "memory batch failed",
-        retryImpl: retryAsyncMock as typeof import("@openclaw/retry").retryAsync,
-      });
-    } catch (caught) {
-      error = caught;
-    }
+        retryImpl: createRetryRunner({ sleep }),
+      }),
+    ).rejects.toMatchObject({ status: 400, message: "memory batch failed (400): invalid input" });
 
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toBe("memory batch failed: 503 backend down");
-    expect((error as { status?: unknown }).status).toBe(503);
+    expect(remoteHttpMock).toHaveBeenCalledOnce();
+    expect(sleep).not.toHaveBeenCalled();
   });
 });

--- a/packages/memory-host-sdk/src/host/batch-http.ts
+++ b/packages/memory-host-sdk/src/host/batch-http.ts
@@ -24,7 +24,6 @@ export async function postJsonWithRetry<T>(params: {
         fetchImpl: params.fetchImpl,
         body: params.body,
         errorPrefix: params.errorPrefix,
-        attachStatus: true,
         parse: async (payload) => payload as T,
       });
     },

--- a/packages/memory-host-sdk/src/host/openclaw-runtime-network.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime-network.ts
@@ -1,6 +1,12 @@
 // Narrow network/runtime facade re-exported for memory remote HTTP helpers.
+import type { createProviderHttpError as CreateProviderHttpError } from "../../../../src/agents/provider-http-errors.js";
 
 export { fetchWithSsrFGuard } from "../../../../src/infra/net/fetch-guard.js";
 export { shouldUseEnvHttpProxyForUrl } from "../../../../src/infra/net/proxy-env.js";
 export { ssrfPolicyFromHttpBaseUrlAllowedHostname } from "../../../../src/infra/net/ssrf.js";
 export type { SsrFPolicy } from "../../../../src/infra/net/ssrf.js";
+
+export const createProviderHttpError: typeof CreateProviderHttpError = async (...args) => {
+  const http = await import("../../../../src/agents/provider-http-errors.js");
+  return http.createProviderHttpError(...args);
+};

--- a/packages/memory-host-sdk/src/host/post-json.test.ts
+++ b/packages/memory-host-sdk/src/host/post-json.test.ts
@@ -75,8 +75,8 @@ describe("postJson", () => {
     });
   });
 
-  it("applies abort signals while reading successful response bodies", async () => {
-    const fixture = createPendingResponse();
+  it.each([200, 429])("aborts response body reads for HTTP %s", async (status) => {
+    const fixture = createPendingResponse({ status });
     const controller = new AbortController();
     const expected = new Error("body aborted");
     remoteHttpMock.mockImplementationOnce(async (params) => {
@@ -112,28 +112,30 @@ describe("postJson", () => {
     }
   });
 
-  it("attaches status to thrown error when requested", async () => {
+  it("preserves HTTP cooldown and structured quota metadata", async () => {
     remoteHttpMock.mockImplementationOnce(async (params) => {
-      return await params.onResponse(textResponse("bad gateway", 502));
+      return await params.onResponse(
+        new Response(
+          JSON.stringify({ error: { code: "insufficient_quota", message: "Quota exhausted" } }),
+          { status: 429, headers: { "Retry-After": "18" } },
+        ),
+      );
     });
 
-    let error: unknown;
-    try {
-      await postJson({
+    await expect(
+      postJson({
         url: "https://memory.example/v1/post",
         headers: {},
         body: {},
         errorPrefix: "post failed",
-        attachStatus: true,
         parse: () => ({}),
-      });
-    } catch (caught) {
-      error = caught;
-    }
-
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toBe("post failed: 502 bad gateway");
-    expect((error as { status?: unknown }).status).toBe(502);
+      }),
+    ).rejects.toMatchObject({
+      status: 429,
+      statusCode: 429,
+      errorCode: "insufficient_quota",
+      retryAfterMs: 18_000,
+    });
   });
 
   it("bounds non-ok response bodies before formatting the error", async () => {
@@ -158,7 +160,7 @@ describe("postJson", () => {
         errorPrefix: "post failed",
         parse: () => ({}),
       }),
-    ).rejects.toThrow(`post failed: 502 ${"x".repeat(1_000)}... [truncated]`);
+    ).rejects.toMatchObject({ status: 502, errorBody: `${"x".repeat(499)}…` });
     expect(canceled).toBe(true);
   });
 

--- a/packages/memory-host-sdk/src/host/post-json.ts
+++ b/packages/memory-host-sdk/src/host/post-json.ts
@@ -1,4 +1,4 @@
-import type { SsrFPolicy } from "./openclaw-runtime-network.js";
+import { createProviderHttpError, type SsrFPolicy } from "./openclaw-runtime-network.js";
 import { withRemoteHttpResponse } from "./remote-http.js";
 import { readResponseJsonWithLimit } from "./response-snippet.js";
 
@@ -28,9 +28,6 @@ export async function postJson<T>(params: {
     },
     onResponse: async (res) => {
       if (!res.ok) {
-        // Keep provider normalization off the memory host's eager import closure.
-        const { createProviderHttpError } =
-          await import("../../../../src/agents/provider-http-errors.js");
         throw await createProviderHttpError(res, params.errorPrefix, {
           requestHeaders: params.headers,
           signal: params.signal,

--- a/packages/memory-host-sdk/src/host/post-json.ts
+++ b/packages/memory-host-sdk/src/host/post-json.ts
@@ -1,14 +1,10 @@
-import { formatErrorMessage } from "./error-utils.js";
 import type { SsrFPolicy } from "./openclaw-runtime-network.js";
 import { withRemoteHttpResponse } from "./remote-http.js";
-import {
-  readMemoryHostResponseTextSnippet,
-  readResponseJsonWithLimit,
-} from "./response-snippet.js";
+import { readResponseJsonWithLimit } from "./response-snippet.js";
 
 // Shared JSON POST helper for guarded remote memory provider calls.
 
-/** POST JSON, parse bounded response JSON, and attach status metadata when requested. */
+/** POST JSON, parse bounded response JSON, and preserve provider error metadata. */
 export async function postJson<T>(params: {
   url: string;
   headers: Record<string, string>;
@@ -17,7 +13,6 @@ export async function postJson<T>(params: {
   signal?: AbortSignal;
   body: unknown;
   errorPrefix: string;
-  attachStatus?: boolean;
   maxResponseBytes?: number;
   parse: (payload: unknown) => T | Promise<T>;
 }): Promise<T> {
@@ -33,16 +28,14 @@ export async function postJson<T>(params: {
     },
     onResponse: async (res) => {
       if (!res.ok) {
-        const text = await readMemoryHostResponseTextSnippet(res, { signal: params.signal });
-        const err = new Error(
-          `${params.errorPrefix}: ${res.status} ${formatErrorMessage(text)}`,
-        ) as Error & {
-          status?: number;
-        };
-        if (params.attachStatus) {
-          err.status = res.status;
-        }
-        throw err;
+        // Keep provider normalization off the memory host's eager import closure.
+        const { createProviderHttpError } =
+          await import("../../../../src/agents/provider-http-errors.js");
+        throw await createProviderHttpError(res, params.errorPrefix, {
+          requestHeaders: params.headers,
+          signal: params.signal,
+          maxBodyBytes: 8 * 1024,
+        });
       }
       const payload = await readResponseJsonWithLimit(res, {
         errorPrefix: params.errorPrefix,

--- a/packages/memory-host-sdk/src/host/remote-error-redaction.test.ts
+++ b/packages/memory-host-sdk/src/host/remote-error-redaction.test.ts
@@ -105,8 +105,8 @@ describe("memory remote error redaction", { concurrent: false }, () => {
       }).catch((cause: unknown) => cause);
 
       expect(error).toBeInstanceOf(Error);
-      expect((error as Error).message).toContain("embedding fetch failed: 401");
-      expect((error as Error).message).toContain("Authorization: bearer ");
+      expect((error as Error).message).toContain("embedding fetch failed (401)");
+      expect((error as Error).message).toContain("Authorization: ***");
       expect((error as Error).message).not.toContain(API_KEY);
       expect((error as Error).message).not.toContain(UNIQUE_NEEDLE);
 
@@ -166,7 +166,6 @@ describe("memory remote error redaction", { concurrent: false }, () => {
         ssrfPolicy: buildRemoteBaseUrlPolicy(baseUrl),
         body: {},
         errorPrefix: "post failed",
-        attachStatus: true,
         parse: (payload) => payload,
       });
 
@@ -180,7 +179,7 @@ describe("memory remote error redaction", { concurrent: false }, () => {
       const benignError = await request("/v1/post/benign").catch((cause: unknown) => cause);
       expect(benignError).toBeInstanceOf(Error);
       expect((benignError as { status?: unknown }).status).toBe(400);
-      expect((benignError as Error).message).toBe("post failed: 400 harmless diagnostic");
+      expect((benignError as Error).message).toBe("post failed (400): harmless diagnostic");
     } finally {
       await closeServer(server);
     }

--- a/src/agents/provider-http-errors.test.ts
+++ b/src/agents/provider-http-errors.test.ts
@@ -304,6 +304,81 @@ describe("provider error utils", () => {
     expect(providerError.errorBody).not.toContain("sk-secret1234567890abcd");
   });
 
+  it.each([
+    ["delta seconds", "12", 12_000],
+    ["HTTP date", "Fri, 01 May 2026 12:00:05 GMT", 5_000],
+    ["past HTTP date", "Fri, 01 May 2026 11:59:55 GMT", 0],
+  ])("preserves Retry-After $name as structured milliseconds", async (_name, value, expected) => {
+    const now = Date.UTC(2026, 4, 1, 12, 0, 0);
+    // Shared-worker runs (--isolate=false): restore Date.now even on assertion failure.
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      const error = await createProviderHttpError(
+        new Response(null, { status: 429, headers: { "Retry-After": value } }),
+        "Provider API error",
+      );
+
+      expect(error).toMatchObject({ retryAfterMs: expected });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("uses the largest valid provider cooldown minimum", async () => {
+    const error = await createProviderHttpError(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 429,
+            status: "RESOURCE_EXHAUSTED",
+            details: [
+              {
+                "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                retryDelay: "21.549315790s",
+              },
+            ],
+          },
+        }),
+        { status: 429, headers: { "Retry-After": "30" } },
+      ),
+      "Provider API error",
+    );
+
+    expect(error).toMatchObject({ retryAfterMs: 30_000 });
+  });
+
+  it.each([
+    ["negative header", { header: "-1" }],
+    ["unsafe header", { header: "9007199254741" }],
+    ["negative RetryInfo", { retryDelay: "-1s" }],
+    ["malformed RetryInfo", { retryDelay: "NaNs" }],
+    ["over-precise RetryInfo", { retryDelay: "1.0000000001s" }],
+    ["unsafe RetryInfo", { retryDelay: "9007199254741s" }],
+  ])("ignores $name cooldown hints", async (_name, value) => {
+    const body =
+      "retryDelay" in value
+        ? JSON.stringify({
+            error: {
+              details: [
+                {
+                  "@type": "type.googleapis.com/google.rpc.RetryInfo",
+                  retryDelay: value.retryDelay,
+                },
+              ],
+            },
+          })
+        : null;
+    const error = await createProviderHttpError(
+      new Response(body, {
+        status: 429,
+        headers: "header" in value ? { "Retry-After": value.header } : undefined,
+      }),
+      "Provider API error",
+    );
+
+    expect((error as ProviderHttpError).retryAfterMs).toBeUndefined();
+  });
+
   it("keeps legacy HTTP status formatting while sharing provider parsing", async () => {
     const response = new Response(
       JSON.stringify({

--- a/src/agents/provider-http-errors.test.ts
+++ b/src/agents/provider-http-errors.test.ts
@@ -324,54 +324,14 @@ describe("provider error utils", () => {
     }
   });
 
-  it("uses the largest valid provider cooldown minimum", async () => {
-    const error = await createProviderHttpError(
-      new Response(
-        JSON.stringify({
-          error: {
-            code: 429,
-            status: "RESOURCE_EXHAUSTED",
-            details: [
-              {
-                "@type": "type.googleapis.com/google.rpc.RetryInfo",
-                retryDelay: "21.549315790s",
-              },
-            ],
-          },
-        }),
-        { status: 429, headers: { "Retry-After": "30" } },
-      ),
-      "Provider API error",
-    );
-
-    expect(error).toMatchObject({ retryAfterMs: 30_000 });
-  });
-
   it.each([
     ["negative header", { header: "-1" }],
     ["unsafe header", { header: "9007199254741" }],
-    ["negative RetryInfo", { retryDelay: "-1s" }],
-    ["malformed RetryInfo", { retryDelay: "NaNs" }],
-    ["over-precise RetryInfo", { retryDelay: "1.0000000001s" }],
-    ["unsafe RetryInfo", { retryDelay: "9007199254741s" }],
   ])("ignores $name cooldown hints", async (_name, value) => {
-    const body =
-      "retryDelay" in value
-        ? JSON.stringify({
-            error: {
-              details: [
-                {
-                  "@type": "type.googleapis.com/google.rpc.RetryInfo",
-                  retryDelay: value.retryDelay,
-                },
-              ],
-            },
-          })
-        : null;
     const error = await createProviderHttpError(
-      new Response(body, {
+      new Response(null, {
         status: 429,
-        headers: "header" in value ? { "Retry-After": value.header } : undefined,
+        headers: { "Retry-After": value.header },
       }),
       "Provider API error",
     );

--- a/src/agents/provider-http-errors.test.ts
+++ b/src/agents/provider-http-errors.test.ts
@@ -449,6 +449,41 @@ describe("provider error utils", () => {
     expect(providerError.errorBody).not.toContain("sk-secret1234567890abcd");
   });
 
+  it.each([
+    ["delta seconds", "12", 12_000],
+    ["HTTP date", "Fri, 01 May 2026 12:00:05 GMT", 5_000],
+    ["past HTTP date", "Fri, 01 May 2026 11:59:55 GMT", 0],
+  ])("preserves Retry-After $name as structured milliseconds", async (_name, value, expected) => {
+    const now = Date.UTC(2026, 4, 1, 12, 0, 0);
+    // Shared-worker runs (--isolate=false): restore Date.now even on assertion failure.
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      const error = await createProviderHttpError(
+        new Response(null, { status: 429, headers: { "Retry-After": value } }),
+        "Provider API error",
+      );
+
+      expect(error).toMatchObject({ retryAfterMs: expected });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it.each([
+    ["negative header", { header: "-1" }],
+    ["unsafe header", { header: "9007199254741" }],
+  ])("ignores $name cooldown hints", async (_name, value) => {
+    const error = await createProviderHttpError(
+      new Response(null, {
+        status: 429,
+        headers: { "Retry-After": value.header },
+      }),
+      "Provider API error",
+    );
+
+    expect((error as ProviderHttpError).retryAfterMs).toBeUndefined();
+  });
+
   it("keeps legacy HTTP status formatting while sharing provider parsing", async () => {
     const response = new Response(
       JSON.stringify({

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -12,6 +12,7 @@ import {
   readResponseWithLimit,
   type ReadResponseTextPrefixOptions,
 } from "../infra/http-body.js";
+import { parseRetryAfterHeaderSeconds } from "../infra/retry-after.js";
 import { redactSensitiveText, redactToolPayloadText } from "../logging/redact.js";
 import type { ModelProviderRequestTransportOverrides } from "./provider-request-config.js";
 import { redactProviderResponseErrorText } from "./provider-request-header-redaction.js";
@@ -213,7 +214,53 @@ type ProviderErrorPayloadMetadata = {
   detail?: string;
   code?: string;
   type?: string;
+  retryAfterMs?: number;
 };
+
+const GOOGLE_RETRY_INFO_TYPE = "type.googleapis.com/google.rpc.RetryInfo";
+const GOOGLE_RETRY_DELAY_RE = /^(\d+)(?:\.(\d{1,9}))?s$/u;
+
+function parseGoogleRetryDelayMs(value: unknown): number | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const match = GOOGLE_RETRY_DELAY_RE.exec(value);
+  if (!match) {
+    return undefined;
+  }
+  const seconds = Number(match[1]);
+  const fractionalMs = match[2] ? Math.ceil(Number(`0.${match[2]}`) * 1000) : 0;
+  const delayMs = seconds * 1000 + fractionalMs;
+  return Number.isSafeInteger(delayMs) ? delayMs : undefined;
+}
+
+function extractGoogleRetryInfoDelayMs(payload: unknown): number | undefined {
+  const details = asOptionalRecord(asOptionalRecord(payload)?.error)?.details;
+  if (!Array.isArray(details)) {
+    return undefined;
+  }
+
+  let retryAfterMs: number | undefined;
+  for (const rawDetail of details) {
+    const detail = asOptionalRecord(rawDetail);
+    if (trimToUndefined(detail?.["@type"]) !== GOOGLE_RETRY_INFO_TYPE) {
+      continue;
+    }
+    const candidate = parseGoogleRetryDelayMs(detail?.retryDelay);
+    retryAfterMs =
+      candidate === undefined ? retryAfterMs : Math.max(retryAfterMs ?? candidate, candidate);
+  }
+  return retryAfterMs;
+}
+
+function extractRetryAfterHeaderMs(response: Response): number | undefined {
+  const seconds = parseRetryAfterHeaderSeconds(response.headers.get("Retry-After"));
+  if (seconds === undefined) {
+    return undefined;
+  }
+  const delayMs = Math.ceil(seconds * 1000);
+  return Number.isSafeInteger(delayMs) ? delayMs : undefined;
+}
 
 function extractProviderErrorPayloadMetadata(payload: unknown): ProviderErrorPayloadMetadata {
   const root = asOptionalRecord(payload);
@@ -229,10 +276,12 @@ function extractProviderErrorPayloadMetadata(payload: unknown): ProviderErrorPay
     trimToUndefined(subject.error_description) ?? trimToUndefined(root?.error_description);
   const oauthCode = errorDescription ? trimToUndefined(root?.error) : undefined;
   const code = trimToUndefined(subject.code) ?? trimToUndefined(subject.status) ?? oauthCode;
+  const retryAfterMs = extractGoogleRetryInfoDelayMs(payload);
   return {
     ...(detail ? { detail: redactSensitiveText(detail) } : {}),
     ...(code ? { code } : {}),
     ...(type ? { type } : {}),
+    ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
   };
 }
 
@@ -243,6 +292,7 @@ type ProviderHttpErrorInfo = {
   type?: string;
   body?: string;
   requestId?: string;
+  retryAfterMs?: number;
 };
 
 /** Extracts normalized provider error metadata while keeping the raw body bounded and redacted. */
@@ -282,8 +332,12 @@ async function extractProviderErrorInfo(
       ? redactProviderResponseErrorText(rawRequestId, options.requestHeaders)
       : rawRequestId;
   const rawBody = trimToUndefined(prefix?.text);
+  const headerRetryAfterMs = extractRetryAfterHeaderMs(response);
   if (!rawBody) {
-    return requestId ? { requestId } : {};
+    return {
+      ...(requestId ? { requestId } : {}),
+      ...(headerRetryAfterMs !== undefined ? { retryAfterMs: headerRetryAfterMs } : {}),
+    };
   }
   // Redact before metadata extraction or preview truncation can split a credential.
   const safeBody = options?.requestHeaders
@@ -294,10 +348,15 @@ async function extractProviderErrorInfo(
   const body = redactProviderErrorBody(safeBody);
   try {
     const metadata = extractProviderErrorPayloadMetadata(JSON.parse(safeBody));
+    const retryAfterMs =
+      metadata.retryAfterMs === undefined
+        ? headerRetryAfterMs
+        : Math.max(metadata.retryAfterMs, headerRetryAfterMs ?? metadata.retryAfterMs);
     return {
       ...(metadata.detail ? { detail: metadata.detail } : { detail: body }),
       ...(metadata.code ? { code: metadata.code } : {}),
       ...(metadata.type ? { type: metadata.type } : {}),
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
       body,
       ...(requestId ? { requestId } : {}),
     };
@@ -306,6 +365,7 @@ async function extractProviderErrorInfo(
       detail: body,
       body,
       ...(requestId ? { requestId } : {}),
+      ...(headerRetryAfterMs !== undefined ? { retryAfterMs: headerRetryAfterMs } : {}),
     };
   }
 }
@@ -327,6 +387,7 @@ export function extractProviderRequestId(response: Response): string | undefined
 export class ProviderHttpError extends Error {
   readonly status: number;
   readonly statusCode: number;
+  readonly retryAfterMs?: number;
   readonly code?: string;
   readonly errorCode?: string;
   readonly errorType?: string;
@@ -341,6 +402,7 @@ export class ProviderHttpError extends Error {
       type?: string;
       body?: string;
       requestId?: string;
+      retryAfterMs?: number;
     },
   ) {
     super(message);
@@ -352,6 +414,7 @@ export class ProviderHttpError extends Error {
     this.errorType = params.type;
     this.errorBody = params.body;
     this.requestId = params.requestId;
+    this.retryAfterMs = params.retryAfterMs;
   }
 }
 
@@ -392,6 +455,7 @@ export async function createProviderHttpError(
       type: info.type,
       body: info.body,
       requestId: info.requestId,
+      retryAfterMs: info.retryAfterMs,
     },
   );
 }

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -214,53 +214,7 @@ type ProviderErrorPayloadMetadata = {
   detail?: string;
   code?: string;
   type?: string;
-  retryAfterMs?: number;
 };
-
-const GOOGLE_RETRY_INFO_TYPE = "type.googleapis.com/google.rpc.RetryInfo";
-const GOOGLE_RETRY_DELAY_RE = /^(\d+)(?:\.(\d{1,9}))?s$/u;
-
-function parseGoogleRetryDelayMs(value: unknown): number | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const match = GOOGLE_RETRY_DELAY_RE.exec(value);
-  if (!match) {
-    return undefined;
-  }
-  const seconds = Number(match[1]);
-  const fractionalMs = match[2] ? Math.ceil(Number(`0.${match[2]}`) * 1000) : 0;
-  const delayMs = seconds * 1000 + fractionalMs;
-  return Number.isSafeInteger(delayMs) ? delayMs : undefined;
-}
-
-function extractGoogleRetryInfoDelayMs(payload: unknown): number | undefined {
-  const details = asOptionalRecord(asOptionalRecord(payload)?.error)?.details;
-  if (!Array.isArray(details)) {
-    return undefined;
-  }
-
-  let retryAfterMs: number | undefined;
-  for (const rawDetail of details) {
-    const detail = asOptionalRecord(rawDetail);
-    if (trimToUndefined(detail?.["@type"]) !== GOOGLE_RETRY_INFO_TYPE) {
-      continue;
-    }
-    const candidate = parseGoogleRetryDelayMs(detail?.retryDelay);
-    retryAfterMs =
-      candidate === undefined ? retryAfterMs : Math.max(retryAfterMs ?? candidate, candidate);
-  }
-  return retryAfterMs;
-}
-
-function extractRetryAfterHeaderMs(response: Response): number | undefined {
-  const seconds = parseRetryAfterHeaderSeconds(response.headers.get("Retry-After"));
-  if (seconds === undefined) {
-    return undefined;
-  }
-  const delayMs = Math.ceil(seconds * 1000);
-  return Number.isSafeInteger(delayMs) ? delayMs : undefined;
-}
 
 function extractProviderErrorPayloadMetadata(payload: unknown): ProviderErrorPayloadMetadata {
   const root = asOptionalRecord(payload);
@@ -276,12 +230,10 @@ function extractProviderErrorPayloadMetadata(payload: unknown): ProviderErrorPay
     trimToUndefined(subject.error_description) ?? trimToUndefined(root?.error_description);
   const oauthCode = errorDescription ? trimToUndefined(root?.error) : undefined;
   const code = trimToUndefined(subject.code) ?? trimToUndefined(subject.status) ?? oauthCode;
-  const retryAfterMs = extractGoogleRetryInfoDelayMs(payload);
   return {
     ...(detail ? { detail: redactSensitiveText(detail) } : {}),
     ...(code ? { code } : {}),
     ...(type ? { type } : {}),
-    ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
   };
 }
 
@@ -332,7 +284,9 @@ async function extractProviderErrorInfo(
       ? redactProviderResponseErrorText(rawRequestId, options.requestHeaders)
       : rawRequestId;
   const rawBody = trimToUndefined(prefix?.text);
-  const headerRetryAfterMs = extractRetryAfterHeaderMs(response);
+  const retryAfterSeconds = parseRetryAfterHeaderSeconds(response.headers.get("Retry-After"));
+  const headerRetryAfterMs =
+    retryAfterSeconds === undefined ? undefined : Math.ceil(retryAfterSeconds * 1000);
   if (!rawBody) {
     return {
       ...(requestId ? { requestId } : {}),
@@ -348,15 +302,11 @@ async function extractProviderErrorInfo(
   const body = redactProviderErrorBody(safeBody);
   try {
     const metadata = extractProviderErrorPayloadMetadata(JSON.parse(safeBody));
-    const retryAfterMs =
-      metadata.retryAfterMs === undefined
-        ? headerRetryAfterMs
-        : Math.max(metadata.retryAfterMs, headerRetryAfterMs ?? metadata.retryAfterMs);
     return {
       ...(metadata.detail ? { detail: metadata.detail } : { detail: body }),
       ...(metadata.code ? { code: metadata.code } : {}),
       ...(metadata.type ? { type: metadata.type } : {}),
-      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+      ...(headerRetryAfterMs !== undefined ? { retryAfterMs: headerRetryAfterMs } : {}),
       body,
       ...(requestId ? { requestId } : {}),
     };

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -12,6 +12,7 @@ import {
   readResponseWithLimit,
   type ReadResponseTextPrefixOptions,
 } from "../infra/http-body.js";
+import { parseRetryAfterHeaderSeconds } from "../infra/retry-after.js";
 import { redactSensitiveText, redactToolPayloadText } from "../logging/redact.js";
 import type { ModelProviderRequestTransportOverrides } from "./provider-request-config.js";
 import { redactProviderResponseErrorText } from "./provider-request-header-redaction.js";
@@ -115,6 +116,8 @@ function readProviderResponseBytes(
 /** Options for bounded provider error-body normalization. */
 type ProviderHttpErrorOptions = {
   statusPrefix?: string;
+  signal?: AbortSignal;
+  maxBodyBytes?: number;
   bodyTimeoutMs?: ReadResponseTextPrefixOptions["timeoutMs"];
   onBodyTimeout?: NonNullable<ReadResponseTextPrefixOptions["onTimeout"]>;
   /** Scrub reflected request credentials before retaining response diagnostics. */
@@ -219,6 +222,7 @@ export function formatProviderErrorPayload(payload: unknown): string | undefined
 type ProviderHttpErrorInfo = ProviderErrorPayloadMetadata & {
   body?: string;
   requestId?: string;
+  retryAfterMs?: number;
 };
 
 /** Extracts normalized provider error metadata while keeping the raw body bounded and redacted. */
@@ -227,7 +231,8 @@ async function extractProviderErrorInfo(
   options?: ProviderHttpErrorOptions,
 ): Promise<ProviderHttpErrorInfo> {
   const bodyTimeoutMs = options?.bodyTimeoutMs;
-  const prefix = await readResponseTextPrefix(response, 16 * 1024, {
+  const prefix = await readResponseTextPrefix(response, options?.maxBodyBytes ?? 16 * 1024, {
+    signal: options?.signal,
     chunkTimeoutMs: 10_000,
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`error body read stalled for ${chunkTimeoutMs}ms`),
@@ -247,6 +252,7 @@ async function extractProviderErrorInfo(
           new Error(`Provider error body timed out after ${params.timeoutMs}ms`),
       ),
   }).catch((error: unknown) => {
+    options?.signal?.throwIfAborted();
     if (error instanceof ProviderErrorBodyTimeout) {
       throw error.timeoutError;
     }
@@ -256,14 +262,18 @@ async function extractProviderErrorInfo(
     }
     return undefined;
   });
+  options?.signal?.throwIfAborted();
   const rawRequestId = extractProviderRequestId(response);
   const requestId =
     rawRequestId && options?.requestHeaders
       ? redactProviderResponseErrorText(rawRequestId, options.requestHeaders)
       : rawRequestId;
   const rawBody = trimToUndefined(prefix?.text);
+  const retryAfterSeconds = parseRetryAfterHeaderSeconds(response.headers.get("Retry-After"));
+  const headerRetryAfterMs =
+    retryAfterSeconds === undefined ? undefined : Math.ceil(retryAfterSeconds * 1000);
   if (!rawBody) {
-    return { requestId };
+    return { requestId, retryAfterMs: headerRetryAfterMs };
   }
   // Redact before metadata extraction or preview truncation can split a credential.
   const safeBody = options?.requestHeaders
@@ -279,6 +289,7 @@ async function extractProviderErrorInfo(
       detail: (metadata.detail && redactSensitiveText(metadata.detail)) || body,
       code: metadata.code,
       type: metadata.type,
+      retryAfterMs: headerRetryAfterMs,
       body,
       requestId,
     };
@@ -287,6 +298,7 @@ async function extractProviderErrorInfo(
       detail: body,
       body,
       requestId,
+      retryAfterMs: headerRetryAfterMs,
     };
   }
 }
@@ -308,6 +320,7 @@ export function extractProviderRequestId(response: Response): string | undefined
 export class ProviderHttpError extends Error {
   readonly status: number;
   readonly statusCode: number;
+  retryAfterMs?: number;
   readonly code?: string;
   readonly errorCode?: string;
   readonly errorType?: string;
@@ -322,6 +335,7 @@ export class ProviderHttpError extends Error {
       type?: string;
       body?: string;
       requestId?: string;
+      retryAfterMs?: number;
     },
   ) {
     super(message);
@@ -333,6 +347,7 @@ export class ProviderHttpError extends Error {
     this.errorType = params.type;
     this.errorBody = params.body;
     this.requestId = params.requestId;
+    this.retryAfterMs = params.retryAfterMs;
   }
 }
 
@@ -357,7 +372,7 @@ export async function createProviderHttpError(
   response: Response,
   label: string,
   options?: ProviderHttpErrorOptions,
-): Promise<Error> {
+): Promise<ProviderHttpError> {
   const info = await extractProviderErrorInfo(response, options);
   return new ProviderHttpError(
     formatProviderHttpErrorMessage({
@@ -373,6 +388,7 @@ export async function createProviderHttpError(
       type: info.type,
       body: info.body,
       requestId: info.requestId,
+      retryAfterMs: info.retryAfterMs,
     },
   );
 }

--- a/src/agents/provider-request-header-redaction.ts
+++ b/src/agents/provider-request-header-redaction.ts
@@ -158,8 +158,10 @@ export async function readProviderResponseErrorText(
   response: Response,
   limitBytes: number,
   headers: HeadersInit,
+  signal?: AbortSignal,
 ): Promise<string> {
   const result = await readResponseTextPrefix(response, limitBytes, {
+    signal,
     chunkTimeoutMs: 10_000,
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`error body read stalled for ${chunkTimeoutMs}ms`),

--- a/src/infra/http-body.response.test.ts
+++ b/src/infra/http-body.response.test.ts
@@ -1,6 +1,7 @@
 // Tests bounded HTTP response reads and cleanup behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import {
   cancelUnreadResponseBody,
   readResponseTextPrefix,
@@ -132,6 +133,58 @@ describe("cancelUnreadResponseBody", () => {
 describe("readResponseWithLimit", () => {
   beforeEach(() => {
     vi.useRealTimers();
+  });
+
+  it.each([undefined, 1_000])(
+    "aborts prefix reads without awaiting cancellation (deadline %s)",
+    async (timeoutMs) => {
+      const readStarted = createDeferred();
+      const cancel = vi.fn(async () => await new Promise<void>(() => {}));
+      const body = new ReadableStream<Uint8Array>(
+        {
+          pull() {
+            readStarted.resolve();
+          },
+          cancel,
+        },
+        { highWaterMark: 0 },
+      );
+      const controller = new AbortController();
+      const reason = new Error("index request cancelled");
+      const result = readResponseTextPrefix(new Response(body), 8, {
+        signal: controller.signal,
+        timeoutMs,
+      }).catch((error: unknown) => error);
+
+      try {
+        await withTestTimeout(readStarted.promise, 1_000, "response read did not start");
+        controller.abort(reason);
+
+        await expect(withTestTimeout(result, 1_000, "response abort did not settle")).resolves.toBe(
+          reason,
+        );
+        expect(cancel).toHaveBeenCalledOnce();
+        expect(cancel).toHaveBeenCalledWith(reason);
+        expect(body.locked).toBe(false);
+      } finally {
+        controller.abort(reason);
+      }
+    },
+  );
+
+  it("cancels a pre-aborted full-body read without pulling or retaining the reader", async () => {
+    const pull = vi.fn();
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({ pull, cancel }, { highWaterMark: 0 });
+    const reason = new Error("request already cancelled");
+
+    await expect(
+      readResponseWithLimit(new Response(body), 8, { signal: AbortSignal.abort(reason) }),
+    ).rejects.toBe(reason);
+
+    expect(pull).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledWith(reason);
+    expect(body.locked).toBe(false);
   });
 
   it.each(["prefix", "overflow", "deadline"] as const)(

--- a/src/infra/http-response-body-timeout.ts
+++ b/src/infra/http-response-body-timeout.ts
@@ -13,57 +13,77 @@ function createResponseBodyTimeoutError(message: string): Error {
 export async function withResponseBodyTimeout<T>(params: {
   timeoutMs: number | undefined;
   onTimeout: TimeoutErrorFactory | undefined;
+  signal?: AbortSignal;
   cancel: (error: Error) => Promise<unknown>;
   read: (refreshTimeout?: () => void) => Promise<T>;
 }): Promise<T> {
-  if (params.timeoutMs === undefined) {
+  if (params.timeoutMs === undefined && !params.signal) {
     return await params.read();
   }
-  const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 1);
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  let timeoutError: Error | undefined;
+  let stoppedError: Error | undefined;
 
   return await new Promise<T>((resolve, reject) => {
     const clear = () => {
+      params.signal?.removeEventListener("abort", onAbort);
       if (timeoutId !== undefined) {
         clearTimeout(timeoutId);
         timeoutId = undefined;
       }
     };
 
-    timeoutId = setTimeout(() => {
-      const error =
-        params.onTimeout?.({ timeoutMs }) ??
-        createResponseBodyTimeoutError(`Response body timed out after ${timeoutMs}ms`);
-      timeoutError = error;
+    const stop = (error: Error) => {
+      if (stoppedError) {
+        return;
+      }
+      stoppedError = error;
       clear();
       void params.cancel(error).catch(() => undefined);
       reject(error);
-    }, timeoutMs);
-    if (typeof timeoutId === "object" && "unref" in timeoutId) {
-      timeoutId.unref();
+    };
+    const onAbort = () => stop(toErrorObject(params.signal?.reason, "Response body read aborted"));
+    params.signal?.addEventListener("abort", onAbort, { once: true });
+    if (params.signal?.aborted) {
+      onAbort();
+      return;
+    }
+
+    if (params.timeoutMs !== undefined) {
+      const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 1);
+      timeoutId = setTimeout(() => {
+        stop(
+          params.onTimeout?.({ timeoutMs }) ??
+            createResponseBodyTimeoutError(`Response body timed out after ${timeoutMs}ms`),
+        );
+      }, timeoutMs);
+      if (typeof timeoutId === "object" && "unref" in timeoutId) {
+        timeoutId.unref();
+      }
     }
 
     void Promise.resolve()
-      .then(() =>
-        params.read(() => {
-          // A late read must not restart an expired deadline or consume another chunk.
-          if (timeoutError) {
-            throw timeoutError;
+      .then(() => {
+        if (stoppedError) {
+          throw stoppedError;
+        }
+        return params.read(() => {
+          // A late read must not restart a stopped deadline or consume another chunk.
+          if (stoppedError) {
+            throw stoppedError;
           }
           timeoutId?.refresh();
-        }),
-      )
+        });
+      })
       .then(
         (value) => {
           clear();
-          if (!timeoutError) {
+          if (!stoppedError) {
             resolve(value);
           }
         },
         (error: unknown) => {
           clear();
-          if (!timeoutError) {
+          if (!stoppedError) {
             reject(toErrorObject(error, "Non-Error rejection"));
           }
         },

--- a/src/infra/http-response-body.ts
+++ b/src/infra/http-response-body.ts
@@ -21,6 +21,7 @@ type ReadResponsePrefixResult = {
 };
 
 export type ReadResponseTextPrefixOptions = {
+  signal?: AbortSignal;
   chunkTimeoutMs?: number;
   onIdleTimeout?: (params: { chunkTimeoutMs: number }) => Error;
   /** Static timeout or lazy resolver evaluated immediately before body consumption. */
@@ -38,32 +39,25 @@ async function readResponsePrefixFromReader(
   options?: ReadResponsePrefixOptions,
 ): Promise<ReadResponsePrefixResult> {
   const chunks: Uint8Array[] = [];
-  let result: { size: number; truncated: boolean };
-  try {
-    result = await withResponseBodyIdleTimeout(
-      reader,
-      options?.chunkTimeoutMs || undefined,
-      options?.onIdleTimeout,
-      (refreshTimeout) =>
-        consumeResponseBytes({
-          maxBytes,
-          stopAtLimit: options?.stopAtLimit,
-          read: () => {
-            refreshTimeout?.();
-            return reader.read();
-          },
-          onChunk: (chunk) => chunks.push(chunk),
-          onLimit: () => {
-            // Capture tees must not delay bounded dispatcher release.
-            void reader.cancel().catch(() => undefined);
-          },
-        }),
-    );
-  } finally {
-    try {
-      reader.releaseLock();
-    } catch {}
-  }
+  const result = await withResponseBodyIdleTimeout(
+    reader,
+    options?.chunkTimeoutMs || undefined,
+    options?.onIdleTimeout,
+    (refreshTimeout) =>
+      consumeResponseBytes({
+        maxBytes,
+        stopAtLimit: options?.stopAtLimit,
+        read: () => {
+          refreshTimeout?.();
+          return reader.read();
+        },
+        onChunk: (chunk) => chunks.push(chunk),
+        onLimit: () => {
+          // Capture tees must not delay bounded dispatcher release.
+          void reader.cancel().catch(() => undefined);
+        },
+      }),
+  );
 
   return {
     // Full-body readers reject overflow before allocating a contiguous copy.
@@ -93,6 +87,7 @@ async function readResponsePrefix(
     return await withResponseBodyTimeout({
       timeoutMs,
       onTimeout: options?.onTimeout,
+      signal: options?.signal,
       cancel: async (error) => await body?.cancel(error),
       read: async () => {
         const fallback = Buffer.from(await response.arrayBuffer());
@@ -107,12 +102,17 @@ async function readResponsePrefix(
   }
 
   const reader = body.getReader();
-  return await withResponseBodyTimeout({
-    timeoutMs,
-    onTimeout: options?.onTimeout,
-    cancel: async (error) => await reader.cancel(error),
-    read: async () => await readResponsePrefixFromReader(reader, maxBytes, options),
-  });
+  try {
+    return await withResponseBodyTimeout({
+      timeoutMs,
+      onTimeout: options?.onTimeout,
+      signal: options?.signal,
+      cancel: async (error) => await reader.cancel(error),
+      read: async () => await readResponsePrefixFromReader(reader, maxBytes, options),
+    });
+  } finally {
+    reader.releaseLock();
+  }
 }
 
 export type ReadResponseTextPrefixResult = {
@@ -148,6 +148,7 @@ export async function readResponseWithLimit(
 ): Promise<Buffer> {
   const onOverflow = options?.onOverflow;
   const prefix = await readResponsePrefix(response, maxBytes, {
+    signal: options?.signal,
     chunkTimeoutMs: options?.chunkTimeoutMs,
     onIdleTimeout: options?.onIdleTimeout,
     timeoutMs: options?.timeoutMs,
@@ -172,6 +173,7 @@ export async function readResponseTextSnippet(
   const maxBytes = options?.maxBytes ?? 8 * 1024;
   const maxChars = options?.maxChars ?? 200;
   const prefix = await readResponseTextPrefix(response, maxBytes, {
+    signal: options?.signal,
     chunkTimeoutMs: options?.chunkTimeoutMs,
     onIdleTimeout: options?.onIdleTimeout,
     timeoutMs: options?.timeoutMs,


### PR DESCRIPTION
Closes #108893

## What Problem This Solves

Memory indexing gives up before an embedding provider's cooldown expires. Both Google and generic OpenAI-compatible embedding paths exhaust three short attempts, leaving the index incomplete despite a valid `Retry-After` response.

## Change

Carry validated cooldown and quota metadata through the existing shared HTTP error owner, including the generic embedding request path. Keep Google `RetryInfo` decoding at the Google boundary, with a bounded, redacted response clone that closes when the caller cancels.

Keep one memory retry loop. Index rate limits get at most five attempts and 60 seconds per wait; other transient errors retain three attempts. Interactive search keeps three attempts, at most eight seconds of total retry sleep, and the existing tool deadline. Structured permanent quota errors without a retry hint stop without another memory retry.

The generic error path retains its 8 KiB input bound and existing batch retry behavior. It now uses the shared diagnostic format and 500-character error-body preview. No configuration surface, persistent schema, vector metadata, authentication contract, or endpoint changes.

## Evidence

- Built public `memory index --force --verbose`: pinned main fails before an enforced ten-second server cooldown, with zero of three files indexed. This candidate waits until the cooldown ends and indexes all three files through both Google and OpenAI-compatible providers.
- Google public controls honor a six-second `RetryInfo` over a two-second header. An oversized body with a trailing hint falls back to the valid two-second header. Both index every file.
- Public `agent exec` calls the real `memory_search` tool and delivers its actual result to the continuation. A persistent long-hint query makes three attempts, sleeps 8,000 ms total, and returns unavailable after 8,117 ms. Permanent quota index/query controls do not retry. Caller SIGINT interrupts a pending wait and exits through normal cleanup in 66 ms.
- 364 focused tests pass. Header propagation fails on main and passes with the fix; real response-clone cancellation tests fail before the corrective change and pass afterward. Syntax lint, formatting, safety/size checks, docs links, and the complete native build with CLI/SDK/doctor-closure checks pass. Independent behavior and source judgments agree within the recorded proof boundaries.

## Limits

The HTTPS providers and chat responses are synthetic; the proof covers real CLI, HTTP, and agent-tool behavior, not external model reasoning or answer quality. Existing temporary-429 search guidance can still incorrectly recommend topping up quota. A cancelled turn also logs refusal to append a prompt-error diagnostic after abort; the index remains intact. These separate diagnostic paths are unchanged. Failed setup and control attempts remain retained.

Preserves @shojikumaru's three commits and original repair intent.
