### PR TITLE
fix(line): keep the words and options a quick-reply prompt leaves behind

### DIFF
--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -297,8 +297,10 @@ A `buttons` block renders a Flex card that carries the presentation's title and
 text. A presentation whose only control is a `select` renders no card, because
 quick replies attach to the reply's own text message; its title and text blocks
 are appended to that text instead. LINE draws at most 13 quick replies on one
-message, counted across every `select` block in the reply rather than per block,
-and the options past that are appended to the same text.
+message, counted across every `select` block in the reply rather than per block.
+Each select keeps its prompt and any overflow options together in that text.
+Prompts and overflow option names remain complete; only native quick-reply button
+labels are shortened to LINE's 20-character limit.
 
 ```json5
 {

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -293,6 +293,13 @@ Use the shared message presentation fields for portable choices. LINE renders
 `buttons` blocks as Flex controls and `select` blocks as quick replies. A two-button
 block is the portable confirm-style form.
 
+A `buttons` block renders a Flex card that carries the presentation's title and
+text. A presentation whose only control is a `select` renders no card, because
+quick replies attach to the reply's own text message; its title and text blocks
+are appended to that text instead. LINE draws at most 13 quick replies on one
+message, counted across every `select` block in the reply rather than per block,
+and the options past that are appended to the same text.
+
 ```json5
 {
   action: "send",

--- a/extensions/line/src/channel.rich-messages.test.ts
+++ b/extensions/line/src/channel.rich-messages.test.ts
@@ -137,6 +137,58 @@ describe("LINE rich-message boundaries", () => {
     expect(line?.quickReplyItems).toHaveLength(1);
   });
 
+  it.each([undefined, "", "   "])("keeps the select prompt when fallback text is %j", (text) => {
+    const prepared = prepareLineReplyPayload({
+      text,
+      presentationTextMode: "fallback",
+      presentation: {
+        title: "Choose a deployment",
+        blocks: [
+          {
+            type: "select",
+            placeholder: "Which environment should receive this deployment?",
+            options: [{ label: "Staging", action: { type: "callback", value: "staging" } }],
+          },
+        ],
+      },
+    });
+
+    expect(prepared.text).toBe(
+      "Choose a deployment\n\nWhich environment should receive this deployment?",
+    );
+  });
+
+  it("preserves full select prompts and overflow labels while bounding native labels", () => {
+    const placeholder = "Which region should receive this deployment?";
+    const options = Array.from({ length: 8 }, (_, index) => ({
+      label: `Deployment region number ${index + 1}`,
+      action: { type: "command" as const, command: `/region ${index + 1}` },
+    }));
+    const prepared = prepareLineReplyPayload({
+      presentation: {
+        blocks: [
+          { type: "select", placeholder: "Choose the first region", options },
+          { type: "select", placeholder, options },
+        ],
+      },
+    });
+    const line = prepared.channelData?.line as {
+      quickReplyItems: Parameters<typeof createLineQuickReply>[0];
+    };
+
+    expect(prepared.text).toBe(
+      `Choose the first region\n\n${placeholder}:\n` +
+        options
+          .slice(5)
+          .map((option) => `- ${option.label}: \`${option.action.command}\``)
+          .join("\n"),
+    );
+    const native = createLineQuickReply(line.quickReplyItems);
+    expect(native.items).toHaveLength(13);
+    expect(native.items?.every((item) => (item.action?.label?.length ?? 0) <= 20)).toBe(true);
+    expect(native.items?.at(-1)?.action).toMatchObject({ type: "message", text: "/region 5" });
+  });
+
   it("keeps the words around quick replies when no Flex body carries them", () => {
     const prepared = prepareLineReplyPayload({
       text: "Here are the files.",

--- a/extensions/line/src/channel.rich-messages.test.ts
+++ b/extensions/line/src/channel.rich-messages.test.ts
@@ -130,11 +130,239 @@ describe("LINE rich-message boundaries", () => {
     const line = prepared.channelData?.line as
       | { quickReplyItems?: unknown[]; flexMessage?: unknown }
       | undefined;
-    // A select alone renders no Flex body, so the prose is still the only thing
-    // carrying the question. Clearing it delivers bare option labels.
+    // A select alone renders no Flex body. The author's own prose says the same
+    // thing the renderer would rebuild, so it stays exactly as written.
     expect(prepared.text).toBe("Agent needs input:\n1. Alpha");
     expect(line?.flexMessage).toBeUndefined();
     expect(line?.quickReplyItems).toHaveLength(1);
+  });
+
+  it("keeps the words around quick replies when no Flex body carries them", () => {
+    const prepared = prepareLineReplyPayload({
+      text: "Here are the files.",
+      presentation: {
+        title: "Pick a file",
+        blocks: [
+          { type: "text", text: "Which file should I open?" },
+          {
+            type: "select",
+            options: [{ label: "notes.md", action: { type: "callback", value: "notes" } }],
+          },
+        ],
+      },
+    });
+
+    const line = prepared.channelData?.line as
+      | { quickReplyItems?: unknown[]; flexMessage?: unknown }
+      | undefined;
+    expect(line?.flexMessage).toBeUndefined();
+    expect(line?.quickReplyItems).toHaveLength(1);
+    expect(prepared.text).toContain("Here are the files.");
+    expect(prepared.text).toContain("Pick a file");
+    expect(prepared.text).toContain("Which file should I open?");
+    // The one option LINE draws natively must not also be listed as prose.
+    expect(prepared.text).not.toContain("notes.md");
+  });
+
+  it("keeps the options that did not fit LINE's quick reply row", () => {
+    const options = Array.from({ length: 20 }, (_, index) => ({
+      label: `Option ${index + 1}`,
+      action: { type: "callback" as const, value: `opt-${index + 1}` },
+    }));
+
+    const prepared = prepareLineReplyPayload({
+      text: "Here are the files.",
+      presentation: { blocks: [{ type: "select", options }] },
+    });
+
+    const line = prepared.channelData?.line as { quickReplyItems?: unknown[] } | undefined;
+    // LINE accepts 13 quick replies; the rest have to reach the user as text.
+    expect(line?.quickReplyItems).toHaveLength(13);
+    for (const label of ["Option 14", "Option 20"]) {
+      expect(prepared.text).toContain(label);
+    }
+    expect(prepared.text).not.toContain("Option 1\n");
+  });
+
+  it("keeps a select prompt's title when the title is all it carries", () => {
+    const prepared = prepareLineReplyPayload({
+      text: "Here are the files.",
+      presentation: {
+        title: "Pick a file",
+        blocks: [
+          {
+            type: "select",
+            options: [{ label: "notes.md", action: { type: "callback", value: "notes" } }],
+          },
+        ],
+      },
+    });
+
+    expect(prepared.text).toBe("Here are the files.\n\nPick a file");
+  });
+
+  it("keeps that title on the outbound path, which delivers no fallback text of its own", async () => {
+    // Core blanks the text before calling the renderer when the producer marked
+    // it as the presentation's fallback, so the title is the only prose left.
+    const rendered = await lineOutboundAdapter.renderPresentation?.({
+      payload: { text: undefined },
+      presentation: {
+        title: "Pick a file",
+        blocks: [
+          {
+            type: "select",
+            options: [{ label: "notes.md", action: { type: "callback", value: "notes" } }],
+          },
+        ],
+      },
+    } as never);
+
+    expect(rendered?.text).toBe("Pick a file");
+    const line = rendered?.channelData?.line as { quickReplyItems?: unknown[] } | undefined;
+    expect(line?.quickReplyItems).toHaveLength(1);
+  });
+
+  it("keeps a select's placeholder when every option became a chip", () => {
+    const presentation = {
+      blocks: [
+        {
+          type: "select" as const,
+          placeholder: "Pick a day",
+          options: [
+            { label: "Mon", action: { type: "callback" as const, value: "mon" } },
+            { label: "Tue", action: { type: "callback" as const, value: "tue" } },
+          ],
+        },
+      ],
+    };
+
+    const prepared = prepareLineReplyPayload({ text: "Here you go.", presentation });
+
+    // The placeholder is the prompt for those chips; the fallback renderer drops
+    // a select with no options, so it cannot ride along inside the block.
+    expect(prepared.text).toBe("Here you go.\n\nPick a day");
+    const line = prepared.channelData?.line as { quickReplyItems?: unknown[] } | undefined;
+    expect(line?.quickReplyItems).toHaveLength(2);
+  });
+
+  it("keeps that placeholder on the outbound path too", async () => {
+    const rendered = await lineOutboundAdapter.renderPresentation?.({
+      payload: { text: undefined },
+      presentation: {
+        blocks: [
+          {
+            type: "select",
+            placeholder: "Pick a day",
+            options: [{ label: "Mon", action: { type: "callback", value: "mon" } }],
+          },
+        ],
+      },
+    } as never);
+
+    expect(rendered?.text).toBe("Pick a day");
+  });
+
+  it("keeps each select's own heading over its own leftovers", () => {
+    const block = (placeholder: string, prefix: string) => ({
+      type: "select" as const,
+      placeholder,
+      options: Array.from({ length: 8 }, (_, index) => ({
+        label: `${prefix}-${index + 1}`,
+        action: { type: "callback" as const, value: `${prefix}-${index + 1}` },
+      })),
+    });
+
+    const prepared = prepareLineReplyPayload({
+      text: "Choose.",
+      presentation: { blocks: [block("Environment", "env"), block("Region", "region")] },
+    });
+
+    // The row fills in order, so the first select keeps only its prompt while the
+    // second one's leftovers stay under the heading they belong to.
+    expect(prepared.text).toBe(
+      "Choose.\n\nEnvironment\n\nRegion:\n- region-6\n- region-7\n- region-8",
+    );
+  });
+
+  it("keeps the options two select blocks push past LINE's one-message limit", () => {
+    const block = (prefix: string) => ({
+      type: "select" as const,
+      options: Array.from({ length: 8 }, (_, index) => ({
+        label: `${prefix}-${index + 1}`,
+        action: { type: "callback" as const, value: `${prefix}-${index + 1}` },
+      })),
+    });
+
+    const prepared = prepareLineReplyPayload({
+      text: "Pick an environment and a region.",
+      presentation: { blocks: [block("env"), block("region")] },
+    });
+
+    const line = prepared.channelData?.line as { quickReplyItems?: Array<{ label: string }> };
+    // Each block fits on its own; together they exceed what one message carries.
+    expect(line.quickReplyItems).toHaveLength(13);
+    expect(line.quickReplyItems?.at(-1)?.label).toBe("region-5");
+    for (const label of ["region-6", "region-7", "region-8"]) {
+      expect(prepared.text).toContain(label);
+    }
+    // The thirteen LINE draws must not also be listed as prose.
+    expect(prepared.text).not.toContain("env-1");
+  });
+
+  it("keeps the overflow options beside a Flex card without repeating the card", () => {
+    const block = (prefix: string) => ({
+      type: "select" as const,
+      options: Array.from({ length: 8 }, (_, index) => ({
+        label: `${prefix}-${index + 1}`,
+        action: { type: "callback" as const, value: `${prefix}-${index + 1}` },
+      })),
+    });
+
+    const prepared = prepareLineReplyPayload({
+      text: "Choose a target.",
+      presentation: {
+        title: "Deploy",
+        blocks: [
+          { type: "text", text: "Staging is green." },
+          {
+            type: "buttons",
+            buttons: [{ label: "Deploy", action: { type: "command", command: "/deploy" } }],
+          },
+          block("env"),
+          block("region"),
+        ],
+      },
+    });
+
+    const line = prepared.channelData?.line as {
+      flexMessage?: unknown;
+      quickReplyItems?: unknown[];
+    };
+    expect(line.flexMessage).toBeDefined();
+    expect(line.quickReplyItems).toHaveLength(13);
+    expect(prepared.text).toContain("region-8");
+    // The card already carries the title and the text block; the text must not repeat them.
+    expect(prepared.text).not.toContain("Staging is green.");
+    expect(prepared.text).not.toContain("Deploy");
+  });
+
+  it("keeps a table beside a select instead of dropping it", () => {
+    const prepared = prepareLineReplyPayload({
+      text: "Here is this week's usage.",
+      presentation: {
+        blocks: [
+          { type: "table", caption: "Runs", headers: ["Day", "Runs"], rows: [["Mon", "12"]] },
+          {
+            type: "select",
+            options: [{ label: "Mon", action: { type: "callback", value: "mon" } }],
+          },
+        ],
+      },
+    });
+
+    expect(prepared.text).toContain("Here is this week's usage.");
+    expect(prepared.text).toContain("Runs");
+    expect(prepared.text).toContain("12");
   });
 
   it("replaces fallback text once a Flex body renders the same controls", () => {

--- a/extensions/line/src/rich-messages.ts
+++ b/extensions/line/src/rich-messages.ts
@@ -118,9 +118,7 @@ export const lineMessageActions: ChannelMessageActionAdapter = {
   prepareSendPayload: ({ payload }) => payload,
 };
 
-// LINE caps quick replies per message, not per select block, and rejects the
-// whole request at one item over. Core budgets each block against this same
-// number, so several blocks can still add up past it.
+// LINE's 13-item quick-reply budget is shared by every select in one message.
 const LINE_QUICK_REPLY_LIMIT = 13;
 
 export const LINE_PRESENTATION_CAPABILITIES = {
@@ -130,7 +128,9 @@ export const LINE_PRESENTATION_CAPABILITIES = {
   context: true,
   limits: {
     actions: { maxActions: 4, maxActionsPerRow: 1, maxRows: 4, maxLabelLength: 40 },
-    selects: { maxOptions: LINE_QUICK_REPLY_LIMIT, maxLabelLength: 20, maxValueBytes: 300 },
+    // Native action encoding bounds labels; clipping here also loses plain-text
+    // placeholders and option names that overflow the shared quick-reply row.
+    selects: { maxOptions: LINE_QUICK_REPLY_LIMIT, maxValueBytes: 300 },
     text: { markdownDialect: "plain" },
   },
 } satisfies NonNullable<ChannelOutboundAdapter["presentationCapabilities"]>;
@@ -157,86 +157,73 @@ export function renderLinePresentation(
   payload: ReplyPayload,
   presentation: MessagePresentation,
 ): ReplyPayload | null {
-  const buttons = presentation.blocks.flatMap((block) =>
-    block.type === "buttons" ? block.buttons : [],
+  const hasCard = presentation.blocks.some(
+    (block) => block.type === "buttons" && block.buttons.length > 0,
   );
-  const buttonActions = buttons.map(toLineAction);
-  const options = presentation.blocks.flatMap((block) =>
-    block.type === "select" ? block.options : [],
-  );
-  const quickReplyItems = options.flatMap<LineQuickReplyItem>((option) => {
-    const action = resolveMessagePresentationOptionAction(option);
-    return action?.type === "command" || action?.type === "callback"
-      ? [{ label: option.label, action }]
-      : [];
-  });
-  if (
-    (buttons.length > 0 && buttonActions.some((action) => !action)) ||
-    quickReplyItems.length !== options.length ||
-    (buttons.length === 0 && options.length === 0)
-  ) {
+  const buttons: Array<{ label: string; action: Action }> = [];
+  const quickReplyItems: LineQuickReplyItem[] = [];
+  const carriedBlocks: MessagePresentationBlock[] = [];
+  const cardBody: string[] = [];
+  for (const block of presentation.blocks) {
+    if (block.type === "buttons") {
+      for (const button of block.buttons) {
+        const action = toLineAction(button);
+        if (!action) {
+          return null;
+        }
+        buttons.push({ label: button.label, action });
+      }
+    } else if (block.type === "select") {
+      const overflow: typeof block.options = [];
+      for (const option of block.options) {
+        const action = resolveMessagePresentationOptionAction(option);
+        if (!action) {
+          return null;
+        }
+        if (quickReplyItems.length < LINE_QUICK_REPLY_LIMIT) {
+          quickReplyItems.push({ label: option.label, action });
+        } else {
+          overflow.push(option);
+        }
+      }
+      // Keep each prompt beside its own overflow; an empty select would lose its
+      // placeholder in the fallback renderer even though its chips still need it.
+      if (overflow.length > 0) {
+        carriedBlocks.push({ ...block, options: overflow });
+      } else if (block.placeholder) {
+        carriedBlocks.push({ type: "context", text: block.placeholder });
+      }
+    } else if (!hasCard) {
+      carriedBlocks.push(block);
+    } else if (block.type === "text" || block.type === "context") {
+      cardBody.push(block.text);
+    }
+  }
+  if (buttons.length === 0 && quickReplyItems.length === 0) {
     return null;
   }
 
   const lineData = isRecord(payload.channelData?.line) ? payload.channelData.line : {};
-  const cardBody = presentation.blocks
-    .flatMap((block) => (block.type === "text" || block.type === "context" ? [block.text] : []))
-    .join("\n");
   const title = presentation.title || "Choose an option";
-  const flexMessage =
-    buttonActions.length > 0
-      ? {
-          altText: title,
-          contents: createActionCard(
-            title,
-            cardBody || "Choose an option.",
-            buttons.map((button, index) => ({
-              label: button.label,
-              action: buttonActions[index]!,
-            })),
-          ),
-        }
-      : undefined;
-  // Quick replies ride on the reply's own text message, so a select-only
-  // presentation renders no card and has nowhere native to keep its words.
-  // Everything LINE did not draw joins that text or it reaches nobody.
-  let drawn = 0;
-  const carriedBlocks = presentation.blocks.flatMap<MessagePresentationBlock>((block) => {
-    if (block.type !== "select") {
-      // A card already shows the title and the text blocks; only selects are left.
-      return flexMessage ? [] : [block];
-    }
-    // LINE fills one shared quick-reply row, so each select draws from what the
-    // blocks before it left. Keeping the block carries its own prompt with its
-    // own leftovers instead of pooling every select under one generic heading.
-    const spill = block.options.slice(Math.max(0, LINE_QUICK_REPLY_LIMIT - drawn));
-    drawn += block.options.length - spill.length;
-    if (spill.length > 0) {
-      return [{ ...block, options: spill }];
-    }
-    // Every option became a chip. The fallback renderer drops a select with no
-    // options, so the prompt that explains those chips needs its own block.
-    return block.placeholder ? [{ type: "context", text: block.placeholder }] : [];
-  });
-  const undrawn = flexMessage
-    ? { blocks: carriedBlocks }
-    : { ...presentation, blocks: carriedBlocks };
-  // Ask the renderer rather than predicting it: anything it adds to the reply
-  // text is content LINE would otherwise drop, whichever field it came from.
-  const rendered = renderMessagePresentationFallbackText({
+  const flexMessage = hasCard
+    ? {
+        altText: title,
+        contents: createActionCard(title, cardBody.join("\n") || "Choose an option.", buttons),
+      }
+    : undefined;
+  const text = renderMessagePresentationFallbackText({
     text: payload.text,
-    presentation: undrawn,
+    presentation: { title: hasCard ? undefined : presentation.title, blocks: carriedBlocks },
   });
-  const carriedText = rendered === (payload.text ?? "") ? undefined : rendered;
   return {
     ...payload,
-    ...(carriedText ? { text: carriedText } : {}),
+    ...(text ? { text } : {}),
     channelData: {
       ...payload.channelData,
       line: {
         ...lineData,
         ...(flexMessage ? { flexMessage } : {}),
-        quickReplyItems: quickReplyItems.slice(0, LINE_QUICK_REPLY_LIMIT),
+        quickReplyItems,
       },
     },
   };
@@ -256,7 +243,7 @@ export function prepareLineReplyPayload(payload: ReplyPayload): ReplyPayload {
   }
   const { presentation: _presentation, presentationTextMode, ...rest } = payload;
   // "fallback" text already renders these controls as prose; native ones replace it.
-  const usesFallbackText = presentationTextMode === "fallback";
+  const usesFallbackText = presentationTextMode === "fallback" && Boolean(rest.text?.trim());
   const rendered = renderLinePresentation(
     usesFallbackText ? { ...rest, text: undefined } : rest,
     adaptMessagePresentationForChannel({

--- a/extensions/line/src/rich-messages.ts
+++ b/extensions/line/src/rich-messages.ts
@@ -9,6 +9,7 @@ import {
   resolveMessagePresentationButtonAction,
   resolveMessagePresentationOptionAction,
   type MessagePresentation,
+  type MessagePresentationBlock,
   type MessagePresentationButton,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
@@ -117,6 +118,11 @@ export const lineMessageActions: ChannelMessageActionAdapter = {
   prepareSendPayload: ({ payload }) => payload,
 };
 
+// LINE caps quick replies per message, not per select block, and rejects the
+// whole request at one item over. Core budgets each block against this same
+// number, so several blocks can still add up past it.
+const LINE_QUICK_REPLY_LIMIT = 13;
+
 export const LINE_PRESENTATION_CAPABILITIES = {
   supported: true,
   buttons: true,
@@ -124,7 +130,7 @@ export const LINE_PRESENTATION_CAPABILITIES = {
   context: true,
   limits: {
     actions: { maxActions: 4, maxActionsPerRow: 1, maxRows: 4, maxLabelLength: 40 },
-    selects: { maxOptions: 13, maxLabelLength: 20, maxValueBytes: 300 },
+    selects: { maxOptions: LINE_QUICK_REPLY_LIMIT, maxLabelLength: 20, maxValueBytes: 300 },
     text: { markdownDialect: "plain" },
   },
 } satisfies NonNullable<ChannelOutboundAdapter["presentationCapabilities"]>;
@@ -173,7 +179,7 @@ export function renderLinePresentation(
   }
 
   const lineData = isRecord(payload.channelData?.line) ? payload.channelData.line : {};
-  const text = presentation.blocks
+  const cardBody = presentation.blocks
     .flatMap((block) => (block.type === "text" || block.type === "context" ? [block.text] : []))
     .join("\n");
   const title = presentation.title || "Choose an option";
@@ -183,7 +189,7 @@ export function renderLinePresentation(
           altText: title,
           contents: createActionCard(
             title,
-            text || "Choose an option.",
+            cardBody || "Choose an option.",
             buttons.map((button, index) => ({
               label: button.label,
               action: buttonActions[index]!,
@@ -191,11 +197,47 @@ export function renderLinePresentation(
           ),
         }
       : undefined;
+  // Quick replies ride on the reply's own text message, so a select-only
+  // presentation renders no card and has nowhere native to keep its words.
+  // Everything LINE did not draw joins that text or it reaches nobody.
+  let drawn = 0;
+  const carriedBlocks = presentation.blocks.flatMap<MessagePresentationBlock>((block) => {
+    if (block.type !== "select") {
+      // A card already shows the title and the text blocks; only selects are left.
+      return flexMessage ? [] : [block];
+    }
+    // LINE fills one shared quick-reply row, so each select draws from what the
+    // blocks before it left. Keeping the block carries its own prompt with its
+    // own leftovers instead of pooling every select under one generic heading.
+    const spill = block.options.slice(Math.max(0, LINE_QUICK_REPLY_LIMIT - drawn));
+    drawn += block.options.length - spill.length;
+    if (spill.length > 0) {
+      return [{ ...block, options: spill }];
+    }
+    // Every option became a chip. The fallback renderer drops a select with no
+    // options, so the prompt that explains those chips needs its own block.
+    return block.placeholder ? [{ type: "context", text: block.placeholder }] : [];
+  });
+  const undrawn = flexMessage
+    ? { blocks: carriedBlocks }
+    : { ...presentation, blocks: carriedBlocks };
+  // Ask the renderer rather than predicting it: anything it adds to the reply
+  // text is content LINE would otherwise drop, whichever field it came from.
+  const rendered = renderMessagePresentationFallbackText({
+    text: payload.text,
+    presentation: undrawn,
+  });
+  const carriedText = rendered === (payload.text ?? "") ? undefined : rendered;
   return {
     ...payload,
+    ...(carriedText ? { text: carriedText } : {}),
     channelData: {
       ...payload.channelData,
-      line: { ...lineData, ...(flexMessage ? { flexMessage } : {}), quickReplyItems },
+      line: {
+        ...lineData,
+        ...(flexMessage ? { flexMessage } : {}),
+        quickReplyItems: quickReplyItems.slice(0, LINE_QUICK_REPLY_LIMIT),
+      },
     },
   };
 }
@@ -223,9 +265,9 @@ export function prepareLineReplyPayload(payload: ReplyPayload): ReplyPayload {
     }),
   );
   if (rendered) {
-    // Only a Flex body replaces the fallback prose. A select-only presentation
-    // renders quick replies without one, so dropping the text there would send
-    // bare option labels and lose the question they answer.
+    // Only a Flex body replaces the fallback prose. Without a card the renderer
+    // rebuilds the words it could not draw, and the author's own fallback text
+    // is the better rendering of the same facts, so it wins.
     const renderedLine = isRecord(rendered.channelData?.line) ? rendered.channelData.line : {};
     return usesFallbackText && renderedLine.flexMessage === undefined
       ? { ...rendered, text: rest.text }
@@ -321,7 +363,7 @@ export function renderLineCard(card: LineRichCard): { altText: string; contents:
 
 export function createLineQuickReply(items: LineQuickReplyItem[]): messagingApi.QuickReply {
   return {
-    items: items.slice(0, 13).map((item) => ({
+    items: items.slice(0, LINE_QUICK_REPLY_LIMIT).map((item) => ({
       type: "action",
       action:
         item.action.type === "command"

--- a/extensions/line/src/row-overflow-delivery.loopback.test.ts
+++ b/extensions/line/src/row-overflow-delivery.loopback.test.ts
@@ -1,4 +1,8 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import {
+  adaptMessagePresentationForChannel,
+  type MessagePresentation,
+} from "openclaw/plugin-sdk/interactive-runtime";
 import { chunkMarkdownText } from "openclaw/plugin-sdk/reply-runtime";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginRuntime } from "../api.js";
@@ -6,10 +10,17 @@ import { deliverLineAutoReply } from "./auto-reply-delivery.js";
 import { baseDeliveryParams, createDeps } from "./auto-reply-delivery.test-helpers.js";
 import { processLineMessage } from "./markdown-to-line.js";
 import { lineOutboundAdapter } from "./outbound.js";
+import { LINE_PRESENTATION_CAPABILITIES, prepareLineReplyPayload } from "./rich-messages.js";
 import { setLineRuntime } from "./runtime.js";
-import { pushMessagesLine } from "./send.js";
+import { createFlexMessage, pushMessagesLine, replyMessageLine } from "./send.js";
+import type { LineChannelData } from "./types.js";
 
-type WireMessage = { type: string; text?: string; altText?: string };
+type WireMessage = {
+  type: string;
+  text?: string;
+  altText?: string;
+  quickReply?: { items: Array<{ action: { label: string; text?: string; data?: string } }> };
+};
 
 type RecordedLineApiRequest = {
   method: string;
@@ -235,6 +246,103 @@ describe("Row-overflow table delivery through production outbound adapter over l
     vi.doUnmock("openclaw/plugin-sdk/runtime-env");
     vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
     vi.resetModules();
+  });
+
+  it.each([
+    { delivery: "reply", card: false },
+    { delivery: "reply", card: true },
+    { delivery: "push", card: false },
+    { delivery: "push", card: true },
+  ])("carries every select through $delivery requests (card=$card)", async ({ delivery, card }) => {
+    const selects = ["environment", "region", "version"].map((kind) => ({
+      type: "select" as const,
+      placeholder: `Which ${kind} should receive this deployment?`,
+      options: Array.from({ length: 8 }, (_, index) => ({
+        label: `${kind}-${index + 1} full deployment name`,
+        action: { type: "command" as const, command: `/${kind} ${index + 1}` },
+      })),
+    }));
+    const presentation: MessagePresentation = {
+      title: "Deployment choices",
+      blocks: [
+        { type: "context", text: "Review all three choices." },
+        ...(card
+          ? [
+              {
+                type: "buttons" as const,
+                buttons: [
+                  { label: "Help", action: { type: "command" as const, command: "/help" } },
+                ],
+              },
+            ]
+          : []),
+        ...selects,
+      ],
+    };
+    const payload = { text: "Deployment details. ".repeat(1_500), presentation };
+    const prepared =
+      delivery === "reply"
+        ? prepareLineReplyPayload(payload)
+        : await lineOutboundAdapter.renderPresentation!({
+            payload,
+            presentation: adaptMessagePresentationForChannel({
+              presentation,
+              capabilities: LINE_PRESENTATION_CAPABILITIES,
+            }),
+            ctx: {} as never,
+          });
+    if (!prepared) {
+      throw new Error("LINE presentation did not render");
+    }
+    if (delivery === "reply") {
+      const { deps } = createDeps({
+        processLineMessage,
+        chunkMarkdownText,
+        createFlexMessage,
+        pushMessagesLine,
+        replyMessageLine,
+      });
+      await deliverLineAutoReply({
+        ...baseDeliveryParams,
+        cfg: LINE_TEST_CFG,
+        accountId: "default",
+        payload: prepared,
+        lineData: prepared.channelData?.line as LineChannelData,
+        deps,
+      });
+    } else {
+      await lineOutboundAdapter.sendPayload!({
+        to: "line:user:Uselect",
+        text: prepared.text ?? "",
+        payload: prepared,
+        cfg: LINE_TEST_CFG,
+      });
+    }
+
+    const messages = collectAllWireMessages(requests);
+    const text = messages
+      .filter((message) => message.type === "text")
+      .map((message) => message.text)
+      .join("\n");
+    const options = selects.flatMap((select) => select.options);
+    const controls = messages.flatMap((message) => message.quickReply?.items ?? []);
+    expect(requests.length).toBeGreaterThan(1);
+    expect(requests.every((request) => request.body.messages.length <= 5)).toBe(true);
+    expect(requests[0]?.path).toBe(`/v2/bot/message/${delivery}`);
+    expect(controls).toHaveLength(13);
+    expect(controls.map(({ action }) => action.text)).toEqual(
+      options.slice(0, 13).map((option) => option.action.command),
+    );
+    expect(controls.every(({ action }) => Array.from(action.label).length <= 20)).toBe(true);
+    expect(messages.filter((message) => message.quickReply)).toEqual([messages.at(-1)]);
+    for (const select of selects) {
+      expect(text).toContain(select.placeholder);
+    }
+    for (const option of options.slice(13)) {
+      expect(text).toContain(`${option.label}: ${option.action.command}`);
+    }
+    expect(messages.filter((message) => message.type === "flex")).toHaveLength(card ? 1 : 0);
+    expect(text.includes(presentation.title!)).toBe(!card);
   });
 
   it("delivers all 15 rows of a 2-column overflow table through the production outbound adapter", async () => {


### PR DESCRIPTION
Closes #134975

## What Problem This Solves

Fixes an issue where LINE users receive choice buttons without the question, title, or some of the offered choices. Select-only presentations discarded their surrounding text, and multiple selects could exceed LINE's shared 13-button row. The API accepted the shortened message, so delivery looked successful even when content was missing.

## Why This Change Was Made

The LINE renderer now puts content that has no native home through the existing shared fallback renderer. Each select keeps its prompt beside its overflow choices; content already carried by a Flex card is not repeated. One loop owns the native button budget and the remaining text.

The maintainer improvement also preserves full prompts and overflow labels until native encoding, where LINE's 20-character quick-reply label limit belongs. Missing, empty, or whitespace-only authored fallback text no longer erases the generated question. Redundant flattened-option arrays, parallel button-action arrays, and drawn-option bookkeeping were removed. No configuration, schema, dependency, or authorization policy changes.

## User Impact

Users can read the question and every choice on both replies and explicit sends. Native controls keep their original action values; choices beyond the native row remain visible as text. The LINE documentation describes this behavior. Thanks @edenfunf; original contributor credit is preserved as xuyuanhao.

## Evidence

Independently verified from code and isolated execution. The affected pre-PR owner is byte-identical on captured main `0ac185506ca7f4d2049e58d340279de808526850` and stable `v2026.8.2` (`0965053fe6b9341776df147a6934b7485c60b5ca`). Four added regressions first failed on the contributor implementation: absent/empty/blank fallback text and early truncation of prompts/overflow labels.

- 72 focused LINE tests pass, including real HTTP reply/push × card/no-card cases with three sets of eight choices, long labels, and more than five output messages.
- Full `pnpm check:changed` passes, including plugin and test typechecks, lint, format, boundary/dead-export checks, database/media guards, and runtime-cycle checks.
- The private QA runtime build passes. The real Gateway loads the LINE plugin and a registered fixture command, accepts signed webhooks, and executes `message.action` RPC sends through the native transport code. Both builds use the same synthetic HTTPS LINE endpoint; only the renderer changes for the controlled before/after comparison.

| Gateway flow | Pre-PR owner | Improved owner |
| --- | --- | --- |
| single / signed-webhook | Lost prompts, title | Pass (1 request) |
| single / message-action-rpc | Lost prompts, title | Pass (1 request) |
| multiple / signed-webhook | Lost prompts, overflow, title | Pass (1 request) |
| multiple / message-action-rpc | Lost prompts, overflow, title | Pass (1 request) |
| mixed / signed-webhook | Lost prompts, overflow | Pass (2 requests) |
| mixed / message-action-rpc | Lost prompts, overflow | Pass (8 requests) |
| emptyFallback / signed-webhook | Lost prompts, title | Pass (1 request) |

Every pre-PR request was accepted despite the missing content. The improved mixed-card case spans two requests on the reply path and eight on the push path; all action values survive and quick replies appear only on the final message. Invalid webhook signatures return 401.

The tested improved renderer SHA-256 is `f217e47ce472cc75daee77273bfe786d56a1e698bcf1b06ce808730f3b1b8a7c`, identical to maintainer commit `4dd01333e0bf9e226ab343f3b2d4875252f2e881`. The controlled worker checkout remains at contributor head `d7c76e4d38c57fb970b2a100af871526b0ec65e6`; source hashes bind each rebuilt variant, rather than claiming an uncommitted variant was that Git commit.

Proof run: [before/after Gateway replay](https://crabbox.openclaw.ai/portal/runs/run_cd638b532ee7). Verdict SHA-256: before `bed8c58c103996be4db77459b6400209b767d5158744d59bc486088e6797f15e`; improved `7965614f06ac25de26199960b1317fa2861175818386edb818cf52af734bed89`.

This is real Gateway and transport execution against a synthetic LINE API, not authenticated LINE service or native iOS/Android UI proof. No native-client screenshots were available. The registered command supplies the exact payload; model generation quality is outside this test.

Direct contract checks: installed `@line/bot-sdk` 11.2.0 and LINE's [quick-reply reference](https://developers.line.biz/en/reference/messaging-api/nojs/#items-object) and [label specifications](https://developers.line.biz/en/reference/messaging-api/nojs/#label-specifications).

Independent Codex review of the complete contributor-plus-maintainer diff is clean at P0–P2. Production delta is +70/-41 (net +29), reduced by 13 lines from the contributor implementation; the remaining growth preserves formerly discarded semantic content at its owning renderer. Test delta is +393/-5 (includes formatting), docs +9/-0.

The [fresh ClawSweeper review](https://github.com/openclaw/openclaw/pull/134976#issuecomment-5491341079) completed on maintainer head `4dd01333e0bf9e226ab343f3b2d4875252f2e881` at 22:25 UTC with no actionable correctness finding or Rank-up moves. Its remaining production-growth concern is addressed by the single renderer owner and rationale above. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33565742247); landing uses the native prepare/merge gates.
