### PR TITLE
test(msteams): remove copied store and own state fixture cleanup

### DIFF
--- a/extensions/msteams/src/conversation-store-state.test.ts
+++ b/extensions/msteams/src/conversation-store-state.test.ts
@@ -1,17 +1,24 @@
 // Msteams tests cover conversation store state plugin behavior.
 import crypto from "node:crypto";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import {
   createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { createMSTeamsConversationStoreState } from "./conversation-store-state.js";
 import type { StoredConversationReference } from "./conversation-store.js";
 import { setMSTeamsRuntime } from "./runtime.js";
 import { msteamsRuntimeStub } from "./test-support/runtime.js";
+
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterAll(() => {
+    resetPluginStateStoreForTests();
+    cleanup();
+  }),
+);
 
 function conversationStateKey(conversationId: string): string {
   return crypto.createHash("sha256").update(conversationId).digest("hex");
@@ -24,7 +31,7 @@ describe("msteams conversation store (plugin state)", () => {
   });
 
   it("filters expired SQLite entries while preserving entries without lastSeenAt", async () => {
-    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-store-"));
+    const stateDir = tempDirs.make("openclaw-msteams-store-");
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       OPENCLAW_STATE_DIR: stateDir,
@@ -82,7 +89,7 @@ describe("msteams conversation store (plugin state)", () => {
   });
 
   it("ignores a stale legacy JSON file at runtime", async () => {
-    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-store-"));
+    const stateDir = tempDirs.make("openclaw-msteams-store-");
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       OPENCLAW_STATE_DIR: stateDir,
@@ -123,7 +130,7 @@ describe("msteams conversation store (plugin state)", () => {
   });
 
   it("hashes external conversation ids before using plugin-state keys", async () => {
-    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-store-"));
+    const stateDir = tempDirs.make("openclaw-msteams-store-");
     const longConversationId = `a:${"x".repeat(900)}`;
     const store = createMSTeamsConversationStoreState({ stateDir });
 
@@ -140,7 +147,7 @@ describe("msteams conversation store (plugin state)", () => {
   });
 
   it("serializes concurrent upserts so sparse activities preserve independent fields", async () => {
-    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-store-"));
+    const stateDir = tempDirs.make("openclaw-msteams-store-");
     const store = createMSTeamsConversationStoreState({ stateDir });
 
     await store.upsert("conv-race", {
@@ -174,7 +181,7 @@ describe("msteams conversation store (plugin state)", () => {
   });
 
   it("keeps newest conversations by lastSeenAt at the row cap", async () => {
-    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-store-"));
+    const stateDir = tempDirs.make("openclaw-msteams-store-");
     const env: NodeJS.ProcessEnv = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     const sqliteStore = createPluginStateKeyedStoreForTests<StoredConversationReference>(
       "msteams",
@@ -208,7 +215,7 @@ describe("msteams conversation store (plugin state)", () => {
   });
 
   it("treats timestamp-less conversations as oldest during later cap pruning", async () => {
-    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-store-"));
+    const stateDir = tempDirs.make("openclaw-msteams-store-");
     const env: NodeJS.ProcessEnv = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     const sqliteStore = createPluginStateKeyedStoreForTests<StoredConversationReference>(
       "msteams",

--- a/extensions/msteams/src/conversation-store.shared.test.ts
+++ b/extensions/msteams/src/conversation-store.shared.test.ts
@@ -1,86 +1,34 @@
 // Msteams tests cover conversation store.shared plugin behavior.
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  findPreferredDmConversationByUserId,
-  mergeStoredConversationReference,
-  normalizeStoredConversationId,
-  toConversationStoreEntries,
-} from "./conversation-store-helpers.js";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMSTeamsConversationStoreState } from "./conversation-store-state.js";
-import type {
-  MSTeamsConversationStore,
-  MSTeamsConversationStoreEntry,
-  StoredConversationReference,
-} from "./conversation-store.js";
 import { setMSTeamsRuntime } from "./runtime.js";
 import { msteamsRuntimeStub } from "./test-support/runtime.js";
 
-type StoreFactory = {
-  name: string;
-  createStore: () => Promise<MSTeamsConversationStore>;
-};
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterAll(() => {
+    resetPluginStateStoreForTests();
+    cleanup();
+  }),
+);
 
-function createMemoryConversationStore(
-  initial: MSTeamsConversationStoreEntry[] = [],
-): MSTeamsConversationStore {
-  const map = new Map<string, StoredConversationReference>();
-  for (const { conversationId, reference } of initial) {
-    map.set(normalizeStoredConversationId(conversationId), reference);
-  }
-
-  const findPreferredDmByUserId = async (
-    id: string,
-  ): Promise<MSTeamsConversationStoreEntry | null> =>
-    findPreferredDmConversationByUserId(toConversationStoreEntries(map.entries()), id);
-
-  return {
-    upsert: async (conversationId, reference) => {
-      const normalizedId = normalizeStoredConversationId(conversationId);
-      map.set(
-        normalizedId,
-        mergeStoredConversationReference(
-          map.get(normalizedId),
-          reference,
-          new Date().toISOString(),
-        ),
-      );
-    },
-    get: async (conversationId) => map.get(normalizeStoredConversationId(conversationId)) ?? null,
-    list: async () => toConversationStoreEntries(map.entries()),
-    remove: async (conversationId) => map.delete(normalizeStoredConversationId(conversationId)),
-    findPreferredDmByUserId,
-  };
+function createStore() {
+  const stateDir = tempDirs.make("openclaw-msteams-store-");
+  return createMSTeamsConversationStoreState({
+    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    ttlMs: 60_000,
+  });
 }
 
-const storeFactories: StoreFactory[] = [
-  {
-    name: "state",
-    createStore: async () => {
-      const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-store-"));
-      return createMSTeamsConversationStoreState({
-        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-        ttlMs: 60_000,
-      });
-    },
-  },
-  {
-    name: "memory",
-    createStore: async () => createMemoryConversationStore(),
-  },
-];
-
-describe.each(storeFactories)("msteams conversation store ($name)", ({ createStore }) => {
+describe("msteams conversation store ('state')", () => {
   beforeEach(() => {
     resetPluginStateStoreForTests();
     setMSTeamsRuntime(msteamsRuntimeStub);
   });
 
   it("normalizes conversation ids consistently", async () => {
-    const store = await createStore();
+    const store = createStore();
 
     await store.upsert("conv-norm;messageid=123", {
       conversation: { id: "conv-norm" },
@@ -103,7 +51,7 @@ describe.each(storeFactories)("msteams conversation store ($name)", ({ createSto
   });
 
   it("upserts, lists, removes, and resolves users by both AAD and Bot Framework ids", async () => {
-    const store = await createStore();
+    const store = createStore();
 
     vi.useFakeTimers();
     try {
@@ -185,7 +133,7 @@ describe.each(storeFactories)("msteams conversation store ($name)", ({ createSto
   });
 
   it("preserves existing timezone when upsert omits timezone", async () => {
-    const store = await createStore();
+    const store = createStore();
 
     vi.useFakeTimers();
     try {
@@ -220,7 +168,7 @@ describe.each(storeFactories)("msteams conversation store ($name)", ({ createSto
   });
 
   it("prefers the freshest personal conversation for repeated upserts of the same user", async () => {
-    const store = await createStore();
+    const store = createStore();
 
     vi.useFakeTimers();
     try {

--- a/extensions/msteams/src/polls.test.ts
+++ b/extensions/msteams/src/polls.test.ts
@@ -1,13 +1,13 @@
 // Msteams tests cover polls plugin behavior.
 import crypto from "node:crypto";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import {
   createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import {
   buildMSTeamsPollCard,
   createMSTeamsPollStoreState,
@@ -16,6 +16,13 @@ import {
 } from "./polls.js";
 import { setMSTeamsRuntime } from "./runtime.js";
 import { msteamsRuntimeStub } from "./test-support/runtime.js";
+
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterAll(() => {
+    resetPluginStateStoreForTests();
+    cleanup();
+  }),
+);
 
 describe("msteams polls", () => {
   beforeEach(() => {
@@ -50,7 +57,7 @@ describe("msteams polls", () => {
   });
 
   it("stores and records poll votes", async () => {
-    const home = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-polls-"));
+    const home = tempDirs.make("openclaw-msteams-polls-");
     const store = createMSTeamsPollStoreState({ homedir: () => home });
     await store.createPoll({
       id: "poll-2",
@@ -73,7 +80,7 @@ describe("msteams polls", () => {
   });
 
   it("deduplicates selections before enforcing maxSelections", async () => {
-    const home = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-polls-"));
+    const home = tempDirs.make("openclaw-msteams-polls-");
     const store = createMSTeamsPollStoreState({ homedir: () => home });
     await store.createPoll({
       id: "poll-dedupe",
@@ -103,7 +110,7 @@ describe("state poll store", () => {
   });
 
   it("ignores legacy JSON polls at runtime", async () => {
-    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-polls-"));
+    const stateDir = tempDirs.make("openclaw-msteams-polls-");
     const filePath = path.join(stateDir, "msteams-polls.json");
     await fs.promises.writeFile(
       filePath,
@@ -141,7 +148,7 @@ describe("state poll store", () => {
   });
 
   it("hashes external poll ids before using plugin-state keys", async () => {
-    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-polls-"));
+    const stateDir = tempDirs.make("openclaw-msteams-polls-");
     const store = createMSTeamsPollStoreState({ stateDir });
     const longPollId = `poll-${"x".repeat(900)}`;
 
@@ -165,7 +172,7 @@ describe("state poll store", () => {
   });
 
   it("serializes concurrent votes for the same poll", async () => {
-    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-polls-"));
+    const stateDir = tempDirs.make("openclaw-msteams-polls-");
     const store = createMSTeamsPollStoreState({ stateDir });
     await store.createPoll({
       id: "poll-race",
@@ -193,7 +200,7 @@ describe("state poll store", () => {
     { selections: ["0", "1x"], expected: ["0"] },
     { selections: ["+0", "0x1", "1"], expected: ["0", "1"] },
   ])("accepts only strict decimal poll selections", async ({ selections, expected }) => {
-    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-polls-"));
+    const stateDir = tempDirs.make("openclaw-msteams-polls-");
     const store = createMSTeamsPollStoreState({ stateDir });
     await store.createPoll({
       id: "poll-strict-selections",
@@ -214,7 +221,7 @@ describe("state poll store", () => {
   });
 
   it("keeps large vote maps split across bounded rows", async () => {
-    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-polls-"));
+    const stateDir = tempDirs.make("openclaw-msteams-polls-");
     const store = createMSTeamsPollStoreState({ stateDir });
     const votes = Object.fromEntries(
       Array.from({ length: 500 }, (_, index) => [
@@ -239,7 +246,7 @@ describe("state poll store", () => {
   });
 
   it("deletes vote buckets when pruning over the poll cap", async () => {
-    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-polls-"));
+    const stateDir = tempDirs.make("openclaw-msteams-polls-");
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     const metadataStore = createPluginStateKeyedStoreForTests<Omit<MSTeamsPoll, "votes">>(
       "msteams",

--- a/extensions/msteams/src/sso-token-store.test.ts
+++ b/extensions/msteams/src/sso-token-store.test.ts
@@ -1,12 +1,19 @@
 // Msteams tests cover sso token store plugin behavior.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { setMSTeamsRuntime } from "./runtime.js";
 import { createMSTeamsSsoTokenStoreFs } from "./sso-token-store.js";
 import { msteamsRuntimeStub } from "./test-support/runtime.js";
+
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterAll(() => {
+    resetPluginStateStoreForTests();
+    cleanup();
+  }),
+);
 
 describe("msteams sso token store (plugin state)", () => {
   beforeEach(() => {
@@ -15,7 +22,7 @@ describe("msteams sso token store (plugin state)", () => {
   });
 
   it("keeps distinct tokens when connectionName and userId contain the legacy delimiter", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-sso-"));
+    const stateDir = tempDirs.make("openclaw-msteams-sso-");
     const storePath = path.join(stateDir, "msteams-sso-tokens.json");
     const store = createMSTeamsSsoTokenStoreFs({ storePath });
 
@@ -45,7 +52,7 @@ describe("msteams sso token store (plugin state)", () => {
   });
 
   it("ignores legacy flat-key token files at runtime", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-sso-legacy-"));
+    const stateDir = tempDirs.make("openclaw-msteams-sso-legacy-");
     const storePath = path.join(stateDir, "msteams-sso-tokens.json");
     await fs.writeFile(
       storePath,
@@ -78,7 +85,7 @@ describe("msteams sso token store (plugin state)", () => {
   });
 
   it("keeps plugin-state keys bounded for long Teams identifiers", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-sso-long-"));
+    const stateDir = tempDirs.make("openclaw-msteams-sso-long-");
     const store = createMSTeamsSsoTokenStoreFs({ stateDir });
     const token = {
       connectionName: `conn-${"c".repeat(1000)}`,


### PR DESCRIPTION
## What Problem This Solves

The shared Teams suite still replays four cases against a locally copied memory implementation after that production owner was removed. The four state suites also allocate twenty-two real temporary roots without assigning their final directory cleanup to the suite owner.

## Why This Change Was Made

Keep the real state store as the canonical shared-test subject and delete the copied factory plus its table branch. Use the existing temp tracker in each changed file and invoke resetPluginStateStoreForTests before directory cleanup in one afterAll callback. This preserves database closure before deletion independently of relative hook ordering.

## User Impact

Production +0/-0; tests +64/-95 (net -31).

Focused native proof passes 40/40 before and 36/36 after: only the four copied-memory replays disappear. All 24 retained cases in the four changed suites and 12 independent helper cases retain exact native identities, including the quoted state ancestor and repeated poll-row multiplicity. The source inventory retains all 22 real fixture allocations and the existing row/voter caps, concurrent mutations, legacy-file/key-boundary and token-removal assertions.

## Evidence

The normal dedicated MSTeams owner suite passes 1541/1541 across 99 files. Four SSO sensitivity runs each retain one exact injected native failure and two skips, without unhandled, extra hook or outer-timeout failures. At setup-after-allocation and settled-after-save boundaries, the baseline root remains after its corresponding file hook; the candidate root is removed before probe/shared cleanup. The settled candidate retains and observes the real DatabaseSync handle closed while the root still exists, before tracker deletion. The launcher records exact original-source restoration after its joined wrapper executions; current SSO bytes match the reviewed candidate. Full changed-file gate exit 0 is confirmed. Scoped Codex autoreview returned no findings at its requested threshold. No hosted CI or landing is claimed.

Named follow-up: Promise.all can reject before a mutation peer settles; reset is not a queue join, and these faults occur only at quiescent boundaries. The four-run observation covers one SSO fixture, not every allocated root, all four files' failure paths, or arbitrary process death. The launcher records wrapper/stream close, not an independent process-group-dead observation. No local Windows handle/deletion proof is claimed. On Windows the two homedir polls fixtures can use worker OPENCLAW_STATE_DIR, so 22 allocated roots need not mean 22 distinct DB paths. The shared newest-personal case's 60s TTL does not replace the 12 independent ranking helper cases. Cleanup adds real work; no SQLite-work reduction, full in-flight cleanup or elapsed speedup is claimed.

The first full-owner invocation used only the JSON reporter and was stopped by the wrapper's no-output watchdog. Repeating the same owner scope with the normal progress reporter passed all 1,541 cases without changing test or hook timeouts. The configured review model was unavailable; the same isolated Codex review workflow completed with its supported public model.
