### PR TITLE
test(install): use shell command fixtures for baseline selection

### DIFF
--- a/test/scripts/install-previous-version.test.ts
+++ b/test/scripts/install-previous-version.test.ts
@@ -14,27 +14,37 @@ function runInstallerVersionSelection(
 ) {
   const root = tempDirs.make("openclaw-install-previous-");
   const binDir = path.join(root, "bin");
-  const callsFile = path.join(root, "calls.jsonl");
+  const callsFile = path.join(root, "calls.argv");
   mkdirSync(binDir);
   writeFileSync(callsFile, "");
   writeFileSync(
     path.join(binDir, "npm"),
-    `#!/usr/bin/env node
-const fs = require("node:fs");
-const args = process.argv.slice(2);
-while (args[0]?.startsWith("--")) args.shift();
-fs.appendFileSync(process.env.FIXTURE_CALLS, JSON.stringify(args) + "\\n");
-if (args[0] === "install") process.exit(${fixtureStop});
-if (args[0] !== "view") process.exit(74);
-process.stdout.write(args.includes("versions") ? process.env.FIXTURE_VERSIONS : process.env.FIXTURE_TARGET);
+    `#!/bin/sh
+set -eu
+while [ "$#" -gt 0 ]; do
+  case "$1" in --*) shift ;; *) break ;; esac
+done
+printf '%s\\0' "$#" "$@" >> "$FIXTURE_CALLS"
+[ "$#" -gt 0 ] || exit 74
+case "$1" in
+  install) exit ${fixtureStop} ;;
+  view)
+    for arg do
+      if [ "$arg" = versions ]; then printf '%s' "$FIXTURE_VERSIONS"; exit 0; fi
+    done
+    printf '%s' "$FIXTURE_TARGET"
+    ;;
+  *) exit 74 ;;
+esac
 `,
     { mode: 0o755 },
   );
   writeFileSync(
     path.join(binDir, "curl"),
-    `#!/usr/bin/env node
-require("node:fs").appendFileSync(process.env.FIXTURE_CALLS, '["installer"]\\n');
-process.exit(${fixtureStop});
+    `#!/bin/sh
+set -eu
+printf '%s\\0' 1 installer >> "$FIXTURE_CALLS"
+exit ${fixtureStop}
 `,
     { mode: 0o755 },
   );
@@ -61,11 +71,12 @@ process.exit(${fixtureStop});
       OPENCLAW_INSTALL_SMOKE_HEARTBEAT_INTERVAL: "0",
     },
   });
-  const calls = readFileSync(callsFile, "utf8")
-    .trim()
-    .split("\n")
-    .filter(Boolean)
-    .map((line) => JSON.parse(line) as string[]);
+  const fields = readFileSync(callsFile, "utf8").split("\0").slice(0, -1);
+  const calls: string[][] = [];
+  while (fields.length > 0) {
+    const count = Number(fields.shift());
+    calls.push(fields.splice(0, count));
+  }
   return { ...result, calls };
 }
 


### PR DESCRIPTION
The baseline-installer tests launch Node for canned npm and curl responses even though their real subject is the Bash installer and predecessor selector. Replace those two fake executables with POSIX shell fixtures and capture exact argument arrays as count-framed NUL fields.

All 14 cases pass before and after with identical native names and outcomes. The shared installed-version parsing/verification sibling also passes. Exact command-array and exit-status assertions remain, alongside both real Bash runners and ten real Node selector executions.

Production +0/-0; tests +28/-17. This replaces 32 fake npm and two fake curl Node startups with shell starts; all 34 process boundaries remain. Quoted shell arguments and constant printf formatting preserve argv framing. Full changed-file checks passed and scoped Codex review returned no findings. No real npm/curl side effects or measured elapsed improvement are claimed.
