### PR TITLE
fix(ci): settle draft setup before measuring composer renders

### DIFF
--- a/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
+++ b/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
@@ -8,6 +8,7 @@ import {
   requireRecord,
   requireString,
 } from "./chat-flow.test-support.ts";
+import { waitForCommittedComposerDraft } from "./settle.test-support.ts";
 
 // Durable runtime budgets for the chat streaming surface. Byte budgets
 // (scripts/check-control-ui-performance.mts) cannot see rendering work, so
@@ -629,13 +630,18 @@ suite.define(() => {
         await page.locator(".chat-thread-inner").getByText("LONG-TAIL-SENTINEL").waitFor();
 
         const composer = page.locator(".agent-chat__composer-combobox textarea");
+        const scopeKey = "chat:v3:agent:main:main\u0000agent:main";
         await composer.fill("seed");
         await page.getByRole("button", { name: "Send message" }).waitFor();
+        // The first saved draft notifies presence subscribers. Drain that transition
+        // before measuring edits to an already-present draft.
+        await waitForCommittedComposerDraft(page, scopeKey, "seed", 0);
         await installRenderProbe(page);
         await resetRenderProbe(page);
 
         const suffix = " ordinary typing without commands";
         await composer.pressSequentially(suffix);
+        await waitForCommittedComposerDraft(page, scopeKey, `seed${suffix}`, 0);
         expect(await composer.inputValue()).toBe(`seed${suffix}`);
         const probe = await readRenderProbe(page);
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a flaky CI performance check where the first draft's asynchronous save can overlap the interval intended to measure ordinary typing. The composer budget failed with two host updates against its limit of one in [run 33492093127](https://github.com/openclaw/openclaw/actions/runs/33492093127); the unchanged-head retry passed.

## Why This Change Was Made

Wait for the seeded draft's committed browser-store record before installing the render probe, using the existing helper that also crosses a browser render boundary. Keep that same probe active until the typed draft commits, so asynchronous invalidations remain covered. The initial save publishes draft presence to shared subscribers; later content-only saves do not.

This preserves real keyboard input, the long transcript, all assertions, and the one-host-update budget. It adds no sleeps, retries, larger timeouts, or production changes. The failed run did not retain requestUpdate call stacks, so its exact two callers are unknown; the precondition race is verified from the persistence and subscription owners.

## User Impact

No product behavior changes. CI measures steady-state composer work after setup has completed and includes the asynchronous completion of the measured edit.

## Evidence

- Source inspection: composer persistence publishes the presence transition synchronously before requesting durable storage; the existing committed-draft helper awaits the exact IndexedDB record and a browser frame.
- Targeted formatting and lint pass; `git diff --check` passes.
- Fresh managed Codex review: no accepted or actionable findings at the required priority.
- Exact-head browser proof in the native PR checkout: the repaired composer case passed (1/1), then the complete runtime-budget file passed (5/5, 19.588 seconds of test execution). Its unchanged composer assertion covers the complete edit through durable persistence; the other streaming, heap, and idle budgets also passed.
- The native checkout received one frozen dependency install after the linked checkout's stale dependencies prevented browser startup. No tracked dependency files changed. Hosted CI is [run 33494931388](https://github.com/openclaw/openclaw/actions/runs/33494931388).
- Production/tooling LOC: +0/-0. Existing test: +6/-0; no test cases or assertions removed.

Related: #135039, #133465.
