### PR TITLE
fix(doctor): converge redundant shared auth relocation subsets

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -277,6 +277,8 @@ Microsoft Teams conversation, poll, and SSO token imports also verify that selec
 
 Doctor also reports when shared auth still uses the legacy `agents/main/agent/openclaw-agent.sqlite` owner. `openclaw doctor --fix` copies its auth profile and runtime-state rows into `state/openclaw.sqlite`, verifies the exact payloads, removes the source rows, and records the new ownership only after the transaction succeeds. Auth resolution has no dual-read fallback: before migration the legacy database is complete; after migration the shared state database is complete. Once relocated, deleting `main` no longer risks fleet credentials.
 
+If the shared target already contains every legacy profile with identical credential content, Doctor preserves the richer target and completes cleanup, including an empty legacy profile set or older row timestamps. Credential comparison ignores JSON object-key order but preserves every field; it does not select credentials by timestamp. Different credentials, source-only profiles, malformed subset payloads, or differing runtime-state rows remain conflicts. Back up both auth databases, reconcile the reported conflict locally, and rerun `openclaw doctor --fix`. Pending relocation receipts retain the original source digest through interrupted cleanup. After relocation completes, main-agent rows without a pending relocation receipt remain ordinary per-agent overrides.
+
 For the retired QMD memory backend, including config rewrites and derived
 workspace cleanup, see [Migrating from QMD](/concepts/memory-builtin#migrating-from-qmd).
 

--- a/src/infra/state-migrations.shared-auth-store.test.ts
+++ b/src/infra/state-migrations.shared-auth-store.test.ts
@@ -276,19 +276,15 @@ describe("shared auth store relocation", () => {
     const stateRow = source
       .prepare("SELECT state_json, updated_at FROM auth_profile_state WHERE state_key = 'primary'")
       .get() as { state_json: string; updated_at: number };
-    const credential = fixture.sharedStore.profiles["openai:shared"];
     const targetStore = {
       profiles: {
         ...makeStore("openai:extra", "extra-key").profiles,
         ...(scenario === "source-only profile"
           ? {}
-          : {
-              "openai:shared": {
-                key: scenario === "changed credential" ? "different-key" : credential.key,
-                provider: credential.provider,
-                type: credential.type,
-              },
-            }),
+          : makeStore(
+              "openai:shared",
+              scenario === "changed credential" ? "different-key" : "shared-key",
+            ).profiles),
       },
       version: 1,
       ...(scenario === "changed metadata" ? { legacyMetadata: "keep" } : {}),

--- a/src/infra/state-migrations.shared-auth-store.test.ts
+++ b/src/infra/state-migrations.shared-auth-store.test.ts
@@ -244,6 +244,124 @@ describe("shared auth store relocation", () => {
     }).toEqual(sharedBefore);
   });
 
+  it.each([
+    "identical subset",
+    "older subset",
+    "empty subset",
+    "changed credential",
+    "source-only profile",
+    "malformed source",
+    "malformed target",
+    "changed metadata",
+    "changed state",
+  ])("verifies a richer target against a %s before cleanup", async (scenario) => {
+    const fixture = await createFixture();
+    const sourcePath = fixture.sqlite.resolveAuthProfileDatabasePath(fixture.mainAgentDir);
+    const source = new DatabaseSync(sourcePath);
+    const target = fixture.stateDb.openOpenClawStateDatabase({ env: fixture.env }).db;
+    const sourceStore =
+      scenario === "empty subset" ? { version: 1, profiles: {} } : fixture.sharedStore;
+    const sourceJson =
+      scenario === "malformed source"
+        ? '{"version":1,"profiles":{"bad":null}}'
+        : JSON.stringify(sourceStore);
+    source
+      .prepare(
+        "UPDATE auth_profile_store SET store_json = ?, updated_at = 100 WHERE store_key = 'primary'",
+      )
+      .run(sourceJson);
+    const sourceRow = source
+      .prepare("SELECT store_json, updated_at FROM auth_profile_store WHERE store_key = 'primary'")
+      .get();
+    const stateRow = source
+      .prepare("SELECT state_json, updated_at FROM auth_profile_state WHERE state_key = 'primary'")
+      .get() as { state_json: string; updated_at: number };
+    const credential = fixture.sharedStore.profiles["openai:shared"];
+    const targetStore = {
+      profiles: {
+        ...makeStore("openai:extra", "extra-key").profiles,
+        ...(scenario === "source-only profile"
+          ? {}
+          : {
+              "openai:shared": {
+                key: scenario === "changed credential" ? "different-key" : credential.key,
+                provider: credential.provider,
+                type: credential.type,
+              },
+            }),
+      },
+      version: 1,
+      ...(scenario === "changed metadata" ? { legacyMetadata: "keep" } : {}),
+    };
+    const targetRow = {
+      value_json:
+        scenario === "malformed target"
+          ? '{"version":1,"profiles":null}'
+          : JSON.stringify(targetStore),
+      updated_at_ms: scenario === "identical subset" ? 100 : 200,
+    };
+    target
+      .prepare("INSERT INTO config_machine_state VALUES ('authProfiles.store', ?, ?)")
+      .run(targetRow.value_json, targetRow.updated_at_ms);
+    target
+      .prepare("INSERT INTO config_machine_state VALUES ('authProfiles.state', ?, ?)")
+      .run(stateRow.state_json, stateRow.updated_at + Number(scenario === "changed state"));
+
+    const detected = fixture.migration.detectSharedAuthStoreMigration({
+      stateDir: fixture.stateDir,
+      doctorOnlyStateMigrations: true,
+    });
+    const result = await fixture.migration.migrateSharedAuthStore({
+      detected,
+      stateDir: fixture.stateDir,
+    });
+    const converges = scenario.endsWith("subset");
+    expect(result.warnings).toEqual(converges ? [] : [expect.stringMatching(/conflict.*Back up/)]);
+    expect(
+      target
+        .prepare(
+          "SELECT value_json, updated_at_ms FROM config_machine_state WHERE state_key = 'authProfiles.store'",
+        )
+        .get(),
+    ).toEqual(targetRow);
+    expect(
+      source
+        .prepare(
+          "SELECT store_json, updated_at FROM auth_profile_store WHERE store_key = 'primary'",
+        )
+        .get(),
+    ).toEqual(converges ? undefined : sourceRow);
+    expect(
+      source
+        .prepare(
+          "SELECT state_json, updated_at FROM auth_profile_state WHERE state_key = 'primary'",
+        )
+        .get(),
+    ).toEqual(converges ? undefined : stateRow);
+    const receipt = target
+      .prepare(
+        "SELECT source_sha256, source_record_count, status, removed_source FROM migration_sources WHERE target_table = 'auth_profile_stores'",
+      )
+      .get();
+    expect(receipt).toEqual(
+      converges
+        ? {
+            source_sha256: createHash("sha256").update(JSON.stringify(sourceRow)).digest("hex"),
+            source_record_count: 1,
+            status: "completed",
+            removed_source: 1,
+          }
+        : undefined,
+    );
+    expect(
+      fixture.migration.detectSharedAuthStoreMigration({
+        stateDir: fixture.stateDir,
+        doctorOnlyStateMigrations: true,
+      }).hasLegacy,
+    ).toBe(!converges);
+    source.close();
+  });
+
   it("preserves post-relocation main-agent credential overrides without a receipt", async () => {
     const fixture = await createEmptyFixture(false);
     const mainAgentDir = path.dirname(fixture.sourcePath);
@@ -461,9 +579,19 @@ describe("shared auth store relocation", () => {
         )
         .get() as { state_json: string; updated_at: number };
       const target = fixture.stateDb.openOpenClawStateDatabase({ env: fixture.env }).db;
+      const targetStoreJson =
+        crashState === "flipped-cleaned-not-finalized"
+          ? JSON.stringify({
+              ...fixture.sharedStore,
+              profiles: {
+                ...fixture.sharedStore.profiles,
+                ...makeStore("openai:extra", "extra-key").profiles,
+              },
+            })
+          : sourceStore.store_json;
       target
         .prepare("INSERT INTO config_machine_state VALUES ('authProfiles.store', ?, ?)")
-        .run(sourceStore.store_json, sourceStore.updated_at);
+        .run(targetStoreJson, sourceStore.updated_at);
       target
         .prepare("INSERT INTO config_machine_state VALUES ('authProfiles.state', ?, ?)")
         .run(sourceState.state_json, sourceState.updated_at);
@@ -504,10 +632,15 @@ describe("shared auth store relocation", () => {
                (source_key, migration_kind, source_path, target_table, source_sha256,
                 source_size_bytes, source_record_count, last_run_id, status, imported_at,
                 removed_source, report_json)
-             VALUES (?, 'shared-auth-store-state-db', ?, 'auth_profile_stores', NULL,
-                     NULL, NULL, ?, 'ownership-flipped', 1, 0, '{}')`,
+             VALUES (?, 'shared-auth-store-state-db', ?, 'auth_profile_stores', ?,
+                     NULL, 1, ?, 'ownership-flipped', 1, 0, '{}')`,
           )
-          .run(sourceKey, sourcePath, runId);
+          .run(
+            sourceKey,
+            sourcePath,
+            createHash("sha256").update(JSON.stringify(sourceStore)).digest("hex"),
+            runId,
+          );
       }
 
       const detected = fixture.migration.detectSharedAuthStoreMigration({
@@ -533,6 +666,27 @@ describe("shared auth store relocation", () => {
         location: "state-db",
       });
       expect(retry).toEqual({ changes: [], warnings: [] });
+      if (crashState === "flipped-cleaned-not-finalized") {
+        expect(
+          target
+            .prepare(
+              "SELECT source_sha256, source_record_count, status, removed_source FROM migration_sources WHERE target_table = 'auth_profile_stores'",
+            )
+            .get(),
+        ).toEqual({
+          source_sha256: createHash("sha256").update(JSON.stringify(sourceStore)).digest("hex"),
+          source_record_count: 1,
+          status: "completed",
+          removed_source: 1,
+        });
+        expect(
+          target
+            .prepare(
+              "SELECT value_json FROM config_machine_state WHERE state_key = 'authProfiles.store'",
+            )
+            .get(),
+        ).toEqual({ value_json: targetStoreJson });
+      }
       expect(
         target
           .prepare(

--- a/src/infra/state-migrations.shared-auth-store.ts
+++ b/src/infra/state-migrations.shared-auth-store.ts
@@ -204,13 +204,12 @@ function recordMigrationLedger(
             .where("source_key", "=", sourceKey)
             .where("removed_source", "=", 0),
         );
-    return {
-      ...entry,
+    return Object.assign(entry, {
       sourceKey,
       sourceSha256: pending?.source_sha256 ?? rowDigest(entry.row),
       sourceRecordCount: pending?.source_record_count ?? Number(entry.row !== null),
       sourceSizeBytes: pending?.source_size_bytes ?? params.sourceSize,
-    };
+    });
   });
   const runHash = createHash("sha256");
   for (const entry of entries) {

--- a/src/infra/state-migrations.shared-auth-store.ts
+++ b/src/infra/state-migrations.shared-auth-store.ts
@@ -1,8 +1,10 @@
-// Doctor-owned staged relocation of legacy shared auth rows into shared SQLite state.
+/** Doctor-owned staged relocation of legacy shared auth rows into shared SQLite state. */
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { isDeepStrictEqual } from "node:util";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   noteCommittedSharedAuthStoreOwnership,
   resolveSharedAuthStoreOwnership,
@@ -36,6 +38,10 @@ import {
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
+import {
+  recordLegacyMigrationRun,
+  recordLegacyMigrationSource,
+} from "./state-migrations.receipts.js";
 import type { SharedAuthStoreMigrationDetection } from "./state-migrations.shared-auth-store.types.js";
 import type { MigrationMessages } from "./state-migrations.types.js";
 
@@ -54,6 +60,14 @@ type SharedAuthMigrationDatabase = Pick<
 >;
 
 type MigrationStage = "copied" | "ownership-flipped" | "completed";
+
+type MigrationSnapshot = {
+  env: NodeJS.ProcessEnv;
+  sourcePath: string;
+  sourceSize: number | null;
+  sourceRows: AuthRows;
+  now: number;
+};
 
 function sourceMigrationKey(sourcePath: string, sourceTable: string): string {
   return `shared-auth-store:${createHash("sha256")
@@ -91,43 +105,20 @@ function readSourceSnapshot(params: { env: NodeJS.ProcessEnv; sourcePath: string
 
 function readTargetRows(database: DatabaseSync): AuthRows {
   const db = getNodeSqliteKysely<SharedAuthMigrationDatabase>(database);
+  const cells = executeSqliteQuerySync(
+    database,
+    db
+      .selectFrom("config_machine_state")
+      .select(["state_key", "value_json", "updated_at_ms"])
+      .where("state_key", "in", ["authProfiles.store", "authProfiles.state"]),
+  ).rows;
+  const store = cells.find((cell) => cell.state_key === "authProfiles.store");
+  const state = cells.find((cell) => cell.state_key === "authProfiles.state");
+  // Preserve historical row shapes: persisted receipt digests include these field names.
   return {
-    // Shared auth payloads live in config_machine_state; project the KV cell
-    // back to the historical row shape so digest/row-match verification and
-    // persisted receipts stay byte-compatible.
-    store:
-      projectStoreRow(
-        executeSqliteQueryTakeFirstSync(
-          database,
-          db
-            .selectFrom("config_machine_state")
-            .select(["value_json", "updated_at_ms"])
-            .where("state_key", "=", "authProfiles.store"),
-        ),
-      ) ?? null,
-    state:
-      projectStateRow(
-        executeSqliteQueryTakeFirstSync(
-          database,
-          db
-            .selectFrom("config_machine_state")
-            .select(["value_json", "updated_at_ms"])
-            .where("state_key", "=", "authProfiles.state"),
-        ),
-      ) ?? null,
+    store: store ? { store_json: store.value_json, updated_at: store.updated_at_ms } : null,
+    state: state ? { state_json: state.value_json, updated_at: state.updated_at_ms } : null,
   };
-}
-
-function projectStoreRow(
-  row: { value_json: string; updated_at_ms: number } | undefined,
-): StoreRow | null {
-  return row ? { store_json: row.value_json, updated_at: row.updated_at_ms } : null;
-}
-
-function projectStateRow(
-  row: { value_json: string; updated_at_ms: number } | undefined,
-): StateRow | null {
-  return row ? { state_json: row.value_json, updated_at: row.updated_at_ms } : null;
 }
 
 function rowDigest(row: StoreRow | StateRow | null): string {
@@ -136,6 +127,39 @@ function rowDigest(row: StoreRow | StateRow | null): string {
 
 function rowsMatch<T extends StoreRow | StateRow>(left: T, right: T): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function storeIsContained(sourceRow: StoreRow, targetRow: StoreRow): boolean {
+  try {
+    const source: unknown = JSON.parse(sourceRow.store_json);
+    const target: unknown = JSON.parse(targetRow.store_json);
+    if (
+      !isRecord(source) ||
+      !isRecord(target) ||
+      typeof source.version !== "number" ||
+      !Number.isFinite(source.version) ||
+      source.version <= 0 ||
+      !isRecord(source.profiles) ||
+      !isRecord(target.profiles)
+    ) {
+      return false;
+    }
+    const targetProfiles = target.profiles;
+    // Compare raw records, not runtime coercion: dropping malformed entries or unknown
+    // fields would falsely certify that the only remaining copy can be deleted.
+    return (
+      isDeepStrictEqual({ ...source, profiles: targetProfiles }, target) &&
+      Object.values(targetProfiles).every(isRecord) &&
+      Object.entries(source.profiles).every(
+        ([id, credential]) =>
+          isRecord(credential) &&
+          Object.hasOwn(targetProfiles, id) &&
+          isDeepStrictEqual(credential, targetProfiles[id]),
+      )
+    );
+  } catch {
+    return false;
+  }
 }
 
 function assertRowsMatch(expected: AuthRows, actual: AuthRows, label: string): void {
@@ -148,98 +172,96 @@ function assertRowsMatch(expected: AuthRows, actual: AuthRows, label: string): v
   }
 }
 
-function migrationRunId(rows: AuthRows): string {
-  return `shared-auth-store:${createHash("sha256")
-    .update(rowDigest(rows.store))
-    .update(rowDigest(rows.state))
-    .digest("hex")
-    .slice(0, 24)}`;
-}
-
-function recordMigrationLedger(params: {
-  database: DatabaseSync;
-  sourcePath: string;
-  sourceSize: number | null;
-  rows: AuthRows;
-  stage: MigrationStage;
-  now: number;
-}): void {
+function recordMigrationLedger(
+  params: Omit<MigrationSnapshot, "env"> & {
+    database: DatabaseSync;
+    stage: MigrationStage;
+  },
+): void {
   const db = getNodeSqliteKysely<SharedAuthMigrationDatabase>(params.database);
-  const runId = migrationRunId(params.rows);
-  const removedSource = params.stage === "completed" ? 1 : 0;
-  const runReport = JSON.stringify({
-    source: MIGRATION_KIND,
-    target: "auth_profile_stores,auth_profile_state",
-    stage: params.stage,
-    importedRecordCount: Number(params.rows.store !== null) + Number(params.rows.state !== null),
-  });
-  executeSqliteQuerySync(
-    params.database,
-    db
-      .insertInto("migration_runs")
-      .values({
-        id: runId,
-        started_at: params.now,
-        finished_at: params.stage === "completed" ? params.now : null,
-        status: params.stage,
-        report_json: runReport,
-      })
-      .onConflict((conflict) =>
-        conflict.column("id").doUpdateSet({
-          finished_at: params.stage === "completed" ? params.now : null,
-          status: params.stage,
-          report_json: runReport,
-        }),
-      ),
-  );
-  for (const entry of [
+  const entries = [
     {
       sourceTable: "auth_profile_store",
       targetTable: "auth_profile_stores",
-      row: params.rows.store,
+      row: params.sourceRows.store,
     },
     {
       sourceTable: "auth_profile_state",
       targetTable: "auth_profile_state",
-      row: params.rows.state,
+      row: params.sourceRows.state,
     },
-  ] as const) {
-    const reportJson = JSON.stringify({
-      source: entry.sourceTable,
-      target: entry.targetTable,
+  ].map((entry) => {
+    const sourceKey = sourceMigrationKey(params.sourcePath, entry.sourceTable);
+    // A crash after source cleanup leaves only the receipt as source evidence.
+    // Never replace that evidence with a digest of the richer destination.
+    const pending = entry.row
+      ? undefined
+      : executeSqliteQueryTakeFirstSync(
+          params.database,
+          db
+            .selectFrom("migration_sources")
+            .select(["source_sha256", "source_record_count", "source_size_bytes"])
+            .where("source_key", "=", sourceKey)
+            .where("removed_source", "=", 0),
+        );
+    return {
+      ...entry,
+      sourceKey,
+      sourceSha256: pending?.source_sha256 ?? rowDigest(entry.row),
+      sourceRecordCount: pending?.source_record_count ?? Number(entry.row !== null),
+      sourceSizeBytes: pending?.source_size_bytes ?? params.sourceSize,
+    };
+  });
+  const runHash = createHash("sha256");
+  for (const entry of entries) {
+    runHash.update(entry.sourceSha256);
+  }
+  const runId = `shared-auth-store:${runHash.digest("hex").slice(0, 24)}`;
+  recordLegacyMigrationRun(params.database, {
+    runId,
+    startedAt: params.now,
+    finishedAt: params.stage === "completed" ? params.now : null,
+    status: params.stage,
+    reportJson: JSON.stringify({
+      source: MIGRATION_KIND,
+      target: "auth_profile_stores,auth_profile_state",
       stage: params.stage,
-      sourceSha256: rowDigest(entry.row),
-      importedRecordCount: entry.row ? 1 : 0,
+      importedRecordCount: entries.reduce((count, entry) => count + entry.sourceRecordCount, 0),
+    }),
+    upsert: true,
+  });
+  for (const entry of entries) {
+    recordLegacyMigrationSource(params.database, {
+      sourceKey: entry.sourceKey,
+      migrationKind: MIGRATION_KIND,
+      sourcePath: params.sourcePath,
+      targetTable: entry.targetTable,
+      sourceSha256: entry.sourceSha256,
+      sourceSizeBytes: entry.sourceSizeBytes,
+      sourceRecordCount: entry.sourceRecordCount,
+      runId,
+      status: params.stage,
+      importedAt: params.now,
+      reportJson: JSON.stringify({
+        source: entry.sourceTable,
+        target: entry.targetTable,
+        stage: params.stage,
+        sourceSha256: entry.sourceSha256,
+        importedRecordCount: entry.sourceRecordCount,
+      }),
+      upsert: true,
     });
+  }
+  if (params.stage === "completed") {
     executeSqliteQuerySync(
       params.database,
       db
-        .insertInto("migration_sources")
-        .values({
-          source_key: sourceMigrationKey(params.sourcePath, entry.sourceTable),
-          migration_kind: MIGRATION_KIND,
-          source_path: params.sourcePath,
-          target_table: entry.targetTable,
-          source_sha256: rowDigest(entry.row),
-          source_size_bytes: params.sourceSize,
-          source_record_count: entry.row ? 1 : 0,
-          last_run_id: runId,
-          status: params.stage,
-          imported_at: params.now,
-          removed_source: removedSource,
-          report_json: reportJson,
-        })
-        .onConflict((conflict) =>
-          conflict.column("source_key").doUpdateSet({
-            source_sha256: rowDigest(entry.row),
-            source_size_bytes: params.sourceSize,
-            source_record_count: entry.row ? 1 : 0,
-            last_run_id: runId,
-            status: params.stage,
-            imported_at: params.now,
-            removed_source: removedSource,
-            report_json: reportJson,
-          }),
+        .updateTable("migration_sources")
+        .set({ removed_source: 1 })
+        .where(
+          "source_key",
+          "in",
+          entries.map((entry) => entry.sourceKey),
         ),
     );
   }
@@ -299,13 +321,7 @@ function rewriteAuthJsonMigrationReceipts(
   }
 }
 
-function copyRowsToState(params: {
-  env: NodeJS.ProcessEnv;
-  sourcePath: string;
-  sourceSize: number | null;
-  sourceRows: AuthRows;
-  now: number;
-}): AuthRows {
+function copyRowsToState(params: MigrationSnapshot): AuthRows {
   return runOpenClawStateWriteTransaction(
     ({ db: database, path: targetDatabasePath }) => {
       const db = getNodeSqliteKysely<SharedAuthMigrationDatabase>(database);
@@ -313,16 +329,21 @@ function copyRowsToState(params: {
       if (
         params.sourceRows.store &&
         target.store &&
-        !rowsMatch(params.sourceRows.store, target.store)
+        !rowsMatch(params.sourceRows.store, target.store) &&
+        !storeIsContained(params.sourceRows.store, target.store)
       ) {
-        throw new Error("shared auth credential rows conflict with the relocation target");
+        throw new Error(
+          "shared auth credential rows conflict with the relocation target. Back up both auth databases, reconcile differing or missing profiles, then rerun openclaw doctor --fix.",
+        );
       }
       if (
         params.sourceRows.state &&
         target.state &&
         !rowsMatch(params.sourceRows.state, target.state)
       ) {
-        throw new Error("shared auth state rows conflict with the relocation target");
+        throw new Error(
+          "shared auth state rows conflict with the relocation target. Back up both auth databases, reconcile the runtime state, then rerun openclaw doctor --fix.",
+        );
       }
       if (params.sourceRows.store && !target.store) {
         executeSqliteQuerySync(
@@ -345,16 +366,16 @@ function copyRowsToState(params: {
         );
       }
       const canonicalRows = readTargetRows(database);
-      assertRowsMatch(params.sourceRows, canonicalRows, "copy");
+      assertRowsMatch(
+        {
+          store: target.store ?? params.sourceRows.store,
+          state: target.state ?? params.sourceRows.state,
+        },
+        canonicalRows,
+        "copy",
+      );
       rewriteAuthJsonMigrationReceipts(database, params.sourcePath, targetDatabasePath);
-      recordMigrationLedger({
-        database,
-        sourcePath: params.sourcePath,
-        sourceSize: params.sourceSize,
-        rows: canonicalRows,
-        stage: "copied",
-        now: params.now,
-      });
+      recordMigrationLedger({ ...params, database, stage: "copied" });
       return canonicalRows;
     },
     { env: params.env },
@@ -362,40 +383,43 @@ function copyRowsToState(params: {
   );
 }
 
-function flipOwnership(params: {
-  env: NodeJS.ProcessEnv;
-  sourcePath: string;
-  sourceSize: number | null;
-  rows: AuthRows;
-  now: number;
-}): boolean {
-  const flipped = resolveSharedAuthStoreOwnership(params.env).location !== "state-db";
+function advanceMigration(
+  params: MigrationSnapshot & {
+    rows: AuthRows;
+    stage: "ownership-flipped" | "completed";
+  },
+): boolean {
+  const flipping = params.stage === "ownership-flipped";
+  const flipped = flipping && resolveSharedAuthStoreOwnership(params.env).location !== "state-db";
   runOpenClawStateWriteTransaction(
     ({ db: database }) => {
-      assertRowsMatch(params.rows, readTargetRows(database), "ownership");
-      const db = getNodeSqliteKysely<SharedAuthMigrationDatabase>(database);
-      executeSqliteQuerySync(
-        database,
-        db
-          .insertInto("config_machine_state")
-          .values({
-            state_key: SHARED_AUTH_STORE_STATE_KEY,
-            value_json: JSON.stringify({ location: "state-db" }),
-            updated_at_ms: params.now,
-          })
-          .onConflict((conflict) =>
-            conflict.column("state_key").doUpdateSet({
-              value_json: JSON.stringify({ location: "state-db" }),
-              updated_at_ms: params.now,
-            }),
-          ),
-      );
-      recordMigrationLedger({ ...params, database, stage: "ownership-flipped" });
+      assertRowsMatch(params.rows, readTargetRows(database), params.stage);
+      if (flipping) {
+        const db = getNodeSqliteKysely<SharedAuthMigrationDatabase>(database);
+        const ownership = {
+          value_json: JSON.stringify({ location: "state-db" }),
+          updated_at_ms: params.now,
+        };
+        executeSqliteQuerySync(
+          database,
+          db
+            .insertInto("config_machine_state")
+            .values({ state_key: SHARED_AUTH_STORE_STATE_KEY, ...ownership })
+            .onConflict((conflict) => conflict.column("state_key").doUpdateSet(ownership)),
+        );
+      }
+      recordMigrationLedger({ ...params, database });
     },
     { env: params.env },
-    { operationLabel: "state-migration.shared-auth-ownership" },
+    {
+      operationLabel: flipping
+        ? "state-migration.shared-auth-ownership"
+        : "state-migration.shared-auth-finalize",
+    },
   );
-  noteCommittedSharedAuthStoreOwnership({ location: "state-db" }, params.env);
+  if (flipping) {
+    noteCommittedSharedAuthStoreOwnership({ location: "state-db" }, params.env);
+  }
   return flipped;
 }
 
@@ -435,23 +459,6 @@ function cleanupSourceRows(params: { env: NodeJS.ProcessEnv; sourcePath: string 
   } catch (error) {
     throw new SharedAuthStoreSourceInspectionError(params.sourcePath, "clean", error);
   }
-}
-
-function finalizeMigration(params: {
-  env: NodeJS.ProcessEnv;
-  sourcePath: string;
-  sourceSize: number | null;
-  rows: AuthRows;
-  now: number;
-}): void {
-  runOpenClawStateWriteTransaction(
-    ({ db: database }) => {
-      assertRowsMatch(params.rows, readTargetRows(database), "cleanup");
-      recordMigrationLedger({ ...params, database, stage: "completed" });
-    },
-    { env: params.env },
-    { operationLabel: "state-migration.shared-auth-finalize" },
-  );
 }
 
 /** Detect relocation or unfinished cleanup only in the explicit Doctor repair path. */
@@ -495,29 +502,18 @@ export async function migrateSharedAuthStore(params: {
     run: async (env) => {
       const now = params.now?.() ?? Date.now();
       const source = readSourceSnapshot({ env, sourcePath: params.detected.sourcePath });
-      const rows = copyRowsToState({
+      const snapshot = {
         env,
         sourcePath: params.detected.sourcePath,
         sourceSize: source.size,
         sourceRows: source.rows,
         now,
-      });
-      const ownershipFlipped = flipOwnership({
-        env,
-        sourcePath: params.detected.sourcePath,
-        sourceSize: source.size,
-        rows,
-        now,
-      });
+      };
+      const rows = copyRowsToState(snapshot);
+      const ownershipFlipped = advanceMigration({ ...snapshot, rows, stage: "ownership-flipped" });
       const sourceCleaned = cleanupSourceRows({ env, sourcePath: params.detected.sourcePath });
       const relocatedRows = rows.store !== null || rows.state !== null || sourceCleaned;
-      finalizeMigration({
-        env,
-        sourcePath: params.detected.sourcePath,
-        sourceSize: source.size,
-        rows,
-        now,
-      });
+      advanceMigration({ ...snapshot, rows, stage: "completed" });
       return {
         changes: [
           ...(ownershipFlipped && relocatedRows


### PR DESCRIPTION
Closes #132605.
Related: #134608. The receipt-verification producer repair landed separately in #134952 and is not changed here.

## What Problem This Solves

Fixes an issue where users running `openclaw doctor --fix` repeatedly encounter a shared-auth relocation conflict when the canonical target already contains every legacy credential plus additional profiles. Empty legacy profile sets and identical credentials with older row timestamps also fail to converge.

Reported by @jodok; @felixboenkost-droid independently reproduced the empty-subset case.

## Why This Change Was Made

Doctor now accepts strict parsed credential containment, preserves the richer target byte-for-byte, and completes the existing copy/ownership/cleanup sequence. Credential comparison ignores JSON object-key order but preserves every field; timestamps never choose a winner. Changed credentials, missing target profiles, malformed subset payloads, differing top-level metadata, and non-identical runtime-state rows remain fail-closed with backup/reconciliation guidance.

Source evidence and verified target snapshots remain separate. Migration receipts retain the original source digest through interrupted cleanup instead of substituting the richer destination. The implementation reuses the existing receipt writers and consolidates target reads and stage advancement; no schema, config, protocol, runtime fallback, or terminal-receipt replay changes.

## User Impact

Operators can finish a redundant legacy shared-auth relocation without manually deleting credential rows. Genuine conflicts still preserve the source and target for local reconciliation. Main-agent overrides created after completed relocation remain untouched.

## Evidence

Real CLI proof used three isolated SQLite fixtures, synthetic credentials, a temporary home/state directory, disabled channels, and no operator state. The older-subset fixture started with `state-db` ownership and a pending relocation receipt.

```text
node openclaw.mjs doctor --fix --non-interactive --yes
                         before          after / second run
identical subset         conflict        source removed; receipts completed
older subset             conflict        source removed; receipts completed
true credential conflict conflict        source retained; actionable warning
all runs                                 target bytes unchanged; both DBs integrity_check=ok
completed subset receipts                original source digest preserved

node openclaw.mjs gateway run --port 60728
GET http://127.0.0.1:60728/readyz          200
isolated Gateway                         stopped; port released
```

Validation completed: the full focused suite passes (23 tests), while the two new identical/older-subset cases fail against the pre-fix implementation with the expected relocation conflict. The full `pnpm build` passed. Autoreview of the final candidate returned no accepted/actionable findings at the configured P0 threshold.

The complete changed-file gate passed on the final candidate (types, lint, structural/storage guards, and all dead-export scans). The initial fixture typing and map-spread lint findings were fixed; the initial cold-worker timeout passed on a warm rerun without changing timeout limits.

Final source-entry proof repeated all three Doctor scenarios using `node --import ./scripts/tsx.mjs src/entry.ts doctor --fix --non-interactive --yes`. The source-entry Gateway also returned HTTP 200 from `/readyz` on isolated port 54146, then stopped cleanly. Target bytes and original source receipt digests remained intact after startup.

ClawSweeper's exact-head migration/recovery rank-up request is addressed: all 23 focused tests passed again at `54d6b48851f79b29adf920c0d2c6448b7783f13f`, including ordinary relocation and copied-not-flipped, copied-source-empty-not-flipped, flipped-not-cleaned, and flipped-cleaned-not-finalized recovery. The required branch-mode autoreview is scoped-clean at the configured P0 threshold. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33496436187) passed; `node scripts/watch-pr-ci.mjs 135096 54d6b48851f79b29adf920c0d2c6448b7783f13f` exited 0 with `GREEN`.

Production: +190/-195 (net -5). Tests: +154/-4 (net +150). Documentation: +2.

Follow-up: NO-FOLLOW-UP — the useful local simplifications are already incorporated; further abstraction would merge distinct migration contracts rather than remove meaningful duplication.
