### PR TITLE
fix(ci): report full release decisions sooner

### DIFF
--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -119,14 +119,18 @@ passes the Validation SHA as both the candidate ref and `expected_sha`, and
 deletes the temporary ref after successful validation and strict evidence
 verification. The helper reads Release Decision artifacts while the parent is
 active so blockers can surface while Diagnostic Drain collects failures. It
-waits 15 minutes between run-discovery attempts and between parent polling
-iterations. One parent iteration may perform status, decision-artifact, and
-progress-job reads together; the delay limits repeated polling cycles rather
-than spacing every GitHub call. Run discovery makes one immediate check and one
-delayed retry before failing. A not-yet-created artifact remains an unavailable
-polling result; terminal handling and temporary-ref cleanup wait for the parent
-to complete with a conclusion. Failed validations retain both refs for reruns
-and diagnosis. The
+checks parent status and exact-attempt decision metadata every two minutes,
+with full progress-job reads no more often than every 15 minutes. Each regular
+iteration makes at most two metadata requests; it downloads the decision only
+after its named artifact appears, retrying unavailable downloads on subsequent
+iterations. A validated passing decision is retained only for that attempt.
+Parent completion also triggers a decision download when none has been validated,
+so metadata lag cannot skip terminal handling. Discovery makes one immediate
+check and at most three retries, waiting 30, 60, then 120 seconds between checks.
+All reads use the normal cache-aware GitHub route; cache and request latency can
+add to these intervals. The helper retains its 12-hour wait deadline. Successful
+temporary-ref cleanup still requires parent completion and strict evidence
+verification. Failed validations retain both refs for reruns and diagnosis. The
 Validation SHA equals the Code SHA for product validation or the Release SHA
 for changelog-only validation; it is not a third release identity. The workflow
 rejects malformed or mismatched expected SHAs before child dispatch. Every

--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -32,8 +32,9 @@ const RELEASE_EVIDENCE_VERIFIER_PATHS = [
 ];
 const GH_READ_TIMEOUT_MS = 60_000;
 export const FULL_RELEASE_WAIT_TIMEOUT_MINUTES = 720;
-export const FULL_RELEASE_GITHUB_POLL_INTERVAL_MS = 15 * 60_000;
-const FULL_RELEASE_RUN_DISCOVERY_ATTEMPTS = 2;
+export const FULL_RELEASE_GITHUB_POLL_INTERVAL_MS = 2 * 60_000;
+const FULL_RELEASE_PROGRESS_INTERVAL_MS = 15 * 60_000;
+const FULL_RELEASE_RUN_DISCOVERY_DELAYS_MS = [30_000, 60_000, 120_000];
 const RELEASE_DECISION_FILE = "full-release-decision.json";
 const GH_READ_OPTIONS = {
   encoding: "utf8",
@@ -678,12 +679,41 @@ export function tryReadReleaseDecision(
   }
 }
 
+function releaseDecisionAvailable(parentRunId: string, parentRunAttempt: number) {
+  const artifactName = `full-release-decision-${parentRunId}-${parentRunAttempt}`;
+  try {
+    const response: unknown = JSON.parse(
+      execGhRead(
+        [
+          "api",
+          `repos/openclaw/openclaw/actions/runs/${parentRunId}/artifacts?per_page=100&name=${artifactName}`,
+        ],
+        { ...GH_READ_OPTIONS, stdio: ["ignore", "pipe", "pipe"] },
+      ),
+    );
+    if (!isJsonRecord(response) || !Array.isArray(response.artifacts)) {
+      throw new Error(`Full Release Validation run ${parentRunId} returned invalid artifacts`);
+    }
+    return response.artifacts.some(
+      (artifact) =>
+        isJsonRecord(artifact) && artifact.name === artifactName && artifact.expired === false,
+    );
+  } catch (error) {
+    if (classifyReleaseGhTransportError(error) !== "transient") {
+      throw error;
+    }
+    console.warn(`Release Decision metadata unavailable this poll; retrying: ${String(error)}`);
+    return false;
+  }
+}
+
 function waitForWorkflowRun(parentRunId: string, workflowSha: string) {
   let lastSummary = "";
   let consecutiveErrors = 0;
   const startedAt = Date.now();
   const deadline = startedAt + FULL_RELEASE_WAIT_TIMEOUT_MINUTES * 60_000;
-  let nextProgressAt = startedAt + FULL_RELEASE_GITHUB_POLL_INTERVAL_MS;
+  let nextProgressAt = startedAt + FULL_RELEASE_PROGRESS_INTERVAL_MS;
+  let decision: { attempt: number; state: "unavailable" | "ready" | "passed" } | undefined;
   while (Date.now() < deadline) {
     let suite: Record<string, unknown> | undefined;
     try {
@@ -706,15 +736,30 @@ function waitForWorkflowRun(parentRunId: string, workflowSha: string) {
       lastSummary = summary;
     }
     if (suite) {
-      const releaseDecision = tryReadReleaseDecision(
-        parentRunId,
-        requiredPositiveInteger(suite.run_attempt, "parent run attempt"),
-        workflowSha,
-      );
-      if (releaseDecision && releaseDecisionStopsForeground(releaseDecision.state)) {
-        throw new Error(
-          `${formatReleaseStateOutcome(releaseDecision)}\nhttps://github.com/openclaw/openclaw/actions/runs/${parentRunId}`,
-        );
+      const attempt = requiredPositiveInteger(suite.run_attempt, "parent run attempt");
+      if (decision?.attempt !== attempt) {
+        decision = { attempt, state: "unavailable" };
+      }
+      // Metadata is only a readiness hint. Once advertised, keep trying the
+      // authoritative download across status regressions until this attempt validates.
+      if (
+        decision.state === "unavailable" &&
+        (suite.status === "completed" || releaseDecisionAvailable(parentRunId, attempt))
+      ) {
+        decision.state = "ready";
+      }
+      if (decision.state === "ready") {
+        const releaseDecision = tryReadReleaseDecision(parentRunId, attempt, workflowSha);
+        if (releaseDecision && releaseDecisionStopsForeground(releaseDecision.state)) {
+          throw new Error(
+            `${formatReleaseStateOutcome(releaseDecision)}\nhttps://github.com/openclaw/openclaw/actions/runs/${parentRunId}`,
+          );
+        }
+        // The workflow uploads one immutable decision per attempt; final success
+        // still requires the parent's terminal conclusion and strict evidence verifier.
+        if (releaseDecision?.state === "passed") {
+          decision.state = "passed";
+        }
       }
     }
     if (suite?.status === "completed" && stringValue(suite.conclusion)) {
@@ -741,7 +786,7 @@ function waitForWorkflowRun(parentRunId: string, workflowSha: string) {
           `Parent run progress query failed: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
-      nextProgressAt += FULL_RELEASE_GITHUB_POLL_INTERVAL_MS;
+      nextProgressAt = now + FULL_RELEASE_PROGRESS_INTERVAL_MS;
     }
     const remainingMs = deadline - Date.now();
     if (remainingMs <= 0) {
@@ -980,17 +1025,17 @@ function main() {
     }
     parentRunId = collectRunId(dispatchOutput);
     if (!parentRunId && !args.dryRun) {
-      for (let attempt = 0; attempt < FULL_RELEASE_RUN_DISCOVERY_ATTEMPTS; attempt += 1) {
+      for (let attempt = 0; attempt <= FULL_RELEASE_RUN_DISCOVERY_DELAYS_MS.length; attempt += 1) {
         parentRunId = findLatestRunId(branch, workflowSha);
         if (parentRunId) {
           break;
         }
-        if (attempt + 1 < FULL_RELEASE_RUN_DISCOVERY_ATTEMPTS) {
+        if (attempt < FULL_RELEASE_RUN_DISCOVERY_DELAYS_MS.length) {
           Atomics.wait(
             new Int32Array(new SharedArrayBuffer(4)),
             0,
             0,
-            FULL_RELEASE_GITHUB_POLL_INTERVAL_MS,
+            FULL_RELEASE_RUN_DISCOVERY_DELAYS_MS[attempt],
           );
         }
       }

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -56,7 +56,16 @@ function runGit(cwd: string, args: string[]): string {
 function createDispatchFixture(
   options: {
     dispatchReturnsRunUrl?: boolean;
-    parentRunStates?: Array<{ conclusion: string | null; status: string }>;
+    parentRunStates?: Array<{
+      conclusion: string | null;
+      status: string;
+      attempt?: number;
+      artifactReady?: boolean;
+      artifacts?: unknown;
+      metadataError?: string;
+      decisionState?: string;
+      decisionAttempt?: number;
+    }>;
     runDiscoveryMisses?: number;
     workflowSource?: string;
   } = {},
@@ -83,9 +92,13 @@ function createDispatchFixture(
     preloadPath,
     `import { appendFileSync } from "node:fs";
 const wait = Atomics.wait;
+const now = Date.now;
+let elapsed = 0;
+Date.now = () => now() + elapsed;
 Atomics.wait = (array, index, value, timeout) => {
   if (timeout === undefined) return wait(array, index, value);
   appendFileSync(process.env.MOCK_WAIT_CALLS, String(timeout) + "\\n");
+  elapsed += timeout;
   return "timed-out";
 };
 `,
@@ -202,9 +215,36 @@ if (args[0] === "workflow" && args[1] === "run") {
   const index = Number(fs.readFileSync(parentRunIndexPath, "utf8"));
   const state = parentRunStates[Math.min(index, parentRunStates.length - 1)];
   fs.writeFileSync(parentRunIndexPath, String(index + 1));
-  console.log(JSON.stringify({ ...state, head_sha: process.env.MOCK_WORKFLOW_SHA, run_attempt: 1 }));
+  console.log(JSON.stringify({ ...state, head_sha: process.env.MOCK_WORKFLOW_SHA, run_attempt: state.attempt ?? 1 }));
+} else if (args[0] === "api" && args.at(-1).includes("/artifacts?")) {
+  const index = Number(fs.readFileSync(parentRunIndexPath, "utf8")) - 1;
+  const state = parentRunStates[index];
+  if (state.metadataError) {
+    console.error(state.metadataError);
+    process.exit(1);
+  }
+  console.log(JSON.stringify({ artifacts: state.artifacts ?? (state.artifactReady ? [{
+    name: "full-release-decision-123-" + (state.attempt ?? 1), expired: false,
+  }] : []) }));
+} else if (args[0] === "api" && args.at(-1).includes("/jobs?")) {
+  console.log(JSON.stringify({ jobs: [{ name: "Diagnostic Drain", status: "in_progress" }] }));
 } else if (args[0] === "run" && args[1] === "download") {
   const index = Number(fs.readFileSync(parentRunIndexPath, "utf8")) - 1;
+  const state = parentRunStates[index];
+  if (state.decisionState) {
+    const dir = args[args.indexOf("--dir") + 1];
+    fs.writeFileSync(dir + "/full-release-decision.json", JSON.stringify({
+      kind: "openclaw.full-release-decision", mode: "decision", version: 2,
+      parentRunAttempt: state.decisionAttempt ?? state.attempt ?? 1,
+      sourceParentRunAttempt: 1, parentRunId: "123", activeRunIds: ["101"],
+      blockers: [{ child: "normalCi", job: "test", runId: "101" }],
+      cancellation: { cancelledRunIds: [], requested: false }, children: {}, errors: [],
+      executionPlanSha256: "c".repeat(64), releaseProfile: "stable", rerunGroup: "all",
+      state: state.decisionState, targetSha: "b".repeat(40), workflowRef: "main",
+      workflowSha: process.env.MOCK_WORKFLOW_SHA,
+    }));
+    process.exit(0);
+  }
   console.error(parentRunStates[index]?.status === "queued" ? "no artifact matches any of the names or patterns provided" : "no valid artifacts found");
   process.exit(1);
 } else {
@@ -609,7 +649,7 @@ describe("full-release-validation-at-sha", () => {
   it("bounds polling for the exact workflow run", () => {
     const source = readFileSync("scripts/full-release-validation-at-sha.mts", "utf8");
     expect(FULL_RELEASE_WAIT_TIMEOUT_MINUTES).toBe(720);
-    expect(FULL_RELEASE_GITHUB_POLL_INTERVAL_MS).toBe(900_000);
+    expect(FULL_RELEASE_GITHUB_POLL_INTERVAL_MS).toBe(120_000);
     expect(source).toContain("workflowRun.head_sha !== workflowSha");
     expect(source).toContain("return suite;");
     expect(source).toContain("startedAt + FULL_RELEASE_WAIT_TIMEOUT_MINUTES * 60_000");
@@ -623,7 +663,7 @@ describe("full-release-validation-at-sha", () => {
     expect(source).not.toContain("attempt < 480");
   });
 
-  it("waits 15 minutes between run-discovery attempts and parent polling iterations", () => {
+  it("discovers the run promptly and observes completion within two minutes", () => {
     const fixture = createDispatchFixture({
       dispatchReturnsRunUrl: false,
       parentRunStates: [
@@ -635,7 +675,7 @@ describe("full-release-validation-at-sha", () => {
     try {
       const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
       expect(result.status, result.stderr).toBe(0);
-      expect(fixture.readWaits()).toEqual([900_000, 900_000]);
+      expect(fixture.readWaits()).toEqual([30_000, 120_000]);
       const calls = fixture.readCalls(fixture.ghCallsPath);
       expect(calls.filter((args) => args[0] === "run" && args[1] === "list")).toHaveLength(2);
       expect(
@@ -646,18 +686,18 @@ describe("full-release-validation-at-sha", () => {
     }
   });
 
-  it("bounds run discovery to one delayed retry", () => {
+  it("bounds run discovery with backoff through cached registration lag", () => {
     const fixture = createDispatchFixture({
       dispatchReturnsRunUrl: false,
-      runDiscoveryMisses: 2,
+      runDiscoveryMisses: 4,
     });
     try {
       const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("Could not determine Full Release Validation run id.");
-      expect(fixture.readWaits()).toEqual([900_000]);
+      expect(fixture.readWaits()).toEqual([30_000, 60_000, 120_000]);
       const calls = fixture.readCalls(fixture.ghCallsPath);
-      expect(calls.filter((args) => args[0] === "run" && args[1] === "list")).toHaveLength(2);
+      expect(calls.filter((args) => args[0] === "run" && args[1] === "list")).toHaveLength(4);
     } finally {
       fixture.cleanup();
     }
@@ -765,7 +805,7 @@ describe("full-release-validation-at-sha", () => {
   it("bounds GitHub reads without applying a timeout to workflow dispatch", () => {
     const source = readFileSync("scripts/full-release-validation-at-sha.mts", "utf8");
     expect(source).toContain("timeout: GH_READ_TIMEOUT_MS");
-    expect(source.match(/GH_READ_OPTIONS/gu)).toHaveLength(4);
+    expect(source.match(/GH_READ_OPTIONS/gu)).toHaveLength(5);
     expect(source).toContain('const dispatchOutput = run("gh", dispatchArgs');
   });
 
@@ -948,7 +988,7 @@ describe("full-release-validation-at-sha", () => {
   it("retries an absent decision artifact through a parent status regression", () => {
     const fixture = createDispatchFixture({
       parentRunStates: [
-        { conclusion: null, status: "in_progress" },
+        { conclusion: null, status: "in_progress", artifactReady: true },
         { conclusion: null, status: "queued" },
         { conclusion: null, status: "in_progress" },
         { conclusion: "success", status: "completed" },
@@ -994,7 +1034,213 @@ describe("full-release-validation-at-sha", () => {
       expect(
         calls.filter((args) => args[0] === "api" && args[1]?.endsWith("/actions/runs/123")),
       ).toHaveLength(5);
-      expect(calls.filter((args) => args[0] === "run" && args[1] === "download")).toHaveLength(5);
+      expect(calls.filter((args) => args[0] === "run" && args[1] === "download")).toHaveLength(2);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("observes a validated blocker promptly while leaving diagnostic drain and refs intact", () => {
+    const fixture = createDispatchFixture({
+      parentRunStates: [
+        { conclusion: null, status: "in_progress" },
+        {
+          conclusion: null,
+          status: "in_progress",
+          artifactReady: true,
+          decisionState: "blocked_diagnostics_running",
+        },
+      ],
+    });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stderr).toBe(1);
+      expect(result.stderr).toContain("blocked_diagnostics_running");
+      expect(fixture.readWaits()).toEqual([120_000]);
+      const calls = fixture.readCalls(fixture.ghCallsPath);
+      expect(calls.filter((args) => args[0] === "run" && args[1] === "download")).toHaveLength(1);
+      expect(calls.some((args) => args.includes("cancel") || args.includes("watch"))).toBe(false);
+      expect(
+        runGit(fixture.origin, [
+          "for-each-ref",
+          "--format=%(refname)",
+          "refs/heads/release-ci",
+          "refs/heads/validation",
+        ]).split("\n"),
+      ).toHaveLength(2);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("does not redownload a validated decision, and resets readiness for a new attempt", () => {
+    const fixture = createDispatchFixture({
+      parentRunStates: [
+        { conclusion: null, status: "in_progress", artifactReady: true, decisionState: "passed" },
+        { conclusion: null, status: "in_progress", artifactReady: true, decisionState: "passed" },
+        { conclusion: null, status: "queued", attempt: 2 },
+        { conclusion: null, status: "in_progress", attempt: 2, artifactReady: true },
+        {
+          conclusion: null,
+          status: "queued",
+          attempt: 2,
+          decisionState: "blocked_diagnostics_running",
+        },
+      ],
+    });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stderr).toBe(1);
+      expect(result.stderr).toContain("blocked_diagnostics_running");
+      expect(fixture.readWaits()).toEqual([120_000, 120_000, 120_000, 120_000]);
+      const downloads = fixture
+        .readCalls(fixture.ghCallsPath)
+        .filter((args) => args[0] === "run" && args[1] === "download");
+      expect(downloads.map((args) => args[args.indexOf("--name") + 1])).toEqual([
+        "full-release-decision-123-1",
+        "full-release-decision-123-2",
+        "full-release-decision-123-2",
+      ]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("keeps progress reads sparse while checking unpublished decision metadata", () => {
+    const fixture = createDispatchFixture({
+      parentRunStates: [
+        ...Array.from({ length: 10 }, () => ({ conclusion: null, status: "in_progress" })),
+        { conclusion: "success", status: "completed" },
+      ],
+    });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stderr).toBe(0);
+      const calls = fixture.readCalls(fixture.ghCallsPath);
+      expect(calls.filter((args) => args[0] === "run" && args[1] === "download")).toHaveLength(1);
+      expect(calls.filter((args) => args[0] === "api" && args[1]?.includes("/jobs?"))).toHaveLength(
+        1,
+      );
+      expect(
+        calls.filter((args) => args[0] === "api" && args[1]?.includes("/artifacts?")),
+      ).toHaveLength(10);
+      expect(fixture.readWaits()).toEqual(Array(10).fill(120_000));
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it.each([
+    { label: "wrong name", artifacts: [{ name: "full-release-decision-999-1", expired: false }] },
+    { label: "expired", artifacts: [{ name: "full-release-decision-123-1", expired: true }] },
+  ])("does not use $label metadata as a release decision", ({ artifacts }) => {
+    const fixture = createDispatchFixture({
+      parentRunStates: [
+        {
+          conclusion: null,
+          status: "in_progress",
+          artifacts,
+          decisionState: "blocked_diagnostics_running",
+        },
+        { conclusion: "failure", status: "completed", decisionState: "blocked_complete" },
+      ],
+    });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stderr).toBe(1);
+      expect(result.stderr).toContain("blocked_complete");
+      expect(fixture.readWaits()).toEqual([120_000]);
+      const downloads = fixture
+        .readCalls(fixture.ghCallsPath)
+        .filter((args) => args[0] === "run" && args[1] === "download");
+      expect(downloads).toHaveLength(1);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it.each([
+    {
+      label: "permanent denial",
+      metadataError: "HTTP 403: Bad credentials",
+      artifacts: undefined,
+      error: "Bad credentials",
+    },
+    {
+      label: "malformed response",
+      metadataError: undefined,
+      artifacts: {},
+      error: "invalid artifacts",
+    },
+  ])(
+    "stops on $label instead of hiding metadata failures as pending",
+    ({ metadataError, artifacts, error }) => {
+      const fixture = createDispatchFixture({
+        parentRunStates: [{ conclusion: null, status: "in_progress", metadataError, artifacts }],
+      });
+      try {
+        const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+        expect(result.status, result.stderr).toBe(1);
+        expect(result.stderr).toContain(error);
+        expect(fixture.readWaits()).toEqual([]);
+        expect(
+          fixture
+            .readCalls(fixture.ghCallsPath)
+            .some((args) => args[0] === "run" && args[1] === "download"),
+        ).toBe(false);
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  it("recovers a transient metadata failure without downloading an unpublished artifact", () => {
+    const fixture = createDispatchFixture({
+      parentRunStates: [
+        { conclusion: null, status: "in_progress", metadataError: "HTTP 503: Server Error" },
+        { conclusion: "success", status: "completed" },
+      ],
+    });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stderr).toContain("metadata unavailable this poll");
+      expect(fixture.readWaits()).toEqual([120_000]);
+      expect(
+        fixture
+          .readCalls(fixture.ghCallsPath)
+          .filter((args) => args[0] === "run" && args[1] === "download"),
+      ).toHaveLength(1);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("rejects a downloaded decision from another attempt despite ready metadata", () => {
+    const fixture = createDispatchFixture({
+      parentRunStates: [
+        {
+          conclusion: null,
+          status: "in_progress",
+          artifactReady: true,
+          decisionState: "passed",
+          decisionAttempt: 2,
+        },
+      ],
+    });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stderr).toBe(1);
+      expect(result.stderr).toContain("binding is invalid");
+      expect(fixture.readWaits()).toEqual([]);
+      expect(
+        runGit(fixture.origin, [
+          "for-each-ref",
+          "--format=%(refname)",
+          "refs/heads/release-ci",
+          "refs/heads/validation",
+        ]).split("\n"),
+      ).toHaveLength(2);
     } finally {
       fixture.cleanup();
     }


### PR DESCRIPTION
## What Problem This Solves

Full release verification can leave operators waiting up to 15 minutes after a result becomes available. The SHA-pinned helper uses the same delay for parent status, decision downloads, detailed progress, and run discovery.

## Why This Change Was Made

Check parent status and exact-attempt decision metadata every two minutes, while keeping full progress-job reads at least 15 minutes apart. Download decisions only after the named artifact appears, retain validated passing decisions for that attempt, and reset readiness when the attempt changes. Discovery uses bounded 30/60/120-second backoff.

Metadata is only a readiness hint. Downloaded decisions still require the existing identity validation; parent completion and the strict evidence verifier still own success and temporary-ref cleanup. The 12-hour deadline, failure handling, diagnostic drain, and frozen Code/Tooling identities are unchanged. No new configuration or workflow dispatch is added.

## User Impact

Release operators get results sooner without downloading an absent artifact on every observation. This reduces observation delay, not test execution time. Each regular iteration makes at most two metadata requests; cache and network latency remain additional. Application behavior is unchanged.

## Evidence

- Existing CLI fixture reproduced seven intended regressions before the fix (33 passing); all 46 final tests pass.
- Coverage includes prompt discovery, sparse detailed progress, bounded request counts, transient HTTP 503 recovery, permanent denial, malformed/expired metadata, queued status regression, attempt changes, wrong-attempt payload rejection, and retained refs after a blocking decision.
- The actual changed-file gate passed, including script/test typechecks, targeted lint, and guards. Managed Codex review completed scoped-clean at P0 with no findings.
- One read against a completed historical run confirmed GitHub's exact-name artifact filter. No new full release run was dispatched for this change, and the current frozen verification run was left untouched.

The owner is the existing SHA-pinned dispatch helper. The previous coupled polling delay is replaced rather than adding a second watcher. Tooling delta: +61/-16 (net +45), required for readiness tracking and separating metadata from downloads; tests +258/-12, docs +12/-8; application runtime delta zero. Existing generic GitHub watchers do not observe validated Release Decision artifacts while diagnostics continue, so they cannot replace this helper's release contract.
