### PR TITLE
fix(plugins): registry freshness when packageBuild lacks bundledDist

### DIFF
--- a/src/plugins/plugin-registry-comparison.test.ts
+++ b/src/plugins/plugin-registry-comparison.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { InstalledPluginIndexRecord } from "./installed-plugin-index-types.js";
-import type { InstalledPluginIndex } from "./installed-plugin-index.js";
+import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
 import { resolvePluginRegistryContent } from "./plugin-registry-comparison.js";
+import { createInstalledPluginIndexSnapshot } from "./status.test-fixtures.js";
 
 function makePluginRecord(
   overrides: Partial<InstalledPluginIndexRecord> = {},
@@ -10,18 +11,18 @@ function makePluginRecord(
     pluginId: "demo",
     source: "/plugins/demo",
     manifestPath: "/plugins/demo/openclaw.plugin.json",
+    manifestHash: "manifest-hash",
+    rootDir: "/plugins/demo",
+    origin: "bundled",
     enabled: true,
+    startup: { sidecar: false, memory: false, agentHarnesses: [] },
+    compat: [],
     ...overrides,
   };
 }
 
 function makeIndex(plugins: InstalledPluginIndexRecord[]): InstalledPluginIndex {
-  return {
-    generatedAtMs: 1,
-    plugins,
-    installRecords: {},
-    diagnostics: [],
-  };
+  return createInstalledPluginIndexSnapshot(plugins) as InstalledPluginIndex;
 }
 
 describe("resolvePluginRegistryContent packageBuild normalization", () => {

--- a/src/plugins/plugin-registry-comparison.test.ts
+++ b/src/plugins/plugin-registry-comparison.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
-import type { InstalledPluginIndexRecord } from "./installed-plugin-index-types.js";
-import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
+import type {
+  InstalledPluginIndex,
+  InstalledPluginIndexRecord,
+} from "./installed-plugin-index-types.js";
 import { resolvePluginRegistryContent } from "./plugin-registry-comparison.js";
 import { createInstalledPluginIndexSnapshot } from "./status.test-fixtures.js";
 

--- a/src/plugins/plugin-registry-comparison.test.ts
+++ b/src/plugins/plugin-registry-comparison.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { InstalledPluginIndexRecord } from "./installed-plugin-index-types.js";
+import type { InstalledPluginIndex } from "./installed-plugin-index.js";
+import { resolvePluginRegistryContent } from "./plugin-registry-comparison.js";
+
+function makePluginRecord(
+  overrides: Partial<InstalledPluginIndexRecord> = {},
+): InstalledPluginIndexRecord {
+  return {
+    pluginId: "demo",
+    source: "/plugins/demo",
+    manifestPath: "/plugins/demo/openclaw.plugin.json",
+    enabled: true,
+    ...overrides,
+  };
+}
+
+function makeIndex(plugins: InstalledPluginIndexRecord[]): InstalledPluginIndex {
+  return {
+    generatedAtMs: 1,
+    plugins,
+    installRecords: {},
+    diagnostics: [],
+  };
+}
+
+describe("resolvePluginRegistryContent packageBuild normalization", () => {
+  it("treats omitted packageBuild the same as packageBuild without bundledDist", () => {
+    const omitted = resolvePluginRegistryContent(makeIndex([makePluginRecord()]), false) as {
+      plugins: unknown[];
+    };
+    const buildOnly = resolvePluginRegistryContent(
+      makeIndex([
+        makePluginRecord({
+          packageBuild: { openclawVersion: "2026.8.1" },
+        }),
+      ]),
+      false,
+    ) as { plugins: unknown[] };
+
+    expect(buildOnly).toEqual(omitted);
+  });
+
+  it("preserves bundledDist when present", () => {
+    const content = resolvePluginRegistryContent(
+      makeIndex([
+        makePluginRecord({
+          packageBuild: { bundledDist: false, openclawVersion: "2026.8.1" },
+        }),
+      ]),
+      false,
+    ) as { plugins: Array<{ packageBuild?: { bundledDist: boolean } }> };
+
+    expect(content.plugins[0]?.packageBuild).toEqual({ bundledDist: false });
+  });
+});

--- a/src/plugins/plugin-registry-comparison.ts
+++ b/src/plugins/plugin-registry-comparison.ts
@@ -49,12 +49,9 @@ function resolvePluginRegistryRecordContent(
   // build-only metadata that runtime selection does not consume.
   const stableRecord = Object.assign(
     record,
-    packageBuild === undefined
+    packageBuild?.bundledDist === undefined
       ? {}
-      : {
-          packageBuild:
-            packageBuild.bundledDist === undefined ? {} : { bundledDist: packageBuild.bundledDist },
-        },
+      : { packageBuild: { bundledDist: packageBuild.bundledDist } },
   );
   if (!packageJson || !comparePackageJsonPath) {
     return stableRecord;


### PR DESCRIPTION
Closes #134657

## What Problem This Solves

Fixes an issue where `openclaw plugins registry --json` reported `state=stale` with `source-changed` even though plugin sources were unchanged, when persisted records omitted `packageBuild` but derived records normalized to `packageBuild: {}`.

## Why This Change Was Made

`resolvePluginRegistryRecordContent` now omits `packageBuild` unless `bundledDist` is explicitly present, so both shapes compare equal during freshness checks.

## User Impact

Operators stop seeing false stale registry warnings on standard built images.

## Evidence

New `plugin-registry-comparison.test.ts` covers omitted vs build-only metadata and preserved `bundledDist` values.