### PR TITLE
fix(channels): expose failed plugin accounts in status and health

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2875,7 +2875,7 @@ src/gateway/server-methods/approval.ts	8
 src/gateway/server-methods/attachment-normalize.ts	1
 src/gateway/server-methods/base-hash.ts	1
 src/gateway/server-methods/channel-pairing.ts	3
-src/gateway/server-methods/channels.ts	13
+src/gateway/server-methods/channels.ts	12
 src/gateway/server-methods/chat-abort-authorization.ts	3
 src/gateway/server-methods/chat-abort-handler.ts	2
 src/gateway/server-methods/chat-assistant-content.ts	1

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2875,7 +2875,7 @@ src/gateway/server-methods/approval.ts	8
 src/gateway/server-methods/attachment-normalize.ts	1
 src/gateway/server-methods/base-hash.ts	1
 src/gateway/server-methods/channel-pairing.ts	3
-src/gateway/server-methods/channels.ts	16
+src/gateway/server-methods/channels.ts	13
 src/gateway/server-methods/chat-abort-authorization.ts	3
 src/gateway/server-methods/chat-abort-handler.ts	2
 src/gateway/server-methods/chat-assistant-content.ts	1

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -29,6 +29,8 @@ openclaw channels logs --channel all
 openclaw channels dead-letters list --channel telegram --account default
 ```
 
+`channels status` keeps configured channels visible when their plugin fails to load or register. Affected accounts report `running: false`, `lifecycle: "blocked"`, and the plugin error instead of stale probe success. Run `openclaw doctor`, repair or update the plugin, and restart the Gateway before checking again.
+
 `channels list` shows chat channels only: configured accounts by default, with `installed`, `configured`, and `enabled` status tags per account (`--json` for machine output). Pass `--all` to also surface bundled channels that have no configured account yet and installable catalog channels that are not yet on disk. Provider auth and model usage live elsewhere: `openclaw models auth list` for provider auth profiles, `openclaw status` or `openclaw models list` for usage/quota.
 
 `--json` returns a local account inventory from plugin metadata without contacting the Gateway or executing channel setup/runtime code. Configured accounts remain visible even when their plugin has a setup entry. Use `channels status --probe` for live checks.

--- a/src/channels/account-inspection.ts
+++ b/src/channels/account-inspection.ts
@@ -55,7 +55,7 @@ export async function resolveInspectedChannelAccount(params: {
   sourceConfig: OpenClawConfig;
   accountId: string;
 }): Promise<ChannelAccountInspectionResult> {
-  const unavailable = resolveUnavailableChannelAccountSnapshot({
+  const unavailable = resolveUnavailableChannelAccountSnapshot(params.cfg, {
     channelId: params.plugin.id,
     accountId: params.accountId,
   });

--- a/src/channels/plugins/status.ts
+++ b/src/channels/plugins/status.ts
@@ -106,7 +106,7 @@ export async function resolveChannelAccountSnapshot<ResolvedAccount>(params: {
   probe?: unknown;
   audit?: unknown;
 }): Promise<ChannelAccountSnapshot> {
-  const unavailable = resolveUnavailableChannelAccountSnapshot({
+  const unavailable = resolveUnavailableChannelAccountSnapshot(params.cfg, {
     channelId: params.plugin.id,
     accountId: params.accountId,
     runtime: params.runtime,

--- a/src/channels/status/account-state.ts
+++ b/src/channels/status/account-state.ts
@@ -1,4 +1,6 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { redactToolPayloadTextWithConfig } from "../../logging/redact.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
 import {
@@ -55,12 +57,18 @@ export function resolveUnavailableChannelAccountSnapshot(
       (plugin) =>
         plugin.enabled && plugin.status === "error" && plugin.channelIds.includes(params.channelId),
     );
+  // Read-scoped status must redact loader text before truncation can split a credential.
+  const pluginError =
+    failedPlugin &&
+    redactToolPayloadTextWithConfig(
+      `Plugin ${failedPlugin.id} failed: ${failedPlugin.error}`,
+      cfg.logging,
+    );
   // Cold owners have no operational account to resolve or probe. Stale owners
   // retain usable credentials and are excluded by the secrets runtime lookup.
   const lastError = owner
     ? new SecretSurfaceUnavailableError(owner).message
-    : failedPlugin &&
-      `Plugin ${failedPlugin.id} failed: ${failedPlugin.error}; run openclaw doctor`;
+    : pluginError && `${truncateUtf16Safe(pluginError, 1_000)}; run openclaw doctor`;
   if (!lastError) {
     return undefined;
   }

--- a/src/channels/status/account-state.ts
+++ b/src/channels/status/account-state.ts
@@ -1,9 +1,11 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
 import {
   findActiveDegradedSecretOwner,
   SecretSurfaceUnavailableError,
 } from "../../secrets/runtime-degraded-state.js";
+import { isChannelAccountExplicitlyDisabled } from "../account-config-enabled.js";
 import type { ChannelAccountLinkState } from "../plugins/types.adapters.js";
 import type {
   ChannelAccountSnapshot,
@@ -36,19 +38,19 @@ type ChannelAccountStateInput = {
   unlinkedReason?: string;
 };
 
-export function resolveUnavailableChannelAccountSnapshot(params: {
-  channelId: string;
-  accountId: string;
-  runtime?: ChannelAccountSnapshot;
-}): ChannelAccountSnapshot | undefined {
-  const owner = findActiveDegradedSecretOwner(
-    "account",
-    `${params.channelId}:${normalizeAccountId(params.accountId)}`,
-  );
+export function resolveUnavailableChannelAccountSnapshot(
+  cfg: OpenClawConfig,
+  params: {
+    channelId: string;
+    accountId: string;
+    runtime?: ChannelAccountSnapshot;
+  },
+): ChannelAccountSnapshot | undefined {
+  const accountId = normalizeAccountId(params.accountId);
+  const owner = findActiveDegradedSecretOwner("account", `${params.channelId}:${accountId}`);
   const registry = getActivePluginRegistry();
-  const registered = registry?.channels.some(({ plugin }) => plugin.id === params.channelId);
   const failedPlugin =
-    !registered &&
+    !registry?.channels.some(({ plugin }) => plugin.id === params.channelId) &&
     registry?.plugins.find(
       (plugin) =>
         plugin.enabled && plugin.status === "error" && plugin.channelIds.includes(params.channelId),
@@ -62,12 +64,14 @@ export function resolveUnavailableChannelAccountSnapshot(params: {
   if (!lastError) {
     return undefined;
   }
-  // A failed plugin has no live account; prior probes and activity cannot describe this generation.
+  // Failed plugins have no live account: discard old probes/activity, but preserve config disables.
   const runtime = failedPlugin ? undefined : params.runtime;
   return {
     ...runtime,
     accountId: params.accountId,
-    enabled: runtime?.enabled ?? true,
+    enabled: failedPlugin
+      ? !isChannelAccountExplicitlyDisabled({ cfg, channel: params.channelId, accountId })
+      : (runtime?.enabled ?? true),
     configured: true,
     running: false,
     ...(typeof runtime?.connected === "boolean" ? { connected: false } : {}),

--- a/src/channels/status/account-state.ts
+++ b/src/channels/status/account-state.ts
@@ -1,3 +1,4 @@
+import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
 import {
   findActiveDegradedSecretOwner,
@@ -44,19 +45,32 @@ export function resolveUnavailableChannelAccountSnapshot(params: {
     "account",
     `${params.channelId}:${normalizeAccountId(params.accountId)}`,
   );
-  if (!owner) {
-    return undefined;
-  }
+  const registry = getActivePluginRegistry();
+  const registered = registry?.channels.some(({ plugin }) => plugin.id === params.channelId);
+  const failedPlugin =
+    !registered &&
+    registry?.plugins.find(
+      (plugin) =>
+        plugin.enabled && plugin.status === "error" && plugin.channelIds.includes(params.channelId),
+    );
   // Cold owners have no operational account to resolve or probe. Stale owners
   // retain usable credentials and are excluded by the secrets runtime lookup.
-  const lastError = new SecretSurfaceUnavailableError(owner).message;
+  const lastError = owner
+    ? new SecretSurfaceUnavailableError(owner).message
+    : failedPlugin &&
+      `Plugin ${failedPlugin.id} failed: ${failedPlugin.error}; run openclaw doctor`;
+  if (!lastError) {
+    return undefined;
+  }
+  // A failed plugin has no live account; prior probes and activity cannot describe this generation.
+  const runtime = failedPlugin ? undefined : params.runtime;
   return {
-    ...params.runtime,
+    ...runtime,
     accountId: params.accountId,
-    enabled: params.runtime?.enabled ?? true,
+    enabled: runtime?.enabled ?? true,
     configured: true,
     running: false,
-    ...(typeof params.runtime?.connected === "boolean" ? { connected: false } : {}),
+    ...(typeof runtime?.connected === "boolean" ? { connected: false } : {}),
     restartPending: false,
     lifecycle: "blocked",
     stateReason: lastError,

--- a/src/commands/health.plugins.test.ts
+++ b/src/commands/health.plugins.test.ts
@@ -148,6 +148,7 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
   });
 
   it("projects the recorded channel load failure instead of stale successful probes", async () => {
+    const credential = "synthetic-health-loader-credential";
     const probeAccount = vi.fn(async () => ({ ok: true }));
     const base = createChannelTestPluginBase({ id: "broken-channel" });
     inventoryPlugins = [
@@ -168,7 +169,7 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
           status: "error",
           failurePhase: "load",
           channelIds: ["broken-channel"],
-          error: "missing SDK export",
+          error: `missing SDK export; password=${credential}`,
         }),
       ],
     };
@@ -203,6 +204,7 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
       lastError: expect.stringContaining("missing SDK export"),
     });
     expect(snap.channels["broken-channel"]).not.toHaveProperty("probe");
+    expect(JSON.stringify(snap.channels)).not.toContain(credential);
     expect(probeAccount).not.toHaveBeenCalled();
 
     // A different live owner wins over a failed plugin declaring the same channel.

--- a/src/commands/health.plugins.test.ts
+++ b/src/commands/health.plugins.test.ts
@@ -169,7 +169,7 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
           status: "error",
           failurePhase: "load",
           channelIds: ["broken-channel"],
-          error: `missing SDK export; password=${credential}`,
+          error: `missing SDK export; password=${credential}\n${"context ".repeat(300)}`,
         }),
       ],
     };
@@ -204,7 +204,8 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
       lastError: expect.stringContaining("missing SDK export"),
     });
     expect(snap.channels["broken-channel"]).not.toHaveProperty("probe");
-    expect(JSON.stringify(snap.channels)).not.toContain(credential);
+    expect(JSON.stringify(snap)).not.toContain(credential);
+    expect(snap.plugins?.errors[0]?.error.length).toBeLessThanOrEqual(1000);
     expect(probeAccount).not.toHaveBeenCalled();
 
     // A different live owner wins over a failed plugin declaring the same channel.
@@ -230,6 +231,7 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
   });
 
   it("surfaces a failed service while continuing healthy siblings", async () => {
+    const credential = "synthetic-service-credential";
     const siblingStart = vi.fn();
     const registry = {
       ...createTestRegistry([]),
@@ -248,7 +250,7 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
           service: {
             id: "broken",
             start: () => {
-              throw new Error("listen EADDRINUSE: address already in use");
+              throw new Error(`listen EADDRINUSE: address already in use; password=${credential}`);
             },
           },
           source: "test",
@@ -281,8 +283,9 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
       activated: true,
       activationSource: "explicit",
       failurePhase: "service",
-      error: "service broken: listen EADDRINUSE: address already in use",
+      error: expect.stringContaining("service broken: listen EADDRINUSE: address already in use"),
     });
+    expect(JSON.stringify(failed)).not.toContain(credential);
 
     await pluginServicesHandle.stop();
     pluginServicesHandle = undefined;

--- a/src/commands/health.plugins.test.ts
+++ b/src/commands/health.plugins.test.ts
@@ -5,11 +5,12 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { SnapshotSchema } from "../../packages/gateway-protocol/src/schema/snapshot.js";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { createPluginRecord } from "../plugins/status.test-fixtures.js";
 import { createChannelTestPluginBase } from "../test-utils/channel-plugins.js";
 
-const testConfig = { session: { store: "/tmp/x" } };
+const testConfig: OpenClawConfig = { session: { store: "/tmp/x" } };
 const tempDirs = createTempDirTracker();
 let sessionStorePath: string;
 
@@ -64,6 +65,7 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
     pluginServicesHandle = undefined;
     setActiveDegradedPlugins([]);
     inventoryPlugins = [];
+    delete testConfig.channels;
     setActivePluginRegistry(createTestRegistry([]));
     tempDirs.cleanup();
   });
@@ -147,9 +149,15 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
 
   it("projects the recorded channel load failure instead of stale successful probes", async () => {
     const probeAccount = vi.fn(async () => ({ ok: true }));
+    const base = createChannelTestPluginBase({ id: "broken-channel" });
     inventoryPlugins = [
-      { ...createChannelTestPluginBase({ id: "broken-channel" }), status: { probeAccount } },
+      {
+        ...base,
+        config: { ...base.config, listAccountIds: () => ["default", "disabled"] },
+        status: { probeAccount },
+      },
     ];
+    testConfig.channels = { "broken-channel": { accounts: { Disabled: { enabled: false } } } };
     const registry = {
       ...createTestRegistry([]),
       plugins: [
@@ -189,6 +197,11 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
       lifecycle: "blocked",
       lastError: expect.stringContaining("missing SDK export"),
     });
+    expect(snap.channels["broken-channel"]?.accounts?.disabled).toMatchObject({
+      enabled: false,
+      running: false,
+      lastError: expect.stringContaining("missing SDK export"),
+    });
     expect(snap.channels["broken-channel"]).not.toHaveProperty("probe");
     expect(probeAccount).not.toHaveBeenCalled();
 
@@ -207,7 +220,7 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
     const { resolveUnavailableChannelAccountSnapshot } =
       await import("../channels/status/account-state.js");
     expect(
-      resolveUnavailableChannelAccountSnapshot({
+      resolveUnavailableChannelAccountSnapshot(testConfig, {
         channelId: "broken-channel",
         accountId: "default",
       }),

--- a/src/commands/health.plugins.test.ts
+++ b/src/commands/health.plugins.test.ts
@@ -4,8 +4,10 @@ import { Value } from "typebox/value";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { SnapshotSchema } from "../../packages/gateway-protocol/src/schema/snapshot.js";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { createPluginRecord } from "../plugins/status.test-fixtures.js";
+import { createChannelTestPluginBase } from "../test-utils/channel-plugins.js";
 
 const testConfig = { session: { store: "/tmp/x" } };
 const tempDirs = createTempDirTracker();
@@ -17,6 +19,7 @@ let createTestRegistry: typeof import("../test-utils/channel-plugins.js").create
 let collectGatewayHealthSnapshot: typeof import("../gateway/health/collector.js").collectGatewayHealthSnapshot;
 let startPluginServices: typeof import("../plugins/services.js").startPluginServices;
 let pluginServicesHandle: PluginServicesHandle | undefined;
+let inventoryPlugins: ChannelPlugin[] = [];
 
 describe("collectGatewayHealthSnapshot plugin state", () => {
   beforeAll(async () => {
@@ -31,7 +34,7 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
       readSessionStoreSummaryReadOnly: () => ({ count: 0, recent: [], byAgent: new Map() }),
     }));
     vi.doMock("../channels/plugins/read-only.js", () => ({
-      listReadOnlyChannelPluginsForConfig: () => [],
+      listReadOnlyChannelPluginsForConfig: () => inventoryPlugins,
     }));
 
     const [pluginsRuntime, degradedState, channelTestUtils, health, pluginServices] =
@@ -60,6 +63,7 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
     await pluginServicesHandle?.stop();
     pluginServicesHandle = undefined;
     setActiveDegradedPlugins([]);
+    inventoryPlugins = [];
     setActivePluginRegistry(createTestRegistry([]));
     tempDirs.cleanup();
   });
@@ -139,6 +143,75 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
         error: "healthy override has an unrelated import error",
       },
     ]);
+  });
+
+  it("projects the recorded channel load failure instead of stale successful probes", async () => {
+    const probeAccount = vi.fn(async () => ({ ok: true }));
+    inventoryPlugins = [
+      { ...createChannelTestPluginBase({ id: "broken-channel" }), status: { probeAccount } },
+    ];
+    const registry = {
+      ...createTestRegistry([]),
+      plugins: [
+        createPluginRecord({
+          id: "broken-owner",
+          enabled: true,
+          activated: true,
+          status: "error",
+          failurePhase: "load",
+          channelIds: ["broken-channel"],
+          error: "missing SDK export",
+        }),
+      ],
+    };
+    setActivePluginRegistry(registry);
+    const snap = await collectGatewayHealthSnapshot({
+      audience: "admin",
+      timeoutMs: 1000,
+      probe: true,
+      runtimeSnapshot: {
+        channels: {},
+        channelAccounts: {
+          "broken-channel": {
+            default: {
+              accountId: "default",
+              running: true,
+              connected: true,
+              probe: { ok: true },
+            },
+          },
+        },
+      },
+    });
+    expect(snap.channels["broken-channel"]).toMatchObject({
+      configured: true,
+      running: false,
+      lifecycle: "blocked",
+      lastError: expect.stringContaining("missing SDK export"),
+    });
+    expect(snap.channels["broken-channel"]).not.toHaveProperty("probe");
+    expect(probeAccount).not.toHaveBeenCalled();
+
+    // A different live owner wins over a failed plugin declaring the same channel.
+    setActivePluginRegistry({
+      ...registry,
+      ...createTestRegistry([
+        {
+          pluginId: "healthy-owner",
+          plugin: inventoryPlugins[0],
+          source: "test",
+        },
+      ]),
+      plugins: registry.plugins,
+    });
+    const { resolveUnavailableChannelAccountSnapshot } =
+      await import("../channels/status/account-state.js");
+    expect(
+      resolveUnavailableChannelAccountSnapshot({
+        channelId: "broken-channel",
+        accountId: "default",
+      }),
+    ).toBeUndefined();
   });
 
   it("surfaces a failed service while continuing healthy siblings", async () => {

--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -1,6 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { listAgentEntries } from "../../agents/agent-scope.js";
 import { redactChannelStatusSummaryBaseUrl } from "../../channels/account-snapshot-fields.js";
 import { buildChannelAccountSnapshotFromInspection } from "../../channels/account-summary.js";
@@ -17,6 +18,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isDiagnosticFlagEnabled } from "../../infra/diagnostic-flags.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveHeartbeatSummaryForAgent } from "../../infra/heartbeat-summary.js";
+import { redactToolPayloadTextWithConfig } from "../../logging/redact.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   degradedPluginMatchesRoot,
@@ -68,19 +70,6 @@ const debugHealth = (
 
 const resolveHeartbeatSummary = (cfg: OpenClawConfig, agentId: string) =>
   resolveHeartbeatSummaryForAgent(cfg, agentId);
-
-function attachPluginActivation(
-  plugin: NonNullable<ReturnType<typeof getActivePluginRegistry>>["plugins"][number] | undefined,
-  error: PluginHealthErrorSummary,
-): PluginHealthErrorSummary {
-  if (plugin?.activationSource) {
-    error.activationSource = plugin.activationSource;
-  }
-  if (plugin?.activationReason) {
-    error.activationReason = plugin.activationReason;
-  }
-  return error;
-}
 
 export function resolveHealthAgentOrder(cfg: OpenClawConfig) {
   const defaultAgentId = tryResolveLegacyCompatibilityAgentId(cfg);
@@ -171,7 +160,19 @@ export async function buildHealthAgentSummaries(
   });
 }
 
-function buildPluginHealthSummary(): PluginHealthSummary | undefined {
+function buildPluginHealthSummary(cfg: OpenClawConfig): PluginHealthSummary | undefined {
+  // Keep full internal diagnostics, but sanitize both load and service errors before public caching.
+  function projectError(
+    plugin: NonNullable<ReturnType<typeof getActivePluginRegistry>>["plugins"][number] | undefined,
+    error: PluginHealthErrorSummary,
+  ): PluginHealthErrorSummary {
+    return {
+      ...error,
+      activationSource: plugin?.activationSource,
+      activationReason: plugin?.activationReason,
+      error: truncateUtf16Safe(redactToolPayloadTextWithConfig(error.error, cfg.logging), 1_000),
+    };
+  }
   const registry = getActivePluginRegistry();
   const degradedPlugins = listActiveDegradedPlugins();
   const unavailable = degradedPlugins
@@ -199,7 +200,7 @@ function buildPluginHealthSummary(): PluginHealthSummary | undefined {
         ),
     )
     .map((plugin) =>
-      attachPluginActivation(plugin, {
+      projectError(plugin, {
         id: plugin.id,
         origin: plugin.origin,
         activated: plugin.activated === true,
@@ -209,7 +210,7 @@ function buildPluginHealthSummary(): PluginHealthSummary | undefined {
     );
   const serviceErrors = registry
     ? listPluginServiceHealthFailures(registry).map((failure) =>
-        attachPluginActivation(
+        projectError(
           registry.plugins.find((entry) => entry.id === failure.pluginId),
           {
             id: failure.pluginId,
@@ -660,7 +661,7 @@ export async function collectGatewayHealthSnapshot(params: {
     }
   }
 
-  const pluginHealth = buildPluginHealthSummary();
+  const pluginHealth = buildPluginHealthSummary(cfg);
   const contextEngineHealth = buildContextEngineHealthSummary();
   const deliveryQueueHealth = buildDeliveryQueueHealthSummary();
   return {

--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -358,7 +358,7 @@ async function buildHealthAccountRecord(params: {
     (params.accountId === params.defaultAccountId
       ? params.runtimeSnapshot?.channels[params.plugin.id]
       : undefined);
-  const unavailable = resolveUnavailableChannelAccountSnapshot({
+  const unavailable = resolveUnavailableChannelAccountSnapshot(params.cfg, {
     channelId: params.plugin.id,
     accountId: params.accountId,
     runtime: runtimeSnapshot,

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -1405,7 +1405,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       const accounts: Record<string, ChannelAccountSnapshot> = {};
       for (const id of accountIds) {
         const current = store.runtimes.get(id) ?? cloneDefaultRuntime(plugin.id, id);
-        const unavailable = resolveUnavailableChannelAccountSnapshot({
+        const unavailable = resolveUnavailableChannelAccountSnapshot(cfg, {
           channelId: plugin.id,
           accountId: id,
           runtime: current,

--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -320,6 +320,14 @@ describe("channelsHandlers channels.status", () => {
       const healthyProbe = vi.fn(async () => ({ ok: true }));
       const healthy = createChannelPlugin({ id: "healthy", probeAccount: healthyProbe });
       configureAutoEnabledChannels([healthy]);
+      failed.config.listAccountIds = () => ["default", "disabled"];
+      mocks.applyPluginAutoEnable.mockReturnValue({
+        config: {
+          autoEnabled: true,
+          channels: { "broken-channel": { accounts: { Disabled: { enabled: false } } } },
+        },
+        changes: [],
+      });
       mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([failed, healthy]);
       setActivePluginRegistry({
         ...createTestRegistry([]),
@@ -347,6 +355,16 @@ describe("channelsHandlers channels.status", () => {
         configured: true,
         lastError: expect.stringContaining("missing SDK export"),
       });
+      const accounts = requireGatewayRecord(payload.channelAccounts, "accounts")["broken-channel"];
+      expect(accounts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            accountId: "disabled",
+            enabled: false,
+            lastError: expect.stringContaining("missing SDK export"),
+          }),
+        ]),
+      );
       expect(failedProbe).not.toHaveBeenCalled();
       expect(healthyProbe).toHaveBeenCalledOnce();
       mocks.normalizeChannelId.mockReturnValueOnce(null);

--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -315,6 +315,7 @@ describe("channelsHandlers channels.status", () => {
   it.each(["load", "register", "validation"] as const)(
     "keeps a channel visible after its plugin fails during %s",
     async (failurePhase) => {
+      const credential = "synthetic-loader-credential-that-must-not-escape";
       const failedProbe = vi.fn();
       const failed = createChannelPlugin({ id: "broken-channel", probeAccount: failedProbe });
       const healthyProbe = vi.fn(async () => ({ ok: true }));
@@ -324,6 +325,7 @@ describe("channelsHandlers channels.status", () => {
       mocks.applyPluginAutoEnable.mockReturnValue({
         config: {
           autoEnabled: true,
+          logging: { redactSensitive: "off", redactPatterns: ["never-match-custom"] },
           channels: { "broken-channel": { accounts: { Disabled: { enabled: false } } } },
         },
         changes: [],
@@ -338,13 +340,17 @@ describe("channelsHandlers channels.status", () => {
             status: "error",
             failurePhase,
             channelIds: ["broken-channel"],
-            error: "missing SDK export",
+            error: `missing SDK export; Authorization: Bearer ${credential}\n${"context ".repeat(300)}`,
           }),
         ],
       });
 
       const payload = await runChannelsStatus({ probe: true, timeoutMs: 1000 });
 
+      expect(JSON.stringify(payload)).not.toContain(credential);
+      const lastError = firstChannelAccount(payload, "broken-channel").lastError;
+      expect(String(lastError).length).toBeLessThan(1200);
+      expect(lastError).toContain("run openclaw doctor");
       expect(firstChannelAccount(payload, "broken-channel")).toMatchObject({
         configured: true,
         running: false,

--- a/src/gateway/server-methods/channels.status.test.ts
+++ b/src/gateway/server-methods/channels.status.test.ts
@@ -4,7 +4,10 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createPluginRecord } from "../../plugins/status.test-fixtures.js";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { requireGatewayRecord } from "../test-helpers.assertions.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
@@ -26,6 +29,8 @@ const mocks = vi.hoisted(() => ({
   getRuntimeConfig: vi.fn(() => ({})),
   applyPluginAutoEnable: vi.fn(),
   listChannelPlugins: vi.fn(),
+  normalizeChannelId: vi.fn<(value: string) => string | null>((value) => value),
+  listReadOnlyChannelPluginsForConfig: vi.fn(),
   buildChannelUiCatalog: vi.fn(),
   buildChannelAccountSnapshotFromAccount: vi.fn(),
   getChannelActivity: vi.fn(),
@@ -48,7 +53,11 @@ vi.mock("../../channels/plugins/index.js", () => ({
   listChannelPlugins: mocks.listChannelPlugins,
   getLoadedChannelPlugin: vi.fn(),
   getChannelPlugin: vi.fn(),
-  normalizeChannelId: (value: string) => value,
+  normalizeChannelId: mocks.normalizeChannelId,
+}));
+
+vi.mock("../../channels/plugins/read-only.js", () => ({
+  listReadOnlyChannelPluginsForConfig: mocks.listReadOnlyChannelPluginsForConfig,
 }));
 
 vi.mock("../../channels/plugins/catalog.js", () => ({
@@ -174,10 +183,13 @@ function requireRespondPayload(respond: ReturnType<typeof vi.fn>): Record<string
 describe("channelsHandlers channels.status", () => {
   afterEach(() => {
     setActiveDegradedSecretOwners([]);
+    setActivePluginRegistry(createTestRegistry([]));
   });
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.normalizeChannelId.mockImplementation((value: string) => value);
+    mocks.listReadOnlyChannelPluginsForConfig.mockImplementation(() => mocks.listChannelPlugins());
     mocks.getRuntimeConfig.mockReturnValue({});
     mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({ config, changes: [] }));
     mocks.buildChannelUiCatalog.mockReturnValue({
@@ -297,6 +309,52 @@ describe("channelsHandlers channels.status", () => {
         expect(buildChannelSummary).toHaveBeenCalledOnce();
       }
       expect(JSON.stringify(payload)).not.toContain("PRIVATE_TOKEN_REFERENCE");
+    },
+  );
+
+  it.each(["load", "register", "validation"] as const)(
+    "keeps a channel visible after its plugin fails during %s",
+    async (failurePhase) => {
+      const failedProbe = vi.fn();
+      const failed = createChannelPlugin({ id: "broken-channel", probeAccount: failedProbe });
+      const healthyProbe = vi.fn(async () => ({ ok: true }));
+      const healthy = createChannelPlugin({ id: "healthy", probeAccount: healthyProbe });
+      configureAutoEnabledChannels([healthy]);
+      mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([failed, healthy]);
+      setActivePluginRegistry({
+        ...createTestRegistry([]),
+        plugins: [
+          createPluginRecord({
+            id: "broken-owner",
+            enabled: true,
+            status: "error",
+            failurePhase,
+            channelIds: ["broken-channel"],
+            error: "missing SDK export",
+          }),
+        ],
+      });
+
+      const payload = await runChannelsStatus({ probe: true, timeoutMs: 1000 });
+
+      expect(firstChannelAccount(payload, "broken-channel")).toMatchObject({
+        configured: true,
+        running: false,
+        lifecycle: "blocked",
+        lastError: expect.stringContaining("missing SDK export"),
+      });
+      expect(requireGatewayRecord(payload.channels, "channels")["broken-channel"]).toMatchObject({
+        configured: true,
+        lastError: expect.stringContaining("missing SDK export"),
+      });
+      expect(failedProbe).not.toHaveBeenCalled();
+      expect(healthyProbe).toHaveBeenCalledOnce();
+      mocks.normalizeChannelId.mockReturnValueOnce(null);
+      const filtered = await runChannelsStatus({ channel: "broken-channel", probe: false });
+      expect(firstChannelAccount(filtered, "broken-channel").lifecycle).toBe("blocked");
+      expect(requireGatewayRecord(filtered.channelAccounts, "accounts")).not.toHaveProperty(
+        "healthy",
+      );
     },
   );
 

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -26,6 +26,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getChannelActivity } from "../../infra/channel-activity.js";
 import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
+import { isAccountEnabled } from "../../shared/account-enabled.js";
 import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
 import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
@@ -383,20 +384,13 @@ export const channelsHandlers: GatewayRequestHandlers = {
     }
     const statusWarnings: string[] = [];
 
-    const isAccountEnabled = (plugin: ChannelPlugin, account: unknown) =>
-      plugin.config.isEnabled
-        ? plugin.config.isEnabled(account, cfg)
-        : !account ||
-          typeof account !== "object" ||
-          (account as { enabled?: boolean }).enabled !== false;
-
     const buildAccountSnapshot = async (
       channelId: ChannelId,
       plugin: ChannelPlugin,
       accountId: string,
     ) => {
       const runtimeSnapshot = resolveRuntimeAccountSnapshot({ runtime, channelId, accountId });
-      const unavailable = resolveUnavailableChannelAccountSnapshot({
+      const unavailable = resolveUnavailableChannelAccountSnapshot(cfg, {
         channelId,
         accountId,
         runtime: runtimeSnapshot,
@@ -407,7 +401,7 @@ export const channelsHandlers: GatewayRequestHandlers = {
         return { accountId, snapshot: diagnosticSnapshot };
       }
       const account = plugin.config.resolveAccount(cfg, accountId);
-      const enabled = isAccountEnabled(plugin, account);
+      const enabled = plugin.config.isEnabled?.(account, cfg) ?? isAccountEnabled(account);
       let probeResult: unknown;
       let lastProbeAt: number | null = null;
       if (probe && enabled && plugin.status?.probeAccount) {

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -14,9 +14,9 @@ import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.j
 import {
   type ChannelId,
   getChannelPlugin,
-  listChannelPlugins,
   normalizeChannelId,
 } from "../../channels/plugins/index.js";
+import { listReadOnlyChannelPluginsForConfig } from "../../channels/plugins/read-only.js";
 import { buildChannelAccountSnapshotFromAccount } from "../../channels/plugins/status.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
@@ -355,14 +355,17 @@ export const channelsHandlers: GatewayRequestHandlers = {
     const timeoutMsRaw = (params as { timeoutMs?: unknown }).timeoutMs;
     const timeoutMs = resolveChannelsStatusTimeoutMs({ probe, timeoutMsRaw });
     const rawChannel = (params as { channel?: unknown }).channel;
-    const requestedChannel =
-      typeof rawChannel === "string" ? normalizeChannelId(rawChannel) : undefined;
     const runtimeConfig = context.getRuntimeConfig();
     const cfg = resolveGatewayPluginConfig({
       config: runtimeConfig,
     });
     const runtime = context.getRuntimeSnapshot();
-    const plugins = listChannelPlugins();
+    const plugins = listReadOnlyChannelPluginsForConfig(cfg);
+    const requestedChannel =
+      typeof rawChannel === "string"
+        ? (normalizeChannelId(rawChannel) ??
+          plugins.find((plugin) => plugin.id === rawChannel.trim().toLowerCase())?.id)
+        : undefined;
     const selectedPlugins = requestedChannel
       ? plugins.filter((plugin) => plugin.id === requestedChannel)
       : plugins;
@@ -378,22 +381,7 @@ export const channelsHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const pluginMap = new Map<ChannelId, ChannelPlugin>(
-      selectedPlugins.map((plugin) => [plugin.id, plugin]),
-    );
     const statusWarnings: string[] = [];
-
-    const resolveRuntimeSnapshot = (
-      channelId: ChannelId,
-      accountId: string,
-      defaultAccountId: string,
-    ): ChannelAccountSnapshot | undefined => {
-      const accounts = runtime.channelAccounts[channelId];
-      const defaultRuntimeLocal = runtime.channels[channelId];
-      return (
-        accounts?.[accountId] ?? (accountId === defaultAccountId ? defaultRuntimeLocal : undefined)
-      );
-    };
 
     const isAccountEnabled = (plugin: ChannelPlugin, account: unknown) =>
       plugin.config.isEnabled
@@ -406,9 +394,8 @@ export const channelsHandlers: GatewayRequestHandlers = {
       channelId: ChannelId,
       plugin: ChannelPlugin,
       accountId: string,
-      defaultAccountId: string,
     ) => {
-      const runtimeSnapshot = resolveRuntimeSnapshot(channelId, accountId, defaultAccountId);
+      const runtimeSnapshot = resolveRuntimeAccountSnapshot({ runtime, channelId, accountId });
       const unavailable = resolveUnavailableChannelAccountSnapshot({
         channelId,
         accountId,
@@ -509,16 +496,8 @@ export const channelsHandlers: GatewayRequestHandlers = {
       return { accountId, account, snapshot };
     };
 
-    const buildChannelAccounts = async (channelId: ChannelId) => {
-      const plugin = pluginMap.get(channelId);
-      if (!plugin) {
-        return {
-          accounts: [] as ChannelAccountSnapshot[],
-          defaultAccountId: DEFAULT_ACCOUNT_ID,
-          defaultAccount: undefined as ChannelAccountSnapshot | undefined,
-          resolvedAccounts: {} as Record<string, unknown>,
-        };
-      }
+    const buildChannelAccounts = async (plugin: ChannelPlugin) => {
+      const channelId = plugin.id;
       const accountIds = plugin.config.listAccountIds(cfg);
       const defaultAccountId = resolveChannelDefaultAccountId({
         plugin,
@@ -528,8 +507,7 @@ export const channelsHandlers: GatewayRequestHandlers = {
       const resolvedAccounts: Record<string, unknown> = {};
       const { results } = await runTasksWithConcurrency({
         tasks: accountIds.map(
-          (accountId) => async () =>
-            await buildAccountSnapshot(channelId, plugin, accountId, defaultAccountId),
+          (accountId) => async () => await buildAccountSnapshot(channelId, plugin, accountId),
         ),
         limit: probe ? CHANNEL_STATUS_PROBE_CONCURRENCY : accountIds.length || 1,
         onTaskError: (error, index) => {
@@ -570,7 +548,7 @@ export const channelsHandlers: GatewayRequestHandlers = {
     const { results: channelResults } = await runTasksWithConcurrency({
       tasks: statusPlugins.map((plugin) => async () => {
         const { accounts, defaultAccountId, defaultAccount, resolvedAccounts } =
-          await buildChannelAccounts(plugin.id);
+          await buildChannelAccounts(plugin);
         const fallbackSummary = (lastError = defaultAccount?.lastError) => ({
           configured: defaultAccount?.configured ?? false,
           ...(lastError ? { lastError } : {}),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators checking channel status would see no configured channel after its plugin failed to load or register. A retained incompatible Discord plugin could leave the Gateway ready while the channel disappeared from status and its health account had no error.

Related: #122655 (published Discord/core skew), #133828 (retained Discord generation), and #130290 (drift diagnostics and catalog guidance). Thanks to @vguyon-dev, @0xCyda, and @liemnhoang for the reports.

## Why This Change Was Made

The loader already records the failure and manifest-declared channel ownership. Channel status was enumerating only successful registrations, and the shared unavailable-account projection handled only cold secret owners. Status now uses the existing metadata-only inventory, and status/health project the recorded plugin failure without executing failed plugin code or reusing stale successful probes. A healthy registered channel owner wins over an unrelated failed plugin declaring the same channel.

This also removes the redundant channel lookup, duplicate runtime-snapshot resolver, and duplicated account-enablement policy. Explicitly disabled named accounts stay disabled. Loader and service error summaries are redacted and bounded before public health caching; full internal loader diagnostics remain available. No SDK compatibility re-export, configuration option, persistence change, protocol change, or plugin-generation precedence change is added.

## User Impact

A failed configured channel remains visible as blocked and not running, with the plugin error and a doctor recovery hint. Targeted status queries work even when the channel never registered its runtime name. Other channels and existing secret-owner behavior remain intact.

Doctor's running-version comparison is already correct for the reproduced published pair: it reported Discord 2026.7.1 against core 2026.8.1 and recommended the matching update. A second live run overrode the doctor CLI version to 2026.7.1 while the Gateway stayed on 2026.8.1; doctor still selected the running Gateway version. The separate post-upgrade omission is already fixed by #134719. The catalog recovery hint in #130290 and the unrecorded generation-selection sequence in #133828 are not changed here.

## Evidence

- Regression before the fix: all three new load/register/validation cases failed because the failed channel account was absent.
- Focused owner/sibling suite: 168 checks passed across account state, channel manager lifecycle, RPC status, health, and status formatting. Redaction suite: 212 checks passed (189 redactor, 20 RPC, 3 health). The final health projection regression failed before the fix and the RPC/health rerun passed all 23 checks.
- Production: +79/-80 (net -1). Tests: +178/-5 (net +173). Assertion baseline: one shrink-only entry, 16 to 12. Docs: +2.
- Autoreview: final branch review passed at the configured P0 threshold.

Live proof used a disposable state directory, free loopback port, and synthetic credentials. Published core 2026.8.1 plus the officially installed Discord 2026.7.1 reproduced the exact missing privateFileStore export. The Gateway reported ready, channels.status returned an empty channel map, and health.channels.discord.lastError was null while the plugin-level load error was recorded.

The locally packed candidate with the same official Discord 2026.7.1 plugin still records the exact missing export, but now both `channels.status` and `health.channels.discord` expose `lifecycle: blocked`, `running: false`, and the original error plus `run openclaw doctor`. The unchanged published Control UI now shows Discord as “Needs attention” and displays the failure in channel details. The screenshots use synthetic-only state.

Sanitized live transcript:

```text
published core 2026.8.1 + @openclaw/discord@2026.7.1
  plugin load: missing privateFileStore export
  gateway: ready
  channels.status.channelOrder: []
  health.channels.discord.lastError: null
  doctor: discord 2026.7.1 -> expected core 2026.8.1

locally packed candidate + @openclaw/discord@2026.7.1
  plugin load: same missing privateFileStore export
  gateway: ready
  channels.status.channelOrder: [discord]
  channel account: configured=true, running=false, lifecycle=blocked
  channel status + health lastError: Plugin discord failed: ...privateFileStore...; run openclaw doctor
  UI: Discord / Needs attention / Last error shown
  named disabled account: enabled=false, failure remains visible

published core 2026.8.1 + @openclaw/discord@2026.8.1
  plugin: loaded, no registration errors
  provider: starts; synthetic Discord credential receives expected HTTP 401

additional local throwing-plugin fixture, operator.read only
  before: synthetic credential exposed in status and health
  after: accepted scopes=[operator.read]; credential absent from entire status + health response
  error length: channel=1021 including doctor hint; health plugin error=1000
  original Discord loader diagnostic and disabled-account state preserved
```

This is real packaged Gateway load/RPC/UI proof, not authenticated Discord message-delivery proof. Synthetic credentials intentionally cannot connect a Discord bot. Both sides serve the same published UI assets; the candidate tarball is a local runtime-proof artifact, not a release artifact.

Build/check status: full build completed through SDK declarations, plugin bootstrap, runtime postbuild, UI budgets, and CLI metadata. The first declaration attempt rejected changed resolution topology; the guarded retry passed with a stable source tree. All changed-file checks passed. Exact-head CI on d19b1095a0c9dd6606cd6c77eeaad35bbcb94e73 is green: [CI run](https://github.com/openclaw/openclaw/actions/runs/33498785551). A canceled labeler job caused a transient red rollup after a body edit; its rerun passed. No test failure occurred on this final head.

ClawSweeper rank-up: sanitize and bound loader errors, retain useful recovery text, and add a credential-bearing regression. Addressed in both channel projection and the existing health plugin-error summary. The review's persistent-data-model flag does not apply: no store, schema, or persistence semantics changed.

Known follow-ups, not hidden compatibility changes: honor per-account disablement in the general manifest-only inventory (`src/channels/plugins/read-only.ts`), and redact/bound package-verification quarantine diagnostic detail at `toPublicPluginVerificationDiagnostic`. Neither is the loader-registration failure path repaired here; no claim is made that every plugin diagnostic surface is sanitized.

NO-FOLLOW-UP: The repair removes three redundant status/enablement paths and consolidates health error presentation; no additional bounded rent-paying refactor warrants a separate PR.

![Before: configured Discord disappears after plugin load failure](https://github.com/user-attachments/assets/43f089c4-e0b4-4783-a47a-c1c510b1bf86)

![After: Discord remains visible and needs attention](https://github.com/user-attachments/assets/b441fa99-19f0-465d-981e-959d182aeef0)

![After: channel details expose the recorded plugin failure](https://github.com/user-attachments/assets/07c1092c-ffc0-4cfe-85a8-7c44dc3b187c)

Landed via the native prepare/merge flow as `c1db1df98ec181bef66868d1e08aae22013eec88`; verified as an ancestor of `origin/main`. Final ClawSweeper review of the exact head reported no correctness or security findings. Native merge verification warned about mainline drift; the affected runtime overlap was inspected and the normal hosted CI gate passed.
