### PR TITLE
fix(ui): prevent silent E2E builds from timing out

### DIFF
--- a/ui/src/app/vite-build.node.test.ts
+++ b/ui/src/app/vite-build.node.test.ts
@@ -1,11 +1,12 @@
 // @vitest-environment node
 import { createHash } from "node:crypto";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { brotliDecompressSync, gunzipSync } from "node:zlib";
-import { build, type InlineConfig } from "vite";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { build, createLogger, type InlineConfig } from "vite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ControlUiAssetManifest } from "../../../src/gateway/control-ui-asset-manifest.ts";
 import controlUiViteConfig from "../../vite.config.ts";
 
@@ -13,6 +14,16 @@ describe("Control UI Vite build", () => {
   let root: string;
   let outDir: string;
   let config: InlineConfig;
+  const info = vi.fn<(message: string) => void>();
+
+  function captureLogs(level: "info" | "silent") {
+    info.mockReset();
+    config.logLevel = level;
+    config.customLogger = createLogger(level, {
+      allowClearScreen: false,
+      console: { ...console, log: info, error: vi.fn() },
+    });
+  }
 
   beforeEach(async () => {
     root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "control-ui-vite-build-")));
@@ -24,6 +35,7 @@ describe("Control UI Vite build", () => {
       publicDir: false,
       logLevel: "silent",
     };
+    captureLogs("silent");
     await fs.writeFile(
       path.join(root, "index.html"),
       '<button>Load</button><script type="module" src="./main.js"></script>',
@@ -43,10 +55,12 @@ describe("Control UI Vite build", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await fs.rm(root, { recursive: true, force: true });
   });
 
   it("preserves an unresolved import diagnostic with a fresh output directory", async () => {
+    captureLogs("info");
     await fs.writeFile(path.join(root, "main.js"), 'import "./missing-module.js";');
 
     const result = build(config);
@@ -54,10 +68,80 @@ describe("Control UI Vite build", () => {
     await expect(result).rejects.toThrow(/Could not resolve.*missing-module\.js/u);
     await expect(result).rejects.not.toThrow(/ENOENT|asset-manifest/u);
     await expect(fs.stat(outDir)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(info.mock.calls.flat().join("\n")).not.toMatch(/precompression complete|built in/u);
+  });
+
+  it("reports completed compression work before build completion at a bounded cadence", async () => {
+    captureLogs("info");
+    let clockMs = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => clockMs);
+    const writeFileSync = fsSync.writeFileSync;
+    vi.spyOn(fsSync, "writeFileSync").mockImplementation((file, ...args) => {
+      writeFileSync(file, ...args);
+      if (String(file).endsWith(".br") || String(file).endsWith(".gz")) {
+        clockMs += 2_500;
+      }
+    });
+    const activity: Array<{ message: string; elapsed: number; assets: number; sidecars: number }> =
+      [];
+    info.mockImplementation((message: string) => {
+      if (!message.includes("Control UI precompression")) {
+        return;
+      }
+      const emitted = fsSync.readdirSync(path.join(outDir, "assets"));
+      activity.push({
+        message,
+        elapsed: clockMs,
+        assets: emitted.filter(
+          (name) => name.endsWith(".br") && emitted.includes(name.replace(/\.br$/u, ".gz")),
+        ).length,
+        sidecars: emitted.filter((name) => /\.(br|gz)$/u.test(name)).length,
+      });
+      // The logger observes real disk writes while build() is still finalizing.
+      expect(fsSync.existsSync(path.join(outDir, "asset-manifest.json"))).toBe(false);
+    });
+    config.plugins = [
+      ...(config.plugins ?? []),
+      {
+        name: "compression-progress-fixture",
+        generateBundle() {
+          for (let index = 0; index < 4; index++) {
+            this.emitFile({
+              type: "asset",
+              fileName: `assets/extra-${index}.txt`,
+              source: "fixture",
+            });
+          }
+        },
+      },
+    ];
+
+    await build(config);
+
+    const emitted = await fs.readdir(path.join(outDir, "assets"));
+    const completed = emitted.filter((name) => name.endsWith(".gz")).length;
+    expect(completed).toBeGreaterThan(4);
+    expect(
+      activity.map(({ elapsed, assets, sidecars }) => ({ elapsed, assets, sidecars })),
+    ).toEqual([
+      ...Array.from({ length: Math.floor(completed / 2) + 1 }, (_, index) => ({
+        elapsed: index * 10_000,
+        assets: index * 2,
+        sidecars: index * 4,
+      })),
+      { elapsed: completed * 5_000, assets: completed, sidecars: completed * 2 },
+    ]);
+    expect(activity[0]?.message).toMatch(/starting/u);
+    for (const entry of activity.slice(1)) {
+      expect(entry.message).toContain(`${entry.assets} assets (${entry.sidecars} sidecars)`);
+    }
+    expect(activity.at(-1)?.message).toContain("precompression complete");
+    await expect(fs.stat(path.join(outDir, "asset-manifest.json"))).resolves.toBeDefined();
   });
 
   it("inventories final emitted bytes and compressed variants, excluding source maps", async () => {
     await build(config);
+    expect(info).not.toHaveBeenCalled();
 
     const manifest: ControlUiAssetManifest = JSON.parse(
       await fs.readFile(path.join(outDir, "asset-manifest.json"), "utf8"),
@@ -101,6 +185,7 @@ describe("Control UI Vite build", () => {
   });
 
   it("preserves an output write failure without finalizing the build", async () => {
+    captureLogs("info");
     await fs.mkdir(outDir);
     await fs.writeFile(path.join(outDir, "blocked"), "output obstruction");
     config.build = { ...config.build, emptyOutDir: false, assetsDir: "blocked" };
@@ -109,9 +194,33 @@ describe("Control UI Vite build", () => {
 
     await expect(result).rejects.toThrow(/blocked/u);
     await expect(result).rejects.not.toThrow(/scandir|asset-manifest/u);
+    expect(info.mock.calls.flat().join("\n")).not.toMatch(/precompression complete|built in/u);
     expect(await fs.readFile(path.join(outDir, "blocked"), "utf8")).toBe("output obstruction");
     for (const file of ["asset-manifest.json", "sw.js"]) {
       await expect(fs.stat(path.join(outDir, file))).rejects.toMatchObject({ code: "ENOENT" });
     }
+  });
+
+  it("does not count an asset or report completion when its second sidecar write fails", async () => {
+    captureLogs("info");
+    const writeFileSync = fsSync.writeFileSync;
+    vi.spyOn(fsSync, "writeFileSync").mockImplementation((file, ...args) => {
+      if (String(file).endsWith(".gz")) {
+        throw new Error("synthetic gzip write failure");
+      }
+      writeFileSync(file, ...args);
+    });
+
+    await expect(build(config)).rejects.toThrow("synthetic gzip write failure");
+
+    const output = info.mock.calls.flat().join("\n");
+    expect(output).toContain("Control UI precompression: starting");
+    expect(output).not.toMatch(/\d+ assets|precompression complete|built in/u);
+    const emitted = await fs.readdir(path.join(outDir, "assets"));
+    expect(emitted.filter((name) => name.endsWith(".br"))).toHaveLength(1);
+    expect(emitted.filter((name) => name.endsWith(".gz"))).toHaveLength(0);
+    await expect(fs.stat(path.join(outDir, "asset-manifest.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 });

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -809,12 +809,14 @@ export async function buildProductionControlUiE2e(outDir: string, buildId: strin
       cwd: uiRoot,
       encoding: "utf8",
       env,
+      // Forward build activity while spawnSync waits; retain stderr for failures.
+      stdio: ["ignore", "inherit", "pipe"],
       maxBuffer: 10 * 1024 * 1024,
     },
   );
   if (result.status !== 0) {
     throw new Error(
-      `Production Control UI build failed (exit ${result.status ?? "unknown"}):\n${result.stderr || result.stdout}`,
+      `Production Control UI build failed (exit ${result.status ?? "unknown"}):\n${result.stderr || result.error?.message || "See streamed build output above."}`,
     );
   }
 }
@@ -827,7 +829,7 @@ async function runProductionControlUiBuild(outDir: string): Promise<void> {
   await build({
     ...controlUiViteConfig({ outDir }),
     configFile: false,
-    logLevel: "error",
+    logLevel: "info",
     root: path.join(resolveRepoRoot(), "ui"),
   });
 }
@@ -871,7 +873,10 @@ export async function startBundledControlUiE2eServer(outDir: string): Promise<Co
     import("vite"),
     import("../../vite.config.ts"),
   ]);
-  await build(createBundledControlUiE2eConfig(controlUiViteConfig, outDir));
+  await build({
+    ...createBundledControlUiE2eConfig(controlUiViteConfig, outDir),
+    logLevel: "info",
+  });
   return startBuiltControlUiE2eServer(outDir);
 }
 

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -418,15 +418,36 @@ function controlUiPrecompressedAssetsPlugin(buildOutDir: string): Plugin {
     name: "control-ui-precompressed-assets",
     apply: "build",
     writeBundle(_options, bundle) {
+      const logger = this.environment.logger;
+      let completed = 0;
+      let sidecars = 0;
+      let lastProgressAt = performance.now();
+      logger.info("Control UI precompression: starting");
       for (const output of Object.values(bundle)) {
         // Vite's post-build import analysis rewrites lazy preload markers in a
         // later generateBundle hook. Read from disk here so sidecars always
         // encode the exact final bytes that the identity response serves.
         const source = fs.readFileSync(path.join(buildOutDir, output.fileName));
-        for (const variant of createControlUiPrecompressedAssetVariants(output.fileName, source)) {
+        const variants = createControlUiPrecompressedAssetVariants(output.fileName, source);
+        if (variants.length === 0) {
+          continue;
+        }
+        for (const variant of variants) {
           fs.writeFileSync(path.join(buildOutDir, variant.fileName), variant.source);
         }
+        // Only completed writes renew activity; a blocked compression/write must
+        // remain silent so the caller's existing watchdog can still terminate it.
+        completed++;
+        sidecars += variants.length;
+        const now = performance.now();
+        if (now - lastProgressAt >= 10_000) {
+          logger.info(
+            `Control UI precompression: ${completed} assets (${sidecars} sidecars) written`,
+          );
+          lastProgressAt = now;
+        }
       }
+      logger.info(`Control UI precompression complete: ${completed} assets (${sidecars} sidecars)`);
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where developers running local Control UI E2E checks could have an actively progressing build terminated by the no-output watchdog before any assertions ran.

This is a tooling follow-up discovered while validating #134833 (collapsed-user-message overlap). It does not change that CSS repair, its regression test, native Talk, or Gateway behavior.

## Why This Change Was Made

The E2E build suppressed Vite's normal phase output, synchronous precompression emitted no completed-work progress, and the separate production-build helper buffered stdout. The outer watchdog correctly watches child stdout/stderr, making these build paths indistinguishable from a stall during prolonged silence.

Build invocations now expose native phase information; the existing precompression owner reports completed asset pairs at a ten-second minimum cadence; the production child streams stdout while retaining stderr diagnostics. There is no unconditional heartbeat, new build path, dependency change, or watchdog/test deadline increase. A genuinely blocked compression/write remains subject to the existing watchdog.

## User Impact

Developers can observe build phases and actual compression progress while Control UI E2E setup runs. Preview/source-server logging, isolated build output, once-per-shard lifetime, and compression bytes are unchanged. There is no rendered UI or Gateway behavior change.

Build tooling: +22/-1 (net +21) for completed-work reporting at the existing owner. Test support: +8/-3 (net +5) for build logging and stdout streaming. Tests: +111/-2 (net +109).

## Evidence

The historical attempt at `dc59427717beca6184b323f198341a4f79261338` ended with a 300000 ms no-output timeout and exit 143 before assertions. That original delay cannot be attributed retrospectively to one build phase or host resource. A fresh same-head run completed; a scaled watchdog probe demonstrated completed compression work with zero watched output. Sampling a slow diagnostic build showed active filesystem work, not a demonstrated lifecycle deadlock.

Failing-first real-build regressions failed twice before the repair and passed afterward. They check progress against actual emitted sidecars before manifest finalization, bounded cadence, silent logging, preserved import/write diagnostics, and no false completion after a partial sidecar-write failure. Existing watchdog coverage verifies that genuine silence still terminates the process group.

Initial repaired-flow proof used isolated synthetic Chromium contexts and mocked Gateway data with the unchanged default watchdog. A slow run emitted progress at 172 and 318 completed assets before finishing; the separate production child's output arrived before its browser assertion, proving streaming while the synchronous caller waited. The UI production build verified 794 sidecars and performance budgets; the complete changed-file gate passed.

The candidate is commit `7734489e66ffdee39fc4a8fd32204158892d3cf3`, one focused commit over `4002cc5bed0ea608612dec749e80adf17138f6f7`. The three owning files remain otherwise identical on inspected main `2a920ab94d329906246fb98b4bcbc04eaeb2034d`; unrelated native Talk ancestry is excluded.

Resumed local validation initially stopped in the unchanged watchdog fixture before the UI tests ran: its first readiness barrier timed out, and one Git child remained in uninterruptible I/O during shutdown. The failed log and temporary namespace were retained; a later process check confirmed that child had exited. No timeout was changed.

A resumed production build then stopped while loading Vite config because the local dependency tree resolved `pako` 1.0.11 despite both manifests pinning 3.0.1. A frozen-lockfile reinstall restored 3.0.1 without changing the import, dependency pins, lockfile, or source. The failed attempts remain recorded as environment/startup failures, not passing proof.

Refreshed proof on exact commit `7734489e66ffdee39fc4a8fd32204158892d3cf3`:

- Build/config/watchdog suites: **30 passed**. The previously failing unchanged watchdog fixture passed without any timeout or source change.
- Default-watchdog browser proof: **5 passed, 1 intentionally filtered out** across disclosure and production-child deep-link tests. Both real build paths completed.
- Production UI build: **798 finalized sidecars verified**, with all performance budgets passing.
- Fresh independent exact-commit review: **scoped-clean at P0**, no accepted/actionable findings.
- [Exact-head CI run 33488900180](https://github.com/openclaw/openclaw/actions/runs/33488900180): **completed successfully on attempt 1** at `7734489e66ffdee39fc4a8fd32204158892d3cf3`. The exact-head watcher reported zero pending checks and `GREEN`. Repository-native review/prepare/merge gates are in progress.

Focused verification commands:

```bash
node scripts/run-vitest.mjs ui/src/app/vite-build.node.test.ts ui/src/app/vite-config.node.test.ts test/scripts/run-vitest-progress.test.ts
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts ui/src/e2e/service-worker-update.e2e.test.ts -t 'keeps seven short lines|clamps a 1300-character|keeps collapsed paragraphs readable|boots a document loaded on a deep link'
```

```bash
node scripts/ui.js build
```

```bash
node scripts/check-changed.mjs -- ui/vite.config.ts ui/src/test-helpers/control-ui-e2e.ts ui/src/app/vite-build.node.test.ts
```

This changes developer build output rather than visual UI. The independent completed CSS repair's screenshots are not reused as proof of this tooling change. No changelog, provider credentials, live operator Gateway, or deployment changes are included.
