### PR TITLE
refactor(android): unify Talk directive alias parsing

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkDirectiveParser.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkDirectiveParser.kt
@@ -55,46 +55,28 @@ object TalkDirectiveParser {
     val obj = parseJsonObject(head) ?: return TalkDirectiveParseResult(null, text, emptyList())
 
     val speakerBoost =
-      boolValue(obj, listOf("speaker_boost", "speakerBoost"))
-        ?: boolValue(obj, listOf("no_speaker_boost", "noSpeakerBoost"))?.not()
+      obj.readAlias(listOf("speaker_boost", "speakerBoost")) { it.asBooleanOrNull() }
+        ?: obj.readAlias(listOf("no_speaker_boost", "noSpeakerBoost")) { it.asBooleanOrNull() }?.not()
 
     val directive =
       TalkDirective(
-        voiceId = stringValue(obj, listOf("voice", "voice_id", "voiceId")),
-        modelId = stringValue(obj, listOf("model", "model_id", "modelId")),
-        speed = doubleValue(obj, listOf("speed")),
-        rateWpm = intValue(obj, listOf("rate", "wpm")),
-        stability = doubleValue(obj, listOf("stability")),
-        similarity = doubleValue(obj, listOf("similarity", "similarity_boost", "similarityBoost")),
-        style = doubleValue(obj, listOf("style")),
+        voiceId = obj.readAlias(listOf("voice", "voice_id", "voiceId")) { it.asStringOrNull() },
+        modelId = obj.readAlias(listOf("model", "model_id", "modelId")) { it.asStringOrNull() },
+        speed = obj.readAlias(listOf("speed")) { it.asDoubleOrNull() },
+        rateWpm = obj.readAlias(listOf("rate", "wpm")) { it.asIntOrNull() },
+        stability = obj.readAlias(listOf("stability")) { it.asDoubleOrNull() },
+        similarity = obj.readAlias(listOf("similarity", "similarity_boost", "similarityBoost")) { it.asDoubleOrNull() },
+        style = obj.readAlias(listOf("style")) { it.asDoubleOrNull() },
         speakerBoost = speakerBoost,
-        seed = longValue(obj, listOf("seed")),
-        normalize = stringValue(obj, listOf("normalize", "apply_text_normalization")),
-        language = stringValue(obj, listOf("lang", "language_code", "language")),
-        outputFormat = stringValue(obj, listOf("output_format", "format")),
-        latencyTier = intValue(obj, listOf("latency", "latency_tier", "latencyTier")),
-        once = boolValue(obj, listOf("once")),
+        seed = obj.readAlias(listOf("seed")) { it.asLongOrNull() },
+        normalize = obj.readAlias(listOf("normalize", "apply_text_normalization")) { it.asStringOrNull() },
+        language = obj.readAlias(listOf("lang", "language_code", "language")) { it.asStringOrNull() },
+        outputFormat = obj.readAlias(listOf("output_format", "format")) { it.asStringOrNull() },
+        latencyTier = obj.readAlias(listOf("latency", "latency_tier", "latencyTier")) { it.asIntOrNull() },
+        once = obj.readAlias(listOf("once")) { it.asBooleanOrNull() },
       )
 
-    val hasDirective =
-      listOf(
-        directive.voiceId,
-        directive.modelId,
-        directive.speed,
-        directive.rateWpm,
-        directive.stability,
-        directive.similarity,
-        directive.style,
-        directive.speakerBoost,
-        directive.seed,
-        directive.normalize,
-        directive.language,
-        directive.outputFormat,
-        directive.latencyTier,
-        directive.once,
-      ).any { it != null }
-
-    if (!hasDirective) return TalkDirectiveParseResult(null, text, emptyList())
+    if (directive == TalkDirective()) return TalkDirectiveParseResult(null, text, emptyList())
 
     // Keep alias matching case-insensitive so dictated JSON can use snake/camel variants.
     val knownKeys =
@@ -149,65 +131,20 @@ object TalkDirectiveParser {
       null
     }
 
-  private fun stringValue(
-    obj: JsonObject,
+  private inline fun <T : Any> JsonObject.readAlias(
     keys: List<String>,
-  ): String? {
-    for (key in keys) {
-      val value = obj.valueForKey(key).asStringOrNull()?.trim()
-      if (!value.isNullOrEmpty()) return value
-    }
-    return null
-  }
-
-  private fun doubleValue(
-    obj: JsonObject,
-    keys: List<String>,
-  ): Double? {
-    for (key in keys) {
-      val value = obj.valueForKey(key).asDoubleOrNull()
-      if (value != null) return value
-    }
-    return null
-  }
-
-  private fun intValue(
-    obj: JsonObject,
-    keys: List<String>,
-  ): Int? {
-    for (key in keys) {
-      val value = obj.valueForKey(key).asIntOrNull()
-      if (value != null) return value
-    }
-    return null
-  }
-
-  private fun longValue(
-    obj: JsonObject,
-    keys: List<String>,
-  ): Long? {
-    for (key in keys) {
-      val value = obj.valueForKey(key).asLongOrNull()
-      if (value != null) return value
-    }
-    return null
-  }
-
-  private fun boolValue(
-    obj: JsonObject,
-    keys: List<String>,
-  ): Boolean? {
-    for (key in keys) {
-      val value = obj.valueForKey(key).asBooleanOrNull()
-      if (value != null) return value
-    }
-    return null
-  }
+    convert: (JsonElement?) -> T?,
+  ): T? = keys.firstNotNullOfOrNull { convert(valueForKey(it)) }
 
   private fun JsonObject.valueForKey(key: String): JsonElement? = this[key] ?: entries.firstOrNull { it.key.equals(key, ignoreCase = true) }?.value
 }
 
-private fun JsonElement?.asStringOrNull(): String? = (this as? JsonPrimitive)?.takeIf { it.isString }?.content
+private fun JsonElement?.asStringOrNull(): String? =
+  (this as? JsonPrimitive)
+    ?.takeIf { it.isString }
+    ?.content
+    ?.trim()
+    ?.takeIf { it.isNotEmpty() }
 
 private fun JsonElement?.asDoubleOrNull(): Double? {
   val primitive = this as? JsonPrimitive ?: return null

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkDirectiveParserTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkDirectiveParserTest.kt
@@ -60,6 +60,73 @@ class TalkDirectiveParserTest {
   }
 
   @Test
+  fun preservesAliasPriorityNullMaskingAndPrimitiveCoercion() {
+    val input =
+      """
+      {"VOICE":"masked","voice":null,"voice_id":"  selected  ","MODEL":7,"model_id":" model ","speed":"1.25","rate":0,"stability":0,"similarity":"0.4","style":"0.0","speaker_boost":false,"no_speaker_boost":false,"seed":"42","normalize":" ","apply_text_normalization":" auto ","LANG":"masked","lang":null,"language_code":" en ","output_format":" pcm ","latency":"0","once":"yes","z":1,"A":2}
+      Speak.
+      """.trimIndent()
+
+    val result = TalkDirectiveParser.parse(input)
+
+    assertEquals(
+      TalkDirective(
+        voiceId = "selected",
+        modelId = "model",
+        speed = 1.25,
+        rateWpm = 0,
+        stability = 0.0,
+        similarity = 0.4,
+        style = 0.0,
+        speakerBoost = false,
+        seed = 42,
+        normalize = "auto",
+        language = "en",
+        outputFormat = "pcm",
+        latencyTier = 0,
+        once = true,
+      ),
+      result.directive,
+    )
+    assertEquals("Speak.", result.stripped)
+    assertEquals(listOf("A", "z"), result.unknownKeys)
+  }
+
+  @Test
+  fun preservesExactKeyAndCaseCollisionOrdering() {
+    val cases =
+      listOf(
+        "{\"VOICE\":\"first\",\"Voice\":\"second\"}" to "first",
+        "{\"VOICE\":\"case-insensitive\",\"voice\":\"exact\"}" to "exact",
+        "{\"voice\":\"primary\",\"voice_id\":\"secondary\"}" to "primary",
+      )
+
+    for ((json, expected) in cases) {
+      val result = TalkDirectiveParser.parse("$json\nSpeak.")
+      assertEquals(json, expected, result.directive?.voiceId)
+    }
+  }
+
+  @Test
+  fun preservesRejectedTextAndAcceptedWhitespaceExactly() {
+    val rejected = "{\"unknown\":1}\r\nText\r\n"
+    assertEquals(
+      TalkDirectiveParseResult(directive = null, stripped = rejected, unknownKeys = emptyList()),
+      TalkDirectiveParser.parse(rejected),
+    )
+
+    val accepted = "\r\n\r\n{\"voice\":\"v\"}\r\n\r\nHello\r\n"
+    assertEquals(
+      TalkDirectiveParseResult(
+        directive = TalkDirective(voiceId = "v"),
+        stripped = "\n\nHello\n",
+        unknownKeys = emptyList(),
+      ),
+      TalkDirectiveParser.parse(accepted),
+    )
+  }
+
+  @Test
   fun returnsNullWhenNoDirectivePresent() {
     val input =
       """

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkSpeakClientTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkSpeakClientTest.kt
@@ -51,6 +51,32 @@ class TalkSpeakClientTest {
   }
 
   @Test
+  fun serializesParsedDirectiveWithStableBytesAndOmitsOnce() =
+    runTest {
+      var request: Triple<String, String, Long>? = null
+      val client =
+        TalkSpeakClient(
+          requestDetailed = { method, paramsJson, timeoutMs ->
+            request = Triple(method, paramsJson, timeoutMs)
+            GatewaySession.RpcResult(ok = false, payloadJson = null, error = null)
+          },
+        )
+      val parsed =
+        TalkDirectiveParser.parse(
+          """
+          {"voice":"v","model":"m","output_format":"pcm","speed":1.25,"rate":0,"stability":0.0,"similarity":0.4,"style":0.0,"speaker_boost":false,"seed":42,"normalize":"auto","lang":"en","latency":0,"once":true}
+          Say "hello".
+          """.trimIndent(),
+        )
+
+      client.synthesize(text = parsed.stripped, directive = parsed.directive)
+
+      val expectedJson =
+        """{"text":"Say \"hello\".","voiceId":"v","modelId":"m","outputFormat":"pcm","speed":1.25,"rateWpm":0,"stability":0.0,"similarity":0.4,"style":0.0,"speakerBoost":false,"seed":42,"normalize":"auto","language":"en","latencyTier":0}"""
+      assertEquals(Triple("talk.speak", expectedJson, 45_000L), request)
+    }
+
+  @Test
   fun fallsBackOnlyForUnavailableReasons() =
     runTest {
       val client =


### PR DESCRIPTION
## What Problem This Solves

Android Talk parsed each directive type through a separate copy of the same alias-search loop and maintained a second list of every directive field just to detect an empty directive. The parser now owns alias lookup once and uses the existing data class's all-null default to detect absence.

## Why This Change Was Made

A private inline alias reader preserves the first successful conversion, exact-key precedence, case-insensitive insertion order and fallback to later aliases. String conversion owns its existing trim/nonempty rule. Numeric zero and boolean false remain present values. The speech client and Talk lifecycle owners are unchanged.

## User Impact

No intended behavior change. Existing first-line JSON directives, aliases, coercions, unknown-key reporting, text whitespace and speech request bytes remain intact. Production decreases by 63 physical lines (+25/−88), or 58 nonblank lines; focused tests add 93 lines. No configuration, dependency, protocol or public API changes.

## Evidence

The original focused JVM/Robolectric tests passed before production edits. The new characterization tests then passed against unchanged production and again against the final candidate. All 15 selected tests pass with no failures, errors or skips, covering alias precedence, case collisions, null and invalid conversions, zero/false, CRLF and rejected input, exact talk.speak request JSON, and local TTS completion/stop callbacks for a whole long reply.

The pinned Kotlin 2.4.10 collection and data-class code and serialization 1.11.0 map/encoding implementations were directly inspected. The public directive documentation, the historical case-insensitive lookup fix and the Swift sibling's intentionally different leading-blank-line handling were checked. The unchanged speech client preserves request field ordering, defaults, escaping and omission of the local once flag.

Direct Android ktlint and every selected pnpm check:changed gate pass. Fresh managed P2/high review is scoped-clean with no findings. Validation executes the actual parser and speech client on the JVM and the existing Robolectric local-TTS boundary; it does not claim an Android device/UI run or external Gateway/provider acceptance. This refactor changes no screen or visual output.


The latest 09:01 UTC ClawSweeper review has no code finding. Its pending Android condition is now complete: exact-head CI 33489541293 and the required gate are green. Maintainer review accepts the canonical alias parser with the documented first-line, null/false/zero, and reply-local once contracts preserved.
