### PR TITLE
fix: explain unavailable agent harnesses on failed turns

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -193,6 +193,13 @@ configured default. Install and enable the named harness plugin, restart the
 Gateway, then select the model again. This check does not start the runtime or
 verify provider credentials.
 
+If an existing session's harness becomes unavailable, the failed turn reports
+the owner plugin when known and its activation or loading blocker. Follow the error's
+`openclaw doctor --fix` or `openclaw plugins inspect <id> --runtime --json`
+guidance, repair the plugin, and restart the Gateway before retrying. Gateway
+health probes remain independent of model execution; use [Models status](/cli/models)
+and [Doctor](/gateway/doctor) to diagnose the configured route.
+
 Choose the model when you create a session whenever possible. The Control UI's
 **New Chat** composer includes the model picker for this reason: a fresh session
 gives the selected model a clean conversation boundary.

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -208,36 +208,46 @@ describe("harness runtime plugins", () => {
     expect((error as Error).message).not.toContain("absent from this prepared plugin generation");
   });
 
-  it("reports a missing activatable owner as degraded when a sibling owner is blocked", async () => {
-    const config = { plugins: { allow: ["ready-owner"] } } satisfies OpenClawConfig;
-    const pluginRegistry = createEmptyPluginRegistry();
-    attachPreparedPluginFacts(
-      pluginRegistry,
-      config,
-      makeRegistry(
-        ["blocked-owner", "ready-owner"].map((id) => ({
-          id,
-          channels: [],
-          origin: "bundled" as const,
-          activation: { onAgentHarnesses: ["custom-harness"] },
-        })),
-      ),
-    );
+  it.each([1, 3])(
+    "reports a missing activatable owner as degraded with %i blocked sibling owners",
+    async (blockedCount) => {
+      const config = {
+        plugins: { allow: ["ready-owner"], entries: { "ready-owner": { enabled: true } } },
+      } satisfies OpenClawConfig;
+      const pluginRegistry = createEmptyPluginRegistry();
+      attachPreparedPluginFacts(
+        pluginRegistry,
+        config,
+        makeRegistry(
+          [
+            ...Array.from({ length: blockedCount }, (_, index) => `blocked-owner-${index}`),
+            "ready-owner",
+          ].map((id) => ({
+            id,
+            channels: [],
+            origin: "bundled" as const,
+            activation: { onAgentHarnesses: ["custom-harness"] },
+          })),
+        ),
+      );
 
-    const error = await ensureSelectedAgentHarnessPlugin({
-      provider: "custom-provider",
-      modelId: "custom-model",
-      config,
-      agentHarnessRuntimeOverride: "custom-harness",
-      workspaceDir: "/tmp/workspace",
-      pluginRegistry,
-    }).catch((cause: unknown) => cause);
+      const error = await ensureSelectedAgentHarnessPlugin({
+        provider: "custom-provider",
+        modelId: "custom-model",
+        config,
+        agentHarnessRuntimeOverride: "custom-harness",
+        workspaceDir: "/tmp/workspace",
+        pluginRegistry,
+      }).catch((cause: unknown) => cause);
 
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain("reason=owner-plugin-degraded");
-    expect((error as Error).message).toContain('Owner plugin "blocked-owner" is not activatable');
-    expect((error as Error).message).toContain("ready-owner");
-  });
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("reason=owner-plugin-degraded");
+      expect((error as Error).message).toContain(
+        'Owner plugin "blocked-owner-0" is not activatable',
+      );
+      expect((error as Error).message).toContain("ownerPluginIds=");
+    },
+  );
 
   it("reports the prepared owner's loader failure before activation policy", async () => {
     const pluginRegistry = createEmptyPluginRegistry();
@@ -324,34 +334,38 @@ describe("harness runtime plugins", () => {
     );
   });
 
-  it("reports an activated owner missing from the prepared registry as degraded", async () => {
-    const pluginRegistry = createEmptyPluginRegistry();
-    attachPreparedPluginFacts(
-      pluginRegistry,
-      {},
-      makeRegistry([
+  it.each(["config", "bundled", "platform"] as const)(
+    "reports an activated %s owner missing from the prepared registry as degraded",
+    async (mode) => {
+      const pluginRegistry = createEmptyPluginRegistry();
+      const manifestRegistry = makeRegistry([
         {
           id: "custom-owner",
           channels: [],
           activation: { onAgentHarnesses: ["custom-harness"] },
         },
-      ]),
-    );
+      ]);
+      const owner = manifestRegistry.plugins[0]!;
+      owner.origin = mode === "config" ? "config" : "bundled";
+      owner.enabledByDefault = mode === "bundled";
+      owner.enabledByDefaultOnPlatforms = mode === "platform" ? [process.platform] : undefined;
+      attachPreparedPluginFacts(pluginRegistry, {}, manifestRegistry);
 
-    const error = await ensureSelectedAgentHarnessPlugin({
-      provider: "custom-provider",
-      modelId: "custom-model",
-      agentHarnessRuntimeOverride: "custom-harness",
-      workspaceDir: "/tmp/workspace",
-      pluginRegistry,
-    }).catch((cause: unknown) => cause);
+      const error = await ensureSelectedAgentHarnessPlugin({
+        provider: "custom-provider",
+        modelId: "custom-model",
+        agentHarnessRuntimeOverride: "custom-harness",
+        workspaceDir: "/tmp/workspace",
+        pluginRegistry,
+      }).catch((cause: unknown) => cause);
 
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain(
-      "(reason=owner-plugin-degraded, ownerPluginId=custom-owner)",
-    );
-    expect((error as Error).message).toContain("The owner plugin did not register.");
-  });
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain(
+        "(reason=owner-plugin-degraded, ownerPluginId=custom-owner)",
+      );
+      expect((error as Error).message).toContain("The owner plugin did not register.");
+    },
+  );
 
   it("gives an unknown harness without owner metadata a stable reason", async () => {
     const error = await ensureSelectedAgentHarnessPlugin({

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -193,6 +193,52 @@ describe("harness runtime plugins", () => {
     expect(formatForLog((error as Error).message)).toContain('Run "openclaw doctor --fix"');
   });
 
+  it("reports explicit library policy without a prepared registry context", async () => {
+    const error = await ensureSelectedAgentHarnessPlugin({
+      provider: "openai",
+      modelId: "gpt-5.5",
+      config: { plugins: { enabled: false } },
+      agentHarnessRuntimeOverride: "codex",
+      workspaceDir: "/tmp/workspace",
+      pluginRegistry: undefined,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("plugins disabled");
+    expect((error as Error).message).not.toContain("absent from this prepared plugin generation");
+  });
+
+  it("reports a missing activatable owner as degraded when a sibling owner is blocked", async () => {
+    const config = { plugins: { allow: ["ready-owner"] } } satisfies OpenClawConfig;
+    const pluginRegistry = createEmptyPluginRegistry();
+    attachPreparedPluginFacts(
+      pluginRegistry,
+      config,
+      makeRegistry(
+        ["blocked-owner", "ready-owner"].map((id) => ({
+          id,
+          channels: [],
+          origin: "bundled" as const,
+          activation: { onAgentHarnesses: ["custom-harness"] },
+        })),
+      ),
+    );
+
+    const error = await ensureSelectedAgentHarnessPlugin({
+      provider: "custom-provider",
+      modelId: "custom-model",
+      config,
+      agentHarnessRuntimeOverride: "custom-harness",
+      workspaceDir: "/tmp/workspace",
+      pluginRegistry,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("reason=owner-plugin-degraded");
+    expect((error as Error).message).toContain('Owner plugin "blocked-owner" is not activatable');
+    expect((error as Error).message).toContain("ready-owner");
+  });
+
   it("reports the prepared owner's loader failure before activation policy", async () => {
     const pluginRegistry = createEmptyPluginRegistry();
     const config = { plugins: { allow: ["telegram"] } } satisfies OpenClawConfig;

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -5,9 +5,12 @@ import {
   makeRegistry,
 } from "../../config/plugin-auto-enable.test-helpers.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { formatForLog } from "../../gateway/ws-log.js";
 import * as installedManifests from "../../plugins/manifest-registry-installed.js";
 import { restorePluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { createPluginRecord } from "../../plugins/status.test-helpers.js";
+import { prepareOwnedPluginLoadContext } from "../prepared-model-runtime.plugin-context.js";
 import {
   createAgentRuntimeMetadataPluginIdScope,
   resolveAgentRuntimePluginLoadPlan,
@@ -48,6 +51,24 @@ function installedProviderRecord(
     },
     compat: [],
   };
+}
+
+function attachPreparedPluginFacts(
+  pluginRegistry: ReturnType<typeof createEmptyPluginRegistry>,
+  config: OpenClawConfig,
+  manifestRegistry: ReturnType<typeof makeRegistry>,
+) {
+  prepareOwnedPluginLoadContext(
+    {
+      config,
+      workspaceDir: "/tmp/workspace",
+      loadRuntimePlugins: true,
+      runtimePluginSelections: [],
+    },
+    {},
+    pluginRegistry,
+    createPluginMetadataSnapshot({ config, manifestRegistry }),
+  );
 }
 
 vi.mock("../../plugins/providers.js", () => ({
@@ -97,18 +118,224 @@ describe("harness runtime plugins", () => {
     expect(pluginRegistry.agentHarnesses).toHaveLength(1);
   });
 
-  it("explains how to recover when the selected harness registration is missing", async () => {
+  it("carries the missing Codex owner reason and remediation into the turn guard", async () => {
+    const pluginRegistry = createEmptyPluginRegistry();
+    attachPreparedPluginFacts(pluginRegistry, {}, makeRegistry([]));
+
+    const error = await ensureSelectedAgentHarnessPlugin({
+      provider: "openai",
+      modelId: "gpt-5.5",
+      agentHarnessRuntimeOverride: "codex",
+      workspaceDir: "/tmp/workspace",
+      pluginRegistry,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(
+      "(reason=owner-plugin-not-activatable, ownerPluginId=codex)",
+    );
+    expect((error as Error).message).toContain(
+      'Owner plugin "codex" is absent from this prepared plugin generation.',
+    );
+    expect((error as Error).message).toContain('Run "openclaw doctor --fix"');
+  });
+
+  it("reports a manifest owner's restrictive allowlist blocker", async () => {
+    const pluginRegistry = createEmptyPluginRegistry();
+    const config = { plugins: { allow: ["telegram"] } } satisfies OpenClawConfig;
+    attachPreparedPluginFacts(
+      pluginRegistry,
+      config,
+      makeRegistry([
+        {
+          id: "custom-owner",
+          channels: [],
+          activation: { onAgentHarnesses: ["custom-harness"] },
+        },
+      ]),
+    );
+
+    const error = await ensureSelectedAgentHarnessPlugin({
+      provider: "custom-provider",
+      modelId: "custom-model",
+      agentHarnessRuntimeOverride: "custom-harness",
+      workspaceDir: "/tmp/workspace",
+      pluginRegistry,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("ownerPluginId=custom-owner");
+    expect((error as Error).message).toContain(
+      'Owner plugin "custom-owner" is not activatable (not in allowlist)',
+    );
+  });
+
+  it("reports global plugin disablement before a selected Codex owner's absence", async () => {
+    const pluginRegistry = createEmptyPluginRegistry();
+    const config = { plugins: { enabled: false } } satisfies OpenClawConfig;
+    attachPreparedPluginFacts(pluginRegistry, config, makeRegistry([]));
+
+    const error = await ensureSelectedAgentHarnessPlugin({
+      provider: "openai",
+      modelId: "gpt-5.5",
+      agentHarnessRuntimeOverride: "codex",
+      workspaceDir: "/tmp/workspace",
+      pluginRegistry,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("ownerPluginId=codex");
+    expect((error as Error).message).toContain(
+      'Owner plugin "codex" is not activatable (plugins disabled)',
+    );
+    expect((error as Error).message).not.toContain("absent from this prepared plugin generation");
+    // The first chat error uses the Gateway's bounded formatter, before the full reply arrives.
+    expect(formatForLog((error as Error).message)).toContain('Run "openclaw doctor --fix"');
+  });
+
+  it("reports the prepared owner's loader failure before activation policy", async () => {
+    const pluginRegistry = createEmptyPluginRegistry();
+    const config = { plugins: { allow: ["telegram"] } } satisfies OpenClawConfig;
+    attachPreparedPluginFacts(
+      pluginRegistry,
+      config,
+      makeRegistry([
+        {
+          id: "custom-owner",
+          channels: [],
+          activation: { onAgentHarnesses: ["custom-harness"] },
+        },
+      ]),
+    );
+    pluginRegistry.plugins.push(
+      createPluginRecord({
+        id: "custom-owner",
+        status: "error",
+        failurePhase: "register",
+        error: "registration exploded",
+      }),
+    );
+
+    const error = await ensureSelectedAgentHarnessPlugin({
+      provider: "custom-provider",
+      modelId: "custom-model",
+      agentHarnessRuntimeOverride: "custom-harness",
+      workspaceDir: "/tmp/workspace",
+      pluginRegistry,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(
+      "(reason=owner-plugin-degraded, ownerPluginId=custom-owner)",
+    );
+    expect((error as Error).message).toContain(
+      'Owner plugin "custom-owner" failed during register.',
+    );
+    expect((error as Error).message).toContain(
+      'Run "openclaw plugins inspect custom-owner --runtime --json"',
+    );
+    expect((error as Error).message).not.toContain("not in allowlist");
+    expect((error as Error).message).not.toContain("registration exploded");
+    expect(formatForLog((error as Error).message)).toContain(
+      'Run "openclaw plugins inspect custom-owner --runtime --json"',
+    );
+  });
+
+  it("reports a loaded owner that omitted the selected harness registration", async () => {
+    const pluginRegistry = createEmptyPluginRegistry();
+    const config = { plugins: { allow: ["telegram"] } } satisfies OpenClawConfig;
+    attachPreparedPluginFacts(
+      pluginRegistry,
+      config,
+      makeRegistry([
+        {
+          id: "custom-owner",
+          channels: [],
+          activation: { onAgentHarnesses: ["custom-harness"] },
+        },
+      ]),
+    );
+    pluginRegistry.plugins.push(createPluginRecord({ id: "custom-owner", status: "loaded" }));
+
+    const error = await ensureSelectedAgentHarnessPlugin({
+      provider: "custom-provider",
+      modelId: "custom-model",
+      agentHarnessRuntimeOverride: "custom-harness",
+      workspaceDir: "/tmp/workspace",
+      pluginRegistry,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(
+      "(reason=owner-plugin-degraded, ownerPluginId=custom-owner)",
+    );
+    expect((error as Error).message).toContain(
+      'Owner plugin "custom-owner" loaded but did not register agent harness "custom-harness".',
+    );
+    expect((error as Error).message).not.toContain("not in allowlist");
+    expect(formatForLog((error as Error).message)).toContain(
+      'Run "openclaw plugins inspect custom-owner --runtime --json"',
+    );
+  });
+
+  it("reports an activated owner missing from the prepared registry as degraded", async () => {
+    const pluginRegistry = createEmptyPluginRegistry();
+    attachPreparedPluginFacts(
+      pluginRegistry,
+      {},
+      makeRegistry([
+        {
+          id: "custom-owner",
+          channels: [],
+          activation: { onAgentHarnesses: ["custom-harness"] },
+        },
+      ]),
+    );
+
+    const error = await ensureSelectedAgentHarnessPlugin({
+      provider: "custom-provider",
+      modelId: "custom-model",
+      agentHarnessRuntimeOverride: "custom-harness",
+      workspaceDir: "/tmp/workspace",
+      pluginRegistry,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(
+      "(reason=owner-plugin-degraded, ownerPluginId=custom-owner)",
+    );
+    expect((error as Error).message).toContain("The owner plugin did not register.");
+  });
+
+  it("gives an unknown harness without owner metadata a stable reason", async () => {
+    const error = await ensureSelectedAgentHarnessPlugin({
+      provider: "custom-provider",
+      modelId: "custom-model",
+      agentHarnessRuntimeOverride: "unknown-harness",
+      workspaceDir: "/tmp/workspace",
+      pluginRegistry: undefined,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("(reason=owner-plugin-not-activatable)");
+    expect((error as Error).message).toContain(
+      "Enable or reinstall the plugin that provides this runtime",
+    );
+  });
+
+  it("keeps the built-in OpenClaw harness independent from plugin registration", async () => {
+    const pluginRegistry = createEmptyPluginRegistry();
+    attachPreparedPluginFacts(pluginRegistry, { plugins: { enabled: false } }, makeRegistry([]));
+
     await expect(
       ensureSelectedAgentHarnessPlugin({
         provider: "openai",
         modelId: "gpt-5.5",
-        agentHarnessRuntimeOverride: "codex",
+        agentHarnessRuntimeOverride: "openclaw",
         workspaceDir: "/tmp/workspace",
-        pluginRegistry: createEmptyPluginRegistry(),
+        pluginRegistry,
       }),
-    ).rejects.toThrow(
-      'Agent harness runtime "codex" is unavailable because its plugin registration is missing from this prepared run. Enable or reinstall the plugin that provides this runtime, restart the Gateway, then retry.',
-    );
+    ).resolves.toBeUndefined();
   });
 
   it("force-activates a default-disabled harness owner selected for a run", () => {

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -5,6 +5,7 @@ import {
   normalizePluginsConfig,
   resolveEffectivePluginActivationState,
 } from "../../plugins/config-state.js";
+import { isPluginEnabledByDefaultForPlatform } from "../../plugins/default-enablement.js";
 import type { PluginRegistry } from "../../plugins/registry-types.js";
 import {
   pluginInstallPathMatchesRoot,
@@ -43,8 +44,10 @@ type AgentHarnessRuntimePayloadFailure = {
 function describeMissingHarnessRegistration(
   runtime: string,
   pluginRegistry: PluginRegistry | undefined,
+  config: OpenClawConfig | undefined,
 ): string {
   const context = getPluginRuntimeLoadContext(pluginRegistry);
+  const activationSourceConfig = context?.activationSourceConfig ?? config;
   const manifestOwnerPluginIds =
     context?.metadataSnapshot?.plugins
       .filter((plugin) =>
@@ -61,10 +64,8 @@ function describeMissingHarnessRegistration(
           ? ["codex"]
           : [],
     ),
-  ]
-    .toSorted()
-    .slice(0, 3);
-  const plugins = normalizePluginsConfig(context?.activationSourceConfig.plugins);
+  ].toSorted();
+  const plugins = normalizePluginsConfig(activationSourceConfig?.plugins);
   if (ownerPluginIds.length === 0) {
     if (!plugins.enabled) {
       return `(reason=owner-plugin-not-activatable). Plugins are disabled, so no plugin can register agent harness "${runtime}". Enable plugins and the plugin that provides this runtime, restart the Gateway, then retry or select a model that does not require this runtime.`;
@@ -101,7 +102,8 @@ function describeMissingHarnessRegistration(
       id: pluginId,
       origin: plugin.origin,
       config: plugins,
-      rootConfig: context?.activationSourceConfig,
+      rootConfig: activationSourceConfig,
+      enabledByDefault: isPluginEnabledByDefaultForPlatform(plugin),
     });
     if (!activation.activated) {
       blockers.push(
@@ -111,11 +113,13 @@ function describeMissingHarnessRegistration(
   }
   const ownerField = ownerPluginIds.length === 1 ? "ownerPluginId" : "ownerPluginIds";
   const reason =
-    blockers.length > 0
+    blockers.length === ownerPluginIds.length
       ? "reason=owner-plugin-not-activatable, "
       : "reason=owner-plugin-degraded, ";
-  const detail = blockers.length > 0 ? blockers.join("; ") : "The owner plugin did not register";
-  return `(${reason}${ownerField}=${ownerPluginIds.join(",")}). Run "openclaw doctor --fix". ${detail}. Repair the plugin or select a model that does not require this runtime, restart the Gateway, then retry.`;
+  // Bound the rendered summary, not the owner set used to classify availability.
+  const detail =
+    blockers.length > 0 ? blockers.slice(0, 3).join("; ") : "The owner plugin did not register";
+  return `(${reason}${ownerField}=${ownerPluginIds.slice(0, 3).join(",")}). Run "openclaw doctor --fix". ${detail}. Repair the plugin or select a model that does not require this runtime, restart the Gateway, then retry.`;
 }
 
 /**
@@ -218,7 +222,7 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
 
   if (!params.pluginRegistry?.agentHarnesses.some((entry) => entry.harness.id === runtime)) {
     throw new Error(
-      `Agent harness runtime "${runtime}" is unavailable. ${describeMissingHarnessRegistration(runtime, params.pluginRegistry)}`,
+      `Agent harness runtime "${runtime}" is unavailable. ${describeMissingHarnessRegistration(runtime, params.pluginRegistry, params.config)}`,
     );
   }
 }

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -1,11 +1,16 @@
 /** Resolves the selected native harness from a run-owned plugin registry. */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRouteOverridePresence } from "../../plugin-sdk/provider-model-types.js";
+import {
+  normalizePluginsConfig,
+  resolveEffectivePluginActivationState,
+} from "../../plugins/config-state.js";
 import type { PluginRegistry } from "../../plugins/registry-types.js";
 import {
   pluginInstallPathMatchesRoot,
   type PluginVerificationFailureReason,
 } from "../../plugins/runtime-degraded-state.js";
+import { getPluginRuntimeLoadContext } from "../../plugins/runtime/load-context.js";
 import {
   isDefaultAgentRuntimeId,
   OPENCLAW_AGENT_RUNTIME_ID,
@@ -34,6 +39,84 @@ type AgentHarnessRuntimePayloadFailure = {
   installPath?: string;
   reason: PluginVerificationFailureReason;
 };
+
+function describeMissingHarnessRegistration(
+  runtime: string,
+  pluginRegistry: PluginRegistry | undefined,
+): string {
+  const context = getPluginRuntimeLoadContext(pluginRegistry);
+  const manifestOwnerPluginIds =
+    context?.metadataSnapshot?.plugins
+      .filter((plugin) =>
+        plugin.activation?.onAgentHarnesses?.some(
+          (candidate) => normalizeOptionalAgentRuntimeId(candidate) === runtime,
+        ),
+      )
+      .map((plugin) => plugin.id) ?? [];
+  const ownerPluginIds = [
+    ...new Set(
+      manifestOwnerPluginIds.length > 0
+        ? manifestOwnerPluginIds
+        : runtime === "codex"
+          ? ["codex"]
+          : [],
+    ),
+  ]
+    .toSorted()
+    .slice(0, 3);
+  const plugins = normalizePluginsConfig(context?.activationSourceConfig.plugins);
+  if (ownerPluginIds.length === 0) {
+    if (!plugins.enabled) {
+      return `(reason=owner-plugin-not-activatable). Plugins are disabled, so no plugin can register agent harness "${runtime}". Enable plugins and the plugin that provides this runtime, restart the Gateway, then retry or select a model that does not require this runtime.`;
+    }
+    return `(reason=owner-plugin-not-activatable). Enable or reinstall the plugin that provides this runtime, restart the Gateway, then retry.`;
+  }
+
+  const failedOwner = ownerPluginIds
+    .map((pluginId) => pluginRegistry?.plugins.find((plugin) => plugin.id === pluginId))
+    .find((plugin) => plugin?.status === "error");
+  if (failedOwner) {
+    const phase = failedOwner.failurePhase ?? "load";
+    return `(reason=owner-plugin-degraded, ownerPluginId=${failedOwner.id}). Run "openclaw plugins inspect ${failedOwner.id} --runtime --json". Owner plugin "${failedOwner.id}" failed during ${phase}. Repair the reported plugin failure, restart the Gateway, then retry or select a model that does not require this runtime.`;
+  }
+  const loadedOwner = ownerPluginIds
+    .map((pluginId) => pluginRegistry?.plugins.find((plugin) => plugin.id === pluginId))
+    .find((plugin) => plugin?.status === "loaded");
+  if (loadedOwner) {
+    return `(reason=owner-plugin-degraded, ownerPluginId=${loadedOwner.id}). Run "openclaw plugins inspect ${loadedOwner.id} --runtime --json". Owner plugin "${loadedOwner.id}" loaded but did not register agent harness "${runtime}". Repair the reported plugin failure, restart the Gateway, then retry or select a model that does not require this runtime.`;
+  }
+
+  const blockers: string[] = [];
+  for (const pluginId of ownerPluginIds) {
+    if (!plugins.enabled) {
+      blockers.push(`Owner plugin "${pluginId}" is not activatable (plugins disabled)`);
+      continue;
+    }
+    const plugin = context?.metadataSnapshot?.byPluginId.get(pluginId);
+    if (!plugin) {
+      blockers.push(`Owner plugin "${pluginId}" is absent from this prepared plugin generation`);
+      continue;
+    }
+    const activation = resolveEffectivePluginActivationState({
+      id: pluginId,
+      origin: plugin.origin,
+      config: plugins,
+      rootConfig: context?.activationSourceConfig,
+    });
+    if (!activation.activated) {
+      blockers.push(
+        `Owner plugin "${pluginId}" is not activatable${activation.reason ? ` (${activation.reason})` : ""}`,
+      );
+    }
+  }
+  const ownerField = ownerPluginIds.length === 1 ? "ownerPluginId" : "ownerPluginIds";
+  const reason =
+    blockers.length > 0
+      ? "reason=owner-plugin-not-activatable, "
+      : "reason=owner-plugin-degraded, ";
+  const detail = blockers.length > 0 ? blockers.join("; ") : "The owner plugin did not register";
+  return `(${reason}${ownerField}=${ownerPluginIds.join(",")}). Run "openclaw doctor --fix". ${detail}. Repair the plugin or select a model that does not require this runtime, restart the Gateway, then retry.`;
+}
 
 /**
  * Resolves whether manifest-owned harness code is loadable without importing it.
@@ -135,7 +218,7 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
 
   if (!params.pluginRegistry?.agentHarnesses.some((entry) => entry.harness.id === runtime)) {
     throw new Error(
-      `Agent harness runtime "${runtime}" is unavailable because its plugin registration is missing from this prepared run. Enable or reinstall the plugin that provides this runtime, restart the Gateway, then retry.`,
+      `Agent harness runtime "${runtime}" is unavailable. ${describeMissingHarnessRegistration(runtime, params.pluginRegistry)}`,
     );
   }
 }

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -406,6 +406,7 @@ describe("agent runtime plugin registries", () => {
       allowGatewaySubagentBinding: true,
     });
     const error = await ensureSelectedAgentHarnessPlugin({
+      config,
       provider: "openai",
       modelId: "gpt-5.5",
       agentHarnessRuntimeOverride: "codex",
@@ -415,7 +416,7 @@ describe("agent runtime plugin registries", () => {
 
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toContain("plugins disabled");
-    expect(getPluginRuntimeLoadContext(pluginRegistry)?.activationSourceConfig).toBe(config);
+    expect(pluginRegistry).toBe(cachedRegistry);
     expect(getPluginRuntimeLoadContext(cachedRegistry)).toBeUndefined();
     expect(hoisted.loadPluginMetadataSnapshot).not.toHaveBeenCalled();
   });

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -14,6 +14,7 @@ const hoisted = vi.hoisted(() => ({
   resolveAgentRuntimePluginSelections: vi.fn(
     (_config: unknown, selections: readonly unknown[]) => selections,
   ),
+  resolveAgentHarnessOwnerPluginIds: vi.fn(() => ["codex"]),
 }));
 
 vi.mock("../context-engine/registry.js", () => ({
@@ -44,17 +45,24 @@ vi.mock("../plugins/loader.js", () => ({
 }));
 
 vi.mock("./harness/runtime-plugin-load-plan.js", () => ({
+  resolveAgentHarnessOwnerPluginIds: hoisted.resolveAgentHarnessOwnerPluginIds,
   resolveAgentRuntimePluginLoadPlan: hoisted.resolveAgentRuntimePluginLoadPlan,
   resolveAgentRuntimePluginSelections: hoisted.resolveAgentRuntimePluginSelections,
 }));
 
-import { createPluginMetadataSnapshot } from "../config/plugin-auto-enable.test-helpers.js";
+import {
+  createPluginMetadataSnapshot,
+  makeRegistry,
+} from "../config/plugin-auto-enable.test-helpers.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   getPluginRuntimeGatewayRequestScope,
   withPluginRuntimeRegistryScope,
 } from "../plugins/runtime/gateway-request-scope.js";
+import { getPluginRuntimeLoadContext } from "../plugins/runtime/load-context.js";
 import { createPluginRecord } from "../plugins/status.test-helpers.js";
+import { ensureSelectedAgentHarnessPlugin } from "./harness/runtime-plugin.js";
 import {
   createPreparedInboundRegistryLoader,
   prepareWorkspacePluginRegistries,
@@ -502,7 +510,7 @@ describe("agent runtime plugin registries", () => {
 
   it("owns a scoped registry for direct hosts", async () => {
     const config = {} as never;
-    const pluginRegistry = { handle: true } as never;
+    const pluginRegistry = createEmptyPluginRegistry();
     hoisted.loadPluginRegistryHandle.mockReturnValue(pluginRegistry);
 
     await expect(
@@ -514,6 +522,10 @@ describe("agent runtime plugin registries", () => {
     ).resolves.toBe(pluginRegistry);
 
     expect(getPluginRuntimeGatewayRequestScope()).toBeUndefined();
+    expect(getPluginRuntimeLoadContext(pluginRegistry)).toMatchObject({
+      activationSourceConfig: config,
+      metadataSnapshot: expect.any(Object),
+    });
     expect(hoisted.resolveAgentRuntimePluginLoadPlan).toHaveBeenCalledWith({
       config,
       workspaceDir: "/tmp/workspace",
@@ -521,6 +533,113 @@ describe("agent runtime plugin registries", () => {
       selections: [],
       metadataSnapshot: expect.any(Object),
     });
+  });
+
+  it.each([
+    {
+      name: "globally disabled plugins",
+      config: { plugins: { enabled: false } } satisfies OpenClawConfig,
+      runtime: "codex",
+      expectedOwner: 'Owner plugin "codex" is not activatable',
+      expectedReason: "plugins disabled",
+      expectedMetadataLoads: 0,
+    },
+    {
+      name: "globally disabled plugins with an unknown owner",
+      config: { plugins: { enabled: false } } satisfies OpenClawConfig,
+      runtime: "custom-harness",
+      expectedOwner: "no plugin can register agent harness",
+      expectedReason: "Plugins are disabled",
+      expectedMetadataLoads: 0,
+    },
+    {
+      name: "a restrictive allowlist",
+      config: {
+        plugins: { allow: ["openai", "memory-core"] },
+      } satisfies OpenClawConfig,
+      runtime: "codex",
+      expectedOwner: 'Owner plugin "codex" is not activatable',
+      expectedReason: "not in allowlist",
+      expectedMetadataLoads: 1,
+    },
+  ])(
+    "reports exact policy facts for direct hosts with $name",
+    async ({ config, runtime, expectedOwner, expectedReason, expectedMetadataLoads }) => {
+      const pluginRegistry = createEmptyPluginRegistry();
+      hoisted.loadPluginRegistryHandle.mockReturnValue(pluginRegistry);
+      if (config.plugins.enabled !== false) {
+        hoisted.loadPluginMetadataSnapshot.mockReturnValue(
+          createPluginMetadataSnapshot({
+            config,
+            workspaceDir: "/tmp/workspace",
+            manifestRegistry: makeRegistry([
+              {
+                id: "codex",
+                channels: [],
+                activation: { onAgentHarnesses: ["codex"] },
+                origin: "bundled",
+              },
+            ]),
+          }),
+        );
+      }
+
+      const error = await withAgentPluginRegistry({
+        config,
+        workspaceDir: "/tmp/workspace",
+        run: async () => {
+          await ensureSelectedAgentHarnessPlugin({
+            provider: "openai",
+            modelId: "gpt-5.5",
+            config,
+            agentHarnessRuntimeOverride: runtime,
+            workspaceDir: "/tmp/workspace",
+            pluginRegistry: getPluginRuntimeGatewayRequestScope()?.pluginRegistry,
+          });
+        },
+      }).catch((cause: unknown) => cause);
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain(expectedOwner);
+      expect((error as Error).message).toContain(expectedReason);
+      expect((error as Error).message).toContain("reason=owner-plugin-not-activatable");
+      expect((error as Error).message).not.toContain("absent from this prepared plugin generation");
+      expect(hoisted.loadPluginMetadataSnapshot).toHaveBeenCalledTimes(expectedMetadataLoads);
+    },
+  );
+
+  it("retains loaded request plugins when preparing a selected usage harness", async () => {
+    const gatewayRegistry = createEmptyPluginRegistry();
+    gatewayRegistry.plugins.push(
+      createPluginRecord({ id: "request-provider" }),
+      createPluginRecord({ id: "deferred", format: "openclaw", imported: false }),
+    );
+    hoisted.resolveAgentRuntimePluginLoadPlan.mockImplementation(({ config, basePluginIds }) => ({
+      config,
+      pluginIds: [...(basePluginIds ?? []), "selected-harness"],
+    }));
+    hoisted.loadPluginRegistryHandle.mockImplementation(({ onlyPluginIds }) => ({
+      ...createEmptyPluginRegistry(),
+      plugins: onlyPluginIds.map((id: string) => createPluginRecord({ id })),
+    }));
+
+    const loaded = await withPluginRuntimeRegistryScope(gatewayRegistry, () =>
+      withAgentPluginRegistry({
+        config: {},
+        workspaceDir: "/tmp/workspace",
+        selections: [{ provider: "selected-provider", modelId: "", runtime: "selected-harness" }],
+        run: async () => getPluginRuntimeGatewayRequestScope()?.pluginRegistry,
+      }),
+    );
+
+    expect(loaded?.plugins.map((plugin) => plugin.id)).toEqual([
+      "request-provider",
+      "selected-harness",
+    ]);
+    expect(gatewayRegistry.plugins.map((plugin) => plugin.id)).toEqual([
+      "request-provider",
+      "deferred",
+    ]);
   });
 
   it("reuses an existing gateway registry owner", async () => {

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -396,6 +396,30 @@ describe("agent runtime plugin registries", () => {
     });
   });
 
+  it("carries low-level reply policy without rebinding the loader's cached registry", async () => {
+    const config = { plugins: { enabled: false } } satisfies OpenClawConfig;
+    const cachedRegistry = createEmptyPluginRegistry();
+    hoisted.loadPluginRegistryHandle.mockReturnValue(cachedRegistry);
+    const pluginRegistry = loadAgentRuntimePluginRegistryHandle({
+      config,
+      workspaceDir: "/tmp/workspace",
+      allowGatewaySubagentBinding: true,
+    });
+    const error = await ensureSelectedAgentHarnessPlugin({
+      provider: "openai",
+      modelId: "gpt-5.5",
+      agentHarnessRuntimeOverride: "codex",
+      workspaceDir: "/tmp/workspace",
+      pluginRegistry,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("plugins disabled");
+    expect(getPluginRuntimeLoadContext(pluginRegistry)?.activationSourceConfig).toBe(config);
+    expect(getPluginRuntimeLoadContext(cachedRegistry)).toBeUndefined();
+    expect(hoisted.loadPluginMetadataSnapshot).not.toHaveBeenCalled();
+  });
+
   it("keeps an explicit metadata generation source-default without Gateway selection", () => {
     const config = {} as never;
     const metadataSnapshot = createMetadataSnapshot();

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -1,4 +1,3 @@
-import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { adoptRuntimeContextEngineRegistrations } from "../context-engine/registry.js";
 import {
@@ -7,7 +6,7 @@ import {
   registryContainsRuntimePluginIds,
 } from "../plugins/active-runtime-registry.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "../plugins/installed-plugin-index-install-records.js";
-import { loadPluginRegistryHandle } from "../plugins/loader.js";
+import { loadPluginRegistryHandle, type PluginLoadOptions } from "../plugins/loader.js";
 import { adoptRuntimeMemoryRegistrations } from "../plugins/memory-state.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
@@ -20,8 +19,6 @@ import {
   getPluginRuntimeGatewayRequestScope,
   withPluginRuntimeRegistryScope,
 } from "../plugins/runtime/gateway-request-scope.js";
-import { setPluginRuntimeLoadContext } from "../plugins/runtime/load-context.js";
-import { resolvePluginRuntimeLoadContext } from "../plugins/runtime/load-context.resolve.js";
 import { adoptRuntimeWidgetPresenterRegistrations } from "../plugins/widget-presenters.js";
 import { resolveUserPath } from "../utils.js";
 import {
@@ -45,76 +42,59 @@ type AgentRuntimePluginRegistryParams = {
   metadataSnapshot?: PluginMetadataSnapshot;
 };
 
-function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistryParams) {
-  const requestedWorkspaceDir =
-    typeof params.workspaceDir === "string" && params.workspaceDir.trim()
-      ? resolveUserPath(params.workspaceDir)
-      : undefined;
+function resolveAgentRuntimePluginRegistryLoad(
+  params: AgentRuntimePluginRegistryParams,
+): PluginLoadOptions {
+  const loadOptions: PluginLoadOptions = {
+    config: params.config,
+    activationSourceConfig: params.config,
+    env: params.env,
+    workspaceDir:
+      typeof params.workspaceDir === "string" && params.workspaceDir.trim()
+        ? resolveUserPath(params.workspaceDir)
+        : undefined,
+    runtimeOptions: params.allowGatewaySubagentBinding
+      ? { allowGatewaySubagentBinding: true }
+      : undefined,
+  };
   if (params.config?.plugins?.enabled === false) {
-    return {
-      loadOptions: {
-        config: params.config,
-        activationSourceConfig: params.config,
-        ...(params.env ? { env: params.env } : {}),
-        workspaceDir: requestedWorkspaceDir,
-        onlyPluginIds: [],
-        runtimeOptions: params.allowGatewaySubagentBinding
-          ? { allowGatewaySubagentBinding: true }
-          : undefined,
-      },
-    };
+    return { ...loadOptions, onlyPluginIds: [] };
   }
   const metadataSnapshot =
     params.metadataSnapshot ??
     loadPluginMetadataSnapshot({
       config: params.config ?? {},
       env: params.env ?? process.env,
-      ...(requestedWorkspaceDir ? { workspaceDir: requestedWorkspaceDir } : {}),
+      workspaceDir: loadOptions.workspaceDir,
     });
-  const workspaceDir = metadataSnapshot.workspaceDir ?? requestedWorkspaceDir;
-  const metadataLoadOptions = {
-    ...(metadataSnapshot.discovery ? { discovery: metadataSnapshot.discovery } : {}),
-    installRecords: extractPluginInstallRecordsFromInstalledPluginIndex(metadataSnapshot.index),
-    manifestRegistry: metadataSnapshot.manifestRegistry,
-    ...(params.preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
-    ...(workspaceDir ? { workspaceDir } : {}),
-  };
+  const workspaceDir = metadataSnapshot.workspaceDir ?? loadOptions.workspaceDir;
   const requestPluginRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
   // Gateway-hosted fall-through must not cold-load every plugin (30-45s event-loop convoy);
   // startup runtime plugin ids plus selected run owners bound the registry scope.
   const activePluginIds = listLoadedRuntimePluginIds();
   const startupPluginIds =
-    params.basePluginIds !== undefined
-      ? [...params.basePluginIds]
-      : requestPluginRegistry
-        ? listRuntimePluginIdsFromRegistry(requestPluginRegistry)
-        : metadataSnapshot.pluginIds
-          ? [...metadataSnapshot.pluginIds]
-          : activePluginIds.length > 0
-            ? activePluginIds
-            : undefined;
-  const planParams = {
+    params.basePluginIds ??
+    (requestPluginRegistry
+      ? listRuntimePluginIdsFromRegistry(requestPluginRegistry)
+      : (metadataSnapshot.pluginIds ?? (activePluginIds.length > 0 ? activePluginIds : undefined)));
+  const plan = resolveAgentRuntimePluginLoadPlan({
     config: params.config,
     workspaceDir: workspaceDir ?? process.cwd(),
-    ...(startupPluginIds === undefined ? {} : { basePluginIds: startupPluginIds }),
+    basePluginIds: startupPluginIds,
     selections: resolveAgentRuntimePluginSelections(params.config, params.selections ?? []),
     metadataSnapshot,
-  };
-  const plan = resolveAgentRuntimePluginLoadPlan(planParams);
+  });
   return {
-    loadOptions: {
-      config: plan.config,
-      ...(plan.config ? { activationSourceConfig: plan.config } : {}),
-      ...(params.env ? { env: params.env } : {}),
-      ...metadataLoadOptions,
-      ...(startupPluginIds === undefined || plan.pluginIds === undefined
-        ? {}
-        : { onlyPluginIds: plan.pluginIds }),
-      ...(startupPluginIds === undefined ? {} : { channelPluginLoadIntent: "full" as const }),
-      runtimeOptions: params.allowGatewaySubagentBinding
-        ? { allowGatewaySubagentBinding: true }
-        : undefined,
-    },
+    ...loadOptions,
+    config: plan.config,
+    activationSourceConfig: plan.config,
+    workspaceDir,
+    discovery: metadataSnapshot.discovery,
+    installRecords: extractPluginInstallRecordsFromInstalledPluginIndex(metadataSnapshot.index),
+    manifestRegistry: metadataSnapshot.manifestRegistry,
+    preferBuiltPluginArtifacts: params.preferBuiltPluginArtifacts,
+    onlyPluginIds: startupPluginIds === undefined ? undefined : plan.pluginIds,
+    channelPluginLoadIntent: startupPluginIds === undefined ? undefined : "full",
   };
 }
 
@@ -122,17 +102,17 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
 export function loadAgentRuntimePluginRegistryHandle(
   params: AgentRuntimePluginRegistryParams,
 ): PluginRegistry {
-  const load = resolveAgentRuntimePluginRegistryLoad(params);
+  const loadOptions = resolveAgentRuntimePluginRegistryLoad(params);
   if (
     params.reusableRegistry &&
-    load.loadOptions.onlyPluginIds !== undefined &&
-    registryContainsRuntimePluginIds(params.reusableRegistry, load.loadOptions.onlyPluginIds)
+    loadOptions.onlyPluginIds !== undefined &&
+    registryContainsRuntimePluginIds(params.reusableRegistry, loadOptions.onlyPluginIds)
   ) {
     return params.reusableRegistry;
   }
   // Discovery-only load: full mode can replace process-global sandbox backends.
   // Adopt full-only runtime capabilities from the matching composition-root owners.
-  const pluginRegistry = loadPluginRegistryHandle({ ...load.loadOptions, activate: false });
+  const pluginRegistry = loadPluginRegistryHandle({ ...loadOptions, activate: false });
   const activeRegistry = getActivePluginRegistry();
   if (!activeRegistry) {
     return pluginRegistry;
@@ -155,54 +135,38 @@ export async function withAgentPluginRegistry<T>(params: {
   if (requestPluginRegistry && params.selections === undefined) {
     return await params.run(requestPluginRegistry);
   }
-  const env = params.env ?? process.env;
-  const metadataSnapshot =
-    params.config.plugins?.enabled !== false
-      ? loadPluginMetadataSnapshot({
-          config: params.config,
-          env,
-          workspaceDir: params.workspaceDir,
-        })
-      : undefined;
+  // Borrowed Gateway registries must not load direct-host context dependencies.
+  const [{ setPluginRuntimeLoadContext }, { resolvePluginRuntimeLoadContext }] = await Promise.all([
+    import("../plugins/runtime/load-context.js"),
+    import("../plugins/runtime/load-context.resolve.js"),
+  ]);
+  // Direct hosts resolve one policy generation; disabled plugins never reopen discovery.
+  const context = resolvePluginRuntimeLoadContext({
+    config: params.config,
+    activationSourceConfig: params.config,
+    env: params.env,
+    workspaceDir: params.workspaceDir,
+    ...(params.config.plugins?.enabled === false
+      ? { manifestRegistry: { plugins: [], diagnostics: [] } }
+      : { metadataSnapshot: loadPluginMetadataSnapshot(params) }),
+  });
   const pluginRegistry = loadAgentRuntimePluginRegistryHandle({
     basePluginIds: requestPluginRegistry
       ? listRuntimePluginIdsFromRegistry(requestPluginRegistry)
       : [],
     config: params.config,
-    env,
-    ...(metadataSnapshot ? { metadataSnapshot } : {}),
-    ...(params.selections ? { selections: params.selections } : {}),
+    env: context.env,
+    metadataSnapshot: context.metadataSnapshot,
+    selections: params.selections,
     workspaceDir: params.workspaceDir,
   });
   const activeRegistry = getActivePluginRegistry();
   const scopedRegistry =
     activeRegistry &&
-    metadataSnapshot &&
+    context.metadataSnapshot &&
     getActivePluginRegistryWorkspaceDir() === resolveUserPath(params.workspaceDir)
-      ? adoptRuntimeMemoryRegistrations(
-          pluginRegistry,
-          activeRegistry,
-          applyPluginAutoEnable({
-            config: params.config,
-            env,
-            discovery: metadataSnapshot.discovery,
-            manifestRegistry: metadataSnapshot.manifestRegistry,
-          }).config,
-        )
+      ? adoptRuntimeMemoryRegistrations(pluginRegistry, activeRegistry, context.config)
       : pluginRegistry;
-  // Direct hosts own this prepared registry, so turn guards read its exact policy generation.
-  // Disabled plugins carry empty manifest facts instead of reopening discovery for diagnostics.
-  setPluginRuntimeLoadContext(
-    scopedRegistry,
-    resolvePluginRuntimeLoadContext({
-      config: params.config,
-      activationSourceConfig: params.config,
-      env,
-      workspaceDir: params.workspaceDir,
-      ...(metadataSnapshot
-        ? { metadataSnapshot }
-        : { manifestRegistry: { plugins: [], diagnostics: [] } }),
-    }),
-  );
+  setPluginRuntimeLoadContext(scopedRegistry, context);
   return await withPluginRuntimeRegistryScope(scopedRegistry, () => params.run(scopedRegistry));
 }

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -20,6 +20,8 @@ import {
   getPluginRuntimeGatewayRequestScope,
   withPluginRuntimeRegistryScope,
 } from "../plugins/runtime/gateway-request-scope.js";
+import { setPluginRuntimeLoadContext } from "../plugins/runtime/load-context.js";
+import { resolvePluginRuntimeLoadContext } from "../plugins/runtime/load-context.resolve.js";
 import { adoptRuntimeWidgetPresenterRegistrations } from "../plugins/widget-presenters.js";
 import { resolveUserPath } from "../utils.js";
 import {
@@ -144,24 +146,32 @@ export function loadAgentRuntimePluginRegistryHandle(
 /** Binds a scoped plugin generation when a direct host has no Gateway owner. */
 export async function withAgentPluginRegistry<T>(params: {
   config: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  selections?: readonly AgentHarnessPluginSelection[];
   workspaceDir: string;
-  run: () => Promise<T>;
+  run: (pluginRegistry: PluginRegistry) => Promise<T>;
 }): Promise<T> {
-  if (getPluginRuntimeGatewayRequestScope()?.pluginRegistry) {
-    return await params.run();
+  const requestPluginRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+  if (requestPluginRegistry && params.selections === undefined) {
+    return await params.run(requestPluginRegistry);
   }
+  const env = params.env ?? process.env;
   const metadataSnapshot =
     params.config.plugins?.enabled !== false
       ? loadPluginMetadataSnapshot({
           config: params.config,
-          env: process.env,
+          env,
           workspaceDir: params.workspaceDir,
         })
       : undefined;
   const pluginRegistry = loadAgentRuntimePluginRegistryHandle({
-    basePluginIds: [],
+    basePluginIds: requestPluginRegistry
+      ? listRuntimePluginIdsFromRegistry(requestPluginRegistry)
+      : [],
     config: params.config,
+    env,
     ...(metadataSnapshot ? { metadataSnapshot } : {}),
+    ...(params.selections ? { selections: params.selections } : {}),
     workspaceDir: params.workspaceDir,
   });
   const activeRegistry = getActivePluginRegistry();
@@ -174,11 +184,25 @@ export async function withAgentPluginRegistry<T>(params: {
           activeRegistry,
           applyPluginAutoEnable({
             config: params.config,
-            env: process.env,
+            env,
             discovery: metadataSnapshot.discovery,
             manifestRegistry: metadataSnapshot.manifestRegistry,
           }).config,
         )
       : pluginRegistry;
-  return await withPluginRuntimeRegistryScope(scopedRegistry, params.run);
+  // Direct hosts own this prepared registry, so turn guards read its exact policy generation.
+  // Disabled plugins carry empty manifest facts instead of reopening discovery for diagnostics.
+  setPluginRuntimeLoadContext(
+    scopedRegistry,
+    resolvePluginRuntimeLoadContext({
+      config: params.config,
+      activationSourceConfig: params.config,
+      env,
+      workspaceDir: params.workspaceDir,
+      ...(metadataSnapshot
+        ? { metadataSnapshot }
+        : { manifestRegistry: { plugins: [], diagnostics: [] } }),
+    }),
+  );
+  return await withPluginRuntimeRegistryScope(scopedRegistry, () => params.run(scopedRegistry));
 }

--- a/src/gateway/server.sessions.agent-model-catalog.test.ts
+++ b/src/gateway/server.sessions.agent-model-catalog.test.ts
@@ -247,9 +247,11 @@ describe.each(["sessions.create", "sessions.patch"] as const)("%s", (method) => 
       });
     }
     const before = loadSessionEntry(access);
-    const { readConfigFileSnapshot } = await getGatewayConfigModule();
+    const configModule = await getGatewayConfigModule();
+    const { readConfigFileSnapshot } = configModule;
     const beforeConfig = await readConfigFileSnapshot();
     const loadGatewayModelCatalog = createAgentModelCatalogLoader();
+    const configMutations = vi.spyOn(configModule, "mutateConfigFileWithRetry");
     const result = await directSessionReq<{ entry?: SessionEntry }>(
       method,
       {
@@ -262,7 +264,16 @@ describe.each(["sessions.create", "sessions.patch"] as const)("%s", (method) => 
         context: { loadGatewayModelCatalog },
         ...(scenario.error ? { client: { connect: { scopes: ["operator.admin"] } } as never } : {}),
       },
-    );
+    ).finally(async () => {
+      // Admin patches persist defaults in the background; join their writes before
+      // the shared config fixture resets for the next case.
+      await Promise.allSettled(
+        configMutations.mock.results
+          .filter((result) => result.type === "return")
+          .map((result) => result.value),
+      );
+      configMutations.mockRestore();
+    });
 
     expect(loadGatewayModelCatalog).toHaveBeenCalledWith({ agentId: "work" });
     if (fixture) {

--- a/src/gateway/server.sessions.agent-model-catalog.test.ts
+++ b/src/gateway/server.sessions.agent-model-catalog.test.ts
@@ -252,28 +252,33 @@ describe.each(["sessions.create", "sessions.patch"] as const)("%s", (method) => 
     const beforeConfig = await readConfigFileSnapshot();
     const loadGatewayModelCatalog = createAgentModelCatalogLoader();
     const configMutations = vi.spyOn(configModule, "mutateConfigFileWithRetry");
-    const result = await directSessionReq<{ entry?: SessionEntry }>(
-      method,
-      {
-        key,
-        ...(scenario.explicitAgent ? { agentId: "work" } : {}),
-        model: scenario.model,
-        label: "Updated label",
-      },
-      {
-        context: { loadGatewayModelCatalog },
-        ...(scenario.error ? { client: { connect: { scopes: ["operator.admin"] } } as never } : {}),
-      },
-    ).finally(async () => {
+    let result: Awaited<ReturnType<typeof directSessionReq<{ entry?: SessionEntry }>>>;
+    try {
+      result = await directSessionReq<{ entry?: SessionEntry }>(
+        method,
+        {
+          key,
+          ...(scenario.explicitAgent ? { agentId: "work" } : {}),
+          model: scenario.model,
+          label: "Updated label",
+        },
+        {
+          context: { loadGatewayModelCatalog },
+          ...(scenario.error
+            ? { client: { connect: { scopes: ["operator.admin"] } } as never }
+            : {}),
+        },
+      );
+    } finally {
       // Admin patches persist defaults in the background; join their writes before
       // the shared config fixture resets for the next case.
       await Promise.allSettled(
         configMutations.mock.results
-          .filter((result) => result.type === "return")
-          .map((result) => result.value),
+          .filter((mutation) => mutation.type === "return")
+          .map((mutation) => mutation.value),
       );
       configMutations.mockRestore();
-    });
+    }
 
     expect(loadGatewayModelCatalog).toHaveBeenCalledWith({ agentId: "work" });
     if (fixture) {

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -57,7 +57,6 @@ import {
   resolveUsageHookProviderPluginContracts,
 } from "./providers.js";
 import { getActivePluginRegistryWorkspaceDirFromState } from "./runtime-state.js";
-import { withPluginRuntimeRegistryScope } from "./runtime/gateway-request-scope.js";
 import { resolveRuntimeTextTransforms } from "./text-transforms.runtime.js";
 import type {
   ProviderAuthDoctorHintContext,
@@ -668,26 +667,27 @@ export async function resolveProviderUsageSnapshotWithPlugin(params: {
   if (!harness) {
     const workspaceDir =
       params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState() ?? process.cwd();
-    const { loadAgentRuntimePluginRegistryHandle } = await import("../agents/runtime-plugins.js");
+    const { withAgentPluginRegistry } = await import("../agents/runtime-plugins.js");
     const { ensureSelectedAgentHarnessPlugin } =
       await import("../agents/harness/runtime-plugin.js");
-    const pluginRegistry = loadAgentRuntimePluginRegistryHandle({
-      config: params.config,
-      workspaceDir,
+    return await withAgentPluginRegistry({
+      config: params.config ?? {},
+      ...(params.env ? { env: params.env } : {}),
       selections: [{ provider: params.context.provider, modelId: "", runtime: params.provider }],
-    });
-    return await withPluginRuntimeRegistryScope(pluginRegistry, async () => {
-      await ensureSelectedAgentHarnessPlugin({
-        provider: params.context.provider,
-        modelId: "",
-        config: params.config,
-        agentHarnessId: params.provider,
-        workspaceDir,
-        pluginRegistry,
-      });
-      return await getRegisteredAgentHarness(params.provider)?.harness.fetchUsageSnapshot?.(
-        params.context,
-      );
+      workspaceDir,
+      run: async (pluginRegistry) => {
+        await ensureSelectedAgentHarnessPlugin({
+          provider: params.context.provider,
+          modelId: "",
+          config: params.config,
+          agentHarnessId: params.provider,
+          workspaceDir,
+          pluginRegistry,
+        });
+        return await getRegisteredAgentHarness(params.provider)?.harness.fetchUsageSnapshot?.(
+          params.context,
+        );
+      },
     });
   }
   return await harness?.fetchUsageSnapshot?.(params.context);

--- a/src/plugins/provider-runtime.usage-harness.test.ts
+++ b/src/plugins/provider-runtime.usage-harness.test.ts
@@ -1,75 +1,162 @@
 // Verifies provider usage can be contributed by a runtime harness without a text provider.
+import fs from "node:fs";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearAgentHarnesses, registerAgentHarness } from "../agents/harness/registry.js";
+import {
+  makeIsolatedEnv,
+  makeTempDir,
+  resetPluginAutoEnableTestState,
+} from "../config/plugin-auto-enable.test-helpers.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveProviderUsageSnapshotWithPlugin } from "./provider-runtime.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
-import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
-
-const mocks = vi.hoisted(() => ({
-  ensureSelectedAgentHarnessPlugin: vi.fn(),
-  loadAgentRuntimePluginRegistryHandle: vi.fn(),
-}));
-
-vi.mock("../agents/runtime-plugins.js", () => ({
-  loadAgentRuntimePluginRegistryHandle: mocks.loadAgentRuntimePluginRegistryHandle,
-}));
-
-vi.mock("../agents/harness/runtime-plugin.js", () => ({
-  ensureSelectedAgentHarnessPlugin: mocks.ensureSelectedAgentHarnessPlugin,
-}));
+import { withPluginRuntimeRegistryScope } from "./runtime/gateway-request-scope.js";
 
 vi.mock("./provider-hook-runtime.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./provider-hook-runtime.js")>();
   return { ...actual, resolveProviderRuntimePlugin: () => undefined };
 });
 
+function makeCodexManifestEnv(): NodeJS.ProcessEnv {
+  const bundledPluginsDir = path.join(makeTempDir(), "extensions");
+  const pluginDir = path.join(bundledPluginsDir, "codex");
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginDir, "package.json"),
+    JSON.stringify({
+      name: "@openclaw/codex-test",
+      openclaw: { extensions: ["./index.cjs"] },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(pluginDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: "codex",
+      activation: { onAgentHarnesses: ["codex"] },
+      configSchema: { type: "object" },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(pluginDir, "index.cjs"),
+    `module.exports = {
+      id: "codex",
+      register(api) {
+        api.registerAgentHarness({
+          id: "codex",
+          label: "Codex",
+          supports: () => ({ supported: true }),
+          runAttempt: async () => ({ ok: false, error: "unused" }),
+          fetchUsageSnapshot: async () => ({
+            provider: "openai",
+            displayName: "OpenAI",
+            windows: [{ label: "5h", usedPercent: 9 }],
+          }),
+        });
+      },
+    };\n`,
+  );
+  return makeIsolatedEnv({ OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir });
+}
+
 describe("provider runtime harness usage", () => {
   afterEach(() => {
     clearAgentHarnesses();
-    mocks.ensureSelectedAgentHarnessPlugin.mockReset();
-    mocks.loadAgentRuntimePluginRegistryHandle.mockReset();
+    resetPluginAutoEnableTestState();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
   });
 
-  it("keeps a cold-loaded harness usage callback in its registry scope", async () => {
-    const pluginRegistry = createEmptyPluginRegistry();
-    const fetchUsageSnapshot = vi.fn(async () => {
-      expect(getPluginRuntimeGatewayRequestScope()?.pluginRegistry).toBe(pluginRegistry);
-      return {
-        provider: "openai" as const,
-        displayName: "OpenAI",
-        windows: [{ label: "5h", usedPercent: 9 }],
-      };
-    });
-    mocks.loadAgentRuntimePluginRegistryHandle.mockReturnValue(pluginRegistry);
-    mocks.ensureSelectedAgentHarnessPlugin.mockImplementationOnce(async () => {
-      registerAgentHarness({
-        id: "codex",
-        label: "Codex",
-        supports: () => ({ supported: true }),
-        runAttempt: async () => {
-          throw new Error("not used");
-        },
-        fetchUsageSnapshot,
-      });
-    });
+  it("cold-loads the selected default-disabled harness for usage", async () => {
+    const workspaceDir = makeTempDir();
+    const env = makeCodexManifestEnv();
 
     await expect(
       resolveProviderUsageSnapshotWithPlugin({
         provider: "codex",
         config: {},
-        env: {},
-        workspaceDir: process.cwd(),
+        env,
+        workspaceDir,
         context: {
           config: {},
-          env: {},
+          env,
           provider: "openai",
           token: "test-token-placeholder",
           timeoutMs: 5_000,
           fetchFn: fetch,
         },
       }),
+    ).resolves.toEqual({
+      provider: "openai",
+      displayName: "OpenAI",
+      windows: [{ label: "5h", usedPercent: 9 }],
+    });
+  });
+
+  it("does not reuse an unrelated Gateway registry for cold harness usage", async () => {
+    const workspaceDir = makeTempDir();
+    const env = makeCodexManifestEnv();
+
+    await expect(
+      withPluginRuntimeRegistryScope(createEmptyPluginRegistry(), () =>
+        resolveProviderUsageSnapshotWithPlugin({
+          provider: "codex",
+          config: {},
+          env,
+          workspaceDir,
+          context: {
+            config: {},
+            env,
+            provider: "openai",
+            token: "test-token-placeholder",
+            timeoutMs: 5_000,
+            fetchFn: fetch,
+          },
+        }),
+      ),
     ).resolves.toMatchObject({ provider: "openai" });
-    expect(fetchUsageSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      name: "globally disabled plugins",
+      config: { plugins: { enabled: false } } satisfies OpenClawConfig,
+      expectedReason: "plugins disabled",
+    },
+    {
+      name: "a restrictive allowlist",
+      config: { plugins: { allow: ["openai", "memory-core"] } } satisfies OpenClawConfig,
+      expectedReason: "not in allowlist",
+    },
+  ])("preserves $name in cold usage diagnostics", async ({ config, expectedReason }) => {
+    const workspaceDir = makeTempDir();
+    const env = makeCodexManifestEnv();
+    vi.stubEnv("OPENCLAW_STATE_DIR", env.OPENCLAW_STATE_DIR ?? "");
+    vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", env.OPENCLAW_BUNDLED_PLUGINS_DIR ?? "");
+    vi.stubEnv(
+      "OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR",
+      env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR ?? "",
+    );
+
+    const error = await resolveProviderUsageSnapshotWithPlugin({
+      provider: "codex",
+      config,
+      env,
+      workspaceDir,
+      context: {
+        config,
+        env,
+        provider: "openai",
+        token: "test-token-placeholder",
+        timeoutMs: 5_000,
+        fetchFn: fetch,
+      },
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain(expectedReason);
+    expect((error as Error).message).toContain("reason=owner-plugin-not-activatable");
+    expect((error as Error).message).not.toContain("absent from this prepared plugin generation");
   });
 
   it("routes a synthetic hook id to the matching harness", async () => {

--- a/test/scripts/vitest-worker-artifacts.test.ts
+++ b/test/scripts/vitest-worker-artifacts.test.ts
@@ -576,18 +576,20 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
       expect(fs.existsSync(owner.descriptor.directory)).toBe(false);
     }));
 
-  it("preserves scoped and prepared provider hooks in source and compiled TUI payloads", ({
-    workerArtifacts,
-  }) =>
-    workerArtifacts.fixtureLifetime.run(async () => {
-      const { node, prepareWorkers } = workerArtifacts.createFixtureCommands();
-      const owner = createVitestWorkerRun();
-      try {
-        const manifest = await prepareWorkers(owner);
-        console.log(
-          JSON.stringify({ preparationMs: manifest.durationMs, identity: manifest.identity }),
-        );
-        for (const mode of ["source", "compiled"] as const) {
+  it.for(["source", "compiled"] as const)(
+    "preserves scoped and prepared provider hooks in %s TUI payloads",
+    (mode, { workerArtifacts }) =>
+      workerArtifacts.fixtureLifetime.run(async () => {
+        const { node, prepareWorkers } = workerArtifacts.createFixtureCommands();
+        // Each mode owns its cold-process budget; source probes need no compiled generation.
+        const owner = mode === "compiled" ? createVitestWorkerRun() : undefined;
+        try {
+          if (owner) {
+            const manifest = await prepareWorkers(owner);
+            console.log(
+              JSON.stringify({ preparationMs: manifest.durationMs, identity: manifest.identity }),
+            );
+          }
           for (const scope of ["scoped", "prepared"] as const) {
             const directory = workerArtifacts.fixtureDirectory();
             const events = path.join(directory, "provider-events.jsonl");
@@ -712,24 +714,21 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
           `,
             );
             const url = pathToFileURL(
-              mode === "source"
-                ? path.join(root, "src/agents/embedded-agent-runner/run/payloads.ts")
-                : path.join(
+              owner
+                ? path.join(
                     owner.descriptor.directory,
                     "dist/agents/embedded-agent-runner/run/payloads.js",
-                  ),
+                  )
+                : path.join(root, "src/agents/embedded-agent-runner/run/payloads.ts"),
             );
             const result = await node(
               [
                 ...resolveRuntimeWorkerArgv(pathToFileURL(probe)),
                 url.href,
                 pathToFileURL(
-                  mode === "source"
-                    ? path.join(root, "src/plugins/provider-hook-runtime.ts")
-                    : path.join(
-                        owner.descriptor.directory,
-                        "dist/plugins/provider-hook-runtime.js",
-                      ),
+                  owner
+                    ? path.join(owner.descriptor.directory, "dist/plugins/provider-hook-runtime.js")
+                    : path.join(root, "src/plugins/provider-hook-runtime.ts"),
                 ).href,
               ],
               root,
@@ -742,12 +741,14 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
             console.log(result.stdout);
             expect(result.code, result.stderr + result.stdout).toBe(0);
           }
+        } finally {
+          await owner?.dispose();
         }
-      } finally {
-        await owner.dispose();
-      }
-      expect(fs.existsSync(owner.descriptor.directory)).toBe(false);
-    }));
+        if (owner) {
+          expect(fs.existsSync(owner.descriptor.directory)).toBe(false);
+        }
+      }),
+  );
 
   it.each([
     { args: ["run", "--", "--help"], metadata: false },


### PR DESCRIPTION
Related: #134304. Credited replacement for #134468 by @fuller-stack-dev (Json); original report by @goslingmanagment.

## What Problem This Solves

Fixes an issue where users sending turns to an existing model-dependent session receive a generic missing-registration failure when its required agent harness is unavailable, while Gateway health and readiness remain green. The error does not explain which plugin owns the runtime or whether it is disabled, denied, absent, or degraded.

## Why This Change Was Made

The turn guard now diagnoses missing registration from the exact prepared registry's activation context and manifest ownership. Explicit-config library calls retain their policy even without a bound context. Direct hosts resolve one activation context, reuse it for memory adoption, and bind it to their scoped registry; provider usage uses that same owner path. Borrowed Gateway registries do not import direct-host context dependencies.

Owner classification checks the complete owner set before bounding displayed details, respects bundled/platform default enablement, and treats mixed blocked/activatable owners as degraded rather than wholly disabled. Existing registry failures take precedence without echoing raw plugin error text. No configuration, storage, protocol, health, readiness, or model-selection contract changes. Already-landed #134837 is not replayed.

## User Impact

Unavailable turns now report the owner when known, the blocking state, and an actionable doctor/inspection/restart path. Model/auth discovery and process health remain independent of whether a particular turn's required harness can run. The documented recovery applies to existing sessions as well as direct hosts and provider usage.

## Evidence

Verified on the final committed tree:

- `node scripts/run-vitest.mjs src/cli/run-main.cleanup.test.ts src/agents/runtime-plugins.test.ts src/agents/runtime-plugins.memory-corpus.integration.test.ts src/agents/prepared-model-runtime.plugin-context.test.ts src/agents/harness/runtime-plugin.test.ts src/plugins/provider-runtime.usage-harness.test.ts`: 87/87 passed.
- `node scripts/run-vitest.mjs src/gateway/server.sessions.agent-model-catalog.test.ts src/gateway/server-methods/sessions-mutations.sticky-model.test.ts`: ordered 54/54 passed after the final fixture correction.
- `node scripts/run-vitest.mjs test/scripts/vitest-worker-artifacts.test.ts`: 34/34 passed after the CI fixture repair.
- Fresh branch-mode autoreview: no accepted/actionable P0 findings.

`pnpm build` passed, including runtime postbuild, plugin exports, and Control UI budgets. Changed-file checks passed for the original eight paths and separately for the worker-artifact test repair (types, lint, dead exports, architecture, storage, and security guards).

Regression proof includes explicit-config plugin disablement, mixed ownership (including a fourth owner beyond the display cap), bundled/platform defaults, and Json's borrowed-registry lifecycle case. Each newly corrected behavior failed before its fix. The ordered Gateway catalog/sticky suite joins pending config mutations before fixture teardown; activation checks are unchanged.

Direct Codex dependency inspection: `openai/codex` at `0ae94fdd49b05ee7faa4d984d06a68492cb32b54`, `codex-rs/app-server/src/request_processors/catalog_processor.rs:168,242`, `turn_processor.rs:166,499`, and `account_processor.rs:1034`. Catalog/auth and turn-start processing are separate boundaries; this repair does not reinterpret a successful probe as turn executability.

### Built Gateway live-proof transcript

Fresh isolated HOME and state directory, synthetic token, loopback port 50912 (not 18789), no provider credentials or inference. The driver waits for the documented startup admission probe.

```text
GET /startupz -> 200
GET /health -> 200
connect -> ok
chat.send -> accepted
first chat error -> Agent harness runtime "codex" is unavailable. (reason=owner-plugin-not-activatable, ownerPluginId=codex). Run "openclaw doctor --fix". Owner plugin "codex" is not activatable (plugins disabled). Repair the plugin or select a model that does...
final chat error -> ⚠️ Agent failed before reply: Agent harness runtime "codex" is unavailable. (reason=owner-plugin-not-activatable, ownerPluginId=codex). Run "openclaw doctor --fix". Owner plugin "codex" is not activatable (plugins disabled). Repair the plugin or select a model that does not require this runtime, restart the Gateway, then retry.
To view logs, run `openclaw logs --follow` in a terminal.
GET /health after failed turn -> 200
GET /readyz after failed turn -> 200
PASS; owned Gateway stopped, no listener remains
```

An initial fresh driver attempt connected on liveness before startup completed and received the expected startup-sidecars rejection. The corrected driver waits on /startupz; no production retry, timeout increase, or health change was added.

### Hosted CI follow-up

The first exact-head CI run failed only `checks-node-compact-small-29`: the worker-artifact provider-hook case bundled a compiled build and four cold subprocesses under one 120-second deadline. Its log records source/scoped, source/prepared, and compiled/scoped success before the last subprocess was cut off. The original full file passed locally, so this was not a reproduced hook-behavior failure.

The fixture now has separate source and compiled cases. Both still execute scoped and prepared probes with the same assertions and timeout; only the compiled case builds artifacts, so there is still exactly one compiled build total. The full file passes 34/34. This bounded test-owner repair adds one net test line and no production code; fresh hosted CI is required on the updated head.

### Scope and production LOC

Both requested refactors are included: direct-registry activation-context reuse and shared registry-load options remove 38 production lines from the inherited patch. Against the integrated main baseline, production is +177/-102 (net +75), tests are +626/-91 (net +535), and docs are +7/-0. The remaining production growth is justified: visible, state-specific recovery is the missing capability for turns that fail while health remains green. It cannot be supplied by removing the guard, changing service health, or weakening plugin activation. The diagnostic stays at the turn/registry owner boundary, using existing policy helpers rather than a second activation policy.

NO-FOLLOW-UP: both rent-paying refactors are included here; a wider readiness or selection redesign is a separate product decision, with existing follow-ups, not part of this repair.

Co-authored-by: Json <263060202+fuller-stack-dev@users.noreply.github.com>
