### PR TITLE
perf(models): avoid redundant catalog sanitization

### DIFF
--- a/packages/model-catalog-core/src/remote-catalog-bundle.ts
+++ b/packages/model-catalog-core/src/remote-catalog-bundle.ts
@@ -153,11 +153,16 @@ function stripRemoteTransportOverrides(value: unknown): unknown {
   if (!value || typeof value !== "object") {
     return value;
   }
-  return Object.fromEntries(
-    Object.entries(value)
-      .filter(([key]) => key !== "baseUrl" && key !== "headers")
-      .map(([key, entry]) => [key, stripRemoteTransportOverrides(entry)]),
-  );
+  const entries = Object.entries(value);
+  let kept = 0;
+  for (const entry of entries) {
+    if (entry[0] !== "baseUrl" && entry[0] !== "headers") {
+      entry[1] = stripRemoteTransportOverrides(entry[1]);
+      entries[kept++] = entry;
+    }
+  }
+  entries.length = kept;
+  return Object.fromEntries(entries);
 }
 
 /** Removes every transport endpoint/header override before remote data reaches persistence. */

--- a/src/model-catalog/remote-refresh.ts
+++ b/src/model-catalog/remote-refresh.ts
@@ -1,4 +1,5 @@
 import {
+  parseRemoteModelCatalogBundle,
   validateAndSanitizeRemoteModelCatalogBundle,
   type RemoteModelCatalogBundle,
 } from "@openclaw/model-catalog-core";
@@ -39,7 +40,7 @@ function bundleCounts(bundle: RemoteModelCatalogBundle): RefreshCounts {
 }
 
 function storedCounts(bundleJson: string): RefreshCounts & { generatedAt: number } {
-  const bundle = validateAndSanitizeRemoteModelCatalogBundle(JSON.parse(bundleJson));
+  const bundle = parseRemoteModelCatalogBundle(JSON.parse(bundleJson));
   return { ...bundleCounts(bundle), generatedAt: bundle.generatedAt };
 }
 


### PR DESCRIPTION
Catalog refreshes were recursively copying already-sanitized stored bundles just to report provider/model counts. The incoming sanitizer also allocated separate filter/map arrays and new entry pairs at every object.

This keeps schema validation on stored reads, removes only their discarded sanitizer copy, and compacts the sanitizer's owned entry array in place. Incoming HTTP 200 data still validates and strips every transport endpoint/header override before persistence; overlay activation still sanitizes independently. Input objects, property order, conditional requests, races, abort/error behavior, persisted shape and schema version stay unchanged.

Production: +12/−6, net +6; tests: 0. The six extra lines replace intermediate arrays with one bounded owned traversal; there is no new cache, dependency, configuration or alternate compatibility path. Arbitrary manually inserted unsanitized cache rows are not a producer contract; the canonical writer already sanitizes before storing them.

Validation: 20 existing catalog/core/store/overlay/CLI tests pass before and after; the three selected six-hour refresh/shutdown/TTL scheduler tests pass (90 unrelated cases not run). Full changed-code checks passed in 233.36s and the clean committed full build in 200.08s. Independent source and raw-results reviews passed; scoped managed review found no actionable issues at its requested priority threshold.

Measured the complete exported refresh operation with native SQLite and guarded supplied Responses, including validation, serialization and transport lifecycle. This measures operation CPU/wall work, not HTTP download, DNS/TLS, Gateway startup or model latency. Fresh proof covers 32 scenarios and 12 exact-byte workload oracles per variant. The fixed before/candidate/candidate/before sequence retained 528 measured blocks,192 warmups,48 row-local first calls and 12,108 complete operations. Ordinary refreshes save 88–112µs; the captured public-catalog fixture saves 9.3–11.0ms on fresh reads.

Percent change versus before (negative is faster):

| Workload | Median forward | Median reverse | First forward | First reverse |
|---|---:|---:|---:|---:|
| fresh-one | -5.56% | -5.97% | -27.83% | -6.48% |
| fresh-ordinary-transport | -24.15% | -29.36% | -34.31% | -11.58% |
| fresh-public-catalog | -36.92% | -39.53% | -31.94% | -27.57% |
| 304-one | -8.54% | +14.89% | +22.42% | +73.99% |
| 304-ordinary-transport | -18.90% | -11.82% | -22.57% | -21.02% |
| 304-public-catalog | -32.11% | -28.75% | -16.26% | -43.88% |
| retained-newer-one | -2.33% | +2.77% | +60.96% | -23.06% |
| retained-newer-ordinary-transport | -11.77% | -14.48% | -20.66% | -28.64% |
| retained-newer-public-catalog | -15.81% | -20.41% | -28.75% | -16.41% |
| identical-200-ordinary-transport | +3.03% | +2.45% | +36.47% | -7.90% |
| invalid-json-retains-one | -2.48% | -1.86% | +7.10% | +42.31% |
| disabled-one | -3.30% | -0.33% | +21.07% | -9.28% |

Both fresh ordinary/public rows passed the predefined 3% improvement requirement in both orders. No protected row regressed by more than 3% in both orders. All four adverse median comparisons and seven adverse first comparisons are retained above. Identical 200 ordinary refreshes cost an additional 22–28µs (+3.03%/+2.45%); that tradeoff is accepted against the larger stored-read savings. First calls are per row after initialization, not cold process startup. Raw CPU/RSS diagnostics are retained without a heap-savings claim. No samples were discarded or timing runs repeated.

Measurement provenance: source HEAD 3e374966 with precisely the two-file candidate diff; after measurements, commit 0887e60f preserved both owner byte hashes. All six proof/timing outer exits were zero; 18 processes, 12 groups, 6 worker generations and 48 exact coordinator paths were independently confirmed closed/absent.

Real built CLI/HTTP proof passed on clean commit 0887e60f in 6.35s (behavior only, not a speed measurement). Three fresh `openclaw models refresh --json` processes exercised an owned numeric-loopback server: HTTP 200 returned `updated` with one provider/model and exact sanitized durable bytes; a bodyless conditional 304 returned `unchanged` and advanced both persisted check timestamps; malformed UTF-8 returned exit 1 with a visible `cli_error` and preserved the complete prior catalog row byte-for-byte. Independent native Node read-only/query-only SQLite snapshots verified all three outcomes. No injected fetch, clock, build stamp, store, provider credentials or user configuration was used. All 36 observed processes, three CLI groups, listener and eight exact coordinator paths were independently confirmed closed/absent; owned temporary state was removed.

Two earlier real-HTTP attempts are retained as failures after their successful first CLI 200. The second captured a system-Python SQLite SELECT failure against the retained WAL-mode main file with absent sidecars. Separate pristine-copy diagnostics reproduced that read-only limitation in the system runtime; Node's native read-only reader succeeded on the same main bytes. The proof now uses that single independently reviewed native reader, with no writable/immutable fallback. This is a fixture/runtime-specific observation, not a claimed upstream SQLite defect. Neither failed attempt is counted as successful proof, and the performance sequence was not rerun.

ClawSweeper's September 1 10:15 UTC review and its rank-up request are addressed by the completed persisted-row/304/invalid-UTF-8 trace above. The serialized-state heuristic does not represent a data-model change: the canonical producer still writes the identical sanitized bundle and row shape, and schema version and overlay validation are unchanged. No migration is needed. Exact-head CI and native landing validation remain required.
