### PR TITLE
fix(cron): release admission before continuation cleanup

### DIFF
--- a/src/cron/isolated-agent/run.session-lifecycle.test.ts
+++ b/src/cron/isolated-agent/run.session-lifecycle.test.ts
@@ -463,7 +463,6 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
   });
 
   it("removes the idle exact-run continuation only after releasing its admission", async () => {
-    const sessionKey = "agent:main:cron:test-job";
     const sessionId = "isolated-session";
     const storePath = inMemoryStorePath;
     resolveCronSessionMock.mockReturnValue(
@@ -475,7 +474,6 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
       }),
     );
     loadSessionEntryMock.mockReturnValue(undefined);
-    let continuationRowExists = true;
     let admissionActiveDuringRemoval: boolean | undefined;
     removeCronRunContinuationSessionIfIdleMock.mockImplementationOnce(
       async (exactRunSessionKey: string) => {
@@ -484,9 +482,6 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
           exactRunSessionKey,
           sessionId,
         ]);
-        if (!admissionActiveDuringRemoval) {
-          continuationRowExists = false;
-        }
       },
     );
 
@@ -505,7 +500,6 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
 
     expect(removeCronRunContinuationSessionIfIdleMock).toHaveBeenCalledTimes(1);
     expect(admissionActiveDuringRemoval).toBe(false);
-    expect(continuationRowExists).toBe(false);
   });
 
   it.each(["none", "silent", "best-effort", "execution error", "presentation warning"])(

--- a/src/cron/isolated-agent/run.session-lifecycle.test.ts
+++ b/src/cron/isolated-agent/run.session-lifecycle.test.ts
@@ -29,6 +29,7 @@ import {
   mockRunCronFallbackPassthrough,
   patchSessionEntryMock,
   preflightCronModelProviderMock,
+  removeCronRunContinuationSessionIfIdleMock,
   resetRunCronIsolatedAgentTurnHarness,
   resolveCronSessionMock,
   resolveCronDeliveryPlanMock,
@@ -459,6 +460,52 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
     } finally {
       logSessionStateChangeSpy.mockRestore();
     }
+  });
+
+  it("removes the idle exact-run continuation only after releasing its admission", async () => {
+    const sessionKey = "agent:main:cron:test-job";
+    const sessionId = "isolated-session";
+    const storePath = inMemoryStorePath;
+    resolveCronSessionMock.mockReturnValue(
+      makeCronSession({
+        storePath,
+        initialSessionEntry: undefined,
+        isNewSession: true,
+        sessionEntry: makeCronSessionEntry({ sessionId }),
+      }),
+    );
+    loadSessionEntryMock.mockReturnValue(undefined);
+    let continuationRowExists = true;
+    let admissionActiveDuringRemoval: boolean | undefined;
+    removeCronRunContinuationSessionIfIdleMock.mockImplementationOnce(
+      async (exactRunSessionKey: string) => {
+        expect(exactRunSessionKey).toContain(":run:");
+        admissionActiveDuringRemoval = isSessionWorkAdmissionActive(storePath, [
+          exactRunSessionKey,
+          sessionId,
+        ]);
+        if (!admissionActiveDuringRemoval) {
+          continuationRowExists = false;
+        }
+      },
+    );
+
+    await expect(
+      runCronIsolatedAgentTurn(
+        makeIsolatedAgentParamsFixture({
+          agentId: "main",
+          sessionKey: "cron:test-job",
+          job: makeIsolatedAgentJobFixture({
+            sessionTarget: "isolated",
+            delivery: { mode: "none" },
+          }),
+        }),
+      ),
+    ).resolves.toMatchObject({ status: "ok" });
+
+    expect(removeCronRunContinuationSessionIfIdleMock).toHaveBeenCalledTimes(1);
+    expect(admissionActiveDuringRemoval).toBe(false);
+    expect(continuationRowExists).toBe(false);
   });
 
   it.each(["none", "silent", "best-effort", "execution error", "presentation warning"])(

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -96,6 +96,7 @@ export const resolveFastModeStateMock = createMock();
 export const getChannelPluginMock = createMock();
 export const retireSessionMcpRuntimeMock = createMock();
 export const cleanupBrowserSessionsForLifecycleEndMock = createMock();
+export const removeCronRunContinuationSessionIfIdleMock = createMock();
 export const callGatewayMock = createMock();
 export const hasUsableWebSearchProviderMock = createMock();
 export const readSessionMessagesAsyncMock = createMock();
@@ -365,6 +366,10 @@ vi.mock("../../agents/agent-bundle-mcp-tools.js", () => ({
 
 vi.mock("../../browser-lifecycle-cleanup.js", () => ({
   cleanupBrowserSessionsForLifecycleEnd: cleanupBrowserSessionsForLifecycleEndMock,
+}));
+
+vi.mock("../../tasks/cron-run-continuation-cleanup.js", () => ({
+  removeCronRunContinuationSessionIfIdle: removeCronRunContinuationSessionIfIdleMock,
 }));
 
 vi.mock("../../gateway/call.runtime.js", () => ({
@@ -801,6 +806,8 @@ function resetRunSessionMocks(): void {
   resolveCronSessionMock.mockReturnValue(makeCronSession());
   callGatewayMock.mockReset();
   callGatewayMock.mockResolvedValue({ ok: true, deleted: true });
+  removeCronRunContinuationSessionIfIdleMock.mockReset();
+  removeCronRunContinuationSessionIfIdleMock.mockResolvedValue(undefined);
   retireSessionMcpRuntimeMock.mockReset();
   retireSessionMcpRuntimeMock.mockResolvedValue(true);
 }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -373,19 +373,10 @@ export async function runCronIsolatedAgentTurn(params: {
           });
         }
       } finally {
-        // Release runtime references after the run completes (success or failure).
-        // The session entry has already been persisted to disk by this point,
-        // so the in-memory store and run context can be safely dropped.
+        // Release runtime and admission ownership before deleting the exact-run alias.
+        // Deleting while this turn still owns session work deterministically reports
+        // "competing work is in flight" and leaks every otherwise-unused continuation.
         try {
-          if (prepared.context.runContinuationSession) {
-            try {
-              await removeCronRunContinuationSessionIfIdle(prepared.context.runSessionKey);
-            } catch (error) {
-              logWarn(
-                `[cron:${params.job.id}] Failed to remove unused run continuation: ${String(error)}`,
-              );
-            }
-          }
           await disposeCronRunContext({
             sessionId: initialSessionId,
             cronSession: prepared.context.cronSession,
@@ -394,14 +385,26 @@ export async function runCronIsolatedAgentTurn(params: {
           });
         } finally {
           prepared.context.sessionWorkAdmission.release();
-          // Only run-scoped browser identities end with this invocation.
-          // Persistent cron targets keep the session and its tracked tabs alive.
-          if (prepared.context.runSessionKey !== prepared.context.agentSessionKey) {
-            await cleanupBrowserSessionsForLifecycleEnd({
-              cfg: prepared.context.cfgWithAgentDefaults,
-              sessionKeys: [prepared.context.runSessionKey],
-              onWarn: (message) => logWarn(`[cron:${params.job.id}] ${message}`),
-            });
+          try {
+            if (prepared.context.runContinuationSession) {
+              try {
+                await removeCronRunContinuationSessionIfIdle(prepared.context.runSessionKey);
+              } catch (error) {
+                logWarn(
+                  `[cron:${params.job.id}] Failed to remove unused run continuation: ${String(error)}`,
+                );
+              }
+            }
+          } finally {
+            // Only run-scoped browser identities end with this invocation.
+            // Persistent cron targets keep the session and its tracked tabs alive.
+            if (prepared.context.runSessionKey !== prepared.context.agentSessionKey) {
+              await cleanupBrowserSessionsForLifecycleEnd({
+                cfg: prepared.context.cfgWithAgentDefaults,
+                sessionKeys: [prepared.context.runSessionKey],
+                onWarn: (message) => logWarn(`[cron:${params.job.id}] ${message}`),
+              });
+            }
           }
         }
       }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -373,38 +373,35 @@ export async function runCronIsolatedAgentTurn(params: {
           });
         }
       } finally {
-        // Release runtime and admission ownership before deleting the exact-run alias.
-        // Deleting while this turn still owns session work deterministically reports
-        // "competing work is in flight" and leaks every otherwise-unused continuation.
+        // Release admission before exact-run alias deletion starts its own lifecycle mutation.
         try {
-          await disposeCronRunContext({
-            sessionId: initialSessionId,
-            cronSession: prepared.context.cronSession,
-            ownsRunContext,
-            runContextOwnerToken,
-          });
-        } finally {
-          prepared.context.sessionWorkAdmission.release();
           try {
-            if (prepared.context.runContinuationSession) {
-              try {
-                await removeCronRunContinuationSessionIfIdle(prepared.context.runSessionKey);
-              } catch (error) {
-                logWarn(
-                  `[cron:${params.job.id}] Failed to remove unused run continuation: ${String(error)}`,
-                );
-              }
-            }
+            await disposeCronRunContext({
+              sessionId: initialSessionId,
+              cronSession: prepared.context.cronSession,
+              ownsRunContext,
+              runContextOwnerToken,
+            });
           } finally {
-            // Only run-scoped browser identities end with this invocation.
-            // Persistent cron targets keep the session and its tracked tabs alive.
-            if (prepared.context.runSessionKey !== prepared.context.agentSessionKey) {
-              await cleanupBrowserSessionsForLifecycleEnd({
-                cfg: prepared.context.cfgWithAgentDefaults,
-                sessionKeys: [prepared.context.runSessionKey],
-                onWarn: (message) => logWarn(`[cron:${params.job.id}] ${message}`),
-              });
+            prepared.context.sessionWorkAdmission.release();
+          }
+          if (prepared.context.runContinuationSession) {
+            try {
+              await removeCronRunContinuationSessionIfIdle(prepared.context.runSessionKey);
+            } catch (error) {
+              logWarn(
+                `[cron:${params.job.id}] Failed to remove unused run continuation: ${String(error)}`,
+              );
             }
+          }
+        } finally {
+          // Only run-scoped browser identities end here; persistent targets keep tracked tabs.
+          if (prepared.context.runSessionKey !== prepared.context.agentSessionKey) {
+            await cleanupBrowserSessionsForLifecycleEnd({
+              cfg: prepared.context.cfgWithAgentDefaults,
+              sessionKeys: [prepared.context.runSessionKey],
+              onWarn: (message) => logWarn(`[cron:${params.job.id}] ${message}`),
+            });
           }
         }
       }


### PR DESCRIPTION
## What Problem This Solves

Isolated cron runs could finish successfully while retaining an otherwise unused exact-run continuation session. The Gateway logged `Cannot delete session while competing work is in flight` because cleanup treated the completed run's own admission as competing work.

## Why This Change Was Made

The isolated-run finalizer now disposes the runtime and releases session-work admission before it starts exact-run alias deletion. Browser cleanup remains guaranteed by the outer finalizer.

## User Impact

Successful isolated cron jobs no longer retain idle continuation aliases or emit the competing-work cleanup warning.

## Evidence

- Exact current main `2cedaddb5e23848d4358faddcd609afb6570fa94`: two real `cron add` + `cron run --wait` flows completed successfully, each logged the competing-work warning, and SQLite retained two distinct `ready`, `basePersisted=true` exact-run rows.
- Pre-fix regression: `node scripts/run-vitest.mjs src/cron/isolated-agent/run.session-lifecycle.test.ts` failed only the cleanup-order assertion (`admissionActive=true`; 18 passed, 1 failed).
- Exact head `86a9ec8437a7194c13e7261aa6201f3e55b29365`: the same two real Gateway cron flows completed successfully, SQLite retained zero exact-run rows, and the Gateway logged no cleanup warning.
- Focused head tests: 36 passed across the cron finalizer, run-session identity, and continuation cleanup owners. Targeted Oxlint and `git diff --check` passed.
- Production delta: net 0 lines. Tests and test support: +48 lines.

## Worked on by

- @brettdaman
