### PR TITLE
refactor(heartbeat): centralize skipped stage outcomes

### DIFF
--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -131,6 +131,15 @@ function hasActiveRunForSession(
   return Boolean(normalizedSessionKey) && listSessionKeys().includes(normalizedSessionKey);
 }
 
+function skippedHeartbeatStage<T extends string>(reason: T, startedAt: number) {
+  emitHeartbeatEvent({
+    status: "skipped",
+    reason,
+    durationMs: Date.now() - startedAt,
+  });
+  return { kind: "skipped", reason } as const;
+}
+
 export type HeartbeatRunOptions = {
   cfg?: OpenClawConfig;
   agentId?: string;
@@ -192,12 +201,7 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
     // Documented observable skip (`system heartbeat last` / troubleshooting
     // docs promise reason=quiet-hours); every sibling skip past this point
     // emits, so a silent return here hides the window from operators.
-    emitHeartbeatEvent({
-      status: "skipped",
-      reason: "quiet-hours",
-      durationMs: Date.now() - startedAt,
-    });
-    return { kind: "skipped", reason: "quiet-hours" } as const;
+    return skippedHeartbeatStage("quiet-hours", startedAt);
   }
 
   const shouldInspectExecWakeBeforeBusy = shouldPreflightExecEventWake(
@@ -216,22 +220,12 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
     });
   let preflight = shouldInspectExecWakeBeforeBusy ? await resolvePreflight() : undefined;
   if (preflight?.skipReason) {
-    emitHeartbeatEvent({
-      status: "skipped",
-      reason: preflight.skipReason,
-      durationMs: Date.now() - startedAt,
-    });
-    return { kind: "skipped", reason: preflight.skipReason } as const;
+    return skippedHeartbeatStage(preflight.skipReason, startedAt);
   }
 
   const getSize = opts.deps?.getQueueSize ?? getQueueSize;
   if (getSize(CommandLane.Main) > 0) {
-    emitHeartbeatEvent({
-      status: "skipped",
-      reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
-      durationMs: Date.now() - startedAt,
-    });
-    return { kind: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT } as const;
+    return skippedHeartbeatStage(HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT, startedAt);
   }
 
   // Cron executions awaiting heartbeat settlement are idle owners, not competing work.
@@ -269,12 +263,7 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
     getSize(CommandLane.CronNested) > 0 ||
     getSize(CommandLane.HookDispatch) > 0;
   if (cronBusy || cronLaneBusy) {
-    emitHeartbeatEvent({
-      status: "skipped",
-      reason: HEARTBEAT_SKIP_CRON_IN_PROGRESS,
-      durationMs: Date.now() - startedAt,
-    });
-    return { kind: "skipped", reason: HEARTBEAT_SKIP_CRON_IN_PROGRESS } as const;
+    return skippedHeartbeatStage(HEARTBEAT_SKIP_CRON_IN_PROGRESS, startedAt);
   }
 
   const shouldHonorActiveReplyRuns = opts.intent !== "immediate" && opts.intent !== "manual";
@@ -290,12 +279,7 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
     (hasActiveRunForAgent(agentId, listActiveReplyRuns) ||
       hasActiveRunForAgent(agentId, listActiveEmbeddedRuns))
   ) {
-    emitHeartbeatEvent({
-      status: "skipped",
-      reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
-      durationMs: Date.now() - startedAt,
-    });
-    return { kind: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT } as const;
+    return skippedHeartbeatStage(HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT, startedAt);
   }
 
   // Phase 2: Stronger heartbeat deferral while a final delivery replay is pending.
@@ -336,12 +320,7 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
         mainSessionRecovery.view.status === "recoverable")) ||
     hasCurrentRestartRecoveryDelivery
   ) {
-    emitHeartbeatEvent({
-      status: "skipped",
-      reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
-      durationMs: Date.now() - startedAt,
-    });
-    return { kind: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT } as const;
+    return skippedHeartbeatStage(HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT, startedAt);
   }
   const HEARTBEAT_DEFER_WINDOW_MS = 30_000;
   const pendingFinalDeliveryText =
@@ -357,12 +336,7 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
     recentSessionEntry?.updatedAt &&
     startedAt - recentSessionEntry.updatedAt < HEARTBEAT_DEFER_WINDOW_MS
   ) {
-    emitHeartbeatEvent({
-      status: "skipped",
-      reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
-      durationMs: Date.now() - startedAt,
-    });
-    return { kind: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT } as const;
+    return skippedHeartbeatStage(HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT, startedAt);
   }
 
   // Preflight centralizes trigger classification, event inspection, and monitor-scratch gating.
@@ -370,23 +344,13 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
     preflight = await resolvePreflight();
   }
   if (preflight.skipReason) {
-    emitHeartbeatEvent({
-      status: "skipped",
-      reason: preflight.skipReason,
-      durationMs: Date.now() - startedAt,
-    });
-    return { kind: "skipped", reason: preflight.skipReason } as const;
+    return skippedHeartbeatStage(preflight.skipReason, startedAt);
   }
   const { sessionKey } = preflight.session;
   const isReplyRunActive =
     opts.deps?.isReplyRunActive ?? ((key: string) => replyRunRegistry.isActive(key));
   if (isReplyRunActive(sessionKey) || hasActiveRunForSession(sessionKey, listActiveEmbeddedRuns)) {
-    emitHeartbeatEvent({
-      status: "skipped",
-      reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
-      durationMs: Date.now() - startedAt,
-    });
-    return { kind: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT } as const;
+    return skippedHeartbeatStage(HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT, startedAt);
   }
 
   // Check the resolved session lane — if it is busy, skip to avoid interrupting
@@ -394,12 +358,7 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
   // re-schedule this wake automatically.  See #14396 (closed without merge).
   const sessionLaneKey = resolveEmbeddedSessionLane(sessionKey);
   if (getSize(sessionLaneKey) > 0) {
-    emitHeartbeatEvent({
-      status: "skipped",
-      reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
-      durationMs: Date.now() - startedAt,
-    });
-    return { kind: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT } as const;
+    return skippedHeartbeatStage(HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT, startedAt);
   }
 
   return {
@@ -455,12 +414,7 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
     preflight.pendingEventEntries.length === 0 &&
     scheduledTasks.length === 0
   ) {
-    emitHeartbeatEvent({
-      status: "skipped",
-      reason: "no-route",
-      durationMs: Date.now() - startedAt,
-    });
-    return { kind: "skipped", reason: "no-route" } as const;
+    return skippedHeartbeatStage("no-route", startedAt);
   }
   const heartbeatAccountId = heartbeat?.accountId?.trim();
   if (delivery.reason === "unknown-account") {
@@ -536,12 +490,7 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
       isReplyRunActive(isolatedSessionKey) ||
       hasActiveRunForSession(isolatedSessionKey, listActiveEmbeddedRuns)
     ) {
-      emitHeartbeatEvent({
-        status: "skipped",
-        reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
-        durationMs: Date.now() - startedAt,
-      });
-      return { kind: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT } as const;
+      return skippedHeartbeatStage(HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT, startedAt);
     }
     const staleIsolatedEntry = staleIsolatedSessionKey
       ? loadExactSessionEntry({


### PR DESCRIPTION
## What Problem This Solves

The heartbeat execution stages repeated the same skipped event and return value at twelve guards. Their observable event and control-flow result now share one private constructor.

## Why This Change Was Made

The stage owner keeps each guard, preflight, clock expression and ordering unchanged. The helper emits the original event synchronously before returning its original literal reason. Four disabled paths remain intentionally silent. Delivery finalizers retain their separate metadata, cleanup and retry contracts.

## User Impact

No intended behavior change. Quiet-hours, busy-session, recovery, missing-route and isolated-session skips retain their existing events and recorded outcomes. Production decreases by 51 physical lines (+21/−72), or 52 nonblank code lines. Tests, configuration, persistence, dependencies and public APIs are unchanged.

## Evidence

All 92 existing focused tests and a temporary 23-case actual-runner characterization pass. Baseline and candidate captures are byte-identical, including event/result fields, property descriptors, timestamps, last-event identity, listener ordering and the four silent disabled controls. Expanding the twelve helper calls reproduces the original source exactly.

Actual isolated baseline and candidate Gateways were invoked through automations run --wait, system heartbeat last and automations runs. Quiet-hours and no-route outcomes, guidance and durable run records match after excluding generated fixture identities and timing. Both Gateways cleaned up; no model credentials or external channel were used because these paths stop before inference/delivery.

All 28 selected checks pass, and a managed P2/high review is clean. The first candidate Gateway attempt timed out during host test load; the same-deadline run after this lane's tests finished passed. No production timeout, retry or assertion was changed.

## Review follow-up

The exact-head CI run 33489058875 and required gate are green, satisfying the remaining check and rank-up item. Maintainer review accepts this private, behavior-preserving helper with the distinct metadata-bearing finalizer paths unchanged.


Fresh main inspection at 433108d2f784083c4f8183315883109d536dc355 found the already-landed lifecycle callback narrowing to currentEntry. The complete owner/callee diff was inspected. A clean merge retains exactly that upstream change and the reviewed twelve-call skip-helper patch; neither changes the other. The skip proof and exact-head CI remain applicable. No new merged-tree execution run is claimed. The latest 09:24 UTC ClawSweeper review has no actionable code finding, and this maintainer-directed landing accepts its remaining maintainer decision.
