### PR TITLE
perf(browser): index bounded request history by ID

### DIFF
--- a/extensions/browser/src/browser/pw-session-contracts.ts
+++ b/extensions/browser/src/browser/pw-session-contracts.ts
@@ -109,7 +109,8 @@ export type ActionDownloadCapture = {
 export type PageState = {
   console: BrowserConsoleMessage[];
   errors: BrowserPageError[];
-  requests: BrowserNetworkRequest[];
+  requests: Map<string, BrowserNetworkRequest>;
+  // Strong Request keys would retain disposed Playwright page/context graphs.
   requestIds: WeakMap<Request, string>;
   nextRequestId: number;
   armIdUpload: number;

--- a/extensions/browser/src/browser/pw-session-state.ts
+++ b/extensions/browser/src/browser/pw-session-state.ts
@@ -1,3 +1,4 @@
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { resolveExpiresAtMsFromDurationMs } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -12,7 +13,6 @@ import {
   type ArmedDialogResponse,
   type BrowserObservedDialogRecord,
   type BrowserObservedState,
-  type BrowserNetworkRequest,
   type BrowserConsoleMessage,
   type DownloadPayload,
   type PageState,
@@ -43,16 +43,6 @@ function truncateObservedPageText(value: string): string {
 
 export function normalizeCdpUrl(raw: string) {
   return raw.replace(/\/$/, "");
-}
-
-function findNetworkRequestById(state: PageState, id: string): BrowserNetworkRequest | undefined {
-  for (let i = state.requests.length - 1; i >= 0; i -= 1) {
-    const candidate = state.requests[i];
-    if (candidate && candidate.id === id) {
-      return candidate;
-    }
-  }
-  return undefined;
 }
 
 export function targetKey(cdpUrl: string, targetId: string) {
@@ -115,13 +105,7 @@ function rememberRoleRefsForTarget(opts: {
     ...(opts.mode ? { mode: opts.mode } : {}),
     generation,
   });
-  while (roleRefsByTarget.size > MAX_ROLE_REFS_CACHE) {
-    const first = roleRefsByTarget.keys().next();
-    if (first.done) {
-      break;
-    }
-    roleRefsByTarget.delete(first.value);
-  }
+  pruneMapToMaxSize(roleRefsByTarget, MAX_ROLE_REFS_CACHE);
   return generation;
 }
 
@@ -222,7 +206,7 @@ export function ensurePageState(page: Page): PageState {
   const state: PageState = {
     console: [],
     errors: [],
-    requests: [],
+    requests: new Map(),
     requestIds: new WeakMap(),
     nextRequestId: 0,
     armIdUpload: 0,
@@ -265,16 +249,14 @@ export function ensurePageState(page: Page): PageState {
       state.nextRequestId += 1;
       const id = `r${state.nextRequestId}`;
       state.requestIds.set(req, id);
-      state.requests.push({
+      state.requests.set(id, {
         id,
         timestamp: new Date().toISOString(),
         method: req.method(),
         url: truncateObservedPageText(req.url()),
         resourceType: req.resourceType(),
       });
-      if (state.requests.length > MAX_NETWORK_REQUESTS) {
-        state.requests.shift();
-      }
+      pruneMapToMaxSize(state.requests, MAX_NETWORK_REQUESTS);
     });
     page.on("response", (resp: Response) => {
       const req = resp.request();
@@ -282,7 +264,7 @@ export function ensurePageState(page: Page): PageState {
       if (!id) {
         return;
       }
-      const rec = findNetworkRequestById(state, id);
+      const rec = state.requests.get(id);
       if (!rec) {
         return;
       }
@@ -294,7 +276,7 @@ export function ensurePageState(page: Page): PageState {
       if (!id) {
         return;
       }
-      const rec = findNetworkRequestById(state, id);
+      const rec = state.requests.get(id);
       if (!rec) {
         return;
       }

--- a/extensions/browser/src/browser/pw-session.test.ts
+++ b/extensions/browser/src/browser/pw-session.test.ts
@@ -799,7 +799,7 @@ describe("pw-session ensurePageState", () => {
 
     const consoleEntry = state.console.at(-1);
     const errorEntry = state.errors.at(-1);
-    const request = state.requests.at(-1);
+    const request = [...state.requests.values()].at(-1);
     for (const value of [
       consoleEntry?.type,
       consoleEntry?.text,
@@ -829,7 +829,7 @@ describe("pw-session ensurePageState", () => {
     expect(state2).not.toBe(state1);
     expect(state2.console).toStrictEqual([]);
     expect(state2.errors).toStrictEqual([]);
-    expect(state2.requests).toStrictEqual([]);
+    expect(state2.requests).toStrictEqual(new Map());
   });
 
   it.each([

--- a/extensions/browser/src/browser/pw-tools-core.activity.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.activity.test.ts
@@ -109,10 +109,13 @@ describe("getNetworkRequestsViaPlaywright", () => {
       };
       const state = {
         console: [],
-        requests: [
-          matching,
-          { ...matching, id: "2", url: "https://example.com/logo.png", resourceType: "image" },
-        ],
+        requests: new Map([
+          ["1", matching],
+          [
+            "2",
+            { ...matching, id: "2", url: "https://example.com/logo.png", resourceType: "image" },
+          ],
+        ]),
         requestIds: new WeakMap(),
         armIdUpload: 0,
         armIdDownload: 0,
@@ -126,7 +129,7 @@ describe("getNetworkRequestsViaPlaywright", () => {
           clear: true,
         }),
       ).toEqual({ requests: [matching] });
-      expect(state.requests).toEqual([]);
+      expect(state.requests).toEqual(new Map());
     },
   );
 });

--- a/extensions/browser/src/browser/pw-tools-core.activity.ts
+++ b/extensions/browser/src/browser/pw-tools-core.activity.ts
@@ -68,13 +68,13 @@ export async function getNetworkRequestsViaPlaywright(opts: {
 }): Promise<{ requests: BrowserNetworkRequest[] }> {
   const page = await getPageForTargetId(opts);
   const state = ensurePageState(page);
-  const raw = [...state.requests];
+  const raw = [...state.requests.values()];
   const filter = typeof opts.filter === "string" ? opts.filter.trim() : "";
   const requests = filter
     ? raw.filter((r) => r.url.includes(filter) || r.resourceType?.includes(filter))
     : raw;
   if (opts.clear) {
-    state.requests = [];
+    state.requests.clear();
     state.requestIds = new WeakMap();
   }
   return { requests };


### PR DESCRIPTION
## What Problem This Solves

Every browser response or failure scans the captured request history in reverse to find its record. Keeping the bounded history in an insertion-ordered map removes that repeated scan and the array's eviction shifts.

## Why This Change Was Made

Index history records by their existing unique request IDs. Keep the weak Playwright Request-to-ID association, so retained closed Page handles do not acquire strong references to disposed request/context graphs. The public observation API still returns an ordered array.

Reuse the existing bounded-map helper for both request history and the neighboring role-reference cache. This deletes the custom reverse lookup and duplicate pruning loop. The page-state owner still handles response/failure updates and clear/close lifecycle; no protocol, configuration, dependency or SDK surface is added.

## User Impact

Request-history lookup becomes direct while ordering, the 500-record bound, filtering, clearing and late-event behavior stay intact. Production +11/-28 (net -17); tests +10/-7 (net +3), total -14.

## Evidence

- Actual OpenClaw Playwright/CDP API runs before and after used a fresh synthetic Chromium and 600 loopback HTTP requests. Both returned records r101 through r600 in order, with identical successful response fields. Filtering returned the same ten records; clear removed the full history, and the next request had a new monotonic ID and correct response status.
- A controlled Chromium event-handler probe reduced combined request/response handler CPU from 2.793 to 1.725 microseconds per event (about 38%). End-to-end time was effectively unchanged, so this is a lookup-cost result rather than a browser-wide latency claim.
- Deterministic comparison covers duplicate request events, failure updates, eviction, late terminal events and clear. The ID map preserves the former array's insertion order and record identity.
- Installed Playwright source and a closed-page ownership probe explain why request objects remain weak keys. The selected design retained zero Request wrappers after page/context closure, matching the baseline; a rejected strong-key design retained disposed wrappers. No resident-memory reduction is claimed for the selected map itself.
- All 58 focused browser/session/activity/map-pruning tests pass. The complete required changed-check plan passes. Independent source/dependency review and fresh Codex autoreview found no accepted findings within the selected scope and priority.
