### PR TITLE
refactor(qa): unify suite summary verdict accounting

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1070,7 +1070,7 @@ extensions/qa-lab/src/suite-runtime-agent-process.ts	7
 extensions/qa-lab/src/suite-runtime-agent-session.ts	5
 extensions/qa-lab/src/suite-runtime-agent-tools.ts	1
 extensions/qa-lab/src/suite-runtime-gateway.ts	2
-extensions/qa-lab/src/suite-summary.ts	5
+extensions/qa-lab/src/suite-summary.ts	4
 extensions/qa-lab/src/suite-support.ts	1
 extensions/qa-lab/src/test-file-scenario-script-evidence.ts	2
 extensions/qa-lab/src/test-file-scenario-vitest-report.ts	1

--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -375,89 +375,49 @@ export function resolveQaReportOnlyOptionalScenarioNames(
 export function countQaSuiteFailedScenarios(
   scenarios: ReadonlyArray<QaSuiteScenarioStatus>,
 ): number {
-  let failed = 0;
-  for (const scenario of scenarios) {
-    if (isQaSuiteFailureStatus(scenario.status)) {
-      failed += 1;
-    }
-  }
-  return failed;
+  return countQaSuiteScenarioStatuses(Array.from(scenarios, (scenario) => scenario.status)).failed;
 }
 
-function countQaSuiteFailedOrSkippedScenarios(
-  scenarios: ReadonlyArray<QaSuiteScenarioStatus>,
-): number {
-  let blocking = 0;
-  for (const scenario of scenarios) {
-    if (isQaSuiteBlockingStatus(scenario.status)) {
-      blocking += 1;
-    }
-  }
-  return blocking;
-}
-
-function readQaSuiteFailedScenarioCountFromSummary(summary: unknown): number | null {
+function readQaSuiteScenarioCountFromSummary(
+  summary: unknown,
+  mode: "failed" | "blocking",
+): number | null {
   if (!isRecord(summary)) {
     return null;
   }
-  const payload = summary as {
-    counts?: {
-      failed?: unknown;
-    };
-    scenarios?: Array<QaSuiteScenarioStatus>;
+  const { counts, scenarios } = summary as {
+    counts?: { failed?: unknown; skipped?: unknown };
+    scenarios?: QaSuiteScenarioStatus[];
   };
   const entries = readQaSuiteEvidenceEntries(summary);
-  const countedFailures = readNonNegativeCount(payload.counts?.failed);
-  const scenarioFailures = Array.isArray(payload.scenarios)
-    ? countQaSuiteFailedScenarios(payload.scenarios)
-    : null;
-  const evidenceFailures = entries
-    ? entries.filter((entry) => isQaSuiteFailureStatus(readQaSuiteEvidenceEntryStatus(entry)))
-        .length
-    : null;
-  // Counts and scenario rows own scenario cardinality. Raw evidence is a
-  // lower-level fallback only when neither aggregate is available.
-  if (countedFailures !== null || scenarioFailures !== null) {
-    return Math.max(countedFailures ?? 0, scenarioFailures ?? 0);
-  }
-  return evidenceFailures;
-}
-
-function readQaSuiteFailedOrSkippedScenarioCountFromSummary(summary: unknown): number | null {
-  if (!isRecord(summary)) {
-    return null;
-  }
-  const payload = summary as {
-    counts?: {
-      failed?: unknown;
-      skipped?: unknown;
-    };
-    scenarios?: Array<QaSuiteScenarioStatus>;
-  };
-  const entries = readQaSuiteEvidenceEntries(summary);
-  const countedFailures = readNonNegativeCount(payload.counts?.failed);
-  const countedSkipped = readNonNegativeCount(payload.counts?.skipped);
-  const countedBlocking =
+  const countedFailures = readNonNegativeCount(counts?.failed);
+  const countedSkipped = mode === "blocking" ? readNonNegativeCount(counts?.skipped) : null;
+  const counted =
     countedFailures !== null || countedSkipped !== null
       ? (countedFailures ?? 0) + (countedSkipped ?? 0)
       : null;
-  const scenarioBlocking = Array.isArray(payload.scenarios)
-    ? countQaSuiteFailedOrSkippedScenarios(payload.scenarios)
+  const observed = Array.isArray(scenarios)
+    ? countQaSuiteScenarioStatuses(Array.from(scenarios, (scenario) => scenario.status))
     : null;
-  const evidenceBlocking = entries
-    ? entries.filter((entry) => isQaSuiteBlockingStatus(readQaSuiteEvidenceEntryStatus(entry)))
-        .length
+  const scenarioCount = observed
+    ? observed.failed + (mode === "blocking" ? observed.skipped : 0)
     : null;
-  if (countedBlocking !== null || scenarioBlocking !== null) {
-    return Math.max(countedBlocking ?? 0, scenarioBlocking ?? 0);
+  const matchesStatus = mode === "blocking" ? isQaSuiteBlockingStatus : isQaSuiteFailureStatus;
+  const evidenceCount = entries
+    ? entries.filter((entry) => matchesStatus(readQaSuiteEvidenceEntryStatus(entry))).length
+    : null;
+  // Counts and scenario rows own scenario cardinality. Raw evidence is a
+  // lower-level fallback only when neither aggregate is available.
+  if (counted !== null || scenarioCount !== null) {
+    return Math.max(counted ?? 0, scenarioCount ?? 0);
   }
-  return evidenceBlocking;
+  return evidenceCount;
 }
 
 export async function readQaSuiteFailedScenarioCountFromFile(summaryPath: string): Promise<number> {
   const payload = await readCompletedQaSuiteSummaryFile(summaryPath);
   assertQaSuiteSummaryHasExecutedScenarios(payload, summaryPath, "summary_failure_count_missing");
-  const failedScenarioCount = readQaSuiteFailedScenarioCountFromSummary(payload);
+  const failedScenarioCount = readQaSuiteScenarioCountFromSummary(payload, "failed");
   if (failedScenarioCount !== null) {
     return failedScenarioCount;
   }
@@ -479,7 +439,7 @@ export async function readQaSuiteFailedOrSkippedScenarioCountFromFile(
     options?.optionalScenarioNames,
     options?.requireExecutedScenario,
   );
-  const blockingScenarioCount = readQaSuiteFailedOrSkippedScenarioCountFromSummary(payload);
+  const blockingScenarioCount = readQaSuiteScenarioCountFromSummary(payload, "blocking");
   if (blockingScenarioCount !== null) {
     const optionalScenarioNames = options?.optionalScenarioNames;
     if (!optionalScenarioNames?.size || !isRecord(payload)) {
@@ -496,7 +456,7 @@ export async function readQaSuiteFailedOrSkippedScenarioCountFromFile(
     // Optional skips may offset only their independently verified scenario results.
     // Declared failures and count disagreements stay fail-closed.
     return Math.max(
-      readQaSuiteFailedScenarioCountFromSummary(payload) ?? 0,
+      readQaSuiteScenarioCountFromSummary(payload, "failed") ?? 0,
       blockingScenarioCount - reportOnlyOptionalSkips,
     );
   }


### PR DESCRIPTION
## What Problem This Solves

QA suite summaries had parallel failure-only and failure-or-skip evaluators, each repeating count, scenario, and producer-evidence accounting. One private evaluator now selects the intended mode and reuses the existing status counter.

## Why This Change Was Made

The file readers retain their completion, safe-count, executed-work, and optional-skip guards. Counts and scenario rows still own scenario cardinality; producer evidence remains a fallback only when both are absent. Optional report-only skips cannot erase the failure floor. Two obsolete evaluators and the duplicate status loop are deleted.

## User Impact

No intended behavior change. Production decreases by 40 physical lines (+27/−67), or 38 nonblank lines; maintained tests are unchanged. The required assertion-ratchet entry tightens from five to four. Reusing the counter creates a temporary O(n) status array, so this is a maintenance refactor without a performance claim. Sparse arrays retain their existing error behavior.

## Evidence

A baseline run before editing and the candidate run use the real summary builder, atomic artifact writer, filesystem, and verdict readers. All 462 observations across 75 artifact cases match: 535,942 normalized bytes, including errors, own-undefined fields, descriptors, ordering, aliases, counts, optional skips, sparse inputs, and file modes. Normalization removes only the task-temp prefix and stack frames after the error’s first line; raw captures remain retained.

Both versions also run a real isolated Gateway, QA channel and local mock provider through the normal qa suite CLI. The channel conversation passes with identical 1/1/0/0 counts: unmentioned chatter is ignored and the mentioned request receives its exact marker. Generated timings and measured process metrics are excluded from that CLI comparison. No external channel or model request is claimed.

All 304 maintained tests across eight files and all 26 selected checks pass. Fresh managed Codex high/P2 review is scoped-clean. The first CLI fixture incorrectly used an absolute output directory and was corrected before the successful baseline; the initial check run required the exact assertion-ratchet tightening. Neither attempt changed production policy or test deadlines.

A separate source-observed follow-up records a testing-docs mismatch about the generic Vitest no-output deadline; it is outside this verdict refactor and is not claimed fixed.


Maintainer landing review: The latest 10:09 UTC ClawSweeper review is code-clean. Its normal exact-head CI and maintainer-handling request is satisfied by successful CI 33495176576 and root owner review under this user-authorized campaign; there are no rank-up moves. Production +27/-67 = -40 physical, -38 nonblank. Tests unchanged; assertion ratchet 5 to 4. No move or generated deletion counted. Actual local QA runtime and transport, with only temporary paths/stacks and generated CLI timing/process metrics normalized. No external channel or model request is claimed.
