### PR TITLE
test: retain bounded live provider failure diagnostics

### DIFF
--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -123,6 +123,7 @@ import { redactSecrets } from "../logging/redact.js";
 import { normalizeGooglePreviewModelId } from "../plugin-sdk/provider-model-shared.js";
 import { resolveEffectiveThinkingProfile } from "../plugins/provider-thinking.js";
 import { LEGACY_IMPLICIT_AGENT_ID as DEFAULT_AGENT_ID } from "../routing/session-key.js";
+import { extractErrorHttpStatus } from "../shared/assistant-error-format.js";
 import { stripAssistantInternalScaffolding } from "../shared/text/assistant-visible-text.js";
 import { findFinalTagMatches, stripFinalTags } from "../shared/text/final-tags.js";
 import { deleteTestEnvValue, setTestEnvValue, withEnvAsync } from "../test-utils/env.js";
@@ -1035,7 +1036,114 @@ describe("isGatewayLiveModelTimeout", () => {
   });
 });
 
+describe("formatGatewayLiveFailureDiagnostic", () => {
+  it.each([
+    ["google", "gemini-3.1-pro-preview", "503 Service unavailable", "provider-unavailable", 503],
+    ["anthropic", "claude-sonnet-4-6", "429 rate limit", "rate-limit", 429],
+    ["google", "gemini-3.1-pro-preview", "request timed out", "timeout", undefined],
+    [
+      "google",
+      "gemini-3.1-pro-preview",
+      "upstream error from google",
+      "provider-unavailable",
+      undefined,
+    ],
+    ["google", "gemini-3.1-pro-preview", "unexpected reply", "unclassified", undefined],
+  ])(
+    "preserves %s failure facts through the agent.wait envelope: %s / %s",
+    (provider, model, message, classification, explicitHttpStatus) => {
+      const error = formatGatewayLiveAgentWaitFailure({
+        context: "probe",
+        runId: "private-run-id",
+        result: { status: "error", error: message, providerStarted: true },
+      });
+      expect(
+        JSON.parse(
+          formatGatewayLiveFailureDiagnostic({ provider, model, phase: "tool-read", error }),
+        ),
+      ).toEqual({
+        provider,
+        model,
+        phase: "tool-read",
+        classification,
+        ...(explicitHttpStatus ? { explicitHttpStatus } : {}),
+        providerStarted: true,
+      });
+    },
+  );
+
+  it("omits bodies, URLs, credentials and arbitrary exception metadata without losing explicit status", () => {
+    const body =
+      "private-customer-body https://private.invalid/customer?note=private-value Bearer synthetic-private-token";
+    const error = Object.assign(new Error(`503 Service unavailable ${body}`), {
+      code: "OPAQUE_PRIVATE_CREDENTIAL",
+      provider: body,
+      model: body,
+      cause: { classification: body, providerStarted: body },
+    });
+    for (const failure of [
+      error,
+      formatGatewayLiveAgentWaitFailure({
+        context: body,
+        runId: body,
+        result: { status: body, error: error.message, providerStarted: body, stopReason: body },
+      }),
+    ]) {
+      const diagnostic = formatGatewayLiveFailureDiagnostic({
+        provider: "google",
+        model: "gemini-3.1-pro-preview",
+        phase: "tool-read",
+        error: failure,
+      });
+      expect(JSON.parse(diagnostic)).toEqual({
+        provider: "google",
+        model: "gemini-3.1-pro-preview",
+        phase: "tool-read",
+        classification: "provider-unavailable",
+        explicitHttpStatus: 503,
+      });
+      expect(diagnostic).not.toMatch(/private|https|Bearer|OPAQUE/);
+    }
+  });
+
+  it.each([
+    ["p".repeat(128), "m".repeat(256)],
+    ["p".repeat(129), "m".repeat(257)],
+    ["https://private.invalid", "model\nprivate"],
+  ])("keeps identifiers bounded and emits valid JSON", (provider, model) => {
+    const diagnostic = formatGatewayLiveFailureDiagnostic({
+      provider,
+      model,
+      phase: "tool-only-followup",
+      error: new Error("x".repeat(10_000)),
+    });
+    expect(`[live] failure ${diagnostic}\n`.length).toBeLessThanOrEqual(1024);
+    expect(JSON.parse(diagnostic)).toMatchObject({
+      phase: "tool-only-followup",
+      classification: "unclassified",
+    });
+    expect(diagnostic).not.toMatch(/private|https|xxxxx/);
+  });
+});
+
 describe("formatGatewayLiveAgentWaitFailure", () => {
+  it("retains body-free failure evidence before agent.wait flattens the provider error", () => {
+    const failure = formatGatewayLiveAgentWaitFailure({
+      context: "google tool-read",
+      runId: "private-run-id",
+      result: {
+        status: "error",
+        error: "503 Service unavailable: private response body https://private.invalid/customer",
+        providerStarted: true,
+      },
+    });
+    expect(failure.cause).toEqual({
+      classification: "provider-unavailable",
+      explicitHttpStatus: 503,
+      providerStarted: true,
+    });
+  });
+
   it("includes terminal attribution fields without requiring transcript text", () => {
     expect(
       formatGatewayLiveAgentWaitFailure({
@@ -3960,6 +4068,72 @@ async function waitForSessionAssistantText(params: {
   throw new Error(`${timeoutLabel} timeout after ${timeoutMs}ms (${params.context})`);
 }
 
+type GatewayLiveProbePhase =
+  | "session"
+  | "prompt"
+  | "ultra-handoff"
+  | "tool-read"
+  | "tool-exec"
+  | "image"
+  | "tool-only"
+  | "tool-only-followup"
+  | "refusal";
+
+function summarizeGatewayLiveFailure(error: unknown) {
+  const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  return {
+    classification:
+      shouldSkipLiveProviderDrift({
+        error: message,
+        allowAuth: true,
+        allowBilling: true,
+        allowModelNotFound: true,
+        allowProviderUnavailable: true,
+        allowRateLimit: true,
+        allowTimeout: true,
+      })?.reason ?? "unclassified",
+    // An explicit status in the received text is evidence, not an inferred HTTP outcome.
+    explicitHttpStatus: extractErrorHttpStatus(message)?.code,
+  };
+}
+
+class GatewayLiveAgentWaitError extends Error {
+  constructor(
+    message: string,
+    override readonly cause: ReturnType<typeof summarizeGatewayLiveFailure> & {
+      providerStarted?: boolean;
+    },
+  ) {
+    super(message, { cause });
+  }
+}
+
+function formatGatewayLiveFailureDiagnostic(params: {
+  provider: string;
+  model: string;
+  phase: GatewayLiveProbePhase;
+  error: unknown;
+}): string {
+  const identifier = (value: string, limit: number) => {
+    const redacted = redactSecrets(value);
+    return redacted.length <= limit &&
+      /^[a-z0-9][a-z0-9._/-]*$/i.test(redacted) &&
+      !redacted.includes("//")
+      ? redacted
+      : "omitted";
+  };
+  // Secret redaction alone retains arbitrary response bodies and private URLs.
+  // Serialize only closed diagnostic facts; never add error prose or stack traces.
+  return JSON.stringify({
+    provider: identifier(params.provider, 128),
+    model: identifier(params.model, 256),
+    phase: params.phase,
+    ...(params.error instanceof GatewayLiveAgentWaitError
+      ? params.error.cause
+      : summarizeGatewayLiveFailure(params.error)),
+  });
+}
+
 function formatGatewayLiveAgentWaitFailure(params: {
   context: string;
   runId: string;
@@ -3984,10 +4158,16 @@ function formatGatewayLiveAgentWaitFailure(params: {
     typeof result?.stopReason === "string" ? `stopReason=${result.stopReason}` : undefined,
     typeof result?.error === "string" ? `error=${result.error}` : undefined,
   ].filter((value): value is string => Boolean(value));
-  return new Error(
+  return new GatewayLiveAgentWaitError(
     `${params.context}: agent.wait ${status} for runId=${params.runId}${
       details.length > 0 ? ` (${details.join(", ")})` : ""
     }`,
+    {
+      ...summarizeGatewayLiveFailure(result?.error),
+      ...(typeof result?.providerStarted === "boolean"
+        ? { providerStarted: result.providerStarted }
+        : {}),
+    },
   );
 }
 
@@ -5663,6 +5843,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
         if (model.provider === "anthropic" && anthropicKeys.length > 0) {
           process.env.ANTHROPIC_API_KEY = anthropicKeys[attempt];
         }
+        let phase: GatewayLiveProbePhase = "session";
         try {
           const modelResult = await withGatewayLiveModelTimeout<"done" | "skip">(
             (async () => {
@@ -5680,6 +5861,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
                 });
               }
 
+              phase = "prompt";
               logProgress(`${progressLabel}: prompt`);
               let text = await requestGatewayAgentText({
                 client,
@@ -5786,6 +5968,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
                   expectedProvider: normalizeProviderId(model.provider),
                   expectedModelId: model.id,
                 });
+                phase = "ultra-handoff";
                 logProgress(`${progressLabel}: ultra sessions_spawn handoff`);
                 await verifyGatewayUltraSubagentHandoff({
                   client,
@@ -5798,6 +5981,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
               }
 
               // Real tool invocation: force the agent to Read a local file and echo a nonce.
+              phase = "tool-read";
               logProgress(`${progressLabel}: tool-read`);
               const runIdTool = randomUUID();
               const maxToolReadAttempts = 3;
@@ -5889,6 +6073,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
               }
 
               if (params.extraToolProbes) {
+                phase = "tool-exec";
                 logProgress(`${progressLabel}: tool-exec`);
                 const nonceC = randomUUID();
                 // Timeout wrappers do not cancel late tool runs, so keep provider-key attempts
@@ -5970,6 +6155,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
               }
 
               if (params.extraImageProbes && model.input?.includes("image")) {
+                phase = "image";
                 logProgress(`${progressLabel}: image`);
                 // Shorter code => less OCR flake across providers, still tests image attachments end-to-end.
                 const imageCode = randomImageProbeCode();
@@ -6031,6 +6217,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
                 (model.provider === "openai" && model.api === "openai-responses") ||
                 (model.provider === "openai" && model.api === "openai-chatgpt-responses")
               ) {
+                phase = "tool-only";
                 logProgress(`${progressLabel}: tool-only regression`);
                 const runId2 = randomUUID();
                 const firstText = await requestGatewayAgentText({
@@ -6050,6 +6237,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
                   label: params.label,
                 });
 
+                phase = "tool-only-followup";
                 const reply = await requestGatewayAgentText({
                   client,
                   sessionKey,
@@ -6071,6 +6259,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
               }
 
               if (model.provider === "anthropic") {
+                phase = "refusal";
                 await runAnthropicRefusalProbe({
                   client,
                   sessionKey,
@@ -6091,6 +6280,9 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
           logProgress(`${progressLabel}: done`);
           break;
         } catch (err) {
+          logProgress(
+            `failure ${formatGatewayLiveFailureDiagnostic({ provider: model.provider, model: model.id, phase, error: err })}`,
+          );
           const message = String(err);
           if (
             model.provider === "anthropic" &&


### PR DESCRIPTION
The live Gateway model suite can classify an upstream failure as a skip and then correctly fail its zero-success guard, but the skip discards the error evidence needed to diagnose the failure. Full release job 99811190956 reached the Google prompt and tool-read phases, then reported provider unavailability without retaining an upstream status. The old log cannot establish whether that was quota, service availability, or another upstream condition.

Retain a bounded, body-free diagnostic at the common per-model failure boundary before existing retry/skip decisions. The test-local agent.wait error carries only canonical classification, explicit received-text HTTP status when available, and the provider-started boolean; the diagnostic adds source-selected provider/model and the active probe phase. Reuse the existing classifier, status parser, and identifier redactor. Unknown status stays unknown.

Do not log error prose, request/response bodies, URLs, stacks, auth profiles, or arbitrary exception metadata. Keep all existing error messages, retries, deadlines, skip rules, prompts, tool assertions, and zero-success enforcement unchanged. No production helper, configuration, dependency, or product behavior changes. Production LOC delta: 0; test/support: +193/−1.

Validation:

- Pre-fix regression failed because agent.wait discarded the diagnostic evidence.
- All offline owner/sibling tests passed: 174 passed, two live cases skipped deliberately.
- Final focused diagnostics/privacy checks passed: 15 tests.
- Complete changed-file gate passed after resolving an absent dependency in the isolated local checkout; manifests and lockfile were unchanged.
- Managed Codex review returned scoped-clean; the final lint correction narrows unknown values to unclassified rather than coercing arbitrary objects.

Exact-head hosted CI [33498957478](https://github.com/openclaw/openclaw/actions/runs/33498957478) passed, including the required aggregate gate (122 successful jobs, 17 skipped). A single real native Linux Google smoke on head 26b8a8ffdcc8d8687fb1b696a6dc0e17a631b3d5 passed the meaningful prompt, tool-read, and completion in 34.3s. Node 24.19.0 / pnpm 12.1.0; canonical source build passed in 37.1s. HEAD/tree/full source inventory were bound, source remained unchanged, private state/processes were cleaned up, and the temporary worker was stopped. The other 175 cases were outside the focused command.

ClawSweeper rank-up disposition: the requested real Google failure trace is unavailable because this exact-head live attempt succeeded. It is not presented as failure-path proof. The reproduced regression and synthetic agent.wait-envelope/privacy tests prove the failure record and unchanged message handling; the real provider run separately proves the normal prompt/tool flow still works. No artificial upstream failure, changed skip rule, or extra retry was used to manufacture that trace. This is a maintainer-owned test-support change with zero application runtime delta; accepting these complementary proofs while explicitly retaining that gap.

This is native source/build-worker evidence, not Docker/npm package or full-release certification. The original frozen run's availability failure remains unexplained. Existing failure summaries outside this new diagnostic retain their previous behavior.
