### PR TITLE
fix(ui): remove duplicate OpenClaw shortcut from Inbox

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -186,7 +186,7 @@ When your connection is bound to an authenticated Gateway profile, theme, theme 
 
 ## OpenClaw system care
 
-Open **Settings → Ask OpenClaw** to talk to the system setup and repair agent. Toggle it from anywhere with the lobster button in the sidebar footer or the **Ask OpenClaw** command-palette action. The full page and dockable panel share one machine-wide conversation whose durable history lives on the Gateway. Closing the UI never cancels a turn; reopening Ask OpenClaw shows the completed conversation. The panel docks on the right or bottom, remembers its placement and size in the browser profile, and hides itself while the full page is open.
+Open **Settings → Ask OpenClaw** to talk to the system setup and repair agent. To open it alongside your current page, click **Home** in the sidebar footer and select the **Ask OpenClaw** tab, or use the **Ask OpenClaw** command-palette action. The full page and dockable panel share one machine-wide conversation whose durable history lives on the Gateway. Closing the UI never cancels a turn; reopening Ask OpenClaw shows the completed conversation. The panel docks on the right or bottom, remembers its placement and size in the browser profile, and hides itself while the full page is open.
 
 If no AI provider is configured, Ask OpenClaw offers **Connect an AI provider**. If a configured runtime fails to start or verify, the conversation stays visible with the actual error and **Retry**. Sending stays disabled until verification succeeds. Retry checks the runtime without resending your earlier message or clearing your draft.
 

--- a/ui/src/components/sidebar-attention-panel.runtime.ts
+++ b/ui/src/components/sidebar-attention-panel.runtime.ts
@@ -18,7 +18,6 @@ import {
 } from "./sidebar-attention-entries.ts";
 import {
   renderSidebarApprovalItem,
-  renderSidebarAskOpenClawButton,
   renderSidebarIssueItem,
   renderSidebarScopeUpgradeItem,
   renderSidebarUpdateSurface,
@@ -66,14 +65,6 @@ export function renderSidebarAttentionPanel(params: SidebarAttentionPanelParams)
   );
   const hasVisibleDismissals = visibleDismissals.length > 0;
   const tabCounts = sidebarInboxTabCounts(params.entries);
-  const custodianItems = params.entries.filter(
-    (entry) => entry.type === "attention" && entry.action.kind === "askCustodian",
-  );
-  const custodianSeverity = custodianItems.some((item) => item.severity === "error")
-    ? "error"
-    : custodianItems.length
-      ? "warning"
-      : null;
   const renderEntry = (entry: SidebarInboxEntry) => {
     const dismissal = entry.dismissal;
     const onDismiss = dismissal ? () => params.onDismiss(dismissal) : undefined;
@@ -151,11 +142,6 @@ export function renderSidebarAttentionPanel(params: SidebarAttentionPanelParams)
             >
               ${t("attention.dismissShown")}
             </button>
-            ${renderSidebarAskOpenClawButton({
-              count: custodianItems.length,
-              severity: custodianSeverity,
-              snapshot: params.context.gateway.snapshot,
-            })}
             <button
               type="button"
               class="sidebar-brand__icon sidebar-issues-panel__mobile-close"

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../test-helpers/application-context.ts";
 import { createStorageMock as createTestStorageMock } from "../test-helpers/storage.ts";
 import { waitForFast } from "../test-helpers/wait-for.ts";
+import { CUSTODIAN_PANEL_TOGGLE_EVENT } from "./panel-toggle-contract.ts";
 import {
   dismissSidebarAttention,
   dismissalStoreKey,
@@ -552,7 +553,7 @@ describe("sidebar attention refresh ownership", () => {
         { enabled: true, triggersEnabled: true, jobs: 1 },
         { enabled: true, triggersEnabled: true, jobs: 0 },
       ],
-      "models.authStatus": [{ ts: 1, providers: [] }],
+      "models.authStatus": [authStatus(1)],
     };
     const request = vi.fn((method: keyof typeof responses) => {
       const response = responses[method].shift();
@@ -565,7 +566,10 @@ describe("sidebar attention refresh ownership", () => {
     const snapshot = {
       client,
       phase: "connected",
-      hello: null,
+      hello: {
+        auth: { role: "operator", scopes: ["operator.admin"] },
+        features: { methods: ["openclaw.chat"] },
+      },
       assistantAgentId: "main",
       sessionKey: "agent:main:main",
       lastError: null,
@@ -628,6 +632,33 @@ describe("sidebar attention refresh ownership", () => {
     expect(panel.style.top).toBe("50px");
     expect(panel.style.bottom).toBe("");
     expect(panel.style.getPropertyValue("--sidebar-issues-panel-top")).toBe("50px");
+    expect(
+      Array.from(
+        panel.querySelectorAll("header button"),
+        (button) => button.getAttribute("aria-label") ?? button.textContent,
+      ).some((label) => label?.includes("Ask OpenClaw")),
+    ).toBe(false);
+
+    const { custodianAlertStore } = await import("../pages/custodian/custodian-alert-store.ts");
+    const dispatch = vi.spyOn(window, "dispatchEvent");
+    try {
+      const alertAction = panel.querySelector<HTMLButtonElement>(
+        '[data-attention-kind="modelAuthExpired"] .sidebar-issues-panel__action:not(.sidebar-issues-panel__action--primary)',
+      )!;
+      expect(alertAction.textContent?.trim()).toBe("Ask OpenClaw");
+      alertAction.click();
+      await waitForFast(() =>
+        expect(dispatch).toHaveBeenCalledWith(
+          expect.objectContaining({ type: CUSTODIAN_PANEL_TOGGLE_EVENT, detail: { open: true } }),
+        ),
+      );
+      expect(custodianAlertStore.alert?.id).toBe("modelAuthExpired:agent:main\nopenai");
+      expect(element.querySelector(".sidebar-issues-panel")).toBeNull();
+    } finally {
+      custodianAlertStore.dismiss();
+    }
+    trigger.click();
+    await waitForFast(() => expect(element.querySelector(".sidebar-issues-panel")).not.toBeNull());
 
     eventListener?.({ type: "event", event: "cron", payload: {} });
     await waitForFast(() =>

--- a/ui/src/components/sidebar-issue-item.ts
+++ b/ui/src/components/sidebar-issue-item.ts
@@ -12,7 +12,6 @@ import { sessionNavigationTarget } from "../lib/sessions/route-navigation.ts";
 import { areUiSessionKeysEquivalent } from "../lib/sessions/session-key.ts";
 import { renderSidebarApprovalRow } from "./exec-approval-card.ts";
 import { icons } from "./icons.ts";
-import { CUSTODIAN_PANEL_TOGGLE_EVENT } from "./panel-toggle-contract.ts";
 import type { SidebarAttentionItem } from "./sidebar-attention-entries.ts";
 import "./sidebar-update-card.ts";
 
@@ -41,40 +40,6 @@ function renderSidebarDismissButton(itemLabel: string, onDismiss?: () => void) {
   >
     ${icons.x}
   </button>`;
-}
-
-export function renderSidebarAskOpenClawButton(params: {
-  count: number;
-  severity: "error" | "warning" | null;
-  snapshot: ApplicationContext["gateway"]["snapshot"] | undefined;
-}) {
-  if (!canCallGatewayMethod(params.snapshot, "openclaw.chat", "operator.admin")) {
-    return nothing;
-  }
-  const label = params.count
-    ? t(params.count === 1 ? "attention.custodianAlertAria" : "attention.custodianAlertsAria", {
-        count: String(params.count),
-      })
-    : t("nav.askOpenClaw");
-  return html`<openclaw-tooltip .content=${label}>
-    <button
-      type="button"
-      class="sidebar-brand__icon sidebar-footer-bar__custodian sidebar-issues-panel__ask"
-      aria-label=${label}
-      @click=${() => window.dispatchEvent(new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT))}
-    >
-      <span class="sidebar-footer-bar__custodian-glyph">
-        ${icons.lobster}
-        ${params.count
-          ? html`<span
-              class="session-glyph__badge sidebar-footer-bar__custodian-badge sidebar-footer-bar__custodian-badge--${params.severity ??
-              "warning"}"
-              aria-hidden="true"
-            ></span>`
-          : nothing}
-      </span>
-    </button>
-  </openclaw-tooltip>`;
 }
 
 export function renderSidebarApprovalItem(params: {

--- a/ui/src/e2e/custodian-panel-toggle.e2e.test.ts
+++ b/ui/src/e2e/custodian-panel-toggle.e2e.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
+  controlUiSessionUrl,
   installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
@@ -22,13 +23,22 @@ beforeEach(() => {
 
 const CUSTODIAN_SESSION_STORAGE_KEY = "openclaw.custodian.session.v1";
 const MOCK_SESSION_ID = "e2e-custodian-panel";
+const WORK_SESSION_KEY = "agent:main:work";
 
 let browser: Browser;
 let server: ControlUiE2eServer;
 
 function custodianGatewayScenario() {
   return {
-    featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat", "openclaw.chat.history"],
+    sessionKey: WORK_SESSION_KEY,
+    featureMethods: [
+      "chat.metadata",
+      "chat.startup",
+      "chat.history",
+      "chat.send",
+      "openclaw.chat",
+      "openclaw.chat.history",
+    ],
     methodResponses: {
       "openclaw.chat": {
         sessionId: MOCK_SESSION_ID,
@@ -59,7 +69,7 @@ describeControlUiE2e("Control UI Ask OpenClaw panel toggle mocked Gateway E2E", 
     await server?.close();
   });
 
-  it("hides the sidebar footer toggle when openclaw.chat is not advertised", async () => {
+  it("keeps Home available without an OpenClaw tab when openclaw.chat is not advertised", async () => {
     const context = await browser.newContext({
       colorScheme: "dark",
       locale: "en-US",
@@ -67,24 +77,33 @@ describeControlUiE2e("Control UI Ask OpenClaw panel toggle mocked Gateway E2E", 
       viewport: { height: 900, width: 1280 },
     });
     const page = await context.newPage();
-    await installMockGateway(page, { featureMethods: ["chat.metadata", "chat.startup"] });
+    const gateway = await installMockGateway(page, {
+      sessionKey: WORK_SESSION_KEY,
+      featureMethods: ["chat.metadata", "chat.startup", "chat.history", "chat.send"],
+    });
 
     try {
-      const response = await page.goto(`${server.baseUrl}chat`);
+      const response = await page.goto(controlUiSessionUrl(server.baseUrl, WORK_SESSION_KEY));
       expect(response?.status()).toBe(200);
       await page.locator(".shell-chrome-controls__search").waitFor();
       await page.locator(".sidebar-identity-card").waitFor();
-      await expect.poll(() => page.locator(".sidebar-footer-bar__custodian").count()).toBe(0);
+      await page.locator(".sidebar-footer-bar__home").click();
+      const panel = page.locator("openclaw-assistant-panel");
+      await panel.getByRole("button", { name: "Home", exact: true }).waitFor();
+      expect(await panel.getByRole("button", { name: "Ask OpenClaw", exact: true }).count()).toBe(
+        0,
+      );
+      expect(await gateway.getRequests("openclaw.chat")).toHaveLength(0);
       await page.screenshot({
         animations: "disabled",
-        path: path.join(artifactDir, "00-gated-off-no-button.png"),
+        path: path.join(artifactDir, "00-home-without-openclaw-tab.png"),
       });
     } finally {
       await context.close();
     }
   });
 
-  it("toggles the panel from the sidebar and palette and reuses the persisted session id", async () => {
+  it("opens OpenClaw from Home and the palette and reuses the persisted session id", async () => {
     const context = await browser.newContext({
       colorScheme: "dark",
       locale: "en-US",
@@ -96,22 +115,20 @@ describeControlUiE2e("Control UI Ask OpenClaw panel toggle mocked Gateway E2E", 
     const gateway = await installMockGateway(page, custodianGatewayScenario());
 
     try {
-      const response = await page.goto(`${server.baseUrl}chat`);
+      const response = await page.goto(controlUiSessionUrl(server.baseUrl, WORK_SESSION_KEY));
       expect(response?.status()).toBe(200);
 
-      // Ask OpenClaw lives in the Inbox header and renders only while
-      // openclaw.chat is advertised.
-      await page.locator(".sidebar-issues-button").click();
-      const footerToggle = page.locator(".sidebar-issues-panel__ask");
-      await footerToggle.waitFor();
+      await page.locator(".sidebar-footer-bar__home").click();
+      const panel = page.locator("openclaw-assistant-panel");
+      const openClawTab = panel.getByRole("button", { name: "Ask OpenClaw", exact: true });
+      await openClawTab.waitFor();
       await page.screenshot({
         animations: "disabled",
-        path: path.join(artifactDir, "01-sidebar-footer-button.png"),
+        path: path.join(artifactDir, "01-home-dock.png"),
       });
 
       // Opening the panel renders the durable machine-wide history from the Gateway.
-      await footerToggle.click();
-      const panel = page.locator("openclaw-assistant-panel");
+      await openClawTab.click();
       await panel.getByText("Channel repaired.").waitFor();
       const chatRequest = await gateway.waitForRequest("openclaw.chat");
       const firstSessionId = (chatRequest.params as { sessionId?: string }).sessionId;
@@ -121,26 +138,19 @@ describeControlUiE2e("Control UI Ask OpenClaw panel toggle mocked Gateway E2E", 
         path: path.join(artifactDir, "02-panel-open-history.png"),
       });
 
-      // The same Inbox action closes it again.
-      await footerToggle.click();
+      await panel.getByRole("button", { name: "Close assistant sidebar", exact: true }).click();
       await panel.getByText("Channel repaired.").waitFor({ state: "hidden" });
 
-      // The command palette exposes the same toggle from anywhere. Its action
-      // dispatches the identical toggle event the Inbox action uses (pinned by
-      // the palette unit test), so this asserts the gated entry exists and
-      // reopens through the Inbox path — the palette click-through composition
-      // proved timing-flaky on loaded CI runners without adding coverage.
+      // The command palette opens the same conversation directly.
       await page.locator(".shell-chrome-controls__search").click();
       await page.getByPlaceholder("Search chats and commands…").fill("Ask OpenClaw");
-      const paletteItem = page.locator(".cmd-palette__item--active", { hasText: "Ask OpenClaw" });
+      const paletteItem = page.getByRole("option", { name: "Ask OpenClaw", exact: true });
       await paletteItem.waitFor();
       await page.screenshot({
         animations: "disabled",
         path: path.join(artifactDir, "03-palette-item.png"),
       });
-      await page.keyboard.press("Escape");
-      await page.locator(".sidebar-issues-button").click();
-      await page.locator(".sidebar-issues-panel__ask").click();
+      await paletteItem.click();
       await panel.getByText("Channel repaired.").waitFor();
 
       // The server-confirmed session id persists and is reused after a full reload.

--- a/ui/src/e2e/inference-setup-gate.e2e.test.ts
+++ b/ui/src/e2e/inference-setup-gate.e2e.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   createNewSessionPageE2eSuite,
+  controlUiSessionUrl,
   installMockGateway,
 } from "./new-session-page.test-support.ts";
 
@@ -144,8 +145,16 @@ suite.define(() => {
       const runtimeError =
         "OpenClaw requires working inference: The configured runtime could not start. Repair the launcher and retry.";
       const gateway = await installMockGateway(page, {
+        sessionKey: "agent:main:work",
         deferredMethods: ["openclaw.chat"],
-        featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat", "openclaw.chat.history"],
+        featureMethods: [
+          "chat.metadata",
+          "chat.startup",
+          "chat.history",
+          "chat.send",
+          "openclaw.chat",
+          "openclaw.chat.history",
+        ],
         methodResponses: {
           "openclaw.chat.history": {
             turns: [
@@ -160,10 +169,17 @@ suite.define(() => {
       });
 
       try {
-        await page.goto(`${suite.server.baseUrl}${surface === "page" ? "custodian" : "chat"}`);
+        await page.goto(
+          surface === "page"
+            ? `${suite.server.baseUrl}custodian`
+            : controlUiSessionUrl(suite.server.baseUrl, "agent:main:work"),
+        );
         if (surface === "panel") {
-          await page.locator(".sidebar-issues-button").click();
-          await page.locator(".sidebar-issues-panel__ask").click();
+          await page.locator(".sidebar-footer-bar__home").click();
+          await page
+            .locator("openclaw-assistant-panel")
+            .getByRole("button", { name: "Ask OpenClaw", exact: true })
+            .click();
         }
         const chat = page.locator("openclaw-custodian-surface");
         await gateway.waitForRequest("openclaw.chat");

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4508,8 +4508,6 @@ export const en: TranslationMap = {
     },
   },
   attention: {
-    custodianAlertAria: "Ask OpenClaw, {count} undismissed alert",
-    custodianAlertsAria: "Ask OpenClaw, {count} undismissed alerts",
     cronErrorUnknown: "Unknown error",
     cronFailed: "{job} failed",
     cronOverdue: "{job} overdue",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1075,27 +1075,15 @@ openclaw-settings-save-indicator:empty {
   stroke-linejoin: round;
 }
 
-.sidebar-brand__new-thread,
-.sidebar-footer-bar__custodian {
+.sidebar-brand__new-thread {
   width: 32px;
   height: 32px;
   color: var(--text);
 }
 
-.sidebar-brand__new-thread svg,
-.sidebar-footer-bar__custodian svg {
+.sidebar-brand__new-thread svg {
   width: 18px;
   height: 18px;
-}
-
-.sidebar-footer-bar__custodian-glyph {
-  position: relative;
-  display: inline-flex;
-}
-
-.sidebar-footer-bar__custodian-badge--warning,
-.sidebar-footer-bar__custodian-badge--error {
-  color: var(--inbox-attention);
 }
 
 .sidebar-shell__content {

--- a/ui/src/styles/sidebar-issues.css
+++ b/ui/src/styles/sidebar-issues.css
@@ -118,15 +118,6 @@
   min-height: 28px;
 }
 
-.sidebar-issues-panel__ask {
-  flex: 0 0 32px;
-}
-
-.sidebar-issues-panel__ask svg {
-  width: 20px;
-  height: 20px;
-}
-
 .sidebar-issues-panel__mobile-close {
   display: none;
 }
@@ -144,29 +135,6 @@
 
 .shell--mobile-nav .sidebar-issues-panel__mobile-close:active {
   transform: scale(0.97);
-}
-
-.shell--mobile-nav .sidebar-issues-panel__ask {
-  position: absolute;
-  z-index: 3;
-  inset-inline-end: 12px;
-  inset-block-end: calc(12px + env(safe-area-inset-bottom, 0px));
-  width: 40px;
-  height: 40px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-full);
-  background: var(--bg-elevated);
-  box-shadow: var(--shadow-sm);
-}
-
-.shell--mobile-nav .sidebar-issues-panel__ask:hover,
-.shell--mobile-nav .sidebar-issues-panel__ask:focus-visible {
-  background: var(--bg-hover);
-}
-
-.shell--mobile-nav .sidebar-issues-panel__list {
-  padding-block-end: 58px;
-  scroll-padding-block-end: 58px;
 }
 
 .shell--mobile-nav .sidebar-issues-panel__dismiss {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Control UI offered two global shortcuts to OpenClaw: the Home dock already hosts both the selected agent and Ask OpenClaw, but Inbox still displayed the older lobster shortcut. On mobile, that duplicate floated over the bottom of the Inbox sheet.

## Why This Change Was Made

Use the existing Home dock as the shared conversation entry point instead of retaining a second generic entry in Inbox. Remove the obsolete Inbox renderer, alert-badge aggregation, English labels, icon styles, and mobile space reserved for that button. Preserve issue-specific **Ask OpenClaw** actions and their alert context, Inbox counts/tabs/dismissals, the Home dock, and the command-palette action. Update the navigation documentation and migrate older end-to-end tests to the actual Home → Ask OpenClaw flow.

Production LOC: **+2/−97 (net −95)**. Tests: **+90/−33 (net +57)**. Documentation: +1/−1.

## User Impact

Inbox has one fewer redundant control on desktop and mobile. Home still opens the selected agent and OpenClaw, and individual issues can still open OpenClaw with their diagnostic context. No configuration, persistence, protocol, or Gateway behavior changes.

## Evidence

The attached before/after screenshots were captured from the running Control UI with the same deterministic mocked Gateway scenario. Before uses the original source at `36b18316eb5023ded9bc1669e33f47a9c8424abd`; after uses the verified candidate. Desktop and mobile each show one old Inbox shortcut before and zero after, with Home retained. All four captures were inspected and contain only synthetic data.

The new Inbox-header regression failed on the original production code (`expected true to be false`; 34 passed, 1 failed), then passed after removal. It also verifies that the issue-specific Ask OpenClaw action still opens the dock with the correct alert.

Focused unit tests: **49 passed**.

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/components/sidebar-attention.test.ts ui/src/components/sidebar-issue-item.test.ts ui/src/components/assistant-panel.test.ts
```

Browser tests: **9 passed**, covering Home/OpenClaw and palette flows, durable conversation restoration, inference failure/retry behavior, and the mobile Inbox sheet in light/dark and reduced-motion modes.

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/custodian-panel-toggle.e2e.test.ts ui/src/e2e/inference-setup-gate.e2e.test.ts ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
```

Codex autoreview of the exact patch completed with no accepted/actionable findings in its selected P0 scope. The Control UI production build passed with `pnpm ui:build` (3,138 modules). Scoped oxlint, stylelint, formatting, i18n verification, and core/UI type checks passed. Desktop interaction verified Home → Ask OpenClaw and issue-specific alert handoff. Mobile screenshot assertions verified removal of the obsolete 58px button clearance.

Local full `check:changed` was stopped during its lengthy full-tree Knip scan; it is **not** claimed as passed. Remaining scoped lint steps were run separately and passed. Exact-head hosted CI and repository-native prepare/merge gates remain required before landing.

![Desktop before: duplicate OpenClaw shortcut in Inbox](https://github.com/user-attachments/assets/fe2074bd-5d2d-49d6-9e71-a850a6c05aa3)

![Desktop after: duplicate Inbox shortcut removed, Home retained](https://github.com/user-attachments/assets/8b045141-aaee-4867-b9a7-6cbf7f654d06)

![Mobile before: floating duplicate OpenClaw button](https://github.com/user-attachments/assets/7ba025b5-c98e-4a92-9b1f-468e851c373d)

![Mobile after: duplicate button and reserved spacing removed](https://github.com/user-attachments/assets/7a021108-377d-493f-b859-02fcc1a52403)