### PR TITLE
fix: refresh model catalogs after auth and config changes

### DIFF
--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -51,12 +51,14 @@ export function resolvePreparedModelRuntimeOwnerBySnapshot(
 function publishPreparedModelRuntimeOwnerSnapshot(
   owner: PreparedModelRuntimeOwner,
   snapshot: PreparedModelRuntimeSnapshot,
-): void {
+): PreparedModelRuntimeSnapshot {
+  const published = stampPreparedModelRuntimeSnapshotConfig(snapshot, owner.input.config);
   if (owner.snapshot) {
     ownersBySnapshot.delete(owner.snapshot);
   }
-  owner.snapshot = snapshot;
-  ownersBySnapshot.set(snapshot, owner);
+  owner.snapshot = published;
+  ownersBySnapshot.set(published, owner);
+  return published;
 }
 
 export type {
@@ -262,7 +264,7 @@ export function advancePreparedModelRuntimeOwnerConfig(
   if (owner.snapshot) {
     // Existing leases retain their immutable snapshot. New readers receive the same prepared
     // generation with only its planner-approved, model-neutral config stamp advanced.
-    owner.snapshot = stampPreparedModelRuntimeSnapshotConfig(owner.snapshot, config);
+    publishPreparedModelRuntimeOwnerSnapshot(owner, owner.snapshot);
   }
 }
 
@@ -608,11 +610,7 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
             `prepared model runtime snapshot missing after auth refresh for ${candidate.input.agentDir}`,
           );
         }
-        const snapshot = stampPreparedModelRuntimeSnapshotConfig(
-          result.snapshot,
-          candidate.owner.input.config,
-        );
-        publishPreparedModelRuntimeOwnerSnapshot(candidate.owner, snapshot);
+        const snapshot = publishPreparedModelRuntimeOwnerSnapshot(candidate.owner, result.snapshot);
         results.set(candidate.owner, { ...result, snapshot });
         candidate.owner.pluginGeneration = result.pluginGeneration;
         candidate.owner.needsRefresh = false;
@@ -682,8 +680,7 @@ export async function publishModelRuntimeSnapshot(
           `prepared model runtime publication was superseded for ${input.agentDir}`,
         );
       }
-      const snapshot = stampPreparedModelRuntimeSnapshotConfig(result.snapshot, owner.input.config);
-      publishPreparedModelRuntimeOwnerSnapshot(owner, snapshot);
+      const snapshot = publishPreparedModelRuntimeOwnerSnapshot(owner, result.snapshot);
       owner.pluginGeneration = result.pluginGeneration;
       owner.pendingPluginGeneration = undefined;
       owner.pending = undefined;

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -14,6 +14,7 @@ import {
 import { loadPreparedModelCatalogOwnerSnapshot } from "./prepared-model-catalog.js";
 import {
   acquireAgentRunPreparedModelRuntime,
+  advancePreparedModelRuntimeConfig,
   loadPublishedGatewayReplyDispatchRuntime,
   prepareModelRuntimeSnapshot,
   refreshStalePreparedModelRuntimeCatalog,
@@ -68,8 +69,8 @@ describe("prepared model runtime reload auth adoption", () => {
       profileSetChanged: true,
     });
 
-    const published = await prepareModelRuntimeSnapshot(input);
-    expect(published).toMatchObject({
+    const authPublished = await prepareModelRuntimeSnapshot(input);
+    expect(authPublished).toMatchObject({
       modelCatalog: { entries: [] },
     });
     expect(
@@ -78,9 +79,14 @@ describe("prepared model runtime reload auth adoption", () => {
     expect(mocks.buildPreparedModelCatalogSnapshot).not.toHaveBeenCalled();
     expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
 
+    const nextConfig = { logging: { level: "debug" as const } };
+    advancePreparedModelRuntimeConfig(nextConfig);
+    const readInput = { ...input, config: nextConfig };
+    const published = await prepareModelRuntimeSnapshot(readInput);
+
     let requestReadSettled = false;
     const requestRead = loadPreparedModelCatalogOwnerSnapshot({
-      ...input,
+      ...readInput,
       readOnly: true,
     }).then(() => {
       requestReadSettled = true;


### PR DESCRIPTION
Related: #130324. Follow-up to #134361; preserves the config-stamp behavior from #128608 and scoped refresh from #129257.

## What Problem This Solves

Fixes an issue where users opening the model list after a credential change and an unrelated config edit could keep seeing stale model inventory until the Gateway restarted.

## Why This Change Was Made

Config-only updates replaced the prepared snapshot without updating the lookup used for an explicit stale-catalog read. Stamping and registering a snapshot now happen together in the existing publication helper, shared by ordinary, batch, and config-only publication. Existing readers retain their immutable snapshot and auth bindings; no catalog rebuild is added to config-only updates.

Production LOC: **+8/-11 (net -3)**. Tests: **+9/-3 (net +6)**, extending an existing regression test. No new config, schema, protocol, dependency, or compatibility path.

## User Impact

Model-list reads can refresh stale inventory after unrelated settings changes without restarting the Gateway. Ordinary request paths still avoid eager catalog discovery.

## Evidence

The extended existing regression failed before the fix at the missing discovered catalog entries. After the fix, **65 tests across five files passed**, covering auth invalidation, config stamps, concurrent stale reads, retained auth bindings, scoped refresh, and owner publication. Formatting passed; independent Codex review found no accepted/actionable P0 issue.

A separate synthetic Linux Gateway test exercised the real public WebSocket sequence in one process: establish discovered inventory, remove one synthetic auth profile while retaining another, observe the static catalog, apply a logging-only config change, and issue exactly one ordinary `models.list` request. Before the fix, the model stayed static through the unchanged 30-second test deadline. With the exact PR production files, the ordinary request returned its expected prepared fallback at 754ms; one `chat.metadata.changed` event then permitted one read-only `preparedOnly` observation, which returned the discovered model name and 8192-token context window. The after case passed in 21.21 seconds and Gateway shutdown completed in 75ms. No post-logout forced refresh or restart was used.

The public-flow test ran against `41ff392b26f834045077f7bc3cfec4bd2cedce71` with its newer catalog worker. The two PR files matched the published head byte for byte; the before and after fixtures, native runner, limits, source guards, and hook configuration stayed fixed. Canonical build prerequisites completed. Temporary Gateway proof code is not added to the PR. This is synthetic Gateway/WebSocket proof, not an authenticated external-provider test or proof that the broader CPU incident is resolved.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33493511131) completed successfully at `f2f90bcfd1979f1c30bacf7c7b5df19a5f194d52`. The [ClawSweeper review](https://github.com/openclaw/openclaw/pull/135063#issuecomment-5492112253) has no actionable finding; its remaining exact-head CI step is satisfied. A broader local check was previously stopped under host contention after its early guards and is not counted as a complete pass.
