### PR TITLE
refactor(slack): share rich-text fallback rendering

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1125,7 +1125,7 @@ extensions/slack/src/approval-actions.ts	1
 extensions/slack/src/approval-handler.runtime.ts	1
 extensions/slack/src/approval-native-gates.ts	1
 extensions/slack/src/approval-native.ts	2
-extensions/slack/src/blocks-fallback.ts	2
+extensions/slack/src/blocks-fallback.ts	1
 extensions/slack/src/blocks-input.ts	2
 extensions/slack/src/blocks-render.ts	1
 extensions/slack/src/channel-actions.ts	1

--- a/extensions/slack/src/blocks-fallback.ts
+++ b/extensions/slack/src/blocks-fallback.ts
@@ -14,6 +14,7 @@ import {
   renderSlackDataVisualizationMrkdwnFallbackText,
 } from "./data-visualization.js";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
+import { renderSlackRichText } from "./rich-text.js";
 
 type SlackNativeDataFallbackFormat = "plain" | "mrkdwn-safe";
 
@@ -30,19 +31,6 @@ type SlackBlockLike = {
   elements?: unknown;
   fields?: unknown;
   accessory?: unknown;
-};
-
-type SlackRichTextElement = {
-  type?: unknown;
-  text?: unknown;
-  url?: unknown;
-  user_id?: unknown;
-  channel_id?: unknown;
-  usergroup_id?: unknown;
-  name?: unknown;
-  range?: unknown;
-  fallback?: unknown;
-  elements?: unknown;
 };
 
 const SLACK_SELECT_ELEMENT_TYPES = new Set([
@@ -80,68 +68,6 @@ function readTextValue(
   options: RenderSlackBlockFallbackOptions = {},
 ): string | undefined {
   return normalizeOptionalString(value) ?? readTextObject(value, options);
-}
-
-function renderSlackRichTextElement(
-  value: unknown,
-  renderReference: (text: string) => string,
-): string {
-  const element = asOptionalRecord(value) as SlackRichTextElement | undefined;
-  if (!element) {
-    return "";
-  }
-  switch (element.type) {
-    case "rich_text_section":
-    case "rich_text_preformatted":
-    case "rich_text_quote":
-      return renderSlackRichTextElements(element.elements, "", renderReference);
-    case "rich_text_list":
-      return renderSlackRichTextElements(element.elements, "\n", renderReference);
-    case "text":
-      return typeof element.text === "string" ? escapeSlackMrkdwn(element.text) : "";
-    case "link":
-      return escapeSlackMrkdwn(
-        normalizeOptionalString(element.text) ?? normalizeOptionalString(element.url) ?? "",
-      );
-    case "user": {
-      const userId = normalizeOptionalString(element.user_id);
-      return userId ? renderReference(`<@${userId}>`) : "";
-    }
-    case "channel": {
-      const channelId = normalizeOptionalString(element.channel_id);
-      return channelId ? renderReference(`<#${channelId}>`) : "";
-    }
-    case "usergroup": {
-      const usergroupId = normalizeOptionalString(element.usergroup_id);
-      return usergroupId ? renderReference(`<!subteam^${usergroupId}>`) : "";
-    }
-    case "broadcast": {
-      const range = normalizeOptionalString(element.range);
-      return range ? renderReference(`<!${range}>`) : "";
-    }
-    case "emoji": {
-      const name = normalizeOptionalString(element.name);
-      return name ? `:${name}:` : "";
-    }
-    case "date":
-      return escapeSlackMrkdwn(normalizeOptionalString(element.fallback) ?? "");
-    default:
-      return "";
-  }
-}
-
-function renderSlackRichTextElements(
-  value: unknown,
-  separator: string,
-  renderReference: (text: string) => string,
-): string {
-  if (!Array.isArray(value)) {
-    return "";
-  }
-  return value
-    .map((element) => renderSlackRichTextElement(element, renderReference))
-    .filter(Boolean)
-    .join(separator);
 }
 
 function readImageText(block: SlackBlockLike): string | undefined {
@@ -242,10 +168,10 @@ export function renderSlackBlockFallbackText(
       // Inbound references must survive for name resolution; literal text stays escaped
       // so token-shaped text cannot become a native mention. Outbound remains escaped.
       return normalizeOptionalString(
-        renderSlackRichTextElements(
+        renderSlackRichText(
           block.elements,
+          options.nativeReferenceFormat === "plain" ? "native-reference" : "escaped",
           "\n",
-          options.nativeReferenceFormat === "plain" ? (text) => text : escapeSlackMrkdwn,
         ),
       );
     case "header":

--- a/extensions/slack/src/blocks.test.ts
+++ b/extensions/slack/src/blocks.test.ts
@@ -79,6 +79,10 @@ describe("buildSlackBlocksFallbackText", () => {
                   { type: "text", text: "Ada" },
                   { type: "text", text: " " },
                   { type: "user", user_id: "U123" },
+                  {
+                    type: "future_container",
+                    elements: [{ type: "future_leaf", text: " preserved " }],
+                  },
                 ],
               },
             ],
@@ -90,10 +94,10 @@ describe("buildSlackBlocksFallbackText", () => {
     };
 
     expect(renderSlackBlockFallbackText(table, { nativeDataFormat: "plain" })).toBe(
-      ["Name\t42\tNote", "Ada <@U123>\tseven\tA\\tB\\nC\\\\D"].join("\n"),
+      ["Name\t42\tNote", "Ada <@U123> preserved \tseven\tA\\tB\\nC\\\\D"].join("\n"),
     );
     expect(renderSlackBlockFallbackText(table)).toBe(
-      ["Name\t42\tNote", "Ada &lt;@U123&gt;\tseven\tA\\tB\\nC\\\\D"].join("\n"),
+      ["Name\t42\tNote", "Ada &lt;@U123&gt; preserved \tseven\tA\\tB\\nC\\\\D"].join("\n"),
     );
   });
 
@@ -193,6 +197,10 @@ describe("buildSlackBlocksFallbackText", () => {
             },
           ],
         },
+        {
+          type: "future_container",
+          elements: [{ type: "text", text: "hidden-future-text" }],
+        },
       ],
     };
     const richText = renderSlackBlockFallbackText(richTextBlock);
@@ -215,6 +223,7 @@ describe("buildSlackBlocksFallbackText", () => {
     );
     expect(richText).not.toContain("private-block-id");
     expect(richText).not.toContain("private-target");
+    expect(richText).not.toContain("hidden-future-text");
     expect(context).toBe("Updated now Green status");
     expect(context).not.toContain("secret");
   });

--- a/extensions/slack/src/data-table.ts
+++ b/extensions/slack/src/data-table.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
 import { renderSlackMessagePresentationTableFallbackText } from "./presentation-fallback.js";
+import { renderSlackRichText } from "./rich-text.js";
 
 const SLACK_DATA_TABLE_COLUMNS_MAX = 20;
 const SLACK_DATA_TABLE_ROWS_MAX = 100;
@@ -51,72 +52,6 @@ function countCharacters(value: string): number {
   return Array.from(value).length;
 }
 
-function readRichTextLeaf(record: Record<string, unknown>): string {
-  if (record.type === "text" && typeof record.text === "string") {
-    return record.text;
-  }
-  const text = readNonEmptyString(record.text);
-  if (text) {
-    return text;
-  }
-  switch (record.type) {
-    case "link":
-      return readNonEmptyString(record.url) ?? "";
-    case "user": {
-      const userId = readNonEmptyString(record.user_id);
-      return userId ? `<@${userId}>` : "";
-    }
-    case "channel": {
-      const channelId = readNonEmptyString(record.channel_id);
-      return channelId ? `<#${channelId}>` : "";
-    }
-    case "usergroup": {
-      const usergroupId = readNonEmptyString(record.usergroup_id);
-      return usergroupId ? `<!subteam^${usergroupId}>` : "";
-    }
-    case "broadcast": {
-      const range = readNonEmptyString(record.range);
-      return range ? `<!${range}>` : "";
-    }
-    case "emoji": {
-      const name = readNonEmptyString(record.name);
-      return name ? `:${name}:` : "";
-    }
-    case "date":
-      return readNonEmptyString(record.fallback) ?? "";
-    default:
-      return "";
-  }
-}
-
-function readRichTextElements(value: unknown, separator = ""): string {
-  if (!Array.isArray(value)) {
-    return "";
-  }
-  const parts: string[] = [];
-  for (const rawElement of value) {
-    const element = asOptionalRecord(rawElement);
-    if (!element) {
-      continue;
-    }
-    if (Array.isArray(element.elements)) {
-      const rendered = readRichTextElements(
-        element.elements,
-        element.type === "rich_text_list" ? "\n" : "",
-      );
-      if (rendered) {
-        parts.push(rendered);
-      }
-      continue;
-    }
-    const rendered = readRichTextLeaf(element);
-    if (rendered) {
-      parts.push(rendered);
-    }
-  }
-  return parts.join(separator);
-}
-
 function readSlackBasicTableCell(value: unknown): string {
   const cell = asOptionalRecord(value);
   if (!cell) {
@@ -134,7 +69,7 @@ function readSlackBasicTableCell(value: unknown): string {
     }
     return typeof cell.value === "string" ? cell.value : "";
   }
-  return cell.type === "rich_text" ? readRichTextElements(cell.elements, "\n") : "";
+  return cell.type === "rich_text" ? renderSlackRichText(cell.elements, "table", "\n") : "";
 }
 
 function parseSlackBasicTableRows(value: unknown): string[][] | undefined {
@@ -179,7 +114,7 @@ function readSlackDataTableCell(value: unknown, allowRichText: boolean): string 
       : undefined;
   }
   if (allowRichText && cell.type === "rich_text") {
-    return readNonEmptyString(readRichTextElements(cell.elements));
+    return readNonEmptyString(renderSlackRichText(cell.elements, "table"));
   }
   return undefined;
 }

--- a/extensions/slack/src/rich-text.ts
+++ b/extensions/slack/src/rich-text.ts
@@ -1,0 +1,88 @@
+import {
+  asOptionalRecord,
+  normalizeOptionalString,
+  readNonBlankString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
+
+const RICH_TEXT_CONTAINER_TYPES = new Set<unknown>([
+  "rich_text_section",
+  "rich_text_preformatted",
+  "rich_text_quote",
+  "rich_text_list",
+]);
+
+export function renderSlackRichText(
+  value: unknown,
+  mode: "table" | "escaped" | "native-reference",
+  separator = "",
+): string {
+  if (!Array.isArray(value)) {
+    return "";
+  }
+  const table = mode === "table";
+  const read = table ? readNonBlankString : normalizeOptionalString;
+  const literal = table ? (text: string) => text : escapeSlackMrkdwn;
+  const reference = mode === "escaped" ? escapeSlackMrkdwn : (text: string) => text;
+  const formatReference = (raw: unknown, prefix: string, suffix: string) => {
+    const text = read(raw);
+    return text ? reference(`${prefix}${text}${suffix}`) : "";
+  };
+
+  return value
+    .map((rawElement) => {
+      const element = asOptionalRecord(rawElement);
+      if (!element) {
+        return "";
+      }
+
+      // Legacy tables traverse any element container; message fallback accepts only
+      // Slack's named containers. Keep that historical trust boundary mode-owned.
+      if (
+        Array.isArray(element.elements) &&
+        (table || RICH_TEXT_CONTAINER_TYPES.has(element.type))
+      ) {
+        return renderSlackRichText(
+          element.elements,
+          mode,
+          element.type === "rich_text_list" ? "\n" : "",
+        );
+      }
+
+      // Table cells preserve authored whitespace and display text on unknown leaf shapes.
+      if (table) {
+        if (element.type === "text" && typeof element.text === "string") {
+          return element.text;
+        }
+        const text = readNonBlankString(element.text);
+        if (text) {
+          return text;
+        }
+      }
+
+      switch (element.type) {
+        case "text":
+          return typeof element.text === "string" ? literal(element.text) : "";
+        case "link":
+          return literal(read(element.text) ?? read(element.url) ?? "");
+        case "user":
+          return formatReference(element.user_id, "<@", ">");
+        case "channel":
+          return formatReference(element.channel_id, "<#", ">");
+        case "usergroup":
+          return formatReference(element.usergroup_id, "<!subteam^", ">");
+        case "broadcast":
+          return formatReference(element.range, "<!", ">");
+        case "emoji": {
+          const name = read(element.name);
+          return name ? `:${name}:` : "";
+        }
+        case "date":
+          return literal(read(element.fallback) ?? "");
+        default:
+          return "";
+      }
+    })
+    .filter(Boolean)
+    .join(separator);
+}


### PR DESCRIPTION
## What Problem This Solves

Slack block accessibility text and legacy table fallback each walked the same rich-text elements. One private renderer now owns that traversal, with explicit table, escaped, and native-reference modes preserving the intentional differences.

## Why This Change Was Made

Table cells keep authored whitespace and display text from unknown leaf shapes. Message fallback still escapes literals, and native-reference mode preserves generated Slack references without turning literal mention-shaped text into mentions. List separators, unsupported-container handling, and existing public outputs remain unchanged.

## User Impact

No intended behavior change. Production decreases by 51 physical lines (+94/−145), or 39 executable lines after discounting removed type declarations. Two existing fixtures add nine net test lines to protect the intentional unknown-container difference; the required assertion ratchet tightens from two to one. No configuration, dependency, protocol, or storage changes.

## Evidence

All 85 focused tests across four suites pass. A final comparison embeds both frozen original walkers and checks 17,316 generated cases with 69,264 exact outputs and zero mismatches. Original inline baseline harnesses were not retained, so the final reproducible comparison replaces their initial digest-only evidence.

The actual sendMessageSlack flow and installed Slack WebClient 8.0.0 execute through an intercepted fetch boundary. An invalid_blocks response triggers exactly one retry, removes the rejected native data table, retains the legacy table, generated fallback section and controls, preserves request key order and mrkdwn=false, and returns the canonical channel/thread receipt. This proves the sender, SDK serialization and response handling; it does not claim an external Slack message or Gateway run. External workspace acceptance is infeasible without an approved disposable workspace/channel and credentials for this task.

All selected format, type, lint, boundary, dependency, dead-export, and policy checks pass. The final managed Codex high/P2 review is scoped-clean. Its earlier pass misread the existing canonical string-coercion import alias; direct inspection and the fresh review confirmed unchanged trimming behavior. The root reviewer also inspected the installed SDK serialization and rich-text/table type contracts.


Maintainer landing review: The latest 10:14 UTC ClawSweeper review is code-clean, with no before-merge findings or rank-up moves. Exact-head CI 33495699155 is green. Root accepts the private owner refactor under the user-authorized maintainer campaign; normal enforced review rules still apply. Production +94/-145 = -51 physical, -39 executing lines after discounting twelve removed type-declaration lines. Tests +9; assertion ratchet 2 to 1. The transport proof uses actual SDK serialization and an intercepted fetch, not an external Slack workspace. An approved disposable workspace/channel and credentials are unavailable.
