### PR TITLE
fix(models): keep local Ollama routes selectable

### DIFF
--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -745,14 +745,19 @@ export function createModelAuthAvailabilityResolver(
       provider === OPENAI_PROVIDER_ID &&
       synthetic.has("codex") &&
       (target.authRequirement === "subscription" || target.api === OPENAI_CODEX_RESPONSES_API);
-    if (hasSyntheticLocalProviderAuthConfig({ cfg: params.cfg, provider })) {
-      return { availability: undefined, evidence: "synthetic" };
-    }
-    if (
+    const hasDeclaredSyntheticAuth =
       synthetic.has(normalizeProviderIdForAuth(provider)) ||
-      synthetic.has(normalizeProvider(provider)) ||
-      hasCompatibleCodexSyntheticAuth
+      synthetic.has(normalizeProvider(provider));
+    if (
+      hasSyntheticLocalProviderAuthConfig({
+        cfg: params.cfg,
+        provider,
+        route: hasDeclaredSyntheticAuth ? target : undefined,
+      })
     ) {
+      return { availability: true, evidence: "synthetic" };
+    }
+    if (hasDeclaredSyntheticAuth || hasCompatibleCodexSyntheticAuth) {
       return params.preparedSyntheticAuthComplete
         ? { availability: false, evidence: "synthetic", unavailableReason: "missing-auth" }
         : { availability: undefined, evidence: "synthetic" };

--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -238,33 +238,30 @@ export function shouldPreferExplicitConfigApiKeyAuth(
   );
 }
 
-/** True when a custom local provider can use a synthetic no-auth placeholder. */
+/** True when configured or prepared route facts prove a local no-auth provider. */
 export function hasSyntheticLocalProviderAuthConfig(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
+  route?: { api?: string | null; baseUrl?: unknown };
 }): boolean {
   const providerConfig = resolveProviderConfig(params.cfg, params.provider);
-  if (!providerConfig) {
-    return false;
-  }
-  const hasApiConfig =
-    Boolean(providerConfig.api?.trim()) ||
-    Boolean(providerConfig.baseUrl?.trim()) ||
-    (Array.isArray(providerConfig.models) && providerConfig.models.length > 0);
-  if (!hasApiConfig) {
-    return false;
-  }
   const authOverride = resolveProviderAuthOverride(params.cfg, params.provider);
   if (authOverride && authOverride !== "api-key") {
     return false;
   }
   if (
-    !isCustomLocalProviderConfig(providerConfig) ||
-    hasExplicitProviderApiKeyConfig(providerConfig)
+    (!params.route && (!providerConfig || !isCustomLocalProviderConfig(providerConfig))) ||
+    (providerConfig !== undefined && hasExplicitProviderApiKeyConfig(providerConfig))
   ) {
     return false;
   }
-  return Boolean(providerConfig.baseUrl && isLocalAuthProviderBaseUrl(providerConfig.baseUrl));
+  const route = params.route ?? providerConfig;
+  return (
+    typeof route?.api === "string" &&
+    route.api.trim().length > 0 &&
+    typeof route.baseUrl === "string" &&
+    isLocalAuthProviderBaseUrl(route.baseUrl)
+  );
 }
 
 export function resolveProviderAuthOverride(

--- a/src/gateway/server-methods/models-list-auth-resolver.ts
+++ b/src/gateway/server-methods/models-list-auth-resolver.ts
@@ -88,6 +88,9 @@ export function createModelsListEntryEvaluator(params: {
     const next = Promise.resolve().then((): ModelAuthAvailabilityEvaluation => {
       const evaluation = params.authResolver.evaluateModelAuth(entry.provider, {
         modelId: identity?.id ?? entry.id,
+        ...(normalizeProviderId(entry.provider) === "openai"
+          ? {}
+          : { api: entry.api, baseUrl: entry.baseUrl }),
         ...(params.preferredProfileId ? { preferredProfileId: params.preferredProfileId } : {}),
         ...(params.lockedProfileId ? { lockedProfileId: params.lockedProfileId } : {}),
         observedRoutes: routeVariants.map((variant) => ({

--- a/src/gateway/server-methods/models-list-result.provider-outcomes.test.ts
+++ b/src/gateway/server-methods/models-list-result.provider-outcomes.test.ts
@@ -17,6 +17,76 @@ const metadataSnapshot = createPluginMetadataSnapshotFixture();
 const emptyAuthStore = { version: 1, profiles: {} } as const;
 
 describe("models.list provider catalog outcomes", () => {
+  it.each([
+    {
+      name: "implicit provider",
+      providers: undefined,
+      baseUrl: "http://127.0.0.1:11434",
+      available: true,
+    },
+    {
+      name: "empty provider config",
+      providers: { ollama: {} },
+      baseUrl: "http://127.0.0.1:11434",
+      available: true,
+    },
+    {
+      name: "remote route without credentials",
+      providers: undefined,
+      baseUrl: "https://ollama.example.com",
+      available: false,
+    },
+    {
+      name: "explicit auth ownership without credentials",
+      providers: { ollama: { auth: "token" as const } },
+      baseUrl: "http://127.0.0.1:11434",
+      available: false,
+    },
+  ])(
+    "projects a discovered Ollama model with $name as available=$available",
+    async ({ providers, baseUrl, available }) => {
+      const config = {
+        ...(providers ? { models: { providers } } : {}),
+        agents: { defaults: { models: { "ollama/qwen3.5": {} } } },
+      } as OpenClawConfig;
+      const model = {
+        id: "qwen3.5",
+        name: "Qwen 3.5",
+        provider: "ollama",
+        api: "ollama" as const,
+        baseUrl,
+      };
+      const snapshot = markPreparedModelCatalogFull({ entries: [model], routeVariants: [model] });
+      const projector = createGatewayAgentModelCatalogProjector({
+        cfg: config,
+        agentId: "main",
+        snapshot,
+        metadataSnapshot: createPluginMetadataSnapshotFixture({
+          plugins: [{ id: "ollama", providers: ["ollama"], syntheticAuthRefs: ["ollama"] }],
+        }),
+        preparedAuthStore: emptyAuthStore,
+      });
+      const context = {
+        getRuntimeConfig: () => config,
+        loadGatewayModelCatalogSnapshot: vi.fn(),
+        logGateway: { debug: vi.fn() },
+      } as unknown as GatewayRequestContext;
+
+      await expect(
+        buildModelsListResult({
+          context,
+          agentId: "main",
+          params: { view: "configured" },
+          preloadedCatalog: { agentId: "main", config, snapshot },
+          preloadedOnly: true,
+          catalogProjector: projector,
+        }),
+      ).resolves.toEqual({
+        models: [expect.objectContaining({ provider: "ollama", id: "qwen3.5", available })],
+      });
+    },
+  );
+
   it("preserves an auth rejection when no usable models are visible", async () => {
     const config = {} as OpenClawConfig;
     const snapshot = {

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -14,7 +14,6 @@ import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import { createAgentHarnessCatalogEvaluator } from "../../agents/harness/model-catalog-readiness.js";
 import type { ModelAuthAvailabilityEvaluation } from "../../agents/model-auth-availability.js";
-import { hasSyntheticLocalProviderAuthConfig } from "../../agents/model-auth-provider-config.js";
 import {
   buildProviderConfigModelCatalogForBrowse,
   loadPreparedModelCatalogSnapshotForBrowse,
@@ -337,16 +336,10 @@ function createPublicModelsListProjector(params: {
       };
       prepared.set(entry, preparedEntry);
     }
-    const syntheticLocalAvailable =
-      evaluation.availability === undefined &&
-      evaluation.routeResolution === null &&
-      normalizeProviderId(entry.provider) !== "openai" &&
-      hasSyntheticLocalProviderAuthConfig({ cfg: params.cfg, provider: entry.provider });
-    const available = evaluation.availability ?? (syntheticLocalAvailable ? true : undefined);
     // Legacy views require a boolean; inventory consumers preserve unknown state.
     const projectedAvailability = params.preserveUnknownAvailability
-      ? available
-      : (available ?? false);
+      ? evaluation.availability
+      : (evaluation.availability ?? false);
     return Object.assign(
       {},
       preparedEntry,


### PR DESCRIPTION
## What Problem This Solves

The Control UI showed supported local Ollama models but disabled their rows. Selecting one sent no `sessions.patch` request because `models.list` published the model as unavailable.

Closes #134731.

Reported by @BoatAngle.

## Why This Change Was Made

The auth availability owner read only `models.providers` source config for non-OpenAI providers. It ignored the effective `api` and `baseUrl` already carried by the prepared catalog row. An implicit or empty Ollama provider therefore became `missing-auth` even when the bundled plugin had verified and published a local route.

This change passes the exact prepared route into auth evaluation. The evaluator now marks a declared synthetic-auth route available when the route is local and no explicit credential owner overrides it. The downstream Gateway fallback is removed, so one owner now decides availability.

Remote Ollama routes and routes with explicit token auth remain unavailable without credentials.

## User Impact

Operators can select a supported local Ollama model in the Control UI. The selection now reaches `sessions.patch`, updates the session model, and affects the next turn.

## Evidence

- Baseline `9e5be704596c5c4fd38c83253cdebef0498597fc`: the new Gateway regression failed for both implicit and empty provider config. Each row was `available: false` with `missing-auth`.
- Candidate `4aa5dfec99046bd66998a11ef2537def87f05a38`: 85 focused owner and sibling tests passed.
- `node scripts/run-vitest.mjs src/agents/model-auth-availability.test.ts src/gateway/server-methods/models-list-result.provider-outcomes.test.ts src/gateway/server-methods/models-list-result.openai-routes.test.ts --reporter=verbose`
- The committed Chromium Control UI harness proved the exact causal pair: `available: false` disabled the local Ollama row and sent zero `sessions.patch` requests; `available: true` sent `sessions.patch` with the selected Ollama model.
- The host had no Ollama service on port 11434, so a live provider process was infeasible. The proof used the shipped UI bundle, real Chromium interaction, and the committed mock Gateway harness without touching operator state.
- Formatting, focused Oxlint, max-lines ratchet, and `git diff --check` passed.
- `pnpm test:changed` was stopped when it attempted the host-forbidden full TypeScript build. Pull request CI owns type and build validation.
- Production lines: -2 net. Tests: +70 lines. No configuration, protocol, storage, or dependency changes.

### Test audit

- The retained table-driven Gateway test protects the producer boundary and failed before the fix for the intended reason.
- It covers implicit config, empty config, remote routes, and explicit auth ownership.
- No test-only production seam was added.
- An evidence-only Ollama UI case was not retained because existing UI tests already protect both consumer branches.
