### PR TITLE
fix(macos): give shell timeout fixtures a startup-tolerant deadline

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/ShellExecutorTimeoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ShellExecutorTimeoutTests.swift
@@ -16,6 +16,10 @@ private actor ShellLineRecorder {
 }
 
 struct ShellExecutorTimeoutTests {
+    /// The executor's deadline starts at spawn, so allow ample process startup time.
+    /// This is a fixture budget, not the timeout behavior under test.
+    private static let fixtureTimeout: TimeInterval = 1.0
+
     @Test func `streaming captures both streams while delivering stdout lines`() async {
         let recorder = ShellLineRecorder()
         let result = await ShellExecutor.runStreamingDetailed(
@@ -69,14 +73,14 @@ struct ShellExecutorTimeoutTests {
                 command: command,
                 cwd: nil,
                 env: environment,
-                timeout: 0.1,
+                timeout: Self.fixtureTimeout,
                 onStandardOutputLine: { _ in })
         } else {
             await ShellExecutor.runDetailed(
                 command: command,
                 cwd: nil,
                 env: environment,
-                timeout: 0.1)
+                timeout: Self.fixtureTimeout)
         }
 
         #expect(result.timedOut)
@@ -116,14 +120,14 @@ struct ShellExecutorTimeoutTests {
                 command: command,
                 cwd: nil,
                 env: environment,
-                timeout: 0.2,
+                timeout: Self.fixtureTimeout,
                 onStandardOutputLine: { _ in })
         } else {
             await ShellExecutor.runDetailed(
                 command: command,
                 cwd: nil,
                 env: environment,
-                timeout: 0.2)
+                timeout: Self.fixtureTimeout)
         }
 
         #expect(result.timedOut)
@@ -139,6 +143,9 @@ struct ShellExecutorTimeoutTests {
     }
 
     private func readPID(from file: URL) throws -> pid_t {
+        try #require(
+            FileManager.default.fileExists(atPath: file.path),
+            "Timeout fixture did not publish its PID file: \(file.path)")
         let value = try String(contentsOf: file, encoding: .utf8)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return try #require(pid_t(value))


### PR DESCRIPTION
## What Problem This Solves

`ShellExecutorTimeoutTests` is flaky by construction on `main`. Measured on an M-series Mac, the suite failed **2 of 4** runs under load and **1 of 6** under lighter load, always with the same opaque error:

```
Caught error: Error Domain=NSCocoaErrorDomain Code=260
"The file "openclaw-shell-timeout-<uuid>.pid" couldn't be opened because there is no such file."
```

The fixtures run `echo $$ > "$PID_FILE"; trap '' TERM; exec /bin/sleep 30` with a **0.1s** timeout (0.2s for the descendants case), then read that pid file after the call returns. `ShellExecutor` starts its deadline immediately after spawn, so the fixture has to fork, exec `/bin/sh`, and publish its pid inside that budget or the process group is killed before the pid is ever written and the read throws.

Measured `/bin/sh` spawn-to-pid-written latency on the same host: **n=30, min 24 ms, p50 40 ms, p90 67 ms, max 88 ms** — against a 100 ms budget, before Swift Testing's own parallel scheduling and `Process`/pipe setup. CI runs this suite at `--experimental-maximum-parallelization-width` up to 12, so the tail is worse there.

The budget was chosen below process-startup latency. That is the defect itself, not something the budget was hiding.

## Why This Change Was Made

The timeout value is a fixture parameter; the property under test is that a TERM-ignoring process and its descendants are killed and reaped. So the deadline is named, sized above process startup, and documented as a fixture budget — and a fixture that never published now says so instead of surfacing a file-not-found from `String(contentsOf:)`.

Deliberately **not** done, having tried and rejected it:

- **No production change.** `ShellExecutor` is correct here. Across every observed failure, `waitUntilGone` never once returned false — only the test's observation handle raced.
- **The pid file and `kill(pid, 0)` check are kept.** An earlier attempt replaced them with a unique marker in the spawned process's argv checked via `pgrep`. That is wrong: a killed-but-unreaped child becomes `Z <defunct>` and loses its argv, so `pgrep -f` exits 1 while `kill(pid, 0)` still succeeds. Verified directly. Marker absence would have reported "reaped" for a leaked zombie — silently deleting the property the test is named after.
- **No pid exposed from the result type**, which would be a test-only production seam.
- No retries, no weakened assertions, no skipped tests.

## User Impact

None at runtime. Test-only; production LOC delta is 0. CI and local macOS runs stop losing roughly half their `ShellExecutorTimeoutTests` runs to a fixture that never got to publish its pid.

## Evidence

Production LOC delta: 0. Tests: +11 / −4.

Before, on clean `origin/main`:

```
clean-run1: Test run with 5 tests in 1 suite passed after 0.516 seconds.
clean-run2: Test run with 5 tests in 1 suite failed after 0.480 seconds with 1 issue.
clean-run3: Test run with 5 tests in 1 suite failed after 0.576 seconds with 4 issues.
clean-run4: Test run with 5 tests in 1 suite passed after 0.435 seconds.
```

After, 20-iteration bounded loops (no `--repeat`):

```
pass=20 fail=0 of 20        # normal
pass=20 fail=0 of 20        # under 12 CPU burners plus a concurrent pnpm build
```

Wall clock per run goes from ~0.5 s to ~1.2 s. The four timeout cases are separate `@Test`s and run in parallel, so the suite cost is roughly one deadline rather than four.

Mutation proof — with the timeout path's `execution.send(signal: .kill, toProcessGroup: true)` removed:

```
Test "timeout terminates TERM-ignoring descendants" recorded an issue at ShellExecutorTimeoutTests.swift:142:9
Test "streaming timeout terminates TERM-ignoring descendants" recorded an issue at ShellExecutorTimeoutTests.swift:142:9
Test run with 5 tests in 1 suite failed after 30.090 seconds with 2 issues.
```

Both descendants cases fail, and the suite stalls from 1.2 s to 30.1 s because the executor then waits out `sleep 30`. Mutation fully reverted; `git status --porcelain` shows only the test file.

Sibling suites after the revert: `--filter Exec` runs 221 tests in 20 suites with a single failure, `ExecAllowlistTests` at line 1089 — a separate, already-diagnosed defect fixed in #134937, which reproduces here only because this worktree lives under `/private/tmp`. `ShellExecutorTimeoutTests` passes in that run.

`swiftformat --lint --config config/swiftformat` reports `0/1 files require formatting`; `swiftlint --config config/swiftlint.yml` reports no violations on this file.

Follow-up, not fixed here: with the group kill removed, the two `kills and reaps` cases still pass — they detect the regression as a 30 s stall rather than an assertion failure, because the subprocess execution awaits the child either way. Those two cases would be stronger with a bounded-duration assertion.
