### PR TITLE
fix(models): retain externally authenticated providers in the model menu

### DIFF
--- a/docs/auth-credential-semantics.md
+++ b/docs/auth-credential-semantics.md
@@ -85,6 +85,7 @@ Do not write `type: "aws-sdk"` into the credential store; stored credentials are
 - Runtime-only credentials owned by external CLIs (Claude CLI for `claude-cli`, Codex CLI for `openai`, MiniMax CLI for `minimax-portal`) are discovered only when the provider, runtime, or auth profile is in scope for the current operation, or when a stored local profile for that external source already exists.
 - Auth-store callers choose an explicit external-CLI discovery mode: `none` for persisted/plugin auth only, `existing` for refreshing already stored external CLI profiles, or `scoped` for a concrete provider/profile set.
 - Read-only/status paths pass `allowKeychainPrompt: false`; they use file-backed external CLI credentials only and do not read or reuse macOS Keychain results.
+- `/models` reuses external login evidence already prepared with its catalog, so those providers remain visible without a second OpenClaw login. Opening the default menu does not repeat external CLI discovery; explicit auth order and route compatibility still apply.
 
 ## OAuth SecretRef Policy Guard
 

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -7,6 +7,7 @@ import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import { WorkerTaskError, WorkerTaskPool } from "../infra/worker-task-pool.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
   listAgentIds,
   resolveAgentDir,
@@ -47,6 +48,7 @@ import {
   type ProviderAuthWarmSnapshot,
 } from "./model-provider-auth-state.js";
 import { normalizeProviderId } from "./model-selection.js";
+import type { PreparedModelRuntimeAuth } from "./prepared-model-runtime-auth.js";
 import { resolveDefaultAgentWorkspaceDir } from "./workspace.js";
 
 export type ProviderAuthWarmWorkerResult =
@@ -248,6 +250,8 @@ export function createProviderAuthChecker(params: {
   allowPluginSyntheticAuth?: boolean;
   discoverExternalCliAuth?: boolean;
   allowPreparedRuntimeAuth?: boolean;
+  preparedAuth?: PreparedModelRuntimeAuth;
+  metadataSnapshot?: PluginMetadataSnapshot;
 }): ProviderModelAuthChecker {
   const authCache = new Map<string, Promise<ModelAuthAvailabilityEvaluation>>();
   let runtimeAuthLookup: RuntimeProviderAuthLookup | undefined;
@@ -261,9 +265,9 @@ export function createProviderAuthChecker(params: {
       (params.agentId && params.cfg
         ? resolveAgentDir(params.cfg, params.agentId, params.env)
         : undefined);
-    const authStore = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
-      allowKeychainPrompt: false,
-    });
+    const authStore =
+      params.preparedAuth?.authStore ??
+      ensureAuthProfileStoreWithoutExternalProfiles(agentDir, { allowKeychainPrompt: false });
     runtimeAuthLookup ??= createRuntimeProviderAuthLookup({
       cfg: params.cfg,
       workspaceDir: params.workspaceDir,
@@ -273,6 +277,9 @@ export function createProviderAuthChecker(params: {
     modelAuthResolver = createModelAuthAvailabilityResolver({
       cfg: params.cfg ?? {},
       authStore,
+      preparedRuntimeAuthStore: params.preparedAuth?.authStore,
+      preparedRuntimeAuthModes: params.preparedAuth?.authModes,
+      metadataSnapshot: params.metadataSnapshot,
       agentDir,
       workspaceDir: params.workspaceDir,
       env: params.env,
@@ -311,6 +318,7 @@ export function createProviderAuthChecker(params: {
         agentDir: params.agentDir,
         agentId: params.agentId,
         env: params.env,
+        store: params.preparedAuth?.authStore,
         allowPluginSyntheticAuth: params.allowPluginSyntheticAuth,
         discoverExternalCliAuth: params.discoverExternalCliAuth,
         allowPreparedRuntimeAuth: params.allowPreparedRuntimeAuth,

--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -16,6 +16,7 @@ import {
 } from "./models-config.plan.test-support.js";
 import type { ProviderConfig } from "./models-config.providers.secrets.js";
 import { encodePluginModelCatalogRelativePath } from "./plugin-model-catalog.js";
+import { AuthStorage, ModelRegistry } from "./sessions/index.js";
 
 const providerRuntimeMocks = vi.hoisted(() => ({
   normalizeProviderConfigWithPlugin: vi.fn<
@@ -240,11 +241,19 @@ beforeAll(async () => {
       agentDir: "/tmp/openclaw-models-config-env-vars-test",
       env: {},
       existingRaw: "",
-      existingParsed: null,
+      existingParsed: {
+        providers: {
+          retained: createImplicitOpenAiProvider({ auth: "oauth" }),
+          "empty-existing": createImplicitOpenAiProvider({ apiKey: "" }),
+        },
+      },
     },
     {
       resolveImplicitProviders: async () => ({
         openai: createImplicitOpenAiProvider(),
+        oauth: createImplicitOpenAiProvider({ auth: "oauth" }),
+        role: createImplicitOpenAiProvider({ auth: "aws-sdk" }),
+        empty: createImplicitOpenAiProvider({ apiKey: "" }),
         "auth-only": createImplicitOpenAiProvider({
           baseUrl: "https://auth.example/v1",
           api: "openai-responses",
@@ -469,10 +478,37 @@ describe("models-config", () => {
     },
   );
 
-  it("does not write unauthenticated model providers that would invalidate models.json", async () => {
+  it.each(["openai", "oauth", "role", "retained"])(
+    "publishes %s catalog rows without requiring an inline API key",
+    (provider) => {
+      expect(unauthenticatedProviderParsed.providers?.[provider]).toMatchObject({
+        models: [{ id: "gpt-5.5" }],
+      });
+      expect(unauthenticatedProviderParsed.providers?.[provider]).not.toHaveProperty("apiKey");
+    },
+  );
+
+  it.each(["empty", "empty-existing"])("rejects an explicitly empty key in %s", (provider) => {
+    expect(unauthenticatedProviderParsed.providers?.[provider]).toBeUndefined();
+  });
+
+  it("leaves keyless catalog authentication to the registry auth owner", () => {
     expect(unauthenticatedProviderWritePlan.action).toBe("write");
-    expect(unauthenticatedProviderParsed.providers?.openai).toBeUndefined();
     expect(unauthenticatedProviderParsed.providers?.["auth-only"]).toBeDefined();
+    if (unauthenticatedProviderWritePlan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const auth = AuthStorage.inMemory();
+    const registry = ModelRegistry.create(auth, "/tmp/openclaw-keyless-catalog/models.json", {
+      includePluginCatalogs: false,
+      modelsJsonContents: unauthenticatedProviderWritePlan.contents,
+    });
+    const model = registry.find("openai", "gpt-5.5");
+    expect(registry.getError()).toBeUndefined();
+    expect(model).toBeDefined();
+    expect(registry.getAvailable()).not.toContain(model);
+    auth.setRuntimeApiKey("openai", "synthetic-runtime-key");
+    expect(registry.getAvailable()).toContain(model);
   });
 
   it("treats empty replace-mode provider sets as authoritative", async () => {

--- a/src/agents/models-config.merge.ts
+++ b/src/agents/models-config.merge.ts
@@ -292,7 +292,7 @@ function isExistingProviderSelfContained(entry: ExistingProviderConfig): boolean
   if (!Array.isArray(entry.models) || entry.models.length === 0) {
     return true;
   }
-  return Boolean(entry.baseUrl?.trim() && entry.apiKey);
+  return Boolean(entry.baseUrl?.trim() && (entry.apiKey === undefined || entry.apiKey));
 }
 
 /** Merges generated provider config with existing secrets safe to preserve. */

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -258,7 +258,8 @@ function isWritableProviderConfig(provider: ProviderConfig): boolean {
   if (!Array.isArray(provider.models) || provider.models.length === 0) {
     return true;
   }
-  return Boolean(provider.baseUrl?.trim() && provider.apiKey);
+  // AuthStorage can supply omitted keys; an explicitly empty key still violates the schema.
+  return Boolean(provider.baseUrl?.trim() && (provider.apiKey === undefined || provider.apiKey));
 }
 
 function filterWritableProviders(

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -1,14 +1,25 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import { PreparedModelCatalogConfigReplacedError } from "../../agents/prepared-model-catalog.errors.js";
+import { setPreparedModelRuntimeAuthStore } from "../../agents/prepared-model-runtime-auth.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 const catalogMocks = vi.hoisted(() => ({
   loadSnapshot: vi.fn(),
   loadPublishedOwner: vi.fn(),
+  authStore: { version: 1, profiles: {} } as AuthProfileStore,
 }));
 
 vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadPreparedModelCatalogSnapshot: catalogMocks.loadSnapshot,
+  loadPreparedModelCatalogOwnerSnapshot: async (...args: unknown[]) => {
+    const owner = {
+      modelCatalog: await catalogMocks.loadSnapshot(...args),
+      authModes: {},
+    };
+    setPreparedModelRuntimeAuthStore(owner, catalogMocks.authStore);
+    return owner;
+  },
   loadPublishedPreparedModelCatalogOwnerSnapshot: catalogMocks.loadPublishedOwner,
 }));
 
@@ -24,9 +35,51 @@ const replacementCfg = {
 
 afterEach(() => {
   vi.clearAllMocks();
+  catalogMocks.authStore = { version: 1, profiles: {} };
 });
 
 describe("/models browse catalog recovery", () => {
+  it.each([false, true])(
+    "projects prepared external OAuth with explicit exclusion=%s",
+    async (excluded) => {
+      catalogMocks.authStore = {
+        version: 1,
+        profiles: {
+          "openai:external": {
+            type: "oauth",
+            provider: "openai",
+            access: "synthetic-access",
+            refresh: "synthetic-refresh",
+            expires: Date.now() + 3_600_000,
+          },
+        },
+        runtimeExternalProfileIds: ["openai:external"],
+        ...(excluded ? { order: { openai: [] } } : {}),
+      };
+      const subscription = {
+        provider: "openai",
+        id: "gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        api: "openai-chatgpt-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+      };
+      catalogMocks.loadSnapshot.mockResolvedValueOnce({
+        entries: [subscription],
+        routeVariants: [subscription],
+      });
+
+      const data = await buildPreparedModelsProviderData(staleCfg);
+
+      expect(data.providers.includes("openai")).toBe(!excluded);
+      if (!excluded) {
+        expect(data.modelCatalog.find((entry) => entry.provider === "openai")).toMatchObject({
+          api: "openai-chatgpt-responses",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+        });
+      }
+    },
+  );
+
   it("returns the exact-config snapshot when the prepared owner matches", async () => {
     catalogMocks.loadSnapshot.mockResolvedValueOnce({
       entries: [{ provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" }],

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -106,9 +106,9 @@ function setFastModelsCliBackendDeps(): void {
 vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
   loadPreparedModelCatalog: modelCatalogMocks.loadModelCatalog,
-  loadPreparedModelCatalogSnapshot: async (...args: unknown[]) => {
+  loadPreparedModelCatalogOwnerSnapshot: async (...args: unknown[]) => {
     const entries = await modelCatalogMocks.loadModelCatalog(...args);
-    return { entries, routeVariants: entries };
+    return { modelCatalog: { entries, routeVariants: entries }, authModes: {} };
   },
 }));
 

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -37,6 +37,8 @@ import { openAIModelCatalogRoutePolicy } from "../../agents/openai-model-routes.
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-routing.js";
 import { PreparedModelCatalogConfigReplacedError } from "../../agents/prepared-model-catalog.errors.js";
 import * as preparedModelCatalog from "../../agents/prepared-model-catalog.js";
+import { getPreparedModelRuntimeAuthStore } from "../../agents/prepared-model-runtime-auth.js";
+import type { PreparedModelRuntimeSnapshot } from "../../agents/prepared-model-runtime.types.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -196,19 +198,25 @@ async function buildPreparedDataForConfig(
     listCliRuntimeModelBackendBindings().map((binding) => normalizeProviderId(binding.runtime)),
   );
 
+  let loadedOwner: PreparedModelRuntimeSnapshot | undefined;
   const snapshot = await loadPreparedModelCatalogSnapshotForBrowse({
     cfg,
     agentId,
     view: options.view ?? "default",
-    loadCatalog: ({ readOnly }) =>
-      preparedModelCatalog.loadPreparedModelCatalogSnapshot({
+    loadCatalog: async ({ readOnly }) => {
+      loadedOwner = await preparedModelCatalog.loadPreparedModelCatalogOwnerSnapshot({
         config: cfg,
         readOnly,
         refreshFullCatalog: true,
         ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),
         ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
-      }),
+      });
+      return loadedOwner.modelCatalog;
+    },
   });
+  // A timed-out read can complete later. Only pair auth with the catalog actually returned.
+  const owner = loadedOwner?.modelCatalog === snapshot ? loadedOwner : undefined;
+  const authStore = owner && getPreparedModelRuntimeAuthStore(owner);
   const catalog = snapshot.entries;
   const visibilityPolicy = createModelVisibilityPolicy({
     cfg,
@@ -225,6 +233,12 @@ async function buildPreparedDataForConfig(
     allowPluginSyntheticAuth: false,
     discoverExternalCliAuth: false,
     allowPreparedRuntimeAuth: true,
+    ...(authStore && owner
+      ? {
+          preparedAuth: { authStore, authModes: owner.authModes },
+          metadataSnapshot: owner.metadataSnapshot,
+        }
+      : {}),
   });
   const logicalModelKey = (entry: { provider: string; id: string }) =>
     openAIModelCatalogRoutePolicy.resolveIdentity(entry)?.key ?? modelCatalogLogicalKey(entry);

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -376,9 +376,9 @@ vi.mock("../../agents/prepared-model-catalog.js", () => {
   return {
     loadPreparedModelCatalog: loadModelCatalog,
     loadProviderScopedThinkingCatalog: loadModelCatalog,
-    loadPreparedModelCatalogSnapshot: async () => {
+    loadPreparedModelCatalogOwnerSnapshot: async () => {
       const entries = await loadModelCatalog();
-      return { entries, routeVariants: entries };
+      return { modelCatalog: { entries, routeVariants: entries }, authModes: {} };
     },
   };
 });


### PR DESCRIPTION
Closes #134516. Reported by Goslya (@goslingmanagment).

## What Problem This Solves

Fixes an issue where users signed in through the external Codex CLI could see OpenAI as available in the Gateway catalog but not in the shared `/models` provider menu, unless they persisted a second OpenClaw login.

## Why This Change Was Made

The route-aware menu projection discarded the catalog owner's prepared auth evidence and rebuilt its checker from a store without external profiles. The menu now carries the exact catalog owner's private auth store, credential modes, and metadata into the existing route-aware checker. The catalog/auth identity check prevents a late timed-out load from supplying auth for a different returned snapshot.

Isolated Gateway investigation also exposed two publication/merge gates that discarded model rows when an inline API key was omitted. Those gates contradicted the registry's shipped AuthStorage contract from #109622. Both now accept omitted keys while retaining rejection of explicitly empty keys and missing endpoints.

This reuses the existing prepared-owner and registry abstractions. It does not enable external discovery on the default picker hot path, persist external credentials, relax explicit auth order, add configuration, or change provider catalogs. No plugin manifest change is needed because no model definition or provider metadata changes.

#134544 (catalog completeness after hot reload) is explicitly out of scope: **NEEDS-MAINTAINER-DECISION**. This PR does not choose a new reload/discovery policy.

## User Impact

Externally authenticated providers remain visible when their catalog generation already contains usable auth evidence. The bounded default browse path and route compatibility checks remain intact. Catalogs backed by AuthStorage are no longer silently discarded just because credentials are not inline.

## Evidence

- Focused tests: **113 passed across five files**, command exited 0:
  `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/auto-reply/reply/commands-models.catalog-recovery.test.ts src/auto-reply/reply/commands-models.test.ts src/agents/model-provider-auth.test.ts src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.merge.test.ts`.
- The `/model list` alias fixture now follows the owner-snapshot API; **117 tests passed** in `src/auto-reply/reply/directive-handling.model.test.ts`. Current head adds only this test correction to the live-proven runtime.
- Formatting of all nine changed files and `git diff --check`: passed.
- Fresh Codex autoreview: **scoped-clean at P0**, no accepted/actionable findings.
- Runtime build: `node --import ./scripts/tsx.mjs scripts/build-all.mts qaRuntime` passed; includes CLI bootstrap validation and 50 built control-plane module checks. A full build was intentionally interrupted during SDK declaration generation after its runtime bundles completed; it is not counted as a successful full build.
- **Isolated live Gateway with mocked service boundaries**, at `ad70b467798f48266814afab02f39798b88f80d3`: fresh state/home/workspace, synthetic file-backed Codex OAuth, mock OpenAI catalog, and mock Telegram Bot API. No production provider/channel credentials or operator Gateway were used. The built CLI performed a full `models.list` refresh, then two real inbound Telegram `/models` updates traversed polling, dispatch, the shared command, and outbound `sendMessage`.
- Gateway catalog returned `openai/gpt-5.6-luna` with `available: true`. Both Telegram responses contained `anthropic (1)` and `openai (1)` provider buttons. Native OpenClaw auth profiles were empty before and after; the warm menu made no additional catalog request. Gateway and both loopback listeners were verified stopped.

Sanitized mock-gateway verdict:

```json
{
  "ok": true,
  "head": "ad70b467798f48266814afab02f39798b88f80d3",
  "externalOnlyAuth": true,
  "nativeProfilesBefore": 0,
  "nativeProfilesAfter": 0,
  "catalogRequests": 1,
  "gatewayOpenAIAvailable": true,
  "telegramProviderMenus": [["anthropic (1)", "openai (1)"], ["anthropic (1)", "openai (1)"]],
  "cleanupVerified": true
}
```

The first scratch-run attempt used an obsolete startup log matcher and timed out despite the Gateway reaching ready; correcting the fixture readiness signal made the unchanged candidate pass. This is synthetic service-boundary proof, not an authenticated Telegram Test Server or production OpenAI test.

Direct dependency inspection: Codex `codex-rs/login/src/auth/storage.rs:41` and `:185` (`AuthDotJson`, file loader), plus `codex-rs/login/src/token_data.rs:11` and `:130` (`TokenData`, JWT expiry) at `0ae94fdd49b05ee7faa4d984d06a68492cb32b54`; OpenClaw's parser consumes the same file/token contract. Registry schema and validator inspected in `src/agents/sessions/model-registry.ts`; #109622's keyless-catalog change is an ancestor of stable `v2026.8.1`.

Production delta: +31/-8 (**+23**); tests: +96/-7 (**+89**); docs: +1. The production growth passes already-owned typed auth facts across the existing catalog/checker boundary; toggling discovery or adding a downstream provider exception would lose the performance or ownership invariant.

## CI and review follow-through

[Initial CI](https://github.com/openclaw/openclaw/actions/runs/33491395056) exposed a sibling `/model list` test mock still exporting the old snapshot API. The fixture now returns the prepared owner shape, and all 117 tests in that file pass. A fresh managed Codex autoreview including that correction is scoped-clean at P0. The same run also encountered a low-heap canonical Doctor child OOM after emitting the expected result; the unchanged targeted file passed locally (1/1), and the [new exact-head Linux Doctor shard](https://github.com/openclaw/openclaw/actions/runs/33492779043/job/99808180337) passed. No heap limit, timeout, or assertion was relaxed. The earlier post-result OOM remains an explicit CI-stability follow-up for a separate focused investigation; it did not recur in the current Linux shard.

[ClawSweeper review](https://github.com/openclaw/openclaw/pull/135046#issuecomment-5491839092) found no code defect and recommends retaining this single catalog-owner/auth pairing. Its production-growth condition is addressed by the typed handoff and snapshot identity guard described above; no further production path was added. Its stored-data heuristic is not applicable: `metadataSnapshot` is existing private in-memory plugin metadata, not vector metadata, persisted data, or a schema change. The operator explicitly authorized this pure bug-fix landing; the live main rules require `openclaw/ci-gate`, with no separate required approval rule. [Exact-head CI33492779043](https://github.com/openclaw/openclaw/actions/runs/33492779043) completed successfully on `1292baf808f9da137da9f80664442ff1ab5bc93a`. The requested synthetic mock-Gateway flow is the repository's accepted real-behavior proof path for this task; it is not represented as Telegram Test Server proof.
