### PR TITLE
fix(ci): stop skipping lint on changed root tests

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1145,6 +1145,7 @@ Local changed-lane logic lives in `scripts/changed-lanes.mjs` and is executed by
 
 - core production changes run core prod and core test typecheck plus core lint/guards;
 - core test-only changes run only core test typecheck plus core lint;
+- root TypeScript tests and support files run root test typecheck plus targeted type-aware lint within `test/tsconfig/tsconfig.test.root.json`; the discoverable `test/tsconfig.json` inherits that source-only program. It includes `.ts`, `.tsx`, `.d.mts`, and `.d.cts`, not ordinary `.mts`/`.cts`; fixtures and built-artifact Docker clients stay outside targeted root lint;
 - extension production changes run extension prod and extension test typecheck plus extension lint;
 - extension test-only changes run extension test typecheck plus extension lint;
 - bundled channel manifests, package metadata, config schemas, UI hints, and generator owners also run the bundled channel config metadata drift check;

--- a/scripts/changed-lanes.mts
+++ b/scripts/changed-lanes.mts
@@ -23,8 +23,6 @@ export function hasDeadcodeScannedSource(changedPaths: string[]): boolean {
 
 const SCRIPTS_TYPECHECK_PATH_RE =
   /^(?:scripts\/.*\.(?:[cm]?ts|[cm]?tsx)|tsconfig\.scripts\.json)$/u;
-const TEST_ROOT_TYPECHECK_PATH_RE =
-  /^(?:test\/(?!fixtures\/).*\.(?:[cm]?ts|[cm]?tsx)|test\/tsconfig\/tsconfig\.test\.root\.json)$/u;
 /** @internal Shared repository-script contract. */
 export const LIVE_DOCKER_AUTH_SHELL_TARGETS = [
   "scripts/lib/live-docker-auth.sh",
@@ -161,7 +159,11 @@ export function detectChangedLanes(
     if (SCRIPTS_TYPECHECK_PATH_RE.test(changedPath)) {
       lanes.scripts = true;
     }
-    if (TEST_ROOT_TYPECHECK_PATH_RE.test(changedPath)) {
+    if (
+      facts.isRootTestSource ||
+      changedPath === "test/tsconfig.json" ||
+      changedPath === "test/tsconfig/tsconfig.test.root.json"
+    ) {
       lanes.testRoot = true;
     }
 

--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -9,6 +9,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
@@ -113,6 +114,7 @@ const SHRINK_RATCHET_OWNER_PATH = "scripts/lib/shrink-ratchet.mts";
 const CORE_OXLINT_TS_CONFIG = "config/tsconfig/oxlint.core.json";
 const EXTENSIONS_OXLINT_TS_CONFIG = "extensions/tsconfig.json";
 const SCRIPTS_OXLINT_TS_CONFIG = "config/tsconfig/oxlint.scripts.json";
+const ROOT_TEST_TS_CONFIG = "test/tsconfig/tsconfig.test.root.json";
 const TARGETED_LINT_PATH_LIMIT = 8;
 const LINTABLE_CORE_PATH_RE = /^(?:src|ui|packages)\/.+\.[cm]?[jt]sx?$/u;
 const LINTABLE_EXTENSION_PATH_RE = /^extensions\/[^/]+\/.+\.[cm]?[jt]sx?$/u;
@@ -495,6 +497,42 @@ export function createChangedCheckPlan(
   const addTypecheck = (name: string, args: string[]) =>
     typechecks.add(add(name, args, createSparseTsgoSkipEnv(baseEnv)));
   const finishPlan = (summary: string) => {
+    // Full lint shards exclude test/. Keep changed root sources covered even
+    // when another path selects the all-lane early return, without widening lint.
+    let rootTestTargets = result.paths.filter(
+      (file) => getChangedPathFacts(file).isRootTestSource && existsSync(file),
+    );
+    if (rootTestTargets.length > 0) {
+      // --tsconfig affects import resolution, not native semantic discovery or
+      // target selection. Expand the canonical roots before passing explicit files.
+      const ts = createRequire(import.meta.url)("typescript") as typeof import("typescript");
+      const config = ts.getParsedCommandLineOfConfigFile(
+        path.resolve(ROOT_TEST_TS_CONFIG),
+        {},
+        {
+          ...ts.sys,
+          onUnRecoverableConfigFileDiagnostic(diagnostic) {
+            throw new Error(ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"));
+          },
+        },
+      );
+      if (!config || config.errors.length > 0) {
+        throw new Error(
+          `Invalid ${ROOT_TEST_TS_CONFIG}: ${config?.errors.map((error) => ts.flattenDiagnosticMessageText(error.messageText, "\n")).join("\n")}`,
+        );
+      }
+      const roots = new Set(config.fileNames.map((file) => path.resolve(file)));
+      rootTestTargets = rootTestTargets.filter((file) => roots.has(path.resolve(file)));
+    }
+    for (let offset = 0; offset < rootTestTargets.length; offset += TARGETED_LINT_PATH_LIMIT) {
+      const batch = rootTestTargets.slice(offset, offset + TARGETED_LINT_PATH_LIMIT);
+      addCommand(
+        batch.length === 1 ? "lint test root changed file" : "lint test root changed files",
+        "node",
+        ["scripts/run-oxlint.mjs", "--tsconfig", ROOT_TEST_TS_CONFIG, ...batch],
+        baseEnv,
+      );
+    }
     const end = commands.findLastIndex((command) => typechecks.has(command)) + 1;
     const prefix = commands.slice(0, end);
     // These audits produce diagnostics, not compiler inputs. Defer them without
@@ -1012,6 +1050,7 @@ function createTargetedOxlintCommand({
         !LINTABLE_CORE_PATH_RE.test(changedPath) &&
         !LINTABLE_EXTENSION_PATH_RE.test(changedPath) &&
         !LINTABLE_SCRIPT_PATH_RE.test(changedPath) &&
+        !getChangedPathFacts(changedPath).isRootTestSource &&
         !neutralPathRe.test(changedPath) &&
         !MARKDOWN_LINT_OPTIMIZATION_NEUTRAL_PATH_RE.test(changedPath),
     )

--- a/scripts/lib/changed-path-facts.mjs
+++ b/scripts/lib/changed-path-facts.mjs
@@ -31,6 +31,7 @@ const TEST_ONLY_PATH_RE =
   /(^test\/|\/test\/|\/tests\/|(?:^|\/)[^/]+\.(?:test|spec|suite|test-utils|test-(?:helpers|support|harness)|e2e-harness)\.[cm]?[jt]sx?$)/u;
 const NATIVE_ONLY_PATH_RE =
   /^(?:apps\/android\/|apps\/ios\/|apps\/macos\/|apps\/macos-mlx-tts\/|apps\/shared\/|apps\/swabble\/|Swabble\/|appcast\.xml$)/u;
+const ROOT_TEST_SOURCE_PATH_RE = /^test\/(?!fixtures\/).*\.[cm]?tsx?$/u;
 
 /**
  * Normalizes a changed file path into repo-relative POSIX form.
@@ -47,7 +48,7 @@ export function normalizeChangedPath(inputPath) {
 /**
  * Returns shared path facts without imposing a caller's lane-selection policy.
  * @param {unknown} inputPath
- * @returns {{ path: string; surface: ChangedPathSurface; isChangedLaneTest: boolean; isTestOnly: boolean; isNativeOnly: boolean }}
+ * @returns {{ path: string; surface: ChangedPathSurface; isChangedLaneTest: boolean; isRootTestSource: boolean; isTestOnly: boolean; isNativeOnly: boolean }}
  */
 export function getChangedPathFacts(inputPath) {
   const path = typeof inputPath === "string" ? inputPath.trim() : "";
@@ -57,6 +58,7 @@ export function getChangedPathFacts(inputPath) {
     path,
     surface,
     isChangedLaneTest: CHANGED_LANE_TEST_PATH_RE.test(path),
+    isRootTestSource: ROOT_TEST_SOURCE_PATH_RE.test(path),
     isTestOnly: TEST_ONLY_PATH_RE.test(path),
     isNativeOnly: NATIVE_ONLY_PATH_RE.test(path),
   };

--- a/scripts/run-oxlint.mts
+++ b/scripts/run-oxlint.mts
@@ -47,6 +47,7 @@ const OXLINT_VALUE_FLAGS = new Set([
 const OXLINT_BOUNDARY_FREE_TS_CONFIGS = new Set([
   "config/tsconfig/oxlint.core.json",
   "config/tsconfig/oxlint.scripts.json",
+  "test/tsconfig/tsconfig.test.root.json",
 ]);
 const OPENCLAW_FOCUSED_CONFIG_FLAG = "--openclaw-focused-config";
 
@@ -65,7 +66,7 @@ export function shouldPrepareExtensionPackageBoundaryArtifacts(args: string[]) {
     }
     return arg.startsWith("--tsconfig=") ? [arg.slice("--tsconfig=".length)] : [];
   });
-  // Core and script lint resolve workspace sources through the root tsconfig;
+  // Core, script, and root-test lint resolve sources through the root tsconfig;
   // generated plugin package declarations are only an extension-lint input.
   return (
     tsconfigs.length === 0 ||

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -1,6 +1,14 @@
 // Changed Lanes tests cover changed lanes script behavior.
 import { execFileSync, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -135,6 +143,61 @@ function writeRepoFile(repoDir: string, filePath: string, contents: string): voi
 }
 
 const prettyJson = (value: unknown) => `${JSON.stringify(value, null, 2)}\n`;
+
+function createRootTestLintFixture() {
+  const dir = makeTempRepoRoot(tempDirs, "openclaw-changed-root-lint-");
+  git(dir, ["init", "-q", "--initial-branch=main"]);
+  writeRepoFile(dir, "README.md", "Synthetic changed-check fixture.\n");
+  commitAll(dir, "fixture base");
+  for (const file of [
+    ".oxlintrc.json",
+    "tsconfig.json",
+    "test/tsconfig.json",
+    "test/tsconfig/tsconfig.test.json",
+    "test/tsconfig/tsconfig.test.root.json",
+    "test/vitest/vitest.test-shards.d.mts",
+  ]) {
+    writeRepoFile(dir, file, readFileSync(path.join(repoRoot, file), "utf8"));
+  }
+  for (const [file, source] of Object.entries({
+    "src/plugin-sdk/discovery.ts":
+      "export function work(): Promise<void> { return Promise.resolve(); }",
+    "src/contracts.d.ts": "declare function fromCore(): Promise<void>;",
+    "ui/contracts.d.ts": "declare function fromUi(): Promise<void>;",
+    "packages/contracts.d.ts": "declare function fromPackage(): Promise<void>;",
+  })) {
+    writeRepoFile(dir, file, source);
+  }
+  symlinkSync(path.join(repoRoot, "node_modules"), path.join(dir, "node_modules"), "junction");
+  mkdirSync(path.join(dir, "scripts"));
+  for (const script of ["run-oxlint.mjs", "report-test-temp-creations.mjs"]) {
+    symlinkSync(path.join(repoRoot, "scripts", script), path.join(dir, "scripts", script));
+  }
+  // Stub unrelated package gates at the executable boundary: real pnpm could
+  // reconcile the linked toolchain. The CLI and source-only lint wrapper stay real.
+  const binDir = path.join(dir, "bin");
+  for (const bin of ["pnpm", "corepack"]) {
+    writeRepoFile(dir, `bin/${bin}`, "#!/bin/sh\nexit 0\n");
+    chmodSync(path.join(binDir, bin), 0o755);
+    writeRepoFile(dir, `bin/${bin}.cmd`, "@echo off\r\nexit /b 0\r\n");
+  }
+  const env: NodeJS.ProcessEnv = {
+    ...createNestedGitEnv(),
+    OXC_LOG: "debug",
+    PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+  };
+  delete env.OPENCLAW_TESTBOX;
+  delete env.OPENCLAW_OXLINT_SKIP_PREPARE;
+  return {
+    dir,
+    run: (script: string, args: string[]) =>
+      spawnSync(process.execPath, [path.join(repoRoot, script), ...args], {
+        cwd: dir,
+        encoding: "utf8",
+        env,
+      }),
+  };
+}
 
 // Executes the exact "format changed files" plan command with the repo-pinned oxfmt,
 // reconstructing `pnpm format:check <plan args>`. Guards the runtime verdict, not just
@@ -515,6 +578,7 @@ describe("scripts/changed-lanes", () => {
       "pnpm tsgo:test:root",
       "pnpm check:coercion-helpers",
       "pnpm lint:scripts",
+      "node scripts/run-oxlint.mjs --tsconfig test/tsconfig/tsconfig.test.root.json test/scripts/github-activity-helper.test.ts",
     ]);
   });
 
@@ -684,6 +748,157 @@ describe("scripts/changed-lanes", () => {
 
     const result = runChangedFormatLaneWithRepoOxfmt(dir, ["src/deleted.ts", "src/kept.ts"]);
     expect(result.status).toBe(0);
+  });
+
+  it.each([
+    { name: "a root test", count: 1, extension: "ts", otherPaths: [] },
+    {
+      name: "an all-lane mixed diff",
+      count: 1,
+      extension: "tsx",
+      otherPaths: ["vitest.config.ts"],
+    },
+    { name: "the ninth root test", count: 9, extension: "ts", otherPaths: [] },
+  ])(
+    "fails real changed-check lint for $name and passes after repair",
+    ({ count, extension, otherPaths }) => {
+      const { dir, run } = createRootTestLintFixture();
+      const targets = Array.from(
+        { length: count },
+        (_, index) => `test/root-lint-${index}.test.${extension}`,
+      );
+      const broken = targets[count - 1]!;
+      const violation = [
+        'import { work } from "openclaw/plugin-sdk/discovery";',
+        "export function run(ready: boolean) {",
+        "  if (ready) return;",
+        "  work(); fromCore(); fromUi(); fromPackage();",
+        "}",
+        "run(false);",
+        "",
+      ].join("\n");
+      for (const target of targets) {
+        writeRepoFile(dir, target, "export const ready = true;\n");
+      }
+      writeRepoFile(dir, broken, violation);
+      // Neither excluded fixtures nor unchanged tests may be swept into targeted lint.
+      writeRepoFile(dir, "test/fixtures/invalid.ts", violation);
+      writeRepoFile(dir, "test/unchanged.test.ts", violation);
+      const paths = [...targets, "test/fixtures/invalid.ts", "test/deleted.test.ts", ...otherPaths];
+      const failed = run("scripts/check-changed.mjs", ["--base", "HEAD", "--", ...paths]);
+      const diagnostics = failed.stdout + failed.stderr;
+      expect(failed.error, diagnostics).toBeUndefined();
+      expect(failed.status, diagnostics).toBe(1);
+      expect(diagnostics).toContain("eslint(curly)");
+      expect(
+        diagnostics.match(/typescript\(no-floating-promises\)/gu) ?? [],
+        diagnostics,
+      ).toHaveLength(4);
+      expect(diagnostics).toContain(broken);
+      expect(failed.stderr.trim().split("\n").at(-1)).toBe("[check:changed] FAILED (exit 1)");
+
+      writeRepoFile(
+        dir,
+        broken,
+        violation
+          .replace("if (ready) return;", "if (ready) { return; }")
+          .replace(
+            "work(); fromCore(); fromUi(); fromPackage();",
+            "void work(); void fromCore(); void fromUi(); void fromPackage();",
+          ),
+      );
+      const passed = run("scripts/check-changed.mjs", ["--base", "HEAD", "--", ...paths]);
+      expect(passed.error, passed.stdout + passed.stderr).toBeUndefined();
+      expect(passed.status, passed.stdout + passed.stderr).toBe(0);
+      const planned = run("scripts/check-changed.mjs", [
+        "--dry-run",
+        "--base",
+        "HEAD",
+        "--",
+        ...paths,
+      ]);
+      expect(planned.status, planned.stderr).toBe(0);
+      const lintPrefix =
+        "node scripts/run-oxlint.mjs --tsconfig test/tsconfig/tsconfig.test.root.json ";
+      const batches = planned.stderr
+        .split("\n")
+        .filter((line) => line.includes(lintPrefix))
+        .map((line) => line.slice(line.indexOf(lintPrefix) + lintPrefix.length).split(" "));
+      expect(batches.map((batch) => batch.length)).toEqual(count === 9 ? [8, 1] : [1]);
+      expect(batches.flat()).toEqual(targets);
+    },
+  );
+
+  it("discovers the canonical root test program and preserves ambient and source-alias types", () => {
+    const { dir, run } = createRootTestLintFixture();
+    const sources = ["test/discovery.test.ts", "test/component.test.tsx"];
+    const declarations = ["test/vitest/vitest.test-shards.d.mts", "test/vitest/common.d.cts"];
+    const modules = ["test/plain.mts", "test/plain.cts"];
+    for (const file of sources) {
+      writeRepoFile(
+        dir,
+        file,
+        'import { work } from "openclaw/plugin-sdk/discovery";\nwork(); fromCore(); fromUi(); fromPackage();\n',
+      );
+    }
+    writeRepoFile(dir, declarations[1]!, "export declare function work(): Promise<void>;\n");
+    for (const file of modules) {
+      writeRepoFile(dir, file, "void Promise.resolve();\n");
+    }
+    const selected = [...sources, ...declarations, ...modules];
+    const result = run("scripts/run-oxlint.mjs", [
+      "--tsconfig",
+      "test/tsconfig/tsconfig.test.root.json",
+      "--format",
+      "json",
+      ...selected,
+    ]);
+    expect(result.error, result.stderr).toBeUndefined();
+    expect(result.status, result.stdout + result.stderr).toBe(1);
+    const report = JSON.parse(result.stdout) as {
+      number_of_files: number;
+      diagnostics: { filename: string; code: string }[];
+    };
+    expect(report.number_of_files).toBe(selected.length);
+    for (const file of selected) {
+      // Ordinary .mts/.cts are deliberately outside the canonical root program;
+      // declarations with those suffixes are existing program roots.
+      const project = modules.includes(file) ? "<none>" : path.join(dir, "test/tsconfig.json");
+      expect(result.stderr.replaceAll("\\", "/"), result.stdout).toContain(
+        `Got tsconfig for file ${path.join(dir, file).replaceAll("\\", "/")}: ${project.replaceAll("\\", "/")}`,
+      );
+    }
+    for (const file of sources) {
+      expect(
+        report.diagnostics
+          .filter((diagnostic) => diagnostic.filename === file)
+          .map((diagnostic) => diagnostic.code),
+        result.stdout,
+      ).toEqual(Array.from({ length: 4 }, () => "typescript(no-floating-promises)"));
+    }
+    const config = run("scripts/run-tsgo.mjs", ["--showConfig", "-p", "test/tsconfig.json"]);
+    expect(config.error, config.stderr).toBeUndefined();
+    expect(config.status, config.stdout + config.stderr).toBe(0);
+    const project = JSON.parse(config.stdout) as {
+      files: string[];
+      compilerOptions: { types: string[] };
+    };
+    const roots = project.files.map((file) => path.resolve(dir, "test", file));
+    expect(roots).toEqual(
+      expect.arrayContaining(
+        [
+          ...sources,
+          ...declarations,
+          "src/contracts.d.ts",
+          "ui/contracts.d.ts",
+          "packages/contracts.d.ts",
+        ].map((file) => path.join(dir, file)),
+      ),
+    );
+    for (const file of modules) {
+      expect(roots).not.toContain(path.join(dir, file));
+    }
+    expect(project.compilerOptions.types).toEqual(expect.arrayContaining(["node", "vitest"]));
   });
 
   it("uses the merge commit first parent instead of a stale PR payload base", () => {
@@ -872,11 +1087,12 @@ describe("scripts/changed-lanes", () => {
     });
   });
 
-  it("targets mixed core, extension, and script lint without full-owner fan-out", () => {
+  it("targets mixed core, extension, script, and root test lint without full-owner fan-out", () => {
     const result = detectChangedLanes([
       "src/gateway/node-registry.ts",
       "extensions/lmstudio/src/models.fetch.ts",
       "scripts/check-changed.mjs",
+      "test/helpers/temp-dir.ts",
     ]);
     const plan = createChangedCheckPlan(result, { env: { PATH: "/usr/bin" } });
 
@@ -907,6 +1123,15 @@ describe("scripts/changed-lanes", () => {
             "--tsconfig",
             "config/tsconfig/oxlint.scripts.json",
             "scripts/check-changed.mjs",
+          ],
+        }),
+        expect.objectContaining({
+          name: "lint test root changed file",
+          args: [
+            "scripts/run-oxlint.mjs",
+            "--tsconfig",
+            "test/tsconfig/tsconfig.test.root.json",
+            "test/helpers/temp-dir.ts",
           ],
         }),
       ]),
@@ -1084,22 +1309,64 @@ describe("scripts/changed-lanes", () => {
   });
 
   it.each([
+    ["test/ordinary.test.ts", true, true],
+    ["test/scripts/owner.test.ts", true, true],
+    ["test/helpers/support.ts", true, true],
+    ["test/component.test.tsx", true, true],
     ["test/vitest/foo.config.ts", true, true],
     ["test/vitest/vitest-runtime-helper.d.mts", true, true],
-    ["test/fixtures/foo.ts", false, true],
-    ["test/foo.mjs", false, true],
-    ["test/tsconfig/tsconfig.test.root.json", true, true],
+    ["test/vitest/vitest-runtime-helper.d.cts", true, true],
+    ["test/plain.mts", true, false],
+    ["test/plain.cts", true, false],
+    ["test/e2e/qa-lab/runtime/system-agent-first-run-docker-client.ts", true, false],
+    ["test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts", true, false],
+    ["test/deleted.test.ts", true, false],
+    ["test/fixtures/foo.ts", false, false],
+    ["test/foo.mjs", false, false],
+    ["test/tsconfig/tsconfig.test.root.json", true, false],
+    ["test/tsconfig.json", true, false],
   ])(
-    "routes %s to testRoot=%s and tooling=%s",
-    (changedPath, expectedTestRoot, expectedTooling) => {
-      const result = detectChangedLanes([changedPath]);
-      const plan = createChangedCheckPlan(result);
-
-      expect(result.lanes.testRoot).toBe(expectedTestRoot);
-      expect(result.lanes.tooling).toBe(expectedTooling);
-      expect(plan.commands.map((command) => command.args[0]).includes("tsgo:test:root")).toBe(
-        expectedTestRoot,
+    "routes %s to root typecheck=%s and targeted lint=%s",
+    (changedPath, expectedTestRoot, expectedLint) => {
+      const { dir, run } = createRootTestLintFixture();
+      if (!changedPath.endsWith(".json")) {
+        writeRepoFile(
+          dir,
+          changedPath,
+          expectedLint
+            ? "export const ready = true;\n"
+            : 'if (true) console.log("excluded");\nPromise.resolve();\n',
+        );
+      }
+      if (changedPath === "test/deleted.test.ts") {
+        unlinkSync(path.join(dir, changedPath));
+      }
+      const result = run("scripts/check-changed.mjs", [
+        "--dry-run",
+        "--base",
+        "HEAD",
+        "--",
+        changedPath,
+      ]);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stderr.includes("would run: pnpm tsgo:test:root")).toBe(expectedTestRoot);
+      if (!expectedLint) {
+        const excluded = run("scripts/check-changed.mjs", ["--base", "HEAD", "--", changedPath]);
+        expect(excluded.error, excluded.stderr).toBeUndefined();
+        expect(excluded.status, excluded.stdout + excluded.stderr).toBe(0);
+        expect(excluded.stderr).not.toContain("lint test root changed");
+      }
+      const lintCommands = result.stderr
+        .split("\n")
+        .filter((line) => line.includes("would run:") && line.includes("run-oxlint.mjs"));
+      expect(lintCommands).toEqual(
+        expectedLint
+          ? [
+              `[check:changed:dry-run] would run: node scripts/run-oxlint.mjs --tsconfig test/tsconfig/tsconfig.test.root.json ${changedPath}`,
+            ]
+          : [],
       );
+      expect(result.stderr).not.toContain("would run: pnpm lint\n");
     },
   );
 

--- a/test/scripts/oxlint-config.test.ts
+++ b/test/scripts/oxlint-config.test.ts
@@ -325,9 +325,10 @@ describe("oxlint config", () => {
       diagnostics: Array<{ code: string }>;
     };
     expect(report.number_of_files).toBe(selected.length);
-    expect(report.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(
-      Array.from({ length: 5 }, () => "typescript(no-floating-promises)"),
-    );
+    expect(
+      report.diagnostics.map((diagnostic) => diagnostic.code),
+      result.stdout,
+    ).toEqual(Array.from({ length: 5 }, () => "typescript(no-floating-promises)"));
     for (const file of selected) {
       const config = file.endsWith("/runtime.ts")
         ? "extensions/sample/tsconfig.json"
@@ -382,13 +383,6 @@ describe("oxlint config", () => {
     expect(tsconfig.include).toContain("**/*.mts");
     expect(tsconfig.exclude ?? []).not.toContain("**/*.ts");
     expect(tsconfig.exclude ?? []).not.toContain("**/*.mts");
-  });
-
-  it("has a discoverable test tsconfig for type-aware linting", () => {
-    const tsconfig = readJson("test/tsconfig.json") as OxlintTsconfig;
-
-    expect(tsconfig.include).toContain("**/*.ts");
-    expect(tsconfig.exclude ?? []).not.toContain("**/*.ts");
   });
 
   it("does not ignore the bundled extensions tree", () => {

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -335,6 +335,7 @@ describe("run-oxlint", () => {
     ["--tsconfig", "config/tsconfig/oxlint.core.json", "src/index.ts"],
     ["--tsconfig=config/tsconfig/oxlint.core.json", "src/index.ts"],
     ["--tsconfig", "config/tsconfig/oxlint.scripts.json", "scripts/check-changed.mts"],
+    ["--tsconfig", "test/tsconfig/tsconfig.test.root.json", "test/scripts/changed-lanes.test.ts"],
   ])("skips extension artifacts for an exact source-backed config: %s", (...args) => {
     expect(shouldPrepareExtensionPackageBoundaryArtifacts(args)).toBe(false);
   });

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,9 +1,6 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "./tsconfig/tsconfig.test.root.json",
   "compilerOptions": {
-    "noEmit": true,
     "types": ["node", "vitest"]
-  },
-  "include": ["**/*.ts"],
-  "exclude": ["fixtures/**"]
+  }
 }


### PR DESCRIPTION
Closes #135104

## What Problem This Solves

Fixes an issue where developers running the changed-file checks could get a successful result without type-aware lint running on changed TypeScript tests and support files under `test/`. The omission also affected mixed changes that selected the all-lane plan, and a bounded targeted path must not silently drop the ninth or later file.

## Why This Change Was Made

The changed-check finalizer now schedules every existing changed root-test member in bounded batches. It uses the existing canonical root-test configuration to select members rather than copying its exclusion rules. The discoverable `test/tsconfig.json` inherits that same configuration, so native tsgolint discovery uses the intended source aliases and ambient declarations.

Both boundaries matter: Oxlint's `--tsconfig` controls import resolution, not the native semantic project's discovery, and explicitly naming a file bypasses TypeScript project exclusions for lint selection. The repair therefore aligns native project discovery and explicit target membership. It removes the divergent test-config include/exclude lists and avoids unnecessary plugin-declaration preparation for source-backed root lint. Plugin lint retains its declaration prerequisite.

Provenance: the dedicated root-test lane was added as a typecheck-only lane in [the root-test typecheck change](https://github.com/openclaw/openclaw/pull/104475), authored and merged by @steipete on July 11, 2026. The raw parent-to-commit patch confirms that shape; it does not establish that lint coverage was removed in that change. The later TypeScript migration carried that behavior forward.

## User Impact

Developers get real type-aware lint for changed `.ts`, `.tsx`, `.d.mts`, and `.d.cts` files within the canonical root-test program. Unchanged files, deleted files, fixtures, ordinary `.mts`/`.cts` files outside that program, and the existing excluded built-artifact Docker clients are not swept into targeted root lint. There is no application-runtime or channel behavior change, new dependency, lint rule, product configuration option, or baseline relaxation.

The change adds 44 net tooling-source lines, removes 3 net tooling-configuration lines, adds 262 net test lines, and adds one documentation line. The source growth supplies the previously missing bounded lint scheduling and canonical membership check; it does not introduce a second semantic checker or a copied exclusion policy.

## Evidence

Pre-integration native proof used the repository-pinned Node 24.15.0, TypeScript 6.0.3, Oxlint 1.79.0, and tsgolint 7.0.2001:

- The final regression tests produced nine intended failures against the earlier divergent owners, then passed all 20 selected checks against the repaired owners with identical test-file hashes.
- Real native semantic probes detected one versus eight intended Promise violations before/after the discovery repair. The passing form proves source aliases and ambient declarations in both `.ts` and `.tsx`, plus actual declaration-module project membership.
- Explicitly passing the excluded Docker clients still produced diagnostics. The repaired changed-check flow proves those paths are not passed to lint, rather than assuming config exclusions suppress explicit input.
- The complete six-file owner/sibling command passed 394 tests. Both typechecks, explicit source/test lint, and the actual nine-path changed gate passed. The gate included scripts lint over 844 files and root lint over the three changed test files.
- Independent full source review closed the semantic-project discovery finding and its proof gap with no actionable P0-P3 findings. Separate restricted P0 autoreview was clean.

Current-main integration is committed as `bc1b382bb3b0530b78015398dc15bf6ca60a870f`, based on `833a38b92555cbbac7d8763b2a57378b12cdca90`. The rebase was conflict-free and range-diff preserved the repair. All 14 integrated commands passed on the unchanged commit, including the normal frozen installation refresh. The complete six-file run passed **399 tests** (5 + 394), adding main's three Swift-routing and two CI-selector controls to the earlier total. The focused regression passed 20 tests; both typechecks, explicit lint and the actual nine-path changed gate passed. The integrated gate linted 852 script files and exactly the three changed root-test files.

Exact integrated commands:

```bash
node scripts/run-vitest.mjs test/scripts/changed-lanes.test.ts test/scripts/changed-path-facts.test.ts test/scripts/changed-lanes-generated-extension-lint.test.ts test/scripts/run-oxlint.test.ts test/scripts/oxlint-config.test.ts src/scripts/ci-changed-scope.test.ts --reporter=verbose --maxConcurrency=1
```

```bash
node scripts/check-changed.mjs --base 833a38b92555cbbac7d8763b2a57378b12cdca90 -- docs/ci.md scripts/changed-lanes.mts scripts/check-changed.mts scripts/lib/changed-path-facts.mjs scripts/run-oxlint.mts test/scripts/changed-lanes.test.ts test/scripts/oxlint-config.test.ts test/scripts/run-oxlint.test.ts test/tsconfig.json
```

Fresh restricted P0 review and independent full P0-P3 source review of the integrated commit are clean, with no outstanding required local proof gaps. Hosted CI and the normal native landing gates remain required. A warning-only temp-helper migration aid flags the new fixture's use of the existing registered suite helper. Its canonical `afterEach` cleanup ran successfully and left no fixture directories; no warning suppression or cleanup bypass was added.
