### PR TITLE
perf(logging): avoid intermediate timestamp objects

### DIFF
--- a/src/logging/timestamps.ts
+++ b/src/logging/timestamps.ts
@@ -58,30 +58,26 @@ function getTimestampParts(date: Date, timeZone?: string) {
     timestampFormatterCache.set(effectiveTimeZone, fmt);
   }
 
-  const parts = Object.fromEntries(fmt.formatToParts(date).map((part) => [part.type, part.value]));
-  return {
-    year: parts.year,
-    month: parts.month,
-    day: parts.day,
-    hour: parts.hour,
-    minute: parts.minute,
-    second: parts.second,
-    fractionalSecond: parts.fractionalSecond,
-    offset: formatOffset(parts.timeZoneName ?? "GMT"),
-  };
+  // Native Intl supplies the closed set of part names.
+  const parts: Record<string, string> = {};
+  for (const part of fmt.formatToParts(date)) {
+    parts[part.type] = part.value;
+  }
+  return parts;
 }
 
 export function formatTimestamp(date: Date, options?: FormatTimestampOptions): string {
   const style = options?.style ?? "medium";
   const parts = getTimestampParts(date, options?.timeZone);
+  const offset = formatOffset(parts.timeZoneName ?? "GMT");
 
   switch (style) {
     case "short":
-      return `${parts.hour}:${parts.minute}:${parts.second}${parts.offset}`;
+      return `${parts.hour}:${parts.minute}:${parts.second}${offset}`;
     case "medium":
-      return `${parts.hour}:${parts.minute}:${parts.second}.${parts.fractionalSecond}${parts.offset}`;
+      return `${parts.hour}:${parts.minute}:${parts.second}.${parts.fractionalSecond}${offset}`;
     case "long":
-      return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}.${parts.fractionalSecond}${parts.offset}`;
+      return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}.${parts.fractionalSecond}${offset}`;
   }
   throw new Error("Unsupported timestamp style");
 }


### PR DESCRIPTION
## What Problem This Solves

Every formatted log timestamp builds an array of key/value pairs and then a second projected object before constructing the string. Console logging, structured file logging, overflow markers, and local-time CLI displays all pay this repeated work.

## Why This Change Was Made

Keep the canonical `formatTimestamp` owner and collect native Intl parts directly into one private dictionary. Its sole consumer formats the offset and final string. Native Intl supplies a closed set of part names; repeated literal fields retain last-write-wins behavior. This removes the intermediate pair array and private projection without changing formatter options, timezone selection, caches, errors, redaction, or transport lifecycle.

Production: **+10/-14, net -4 lines**. Tests: unchanged. This is an internal, behavior-preserving optimization with no config, schema, protocol, SDK, or documentation contract changes.

## User Impact

Less steady-state timestamp-formatting work on logging paths. Timestamp bytes remain unchanged. This does not claim a measurable reduction in model-turn latency, Gateway startup, total logging throughput, or memory usage.

## Evidence

The complete source owner was measured with native Node 26.8.1 Intl, not an extracted private helper or a substitute formatter. Four fixed-order runs used before/candidate/candidate/before, retaining 756 measured blocks, 672 warmup blocks, and 84 first calls across 21 workloads. All 21 medians improved in both orders, including all 15 predeclared ordinary decision rows.

| Complete formatter workload | Forward before → candidate | Reverse before → candidate |
| --- | --- | --- |
| Default medium | 3.212083 → 2.632000 µs (-18.06%) | 3.325166 → 2.599791 µs (-21.81%) |
| Default long | 3.197250 → 2.680916 µs (-16.15%) | 3.231042 → 2.645125 µs (-18.13%) |
| Explicit UTC short | 3.104208 → 2.539833 µs (-18.18%) | 3.159042 → 2.533000 µs (-19.82%) |

There were no slower median pairs, but **15 slower first-call pairs** are retained. Forward UTC-short's first call rose from 8.231666 to 8.355208 ms. Only the first row is a cold formatter/cache call; later first calls reuse warmed caches. Forward driver system CPU rose by 358 µs and whole-process system CPU by 487 µs; this is not elapsed-time regression. These are four fixed-order processes, not a randomized statistical population. All first-call, CPU, wall-time, and RSS observations remain in the local campaign evidence, without a startup or memory claim.

The paired correctness run checked 63 exact pairs (60 values and three errors), 21 ordered workload oracles, all styles, timezone precedence, invalid/empty/absent zones, fractional offsets, DST edges, leap midnight, milliseconds, historical/extreme Dates, and error precedence. Direct V8 source inspection confirmed the native part-name/data-record contract. Independent review recomputed every measured median and checked raw journals, hashes, process/group closure, and runtime removal.

Source capture was `61763b06923071f1517c32b05243bddfa808a3d4`; timing execution was `e92637ab84fc0ca1786276cca141dc9e6cbbf510` with three unrelated SDK integration paths dirty. The formatter before/candidate bytes match current integration exactly; these are not relabeled current-head timing runs. Candidate SHA256: `ed9a11d6cf2e704dc18706162ccece4bc280bedc464f7041d409e65879b95985`. Raw numerical reduction: `61c4af6b8dcfee10d31bc8caedc38787b905b7beb505218199f29b95d8e683ce`. Fresh independent report: `65f15b015d2cb0175ea9311d2d0e36368daa10b124331d9534509e1eb79e7fb0`.

Canonical validation passed **78 tests before and 78 after** across timestamp, console, file transport, capture, and subsystem suites:

```sh
node scripts/run-vitest.mjs src/logging/timestamps.test.ts src/logging/console-timestamp.test.ts src/logging/logger-timestamp.test.ts src/logging/logger-file-transport.test.ts src/logging/console-capture.test.ts src/logging/subsystem.test.ts --maxWorkers 1 --no-cache
pnpm check:changed -- src/logging/timestamps.ts
```

The complete changed gate passed (types, lint, formatting, boundaries, and Knip; 265.92 s). Managed Codex review finished scoped-clean at its configured P0 scope. Two unsuccessful review attempts are retained: the first failed the source-integrity preflight, the second encountered an unavailable model. The final supported public-model review passed without changing the candidate or weakening isolation.


Fresh integration at commit `71c263b13f3e040f3ac415758e2f81a564087d71` also passed:

- Full `pnpm build`: 179.90 s. Existing dependency bundler warnings did not fail the build.
- Isolated, freshly built Gateway with the real OpenAI provider: readiness 3548.85 ms; READY, batched tool discovery, exact file read, and sequential Markdown/text web fetches all completed. Both web requests returned HTTP 200 through the actual tool flow; 12 session-list responses and five system-event/status results passed.
- Real logging readback: 209 structured file records and 203 captured console timestamp lines all have valid long timestamps with explicit local offsets. Their clocks are independent; no exact console/file clock equality is claimed.
- Gateway main-thread CPU profile retained separately from its worker profile. All 12,350 built-runtime entries matched before/after and at root readback. The owned PID/group and loopback listener were gone, and temporary credential-bearing configs and FIFO were removed.

Real-provider turn timings were 1.48/3.57/5.42/7.84 s and are integration observations only. The existing conservative `replayInvalid` classification for generic `tool_call` remained true on read/web turns; no retry, fallback, or compaction recovery was exercised. Live readback SHA256: `00ddc78f408aa62fcea4ecc607c7cbaaa8415f10913ec25c132198d2764825fd`.


Final landing checks: [CI run 33483592680](https://github.com/openclaw/openclaw/actions/runs/33483592680) succeeded on exact head `71c263b13f3e040f3ac415758e2f81a564087d71` on its first attempt. All 268 check entries completed without failure, cancellation, or timeout. The completed [ClawSweeper review](https://github.com/openclaw/openclaw/pull/134979#issuecomment-5490769252) found no actionable correctness/security issue and requested ordinary maintainer review; that review is complete. A fresh managed review of the exact commit passed at P0 scope, and an independent live audit confirmed the actual console-prefix count, all transcript/tool evidence, profiles, and cleanup. Its report SHA256 is `566266888316f76a2fc115c41e9f0c7d2c961ab367501d7c1e7dbc089044d50c`.

The native review-artifact validator initially rejected a missing space in its required header. The original artifact and failed attempt were retained, the exact stale operation lock was recovered after verifying no associated tools remained, and the corrected artifact passed validation. No source or test changes were made for that administrative retry.
