### PR TITLE
fix: preserve PDF and image analysis in Code Mode

### DIFF
--- a/docs/tools/pdf.md
+++ b/docs/tools/pdf.md
@@ -117,10 +117,11 @@ See [Configuration Reference](/gateway/config-agents#agent-defaults) for full fi
 
 ## Output details
 
-The tool returns text in `content[0].text` and structured metadata in `details`.
+The tool returns analysis in both `content[0].text` and `details.text`, so [Code Mode](/tools/code-mode) and [Tool Search](/tools/tool-search) can read the same result.
 
 Common `details` fields:
 
+- `text`: the analysis text
 - `model`: resolved model ref (`provider/model`)
 - `native`: `true` for native provider mode, `false` for fallback
 - `attempts`: fallback attempts that failed before success

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -785,6 +785,7 @@ async function expectImageToolExecOk(
     path: imagePath,
   });
   expectToolText(result, "ok");
+  expect((result as ToolTextResult).details).toMatchObject({ text: "ok" });
 }
 
 type ToolTextResult = {

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -757,6 +757,8 @@ export function buildTextToolResult(
     details: {
       model: `${result.provider}/${result.model}`,
       ...extraDetails,
+      // Code Mode and Tool Search read details instead of rendered content.
+      text: result.text,
       attempts: result.attempts,
     },
   };

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -678,6 +678,7 @@ describe("createPdfTool", () => {
       expectFields(result.details, {
         native: false,
         model: OPENAI_PDF_MODEL,
+        text: "fallback summary",
       });
       expect(firstCompletionContext()?.systemPrompt).toBeUndefined();
     });


### PR DESCRIPTION
## What Problem This Solves

PDF and fallback image analysis put the answer in rendered content but return only metadata in details. Code Mode and Tool Search intentionally return details to the caller, so they lose a successful analysis. A real PDF turn called the tool four times, then answered that it could not read the document despite no tool failures.

## Why This Change Was Made

Include the analysis text in the shared media result producer's details. Normal rendered output remains available; structured callers receive the same answer without changing the general projection contract. The PDF output reference documents details.text.

## User Impact

Agents using Code Mode or Tool Search can read PDF and image analyses and avoid retrying a successful operation. Production +2/-0 (one field and its contract comment), tests +2/-0, docs +2/-1. The added producer field is the missing result; removing existing rendered content would break direct callers.

## Evidence

- Reproduced the missing structured text in the existing PDF case and 16 existing fallback-image cases. All 139 tests across both files pass after the repair.
- The rebuilt isolated Gateway, using a real OpenAI API key and Code Mode, read the same synthetic PDF and answered its printed words, “Slice parity,” after one PDF call. The earlier run used four PDF calls and returned “Unable to read the PDF.” Observed end-to-end times were 28.8 s before and 8.6 s after; this is a behavior reproduction, not a stable model-latency benchmark.
- Tool Search and Code Mode continue to project details directly. Native image loading has a separate direct-only result and is unaffected. Metadata, rendered text and model-attempt information remain present.
- Independent owner/source investigation and fresh Codex autoreview found no accepted findings in the selected scope and priority.
- Full build and required changed checks passed. A local check initially observed an unrelated worker probe; its temporary edit was removed and the complete check passed again on the clean PR head.
