### PR TITLE
refactor(process): reuse canonical tool result envelopes

### DIFF
--- a/src/agents/bash-tools.process-send-keys.ts
+++ b/src/agents/bash-tools.process-send-keys.ts
@@ -7,6 +7,7 @@ import type { ProcessSession } from "./bash-process-registry.js";
 import { deriveSessionName } from "./bash-tools.shared.js";
 import { encodeKeySequence, hasCursorModeSensitiveKeys } from "./pty-keys.js";
 import type { AgentToolResult } from "./runtime/index.js";
+import { textResult } from "./tools/tool-results.js";
 
 /** Writable stdin surface shared by child-process and PTY session records. */
 export type WritableStdin = {
@@ -19,15 +20,7 @@ export type WritableStdin = {
 };
 
 function failText(text: string): AgentToolResult<unknown> {
-  return {
-    content: [
-      {
-        type: "text",
-        text,
-      },
-    ],
-    details: { status: "failed" },
-  };
+  return textResult(text, { status: "failed" });
 }
 
 export async function writeProcessStdin(stdin: WritableStdin, data: string) {
@@ -70,19 +63,12 @@ export async function handleProcessSendKeys(params: {
     return failText("No key data provided.");
   }
   await writeProcessStdin(params.stdin, data);
-  return {
-    content: [
-      {
-        type: "text",
-        text:
-          `Sent ${Buffer.byteLength(data, "utf8")} bytes to session ${params.sessionId}.` +
-          (warnings.length ? `\nWarnings:\n- ${warnings.join("\n- ")}` : ""),
-      },
-    ],
-    details: {
-      status: "running",
-      sessionId: params.sessionId,
-      name: deriveSessionName(params.session.command),
-    },
-  };
+  const text =
+    `Sent ${Buffer.byteLength(data, "utf8")} bytes to session ${params.sessionId}.` +
+    (warnings.length ? `\nWarnings:\n- ${warnings.join("\n- ")}` : "");
+  return textResult(text, {
+    status: "running",
+    sessionId: params.sessionId,
+    name: deriveSessionName(params.session.command),
+  });
 }

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -49,6 +49,7 @@ import type { AgentToolResult } from "./runtime/index.js";
 import { attachInternalToolResultAcknowledgement } from "./runtime/internal-hooks.js";
 import { PROCESS_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
 import type { AgentToolWithMeta } from "./tools/common.js";
+import { textResult } from "./tools/tool-results.js";
 
 /** Defaults injected by tests, agent scopes, and scoped process registries. */
 export type ProcessToolDefaults = {
@@ -153,15 +154,7 @@ function resolvePollWaitMs(value: unknown) {
 }
 
 function failText(text: string): AgentToolResult<unknown> {
-  return {
-    content: [
-      {
-        type: "text",
-        text,
-      },
-    ],
-    details: { status: "failed" },
-  };
+  return textResult(text, { status: "failed" });
 }
 
 function recordPollRetrySuggestion(sessionId: string, hasNewOutput: boolean): number | undefined {
@@ -220,25 +213,18 @@ function finishedPollResult(
       ? "[earlier output is omitted from this poll; use action=log with offset and limit to inspect retained output]\n\n"
       : "[earlier output is omitted from this poll; omitted output is no longer available through action=log]\n\n"
     : "";
+  const text = appendExecTimeoutRetryGuidance(
+    retentionCapNote(finished) +
+      retainedOutputNote +
+      (output || "(no new output)") +
+      `\n\nProcess exited with ${renderExecExitLabel(finished)}.`,
+    finished.exitReason,
+  );
   return attachInternalToolResultAcknowledgement(
-    {
-      content: [
-        {
-          type: "text",
-          text: appendExecTimeoutRetryGuidance(
-            retentionCapNote(finished) +
-              retainedOutputNote +
-              (output || "(no new output)") +
-              `\n\nProcess exited with ${renderExecExitLabel(finished)}.`,
-            finished.exitReason,
-          ),
-        },
-      ],
-      details: {
-        ...finishedSessionDetails(sessionId, finished),
-        aggregated: finished.aggregated,
-      },
-    },
+    textResult(text, {
+      ...finishedSessionDetails(sessionId, finished),
+      aggregated: finished.aggregated,
+    }),
     () => delivery.acknowledge(),
   );
 }
@@ -380,15 +366,10 @@ export function createProcessTool(
             formatDurationCompact(s.runtimeMs) ?? "n/a"
           }${marker} :: ${label}`;
         });
-        return {
-          content: [
-            {
-              type: "text",
-              text: lines.join("\n") || "No running or recent sessions.",
-            },
-          ],
-          details: { status: "completed", sessions },
-        };
+        return textResult(lines.join("\n") || "No running or recent sessions.", {
+          status: "completed",
+          sessions,
+        });
       }
 
       if (!params.sessionId) {
@@ -432,14 +413,12 @@ export function createProcessTool(
       const runningSessionResult = (
         sessionLocal: ProcessSession,
         text: string,
-      ): AgentToolResult<unknown> => ({
-        content: [{ type: "text", text }],
-        details: {
+      ): AgentToolResult<unknown> =>
+        textResult(text, {
           status: "running",
           sessionId: params.sessionId,
           name: deriveSessionName(sessionLocal.command),
-        },
-      });
+        });
 
       switch (params.action) {
         case "poll": {
@@ -491,27 +470,20 @@ export function createProcessTool(
           const hasNewOutput = output.length > 0;
           const retryInMs = recordPollRetrySuggestion(params.sessionId, hasNewOutput);
           const runtime = describeRunningSession(scopedSession);
+          const text =
+            aggregateOutputNote +
+            retainedOutputNote +
+            (output || "(no new output)") +
+            (buildInputWaitHint(runtime) || "\n\nProcess still running.");
           return attachInternalToolResultAcknowledgement(
-            {
-              content: [
-                {
-                  type: "text",
-                  text:
-                    aggregateOutputNote +
-                    retainedOutputNote +
-                    (output || "(no new output)") +
-                    (buildInputWaitHint(runtime) || "\n\nProcess still running."),
-                },
-              ],
-              details: {
-                status: "running",
-                sessionId: params.sessionId,
-                aggregated: scopedSession.aggregated,
-                name: deriveSessionName(scopedSession.command),
-                ...runningSessionInputDetails(runtime),
-                ...(typeof retryInMs === "number" ? { retryInMs } : {}),
-              },
-            },
+            textResult(text, {
+              status: "running",
+              sessionId: params.sessionId,
+              aggregated: scopedSession.aggregated,
+              name: deriveSessionName(scopedSession.command),
+              ...runningSessionInputDetails(runtime),
+              ...(typeof retryInMs === "number" ? { retryInMs } : {}),
+            }),
             () => delivery.acknowledge(),
           );
         }
@@ -535,16 +507,11 @@ export function createProcessTool(
             retentionCapNote(record) +
             (slice || (scopedSession ? "(no output yet)" : "(no output recorded)")) +
             defaultTailNote(totalLines, window.usingDefaultTail);
-          return {
-            content: [
-              {
-                type: "text",
-                text: runtime
-                  ? text + buildInputWaitHint(runtime)
-                  : appendExecTimeoutRetryGuidance(text, record.exitReason),
-              },
-            ],
-            details: {
+          return textResult(
+            runtime
+              ? text + buildInputWaitHint(runtime)
+              : appendExecTimeoutRetryGuidance(text, record.exitReason),
+            {
               ...(runtime
                 ? {
                     status: record.exited ? "completed" : "running",
@@ -558,7 +525,7 @@ export function createProcessTool(
               totalChars,
               truncated: record.truncated,
             },
-          };
+          );
         }
 
         case "write": {
@@ -639,28 +606,17 @@ export function createProcessTool(
           resetPollRetrySuggestion(params.sessionId);
           // The kill was performed; "failed" here would flag a successful
           // action as a tool error and invite the model to retry it.
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Termination requested for session ${params.sessionId}.`,
-              },
-            ],
-            details: {
-              status: "completed",
-              name: scopedSession ? deriveSessionName(scopedSession.command) : undefined,
-            },
-          };
+          return textResult(`Termination requested for session ${params.sessionId}.`, {
+            status: "completed",
+            name: scopedSession ? deriveSessionName(scopedSession.command) : undefined,
+          });
         }
 
         case "clear": {
           if (scopedFinished) {
             resetPollRetrySuggestion(params.sessionId);
             deleteSession(params.sessionId);
-            return {
-              content: [{ type: "text", text: `Cleared session ${params.sessionId}.` }],
-              details: { status: "completed" },
-            };
+            return textResult(`Cleared session ${params.sessionId}.`, { status: "completed" });
           }
           return failText(`No finished session found for ${params.sessionId}`);
         }
@@ -684,26 +640,15 @@ export function createProcessTool(
             resetPollRetrySuggestion(params.sessionId);
             // Removal succeeded (termination requested + registry row dropped);
             // match the finished-session remove branch's success shape.
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: `Removed session ${params.sessionId} (termination requested).`,
-                },
-              ],
-              details: {
-                status: "completed",
-                name: scopedSession ? deriveSessionName(scopedSession.command) : undefined,
-              },
-            };
+            return textResult(`Removed session ${params.sessionId} (termination requested).`, {
+              status: "completed",
+              name: scopedSession ? deriveSessionName(scopedSession.command) : undefined,
+            });
           }
           if (scopedFinished) {
             resetPollRetrySuggestion(params.sessionId);
             deleteSession(params.sessionId);
-            return {
-              content: [{ type: "text", text: `Removed session ${params.sessionId}.` }],
-              details: { status: "completed" },
-            };
+            return textResult(`Removed session ${params.sessionId}.`, { status: "completed" });
           }
           return failText(`No session found for ${params.sessionId}`);
         }


### PR DESCRIPTION
## What Problem This Solves

Removes twelve repeated text/content/details result envelopes from the background process tools while preserving every action and result.

## Why This Change Was Made

Both process modules now use the existing lightweight `textResult` helper. Process execution, status selection, text composition and details remain with their existing owners. Poll delivery acknowledgement stays attached to the final returned object, so transcript persistence can consume it once and a retained old result cannot consume a successor delivery.

## User Impact

No behavior or performance change is claimed. Production code decreases by 69 lines (+59/−128) across two files. Tests, configuration, dependencies and storage behavior are unchanged.

## Evidence

The same 77 existing tests pass before and after, including real PTY input and an interactive background child controlled through list/log/poll/write/submit/send-keys/kill. Existing delivery tests cover dropped results, transformed or blocked transcript writes, parallel polls and stale retained acknowledgements.

An external direct-source comparison preserves JSON bytes, own property descriptors and ordering, explicit undefined fields, errors, stdin/cancellation effects and exact-object acknowledgement behavior across 812 action/state cases and three acknowledgement scenarios: 1,270,866 identical bytes. All 28 selected type, format, lint, dead-export and architecture checks pass; the final guard alone was repeated to recover a missing shell exit receipt. Independent managed P2 review and deslop are clean. Current main retains the unchanged pre-refactor owner and helper.
