### PR TITLE
test(ci): assert retry delay without waiting in timing fixture

### DIFF
--- a/test/scripts/ci-run-timings.test.ts
+++ b/test/scripts/ci-run-timings.test.ts
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   collectRunJobsFromPages,
@@ -373,8 +373,22 @@ describe("scripts/ci-run-timings.mjs", () => {
     const fakeGhPath = path.join(fixtureDir, "gh");
     const reportPath = path.join(fixtureDir, "reports", "trend.json");
     const retryMarkerPath = path.join(fixtureDir, "retried");
+    const retryWaitsPath = path.join(fixtureDir, "retry-waits.txt");
+    const retryClockPath = path.join(fixtureDir, "retry-clock.mjs");
     const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
     const fixtureNowMs = Date.now();
+    writeFileSync(retryWaitsPath, "");
+    // Only this CLI child skips elapsed backoff; the requested delay remains asserted.
+    writeFileSync(
+      retryClockPath,
+      `import { appendFileSync } from "node:fs";
+const wait = Atomics.wait;
+Atomics.wait = (array, index, value, timeout) => {
+  appendFileSync(${JSON.stringify(retryWaitsPath)}, String(timeout) + "\\n");
+  return wait(array, index, value, 0);
+};
+`,
+    );
     writeFileSync(
       fakeGhPath,
       `#!/usr/bin/env node
@@ -424,6 +438,8 @@ if (endpoint.includes("actions/workflows/ci.yml/runs?")) {
       const result = spawnSync(
         process.execPath,
         [
+          "--import",
+          pathToFileURL(retryClockPath).href,
           "scripts/ci-run-timings.mjs",
           "--trend-hours",
           "24",
@@ -442,12 +458,14 @@ if (endpoint.includes("actions/workflows/ci.yml/runs?")) {
             ...process.env,
             FIXTURE_NOW_MS: String(fixtureNowMs),
             FIXTURE_RETRY_MARKER: retryMarkerPath,
+            GH_TOKEN: "fixture-ci-timing-token",
             OPENCLAW_GH_BIN: fakeGhPath,
           },
         },
       );
 
       expect(result.status, result.stderr).toBe(0);
+      expect(readFileSync(retryWaitsPath, "utf8")).toBe("1000\n");
       const report = JSON.parse(result.stdout);
       expect(JSON.parse(readFileSync(reportPath, "utf8"))).toEqual(report);
       expect(report.apiRequests).toEqual({ jobs: 3, runList: 1, total: 4 });


### PR DESCRIPTION
The retry integration test waits a real second for a canned first-request failure. Preload a clock shim only into that CLI child, record the requested Atomics.wait timeout, and forward the original array/index/value with zero elapsed wait. Assert the requested delay is exactly 1000 ms. A synthetic fixture token keeps fake-gh routing independent of operator authentication.

All 48 timing/plain-gh cases pass before and after with identical ordered native identities. The existing report/stdout/file checks, trend/rerun behavior and exact four API requests remain; direct assertions increase from 38 to39. A managed 1000-to1001 ms owner fault fails on the exact new trace assertion. Original owner bytes were restored and the complete normal suite passed afterward.

Production +0/-0; tests +19/-1. One mandatory real second is removed; four fake-gh API process calls remain. This observes the requested delay, not wall-clock backoff accuracy or live GitHub authentication. Full changed-file checks passed and scoped Codex review returned no findings.

Separate follow-up: the refit workflow's generated PR wording still describes main-push-only inputs after release Gateway samples were added.
