### PR TITLE
fix: keep scheduled model aliases scoped to the selected agent

### DIFF
--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -207,12 +207,21 @@ export async function resolveCronModelSelection(
     config: owner.config,
     agentConfigOverride: ownerAgentConfigOverride,
   });
-  const catalog = owner.modelCatalog.entries;
   const resolvedDefault = resolveConfiguredModelRef({
     cfg: cfgWithAgentDefaults,
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
+    manifestPlugins: owner.metadataSnapshot,
   });
+  // Overrides keep the owner's agent policy; flattened defaults only select the default model.
+  const selectionParams = {
+    cfg: owner.config,
+    catalog: owner.modelCatalog.entries,
+    defaultProvider: resolvedDefault.provider,
+    defaultModel: resolvedDefault.model,
+    agentId: ownerAgentId,
+    manifestPlugins: owner.metadataSnapshot,
+  };
   let provider = resolvedDefault.provider;
   let model = resolvedDefault.model;
   let modelSource: CronModelSelectionSource = "default";
@@ -232,12 +241,8 @@ export async function resolveCronModelSelection(
     // Subagent/agent model config is advisory here: invalid refs fall back to
     // defaults so an agent config typo does not prevent unrelated cron runs.
     const resolvedSubagent = resolveAllowedModelRefCore({
-      cfg: owner.config,
-      catalog,
+      ...selectionParams,
       raw: subagentModelRaw,
-      defaultProvider: resolvedDefault.provider,
-      defaultModel: resolvedDefault.model,
-      agentId: ownerAgentId,
     });
     if (!("error" in resolvedSubagent)) {
       provider = resolvedSubagent.ref.provider;
@@ -252,18 +257,15 @@ export async function resolveCronModelSelection(
     ? resolveHooksGmailModel({
         cfg: owner.config,
         defaultProvider: DEFAULT_PROVIDER,
+        manifestPlugins: owner.metadataSnapshot,
       })
     : null;
   if (hooksGmailModelRef) {
     // Gmail hook models are specialized defaults: apply them only when the
     // configured ref is allowed, otherwise keep the broader cron default.
     const status = getModelRefStatus({
-      cfg: owner.config,
-      catalog,
+      ...selectionParams,
       ref: hooksGmailModelRef,
-      defaultProvider: resolvedDefault.provider,
-      defaultModel: resolvedDefault.model,
-      agentId: ownerAgentId,
     });
     if (status.allowed) {
       provider = hooksGmailModelRef.provider;
@@ -282,12 +284,8 @@ export async function resolveCronModelSelection(
     // Payload model overrides are explicit cron config, so reject disallowed
     // refs instead of silently falling back to defaults.
     const resolvedOverride = resolveAllowedModelRefCore({
-      cfg: owner.config,
-      catalog,
+      ...selectionParams,
       raw: modelOverride,
-      defaultProvider: resolvedDefault.provider,
-      defaultModel: resolvedDefault.model,
-      agentId: ownerAgentId,
     });
     if ("error" in resolvedOverride) {
       return {
@@ -314,12 +312,8 @@ export async function resolveCronModelSelection(
       const sessionProviderOverride =
         params.sessionEntry.providerOverride?.trim() || resolvedDefault.provider;
       const resolvedSessionOverride = resolveAllowedModelRefCore({
-        cfg: owner.config,
-        catalog,
+        ...selectionParams,
         raw: `${sessionProviderOverride}/${sessionModelOverride}`,
-        defaultProvider: resolvedDefault.provider,
-        defaultModel: resolvedDefault.model,
-        agentId: ownerAgentId,
       });
       if (!("error" in resolvedSessionOverride)) {
         provider = resolvedSessionOverride.ref.provider;

--- a/src/cron/isolated-agent/run.model-policy-config-preserved.test.ts
+++ b/src/cron/isolated-agent/run.model-policy-config-preserved.test.ts
@@ -1,8 +1,13 @@
 // Cron policy tests cover per-agent defaults flattening before model resolution.
 import { describe, expect, it } from "vitest";
 import { resolveAgentConfig } from "../../agents/agent-scope.js";
+import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { resolveAllowedModelRefCore } from "../../agents/model-selection-resolve.js";
+import type { ResolvedPublishedModelCatalogOwner } from "../../agents/prepared-model-catalog.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
+import { resolveCronModelSelection } from "./model-selection.js";
 import { resolveCronAgentConfig } from "./run-config.js";
 
 function buildCronConfig(cfg: OpenClawConfig, agentId: string): OpenClawConfig {
@@ -61,4 +66,82 @@ describe("resolveCronAgentConfig model policy preservation", () => {
       ref: { provider: "openai", model: "gpt-5.6-sol" },
     });
   });
+
+  it.each(["default", "subagent", "agent", "payload", "session", "hook"] as const)(
+    "keeps the selected owner's metadata for the %s model",
+    async (source) => {
+      const snapshot = (workspaceDir: string, model: string) => ({
+        ...createPluginMetadataSnapshotFixture({
+          plugins: [
+            {
+              id: "cron-model-policy",
+              modelIdNormalization: {
+                providers: {
+                  custom: { aliases: { legacy: model } },
+                  [DEFAULT_PROVIDER]: { aliases: { legacy: model } },
+                },
+              },
+            },
+          ],
+        }),
+        workspaceDir,
+      });
+      const metadataSnapshot = snapshot("/tmp/cron-owner", "selected");
+      const otherWorkspace = snapshot("/tmp/other-owner", "other");
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: source === "default" ? "custom/legacy" : "custom/baseline" },
+            modelPolicy: { allow: ["custom/legacy", `${DEFAULT_PROVIDER}/legacy`] },
+            ...(source === "subagent" ? { subagents: { model: "custom/legacy" } } : {}),
+          },
+          entries: {
+            worker: {
+              agentDir: "/tmp/cron-agent",
+              workspace: metadataSnapshot.workspaceDir,
+              ...(source === "agent" ? { model: "custom/legacy" } : {}),
+            },
+          },
+        },
+        ...(source === "hook" ? { hooks: { gmail: { model: "legacy" } } } : {}),
+      };
+      const owner: ResolvedPublishedModelCatalogOwner = {
+        catalogOwner: { agentId: "worker", workspaceDir: metadataSnapshot.workspaceDir },
+        agentId: "worker",
+        agentDir: "/tmp/cron-agent",
+        workspaceDir: metadataSnapshot.workspaceDir,
+        config: cfg,
+        authModes: {},
+        authStore: { version: 1, profiles: {} },
+        metadataSnapshot,
+        modelCatalog: { entries: [], routeVariants: [] },
+      };
+      for (const ambient of [metadataSnapshot, otherWorkspace]) {
+        const result = await withPluginRuntimeGenerationScope({ metadataSnapshot: ambient }, () =>
+          resolveCronModelSelection({
+            cfg,
+            owner,
+            agentConfigOverride: resolveAgentConfig(cfg, owner.agentId),
+            agentId: owner.agentId,
+            agentDir: owner.agentDir,
+            workspaceDir: owner.workspaceDir,
+            payload: {
+              kind: "agentTurn",
+              message: "scheduled work",
+              ...(source === "payload" ? { model: "custom/legacy" } : {}),
+            },
+            sessionEntry:
+              source === "session" ? { providerOverride: "custom", modelOverride: "legacy" } : {},
+            isGmailHook: source === "hook",
+          }),
+        );
+        expect(result).toMatchObject({
+          ok: true,
+          provider: source === "hook" ? DEFAULT_PROVIDER : "custom",
+          model: "selected",
+          modelSource: source,
+        });
+      }
+    },
+  );
 });


### PR DESCRIPTION
Related: #130324 and #130706. This is an independent, focused repair extracted from the broader investigation.

## What Problem This Solves

Fixes an issue where scheduled agent runs could resolve a model alias using another workspace's plugin metadata, selecting the wrong canonical model. The problem affected defaults, agent and subagent settings, job overrides, saved session overrides, and Gmail-triggered runs.

## Why This Change Was Made

Cron already selects a published model owner. All model-resolution paths now reuse that owner's metadata through existing APIs. A shared parameter object also removes repeated override-policy arguments while preserving the distinction between flattened defaults and agent-specific authorization. Gmail keeps its existing provider default and precedence.

Production LOC: **+15/-21 (net -6)**. Tests: **+83/-0**, one six-row table in the existing policy suite. No new production API, cache, config, schema, or compatibility path. Executable provider-hook ownership is unchanged and remains separate work.

## User Impact

Scheduled runs consistently use the selected agent's static model aliases even when another workspace has different alias policies. Existing override precedence, rejection messages, and fallback behavior remain intact.

## Evidence

- Before the source fix, all six new cases failed with the competing workspace's model (`other`) instead of the selected owner's model (`selected`). The same cases also check matching ambient metadata.
- After the fix, **83 tests in six files passed**, including all six regression cases and existing model policy, forwarding, precedence, hook, and thinking coverage. No timeout or assertion was relaxed.
- Independent test-audit/deslop inspection found no actionable issue. Managed Codex autoreview completed with no accepted/actionable P0 findings.
- Formatting and production typechecking passed. The local core-test type graph reached its 20-minute wrapper limit without diagnostics; that local run is incomplete. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33493898560) subsequently completed successfully on `ddbbaf0473964ad22faa913e4df4250c6971af11`.
- On that exact head, an isolated Linux build and real child Gateway passed the existing `test/plugin-cron-registry-owner.e2e.test.ts` case `prepares distinct selected and fallback providers for cron under per-agent defaults`. Public `cron.add`, `cron.run`, and `cron.runs` calls exercised selected-provider failure, successful fallback, both provider-hook markers in actual HTTP requests, and an `ok` terminal history entry. One selected case passed; the two unrelated cases were filtered. Source checksums matched before and after. This uses a synthetic local provider, not external-provider authentication.
- Inspected main at `de64e911270f3db1fe97570f6c33bad84bf57b01` has no changes in either target file. The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/135069#issuecomment-5492195381) has no correctness or security findings. Its incomplete-CI evidence risk and Rank-up request are satisfied by the linked successful exact-head CI and the native landing check's passing required `openclaw/ci-gate`.
- This focused selection fix is not a Gateway CPU benchmark or a claim that the broader incident is resolved.
