### PR TITLE
refactor(schema): consolidate JSON Schema child traversal

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3654,7 +3654,7 @@ src/shared/frontmatter.ts	5
 src/shared/global-singleton.ts	4
 src/shared/google-turn-ordering.ts	2
 src/shared/ignore-rules.ts	10
-src/shared/json-schema-defaults.ts	38
+src/shared/json-schema-defaults.ts	28
 src/shared/lazy-runtime.ts	1
 src/shared/message-content-blocks.ts	2
 src/shared/node-list-parse.ts	3

--- a/src/agents/mcp-tool-metadata.test.ts
+++ b/src/agents/mcp-tool-metadata.test.ts
@@ -13,11 +13,18 @@ describe("normalizeMcpToolCatalog", () => {
     ["relative references", "child", "./child"],
     ["local fragments", "#value", "#value"],
     ["reserved path escapes", "a%3Ab", "a%3Ab"],
-  ])("validates tool output schemas with %s", (_label, id, ref) => {
+    [
+      "draft-2020 embedded resources",
+      "value",
+      "./value",
+      "https://json-schema.org/draft/2020-12/schema",
+    ],
+  ])("validates tool output schemas with %s", (_label, id, ref, $schema?: string) => {
     const normalized = normalizeMcpToolCatalog(
       [
         tool("referenced", {
           outputSchema: {
+            ...($schema ? { $schema } : {}),
             $id: "https://schema.example/root",
             type: "object",
             definitions: { value: { $id: id, type: "string" } },

--- a/src/shared/json-schema-defaults.test.ts
+++ b/src/shared/json-schema-defaults.test.ts
@@ -196,3 +196,124 @@ describe("applyJsonSchemaDefaults prototype safety", () => {
     expect(readPollution()).toBeUndefined();
   });
 });
+
+describe("JSON Schema child traversal", () => {
+  it.each([
+    ["$defs", "map"],
+    ["definitions", "map"],
+    ["dependentSchemas", "map"],
+    ["patternProperties", "map"],
+    ["properties", "map"],
+    ["dependencies", "map"],
+    ["additionalItems", "value"],
+    ["additionalProperties", "value"],
+    ["contains", "value"],
+    ["else", "value"],
+    ["if", "value"],
+    ["items", "value"],
+    ["not", "value"],
+    ["propertyNames", "value"],
+    ["then", "value"],
+    ["unevaluatedItems", "value"],
+    ["unevaluatedProperties", "value"],
+    ["items", "array"],
+    ["allOf", "array"],
+    ["anyOf", "array"],
+    ["oneOf", "array"],
+    ["prefixItems", "array"],
+  ])("resolves refs through %s (%s)", (keyword, shape) => {
+    for (const [identifier, ref] of [
+      ["$anchor", "#target"],
+      ["$id", "target"],
+    ] as const) {
+      const target = { [identifier]: "target", default: "selected" };
+      const child =
+        shape === "map"
+          ? { ignored: true, denied: false, target }
+          : shape === "array"
+            ? [true, false, target]
+            : target;
+      const schema = { $ref: ref, [keyword]: child };
+
+      expect(findJsonSchemaShapeError(schema)).toBeUndefined();
+      expect(applyJsonSchemaDefaults(schema, undefined)).toBe("selected");
+    }
+  });
+
+  it.each([
+    ["$anchor", "#target"],
+    ["$id", "target"],
+  ])("materializes map entries but stops after the first %s match", (identifier, ref) => {
+    const reads: string[] = [];
+    const schema = {
+      $ref: ref,
+      $defs: {
+        get first() {
+          reads.push("first");
+          return { [identifier]: "target", default: "first" };
+        },
+        get second() {
+          reads.push("second");
+          return { [identifier]: "target", default: "second" };
+        },
+      },
+      get definitions() {
+        reads.push("later group");
+        return { target: { [identifier]: "target", default: "later" } };
+      },
+    };
+
+    expect(applyJsonSchemaDefaults(schema, undefined)).toBe("first");
+    expect(reads).toEqual(["first", "second"]);
+  });
+
+  it.each(["", "nested"])("does not cross the nested resource boundary %j for anchors", ($id) => {
+    const schema = {
+      $ref: "#target",
+      $defs: { nested: { $id, $anchor: "target", default: "not local" } },
+    };
+
+    expect(findJsonSchemaShapeError(schema)).toBe("<schema>.$ref: unresolved ref");
+    expect(applyJsonSchemaDefaults(schema, undefined)).toBeUndefined();
+  });
+
+  it("ignores property dependencies while resolving a schema dependency", () => {
+    const schema = {
+      $ref: "#target",
+      dependencies: {
+        empty: [],
+        property: ["required"],
+        schema: { $anchor: "target", default: "selected" },
+      },
+    };
+
+    expect(findJsonSchemaShapeError(schema)).toBeUndefined();
+    expect(applyJsonSchemaDefaults(schema, undefined)).toBe("selected");
+  });
+
+  it("settles reverse-ordered dependent schemas beyond the root property count", () => {
+    const schema = {
+      properties: { a: { default: true } },
+      dependentSchemas: Object.fromEntries(
+        (
+          [
+            ["e", "f"],
+            ["d", "e"],
+            ["c", "d"],
+            ["b", "c"],
+            ["a", "b"],
+          ] as const
+        ).map(([trigger, added]) => [trigger, { properties: { [added]: { default: true } } }]),
+      ),
+    };
+
+    expect(applyJsonSchemaDefaults(schema, {})).toEqual({
+      a: true,
+      b: true,
+      c: true,
+      d: true,
+      e: true,
+      f: true,
+    });
+  });
+});

--- a/src/shared/json-schema-defaults.ts
+++ b/src/shared/json-schema-defaults.ts
@@ -152,60 +152,7 @@ function resolveLocalAnchor(
   if (schema.$anchor === anchor || schema.$dynamicAnchor === anchor) {
     return schema;
   }
-  for (const key of schemaMapKeywords) {
-    const value = schema[key];
-    if (!isRecord(value)) {
-      continue;
-    }
-    for (const entry of Object.values(value)) {
-      const resolved = resolveLocalAnchor(entry as JsonSchemaValue, anchor, false);
-      if (resolved !== undefined) {
-        return resolved;
-      }
-    }
-  }
-  if (isRecord(schema.dependencies)) {
-    for (const entry of Object.values(schema.dependencies)) {
-      if (isStringArray(entry)) {
-        continue;
-      }
-      const resolved = resolveLocalAnchor(entry as JsonSchemaValue, anchor, false);
-      if (resolved !== undefined) {
-        return resolved;
-      }
-    }
-  }
-  for (const key of schemaValueKeywords) {
-    const value = schema[key];
-    if (typeof value === "boolean" || isRecord(value)) {
-      const resolved = resolveLocalAnchor(value as JsonSchemaValue, anchor, false);
-      if (resolved !== undefined) {
-        return resolved;
-      }
-      continue;
-    }
-    if (key === "items" && Array.isArray(value)) {
-      for (const entry of value) {
-        const resolved = resolveLocalAnchor(entry as JsonSchemaValue, anchor, false);
-        if (resolved !== undefined) {
-          return resolved;
-        }
-      }
-    }
-  }
-  for (const key of schemaArrayKeywords) {
-    const value = schema[key];
-    if (!Array.isArray(value)) {
-      continue;
-    }
-    for (const entry of value) {
-      const resolved = resolveLocalAnchor(entry as JsonSchemaValue, anchor, false);
-      if (resolved !== undefined) {
-        return resolved;
-      }
-    }
-  }
-  return undefined;
+  return visitSchemaChildren(schema, (child) => resolveLocalAnchor(child, anchor, false));
 }
 
 function resolveLocalRef(
@@ -320,60 +267,12 @@ function resolveSchemaResourceRef(
       }
     }
 
-    for (const key of schemaMapKeywords) {
-      const value = current[key];
-      if (!isRecord(value)) {
-        continue;
-      }
-      for (const entry of Object.values(value)) {
-        const resolved = visit(entry as JsonSchemaValue, currentBaseId);
-        if (resolved.found) {
-          return resolved;
-        }
-      }
-    }
-    if (isRecord(current.dependencies)) {
-      for (const entry of Object.values(current.dependencies)) {
-        if (isStringArray(entry)) {
-          continue;
-        }
-        const resolved = visit(entry as JsonSchemaValue, currentBaseId);
-        if (resolved.found) {
-          return resolved;
-        }
-      }
-    }
-    for (const key of schemaValueKeywords) {
-      const value = current[key];
-      if (typeof value === "boolean" || isRecord(value)) {
-        const resolved = visit(value as JsonSchemaValue, currentBaseId);
-        if (resolved.found) {
-          return resolved;
-        }
-        continue;
-      }
-      if (key === "items" && Array.isArray(value)) {
-        for (const entry of value) {
-          const resolved = visit(entry as JsonSchemaValue, currentBaseId);
-          if (resolved.found) {
-            return resolved;
-          }
-        }
-      }
-    }
-    for (const key of schemaArrayKeywords) {
-      const value = current[key];
-      if (!Array.isArray(value)) {
-        continue;
-      }
-      for (const entry of value) {
-        const resolved = visit(entry as JsonSchemaValue, currentBaseId);
-        if (resolved.found) {
-          return resolved;
-        }
-      }
-    }
-    return { found: false };
+    return (
+      visitSchemaChildren(current, (child) => {
+        const resolved = visit(child, currentBaseId);
+        return resolved.found ? resolved : undefined;
+      }) ?? { found: false }
+    );
   };
 
   return visit(schema, undefined);
@@ -391,6 +290,66 @@ function resolveSchemaRef(
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function visitSchemaChildren<T>(
+  schema: Record<string, unknown>,
+  visit: (child: JsonSchemaValue) => T | undefined,
+): T | undefined {
+  // Materialize each map before descending; stop before reading later groups on a match.
+  for (const key of schemaMapKeywords) {
+    const value = schema[key];
+    if (!isRecord(value)) {
+      continue;
+    }
+    for (const entry of Object.values(value)) {
+      const resolved = visit(entry as JsonSchemaValue);
+      if (resolved !== undefined) {
+        return resolved;
+      }
+    }
+  }
+  if (isRecord(schema.dependencies)) {
+    for (const entry of Object.values(schema.dependencies)) {
+      if (!isStringArray(entry)) {
+        const resolved = visit(entry as JsonSchemaValue);
+        if (resolved !== undefined) {
+          return resolved;
+        }
+      }
+    }
+  }
+  for (const key of schemaValueKeywords) {
+    const value = schema[key];
+    if (typeof value === "boolean" || isRecord(value)) {
+      const resolved = visit(value as JsonSchemaValue);
+      if (resolved !== undefined) {
+        return resolved;
+      }
+      continue;
+    }
+    if (key === "items" && Array.isArray(value)) {
+      for (const entry of value) {
+        const resolved = visit(entry as JsonSchemaValue);
+        if (resolved !== undefined) {
+          return resolved;
+        }
+      }
+    }
+  }
+  for (const key of schemaArrayKeywords) {
+    const value = schema[key];
+    if (!Array.isArray(value)) {
+      continue;
+    }
+    for (const entry of value) {
+      const resolved = visit(entry as JsonSchemaValue);
+      if (resolved !== undefined) {
+        return resolved;
+      }
+    }
+  }
+  return undefined;
 }
 
 function hasDuplicateJsonValues(values: unknown[]): boolean {
@@ -960,43 +919,10 @@ function countSchemaNodes(schema: JsonSchemaValue, seen = new Set<object>()): nu
   }
   seen.add(schema);
   let count = 1;
-  for (const key of schemaMapKeywords) {
-    const value = schema[key];
-    if (!isRecord(value)) {
-      continue;
-    }
-    for (const entry of Object.values(value)) {
-      count += countSchemaNodes(entry as JsonSchemaValue, seen);
-    }
-  }
-  if (isRecord(schema.dependencies)) {
-    for (const entry of Object.values(schema.dependencies)) {
-      if (!isStringArray(entry)) {
-        count += countSchemaNodes(entry as JsonSchemaValue, seen);
-      }
-    }
-  }
-  for (const key of schemaValueKeywords) {
-    const value = schema[key];
-    if (typeof value === "boolean" || isRecord(value)) {
-      count += countSchemaNodes(value as JsonSchemaValue, seen);
-      continue;
-    }
-    if (key === "items" && Array.isArray(value)) {
-      for (const entry of value) {
-        count += countSchemaNodes(entry as JsonSchemaValue, seen);
-      }
-    }
-  }
-  for (const key of schemaArrayKeywords) {
-    const value = schema[key];
-    if (!Array.isArray(value)) {
-      continue;
-    }
-    for (const entry of value) {
-      count += countSchemaNodes(entry as JsonSchemaValue, seen);
-    }
-  }
+  visitSchemaChildren(schema, (child) => {
+    count += countSchemaNodes(child, seen);
+    return undefined;
+  });
   return count;
 }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

JSON Schema defaulting, local reference lookup and schema-size accounting need to agree on which children belong to a schema and in what order they are visited. This internal refactor removes repeated traversal policy that made those paths harder to maintain together; it does not claim a newly fixed user-visible regression.

## Why This Change Was Made

A private synchronous, short-circuiting child visitor now supplies the existing anchor lookup, resource lookup and node-counting paths. Each caller retains its own identity, cycle and result policy. The shared visitor preserves keyword order, map materialization before recursion, lazy access to later keyword groups, boolean schemas, tuple items and schema-versus-property dependencies. The structural validator keeps its separate error/path traversal because that contract is different.

The generator alternative was rejected after adverse paired measurements. The chosen callback removes the duplicated loops without introducing an exported API, fallback, new configuration, depth cap or dependency. Production is **+71/−145 (net −74)**; tests **+129/−1 (net +128)**; the assertion ratchet is **+1/−1 (net 0)**, changing only this owner's count from 38 to 28.

## User Impact

No intended user-visible behavior change. Plugin configuration defaults and MCP JSON Schema validation continue through their existing owners, with additional characterization of child ordering, short-circuiting and embedded draft 2020-12 resources. Public schema types, error formatting and dependency selection are unchanged.

## Evidence

- The pristine five-suite baseline passed 81 cases. Characterized before/after implementations passed the same 113-case vector across shared defaults, plugin-validator siblings, MCP validation and three temporary wide-workload diagnostic cases. Those three diagnostic cases are retained as proof only and are not included in this PR.
- The complete four-file, 30-check changed gate and normal 15-stage default build passed as full aggregates. Earlier stale-ratchet and callback-parameter typing failures were corrected narrowly; earlier timeouts remain recorded, not counted as passing stages. The successful full reruns did not skip stages or change internal deadlines.
- Supported SDK validation accepted both before/after implementations at depths 32, 128, 512 and 1024 for the declared anchor/resource cases. This is finite coverage, not a claim of unlimited recursion equivalence. The final callback timing sample was host-noisy; no causal performance improvement is claimed.
- Installed TypeBox 1.3.17 schema/compiler/default contracts and MCP validation contracts were inspected directly. Captured main `f7bc0a08f6f8b7cd2ed69ca2e4e1cd7ae157dabe` retains the same 18 selected owner/caller/type contexts and all 10 relevant package/snapshot lock records. Global manifest/lock changes are not claimed identical.
- Separate Codex precommit and exact-commit reviews completed with no P0 findings. Each used two complete evidence batches covering all 41 supplied context files; this is scoped P0 review, not all-priority certification. The reviewers did not execute the reported tests/builds. The unchanged full lockfile exceeded the normal individual review-input cap; selected complete dependency sources were supplied instead.
- The normal signed save preserved all four tested afterimages at `0d1d392c308f073acc5d2373d3ca0a281eac5507`. Its only baseline change is this owner's 38→28 row; unrelated upstream baseline reductions must remain intact during Git's normal three-way integration. Hosted exact-head CI and the normal native landing checks remain pending after publication.
