### PR TITLE
refactor(matrix): remove runtime getter aliases

### DIFF
--- a/extensions/matrix/src/matrix/send/chunking.ts
+++ b/extensions/matrix/src/matrix/send/chunking.ts
@@ -36,8 +36,6 @@ type MatrixPreparedChunkedText = MatrixPreparedSingleText & {
   chunks: string[];
 };
 
-const getCore = () => getMatrixRuntime();
-
 function normalizeMatrixEventLimit(limit: number): number {
   if (!Number.isFinite(limit) || limit <= 0) {
     return limit;
@@ -182,7 +180,7 @@ export function prepareMatrixSingleText(
   const cfg = requireRuntimeConfig(opts.cfg, "Matrix text preparation") as CoreConfig;
   const tableMode =
     opts.tableMode ??
-    getCore().channel.text.resolveMarkdownTableMode({
+    getMatrixRuntime().channel.text.resolveMarkdownTableMode({
       cfg,
       channel: "matrix",
       accountId: opts.accountId,
@@ -191,7 +189,7 @@ export function prepareMatrixSingleText(
   const convertedText = renderMatrixMarkdownTables(trimmedText, tableMode);
   const singleEventLimit = normalizeMatrixEventLimit(
     Math.min(
-      getCore().channel.text.resolveTextChunkLimit(cfg, "matrix", opts.accountId),
+      getMatrixRuntime().channel.text.resolveTextChunkLimit(cfg, "matrix", opts.accountId),
       MATRIX_FORMAT_PROFILE.chunk.limit,
     ),
   );
@@ -225,7 +223,7 @@ export function chunkMatrixText(
     };
   }
   const cfg = requireRuntimeConfig(opts.cfg, "Matrix text chunking") as CoreConfig;
-  const chunkMode = getCore().channel.text.resolveChunkMode(cfg, "matrix", opts.accountId);
+  const chunkMode = getMatrixRuntime().channel.text.resolveChunkMode(cfg, "matrix", opts.accountId);
   const collisionRedacted = hasMatrixSpoilerMetadataCollision(preparedText.convertedText)
     ? markdownToMatrixBody(preparedText.convertedText)
     : undefined;
@@ -242,7 +240,7 @@ export function chunkMatrixText(
     );
     let reserve = wrapperReserve;
     while (reserve < preparedText.singleEventLimit) {
-      const protectedChunks = getCore().channel.text.chunkMarkdownTextWithMode(
+      const protectedChunks = getMatrixRuntime().channel.text.chunkMarkdownTextWithMode(
         protectedSpoilers.markdown,
         preparedText.singleEventLimit - reserve,
         chunkMode,

--- a/extensions/matrix/src/matrix/send/formatting.ts
+++ b/extensions/matrix/src/matrix/send/formatting.ts
@@ -22,8 +22,6 @@ import {
   type MatrixThreadRelation,
 } from "./types.js";
 
-const getCore = () => getMatrixRuntime();
-
 async function renderMatrixFormattedContent(params: {
   client: MatrixClient;
   markdown?: string | null;
@@ -169,7 +167,7 @@ export function buildThreadRelation(threadId: string, replyToId?: string): Matri
 }
 
 export function resolveMatrixMsgType(contentType?: string, _fileName?: string): MatrixMediaMsgType {
-  const kind = getCore().media.mediaKindFromMime(contentType ?? "");
+  const kind = getMatrixRuntime().media.mediaKindFromMime(contentType ?? "");
   switch (kind) {
     case "image":
       return MsgType.Image;

--- a/extensions/matrix/src/matrix/send/media.ts
+++ b/extensions/matrix/src/matrix/send/media.ts
@@ -17,8 +17,6 @@ import type {
   MatrixRelation,
 } from "./types.js";
 
-const getCore = () => getMatrixRuntime();
-
 function buildMatrixMediaInfo(params: {
   size: number;
   mimetype?: string;
@@ -172,7 +170,7 @@ export async function prepareImageInfo(params: {
   client: MatrixClient;
   roomId: string;
 }): Promise<DimensionalFileInfo | undefined> {
-  const meta = await getCore()
+  const meta = await getMatrixRuntime()
     .media.getImageMetadata(params.buffer)
     .catch(() => null);
   if (!meta) {
@@ -182,13 +180,13 @@ export async function prepareImageInfo(params: {
   const maxDim = Math.max(meta.width, meta.height);
   if (maxDim > THUMBNAIL_MAX_SIDE) {
     try {
-      const thumbBuffer = await getCore().media.resizeToJpeg({
+      const thumbBuffer = await getMatrixRuntime().media.resizeToJpeg({
         buffer: params.buffer,
         maxSide: THUMBNAIL_MAX_SIDE,
         quality: THUMBNAIL_QUALITY,
         withoutEnlargement: true,
       });
-      const thumbMeta = await getCore()
+      const thumbMeta = await getMatrixRuntime()
         .media.getImageMetadata(thumbBuffer)
         .catch(() => null);
       const result = await uploadMediaWithEncryption(params.client, params.roomId, thumbBuffer, {


### PR DESCRIPTION
## What Problem This Solves

Removes three private Matrix send-module aliases that only forwarded to the canonical plugin runtime getter. The aliases duplicated a runtime access path without adding policy, caching, initialization, or error handling.

## Why This Change Was Made

Matrix runtime ownership already lives in `extensions/matrix/src/runtime.ts`. The send chunking, formatting, and media modules now call `getMatrixRuntime()` directly at the same eight evaluation points, preserving lookup count and order, runtime identity, initialization failure timing and message, and async behavior.

No public API, plugin SDK, configuration, protocol, storage, security, test, documentation, or changelog surface changes.

## User Impact

No user-visible behavior change. Matrix send code has one fewer private forwarding layer and follows the plugin's existing direct runtime-access pattern.

## Evidence

- Production LOC: `+8/-11` nonblank (net `-3`); raw diff `+8/-14` includes three removed separator blank lines. Tests: `+0/-0`.
- Focused Matrix send/media/performance tests: 83 passed.
- Full Matrix plugin lane: 136 test files passed.
- `node scripts/check-changed.mjs -- extensions/matrix/src/matrix/send/chunking.ts extensions/matrix/src/matrix/send/formatting.ts extensions/matrix/src/matrix/send/media.ts`
- `pnpm check:import-cycles`
- `pnpm build`
- `git diff --check`
- Sol/high autoreview: scoped clean, no accepted/actionable findings.
- Current-main and live exact-path PR overlap checks found no target-file changes or competing PR.
- Codex source gate inspected at `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; those CLI completion/debug paths are unrelated to this refactor.
- Bespoke Crabbox/live Matrix proof is not applicable because the change is a byte-equivalent private getter substitution. The standard native PR Testbox remains required before merge.
