### PR TITLE
perf(agents): reuse normalized stream tool-call facts

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1796,7 +1796,7 @@ src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts	3
 src/agents/embedded-agent-runner/run/attempt-stream.ts	9
 src/agents/embedded-agent-runner/run/attempt-subscription-cleanup.ts	2
 src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.ts	17
-src/agents/embedded-agent-runner/run/attempt-tool-call-stream-normalization.ts	7
+src/agents/embedded-agent-runner/run/attempt-tool-call-stream-normalization.ts	6
 src/agents/embedded-agent-runner/run/attempt-tool-call-text-promotion.ts	3
 src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts	3
 src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts	1

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-stream-normalization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-stream-normalization.ts
@@ -1,7 +1,6 @@
 /** Normalizes live streamed tool-call names, ids, and unknown-tool loops. */
 import { randomUUID } from "node:crypto";
 import { stripCompactionReplayCheckpointInPlace } from "@openclaw/ai/transports";
-import { visitObjectContentBlocks } from "../../../shared/message-content-blocks.js";
 import type { StreamFn } from "../../runtime/index.js";
 import { normalizeToolPolicyName } from "../../tool-policy.js";
 import { isRunnerToolCallBlockType } from "./attempt-tool-call-block-type.js";
@@ -20,7 +19,11 @@ function createStandaloneTextToolCallId(): string {
   return `call_${randomUUID().replace(/-/g, "").slice(0, 24)}`;
 }
 
-function normalizeToolCallIdsInMessage(message: unknown, fallbackIdByContentIndex: string[]): void {
+function normalizeToolCallsInMessage(
+  message: unknown,
+  allowedToolNames: Set<string> | undefined,
+  fallbackIdByContentIndex: string[],
+): void {
   if (!message || typeof message !== "object") {
     return;
   }
@@ -29,20 +32,36 @@ function normalizeToolCallIdsInMessage(message: unknown, fallbackIdByContentInde
     return;
   }
 
-  const usedIds = new Set<string>();
+  // Collect every provider id before assigning fallbacks, including ids in later blocks.
+  let usedIds: Set<string> | undefined;
   for (const block of content) {
     if (!block || typeof block !== "object") {
       continue;
     }
-    const typedBlock = block as { type?: unknown; id?: unknown };
-    if (!isRunnerToolCallBlockType(typedBlock.type) || typeof typedBlock.id !== "string") {
+    const typedBlock = block as { type?: unknown; name?: unknown; id?: unknown };
+    if (!isRunnerToolCallBlockType(typedBlock.type)) {
       continue;
     }
-    const trimmedId = typedBlock.id.trim();
-    if (!trimmedId) {
-      continue;
+    usedIds ??= new Set<string>();
+    const rawId = typeof typedBlock.id === "string" ? typedBlock.id : undefined;
+    if (typeof typedBlock.name === "string") {
+      const normalized = resolveToolCallName(typedBlock.name, allowedToolNames, rawId);
+      if (normalized !== null && normalized !== typedBlock.name) {
+        typedBlock.name = normalized;
+      }
+    } else {
+      const inferred = resolveToolCallName("", allowedToolNames, rawId);
+      if (inferred) {
+        typedBlock.name = inferred;
+      }
     }
-    usedIds.add(trimmedId);
+    const trimmedId = rawId?.trim();
+    if (trimmedId) {
+      usedIds.add(trimmedId);
+    }
+  }
+  if (!usedIds) {
+    return;
   }
 
   const assignedIds = new Set<string>();
@@ -76,32 +95,6 @@ function normalizeToolCallIdsInMessage(message: unknown, fallbackIdByContentInde
     usedIds.add(fallbackId);
     assignedIds.add(fallbackId);
   }
-}
-
-function trimWhitespaceFromToolCallNamesInMessage(
-  message: unknown,
-  allowedToolNames: Set<string> | undefined,
-  fallbackIdByContentIndex: string[],
-): void {
-  visitObjectContentBlocks(message, (block) => {
-    const typedBlock = block as { type?: unknown; name?: unknown; id?: unknown };
-    if (!isRunnerToolCallBlockType(typedBlock.type)) {
-      return;
-    }
-    const rawId = typeof typedBlock.id === "string" ? typedBlock.id : undefined;
-    if (typeof typedBlock.name === "string") {
-      const normalized = resolveToolCallName(typedBlock.name, allowedToolNames, rawId);
-      if (normalized !== null && normalized !== typedBlock.name) {
-        typedBlock.name = normalized;
-      }
-      return;
-    }
-    const inferred = resolveToolCallName("", allowedToolNames, rawId);
-    if (inferred) {
-      typedBlock.name = inferred;
-    }
-  });
-  normalizeToolCallIdsInMessage(message, fallbackIdByContentIndex);
 }
 
 function classifyToolCallMessage(
@@ -290,7 +283,7 @@ function wrapStreamTrimToolCallNames(
   const originalResult = stream.result.bind(stream);
   stream.result = async () => {
     const message = await originalResult();
-    trimWhitespaceFromToolCallNamesInMessage(message, allowedToolNames, fallbackIdByContentIndex);
+    normalizeToolCallsInMessage(message, allowedToolNames, fallbackIdByContentIndex);
     guardUnknownToolLoopInMessage(message, unknownToolGuardState, {
       allowedToolNames,
       threshold: options?.unknownToolThreshold,
@@ -302,16 +295,8 @@ function wrapStreamTrimToolCallNames(
   };
 
   wrapStreamObjectEvents(stream, (event) => {
-    trimWhitespaceFromToolCallNamesInMessage(
-      event.partial,
-      allowedToolNames,
-      fallbackIdByContentIndex,
-    );
-    trimWhitespaceFromToolCallNamesInMessage(
-      event.message,
-      allowedToolNames,
-      fallbackIdByContentIndex,
-    );
+    normalizeToolCallsInMessage(event.partial, allowedToolNames, fallbackIdByContentIndex);
+    normalizeToolCallsInMessage(event.message, allowedToolNames, fallbackIdByContentIndex);
     if (event.message && typeof event.message === "object") {
       const countedStreamAttempt = guardUnknownToolLoopInMessage(
         event.message,


### PR DESCRIPTION
## What Problem This Solves

Every partial and final assistant snapshot normalizes tool names and IDs. The owner separately scanned tool blocks for names and then rediscovered those blocks and their provider IDs, even when a response contained only text.

## Why This Change Was Made

Fold name normalization and provider-ID collection into one pass. Allocate the used-ID set only when the snapshot contains a tool block, then keep the existing assignment pass. That second pass is necessary: a generated fallback must not collide with a provider ID in a later block. Remove the redundant helper and intermediate scan rather than add a cache.

Fallback IDs remain stable by content position within one response and fresh for later responses. Duplicate/blank IDs, aliases, live allowed-tool sets, unknown-tool loop counting, replay-checkpoint removal, synchronous/promised streams, and repeated result reads keep their existing owner and semantics. No protocol, configuration, provider routing, prompt text, or persistence change.

Production **+31/-46, net -15 lines**; test delta **0**. The assertion-safety baseline shrinks by exactly the removed assertion (7 to 6); it does not ignore a new violation. The measured candidate was net -7 before the normal formatter collapsed two calls; those eight removed formatting lines have no semantic effect.

## User Impact

Less per-snapshot work during assistant streaming, including text-only responses and ordinary single-tool streams. The controlled experiment below measures complete wrapper traversal, not provider token generation, network latency, or whole-Gateway throughput.

## Evidence

The experiment loads the complete owner through the canonical Vite source path. Correctness uses the native EventStream contract as well as controlled async generators. Timings traverse the complete wrapper with controlled generators so both variants receive identical events; no private normalization function is extracted or replaced. Sixteen workload oracles and eleven focused correctness groups passed before timing.

Four fixed before/candidate/candidate/before processes retained 704 measured blocks, 256 warmup blocks and 64 first operations, covering 510,064 timed complete wrapper exercises. The second pair reverses row order. All rows and slower controls are retained:

| Complete wrapper workload | Forward before → candidate, µs | Change | Reverse before → candidate, µs | Change |
| --- | ---: | ---: | ---: | ---: |
| responses-text-16 | 7.486 → 7.000 | -6.49% | 7.500 → 6.924 | -7.68% |
| responses-text-256 | 66.499 → 64.802 | -2.55% | 67.604 → 62.602 | -7.40% |
| thinking-32 | 12.822 → 11.596 | -9.57% | 13.447 → 11.318 | -15.83% |
| tool-one-8 | 6.533 → 6.229 | -4.65% | 6.877 → 6.554 | -4.69% |
| tool-one-128 | 45.795 → 44.132 | -3.63% | 51.828 → 46.484 | -10.31% |
| mixed-thinking-tool-text | 31.101 → 29.236 | -6.00% | 34.791 → 29.525 | -15.14% |
| tool-four-8 | 24.011 → 24.329 | +1.33% | 29.082 → 26.121 | -10.18% |
| tool-sixteen-16 | 333.035 → 316.343 | -5.01% | 434.380 → 404.566 | -6.86% |
| final-one | 2.184 → 1.847 | -15.43% | 1.763 → 1.829 | +3.75% |
| final-thirty-two | 8.010 → 8.342 | +4.15% | 10.521 → 10.516 | -0.05% |
| events-without-snapshots | 9.917 → 9.647 | -2.73% | 10.056 → 9.358 | -6.94% |
| missing-id-four | 13.880 → 13.622 | -1.86% | 14.346 → 13.299 | -7.30% |
| duplicate-id-four | 11.936 → 11.451 | -4.06% | 10.485 → 10.362 | -1.17% |
| alias-four | 16.584 → 16.090 | -2.98% | 14.720 → 13.916 | -5.46% |
| unknown-eleven-responses | 76.500 → 77.643 | +1.49% | 76.823 → 75.472 | -1.76% |
| live-set-narrow-restore | 6.980 → 7.152 | +2.46% | 7.922 → 7.657 | -3.34% |

The ordinary short single-tool row improved 4.65%/4.69%; the longer single-tool row improved 3.63%/10.31%; text-only 16-event responses improved 6.49%/7.68%. Five adverse median pairs and eight adverse first-operation pairs remain in the evidence. In particular, the short single-tool forward first call increased 223.375→248.625 µs, and mixed-stream first forward increased 42.667→75.500 µs. Forward Vitest user CPU increased 36,148 µs; reverse peak RSS increased 2,128 KiB. No universal first-call, CPU or memory gain is claimed.

The raw numerical reduction and an independent audit agree. All five proof/timing runtimes and canonical worker generations closed; all 15 recorded PIDs and 10 groups were independently absent. Output/journal/oracle hashes matched. The canonical Vite bootstrap dynamic-import warning is retained in every stderr, not suppressed. Source capture `61763b0` and measured execution `71c263b13f3e040f3ac415758e2f81a564087d71` remain historical identities, not relabeled as the final PR. Root numerical SHA-256: `380fad8c7c9e2d97b94189b469683b80e6cddd14cdf44dbd2550f8d5fa7b11ce`; independent raw review: `3d535be9e5b3ed611b7fda16f4e4dbdccd5281f6df4b269b3642fbd900a291f3`.

On the integration base, all 171 tests across the attempt, replay sanitization, prepare, settle and finalize owners passed both before and after. The full changed-code gate passed in 349.49 s, including types, lint, unused exports and import cycles. The baseline ratchet and formatter each rejected the first incomplete local gate attempt; both were corrected before that complete pass. No test assertion or failure was suppressed. A fresh managed Codex review was scoped-clean for P0 defects.

```sh
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.test.ts src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.test.ts src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts src/agents/embedded-agent-runner/run/attempt-stream-finalize.test.ts --maxWorkers 1 --no-cache
pnpm check:changed -- src/agents/embedded-agent-runner/run/attempt-tool-call-stream-normalization.ts config/assertion-safety-baseline.txt
pnpm build
```

A clean build of `dbb5d38f8778cf57c10845fe85c3c681eb37d170` passed in 176.04 s, including UI budgets. Its isolated real OpenAI Gateway completed four turns: READY, Tool Search, exact file readback, and two sequential HTTP-200 web fetches in Markdown/text modes. Readiness was 3834.39 ms; turns were 1781.73, 3972.89, 6170.98 and 10101.70 ms. Ten real Responses requests returned HTTP 200; 17 supporting RPCs succeeded. Read-only SQLite inspection verified all 27 transcript rows, the parent chain and six matched tool calls/results. Both web outputs were bounded to 2,000 visible characters with complete spill files retained.

All 12,356 built files matched before/after and during root readback. The main Node profile contains 19,033 samples over 27,106.305 ms (21,227.619 ms idle); the worker profile has 13 samples over 22.734 ms, retained separately. The conservative generic-tool replay-invalid marker remains on read/web turns; no actual retry, fallback or compaction occurred. Existing allowlist/failover-decision warnings remain qualified, and no error/fatal records were emitted. The owned PID/group and IPv4/IPv6 listener closed; temporary config, last-good config and key FIFO were removed. Root live readback SHA-256: `7bd557cb64c9c328a5ab31beabd1117ac7ee31457bdfa5001c63eb33426f7d45`.

After that proof, the unpublished branch was mechanically rebased onto `c904e712f9c` as `ba47cf5f4b506fce3396d27c2300b6c8abf761e4`. The production owner is byte-identical (SHA-256 `e182ddd1e69248bb68f090e194d3bb71c7c96f25615508e2568b87cb246ca810`); the independent UI baseline reduction is preserved. The relevant owner/prepare/settle/finalize paths and package contracts did not change upstream. Incoming canonical test-launcher changes were inspected; all 171 tests passed again in 14.60 s and a fresh exact-commit Codex review was scoped-clean. Build/live timings remain attributed to their actual pre-rebase revision; hosted CI must attest the final head.

Independent live audit: all 62 checks passed, including exact correspondence of public stream deltas, accumulated snapshots and persisted final text. The main native profile retains two -1 µs intervals (indices 1512 and 3282); neither was clamped or discarded. This is explicitly not a strictly monotonic CPU-utilization or comparative-latency claim. Independent 35-file evidence seal: `02b8c3a99938f704a5ce6b0055ab9137f041a603c8024e6a51b3ca2242814ed4`.
