### PR TITLE
fix(agents): preserve failed-exec warnings on silent turns

### DIFF
--- a/docs/concepts/messages.md
+++ b/docs/concepts/messages.md
@@ -97,6 +97,8 @@ Tool result `content` is the model-visible result; `details` is runtime metadata
 - Persisted session transcripts keep only bounded `details`; oversized metadata is replaced with a compact summary marked `persistedDetailsTruncated: true`.
 - Plugins and tools should put text the model must read in `content`, not only in `details`.
 
+When a tool-error warning is the agent's only reply, WebChat displays and retains it. The warning does not by itself change a completed agent run into a runtime failure; the failed tool result remains recorded separately.
+
 ## Queueing and followups
 
 When a run is already active, inbound messages steer into it by default. `messages.queue` controls the mode:

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -389,16 +389,18 @@ export function buildEmbeddedRunPayloads(params: {
           })
         : false;
       if (!duplicateWarning) {
-        replyItems.push({
+        const warning = {
           text: failureWarning.text,
-          ...(!isRestartStatus
-            ? {
-                isError: true,
-                nonTerminalToolErrorWarning:
-                  hasUserFacingReply && failureWarning.nonTerminalToolErrorWarning,
-              }
-            : {}),
-        });
+          ...(!isRestartStatus ? { isError: true } : {}),
+        };
+        if (!isRestartStatus) {
+          setReplyPayloadMetadata(warning, {
+            toolErrorWarning: { toolName: params.lastToolError.toolName },
+            nonTerminalToolErrorWarning:
+              hasUserFacingReply && failureWarning.nonTerminalToolErrorWarning,
+          });
+        }
+        replyItems.push(warning);
       }
     }
   }
@@ -436,11 +438,6 @@ export function buildEmbeddedRunPayloads(params: {
         explicitFinalSourceReply === false
       ) {
         markReplyPayloadForSourceSuppressionDelivery(payload);
-      }
-      if (item.nonTerminalToolErrorWarning) {
-        setReplyPayloadMetadata(payload, {
-          nonTerminalToolErrorWarning: true,
-        });
       }
       if (heartbeatTerminalToolFailure) {
         setReplyPayloadMetadata(payload, {

--- a/src/agents/embedded-agent-runner/run/source-reply-payloads.ts
+++ b/src/agents/embedded-agent-runner/run/source-reply-payloads.ts
@@ -24,7 +24,6 @@ type EmbeddedRunReplyItem = {
   presentation?: ReplyPayload["presentation"];
   interactive?: ReplyPayload["interactive"];
   channelData?: Record<string, unknown>;
-  nonTerminalToolErrorWarning?: boolean;
   sourceReplyMirror?: { idempotencyKey?: string; transcriptOwner?: true };
 };
 

--- a/src/agents/embedded-agent-runner/run/tool-error-warning.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-error-warning.test.ts
@@ -221,7 +221,7 @@ describe("buildEmbeddedRunPayloads tool warnings", () => {
     });
 
     expectSinglePayloadSummary(payloads, {
-      text: "⚠️ 🛠️ Exec failed (exit 1)",
+      text: "⚠️ Exec failed (exit 1)",
       isError: true,
     });
   });
@@ -239,19 +239,19 @@ describe("buildEmbeddedRunPayloads tool warnings", () => {
     });
 
     expectSinglePayloadSummary(payloads, {
-      text: "⚠️ 🛠️ Exec failed: `python3 /path/to/daily-cost-audit.py`: Command exited with code 1",
+      text: "⚠️ Exec failed: `python3 /path/to/daily-cost-audit.py`: Command exited with code 1",
       isError: true,
     });
     expect(payloads[0]?.text).not.toContain("`run python3");
   });
 
   it.each([
-    [false, "off", "⚠️ 🛠️ Exec blocked (exit 7)"],
-    [false, "full", "⚠️ 🛠️ Exec blocked: `make build`: Command exited with code 7"],
-    [true, "off", "⚠️ 🛠️ Exec failed (exit 7)"],
-    [true, "full", "⚠️ 🛠️ Exec failed: `make build`: Command exited with code 7"],
-    [undefined, "off", "⚠️ 🛠️ Exec failed (exit 7)"],
-    [undefined, "full", "⚠️ 🛠️ Exec failed: `make build`: Command exited with code 7"],
+    [false, "off", "⚠️ Exec blocked (exit 7)"],
+    [false, "full", "⚠️ Exec blocked: `make build`: Command exited with code 7"],
+    [true, "off", "⚠️ Exec failed (exit 7)"],
+    [true, "full", "⚠️ Exec failed: `make build`: Command exited with code 7"],
+    [undefined, "off", "⚠️ Exec failed (exit 7)"],
+    [undefined, "full", "⚠️ Exec failed: `make build`: Command exited with code 7"],
   ] as const)(
     "renders executionStarted=%s at %s verbosity from structured state",
     (executionStarted, verboseLevel, expected) => {
@@ -276,51 +276,50 @@ describe("buildEmbeddedRunPayloads tool warnings", () => {
       title: "prefers raw exec metadata when tool progress detail includes it",
       meta: "run python3 /tmp/audit.py · `python3 /tmp/audit.py`",
       toolResultFormat: "markdown",
-      expected: "⚠️ 🛠️ Exec failed: `python3 /tmp/audit.py`: Command exited with code 1",
+      expected: "⚠️ Exec failed: `python3 /tmp/audit.py`: Command exited with code 1",
     },
     {
       title: "prefers raw exec metadata when the literal command contains backticks",
       meta: "run node inline script, `node -e 'console.log(1, `x`)'`",
       toolResultFormat: "markdown",
-      expected: "⚠️ 🛠️ Exec failed: ``node -e 'console.log(1, `x`)'``: Command exited with code 1",
+      expected: "⚠️ Exec failed: ``node -e 'console.log(1, `x`)'``: Command exited with code 1",
     },
     {
       title: "leaves exec metadata unwrapped for plain tool results",
       meta: "run node inline script, `node -e 'console.log(1, `x`)'`",
       toolResultFormat: "plain",
-      expected: "⚠️ 🛠️ Exec failed: node -e 'console.log(1, `x`)': Command exited with code 1",
+      expected: "⚠️ Exec failed: node -e 'console.log(1, `x`)': Command exited with code 1",
     },
     {
       title: "preserves raw exec context before trailing raw command metadata",
       meta: "run python3 /tmp/audit.py, node: mac-1, `python3 /tmp/audit.py`",
       toolResultFormat: "markdown",
-      expected:
-        "⚠️ 🛠️ Exec failed: `node: mac-1 · python3 /tmp/audit.py`: Command exited with code 1",
+      expected: "⚠️ Exec failed: `node: mac-1 · python3 /tmp/audit.py`: Command exited with code 1",
     },
     {
       title: "does not promote display-summary commas into raw exec context",
       meta: 'search "foo,bar" in src, `rg "foo,bar" src`',
       toolResultFormat: "markdown",
-      expected: '⚠️ 🛠️ Exec failed: `rg "foo,bar" src`: Command exited with code 1',
+      expected: '⚠️ Exec failed: `rg "foo,bar" src`: Command exited with code 1',
     },
     {
       title: "does not treat parenthesized raw command arguments as cwd context",
       meta: 'list files in (in progress) · `ls "(in progress)"`',
       toolResultFormat: "markdown",
-      expected: '⚠️ 🛠️ Exec failed: `ls "(in progress)"`: Command exited with code 1',
+      expected: '⚠️ Exec failed: `ls "(in progress)"`: Command exited with code 1',
     },
     {
       title: "does not duplicate compact cwd labels already present in raw command arguments",
       meta: 'print text (repo) · `printf "%s" "(repo)"`',
       toolResultFormat: "markdown",
-      expected: '⚠️ 🛠️ Exec failed: `printf "%s" "(repo)"`: Command exited with code 1',
+      expected: '⚠️ Exec failed: `printf "%s" "(repo)"`: Command exited with code 1',
     },
     {
       title: "keeps arbitrary exec cwd suffixes inside markdown command text",
       meta: "run python3 /tmp/audit.py (in /tmp/build @everyone)",
       toolResultFormat: "markdown",
       expected:
-        "⚠️ 🛠️ Exec failed: `python3 /tmp/audit.py (in /tmp/build @everyone)`: Command exited with code 1",
+        "⚠️ Exec failed: `python3 /tmp/audit.py (in /tmp/build @everyone)`: Command exited with code 1",
     },
   ] as const)("$title", ({ meta, toolResultFormat, expected }) => {
     const payloads = buildPayloads({
@@ -373,15 +372,15 @@ describe("buildEmbeddedRunPayloads tool warnings", () => {
     });
 
     expectSinglePayloadSummary(cwdPayloads, {
-      text: "⚠️ 🛠️ Exec failed: `python3 audit.py (in /tmp/build)`: Command exited with code 1",
+      text: "⚠️ Exec failed: `python3 audit.py (in /tmp/build)`: Command exited with code 1",
       isError: true,
     });
     expectSinglePayloadSummary(workspaceNodePayloads, {
-      text: "⚠️ 🛠️ Exec failed: `node: mac-1 · python3 audit.py (workspace)`: Command exited with code 1",
+      text: "⚠️ Exec failed: `node: mac-1 · python3 audit.py (workspace)`: Command exited with code 1",
       isError: true,
     });
     expectSinglePayloadSummary(semanticCompactPayloads, {
-      text: "⚠️ 🛠️ Exec failed: `git status (repo)`: Command exited with code 1",
+      text: "⚠️ Exec failed: `git status (repo)`: Command exited with code 1",
       isError: true,
     });
   });
@@ -391,52 +390,52 @@ describe("buildEmbeddedRunPayloads tool warnings", () => {
       name: "strips a literal synthetic run prefix",
       meta: "run make build",
       error: "Command failed with exit code 2",
-      expected: "⚠️ 🛠️ Exec failed: `make build`: Command failed with exit code 2",
+      expected: "⚠️ Exec failed: `make build`: Command failed with exit code 2",
     },
     {
       name: "preserves a semantic test summary",
       meta: "run tests",
       error: "Command failed with exit code 1",
-      expected: "⚠️ 🛠️ Exec failed: `run tests`: Command failed with exit code 1",
+      expected: "⚠️ Exec failed: `run tests`: Command failed with exit code 1",
     },
     {
       name: "preserves a semantic deploy summary",
       meta: "run deploy",
       error: "Command failed with exit code 1",
-      expected: "⚠️ 🛠️ Exec failed: `run deploy`: Command failed with exit code 1",
+      expected: "⚠️ Exec failed: `run deploy`: Command failed with exit code 1",
     },
     {
       name: "preserves a compound summary",
       meta: "run tests → install dependencies",
       error: "Command failed with exit code 1",
       expected:
-        "⚠️ 🛠️ Exec failed: `run tests → install dependencies`: Command failed with exit code 1",
+        "⚠️ Exec failed: `run tests → install dependencies`: Command failed with exit code 1",
     },
     {
       name: "preserves an inline-script summary",
       meta: "run node inline script",
       error: "Command failed with exit code 1",
-      expected: "⚠️ 🛠️ Exec failed: `run node inline script`: Command failed with exit code 1",
+      expected: "⚠️ Exec failed: `run node inline script`: Command failed with exit code 1",
     },
     {
       name: "preserves a heredoc summary",
       meta: "run python3 inline script (heredoc)",
       error: "Command failed with exit code 1",
       expected:
-        "⚠️ 🛠️ Exec failed: `run python3 inline script (heredoc)`: Command failed with exit code 1",
+        "⚠️ Exec failed: `run python3 inline script (heredoc)`: Command failed with exit code 1",
     },
     {
       name: "preserves a sed summary",
       meta: "run sed on file",
       error: "Command failed with exit code 1",
-      expected: "⚠️ 🛠️ Exec failed: `run sed on file`: Command failed with exit code 1",
+      expected: "⚠️ Exec failed: `run sed on file`: Command failed with exit code 1",
     },
     {
       name: "preserves a pipeline summary",
       meta: "run tests -> show first 3 lines",
       error: "Command failed with exit code 1",
       expected:
-        "⚠️ 🛠️ Exec failed: `run tests -> show first 3 lines`: Command failed with exit code 1",
+        "⚠️ Exec failed: `run tests -> show first 3 lines`: Command failed with exit code 1",
     },
   ])("formats exec metadata: $name", ({ meta, error, expected }) => {
     const payloads = buildPayloads({
@@ -468,7 +467,7 @@ describe("buildEmbeddedRunPayloads tool warnings", () => {
     });
 
     expectSinglePayloadSummary(payloads, {
-      text: "⚠️ 🛠️ Bash failed: `show matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt` (workspace): Command exited with code 1",
+      text: "⚠️ Bash failed: `show matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt` (workspace): Command exited with code 1",
       isError: true,
     });
   });

--- a/src/agents/embedded-agent-runner/run/tool-error-warning.ts
+++ b/src/agents/embedded-agent-runner/run/tool-error-warning.ts
@@ -1,20 +1,20 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { VerboseLevel } from "../../../auto-reply/thinking.js";
-import { formatToolAggregate } from "../../../auto-reply/tool-meta.js";
+import { formatToolAggregateParts } from "../../../auto-reply/tool-meta.js";
 import { formatInlineCodeSpan } from "../../../shared/markdown-code.js";
+import { resolveToolDisplay } from "../../tool-display.js";
 import { isExecLikeToolName, type ToolErrorSummary } from "../../tool-error-summary.js";
 
-type ToolErrorWarningPolicy = {
-  showWarning: boolean;
-  includeDetails: boolean;
-};
-
-function isVerboseToolDetailEnabled(level?: VerboseLevel): boolean {
-  return level === "full";
-}
-
-function shouldMarkNonTerminalToolErrorWarning(lastToolError: ToolErrorSummary): boolean {
-  return lastToolError.middlewareError === true;
+function formatWarningToolLabel(
+  toolName: string,
+  metas: string[] | undefined,
+  markdown: boolean,
+): string {
+  // Progress prefixes are reserved internal traces. User warnings use the label
+  // and the same escaped details so every text-only display can retain them.
+  const { label } = resolveToolDisplay({ name: toolName });
+  const { detail } = formatToolAggregateParts(toolName, metas, { markdown });
+  return detail ? `${label}: ${detail}` : label;
 }
 
 function formatToolErrorWarningText(params: {
@@ -25,10 +25,10 @@ function formatToolErrorWarningText(params: {
   const failureVerb = params.lastToolError.executionStarted === false ? "blocked" : "failed";
   const terminalDiagnostic = params.lastToolError.terminalDiagnostic;
   if (terminalDiagnostic?.kind === "process") {
-    const toolLabel = formatToolAggregate(
+    const toolLabel = formatWarningToolLabel(
       "process",
       params.includeDetails ? [terminalDiagnostic.sessionId] : undefined,
-      { markdown: params.useMarkdown },
+      params.useMarkdown,
     );
     const reason =
       terminalDiagnostic.reason.kind === "exit"
@@ -47,9 +47,7 @@ function formatToolErrorWarningText(params: {
   const includeError =
     params.includeDetails || params.lastToolError.errorCode === "approval_timeout";
   if (isExecLikeToolName(params.lastToolError.toolName)) {
-    const toolLabel = formatToolAggregate(params.lastToolError.toolName, undefined, {
-      markdown: params.useMarkdown,
-    });
+    const toolLabel = resolveToolDisplay({ name: params.lastToolError.toolName }).label;
     const subject = params.includeDetails
       ? formatExecLikeFailureSubject(params.lastToolError.meta, params.useMarkdown)
       : "";
@@ -63,10 +61,10 @@ function formatToolErrorWarningText(params: {
       : `⚠️ ${toolLabel} ${failureVerb}${conciseExitSuffix}${errorSuffix}`;
   }
 
-  const toolSummary = formatToolAggregate(
+  const toolSummary = formatWarningToolLabel(
     params.lastToolError.toolName,
     params.includeDetails && params.lastToolError.meta ? [params.lastToolError.meta] : undefined,
-    { markdown: params.useMarkdown },
+    params.useMarkdown,
   );
   const errorSuffix =
     includeError && params.lastToolError.error ? `: ${params.lastToolError.error}` : "";
@@ -288,22 +286,6 @@ function maybeWrapInlineCode(value: string, markdown: boolean): string {
   return markdown ? formatInlineCodeSpan(value) : value;
 }
 /** Warn only when a tool failure would otherwise leave the user with no reply. */
-function resolveToolErrorWarningPolicy(params: {
-  hasUserFacingReply: boolean;
-  suppressToolErrors: boolean;
-  suppressToolErrorWarnings?: boolean;
-  verboseLevel?: VerboseLevel;
-}): ToolErrorWarningPolicy {
-  const includeDetails = isVerboseToolDetailEnabled(params.verboseLevel);
-  return {
-    showWarning:
-      !params.hasUserFacingReply &&
-      !params.suppressToolErrors &&
-      params.suppressToolErrorWarnings !== true,
-    includeDetails,
-  };
-}
-
 export function buildFailureWarning(params: {
   lastToolError: ToolErrorSummary;
   hasUserFacingReply: boolean;
@@ -312,16 +294,19 @@ export function buildFailureWarning(params: {
   verboseLevel?: VerboseLevel;
   useMarkdown: boolean;
 }): { text: string; nonTerminalToolErrorWarning: boolean } | undefined {
-  const warningPolicy = resolveToolErrorWarningPolicy(params);
-  if (!warningPolicy.showWarning) {
+  if (
+    params.hasUserFacingReply ||
+    params.suppressToolErrors ||
+    params.suppressToolErrorWarnings === true
+  ) {
     return undefined;
   }
   return {
     text: formatToolErrorWarningText({
       lastToolError: params.lastToolError,
-      includeDetails: warningPolicy.includeDetails,
+      includeDetails: params.verboseLevel === "full",
       useMarkdown: params.useMarkdown,
     }),
-    nonTerminalToolErrorWarning: shouldMarkNonTerminalToolErrorWarning(params.lastToolError),
+    nonTerminalToolErrorWarning: params.lastToolError.middlewareError === true,
   };
 }

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -2744,7 +2744,7 @@ describe("handleToolExecutionEnd timeout metadata", () => {
       sessionKey: "agent:unit-session",
       toolResultFormat: "markdown",
     });
-    expect(payloads[0]?.text).toBe("⚠️ 🛠️ Exec failed (exit 1)");
+    expect(payloads[0]?.text).toBe("⚠️ Exec failed (exit 1)");
   });
 
   it("records structured error codes for failed tool results", async () => {
@@ -3079,7 +3079,7 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
       sessionKey: "agent:unit-session",
       toolResultFormat: "markdown",
     });
-    expect(payloads[0]?.text).toBe("⚠️ 🛠️ Exec blocked");
+    expect(payloads[0]?.text).toBe("⚠️ Exec blocked");
   });
 
   it("records an actionable failure when unavailable-approval notice delivery rejects", async () => {

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -356,6 +356,8 @@ export type ReplyPayloadMetadata = {
     idempotencyKey?: string;
   };
   beforeAgentRunBlocked?: boolean;
+  /** The warning owner observed this tool failure; presentation text is not evidence. */
+  toolErrorWarning?: { toolName: string };
   /** Warning synthesized from an observed tool error after the run produced assistant output. */
   nonTerminalToolErrorWarning?: boolean;
   /** Unresolved mutating tool failure that makes a heartbeat run terminally failed. */

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -2,8 +2,13 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it } from "vitest";
+import { buildEmbeddedRunPayloads } from "../../agents/embedded-agent-runner/run/payloads.js";
 import type { ChannelThreadingAdapter } from "../../channels/plugins/types.public.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  sanitizeAssistantVisibleText,
+  stripAssistantInternalScaffolding,
+} from "../../shared/text/assistant-visible-text.js";
 import {
   createChannelTestPluginBase,
   createTestRegistry,
@@ -16,6 +21,7 @@ import {
 import type { ReplyPayload } from "../types.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
 import { createBlockReplyContentKey, createBlockReplyPipeline } from "./block-reply-pipeline.js";
+import { normalizeReplyPayload } from "./normalize-reply.js";
 import { createReplyToModeFilterForChannel } from "./reply-threading.js";
 
 const baseParams = {
@@ -1180,6 +1186,38 @@ describe("buildReplyPayloads media filter integration", () => {
       isError: true,
     });
   });
+
+  it.each(["exec", "bash"])(
+    "delivers the real %s failure warning after a silent answer",
+    async (toolName) => {
+      const payloads = buildEmbeddedRunPayloads({
+        assistantTexts: ["NO_REPLY"],
+        lastAssistant: undefined,
+        lastToolError: { toolName, error: "Command not found" },
+        sessionKey: "agent:main:warning",
+      });
+      const { replyPayloads } = await buildTestReplyPayloads({ payloads });
+      const delivered = replyPayloads
+        .map((payload) => normalizeReplyPayload(payload))
+        .filter(Boolean);
+
+      expect(delivered).toEqual([
+        expect.objectContaining({
+          text: `⚠️ ${toolName === "exec" ? "Exec" : "Bash"} failed`,
+          isError: true,
+        }),
+      ]);
+      // Both channel text cleanup and Control UI display must retain the warning.
+      expect(sanitizeAssistantVisibleText(delivered[0]?.text ?? "")).toBe(delivered[0]?.text);
+      expect(stripAssistantInternalScaffolding(delivered[0]?.text ?? "")).toBe(delivered[0]?.text);
+      expect(
+        normalizeReplyPayload({
+          text: `⚠️ 🛠️ ${toolName === "exec" ? "Exec" : "Bash"} failed`,
+          isError: true,
+        }),
+      ).toBeNull();
+    },
+  );
 
   it("keeps voice media payloads during silent turns", async () => {
     const { replyPayloads } = await buildTestReplyPayloads({

--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -1,11 +1,16 @@
 // Isolated agent helper tests cover utility behavior used by cron agent runs.
 import { describe, expect, it } from "vitest";
+import { buildEmbeddedRunPayloads } from "../agents/embedded-agent-runner/run/payloads.js";
 import {
   getReplyPayloadMetadata,
   setReplyPayloadMetadata,
   type ReplyPayload,
 } from "../auto-reply/reply-payload.js";
 import { resolveCronPayloadOutcome } from "./isolated-agent/helpers.js";
+
+function createToolWarning(text: string, toolName: string): ReplyPayload {
+  return setReplyPayloadMetadata({ text, isError: true }, { toolErrorWarning: { toolName } });
+}
 
 describe("resolveCronPayloadOutcome", () => {
   it("uses the last non-empty non-error payload as summary and output", () => {
@@ -21,10 +26,7 @@ describe("resolveCronPayloadOutcome", () => {
   it("returns a fatal error from the last error payload when no success follows", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [
-        {
-          text: "⚠️ 🛠️ Exec failed: /bin/bash: line 1: python: command not found",
-          isError: true,
-        },
+        createToolWarning("⚠️ Exec failed: /bin/bash: line 1: python: command not found", "exec"),
       ],
     });
 
@@ -40,7 +42,7 @@ describe("resolveCronPayloadOutcome", () => {
     ["reasoning-prefixed", "<think>internal reasoning</think>\nNO_REPLY"],
   ])("keeps tool warnings fatal when terminal output is a silent %s", (_label, text) => {
     const result = resolveCronPayloadOutcome({
-      payloads: [{ text: "⚠️ 🛠️ Bash failed: mount unavailable", isError: true }],
+      payloads: [createToolWarning("⚠️ Bash failed: mount unavailable", "bash")],
       finalAssistantVisibleText: text,
       preferFinalAssistantVisibleText: true,
     });
@@ -51,7 +53,12 @@ describe("resolveCronPayloadOutcome", () => {
 
   it("keeps genuine visible terminal output as recovery proof", () => {
     const result = resolveCronPayloadOutcome({
-      payloads: [{ text: "⚠️ 🛠️ Bash failed: mount unavailable", isError: true }],
+      payloads: buildEmbeddedRunPayloads({
+        assistantTexts: [],
+        lastAssistant: undefined,
+        lastToolError: { toolName: "bash", error: "mount unavailable" },
+        sessionKey: "cron:test",
+      }),
       finalAssistantVisibleText: "Mount restored; report written.",
       preferFinalAssistantVisibleText: true,
     });
@@ -62,12 +69,7 @@ describe("resolveCronPayloadOutcome", () => {
 
   it("lets preferred final assistant text recover a plain tool warning", () => {
     const result = resolveCronPayloadOutcome({
-      payloads: [
-        {
-          text: "⚠️ 🛠️ jq -s '{total:length}' (agent) failed",
-          isError: true,
-        },
-      ],
+      payloads: [createToolWarning("⚠️ Exec failed: jq -s '{total:length}'", "exec")],
       finalAssistantVisibleText: "**Clawsweeper 6h report**\nClosed: 34 total",
       preferFinalAssistantVisibleText: true,
     });
@@ -84,14 +86,8 @@ describe("resolveCronPayloadOutcome", () => {
   it("lets final assistant text recover multiple plain tool warnings globally", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [
-        {
-          text: "⚠️ 🛠️ zsh (agent) failed",
-          isError: true,
-        },
-        {
-          text: "⚠️ 🛠️ node (agent) failed",
-          isError: true,
-        },
+        createToolWarning("⚠️ Exec failed: zsh", "exec"),
+        createToolWarning("⚠️ Bash failed: node", "Bash"),
       ],
       finalAssistantVisibleText: "**Daily GTM analytics**\nPostHog and revenue summary complete.",
     });
@@ -165,14 +161,14 @@ describe("resolveCronPayloadOutcome", () => {
 
   it("treats trailing message delivery warnings as non-fatal when final assistant text exists", () => {
     const result = resolveCronPayloadOutcome({
-      payloads: [{ text: "Draft output" }, { text: "⚠️ ✉️ Message failed", isError: true }],
+      payloads: [{ text: "Draft output" }, createToolWarning("⚠️ Message failed", "message")],
       finalAssistantVisibleText: "Final cron report",
       preferFinalAssistantVisibleText: true,
     });
 
     expect(result.hasFatalErrorPayload).toBe(false);
     expect(result.embeddedRunError).toBeUndefined();
-    expect(result.pendingPresentationWarningError).toBe("⚠️ ✉️ Message failed");
+    expect(result.pendingPresentationWarningError).toBe("⚠️ Message failed");
     expect(result.summary).toBe("Final cron report");
     expect(result.outputText).toBe("Final cron report");
     expect(result.deliveryPayloads).toEqual([{ text: "Final cron report" }]);
@@ -180,39 +176,44 @@ describe("resolveCronPayloadOutcome", () => {
 
   it("keeps trailing canvas warnings fatal even when earlier assistant output exists", () => {
     const result = resolveCronPayloadOutcome({
-      payloads: [{ text: "Saved report to disk." }, { text: "⚠️ 🖼️ Canvas failed", isError: true }],
+      payloads: [
+        { text: "Saved report to disk." },
+        createToolWarning("⚠️ Canvas failed", "canvas"),
+      ],
+      finalAssistantVisibleText: "Saved report to disk.",
     });
 
     expect(result.hasFatalErrorPayload).toBe(true);
     expect(result.pendingPresentationWarningError).toBeUndefined();
-    expect(result.embeddedRunError).toBe("⚠️ 🖼️ Canvas failed");
-    expect(result.deliveryPayloads).toEqual([{ text: "⚠️ 🖼️ Canvas failed", isError: true }]);
+    expect(result.embeddedRunError).toBe("⚠️ Canvas failed");
+    expect(result.deliveryPayloads).toEqual([{ text: "⚠️ Canvas failed", isError: true }]);
   });
 
   it("keeps standalone presentation warnings fatal when there is no cron output", () => {
     const result = resolveCronPayloadOutcome({
-      payloads: [{ text: "⚠️ ✉️ Message failed", isError: true }],
+      payloads: [createToolWarning("⚠️ Message failed", "message")],
     });
 
     expect(result.hasFatalErrorPayload).toBe(true);
-    expect(result.embeddedRunError).toBe("⚠️ ✉️ Message failed");
-    expect(result.deliveryPayloads).toEqual([{ text: "⚠️ ✉️ Message failed", isError: true }]);
+    expect(result.embeddedRunError).toBe("⚠️ Message failed");
+    expect(result.deliveryPayloads).toEqual([{ text: "⚠️ Message failed", isError: true }]);
   });
 
-  it("keeps real trailing errors fatal even when earlier assistant output exists", () => {
-    const result = resolveCronPayloadOutcome({
-      payloads: [{ text: "Partial result" }, { text: "model provider unreachable", isError: true }],
-      finalAssistantVisibleText: "Partial result",
-      preferFinalAssistantVisibleText: true,
-    });
+  it.each(["model provider unreachable", "⚠️ 🛠️ Exec failed", "⚠️ ✉️ Message failed"])(
+    "keeps unmarked trailing error %s fatal despite earlier output",
+    (errorText) => {
+      const result = resolveCronPayloadOutcome({
+        payloads: [{ text: "Partial result" }, { text: errorText, isError: true }],
+        finalAssistantVisibleText: "Partial result",
+        preferFinalAssistantVisibleText: true,
+      });
 
-    expect(result.hasFatalErrorPayload).toBe(true);
-    expect(result.embeddedRunError).toBe("model provider unreachable");
-    expect(result.outputText).toBe("model provider unreachable");
-    expect(result.deliveryPayloads).toEqual([
-      { text: "model provider unreachable", isError: true },
-    ]);
-  });
+      expect(result.hasFatalErrorPayload).toBe(true);
+      expect(result.embeddedRunError).toBe(errorText);
+      expect(result.outputText).toBe(errorText);
+      expect(result.deliveryPayloads).toEqual([{ text: errorText, isError: true }]);
+    },
+  );
 
   it("keeps error payloads fatal when the run also reported a run-level error", () => {
     const result = resolveCronPayloadOutcome({
@@ -370,8 +371,8 @@ describe("resolveCronPayloadOutcome", () => {
     },
     {
       name: "matching recovered tool warning",
-      texts: ["⚠️ 🛠️ Exec failed"],
-      finalText: "⚠️ 🛠️ Exec failed",
+      texts: ["⚠️ Exec failed"],
+      finalText: "⚠️ Exec failed",
       speech: false,
       isError: true,
     },
@@ -382,6 +383,7 @@ describe("resolveCronPayloadOutcome", () => {
         { text, ...(isError ? { isError } : {}) },
         {
           tts,
+          ...(isError ? { toolErrorWarning: { toolName: "exec" } } : {}),
           sourceReplyTranscriptMirror: { sessionKey: "agent:main:source" },
           pendingFinalDeliveryCompletion: {
             deliveryId: "delivery-1",

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -1,6 +1,10 @@
 /** Normalizes isolated cron run output into summaries, delivery payloads, and error state. */
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
+import { isExecLikeToolName } from "../../agents/tool-error-summary.js";
 import { isHeartbeatAcknowledgementText } from "../../auto-reply/heartbeat.js";
 import {
   getReplyPayloadMetadata,
@@ -211,16 +215,10 @@ function pickDeliverablePayloads(payloads: DeliveryPayload[]): DeliveryPayload[]
   return lastDeliverablePayload ? [lastDeliverablePayload] : [];
 }
 
-function isCronMessagePresentationWarning(text: string | undefined): boolean {
-  const normalized = normalizeOptionalString(text)?.toLowerCase();
-  return (
-    normalized === "⚠️ ✉️ message failed" ||
-    normalized?.startsWith("⚠️ ✉️ message failed:") === true
+function readToolErrorWarningName(payload: object | undefined): string | undefined {
+  return normalizeOptionalLowercaseString(
+    payload && getReplyPayloadMetadata(payload)?.toolErrorWarning?.toolName,
   );
-}
-
-function isCronToolWarning(text: string | undefined): boolean {
-  return normalizeOptionalString(text)?.startsWith("⚠️ 🛠️ ") === true;
 }
 
 function isNonTerminalToolErrorWarning(payload: object | undefined): boolean {
@@ -251,10 +249,10 @@ export function resolveCronPayloadOutcome(params: {
   const lastErrorPayloadIndex = params.payloads.findLastIndex(
     (payload) => payload?.isError === true,
   );
-  const lastErrorPayloadText = [...params.payloads]
-    .toReversed()
-    .find((payload) => payload?.isError === true && Boolean(payload?.text?.trim()))
-    ?.text?.trim();
+  const lastTextErrorPayload = params.payloads.findLast(
+    (payload) => payload?.isError === true && Boolean(payload?.text?.trim()),
+  );
+  const lastErrorPayloadText = lastTextErrorPayload?.text?.trim();
   const errorPayloads = params.payloads.filter((payload) => payload?.isError === true);
   const finalText = normalizeOptionalString(params.finalAssistantVisibleText);
   const normalizedFinalAssistantVisibleText =
@@ -284,7 +282,7 @@ export function resolveCronPayloadOutcome(params: {
     !params.runLevelError &&
     params.failureSignal?.fatalForCron !== true &&
     lastErrorPayloadIndex >= 0 &&
-    isCronMessagePresentationWarning(lastErrorPayloadText) &&
+    readToolErrorWarningName(lastTextErrorPayload) === "message" &&
     (normalizedFinalAssistantVisibleText !== undefined || hasSuccessfulPayloadBeforeLastError);
   const hasStructuredDeliveryPayloads = selectedDeliveryPayloads.some((payload) =>
     payloadHasStructuredDeliveryContent(payload),
@@ -295,7 +293,7 @@ export function resolveCronPayloadOutcome(params: {
     normalizedFinalAssistantVisibleText !== undefined &&
     !hasStructuredDeliveryPayloads &&
     errorPayloads.length > 0 &&
-    errorPayloads.every((payload) => isCronToolWarning(payload?.text));
+    errorPayloads.every((payload) => isExecLikeToolName(readToolErrorWarningName(payload) ?? ""));
   // Structured error payloads stay fatal unless later successful output or a
   // known non-terminal warning proves the agent recovered.
   const hasFatalStructuredErrorPayload =

--- a/src/cron/isolated-agent/run.session-lifecycle.test.ts
+++ b/src/cron/isolated-agent/run.session-lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
   drainPendingContextEngineTurnsBeforeRun,
   type ContextEngineTurnAttemptFacts,
 } from "../../agents/harness/context-engine-turn-attempt.js";
+import { setReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { ContextEngine } from "../../context-engine/types.js";
 import * as diagnostic from "../../logging/diagnostic.js";
@@ -487,7 +488,12 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
         payloads: [
           { text: outcome === "silent" ? "NO_REPLY" : "Report" },
           ...(outcome === "presentation warning"
-            ? [{ text: "⚠️ ✉️ Message failed", isError: true }]
+            ? [
+                setReplyPayloadMetadata(
+                  { text: "⚠️ Message failed", isError: true },
+                  { toolErrorWarning: { toolName: "message" } },
+                ),
+              ]
             : []),
         ],
         meta: {

--- a/src/gateway/server-methods/chat-send-agent-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-agent-dispatch.ts
@@ -9,6 +9,7 @@ import { classifyAgentRunTerminalOutcome } from "../../agents/agent-run-terminal
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { dispatchInboundMessageWithProjectedDispatcher } from "../../auto-reply/dispatch.js";
 import type { ReplyDispatchRun } from "../../auto-reply/get-reply-options.types.js";
+import { isReplyPayloadStatusNotice } from "../../auto-reply/reply-payload.js";
 import type { ReplyMessageInjectionAttempt } from "../../auto-reply/reply/reply-run-registry.js";
 import { readAgentRunTerminalOutcome } from "../../channels/turn/agent-run-terminal-outcome.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
@@ -454,17 +455,22 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
           // Delivered warnings or source replies cannot replace either authoritative result.
           const runtimeClassification = runtimeOutcome
             ? classifyAgentRunTerminalOutcome(runtimeOutcome)
-            : recordedOutcome === "failed"
-              ? "failure"
-              : recordedOutcome === "completed"
-                ? "success"
-                : undefined;
+            : recordedOutcome && (recordedOutcome === "failed" ? "failure" : "success");
           const runtimeCancelled = runtimeClassification === "cancellation";
           const runtimeFailed =
             runtimeClassification === "failure" || runtimeClassification === "timeout";
           const returnedAgentErrorPayloads = replyDispatch.deliveredReplies
             .map((entryInner) => entryInner.payload)
             .filter((payload) => payload.isError);
+          // Native streams cannot publish a host-authored warning. Give a warning-only
+          // turn the normal reply owner without reclassifying the runtime outcome.
+          const hasOnlyFinalWarnings =
+            returnedAgentErrorPayloads.length > 0 &&
+            replyDispatch.deliveredReplies.every(
+              ({ kind, payload }) =>
+                (kind === "final" && payload.isError === true) ||
+                isReplyPayloadStatusNotice(payload),
+            );
           const hasReturnedAgentError = runtimeClassification
             ? runtimeFailed
             : returnedAgentErrorPayloads.length > 0 &&
@@ -491,7 +497,7 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
           // A dispatched runtime owns its persisted turn; this owner projects
           // only settled, post-hook replies. Native runtimes project their own stream.
           if (
-            (!agentRunStarted || replyDispatchRun) &&
+            (!agentRunStarted || replyDispatchRun || hasOnlyFinalWarnings) &&
             !queuedFollowup.isEnqueued() &&
             !hasReturnedAgentError &&
             !context.chatRunState.hasAbortMarker(clientRunId)

--- a/src/gateway/server-methods/chat-send-source-finalization.ts
+++ b/src/gateway/server-methods/chat-send-source-finalization.ts
@@ -47,17 +47,10 @@ function selectChatSendAgentReplyPayloads(params: {
   return params.deliveredReplies
     .filter((entry) => {
       const { payload } = entry;
-      if (getReplyPayloadMetadata(payload)?.sessionWriterDeliveryAuthority) {
-        return entry.kind === "final" && payload.isError !== true;
-      }
-      if (isSourceReplyTranscriptMirrorPayload(payload)) {
-        return entry.kind === "final" && payload.isError !== true;
-      }
-      return (
-        !params.hasReturnedAgentErrorPayloads &&
-        (entry.kind === "block" || entry.kind === "final") &&
-        isReplyPayloadStatusNotice(payload)
-      );
+      return getReplyPayloadMetadata(payload)?.sessionWriterDeliveryAuthority ||
+        isSourceReplyTranscriptMirrorPayload(payload)
+        ? entry.kind === "final" && payload.isError !== true
+        : !params.hasReturnedAgentErrorPayloads && isReplyPayloadStatusNotice(payload);
     })
     .map((entry) => entry.payload);
 }

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -4382,6 +4382,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     ["recorded failure with source reply", true, "source", "failed"],
     ["recorded success with ordinary output", true, "ordinary", "completed"],
     ["recorded success with a recoverable warning", true, "warning", "completed"],
+    ["recorded success with only a tool warning", true, "warning-only", "completed"],
     ["recorded success with source reply plus warning", true, "source-warning", "completed"],
   ] as const)(
     "projects agent-run terminal: $0",
@@ -4392,7 +4393,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       const runId = `idem-agent-terminal-${name.replaceAll(" ", "-")}`;
       const failed = outcome === "failed" || presentation === "error";
       const sourceReply = presentation === "source" || presentation === "source-warning";
-      const replyText = "Partial agent reply";
+      const replyText = presentation === "warning-only" ? "⚠️ Exec failed" : "Partial agent reply";
       const errorMessage =
         presentation === "error"
           ? agentStarted
@@ -4425,7 +4426,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             mediaUrls: [mediaUrl],
           }),
         ];
-      } else if (presentation === "empty") {
+      } else if (presentation === "empty" || presentation === "warning-only") {
         mockState.finalText = "";
       } else if (presentation === "error") {
         mockState.dispatchedReplies = [
@@ -4438,10 +4439,14 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         mockState.runtimeAssistantTextsBeforeDelivery = [replyText];
         mockState.dispatchedReplies = [{ kind: "final", payload: { text: replyText } }];
       }
-      if (presentation === "warning" || presentation === "source-warning") {
+      if (
+        presentation === "warning" ||
+        presentation === "warning-only" ||
+        presentation === "source-warning"
+      ) {
         mockState.dispatchedReplies.push({
           kind: "final",
-          payload: { text: "tool warning", isError: true },
+          payload: { text: "⚠️ Exec failed", isError: true },
         });
       }
       if (outcome) {
@@ -4497,7 +4502,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           }),
         ]);
         expect(broadcasts[0]).not.toHaveProperty("message");
-      } else if (sourceReply) {
+      } else if (sourceReply || presentation === "warning-only") {
         expect(broadcasts).toEqual([expect.objectContaining({ runId, state: "final" })]);
         expect(extractFirstTextBlock(broadcasts[0])).toBe(replyText);
       } else {


### PR DESCRIPTION
Closes #135068

## What Problem This Solves

Fixes an issue where users would see the agent stop without an explanation when exec failed and the model produced no visible answer. The failure remained in the tool transcript, but its only user-facing warning disappeared before delivery. Credit to **nick.sy** for the Discord report, acknowledged by **zeroSignal**; the report and original links are preserved in #135068.

## Why This Change Was Made

The warning producer reused a reserved internal tool-progress format. The trace-filter change in d2d3171bb766289d7c59170a4bc3c4dd79859c38 (#111877) consequently removed real host warnings as well as model-echoed traces. Warnings now use the canonical tool display label and existing escaped details, without the internal progress prefix. The shared, Control UI, and Discord trace filters remain unchanged.

A separate regression in 13186412420b6003c33a19064578dc5ebe0055f7 (#132182) correctly made recorded runtime completion authoritative, but left native warning-only WebChat replies without a final delivery owner. Those replies now use the existing append-and-broadcast flow. A completed agent run remains completed; the failed tool and its visible explanation are separate facts.

The warning owner also records its tool name in private payload metadata. Cron uses that fact instead of guessing warning identity from display text, retaining its existing exec/bash recovery and message-delivery rules. This does not change configuration, protocol, schema, dependencies, tool exit classification, or warning suppression/verbosity policy.

## User Impact

An otherwise silent failed-exec turn now displays and retains a warning. Existing normal answers still suppress an extra warning. Informational nonzero exit codes retain their existing behavior; this does not undo the explicit exit-status policy from #115737.

## Evidence

The real isolated development Gateway, exec tool, shell, dispatcher, WebSocket events, and transcript store were exercised with a deterministic local QA provider. Only model inference was mocked. Temporary state, synthetic authentication, and a free non-18789 port were used; the owned Gateway was confirmed stopped and its state removed.

```text
command: printf SILENT_EXEC_STARTED; exit 127
model's final reply: NO_REPLY

Before:
  real exec calls: 1
  tool output returned to model: yes
  stored toolResult.isError: true
  agent.wait.status: ok
  final warning in chat events/history: absent

After:
  real exec calls: 1
  tool output returned to model: yes
  stored toolResult.isError: true
  agent.wait.status: ok
  final chat message: ⚠️ Exec failed
  persisted assistant warning: exactly 1
  Control UI text extractor: ⚠️ Exec failed
  owned Gateway: confirmed-stopped
  temporary state: removed
```

Four live cases passed in order: exit 7 + `NO_REPLY` retains the settled-turn fallback without repeating exec; exit 127 + `NO_REPLY` emits the warning; exits 7 and 127 + a normal final reply each deliver that reply once, without an extra warning. Every case ran exec exactly once. Actual transcript messages passed through the Control UI's production text extractor and matched final WebSocket messages.

The exec/bash payload regression tests failed on the old formatter with an empty delivery list. The WebChat warning-only regression failed on unchanged Gateway code with no final broadcast. Cron's new unmarked-error cases also failed against the old text-based classifier.

Passing focused checks: 213 WebChat tests; 81 reply-normalization tests; 42 warning-producer tests; 5 process-error sibling tests; 48 cron helper tests; 18 cron lifecycle tests; 25 cron meta-error tests; 186 tool-event handler tests. The earlier ACP completion sibling run passed 16/16 after an unchanged isolated rerun (its initial combined cold run timed out in three cases). All were run through `node scripts/run-vitest.mjs`.

Pre-commit and exact-branch Codex autoreview are clean at the requested P0 scope. The complete `node scripts/check-changed.mjs` gate passed for the original 13 changed paths and the additional tool-event test file. An earlier attempt caught a new test-helper name collision; it was corrected and the full gate rerun. The first exact-head CI run found six tool-event cases sharing two stale warning-label assertions; both assertions were corrected without changing production behavior; all 186 tests in that file pass. Exact-head CI passed on `a6c6e3036ec595d5e87fe6c67ee4834916b806ed`: [run 33500097457](https://github.com/openclaw/openclaw/actions/runs/33500097457), including `openclaw/ci-gate`; the complete PR rollup has 230 passing and 42 skipped checks, with none outstanding.

Limits: historical release comparison uses raw-parent patch/source proof (present in v2026.8.1, absent from v2026.7.1), not a full historical application build. The original Discord report had no exact failing command, so this proves a matching regression rather than every reported occurrence. Browser automation was unavailable through the configured Chrome relay; rendered-browser screenshots and a live Discord round-trip are not claimed.

Production: **+67/-87, net -20**. Tests: **+133/-83, net +50**. Docs: **+2**. No changelog edit.

Follow-up pass: a separate refactor will remove the provably dead private nonterminal-warning return plumbing left by the earlier two-rule warning policy, while preserving the public metadata/predicate contract. Separately noted for a future audit: Discord's existing changed-text sanitizer clone does not copy private payload metadata; this repair leaves its filters and clone path unchanged.

Pre-land ClawSweeper review: the completed current-head review found no introduced correctness/security defect. Its two remaining process items are satisfied: exact-head CI is green, and this PR remains the canonical repair for #135068. The later same-head review-start placeholder does not change that completed review. Separate main-CI investigation is tracked in #135144.
