### PR TITLE
refactor(whatsapp): share text and media dispatch preparation

### DIFF
--- a/extensions/whatsapp/src/outbound-base.test.ts
+++ b/extensions/whatsapp/src/outbound-base.test.ts
@@ -64,7 +64,11 @@ describe("createWhatsAppOutboundBase", () => {
     expect(result.messageId).toBe("msg-1");
   });
 
-  it("forwards audioAsVoice to sendMessageWhatsApp", async () => {
+  it.each([
+    { name: "true", audioAsVoice: true, hasOption: true },
+    { name: "false", audioAsVoice: false, hasOption: true },
+    { name: "omitted", audioAsVoice: undefined, hasOption: false },
+  ])("forwards audioAsVoice when $name", async ({ audioAsVoice, hasOption }) => {
     const sendMessageWhatsApp = vi.fn(async () => ({
       messageId: "msg-voice",
       toJid: "15551234567@s.whatsapp.net",
@@ -81,14 +85,15 @@ describe("createWhatsAppOutboundBase", () => {
       to: "whatsapp:+15551234567",
       text: "voice",
       mediaUrl: "/tmp/workspace/voice.ogg",
-      audioAsVoice: true,
+      ...(audioAsVoice === undefined ? {} : { audioAsVoice }),
       accountId: "default",
       deps: { sendWhatsApp: sendMessageWhatsApp },
     });
 
     const options = sendMessageOptionsAt(sendMessageWhatsApp, 0, "whatsapp:+15551234567", "voice");
     expect(options.mediaUrl).toBe("/tmp/workspace/voice.ogg");
-    expect(options.audioAsVoice).toBe(true);
+    expect(Object.hasOwn(options, "audioAsVoice")).toBe(hasOption);
+    expect(options.audioAsVoice).toBe(audioAsVoice);
     expect(options.accountId).toBe("default");
   });
 
@@ -168,6 +173,63 @@ describe("createWhatsAppOutboundBase", () => {
       participant: "111@s.whatsapp.net",
       messageText: "quoted body",
     });
+  });
+
+  it("resolves media quotes before caption normalization can expire the cache", async () => {
+    let now = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+    try {
+      cacheInboundMessageMeta("default", "15551234567@s.whatsapp.net", "reply-near-expiry", {
+        participant: "111@s.whatsapp.net",
+        body: "cached quote body",
+      });
+      now += 10 * 60 * 1000 - 1;
+      const liveSender = vi.fn(async () => ({
+        messageId: "live-message",
+        toJid: "15551234567@s.whatsapp.net",
+      }));
+      const dependencySender = vi.fn(async () => ({
+        messageId: "dependency-message",
+        toJid: "15551234567@s.whatsapp.net",
+      }));
+      const outbound = createWhatsAppOutboundBase({
+        sendMessageWhatsApp: liveSender,
+        sendPollWhatsApp: vi.fn(),
+        shouldLogVerbose: () => false,
+        resolveTarget: ({ to }) => ({ ok: true as const, to: to ?? "" }),
+        normalizeText: (text) => {
+          now += 2;
+          return `normalized:${text ?? ""}`;
+        },
+      });
+
+      await outbound.sendMedia!({
+        cfg: {} as never,
+        to: "whatsapp:+15551234567",
+        text: "caption",
+        mediaUrl: "fixture://photo.png",
+        accountId: "default",
+        deps: { sendWhatsApp: dependencySender },
+        replyToId: "reply-near-expiry",
+      });
+
+      expect(dependencySender).not.toHaveBeenCalled();
+      const options = sendMessageOptionsAt(
+        liveSender,
+        0,
+        "whatsapp:+15551234567",
+        "normalized:caption",
+      );
+      expect(options.quotedMessageKey).toEqual({
+        id: "reply-near-expiry",
+        remoteJid: "15551234567@s.whatsapp.net",
+        fromMe: false,
+        participant: "111@s.whatsapp.net",
+        messageText: "cached quote body",
+      });
+    } finally {
+      dateNow.mockRestore();
+    }
   });
 
   it("uses the implicit authDir default account for quote metadata lookup", async () => {

--- a/extensions/whatsapp/src/outbound-base.ts
+++ b/extensions/whatsapp/src/outbound-base.ts
@@ -19,6 +19,8 @@ import { toWhatsappJid } from "./text-runtime.js";
 
 type WhatsAppSendMessage = typeof import("./send.js").sendMessageWhatsApp;
 type WhatsAppSendPoll = typeof import("./send.js").sendPollWhatsApp;
+type WhatsAppSendOptions = Parameters<WhatsAppSendMessage>[2];
+type WhatsAppDispatchParams = Parameters<NonNullable<ChannelOutboundAdapter["sendText"]>>[0];
 
 type CreateWhatsAppOutboundBaseParams = {
   sendMessageWhatsApp: WhatsAppSendMessage;
@@ -81,6 +83,49 @@ export function createWhatsAppOutboundBase({
     };
   };
 
+  const dispatchMessage = async (
+    params: WhatsAppDispatchParams,
+    text: string | undefined,
+    mediaOptions?: Pick<
+      WhatsAppSendOptions,
+      "mediaUrl" | "mediaAccess" | "mediaLocalRoots" | "mediaReadFile" | "audioAsVoice"
+    >,
+    mediaDeliveryOptions?: Pick<WhatsAppSendOptions, "forceDocument">,
+  ) => {
+    const lookupAccountId = resolveQuoteLookupAccountId(params.cfg, params.accountId);
+    const quotedMessageKey = resolveQuotedMessageKey({
+      accountId: lookupAccountId,
+      to: params.to,
+      replyToId: params.replyToId,
+    });
+    const send = quotedMessageKey
+      ? sendMessageWhatsApp
+      : (resolveOutboundSendDep<WhatsAppSendMessage>(params.deps, "whatsapp", {
+          legacyKeys: WHATSAPP_LEGACY_OUTBOUND_SEND_DEP_KEYS,
+        }) ?? sendMessageWhatsApp);
+    const onDeliveryResult = params.onDeliveryResult;
+    return await send(params.to, text ?? normalizeText(params.text), {
+      verbose: false,
+      cfg: params.cfg,
+      ...mediaOptions,
+      accountId: params.accountId ?? undefined,
+      gifPlayback: params.gifPlayback,
+      ...mediaDeliveryOptions,
+      replyToIdSource: params.replyToIdSource,
+      replyToMode: params.replyToMode,
+      formatting: params.formatting,
+      onPlatformSendDispatch: params.onPlatformSendDispatch,
+      ...(quotedMessageKey ? { quotedMessageKey } : {}),
+      ...(onDeliveryResult
+        ? {
+            onDeliveryResult: async (result) => {
+              await onDeliveryResult(attachChannelToResult("whatsapp", result));
+            },
+          }
+        : {}),
+    });
+  };
+
   const outbound: WhatsAppOutboundBaseCore = {
     deliveryMode: "gateway",
     textChunkLimit: 4000,
@@ -96,110 +141,26 @@ export function createWhatsAppOutboundBase({
     resolveTarget,
     ...createAttachedChannelResultAdapter({
       channel: "whatsapp",
-      sendText: async ({
-        cfg,
-        to,
-        text,
-        accountId,
-        deps,
-        gifPlayback,
-        replyToId,
-        replyToIdSource,
-        replyToMode,
-        formatting,
-        onPlatformSendDispatch,
-        onDeliveryResult,
-      }) => {
-        const normalizedText = normalizeText(text);
+      sendText: async (params) => {
+        const normalizedText = normalizeText(params.text);
         if (skipEmptyText && !normalizedText) {
           return { messageId: "" };
         }
-        const lookupAccountId = resolveQuoteLookupAccountId(cfg, accountId);
-        const quotedMessageKey = resolveQuotedMessageKey({
-          accountId: lookupAccountId,
-          to,
-          replyToId,
-        });
-        const send = quotedMessageKey
-          ? sendMessageWhatsApp
-          : (resolveOutboundSendDep<WhatsAppSendMessage>(deps, "whatsapp", {
-              legacyKeys: WHATSAPP_LEGACY_OUTBOUND_SEND_DEP_KEYS,
-            }) ?? sendMessageWhatsApp);
-        return await send(to, normalizedText, {
-          verbose: false,
-          cfg,
-          accountId: accountId ?? undefined,
-          gifPlayback,
-          replyToIdSource,
-          replyToMode,
-          formatting,
-          onPlatformSendDispatch,
-          ...(quotedMessageKey ? { quotedMessageKey } : {}),
-          ...(onDeliveryResult
-            ? {
-                onDeliveryResult: async (result) => {
-                  await onDeliveryResult(attachChannelToResult("whatsapp", result));
-                },
-              }
-            : {}),
-        });
+        return await dispatchMessage(params, normalizedText);
       },
-      sendMedia: async ({
-        cfg,
-        to,
-        text,
-        mediaUrl,
-        mediaAccess,
-        mediaLocalRoots,
-        mediaReadFile,
-        audioAsVoice,
-        accountId,
-        deps,
-        gifPlayback,
-        forceDocument,
-        replyToId,
-        replyToIdSource,
-        replyToMode,
-        formatting,
-        onPlatformSendDispatch,
-        onDeliveryResult,
-      }) => {
-        const lookupAccountId = resolveQuoteLookupAccountId(cfg, accountId);
-        const quotedMessageKey = resolveQuotedMessageKey({
-          accountId: lookupAccountId,
-          to,
-          replyToId,
-        });
-        const send = quotedMessageKey
-          ? sendMessageWhatsApp
-          : (resolveOutboundSendDep<WhatsAppSendMessage>(deps, "whatsapp", {
-              legacyKeys: WHATSAPP_LEGACY_OUTBOUND_SEND_DEP_KEYS,
-            }) ?? sendMessageWhatsApp);
-        return await send(to, normalizeText(text), {
-          verbose: false,
-          cfg,
-          mediaUrl,
-          mediaAccess,
-          mediaLocalRoots,
-          mediaReadFile,
-          ...(audioAsVoice === undefined ? {} : { audioAsVoice }),
-          accountId: accountId ?? undefined,
-          gifPlayback,
-          forceDocument,
-          replyToIdSource,
-          replyToMode,
-          formatting,
-          onPlatformSendDispatch,
-          ...(quotedMessageKey ? { quotedMessageKey } : {}),
-          ...(onDeliveryResult
-            ? {
-                onDeliveryResult: async (result) => {
-                  await onDeliveryResult(attachChannelToResult("whatsapp", result));
-                },
-              }
-            : {}),
-        });
-      },
+      sendMedia: async (params) =>
+        await dispatchMessage(
+          params,
+          undefined,
+          {
+            mediaUrl: params.mediaUrl,
+            mediaAccess: params.mediaAccess,
+            mediaLocalRoots: params.mediaLocalRoots,
+            mediaReadFile: params.mediaReadFile,
+            ...(params.audioAsVoice === undefined ? {} : { audioAsVoice: params.audioAsVoice }),
+          },
+          { forceDocument: params.forceDocument },
+        ),
       sendPoll: async ({ cfg, to, poll, accountId }) =>
         await sendPollWhatsApp(to, poll, {
           verbose: shouldLogVerbose(),

--- a/extensions/whatsapp/src/send.delivery-recovery.test.ts
+++ b/extensions/whatsapp/src/send.delivery-recovery.test.ts
@@ -1,4 +1,6 @@
 // Whatsapp tests cover the durable outbound handoff across startup recovery.
+import type { AnyMessageContent, MiscMessageGenerationOptions, WAMessage } from "baileys";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { sendDurableMessageBatch } from "openclaw/plugin-sdk/channel-outbound";
 import {
   createEmptyPluginRegistry,
@@ -13,12 +15,28 @@ import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-run
 import { withStateDirEnv } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { whatsappChannelOutbound, whatsappMessageAdapter } from "./channel-outbound.js";
+import { createWebSendApi } from "./inbound/send-api.js";
 import { createAcceptedWhatsAppSendResult } from "./inbound/send-result.test-helper.js";
 import type { ActiveWebListener } from "./inbound/types.js";
 
 const runtimeContextMocks = vi.hoisted(() => ({
   controllers: new Map<string, unknown>(),
+  loadOutboundMediaFromUrl: vi.fn(),
 }));
+
+vi.mock("openclaw/plugin-sdk/channel-activity-runtime", async () => {
+  const actual = await vi.importActual<
+    typeof import("openclaw/plugin-sdk/channel-activity-runtime")
+  >("openclaw/plugin-sdk/channel-activity-runtime");
+  return { ...actual, recordChannelActivity: vi.fn() };
+});
+
+vi.mock("openclaw/plugin-sdk/outbound-media", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/outbound-media")>(
+    "openclaw/plugin-sdk/outbound-media",
+  );
+  return { ...actual, loadOutboundMediaFromUrl: runtimeContextMocks.loadOutboundMediaFromUrl };
+});
 
 vi.mock("./connection-controller-runtime-context.js", () => ({
   getWhatsAppConnectionController: (accountId: string) =>
@@ -54,6 +72,7 @@ async function drainDefaultWhatsAppDeliveries(stateDir: string) {
 describe("WhatsApp delivery recovery", () => {
   beforeEach(() => {
     runtimeContextMocks.controllers.clear();
+    runtimeContextMocks.loadOutboundMediaFromUrl.mockReset();
     setActivePluginRegistry(
       createTestRegistry([
         {
@@ -168,6 +187,226 @@ describe("WhatsApp delivery recovery", () => {
     expect(onPlatformSendDispatch).toHaveBeenCalledTimes(parts.length);
     expect(onDeliveryResult.mock.calls.map(([result]) => result.messageId)).toEqual(
       parts.map((_, index) => `payload-${index + 1}`),
+    );
+  });
+
+  it("preserves payloads, receipts, and callback order through the active web socket", async () => {
+    const order: string[] = [];
+    const nativeSendsToReject = new Set<number>();
+    const socketSend = vi.fn(
+      async (jid: string, content: AnyMessageContent, options?: MiscMessageGenerationOptions) => {
+        const sequence = socketSend.mock.calls.length;
+        order.push(`socket:${sequence}`);
+        if (nativeSendsToReject.delete(sequence)) {
+          throw new Error("fixture transport failed");
+        }
+        return {
+          key: { id: `native-${sequence}`, remoteJid: jid, fromMe: true },
+          message: content,
+          ...(options ? { messageStubParameters: ["quoted"] } : {}),
+        } as WAMessage;
+      },
+    );
+    const sendApi = createWebSendApi({
+      sock: {
+        sendMessage: socketSend,
+        sendPresenceUpdate: vi.fn(async () => undefined),
+      },
+      defaultAccountId: accountId,
+    });
+    runtimeContextMocks.controllers.set(accountId, {
+      getActiveListener: () => sendApi,
+    });
+    const mediaAccess = {
+      localRoots: ["/tmp/whatsapp-dispatch-fixture"],
+      readFile: vi.fn(async () => Buffer.from("host-read")),
+    };
+    const mediaLocalRoots = ["/tmp/whatsapp-dispatch-legacy"];
+    const mediaReadFile = vi.fn(async () => Buffer.from("legacy-read"));
+    const media = {
+      "fixture://captionless.pdf": {
+        buffer: Buffer.from("pdf"),
+        contentType: "application/pdf",
+        kind: "document",
+        fileName: "captionless.pdf",
+      },
+      "fixture://forced.png": {
+        buffer: Buffer.from("png"),
+        contentType: "image/png",
+        kind: "image",
+        fileName: "forced.png",
+      },
+      "fixture://voice.ogg": {
+        buffer: Buffer.from("ogg"),
+        contentType: "audio/ogg",
+        kind: "audio",
+        fileName: "voice.ogg",
+      },
+    } as const;
+    runtimeContextMocks.loadOutboundMediaFromUrl.mockImplementation(async (url: string) => {
+      const fixture = media[url as keyof typeof media];
+      if (!fixture) {
+        throw new Error(`missing fixture: ${url}`);
+      }
+      return fixture;
+    });
+    const progress: string[] = [];
+    const sendPayload = async (
+      payload: Parameters<NonNullable<typeof whatsappChannelOutbound.sendPayload>>[0]["payload"],
+      extra: Partial<Parameters<NonNullable<typeof whatsappChannelOutbound.sendPayload>>[0]> = {},
+    ) =>
+      await whatsappChannelOutbound.sendPayload!({
+        cfg,
+        to: "+1555",
+        payload,
+        text: payload.text ?? "",
+        mediaAccess,
+        mediaLocalRoots,
+        mediaReadFile,
+        onPlatformSendDispatch: async () => {
+          order.push("dispatch");
+        },
+        onDeliveryResult: async (result) => {
+          progress.push(result.messageId);
+          order.push(`progress:${result.messageId}`);
+        },
+        ...extra,
+      });
+
+    const textResult = await sendPayload({ text: "plain text" });
+    const captionlessResult = await sendPayload({
+      text: "",
+      mediaUrl: "fixture://captionless.pdf",
+    });
+    const documentResult = await sendPayload(
+      { text: "document caption", mediaUrl: "fixture://forced.png" },
+      { forceDocument: true },
+    );
+    const voiceResult = await sendPayload({
+      text: "voice caption",
+      mediaUrl: "fixture://voice.ogg",
+      audioAsVoice: false,
+    });
+    const quotedResult = await sendPayload(
+      { text: "quoted text" },
+      { replyToId: "quoted-1", replyToIdSource: "explicit", replyToMode: "all" },
+    );
+    nativeSendsToReject.add(socketSend.mock.calls.length + 2);
+    const failure = await sendPayload({
+      text: "caption fails after voice acceptance",
+      mediaUrl: "fixture://voice.ogg",
+    }).catch((error: unknown) => error);
+
+    expect([textResult, captionlessResult, documentResult, voiceResult, quotedResult]).toEqual([
+      { channel: "whatsapp", messageId: "native-1", toJid: "1555@s.whatsapp.net" },
+      { channel: "whatsapp", messageId: "native-2", toJid: "1555@s.whatsapp.net" },
+      { channel: "whatsapp", messageId: "native-3", toJid: "1555@s.whatsapp.net" },
+      { channel: "whatsapp", messageId: "native-4", toJid: "1555@s.whatsapp.net" },
+      { channel: "whatsapp", messageId: "native-6", toJid: "1555@s.whatsapp.net" },
+    ]);
+    expect(socketSend.mock.calls).toEqual([
+      ["1555@s.whatsapp.net", { text: "plain text" }],
+      [
+        "1555@s.whatsapp.net",
+        {
+          document: Buffer.from("pdf"),
+          fileName: "captionless.pdf",
+          caption: undefined,
+          mimetype: "application/pdf",
+        },
+      ],
+      [
+        "1555@s.whatsapp.net",
+        {
+          document: Buffer.from("png"),
+          fileName: "forced.png",
+          caption: "document caption",
+          mimetype: "image/png",
+        },
+      ],
+      [
+        "1555@s.whatsapp.net",
+        { audio: Buffer.from("ogg"), ptt: true, mimetype: "audio/ogg; codecs=opus" },
+      ],
+      ["1555@s.whatsapp.net", { text: "voice caption" }],
+      [
+        "1555@s.whatsapp.net",
+        { text: "quoted text" },
+        {
+          quoted: expect.objectContaining({
+            key: expect.objectContaining({
+              id: "quoted-1",
+              remoteJid: "1555@s.whatsapp.net",
+              fromMe: false,
+            }),
+          }),
+        },
+      ],
+      [
+        "1555@s.whatsapp.net",
+        { audio: Buffer.from("ogg"), ptt: true, mimetype: "audio/ogg; codecs=opus" },
+      ],
+      ["1555@s.whatsapp.net", { text: "caption fails after voice acceptance" }],
+    ]);
+    expect(progress).toEqual([
+      "native-1",
+      "native-2",
+      "native-3",
+      "native-4",
+      "native-5",
+      "native-6",
+      "native-7",
+    ]);
+    expect(order).toEqual([
+      "dispatch",
+      "socket:1",
+      "progress:native-1",
+      "dispatch",
+      "socket:2",
+      "progress:native-2",
+      "dispatch",
+      "socket:3",
+      "progress:native-3",
+      "dispatch",
+      "socket:4",
+      "progress:native-4",
+      "dispatch",
+      "socket:5",
+      "progress:native-5",
+      "dispatch",
+      "socket:6",
+      "progress:native-6",
+      "dispatch",
+      "socket:7",
+      "progress:native-7",
+      "dispatch",
+      "socket:8",
+    ]);
+    expect(runtimeContextMocks.loadOutboundMediaFromUrl.mock.calls).toEqual(
+      [...Object.keys(media), "fixture://voice.ogg"].map((url, index) => [
+        url,
+        {
+          maxBytes: 50 * 1024 * 1024,
+          optimizeImages: index === 1 ? false : undefined,
+          mediaAccess,
+          mediaLocalRoots,
+          mediaReadFile,
+        },
+      ]),
+    );
+    expect(isChannelPartialDeliveryError(failure)).toBe(true);
+    if (!isChannelPartialDeliveryError(failure)) {
+      throw new Error("accepted fixture voice delivery did not preserve its receipt");
+    }
+    expect(failure.deliveryResult).toMatchObject({
+      messageIds: ["native-7"],
+      receipt: { platformMessageIds: ["native-7"] },
+    });
+    expect(failure).toHaveProperty(
+      "cause",
+      expect.objectContaining({
+        message: "fixture transport failed",
+      }),
     );
   });
 


### PR DESCRIPTION
WhatsApp text and media sends duplicated account selection, quote lookup, sender selection and delivery-result attachment. One private dispatch owner now prepares those shared fields while each caller retains its text/media options and normalization order.

Text still normalizes and suppresses empty messages before dispatch. Media still resolves the account, cached quote and sender before normalizing its caption. This ordering matters near quote-cache expiry: the first unpublished candidate normalized too early and lost quote preview/participant metadata. A before-edit comparison reproduced that difference; the corrected candidate and its regression test preserve the original payload exactly. This PR is a behavior-preserving refactor, not a claim that the unpublished ordering regression shipped.

Production is **+61/-100, net 39 lines deleted**; tests are +301 net. Optional `audioAsVoice` presence, media fields, formatting, account defaults, quoted sender selection, callback ordering and channel-attached results remain unchanged. No configuration, protocol, authorization, dependency or persistence behavior changes.

Validation includes 106 passing tests across the outbound, channel, send-API and delivery-recovery owners, all selected changed-path gates, clean diff checks and independent Codex P2 review. The actual outbound adapter and active web-send API run through a local Baileys-compatible socket fixture, checking text, captionless documents, forced documents, voice/caption sends, quoted replies, exact payloads and delivery callback order. A later transport failure preserves the previously accepted send receipt and partial-delivery error.

The quote-TTL regression failed against the first candidate and passed after correction; the final baseline/candidate observation matches sender, body, quote preview, participant and JID. External WhatsApp delivery is unproven because no disposable linked account/recipient was provisioned. The local proof exercises OpenClaw's real adapter/send logic with fixture media loading and socket transport, not external service acceptance.


Maintainer review resolves the ClawSweeper dependency limitation: I directly inspected the installed Baileys **7.0.0-rc14** implementation and types. `lib/Socket/messages-send.d.ts:36` declares the same `(jid, content, options?) => Promise<WAMessage | undefined>` boundary; `lib/Types/Message.d.ts:116-258` defines the text, Buffer media/document/audio and quoted-message shapes used here. `lib/Socket/messages-send.js:1053-1144` generates the message, awaits `relayMessage`, and returns it; the inspected relay path awaits `sendNode` at line 835. The fixture exercises OpenClaw's behavior at that boundary; it does not claim to run the Baileys socket or confirm remote WhatsApp delivery.

The first-candidate quote-TTL ordering error was reproduced and corrected before publication. The final text and media normalization points preserve the original order. All 106 focused tests, selected gates, and [exact-head CI 33496765504](https://github.com/openclaw/openclaw/actions/runs/33496765504) pass. Root accepts the private owner consolidation under this maintainer campaign. Production is net −39 lines; no code finding or rank-up move remains.
