### PR TITLE
fix(gateway): retain catalog runtime during session creation

### DIFF
--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -40,6 +40,10 @@ import { withTimeout } from "../infra/fs-safe.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import {
+  createColdPluginFixture,
+  isColdPluginRuntimeLoaded,
+} from "../plugins/test-helpers/cold-plugin-fixtures.js";
+import {
   beginSessionWorkAdmission,
   getSessionWorkAdmissionRelease,
   isSessionLifecycleMutationActive,
@@ -4030,82 +4034,126 @@ test("sessions.create does not parent the main session to itself", async () => {
   expect(created.payload?.entry?.parentSessionKey).toBeUndefined();
 });
 
-test("sessions.create resolves a catalog target server-side and pins its runtime", async () => {
-  const { storePath } = await createSessionStoreDir();
-  testState.agentConfig = { model: { primary: "anthropic/claude-opus-4-8" } };
-  agentDiscoveryMock.enabled = true;
-  agentDiscoveryMock.models = [
-    { id: "claude-opus-4-8", name: "Claude Opus 4.8", provider: "anthropic" },
-  ];
-  const resolveCreateSession = vi.fn(() => ({
-    model: "anthropic/claude-opus-4-8",
-    agentRuntime: "claude-cli",
-  }));
-  const registry = createEmptyPluginRegistry();
-  registry.sessionCatalogs.push({
-    pluginId: "anthropic",
-    source: "test",
-    provider: {
-      id: "claude",
-      label: "Claude Code",
-      resolveCreateSession,
-      list: vi.fn(async () => []),
-      read: vi.fn(async ({ hostId, threadId }) => ({ hostId, threadId, items: [] })),
-    },
-  });
-  setActivePluginRegistry(registry);
-
-  try {
-    const created = await directSessionReq<{
-      entry?: {
-        providerOverride?: string;
-        modelOverride?: string;
-        agentRuntimeOverride?: string;
-        modelSelectionLocked?: boolean;
-        pluginOwnerId?: string;
-      };
-      key?: string;
-    }>("sessions.create", { agentId: "main", catalogId: "claude" });
-
-    expect(created.ok).toBe(true);
-    expect(created.payload?.entry).toMatchObject({
-      providerOverride: "anthropic",
-      modelOverride: "claude-opus-4-8",
-      agentRuntimeOverride: "claude-cli",
-      modelSelectionLocked: true,
-      pluginOwnerId: "anthropic",
-    });
-    expect(resolveCreateSession).toHaveBeenCalledWith({ agentId: "main" });
-
-    const patched = await directSessionReq("sessions.patch", {
-      key: created.payload?.key,
-      agentId: "main",
+test.each(["cli", "enabled", "disabled"] as const)(
+  "sessions.create resolves a catalog target server-side with a %s harness",
+  async (harness) => {
+    const { dir, storePath } = await createSessionStoreDir();
+    testState.agentConfig = {
+      model: { primary: "anthropic/claude-opus-4-8" },
+      models: { "anthropic/claude-opus-4-8": { agentRuntime: { id: "missing-harness" } } },
+    };
+    agentDiscoveryMock.enabled = true;
+    agentDiscoveryMock.models = [
+      { id: "claude-opus-4-8", name: "Claude Opus 4.8", provider: "anthropic" },
+    ];
+    const agentRuntime = harness === "cli" ? "claude-cli" : "fixture-harness";
+    let fixture: ReturnType<typeof createColdPluginFixture> | undefined;
+    if (harness !== "cli") {
+      const rootDir = await fs.mkdtemp(path.join(dir, "catalog-harness-"));
+      fixture = createColdPluginFixture({
+        rootDir,
+        pluginId: "fixture-harness",
+        manifest: { activation: { onAgentHarnesses: ["fixture-harness"] } },
+      });
+      const { writeConfigFile } = await getGatewayConfigModule();
+      await writeConfigFile({
+        plugins: {
+          load: { paths: [rootDir] },
+          entries: { "fixture-harness": { enabled: harness === "enabled" } },
+        },
+      });
+    }
+    const resolveCreateSession = vi.fn(() => ({
       model: "anthropic/claude-opus-4-8",
+      agentRuntime,
+    }));
+    const registry = createEmptyPluginRegistry();
+    if (harness === "cli") {
+      registry.cliBackends.push({
+        pluginId: "anthropic",
+        source: "test",
+        backend: {
+          id: "claude-cli",
+          modelProvider: "anthropic",
+          config: { command: "claude" },
+          bundleMcp: false,
+        },
+      });
+    }
+    registry.sessionCatalogs.push({
+      pluginId: "anthropic",
+      source: "test",
+      provider: {
+        id: "claude",
+        label: "Claude Code",
+        resolveCreateSession,
+        list: vi.fn(async () => []),
+        read: vi.fn(async ({ hostId, threadId }) => ({ hostId, threadId, items: [] })),
+      },
     });
-    expect(patched.ok).toBe(false);
-    expect(patched.error).toMatchObject({
-      code: "INVALID_REQUEST",
-      message: "Model selection is locked for this session.",
-    });
+    setActivePluginRegistry(registry);
 
-    const deleted = await directSessionReq("sessions.delete", {
-      key: created.payload?.key,
-      agentId: "main",
-      deleteTranscript: false,
-    });
-    expect(deleted.ok).toBe(true);
-    expect(
-      loadSessionEntry({
+    try {
+      const created = await directSessionReq<{
+        entry?: {
+          providerOverride?: string;
+          modelOverride?: string;
+          agentRuntimeOverride?: string;
+          modelSelectionLocked?: boolean;
+          pluginOwnerId?: string;
+        };
+        key?: string;
+      }>("sessions.create", { agentId: "main", catalogId: "claude" });
+
+      if (fixture) {
+        expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
+      }
+      if (harness === "disabled") {
+        expect(created.ok).toBe(false);
+        expect(created.error?.message).toContain('requires agent harness "fixture-harness"');
+        expect(created.payload).toBeUndefined();
+        return;
+      }
+      expect(created.ok, JSON.stringify(created.error)).toBe(true);
+      expect(created.payload?.entry).toMatchObject({
+        providerOverride: "anthropic",
+        modelOverride: "claude-opus-4-8",
+        agentRuntimeOverride: agentRuntime,
+        modelSelectionLocked: true,
+        pluginOwnerId: "anthropic",
+      });
+      expect(resolveCreateSession).toHaveBeenCalledWith({ agentId: "main" });
+
+      const patched = await directSessionReq("sessions.patch", {
+        key: created.payload?.key,
         agentId: "main",
-        sessionKey: created.payload?.key ?? "",
-        storePath,
-      }),
-    ).toBeUndefined();
-  } finally {
-    testState.agentConfig = undefined;
-    setActivePluginRegistry(createEmptyPluginRegistry());
-  }
-});
+        model: "anthropic/claude-opus-4-8",
+      });
+      expect(patched.ok).toBe(false);
+      expect(patched.error).toMatchObject({
+        code: "INVALID_REQUEST",
+        message: "Model selection is locked for this session.",
+      });
+
+      const deleted = await directSessionReq("sessions.delete", {
+        key: created.payload?.key,
+        agentId: "main",
+        deleteTranscript: false,
+      });
+      expect(deleted.ok).toBe(true);
+      expect(
+        loadSessionEntry({
+          agentId: "main",
+          sessionKey: created.payload?.key ?? "",
+          storePath,
+        }),
+      ).toBeUndefined();
+    } finally {
+      testState.agentConfig = undefined;
+      setActivePluginRegistry(createEmptyPluginRegistry());
+    }
+  },
+);
 
 test("sessions.create rejects a caller-supplied key for a catalog target", async () => {
   const { storePath } = await createSessionStoreDir();
@@ -4214,6 +4262,16 @@ test("sessions.create bypasses main-session reset for a catalog target", async (
     },
   });
   const registry = createEmptyPluginRegistry();
+  registry.cliBackends.push({
+    pluginId: "anthropic",
+    source: "test",
+    backend: {
+      id: "claude-cli",
+      modelProvider: "anthropic",
+      config: { command: "claude" },
+      bundleMcp: false,
+    },
+  });
   registry.sessionCatalogs.push({
     pluginId: "anthropic",
     source: "test",

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -1109,6 +1109,7 @@ export async function createGatewaySession(params: {
           storeKey: target.canonicalKey,
           agentId: target.agentId,
           preparedSessionRoot: sessionRoot,
+          preparedAgentRuntime: catalogAgentRuntime,
           // Patch appliers read key presence as caller intent (present = change,
           // null = clear), so omitted create fields must stay absent: a present
           // undefined model trips the selection lock and drops modelFallback,

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -131,6 +131,8 @@ export async function projectSessionsPatchEntry(params: {
   patch: SessionsPatchParams;
   /** Canonical root prepared by the trusted create path; never accepted from public patches. */
   preparedSessionRoot?: string;
+  /** Trusted catalog runtime must own selection checks before the new row is persisted. */
+  preparedAgentRuntime?: string;
   archivedBy?: SessionEntry["archivedBy"];
   loadGatewayModelCatalog?: () => Promise<ModelCatalogEntry[]>;
   providerAuthMetadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins">;
@@ -185,6 +187,7 @@ export async function projectSessionsPatchEntry(params: {
       entry,
     });
     return (
+      params.preparedAgentRuntime ??
       acpMeta?.backend ??
       resolveEffectiveAgentRuntime({
         cfg,


### PR DESCRIPTION
Follow-up to #134837. A registered session catalog selects a model/runtime pair, but `sessions.create` previously passed only the model into its late validation step. That step resolved the runtime again from configuration, so a valid catalog selection could fail with an error naming an unrelated configured harness.

Pass the already-normalized catalog runtime into the existing patch projection as trusted prepared context. Harness admission and thinking-level checks then validate the same pair that creation will persist. The registered catalog still owns the selection and plugin identity; public patches cannot supply this internal value. Validation remains before the transcript-header/session-row write, with existing lifecycle preparation and rollback ordering intact.

The regression cases exercise the actual create handler and session storage with a conflicting configured runtime:

| Catalog runtime | Previous result | Repaired result |
| --- | --- | --- |
| Registered CLI backend | Rejected against configured harness | Creates with catalog runtime, plugin owner, and model-selection lock |
| Enabled harness plugin | Rejected against configured harness | Creates without loading the plugin runtime |
| Disabled harness plugin | Error names configured harness | Rejects with guidance naming the disabled catalog harness |

All three cases fail against the previous validation path. Seven focused catalog/sibling cases passed on the earlier integrated candidate, covering agent authorization, caller-key rejection, model locking, deletion, main-session reset avoidance, and catalog-based worktree naming/initial-send behavior. Those seven cases were not rerun as a separate focused suite on the final base. The source gate passes, and complete-candidate Codex autoreview is P0 scoped-clean.

A previous integrated candidate passed both create/patch suites, 236 tests. On the refreshed base, 235 passed and the unrelated worktree-title overall-timeout fixture exceeded its existing 15-second deadline. That request has no catalog target, model, or thinking patch, so it does not enter the changed runtime-selection path. One subsequent diagnostic run, with the same deadline/assertions and temporary phase observations, passed in 9.638 seconds: the expected eight-second naming timeout fired, the admitted run drained, and cleanup completed. The original failure's phase remains unknown. Diagnostic instrumentation was removed and all three source hashes restored; no timeout or assertion was weakened. The full-suite title timeout remains a named follow-up if it recurs.

```sh
node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts src/gateway/sessions-patch.test.ts
node scripts/check-changed.mjs src/gateway/session-create-service.ts src/gateway/sessions-patch.ts src/gateway/server.sessions.create.test.ts
```

Production is +4/-0 and tests +129/-71 across three files. The four production lines carry one documented internal value through the canonical validator; no new resolver, early persistence, config option, protocol field, dependency, or SQLite change is introduced. The earlier UI repair and screenshots remain on #134837; this follow-up's evidence is handler/storage behavior, not installed-provider inference or browser proof. Independent review of committed head `25f141b291d32f40f3e6a40539d76285604bcaba` completed with no actionable findings across priorities. Exact-head hosted checks completed with 228 successes, 107 skips, and one neutral result; native landing verification remains the final step.

The [ClawSweeper review](https://github.com/openclaw/openclaw/pull/135048#issuecomment-5491900900) found no correctness defect. Its production-growth item is resolved by retaining the trusted create-only handoff through the existing validator described above, and its final-validation item is satisfied by the completed exact-head CI. No code changed after that review.
