### PR TITLE
fix(ui): keep late dictation transcript after Stop

### DIFF
--- a/ui/src/e2e/browser-dictation-status.e2e.test.ts
+++ b/ui/src/e2e/browser-dictation-status.e2e.test.ts
@@ -79,6 +79,80 @@ suite.define(() => {
     });
   });
 
+  it.each([
+    { name: "captured selection", editedDraft: null, expected: "ship please now it" },
+    {
+      name: "live draft edits",
+      editedDraft: "ship it today",
+      expected: "ship it today please now",
+    },
+  ])("keeps every matching final after Stop with $name", async ({ editedDraft, expected }) => {
+    await suite.withPage({ permissions: ["microphone"] }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["talk.session.create", "talk.session.close"],
+        methodResponses: {
+          "talk.catalog": {
+            transcription: { ready: true, providers: [] },
+            realtime: { providers: [] },
+            speech: { providers: [] },
+            modes: [],
+            transports: [],
+            brains: [],
+          },
+          "talk.session.create": {
+            sessionId: "dictation-late-final-proof",
+            transcriptionSessionId: "dictation-late-final-proof",
+            audio: { inputEncoding: "g711_ulaw", inputSampleRateHz: 8000 },
+          },
+        },
+      });
+      await installTalkBrowserFixtures(page);
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const textarea = page.locator(".agent-chat__composer-combobox textarea");
+      await textarea.fill("ship it");
+      await textarea.evaluate((element: HTMLTextAreaElement) => element.setSelectionRange(5, 5));
+
+      await page.getByRole("button", { name: "Start voice input" }).hover();
+      await page.mouse.down();
+      await gateway.waitForRequest("talk.session.create");
+      await gateway.resolveDeferred("talk.session.create");
+      await page.mouse.up();
+      await page.getByRole("button", { name: "Stop and keep text" }).click();
+      await gateway.waitForRequest("talk.session.close");
+      if (editedDraft) {
+        await textarea.fill(editedDraft);
+      }
+
+      await gateway.emitGatewayEvent("talk.event", {
+        transcriptionSessionId: "stale-dictation",
+        type: "transcript",
+        text: "ignore this",
+        final: true,
+      });
+      await gateway.emitGatewayEvent("talk.event", {
+        transcriptionSessionId: "dictation-late-final-proof",
+        type: "transcript",
+        text: "please",
+        final: true,
+      });
+      await gateway.emitGatewayEvent("talk.event", {
+        transcriptionSessionId: "dictation-late-final-proof",
+        type: "transcript",
+        text: "now",
+        final: true,
+      });
+      await gateway.emitGatewayEvent("talk.event", {
+        transcriptionSessionId: "dictation-late-final-proof",
+        type: "close",
+        reason: "completed",
+      });
+      await captureComposerProof(suite, page, "dictation-late-finals.png");
+
+      await expect.poll(() => textarea.inputValue()).toBe(expected);
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+    });
+  });
+
   it.each([false, true])(
     "cancels new-session dictation after dismissing any tooltip (open: %s)",
     async (tooltipOpen) => {
@@ -187,6 +261,58 @@ suite.define(() => {
       });
     },
   );
+
+  it("preserves new-session edits before late finals commit", async () => {
+    await suite.withPage({ permissions: ["microphone"] }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["talk.session.create", "talk.session.close"],
+        featureMethods: ["chat.metadata", "chat.startup", "sessions.create", "sessions.dispatch"],
+        methodResponses: {
+          "talk.catalog": {
+            transcription: { ready: true, providers: [] },
+            realtime: { providers: [] },
+            speech: { providers: [] },
+            modes: [],
+            transports: [],
+            brains: [],
+          },
+          "talk.session.create": {
+            sessionId: "dictation-new-session-late-final",
+            transcriptionSessionId: "dictation-new-session-late-final",
+            audio: { inputEncoding: "g711_ulaw", inputSampleRateHz: 8000 },
+          },
+        },
+      });
+      await installTalkBrowserFixtures(page);
+      await page.goto(`${suite.server.baseUrl}new`);
+      const textarea = page.locator(".new-session-page__message");
+      await textarea.fill("keep draft");
+      await page.getByRole("button", { name: "Dictate", exact: true }).click();
+      await gateway.waitForRequest("talk.session.create");
+      await gateway.resolveDeferred("talk.session.create");
+      await page.getByRole("button", { name: "Stop and keep text" }).click();
+      await gateway.waitForRequest("talk.session.close");
+      await textarea.fill("keep draft today");
+
+      for (const text of ["spoken", "task"]) {
+        await gateway.emitGatewayEvent("talk.event", {
+          transcriptionSessionId: "dictation-new-session-late-final",
+          type: "transcript",
+          text,
+          final: true,
+        });
+      }
+      await gateway.emitGatewayEvent("talk.event", {
+        transcriptionSessionId: "dictation-new-session-late-final",
+        type: "close",
+        reason: "completed",
+      });
+
+      await expect.poll(() => textarea.inputValue()).toBe("keep draft today spoken task");
+      expect(await gateway.getRequests("sessions.create")).toHaveLength(0);
+      await captureComposerProof(suite, page, "dictation-new-session-late-finals.png");
+    });
+  });
 
   it("keeps the hold-to-dictate switch interactive without closing the microphone picker", async () => {
     await suite.withPage({ permissions: ["microphone"] }, async ({ page }) => {

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -492,13 +492,20 @@ export function renderChatComposer(props: ChatComposerProps) {
     enabled: props.composerHoldToRecord !== false,
     dictationAvailable: devicePicker.dictationStatus === "ready",
     realtimeTalkActive: props.realtimeTalkActive === true,
-    onCommit: (transcript: string) => {
+    onCommit: (transcript: string, late?: true) => {
       const target = state.composerTextarea;
-      const selection = state.dictationSelection ?? {
-        start: target?.selectionStart ?? visibleDraft.length,
-        end: target?.selectionEnd ?? visibleDraft.length,
-        value: props.getDraft?.() ?? props.draft,
-      };
+      const captured = state.dictationSelection;
+      const liveValue = target?.value ?? props.getDraft?.() ?? props.draft;
+      // Stop unlocks the draft. Preserve later edits by using the live caret only
+      // when a delayed final finds that the captured draft has changed.
+      const selection =
+        captured && (!late || captured.value === liveValue)
+          ? captured
+          : {
+              start: target?.selectionStart ?? liveValue.length,
+              end: target?.selectionEnd ?? liveValue.length,
+              value: liveValue,
+            };
       const insertion = insertComposerDictation(
         selection.value,
         transcript,

--- a/ui/src/pages/chat/composer-dictation.test.ts
+++ b/ui/src/pages/chat/composer-dictation.test.ts
@@ -265,7 +265,7 @@ describe("ComposerDictationController", () => {
     }
   });
 
-  it("commits and unlocks immediately while remote close finishes in background", async () => {
+  it("unlocks immediately and rejects a pending result after a new session starts", async () => {
     let resolveClose: () => void = () => {};
     const close = new Promise<void>((resolve) => {
       resolveClose = resolve;
@@ -287,15 +287,15 @@ describe("ComposerDictationController", () => {
     });
     const { controller, onCommit, target } = createHarness();
     await startHold(target);
-    emit({ transcriptionSessionId: "dictation-1", type: "partial", text: "keep this now" });
 
     const committed = controller.finishActive();
 
     expect(controller.active).toBe(false);
     expect(controller.locksComposer).toBe(false);
-    expect(onCommit).toHaveBeenCalledWith("keep this now");
-    await expect(committed).resolves.toBe(true);
-    expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" });
+    expect(onCommit).not.toHaveBeenCalled();
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
+    );
     try {
       expect(controller.startDirect()).toBe(true);
       await waitForFast(() => expect(sessionsCreated).toBe(2));
@@ -310,7 +310,9 @@ describe("ComposerDictationController", () => {
         final: true,
       });
       expect(controller.transcript).toBe("new preview");
-      expect(onCommit).toHaveBeenCalledExactlyOnceWith("keep this now");
+      resolveClose();
+      await expect(committed).resolves.toBe(false);
+      expect(onCommit).not.toHaveBeenCalled();
     } finally {
       resolveClose();
       controller.dispose();
@@ -559,6 +561,10 @@ describe("ComposerDictationController", () => {
     const withoutTranscript = createHarness();
     await startHold(withoutTranscript.target);
     const empty = withoutTranscript.controller.finishActive();
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
     await expect(empty).resolves.toBe(false);
     withoutTranscript.controller.dispose();
   });
@@ -625,6 +631,43 @@ describe("ComposerDictationController", () => {
       order.indexOf("talk.session.close"),
     );
     expect(onCommit).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
+  it("bounds Stop while transcription session creation remains pending", async () => {
+    let resolveCreate: (result: {
+      sessionId: string;
+      transcriptionSessionId: string;
+      audio: { inputEncoding: string; inputSampleRateHz: number };
+    }) => void = () => undefined;
+    const createResult = new Promise<{
+      sessionId: string;
+      transcriptionSessionId: string;
+      audio: { inputEncoding: string; inputSampleRateHz: number };
+    }>((resolve) => {
+      resolveCreate = resolve;
+    });
+    request = vi.fn(async (method: string) =>
+      method === "talk.session.create" ? createResult : { ok: true },
+    );
+    const { controller, target } = createHarness();
+    await startHold(target);
+
+    const finished = controller.finishActive();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(finished).resolves.toBe(false);
+    expect(controller.locksComposer).toBe(false);
+    expect(request).not.toHaveBeenCalledWith("talk.session.close", expect.anything());
+
+    resolveCreate({
+      sessionId: "late-session",
+      transcriptionSessionId: "late-session",
+      audio: { inputEncoding: "g711_ulaw", inputSampleRateHz: 8000 },
+    });
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "late-session" }),
+    );
     controller.dispose();
   });
 

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -16,6 +16,7 @@ import { RealtimeTalkLevelSignal } from "./realtime-talk-level.ts";
 
 const HOLD_ARM_DELAY_MS = 150,
   HOLD_PROGRESS_MS = 350;
+const FINAL_TRANSCRIPT_MAX_WAIT_MS = 10_000;
 const DICTATION_ENCODING = "g711_ulaw";
 const DICTATION_SAMPLE_RATE_HZ = 8000;
 const MAX_PENDING_AUDIO_SAMPLES = DICTATION_SAMPLE_RATE_HZ * 10;
@@ -61,7 +62,7 @@ type ComposerDictationControllerOptions = {
   enabled: boolean;
   dictationAvailable?: boolean;
   realtimeTalkActive: boolean;
-  onCommit: (text: string) => void;
+  onCommit: (text: string, late?: true) => void;
   onError: (message: string, failure: ComposerDictationFailure) => void;
   onStateChange: () => void;
   onTap?: () => void;
@@ -128,6 +129,8 @@ class ComposerDictationSession {
   private stopped = false;
   private discarded = false;
   private failed = false;
+  private gatewayDisconnected = false;
+  private settleLateFinalDrain: ((discard: boolean) => void) | null = null;
 
   constructor(
     private readonly client: GatewayBrowserClient,
@@ -189,10 +192,27 @@ class ComposerDictationSession {
     return this.transcriptIncludingPartial();
   }
 
-  async finish(): Promise<void> {
+  async finish(drainFinalTranscript = false): Promise<string> {
+    const lateFinal =
+      drainFinalTranscript && !this.gatewayDisconnected ? this.waitForLateFinal() : null;
+    const cleanup = this.stopAndClose(true);
+    if (lateFinal) {
+      // The bounded final result must not inherit stalled create, append, or close RPCs.
+      void cleanup.catch(() => undefined);
+      return lateFinal;
+    }
+    return cleanup.then(() => this.transcriptIncludingPartial());
+  }
+
+  async cancel(): Promise<void> {
+    this.discarded = true;
+    await this.stopAndClose(false);
+  }
+
+  private async stopAndClose(reportStartFailure: boolean): Promise<void> {
     await this.stopCapture();
     await this.startPromise?.catch((error: unknown) => {
-      if (!isAbortError(error)) {
+      if (reportStartFailure && !isAbortError(error)) {
         this.reportFailure(messageFromError(error));
       }
     });
@@ -200,16 +220,14 @@ class ComposerDictationSession {
     await this.closeRemote();
   }
 
-  async cancel(): Promise<void> {
-    this.discarded = true;
-    await this.stopCapture();
-    await this.startPromise?.catch(() => undefined);
-    await this.appendChain;
-    await this.closeRemote();
+  markGatewayDisconnected(): boolean {
+    this.gatewayDisconnected = true;
+    this.settleLateFinalDrain?.(false);
+    return this.hasTranscript();
   }
 
-  markGatewayDisconnected(): boolean {
-    return this.hasTranscript();
+  cancelPendingFinal(): void {
+    this.settleLateFinalDrain?.(true);
   }
 
   private appendAudio(samples: Float32Array): void {
@@ -261,11 +279,6 @@ class ComposerDictationSession {
     ) {
       return;
     }
-    if (payload.type === "partial" && typeof payload.text === "string") {
-      this.currentPartial = payload.text.trim();
-      this.callbacks.onTranscriptChange();
-      return;
-    }
     if (payload.type === "transcript" && typeof payload.text === "string") {
       const text = payload.text.trim();
       if (payload.final !== true) {
@@ -277,6 +290,11 @@ class ComposerDictationSession {
         this.finalTranscripts.push(text);
         this.currentPartial = "";
       }
+      this.callbacks.onTranscriptChange();
+      return;
+    }
+    if (payload.type === "partial" && typeof payload.text === "string") {
+      this.currentPartial = payload.text.trim();
       this.callbacks.onTranscriptChange();
       return;
     }
@@ -317,7 +335,6 @@ class ComposerDictationSession {
     this.stopped = true;
     this.input.stop();
     this.inputPump.stop();
-    // Retire UI events immediately; queued audio may still drain into remote close.
     this.unsubscribe?.();
     this.unsubscribe = null;
     this.inputMeter?.stop();
@@ -336,6 +353,38 @@ class ComposerDictationSession {
       .catch(() => undefined);
     return this.closePromise;
   }
+
+  private waitForLateFinal(): Promise<string> {
+    return new Promise((resolve) => {
+      const transcripts: string[] = [];
+      let unsubscribe = () => {};
+      const finish = (text: string) => {
+        globalThis.clearTimeout(timer);
+        unsubscribe();
+        this.settleLateFinalDrain = null;
+        resolve(text);
+      };
+      const transcript = () => transcripts.join(" ").trim();
+      const timer = globalThis.setTimeout(() => finish(transcript()), FINAL_TRANSCRIPT_MAX_WAIT_MS);
+      unsubscribe = this.client.addEventListener((frame) => {
+        const payload = eventPayload(frame);
+        if (!payload || payload.transcriptionSessionId !== this.transcriptionSessionId) {
+          return;
+        }
+        if (
+          payload.type === "transcript" &&
+          payload.final === true &&
+          typeof payload.text === "string" &&
+          payload.text.trim()
+        ) {
+          transcripts.push(payload.text.trim());
+        } else if (payload.type === "error" || payload.type === "close") {
+          finish(transcript());
+        }
+      });
+      this.settleLateFinalDrain = (discard) => finish(discard ? "" : transcript());
+    });
+  }
 }
 
 export class ComposerDictationController {
@@ -350,6 +399,7 @@ export class ComposerDictationController {
   private suppressClick = false;
   private suppressedPointerId: number | null = null;
   private suppressClickTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private pendingCommitSession: ComposerDictationSession | null = null;
   private disposed = false;
 
   constructor(options: ComposerDictationControllerOptions) {
@@ -399,6 +449,9 @@ export class ComposerDictationController {
 
   update(options: ComposerDictationControllerOptions): void {
     this.options = options;
+    if (!options.connected) {
+      this.pendingCommitSession?.markGatewayDisconnected();
+    }
     if (this.phase === "stopping") {
       return;
     }
@@ -471,6 +524,7 @@ export class ComposerDictationController {
 
   dispose(): void {
     this.disposed = true;
+    this.retirePendingCommit();
     this.clearClickSuppression();
     void this.stop({ commit: false });
   }
@@ -592,6 +646,7 @@ export class ComposerDictationController {
         }
       },
     });
+    this.retirePendingCommit();
     this.session = session;
     try {
       await session.start();
@@ -623,16 +678,46 @@ export class ComposerDictationController {
     if (committed) {
       this.options.onCommit(transcript);
     }
-    // UI ownership ends at the operator action. Provider close can be slow, but
-    // it must never retain the composer in a transient finalizing state.
-    const close = options.commit ? session.finish() : session.cancel();
-    void close.catch(() => undefined);
-    return Promise.resolve(committed);
+    if (!options.commit) {
+      void session.cancel().catch(() => undefined);
+      return Promise.resolve(false);
+    }
+    if (committed) {
+      void session.finish().catch(() => undefined);
+      return Promise.resolve(true);
+    }
+    // The composer unlocks immediately, while this exact stopped session keeps
+    // ownership of its bounded final accumulator until a new session supersedes it.
+    this.pendingCommitSession = session;
+    return session
+      .finish(true)
+      .then((lateTranscript) => {
+        const ownsPendingCommit = this.pendingCommitSession === session;
+        if (ownsPendingCommit) {
+          this.pendingCommitSession = null;
+        }
+        if (!ownsPendingCommit || !lateTranscript || !wasActive || this.disposed) {
+          return false;
+        }
+        this.options.onCommit(lateTranscript, true);
+        return true;
+      })
+      .catch(() => {
+        if (this.pendingCommitSession === session) {
+          this.pendingCommitSession = null;
+        }
+        return false;
+      });
   }
 
   private reset(): void {
     this.inputLevel.set(0);
     this.setPhase("idle");
+  }
+
+  private retirePendingCommit(): void {
+    this.pendingCommitSession?.cancelPendingFinal();
+    this.pendingCommitSession = null;
   }
 
   private clearPointerGesture(): void {

--- a/ui/src/pages/new-session/composer-dictation-control.ts
+++ b/ui/src/pages/new-session/composer-dictation-control.ts
@@ -76,13 +76,13 @@ export class NewSessionDictationControl {
       enabled,
       dictationAvailable: this.devicePicker.dictationStatus === "ready",
       realtimeTalkActive: false,
-      onCommit: (transcript: string) => {
+      onCommit: (transcript: string, late?: true) => {
         // Route changes replace draft ownership. Object identity keeps even an
         // A -> B -> A transition from accepting the prior route's snapshot.
         if (!ownsDraft() || !this.options.canCommit()) {
           return;
         }
-        const next = this.options.textarea.insertTranscript(transcript);
+        const next = this.options.textarea.insertTranscript(transcript, late);
         if (next !== null) {
           this.options.onMessage(next);
         }

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -914,6 +914,18 @@ describe("new-session composer dictation insertion", () => {
     expect(textarea.value).toBe("ship please it");
   });
 
+  it("preserves edits made after Stop before inserting a late transcript", () => {
+    const { composer, textareaController } = renderComposer({ message: "ship it" });
+    const textarea = draftTextarea(composer, "ship it", 4);
+    textareaController.captureSelection();
+    textarea.value = "ship it today";
+    textarea.selectionStart = 4;
+    textarea.selectionEnd = 4;
+
+    expect(textareaController.insertTranscript("please", true)).toBe("ship please it today");
+    expect(textarea.value).toBe("ship please it today");
+  });
+
   it("replaces the range the writer had highlighted", () => {
     const { composer, textareaController } = renderComposer({ message: "ship the thing" });
     draftTextarea(composer, "ship the thing", 5, 14);

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -282,16 +282,21 @@ export class NewSessionComposerTextareaController {
    * Writing the final insertion directly grows the box before the next render
    * commits that same value into the page-owned draft.
    */
-  insertTranscript(transcript: string): string | null {
+  insertTranscript(transcript: string, late?: true): string | null {
     const target = this.textarea;
     if (!target) {
       return null;
     }
-    const selection = this.capturedSelection ?? {
-      start: target.value.length,
-      end: target.value.length,
-      value: target.value,
-    };
+    const captured = this.capturedSelection;
+    // Delayed finals must not replace edits made after Stop unlocked this draft.
+    const selection =
+      captured && (!late || captured.value === target.value)
+        ? captured
+        : {
+            start: late ? target.selectionStart : target.value.length,
+            end: late ? target.selectionEnd : target.value.length,
+            value: target.value,
+          };
     this.capturedSelection = null;
     const insertion = insertComposerDictation(
       selection.value,


### PR DESCRIPTION
Closes #135026

## What Problem This Solves

Fixes an issue where Control UI users could lose a complete dictated utterance when they pressed **Stop and keep text** before the first transcript preview appeared.

## Why This Change Was Made

The dictation session now keeps one bounded, exact-session accumulator for an empty Stop snapshot. Matching late finals commit together without waiting for session creation, queued audio, or the close request, while ordered remote cleanup continues in the background. If the user edits after Stop, both chat composers insert at the live caret instead of restoring the old captured draft.

## User Impact

Dictation text that arrives just after Stop is inserted once at the captured composer selection. Multiple final segments stay complete, the action does not send the message, and stale session events remain ignored.

## Evidence

- Baseline `9e5be704596c5c4fd38c83253cdebef0498597fc`: the Chromium regression failed with `ship it` instead of `ship please it` in [Testbox run 33495067726](https://github.com/openclaw/openclaw/actions/runs/33495067726).
- Exact head `98c7bd405c16b86353bbba6eccebd08525ff5d72`: the three corrected browser scenarios passed in [Testbox run 33503165348](https://github.com/openclaw/openclaw/actions/runs/33503165348); the prior lifecycle head passed all 11 browser cases in [Testbox run 33501391556](https://github.com/openclaw/openclaw/actions/runs/33501391556).
- Focused owner and sibling tests: 161 passed across dictation, both composer owners, new-session ownership, and composer actions; the deferred-create deadline regression passes with fake timers.
- Max-lines, assertion-safety, formatting, Oxlint, and `git diff --check` passed.
- P0 Autoreview reported `patch is correct` with no actionable finding.
- Testbox created before and after composer screenshots, but its one-shot workflow did not upload them.

Production LOC: +133/-36 (net +97). The growth owns the bounded exact-session accumulator, background ordered cleanup, pending-session authority, and live-draft insertion rules shared by both composers. Tests: +187/-6 (net +181).

Provenance: commit `7a19a0d96242f63661a0e8809d32b375c0809cbe` removed the prior final-drain wait while unlocking the composer; raw parent `bbfeb32ad02bdf5305f71a90d519fd575e524df1` confirms the behavior change. PR metadata is unavailable for that commit.
