### PR TITLE
fix(agents): surface bucketed tool-loop warnings

### DIFF
--- a/docs/tools/loop-detection.md
+++ b/docs/tools/loop-detection.md
@@ -138,7 +138,11 @@ When a loop is detected, OpenClaw logs a loop event and either warns or blocks
 the next tool-cycle depending on severity, protecting against runaway token
 spend and lockups while preserving normal tool access.
 
-- Warnings come first.
+- Warnings come first. On OpenClaw-executed tool calls, a short system note is
+  appended to the affected tool result so the model can change approach before
+  a critical block. Warnings share the diagnostic log's rate limit, rather than
+  appearing on every repeated call. The raw outcome is recorded before the note
+  is added, so warning text does not count as progress.
 - Blocking follows once a pattern persists past the warning threshold.
 - In the embedded agent loop, the first critical loop blocks the whole tool
   batch before any tool in that batch runs. The model then gets one more

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -2103,6 +2103,82 @@ describe("agentLoop tool termination", () => {
     expect(events.slice(agentEnd + 1)).toEqual([]);
   });
 
+  it.each(["parallel", "sequential"] as const)(
+    "delivers loop warnings after raw outcome hooks in %s batches",
+    async (toolExecution) => {
+      const executed: string[] = [];
+      const requestMessages: Message[][] = [];
+      const rawOutcomes: AgentToolResult<unknown>[] = [];
+      const streamFn = createTurnSequenceStream(
+        [
+          [
+            { type: "toolCall", id: "warned", name: "read", arguments: {} },
+            { type: "toolCall", id: "sibling", name: "list", arguments: {} },
+          ],
+          [{ type: "toolCall", id: "next", name: "read", arguments: {} }],
+          [{ type: "text", text: "done" }],
+        ],
+        requestMessages,
+      );
+      const events = await collectEvents(
+        agentLoop(
+          [{ role: "user", content: "run", timestamp: 1 }],
+          {
+            systemPrompt: "",
+            messages: [],
+            tools: [makeTool("read", executed), makeTool("list", executed)],
+          },
+          {
+            ...config,
+            toolExecution,
+            beforeToolBatch: async ({ calls }) => ({
+              warnings: calls
+                .filter(({ toolCall }) => toolCall.id === "warned")
+                .map(({ toolCall }) => ({
+                  kind: "tool-loop-warning" as const,
+                  toolCallId: toolCall.id,
+                  count: 10,
+                })),
+            }),
+            afterToolCall: async ({ result }) => {
+              rawOutcomes.push(result);
+            },
+            afterToolOutcome: async ({ result }) => {
+              rawOutcomes.push(result);
+              return { content: [...result.content, { type: "text", text: "outcome hook" }] };
+            },
+          },
+          undefined,
+          streamFn,
+        ),
+      );
+      expect(rawOutcomes.every((result) => result.content.length === 1)).toBe(true);
+      const results = requestMessages.at(-1)?.filter((message) => message.role === "toolResult");
+      expect(results?.map((message) => message.content)).toEqual([
+        [
+          { type: "text", text: "read result" },
+          { type: "text", text: "outcome hook" },
+          {
+            type: "text",
+            text: "[System note: Tool-loop warning after 10 repeated calls. Change your approach or stop if you are not making progress.]",
+          },
+        ],
+        [
+          { type: "text", text: "list result" },
+          { type: "text", text: "outcome hook" },
+        ],
+        [
+          { type: "text", text: "read result" },
+          { type: "text", text: "outcome hook" },
+        ],
+      ]);
+      expect(
+        events.filter((event) => event.type === "tool_execution_end").map((event) => event.result),
+      ).toEqual(results?.map((message) => expect.objectContaining({ content: message.content })));
+      expect(executed).toEqual(["read", "list", "read"]);
+    },
+  );
+
   it("gives the model one recovery turn with the normal tool catalog", async () => {
     const executed: string[] = [];
     const providerToolNames: string[][] = [];
@@ -2622,6 +2698,9 @@ describe("agentLoop tool termination", () => {
       { systemPrompt: "", messages: [], tools: [tool] },
       {
         ...config,
+        beforeToolBatch: async () => ({
+          warnings: [{ kind: "tool-loop-warning", toolCallId: "commit-probe", count: 10 }],
+        }),
         afterToolCall: async () => ({ details: { phase: "after-call" } }),
         afterToolOutcome: async () => ({ details: { phase: "after-outcome" } }),
       },
@@ -2945,7 +3024,7 @@ describe("agentLoop tool termination", () => {
     expect(events.at(-1)).toMatchObject({ type: "agent_end" });
   });
 
-  it("normalizes a tool result with missing content before the next model turn", async () => {
+  it.each([false, true])("normalizes missing tool content with loop warning=%s", async (warn) => {
     const contexts: Context[] = [];
     const streamFn = createTurnSequenceStream(
       [
@@ -2969,7 +3048,14 @@ describe("agentLoop tool termination", () => {
       agentLoop(
         [{ role: "user", content: "run", timestamp: 1 }],
         { systemPrompt: "", messages: [], tools: [tool] },
-        config,
+        {
+          ...config,
+          beforeToolBatch: async () => ({
+            warnings: warn
+              ? [{ kind: "tool-loop-warning", toolCallId: "call-empty", count: 10 }]
+              : [],
+          }),
+        },
         undefined,
         streamFn,
       ),
@@ -2980,7 +3066,9 @@ describe("agentLoop tool termination", () => {
       expect.objectContaining({
         role: "toolResult",
         toolName: "empty",
-        content: [],
+        content: warn
+          ? [{ type: "text", text: expect.stringContaining("Tool-loop warning after 10") }]
+          : [],
       }),
     );
   });

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -15,6 +15,7 @@ import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { TranscriptNotContinuableError } from "./errors.js";
 import { uuidv7 } from "./harness/session/uuid.js";
 import {
+  appendToolLoopWarning,
   copyInternalToolResultState,
   getInternalToolExecutionPreparer,
   getInternalSyncSteeringGetter,
@@ -46,6 +47,7 @@ import type {
   AgentToolResult,
   StreamFn,
   ToolLoopIntervention,
+  ToolLoopWarning,
 } from "./types.js";
 import { validateToolArguments } from "./validation.js";
 
@@ -690,6 +692,7 @@ async function executeToolCalls(
         });
       }
       batch.lifecycle = admission ? takeInternalToolBatchLifecycle(admission) : undefined;
+      batch.warnings = admission?.warnings;
     }
   }
   let hasSequentialToolCall = false;
@@ -729,6 +732,7 @@ type ToolBatchContext = {
   resolved: Map<AgentToolCall, ResolvedToolCallOutcome>;
   validated: Map<AgentToolCall, ValidatedToolCallOutcome>;
   lifecycle?: InternalToolBatchLifecycle;
+  warnings?: ToolLoopWarning[];
 };
 
 type ResolvedToolCallOutcome =
@@ -1633,6 +1637,16 @@ async function finalizeExecutedToolCall(
 }
 
 async function finalizeToolCallOutcome(
+  batch: ToolBatchContext,
+  finalized: FinalizedToolCallOutcome,
+  args: unknown,
+): Promise<FinalizedToolCallOutcome> {
+  const outcome = await applyToolOutcomeHook(batch, finalized, args);
+  const warning = batch.warnings?.find((entry) => entry.toolCallId === outcome.toolCall.id);
+  return warning ? { ...outcome, result: appendToolLoopWarning(outcome.result, warning) } : outcome;
+}
+
+async function applyToolOutcomeHook(
   batch: ToolBatchContext,
   finalized: FinalizedToolCallOutcome,
   args: unknown,

--- a/packages/agent-core/src/internal-hooks.ts
+++ b/packages/agent-core/src/internal-hooks.ts
@@ -5,6 +5,7 @@ import type {
   AgentToolUpdateCallback,
   InternalBeforeToolBatchContext,
   InternalBeforeToolBatchResult,
+  ToolLoopWarning,
 } from "./types.js";
 
 export type InternalBeforeToolBatchHook = (
@@ -168,6 +169,24 @@ export function copyInternalToolResultState<T extends object>(source: object, ta
     toolResultProvenanceByValue.set(target, provenance);
   }
   return target;
+}
+
+/** Call only after raw outcome recording: feedback must not change no-progress hashes. */
+export function appendToolLoopWarning<T extends AgentToolResult<unknown>>(
+  result: T,
+  warning: ToolLoopWarning,
+): T {
+  return copyInternalToolResultState(result, {
+    ...result,
+    content: [
+      // Match transcript normalization for tools that omit display content.
+      ...(result.content ?? []),
+      {
+        type: "text",
+        text: `[System note: Tool-loop warning after ${warning.count} repeated calls. Change your approach or stop if you are not making progress.]`,
+      },
+    ],
+  });
 }
 
 /** Commit one tool result after its owning message has attached. */

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -75,6 +75,13 @@ export interface ToolLoopIntervention {
   reason: string;
 }
 
+/** Bucketed feedback for an admitted call, not a veto or recovery attempt. */
+export interface ToolLoopWarning {
+  kind: "tool-loop-warning";
+  toolCallId: string;
+  count: number;
+}
+
 /** Context for OpenClaw-owned whole-batch tool admission. */
 export interface InternalBeforeToolBatchContext {
   assistantMessage: AssistantMessage;
@@ -83,9 +90,9 @@ export interface InternalBeforeToolBatchContext {
 }
 
 /** Result of OpenClaw-owned whole-batch tool admission. */
-export interface InternalBeforeToolBatchResult {
-  intervention?: ToolLoopIntervention;
-}
+export type InternalBeforeToolBatchResult =
+  | { intervention: ToolLoopIntervention; warnings?: never }
+  | { intervention?: never; warnings?: ToolLoopWarning[] };
 
 export interface DeferredToolCallContext {
   /** The assistant message that requested the deferred tool call. */

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -1017,12 +1017,28 @@ describe("before_tool_call loop detection behavior", () => {
     await expectUnblockedToolExecution(secondRunTool, "new-run-0", params);
   });
 
-  it("escalates generic repeat diagnostics from warning to critical", async () => {
+  it.each(["success", "error"])("warns on repeated %s results before blocking", async (status) => {
     await withToolLoopEvents(async (emitted) => {
-      const { tool, params } = createGenericReadRepeatFixture();
+      const { tool, params, execute } = createGenericReadRepeatFixture();
+      const rawResult = {
+        content: [{ type: "text", text: "same output" }],
+        details: { status },
+      };
+      execute.mockResolvedValue(rawResult);
 
       for (let i = 0; i < 21; i += 1) {
-        await tool.execute(`read-bucket-${i}`, params, undefined, undefined);
+        const result = await tool.execute(`read-bucket-${i}`, params, undefined, undefined);
+        if (i === 20) {
+          expectToolLoopBlockedResult(result, "identical outcomes");
+        } else {
+          expect(result.content).toEqual([
+            ...rawResult.content,
+            ...(i === 10
+              ? [{ type: "text", text: expect.stringMatching(/\[.*10.*change.*stop.*\]/i) }]
+              : []),
+          ]);
+          expect(result.details).toEqual(rawResult.details);
+        }
       }
 
       const genericEvents = emitted.filter((evt) => evt.detector === "generic_repeat");
@@ -1030,6 +1046,12 @@ describe("before_tool_call loop detection behavior", () => {
         ["warning", 10],
         ["critical", 20],
       ]);
+      expect(execute).toHaveBeenCalledTimes(20);
+      expect(rawResult.content).toEqual([{ type: "text", text: "same output" }]);
+      const outcomes = getDiagnosticSessionState({ sessionKey: "main" }).toolCallHistory;
+      const resultHashes = outcomes?.flatMap((outcome) => outcome.resultHash ?? []);
+      expect(resultHashes).toHaveLength(20);
+      expect(new Set(resultHashes).size).toBe(1);
     });
   });
 

--- a/src/agents/agent-tools.before-tool-call.policy.ts
+++ b/src/agents/agent-tools.before-tool-call.policy.ts
@@ -5,6 +5,7 @@
  * trusted policies, approvals, normal hooks, and final owner approval must
  * remain in this sequence.
  */
+import type { ToolLoopWarning } from "@openclaw/agent-core";
 import { freezeDiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
 import { getGlobalHookRunnerRegistry } from "../plugins/hook-runner-global-state.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
@@ -108,6 +109,13 @@ export async function runBeforeToolCallHook(args: {
 }): Promise<HookOutcome> {
   const toolName = normalizeToolPolicyName(args.toolName || "tool");
   const params = args.params;
+  let loopWarning: ToolLoopWarning | undefined;
+  const withLoopWarning = (outcome: HookOutcome): HookOutcome => {
+    if (!outcome.blocked && loopWarning) {
+      outcome.loopWarning = loopWarning;
+    }
+    return outcome;
+  };
   let releaseArgumentChurnPolicyWait: (() => void) | undefined;
 
   try {
@@ -141,7 +149,7 @@ export async function runBeforeToolCallHook(args: {
           { toolName, params, toolCallId: args.toolCallId },
           args.ctx,
         );
-        if (intervention) {
+        if (intervention?.kind === "critical-tool-loop") {
           const outcome: HookOutcome = {
             blocked: true,
             kind: "veto",
@@ -152,6 +160,7 @@ export async function runBeforeToolCallHook(args: {
           markPrivateDecision(outcome, "genericDecision");
           return outcome;
         }
+        loopWarning = intervention;
       }
     }
 
@@ -185,7 +194,7 @@ export async function runBeforeToolCallHook(args: {
       };
     }
     if (!initialCorePolicyResult && !shouldRunTrustedPolicies && !hasBeforeToolCallHooks) {
-      return { blocked: false, params };
+      return withLoopWarning({ blocked: false, params });
     }
     const deriveOptions =
       args.ctx?.cwd || args.ctx?.sandbox
@@ -291,7 +300,7 @@ export async function runBeforeToolCallHook(args: {
           return approvalOutcome;
         }
         if (approvalOutcome.deferredApproval) {
-          return approvalOutcome;
+          return withLoopWarning(approvalOutcome);
         }
         trustedApprovalParams = approvalOutcome.params;
         trustedApprovalResolution = approvalOutcome.approvalResolution;
@@ -318,7 +327,7 @@ export async function runBeforeToolCallHook(args: {
         signal: args.signal,
       });
       if (finalApprovalOutcome) {
-        return finalApprovalOutcome;
+        return withLoopWarning(finalApprovalOutcome);
       }
       const allowed: HookOutcome = {
         blocked: false as const,
@@ -328,7 +337,7 @@ export async function runBeforeToolCallHook(args: {
         markPrivateDecision(allowed, "ownerDecision");
         allowed.approvalResolution = trustedApprovalResolution;
       }
-      return allowed;
+      return withLoopWarning(allowed);
     }
     const hookEventParams = isPlainObject(policyAdjustedParams) ? policyAdjustedParams : {};
     const callerIdentity = getGatewayToolCallerIdentity();
@@ -385,7 +394,7 @@ export async function runBeforeToolCallHook(args: {
           return approvalOutcome;
         }
         if (approvalOutcome.deferredApproval) {
-          return approvalOutcome;
+          return withLoopWarning(approvalOutcome);
         }
         finalParams = approvalOutcome.params;
         finalApprovalResolution = approvalOutcome.approvalResolution ?? finalApprovalResolution;
@@ -409,7 +418,7 @@ export async function runBeforeToolCallHook(args: {
       signal: args.signal,
     });
     if (finalApprovalOutcome) {
-      return finalApprovalOutcome;
+      return withLoopWarning(finalApprovalOutcome);
     }
     const allowed: HookOutcome = {
       blocked: false as const,
@@ -421,7 +430,7 @@ export async function runBeforeToolCallHook(args: {
     if (finalApprovalResolution) {
       allowed.approvalResolution = finalApprovalResolution;
     }
-    return allowed;
+    return withLoopWarning(allowed);
   } catch (err) {
     const toolCallId = args.toolCallId ? ` toolCallId=${args.toolCallId}` : "";
     const cause = unwrapErrorCause(err);

--- a/src/agents/agent-tools.before-tool-call.types.ts
+++ b/src/agents/agent-tools.before-tool-call.types.ts
@@ -3,6 +3,7 @@
  * Kept separate from the facade so implementation modules do not import back
  * through the barrel that re-exports them.
  */
+import type { ToolLoopWarning } from "@openclaw/agent-core";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
 import type { DiagnosticToolTerminalReason } from "../infra/diagnostic-events.js";
@@ -119,4 +120,5 @@ export type HookOutcome =
       ownerDecision?: true;
       approvalResolution?: PluginApprovalResolution;
       deferredApproval?: DeferredPluginToolApproval;
+      loopWarning?: ToolLoopWarning;
     };

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -83,7 +83,10 @@ import {
   normalizeCodeModeExecBeforeHookParams,
   reconcileCodeModeExecBeforeHookParams,
 } from "./code-mode-control-tools.js";
-import { attachInternalToolExecutionPreparer } from "./runtime/internal-hooks.js";
+import {
+  appendToolLoopWarning,
+  attachInternalToolExecutionPreparer,
+} from "./runtime/internal-hooks.js";
 import { buildToolMutationState } from "./tool-mutation.js";
 import { normalizeToolPolicyName } from "./tool-policy.js";
 import {
@@ -218,8 +221,7 @@ export function recordAdjustedParamsForToolCall(
   if (!cloneResult.ok) {
     return;
   }
-  const adjustedParamsKey = buildAdjustedParamsKey({ runId, toolCallId });
-  adjustedParamsByToolCallId.set(adjustedParamsKey, cloneResult.value);
+  adjustedParamsByToolCallId.set(buildAdjustedParamsKey({ runId, toolCallId }), cloneResult.value);
   pruneMapToMaxSize(adjustedParamsByToolCallId, MAX_TRACKED_ADJUSTED_PARAMS);
 }
 
@@ -286,10 +288,6 @@ export function buildBlockedToolResult(params: {
   preExecutionBlockedToolResults.add(result);
   return result;
 }
-
-// Build the private (trusted-listener-only) tool content payload for a tool
-// execution diagnostic event. Raw args/results never ride the public event bus;
-// consumers (e.g. diagnostics-otel) bound and redact before export.
 
 export function wrapToolWithBeforeToolCallHook(
   tool: AnyAgentTool,
@@ -600,11 +598,10 @@ export function wrapToolWithBeforeToolCallHook(
               toolCallId,
             });
           }
-          const terminalEvent = resolveToolResultTerminalDiagnostic(result, durationMs);
           emitTrustedDiagnosticEventWithPrivateData(
             {
               ...eventBase,
-              ...terminalEvent,
+              ...resolveToolResultTerminalDiagnostic(result, durationMs),
             },
             buildToolContentPrivateData(toolContentPolicy, {
               input: executeParams,
@@ -613,7 +610,8 @@ export function wrapToolWithBeforeToolCallHook(
             }),
           );
         }
-        return result;
+        // Keep loop hashes and diagnostics on the raw outcome; this note is model feedback only.
+        return outcome.loopWarning ? appendToolLoopWarning(result, outcome.loopWarning) : result;
       } catch (err) {
         if (hookOptions.emitDiagnostics) {
           emitTrustedDiagnosticEventWithPrivateData(

--- a/src/agents/runtime/internal-hooks.ts
+++ b/src/agents/runtime/internal-hooks.ts
@@ -1,5 +1,6 @@
 export {
   acknowledgeInternalToolResult,
+  appendToolLoopWarning,
   attachInternalToolBatchLifecycle,
   attachInternalToolExecutionPreparer,
   attachInternalToolResultAcknowledgement,

--- a/src/agents/tool-loop-admission.test.ts
+++ b/src/agents/tool-loop-admission.test.ts
@@ -36,6 +36,53 @@ describe("whole-batch tool-loop admission", () => {
     resetAdjustedParamsByToolCallIdForTests();
   });
 
+  it.each([
+    ["read", { path: "/tmp/repeated" }, "generic_repeat"],
+    ["process", { action: "poll", sessionId: "process-1" }, "known_poll_no_progress"],
+  ] as const)(
+    "returns bucketed warnings before %s reaches a critical loop",
+    async (name, args, detector) => {
+      const state = getDiagnosticSessionState(ctx);
+      const warningCounts: number[] = [];
+      const unsubscribe = onDiagnosticEvent((event) => {
+        if (event.type === "tool.loop" && event.action === "warn") {
+          warningCounts.push(event.count);
+        }
+      });
+      const result = { content: [{ type: "text", text: "unchanged" }], details: {} };
+      try {
+        for (let index = 0; index < 20; index += 1) {
+          const candidate = call(`repeat-${index}`, name, args);
+          const admission = await admitToolCallBatch([candidate], ctx);
+          expect(admission.intervention).toBeUndefined();
+          expect(admission.warnings ?? []).toEqual(
+            index === 10
+              ? [{ kind: "tool-loop-warning", toolCallId: candidate.toolCall.id, count: index }]
+              : [],
+          );
+          admission.commitReadyCalls?.([{ toolCallId: candidate.toolCall.id, args }]);
+          recordToolCallOutcome(state, {
+            toolName: name,
+            toolParams: args,
+            toolCallId: candidate.toolCall.id,
+            result,
+            runId: ctx.runId,
+          });
+        }
+        expect(warningCounts).toEqual([10]);
+        expect(state.toolCallHistory).toHaveLength(20);
+        expect(new Set(state.toolCallHistory?.map((entry) => entry.resultHash)).size).toBe(1);
+        await expect(
+          admitToolCallBatch([call("critical", name, args)], ctx),
+        ).resolves.toMatchObject({
+          intervention: { kind: "critical-tool-loop", toolCallId: "critical", detector, count: 20 },
+        });
+      } finally {
+        unsubscribe();
+      }
+    },
+  );
+
   it("returns a typed critical intervention and records only veto evidence", async () => {
     const state = getDiagnosticSessionState({
       sessionKey: ctx.sessionKey,

--- a/src/agents/tool-loop-admission.ts
+++ b/src/agents/tool-loop-admission.ts
@@ -2,6 +2,7 @@ import type {
   InternalBeforeToolBatchResult,
   InternalToolBatchCall,
   ToolLoopIntervention,
+  ToolLoopWarning,
 } from "@openclaw/agent-core";
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import {
@@ -32,21 +33,20 @@ async function evaluateToolLoopCall(
   call: ToolLoopCall,
   ctx: HookContext,
   stateOverride?: SessionState,
-): Promise<ToolLoopIntervention | undefined> {
+): Promise<ToolLoopIntervention | ToolLoopWarning | undefined> {
   if (!ctx.sessionKey || ctx.loopDetection?.enabled !== true) {
     return undefined;
   }
   const toolName = normalizeToolPolicyName(call.toolName || "tool");
   const { getDiagnosticSessionState, logToolLoopAction, detectToolCallLoop } =
     await loadBeforeToolCallRuntime();
-  const sessionState =
-    stateOverride ??
-    getDiagnosticSessionState({
-      sessionKey: ctx.sessionKey,
-      sessionId: ctx.sessionId,
-    });
+  // Project history for atomic admission, but keep warning buckets on the session owner.
+  const sessionState = getDiagnosticSessionState({
+    sessionKey: ctx.sessionKey,
+    sessionId: ctx.sessionId,
+  });
   const result = detectToolCallLoop(
-    sessionState,
+    stateOverride ?? sessionState,
     toolName,
     call.params,
     ctx.loopDetection,
@@ -93,6 +93,11 @@ async function evaluateToolLoopCall(
       message: result.message,
       pairedToolName: result.pairedToolName,
     });
+    return {
+      kind: "tool-loop-warning",
+      toolCallId: call.toolCallId ?? "",
+      count: result.count,
+    };
   }
   return undefined;
 }
@@ -116,9 +121,9 @@ async function recordToolLoopCall(call: ToolLoopCall, ctx: HookContext): Promise
 export async function admitSingleToolCallLoop(
   call: ToolLoopCall,
   ctx: HookContext,
-): Promise<ToolLoopIntervention | undefined> {
+): Promise<ToolLoopIntervention | ToolLoopWarning | undefined> {
   const intervention = await evaluateToolLoopCall(call, ctx);
-  if (!intervention) {
+  if (intervention?.kind !== "critical-tool-loop") {
     await recordToolLoopCall(call, ctx);
   }
   return intervention;
@@ -181,6 +186,7 @@ export async function admitToolCallBatch(
       projectedState.toolCallHistory?.push(projectedCall);
     }
   };
+  const warnings: ToolLoopWarning[] = [];
   for (const call of calls) {
     const toolName = normalizeToolPolicyName(call.toolCall.name || "tool");
     const intervention = await evaluateToolLoopCall(
@@ -192,7 +198,7 @@ export async function admitToolCallBatch(
       ctx,
       projectedState,
     );
-    if (intervention) {
+    if (intervention?.kind === "critical-tool-loop") {
       // Preserve only denial evidence. No call in this batch executed, but a
       // recovery retry must still see same-action siblings that crossed the
       // threshold. Unrelated skipped actions remain valid recovery choices.
@@ -206,6 +212,9 @@ export async function admitToolCallBatch(
         }
       }
       return { intervention };
+    }
+    if (intervention) {
+      warnings.push(intervention);
     }
     // A later sibling must assume this candidate makes no progress.
     projectLoopVeto(call);
@@ -249,6 +258,7 @@ export async function admitToolCallBatch(
     committedIds.add(readyCall.toolCallId);
   };
   return {
+    warnings,
     commitReadyCalls(readyCalls) {
       if (readyCalls.length === 1 && readyCalls[0]) {
         commitReadyCall(readyCalls[0]);


### PR DESCRIPTION
## What Problem This Solves

Tool-loop warnings appeared in diagnostics but not in tool results, leaving the model without loop feedback until a critical block.

## Why This Change Was Made

Return the existing bucketed warning as typed admission feedback and append a short system note after raw outcome recording. This gives the model a chance to change approach without changing outcome hashing or no-progress escalation. Keep warning buckets on the canonical session instead of losing lazy initialization on a projected history copy.

Discovery source: NetEase Youdao's LobsterAI patch stack (github.com/netease-youdao/LobsterAI). Only the model-visible warning and record-before-decoration idea is adopted; existing critical recovery remains intact.

## User Impact

With rolling tool-loop detection enabled, affected OpenClaw tool results carry a short warning at the diagnostic bucket boundary. Normal and unrelated sibling results remain unchanged. No new config; critical blocking, one-shot recovery, and termination stay unchanged. Documentation explains the warning and hashing behavior.

## Evidence

327 targeted tests passed across agent-core, admission/detection, embedded-runner wiring, and the wrapper E2E suite in supported focused source-fixture mode. The four admission/agent-core regressions were observed failing against the base for missing warning feedback; wrapper pre-fix failure is verified from the unchanged raw-result return in the base diff, with its full candidate suite green. The critical renderer/batch-completion function is byte-identical to base. Autoreview is scoped-clean at P0. `pnpm check:changed` passed with exit code 0.

Production delta: +60 lines; tests: +157; docs: +4. Growth implements typed transport and one shared result decorator without new detection/state paths. Full product-build, live-provider, and native-tool feedback proof are not claimed; native/CLI-only outcomes remain outside this result-decoration change.

## Final Git verification

`git commit -F .loop-warnings-commit.log` passed; the pre-commit formatter completed successfully. `git diff --exit-code HEAD` returned 0, so the committed tree exactly matches the final verified candidate. `git status -sb`:

```text
## steipete/tool-loop-model-warnings
```

`git check-ignore WORKER_RESULT.md` prints the report filename, and `git ls-files WORKER_RESULT.md` is empty. The report remains untracked through Git's info exclude, not `.gitignore`. No push, pull, PR, changelog, lockfile, baseline, or inventory changes.
