### PR TITLE
perf: release superseded channel avatar buffers

### DIFF
--- a/src/gateway/channel-avatar-http.test.ts
+++ b/src/gateway/channel-avatar-http.test.ts
@@ -138,6 +138,28 @@ describe("handleChannelAvatarHttpRequest", () => {
     expect(mocks.readMedia).toHaveBeenCalledTimes(1);
   });
 
+  it("releases superseded avatars without evicting another session's cached image", async () => {
+    const stable = await fetch(avatarRoute("agent:main:stable-avatar"));
+    await stable.arrayBuffer();
+
+    for (let revision = 0; revision < 130; revision++) {
+      const reference = `/state/media/inbound/rotating-avatar-${revision}.png`;
+      const buffer = Buffer.concat([PNG_BYTES, Buffer.from(String(revision))]);
+      mocks.loadEntry.mockReturnValue({ entry: avatarEntry(reference) });
+      mocks.readMedia.mockResolvedValue({ buffer });
+      const response = await fetch(avatarRoute("agent:main:rotating-avatar"));
+      expect(Buffer.from(await response.arrayBuffer()).equals(buffer)).toBe(true);
+    }
+
+    mocks.loadEntry.mockReturnValue({ entry: avatarEntry() });
+    mocks.readMedia.mockResolvedValue({ buffer: PNG_BYTES });
+    const readsBeforeRevisit = mocks.readMedia.mock.calls.length;
+    const revisited = await fetch(avatarRoute("agent:main:stable-avatar"));
+
+    expect(Buffer.from(await revisited.arrayBuffer()).equals(PNG_BYTES)).toBe(true);
+    expect(mocks.readMedia).toHaveBeenCalledTimes(readsBeforeRevisit);
+  });
+
   it("keeps representation headers but omits bytes on HEAD", async () => {
     const response = await fetch(avatarRoute("agent:main:head"), { method: "HEAD" });
 

--- a/src/gateway/channel-avatar-http.ts
+++ b/src/gateway/channel-avatar-http.ts
@@ -20,13 +20,12 @@ import { authorizeControlUiSessionOwnerReadRequestOrReply } from "./http-utils.j
 
 const CHANNEL_AVATAR_CACHE_MAX_ENTRIES = 128;
 
-type ChannelAvatarCacheIndex = {
+type ChannelAvatarCacheEntry = {
   reference: string;
-  imageKey: string;
+  image: HttpImageRepresentation;
 };
 
-const channelAvatarIndex = new Map<string, ChannelAvatarCacheIndex>();
-const channelAvatarBytes = new Map<string, HttpImageRepresentation>();
+const channelAvatarCache = new Map<string, ChannelAvatarCacheEntry>();
 
 const getSessionStoreModule = createLazyRuntimeModule(() => import("./session-utils-store.js"));
 
@@ -34,20 +33,13 @@ function touchChannelAvatarCache(
   sessionKey: string,
   reference: string,
 ): HttpImageRepresentation | undefined {
-  const indexed = channelAvatarIndex.get(sessionKey);
-  if (!indexed || indexed.reference !== reference) {
+  const cached = channelAvatarCache.get(sessionKey);
+  if (!cached || cached.reference !== reference) {
     return undefined;
   }
-  const image = channelAvatarBytes.get(indexed.imageKey);
-  if (!image) {
-    channelAvatarIndex.delete(sessionKey);
-    return undefined;
-  }
-  channelAvatarIndex.delete(sessionKey);
-  channelAvatarIndex.set(sessionKey, indexed);
-  channelAvatarBytes.delete(indexed.imageKey);
-  channelAvatarBytes.set(indexed.imageKey, image);
-  return image;
+  channelAvatarCache.delete(sessionKey);
+  channelAvatarCache.set(sessionKey, cached);
+  return cached.image;
 }
 
 async function loadChannelAvatar(
@@ -67,13 +59,10 @@ async function loadChannelAvatar(
   if (!image) {
     return undefined;
   }
-  // The ETag is the content hash, so the cache key cannot alias changed bytes
-  // even when a session is rerouted to a new media-store reference.
-  const imageKey = `${sessionKey}\0${image.etag}`;
-  channelAvatarBytes.set(imageKey, image);
-  channelAvatarIndex.set(sessionKey, { reference, imageKey });
-  pruneMapToMaxSize(channelAvatarBytes, CHANNEL_AVATAR_CACHE_MAX_ENTRIES);
-  pruneMapToMaxSize(channelAvatarIndex, CHANNEL_AVATAR_CACHE_MAX_ENTRIES);
+  // Superseded images must not retain bytes or evict other sessions' current avatars.
+  channelAvatarCache.delete(sessionKey);
+  channelAvatarCache.set(sessionKey, { reference, image });
+  pruneMapToMaxSize(channelAvatarCache, CHANNEL_AVATAR_CACHE_MAX_ENTRIES);
   return image;
 }
 


### PR DESCRIPTION
## What Problem This Solves

A conversation that changes its avatar repeatedly leaves superseded image buffers in the Gateway cache. Those obsolete images can evict another conversation's still-current avatar and force unnecessary media reads.

## Why This Change Was Made

Keep one LRU entry per session containing its reference and image representation. The former image map was keyed by session plus content hash, so it never shared image bytes between sessions; it only retained historical versions. Replacing that pair of maps releases superseded bytes at the owning cache.

## User Impact

Current avatars retain the same bytes, ETags, headers, and authorization behavior. The cache still holds at most 128 sessions, while avatar rotation no longer consumes additional slots. Production LOC +12/-23 (net -11); regression coverage +22 lines.

## Evidence

- New real HTTP-route regression fails on the original code (132 media reads instead of 131) and passes after the repair. It rotates one conversation 130 times, then verifies a second conversation still uses its current cached image.
- All 12 channel-avatar route tests pass, covering authentication/owner denial, ETag 304, HEAD, missing media, malformed paths, and method handling.
- Actual cache-owner retention probe: 256 successive 512 KiB avatars for one synthetic session retained 128 buffers / 64 MiB before, versus 1 buffer / 0.5 MiB after. This is a bounded synthetic stress measurement, not typical avatar traffic or whole-Gateway memory usage.
- Workspace-icon and assistant-avatar sibling owners were inspected; their snapshots already own their retained representations directly and do not retain historical content-hash versions.
- Fresh independent Codex autoreview found no actionable findings.
- `node scripts/check-changed.mjs -- src/gateway/channel-avatar-http.ts src/gateway/channel-avatar-http.test.ts` passed, including core/core-test typechecks, lint and guards.
- `pnpm build` passed. The rebuilt dev Gateway served an authenticated synthetic avatar from its real session and media stores, returned matching bytes, 304 for the current ETag and bodyless HEAD; after replacing the stored media reference it returned 200 and the new bytes/ETag even with the old If-None-Match header.
