### PR TITLE
refactor(slack): share channel list page request

### DIFF
--- a/extensions/slack/src/cursor-pages.ts
+++ b/extensions/slack/src/cursor-pages.ts
@@ -1,3 +1,5 @@
+import type { WebClient } from "@slack/web-api";
+
 type SlackCursorResponse = {
   response_metadata?: { next_cursor?: string };
 };
@@ -5,6 +7,14 @@ type SlackCursorResponse = {
 // Slack documents an empty cursor as the only normal termination signal. This
 // backstop is deliberately far above any plausible channel or user directory.
 const SLACK_CURSOR_PAGE_LIMIT = 10_000;
+
+export const fetchSlackChannelListPage = (client: WebClient, cursor?: string) =>
+  client.conversations.list({
+    types: "public_channel,private_channel",
+    exclude_archived: false,
+    limit: 1000,
+    cursor,
+  });
 
 export async function collectSlackCursorPages<
   TItem,

--- a/extensions/slack/src/directory-live.ts
+++ b/extensions/slack/src/directory-live.ts
@@ -11,7 +11,7 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveSlackAccount } from "./accounts.js";
 import { createSlackLookupClient } from "./client.js";
-import { collectSlackCursorPages } from "./cursor-pages.js";
+import { collectSlackCursorPages, fetchSlackChannelListPage } from "./cursor-pages.js";
 
 type SlackUser = NonNullable<UsersListResponse["members"]>[number];
 type SlackChannel = NonNullable<ConversationsListResponse["channels"]>[number];
@@ -135,13 +135,7 @@ export async function listSlackDirectoryGroupsLive(
   }
   const query = normalizeQuery(params.query);
   const channels = await collectSlackCursorPages({
-    fetchPage: (cursor) =>
-      client.conversations.list({
-        types: "public_channel,private_channel",
-        exclude_archived: false,
-        limit: 1000,
-        cursor,
-      }),
+    fetchPage: (cursor) => fetchSlackChannelListPage(client, cursor),
     collectPageItems: (res) => (Array.isArray(res.channels) ? res.channels : []),
   });
 

--- a/extensions/slack/src/resolve-channels.test.ts
+++ b/extensions/slack/src/resolve-channels.test.ts
@@ -31,6 +31,12 @@ describe("resolveSlackChannelAllowlist", () => {
     expect(slackClientMocks.createSlackLookupClient).toHaveBeenCalledOnce();
     expect(slackClientMocks.createSlackLookupClient).toHaveBeenCalledWith(fixture);
     expect(slackClientMocks.conversationsList).toHaveBeenCalledOnce();
+    expect(slackClientMocks.conversationsList).toHaveBeenCalledWith({
+      types: "public_channel,private_channel",
+      exclude_archived: false,
+      limit: 1000,
+      cursor: undefined,
+    });
   });
 
   it("returns stable channel ids without listing a workspace", async () => {

--- a/extensions/slack/src/resolve-channels.ts
+++ b/extensions/slack/src/resolve-channels.ts
@@ -3,7 +3,7 @@ import type { WebClient } from "@slack/web-api";
 import { resolveDirectoryAllowlistEntries } from "openclaw/plugin-sdk/directory-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { createSlackLookupClient } from "./client.js";
-import { collectSlackCursorPages } from "./cursor-pages.js";
+import { collectSlackCursorPages, fetchSlackChannelListPage } from "./cursor-pages.js";
 import { formatSlackTarget, parseSlackTarget } from "./target-parsing.js";
 
 export type SlackChannelLookup = {
@@ -61,13 +61,7 @@ function parseSlackChannelMention(raw: string): { id?: string; name?: string } {
 
 async function listSlackChannels(client: WebClient): Promise<SlackChannelLookup[]> {
   return collectSlackCursorPages({
-    fetchPage: (cursor) =>
-      client.conversations.list({
-        types: "public_channel,private_channel",
-        exclude_archived: false,
-        limit: 1000,
-        cursor,
-      }),
+    fetchPage: (cursor) => fetchSlackChannelListPage(client, cursor),
     collectPageItems: (res) =>
       (res.channels ?? [])
         .map((channel) => {


### PR DESCRIPTION
## What Problem This Solves

Slack channel directory and allowlist resolution independently encoded the same `conversations.list` page request. That duplicated request policy could drift across the two lookup flows.

## Why This Change Was Made

Moves the channel-list page request into the private Slack cursor-page owner and routes both existing callers through it. The request invariant remains exact: public and private channels, archived channels included, 1,000-item pages, and the current cursor.

No public barrel, Plugin SDK, configuration, protocol, storage, security, documentation, or changelog surface changes.

## User Impact

No user-visible behavior changes. Slack directory listing and channel allowlist resolution now share one request contract.

## Evidence

- Root cause: the directory and resolver modules evolved separate copies of one Slack API request tuple.
- Architectural owner: private Slack cursor-page request/pagination code in `extensions/slack/src/cursor-pages.ts`.
- Production LOC: `+14/-16`, net `-2`.
- Tests: `+6`; the resolver boundary now asserts all four request options, including an undefined initial cursor.
- Focused tests: 3 files, 14 tests passed.
- Full Slack plugin suite: 145 files, 2,684 tests passed.
- Import-cycle, extension typecheck/test typecheck, formatting, lint, dead-export, plugin-boundary, database-first, media-download, runtime-sidecar, and related changed-file guards passed.
- Exact Sol/high autoreview: scoped clean, correctness 0.98.
- Exact-head CI run `33493103905`: 64 successful checks, 100 skipped, 1 neutral, no failures.
- Local `pnpm build` completed core/package/plugin phases but the UI phase could not resolve `mermaid` because this linked worktree uses a shared root install predating the current `ui/package.json`. Exact-head CI provided hydrated build proof.
- Landing blocker: ClawSweeper run `33493248799` failed with `codex_execution` before durable review publication. Native Testbox and merge gates were not started.
- Open PR and local worktree scans found no overlap on the four touched paths immediately before implementation.
- Live Slack/Crabbox proof is intentionally omitted because request bytes, client selection, cursor progression, and error behavior are unchanged.
