### PR TITLE
fix(gateway): preserve provider details on chat error events

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -21540,6 +21540,7 @@ public struct ChatErrorEvent: Codable, Sendable {
     public let message: AnyCodable?
     public let errormessage: String?
     public let errorkind: AnyCodable?
+    public let errordetail: [String: AnyCodable]?
     public let usage: AnyCodable?
     public let stopreason: String?
 
@@ -21553,6 +21554,7 @@ public struct ChatErrorEvent: Codable, Sendable {
         message: AnyCodable? = nil,
         errormessage: String? = nil,
         errorkind: AnyCodable? = nil,
+        errordetail: [String: AnyCodable]? = nil,
         usage: AnyCodable? = nil,
         stopreason: String? = nil)
     {
@@ -21565,6 +21567,7 @@ public struct ChatErrorEvent: Codable, Sendable {
         self.message = message
         self.errormessage = errormessage
         self.errorkind = errorkind
+        self.errordetail = errordetail
         self.usage = usage
         self.stopreason = stopreason
     }
@@ -21579,6 +21582,7 @@ public struct ChatErrorEvent: Codable, Sendable {
         case message
         case errormessage = "errorMessage"
         case errorkind = "errorKind"
+        case errordetail = "errorDetail"
         case usage
         case stopreason = "stopReason"
     }

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -824,6 +824,17 @@ count.
   events. In protocol v4, delta payloads carry `deltaText`; `message` remains
   the cumulative assistant snapshot. Non-prefix replacements set
   `replace=true` and use `deltaText` as the replacement text.
+  Failed runs (`state: "error"`) may include `errorDetail` alongside the coarse
+  `errorKind` and human-readable `errorMessage`. This closed object has seven
+  optional fields: `provider`, `model`, `failoverReason`,
+  `providerRuntimeFailureKind`, `providerErrorType`, `httpStatus`, and
+  `providerErrorMessagePreview`. Strings are capped at 300 characters; `httpStatus`
+  is an integer from 100 through 599. Details come from the failed attempt's
+  sanitized provider observation, not from reparsing the user-facing message.
+  The preview is credential-redacted and may be shorter than the protocol cap.
+  Raw bodies, raw previews, and diagnostic hashes are never included in
+  `errorDetail`. Runs without provider observations omit it; successful and
+  canceled events do not carry it. This is an additive protocol-v4 field.
 - `session.message`, `session.operation`, `session.tool`: transcript, in-flight
   session operation, and event-stream updates for a subscribed session.
 - `session.approval`: sanitized pending and terminal approval truth for an

--- a/packages/gateway-protocol/src/schema/logs-chat.test.ts
+++ b/packages/gateway-protocol/src/schema/logs-chat.test.ts
@@ -84,6 +84,58 @@ describe("ChatStatusEventSchema", () => {
   });
 });
 
+describe("ChatErrorEventSchema", () => {
+  const event = { runId: "run-1", sessionKey: "agent:main:main", seq: 1, state: "error" };
+  const detail = {
+    provider: "openai",
+    model: "gpt-5.6-luna",
+    failoverReason: "server_error",
+    providerRuntimeFailureKind: "timeout",
+    providerErrorType: "server_error",
+    httpStatus: 502,
+    providerErrorMessagePreview: "Upstream unavailable",
+  };
+
+  it("round-trips optional closed provider error details", () => {
+    for (const errorDetail of [
+      undefined,
+      {},
+      ...Object.entries(detail).map(([key, value]) => ({ [key]: value })),
+      detail,
+    ]) {
+      const serialized = JSON.stringify({ ...event, errorDetail });
+      const wire = JSON.parse(serialized);
+      expect(Value.Check(ChatEventSchema, wire)).toBe(true);
+    }
+    expect(
+      Value.Check(ChatEventSchema, {
+        ...event,
+        errorDetail: { ...detail, rawErrorPreview: "raw" },
+      }),
+    ).toBe(false);
+    expect(Value.Check(ChatEventSchema, { ...event, state: "final", errorDetail: detail })).toBe(
+      false,
+    );
+  });
+
+  it("enforces string and HTTP status bounds", () => {
+    for (const key of Object.keys(detail).filter((field) => field !== "httpStatus")) {
+      expect(
+        Value.Check(ChatEventSchema, { ...event, errorDetail: { [key]: "x".repeat(300) } }),
+      ).toBe(true);
+      expect(
+        Value.Check(ChatEventSchema, { ...event, errorDetail: { [key]: "x".repeat(301) } }),
+      ).toBe(false);
+    }
+    for (const httpStatus of [100, 599]) {
+      expect(Value.Check(ChatEventSchema, { ...event, errorDetail: { httpStatus } })).toBe(true);
+    }
+    for (const httpStatus of [99, 600, 502.5, "502"]) {
+      expect(Value.Check(ChatEventSchema, { ...event, errorDetail: { httpStatus } })).toBe(false);
+    }
+  });
+});
+
 describe("ChatSendParamsSchema", () => {
   const send = {
     sessionKey: "agent:main:main",

--- a/packages/gateway-protocol/src/schema/logs-chat.ts
+++ b/packages/gateway-protocol/src/schema/logs-chat.ts
@@ -1,4 +1,6 @@
 // Gateway Protocol schema module defines protocol validation shapes.
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { Static } from "typebox";
 import { Type } from "typebox";
 import {
@@ -332,13 +334,61 @@ export const ChatAbortedEventSchema = closedObject({
   stopReason: Type.Optional(Type.String()),
 });
 
-/** Terminal event for failed chat runs with an optional normalized failure kind. */
+const CHAT_ERROR_DETAIL_MAX_CHARS = 300;
+const ChatErrorDetailTextSchema = Type.Optional(
+  Type.String({ maxLength: CHAT_ERROR_DETAIL_MAX_CHARS }),
+);
+const ChatErrorDetailSchema = closedObject({
+  provider: ChatErrorDetailTextSchema,
+  model: ChatErrorDetailTextSchema,
+  failoverReason: ChatErrorDetailTextSchema,
+  providerRuntimeFailureKind: ChatErrorDetailTextSchema,
+  providerErrorType: ChatErrorDetailTextSchema,
+  httpStatus: Type.Optional(Type.Integer({ minimum: 100, maximum: 599 })),
+  providerErrorMessagePreview: ChatErrorDetailTextSchema,
+});
+
+type ChatErrorDetail = Static<typeof ChatErrorDetailSchema>;
+
+/** Bounds already-redacted provider facts before lifecycle and chat publication. */
+export function projectChatErrorDetail(observation: unknown): ChatErrorDetail | undefined {
+  const source = asOptionalRecord(observation);
+  if (!source) {
+    return undefined;
+  }
+  const readText = (value: unknown) =>
+    typeof value === "string" && value.trim()
+      ? truncateUtf16Safe(value.trim(), CHAT_ERROR_DETAIL_MAX_CHARS)
+      : undefined;
+  const httpStatus = typeof source.httpStatus === "number" ? source.httpStatus : undefined;
+  // Only the observation owner's redacted facts cross this boundary; raw previews,
+  // bodies, and correlation hashes remain outside the closed chat contract.
+  const detail: ChatErrorDetail = {
+    provider: readText(source.provider),
+    model: readText(source.model),
+    failoverReason: readText(source.failoverReason),
+    providerRuntimeFailureKind: readText(source.providerRuntimeFailureKind),
+    providerErrorType: readText(source.providerErrorType),
+    httpStatus:
+      httpStatus !== undefined &&
+      Number.isInteger(httpStatus) &&
+      httpStatus >= 100 &&
+      httpStatus <= 599
+        ? httpStatus
+        : undefined,
+    providerErrorMessagePreview: readText(source.providerErrorMessagePreview),
+  };
+  return Object.values(detail).some((value) => value !== undefined) ? detail : undefined;
+}
+
+/** Terminal event for failed chat runs with optional sanitized provider diagnostics. */
 export const ChatErrorEventSchema = closedObject({
   ...ChatEventBaseSchema,
   state: Type.Literal("error"),
   message: Type.Optional(Type.Unknown()),
   errorMessage: Type.Optional(Type.String()),
   errorKind: Type.Optional(ChatEventErrorKindSchema),
+  errorDetail: Type.Optional(ChatErrorDetailSchema),
   usage: Type.Optional(Type.Unknown()),
   stopReason: Type.Optional(Type.String()),
 });

--- a/src/agents/command/attempt-callbacks.test.ts
+++ b/src/agents/command/attempt-callbacks.test.ts
@@ -63,6 +63,7 @@ describe("createAgentAttemptLifecycleCallbacks", () => {
     const state: AgentAttemptLifecycleState = {
       currentTurnUserMessagePersisted: true,
       lifecycleError: "provider failed",
+      lifecycleErrorObservation: { provider: "openai", httpStatus: 502 },
       lifecycleFinishing: true,
       lifecycleEnded: false,
     };
@@ -73,6 +74,7 @@ describe("createAgentAttemptLifecycleCallbacks", () => {
     expect(state).toEqual({
       currentTurnUserMessagePersisted: true,
       lifecycleError: undefined,
+      lifecycleErrorObservation: undefined,
       lifecycleFinishing: false,
       lifecycleEnded: false,
     });

--- a/src/agents/command/attempt-callbacks.ts
+++ b/src/agents/command/attempt-callbacks.ts
@@ -1,12 +1,14 @@
 /**
  * Lifecycle callback state helpers for a single agent attempt.
  */
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AgentMessage } from "../runtime/index.js";
 
 /** Mutable lifecycle flags observed while a single agent attempt runs. */
 export type AgentAttemptLifecycleState = {
   currentTurnUserMessagePersisted: boolean;
   lifecycleError?: string;
+  lifecycleErrorObservation?: Record<string, unknown>;
   lifecycleFinishing: boolean;
   lifecycleEnded: boolean;
 };
@@ -38,12 +40,14 @@ export function createAgentAttemptLifecycleCallbacks(
         // A same-candidate retry replaces deferred terminal state from the
         // preceding attempt; retaining it would abort a recovered run.
         state.lifecycleError = undefined;
+        state.lifecycleErrorObservation = undefined;
         state.lifecycleFinishing = false;
         state.lifecycleEnded = false;
         return onRuntimeTurnStarted?.();
       }
       if (typeof evt.data.error === "string" && evt.data.error.trim()) {
         state.lifecycleError = evt.data.error;
+        state.lifecycleErrorObservation = asOptionalRecord(evt.data.errorObservation);
       }
       // Finishing means output ended but transcript/session persistence may still
       // need to run; end/error means the runtime lifecycle is complete.

--- a/src/agents/command/lifecycle.ts
+++ b/src/agents/command/lifecycle.ts
@@ -94,6 +94,9 @@ export function createAgentCommandLifecycle(params: {
         ...(timeoutPhase ? { timeoutPhase } : {}),
         ...(providerStarted !== undefined ? { providerStarted } : {}),
         ...(error ? { error: formatErrorMessage(error) } : {}),
+        ...(error && params.state.lifecycleErrorObservation
+          ? { errorObservation: params.state.lifecycleErrorObservation }
+          : {}),
         ...(fallbackExhausted ? { fallbackExhaustedFailure: true } : {}),
         ...(terminalDelivery ? { terminalDelivery } : {}),
         ...(terminalReceipt ? { terminalReceipt } : {}),
@@ -120,6 +123,9 @@ export function createAgentCommandLifecycle(params: {
           startedAt: params.startedAt,
           endedAt: Date.now(),
           error: formatLifecycleError(error),
+          ...(params.state.lifecycleErrorObservation
+            ? { errorObservation: params.state.lifecycleErrorObservation }
+            : {}),
           ...extraData,
         },
       });

--- a/src/agents/embedded-agent-error-observation.test.ts
+++ b/src/agents/embedded-agent-error-observation.test.ts
@@ -53,6 +53,15 @@ describe("buildApiErrorObservationFields", () => {
     expect(observed.rawErrorPreview).toContain("Cookie: session=");
   });
 
+  it("redacts provider error types as well as message previews", () => {
+    const observed = buildApiErrorObservationFields(
+      JSON.stringify({
+        error: { type: `x-api-key: ${OBSERVATION_BEARER_TOKEN}`, message: "Request failed" },
+      }),
+    );
+    expect(observed.providerErrorType).toBe("x-api-key: ***");
+  });
+
   it("does not let cookie redaction consume unrelated fields on the same line", () => {
     const observed = buildApiErrorObservationFields(
       `Cookie: session=${OBSERVATION_COOKIE_VALUE} status=503 request_id=req_cookie`,

--- a/src/agents/embedded-agent-error-observation.ts
+++ b/src/agents/embedded-agent-error-observation.ts
@@ -171,7 +171,7 @@ export function buildApiErrorObservationFields(
         },
         { providerPlugin: opts?.providerOwner ?? null },
       ),
-      providerErrorType: parsed?.type,
+      providerErrorType: redactObservationText(parsed?.type),
       providerErrorMessagePreview: truncateForObservation(
         redactedProviderMessage,
         PROVIDER_ERROR_PREVIEW_MAX_CHARS,

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -254,20 +254,22 @@ describe("handleAgentEnd", () => {
     expect(meta.error).toBe("LLM request failed.");
     const userFacingLifecycleText = JSON.stringify(onAgentEvent.mock.calls);
     expect(userFacingLifecycleText).not.toContain("SECRET_CANARY_69737");
+    expect(userFacingLifecycleText).not.toContain("rawError");
     expect(userFacingLifecycleText).toContain("LLM request failed.");
     expect(onAgentEvent).toHaveBeenCalledWith({
       stream: "lifecycle",
       data: {
         phase: "error",
         error: "LLM request failed.",
+        errorObservation: expect.objectContaining({ providerRuntimeFailureKind: "unclassified" }),
       },
     });
   });
 
-  it("suppresses structured provider error messages in user-facing lifecycle events", async () => {
+  it("publishes only redacted structured provider previews in lifecycle events", async () => {
     const onAgentEvent = vi.fn();
     const rawError =
-      '{"type":"error","error":{"type":"server_error","message":"SECRET_CANARY_69737"}}';
+      '{"type":"error","error":{"type":"server_error","message":"Upstream failed x-api-key: SECRET_CANARY_69737"}}';
     const ctx = createContext(
       {
         role: "assistant",
@@ -287,12 +289,17 @@ describe("handleAgentEnd", () => {
     expect(meta.error).toBe(expectedError);
     const userFacingLifecycleText = JSON.stringify(onAgentEvent.mock.calls);
     expect(userFacingLifecycleText).not.toContain("SECRET_CANARY_69737");
+    expect(userFacingLifecycleText).not.toContain("rawError");
     expect(userFacingLifecycleText).not.toContain("LLM error server_error");
     expect(onAgentEvent).toHaveBeenCalledWith({
       stream: "lifecycle",
       data: {
         phase: "error",
         error: expectedError,
+        errorObservation: expect.objectContaining({
+          providerErrorType: "server_error",
+          providerErrorMessagePreview: "Upstream failed x-api-key: ***",
+        }),
       },
     });
   });
@@ -324,6 +331,7 @@ describe("handleAgentEnd", () => {
       data: {
         phase: "error",
         error: "LLM request failed: connection refused by the provider endpoint.",
+        errorObservation: expect.objectContaining({ providerRuntimeFailureKind: "timeout" }),
         livenessState: "blocked",
       },
     });
@@ -549,6 +557,7 @@ describe("handleAgentEnd", () => {
       data: {
         phase: "error",
         error: "LLM request failed.",
+        errorObservation: expect.objectContaining({ providerRuntimeFailureKind: "unclassified" }),
       },
     });
   });
@@ -1238,6 +1247,7 @@ describe("handleAgentEnd", () => {
       data: {
         phase: "error",
         error: "LLM request failed: connection refused by the provider endpoint.",
+        errorObservation: expect.objectContaining({ providerRuntimeFailureKind: "timeout" }),
       },
     });
   });

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -2,6 +2,7 @@
  * Handles lifecycle and compaction events from subscribed embedded-agent sessions.
  */
 import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
+import { projectChatErrorDetail } from "../../packages/gateway-protocol/src/schema/logs-chat.js";
 import { createInlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { hasAcceptedSessionSpawn } from "./accepted-session-spawn.js";
@@ -69,6 +70,7 @@ export function handleAgentEnd(
   const lastAssistant = ctx.state.lastAssistant;
   const isError = isAssistantMessage(lastAssistant) && lastAssistant.stopReason === "error";
   let lifecycleErrorText: string | undefined;
+  let errorObservation: ReturnType<typeof projectChatErrorDetail>;
   // Terminal delivery does not depend on streamed text alone: when the streamed
   // assistant texts are empty, payload building falls back to the completed
   // assistant message's visible text, so such a turn still reaches the user.
@@ -168,6 +170,14 @@ export function handleAgentEnd(
         provider: lastAssistant.provider,
       }).textPreview ?? GENERIC_ASSISTANT_ERROR_TEXT;
     lifecycleErrorText = safeErrorText;
+    // Lifecycle events also reach clients, so log-only diagnostics must not leave here.
+    errorObservation = projectChatErrorDetail({
+      provider: lastAssistant.provider,
+      model: lastAssistant.model,
+      failoverReason,
+      ...observedError,
+      httpStatus: observedError.httpCode ? Number(observedError.httpCode) : undefined,
+    });
     const safeRunId = sanitizeForConsole(ctx.params.runId) ?? "-";
     const safeModel = sanitizeForConsole(lastAssistant.model) ?? "unknown";
     const safeProvider = sanitizeForConsole(lastAssistant.provider) ?? "unknown";
@@ -209,6 +219,7 @@ export function handleAgentEnd(
         ? summarizeToolValidationError(ctx.state.lastToolError)
         : undefined;
     const terminalMeta = {
+      ...(errorObservation ? { errorObservation } : {}),
       ...(terminalStopReason ? { stopReason: terminalStopReason } : {}),
       ...(ctx.state.yielded === true ? { yielded: true } : {}),
       ...(ctx.state.timeoutPhase ? { timeoutPhase: ctx.state.timeoutPhase } : {}),

--- a/src/auto-reply/reply/agent-lifecycle-terminal.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.ts
@@ -23,6 +23,7 @@ const DEFERRED_TERMINAL_METADATA_KEYS = [
   "aborted",
   "livenessState",
   "replayInvalid",
+  "errorObservation",
 ] as const;
 
 export function resolveAgentLifecycleTerminalMetadata(meta: unknown): Record<string, unknown> {

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -3,13 +3,23 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
+import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatEventSchema } from "../../packages/gateway-protocol/src/schema/logs-chat.js";
+import { buildAgentRunTerminalOutcome } from "../agents/agent-run-terminal-outcome.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
+import {
+  createAgentAttemptLifecycleCallbacks,
+  type AgentAttemptLifecycleState,
+} from "../agents/command/attempt-callbacks.js";
+import { createAgentCommandLifecycle } from "../agents/command/lifecycle.js";
+import { createSubscribedSessionHarness } from "../agents/embedded-agent-subscribe.e2e-harness.js";
 import { buildAssistantStreamData } from "../agents/embedded-agent-subscribe.handlers.messages.stream.js";
 import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
 } from "../agents/internal-runtime-context.js";
+import { createAgentLifecycleTerminalBackstop } from "../auto-reply/reply/agent-lifecycle-terminal.js";
 import { formatChannelProgressDraftLine } from "../channels/streaming.js";
 import {
   emitAgentEvent as emitRuntimeAgentEvent,
@@ -4487,6 +4497,169 @@ describe("agent event handler", () => {
     };
     expect(nodePayload.errorKind).toBe("rate_limit");
     expect(nodePayload).not.toHaveProperty("message");
+    expect(payload).not.toHaveProperty("errorDetail");
+  });
+
+  it.each([
+    ["error", "direct"],
+    ["stop", "direct"],
+    ["error", "command"],
+    ["stop", "command"],
+    ["error", "reply"],
+    ["stop", "reply"],
+  ] as const)(
+    "projects subscribed provider %s terminals through %s ownership",
+    (stopReason, owner) => {
+      const runId = `run-provider-${stopReason}`;
+      const { broadcast, nodeSendToSession, handler, chatRunState } = createHarness({
+        lifecycleErrorRetryGraceMs: 0,
+      });
+      registerChatRun(chatRunState, runId, "session-provider-detail", runId);
+      const state: AgentAttemptLifecycleState = {
+        currentTurnUserMessagePersisted: true,
+        lifecycleFinishing: false,
+        lifecycleEnded: false,
+      };
+      const callbacks = createAgentAttemptLifecycleCallbacks(state);
+      const command = createAgentCommandLifecycle({
+        runId,
+        lifecycleGeneration: getAgentEventLifecycleGeneration,
+        startedAt: 1,
+        state,
+      });
+      const reply = createAgentLifecycleTerminalBackstop({
+        runId,
+        getLifecycleGeneration: getAgentEventLifecycleGeneration,
+        resolveTerminationFields: () => ({}),
+      });
+      const onAgentEvent = vi.fn((event) => {
+        if (owner === "command") {
+          void callbacks.onAgentEvent(event);
+        }
+        if (owner === "reply") {
+          reply.note(event);
+        }
+      });
+      const unlisten = onAgentRuntimeEvent(handler);
+      const { emit, subscription } = createSubscribedSessionHarness({
+        runId,
+        onAgentEvent,
+        terminalLifecyclePhase: owner === "direct" ? "end" : "finishing",
+      });
+      try {
+        const message = {
+          role: "assistant",
+          stopReason,
+          provider: "openai",
+          model: "gpt-5.6-luna",
+          content: stopReason === "stop" ? [{ type: "text", text: "Done" }] : [],
+          errorMessage:
+            '502 {"error":{"type":"server_error","message":"Upstream unavailable x-api-key: synthetic-provider-credential"}}',
+        };
+        emit({ type: "message_end", message });
+        emit({ type: "agent_end" });
+        const terminal = {
+          metadata: {},
+          outcome: buildAgentRunTerminalOutcome({
+            status: stopReason === "error" ? "error" : "ok",
+            stopReason,
+          }),
+        };
+        if (owner === "command") {
+          if (stopReason === "error") {
+            command.emitResultError({ payloads: [], meta: { durationMs: 0 } }, true, terminal);
+          } else {
+            command.emitEnd(terminal);
+          }
+        }
+        if (owner === "reply") {
+          reply.emit(
+            stopReason === "error" ? "error" : "end",
+            stopReason === "error" ? "Provider failed" : { meta: {} },
+          );
+        }
+        const payload = chatBroadcastCalls(broadcast).at(-1)?.[1];
+        const serialized = JSON.stringify(payload);
+        const wire = JSON.parse(serialized);
+        expect(Value.Check(ChatEventSchema, wire)).toBe(true);
+        expect(sessionChatCalls(nodeSendToSession).at(-1)?.[2]).toEqual(payload);
+        if (stopReason === "error") {
+          expect(wire.errorDetail).toEqual({
+            provider: "openai",
+            model: "gpt-5.6-luna",
+            failoverReason: "server_error",
+            providerRuntimeFailureKind: "timeout",
+            providerErrorType: "server_error",
+            httpStatus: 502,
+            providerErrorMessagePreview: "Upstream unavailable x-api-key: ***",
+          });
+          const callbackTerminal = onAgentEvent.mock.calls.find(
+            ([event]) => event.stream === "lifecycle" && event.data.error,
+          )?.[0];
+          const runtimeTerminal = agentBroadcastCalls(broadcast).find(
+            ([, event]) => event.stream === "lifecycle" && event.data.phase === "error",
+          )?.[1];
+          expect(callbackTerminal.data.errorObservation).toMatchObject({
+            provider: "openai",
+            model: "gpt-5.6-luna",
+            httpStatus: 502,
+            providerErrorMessagePreview: wire.errorDetail.providerErrorMessagePreview,
+          });
+          expect(runtimeTerminal.data.errorObservation).toEqual(
+            callbackTerminal.data.errorObservation,
+          );
+          expect(serialized).not.toContain("synthetic-provider-credential");
+          expect(JSON.stringify(callbackTerminal.data.errorObservation)).not.toContain("rawError");
+        } else {
+          expect(wire.state).toBe("final");
+          expect(wire).not.toHaveProperty("errorDetail");
+        }
+      } finally {
+        subscription.unsubscribe();
+        unlisten();
+        handler.dispose();
+      }
+    },
+  );
+
+  it("bounds the chat error allowlist and omits invalid or log-only facts", () => {
+    const { broadcast, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-bounded-error",
+      lifecycleErrorRetryGraceMs: 0,
+    });
+    try {
+      emitAgentEvent(handler, "run-bounded-error", "lifecycle", {
+        phase: "error",
+        error: "Request failed",
+        errorObservation: {
+          provider: "p".repeat(301),
+          model: "m".repeat(301),
+          failoverReason: "f".repeat(301),
+          providerRuntimeFailureKind: "k".repeat(301),
+          providerErrorType: "t".repeat(301),
+          providerErrorMessagePreview: `${"x".repeat(299)}🚀tail`,
+          httpStatus: "invalid",
+          rawErrorPreview: "log-only",
+          rawErrorHash: "log-only",
+          errorBody: "log-only",
+          unexpected: "log-only",
+        },
+      });
+      const serialized = JSON.stringify(chatBroadcastCalls(broadcast).at(-1)?.[1]);
+      const payload = JSON.parse(serialized);
+      expect(serialized).not.toContain("log-only");
+      expect(payload.errorDetail).toEqual({
+        provider: "p".repeat(300),
+        model: "m".repeat(300),
+        failoverReason: "f".repeat(300),
+        providerRuntimeFailureKind: "k".repeat(300),
+        providerErrorType: "t".repeat(300),
+        providerErrorMessagePreview: "x".repeat(299),
+      });
+      expect(Value.Check(ChatEventSchema, payload)).toBe(true);
+    } finally {
+      handler.dispose();
+    }
   });
 
   it("suppresses delayed lifecycle chat errors for active chat.send runs while still cleaning up", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1,9 +1,10 @@
 // Gateway chat runtime projects agent events into chat/session subscriber
 // streams, lifecycle persistence, heartbeat visibility, and live UI updates.
 import { performance } from "node:perf_hooks";
-import type {
-  ChatEvent,
-  ChatRunStartupPhase,
+import {
+  projectChatErrorDetail,
+  type ChatEvent,
+  type ChatRunStartupPhase,
 } from "../../packages/gateway-protocol/src/schema/logs-chat.js";
 import { isAgentLifecycleYieldedWaiting } from "../agents/agent-lifecycle-parent-state.js";
 import {
@@ -773,6 +774,7 @@ export function createAgentEventHandler({
               firstAssistantTimingEntry: finished,
               abortErrorMessage: readToolValidationErrorSummary(evt.data?.toolErrorSummary),
               yielded: yieldedWaiting ? true : undefined,
+              errorObservation: evt.data?.errorObservation,
             },
           );
         }
@@ -1130,6 +1132,7 @@ export function createAgentEventHandler({
       firstAssistantTimingEntry?: ChatRunEntry;
       abortErrorMessage?: string;
       yielded?: true;
+      errorObservation?: unknown;
     },
   ) => {
     const { text, shouldSuppressSilent } = resolveBufferedChatTextState(clientRunId, sourceRunId, {
@@ -1170,6 +1173,7 @@ export function createAgentEventHandler({
       sendChatPayload(sessionKey, payload, opts);
       return;
     }
+    const errorDetail = projectChatErrorDetail(opts?.errorObservation);
     const payload = {
       runId: clientRunId,
       sessionKey,
@@ -1179,6 +1183,7 @@ export function createAgentEventHandler({
       state: "error" as const,
       errorMessage: error ? formatForLog(error) : undefined,
       ...(errorKind && { errorKind }),
+      ...(errorDetail ? { errorDetail } : {}),
       ...(stopReason && { stopReason }),
     };
     sendChatPayload(sessionKey, payload, opts);


### PR DESCRIPTION
## What Problem This Solves

Chat clients could not distinguish a provider HTTP outage from other failed runs without Gateway logs, although the lifecycle producer already recorded sanitized diagnostic facts.

## Why This Change Was Made

Preserve those facts at the lifecycle owner, including deferred command/auto-reply terminals, and expose one bounded, closed allowlist through `errorDetail`. Apply the same projection before lifecycle publication and at the chat builder so raw log diagnostics cannot escape through either stream. Reuse the existing credential redactor, including for provider error types.

Discovery source: NetEase Youdao's LobsterAI patch stack (github.com/netease-youdao/LobsterAI). Its arbitrary-key payload-spreading mechanism was not adopted.

## User Impact

Clients can inspect optional provider/model, failure classifications, HTTP status, and a credential-redacted message preview on failed chat events. Existing coarse error kind/message behavior is unchanged. No configuration or protocol-version bump. The protocol reference documents the additive field; Control UI presentation remains a named follow-up.

## Evidence

278 tests passed across eight existing files, covering the closed/all-optional schema, bounds, redaction, direct/command/reply lifecycle-to-Gateway delivery, clean-run omission, and retry cleanup. The protocol package build and built-entry-point smoke passed, as did focused lint, formatting, whitespace checks, and fresh scoped-clean Codex autoreview. The full `pnpm check:changed` gate passed with exit code 0. Production net +77 implements the requested closed protocol capability and lifecycle ownership handoff; tests net +246 and docs +11. No live provider outage was induced; proof uses synthetic provider failure through real lifecycle and Gateway handlers.
