### PR TITLE
fix: retire late plugin loads when the Gateway shuts down

### DIFF
--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -3512,36 +3512,40 @@ describe("startGatewayPostAttachRuntime", () => {
     }
   });
 
-  it("fences plugin publication when close begins during deferred plugin loading", async () => {
+  it("retires unadopted startup plugins when close begins during deferred loading", async () => {
     let closeStarted = false;
-    let releasePluginLoad: (() => void) | undefined;
-    const pluginLoadReady = new Promise<void>((resolve) => {
-      releasePluginLoad = resolve;
-    });
+    const pluginLoadStarted = createDeferred();
+    const pluginLoadReady = createDeferred();
+    const retireGatewayRuntimeBindings = vi.fn();
     const onStartupPluginsLoaded = vi.fn();
     const startGatewaySidecarsValue = vi.fn(async () => ({
       pluginServices: null,
       postReadySidecars: [],
     }));
     const runtime = await startGatewayPostAttachRuntime(
-      {
-        ...createPostAttachParams({
-          sidecarStartup: "defer",
-          isClosing: () => closeStarted,
-          loadStartupPlugins: async () => {
-            await pluginLoadReady;
-            return { pluginRegistry: createPostAttachParams().pluginRegistry, gatewayMethods: [] };
-          },
-          onStartupPluginsLoaded,
-        }),
-      },
+      createPostAttachParams({
+        sidecarStartup: "defer",
+        isClosing: () => closeStarted,
+        loadStartupPlugins: async () => {
+          pluginLoadStarted.resolve();
+          await pluginLoadReady.promise;
+          return {
+            pluginRegistry: createPostAttachParams().pluginRegistry,
+            gatewayMethods: [],
+            retireGatewayRuntimeBindings,
+          };
+        },
+        onStartupPluginsLoaded,
+      }),
       createPostAttachRuntimeDeps({ startGatewaySidecars: startGatewaySidecarsValue }),
     );
 
+    await pluginLoadStarted.promise;
     closeStarted = true;
-    releasePluginLoad?.();
+    pluginLoadReady.resolve();
     await expect(runtime.startupSettled).resolves.toBeUndefined();
 
+    expect(retireGatewayRuntimeBindings).toHaveBeenCalledOnce();
     expect(onStartupPluginsLoaded).not.toHaveBeenCalled();
     expect(startGatewaySidecarsValue).not.toHaveBeenCalled();
   });

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -1283,7 +1283,8 @@ export async function startGatewayPostAttachRuntime(
         params.loadStartupPlugins!(),
       );
       await params.pluginRuntimeClaim?.waitForUnblocked();
-      if (params.pluginRuntimeClaim?.isCurrent() === false) {
+      if (params.isClosing?.() || params.pluginRuntimeClaim?.isCurrent() === false) {
+        // Shutdown only owns attached bindings; retire unadopted results here.
         loaded.retireGatewayRuntimeBindings?.();
         pluginRegistry = params.getCurrentPluginRegistry?.() ?? pluginRegistry;
         startupPluginsLoaded = true;
@@ -1298,9 +1299,7 @@ export async function startGatewayPostAttachRuntime(
         ],
         ["gatewayMethodCount", loaded.gatewayMethods.length],
       ]);
-      if (params.isClosing?.() !== true) {
-        await params.onStartupPluginsLoaded?.(loaded);
-      }
+      await params.onStartupPluginsLoaded?.(loaded);
       return loaded;
     })();
     return await startupPluginsLoadPromise;


### PR DESCRIPTION
Related: #130324 (Gateway CPU investigation); split from #130706 (Gateway metadata ownership refactor).

<details>
<summary>Additional instructions</summary>

Maintainers can push to this repository branch.

</details>

## What Problem This Solves

Resolves a problem where stopping a Gateway during deferred plugin startup could leave the late plugin's Gateway bindings unretired. This is a focused shutdown cleanup repair; it does not claim to resolve the full CPU incident.

## Why This Change Was Made

Shutdown owns only bindings already attached to the Gateway. A late load could still have a current generation claim, while the later close check skipped attachment without retiring the result. Fold shutdown into the existing stale-result retirement path and remove the redundant later close guard. No new lifecycle owner, API, configuration, or persistence format is introduced.

Production: **+3/-4 (net -1)**. Existing regression test: **+21/-17 (net +4)**. No new test file.

## User Impact

Plugins that finish loading after shutdown begins are retired instead of retaining an unadopted Gateway binding. Normal attachment, generation replacement, and shutdown ordering are preserved. No operator action is required.

## Evidence

The revised existing test waits for the loader to enter before starting shutdown. On unchanged production it fails because retirement is called zero times rather than once. With the fix, that case and five existing attachment, generation-replacement, plugin-service-close, and worker-start-close cases pass: **6 passed**.

The two touched files are unchanged upstream through `b4385b818629cd674ffc75c5a859776bd167b99d`. Formatting and `git diff --check` pass. Independent Codex review completed with no accepted/actionable P0 findings. Test process groups and isolated state were cleaned up.

Exact focused commands (Node 24.19.0; private pnpm 12.1.0 installation):

```sh
node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts -t 'retires unadopted startup plugins when close begins during deferred loading' --maxWorkers=2 --reporter=verbose --reporter=json --outputFile=.artifacts/startup-close/before/vitest.json
node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts -t 'retires unadopted startup plugins when close begins during deferred loading|waits for startup plugin attachment before channel sidecars|adopts a winning plugin generation without publishing stale deferred startup state|returns before loading startup plugins with deferred sidecars|stops plugin services that finish starting after deferred close begins|stops worker placement once when close begins while it starts' --maxWorkers=2 --reporter=verbose --reporter=json --outputFile=.artifacts/startup-close/after/vitest.json
```

The same deterministic real Gateway integration case also fails before and passes after the fix. A temporary fixture in the existing `server-plugins.lifecycle.test.ts` loads a real registered plugin, holds the original asynchronous loader's return, closes the Gateway through its public server handle, then releases the result. The binding is available before close; the startup claim remains current; the already-attached registry is unchanged. Unpatched code calls retirement zero times; the fix calls it exactly once. The unchanged case produced **1 failed / 4 skipped before**, then **1 passed / 4 skipped after**, with identical prerequisites and limits. Both process groups drained and isolated state was removed.

The 89-line integration fixture is validation-only; the permanent PR remains two files and net +4 test lines. This is real Gateway integration with a test-only scheduling gate, not an uninstrumented CLI, external-provider, channel, or CPU-performance proof.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33499321200) passed at `dd54d3405a16367751a3e01f1bc51082fd7d39d0`. The [ClawSweeper review](https://github.com/openclaw/openclaw/pull/135122#issuecomment-5492868745) found no actionable code issue; its requested lifecycle integration and exact-head CI are now complete.
