### PR TITLE
Use per-stream commentary ids to stop WebChat duplicate segments (#134971)

### DIFF
--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -1203,6 +1203,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
         }
         const blocks = output.content;
         const blockIndexes = new Map<number, number>();
+        const commentarySequence = { next: 0 };
         // Preview schedules are per active tool call; WeakMap keys die with the block.
         const toolArgumentPreviewSchedules = new WeakMap<
           Extract<TransportContentBlock, { type: "toolCall" }>,
@@ -1504,7 +1505,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               continue;
             }
             if (contentBlock?.type === "tool_use") {
-              tagPendingCommentaryText(output.content);
+              tagPendingCommentaryText(output.content, { commentarySequence });
               flushPendingTextEnds();
               const block: TransportContentBlock = {
                 type: "toolCall",
@@ -1726,7 +1727,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               output.stopReason === "toolUse" ||
               output.content.some((block) => block.type === "toolCall")
             ) {
-              tagPendingCommentaryText(output.content);
+              tagPendingCommentaryText(output.content, { commentarySequence });
             }
             flushPendingTextEnds();
           }
@@ -1769,7 +1770,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
           output.stopReason === "toolUse" ||
           output.content.some((block) => block.type === "toolCall")
         ) {
-          tagPendingCommentaryText(output.content);
+          tagPendingCommentaryText(output.content, { commentarySequence });
         }
         flushPendingTextEnds();
         finalizeTransportStream({ stream, output });

--- a/packages/ai/src/transports/openai-completions-stream-reasoning.ts
+++ b/packages/ai/src/transports/openai-completions-stream-reasoning.ts
@@ -1,0 +1,33 @@
+import type { ChatCompletionChunk } from "openai/resources/chat/completions.js";
+import type { OpenAICompletionsOptions } from "../provider-options.js";
+import {
+  isOpenAICompletionsThinkingEnabled,
+  type OpenAIModeModel,
+} from "./openai-transport-shared.js";
+
+function resolveOpenAICompletionsReasoningEffort(options: OpenAICompletionsOptions | undefined) {
+  return options?.reasoningEffort ?? options?.reasoning ?? "high";
+}
+
+export function shouldEmitOpenAICompletionsReasoning(
+  model: OpenAIModeModel,
+  options: OpenAICompletionsOptions | undefined,
+) {
+  if (!model.reasoning) {
+    return false;
+  }
+  const effort = resolveOpenAICompletionsReasoningEffort(options);
+  if (!effort || !isOpenAICompletionsThinkingEnabled(effort)) {
+    return false;
+  }
+  return true;
+}
+
+export function hasOpenAICompletionsReasoningUsageActivity(
+  rawUsage: NonNullable<ChatCompletionChunk["usage"]>,
+) {
+  const reasoningTokens = rawUsage.completion_tokens_details?.reasoning_tokens;
+  return (
+    typeof reasoningTokens === "number" && Number.isFinite(reasoningTokens) && reasoningTokens > 0
+  );
+}

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { AssistantMessageEvent, Model } from "@openclaw/llm-core";
 import type { ChatCompletionChunk } from "openai/resources/chat/completions.js";
-import type { OpenAICompletionsOptions } from "../provider-options.js";
 import {
   createOpenAICompletionsToolCallDeltaNormalizer,
   createOpenAIEncryptedToolCallReasoningTracker,
@@ -9,11 +8,9 @@ import {
 } from "../providers/openai-completions-tool-calls.js";
 import { mapOpenAIStopReason } from "../providers/openai-stop-reason.js";
 import {
-  clearPendingCommentaryText,
+  finalizeStreamCommentaryPhases,
   rememberPendingCommentaryTags,
-  tagInterruptedTextPhases,
   tagPendingCommentaryText,
-  tagUnresolvedTextAsCommentary,
   type PendingCommentaryTags,
 } from "../utils/assistant-text-phase.js";
 import {
@@ -29,10 +26,10 @@ import {
   createDsmlRecoverer,
   type RecoveredDeepSeekDsmlToolCall,
 } from "./openai-completions-dsml.js";
+import { hasOpenAICompletionsReasoningUsageActivity } from "./openai-completions-stream-reasoning.js";
 import { getCompat } from "./openai-transport-params.js";
 import {
   createModelStreamCooperativeScheduler,
-  isOpenAICompletionsThinkingEnabled,
   parseOpenAICompletionsUsage,
   readOpenAICompletionsContentDeltas,
   readOpenAICompletionsReasoningBatch,
@@ -42,6 +39,8 @@ import {
   type OpenAICompletionsTextSource,
   type OpenAIModeModel,
 } from "./openai-transport-shared.js";
+
+export { shouldEmitOpenAICompletionsReasoning } from "./openai-completions-stream-reasoning.js";
 
 type OpenAICompatibleChoice = ChatCompletionChunk["choices"][number] & {
   // Some compatible providers attach usage per choice instead of per chunk.
@@ -682,53 +681,13 @@ export async function processCompletionsStream(
       });
     },
   });
-  if (
-    confirmedInterruptedTextBlock &&
-    output.stopReason !== "toolUse" &&
-    output.stopReason !== "error" &&
-    output.stopReason !== "aborted"
-  ) {
-    tagInterruptedTextPhases(
-      output.content,
-      confirmedInterruptedTextBlock,
-      explicitVisibleTextBlocks,
-      { commentarySequence },
-    );
-  }
-  if (output.stopReason !== "toolUse") {
-    clearPendingCommentaryText(provisionalCommentaryTags);
-  }
-  if (output.stopReason === "error" || output.stopReason === "aborted") {
-    tagUnresolvedTextAsCommentary(output, { commentarySequence });
-  }
-  if (output.stopReason === "toolUse") {
-    tagPendingCommentaryText(output.content, { commentarySequence });
-  }
-}
-
-function resolveOpenAICompletionsReasoningEffort(options: OpenAICompletionsOptions | undefined) {
-  return options?.reasoningEffort ?? options?.reasoning ?? "high";
-}
-
-export function shouldEmitOpenAICompletionsReasoning(
-  model: OpenAIModeModel,
-  options: OpenAICompletionsOptions | undefined,
-) {
-  if (!model.reasoning) {
-    return false;
-  }
-  const effort = resolveOpenAICompletionsReasoningEffort(options);
-  if (!effort || !isOpenAICompletionsThinkingEnabled(effort)) {
-    return false;
-  }
-  return true;
-}
-
-function hasOpenAICompletionsReasoningUsageActivity(
-  rawUsage: NonNullable<ChatCompletionChunk["usage"]>,
-) {
-  const reasoningTokens = rawUsage.completion_tokens_details?.reasoning_tokens;
-  return (
-    typeof reasoningTokens === "number" && Number.isFinite(reasoningTokens) && reasoningTokens > 0
-  );
+  finalizeStreamCommentaryPhases({
+    stopReason: output.stopReason,
+    content: output.content,
+    provisionalCommentaryTags,
+    commentarySequence,
+    confirmedInterruptedTextBlock,
+    explicitVisibleTextBlocks,
+    output,
+  });
 }

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -138,6 +138,7 @@ export async function processCompletionsStream(
   // Preview schedules are per active tool call; WeakMap keys die with the block.
   const toolArgumentPreviewSchedules = new WeakMap<ToolCallBlock, ToolArgumentPreviewSchedule>();
   const provisionalCommentaryTags = directMode ? options.provisionalCommentaryTags : new Map();
+  const commentarySequence = { next: 0 };
   const contentBlockIndices = new WeakMap<TextBlock | ThinkingBlock, number>();
   const toolCallBlockIndices = new WeakMap<ToolCallBlock, number>();
   let explicitVisibleTextBlocks: Set<TextBlock> | undefined;
@@ -308,7 +309,7 @@ export async function processCompletionsStream(
     }
     rememberPendingCommentaryTags(
       provisionalCommentaryTags,
-      tagPendingCommentaryText(output.content),
+      tagPendingCommentaryText(output.content, { commentarySequence }),
     );
     const block: ToolCallBlock = {
       type: "toolCall",
@@ -563,7 +564,7 @@ export async function processCompletionsStream(
         flushReasoningTagTextPartitioner();
         rememberPendingCommentaryTags(
           provisionalCommentaryTags,
-          tagPendingCommentaryText(output.content),
+          tagPendingCommentaryText(output.content, { commentarySequence }),
         );
         for (const toolCall of toolCallDeltas) {
           const streamIndex = typeof toolCall.index === "number" ? toolCall.index : undefined;
@@ -691,16 +692,17 @@ export async function processCompletionsStream(
       output.content,
       confirmedInterruptedTextBlock,
       explicitVisibleTextBlocks,
+      { commentarySequence },
     );
   }
   if (output.stopReason !== "toolUse") {
     clearPendingCommentaryText(provisionalCommentaryTags);
   }
   if (output.stopReason === "error" || output.stopReason === "aborted") {
-    tagUnresolvedTextAsCommentary(output);
+    tagUnresolvedTextAsCommentary(output, { commentarySequence });
   }
   if (output.stopReason === "toolUse") {
-    tagPendingCommentaryText(output.content);
+    tagPendingCommentaryText(output.content, { commentarySequence });
   }
 }
 

--- a/packages/ai/src/utils/assistant-text-phase.test.ts
+++ b/packages/ai/src/utils/assistant-text-phase.test.ts
@@ -28,8 +28,8 @@ describe("assistant text phase tags", () => {
   });
 
   it("assigns monotonic commentary ids across separate tagging passes", () => {
-    const firstMessage = [{ type: "text", text: "Checking inventory." }];
-    const secondMessage = [{ type: "text", text: "Still working." }];
+    const firstMessage: TestTextBlock[] = [{ type: "text", text: "Checking inventory." }];
+    const secondMessage: TestTextBlock[] = [{ type: "text", text: "Still working." }];
     const commentarySequence = { next: 0 };
 
     tagPendingCommentaryText(firstMessage, { commentarySequence });

--- a/packages/ai/src/utils/assistant-text-phase.test.ts
+++ b/packages/ai/src/utils/assistant-text-phase.test.ts
@@ -27,6 +27,22 @@ describe("assistant text phase tags", () => {
     expect(content[2]?.textSignature).toBe("provider-signature");
   });
 
+  it("assigns monotonic commentary ids across separate tagging passes", () => {
+    const firstMessage = [{ type: "text", text: "Checking inventory." }];
+    const secondMessage = [{ type: "text", text: "Still working." }];
+    const commentarySequence = { next: 0 };
+
+    tagPendingCommentaryText(firstMessage, { commentarySequence });
+    tagPendingCommentaryText(secondMessage, { commentarySequence });
+
+    expect(JSON.parse(String(firstMessage[0]?.textSignature))).toMatchObject({
+      id: "commentary-0",
+    });
+    expect(JSON.parse(String(secondMessage[0]?.textSignature))).toMatchObject({
+      id: "commentary-1",
+    });
+  });
+
   it("rolls back only unchanged signatures created by this turn", () => {
     const generated: TestTextBlock = { type: "text", text: "generated" };
     const replaced: TestTextBlock = { type: "text", text: "replaced" };

--- a/packages/ai/src/utils/assistant-text-phase.ts
+++ b/packages/ai/src/utils/assistant-text-phase.ts
@@ -122,3 +122,42 @@ export function rememberPendingCommentaryTags(
     target.set(block, signature);
   }
 }
+
+/** Applies end-of-stream commentary tagging for completions transports. */
+export function finalizeStreamCommentaryPhases(params: {
+  stopReason: string | undefined;
+  content: ReadonlyArray<unknown>;
+  provisionalCommentaryTags: PendingCommentaryTags;
+  commentarySequence: { next: number };
+  confirmedInterruptedTextBlock?: unknown;
+  explicitVisibleTextBlocks?: ReadonlySet<unknown>;
+  output: {
+    content: ReadonlyArray<unknown>;
+    openclawDelivery?: { textPhaseRequiresTerminal?: true };
+  };
+}): void {
+  if (
+    params.confirmedInterruptedTextBlock &&
+    params.stopReason !== "toolUse" &&
+    params.stopReason !== "error" &&
+    params.stopReason !== "aborted"
+  ) {
+    tagInterruptedTextPhases(
+      params.content,
+      params.confirmedInterruptedTextBlock,
+      params.explicitVisibleTextBlocks,
+      { commentarySequence: params.commentarySequence },
+    );
+  }
+  if (params.stopReason !== "toolUse") {
+    clearPendingCommentaryText(params.provisionalCommentaryTags);
+  }
+  if (params.stopReason === "error" || params.stopReason === "aborted") {
+    tagUnresolvedTextAsCommentary(params.output, {
+      commentarySequence: params.commentarySequence,
+    });
+  }
+  if (params.stopReason === "toolUse") {
+    tagPendingCommentaryText(params.content, { commentarySequence: params.commentarySequence });
+  }
+}

--- a/packages/ai/src/utils/assistant-text-phase.ts
+++ b/packages/ai/src/utils/assistant-text-phase.ts
@@ -59,7 +59,7 @@ export function tagPendingCommentaryText(
 }
 
 /** Records the confirmed final-answer boundary after reasoning resumes. */
-export function tagInterruptedTextPhases(
+function tagInterruptedTextPhases(
   content: ReadonlyArray<unknown>,
   interruptedText: unknown,
   preservedVisibleText: ReadonlySet<unknown> = EMPTY_ASSISTANT_TEXT_BLOCK_SET,

--- a/packages/ai/src/utils/assistant-text-phase.ts
+++ b/packages/ai/src/utils/assistant-text-phase.ts
@@ -6,6 +6,11 @@ type AssistantTextPhaseBlock = {
 
 export type PendingCommentaryTags = Map<AssistantTextPhaseBlock, string>;
 
+export type CommentaryTagOptions = {
+  /** Monotonic per-stream counter so commentary ids stay unique across assistant messages. */
+  commentarySequence?: { next: number };
+};
+
 const EMPTY_ASSISTANT_TEXT_BLOCK_SET: ReadonlySet<unknown> = new Set();
 
 function isAssistantTextPhaseBlock(block: unknown): block is AssistantTextPhaseBlock {
@@ -24,6 +29,7 @@ function tagUnphasedText(
   content: ReadonlyArray<unknown>,
   phase: "commentary" | "final_answer",
   idPrefix: string,
+  commentarySequence?: CommentaryTagOptions["commentarySequence"],
 ): PendingCommentaryTags {
   const textBlocks = content.filter(isAssistantTextPhaseBlock);
   let phaseIndex = textBlocks.filter((block) => block.textSignature !== undefined).length;
@@ -32,7 +38,11 @@ function tagUnphasedText(
     if (block.text.trim().length === 0 || block.textSignature !== undefined) {
       continue;
     }
-    const signature = encodeAssistantTextSignatureV1(`${idPrefix}-${phaseIndex}`, phase);
+    const id =
+      phase === "commentary" && commentarySequence
+        ? `${idPrefix}-${commentarySequence.next++}`
+        : `${idPrefix}-${phaseIndex}`;
+    const signature = encodeAssistantTextSignatureV1(id, phase);
     block.textSignature = signature;
     tagged.set(block, signature);
     phaseIndex += 1;
@@ -41,8 +51,11 @@ function tagUnphasedText(
 }
 
 /** Tags unphased narration before a tool-call event becomes consumer-visible. */
-export function tagPendingCommentaryText(content: ReadonlyArray<unknown>): PendingCommentaryTags {
-  return tagUnphasedText(content, "commentary", "commentary");
+export function tagPendingCommentaryText(
+  content: ReadonlyArray<unknown>,
+  options?: CommentaryTagOptions,
+): PendingCommentaryTags {
+  return tagUnphasedText(content, "commentary", "commentary", options?.commentarySequence);
 }
 
 /** Records the confirmed final-answer boundary after reasoning resumes. */
@@ -50,6 +63,7 @@ export function tagInterruptedTextPhases(
   content: ReadonlyArray<unknown>,
   interruptedText: unknown,
   preservedVisibleText: ReadonlySet<unknown> = EMPTY_ASSISTANT_TEXT_BLOCK_SET,
+  options?: CommentaryTagOptions,
 ): void {
   const interruptedTextIndex = content.indexOf(interruptedText);
   if (interruptedTextIndex === -1) {
@@ -68,6 +82,7 @@ export function tagInterruptedTextPhases(
     content.slice(0, finalAnswerIndex).filter((block) => !preservedVisibleText.has(block)),
     "commentary",
     "commentary",
+    options?.commentarySequence,
   );
   tagUnphasedText(
     content.filter((block, index) => index >= finalAnswerIndex || preservedVisibleText.has(block)),
@@ -77,12 +92,15 @@ export function tagInterruptedTextPhases(
 }
 
 /** Prevents unresolved completion text from becoming a fallback answer after stream failure. */
-export function tagUnresolvedTextAsCommentary(message: {
-  content: ReadonlyArray<unknown>;
-  openclawDelivery?: { textPhaseRequiresTerminal?: true };
-}): void {
+export function tagUnresolvedTextAsCommentary(
+  message: {
+    content: ReadonlyArray<unknown>;
+    openclawDelivery?: { textPhaseRequiresTerminal?: true };
+  },
+  options?: CommentaryTagOptions,
+): void {
   if (message.openclawDelivery?.textPhaseRequiresTerminal) {
-    tagUnphasedText(message.content, "commentary", "commentary");
+    tagUnphasedText(message.content, "commentary", "commentary", options?.commentarySequence);
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves
WebChat duplicated assistant commentary segments because every mid-turn message reused `commentary-0`, breaking stream-segment reconciliation across tool-call boundaries.

## Evidence
- `assistant-text-phase` test verifies monotonic `commentary-N` ids across separate tagging passes
- OpenAI/Anthropic transport streams now share a per-stream commentary sequence counter

## Summary
- Add an optional per-stream `commentarySequence` counter for `tagPendingCommentaryText`
- Wire OpenAI and Anthropic transport streams to allocate monotonic `commentary-N` itemIds across tool-call boundaries

Fixes #134971

## Test plan
- [x] `assistant-text-phase` monotonic cross-pass commentary id case