### PR TITLE
fix(ui): keep reopened dropdowns dismissible

### DIFF
--- a/patches/@awesome.me__webawesome@3.12.0.patch
+++ b/patches/@awesome.me__webawesome@3.12.0.patch
@@ -1,5 +1,142 @@
+diff --git a/dist/chunks/chunk.JZGJWX35.js b/dist/chunks/chunk.JZGJWX35.js
+index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..5f5c117348f587881c9c442a06cdae8cf6e3e7fd 100644
+--- a/dist/chunks/chunk.JZGJWX35.js
++++ b/dist/chunks/chunk.JZGJWX35.js
+@@ -29,6 +29,7 @@ var WaDropdownItem = class extends WebAwesomeElement {
+   constructor() {
+     super(...arguments);
+     this.hasSlotController = new HasSlotController(this, "[default]", "start", "end");
++    this.submenuGeneration = 0;
+     this.active = false;
+     this.variant = "default";
+     this.size = "m";
+@@ -67,7 +68,6 @@ var WaDropdownItem = class extends WebAwesomeElement {
+     /** Handles pointer enter to open the submenu on hover */
+     this.handlePointerEnter = (event) => {
+       if (event.pointerType === "mouse" && this.hasSubmenu && !this.disabled) {
+-        this.notifyParentOfOpening();
+         this.submenuOpen = true;
+       }
+     };
+@@ -84,7 +84,15 @@ var WaDropdownItem = class extends WebAwesomeElement {
+   }
+   disconnectedCallback() {
+     super.disconnectedCallback();
+-    this.closeSubmenu();
++    this.submenuGeneration++;
++    void this.closeSubmenu();
++    const submenu = this.submenuElement;
++    if (submenu) {
++      submenu.classList.remove("show", "hide");
++      submenu.hidden = true;
++      submenu.removeAttribute("data-visible");
++      submenu.hidePopover?.();
++    }
+     this.removeEventListener?.("click", this.handleHostClick);
+     this.removeEventListener?.("pointerenter", this.handlePointerEnter);
+     this.shadowRoot?.removeEventListener?.("click", this.handleClick, { capture: true });
+@@ -127,11 +135,8 @@ var WaDropdownItem = class extends WebAwesomeElement {
+     }
+     if (changedProperties.has("submenuOpen")) {
+       this.customStates.set("submenu-open", this.submenuOpen);
+-      if (this.submenuOpen) {
+-        this.openSubmenu();
+-      } else {
+-        this.closeSubmenu();
+-      }
++      const previousAnimation = this.submenuAnimation;
++      this.submenuAnimation = this.updateSubmenuVisibility(previousAnimation);
+     }
+   }
+   /** Update the has-submenu custom state */
+@@ -140,22 +145,48 @@ var WaDropdownItem = class extends WebAwesomeElement {
+   }
+   /** Opens the submenu. */
+   async openSubmenu() {
+-    const submenu = this.submenuElement;
+-    if (!this.hasSubmenu || !submenu || !this.isConnected) return;
+-    this.notifyParentOfOpening();
+-    submenu.showPopover?.();
+-    submenu.hidden = false;
+-    submenu.setAttribute("data-visible", "");
++    if (!this.hasSubmenu || !this.submenuElement || !this.isConnected) return;
+     this.submenuOpen = true;
+-    this.setAttribute("aria-expanded", "true");
+-    await animateWithClass(submenu, "show");
+-    setTimeout(() => {
++    await this.updateComplete;
++    return this.submenuAnimation;
++  }
++  /** Reconciles property and public-method requests through one submenu lifecycle. */
++  async updateSubmenuVisibility(previousAnimation) {
++    const submenu = this.submenuElement;
++    if (!this.hasSubmenu || !submenu || !this.isConnected) {
++      await previousAnimation;
++      return;
++    }
++    const open = this.submenuOpen;
++    const generation = ++this.submenuGeneration;
++    const isCurrent = () => generation === this.submenuGeneration && this.isConnected && this.submenuOpen === open;
++    this.setAttribute("aria-expanded", String(open));
++    // Retire the previous class before joining its cleanup. A stale close must never
++    // hide a reopened native popover, and repeated public requests share this promise.
++    submenu.classList.remove("show", "hide");
++    if (open) {
++      this.notifyParentOfOpening();
++      submenu.showPopover?.();
++      submenu.hidden = false;
++      submenu.setAttribute("data-visible", "");
++    }
++    await previousAnimation;
++    await this.updateComplete;
++    if (!isCurrent()) return;
++    // Focus once when opening becomes usable, not again when the animation finishes:
++    // the operator may already have moved focus or returned to the parent by then.
++    if (open) {
+       const items = this.getSubmenuItems();
+-      if (items.length > 0) {
+-        items.forEach((item, index) => item.active = index === 0);
+-        items[0].focus({ preventScroll: true });
+-      }
+-    }, 0);
++      items.forEach((item, index) => item.active = index === 0);
++      items[0]?.focus({ preventScroll: true });
++    }
++    await animateWithClass(submenu, open ? "show" : "hide");
++    if (!isCurrent()) return;
++    if (!open) {
++      submenu.hidden = true;
++      submenu.removeAttribute("data-visible");
++      submenu.hidePopover?.();
++    }
+   }
+   /** Notifies the parent dropdown that this item is opening its submenu */
+   notifyParentOfOpening() {
+@@ -177,18 +208,11 @@ var WaDropdownItem = class extends WebAwesomeElement {
+   }
+   /** Closes the submenu. */
+   async closeSubmenu() {
+-    const submenu = this.submenuElement;
+-    if (!this.hasSubmenu || !submenu) return;
++    // A never-connected item's first update cannot settle; closing it is a public no-op.
++    if (!this.hasSubmenu || !this.submenuElement) return;
+     this.submenuOpen = false;
+-    this.setAttribute("aria-expanded", "false");
+-    if (!submenu.hidden) {
+-      await animateWithClass(submenu, "hide");
+-      if (submenu?.isConnected) {
+-        submenu.hidden = true;
+-        submenu.removeAttribute("data-visible");
+-        submenu.hidePopover?.();
+-      }
+-    }
++    await this.updateComplete;
++    return this.submenuAnimation;
+   }
+   /** Determines whether the item navigates when selected. Items with submenus never navigate. */
+   isLink() {
 diff --git a/dist/chunks/chunk.KZJTFPDQ.js b/dist/chunks/chunk.KZJTFPDQ.js
-index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..2cb2c0b0ddf9b6cc8162b14bdbb0770dd51c3be2 100644
+index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..ece47ac72d6dff3538e5325fecaa2b66aa8de557 100644
 --- a/dist/chunks/chunk.KZJTFPDQ.js
 +++ b/dist/chunks/chunk.KZJTFPDQ.js
 @@ -68,7 +68,7 @@ var WaDropdown = class extends WebAwesomeElement {
@@ -38,7 +175,7 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..2cb2c0b0ddf9b6cc8162b14bdbb0770d
        let itemToSelect;
        if (event.key === "ArrowUp") {
          event.preventDefault();
-@@ -113,23 +102,15 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -113,38 +102,24 @@ var WaDropdown = class extends WebAwesomeElement {
            itemToSelect = items[0];
          }
        }
@@ -47,7 +184,7 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..2cb2c0b0ddf9b6cc8162b14bdbb0770d
          if (activeItem.hasSubmenu) {
            event.preventDefault();
            event.stopPropagation();
--          activeItem.submenuOpen = true;
+           activeItem.submenuOpen = true;
 -          this.addToSubmenuStack(activeItem);
 -          setTimeout(() => {
 -            const submenuItems = this.getSubmenuItems(activeItem);
@@ -56,7 +193,6 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..2cb2c0b0ddf9b6cc8162b14bdbb0770d
 -              submenuItems[0].focus({ preventScroll: true });
 -            }
 -          }, 0);
-+          this.openKeyboardSubmenu(activeItem);
            return;
          }
        }
@@ -65,7 +201,26 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..2cb2c0b0ddf9b6cc8162b14bdbb0770d
          event.preventDefault();
          event.stopPropagation();
          const removedItem = this.removeFromSubmenuStack();
-@@ -154,7 +135,7 @@ var WaDropdown = class extends WebAwesomeElement {
+         if (removedItem) {
+           removedItem.submenuOpen = false;
+-          setTimeout(() => {
+-            removedItem.focus({ preventScroll: true });
+-            removedItem.active = true;
+-            const parentItems = removedItem.slot === "submenu" ? this.getSubmenuItems(removedItem.parentElement) : this.getItems();
+-            parentItems.forEach((item) => {
+-              if (item !== removedItem) {
+-                item.active = false;
+-              }
+-            });
+-          }, 0);
++          // Returning focus belongs to this keypress, not a timer that can outlive a reopen.
++          removedItem.focus({ preventScroll: true });
++          const parentItems = removedItem.slot === "submenu" ? this.getSubmenuItems(removedItem.parentElement) : this.getItems();
++          parentItems.forEach((item) => item.active = item === removedItem);
+         }
+         return;
+       }
+@@ -154,7 +129,7 @@ var WaDropdown = class extends WebAwesomeElement {
          itemToSelect = event.key === "Home" ? items[0] : items[items.length - 1];
        }
        if (event.key === "Tab") {
@@ -74,7 +229,7 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..2cb2c0b0ddf9b6cc8162b14bdbb0770d
        }
        if (event.key.length === 1 && !(event.metaKey || event.ctrlKey || event.altKey) && !(event.key === " " && this.userTypedQuery === "")) {
          clearTimeout(this.userTypedTimeout);
-@@ -180,19 +161,11 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -180,19 +155,11 @@ var WaDropdown = class extends WebAwesomeElement {
          itemToSelect.scrollIntoView({ block: "nearest" });
          return;
        }
@@ -83,7 +238,7 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..2cb2c0b0ddf9b6cc8162b14bdbb0770d
          event.preventDefault();
          event.stopPropagation();
          if (activeItem.hasSubmenu) {
--          activeItem.submenuOpen = true;
+           activeItem.submenuOpen = true;
 -          this.addToSubmenuStack(activeItem);
 -          setTimeout(() => {
 -            const submenuItems = this.getSubmenuItems(activeItem);
@@ -92,11 +247,10 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..2cb2c0b0ddf9b6cc8162b14bdbb0770d
 -              submenuItems[0].focus({ preventScroll: true });
 -            }
 -          }, 0);
-+          this.openKeyboardSubmenu(activeItem);
          } else {
            this.makeSelection(activeItem, event);
          }
-@@ -241,15 +214,22 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -241,15 +208,22 @@ var WaDropdown = class extends WebAwesomeElement {
    handleSizeChange() {
      warnDeprecatedSize(this.localName, this.size);
    }
@@ -122,7 +276,7 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..2cb2c0b0ddf9b6cc8162b14bdbb0770d
      unregisterDismissible(this);
    }
    firstUpdated(changedProperties) {
-@@ -266,12 +246,7 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -266,12 +240,7 @@ var WaDropdown = class extends WebAwesomeElement {
          return;
        }
        this.customStates.set("open", this.open);
@@ -136,22 +290,8 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..2cb2c0b0ddf9b6cc8162b14bdbb0770d
      }
      if (changedProperties.has("size")) {
        this.syncItemSizes();
-@@ -313,9 +288,21 @@ var WaDropdown = class extends WebAwesomeElement {
-   removeFromSubmenuStack() {
-     return this.openSubmenuStack.pop();
+@@ -315,7 +284,7 @@ var WaDropdown = class extends WebAwesomeElement {
    }
-+  /** Opens a submenu for keyboard navigation after its items update. */
-+  openKeyboardSubmenu(item) {
-+    item.submenuOpen = true;
-+    this.addToSubmenuStack(item);
-+    setTimeout(() => {
-+      const submenuItems = this.getSubmenuItems(item);
-+      if (submenuItems.length > 0) {
-+        submenuItems.forEach((item2, index) => item2.active = index === 0);
-+        submenuItems[0].focus({ preventScroll: true });
-+      }
-+    }, 0);
-+  }
    /** Gets the current active submenu item */
    getCurrentSubmenuItem() {
 -    return this.openSubmenuStack.length > 0 ? this.openSubmenuStack[this.openSubmenuStack.length - 1] : void 0;
@@ -159,7 +299,7 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..2cb2c0b0ddf9b6cc8162b14bdbb0770d
    }
    /** Closes all submenus in the dropdown. */
    closeAllSubmenus() {
-@@ -347,57 +334,57 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -347,57 +316,57 @@ var WaDropdown = class extends WebAwesomeElement {
    getTrigger() {
      return this.querySelector('[slot="trigger"]');
    }
@@ -230,8 +370,8 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..2cb2c0b0ddf9b6cc8162b14bdbb0770d
 -    if (hideEvent.defaultPrevented) {
 -      this.open = true;
 -      return;
-+    // Cancel first and let the old helper remove its class/listeners before starting
-+    // another animation; otherwise its cancellation event can finish the new one.
++    // Join canceled animation cleanup before reusing its class. Show and hide share
++    // one CSS animation name, so overlapping helpers cannot own separate animations.
 +    this.menu.classList.remove("show", "hide");
 +    await this.menuAnimation;
 +    if (!isCurrent()) return;
@@ -263,16 +403,66 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..2cb2c0b0ddf9b6cc8162b14bdbb0770d
    }
    /** Handles clicks on the menu. */
    handleMenuClick(event) {
+diff --git a/dist/chunks/chunk.L6CIKOFQ.js b/dist/chunks/chunk.L6CIKOFQ.js
+index 20d309f89017ef7d1857f3b1c88216a88354fefd..ea0b8ee34255009d9d9e86605dbdc05969ea3840 100644
+--- a/dist/chunks/chunk.L6CIKOFQ.js
++++ b/dist/chunks/chunk.L6CIKOFQ.js
+@@ -5,32 +5,19 @@ async function animate(el, keyframes, options) {
+   return el.animate(keyframes, options).finished.catch(() => {
+   });
+ }
+-function animateWithClass(el, className) {
+-  return new Promise((resolve) => {
+-    const controller = new AbortController();
+-    const { signal } = controller;
+-    if (el.classList.contains(className)) {
+-      return;
+-    }
+-    el.classList.add(className);
+-    let resolved = false;
+-    let onEnd = () => {
+-      if (resolved) {
+-        return;
+-      }
+-      resolved = true;
+-      el.classList.remove(className);
+-      resolve();
+-      controller.abort();
+-    };
+-    el.addEventListener("animationend", onEnd, { once: true, signal });
+-    el.addEventListener("animationcancel", onEnd, { once: true, signal });
+-    requestAnimationFrame(() => {
+-      if (!resolved && el.getAnimations().length === 0) {
+-        onEnd();
+-      }
+-    });
+-  });
++async function animateWithClass(el, className) {
++  // Observe pending class removal before reusing the same animation name;
++  // otherwise an immediate show/hide can reuse the completed CSSAnimation.
++  el.getAnimations();
++  el.classList.add(className);
++  // Popup activation is reactive: let its display styles render before sampling.
++  // Native completion also settles animations canceled before animationstart, unlike DOM events.
++  await new Promise((resolve) => requestAnimationFrame(() => resolve()));
++  const animations = el.getAnimations().filter(
++    (animation) => animation instanceof CSSAnimation && animation.effect?.getComputedTiming().endTime !== Infinity
++  );
++  await Promise.allSettled(animations.map((animation) => animation.finished));
++  el.classList.remove(className);
+ }
+ function parseDuration(duration) {
+   duration = duration.toString().toLowerCase();
 diff --git a/dist/components/dropdown/dropdown.d.ts b/dist/components/dropdown/dropdown.d.ts
-index 561ccfa258274c2c41cb728c0bfef26381c9f30c..f2cb50e06a20720603f4e8a48253384452363a19 100644
+index 561ccfa258274c2c41cb728c0bfef26381c9f30c..7a7daf1c941e51f5104ad6342f4f4f49d3fd522d 100644
 --- a/dist/components/dropdown/dropdown.d.ts
 +++ b/dist/components/dropdown/dropdown.d.ts
 @@ -34,6 +34,8 @@ export default class WaDropdown extends WebAwesomeElement {
      private userTypedQuery;
      private userTypedTimeout;
      private openSubmenuStack;
-+    private menuTransition;
-+    private menuAnimation;
++    private menuTransition?;
++    private menuAnimation?;
      defaultSlot: HTMLSlotElement;
      private menu;
      private popup;
@@ -284,16 +474,7 @@ index 561ccfa258274c2c41cb728c0bfef26381c9f30c..f2cb50e06a20720603f4e8a482533844
      disconnectedCallback(): void;
      firstUpdated(changedProperties: PropertyValues<typeof this>): void;
      updated(changedProperties: PropertyValues<typeof this>): Promise<void>;
-@@ -64,6 +67,8 @@ export default class WaDropdown extends WebAwesomeElement {
-     private addToSubmenuStack;
-     /** Removes the last item from the submenu stack */
-     private removeFromSubmenuStack;
-+    /** Opens a submenu for keyboard navigation after its items update. */
-+    private openKeyboardSubmenu;
-     /** Gets the current active submenu item */
-     private getCurrentSubmenuItem;
-     /** Closes all submenus in the dropdown. */
-@@ -72,10 +77,8 @@ export default class WaDropdown extends WebAwesomeElement {
+@@ -72,10 +75,8 @@ export default class WaDropdown extends WebAwesomeElement {
      private closeSiblingSubmenus;
      /** Get the slotted trigger button, a <wa-button> or <button> element */
      private getTrigger;
@@ -306,8 +487,45 @@ index 561ccfa258274c2c41cb728c0bfef26381c9f30c..f2cb50e06a20720603f4e8a482533844
      /** Handles key down events when the menu is open */
      private handleDocumentKeyDown;
      /** Handles pointer down events when the dropdown is open. */
+diff --git a/dist/components/dropdown-item/dropdown-item.d.ts b/dist/components/dropdown-item/dropdown-item.d.ts
+index 1e458bc4c742d94cd58d688acde8a45f9c681763..477eac752d3d2c0a81ee3a59a80c09b81d972888 100644
+--- a/dist/components/dropdown-item/dropdown-item.d.ts
++++ b/dist/components/dropdown-item/dropdown-item.d.ts
+@@ -35,6 +35,8 @@ import '../icon/icon.js';
+ export default class WaDropdownItem extends WebAwesomeElement {
+     static css: import("lit").CSSResult;
+     private readonly hasSlotController;
++    private submenuGeneration;
++    private submenuAnimation?;
+     submenuElement: HTMLDivElement;
+     private linkElement;
+     /** @internal The controller will set this property to true when the item is active. */
+@@ -91,6 +93,8 @@ export default class WaDropdownItem extends WebAwesomeElement {
+     private updateHasSubmenuState;
+     /** Opens the submenu. */
+     openSubmenu(): Promise<void>;
++    /** Reconciles property and public-method requests through one submenu lifecycle. */
++    private updateSubmenuVisibility;
+     /** Notifies the parent dropdown that this item is opening its submenu */
+     private notifyParentOfOpening;
+     /** Closes the submenu. */
+diff --git a/dist/internal/animate.d.ts b/dist/internal/animate.d.ts
+index bedb1923179f2a73be2eaf24e8c1a3c35718683d..04dc1c15097ad58de31a8670e2c870d3a475b96f 100644
+--- a/dist/internal/animate.d.ts
++++ b/dist/internal/animate.d.ts
+@@ -1,9 +1,6 @@
+ /** Same as `el.animate()`, except returns a promise that doesn't throw an error when the animation is canceled. */
+ export declare function animate(el: Element, keyframes: Keyframe[], options?: KeyframeAnimationOptions): Promise<void | Animation>;
+-/**
+- * Applies a class to the specified element to animate it. The class is removed after the animation finishes and then
+- * the promise resolves. If a timeout is provided, the class will be removed and the animation will
+- */
++/** Applies an animation class and removes it after its finite CSS animations finish or are canceled. */
+ export declare function animateWithClass(el: Element, className: string): Promise<void>;
+ /** Parses a CSS duration and returns the number of milliseconds. */
+ export declare function parseDuration(duration: number | string): number;
 diff --git a/dist-cdn/chunks/chunk.63RYV7SI.js b/dist-cdn/chunks/chunk.63RYV7SI.js
-index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..6c3b2a0679051c2e4c125cacb634ae2d40e03f4f 100644
+index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..75fb3bc5a3e2870e855a1679cd4e2474ee90b404 100644
 --- a/dist-cdn/chunks/chunk.63RYV7SI.js
 +++ b/dist-cdn/chunks/chunk.63RYV7SI.js
 @@ -78,7 +78,7 @@ var WaDropdown = class extends WebAwesomeElement {
@@ -346,7 +564,7 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..6c3b2a0679051c2e4c125cacb634ae2d
        let itemToSelect;
        if (event.key === "ArrowUp") {
          event.preventDefault();
-@@ -123,23 +112,15 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -123,38 +112,24 @@ var WaDropdown = class extends WebAwesomeElement {
            itemToSelect = items[0];
          }
        }
@@ -355,7 +573,7 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..6c3b2a0679051c2e4c125cacb634ae2d
          if (activeItem.hasSubmenu) {
            event.preventDefault();
            event.stopPropagation();
--          activeItem.submenuOpen = true;
+           activeItem.submenuOpen = true;
 -          this.addToSubmenuStack(activeItem);
 -          setTimeout(() => {
 -            const submenuItems = this.getSubmenuItems(activeItem);
@@ -364,7 +582,6 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..6c3b2a0679051c2e4c125cacb634ae2d
 -              submenuItems[0].focus({ preventScroll: true });
 -            }
 -          }, 0);
-+          this.openKeyboardSubmenu(activeItem);
            return;
          }
        }
@@ -373,7 +590,26 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..6c3b2a0679051c2e4c125cacb634ae2d
          event.preventDefault();
          event.stopPropagation();
          const removedItem = this.removeFromSubmenuStack();
-@@ -164,7 +145,7 @@ var WaDropdown = class extends WebAwesomeElement {
+         if (removedItem) {
+           removedItem.submenuOpen = false;
+-          setTimeout(() => {
+-            removedItem.focus({ preventScroll: true });
+-            removedItem.active = true;
+-            const parentItems = removedItem.slot === "submenu" ? this.getSubmenuItems(removedItem.parentElement) : this.getItems();
+-            parentItems.forEach((item) => {
+-              if (item !== removedItem) {
+-                item.active = false;
+-              }
+-            });
+-          }, 0);
++          // Returning focus belongs to this keypress, not a timer that can outlive a reopen.
++          removedItem.focus({ preventScroll: true });
++          const parentItems = removedItem.slot === "submenu" ? this.getSubmenuItems(removedItem.parentElement) : this.getItems();
++          parentItems.forEach((item) => item.active = item === removedItem);
+         }
+         return;
+       }
+@@ -164,7 +139,7 @@ var WaDropdown = class extends WebAwesomeElement {
          itemToSelect = event.key === "Home" ? items[0] : items[items.length - 1];
        }
        if (event.key === "Tab") {
@@ -382,7 +618,7 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..6c3b2a0679051c2e4c125cacb634ae2d
        }
        if (event.key.length === 1 && !(event.metaKey || event.ctrlKey || event.altKey) && !(event.key === " " && this.userTypedQuery === "")) {
          clearTimeout(this.userTypedTimeout);
-@@ -190,19 +171,11 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -190,19 +165,11 @@ var WaDropdown = class extends WebAwesomeElement {
          itemToSelect.scrollIntoView({ block: "nearest" });
          return;
        }
@@ -391,7 +627,7 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..6c3b2a0679051c2e4c125cacb634ae2d
          event.preventDefault();
          event.stopPropagation();
          if (activeItem.hasSubmenu) {
--          activeItem.submenuOpen = true;
+           activeItem.submenuOpen = true;
 -          this.addToSubmenuStack(activeItem);
 -          setTimeout(() => {
 -            const submenuItems = this.getSubmenuItems(activeItem);
@@ -400,11 +636,10 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..6c3b2a0679051c2e4c125cacb634ae2d
 -              submenuItems[0].focus({ preventScroll: true });
 -            }
 -          }, 0);
-+          this.openKeyboardSubmenu(activeItem);
          } else {
            this.makeSelection(activeItem, event);
          }
-@@ -251,15 +224,22 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -251,15 +218,22 @@ var WaDropdown = class extends WebAwesomeElement {
    handleSizeChange() {
      warnDeprecatedSize(this.localName, this.size);
    }
@@ -430,7 +665,7 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..6c3b2a0679051c2e4c125cacb634ae2d
      unregisterDismissible(this);
    }
    firstUpdated(changedProperties) {
-@@ -276,12 +256,7 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -276,12 +250,7 @@ var WaDropdown = class extends WebAwesomeElement {
          return;
        }
        this.customStates.set("open", this.open);
@@ -444,22 +679,8 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..6c3b2a0679051c2e4c125cacb634ae2d
      }
      if (changedProperties.has("size")) {
        this.syncItemSizes();
-@@ -323,9 +298,21 @@ var WaDropdown = class extends WebAwesomeElement {
-   removeFromSubmenuStack() {
-     return this.openSubmenuStack.pop();
+@@ -325,7 +294,7 @@ var WaDropdown = class extends WebAwesomeElement {
    }
-+  /** Opens a submenu for keyboard navigation after its items update. */
-+  openKeyboardSubmenu(item) {
-+    item.submenuOpen = true;
-+    this.addToSubmenuStack(item);
-+    setTimeout(() => {
-+      const submenuItems = this.getSubmenuItems(item);
-+      if (submenuItems.length > 0) {
-+        submenuItems.forEach((item2, index) => item2.active = index === 0);
-+        submenuItems[0].focus({ preventScroll: true });
-+      }
-+    }, 0);
-+  }
    /** Gets the current active submenu item */
    getCurrentSubmenuItem() {
 -    return this.openSubmenuStack.length > 0 ? this.openSubmenuStack[this.openSubmenuStack.length - 1] : void 0;
@@ -467,7 +688,7 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..6c3b2a0679051c2e4c125cacb634ae2d
    }
    /** Closes all submenus in the dropdown. */
    closeAllSubmenus() {
-@@ -357,57 +344,57 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -357,57 +326,57 @@ var WaDropdown = class extends WebAwesomeElement {
    getTrigger() {
      return this.querySelector('[slot="trigger"]');
    }
@@ -538,8 +759,8 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..6c3b2a0679051c2e4c125cacb634ae2d
 -    if (hideEvent.defaultPrevented) {
 -      this.open = true;
 -      return;
-+    // Cancel first and let the old helper remove its class/listeners before starting
-+    // another animation; otherwise its cancellation event can finish the new one.
++    // Join canceled animation cleanup before reusing its class. Show and hide share
++    // one CSS animation name, so overlapping helpers cannot own separate animations.
 +    this.menu.classList.remove("show", "hide");
 +    await this.menuAnimation;
 +    if (!isCurrent()) return;
@@ -571,16 +792,203 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..6c3b2a0679051c2e4c125cacb634ae2d
    }
    /** Handles clicks on the menu. */
    handleMenuClick(event) {
+diff --git a/dist-cdn/chunks/chunk.L6CIKOFQ.js b/dist-cdn/chunks/chunk.L6CIKOFQ.js
+index 20d309f89017ef7d1857f3b1c88216a88354fefd..ea0b8ee34255009d9d9e86605dbdc05969ea3840 100644
+--- a/dist-cdn/chunks/chunk.L6CIKOFQ.js
++++ b/dist-cdn/chunks/chunk.L6CIKOFQ.js
+@@ -5,32 +5,19 @@ async function animate(el, keyframes, options) {
+   return el.animate(keyframes, options).finished.catch(() => {
+   });
+ }
+-function animateWithClass(el, className) {
+-  return new Promise((resolve) => {
+-    const controller = new AbortController();
+-    const { signal } = controller;
+-    if (el.classList.contains(className)) {
+-      return;
+-    }
+-    el.classList.add(className);
+-    let resolved = false;
+-    let onEnd = () => {
+-      if (resolved) {
+-        return;
+-      }
+-      resolved = true;
+-      el.classList.remove(className);
+-      resolve();
+-      controller.abort();
+-    };
+-    el.addEventListener("animationend", onEnd, { once: true, signal });
+-    el.addEventListener("animationcancel", onEnd, { once: true, signal });
+-    requestAnimationFrame(() => {
+-      if (!resolved && el.getAnimations().length === 0) {
+-        onEnd();
+-      }
+-    });
+-  });
++async function animateWithClass(el, className) {
++  // Observe pending class removal before reusing the same animation name;
++  // otherwise an immediate show/hide can reuse the completed CSSAnimation.
++  el.getAnimations();
++  el.classList.add(className);
++  // Popup activation is reactive: let its display styles render before sampling.
++  // Native completion also settles animations canceled before animationstart, unlike DOM events.
++  await new Promise((resolve) => requestAnimationFrame(() => resolve()));
++  const animations = el.getAnimations().filter(
++    (animation) => animation instanceof CSSAnimation && animation.effect?.getComputedTiming().endTime !== Infinity
++  );
++  await Promise.allSettled(animations.map((animation) => animation.finished));
++  el.classList.remove(className);
+ }
+ function parseDuration(duration) {
+   duration = duration.toString().toLowerCase();
+diff --git a/dist-cdn/chunks/chunk.W2C46OQX.js b/dist-cdn/chunks/chunk.W2C46OQX.js
+index da164574ce537b386894e751d6e9727cc9249d08..a7e2836f90d6aa15931bbdc30db79b8a141e752d 100644
+--- a/dist-cdn/chunks/chunk.W2C46OQX.js
++++ b/dist-cdn/chunks/chunk.W2C46OQX.js
+@@ -36,6 +36,7 @@ var WaDropdownItem = class extends WebAwesomeElement {
+   constructor() {
+     super(...arguments);
+     this.hasSlotController = new HasSlotController(this, "[default]", "start", "end");
++    this.submenuGeneration = 0;
+     this.active = false;
+     this.variant = "default";
+     this.size = "m";
+@@ -74,7 +75,6 @@ var WaDropdownItem = class extends WebAwesomeElement {
+     /** Handles pointer enter to open the submenu on hover */
+     this.handlePointerEnter = (event) => {
+       if (event.pointerType === "mouse" && this.hasSubmenu && !this.disabled) {
+-        this.notifyParentOfOpening();
+         this.submenuOpen = true;
+       }
+     };
+@@ -91,7 +91,15 @@ var WaDropdownItem = class extends WebAwesomeElement {
+   }
+   disconnectedCallback() {
+     super.disconnectedCallback();
+-    this.closeSubmenu();
++    this.submenuGeneration++;
++    void this.closeSubmenu();
++    const submenu = this.submenuElement;
++    if (submenu) {
++      submenu.classList.remove("show", "hide");
++      submenu.hidden = true;
++      submenu.removeAttribute("data-visible");
++      submenu.hidePopover?.();
++    }
+     this.removeEventListener?.("click", this.handleHostClick);
+     this.removeEventListener?.("pointerenter", this.handlePointerEnter);
+     this.shadowRoot?.removeEventListener?.("click", this.handleClick, { capture: true });
+@@ -134,11 +142,8 @@ var WaDropdownItem = class extends WebAwesomeElement {
+     }
+     if (changedProperties.has("submenuOpen")) {
+       this.customStates.set("submenu-open", this.submenuOpen);
+-      if (this.submenuOpen) {
+-        this.openSubmenu();
+-      } else {
+-        this.closeSubmenu();
+-      }
++      const previousAnimation = this.submenuAnimation;
++      this.submenuAnimation = this.updateSubmenuVisibility(previousAnimation);
+     }
+   }
+   /** Update the has-submenu custom state */
+@@ -147,22 +152,48 @@ var WaDropdownItem = class extends WebAwesomeElement {
+   }
+   /** Opens the submenu. */
+   async openSubmenu() {
+-    const submenu = this.submenuElement;
+-    if (!this.hasSubmenu || !submenu || !this.isConnected) return;
+-    this.notifyParentOfOpening();
+-    submenu.showPopover?.();
+-    submenu.hidden = false;
+-    submenu.setAttribute("data-visible", "");
++    if (!this.hasSubmenu || !this.submenuElement || !this.isConnected) return;
+     this.submenuOpen = true;
+-    this.setAttribute("aria-expanded", "true");
+-    await animateWithClass(submenu, "show");
+-    setTimeout(() => {
++    await this.updateComplete;
++    return this.submenuAnimation;
++  }
++  /** Reconciles property and public-method requests through one submenu lifecycle. */
++  async updateSubmenuVisibility(previousAnimation) {
++    const submenu = this.submenuElement;
++    if (!this.hasSubmenu || !submenu || !this.isConnected) {
++      await previousAnimation;
++      return;
++    }
++    const open = this.submenuOpen;
++    const generation = ++this.submenuGeneration;
++    const isCurrent = () => generation === this.submenuGeneration && this.isConnected && this.submenuOpen === open;
++    this.setAttribute("aria-expanded", String(open));
++    // Retire the previous class before joining its cleanup. A stale close must never
++    // hide a reopened native popover, and repeated public requests share this promise.
++    submenu.classList.remove("show", "hide");
++    if (open) {
++      this.notifyParentOfOpening();
++      submenu.showPopover?.();
++      submenu.hidden = false;
++      submenu.setAttribute("data-visible", "");
++    }
++    await previousAnimation;
++    await this.updateComplete;
++    if (!isCurrent()) return;
++    // Focus once when opening becomes usable, not again when the animation finishes:
++    // the operator may already have moved focus or returned to the parent by then.
++    if (open) {
+       const items = this.getSubmenuItems();
+-      if (items.length > 0) {
+-        items.forEach((item, index) => item.active = index === 0);
+-        items[0].focus({ preventScroll: true });
+-      }
+-    }, 0);
++      items.forEach((item, index) => item.active = index === 0);
++      items[0]?.focus({ preventScroll: true });
++    }
++    await animateWithClass(submenu, open ? "show" : "hide");
++    if (!isCurrent()) return;
++    if (!open) {
++      submenu.hidden = true;
++      submenu.removeAttribute("data-visible");
++      submenu.hidePopover?.();
++    }
+   }
+   /** Notifies the parent dropdown that this item is opening its submenu */
+   notifyParentOfOpening() {
+@@ -184,18 +215,11 @@ var WaDropdownItem = class extends WebAwesomeElement {
+   }
+   /** Closes the submenu. */
+   async closeSubmenu() {
+-    const submenu = this.submenuElement;
+-    if (!this.hasSubmenu || !submenu) return;
++    // A never-connected item's first update cannot settle; closing it is a public no-op.
++    if (!this.hasSubmenu || !this.submenuElement) return;
+     this.submenuOpen = false;
+-    this.setAttribute("aria-expanded", "false");
+-    if (!submenu.hidden) {
+-      await animateWithClass(submenu, "hide");
+-      if (submenu?.isConnected) {
+-        submenu.hidden = true;
+-        submenu.removeAttribute("data-visible");
+-        submenu.hidePopover?.();
+-      }
+-    }
++    await this.updateComplete;
++    return this.submenuAnimation;
+   }
+   /** Determines whether the item navigates when selected. Items with submenus never navigate. */
+   isLink() {
 diff --git a/dist-cdn/components/dropdown/dropdown.d.ts b/dist-cdn/components/dropdown/dropdown.d.ts
-index 561ccfa258274c2c41cb728c0bfef26381c9f30c..f2cb50e06a20720603f4e8a48253384452363a19 100644
+index 561ccfa258274c2c41cb728c0bfef26381c9f30c..7a7daf1c941e51f5104ad6342f4f4f49d3fd522d 100644
 --- a/dist-cdn/components/dropdown/dropdown.d.ts
 +++ b/dist-cdn/components/dropdown/dropdown.d.ts
 @@ -34,6 +34,8 @@ export default class WaDropdown extends WebAwesomeElement {
      private userTypedQuery;
      private userTypedTimeout;
      private openSubmenuStack;
-+    private menuTransition;
-+    private menuAnimation;
++    private menuTransition?;
++    private menuAnimation?;
      defaultSlot: HTMLSlotElement;
      private menu;
      private popup;
@@ -592,16 +1000,7 @@ index 561ccfa258274c2c41cb728c0bfef26381c9f30c..f2cb50e06a20720603f4e8a482533844
      disconnectedCallback(): void;
      firstUpdated(changedProperties: PropertyValues<typeof this>): void;
      updated(changedProperties: PropertyValues<typeof this>): Promise<void>;
-@@ -64,6 +67,8 @@ export default class WaDropdown extends WebAwesomeElement {
-     private addToSubmenuStack;
-     /** Removes the last item from the submenu stack */
-     private removeFromSubmenuStack;
-+    /** Opens a submenu for keyboard navigation after its items update. */
-+    private openKeyboardSubmenu;
-     /** Gets the current active submenu item */
-     private getCurrentSubmenuItem;
-     /** Closes all submenus in the dropdown. */
-@@ -72,10 +77,8 @@ export default class WaDropdown extends WebAwesomeElement {
+@@ -72,10 +75,8 @@ export default class WaDropdown extends WebAwesomeElement {
      private closeSiblingSubmenus;
      /** Get the slotted trigger button, a <wa-button> or <button> element */
      private getTrigger;
@@ -614,3 +1013,40 @@ index 561ccfa258274c2c41cb728c0bfef26381c9f30c..f2cb50e06a20720603f4e8a482533844
      /** Handles key down events when the menu is open */
      private handleDocumentKeyDown;
      /** Handles pointer down events when the dropdown is open. */
+diff --git a/dist-cdn/components/dropdown-item/dropdown-item.d.ts b/dist-cdn/components/dropdown-item/dropdown-item.d.ts
+index 1e458bc4c742d94cd58d688acde8a45f9c681763..477eac752d3d2c0a81ee3a59a80c09b81d972888 100644
+--- a/dist-cdn/components/dropdown-item/dropdown-item.d.ts
++++ b/dist-cdn/components/dropdown-item/dropdown-item.d.ts
+@@ -35,6 +35,8 @@ import '../icon/icon.js';
+ export default class WaDropdownItem extends WebAwesomeElement {
+     static css: import("lit").CSSResult;
+     private readonly hasSlotController;
++    private submenuGeneration;
++    private submenuAnimation?;
+     submenuElement: HTMLDivElement;
+     private linkElement;
+     /** @internal The controller will set this property to true when the item is active. */
+@@ -91,6 +93,8 @@ export default class WaDropdownItem extends WebAwesomeElement {
+     private updateHasSubmenuState;
+     /** Opens the submenu. */
+     openSubmenu(): Promise<void>;
++    /** Reconciles property and public-method requests through one submenu lifecycle. */
++    private updateSubmenuVisibility;
+     /** Notifies the parent dropdown that this item is opening its submenu */
+     private notifyParentOfOpening;
+     /** Closes the submenu. */
+diff --git a/dist-cdn/internal/animate.d.ts b/dist-cdn/internal/animate.d.ts
+index bedb1923179f2a73be2eaf24e8c1a3c35718683d..04dc1c15097ad58de31a8670e2c870d3a475b96f 100644
+--- a/dist-cdn/internal/animate.d.ts
++++ b/dist-cdn/internal/animate.d.ts
+@@ -1,9 +1,6 @@
+ /** Same as `el.animate()`, except returns a promise that doesn't throw an error when the animation is canceled. */
+ export declare function animate(el: Element, keyframes: Keyframe[], options?: KeyframeAnimationOptions): Promise<void | Animation>;
+-/**
+- * Applies a class to the specified element to animate it. The class is removed after the animation finishes and then
+- * the promise resolves. If a timeout is provided, the class will be removed and the animation will
+- */
++/** Applies an animation class and removes it after its finite CSS animations finish or are canceled. */
+ export declare function animateWithClass(el: Element, className: string): Promise<void>;
+ /** Parses a CSS duration and returns the number of milliseconds. */
+ export declare function parseDuration(duration: number | string): number;

--- a/patches/@awesome.me__webawesome@3.12.0.patch
+++ b/patches/@awesome.me__webawesome@3.12.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/chunks/chunk.JZGJWX35.js b/dist/chunks/chunk.JZGJWX35.js
-index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..5f5c117348f587881c9c442a06cdae8cf6e3e7fd 100644
+index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..88a02b047b464273e155d7f4c831efc18384bb39 100644
 --- a/dist/chunks/chunk.JZGJWX35.js
 +++ b/dist/chunks/chunk.JZGJWX35.js
 @@ -29,6 +29,7 @@ var WaDropdownItem = class extends WebAwesomeElement {
@@ -49,7 +49,7 @@ index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..5f5c117348f587881c9c442a06cdae8c
      }
    }
    /** Update the has-submenu custom state */
-@@ -140,22 +145,48 @@ var WaDropdownItem = class extends WebAwesomeElement {
+@@ -140,22 +145,49 @@ var WaDropdownItem = class extends WebAwesomeElement {
    }
    /** Opens the submenu. */
    async openSubmenu() {
@@ -77,7 +77,6 @@ index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..5f5c117348f587881c9c442a06cdae8c
 +    const open = this.submenuOpen;
 +    const generation = ++this.submenuGeneration;
 +    const isCurrent = () => generation === this.submenuGeneration && this.isConnected && this.submenuOpen === open;
-+    this.setAttribute("aria-expanded", String(open));
 +    // Retire the previous class before joining its cleanup. A stale close must never
 +    // hide a reopened native popover, and repeated public requests share this promise.
 +    submenu.classList.remove("show", "hide");
@@ -87,6 +86,8 @@ index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..5f5c117348f587881c9c442a06cdae8c
 +      submenu.hidden = false;
 +      submenu.setAttribute("data-visible", "");
 +    }
++    // Opening observers initialize embedded controls before the expanded state changes.
++    this.setAttribute("aria-expanded", String(open));
 +    await previousAnimation;
 +    await this.updateComplete;
 +    if (!isCurrent()) return;
@@ -112,7 +113,7 @@ index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..5f5c117348f587881c9c442a06cdae8c
    }
    /** Notifies the parent dropdown that this item is opening its submenu */
    notifyParentOfOpening() {
-@@ -177,18 +208,11 @@ var WaDropdownItem = class extends WebAwesomeElement {
+@@ -177,18 +209,11 @@ var WaDropdownItem = class extends WebAwesomeElement {
    }
    /** Closes the submenu. */
    async closeSubmenu() {
@@ -843,7 +844,7 @@ index 20d309f89017ef7d1857f3b1c88216a88354fefd..ea0b8ee34255009d9d9e86605dbdc059
  function parseDuration(duration) {
    duration = duration.toString().toLowerCase();
 diff --git a/dist-cdn/chunks/chunk.W2C46OQX.js b/dist-cdn/chunks/chunk.W2C46OQX.js
-index da164574ce537b386894e751d6e9727cc9249d08..a7e2836f90d6aa15931bbdc30db79b8a141e752d 100644
+index da164574ce537b386894e751d6e9727cc9249d08..fb180692bc81c4b0efb8c8fd86f6fc121a7e3acd 100644
 --- a/dist-cdn/chunks/chunk.W2C46OQX.js
 +++ b/dist-cdn/chunks/chunk.W2C46OQX.js
 @@ -36,6 +36,7 @@ var WaDropdownItem = class extends WebAwesomeElement {
@@ -893,7 +894,7 @@ index da164574ce537b386894e751d6e9727cc9249d08..a7e2836f90d6aa15931bbdc30db79b8a
      }
    }
    /** Update the has-submenu custom state */
-@@ -147,22 +152,48 @@ var WaDropdownItem = class extends WebAwesomeElement {
+@@ -147,22 +152,49 @@ var WaDropdownItem = class extends WebAwesomeElement {
    }
    /** Opens the submenu. */
    async openSubmenu() {
@@ -921,7 +922,6 @@ index da164574ce537b386894e751d6e9727cc9249d08..a7e2836f90d6aa15931bbdc30db79b8a
 +    const open = this.submenuOpen;
 +    const generation = ++this.submenuGeneration;
 +    const isCurrent = () => generation === this.submenuGeneration && this.isConnected && this.submenuOpen === open;
-+    this.setAttribute("aria-expanded", String(open));
 +    // Retire the previous class before joining its cleanup. A stale close must never
 +    // hide a reopened native popover, and repeated public requests share this promise.
 +    submenu.classList.remove("show", "hide");
@@ -931,6 +931,8 @@ index da164574ce537b386894e751d6e9727cc9249d08..a7e2836f90d6aa15931bbdc30db79b8a
 +      submenu.hidden = false;
 +      submenu.setAttribute("data-visible", "");
 +    }
++    // Opening observers initialize embedded controls before the expanded state changes.
++    this.setAttribute("aria-expanded", String(open));
 +    await previousAnimation;
 +    await this.updateComplete;
 +    if (!isCurrent()) return;
@@ -956,7 +958,7 @@ index da164574ce537b386894e751d6e9727cc9249d08..a7e2836f90d6aa15931bbdc30db79b8a
    }
    /** Notifies the parent dropdown that this item is opening its submenu */
    notifyParentOfOpening() {
-@@ -184,18 +215,11 @@ var WaDropdownItem = class extends WebAwesomeElement {
+@@ -184,18 +216,11 @@ var WaDropdownItem = class extends WebAwesomeElement {
    }
    /** Closes the submenu. */
    async closeSubmenu() {

--- a/patches/@awesome.me__webawesome@3.12.0.patch
+++ b/patches/@awesome.me__webawesome@3.12.0.patch
@@ -1,0 +1,616 @@
+diff --git a/dist/chunks/chunk.KZJTFPDQ.js b/dist/chunks/chunk.KZJTFPDQ.js
+index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..2cb2c0b0ddf9b6cc8162b14bdbb0770dd51c3be2 100644
+--- a/dist/chunks/chunk.KZJTFPDQ.js
++++ b/dist/chunks/chunk.KZJTFPDQ.js
+@@ -68,7 +68,7 @@ var WaDropdown = class extends WebAwesomeElement {
+     this.distance = 0;
+     this.skidding = 0;
+     /** Handles key down events when the menu is open */
+-    this.handleDocumentKeyDown = async (event) => {
++    this.handleDocumentKeyDown = (event) => {
+       const isRtl = this.localize.dir() === "rtl";
+       if (event.key === "Escape" && this.open && isTopDismissible(this)) {
+         const trigger = this.getTrigger();
+@@ -78,22 +78,11 @@ var WaDropdown = class extends WebAwesomeElement {
+         trigger?.focus({ preventScroll: true });
+         return;
+       }
+-      const activeElement = [...activeElements()].find((el) => el.localName === "wa-dropdown-item");
+-      const isFocusedOnItem = activeElement?.localName === "wa-dropdown-item";
++      const focusedItem = [...activeElements()].find((el) => el.localName === "wa-dropdown-item");
+       const currentSubmenuItem = this.getCurrentSubmenuItem();
+-      const isInSubmenu = !!currentSubmenuItem;
+-      let items;
+-      let activeItem;
+-      let activeItemIndex;
+-      if (isInSubmenu) {
+-        items = this.getSubmenuItems(currentSubmenuItem);
+-        activeItem = items.find((item) => item.active || item === activeElement);
+-        activeItemIndex = activeItem ? items.indexOf(activeItem) : -1;
+-      } else {
+-        items = this.getItems();
+-        activeItem = items.find((item) => item.active || item === activeElement);
+-        activeItemIndex = activeItem ? items.indexOf(activeItem) : -1;
+-      }
++      const items = currentSubmenuItem ? this.getSubmenuItems(currentSubmenuItem) : this.getItems();
++      const activeItem = items.find((item) => item.active || item === focusedItem);
++      const activeItemIndex = activeItem ? items.indexOf(activeItem) : -1;
+       let itemToSelect;
+       if (event.key === "ArrowUp") {
+         event.preventDefault();
+@@ -113,23 +102,15 @@ var WaDropdown = class extends WebAwesomeElement {
+           itemToSelect = items[0];
+         }
+       }
+-      if (event.key === (isRtl ? "ArrowLeft" : "ArrowRight") && isFocusedOnItem && activeItem) {
++      if (event.key === (isRtl ? "ArrowLeft" : "ArrowRight") && focusedItem && activeItem) {
+         if (activeItem.hasSubmenu) {
+           event.preventDefault();
+           event.stopPropagation();
+-          activeItem.submenuOpen = true;
+-          this.addToSubmenuStack(activeItem);
+-          setTimeout(() => {
+-            const submenuItems = this.getSubmenuItems(activeItem);
+-            if (submenuItems.length > 0) {
+-              submenuItems.forEach((item, index) => item.active = index === 0);
+-              submenuItems[0].focus({ preventScroll: true });
+-            }
+-          }, 0);
++          this.openKeyboardSubmenu(activeItem);
+           return;
+         }
+       }
+-      if (event.key === (isRtl ? "ArrowRight" : "ArrowLeft") && isInSubmenu) {
++      if (event.key === (isRtl ? "ArrowRight" : "ArrowLeft") && currentSubmenuItem) {
+         event.preventDefault();
+         event.stopPropagation();
+         const removedItem = this.removeFromSubmenuStack();
+@@ -154,7 +135,7 @@ var WaDropdown = class extends WebAwesomeElement {
+         itemToSelect = event.key === "Home" ? items[0] : items[items.length - 1];
+       }
+       if (event.key === "Tab") {
+-        await this.hideMenu();
++        this.open = false;
+       }
+       if (event.key.length === 1 && !(event.metaKey || event.ctrlKey || event.altKey) && !(event.key === " " && this.userTypedQuery === "")) {
+         clearTimeout(this.userTypedTimeout);
+@@ -180,19 +161,11 @@ var WaDropdown = class extends WebAwesomeElement {
+         itemToSelect.scrollIntoView({ block: "nearest" });
+         return;
+       }
+-      if ((event.key === "Enter" || event.key === " " && this.userTypedQuery === "") && isFocusedOnItem && activeItem) {
++      if ((event.key === "Enter" || event.key === " " && this.userTypedQuery === "") && focusedItem && activeItem) {
+         event.preventDefault();
+         event.stopPropagation();
+         if (activeItem.hasSubmenu) {
+-          activeItem.submenuOpen = true;
+-          this.addToSubmenuStack(activeItem);
+-          setTimeout(() => {
+-            const submenuItems = this.getSubmenuItems(activeItem);
+-            if (submenuItems.length > 0) {
+-              submenuItems.forEach((item, index) => item.active = index === 0);
+-              submenuItems[0].focus({ preventScroll: true });
+-            }
+-          }, 0);
++          this.openKeyboardSubmenu(activeItem);
+         } else {
+           this.makeSelection(activeItem, event);
+         }
+@@ -241,15 +214,22 @@ var WaDropdown = class extends WebAwesomeElement {
+   handleSizeChange() {
+     warnDeprecatedSize(this.localName, this.size);
+   }
++  connectedCallback() {
++    super.connectedCallback();
++    if (this.hasUpdated && this.open) {
++      void this.updateMenuVisibility(true);
++    }
++  }
+   disconnectedCallback() {
+     super.disconnectedCallback();
++    this.menuTransition?.abort();
++    this.menu?.classList.remove("show", "hide");
++    if (this.popup) this.popup.active = false;
++    openDropdowns.delete(this);
+     clearInterval(this.userTypedTimeout);
+     this.closeAllSubmenus();
+     this.submenuCleanups.forEach((cleanup) => cleanup());
+     this.submenuCleanups.clear();
+-    document.removeEventListener("mousemove", this.handleGlobalMouseMove);
+-    document.removeEventListener("keydown", this.handleDocumentKeyDown);
+-    document.removeEventListener("pointerdown", this.handleDocumentPointerDown);
+     unregisterDismissible(this);
+   }
+   firstUpdated(changedProperties) {
+@@ -266,12 +246,7 @@ var WaDropdown = class extends WebAwesomeElement {
+         return;
+       }
+       this.customStates.set("open", this.open);
+-      if (this.open) {
+-        await this.showMenu();
+-      } else {
+-        this.closeAllSubmenus();
+-        await this.hideMenu();
+-      }
++      await this.updateMenuVisibility(this.open);
+     }
+     if (changedProperties.has("size")) {
+       this.syncItemSizes();
+@@ -313,9 +288,21 @@ var WaDropdown = class extends WebAwesomeElement {
+   removeFromSubmenuStack() {
+     return this.openSubmenuStack.pop();
+   }
++  /** Opens a submenu for keyboard navigation after its items update. */
++  openKeyboardSubmenu(item) {
++    item.submenuOpen = true;
++    this.addToSubmenuStack(item);
++    setTimeout(() => {
++      const submenuItems = this.getSubmenuItems(item);
++      if (submenuItems.length > 0) {
++        submenuItems.forEach((item2, index) => item2.active = index === 0);
++        submenuItems[0].focus({ preventScroll: true });
++      }
++    }, 0);
++  }
+   /** Gets the current active submenu item */
+   getCurrentSubmenuItem() {
+-    return this.openSubmenuStack.length > 0 ? this.openSubmenuStack[this.openSubmenuStack.length - 1] : void 0;
++    return this.openSubmenuStack[this.openSubmenuStack.length - 1];
+   }
+   /** Closes all submenus in the dropdown. */
+   closeAllSubmenus() {
+@@ -347,57 +334,57 @@ var WaDropdown = class extends WebAwesomeElement {
+   getTrigger() {
+     return this.querySelector('[slot="trigger"]');
+   }
+-  /** Shows the dropdown menu. This should only be called from within updated(). */
+-  async showMenu() {
+-    const anchor = this.getTrigger();
+-    if (!anchor || !this.popup || !this.menu) return;
+-    const showEvent = new WaShowEvent();
+-    this.dispatchEvent(showEvent);
+-    if (showEvent.defaultPrevented) {
+-      this.open = false;
++  /** Reconciles accepted visibility and its animation from updates or reconnection. */
++  async updateMenuVisibility(open) {
++    if (!this.isConnected || !this.popup || !this.menu || open && !this.getTrigger()) return;
++    const event = open ? new WaShowEvent() : new WaHideEvent({ source: this });
++    this.dispatchEvent(event);
++    if (event.defaultPrevented) {
++      this.open = !open;
+       return;
+     }
+-    if (this.popup.active) {
+-      return;
++    // Membership records accepted open ownership. The popup stays active while hiding,
++    // so its active flag cannot distinguish a canceled hide from a reopen.
++    if (!this.isConnected || this.open !== open || open && openDropdowns.has(this)) return;
++    // One cancellation owner releases document listeners and fences completion on
++    // replacement or disconnection; a veto above leaves that ownership untouched.
++    this.menuTransition?.abort();
++    this.menuTransition = new AbortController();
++    const { signal } = this.menuTransition;
++    const isCurrent = () => !signal.aborted && this.isConnected && this.open === open;
++    if (open) {
++      openDropdowns.forEach((dropdown) => dropdown.open = false);
++      this.popup.active = true;
++      openDropdowns.add(this);
++      registerDismissible(this);
++      document.addEventListener("keydown", this.handleDocumentKeyDown, { signal });
++      document.addEventListener("pointerdown", this.handleDocumentPointerDown, { signal });
++      document.addEventListener("mousemove", this.handleGlobalMouseMove, { signal });
++    } else {
++      this.closeAllSubmenus();
++      openDropdowns.delete(this);
++      unregisterDismissible(this);
+     }
+-    openDropdowns.forEach((dropdown) => dropdown.open = false);
+-    this.popup.active = true;
+-    this.open = true;
+-    openDropdowns.add(this);
+-    registerDismissible(this);
+     this.syncAriaAttributes();
+-    document.addEventListener("keydown", this.handleDocumentKeyDown);
+-    document.addEventListener("pointerdown", this.handleDocumentPointerDown);
+-    document.addEventListener("mousemove", this.handleGlobalMouseMove);
+-    this.menu.classList.remove("hide");
+-    await animateWithClass(this.menu, "show");
+-    const items = this.getItems();
+-    if (items.length > 0) {
+-      items.forEach((item, index) => item.active = index === 0);
+-      items[0].focus({ preventScroll: true });
+-    }
+-    this.dispatchEvent(new WaAfterShowEvent());
+-  }
+-  /** Hides the dropdown menu. This should only be called from within updated(). */
+-  async hideMenu() {
+-    if (!this.popup || !this.menu) return;
+-    const hideEvent = new WaHideEvent({ source: this });
+-    this.dispatchEvent(hideEvent);
+-    if (hideEvent.defaultPrevented) {
+-      this.open = true;
+-      return;
++    // Cancel first and let the old helper remove its class/listeners before starting
++    // another animation; otherwise its cancellation event can finish the new one.
++    this.menu.classList.remove("show", "hide");
++    await this.menuAnimation;
++    if (!isCurrent()) return;
++    this.menuAnimation = animateWithClass(this.menu, open ? "show" : "hide");
++    await this.menuAnimation;
++    if (!isCurrent()) return;
++    if (open) {
++      const items = this.getItems();
++      if (items.length > 0) {
++        items.forEach((item, index) => item.active = index === 0);
++        items[0].focus({ preventScroll: true });
++      }
++      if (isCurrent()) this.dispatchEvent(new WaAfterShowEvent());
++    } else {
++      this.popup.active = false;
++      this.dispatchEvent(new WaAfterHideEvent());
+     }
+-    this.open = false;
+-    openDropdowns.delete(this);
+-    unregisterDismissible(this);
+-    this.syncAriaAttributes();
+-    document.removeEventListener("keydown", this.handleDocumentKeyDown);
+-    document.removeEventListener("pointerdown", this.handleDocumentPointerDown);
+-    document.removeEventListener("mousemove", this.handleGlobalMouseMove);
+-    this.menu.classList.remove("show");
+-    await animateWithClass(this.menu, "hide");
+-    this.popup.active = this.open;
+-    this.dispatchEvent(new WaAfterHideEvent());
+   }
+   /** Handles clicks on the menu. */
+   handleMenuClick(event) {
+diff --git a/dist/components/dropdown/dropdown.d.ts b/dist/components/dropdown/dropdown.d.ts
+index 561ccfa258274c2c41cb728c0bfef26381c9f30c..f2cb50e06a20720603f4e8a48253384452363a19 100644
+--- a/dist/components/dropdown/dropdown.d.ts
++++ b/dist/components/dropdown/dropdown.d.ts
+@@ -34,6 +34,8 @@ export default class WaDropdown extends WebAwesomeElement {
+     private userTypedQuery;
+     private userTypedTimeout;
+     private openSubmenuStack;
++    private menuTransition;
++    private menuAnimation;
+     defaultSlot: HTMLSlotElement;
+     private menu;
+     private popup;
+@@ -51,6 +53,7 @@ export default class WaDropdown extends WebAwesomeElement {
+     distance: number;
+     /** The offset of the dropdown menu along its trigger. */
+     skidding: number;
++    connectedCallback(): void;
+     disconnectedCallback(): void;
+     firstUpdated(changedProperties: PropertyValues<typeof this>): void;
+     updated(changedProperties: PropertyValues<typeof this>): Promise<void>;
+@@ -64,6 +67,8 @@ export default class WaDropdown extends WebAwesomeElement {
+     private addToSubmenuStack;
+     /** Removes the last item from the submenu stack */
+     private removeFromSubmenuStack;
++    /** Opens a submenu for keyboard navigation after its items update. */
++    private openKeyboardSubmenu;
+     /** Gets the current active submenu item */
+     private getCurrentSubmenuItem;
+     /** Closes all submenus in the dropdown. */
+@@ -72,10 +77,8 @@ export default class WaDropdown extends WebAwesomeElement {
+     private closeSiblingSubmenus;
+     /** Get the slotted trigger button, a <wa-button> or <button> element */
+     private getTrigger;
+-    /** Shows the dropdown menu. This should only be called from within updated(). */
+-    private showMenu;
+-    /** Hides the dropdown menu. This should only be called from within updated(). */
+-    private hideMenu;
++    /** Reconciles accepted visibility and its animation from updates or reconnection. */
++    private updateMenuVisibility;
+     /** Handles key down events when the menu is open */
+     private handleDocumentKeyDown;
+     /** Handles pointer down events when the dropdown is open. */
+diff --git a/dist-cdn/chunks/chunk.63RYV7SI.js b/dist-cdn/chunks/chunk.63RYV7SI.js
+index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..6c3b2a0679051c2e4c125cacb634ae2d40e03f4f 100644
+--- a/dist-cdn/chunks/chunk.63RYV7SI.js
++++ b/dist-cdn/chunks/chunk.63RYV7SI.js
+@@ -78,7 +78,7 @@ var WaDropdown = class extends WebAwesomeElement {
+     this.distance = 0;
+     this.skidding = 0;
+     /** Handles key down events when the menu is open */
+-    this.handleDocumentKeyDown = async (event) => {
++    this.handleDocumentKeyDown = (event) => {
+       const isRtl = this.localize.dir() === "rtl";
+       if (event.key === "Escape" && this.open && isTopDismissible(this)) {
+         const trigger = this.getTrigger();
+@@ -88,22 +88,11 @@ var WaDropdown = class extends WebAwesomeElement {
+         trigger?.focus({ preventScroll: true });
+         return;
+       }
+-      const activeElement = [...activeElements()].find((el) => el.localName === "wa-dropdown-item");
+-      const isFocusedOnItem = activeElement?.localName === "wa-dropdown-item";
++      const focusedItem = [...activeElements()].find((el) => el.localName === "wa-dropdown-item");
+       const currentSubmenuItem = this.getCurrentSubmenuItem();
+-      const isInSubmenu = !!currentSubmenuItem;
+-      let items;
+-      let activeItem;
+-      let activeItemIndex;
+-      if (isInSubmenu) {
+-        items = this.getSubmenuItems(currentSubmenuItem);
+-        activeItem = items.find((item) => item.active || item === activeElement);
+-        activeItemIndex = activeItem ? items.indexOf(activeItem) : -1;
+-      } else {
+-        items = this.getItems();
+-        activeItem = items.find((item) => item.active || item === activeElement);
+-        activeItemIndex = activeItem ? items.indexOf(activeItem) : -1;
+-      }
++      const items = currentSubmenuItem ? this.getSubmenuItems(currentSubmenuItem) : this.getItems();
++      const activeItem = items.find((item) => item.active || item === focusedItem);
++      const activeItemIndex = activeItem ? items.indexOf(activeItem) : -1;
+       let itemToSelect;
+       if (event.key === "ArrowUp") {
+         event.preventDefault();
+@@ -123,23 +112,15 @@ var WaDropdown = class extends WebAwesomeElement {
+           itemToSelect = items[0];
+         }
+       }
+-      if (event.key === (isRtl ? "ArrowLeft" : "ArrowRight") && isFocusedOnItem && activeItem) {
++      if (event.key === (isRtl ? "ArrowLeft" : "ArrowRight") && focusedItem && activeItem) {
+         if (activeItem.hasSubmenu) {
+           event.preventDefault();
+           event.stopPropagation();
+-          activeItem.submenuOpen = true;
+-          this.addToSubmenuStack(activeItem);
+-          setTimeout(() => {
+-            const submenuItems = this.getSubmenuItems(activeItem);
+-            if (submenuItems.length > 0) {
+-              submenuItems.forEach((item, index) => item.active = index === 0);
+-              submenuItems[0].focus({ preventScroll: true });
+-            }
+-          }, 0);
++          this.openKeyboardSubmenu(activeItem);
+           return;
+         }
+       }
+-      if (event.key === (isRtl ? "ArrowRight" : "ArrowLeft") && isInSubmenu) {
++      if (event.key === (isRtl ? "ArrowRight" : "ArrowLeft") && currentSubmenuItem) {
+         event.preventDefault();
+         event.stopPropagation();
+         const removedItem = this.removeFromSubmenuStack();
+@@ -164,7 +145,7 @@ var WaDropdown = class extends WebAwesomeElement {
+         itemToSelect = event.key === "Home" ? items[0] : items[items.length - 1];
+       }
+       if (event.key === "Tab") {
+-        await this.hideMenu();
++        this.open = false;
+       }
+       if (event.key.length === 1 && !(event.metaKey || event.ctrlKey || event.altKey) && !(event.key === " " && this.userTypedQuery === "")) {
+         clearTimeout(this.userTypedTimeout);
+@@ -190,19 +171,11 @@ var WaDropdown = class extends WebAwesomeElement {
+         itemToSelect.scrollIntoView({ block: "nearest" });
+         return;
+       }
+-      if ((event.key === "Enter" || event.key === " " && this.userTypedQuery === "") && isFocusedOnItem && activeItem) {
++      if ((event.key === "Enter" || event.key === " " && this.userTypedQuery === "") && focusedItem && activeItem) {
+         event.preventDefault();
+         event.stopPropagation();
+         if (activeItem.hasSubmenu) {
+-          activeItem.submenuOpen = true;
+-          this.addToSubmenuStack(activeItem);
+-          setTimeout(() => {
+-            const submenuItems = this.getSubmenuItems(activeItem);
+-            if (submenuItems.length > 0) {
+-              submenuItems.forEach((item, index) => item.active = index === 0);
+-              submenuItems[0].focus({ preventScroll: true });
+-            }
+-          }, 0);
++          this.openKeyboardSubmenu(activeItem);
+         } else {
+           this.makeSelection(activeItem, event);
+         }
+@@ -251,15 +224,22 @@ var WaDropdown = class extends WebAwesomeElement {
+   handleSizeChange() {
+     warnDeprecatedSize(this.localName, this.size);
+   }
++  connectedCallback() {
++    super.connectedCallback();
++    if (this.hasUpdated && this.open) {
++      void this.updateMenuVisibility(true);
++    }
++  }
+   disconnectedCallback() {
+     super.disconnectedCallback();
++    this.menuTransition?.abort();
++    this.menu?.classList.remove("show", "hide");
++    if (this.popup) this.popup.active = false;
++    openDropdowns.delete(this);
+     clearInterval(this.userTypedTimeout);
+     this.closeAllSubmenus();
+     this.submenuCleanups.forEach((cleanup) => cleanup());
+     this.submenuCleanups.clear();
+-    document.removeEventListener("mousemove", this.handleGlobalMouseMove);
+-    document.removeEventListener("keydown", this.handleDocumentKeyDown);
+-    document.removeEventListener("pointerdown", this.handleDocumentPointerDown);
+     unregisterDismissible(this);
+   }
+   firstUpdated(changedProperties) {
+@@ -276,12 +256,7 @@ var WaDropdown = class extends WebAwesomeElement {
+         return;
+       }
+       this.customStates.set("open", this.open);
+-      if (this.open) {
+-        await this.showMenu();
+-      } else {
+-        this.closeAllSubmenus();
+-        await this.hideMenu();
+-      }
++      await this.updateMenuVisibility(this.open);
+     }
+     if (changedProperties.has("size")) {
+       this.syncItemSizes();
+@@ -323,9 +298,21 @@ var WaDropdown = class extends WebAwesomeElement {
+   removeFromSubmenuStack() {
+     return this.openSubmenuStack.pop();
+   }
++  /** Opens a submenu for keyboard navigation after its items update. */
++  openKeyboardSubmenu(item) {
++    item.submenuOpen = true;
++    this.addToSubmenuStack(item);
++    setTimeout(() => {
++      const submenuItems = this.getSubmenuItems(item);
++      if (submenuItems.length > 0) {
++        submenuItems.forEach((item2, index) => item2.active = index === 0);
++        submenuItems[0].focus({ preventScroll: true });
++      }
++    }, 0);
++  }
+   /** Gets the current active submenu item */
+   getCurrentSubmenuItem() {
+-    return this.openSubmenuStack.length > 0 ? this.openSubmenuStack[this.openSubmenuStack.length - 1] : void 0;
++    return this.openSubmenuStack[this.openSubmenuStack.length - 1];
+   }
+   /** Closes all submenus in the dropdown. */
+   closeAllSubmenus() {
+@@ -357,57 +344,57 @@ var WaDropdown = class extends WebAwesomeElement {
+   getTrigger() {
+     return this.querySelector('[slot="trigger"]');
+   }
+-  /** Shows the dropdown menu. This should only be called from within updated(). */
+-  async showMenu() {
+-    const anchor = this.getTrigger();
+-    if (!anchor || !this.popup || !this.menu) return;
+-    const showEvent = new WaShowEvent();
+-    this.dispatchEvent(showEvent);
+-    if (showEvent.defaultPrevented) {
+-      this.open = false;
++  /** Reconciles accepted visibility and its animation from updates or reconnection. */
++  async updateMenuVisibility(open) {
++    if (!this.isConnected || !this.popup || !this.menu || open && !this.getTrigger()) return;
++    const event = open ? new WaShowEvent() : new WaHideEvent({ source: this });
++    this.dispatchEvent(event);
++    if (event.defaultPrevented) {
++      this.open = !open;
+       return;
+     }
+-    if (this.popup.active) {
+-      return;
++    // Membership records accepted open ownership. The popup stays active while hiding,
++    // so its active flag cannot distinguish a canceled hide from a reopen.
++    if (!this.isConnected || this.open !== open || open && openDropdowns.has(this)) return;
++    // One cancellation owner releases document listeners and fences completion on
++    // replacement or disconnection; a veto above leaves that ownership untouched.
++    this.menuTransition?.abort();
++    this.menuTransition = new AbortController();
++    const { signal } = this.menuTransition;
++    const isCurrent = () => !signal.aborted && this.isConnected && this.open === open;
++    if (open) {
++      openDropdowns.forEach((dropdown) => dropdown.open = false);
++      this.popup.active = true;
++      openDropdowns.add(this);
++      registerDismissible(this);
++      document.addEventListener("keydown", this.handleDocumentKeyDown, { signal });
++      document.addEventListener("pointerdown", this.handleDocumentPointerDown, { signal });
++      document.addEventListener("mousemove", this.handleGlobalMouseMove, { signal });
++    } else {
++      this.closeAllSubmenus();
++      openDropdowns.delete(this);
++      unregisterDismissible(this);
+     }
+-    openDropdowns.forEach((dropdown) => dropdown.open = false);
+-    this.popup.active = true;
+-    this.open = true;
+-    openDropdowns.add(this);
+-    registerDismissible(this);
+     this.syncAriaAttributes();
+-    document.addEventListener("keydown", this.handleDocumentKeyDown);
+-    document.addEventListener("pointerdown", this.handleDocumentPointerDown);
+-    document.addEventListener("mousemove", this.handleGlobalMouseMove);
+-    this.menu.classList.remove("hide");
+-    await animateWithClass(this.menu, "show");
+-    const items = this.getItems();
+-    if (items.length > 0) {
+-      items.forEach((item, index) => item.active = index === 0);
+-      items[0].focus({ preventScroll: true });
+-    }
+-    this.dispatchEvent(new WaAfterShowEvent());
+-  }
+-  /** Hides the dropdown menu. This should only be called from within updated(). */
+-  async hideMenu() {
+-    if (!this.popup || !this.menu) return;
+-    const hideEvent = new WaHideEvent({ source: this });
+-    this.dispatchEvent(hideEvent);
+-    if (hideEvent.defaultPrevented) {
+-      this.open = true;
+-      return;
++    // Cancel first and let the old helper remove its class/listeners before starting
++    // another animation; otherwise its cancellation event can finish the new one.
++    this.menu.classList.remove("show", "hide");
++    await this.menuAnimation;
++    if (!isCurrent()) return;
++    this.menuAnimation = animateWithClass(this.menu, open ? "show" : "hide");
++    await this.menuAnimation;
++    if (!isCurrent()) return;
++    if (open) {
++      const items = this.getItems();
++      if (items.length > 0) {
++        items.forEach((item, index) => item.active = index === 0);
++        items[0].focus({ preventScroll: true });
++      }
++      if (isCurrent()) this.dispatchEvent(new WaAfterShowEvent());
++    } else {
++      this.popup.active = false;
++      this.dispatchEvent(new WaAfterHideEvent());
+     }
+-    this.open = false;
+-    openDropdowns.delete(this);
+-    unregisterDismissible(this);
+-    this.syncAriaAttributes();
+-    document.removeEventListener("keydown", this.handleDocumentKeyDown);
+-    document.removeEventListener("pointerdown", this.handleDocumentPointerDown);
+-    document.removeEventListener("mousemove", this.handleGlobalMouseMove);
+-    this.menu.classList.remove("show");
+-    await animateWithClass(this.menu, "hide");
+-    this.popup.active = this.open;
+-    this.dispatchEvent(new WaAfterHideEvent());
+   }
+   /** Handles clicks on the menu. */
+   handleMenuClick(event) {
+diff --git a/dist-cdn/components/dropdown/dropdown.d.ts b/dist-cdn/components/dropdown/dropdown.d.ts
+index 561ccfa258274c2c41cb728c0bfef26381c9f30c..f2cb50e06a20720603f4e8a48253384452363a19 100644
+--- a/dist-cdn/components/dropdown/dropdown.d.ts
++++ b/dist-cdn/components/dropdown/dropdown.d.ts
+@@ -34,6 +34,8 @@ export default class WaDropdown extends WebAwesomeElement {
+     private userTypedQuery;
+     private userTypedTimeout;
+     private openSubmenuStack;
++    private menuTransition;
++    private menuAnimation;
+     defaultSlot: HTMLSlotElement;
+     private menu;
+     private popup;
+@@ -51,6 +53,7 @@ export default class WaDropdown extends WebAwesomeElement {
+     distance: number;
+     /** The offset of the dropdown menu along its trigger. */
+     skidding: number;
++    connectedCallback(): void;
+     disconnectedCallback(): void;
+     firstUpdated(changedProperties: PropertyValues<typeof this>): void;
+     updated(changedProperties: PropertyValues<typeof this>): Promise<void>;
+@@ -64,6 +67,8 @@ export default class WaDropdown extends WebAwesomeElement {
+     private addToSubmenuStack;
+     /** Removes the last item from the submenu stack */
+     private removeFromSubmenuStack;
++    /** Opens a submenu for keyboard navigation after its items update. */
++    private openKeyboardSubmenu;
+     /** Gets the current active submenu item */
+     private getCurrentSubmenuItem;
+     /** Closes all submenus in the dropdown. */
+@@ -72,10 +77,8 @@ export default class WaDropdown extends WebAwesomeElement {
+     private closeSiblingSubmenus;
+     /** Get the slotted trigger button, a <wa-button> or <button> element */
+     private getTrigger;
+-    /** Shows the dropdown menu. This should only be called from within updated(). */
+-    private showMenu;
+-    /** Hides the dropdown menu. This should only be called from within updated(). */
+-    private hideMenu;
++    /** Reconciles accepted visibility and its animation from updates or reconnection. */
++    private updateMenuVisibility;
+     /** Handles key down events when the menu is open */
+     private handleDocumentKeyDown;
+     /** Handles pointer down events when the dropdown is open. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,7 @@ overrides:
 packageExtensionsChecksum: sha256-zZ8fyodhMTumshonC7kktCqTPsiHL3UAyS9vltFAlMo=
 
 patchedDependencies:
-  '@awesome.me/webawesome@3.12.0': 9a8fb4b11b44a0cd63e5e7d7ea16314361217d02902b46c1ec4ea0072951b602
+  '@awesome.me/webawesome@3.12.0': bc34fe9e2ae30000725c1a8361518c2fd62712eb65d6e23db44abd9a9d5131ff
   '@vitest/runner@4.1.11': 55258cdf55f944f5e9bfbc52251b3696225ca2993e2d9f56b90b88f764193d93
   matrix-js-sdk@42.2.0: 9e97147d99b86977d6665a676cdf853434ef61eee7cfb176bb66c9c48da599b4
   vitest@4.1.11: c21477c229514823498ab3a08311070cec46b1811e866bc1b3f6ff3f5720da2e
@@ -2493,7 +2493,7 @@ importers:
     dependencies:
       '@awesome.me/webawesome':
         specifier: 3.12.0
-        version: 3.12.0(patch_hash=9a8fb4b11b44a0cd63e5e7d7ea16314361217d02902b46c1ec4ea0072951b602)(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)
+        version: 3.12.0(patch_hash=bc34fe9e2ae30000725c1a8361518c2fd62712eb65d6e23db44abd9a9d5131ff)(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)
       '@codemirror/commands':
         specifier: 6.11.0
         version: 6.11.0
@@ -9536,7 +9536,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@awesome.me/webawesome@3.12.0(patch_hash=9a8fb4b11b44a0cd63e5e7d7ea16314361217d02902b46c1ec4ea0072951b602)(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)':
+  '@awesome.me/webawesome@3.12.0(patch_hash=bc34fe9e2ae30000725c1a8361518c2fd62712eb65d6e23db44abd9a9d5131ff)(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)':
     dependencies:
       '@ctrl/tinycolor': 4.1.0
       '@floating-ui/dom': 1.8.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,7 @@ overrides:
 packageExtensionsChecksum: sha256-zZ8fyodhMTumshonC7kktCqTPsiHL3UAyS9vltFAlMo=
 
 patchedDependencies:
-  '@awesome.me/webawesome@3.12.0': 7008628a7ea5c46ed39c2998887003fcdae54c6c9340f5ebb3dc7ab0089d027a
+  '@awesome.me/webawesome@3.12.0': 9a8fb4b11b44a0cd63e5e7d7ea16314361217d02902b46c1ec4ea0072951b602
   '@vitest/runner@4.1.11': 55258cdf55f944f5e9bfbc52251b3696225ca2993e2d9f56b90b88f764193d93
   matrix-js-sdk@42.2.0: 9e97147d99b86977d6665a676cdf853434ef61eee7cfb176bb66c9c48da599b4
   vitest@4.1.11: c21477c229514823498ab3a08311070cec46b1811e866bc1b3f6ff3f5720da2e
@@ -2493,7 +2493,7 @@ importers:
     dependencies:
       '@awesome.me/webawesome':
         specifier: 3.12.0
-        version: 3.12.0(patch_hash=7008628a7ea5c46ed39c2998887003fcdae54c6c9340f5ebb3dc7ab0089d027a)(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)
+        version: 3.12.0(patch_hash=9a8fb4b11b44a0cd63e5e7d7ea16314361217d02902b46c1ec4ea0072951b602)(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)
       '@codemirror/commands':
         specifier: 6.11.0
         version: 6.11.0
@@ -9536,7 +9536,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@awesome.me/webawesome@3.12.0(patch_hash=7008628a7ea5c46ed39c2998887003fcdae54c6c9340f5ebb3dc7ab0089d027a)(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)':
+  '@awesome.me/webawesome@3.12.0(patch_hash=9a8fb4b11b44a0cd63e5e7d7ea16314361217d02902b46c1ec4ea0072951b602)(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)':
     dependencies:
       '@ctrl/tinycolor': 4.1.0
       '@floating-ui/dom': 1.8.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,7 @@ overrides:
 packageExtensionsChecksum: sha256-zZ8fyodhMTumshonC7kktCqTPsiHL3UAyS9vltFAlMo=
 
 patchedDependencies:
+  '@awesome.me/webawesome@3.12.0': 7008628a7ea5c46ed39c2998887003fcdae54c6c9340f5ebb3dc7ab0089d027a
   '@vitest/runner@4.1.11': 55258cdf55f944f5e9bfbc52251b3696225ca2993e2d9f56b90b88f764193d93
   matrix-js-sdk@42.2.0: 9e97147d99b86977d6665a676cdf853434ef61eee7cfb176bb66c9c48da599b4
   vitest@4.1.11: c21477c229514823498ab3a08311070cec46b1811e866bc1b3f6ff3f5720da2e
@@ -2492,7 +2493,7 @@ importers:
     dependencies:
       '@awesome.me/webawesome':
         specifier: 3.12.0
-        version: 3.12.0(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)
+        version: 3.12.0(patch_hash=7008628a7ea5c46ed39c2998887003fcdae54c6c9340f5ebb3dc7ab0089d027a)(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)
       '@codemirror/commands':
         specifier: 6.11.0
         version: 6.11.0
@@ -9535,7 +9536,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@awesome.me/webawesome@3.12.0(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)':
+  '@awesome.me/webawesome@3.12.0(patch_hash=7008628a7ea5c46ed39c2998887003fcdae54c6c9340f5ebb3dc7ab0089d027a)(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)':
     dependencies:
       '@ctrl/tinycolor': 4.1.0
       '@floating-ui/dom': 1.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -90,6 +90,7 @@ packageExtensions:
         optional: true
 
 patchedDependencies:
+  "@awesome.me/webawesome@3.12.0": patches/@awesome.me__webawesome@3.12.0.patch
   "@vitest/runner@4.1.11": patches/@vitest__runner@4.1.11.patch
   "vitest@4.1.11": patches/vitest@4.1.11.patch
   "matrix-js-sdk@42.2.0": patches/matrix-js-sdk@42.2.0.patch

--- a/scripts/check-package-patches.mts
+++ b/scripts/check-package-patches.mts
@@ -10,6 +10,7 @@ import YAML from "yaml";
 import { pnpmLockfileDocuments } from "./lib/pnpm-lockfile-documents.mjs";
 
 const ALLOWED_PATCHED_DEPENDENCIES = new Map([
+  ["@awesome.me/webawesome@3.12.0", "patches/@awesome.me__webawesome@3.12.0.patch"],
   ["@vitest/runner@4.1.11", "patches/@vitest__runner@4.1.11.patch"],
   ["vitest@4.1.11", "patches/vitest@4.1.11.patch"],
   ["baileys@7.0.0-rc12", "patches/baileys@7.0.0-rc12.patch"],

--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -841,45 +841,122 @@ describe("openclaw test instance", () => {
     },
   );
 
-  it("force-kills Windows gateway descendants before retry cleanup settles", async () => {
+  it.each([true, false])(
+    "joins Windows gateway closure before retry cleanup (inherited pipes=%s)",
+    async (inheritedPipes) => {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const kill = vi.fn(() => true);
+      // SAFETY: The stub supplies every process and pipe member consumed by the stopper.
+      const child = {
+        exitCode: 1,
+        kill,
+        pid: 12345,
+        signalCode: null,
+        stderr,
+        stdout,
+      } as unknown as Parameters<typeof testing.stopGatewayProcess>[0];
+      const closePipes = () => {
+        stdout.destroy();
+        stderr.destroy();
+      };
+      const runTaskkill = vi.fn(() => {
+        closePipes();
+        return { status: 0 };
+      });
+      if (!inheritedPipes) {
+        setImmediate(closePipes);
+      }
+
+      await expect(
+        testing.stopGatewayProcess(child, Date.now() + 500, 250, {
+          forceWindowsTree: true,
+          platform: "win32",
+          runTaskkill,
+        }),
+      ).resolves.toBe(true);
+
+      if (inheritedPipes) {
+        expect(runTaskkill).toHaveBeenCalledOnce();
+        expect(runTaskkill).toHaveBeenCalledWith(
+          path.win32.join("C:\\Windows", "System32", "taskkill.exe"),
+          ["/PID", "12345", "/T", "/F"],
+          {
+            killSignal: "SIGKILL",
+            stdio: "ignore",
+            timeout: 10_000,
+          },
+        );
+      } else {
+        expect(runTaskkill).not.toHaveBeenCalled();
+      }
+      expect(kill).not.toHaveBeenCalled();
+      expect(stdout.closed).toBe(true);
+      expect(stderr.closed).toBe(true);
+    },
+  );
+
+  it.each([
+    { label: "joined closure", taskkillStatus: 0, closePipes: true, stopped: true },
+    { label: "held pipe", taskkillStatus: 0, closePipes: false, stopped: false },
+    { label: "unverified tree", taskkillStatus: 1, closePipes: true, stopped: false },
+  ])("observes Windows $label after blocking termination", async (scenario) => {
     const stdout = new PassThrough();
     const stderr = new PassThrough();
-    const kill = vi.fn(() => true);
-    const child = {
-      exitCode: 1,
-      kill,
+    const processState = createGatewayProcessState();
+    // SAFETY: The stub supplies every process and pipe member consumed by the stopper.
+    const child = Object.assign(processState, {
       pid: 12345,
-      signalCode: null,
-      stderr,
+      kill: vi.fn(() => true),
       stdout,
-    } as unknown as Parameters<typeof testing.stopGatewayProcess>[0];
+      stderr,
+    }) as unknown as Parameters<typeof testing.stopGatewayProcess>[0];
+    const observed = createDeferred();
+    const now = Date.now.bind(Date);
+    let offset = 0;
+    let scheduled = false;
+    const clock = vi.spyOn(Date, "now").mockImplementation(() => now() + offset);
     const runTaskkill = vi.fn(() => {
-      stdout.destroy();
-      stderr.destroy();
-      return { status: 0 };
+      // A synchronous taskkill consumes wall time before Node can deliver exit/close.
+      offset += 1_000;
+      if (!scheduled) {
+        scheduled = true;
+        setImmediate(() => {
+          processState.exitCode = 0;
+          stdout.destroy();
+          if (scenario.closePipes) {
+            stderr.destroy();
+          }
+          observed.resolve();
+        });
+      }
+      return { status: scenario.taskkillStatus };
     });
-
-    await expect(
-      testing.stopGatewayProcess(child, Date.now() + 500, 250, {
-        forceWindowsTree: true,
+    try {
+      const stopped = await testing.stopGatewayProcess(child, Date.now() + 500, 250, {
         platform: "win32",
         runTaskkill,
-      }),
-    ).resolves.toBe(true);
-
-    expect(runTaskkill).toHaveBeenCalledOnce();
-    expect(runTaskkill).toHaveBeenCalledWith(
-      path.win32.join("C:\\Windows", "System32", "taskkill.exe"),
-      ["/PID", "12345", "/T", "/F"],
-      {
-        killSignal: "SIGKILL",
-        stdio: "ignore",
-        timeout: 10_000,
-      },
-    );
-    expect(kill).not.toHaveBeenCalled();
-    expect(stdout.closed).toBe(true);
-    expect(stderr.closed).toBe(true);
+      });
+      expect(stopped).toBe(scenario.stopped);
+      expect(runTaskkill).toHaveBeenCalledTimes(scenario.taskkillStatus === 0 ? 1 : 2);
+      if (!scenario.closePipes) {
+        expect(stderr.closed).toBe(false);
+      }
+      if (stopped) {
+        expect(child.exitCode).toBe(0);
+        expect(stdout.closed && stderr.closed).toBe(true);
+      }
+    } finally {
+      if (scheduled) {
+        await observed.promise;
+      }
+      const closed = Promise.all(
+        [stdout, stderr].map((pipe) => (pipe.closed ? Promise.resolve() : once(pipe, "close"))),
+      );
+      stdout.destroy();
+      stderr.destroy();
+      await closed.finally(() => clock.mockRestore());
+    }
   });
 
   it("keeps only bounded child output tails in helper logs", () => {

--- a/test/helpers/openclaw-test-instance.ts
+++ b/test/helpers/openclaw-test-instance.ts
@@ -333,7 +333,7 @@ async function stopGatewayProcess(
         Math.max(0, Math.floor((deadline - Date.now()) / Math.max(1, remainingSteps))),
       ),
     );
-  const terminate = (signal: NodeJS.Signals) => {
+  const terminate = (signal: NodeJS.Signals) =>
     terminateManagedChild(
       child,
       signal,
@@ -343,16 +343,33 @@ async function stopGatewayProcess(
             platform,
           },
     );
-  };
-  const forceWindowsTree = options.forceWindowsTree === true && platform === "win32";
-  const signals = forceWindowsTree ? (["SIGKILL"] as const) : (["SIGTERM", "SIGKILL"] as const);
 
   if (hasGatewayProcessClosed(child)) {
     return true;
   }
+  if (platform === "win32") {
+    if (hasChildExited(child) && (await waitForClose(2))) {
+      return true;
+    }
+    if (Date.now() >= deadline) {
+      return false;
+    }
+    // Taskkill owns its bounded synchronous TERM/force sequence. Node cannot observe
+    // exit or pipe closure until it returns, so charge the existing close allowance afterward.
+    try {
+      const termination = terminate(options.forceWindowsTree ? "SIGKILL" : "SIGTERM");
+      return (
+        termination?.processTreeState === "terminated" &&
+        (await waitForGatewayClose(child, stopTimeoutMs))
+      );
+    } catch {
+      return false;
+    }
+  }
+  const signals = ["SIGTERM", "SIGKILL"] as const;
   // An exited leader can leave inherited stdio open in descendants. Let it
   // settle briefly, then terminate the owned tree before releasing the slot.
-  if (!forceWindowsTree && hasChildExited(child) && (await waitForClose(signals.length + 1))) {
+  if (hasChildExited(child) && (await waitForClose(signals.length + 1))) {
     return true;
   }
   for (const [index, signal] of signals.entries()) {

--- a/test/scripts/check-package-patches.test.ts
+++ b/test/scripts/check-package-patches.test.ts
@@ -55,6 +55,7 @@ afterEach(() => {
 describe("check-package-patches", () => {
   it("allows approved pnpm patches together", () => {
     const approvedPatches = [
+      ["@awesome.me/webawesome@3.12.0", "patches/@awesome.me__webawesome@3.12.0.patch"],
       ["baileys@7.0.0-rc12", "patches/baileys@7.0.0-rc12.patch"],
       ["baileys@7.0.0-rc13", "patches/baileys@7.0.0-rc13.patch"],
       ["@vitest/runner@4.1.11", "patches/@vitest__runner@4.1.11.patch"],

--- a/ui/src/components/web-awesome-dropdown.browser.test.ts
+++ b/ui/src/components/web-awesome-dropdown.browser.test.ts
@@ -334,13 +334,16 @@ describe.runIf(browserMode)("Web Awesome dropdown lifecycle", () => {
   it("settles repeated public submenu requests through the same visibility lifecycle", async () => {
     const f = await fixture();
     await open(f);
-    let openings = 0;
-    f.parent.addEventListener("submenu-opening", () => openings++);
+    const openingStates: (string | null)[] = [];
+    f.parent.addEventListener("submenu-opening", () => {
+      openingStates.push(f.parent.getAttribute("aria-expanded"));
+    });
     let completed = 0;
     const requests = [f.parent.openSubmenu(), f.parent.openSubmenu()];
     void Promise.all(requests).then(() => completed++);
     await expect.poll(() => completed).toBe(1);
-    expect(openings).toBe(1);
+    // Embedded controls recognize a fresh opening from its pre-expansion state.
+    expect(openingStates).toEqual(["false"]);
     expect(f.parent.submenuElement.hidden).toBe(false);
     expect(document.activeElement).toBe(f.nested);
     void Promise.all([f.parent.closeSubmenu(), f.parent.closeSubmenu()]).then(() => completed++);

--- a/ui/src/components/web-awesome-dropdown.browser.test.ts
+++ b/ui/src/components/web-awesome-dropdown.browser.test.ts
@@ -53,26 +53,35 @@ async function open(f: Fixture) {
 }
 
 // Run in the animation-start task, not after a host RPC that can outlast the animation.
-async function duringAnimation(f: Fixture, state: "show" | "hide", action: () => void) {
+async function duringElementAnimation(
+  element: HTMLElement,
+  state: "show" | "hide",
+  request: () => unknown,
+  action: () => void,
+) {
   let observed = false;
   const listener = (event: AnimationEvent) => {
-    if (event.target !== f.menu || !f.menu.classList.contains(state)) {
+    if (event.target !== element || !element.classList.contains(state)) {
       return;
     }
-    f.menu.removeEventListener("animationstart", listener);
-    expect(f.menu.getAnimations().some((animation) => animation.playState === "running")).toBe(
+    element.removeEventListener("animationstart", listener);
+    expect(element.getAnimations().some((animation) => animation.playState === "running")).toBe(
       true,
     );
     observed = true;
     action();
   };
-  f.menu.addEventListener("animationstart", listener);
-  f.dropdown.open = state === "show";
+  element.addEventListener("animationstart", listener);
   try {
+    await request();
     await expect.poll(() => observed).toBe(true);
   } finally {
-    f.menu.removeEventListener("animationstart", listener);
+    element.removeEventListener("animationstart", listener);
   }
+}
+
+async function duringAnimation(f: Fixture, state: "show" | "hide", action: () => void) {
+  await duringElementAnimation(f.menu, state, () => (f.dropdown.open = state === "show"), action);
 }
 
 async function reopen(f: Fixture) {
@@ -174,6 +183,59 @@ describe.runIf(browserMode)("Web Awesome dropdown lifecycle", () => {
     },
   );
 
+  it("settles a pending show canceled after its first animation sample", async () => {
+    const f = await fixture();
+    let starts = 0;
+    let observed: { pending: boolean; starts: number } | undefined;
+    f.menu.addEventListener("animationstart", () => starts++);
+    const observer = new MutationObserver(() => {
+      if (!f.menu.classList.contains("show")) {
+        return;
+      }
+      observer.disconnect();
+      // Queue behind the helper's first frame, before the pending CSS animation starts.
+      requestAnimationFrame(() => {
+        observed = {
+          pending: f.menu.getAnimations().some((animation) => animation.pending),
+          starts,
+        };
+        f.dropdown.open = false;
+        f.outside.focus();
+      });
+    });
+    observer.observe(f.menu, { attributes: true, attributeFilter: ["class"] });
+    try {
+      f.dropdown.open = true;
+      await expect.poll(() => observed).toEqual({ pending: true, starts: 0 });
+      await closed(f);
+      expect(count(f, "wa-after-show")).toBe(0);
+      expect(document.activeElement).toBe(f.outside);
+      await open(f);
+    } finally {
+      observer.disconnect();
+    }
+  });
+
+  it("closes without waiting for an unrelated paused transition when menu animation is disabled", async () => {
+    const f = await fixture();
+    await open(f);
+    f.menu.style.animation = "none";
+    f.menu.style.transition = "opacity 100ms linear";
+    expect(getComputedStyle(f.menu).opacity).toBe("1");
+    f.menu.style.opacity = "0.9";
+    const transition = f.menu
+      .getAnimations()
+      .find((animation) => animation instanceof CSSTransition);
+    expect(transition).toBeDefined();
+    transition!.pause();
+    try {
+      f.dropdown.open = false;
+      await closed(f);
+    } finally {
+      transition!.cancel();
+    }
+  });
+
   it("keeps a canceled show closed and a subsequent accepted show functional", async () => {
     const f = await fixture();
     f.dropdown.addEventListener("wa-show", (event) => event.preventDefault(), { once: true });
@@ -217,6 +279,107 @@ describe.runIf(browserMode)("Web Awesome dropdown lifecycle", () => {
     await userEvent.keyboard("{Escape}");
     await closed(f);
   });
+
+  it("keeps a reopened submenu visible after its interrupted hide finishes", async () => {
+    const f = await fixture();
+    await open(f);
+    f.parent.submenuOpen = true;
+    await expect.poll(() => document.activeElement).toBe(f.nested);
+    const submenu = f.parent.submenuElement;
+    await duringElementAnimation(
+      submenu,
+      "hide",
+      () => (f.parent.submenuOpen = false),
+      () => {
+        f.parent.submenuOpen = true;
+        f.parent.focus();
+      },
+    );
+    await expect.poll(() => submenu.getAnimations().length).toBe(0);
+    expect(f.parent.submenuOpen).toBe(true);
+    expect(submenu.hidden).toBe(false);
+    expect(submenu.matches(":popover-open")).toBe(true);
+    await expect.poll(() => document.activeElement).toBe(f.nested);
+  });
+
+  it("focuses keyboard submenus on opening without a late animation focus reset", async () => {
+    const { userEvent } = await import("vitest/browser");
+    const f = await fixture();
+    await open(f);
+    await userEvent.keyboard("{ArrowDown}");
+    const submenu = f.parent.submenuElement;
+    await duringElementAnimation(
+      submenu,
+      "show",
+      () => userEvent.keyboard("{ArrowRight}"),
+      () => {
+        expect(document.activeElement).toBe(f.nested);
+        f.outside.focus();
+      },
+    );
+    await expect.poll(() => submenu.getAnimations().length).toBe(0);
+    await frame();
+    expect(document.activeElement).toBe(f.outside);
+  });
+
+  it("settles a never-connected submenu close as a public no-op", async () => {
+    const item = document.createElement("wa-dropdown-item");
+    let completed = false;
+    void item.closeSubmenu().then(() => (completed = true));
+    await expect.poll(() => completed).toBe(true);
+    expect(item.isConnected).toBe(false);
+    expect(item.submenuOpen).toBe(false);
+  });
+
+  it("settles repeated public submenu requests through the same visibility lifecycle", async () => {
+    const f = await fixture();
+    await open(f);
+    let openings = 0;
+    f.parent.addEventListener("submenu-opening", () => openings++);
+    let completed = 0;
+    const requests = [f.parent.openSubmenu(), f.parent.openSubmenu()];
+    void Promise.all(requests).then(() => completed++);
+    await expect.poll(() => completed).toBe(1);
+    expect(openings).toBe(1);
+    expect(f.parent.submenuElement.hidden).toBe(false);
+    expect(document.activeElement).toBe(f.nested);
+    void Promise.all([f.parent.closeSubmenu(), f.parent.closeSubmenu()]).then(() => completed++);
+    await expect.poll(() => completed).toBe(2);
+    expect(f.parent.submenuOpen).toBe(false);
+    expect(f.parent.submenuElement.hidden).toBe(true);
+    expect(f.parent.submenuElement.matches(":popover-open")).toBe(false);
+  });
+
+  it.each(["show", "hide"] as const)(
+    "retires an interrupted submenu %s on disconnect before a fresh public reopen",
+    async (phase) => {
+      const f = await fixture();
+      await open(f);
+      if (phase === "hide") {
+        await f.parent.openSubmenu();
+      }
+      const submenu = f.parent.submenuElement;
+      await duringElementAnimation(
+        submenu,
+        phase,
+        () => (f.parent.submenuOpen = phase === "show"),
+        () => {
+          f.parent.remove();
+          f.outside.focus();
+        },
+      );
+      await frame();
+      expect(f.parent.submenuOpen).toBe(false);
+      expect(submenu.hidden).toBe(true);
+      expect(submenu.matches(":popover-open")).toBe(false);
+      expect(document.activeElement).toBe(f.outside);
+      f.dropdown.append(f.parent);
+      await f.parent.openSubmenu();
+      expect(submenu.hidden).toBe(false);
+      expect(submenu.matches(":popover-open")).toBe(true);
+      expect(document.activeElement).toBe(f.nested);
+    },
+  );
 
   it.each([
     { dir: "ltr", openKey: "ArrowRight" },
@@ -292,6 +455,42 @@ describe.runIf(browserMode)("Web Awesome dropdown lifecycle", () => {
       expect(document.activeElement).toBe(f.item);
       await userEvent.keyboard("{Escape}");
       await closed(f);
+    },
+  );
+
+  it.each(["wa-tooltip", "wa-popover"] as const)(
+    "waits for %s reactive popup rendering and its actual opening animation",
+    async (tag) => {
+      const f = await fixture();
+      const surface = document.createElement(tag);
+      f.outside.id = "animation-proof-anchor";
+      surface.for = f.outside.id;
+      surface.textContent = "Details";
+      if (tag === "wa-tooltip") {
+        surface.setAttribute("trigger", "manual");
+      }
+      f.host.append(surface);
+      await surface.updateComplete;
+      const popup = surface.shadowRoot!.querySelector("wa-popup")!;
+      let starts = 0;
+      let shown = false;
+      let hidden = false;
+      popup.popup.addEventListener(
+        "animationstart",
+        () => {
+          expect(shown).toBe(false);
+          starts++;
+        },
+        { once: true },
+      );
+      surface.addEventListener("wa-after-show", () => (shown = true));
+      surface.addEventListener("wa-after-hide", () => (hidden = true));
+      surface.open = true;
+      await expect.poll(() => shown).toBe(true);
+      expect(starts).toBe(1);
+      surface.open = false;
+      await expect.poll(() => hidden).toBe(true);
+      expect(popup.active).toBe(false);
     },
   );
 

--- a/ui/src/components/web-awesome-dropdown.browser.test.ts
+++ b/ui/src/components/web-awesome-dropdown.browser.test.ts
@@ -1,0 +1,306 @@
+import type { WaSelectEvent } from "@awesome.me/webawesome/dist/events/select.js";
+import { afterEach, describe, expect, it } from "vitest";
+import "@awesome.me/webawesome/dist/styles/themes/default.css";
+import "@awesome.me/webawesome/dist/components/popover/popover.js";
+import "./web-awesome.ts";
+import "./tooltip.ts";
+
+const browserMode = "__vitest_browser__" in globalThis;
+
+async function fixture(initialOpen = false) {
+  const host = document.createElement("div");
+  host.innerHTML = `<wa-dropdown ${initialOpen ? "open" : ""}>
+    <button slot="trigger">Actions</button>
+    <wa-dropdown-item type="checkbox" value="search">Web search</wa-dropdown-item>
+    <wa-dropdown-item>More<wa-dropdown-item slot="submenu" value="nested">Nested action</wa-dropdown-item></wa-dropdown-item>
+  </wa-dropdown><button data-outside>Outside</button>`;
+  const dropdown = host.querySelector("wa-dropdown")!;
+  const trigger = host.querySelector("button")!;
+  const outside = host.querySelector<HTMLButtonElement>("[data-outside]")!;
+  const item = host.querySelector("wa-dropdown-item")!;
+  const parent = host.querySelectorAll("wa-dropdown-item")[1];
+  const nested = host.querySelectorAll("wa-dropdown-item")[2];
+  if (!parent || !nested) {
+    throw new Error("Dropdown fixture requires a submenu parent and nested item");
+  }
+  const events: { type: string; open: boolean; connected: boolean }[] = [];
+  for (const type of ["wa-show", "wa-hide", "wa-after-show", "wa-after-hide"]) {
+    dropdown.addEventListener(type, (event) => {
+      if (event.target === dropdown) {
+        events.push({ type, open: dropdown.open, connected: dropdown.isConnected });
+      }
+    });
+  }
+  document.body.append(host);
+  await dropdown.updateComplete;
+  await Promise.all([item.updateComplete, parent.updateComplete, nested.updateComplete]);
+  const menu = dropdown.shadowRoot!.querySelector<HTMLElement>('[part="menu"]')!;
+  const popup = dropdown.shadowRoot!.querySelector("wa-popup")!;
+  return { host, dropdown, trigger, outside, item, parent, nested, menu, popup, events };
+}
+
+type Fixture = Awaited<ReturnType<typeof fixture>>;
+const frame = () =>
+  new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+const count = (f: Fixture, type: string) => f.events.filter((event) => event.type === type).length;
+
+async function open(f: Fixture) {
+  const before = count(f, "wa-after-show");
+  f.dropdown.open = true;
+  await expect.poll(() => count(f, "wa-after-show")).toBe(before + 1);
+}
+
+// Run in the animation-start task, not after a host RPC that can outlast the animation.
+async function duringAnimation(f: Fixture, state: "show" | "hide", action: () => void) {
+  let observed = false;
+  const listener = (event: AnimationEvent) => {
+    if (event.target !== f.menu || !f.menu.classList.contains(state)) {
+      return;
+    }
+    f.menu.removeEventListener("animationstart", listener);
+    expect(f.menu.getAnimations().some((animation) => animation.playState === "running")).toBe(
+      true,
+    );
+    observed = true;
+    action();
+  };
+  f.menu.addEventListener("animationstart", listener);
+  f.dropdown.open = state === "show";
+  try {
+    await expect.poll(() => observed).toBe(true);
+  } finally {
+    f.menu.removeEventListener("animationstart", listener);
+  }
+}
+
+async function reopen(f: Fixture) {
+  await open(f);
+  await duringAnimation(f, "hide", () => {
+    f.dropdown.open = true;
+  });
+  await expect.poll(() => count(f, "wa-after-show")).toBe(2);
+  expect(count(f, "wa-after-hide")).toBe(0);
+  expect(f.dropdown.open).toBe(true);
+}
+
+async function closed(f: Fixture) {
+  await expect.poll(() => f.popup.active).toBe(false);
+  expect(f.dropdown.open).toBe(false);
+  expect(f.menu.getAnimations()).toHaveLength(0);
+  expect(f.events.filter((event) => event.type === "wa-after-hide")).toEqual([
+    { type: "wa-after-hide", open: false, connected: true },
+  ]);
+}
+
+afterEach(() => document.body.replaceChildren());
+
+describe.runIf(browserMode)("Web Awesome dropdown lifecycle", () => {
+  it.each(["Escape", "pointer", "Tab"] as const)(
+    "reacquires %s dismissal after an observed hide/reopen",
+    async (dismissal) => {
+      const { page, userEvent } = await import("vitest/browser");
+      const f = await fixture();
+      f.dropdown.addEventListener("wa-select", (event) => event.preventDefault());
+      await reopen(f);
+      await page.elementLocator(f.item).click();
+      expect(f.item.checked).toBe(true);
+      expect(f.dropdown.open).toBe(true);
+      expect(document.querySelector("openclaw-tooltip[open]")).toBeNull();
+      if (dismissal === "pointer") {
+        await page.elementLocator(f.outside).click();
+      } else {
+        await userEvent.keyboard(`{${dismissal}}`);
+      }
+      await closed(f);
+      expect(document.activeElement).toBe(dismissal === "Escape" ? f.trigger : f.outside);
+      await page.elementLocator(f.outside).hover();
+      f.outside.focus();
+      await userEvent.keyboard("{ArrowDown}");
+      expect(document.activeElement).toBe(f.outside);
+    },
+  );
+
+  it("dismisses a real tooltip first without changing menu selection or focus", async () => {
+    const { userEvent } = await import("vitest/browser");
+    const f = await fixture();
+    await reopen(f);
+    f.item.checked = true;
+    const tooltip = document.createElement("openclaw-tooltip");
+    tooltip.content = "Search the web for current information";
+    tooltip.anchor = f.item;
+    f.host.append(tooltip);
+    await tooltip.updateComplete;
+    f.outside.focus();
+    f.item.focus();
+    const hint = tooltip.shadowRoot!.querySelector("wa-tooltip")!;
+    await expect.poll(() => hint.open).toBe(true);
+    await userEvent.keyboard("{Escape}");
+    await expect.poll(() => hint.open).toBe(false);
+    expect(f.dropdown.open).toBe(true);
+    expect(f.item.checked).toBe(true);
+    expect(document.activeElement).toBe(f.item);
+    expect(count(f, "wa-after-hide")).toBe(0);
+    await userEvent.keyboard("{Escape}");
+    await closed(f);
+    expect(document.activeElement).toBe(f.trigger);
+  });
+
+  it.each(["before frame", "running", "zero duration"] as const)(
+    "settles rapid reversals without stale focus or completion (%s)",
+    async (timing) => {
+      const f = await fixture();
+      if (timing === "zero duration") {
+        f.dropdown.style.setProperty("--show-duration", "0ms");
+        f.dropdown.style.setProperty("--hide-duration", "0ms");
+      }
+      if (timing === "running") {
+        await duringAnimation(f, "show", () => {
+          f.dropdown.open = false;
+          f.outside.focus();
+        });
+      } else {
+        f.dropdown.open = true;
+        await f.dropdown.updateComplete;
+        f.dropdown.open = false;
+        f.outside.focus();
+      }
+      await closed(f);
+      expect(count(f, "wa-after-show")).toBe(0);
+      expect(document.activeElement).toBe(f.outside);
+      await open(f);
+      expect(document.activeElement).toBe(f.item);
+    },
+  );
+
+  it("keeps a canceled show closed and a subsequent accepted show functional", async () => {
+    const f = await fixture();
+    f.dropdown.addEventListener("wa-show", (event) => event.preventDefault(), { once: true });
+    f.dropdown.open = true;
+    await expect.poll(() => f.dropdown.open).toBe(false);
+    await frame();
+    expect(f.popup.active).toBe(false);
+    expect(count(f, "wa-after-show")).toBe(0);
+    await open(f);
+  });
+
+  it("preserves an active show when hide is canceled", async () => {
+    const f = await fixture();
+    f.dropdown.addEventListener("wa-hide", (event) => event.preventDefault(), { once: true });
+    await duringAnimation(f, "show", () => {
+      f.dropdown.open = false;
+    });
+    await expect.poll(() => count(f, "wa-after-show")).toBe(1);
+    expect(f.dropdown.open).toBe(true);
+    expect(count(f, "wa-after-hide")).toBe(0);
+  });
+
+  it("retains dismissal stack order when a hide is canceled below a popover", async () => {
+    const { userEvent } = await import("vitest/browser");
+    const f = await fixture();
+    await open(f);
+    const popover = document.createElement("wa-popover");
+    popover.textContent = "Additional details";
+    popover.anchor = f.item;
+    f.host.append(popover);
+    await popover.updateComplete;
+    popover.open = true;
+    await expect.poll(() => popover.open).toBe(true);
+    await popover.updateComplete;
+    f.dropdown.addEventListener("wa-hide", (event) => event.preventDefault(), { once: true });
+    f.dropdown.open = false;
+    await expect.poll(() => f.dropdown.open).toBe(true);
+    await userEvent.keyboard("{Escape}");
+    await expect.poll(() => popover.open).toBe(false);
+    expect(f.dropdown.open).toBe(true);
+    await userEvent.keyboard("{Escape}");
+    await closed(f);
+  });
+
+  it.each([
+    { dir: "ltr", openKey: "ArrowRight" },
+    { dir: "rtl", openKey: "ArrowLeft" },
+    { dir: "ltr", openKey: "Enter" },
+    { dir: "rtl", openKey: "Enter" },
+  ])(
+    "preserves canceled-hide submenus and $dir navigation via $openKey",
+    async ({ dir, openKey }) => {
+      const { userEvent } = await import("vitest/browser");
+      const f = await fixture();
+      f.dropdown.dir = dir;
+      await open(f);
+      await userEvent.keyboard("{ArrowDown}");
+      await userEvent.keyboard(`{${openKey}}`);
+      await expect.poll(() => document.activeElement).toBe(f.nested);
+      f.dropdown.addEventListener("wa-hide", (event) => event.preventDefault(), { once: true });
+      f.dropdown.open = false;
+      await expect.poll(() => f.dropdown.open).toBe(true);
+      expect(f.parent.submenuOpen).toBe(true);
+      await userEvent.keyboard(dir === "rtl" ? "{ArrowRight}" : "{ArrowLeft}");
+      await expect.poll(() => document.activeElement).toBe(f.parent);
+      expect(f.parent.submenuOpen).toBe(false);
+      await userEvent.keyboard(`{${openKey}}`);
+      await expect.poll(() => document.activeElement).toBe(f.nested);
+      const selected: Element[] = [];
+      f.dropdown.addEventListener("wa-select", (event: WaSelectEvent) =>
+        selected.push(event.detail.item),
+      );
+      await userEvent.keyboard("{Enter}");
+      await closed(f);
+      expect(selected).toHaveLength(1);
+      expect(selected[0]).toBe(f.nested);
+    },
+  );
+
+  it.each(["show", "hide", "reopen"] as const)(
+    "cleans up an interrupted %s across disconnect and remount",
+    async (phase) => {
+      const { userEvent } = await import("vitest/browser");
+      const f = await fixture();
+      if (phase !== "show") {
+        await open(f);
+      }
+      const disconnect = () =>
+        requestAnimationFrame(() => {
+          expect(
+            f.menu.getAnimations().some((animation) => animation.playState === "running"),
+          ).toBe(true);
+          if (phase === "reopen") {
+            f.dropdown.open = true;
+          }
+          f.dropdown.remove();
+        });
+      await duringAnimation(f, phase === "show" ? "show" : "hide", disconnect);
+      await expect.poll(() => f.dropdown.isConnected).toBe(false);
+      const completions = f.events.filter((event) => event.type.startsWith("wa-after"));
+      f.outside.focus();
+      await frame();
+      await frame();
+      await userEvent.keyboard("{ArrowDown}");
+      expect(document.activeElement).toBe(f.outside);
+      expect(f.events.filter((event) => event.type.startsWith("wa-after"))).toEqual(completions);
+      const sibling = await fixture();
+      await open(sibling);
+      expect(f.dropdown.open).toBe(phase !== "hide");
+      await userEvent.keyboard("{Escape}");
+      await closed(sibling);
+      const before = count(f, "wa-after-show");
+      f.dropdown.open = true;
+      f.host.prepend(f.dropdown);
+      await expect.poll(() => count(f, "wa-after-show")).toBe(before + 1);
+      expect(document.activeElement).toBe(f.item);
+      await userEvent.keyboard("{Escape}");
+      await closed(f);
+    },
+  );
+
+  it("registers an initially open dropdown after client upgrade", async () => {
+    const { userEvent } = await import("vitest/browser");
+    const f = await fixture(true);
+    await expect.poll(() => count(f, "wa-after-show")).toBe(1);
+    await userEvent.keyboard("{Escape}");
+    await closed(f);
+    expect(document.activeElement).toBe(f.trigger);
+  });
+});

--- a/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
@@ -390,7 +390,22 @@ suite.define(() => {
       expect(await gateway.getRequests("sessions.catalog.startTerminal")).toHaveLength(0);
       await composer.locator(".new-session-page__selection-status").click();
       await capabilityMenu.getByRole("menuitemcheckbox", { name: "Web search" }).click();
+      // A tooltip owns the first Escape only while a hint is actually open.
+      const openHints = page.locator("openclaw-tooltip[open]");
+      if (await openHints.count()) {
+        await page.keyboard.press("Escape");
+        await expect.poll(() => openHints.count()).toBe(0);
+        expect(await capabilityMenu.getAttribute("open")).not.toBeNull();
+      }
       await page.keyboard.press("Escape");
+      await expect.poll(() => capabilityMenu.getAttribute("open")).toBeNull();
+      await expect
+        .poll(() =>
+          composer
+            .getByRole("button", { name: "Add attachment" })
+            .evaluate((button) => button.matches(":focus")),
+        )
+        .toBe(true);
       await expect.poll(() => terminalTrigger.isEnabled()).toBe(true);
 
       if (captureCliAgentsProof) {


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/134997 — dropdowns stuck open after hide/reopen.
Related: https://github.com/openclaw/openclaw/issues/124364 — broader menu-surface standardization; not closed by this repair.

<details>
<summary>Additional instructions</summary>

This same-repository branch is editable by maintainers.

</details>

## What Problem This Solves

Reopening the Control UI capability dropdown during its hide animation could leave it visibly open without Escape/outside-pointer dismissal. The captured physical flow is Add attachment → Web search override → Escape → immediately reopen from the overrides pill → Escape with no tooltip.

CI also exposed connected ownership defects: a logically closed popup could still intercept clicks because its animation Promise never settled; stale submenu completion could hide a reopened submenu; and the intermediate refactor reversed an opening-event contract used to initialize keyboard focus in embedded appearance controls. These are repaired at the dependency owners, not hidden with caller timing workarounds.

Runtime failure was captured on Web Awesome 3.12.0. The original outer show/hide section matches 3.11 source, but no 3.11 runtime timing claim is made. The introducing release/commit is not established by that source comparison.

## Why This Change Was Made

The repair has three dependency-owned boundaries:

- **Dropdown visibility:** accepted-open membership, not animated `popup.active`, owns listeners and dismissible registration. An AbortController fences cleanup and stale completion. Reopen restores ownership immediately; Tab, disconnect and remount use the same lifecycle.
- **Submenu visibility/focus:** one reactive owner serializes cleanup and fences stale work. Public `openSubmenu()` / `closeSubmenu()` retain their `Promise<void>` and no-element/no-submenu contracts. Opening focus happens once when usable, not again after animation. The `submenu-opening` event retains upstream ordering before expanded state changes, so embedded controls recognize fresh openings without resetting custom-editor state on repeated setup.
- **CSS animation completion:** finite native `CSSAnimation.finished` promises settle completion and cancellation before `animationstart`; unrelated transitions/script effects cannot strand the request. A render frame lets Lit apply popup display styles, and an initial `getAnimations()` flushes pending class removal before reusing a keyframe name under the CSS Animations pending-style contract.

The maintainer explicitly approved this exact-version `@awesome.me/webawesome@3.12.0` patch. All twelve normal/CDN JavaScript/declaration outputs match the installed candidate, with native pnpm patch hashes and an exact approval-guard entry. No dependency version, public configuration, budget/baseline or compatibility fallback changes. Retire the patch once an upstream release containing the same repaired contracts passes the retained regressions.

Applied package production is **+302/-336 (net -34)**; including the repository guard, **+303/-336 (net -33)**. Typed upstream owners are **+156/-201 (net -45)**. Tests are **+632/-31 (net +601)**; the bounded Windows CI helper follow-through is **+22/-5 test-support lines (net +17)**. Lock/workspace metadata is separate; raw patch-container context and duplicate distributions are not all new runtime implementation.

Consumer guards, sleeps, double-Escape and broader mocks would conceal the owner defects. Another UI wrapper would duplicate policy. A version bump did not provide an existing fix at the inspected upstream revision. None was added; the existing appearance consumer remains unchanged.

### Bounded CI follow-through

Once every UI check passed, Windows CI exposed a pre-existing test-fixture shutdown defect. Synchronous `taskkill` could consume the outer wait deadline before Node could deliver exit/pipe-close observations. The helper now joins naturally exiting children before targeting a dead PID, then gives a successful Windows termination the existing close allowance. Held pipes and unverified termination remain failures. The timeout constants and POSIX deadline/escalation behavior are unchanged; there is no production Gateway, cron, heartbeat-environment or UI change in this follow-through.

Two deterministic regressions fail on the old helper and pass after repair, using its existing termination injection seam and a real event-loop turn. The retained CI log lacks taskkill timing/result and child/pipe facts, so it supports this failure pattern but does not uniquely prove that defect caused the individual failed run. The fresh native Windows CI run remains required.

## User Impact

Reopened dropdowns dismiss with Escape, outside pointer input and native Tab. A visible tooltip still consumes its Escape first. Reopened submenus stay visible, repeated public requests settle, keyboard selection is not reset by late focus, and closed menus stop intercepting later controls. Desktop appearance pickers initialize keyboard focus correctly while retaining custom-emoji editing and compact-menu behavior.

## Evidence

Final pushed head: `f4b33b4ecacfd0a8e962066ec908e46ed7009780`.
Final patch SHA-256: `bc34fe9e2ae30000725c1a8361518c2fd62712eb65d6e23db44abd9a9d5131ff`.

- **47 real Chromium browser cases passed** on the final installed patch: observed hide/reopen, Escape/pointer/Tab, tooltip precedence, rapid/zero-duration reversal, vetoed events, popover ordering, submenu LTR/RTL/Enter, pending-start cancellation, render readiness, public-method completion, notification ordering, early focus and disconnect/remount, plus modal/tooltip siblings.
- **48 unit cases passed:** eight patch-policy and 40 tooltip cases.
- **88 helper/process-lifecycle cases passed, one platform-specific case skipped**, including late Windows closure observations, naturally closing versus inherited pipes, unsuccessful termination, and the existing real POSIX child/group controls.
- **Nine selected application/observational cases passed:** sidebar/header/compact appearance keyboard flows, desktop/compact color editing, two appearance screenshot probes, and all three application flows that failed in the first CI run. The appearance keyboard cases cover custom emoji entry/application/back navigation, reset and Tab out, not merely initial focus.
- **Failing-before evidence:** the initial 18-case dropdown suite failed 14 cases on stock 3.12.0; five added CI regressions failed on the initial patch. Actual permission/group application replays captured a closed-but-active popup and pending animation Promise before repair. Both desktop appearance cases failed locally on the intermediate patch, while compact passed. The strengthened existing browser case independently failed with `['true']` rather than `['false']` at the opening notification.
- Fresh native owner compilation and all six declaration comparisons passed. All twelve installed outputs were byte-checked. The final ordering correction changes only the two dropdown-item JavaScript chunks; ten outputs are byte-identical to the preceding candidate.
- **Fresh complete-PR Codex autoreview:** scoped-clean at the configured P0 threshold, no accepted findings. The reviewer did not independently execute tests.
- **The final full classified changed gate passed**, including all selected type graphs, 94 npm lock checks, Knip, lint/boundaries/i18n and runtime import cycles.
- **[Exact-head CI33502849316 passed](https://github.com/openclaw/openclaw/actions/runs/33502849316)** on `f4b33b4ecacfd0a8e962066ec908e46ed7009780`, including Windows Node 22 and required `openclaw/ci-gate`. No required check was bypassed.

The first failed CI was [run 33486183794](https://github.com/openclaw/openclaw/actions/runs/33486183794). The second was [run 33497899699](https://github.com/openclaw/openclaw/actions/runs/33497899699), whose remaining failure identified the appearance opening-order regression. [Run 33499998309](https://github.com/openclaw/openclaw/actions/runs/33499998309) passed every UI check and failed only the Windows fixture teardown plus its aggregate gate. Those failures were investigated and repaired, not waived or rerun away.

Reproducible commands:

```bash
node scripts/run-vitest.mjs run --config ui/vitest.config.ts --configLoader runner --project browser --maxWorkers 1 ui/src/components/web-awesome-dropdown.browser.test.ts ui/src/components/modal-dialog.browser.test.ts ui/src/components/tooltip-title.browser.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/check-package-patches.test.ts ui/src/components/tooltip.test.ts
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-color.e2e.test.ts
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.places.e2e.test.ts ui/src/e2e/session-management.group-defaults.e2e.test.ts ui/src/e2e/sidebar-account-footer.e2e.test.ts -t "drafts a session with a browsed|starts a session from a group|keeps the feature account target"
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/helpers/openclaw-test-instance.test.ts test/scripts/managed-child-process.test.ts
```

```bash
node scripts/check-changed.mjs
```

**Local build exception, not a pass:** the final `pnpm ui:build` compiled and finalized 794 sidecars, then failed only startup gzip: **347445 B against 347353 B, 92 B over** on this original base. The maintainer explicitly requested “waive gate and land PR”; this waives the local size gate for the repair, not behavioral failures or required CI. No threshold/baseline was changed. Earlier 14-byte and 68-byte measurements are historical, not the final measurement or a new numeric allowance.

Immutable upstream 3.12 source: `03bc24f7e2409fcaaff1bec8b66c9b96949061d6`; inspected upstream `next`: `2dfbd2624f09ab38a2078335dd5ffbfdff619efa`. Dependency contract: [CSS Animations pending style changes](https://drafts.csswg.org/css-animations-2/#requirements-on-pending-style-changes).

### Before / after

The original before capture shows the capability menu still open after Escape. The repaired capture/clip show trusted-input hide/reopen, a subsequent no-tooltip Escape, inactive popup and restored Add attachment focus. That physical replay was recorded on the preceding candidate; the final correction leaves the dropdown/animation-helper outputs unchanged. The final installed candidate additionally has fresh appearance-focus before/after proof in the [follow-up comment](https://github.com/openclaw/openclaw/pull/135006#issuecomment-5491608360).

All captures were inspected and use synthetic Gateway fixture data. The Add attachment tooltip is caused by restored focus. The menu clip stops before the fixture's unsupported terminal-attachment step: no live provider or real attached-terminal claim. Firefox/WebKit and SSR hydration timing are not claimed.

![Before: original dropdown remains open after Escape](https://github.com/user-attachments/assets/4b432771-60cb-45ad-860e-b2127b3e2d8e)

![After: repaired dropdown closed with trigger focus](https://github.com/user-attachments/assets/faf17d9f-4b71-4f74-bec1-4fbe0d65f8b2)

https://github.com/user-attachments/assets/c02f65ce-175d-4d80-bd91-1441e8d24ce5

### Named follow-up

**Stale sibling-submenu keyboard context:** opening A, switching to sibling B, returning from B with ArrowLeft, then pressing ArrowDown can leave navigation on a closed branch because `openSubmenuStack` retains A. The same real-browser reproduction fails on pristine 3.12.0 and the repaired runtime; it is not introduced here. A separate task retains the reproduction and both logs. Native consumers include `app-sidebar-agent-menu.ts` and `session-diff-menus.ts` (source exposure, not app-specific reproduction). No unrelated stack-policy refactor was added to this repair.
