### PR TITLE
fix(cli): spawn wrapper shims by their resolved path

### DIFF
--- a/src/agents/cli-executable-identity.test.ts
+++ b/src/agents/cli-executable-identity.test.ts
@@ -212,6 +212,28 @@ describe("CLI executable implementation identity", () => {
     }
   });
 
+  it("spawns a wrapper shim by its resolved path instead of the real target", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-shim-"));
+    tempDirs.push(root);
+    const realBinary = path.join(root, "mise");
+    const shim = path.join(root, "claude");
+    fs.copyFileSync(process.execPath, realBinary);
+    fs.chmodSync(realBinary, 0o755);
+    fs.symlinkSync(realBinary, shim);
+
+    const identity = await resolveCliExecutableIdentity({
+      command: shim,
+      runtimeArtifact: {
+        ...commandPackagePolicy,
+        nativeExecutableNames: ["mise"],
+      },
+    });
+
+    expect(identity?.runtimeArtifact).toEqual({ kind: "self-contained-executable" });
+    expect(identity?.resolvedPath).toBe(fs.realpathSync(realBinary));
+    expect(identity?.invocation.command).toBe(shim);
+  });
+
   it("rejects package script shebang flags that can load external code", async () => {
     const fixture = makePackage();
     fs.writeFileSync(

--- a/src/agents/cli-executable-identity.test.ts
+++ b/src/agents/cli-executable-identity.test.ts
@@ -212,7 +212,7 @@ describe("CLI executable implementation identity", () => {
     }
   });
 
-  it("spawns a wrapper shim by its resolved path instead of the real target", async () => {
+  it("binds a wrapper shim launch to its canonical target and carries the shim name via argv0", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-shim-"));
     tempDirs.push(root);
     const realBinary = path.join(root, "mise");
@@ -231,7 +231,35 @@ describe("CLI executable implementation identity", () => {
 
     expect(identity?.runtimeArtifact).toEqual({ kind: "self-contained-executable" });
     expect(identity?.resolvedPath).toBe(fs.realpathSync(realBinary));
-    expect(identity?.invocation.command).toBe(shim);
+    expect(identity?.invocation.command).toBe(fs.realpathSync(realBinary));
+    expect(identity?.invocation.argv0).toBe(shim);
+  });
+
+  it("keeps the launch command canonical when a wrapper shim is retargeted after resolution", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-shim-race-"));
+    tempDirs.push(root);
+    const realBinary = path.join(root, "mise");
+    const otherBinary = path.join(root, "attacker");
+    const shim = path.join(root, "claude");
+    fs.copyFileSync(process.execPath, realBinary);
+    fs.chmodSync(realBinary, 0o755);
+    fs.copyFileSync(process.execPath, otherBinary);
+    fs.chmodSync(otherBinary, 0o755);
+    fs.symlinkSync(realBinary, shim);
+
+    const identity = await resolveCliExecutableIdentity({
+      command: shim,
+      runtimeArtifact: { ...commandPackagePolicy, nativeExecutableNames: ["mise"] },
+    });
+    const canonicalCommand = identity?.invocation.command;
+    expect(canonicalCommand).toBe(fs.realpathSync(realBinary));
+
+    // Retarget the alias after resolution; the launch command must not follow it.
+    fs.unlinkSync(shim);
+    fs.symlinkSync(otherBinary, shim);
+
+    expect(identity?.invocation.command).toBe(canonicalCommand);
+    expect(identity?.invocation.argv0).toBe(shim);
   });
 
   it("rejects package script shebang flags that can load external code", async () => {

--- a/src/agents/cli-executable-identity.ts
+++ b/src/agents/cli-executable-identity.ts
@@ -29,6 +29,13 @@ export type CliExecutableIdentity = Readonly<{
     command: string;
     leadingArgv: readonly string[];
     resolution: "direct" | "node-entrypoint" | "exe-entrypoint";
+    /**
+     * Optional argv[0] override for wrapper shims (mise/asdf/direnv). The
+     * command stays bound to the hashed canonical target; argv0 carries the
+     * shim name so the wrapper can route its own argv without dereferencing a
+     * mutable alias at launch.
+     */
+    argv0?: string;
   }>;
   files: readonly CliExecutableFileIdentity[];
   runtimeArtifact:
@@ -472,20 +479,21 @@ async function resolvePosixIdentity(params: {
     };
   }
   const resolvedPath = commandFile.identity.path;
-  // A wrapper shim (e.g. mise, asdf, direnv) presents a different basename
-  // than the real target. Spawn the original resolved path so the shim can
-  // route its own argv; the owner proof still hashes the real target file.
-  const invocationCommand =
+  // A wrapper shim (mise/asdf/direnv) routes on argv[0]. Keep the launch bound
+  // to the hashed canonical target and convey the shim name via argv0, so a
+  // retargeted alias can never start a different program after verification.
+  const wrapperShim =
     path.basename(resolvedPath) !== path.basename(params.resolvedPath)
       ? params.resolvedPath
-      : resolvedPath;
+      : undefined;
   return {
     command: params.command,
     resolvedPath,
     invocation: {
-      command: invocationCommand,
+      command: resolvedPath,
       leadingArgv: [],
       resolution: "direct",
+      ...(wrapperShim ? { argv0: wrapperShim } : {}),
     },
     files: dedupeFileIdentities(files),
     runtimeArtifact,

--- a/src/agents/cli-executable-identity.ts
+++ b/src/agents/cli-executable-identity.ts
@@ -472,12 +472,18 @@ async function resolvePosixIdentity(params: {
     };
   }
   const resolvedPath = commandFile.identity.path;
+  // A wrapper shim (e.g. mise, asdf, direnv) presents a different basename
+  // than the real target. Spawn the original resolved path so the shim can
+  // route its own argv; the owner proof still hashes the real target file.
+  const invocationCommand =
+    path.basename(resolvedPath) !== path.basename(params.resolvedPath)
+      ? params.resolvedPath
+      : resolvedPath;
   return {
     command: params.command,
     resolvedPath,
     invocation: {
-      // Spawn the exact file opened and hashed, not a mutable symlink alias.
-      command: resolvedPath,
+      command: invocationCommand,
       leadingArgv: [],
       resolution: "direct",
     },

--- a/src/agents/cli-runner/execute-process.ts
+++ b/src/agents/cli-runner/execute-process.ts
@@ -82,6 +82,7 @@ export async function executeCliProcess(params: {
   resolvedSessionId?: string;
   executionCommand: string;
   executionLeadingArgv: readonly string[];
+  executionArgv0?: string;
   executionArgs: string[];
   env: Record<string, string>;
   prompt: string;
@@ -269,6 +270,7 @@ export async function executeCliProcess(params: {
         replaceExistingScope: Boolean(params.useResume && scopeKey),
         mode: "child",
         argv: [params.executionCommand, ...params.executionLeadingArgv, ...params.executionArgs],
+        ...(params.executionArgv0 ? { argv0: params.executionArgv0 } : {}),
         timeoutMs: runParams.timeoutMs,
         noOutputTimeoutMs: params.noOutputTimeoutMs,
         cwd: context.cwd ?? context.workspaceDir,

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -466,6 +466,7 @@ export async function executePreparedCliRun(
 
       let executionCommand = backend.command;
       let executionLeadingArgv: readonly string[] = [];
+      let executionArgv0: string | undefined;
       context.runtimeOwnerFingerprint = undefined;
       context.runtimeArtifactFingerprint = undefined;
       const exactToolAvailabilityVersionPolicy = params.cliToolAvailability
@@ -509,6 +510,7 @@ export async function executePreparedCliRun(
         }
         executionCommand = executableIdentity.invocation.command;
         executionLeadingArgv = executableIdentity.invocation.leadingArgv;
+        executionArgv0 = executableIdentity.invocation.argv0;
         context.runtimeArtifactFingerprint = fingerprintCliRuntimeArtifact({
           provider: params.provider,
           backendId: context.backendResolved.id,
@@ -577,6 +579,7 @@ export async function executePreparedCliRun(
         resolvedSessionId,
         executionCommand,
         executionLeadingArgv,
+        executionArgv0,
         executionArgs: args,
         env,
         prompt,

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -164,6 +164,23 @@ describe("createChildAdapter", () => {
     expect(killMock).toHaveBeenCalledWith("SIGKILL");
   });
 
+  it("skips the Linux OOM wrapper so a shim argv0 reaches the final exec", async () => {
+    setPlatform("linux");
+    const { child } = createStubChild();
+    spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
+    await createChildAdapter({
+      argv: ["/opt/mise/libexec/mise", "x", "claude", "-p"],
+      argv0: "/home/me/.local/share/mise/shims/claude",
+      stdinMode: "pipe-open",
+    });
+
+    const spawnArgs = firstSpawnWithFallbackParams(spawnWithFallbackMock);
+    expect(spawnArgs.argv[0]).toBe("/opt/mise/libexec/mise");
+    expect(spawnArgs.options?.argv0).toBe("/home/me/.local/share/mise/shims/claude");
+    // The OOM wrapper's `sh -c` would overwrite argv0, so it must be bypassed.
+    expect(spawnArgs.argv[1]).not.toBe("-c");
+  });
+
   it("creates owned worker trees in a dedicated POSIX process group without fallback", async () => {
     process.env.OPENCLAW_SERVICE_MARKER = "service-managed";
     const { child, disconnectMock, sendMock } = createStubChild();

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -119,9 +119,12 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     env: baseEnv,
     windowsVerbatimArguments: params.windowsVerbatimArguments,
   });
-  const preparedSpawn = params.exactEnv
-    ? { command: invocation.command, args: invocation.args, env: baseEnv, wrapped: false }
-    : prepareOomScoreAdjustedSpawn(invocation.command, invocation.args, { env: baseEnv });
+  // A shim argv0 must survive to the final exec; the Linux OOM wrapper's
+  // `sh -c ... exec "$0"` would overwrite it with the canonical target name.
+  const preparedSpawn =
+    params.exactEnv || params.argv0
+      ? { command: invocation.command, args: invocation.args, env: baseEnv, wrapped: false }
+      : prepareOomScoreAdjustedSpawn(invocation.command, invocation.args, { env: baseEnv });
 
   const stdinMode = params.stdinMode ?? (params.input !== undefined ? "pipe-closed" : "inherit");
 

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -90,6 +90,8 @@ type ChildAdapterInput = {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   windowsVerbatimArguments?: boolean;
+  /** Override argv[0] while keeping the executed command bound to the verified canonical file. */
+  argv0?: string;
   input?: string;
   stdinMode?: "inherit" | "pipe-open" | "pipe-closed";
   secretInput?: SpawnSecretInput;
@@ -159,6 +161,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     detached: useDetached,
     windowsHide: true,
     windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+    ...(params.argv0 ? { argv0: params.argv0 } : {}),
   };
 
   const spawned = await spawnWithFallback({

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -139,6 +139,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
       input: params.input,
       secretInput: params.secretInput,
       oomScoreWrapperSelected: preparedSpawn.wrapped,
+      ...(params.argv0 ? { argv0: params.argv0 } : {}),
     });
   }
 

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -216,6 +216,7 @@ export function runServiceChildGroupAnchor(): void {
         stdio,
         detached: false,
         windowsHide: true,
+        ...(start.argv0 ? { argv0: start.argv0 } : {}),
       });
     } catch (error) {
       await reportStartupFailure(error instanceof Error ? error.message : String(error));

--- a/src/process/supervisor/service-child-protocol.ts
+++ b/src/process/supervisor/service-child-protocol.ts
@@ -3,6 +3,7 @@ export type ServiceChildStart = {
   generation: string;
   command: string;
   args: string[];
+  argv0?: string;
   cwd?: string;
   env?: Record<string, string>;
   stdinMode: "inherit" | "pipe-open" | "pipe-closed";

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -133,6 +133,7 @@ export async function createServiceChildRelayAdapter(params: {
   secretInput?: SpawnSecretInput;
   oomScoreWrapperSelected: boolean;
   windowsShellCommand?: string;
+  argv0?: string;
 }): Promise<ServiceChildRelayAdapter> {
   const generation = randomUUID();
   const useWindowsJobAnchor =
@@ -420,6 +421,7 @@ export async function createServiceChildRelayAdapter(params: {
     generation,
     command: params.command,
     args: params.args,
+    ...(params.argv0 ? { argv0: params.argv0 } : {}),
     cwd: params.cwd,
     env: params.env ? toStringEnv(params.env) : undefined,
     stdinMode: params.stdinMode,

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -329,6 +329,7 @@ export function createProcessSupervisor(): ProcessSupervisor & {
                 env: input.env,
                 exactEnv: input.exactEnv,
                 windowsVerbatimArguments: input.windowsVerbatimArguments,
+                ...(input.argv0 ? { argv0: input.argv0 } : {}),
                 input: input.input,
                 stdinMode: input.stdinMode,
                 secretInput: input.secretInput,

--- a/src/process/supervisor/types.ts
+++ b/src/process/supervisor/types.ts
@@ -104,6 +104,12 @@ type SpawnBaseInput = {
 type SpawnChildInput = SpawnBaseInput & {
   mode: "child";
   argv: string[];
+  /**
+   * Override argv[0] without changing the executed command. Wrapper shims
+   * (mise/asdf) route on argv[0], so this keeps the launch bound to the
+   * verified canonical file while carrying the shim name.
+   */
+  argv0?: string;
   /** Preserve a caller-prepared environment without environment-mutating spawn wrappers. */
   exactEnv?: true;
   windowsVerbatimArguments?: boolean;


### PR DESCRIPTION
Closes #135013

## What Problem This Solves

Fixes an issue where the claude-cli backend failed to connect when the gateway PATH resolved `claude` to a mise shim. The identity resolver spawned the shim's real target (`mise`) instead of the shim itself, so Claude Code's `-p` headless flag was rejected by mise's argument parser.

## Why This Change Was Made

`resolvePosixIdentity` canonicalizes the resolved command and then uses that real path as the spawn command. For a wrapper shim (mise, asdf, direnv), the real target has a different basename than the requested command, so the shim's argv[0] routing is lost.

The fix keeps the launch **bound to the hashed canonical target** and conveys the shim name through a dedicated `argv0` field that the process supervisor passes to `child_process.spawn` as `options.argv0`. This preserves the owner-boundary invariant: the executed file is always the exact canonical file that was hashed, and a mutable alias is never dereferenced at launch.

## Security invariant

- `invocation.command` is always the canonical (realpath) file that was opened and hashed.
- `invocation.argv0` only carries the shim name for argv[0] routing; it never selects the executed binary.
- The Linux OOM-adjustment wrapper is bypassed when argv0 is present, because its `sh -c ... exec "$0"` would overwrite the shim name with the canonical target.
- A retargeted alias cannot start a different program: the race regression retargets the shim after resolution and asserts the launch command is unchanged.

## User Impact

A claude-cli backend reachable only through a mise shim now connects and verifies correctly instead of failing with mise's `unexpected argument '-p'` usage text, without reopening a mutable-alias launch path.

## Evidence

Exact head: `7631a2bfe4bc82e7648e473846b144873c287212`.

- `src/agents/cli-executable-identity.test.ts` — 12 passed, 1 skipped (Windows-only), including:
  - a wrapper-shim regression asserting `invocation.command` is the canonical target and `invocation.argv0` is the shim path;
  - a race regression retargeting the shim after resolution and asserting the launch command stays canonical.
- `src/agents/cli-auth-epoch.test.ts` — 24 passed (canonical-invocation invariant preserved).
- `src/process/supervisor/adapters/child.test.ts` — 42 passed, including a Linux regression asserting argv0 is bypassed around the OOM wrapper and carried to the final spawn.
- `src/process/supervisor/*` — 167 passed; cli-runner supervisor-capture/pending-cancellation — 4 passed.
- Production typecheck and `check:changed` pass; the only local lane failure is unchanged `ui/vite.config.ts` missing a `pako` declaration in the reused dependency tree.

## AI Assistance

AI-assisted implementation. I manually verified the identity resolver, the argv0 launch boundary, the race regression, and the changed-file gates.
