### PR TITLE
perf(web-search): defer bundled provider runtime imports

### DIFF
--- a/src/plugins/web-provider-public-artifacts.ts
+++ b/src/plugins/web-provider-public-artifacts.ts
@@ -84,16 +84,20 @@ function resolveBundledCandidatePluginIds(params: {
 }
 
 function resolveBundledRuntimeCandidatePluginIds(params: {
+  contract: "webSearchProviders" | "webFetchProviders";
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
   onlyPluginIds: readonly string[];
   manifestRecords?: readonly PluginManifestRecord[];
 }): string[] | null {
-  const resolvedConfig = resolveBundledWebFetchResolutionConfig(params).config;
+  const search = params.contract === "webSearchProviders";
+  const resolvedConfig = (
+    search ? resolveBundledWebSearchResolutionConfig : resolveBundledWebFetchResolutionConfig
+  )(params).config;
   const candidates = resolveManifestDeclaredWebProviderCandidates({
-    contract: "webFetchProviders",
-    configKey: "webFetch",
+    contract: params.contract,
+    configKey: search ? "webSearch" : "webFetch",
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
@@ -115,7 +119,7 @@ function resolveBundledRuntimeCandidatePluginIds(params: {
       workspaceDir: params.workspaceDir,
       env: params.env,
       onlyPluginIds: pluginIds,
-      contract: "webFetchProviders",
+      contract: params.contract,
       manifestRecords: candidates.manifestRecords,
     }).map((plugin) => plugin.id),
   );
@@ -205,12 +209,25 @@ export function resolveBundledWebFetchProvidersFromPublicArtifacts(
   });
 }
 
+export function resolveEnabledBundledWebSearchProvidersFromPublicArtifacts(
+  params: BundledWebProviderPublicArtifactParams & { onlyPluginIds: readonly string[] },
+): PluginWebSearchProviderEntry[] | null {
+  const pluginIds = resolveBundledRuntimeCandidatePluginIds({
+    ...params,
+    contract: "webSearchProviders",
+  });
+  return pluginIds
+    ? resolveBundledExplicitWebSearchProvidersFromPublicArtifacts({ onlyPluginIds: pluginIds })
+    : null;
+}
+
 export function resolveBundledRuntimeWebFetchProvidersFromPublicArtifacts(
   params: BundledWebProviderPublicArtifactParams & {
     onlyPluginIds: readonly string[];
   },
 ): PluginWebFetchProviderEntry[] | null {
   const pluginIds = resolveBundledRuntimeCandidatePluginIds({
+    contract: "webFetchProviders",
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,

--- a/src/plugins/web-search-providers.runtime.test.ts
+++ b/src/plugins/web-search-providers.runtime.test.ts
@@ -1,6 +1,8 @@
 /** Covers runtime loading and sorting for plugin web search providers. */
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createWebSearchTestProvider } from "../test-utils/web-provider-runtime.test-helpers.js";
+import * as publicArtifacts from "./web-provider-public-artifacts.explicit.js";
 
 type RegistryModule = typeof import("./registry.js");
 type RuntimeModule = typeof import("./runtime.js");
@@ -34,6 +36,7 @@ let loadInstalledPluginManifestRegistryMock: ReturnType<
 >;
 let setActivePluginRegistry: RuntimeModule["setActivePluginRegistry"];
 let resolvePluginWebSearchProviders: WebSearchProvidersRuntimeModule["resolvePluginWebSearchProviders"];
+let resolveRuntimeWebSearchProviders: WebSearchProvidersRuntimeModule["resolveRuntimeWebSearchProviders"];
 let loadOpenClawPluginsMock: ReturnType<typeof vi.fn>;
 let loaderModule: typeof import("./loader.js");
 let pluginAutoEnableModule: PluginAutoEnableModule;
@@ -320,7 +323,8 @@ describe("resolvePluginWebSearchProviders", () => {
     loaderModule = await import("./loader.js");
     pluginAutoEnableModule = await import("../config/plugin-auto-enable.js");
     ({ resetPluginRuntimeStateForTest, setActivePluginRegistry } = await import("./runtime.js"));
-    ({ resolvePluginWebSearchProviders } = await import("./web-search-providers.runtime.js"));
+    ({ resolvePluginWebSearchProviders, resolveRuntimeWebSearchProviders } =
+      await import("./web-search-providers.runtime.js"));
   });
 
   beforeEach(() => {
@@ -360,6 +364,63 @@ describe("resolvePluginWebSearchProviders", () => {
 
     expectBundledRuntimeProviderKeys(providers);
     expectLoaderCallCount(1);
+  });
+
+  it("loads only the selected runtime when a bundled search tool is created", () => {
+    loadInstalledPluginManifestRegistryMock.mockReturnValue({
+      plugins: [
+        createWebSearchManifestRecord({ id: "brave", providerId: "brave" }),
+        createWebSearchManifestRecord({ id: "google", providerId: "gemini" }),
+      ],
+      diagnostics: [],
+    });
+    vi.spyOn(
+      publicArtifacts,
+      "resolveBundledExplicitWebSearchProvidersFromPublicArtifacts",
+    ).mockReturnValue([
+      createWebSearchTestProvider({
+        pluginId: "brave",
+        id: "brave",
+        credentialPath: "plugins.entries.brave.config.webSearch.apiKey",
+        createTool: () => null,
+      }),
+      createWebSearchTestProvider({
+        pluginId: "google",
+        id: "gemini",
+        credentialPath: "plugins.entries.google.config.webSearch.apiKey",
+        createTool: () => null,
+      }),
+    ]);
+    const config = {
+      plugins: {
+        allow: ["brave", "google"],
+        entries: { brave: { enabled: true }, google: { enabled: true } },
+      },
+    };
+
+    const providers = resolveRuntimeWebSearchProviders(createSnapshotParams({ config }));
+    expect(toRuntimeProviderKeys(providers)).toEqual(["brave:brave", "google:gemini"]);
+    expectLoaderCallCount(0);
+
+    expect(providers[0]?.createTool({ config })?.description).toBe("brave");
+    expectLoaderCallCount(1);
+    expect(
+      requireLastCallFirstArg(loadOpenClawPluginsMock, "loadOpenClawPlugins").onlyPluginIds,
+    ).toEqual(["brave"]);
+  });
+
+  it("does not discover explicitly disabled bundled providers", () => {
+    loadInstalledPluginManifestRegistryMock.mockReturnValue({
+      plugins: [createWebSearchManifestRecord({ id: "brave", providerId: "brave" })],
+      diagnostics: [],
+    });
+    const providers = resolveRuntimeWebSearchProviders({
+      config: { plugins: { entries: { brave: { enabled: false } } } },
+      onlyPluginIds: ["brave"],
+    });
+
+    expect(providers).toEqual([]);
+    expectLoaderCallCount(0);
   });
 
   it("loads manifest-declared web-search providers in setup mode", () => {

--- a/src/plugins/web-search-providers.runtime.ts
+++ b/src/plugins/web-search-providers.runtime.ts
@@ -3,7 +3,10 @@ import { loadOpenClawPlugins } from "./loader.js";
 import type { PluginLoadOptions } from "./loader.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginWebSearchProviderEntry } from "./types.js";
-import { resolveBundledWebSearchProvidersFromPublicArtifacts } from "./web-provider-public-artifacts.js";
+import {
+  resolveBundledWebSearchProvidersFromPublicArtifacts,
+  resolveEnabledBundledWebSearchProvidersFromPublicArtifacts,
+} from "./web-provider-public-artifacts.js";
 import {
   mapRegistryProviders,
   resolveManifestDeclaredWebProviderCandidatePluginIds,
@@ -45,6 +48,32 @@ function mapRegistryWebSearchProviders(params: {
   });
 }
 
+const providerResolution = {
+  resolveBundledResolutionConfig: resolveBundledWebSearchResolutionConfig,
+  resolveCandidatePluginIds: resolveWebSearchCandidatePluginIds,
+  mapRegistryProviders: mapRegistryWebSearchProviders,
+};
+
+function resolveLazyBundledWebSearchProviders(
+  params: Parameters<typeof resolveEnabledBundledWebSearchProvidersFromPublicArtifacts>[0],
+): PluginWebSearchProviderEntry[] | null {
+  const providers = resolveEnabledBundledWebSearchProvidersFromPublicArtifacts(params);
+  return (
+    providers?.map((provider) => {
+      const lazyProvider = Object.assign({}, provider);
+      lazyProvider.createTool = (context) => {
+        // Public descriptors can have setup-only factories; execution belongs to the scoped registry.
+        const runtime = resolvePluginWebProviders(
+          { ...params, onlyPluginIds: [provider.pluginId] },
+          providerResolution,
+        ).find((entry) => entry.pluginId === provider.pluginId && entry.id === provider.id);
+        return runtime?.createTool(context) ?? null;
+      };
+      return lazyProvider;
+    }) ?? null
+  );
+}
+
 export function resolvePluginWebSearchProviders(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
@@ -57,9 +86,7 @@ export function resolvePluginWebSearchProviders(params: {
   manifestRecords?: readonly PluginManifestRecord[];
 }): PluginWebSearchProviderEntry[] {
   return resolvePluginWebProviders(params, {
-    resolveBundledResolutionConfig: resolveBundledWebSearchResolutionConfig,
-    resolveCandidatePluginIds: resolveWebSearchCandidatePluginIds,
-    mapRegistryProviders: mapRegistryWebSearchProviders,
+    ...providerResolution,
     resolveBundledPublicArtifactProviders: resolveBundledWebSearchProvidersFromPublicArtifacts,
   });
 }
@@ -73,8 +100,7 @@ export function resolveRuntimeWebSearchProviders(params: {
   manifestRecords?: readonly PluginManifestRecord[];
 }): PluginWebSearchProviderEntry[] {
   return resolvePluginWebProviders(params, {
-    resolveBundledResolutionConfig: resolveBundledWebSearchResolutionConfig,
-    resolveCandidatePluginIds: resolveWebSearchCandidatePluginIds,
-    mapRegistryProviders: mapRegistryWebSearchProviders,
+    ...providerResolution,
+    resolveBundledRuntimeArtifactProviders: resolveLazyBundledWebSearchProviders,
   });
 }

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -235,66 +235,6 @@ function resolveRuntimePreferredWebSearchProviderId(params: {
     : undefined;
 }
 
-function resolveExplicitWebSearchProviderId(params: {
-  search?: WebSearchConfig;
-  runtimeWebSearch?: RuntimeWebSearchMetadata;
-  providerId?: string;
-  includeRuntimeSelection?: boolean;
-}): string | undefined {
-  const callerProviderId = normalizeOptionalLowercaseString(params.providerId);
-  if (callerProviderId) {
-    return callerProviderId;
-  }
-
-  if (params.includeRuntimeSelection && params.runtimeWebSearch?.providerSource === "configured") {
-    const runtimeProviderId = normalizeOptionalLowercaseString(
-      params.runtimeWebSearch.selectedProvider ?? params.runtimeWebSearch.providerConfigured,
-    );
-    if (runtimeProviderId) {
-      return runtimeProviderId;
-    }
-  }
-
-  const configuredProviderId =
-    params.search && "provider" in params.search
-      ? normalizeOptionalLowercaseString(params.search.provider)
-      : undefined;
-  if (configuredProviderId) {
-    return configuredProviderId;
-  }
-  return undefined;
-}
-
-function resolveExplicitWebSearchProviderPluginIds(params: {
-  config?: OpenClawConfig;
-  search?: WebSearchConfig;
-  runtimeWebSearch?: RuntimeWebSearchMetadata;
-  providerId?: string;
-  includeRuntimeSelection?: boolean;
-}): readonly string[] | undefined {
-  const providerId = resolveExplicitWebSearchProviderId(params);
-  if (!providerId) {
-    return undefined;
-  }
-  const ownerPluginId = resolveManifestContractOwnerPluginId({
-    config: params.config,
-    contract: "webSearchProviders",
-    value: providerId,
-  });
-  return ownerPluginId ? [ownerPluginId] : undefined;
-}
-
-function resolveWebSearchProviderLoadScope(params: {
-  config?: OpenClawConfig;
-  search?: WebSearchConfig;
-  runtimeWebSearch?: RuntimeWebSearchMetadata;
-  providerId?: string;
-  includeRuntimeSelection?: boolean;
-}): { onlyPluginIds?: readonly string[] } {
-  const onlyPluginIds = resolveExplicitWebSearchProviderPluginIds(params);
-  return onlyPluginIds ? { onlyPluginIds } : {};
-}
-
 type WebSearchRequestContext = {
   config?: OpenClawConfig;
   search?: WebSearchConfig;
@@ -325,23 +265,31 @@ function loadSortedWebSearchProviders(
     preferRuntimeProviders?: boolean;
   },
 ): PluginWebSearchProviderEntry[] {
-  const loadScope = resolveWebSearchProviderLoadScope({
-    config: params.config,
-    search: params.search,
-    runtimeWebSearch: params.runtimeWebSearch,
-    providerId: params.providerId,
-    includeRuntimeSelection: Boolean(params.preferRuntimeProviders),
-  });
+  const runtimeProviderId =
+    params.preferRuntimeProviders && params.runtimeWebSearch?.providerSource === "configured"
+      ? normalizeOptionalLowercaseString(
+          params.runtimeWebSearch.selectedProvider ?? params.runtimeWebSearch.providerConfigured,
+        )
+      : undefined;
+  const providerId =
+    normalizeOptionalLowercaseString(params.providerId) ??
+    runtimeProviderId ??
+    normalizeOptionalLowercaseString(params.search?.provider);
+  const pluginId = providerId
+    ? resolveManifestContractOwnerPluginId({
+        config: params.config,
+        contract: "webSearchProviders",
+        value: providerId,
+      })
+    : undefined;
+  const resolveProviders = params.preferRuntimeProviders
+    ? resolveRuntimeWebSearchProviders
+    : resolvePluginWebSearchProviders;
   return sortWebSearchProvidersForAutoDetect(
-    params.preferRuntimeProviders
-      ? resolveRuntimeWebSearchProviders({
-          config: params.config,
-          ...loadScope,
-        })
-      : resolvePluginWebSearchProviders({
-          config: params.config,
-          ...loadScope,
-        }),
+    resolveProviders({
+      config: params.config,
+      ...(pluginId ? { onlyPluginIds: [pluginId] } : {}),
+    }),
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Managed web-search discovery loads every eligible bundled provider runtime before it knows whether any provider can serve the request. A fresh built process with no configured provider imports 15 runtime plugins just to return the existing unavailable-provider error.

## Why This Change Was Made

Use the existing shared resolver's runtime-artifact hook to enumerate enabled bundled search descriptors from their light public artifacts. Each descriptor creates its tool through the canonical resolver scoped to that descriptor's owner. This preserves setup-only public factories, active-registry compatibility checks, plugin activation, and external-plugin fallback behavior. Search now shares the enabled-artifact selection owner already used by web fetch.

The provider-scope helpers are folded into their one caller, deleting repeated forwarding and selection branches. Production +78/-87 (net -9); tests +62/-1 (net +61). There are no new configuration options, caches, dependencies, or persistence changes.

## User Impact

Bundled provider inventory and unavailable-provider paths avoid loading unrelated executable plugins. A selected provider still executes through its runtime registration. Explicit selection, auto-detection order, credentials and SecretRefs, provider fallback, cancellation, disabled plugin entries, and mixed external installations retain their existing contracts.

## Evidence

- A three-sample, fresh-process comparison used the same built bundle, restoring the previous eager resolver in the baseline process only. The unavailable-provider result was identical. Runtime imports fell from 15 to 0, median post-GC heap growth from 166,442,496 to 18,785,216 bytes, RSS growth from 675,217,408 to 19,398,656 bytes, and discovery time from 3,460.83 to 168.04 ms. These are cold discovery measurements, not whole-Gateway or model-latency guarantees.
- A source probe enumerated providers without imports, then created a Brave tool and imported Brave alone. Explicit plugin disablement and the existing bundled global-enable compatibility behavior were preserved. Separate built entrypoint memory profiles completed for Brave and XAI.
- All 86 tests in the runtime, shared resolver, public artifact, explicit-fast-path and fallback suites pass. The new lazy-loading regression failed against the old code. Existing cases cover active registries, credentials and SecretRefs, auto-detection, explicit and unknown selections, fallback, cancellation, alias ownership and external artifact resolution.
- The rebuilt isolated Gateway used a real OpenAI API key and configured DuckDuckGo for managed search. A CodeMode turn executed web_search and web_fetch, returned the correct Node Buffer documentation answer, and recorded three tool calls with zero failures in 4.464 s.
- Full build and the complete required changed-check plan passed, including core/test typechecks, lint, dead-export checks and runtime guards. Fresh Codex autoreview is scoped-clean at the required priority; manual owner and sibling review preserved the shared resolver's activation and registry checks.
