### PR TITLE
fix(release): continue advisory checks after resource-specific denials

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -514,11 +514,18 @@ jobs:
         id: dependency_evidence
         env:
           GH_TOKEN: ${{ github.token }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
           RELEASE_REF: ${{ inputs.tag }}
           RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
         run: |
           set -euo pipefail
-          node --import tsx scripts/generate-dependency-release-evidence.mts \
+          tooling_dir="${GITHUB_WORKSPACE}/.artifacts/plugin-sdk-release-tooling"
+          if [[ "$(git -C "$tooling_dir" rev-parse HEAD)" != "$WORKFLOW_SHA" ]] || [[ -n "$(git -C "$tooling_dir" status --porcelain)" ]]; then
+            echo "Trusted dependency release tooling must match the unmodified workflow SHA." >&2
+            exit 1
+          fi
+          node --import "$tooling_dir/scripts/tsx.mjs" "$tooling_dir/scripts/generate-dependency-release-evidence.mts" \
+            --root "$GITHUB_WORKSPACE" \
             --release-ref "$RELEASE_REF" \
             --npm-dist-tag "$RELEASE_NPM_DIST_TAG" \
             --output-dir "$RUNNER_TEMP/openclaw-release-dependency-evidence" \

--- a/scripts/dependency-ownership-surface-report.mts
+++ b/scripts/dependency-ownership-surface-report.mts
@@ -32,6 +32,7 @@ type RootDependency = {
 type Closure = { missing: string[]; packageKeys: string[] };
 type ReportParams = { ownershipPath?: string; repoRoot?: string };
 type ParseOptions = {
+  rootDir: string;
   asJson: boolean;
   check: boolean;
   jsonPath: string | null;
@@ -478,6 +479,7 @@ function printTextReport(report: DependencyOwnershipReport) {
 
 export function parseArgs(argv: string[]): ParseOptions {
   const options: ParseOptions = {
+    rootDir: process.cwd(),
     asJson: false,
     check: false,
     jsonPath: null,
@@ -498,6 +500,11 @@ export function parseArgs(argv: string[]): ParseOptions {
     }
     if (arg === "--check") {
       options.check = true;
+      continue;
+    }
+    if (arg === "--root") {
+      setOnce(arg, "rootDir", requireOptionArgument(argv, index, arg));
+      index += 1;
       continue;
     }
     if (arg === "--json") {
@@ -533,7 +540,7 @@ function writeArtifact(filePath: string | null, content: string) {
 
 function main(argv: string[] = process.argv.slice(2)) {
   const options = parseArgs(argv);
-  const report = collectDependencyOwnershipSurfaceReport();
+  const report = collectDependencyOwnershipSurfaceReport({ repoRoot: options.rootDir });
   writeArtifact(options.jsonPath, `${JSON.stringify(report, null, 2)}\n`);
   writeArtifact(options.markdownPath, renderDependencyOwnershipSurfaceMarkdownReport(report));
   if (options.check) {

--- a/scripts/generate-dependency-release-evidence.mts
+++ b/scripts/generate-dependency-release-evidence.mts
@@ -353,8 +353,8 @@ function runEvidenceReports(
  * Generates dependency evidence reports, manifest, and summaries for a release.
  */
 async function generateDependencyReleaseEvidence({
-  rootDir = process.cwd(),
-  outputDir,
+  rootDir: sourceRoot = process.cwd(),
+  outputDir: requestedOutputDir,
   releaseRef,
   npmDistTag,
   baseRef = null,
@@ -365,7 +365,7 @@ async function generateDependencyReleaseEvidence({
   execFileSyncImpl = execFileSync,
   now = new Date(),
 }: GenerateEvidenceParams = {}) {
-  if (!outputDir) {
+  if (!requestedOutputDir) {
     throw new Error("Expected --output-dir <path>.");
   }
   if (!releaseRef) {
@@ -375,8 +375,8 @@ async function generateDependencyReleaseEvidence({
     throw new Error("Expected --npm-dist-tag <tag>.");
   }
 
-  rootDir = path.resolve(rootDir);
-  outputDir = path.resolve(outputDir);
+  const rootDir = path.resolve(sourceRoot);
+  const outputDir = path.resolve(requestedOutputDir);
   await rm(outputDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
   // Publish the artifact location before a blocking report exits so CI can retain its evidence.

--- a/scripts/generate-dependency-release-evidence.mts
+++ b/scripts/generate-dependency-release-evidence.mts
@@ -325,60 +325,28 @@ function runEvidenceReports(
   baseRef: string,
   execFileSyncImpl: ExecFileSyncLike,
 ) {
-  runCommand(
-    "pnpm",
-    [
-      "deps:vuln:gate",
-      "--",
-      "--json",
-      reportPath(outputDir, "dependency-vulnerability-gate.json"),
-      "--markdown",
-      reportPath(outputDir, "dependency-vulnerability-gate.md"),
-    ],
-    rootDir,
-    execFileSyncImpl,
-  );
-  runCommand(
-    "pnpm",
-    [
-      "deps:transitive-risk:report",
-      "--",
-      "--json",
-      reportPath(outputDir, "transitive-manifest-risk-report.json"),
-      "--markdown",
-      reportPath(outputDir, "transitive-manifest-risk-report.md"),
-    ],
-    rootDir,
-    execFileSyncImpl,
-  );
-  runCommand(
-    "pnpm",
-    [
-      "deps:ownership-surface:report",
-      "--",
-      "--json",
-      reportPath(outputDir, "dependency-ownership-surface-report.json"),
-      "--markdown",
-      reportPath(outputDir, "dependency-ownership-surface-report.md"),
-    ],
-    rootDir,
-    execFileSyncImpl,
-  );
-  runCommand(
-    "pnpm",
-    [
-      "deps:changes:report",
-      "--",
-      "--base-ref",
-      baseRef,
-      "--json",
-      reportPath(outputDir, "dependency-changes-report.json"),
-      "--markdown",
-      reportPath(outputDir, "dependency-changes-report.md"),
-    ],
-    rootDir,
-    execFileSyncImpl,
-  );
+  // Report implementations belong to this tooling checkout; --root selects only the source data.
+  // Release branches can keep frozen product bytes while trusted release tooling is repaired.
+  for (const report of DEPENDENCY_EVIDENCE_REPORTS) {
+    runCommand(
+      "pnpm",
+      [
+        "--dir",
+        path.resolve(import.meta.dirname, ".."),
+        report.command.slice("pnpm ".length),
+        "--",
+        "--root",
+        rootDir,
+        ...(report.json === "dependency-changes-report.json" ? ["--base-ref", baseRef] : []),
+        "--json",
+        reportPath(outputDir, report.json),
+        "--markdown",
+        reportPath(outputDir, report.markdown),
+      ],
+      rootDir,
+      execFileSyncImpl,
+    );
+  }
 }
 
 /**
@@ -407,6 +375,8 @@ async function generateDependencyReleaseEvidence({
     throw new Error("Expected --npm-dist-tag <tag>.");
   }
 
+  rootDir = path.resolve(rootDir);
+  outputDir = path.resolve(outputDir);
   await rm(outputDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
   // Publish the artifact location before a blocking report exits so CI can retain its evidence.

--- a/scripts/lib/upstream-repository-advisories.mts
+++ b/scripts/lib/upstream-repository-advisories.mts
@@ -307,9 +307,33 @@ export async function fetchPublishedRepositoryAdvisories({
               (response.status === 429 ||
                 (response.status === 403 && response.headers.get("x-ratelimit-remaining") === "0"));
             const reason = rateLimited ? "rate-limited" : "request-failed";
-            // Secondary limits can return 403 with primary quota remaining. Do not
-            // continue through repositories after a throttle or credential denial.
-            if (github && [401, 403, 429].includes(response.status)) {
+            let resourceDenied = false;
+            if (
+              github &&
+              response.status === 403 &&
+              !rateLimited &&
+              !response.headers.has("retry-after")
+            ) {
+              try {
+                const error: unknown = JSON.parse(
+                  await readBoundedResponseText(
+                    response,
+                    "GitHub advisory denial",
+                    MAX_RESPONSE_BYTES,
+                    { signal, timeoutPromise },
+                  ),
+                );
+                // GitHub documents these as resource-scoped permission failures, not throttling.
+                // Keep that advisory unresolved without poisoning unrelated reviewed requests.
+                resourceDenied =
+                  isRecord(error) &&
+                  (error.message === "Resource not accessible by integration" ||
+                    error.message === "Resource not accessible by personal access token");
+              } catch {
+                // Unknown or unreadable 403 responses may be secondary limits: stop globally.
+              }
+            }
+            if (github && [401, 403, 429].includes(response.status) && !resourceDenied) {
               githubFailure = reason;
             }
             void response.body?.cancel().catch(() => undefined);

--- a/test/scripts/dependency-ownership-surface-report.test.ts
+++ b/test/scripts/dependency-ownership-surface-report.test.ts
@@ -1,4 +1,5 @@
 // Dependency Ownership Surface Report tests cover dependency ownership surface report script behavior.
+import { execFileSync } from "node:child_process";
 import { readFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -142,6 +143,22 @@ snapshots:
         );
       }
       const report = collectDependencyOwnershipSurfaceReport({ repoRoot });
+      const cliReport = JSON.parse(
+        execFileSync(
+          process.execPath,
+          [
+            "--import",
+            path.resolve("scripts/tsx.mjs"),
+            path.resolve("scripts/dependency-ownership-surface-report.mts"),
+            "--root",
+            repoRoot,
+            "--json",
+          ],
+          { encoding: "utf8" },
+        ),
+      );
+      expect(cliReport.summary).toEqual(report.summary);
+      expect(cliReport.ownershipGaps).toEqual(report.ownershipGaps);
 
       expect(report.summary).toEqual({
         buildRiskPackageCount: withToolchain ? 2 : 1,

--- a/test/scripts/generate-dependency-release-evidence.test.ts
+++ b/test/scripts/generate-dependency-release-evidence.test.ts
@@ -222,21 +222,32 @@ describe("generate-dependency-release-evidence", () => {
   });
 
   it.skipIf(process.platform === "win32")(
-    "retains gate artifacts and publishes their directory when the gate fails",
+    "uses trusted report tooling for a separate target and retains blocking evidence",
     async () => {
       const dir = await mkdtemp(path.join(tmpdir(), "openclaw-release-dependency-failure-test-"));
       try {
         const binDir = path.join(dir, "bin");
         const outputDir = path.join(dir, "evidence");
+        const sourceDir = path.join(dir, "candidate");
+        const marker = path.join(dir, "candidate-tooling-executed");
         const githubOutput = path.join(dir, "github-output");
         await mkdir(binDir);
+        await mkdir(sourceDir);
+        await writeJson(sourceDir, "package.json", { version: "2026.5.13" });
+        await writeFile(
+          path.join(binDir, "git"),
+          '#!/usr/bin/env node\nconsole.log("a".repeat(40));\n',
+          { mode: 0o755 },
+        );
         await writeFile(
           path.join(binDir, "pnpm"),
           [
             "#!/usr/bin/env node",
             'const { writeFileSync } = require("node:fs");',
             "const args = process.argv.slice(2);",
-            'if (args[0] !== "deps:vuln:gate") throw new Error("Unexpected report command");',
+            'const toolingRoot = args[0] === "--dir" ? args[1] : process.cwd();',
+            'if (toolingRoot === process.env.RELEASE_TEST_SOURCE_ROOT) { writeFileSync(process.env.RELEASE_TEST_MARKER, "candidate"); throw new Error("Candidate tooling executed"); }',
+            'if (args[2] !== "deps:vuln:gate" || args[args.indexOf("--root") + 1] !== process.env.RELEASE_TEST_SOURCE_ROOT) throw new Error("Wrong report or target");',
             'writeFileSync(args[args.indexOf("--json") + 1], JSON.stringify({ blockers: [{ id: "GHSA-fixture" }] }));',
             'writeFileSync(args[args.indexOf("--markdown") + 1], "# Blocking advisory evidence\\n");',
             "process.exitCode = 1;",
@@ -246,6 +257,8 @@ describe("generate-dependency-release-evidence", () => {
 
         const result = runCli(
           [
+            "--root",
+            sourceDir,
             "--output-dir",
             outputDir,
             "--release-ref",
@@ -259,11 +272,17 @@ describe("generate-dependency-release-evidence", () => {
             "--github-step-summary",
             "",
           ],
-          { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+          {
+            ...process.env,
+            PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+            RELEASE_TEST_SOURCE_ROOT: sourceDir,
+            RELEASE_TEST_MARKER: marker,
+          },
         );
 
         expect(result.status).toBe(1);
-        expect(result.stderr).toContain("Command failed: pnpm deps:vuln:gate");
+        expect(result.stderr).toContain("Command failed: pnpm --dir");
+        await expect(readFile(marker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
         await expect(readFile(githubOutput, "utf8")).resolves.toBe(`dir=${outputDir}\n`);
         await expect(
           readFile(path.join(outputDir, "dependency-vulnerability-gate.json"), "utf8"),

--- a/test/scripts/upstream-repository-advisories.test.ts
+++ b/test/scripts/upstream-repository-advisories.test.ts
@@ -238,6 +238,47 @@ describe("published upstream repository advisories", () => {
     );
   });
 
+  it.each(["integration", "personal access token"])(
+    "keeps resource denial by %s local while preserving real findings and reconciling stale ranges",
+    async (actor) => {
+      const ids = Array.from({ length: 6 }, (_, index) => `GHSA-2222-3333-444${index}`);
+      const inaccessible = ids.slice(0, 4);
+      const trueMatch = expectDefined(ids[4], "true advisory");
+      const staleMatch = expectDefined(ids[5], "stale advisory");
+      const secret = "synthetic-advisory-secret";
+      vi.stubEnv("GH_TOKEN", secret);
+      const source = createSourceFetch({
+        page: () => Response.json(ids.map((id) => advisory("< 2.0.0", { ghsa_id: id }))),
+        reviewed: (url) => {
+          const id = url.pathname.split("/").at(-1) ?? "";
+          if (inaccessible.includes(id)) {
+            return Response.json(
+              { message: `Resource not accessible by ${actor}`, diagnostic: secret },
+              { status: 403, headers: { "x-ratelimit-remaining": "100" } },
+            );
+          }
+          return Response.json({
+            ghsa_id: id,
+            published_at: "2026-08-01T00:00:00Z",
+            github_reviewed_at: "2026-08-02T00:00:00Z",
+            withdrawn_at: null,
+            vulnerabilities: [vulnerability(id === staleMatch ? "< 1.0.0" : "< 2.0.0")],
+          });
+        },
+      });
+      const report = await scan(source.fetchImpl);
+      expect(report.advisories.map(({ id }) => id)).toEqual([...inaccessible, trueMatch]);
+      expect(report.coverage.issues).toEqual(
+        inaccessible.map((id) => ({ subject: `fixture#${id}`, reason: "request-failed" })),
+      );
+      expect(report.coverage.reconciliations).toMatchObject([
+        { id: trueMatch, matchedVersions: ["1.0.0"] },
+        { id: staleMatch, matchedVersions: [] },
+      ]);
+      expect(JSON.stringify(report)).not.toContain(secret);
+    },
+  );
+
   it("sends the token only to fixed GitHub requests and refuses redirects on every request", async () => {
     vi.stubEnv("GH_TOKEN", "synthetic-upstream-test-token");
     const source = createSourceFetch();
@@ -700,27 +741,64 @@ describe("published upstream repository advisories", () => {
     { code: 429, remaining: "0", reason: "rate-limited" },
     { code: 403, remaining: "100", reason: "request-failed" },
     { code: 401, remaining: "100", reason: "request-failed" },
-  ])(
-    "stops scheduling GitHub work after HTTP $code (remaining $remaining)",
-    async ({ code, remaining, reason: expectedReason }) => {
-      const source = createSourceFetch({
-        manifest: (url) =>
-          manifest(url, `https://github.com/fixture/${url.pathname.split("/")[1]}`),
-        page: () =>
-          new Response(null, { status: code, headers: { "x-ratelimit-remaining": remaining } }),
-      });
-      const payload = Object.fromEntries(
-        Array.from({ length: 8 }, (_, index) => [`package-${index}`, ["1.0.0"]]),
-      );
-      const report = await scan(source.fetchImpl, payload);
-      expect(source.calls.filter(({ url }) => url.origin === REGISTRY)).toHaveLength(8);
-      expect(
-        source.calls.some(({ url }) =>
-          /\/repos\/fixture\/package-[4-7](?:\/|$)/u.test(url.pathname),
-        ),
-      ).toBe(false);
-      expect(report.coverage.status).toBe("partial");
-      expect(report.coverage.issues.some(({ reason }) => reason === expectedReason)).toBe(true);
+    {
+      code: 403,
+      remaining: "100",
+      reason: "request-failed",
+      body: JSON.stringify({ message: "You have exceeded a secondary rate limit." }),
     },
-  );
+    {
+      code: 403,
+      remaining: "100",
+      reason: "request-failed",
+      body: JSON.stringify({ message: "Unknown denial", diagnostic: "synthetic-advisory-secret" }),
+    },
+    { code: 403, remaining: "100", reason: "request-failed", body: "{" },
+    {
+      code: 403,
+      remaining: "100",
+      reason: "request-failed",
+      body: JSON.stringify({
+        message: "Resource not accessible by integration",
+        padding: "x".repeat(2 * 1024 * 1024),
+      }),
+    },
+    {
+      code: 403,
+      remaining: "0",
+      reason: "rate-limited",
+      body: JSON.stringify({ message: "Resource not accessible by integration" }),
+    },
+    {
+      code: 403,
+      remaining: "100",
+      reason: "request-failed",
+      body: JSON.stringify({ message: "Resource not accessible by integration" }),
+      retryAfter: "60",
+    },
+  ])("stops scheduling GitHub work after HTTP $code (remaining $remaining)", async (entry) => {
+    const { code, remaining, reason: expectedReason } = entry;
+    const source = createSourceFetch({
+      manifest: (url) => manifest(url, `https://github.com/fixture/${url.pathname.split("/")[1]}`),
+      page: () =>
+        new Response("body" in entry ? entry.body : null, {
+          status: code,
+          headers: {
+            "x-ratelimit-remaining": remaining,
+            ...("retryAfter" in entry ? { "retry-after": entry.retryAfter } : {}),
+          },
+        }),
+    });
+    const payload = Object.fromEntries(
+      Array.from({ length: 8 }, (_, index) => [`package-${index}`, ["1.0.0"]]),
+    );
+    const report = await scan(source.fetchImpl, payload);
+    expect(source.calls.filter(({ url }) => url.origin === REGISTRY)).toHaveLength(8);
+    expect(
+      source.calls.some(({ url }) => /\/repos\/fixture\/package-[4-7](?:\/|$)/u.test(url.pathname)),
+    ).toBe(false);
+    expect(report.coverage.status).toBe("partial");
+    expect(report.coverage.issues.some(({ reason }) => reason === expectedReason)).toBe(true);
+    expect(JSON.stringify(report)).not.toContain("synthetic-advisory-secret");
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where npm release preflight retained obsolete dependency blockers after GitHub denied access to an unrelated advisory. The 2026.8.2 candidate hit the same failure twice despite successful source, build, SDK, and release-content checks.

## Why This Change Was Made

GitHub's documented resource-specific 403 response was stored as a global API failure, preventing subsequent accessible advisory requests. Recognize only the exact documented resource-denial messages in bounded responses without throttling indicators. Inaccessible advisories and coverage failures remain in the report; authentication failures, throttling, malformed responses, and unknown denials retain the global stop.

Dependency report implementations now run from the existing verified workflow tooling checkout, while all four reports read the frozen release candidate through `--root`. The ownership report gains the same source-root CLI selection already supported by its siblings. This lets trusted tooling repairs reach frozen candidates without changing product bytes or weakening evidence gates.

## User Impact

Unblocks accurate release dependency checks. No product runtime, dependency versions, public configuration, or release candidate contents change.

## Evidence

- Failed npm preflight: https://github.com/openclaw/openclaw/actions/runs/33477283884 (attempt 2).
- Same-permission hosted diagnostic: https://github.com/openclaw/openclaw/actions/runs/33485084967. Eight resource-specific 403s and five successful responses, including all four affected blocker IDs after earlier denials; no exhausted quota or Retry-After indication.
- Repaired real scanner: https://github.com/openclaw/openclaw/actions/runs/33486590784. All four obsolete high blockers reconcile to no matching candidate version; three inaccessible moderate advisories and their coverage failures remain recorded. Successful requests after 403s are captured with the original permissions.
- Scanner regression: two failures before the fix, 114 focused tests pass afterward; changed checks and independent Codex review pass.
- Generator regression proves the trusted checkout supplies executable tooling and the separate candidate supplies data, while failed report artifacts remain available.
- Integration checks: script and test-root types, format, dependency/policy guards pass. The final mechanical const-local correction passes targeted script lint and independent Codex review (0.99); hosted checks bind the final PR head.
- Ownership CLI regression: both existing lockfile fixture variants fail on unsupported `--root` before repair; all 18 generator/ownership tests pass afterward.
- GitHub contract: https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api#resource-not-accessible and https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api#rate-limit-errors.

Root cause belongs to the shared GitHub request classifier; treating every 403 as local would incorrectly continue after secondary throttling. Broad token permissions or dropping findings would hide the failure and are unnecessary. The report-runner refactor removes duplicated command dispatch while retaining each canonical package script and report policy.

Patch provenance: the global denial latch is present in the raw parent-to-commit patch for ed280fe6698 (#133688); ce9ef22169f (#134870) carries it forward while adding reviewed-advisory reconciliation, where this release encountered it. This identifies code history, not responsibility for GitHub's current access behavior.

Production runtime delta: 0. Release tooling/workflow delta: +67/-59 (net +8); tests: +140/-26 (net +114). The small tooling growth implements bounded resource-denial classification and the missing report-root contract.
