### PR TITLE
improve(ui): speed up session switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI session switching:** reuse sidebar projections during navigation and read only the selected session's metadata when loading conversation branches.
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.
 
 - **macOS AI setup:** show confirmed capability-review cancellation and retry guidance directly instead of a misleading Gateway failure headline. (#134573)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI session switching:** reuse sidebar projections during navigation and read only the selected session's metadata when loading conversation branches.
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.
 
 - **macOS AI setup:** show confirmed capability-review cancellation and retry guidance directly instead of a misleading Gateway failure headline. (#134573)

--- a/src/gateway/server-methods/sessions-rewind.storage.test.ts
+++ b/src/gateway/server-methods/sessions-rewind.storage.test.ts
@@ -7,6 +7,7 @@ import {
   errorShape,
   type SessionsForkResult,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { resolveInternalSessionEffectsIdentity } from "../../config/sessions/internal-session-key.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
 import {
   appendTranscriptEvent,
@@ -15,6 +16,7 @@ import {
   listSessionEntriesCore,
   loadSessionEntry,
   loadTranscriptEvents,
+  upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
 import { writeSessionEntry } from "../../config/sessions/session-accessor.sqlite-entry-store.js";
 import * as sqliteSessionScope from "../../config/sessions/session-accessor.sqlite-scope.js";
@@ -133,9 +135,12 @@ it.each(mutationMethods)(
   },
 );
 
-async function seedMessageCutSource(incognito = false) {
+async function seedMessageCutSource(
+  incognito = false,
+  identity?: { sessionKey: string; sessionId: string },
+) {
   const sessionKey = `agent:main:dashboard:${incognito ? "incognito-" : ""}source`;
-  const scope = { agentId: "main", sessionKey, sessionId: "message-fork-source" };
+  const scope = { agentId: "main", sessionKey, sessionId: "message-fork-source", ...identity };
   const created = await createSessionEntryWithTranscript(scope, () => ({
     ok: true,
     entry: {
@@ -177,6 +182,62 @@ function context(): GatewayRequestContext {
     getSessionEventSubscriberConnIds: () => new Set(),
   } as unknown as GatewayRequestContext;
 }
+
+it.each([
+  { kind: "visible", hidden: false },
+  { kind: "hidden internal-effects", hidden: true },
+])("lists $kind session branches without decoding unrelated metadata", async ({ hidden }) => {
+  await withOpenClawTestState({ label: "branch-list-bounded-read" }, async (state) => {
+    await state.writeConfig(cfg);
+    const identity = hidden
+      ? resolveInternalSessionEffectsIdentity({ agentId: "main", runId: "branch-list-hidden" })
+      : undefined;
+    const scope = await seedMessageCutSource(false, identity);
+    const unrelatedPrompt = "unrelated-session-skill-prompt".repeat(128);
+    for (let index = 0; index < 3; index += 1) {
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey: `agent:main:unrelated-${index}` },
+        {
+          sessionId: `unrelated-${index}`,
+          updatedAt: index + 1,
+          skillsSnapshot: { prompt: unrelatedPrompt, skills: [] },
+        },
+      );
+    }
+    const method = "sessions.branches.list";
+    const params = { sessionKey: scope.sessionKey };
+    const respond = vi.fn<RespondFn>();
+    const parse = vi.spyOn(JSON, "parse");
+    try {
+      await expectDefined(
+        sessionRewindHandlers[method],
+        method,
+      )({
+        req: { type: "req", id: "branch-list-bounded-read", method, params },
+        params,
+        respond,
+        context: context(),
+        client: null,
+        isWebchatConnect: () => false,
+      });
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        {
+          branches: hidden
+            ? []
+            : expect.arrayContaining([
+                expect.objectContaining({ leafEntryId: "user-2", active: true }),
+                expect.objectContaining({ leafEntryId: "alternate-user", active: false }),
+              ]),
+        },
+        undefined,
+      );
+      expect(parse.mock.calls.filter(([text]) => text.includes(unrelatedPrompt))).toHaveLength(0);
+    } finally {
+      parse.mockRestore();
+    }
+  });
+});
 
 function mutationParams(method: MutationMethod, sessionKey: string) {
   return {

--- a/src/gateway/server-methods/sessions-shared.ts
+++ b/src/gateway/server-methods/sessions-shared.ts
@@ -7,6 +7,7 @@ import {
   type SessionsPatchParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { isInternalSessionEffectsKey } from "../../config/sessions/internal-session-key.js";
 import { resolveAgentMainSessionKey } from "../../config/sessions/main-session.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -136,36 +137,16 @@ export function loadAccessorSessionEntryForGatewayTarget(params: {
   const target = resolveGatewaySessionStoreTargetWithStore({
     cfg: params.cfg,
     key: params.key,
-    clone: false,
+    exactRead: true,
     ...(params.agentId ? { agentId: params.agentId } : {}),
   });
-  let best:
-    | {
-        entry: SessionEntry;
-        sessionStoreKey: string;
-      }
-    | undefined;
-  for (const sessionStoreKey of target.storeKeys) {
-    const entry = target.store[sessionStoreKey];
-    if (entry) {
-      if (!best || (entry.updatedAt ?? 0) > (best.entry.updatedAt ?? 0)) {
-        best = { entry, sessionStoreKey };
-      }
-    }
-  }
-  if (best) {
-    return {
-      target,
-      storePath: target.storePath,
-      entry: best.entry,
-      canonicalKey: target.canonicalKey,
-      sessionStoreKey: best.sessionStoreKey,
-    };
-  }
   return {
     target,
     storePath: target.storePath,
-    entry: undefined,
+    // Exact probes include internal-effects rows that operator inventory reads hide.
+    entry: isInternalSessionEffectsKey(target.canonicalKey)
+      ? undefined
+      : resolveCanonicalSessionEntryFromStoreKeys(target.store, target.storeKeys),
     canonicalKey: target.canonicalKey,
     sessionStoreKey: target.canonicalKey,
   };

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -327,7 +327,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       commit: () => {
         this.prepareSessionNavigation(sessionKey, target.options.pathname);
         this.onNavigate?.(face, target.options);
-        this.bindLiteralSession(sessionKey, this.selectedAgentIdForSessions(), target.options);
+        this.bindLiteralSession(sessionKey, navigationState.selectedAgentId, target.options);
         return true;
       },
       face,
@@ -369,9 +369,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     });
   }
 
-  reconciledSidebarZone() {
-    const navigationState = this.getSessionNavigationState();
-    const rows = this.selectedAgentSessionRows(navigationState);
+  reconciledSidebarZone(rows = this.selectedAgentSessionRows(this.getSessionNavigationState())) {
     return buildReconciledSidebarZone({
       sidebarEntries: this.sidebarEntries,
       rows,
@@ -401,7 +399,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     const navigationState = this.getSessionNavigationState();
     const rows = this.selectedAgentSessionRows(navigationState);
     const { visibleRows } = this.zonedVisibleSections(rows);
-    const { entries, sessionRows } = this.reconciledSidebarZone();
+    const { entries, sessionRows } = this.reconciledSidebarZone(rows);
     const pinnedRows = entries.flatMap((entry) => {
       const row = entry.type === "session" ? sessionRows.get(entry.key) : undefined;
       return row ? [row] : [];

--- a/ui/src/components/app-sidebar-session-pr-indicators.test.ts
+++ b/ui/src/components/app-sidebar-session-pr-indicators.test.ts
@@ -76,9 +76,10 @@ describe("SessionPullRequestIndicatorsController", () => {
     vi.useFakeTimers();
     const host = new TestHost();
     const harness = createGatewayHarness();
+    const getRows = vi.fn(() => []);
     const controller = new SessionPullRequestIndicatorsController(host, {
       getConnected: () => true,
-      getRows: () => [],
+      getRows,
       getSelectedAgentId: () => "main",
       getGateway: () => harness.gateway,
       getSessions: () => undefined,
@@ -86,8 +87,10 @@ describe("SessionPullRequestIndicatorsController", () => {
 
     controller.hostConnected();
     controller.hostUpdated();
+    controller.hostUpdated();
     await vi.advanceTimersByTimeAsync(0);
 
+    expect(getRows).toHaveBeenCalledOnce();
     expect(host.requestUpdate).not.toHaveBeenCalled();
   });
 
@@ -102,9 +105,10 @@ describe("SessionPullRequestIndicatorsController", () => {
         isChild: false,
         worktreeId: "wt-demo",
       } as SidebarRecentSession;
+      const getRows = vi.fn(() => [row]);
       const controller = new SessionPullRequestIndicatorsController(host, {
         getConnected: () => true,
-        getRows: () => [row],
+        getRows,
         getSelectedAgentId: () => "main",
         getGateway: () => harness.gateway,
         getSessions: () => undefined,
@@ -117,6 +121,7 @@ describe("SessionPullRequestIndicatorsController", () => {
       expect(harness.request).toHaveBeenCalledWith(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD, {
         sessionKeys: [row.key],
       });
+      expect(getRows).toHaveBeenCalledOnce();
 
       harness.emit({
         sessions: {
@@ -138,6 +143,7 @@ describe("SessionPullRequestIndicatorsController", () => {
           },
         },
       });
+      expect(getRows).toHaveBeenCalledTimes(2);
       expect(controller.summary(row.key, row.worktreeId ?? "")).toEqual({
         numbers: [1, 2],
         state,

--- a/ui/src/components/app-sidebar-session-pr-indicators.ts
+++ b/ui/src/components/app-sidebar-session-pr-indicators.ts
@@ -113,13 +113,13 @@ export class SessionPullRequestIndicatorsController implements ReactiveControlle
     );
   }
 
-  private applySnapshots(): void {
+  private applySnapshots(rows?: readonly SidebarRecentSession[]): void {
     const store = this.store;
     if (!store) {
       return;
     }
     let changed = false;
-    for (const session of this.eligibleRows()) {
+    for (const session of rows ?? this.eligibleRows()) {
       if (!session.worktreeId) {
         continue;
       }
@@ -206,6 +206,6 @@ export class SessionPullRequestIndicatorsController implements ReactiveControlle
       this,
       eligibleRows.map((session) => this.scopedKey(session.key)),
     );
-    this.applySnapshots();
+    this.applySnapshots(eligibleRows);
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Switching Control UI sessions repeats sidebar navigation and row projections, with the cost growing as the session roster grows. Loading conversation branches also asks the selected-session Gateway helper to decode the entire session inventory, including unrelated saved skill prompts.

This is a maintainer-requested performance and simplification pass. It complements the cold-session presentation work in #134868; it does not change the pane reveal sequence.

## Why This Change Was Made

Reuse navigation state and sidebar rows already prepared by the current operation, including the PR-indicator refresh. Pushed PR snapshots still obtain fresh rows. At the Gateway boundary, use the existing exact session reader and canonical resolver instead of loading every session and repeating the obsolete freshest-entry selection loop. Preserve the operator-facing exclusion of internal-effects sessions at this boundary; the general exact reader continues to support internal callers.

The full-inventory reader remains available to callers that actually need it. Retained-pane identity, scroll position, drafts, route supersession, read-only missing-store behavior, and mutation revalidation retain their existing owners. There is no new cache, configuration option, dependency, schema, or persistence contract.

Production delta: **+12 / −33, net −21 lines**. Tests: **+71 / −4, net +67 lines**. The tests extend existing boundary coverage and protect bounded work and hidden-session visibility.

## User Impact

Session switching performs less repeated work, particularly with larger session rosters. Opening conversation branches reads metadata for the selected session rather than hydrating unrelated sessions. Appearance and navigation behavior remain the same.

In the controlled browser fixture, the 500-session retained-switch median improved by **11–17%**. Smaller rosters and tail latency did not show a clear improvement. These are local measurements, not a guaranteed latency reduction for every Gateway.

## Evidence

### Measured work and latency

Real Chromium, production UI bundle, synthetic Gateway transport with PR-subscription capability enabled. Each timing round contains four warmups and 24 retained switches between conversations with 70 and 30 messages. The candidate was bracketed by two baseline runs; medians below are recomputed conventionally from the raw samples. Timing starts at the browser click event and ends when the correct pane and composer are interactive.

| Session roster | Baseline median / p95 | Candidate median / p95 | Baseline recheck median / p95 |
| --- | --- | --- | --- |
| 50 | 32.9 / 41.7 ms | 33.1 / 46.7 ms | 35.4 / 45.7 ms |
| 500 | 62.75 / 74.8 ms | 55.6 / 76.4 ms | 67.25 / 77.9 ms |

Separate instrumented runs, with six retained switches per roster, reduced uncached sidebar getter work outside render preparation from **9 to 4 navigation builds** and **4 to 1 row projections** at both roster sizes. First-open getter work fell from 23 to 10 navigation builds and from 12 to 3 row projections. These diagnostic counters include two animation frames and a timer after interactive readiness; they exclude render-preparation calls made directly through the base class. CPU profiles corroborate the repeated-work reduction. No retained-switch history or branch reload was introduced; the expected foreground PR-subscription update remains. No page errors or external-network attempts were observed. Visible-paint timing and p95 showed no clear win.

A separate real-SQLite fixture calls the actual `sessions.branches.list` handler, with 70 selected-session messages and 150 unrelated sessions containing 64 KiB skill prompts. Across 20 warmups and 150 samples, branch-list median / p95 changed from **7.14 / 9.51 ms to 0.29 / 0.81 ms**; unrelated metadata decodes fell from **150 to 0**. With zero unrelated sessions, median changed from 0.36 to 0.30 ms and p95 was noisier/worse. This fixture measures the handler boundary, not browser or network latency.

Measurements compare commit `113805d6a517c27b7c2521be58c2e1fd84093ba0` with the measured production/test patch. That patch was subsequently rebased onto `addb509571ee2e77a5ed72f0c4cae29c1711df73`; measurements are not presented as a fresh timing run of that newer base. The shared-reader change in #134935 was inspected: this helper still chooses the read-only exact path, while the newer tests cover owned versus borrowed missing-store behavior.

### Regression and integration proof

- Before the fix, both new real-SQLite handler cases fail with three unrelated metadata decodes instead of zero; five extended PR-indicator cases fail with two row reads instead of one.
- 449 focused tests passed across the Gateway handlers, exact-row reader, sidebar navigation/PR indicators, retained sessions, and router outlet on the measurement base.
- Two selected real-Chromium Mock Gateway E2E tests passed: retained scroll/end anchors without history reload, and immediate UUID sidebar navigation with an outbox-only list refresh.
- Production UI build passed all startup/JavaScript/CSS budgets.
- Changed-file validation passed formatting, lint, core/core-test/UI typechecks, i18n, exports, storage/schema, plugin boundaries, and import-cycle guards.
- Fresh Codex Autoreview of the rebased code completed with no accepted/actionable P0 findings. The only subsequent commit removes the release-owned changelog edit; production and test blobs are identical to the reviewed head. All 62 focused Gateway tests passed against the newer shared reader after rebasing; exact-head CI is required before landing.

Proof limitation: the available browser tooling rejected access to the live task-owned dev Gateway under its URL policy. That access restriction was not bypassed. The browser measurements and screenshots use an isolated synthetic transport; the SQLite handler fixture is separate. Neither is claimed as live authenticated Gateway/browser proof. A single candidate round on a shared host does not establish a statistically significant tail-latency improvement.

### Before and after

The sanitized 500-session retained view is byte-identical before and after; the change reduces work, not layout.

| Before | After |
| --- | --- |
| ![Before: synthetic retained session](https://github.com/user-attachments/assets/988cb54a-d9f2-45ed-8695-e1920431e930) | ![After: synthetic retained session](https://github.com/user-attachments/assets/85621289-a000-41d6-8076-8bc4b207cad2) |
