### PR TITLE
refactor(ui): share markdown link boundary checks

### DIFF
--- a/ui/src/components/markdown-link-boundary.ts
+++ b/ui/src/components/markdown-link-boundary.ts
@@ -1,0 +1,8 @@
+export function hasMarkdownLinkBoundaries(value: string, start: number, end: number): boolean {
+  const before = value[start - 1];
+  const after = value[end];
+  return (
+    (before === undefined || /\s/.test(before) || "([{<\"'`".includes(before)) &&
+    (after === undefined || /\s/.test(after) || ".,;:!?)]}>\"'".includes(after))
+  );
+}

--- a/ui/src/components/markdown-parser.ts
+++ b/ui/src/components/markdown-parser.ts
@@ -16,6 +16,7 @@ import {
   parseMarkdownFileLinkTarget,
   splitMarkdownFileLineSuffix,
 } from "./markdown-file-links.ts";
+import { hasMarkdownLinkBoundaries } from "./markdown-link-boundary.ts";
 import type { MarkdownRenderEnv } from "./markdown-render-options.ts";
 import { installMarkdownSessionLinks, SESSION_LINK_SCAN_RE } from "./markdown-session-links.ts";
 import { installMarkdownTables } from "./markdown-tables.ts";
@@ -126,16 +127,6 @@ function formatGitHubLinkLabel(url: URL): string {
   const fallbackSegments = segments.length > 2 ? segments.slice(2) : segments;
   const path = fallbackSegments.map((segment) => decodeGitHubPathSegment(segment) ?? segment);
   return ["github.com", ...path].join("/");
-}
-
-function isFileLinkBoundaryBefore(value: string, index: number): boolean {
-  const char = value[index - 1];
-  return char === undefined || /\s/.test(char) || "([{<\"'`".includes(char);
-}
-
-function isFileLinkBoundaryAfter(value: string, index: number): boolean {
-  const char = value[index];
-  return char === undefined || /\s/.test(char) || ".,;:!?)]}>\"'".includes(char);
 }
 
 export function createMarkdownParser(): MarkdownItParser {
@@ -445,10 +436,7 @@ export function createMarkdownParser(): MarkdownItParser {
           const matchIndex = match.index;
           const matched = match[0];
           const matchEnd = matchIndex + matched.length;
-          if (
-            !isFileLinkBoundaryBefore(token.content, matchIndex) ||
-            !isFileLinkBoundaryAfter(token.content, matchEnd)
-          ) {
+          if (!hasMarkdownLinkBoundaries(token.content, matchIndex, matchEnd)) {
             continue;
           }
           const target = parseMarkdownFileLinkTarget(matched);

--- a/ui/src/components/markdown-session-links.ts
+++ b/ui/src/components/markdown-session-links.ts
@@ -3,6 +3,7 @@ import type { MarkdownIt } from "markdown-it";
 import type { ApplicationContext } from "../app/context.ts";
 import { sessionNavigationTarget } from "../lib/sessions/route-navigation.ts";
 import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
+import { hasMarkdownLinkBoundaries } from "./markdown-link-boundary.ts";
 
 export const SESSION_LINK_SCAN_RE = /agent:[^\s<>"'`]*[^\s<>"'`.,;:!?)}\]]/g;
 
@@ -25,16 +26,6 @@ export type SessionLinkTarget = SessionKeyTarget | SessionPathTarget;
 type SessionLinkMeta = {
   sessionKey: string;
 };
-
-function isSessionLinkBoundaryBefore(value: string, index: number): boolean {
-  const char = value[index - 1];
-  return char === undefined || /\s/.test(char) || "([{<\"'`".includes(char);
-}
-
-function isSessionLinkBoundaryAfter(value: string, index: number): boolean {
-  const char = value[index];
-  return char === undefined || /\s/.test(char) || ".,;:!?)]}>\"'".includes(char);
-}
 
 function parseSessionLinkKey(raw: string): SessionKeyTarget | null {
   const sessionKey = raw.trim();
@@ -95,8 +86,7 @@ export function installMarkdownSessionLinks(markdownParser: MarkdownIt, scanPatt
           const matched = match[0];
           const matchEnd = matchIndex + matched.length;
           if (
-            !isSessionLinkBoundaryBefore(token.content, matchIndex) ||
-            !isSessionLinkBoundaryAfter(token.content, matchEnd) ||
+            !hasMarkdownLinkBoundaries(token.content, matchIndex, matchEnd) ||
             !parseSessionLinkKey(matched)
           ) {
             continue;


### PR DESCRIPTION
## What Problem This Solves

File and session linkification maintained byte-identical markdown boundary checks in separate modules. Keeping the policy duplicated made punctuation behavior liable to drift.

## Why This Change Was Made

Moves the shared boundary predicate into one private Control UI component helper and keeps both linkifiers on that canonical implementation. The punctuation sets and rendered behavior are unchanged; no public, SDK, configuration, or persistence surface changes.

## User Impact

No user-visible behavior change. File and session links retain the same boundary and punctuation handling.

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/markdown-links.test.ts ui/src/components/markdown-session-links.test.ts ui/src/pages/chat/components/chat-transcript-render.test.ts` — 118 tests passed
- `pnpm check:import-cycles` — 0 runtime value cycles
- `pnpm ui:build` — passed, including Control UI performance limits
- `node scripts/check-changed.mjs -- ui/src/components/markdown-link-boundary.ts ui/src/components/markdown-parser.ts ui/src/components/markdown-session-links.ts` — passed
- Sol/high autoreview — scoped clean, no accepted/actionable findings
- Production LOC: +12/-26, net -14; tests: +0/-0
- Screenshots omitted because this is a behavior-preserving internal refactor with no visual output change
