### PR TITLE
refactor(feishu): centralize document table patch actions

### DIFF
--- a/extensions/feishu/src/docx-table-actions.test.ts
+++ b/extensions/feishu/src/docx-table-actions.test.ts
@@ -1,0 +1,329 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import * as Lark from "@larksuiteoapi/node-sdk";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
+
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+const toolAccountModule = await import("./tool-account.js");
+vi.spyOn(toolAccountModule, "createFeishuToolClient").mockImplementation(() =>
+  createFeishuClientMock(),
+);
+vi.spyOn(toolAccountModule, "resolveAnyEnabledFeishuToolsConfig").mockReturnValue({
+  doc: true,
+  chat: false,
+  wiki: false,
+  drive: false,
+  perm: false,
+  scopes: false,
+  bitable: false,
+});
+const { registerFeishuDocTools } = await import("./docx.js");
+
+type Patch = Lark.Client["docx"]["documentBlock"]["patch"];
+type PatchResponse = Awaited<ReturnType<Patch>>;
+const block = { block_id: "table_reply", block_type: 31 };
+const actions = [
+  {
+    action: "insert_table_row",
+    fields: { row_index: 2 },
+    data: { insert_table_row: { row_index: 2 } },
+    counts: {},
+  },
+  {
+    action: "insert_table_column",
+    fields: { column_index: 3 },
+    data: { insert_table_column: { column_index: 3 } },
+    counts: {},
+  },
+  {
+    action: "delete_table_rows",
+    fields: { row_start: 2, row_count: 3 },
+    data: { delete_table_rows: { row_start_index: 2, row_end_index: 5 } },
+    counts: { rows_deleted: 3 },
+  },
+  {
+    action: "delete_table_columns",
+    fields: { column_start: 3, column_count: 2 },
+    data: { delete_table_columns: { column_start_index: 3, column_end_index: 5 } },
+    counts: { columns_deleted: 2 },
+  },
+  {
+    action: "merge_table_cells",
+    fields: { row_start: 1, row_end: 3, column_start: 2, column_end: 5 },
+    data: {
+      merge_table_cells: {
+        row_start_index: 1,
+        row_end_index: 3,
+        column_start_index: 2,
+        column_end_index: 5,
+      },
+    },
+    counts: {},
+  },
+];
+
+function createClient(httpInstance?: Lark.HttpInstance) {
+  return new Lark.Client({
+    appId: "loopback-table-app",
+    appSecret: "loopback-table-placeholder", // pragma: allowlist secret
+    domain: Lark.Domain.Feishu,
+    loggerLevel: Lark.LoggerLevel.error,
+    disableTokenCache: true,
+    httpInstance,
+  });
+}
+
+function resolveTool(client: Lark.Client) {
+  createFeishuClientMock.mockReturnValue(client);
+  const harness = createToolFactoryHarness({});
+  registerFeishuDocTools(harness.api);
+  return harness.resolveTool("feishu_doc");
+}
+
+function paramsFor(sample: (typeof actions)[number]): Record<string, unknown> {
+  return {
+    action: sample.action,
+    doc_token: "doc_table",
+    block_id: "table_target",
+    ...sample.fields,
+  };
+}
+
+function expectResult(
+  result: { details: Record<string, unknown> },
+  details: Record<string, unknown>,
+) {
+  expect(result.details).toStrictEqual(details);
+  expect(Object.keys(result.details)).toEqual(Object.keys(details));
+  const { content } = result as {
+    details: Record<string, unknown>;
+    content: Array<{ type: string; text: string }>;
+  };
+  expect(content).toHaveLength(1);
+  expect(content[0]?.type).toBe("text");
+  expect(content[0]?.text).toContain(`\nSource: API\n---\n${JSON.stringify(details, null, 2)}\n`);
+}
+
+describe("registered feishu_doc table patches", () => {
+  afterAll(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+  beforeEach(() => {
+    createFeishuClientMock.mockReset();
+  });
+
+  it.each(actions)(
+    "captures $action before PATCH settles and returns the exact result",
+    async (sample) => {
+      const client = createClient();
+      const response = createDeferred<PatchResponse>();
+      const patch = vi.spyOn(client.docx.documentBlock, "patch").mockReturnValue(response.promise);
+      const params = paramsFor(sample);
+      const pending = resolveTool(client).execute("table-patch", params);
+      const request = {
+        path: { document_id: "doc_table", block_id: "table_target" },
+        data: sample.data,
+      };
+      expect(patch).toHaveBeenCalledExactlyOnceWith(request);
+      expect(JSON.stringify(patch.mock.calls[0]?.[0])).toBe(JSON.stringify(request));
+      for (const key of Object.keys(params)) {
+        params[key] = 99;
+      }
+      response.resolve({ code: 0, data: { block, client_token: "table-client-token" } });
+      expectResult(await pending, { success: true, ...sample.counts, block });
+    },
+  );
+
+  it.each(actions)(
+    "keeps an own undefined block for $action without response data",
+    async (sample) => {
+      const client = createClient();
+      vi.spyOn(client.docx.documentBlock, "patch").mockResolvedValue({ code: 0 });
+      expectResult(await resolveTool(client).execute("missing-data", paramsFor(sample)), {
+        success: true,
+        ...sample.counts,
+        block: undefined,
+      });
+    },
+  );
+
+  it.each([
+    { label: "omitted", fields: {}, index: -1, end: 3, count: 1 },
+    { label: "undefined", fields: { value: undefined }, index: -1, end: 3, count: 1 },
+    { label: "zero", fields: { value: 0 }, index: 0, end: 2, count: 0 },
+    { label: "null", fields: { value: null }, index: null, end: 2, count: null },
+  ])(
+    "preserves $label defaults at the registered-tool boundary",
+    async ({ fields, index, end, count }) => {
+      const cases = [
+        {
+          action: "insert_table_row",
+          field: "row_index",
+          input: {},
+          data: { insert_table_row: { row_index: index } },
+          counts: {},
+        },
+        {
+          action: "insert_table_column",
+          field: "column_index",
+          input: {},
+          data: { insert_table_column: { column_index: index } },
+          counts: {},
+        },
+        {
+          action: "delete_table_rows",
+          field: "row_count",
+          input: { row_start: 2 },
+          data: { delete_table_rows: { row_start_index: 2, row_end_index: end } },
+          counts: { rows_deleted: count },
+        },
+        {
+          action: "delete_table_columns",
+          field: "column_count",
+          input: { column_start: 2 },
+          data: { delete_table_columns: { column_start_index: 2, column_end_index: end } },
+          counts: { columns_deleted: count },
+        },
+      ];
+      const client = createClient();
+      const patch = vi
+        .spyOn(client.docx.documentBlock, "patch")
+        .mockResolvedValue({ code: 0, data: { client_token: "table-client-token" } });
+      const tool = resolveTool(client);
+      for (const sample of cases) {
+        const result = await tool.execute("default-value", {
+          action: sample.action,
+          doc_token: "doc_table",
+          block_id: "table_target",
+          ...sample.input,
+          ...(Object.hasOwn(fields, "value") ? { [sample.field]: fields.value } : {}),
+        });
+        expect(patch).toHaveBeenLastCalledWith({
+          path: { document_id: "doc_table", block_id: "table_target" },
+          data: sample.data,
+        });
+        expectResult(result, { success: true, ...sample.counts, block: undefined });
+      }
+      expect(patch).toHaveBeenCalledTimes(4);
+    },
+  );
+
+  it.each(actions)("reports $action API errors before inspecting response data", async (sample) => {
+    const client = createClient();
+    const patch = vi.spyOn(client.docx.documentBlock, "patch");
+    const tool = resolveTool(client);
+    for (const code of [999, undefined]) {
+      patch.mockResolvedValueOnce({
+        code,
+        msg: "table denied",
+        get data(): never {
+          throw new Error("data read before code");
+        },
+      });
+      expectResult(await tool.execute("api-error", paramsFor(sample)), { error: "table denied" });
+    }
+    expect(patch).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(actions)(
+    "awaits $action SDK failures before returning the fenced error",
+    async (sample) => {
+      const client = createClient();
+      const patch = vi.spyOn(client.docx.documentBlock, "patch");
+      const tool = resolveTool(client);
+      for (const failure of ["throw", "reject"] as const) {
+        const events: string[] = [];
+        patch.mockImplementationOnce(() => {
+          events.push("patch");
+          if (failure === "throw") {
+            throw new Error("transport failed");
+          }
+          return Promise.reject(new Error("transport failed"));
+        });
+        const pending = Promise.resolve(tool.execute("sdk-error", paramsFor(sample))).then(
+          (result) => {
+            events.push("result");
+            return result;
+          },
+        );
+        events.push("returned");
+        await Promise.resolve();
+        events.push("microtask");
+        expectResult(await pending, { error: "transport failed" });
+        expect(events).toEqual(["patch", "returned", "microtask", "result"]);
+      }
+      expect(patch).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("sends all five PATCH variants through the installed SDK to loopback HTTP", async () => {
+    const requests: Array<{ method: string | undefined; url: string | undefined; body: string }> =
+      [];
+    let reply: PatchResponse = { code: 0, data: { block, client_token: "table-client-token" } };
+    const server = createServer((request, response) => {
+      void (async () => {
+        const chunks: Buffer[] = [];
+        for await (const chunk of request) {
+          chunks.push(Buffer.from(chunk));
+        }
+        requests.push({
+          method: request.method,
+          url: request.url,
+          body: Buffer.concat(chunks).toString("utf8"),
+        });
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify(reply));
+      })().catch(() => response.writeHead(500).end());
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address() as AddressInfo;
+      const transport = Object.create(Lark.defaultHttpInstance) as Lark.HttpInstance;
+      transport.request = async (options) => {
+        const upstream = new URL(options.url ?? "");
+        const target = new URL(
+          `${upstream.pathname}${upstream.search}`,
+          `http://127.0.0.1:${address.port}`,
+        );
+        const response = await fetch(target, {
+          method: options.method,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(options.data),
+        });
+        return response.json();
+      };
+      const tool = resolveTool(createClient(transport));
+      for (const sample of actions) {
+        reply = { code: 0, data: { block, client_token: "table-client-token" } };
+        expectResult(await tool.execute("http-patch", paramsFor(sample)), {
+          success: true,
+          ...sample.counts,
+          block,
+        });
+        reply = { code: 999, msg: "loopback table denied" };
+        expectResult(await tool.execute("http-error", paramsFor(sample)), {
+          error: "loopback table denied",
+        });
+      }
+      expect(requests).toEqual(
+        actions.flatMap((sample) =>
+          Array.from({ length: 2 }, () => ({
+            method: "PATCH",
+            url: "/open-apis/docx/v1/documents/doc_table/blocks/table_target",
+            body: JSON.stringify(sample.data),
+          })),
+        ),
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/extensions/feishu/src/docx-table-ops.ts
+++ b/extensions/feishu/src/docx-table-ops.ts
@@ -8,6 +8,7 @@
  */
 
 import type * as Lark from "@larksuiteoapi/node-sdk";
+import type { FeishuDocParams } from "./doc-schema.js";
 import type { FeishuBlockTable, FeishuDocxBlock } from "./docx-types.js";
 
 // ============ Table Utilities ============
@@ -17,23 +18,6 @@ const MIN_COLUMN_WIDTH = 50; // Feishu API minimum
 const MAX_COLUMN_WIDTH = 400; // Reasonable maximum for readability
 const DEFAULT_TABLE_WIDTH = 730; // Approximate Feishu page content width
 
-/**
- * Calculate adaptive column widths based on cell content length.
- *
- * Algorithm:
- * 1. For each column, find the max content length across all rows
- * 2. Weight CJK characters as 2x width (they render wider)
- * 3. Calculate proportional widths based on content length
- * 4. Apply min/max constraints
- * 5. Redistribute remaining space to fill total table width
- *
- * Total width is derived from the original column_width values returned
- * by the Convert API, ensuring tables match Feishu's expected dimensions.
- *
- * @param blocks - Array of blocks from Convert API
- * @param tableBlockId - The block_id of the table block
- * @returns Array of column widths in pixels
- */
 function normalizeChildBlockIds(children: string[] | string | undefined): string[] {
   if (Array.isArray(children)) {
     return children;
@@ -222,99 +206,75 @@ export function cleanBlocksForDescendant(blocks: FeishuDocxBlock[]): FeishuDocxB
 
 // ============ Table Row/Column Operations ============
 
-export async function insertTableRow(
-  client: Lark.Client,
-  docToken: string,
-  blockId: string,
-  rowIndex = -1,
-) {
-  const res = await client.docx.documentBlock.patch({
-    path: { document_id: docToken, block_id: blockId },
-    data: { insert_table_row: { row_index: rowIndex } },
-  });
-  if (res.code !== 0) {
-    throw new Error(res.msg);
+type TableAction = Extract<
+  FeishuDocParams,
+  {
+    action:
+      | "insert_table_row"
+      | "insert_table_column"
+      | "delete_table_rows"
+      | "delete_table_columns"
+      | "merge_table_cells";
   }
-  return { success: true, block: res.data?.block };
-}
+>;
+type TablePatchData = NonNullable<
+  NonNullable<Parameters<Lark.Client["docx"]["documentBlock"]["patch"]>[0]>["data"]
+>;
 
-export async function insertTableColumn(
-  client: Lark.Client,
-  docToken: string,
-  blockId: string,
-  columnIndex = -1,
-) {
+export async function patchTable(client: Lark.Client, params: TableAction) {
+  const { doc_token, block_id } = params;
+  let data: TablePatchData;
+  const counts: { rows_deleted?: number; columns_deleted?: number } = {};
+  // Capture result counts before the request; defaults apply only to undefined inputs.
+  switch (params.action) {
+    case "insert_table_row": {
+      const { row_index = -1 } = params;
+      data = { insert_table_row: { row_index } };
+      break;
+    }
+    case "insert_table_column": {
+      const { column_index = -1 } = params;
+      data = { insert_table_column: { column_index } };
+      break;
+    }
+    case "delete_table_rows": {
+      const { row_start, row_count = 1 } = params;
+      data = {
+        delete_table_rows: { row_start_index: row_start, row_end_index: row_start + row_count },
+      };
+      counts.rows_deleted = row_count;
+      break;
+    }
+    case "delete_table_columns": {
+      const { column_start, column_count = 1 } = params;
+      data = {
+        delete_table_columns: {
+          column_start_index: column_start,
+          column_end_index: column_start + column_count,
+        },
+      };
+      counts.columns_deleted = column_count;
+      break;
+    }
+    case "merge_table_cells": {
+      const { row_start, row_end, column_start, column_end } = params;
+      data = {
+        merge_table_cells: {
+          row_start_index: row_start,
+          row_end_index: row_end,
+          column_start_index: column_start,
+          column_end_index: column_end,
+        },
+      };
+      break;
+    }
+  }
   const res = await client.docx.documentBlock.patch({
-    path: { document_id: docToken, block_id: blockId },
-    data: { insert_table_column: { column_index: columnIndex } },
+    path: { document_id: doc_token, block_id },
+    data,
   });
   if (res.code !== 0) {
     throw new Error(res.msg);
   }
-  return { success: true, block: res.data?.block };
-}
-
-export async function deleteTableRows(
-  client: Lark.Client,
-  docToken: string,
-  blockId: string,
-  rowStart: number,
-  rowCount = 1,
-) {
-  const res = await client.docx.documentBlock.patch({
-    path: { document_id: docToken, block_id: blockId },
-    data: { delete_table_rows: { row_start_index: rowStart, row_end_index: rowStart + rowCount } },
-  });
-  if (res.code !== 0) {
-    throw new Error(res.msg);
-  }
-  return { success: true, rows_deleted: rowCount, block: res.data?.block };
-}
-
-export async function deleteTableColumns(
-  client: Lark.Client,
-  docToken: string,
-  blockId: string,
-  columnStart: number,
-  columnCount = 1,
-) {
-  const res = await client.docx.documentBlock.patch({
-    path: { document_id: docToken, block_id: blockId },
-    data: {
-      delete_table_columns: {
-        column_start_index: columnStart,
-        column_end_index: columnStart + columnCount,
-      },
-    },
-  });
-  if (res.code !== 0) {
-    throw new Error(res.msg);
-  }
-  return { success: true, columns_deleted: columnCount, block: res.data?.block };
-}
-
-export async function mergeTableCells(
-  client: Lark.Client,
-  docToken: string,
-  blockId: string,
-  rowStart: number,
-  rowEnd: number,
-  columnStart: number,
-  columnEnd: number,
-) {
-  const res = await client.docx.documentBlock.patch({
-    path: { document_id: docToken, block_id: blockId },
-    data: {
-      merge_table_cells: {
-        row_start_index: rowStart,
-        row_end_index: rowEnd,
-        column_start_index: columnStart,
-        column_end_index: columnEnd,
-      },
-    },
-  });
-  if (res.code !== 0) {
-    throw new Error(res.msg);
-  }
-  return { success: true, block: res.data?.block };
+  return { success: true, ...counts, block: res.data?.block };
 }

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -16,14 +16,7 @@ import {
   type DocxMarkdownChunk,
   type DocxMarkdownImage,
 } from "./docx-markdown.js";
-import {
-  cleanBlocksForDescendant,
-  insertTableRow,
-  insertTableColumn,
-  deleteTableRows,
-  deleteTableColumns,
-  mergeTableCells,
-} from "./docx-table-ops.js";
+import { cleanBlocksForDescendant, patchTable } from "./docx-table-ops.js";
 import type { FeishuDocxBlock, FeishuDocxBlockChild } from "./docx-types.js";
 import { resolveDocxUploadInput } from "./docx-upload-input.js";
 import {
@@ -1386,43 +1379,11 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                 case "color_text":
                   return json(await updateColorText(client, p.doc_token, p.block_id, p.content));
                 case "insert_table_row":
-                  return json(await insertTableRow(client, p.doc_token, p.block_id, p.row_index));
                 case "insert_table_column":
-                  return json(
-                    await insertTableColumn(client, p.doc_token, p.block_id, p.column_index),
-                  );
                 case "delete_table_rows":
-                  return json(
-                    await deleteTableRows(
-                      client,
-                      p.doc_token,
-                      p.block_id,
-                      p.row_start,
-                      p.row_count,
-                    ),
-                  );
                 case "delete_table_columns":
-                  return json(
-                    await deleteTableColumns(
-                      client,
-                      p.doc_token,
-                      p.block_id,
-                      p.column_start,
-                      p.column_count,
-                    ),
-                  );
                 case "merge_table_cells":
-                  return json(
-                    await mergeTableCells(
-                      client,
-                      p.doc_token,
-                      p.block_id,
-                      p.row_start,
-                      p.row_end,
-                      p.column_start,
-                      p.column_end,
-                    ),
-                  );
+                  return json(await patchTable(client, p));
                 default:
                   return json({ error: "Unknown action" });
               }


### PR DESCRIPTION
## What Problem This Solves

Five Feishu document table actions repeated the same SDK PATCH, response-code check and result construction. They now share one private table-action owner, with the action union derived from the existing tool schema and the payload type derived from the installed SDK.

## Why This Change Was Made

The document dispatcher forwards the narrowed action directly. Insert-row, insert-column, delete-row, delete-column and merge-cell actions retain their native payload fields, undefined-only defaults, exclusive deletion endpoints and counts captured before the request. The response code is still checked before reading response data, and the outer tool retains its error handling and network-result fencing. An unrelated adaptive-width JSDoc attached to the child-ID normalizer was also removed.

## User Impact

No intended behavior change. Production decreases by 79 physical lines (+67/−146): the refactor removes 62 lines, or 59 nonblank lines, and the misplaced comment contributes another 17. Focused tests add 329 lines. Table creation, cell writes, color-text operations and descendant cleanup retain their distinct contracts.

## Evidence

All 25 new registered-tool characterization cases pass on unchanged baseline production and on the candidate. The baseline's 45 sibling tests and the candidate's 96 focused tests pass. Baseline and candidate captures contain 57 records and compare byte-identically after normalizing only random result-fence IDs; explicit undefined fields are encoded. They cover all five actions, omitted and zero/null inputs, mutation while an SDK request is pending, response-code errors, synchronous throws and rejected promises.

Ten requests execute the installed Lark SDK 1.73.0 PATCH method through a custom loopback HTTP bridge, checking exact request bytes, paths and results. The SDK request types, method implementation, payload formatting and default Axios response unwrapping were directly inspected. The bridge proves the registered tool and SDK method's request/result mapping; it does not execute the default Axios transport or prove external Feishu service acceptance. An external document run is infeasible in this task because no approved disposable Feishu account/document or mutation credentials are available.

All selected type, format, lint, dependency and architecture gates pass. Those checks precede only the final comment removal; restoring that comment reproduces the previously checked source hash exactly. The final three-file format check and fresh managed P2 review cover the complete final diff. No configuration, public API, dependency, persistence or protocol surface changes.

## Review follow-up

The exact-head CI run 33489063484 and required gate are green. Maintainer review accepts the private table-action consolidation. The SDK source and transport inspection described above resolves the review checkout’s missing-dependency limitation. The automated “vector/embedding metadata” classification does not describe this diff: it constructs existing document-table PATCH fields and changes no persistent store, vector metadata, schema, or upgrade contract. External Feishu acceptance remains unclaimed for the stated account/document limitation.


The latest 09:25 UTC review was read in full. Fresh native main inspection at 9e5be704596c5c4fd38c83253cdebef0498597fc confirms the changed owners and immediate schema/result dependencies remain byte-identical to the tested base. Direct inspection of installed Lark SDK 1.73.0 types, PATCH method, payload handling and Axios unwrapping resolves the review environment’s missing SDK source. Exact-head CI 33489063484 and the ten actual SDK loopback requests satisfy the optional rank-up. Maintainer review accepts this consolidation. The persistent vector-data classification is inapplicable: no database, embedding metadata, schema or upgrade path changes.
