### PR TITLE
refactor(talk): share Apple voice configuration helpers

### DIFF
--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -372,37 +372,24 @@ enum TalkModeGatewayConfigParser {
             allowLegacyFallback: false)
         let activeProvider = selection?.provider ?? defaultProvider
         let activeConfig = selection?.config
-        let voiceAliases: [String: String]
-        if let aliases = activeConfig?["voiceAliases"]?.dictionaryValue {
-            var resolved: [String: String] = [:]
-            for (key, value) in aliases {
-                guard let id = value.stringValue else { continue }
-                let normalizedKey = key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-                let trimmedId = id.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !normalizedKey.isEmpty, !trimmedId.isEmpty else { continue }
-                resolved[normalizedKey] = trimmedId
-            }
-            voiceAliases = resolved
-        } else {
-            voiceAliases = [:]
-        }
-        let model = Self.firstString(activeConfig, keys: ["modelId", "model"])
+        let voiceAliases = TalkVoiceAliases.normalizedMap(activeConfig?["voiceAliases"])
+        let model = TalkConfigParsing.firstNonEmptyString(activeConfig, keys: ["modelId", "model"])
         let defaultModelId = (model?.isEmpty == false) ? model! : defaultModelIdFallback
-        let defaultVoiceId = Self.firstString(activeConfig, keys: ["voiceId", "voice"])
-        let defaultOutputFormat = Self.firstString(activeConfig, keys: ["outputFormat"])
+        let defaultVoiceId = TalkConfigParsing.firstNonEmptyString(activeConfig, keys: ["voiceId", "voice"])
+        let defaultOutputFormat = TalkConfigParsing.firstNonEmptyString(activeConfig, keys: ["outputFormat"])
         let realtime = talk?["realtime"]?.dictionaryValue
         let realtimeProviders = realtime?["providers"]?.dictionaryValue
-        let realtimeProvider = Self.firstString(realtime, keys: ["provider"])
-            ?? Self.singleRealtimeProviderId(realtimeProviders)
-        let realtimeProviderConfig = Self.realtimeProviderConfig(
+        let realtimeProvider = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["provider"])
+            ?? TalkConfigParsing.singleRealtimeProviderID(realtimeProviders)
+        let realtimeProviderConfig = TalkConfigParsing.realtimeProviderConfig(
             providers: realtimeProviders,
             provider: realtimeProvider)
-        let realtimeModel = Self.firstString(realtime, keys: ["model"])
-            ?? Self.firstString(realtimeProviderConfig, keys: ["model"])
+        let realtimeModel = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["model"])
+            ?? TalkConfigParsing.firstNonEmptyString(realtimeProviderConfig, keys: ["model"])
         let realtimeModelId = realtimeModel ?? defaultRealtimeModelIdFallback
-        let realtimeVoiceId = Self.firstString(realtime, keys: ["voice"])
-            ?? Self.firstString(realtimeProviderConfig, keys: ["voice"])
-        let realtimeTransport = Self.firstString(realtime, keys: ["transport"])?.lowercased()
+        let realtimeVoiceId = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["voice"])
+            ?? TalkConfigParsing.firstNonEmptyString(realtimeProviderConfig, keys: ["voice"])
+        let realtimeTransport = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["transport"])?.lowercased()
         // Direct provider WebRTC can answer before consulting the agent, so this explicit
         // policy must stay on the relay that enforces final-transcript consultations.
         let requiresForcedAgentConsultRelay = Self.requiresForcedAgentConsultRelay(realtime)
@@ -410,7 +397,7 @@ enum TalkModeGatewayConfigParser {
             || realtimeTransport == "gateway-relay"
             || realtimeTransport == "provider-websocket"
             || Self.usesAzureOpenAI(provider: realtimeProvider, config: realtimeProviderConfig)
-        let openAIProviderConfig = Self.realtimeProviderConfig(
+        let openAIProviderConfig = TalkConfigParsing.realtimeProviderConfig(
             providers: realtimeProviders,
             provider: "openai")
         let openAIRequiresGatewayRealtimeTransport = requiresForcedAgentConsultRelay
@@ -448,17 +435,8 @@ enum TalkModeGatewayConfigParser {
             speechLocaleID: speechLocaleID)
     }
 
-    private static func firstString(_ config: [String: AnyCodable]?, keys: [String]) -> String? {
-        guard let config else { return nil }
-        for key in keys {
-            let value = config[key]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
-            if value?.isEmpty == false { return value }
-        }
-        return nil
-    }
-
     private static func requiresForcedAgentConsultRelay(_ realtime: [String: AnyCodable]?) -> Bool {
-        self.firstString(realtime, keys: ["consultRouting"])?.lowercased() == "force-agent-consult"
+        TalkConfigParsing.firstNonEmptyString(realtime, keys: ["consultRouting"])?.lowercased() == "force-agent-consult"
     }
 
     private static func resolvedExecutionMode(
@@ -466,11 +444,11 @@ enum TalkModeGatewayConfigParser {
         requiresGatewayRealtimeTransport: Bool) -> TalkModeExecutionMode
     {
         guard let realtime else { return .native }
-        let mode = Self.firstString(realtime, keys: ["mode"])?.lowercased()
-        let transport = Self.firstString(realtime, keys: ["transport"])?.lowercased()
-        let provider = Self.firstString(realtime, keys: ["provider"])?.lowercased()
-            ?? Self.singleRealtimeProviderId(realtime["providers"]?.dictionaryValue)?.lowercased()
-        let brain = Self.firstString(realtime, keys: ["brain"])?.lowercased()
+        let mode = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["mode"])?.lowercased()
+        let transport = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["transport"])?.lowercased()
+        let provider = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["provider"])?.lowercased()
+            ?? TalkConfigParsing.singleRealtimeProviderID(realtime["providers"]?.dictionaryValue)?.lowercased()
+        let brain = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["brain"])?.lowercased()
         guard mode == "realtime" else {
             return .native
         }
@@ -506,32 +484,6 @@ enum TalkModeGatewayConfigParser {
         config: [String: AnyCodable]?) -> Bool
     {
         guard provider?.caseInsensitiveCompare("openai") == .orderedSame else { return false }
-        return self.firstString(config, keys: ["azureEndpoint", "azureDeployment"]) != nil
-    }
-
-    private static func singleRealtimeProviderId(_ providers: [String: AnyCodable]?) -> String? {
-        guard let providers, providers.count == 1 else { return nil }
-        let provider = providers.keys.first?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return provider?.isEmpty == false ? provider : nil
-    }
-
-    private static func realtimeProviderConfig(
-        providers: [String: AnyCodable]?,
-        provider: String?) -> [String: AnyCodable]?
-    {
-        guard let providers else { return nil }
-        if let provider {
-            if let exact = providers[provider]?.dictionaryValue {
-                return exact
-            }
-            return providers.first { key, _ in
-                key.trimmingCharacters(in: .whitespacesAndNewlines)
-                    .caseInsensitiveCompare(provider) == .orderedSame
-            }?.value.dictionaryValue
-        }
-        if providers.count == 1 {
-            return providers.values.first?.dictionaryValue
-        }
-        return nil
+        return TalkConfigParsing.firstNonEmptyString(config, keys: ["azureEndpoint", "azureDeployment"]) != nil
     }
 }

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -2963,7 +2963,7 @@ final class TalkModeManager: NSObject {
         do {
             let started = Date()
             let requestedVoice = directive?.voiceId?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let resolvedVoice = resolveVoiceAlias(requestedVoice)
+            let resolvedVoice = TalkVoiceAliases.resolve(requestedVoice, aliases: self.voiceAliases)
             if requestedVoice?.isEmpty == false, resolvedVoice == nil {
                 self.logger.warning("unknown voice alias \(requestedVoice ?? "?", privacy: .public)")
             }
@@ -3285,7 +3285,9 @@ final class TalkModeManager: NSObject {
     private func applyDirective(_ directive: TalkDirective?) {
         let requestedVoice = directive?.voiceId?.trimmingCharacters(in: .whitespacesAndNewlines)
         let usesGatewayVoiceIds = self.runtimeRoute.usesGatewayTalkSpeak
-        let resolvedVoice = usesGatewayVoiceIds ? requestedVoice : resolveVoiceAlias(requestedVoice)
+        let resolvedVoice = usesGatewayVoiceIds
+            ? requestedVoice
+            : TalkVoiceAliases.resolve(requestedVoice, aliases: self.voiceAliases)
         if !usesGatewayVoiceIds, requestedVoice?.isEmpty == false, resolvedVoice == nil {
             self.logger.warning("unknown voice alias \(requestedVoice ?? "?", privacy: .public)")
         }
@@ -3632,7 +3634,7 @@ final class TalkModeManager: NSObject {
         speechGeneration: Int) async -> IncrementalSpeechContext
     {
         let requestedVoice = directive?.voiceId?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolvedVoice = resolveVoiceAlias(requestedVoice)
+        let resolvedVoice = TalkVoiceAliases.resolve(requestedVoice, aliases: self.voiceAliases)
         if requestedVoice?.isEmpty == false, resolvedVoice == nil {
             self.logger.warning("unknown voice alias \(requestedVoice ?? "?", privacy: .public)")
         }
@@ -3965,19 +3967,6 @@ private struct IncrementalSpeechBuffer {
 }
 
 extension TalkModeManager {
-    func resolveVoiceAlias(_ value: String?) -> String? {
-        let trimmed = (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        let normalized = trimmed.lowercased()
-        if let mapped = voiceAliases[normalized] {
-            return mapped
-        }
-        if self.voiceAliases.values.contains(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) {
-            return trimmed
-        }
-        return Self.isLikelyVoiceId(trimmed) ? trimmed : nil
-    }
-
     func resolveVoiceId(
         preferred: String?,
         apiKey: String,
@@ -3987,10 +3976,10 @@ extension TalkModeManager {
         if !trimmed.isEmpty {
             // Config / directives can provide a raw ElevenLabs voiceId (not an alias).
             // Accept it directly to avoid unnecessary listVoices calls (and accidental fallback selection).
-            if Self.isLikelyVoiceId(trimmed) {
+            if TalkVoiceAliases.isLikelyID(trimmed) {
                 return trimmed
             }
-            if let resolved = resolveVoiceAlias(trimmed) {
+            if let resolved = TalkVoiceAliases.resolve(trimmed, aliases: self.voiceAliases) {
                 return resolved
             }
             self.logger.warning("unknown voice alias \(trimmed, privacy: .public)")
@@ -4021,11 +4010,6 @@ extension TalkModeManager {
             self.logger.error("elevenlabs list voices failed: \(error.localizedDescription, privacy: .public)")
             return nil
         }
-    }
-
-    static func isLikelyVoiceId(_ value: String) -> Bool {
-        guard value.count >= 10 else { return false }
-        return value.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }
     }
 
     private static func normalizedTalkApiKey(_ raw: String?) -> String? {

--- a/apps/macos/Sources/OpenClaw/TalkModeGatewayConfig.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeGatewayConfig.swift
@@ -50,14 +50,7 @@ enum TalkModeGatewayConfigParser {
         let ui = snapshot.config?["ui"]?.dictionaryValue
         let rawSeam = ui?["seamColor"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let voice = activeConfig?["voiceId"]?.stringValue
-        let rawAliases = activeConfig?["voiceAliases"]?.dictionaryValue
-        let resolvedAliases: [String: String] =
-            rawAliases?.reduce(into: [:]) { acc, entry in
-                let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-                let value = entry.value.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                guard !key.isEmpty, !value.isEmpty else { return }
-                acc[key] = value
-            } ?? [:]
+        let resolvedAliases = TalkVoiceAliases.normalizedMap(activeConfig?["voiceAliases"])
         let model = activeConfig?["modelId"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
         let resolvedModel: String? = if model?.isEmpty == false {
             model!
@@ -76,20 +69,23 @@ enum TalkModeGatewayConfigParser {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let realtime = talk?["realtime"]?.dictionaryValue
         let realtimeProviders = realtime?["providers"]?.dictionaryValue
-        let realtimeProvider = Self.firstString(realtime, keys: ["provider"])
-            ?? Self.singleRealtimeProviderId(realtimeProviders)
-        let realtimeProviderConfig = Self.realtimeProviderConfig(
+        let realtimeProvider = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["provider"])
+            ?? TalkConfigParsing.singleRealtimeProviderID(realtimeProviders)
+        let realtimeProviderConfig = TalkConfigParsing.realtimeProviderConfig(
             providers: realtimeProviders,
             provider: realtimeProvider)
-        let realtimeModelId = Self.firstString(realtime, keys: ["model"])
-            ?? Self.firstString(realtimeProviderConfig, keys: ["model"])
-        let realtimeSpeakerVoice = Self.firstString(
+        let realtimeModelId = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["model"])
+            ?? TalkConfigParsing.firstNonEmptyString(realtimeProviderConfig, keys: ["model"])
+        let realtimeSpeakerVoice = TalkConfigParsing.firstNonEmptyString(
             realtime,
             keys: ["speakerVoice", "voice"])
-            ?? Self.firstString(realtimeProviderConfig, keys: ["speakerVoice", "voice"])
-        let realtimeMode = Self.firstString(realtime, keys: ["mode"])?.lowercased()
-        let realtimeTransport = Self.firstString(realtime, keys: ["transport"])?.lowercased()
-        let realtimeBrain = Self.firstString(realtime, keys: ["brain"])?.lowercased()
+            ?? TalkConfigParsing.firstNonEmptyString(
+                realtimeProviderConfig,
+                keys: ["speakerVoice", "voice"])
+        let realtimeMode = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["mode"])?.lowercased()
+        let realtimeTransport =
+            TalkConfigParsing.firstNonEmptyString(realtime, keys: ["transport"])?.lowercased()
+        let realtimeBrain = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["brain"])?.lowercased()
         let resolvedVoice: String? = if activeProvider == defaultProvider {
             (voice?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? voice : nil) ??
                 (envVoice?.isEmpty == false ? envVoice : nil) ??
@@ -160,43 +156,5 @@ enum TalkModeGatewayConfigParser {
             realtimeMode: nil,
             realtimeTransport: nil,
             realtimeBrain: nil)
-    }
-
-    private static func firstString(
-        _ config: [String: AnyCodable]?,
-        keys: [String]) -> String?
-    {
-        guard let config else { return nil }
-        for key in keys {
-            let value = config[key]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
-            if value?.isEmpty == false { return value }
-        }
-        return nil
-    }
-
-    private static func singleRealtimeProviderId(_ providers: [String: AnyCodable]?) -> String? {
-        guard let providers, providers.count == 1 else { return nil }
-        let provider = providers.keys.first?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return provider?.isEmpty == false ? provider : nil
-    }
-
-    private static func realtimeProviderConfig(
-        providers: [String: AnyCodable]?,
-        provider: String?) -> [String: AnyCodable]?
-    {
-        guard let providers else { return nil }
-        if let provider {
-            if let exact = providers[provider]?.dictionaryValue {
-                return exact
-            }
-            return providers.first { key, _ in
-                key.trimmingCharacters(in: .whitespacesAndNewlines)
-                    .caseInsensitiveCompare(provider) == .orderedSame
-            }?.value.dictionaryValue
-        }
-        if providers.count == 1 {
-            return providers.values.first?.dictionaryValue
-        }
-        return nil
     }
 }

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -950,7 +950,7 @@ extension TalkModeRuntime {
         }
 
         let requestedVoice = directive?.voiceId?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolvedVoice = self.resolveVoiceAlias(requestedVoice)
+        let resolvedVoice = TalkVoiceAliases.resolve(requestedVoice, aliases: self.voiceAliases)
         if let requestedVoice, !requestedVoice.isEmpty, resolvedVoice == nil {
             self.logger.warning("talk unknown voice alias \(requestedVoice, privacy: .public)")
         }
@@ -1219,7 +1219,7 @@ extension TalkModeRuntime {
     private func resolveVoiceId(preferred: String?, apiKey: String) async -> String? {
         let trimmed = preferred?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if !trimmed.isEmpty {
-            if let resolved = resolveVoiceAlias(trimmed) {
+            if let resolved = TalkVoiceAliases.resolve(trimmed, aliases: self.voiceAliases) {
                 return resolved
             }
             self.ttsLogger.warning("talk unknown voice alias \(trimmed, privacy: .public)")
@@ -1249,24 +1249,6 @@ extension TalkModeRuntime {
             self.ttsLogger.error("elevenlabs list voices failed: \(error.localizedDescription, privacy: .public)")
             return nil
         }
-    }
-
-    private func resolveVoiceAlias(_ value: String?) -> String? {
-        let trimmed = (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        let normalized = trimmed.lowercased()
-        if let mapped = voiceAliases[normalized] {
-            return mapped
-        }
-        if self.voiceAliases.values.contains(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) {
-            return trimmed
-        }
-        return Self.isLikelyVoiceId(trimmed) ? trimmed : nil
-    }
-
-    private static func isLikelyVoiceId(_ value: String) -> Bool {
-        guard value.count >= 10 else { return false }
-        return value.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }
     }
 
     func stopSpeaking(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkConfigParsing.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkConfigParsing.swift
@@ -37,6 +37,44 @@ public enum TalkConfigParsing {
             normalizedPayload: false)
     }
 
+    public static func firstNonEmptyString(
+        _ config: [String: AnyCodable]?,
+        keys: [String]) -> String?
+    {
+        guard let config else { return nil }
+        for key in keys {
+            let value = config[key]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if value?.isEmpty == false { return value }
+        }
+        return nil
+    }
+
+    public static func singleRealtimeProviderID(_ providers: [String: AnyCodable]?) -> String? {
+        guard let providers, providers.count == 1 else { return nil }
+        let provider = providers.keys.first?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return provider?.isEmpty == false ? provider : nil
+    }
+
+    public static func realtimeProviderConfig(
+        providers: [String: AnyCodable]?,
+        provider: String?) -> [String: AnyCodable]?
+    {
+        guard let providers else { return nil }
+        if let provider {
+            if let exact = providers[provider]?.dictionaryValue {
+                return exact
+            }
+            return providers.first { key, _ in
+                key.trimmingCharacters(in: .whitespacesAndNewlines)
+                    .caseInsensitiveCompare(provider) == .orderedSame
+            }?.value.dictionaryValue
+        }
+        if providers.count == 1 {
+            return providers.values.first?.dictionaryValue
+        }
+        return nil
+    }
+
     public static func resolvedPositiveInt(_ value: AnyCodable?, fallback: Int) -> Int {
         if let timeout = value?.intValue, timeout > 0 {
             return timeout

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkDirective.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkDirective.swift
@@ -61,6 +61,34 @@ public struct TalkDirectiveParseResult: Equatable, Sendable {
     }
 }
 
+public enum TalkVoiceAliases {
+    public static func normalizedMap(_ value: AnyCodable?) -> [String: String] {
+        value?.dictionaryValue?.reduce(into: [:]) { result, entry in
+            let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let value = entry.value.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard !key.isEmpty, !value.isEmpty else { return }
+            result[key] = value
+        } ?? [:]
+    }
+
+    public static func resolve(_ value: String?, aliases: [String: String]) -> String? {
+        let trimmed = (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if let mapped = aliases[trimmed.lowercased()] {
+            return mapped
+        }
+        if aliases.values.contains(where: { $0.caseInsensitiveCompare(trimmed) == .orderedSame }) {
+            return trimmed
+        }
+        return self.isLikelyID(trimmed) ? trimmed : nil
+    }
+
+    public static func isLikelyID(_ value: String) -> Bool {
+        guard value.count >= 10 else { return false }
+        return value.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }
+    }
+}
+
 public enum TalkDirectiveParser {
     public static func parse(_ text: String) -> TalkDirectiveParseResult {
         let normalized = text.replacingOccurrences(of: "\r\n", with: "\n")

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkDirectiveTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkDirectiveTests.swift
@@ -1,7 +1,36 @@
+import Foundation
 import XCTest
 @testable import OpenClawKit
 
 final class TalkDirectiveTests: XCTestCase {
+    func testResolvesNormalizedVoiceAliases() {
+        let aliases = TalkVoiceAliases.normalizedMap(AnyCodable([
+            " Reader ": " Short-ID ", "longalias1": "mapped", "zero": "0",
+            "blank": " ", " ": "ignored", "bool": false,
+            "number": NSNumber(value: 0), "null": NSNull(),
+        ]))
+
+        XCTAssertEqual(aliases, ["reader": "Short-ID", "longalias1": "mapped", "zero": "0"])
+        XCTAssertEqual(TalkVoiceAliases.resolve(" READER ", aliases: aliases), "Short-ID")
+        XCTAssertEqual(TalkVoiceAliases.resolve("short-id", aliases: aliases), "short-id")
+        XCTAssertEqual(TalkVoiceAliases.resolve("longalias1", aliases: aliases), "mapped")
+        XCTAssertEqual(TalkVoiceAliases.resolve("abcdefghij", aliases: aliases), "abcdefghij")
+        XCTAssertNil(TalkVoiceAliases.resolve("unknown", aliases: aliases))
+        XCTAssertNil(TalkVoiceAliases.resolve(nil, aliases: aliases))
+    }
+
+    func testVoiceIDsPreserveUnicodeCharacterSemantics() {
+        for voice in [
+            "声声声声声声声声声声", "١٢٣٤٥٦٧٨٩٠", "abc_def-01",
+            String(repeating: "e\u{301}", count: 10),
+        ] {
+            XCTAssertEqual(TalkVoiceAliases.resolve(voice, aliases: [:]), voice)
+        }
+        for voice in ["abcdefghi", String(repeating: "e\u{301}", count: 9), "abc def012", "😀😀😀😀😀😀😀😀😀😀"] {
+            XCTAssertNil(TalkVoiceAliases.resolve(voice, aliases: [:]))
+        }
+    }
+
     func testParsesDirectiveAndStripsLine() {
         let text = """
         {"voice":"abc123","once":true}


### PR DESCRIPTION
The macOS and iOS Talk clients duplicated voice-alias normalization, resolution and realtime configuration lookup. These mechanics now live in the existing OpenClawKit owners, and both clients use them. Platform-specific defaults, credential precedence, transport routing, gateway voice IDs and the intentionally different raw-ID lookup order remain at their callers.

Production changes are +109/−167: **58 lines removed**, or 54 excluding blank lines. Two focused alias/Unicode cases add 29 test lines. This removes the duplicate implementations without changing configuration or audio behavior.

Validation: 53 baseline and 55 candidate maintained Swift value tests pass, plus 23 isolated existing iOS value cases. Across 66 configuration cases, 860 observations are byte-identical. The capture preserves typed values, optionals and arrays, and canonicalizes dictionary key order; it does not claim raw dictionary iteration-order proof. Source hashes independently tie all 49 copied modules/excerpts to the frozen baseline or reviewed candidate. All 13 selected checks pass, including Swift formatting, syntax, SwiftLint and 1,036 macOS process/packaging test executions.

The local proof compiles actual complete value/configuration modules and clearly identified runtime excerpts. Full application builds, simulator execution and audio playback were not run locally: this checkout lacks the app build dependencies, and the native app launcher requires the disposable CI environment before Keychain setup. Normal macOS and iOS CI remains required before landing. Managed Codex high/P2 review is clean; the lead also read both full runtime owners. The review service rejected the oversized optional whole iOS runtime input, so its successful retry reviewed the complete patch and 30 other source datasets; both receipts are retained.


Maintainer validation: the existing OpenClawKit boundary is the right owner for these identical mechanics. The full iOS and macOS runtime callers were reviewed directly, including their intentional voice-ID lookup difference. Production is −58 lines (−54 nonblank), with +29 test lines; configuration and audio routing behavior are preserved.

Exact-head CI [33499434917](https://github.com/openclaw/openclaw/actions/runs/33499434917) is successful, including `macos-swift`, `ios-build`, screenshot lanes, and the required gate; native dead-code scans also passed. This complements the 860 matching local value observations and source-provenance checks. The latest ClawSweeper review has no actionable finding or rank-up move; its maintainer-review request is addressed. Local runtime-excerpt and reviewer-size limitations remain disclosed above, and no physical audio playback is claimed.
