### PR TITLE
fix(memory): sync aborts when USER.md is a symlink

### DIFF
--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -223,6 +223,27 @@ describe("memory host SDK package internals", () => {
     ]);
   });
 
+  it.skipIf(process.platform === "win32")(
+    "skips a symlinked USER.md without dropping regular memory files",
+    async () => {
+      const workspaceDir = getTmpDir();
+      const memoryDir = path.join(workspaceDir, "memory");
+      const externalUserPath = path.join(workspaceDir, "external-user.md");
+      await fs.mkdir(memoryDir);
+      await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# Memory");
+      await fs.writeFile(path.join(memoryDir, "note.md"), "# Note");
+      await fs.writeFile(externalUserPath, "# External user");
+      await fs.symlink(externalUserPath, path.join(workspaceDir, "USER.md"));
+
+      const files = await listMemoryFiles(workspaceDir);
+
+      expect(files.map((file) => path.relative(workspaceDir, file)).toSorted()).toEqual([
+        "MEMORY.md",
+        path.join("memory", "note.md"),
+      ]);
+    },
+  );
+
   it.each([
     {
       label: "primary memory file",
@@ -319,6 +340,19 @@ describe("memory host SDK package internals", () => {
     expect(isMemoryPath("dreams.md")).toBe(true);
     expect(isMemoryPath("DREAMS.md")).toBe(true);
   });
+
+  it.skipIf(process.platform === "win32")(
+    "skips a memory file replaced by a symlink before entry construction",
+    async () => {
+      const workspaceDir = getTmpDir();
+      const externalNotePath = path.join(workspaceDir, "external-note.md");
+      const notePath = path.join(workspaceDir, "note.md");
+      await fs.writeFile(externalNotePath, "# External note");
+      await fs.symlink(externalNotePath, notePath);
+
+      await expect(buildFileEntry(notePath, workspaceDir)).resolves.toBeNull();
+    },
+  );
 
   it("builds markdown and multimodal file entries", async () => {
     const tmpDir = getTmpDir();

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -1,6 +1,6 @@
 // Memory Host SDK module implements internal behavior.
 import crypto from "node:crypto";
-import fsSync from "node:fs";
+import fsSync, { type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
@@ -180,6 +180,18 @@ function shouldDescendMemoryEntry(
   return entry.kind === "directory" && entry.name !== ".openclaw-repair";
 }
 
+async function statEligibleMemoryFile(absPath: string): Promise<Stats | null> {
+  try {
+    const stat = await fs.lstat(absPath);
+    return stat.isFile() && !stat.isSymbolicLink() ? stat : null;
+  } catch (error) {
+    if (isFileMissingError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 async function collectMemoryFilesFromDir(
   dir: string,
   files: string[],
@@ -215,20 +227,11 @@ export async function listMemoryFiles(
     shouldSkipRootMemoryAuxiliaryPath({ workspaceDir, absPath });
 
   const addMarkdownFile = async (absPath: string) => {
-    try {
-      const stat = await statRegularFile(absPath);
-      if (stat.missing) {
-        return;
-      }
-      if (!absPath.endsWith(".md")) {
-        return;
-      }
-      result.push(absPath);
-    } catch (error) {
-      if (!isFileMissingError(error)) {
-        throw error;
-      }
+    const stat = await statEligibleMemoryFile(absPath);
+    if (!stat || !absPath.endsWith(".md")) {
+      return;
     }
+    result.push(absPath);
   };
 
   const memoryFile = await resolveCanonicalRootMemoryFile(workspaceDir);
@@ -308,11 +311,10 @@ export async function buildFileEntry(
   workspaceDir: string,
   multimodal?: MemoryMultimodalSettings,
 ): Promise<MemoryFileEntry | null> {
-  const regularFile = await statRegularFile(absPath);
-  if (regularFile.missing) {
+  const stat = await statEligibleMemoryFile(absPath);
+  if (!stat) {
     return null;
   }
-  const stat = regularFile.stat;
   const normalizedPath = path.relative(workspaceDir, absPath).replace(/\\/g, "/");
   const multimodalSettings = multimodal ?? DISABLED_MULTIMODAL_SETTINGS;
   const modality = classifyMemoryMultimodalPath(absPath, multimodalSettings);


### PR DESCRIPTION
Related: #134967

> **Superseded by merged PR [#135042](https://github.com/openclaw/openclaw/pull/135042).** GitHub records it as merged into `main` on September 1, 2026, with merge commit `a12308adcc35c7f92b7eb31c08f1af7952670eea`; that merged PR also closes #134967.
>
> The merged change provides the same owner-boundary repair through `statEnumerableMemoryFile`, applies it to both workspace-root discovery and entry construction, and includes equivalent SDK regressions plus FTS reindex and real memory-index symlink E2E coverage. Current `main` therefore contains the same-or-better fix, so this PR should not be merged.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users with a symlinked `USER.md` would have the entire built-in memory sync abort with `path must be a regular file`, preventing valid `MEMORY.md` and `memory/*.md` files from being indexed.

## Why This Change Was Made

Memory discovery now treats missing, symlinked, and other non-regular file candidates as ineligible at the enumeration and entry-construction boundary, matching the existing skip-not-follow policy for memory directories and extra paths. Operational filesystem failures still propagate, and actual file reads retain strict regular-file checks. The canonical `MEMORY.md` resolver already skips stable symlinks; this change closes the directly probed `USER.md` path and the replacement-before-entry race.

## User Impact

Operators can keep a symlinked `USER.md` without breaking indexing of their regular memory files. Symlink targets remain excluded and are never followed.

## Evidence

- Pre-fix regressions failed with `Error: path must be a regular file` from both the symlinked `USER.md` enumeration path and the replacement-before-entry path.
- Focused owner suite: `packages/memory-host-sdk/src/host/internal.test.ts` — 23 tests passed.
- Required changed checks passed for the two touched files, including formatting, core and core-test type checks, lint, import-cycle, package-boundary, and repository guard checks.

### Inspectable real CLI proof

The isolated workspace contained regular `MEMORY.md` and `memory/note.md` files plus a `USER.md` symlink whose target contained the unique token `externaluser134967`. Memory search used the documented FTS-only configuration (`provider: "none"`, vector search disabled). Local directory names are replaced below with placeholders; command results and indexed paths are unchanged.

```console
$ OPENCLAW_STATE_DIR=<isolated-state> OPENCLAW_WORKSPACE_DIR=<isolated-workspace> \
    pnpm --silent openclaw memory index --agent main --force --verbose
Memory Index (main)
Provider: none (requested: none)
Model: none
Memory index updated (main): 2 files indexed.

$ OPENCLAW_STATE_DIR=<isolated-state> OPENCLAW_WORKSPACE_DIR=<isolated-workspace> \
    pnpm --silent openclaw memory search --agent main --json --query root134967
{
  "results": [
    {
      "path": "MEMORY.md",
      "startLine": 1,
      "endLine": 3,
      "snippet": "# Root memory\nroot134967\n",
      "source": "memory"
    }
  ]
}

$ OPENCLAW_STATE_DIR=<isolated-state> OPENCLAW_WORKSPACE_DIR=<isolated-workspace> \
    pnpm --silent openclaw memory search --agent main --json --query nested134967
{
  "results": [
    {
      "path": "memory/note.md",
      "startLine": 1,
      "endLine": 3,
      "snippet": "# Nested memory\nnested134967\n",
      "source": "memory"
    }
  ]
}

$ OPENCLAW_STATE_DIR=<isolated-state> OPENCLAW_WORKSPACE_DIR=<isolated-workspace> \
    pnpm --silent openclaw memory search --agent main --json --query externaluser134967
{
  "results": []
}
```

The command sequence exited successfully, indexed both regular files, excluded the symlink target, and emitted no `path must be a regular file` error.
