### PR TITLE
perf: reuse owned provider response buffers

### DIFF
--- a/extensions/azure-speech/tts.ts
+++ b/extensions/azure-speech/tts.ts
@@ -222,13 +222,11 @@ export async function azureSpeechTTS(params: {
 
   try {
     await assertOkOrThrowProviderError(response, "Azure Speech TTS API error");
-    return Buffer.from(
-      await readProviderBinaryResponse(response, "Azure Speech TTS API error", "audio", {
-        maxBytes: params.maxBytes ?? DEFAULT_AZURE_SPEECH_MAX_BYTES,
-        onOverflow: ({ maxBytes }) =>
-          new Error(`Azure Speech TTS audio response exceeds ${maxBytes} bytes`),
-      }),
-    );
+    return await readProviderBinaryResponse(response, "Azure Speech TTS API error", "audio", {
+      maxBytes: params.maxBytes ?? DEFAULT_AZURE_SPEECH_MAX_BYTES,
+      onOverflow: ({ maxBytes }) =>
+        new Error(`Azure Speech TTS audio response exceeds ${maxBytes} bytes`),
+    });
   } finally {
     await release();
   }

--- a/extensions/deepinfra/speech-provider.test.ts
+++ b/extensions/deepinfra/speech-provider.test.ts
@@ -3,29 +3,22 @@ import { requireFirstPostJsonRequest } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { buildDeepInfraSpeechProvider } from "./speech-provider.js";
 
-const {
-  assertOkOrThrowHttpErrorMock,
-  postJsonRequestMock,
-  readProviderBinaryResponseMock,
-  resolveProviderHttpRequestConfigMock,
-} = vi.hoisted(() => ({
-  assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
-  postJsonRequestMock: vi.fn(),
-  readProviderBinaryResponseMock: vi.fn(async (response: Response) => {
-    return new Uint8Array(await response.arrayBuffer());
-  }),
-  resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
-    baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://api.deepinfra.com/v1/openai",
-    allowPrivateNetwork: false,
-    headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
-    dispatcherPolicy: undefined,
-  })),
-}));
+const { assertOkOrThrowHttpErrorMock, postJsonRequestMock, resolveProviderHttpRequestConfigMock } =
+  vi.hoisted(() => ({
+    assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
+    postJsonRequestMock: vi.fn(),
+    resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
+      baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://api.deepinfra.com/v1/openai",
+      allowPrivateNetwork: false,
+      headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
+      dispatcherPolicy: undefined,
+    })),
+  }));
 
-vi.mock("openclaw/plugin-sdk/provider-http", () => ({
+vi.mock("openclaw/plugin-sdk/provider-http", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/provider-http")>()),
   assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
   postJsonRequest: postJsonRequestMock,
-  readProviderBinaryResponse: readProviderBinaryResponseMock,
   resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
 }));
 
@@ -38,7 +31,6 @@ describe("deepinfra speech provider", () => {
   afterEach(() => {
     assertOkOrThrowHttpErrorMock.mockClear();
     postJsonRequestMock.mockReset();
-    readProviderBinaryResponseMock.mockClear();
     resolveProviderHttpRequestConfigMock.mockClear();
     vi.unstubAllEnvs();
   });

--- a/extensions/elevenlabs/tts.ts
+++ b/extensions/elevenlabs/tts.ts
@@ -155,7 +155,7 @@ export async function elevenLabsTTS(params: ElevenLabsTtsRequestParams): Promise
   try {
     await assertOkOrThrowProviderError(response, "ElevenLabs API error");
 
-    return Buffer.from(await readProviderBinaryResponse(response, "ElevenLabs API error", "audio"));
+    return await readProviderBinaryResponse(response, "ElevenLabs API error", "audio");
   } finally {
     await release();
   }

--- a/extensions/fish-audio-speech/tts.ts
+++ b/extensions/fish-audio-speech/tts.ts
@@ -85,11 +85,9 @@ export async function fishAudioTts(params: FishAudioTtsRequest): Promise<Buffer>
   const { response, release } = await requestFishAudioTts(params);
   try {
     await assertOkOrThrowProviderError(response, "Fish Audio TTS API error");
-    return Buffer.from(
-      await readProviderBinaryResponse(response, "Fish Audio TTS API error", "audio", {
-        maxBytes: params.maxBytes,
-      }),
-    );
+    return await readProviderBinaryResponse(response, "Fish Audio TTS API error", "audio", {
+      maxBytes: params.maxBytes,
+    });
   } finally {
     await release();
   }

--- a/extensions/gradium/tts.ts
+++ b/extensions/gradium/tts.ts
@@ -56,13 +56,11 @@ export async function gradiumTTS(params: {
   try {
     await assertOkOrThrowProviderError(response, "Gradium API error");
 
-    return Buffer.from(
-      await readProviderBinaryResponse(response, "Gradium API error", "audio", {
-        maxBytes,
-        onOverflow: ({ maxBytes: maxBytesLocal }) =>
-          new Error(`Gradium TTS audio response exceeds ${maxBytesLocal} bytes`),
-      }),
-    );
+    return await readProviderBinaryResponse(response, "Gradium API error", "audio", {
+      maxBytes,
+      onOverflow: ({ maxBytes: maxBytesLocal }) =>
+        new Error(`Gradium TTS audio response exceeds ${maxBytesLocal} bytes`),
+    });
   } finally {
     await release();
   }

--- a/extensions/openai/tts.ts
+++ b/extensions/openai/tts.ts
@@ -187,13 +187,11 @@ export async function openaiTTS(params: {
 
     await assertOkOrThrowProviderError(response, "OpenAI TTS API error");
 
-    return Buffer.from(
-      await readProviderBinaryResponse(response, "OpenAI TTS API error", "audio", {
-        maxBytes,
-        onOverflow: ({ maxBytes: maxBytesLocal }) =>
-          new Error(`OpenAI TTS audio response exceeds ${maxBytesLocal} bytes`),
-      }),
-    );
+    return await readProviderBinaryResponse(response, "OpenAI TTS API error", "audio", {
+      maxBytes,
+      onOverflow: ({ maxBytes: maxBytesLocal }) =>
+        new Error(`OpenAI TTS audio response exceeds ${maxBytesLocal} bytes`),
+    });
   } finally {
     await release();
   }

--- a/extensions/openrouter/speech-provider.test.ts
+++ b/extensions/openrouter/speech-provider.test.ts
@@ -2,30 +2,22 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildOpenRouterSpeechProvider } from "./speech-provider.js";
 
-const {
-  assertOkOrThrowHttpErrorMock,
-  postJsonRequestMock,
-  readProviderBinaryResponseMock,
-  resolveProviderHttpRequestConfigMock,
-} = vi.hoisted(() => ({
-  assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
-  postJsonRequestMock: vi.fn(),
-  readProviderBinaryResponseMock: vi.fn(async (response: Response) => {
-    return new Uint8Array(await response.arrayBuffer());
-  }),
-  resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
-    baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://openrouter.ai/api/v1",
-    allowPrivateNetwork: false,
-    headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
-    dispatcherPolicy: undefined,
-  })),
-}));
+const { assertOkOrThrowHttpErrorMock, postJsonRequestMock, resolveProviderHttpRequestConfigMock } =
+  vi.hoisted(() => ({
+    assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
+    postJsonRequestMock: vi.fn(),
+    resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
+      baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://openrouter.ai/api/v1",
+      allowPrivateNetwork: false,
+      headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
+      dispatcherPolicy: undefined,
+    })),
+  }));
 
 vi.mock("openclaw/plugin-sdk/provider-http", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/provider-http")>()),
   assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
   postJsonRequest: postJsonRequestMock,
-  readProviderBinaryResponse: readProviderBinaryResponseMock,
   resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
 }));
 
@@ -64,7 +56,6 @@ describe("openrouter speech provider", () => {
   afterEach(() => {
     assertOkOrThrowHttpErrorMock.mockClear();
     postJsonRequestMock.mockReset();
-    readProviderBinaryResponseMock.mockClear();
     resolveProviderHttpRequestConfigMock.mockClear();
     vi.unstubAllEnvs();
   });
@@ -185,11 +176,6 @@ describe("openrouter speech provider", () => {
       dispatcherPolicy: undefined,
     });
     expect(result.audioBuffer).toEqual(Buffer.from([1, 2, 3]));
-    expect(readProviderBinaryResponseMock).toHaveBeenCalledWith(
-      expect.any(Response),
-      "OpenRouter TTS API error",
-      "audio",
-    );
     expect(result.outputFormat).toBe("mp3");
     expect(result.fileExtension).toBe(".mp3");
     expect(result.voiceCompatible).toBe(true);

--- a/extensions/xai/tts.ts
+++ b/extensions/xai/tts.ts
@@ -469,13 +469,11 @@ export async function xaiTTS(params: {
   try {
     await assertOkOrThrowProviderError(response, "xAI TTS API error");
 
-    return Buffer.from(
-      await readProviderBinaryResponse(response, "xAI TTS API error", "audio", {
-        maxBytes,
-        onOverflow: ({ maxBytes: maxBytesLocal }) =>
-          new Error(`xAI TTS audio response exceeds ${maxBytesLocal} bytes`),
-      }),
-    );
+    return await readProviderBinaryResponse(response, "xAI TTS API error", "audio", {
+      maxBytes,
+      onOverflow: ({ maxBytes: maxBytesLocal }) =>
+        new Error(`xAI TTS audio response exceeds ${maxBytesLocal} bytes`),
+    });
   } finally {
     await release();
   }

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -98,7 +98,7 @@ function readProviderResponseBytes(
   label: string,
   kind: string,
   opts?: ProviderResponseReadOptions,
-): Promise<Uint8Array> {
+): Promise<Buffer> {
   return readResponseWithLimit(response, opts?.maxBytes ?? PROVIDER_RESPONSE_MAX_BYTES, {
     ...opts,
     chunkTimeoutMs: opts?.chunkTimeoutMs ?? 30_000,
@@ -502,7 +502,7 @@ export async function readProviderBinaryResponse(
   label: string,
   kind = "binary",
   opts?: ProviderResponseReadOptions,
-): Promise<Uint8Array> {
+): Promise<Buffer> {
   try {
     assertProviderBinaryResponseContent(response, label, kind);
   } catch (error) {

--- a/src/media-generation/provider-assets.ts
+++ b/src/media-generation/provider-assets.ts
@@ -71,9 +71,7 @@ export async function downloadGeneratedVideoAsset(params: {
         new Error(`${params.label} exceeds ${maxBytesLocal} bytes`),
     };
     const buffer = params.validateBinaryResponse
-      ? Buffer.from(
-          await readProviderBinaryResponse(handle.response, params.label, "video", readOptions),
-        )
+      ? await readProviderBinaryResponse(handle.response, params.label, "video", readOptions)
       : await readResponseWithLimit(handle.response, maxBytes, readOptions);
     const ext = extensionForMime(mimeType)?.replace(/^\./u, "") ?? "mp4";
     return {

--- a/src/music-generation/provider-assets.ts
+++ b/src/music-generation/provider-assets.ts
@@ -162,9 +162,7 @@ export async function downloadGeneratedMusicAsset(params: {
         new Error(`${params.provider} generated music download exceeds ${maxBytesLocal} bytes`),
     };
     const buffer = params.validateBinaryResponse
-      ? Buffer.from(
-          await readProviderBinaryResponse(handle.response, deadline.label, "audio", readOptions),
-        )
+      ? await readProviderBinaryResponse(handle.response, deadline.label, "audio", readOptions)
       : await readResponseWithLimit(handle.response, maxBytes, readOptions);
     return {
       buffer,

--- a/src/tts/openai-compatible-speech-provider.test.ts
+++ b/src/tts/openai-compatible-speech-provider.test.ts
@@ -23,39 +23,27 @@ vi.mock("./provider-registry.js", async () => {
   };
 });
 
-const {
-  assertOkOrThrowHttpErrorMock,
-  postJsonRequestMock,
-  readProviderBinaryResponseMock,
-  resolveProviderHttpRequestConfigMock,
-} = vi.hoisted(() => ({
-  assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
-  postJsonRequestMock: vi.fn(),
-  readProviderBinaryResponseMock: vi.fn(async (response: Response, label: string) => {
-    const contentType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase();
-    if (contentType === "application/json" || contentType?.startsWith("text/")) {
-      throw new Error(`${label}: malformed audio response`);
-    }
-    const bytes = new Uint8Array(await response.arrayBuffer());
-    if (bytes.byteLength === 0) {
-      throw new Error(`${label}: malformed audio response`);
-    }
-    return bytes;
-  }),
-  resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
-    baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://example.test/v1",
-    allowPrivateNetwork: false,
-    headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
-    dispatcherPolicy: undefined,
-  })),
-}));
+const { assertOkOrThrowHttpErrorMock, postJsonRequestMock, resolveProviderHttpRequestConfigMock } =
+  vi.hoisted(() => ({
+    assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
+    postJsonRequestMock: vi.fn(),
+    resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
+      baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://example.test/v1",
+      allowPrivateNetwork: false,
+      headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
+      dispatcherPolicy: undefined,
+    })),
+  }));
 
-vi.mock("openclaw/plugin-sdk/provider-http", () => ({
-  assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
-  postJsonRequest: postJsonRequestMock,
-  readProviderBinaryResponse: readProviderBinaryResponseMock,
-  resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
-}));
+vi.mock("openclaw/plugin-sdk/provider-http", async () => {
+  const { readProviderBinaryResponse } = await import("../agents/provider-http-errors.js");
+  return {
+    assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
+    postJsonRequest: postJsonRequestMock,
+    readProviderBinaryResponse,
+    resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
+  };
+});
 
 function requireFirstMockArg(mock: ReturnType<typeof vi.fn>): Record<string, unknown> {
   const [call] = mock.mock.calls;
@@ -73,7 +61,6 @@ describe("createOpenAiCompatibleSpeechProvider", () => {
   afterEach(() => {
     assertOkOrThrowHttpErrorMock.mockClear();
     postJsonRequestMock.mockReset();
-    readProviderBinaryResponseMock.mockClear();
     resolveProviderHttpRequestConfigMock.mockClear();
     providerState.provider = undefined;
     vi.unstubAllEnvs();

--- a/src/tts/openai-compatible-speech-provider.ts
+++ b/src/tts/openai-compatible-speech-provider.ts
@@ -393,12 +393,10 @@ export function createOpenAiCompatibleSpeechProvider<
           options.apiErrorLabel ?? `${options.label} TTS API error`,
         );
         return {
-          audioBuffer: Buffer.from(
-            await readProviderBinaryResponse(
-              response,
-              options.apiErrorLabel ?? `${options.label} TTS API error`,
-              "audio",
-            ),
+          audioBuffer: await readProviderBinaryResponse(
+            response,
+            options.apiErrorLabel ?? `${options.label} TTS API error`,
+            "audio",
           ),
           outputFormat: responseFormat,
           fileExtension: responseFormatToFileExtension(responseFormat),


### PR DESCRIPTION
## What Problem This Solves

The bounded provider response reader already returns an owned Buffer, but its Uint8Array return type hid that fact. Speech and generated-media callers consequently copied the complete response with Buffer.from before returning it.

## Why This Change Was Made

Preserve Buffer in the shared reader's return type and return those already-owned bytes directly from all affected buffered speech, video and music callers. The transport is still released only after the read completes; content-type, empty-body, timeout and size-limit behavior stays at the shared reader.

The OpenAI-compatible speech tests, including the DeepInfra and OpenRouter factories, also contained handwritten binary-reader replacements that returned a different runtime type. They now use the real reader, deleting those duplicate implementations while preserving byte, request-header and transport-release assertions.

## User Impact

Buffered speech and generated-media downloads avoid an additional response-sized allocation and copy. The public helper already returned Buffer at runtime, so Uint8Array consumers remain compatible. Production LOC +32/-48 (net -16).

## Evidence

- Actual video and music asset helpers downloaded identical 32 MiB payloads over loopback HTTP. Each path made one full-buffer copy before and zero after; byte-for-byte content, SHA-256 and transport release matched. This removes 32 MiB of copy allocation per probe download, not a claimed constant reduction in whole-process RSS.
- A real OpenAI speech request through the changed plugin returned a valid 91,244-byte WAV Buffer; RIFF/WAVE headers and non-empty audio were verified.
- The shared HTTP reader already establishes independent byte ownership. [Node's Buffer documentation](https://nodejs.org/api/buffer.html#static-method-bufferfrombuffer) confirms Buffer.from(Buffer) copies those bytes again.
- All 141 tests passed across ten shared-reader, generated-media and speech-provider files. They cover response bytes, request construction, size limits, timeouts, cancellation/release, empty responses and malformed content. Eleven additional DeepInfra/OpenRouter tests pass after removing their inaccurate reader mocks. The initial CI run exposed those sibling fixtures; the OpenRouter failure was reproduced locally before the test cleanup. Test LOC +44/-79 (net -35); only internal mock-call assertions were removed, while observable output and lifecycle assertions remain.
- Independent source investigation and fresh Codex autoreview found no accepted findings in the selected scope and priority.
- Full `check-changed` passed, including core and plugin typechecks, lint and guards. Full `pnpm build` passed, including generated SDK declarations and built plugin checks.
