### PR TITLE
test(ui): serve static avatar fixtures without screenshots

### DIFF
--- a/ui/src/e2e/session-ownership-visuals.test-support.ts
+++ b/ui/src/e2e/session-ownership-visuals.test-support.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import type { BrowserContext, Locator, Page } from "playwright";
+import type { Locator, Page } from "playwright";
 import { expect } from "vitest";
 
 export const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
@@ -10,31 +10,18 @@ type AvatarFixture = {
   label: string;
 };
 
-async function createAvatarPng(context: BrowserContext, background: string, label: string) {
-  const avatarPage = await context.newPage();
-  try {
-    await avatarPage.setViewportSize({ width: 64, height: 64 });
-    await avatarPage.setContent(
-      `<body style="margin:0;width:64px;height:64px;display:grid;place-items:center;background:${background};color:white;font:700 26px system-ui">${label}</body>`,
-    );
-    return await avatarPage.screenshot({ animations: "disabled", type: "png" });
-  } finally {
-    await avatarPage.close().catch(() => {});
-  }
-}
-
-export async function routeAvatarFixtures(
-  context: BrowserContext,
-  page: Page,
-  fixtures: readonly AvatarFixture[],
-) {
+export async function routeAvatarFixtures(page: Page, fixtures: readonly AvatarFixture[]) {
   await Promise.all(
-    fixtures.map(async ({ id, background, label }) => {
-      const body = await createAvatarPng(context, background, label);
-      await page.route(`**/api/users/${id}/avatar*`, (route) =>
-        route.fulfill({ body, contentType: "image/png", status: 200 }),
-      );
-    }),
+    fixtures.map(({ id, background, label }) =>
+      page.route(`**/api/users/${id}/avatar*`, (route) =>
+        route.fulfill({
+          // Static input assets must not depend on browser screenshot availability.
+          body: `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><rect width="64" height="64" fill="${background}"/><text x="32" y="32" text-anchor="middle" dominant-baseline="central" fill="white" style="font:700 26px system-ui">${label}</text></svg>`,
+          contentType: "image/svg+xml",
+          status: 200,
+        }),
+      ),
+    ),
   );
 }
 

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -158,7 +158,7 @@ suite.define(() => {
     const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
-    await routeAvatarFixtures(context, currentPage, [
+    await routeAvatarFixtures(currentPage, [
       { id: "profile-ada", background: "#3f6f76", label: "A" },
       { id: "profile-bob", background: "#985b42", label: "B" },
     ]);
@@ -279,7 +279,7 @@ suite.define(() => {
     });
     const currentPage = await context.newPage();
     page = currentPage;
-    await routeAvatarFixtures(context, currentPage, [
+    await routeAvatarFixtures(currentPage, [
       { id: "profile-patrick", background: "#27496d", label: "P" },
       { id: "profile-ada", background: "#3f6f76", label: "A" },
       { id: "profile-bob", background: "#985b42", label: "B" },

--- a/ui/src/e2e/session-person-grouping-presence.e2e.test.ts
+++ b/ui/src/e2e/session-person-grouping-presence.e2e.test.ts
@@ -82,7 +82,7 @@ suite.define(() => {
         : {}),
     });
     const page = await context.newPage();
-    await routeAvatarFixtures(context, page, [
+    await routeAvatarFixtures(page, [
       { id: "profile-ada", background: "#3f6f76", label: "A" },
       { id: "profile-bob", background: "#985b42", label: "B" },
       { id: "profile-morgan", background: "#66508c", label: "M" },


### PR DESCRIPTION
Release verification can fail before UI navigation while generating static avatar inputs: the session person-grouping fixture hit `Page.captureScreenshot: Unable to capture screenshot` in run 33492358025, job 99808929495. The test opens auxiliary Chromium pages solely to render initials into PNGs, adding a screenshot dependency unrelated to the behavior under test.

Serve authored 64×64 SVG avatar fixtures directly through the existing Playwright routes. Preserve the fixture colors/initials, the application's supported image MIME contract, all ownership/presence assertions, and the actual UI proof screenshots. Remove the auxiliary pages and PNG generation path; update both consumers. No production behavior, dependencies, configuration, retries, timeouts, or assertions change. Production LOC delta: 0; test/support: +15/−28.

Validation on the reviewed three-file candidate:
- Both real browser suites passed: 14 tests, 26.24 seconds, Node 24.20.0 and Playwright 1.62.1.
- Complete changed-file gate passed.
- Independent managed Codex review returned scoped-clean with no actionable findings.

The original failure is retained as observed CI evidence; this does not claim a deterministic reproduction of Chromium's underlying screenshot failure. The repair removes that unnecessary fixture operation. The frozen full release run remains failed and is not certified by this focused proof. No user-facing changelog entry is needed for this test-only change.
