### PR TITLE
fix(feishu): validate document API outcomes before reporting success

### DIFF
--- a/extensions/feishu/src/docx-create-loopback.test.ts
+++ b/extensions/feishu/src/docx-create-loopback.test.ts
@@ -6,7 +6,9 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
 
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
+const readRemoteMediaBufferMock = vi.hoisted(() => vi.fn());
 const toolAccountModule = await import("./tool-account.js");
+const runtimeModule = await import("./runtime.js");
 
 vi.spyOn(toolAccountModule, "createFeishuToolClient").mockImplementation(() =>
   createFeishuClientMock(),
@@ -23,6 +25,9 @@ vi.spyOn(toolAccountModule, "resolveAnyEnabledFeishuToolsConfig").mockReturnValu
 vi.spyOn(toolAccountModule, "resolveFeishuToolAccount").mockReturnValue({
   config: { mediaMaxMb: 30 },
 } as ReturnType<typeof toolAccountModule.resolveFeishuToolAccount>);
+vi.spyOn(runtimeModule, "getFeishuRuntime").mockReturnValue({
+  channel: { media: { readRemoteMediaBuffer: readRemoteMediaBufferMock } },
+} as unknown as ReturnType<typeof runtimeModule.getFeishuRuntime>);
 
 const { registerFeishuDocTools } = await import("./docx.js");
 
@@ -34,6 +39,10 @@ describe("feishu_doc contract over the real Lark SDK", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    readRemoteMediaBufferMock.mockResolvedValue({
+      buffer: Buffer.from("loopback image", "utf8"),
+      fileName: "loopback.png",
+    });
   });
 
   it("rejects create content before HTTP and supports the create-then-write API workflow", async () => {
@@ -306,4 +315,215 @@ describe("feishu_doc contract over the real Lark SDK", () => {
       }
     },
   );
+
+  it("reports fulfilled nonzero image and permission responses as partial failures", async () => {
+    const requests: Array<{ method: string; path: string; body?: string }> = [];
+    const patchResponses = [
+      { code: 230001, msg: "replace rejected" },
+      { code: 0, data: { block: { block_id: "image_two", block_type: 27 } } },
+    ];
+    const server = createServer((request, response) => {
+      void (async () => {
+        const bodyChunks: Buffer[] = [];
+        for await (const chunk of request) {
+          bodyChunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+        }
+        const pathname = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+        const rawBody = Buffer.concat(bodyChunks).toString("utf8");
+        requests.push({
+          method: request.method ?? "",
+          path: pathname,
+          ...(rawBody ? { body: rawBody } : {}),
+        });
+
+        const sendJson = (body: unknown) => {
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end(JSON.stringify(body));
+        };
+        if (request.method === "POST" && pathname === "/open-apis/docx/v1/documents") {
+          const title = (JSON.parse(rawBody) as { title?: string }).title;
+          sendJson({
+            code: 0,
+            data: {
+              document: {
+                document_id: title === "Permission OK" ? "doc_permission_ok" : "doc_permission_no",
+                title,
+              },
+            },
+          });
+          return;
+        }
+        if (
+          request.method === "POST" &&
+          pathname === "/open-apis/drive/v1/permissions/doc_permission_ok/members"
+        ) {
+          sendJson({ code: 0, data: { member: { member_id: "ou_requester" } } });
+          return;
+        }
+        if (
+          request.method === "POST" &&
+          pathname === "/open-apis/drive/v1/permissions/doc_permission_no/members"
+        ) {
+          sendJson({ code: 999, msg: "grant denied" });
+          return;
+        }
+        if (
+          request.method === "POST" &&
+          pathname === "/open-apis/docx/v1/documents/blocks/convert"
+        ) {
+          sendJson({
+            code: 0,
+            data: {
+              blocks: [
+                { block_type: 27, block_id: "image_one" },
+                { block_type: 27, block_id: "image_two" },
+              ],
+              first_level_block_ids: ["image_one", "image_two"],
+            },
+          });
+          return;
+        }
+        if (
+          request.method === "GET" &&
+          pathname === "/open-apis/docx/v1/documents/doc_images/blocks"
+        ) {
+          sendJson({ code: 0, data: { items: [] } });
+          return;
+        }
+        if (
+          request.method === "POST" &&
+          pathname === "/open-apis/docx/v1/documents/doc_images/blocks/doc_images/descendant"
+        ) {
+          sendJson({
+            code: 0,
+            data: {
+              children: [
+                { block_type: 27, block_id: "image_one" },
+                { block_type: 27, block_id: "image_two" },
+              ],
+            },
+          });
+          return;
+        }
+        if (request.method === "POST" && pathname === "/open-apis/drive/v1/medias/upload_all") {
+          sendJson({ code: 0, data: { file_token: `file_${requests.length}` } });
+          return;
+        }
+        if (
+          request.method === "PATCH" &&
+          pathname.startsWith("/open-apis/docx/v1/documents/doc_images/blocks/image_")
+        ) {
+          sendJson(patchResponses.shift());
+          return;
+        }
+        response.writeHead(404).end();
+      })().catch((error: unknown) => {
+        response.writeHead(500, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: String(error) }));
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const address = server.address() as AddressInfo;
+      const loopbackHttp = Object.create(Lark.defaultHttpInstance) as Lark.HttpInstance;
+      loopbackHttp.request = async (options) => {
+        const upstream = new URL(options.url ?? "");
+        const target = new URL(
+          `${upstream.pathname}${upstream.search}`,
+          `http://127.0.0.1:${address.port}`,
+        );
+        const method = options.method ?? "GET";
+        const response = await fetch(target, {
+          method,
+          headers: { "content-type": "application/json" },
+          ...(method === "GET" || method === "HEAD"
+            ? {}
+            : { body: JSON.stringify(options.data ?? {}) }),
+        });
+        return response.json();
+      };
+      createFeishuClientMock.mockReturnValue(
+        new Lark.Client({
+          appId: "loopback-test-app",
+          appSecret: "loopback-test-placeholder", // pragma: allowlist secret
+          domain: Lark.Domain.Feishu,
+          loggerLevel: Lark.LoggerLevel.error,
+          disableTokenCache: true,
+          httpInstance: loopbackHttp,
+        }),
+      );
+
+      const harness = createToolFactoryHarness({
+        channels: {
+          feishu: { enabled: true, appId: "app_id", appSecret: "app_secret" },
+        },
+      });
+      registerFeishuDocTools(harness.api);
+      const requesterContext = {
+        messageChannel: "feishu",
+        requesterSenderId: "ou_requester",
+      } as Parameters<typeof harness.resolveTool>[1] & {
+        messageChannel: string;
+        requesterSenderId: string;
+      };
+      const tool = harness.resolveTool("feishu_doc", requesterContext);
+
+      const permissionOk = await tool.execute("permission-ok", {
+        action: "create",
+        title: "Permission OK",
+      });
+      expect(JSON.stringify(permissionOk.details)).toBe(
+        '{"document_id":"doc_permission_ok","title":"Permission OK","url":"https://feishu.cn/docx/doc_permission_ok","requester_permission_added":true,"requester_open_id":"ou_requester","requester_perm_type":"edit"}',
+      );
+
+      const permissionDenied = await tool.execute("permission-denied", {
+        action: "create",
+        title: "Permission Denied",
+      });
+      expect
+        .soft(JSON.stringify(permissionDenied.details))
+        .toBe(
+          '{"document_id":"doc_permission_no","title":"Permission Denied","url":"https://feishu.cn/docx/doc_permission_no","requester_permission_added":false,"requester_open_id":"ou_requester","requester_perm_type":"edit","requester_permission_error":"grant denied"}',
+        );
+
+      const imageWrite = await tool.execute("image-write", {
+        action: "write",
+        doc_token: "doc_images",
+        content: "![one](https://cdn.test/one.png)\n![two](https://cdn.test/two.png)",
+      });
+      expect
+        .soft(JSON.stringify(imageWrite.details))
+        .toBe('{"success":true,"blocks_deleted":0,"blocks_added":2,"images_processed":1}');
+      expect(readRemoteMediaBufferMock).toHaveBeenCalledTimes(2);
+      expect(
+        requests.filter((request) => request.method === "PATCH").map((request) => request.path),
+      ).toEqual([
+        "/open-apis/docx/v1/documents/doc_images/blocks/image_one",
+        "/open-apis/docx/v1/documents/doc_images/blocks/image_two",
+      ]);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Failed to process image https://cdn.test/one.png:",
+        expect.objectContaining({ message: "replace rejected" }),
+      );
+      expect(
+        requests
+          .filter((request) => request.path.includes("/permissions/"))
+          .map((request) => request.body),
+      ).toEqual([
+        '{"member_type":"openid","member_id":"ou_requester","perm":"edit"}',
+        '{"member_type":"openid","member_id":"ou_requester","perm":"edit"}',
+      ]);
+    } finally {
+      consoleErrorSpy.mockRestore();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
 });

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -97,13 +97,17 @@ function cleanBlocksForInsert(blocks: FeishuDocxBlock[]): {
 /** Max blocks per documentBlockChildren.create request */
 const MAX_CONVERT_RETRY_DEPTH = 8;
 
+function assertFeishuDocApiSuccess(response: { code?: number; msg?: string }) {
+  if (response.code !== 0) {
+    throw new Error(response.msg);
+  }
+}
+
 async function convertMarkdown(client: Lark.Client, markdown: string) {
   const res = await client.docx.document.convert({
     data: { content_type: "markdown", content: markdown },
   });
-  if (res.code !== 0) {
-    throw new Error(res.msg);
-  }
+  assertFeishuDocApiSuccess(res);
   return {
     blocks: res.data?.blocks ?? [],
     firstLevelBlockIds: res.data?.first_level_block_ids ?? [],
@@ -273,9 +277,7 @@ async function insertBlocks(
         ...(index !== undefined ? { index: index + offset } : {}),
       },
     });
-    if (res.code !== 0) {
-      throw new Error(res.msg);
-    }
+    assertFeishuDocApiSuccess(res);
     allInserted.push(...(res.data?.children ?? []));
   }
   return { children: allInserted, skipped };
@@ -372,9 +374,7 @@ async function clearDocumentContent(client: Lark.Client, docToken: string) {
   const existing = await client.docx.documentBlock.list({
     path: { document_id: docToken },
   });
-  if (existing.code !== 0) {
-    throw new Error(existing.msg);
-  }
+  assertFeishuDocApiSuccess(existing);
 
   const childIds =
     existing.data?.items
@@ -386,9 +386,7 @@ async function clearDocumentContent(client: Lark.Client, docToken: string) {
       path: { document_id: docToken, block_id: docToken },
       data: { start_index: 0, end_index: childIds.length },
     });
-    if (res.code !== 0) {
-      throw new Error(res.msg);
-    }
+    assertFeishuDocApiSuccess(res);
   }
 
   return childIds.length;
@@ -461,12 +459,13 @@ async function processImages(
         docToken,
       );
 
-      await client.docx.documentBlock.patch({
+      const patchRes = await client.docx.documentBlock.patch({
         path: { document_id: docToken, block_id: blockId },
         data: {
           replace_image: { token: fileToken },
         },
       });
+      assertFeishuDocApiSuccess(patchRes);
 
       processed++;
     } catch (err) {
@@ -579,9 +578,7 @@ async function uploadImageBlock(
     path: { document_id: docToken, block_id: imageBlockId },
     data: { replace_image: { token: fileToken } },
   });
-  if (patchRes.code !== 0) {
-    throw new Error(patchRes.msg);
-  }
+  assertFeishuDocApiSuccess(patchRes);
 
   return {
     success: true,
@@ -635,9 +632,7 @@ async function uploadFileBlock(
   const childrenRes = await client.docx.documentBlockChildren.get({
     path: { document_id: docToken, block_id: parentId },
   });
-  if (childrenRes.code !== 0) {
-    throw new Error(childrenRes.msg);
-  }
+  assertFeishuDocApiSuccess(childrenRes);
   const items = childrenRes.data?.items ?? [];
   const placeholderIdx = items.findIndex((item) => item.block_id === placeholderBlock.block_id);
   if (placeholderIdx >= 0) {
@@ -645,9 +640,7 @@ async function uploadFileBlock(
       path: { document_id: docToken, block_id: parentId },
       data: { start_index: placeholderIdx, end_index: placeholderIdx + 1 },
     });
-    if (deleteRes.code !== 0) {
-      throw new Error(deleteRes.msg);
-    }
+    assertFeishuDocApiSuccess(deleteRes);
   }
 
   // Upload file to Feishu drive
@@ -686,9 +679,7 @@ async function readDoc(client: Lark.Client, docToken: string) {
     client.docx.documentBlock.list({ path: { document_id: docToken } }),
   ]);
 
-  if (contentRes.code !== 0) {
-    throw new Error(contentRes.msg);
-  }
+  assertFeishuDocApiSuccess(contentRes);
 
   const blocks = blocksRes.data?.items ?? [];
   const blockCounts: Record<string, number> = {};
@@ -728,9 +719,7 @@ async function createDoc(
   const res = await client.docx.document.create({
     data: { title, folder_token: folderToken },
   });
-  if (res.code !== 0) {
-    throw new Error(res.msg);
-  }
+  assertFeishuDocApiSuccess(res);
   const doc = res.data?.document;
   const docToken = doc?.document_id;
   if (!docToken) {
@@ -749,7 +738,7 @@ async function createDoc(
       requesterPermissionSkippedReason = "trusted requester identity unavailable";
     } else {
       try {
-        await client.drive.permissionMember.create({
+        const permissionRes = await client.drive.permissionMember.create({
           path: { token: docToken },
           params: { type: "docx", need_notification: false },
           data: {
@@ -758,6 +747,7 @@ async function createDoc(
             perm: requesterPermType,
           },
         });
+        assertFeishuDocApiSuccess(permissionRes);
         requesterPermissionAdded = true;
       } catch (err) {
         requesterPermissionError = formatErrorMessage(err);
@@ -854,9 +844,7 @@ async function insertDoc(
   const blockInfo = await client.docx.documentBlock.get({
     path: { document_id: docToken, block_id: afterBlockId },
   });
-  if (blockInfo.code !== 0) {
-    throw new Error(blockInfo.msg);
-  }
+  assertFeishuDocApiSuccess(blockInfo);
 
   const parentId = blockInfo.data?.block?.parent_id ?? docToken;
 
@@ -871,9 +859,7 @@ async function insertDoc(
       path: { document_id: docToken, block_id: parentId },
       params: pageToken ? { page_token: pageToken } : {},
     });
-    if (childrenRes.code !== 0) {
-      throw new Error(childrenRes.msg);
-    }
+    assertFeishuDocApiSuccess(childrenRes);
     items.push(...(childrenRes.data?.items ?? []));
     if (childrenRes.data?.has_more !== true) {
       break;
@@ -956,9 +942,7 @@ async function createTable(
     },
   });
 
-  if (res.code !== 0) {
-    throw new Error(res.msg);
-  }
+  assertFeishuDocApiSuccess(res);
 
   const tableBlock = res.data?.children?.find((b) => b.block_type === 31);
   const cells = normalizeInsertedChildBlocks(tableBlock?.children);
@@ -987,9 +971,7 @@ async function writeTableCells(
   const tableRes = await client.docx.documentBlock.get({
     path: { document_id: docToken, block_id: tableBlockId },
   });
-  if (tableRes.code !== 0) {
-    throw new Error(tableRes.msg);
-  }
+  assertFeishuDocApiSuccess(tableRes);
 
   const tableBlock = tableRes.data?.block;
   if (tableBlock?.block_type !== 31) {
@@ -1024,9 +1006,7 @@ async function writeTableCells(
       const childrenRes = await client.docx.documentBlockChildren.get({
         path: { document_id: docToken, block_id: cellId },
       });
-      if (childrenRes.code !== 0) {
-        throw new Error(childrenRes.msg);
-      }
+      assertFeishuDocApiSuccess(childrenRes);
 
       const existingChildren = childrenRes.data?.items ?? [];
       if (existingChildren.length > 0) {
@@ -1034,9 +1014,7 @@ async function writeTableCells(
           path: { document_id: docToken, block_id: cellId },
           data: { start_index: 0, end_index: existingChildren.length },
         });
-        if (delRes.code !== 0) {
-          throw new Error(delRes.msg);
-        }
+        assertFeishuDocApiSuccess(delRes);
       }
 
       const text = rowValues[c] ?? "";
@@ -1104,9 +1082,7 @@ async function updateBlock(
   const blockInfo = await client.docx.documentBlock.get({
     path: { document_id: docToken, block_id: blockId },
   });
-  if (blockInfo.code !== 0) {
-    throw new Error(blockInfo.msg);
-  }
+  assertFeishuDocApiSuccess(blockInfo);
 
   const res = await client.docx.documentBlock.patch({
     path: { document_id: docToken, block_id: blockId },
@@ -1116,9 +1092,7 @@ async function updateBlock(
       },
     },
   });
-  if (res.code !== 0) {
-    throw new Error(res.msg);
-  }
+  assertFeishuDocApiSuccess(res);
 
   return { success: true, block_id: blockId };
 }
@@ -1127,18 +1101,14 @@ async function deleteBlock(client: Lark.Client, docToken: string, blockId: strin
   const blockInfo = await client.docx.documentBlock.get({
     path: { document_id: docToken, block_id: blockId },
   });
-  if (blockInfo.code !== 0) {
-    throw new Error(blockInfo.msg);
-  }
+  assertFeishuDocApiSuccess(blockInfo);
 
   const parentId = blockInfo.data?.block?.parent_id ?? docToken;
 
   const children = await client.docx.documentBlockChildren.get({
     path: { document_id: docToken, block_id: parentId },
   });
-  if (children.code !== 0) {
-    throw new Error(children.msg);
-  }
+  assertFeishuDocApiSuccess(children);
 
   const items = children.data?.items ?? [];
   const index = items.findIndex((item) => item.block_id === blockId);
@@ -1150,9 +1120,7 @@ async function deleteBlock(client: Lark.Client, docToken: string, blockId: strin
     path: { document_id: docToken, block_id: parentId },
     data: { start_index: index, end_index: index + 1 },
   });
-  if (res.code !== 0) {
-    throw new Error(res.msg);
-  }
+  assertFeishuDocApiSuccess(res);
 
   return { success: true, deleted_block_id: blockId };
 }
@@ -1161,9 +1129,7 @@ async function listBlocks(client: Lark.Client, docToken: string) {
   const res = await client.docx.documentBlock.list({
     path: { document_id: docToken },
   });
-  if (res.code !== 0) {
-    throw new Error(res.msg);
-  }
+  assertFeishuDocApiSuccess(res);
 
   return {
     blocks: res.data?.items ?? [],
@@ -1174,9 +1140,7 @@ async function getBlock(client: Lark.Client, docToken: string, blockId: string) 
   const res = await client.docx.documentBlock.get({
     path: { document_id: docToken, block_id: blockId },
   });
-  if (res.code !== 0) {
-    throw new Error(res.msg);
-  }
+  assertFeishuDocApiSuccess(res);
 
   return {
     block: res.data?.block,
@@ -1185,9 +1149,7 @@ async function getBlock(client: Lark.Client, docToken: string, blockId: string) 
 
 async function listAppScopes(client: Lark.Client) {
   const res = await client.application.scope.list({});
-  if (res.code !== 0) {
-    throw new Error(res.msg);
-  }
+  assertFeishuDocApiSuccess(res);
 
   const scopes = res.data?.scopes ?? [];
   const granted = scopes.filter((s) => s.grant_status === 1);


### PR DESCRIPTION
Feishu document creation could report that requester access was granted after the API returned HTTP 200 with a nonzero error code. Markdown image processing could similarly count a rejected image replacement as successful. The Lark SDK fulfills these response bodies; the document owner must inspect their outcome before recording success.

One private assertion now owns the existing `code !== 0` contract, replacing 23 repeated checks and covering the two missing checks. Permission failures preserve the successfully created document and return `requester_permission_added: false` with the original error. A failed image replacement is logged and omitted from the success count while later images continue. Distinct descendant, missing-ID, pagination and upload errors retain their existing handling. No permission policy or requested scope changes.

Production is +33/-71, **net -38 lines**; the regression adds 220 test lines. This is real duplicate-policy removal, including the helper and both new checks. No configuration, dependency, storage, schema or protocol change.

The baseline regression runs the registered tool and installed Lark 1.73.0 client through a local HTTP bridge. A fulfilled permission error reports success before the patch, and a rejected first image PATCH incorrectly produces `images_processed: 2`. The same run now returns the permission error and `images_processed: 1`, with both ordered image requests observed. Successful request/output bytes and the existing log prefix are also asserted. All four loopback tests, all 53 controls across six files, every selected changed-path gate, and fresh managed Codex high/P2 review pass.

The acting maintainer directly inspected the installed SDK request methods and response handling, the complete changed owner paths, callers, existing tests and Feishu documentation. This is actual SDK/HTTP behavior proof, not external Feishu acceptance: an approved disposable account/document is unavailable. The transport bridge substitutes for default Axios; no authenticated external mutation was made.

Named follow-up: `readDoc` retains its existing auxiliary metadata/block-list failure policy; changing that policy needs separate product evidence. No release changelog entry is added for this unreleased maintainer repair.





Review follow-up for the ClawSweeper review at 12:08 UTC: the dependency-source gap is resolved. I directly inspected the installed, repository-pinned Lark SDK 1.73.0: `lib/index.js:196` unwraps successful Axios responses as `resp.data`; `:43725` document-block PATCH and `:46386` permission-member creation return that request promise with only a rejection logger. Neither endpoint rejects fulfilled nonzero API result codes. `:100712` selects the default HTTP client when no custom client is supplied. The inspected SDK file SHA-256 is `f44d1f5bdef82551e9a5b5d792dc2bfb6d4f588d0eb47a0eafbee29b1a5b5f17`.

This confirms the contract exercised by the actual Lark-client loopback regression: the document owner must inspect the result before recording permission or image success. The separate read-metadata policy, per-image continuation and partial-document behavior remain unchanged. No external Feishu service acceptance is claimed. The review lists no additional correctness findings or rank-up moves.

[Exact-head CI 33497366508](https://github.com/openclaw/openclaw/actions/runs/33497366508) is green. The source integration with the already-landed table-action consolidation retains the response assertions and both repaired success counters. This root-cause repair and its 38-line production reduction are accepted for the user-authorized landing campaign.
