### PR TITLE
perf(cua-computer): bound fragmented MCP response copies

### DIFF
--- a/extensions/cua-computer/src/mcp-driver-client.test.ts
+++ b/extensions/cua-computer/src/mcp-driver-client.test.ts
@@ -16,7 +16,7 @@ type FakeEndpoint = {
   socketPath: string;
   requests: RpcRequest[];
   respond: (request: RpcRequest, result: unknown) => void;
-  writeRaw: (request: RpcRequest, value: string) => void;
+  writeRaw: (request: RpcRequest, value: string | Buffer) => void;
   close: () => Promise<void>;
 };
 
@@ -89,7 +89,7 @@ socket.on("close", () => process.exit(0));
       const writer = request.id === undefined ? undefined : writers.get(request.id);
       writer?.write(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result })}\n`);
     },
-    writeRaw: (request: RpcRequest, value: string) => {
+    writeRaw: (request: RpcRequest, value: string | Buffer) => {
       const writer = request.id === undefined ? undefined : writers.get(request.id);
       writer?.write(value);
     },
@@ -279,6 +279,59 @@ describe.runIf(process.platform !== "win32")("CUA MCP proxy transport", () => {
       count: 1,
       target: { kind: "desktop", display_id: "primary" },
     });
+  });
+
+  it("preserves UTF-8 and routes multiple out-of-order responses", async () => {
+    const held: RpcRequest[] = [];
+    const endpoint = await createFakeEndpoint((request, fake) => {
+      if (request.method === "initialize") {
+        fake.respond(request, {
+          protocolVersion: "2025-06-18",
+          capabilities: { tools: {} },
+          serverInfo: { name: "fake-cua-driver", version: "0.20.0" },
+        });
+      } else if (request.method === "tools/call" && request.params?.name === "start_session") {
+        fake.respond(request, sessionState("window"));
+      } else if (request.method === "tools/call" && request.params?.name === "list_windows") {
+        held.push(request);
+      } else if (request.method === "tools/call" && request.params?.name === "end_session") {
+        fake.respond(request, toolResult({ session: "openclaw-test", active: false }));
+      }
+    });
+    const driver = createCuaMcpDriver(endpoint);
+    onTestFinished(() => driver.dispose());
+    const settlement: string[] = [];
+    const firstCall = driver.callTool("list_windows", { marker: "first" }).then((result) => {
+      settlement.push("first");
+      return result;
+    });
+    const secondCall = driver.callTool("list_windows", { marker: "second" }).then((result) => {
+      settlement.push("second");
+      return result;
+    });
+    await vi.waitFor(() => expect(held).toHaveLength(2));
+    const firstRequest = held.find((request) => request.params?.arguments?.marker === "first");
+    const secondRequest = held.find((request) => request.params?.arguments?.marker === "second");
+    if (!firstRequest || !secondRequest) {
+      throw new Error("fixture did not receive both tagged requests");
+    }
+
+    const framed = Buffer.from(
+      `${JSON.stringify({ jsonrpc: "2.0", id: secondRequest.id, result: toolResult({ marker: "second", text: "β雪" }) })}\n\n${JSON.stringify({ jsonrpc: "2.0", id: firstRequest.id, result: toolResult({ marker: "first" }) })}\n`,
+    );
+    const split = framed.indexOf(Buffer.from("雪")) + 1;
+    expect(split).toBeGreaterThan(0);
+    endpoint.writeRaw(secondRequest, framed.subarray(0, split));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    endpoint.writeRaw(secondRequest, framed.subarray(split));
+
+    const [first, second] = await Promise.all([firstCall, secondCall]);
+    expect(JSON.parse(first.structuredJson!)).toEqual({ marker: "first" });
+    expect(JSON.parse(second.structuredJson!)).toEqual({ marker: "second", text: "β雪" });
+    expect(settlement).toEqual(["second", "first"]);
+    await driver.dispose();
   });
 
   it("fails closed on invalid proxy JSON", async () => {

--- a/extensions/cua-computer/src/mcp-driver-client.ts
+++ b/extensions/cua-computer/src/mcp-driver-client.ts
@@ -194,6 +194,7 @@ class CuaMcpProxyClient {
   private readonly ready: Promise<void>;
   private nextId = 0;
   private stdout = Buffer.alloc(0);
+  private stdoutBytes = 0;
   private stderr = Buffer.alloc(0);
   private available = false;
   private failure: Error | undefined;
@@ -258,6 +259,8 @@ class CuaMcpProxyClient {
     this.stopped = true;
     this.available = false;
     this.rejectPending(driverUnavailable("CUA MCP proxy is stopping"));
+    this.stdout = Buffer.alloc(0);
+    this.stdoutBytes = 0;
     this.child.stdin.end();
     if (await this.waitForExit(MCP_SHUTDOWN_TIMEOUT_MS)) {
       return;
@@ -339,18 +342,26 @@ class CuaMcpProxyClient {
     if (this.failure || this.stopped) {
       return;
     }
-    this.stdout = Buffer.concat([this.stdout, chunk]);
-    if (this.stdout.length > MAX_MCP_LINE_BYTES) {
+    // Preserve the existing pre-drain cap for the entire delivered stdout chunk.
+    if (this.stdoutBytes + chunk.length > MAX_MCP_LINE_BYTES) {
       this.fail(driverProtocolError("CUA MCP response exceeded the line-size limit"));
       return;
     }
-    while (true) {
-      const newline = this.stdout.indexOf(0x0a);
+    let start = 0;
+    while (start < chunk.length) {
+      const newline = chunk.indexOf(0x0a, start);
       if (newline < 0) {
+        this.appendStdout(chunk.subarray(start));
         return;
       }
-      const line = this.stdout.subarray(0, newline);
-      this.stdout = this.stdout.subarray(newline + 1);
+      let line = chunk.subarray(start, newline);
+      start = newline + 1;
+      if (this.stdoutBytes > 0) {
+        this.appendStdout(line);
+        line = this.stdout.subarray(0, this.stdoutBytes);
+        this.stdout = Buffer.alloc(0);
+        this.stdoutBytes = 0;
+      }
       if (line.length === 0) {
         continue;
       }
@@ -387,6 +398,18 @@ class CuaMcpProxyClient {
     }
   }
 
+  private appendStdout(chunk: Buffer): void {
+    const required = this.stdoutBytes + chunk.length;
+    if (required > this.stdout.length) {
+      const capacity = Math.min(MAX_MCP_LINE_BYTES, Math.max(required, this.stdout.length * 2));
+      const stdout = Buffer.allocUnsafe(capacity);
+      this.stdout.copy(stdout, 0, 0, this.stdoutBytes);
+      this.stdout = stdout;
+    }
+    chunk.copy(this.stdout, this.stdoutBytes);
+    this.stdoutBytes = required;
+  }
+
   private fail(error: Error): void {
     if (this.failure || this.stopped) {
       return;
@@ -394,6 +417,8 @@ class CuaMcpProxyClient {
     this.failure = error;
     this.available = false;
     this.rejectPending(error);
+    this.stdout = Buffer.alloc(0);
+    this.stdoutBytes = 0;
     this.child.kill("SIGTERM");
   }
 


### PR DESCRIPTION
## What Problem This Solves

The CUA MCP client copies the entire incomplete JSON response on every stdout chunk. Large fragmented responses therefore cause quadratic copying and large allocation spikes. After parsing a complete response, an empty subarray can also keep its entire backing buffer alive.

## Why This Change Was Made

Keep one partial-frame buffer with geometric capacity growth and a separate live-byte count. Parse complete lines directly from incoming chunks and release partial-frame storage on completion, protocol failure, and shutdown. The response-routing owner, raw UTF-8 framing, and existing 256 MiB pre-drain limit remain unchanged.

This replaces the old concatenation path. A fragment array was rejected because the byte limit would not bound the number of retained fragment objects. The MCP SDK reader also concatenates partial buffers and has different parsing and limit contracts.

## User Impact

Large CUA responses require less temporary memory and copying, and completed frames no longer retain their backing bytes. Production +31/-6 (net +25) implements the bounded accumulator and its release lifecycle; tests +55/-2 (net +53) extend the existing subprocess fixture. No configuration, dependency, or protocol surface changes.

## Evidence

- The actual client spawned a synthetic MCP subprocess and returned an identical 8 MiB result before and after. An OS RSS high-water measurement showed peak growth of 613,269,504 bytes before and 63,340,544 after. Post-GC array-buffer storage retained by the completed baseline frame was about 8.3 MB; the candidate returned to its starting allocation. These numbers cover that response size and host, not every workload.
- A 100,000 one-byte-write probe held about 250 KB of additional heap in the candidate; it does not retain one object per delivered fragment. A 257 MiB no-newline response hit the existing limit and released its array-buffer storage. Near the 256 MiB cap, old and new capacity buffers can coexist during growth; that existing maximum-size stress still peaks much higher than the 8 MiB case.
- Actual-client checks preserved UTF-8 text, empty/multiple lines, unknown IDs, out-of-order responses, and settlement of a valid response before later invalid JSON. Pending calls then rejected and availability failed closed.
- All 32 focused MCP, provider and direct-driver tests pass. The final MCP fixture rerun passes all four cases, including batched Unicode and out-of-order responses. The complete changed-check plan passes.
- Independent source/dependency review and fresh Codex autoreview found no accepted findings in the selected scope and priority. The native direct-driver sibling retains its own transport lifecycle.
