### PR TITLE
refactor(memory-wiki): share tool registration and result adapters

### DIFF
--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -199,56 +199,39 @@ export default definePluginEntry({
       },
       { name: "wiki_status" },
     );
-    api.registerTool(
-      (ctx) => {
-        const resolved = resolveToolContext(ctx.agentId);
-        return resolved
-          ? createWikiLintTool(resolved.config, resolved.appConfig, resolved.signal)
-          : null;
-      },
-      { name: "wiki_lint" },
-    );
-    api.registerTool(
-      (ctx) => {
-        const resolved = resolveToolContext(ctx.agentId);
-        return resolved
-          ? createWikiApplyTool(resolved.config, resolved.appConfig, resolved.signal)
-          : null;
-      },
-      { name: "wiki_apply" },
-    );
-    api.registerTool(
-      (ctx) => {
-        const resolved = resolveToolContext(ctx.agentId);
-        if (!resolved) {
-          return null;
-        }
-        return createWikiSearchTool(resolved.config, resolved.appConfig, {
-          agentId: resolved.config.agentId ?? ctx.agentId,
-          agentSessionKey: ctx.sessionKey,
-          sandboxed: ctx.sandboxed,
-          conversationRecall: ctx.conversationRecall,
-          ...(resolved.signal ? { signal: resolved.signal } : {}),
-        });
-      },
-      { name: "wiki_search" },
-    );
-    api.registerTool(
-      (ctx) => {
-        const resolved = resolveToolContext(ctx.agentId);
-        if (!resolved) {
-          return null;
-        }
-        return createWikiGetTool(resolved.config, resolved.appConfig, {
-          agentId: resolved.config.agentId ?? ctx.agentId,
-          agentSessionKey: ctx.sessionKey,
-          sandboxed: ctx.sandboxed,
-          conversationRecall: ctx.conversationRecall,
-          ...(resolved.signal ? { signal: resolved.signal } : {}),
-        });
-      },
-      { name: "wiki_get" },
-    );
+    for (const [name, createTool] of [
+      ["wiki_lint", createWikiLintTool],
+      ["wiki_apply", createWikiApplyTool],
+    ] as const) {
+      api.registerTool(
+        (ctx) => {
+          const resolved = resolveToolContext(ctx.agentId);
+          return resolved ? createTool(resolved.config, resolved.appConfig, resolved.signal) : null;
+        },
+        { name },
+      );
+    }
+    for (const [name, createTool] of [
+      ["wiki_search", createWikiSearchTool],
+      ["wiki_get", createWikiGetTool],
+    ] as const) {
+      api.registerTool(
+        (ctx) => {
+          const resolved = resolveToolContext(ctx.agentId);
+          if (!resolved) {
+            return null;
+          }
+          return createTool(resolved.config, resolved.appConfig, {
+            agentId: resolved.config.agentId ?? ctx.agentId,
+            agentSessionKey: ctx.sessionKey,
+            sandboxed: ctx.sandboxed,
+            conversationRecall: ctx.conversationRecall,
+            ...(resolved.signal ? { signal: resolved.signal } : {}),
+          });
+        },
+        { name },
+      );
+    }
     api.registerCli(
       async ({ program }) => {
         const { registerWikiCli } = await import("./src/cli.js");

--- a/extensions/memory-wiki/src/tool.ts
+++ b/extensions/memory-wiki/src/tool.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { optionalFiniteNumberSchema } from "openclaw/plugin-sdk/channel-actions";
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 import { asNonArrayRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { textResult } from "openclaw/plugin-sdk/tool-results";
 import { Type } from "typebox";
 import type { AnyAgentTool, OpenClawConfig } from "../api.js";
 import { applyMemoryWikiMutation, normalizeMemoryWikiMutationInput } from "./apply.js";
@@ -140,10 +141,7 @@ export function createWikiStatusTool(
         appConfig,
         callerAgentId: memoryContext.agentId,
       });
-      return {
-        content: [{ type: "text", text: renderMemoryWikiStatus(status) }],
-        details: status,
-      };
+      return textResult(renderMemoryWikiStatus(status), status);
     },
   };
 }
@@ -190,10 +188,7 @@ export function createWikiSearchTool(
                   `${index + 1}. ${result.title} (${result.corpus}/${result.kind})\nPath: ${result.path}${typeof result.startLine === "number" && typeof result.endLine === "number" ? `\nLines: ${result.startLine}-${result.endLine}` : ""}${result.provenanceLabel ? `\nProvenance: ${result.provenanceLabel}` : ""}${result.matchedClaimId ? `\nClaim: ${result.matchedClaimId}` : ""}${result.evidenceKinds && result.evidenceKinds.length > 0 ? `\nEvidence: ${result.evidenceKinds.join(", ")}` : ""}\nSnippet: ${result.snippet}`,
               )
               .join("\n\n");
-      return {
-        content: [{ type: "text", text }],
-        details: { results },
-      };
+      return textResult(text, { results });
     },
   };
 }
@@ -228,15 +223,12 @@ export function createWikiLintTool(
               `Provenance gaps: ${provenance}`,
               `Report: ${reportPath}`,
             ].join("\n");
-      return {
-        content: [{ type: "text", text: summary }],
-        details: {
-          issueCount: result.issueCount,
-          issues: result.issues,
-          issuesByCategory: result.issuesByCategory,
-          reportPath,
-        },
-      };
+      return textResult(summary, {
+        issueCount: result.issueCount,
+        issues: result.issues,
+        issuesByCategory: result.issuesByCategory,
+        reportPath,
+      });
     },
   };
 }
@@ -265,15 +257,10 @@ export function createWikiApplyTool(
         result.compile.updatedFiles.length > 0
           ? `Refreshed ${result.compile.updatedFiles.length} index file${result.compile.updatedFiles.length === 1 ? "" : "s"}.`
           : "Indexes unchanged.";
-      return {
-        content: [
-          {
-            type: "text",
-            text: `${action} ${result.pagePath} via ${result.operation}. ${compileSummary}`,
-          },
-        ],
-        details: result,
-      };
+      return textResult(
+        `${action} ${result.pagePath} via ${result.operation}. ${compileSummary}`,
+        result,
+      );
     },
   };
 }
@@ -299,10 +286,7 @@ export function createWikiGetTool(
       };
       const lookup = typeof params.lookup === "string" ? params.lookup.trim() : "";
       if (!lookup) {
-        return {
-          content: [{ type: "text", text: "wiki_get requires a non-empty `lookup` path or id." }],
-          details: { found: false },
-        };
+        return textResult("wiki_get requires a non-empty `lookup` path or id.", { found: false });
       }
       await syncImportedSourcesIfNeeded(config, appConfig, memoryContext.signal);
       const result = await getMemoryWikiPage({
@@ -319,15 +303,9 @@ export function createWikiGetTool(
         ...(params.corpus ? { searchCorpus: params.corpus } : {}),
       });
       if (!result) {
-        return {
-          content: [{ type: "text", text: `Wiki page not found: ${lookup}` }],
-          details: { found: false },
-        };
+        return textResult(`Wiki page not found: ${lookup}`, { found: false });
       }
-      return {
-        content: [{ type: "text", text: result.content }],
-        details: { found: true, ...result },
-      };
+      return textResult(result.content, { found: true, ...result });
     },
   };
 }


### PR DESCRIPTION
Memory Wiki's tool adapter repeated two pairs of factory registrations and seven plain-text result envelopes. The registration pairs now share their existing context projection, and the tools use the lightweight SDK `textResult` helper. The five named tools still register synchronously in the same order; status retains its distinct callback.

The factories resolve the current app configuration and service signal on every invocation. Agent/session/sandbox/recall context, context-free multi-agent omission, unknown-agent errors, stop/restart fencing, and independent tool objects remain unchanged. Result text, detail references, own-property order, `undefined` values, spread precedence, lint report projection, and error rejection behavior are preserved. Invalid `wiki_get` input still returns before filesystem work, while a successful empty read remains `found: true`.

This removes **39 production lines** (+49/−88), all nonblank/noncomment adapter code across the two owners. It adds no helper, type, public API, configuration, dependency, schema, or storage behavior. Tests and generated files are unchanged. The newly imported SDK helper and registration contracts exist at the plugin's stable peer floor, `v2026.8.1`, as verified from the immutable local tag.

Validation covers 83 maintained tests across seven files and all 24 selected changed-file checks, including production/test types, lint, all three unused-export scans, doctor contracts, plugin boundaries, and zero runtime import cycles. Fresh managed P2 review is clean. A temporary integration harness invokes the actual plugin registration, all five factories, and real isolated vault operations before and after the patch: 64 tool invocations and 88 capture records match across 2,220,243 normalized bytes, including 1,074 own-undefined nodes and four shared-reference nodes. Only three temporary vault path prefixes are normalized; error stacks are retained separately, while names/messages/descriptors remain compared.

The integration proof uses a synthetic host API/KV/blob store and external memory/session seams with real filesystem, query, lint, mutation, compile, and lifecycle code. It does not claim a live Gateway, model/provider, operator store, or remote memory-engine run. One initial baseline attempt hit the unchanged silence watchdog before tests; another exposed an incorrect fixture assumption about search-only recall context. Both are preserved, and the corrected baseline/candidate captures pass without changing production policy or increasing timeouts. Whether recall should also restrict ordinary explicit reads is a separate product-contract question, not a fixed bug in this refactor. No release changelog entry is required for this internal simplification.


The latest 09:51 UTC ClawSweeper review is code-clean with no before-merge finding or rank-up list. The automatic storage/vector classification is false: only registration and result envelopes change; no database, schema, embedding, migration or persisted data code changes. Exact-head CI 33493810666 is green; maintainer review accepts the refactor.
