### PR TITLE
fix: usage peak error hours shift during daylight saving

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -429,6 +429,7 @@ select it to open the owning Approvals page.
   </Accordion>
   <Accordion title="Usage">
     - Session-derived token and estimated-cost analysis stays separate from provider billing.
+    - Select **Local** or **UTC** for hourly charts and peak error hours. Historical hour labels stay tied to the selected time zone, including when you view them across a daylight-saving transition.
     - Provider cards call `usage.status` and show live plan names, quota windows, balances, spend, and budgets reported by configured provider plugins.
     - A provider usage failure does not block the session/cost dashboard; unavailable provider cards show their own error state.
     - Incomplete session/cost totals stay readable while the visible, focused page checks for updates. Automatic checks are bounded; if they pause, select **Refresh** to check again.

--- a/ui/src/e2e/usage-cost-analysis.e2e.test.ts
+++ b/ui/src/e2e/usage-cost-analysis.e2e.test.ts
@@ -97,6 +97,180 @@ function emptyUsageResponses() {
 }
 
 suite.define(() => {
+  it.each([
+    { timeZone: "utc", quarterIndex: 8 },
+    { timeZone: "local", quarterIndex: 28 },
+  ] as const)(
+    "keeps historical $timeZone error-hour labels stable across today's DST gap",
+    async ({ timeZone, quarterIndex }) => {
+      const date = "2026-01-15";
+      const updatedAt = Date.parse("2026-01-15T07:00:00Z");
+      const usageTotals = { ...emptyTotals, output: 100, totalTokens: 100 };
+      const messages = {
+        total: 10,
+        user: 5,
+        assistant: 5,
+        toolCalls: 0,
+        toolResults: 0,
+        errors: 5,
+      };
+      const empty = emptyUsageResponses();
+      const match = {
+        startDate: date,
+        endDate: date,
+        ...(timeZone === "utc"
+          ? { mode: "utc" }
+          : { mode: "specific", timeZone: "America/New_York" }),
+      };
+      const artifactDir = recordVisuals ? path.join(suite.artifactDir, "usage-hour-labels") : null;
+      if (artifactDir) {
+        await mkdir(artifactDir, { recursive: true });
+      }
+      await suite.withPage(
+        {
+          locale: "en-US",
+          serviceWorkers: "block",
+          timezoneId: "America/New_York",
+          viewport: { height: 1_000, width: 1_440 },
+          ...(artifactDir
+            ? { recordVideo: { dir: artifactDir, size: { height: 1_000, width: 1_440 } } }
+            : {}),
+        },
+        async ({ page }) => {
+          await page.clock.setFixedTime(new Date("2026-03-07T17:00:00Z"));
+          expect(
+            await page.evaluate(() => [
+              new Date("2026-01-15T07:00:00Z").getHours(),
+              new Date("2026-03-08T07:00:00Z").getHours(),
+            ]),
+          ).toEqual([2, 3]);
+          const gateway = await installMockGateway(page, {
+            methodResponses: {
+              "sessions.usage": {
+                cases: [
+                  {
+                    match,
+                    response: {
+                      ...empty["sessions.usage"],
+                      updatedAt,
+                      startDate: date,
+                      endDate: date,
+                      totals: usageTotals,
+                      sessions: [
+                        {
+                          key: "agent:main:historical-hour",
+                          label: "Historical hour",
+                          agentId: "main",
+                          updatedAt,
+                          usage: {
+                            ...usageTotals,
+                            activityDates: [date],
+                            messageCounts: messages,
+                            utcQuarterHourMessageCounts: [{ date, quarterIndex, ...messages }],
+                            utcQuarterHourTokenUsage: [{ date, quarterIndex, ...usageTotals }],
+                          },
+                        },
+                      ],
+                      aggregates: { ...empty["sessions.usage"].aggregates, messages },
+                    },
+                  },
+                  { match: {}, response: empty["sessions.usage"] },
+                ],
+              },
+              "usage.cost": {
+                cases: [
+                  {
+                    match,
+                    response: {
+                      updatedAt,
+                      days: 1,
+                      daily: [{ date, ...usageTotals }],
+                      totals: usageTotals,
+                    },
+                  },
+                  { match: {}, response: empty["usage.cost"] },
+                ],
+              },
+              "usage.status": { updatedAt, providers: [] },
+            },
+          });
+          await page.goto(`${suite.server.baseUrl}usage`);
+          await page.locator(".usage-select").selectOption(timeZone);
+          const dateInputs = await page.locator(".usage-date-input").all();
+          expect(dateInputs).toHaveLength(2);
+          for (const input of dateInputs) {
+            await input.fill(date);
+            await input.press("Tab");
+          }
+          await expect
+            .poll(async () => (await gateway.getRequests("sessions.usage")).at(-1)?.params)
+            .toMatchObject(match);
+          const hours = page.locator(".usage-error-list--hours");
+          const cells = page.locator(".usage-hour-cell");
+          const refresh = page
+            .locator(".usage-controls")
+            .getByRole("button", { name: "Refresh", exact: true });
+          for (const [stage, now] of [
+            ["control", "2026-03-07T17:00:00Z"],
+            ["dst-gap", "2026-03-08T16:00:00Z"],
+          ] as const) {
+            await page.clock.setFixedTime(new Date(now));
+            const requests = (await gateway.getRequests("sessions.usage")).length;
+            await refresh.click();
+            await gateway.waitForRequest("sessions.usage", { after: requests });
+            await expect.poll(() => refresh.isEnabled()).toBe(true);
+            await expect.poll(() => cells.count()).toBe(24);
+            await expect
+              .poll(() => cells.nth(2).getAttribute("aria-label"))
+              .toBe("2:00 · 100 tokens");
+            await expect
+              .poll(() => page.locator(".daily-bar-label").allTextContents())
+              .toEqual(["Jan 15"]);
+            await expect
+              .poll(() => page.locator(".daily-bar-wrapper").getAttribute("aria-label"))
+              .toBe("January 15, 2026: 100 tokens, $0.00");
+            await hours.scrollIntoViewIfNeeded();
+            await expect.poll(() => hours.isVisible()).toBe(true);
+            if (artifactDir) {
+              await page.screenshot({
+                animations: "disabled",
+                path: path.join(artifactDir, `${timeZone}-${stage}.png`),
+              });
+            }
+            await expect
+              .poll(async () => ({
+                labels: (await hours.locator(".usage-error-date").allTextContents()).map((text) =>
+                  text.trim(),
+                ),
+                rates: (await hours.locator(".usage-error-rate").allTextContents()).map((text) =>
+                  text.trim(),
+                ),
+                details: (await hours.locator(".usage-error-sub").allTextContents()).map((text) =>
+                  text.trim(),
+                ),
+              }))
+              .toEqual({ labels: ["2 AM"], rates: ["50.00%"], details: ["5 errors · 10 msgs"] });
+          }
+          await cells.nth(2).click();
+          await expect.poll(() => cells.nth(2).getAttribute("aria-pressed")).toBe("true");
+          await expect
+            .poll(() => page.locator(".session-bar-title").allTextContents())
+            .toEqual(["Historical hour"]);
+          await expect.poll(() => hours.locator(".usage-error-date").textContent()).toBe("2 AM");
+          await cells.nth(2).click();
+          await cells.nth(3).click();
+          await expect.poll(() => page.locator(".session-bar-title").allTextContents()).toEqual([]);
+          await expect.poll(() => hours.count()).toBe(0);
+          await page.getByRole("button", { name: "Remove hours filter", exact: true }).click();
+          await expect
+            .poll(() => page.locator(".session-bar-title").allTextContents())
+            .toEqual(["Historical hour"]);
+          await expect.poll(() => hours.locator(".usage-error-date").textContent()).toBe("2 AM");
+        },
+      );
+    },
+  );
+
   it.each(["recent-sort", "filtered", "recent-tab"])(
     "selects the visible session range with Shift-click (%s)",
     async (scenario) => {

--- a/ui/src/pages/usage/helpers.node.test.ts
+++ b/ui/src/pages/usage/helpers.node.test.ts
@@ -110,7 +110,7 @@ describe("usage-helpers", () => {
   it("supports numeric filters like minTokens/maxTokens", () => {
     const a = {
       key: "a",
-      usage: { totalTokens: 100, totalCost: 20, messageCounts: { total: 30 } },
+      usage: { totalTokens: 1_000, totalCost: 20, messageCounts: { total: 30 } },
     };
     const b = {
       key: "b",
@@ -118,6 +118,7 @@ describe("usage-helpers", () => {
     };
     const filters = [
       "minTokens:10",
+      "minTokens:1k",
       "minCost:10",
       "minMessages:10",
       "maxTokens:10",
@@ -125,12 +126,12 @@ describe("usage-helpers", () => {
       "maxMessages:10",
     ];
 
-    for (const filter of filters.slice(0, 3)) {
+    for (const filter of filters.slice(0, 4)) {
       const result = filterSessionsByQuery([a, b], filter);
       expect(result.sessions).toEqual([a]);
       expect(result.warnings).toEqual([]);
     }
-    for (const filter of filters.slice(3)) {
+    for (const filter of filters.slice(4)) {
       const result = filterSessionsByQuery([a, b], filter);
       expect(result.sessions).toEqual([b]);
       expect(result.warnings).toEqual([]);
@@ -164,7 +165,6 @@ describe("usage-helpers", () => {
   it("rejects non-decimal numeric filter values", () => {
     const session = { key: "a", usage: { totalTokens: 10_000, totalCost: 0 } };
 
-    expect(filterSessionsByQuery([session], "minTokens:1k").sessions).toEqual([session]);
     expect(filterSessionsByQuery([session], "minTokens:1e3").warnings).toEqual([
       "Invalid number for minTokens",
     ]);

--- a/ui/src/pages/usage/metrics.node.test.ts
+++ b/ui/src/pages/usage/metrics.node.test.ts
@@ -1,6 +1,5 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { withEnvAsync } from "../../../../src/test-utils/env.js";
 import {
   buildUsageCostWindows,
   buildUsageCostWindowSummary,
@@ -26,16 +25,14 @@ function costDay(date: string, totalCost: number, totalTokens: number) {
 }
 
 describe("usage metrics date labels", () => {
-  it("formats YYYY-MM-DD values as stable calendar dates in negative UTC offsets", async () => {
-    await withEnvAsync({ TZ: "America/Los_Angeles" }, async () => {
-      const date = new Date(2026, 1, 1);
-      expect(formatDayLabel("2026-02-01")).toBe(
-        date.toLocaleDateString(undefined, { month: "short", day: "numeric" }),
-      );
-      expect(formatFullDate("2026-02-01")).toBe(
-        date.toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" }),
-      );
-    });
+  it("formats YYYY-MM-DD values as local calendar dates", () => {
+    const date = new Date(2026, 1, 1);
+    expect(formatDayLabel("2026-02-01")).toBe(
+      date.toLocaleDateString(undefined, { month: "short", day: "numeric" }),
+    );
+    expect(formatFullDate("2026-02-01")).toBe(
+      date.toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" }),
+    );
   });
 
   it("leaves invalid day labels unchanged", () => {

--- a/ui/src/pages/usage/metrics.ts
+++ b/ui/src/pages/usage/metrics.ts
@@ -36,9 +36,9 @@ function formatUsageCost(n: number, decimals = 2): string {
 }
 
 function formatHourLabel(hour: number): string {
-  const date = new Date();
-  date.setHours(hour, 0, 0, 0);
-  return date.toLocaleTimeString(undefined, { hour: "numeric" });
+  // The bucket hour is already zoned; a fixed UTC date avoids local DST normalization.
+  const date = new Date(Date.UTC(1970, 0, 1, hour));
+  return date.toLocaleTimeString(undefined, { hour: "numeric", timeZone: "UTC" });
 }
 
 function forEachSessionHourSlice(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing historical **Peak Error Hours** on the Usage page would see a 2 AM bucket labeled 3 AM when today falls on the spring daylight-saving transition. Both Local and UTC views are affected; the stored bucket and counts are correct.

## Why This Change Was Made

The formatter placed an already-zoned hour onto today's local date, introducing a second, unrelated daylight-saving conversion. Format that hour on a fixed UTC reference while retaining locale-specific display conventions. Bucket allocation, ranking, rates, message counts, and hour filtering keep their existing owners.

The test audit also removes an ineffective worker-local `TZ` setup while keeping all five date/cost-window cases. The existing `1k` filter check now verifies inclusion, exclusion, and no warnings; it catches two deliberate parser faults that the old positive-only assertion missed.

Production: +3/-3 (net 0). Tests: +186/-15 (net +171). Documentation: +1. No API, configuration, dependency, or storage change.

## User Impact

Historical peak-error labels stay on the correct hour across daylight-saving transitions. Selecting or clearing an hour filter continues to use the same bucket shown by the hourly chart.

## Evidence

- [Bundled Control UI proof](https://github.com/openclaw/openclaw/actions/runs/33500497191) in Chromium on Linux/Node 24.19.0, with native America/New_York timezone and synthetic Gateway data: both original UTC/local cases fail only at the 2 AM → 3 AM label assertion; both fixed cases pass. Date labels, rates/counts, hourly tokens, matching/wrong-hour selection, and clear-filter recovery are asserted. The eight unrelated E2E cases were not selected in this focused proof.
- All 59 local Usage metrics, query, date, numeric-filter, and CSV/security cases pass.
- Numeric controls: rejecting the suffix or treating `k` as multiplier 1 passes the old test but fails the replacement. The original owner with replacement assertions passes all 28 helper/query cases.
- Managed Codex review: no actionable findings at the requested P0 scope. All 20 configured changed checks passed, including core-test/UI types, formatting, lint, and dead exports ([Linux Testbox run](https://github.com/openclaw/openclaw/actions/runs/33500925884), command exit 0; one-shot lease stopped normally). These checks and the Chromium proof cover the reviewed Usage behavior. The refresh preserves the four runtime/test afterimages and the Usage documentation addition alongside unrelated main documentation changes; fresh exact-head CI is required for the refreshed head.

The previous PR CI failed in the Chromium bootstrap, outside the Usage cases. This refresh includes the separately proved stale-group browser repair in #135186 before obtaining new exact-head CI.

The following before/after captures use synthetic data only. They show the same 50% rate and 5 errors out of 10 messages; only the incorrect label changes.

| View | Before: incorrect 3 AM | After: correct 2 AM |
| --- | --- | --- |
| Local | ![Local before](https://github.com/user-attachments/assets/fa4297d8-a390-4c77-96b9-210649d095e6) | ![Local after](https://github.com/user-attachments/assets/ca294b20-5b86-41fb-b55f-4ce33611c07e) |
| UTC | ![UTC before](https://github.com/user-attachments/assets/f5e77370-b7e3-450e-9fb0-1aa08b15826e) | ![UTC after](https://github.com/user-attachments/assets/fd8cd13c-218d-4946-a0d5-30e7e78970cc) |


This is real-browser proof with a mocked Gateway, not an authenticated operator-Gateway run. The real-profile Chrome relay was unavailable, and the installed OpenClaw CLI exposed no browser command; no operator session or system clock was changed. Native Chromium timezone/clock behavior is exercised directly. Bug introduction is unknown in the available shallow history.
