### PR TITLE
refactor(policy): share channel deny rule guard

### DIFF
--- a/extensions/policy/src/doctor/access-findings.ts
+++ b/extensions/policy/src/doctor/access-findings.ts
@@ -2,8 +2,7 @@ import type { HealthFinding } from "openclaw/plugin-sdk/health";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { CHECK_IDS } from "./check-ids.js";
 import { SUPPORTED_AUTH_PROFILE_METADATA } from "./policy-constants.js";
-import { isChannelDenyRule } from "./policy-runtime.js";
-import { unsupportedPolicyKey } from "./shape-helpers.js";
+import { isChannelDenyRule, unsupportedPolicyKey } from "./shape-helpers.js";
 import { ocPathSegment } from "./utils.js";
 
 export function authProfileMetadataRequirementFindings(

--- a/extensions/policy/src/doctor/policy-runtime.ts
+++ b/extensions/policy/src/doctor/policy-runtime.ts
@@ -17,6 +17,7 @@ import {
   SUPPORTED_AUTH_PROFILE_METADATA,
   SUPPORTED_AUTH_PROFILE_MODES,
 } from "./policy-constants.js";
+import { isChannelDenyRule } from "./shape-helpers.js";
 import { readPolicyStringArray } from "./utils.js";
 
 export const normalizePolicyChannelId: (value: string) => string = normalizeLowercaseStringOrEmpty;
@@ -189,20 +190,6 @@ export function readChannelDenyRules(
       }
       return next;
     });
-}
-
-export function isChannelDenyRule(value: unknown): value is {
-  readonly id?: string;
-  readonly when?: { readonly provider?: string };
-  readonly reason?: string;
-} {
-  return (
-    isRecord(value) &&
-    (value.id === undefined || typeof value.id === "string") &&
-    (value.reason === undefined || typeof value.reason === "string") &&
-    isRecord(value.when) &&
-    typeof value.when.provider === "string"
-  );
 }
 
 export function channelIdsFromFindings(findings: readonly HealthFinding[]): readonly string[] {

--- a/extensions/policy/src/doctor/shape-helpers.ts
+++ b/extensions/policy/src/doctor/shape-helpers.ts
@@ -11,6 +11,20 @@ export function unsupportedPolicyKey(
   return Object.keys(value).find((key) => !allowed.has(key));
 }
 
+export function isChannelDenyRule(value: unknown): value is {
+  readonly id?: string;
+  readonly when?: { readonly provider?: string };
+  readonly reason?: string;
+} {
+  return (
+    isRecord(value) &&
+    (value.id === undefined || typeof value.id === "string") &&
+    (value.reason === undefined || typeof value.reason === "string") &&
+    isRecord(value.when) &&
+    typeof value.when.provider === "string"
+  );
+}
+
 export function policyStringArrayShapeFinding(
   value: unknown,
   params: {

--- a/extensions/policy/src/doctor/strictness.ts
+++ b/extensions/policy/src/doctor/strictness.ts
@@ -9,6 +9,7 @@ import {
 import { ROUTING_MATCH_KINDS } from "../policy-routing.js";
 import { expandPolicyToolRequirement, toolListCoversTool } from "../tool-policy-conformance.js";
 import type { PolicyRuleMetadata } from "./metadata.js";
+import { isChannelDenyRule } from "./shape-helpers.js";
 
 type ExecApprovalAllowlistRequirement = {
   readonly key: string;
@@ -356,18 +357,4 @@ function execApprovalAllowlistRequirementKey(
   argPattern: string | undefined,
 ): string {
   return `${pattern}\0${argPattern ?? ""}`;
-}
-
-function isChannelDenyRule(value: unknown): value is {
-  readonly id?: string;
-  readonly when?: { readonly provider?: string };
-  readonly reason?: string;
-} {
-  return (
-    isRecord(value) &&
-    (value.id === undefined || typeof value.id === "string") &&
-    (value.reason === undefined || typeof value.reason === "string") &&
-    isRecord(value.when) &&
-    typeof value.when.provider === "string"
-  );
 }


### PR DESCRIPTION
## What Problem This Solves

The policy doctor had two identical channel deny-rule validators in separate modules. That duplication made the validation contract easier to drift during future policy maintenance.

## Why This Change Was Made

Moves the unchanged validator into the existing private policy shape helper and routes all three callers through that single owner. This does not change the Plugin SDK, configuration, or runtime behavior.

## User Impact

No user-visible behavior change. Policy validation and strictness comparison now share one canonical channel deny-rule shape check.

## Evidence

- `node_modules/.bin/oxfmt extensions/policy/src/doctor/strictness.ts extensions/policy/src/doctor/policy-runtime.ts extensions/policy/src/doctor/access-findings.ts extensions/policy/src/doctor/shape-helpers.ts`
- `pnpm test extensions/policy/src/doctor/strictness.test.ts extensions/policy/src/doctor/register.test.ts extensions/policy/src/cli.test.ts` (`341` tests passed)
- `pnpm check:changed -- extensions/policy/src/doctor/strictness.ts extensions/policy/src/doctor/policy-runtime.ts extensions/policy/src/doctor/access-findings.ts extensions/policy/src/doctor/shape-helpers.ts` (all changed-surface lanes passed; the sparse checkout initially omitted tracked `ui/config` inputs required by the dead-export scan)
- `node --import tsx scripts/check-deadcode-exports.mts` (passed after materializing the tracked sparse-checkout inputs)
- `pnpm check:import-cycles` (`0` runtime value cycles)
- `git diff --check`
- Autoreview: scoped clean, no accepted or actionable findings
- Production LOC: `+17/-30`, net `-13`
