### PR TITLE
perf: release superseded message-tool catalogs

### DIFF
--- a/src/plugins/prepared-message-tool-catalog.ts
+++ b/src/plugins/prepared-message-tool-catalog.ts
@@ -19,8 +19,8 @@ export type PreparedMessageToolCatalog = Readonly<{
   getChannel: (id: string) => PreparedMessageToolCatalogEntry | undefined;
 }>;
 
-const catalogsByRegistry = new WeakMap<PluginRegistry, Map<number, PreparedMessageToolCatalog>>();
-const latestCatalogByRegistry = new WeakMap<PluginRegistry, PreparedMessageToolCatalog>();
+// Prepared runs retain their own catalog; this cache owns only the latest generation.
+const catalogsByRegistry = new WeakMap<PluginRegistry, PreparedMessageToolCatalog>();
 
 function selectedRegistry(
   snapshot: ActivePluginChannelRegistrySnapshot,
@@ -42,9 +42,8 @@ export function settlePreparedMessageToolCatalog(
     return undefined;
   }
   const version = preparedVersion ?? snapshot?.version ?? 0;
-  let catalogs = catalogsByRegistry.get(registry);
-  const existing = catalogs?.get(version);
-  if (existing) {
+  const existing = catalogsByRegistry.get(registry);
+  if (existing?.version === version) {
     return existing;
   }
   const channels = Object.freeze(
@@ -64,12 +63,7 @@ export function settlePreparedMessageToolCatalog(
     channels,
     getChannel: (id: string) => byId.get(id),
   });
-  if (!catalogs) {
-    catalogs = new Map();
-    catalogsByRegistry.set(registry, catalogs);
-  }
-  catalogs.set(version, catalog);
-  latestCatalogByRegistry.set(registry, catalog);
+  catalogsByRegistry.set(registry, catalog);
   return catalog;
 }
 
@@ -80,12 +74,13 @@ export function getPreparedMessageToolCatalog(): PreparedMessageToolCatalog | un
   if (!registry) {
     return undefined;
   }
-  return catalogsByRegistry.get(registry)?.get(snapshot.version);
+  const catalog = catalogsByRegistry.get(registry);
+  return catalog?.version === snapshot.version ? catalog : undefined;
 }
 
-/** Returns the catalog settled for one exact runtime registry generation. */
+/** Returns the latest catalog settled for this runtime registry. */
 export function getPreparedMessageToolCatalogForRegistry(
   registry: PluginRegistry,
 ): PreparedMessageToolCatalog | undefined {
-  return latestCatalogByRegistry.get(registry);
+  return catalogsByRegistry.get(registry);
 }


### PR DESCRIPTION
## What Problem This Solves

Reactivating a plugin registry retained a prepared message-tool catalog for every generation. The active lookup only needs the current generation, and prepared runs already hold their own catalog references, so the historical map accumulated unused channel projections.

## Why This Change Was Made

Keep one current catalog per registry in the existing WeakMap and check its version on active lookup. This removes the nested generation map and the duplicate latest-catalog map. Existing runs retain their frozen catalogs directly; registry replacement and rollback continue to settle a new current generation.

## User Impact

Repeated registry activation no longer retains historical catalogs for the lifetime of a reused registry. Channel ordering, first-wins registration, message capabilities and retained-run behavior are unchanged. Production LOC +9/-14 (net -5); tests are unchanged.

## Evidence

- 21 existing tests passed across the prepared message catalog, plugin runtime and prepared inbound-registry suites, including registry replacement, refresh, cleanup, ordering and retained catalogs.
- Actual catalog-owner probe with 2,000 generations and 32 synthetic channels: retained heap after forced GC fell from 6,506,896 to 35,520 bytes. The retained first-generation catalog and latest-generation lookup both remained correct. This is isolated retention evidence, not a whole-Gateway RSS claim.
- Source review followed registry install, staged rollback and restore through prepared runtime facts and message-tool discovery. Consumers keep the prepared catalog itself; no consumer reads arbitrary historical generations from this cache.
- Independent source investigation and fresh Codex autoreview found no actionable issue.
- Full `check-changed` and `pnpm build` passed. The rebuilt isolated Gateway completed two successive turns in one session using a real direct OpenAI API key; both used Code Mode and successfully fetched Node.js documentation with zero tool failures.
