### PR TITLE
fix(acpx): start source MCP tools outside the repo

### DIFF
--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -18,6 +18,12 @@ function expectedMcpServerArgs(params: { sourceEntry: string; distEntry: string 
   return ["--import", TSX_IMPORT, path.resolve(params.sourceEntry)];
 }
 
+function expectedMcpServerEnv(distEntry: string): Record<string, string> | undefined {
+  return fs.existsSync(path.resolve(distEntry))
+    ? undefined
+    : { TSX_TSCONFIG_PATH: path.resolve("tsconfig.json") };
+}
+
 describe("embedded acpx plugin config", () => {
   it("resolves workspace stateDir and cwd by default", () => {
     const workspaceDir = path.resolve("/tmp/openclaw-acpx");
@@ -156,6 +162,7 @@ describe("embedded acpx plugin config", () => {
         sourceEntry: "src/mcp/plugin-tools-serve.ts",
         distEntry: "dist/mcp/plugin-tools-serve.js",
       }),
+      env: expectedMcpServerEnv("dist/mcp/plugin-tools-serve.js"),
     });
   });
 
@@ -174,6 +181,7 @@ describe("embedded acpx plugin config", () => {
         sourceEntry: "src/mcp/openclaw-tools-serve.ts",
         distEntry: "dist/mcp/openclaw-tools-serve.js",
       }),
+      env: expectedMcpServerEnv("dist/mcp/openclaw-tools-serve.js"),
     });
   });
 

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -163,6 +163,9 @@ function resolvePluginToolsMcpServerConfig(moduleUrl: string = import.meta.url):
   return {
     command: process.execPath,
     args: ["--import", resolveTsxImportSpecifier(), sourceEntry],
+    // ACP sessions keep their workspace cwd; pin the source config so tsx can
+    // resolve OpenClaw workspace aliases without cwd-based discovery.
+    env: { TSX_TSCONFIG_PATH: path.join(openClawRoot, "tsconfig.json") },
   };
 }
 
@@ -180,6 +183,9 @@ function resolveOpenClawToolsMcpServerConfig(moduleUrl: string = import.meta.url
   return {
     command: process.execPath,
     args: ["--import", resolveTsxImportSpecifier(), sourceEntry],
+    // ACP sessions keep their workspace cwd; pin the source config so tsx can
+    // resolve OpenClaw workspace aliases without cwd-based discovery.
+    env: { TSX_TSCONFIG_PATH: path.join(openClawRoot, "tsconfig.json") },
   };
 }
 


### PR DESCRIPTION
Related: #134989

## What Problem This Solves

Fixes an issue where developers running OpenClaw from a source checkout could bind an external ACP harness, but its built-in MCP tools server failed on the first routed turn when the harness workspace was outside the OpenClaw repository.

## Why This Change Was Made

Source MCP launchers now give `tsx` the absolute OpenClaw `tsconfig.json` path. This preserves the ACP session workspace while letting both built-in MCP source servers resolve workspace package aliases. Built package launchers remain unchanged.

Production LOC: +6/-0, including four invariant-comment lines. Tests: +8/-0.

## User Impact

Developers can use built-in OpenClaw and plugin MCP tools from ACP sessions while running an unbuilt source checkout from any workspace.

## Evidence

- Exact current-main red: Gateway bind succeeded, then the first routed Muse turn failed because the required `openclaw-tools` transport closed during source startup.
- Child stderr: `ERR_MODULE_NOT_FOUND` for `@openclaw/normalization-core` from the external ACP workspace.
- Regression test: both source MCP configurations failed before the fix and pass after it.
- Real MCP stdio client: external-cwd source startup lists `automations` in 2.4–5 seconds.
- Exact-head live green: Gateway → ACPX → Muse Code → source MCP server passed 8/8, including bind and three routed turns.
- `env -u CODEX_HOME pnpm test:extension acpx` — 275/275 passed.
- P1 autoreview — clean, 0.96.
- Fable best-fix review — clean.

One initial cold post-fix run hit Muse's MCP startup timeout. The immediate exact rerun passed; #134989 tracks that separate source-only latency investigation without weakening startup checks here.

Provenance: source fallback carried forward from commit `c2ac1e3ef4e0` (2026-04-22, Peter Steinberger); GitHub maps no PR to that commit.
