### PR TITLE
fix(release): fail closed on unrelated Docker not-found errors

### DIFF
--- a/scripts/docker-channel-promote.mjs
+++ b/scripts/docker-channel-promote.mjs
@@ -4,6 +4,7 @@ import { execFileSync } from "node:child_process";
 import process from "node:process";
 import { parseArgs } from "node:util";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
+import { isMissingManifestError } from "./lib/docker-manifest-error.mjs";
 import { resolveDockerReleasePolicy } from "./lib/docker-release-policy.mjs";
 import { compareReleaseVersions } from "./lib/release-version.mjs";
 import { parsePlatform, verifyDockerAttestations } from "./verify-docker-attestations.mjs";
@@ -104,27 +105,6 @@ function inspectManifestDigest(imageRef, execFileSyncImpl) {
   return digest;
 }
 
-function formatCommandError(error) {
-  if (!(error instanceof Error)) {
-    return String(error);
-  }
-  const output = [error.message];
-  for (const field of ["stderr", "stdout"]) {
-    const value = error[field];
-    if (typeof value === "string") {
-      output.push(value);
-    } else if (Buffer.isBuffer(value)) {
-      output.push(value.toString("utf8"));
-    }
-  }
-  return output.join("\n");
-}
-
-function isMissingManifestError(error) {
-  const message = formatCommandError(error);
-  return /(?:manifest unknown|no such manifest|:\s*not found(?:\s|$))/i.test(message);
-}
-
 function formatPlatform(platform) {
   const suffix = platform.variant ? `/${platform.variant}` : "";
   return `${platform.os}/${platform.architecture}${suffix}`;
@@ -150,7 +130,7 @@ function inspectImageVersion(imageRef, execFileSyncImpl, { allowMissing = false 
         execFileSyncImpl,
       );
     } catch (error) {
-      if (allowMissing && index === 0 && isMissingManifestError(error)) {
+      if (allowMissing && index === 0 && isMissingManifestError(error, imageRef)) {
         return null;
       }
       throw error;

--- a/scripts/lib/docker-manifest-error.mjs
+++ b/scripts/lib/docker-manifest-error.mjs
@@ -1,0 +1,25 @@
+import { escapeRegExp } from "./regexp.mjs";
+
+function formatCommandError(error) {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+  const output = [error.message];
+  for (const field of ["stderr", "stdout"]) {
+    const value = error[field];
+    if (typeof value === "string") {
+      output.push(value);
+    } else if (Buffer.isBuffer(value)) {
+      output.push(value.toString("utf8"));
+    }
+  }
+  return output.join("\n");
+}
+
+export function isMissingManifestError(error, imageRef) {
+  const message = formatCommandError(error);
+  return (
+    /(?:manifest unknown|no such manifest)/iu.test(message) ||
+    new RegExp(`(?:^|[\\s"'(])${escapeRegExp(imageRef)}:\\s*not found(?:\\s|$)`, "iu").test(message)
+  );
+}

--- a/scripts/vercel-container-registry-publish.mjs
+++ b/scripts/vercel-container-registry-publish.mjs
@@ -4,6 +4,7 @@ import { execFileSync } from "node:child_process";
 import process from "node:process";
 import { parseArgs } from "node:util";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
+import { isMissingManifestError } from "./lib/docker-manifest-error.mjs";
 import { resolveDockerReleasePolicy } from "./lib/docker-release-policy.mjs";
 import { compareReleaseVersions } from "./lib/release-version.mjs";
 import { verifyDockerAttestations } from "./verify-docker-attestations.mjs";
@@ -164,28 +165,6 @@ function inspectManifestDescriptor(imageRef, execFileSyncImpl) {
   }
 }
 
-function formatCommandError(error) {
-  if (!(error instanceof Error)) {
-    return String(error);
-  }
-  const output = [error.message];
-  for (const field of ["stderr", "stdout"]) {
-    const value = error[field];
-    if (typeof value === "string") {
-      output.push(value);
-    } else if (Buffer.isBuffer(value)) {
-      output.push(value.toString("utf8"));
-    }
-  }
-  return output.join("\n");
-}
-
-function isMissingManifestError(error) {
-  return /(?:manifest unknown|no such manifest|:\s*not found(?:\s|$))/i.test(
-    formatCommandError(error),
-  );
-}
-
 function inspectImageVersion(imageRef, execFileSyncImpl, { allowMissing = false } = {}) {
   const versions = new Map();
   for (const [index, architecture] of ARCHITECTURES.entries()) {
@@ -197,7 +176,7 @@ function inspectImageVersion(imageRef, execFileSyncImpl, { allowMissing = false 
         execFileSyncImpl,
       );
     } catch (error) {
-      if (allowMissing && index === 0 && isMissingManifestError(error)) {
+      if (allowMissing && index === 0 && isMissingManifestError(error, imageRef)) {
         return null;
       }
       throw error;

--- a/test/scripts/docker-channel-promote.test.ts
+++ b/test/scripts/docker-channel-promote.test.ts
@@ -348,7 +348,26 @@ describe("Docker channel promotion", () => {
     expect(execFileSyncImpl.mock.calls.some(([, args]) => args[2] === "create")).toBe(true);
   });
 
-  it("allows a first promotion when the target alias does not exist", () => {
+  it.each([
+    [
+      "manifest unknown in the error message",
+      (ref: string) => new Error(`${ref}: manifest unknown`),
+    ],
+    [
+      "no such manifest in buffered stderr",
+      () =>
+        Object.assign(new Error("docker inspect failed"), {
+          stderr: Buffer.from("no such manifest"),
+        }),
+    ],
+    [
+      "the exact image reference not found in stdout",
+      (ref: string) =>
+        Object.assign(new Error("docker inspect failed"), {
+          stdout: `ERROR: ${ref}: not found`,
+        }),
+    ],
+  ])("allows a first promotion for %s", (_label, createMissingError) => {
     let created = false;
     const execFileSyncImpl = vi.fn((_command: string, args: string[]) => {
       if (args[2] === "create") {
@@ -357,9 +376,7 @@ describe("Docker channel promotion", () => {
       }
       if (args.at(-1)?.includes(".Image")) {
         if (!args[3]!.includes("@") && !created) {
-          const error = new Error("docker inspect failed");
-          Object.assign(error, { stderr: `ERROR: ${args[3]}: not found` });
-          throw error;
+          throw createMissingError(args[3]!);
         }
         return imageConfig("2026.6.33");
       }
@@ -374,12 +391,20 @@ describe("Docker channel promotion", () => {
     expect(created).toBe(true);
   });
 
-  it("fails closed when an existing alias cannot be inspected", () => {
+  it.each([
+    [
+      "an unrelated executable lookup",
+      Object.assign(new Error("docker inspect failed"), {
+        stderr: "docker credential helper: not found",
+      }),
+    ],
+    ["authentication", new Error("unauthorized: authentication required")],
+    ["a timeout", new Error("docker inspect timed out")],
+    ["a transport failure", new Error("read: connection reset by peer")],
+  ])("fails closed on %s while inspecting an existing alias", (_label, inspectionError) => {
     const execFileSyncImpl = vi.fn((_command: string, args: string[]) => {
       if (args.at(-1)?.includes(".Image") && !args[3]!.includes("@")) {
-        const error = new Error("unauthorized: authentication required");
-        Object.assign(error, { stderr: "denied: requested access to the resource is denied" });
-        throw error;
+        throw inspectionError;
       }
       if (args.at(-1)?.includes(".Image")) {
         return imageConfig("2026.6.33");
@@ -392,7 +417,28 @@ describe("Docker channel promotion", () => {
         { version: "2026.6.33", images: images.slice(0, 1) },
         { execFileSyncImpl, verifyAttestationsImpl: skipAttestationVerification },
       ),
-    ).toThrow("unauthorized");
+    ).toThrow(inspectionError.message);
+    expect(execFileSyncImpl.mock.calls.some(([, args]) => args[2] === "create")).toBe(false);
+  });
+
+  it("does not treat a longer image token as the inspected alias", () => {
+    const execFileSyncImpl = vi.fn((_command: string, args: string[]) => {
+      if (args.at(-1)?.includes(".Image") && !args[3]!.includes("@")) {
+        const error = new Error("docker inspect failed");
+        Object.assign(error, { stderr: `mirror-${args[3]}: not found` });
+        throw error;
+      }
+      return args.at(-1)?.includes(".Image")
+        ? imageConfig("2026.6.33")
+        : JSON.stringify({ digest });
+    });
+
+    expect(() =>
+      promoteDockerChannel(
+        { version: "2026.6.33", images: images.slice(0, 1) },
+        { execFileSyncImpl, verifyAttestationsImpl: skipAttestationVerification },
+      ),
+    ).toThrow("docker inspect failed");
     expect(execFileSyncImpl.mock.calls.some(([, args]) => args[2] === "create")).toBe(false);
   });
 

--- a/test/scripts/vercel-container-registry-publish.test.ts
+++ b/test/scripts/vercel-container-registry-publish.test.ts
@@ -444,6 +444,33 @@ describe("Vercel Container Registry publishing", () => {
     ).toBe(false);
   });
 
+  it("allows a first VCR alias publication when the exact target ref is absent", () => {
+    const calls: string[][] = [];
+    const execute = successfulExecutor(calls);
+    let created = false;
+    const execFileSyncImpl = vi.fn((command: string, args: string[]) => {
+      if (args[2] === "create") {
+        created = true;
+      } else if (args.at(-1)?.includes(".Image") && !args[3]!.includes("@") && !created) {
+        const error = new Error("docker inspect failed");
+        Object.assign(error, { stderr: `ERROR: ${args[3]}: not found` });
+        throw error;
+      }
+      return execute(command, args);
+    });
+
+    promoteVercelContainerRegistryAliases(
+      {
+        includeBrowser: false,
+        targetImage,
+        version: "2026.7.2",
+      },
+      { execFileSyncImpl, log: () => {} },
+    );
+
+    expect(calls.filter((args) => args[2] === "create")).toHaveLength(2);
+  });
+
   it("transports only secret-safe digests across the VCR workflow boundary", () => {
     const dockerRelease = readWorkflow(".github/workflows/docker-release.yml");
     const releaseWorkflow = readWorkflow(".github/workflows/openclaw-release-publish.yml");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Docker release promotion could treat an unrelated command failure ending in `: not found`, such as a missing credential helper, as proof that a moving alias did not exist. That could allow alias writes without successfully reading the current channel version.

## Why This Change Was Made

Both Docker promotion scripts now share one private missing-manifest classifier. It accepts Docker's explicit `manifest unknown` and `no such manifest` markers, or `not found` only when it names the exact inspected image reference with a Docker-output token boundary.

Authentication, timeout, transport, immutable-source, and attestation failures remain fatal. No workflow, configuration, SDK, dependency, or public API changes are included.

## User Impact

Release operators retain first-publication behavior for absent aliases, while unrelated Docker and credential failures now fail closed before any alias write.

## Evidence

- Pre-fix boundary repro: `docker credential helper: not found` was treated as a missing alias and an alias write executed.
- Post-fix boundary repro: the same error remains fatal and no alias write executes.
- Focused Vitest: 49 passed, 1 skipped across both Docker promotion consumer suites.
- `pnpm tsgo:scripts`
- `pnpm tsgo:test:root`
- `node scripts/check-changed.mjs -- <five changed files>`
- AWS Crabbox read-only Buildx probe: run `run_89a539125dd0`, lease `cbx_035389529fc5`, Buildx `v0.36.0`; a nonexistent public GHCR tag returned the exact `ERROR: <image-ref>: not found` form. No credentials, registry writes, VCR publication, or release flow.

```text
github.com/docker/buildx v0.36.0
ERROR: ghcr.io/openclaw/openclaw:missing-manifest-proof-20260901: not found
```

- Exact Codex Sol autoreview on the final branch: scoped clean, 0.99 correctness, no actionable findings or exposed credentials.
- Production LOC: +29/-45 (net -16). Tests: +82/-9.
- Direct Codex source inspection completed at `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; both ranges are unrelated CLI/completion plumbing.
