### PR TITLE
fix(memory): keep replies responsive during legacy index repair

### DIFF
--- a/docs/concepts/memory-builtin.md
+++ b/docs/concepts/memory-builtin.md
@@ -119,6 +119,10 @@ Full reindexes build a replacement in a temporary database and publish the
 memory tables atomically. Concurrent searches and status reads keep using the
 published index; a failed rebuild leaves that index intact.
 
+After an upgrade, automatic project and trigger recall may need to repair
+legacy provenance. That repair runs in the background. Replies continue while
+automatic recall stays empty until the affected sources have been reclassified.
+
 <Info>
 You can also index Markdown files outside the workspace with
 `memory.search.extraPaths`. See the

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -354,7 +354,7 @@ describe("memory index", () => {
     }
   });
 
-  it("reindexes legacy curated provenance before the first automatic candidate read", async () => {
+  it("withholds legacy curated candidates until background provenance repair succeeds", async () => {
     const projectKey = "github.com/openclaw/openclaw";
     await fs.writeFile(
       path.join(fixture.paths.workspace, "MEMORY.md"),
@@ -414,6 +414,13 @@ describe("memory index", () => {
         upgradedManager as unknown as { runSync: (params?: MemorySyncParams) => Promise<void> },
         "runSync",
       );
+      await expect(
+        Promise.all([
+          upgradedManager.listCuratedProjectCandidates({ activeProjectKeys: [projectKey] }),
+          upgradedManager.listTriggerCandidates({ activeProjectKeys: [projectKey] }),
+        ]),
+      ).resolves.toEqual([[], []]);
+      await upgradedManager.sync({ reason: "test-repair-complete" });
       const [projectCandidates, triggerCandidates] = await Promise.all([
         upgradedManager.listCuratedProjectCandidates({ activeProjectKeys: [projectKey] }),
         upgradedManager.listTriggerCandidates({ activeProjectKeys: [projectKey] }),

--- a/extensions/memory-core/src/memory/manager-candidate-repair.test.ts
+++ b/extensions/memory-core/src/memory/manager-candidate-repair.test.ts
@@ -170,7 +170,9 @@ describe("automatic candidates during provenance repair", () => {
       initialization.resolve();
       await retryStarted.promise;
       // Give teardown a turn to finish while the admitted retry remains gated.
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(closeSettled).toBe(false);
       retry.resolve();
       await closing;

--- a/extensions/memory-core/src/memory/manager-candidate-repair.test.ts
+++ b/extensions/memory-core/src/memory/manager-candidate-repair.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { MemorySyncParams } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { describe, expect, it, vi } from "vitest";
 import { createManagerIndexFixture } from "./manager-index.test-support.js";
 import type { MemoryIndexMeta } from "./manager-reindex-state.js";
@@ -112,4 +113,89 @@ describe("automatic candidates during provenance repair", () => {
       );
     },
   );
+
+  it("drains admitted candidate repair retries before closing the database", async () => {
+    const projectKey = "github.com/example/project";
+    await fs.writeFile(
+      path.join(fixture.paths.workspace, "MEMORY.md"),
+      `- Preserve the release preference. <!-- trigger: release local --> <!-- project: ${projectKey} -->\n`,
+    );
+    const ftsConfig = fixture.createConfig({ provider: "none", vectorEnabled: false });
+    const initial = await fixture.getFreshManager(ftsConfig, "cli");
+    await initial.sync({ reason: "cli", force: true });
+    // The existing migration will invalidate these sources on the next open.
+    const initialDb = Reflect.get(initial, "db") as DatabaseSync;
+    initialDb.exec("DELETE FROM memory_index_chunk_provenance");
+    await initial.close();
+
+    const initialization = createDeferred<void>();
+    const retryStarted = createDeferred<void>();
+    const retry = createDeferred<void>();
+    fixture.provider.providerInitGate = initialization.promise;
+    fixture.provider.providerCreationFailure = "local";
+    const upgraded = await fixture.getFreshManager(
+      fixture.createConfig({ provider: "local", vectorEnabled: false }),
+      "cli",
+    );
+    const owner = upgraded as unknown as {
+      runSync: (params?: MemorySyncParams) => Promise<void>;
+    };
+    const runSync = owner.runSync.bind(upgraded);
+    let pendingRetry: Promise<void> | undefined;
+    const retryGate = vi.spyOn(owner, "runSync").mockImplementation((params) => {
+      retryStarted.resolve();
+      pendingRetry = retry.promise.then(() => runSync(params));
+      return pendingRetry;
+    });
+    // This is the same public sync admission used by detached startup catch-up.
+    // Attach rejection handling immediately; its failed initialization is expected.
+    const startup = upgraded.sync({ reason: "session-startup-catchup" });
+    const startupOutcome = startup.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    let closing: Promise<void> | undefined;
+    let closeSettled = false;
+    try {
+      await vi.waitFor(() => expect(fixture.provider.providerCalls.at(-1)?.provider).toBe("local"));
+      await expect(
+        upgraded.listCuratedProjectCandidates({ activeProjectKeys: [projectKey] }),
+      ).resolves.toEqual([]);
+      closing = upgraded.close().then(() => {
+        closeSettled = true;
+      });
+      // Let close enter its drain before the already-running sync fails. This
+      // reproduces the original execution order without a timing-based sleep.
+      await Promise.resolve();
+      initialization.resolve();
+      await retryStarted.promise;
+      // Give teardown a turn to finish while the admitted retry remains gated.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(closeSettled).toBe(false);
+      retry.resolve();
+      await closing;
+      expect(await startupOutcome).toBeInstanceOf(Error);
+
+      // Observable persistence proof: close did not merely cancel or abandon
+      // the retry; its classified candidates survive a fresh manager open.
+      const reopened = await fixture.getFreshManager(ftsConfig, "cli");
+      expect(
+        await reopened.listCuratedProjectCandidates({ activeProjectKeys: [projectKey] }),
+      ).toEqual([
+        expect.objectContaining({
+          projectKey,
+          triggers: "release local",
+          provenance: expect.objectContaining({ originClass: "agent" }),
+        }),
+      ]);
+    } finally {
+      initialization.resolve();
+      retry.resolve();
+      await startupOutcome;
+      await pendingRetry?.catch(() => undefined);
+      await closing;
+      await upgraded.close();
+      retryGate.mockRestore();
+    }
+  });
 });

--- a/extensions/memory-core/src/memory/manager-candidate-repair.test.ts
+++ b/extensions/memory-core/src/memory/manager-candidate-repair.test.ts
@@ -1,0 +1,115 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { describe, expect, it, vi } from "vitest";
+import { createManagerIndexFixture } from "./manager-index.test-support.js";
+import type { MemoryIndexMeta } from "./manager-reindex-state.js";
+
+const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
+
+describe("automatic candidates during provenance repair", () => {
+  const fixture = createManagerIndexFixture({
+    getMemorySearchManager,
+    closeAllMemorySearchManagers,
+  });
+
+  it.each([false, true])(
+    "returns promptly while a large rebuild is pending (startup catch-up: %s)",
+    async (startupCatchup) => {
+      const projectKey = "github.com/example/project";
+      await fs.writeFile(
+        path.join(fixture.paths.workspace, "MEMORY.md"),
+        `- Keep the release local. <!-- trigger: release local --> <!-- project: ${projectKey} -->\n`,
+      );
+      await Promise.all(
+        Array.from({ length: 256 }, (_, index) =>
+          fs.writeFile(
+            path.join(fixture.paths.memory, `entry-${index}.md`),
+            `# Entry ${index}\nSynthetic memory content ${index}.\n`,
+          ),
+        ),
+      );
+      const cfg = fixture.createConfig({
+        provider: "batch-wide-test",
+        batchEnabled: true,
+        vectorEnabled: false,
+        sources: startupCatchup ? ["memory", "sessions"] : ["memory"],
+        sessionMemory: startupCatchup,
+      });
+      if (startupCatchup) {
+        await fixture.seedSessionTranscript({
+          sessionId: "legacy-session",
+          messages: [{ role: "user", timestamp: 1, content: "Remember the release preference." }],
+        });
+      }
+      const initial = await fixture.getFreshManager(cfg, "cli");
+      await initial.sync({ reason: "cli", force: true });
+      const db = Reflect.get(initial, "db") as DatabaseSync;
+      // Older indexes have neither classified provenance nor a chunking version.
+      db.exec("DELETE FROM memory_index_chunk_provenance; DELETE FROM memory_embedding_cache");
+      const row = db
+        .prepare("SELECT value FROM memory_index_meta WHERE key = 'memory_index_meta_v1'")
+        .get() as { value: string };
+      const meta = JSON.parse(row.value) as MemoryIndexMeta;
+      delete meta.provenanceVersion;
+      delete meta.chunkingVersion;
+      db.prepare("UPDATE memory_index_meta SET value = ? WHERE key = 'memory_index_meta_v1'").run(
+        JSON.stringify(meta),
+      );
+      await initial.close();
+
+      const gate = createDeferred<void>();
+      fixture.provider.providerRuntimeBatchGate = gate.promise;
+      const upgraded = await fixture.getFreshManager(cfg);
+      const candidates: Promise<unknown>[] = [];
+      try {
+        expect(upgraded.status().custom?.indexIdentity).toMatchObject({
+          status: "mismatched",
+          reason: "index provenance classifier changed",
+        });
+        if (startupCatchup) {
+          await vi.waitFor(() => expect(fixture.provider.providerRuntimeActiveBatchCalls).toBe(1), {
+            timeout: 10_000,
+          });
+        }
+        let completed = 0;
+        for (const lookup of [
+          () => upgraded.listCuratedProjectCandidates({ activeProjectKeys: [projectKey] }),
+          () => upgraded.listTriggerCandidates({ activeProjectKeys: [projectKey] }),
+        ]) {
+          candidates.push(
+            lookup().then((results) => {
+              completed += 1;
+              return results;
+            }),
+          );
+        }
+        await vi.waitFor(() => expect(completed).toBe(2));
+        expect(await Promise.all(candidates)).toEqual([[], []]);
+        await vi.waitFor(() => expect(fixture.provider.providerRuntimeActiveBatchCalls).toBe(1), {
+          timeout: 10_000,
+        });
+        expect(upgraded.status().dirty).toBe(true);
+      } finally {
+        gate.resolve();
+        await Promise.allSettled(candidates);
+      }
+      await upgraded.sync({ reason: "test-repair-complete" });
+      expect(upgraded.status().dirty).toBe(false);
+      const expected = [
+        expect.objectContaining({
+          projectKey,
+          triggers: "release local",
+          provenance: expect.objectContaining({ originClass: "agent" }),
+        }),
+      ];
+      expect(
+        await upgraded.listCuratedProjectCandidates({ activeProjectKeys: [projectKey] }),
+      ).toEqual(expected);
+      expect(await upgraded.listTriggerCandidates({ activeProjectKeys: [projectKey] })).toEqual(
+        expected,
+      );
+    },
+  );
+});

--- a/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
+++ b/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
@@ -115,27 +115,22 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
   ): Promise<MemorySearchResult[]> {
     return await this.withManagerOperation(async () => {
       if (this.memorySourceProvenanceRepairPending) {
-        const repairPending = () =>
+        this.memorySourceProvenanceRepairPending =
           this.db
             .prepare(
               `SELECT 1 FROM memory_index_sources
                WHERE source = 'memory' AND hash = '' LIMIT 1`,
             )
             .get() !== undefined;
-        try {
-          // Provenance schema adoption invalidates legacy source hashes. Finish that
-          // owner-classified reindex before the first automatic candidate read.
-          if (repairPending()) {
-            await this.syncAdmitted(
-              { reason: "search" },
-              { allowEmbeddingBootstrapFallback: true },
-            );
-          }
-        } catch (err) {
-          log.warn(`memory sync failed (automatic candidates): ${formatErrorMessage(err)}`);
-        }
-        this.memorySourceProvenanceRepairPending = repairPending();
         if (this.memorySourceProvenanceRepairPending) {
+          // Automatic recall runs before the model. Let the manager own and drain
+          // repair without holding the reply; unclassified sources stay excluded.
+          void this.syncAdmitted(
+            { reason: "search" },
+            { allowEmbeddingBootstrapFallback: true },
+          ).catch((err: unknown) => {
+            log.warn(`memory sync failed (automatic candidates): ${formatErrorMessage(err)}`);
+          });
           return [];
         }
       }

--- a/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
+++ b/extensions/memory-core/src/memory/manager-keyword-retrieval.ts
@@ -123,11 +123,10 @@ export abstract class MemoryKeywordRetrieval extends MemoryProviderLifecycle {
             )
             .get() !== undefined;
         if (this.memorySourceProvenanceRepairPending) {
-          // Automatic recall runs before the model. Let the manager own and drain
-          // repair without holding the reply; unclassified sources stay excluded.
-          void this.syncAdmitted(
-            { reason: "search" },
-            { allowEmbeddingBootstrapFallback: true },
+          // Automatic recall runs before the model. Keep repair admitted for teardown
+          // without holding the reply; unclassified sources stay excluded.
+          void this.withManagerOperation(() =>
+            this.syncAdmitted({ reason: "search" }, { allowEmbeddingBootstrapFallback: true }),
           ).catch((err: unknown) => {
             log.warn(`memory sync failed (automatic candidates): ${formatErrorMessage(err)}`);
           });


### PR DESCRIPTION
Related: #134461

## What Problem This Solves

Fixes an issue where users sending ordinary Gateway-backed messages after an upgrade could wait for a full memory rebuild before the chat provider was called. Slow embeddings could turn that wait into a foreground command-lane timeout. Thanks @LifeViwer for the detailed report and A/B isolation.

## Why This Change Was Made

Automatic project and trigger recall share the memory manager's curated-candidate reader. That reader awaited legacy-provenance repair, including an already-running startup sync. Detach the read from repair while keeping the complete repair operation admitted under the manager's existing lifecycle, so retries and shutdown still drain correctly. Unclassified candidates remain excluded until repair succeeds.

The normal startup-catch-up path was already detached; the exception was the pre-model candidate read. No new scheduler, configuration, schema, dependency, or protocol change is needed. Explicit indexing and ordinary search semantics are unchanged.

## User Impact

Foreground replies remain available while a legitimate legacy-index rebuild is running. Automatic curated recall is temporarily empty until affected sources are classified, then becomes available on subsequent turns. Operators no longer need to disable memory solely to keep foreground replies working during this repair.

## Evidence

Final-source owner tests: **9 passed**, covering both startup-catch-up variants, repair publication, quarantine filtering, provider identity mismatch, and shutdown draining. Both foreground cases fail against the original awaited implementation (zero candidate reads complete while embeddings are held). The shutdown retry regression also fails against the recovered bare-detachment patch: close resolves while the admitted retry remains gated.

Caller/sibling tests: **28 passed** across project-memory bootstrap and active-memory trigger recall. Repository doctor-contract checks: **5 passed**. Local and committed-branch autoreview: scoped-clean at the configured P0 threshold, no accepted/actionable findings.

Final-source live proof passed through a real isolated Gateway and a synthetic loopback chat/embedding provider: **1,200 files / 1,212 seeded chunks**. The foreground turn was admitted with four embeddings held, reached the provider in **443 ms**, and returned `REINDEX_FOREGROUND_OK` in **600 ms**, before gate release. Reindex then published, its shadow was removed, and a fresh turn's provider request contained the restored **Project Memory** entry. Cleanup left zero owned processes and no errors.

Sanitized live transcript (elapsed from fixture readiness):

```text
56.590s  four embedding requests held
56.621s  foreground Gateway RPC accepted
57.064s  chat-provider request observed (+443ms, embeddings still held)
57.227s  successful final reply (+600ms, embeddings still held)
57.227s  embedding gate released
121.619s reindex published; shadow removed
122.485s restored Project Memory observed in fresh turn's provider payload
122.827s post-repair turn completed successfully
125.220s cleanup: ownedChildrenRemaining=0, cleanupIssues=[]
```

`pnpm build` passed. Source-byte identity and generated owner code were verified against `ea97c49762ca4a5789f6bc412b8a3e75c533df80`. The build started with the final uncommitted source, so its start-time label names the preceding commit; the tested source and generated memory runtime contain the committed lifecycle correction. A test-only lint correction is now in `d37acc412d47af5d8c3a0001c8385d6bdb214fee`; its production tree is identical to the live-tested source. The shutdown regression passed again. `node scripts/check-changed.mjs -- <four changed paths>` passed in full after that correction, including plugin production/test types, lint, provenance/storage guards, all unused-export scans, and zero runtime import cycles.

ClawSweeper rank-up move addressed: this trace covers prompt reply delivery, repair publication, and subsequent automatic-recall restoration. There is no persistent data-model change: the patch changes only scheduling at the existing reader, reusing the existing provenance migration, sync slot, and lifecycle admission.

Production LOC: **+8/-14 (net -6)**; test LOC: **+211/-1 (net +210)**; docs: **+4**. No generated, lockfile, configuration, schema, or protocol changes.

Source trace: `src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts` → `src/agents/project-memory-bootstrap.ts` → `extensions/memory-core/src/memory/manager-keyword-retrieval.ts`. The trigger-recall sibling uses the same candidate reader. The existing `withManagerOperation` admission/idle drain and `syncAdmitted` sync slot remain the sole lifecycle owners.

Provenance: raw-parent/patch inspection shows the synchronous candidate-repair await was introduced in 67c06ed54f66487f108c393857e74ed15422d8b4 (#127469) and remains in v2026.8.1 and inspected current main. Provenance mismatch alone does not force a full rebuild; the reproduction also seeds a legacy missing chunking version, which legitimately triggers one.

Live proof uses only synthetic data and synthetic loopback provider tokens, a separate temporary state directory, and a free port other than 18789. It holds embedding requests, admits a fresh foreground turn through Gateway RPC, checks the actual provider request and terminal reply, then releases embeddings and verifies publication, shadow cleanup, and owned-process shutdown. It does not use a real chat-provider account or Telegram.

NO-FOLLOW-UP: the lifecycle correction belongs in this same scheduling repair; no separate rent-paying refactor was identified.
