### PR TITLE
fix(agents): Anthropic provider_refusal is terminal (no empty-error retry)

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.error-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.error-recovery.test.ts
@@ -99,6 +99,33 @@ describe("incomplete-turn error recovery", () => {
     ).toBe(true);
   });
 
+  it("does not retry errored turns with structured provider refusals", () => {
+    const assistant = makeLastAssistant({
+      stopReason: "error",
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      errorMessage: "Anthropic refusal (category: cyber): This request is not allowed.",
+      diagnostics: [
+        {
+          type: "provider_refusal",
+          timestamp: Date.now(),
+          details: {
+            provider: "anthropic",
+            category: "cyber",
+            explanation: "This request is not allowed.",
+          },
+        },
+      ],
+      usage: { input: 3, output: 0, totalTokens: 3 },
+    });
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({ assistantTexts: [], lastAssistant: assistant }),
+        assistant,
+      }),
+    ).toBe(false);
+  });
+
   it("does not retry an ambiguous post-dispatch provider outcome", () => {
     const assistant = makeLastAssistant({
       stopReason: "error",

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
@@ -73,6 +73,9 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
   if (!assistant || assistant.stopReason !== "error" || isReplayUnsafeAssistantError(assistant)) {
     return false;
   }
+  if (assistant.diagnostics?.some((diagnostic) => diagnostic.type === "provider_refusal")) {
+    return false;
+  }
 
   const content = (assistant as { content?: unknown }).content;
   if (!Array.isArray(content)) {


### PR DESCRIPTION
Closes #134968

## What Problem This Solves

Fixes an issue where embedded Anthropic turns that returned a structured `provider_refusal` diagnostic with no assistant text were retried as transient empty errors, hiding the provider's terminal refusal from the user.

## Why This Change Was Made

`shouldRetrySilentErrorAssistantTurn` now treats `provider_refusal` diagnostics as non-retryable, matching the existing structured signal from `anthropic-refusal.ts`.

## User Impact

Anthropic refusals surface once instead of being silently resent through the empty-error retry path.

## Evidence

Added regression test in `run.incomplete-turn.error-recovery.test.ts`; existing incomplete-turn suite passes.