### PR TITLE
refactor(qa): share mock assistant streaming event construction

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts
@@ -275,11 +275,13 @@ function appendAssistantMessageEvents(
       text: spec.text,
     });
   }
+  const item = buildAssistantOutputItem(spec);
   events.push({
     type: "response.output_item.done",
     output_index: outputIndex,
-    item: buildAssistantOutputItem(spec),
+    item,
   });
+  return item;
 }
 
 export function buildAssistantThenToolCallEvents(
@@ -357,6 +359,21 @@ export function buildAssistantEvents(
   return events;
 }
 
+export function buildStreamingFinalAnswerEvents(
+  id: string,
+  text: string,
+  previewText = text,
+): StreamEvent[] {
+  return buildAssistantEvents([
+    {
+      id,
+      phase: "final_answer",
+      streamDeltas: splitMockStreamingText(previewText),
+      text,
+    },
+  ]);
+}
+
 export function buildReasoningOnlyEvents(summaryText: string, id: string): StreamEvent[] {
   const reasoningItem = {
     type: "reasoning",
@@ -400,12 +417,7 @@ export function buildReasoningAndAssistantEvents(params: {
     id: params.reasoningId,
     summary: [],
   } as const;
-  const answerItem = buildAssistantOutputItem({
-    id: params.answerId ?? "msg_mock_reasoned_answer",
-    phase: "final_answer",
-    text: params.answerText,
-  });
-  return [
+  const events: StreamEvent[] = [
     {
       type: "response.output_item.added",
       output_index: 0,
@@ -420,45 +432,25 @@ export function buildReasoningAndAssistantEvents(params: {
       output_index: 0,
       item: reasoningItem,
     },
+  ];
+  const answerItem = appendAssistantMessageEvents(
+    events,
     {
-      type: "response.output_item.added",
-      output_index: 1,
-      item: {
-        type: "message",
-        id: answerItem.id,
-        role: "assistant",
-        phase: "final_answer",
-        content: [],
-        status: "in_progress",
-      },
-    },
-    {
-      type: "response.output_text.delta",
-      item_id: answerItem.id,
-      output_index: 1,
-      content_index: 0,
-      delta: params.answerText,
-    },
-    {
-      type: "response.output_text.done",
-      item_id: answerItem.id,
-      output_index: 1,
-      content_index: 0,
+      id: params.answerId ?? "msg_mock_reasoned_answer",
+      phase: "final_answer",
+      streamDeltas: [params.answerText],
       text: params.answerText,
     },
-    {
-      type: "response.output_item.done",
-      output_index: 1,
-      item: answerItem,
+    1,
+  );
+  events.push({
+    type: "response.completed",
+    response: {
+      id: `resp_${params.reasoningId}`,
+      status: "completed",
+      output: [reasoningItem, answerItem],
+      usage: { input_tokens: 64, output_tokens: 16, total_tokens: 80 },
     },
-    {
-      type: "response.completed",
-      response: {
-        id: `resp_${params.reasoningId}`,
-        status: "completed",
-        output: [reasoningItem, answerItem],
-        usage: { input_tokens: 64, output_tokens: 16, total_tokens: 80 },
-      },
-    },
-  ];
+  });
+  return events;
 }

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -151,6 +151,7 @@ import {
   buildQaLongFinalText,
   buildAssistantThenToolCallEvents,
   buildAssistantEvents,
+  buildStreamingFinalAnswerEvents,
   buildPartialFailureEvents,
   buildReasoningOnlyEvents,
   buildReasoningAndAssistantEvents,
@@ -1503,25 +1504,11 @@ async function buildResponsesPayload(
       segmentCount: 96,
       startMarker: "TELEGRAM-LONG-FINAL-3CHUNK-BEGIN",
     });
-    return buildAssistantEvents([
-      {
-        id: "msg_mock_telegram_long_final_three_chunk",
-        phase: "final_answer",
-        streamDeltas: splitMockStreamingText(text),
-        text,
-      },
-    ]);
+    return buildStreamingFinalAnswerEvents("msg_mock_telegram_long_final_three_chunk", text);
   }
   if (QA_TELEGRAM_LONG_FINAL_PROMPT_RE.test(allInputText)) {
     const text = buildQaLongFinalText();
-    return buildAssistantEvents([
-      {
-        id: "msg_mock_telegram_long_final",
-        phase: "final_answer",
-        streamDeltas: splitMockStreamingText(text),
-        text,
-      },
-    ]);
+    return buildStreamingFinalAnswerEvents("msg_mock_telegram_long_final", text);
   }
   if (QA_WHATSAPP_LONG_FINAL_PROMPT_RE.test(allInputText)) {
     const text = buildQaLongFinalText({
@@ -1530,14 +1517,7 @@ async function buildResponsesPayload(
       segmentCount: 64,
       startMarker: "WHATSAPP-LONG-FINAL-BEGIN",
     });
-    return buildAssistantEvents([
-      {
-        id: "msg_mock_whatsapp_long_final",
-        phase: "final_answer",
-        streamDeltas: splitMockStreamingText(text),
-        text,
-      },
-    ]);
+    return buildStreamingFinalAnswerEvents("msg_mock_whatsapp_long_final", text);
   }
   const whatsAppPendingHistoryReply = buildWhatsAppPendingHistoryReply(prompt, input);
   if (whatsAppPendingHistoryReply) {
@@ -1635,48 +1615,30 @@ async function buildResponsesPayload(
     QA_STREAMING_PROMPT_RE.test(allInputText) &&
     allInputText.includes(QA_TELEGRAM_STREAM_SINGLE_MARKER)
   ) {
-    return buildAssistantEvents([
-      {
-        id: "msg_mock_telegram_quiet_stream",
-        phase: "final_answer",
-        streamDeltas: splitMockStreamingText(QA_TELEGRAM_STREAM_SINGLE_MARKER),
-        text: QA_TELEGRAM_STREAM_SINGLE_MARKER,
-      },
-    ]);
+    return buildStreamingFinalAnswerEvents(
+      "msg_mock_telegram_quiet_stream",
+      QA_TELEGRAM_STREAM_SINGLE_MARKER,
+    );
   }
   if (
     QA_FINAL_ONLY_MARKER_STREAMING_PROMPT_RE.test(scenarioFamilyPrompt) &&
     scenarioFamilyReplyDirective
   ) {
-    return buildAssistantEvents([
-      {
-        id: "msg_mock_final_only_marker_stream",
-        phase: "final_answer",
-        streamDeltas: splitMockStreamingText("QA streaming preview in progress"),
-        text: scenarioFamilyReplyDirective,
-      },
-    ]);
+    return buildStreamingFinalAnswerEvents(
+      "msg_mock_final_only_marker_stream",
+      scenarioFamilyReplyDirective,
+      "QA streaming preview in progress",
+    );
   }
   if (QA_STREAMING_PROMPT_RE.test(scenarioFamilyPrompt) && scenarioFamilyReplyDirective) {
-    return buildAssistantEvents([
-      {
-        id: "msg_mock_quiet_stream",
-        phase: "final_answer",
-        streamDeltas: splitMockStreamingText(scenarioFamilyReplyDirective),
-        text: scenarioFamilyReplyDirective,
-      },
-    ]);
+    return buildStreamingFinalAnswerEvents("msg_mock_quiet_stream", scenarioFamilyReplyDirective);
   }
   if (slackProgressDirectives) {
     if (hasSlackProgressToolOutput) {
-      return buildAssistantEvents([
-        {
-          id: "msg_mock_slack_progress_final",
-          phase: "final_answer",
-          streamDeltas: splitMockStreamingText(slackProgressDirectives.finalMarker),
-          text: slackProgressDirectives.finalMarker,
-        },
-      ]);
+      return buildStreamingFinalAnswerEvents(
+        "msg_mock_slack_progress_final",
+        slackProgressDirectives.finalMarker,
+      );
     }
     if (hasDeclaredTool(body, "exec")) {
       return buildAssistantThenToolCallEvents(
@@ -1730,14 +1692,7 @@ async function buildResponsesPayload(
         },
       );
     }
-    return buildAssistantEvents([
-      {
-        id: "msg_mock_block_2",
-        phase: "final_answer",
-        streamDeltas: splitMockStreamingText(blockStreamingMarkers.second),
-        text: blockStreamingMarkers.second,
-      },
-    ]);
+    return buildStreamingFinalAnswerEvents("msg_mock_block_2", blockStreamingMarkers.second);
   }
   if (isStrandedFinalRetryFailureRequest(allInputText)) {
     return buildAssistantEvents(buildStrandedFinalRetryFailureText());


### PR DESCRIPTION
The QA mock repeated the same final-message streaming specification in eight scenario branches and built the assistant half of reasoning responses separately. The existing event owner now constructs both, preserving scenario decisions and the transport adapters.

Event order, IDs, indexes, phase, usage, empty and whitespace answers, preview/final text differences, and completion object identity remain unchanged. The reasoning path still emits one delta even for an empty answer. Production is **+55/-108, net -53 lines** (-54 nonblank); tests are unchanged. No API, configuration, dependency, storage or scenario policy changes.

Validation used 306 passing maintained tests across five files, all 24 selected changed-path gates, and a clean independent Codex P2 review. Fifty-nine baseline/candidate observations cover actual loopback HTTP, streaming/nonstreaming responses, OpenAI 7.5.0, WebSocket warmup and continuation, stale response IDs, sequence numbers, Anthropic wire siblings and in-memory object identity. Exact comparisons preserve own-field order and undefined values; only recorded timestamp/random-ID fields are normalized. Original observations are retained.

The real built QA CLI also ran against temporary Gateways before and after. Channel message flows, thinking visibility and blank-answer model fallback passed in both versions. The separate agent progress follow-through scenario failed the same existing final-tool-trace assertion in both: the read and matched result complete, and the final marker is delivered, but the final edited QA-channel event omits `toolCalls`. That failure is recorded as a separate follow-up; no assertions or verdicts were weakened, and these runs are not claimed wholly green. The fallback flow retained three primary attempts, one alternate attempt and exactly one visible answer.

The acting maintainer inspected the sibling Codex source at `94cbbddafc1776d5e377bca1b05932c697e82238`, including `codex-rs/codex-api/src/sse/responses.rs:1` and `codex-rs/protocol/src/models.rs:900`, for the event-consumption contract. This is real local transport and QA-runtime proof, not an executed Codex runtime, hosted-provider or external-channel acceptance claim. The changed code is an internal mock and needs no external account.


Maintainer landing review: The latest 10:17 UTC ClawSweeper review is code-clean. Its request for normal exact-head checks and maintainer handling is satisfied by successful CI 33495934278 and root review under the user-authorized campaign. No rank-up move remains. Production +55/-108 = -53 physical, -54 nonblank. Tests unchanged; no formatting or move inflation. Actual local QA and wire-client proof, not a running Codex instance or hosted-provider/external-channel acceptance claim. The unchanged progress-scenario failure remains recorded.
