### PR TITLE
fix(security): security audit skips SecretRef-backed gateway password

### DIFF
--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -31,6 +31,41 @@ describe("collectSecretsInConfigFindings", () => {
     setConfigResolutionFacts(config, new Set());
     expect(collectSecretsInConfigFindings(config)).toHaveLength(1);
   });
+
+  it("does not flag gateway passwords externalized via file or exec SecretRefs", () => {
+    const fileConfig = {
+      gateway: {
+        auth: {
+          password: { source: "file", provider: "default", id: "/run/secrets/gateway-password" },
+        },
+      },
+    } satisfies OpenClawConfig;
+    expect(collectSecretsInConfigFindings(fileConfig)).toHaveLength(0);
+
+    const execConfig = {
+      gateway: {
+        auth: {
+          password: { source: "exec", provider: "vault", id: "gateway/password" },
+        },
+      },
+    } satisfies OpenClawConfig;
+    expect(collectSecretsInConfigFindings(execConfig)).toHaveLength(0);
+  });
+
+  it("flags plaintext hooks tokens but not SecretRef-backed tokens", () => {
+    const plaintext = {
+      hooks: { enabled: true, token: "hooks-plaintext-token" },
+    } satisfies OpenClawConfig;
+    expect(collectSecretsInConfigFindings(plaintext)).toHaveLength(1);
+
+    const secretRef = {
+      hooks: {
+        enabled: true,
+        token: { source: "file", provider: "default", id: "/run/secrets/hooks-token" },
+      },
+    } satisfies OpenClawConfig;
+    expect(collectSecretsInConfigFindings(secretRef)).toHaveLength(0);
+  });
 });
 
 describe("collectAttackSurfaceSummaryFindings", () => {

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -15,7 +15,7 @@ import { isToolAllowedByPolicies } from "../agents/tool-policy-match.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { describeBinding } from "../commands/agents.binding-format.js";
 import { mergeAccountConfig } from "../config/channel-account-config.js";
-import { hasUnresolvedConfigPath } from "../config/resolution-facts.js";
+import { hasUnresolvedConfigPath, resolveConfigSecretRef } from "../config/resolution-facts.js";
 import type { GatewayAuthConfig } from "../config/types.gateway.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { AgentToolsConfig } from "../config/types.tools.js";
@@ -589,10 +589,28 @@ export function collectSyncedFolderFindings(params: {
   return findings;
 }
 
+function isPersistedPlaintextSecret(cfg: OpenClawConfig, path: string, value: unknown): boolean {
+  if (hasUnresolvedConfigPath(cfg, path)) {
+    return false;
+  }
+  if (
+    resolveConfigSecretRef({
+      config: cfg,
+      path,
+      value,
+      defaults: cfg.secrets?.defaults,
+    })
+  ) {
+    return false;
+  }
+  const literal = normalizeOptionalString(value) ?? "";
+  return literal.length > 0;
+}
+
 export function collectSecretsInConfigFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
-  const password = normalizeOptionalString(cfg.gateway?.auth?.password) ?? "";
-  if (password && !hasUnresolvedConfigPath(cfg, "gateway.auth.password")) {
+  const passwordValue = cfg.gateway?.auth?.password;
+  if (isPersistedPlaintextSecret(cfg, "gateway.auth.password", passwordValue)) {
     findings.push({
       checkId: "config.secrets.gateway_password_in_config",
       severity: "warn",
@@ -604,8 +622,11 @@ export function collectSecretsInConfigFindings(cfg: OpenClawConfig): SecurityAud
     });
   }
 
-  const hooksToken = normalizeOptionalString(cfg.hooks?.token) ?? "";
-  if (cfg.hooks?.enabled === true && hooksToken && !hasUnresolvedConfigPath(cfg, "hooks.token")) {
+  const hooksTokenValue = cfg.hooks?.token;
+  if (
+    cfg.hooks?.enabled === true &&
+    isPersistedPlaintextSecret(cfg, "hooks.token", hooksTokenValue)
+  ) {
     findings.push({
       checkId: "config.secrets.hooks_token_in_config",
       severity: "info",

--- a/src/security/audit-secrets-in-config.test.ts
+++ b/src/security/audit-secrets-in-config.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { runSecurityAuditCore } from "./audit.js";
+
+describe("security audit secrets-in-config", () => {
+  it("does not warn when source config externalizes the gateway password but resolved config materialized it", async () => {
+    const sourceConfig = {
+      gateway: {
+        auth: {
+          password: { source: "file", provider: "default", id: "/run/secrets/gateway-password" },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const resolvedConfig = {
+      gateway: {
+        auth: { password: "resolved-secret-value" },
+      },
+    } satisfies OpenClawConfig;
+
+    const report = await runSecurityAuditCore({
+      config: resolvedConfig,
+      sourceConfig,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+      loadPluginSecurityCollectors: false,
+    });
+    expect(
+      report.findings.filter(
+        (finding) => finding.checkId === "config.secrets.gateway_password_in_config",
+      ),
+    ).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #111468

## What Problem This Solves

Fixes an issue where operators externalizing `gateway.auth.password` or `hooks.token` via file/exec SecretRefs would still see `config.secrets.gateway_password_in_config` (or hooks token) warnings during `openclaw security audit`.

## Why This Change Was Made

The audit already classifies secrets against `sourceConfig`, but only treated unresolved `${ENV}` templates as externalized. Structured SecretRef objects were still read as persisted plaintext after resolution. This adds explicit SecretRef detection via `resolveConfigSecretRef` so file/exec/env/store references are not flagged.

## User Impact

Operators using SecretRefs for gateway auth or hooks tokens get accurate audit results without false-positive "stored in config" warnings.

## Evidence

```
✓ collectSecretsInConfigFindings > does not flag gateway passwords externalized via file or exec SecretRefs
✓ collectSecretsInConfigFindings > flags plaintext hooks tokens but not SecretRef-backed tokens
✓ security audit secrets-in-config > does not warn when source config externalizes the gateway password but resolved config materialized it
```

Ran: `node scripts/run-vitest.mjs src/security/audit-extra.sync.test.ts src/security/audit-secrets-in-config.test.ts`