### PR TITLE
fix(ci): route Swift metadata changes to their owner tests

### DIFF
--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -131,6 +131,7 @@ const ANDROID_VERSION_SYNC_PATHS = new Set([
   "apps/android/fastlane/metadata/android/en-US/release_notes.txt",
   "apps/android/version.json",
 ]);
+const SWIFT_BUILD_CACHE_METADATA_TEST_PATH = "test/scripts/swift-build-cache-metadata.test.ts";
 const MACOS_APP_CI_PATH_RE =
   /^(?:apps\/(?:macos\/(?!Tests\/.+\.swift$)|(?:macos-mlx-tts|shared|swabble)\/)|Swabble\/|src\/(?:shared\/worker-bundle-hash\.ts|worker\/workspace-rsync-receiver\.ts|gateway\/worker-environments\/workspace-(?:accepted-(?:remote-script|sync)|mutation-remote-script|rsync-path\.test|sync(?:-helpers)?)\.ts)$)/u;
 let corepackPnpmShimDir: string | undefined;
@@ -162,11 +163,14 @@ function hasAndroidVersionSyncPath(paths: string[]) {
 }
 
 function hasMacosAppCiPath(paths: string[]) {
-  // Native-source policy stays local; script and test owners share the CI selector.
+  // The metadata test has its own command; production edits still need native app proof.
   // Swift test-target sources do not feed the packaged app; native CI still covers them.
   return paths.some((changedPath) => {
     const normalized = normalizeChangedPath(changedPath);
-    return MACOS_APP_CI_PATH_RE.test(normalized) || isMacosToolingPath(normalized);
+    return (
+      normalized !== SWIFT_BUILD_CACHE_METADATA_TEST_PATH &&
+      (MACOS_APP_CI_PATH_RE.test(normalized) || isMacosToolingPath(normalized))
+    );
   });
 }
 
@@ -679,6 +683,19 @@ export function createChangedCheckPlan(
     add(
       "appcast owner tests",
       ["test:serial", "test/appcast.test.ts", "test/scripts/make-appcast.test.ts"],
+      baseEnv,
+    );
+  }
+  if (
+    result.paths.some(
+      (changedPath) =>
+        changedPath === "scripts/swift-build-cache-metadata.py" ||
+        changedPath === SWIFT_BUILD_CACHE_METADATA_TEST_PATH,
+    )
+  ) {
+    add(
+      "Swift build cache metadata tests",
+      ["test:serial", SWIFT_BUILD_CACHE_METADATA_TEST_PATH],
       baseEnv,
     );
   }

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -2348,6 +2348,31 @@ describe("scripts/changed-lanes", () => {
     },
   );
 
+  it.each<[string, string[], boolean]>([
+    ["standalone test", ["test/scripts/swift-build-cache-metadata.test.ts"], false],
+    ["production owner", ["scripts/swift-build-cache-metadata.py"], true],
+    [
+      "test with a native dependency",
+      ["test/scripts/swift-build-cache-metadata.test.ts", "scripts/lib/swift-toolchain.sh"],
+      true,
+    ],
+  ])("routes Swift cache metadata checks for %s", (_label, paths, macosCi) => {
+    const plan = createChangedCheckPlan(detectChangedLanes(paths), {
+      env: { PATH: "/usr/bin" },
+      platform: "linux",
+      swiftlintAvailable: false,
+    });
+
+    expect(
+      plan.commands.filter((command) => command.name === "Swift build cache metadata tests"),
+    ).toEqual([
+      expect.objectContaining({
+        args: ["test:serial", "test/scripts/swift-build-cache-metadata.test.ts"],
+      }),
+    ]);
+    expect(plan.commands.some((command) => command.args[0] === "test:macos:ci")).toBe(macosCi);
+  });
+
   it("routes appcast changes to appcast owner tests", () => {
     const result = detectChangedLanes(["appcast.xml"]);
     const plan = createChangedCheckPlan(result);


### PR DESCRIPTION
Editing the Swift cache metadata test selects the broad local Mac suite, yet the changed-file planner has no explicit command for its nine-case Python-backed owner test. Route both the test and Python owner to that existing serial suite, and exclude only the standalone test path from broad Mac selection.

The new regression rows fail on the original planner because the owner command is missing. After the fix, 309/309 focused cases pass, preserving all 306 prior cases and adding the three routing cases. The real serial metadata command passes 9/9. Standalone, Python-owner and mixed-native dry-runs select the owner exactly once; broader native validation remains selected for the latter two. Hosted CI routing is unchanged.

Production tooling +19/-2; tests +25/-0. The net 17 tooling lines establish the missing owner command using the existing dispatcher and an exact test-path exclusion. The standalone test avoids the reviewed three-part, twenty-file Mac aggregate; no measured elapsed gain is claimed. Full changed-file checks passed and final scoped Codex review returned no findings. An earlier review stopped on source-snapshot verification; the successful retry ran after all proof and gate processes completed.
