### PR TITLE
test: isolate static provider catalog assertions

### DIFF
--- a/extensions/deepseek/index.test.ts
+++ b/extensions/deepseek/index.test.ts
@@ -188,7 +188,7 @@ describe("deepseek provider plugin", () => {
 
   it("builds the static DeepSeek model catalog", async () => {
     const provider = await registerSingleProviderPlugin(deepseekPlugin);
-    const catalogProvider = await runSingleProviderCatalog(provider);
+    const catalogProvider = await runSingleProviderCatalog({ catalog: provider.staticCatalog });
 
     expect(catalogProvider.api).toBe("openai-completions");
     expect(catalogProvider.baseUrl).toBe("https://api.deepseek.com");

--- a/extensions/fireworks/index.test.ts
+++ b/extensions/fireworks/index.test.ts
@@ -55,9 +55,9 @@ describe("fireworks provider plugin", () => {
     expect(resolved.method.id).toBe("api-key");
   });
 
-  it("builds the Fireworks catalog", async () => {
+  it("builds the static Fireworks catalog", async () => {
     const provider = await registerSingleProviderPlugin(fireworksPlugin);
-    const catalogProvider = await runSingleProviderCatalog(provider);
+    const catalogProvider = await runSingleProviderCatalog({ catalog: provider.staticCatalog });
 
     expect(catalogProvider.api).toBe("openai-completions");
     expect(catalogProvider.baseUrl).toBe(FIREWORKS_BASE_URL);

--- a/extensions/qianfan/index.test.ts
+++ b/extensions/qianfan/index.test.ts
@@ -42,7 +42,7 @@ describe("qianfan provider plugin", () => {
 
   it("builds the static Qianfan model catalog", async () => {
     const provider = await registerSingleProviderPlugin(qianfanPlugin);
-    const catalogProvider = await runSingleProviderCatalog(provider);
+    const catalogProvider = await runSingleProviderCatalog({ catalog: provider.staticCatalog });
 
     expect(catalogProvider.api).toBe("openai-completions");
     expect(catalogProvider.baseUrl).toBe("https://qianfan.baidubce.com/v2");

--- a/extensions/tencent/index.test.ts
+++ b/extensions/tencent/index.test.ts
@@ -133,7 +133,7 @@ describe("tencent provider plugin", () => {
 
   it("builds the static Tencent TokenHub model catalog with reasoning flags", async () => {
     const provider = await getTokenHubProvider();
-    const catalogProvider = await runSingleProviderCatalog(provider);
+    const catalogProvider = await runSingleProviderCatalog({ catalog: provider.staticCatalog });
 
     expect(catalogProvider.api).toBe("openai-completions");
     expect(catalogProvider.baseUrl).toBe("https://tokenhub.tencentmaas.com/v1");
@@ -165,7 +165,7 @@ describe("tencent provider plugin", () => {
 
   it("builds the static Tencent TokenPlan model catalog with reasoning flags", async () => {
     const provider = await getTokenPlanProvider();
-    const catalogProvider = await runSingleProviderCatalog(provider);
+    const catalogProvider = await runSingleProviderCatalog({ catalog: provider.staticCatalog });
 
     expect(catalogProvider.api).toBe("openai-completions");
     expect(catalogProvider.baseUrl).toBe("https://api.lkeap.cloud.tencent.com/plan/v3");

--- a/extensions/xiaomi/index.test.ts
+++ b/extensions/xiaomi/index.test.ts
@@ -8,6 +8,7 @@ import {
   type RegisteredProviderCollections,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { buildOpenAICompletionsParams } from "openclaw/plugin-sdk/provider-transport-runtime";
+import * as ssrfRuntime from "openclaw/plugin-sdk/ssrf-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
 import xiaomiPlugin from "./index.js";
@@ -256,7 +257,7 @@ describe("xiaomi provider plugin", () => {
 
   it("builds the static Xiaomi model catalog with reasoning flags", async () => {
     const provider = await getXiaomiProvider();
-    const catalogProvider = await runSingleProviderCatalog(provider);
+    const catalogProvider = await runSingleProviderCatalog({ catalog: provider.staticCatalog });
 
     expect(catalogProvider.api).toBe("openai-completions");
     expect(catalogProvider.baseUrl).toBe("https://api.xiaomimimo.com/v1");
@@ -273,54 +274,74 @@ describe("xiaomi provider plugin", () => {
   });
 
   it("exposes Token Plan v2.5 catalog rows only after a provider config selects a region", async () => {
-    const provider = await getXiaomiTokenPlanProvider();
+    const response = Response.json({ data: [] });
+    const release = vi.fn(async () => undefined);
+    const guardedFetch = vi.spyOn(ssrfRuntime, "fetchWithSsrFGuard").mockResolvedValue({
+      response,
+      finalUrl: "https://token-plan-cn.xiaomimimo.com/v1/models",
+      release,
+    });
 
-    const missingConfig = await provider.catalog?.run({
-      config: {},
-      env: {},
-      resolveProviderApiKey: () => ({ apiKey: "tp-test" }),
-      resolveProviderAuth: () => ({
-        apiKey: "tp-test",
-        mode: "api_key",
-        source: "env",
-      }),
-    } as never);
-    expect(missingConfig).toBeNull();
+    try {
+      const provider = await getXiaomiTokenPlanProvider();
 
-    const configured = await provider.catalog?.run({
-      config: {
-        models: {
-          providers: {
-            "xiaomi-token-plan": {
-              baseUrl: "https://token-plan-cn.xiaomimimo.com/v1",
+      const missingConfig = await provider.catalog?.run({
+        config: {},
+        env: {},
+        resolveProviderApiKey: () => ({ apiKey: "tp-test" }),
+        resolveProviderAuth: () => ({
+          apiKey: "tp-test",
+          mode: "api_key",
+          source: "env",
+        }),
+      } as never);
+      expect(missingConfig).toBeNull();
+      expect(guardedFetch).not.toHaveBeenCalled();
+
+      const configured = await provider.catalog?.run({
+        config: {
+          models: {
+            providers: {
+              "xiaomi-token-plan": {
+                baseUrl: "https://token-plan-cn.xiaomimimo.com/v1",
+              },
             },
           },
         },
-      },
-      env: {},
-      resolveProviderApiKey: () => ({ apiKey: "tp-test" }),
-      resolveProviderAuth: () => ({
-        apiKey: "tp-test",
-        mode: "api_key",
-        source: "profile",
-        profileId: "xiaomi-token-plan:default",
-      }),
-    } as never);
-    if (!configured || !("provider" in configured)) {
-      throw new Error("expected configured Xiaomi Token Plan catalog");
-    }
-    expect(configured.provider.baseUrl).toBe("https://token-plan-cn.xiaomimimo.com/v1");
-    expect(configured.provider.api).toBe("openai-completions");
-    expect(configured.provider.models?.map((model) => model.id)).toEqual([
-      "mimo-v2.5-pro",
-      "mimo-v2.5",
-    ]);
-    expect(configured.provider.models?.find((model) => model.id === "mimo-v2.5")?.input).toEqual([
-      "text",
-      "image",
-    ]);
-    for (const model of configured.provider.models ?? []) {
-      expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+        env: {},
+        resolveProviderApiKey: () => ({ apiKey: "tp-test" }),
+        resolveProviderAuth: () => ({
+          apiKey: "tp-test",
+          mode: "api_key",
+          source: "profile",
+          profileId: "xiaomi-token-plan:default",
+        }),
+      } as never);
+      if (!configured || !("provider" in configured)) {
+        throw new Error("expected configured Xiaomi Token Plan catalog");
+      }
+      expect(configured.provider.baseUrl).toBe("https://token-plan-cn.xiaomimimo.com/v1");
+      expect(configured.provider.api).toBe("openai-completions");
+      expect(configured.provider.models?.map((model) => model.id)).toEqual([
+        "mimo-v2.5-pro",
+        "mimo-v2.5",
+      ]);
+      expect(configured.provider.models?.find((model) => model.id === "mimo-v2.5")?.input).toEqual([
+        "text",
+        "image",
+      ]);
+      for (const model of configured.provider.models ?? []) {
+        expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+      }
+      expect(guardedFetch).toHaveBeenCalledOnce();
+      const request = guardedFetch.mock.calls[0]?.[0];
+      expect(request?.url).toBe("https://token-plan-cn.xiaomimimo.com/v1/models");
+      expect(request?.init?.method ?? "GET").toBe("GET");
+      expect(new Headers(request?.init?.headers).get("authorization")).toBe("Bearer tp-test");
+      expect(response.bodyUsed).toBe(true);
+      expect(release).toHaveBeenCalledOnce();
+    } finally {
+      guardedFetch.mockRestore();
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Provider tests that assert bundled model data currently call network-capable discovery hooks. Six static-catalog assertions across Qianfan, DeepSeek, Fireworks, Tencent and Xiaomi can therefore depend on transport despite testing local metadata.

## Why This Change Was Made

Use each provider’s existing static-catalog hook for those assertions. Keep Xiaomi’s separate regional discovery case on the live hook, with a scoped synthetic response and checks for the configured request, response consumption and release. Existing model, cost, default-selection and registration assertions remain.

## User Impact

No production behavior changes. All 55 owner cases and 17 SDK cases are retained; production delta is zero and tests are net +21 lines. Arcee and Baseten’s live-discovery tests remain unchanged.

## Evidence

On Linux with Node 24.19.0 at base 6e9b0851434ee27a9920298aa1db154350cfedab, transport controls reproduced all six unintended static requests. The candidate passed all 55 owner cases, including Xiaomi’s regional request and cleanup checks. The ordinary owner/SDK group then passed all 72 cases without the diagnostic instrumentation. The configured test machine stopped normally.

This verifies static-catalog and synthetic transport behavior; it is not live vendor API validation.

Managed Codex review completed with no accepted P0 findings. The normal changed check passed all 19 checks, including extension-test typechecking and final lint with zero warnings or errors. Its one-shot test machine stopped and its temporary checkout was removed.
