### PR TITLE
fix(ai): honor Model Studio cache defaults and retention

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1754,7 +1754,7 @@ src/agents/embedded-agent-runner/delivery-evidence.ts	12
 src/agents/embedded-agent-runner/direct-compaction-preparation.ts	1
 src/agents/embedded-agent-runner/empty-assistant-turn.ts	1
 src/agents/embedded-agent-runner/extensions.ts	1
-src/agents/embedded-agent-runner/extra-params.ts	12
+src/agents/embedded-agent-runner/extra-params.ts	10
 src/agents/embedded-agent-runner/google-prompt-cache.ts	5
 src/agents/embedded-agent-runner/history.ts	2
 src/agents/embedded-agent-runner/message-visibility.ts	13

--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -100,10 +100,12 @@ Source: `packages/ai/src/transports/anthropic-payload-policy.ts` (`resolveAnthro
 ### Model Studio / DashScope (Qwen)
 
 OpenClaw's direct-provider adapter enables explicit prompt caching by default on
-Model Studio / DashScope OpenAI-compatible routes, using
+native or default Model Studio / DashScope OpenAI-compatible routes, using
 `compat.cacheControlFormat: "anthropic"` and the
 existing system, last-tool, and last-conversation cache markers. Explicit model
-compat settings take precedence over detected defaults.
+compat settings take precedence over detected defaults. Custom proxy endpoints
+receive no automatic format default; set `compat.cacheControlFormat: "anthropic"`
+explicitly only when the proxy supports these markers.
 
 The embedded runner's boundary-aware Chat Completions transport does not yet apply
 these markers; detecting the format alone does not enable explicit caching there.

--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -97,6 +97,30 @@ agents:
 
 Source: `packages/ai/src/transports/anthropic-payload-policy.ts` (`resolveAnthropicEphemeralCacheControl`, `isLongTtlEligibleEndpoint`).
 
+### Model Studio / DashScope (Qwen)
+
+OpenClaw's direct-provider adapter enables explicit prompt caching by default on
+Model Studio / DashScope OpenAI-compatible routes, using
+`compat.cacheControlFormat: "anthropic"` and the
+existing system, last-tool, and last-conversation cache markers. Explicit model
+compat settings take precedence over detected defaults.
+
+The embedded runner's boundary-aware Chat Completions transport does not yet apply
+these markers; detecting the format alone does not enable explicit caching there.
+
+Explicit `cacheRetention` values reach this transport without enabling
+`compat.supportsPromptCacheKey`; leave that flag unset because this route does not
+need OpenAI's `prompt_cache_key` or `prompt_cache_retention` fields. With no explicit
+retention, the transport keeps its `"short"` default. Model Studio uses a five-minute
+explicit cache window, so `"long"` keeps ephemeral markers without requesting a
+one-hour TTL.
+
+To disable OpenClaw's explicit markers, set `cacheRetention: "none"`. The current
+`compat.cacheControlFormat` schema accepts only `"anthropic"`, not a disable value;
+omitting it uses the detected default. Alibaba's automatic implicit caching is
+separate and cannot be disabled. Supported models, minimum prompt lengths, and
+cache billing are described in [Model Studio context caching](https://www.alibabacloud.com/help/en/model-studio/context-cache).
+
 ### OpenAI (direct API)
 
 - Prompt caching is automatic on supported recent models; OpenClaw does not inject block-level cache markers.

--- a/packages/ai/src/providers/openai-completions.compat.test.ts
+++ b/packages/ai/src/providers/openai-completions.compat.test.ts
@@ -93,6 +93,7 @@ function resolveTestEndpointClass(baseUrl: string | undefined): string {
     "llm.chutes.ai": "chutes-native",
     "api.z.ai": "zai-native",
     "api.deepseek.com": "deepseek-native",
+    "dashscope.aliyuncs.com": "modelstudio-native",
     "127.0.0.1": "local",
     localhost: "local",
   };
@@ -510,6 +511,74 @@ afterEach(() => {
 });
 
 describe("OpenAI-compatible completions compatibility", () => {
+  it.each([
+    { provider: "dashscope", baseUrl: "", expected: "anthropic" },
+    { provider: "modelstudio", baseUrl: "", expected: "anthropic" },
+    { provider: "qwen", baseUrl: "", expected: "anthropic" },
+    {
+      provider: "custom",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      expected: "anthropic",
+    },
+    { provider: "custom", baseUrl: "https://proxy.example/v1", expected: undefined },
+    { provider: "moonshot", baseUrl: "https://api.moonshot.ai/v1", expected: undefined },
+  ])("defaults cache markers for $provider at $baseUrl", ({ provider, baseUrl, expected }) => {
+    expect(
+      resolveOpenAICompletionsCompat(createModel({ provider, baseUrl })).cacheControlFormat,
+    ).toBe(expected);
+  });
+
+  it("honors explicit cache compatibility settings on Model Studio", () => {
+    const compat = { cacheControlFormat: "anthropic", supportsLongCacheRetention: true } as const;
+    expect(
+      resolveOpenAICompletionsCompat(createModel({ provider: "modelstudio", compat })),
+    ).toMatchObject(compat);
+  });
+
+  it.each([undefined, "short", "long", "none"] as const)(
+    "sends Model Studio cache markers without OpenAI cache fields for retention %s",
+    async (cacheRetention) => {
+      const model = createModel({
+        id: "qwen-plus",
+        provider: "custom",
+        baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      });
+      await streamOpenAICompletions(
+        model,
+        {
+          systemPrompt: "Follow instructions.",
+          messages: [userMessage, { ...userMessage, content: "latest", timestamp: 2 }],
+          tools: ["alpha", "zeta"].map((name) => ({
+            name,
+            description: name,
+            parameters: { type: "object", properties: {} },
+          })),
+        },
+        { apiKey: "test", sessionId: "session-test", cacheRetention },
+      ).result();
+
+      const cacheControl = cacheRetention === "none" ? undefined : { type: "ephemeral" };
+      const content = (text: string) =>
+        cacheControl ? [{ type: "text", text, cache_control: cacheControl }] : text;
+      const expectedPayload = {
+        model: "qwen-plus",
+        messages: [
+          { role: "system", content: content("Follow instructions.") },
+          { role: "user", content: "hello" },
+          { role: "user", content: content("latest") },
+        ],
+        stream: true,
+        tools: ["alpha", "zeta"].map((name) => ({
+          type: "function",
+          function: { name, description: name, parameters: { type: "object", properties: {} } },
+          cache_control: name === "zeta" ? cacheControl : undefined,
+        })),
+      };
+      // Compare wire JSON, where undefined cache fields must be omitted.
+      expect(JSON.stringify(mockOpenAI.payloads[0])).toBe(JSON.stringify(expectedPayload));
+    },
+  );
+
   it.each(legacyMatrixParityCases)(
     "maps former provider matrix case %s to canonical endpoint policy",
     (_name, overrides, legacyExpected, expected, divergence) => {

--- a/packages/ai/src/providers/openai-completions.compat.test.ts
+++ b/packages/ai/src/providers/openai-completions.compat.test.ts
@@ -126,7 +126,9 @@ function resolveTestCapabilities(
       ? "moonshot"
       : provider === "openai" || provider === "azure-openai"
         ? "openai-family"
-        : (provider ?? "unknown");
+        : provider === "qwen" || provider === "dashscope"
+          ? "modelstudio"
+          : (provider ?? "unknown");
   const usesConfiguredBaseUrl = endpointClass !== "default";
   const usesKnownNativeOpenAIEndpoint =
     endpointClass === "openai-public" ||
@@ -521,6 +523,7 @@ describe("OpenAI-compatible completions compatibility", () => {
       expected: "anthropic",
     },
     { provider: "custom", baseUrl: "https://proxy.example/v1", expected: undefined },
+    { provider: "qwen", baseUrl: "https://proxy.example/v1", expected: undefined },
     { provider: "moonshot", baseUrl: "https://api.moonshot.ai/v1", expected: undefined },
   ])("defaults cache markers for $provider at $baseUrl", ({ provider, baseUrl, expected }) => {
     expect(
@@ -534,6 +537,37 @@ describe("OpenAI-compatible completions compatibility", () => {
       resolveOpenAICompletionsCompat(createModel({ provider: "modelstudio", compat })),
     ).toMatchObject(compat);
   });
+
+  it.each([undefined, "anthropic"] as const)(
+    "requires explicit cache format %s for Qwen behind a custom endpoint",
+    async (cacheControlFormat) => {
+      const model = createModel({
+        id: "qwen-plus",
+        provider: "qwen",
+        compat: { cacheControlFormat },
+      });
+      await streamOpenAICompletions(
+        model,
+        {
+          systemPrompt: "Follow instructions.",
+          messages: [userMessage],
+          tools: [
+            {
+              name: "lookup",
+              description: "Look up data",
+              parameters: { type: "object", properties: {} },
+            },
+          ],
+        },
+        { apiKey: "test", cacheRetention: "short" },
+      ).result();
+
+      expect(mockOpenAI.payloads).toHaveLength(1);
+      const markers = JSON.stringify(mockOpenAI.payloads[0]).match(/"cache_control":/g) ?? [];
+      expect(markers).toHaveLength(cacheControlFormat === "anthropic" ? 3 : 0);
+      expect(resolveOpenAICompletionsCompat(model).cacheControlFormat).toBe(cacheControlFormat);
+    },
+  );
 
   it.each([undefined, "short", "long", "none"] as const)(
     "sends Model Studio cache markers without OpenAI cache fields for retention %s",

--- a/packages/ai/src/transports/openai-completions-compat.ts
+++ b/packages/ai/src/transports/openai-completions-compat.ts
@@ -159,7 +159,8 @@ function resolveOpenAICompletionsCompatDefaults(
     requiresReasoningContentOnAssistantMessages: isDeepSeek || isXiaomi,
     requiresNonEmptyUserOrAssistantMessage: isModelStudioLike,
     cacheControlFormat:
-      isModelStudioLike || (provider === "openrouter" && modelId?.startsWith("anthropic/") === true)
+      (isModelStudioLike && endpointClass !== "custom") ||
+      (provider === "openrouter" && modelId?.startsWith("anthropic/") === true)
         ? "anthropic"
         : undefined,
     sessionAffinityFormat: isOpenRouterLike ? "openrouter" : "openai",

--- a/packages/ai/src/transports/openai-completions-compat.ts
+++ b/packages/ai/src/transports/openai-completions-compat.ts
@@ -159,11 +159,12 @@ function resolveOpenAICompletionsCompatDefaults(
     requiresReasoningContentOnAssistantMessages: isDeepSeek || isXiaomi,
     requiresNonEmptyUserOrAssistantMessage: isModelStudioLike,
     cacheControlFormat:
-      provider === "openrouter" && modelId?.startsWith("anthropic/") === true
+      isModelStudioLike || (provider === "openrouter" && modelId?.startsWith("anthropic/") === true)
         ? "anthropic"
         : undefined,
     sessionAffinityFormat: isOpenRouterLike ? "openrouter" : "openai",
     supportsLongCacheRetention:
+      !isModelStudioLike &&
       provider !== "cloudflare-workers-ai" &&
       provider !== "cloudflare-ai-gateway" &&
       knownProviderFamily !== "together" &&
@@ -242,7 +243,7 @@ function resolveSessionAffinity(
 
 /** Applies explicit model overrides once on top of the canonical transport defaults. */
 export function resolveOpenAICompletionsCompat(
-  model: Model<"openai-completions">,
+  model: Pick<Model<"openai-completions">, "id" | "provider" | "baseUrl" | "compat">,
   resolveCapabilities?: (input: AiProviderRequestPolicyInput) => ProviderRequestCapabilities,
 ): ResolvedOpenAICompletionsCompat {
   const { defaults } = detectOpenAICompletionsCompat(model, resolveCapabilities);

--- a/src/agents/embedded-agent-runner/extra-params.cache-retention-default.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.cache-retention-default.test.ts
@@ -2,7 +2,7 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { applyExtraParamsToAgent } from "./extra-params.js";
-import { testing as extraParamsTesting } from "./extra-params.test-support.js";
+import { runExtraParamsCase, testing as extraParamsTesting } from "./extra-params.test-support.js";
 import { log } from "./logger.js";
 import { resolveCacheRetention } from "./prompt-cache-retention.js";
 
@@ -56,6 +56,29 @@ afterEach(() => {
 });
 
 describe("cacheRetention default behavior", () => {
+  it.each([undefined, "none", "short", "long"] as const)(
+    "forwards Model Studio explicit retention %s without opting into cache keys",
+    (cacheRetention) => {
+      const captured = runExtraParamsCase({
+        model: {
+          id: "qwen-plus",
+          name: "Qwen Plus",
+          api: "openai-completions",
+          provider: "qwen",
+          baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128_000,
+          maxTokens: 4_096,
+        },
+        cfg: { agents: { defaults: { params: { temperature: 0.5, cacheRetention } } } },
+        payload: {},
+      });
+      expect(captured.options?.cacheRetention).toBe(cacheRetention);
+    },
+  );
+
   it("returns 'short' for Anthropic when not configured", () => {
     applyAndExpectWrapped({
       modelId: "claude-3-sonnet",

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -2,6 +2,7 @@ import {
   canonicalizeMaxTokensParam,
   resolveMaxTokensParam,
   detectOpenAICompletionsCompat,
+  resolveOpenAICompletionsCompat,
 } from "@openclaw/ai/transports";
 import {
   type NativeWebSearchToolPolicyParams,
@@ -561,20 +562,15 @@ function createStreamFnWithExtraParams(
     streamParams.stop = resolvedStop;
   }
 
-  const readSupportsPromptCacheKey = (m: unknown): boolean => {
-    const compat = (m as { compat?: unknown })?.compat;
-    if (!compat || typeof compat !== "object") {
-      return false;
-    }
-    return (compat as Record<string, unknown>).supportsPromptCacheKey === true;
-  };
+  const readCacheCompat = (m?: ProviderRuntimeModel) =>
+    m?.api === "openai-completions" ? resolveOpenAICompletionsCompat(m) : m?.compat;
 
   const initialCacheRetention = resolveCacheRetention(
     extraParams,
     provider,
     typeof model?.api === "string" ? model.api : undefined,
     typeof model?.id === "string" ? model.id : undefined,
-    readSupportsPromptCacheKey(model),
+    readCacheCompat(model),
   );
   if (Object.keys(streamParams).length > 0 || initialCacheRetention) {
     const debugParams = initialCacheRetention
@@ -590,7 +586,7 @@ function createStreamFnWithExtraParams(
       provider,
       typeof callModel.api === "string" ? callModel.api : undefined,
       typeof callModel.id === "string" ? callModel.id : undefined,
-      readSupportsPromptCacheKey(callModel),
+      readCacheCompat(callModel),
     );
     if (Object.keys(streamParams).length === 0 && !cacheRetention) {
       return underlying(callModel, context, options);

--- a/src/agents/embedded-agent-runner/prompt-cache-retention.test.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-retention.test.ts
@@ -3,6 +3,17 @@ import { describe, expect, it } from "vitest";
 import { isGooglePromptCacheEligible, resolveCacheRetention } from "./prompt-cache-retention.js";
 
 describe("prompt cache retention", () => {
+  it.each([undefined, "none", "short", "long"] as const)(
+    "honors explicit retention %s for Anthropic-marker completions without cache keys",
+    (cacheRetention) => {
+      expect(
+        resolveCacheRetention({ cacheRetention }, "custom", "openai-completions", "qwen-plus", {
+          cacheControlFormat: "anthropic",
+        }),
+      ).toBe(cacheRetention);
+    },
+  );
+
   it("passes explicit cacheRetention through for direct Google models", () => {
     expect(
       resolveCacheRetention(
@@ -40,7 +51,7 @@ describe("prompt cache retention", () => {
         "omlx-local",
         "openai-completions",
         "local_model",
-        true,
+        { supportsPromptCacheKey: true },
       ),
     ).toBe("long");
     expect(
@@ -49,7 +60,7 @@ describe("prompt cache retention", () => {
         "omlx-local",
         "openai-completions",
         "local_model",
-        true,
+        { supportsPromptCacheKey: true },
       ),
     ).toBe("short");
     expect(
@@ -58,7 +69,7 @@ describe("prompt cache retention", () => {
         "omlx-local",
         "openai-completions",
         "local_model",
-        true,
+        { supportsPromptCacheKey: true },
       ),
     ).toBe("none");
   });
@@ -91,7 +102,7 @@ describe("prompt cache retention", () => {
         "omlx-local",
         "openai-completions",
         "local_model",
-        false,
+        { supportsPromptCacheKey: false },
       ),
     ).toBeUndefined();
   });
@@ -101,10 +112,14 @@ describe("prompt cache retention", () => {
     // to the transport-level default ("short") rather than receiving a
     // wrapper-injected value.
     expect(
-      resolveCacheRetention(undefined, "omlx-local", "openai-completions", "local_model", true),
+      resolveCacheRetention(undefined, "omlx-local", "openai-completions", "local_model", {
+        supportsPromptCacheKey: true,
+      }),
     ).toBeUndefined();
     expect(
-      resolveCacheRetention({}, "omlx-local", "openai-completions", "local_model", true),
+      resolveCacheRetention({}, "omlx-local", "openai-completions", "local_model", {
+        supportsPromptCacheKey: true,
+      }),
     ).toBeUndefined();
   });
 
@@ -118,7 +133,7 @@ describe("prompt cache retention", () => {
         "omlx-local",
         "openai-completions",
         "local_model",
-        true,
+        { supportsPromptCacheKey: true },
       ),
     ).toBeUndefined();
     expect(
@@ -127,7 +142,7 @@ describe("prompt cache retention", () => {
         "omlx-local",
         "openai-completions",
         "local_model",
-        true,
+        { supportsPromptCacheKey: true },
       ),
     ).toBeUndefined();
   });

--- a/src/agents/embedded-agent-runner/prompt-cache-retention.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-retention.ts
@@ -3,6 +3,7 @@
  */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { resolveAnthropicCacheRetentionFamily } from "../../llm/providers/stream-wrappers/anthropic-family-cache-semantics.js";
+import type { OpenAICompletionsCompat } from "../../llm/types.js";
 
 type CacheRetention = "none" | "short" | "long";
 
@@ -26,7 +27,7 @@ export function resolveCacheRetention(
   provider: string,
   modelApi?: string,
   modelId?: string,
-  supportsPromptCacheKey?: boolean,
+  compat?: Pick<OpenAICompletionsCompat, "supportsPromptCacheKey" | "cacheControlFormat">,
 ): CacheRetention | undefined {
   const hasExplicitCacheConfig =
     extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
@@ -37,16 +38,12 @@ export function resolveCacheRetention(
     hasExplicitCacheConfig,
   });
   const googleEligible = isGooglePromptCacheEligible({ modelApi, modelId });
-  // OpenAI-compatible completions backends (oMLX, llama.cpp, etc.) opt into
-  // prompt caching via `compat.supportsPromptCacheKey: true`. Without that
-  // flag they sit outside the anthropic/google family gates, so issue #81281
-  // dropped the user's explicit `cacheRetention` before the transport layer
-  // could emit it. Proxies that route non-cacheable models via the same
-  // openai-completions wire (amazon-bedrock + amazon.* nova models) leave
-  // the flag unset, so the existing family gate still applies to them.
-  const cacheKeyEligible = supportsPromptCacheKey === true;
+  // Marker-based caches accept retention without accepting OpenAI cache-key fields.
+  // Keep these capabilities independent so explicit "none" can suppress markers.
+  const compatEligible =
+    compat?.supportsPromptCacheKey === true || compat?.cacheControlFormat === "anthropic";
 
-  if (!family && !googleEligible && !cacheKeyEligible) {
+  if (!family && !googleEligible && !compatEligible) {
     return undefined;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes missing default explicit-cache markers in the direct Model Studio / DashScope
adapter and prevents explicit retention from being dropped on marker-compatible
Chat Completions routes. **This branch is incomplete for normal embedded sessions**:
their separate payload builder still needs to share the marker writer.

## Why This Change Was Made

Reuse the existing compatibility owner and marker implementation rather than adding
another cache protocol. Retention eligibility must recognize markers independently
of OpenAI cache-key support, including when compatibility is detected rather than
explicitly configured. Discovery source: NetEase Youdao's LobsterAI patch stack
(github.com/netease-youdao/LobsterAI).

## User Impact

Direct-provider requests receive ephemeral cache markers by default on recognized
Model Studio routes. Explicit retention reaches the transport without enabling
OpenAI cache-key fields. `cacheRetention: "none"` suppresses explicit markers;
implicit provider caching is separate. The default provider retention stays short.
The embedded-transport gap and compatibility-format opt-out remain blocking follow-ups.

## Evidence

The targeted/sibling run passed 135 tests across five files; all 61 payload tests
passed again after test-only lint cleanup. `pnpm check:changed` passed, and fresh
Codex autoreview was clean at its configured P0-only threshold. Added coverage checks compatibility defaults, retained
explicit settings, forwarded retention, and exact serialized payloads at system,
last-tool, and last-conversation positions with no OpenAI cache-key fields. Live
provider acceptance and actual cache hits have not been tested.
