### PR TITLE
perf: reuse validators for rebuilt tool schemas

### DIFF
--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -311,8 +311,6 @@ function matchesCachedToolSearchIndex(
 let schemaValidatorModulePromise:
   | Promise<typeof import("../plugins/schema-validator.js")>
   | undefined;
-const catalogSchemaCacheIds = new WeakMap<object, number>();
-let nextCatalogSchemaCacheId = 0;
 
 function getCatalogSchemaCacheKey(
   entry: ToolSearchCatalogEntry,
@@ -320,17 +318,8 @@ function getCatalogSchemaCacheKey(
   schema: unknown,
 ): string {
   const prefix = `tool-${schemaName === "inputSchema" ? "input" : "output"}:${entry.id}`;
-  if (typeof schema !== "object" || schema === null) {
-    return `${prefix}:${String(schema)}`;
-  }
-  let schemaCacheId = catalogSchemaCacheIds.get(schema);
-  if (schemaCacheId === undefined) {
-    schemaCacheId = nextCatalogSchemaCacheId++;
-    catalogSchemaCacheIds.set(schema, schemaCacheId);
-  }
-  // Trusted schemas can be edited in place, so object identity alone cannot
-  // safely reuse a compiled validator after its constraints have changed.
-  return `${prefix}:${schemaCacheId}:${JSON.stringify(schema)}`;
+  // Content keys reuse rebuilt tool schemas while invalidating in-place constraint changes.
+  return `${prefix}:${JSON.stringify(schema)}`;
 }
 
 async function validateCatalogSchemaValue(


### PR DESCRIPTION
## What Problem This Solves

Tool Search and Code Mode could compile and retain a new validator whenever a tool catalog rebuilt an equivalent schema object. The cache key combined serialized schema content with a unique object ID, defeating reuse across otherwise identical catalogs.

## Why This Change Was Made

Key validators by tool ID, input/output role, and serialized schema content. The schema validator already compares schema fingerprints when objects differ; a separate identity map and counter are unnecessary. In-place constraint changes still produce different keys, and different tool contracts remain isolated.

## User Impact

Repeated tool catalogs reuse compiled validators instead of filling the bounded validator cache with equivalent copies. Production LOC +2/-13 (net -11); existing tests are retained unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/agents/tool-search-runtime.test.ts src/plugins/schema-validator.test.ts`: all 100 tests passed, including distinct-catalog contracts, in-place mutation, invalid schemas, input/output validation and format semantics.
- Actual `ToolSearchRuntime.call` probe: 512 rebuilt equivalent 100-property output schemas. Both revisions returned the same tool results; retained heap fell from approximately 50 MB to less than 0.3 MB after forced GC. This is isolated owner-level allocation evidence, not a whole-Gateway RSS claim.
- The TypeBox dependency creates a new Validator with retained build/evaluation state per compilation; the owning schema cache already reuses equal JSON fingerprints across differing object identities.
- Independent source review accepted the owner change; fresh Codex autoreview found no actionable issues.
- `node scripts/check-changed.mjs -- src/agents/tool-search-runtime.ts` passed, including core/core-test typechecks, lint and guards.
- Full `pnpm build` passed. A rebuilt, isolated dev Gateway used a real OpenAI API key for a Code Mode turn that fetched the Node.js Buffer and Process documentation. The terminal receipt recorded successful `web_fetch` and `exec`, two bridge calls, no tool failures, and `codeModeEngaged: true`.
