### PR TITLE
perf(pdf): avoid unused document encodings and buffer copies

### DIFF
--- a/extensions/document-extract/document-extractor.test.ts
+++ b/extensions/document-extract/document-extractor.test.ts
@@ -63,7 +63,7 @@ describe("PDF document extractor", () => {
         images: [
           {
             type: "image",
-            bytes: Uint8Array.from(Buffer.from("png1")),
+            bytes: Uint8Array.from(Buffer.from("!png1?")).subarray(1, 5),
             mimeType: "image/png",
             page: 1,
             width: 5,
@@ -86,12 +86,14 @@ describe("PDF document extractor", () => {
       });
     const extractor = createPdfDocumentExtractor();
 
-    const result = await extractor.extract(request());
+    const input = request({ buffer: Buffer.from("!%PDF-1.4?").subarray(1, -1) });
+    const result = await extractor.extract(input);
 
     if (!result) {
       throw new Error("Expected PDF extraction result");
     }
     expect(openPdfMock).toHaveBeenCalledWith(expect.any(Uint8Array));
+    expect(Buffer.from(openPdfMock.mock.calls[0]?.[0] ?? [])).toEqual(input.buffer);
     expect(pdfDocument.extract).toHaveBeenNthCalledWith(1, {
       mode: "text",
       maxPages: 2,

--- a/extensions/document-extract/document-extractor.ts
+++ b/extensions/document-extract/document-extractor.ts
@@ -26,12 +26,9 @@ async function loadPdfEngine(): Promise<PdfEngine> {
   return pdfEnginePromise;
 }
 
-function toDocumentImage(image: PdfImage): DocumentExtractedImage {
-  return {
-    type: "image",
-    data: Buffer.from(image.bytes).toString("base64"),
-    mimeType: image.mimeType,
-  };
+function toDocumentImage({ bytes, mimeType }: PdfImage): DocumentExtractedImage {
+  const data = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString("base64");
+  return { type: "image", data, mimeType };
 }
 
 function isPdfPasswordError(err: unknown): boolean {
@@ -61,7 +58,7 @@ async function extractPdfContent(
   const engine = await loadPdfEngine();
   const pdf = await openPdfDocument({
     engine,
-    input: new Uint8Array(request.buffer),
+    input: request.buffer,
     ...(request.password ? { password: request.password } : {}),
   });
   try {

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -149,7 +149,7 @@ async function runPdfPrompt(params: {
   pdfModelConfig: ImageModelConfig;
   modelOverride?: string;
   prompt: string;
-  pdfBuffers: Array<{ base64: string; filename: string }>;
+  pdfBuffers: Array<{ buffer: Buffer; filename: string }>;
   password?: string;
   pageNumbers?: number[];
   getExtractions: () => Promise<PdfExtractedContent[]>;
@@ -209,6 +209,7 @@ async function runPdfPrompt(params: {
       preparedRuntime.config,
       committedPdfModelConfig,
     );
+    let nativePdfs: Array<{ base64: string; filename: string }> | undefined;
     let extractionCache: PdfExtractedContent[] | null = null;
     const getExtractions = async (): Promise<PdfExtractedContent[]> => {
       if (!extractionCache) {
@@ -257,14 +258,14 @@ async function runPdfPrompt(params: {
             );
           }
 
-          const pdfs = params.pdfBuffers.map((p) => ({
-            base64: p.base64,
-            filename: p.filename,
-          }));
+          // Encode only native requests, once across retries, after checking cancellation.
+          params.signal?.throwIfAborted();
+          const pdfs = (nativePdfs ??= params.pdfBuffers.map(({ buffer, filename }) => ({
+            base64: buffer.toString("base64"),
+            filename,
+          })));
 
           if (provider === "anthropic") {
-            // A run cancelled mid-dispatch must not buy another provider call.
-            params.signal?.throwIfAborted();
             const text = await anthropicAnalyzePdf({
               apiKey,
               modelId,
@@ -282,8 +283,6 @@ async function runPdfPrompt(params: {
           }
 
           if (provider === "google") {
-            // A run cancelled mid-dispatch must not buy another provider call.
-            params.signal?.throwIfAborted();
             const text = await geminiAnalyzePdf({
               apiKey,
               modelId,
@@ -490,7 +489,6 @@ export function createPdfTool(options?: {
 
       // MARK: - Load each PDF
       const loadedPdfs: Array<{
-        base64: string;
         buffer: Buffer;
         filename: string;
         resolvedPath: string;
@@ -569,7 +567,6 @@ export function createPdfTool(options?: {
           }
         }
 
-        const base64 = media.buffer.toString("base64");
         const filename =
           media.fileName ??
           (isHttpUrl
@@ -577,7 +574,6 @@ export function createPdfTool(options?: {
             : "document.pdf");
 
         loadedPdfs.push({
-          base64,
           buffer: media.buffer,
           filename,
           resolvedPath,
@@ -619,7 +615,7 @@ export function createPdfTool(options?: {
         pdfModelConfig,
         modelOverride,
         prompt: promptRaw,
-        pdfBuffers: loadedPdfs.map((p) => ({ base64: p.base64, filename: p.filename })),
+        pdfBuffers: loadedPdfs,
         ...(password ? { password } : {}),
         pageNumbers,
         getExtractions,


### PR DESCRIPTION
## What Problem This Solves

PDF analysis eagerly base64-encodes every input even when the selected provider uses text/image extraction. The extraction plugin also copies the complete PDF before opening it and copies each rendered image before encoding it.

## Why This Change Was Made

Keep the owned input Buffer through extraction, and lazily build the native-provider base64 payload only when a native PDF provider is actually tried. Reuse that payload across native-provider fallbacks. Pass PDF bytes directly to the extraction engine and encode rendered images through views that preserve their byte offset and length.

The PDF tool owns provider routing and cancellation; the extraction plugin owns the engine input and rendered-image projection. The engine accepts Uint8Array input and copies it into its own WASM memory. Buffer is a valid input with the same byte boundaries. The old eager encoding and two redundant copy paths are removed.

## User Impact

Extraction-only PDF analysis avoids allocating a base64 string for the original document and avoids duplicate PDF/image buffers. Native-provider payloads, fallback order, cancellation and extracted text/images keep their existing behavior. Production +13/-20 (net -7); tests +4/-2 (net +2). No dependency, configuration or protocol changes.

## Evidence

- A rebuilt isolated Gateway using a real OpenAI API key read an 8,543,043-byte synthetic PDF and returned its exact printed text, `Slice parity`, through CodeMode. It used one PDF call, with zero tool failures. Process-local instrumentation counted zero base64 encodings of the original PDF, compared with one on the successful baseline extraction path.
- Actual extraction-plugin before/after probes used a PDF view with a nonzero byte offset. Both returned identical text and the same 26,605-byte PNG/hash. Invalid-PDF behavior also matched. The password option on the unencrypted fixture matched; this probe does not claim coverage of a real encrypted document.
- The existing extractor fixture now verifies nonzero-offset PDF and image views, including the exact bytes passed to the engine. Native provider, runtime-abort and extraction tests all pass: 52 focused cases.
- Full build and the complete required changed-check plan pass. Independent source/dependency review and fresh Codex autoreview found no accepted findings in the selected scope and priority.

The live turn establishes correctness and removal of the measured allocation; provider response time and whole-Gateway RSS are not claimed as stable before/after improvements.
