### PR TITLE
refactor(discord): share concrete select menu construction

### DIFF
--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -2,6 +2,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 // Discord tests cover runtime plugin behavior.
 import {
   ChannelType,
+  ComponentType,
   MessageFlags,
   PermissionFlagsBits,
   type RESTGetAPIGuildEmojisResult,
@@ -2270,7 +2271,22 @@ describe("handleDiscordMessagingAction", () => {
         {
           to: "channel:123",
           content: "fallback text",
-          components: JSON.stringify({ blocks: [{ type: "text", text: "Gateway proof" }] }),
+          components: JSON.stringify({
+            blocks: [
+              { type: "text", text: "Gateway proof" },
+              {
+                type: "actions",
+                select: {
+                  type: "string",
+                  options: [{ label: "One", value: "one" }],
+                },
+              },
+              { type: "actions", select: { type: "user" } },
+              { type: "actions", select: { type: "role" } },
+              { type: "actions", select: { type: "mentionable" } },
+              { type: "actions", select: { type: "channel" } },
+            ],
+          }),
         },
         enableAllActions,
       );
@@ -2279,14 +2295,21 @@ describe("handleDiscordMessagingAction", () => {
       expect(post).toBeDefined();
       const body = JSON.parse(post?.body ?? "{}") as Record<string, unknown>;
       expect(body.flags).toBe(MessageFlags.IsComponentsV2);
-      expect(body.components).toEqual([
-        {
-          type: 17,
-          components: [
-            { type: 10, content: "fallback text" },
-            { type: 10, content: "Gateway proof" },
-          ],
-        },
+      const container = (body.components as Array<{ components?: unknown[] }>)[0];
+      expect(container?.components?.slice(0, 2)).toEqual([
+        { type: ComponentType.TextDisplay, content: "fallback text" },
+        { type: ComponentType.TextDisplay, content: "Gateway proof" },
+      ]);
+      expect(
+        container?.components
+          ?.slice(2)
+          .map((row) => (row as { components?: Array<{ type?: number }> }).components?.[0]?.type),
+      ).toEqual([
+        ComponentType.StringSelect,
+        ComponentType.UserSelect,
+        ComponentType.RoleSelect,
+        ComponentType.MentionableSelect,
+        ComponentType.ChannelSelect,
       ]);
     } finally {
       await loopback.close();

--- a/extensions/discord/src/components.builders.ts
+++ b/extensions/discord/src/components.builders.ts
@@ -36,6 +36,51 @@ function createShortId(prefix: string) {
   return `${prefix}${crypto.randomBytes(6).toString("base64url")}`;
 }
 
+type DiscordSelectMenuByType = {
+  string: StringSelectMenu;
+  user: UserSelectMenu;
+  role: RoleSelectMenu;
+  mentionable: MentionableSelectMenu;
+  channel: ChannelSelectMenu;
+};
+type DiscordSelectMenu = DiscordSelectMenuByType[DiscordComponentSelectType];
+
+const selectMenuConstructors = {
+  string: class extends StringSelectMenu {
+    customId = "";
+    override options: NonNullable<DiscordComponentSelectSpec["options"]> = [];
+  },
+  user: class extends UserSelectMenu {
+    customId = "";
+  },
+  role: class extends RoleSelectMenu {
+    customId = "";
+  },
+  mentionable: class extends MentionableSelectMenu {
+    customId = "";
+  },
+  channel: class extends ChannelSelectMenu {
+    customId = "";
+  },
+} satisfies {
+  [Type in DiscordComponentSelectType]: new () => DiscordSelectMenuByType[Type];
+};
+
+export function createDiscordSelectMenu<Type extends DiscordComponentSelectType>(
+  type: Type,
+  customId: string,
+  options?: DiscordComponentSelectSpec["options"],
+): DiscordSelectMenuByType[Type] {
+  // SAFETY: the constructor map satisfies the same Type-to-select-class relationship.
+  const SelectMenu = selectMenuConstructors[type] as new () => DiscordSelectMenuByType[Type];
+  const select = new SelectMenu();
+  select.customId = customId;
+  if (select instanceof StringSelectMenu) {
+    select.options = options ?? [];
+  }
+  return select;
+}
+
 function buildTextDisplays(text?: string, texts?: string[]): TextDisplay[] {
   if (texts && texts.length > 0) {
     return texts.map((entry) => new TextDisplay(entry));
@@ -109,12 +154,7 @@ function createSelectComponent(params: {
   spec: DiscordComponentSelectSpec;
   componentId?: string;
 }): {
-  component:
-    | StringSelectMenu
-    | UserSelectMenu
-    | RoleSelectMenu
-    | MentionableSelectMenu
-    | ChannelSelectMenu;
+  component: DiscordSelectMenu;
   entry: DiscordComponentEntry;
 } {
   const type = normalizeLowercaseStringOrEmpty(
@@ -122,105 +162,42 @@ function createSelectComponent(params: {
   ) as DiscordComponentSelectType;
   const componentId = params.componentId ?? createShortId("sel_");
   const customId = buildDiscordComponentCustomIdImpl({ componentId });
-  const createEntry = (
-    selectType: DiscordComponentSelectType,
-    label: string,
-    options?: DiscordComponentEntry["options"],
-  ): DiscordComponentEntry => ({
-    id: componentId,
-    kind: "select",
-    label,
-    ...(params.spec.callbackData !== undefined ? { callbackData: params.spec.callbackData } : {}),
-    ...(params.spec.callbackDataKind !== undefined
-      ? { callbackDataKind: params.spec.callbackDataKind }
-      : {}),
-    selectType,
-    ...(options ? { options } : {}),
-    ...(params.spec.allowedUsers !== undefined ? { allowedUsers: params.spec.allowedUsers } : {}),
-  });
-
-  if (type === "string") {
-    const options = params.spec.options ?? [];
-    if (options.length === 0) {
-      throw new Error("String select menus require options");
-    }
-    class DynamicStringSelect extends StringSelectMenu {
-      customId = customId;
-      override options = options;
-      override minValues = params.spec.minValues;
-      override maxValues = params.spec.maxValues;
-      override placeholder = params.spec.placeholder;
-      override disabled = false;
-    }
-    return {
-      component: new DynamicStringSelect(),
-      entry: createEntry(
-        "string",
-        params.spec.placeholder ?? "select",
-        options.map((option) => ({ value: option.value, label: option.label })),
-      ),
-    };
+  const options = params.spec.options ?? [];
+  if (type === "string" && options.length === 0) {
+    throw new Error("String select menus require options");
   }
-  if (type === "user") {
-    class DynamicUserSelect extends UserSelectMenu {
-      customId = customId;
-      override minValues = params.spec.minValues;
-      override maxValues = params.spec.maxValues;
-      override placeholder = params.spec.placeholder;
-      override disabled = false;
-    }
-    return {
-      component: new DynamicUserSelect(),
-      entry: createEntry("user", params.spec.placeholder ?? "user select"),
-    };
-  }
-  if (type === "role") {
-    class DynamicRoleSelect extends RoleSelectMenu {
-      customId = customId;
-      override minValues = params.spec.minValues;
-      override maxValues = params.spec.maxValues;
-      override placeholder = params.spec.placeholder;
-      override disabled = false;
-    }
-    return {
-      component: new DynamicRoleSelect(),
-      entry: createEntry("role", params.spec.placeholder ?? "role select"),
-    };
-  }
-  if (type === "mentionable") {
-    class DynamicMentionableSelect extends MentionableSelectMenu {
-      customId = customId;
-      override minValues = params.spec.minValues;
-      override maxValues = params.spec.maxValues;
-      override placeholder = params.spec.placeholder;
-      override disabled = false;
-    }
-    return {
-      component: new DynamicMentionableSelect(),
-      entry: createEntry("mentionable", params.spec.placeholder ?? "mentionable select"),
-    };
-  }
-  class DynamicChannelSelect extends ChannelSelectMenu {
-    customId = customId;
-    override minValues = params.spec.minValues;
-    override maxValues = params.spec.maxValues;
-    override placeholder = params.spec.placeholder;
-    override disabled = false;
-  }
+  const select = createDiscordSelectMenu(type, customId, options);
+  select.minValues = params.spec.minValues;
+  select.maxValues = params.spec.maxValues;
+  select.placeholder = params.spec.placeholder;
+  select.disabled = false;
+  const labels: Record<DiscordComponentSelectType, string> = {
+    string: "select",
+    user: "user select",
+    role: "role select",
+    mentionable: "mentionable select",
+    channel: "channel select",
+  };
   return {
-    component: new DynamicChannelSelect(),
-    entry: createEntry("channel", params.spec.placeholder ?? "channel select"),
+    component: select,
+    entry: {
+      id: componentId,
+      kind: "select",
+      label: params.spec.placeholder ?? labels[type],
+      ...(params.spec.callbackData !== undefined ? { callbackData: params.spec.callbackData } : {}),
+      ...(params.spec.callbackDataKind !== undefined
+        ? { callbackDataKind: params.spec.callbackDataKind }
+        : {}),
+      selectType: type,
+      ...(type === "string"
+        ? { options: options.map((option) => ({ value: option.value, label: option.label })) }
+        : {}),
+      ...(params.spec.allowedUsers !== undefined ? { allowedUsers: params.spec.allowedUsers } : {}),
+    },
   };
 }
 
-function isSelectComponent(
-  component: unknown,
-): component is
-  | StringSelectMenu
-  | UserSelectMenu
-  | RoleSelectMenu
-  | MentionableSelectMenu
-  | ChannelSelectMenu {
+function isSelectComponent(component: unknown): component is DiscordSelectMenu {
   return (
     component instanceof StringSelectMenu ||
     component instanceof UserSelectMenu ||

--- a/extensions/discord/src/components.modal.ts
+++ b/extensions/discord/src/components.modal.ts
@@ -3,6 +3,7 @@ import {
   buildDiscordModalCustomId as buildDiscordModalCustomIdImpl,
   parseDiscordModalCustomIdForInteraction as parseDiscordModalCustomIdForInteractionImpl,
 } from "./component-custom-id.js";
+import { createDiscordSelectMenu } from "./components.builders.js";
 import { mapTextInputStyle } from "./components.parse.js";
 import type { DiscordModalEntry, DiscordModalFieldDefinition } from "./components.types.js";
 import {
@@ -35,37 +36,15 @@ function createModalFieldComponent(
     }
     return new DynamicTextInput();
   }
-  if (field.type === "select") {
-    const options = field.options ?? [];
-    class DynamicModalSelect extends StringSelectMenu {
-      customId = field.id;
-      override options = options;
-      override required = field.required;
-      override minValues = field.minValues;
-      override maxValues = field.maxValues;
-      override placeholder = field.placeholder;
-    }
-    return new DynamicModalSelect();
-  }
-  if (field.type === "role-select") {
-    class DynamicModalRoleSelect extends RoleSelectMenu {
-      customId = field.id;
-      override required = field.required;
-      override minValues = field.minValues;
-      override maxValues = field.maxValues;
-      override placeholder = field.placeholder;
-    }
-    return new DynamicModalRoleSelect();
-  }
-  if (field.type === "user-select") {
-    class DynamicModalUserSelect extends UserSelectMenu {
-      customId = field.id;
-      override required = field.required;
-      override minValues = field.minValues;
-      override maxValues = field.maxValues;
-      override placeholder = field.placeholder;
-    }
-    return new DynamicModalUserSelect();
+  if (field.type === "select" || field.type === "role-select" || field.type === "user-select") {
+    const type =
+      field.type === "select" ? "string" : field.type === "role-select" ? "role" : "user";
+    const select = createDiscordSelectMenu(type, field.id, field.options);
+    select.required = field.required;
+    select.minValues = field.minValues;
+    select.maxValues = field.maxValues;
+    select.placeholder = field.placeholder;
+    return select;
   }
   if (field.type === "checkbox") {
     const options = field.options ?? [];

--- a/extensions/discord/src/components.selects.test.ts
+++ b/extensions/discord/src/components.selects.test.ts
@@ -1,0 +1,329 @@
+// Discord tests cover select component construction and delivery parity.
+import { ComponentType, InteractionResponseType } from "discord-api-types/v10";
+import { describe, expect, it } from "vitest";
+import { buildDiscordComponentMessage, createDiscordFormModal } from "./components.js";
+import type { DiscordComponentBlock } from "./components.types.js";
+import {
+  ButtonInteraction,
+  ChannelSelectMenu,
+  Container,
+  MentionableSelectMenu,
+  RoleSelectMenu,
+  Row,
+  StringSelectMenu,
+  UserSelectMenu,
+  createInteraction,
+} from "./internal/discord.js";
+import {
+  createInternalComponentInteractionPayload,
+  createInternalTestClient,
+} from "./internal/test-builders.test-support.js";
+import { createDiscordLoopbackRest } from "./send.test-harness.js";
+
+const GENERATED_DISCORD_ID_PATTERN =
+  /(?<![A-Za-z0-9_-])(?:btn|fld|grp|mdl|sel)_[A-Za-z0-9_-]{8}(?![A-Za-z0-9_-])/gu;
+const SELECT_BASE_KEYS = [
+  "isV2",
+  "defer",
+  "ephemeral",
+  "customIdParser",
+  "disabled",
+  "type",
+  "customId",
+];
+
+function normalizeGeneratedDiscordIds(value: unknown): unknown {
+  const ids = new Map<string, string>();
+  const counters = new Map<string, number>();
+  return JSON.parse(
+    JSON.stringify(value).replace(GENERATED_DISCORD_ID_PATTERN, (id) => {
+      const existing = ids.get(id);
+      if (existing) {
+        return existing;
+      }
+      const prefix = id.slice(0, 3);
+      const normalized = `${prefix}_${(counters.get(prefix) ?? 0) + 1}`;
+      counters.set(prefix, (counters.get(prefix) ?? 0) + 1);
+      ids.set(id, normalized);
+      return normalized;
+    }),
+  ) as unknown;
+}
+
+function readFirstActionRow(result: ReturnType<typeof buildDiscordComponentMessage>) {
+  const container = result.components[0];
+  if (!(container instanceof Container)) {
+    throw new Error("Expected a Discord component container");
+  }
+  const row = container.components[0];
+  if (!(row instanceof Row)) {
+    throw new Error("Expected a Discord action row");
+  }
+  return row;
+}
+
+describe("discord select components", () => {
+  it.each([
+    ["string", ComponentType.StringSelect, StringSelectMenu, "select"],
+    ["user", ComponentType.UserSelect, UserSelectMenu, "user select"],
+    ["role", ComponentType.RoleSelect, RoleSelectMenu, "role select"],
+    ["mentionable", ComponentType.MentionableSelect, MentionableSelectMenu, "mentionable select"],
+    ["channel", ComponentType.ChannelSelect, ChannelSelectMenu, "channel select"],
+  ] as const)(
+    "preserves %s identity, own properties, payload, and metadata",
+    (type, componentType, constructor, defaultLabel) => {
+      const options = [
+        {
+          label: "Primary",
+          value: "primary",
+          description: "First choice",
+          emoji: { name: "1️⃣" },
+          default: true,
+        },
+      ];
+      const result = buildDiscordComponentMessage({
+        spec: {
+          reusable: false,
+          blocks: [
+            {
+              type: "actions",
+              select: {
+                type,
+                callbackData: "select:callback",
+                callbackDataKind: "callback",
+                minValues: 0,
+                maxValues: 2,
+                options,
+                allowedUsers: ["user-1"],
+              },
+            },
+          ],
+        },
+        sessionKey: "session-1",
+        agentId: "agent-1",
+        accountId: "default",
+      });
+      const select = readFirstActionRow(result).components[0];
+      if (!select) {
+        throw new Error("Expected a Discord select component");
+      }
+
+      expect(select).toBeInstanceOf(constructor);
+      expect(Object.keys(select)).toEqual([
+        ...SELECT_BASE_KEYS,
+        ...(type === "string" ? ["options"] : []),
+        "minValues",
+        "maxValues",
+        "placeholder",
+      ]);
+      expect(normalizeGeneratedDiscordIds(select.serialize())).toEqual({
+        type: componentType,
+        ...(type === "string" ? { options } : {}),
+        custom_id: "occomp:cid=sel_1",
+        min_values: 0,
+        max_values: 2,
+      });
+      expect(normalizeGeneratedDiscordIds(result.entries)).toEqual([
+        {
+          id: "sel_1",
+          kind: "select",
+          label: defaultLabel,
+          callbackData: "select:callback",
+          callbackDataKind: "callback",
+          selectType: type,
+          ...(type === "string" ? { options: [{ value: "primary", label: "Primary" }] } : {}),
+          allowedUsers: ["user-1"],
+          sessionKey: "session-1",
+          agentId: "agent-1",
+          accountId: "default",
+          reusable: false,
+          consumptionGroupId: "grp_1",
+          consumptionGroupEntryIds: ["sel_1"],
+        },
+      ]);
+    },
+  );
+
+  it("preserves modal identity, required values, own properties, and callback payload", async () => {
+    const result = buildDiscordComponentMessage({
+      spec: {
+        modal: {
+          title: "Select details",
+          fields: [
+            {
+              type: "select",
+              label: "Priority",
+              options: [{ label: "High", value: "high", default: true }],
+              minValues: 1,
+              maxValues: 1,
+              placeholder: "Pick priority",
+            },
+            {
+              type: "role-select",
+              label: "Roles",
+              required: false,
+              minValues: 0,
+              maxValues: 2,
+              placeholder: "Pick roles",
+            },
+            {
+              type: "user-select",
+              label: "Owner",
+              required: true,
+              minValues: 1,
+              maxValues: 1,
+              placeholder: "Pick owner",
+            },
+          ],
+        },
+      },
+    });
+    const modalEntry = result.modals[0];
+    if (!modalEntry) {
+      throw new Error("Expected a Discord modal entry");
+    }
+    const modal = createDiscordFormModal(modalEntry);
+    const fields = modal.components.map((label) => {
+      if (!("component" in label) || !label.component) {
+        throw new Error("Expected a Discord modal label component");
+      }
+      return label.component;
+    });
+
+    expect(fields[0]).toBeInstanceOf(StringSelectMenu);
+    expect(fields[1]).toBeInstanceOf(RoleSelectMenu);
+    expect(fields[2]).toBeInstanceOf(UserSelectMenu);
+    expect(fields.map((field) => Object.keys(field))).toEqual([
+      [...SELECT_BASE_KEYS, "options", "required", "minValues", "maxValues", "placeholder"],
+      [...SELECT_BASE_KEYS, "required", "minValues", "maxValues", "placeholder"],
+      [...SELECT_BASE_KEYS, "required", "minValues", "maxValues", "placeholder"],
+    ]);
+
+    const serialized = normalizeGeneratedDiscordIds(modal.serialize());
+    expect(serialized).toEqual({
+      title: "Select details",
+      custom_id: "ocmodal:mid=mdl_1",
+      components: [
+        {
+          type: ComponentType.Label,
+          label: "Priority",
+          component: {
+            type: ComponentType.StringSelect,
+            options: [{ label: "High", value: "high", default: true }],
+            custom_id: "fld_1",
+            min_values: 1,
+            max_values: 1,
+            placeholder: "Pick priority",
+          },
+        },
+        {
+          type: ComponentType.Label,
+          label: "Roles",
+          component: {
+            type: ComponentType.RoleSelect,
+            custom_id: "fld_2",
+            placeholder: "Pick roles",
+            min_values: 0,
+            max_values: 2,
+            required: false,
+          },
+        },
+        {
+          type: ComponentType.Label,
+          label: "Owner",
+          component: {
+            type: ComponentType.UserSelect,
+            custom_id: "fld_3",
+            placeholder: "Pick owner",
+            min_values: 1,
+            max_values: 1,
+            required: true,
+          },
+        },
+      ],
+    });
+
+    const loopback = await createDiscordLoopbackRest();
+    try {
+      const client = createInternalTestClient();
+      client.rest = loopback.rest;
+      const interaction = createInteraction(
+        client,
+        createInternalComponentInteractionPayload({
+          id: "interaction-1",
+          token: "interaction-token",
+        }),
+      );
+      if (!(interaction instanceof ButtonInteraction)) {
+        throw new Error("Expected a Discord button interaction");
+      }
+      await interaction.showModal(modal);
+
+      expect(loopback.requests).toHaveLength(1);
+      expect(loopback.requests[0]?.method).toBe("POST");
+      expect(loopback.requests[0]?.path).toBe(
+        "/v10/interactions/interaction-1/interaction-token/callback",
+      );
+      expect(normalizeGeneratedDiscordIds(JSON.parse(loopback.requests[0]?.body ?? "{}"))).toEqual({
+        type: InteractionResponseType.Modal,
+        data: serialized,
+      });
+    } finally {
+      await loopback.close();
+    }
+  });
+
+  it.each([
+    ["no preceding row", [], [1]],
+    [
+      "four preceding buttons",
+      [
+        {
+          type: "actions" as const,
+          buttons: Array.from({ length: 4 }, (_, index) => ({ label: `Button ${index + 1}` })),
+        },
+      ],
+      [5],
+    ],
+    [
+      "five preceding buttons",
+      [
+        {
+          type: "actions" as const,
+          buttons: Array.from({ length: 5 }, (_, index) => ({ label: `Button ${index + 1}` })),
+        },
+      ],
+      [5, 1],
+    ],
+    [
+      "preceding select",
+      [
+        {
+          type: "actions" as const,
+          select: {
+            type: "string" as const,
+            options: [{ label: "One", value: "one" }],
+          },
+        },
+      ],
+      [1, 1],
+    ],
+  ] satisfies Array<[string, DiscordComponentBlock[], number[]]>)(
+    "keeps the modal trigger row placement after %s",
+    (_label, blocks, expectedSizes) => {
+      const result = buildDiscordComponentMessage({
+        spec: {
+          blocks: [...blocks],
+          modal: { title: "Details", fields: [{ type: "text", label: "Name" }] },
+        },
+      });
+      const container = result.components[0];
+      if (!(container instanceof Container)) {
+        throw new Error("Expected a Discord component container");
+      }
+      const rows = container.components.filter((component) => component instanceof Row);
+      expect(rows.map((row) => row.components.length)).toEqual(expectedSizes);
+      expect(rows.at(-1)?.components.at(-1)?.type).toBe(ComponentType.Button);
+    },
+  );
+});

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -1,5 +1,5 @@
 // Discord tests cover send.components plugin behavior.
-import { ChannelType, MessageFlags } from "discord-api-types/v10";
+import { ChannelType, ComponentType, MessageFlags } from "discord-api-types/v10";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDiscordLoopbackRest, makeDiscordRest } from "./send.test-harness.js";
 
@@ -230,53 +230,54 @@ describe("sendDiscordComponentMessage", () => {
   });
 
   it("edits component messages and refreshes component registry entries", async () => {
-    const { rest, patchMock, getMock } = makeDiscordRest();
-    getMock.mockResolvedValueOnce({
-      type: ChannelType.GuildText,
-      id: "chan-1",
-    });
-    patchMock.mockResolvedValueOnce({ id: "msg1", channel_id: "chan-1" });
+    const loopback = await createDiscordLoopbackRest();
+    try {
+      await editDiscordComponentMessage(
+        "channel:chan-1",
+        "msg1",
+        {
+          text: "Updated picker",
+          blocks: [
+            {
+              type: "actions",
+              select: {
+                type: "string",
+                options: [{ label: "One", value: "one" }],
+              },
+            },
+          ],
+        },
+        {
+          cfg: DISCORD_TEST_CFG,
+          rest: loopback.rest,
+          token: "t",
+          sessionKey: "agent:main:discord:channel:chan-1",
+          agentId: "main",
+        },
+      );
 
-    await editDiscordComponentMessage(
-      "channel:chan-1",
-      "msg1",
-      {
-        text: "Updated picker",
-        blocks: [{ type: "actions", buttons: [{ label: "Tap" }] }],
-      },
-      {
-        cfg: DISCORD_TEST_CFG,
-        rest,
-        token: "t",
-        sessionKey: "agent:main:discord:channel:chan-1",
-        agentId: "main",
-      },
-    );
-
-    expect(patchMock).toHaveBeenCalledTimes(1);
-    const [patchUrl, patchRequest] = readMockCall(patchMock, 0) as [
-      string,
-      {
-        body?: {
-          flags?: unknown;
-          components?: unknown[];
-          nonce?: unknown;
-          enforce_nonce?: unknown;
-        };
-      },
-    ];
-    expect(patchUrl).toContain("/channels/chan-1/messages/msg1");
-    expect(patchRequest?.body?.flags).toBe(MessageFlags.IsComponentsV2);
-    expect(Array.isArray(patchRequest?.body?.components)).toBe(true);
-    expect(patchRequest?.body?.components).toHaveLength(1);
-    expect(patchRequest?.body).not.toHaveProperty("nonce");
-    expect(patchRequest?.body).not.toHaveProperty("enforce_nonce");
-    expect(registerMock).toHaveBeenCalledTimes(1);
-    const args = readRecordArg(registerMock, 0, 0);
-    expect(args.messageId).toBe("msg1");
-    expect((args.entries as Array<{ sessionKey?: string }>)[0]?.sessionKey).toBe(
-      "agent:main:discord:channel:chan-1",
-    );
+      const patch = loopback.requests.find((request) => request.method === "PATCH");
+      expect(patch?.path).toBe("/v10/channels/chan-1/messages/msg1");
+      const body = JSON.parse(patch?.body ?? "{}") as {
+        flags?: unknown;
+        components?: Array<{ components?: Array<{ components?: Array<{ type?: number }> }> }>;
+      };
+      expect(body.flags).toBe(MessageFlags.IsComponentsV2);
+      expect(body.components).toHaveLength(1);
+      expect(body.components?.[0]?.components?.[1]?.components?.[0]?.type).toBe(
+        ComponentType.StringSelect,
+      );
+      expect(body).not.toHaveProperty("nonce");
+      expect(body).not.toHaveProperty("enforce_nonce");
+      expect(registerMock).toHaveBeenCalledTimes(1);
+      const args = readRecordArg(registerMock, 0, 0);
+      expect(args.messageId).toBe("loopback-message");
+      expect((args.entries as Array<{ sessionKey?: string }>)[0]?.sessionKey).toBe(
+        "agent:main:discord:channel:chan-1",
+      );
+    } finally {
+      await loopback.close();
+    }
   });
 
   it("treats bare numeric component edit targets as channels", async () => {


### PR DESCRIPTION
## What Problem This Solves

Discord message selects and modal selects repeated concrete subclass construction and field assignment. They now use one private constructor map for the existing five select classes, with message and modal owners retaining their distinct metadata and field order.

## Why This Change Was Made

The map covers string, user, role, mentionable and channel selects. String options remain exclusive to the string class; modal required values retain omitted, false and true behavior. Message callback/registry entries, default labels, action-row placement, select limits and public parsing stay at their existing owners.

## User Impact

No intended behavior or visual change. Production decreases by 44 lines (+87/−131); tests add 353 lines (+409/−56). The new helper stays within the plugin and introduces no SDK export, configuration, dependency, protocol or persistence surface.

## Evidence

The characterization suite passes against the original construction before the refactor and against the final candidate: 231 tests each. It checks all five message classes and three modal classes, own-property order and optional fields, serialized component payloads, callback and registry metadata, and modal-trigger row placement. Generated component IDs are normalized by a bounded prefix pattern with consistent identity mapping.

Actual message action dispatch reaches the real component builder and REST client over local HTTP, covering a message POST containing all five select types. Additional loopback cases verify message-edit PATCH payloads and refreshed registry entries, plus the actual interaction modal callback POST. This uses synthetic local transport fixtures; no external Discord send or client screenshot is claimed. The payload and layout contracts remain unchanged.

All selected format, type, lint, dependency and architecture gates pass. The first Knip attempt reached its normal 600-second limit under host load; one fresh retry passed all three scans with zero entries, and the remaining selected checks passed without changed limits or skips. Fresh managed P2/high review and deslop are clean. Current-main source for the owners, parser and concrete component classes is unchanged from the tested base.


The latest 09:50 UTC ClawSweeper review has no code defect. Its before-merge and rank-up request to finish the exact-head build is satisfied by successful CI 33493597044. Maintainer review accepts the private constructor boundary.
