### PR TITLE
test(doctor): exit memory probe after result flush

### DIFF
--- a/src/commands/doctor-session-canonical-keys.memory.test-support.ts
+++ b/src/commands/doctor-session-canonical-keys.memory.test-support.ts
@@ -19,7 +19,8 @@ async function main(): Promise<void> {
     },
     env,
   });
-  process.stdout.write(JSON.stringify(result));
+  // The 160 MiB proof covers repair and result serialization, not unrelated Node shutdown tasks.
+  process.stdout.write(JSON.stringify(result), () => process.exit(0));
 }
 
 // Node resolves the bundle through shared node_modules; compare canonical paths.


### PR DESCRIPTION
## Summary

- flush the constrained Doctor memory probe result before terminating its child process
- exclude unrelated Node shutdown-task draining from the 160 MiB repair-memory contract
- keep the fixture size, heap limit, assertions, and production code unchanged

## Root cause

Full Release Validation normal CI completed the bounded session-repair scan and emitted valid JSON, then Node 24.19.0 aborted while draining V8 foreground tasks during natural shutdown. The test owns repair and result-serialization memory; synchronous read-only database cleanup has already completed before the result is written.

Evidence: https://github.com/openclaw/openclaw/actions/runs/33498038911/job/99824859272

## Test audit

- protected invariant: large canonical session scans remain within the 160 MiB child heap
- credible regression: retaining complete entry JSON across the scan
- existing coverage does not enforce the heap boundary
- the helper is test-only and adds no production seam

## Verification

- `npx --yes node@24.19.0 scripts/run-vitest.mjs src/commands/doctor-session-canonical-keys.memory.test.ts` (3 serial passes)
- Blacksmith Testbox, Node 24.19.0: https://github.com/openclaw/openclaw/actions/runs/33500799950
- changed-file gate and dead-code check
- `git diff --check`
- scoped autoreview: clean

Production LOC: `0`. Test support: `+2/-1`.
