### PR TITLE
test(oc-path): own CLI fixtures and registration cleanup

### DIFF
--- a/extensions/oc-path/src/cli.test.ts
+++ b/extensions/oc-path/src/cli.test.ts
@@ -8,17 +8,16 @@ import { execFileSync } from "node:child_process";
 import {
   closeSync,
   constants as fsConstants,
-  mkdtempSync,
   openSync,
   promises as fs,
   readFileSync,
   writeFileSync,
   writeSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Command, CommanderError } from "commander";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { registerOcPathCli } from "../cli-registration.js";
 import { registerPathCli } from "./cli.js";
 
@@ -124,14 +123,14 @@ async function invokePathCli(args: string[], runtime: TestRuntime): Promise<void
     runtime.error(String(chunk));
     return true;
   }) as typeof process.stderr.write);
-  const program = new Command();
-  program.exitOverride();
-  program.configureOutput({
-    writeOut: (value) => runtime.writeStdout(value),
-    writeErr: (value) => runtime.error(value),
-  });
-  registerPathCli(program);
   try {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({
+      writeOut: (value) => runtime.writeStdout(value),
+      writeErr: (value) => runtime.error(value),
+    });
+    registerPathCli(program);
     await program.parseAsync(["node", "openclaw", "path", ...args]);
     runtime.exitCode = process.exitCode ?? 0;
   } catch (error) {
@@ -208,22 +207,14 @@ async function pathEmitCommand(
 }
 
 describe("openclaw path CLI", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
   it("reports its TTY-aware machine-output mode to the CLI", () => {
     const argv = ["node", "openclaw", "path", "validate", "oc://AGENTS.md"];
     expect(isPathMachineOutput({ argv, stdoutIsTTY: false })).toBe(true);
     expect(isPathMachineOutput({ argv, stdoutIsTTY: true })).toBe(false);
     expect(isPathMachineOutput({ argv: [...argv, "--json"], stdoutIsTTY: true })).toBe(true);
     expect(isPathMachineOutput({ argv: [...argv, "--human"], stdoutIsTTY: false })).toBe(false);
-  });
-
-  let workspaceDir: string;
-
-  beforeEach(() => {
-    workspaceDir = mkdtempSync(join(tmpdir(), "oc-path-cli-"));
-  });
-  afterEach(() => {
-    // mkdtemp leaves a small dir; OS will GC it. Skip cleanup to keep
-    // the test deterministic on Windows where rmdir flakes.
   });
 
   describe("validate", () => {
@@ -255,6 +246,7 @@ describe("openclaw path CLI", () => {
 
   describe("resolve", () => {
     it("CLI-R01 finds a leaf in jsonc and prints it", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "gateway.jsonc");
       writeFileSync(filePath, '{ "version": "1.0" }', "utf-8");
       const rt = createTestRuntime();
@@ -267,6 +259,7 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-R04 finds a leaf in yaml and prints it", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "workflow.yaml");
       writeFileSync(filePath, "name: inbox-triage\nsteps:\n  - id: fetch\n", "utf-8");
       const rt = createTestRuntime();
@@ -283,6 +276,7 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-R02 returns 1 for not-found path", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "gateway.jsonc");
       writeFileSync(filePath, '{ "version": "1.0" }', "utf-8");
       const rt = createTestRuntime();
@@ -300,6 +294,7 @@ describe("openclaw path CLI", () => {
     });
 
     it("bounds every file-loading verb before parsing oversized input", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "oversized.json");
       const content = `"${"界".repeat(Math.floor(JSONC_INPUT_LIMIT_BYTES / 3) + 1)}"`;
       writeFileSync(filePath, content, "utf-8");
@@ -364,6 +359,7 @@ describe("openclaw path CLI", () => {
     it.runIf(process.platform !== "win32")(
       "rejects a FIFO without waiting for a writer",
       async () => {
+        const workspaceDir = tempDirs.make("oc-path-cli-");
         const fifoPath = join(workspaceDir, "input.json");
         execFileSync("mkfifo", [fifoPath]);
         const releaseBlockedReader = setTimeout(() => {
@@ -389,6 +385,7 @@ describe("openclaw path CLI", () => {
 
   describe("set", () => {
     it("CLI-S01 writes new bytes when path resolves", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "gateway.jsonc");
       writeFileSync(filePath, '{ "version": "1.0" }', "utf-8");
       const rt = createTestRuntime();
@@ -404,6 +401,7 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-S02 --dry-run does not write to disk", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "gateway.jsonc");
       const before = '{ "version": "1.0" }';
       writeFileSync(filePath, before, "utf-8");
@@ -423,6 +421,7 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-S02b --dry-run human output reports the rendered UTF-8 byte count", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "gateway.jsonc");
       const before = '{ "version": "1.0" }';
       writeFileSync(filePath, before, "utf-8");
@@ -443,6 +442,7 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-S05 --dry-run --diff prints a unified diff", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "gateway.jsonc");
       const before = '{\n  "version": "1.0",\n  "enabled": true\n}\n';
       writeFileSync(filePath, before, "utf-8");
@@ -463,6 +463,7 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-S05c --dry-run --diff shows line-ending-only byte changes", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "AGENTS.md");
       const before = "---\r\nname: x\r\n---\r\n";
       writeFileSync(filePath, before, "utf-8");
@@ -481,6 +482,7 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-S06 --dry-run --diff includes diff in JSON output", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "gateway.jsonc");
       writeFileSync(filePath, '{ "version": "1.0" }', "utf-8");
       const rt = createTestRuntime();
@@ -499,6 +501,7 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-S07 rejects --diff without --dry-run", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "gateway.jsonc");
       const before = '{ "version": "1.0" }';
       writeFileSync(filePath, before, "utf-8");
@@ -518,6 +521,7 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-S08 sets slash-deep JSONC paths and parsed JSON values", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "openclaw.json");
       writeFileSync(
         filePath,
@@ -555,16 +559,12 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-S03 sentinel-bearing value is refused at emit", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "gateway.jsonc");
       writeFileSync(filePath, '{ "token": "x" }', "utf-8");
       const rt = createTestRuntime();
-      // The sentinel-bearing value is accepted into the AST by setOcPath,
-      // but `emitForKind` refuses to serialize it (defense-in-depth at
-      // the per-kind emit boundary). The CLI handler must catch that
-      // refusal and route it through the structured error boundary —
-      // a thrown error escaping commander would print raw `String(err)`
-      // and bypass our JSON/human scrubbing. Pin the structured shape:
-      // exit code 1, stable code OC_EMIT_SENTINEL, message scrubbed.
+      // Sentinel values can enter the AST, but emit must reject them through
+      // the structured CLI error boundary instead of escaping Commander.
       await pathSetCommand(
         "oc://gateway.jsonc/token",
         "__OPENCLAW_REDACTED__",
@@ -573,12 +573,7 @@ describe("openclaw path CLI", () => {
       );
       expect(rt.exitCode).toBe(1);
       expect(stderrText(rt)).toContain("OC_EMIT_SENTINEL");
-      // F13 — file context in sentinel error. Without fileNameForGuard
-      // plumbing through emitForKind, the message would carry the
-      // empty-slot fallback (`oc:///[raw]`); now it carries the actual
-      // file (`oc://gateway.jsonc/[raw]`). Forensics + audit pipelines
-      // rely on this — without the file context, "sentinel rejected
-      // somewhere" doesn't tell you WHICH file was involved.
+      // Include the actual file in the sentinel error so operators can locate it.
       expect(stderrText(rt)).toContain("gateway.jsonc");
     });
 
@@ -590,6 +585,7 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-S05 malformed yaml returns structured parse-error", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "workflow.yaml");
       const before = "key: value\n  bad indent: oops\n";
       writeFileSync(filePath, before, "utf-8");
@@ -609,6 +605,7 @@ describe("openclaw path CLI", () => {
 
   describe("find", () => {
     it("CLI-F01 enumerates wildcard matches", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "config.jsonc");
       writeFileSync(filePath, '{ "items": [ { "id": "a" }, { "id": "b" } ] }', "utf-8");
       const rt = createTestRuntime();
@@ -619,6 +616,7 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-F02 returns 1 when zero matches", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "gateway.jsonc");
       writeFileSync(filePath, "{}", "utf-8");
       const rt = createTestRuntime();
@@ -627,10 +625,8 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-F03 file-slot wildcard rejected with clear error (no ENOENT)", async () => {
-      // Closes Galin P3 (round 8): `find` resolves `pattern.file` to one
-      // literal path, so `oc://*.jsonc/...` would silently ENOENT during
-      // fs.readFile. The CLI now surfaces a clear error before touching
-      // the filesystem, with stable code OC_PATH_FILE_WILDCARD_UNSUPPORTED.
+      const workspaceDir = tempDirs.make("oc-path-cli-");
+      // File-slot wildcards must fail clearly before filesystem access.
       const rt = createTestRuntime();
       await pathFindCommand("oc://*.jsonc/items", { cwd: workspaceDir, json: true }, rt);
       expect(rt.exitCode).toBe(2);
@@ -641,6 +637,7 @@ describe("openclaw path CLI", () => {
 
   describe("emit", () => {
     it("CLI-E01 round-trips jsonc bytes verbatim (byte-fidelity proof)", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "gateway.jsonc");
       const before = '// keep this comment\n{\n  "v": 1\n}\n';
       writeFileSync(filePath, before, "utf-8");
@@ -653,6 +650,7 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-E02 round-trips md verbatim", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "AGENTS.md");
       const before = "## Tools\n- gh\n## Boundaries\n- never rm -rf\n";
       writeFileSync(filePath, before, "utf-8");
@@ -665,6 +663,7 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-E04 round-trips yaml verbatim", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "workflow.yaml");
       const before = "# keep comment\nname: inbox-triage\nsteps:\n  - id: fetch\n";
       writeFileSync(filePath, before, "utf-8");
@@ -677,6 +676,7 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-S07b reports accurate UTF-8 byte counts for multibyte set output", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "gateway.jsonc");
       const before = '{\n  "version": "1.0"\n}\n';
       writeFileSync(filePath, before, "utf-8");
@@ -700,15 +700,11 @@ describe("openclaw path CLI", () => {
     });
 
     it("CLI-E03 emit --cwd resolves <file> against the supplied directory", async () => {
-      // Closes round-10 finding F2: emit advertises --cwd / --file in
-      // the docs but the handler resolved <file> against process.cwd()
-      // ignoring both. Pin the new wiring: a relative <file> resolves
-      // against --cwd, not against process.cwd().
+      // A relative file must resolve against --cwd, not the process directory.
+      const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "AGENTS.md");
       writeFileSync(filePath, "## Tools\n- gh\n", "utf-8");
       const rt = createTestRuntime();
-      // Pass a RELATIVE filename + explicit --cwd. If the handler
-      // ignored --cwd, loadAst would ENOENT against process.cwd().
       await pathEmitCommand("AGENTS.md", { cwd: workspaceDir, json: true }, rt);
       expect(rt.exitCode).toBe(0);
       const out = JSON.parse(stdoutText(rt));


### PR DESCRIPTION
## What Problem This Solves

The oc-path CLI suite creates a temporary directory before every case, including six cases that never use one, then leaves cleanup to broader process lifetime. Its CLI helper also registers Commander commands before entering the existing cleanup try, so a registration exception skips restoration of stdout, stderr and the prior exit code.

## Why This Change Was Made

Use the existing public temporary-directory tracker and allocate one private root inside each filesystem case. The tracker records allocation before returning and removes the root after that case, including failures after allocation. Commander construction, configuration and registration now enter the helper's existing try/finally. Brief comments retain the file-context, wildcard and cwd invariants while removing review-history prose.

All 29 POSIX cases and 89 source matcher expressions remain. Keep the actual empty CLI-F03 directory, the five file-loading verbs against the >16 MiB multibyte input, the real FIFO subprocess and its unchanged 250ms fallback/clear, real writes and dry-run byte comparisons, JSONC/YAML/Markdown roundtrips, UTF-8 counts and structured errors. Each filesystem case keeps its own directory.

## User Impact

Test-only: production +0/-0. Tests +39/-43 (net -4) in the final supplied diff. POSIX directory allocations fall from 29 to 23; Windows allocations fall from 28 to 22 while retaining 28 runnable cases and the existing FIFO skip. The remaining roots gain per-case cleanup. Cleanup adds real deletion work, so no elapsed-time speedup is claimed. A root surviving until wrapper cleanup is not evidence of a persistent host leak.

## Evidence

Before and after each pass 29/29 with identical ordered native case identities and statuses, including the real FIFO and five-verb oversized-input cases. Four separate sensitivity runs each produce exactly one intended failure. CLI-R01 records one root before the write: it remains after baseline owning hooks and is gone after candidate hooks, observed before bulk cleanup. CLI-V01 uses an actual duplicate Commander option; before broader hooks, baseline stdout/stderr identities and prior exitCode are unrestored, while the candidate restores all three. That selected case allocates one baseline root and no candidate root. Original named/dependency errors remain visible. Raw traces, exact source-restoration receipts and backups, task-owned root cleanup, dead managed groups and completed output logs agree; native completion reports no unhandled errors or extra failures. The full changed-file gate's final exit 0 is supplied by root and its saved log is retained. Scoped autoreview returned no findings at its requested threshold.

The unchanged selected-case assertions are not reached under the intended faults; the normal passing suite supplies their behavior proof.

```sh
node scripts/run-vitest.mjs run extensions/oc-path/src/cli.test.ts --reporter=verbose --reporter=json
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base 113805d6a517c27b7c2521be58c2e1fd84093ba0
```

Latest ClawSweeper Rank-up disposition and exact-head CI, including Windows cleanup portability, remain pending. Local proof does not establish those landing checks.

Named follow-up: **oc-path CLI helper ownership during partial spy installation**. The try still starts after both output spies are installed; failure during spy installation remains outside cleanup. No production registration defect, persistent host leak, external-process-kill cleanup or elapsed-time speedup is claimed.
