### PR TITLE
refactor(mattermost): share wildcard callback host check

### DIFF
--- a/extensions/mattermost/src/mattermost/callback-host.ts
+++ b/extensions/mattermost/src/mattermost/callback-host.ts
@@ -1,0 +1,11 @@
+export function isWildcardBindHost(rawHost: string): boolean {
+  const trimmed = rawHost.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const host = trimmed.startsWith("[") && trimmed.endsWith("]") ? trimmed.slice(1, -1) : trimmed;
+
+  // Wildcard listen hosts are valid bind addresses but are not routable callback
+  // destinations. Never expose them in callback URLs derived from gateway.customBindHost.
+  return host === "0.0.0.0" || host === "::" || host === "0:0:0:0:0:0:0:0" || host === "::0";
+}

--- a/extensions/mattermost/src/mattermost/interactions.ts
+++ b/extensions/mattermost/src/mattermost/interactions.ts
@@ -8,6 +8,7 @@ import {
   normalizeStringifiedOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getMattermostRuntime } from "../runtime.js";
+import { isWildcardBindHost } from "./callback-host.js";
 import { updateMattermostPost, type MattermostClient, type MattermostPost } from "./client.js";
 import {
   isTrustedProxyAddress,
@@ -75,15 +76,6 @@ type InteractionCallbackConfig = Pick<OpenClawConfig, "gateway" | "channels"> & 
 
 export function resolveInteractionCallbackPath(accountId: string): string {
   return `/mattermost/interactions/${accountId}`;
-}
-
-function isWildcardBindHost(rawHost: string): boolean {
-  const trimmed = rawHost.trim();
-  if (!trimmed) {
-    return false;
-  }
-  const host = trimmed.startsWith("[") && trimmed.endsWith("]") ? trimmed.slice(1, -1) : trimmed;
-  return host === "0.0.0.0" || host === "::" || host === "0:0:0:0:0:0:0:0" || host === "::0";
 }
 
 function normalizeCallbackBaseUrl(baseUrl: string): string {

--- a/extensions/mattermost/src/mattermost/slash-commands.ts
+++ b/extensions/mattermost/src/mattermost/slash-commands.ts
@@ -1,6 +1,7 @@
 // Mattermost plugin module implements slash commands behavior.
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf8Prefix } from "openclaw/plugin-sdk/text-utility-runtime";
+import { isWildcardBindHost } from "./callback-host.js";
 import type { MattermostClient } from "./client.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -578,19 +579,6 @@ export function resolveCallbackUrl(params: {
   if (params.config.callbackUrl) {
     return params.config.callbackUrl;
   }
-
-  const isWildcardBindHost = (rawHost: string): boolean => {
-    const trimmed = rawHost.trim();
-    if (!trimmed) {
-      return false;
-    }
-    const host = trimmed.startsWith("[") && trimmed.endsWith("]") ? trimmed.slice(1, -1) : trimmed;
-
-    // NOTE: Wildcard listen hosts are valid bind addresses but are not routable callback
-    // destinations. Don't emit callback URLs like http://0.0.0.0:3015/... or http://[::]:3015/...
-    // when an operator sets gateway.customBindHost.
-    return host === "0.0.0.0" || host === "::" || host === "0:0:0:0:0:0:0:0" || host === "::0";
-  };
 
   let host =
     params.gatewayHost && !isWildcardBindHost(params.gatewayHost)


### PR DESCRIPTION
## What Problem This Solves

Mattermost interaction and slash-command callback URL derivation each maintained a private copy of the same wildcard bind-host classifier. The duplicated policy could drift and produce inconsistent callback destinations even though both paths must reject the same non-routable listener addresses.

## Why This Change Was Made

The Mattermost plugin now owns one private `isWildcardBindHost` helper and both callback URL paths use it. This removes the two duplicate implementations without adding a Plugin SDK seam, config, barrel export, or compatibility path.

Root cause: the interaction and slash-command features independently implemented the same callback-host invariant.

Architectural owner: Mattermost callback URL derivation.

Canonical fix: `extensions/mattermost/src/mattermost/callback-host.ts`.

Removed duplicates: local classifiers in `interactions.ts` and `slash-commands.ts`.

## User Impact

No user-visible behavior changes. Whitespace trimming, empty-host handling, bracketed IPv6 normalization, and the four wildcard spellings remain identical; wildcard listener hosts still fall back to `localhost` in both callback flows.

Production LOC: +13/-22 (net -9). Tests: +0/-0.

## Evidence

- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/interactions.test.ts extensions/mattermost/src/mattermost/slash-commands.test.ts` - 2 files, 59 tests passed.
- `pnpm test:extension mattermost` - 54 files, 840 tests passed.
- `pnpm check:import-cycles` - 0 runtime value cycles.
- `pnpm build` - passed.
- `node scripts/check-changed.mjs -- extensions/mattermost/src/mattermost/callback-host.ts extensions/mattermost/src/mattermost/interactions.ts extensions/mattermost/src/mattermost/slash-commands.ts` - passed.
- `git diff --check` - passed.
- Exact `gpt-5.6-sol` high-reasoning autoreview of the signed commit - scoped clean, no accepted/actionable findings.

Sibling coverage: existing interaction and slash-command tests both exercise wildcard-host fallback. The full Mattermost extension lane covers their runtime owners and callers.

Observed behavior: both callback URL paths still produce `localhost` for wildcard bind hosts and preserve routable custom hosts.

A dedicated live Mattermost or Crabbox run is not justified for this behavior-neutral private classifier move. Native Testbox and repository merge gates remain required before landing.
