### PR TITLE
fix: show concise OAuth errors in Control UI

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -29,7 +29,7 @@ import {
   resolveOpenAICallbackHost,
   resolveOpenAIRedirectUri,
 } from "./openai-chatgpt-oauth-authorization.runtime.js";
-import { loginOpenAICodex } from "./openai-chatgpt-oauth-flow.runtime.js";
+import { loginOpenAICodex, refreshOpenAICodexToken } from "./openai-chatgpt-oauth-flow.runtime.js";
 import {
   exchangeOpenAIAuthorizationCode,
   refreshOpenAIAccessToken,
@@ -123,6 +123,97 @@ afterEach(() => {
 });
 
 describe("OpenAI Codex OAuth flow", () => {
+  it("uses the provider message for failed token refreshes without exposing the response body", async () => {
+    const providerMessage =
+      "Your refresh token has already been used to generate a new access token. Please try signing in again.";
+    const responseBody = {
+      error: {
+        message: providerMessage,
+        type: "invalid_request_error",
+        code: "refresh_token_reused",
+        refresh_token: "must-not-leak",
+      },
+    };
+    mockTokenResponse(responseBody, 401);
+
+    await expect(refreshOpenAIAccessToken("old-refresh-token")).resolves.toEqual({
+      type: "failed",
+      operation: "refresh",
+      status: 401,
+      reason: "refresh_token_reused",
+      summary: providerMessage,
+      code: "refresh_token_reused",
+      errorType: "invalid_request_error",
+    });
+
+    mockTokenResponse(responseBody, 401);
+    const error = await refreshOpenAICodexToken("old-refresh-token").catch(
+      (caught: unknown) => caught,
+    );
+    expect(error).toMatchObject({
+      message: `${providerMessage}\n\nOpenAI Codex token refresh failed (HTTP 401; code=refresh_token_reused; type=invalid_request_error).`,
+      oauthRefreshFailure: {
+        errorType: "invalid_request_error",
+        reason: "refresh_token_reused",
+        status: 401,
+        summary: providerMessage,
+      },
+    });
+    expect(JSON.stringify(error)).not.toContain("must-not-leak");
+
+    mockTokenResponseText("refresh_token=must-not-leak", 401);
+    await expect(refreshOpenAIAccessToken("old-refresh-token")).resolves.toEqual({
+      type: "failed",
+      operation: "refresh",
+      status: 401,
+      summary: "OpenAI Codex token refresh failed (HTTP 401).",
+    });
+    mockTokenResponseText("refresh_token=must-not-leak", 401);
+    await expect(refreshOpenAICodexToken("old-refresh-token")).rejects.toMatchObject({
+      oauthRefreshFailure: {
+        status: 401,
+        summary: "OpenAI Codex token refresh failed (HTTP 401).",
+      },
+    });
+
+    mockTokenResponse({ error: { code: "refresh_token_reused" } }, 401);
+    await expect(refreshOpenAIAccessToken("old-refresh-token")).resolves.toEqual({
+      type: "failed",
+      operation: "refresh",
+      status: 401,
+      reason: "refresh_token_reused",
+      summary: "OpenAI Codex token refresh failed (HTTP 401).",
+      code: "refresh_token_reused",
+    });
+    mockTokenResponse({ error: { code: "refresh_token_reused" } }, 401);
+    await expect(refreshOpenAICodexToken("old-refresh-token")).rejects.toMatchObject({
+      oauthRefreshFailure: {
+        reason: "refresh_token_reused",
+        status: 401,
+        summary: "OpenAI Codex token refresh failed (HTTP 401).",
+      },
+    });
+
+    mockTokenResponse(
+      {
+        error: {
+          message: "Your refresh token is expired.",
+          type: "invalid_request_error",
+          code: "refresh_token_expired",
+        },
+      },
+      401,
+    );
+    await expect(refreshOpenAICodexToken("old-refresh-token")).rejects.toMatchObject({
+      oauthRefreshFailure: {
+        errorType: "invalid_request_error",
+        reason: "expired",
+        status: 401,
+        summary: "Your refresh token is expired.",
+      },
+    });
+  });
+
   it("cancels provider login before opening the OAuth flow", async () => {
     const controller = new AbortController();
     controller.abort();
@@ -282,7 +373,8 @@ describe("OpenAI Codex OAuth flow", () => {
     );
     expect(result).toMatchObject({
       type: "failed",
-      message: "OpenAI Codex token exchange timed out after 5ms",
+      operation: "exchange",
+      summary: "OpenAI Codex token exchange timed out after 5ms",
     });
   });
 
@@ -334,7 +426,9 @@ describe("OpenAI Codex OAuth flow", () => {
     expect(ssrfMocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       type: "failed",
-      message: "Login cancelled",
+      cancelled: true,
+      operation: "exchange",
+      summary: "Login cancelled",
     });
   });
 
@@ -352,7 +446,8 @@ describe("OpenAI Codex OAuth flow", () => {
 
     expect(result).toEqual({
       type: "failed",
-      message: "OpenAI Codex token exchange response missing fields: expires_in",
+      operation: "exchange",
+      summary: "OpenAI Codex token exchange response missing fields: expires_in",
     });
   });
 
@@ -375,7 +470,8 @@ describe("OpenAI Codex OAuth flow", () => {
 
       expect(result).toEqual({
         type: "failed",
-        message: `OpenAI Codex token ${operation} failed: response is not valid JSON`,
+        operation,
+        summary: `OpenAI Codex token ${operation} failed: response is not valid JSON`,
       });
     },
   );
@@ -393,7 +489,8 @@ describe("OpenAI Codex OAuth flow", () => {
     );
     expect(result).toMatchObject({
       type: "failed",
-      message: "OpenAI Codex token refresh timed out after 5ms",
+      operation: "refresh",
+      summary: "OpenAI Codex token refresh timed out after 5ms",
     });
   });
 
@@ -408,7 +505,8 @@ describe("OpenAI Codex OAuth flow", () => {
 
     expect(result).toEqual({
       type: "failed",
-      message: "OpenAI Codex token refresh response missing fields: expires_in",
+      operation: "refresh",
+      summary: "OpenAI Codex token refresh response missing fields: expires_in",
     });
   });
 
@@ -519,7 +617,8 @@ describe("OpenAI Codex OAuth bounded token response reads", () => {
 
         expect(result).toEqual({
           type: "failed",
-          message: `OpenAI Codex token ${operation} failed: expected JSON object response`,
+          operation,
+          summary: `OpenAI Codex token ${operation} failed: expected JSON object response`,
         });
         expect(release).toHaveBeenCalledOnce();
       } finally {
@@ -597,7 +696,7 @@ describe("OpenAI Codex OAuth bounded token response reads", () => {
       );
 
       expect(result).toMatchObject({ type: "failed" });
-      expect((result as { type: "failed"; message: string }).message).toContain("too large");
+      expect((result as { type: "failed"; summary: string }).summary).toContain("too large");
       expect(release).toHaveBeenCalledOnce();
     } finally {
       await closeServer(server);

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -170,7 +170,26 @@ function resolveOpenAICredentials(
   result: Awaited<ReturnType<typeof refreshOpenAIAccessToken>>,
 ): OAuthCredentials {
   if (result.type !== "success") {
-    throw new Error(result.message);
+    if (result.cancelled) {
+      throw createOAuthLoginCancelledError();
+    }
+    const facts = [
+      result.status ? `HTTP ${result.status}` : undefined,
+      result.code ? `code=${result.code}` : undefined,
+      result.errorType ? `type=${result.errorType}` : undefined,
+    ].filter((value): value is string => Boolean(value));
+    const diagnostic =
+      facts.length > 0
+        ? `OpenAI Codex token ${result.operation} failed (${facts.join("; ")}).`
+        : undefined;
+    throw Object.assign(new Error([result.summary, diagnostic].filter(Boolean).join("\n\n")), {
+      oauthRefreshFailure: {
+        summary: result.summary,
+        ...(result.errorType ? { errorType: result.errorType } : {}),
+        ...(result.reason ? { reason: result.reason } : {}),
+        ...(result.status ? { status: result.status } : {}),
+      },
+    });
   }
   const accountId = resolveOpenAICodexAuthIdentity({ access: result.access }).accountId;
   if (!accountId) {

--- a/extensions/openai/openai-chatgpt-oauth-token.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-token.runtime.ts
@@ -4,8 +4,14 @@ import {
   throwIfOAuthLoginAborted,
 } from "openclaw/plugin-sdk/provider-oauth-runtime";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
-import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  asOptionalRecord,
+  isRecord,
+  normalizeBoundedOptionalString,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const TOKEN_URL = "https://auth.openai.com/oauth/token";
@@ -16,9 +22,26 @@ const OAUTH_TOKEN_SSRF_POLICY = {
 } satisfies SsrFPolicy;
 const TOKEN_REQUEST_TIMEOUT_MS = 30_000;
 const OAUTH_TOKEN_RESPONSE_BODY_LIMIT_BYTES = 1 * 1024 * 1024;
+const OAUTH_TOKEN_ERROR_SUMMARY_MAX_CHARS = 500;
 
 type TokenSuccess = { type: "success"; access: string; refresh: string; expires: number };
-type TokenFailure = { type: "failed"; message: string; status?: number };
+type TokenFailureReason =
+  | "refresh_token_reused"
+  | "expired"
+  | "invalid_grant"
+  | "invalid_refresh_token"
+  | "token_invalidated"
+  | "revoked";
+type TokenFailure = {
+  type: "failed";
+  operation: "exchange" | "refresh";
+  summary: string;
+  cancelled?: true;
+  code?: string;
+  errorType?: string;
+  reason?: TokenFailureReason;
+  status?: number;
+};
 type TokenResult = TokenSuccess | TokenFailure;
 type TokenResponseJson = {
   access_token?: string;
@@ -29,6 +52,69 @@ type TokenRequestOptions = {
   signal?: AbortSignal;
   timeoutMs?: number;
 };
+
+const TOKEN_FAILURE_REASON_BY_CODE: Readonly<Record<string, TokenFailureReason>> = {
+  invalid_grant: "invalid_grant",
+  invalid_refresh_token: "invalid_refresh_token",
+  refresh_token_expired: "expired",
+  refresh_token_invalidated: "token_invalidated",
+  refresh_token_reused: "refresh_token_reused",
+};
+const TOKEN_FAILURE_CODES = new Set(Object.keys(TOKEN_FAILURE_REASON_BY_CODE));
+
+function normalizeTokenErrorSummary(value: unknown): string | undefined {
+  const normalized = normalizeBoundedOptionalString(value, OAUTH_TOKEN_ERROR_SUMMARY_MAX_CHARS * 4)
+    ?.replace(/\s+/gu, " ")
+    .trim();
+  return normalized
+    ? normalizeBoundedOptionalString(
+        redactSensitiveText(normalized, { mode: "tools" }),
+        OAUTH_TOKEN_ERROR_SUMMARY_MAX_CHARS,
+      )
+    : undefined;
+}
+
+function normalizeTokenErrorFact(
+  value: unknown,
+  allowlist: ReadonlySet<string>,
+): string | undefined {
+  const normalized = normalizeOptionalString(value)?.toLowerCase();
+  return normalized && allowlist.has(normalized) ? normalized : undefined;
+}
+
+function buildTokenResponseFailure(params: {
+  response: Response;
+  operation: "exchange" | "refresh";
+  text: string;
+}): TokenFailure {
+  let body: Record<string, unknown> | undefined;
+  try {
+    body = asOptionalRecord(JSON.parse(params.text));
+  } catch {
+    // Non-JSON responses use the bounded generic message below.
+  }
+  const error = asOptionalRecord(body?.error);
+  const code = normalizeTokenErrorFact(
+    error?.code ?? (typeof body?.error === "string" ? body.error : body?.code),
+    TOKEN_FAILURE_CODES,
+  );
+  const rawType = normalizeOptionalString(error?.type ?? body?.type)?.toLowerCase();
+  const errorType =
+    rawType === "invalid_grant" || rawType === "invalid_request_error" ? rawType : undefined;
+  const reason = code ? TOKEN_FAILURE_REASON_BY_CODE[code] : undefined;
+  const summary =
+    normalizeTokenErrorSummary(error?.message ?? body?.error_description ?? body?.message) ??
+    `OpenAI Codex token ${params.operation} failed (HTTP ${params.response.status}).`;
+  return {
+    type: "failed",
+    operation: params.operation,
+    summary,
+    status: params.response.status,
+    ...(code ? { code } : {}),
+    ...(errorType ? { errorType } : {}),
+    ...(reason ? { reason } : {}),
+  };
+}
 
 function formatMissingTokenResponseFields(
   json: TokenResponseJson,
@@ -59,7 +145,12 @@ function formatTokenRequestError(
   if (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) {
     return `OpenAI Codex token ${operation} timed out after ${timeoutMs}ms`;
   }
-  return `OpenAI Codex token ${operation} error: ${error instanceof Error ? error.message : String(error)}`;
+  const detail = normalizeTokenErrorSummary(error instanceof Error ? error.message : String(error));
+  return (
+    normalizeTokenErrorSummary(
+      `OpenAI Codex token ${operation} error${detail ? `: ${detail}` : ""}`,
+    ) ?? `OpenAI Codex token ${operation} error`
+  );
 }
 
 async function postTokenForm(
@@ -110,11 +201,7 @@ async function readOpenAITokenResponse(
 ): Promise<TokenResult> {
   if (!response.ok) {
     const text = await response.text().catch(() => "");
-    return {
-      type: "failed",
-      status: response.status,
-      message: `OpenAI Codex token ${operation} failed (${response.status}): ${text || response.statusText}`,
-    };
+    return buildTokenResponseFailure({ response, operation, text });
   }
   let json: TokenResponseJson;
   try {
@@ -122,13 +209,15 @@ async function readOpenAITokenResponse(
   } catch {
     return {
       type: "failed",
-      message: `OpenAI Codex token ${operation} failed: response is not valid JSON`,
+      operation,
+      summary: `OpenAI Codex token ${operation} failed: response is not valid JSON`,
     };
   }
   if (!isRecord(json)) {
     return {
       type: "failed",
-      message: `OpenAI Codex token ${operation} failed: expected JSON object response`,
+      operation,
+      summary: `OpenAI Codex token ${operation} failed: expected JSON object response`,
     };
   }
   const expires = resolveOAuthTokenExpiresAt(json.expires_in);
@@ -136,7 +225,8 @@ async function readOpenAITokenResponse(
   if (!json.access_token || !refreshToken || expires === undefined) {
     return {
       type: "failed",
-      message: `OpenAI Codex token ${operation} response missing fields: ${formatMissingTokenResponseFields(json, existingRefreshToken)}`,
+      operation,
+      summary: `OpenAI Codex token ${operation} response missing fields: ${formatMissingTokenResponseFields(json, existingRefreshToken)}`,
     };
   }
   return {
@@ -169,7 +259,9 @@ export async function exchangeOpenAIAuthorizationCode(
   } catch (error) {
     return {
       type: "failed",
-      message: formatTokenRequestError("exchange", error, timeoutMs, options.signal),
+      operation: "exchange",
+      ...(options.signal?.aborted ? { cancelled: true } : {}),
+      summary: formatTokenRequestError("exchange", error, timeoutMs, options.signal),
     };
   }
   return await readOpenAITokenResponse(response, "exchange");
@@ -193,7 +285,9 @@ export async function refreshOpenAIAccessToken(
   } catch (error) {
     return {
       type: "failed",
-      message: formatTokenRequestError("refresh", error, timeoutMs, options.signal),
+      operation: "refresh",
+      ...(options.signal?.aborted ? { cancelled: true } : {}),
+      summary: formatTokenRequestError("refresh", error, timeoutMs, options.signal),
     };
   }
 }

--- a/src/agents/auth-profiles/oauth-manager.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.test.ts
@@ -169,8 +169,18 @@ describe("OAuthManagerRefreshError", () => {
       }),
       profileId: "openai:oauth",
       refreshedStore,
-      cause: new Error(
-        "refresh rejected error-access error-refresh error-id-token store-access store-refresh store-id-token",
+      cause: Object.assign(
+        new Error(
+          "refresh rejected error-access error-refresh error-id-token store-access store-refresh store-id-token",
+        ),
+        {
+          oauthRefreshFailure: {
+            errorType: "invalid_request_error",
+            reason: "refresh_token_reused",
+            status: 401,
+            summary: "refresh rejected error-access",
+          },
+        },
       ),
     });
 
@@ -182,6 +192,10 @@ describe("OAuthManagerRefreshError", () => {
     expect(error.message).not.toContain("store-refresh");
     expect(error.message).not.toContain("store-id-token");
     expect(error.message.match(/\[redacted\]/g)?.length).toBe(6);
+    expect(error.reason).toBe("refresh_token_reused");
+    expect(error.status).toBe(401);
+    expect(error.errorType).toBe("invalid_request_error");
+    expect(error.summary).toBe("refresh rejected [redacted]");
     const surfacedCauseMessage = formatErrorMessage(error.cause);
     expect(surfacedCauseMessage).not.toContain("error-access");
     expect(surfacedCauseMessage).not.toContain("error-refresh");

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -17,7 +17,10 @@ import {
 } from "./constants.js";
 import { hasUsableOAuthCredential } from "./credential-state.js";
 import { shouldMirrorRefreshedOAuthCredential } from "./oauth-identity.js";
-import { OAuthRefreshFailureError } from "./oauth-refresh-failure.js";
+import {
+  OAuthRefreshFailureError,
+  readProviderOAuthRefreshFailure,
+} from "./oauth-refresh-failure.js";
 import {
   buildRefreshContentionError,
   isGlobalRefreshLockTimeoutError,
@@ -96,12 +99,19 @@ export class OAuthManagerRefreshError extends OAuthRefreshFailureError {
       ...(params.attemptedCredentials ?? []),
       storedCredential?.type === "oauth" ? storedCredential : undefined,
     );
+    const presentation = readProviderOAuthRefreshFailure(params.cause);
     const causeMessage = formatRedactedOAuthRefreshError(surfacedCause, secrets);
     super({
       provider: params.credential.provider,
       profileId: params.profileId,
       message: `OAuth token refresh failed for ${params.credential.provider}: ${causeMessage}`,
       cause: createRedactedOAuthRefreshCause(surfacedCause, secrets),
+      errorType: presentation?.errorType,
+      reason: presentation?.reason,
+      status: presentation?.status,
+      summary: presentation?.summary
+        ? formatRedactedOAuthRefreshError(presentation.summary, secrets)
+        : undefined,
     });
     this.name = "OAuthManagerRefreshError";
     this.#credential = params.credential;

--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -115,12 +115,19 @@ describe("oauth refresh failure hints", () => {
           provider: "openai",
           profileId: "openai:user@example.com",
           message: "invalid_grant",
+          errorType: "invalid_grant",
+          reason: "invalid_grant",
+          status: 401,
+          summary: "Please sign in again.",
         }),
       ),
     ).toEqual({
+      errorType: "invalid_grant",
       provider: "openai",
       profileId: "openai:user@example.com",
       reason: "invalid_grant",
+      status: 401,
+      summary: "Please sign in again.",
     });
   });
 
@@ -177,6 +184,27 @@ describe("oauth refresh failure hints", () => {
       profileId: "openai:work",
       reason: "token_invalidated",
     });
+  });
+
+  it("prefers a structured OAuth cause over legacy failover raw text", () => {
+    const summary = "Please sign in again.";
+    const cause = new OAuthRefreshFailureError({
+      provider: "openai",
+      message: "wrapped provider failure",
+      reason: "refresh_token_reused",
+      summary,
+    });
+
+    expect(
+      classifyOAuthRefreshFailureError(
+        new FailoverError("Authentication refresh failed", {
+          reason: "auth_permanent",
+          provider: "openai",
+          rawError: "OAuth token refresh failed for openai: refresh_token_reused",
+          cause,
+        }),
+      ),
+    ).toMatchObject({ provider: "openai", reason: "refresh_token_reused", summary });
   });
 
   it("classifies claude-cli subprocess 401 OAuth expiry as a provider refresh failure", () => {

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -1,5 +1,6 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeBoundedOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 /**
@@ -12,6 +13,7 @@ import type { AuthProfileFailureReason } from "./types.js";
 
 export type OAuthRefreshFailureReason =
   | "refresh_token_reused"
+  | "expired"
   | "invalid_grant"
   | "sign_in_again"
   | "invalid_refresh_token"
@@ -19,10 +21,60 @@ export type OAuthRefreshFailureReason =
   | "revoked";
 
 type OAuthRefreshFailure = {
+  errorType?: string;
   provider: string | null;
   profileId?: string;
   reason: OAuthRefreshFailureReason | null;
+  status?: number;
+  summary?: string;
 };
+
+export type OAuthRefreshFailurePresentation = {
+  errorType?: string;
+  reason?: OAuthRefreshFailureReason;
+  status?: number;
+  summary?: string;
+};
+
+const OAUTH_REFRESH_FAILURE_ERROR_TYPE_MAX_CHARS = 100;
+const OAUTH_REFRESH_FAILURE_SUMMARY_MAX_CHARS = 500;
+
+export function readProviderOAuthRefreshFailure(
+  error: unknown,
+): OAuthRefreshFailurePresentation | null {
+  const presentation = asOptionalRecord(asOptionalRecord(error)?.oauthRefreshFailure);
+  if (!presentation) {
+    return null;
+  }
+  const summary = normalizeBoundedOptionalString(
+    presentation.summary,
+    OAUTH_REFRESH_FAILURE_SUMMARY_MAX_CHARS,
+  );
+  const errorType = normalizeBoundedOptionalString(
+    presentation.errorType,
+    OAUTH_REFRESH_FAILURE_ERROR_TYPE_MAX_CHARS,
+  );
+  const reason =
+    typeof presentation.reason === "string"
+      ? classifyOAuthRefreshFailureReason(presentation.reason)
+      : null;
+  const status =
+    typeof presentation.status === "number" &&
+    Number.isInteger(presentation.status) &&
+    presentation.status >= 100 &&
+    presentation.status <= 599
+      ? presentation.status
+      : undefined;
+  if (!summary && !errorType && !reason && !status) {
+    return null;
+  }
+  return {
+    ...(errorType ? { errorType } : {}),
+    ...(reason ? { reason } : {}),
+    ...(status ? { status } : {}),
+    ...(summary ? { summary } : {}),
+  };
+}
 
 type StructuredClaudeCliAuthFailure = {
   provider?: unknown;
@@ -33,16 +85,44 @@ type StructuredClaudeCliAuthFailure = {
 
 /** Error type that carries provider and classified OAuth refresh failure reason. */
 export class OAuthRefreshFailureError extends Error {
+  readonly errorType?: string;
   readonly provider: string;
   readonly profileId?: string;
   readonly reason: OAuthRefreshFailureReason | null;
+  readonly status?: number;
+  readonly summary?: string;
 
-  constructor(params: { provider: string; profileId?: string; message: string; cause?: unknown }) {
+  constructor(params: {
+    provider: string;
+    profileId?: string;
+    message: string;
+    cause?: unknown;
+    errorType?: string;
+    reason?: OAuthRefreshFailureReason | null;
+    status?: number;
+    summary?: string;
+  }) {
     super(params.message, { cause: params.cause });
+    const inherited =
+      params.cause instanceof OAuthRefreshFailureError
+        ? params.cause
+        : readProviderOAuthRefreshFailure(params.cause);
     this.name = "OAuthRefreshFailureError";
+    this.errorType = normalizeBoundedOptionalString(
+      params.errorType ?? inherited?.errorType,
+      OAUTH_REFRESH_FAILURE_ERROR_TYPE_MAX_CHARS,
+    );
     this.provider = params.provider;
     this.profileId = params.profileId;
-    this.reason = classifyOAuthRefreshFailureReason(params.message);
+    this.reason =
+      params.reason !== undefined
+        ? params.reason
+        : (inherited?.reason ?? classifyOAuthRefreshFailureReason(params.message));
+    this.status = params.status ?? inherited?.status;
+    this.summary = normalizeBoundedOptionalString(
+      params.summary ?? inherited?.summary,
+      OAUTH_REFRESH_FAILURE_SUMMARY_MAX_CHARS,
+    );
   }
 }
 
@@ -148,6 +228,9 @@ export function classifyOAuthRefreshFailureReason(
   if (lower.includes("refresh_token_reused")) {
     return "refresh_token_reused";
   }
+  if (lower.includes("refresh_token_expired")) {
+    return "expired";
+  }
   if (lower.includes("invalid_grant")) {
     return "invalid_grant";
   }
@@ -155,13 +238,14 @@ export function classifyOAuthRefreshFailureReason(
     return "token_invalidated";
   }
   if (
+    lower.includes("sign_in_again") ||
     lower.includes("signing in again") ||
     lower.includes("sign in again") ||
     lower.includes("log in again")
   ) {
     return "sign_in_again";
   }
-  if (lower.includes("invalid refresh token")) {
+  if (lower.includes("invalid_refresh_token") || lower.includes("invalid refresh token")) {
     return "invalid_refresh_token";
   }
   if (lower.includes("expired or revoked") || lower.includes("revoked")) {
@@ -191,6 +275,7 @@ export function classifyOAuthRefreshFailure(message: string): OAuthRefreshFailur
 /** Classify provider/reason from the structured OAuth refresh failure error. */
 export function classifyOAuthRefreshFailureError(err: unknown): OAuthRefreshFailure | null {
   const seen = new Set<object>();
+  let rawFallback: OAuthRefreshFailure | null = null;
   let candidate = err;
   while (candidate && typeof candidate === "object") {
     const claudeCliReason = classifyStructuredClaudeCliOAuthFailureReason(candidate);
@@ -203,9 +288,12 @@ export function classifyOAuthRefreshFailureError(err: unknown): OAuthRefreshFail
     if (candidate instanceof OAuthRefreshFailureError) {
       const profileId = sanitizeOAuthRefreshFailureProfileId(candidate.profileId);
       return {
+        ...(candidate.errorType ? { errorType: candidate.errorType } : {}),
         provider: sanitizeOAuthRefreshFailureProvider(candidate.provider),
         ...(profileId ? { profileId } : {}),
         reason: candidate.reason,
+        ...(candidate.status ? { status: candidate.status } : {}),
+        ...(candidate.summary ? { summary: candidate.summary } : {}),
       };
     }
     const record = asOptionalRecord(candidate);
@@ -217,16 +305,16 @@ export function classifyOAuthRefreshFailureError(err: unknown): OAuthRefreshFail
         const profileId = sanitizeOAuthRefreshFailureProfileId(
           typeof rawProfileId === "string" ? rawProfileId : undefined,
         );
-        return { ...classified, ...(profileId ? { profileId } : {}) };
+        rawFallback ??= { ...classified, ...(profileId ? { profileId } : {}) };
       }
     }
     if (seen.has(candidate)) {
-      return null;
+      return rawFallback;
     }
     seen.add(candidate);
     candidate = (candidate as { cause?: unknown }).cause;
   }
-  return null;
+  return rawFallback;
 }
 
 /** Build the login command operators should run after OAuth refresh failure. */

--- a/src/auto-reply/reply/agent-lifecycle-terminal.test.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { OAuthRefreshFailureError } from "../../agents/auth-profiles/oauth-refresh-failure.js";
 import { FailoverError } from "../../agents/failover-error.js";
 import { renderFailoverCodeUserCopy } from "../../agents/failover/user-copy.js";
 import * as providerFailover from "../../plugins/provider-failover.js";
@@ -9,6 +10,40 @@ const { emitAgentEvent } = vi.hoisted(() => ({ emitAgentEvent: vi.fn() }));
 vi.mock("../../infra/agent-events.js", () => ({ emitAgentEvent }));
 
 describe("createAgentLifecycleTerminalBackstop", () => {
+  it("publishes the provider-owned OAuth summary instead of the wrapped diagnostic", () => {
+    emitAgentEvent.mockClear();
+    const summary =
+      "Your refresh token has already been used to generate a new access token. Please try signing in again.";
+    const rawDiagnostic = `OAuth token refresh failed for openai: {"error":{"message":"${summary}"}}`;
+    const oauthError = new OAuthRefreshFailureError({
+      provider: "openai",
+      message: rawDiagnostic,
+      errorType: "invalid_request_error",
+      reason: "refresh_token_reused",
+      status: 401,
+      summary,
+    });
+    const error = new Error("wrapped OAuth refresh failure", { cause: oauthError });
+    const terminal = createAgentLifecycleTerminalBackstop({
+      runId: "oauth-refresh-failure",
+      getLifecycleGeneration: () => "test-generation",
+      resolveTerminationFields: () => ({}),
+    });
+
+    terminal.emit("error", error);
+
+    const event = emitAgentEvent.mock.calls[0]?.[0];
+    expect(event.data.error).toBe(`⚠️ ${summary}`);
+    expect(event.data.errorObservation).toEqual({
+      provider: "openai",
+      failoverReason: "refresh_token_reused",
+      providerRuntimeFailureKind: "auth_refresh",
+      providerErrorType: "invalid_request_error",
+      httpStatus: 401,
+    });
+    expect(JSON.stringify(event)).not.toContain(rawDiagnostic);
+  });
+
   it.each(["typed", "raw"] as const)(
     "publishes bounded selected-profile recovery from %s failures without discovering providers",
     (kind) => {

--- a/src/auto-reply/reply/agent-lifecycle-terminal.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.ts
@@ -1,4 +1,5 @@
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
+import { classifyOAuthRefreshFailureError } from "../../agents/auth-profiles/oauth-refresh-failure.js";
 import { getFailoverErrorCode } from "../../agents/failover/error.js";
 import { renderFailoverCodeUserCopy } from "../../agents/failover/user-copy.js";
 import { AGENT_RUN_RESTART_ABORT_STOP_REASON } from "../../agents/run-termination.js";
@@ -102,9 +103,20 @@ export function createAgentLifecycleTerminalBackstop(params: {
       data.aborted = true;
       data.stopReason = AGENT_RUN_RESTART_ABORT_STOP_REASON;
     } else if (phase === "error") {
+      const oauthFailure = classifyOAuthRefreshFailureError(resultOrError);
       data.error =
         renderFailoverCodeUserCopy(getFailoverErrorCode(resultOrError)) ??
+        (oauthFailure?.summary ? `⚠️ ${oauthFailure.summary}` : undefined) ??
         formatErrorMessage(resultOrError);
+      if (oauthFailure?.summary) {
+        data.errorObservation = {
+          ...(oauthFailure.provider ? { provider: oauthFailure.provider } : {}),
+          ...(oauthFailure.reason ? { failoverReason: oauthFailure.reason } : {}),
+          providerRuntimeFailureKind: "auth_refresh",
+          ...(oauthFailure.errorType ? { providerErrorType: oauthFailure.errorType } : {}),
+          ...(oauthFailure.status ? { httpStatus: oauthFailure.status } : {}),
+        };
+      }
       Object.assign(data, terminationFields);
     } else {
       const meta =

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -209,6 +209,8 @@ function formatOAuthRefreshFailureReason(reason: OAuthRefreshFailureReason | nul
   switch (reason) {
     case "refresh_token_reused":
       return "refresh_token_reused";
+    case "expired":
+      return "expired";
     case "invalid_grant":
       return "invalid_grant";
     case "sign_in_again":

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -94,6 +94,45 @@ suite.define(() => {
       );
     },
   );
+
+  it("does not repeat an auth failure below the composer when the run error is visible", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const message =
+        "Your refresh token has already been used to generate a new access token. Please try signing in again.";
+      const gateway = await installMockGateway(page, {
+        inFlightRun: { runId: "auth-failed-run", text: "" },
+        models: [
+          {
+            id: "gpt-5.5",
+            name: "GPT-5.5",
+            provider: "openai",
+            available: false,
+            unavailableReason: "auth-failed",
+          },
+        ],
+      });
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      await gateway.emitGatewayEvent("chat", {
+        errorDetail: {
+          provider: "openai",
+          failoverReason: "refresh_token_reused",
+          providerRuntimeFailureKind: "auth_refresh",
+          providerErrorType: "invalid_request_error",
+          httpStatus: 401,
+        },
+        errorMessage: `⚠️ ${message}`,
+        runId: "auth-failed-run",
+        sessionKey: "main",
+        state: "error",
+      });
+      await expect.poll(() => page.locator(".chat-error").textContent()).toContain(message);
+      await expect.poll(() => page.locator(".agent-chat__composer-status-band").count()).toBe(0);
+      await expect.poll(() => page.locator(".agent-chat__input textarea").isDisabled()).toBe(true);
+    });
+  });
+
   it("keeps the loading model picker beside the microphone", async () => {
     const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
     const artifactDir = artifactRoot

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -2135,6 +2135,33 @@ describe("handleChatGatewayEvent", () => {
     expect(state.chatRunError).toEqual({ summary: diagnostic, runId: "run-1" });
   });
 
+  it("adds bounded OAuth facts to live errors without changing the summary", () => {
+    const summary =
+      "⚠️ Your refresh token has already been used to generate a new access token. Please try signing in again.";
+    const state = createState({ sessionKey: "main", chatRunId: "run-1" });
+
+    expect(
+      handleChatGatewayEvent(state, {
+        runId: "run-1",
+        sessionKey: "main",
+        state: "error",
+        errorMessage: summary,
+        errorDetail: {
+          provider: "openai",
+          failoverReason: "refresh_token_reused",
+          providerRuntimeFailureKind: "auth_refresh",
+          providerErrorType: "invalid_request_error",
+          httpStatus: 401,
+        },
+      }),
+    ).toBe("error");
+    expect(state.chatRunError).toEqual({
+      kind: "auth_refresh",
+      runId: "run-1",
+      summary: `${summary}\n\nProvider: openai\nHTTP status: 401\nReason: refresh_token_reused\nType: invalid_request_error`,
+    });
+  });
+
   it("uses server guidance when an error follows a source-reply final", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -153,15 +153,32 @@ function normalizeChatErrorComparisonText(text: string): string {
     .trim();
 }
 
+function formatGatewayErrorDetail(payload: ChatEventPayload): string | null {
+  const detail = payload.errorDetail;
+  if (!detail || detail.providerRuntimeFailureKind !== "auth_refresh") {
+    return null;
+  }
+  const lines = [
+    detail.provider ? `Provider: ${detail.provider}` : undefined,
+    detail.httpStatus ? `HTTP status: ${detail.httpStatus}` : undefined,
+    detail.failoverReason ? `Reason: ${detail.failoverReason}` : undefined,
+    detail.providerErrorType ? `Type: ${detail.providerErrorType}` : undefined,
+  ].filter((line): line is string => Boolean(line));
+  return lines.length > 0 ? lines.join("\n") : null;
+}
+
 function resolveGatewayErrorText(
   payload: ChatEventPayload,
   message: Record<string, unknown> | null,
 ): string {
   const errorText = payload.errorMessage?.trim();
   if (errorText) {
-    return errorText.startsWith("⚠️") || errorText.startsWith("Error:")
-      ? errorText
-      : `Error: ${errorText}`;
+    const summary =
+      errorText.startsWith("⚠️") || errorText.startsWith("Error:")
+        ? errorText
+        : `Error: ${errorText}`;
+    const detail = formatGatewayErrorDetail(payload);
+    return detail ? `${summary}\n\n${detail}` : summary;
   }
   const messageText = message ? extractText(message)?.trim() : null;
   return messageText || "chat error";
@@ -324,7 +341,14 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       ) {
         // Late diagnostics belong to the active, pending, or latest locally terminal run;
         // publishing them over a newer response falsely marks the new run failed.
-        setChatRunError(state, resolveGatewayErrorText(payload, null), payload.runId);
+        setChatRunError(
+          state,
+          resolveGatewayErrorText(payload, null),
+          payload.runId,
+          payload.errorDetail?.providerRuntimeFailureKind === "auth_refresh"
+            ? "auth_refresh"
+            : undefined,
+        );
       }
       if (payload.state === "error") {
         reconcileOwnedTerminalRun();
@@ -478,7 +502,14 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       publishChatSessionProjectionMessages(state, materializeVisibleStream(), { scope });
     }
     if (payload.errorMessage?.trim()) {
-      setChatRunError(state, resolveGatewayErrorText(payload, null), payload.runId);
+      setChatRunError(
+        state,
+        resolveGatewayErrorText(payload, null),
+        payload.runId,
+        payload.errorDetail?.providerRuntimeFailureKind === "auth_refresh"
+          ? "auth_refresh"
+          : undefined,
+      );
     }
     reconcileOwnedTerminalRun();
   } else if (payload.state === "error") {
@@ -538,6 +569,9 @@ function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       state,
       resolveGatewayErrorText(payload, projectedErrorMessage ? visiblePayloadMessage : null),
       payload.runId,
+      payload.errorDetail?.providerRuntimeFailureKind === "auth_refresh"
+        ? "auth_refresh"
+        : undefined,
     );
   }
   if (payload.state !== "delta") {

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -1,3 +1,4 @@
+import type { ChatEvent } from "../../../../packages/gateway-protocol/src/schema/logs-chat.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentsListResult } from "../../api/types.ts";
 import {
@@ -21,6 +22,8 @@ type LoadChatHistoryOptions = {
   supersedeInFlight?: boolean;
   startup?: boolean;
 };
+
+type ChatErrorDetail = Extract<ChatEvent, { state: "error" }>["errorDetail"];
 
 export async function loadChatHistory(
   state: ChatState,
@@ -187,6 +190,7 @@ export type ChatEventPayload = {
   deltaText?: string;
   replace?: boolean;
   errorMessage?: string;
+  errorDetail?: ChatErrorDetail;
   stopReason?: string;
   yielded?: true;
 };

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -442,6 +442,11 @@ export class ChatPane extends ChatPaneLayoutRender {
         ? (typing, preview) => this.sendTypingState(typing, preview)
         : undefined,
       ...composerAvailability,
+      disabledReason:
+        state.chatRunError?.kind === "auth_refresh" &&
+        composerAvailability.disabledReason === modelUnavailableMessage
+          ? null
+          : composerAvailability.disabledReason,
       modelSetupRequired:
         modelSetupRequired && !selectedSessionArchived && !restartRecoveryTombstoned,
       onModelSetup: () => this.context.navigate("model-setup"),

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -35,6 +35,7 @@ import { resetToolStream, resetToolStreamRun } from "./tool-stream.ts";
 export const CHAT_RUN_STATUS_TOAST_DURATION_MS = 5_000;
 
 export type ChatRunError = {
+  kind?: "auth_refresh";
   summary: string;
   /** Display ownership only; the session reducer retains each run's diagnostic. */
   runId?: string;
@@ -194,9 +195,14 @@ export function setChatRunError(
   state: { chatRunError?: ChatRunError | null },
   summary: string,
   runId?: string,
+  kind?: ChatRunError["kind"],
 ) {
   setChatRunOwner(state, runId);
-  state.chatRunError = { summary: formatUiExternalText(summary), ...(runId ? { runId } : {}) };
+  state.chatRunError = {
+    ...(kind ? { kind } : {}),
+    summary: formatUiExternalText(summary),
+    ...(runId ? { runId } : {}),
+  };
 }
 
 type SessionRunHost = {


### PR DESCRIPTION
Closes #134916

## Problem

OpenAI OAuth refresh failures embedded the complete provider response body in an error string. Wrappers carried that raw JSON into the Control UI headline and **Error details**, while model availability also repeated a generic authentication failure below the composer.

## Fix

- Parse failed OpenAI token responses at the provider owner.
- Keep only a bounded, redacted provider message and allowlisted status/code/type facts.
- Preserve that structured summary through OAuth and failover wrappers.
- Publish the concise summary with bounded details to the Control UI.
- Hide the generic composer authentication notice only while the matching live auth-refresh error is visible; sending remains blocked.

Malformed, plain-text, oversized, and unknown responses use a generic HTTP-status summary. Cancellation, timeouts, non-auth errors, history recovery, and unrelated model-unavailable guidance retain their existing behavior.

## Result

The reported failure now displays:

> Your refresh token has already been used to generate a new access token. Please try signing in again.

The raw response object is absent. Expanding **Error details** shows only bounded provider, HTTP status, reason, and type facts.

## Visual Evidence

| View | Before | Exact-head after |
| --- | --- | --- |
| Collapsed error | ![Current main error summary exposing the raw JSON opening brace](https://github.com/user-attachments/assets/20be1212-b3f6-46ad-965b-5f4af3b1eaef) | ![Exact candidate showing only the provider message](https://github.com/user-attachments/assets/faabf72f-8652-435d-ba2f-51bd5fc38751) |
| Error disclosure | ![Current main expanded disclosure showing the raw response object](https://github.com/user-attachments/assets/3092e8e6-0f89-4fc3-9de3-351d7c95e1bf) | ![Exact candidate showing bounded safe OAuth facts](https://github.com/user-attachments/assets/e0af9690-3242-45bf-a011-0bf70499f913) |
| Composer | Generic authentication notice repeated below the specific run error | ![Exact candidate with the duplicate composer notice removed while send remains blocked](https://github.com/user-attachments/assets/5ad7fa93-49f2-49c7-a9c1-1579d980a1fa) |

### Interaction Recording

https://github.com/user-attachments/assets/532a30ad-813c-48d6-9829-569797973855

The focused recording demonstrates error disclosure, safe copy text, and replacement-run cleanup. The same interaction was recaptured and validated on the exact final head.

## Scope

- 16 files
- Production: +301/-27
- Tests: +253/-11
- Total: +554/-38

Production growth is the typed, bounded presentation path across the existing provider, auth, lifecycle, Gateway, and UI ownership boundaries; it does not add configuration, persistence, protocol versions, or parallel runtime paths.

## Verification

- Exact candidate: `28b70d69703a4a09418d1c75ae21ff09b90c1d38`
- Exact tree: `647145436d2a95fb3156715f5bf9b1664a263876`
- Remote focused provider/auth/lifecycle/UI tests passed.
- Remote `pnpm check:changed` passed.
- Composer E2E: 9/9 passed.
- Independent blocker review: clean after both findings were fixed.
- Exact-head visual proof validated at 1280x900; no raw JSON, duplicate composer notice count 0, and served/build asset hashes match.
- Current Codex OAuth source still extracts the nested provider message and distinguishes expired, reused, and invalidated refresh-token failures.
