### PR TITLE
fix(qa): preserve nested suite ownership and share progress transitions

### DIFF
--- a/extensions/qa-lab/src/suite-progress.ts
+++ b/extensions/qa-lab/src/suite-progress.ts
@@ -82,6 +82,18 @@ export function createQaSuiteProgressController(params: {
       }
       emit("running");
     },
+    recordScenarioResult(scenarioId: string, result: QaSuiteProgressResult["result"]) {
+      // Runner outcomes retain catalog titles and assign even empty details.
+      // Aggregate results below instead merge names/details from child reports.
+      outcomes.set(scenarioId, {
+        ...outcomes.get(scenarioId)!,
+        status: result.status,
+        details: result.details,
+        steps: result.steps,
+        finishedAt: new Date().toISOString(),
+      });
+      emit("running");
+    },
     recordResults(entries: readonly QaSuiteProgressResult[]) {
       const finishedAt = new Date().toISOString();
       for (const entry of entries) {

--- a/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
@@ -1,10 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import type { QaLabServerHandle } from "./lab-server.types.js";
 import type { QaTransportAdapterFactory } from "./qa-transport-registry.js";
+import * as scenarioCatalog from "./scenario-catalog.js";
 import type { writeQaSuiteArtifacts } from "./suite-artifacts.js";
 import { runQaFlowSuiteIsolated } from "./suite-run-isolated.js";
 import { runQaFlowSuiteStandard } from "./suite-run-standard.js";
+import { runQaFlowSuiteFromRuntime } from "./suite-run.runtime.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
 import type {
   QaSuiteResolvedRunContext,
@@ -12,6 +16,10 @@ import type {
   QaSuiteScenarioResult,
   QaSuiteScenarioRunner,
 } from "./suite-types.js";
+import * as suite from "./suite.js";
+import { createTempDirHarness } from "./temp-dir.test-helper.js";
+
+const tempDirs = createTempDirHarness();
 
 const mocks = vi.hoisted(() => ({
   disposeRegisteredAgentHarnesses: vi.fn(async () => {}),
@@ -73,6 +81,7 @@ vi.mock("./providers/server-runtime.js", () => ({
   startQaProviderServer: vi.fn(async () => undefined),
 }));
 vi.mock("./suite-artifacts.js", () => ({
+  invalidateQaSuiteArtifactGeneration: vi.fn(async () => {}),
   writeQaSuiteArtifacts: mocks.writeQaSuiteArtifacts,
 }));
 vi.mock("./suite-runtime-gateway.js", () => ({
@@ -121,6 +130,176 @@ describe("isolated QA suite transport cleanup", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.disposeRegisteredAgentHarnesses.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+    await tempDirs.cleanup();
+  });
+
+  it.each(["running", "pass", "fail"])(
+    "preserves the %s progress publication exception boundary",
+    async (status) => {
+      const lab = createCleanupTestLab();
+      const publicationError = new Error("progress publication rejected");
+      vi.mocked(lab.setScenarioRun).mockImplementation((next) => {
+        if (next?.scenarios[0]?.status === status) {
+          throw publicationError;
+        }
+      });
+      const runChild = vi.fn<QaSuiteRunner>().mockResolvedValue({
+        outputDir: "/qa-child",
+        evidencePath: "/qa-child/qa-evidence.json",
+        reportPath: "/qa-child/qa-suite-report.md",
+        summaryPath: "/qa-child/qa-suite-summary.json",
+        report: "",
+        scenarios: [{ name: "worker result", status: "pass", steps: [] }],
+        startedScenarioIds: ["leased-channel-scenario"],
+        watchUrl: lab.baseUrl,
+      });
+      if (status === "fail") {
+        runChild.mockRejectedValueOnce(new Error("worker failed"));
+      }
+      const run = runQaFlowSuiteIsolated(
+        { lab, startLab: async () => lab },
+        createCleanupTestContext(),
+        runChild,
+      );
+      if (status === "pass") {
+        await expect(run).resolves.toMatchObject({
+          scenarios: [{ status: "fail", details: publicationError.message }],
+        });
+      } else {
+        await expect(run).rejects.toBe(publicationError);
+        expect(mocks.writeQaSuiteArtifacts).not.toHaveBeenCalled();
+      }
+      expect(runChild).toHaveBeenCalledTimes(status === "running" ? 0 : 1);
+      expect(mocks.disposeRegisteredAgentHarnesses).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("keeps out-of-order progress times while draining partial artifacts before cleanup", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const at = (second: number) => new Date(Date.UTC(2026, 7, 4, 0, 0, second));
+    vi.setSystemTime(at(0));
+    const lab = createCleanupTestLab();
+    const context = createCleanupTestContext();
+    context.concurrency = 2;
+    context.selectedScenarios = ["first", "second"].map((id) => {
+      const scenario = makeQaSuiteTestScenario(id);
+      scenario.title = `Catalog ${id}`;
+      return scenario;
+    });
+    const snapshots: Parameters<QaLabServerHandle["setScenarioRun"]>[0][] = [];
+    const completed = [createDeferred<void>(), createDeferred<void>()];
+    vi.mocked(lab.setScenarioRun).mockImplementation((next) => {
+      snapshots.push(structuredClone(next));
+      next?.scenarios.forEach((scenario, index) => {
+        if (scenario.status === "pass") {
+          completed[index]!.resolve();
+        }
+      });
+    });
+    const workers = [
+      createDeferred<Awaited<ReturnType<QaSuiteRunner>>>(),
+      createDeferred<Awaited<ReturnType<QaSuiteRunner>>>(),
+    ];
+    const allStarted = createDeferred<void>();
+    const runChild = vi.fn<QaSuiteRunner>().mockImplementation(() => {
+      if (runChild.mock.calls.length === 2) {
+        allStarted.resolve();
+      }
+      return workers[runChild.mock.calls.length - 1]!.promise;
+    });
+    const partialWrite = createDeferred<void>();
+    const artifacts = {
+      evidence: undefined,
+      evidencePath: "/qa-output/qa-evidence.json",
+      report: "",
+      reportPath: "/qa-output/qa-suite-report.md",
+      summaryPath: "/qa-output/qa-suite-summary.json",
+    };
+    mocks.writeQaSuiteArtifacts.mockImplementationOnce(async () => {
+      await partialWrite.promise;
+      return artifacts;
+    });
+    mocks.disposeRegisteredAgentHarnesses.mockImplementationOnce(async () => {
+      expect(mocks.writeQaSuiteArtifacts).toHaveBeenCalledTimes(2);
+      expect(snapshots.at(-1)?.status).toBe("running");
+      vi.setSystemTime(at(10));
+    });
+    const results: QaSuiteScenarioResult[] = [
+      { name: "result first", status: "pass", steps: [] },
+      {
+        name: "result second",
+        status: "pass",
+        details: "",
+        steps: [{ name: "check", status: "pass" }],
+      },
+    ];
+    const run = runQaFlowSuiteIsolated(
+      { lab, startLab: async () => lab, workerStartStaggerMs: 0 },
+      context,
+      runChild,
+    );
+    await allStarted.promise;
+    for (const index of [1, 0]) {
+      vi.setSystemTime(at(2 - index));
+      workers[index]!.resolve({
+        ...artifacts,
+        outputDir: "/qa-child",
+        scenarios: [results[index]!],
+        startedScenarioIds: [context.selectedScenarios[index]!.id],
+        watchUrl: lab.baseUrl,
+      });
+      await completed[index]!.promise;
+    }
+    expect(mocks.writeQaSuiteArtifacts).toHaveBeenCalledOnce();
+    expect(mocks.disposeRegisteredAgentHarnesses).not.toHaveBeenCalled();
+    partialWrite.resolve();
+    const result = await run;
+
+    expect(result.scenarios).toEqual(results);
+    expect(
+      snapshots.map((snapshot) => snapshot?.scenarios.map((scenario) => scenario.status)),
+    ).toEqual([
+      ["pending", "pending"],
+      ["running", "pending"],
+      ["running", "running"],
+      ["running", "pass"],
+      ["pass", "pass"],
+      ["pass", "pass"],
+    ]);
+    expect(snapshots.at(-1)).toStrictEqual({
+      kind: "suite",
+      status: "completed",
+      startedAt: at(0).toISOString(),
+      finishedAt: at(10).toISOString(),
+      scenarios: context.selectedScenarios.map((scenario, index) => ({
+        id: scenario.id,
+        name: scenario.title,
+        status: "pass",
+        details: results[index]!.details,
+        steps: results[index]!.steps,
+        startedAt: at(0).toISOString(),
+        finishedAt: at(2 - index).toISOString(),
+      })),
+    });
+    expect(
+      mocks.writeQaSuiteArtifacts.mock.calls.map(([params]) => [params.status, params.scenarios]),
+    ).toEqual([
+      ["running", [results[1]]],
+      ["running", results],
+      [undefined, results],
+    ]);
+    expect(mocks.disposeRegisteredAgentHarnesses.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.writeQaSuiteArtifacts.mock.invocationCallOrder[2]!,
+    );
+    expect(vi.mocked(lab.setLatestReport).mock.invocationCallOrder.at(-1)!).toBeLessThan(
+      vi.mocked(lab.setScenarioRun).mock.invocationCallOrder.at(-1)!,
+    );
   });
 
   it("records a rejected dispatched worker and leaves the fail-fast tail unstarted", async () => {
@@ -253,7 +432,9 @@ describe("isolated QA suite transport cleanup", () => {
     stderrWrite.mockRestore();
   });
 
-  it("keeps Crabline workers concurrent while publishing readiness only from the final aggregate", async () => {
+  it("preserves nested publication ownership through concurrent worker runtime preparation", async () => {
+    vi.stubEnv("OPENCLAW_QA_SUITE_PROGRESS", "1");
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     const lab = createCleanupTestLab();
     const selection = {
       capabilityMatrixPath: "crabline-channel-driver-capabilities.json",
@@ -276,8 +457,11 @@ describe("isolated QA suite transport cleanup", () => {
       releaseScenarioExecutions = resolve;
     });
     const context = createCleanupTestContext();
+    context.repoRoot = await tempDirs.makeTempDir("qa-nested-workers-");
+    context.outputDir = path.join(context.repoRoot, "output");
     context.channelDriver = "crabline";
     context.concurrency = 2;
+    context.progressEnabled = true;
     context.selectedScenarios = [
       makeQaSuiteTestScenario("first-crabline-scenario"),
       makeQaSuiteTestScenario("second-crabline-scenario"),
@@ -297,6 +481,12 @@ describe("isolated QA suite transport cleanup", () => {
           steps: [],
         };
       });
+    vi.spyOn(scenarioCatalog, "readQaBootstrapScenarioCatalog").mockReturnValue({
+      agentIdentityMarkdown: "test",
+      kickoffTask: "test",
+      scenarios: context.selectedScenarios,
+    });
+    vi.spyOn(suite, "runQaSuiteScenarioDefinitionForRuntime").mockImplementation(runScenario);
     const runChild = vi.fn<QaSuiteRunner>().mockImplementation(async (params) => {
       if (!params) {
         throw new Error("expected nested standard run params");
@@ -311,22 +501,8 @@ describe("isolated QA suite transport cleanup", () => {
       if (scenarioId === "second-crabline-scenario") {
         await firstScenarioStarted;
       }
-      const scenario = context.selectedScenarios.find((candidate) => candidate.id === scenarioId);
-      if (!scenario) {
-        throw new Error(`missing scenario ${scenarioId}`);
-      }
       try {
-        return await runQaFlowSuiteStandard(
-          params,
-          {
-            ...context,
-            startedAt: new Date("2026-08-04T00:00:01.000Z"),
-            outputDir: params.outputDir ?? `/qa-child/${scenarioId}`,
-            selectedScenarios: [scenario],
-            concurrency: 1,
-          },
-          runScenario,
-        );
+        return await runQaFlowSuiteFromRuntime(params);
       } finally {
         activeWorkers -= 1;
       }
@@ -349,6 +525,13 @@ describe("isolated QA suite transport cleanup", () => {
       expect.objectContaining({ name: "second-crabline-scenario", status: "pass" }),
     ]);
     expect(runScenario).toHaveBeenCalledTimes(2);
+    expect(
+      stderrWrite.mock.calls
+        .flat()
+        .join("")
+        .split("\n")
+        .filter((line) => line.startsWith("[qa-suite] run complete")),
+    ).toEqual(["[qa-suite] run complete"]);
     expect(mocks.writeQaSuiteArtifacts).toHaveBeenCalledTimes(5);
     for (const [nonFinalArtifacts] of mocks.writeQaSuiteArtifacts.mock.calls.slice(0, -1)) {
       expect(nonFinalArtifacts).toMatchObject({ channel: "telegram", channelDriver: "crabline" });

--- a/extensions/qa-lab/src/suite-run-isolated.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.ts
@@ -1,13 +1,14 @@
 import path from "node:path";
 import { disposeRegisteredAgentHarnesses } from "openclaw/plugin-sdk/agent-harness";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import type { QaLabLatestReport, QaLabScenarioOutcome } from "./lab-server.types.js";
+import type { QaLabLatestReport } from "./lab-server.types.js";
 import {
   formatQaScenarioFailureSuffix,
   sanitizeQaProgressValue as sanitizeQaSuiteProgressValue,
 } from "./progress-format.js";
 import { writeQaSuiteArtifacts } from "./suite-artifacts.js";
 import { mapQaSuiteWithConcurrency, resolveQaSuiteWorkerStartStaggerMs } from "./suite-planning.js";
+import { createQaSuiteProgressController } from "./suite-progress.js";
 import { buildQaIsolatedScenarioWorkerParams } from "./suite-support.js";
 import type {
   QaSuiteResolvedRunContext,
@@ -68,18 +69,11 @@ export async function runQaFlowSuiteIsolated(
     transportId,
   });
   const transport = transportFactoryResult.adapter;
-  const liveScenarioOutcomes: QaLabScenarioOutcome[] = selectedScenarios.map((scenario) => ({
-    id: scenario.id,
-    name: scenario.title,
-    status: "pending",
-  }));
-  const updateScenarioRun = () =>
-    lab.setScenarioRun({
-      kind: "suite",
-      status: "running",
-      startedAt: startedAt.toISOString(),
-      scenarios: [...liveScenarioOutcomes],
-    });
+  const progress = createQaSuiteProgressController({
+    lab,
+    scenarios: selectedScenarios,
+    startedAt: startedAt.toISOString(),
+  });
   const completedScenarioResults: Array<QaSuiteScenarioResult | undefined> = Array.from({
     length: selectedScenarios.length,
   });
@@ -150,7 +144,7 @@ export async function runQaFlowSuiteIsolated(
       await transportFactoryResult.cleanupWithoutGateway();
       parentTransportCleaned = true;
     }
-    updateScenarioRun();
+    progress.start();
     const workerStartStaggerMs =
       params?.workerStartStaggerMs ?? resolveQaSuiteWorkerStartStaggerMs(concurrency);
     writeQaSuiteProgress(progressEnabled, `scenario start stagger=${workerStartStaggerMs}ms`);
@@ -163,13 +157,7 @@ export async function runQaFlowSuiteIsolated(
           progressEnabled,
           `scenario start (${index + 1}/${selectedScenarios.length}): ${scenarioIdForLog}`,
         );
-        liveScenarioOutcomes[index] = {
-          id: scenario.id,
-          name: scenario.title,
-          status: "running",
-          startedAt: new Date().toISOString(),
-        };
-        updateScenarioRun();
+        progress.markRunning([scenario.id]);
         try {
           const scenarioOutputDir = path.join(outputDir, "scenarios", scenario.id);
           const workerParams = markQaSuiteNestedRun(
@@ -207,16 +195,7 @@ export async function runQaFlowSuiteIsolated(
                 },
               ],
             } satisfies QaSuiteScenarioResult);
-          liveScenarioOutcomes[index] = {
-            id: scenario.id,
-            name: scenario.title,
-            status: scenarioResult.status,
-            details: scenarioResult.details,
-            steps: scenarioResult.steps,
-            startedAt: liveScenarioOutcomes[index]?.startedAt,
-            finishedAt: new Date().toISOString(),
-          };
-          updateScenarioRun();
+          progress.recordScenarioResult(scenario.id, scenarioResult);
           writeQaSuiteProgress(
             progressEnabled,
             `scenario ${scenarioResult.status} (${index + 1}/${selectedScenarios.length}): ${scenarioIdForLog}${formatQaScenarioFailureSuffix(scenarioResult)}`,
@@ -238,16 +217,7 @@ export async function runQaFlowSuiteIsolated(
               },
             ],
           } satisfies QaSuiteScenarioResult;
-          liveScenarioOutcomes[index] = {
-            id: scenario.id,
-            name: scenario.title,
-            status: "fail",
-            details,
-            steps: scenarioResult.steps,
-            startedAt: liveScenarioOutcomes[index]?.startedAt,
-            finishedAt: new Date().toISOString(),
-          };
-          updateScenarioRun();
+          progress.recordScenarioResult(scenario.id, scenarioResult);
           writeQaSuiteProgress(
             progressEnabled,
             `scenario fail (${index + 1}/${selectedScenarios.length}): ${scenarioIdForLog}${formatQaScenarioFailureSuffix(scenarioResult)}`,
@@ -321,13 +291,7 @@ export async function runQaFlowSuiteIsolated(
     markdown: report,
     generatedAt: terminalFinishedAt.toISOString(),
   } satisfies QaLabLatestReport);
-  lab.setScenarioRun({
-    kind: "suite",
-    status: "completed",
-    startedAt: startedAt.toISOString(),
-    finishedAt: terminalFinishedAt.toISOString(),
-    scenarios: [...liveScenarioOutcomes],
-  });
+  progress.complete([], terminalFinishedAt.toISOString());
   const result = {
     outputDir,
     evidence,

--- a/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
+++ b/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
@@ -149,6 +149,7 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  vi.useRealTimers();
   vi.unstubAllEnvs();
   await tempDirs.cleanup();
 });
@@ -219,6 +220,97 @@ describe("QA suite Control UI ownership", () => {
 });
 
 describe("QA runtime parity scenario retry isolation", () => {
+  it.each([false, true])(
+    "preserves runner progress through cleanup (failFast=%s)",
+    async (failFast) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      const at = (second: number) => new Date(Date.UTC(2026, 7, 4, 0, 0, second));
+      vi.setSystemTime(at(0));
+      const lab = makeRetryTestLab();
+      const context = makeRetryTestContext();
+      context.selectedScenarios = ["first", "second", "tail"].map((id) => {
+        const scenario = makeQaSuiteTestScenario(id);
+        scenario.title = `Catalog ${id}`;
+        if (scenario.execution.kind === "flow") {
+          scenario.execution.retryCount = 0;
+        }
+        return scenario;
+      });
+      const snapshots: Parameters<QaLabServerHandle["setScenarioRun"]>[0][] = [];
+      vi.mocked(lab.setScenarioRun).mockImplementation((next) =>
+        snapshots.push(structuredClone(next)),
+      );
+      const results: QaSuiteScenarioResult[] = [
+        {
+          name: "result first",
+          status: "pass",
+          details: "",
+          steps: [{ name: "check", status: "pass" }],
+        },
+        { name: "result second", status: "fail", steps: [] },
+        { name: "result tail", status: "skip", details: "not applicable", steps: [] },
+      ];
+      const runScenario = vi.fn<QaSuiteScenarioRunner>().mockImplementation(async () => {
+        const index = runScenario.mock.calls.length - 1;
+        vi.setSystemTime(at(index + 1));
+        return results[index]!;
+      });
+      mocks.runQaFlowSuiteCleanupPlan.mockImplementationOnce(async () => {
+        expect(snapshots.every((snapshot) => snapshot?.status === "running")).toBe(true);
+        expect(mocks.writeQaSuiteArtifacts).not.toHaveBeenCalled();
+        vi.setSystemTime(at(10));
+        return [];
+      });
+
+      await runQaFlowSuiteStandard({ lab, failFast }, context, runScenario);
+
+      const finishedCount = failFast ? 2 : 3;
+      const finalStatuses = failFast ? ["pass", "fail", "pending"] : ["pass", "fail", "skip"];
+      expect(
+        snapshots.map((snapshot) => snapshot?.scenarios.map((scenario) => scenario.status)),
+      ).toEqual([
+        ["pending", "pending", "pending"],
+        ["running", "pending", "pending"],
+        ["pass", "pending", "pending"],
+        ["pass", "running", "pending"],
+        ["pass", "fail", "pending"],
+        ...(failFast
+          ? []
+          : [
+              ["pass", "fail", "running"],
+              ["pass", "fail", "skip"],
+            ]),
+        finalStatuses,
+      ]);
+      expect(snapshots.at(-1)).toStrictEqual({
+        kind: "suite",
+        status: "completed",
+        startedAt: at(0).toISOString(),
+        finishedAt: at(10).toISOString(),
+        scenarios: context.selectedScenarios.map((scenario, index) =>
+          Object.assign(
+            { id: scenario.id, name: scenario.title, status: finalStatuses[index] },
+            index < finishedCount
+              ? {
+                  details: results[index]!.details,
+                  steps: results[index]!.steps,
+                  startedAt: at(index).toISOString(),
+                  finishedAt: at(index + 1).toISOString(),
+                }
+              : {},
+          ),
+        ),
+      });
+      expect(runScenario).toHaveBeenCalledTimes(finishedCount);
+      expect(mocks.writeQaSuiteArtifacts.mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(lab.setLatestReport).mock.invocationCallOrder[0]!,
+      );
+      expect(vi.mocked(lab.setLatestReport).mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(lab.setScenarioRun).mock.invocationCallOrder.at(-1)!,
+      );
+    },
+  );
+
   it("does not publish terminal artifacts when cleanup fails", async () => {
     const lab = makeRetryTestLab();
     const cleanupError = Object.assign(new Error("gateway shutdown socket reset"), {

--- a/extensions/qa-lab/src/suite-run-standard.ts
+++ b/extensions/qa-lab/src/suite-run-standard.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { disposeRegisteredAgentHarnesses } from "openclaw/plugin-sdk/agent-harness";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createQaGatewayChild } from "./gateway-child.js";
-import type { QaLabLatestReport, QaLabScenarioOutcome } from "./lab-server.types.js";
+import type { QaLabLatestReport } from "./lab-server.types.js";
 import {
   formatQaScenarioFailureSuffix,
   sanitizeQaProgressValue as sanitizeQaSuiteProgressValue,
@@ -23,6 +23,7 @@ import {
   collectQaSuiteTransportPolicy,
   scenarioRequiresControlUi,
 } from "./suite-planning.js";
+import { createQaSuiteProgressController } from "./suite-progress.js";
 import { runQaSuiteRoundTripProbe } from "./suite-round-trip.js";
 import { waitForGatewayHealthy, waitForTransportReady } from "./suite-runtime-gateway.js";
 import {
@@ -203,18 +204,12 @@ export async function runQaFlowSuiteStandard(
     }
     const scenarios: QaSuiteScenarioResult[] = [];
     let runtimeParityCellTiming: QaRuntimeParityCellTiming | undefined;
-    const liveScenarioOutcomes: QaLabScenarioOutcome[] = selectedScenarios.map((scenario) => ({
-      id: scenario.id,
-      name: scenario.title,
-      status: "pending",
-    }));
-
-    lab.setScenarioRun({
-      kind: "suite",
-      status: "running",
+    const progress = createQaSuiteProgressController({
+      lab,
+      scenarios: selectedScenarios,
       startedAt: startedAt.toISOString(),
-      scenarios: liveScenarioOutcomes,
     });
+    progress.start();
 
     const gatewayProcessRssSamples: QaSuiteGatewayRssSample[] = [];
     const sampleGatewayProcessRss = (label: string) => {
@@ -253,18 +248,7 @@ export async function runQaFlowSuiteStandard(
         `scenario start (${index + 1}/${selectedScenarios.length}): ${scenarioIdForLog}`,
       );
       sampleGatewayProcessRss(`scenario:${scenario.id}:start`);
-      liveScenarioOutcomes[index] = {
-        id: scenario.id,
-        name: scenario.title,
-        status: "running",
-        startedAt: new Date().toISOString(),
-      };
-      lab.setScenarioRun({
-        kind: "suite",
-        status: "running",
-        startedAt: startedAt.toISOString(),
-        scenarios: [...liveScenarioOutcomes],
-      });
+      progress.markRunning([scenario.id]);
 
       const scenarioBootstrapFinishedAt = new Date();
       let scenarioExecutionStartedAt = scenarioBootstrapFinishedAt;
@@ -328,21 +312,7 @@ export async function runQaFlowSuiteStandard(
         progressEnabled,
         `scenario ${scenarioResult.status} (${index + 1}/${selectedScenarios.length}): ${scenarioIdForLog}${formatQaScenarioFailureSuffix(scenarioResult)}`,
       );
-      liveScenarioOutcomes[index] = {
-        id: scenario.id,
-        name: scenario.title,
-        status: scenarioResult.status,
-        details: scenarioResult.details,
-        steps: scenarioResult.steps,
-        startedAt: liveScenarioOutcomes[index]?.startedAt,
-        finishedAt: new Date().toISOString(),
-      };
-      lab.setScenarioRun({
-        kind: "suite",
-        status: "running",
-        startedAt: startedAt.toISOString(),
-        scenarios: [...liveScenarioOutcomes],
-      });
+      progress.recordScenarioResult(scenario.id, scenarioResult);
       if (params?.failFast === true && scenarioResult.status === "fail") {
         break;
       }
@@ -424,13 +394,7 @@ export async function runQaFlowSuiteStandard(
         markdown: report,
         generatedAt: finishedAt.toISOString(),
       } satisfies QaLabLatestReport);
-      lab.setScenarioRun({
-        kind: "suite",
-        status: "completed",
-        startedAt: startedAt.toISOString(),
-        finishedAt: finishedAt.toISOString(),
-        scenarios: [...liveScenarioOutcomes],
-      });
+      progress.complete([], finishedAt.toISOString());
       return {
         outputDir,
         evidence,

--- a/extensions/qa-lab/src/suite-run.runtime.ts
+++ b/extensions/qa-lab/src/suite-run.runtime.ts
@@ -24,6 +24,8 @@ import { shouldCaptureGatewayHeapCheckpoints } from "./suite-support.js";
 import type { QaSuiteResolvedRunContext, QaSuiteResult, QaSuiteRunParams } from "./suite-types.js";
 import {
   formatQaSuiteRunStartProgress,
+  isQaSuiteNestedRun,
+  markQaSuiteNestedRun,
   runQaSuiteScenarioDefinitionForRuntime,
   shouldLogQaSuiteProgress,
   shouldRunQaSuiteWithIsolatedScenarioWorkers,
@@ -86,6 +88,10 @@ export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Prom
       }),
     }),
   };
+  // Preparation copies params, so carry the child's publication ownership to the new object.
+  if (isQaSuiteNestedRun(params)) {
+    markQaSuiteNestedRun(preparedParams);
+  }
   const enabledPluginIds = [
     ...new Set([
       ...collectQaSuitePluginIds(selectedScenarios),

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
@@ -1,18 +1,20 @@
-import { describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import type { QaLabServerHandle } from "./lab-server.types.js";
 import {
   createQaTransportAdapter,
   type QaTransportAdapterFactory,
 } from "./qa-transport-registry.js";
-import { runQaFlowSuiteStandard } from "./suite-run-standard.js";
+import * as scenarioCatalog from "./scenario-catalog.js";
+import { runQaFlowSuiteFromRuntime } from "./suite-run.runtime.js";
 import { runQaRuntimeParitySuite } from "./suite-runtime-parity-runner.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
-import type {
-  QaSuiteResolvedRunContext,
-  QaSuiteRunner,
-  QaSuiteScenarioRunner,
-} from "./suite-types.js";
+import type { QaSuiteRunner, QaSuiteScenarioRunner } from "./suite-types.js";
+import * as suite from "./suite.js";
+import { createTempDirHarness } from "./temp-dir.test-helper.js";
+
+const tempDirs = createTempDirHarness();
 
 const mocks = vi.hoisted(() => ({
   captureRuntimeParityCell: vi.fn(
@@ -104,6 +106,7 @@ vi.mock("./runtime-parity.js", async (importOriginal) => ({
   captureRuntimeParityCell: mocks.captureRuntimeParityCell,
 }));
 vi.mock("./suite-artifacts.js", () => ({
+  invalidateQaSuiteArtifactGeneration: vi.fn(async () => {}),
   writeQaSuiteArtifacts: mocks.writeQaSuiteArtifacts,
 }));
 vi.mock("./suite-runtime-gateway.js", () => ({
@@ -113,6 +116,12 @@ vi.mock("./suite-runtime-gateway.js", () => ({
 vi.mock("./web-runtime.js", () => ({
   closeQaWebSessions: vi.fn(async () => {}),
 }));
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  await tempDirs.cleanup();
+});
 
 function createCleanupTestLab(): QaLabServerHandle {
   return {
@@ -283,95 +292,81 @@ describe("runtime parity suite transport cleanup", () => {
     expect(runChild).toHaveBeenCalledTimes(2);
   });
 
-  it("prints one generic completion after real nested standard cells and parent cleanup", async () => {
-    mocks.writeQaSuiteArtifacts.mockClear();
-    const scenario = makeQaSuiteTestScenario("runtime-cleanup");
-    const selection = {
-      capabilityMatrixPath: "crabline-channel-driver-capabilities.json",
-      channel: "telegram",
-      channelDriver: "crabline",
-      providerReadinessArtifactPath: "crabline-provider-readiness.json",
-    } as const;
-    const parentLab = createCleanupTestLab();
-    const openClawLab = createCleanupTestLab();
-    const codexLab = createCleanupTestLab();
-    const startLab = vi
-      .fn<() => Promise<QaLabServerHandle>>()
-      .mockResolvedValueOnce(parentLab)
-      .mockResolvedValueOnce(openClawLab)
-      .mockResolvedValueOnce(codexLab);
-    const runScenario = vi
-      .fn<QaSuiteScenarioRunner>()
-      .mockResolvedValue({ name: scenario.title, status: "pass", steps: [] });
-    const runChild: QaSuiteRunner = async (childParams) => {
-      if (!childParams) {
-        throw new Error("expected nested standard run params");
-      }
-      const context: QaSuiteResolvedRunContext = {
-        startedAt: new Date("2026-08-04T00:00:01.000Z"),
-        repoRoot: childParams.repoRoot ?? "/qa-repo",
-        outputDir: childParams.outputDir ?? "/qa-output/runtime-cell",
-        transportId: childParams.transportId ?? "qa-channel",
-        selectedScenarios: [scenario],
-        providerMode: childParams.providerMode ?? "mock-openai",
-        primaryModel: childParams.primaryModel ?? "mock-openai/test-model",
-        alternateModel: childParams.alternateModel ?? "mock-openai/test-model-alt",
-        fastMode: childParams.fastMode ?? true,
-        channelDriver: childParams.channelDriver,
-        enabledPluginIds: childParams.enabledPluginIds ?? [],
-        gatewayConfigPatches: [],
-        gatewayRuntimeOptions: undefined,
-        concurrency: 1,
-        progressEnabled: true,
-        gatewayHeapCheckpointsEnabled: false,
-      };
-      return await runQaFlowSuiteStandard(childParams, context, runScenario);
-    };
-    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-
-    try {
-      await runQaRuntimeParitySuite({
-        runQaFlowSuite: runChild,
-        repoRoot: "/qa-repo",
-        outputDir: "/qa-output",
-        startedAt: new Date("2026-08-04T00:00:00.000Z"),
-        providerMode: "mock-openai",
-        transportId: "qa-channel",
-        channelId: "telegram",
-        channelDriverSelection: selection,
-        primaryModel: "mock-openai/test-model",
-        alternateModel: "mock-openai/test-model-alt",
-        fastMode: true,
-        concurrency: 1,
-        selectedScenarios: [scenario],
-        startLab,
-        progressEnabled: true,
-        runtimePair: ["openclaw", "codex"],
-      });
-
-      const completionLines = stderrWrite.mock.calls
-        .flat()
-        .join("")
-        .split("\n")
-        .filter((line) => line.startsWith("[qa-suite] run complete"));
-      expect(completionLines).toEqual(["[qa-suite] run complete"]);
-      expect(runScenario).toHaveBeenCalledTimes(2);
-      expect(mocks.writeQaSuiteArtifacts).toHaveBeenCalledTimes(3);
-      for (const [cellArtifacts] of mocks.writeQaSuiteArtifacts.mock.calls.slice(0, -1)) {
-        expect(cellArtifacts.channelDriverSelection).toBeUndefined();
-      }
-      expect(mocks.writeQaSuiteArtifacts.mock.calls.at(-1)?.[0]).toMatchObject({
+  it.each([true, false])(
+    "preserves runtime preparation publication ownership with parity=%s",
+    async (parity) => {
+      vi.stubEnv("OPENCLAW_QA_SUITE_PROGRESS", "1");
+      mocks.writeQaSuiteArtifacts.mockClear();
+      const repoRoot = await tempDirs.makeTempDir("qa-runtime-publication-");
+      const scenario = makeQaSuiteTestScenario("runtime-cleanup");
+      const selection = {
+        capabilityMatrixPath: "crabline-channel-driver-capabilities.json",
         channel: "telegram",
         channelDriver: "crabline",
-        channelDriverSelection: selection,
+        providerReadinessArtifactPath: "crabline-provider-readiness.json",
+      } as const;
+      const labs = Array.from({ length: parity ? 3 : 1 }, createCleanupTestLab);
+      const startLab = vi.fn<() => Promise<QaLabServerHandle>>();
+      for (const lab of labs) {
+        startLab.mockResolvedValueOnce(lab);
+      }
+      const runScenario = vi
+        .fn<QaSuiteScenarioRunner>()
+        .mockResolvedValue({ name: scenario.title, status: "pass", steps: [] });
+      vi.spyOn(scenarioCatalog, "readQaBootstrapScenarioCatalog").mockReturnValue({
+        agentIdentityMarkdown: "test",
+        kickoffTask: "test",
+        scenarios: [scenario],
       });
-      expect(openClawLab.stop).toHaveBeenCalledOnce();
-      expect(codexLab.stop).toHaveBeenCalledOnce();
-      expect(parentLab.stop).toHaveBeenCalledOnce();
-    } finally {
-      stderrWrite.mockRestore();
-    }
-  });
+      vi.spyOn(suite, "runQaSuiteScenarioDefinitionForRuntime").mockImplementation(runScenario);
+      const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+      try {
+        const result = await runQaFlowSuiteFromRuntime({
+          repoRoot,
+          outputDir: path.join(repoRoot, "output"),
+          providerMode: "mock-openai",
+          transportId: "qa-channel",
+          channelId: "telegram",
+          channelDriverSelection: selection,
+          primaryModel: "mock-openai/test-model",
+          alternateModel: "mock-openai/test-model-alt",
+          fastMode: true,
+          concurrency: 1,
+          scenarioIds: [scenario.id],
+          startLab,
+          ...(parity ? { runtimePair: ["openclaw", "codex"] } : {}),
+        });
+
+        const completionLines = stderrWrite.mock.calls
+          .flat()
+          .join("")
+          .split("\n")
+          .filter((line) => line.startsWith("[qa-suite] run complete"));
+        expect(result.scenarios).toEqual([expect.objectContaining({ status: "pass" })]);
+        expect(completionLines).toEqual([
+          parity
+            ? "[qa-suite] run complete"
+            : "[qa-suite] run complete: passed=1 failed=0 skipped=0 total=1",
+        ]);
+        expect(runScenario).toHaveBeenCalledTimes(parity ? 2 : 1);
+        expect(mocks.writeQaSuiteArtifacts).toHaveBeenCalledTimes(labs.length);
+        for (const [cellArtifacts] of mocks.writeQaSuiteArtifacts.mock.calls.slice(0, -1)) {
+          expect(cellArtifacts.channelDriverSelection).toBeUndefined();
+        }
+        expect(mocks.writeQaSuiteArtifacts.mock.calls.at(-1)?.[0]).toMatchObject({
+          channel: "telegram",
+          channelDriver: "crabline",
+          channelDriverSelection: selection,
+        });
+        for (const lab of labs) {
+          expect(lab.stop).toHaveBeenCalledOnce();
+        }
+      } finally {
+        stderrWrite.mockRestore();
+      }
+    },
+  );
 
   it("preserves the scenario error when its owned lab cleanup fails", async () => {
     const lab = createCleanupTestLab();

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.ts
@@ -1,11 +1,7 @@
 import path from "node:path";
 import type { OpenClawCrablineChannelDriverSelection } from "@openclaw/crabline";
 import type { QaCliBackendAuthMode } from "./gateway-child.js";
-import type {
-  QaLabLatestReport,
-  QaLabScenarioOutcome,
-  QaLabServerHandle,
-} from "./lab-server.types.js";
+import type { QaLabLatestReport, QaLabServerHandle } from "./lab-server.types.js";
 import type { QaProviderMode } from "./model-selection.js";
 import { sanitizeQaProgressValue as sanitizeQaSuiteProgressValue } from "./progress-format.js";
 import type { QaThinkingLevel } from "./qa-gateway-config.js";
@@ -24,6 +20,7 @@ import {
   resolveQaSuiteWorkerStartStaggerMs,
   scenarioRequiresControlUi,
 } from "./suite-planning.js";
+import { createQaSuiteProgressController } from "./suite-progress.js";
 import { buildRuntimeParityScenarioResult } from "./suite-runtime-parity-result.js";
 import { remapModelRefForForcedRuntime } from "./suite-support.js";
 import type {
@@ -95,17 +92,12 @@ export async function runQaRuntimeParitySuite(params: {
     transportId: params.transportId,
   });
   const transport = transportFactoryResult.adapter;
-  const liveScenarioOutcomes: QaLabScenarioOutcome[] = params.selectedScenarios.map((scenario) => ({
-    id: scenario.id,
-    name: scenario.title,
-    status: "pending",
-  }));
-  lab.setScenarioRun({
-    kind: "suite",
-    status: "running",
+  const progress = createQaSuiteProgressController({
+    lab,
+    scenarios: params.selectedScenarios,
     startedAt: params.startedAt.toISOString(),
-    scenarios: [...liveScenarioOutcomes],
   });
+  progress.start();
 
   let runFailed = false;
   let runError: unknown;
@@ -129,18 +121,7 @@ export async function runQaRuntimeParitySuite(params: {
           params.progressEnabled,
           `runtime pair start (${index + 1}/${params.selectedScenarios.length}): ${scenarioIdForLog}`,
         );
-        liveScenarioOutcomes[index] = {
-          id: scenario.id,
-          name: scenario.title,
-          status: "running",
-          startedAt: new Date().toISOString(),
-        };
-        lab.setScenarioRun({
-          kind: "suite",
-          status: "running",
-          startedAt: params.startedAt.toISOString(),
-          scenarios: [...liveScenarioOutcomes],
-        });
+        progress.markRunning([scenario.id]);
 
         const parity = await runRuntimeParityScenario({
           scenarioId: scenario.id,
@@ -232,21 +213,7 @@ export async function runQaRuntimeParitySuite(params: {
           scenarioName: scenario.title,
           result: parity,
         });
-        liveScenarioOutcomes[index] = {
-          id: scenario.id,
-          name: scenario.title,
-          status: parityScenarioResult.status,
-          details: parityScenarioResult.details,
-          steps: parityScenarioResult.steps,
-          startedAt: liveScenarioOutcomes[index]?.startedAt,
-          finishedAt: new Date().toISOString(),
-        };
-        lab.setScenarioRun({
-          kind: "suite",
-          status: "running",
-          startedAt: params.startedAt.toISOString(),
-          scenarios: [...liveScenarioOutcomes],
-        });
+        progress.recordScenarioResult(scenario.id, parityScenarioResult);
         writeQaSuiteProgress(
           params.progressEnabled,
           `runtime pair ${parityScenarioResult.status} (${index + 1}/${params.selectedScenarios.length}): ${scenarioIdForLog}`,
@@ -291,13 +258,7 @@ export async function runQaRuntimeParitySuite(params: {
         markdown: report,
         generatedAt: finishedAt.toISOString(),
       } satisfies QaLabLatestReport);
-      lab.setScenarioRun({
-        kind: "suite",
-        status: "completed",
-        startedAt: params.startedAt.toISOString(),
-        finishedAt: finishedAt.toISOString(),
-        scenarios: [...liveScenarioOutcomes],
-      });
+      progress.complete([], finishedAt.toISOString());
       return {
         outputDir: params.outputDir,
         evidence,


### PR DESCRIPTION
## What Problem This Solves

Nested QA suite workers could print top-level completion and request provider-readiness publication after runtime preparation copied their parameters. An isolated two-worker run produced three completion lines instead of one; parity cells also repeated readiness work.

## Why This Change Was Made

The nested marker is private WeakSet membership on the parameter object. Adapter preparation created a new object without transferring that membership. The preparation owner now preserves it, so the outer suite remains the sole owner of final completion/readiness publication. Standard, isolated and parity runners also reuse the existing progress controller, removing their duplicate pending/running/result/completed bookkeeping while preserving catalog order, titles, explicit empty details and cleanup-before-completion ordering.

## User Impact

QA operators receive one aggregate completion and readiness publication per outer run. Production code decreases by 93 physical lines (+48/−141), or 90 after excluding formatting-only deletions; focused test code adds 270 lines. This is an internal QA runner repair with no new configuration or public runtime surface.

## Evidence

The original runtime-copy regressions fail before the repair and pass afterward, with an unmarked top-level control. All 139 focused tests and every selected type, lint, format, dependency and architecture gate pass. Fresh managed P2/high review completed two passes with no findings.

Two external five-case harnesses execute the actual preparation, marker and runner owners with Gateway/provider/transport/artifact boundaries explicitly replaced by fixtures. They cover concurrent children, standard/parity dispatch, owned and borrowed labs, reversed parity order and cleanup failures. All 39 progress snapshots preserve structural values, timestamps, explicit undefined fields, scenario/step order, artifact inputs and event order. Finished progress objects retain `startedAt` at a different property insertion position, so raw progress JSON byte equality is not claimed. This evidence does not claim a live channel or actual agent-runtime run.

The copied-parameter regression is visible in commit `3ee32fb9c10dcf9d5713c0c4891e55227f5b1f0d`; current main retains that path. Release-note context: prevent nested QA workers from duplicating final completion and readiness publication while consolidating progress transitions at their existing owner.

## Review follow-up

The exact-head CI run 33489055603 and required gate are green, including all six QA smoke profiles. The latest ClawSweeper review has no actionable finding. Maintainer review accepts the preparation-boundary ownership repair and shared progress controller.

### Current-main review follow-up

The September 1 09:25 UTC ClawSweeper request to refresh the merge is addressed: native preparation refreshed main to `6e032fae86969fd33af566c7526f123374b9d5a3`, and a clean merge-tree check at that base retains all five tested production owners byte-for-byte. The only inspected dependency drift is the already-landed shared-type refactor in `suite.ts`; its emitted JavaScript remains byte-identical (17,148 bytes). The 139 focused tests, nested ownership reproduction, and six successful exact-head QA CI smoke profiles therefore still cover the runtime being merged. Repeating those unchanged runtime tests solely for the erased-type change is skipped.

The requested maintainer decision is accepted under the user-directed QA/cleanup landing campaign: retain marker transfer at the parameter-copy owner and one shared progress controller. No code finding or security issue remains. Native landing will recheck mergeability and required checks immediately before merge.
