### PR TITLE
test(ui): use native CRC32 for the large paste fixture

### DIFF
--- a/ui/src/e2e/chat-large-paste-99213.e2e.test.ts
+++ b/ui/src/e2e/chat-large-paste-99213.e2e.test.ts
@@ -2,6 +2,7 @@
 // real chat composer and verify chat.send receives it without overflowing base64 handling.
 import { copyFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { crc32 } from "node:zlib";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -44,17 +45,6 @@ function requireArray(value: unknown, label: string): unknown[] {
     throw new Error(`Expected ${label} to be an array`);
   }
   return value;
-}
-
-function crc32(bytes: Uint8Array): number {
-  let crc = 0xffffffff;
-  for (const byte of bytes) {
-    crc ^= byte;
-    for (let bit = 0; bit < 8; bit += 1) {
-      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
-    }
-  }
-  return (crc ^ 0xffffffff) >>> 0;
 }
 
 function uint32(value: number): Uint8Array {


### PR DESCRIPTION
The large-image browser fixture computes PNG CRC32 through a duplicated JavaScript bit loop. Use Node's native zlib CRC32 and delete that helper.

The actual applied generator produces the same complete 1,901,669-byte PNG, including its signature, chunk order and all four CRCs (SHA256 216284b9cb950e617cb0c6b5fc8bc3718072afe4610a701900459f51d66d1094). The original real Chromium paste/send test passes before and after. All chat.send/base64/attachment assertions, transcript non-overlap, final response, deadlines and cleanup remain. Before/after screenshots, video and summary artifacts are retained; the after screenshots show the pasted image and completed response.

Production +0/-0; tests +1/-11. This removes 15,213,032 JavaScript inner-loop iterations over 1,901,629 CRC input bytes; native checksum work remains. Full changed-file checks passed and scoped Codex review returned no findings.

Local browser proof used the existing checkout's Web Awesome 3.11 graph; the lock requires 3.12, so it is not frozen-lock parity or hosted startup-budget proof. No dependency reconciliation or measured elapsed gain is claimed. Hosted checks are recorded separately before landing.

Follow-up: profile the isolated UI E2E changed-file gate. Its three Knip scopes each exceeded120s here; all passed with zero entries. This records observed validation cost without assuming the scans can be removed.
