### PR TITLE
refactor(memory-wiki): inline gateway source sync

### DIFF
--- a/extensions/memory-wiki/src/gateway.ts
+++ b/extensions/memory-wiki/src/gateway.ts
@@ -99,18 +99,6 @@ function respondError(respond: GatewayRespond, error: unknown) {
   respond(false, undefined, { code: "internal_error", message });
 }
 
-async function syncImportedSourcesIfNeeded(
-  config: ResolvedMemoryWikiConfig,
-  appConfig?: OpenClawConfig,
-  signal?: AbortSignal,
-) {
-  await syncMemoryWikiImportedSources({
-    config,
-    appConfig,
-    ...(signal ? { signal } : {}),
-  });
-}
-
 export function registerMemoryWikiGatewayMethods(params: {
   api: OpenClawPluginApi;
   config: ResolvedMemoryWikiConfig;
@@ -189,7 +177,7 @@ export function registerMemoryWikiGatewayMethods(params: {
     async ({ params: requestParams, respond }) => {
       try {
         const { appConfig, config, signal } = resolveRequestContext(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig, signal);
+        await syncMemoryWikiImportedSources({ config, appConfig, ...(signal ? { signal } : {}) });
         respond(
           true,
           await resolveMemoryWikiStatus(config, {
@@ -266,7 +254,7 @@ export function registerMemoryWikiGatewayMethods(params: {
     async ({ params: requestParams, respond }) => {
       try {
         const { appConfig, config, signal } = resolveRequestContext(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig, signal);
+        await syncMemoryWikiImportedSources({ config, appConfig, ...(signal ? { signal } : {}) });
         const status = await resolveMemoryWikiStatus(config, {
           appConfig,
         });
@@ -283,7 +271,7 @@ export function registerMemoryWikiGatewayMethods(params: {
     async ({ params: requestParams, respond }) => {
       try {
         const { appConfig, config, signal } = resolveRequestContext(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig, signal);
+        await syncMemoryWikiImportedSources({ config, appConfig, ...(signal ? { signal } : {}) });
         respond(true, await compileMemoryWikiVault(config, signal ? { signal } : undefined));
       } catch (error) {
         respondError(respond, error);
@@ -320,7 +308,7 @@ export function registerMemoryWikiGatewayMethods(params: {
     async ({ params: requestParams, respond }) => {
       try {
         const { appConfig, config, signal } = resolveRequestContext(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig, signal);
+        await syncMemoryWikiImportedSources({ config, appConfig, ...(signal ? { signal } : {}) });
         respond(true, await lintMemoryWikiVault(config, signal ? { signal } : undefined));
       } catch (error) {
         respondError(respond, error);
@@ -377,7 +365,7 @@ export function registerMemoryWikiGatewayMethods(params: {
     async ({ params: requestParams, respond }) => {
       try {
         const { agentId, appConfig, config, signal } = resolveRequestContext(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig, signal);
+        await syncMemoryWikiImportedSources({ config, appConfig, ...(signal ? { signal } : {}) });
         const query = readStringParam(requestParams, "query", { required: true });
         const maxResults = readPositiveIntegerParam(requestParams, "maxResults");
         const searchBackend = readEnumParam(requestParams, "backend", WIKI_SEARCH_BACKENDS);
@@ -410,7 +398,7 @@ export function registerMemoryWikiGatewayMethods(params: {
         const { appConfig, config, signal } = resolveRequestContext(requestParams);
         // Source sync can write imported pages and indexes, so validate first.
         const mutation = normalizeMemoryWikiMutationInput(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig, signal);
+        await syncMemoryWikiImportedSources({ config, appConfig, ...(signal ? { signal } : {}) });
         respond(
           true,
           await applyMemoryWikiMutation({
@@ -431,7 +419,7 @@ export function registerMemoryWikiGatewayMethods(params: {
     async ({ params: requestParams, respond }) => {
       try {
         const { agentId, appConfig, config, signal } = resolveRequestContext(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig, signal);
+        await syncMemoryWikiImportedSources({ config, appConfig, ...(signal ? { signal } : {}) });
         const lookup = readStringParam(requestParams, "lookup", { required: true });
         const fromLine = readPositiveIntegerParam(requestParams, "fromLine");
         const lineCount = readPositiveIntegerParam(requestParams, "lineCount");


### PR DESCRIPTION
## What Problem This Solves

The Memory Wiki gateway carried a local positional wrapper around the canonical source-sync object API. That wrapper owned no policy, lifecycle, ordering, or error behavior, and duplicated an already-direct call pattern in the same module.

## Why This Change Was Made

Delete `syncImportedSourcesIfNeeded` and have its seven gateway call sites invoke `syncMemoryWikiImportedSources` directly. Each call preserves the same `config`, `appConfig`, conditional `signal` property, `await` ordering, and surrounding `try`/`catch` boundary.

The architectural owner remains `extensions/memory-wiki/src/source-sync.ts`; tool-side wrappers and all config, storage, SDK, docs, and test surfaces remain unchanged.

## User Impact

No user-visible behavior change. The gateway now has one fewer adapter and one canonical source-sync call shape.

## Evidence

- Focused gateway/source-sync/lifecycle tests: 3 files, 67 tests passed.
- `pnpm test:extension memory-wiki`: 42 files, 489 tests passed.
- `node scripts/check-changed.mjs -- extensions/memory-wiki/src/gateway.ts`: all selected checks passed except the dead-export scan initially lacked tracked `ui/config` files omitted by the shared worktree sparse profile.
- After materializing those tracked sparse files, `node --import tsx scripts/check-deadcode-exports.mts`: production, full-tree, and script scans passed with 0 entries.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `pnpm build`: passed.
- `git diff --check`: passed.
- Exact Codex Sol/high autoreview: scoped clean, no accepted/actionable findings.
- No bespoke Crabbox/live proof: this is a byte-equivalent private refactor. Native PR Testbox remains required before merge.

Production LOC: `+7/-19`, net `-12`.
Test LOC: `0`.

Overlap checked on September 1, 2026:

- #105550 changes Memory Wiki tool-side behavior, not `gateway.ts`.
- #113746 changes Memory Wiki batch/tool behavior, not `gateway.ts`.
