### PR TITLE
fix(plugin-sdk): harden SQLite WAL retry deadline

### DIFF
--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -941,29 +941,6 @@ describe("sqlite WAL maintenance", () => {
     ]);
   });
 
-  it("retries the WAL transition when the wall clock jumps forward during the retry window", () => {
-    vi.useFakeTimers();
-    const db = createMockDb();
-    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
-    let journalModeAttempts = 0;
-    vi.mocked(db["exec"]).mockImplementation((sql) => {
-      if (sql === "PRAGMA journal_mode = WAL;" && journalModeAttempts++ === 0) {
-        vi.setSystemTime(Date.now() + 1_000_000);
-        throw Object.assign(new Error("database is locked"), {
-          code: "ERR_SQLITE_ERROR",
-          errcode: 5,
-        });
-      }
-    });
-
-    configureSqliteConnectionPragmas(db, {
-      busyTimeoutMs: 50,
-      checkpointIntervalMs: 0,
-    });
-
-    expect(journalModeAttempts).toBe(2);
-  });
-
   it("rejects a WAL transition that SQLite silently declines", () => {
     const db = createMockDb();
     vi.spyOn(process, "platform", "get").mockReturnValue("linux");

--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -941,6 +941,29 @@ describe("sqlite WAL maintenance", () => {
     ]);
   });
 
+  it("retries the WAL transition when the wall clock jumps forward during the retry window", () => {
+    vi.useFakeTimers();
+    const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    let journalModeAttempts = 0;
+    vi.mocked(db["exec"]).mockImplementation((sql) => {
+      if (sql === "PRAGMA journal_mode = WAL;" && journalModeAttempts++ === 0) {
+        vi.setSystemTime(Date.now() + 1_000_000);
+        throw Object.assign(new Error("database is locked"), {
+          code: "ERR_SQLITE_ERROR",
+          errcode: 5,
+        });
+      }
+    });
+
+    configureSqliteConnectionPragmas(db, {
+      busyTimeoutMs: 50,
+      checkpointIntervalMs: 0,
+    });
+
+    expect(journalModeAttempts).toBe(2);
+  });
+
   it("rejects a WAL transition that SQLite silently declines", () => {
     const db = createMockDb();
     vi.spyOn(process, "platform", "get").mockReturnValue("linux");

--- a/src/infra/sqlite-wal.ts
+++ b/src/infra/sqlite-wal.ts
@@ -1,6 +1,7 @@
 // Configures SQLite WAL and related pragmas for local stores.
 import fs, { type BigIntStats } from "node:fs";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import type { DatabaseSync } from "node:sqlite";
 import { decodeMountInfoPath } from "@openclaw/normalization-core/mountinfo-path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
@@ -498,7 +499,7 @@ function enableWalJournalMode(
   retryTimeoutMs: number,
   options: SqliteWalMaintenanceOptions,
 ): boolean {
-  const deadline = Date.now() + retryTimeoutMs;
+  const deadline = performance.now() + retryTimeoutMs;
   let restoreBusyTimeout = false;
   try {
     while (true) {
@@ -519,7 +520,7 @@ function enableWalJournalMode(
           `${label}${location} could not enable WAL; SQLite kept journal_mode=${journalMode ?? "unknown"}.`,
         );
       } catch (error) {
-        const remainingMs = deadline - Date.now();
+        const remainingMs = Math.max(0, deadline - performance.now());
         if (!isSqliteLockError(error) || remainingMs <= 0) {
           throw error;
         }

--- a/src/plugin-sdk/plugin-state-runtime.test.ts
+++ b/src/plugin-sdk/plugin-state-runtime.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
-import { createPluginStateErrorReporter } from "./plugin-state-runtime.js";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  configureSqliteConnectionPragmas,
+  createPluginStateErrorReporter,
+} from "./plugin-state-runtime.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
 
 describe("createPluginStateErrorReporter", () => {
   it("logs state failures with plugin bindings and default details", () => {
@@ -42,5 +55,46 @@ describe("createPluginStateErrorReporter", () => {
 
     expect(() => runtimeFailure(new Error("boom"))).not.toThrow();
     expect(() => formattingFailure(new Error("boom"))).not.toThrow();
+  });
+});
+
+describe("published plugin state SQLite runtime", () => {
+  it("keeps the WAL retry budget stable across wall-clock jumps", () => {
+    vi.useFakeTimers();
+    const databasePath = path.join(tempDirs.make("openclaw-plugin-state-wal-"), "state.sqlite");
+    const database = new DatabaseSync(databasePath);
+    let journalModeAttempts = 0;
+    const instrumentedDatabase = new Proxy(database, {
+      get(target, property) {
+        if (property === "exec") {
+          return (sql: string) => {
+            if (sql === "PRAGMA journal_mode = WAL;" && journalModeAttempts++ === 0) {
+              vi.setSystemTime(Date.now() + 1_000_000);
+              throw Object.assign(new Error("database is locked"), {
+                code: "ERR_SQLITE_ERROR",
+                errcode: 5,
+              });
+            }
+            return target.exec(sql);
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+
+    try {
+      const maintenance = configureSqliteConnectionPragmas(instrumentedDatabase, {
+        busyTimeoutMs: 50,
+        checkpointIntervalMs: 0,
+        databasePath,
+      });
+
+      expect(journalModeAttempts).toBe(2);
+      expect(database.prepare("PRAGMA journal_mode;").get()).toEqual({ journal_mode: "wal" });
+      expect(maintenance.close()).toBe(true);
+    } finally {
+      database.close();
+    }
   });
 });


### PR DESCRIPTION
<!--
Related: gap finding sqlite-wal-monotonic-deadline
-->

## What Problem This Solves

The published `openclaw/plugin-sdk/plugin-state-runtime` SQLite helper gives a transient WAL lock a bounded retry window. That window used `Date.now()`, so a forward wall-clock adjustment could expire it after the first lock result.

This is Plugin SDK hardening. It does not add a Gateway, command-line interface, or configuration behavior.

## Why This Change Was Made

Elapsed-time deadlines must use one monotonic clock. The WAL owner now computes and reads the retry deadline with `performance.now()`, while keeping the existing lock classification, busy-timeout restoration, and retry interval.

## User Impact

Plugins that use the published SQLite connection helper no longer lose their bounded WAL retry window when the system wall clock changes. No configuration or public API shape changes.

## Evidence

The regression uses the published Plugin SDK runtime with a real `node:sqlite` `DatabaseSync` file. It injects one transient SQLite BUSY result while moving only the wall clock forward.

### Before fix

With the two production clock reads restored to `Date.now()`, the published-runtime test fails on the first WAL attempt with `database is locked`.

```text
FAIL src/plugin-sdk/plugin-state-runtime.test.ts
Error: database is locked
  at enableWalJournalMode
  at configureSqliteConnectionPragmas
```

### After fix

The same test reaches WAL mode on the second attempt and closes maintenance successfully.

```bash
node scripts/run-vitest.mjs src/infra/sqlite-wal.test.ts src/plugin-sdk/plugin-state-runtime.test.ts
```

```text
Test Files  2 passed (2)
Tests       56 passed (56)
```

Additional exact-head checks:

- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/infra/sqlite-wal.test.ts src/infra/sqlite-wal.ts src/plugin-sdk/plugin-state-runtime.test.ts`
- `node_modules/.bin/oxfmt --check src/infra/sqlite-wal.ts src/infra/sqlite-wal.test.ts src/plugin-sdk/plugin-state-runtime.test.ts`
- `git diff --check origin/main...HEAD`

Local TypeScript and build checks were not run because this maintainer host forbids them. Exact-head continuous integration owns those checks.

The original contributor also supplied a real SQLite primitive trace at the original production head: https://github.com/xialonglee/openclaw/actions/runs/33493255265
