### PR TITLE
fix(memory-core): recover orphaned workspace locks after PID reuse

### DIFF
--- a/extensions/memory-core/src/memory-workspace-lock.test.ts
+++ b/extensions/memory-core/src/memory-workspace-lock.test.ts
@@ -1,20 +1,15 @@
-// Workspace lock tests cover orphaned-row recovery for the sqlite-backed lock.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
-import { createPluginStateKeyedStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { getFileLockProcessStartTime } from "openclaw/plugin-sdk/process-runtime";
 import { afterAll, beforeAll, afterEach, describe, expect, it, vi } from "vitest";
-import { configureMemoryCoreDreamingState, memoryCoreWorkspaceStateKey } from "./dreaming-state.js";
 import { withMemoryWorkspaceLock } from "./memory-workspace-lock.js";
+import { auditShortTermPromotionArtifacts } from "./short-term-promotion-artifacts.js";
 import {
   configureMemoryCoreDreamingStateForTests,
   resetMemoryCoreDreamingStateForTests,
   shortTermTestState as testing,
 } from "./test-helpers.js";
-
-// Mirrors the lock module's unexported SHORT_TERM_LOCK_TTL_MS.
-const LOCK_TTL_MS = 10 * 60_000;
 
 describe("memory workspace lock orphan recovery", () => {
   let fixtureRoot = "";
@@ -26,14 +21,14 @@ describe("memory workspace lock orphan recovery", () => {
   });
 
   afterAll(async () => {
-    if (!fixtureRoot) {
-      return;
+    if (fixtureRoot) {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
     }
-    await fs.rm(fixtureRoot, { recursive: true, force: true });
     resetMemoryCoreDreamingStateForTests();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -43,47 +38,75 @@ describe("memory workspace lock orphan recovery", () => {
     return workspaceDir;
   }
 
-  it("steals an orphaned lock whose recycled owner pid still answers the liveness probe", async () => {
+  it("reclaims a stale legacy lock after its process id is reused", async () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now);
     const workspaceDir = await makeWorkspace();
-    // The container-restart shape from #134999: the owner pid is alive in the
-    // new pid namespace (here: this very process), so only the lock TTL's age
-    // bound can unwedge the row.
-    const lockTtlMs = LOCK_TTL_MS;
     await testing.writeShortTermLock(workspaceDir, {
-      owner: `${process.pid}:${Date.now() - lockTtlMs - 5_000}`,
-      acquiredAt: Date.now() - lockTtlMs - 5_000,
+      owner: `${process.pid}:${now - 120_000}`,
+      acquiredAt: now - 120_000,
     });
 
-    await expect(withMemoryWorkspaceLock(workspaceDir, async () => "recovered")).resolves.toBe(
-      "recovered",
+    const result = withMemoryWorkspaceLock(workspaceDir, async () => "recovered").then(
+      (value) => ({ status: "resolved" as const, value }),
+      (error: unknown) => ({ status: "rejected" as const, error: String(error) }),
     );
+    await vi.advanceTimersByTimeAsync(10_040);
+
+    expect(await result).toEqual({ status: "resolved", value: "recovered" });
   });
 
-  it("registers the workspace lock with a store TTL so orphaned rows self-expire", async () => {
-    const workspaceDir = await makeWorkspace();
-    const registered: Array<{ key: string; ttlMs?: number }> = [];
-    configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) => {
-      const store = createPluginStateKeyedStoreForTests<T>("memory-core", {
-        ...options,
-        env: { ...process.env },
-      });
-      return {
-        ...store,
-        registerIfAbsent: (key: string, value: T, opts?: { ttlMs?: number }) => {
-          registered.push({ key, ttlMs: opts?.ttlMs });
-          return store.registerIfAbsent(key, value, opts);
-        },
-      };
-    });
-    try {
-      await withMemoryWorkspaceLock(workspaceDir, async () => undefined);
-    } finally {
-      await configureMemoryCoreDreamingStateForTests();
+  it("reclaims a stale lock when a live process id has a different start identity", async () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const ownerStartTime = getFileLockProcessStartTime(process.ppid);
+    expect(ownerStartTime).not.toBeNull();
+    if (ownerStartTime === null) {
+      throw new Error("Expected the test runner process start identity");
     }
+    const workspaceDir = await makeWorkspace();
+    await testing.writeShortTermLock(workspaceDir, {
+      owner: `${process.ppid}:${now - 120_000}`,
+      ownerStartTime: ownerStartTime + 1,
+      acquiredAt: now - 120_000,
+    });
 
-    const lockKey = memoryCoreWorkspaceStateKey(workspaceDir);
-    expect(registered.filter((entry) => entry.key === lockKey)).toEqual([
-      { key: lockKey, ttlMs: LOCK_TTL_MS },
-    ]);
+    const result = withMemoryWorkspaceLock(workspaceDir, async () => "recovered").then(
+      (value) => ({ status: "resolved" as const, value }),
+      (error: unknown) => ({ status: "rejected" as const, error: String(error) }),
+    );
+    await vi.advanceTimersByTimeAsync(10_040);
+
+    expect(await result).toEqual({ status: "resolved", value: "recovered" });
+  });
+
+  it("keeps a stale-looking lock while its owner task is active", async () => {
+    const workspaceDir = await makeWorkspace();
+    let enteredResolve: (() => void) | undefined;
+    let releaseResolve: (() => void) | undefined;
+    const entered = new Promise<void>((resolve) => {
+      enteredResolve = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      releaseResolve = resolve;
+    });
+    const owner = withMemoryWorkspaceLock(workspaceDir, async () => {
+      enteredResolve?.();
+      await release;
+    });
+    await entered;
+
+    const now = Date.now();
+    vi.spyOn(Date, "now").mockReturnValue(now + 120_000);
+    try {
+      const audit = await auditShortTermPromotionArtifacts({ workspaceDir });
+      expect(audit.issues.map((issue) => issue.code)).not.toContain("recall-lock-stale");
+    } finally {
+      vi.restoreAllMocks();
+      releaseResolve?.();
+      await owner;
+    }
   });
 });

--- a/extensions/memory-core/src/memory-workspace-lock.test.ts
+++ b/extensions/memory-core/src/memory-workspace-lock.test.ts
@@ -1,0 +1,89 @@
+// Workspace lock tests cover orphaned-row recovery for the sqlite-backed lock.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { createPluginStateKeyedStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterAll, beforeAll, afterEach, describe, expect, it, vi } from "vitest";
+import { configureMemoryCoreDreamingState, memoryCoreWorkspaceStateKey } from "./dreaming-state.js";
+import { SHORT_TERM_LOCK_TTL_MS, withMemoryWorkspaceLock } from "./memory-workspace-lock.js";
+import {
+  configureMemoryCoreDreamingStateForTests,
+  resetMemoryCoreDreamingStateForTests,
+  shortTermTestState as testing,
+} from "./test-helpers.js";
+
+describe("memory workspace lock orphan recovery", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+
+  beforeAll(async () => {
+    await configureMemoryCoreDreamingStateForTests();
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-lock-"));
+  });
+
+  afterAll(async () => {
+    if (!fixtureRoot) {
+      return;
+    }
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+    resetMemoryCoreDreamingStateForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function makeWorkspace(): Promise<string> {
+    const workspaceDir = path.join(fixtureRoot, `case-${caseId++}`);
+    await fs.mkdir(path.join(workspaceDir, "memory", ".dreams"), { recursive: true });
+    return workspaceDir;
+  }
+
+  it("steals an orphaned lock whose recycled owner pid still answers the liveness probe", async () => {
+    const workspaceDir = await makeWorkspace();
+    // The container-restart shape from #134999: the owner pid is alive in the
+    // new pid namespace (here: this very process), so only the lock TTL's age
+    // bound can unwedge the row. The fallback keeps this test behavioral when
+    // the source is reverted for red-green runs.
+    const lockTtlMs = Number.isFinite(SHORT_TERM_LOCK_TTL_MS)
+      ? SHORT_TERM_LOCK_TTL_MS
+      : 10 * 60_000;
+    await testing.writeShortTermLock(workspaceDir, {
+      owner: `${process.pid}:${Date.now() - lockTtlMs - 5_000}`,
+      acquiredAt: Date.now() - lockTtlMs - 5_000,
+    });
+
+    await expect(withMemoryWorkspaceLock(workspaceDir, async () => "recovered")).resolves.toBe(
+      "recovered",
+    );
+  });
+
+  it("registers the workspace lock with a store TTL so orphaned rows self-expire", async () => {
+    const workspaceDir = await makeWorkspace();
+    const registered: Array<{ key: string; ttlMs?: number }> = [];
+    configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) => {
+      const store = createPluginStateKeyedStoreForTests<T>("memory-core", {
+        ...options,
+        env: { ...process.env },
+      });
+      return {
+        ...store,
+        registerIfAbsent: (key: string, value: T, opts?: { ttlMs?: number }) => {
+          registered.push({ key, ttlMs: opts?.ttlMs });
+          return store.registerIfAbsent(key, value, opts);
+        },
+      };
+    });
+    try {
+      await withMemoryWorkspaceLock(workspaceDir, async () => undefined);
+    } finally {
+      await configureMemoryCoreDreamingStateForTests();
+    }
+
+    const lockKey = memoryCoreWorkspaceStateKey(workspaceDir);
+    expect(registered.filter((entry) => entry.key === lockKey)).toEqual([
+      { key: lockKey, ttlMs: SHORT_TERM_LOCK_TTL_MS },
+    ]);
+  });
+});

--- a/extensions/memory-core/src/memory-workspace-lock.test.ts
+++ b/extensions/memory-core/src/memory-workspace-lock.test.ts
@@ -6,12 +6,15 @@ import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-run
 import { createPluginStateKeyedStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterAll, beforeAll, afterEach, describe, expect, it, vi } from "vitest";
 import { configureMemoryCoreDreamingState, memoryCoreWorkspaceStateKey } from "./dreaming-state.js";
-import { SHORT_TERM_LOCK_TTL_MS, withMemoryWorkspaceLock } from "./memory-workspace-lock.js";
+import { withMemoryWorkspaceLock } from "./memory-workspace-lock.js";
 import {
   configureMemoryCoreDreamingStateForTests,
   resetMemoryCoreDreamingStateForTests,
   shortTermTestState as testing,
 } from "./test-helpers.js";
+
+// Mirrors the lock module's unexported SHORT_TERM_LOCK_TTL_MS.
+const LOCK_TTL_MS = 10 * 60_000;
 
 describe("memory workspace lock orphan recovery", () => {
   let fixtureRoot = "";
@@ -44,11 +47,8 @@ describe("memory workspace lock orphan recovery", () => {
     const workspaceDir = await makeWorkspace();
     // The container-restart shape from #134999: the owner pid is alive in the
     // new pid namespace (here: this very process), so only the lock TTL's age
-    // bound can unwedge the row. The fallback keeps this test behavioral when
-    // the source is reverted for red-green runs.
-    const lockTtlMs = Number.isFinite(SHORT_TERM_LOCK_TTL_MS)
-      ? SHORT_TERM_LOCK_TTL_MS
-      : 10 * 60_000;
+    // bound can unwedge the row.
+    const lockTtlMs = LOCK_TTL_MS;
     await testing.writeShortTermLock(workspaceDir, {
       owner: `${process.pid}:${Date.now() - lockTtlMs - 5_000}`,
       acquiredAt: Date.now() - lockTtlMs - 5_000,
@@ -83,7 +83,7 @@ describe("memory workspace lock orphan recovery", () => {
 
     const lockKey = memoryCoreWorkspaceStateKey(workspaceDir);
     expect(registered.filter((entry) => entry.key === lockKey)).toEqual([
-      { key: lockKey, ttlMs: SHORT_TERM_LOCK_TTL_MS },
+      { key: lockKey, ttlMs: LOCK_TTL_MS },
     ]);
   });
 });

--- a/extensions/memory-core/src/memory-workspace-lock.ts
+++ b/extensions/memory-core/src/memory-workspace-lock.ts
@@ -1,8 +1,10 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import fsSync from "node:fs";
-import { extractErrorCode } from "openclaw/plugin-sdk/error-runtime";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  getFileLockProcessStartTime,
+  isPidDefinitelyDead,
+} from "openclaw/plugin-sdk/process-runtime";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import {
   SHORT_TERM_LOCK_MAX_ENTRIES,
@@ -15,16 +17,9 @@ import type { ShortTermLockEntry } from "./short-term-promotion-types.js";
 
 const MEMORY_WORKSPACE_LOCK_WAIT_TIMEOUT_MS = 10_000;
 const SHORT_TERM_LOCK_STALE_MS = 60_000;
-/**
- * Store-level backstop for orphaned lock rows: a lock is registered with this
- * TTL, and a row older than it is stealable even when its owner pid answers
- * the liveness probe. Container pid namespaces reset across restarts, so a
- * recycled pid (pid 1 in particular) can keep a dead holder's lock looking
- * alive forever without this age bound.
- */
-const SHORT_TERM_LOCK_TTL_MS = 10 * 60_000;
 const MEMORY_WORKSPACE_LOCK_RETRY_DELAY_MS = 40;
 const inProcessMemoryWorkspaceLocks = new KeyedAsyncQueue();
+const activeMemoryWorkspaceLockOwners = new Map<string, string>();
 
 type MemoryWorkspaceLease = { key: string; active: boolean };
 type MemoryWorkspaceLockScope = {
@@ -75,53 +70,36 @@ export function resolveLockPath(workspaceDir: string): string {
 
 function parseLockOwnerPid(raw: string): number | null {
   const match = raw.trim().match(/^(\d+):/);
-  if (!match) {
-    return null;
-  }
-  const pid = Number.parseInt(match[1] ?? "", 10);
-  if (!Number.isInteger(pid) || pid <= 0) {
-    return null;
-  }
-  return pid;
+  const pid = Number.parseInt(match?.[1] ?? "", 10);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
 }
 
-function isProcessLikelyAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-  } catch (err) {
-    if (extractErrorCode(err) === "ESRCH") {
-      return false;
-    }
-    // EPERM and unknown errors remain potentially alive unless procfs proves a zombie.
-  }
-  if (process.platform !== "linux") {
-    return true;
-  }
-  try {
-    const status = fsSync.readFileSync(`/proc/${pid}/status`, "utf8");
-    const state = status.match(/^State:\s+(\S)/m)?.[1];
-    return state !== "Z" && state !== "X";
-  } catch {
-    // An unreadable proc entry is not enough evidence to steal an active lock.
-    return true;
-  }
-}
-
-/**
- * Decides whether a held lock row may be stolen. Beyond the pid-liveness
- * rule, a row that has outlived the lock TTL is stealable unconditionally:
- * container restarts reset pid namespaces, so a recycled owner pid can answer
- * the liveness probe for a holder that died weeks ago.
- */
-export function isShortTermLockStealable(existing: ShortTermLockEntry, nowMs: number): boolean {
-  if (nowMs - existing.acquiredAt > SHORT_TERM_LOCK_TTL_MS) {
-    return true;
-  }
+export function isShortTermLockStealable(
+  lockKey: string,
+  existing: ShortTermLockEntry,
+  nowMs: number,
+): boolean {
   if (nowMs - existing.acquiredAt <= SHORT_TERM_LOCK_STALE_MS) {
     return false;
   }
   const ownerPid = parseLockOwnerPid(existing.owner);
-  return ownerPid === null || !isProcessLikelyAlive(ownerPid);
+  if (ownerPid === null) {
+    return true;
+  }
+  if (ownerPid === process.pid) {
+    // The current process can own this row only through the tracked local lease.
+    // A same-PID row without that lease survived a prior process or failed cleanup.
+    return activeMemoryWorkspaceLockOwners.get(lockKey) !== existing.owner;
+  }
+  if (isPidDefinitelyDead(ownerPid)) {
+    return true;
+  }
+  // Shipped rows lack start identity. Keep a live foreign PID authoritative.
+  if (existing.ownerStartTime === undefined) {
+    return false;
+  }
+  const currentStartTime = getFileLockProcessStartTime(ownerPid);
+  return currentStartTime !== null && currentStartTime !== existing.ownerStartTime;
 }
 
 export async function deleteShortTermLockEntryIfCurrent(
@@ -163,27 +141,28 @@ export async function withMemoryWorkspaceLock<T>(
     const startedAt = Date.now();
 
     while (true) {
+      const acquiredAt = Date.now();
+      const ownerStartTime = getFileLockProcessStartTime(process.pid);
       const lockEntry: ShortTermLockEntry = {
-        owner: `${process.pid}:${Date.now()}`,
-        acquiredAt: Date.now(),
+        owner: `${process.pid}:${acquiredAt}`,
+        acquiredAt,
+        ...(ownerStartTime === null ? {} : { ownerStartTime }),
       };
-      // The TTL is the durable backstop: an unclean exit leaves a row that
-      // self-expires instead of wedging every later sync behind a dead owner.
-      const acquired = await lockStore.registerIfAbsent(lockKey, lockEntry, {
-        ttlMs: SHORT_TERM_LOCK_TTL_MS,
-      });
+      const acquired = await lockStore.registerIfAbsent(lockKey, lockEntry);
       if (acquired) {
         const lease = { key: lockKey, active: true };
+        activeMemoryWorkspaceLockOwners.set(lockKey, lockEntry.owner);
         try {
           return await runWorkspaceLockScope(lease, task);
         } finally {
           lease.active = false;
+          activeMemoryWorkspaceLockOwners.delete(lockKey);
           await deleteShortTermLockEntryIfCurrent(lockStore, lockKey, lockEntry).catch(() => false);
         }
       }
 
       const existing = await lockStore.lookup(lockKey);
-      if (existing && isShortTermLockStealable(existing, Date.now())) {
+      if (existing && isShortTermLockStealable(lockKey, existing, Date.now())) {
         if (await deleteShortTermLockEntryIfCurrent(lockStore, lockKey, existing)) {
           continue;
         }

--- a/extensions/memory-core/src/memory-workspace-lock.ts
+++ b/extensions/memory-core/src/memory-workspace-lock.ts
@@ -14,7 +14,7 @@ import {
 import type { ShortTermLockEntry } from "./short-term-promotion-types.js";
 
 const MEMORY_WORKSPACE_LOCK_WAIT_TIMEOUT_MS = 10_000;
-export const SHORT_TERM_LOCK_STALE_MS = 60_000;
+const SHORT_TERM_LOCK_STALE_MS = 60_000;
 /**
  * Store-level backstop for orphaned lock rows: a lock is registered with this
  * TTL, and a row older than it is stealable even when its owner pid answers
@@ -22,7 +22,7 @@ export const SHORT_TERM_LOCK_STALE_MS = 60_000;
  * recycled pid (pid 1 in particular) can keep a dead holder's lock looking
  * alive forever without this age bound.
  */
-export const SHORT_TERM_LOCK_TTL_MS = 10 * 60_000;
+const SHORT_TERM_LOCK_TTL_MS = 10 * 60_000;
 const MEMORY_WORKSPACE_LOCK_RETRY_DELAY_MS = 40;
 const inProcessMemoryWorkspaceLocks = new KeyedAsyncQueue();
 
@@ -73,7 +73,7 @@ export function resolveLockPath(workspaceDir: string): string {
   return memoryCoreStateReference(SHORT_TERM_LOCK_NAMESPACE, workspaceDir);
 }
 
-export function parseLockOwnerPid(raw: string): number | null {
+function parseLockOwnerPid(raw: string): number | null {
   const match = raw.trim().match(/^(\d+):/);
   if (!match) {
     return null;
@@ -85,7 +85,7 @@ export function parseLockOwnerPid(raw: string): number | null {
   return pid;
 }
 
-export function isProcessLikelyAlive(pid: number): boolean {
+function isProcessLikelyAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
   } catch (err) {

--- a/extensions/memory-core/src/memory-workspace-lock.ts
+++ b/extensions/memory-core/src/memory-workspace-lock.ts
@@ -15,6 +15,14 @@ import type { ShortTermLockEntry } from "./short-term-promotion-types.js";
 
 const MEMORY_WORKSPACE_LOCK_WAIT_TIMEOUT_MS = 10_000;
 export const SHORT_TERM_LOCK_STALE_MS = 60_000;
+/**
+ * Store-level backstop for orphaned lock rows: a lock is registered with this
+ * TTL, and a row older than it is stealable even when its owner pid answers
+ * the liveness probe. Container pid namespaces reset across restarts, so a
+ * recycled pid (pid 1 in particular) can keep a dead holder's lock looking
+ * alive forever without this age bound.
+ */
+export const SHORT_TERM_LOCK_TTL_MS = 10 * 60_000;
 const MEMORY_WORKSPACE_LOCK_RETRY_DELAY_MS = 40;
 const inProcessMemoryWorkspaceLocks = new KeyedAsyncQueue();
 
@@ -99,6 +107,23 @@ export function isProcessLikelyAlive(pid: number): boolean {
   }
 }
 
+/**
+ * Decides whether a held lock row may be stolen. Beyond the pid-liveness
+ * rule, a row that has outlived the lock TTL is stealable unconditionally:
+ * container restarts reset pid namespaces, so a recycled owner pid can answer
+ * the liveness probe for a holder that died weeks ago.
+ */
+export function isShortTermLockStealable(existing: ShortTermLockEntry, nowMs: number): boolean {
+  if (nowMs - existing.acquiredAt > SHORT_TERM_LOCK_TTL_MS) {
+    return true;
+  }
+  if (nowMs - existing.acquiredAt <= SHORT_TERM_LOCK_STALE_MS) {
+    return false;
+  }
+  const ownerPid = parseLockOwnerPid(existing.owner);
+  return ownerPid === null || !isProcessLikelyAlive(ownerPid);
+}
+
 export async function deleteShortTermLockEntryIfCurrent(
   lockStore: PluginStateKeyedStore<ShortTermLockEntry>,
   lockKey: string,
@@ -142,7 +167,11 @@ export async function withMemoryWorkspaceLock<T>(
         owner: `${process.pid}:${Date.now()}`,
         acquiredAt: Date.now(),
       };
-      const acquired = await lockStore.registerIfAbsent(lockKey, lockEntry);
+      // The TTL is the durable backstop: an unclean exit leaves a row that
+      // self-expires instead of wedging every later sync behind a dead owner.
+      const acquired = await lockStore.registerIfAbsent(lockKey, lockEntry, {
+        ttlMs: SHORT_TERM_LOCK_TTL_MS,
+      });
       if (acquired) {
         const lease = { key: lockKey, active: true };
         try {
@@ -154,12 +183,9 @@ export async function withMemoryWorkspaceLock<T>(
       }
 
       const existing = await lockStore.lookup(lockKey);
-      if (existing && Date.now() - existing.acquiredAt > SHORT_TERM_LOCK_STALE_MS) {
-        const ownerPid = parseLockOwnerPid(existing.owner);
-        if (ownerPid === null || !isProcessLikelyAlive(ownerPid)) {
-          if (await deleteShortTermLockEntryIfCurrent(lockStore, lockKey, existing)) {
-            continue;
-          }
+      if (existing && isShortTermLockStealable(existing, Date.now())) {
+        if (await deleteShortTermLockEntryIfCurrent(lockStore, lockKey, existing)) {
+          continue;
         }
       }
 

--- a/extensions/memory-core/src/short-term-promotion-artifacts.ts
+++ b/extensions/memory-core/src/short-term-promotion-artifacts.ts
@@ -135,7 +135,7 @@ export async function auditShortTermPromotionArtifacts(params: {
   });
   const lockEntry = await lockStore.lookup(lockKey);
   if (lockEntry) {
-    if (isShortTermLockStealable(lockEntry, Date.now())) {
+    if (isShortTermLockStealable(lockKey, lockEntry, Date.now())) {
       issues.push({
         severity: "warn",
         code: "recall-lock-stale",
@@ -178,7 +178,7 @@ export async function repairShortTermPromotionArtifacts(params: {
     maxEntries: SHORT_TERM_LOCK_MAX_ENTRIES,
   });
   const lockEntry = await lockStore.lookup(lockKey);
-  if (lockEntry && isShortTermLockStealable(lockEntry, Date.now())) {
+  if (lockEntry && isShortTermLockStealable(lockKey, lockEntry, Date.now())) {
     removedStaleLock = await deleteShortTermLockEntryIfCurrent(lockStore, lockKey, lockEntry);
   }
 

--- a/extensions/memory-core/src/short-term-promotion-artifacts.ts
+++ b/extensions/memory-core/src/short-term-promotion-artifacts.ts
@@ -12,10 +12,8 @@ import {
   readMemoryCoreWorkspaceEntries,
 } from "./dreaming-state.js";
 import {
-  SHORT_TERM_LOCK_STALE_MS,
   deleteShortTermLockEntryIfCurrent,
-  isProcessLikelyAlive,
-  parseLockOwnerPid,
+  isShortTermLockStealable,
   resolveLockPath,
   withMemoryWorkspaceLock,
 } from "./memory-workspace-lock.js";
@@ -137,12 +135,7 @@ export async function auditShortTermPromotionArtifacts(params: {
   });
   const lockEntry = await lockStore.lookup(lockKey);
   if (lockEntry) {
-    const ageMs = Date.now() - lockEntry.acquiredAt;
-    const ownerPid = parseLockOwnerPid(lockEntry.owner);
-    if (
-      ageMs > SHORT_TERM_LOCK_STALE_MS &&
-      (ownerPid === null || !isProcessLikelyAlive(ownerPid))
-    ) {
+    if (isShortTermLockStealable(lockEntry, Date.now())) {
       issues.push({
         severity: "warn",
         code: "recall-lock-stale",
@@ -185,11 +178,8 @@ export async function repairShortTermPromotionArtifacts(params: {
     maxEntries: SHORT_TERM_LOCK_MAX_ENTRIES,
   });
   const lockEntry = await lockStore.lookup(lockKey);
-  if (lockEntry && Date.now() - lockEntry.acquiredAt > SHORT_TERM_LOCK_STALE_MS) {
-    const ownerPid = parseLockOwnerPid(lockEntry.owner);
-    if (ownerPid === null || !isProcessLikelyAlive(ownerPid)) {
-      removedStaleLock = await deleteShortTermLockEntryIfCurrent(lockStore, lockKey, lockEntry);
-    }
+  if (lockEntry && isShortTermLockStealable(lockEntry, Date.now())) {
+    removedStaleLock = await deleteShortTermLockEntryIfCurrent(lockStore, lockKey, lockEntry);
   }
 
   await withMemoryWorkspaceLock(workspaceDir, async () => {

--- a/extensions/memory-core/src/short-term-promotion-types.ts
+++ b/extensions/memory-core/src/short-term-promotion-types.ts
@@ -69,6 +69,7 @@ export type ShortTermStoreMeta = {
 export type ShortTermLockEntry = {
   owner: string;
   acquiredAt: number;
+  ownerStartTime?: number;
 };
 
 type PromotionComponents = {

--- a/extensions/memory-core/src/test-helpers.ts
+++ b/extensions/memory-core/src/test-helpers.ts
@@ -31,6 +31,7 @@ import {
   writeMemoryCoreWorkspaceEntry,
 } from "./dreaming-state.js";
 import { normalizeShortTermPhaseSignalStore } from "./short-term-promotion-store.js";
+import type { ShortTermLockEntry } from "./short-term-promotion-types.js";
 import { normalizeShortTermRecallStore } from "./short-term-promotion-utils.js";
 import type { ShortTermRecallEntry } from "./short-term-promotion.js";
 
@@ -52,11 +53,6 @@ export function resetMemoryCoreDreamingStateForTests(): void {
 }
 
 type ShortTermStoreMeta = { updatedAt: string };
-
-type ShortTermLockEntry = {
-  owner: string;
-  acquiredAt: number;
-};
 
 async function readShortTermStoreEntries<T>(params: {
   namespace: string;

--- a/src/plugin-sdk/process-runtime.ts
+++ b/src/plugin-sdk/process-runtime.ts
@@ -14,5 +14,9 @@ export { prepareOomScoreAdjustedSpawn } from "../process/linux-oom-score.js";
 export type { OomScoreAdjustedSpawn, OomWrapOptions } from "../process/linux-oom-score.js";
 export { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 export { killProcessTree } from "../process/kill-tree.js";
-export { isPidAlive } from "../shared/pid-alive.js";
+export {
+  getFileLockProcessStartTime,
+  isPidAlive,
+  isPidDefinitelyDead,
+} from "../shared/pid-alive.js";
 export { prepareSecretInputStdio, type SpawnStdioEntry } from "../process/spawn-secret-input.js";


### PR DESCRIPTION
## What Problem This Solves

Fixes #134999.

Memory Core stores its cross-process workspace lock in SQLite. A crash can leave that row behind. The old recovery check used only the recorded process ID. After a container restart reuses that process ID, every later memory sync treats the orphan as active and times out.

## Why This Change Was Made

The lock owner now records the operating-system process start identity with the existing process ID. Recovery uses one owner predicate across lock acquisition, status audit, and repair:

- a dead process is stale;
- a live process with a different start identity is stale;
- a legacy row that names this process but has no active in-process lease is stale;
- a tracked active holder remains authoritative for any duration.

This replaces the first version's fixed 10-minute expiry. That expiry could release a legitimate long-running memory operation and admit a second writer.

The change keeps the stored `owner` value compatible with existing rows. It adds no database schema, configuration, or protocol change.

The supported topology does not permit concurrent containers to share one mutable state directory. The [Gateway lock contract](https://docs.openclaw.ai/gateway/gateway-lock) requires each Gateway instance to use a unique `OPENCLAW_STATE_DIR`, including multi-Gateway mode. Memory maintenance commands run on that Gateway host. Within this supported boundary, live peer processes have distinct PIDs, and process start identity distinguishes later PID reuse.

## User Impact

`openclaw memory index`, automatic sync, status repair, and other Memory Core workspace writers recover from crash residue after process-ID reuse. Active long-running operations keep exclusive ownership.

## Evidence

Baseline: `9e5be704596c5c4fd38c83253cdebef0498597fc`

Exact head: `e2879be24ba90ad41be64103a59f983085be492e`

- Real path red: an isolated `openclaw memory index --force --agent main` with a stale row owned by the command's reused live process ID failed with `Timed out waiting for memory workspace lock`.
- Regression red: the same-PID owner test failed on baseline for that exact timeout; the active-holder control passed.
- Exact-head green: Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/33497699519 built the committed head, seeded the same current-PID stale row, and indexed one file successfully.
- Anti-cheat: after changing the corpus to `amber kestrel 7391`, `memory search` returned the changed text from `memory/proof.md`.
- Cleanup: the workspace lock row count was zero after the successful command.
- Focused tests: 118 checks passed across the lock owner, Memory Core sibling flows, plugin-state store, process identity, and stale-lock policy.
- Production code: +50/-50, net zero. Tests and test support: +113/-5.

Continuous integration and the exact-head landing review remain required before merge.
