### PR TITLE
refactor(feishu): unify Drive comment preparation and paging

### DIFF
--- a/extensions/feishu/src/drive-comments-loopback.test.ts
+++ b/extensions/feishu/src/drive-comments-loopback.test.ts
@@ -1,0 +1,472 @@
+import { createServer } from "node:http";
+import * as Lark from "@larksuiteoapi/node-sdk";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterAll, afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { createCommentTypingReactionLifecycle } from "./comment-reaction.js";
+import { registerFeishuDriveTools } from "./drive.js";
+import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
+
+const config = {
+  channels: {
+    feishu: {
+      enabled: true,
+      appId: "loopback-test-app",
+      appSecret: "loopback-test-placeholder", // pragma: allowlist secret
+      tools: { drive: true },
+    },
+  },
+};
+
+type DeliveryContext = { channel?: string; to?: string; threadId?: string | number };
+type WireRequest = { method: string; url: string; body: string };
+type ApiReply = { body: unknown; status?: number; wait?: Promise<void>; received?: () => void };
+
+async function createDriveLoopback(replies: ApiReply[], deliveryContext?: DeliveryContext) {
+  const requests: WireRequest[] = [];
+  const logs: Array<{ level: string; message: string }> = [];
+  for (const level of ["info", "warn"] as const) {
+    vi.spyOn(console, level).mockImplementation((message) => {
+      logs.push({ level, message: String(message) });
+    });
+  }
+  const server = createServer((request, response) => {
+    void (async () => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      requests.push({
+        method: request.method ?? "",
+        url: request.url ?? "",
+        body: Buffer.concat(chunks).toString("utf8"),
+      });
+      const reply = replies[requests.length - 1];
+      if (!reply) {
+        response.writeHead(500).end("Unexpected request");
+        return;
+      }
+      reply.received?.();
+      await reply.wait;
+      response.writeHead(reply.status ?? 200, { "content-type": "application/json" });
+      response.end(JSON.stringify(reply.body));
+    })().catch((error: unknown) => {
+      response.writeHead(500).end(String(error));
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  onTestFinished(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Missing loopback server address");
+  }
+  const origin = `http://127.0.0.1:${address.port}`;
+  const client = new Lark.Client({
+    appId: config.channels.feishu.appId,
+    appSecret: config.channels.feishu.appSecret,
+    domain: origin,
+    disableTokenCache: true,
+    loggerLevel: Lark.LoggerLevel.error,
+  });
+  const sdkErrors = vi.spyOn(client.logger, "error").mockImplementation(() => {});
+  vi.spyOn(await import("./client.js"), "createFeishuClient").mockReturnValue(client);
+  const harness = createToolFactoryHarness(config);
+  registerFeishuDriveTools(harness.api);
+  const context = { agentAccountId: undefined, deliveryContext };
+  return {
+    requests,
+    logs,
+    sdkErrors,
+    tool: harness.resolveTool("feishu_drive", context),
+  };
+}
+
+function expectDriveOutcome(
+  fixture: Awaited<ReturnType<typeof createDriveLoopback>>,
+  result: { details: Record<string, unknown> },
+  requests: WireRequest[],
+  details: Record<string, unknown>,
+) {
+  expect(fixture.requests).toEqual(requests);
+  expect(result.details).toStrictEqual(details);
+  expect(result).toMatchObject({
+    content: [{ type: "text", text: expect.stringContaining("EXTERNAL_UNTRUSTED_CONTENT") }],
+  });
+}
+
+describe("feishu_drive comments through the installed Lark SDK", () => {
+  afterEach(() => vi.restoreAllMocks());
+  afterAll(() => vi.resetModules());
+
+  it.each(["list_comments", "list_comment_replies"] as const)(
+    "encodes %s pagination and retains its normalized result shape",
+    async (action) => {
+      const reply = {
+        reply_id: "r1",
+        user_id: "u1",
+        create_time: 10,
+        content: { elements: [{ type: "text_run", text_run: { text: "Reply text" } }] },
+      };
+      const normalizedReply = {
+        reply_id: "r1",
+        user_id: "u1",
+        create_time: 10,
+        update_time: undefined,
+        text: "Reply text",
+      };
+      const isReplies = action === "list_comment_replies";
+      const fixture = await createDriveLoopback([
+        {
+          body: {
+            code: 0,
+            data: {
+              has_more: true,
+              page_token: "next + cursor",
+              items: isReplies
+                ? [reply]
+                : [{ comment_id: "c1", reply_list: { replies: [reply, reply] } }],
+            },
+          },
+        },
+        { body: { code: 0 } },
+      ]);
+      const params = {
+        action,
+        file_token: " doc/+ ",
+        file_type: "sheet",
+        comment_id: " comment/+ ",
+        page_size: 201,
+        page_token: " cursor +/ ",
+      };
+      const result = await fixture.tool.execute("page", params);
+      const path =
+        "/open-apis/drive/v1/files/%20doc%2F%2B%20/comments" +
+        (isReplies ? "/%20comment%2F%2B%20/replies" : "");
+      const request = {
+        method: "GET",
+        url: `${path}?file_type=sheet&page_size=100&page_token=cursor+%2B%2F&user_id_type=open_id`,
+        body: "",
+      };
+      const items = isReplies
+        ? { replies: [normalizedReply] }
+        : {
+            comments: [
+              {
+                comment_id: "c1",
+                user_id: undefined,
+                create_time: undefined,
+                update_time: undefined,
+                is_solved: undefined,
+                is_whole: undefined,
+                quote: undefined,
+                text: "Reply text",
+                has_more_replies: undefined,
+                replies_page_token: undefined,
+                replies: [normalizedReply],
+              },
+            ],
+          };
+      expectDriveOutcome(fixture, result, [request], {
+        has_more: true,
+        page_token: "next + cursor",
+        ...items,
+      });
+      expect(Object.keys(result.details)).toEqual([
+        "has_more",
+        "page_token",
+        isReplies ? "replies" : "comments",
+      ]);
+      const empty = await fixture.tool.execute("empty-page", {
+        ...params,
+        page_size: 0,
+        page_token: " ",
+      });
+      expectDriveOutcome(
+        fixture,
+        empty,
+        [
+          request,
+          {
+            method: "GET",
+            url: `${path}?file_type=sheet&page_size=1&user_id_type=open_id`,
+            body: "",
+          },
+        ],
+        {
+          has_more: false,
+          page_token: undefined,
+          ...(isReplies ? { replies: [] } : { comments: [] }),
+        },
+      );
+      expect(fixture.logs).toEqual([]);
+    },
+  );
+
+  it.each([
+    {
+      action: "list_comments",
+      ambient: undefined,
+      token: " raw/+ ",
+      file: "%20raw%2F%2B%20",
+      type: "docx",
+      defaulted: true,
+    },
+    {
+      action: "list_comments",
+      ambient: "comment:sheet:ambient_file:ambient_comment",
+      token: " ",
+      file: "ambient_file",
+      type: "sheet",
+      defaulted: false,
+    },
+    {
+      action: "list_comment_replies",
+      ambient: "comment:file:ambient_file:ambient_comment",
+      token: " ",
+      file: "ambient_file",
+      type: "file",
+      defaulted: false,
+    },
+    {
+      action: "list_comment_replies",
+      ambient: "comment:sheet:ambient_file:ambient_comment",
+      channel: "slack",
+      token: " raw/+ ",
+      file: "%20raw%2F%2B%20",
+      type: "docx",
+      defaulted: true,
+    },
+    {
+      action: "add_comment",
+      ambient: "comment:doc:ambient_file:ambient_comment",
+      token: " ",
+      file: "ambient_file",
+      type: "doc",
+      defaulted: false,
+    },
+    {
+      action: "add_comment",
+      ambient: "comment:slides:ambient_file:ambient_comment",
+      token: " raw/+ ",
+      file: "%20raw%2F%2B%20",
+      type: "docx",
+      defaulted: true,
+    },
+    {
+      action: "reply_comment",
+      ambient: "comment:slides:ambient_file:ambient_comment",
+      token: " ",
+      file: "ambient_file",
+      type: "slides",
+      defaulted: false,
+    },
+    {
+      action: "reply_comment",
+      ambient: "comment:doc:ambient_file:ambient_comment",
+      token: " explicit/+ ",
+      file: "explicit%2F%2B",
+      type: "docx",
+      defaulted: false,
+      explicitType: "docx",
+    },
+  ])("resolves $action targets over HTTP ($type, $file)", async (testCase) => {
+    const isReply = testCase.action === "reply_comment";
+    const fixture = await createDriveLoopback(
+      [
+        ...(isReply ? [{ body: { code: 0, data: { items: [] } } }] : []),
+        { body: { code: 0, data: {} } },
+      ],
+      testCase.ambient
+        ? { channel: testCase.channel ?? "feishu", to: testCase.ambient }
+        : undefined,
+    );
+    const result = await fixture.tool.execute("target", {
+      action: testCase.action,
+      file_token: testCase.token,
+      ...(testCase.explicitType ? { file_type: testCase.explicitType } : {}),
+      comment_id: " ",
+      content: "Hello + 世界",
+    });
+    const filePath = `/open-apis/drive/v1/files/${testCase.file}`;
+    const commentId = testCase.defaulted ? "%20" : "ambient_comment";
+    let requests: WireRequest[];
+    let details: Record<string, unknown>;
+    if (testCase.action === "add_comment") {
+      requests = [
+        {
+          method: "POST",
+          url: `${filePath}/new_comments`,
+          body: JSON.stringify({
+            file_type: testCase.type,
+            reply_elements: [{ type: "text", text: "Hello + 世界" }],
+          }),
+        },
+      ];
+      details = { success: true };
+    } else if (isReply) {
+      requests = [
+        {
+          method: "POST",
+          url: `${filePath}/comments/batch_query?file_type=${testCase.type}&user_id_type=open_id`,
+          body: '{"comment_ids":["ambient_comment"]}',
+        },
+        {
+          method: "POST",
+          url: `${filePath}/comments/${commentId}/replies?file_type=${testCase.type}`,
+          body: '{"content":{"elements":[{"type":"text_run","text_run":{"text":"Hello + 世界"}}]}}',
+        },
+      ];
+      details = { delivery_mode: "reply_comment", success: true };
+    } else {
+      const replies = testCase.action === "list_comment_replies";
+      requests = [
+        {
+          method: "GET",
+          url: `${filePath}/comments${replies ? `/${commentId}/replies` : ""}?file_type=${testCase.type}&user_id_type=open_id`,
+          body: "",
+        },
+      ];
+      details = {
+        has_more: false,
+        page_token: undefined,
+        ...(replies ? { replies: [] } : { comments: [] }),
+      };
+    }
+    expectDriveOutcome(fixture, result, requests, details);
+    expect(fixture.logs).toEqual(
+      testCase.defaulted
+        ? [
+            {
+              level: "info",
+              message: `[feishu_drive] ${testCase.action} missing file_type; defaulting to docx file_token=${testCase.token}`,
+            },
+          ]
+        : [],
+    );
+  });
+
+  it.each(["list_comments", "list_comment_replies"])(
+    "surfaces fulfilled API failures and HTTP failures for %s",
+    async (action) => {
+      const fixture = await createDriveLoopback([
+        { body: { code: 9999, msg: "Denied by Drive" } },
+        { status: 403, body: { code: 9999, msg: "Denied by Drive" } },
+      ]);
+      const params = { action, file_token: "file", file_type: "docx", comment_id: "comment" };
+      const request = {
+        method: "GET",
+        url: `/open-apis/drive/v1/files/file/comments${action === "list_comment_replies" ? "/comment/replies" : ""}?file_type=docx&user_id_type=open_id`,
+        body: "",
+      };
+      expectDriveOutcome(fixture, await fixture.tool.execute("api-error", params), [request], {
+        error: "Denied by Drive",
+      });
+      expect(fixture.sdkErrors).not.toHaveBeenCalled();
+      expectDriveOutcome(
+        fixture,
+        await fixture.tool.execute("http-error", params),
+        [request, request],
+        { error: "Request failed with status code 403" },
+      );
+      expect(fixture.sdkErrors).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([
+    { action: "add_comment", failure: false },
+    { action: "reply_comment", failure: false },
+    { action: "add_comment", failure: true },
+    { action: "reply_comment", failure: true },
+  ])(
+    "returns $action (failure=$failure) before its typing delete completes",
+    async ({ action, failure }) => {
+      const deletionStarted = createDeferred<void>();
+      const releaseDeletion = createDeferred<void>();
+      const isReply = action === "reply_comment";
+      const fixture = await createDriveLoopback(
+        [
+          { body: { code: 0 } },
+          ...(isReply ? [{ body: { code: 0, data: { items: [] } } }] : []),
+          {
+            body: failure
+              ? { code: 9999, msg: "Write denied" }
+              : { code: 0, data: { id: "written" } },
+          },
+          { body: { code: 0 }, wait: releaseDeletion.promise, received: deletionStarted.resolve },
+        ],
+        { channel: "feishu", to: "comment:docx:file:comment", threadId: "typing_reply" },
+      );
+      const lifecycle = createCommentTypingReactionLifecycle({
+        cfg: config,
+        fileType: "docx",
+        fileToken: "file",
+        replyId: "typing_reply",
+      });
+      await lifecycle.start();
+      const output = fixture.tool.execute("write", { action, content: "Write text" });
+      let returned = false;
+      void Promise.resolve(output).then(() => {
+        returned = true;
+      });
+      try {
+        await deletionStarted.promise;
+        expect(returned).toBe(true);
+        const reaction = (reactionAction: string) => ({
+          method: "POST",
+          url: "/open-apis/drive/v2/files/file/comments/reaction?file_type=docx",
+          body: JSON.stringify({
+            action: reactionAction,
+            reply_id: "typing_reply",
+            reaction_type: "Typing",
+          }),
+        });
+        expectDriveOutcome(
+          fixture,
+          await output,
+          [
+            reaction("add"),
+            ...(isReply
+              ? [
+                  {
+                    method: "POST",
+                    url: "/open-apis/drive/v1/files/file/comments/batch_query?file_type=docx&user_id_type=open_id",
+                    body: '{"comment_ids":["comment"]}',
+                  },
+                ]
+              : []),
+            {
+              method: "POST",
+              url: isReply
+                ? "/open-apis/drive/v1/files/file/comments/comment/replies?file_type=docx"
+                : "/open-apis/drive/v1/files/file/new_comments",
+              body: isReply
+                ? '{"content":{"elements":[{"type":"text_run","text_run":{"text":"Write text"}}]}}'
+                : '{"file_type":"docx","reply_elements":[{"type":"text","text":"Write text"}]}',
+            },
+            reaction("delete"),
+          ],
+          failure
+            ? { error: "Write denied" }
+            : {
+                ...(isReply ? { delivery_mode: "reply_comment" } : {}),
+                success: true,
+                id: "written",
+              },
+        );
+      } finally {
+        releaseDeletion.resolve();
+        await lifecycle.cleanup();
+        await output;
+      }
+      expect(
+        fixture.requests.filter((request) => request.body.includes('"action":"delete"')),
+      ).toHaveLength(1);
+    },
+  );
+});

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -188,81 +188,41 @@ function resolveAmbientCommentTarget(context: FeishuDriveToolContext | undefined
   return parseFeishuCommentTarget(deliveryContext?.to);
 }
 
-function applyAmbientCommentDefaults<
+function resolveDriveCommentParams<
   T extends {
     file_token?: string;
     file_type?: CommentFileType;
     comment_id?: string;
   },
->(params: T, context: FeishuDriveToolContext | undefined): T {
-  const ambient = resolveAmbientCommentTarget(context);
-  if (!ambient) {
-    return params;
-  }
-  return {
-    ...params,
-    file_token: params.file_token?.trim() || ambient.fileToken,
-    file_type: params.file_type ?? ambient.fileType,
-    comment_id: params.comment_id?.trim() || ambient.commentId,
-  };
-}
-
-function applyAddCommentAmbientDefaults<
-  T extends {
-    file_token?: string;
-    file_type?: "doc" | "docx";
-  },
->(params: T, context: FeishuDriveToolContext | undefined): T {
-  const ambient = resolveAmbientCommentTarget(context);
-  if (!ambient || (ambient.fileType !== "doc" && ambient.fileType !== "docx")) {
-    return params;
-  }
-  return {
-    ...params,
-    file_token: params.file_token?.trim() || ambient.fileToken,
-    file_type: params.file_type ?? ambient.fileType,
-  };
-}
-
-function applyAddCommentDefaults<
-  T extends {
-    file_token?: string;
-    file_type?: "doc" | "docx";
-  },
->(params: T): T & { file_type: "doc" | "docx" } {
-  const fileType = params.file_type ?? "docx";
-  if (!params.file_type) {
-    console.info(
-      `[feishu_drive] add_comment missing file_type; defaulting to docx ` +
-        `file_token=${params.file_token ?? "unknown"}`,
-    );
-  }
-  return {
-    ...params,
-    file_type: fileType,
-  };
-}
-
-function applyCommentFileTypeDefault<
-  T extends {
-    file_token?: string;
-    file_type?: CommentFileType;
-  },
 >(
   params: T,
-  action: "list_comments" | "list_comment_replies" | "reply_comment",
-): T & {
-  file_type: CommentFileType;
-} {
-  const fileType = params.file_type ?? "docx";
-  if (!params.file_type) {
+  context: FeishuDriveToolContext | undefined,
+  action: "list_comments" | "list_comment_replies" | "add_comment" | "reply_comment",
+): T & { file_type: CommentFileType } {
+  const ambient = resolveAmbientCommentTarget(context);
+  let resolved = params;
+  if (
+    ambient &&
+    (action !== "add_comment" || ambient.fileType === "doc" || ambient.fileType === "docx")
+  ) {
+    resolved = {
+      ...params,
+      file_token: params.file_token?.trim() || ambient.fileToken,
+      file_type: params.file_type ?? ambient.fileType,
+      ...(action !== "add_comment" && {
+        comment_id: params.comment_id?.trim() || ambient.commentId,
+      }),
+    };
+  }
+  const fileType = resolved.file_type ?? "docx";
+  if (!resolved.file_type) {
     console.info(
       `[feishu_drive] ${action} missing file_type; defaulting to docx ` +
-        `file_token=${params.file_token ?? "unknown"}`,
+        `file_token=${resolved.file_token ?? "unknown"}`,
     );
   }
   return {
-    ...params,
+    ...resolved,
     file_type: fileType,
   };
 }
@@ -519,21 +479,21 @@ async function deleteFile(client: Lark.Client, fileToken: string, type: string) 
   };
 }
 
-async function listComments(
+async function listDriveCommentPage(
   client: Lark.Client,
-  params: {
-    file_token: string;
+  params: Extract<FeishuDriveParams, { action: "list_comments" | "list_comment_replies" }> & {
     file_type: CommentFileType;
-    page_size?: number;
-    page_token?: string;
   },
 ) {
+  const filePath = `/open-apis/drive/v1/files/${encodeURIComponent(params.file_token)}/comments`;
+  const isReplies = params.action === "list_comment_replies";
+  const url = isReplies ? `${filePath}/${encodeURIComponent(params.comment_id)}/replies` : filePath;
   const response = assertDriveApiSuccess(
-    await requestDriveApi<FeishuDriveListCommentsResponse>({
+    await requestDriveApi<FeishuDriveListCommentsResponse | FeishuDriveListRepliesResponse>({
       client,
       method: "GET",
       url:
-        `/open-apis/drive/v1/files/${encodeURIComponent(params.file_token)}/comments` +
+        url +
         encodeQuery({
           file_type: params.file_type,
           page_size: normalizeCommentPageSize(params.page_size),
@@ -545,40 +505,9 @@ async function listComments(
   return {
     has_more: response.data?.has_more ?? false,
     page_token: response.data?.page_token,
-    comments: (response.data?.items ?? []).map(normalizeCommentCard),
-  };
-}
-
-async function listCommentReplies(
-  client: Lark.Client,
-  params: {
-    file_token: string;
-    file_type: CommentFileType;
-    comment_id: string;
-    page_size?: number;
-    page_token?: string;
-  },
-) {
-  const response = assertDriveApiSuccess(
-    await requestDriveApi<FeishuDriveListRepliesResponse>({
-      client,
-      method: "GET",
-      url:
-        `/open-apis/drive/v1/files/${encodeURIComponent(params.file_token)}/comments/${encodeURIComponent(
-          params.comment_id,
-        )}/replies` +
-        encodeQuery({
-          file_type: params.file_type,
-          page_size: normalizeCommentPageSize(params.page_size),
-          page_token: params.page_token,
-          user_id_type: "open_id",
-        }),
-    }),
-  );
-  return {
-    has_more: response.data?.has_more ?? false,
-    page_token: response.data?.page_token,
-    replies: (response.data?.items ?? []).map(normalizeCommentReply),
+    ...(isReplies
+      ? { replies: (response.data?.items ?? []).map(normalizeCommentReply) }
+      : { comments: (response.data?.items ?? []).map(normalizeCommentCard) }),
   };
 }
 
@@ -840,39 +769,22 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
                 return jsonResult(await moveFile(client, p.file_token, p.type, p.folder_token));
               case "delete":
                 return jsonResult(await deleteFile(client, p.file_token, p.type));
-              case "list_comments": {
-                const resolved = applyCommentFileTypeDefault(
-                  applyAmbientCommentDefaults(p, ctx),
-                  "list_comments",
-                );
-                return jsonResult(await listComments(client, resolved));
-              }
+              case "list_comments":
               case "list_comment_replies": {
-                const resolved = applyCommentFileTypeDefault(
-                  applyAmbientCommentDefaults(p, ctx),
-                  "list_comment_replies",
-                );
-                return jsonResult(await listCommentReplies(client, resolved));
+                const resolved = resolveDriveCommentParams(p, ctx, p.action);
+                return jsonResult(await listDriveCommentPage(client, resolved));
               }
-              case "add_comment": {
-                const resolved = applyAddCommentDefaults(applyAddCommentAmbientDefaults(p, ctx));
-                try {
-                  return jsonResult(await addComment(client, resolved));
-                } finally {
-                  void cleanupAmbientCommentTypingReaction({
-                    client: getDriveInternalClient(client),
-                    deliveryContext: ctx.deliveryContext,
-                  });
-                }
-              }
+              case "add_comment":
               case "reply_comment": {
-                const resolved = applyCommentFileTypeDefault(
-                  applyAmbientCommentDefaults(p, ctx),
-                  "reply_comment",
-                );
+                const resolved = resolveDriveCommentParams(p, ctx, p.action);
                 try {
-                  return jsonResult(await deliverCommentThreadText(client, resolved));
+                  return jsonResult(
+                    await (resolved.action === "add_comment"
+                      ? addComment(client, resolved)
+                      : deliverCommentThreadText(client, resolved)),
+                  );
                 } finally {
+                  // Typing cleanup must not delay the visible write result.
                   void cleanupAmbientCommentTypingReaction({
                     client: getDriveInternalClient(client),
                     deliveryContext: ctx.deliveryContext,


### PR DESCRIPTION
Feishu Drive comment actions repeated the same ambient-target preparation, pagination request, and typing-cleanup flow. This consolidates those paths inside the existing Drive owner: four preparation helpers become one, both page readers share their request/response path, and both comment writes share their existing nonblocking cleanup.

Behavior is preserved. Explicit and ambient targets retain their precedence and trimming rules, including the doc/docx restriction for adding comments. Pagination bounds, URL/query ordering, normalized result fields (including own `undefined` values), API errors, external-content fencing, and account selection stay unchanged. Typing cleanup still runs once after a write and does not delay its visible result. The exported comment delivery helper and 21 other existing functions are byte-identical, preserving whole-comment and reply compatibility paths used by channel delivery.

Production changes are **+44/−132, net −88 physical lines** (−84 nonblank). A conservative count excluding signatures, types, and wrapping still removes 44 flow lines. The new installed-SDK loopback test adds 472 test lines. No code move, generated file, dependency, schema, configuration, or public API change contributes to the reduction.

Validation:

- The same 72 tests across five files pass before and after the refactor. The final permanent loopback test passes all 16 cases after its test-only type/import corrections.
- 8,000 preparation cases produce identical values, key ownership/order, reference behavior, logs, and error names/messages. An additional registered-tool corpus produces identical results for 20 outcomes and 32 real HTTP requests through installed Lark SDK 1.73.0 and its default Axios transport. Only ephemeral ports and external-content fence nonces are normalized.
- The four write cases hold the actual cleanup HTTP response open, require the tool result first, and then verify exactly one cleanup request. Page cases cover encoded IDs, missing data, defaults, fulfilled API errors, and HTTP errors.
- All 25 selected changed-file checks pass, including production/test typechecks, all three unused-export scans, lint, plugin boundaries, and zero runtime import cycles. Fresh managed P2 review is clean.

The SDK's generic request implementation, default response unwrapping, and request types were inspected directly. This is real SDK transport over localhost; external Feishu acceptance was not run because no approved disposable account/document and mutation credentials were available. The unchanged broad account-routing test timed out twice in its six-tool import hook before executing tests; it was not retried again or counted as passed. The existing nine-case account-owner suite is included in the successful 72-test proof.

Separate observations remain follow-ups: Feishu Wiki skill text advertises search while its tool reports that search is unavailable, and overlapping typing-start/cleanup may deserve a lifecycle reproduction. Neither is claimed fixed here. This internal behavior-preserving refactor needs no release changelog entry.


The latest 09:50 UTC ClawSweeper review has no code finding or rank-up list. Exact-head CI 33493639519 is green. Root owner/SDK review accepts the behavior-preserving consolidation under the user-directed maintainer campaign; no separate enforced owner approval was identified.
