### PR TITLE
test: prebuild the Doctor Gateway readiness fixture

### DIFF
--- a/scripts/lib/vitest-build-prerequisites.mts
+++ b/scripts/lib/vitest-build-prerequisites.mts
@@ -32,6 +32,12 @@ const runtimeConsumers = [
     dir: "src/cli",
   },
   {
+    file: "src/commands/doctor-config-preflight.process.test.ts",
+    configs: ["test/vitest/vitest.commands.config.ts"],
+    mode: "runtime",
+    dir: "src/commands",
+  },
+  {
     file: "test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts",
     configs: ["test/vitest/vitest.tooling.config.ts"],
     mode: "runtime",

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterAll, describe, expect, it } from "vitest";
-import { testing as openclawTestInstanceTesting } from "../../test/helpers/openclaw-test-instance.js";
+import { createOpenClawTestInstance } from "../../test/helpers/openclaw-test-instance.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { resolveGatewayLockDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -16,7 +16,6 @@ import {
   ensureOpenClawAgentDatabaseSchema,
   OPENCLAW_AGENT_SCHEMA_VERSION,
 } from "../state/openclaw-agent-db.js";
-import { getFreePort } from "../test-utils/ports.js";
 import {
   createSourceRuntime,
   runIsolatedModuleScript,
@@ -384,33 +383,25 @@ describe("doctor invalid config process exit", () => {
 // Synchronous CLI probes must not consume neighboring cases' timeout budgets.
 describe("gateway startup-migration refusal", () => {
   it("quarantines every invalid legacy automation before Gateway readiness", async () => {
-    const root = await fs.promises.realpath(tempDirs.make("openclaw-cron-upgrade-ready-"));
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(root, "openclaw.json");
-    const storePath = path.join(stateDir, "cron", "jobs.json");
-    const port = await getFreePort();
-    const runtimeRoot = createSourceRuntime(root);
-    const env: NodeJS.ProcessEnv = {
-      ...process.env,
-      HOME: root,
-      USERPROFILE: root,
-      OPENCLAW_CONFIG_PATH: configPath,
-      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
-      OPENCLAW_NO_RESPAWN: "1",
-      OPENCLAW_SKIP_CHANNELS: "1",
-      OPENCLAW_STATE_DIR: stateDir,
-      OPENCLAW_TEST_FAST: "1",
-      NO_COLOR: "1",
-    };
-    delete env.NODE_ENV;
-    delete env.OPENCLAW_HOME;
-    delete env.VITEST;
-
-    fs.mkdirSync(path.dirname(storePath), { recursive: true });
-    fs.writeFileSync(
-      configPath,
-      JSON.stringify({ gateway: { mode: "local", auth: { mode: "none" } } }),
-    );
+    // The scheduler builds this runtime before workers; source compilation must
+    // not consume the Gateway's readiness deadline.
+    const gateway = await createOpenClawTestInstance({
+      name: "cron-upgrade-ready",
+      startTimeoutMs: 30_000,
+      config: {
+        gateway: { mode: "local", auth: { mode: "none" } },
+        plugins: { enabled: false },
+      },
+      env: {
+        NODE_ENV: undefined,
+        VITEST: undefined,
+        OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+        OPENCLAW_SKIP_CRON: undefined,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_NO_RESPAWN: "1",
+      },
+    });
+    const storePath = path.join(gateway.stateDir, "cron", "jobs.json");
     const job = {
       name: "Legacy automation",
       enabled: true,
@@ -422,66 +413,37 @@ describe("gateway startup-migration refusal", () => {
       payload: { kind: "systemEvent", text: "tick" },
       state: {},
     };
-    fs.writeFileSync(
-      storePath,
-      JSON.stringify({
+    try {
+      await gateway.state.writeJson("cron/jobs.json", {
         version: 1,
         jobs: [
           { ...job, id: "valid-job" },
           { ...job, id: "invalid-state-job", state: { nextRunAtMs: -1 } },
           { ...job, id: "invalid-trigger-job", trigger: { script: [] } },
         ],
-      }),
-    );
-    const stdout = openclawTestInstanceTesting.createBoundedStringLog();
-    const stderr = openclawTestInstanceTesting.createBoundedStringLog();
-    const gateway = spawn(
-      process.execPath,
-      [
-        "--preserve-symlinks",
-        "--preserve-symlinks-main",
-        "--import",
-        "tsx",
-        path.join(runtimeRoot, "src", "entry.ts"),
-        "gateway",
-        "run",
-        "--allow-unconfigured",
-        "--port",
-        String(port),
-      ],
-      { cwd: runtimeRoot, env, stdio: ["ignore", "pipe", "pipe"] },
-    );
-    gateway.stdout.setEncoding("utf8");
-    gateway.stderr.setEncoding("utf8");
-    gateway.stdout.on("data", (chunk) => openclawTestInstanceTesting.appendLogChunk(stdout, chunk));
-    gateway.stderr.on("data", (chunk) => openclawTestInstanceTesting.appendLogChunk(stderr, chunk));
-
-    try {
-      await openclawTestInstanceTesting.waitForGatewayReady(gateway, stdout, stderr, port, 30_000);
-      const response = await fetch(`http://127.0.0.1:${port}/readyz`);
+      });
+      await gateway.startGateway();
+      const response = await fetch(`http://127.0.0.1:${gateway.port}/readyz`);
       await expect(response.json()).resolves.toMatchObject({ ready: true, failing: [] });
-    } finally {
-      expect(
-        await openclawTestInstanceTesting.stopGatewayProcess(gateway, Date.now() + 5_000, 1_500, {
-          forceWindowsTree: true,
-        }),
-      ).toBe(true);
-    }
+      await gateway.stopGateway();
 
-    const loaded = await loadCronJobsStoreWithConfigJobsReadOnly(storePath, env);
-    expect(loaded.store.jobs.map((entry) => entry.id)).toContain("valid-job");
-    expect(
-      loadCronQuarantinedJobs(storePath, env).map((entry) => ({
-        sourceIndex: entry.sourceIndex,
-        reason: entry.reason,
-        id: entry.job?.id,
-      })),
-    ).toEqual([
-      { sourceIndex: 1, reason: "invalid-state", id: "invalid-state-job" },
-      { sourceIndex: 2, reason: "invalid-trigger", id: "invalid-trigger-job" },
-    ]);
-    expect(fs.existsSync(storePath)).toBe(false);
-    expect(fs.existsSync(`${storePath}.migrated`)).toBe(true);
+      const loaded = await loadCronJobsStoreWithConfigJobsReadOnly(storePath, gateway.env);
+      expect(loaded.store.jobs.map((entry) => entry.id)).toContain("valid-job");
+      expect(
+        loadCronQuarantinedJobs(storePath, gateway.env).map((entry) => ({
+          sourceIndex: entry.sourceIndex,
+          reason: entry.reason,
+          id: entry.job?.id,
+        })),
+      ).toEqual([
+        { sourceIndex: 1, reason: "invalid-state", id: "invalid-state-job" },
+        { sourceIndex: 2, reason: "invalid-trigger", id: "invalid-trigger-job" },
+      ]);
+      expect(fs.existsSync(storePath)).toBe(false);
+      expect(fs.existsSync(`${storePath}.migrated`)).toBe(true);
+    } finally {
+      await gateway.cleanup();
+    }
   }, 45_000);
 
   it("repairs the stable upgrade config and additive state schema before readiness", async () => {

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -389,8 +389,8 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       runnerBackend: "hybrid",
     };
     const fallback = createNodeTestShardBundles(options);
-    // The whole CLI group pays 77s of tests plus its 100s runtime build.
-    // It must stay alone; all other non-dist fallback jobs remain within 150s.
+    // CLI and Doctor readiness each pay for a 100s runtime build before tests.
+    // They stay alone; all other non-dist fallback jobs remain within 150s.
     expect(
       fallback
         .filter((shard) => !shard.requiresDist)
@@ -400,7 +400,14 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
           pretestBuildMode: shard.pretestBuildMode,
           predictedSeconds: shard.predictedSeconds,
         })),
-    ).toEqual([{ groups: ["agentic-cli"], pretestBuildMode: "runtime", predictedSeconds: 177 }]);
+    ).toEqual([
+      { groups: ["agentic-cli"], pretestBuildMode: "runtime", predictedSeconds: 177 },
+      {
+        groups: ["agentic-commands-doctor-config-state"],
+        pretestBuildMode: "runtime",
+        predictedSeconds: 158,
+      },
+    ]);
     const agentChatStripes = fallback
       .flatMap((shard) => shard.groups)
       .filter((group) => group.shard_name.startsWith("agentic-control-plane-agent-chat-hosted-"));
@@ -1036,6 +1043,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
   it("preserves runtime preparation and core-only ownership in full and compact plans", () => {
     const qaConfig = "test/vitest/vitest.extension-qa.config.ts";
     const runtimeTargets = [
+      "src/commands/doctor-config-preflight.process.test.ts",
       "test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts",
       "src/gateway/gateway-active-memory.test.ts",
       "src/gateway/gateway-concurrent-streams.test.ts",
@@ -1588,6 +1596,9 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
         checkName: `checks-node-${shard.shardName}`,
         configs: ["test/vitest/vitest.commands.config.ts"],
         includePatterns: shard.includePatterns,
+        ...(shard.shardName === "agentic-commands-doctor-config-state"
+          ? { pretestBuildMode: "runtime" }
+          : {}),
         requiresDist: false,
         runner: DEFAULT_NODE_TEST_RUNNER,
         shardName: shard.shardName,

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -65,6 +65,9 @@ describe("test runtime prerequisites", () => {
     ["CLI directory", ["src/cli"], "runtime"],
     ["CLI config", ["test/vitest/vitest.cli.config.ts"], "runtime"],
     ["ordinary CLI unit test", ["src/cli/command-path-policy.test.ts"], undefined],
+    ["Doctor Gateway process", ["src/commands/doctor-config-preflight.process.test.ts"], "runtime"],
+    ["commands config", ["test/vitest/vitest.commands.config.ts"], "runtime"],
+    ["ordinary Doctor unit test", ["src/commands/doctor-state-integrity.test.ts"], undefined],
     ["Active Memory Gateway", ["src/gateway/gateway-active-memory.test.ts"], "runtime"],
     ["concurrent Gateway streams", ["src/gateway/gateway-concurrent-streams.test.ts"], "runtime"],
     [
@@ -554,7 +557,9 @@ describe("scripts/test-projects changed-target routing", () => {
     ]) {
       const plan = resolveChangedTestTargetPlan([file]);
       expect(plan.mode).toBe("targets");
-      if (plan.mode !== "targets") throw new Error(`Missing recovery test owner: ${file}`);
+      if (plan.mode !== "targets") {
+        throw new Error(`Missing recovery test owner: ${file}`);
+      }
       expect(plan.targets).toContain("test/scripts/upgrade-survivor-recovery-cleanup.test.ts");
     }
   });
@@ -904,7 +909,9 @@ describe("scripts/test-projects changed-target routing", () => {
       (cwd) => {
         const targets = resolveChangedTestTargetPlan([changedPath], { cwd }).targets;
 
-        for (const exactTarget of exactTargets) expect(targets).toContain(exactTarget);
+        for (const exactTarget of exactTargets) {
+          expect(targets).toContain(exactTarget);
+        }
         expect(targets).toContain("test/scripts/direct-workflow-reference.test.ts");
         expect(targets).toContain("test/scripts/ci-workflow-guards.test.ts");
       },


### PR DESCRIPTION
## Why

The Doctor process test starts an isolated source CLI and charges cold TypeScript loading against the Gateway's 30-second readiness deadline. Full release verification and ordinary PR CI repeatedly reached HTTP startup near the deadline, then timed out before `/readyz` responded. This case verifies legacy automation migration and readiness; sibling cases separately verify source-package assets.

## Change

Use the existing `createOpenClawTestInstance` lifecycle for this case and register the test as a built-runtime consumer. The scheduler prepares runtime before admitting workers, avoiding child builds while neighboring tests import runtime artifacts. Keep full Gateway/cron startup, the 30-second readiness budget, the 45-second test budget, and all valid-job, quarantine, archive, and readiness assertions.

This extracts the Doctor fixture and prerequisite repair from commit 81408ee in #134714. It excludes that PR's dashboard and credential changes and does not modify its branch. Update the existing planner expectations and full/compact prerequisite coverage as part of the same repair.

## Validation

- The two stale planner expectations were reproduced failing; 28 focused prerequisite/planner tests pass after correction.
- Retained hosted evidence for the same three fixture/prerequisite source files: CI 33477126045, job 99758747574, all 11 Doctor process cases and its 310-test group passed. The quarantine case completed in 2.028 seconds after a 38.6-second runtime prebuild on Node 24.19 with two workers.
- Managed Codex review completed with no accepted findings. The exact four-file candidate passed the changed-scope static gate, including repository guards, types, Knip and lint. The outer command used Node 24.20; pnpm-resolved local children used Node 26.8.1. Node 24.19 hosted/native results are tracked separately.
- Fresh committed-head native proof and PR CI are pending; the retained hosted evidence above is limited to the matching fixture/prerequisite files.

The canonical helper has different ancillary-service defaults and an existing bounded migration-convergence restart. Full Gateway and cron modes are explicitly restored; this case disables plugins. The source-file size reduction changes its position in cold file scheduling, so the retained hosted result is not represented as exact original 24-file ordering. Source-asset sibling fixtures remain unchanged.

Runtime production delta: zero. Test scheduling registration: +6 lines. Test code: +65/-85, net -20. Removed the case's bespoke source spawn, log buffering, manual stop, and state setup. No production readiness, storage schema, configuration surface, or timeout changes.
