### PR TITLE
refactor(deps): centralize dependency spec policy

### DIFF
--- a/scripts/check-dependency-pins.mts
+++ b/scripts/check-dependency-pins.mts
@@ -7,15 +7,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { asRecord } from "@openclaw/normalization-core/record-coerce";
 import YAML from "yaml";
+import { classifyDependencySpec } from "./lib/dependency-spec-policy.mts";
 
 const PACKAGE_DEPENDENCY_SECTIONS = ["dependencies", "devDependencies", "optionalDependencies"];
 const WORKSPACE_DEPENDENCY_SECTIONS = ["overrides"];
-const EXACT_SEMVER_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
-const EXACT_NPM_ALIAS_PATTERN =
-  /^npm:(?:@[^/\s]+\/)?[^@\s]+@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
-const PINNED_GIT_PATTERN = /(?:#|\/commit\/)[0-9a-f]{40}$/iu;
-const PINNED_GITHUB_TARBALL_PATTERN =
-  /^https:\/\/codeload\.github\.com\/[^/\s]+\/[^/\s]+\/tar\.gz\/[0-9a-f]{40}$/iu;
 const DEFAULT_GIT_TIMEOUT_MS = 60_000;
 
 type DependencyPinViolation = {
@@ -68,25 +63,6 @@ function readTrackedJson(
   return asRecord(JSON.parse(runGit(cwd, ["show", `:${relativePath}`], timeoutMs)) as unknown);
 }
 
-function isAllowedPinnedSpec(spec: unknown): boolean {
-  if (typeof spec !== "string") {
-    return false;
-  }
-  if (EXACT_SEMVER_PATTERN.test(spec) || EXACT_NPM_ALIAS_PATTERN.test(spec)) {
-    return true;
-  }
-  if (spec === "workspace:*" || spec.startsWith("file:") || spec.startsWith("link:")) {
-    return true;
-  }
-  if (/^(?:git\+|github:|gitlab:|bitbucket:)/u.test(spec)) {
-    return PINNED_GIT_PATTERN.test(spec);
-  }
-  if (PINNED_GITHUB_TARBALL_PATTERN.test(spec)) {
-    return true;
-  }
-  return false;
-}
-
 function collectPackageJsonViolations(
   cwd: string,
   timeoutMs = DEFAULT_GIT_TIMEOUT_MS,
@@ -96,7 +72,7 @@ function collectPackageJsonViolations(
     const packageJson = readTrackedJson(cwd, relativePath, timeoutMs);
     for (const section of PACKAGE_DEPENDENCY_SECTIONS) {
       for (const [name, spec] of Object.entries(asRecord(packageJson[section]))) {
-        if (!isAllowedPinnedSpec(spec)) {
+        if (!classifyDependencySpec(spec).allowedPinned) {
           violations.push({ file: relativePath, section, name, spec });
         }
       }
@@ -115,7 +91,7 @@ function collectDependencyMapViolations(
     if (section === "overrides" && spec === "-") {
       continue;
     }
-    if (!isAllowedPinnedSpec(spec)) {
+    if (!classifyDependencySpec(spec).allowedPinned) {
       violations.push({ file, section, name, spec });
     }
   }

--- a/scripts/lib/dependency-spec-policy.mts
+++ b/scripts/lib/dependency-spec-policy.mts
@@ -1,0 +1,34 @@
+import { valid as validSemver } from "semver";
+
+const NPM_ALIAS_PATTERN = /^npm:(?:@[^/@\s]+\/[^/@\s]+|[^/@\s]+)@(.+)$/u;
+const PINNED_GIT_PATTERN =
+  /^(?:git\+|github:|gitlab:|bitbucket:)[^#\s]+#[0-9a-f]{40}(?:&path:[^&\s]+)?$/iu;
+const PINNED_GITHUB_TARBALL_PATTERN =
+  /^https:\/\/codeload\.github\.com\/[^/\s]+\/[^/\s]+\/tar\.gz\/[0-9a-f]{40}$/iu;
+const EXOTIC_SPEC_PATTERN = /^(?:git\+|git:|github:|gitlab:|bitbucket:|https?:|ssh:)/iu;
+const SCP_GIT_PATTERN = /^[^@:/\s]+@[^/:\s]+:[^\s]+$/u;
+
+function isExactRegistryVersion(spec: string): boolean {
+  return /^\d/u.test(spec) && spec === spec.trim() && validSemver(spec) !== null;
+}
+
+export function classifyDependencySpec(
+  spec: unknown,
+): Readonly<{ allowedPinned: boolean; exotic: boolean }> {
+  if (typeof spec !== "string") {
+    return { allowedPinned: false, exotic: false };
+  }
+  const aliasVersion = NPM_ALIAS_PATTERN.exec(spec)?.[1];
+  const pinnedGit = PINNED_GIT_PATTERN.test(spec);
+  const pinnedTarball = PINNED_GITHUB_TARBALL_PATTERN.test(spec);
+  return {
+    allowedPinned:
+      isExactRegistryVersion(spec) ||
+      (aliasVersion !== undefined && isExactRegistryVersion(aliasVersion)) ||
+      spec === "workspace:*" ||
+      ((spec.startsWith("file:") || spec.startsWith("link:")) && /\S/u.test(spec.slice(5))) ||
+      pinnedGit ||
+      pinnedTarball,
+    exotic: EXOTIC_SPEC_PATTERN.test(spec) || SCP_GIT_PATTERN.test(spec),
+  };
+}

--- a/scripts/transitive-manifest-risk-report.mts
+++ b/scripts/transitive-manifest-risk-report.mts
@@ -8,6 +8,7 @@ import process from "node:process";
 import { asRecord, isRecord } from "@openclaw/normalization-core/record-coerce";
 import YAML from "yaml";
 import { readBoundedResponseText } from "./lib/bounded-response.mjs";
+import { classifyDependencySpec } from "./lib/dependency-spec-policy.mts";
 import { escapeRegExp } from "./lib/regexp.mjs";
 import { parseReportCliArgs, writeReportArtifact } from "./lib/report-cli-helpers.mts";
 import {
@@ -16,13 +17,6 @@ import {
 } from "./pre-commit/pnpm-audit-prod.mjs";
 
 const INSTALL_LIFECYCLE_SCRIPTS = ["preinstall", "install", "postinstall", "prepare"];
-const EXACT_SEMVER_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
-const EXACT_NPM_ALIAS_PATTERN =
-  /^npm:(?:@[^/\s]+\/)?[^@\s]+@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
-const PINNED_GIT_PATTERN = /(?:#|\/commit\/)[0-9a-f]{40}$/iu;
-const PINNED_GITHUB_TARBALL_PATTERN =
-  /^https:\/\/codeload\.github\.com\/[^/\s]+\/[^/\s]+\/tar\.gz\/[0-9a-f]{40}$/iu;
-const EXOTIC_SPEC_PATTERN = /^(?:git\+|github:|gitlab:|bitbucket:|https?:)/iu;
 const RECENTLY_PUBLISHED_VERSION_TYPE = "recently-published-version";
 const NPM_PACKUMENT_ACCEPT_HEADER = "application/json";
 /** Maximum npm packument response size accepted by the risk scanner. */
@@ -47,25 +41,6 @@ type ManifestFindingsOptions = PackageVersion &
     minimumReleaseAgeMinutes: number | null;
     minimumReleaseAgeExclude?: string[];
   };
-
-function isAllowedPinnedSpec(spec: unknown) {
-  if (typeof spec !== "string") {
-    return false;
-  }
-  if (EXACT_SEMVER_PATTERN.test(spec) || EXACT_NPM_ALIAS_PATTERN.test(spec)) {
-    return true;
-  }
-  if (spec === "workspace:*" || spec.startsWith("file:") || spec.startsWith("link:")) {
-    return true;
-  }
-  if (/^(?:git\+|github:|gitlab:|bitbucket:)/u.test(spec)) {
-    return PINNED_GIT_PATTERN.test(spec);
-  }
-  if (PINNED_GITHUB_TARBALL_PATTERN.test(spec)) {
-    return true;
-  }
-  return false;
-}
 
 function encodePackageName(name: string) {
   return encodeURIComponent(name).replace(/^%40/u, "@");
@@ -189,7 +164,8 @@ function collectManifestFindings({
   for (const section of ["dependencies", "optionalDependencies"] as const) {
     const dependencies = asRecord(manifest[section]);
     for (const [dependencyName, spec] of Object.entries(dependencies)) {
-      if (!isAllowedPinnedSpec(spec)) {
+      const classification = classifyDependencySpec(spec);
+      if (!classification.allowedPinned) {
         findings.push({
           type: "floating-transitive-spec",
           packageName,
@@ -197,7 +173,7 @@ function collectManifestFindings({
           dependency: { name: dependencyName, spec, section },
         });
       }
-      if (typeof spec === "string" && EXOTIC_SPEC_PATTERN.test(spec)) {
+      if (classification.exotic && typeof spec === "string") {
         findings.push({
           type: "exotic-source",
           packageName,
@@ -305,7 +281,7 @@ export async function createTransitiveManifestRiskReport({
   const workspaceExcludedFindings: ManifestFinding[] = [];
   const metadataFailures: Array<PackageVersion & { error: string }> = [];
   for (const { packageName, version } of packageVersions) {
-    if (EXOTIC_SPEC_PATTERN.test(version)) {
+    if (classifyDependencySpec(version).exotic) {
       findings.push({
         type: "exotic-source",
         packageName,

--- a/test/scripts/check-dependency-pins.test.ts
+++ b/test/scripts/check-dependency-pins.test.ts
@@ -83,6 +83,8 @@ describe("check-dependency-pins", () => {
         linked: "link:../linked",
         local: "file:../local",
         gitPinned: "github:owner/repo#0123456789abcdef0123456789abcdef01234567",
+        gitPinnedPath:
+          "github:owner/repo#0123456789abcdef0123456789abcdef01234567&path:packages/pkg",
         tarballPinned:
           "https://codeload.github.com/owner/repo/tar.gz/0123456789abcdef0123456789abcdef01234567",
       },
@@ -124,7 +126,10 @@ packageExtensions:
         wildcard: "*",
         tag: "latest",
         broad: ">=1 <2",
+        malformedSemver: "01.2.3",
         gitFloating: "github:owner/repo#main",
+        fragmentlessGitPath:
+          "git+https://github.com/owner/repo/commit/0123456789abcdef0123456789abcdef01234567",
         invalidRemoval: "-",
       },
     });
@@ -162,8 +167,20 @@ packageExtensions:
       {
         file: "package.json",
         section: "dependencies",
+        name: "malformedSemver",
+        spec: "01.2.3",
+      },
+      {
+        file: "package.json",
+        section: "dependencies",
         name: "gitFloating",
         spec: "github:owner/repo#main",
+      },
+      {
+        file: "package.json",
+        section: "dependencies",
+        name: "fragmentlessGitPath",
+        spec: "git+https://github.com/owner/repo/commit/0123456789abcdef0123456789abcdef01234567",
       },
       { file: "package.json", section: "dependencies", name: "invalidRemoval", spec: "-" },
     ]);

--- a/test/scripts/dependency-spec-policy.test.ts
+++ b/test/scripts/dependency-spec-policy.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { classifyDependencySpec } from "../../scripts/lib/dependency-spec-policy.mts";
+
+describe("dependency spec policy", () => {
+  it.each([
+    ["exact registry version", "1.2.3", true, false],
+    ["prerelease registry version", "1.2.3-beta.1", true, false],
+    ["build registry version", "1.2.3+build.1", true, false],
+    ["leading-zero registry version", "01.2.3", false, false],
+    ["malformed prerelease", "1.2.3-a..b", false, false],
+    ["trimmed registry version", " 1.2.3", false, false],
+    ["v-prefixed registry version", "v1.2.3", false, false],
+    ["equals-prefixed registry version", "=1.2.3", false, false],
+    ["range", "^1.2.3", false, false],
+    ["tag", "latest", false, false],
+    ["exact unscoped alias", "npm:real-package@2.3.4", true, false],
+    ["exact scoped alias", "npm:@scope/real-package@2.3.4", true, false],
+    ["ranged alias", "npm:@scope/real-package@^2.3.4", false, false],
+    ["nested alias", "npm:alias@npm:real-package@2.3.4", false, false],
+    ["workspace package", "workspace:*", true, false],
+    ["ranged workspace package", "workspace:^", false, false],
+    ["file package", "file:../local", true, false],
+    ["linked package", "link:../linked", true, false],
+    ["empty file package", "file:", false, false],
+    ["empty linked package", "link:", false, false],
+    ["whitespace-only file package", "file: ", false, false],
+    ["whitespace-only linked package", "link:\t", false, false],
+    ["unsupported path package", "path:../local", false, false],
+    [
+      "SHA-pinned hosted Git package",
+      "github:owner/repo#0123456789abcdef0123456789abcdef01234567",
+      true,
+      true,
+    ],
+    [
+      "SHA-pinned Git package with empty path",
+      "github:owner/repo#0123456789abcdef0123456789abcdef01234567&path:",
+      false,
+      true,
+    ],
+    [
+      "SHA-pinned Git package with multiple paths",
+      "github:owner/repo#0123456789abcdef0123456789abcdef01234567&path:a&path:b",
+      false,
+      true,
+    ],
+    [
+      "SHA-pinned Git package with path",
+      "git+ssh://git@example.test/owner/repo.git#0123456789abcdef0123456789abcdef01234567&path:packages/pkg",
+      true,
+      true,
+    ],
+    ["branch Git package", "github:owner/repo#main", false, true],
+    ["short-SHA Git package", "gitlab:owner/repo#0123456", false, true],
+    [
+      "fragment-less Git commit path",
+      "git+https://github.com/owner/repo/commit/0123456789abcdef0123456789abcdef01234567",
+      false,
+      true,
+    ],
+    [
+      "branch plus false commit path",
+      "github:owner/repo#main&path:packages/commit/0123456789abcdef0123456789abcdef01234567",
+      false,
+      true,
+    ],
+    [
+      "SHA-pinned GitHub codeload package",
+      "https://codeload.github.com/owner/repo/tar.gz/0123456789abcdef0123456789abcdef01234567",
+      true,
+      true,
+    ],
+    [
+      "queried GitHub codeload package",
+      "https://codeload.github.com/owner/repo/tar.gz/0123456789abcdef0123456789abcdef01234567?x=1",
+      false,
+      true,
+    ],
+    ["remote archive", "https://example.test/package.tgz", false, true],
+    ["Git protocol", "git://example.test/owner/repo.git#main", false, true],
+    ["SSH Git package", "ssh://git@example.test/owner/repo.git#main", false, true],
+    ["scp-style Git package", "git@example.test:owner/repo.git#main", false, true],
+    ["unknown protocol", "custom:package", false, false],
+    ["empty spec", "", false, false],
+    ["non-string spec", 42, false, false],
+  ])("%s", (_name, spec, allowedPinned, exotic) => {
+    expect(classifyDependencySpec(spec)).toEqual({ allowedPinned, exotic });
+  });
+});

--- a/test/scripts/transitive-manifest-risk-report.test.ts
+++ b/test/scripts/transitive-manifest-risk-report.test.ts
@@ -53,6 +53,10 @@ describe("transitive-manifest-risk-report", () => {
               floating: "^1.2.3",
               exact: "2.0.0",
               gitdep: "github:owner/repo#main",
+              malformedSemver: "01.2.3",
+              fragmentlessGitPath:
+                "git+https://github.com/owner/repo/commit/0123456789abcdef0123456789abcdef01234567",
+              pinnedGit: "github:owner/repo#0123456789abcdef0123456789abcdef01234567",
             },
             optionalDependencies: {
               optionalFloating: "~3.0.0",
@@ -66,8 +70,8 @@ describe("transitive-manifest-risk-report", () => {
     });
 
     expect(report.byType).toEqual({
-      "exotic-source": 2,
-      "floating-transitive-spec": 3,
+      "exotic-source": 4,
+      "floating-transitive-spec": 5,
       "lifecycle-script": 1,
       "recently-published-version": 1,
     });


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-tooling problem where the direct dependency pin guard and transitive manifest report maintained separate dependency-spec classifiers. Both copies accepted malformed SemVer such as `01.2.3` and treated a Git URL ending in `/commit/<sha>` without a revision fragment as immutable.

## Why This Change Was Made

Adds one private dependency-spec policy returning the two facts its consumers need: whether a spec is allowed by the exact-pin policy and whether it is an exotic source. Registry versions use the existing `semver` parser with canonical-input checks; Git pins require an exact 40-character SHA fragment with at most one non-empty `path:` parameter. Consumer-specific exceptions remain local.

## User Impact

Dependency release checks now agree on one policy and reject malformed or moving specs that previously looked pinned. There are no runtime, config, SDK, protocol, lockfile, or dependency changes.

## Evidence

- Pre-fix reproduction: malformed SemVer plus fragment-less `/commit/<sha>` expected 2 violations and produced 0.
- Focused Vitest: 56 tests passed across unit-fast and tooling shards.
- `pnpm deps:pins:check`: 646 specs across 180 manifests, 0 violations.
- `pnpm tsgo:scripts`: passed.
- `pnpm tsgo:test:root`: passed.
- `node scripts/check-changed.mjs -- <six changed files>`: passed.
- Real registry smoke: 1,643 resolved manifests inspected; 2,518 report-only signals; 2 metadata failures; exit 0.
- Exact autoreview on the rebased head: scoped clean, no accepted/actionable findings.
- Production LOC: +42/-56 (net -14). Tests: +112/-2.
