### PR TITLE
perf: reduce CodeMode memory use between tool calls

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -1188,7 +1188,10 @@ session.`.
 runs.`.
 
 Snapshot storage is bounded by `maxSnapshotBytes` per run, the per-process
-suspended-run cap above, and `snapshotTtlSeconds`.
+suspended-run cap above, and `snapshotTtlSeconds`. The worker checks the snapshot
+size, including QuickJS metadata, before handing pending work to the Gateway.
+These limits and `memoryLimitBytes` bound guest state, not total Gateway memory;
+warm worker threads and TypeScript compilers also retain memory.
 
 ## QuickJS-WASI runtime
 
@@ -1200,6 +1203,8 @@ create one isolated VM per code-mode run or resume; register host callbacks
 by stable names; set memory and interrupt limits; evaluate JavaScript; drain
 pending jobs; snapshot suspended VM state; restore snapshots for `wait`;
 dispose VM handles and snapshots after terminal states.
+Snapshot buffers transfer directly between workers and the Gateway without
+copying the VM heap through a storage serialization format.
 
 The runtime executes in a Node.js worker thread, outside OpenClaw's main
 event loop. A guest infinite loop must not block the Gateway process

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -18,7 +18,6 @@ import {
   codeModeFailureCode,
   codeModeFailureMessage,
   createCodeModeApiFilesForRun,
-  enforceSnapshotPayloadLimits,
   toToolSearchConfig,
   type CodeModeConfig,
   type CodeModeLanguage,
@@ -307,10 +306,6 @@ async function settleCodeModeResult(params: {
     }
     let releaseReservation: (() => void) | undefined;
     try {
-      enforceSnapshotPayloadLimits({
-        snapshotBytes: result.snapshotBytes,
-        config: params.config,
-      });
       if (!params.reservedActiveRunSlot) {
         releaseReservation = reserveActiveRunSlot();
       }
@@ -361,7 +356,7 @@ async function settleCodeModeResult(params: {
           pending,
           replaySafe: params.replaySafe,
           settlementMode: result.settlementMode,
-          snapshotBytes: result.snapshotBytes,
+          snapshot: result.snapshot,
           parentToolCallId: params.parentToolCallId,
           ctx: params.ctx,
           config: params.config,
@@ -383,7 +378,7 @@ async function settleCodeModeResult(params: {
       result = await runCodeModeWorker(
         {
           kind: "resume",
-          snapshotBytes: result.snapshotBytes,
+          snapshot: result.snapshot,
           config: {
             ...params.config,
             timeoutMs: resumeBudgetMs,
@@ -437,12 +432,6 @@ async function settleCodeModeResult(params: {
     }
     let releaseReservation: (() => void) | undefined;
     try {
-      // A resumed guest can grow its next snapshot before the shared deadline
-      // expires; validate that new payload before reserving or parking it.
-      enforceSnapshotPayloadLimits({
-        snapshotBytes: result.snapshotBytes,
-        config: params.config,
-      });
       // Reserve before launching fresh work; transferred snapshots must
       // obey the same process-wide active-run cap as initial suspensions.
       if (!params.reservedActiveRunSlot) {
@@ -475,7 +464,7 @@ async function settleCodeModeResult(params: {
         pending,
         replaySafe: params.replaySafe && pendingReplaySafe,
         settlementMode: result.settlementMode,
-        snapshotBytes: result.snapshotBytes,
+        snapshot: result.snapshot,
         parentToolCallId: params.parentToolCallId,
         ctx: params.ctx,
         config: params.config,
@@ -604,7 +593,7 @@ export async function runWait(params: {
     const result = await runCodeModeWorker(
       {
         kind: "resume",
-        snapshotBytes: state.snapshotBytes,
+        snapshot: state.snapshot,
         config: {
           ...state.config,
           timeoutMs: resumeBudgetMs,

--- a/src/agents/code-mode-headless.test.ts
+++ b/src/agents/code-mode-headless.test.ts
@@ -71,6 +71,46 @@ describe("headless Code Mode", () => {
     expect(second.execute).toHaveBeenCalledOnce();
   });
 
+  it("preserves output and cancels earlier tools when a headless resume exceeds the snapshot cap", async () => {
+    const pendingStarted = createDeferred<AbortSignal | undefined>();
+    const pending = fakeTool("headless_snapshot_pending", async (_toolCallId, _input, signal) => {
+      pendingStarted.resolve(signal);
+      await new Promise<void>((resolve) => {
+        signal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      return jsonResult({ canceled: true });
+    });
+    const fixture = fakeTool("headless_snapshot_fixture", async () => {
+      await pendingStarted.promise;
+      return jsonResult({ ok: true });
+    });
+    const fresh = fakeTool("headless_snapshot_fresh", async () => jsonResult({ ok: true }));
+    const result = expectFailed(
+      await runCodeModeScriptHeadless({
+        ctx: createHeadlessCodeModeHarness([pending, fixture, fresh]),
+        code: `void headless_snapshot_pending({});
+          text("accepted first");
+          await headless_snapshot_fixture({});
+          const retained = new Uint8Array(16 * 1024 * 1024);
+          retained[0] = 7;
+          text("accepted inline");
+          await headless_snapshot_fresh({});
+          return retained[0];`,
+      }),
+    );
+
+    expect(result.code).toBe("snapshot_limit_exceeded");
+    expect(result.toolCallCount).toBe(2);
+    expect(result.output).toEqual([
+      { type: "text", text: "accepted first" },
+      { type: "text", text: "accepted inline" },
+    ]);
+    expect(pending.execute).toHaveBeenCalledOnce();
+    expect(fixture.execute).toHaveBeenCalledOnce();
+    expect(fresh.execute).not.toHaveBeenCalled();
+    expect((await pendingStarted.promise)?.aborted).toBe(true);
+  });
+
   it("keeps the headless race winner when the later-started tool settles first", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     const events: string[] = [];

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -17,7 +17,6 @@ import {
   codeModeFailureCode,
   codeModeFailureMessage,
   createCodeModeApiFilesForRun,
-  enforceSnapshotPayloadLimits,
   readPositiveInteger,
   resolveCodeModeHeadlessConfig,
   toToolSearchConfig,
@@ -279,7 +278,6 @@ export async function runCodeModeScriptHeadless(params: {
         });
       }
 
-      enforceSnapshotPayloadLimits({ snapshotBytes: result.snapshotBytes, config });
       cancelPendingBridgeStatesById(pending, result.canceledRequestIds);
       const pendingIds = new Set(pending.map((entry) => entry.id));
       const newRequests = result.pendingRequests.filter((request) => !pendingIds.has(request.id));
@@ -340,7 +338,7 @@ export async function runCodeModeScriptHeadless(params: {
       result = await runHeadlessWorkerLeg({
         input: {
           kind: "resume",
-          snapshotBytes: result.snapshotBytes,
+          snapshot: result.snapshot,
           settledRequests,
           pendingRequests: pending.map(({ id, method, args }) => ({ id, method, args })),
         },

--- a/src/agents/code-mode-runtime.ts
+++ b/src/agents/code-mode-runtime.ts
@@ -252,23 +252,11 @@ export function resolveCodeModeHeadlessConfig(
   } as OpenClawConfig);
 }
 
-class CodeModeLimitError extends ToolInputError {
-  readonly code = "snapshot_limit_exceeded" as const;
-
-  constructor(message: string) {
-    super(message);
-    this.name = "CodeModeLimitError";
-  }
-}
-
 function isRuntimeInterruptedError(error: unknown): boolean {
   return (error instanceof Error ? error.message : error) === "interrupted";
 }
 
 export function codeModeFailureCode(error: unknown): CodeModeFailureCode {
-  if (error instanceof CodeModeLimitError) {
-    return error.code;
-  }
   if (isRuntimeInterruptedError(error)) {
     return "timeout";
   }
@@ -324,13 +312,4 @@ export function createCodeModeApiFilesForRun(
 ) {
   const { apiFiles: files } = namespaceRuntime;
   return swarmEnabled ? files : files.filter((file) => file.path !== "agents.d.ts");
-}
-
-export function enforceSnapshotPayloadLimits(params: {
-  snapshotBytes: Uint8Array;
-  config: CodeModeConfig;
-}) {
-  if (params.snapshotBytes.byteLength > params.config.maxSnapshotBytes) {
-    throw new CodeModeLimitError("code mode snapshot limit exceeded");
-  }
 }

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -3,6 +3,7 @@ import {
   isFutureDateTimestampMs,
   resolveExpiresAtMsFromDurationSeconds,
 } from "@openclaw/normalization-core/number-coercion";
+import type { Snapshot } from "quickjs-wasi";
 import { raceWithAbortSignal } from "./agent-tools.abort.js";
 import { runBridgeRequest } from "./code-mode-bridge.js";
 import type { CodeModeCatalogProjection } from "./code-mode-catalog.js";
@@ -44,7 +45,7 @@ type CodeModeRunState = {
   parentToolCallId: string;
   ctx: ToolSearchToolContext;
   config: CodeModeConfig;
-  snapshotBytes: Uint8Array;
+  snapshot: Snapshot;
   pending: PendingBridgeState[];
   settlementMode: CodeModeSettlementMode;
   // True only when every future bridge call is enforced read-only before execution.
@@ -455,7 +456,7 @@ export function storeSnapshotState(params: {
   pending: PendingBridgeState[];
   replaySafe: boolean;
   settlementMode: CodeModeSettlementMode;
-  snapshotBytes: Uint8Array;
+  snapshot: Snapshot;
   parentToolCallId: string;
   ctx: ToolSearchToolContext;
   config: CodeModeConfig;
@@ -490,7 +491,7 @@ export function storeSnapshotState(params: {
     parentToolCallId: params.parentToolCallId,
     ctx: params.ctx,
     config: params.config,
-    snapshotBytes: params.snapshotBytes,
+    snapshot: params.snapshot,
     pending: params.pending,
     settlementMode: params.settlementMode,
     replaySafe: params.replaySafe,

--- a/src/agents/code-mode-swarm.test.ts
+++ b/src/agents/code-mode-swarm.test.ts
@@ -87,7 +87,7 @@ function workerResume(
     .runCodeModeWorker(
       {
         kind: "resume",
-        snapshotBytes: waiting.snapshotBytes,
+        snapshot: waiting.snapshot,
         config,
         settledRequests,
       },

--- a/src/agents/code-mode-worker-lifecycle.test.ts
+++ b/src/agents/code-mode-worker-lifecycle.test.ts
@@ -56,7 +56,13 @@ function parkExpiringRun(method: "callValue" | "agentWait") {
     pending: [pending],
     replaySafe: false,
     settlementMode: { kind: "awaiting" },
-    snapshotBytes: new Uint8Array([1]),
+    snapshot: {
+      memory: new Uint8Array([1]),
+      stackPointer: 0,
+      runtimePtr: 0,
+      contextPtr: 0,
+      extensions: [],
+    },
     parentToolCallId: "code-mode-lifecycle",
     ctx,
     config,
@@ -75,6 +81,79 @@ afterEach(() => {
 });
 
 describe("Code Mode worker lifecycle", () => {
+  it("transfers snapshot heaps across resumes without storage codec copies", async () => {
+    const tempDirs = useAutoCleanupTempDirTracker(onTestFinished);
+    const dir = tempDirs.make("code-mode-snapshot-transfer-");
+    const workerPath = path.join(dir, "snapshot-worker.ts");
+    const quickJsUrl = pathToFileURL(createRequire(import.meta.url).resolve("quickjs-wasi"));
+    await writeFile(path.join(dir, "package.json"), '{"type":"module"}');
+    // The dependency's storage codec copies the whole heap in both directions.
+    // Exercise real snapshots and restores while allowing metadata-only accounting.
+    await writeFile(
+      workerPath,
+      `
+      import { parentPort } from "node:worker_threads";
+      const { QuickJS } = await import(${JSON.stringify(quickJsUrl.href)});
+      const serialize = QuickJS.serializeSnapshot;
+      QuickJS.serializeSnapshot = (snapshot) => {
+        if (snapshot.memory.byteLength > 0) throw new Error("snapshot heap serialization copies memory");
+        return serialize(snapshot);
+      };
+      QuickJS.deserializeSnapshot = () => { throw new Error("snapshot heap deserialization copies memory"); };
+      const postMessage = parentPort.postMessage.bind(parentPort);
+      parentPort.postMessage = (message, transferList) => {
+        if (message.value?.status === "waiting" &&
+            !transferList?.includes(message.value.snapshot.memory.buffer)) {
+          throw new Error("snapshot heap must transfer to the host");
+        }
+        postMessage(message, transferList);
+      };
+      await import(${JSON.stringify(new URL("./code-mode.worker.ts", import.meta.url).href)});
+      `,
+    );
+    const workerUrl = pathToFileURL(workerPath);
+    const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
+    let result = await runCodeModeWorker(
+      {
+        kind: "exec",
+        source: `const bytes = new Uint8Array(1024 * 1024);
+          bytes[0] = 7;
+          await yield_control();
+          bytes[bytes.length - 1] = bytes[0] + 2;
+          await yield_control();
+          return [bytes.length, bytes[0], bytes[bytes.length - 1]];`,
+        config,
+        catalog: [],
+      },
+      10_000,
+      workerUrl,
+    );
+    for (let leg = 0; leg < 2; leg++) {
+      expect(result, result.status === "failed" ? result.error : undefined).toMatchObject({
+        status: "waiting",
+      });
+      if (result.status !== "waiting") {
+        throw new Error("expected a suspended guest");
+      }
+      const memory = result.snapshot.memory.buffer;
+      result = await runCodeModeWorker(
+        {
+          kind: "resume",
+          snapshot: result.snapshot,
+          config,
+          settledRequests: result.pendingRequests.map(({ id }) => ({ id, ok: true, value: null })),
+        },
+        10_000,
+        workerUrl,
+      );
+      expect(memory.byteLength).toBe(0);
+    }
+    expect(result).toMatchObject({
+      status: "completed",
+      value: { kind: "complete", json: "[1048576,7,9]" },
+    });
+  });
+
   it("isolates guest globals, bridge failures, and cancellations across warm executions", async () => {
     const config = resolveCodeModeConfig({
       tools: { codeMode: { enabled: true, maxPendingToolCalls: 1 } },
@@ -219,7 +298,7 @@ describe("Code Mode worker lifecycle", () => {
         input = {
           kind,
           config,
-          snapshotBytes: suspended.snapshotBytes,
+          snapshot: suspended.snapshot,
           settledRequests: suspended.pendingRequests.map(({ id }) => ({
             id,
             ok: true,

--- a/src/agents/code-mode-worker-types.ts
+++ b/src/agents/code-mode-worker-types.ts
@@ -1,4 +1,5 @@
 import type { Result } from "@openclaw/normalization-core/result";
+import type { Snapshot } from "quickjs-wasi";
 import type { CodeModeJsonSource, CodeModeOutputSource } from "./code-mode-json.js";
 import type { CodeModeApiVirtualFile } from "./code-mode-namespaces.js";
 
@@ -63,7 +64,7 @@ type CodeModeWorkerInput =
     }
   | {
       kind: "resume";
-      snapshotBytes: Uint8Array;
+      snapshot: Snapshot;
       config: CodeModeConfig;
       settledRequests: SettledBridgeRequest[];
       pendingRequests?: PendingBridgeRequest[];
@@ -87,7 +88,7 @@ type CodeModeWorkerOutcome<Output, Value> =
     }
   | {
       status: "waiting";
-      snapshotBytes: Uint8Array;
+      snapshot: Snapshot;
       pendingRequests: PendingBridgeRequest[];
       canceledRequestIds: string[];
       settlementMode: CodeModeSettlementMode;

--- a/src/agents/code-mode-worker.ts
+++ b/src/agents/code-mode-worker.ts
@@ -4,24 +4,14 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import { WorkerTaskError, WorkerTaskPool } from "../infra/worker-task-pool.js";
+import { createLazyPromise } from "../shared/lazy-promise.js";
 import { EMPTY_CODE_MODE_OUTPUT } from "./code-mode-json.js";
 import type { CodeModeFailureCode, CodeModeWorkerResult } from "./code-mode-runtime.js";
 
-let quickJsWasmModulePromise: Promise<WebAssembly.Module> | undefined;
-
-function getQuickJsWasmModule(): Promise<WebAssembly.Module> {
-  quickJsWasmModulePromise ??= Promise.resolve()
-    .then(() => createRequire(import.meta.url).resolve("quickjs-wasi/quickjs.wasm"))
-    .then((wasmPath) => readFile(wasmPath))
-    .then((bytes) => WebAssembly.compile(bytes))
-    .catch((error: unknown) => {
-      // Failed initialization is transient host state, not a process-wide
-      // verdict; later runs must retry without bypassing their watchdog.
-      quickJsWasmModulePromise = undefined;
-      throw error;
-    });
-  return quickJsWasmModulePromise;
-}
+const getQuickJsWasmModule = createLazyPromise(async () => {
+  const wasmPath = createRequire(import.meta.url).resolve("quickjs-wasi/quickjs.wasm");
+  return WebAssembly.compile(await readFile(wasmPath));
+});
 
 function codeModeWorkerUrl(): URL {
   return resolveRuntimeWorkerUrl({
@@ -112,8 +102,8 @@ export async function runCodeModeWorker(
         // A committed resume consumes this snapshot. Failure already closes
         // the run, so transferring ownership avoids copying its entire heap.
         transferList: (input) =>
-          isRecord(input) && input.snapshotBytes instanceof Uint8Array
-            ? [input.snapshotBytes.buffer as ArrayBuffer] // SAFETY: QuickJS allocates a dedicated ArrayBuffer.
+          isRecord(input) && isRecord(input.snapshot) && input.snapshot.memory instanceof Uint8Array
+            ? [input.snapshot.memory.buffer as ArrayBuffer] // SAFETY: QuickJS.snapshot owns a dedicated ArrayBuffer.
             : [],
       },
     );

--- a/src/agents/code-mode.bridge.lifecycle.test.ts
+++ b/src/agents/code-mode.bridge.lifecycle.test.ts
@@ -546,7 +546,7 @@ describe("Code Mode subscribed bridge lifecycle", () => {
         );
         expect(pending.settled).toBeUndefined();
         expect(otherPending.settled).toBeUndefined();
-        expect(ownerState.snapshotBytes.byteLength).toBeGreaterThan(0);
+        expect(ownerState.snapshot.memory.byteLength).toBeGreaterThan(0);
         expect(testing.resumingRunIds.size).toBe(0);
 
         // Both exec calls have returned; no wait is in flight to perform owner cleanup.

--- a/src/agents/code-mode.limits.test.ts
+++ b/src/agents/code-mode.limits.test.ts
@@ -1,9 +1,10 @@
 /** Tests Code Mode runtime and output limits. */
 
 import { expectDefined } from "@openclaw/normalization-core";
+import { QuickJS } from "quickjs-wasi";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { EMPTY_CODE_MODE_OUTPUT } from "./code-mode-json.js";
-import * as runtimeLimits from "./code-mode-runtime.js";
 import { codeModeFailureCode } from "./code-mode-runtime.js";
 import { applyCodeModeCatalog, createCodeModeTools, resolveCodeModeConfig } from "./code-mode.js";
 import {
@@ -178,42 +179,58 @@ describe("Code Mode runtime and output limits", () => {
   );
 
   it.each(["exec", "wait"])(
-    "preserves accepted inline output after a later %s host failure",
+    "preserves output and cancels earlier tools when a %s resume exceeds the snapshot cap",
     async (mode) => {
       const { ctx, config, tools } = createCodeModeHarness();
-      const fixture = pluginTool("output_fixture", "Output fixture");
-      applyCodeModeCatalog({ ...ctx, config, tools: [...tools, fixture] });
+      const pendingStarted = createDeferred<AbortSignal>();
+      const pending = pluginToolWithExecute(
+        "snapshot_pending",
+        "Pending snapshot fixture",
+        async (_toolCallId, _input, signal) => {
+          const pendingSignal = expectDefined(signal, "pending bridge signal");
+          pendingStarted.resolve(pendingSignal);
+          await new Promise<void>((resolve) => {
+            pendingSignal.addEventListener("abort", () => resolve(), { once: true });
+          });
+          return { content: [], details: true };
+        },
+      );
+      const fixture = pluginToolWithExecute("output_fixture", "Output fixture", async () => {
+        await pendingStarted.promise;
+        return { content: [], details: true };
+      });
+      const fresh = pluginTool("snapshot_fresh", "Fresh snapshot fixture");
+      applyCodeModeCatalog({ ...ctx, config, tools: [...tools, pending, fixture, fresh] });
       const exec = expectDefined(tools[0], "exec");
       const wait = expectDefined(tools[1], "wait");
       const input = {
-        code: `${mode === "wait" ? 'text("delivered"); await yield_control();' : ""} text("accepted first"); await output_fixture({}); text("accepted inline"); await yield_control();`,
+        code: `${mode === "wait" ? 'text("delivered"); await yield_control();' : ""}
+          void snapshot_pending({});
+          text("accepted first");
+          await output_fixture({});
+          const retained = new Uint8Array(16 * 1024 * 1024);
+          retained[0] = 7;
+          text("accepted inline");
+          await snapshot_fresh({});
+          return retained[0];`,
       };
       const first = mode === "wait" ? resultDetails(await exec.execute("park", input)) : undefined;
       if (first) {
-        expect(first.output).toEqual([{ type: "text", text: "delivered" }]);
-      }
-      const enforce = runtimeLimits.enforceSnapshotPayloadLimits;
-      let validations = 0;
-      const fault = vi
-        .spyOn(runtimeLimits, "enforceSnapshotPayloadLimits")
-        .mockImplementation((params) => {
-          if (++validations === 2) {
-            throw new Error("host snapshot check failed");
-          }
-          enforce(params);
+        expect(first).toMatchObject({
+          status: "waiting",
+          output: [{ type: "text", text: "delivered" }],
         });
-      let result;
-      try {
-        result = resultDetails(
-          await (first
-            ? wait.execute("resume", { runId: first.runId })
-            : exec.execute("inline", input)),
-        );
-      } finally {
-        fault.mockRestore();
       }
-      expect(result).toMatchObject({ status: "failed", error: "host snapshot check failed" });
+      const result = resultDetails(
+        await (first
+          ? wait.execute("resume", { runId: first.runId })
+          : exec.execute("inline", input)),
+      );
+      expect(result).toMatchObject({ status: "failed", code: "snapshot_limit_exceeded" });
+      expect(pending.execute).toHaveBeenCalledOnce();
       expect(fixture.execute).toHaveBeenCalledOnce();
+      expect(fresh.execute).not.toHaveBeenCalled();
+      expect((await pendingStarted.promise).aborted).toBe(true);
       expect(result.output).toEqual([
         { type: "text", text: "accepted first" },
         { type: "text", text: "accepted inline" },
@@ -335,23 +352,28 @@ describe("Code Mode runtime and output limits", () => {
     expect(details.bridgeDispatchStarted).toBe(false);
   });
 
-  it("classifies snapshot limit failures", async () => {
-    const config = resolveCodeModeConfig({
-      tools: { codeMode: { enabled: true, maxSnapshotBytes: 1024 } },
-    } as never);
+  it("enforces the exact encoded snapshot byte limit", async () => {
+    const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
+    const execute = (maxSnapshotBytes = config.maxSnapshotBytes) =>
+      testing.runCodeModeWorker(
+        {
+          kind: "exec",
+          source: 'const value = "x".repeat(100000); await yield_control("pause"); return value;',
+          config: { ...config, maxSnapshotBytes },
+          catalog: [],
+        },
+        5_000,
+      );
+    const probe = await execute();
+    expect(probe.status).toBe("waiting");
+    if (probe.status !== "waiting") {
+      throw new Error("expected a suspended guest to measure its snapshot");
+    }
+    const encodedBytes = QuickJS.serializeSnapshot(probe.snapshot).byteLength;
 
-    const result = await testing.runCodeModeWorker(
-      {
-        kind: "exec",
-        source: 'const value = "x".repeat(100000); await yield_control("pause"); return value;',
-        config,
-        catalog: [],
-      },
-      5000,
-    );
-
-    expect(result.status).toBe("failed");
-    expect(result).toMatchObject({
+    expect(await execute(encodedBytes)).toMatchObject({ status: "waiting" });
+    expect(await execute(encodedBytes - 1)).toMatchObject({
+      status: "failed",
       code: "snapshot_limit_exceeded",
       error: "code mode snapshot limit exceeded",
     });

--- a/src/agents/code-mode.wait.test.ts
+++ b/src/agents/code-mode.wait.test.ts
@@ -504,35 +504,58 @@ describe("Code Mode wait, scope, and suspended runs", () => {
     expect(new Set([...testing.activeRuns.values()].map((state) => state.replayId)).size).toBe(2);
   });
 
-  it("fails yield suspension when snapshot expiry would exceed the Date range", async () => {
-    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
-    applyCodeModeCatalog({
-      tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
-      config,
-      sessionId: "session-code-mode",
-      sessionKey: "agent:main:main",
-      runId: "run-code-mode",
-      catalogRef,
-    });
-    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(8_640_000_000_000_000);
-    let details: Record<string, unknown>;
-    try {
-      details = resultDetails(
-        await expectDefined(codeModeTools[0], "codeModeTools[0] test invariant").execute(
-          "code-call-yield-overflow",
-          {
-            code: 'await yield_control("pause"); return "done";',
-          },
-        ),
-      );
-    } finally {
-      nowSpy.mockRestore();
-    }
+  it.each(["exec", "wait"])(
+    "preserves accepted output when %s snapshot expiry would exceed the Date range",
+    async (mode) => {
+      const { ctx } = createCodeModeHarness();
+      const config = { tools: { codeMode: { enabled: true, snapshotTtlSeconds: 1 } } };
+      const tools = createCodeModeTools({ ...ctx, config, runtimeConfig: config });
+      const fixture = pluginTool("expiry_fixture", "Expiry fixture");
+      applyCodeModeCatalog({ ...ctx, config, tools: [...tools, fixture] });
+      const exec = expectDefined(tools[0], "exec");
+      const wait = expectDefined(tools[1], "wait");
+      const dateLimit = 8_640_000_000_000_000;
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(dateLimit - 1_000);
+      let details: Record<string, unknown>;
+      try {
+        const input = {
+          code: `${mode === "wait" ? 'text("delivered"); await yield_control();' : ""}
+            text("accepted first");
+            await expiry_fixture({});
+            text("accepted inline");
+            await yield_control("pause");
+            return "done";`,
+        };
+        const first =
+          mode === "wait" ? resultDetails(await exec.execute("park", input)) : undefined;
+        if (first) {
+          expect(first).toMatchObject({
+            status: "waiting",
+            output: [{ type: "text", text: "delivered" }],
+          });
+        }
+        // Admit wait before the parked run expires. Renewal overflows without
+        // consuming the new call's execution budget before its guest resumes.
+        nowSpy.mockReturnValue(dateLimit - 1);
+        details = resultDetails(
+          await (first
+            ? wait.execute("resume", { runId: first.runId })
+            : exec.execute("code-call-yield-overflow", input)),
+        );
+      } finally {
+        nowSpy.mockRestore();
+      }
 
-    expect(details.status).toBe("failed");
-    expect(details.error).toBe("code mode run expiry is unavailable.");
-    expect(testing.activeRuns.size).toBe(0);
-  });
+      expect(details.status).toBe("failed");
+      expect(details.error).toBe("code mode run expiry is unavailable.");
+      expect(details.output).toEqual([
+        { type: "text", text: "accepted first" },
+        { type: "text", text: "accepted inline" },
+      ]);
+      expect(fixture.execute).toHaveBeenCalledOnce();
+      expect(testing.activeRuns.size).toBe(0);
+    },
+  );
 
   it("expires suspended runs with invalid expiry timestamps", async () => {
     const { tools: codeModeTools } = createCodeModeHarness();

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -2,7 +2,7 @@
  * QuickJS worker for Code Mode guest execution and suspended VM snapshots.
  */
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { EvalFlags, JSException, QuickJS, type JSValueHandle } from "quickjs-wasi";
+import { EvalFlags, JSException, QuickJS, type JSValueHandle, type Snapshot } from "quickjs-wasi";
 import { serveWorkerTasks } from "../infra/worker-task-pool.js";
 import { CODE_MODE_CONTROLLER_SOURCE } from "./code-mode-controller-source.js";
 import {
@@ -186,7 +186,7 @@ async function createVm(input: CodeModeWorkerPayload, bridge: BridgeState): Prom
   };
   const vm =
     input.kind === "resume"
-      ? await QuickJS.restore(QuickJS.deserializeSnapshot(input.snapshotBytes), options)
+      ? await QuickJS.restore(input.snapshot, options)
       : await QuickJS.create(options);
   try {
     const callbacks = [
@@ -333,13 +333,16 @@ function waitingResult(params: {
   output: unknown[];
   config: CodeModeConfig;
 }): CodeModeWorkerResult {
-  const snapshotBytes = QuickJS.serializeSnapshot(params.vm.snapshot());
-  if (snapshotBytes.byteLength > params.config.maxSnapshotBytes) {
+  const snapshot = params.vm.snapshot();
+  // Preserve the encoded-size cap, but serialize only metadata: the snapshot
+  // already owns transferable memory, so the storage codec would copy it again.
+  const metadata = QuickJS.serializeSnapshot({ ...snapshot, memory: new Uint8Array() });
+  if (snapshot.memory.byteLength + metadata.byteLength > params.config.maxSnapshotBytes) {
     throw new CodeModeWorkerFailure("snapshot_limit_exceeded", "code mode snapshot limit exceeded");
   }
   return {
     status: "waiting",
-    snapshotBytes,
+    snapshot,
     pendingRequests: params.bridge.pendingRequests,
     canceledRequestIds: params.bridge.canceledRequestIds,
     settlementMode: params.settlementMode,
@@ -502,12 +505,14 @@ async function main(input: unknown): Promise<CodeModeWorkerThreadResult> {
         config,
       );
     }
-    if (input.kind === "resume" && input.snapshotBytes instanceof Uint8Array) {
+    // SAFETY: This process's QuickJS workers produce snapshots; the host returns them unchanged.
+    const snapshot = input.snapshot as Snapshot | undefined;
+    if (input.kind === "resume" && snapshot?.memory instanceof Uint8Array) {
       return captureWorkerResult(
         await run({
           kind: "resume",
           wasmModule: input.wasmModule,
-          snapshotBytes: input.snapshotBytes,
+          snapshot,
           config,
           settledRequests: Array.isArray(input.settledRequests)
             ? (input.settledRequests as SettledBridgeRequest[])
@@ -541,6 +546,6 @@ async function main(input: unknown): Promise<CodeModeWorkerThreadResult> {
 
 serveWorkerTasks(main, {
   transferList: (result) =>
-    // SAFETY: QuickJS.serializeSnapshot allocates a dedicated, transferable ArrayBuffer.
-    result.status === "waiting" ? [result.snapshotBytes.buffer as ArrayBuffer] : [],
+    // SAFETY: QuickJS.snapshot allocates a dedicated, transferable ArrayBuffer.
+    result.status === "waiting" ? [result.snapshot.memory.buffer as ArrayBuffer] : [],
 });


### PR DESCRIPTION
Related: #134935

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Concurrent CodeMode programs repeatedly allocate and copy their guest heaps when pausing for host tools and resuming. The warm workers introduced in #134935 improve execution latency, but this unnecessary copying increases process memory under load.

## Why This Change Was Made

Transfer QuickJS's owned `Snapshot.memory` buffer directly between the Gateway and worker. Keep the existing encoded-size limit at its producer by counting heap bytes plus the dependency's serialized metadata; remove the full-heap encoder/decoder, three duplicate parent checks, and their obsolete exception path. Reuse `createLazyPromise` for the shared WASM module instead of a separate promise cache.

## User Impact

CodeMode continuations use less resident memory while retaining warm-worker parallelism. Inline execution, explicit wait, and headless execution share the same snapshot ownership and limits. Tool authority, cancellation, and deadlines retain their existing behavior. Documentation now distinguishes guest-state limits from overall Gateway memory, which also includes workers and TypeScript compilers.

## Evidence

Three fresh alternating baseline/candidate process pairs used native Node 24.19.0, identical dependencies and 150-plugin inventories, and the same built CodeMode workload. Baseline: `15e4348d8bbcc375b12404cbb58b9e5bb22dcd54`, descended from #134935; the affected runtime/pool/lockfile bytes match that landed change. Each process verified 190 actual host-tool bridges and independent context results, for 1,140 bridges across the six paired processes.

| Measurement | Baseline | This change |
| --- | ---: | ---: |
| Warm 16-context median RSS | 2,256.92 MiB | 2,061.56 MiB (−8.66%) |
| Warm 16-context RSS range | 2,224.25–2,288.56 MiB | 1,873.75–2,095.47 MiB |
| Warm 16-context median sampled peak RSS | 2,256.92 MiB | 2,066.91 MiB |
| Sustained diagnostic median RSS | 2,380.40 MiB | 2,072.00 MiB (−12.96%) |
| RSS three seconds after normal worker retirement | 2,132.13 MiB | 1,858.50 MiB (−12.83%) |

Every warm pair reduced RSS, by 193.09, 350.50, and 195.36 MiB. The sustained diagnostic ran 20 additional 16-context batches, verified 1,790 bridges per side, and observed all 16 actual worker exits after the normal 60-second idle interval. Its baseline was recorded earlier, separately from the fresh paired window. No forced GC or heap snapshots were used. Twenty batches do not establish a permanent memory plateau or leak-free uptime.

Warm 16-context median measured stage CPU was 631.99→587.66 ms and wall time 45.11→42.63 ms, but individual pairs varied in direction under host contention. These measurements exclude import/startup and sampling gaps; they do not establish a consistent latency or overall Gateway throughput improvement.

- The new real-worker regression failed before the production change with `snapshot heap serialization copies memory`, then passed. It forbids full-heap codec use, verifies outbound transfer and parent buffer detachment, and preserves a 1 MiB typed array across two restores.
- **195 tests passed across 12 files**, covering worker lifecycle, exact metadata-inclusive limits, resumed heap growth, output preservation, bridge cancellation, deadlines, headless execution, explicit wait, swarm behavior, TypeScript, import boundaries, the pool, and the shared lazy helper.
- **Full `pnpm build` passed**, including SDK declarations, built CLI/plugin loading, export checks, and Control UI checks. Both matching `sourcePerformance` builds passed. Production and core-test type checks and changed-file formatting passed.
- Direct inspection of `quickjs-wasi` 3.5.0 source/types confirms that `snapshot()` owns its buffer, the old encoder and decoder each copy the entire heap, and `restore()` copies it into a new VM. Metadata-only serialization preserves the prior limit exactly.
- Fresh Codex autoreview of the frozen diff: **0 findings, scoped clean**.
- **Production LOC: +33/−70 (net −37). Tests: +238/−74 (net +164). Docs: +6/−1 (net +5).**

The initial parallel unused-export run passed production and script scans; its full-tree scan hit the unchanged 600-second timeout without reporting a finding. The isolated full-tree retry passed in 84 seconds. Both changed-file lint groups passed.

All remaining selected repository guards passed, including schema/storage, runtime sidecars, import cycles, and auth-boundary checks. The committed patch and all 62 scoped source hashes exactly match the measured source. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33490296376) on `8dcf7fccf397c3d707ffaf217d2ee3077ba7c63f`: 199 successful jobs, 16 intentional skips, no failures; the required `openclaw/ci-gate` is green.

Native review artifact validation and preparation passed on the same commit. Both [ClawSweeper rank-up moves](https://github.com/openclaw/openclaw/pull/135040#issuecomment-5491692265) are satisfied: the pinned dependency contract was directly verified and exact-head CI is green. Snapshots remain transient process-local state; the review's storage heuristic does not represent a persistence or public-format change.
