### PR TITLE
ci: skip full history for release artifact consumers

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -944,7 +944,8 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ github.sha }}
-          fetch-depth: 0
+          # Artifact validation reads the immutable tuple, not source history.
+          fetch-depth: ${{ needs.resolve_target.outputs.package_mode == 'artifact' && 1 || 0 }}
           filter: blob:none
 
       - name: Validate release package source metadata

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1535,6 +1535,7 @@ describe("ci workflow guards", () => {
       );
       expect(checkout.with.ref).toBe("${{ github.sha }}");
       expect(checkout.with["persist-credentials"]).toBe(false);
+      expect(checkout.with.filter).toBe("blob:none");
       const fetchDepth = checkout.with["fetch-depth"];
       expect(
         typeof fetchDepth === "string"

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -120,6 +120,7 @@ function evaluateWorkflowExpression(
     hostedRunnerProfileContract?: boolean;
     matrix?: Record<string, unknown>;
     preflightOutputs?: Record<string, string>;
+    resolveTargetOutputs?: Record<string, string>;
     releaseGate?: boolean;
     repository: string;
     runCheck?: boolean;
@@ -181,6 +182,7 @@ function evaluateWorkflowExpression(
     runner: { environment: context.runnerEnvironment ?? "" },
     steps: context.steps ?? {},
     needs: {
+      resolve_target: { outputs: context.resolveTargetOutputs ?? {} },
       preflight: {
         outputs: {
           frozen_target: String(context.frozenTarget ?? false),
@@ -1519,6 +1521,33 @@ describe("ci workflow guards", () => {
 
     expect(readCiWorkflow()).toEqual(expected);
   });
+
+  it.each([
+    ["artifact", 1],
+    ["source", 0],
+    ["published", 0],
+  ] as const)(
+    "fetches the required release preparation history for %s mode",
+    (packageMode, depth) => {
+      const prepare = readReleaseChecksWorkflow().jobs.prepare_release_package;
+      const checkout = prepare.steps.find(
+        (step: WorkflowStep) => step.name === "Checkout trusted workflow ref",
+      );
+      expect(checkout.with.ref).toBe("${{ github.sha }}");
+      expect(checkout.with["persist-credentials"]).toBe(false);
+      const fetchDepth = checkout.with["fetch-depth"];
+      expect(
+        typeof fetchDepth === "string"
+          ? evaluateWorkflowExpression(fetchDepth, {
+              eventName: "workflow_dispatch",
+              repository: "openclaw/openclaw",
+              runAttempt: 1,
+              resolveTargetOutputs: { package_mode: packageMode },
+            })
+          : fetchDepth,
+      ).toBe(depth);
+    },
+  );
 
   it("gates frozen runtime-pair compatibility on the trusted suite outcome", () => {
     const workflow = readReleaseChecksWorkflow();

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -9665,7 +9665,6 @@ esac
         "resolve_target",
         "Checkout selected ref for reachability fallback",
       ],
-      [RELEASE_CHECKS_WORKFLOW, "prepare_release_package", "Checkout trusted workflow ref"],
       [PACKAGE_ACCEPTANCE_WORKFLOW, "resolve_package", "Checkout package workflow ref"],
       [PLUGIN_NPM_RELEASE_WORKFLOW, "preview_plugins_npm", "Checkout"],
       [PLUGIN_CLAWHUB_RELEASE_WORKFLOW, "preview_plugins_clawhub", "Checkout"],


### PR DESCRIPTION
## What Problem This Solves

Release verification unnecessarily downloads full Git history before consuming an already-built package artifact. In full run 33492317066, candidate job 99810968196 spent 108 of its 113 seconds checking out trusted workflow tooling, delaying downstream Windows upgrade verification.

## Why This Change Was Made

Use a depth-one checkout only when the package mode is `artifact`. That path validates the immutable candidate identity and uploaded artifact through jq and the existing artifact helper; it does not read Git history. Source and published-package modes retain full history.

The exact workflow SHA, credential isolation, blob filtering, producer-attempt checks, package and registry digests, and downstream gates are unchanged.

## User Impact

Less preparation overhead for release verification, with no application behavior, coverage, timeout, or artifact-trust changes. The measured 108 seconds identifies avoidable work; an exact time saving has not yet been measured on the new workflow.

## Evidence

The regression fails before the change for artifact mode and passes afterward; source and published modes retain depth zero. The final four focused workflow suites passed 624 tests with two existing skips. Full workflow checks (including actionlint and zizmor), the changed-file gate, and independent Codex review passed.

Workflow delta: +2/-1, including the explanatory comment. Tests: +30/-1. Application runtime delta: zero.

## Final merge checks

Exact head `52c38fadbb5be13b39330b1fc66ced2b4627b2f7` passed [CI 33500985541](https://github.com/openclaw/openclaw/actions/runs/33500985541), including required gate 99836163822. The first CI run exposed a sibling test that still required full history unconditionally; that obsolete table entry was removed, while the explicit artifact/source/published mode coverage remains. This was a test correction followed by new exact-head CI, not a blind retry.

Both ClawSweeper rank-up requests are complete. I personally inspected pinned checkout `3d3c42e5aac5ba805825da76410c181273ba90b1`: [action.yml](https://github.com/actions/checkout/blob/3d3c42e5aac5ba805825da76410c181273ba90b1/action.yml) defines fetch-depth, [input-helper.ts](https://github.com/actions/checkout/blob/3d3c42e5aac5ba805825da76410c181273ba90b1/src/input-helper.ts) converts the evaluated input with Number and Math.floor, and [git-source-provider.ts](https://github.com/actions/checkout/blob/3d3c42e5aac5ba805825da76410c181273ba90b1/src/git-source-provider.ts) sends positive depth to the targeted fetch while retaining all-history behavior for zero. The expression yields 1 for artifact mode and 0 for source/published mode. Independent managed review and the local changed-file gate passed on the unchanged final patch. No measured post-change wall-time saving is claimed yet.
