### PR TITLE
fix(agents): account for repaired messages in compaction pruning

### DIFF
--- a/packages/agent-core/src/harness/session/tool-result-pairing.ts
+++ b/packages/agent-core/src/harness/session/tool-result-pairing.ts
@@ -40,6 +40,7 @@ type ToolUsePairingClassification = {
   frames: ToolUsePairingFrame[];
   droppedDuplicateCount: number;
   droppedOrphanCount: number;
+  droppedResults: ToolResultMessage[];
 };
 
 type ToolCallOccurrenceQueue<T> = {
@@ -233,6 +234,7 @@ export function classifyToolUseResultPairing(
   );
   let droppedDuplicateCount = 0;
   let droppedOrphanCount = 0;
+  const droppedResults: ToolResultMessage[] = [];
   const preserveUnframed = options?.preserveUnframedToolResults === true;
   const frameRecords: Array<ToolUsePairingFrame & { unclaimedResults: ToolResultRecord[] }> =
     frameStartIndexes.map((startIndex, frameIndex) => {
@@ -287,7 +289,11 @@ export function classifyToolUseResultPairing(
           if (replaceable) {
             replaceable.result = normalizeToolResultName(normalized, replaceable.name);
             replaceable.sourceResult = message;
+          } else if (!preserveUnframed) {
+            droppedResults.push(message);
           }
+        } else if (!preserveUnframed) {
+          droppedResults.push(message);
         }
       }
       const stopReason = (assistant as { stopReason?: string }).stopReason;
@@ -326,6 +332,9 @@ export function classifyToolUseResultPairing(
         : [];
       if (candidates.length !== 1) {
         droppedOrphanCount += preserveUnframed ? 0 : 1;
+        if (!preserveUnframed) {
+          droppedResults.push(record.sourceResult);
+        }
         continue;
       }
       const candidate = candidates[0];
@@ -341,7 +350,7 @@ export function classifyToolUseResultPairing(
     }
   }
 
-  return { frames: frameRecords, droppedDuplicateCount, droppedOrphanCount };
+  return { frames: frameRecords, droppedDuplicateCount, droppedOrphanCount, droppedResults };
 }
 
 /** Select reset-tail model context without changing persisted entry bytes or order. */

--- a/packages/agent-core/src/harness/session/tool-result-pairing.ts
+++ b/packages/agent-core/src/harness/session/tool-result-pairing.ts
@@ -358,6 +358,15 @@ export function classifyToolUseResultPairing(
         continue;
       }
       droppedDuplicateCount += candidate.result ? 1 : 0;
+      if (candidate.result && isSyntheticMissingToolResult(candidate.result)) {
+        const discardedSource = candidate.sourceResult;
+        if (discardedSource) {
+          droppedResults.push({
+            message: discardedSource,
+            index: candidate.sourceResultIndex ?? record.index,
+          });
+        }
+      }
       candidate.result = normalizeToolResultName(record.result, candidate.name);
       candidate.sourceResult = record.sourceResult;
       candidate.sourceResultIndex = record.index;

--- a/packages/agent-core/src/harness/session/tool-result-pairing.ts
+++ b/packages/agent-core/src/harness/session/tool-result-pairing.ts
@@ -305,10 +305,10 @@ export function classifyToolUseResultPairing(
             replaceable.result = normalizeToolResultName(normalized, replaceable.name);
             replaceable.sourceResult = message;
             replaceable.sourceResultIndex = index;
-          } else if (!preserveUnframed) {
+          } else {
             droppedResults.push({ message, index });
           }
-        } else if (!preserveUnframed) {
+        } else {
           droppedResults.push({ message, index });
         }
       }

--- a/packages/agent-core/src/harness/session/tool-result-pairing.ts
+++ b/packages/agent-core/src/harness/session/tool-result-pairing.ts
@@ -17,6 +17,7 @@ type ToolCallOccurrence = {
   name?: string;
   result?: ToolResultMessage;
   sourceResult?: ToolResultMessage;
+  sourceResultIndex?: number;
 };
 
 type ToolResultMessage = Extract<AgentMessage, { role: "toolResult" }>;
@@ -24,6 +25,7 @@ type ToolResultMessage = Extract<AgentMessage, { role: "toolResult" }>;
 type ToolResultRecord = {
   result: ToolResultMessage;
   sourceResult: ToolResultMessage;
+  index: number;
   id?: string;
 };
 
@@ -40,7 +42,7 @@ type ToolUsePairingClassification = {
   frames: ToolUsePairingFrame[];
   droppedDuplicateCount: number;
   droppedOrphanCount: number;
-  droppedResults: ToolResultMessage[];
+  droppedResults: Array<{ message: ToolResultMessage; index: number }>;
 };
 
 type ToolCallOccurrenceQueue<T> = {
@@ -234,7 +236,7 @@ export function classifyToolUseResultPairing(
   );
   let droppedDuplicateCount = 0;
   let droppedOrphanCount = 0;
-  const droppedResults: ToolResultMessage[] = [];
+  const droppedResults: Array<{ message: ToolResultMessage; index: number }> = [];
   const preserveUnframed = options?.preserveUnframedToolResults === true;
   const frameRecords: Array<ToolUsePairingFrame & { unclaimedResults: ToolResultRecord[] }> =
     frameStartIndexes.map((startIndex, frameIndex) => {
@@ -266,6 +268,7 @@ export function classifyToolUseResultPairing(
         if (occurrence) {
           occurrence.result = normalizeToolResultName(normalized, occurrence.name);
           occurrence.sourceResult = message;
+          occurrence.sourceResultIndex = index;
           if (isSyntheticMissingToolResult(occurrence.result)) {
             const synthetic = syntheticById.get(occurrence.id);
             if (synthetic) {
@@ -277,7 +280,12 @@ export function classifyToolUseResultPairing(
           continue;
         }
         if (!id || !occurrences.some((candidate) => candidate.id === id)) {
-          unclaimedResults.push({ result: normalized, sourceResult: message, id: id ?? undefined });
+          unclaimedResults.push({
+            result: normalized,
+            sourceResult: message,
+            index,
+            id: id ?? undefined,
+          });
           if (preserveUnframed) {
             remainder.push(normalized);
           }
@@ -287,13 +295,21 @@ export function classifyToolUseResultPairing(
         if (!isSyntheticMissingToolResult(normalized)) {
           const replaceable = syntheticById.get(id)?.shift();
           if (replaceable) {
+            const discardedSource = replaceable.sourceResult;
+            if (discardedSource) {
+              droppedResults.push({
+                message: discardedSource,
+                index: replaceable.sourceResultIndex ?? index,
+              });
+            }
             replaceable.result = normalizeToolResultName(normalized, replaceable.name);
             replaceable.sourceResult = message;
+            replaceable.sourceResultIndex = index;
           } else if (!preserveUnframed) {
-            droppedResults.push(message);
+            droppedResults.push({ message, index });
           }
         } else if (!preserveUnframed) {
-          droppedResults.push(message);
+          droppedResults.push({ message, index });
         }
       }
       const stopReason = (assistant as { stopReason?: string }).stopReason;
@@ -333,7 +349,7 @@ export function classifyToolUseResultPairing(
       if (candidates.length !== 1) {
         droppedOrphanCount += preserveUnframed ? 0 : 1;
         if (!preserveUnframed) {
-          droppedResults.push(record.sourceResult);
+          droppedResults.push({ message: record.sourceResult, index: record.index });
         }
         continue;
       }
@@ -344,6 +360,7 @@ export function classifyToolUseResultPairing(
       droppedDuplicateCount += candidate.result ? 1 : 0;
       candidate.result = normalizeToolResultName(record.result, candidate.name);
       candidate.sourceResult = record.sourceResult;
+      candidate.sourceResultIndex = record.index;
       if (preserveUnframed) {
         frame.remainder = frame.remainder.filter((message) => message !== record.result);
       }

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2027,6 +2027,61 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(messagesToSummarize).toStrictEqual(transcriptBefore);
   });
 
+  it("sends pairing-discarded retained results to the dropped-history summary", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages
+      .mockResolvedValueOnce(summaryResult("dropped history summary"))
+      .mockResolvedValueOnce(summaryResult("main history summary"));
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture({ contextWindow: 2_000 });
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      maxHistoryShare: 0.5,
+      recentTurnsPreserve: 0,
+    });
+
+    const compactionHandler = createCompactionHandler();
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyMock: vi.fn().mockResolvedValue("test-key"),
+    });
+    const messagesToSummarize: AgentMessage[] = [
+      { role: "user", content: "x".repeat(4_000), timestamp: 1 },
+      castAgentMessage({
+        role: "toolResult",
+        toolCallId: "missing-call",
+        toolName: "test_tool",
+        content: [{ type: "text", text: "orphan-result ".repeat(500) }],
+        isError: false,
+        timestamp: 2,
+      }),
+      { role: "user", content: "x".repeat(4_000), timestamp: 3 },
+    ];
+    const event = {
+      preparation: {
+        messagesToSummarize,
+        turnPrefixMessages: [],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 10_000,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4000 },
+        previousSummary: undefined,
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const result = await compactionHandler(event, mockContext);
+
+    expectCompactionResult(result as Parameters<typeof expectCompactionResult>[0]);
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(2);
+    const droppedCall = requireRecord(mockCallArg(mockSummarizeInStages));
+    const droppedMessages = requireArray(droppedCall.messages) as AgentMessage[];
+    expect(droppedMessages.map((message) => message.timestamp)).toEqual([1, 2]);
+  });
+
   it("propagates caller abort while summarizing dropped history", async () => {
     mockSummarizeInStages.mockReset();
     const controller = new AbortController();

--- a/src/agents/compaction-planning.ts
+++ b/src/agents/compaction-planning.ts
@@ -328,6 +328,9 @@ function pruneHistoryForContextShare(params: {
   let droppedTokens = 0;
 
   const parts = normalizeCompactionParts(params.parts ?? DEFAULT_PARTS, keptMessages.length);
+  const originalMessageIndexes = new Map(
+    params.messages.map((message, index) => [message, index] as const),
+  );
 
   while (keptMessages.length > 0 && estimateMessagesTokens(keptMessages) > budgetTokens) {
     const chunks = splitMessagesByTokenShare(keptMessages, parts);
@@ -346,6 +349,12 @@ function pruneHistoryForContextShare(params: {
     allDroppedMessages.push(...dropped, ...repairedDropped);
     keptMessages = repairReport.messages;
   }
+
+  allDroppedMessages.sort(
+    (left, right) =>
+      (originalMessageIndexes.get(left) ?? params.messages.length) -
+      (originalMessageIndexes.get(right) ?? params.messages.length),
+  );
 
   return {
     messages: keptMessages,

--- a/src/agents/compaction-planning.ts
+++ b/src/agents/compaction-planning.ts
@@ -336,12 +336,15 @@ function pruneHistoryForContextShare(params: {
     }
     const dropped = chunks[0]!;
     // Dropping a call owner also drops orphaned results; providers reject replay without the pair.
-    const repairReport = repairToolUseResultPairing(chunks.slice(1).flat());
+    const retained = chunks.slice(1).flat();
+    const repairReport = repairToolUseResultPairing(retained);
+    const retainedAfterRepair = new Set(repairReport.messages);
+    const repairedDropped = retained.filter((message) => !retainedAfterRepair.has(message));
 
     droppedChunks += 1;
-    droppedMessages += dropped.length + repairReport.droppedOrphanCount;
-    droppedTokens += estimateMessagesTokens(dropped);
-    allDroppedMessages.push(...dropped);
+    droppedMessages += dropped.length + repairedDropped.length;
+    droppedTokens += estimateMessagesTokens(dropped) + estimateMessagesTokens(repairedDropped);
+    allDroppedMessages.push(...dropped, ...repairedDropped);
     keptMessages = repairReport.messages;
   }
 

--- a/src/agents/compaction-planning.ts
+++ b/src/agents/compaction-planning.ts
@@ -324,8 +324,6 @@ function pruneHistoryForContextShare(params: {
   let keptMessages = params.messages;
   const allDroppedMessages: AgentMessage[] = [];
   let droppedChunks = 0;
-  let droppedMessages = 0;
-  let droppedTokens = 0;
 
   const parts = normalizeCompactionParts(params.parts ?? DEFAULT_PARTS, keptMessages.length);
   const originalMessageIndexes = new Map(
@@ -344,8 +342,6 @@ function pruneHistoryForContextShare(params: {
     const repairedDropped = repairReport.discarded;
 
     droppedChunks += 1;
-    droppedMessages += dropped.length + repairedDropped.length;
-    droppedTokens += estimateMessagesTokens(dropped) + estimateMessagesTokens(repairedDropped);
     allDroppedMessages.push(...dropped, ...repairedDropped);
     keptMessages = repairReport.messages;
   }
@@ -360,8 +356,8 @@ function pruneHistoryForContextShare(params: {
     messages: keptMessages,
     droppedMessagesList: allDroppedMessages,
     droppedChunks,
-    droppedMessages,
-    droppedTokens,
+    droppedMessages: allDroppedMessages.length,
+    droppedTokens: estimateMessagesTokens(allDroppedMessages),
     keptTokens: estimateMessagesTokens(keptMessages),
     budgetTokens,
   };

--- a/src/agents/compaction-planning.ts
+++ b/src/agents/compaction-planning.ts
@@ -338,8 +338,7 @@ function pruneHistoryForContextShare(params: {
     // Dropping a call owner also drops orphaned results; providers reject replay without the pair.
     const retained = chunks.slice(1).flat();
     const repairReport = repairToolUseResultPairing(retained);
-    const retainedAfterRepair = new Set(repairReport.messages);
-    const repairedDropped = retained.filter((message) => !retainedAfterRepair.has(message));
+    const repairedDropped = repairReport.discarded;
 
     droppedChunks += 1;
     droppedMessages += dropped.length + repairedDropped.length;

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -636,12 +636,9 @@ describe("pruneHistoryForContextShare", () => {
     });
 
     expect(pruned.messages).not.toContain(messages[2]!);
-    expect(pruned.droppedMessagesList).toEqual([
-      messages[0],
-      messages[1],
-      messages[2],
-      messages[4],
-    ]);
+    expect(
+      pruned.droppedMessagesList.map((message) => message.timestamp).toSorted(compareTimestampIds),
+    ).toEqual([1, 2, 3, 5]);
     expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length);
   });
 

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -587,4 +587,30 @@ describe("pruneHistoryForContextShare", () => {
     expect(keptToolResults).toHaveLength(0);
     expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length);
   });
+
+  it("accounts for orphaned tool_results removed from the retained suffix", () => {
+    const messages: AgentMessage[] = [
+      makeMessage(1, 4000),
+      makeToolResult(2, "missing-call", "orphan-result ".repeat(500)),
+      makeMessage(3, 4000),
+    ];
+    const chunks = splitMessagesByTokenShare(messages, 2);
+    const retained = chunks.slice(1).flat();
+    const retainedTokens = estimateMessagesTokens(retained);
+    const totalTokens = estimateMessagesTokens(messages);
+    const pruned = pruneHistoryForContextShare({
+      messages,
+      maxContextTokens: Math.ceil(totalTokens),
+      maxHistoryShare: 0.5,
+      parts: 2,
+    });
+
+    expect(chunks[0]).toContain(messages[0]);
+    expect(retained).toContain(messages[1]);
+    expect(pruned.messages).not.toContain(messages[1]);
+    expect(pruned.droppedMessagesList).toEqual([messages[0], messages[1]]);
+    expect(pruned.droppedMessages).toBe(2);
+    expect(pruned.droppedTokens).toBe(estimateMessagesTokens([messages[0], messages[1]]));
+    expect(retainedTokens).toBeGreaterThan(0);
+  });
 });

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -610,7 +610,7 @@ describe("pruneHistoryForContextShare", () => {
     expect(pruned.messages).not.toContain(messages[1]);
     expect(pruned.droppedMessagesList).toEqual([messages[0], messages[1]]);
     expect(pruned.droppedMessages).toBe(2);
-    expect(pruned.droppedTokens).toBe(estimateMessagesTokens([messages[0], messages[1]]));
+    expect(pruned.droppedTokens).toBe(estimateMessagesTokens([messages[0]!, messages[1]!]));
     expect(retainedTokens).toBeGreaterThan(0);
   });
 
@@ -619,20 +619,19 @@ describe("pruneHistoryForContextShare", () => {
       makeMessage(1, 4000),
       makeAssistantToolCall(2, "call_read", "result"),
       { ...makeToolResult(3, "call_read", "result"), toolName: "   " },
-      makeMessage(4, 4000),
     ];
     const pruned = pruneHistoryForContextShare({
       messages,
       maxContextTokens: Math.ceil(estimateMessagesTokens(messages)),
-      maxHistoryShare: 0.5,
+      maxHistoryShare: 0.75,
       parts: 2,
     });
 
-    expect(pruned.droppedMessagesList).not.toContain(messages[2]);
+    expect(pruned.droppedMessagesList).not.toContain(messages[2]!);
     expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length);
-    expect(pruned.messages).not.toContain(messages[2]);
-    expect(
-      pruned.messages.find((message) => message.role === "toolResult"),
-    ).toMatchObject({ toolName: "test_tool" });
+    expect(pruned.messages).not.toContain(messages[2]!);
+    expect(pruned.messages.find((message) => message.role === "toolResult")).toMatchObject({
+      toolName: "test_tool",
+    });
   });
 });

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -638,6 +638,7 @@ describe("pruneHistoryForContextShare", () => {
     expect(pruned.messages).not.toContain(messages[2]!);
     expect(pruned.droppedMessagesList.map((message) => message.timestamp)).toEqual([1, 2, 3, 5]);
     expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length);
+    expect(pruned.droppedTokens).toBe(estimateMessagesTokens(pruned.droppedMessagesList));
   });
 
   it("does not count normalized retained tool_results as dropped", () => {

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -636,9 +636,7 @@ describe("pruneHistoryForContextShare", () => {
     });
 
     expect(pruned.messages).not.toContain(messages[2]!);
-    expect(
-      pruned.droppedMessagesList.map((message) => message.timestamp).toSorted(compareTimestampIds),
-    ).toEqual([1, 2, 3, 5]);
+    expect(pruned.droppedMessagesList.map((message) => message.timestamp)).toEqual([1, 2, 3, 5]);
     expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length);
   });
 

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -636,7 +636,12 @@ describe("pruneHistoryForContextShare", () => {
     });
 
     expect(pruned.messages).not.toContain(messages[2]!);
-    expect(pruned.droppedMessagesList).toEqual([messages[0], messages[1], messages[2], messages[4]]);
+    expect(pruned.droppedMessagesList).toEqual([
+      messages[0],
+      messages[1],
+      messages[2],
+      messages[4],
+    ]);
     expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length);
   });
 

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -636,8 +636,8 @@ describe("pruneHistoryForContextShare", () => {
     });
 
     expect(pruned.messages).not.toContain(messages[2]!);
-    expect(pruned.droppedMessagesList).toEqual([messages[0], messages[2]]);
-    expect(pruned.droppedMessages).toBe(2);
+    expect(pruned.droppedMessagesList).toEqual([messages[0], messages[1], messages[2], messages[4]]);
+    expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length);
   });
 
   it("does not count normalized retained tool_results as dropped", () => {

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -613,4 +613,26 @@ describe("pruneHistoryForContextShare", () => {
     expect(pruned.droppedTokens).toBe(estimateMessagesTokens([messages[0], messages[1]]));
     expect(retainedTokens).toBeGreaterThan(0);
   });
+
+  it("does not count normalized retained tool_results as dropped", () => {
+    const messages: AgentMessage[] = [
+      makeMessage(1, 4000),
+      makeAssistantToolCall(2, "call_read", "result"),
+      { ...makeToolResult(3, "call_read", "result"), toolName: "   " },
+      makeMessage(4, 4000),
+    ];
+    const pruned = pruneHistoryForContextShare({
+      messages,
+      maxContextTokens: Math.ceil(estimateMessagesTokens(messages)),
+      maxHistoryShare: 0.5,
+      parts: 2,
+    });
+
+    expect(pruned.droppedMessagesList).not.toContain(messages[2]);
+    expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length);
+    expect(pruned.messages).not.toContain(messages[2]);
+    expect(
+      pruned.messages.find((message) => message.role === "toolResult"),
+    ).toMatchObject({ toolName: "test_tool" });
+  });
 });

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -614,6 +614,32 @@ describe("pruneHistoryForContextShare", () => {
     expect(retainedTokens).toBeGreaterThan(0);
   });
 
+  it("accounts for synthetic results displaced across retained tool frames", () => {
+    const messages: AgentMessage[] = [
+      makeMessage(1, 4000),
+      makeAssistantToolCall(2, "call_first"),
+      {
+        ...makeToolResult(3, "call_first", "synthetic result"),
+        details: { openclawSyntheticMissingToolResult: true },
+        isError: true,
+      },
+      makeAssistantToolCall(4, "call_second"),
+      makeToolResult(5, "call_first", "real result"),
+      makeToolResult(6, "call_second", "second result"),
+    ];
+    const totalTokens = estimateMessagesTokens(messages);
+    const pruned = pruneHistoryForContextShare({
+      messages,
+      maxContextTokens: Math.ceil(totalTokens),
+      maxHistoryShare: 0.5,
+      parts: 2,
+    });
+
+    expect(pruned.messages).not.toContain(messages[2]!);
+    expect(pruned.droppedMessagesList).toEqual([messages[0], messages[2]]);
+    expect(pruned.droppedMessages).toBe(2);
+  });
+
   it("does not count normalized retained tool_results as dropped", () => {
     const messages: AgentMessage[] = [
       makeMessage(1, 4000),

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -838,6 +838,7 @@ describe("repairToolUseResultPairing prefers real result over synthetic error", 
     expect(toolResults[0]?.content?.[0]?.text).toBe("real output");
     expect(toolResults[1]?.toolCallId).toBe("call_2");
     expect(toolResults[1]?.content?.[0]?.text).toBe("second output");
+    expect(result.discarded).toEqual([input[1]]);
   });
 
   it("two real results → keeps first (unchanged behavior)", () => {

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -858,17 +858,19 @@ describe("repairToolUseResultPairing prefers real result over synthetic error", 
   });
 
   it("reports duplicate results discarded when preserving unframed results", () => {
+    const preservedUnframed = makeRealResult("call_orphan", "preserved unframed");
     const input = castAgentMessages([
       makeAssistant("call_1"),
       makeRealResult("call_1", "first real"),
       makeRealResult("call_1", "second real"),
+      preservedUnframed,
     ]);
 
     const result = repairToolUseResultPairing(input, {
       preserveUnframedToolResults: true,
     });
 
-    expect(result.messages).toEqual([input[0], input[1]]);
+    expect(result.messages).toEqual([input[0], input[1], preservedUnframed]);
     expect(result.discarded).toEqual([input[2]]);
     expect(result.droppedDuplicateCount).toBe(1);
   });

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -857,6 +857,22 @@ describe("repairToolUseResultPairing prefers real result over synthetic error", 
     expect(toolResults[0]?.content?.[0]?.text).toBe("first real");
   });
 
+  it("reports duplicate results discarded when preserving unframed results", () => {
+    const input = castAgentMessages([
+      makeAssistant("call_1"),
+      makeRealResult("call_1", "first real"),
+      makeRealResult("call_1", "second real"),
+    ]);
+
+    const result = repairToolUseResultPairing(input, {
+      preserveUnframedToolResults: true,
+    });
+
+    expect(result.messages).toEqual([input[0], input[1]]);
+    expect(result.discarded).toEqual([input[2]]);
+    expect(result.droppedDuplicateCount).toBe(1);
+  });
+
   it("two synthetic errors → keeps first (unchanged behavior)", () => {
     const input = castAgentMessages([
       makeAssistant("call_1"),

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -332,6 +332,23 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(result.discarded).toEqual([orphan]);
   });
 
+  it("does not report preserved unframed results as discarded", () => {
+    const orphan = castAgentMessage({
+      role: "toolResult",
+      toolCallId: "call_orphan",
+      toolName: "read",
+      content: [{ type: "text", text: "orphan" }],
+      isError: false,
+    });
+
+    const result = repairToolUseResultPairing([orphan], {
+      preserveUnframedToolResults: true,
+    });
+
+    expect(result.messages).toEqual([orphan]);
+    expect(result.discarded).toEqual([]);
+  });
+
   it("skips tool call extraction for assistant messages with stopReason 'error'", () => {
     // When an assistant message has stopReason: "error", its tool_use blocks may be
     // incomplete/malformed. We should NOT create synthetic tool_results for them,
@@ -714,6 +731,20 @@ describe("repairToolUseResultPairing prefers real result over synthetic error", 
     expect(toolResults).toHaveLength(1);
     expect(toolResults[0]?.isError).not.toBe(true);
     expect(toolResults[0]?.content?.[0]?.text).toBe("real output");
+    expect(result.discarded).toEqual([input[1]]);
+  });
+
+  it("returns discarded results in transcript order", () => {
+    const input = castAgentMessages([
+      makeAssistant("call_1"),
+      makeSyntheticResult("call_1"),
+      makeRealResult("call_orphan", "orphan"),
+      makeRealResult("call_1"),
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    expect(result.discarded).toEqual([input[1], input[2]]);
   });
 
   it("custom synthetic text first, real second → keeps real when configured", () => {

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -313,6 +313,25 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(out.map((m) => m.role)).toEqual(["user", "assistant"]);
   });
 
+  it("reports the original messages discarded during pairing repair", () => {
+    const orphan = {
+      role: "toolResult" as const,
+      toolCallId: "call_orphan",
+      toolName: "read",
+      content: [{ type: "text" as const, text: "orphan" }],
+      isError: false,
+    };
+    const input = castAgentMessages([
+      { role: "user", content: "hello" },
+      orphan,
+      { role: "assistant", content: [{ type: "text", text: "ok" }] },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    expect(result.discarded).toEqual([orphan]);
+  });
+
   it("skips tool call extraction for assistant messages with stopReason 'error'", () => {
     // When an assistant message has stopReason: "error", its tool_use blocks may be
     // incomplete/malformed. We should NOT create synthetic tool_results for them,
@@ -621,6 +640,7 @@ describe("repairToolUseResultPairing repeated per-turn ids", () => {
         (message) => message.role === "toolResult" && message.toolCallId === "call_read",
       ),
     ).toMatchObject({ toolName: "exec" });
+    expect(result.discarded).toEqual([]);
   });
 
   it("handles a long valid repeated-id transcript as an unchanged linear pass", () => {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -443,6 +443,7 @@ export function sanitizeToolUseResultPairingForModel(
 type ToolUseRepairReport = {
   messages: AgentMessage[];
   added: Array<Extract<AgentMessage, { role: "toolResult" }>>;
+  discarded: AgentMessage[];
   droppedDuplicateCount: number;
   droppedOrphanCount: number;
   moved: boolean;
@@ -471,6 +472,7 @@ export function repairToolUseResultPairing(
   const { frames } = pairing;
   const droppedDuplicateCount = pairing.droppedDuplicateCount;
   let droppedOrphanCount = pairing.droppedOrphanCount;
+  const discarded: AgentMessage[] = [...pairing.droppedResults];
 
   const out: AgentMessage[] = [];
   let cursor = 0;
@@ -482,6 +484,7 @@ export function repairToolUseResultPairing(
       }
       if (message.role === "toolResult" && !preserveUnframed) {
         droppedOrphanCount += 1;
+        discarded.push(message);
         continue;
       }
       out.push(message);
@@ -511,6 +514,12 @@ export function repairToolUseResultPairing(
         added.push(missing);
         out.push(missing);
       }
+    } else {
+      for (const occurrence of frame.occurrences) {
+        if (occurrence.sourceResult) {
+          discarded.push(occurrence.sourceResult);
+        }
+      }
     }
     out.push(...frame.remainder);
   }
@@ -521,6 +530,7 @@ export function repairToolUseResultPairing(
   return {
     messages: changed ? out : messages,
     added,
+    discarded,
     droppedDuplicateCount,
     droppedOrphanCount,
     moved: changed,

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -472,19 +472,22 @@ export function repairToolUseResultPairing(
   const { frames } = pairing;
   const droppedDuplicateCount = pairing.droppedDuplicateCount;
   let droppedOrphanCount = pairing.droppedOrphanCount;
-  const discarded: AgentMessage[] = [...pairing.droppedResults];
+  const discarded: Array<{ message: AgentMessage; index: number }> = pairing.droppedResults.map(
+    ({ message, index }) => ({ message, index }),
+  );
 
   const out: AgentMessage[] = [];
   let cursor = 0;
   const pushUnframedRange = (endIndex: number) => {
     for (; cursor < endIndex; cursor += 1) {
+      const sourceIndex = cursor;
       const message = messages[cursor];
       if (!message || typeof message !== "object") {
         continue;
       }
       if (message.role === "toolResult" && !preserveUnframed) {
         droppedOrphanCount += 1;
-        discarded.push(message);
+        discarded.push({ message, index: sourceIndex });
         continue;
       }
       out.push(message);
@@ -517,7 +520,10 @@ export function repairToolUseResultPairing(
     } else {
       for (const occurrence of frame.occurrences) {
         if (occurrence.sourceResult) {
-          discarded.push(occurrence.sourceResult);
+          discarded.push({
+            message: occurrence.sourceResult,
+            index: occurrence.sourceResultIndex ?? messages.indexOf(occurrence.sourceResult),
+          });
         }
       }
     }
@@ -527,10 +533,11 @@ export function repairToolUseResultPairing(
 
   const changed =
     out.length !== messages.length || out.some((message, index) => message !== messages[index]);
+  discarded.sort((left, right) => left.index - right.index);
   return {
     messages: changed ? out : messages,
     added,
-    discarded,
+    discarded: discarded.map(({ message }) => message),
     droppedDuplicateCount,
     droppedOrphanCount,
     moved: changed,


### PR DESCRIPTION
## What Problem This Solves

Compaction pruning could remove orphaned, duplicate, or displaced tool results from retained history while omitting them from dropped-history summaries and token totals.

## Why This Change Was Made

Pairing repair now returns the original messages it discards, with source order preserved. The compaction planning owner adds those messages to one canonical dropped-history list and derives the count and token total from that list.

Pairing and pruning policy are unchanged. Preserved unframed results remain preserved. Matching framed results still win over synthetic results. Duplicate and orphan removal rules remain unchanged.

## User Impact

Dropped-history summaries include every message removed during retained-history repair. Compaction counts and token totals match the ordered dropped history.

## Evidence

- Baseline main `368f1e77670a3cbe134896c0db631f8321853eaf` reproduced the bug: the orphan case reported count `2` but listed only `[1]` and counted `1000` tokens instead of `2750`; the displaced synthetic case listed only `[1]` and counted `1000` instead of the full removed set.
- Exact head `7bd0c0b5843711b8e48bb0e37167e5f6de67c912` passes 29 compaction tests, 68 transcript-repair tests, and 154 compaction-safeguard tests.
- Production prune proof reports orphan drops `[1, 2]` with count `2` and exact token total `2750`.
- Production prune proof reports displaced synthetic/real drops `[1, 2, 3, 5]` with count `4` and exact token total `2010`.
- Preserved-unframed proof keeps `[1, 2, 4]` and reports framed duplicate `[3]` with duplicate count `1`.
- The proof covers orphan, duplicate, framed, and preserved-unframed result modes.
- No persisted data model, SQLite schema, protocol, config, or public API changed. The discard report is return-only planning data.
- Core Oxlint, Oxfmt, and `git diff --check` pass.
- Typecheck remains delegated to CI because repository policy forbids OpenClaw typecheck on this host.

## Review Metrics

- Production delta: net `-5` lines in the planning owner; pairing provenance is the existing repair boundary.
- Test delta: `+4` lines beyond the contributor branch for the preserved-unframed assertion and exact prune token check.

## Product Path

Compaction planning selects retained history, repairs tool-result pairing, and sends the ordered dropped history to the compaction summary flow.
