### PR TITLE
refactor(feishu): share API success assertion

### DIFF
--- a/extensions/feishu/src/api-response.ts
+++ b/extensions/feishu/src/api-response.ts
@@ -1,0 +1,8 @@
+export function assertFeishuApiSuccess(
+  response: { code?: number; msg?: string },
+  errorPrefix: string,
+): void {
+  if (response.code !== 0) {
+    throw new Error(`${errorPrefix}: ${response.msg || `code ${response.code}`}`);
+  }
+}

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -24,12 +24,13 @@ import {
 } from "openclaw/plugin-sdk/temp-path";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { assertFeishuApiSuccess } from "./api-response.js";
 import { createFeishuClient } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
 import { saveMediaStreamWithIdleTimeout } from "./media-chunk-idle.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
+import { toFeishuSendResult } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
 import { sendReplyOrFallbackDirect } from "./send.js";
 
@@ -596,7 +597,7 @@ async function sendImageFeishu(params: {
     "Feishu image send failed",
     { includeNestedErrorLogId: true },
   );
-  assertFeishuMessageApiSuccess(response, "Feishu image send failed");
+  assertFeishuApiSuccess(response, "Feishu image send failed");
   return toFeishuSendResult(response, receiveId, "media", "Feishu image send failed");
 }
 

--- a/extensions/feishu/src/pins.ts
+++ b/extensions/feishu/src/pins.ts
@@ -1,6 +1,7 @@
 // Feishu plugin module implements pins behavior.
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { assertFeishuApiSuccess } from "./api-response.js";
 import { createFeishuClient } from "./client.js";
 
 type FeishuPin = {
@@ -10,12 +11,6 @@ type FeishuPin = {
   operatorIdType?: string;
   createTime?: string;
 };
-
-function assertFeishuPinApiSuccess(response: { code?: number; msg?: string }, action: string) {
-  if (response.code !== 0) {
-    throw new Error(`Feishu ${action} failed: ${response.msg || `code ${response.code}`}`);
-  }
-}
 
 function normalizePin(pin: {
   message_id: string;
@@ -49,7 +44,7 @@ export async function createPinFeishu(params: {
       message_id: params.messageId,
     },
   });
-  assertFeishuPinApiSuccess(response, "pin create");
+  assertFeishuApiSuccess(response, "Feishu pin create failed");
   return response.data?.pin ? normalizePin(response.data.pin) : null;
 }
 
@@ -69,7 +64,7 @@ export async function removePinFeishu(params: {
       message_id: params.messageId,
     },
   });
-  assertFeishuPinApiSuccess(response, "pin delete");
+  assertFeishuApiSuccess(response, "Feishu pin delete failed");
 }
 
 export async function listPinsFeishu(params: {
@@ -98,7 +93,7 @@ export async function listPinsFeishu(params: {
       ...(params.pageToken ? { page_token: params.pageToken } : {}),
     },
   });
-  assertFeishuPinApiSuccess(response, "pin list");
+  assertFeishuApiSuccess(response, "Feishu pin list failed");
 
   return {
     chatId: params.chatId,

--- a/extensions/feishu/src/reactions.ts
+++ b/extensions/feishu/src/reactions.ts
@@ -1,6 +1,7 @@
 // Feishu plugin module implements reactions behavior.
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { assertFeishuApiSuccess } from "./api-response.js";
 import { createFeishuClient } from "./client.js";
 
 type FeishuReaction = {
@@ -16,12 +17,6 @@ function resolveConfiguredFeishuClient(params: { cfg: ClawdbotConfig; accountId?
     throw new Error(`Feishu account "${account.accountId}" not configured`);
   }
   return createFeishuClient(account);
-}
-
-function assertFeishuReactionApiSuccess(response: { code?: number; msg?: string }, action: string) {
-  if (response.code !== 0) {
-    throw new Error(`Feishu ${action} failed: ${response.msg || `code ${response.code}`}`);
-  }
 }
 
 /**
@@ -51,7 +46,7 @@ export async function addReactionFeishu(params: {
     data?: { reaction_id?: string };
   };
 
-  assertFeishuReactionApiSuccess(response, "add reaction");
+  assertFeishuApiSuccess(response, "Feishu add reaction failed");
 
   const reactionId = response.data?.reaction_id;
   if (!reactionId) {
@@ -80,7 +75,7 @@ export async function removeReactionFeishu(params: {
     },
   })) as { code?: number; msg?: string };
 
-  assertFeishuReactionApiSuccess(response, "remove reaction");
+  assertFeishuApiSuccess(response, "Feishu remove reaction failed");
 }
 
 /**
@@ -125,7 +120,7 @@ export async function listReactionsFeishu(params: {
       };
     };
 
-    assertFeishuReactionApiSuccess(response, "list reactions");
+    assertFeishuApiSuccess(response, "Feishu list reactions failed");
 
     for (const item of response.data?.items ?? []) {
       reactions.push({

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -57,15 +57,6 @@ export function createFeishuSendReceipt(params: {
   });
 }
 
-export function assertFeishuMessageApiSuccess(
-  response: FeishuMessageApiResponse,
-  errorPrefix: string,
-) {
-  if (response.code !== 0) {
-    throw new Error(`${errorPrefix}: ${response.msg || `code ${response.code}`}`);
-  }
-}
-
 export function toFeishuSendResult(
   response: FeishuMessageApiResponse,
   chatId: string,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -6,6 +6,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { assertFeishuApiSuccess } from "./api-response.js";
 import { createFeishuClient } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import { parseInteractiveCardContent } from "./interactive-message-content.js";
@@ -20,11 +21,7 @@ import type { MentionTarget } from "./mention-target.types.js";
 import { buildMentionedCardContent } from "./mention.js";
 import { resolveFeishuCardTemplate } from "./native-card.js";
 import { parsePostContent } from "./post.js";
-import {
-  assertFeishuMessageApiSuccess,
-  resolveFeishuReceiptKind,
-  toFeishuSendResult,
-} from "./send-result.js";
+import { resolveFeishuReceiptKind, toFeishuSendResult } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
 import type { FeishuChatType, FeishuMessageInfo, FeishuSendResult } from "./types.js";
 
@@ -130,7 +127,7 @@ async function sendFallbackDirect(
     errorPrefix,
     { includeNestedErrorLogId: true },
   );
-  assertFeishuMessageApiSuccess(response, errorPrefix);
+  assertFeishuApiSuccess(response, errorPrefix);
   return toFeishuSendResult(
     response,
     params.receiveId,
@@ -198,7 +195,7 @@ export async function sendReplyOrFallbackDirect(
     }
     return sendFallbackDirect(client, params.directParams, params.directErrorPrefix);
   }
-  assertFeishuMessageApiSuccess(response, params.replyErrorPrefix);
+  assertFeishuApiSuccess(response, params.replyErrorPrefix);
   return toFeishuSendResult(
     response,
     params.directParams.receiveId,
@@ -556,9 +553,7 @@ export async function editMessageFeishu(params: {
       data: { content },
     });
 
-    if (response.code !== 0) {
-      throw new Error(`Feishu message edit failed: ${response.msg || `code ${response.code}`}`);
-    }
+    assertFeishuApiSuccess(response, "Feishu message edit failed");
 
     return { messageId, contentType: "interactive" };
   }
@@ -577,9 +572,7 @@ export async function editMessageFeishu(params: {
     data: { msg_type: "post", content },
   });
 
-  if (response.code !== 0) {
-    throw new Error(`Feishu message edit failed: ${response.msg || `code ${response.code}`}`);
-  }
+  assertFeishuApiSuccess(response, "Feishu message edit failed");
 
   return { messageId, contentType: "post" };
 }


### PR DESCRIPTION
## What Problem This Solves

Feishu message sending, message edits, pins, and reactions independently enforced the same API success rule through copied helpers and inline checks. That duplicated vendor-response policy could drift across adjacent operations.

## Why This Change Was Made

This moves the private `code === 0` success contract into `extensions/feishu/src/api-response.ts` and reuses it only from message send/edit, image-message send, pin, and reaction paths. Existing complete error prefixes and the exact failure expression remain unchanged:

```ts
response.code !== 0
response.msg || `code ${response.code}`
```

Media upload/download, message lookup-to-null, thread listing, typing/retry behavior, public barrels, config, SDK, storage, and docs remain out of scope.

## User Impact

No user-visible behavior change. Feishu API failures keep the same operation-specific error text, including missing-code and empty-message fallbacks, while one private owner now defines the shared success invariant.

## Evidence

- Root cause: independently evolved Feishu modules copied one vendor-response assertion.
- Architectural owner: private `@openclaw/feishu` API response validation.
- Canonical fix: `assertFeishuApiSuccess(response, errorPrefix)` in `extensions/feishu/src/api-response.ts`.
- Removed duplicates: message assertion in `send-result.ts`, pin/reaction local helpers, and two inline message-edit checks.
- Production LOC: `+25/-42`, net `-17`. Tests: `0`.
- Pinned `@larksuiteoapi/node-sdk` `1.73.0` declarations confirm the covered message, pin, and reaction responses expose optional `code` and `msg`.
- `node scripts/run-vitest.mjs extensions/feishu/src/send-result.test.ts extensions/feishu/src/send.test.ts extensions/feishu/src/send.reply-fallback.test.ts extensions/feishu/src/media.test.ts extensions/feishu/src/media-upload-contract.test.ts extensions/feishu/src/reactions.test.ts` - 6 files, 141 tests passed.
- `pnpm test:extension feishu` - 99 files, 1,887 tests passed.
- `pnpm check:import-cycles` - 0 runtime value cycles.
- `pnpm build` - passed.
- `node scripts/check-changed.mjs -- extensions/feishu/src/api-response.ts extensions/feishu/src/send-result.ts extensions/feishu/src/send.ts extensions/feishu/src/media.ts extensions/feishu/src/pins.ts extensions/feishu/src/reactions.ts` - passed.
- Exact Sol/high autoreview: scoped-clean, patch correct at 0.96 confidence.
- Live overlap recheck on September 1, 2026: #104322, #122193, #97295, #121808, #93940, #102898, and #98458 remain open; none changed after independent review, and current `main` did not change the six target files.
- Bespoke Crabbox/live API proof is intentionally omitted because this is a byte-preserving private extraction. Native PR Testbox remains required before merge.
