### PR TITLE
fix(cli): keep zsh subcommand descriptions literal

### DIFF
--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -14,6 +14,7 @@ import {
   runGeneratedBashCompletion,
   runGeneratedFishCompletion,
 } from "./completion-cli.test-support.js";
+import { registerModelsCli } from "./models-cli.js";
 
 const powerShellCompletion = new PowerShellCompletionRunner();
 
@@ -85,6 +86,73 @@ describe("completion-cli", () => {
     );
     expect(script).not.toContain("John'\\''s");
   });
+
+  it.skipIf(process.platform === "win32").each(["built-in", "root", "nested"] as const)(
+    "keeps %s command descriptions literal through real zsh parsing",
+    (scope) => {
+      const program = new Command().name("openclaw");
+      let describedCommand: Command;
+      let completionFunction: string;
+      if (scope === "built-in") {
+        registerModelsCli(program);
+        const auth = program.commands
+          .find((command) => command.name() === "models")
+          ?.commands.find((command) => command.name() === "auth");
+        const logout = auth?.commands.find((command) => command.name() === "logout");
+        if (!logout) {
+          throw new Error("Models auth logout command is unavailable");
+        }
+        describedCommand = logout;
+        completionFunction = "_openclaw_models_auth";
+      } else {
+        const parent = scope === "nested" ? program.command("parent") : program;
+        describedCommand = parent
+          .command("inspect")
+          .alias("review")
+          .description(
+            'Show John\'s "literal" $OPENCLAW_COMPLETION_LITERAL with `models auth list`',
+          );
+        completionFunction = scope === "nested" ? "_openclaw_parent" : "_openclaw_root_completion";
+      }
+
+      const result = spawnSync(
+        "zsh",
+        [
+          "-fc",
+          `${getCompletionScript("zsh", program)}
+OPENCLAW_COMPLETION_LITERAL=expanded-value
+models() { printf '%s\\n' "OPENCLAW_COMPLETION_DESCRIPTION_EVALUATED:$*" >&2; }
+_arguments() {
+  local spec
+  for spec in "$@"; do
+    if [[ "$spec" == "1: :"* ]]; then
+      local -a action
+      eval "action=( \${spec#1: :} )"
+      printf '%s\\0' "\${action[@]}"
+    fi
+  done
+}
+${completionFunction}
+`,
+        ],
+        { encoding: "utf8", timeout: 10_000 },
+      );
+      if (result.error) {
+        if ("code" in result.error && result.error.code === "ENOENT") {
+          return;
+        }
+        throw result.error;
+      }
+
+      expect(result.stderr).toBe("");
+      expect(result.status).toBe(0);
+      const action = result.stdout.split("\0").filter(Boolean);
+      expect(action.slice(0, 2)).toEqual(["_values", "command"]);
+      for (const name of [describedCommand.name(), ...describedCommand.aliases()]) {
+        expect(action).toContain(`${name}[${describedCommand.description()}]`);
+      }
+    },
+  );
 
   it("marks zsh option arguments and completes validated shell choices", () => {
     const script = getCompletionScript("zsh", createDocumentedCompletionProgram());

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -324,12 +324,7 @@ function escapeZshCompletionChoice(choice: string): string {
 function generateZshSubcmdList(cmd: Command): string {
   const list = visibleCompletionCommands(cmd)
     .flatMap((c) => {
-      const desc = c
-        .description()
-        .replace(/\\/g, "\\\\")
-        .replace(/'/g, "'\\''")
-        .replace(/\[/g, "\\[")
-        .replace(/\]/g, "\\]");
+      const desc = escapeZshDoubleQuotedDescription(c.description()).replace(/'/g, "'\\''");
       return commandNameVariants(c).map((name) => `'${name}[${desc}]'`);
     })
     .join(" ");


### PR DESCRIPTION
Closes #135089. Related: #76126 and #64490.

## What Problem This Solves

Fixes an issue where users pressing Tab in zsh would execute command examples embedded in subcommand descriptions. For `openclaw models auth `, the built-in logout hint loses its literal `models auth list` text during completion.

## Why This Change Was Made

Subcommand descriptions duplicated incomplete escaping inside a double-quoted `_arguments` specification. Reuse the existing option-description encoder and retain the separate single-quote layer. This removes the duplicate path without adding a helper, dependency, or configuration option.

Production: **+1/−6, net −5 lines**. Tests: **+68 lines**. Thanks to @walker1211 for the subcommand report in #76126; the merged #64490 addressed the option-description sibling. Introduction provenance is unknown.

## User Impact

Newly generated zsh completions preserve literal command descriptions and aliases, including quotes, dollar signs, and backticks. Other shell generators and completion installation behavior are unchanged.

## Evidence

- Three regression cases—built-in models registration, root commands, and nested aliases—fail on the original generator and pass after the repair, including after formatting.
- Real interactive `zsh -f` proof uses the actual `registerModelsCli`/`getCompletionScript` output and normal `compinit -D`, `_arguments`, and `_values`. Before: Tab invokes a harmless recording `models` function once and displays `Remove a saved auth profile (see  for ids)`. After: no invocation, and the complete literal description is retained. The typed command was never submitted; no auth action, full built CLI, profile change, or installation was performed.
- Five completion owner/sibling test files: **78 passed**, **107 skipped** because Fish and PowerShell are unavailable; native zsh cases ran.
- Independent managed P0–P2 review: no actionable findings. The unchanged encoder and zsh parsing boundary were also inspected directly.
- All 29 normal changed-file checks passed, including typechecks, formatting, lint, dependency boundaries, and unused-export checks.

Focused reproduction command:

```sh
node scripts/run-vitest.mjs src/cli/completion-cli.test.ts \
  -t 'command descriptions literal through real zsh parsing'
```

Environment: macOS 27.0 arm64, Node 24.20.0, pnpm 12.1.0, zsh 5.9.2.
