### PR TITLE
fix(auto-reply): bound prompt segment scans at EOF

### DIFF
--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -105,6 +105,8 @@ Final payloads are assembled from assistant text (plus optional reasoning), inli
 - Messaging tool duplicates are removed from the final payload list.
 - If no renderable payloads remain and a tool errored, a fallback tool error reply is emitted unless a messaging tool already sent a user-visible reply.
 
+Prompt-segment diagnostics attribute attachment/context blocks and generated inbound metadata separately from user text. A prompt containing only those blocks does not need trailing user text for reply processing to complete.
+
 ## Compaction and retries
 
 Auto-compaction emits `compaction` stream events and can trigger a retry. On retry, in-memory buffers and tool summaries reset to avoid duplicate output. See [Compaction](/concepts/compaction).

--- a/src/auto-reply/reply/agent-runner-trace.test.ts
+++ b/src/auto-reply/reply/agent-runner-trace.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { derivePromptSegments } from "./agent-runner-trace.js";
+import { markInboundContextLabel } from "./inbound-context-marker.js";
+
+describe("derivePromptSegments", () => {
+  const context = "Context:\n<attachment>\nimg\n</attachment>";
+  const metadata = `${markInboundContextLabel("Conversation info:")}\n\`\`\`json\n{}\n\`\`\``;
+
+  it.each([
+    { name: "Context block at EOF", block: context, trailing: "", key: "attachment" },
+    {
+      name: "Context block with trailing empty lines",
+      block: context,
+      trailing: "\n\n",
+      key: "attachment",
+    },
+    { name: "metadata fence at EOF", block: metadata, trailing: "", key: "conversation_metadata" },
+    {
+      name: "metadata fence with trailing empty lines",
+      block: metadata,
+      trailing: "\n\n",
+      key: "conversation_metadata",
+    },
+  ])("attributes $name without user content", ({ block, trailing, key }) => {
+    expect(derivePromptSegments(block + trailing)).toEqual([{ key, chars: block.length }]);
+  });
+
+  it("keeps user content after consecutive context and metadata blocks", () => {
+    expect(derivePromptSegments(`${context}\n\n${metadata}\n\nHello`)).toEqual([
+      { key: "attachment", chars: context.length },
+      { key: "conversation_metadata", chars: metadata.length },
+      { key: "user_message", chars: 6 },
+    ]);
+  });
+});

--- a/src/auto-reply/reply/agent-runner-trace.ts
+++ b/src/auto-reply/reply/agent-runner-trace.ts
@@ -229,7 +229,7 @@ export function derivePromptSegments(
             lines.slice(index, end + 1).join("\n").length,
           );
           index = end + 1;
-          while ((lines[index] ?? "") === "") {
+          while (index < lines.length && lines[index] === "") {
             index += 1;
           }
           continue;
@@ -258,7 +258,7 @@ export function derivePromptSegments(
             lines.slice(start, end + 1).join("\n").length,
           );
           index = end + 1;
-          while ((lines[index] ?? "") === "") {
+          while (index < lines.length && lines[index] === "") {
             index += 1;
           }
           continue;


### PR DESCRIPTION

## What Problem This Solves

Reply completion can block the event loop indefinitely when the prompt ends with a closed Context tag block or generated inbound JSON metadata fence, including attachment/context-only input and trailing blank lines. The diagnostic parser runs even when trace output is disabled.

## Why This Change Was Made

Bound the two blank-line skip loops at their owner, `derivePromptSegments`, instead of deleting fallback attribution in reply completion. All other loops in the function already stop at EOF. Discovery source: NetEase Youdao's LobsterAI patch stack (github.com/netease-youdao/LobsterAI); the implementation preserves current main's fallback and fixes the parser itself.

## User Impact

Context-only prompts no longer get stuck during reply completion. Segment attribution remains available without requiring extra user text after context or metadata blocks. No configuration changes are required.

## Evidence

- Pre-fix proof: the four EOF regression inputs time out under a 1000 ms Node VM execution budget against the exact parser from base `2e3cae2ae3524eff681fa0064696a634b9279204`. The same source probe returns correct attribution after the fix. No test-only production seam or working-tree stash is used.
- `pnpm test src/auto-reply/reply/agent-runner-trace.test.ts`: 5 passed.
- `pnpm test src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/auto-reply/reply/strip-inbound-meta.test.ts`: 138 passed, including existing raw-trace fallback attribution and sender-authorization coverage.
- `pnpm check:changed`: passed in full, with no skipped checks.
- Formatting and `git diff --check`: passed. Codex autoreview: scoped-clean, no accepted/actionable findings.
- Production LOC: +2/-2 (net 0); tests +35; docs +2. No changelog or baseline changes.
- Proof limit: no live gateway/channel E2E was run. The EOF regression is proved at the synchronous parser owner; existing local runner and stripper suites cover adjacent behavior. Live-channel proof remains a pre-landing follow-up if required by the landing workflow.
