### PR TITLE
fix(tooling): preserve compiled plugin loading in source Gateways

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -170,9 +170,15 @@ reconcile dependencies before the remote wrapper starts.
 
 ## Core commands
 
-Maintained JavaScript tooling wrappers and root package commands use tsx's
-in-process transform cache. They skip its shared disk cache before the loader
-starts, and child tooling inherits that policy. This cache policy does not clean
+Maintained JavaScript tooling wrappers and root package commands load TypeScript
+through `scripts/tsx.mjs`, using tsx's ESM entry. This preserves native loading of
+compiled ESM plugins and their import-only dependencies, including when loaded
+through `require()`. Source TypeScript imports and tsconfig path aliases remain
+available.
+
+These launchers retain tsx's in-process transform cache and Node's module cache.
+They skip tsx's shared disk cache before the loader starts, and child tooling
+inherits that policy. This cache policy does not clean
 existing temporary directories, Node or Vitest caches, or other global caches. Standalone
 `pnpm ui:build` keeps native startup and applies the same preload to its post-build
 validators; it does not require `TSX_DISABLE_CACHE` in the invoking shell. Raw

--- a/scripts/lib/tsx-cli-shim.mjs
+++ b/scripts/lib/tsx-cli-shim.mjs
@@ -41,7 +41,9 @@ function resolveTsxImport(checkoutRoot) {
   ].filter(Boolean)) {
     try {
       const require = createRequire(path.join(candidateRoot, "package.json"));
-      const importUrl = pathToFileURL(require.resolve("tsx")).href;
+      // Keep compiled ESM native: tsx's CJS hook rewrites its import-only
+      // dependency edges into require() calls with incompatible export conditions.
+      const importUrl = pathToFileURL(require.resolve("tsx/esm")).href;
       const selectedModulesDir =
         candidateRoot === hydratedTsxRoot
           ? path.dirname(candidateRoot)

--- a/test/scripts/direct-run-entrypoints.test-support.ts
+++ b/test/scripts/direct-run-entrypoints.test-support.ts
@@ -1,6 +1,7 @@
 import { copyFileSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { inspect } from "node:util";
 import { runNodeScript } from "../helpers/run-node-script.js";
 
@@ -25,6 +26,51 @@ export const TSX_SHIM_WRAPPERS = [
   "scripts/e2e/kitchen-sink-rpc-walk.mjs",
   "scripts/perf/summarize-cpuprofile.mjs",
 ] as const;
+
+export function writeEsmPluginFixture(fixtureRoot: string) {
+  const pluginRoot = path.join(fixtureRoot, "compiled-plugin");
+  const dependencyRoot = path.join(pluginRoot, "node_modules", "import-only");
+  mkdirSync(dependencyRoot, { recursive: true });
+  writeFileSync(path.join(pluginRoot, "package.json"), JSON.stringify({ type: "module" }));
+  writeFileSync(
+    path.join(dependencyRoot, "package.json"),
+    JSON.stringify({ type: "module", exports: { import: "./index.js" } }),
+  );
+  writeFileSync(path.join(dependencyRoot, "index.js"), 'export const value = "import-only";');
+  const pluginPath = path.join(pluginRoot, "index.js");
+  writeFileSync(
+    pluginPath,
+    `export { value } from "import-only";
+globalThis.pluginEvaluations = (globalThis.pluginEvaluations ?? 0) + 1;
+export const instance = {};
+`,
+  );
+  writeFileSync(
+    path.join(pluginRoot, "loader.cjs"),
+    'module.exports = { load: () => require("./index.js") };',
+  );
+  return `
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { parseBoolean } from "@openclaw/normalization-core/boolean-coercion";
+enum Transformed { Value = "transformed" }
+try {
+const require = createRequire(${JSON.stringify(pathToFileURL(pluginPath).href)});
+const loader = require("./loader.cjs");
+const first = loader.load();
+const imported = await import(${JSON.stringify(pathToFileURL(pluginPath).href)});
+assert.strictEqual(loader.load(), first);
+assert.strictEqual(imported.instance, first.instance);
+assert.strictEqual(require("./loader.cjs"), loader);
+assert.strictEqual(require(${JSON.stringify(path.resolve("packages/normalization-core/src/boolean-coercion.ts"))}).parseBoolean, parseBoolean);
+console.log(JSON.stringify({ value: first.value, evaluations: globalThis.pluginEvaluations,
+  transformed: Transformed.Value, sourceAlias: parseBoolean(" TRUE ") }));
+} catch (error) {
+  console.error(error.code + ": " + error.message);
+  process.exitCode = 1;
+}
+`;
+}
 
 export async function withShimFixture<T>(
   wrapper: (typeof TSX_SHIM_WRAPPERS)[number],

--- a/test/scripts/direct-run-entrypoints.test.ts
+++ b/test/scripts/direct-run-entrypoints.test.ts
@@ -24,6 +24,7 @@ import {
   formatShimResult,
   TSX_SHIM_WRAPPERS,
   withShimFixture,
+  writeEsmPluginFixture,
 } from "./direct-run-entrypoints.test-support.js";
 
 const DIRECT_RUN_SCRIPTS = [
@@ -111,7 +112,7 @@ function writeTsxFixture(modulesDir: string, marker: string) {
   mkdirSync(packageDir, { recursive: true });
   writeFileSync(
     path.join(packageDir, "package.json"),
-    JSON.stringify({ name: "tsx", type: "module", exports: "./loader.mjs" }),
+    JSON.stringify({ name: "tsx", type: "module", exports: { "./esm": "./loader.mjs" } }),
   );
   writeFileSync(
     path.join(packageDir, "loader.mjs"),
@@ -165,6 +166,36 @@ function expectShimLoader(result: Awaited<ReturnType<typeof runShimFixture>>, lo
 }
 
 describe("script direct-run entrypoints", () => {
+  it.each(["wrapper", "preload"])(
+    "loads compiled ESM through require from the %s with import-only dependencies",
+    async (entrypoint) => {
+      await withShimFixture(TSX_SHIM_WRAPPERS[0], async (fixture) => {
+        const { fixtureRoot, implementationPath, wrapperPath, runNode } = fixture;
+        writeFileSync(implementationPath, writeEsmPluginFixture(fixtureRoot));
+        const env: NodeJS.ProcessEnv = {
+          ...process.env,
+          PNPM_CONFIG_MODULES_DIR: path.dirname(
+            path.dirname(createRequire(import.meta.url).resolve("tsx/package.json")),
+          ),
+        };
+        delete env.NODE_OPTIONS;
+        const args =
+          entrypoint === "wrapper"
+            ? [wrapperPath]
+            : ["--import", "./scripts/tsx.mjs", implementationPath];
+        const result = await runNode(args, env, process.cwd());
+        expect(result.error, formatShimResult(result)).toBeUndefined();
+        expect(result.status, formatShimResult(result)).toBe(0);
+        expect(JSON.parse(result.stdout)).toEqual({
+          value: "import-only",
+          evaluations: 1,
+          transformed: "transformed",
+          sourceAlias: true,
+        });
+      });
+    },
+  );
+
   it.each([false, true])(
     "preserves preloads when forking into another cwd (equals=%s)",
     async (equals) => {

--- a/test/scripts/release-preflight.test.ts
+++ b/test/scripts/release-preflight.test.ts
@@ -192,7 +192,7 @@ describe("scripts/release-preflight.mjs", () => {
     const result = runIsolatedPreflight(["--macos-versions-only", "--check"]);
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("Cannot find module 'tsx'");
+    expect(result.stderr).toContain("Cannot find module 'tsx/esm'");
     expect(result.stderr).toContain("[release-preflight] FAILED (exit 1)");
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running a source Gateway would lose OpenAI and memory-core plugin capabilities when the repository TypeScript preload loaded their compiled JavaScript entries. The Gateway could still report ready and serve the Control UI, while repeated plugin discovery logged `ERR_PACKAGE_PATH_NOT_EXPORTED`.

Closes #134864. AI-assisted maintainer repair.

## Why This Change Was Made

The shared tooling preload now selects tsx's documented ESM entry rather than its full entry. The full entry installs CommonJS hooks that rewrite a valid compiled ESM dependency edge (`execa` → `npm-run-path` → the import-only `unicorn-magic` export) into an unsupported `require()`; selecting `tsx/esm` corrects that environment at its producer instead of changing plugin policy, dependency exports, or fallback handling.

This removes the unwanted global CommonJS transformation from the maintained source launchers. It does not change the dependency versions or the existing cache policy. Source TypeScript, tsconfig aliases, native CommonJS, inherited forks, and module identity remain covered.

## User Impact

Source-Gateway development and proof runs can load the compiled plugins and use their registered capabilities. **No additional cache is disabled:** tsx's in-process transform cache and Node's module cache remain enabled, and the existing shared-disk-cache setting is unchanged. The normal native built CLI remains working. No configuration options, migrations, schema changes, or version bumps are introduced.

## Evidence

The reported failure and repair were exercised through real isolated source Gateways on Node 24.20.0, using freshly built Control UI/plugin artifacts, fresh secretless HOME/state directories, separate loopback ports, and a local mock HTTP provider. The most recent comparison ran on exact PR head `4e3926ac662d72a96950b9bde88fa9748a5eb1ff`, holding the cache policy constant and comparing full tsx with the repaired repository preload. It reproduced the same outcomes as the earlier verified patch on `2b6b1e2a8b81ee420bc08244d34a5927a404f785`.

Current head `4e3926ac662d72a96950b9bde88fa9748a5eb1ff` preserves all four code/test files byte-for-byte from that verified patch and retains newer upstream documentation. Its fresh full `pnpm build` has passed in 47m52s with no ineffective-dynamic-import warnings. The current multi-config replay has 133 tooling cases passing (one platform skip), but cold preparation in the broader native-loader group exceeded its existing timeout. An isolated first-case diagnostic passes, and matched diagnostics in the original native-first order pass 16 cases (two unselected), with 23.318s preparation and a 54.775s loader case. No assertion, timeout, pool, or isolation setting was relaxed. Source inspection confirms the separate Vitest process is spawned with explicit arguments and does not inherit the parent's changed tsx registration; no ambient loader preload was present. Different default cache paths/preparation costs remain a local proof caveat, not a demonstrated regression from this patch. The renewed current-head Gateway proof, selected changed-file checks, and fresh isolated Codex review (no actionable P0 findings) have completed successfully. [Exact-head CI run 33530598869](https://github.com/openclaw/openclaw/actions/runs/33530598869) completed successfully, and the repo CI watcher ended `GREEN`. The current built CLI also loads OpenAI with eight capabilities and no diagnostics. Both proof Gateways shut down with no cleanup errors, their synthetic state removed, and both ports closed.

| Actual boundary | Full-tsx baseline | Repaired repository preload |
| --- | --- | --- |
| Compiled OpenAI and memory-core registration | Both error | Both loaded |
| Actual registered provider/image-provider objects | Empty | `openai` |
| OpenAI HTTP route | Absent | Registered |
| `image_generate` provider listing | No providers | OpenAI available |
| Image generation through `/tools/invoke` | Capability unavailable | Mock `/v1/images/generations` reached; PNG saved; owning task persisted `status=succeeded`, `error=null` |
| HTTP readiness and built Control UI | Both available despite plugin failures | Both available |

The image task's delivery status was `not_applicable` in this HTTP-only rig; no external channel delivery is claimed. The UI's installed-plugin catalog and HTTP readiness are not used as runtime plugin-health evidence.

Focused reproducible dependency controls (full-tsx fails with the export error; the repaired repository preload succeeds):

```bash
node --import tsx -e 'require("execa")'
```

```bash
node --import ./scripts/tsx.mjs -e 'require("execa")'
```

Validation completed on the original verified source snapshot:

- The new generated-plugin regression fails on the pre-fix production code for the intended import-only export error in both wrapper and direct-preload cases, then passes on the repair. It also verifies a single module evaluation and shared identity across repeated require/import, real TypeScript transformation, source aliases, and native CommonJS loading.
- `node scripts/run-vitest.mjs test/scripts/direct-run-entrypoints.test.ts test/scripts/managed-child-process.test.ts test/scripts/release-preflight.test.ts src/plugins/native-module-require.test.ts src/plugins/loader.native-module-loader.test.ts`: **150 passed, one Linux-only test skipped on macOS**.
- `node scripts/check-changed.mjs -- scripts/lib/tsx-cli-shim.mjs test/scripts/direct-run-entrypoints.test.ts test/scripts/direct-run-entrypoints.test-support.ts test/scripts/release-preflight.test.ts docs/reference/test.md`: passed, including formatting, lint, root-test types, and selected guards. Checked on Node 24 and again on Node 26.
- `pnpm build`: passed in 7m57s, with no ineffective-dynamic-import warnings.
- Fresh native built CLI runtime inspection: OpenAI loaded, eight capabilities, no diagnostics. Separate Node 24.20.0 and 26.8.1 controls preserve require/import identity, source transforms, and aliases.
- Independent isolated Codex autoreview: no actionable findings at the requested P0 threshold. Direct owner/caller/sibling and installed dependency-contract inspection supplemented that review.

Installed dependency contracts inspected directly: tsx 4.23.12, Execa 10.0.1, npm-run-path 6.0.0, unicorn-magic 0.3.0. No live OpenAI API credentials or freshly installed npm tarball were used; these results establish source-loader integration, not an external-provider service claim. Windows execution and a performance benchmark were not run locally; no overall speed claim is made.

Production/tooling LOC: +3/-1, entirely the one-for-one executable substitution plus two explanatory comment lines (**executable net zero**). Tests/support: +79/-2. Docs: +9/-3. No new production helper, fallback, or branch.

Related source-public-artifact repair #132166 is already merged; this change repairs the distinct full-preload interception of the compiled native path. Original regression introduction is unknown; no carrier commit or contributor is blamed. A separate follow-up is recorded for the older native-loader tests' partial mock: it watches `getCachedPluginSourceModuleLoader`, while the current runtime calls `getCachedPluginModuleLoader`. This PR adds real fresh-process boundary coverage without expanding into that test cleanup or changing runtime health presentation/negative-result reuse.

Release context: source Gateway runs retain compiled-plugin capabilities without disabling additional caching. Updated operator/developer documentation: https://docs.openclaw.ai/reference/test.

### Supplementary UI parity from the original proof snapshot

Both screenshots show the static installed-plugin catalog remaining available. They are not runtime plugin-health proof; actual registration and capability behavior are recorded above.

![Baseline static catalog despite runtime load failures](https://github.com/user-attachments/assets/c53311b4-7e4d-4cd0-9706-252f7b2aea82)

![Repaired source Gateway static catalog](https://github.com/user-attachments/assets/7c2e3251-f390-4c88-8b67-5ceeb9547167)
