### PR TITLE
fix(ui): restore failed cloud sessions from Chat

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -8206,6 +8206,7 @@ public struct FailedSessionPlacement: Codable, Sendable {
     public let terminalreason: String?
     public let terminalatms: Int?
     public let recoveryerror: String
+    public let recoveryaction: String?
 
     public init(
         state: String,
@@ -8225,7 +8226,8 @@ public struct FailedSessionPlacement: Codable, Sendable {
         workspaceresultconflict: [String: AnyCodable]? = nil,
         terminalreason: String? = nil,
         terminalatms: Int? = nil,
-        recoveryerror: String)
+        recoveryerror: String,
+        recoveryaction: String? = nil)
     {
         self.state = state
         self.generation = generation
@@ -8245,6 +8247,7 @@ public struct FailedSessionPlacement: Codable, Sendable {
         self.terminalreason = terminalreason
         self.terminalatms = terminalatms
         self.recoveryerror = recoveryerror
+        self.recoveryaction = recoveryaction
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -8266,6 +8269,7 @@ public struct FailedSessionPlacement: Codable, Sendable {
         case terminalreason = "terminalReason"
         case terminalatms = "terminalAtMs"
         case recoveryerror = "recoveryError"
+        case recoveryaction = "recoveryAction"
     }
 }
 

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3995,7 +3995,7 @@ ui/src/pages/chat/chat-page.ts	1
 ui/src/pages/chat/chat-pane-board.ts	2
 ui/src/pages/chat/chat-pane-browser-annotation.ts	2
 ui/src/pages/chat/chat-pane-lifecycle.ts	4
-ui/src/pages/chat/chat-pane-render.ts	4
+ui/src/pages/chat/chat-pane-render.ts	3
 ui/src/pages/chat/chat-progress.ts	2
 ui/src/pages/chat/chat-queue.ts	1
 ui/src/pages/chat/chat-realtime.ts	1

--- a/packages/gateway-protocol/src/schema/session-placement.test.ts
+++ b/packages/gateway-protocol/src/schema/session-placement.test.ts
@@ -399,6 +399,18 @@ describe("session dispatch protocol schemas", () => {
     expect(Value.Check(SessionPlacementSchema, failed)).toBe(true);
     expect(
       Value.Check(SessionPlacementSchema, {
+        ...failed,
+        recoveryAction: "restart",
+      }),
+    ).toBe(true);
+    expect(
+      Value.Check(SessionPlacementSchema, {
+        ...failed,
+        recoveryAction: "stop-first",
+      }),
+    ).toBe(true);
+    expect(
+      Value.Check(SessionPlacementSchema, {
         state: "failed",
         ...basePlacement,
       }),

--- a/packages/gateway-protocol/src/schema/session-placement.ts
+++ b/packages/gateway-protocol/src/schema/session-placement.ts
@@ -183,6 +183,7 @@ const FailedSessionPlacementSchema = closedObject({
   ...SessionPlacementTimingProperties,
   ...TerminalSessionPlacementProperties,
   recoveryError: NonEmptyString,
+  recoveryAction: Type.Optional(Type.Enum(["restart", "stop-first"] as const, { type: "string" })),
 });
 
 /** Gateway-visible placement projection; `state` remains the closed discriminator. */

--- a/src/gateway/server-methods/session-placement-read-projection.ts
+++ b/src/gateway/server-methods/session-placement-read-projection.ts
@@ -5,6 +5,7 @@ import {
   readWorkerPlacementIdentity,
 } from "../worker-environments/placement-projector.js";
 import type { WorkerSessionPlacementRecord } from "../worker-environments/placement-store.js";
+import { isFailedWorkerPlacementEnvironmentGone } from "../worker-environments/session-placement-lifecycle.js";
 import type { GatewayRequestContext } from "./types.js";
 
 function projectSessionPlacementFields(params: {
@@ -15,6 +16,15 @@ function projectSessionPlacementFields(params: {
 }) {
   const placement = params.sessionId ? params.placements?.get(params.sessionId) : undefined;
   const move = params.sessionId ? params.moves?.get(params.sessionId) : undefined;
+  const failedRecoveryAction =
+    placement?.state === "failed"
+      ? isFailedWorkerPlacementEnvironmentGone({
+          environmentService: params.context.workerEnvironmentService,
+          placement,
+        })
+        ? "restart"
+        : "stop-first"
+      : undefined;
   return {
     ...(placement
       ? {
@@ -23,6 +33,7 @@ function projectSessionPlacementFields(params: {
             params.context.workerPlacementDiskSpaceReader?.read(placement),
             params.context.workerPlacementRunnerAvailabilityReader?.read(placement),
             readWorkerPlacementIdentity(placement, params.context.workerEnvironmentService),
+            failedRecoveryAction,
           ),
         }
       : {}),

--- a/src/gateway/server.sessions.placement-projection.test.ts
+++ b/src/gateway/server.sessions.placement-projection.test.ts
@@ -328,6 +328,7 @@ test.each([
     expect(result.ok).toBe(true);
     expect(result.payload?.session?.placement).toMatchObject({
       state: "failed",
+      recoveryAction: "restart",
       terminalReason: "cloud worker disappeared: provider reported lease destroyed",
       terminalAtMs: 400,
     });
@@ -341,3 +342,44 @@ test.each([
     }
   },
 );
+
+test("sessions.describe requires worker teardown before failed-placement restart", async () => {
+  await seedSessionRows();
+  const active = activePlacementRecord();
+  const placement = {
+    ...active,
+    state: "failed" as const,
+    turnClaim: null,
+    recoveryError: "worker unavailable",
+    terminalReason: "worker unavailable",
+    terminalAtMs: 400,
+  } satisfies WorkerSessionPlacementRecord;
+
+  const result = await directSessionReq<{ session: GatewaySessionRow | null }>(
+    "sessions.describe",
+    { key: "main" },
+    {
+      context: {
+        workerSessionPlacementService: {
+          getMany: () => new Map([[placement.sessionId, placement]]),
+        },
+        workerEnvironmentService: {
+          get: () => ({
+            providerId: "machine0",
+            profileId: "team",
+            ownerEpoch: placement.activeOwnerEpoch,
+            state: "failed",
+            leaseId: "lease-live",
+          }),
+          inventoryVersion: () => 0,
+        },
+      },
+    },
+  );
+
+  expect(result.ok).toBe(true);
+  expect(result.payload?.session?.placement).toMatchObject({
+    state: "failed",
+    recoveryAction: "stop-first",
+  });
+});

--- a/src/gateway/worker-environments/placement-projector.ts
+++ b/src/gateway/worker-environments/placement-projector.ts
@@ -97,6 +97,7 @@ export function projectWorkerSessionPlacement(
   diskSpace?: SessionPlacementDiskSpace,
   runner?: SessionPlacementRunner,
   identity?: { providerId: string; profileId: string },
+  failedRecoveryAction?: "restart" | "stop-first",
 ): SessionPlacement {
   const timing = {
     generation: record.generation,
@@ -238,6 +239,7 @@ export function projectWorkerSessionPlacement(
           : {}),
         ...conflict,
         recoveryError: record.recoveryError,
+        ...(failedRecoveryAction ? { recoveryAction: failedRecoveryAction } : {}),
         ...terminal,
       };
   }

--- a/ui/src/components/session-placement-move-dialog.ts
+++ b/ui/src/components/session-placement-move-dialog.ts
@@ -20,6 +20,7 @@ type Catalog = {
 };
 
 type Options = {
+  mode: "move" | "restart";
   sessionLabel: string;
   activeRun: boolean;
   deviceDisabledReason?: string;
@@ -29,7 +30,10 @@ type Options = {
 
 let active = false;
 
-function targetKey(target: SessionMoveTarget): string {
+function targetKey(target: SessionMoveTarget | null): string {
+  if (!target) {
+    return "";
+  }
   switch (target.kind) {
     case "gateway":
       return "gateway";
@@ -41,7 +45,7 @@ function targetKey(target: SessionMoveTarget): string {
   throw new Error("Unknown session placement move target");
 }
 
-export function showSessionPlacementMoveDialog(
+export function showSessionPlacementTargetDialog(
   options: Options,
 ): Promise<SessionMoveTarget | null> {
   if (active) {
@@ -54,7 +58,7 @@ export function showSessionPlacementMoveDialog(
     let loading = true;
     let loadError: string | null = null;
     let catalog: Catalog = { profiles: [], devices: [] };
-    let selected: SessionMoveTarget = { kind: "gateway" };
+    let selected: SessionMoveTarget | null = options.mode === "move" ? { kind: "gateway" } : null;
     const cloudMachines = new DraftCloudMachineState();
 
     const finish = (result: SessionMoveTarget | null) => {
@@ -71,6 +75,9 @@ export function showSessionPlacementMoveDialog(
 
     const submit = (event: Event) => {
       event.preventDefault();
+      if (!selected) {
+        return;
+      }
       if (selected.kind !== "profile") {
         finish(selected);
         return;
@@ -84,40 +91,60 @@ export function showSessionPlacementMoveDialog(
 
     function paint() {
       const selectedKey = targetKey(selected);
+      const restart = options.mode === "restart";
       render(
         html`
           <openclaw-modal-dialog
-            label=${t("sessionsView.moveSessionTitle")}
+            label=${t(
+              restart ? "sessionsView.restartSessionTitle" : "sessionsView.moveSessionTitle",
+            )}
             @modal-cancel=${() => finish(null)}
           >
             <form class="exec-approval-card" @submit=${submit}>
               <div class="exec-approval-header">
-                <div class="exec-approval-title">${t("sessionsView.moveSessionTitle")}</div>
+                <div class="exec-approval-title">
+                  ${t(
+                    restart ? "sessionsView.restartSessionTitle" : "sessionsView.moveSessionTitle",
+                  )}
+                </div>
                 <div class="muted">
-                  ${t("sessionsView.moveSessionDescription", { session: options.sessionLabel })}
+                  ${t(
+                    restart
+                      ? "sessionsView.restartSessionDescription"
+                      : "sessionsView.moveSessionDescription",
+                    { session: options.sessionLabel },
+                  )}
                 </div>
               </div>
-              ${options.activeRun
+              ${restart
                 ? html`<div class="exec-approval-error" role="alert">
-                    ${t("sessionsView.moveSessionActiveRunWarning")}
+                    ${t("sessionsView.restartSessionWarning")}
                   </div>`
-                : html`<div class="callout">${t("sessionsView.moveSessionNoReplayWarning")}</div>`}
+                : options.activeRun
+                  ? html`<div class="exec-approval-error" role="alert">
+                      ${t("sessionsView.moveSessionActiveRunWarning")}
+                    </div>`
+                  : html`<div class="callout">
+                      ${t("sessionsView.moveSessionNoReplayWarning")}
+                    </div>`}
               ${loading
                 ? html`<div class="muted">${t("common.loading")}</div>`
                 : loadError
                   ? html`<div class="exec-approval-error" role="alert">${loadError}</div>`
                   : html`
                       <div class="new-session-page__picker-root">
-                        ${renderSessionMenuItem(
-                          {
-                            value: "gateway",
-                            label: t("newSession.gateway"),
-                            icon: icons.monitor,
-                            checked: selectedKey === "gateway",
-                            onSelect: () => select({ kind: "gateway" }),
-                          },
-                          false,
-                        )}
+                        ${restart
+                          ? nothing
+                          : renderSessionMenuItem(
+                              {
+                                value: "gateway",
+                                label: t("newSession.gateway"),
+                                icon: icons.monitor,
+                                checked: selectedKey === "gateway",
+                                onSelect: () => select({ kind: "gateway" }),
+                              },
+                              false,
+                            )}
                         ${catalog.devices.length > 0
                           ? html`
                               <div class="new-session-page__menu-title">
@@ -154,7 +181,7 @@ export function showSessionPlacementMoveDialog(
                               </div>
                               ${catalog.profiles.map((profile) => {
                                 const profileSelected =
-                                  selected.kind === "profile" && selected.profileId === profile.id;
+                                  selected?.kind === "profile" && selected.profileId === profile.id;
                                 const machines = profile.machines ?? [];
                                 const selectedMachineId =
                                   cloudMachines.resolve(profile.id) ||
@@ -199,9 +226,13 @@ export function showSessionPlacementMoveDialog(
                 <button
                   type="submit"
                   class="btn primary"
-                  ?disabled=${loading || Boolean(loadError)}
+                  ?disabled=${loading || Boolean(loadError) || !selected}
                 >
-                  ${t("sessionsView.moveSessionAction")}
+                  ${t(
+                    restart
+                      ? "sessionsView.restartSessionAction"
+                      : "sessionsView.moveSessionAction",
+                  )}
                 </button>
                 <button type="button" class="btn" @click=${() => finish(null)}>
                   ${t("common.cancel")}

--- a/ui/src/i18n/locales/en-session-placement.ts
+++ b/ui/src/i18n/locales/en-session-placement.ts
@@ -23,6 +23,19 @@ const enSessionPlacement = {
       "Reconnect the device to stop and sync its workspace, or Continue on Gateway.",
     stopDeviceWorkerConfirm: 'Stop the device worker for "{session}" after it reconnects?',
     stopDeviceWorkerConfirmAction: "Stop device worker",
+    restartSession: "Restart session…",
+    restartingSession: "Restarting session…",
+    restartSessionTitle: "Restart session",
+    restartSessionDescription: 'Choose where "{session}" should restart.',
+    restartSessionWarning:
+      "A new worker starts from the last reconciled worktree. Changes that the previous worker did not upload may be lost.",
+    restartSessionAction: "Restart session",
+    stoppingSession: "Stopping session…",
+    finishingSessionMove: "Finishing session move…",
+    failedSessionTitle: "Runner failed",
+    failedSessionRestartPrompt: "Restart this session to continue.",
+    failedSessionStopPrompt: "Stop the failed worker before restarting this session.",
+    failedSessionUnavailable: "This session's runner failed and cannot accept messages.",
   },
 } satisfies TranslationMap;
 

--- a/ui/src/pages/chat/chat-composer-availability.ts
+++ b/ui/src/pages/chat/chat-composer-availability.ts
@@ -1,0 +1,49 @@
+import type { PlacementComposerPresentation } from "./chat-pane-placement.ts";
+import type {
+  ChatComposerDisabledBanner,
+  ChatComposerProps,
+} from "./components/chat-composer-types.ts";
+
+type ComposerAvailability = Pick<
+  ChatComposerProps,
+  "canSend" | "disabledReason" | "disabledReasonTone" | "disabledReasonBusy" | "disabledBanner"
+>;
+
+export function resolveComposerAvailability(params: {
+  catalog: boolean;
+  catalogCanSend: boolean;
+  catalogDisabledReason: string | null;
+  modelSetupRequired: boolean;
+  baseDisabledReason: string | null;
+  baseDisabledReasonTone: "info" | "danger";
+  selectedSessionArchived: boolean;
+  restartRecoveryTombstoned: boolean;
+  placement: PlacementComposerPresentation;
+  sendHoldReason: string | null;
+  placementStartupPending: boolean;
+  sessionDisabledBanner: ChatComposerDisabledBanner | undefined;
+}): ComposerAvailability {
+  const placementFailureReason =
+    params.placement.state.kind === "failed" && !params.placement.state.recoveryAction
+      ? params.placement.failedUnavailableMessage
+      : null;
+  return {
+    canSend: params.catalog
+      ? params.catalogCanSend
+      : !params.modelSetupRequired &&
+        !params.baseDisabledReason &&
+        !params.selectedSessionArchived &&
+        !params.restartRecoveryTombstoned &&
+        !params.placement.blocksSend &&
+        !params.sendHoldReason,
+    disabledReason:
+      params.catalogDisabledReason ??
+      params.baseDisabledReason ??
+      params.placement.busyMessage ??
+      placementFailureReason ??
+      (params.placementStartupPending ? null : params.sendHoldReason),
+    disabledReasonTone: params.placement.busyMessage ? "info" : params.baseDisabledReasonTone,
+    disabledReasonBusy: params.placement.busyMessage !== null,
+    disabledBanner: params.sessionDisabledBanner ?? params.placement.disabledBanner,
+  };
+}

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -331,6 +331,22 @@ describe("renderChatComposer controls", () => {
     expect(container.querySelector<HTMLTextAreaElement>("textarea")?.disabled).toBe(true);
   });
 
+  it("shows placement work as an attached busy status while composing is disabled", () => {
+    const { container } = renderComposer({
+      canSend: false,
+      disabledReason: "Preparing workspace…",
+      disabledReasonTone: "info",
+      disabledReasonBusy: true,
+      draft: "Keep this draft",
+    });
+
+    expect(container.querySelector<HTMLTextAreaElement>("textarea")?.disabled).toBe(true);
+    expect(container.querySelector(".agent-chat__input")?.getAttribute("aria-busy")).toBe("true");
+    const status = container.querySelector('.agent-chat__composer-underlaps[data-tone="info"]');
+    expect(status?.textContent).toContain("Preparing workspace…");
+    expect(status?.querySelector(".btn__spinner")).not.toBeNull();
+  });
+
   it("opens the microphone picker, marks the selected input, and persists a selection", async () => {
     discoverRealtimeTalkInputsMock.mockResolvedValue({
       devices: [

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -292,6 +292,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   } | null = null;
   @litState() protected headerPlacementMovingKey: string | null = null;
   @litState() protected headerPlacementReclaimingKey: string | null = null;
+  @litState() protected headerPlacementRestartingKey: string | null = null;
   @litState() protected presencePayload: PresencePayload | undefined;
   @litState() protected sessionSharingStates = new Map<string, ChatSessionSharingState>();
   protected readonly sessionParticipationTracker = new SessionParticipationTracker();

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -24,6 +24,7 @@ import { getChatHistoryLoadState } from "./chat-history-state.ts";
 import { syncSelectedSessionMessageSubscription } from "./chat-history-subscription.ts";
 import { applyChatAgentsList, resumePendingChatHistoryLoad } from "./chat-history.ts";
 import { ChatPaneLifecycle } from "./chat-pane-lifecycle.ts";
+import { resolvePlacementComposer } from "./chat-pane-placement.ts";
 import {
   applySelectedSessionProjection,
   resolveAssistantAttachmentAuthToken,
@@ -55,6 +56,22 @@ import { reconcileWaitingApprovalsFromSnapshot } from "./tool-stream-status.ts";
 export abstract class ChatPaneContext extends ChatPaneLifecycle {
   private gatewayConnectionLifecycle?: ReturnType<typeof createGatewayConnectionLifecycle>;
   private outboxRecoveryReady = false;
+
+  protected placementComposerPresentation(
+    row: GatewaySessionRow | undefined,
+    startupPending: boolean,
+  ) {
+    return resolvePlacementComposer({
+      gatewaySnapshot: this.context.gateway.snapshot,
+      movingKey: this.headerPlacementMovingKey,
+      reclaimingKey: this.headerPlacementReclaimingKey,
+      restartingKey: this.headerPlacementRestartingKey,
+      row,
+      startupPending,
+      onRestart: () => row && void this.restartHeaderPlacement(row),
+      onReclaim: () => row && void this.reclaimHeaderPlacement(row),
+    });
+  }
 
   override disconnectedCallback() {
     this.continueInTerminalDialog = null;
@@ -88,6 +105,32 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
     };
     const { moveChatPanePlacement } = await import("./chat-pane-placement.runtime.ts");
     await moveChatPanePlacement(params);
+  }
+
+  protected async restartHeaderPlacement(row: GatewaySessionRow): Promise<void> {
+    const scope = this.captureConnectionScope();
+    if (!scope) {
+      return;
+    }
+    const onRestartingChange = (restartingKey: string | null) => {
+      if (restartingKey !== null || this.headerPlacementRestartingKey === row.key) {
+        this.headerPlacementRestartingKey = restartingKey;
+      }
+    };
+    const params = {
+      client: scope.client,
+      connectionGeneration: scope.generation,
+      gatewaySnapshot: scope.context.gateway.snapshot,
+      restartingKey: this.headerPlacementRestartingKey,
+      row,
+      isCurrent: () => this.ownsHeaderOutcomeScope(scope),
+      onRestartingChange,
+      publishError: (error: unknown) => this.publishHeaderError(error, scope.headerOutcomeOwner),
+      refreshReplacement: (agentId?: string | null) => scope.sessions.refreshReplacement(agentId),
+      requestUpdate: () => this.requestUpdate(),
+    };
+    const { restartChatPanePlacement } = await import("./chat-pane-placement.runtime.ts");
+    await restartChatPanePlacement(params);
   }
 
   protected async reclaimHeaderPlacement(row: GatewaySessionRow): Promise<void> {

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -396,6 +396,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       gatewaySnapshot: this.context.gateway.snapshot,
       movingKey: this.headerPlacementMovingKey,
       reclaimingKey: this.headerPlacementReclaimingKey,
+      restartingKey: this.headerPlacementRestartingKey,
       row,
     });
     const key = this.state?.sessionKey ?? "";
@@ -561,8 +562,10 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
             ></openclaw-chat-header-session-menu>`
           : nothing,
       placementMoving: placement.moving,
+      placementRestarting: placement.restarting,
       placementMoveDisabledReason: placement.moveDisabledReason,
       placementReclaimDisabledReason: placement.reclaimDisabledReason,
+      placementRestartDisabledReason: placement.restartDisabledReason,
       nativeGateways: this.nativeGateways,
       gatewaysSnapshot: this.gatewaysSnapshot,
       onboarding: this.onboarding,
@@ -587,6 +590,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       },
       onPlacementMove: () => row && void this.moveHeaderPlacement(row),
       onPlacementReclaim: () => row && void this.reclaimHeaderPlacement(row),
+      onPlacementRestart: () => row && void this.restartHeaderPlacement(row),
       onBranchSelect: (leafEntryId) => {
         const access = readChatSessionActionAccess(
           this.context.gateway.snapshot,

--- a/ui/src/pages/chat/chat-pane-placement-composer.test.ts
+++ b/ui/src/pages/chat/chat-pane-placement-composer.test.ts
@@ -1,0 +1,108 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+import type { GatewaySessionRow } from "../../api/types.ts";
+import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { resolveComposerAvailability } from "./chat-composer-availability.ts";
+import { resolvePlacementComposer } from "./chat-pane-placement.ts";
+
+function placementSession(
+  state: NonNullable<GatewaySessionRow["placement"]>["state"],
+  recoveryAction?: "restart" | "stop-first",
+): GatewaySessionRow {
+  return {
+    key: "agent:main:cloud",
+    kind: "direct",
+    updatedAt: 0,
+    placement: {
+      state,
+      ...(recoveryAction ? { recoveryAction } : {}),
+    } as GatewaySessionRow["placement"],
+  };
+}
+
+function presentation(
+  row: GatewaySessionRow,
+  overrides: Partial<Parameters<typeof resolvePlacementComposer>[0]> = {},
+) {
+  return resolvePlacementComposer({
+    gatewaySnapshot: {
+      hello: {
+        features: { methods: ["sessions.dispatch", "sessions.reclaim"] },
+        auth: { role: "operator", scopes: ["operator.read", "operator.write"] },
+      },
+    } as ApplicationGatewaySnapshot,
+    movingKey: null,
+    reclaimingKey: null,
+    restartingKey: null,
+    row,
+    startupPending: false,
+    onRestart: vi.fn(),
+    onReclaim: vi.fn(),
+    ...overrides,
+  });
+}
+
+describe("chat placement composer presentation", () => {
+  it.each([
+    ["active", "ready", undefined],
+    ["reclaimed", "ready", undefined],
+    ["provisioning", "busy", "Provisioning environment…"],
+    ["syncing", "busy", "Preparing workspace…"],
+    ["starting", "busy", "Starting…"],
+    ["draining", "busy", "Finishing session move…"],
+    ["reconciling", "busy", "Finishing session move…"],
+  ] as const)("projects %s placement into a %s composer", (state, kind, busyMessage) => {
+    const result = presentation(placementSession(state));
+
+    expect(result.state.kind).toBe(kind);
+    expect(result.blocksSend).toBe(kind !== "ready");
+    expect(result.busyMessage).toBe(busyMessage ?? null);
+    expect(
+      resolveComposerAvailability({
+        catalog: false,
+        catalogCanSend: false,
+        catalogDisabledReason: null,
+        modelSetupRequired: false,
+        baseDisabledReason: null,
+        baseDisabledReasonTone: "danger",
+        selectedSessionArchived: false,
+        restartRecoveryTombstoned: false,
+        placement: result,
+        sendHoldReason: null,
+        placementStartupPending: false,
+        sessionDisabledBanner: undefined,
+      }).canSend,
+    ).toBe(kind === "ready");
+  });
+
+  it.each(["restart", "stop-first"] as const)(
+    "projects failed %s recovery into an actionable composer banner",
+    (recoveryAction) => {
+      const onRestart = vi.fn();
+      const onReclaim = vi.fn();
+      const result = presentation(placementSession("failed", recoveryAction), {
+        onRestart,
+        onReclaim,
+      });
+
+      expect(result.state).toEqual({ kind: "failed", recoveryAction });
+      expect(result.blocksSend).toBe(true);
+      expect(result.disabledBanner?.title).toBe("Runner failed");
+      expect(result.disabledBanner?.actionLabel).toBe(
+        recoveryAction === "restart" ? "Restart session…" : "Stop cloud worker…",
+      );
+      result.disabledBanner?.onAction();
+      expect(recoveryAction === "restart" ? onRestart : onReclaim).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("projects local restart work ahead of the stale failed placement", () => {
+    const row = placementSession("failed", "restart");
+    const result = presentation(row, { restartingKey: row.key });
+
+    expect(result.state).toEqual({ kind: "busy", message: "Restarting session…" });
+    expect(result.busyMessage).toBe("Restarting session…");
+    expect(result.disabledBanner).toBeUndefined();
+  });
+});

--- a/ui/src/pages/chat/chat-pane-placement-restart.test.ts
+++ b/ui/src/pages/chat/chat-pane-placement-restart.test.ts
@@ -1,0 +1,82 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow } from "../../api/types.ts";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { installDialogPolyfill } from "../../test-helpers/modal-dialog.ts";
+import { createTestChatPane } from "./chat-pane.test-support.ts";
+
+let restoreDialogPolyfill: () => void;
+
+beforeEach(() => {
+  restoreDialogPolyfill = installDialogPolyfill();
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  restoreDialogPolyfill();
+});
+
+describe("chat pane placement restart", () => {
+  it("restarts a failed placement on a selected profile without creating a session", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "environments.list") {
+        return {
+          profiles: [{ id: "aws", providerId: "crabbox" }],
+          environments: [],
+        };
+      }
+      return { ok: true };
+    });
+    const refreshReplacement = vi.fn(async () => undefined);
+    const { pane } = createTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions: { refreshReplacement } as unknown as SessionCapability,
+    });
+    pane.context.gateway.snapshot.hello = {
+      features: { methods: ["sessions.dispatch"] },
+      auth: {
+        role: "operator",
+        scopes: ["operator.admin", "operator.read", "operator.write"],
+      },
+    } as never;
+    const session: GatewaySessionRow = {
+      key: "agent:main:failed-worker",
+      label: "Failed worker session",
+      kind: "direct",
+      updatedAt: 0,
+      placement: {
+        state: "failed",
+        generation: 2,
+        createdAtMs: 1,
+        updatedAtMs: 2,
+        stateChangedAtMs: 2,
+        recoveryError: "worker disappeared",
+        recoveryAction: "restart",
+      },
+    };
+
+    const restarting = pane.restartHeaderPlacement(session);
+    await vi.waitFor(() => {
+      expect(document.body.querySelector('[data-value="cloud:aws"]')).not.toBeNull();
+    });
+    expect(document.body.textContent).toContain(
+      "Changes that the previous worker did not upload may be lost.",
+    );
+    document.body.querySelector<HTMLButtonElement>('[data-value="cloud:aws"]')?.click();
+    const restartButton = [...document.body.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent?.trim() === "Restart session",
+    );
+    restartButton?.click();
+    await restarting;
+
+    expect(request).toHaveBeenCalledWith("sessions.dispatch", {
+      key: session.key,
+      agentId: "main",
+      profileId: "aws",
+    });
+    expect(request.mock.calls.some(([method]) => method === "sessions.create")).toBe(false);
+    expect(refreshReplacement).toHaveBeenCalledWith("main");
+  });
+});

--- a/ui/src/pages/chat/chat-pane-placement.runtime.ts
+++ b/ui/src/pages/chat/chat-pane-placement.runtime.ts
@@ -28,6 +28,39 @@ async function loadPlacementMoveCatalog(
   };
 }
 
+async function selectChatPanePlacementTarget(params: {
+  client: GatewayBrowserClient;
+  gatewaySnapshot: ApplicationGatewaySnapshot;
+  mode: "move" | "restart";
+  row: GatewaySessionRow;
+}): Promise<SessionMoveTarget | null> {
+  const { showSessionPlacementTargetDialog } =
+    await import("../../components/session-placement-move-dialog.ts");
+  const runtime = params.row.agentRuntime;
+  return await showSessionPlacementTargetDialog({
+    mode: params.mode,
+    sessionLabel: params.row.label || params.row.key,
+    activeRun: params.row.hasActiveRun === true,
+    deviceDisabledReason:
+      runtime && !runtime.devicePlacement ? t("newSession.deviceRuntimeUnsupported") : undefined,
+    profileDisabledReason: (profile) => {
+      if (runtime?.cloudPlacementSupported === false) {
+        return t("newSession.cloudRuntimeUnsupported", { runtime: runtime.id });
+      }
+      return runtime?.cloudPlacementExecutionMode &&
+        !draftCloudProfileSupportsExecutionMode(profile, runtime.cloudPlacementExecutionMode)
+        ? t("newSession.cloudProfileRuntimeUnsupported", { runtime: runtime.id })
+        : undefined;
+    },
+    loadCatalog: async () =>
+      await loadPlacementMoveCatalog(
+        params.client,
+        hasOperatorAdminAccess(params.gatewaySnapshot.hello?.auth ?? null),
+        runtime?.devicePlacement,
+      ),
+  });
+}
+
 export async function moveChatPanePlacement(params: {
   client: GatewayBrowserClient | null;
   connectionGeneration: number;
@@ -73,29 +106,11 @@ export async function moveChatPanePlacement(params: {
     });
     target = confirmed ? { kind: "gateway" } : null;
   } else {
-    const { showSessionPlacementMoveDialog } =
-      await import("../../components/session-placement-move-dialog.ts");
-    const runtime = params.row.agentRuntime;
-    target = await showSessionPlacementMoveDialog({
-      sessionLabel: params.row.label || params.row.key,
-      activeRun: params.row.hasActiveRun === true,
-      deviceDisabledReason:
-        runtime && !runtime.devicePlacement ? t("newSession.deviceRuntimeUnsupported") : undefined,
-      profileDisabledReason: (profile) => {
-        if (runtime?.cloudPlacementSupported === false) {
-          return t("newSession.cloudRuntimeUnsupported", { runtime: runtime.id });
-        }
-        return runtime?.cloudPlacementExecutionMode &&
-          !draftCloudProfileSupportsExecutionMode(profile, runtime.cloudPlacementExecutionMode)
-          ? t("newSession.cloudProfileRuntimeUnsupported", { runtime: runtime.id })
-          : undefined;
-      },
-      loadCatalog: async () =>
-        await loadPlacementMoveCatalog(
-          client,
-          hasOperatorAdminAccess(params.gatewaySnapshot.hello?.auth ?? null),
-          runtime?.devicePlacement,
-        ),
+    target = await selectChatPanePlacementTarget({
+      client,
+      gatewaySnapshot: params.gatewaySnapshot,
+      mode: "move",
+      row: params.row,
     });
   }
   if (!target) {
@@ -128,6 +143,76 @@ export async function moveChatPanePlacement(params: {
     }
   } finally {
     params.onMovingChange(null);
+    params.requestUpdate();
+  }
+}
+
+export async function restartChatPanePlacement(params: {
+  client: GatewayBrowserClient | null;
+  connectionGeneration: number;
+  gatewaySnapshot: ApplicationGatewaySnapshot;
+  restartingKey: string | null;
+  row: GatewaySessionRow;
+  isCurrent: (client: GatewayBrowserClient, generation: number) => boolean;
+  onRestartingChange: (restartingKey: string | null) => void;
+  publishError: (error: unknown) => void;
+  refreshReplacement: (agentId?: string | null) => Promise<void>;
+  requestUpdate: () => void;
+}): Promise<void> {
+  const client = params.client;
+  const placement = params.row.placement;
+  if (
+    !client ||
+    params.restartingKey === params.row.key ||
+    placement?.state !== "failed" ||
+    placement.recoveryAction !== "restart"
+  ) {
+    return;
+  }
+  const access = readSessionMethodAccess(params.gatewaySnapshot, {
+    method: "sessions.dispatch",
+    requiredScope: "operator.write",
+  });
+  if (!access.allowed) {
+    params.publishError(access.reason);
+    return;
+  }
+  const target = await selectChatPanePlacementTarget({
+    client,
+    gatewaySnapshot: params.gatewaySnapshot,
+    mode: "restart",
+    row: params.row,
+  });
+  if (!target || target.kind === "gateway") {
+    return;
+  }
+  if (!params.isCurrent(client, params.connectionGeneration)) {
+    params.publishError(t("sessionsView.actionUnavailable"));
+    return;
+  }
+  const agentId = parseAgentSessionKey(params.row.key)?.agentId;
+  params.onRestartingChange(params.row.key);
+  try {
+    await client.request("sessions.dispatch", {
+      key: params.row.key,
+      ...(agentId ? { agentId } : {}),
+      ...(target.kind === "profile"
+        ? {
+            profileId: target.profileId,
+            ...(target.machineClass ? { machineClass: target.machineClass } : {}),
+          }
+        : { deviceId: target.deviceId }),
+    });
+    if (params.isCurrent(client, params.connectionGeneration)) {
+      await params.refreshReplacement(agentId);
+    }
+  } catch (error) {
+    if (params.isCurrent(client, params.connectionGeneration)) {
+      await params.refreshReplacement(agentId).catch(() => undefined);
+      params.publishError(error);
+    }
+  } finally {
+    params.onRestartingChange(null);
     params.requestUpdate();
   }
 }

--- a/ui/src/pages/chat/chat-pane-placement.test.ts
+++ b/ui/src/pages/chat/chat-pane-placement.test.ts
@@ -91,9 +91,11 @@ describe("chat pane placement", () => {
       }),
     ).toEqual({
       moving: false,
+      restarting: false,
       moveDisabledReason: undefined,
       reclaimDisabledReason:
         "Reconnect the device to stop and sync its workspace, or Continue on Gateway.",
+      restartDisabledReason: "This Gateway does not support this session action.",
     });
     expect(
       resolveChatPanePlacement({
@@ -104,8 +106,10 @@ describe("chat pane placement", () => {
       }),
     ).toEqual({
       moving: false,
+      restarting: false,
       moveDisabledReason: undefined,
       reclaimDisabledReason: undefined,
+      restartDisabledReason: "This Gateway does not support this session action.",
     });
   });
 
@@ -158,8 +162,10 @@ describe("chat pane placement", () => {
 
     expect(placement).toEqual({
       moving: false,
+      restarting: false,
       moveDisabledReason: "This Gateway does not support this session action.",
       reclaimDisabledReason: undefined,
+      restartDisabledReason: "This Gateway does not support this session action.",
     });
     expect(request).toHaveBeenCalledWith(
       "sessions.reclaim",

--- a/ui/src/pages/chat/chat-pane-placement.ts
+++ b/ui/src/pages/chat/chat-pane-placement.ts
@@ -5,8 +5,110 @@ import { resolveCloudWorkerStopAction } from "../../components/cloud-worker-stop
 import { t } from "../../i18n/index.ts";
 import { registerSessionPlacementEnglish } from "../../i18n/locales/en-session-placement.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
+import type { ChatComposerDisabledBanner } from "./components/chat-composer-types.ts";
 
 registerSessionPlacementEnglish();
+
+type ChatPanePlacementComposerState =
+  | { kind: "ready" }
+  | { kind: "busy"; message: string }
+  | { kind: "failed"; recoveryAction?: "restart" | "stop-first" };
+
+export type PlacementComposerPresentation = {
+  state: ChatPanePlacementComposerState;
+  blocksSend: boolean;
+  busyMessage: string | null;
+  diskSpace: Extract<NonNullable<GatewaySessionRow["placement"]>, { state: "active" }>["diskSpace"];
+  runError: { summary: string } | null;
+  failedUnavailableMessage: string;
+  disabledBanner: ChatComposerDisabledBanner | undefined;
+};
+
+function resolvePlacementComposerState(params: {
+  reclaimingKey: string | null;
+  restartingKey: string | null;
+  row: GatewaySessionRow | undefined;
+}): ChatPanePlacementComposerState {
+  if (params.restartingKey === params.row?.key) {
+    return { kind: "busy", message: t("sessionsView.restartingSession") };
+  }
+  if (params.reclaimingKey === params.row?.key) {
+    return { kind: "busy", message: t("sessionsView.stoppingSession") };
+  }
+  switch (params.row?.placement?.state) {
+    case "requested":
+    case "provisioning":
+      return { kind: "busy", message: t("chat.startupStatus.provisioningEnvironment") };
+    case "syncing":
+      return { kind: "busy", message: t("chat.startupStatus.preparingWorkspace") };
+    case "starting":
+      return { kind: "busy", message: t("newSession.starting") };
+    case "draining":
+    case "reconciling":
+      return { kind: "busy", message: t("sessionsView.finishingSessionMove") };
+    case "failed":
+      return {
+        kind: "failed",
+        ...(params.row.placement.recoveryAction
+          ? { recoveryAction: params.row.placement.recoveryAction }
+          : {}),
+      };
+    default:
+      // Local, active, and reclaimed placements can all accept a turn. Reclaimed
+      // placements intentionally redispatch when the next turn is admitted.
+      return { kind: "ready" };
+  }
+}
+
+export function resolvePlacementComposer(params: {
+  gatewaySnapshot: ApplicationGatewaySnapshot;
+  movingKey: string | null;
+  reclaimingKey: string | null;
+  restartingKey: string | null;
+  row: GatewaySessionRow | undefined;
+  startupPending: boolean;
+  onRestart: () => void;
+  onReclaim: () => void;
+}): PlacementComposerPresentation {
+  const state = resolvePlacementComposerState(params);
+  const controls = resolveChatPanePlacement(params);
+  const busyMessage = !params.startupPending && state.kind === "busy" ? state.message : null;
+  const placement = params.row?.placement;
+  const terminalReason =
+    placement && "terminalReason" in placement ? placement.terminalReason : undefined;
+  const failureReason = placement?.state === "failed" ? placement.recoveryError : terminalReason;
+  const common = {
+    state,
+    blocksSend: state.kind !== "ready",
+    busyMessage,
+    diskSpace: placement?.state === "active" ? placement.diskSpace : undefined,
+    runError: failureReason
+      ? { summary: t("chat.cloudWorkerFailed", { error: failureReason }) }
+      : null,
+    failedUnavailableMessage: t("sessionsView.failedSessionUnavailable"),
+  };
+  if (params.startupPending || state.kind !== "failed" || !state.recoveryAction || !params.row) {
+    return { ...common, disabledBanner: undefined };
+  }
+  const restart = state.recoveryAction === "restart";
+  return {
+    ...common,
+    disabledBanner: {
+      kind: "above-composer",
+      title: t("sessionsView.failedSessionTitle"),
+      text: t(
+        restart
+          ? "sessionsView.failedSessionRestartPrompt"
+          : "sessionsView.failedSessionStopPrompt",
+      ),
+      icon: "warning",
+      actionLabel: t(restart ? "sessionsView.restartSession" : "sessionsView.stopCloudWorker"),
+      actionStyle: "primary",
+      disabledReason: restart ? controls.restartDisabledReason : controls.reclaimDisabledReason,
+      onAction: restart ? params.onRestart : params.onReclaim,
+    },
+  };
+}
 
 export function resolveChatPaneDesktopTarget(
   session: GatewaySessionRow | undefined,
@@ -34,16 +136,20 @@ export function resolveChatPanePlacement(params: {
   gatewaySnapshot: ApplicationGatewaySnapshot;
   movingKey: string | null;
   reclaimingKey: string | null;
+  restartingKey?: string | null;
   row: GatewaySessionRow | undefined;
 }): {
   moving: boolean;
+  restarting: boolean;
   moveDisabledReason: string | undefined;
   reclaimDisabledReason: string | undefined;
+  restartDisabledReason: string | undefined;
 } {
   const moving =
     params.movingKey === params.row?.key ||
     (params.row?.placementMove !== undefined && params.row.placementMove.error === undefined);
   const reclaiming = params.reclaimingKey === params.row?.key;
+  const restarting = params.restartingKey === params.row?.key;
   const action = resolveCloudWorkerStopAction(params.row?.placement);
   const moveAccess = readSessionMethodAccess(params.gatewaySnapshot, {
     method: "sessions.move",
@@ -53,7 +159,13 @@ export function resolveChatPanePlacement(params: {
     method: "sessions.reclaim",
     requiredScope: "operator.write",
   });
+  const restartAccess = readSessionMethodAccess(params.gatewaySnapshot, {
+    method: "sessions.dispatch",
+    requiredScope: "operator.write",
+  });
   const placementState = params.row?.placement?.state;
+  const recoveryAction =
+    placementState === "failed" ? params.row?.placement?.recoveryAction : undefined;
   const runner = placementState === "active" ? params.row?.placement?.runner : undefined;
   const deviceOffline = runner?.kind === "device" && runner.status === "offline";
   const moveDisabledReason = moving
@@ -65,20 +177,33 @@ export function resolveChatPanePlacement(params: {
         : moveAccess.allowed
           ? undefined
           : moveAccess.reason;
+  const restartDisabledReason = restarting
+    ? t("common.loading")
+    : moving || reclaiming
+      ? t("sessionsView.actionUnavailable")
+      : recoveryAction !== "restart"
+        ? t("sessionsView.actionUnavailable")
+        : restartAccess.allowed
+          ? undefined
+          : restartAccess.reason;
   const reclaimDisabledReason = reclaiming
     ? t("common.loading")
-    : deviceOffline
-      ? t("sessionsView.offlineDeviceStopUnavailable")
-      : action?.blocksActiveRun && params.row?.hasActiveRun === true
-        ? t("sessionsView.activeRun")
-        : action?.method !== "sessions.reclaim"
-          ? t("sessionsView.actionUnavailable")
-          : reclaimAccess.allowed
-            ? undefined
-            : reclaimAccess.reason;
+    : restarting
+      ? t("sessionsView.actionUnavailable")
+      : deviceOffline
+        ? t("sessionsView.offlineDeviceStopUnavailable")
+        : action?.blocksActiveRun && params.row?.hasActiveRun === true
+          ? t("sessionsView.activeRun")
+          : action?.method !== "sessions.reclaim"
+            ? t("sessionsView.actionUnavailable")
+            : reclaimAccess.allowed
+              ? undefined
+              : reclaimAccess.reason;
   return {
     moving,
+    restarting,
     moveDisabledReason,
     reclaimDisabledReason,
+    restartDisabledReason,
   };
 }

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -30,6 +30,7 @@ import {
   resolveUiConfiguredMainKey,
 } from "../../lib/sessions/session-key.ts";
 import { showToast } from "../../lib/toast.ts";
+import { resolveComposerAvailability } from "./chat-composer-availability.ts";
 import { mutateChatGoal, submitChatGoalDraft } from "./chat-goals.ts";
 import { clearChatHistory } from "./chat-history-actions.ts";
 import { getChatHistoryVersion } from "./chat-history-state.ts";
@@ -100,13 +101,6 @@ export class ChatPane extends ChatPaneLayoutRender {
     });
     const workspaceConflict = workspaceResultConflictFromPlacement(selectedSession?.placement);
     const placement = selectedSession?.placement;
-    const diskSpace = placement?.state === "active" ? placement.diskSpace : undefined;
-    const terminalReason = (placement as { terminalReason?: string } | undefined)?.terminalReason;
-    const placementFailureReason =
-      placement?.state === "failed" ? placement.recoveryError : terminalReason;
-    const placementRunError = placementFailureReason
-      ? { summary: t("chat.cloudWorkerFailed", { error: placementFailureReason }) }
-      : null;
     const visibleWorkspaceConflict =
       workspaceConflict &&
       this.dismissedWorkspaceConflictRefs.get(selectedSession?.key ?? state.sessionKey) !==
@@ -175,6 +169,10 @@ export class ChatPane extends ChatPaneLayoutRender {
       session: selectedSession,
     });
     const gatewaySnapshot = this.context.gateway.snapshot;
+    const placementComposer = this.placementComposerPresentation(
+      selectedSession,
+      placementStartup !== null,
+    );
     const canDismissProgressCard =
       state.connected &&
       !sessionParticipationBlocked &&
@@ -328,6 +326,29 @@ export class ChatPane extends ChatPaneLayoutRender {
           }
         : null,
     );
+    const sessionDisabledBanner = this.sessionDisabledBanner({
+      catalogDisabledReason,
+      modelSetupRequired,
+      restartRecoveryTombstoned,
+      selectedSessionArchived,
+      selectedSessionId: selectedSession?.sessionId?.trim() || undefined,
+      sessionKey: state.sessionKey,
+      unarchiveAccess: mutationAccess.unarchive,
+    });
+    const composerAvailability = resolveComposerAvailability({
+      catalog: Boolean(catalogKey),
+      catalogCanSend: this.catalogSession?.canContinue === true,
+      catalogDisabledReason,
+      modelSetupRequired,
+      baseDisabledReason: disabledReason,
+      baseDisabledReasonTone: sessionParticipationBlocked && !suggestionViewer ? "info" : "danger",
+      selectedSessionArchived,
+      restartRecoveryTombstoned,
+      placement: placementComposer,
+      sendHoldReason,
+      placementStartupPending: placementStartup !== null,
+      sessionDisabledBanner,
+    });
     const props: ChatProps = {
       transcript: this.transcript,
       paneId: this.presentationId,
@@ -419,35 +440,13 @@ export class ChatPane extends ChatPaneLayoutRender {
       onTypingChange: typingEnabled
         ? (typing, preview) => this.sendTypingState(typing, preview)
         : undefined,
-      canSend: catalogKey
-        ? this.catalogSession?.canContinue === true
-        : !modelSetupRequired &&
-          !modelUnavailableMessage &&
-          !selectedSessionArchived &&
-          !restartRecoveryTombstoned &&
-          (!sessionParticipationBlocked || suggestionViewer) &&
-          !sendHoldReason,
-      disabledReason:
-        catalogDisabledReason ?? disabledReason ?? (placementStartup ? null : sendHoldReason),
-      disabledReasonTone:
-        sessionParticipationBlocked && !suggestionViewer && !catalogDisabledReason
-          ? "info"
-          : "danger",
-      disabledBanner: this.sessionDisabledBanner({
-        catalogDisabledReason,
-        modelSetupRequired,
-        restartRecoveryTombstoned,
-        selectedSessionArchived,
-        selectedSessionId: selectedSession?.sessionId?.trim() || undefined,
-        sessionKey: state.sessionKey,
-        unarchiveAccess: mutationAccess.unarchive,
-      }),
+      ...composerAvailability,
       modelSetupRequired:
         modelSetupRequired && !selectedSessionArchived && !restartRecoveryTombstoned,
       onModelSetup: () => this.context.navigate("model-setup"),
       error: state.lastError,
-      diskSpace,
-      runError: catalogKey ? null : (state.chatRunError ?? placementRunError),
+      diskSpace: placementComposer.diskSpace,
+      runError: catalogKey ? null : (state.chatRunError ?? placementComposer.runError),
       inlineApproval: sessionParticipationBlocked ? null : inlineApproval,
       approvalBusy: overlays?.snapshot?.approvalBusy,
       approvalCanGrant: overlays?.snapshot?.approvalCanGrant ?? false,

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -154,8 +154,10 @@ export type TestChatPane = HTMLElement & {
   ) => Promise<void>;
   headerPlacementMovingKey: string | null;
   headerPlacementReclaimingKey: string | null;
+  headerPlacementRestartingKey: string | null;
   moveHeaderPlacement: (row: GatewaySessionRow) => Promise<void>;
   reclaimHeaderPlacement: (row: GatewaySessionRow) => Promise<void>;
+  restartHeaderPlacement: (row: GatewaySessionRow) => Promise<void>;
   markSessionRead: (row: GatewaySessionRow | undefined) => void;
   applySessionsState: (stateValue: ApplicationContext["sessions"]["state"]) => void;
   renderPaneHeader: (

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -75,6 +75,7 @@ export type ChatComposerProps = ChatAttachmentControlsProps & {
   canSend: boolean;
   disabledReason: string | null;
   disabledReasonTone?: "info" | "danger";
+  disabledReasonBusy?: boolean;
   disabledBanner?: ChatComposerDisabledBanner;
   runError?: { summary: string } | null;
   sending: boolean;

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -201,8 +201,9 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
     ? {
         text: props.disabledReason,
         tone: props.disabledReasonTone ?? ("danger" as const),
-        icon:
-          (props.disabledReasonTone ?? "danger") === "danger"
+        icon: props.disabledReasonBusy
+          ? html`<span class="btn__spinner" aria-hidden="true"></span>`
+          : (props.disabledReasonTone ?? "danger") === "danger"
             ? icons.alertTriangle
             : icons.shieldQuestion,
       }
@@ -219,6 +220,7 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
             class="agent-chat__composer-status-band"
             role=${primaryComposerStatus.tone === "danger" ? "alert" : "status"}
             aria-live="polite"
+            aria-busy=${props.disabledReasonBusy ? "true" : "false"}
           >
             <span class="agent-chat__composer-status-icon" aria-hidden="true"
               >${primaryComposerStatus.icon}</span
@@ -313,6 +315,7 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
             class="agent-chat__input agent-chat__input--chat agent-chat__input--mobile-toolbar ${props.offline
               ? "agent-chat__input--offline"
               : ""}${dictation?.active ? " agent-chat__input--dictating" : ""}"
+            aria-busy=${props.disabledReasonBusy ? "true" : "false"}
             @wa-show=${handleChatComposerDropdownShow}
             @wa-after-show=${restorePointerOpenedChatComposerTrigger}
             @openclaw-composer-dismiss-invocations=${() => {

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -78,8 +78,10 @@ type ChatPaneHeaderProps = {
   sharingControl?: TemplateResult | typeof nothing;
   sessionMenuAction: TemplateResult | typeof nothing;
   placementMoving?: boolean;
+  placementRestarting?: boolean;
   placementMoveDisabledReason?: string;
   placementReclaimDisabledReason?: string;
+  placementRestartDisabledReason?: string;
   nativeGateways?: NativeGatewaysCapability | null;
   gatewaysSnapshot?: NativeGatewaysSnapshot | null;
   onboarding?: boolean;
@@ -92,6 +94,7 @@ type ChatPaneHeaderProps = {
   onOpenParentSession: (sessionKey: string) => void;
   onPlacementMove?: () => void;
   onPlacementReclaim?: () => void;
+  onPlacementRestart?: () => void;
   onBranchSelect: (leafEntryId: string) => void;
   onOpenSplitView?: () => void;
   onSplitDown?: (paneId: string) => void;

--- a/ui/src/pages/chat/components/chat-pane-placement.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-placement.test.ts
@@ -82,4 +82,58 @@ describe("chat pane device placement", () => {
       expect(reclaim?.hasAttribute("disabled")).toBe(false);
     }
   });
+
+  it("offers restart without a redundant stop action after a failed worker is gone", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    containers.push(container);
+    const session: GatewaySessionRow = {
+      key: "agent:main:failed-worker",
+      kind: "direct",
+      updatedAt: 0,
+      placement: {
+        state: "failed",
+        generation: 2,
+        createdAtMs: 100_000,
+        updatedAtMs: 300_000,
+        stateChangedAtMs: 300_000,
+        recoveryError: "worker disappeared",
+        recoveryAction: "restart",
+      },
+    };
+
+    render(renderChatPanePlacement({ session }), container);
+
+    expect(container.querySelector(".chat-pane__placement-restart")?.textContent?.trim()).toBe(
+      "Restart session…",
+    );
+    expect(container.querySelector(".chat-pane__placement-reclaim")).toBeNull();
+  });
+
+  it("requires stop before restart while the failed worker environment may remain", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    containers.push(container);
+    const session: GatewaySessionRow = {
+      key: "agent:main:failed-worker",
+      kind: "direct",
+      updatedAt: 0,
+      placement: {
+        state: "failed",
+        generation: 2,
+        createdAtMs: 100_000,
+        updatedAtMs: 300_000,
+        stateChangedAtMs: 300_000,
+        recoveryError: "worker disappeared",
+        recoveryAction: "stop-first",
+      },
+    };
+
+    render(renderChatPanePlacement({ session }), container);
+
+    expect(container.querySelector(".chat-pane__placement-restart")).toBeNull();
+    expect(container.querySelector(".chat-pane__placement-reclaim")?.textContent?.trim()).toBe(
+      "Stop cloud worker…",
+    );
+  });
 });

--- a/ui/src/pages/chat/components/chat-pane-placement.ts
+++ b/ui/src/pages/chat/components/chat-pane-placement.ts
@@ -12,10 +12,13 @@ registerSessionPlacementEnglish();
 export function renderChatPanePlacement(props: {
   session: GatewaySessionRow | undefined;
   placementMoving?: boolean;
+  placementRestarting?: boolean;
   placementMoveDisabledReason?: string;
   placementReclaimDisabledReason?: string;
+  placementRestartDisabledReason?: string;
   onPlacementMove?: () => void;
   onPlacementReclaim?: () => void;
+  onPlacementRestart?: () => void;
 }): TemplateResult | typeof nothing {
   const placement = props.session?.placement;
   const placementState = placement?.state;
@@ -33,6 +36,7 @@ export function renderChatPanePlacement(props: {
   const hasFacts = Boolean(providerId || profileId || environmentId);
   const runner = placement?.state === "active" ? placement.runner : undefined;
   const deviceOffline = runner?.kind === "device" && runner.status === "offline";
+  const restartable = placement?.state === "failed" && placement.recoveryAction === "restart";
   const moveTarget =
     placementMove?.target.kind === "gateway"
       ? t("sessionsView.moveSessionGatewayTarget")
@@ -45,17 +49,20 @@ export function renderChatPanePlacement(props: {
     ? t("sessionsView.moveSessionFailed")
     : placementMove && moveTarget
       ? t("sessionsView.movingSession", { target: moveTarget })
-      : props.placementMoving
-        ? t("sessionsView.movingSessionGeneric")
-        : deviceOffline
-          ? t("sessionsView.deviceOffline")
-          : runner?.kind === "device"
-            ? t("sessionsView.runsOnDevice")
-            : providerId && profileId
-              ? `${providerId} · ${profileId}`
-              : t("newSession.runsOn", { place: t("newSession.cloud") });
+      : props.placementRestarting
+        ? t("sessionsView.restartingSession")
+        : props.placementMoving
+          ? t("sessionsView.movingSessionGeneric")
+          : deviceOffline
+            ? t("sessionsView.deviceOffline")
+            : runner?.kind === "device"
+              ? t("sessionsView.runsOnDevice")
+              : providerId && profileId
+                ? `${providerId} · ${profileId}`
+                : t("newSession.runsOn", { place: t("newSession.cloud") });
   const moveDisabledReason = props.placementMoveDisabledReason;
   const reclaimDisabledReason = props.placementReclaimDisabledReason;
+  const restartDisabledReason = props.placementRestartDisabledReason;
   const age = formatRelativeTimestamp(placement?.stateChangedAtMs, {
     fallback: "",
   });
@@ -97,36 +104,55 @@ export function renderChatPanePlacement(props: {
                 : nothing}
             </dl>`
           : nothing}
-        <wa-dropdown-item
-          class="session-menu__item chat-pane__placement-move ${deviceOffline
-            ? "session-menu__item--destructive"
-            : ""}"
-          variant=${deviceOffline ? "danger" : nothing}
-          ?disabled=${Boolean(moveDisabledReason)}
-          title=${moveDisabledReason ?? nothing}
-          @click=${() => !moveDisabledReason && props.onPlacementMove?.()}
-        >
-          <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.monitor}</span>
-          <span class="session-menu__text"
-            >${deviceOffline
-              ? t("sessionsView.continueOnGatewayMenu")
-              : t("sessionsView.moveSession")}</span
-          >
-        </wa-dropdown-item>
-        <wa-dropdown-item
-          class="session-menu__item session-menu__item--destructive chat-pane__placement-reclaim"
-          variant="danger"
-          ?disabled=${Boolean(reclaimDisabledReason)}
-          title=${reclaimDisabledReason ?? nothing}
-          @click=${() => !reclaimDisabledReason && props.onPlacementReclaim?.()}
-        >
-          <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.stop}</span>
-          <span class="session-menu__text"
-            >${runner?.kind === "device"
-              ? t("sessionsView.stopDeviceWorker")
-              : t("sessionsView.stopCloudWorker")}</span
-          >
-        </wa-dropdown-item>
+        ${placementState === "active"
+          ? html`<wa-dropdown-item
+              class="session-menu__item chat-pane__placement-move ${deviceOffline
+                ? "session-menu__item--destructive"
+                : ""}"
+              variant=${deviceOffline ? "danger" : nothing}
+              ?disabled=${Boolean(moveDisabledReason)}
+              title=${moveDisabledReason ?? nothing}
+              @click=${() => !moveDisabledReason && props.onPlacementMove?.()}
+            >
+              <span slot="icon" class="session-menu__icon" aria-hidden="true"
+                >${icons.monitor}</span
+              >
+              <span class="session-menu__text"
+                >${deviceOffline
+                  ? t("sessionsView.continueOnGatewayMenu")
+                  : t("sessionsView.moveSession")}</span
+              >
+            </wa-dropdown-item>`
+          : nothing}
+        ${restartable
+          ? html`<wa-dropdown-item
+              class="session-menu__item chat-pane__placement-restart"
+              ?disabled=${Boolean(restartDisabledReason)}
+              title=${restartDisabledReason ?? nothing}
+              @click=${() => !restartDisabledReason && props.onPlacementRestart?.()}
+            >
+              <span slot="icon" class="session-menu__icon" aria-hidden="true"
+                >${icons.monitor}</span
+              >
+              <span class="session-menu__text">${t("sessionsView.restartSession")}</span>
+            </wa-dropdown-item>`
+          : nothing}
+        ${restartable
+          ? nothing
+          : html`<wa-dropdown-item
+              class="session-menu__item session-menu__item--destructive chat-pane__placement-reclaim"
+              variant="danger"
+              ?disabled=${Boolean(reclaimDisabledReason)}
+              title=${reclaimDisabledReason ?? nothing}
+              @click=${() => !reclaimDisabledReason && props.onPlacementReclaim?.()}
+            >
+              <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.stop}</span>
+              <span class="session-menu__text"
+                >${runner?.kind === "device"
+                  ? t("sessionsView.stopDeviceWorker")
+                  : t("sessionsView.stopCloudWorker")}</span
+              >
+            </wa-dropdown-item>`}
       </wa-dropdown>
       ${deviceOffline
         ? html`<div class="chat-pane__placement-note" role="status">


### PR DESCRIPTION
Closes #134506

## What Problem This Solves

Fixes an issue where operators could not continue an established session from the Control UI after its remote worker placement failed. Recovery required a manual `sessions.dispatch` RPC, and the composer still accepted turns while replacement placement was syncing even though worker admission rejected them.

## Why This Change Was Made

The Gateway projects a closed `recoveryAction` from worker-environment lifecycle evidence. Chat uses that projection to offer either **Restart session…** or **Stop cloud worker…**, reuses the existing target picker, and keeps environment-liveness admission in the Gateway.

The composer also treats `requested`, `provisioning`, `syncing`, `starting`, `draining`, `reconciling`, and `failed` placements as unavailable. Transitional states show an attached busy status; `local`, `active`, and `reclaimed` remain sendable.

## User Impact

Operators can recover failed cloud or device sessions from Chat without creating a replacement session or invoking a low-level RPC. While a replacement environment is being prepared, Chat disables sending and explains the current placement step.

## Evidence

**Before:** failed placement exposed an error but no recovery action near the composer.

![Failed placement before the fix](https://github.com/user-attachments/assets/5431f0c9-d48c-43d1-92c4-867717dce448)

**After:** failed placement exposes the recovery action beside the disabled composer.

![Failed placement recovery after the fix](https://github.com/user-attachments/assets/4172fc62-f8a8-4a1c-8a27-75bd44ea8ba1)

- Live OCM verification restarted the existing session and preserved its session identity. The replacement placement progressed through `syncing` to `active`.
- Mocked Chromium verification covered failed recovery and syncing progress; both scenarios passed.
- `pnpm test packages/gateway-protocol/src/schema/session-placement.test.ts src/gateway/server.sessions.placement-projection.test.ts`: 50 tests passed after rebasing onto `origin/main`.
- `pnpm --dir ui exec vitest run --config vitest.config.ts src/pages/chat/chat-pane-placement-composer.test.ts src/pages/chat/chat-pane-placement-restart.test.ts src/pages/chat/chat-pane-placement.test.ts src/pages/chat/components/chat-pane-placement.test.ts src/pages/chat/chat-composer.test.ts`: 76 tests passed after rebasing.
- `node scripts/check-changed.mjs`: complete changed-file gate passed.
- `pnpm ui:build`: production Control UI build passed.
- P0 Autoreview: 12 of 12 review passes returned no actionable findings.
