### PR TITLE
perf(infra): reuse the current process start identity

### DIFF
--- a/src/infra/file-lock-sync.ts
+++ b/src/infra/file-lock-sync.ts
@@ -4,12 +4,10 @@ import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
 import { acquireFileLockSync } from "./file-lock-manager.js";
 import { isLockOwnerDefinitelyStale } from "./stale-lock-file.js";
 
-let processStartTime: number | null | undefined;
-
 /** Synchronous lock for legacy stores that cannot transact in SQLite yet. */
 export function acquireFileLockSyncWithRetry(path: string): () => void {
   rejectUnsupportedLockPath(`${path}.lock`);
-  processStartTime ??= getFileLockProcessStartTime(process.pid);
+  const processStartTime = getFileLockProcessStartTime(process.pid);
   const createPayload = () => ({
     pid: process.pid,
     createdAt: new Date().toISOString(),

--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -94,16 +94,6 @@ function createLockPayload(params: {
   };
 }
 
-function mockProcStatRead(params: { onProcRead: () => string }) {
-  const readFileSync = fsSync.readFileSync;
-  return vi.spyOn(fsSync, "readFileSync").mockImplementation((filePath, encoding) => {
-    if (filePath === `/proc/${process.pid}/stat`) {
-      return params.onProcRead();
-    }
-    return readFileSync(filePath as never, encoding as never) as never;
-  });
-}
-
 async function writeLockFile(
   env: NodeJS.ProcessEnv,
   params: { startTime: number; createdAt?: string } = { startTime: 111 },
@@ -116,14 +106,6 @@ async function writeLockFile(
   });
   await fs.writeFile(lockPath, JSON.stringify(payload), "utf8");
   return { lockPath, configPath };
-}
-
-function createEaccesProcStatSpy() {
-  return mockProcStatRead({
-    onProcRead: () => {
-      throw new Error("EACCES");
-    },
-  });
 }
 
 function createPortProbeConnectionSpy(result: "connect" | "refused") {
@@ -601,18 +583,16 @@ describe("gateway lock", () => {
     const env = await makeEnv();
     const { stateLockPath } = resolveLockPath(env);
     await writeLockFile(env);
-    const spy = createEaccesProcStatSpy();
 
     const pending = acquireForTest(env, {
       timeoutMs: 15,
       staleMs: 10_000,
       platform: "linux",
+      readProcessStartTime: () => null,
       readProcessCmdline: () => null,
     });
     await expect(pending).rejects.toBeInstanceOf(GatewayLockError);
     await expect(fs.access(stateLockPath)).rejects.toMatchObject({ code: "ENOENT" });
-
-    spy.mockRestore();
   });
 
   it("keeps a verified maintenance owner when process start identity is unavailable", async () => {
@@ -631,26 +611,22 @@ describe("gateway lock", () => {
       ),
       "utf8",
     );
-    const spy = createEaccesProcStatSpy();
 
-    try {
-      await expect(
-        acquireForTest(env, {
-          timeoutMs: 15,
-          staleMs: 0,
-          platform: "linux",
-          readProcessCmdline: () => [
-            "node",
-            "/srv/openclaw/openclaw.mjs",
-            "doctor",
-            "--state-sqlite",
-            "compact",
-          ],
-        }),
-      ).rejects.toBeInstanceOf(GatewayLockError);
-    } finally {
-      spy.mockRestore();
-    }
+    await expect(
+      acquireForTest(env, {
+        timeoutMs: 15,
+        staleMs: 0,
+        platform: "linux",
+        readProcessStartTime: () => null,
+        readProcessCmdline: () => [
+          "node",
+          "/srv/openclaw/openclaw.mjs",
+          "doctor",
+          "--state-sqlite",
+          "compact",
+        ],
+      }),
+    ).rejects.toBeInstanceOf(GatewayLockError);
   });
 
   it("reclaims a maintenance lock when its live pid belongs to another process", async () => {
@@ -668,18 +644,14 @@ describe("gateway lock", () => {
       ),
       "utf8",
     );
-    const spy = createEaccesProcStatSpy();
 
-    try {
-      const lock = await acquireForTest(env, {
-        platform: "linux",
-        readProcessCmdline: () => ["node", "worker.js"],
-        timeoutMs: 80,
-      });
-      await expectGatewayLock(lock).release();
-    } finally {
-      spy.mockRestore();
-    }
+    const lock = await acquireForTest(env, {
+      platform: "linux",
+      readProcessStartTime: () => null,
+      readProcessCmdline: () => ["node", "worker.js"],
+      timeoutMs: 80,
+    });
+    await expectGatewayLock(lock).release();
   });
 
   it("reclaims a Windows maintenance lock when the pid creation time changed", async () => {
@@ -750,20 +722,16 @@ describe("gateway lock", () => {
       ),
       "utf8",
     );
-    const spy = createEaccesProcStatSpy();
 
-    try {
-      await expect(
-        acquireForTest(env, {
-          platform: "linux",
-          readProcessCmdline: () => null,
-          staleMs: 10_000,
-          timeoutMs: 15,
-        }),
-      ).rejects.toBeInstanceOf(GatewayLockError);
-    } finally {
-      spy.mockRestore();
-    }
+    await expect(
+      acquireForTest(env, {
+        platform: "linux",
+        readProcessStartTime: () => null,
+        readProcessCmdline: () => null,
+        staleMs: 10_000,
+        timeoutMs: 15,
+      }),
+    ).rejects.toBeInstanceOf(GatewayLockError);
   });
 
   it("keeps an old maintenance owner when its live identity is unreadable", async () => {
@@ -782,27 +750,22 @@ describe("gateway lock", () => {
       ),
       "utf8",
     );
-    const spy = createEaccesProcStatSpy();
 
-    try {
-      await expect(
-        acquireForTest(env, {
-          platform: "linux",
-          readProcessCmdline: () => null,
-          staleMs: 0,
-          timeoutMs: 80,
-        }),
-      ).rejects.toBeInstanceOf(GatewayLockError);
-    } finally {
-      spy.mockRestore();
-    }
+    await expect(
+      acquireForTest(env, {
+        platform: "linux",
+        readProcessStartTime: () => null,
+        readProcessCmdline: () => null,
+        staleMs: 0,
+        timeoutMs: 80,
+      }),
+    ).rejects.toBeInstanceOf(GatewayLockError);
   });
 
   it("keeps lock when fs.stat fails until payload is stale", async () => {
     vi.useRealTimers();
     const env = await makeEnv();
     await writeLockFile(env);
-    const procSpy = createEaccesProcStatSpy();
     const statSpy = vi
       .spyOn(fs, "stat")
       .mockRejectedValue(Object.assign(new Error("EPERM"), { code: "EPERM" }));
@@ -811,11 +774,11 @@ describe("gateway lock", () => {
       timeoutMs: 20,
       staleMs: 10_000,
       platform: "linux",
+      readProcessStartTime: () => null,
       readProcessCmdline: () => null,
     });
     await expect(pending).rejects.toBeInstanceOf(GatewayLockError);
 
-    procSpy.mockRestore();
     statSpy.mockRestore();
   });
 

--- a/src/shared/pid-alive.test.ts
+++ b/src/shared/pid-alive.test.ts
@@ -243,24 +243,51 @@ describe("process start times", () => {
     });
   });
 
-  it("reuses a successful Windows identity for the running process", () => {
-    readWindowsProcessStartTimeSyncMock.mockReturnValue(1_752_000_000_123);
+  it.each(["darwin", "linux", "win32"] as const)(
+    "retries failed self probes and keeps foreign %s identities fresh",
+    async (platform) => {
+      const identity = platform === "linux" ? 0 : 1_752_000_000;
+      const foreignPid = process.pid + 1;
+      const probe = vi
+        .fn<(pid: number) => number | null>()
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce(identity)
+        .mockReturnValueOnce(111)
+        .mockReturnValueOnce(222);
+      readWindowsProcessStartTimeSyncMock.mockImplementation(probe);
+      vi.spyOn(childProcess, "execFileSync").mockImplementation((_file, args) => {
+        const value = probe(Number(args?.[3]));
+        if (value === null) {
+          throw new Error("process start time unavailable");
+        }
+        return new Date(value * 1000).toUTCString();
+      });
+      const originalReadFileSync = fsSync.readFileSync;
+      vi.spyOn(fsSync, "readFileSync").mockImplementation((filePath, encoding) => {
+        const pid = /^\/proc\/(\d+)\/stat$/.exec(String(filePath))?.[1];
+        if (!pid) {
+          return originalReadFileSync(filePath as never, encoding as never) as never;
+        }
+        const value = probe(Number(pid));
+        return (
+          value === null ? "unavailable" : `${pid} (node) S ${"0 ".repeat(18)}${value}`
+        ) as never;
+      });
 
-    return withMockedPlatform("win32", async () => {
-      expect(getFileLockProcessStartTime(process.pid)).toBe(1_752_000_000_123);
-      expect(getFileLockProcessStartTime(process.pid)).toBe(1_752_000_000_123);
-      expect(readWindowsProcessStartTimeSyncMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("re-reads foreign Windows identities so PID reuse stays observable", () => {
-    readWindowsProcessStartTimeSyncMock.mockReturnValueOnce(111).mockReturnValueOnce(222);
-
-    return withMockedPlatform("win32", async () => {
-      expect(getFileLockProcessStartTime(42)).toBe(111);
-      expect(getFileLockProcessStartTime(42)).toBe(222);
-    });
-  });
+      await withMockedPlatform(platform, async () => {
+        // Each simulated platform needs a fresh module's process-lifetime state.
+        vi.resetModules();
+        const { getFileLockProcessStartTime: readIdentity } = await import("./pid-alive.js");
+        expect(readIdentity(process.pid)).toBeNull();
+        expect(readIdentity(process.pid)).toBe(identity);
+        expect(readIdentity(process.pid)).toBe(identity);
+        expect(readIdentity(foreignPid)).toBe(111);
+        expect(readIdentity(foreignPid)).toBe(222);
+        expect(readIdentity(process.pid)).toBe(identity);
+        expect(probe).toHaveBeenCalledTimes(4);
+      });
+    },
+  );
 
   it("fails closed when the Windows identity reader finds nothing", () => {
     readWindowsProcessStartTimeSyncMock.mockReturnValue(null);

--- a/src/shared/pid-alive.test.ts
+++ b/src/shared/pid-alive.test.ts
@@ -269,9 +269,10 @@ describe("process start times", () => {
           return originalReadFileSync(filePath as never, encoding as never) as never;
         }
         const value = probe(Number(pid));
-        return (
-          value === null ? "unavailable" : `${pid} (node) S ${"0 ".repeat(18)}${value}`
-        ) as never;
+        if (value === null) {
+          throw new Error("process start time unavailable");
+        }
+        return `${pid} (node) S ${"0 ".repeat(18)}${value}` as never;
       });
 
       await withMockedPlatform(platform, async () => {

--- a/src/shared/pid-alive.ts
+++ b/src/shared/pid-alive.ts
@@ -4,10 +4,9 @@ import fsSync from "node:fs";
 import { readWindowsProcessStartTimeSync } from "../infra/windows-process-start.ts";
 
 const PROCESS_START_TIMEOUT_MS = 1000;
-// Cron reads its own identity on every tick. Cache only a successful Windows
-// read: the identity cannot change while this process lives, and foreign PIDs
-// must stay live so PID reuse is still detected.
-let selfWindowsStartTime: number | null = null;
+// Cache only a successful self read: this identity lasts for the process.
+// Failed reads must retry, and foreign PIDs must stay fresh to detect PID reuse.
+let selfStartTime: number | null = null;
 
 function isValidPid(pid: number): boolean {
   return Number.isInteger(pid) && pid > 0;
@@ -109,19 +108,18 @@ export function getFileLockProcessStartTime(pid: number): number | null {
   if (!isValidPid(pid)) {
     return null;
   }
-  if (process.platform === "darwin") {
-    return getDarwinProcessStartTime(pid);
-  }
-  if (process.platform !== "win32") {
-    return getProcessStartTime(pid);
-  }
   const isSelf = pid === process.pid;
-  if (isSelf && selfWindowsStartTime !== null) {
-    return selfWindowsStartTime;
+  if (isSelf && selfStartTime !== null) {
+    return selfStartTime;
   }
-  const startTime = readWindowsProcessStartTimeSync(pid);
+  const startTime =
+    process.platform === "darwin"
+      ? getDarwinProcessStartTime(pid)
+      : process.platform === "win32"
+        ? readWindowsProcessStartTimeSync(pid)
+        : getProcessStartTime(pid);
   if (isSelf && startTime !== null) {
-    selfWindowsStartTime = startTime;
+    selfStartTime = startTime;
   }
   return startTime;
 }


### PR DESCRIPTION
## What Problem This Solves

Cron claims and agent database opens repeatedly probe their own process start identity. On macOS each probe launches `/bin/ps`, although that identity cannot change during the process lifetime. The synchronous file-lock caller also maintains a second successful-self cache.

## Why This Change Was Made

Extend the canonical reader's existing successful-self cache to macOS and Linux, and let synchronous file locking use that owner instead of a separate scalar. Invalid PIDs are still rejected first; unavailable reads still retry; a valid Linux zero remains cacheable. Foreign PIDs are always re-read, and the separate Linux runtime-state reader stays uncached.

This caches identity, not liveness or authority. Lease ownership, PID reuse, stale-lock policy, maintenance fences, and handoff claims still use their existing checks. The plugin SDK's separate first-result policy remains unchanged. No schema, persisted payload, configuration, timeout, or fallback changes.

Production: **+13/-17, net -4 lines**. Tests: **+87/-96, net -9**, consolidating the Windows-only self/foreign cases into one three-platform table. It covers failed-read retry, successful-self reuse including zero, fresh foreign reads, and self identity after those foreign reads. Each simulated platform gets a fresh module; no production test seam is added.

## User Impact

Less repeated synchronous process-discovery work during claims and database opens. Windows retains its existing successful-self behavior. No general Gateway startup, model-turn latency, Linux/Windows timing, or memory improvement is claimed.

## Evidence

The measured flows use both complete source owners at their canonical Vite IDs, actual SQLite/Kysely storage, public lease/open APIs, native macOS process probes, and a real foreign process. No extracted cache algorithm, replacement database, or historical dist is used. Four fixed before/candidate/candidate/before processes retain 352 measured blocks, 128 warmup blocks, 32 first blocks, and four standalone cold claims. Values below are per complete operation within the declared batch.

| Complete operation | Forward before → candidate, ms/op | Change | Reverse before → candidate, ms/op | Change |
| --- | ---: | ---: | ---: | ---: |
| Claim / readback / release, batch 1 | 2.522708 → 0.656833 | -73.96% | 2.736875 → 0.633791 | -76.84% |
| Claim / readback / release, batch 4 | 2.361250 → 0.625750 | -73.50% | 2.386062 → 0.622990 | -73.89% |
| Claim / readback / release, batch 16 | 2.156766 → 0.551396 | -74.43% | 2.221029 → 0.552594 | -75.12% |
| agent-open-close-1 | 15.947166 → 13.987792 | -12.29% | 16.255375 → 14.226000 | -12.48% |
| agent-open-close-4 | 15.815791 → 13.626781 | -13.84% | 15.964354 → 13.815490 | -13.46% |
| maintenance-empty-1 | 0.096708 → 0.100666 | +4.09% | 0.121208 → 0.108625 | -10.38% |
| maintenance-foreign-live-1 | 2.221333 → 2.243709 | +1.01% | 2.259208 → 2.292875 | +1.49% |
| maintenance-dead-owner-1 | 0.219833 → 0.238500 | +8.49% | 0.203792 → 0.204416 | +0.31% |

All five ordinary claim/open rows improved in both orders and passed the predeclared gain/cost gates. The empty-maintenance and foreign/dead-owner controls stay in the table: five adverse median pairs and five adverse first pairs are retained. The first forward agent open increased by 0.262 ms (+0.59%); empty reverse maintenance by 26.875 µs (+11%); forward dead-owner cleanup by 0.228376 ms (+3.29%). Standalone cold claims were 84.018→79.695 ms forward and 91.022→90.994 ms reverse. Later first-row blocks follow that initial claim, so they are not cold-process measurements.

Observed main-module Darwin start-time probes fell from 417 to 1 per timing child; 16 foreign identity probes remained fresh per child. This observer counts only exact Darwin `lstart` calls, not every process or filesystem operation. Each loaded module instance may read once; there is no cross-loader process-global guarantee. Reverse peak RSS was higher and all CPU/RSS/wall observations are retained without a memory claim.

Before/candidate correctness proofs agreed on eight complete-operation oracles, seven core observations, and five additional file-lock controls. Coverage includes first unknown identity followed by success, real live foreign owners, known mismatch cleanup, unknown foreign preservation, dead owners, self lease exclusion until release, path rejection before identity lookup, failed-read omission and retry, and proper file-lock release. Native timings have no injected faults. Both proofs and all four timing processes exited zero; owned PIDs, groups, runtimes and reserved coordinator files were independently confirmed removed.

Historical source capture remains `61763b06923071f1517c32b05243bddfa808a3d4`; measured execution was `85f41346fc9eb74490388e8dfb0ce1567a17f672`. The two changed owners match the current integration bytes exactly. Current common SQLite schema work was included symmetrically at that measured revision. This is selected source/toolchain pinning with canonical Vitest setup, not an OS sandbox or exhaustive dependency attestation. Independent raw reduction: `0f699658d122e8e43e4c65ad4f2a41899f9390d7ee37090e46e05223b9a0c216`; root numerical report: `9cc69bb270c27c8f736b27d3bdf072afbe8108d815324e2a19c742408ee3bcfe`.

Canonical baseline: 61 tests passed. The expanded test then failed on the old macOS/Linux owners at the expected repeated-self lookup, while Windows and the other 22 cases passed. With the production refactor, all 62 tests passed across PID identity/liveness, stale locks, cron receipts, retired database leases, and concurrent settings writes. The final strengthened three-platform table also passed all 24 focused tests.

```sh
node scripts/run-vitest.mjs src/shared/pid-alive.test.ts src/infra/stale-lock-file.test.ts src/agents/sessions/settings-storage.test.ts src/cron/store/run-receipt-store.test.ts src/cron/store/run-receipt-store.null-start-time.test.ts src/state/openclaw-agent-db-retired-lease-repair.test.ts --maxWorkers 1 --no-cache
```


The measured production integration is `0ce3af53d69d12a56353909c19dbec4b55850a5d`, rebased onto `2a920ab` to adopt the newly enforced merge-review workflow. All three changed files and the patch stayed byte-identical; historical benchmark and check receipts keep their original revisions. The rebased commit passed the same 62 canonical tests in 12.13 s. The full changed-file gate passed on the identical patch before rebase (254.77 s); a fresh managed Codex review of the rebased commit was scoped-clean for P0 defects. Independent source review covered lease, cron, lock, worker, handoff, Doctor and SDK callers.

Fresh `pnpm build` passed in 154.47 s, including UI asset budgets. Existing dependency declaration/eval warnings remain; they were not suppressed. A real OpenAI development Gateway built from this exact commit completed four turns: READY, Tool Search, exact file readback, and two sequential live fetches of the Node performance documentation in Markdown/text mode (both HTTP 200). Readiness was 3522.55 ms; turn wall times were 2266.54, 3288.24, 5585.77 and 9696.79 ms. Twelve session-list responses plus five event/status RPCs succeeded. Read-only SQLite inspection verified all 27 transcript rows, their parent chain, and six paired tool calls/results.

The full 12,356-file dist manifest matched before, after and during independent readback. Native Node profiles retained the main thread's 17,521 samples over 25,130.588 ms and the worker's 11 samples over 21.567 ms separately. Most main-thread time was idle; this is integration evidence, not a controlled whole-Gateway performance or memory claim. The conservative generic `tool_call` replay-invalid marker remained on read/web turns; no retry, fallback or compaction was invoked. The owned Gateway PID/group exited zero, its listener closed, and the temporary config, last-good config and key FIFO were removed. Root live readback: `e72cea94607727876fa643881395271eb9b801747d1911e31c136e857e837be5`.

The cache contract was also checked directly against [Apple's process start-time initialization](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/kern/kern_fork.c#L1058), [Darwin ps lstart formatting](https://github.com/apple-oss-distributions/adv_cmds/blob/main/ps/print.c#L649), [Linux proc start-time production](https://github.com/torvalds/linux/blob/master/fs/proc/array.c#L552), and [Windows' fixed, read-only CreationDate property](https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-process#properties). These are upstream contract checks, not Linux/Windows runtime measurements. The existing supported process environment remains fixed; replacing procfs/time namespaces within a running process is not a new supported contract.


The first Linux CI run, [33486350749](https://github.com/openclaw/openclaw/actions/runs/33486350749), exposed five existing Gateway-lock fixtures that paired the real process PID with synthetic start time `111`, then mocked procfs failure after an earlier case had populated the valid self cache. The owner correctly observed a known identity mismatch, so the fixtures no longer exercised their stated unavailable-identity branch. A sixth passing maintenance fixture also took the wrong branch.

Follow-up commit `ac4a5d555bbcb27c53819d5d875ba6f10906e94b` supplies `readProcessStartTime: () => null` through the existing Gateway-lock owner interface in all six cases and removes the obsolete lower-level filesystem spies. The existing Linux reader lifecycle test now throws a real read error for its first unavailable probe; the separate malformed-stat tests remain. Production bytes, all test cases, assertions, timeouts and stale thresholds are unchanged. This follow-up removes 36 test lines; it does not add cache invalidation or a test-only production seam.

All 42 Gateway-lock tests ran in their full files and original order, together with all 24 process-identity tests (66 passed, 3.84 s) on macOS. The changed-file gate passed in 91.60 s, and the follow-up received a fresh scoped-clean Codex P0 review. Fresh Linux CI on the new head is still required before merge; local simulated-platform tests are not presented as Linux runtime proof. The earlier build and real Gateway run attest unchanged production bytes, not the revised Linux fixtures.

```sh
node scripts/run-vitest.mjs src/infra/gateway-lock.test.ts src/infra/gateway-lock.roles.test.ts src/infra/gateway-lock.state-dir.test.ts src/shared/pid-alive.test.ts --maxWorkers 1 --no-cache
pnpm check:changed -- src/infra/gateway-lock.test.ts src/shared/pid-alive.test.ts
```

Named follow-up: two inherited test titles still mention stale-age behavior that their current live-PID scenarios do not reach. The retained `fs.stat` failure mock is not claimed as ownerless stat-error coverage; that separate fixture audit is recorded rather than silently weakening or deleting assertions here.
