### PR TITLE
refactor(commands): share structured action argument formatting

### DIFF
--- a/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
+++ b/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
@@ -55,12 +55,15 @@ function createConfig(): OpenClawConfig {
   } as OpenClawConfig;
 }
 
-function createCommand(cfg: OpenClawConfig, discordConfig?: DiscordAccountConfig) {
-  const commandSpec: NativeCommandSpec = {
+function createCommand(
+  cfg: OpenClawConfig,
+  discordConfig?: DiscordAccountConfig,
+  commandSpec: NativeCommandSpec = {
     name: "ping",
     description: "Ping",
     acceptsArgs: false,
-  };
+  },
+) {
   return createDiscordNativeCommand({
     command: commandSpec,
     cfg,
@@ -123,12 +126,17 @@ async function runGuildSlashCommand(params?: {
   userId?: string;
   mutateConfig?: (cfg: OpenClawConfig) => void;
   runtimeDiscordConfig?: DiscordAccountConfig;
+  commandSpec?: NativeCommandSpec;
+  optionValues?: Record<string, string>;
   mutateInteraction?: (interaction: MockCommandInteraction) => void;
 }) {
   const cfg = createConfig();
   params?.mutateConfig?.(cfg);
-  const command = createCommand(cfg, params?.runtimeDiscordConfig);
+  const command = createCommand(cfg, params?.runtimeDiscordConfig, params?.commandSpec);
   const interaction = createInteraction({ userId: params?.userId });
+  interaction.options.getString.mockImplementation(
+    (name: string) => params?.optionValues?.[name] ?? null,
+  );
   params?.mutateInteraction?.(interaction);
   vi.mocked(matchPluginCommand).mockReturnValue(null);
   const dispatchSpy = createDispatchSpy();
@@ -535,6 +543,72 @@ describe("Discord native slash commands with commands.allowFrom", () => {
     expect(interaction.followUp).toHaveBeenCalledWith({ content: longReply, ephemeral: true });
     expect(interaction.reply).not.toHaveBeenCalled();
   });
+
+  const structuredDiscordArgCases: Array<{
+    command: string;
+    optionValues: Record<string, string>;
+    expectedPrompt: string;
+  }> = [
+    {
+      command: "config",
+      optionValues: { action: " GET ", path: " agents.defaults.model " },
+      expectedPrompt: "/config get agents.defaults.model",
+    },
+    {
+      command: "config",
+      optionValues: { action: "set", path: "agents.defaults.model" },
+      expectedPrompt: "/config set agents.defaults.model",
+    },
+    {
+      command: "mcp",
+      optionValues: { action: "get", path: "servers.github" },
+      expectedPrompt: "/mcp get servers.github",
+    },
+    { command: "mcp", optionValues: { action: "get" }, expectedPrompt: "/mcp get" },
+    {
+      command: "plugins",
+      optionValues: { action: "get", path: "discord" },
+      expectedPrompt: "/plugins get discord",
+    },
+    {
+      command: "plugins",
+      optionValues: { action: "list", path: "ignored" },
+      expectedPrompt: "/plugins list",
+    },
+    {
+      command: "debug",
+      optionValues: { action: "show", path: "ignored" },
+      expectedPrompt: "/debug show",
+    },
+    { command: "debug", optionValues: { action: "unset" }, expectedPrompt: "/debug unset" },
+  ];
+
+  it.each(structuredDiscordArgCases)(
+    "serializes structured /$command args and delivers the visible reply",
+    async ({ command, optionValues, expectedPrompt }) => {
+      const visibleReply = `Handled ${expectedPrompt}`;
+      const { interaction } = await runGuildSlashCommand({
+        commandSpec: {
+          name: command,
+          description: `Test ${command}`,
+          acceptsArgs: true,
+        },
+        optionValues,
+      });
+      const dispatchCall = firstDispatchReplyCall();
+
+      expect(dispatchCall.ctx.Body).toBe(expectedPrompt);
+      expect(dispatchCall.ctx.CommandArgs?.raw).toBe(expectedPrompt.slice(command.length + 2));
+
+      await dispatchCall.dispatcherOptions.deliver({ text: visibleReply }, { kind: "final" });
+
+      expect(interaction.followUp).toHaveBeenCalledWith({
+        content: visibleReply,
+        ephemeral: true,
+      });
+      expect(interaction.reply).not.toHaveBeenCalled();
+    },
+  );
 
   it("swallows expired slash interactions before dispatch when defer returns Unknown interaction", async () => {
     const cfg = createConfig();

--- a/src/auto-reply/commands-args.ts
+++ b/src/auto-reply/commands-args.ts
@@ -29,9 +29,7 @@ function normalizeArgValue(value: unknown): string | undefined {
 
 function formatActionArgs(
   values: CommandArgValues,
-  params: {
-    formatKnownAction: (action: string, path: string | undefined) => string | undefined;
-  },
+  pathActions: readonly string[] = ["show", "get"],
 ): string | undefined {
   const action = normalizeOptionalLowercaseString(normalizeArgValue(values.action));
   const path = normalizeArgValue(values.path);
@@ -39,76 +37,11 @@ function formatActionArgs(
   if (!action) {
     return undefined;
   }
-  const knownAction = params.formatKnownAction(action, path);
-  if (knownAction) {
-    return knownAction;
+  if (action === "set" && path && value) {
+    return `${action} ${path}=${value}`;
   }
-  return formatSetUnsetArgAction(action, { path, value });
-}
-
-const formatConfigArgs: CommandArgsFormatter = (values) =>
-  formatActionArgs(values, {
-    formatKnownAction: (action, path) => {
-      if (action === "show" || action === "get") {
-        return path ? `${action} ${path}` : action;
-      }
-      return undefined;
-    },
-  });
-
-const formatMcpArgs: CommandArgsFormatter = (values) =>
-  formatActionArgs(values, {
-    formatKnownAction: (action, path) => {
-      if (action === "show" || action === "get") {
-        return path ? `${action} ${path}` : action;
-      }
-      return undefined;
-    },
-  });
-
-const formatPluginsArgs: CommandArgsFormatter = (values) =>
-  formatActionArgs(values, {
-    formatKnownAction: (action, path) => {
-      if (action === "list") {
-        return "list";
-      }
-      if (action === "show" || action === "get") {
-        return path ? `${action} ${path}` : action;
-      }
-      if (action === "enable" || action === "disable") {
-        return path ? `${action} ${path}` : action;
-      }
-      return undefined;
-    },
-  });
-
-const formatDebugArgs: CommandArgsFormatter = (values) =>
-  formatActionArgs(values, {
-    formatKnownAction: (action) => {
-      if (action === "show" || action === "reset") {
-        return action;
-      }
-      return undefined;
-    },
-  });
-
-function formatSetUnsetArgAction(
-  action: string,
-  params: { path: string | undefined; value: string | undefined },
-): string {
-  if (action === "unset") {
-    return params.path ? `${action} ${params.path}` : action;
-  }
-  if (action === "set") {
-    if (!params.path) {
-      return action;
-    }
-    if (!params.value) {
-      return `${action} ${params.path}`;
-    }
-    return `${action} ${params.path}=${params.value}`;
-  }
-  return action;
+  const includesPath = action === "set" || action === "unset" || pathActions.includes(action);
+  return path && includesPath ? `${action} ${path}` : action;
 }
 
 const formatQueueArgs: CommandArgsFormatter = (values) => {
@@ -155,10 +88,10 @@ const formatExecArgs: CommandArgsFormatter = (values) => {
 
 /** Command-specific serializers used when rebuilding slash-command text from parsed args. */
 export const COMMAND_ARG_FORMATTERS: Record<string, CommandArgsFormatter> = {
-  config: formatConfigArgs,
-  mcp: formatMcpArgs,
-  plugins: formatPluginsArgs,
-  debug: formatDebugArgs,
+  config: formatActionArgs,
+  mcp: formatActionArgs,
+  plugins: (values) => formatActionArgs(values, ["show", "get", "enable", "disable"]),
+  debug: (values) => formatActionArgs(values, []),
   queue: formatQueueArgs,
   exec: formatExecArgs,
 };

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -21,7 +21,11 @@ import {
   serializeCommandArgs,
   shouldHandleTextCommands,
 } from "./commands-registry.js";
-import type { ChatCommandDefinition, NativeCommandSpec } from "./commands-registry.types.js";
+import type {
+  ChatCommandDefinition,
+  CommandArgValues,
+  NativeCommandSpec,
+} from "./commands-registry.types.js";
 
 type NativeCommandNameResolver = (params: { commandKey: string; defaultName: string }) => string;
 
@@ -735,6 +739,54 @@ describe("commands registry args", () => {
       "/model gpt-5.4",
     );
   });
+
+  const structuredArgCases: Array<{
+    command: string;
+    values: CommandArgValues;
+    expected: string;
+  }> = [
+    {
+      command: "config",
+      values: { action: " GET ", path: " agents.defaults.model " },
+      expected: "/config get agents.defaults.model",
+    },
+    {
+      command: "config",
+      values: { action: "set", path: "agents.defaults.model" },
+      expected: "/config set agents.defaults.model",
+    },
+    {
+      command: "mcp",
+      values: { action: "get", path: "servers.github" },
+      expected: "/mcp get servers.github",
+    },
+    { command: "mcp", values: { action: "get" }, expected: "/mcp get" },
+    {
+      command: "plugins",
+      values: { action: "get", path: "discord" },
+      expected: "/plugins get discord",
+    },
+    {
+      command: "plugins",
+      values: { action: "list", path: "ignored" },
+      expected: "/plugins list",
+    },
+    {
+      command: "debug",
+      values: { action: "show", path: "ignored" },
+      expected: "/debug show",
+    },
+    { command: "debug", values: { action: "unset" }, expected: "/debug unset" },
+  ];
+
+  it.each(structuredArgCases)(
+    "serializes structured $command args through its registry definition",
+    (testCase) => {
+      expect(buildCommandTextFromArgs(requireChatCommand(testCase.command), testCase)).toBe(
+        testCase.expected,
+      );
+    },
+  );
 
   it("resolves auto arg menus when missing a choice arg", () => {
     const command = createUsageModeCommand();


### PR DESCRIPTION
## What Problem This Solves

Config, MCP, plugins and debug commands rebuilt their structured arguments through four near-identical callbacks plus a second set/unset helper. They now share one private formatter, with each command supplying only its existing path-bearing actions.

## Why This Change Was Made

The formatter retains the existing action/path/value read and normalization order, then constructs set assignments or action/path text in one place. Missing operands, unknown actions, plugin list behavior and debug path suppression retain their existing results. Queue and exec formatting, command definitions and authorization stay with their current owners.

## User Impact

No intended behavior change. Production decreases by 67 physical lines (+9/−76), or 62 nonblank code lines; focused tests add 126 physical lines. No configuration, dependency, storage, public API or command syntax changes.

## Evidence

All 86 focused tests pass across five files and three Vitest shards. New registry and structured Discord command cases pass against the original formatter before the refactor. The final differential compares 30,412 formatter cases and 2,160 actual parser cases across nine real modules, preserving exact command text, returned values, thrown error identity and getter order.

The Discord fixture exercises native command option reading, registry serialization and dispatch context, then calls the existing delivery callback and checks the visible ephemeral reply. Dispatch and Discord interaction transport are fixtures; this does not claim a running Gateway or external Discord API acceptance. The pure formatter changes no network request contract.

All selected changed-file checks and fresh managed P2/high review pass. Early new-test table inference failures were corrected with explicit existing argument types; final typechecks and tests are green. The gate log reaches every selected check; its final guard was also rerun directly to retain an unambiguous exit receipt. The production owner and immediate callers remain unchanged on current main, and the original owner matches stable v2026.8.1.


The latest 09:50 UTC ClawSweeper review has no correctness finding. Its optional exact-head CI and normal maintainer review actions are complete; required CI 33493805299 is green and this user-directed maintainer campaign accepts the private serializer refactor.
