### PR TITLE
test(infra): consolidate abortable sleep timing coverage

### DIFF
--- a/src/infra/backoff.test.ts
+++ b/src/infra/backoff.test.ts
@@ -55,21 +55,6 @@ describe("backoff helpers", () => {
     expect(error.cause).toBe(controller.signal.reason);
   });
 
-  it("advances with fake timers", async () => {
-    vi.useFakeTimers();
-    try {
-      const sleeper = sleepWithAbort(50);
-      await vi.advanceTimersByTimeAsync(49);
-      await expect(
-        Promise.race([sleeper.then(() => "done"), Promise.resolve("pending")]),
-      ).resolves.toBe("pending");
-      await vi.advanceTimersByTimeAsync(1);
-      await expect(sleeper).resolves.toBeUndefined();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   it("removes the abort listener after the sleep completes", async () => {
     vi.useFakeTimers();
     const controller = new AbortController();
@@ -77,11 +62,15 @@ describe("backoff helpers", () => {
     const removeEventListenerSpy = vi.spyOn(controller.signal, "removeEventListener");
     try {
       const sleeper = sleepWithAbort(50, controller.signal);
+      const onSettled = vi.fn();
+      void sleeper.then(onSettled);
       const abortListener = addEventListenerSpy.mock.calls[0]?.[1];
 
       expect(abortListener).toBeDefined();
       expect(vi.getTimerCount()).toBe(1);
-      await vi.advanceTimersByTimeAsync(50);
+      await vi.advanceTimersByTimeAsync(49);
+      expect(onSettled).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
       await expect(sleeper).resolves.toBeUndefined();
 
       expect(removeEventListenerSpy).toHaveBeenCalledWith("abort", abortListener);


### PR DESCRIPTION
The fake-timer sleep test's `Promise.race` check could report “pending” after the sleep had already resolved. Consolidate its timing check into the existing successful-completion test: observe the real promise, assert it is still unsettled at 49 ms, then verify fulfillment at 50 ms and removal of the original abort listener and timer.

The duplicate case is removed; active/pre-abort handling, registration-race coverage, duration clamping, package retry and transport readiness coverage remain. Production is unchanged; tests are +5/−16 lines.

On `9e82b2a372d2e5cd32a8f241ac7a1c9f173f6753`, the ordinary three-file group passed 29 cases before and 28 after, preserving every surviving case's project and within-file order:

```sh
node scripts/run-vitest.mjs src/infra/backoff.test.ts packages/retry/src/index.test.ts src/infra/transport-ready.test.ts --reporter=verbose
```

A temporary early-timer fault in the real retry owner made a requested 50 ms sleep resolve at 1 ms. Both original timing cases still passed; the consolidated test failed at its 49 ms assertion. The production owner was restored before the final normal run, and both files were restored after proof. The fault is absent from this patch.

The patch is unchanged on base `318edff41a2e77a8478867705a8d85abc45c14c7`; the retry owner, timer dependencies and relevant unit-runner contracts were requalified. Managed Codex review completed with no findings. The normal changed gate passed on configured Blacksmith Testbox in 358.781 seconds, including the selected infra test typecheck, formatting, lint and all three dead-export scans. The one-shot lease stopped and its local sync registration was removed. Exact-head hosted CI follows publication.

Changed gate: `node scripts/check-changed.mjs --base origin/main --head HEAD -- src/infra/backoff.test.ts`. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/33485338614); the delegated command returned 0. Its backing Actions step can appear cancelled during normal one-shot lease cleanup.
