### PR TITLE
test(google-meet): unify repeated CLI output cases

### DIFF
--- a/extensions/google-meet/src/cli-artifacts.test.ts
+++ b/extensions/google-meet/src/cli-artifacts.test.ts
@@ -165,54 +165,42 @@ describe("google-meet CLI", () => {
     ).rejects.toThrow("access policy options require OAuth/API room creation");
   });
 
-  it("prints the latest conference record", async () => {
-    stubMeetArtifactsApi();
-    const stdout = captureStdout();
+  for (const { name, selectorArgs, expected } of [
+    {
+      name: "prints the latest conference record",
+      selectorArgs: ["--meeting", "abc-defg-hij"],
+      expected: "space: spaces/abc-defg-hij",
+    },
+    {
+      name: "prints the latest conference record from today's calendar",
+      selectorArgs: ["--today"],
+      expected: "calendar event: Project sync",
+    },
+  ]) {
+    it(name, async () => {
+      stubMeetArtifactsApi();
+      const stdout = captureStdout();
 
-    try {
-      await setupCli({}).parseAsync(
-        [
-          "googlemeet",
-          "latest",
-          "--access-token",
-          "token",
-          "--expires-at",
-          String(Date.now() + 120_000),
-          "--meeting",
-          "abc-defg-hij",
-        ],
-        { from: "user" },
-      );
-      expect(stdout.output()).toContain("space: spaces/abc-defg-hij");
-      expect(stdout.output()).toContain("conference record: conferenceRecords/rec-1");
-    } finally {
-      stdout.restore();
-    }
-  });
-
-  it("prints the latest conference record from today's calendar", async () => {
-    stubMeetArtifactsApi();
-    const stdout = captureStdout();
-
-    try {
-      await setupCli({}).parseAsync(
-        [
-          "googlemeet",
-          "latest",
-          "--access-token",
-          "token",
-          "--expires-at",
-          String(Date.now() + 120_000),
-          "--today",
-        ],
-        { from: "user" },
-      );
-      expect(stdout.output()).toContain("calendar event: Project sync");
-      expect(stdout.output()).toContain("conference record: conferenceRecords/rec-1");
-    } finally {
-      stdout.restore();
-    }
-  });
+      try {
+        await setupCli({}).parseAsync(
+          [
+            "googlemeet",
+            "latest",
+            "--access-token",
+            "token",
+            "--expires-at",
+            String(Date.now() + 120_000),
+            ...selectorArgs,
+          ],
+          { from: "user" },
+        );
+        expect(stdout.output()).toContain(expected);
+        expect(stdout.output()).toContain("conference record: conferenceRecords/rec-1");
+      } finally {
+        stdout.restore();
+      }
+    });
+  }
 
   it("prints calendar event previews", async () => {
     stubMeetArtifactsApi();
@@ -369,84 +357,51 @@ describe("google-meet CLI", () => {
     },
   );
 
-  it("prints CSV attendance output", async () => {
-    stubMeetArtifactsApi();
-    const stdout = captureStdout();
+  for (const { name, options, expected } of [
+    {
+      name: "prints CSV attendance output",
+      options: {},
+      expected: ["conferenceRecord,displayName,user", "conferenceRecords/rec-1,Alice,users/alice"],
+    },
+    {
+      name: "neutralizes spreadsheet formulas in CSV attendance output",
+      options: { participantDisplayName: " \t=1+1" },
+      expected: ["conferenceRecords/rec-1,' \t=1+1,users/alice"],
+    },
+    {
+      name: "quotes carriage returns in formula-neutralized CSV cells",
+      options: { participantDisplayName: "\r=1+1" },
+      expected: ['conferenceRecords/rec-1,"\'\r=1+1",users/alice'],
+    },
+  ]) {
+    it(name, async () => {
+      stubMeetArtifactsApi(options);
+      const stdout = captureStdout();
 
-    try {
-      await setupCli({}).parseAsync(
-        [
-          "googlemeet",
-          "attendance",
-          "--access-token",
-          "token",
-          "--expires-at",
-          String(Date.now() + 120_000),
-          "--conference-record",
-          "rec-1",
-          "--format",
-          "csv",
-        ],
-        { from: "user" },
-      );
-      expect(stdout.output()).toContain("conferenceRecord,displayName,user");
-      expect(stdout.output()).toContain("conferenceRecords/rec-1,Alice,users/alice");
-    } finally {
-      stdout.restore();
-    }
-  });
-
-  it("neutralizes spreadsheet formulas in CSV attendance output", async () => {
-    stubMeetArtifactsApi({ participantDisplayName: " \t=1+1" });
-    const stdout = captureStdout();
-
-    try {
-      await setupCli({}).parseAsync(
-        [
-          "googlemeet",
-          "attendance",
-          "--access-token",
-          "token",
-          "--expires-at",
-          String(Date.now() + 120_000),
-          "--conference-record",
-          "rec-1",
-          "--format",
-          "csv",
-        ],
-        { from: "user" },
-      );
-      expect(stdout.output()).toContain("conferenceRecords/rec-1,' \t=1+1,users/alice");
-    } finally {
-      stdout.restore();
-    }
-  });
-
-  it("quotes carriage returns in formula-neutralized CSV cells", async () => {
-    stubMeetArtifactsApi({ participantDisplayName: "\r=1+1" });
-    const stdout = captureStdout();
-
-    try {
-      await setupCli({}).parseAsync(
-        [
-          "googlemeet",
-          "attendance",
-          "--access-token",
-          "token",
-          "--expires-at",
-          String(Date.now() + 120_000),
-          "--conference-record",
-          "rec-1",
-          "--format",
-          "csv",
-        ],
-        { from: "user" },
-      );
-      expect(stdout.output()).toContain('conferenceRecords/rec-1,"\'\r=1+1",users/alice');
-    } finally {
-      stdout.restore();
-    }
-  });
+      try {
+        await setupCli({}).parseAsync(
+          [
+            "googlemeet",
+            "attendance",
+            "--access-token",
+            "token",
+            "--expires-at",
+            String(Date.now() + 120_000),
+            "--conference-record",
+            "rec-1",
+            "--format",
+            "csv",
+          ],
+          { from: "user" },
+        );
+        for (const text of expected) {
+          expect(stdout.output()).toContain(text);
+        }
+      } finally {
+        stdout.restore();
+      }
+    });
+  }
 
   it("writes an export bundle", async () => {
     stubMeetArtifactsApi();


### PR DESCRIPTION
Meet CLI artifact tests repeat the same setup and cleanup across five conference and CSV cases. This consolidates them into two tables while retaining fresh parser/transport/stdout fixtures for each case and every original literal test name.

All 21 focused tests pass before and after, with exact ordered native identities and outcomes. The eight selected substring assertions still cover normal output, formula neutralization and real TAB/CR bytes; export ZIP readback and OS-rejected write coverage remain. Production +0/-0; tests +79/-124.

Scoped Codex autoreview found no issues at its requested threshold. The full changed-file gate passed; final hosted checks will be recorded before landing. This is test consolidation: the five selected CLI executions remain, so no elapsed-time gain is claimed.

Named follow-up: existing export/native-write setup occurs before its cleanup try and can bypass cleanup if setup fails. These table rows allocate no disk roots and do not change that separate lifecycle gap.
