### PR TITLE
refactor(agents): remove dead private tool-warning state

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -367,8 +367,8 @@ export function buildEmbeddedRunPayloads(params: {
     // A restart intentionally aborts the active tool while the Gateway takes over.
     // Keep that lifecycle status independent from tool-error suppression.
     const isRestartStatus = params.runStopReason === "restart";
-    const failureWarning = isRestartStatus
-      ? { text: "Gateway restarting…", nonTerminalToolErrorWarning: false }
+    const warningText = isRestartStatus
+      ? "Gateway restarting…"
       : buildFailureWarning({
           lastToolError: params.lastToolError,
           hasUserFacingReply,
@@ -377,8 +377,8 @@ export function buildEmbeddedRunPayloads(params: {
           verboseLevel: params.verboseLevel,
           useMarkdown,
         });
-    if (failureWarning) {
-      const normalizedWarning = normalizeTextForComparison(failureWarning.text);
+    if (warningText) {
+      const normalizedWarning = normalizeTextForComparison(warningText);
       const duplicateWarning = normalizedWarning
         ? replyItems.some((item) => {
             if (!item.text) {
@@ -390,14 +390,12 @@ export function buildEmbeddedRunPayloads(params: {
         : false;
       if (!duplicateWarning) {
         const warning = {
-          text: failureWarning.text,
+          text: warningText,
           ...(!isRestartStatus ? { isError: true } : {}),
         };
         if (!isRestartStatus) {
           setReplyPayloadMetadata(warning, {
             toolErrorWarning: { toolName: params.lastToolError.toolName },
-            nonTerminalToolErrorWarning:
-              hasUserFacingReply && failureWarning.nonTerminalToolErrorWarning,
           });
         }
         replyItems.push(warning);

--- a/src/agents/embedded-agent-runner/run/tool-error-warning.ts
+++ b/src/agents/embedded-agent-runner/run/tool-error-warning.ts
@@ -293,7 +293,7 @@ export function buildFailureWarning(params: {
   suppressToolErrorWarnings?: boolean;
   verboseLevel?: VerboseLevel;
   useMarkdown: boolean;
-}): { text: string; nonTerminalToolErrorWarning: boolean } | undefined {
+}): string | undefined {
   if (
     params.hasUserFacingReply ||
     params.suppressToolErrors ||
@@ -301,12 +301,9 @@ export function buildFailureWarning(params: {
   ) {
     return undefined;
   }
-  return {
-    text: formatToolErrorWarningText({
-      lastToolError: params.lastToolError,
-      includeDetails: params.verboseLevel === "full",
-      useMarkdown: params.useMarkdown,
-    }),
-    nonTerminalToolErrorWarning: params.lastToolError.middlewareError === true,
-  };
+  return formatToolErrorWarningText({
+    lastToolError: params.lastToolError,
+    includeDetails: params.verboseLevel === "full",
+    useMarkdown: params.useMarkdown,
+  });
 }


### PR DESCRIPTION
## What Problem This Solves

Removes dead private warning-state plumbing left by the earlier two-rule warning policy. This is the separate follow-up cleanup to #135119, which restores visible failed-exec warnings for #135068 (reported by nick.sy and acknowledged by zeroSignal).

## Why This Change Was Made

The private warning formatter returns only when there is no user-facing reply. Its sole caller then combined a returned nonterminal flag with `hasUserFacingReply`, so that flag could never become true. The restart branch's placeholder flag was also unused.

The formatter now returns its warning text directly. The public reply-payload metadata field, predicate, and marked-warning consumers remain unchanged. This is private implementation cleanup, not a warning-policy, configuration, protocol, or storage change.

## User Impact

No intended behavior change. Failed-exec warnings, ordinary final answers, restart notices, and existing marked nonterminal warnings retain their current behavior.

## Evidence

The same 196 existing tests passed before and after the two-file cleanup. No new tests merely restating the implementation were added.

Production: **+11/-16, net -5**. Tests: **0**. No changelog edit.

A rebuilt isolated development Gateway passed the same four ordered real-exec cases as the primary fix. Model inference was deterministic/local; Gateway, exec/shell, WebSocket events, transcript persistence, and the Control UI text extractor were real. Temporary state, synthetic auth, and a free non-18789 port were used.

```text
exit 7 + NO_REPLY: existing settled-turn fallback, exactly once
exit 127 + NO_REPLY: ⚠️ Exec failed, one final message and one persisted warning
exit 7 + normal answer: normal answer once, no extra warning
exit 127 + normal answer: normal answer once, failed tool result retained
all cases: one exec call; output returned to model; agent.wait=ok
cleanup: Gateway confirmed stopped; temporary state removed
```

Local Codex autoreview found no actionable issues at the requested P0 scope. The focused wrapper run passed all 196 tests. No browser screenshot or live Discord round-trip is claimed. The unrelated intermittent workspace-lock CI failure discovered while checking the parent is tracked in #135144; current-main CI passed before the parent merged.

No further warning-owner refactor is needed after this private-state cleanup. Public metadata remains an existing contract, not dead private plumbing to remove here.

The full `node scripts/check-changed.mjs` gate passed in the installed task worktree. The earlier dependency-less worktree attempt stopped on missing Lit declarations; no dependency/configuration workaround was added. This commit was mechanically rebased onto the verified #135119 merge; affected owners and consumers are byte-identical across that move. The final head `df0436c8a106fcc3825dd1a150d777d2b150bf22` was rebuilt and the four-case live proof repeated successfully, including cleanup. All 196 focused tests passed again on that head, and branch autoreview is clean at P0 scope. Exact-head CI [33502110170](https://github.com/openclaw/openclaw/actions/runs/33502110170) and the required `openclaw/ci-gate` passed. The native watcher finished `GREEN` with zero pending checks, correctly accounting for 64 superseded checks from earlier workflow runs.

Pre-land ClawSweeper check: current-head review-start placeholder only; no completed findings or Rank-up moves published yet.
