### PR TITLE
fix(agents): harden cleanup completion paths

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -462,6 +462,9 @@ remain spawnable while inheriting defaults.
 - Auto-archive applies equally to depth-1 and depth-2 sessions.
 - Browser cleanup is separate from archive cleanup: tracked browser tabs/processes are best-effort closed when the run finishes, even if the transcript/session record is kept.
 
+The `subagent_ended` plugin hook is best-effort. Hook execution or plugin runtime
+loading failures are logged and do not abort sub-agent cleanup.
+
 ## Nested sub-agents
 
 By default, sub-agents cannot spawn their own sub-agents

--- a/src/agents/subagents/registry/subagent-registry-context-cleanup.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-context-cleanup.test.ts
@@ -1,14 +1,43 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSubagentRunRecord } from "../../subagent-test-fixtures.test-helpers.js";
 import { createSubagentRegistryContextCleanup } from "./subagent-registry-context-cleanup.js";
 import {
   resetSubagentRegistryRuntimeLoadersForTests,
   setSubagentRegistryDepsForTest,
+  subagentRegistryDeps,
 } from "./subagent-registry-deps.js";
 
 describe("subagent registry context cleanup", () => {
   afterEach(() => {
     setSubagentRegistryDepsForTest();
     resetSubagentRegistryRuntimeLoadersForTests();
+  });
+
+  it("completes ended-hook cleanup when the plugin runtime loader rejects", async () => {
+    const error = new Error("plugin runtime import failed");
+    setSubagentRegistryDepsForTest({
+      getRuntimeConfig: () => ({}),
+      loadAgentRuntimePluginRegistryHandle: () => {
+        throw error;
+      },
+    });
+    const warn = vi.fn();
+    const persist = vi.fn();
+    const cleanup = createSubagentRegistryContextCleanup({
+      deps: () => subagentRegistryDeps,
+      persist,
+      warn,
+    });
+    const entry = createSubagentRunRecord({ runId: "run-ended", endedAt: 4_000 });
+
+    await expect(cleanup.emitSubagentEndedHookForRun({ entry })).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith("subagent_ended hook failed (best-effort)", {
+      phase: "plugin-runtime",
+      err: error,
+    });
+    expect(entry.endedHookEmittedAt).toBeUndefined();
+    expect(persist).not.toHaveBeenCalled();
   });
 
   it("rechecks lifecycle ownership after resolving the context engine", async () => {

--- a/src/agents/subagents/registry/subagent-registry-context-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-context-cleanup.ts
@@ -135,39 +135,44 @@ export function createSubagentRegistryContextCleanup(config: {
     if (params.entry.endedHookEmittedAt) {
       return;
     }
-    const cfg = deps().getRuntimeConfig();
-    const registry = await loadSubagentRegistryPluginRuntimeHandle({
-      config: cfg,
-      ...(params.entry.workspaceDir ? { workspaceDir: params.entry.workspaceDir } : {}),
-      allowGatewaySubagentBinding: true,
-    });
-    await withPluginRuntimeRegistryScope(registry, async () => {
-      if (params.entry.endedHookEmittedAt || params.isCurrent?.() === false) {
-        return;
-      }
-      // Plugin loading yields after the terminal lock is released. Resolve the
-      // event from the canonical row only after that boundary so an older callback
-      // cannot claim the exactly-once hook with a superseded timeout or error.
-      const reason = params.entry.endedReason ?? params.reason ?? SUBAGENT_ENDED_REASON_COMPLETE;
-      const outcome =
-        reason === SUBAGENT_ENDED_REASON_KILLED
-          ? SUBAGENT_ENDED_OUTCOME_KILLED
-          : resolveLifecycleOutcomeFromRunOutcome(params.entry.execution.outcome);
-      const error =
-        params.entry.execution.outcome?.status === "error"
-          ? params.entry.execution.outcome.error
-          : undefined;
-      await emitSubagentEndedHookOnce({
-        entry: params.entry,
-        reason,
-        sendFarewell: params.sendFarewell,
-        accountId: params.accountId ?? params.entry.requesterOrigin?.accountId,
-        outcome,
-        error,
-        inFlightRunIds: endedHookInFlightRunIds,
-        persist,
+    // Loading and entering plugin scope are part of the best-effort hook boundary.
+    try {
+      const cfg = deps().getRuntimeConfig();
+      const registry = await loadSubagentRegistryPluginRuntimeHandle({
+        config: cfg,
+        ...(params.entry.workspaceDir ? { workspaceDir: params.entry.workspaceDir } : {}),
+        allowGatewaySubagentBinding: true,
       });
-    });
+      await withPluginRuntimeRegistryScope(registry, async () => {
+        if (params.entry.endedHookEmittedAt || params.isCurrent?.() === false) {
+          return;
+        }
+        // Plugin loading yields after the terminal lock is released. Resolve the
+        // event from the canonical row only after that boundary so an older callback
+        // cannot claim the exactly-once hook with a superseded timeout or error.
+        const reason = params.entry.endedReason ?? params.reason ?? SUBAGENT_ENDED_REASON_COMPLETE;
+        const outcome =
+          reason === SUBAGENT_ENDED_REASON_KILLED
+            ? SUBAGENT_ENDED_OUTCOME_KILLED
+            : resolveLifecycleOutcomeFromRunOutcome(params.entry.execution.outcome);
+        const error =
+          params.entry.execution.outcome?.status === "error"
+            ? params.entry.execution.outcome.error
+            : undefined;
+        await emitSubagentEndedHookOnce({
+          entry: params.entry,
+          reason,
+          sendFarewell: params.sendFarewell,
+          accountId: params.accountId ?? params.entry.requesterOrigin?.accountId,
+          outcome,
+          error,
+          inFlightRunIds: endedHookInFlightRunIds,
+          persist,
+        });
+      });
+    } catch (err) {
+      warn("subagent_ended hook failed (best-effort)", { phase: "plugin-runtime", err });
+    }
   }
 
   return {


### PR DESCRIPTION
## What Problem This Solves

A subagent's `subagent_ended` plugin hook path could escape the cleanup flow: `emitSubagentEndedHookForRun` awaited the plugin-runtime handle load and registry scope entry outside any catch, so a dynamic-import failure or scope error propagated out of subagent cleanup instead of degrading to a logged warning. Cleanup ordering was already hardened on main; this closes the remaining escape hatch.

## Why This Change Was Made

Cleanup must be best-effort end to end: a broken or partially installed plugin runtime should never strand subagent lifecycle cleanup. The load + scope steps now sit inside the same try/catch discipline as hook execution, with a phase-tagged warning. Discovery source: NetEase Youdao's LobsterAI patch stack (github.com/netease-youdao/LobsterAI); the originally planned second hardening (cooperative worker exit in the provider-auth warm worker) was dropped during rebase because main's worker-task pool refactor (persistent `serveWorkerTasks` workers) already made it obsolete.

## User Impact

Operators with a broken plugin runtime no longer risk subagent cleanup being interrupted; they get a warning log and cleanup completes.

## Evidence

- Regression test makes the plugin-runtime loader reject and asserts cleanup still completes (fails pre-fix for the intended rejection).
- Targeted suite green post-rebase: `node scripts/run-vitest.mjs src/agents/subagents/registry/subagent-registry-context-cleanup.test.ts` — 1 shard passed.
- `pnpm check:changed` and full `pnpm build` passed on the pre-rebase equivalent diff; Codex autoreview scoped-clean (P0).
- Production delta: +5 net lines in `subagent-registry-context-cleanup.ts` (rest is refactor moves); tests +29; docs +3.
