### PR TITLE
improve(media-core): drop "." and ".." from basenameFromAnyPath

### DIFF
--- a/packages/media-core/src/file-name.test.ts
+++ b/packages/media-core/src/file-name.test.ts
@@ -1,36 +1,39 @@
 import { describe, expect, it } from "vitest";
 import { basenameFromAnyPath, extnameFromAnyPath, nameFromAnyPath } from "./file-name.js";
 
-describe("basenameFromAnyPath", () => {
+describe("filename extraction", () => {
   it.each([
-    ["a/b/c.txt", "c.txt"],
-    ["a\\b\\c.txt", "c.txt"],
-    ["../../evil.txt", "evil.txt"],
-    ["..\\..\\evil.txt", "evil.txt"],
-    ["normal.png", "normal.png"],
-    ["...", "..."],
-    ["file..txt", "file..txt"],
-    ["", ""],
-  ])("reduces %j to %j", (input, expected) => {
-    expect(basenameFromAnyPath(input)).toBe(expected);
+    ".",
+    "..",
+    "folder/.",
+    "folder/..",
+    "./",
+    "../",
+    "C:\\folder\\.",
+    "C:\\folder\\..",
+    ".\\",
+    "..\\",
+  ])("treats navigation segment %j as a missing filename", (value) => {
+    expect(basenameFromAnyPath(value)).toBe("");
+    expect(nameFromAnyPath(value)).toBe("");
+    expect(extnameFromAnyPath(value)).toBe("");
   });
 
-  it.each([".", "..", "foo/.", "foo/..", "a/b/..", "..\\", "foo\\..", "C:\\x\\..", "/a/b/../"])(
-    "never returns a path-navigation segment for %j",
-    (input) => {
-      expect(basenameFromAnyPath(input)).toBe("");
-    },
-  );
-});
-
-describe("nameFromAnyPath / extnameFromAnyPath", () => {
-  it("splits a normal filename into name and extension", () => {
-    expect(nameFromAnyPath("a/b/c.txt")).toBe("c");
-    expect(extnameFromAnyPath("a/b/c.txt")).toBe(".txt");
-  });
-
-  it("does not leak a path-navigation segment", () => {
-    expect(nameFromAnyPath("foo/..")).toBe("");
-    expect(extnameFromAnyPath("foo/..")).toBe("");
+  it.each([
+    ["", "", "", ""],
+    ["/", "", "", ""],
+    ["C:\\", "", "", ""],
+    ["../report.txt", "report.txt", "report", ".txt"],
+    ["C:\\folder\\invoice.TXT", "invoice.TXT", "invoice", ".TXT"],
+    ["folder\\nested/report.tar.gz", "report.tar.gz", "report.tar", ".gz"],
+    ["...", "...", "..", "."],
+    ["file..txt", "file..txt", "file.", ".txt"],
+    [".gitignore", ".gitignore", ".gitignore", ""],
+    ["写真.png", "写真.png", "写真", ".png"],
+    ["folder/report.txt/", "report.txt", "report", ".txt"],
+  ])("preserves filename components for %j", (value, base, name, extension) => {
+    expect(basenameFromAnyPath(value)).toBe(base);
+    expect(nameFromAnyPath(value)).toBe(name);
+    expect(extnameFromAnyPath(value)).toBe(extension);
   });
 });

--- a/packages/media-core/src/file-name.test.ts
+++ b/packages/media-core/src/file-name.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { basenameFromAnyPath, extnameFromAnyPath, nameFromAnyPath } from "./file-name.js";
+
+describe("basenameFromAnyPath", () => {
+  it.each([
+    ["a/b/c.txt", "c.txt"],
+    ["a\\b\\c.txt", "c.txt"],
+    ["../../evil.txt", "evil.txt"],
+    ["..\\..\\evil.txt", "evil.txt"],
+    ["normal.png", "normal.png"],
+    ["...", "..."],
+    ["file..txt", "file..txt"],
+    ["", ""],
+  ])("reduces %j to %j", (input, expected) => {
+    expect(basenameFromAnyPath(input)).toBe(expected);
+  });
+
+  it.each([".", "..", "foo/.", "foo/..", "a/b/..", "..\\", "foo\\..", "C:\\x\\..", "/a/b/../"])(
+    "never returns a path-navigation segment for %j",
+    (input) => {
+      expect(basenameFromAnyPath(input)).toBe("");
+    },
+  );
+});
+
+describe("nameFromAnyPath / extnameFromAnyPath", () => {
+  it("splits a normal filename into name and extension", () => {
+    expect(nameFromAnyPath("a/b/c.txt")).toBe("c");
+    expect(extnameFromAnyPath("a/b/c.txt")).toBe(".txt");
+  });
+
+  it("does not leak a path-navigation segment", () => {
+    expect(nameFromAnyPath("foo/..")).toBe("");
+    expect(extnameFromAnyPath("foo/..")).toBe("");
+  });
+});

--- a/packages/media-core/src/file-name.ts
+++ b/packages/media-core/src/file-name.ts
@@ -1,9 +1,17 @@
 // Media Core module implements file name behavior.
 import path from "node:path";
 
-/** Returns the final filename segment for either POSIX or Windows-style paths. */
+/**
+ * Returns the final filename segment for either POSIX or Windows-style paths.
+ *
+ * A bare "." or ".." is a path-navigation segment rather than a filename, so it
+ * collapses to "". Callers treat "" as "no filename" and fall back, and this
+ * keeps a literal ".." from reaching code that joins the result into a path or
+ * uses it as a stored filename.
+ */
 export function basenameFromAnyPath(value: string): string {
-  return path.win32.basename(path.posix.basename(value));
+  const base = path.win32.basename(path.posix.basename(value));
+  return base === "." || base === ".." ? "" : base;
 }
 
 /** Returns the extension from the final filename segment of any path flavor. */

--- a/packages/media-core/src/file-name.ts
+++ b/packages/media-core/src/file-name.ts
@@ -1,14 +1,7 @@
 // Media Core module implements file name behavior.
 import path from "node:path";
 
-/**
- * Returns the final filename segment for either POSIX or Windows-style paths.
- *
- * A bare "." or ".." is a path-navigation segment rather than a filename, so it
- * collapses to "". Callers treat "" as "no filename" and fall back, and this
- * keeps a literal ".." from reaching code that joins the result into a path or
- * uses it as a stored filename.
- */
+/** Returns the final filename segment for either POSIX or Windows-style paths. */
 export function basenameFromAnyPath(value: string): string {
   const base = path.win32.basename(path.posix.basename(value));
   return base === "." || base === ".." ? "" : base;
@@ -21,7 +14,5 @@ export function extnameFromAnyPath(value: string): string {
 
 /** Returns the extensionless filename from the final segment of any path flavor. */
 export function nameFromAnyPath(value: string): string {
-  const base = basenameFromAnyPath(value);
-  const ext = path.extname(base);
-  return path.basename(base, ext);
+  return path.parse(basenameFromAnyPath(value)).name;
 }

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -1412,6 +1412,26 @@ describe("readRemoteMediaBuffer", () => {
       fileName: "fallback.csv",
     },
     {
+      name: "unusable extended filename dot before plain",
+      header: "attachment; filename*=UTF-8''.; filename=fallback.csv",
+      fileName: "fallback.csv",
+    },
+    {
+      name: "unusable extended filename dot after plain",
+      header: "attachment; filename=fallback.csv; filename*=UTF-8''.",
+      fileName: "fallback.csv",
+    },
+    {
+      name: "unusable extended filename encoded parent before plain",
+      header: "attachment; filename*=UTF-8''%2E%2E; filename=fallback.csv",
+      fileName: "fallback.csv",
+    },
+    {
+      name: "unusable extended filename encoded parent after plain",
+      header: "attachment; filename=fallback.csv; filename*=UTF-8''%2E%2E",
+      fileName: "fallback.csv",
+    },
+    {
       name: "unsupported extended charset falls back to plain filename",
       header: "attachment; filename*=UTF-16''bad.csv; filename=fallback.csv",
       fileName: "fallback.csv",

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -248,9 +248,10 @@ function parseContentDispositionFileName(header?: string | null): string | undef
     if (parameter.name !== "filename*") {
       continue;
     }
-    const decoded = decodeExtendedRemoteFileName(parameter.value);
-    if (decoded) {
-      return basenameFromAnyPath(decoded) || undefined;
+    // An unusable extended name must not hide a valid plain filename.
+    const fileName = basenameFromAnyPath(decodeExtendedRemoteFileName(parameter.value) ?? "");
+    if (fileName) {
+      return fileName;
     }
   }
   return fallbackFileName;


### PR DESCRIPTION
## What Problem This Solves

Remote attachments with a terminal `.` or `..` path segment can acquire an unusable filename. Media Core now treats those navigation segments as missing, allowing the existing header, hint, and URL selection to provide a usable name.

The final change also preserves a valid plain Content-Disposition filename when a paired `filename*` decodes to an unusable navigation name. For example, `filename=fallback.csv; filename*=UTF-8''%2E%2E` must retain `fallback.csv`, regardless of parameter order, for both buffered and stored downloads.

## Why This Change Was Made

Normalize at the shared filename owner so basename, extension, and extensionless-name consumers agree. In the Content-Disposition parser, normalize the extended value before deciding whether it outranks the plain fallback; a successfully decoded value is not necessarily a usable filename. This addresses the latest ClawSweeper finding and its rank-up request without adding another fallback path or changing transport policy.

The complete change is production +7/-7 (net **0**) and tests +59. The follow-up adds twenty lines to the existing table that already exercises both download modes; no new test-only production seam is introduced. Existing valid filenames, Unicode names, malformed-encoding recovery, platform path handling, and stored-file byte contents remain covered.

[RFC 6266 sections 3 and 4.3](https://www.rfc-editor.org/rfc/rfc6266#section-4.3) were checked directly: extended filenames normally take priority, supplied names are advisory, and navigation names should be ignored or substituted. Preserving the existing plain-name recovery after normalization is consistent with that contract.

## User Impact

Attachments keep a usable supplied filename after invalid navigation metadata is discarded. Valid extended names still take priority. No operator action is required; write-boundary sanitization remains unchanged.

## Evidence

Proof used independently authored maintainer changes over trusted main `c9b6c24b1970f0647316e6a6c4d500532214e80b`, in [Testbox run 33582760544](https://github.com/openclaw/openclaw/actions/runs/33582760544).

- Before the parser repair, all four new regression rows failed. Actual HTTP requests produced exactly eight paired-header failures across buffered/stored downloads, both parameter orders, and dot/encoded-parent values; the other 28 results passed. Those failures returned `download.txt` and `text/plain` instead of the valid plain header's CSV name and type.
- After repair, all 89 fetch tests and 21 shared filename tests passed. The same 36 actual HTTP requests passed, including `fallback.csv` and `text/csv` for every paired-header case. Downloaded and stored bytes matched; stored files and server sockets were cleaned up.
- Fresh full-candidate P0 review completed with no findings. The reviewer performed static review; the test and HTTP results above came from separate execution.
- Required four-file changed gate passed with exit 0, including core and core-test type checks, lint (zero warnings/errors), dead-export scans, import-cycle checks, and repository guards. Final source hashes still matched the reviewed candidate; task state was removed and the lease stopped cleanly.

This is production fetch/store behavior exercised over synthetic loopback HTTP on a Linux Testbox. The wrapper reported success and exit 0; an ancillary runner-portal sync timed out after the completed proof. No authenticated external service or contributor-code execution is claimed. No schema, configuration, dependency, or persisted-state design changes are involved.

## Contributor Credit

Original fix and reproduction by @arpe1618. Preserve `Co-authored-by: arpe1618 <razark2978@naver.com>` in the final commit.
