### PR TITLE
refactor(release): share JSON key sorter

### DIFF
--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -33,6 +33,7 @@ import {
   validateReleaseTelegramWaiverBinding,
   verifyReleaseStateArtifacts,
 } from "./full-release-validation-policy.mjs";
+import { sortJsonValueKeys } from "./lib/canonical-json.mjs";
 
 export * from "./full-release-validation-policy.mjs";
 
@@ -378,20 +379,6 @@ function changedPathsValue(value) {
   }
 }
 
-function canonicalJson(value) {
-  if (Array.isArray(value)) {
-    return value.map(canonicalJson);
-  }
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value)
-        .toSorted(([left], [right]) => left.localeCompare(right))
-        .map(([key, entry]) => [key, canonicalJson(entry)]),
-    );
-  }
-  return value;
-}
-
 async function validateReuse(executionPlan, signal) {
   const { children: plan, evidenceReuse, trustedWorkflow } = executionPlan;
   if (!evidenceReuse.requested) {
@@ -452,7 +439,7 @@ async function validateReuse(executionPlan, signal) {
       blockers: [],
       children: hydrateReusedPlan(plan, evidence),
       errors: [],
-      sourceManifest: canonicalJson(evidence.manifest),
+      sourceManifest: sortJsonValueKeys(evidence.manifest),
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -884,8 +871,8 @@ async function collectMode(mode) {
       };
     }
     if (
-      JSON.stringify(canonicalJson(decisionReuse.sourceManifest)) !==
-      JSON.stringify(canonicalJson(executionPlan.evidenceReuse.sourceManifest))
+      JSON.stringify(sortJsonValueKeys(decisionReuse.sourceManifest)) !==
+      JSON.stringify(sortJsonValueKeys(executionPlan.evidenceReuse.sourceManifest))
     ) {
       decisionReuse = {
         ...decisionReuse,
@@ -1092,13 +1079,13 @@ async function validateManifestMode() {
     manifest.targetSha !== executionPlan.targetSha ||
     manifest.releaseProfile !== executionPlan.releaseProfile ||
     manifest.rerunGroup !== executionPlan.rerunGroup ||
-    JSON.stringify(canonicalJson(manifest.childRunIds)) !==
-      JSON.stringify(canonicalJson(expectedChildRunIds)) ||
-    JSON.stringify(canonicalJson(manifest.evidenceReuse)) !==
-      JSON.stringify(canonicalJson(expectedEvidenceReuse)) ||
+    JSON.stringify(sortJsonValueKeys(manifest.childRunIds)) !==
+      JSON.stringify(sortJsonValueKeys(expectedChildRunIds)) ||
+    JSON.stringify(sortJsonValueKeys(manifest.evidenceReuse)) !==
+      JSON.stringify(sortJsonValueKeys(expectedEvidenceReuse)) ||
     (executionPlan.attemptEvidenceVersion !== undefined &&
-      JSON.stringify(canonicalJson(rawManifest.childEvidence)) !==
-        JSON.stringify(canonicalJson(expectedChildEvidence))) ||
+      JSON.stringify(sortJsonValueKeys(rawManifest.childEvidence)) !==
+        JSON.stringify(sortJsonValueKeys(expectedChildEvidence))) ||
     rawManifest.executionPlanSha256 !== executionPlan.sha256 ||
     Number(rawManifest.sourceParentRunAttempt) !== executionPlan.parentRunAttempt
   ) {

--- a/scripts/lib/canonical-json.d.mts
+++ b/scripts/lib/canonical-json.d.mts
@@ -1,2 +1,3 @@
+export function sortJsonValueKeys(value: unknown): unknown;
 export function canonicalizeJsonValue(value: unknown): unknown;
 export function canonicalAsciiJson(value: unknown): string;

--- a/scripts/lib/canonical-json.mjs
+++ b/scripts/lib/canonical-json.mjs
@@ -9,6 +9,21 @@ function canonicalPath(parent, key) {
   return `${parent}[${JSON.stringify(key)}]`;
 }
 
+// This intentionally sorts JSON-like values without validating JSON.
+export function sortJsonValueKeys(value) {
+  if (Array.isArray(value)) {
+    return value.map(sortJsonValueKeys);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .toSorted(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, sortJsonValueKeys(entry)]),
+    );
+  }
+  return value;
+}
+
 export function canonicalizeJsonValue(value, path = "$", ancestors = new Set()) {
   if (value === null || typeof value === "string" || typeof value === "boolean") {
     return value;

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -29,6 +29,7 @@ import {
   validateReleaseStateArtifact,
   validateReleaseTelegramWaiverBinding,
 } from "./full-release-validation-policy.mjs";
+import { sortJsonValueKeys } from "./lib/canonical-json.mjs";
 import {
   execGhRead,
   execGhReadAsync,
@@ -36,6 +37,7 @@ import {
   resolvePlainGhBin,
 } from "./lib/plain-gh.mjs";
 
+const sortReleaseJsonValueKeys = /** @type {<T>(value: T) => T} */ (sortJsonValueKeys); // Validated release JSON preserves its structural type.
 const DEFAULT_REPO = process.env.OPENCLAW_RELEASE_REPO || "openclaw/openclaw";
 const RELEASE_EVIDENCE_SCHEMA = "openclaw.release-validation-evidence/v3";
 const PHASED_RELEASE_EVIDENCE_SCHEMA = "openclaw.release-validation-evidence/v4";
@@ -683,20 +685,6 @@ function consumeExpectedRunAttempt(expectedRunAttempts, runId, runAttempt, label
   }
 }
 
-function canonicalJson(value) {
-  if (Array.isArray(value)) {
-    return value.map(canonicalJson);
-  }
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value)
-        .toSorted(([left], [right]) => left.localeCompare(right))
-        .map(([key, entry]) => [key, canonicalJson(entry)]),
-    );
-  }
-  return value;
-}
-
 function normalizeManifestChildEvidence(value) {
   if (value === undefined) {
     return undefined;
@@ -800,7 +788,7 @@ function normalizeManifestChildEvidence(value) {
 }
 
 function manifestEvidenceIdentity(manifest) {
-  return canonicalJson({
+  return sortReleaseJsonValueKeys({
     childRunIds: manifest.childRunIds,
     controls: manifest.controls,
     releaseProfile: manifest.releaseProfile,
@@ -875,9 +863,9 @@ export function validateParentManifest(value, expected) {
   }
   if (
     Object.hasOwn(expected, "candidateBinding") &&
-    JSON.stringify(canonicalJson(candidateBinding)) !==
+    JSON.stringify(sortReleaseJsonValueKeys(candidateBinding)) !==
       JSON.stringify(
-        canonicalJson(
+        sortReleaseJsonValueKeys(
           expected.candidateBinding === null
             ? null
             : validateFullReleaseCandidateBinding(expected.candidateBinding),
@@ -1226,7 +1214,7 @@ function childDispatchAttempt(displayTitle, child, parentRunId, parentRunAttempt
 }
 
 function parentJobExecutionFingerprint(job) {
-  return canonicalJson({
+  return sortReleaseJsonValueKeys({
     completedAt: job.completed_at,
     conclusion: job.conclusion,
     name: job.name,
@@ -1610,7 +1598,8 @@ function downloadParentManifestEvidence(runId, runAttempt, repository, manifestP
     if (manifestPath) {
       const providedManifest = JSON.parse(readFileSync(resolve(manifestPath), "utf8"));
       if (
-        JSON.stringify(canonicalJson(providedManifest)) !== JSON.stringify(canonicalJson(manifest))
+        JSON.stringify(sortReleaseJsonValueKeys(providedManifest)) !==
+        JSON.stringify(sortReleaseJsonValueKeys(manifest))
       ) {
         throw new Error("provided release validation manifest differs from the run artifact");
       }
@@ -1745,7 +1734,7 @@ async function loadValidatedParentEvidence({
   return {
     artifact: manifestEvidence.artifact,
     manifest,
-    manifestJson: canonicalJson(manifestEvidence.manifest),
+    manifestJson: sortReleaseJsonValueKeys(manifestEvidence.manifest),
     parentRun,
     parentView,
   };
@@ -2050,8 +2039,8 @@ async function validateStrictChildRun({
       ...evidence,
     };
     if (
-      JSON.stringify(canonicalJson(childEvidence)) !==
-      JSON.stringify(canonicalJson(expectedEvidence))
+      JSON.stringify(sortReleaseJsonValueKeys(childEvidence)) !==
+      JSON.stringify(sortReleaseJsonValueKeys(expectedEvidence))
     ) {
       throw new Error(`manifest child composite evidence mismatch: ${child.name}`);
     }
@@ -2211,8 +2200,8 @@ export async function validateReleaseRunEvidence(
       manifest.rerunGroup !== "all" ||
       manifest.releaseProfile !== reuseRequest.releaseProfile ||
       manifest.runReleaseSoak !== reuseRequest.runReleaseSoak ||
-      JSON.stringify(canonicalJson(manifest.validationInputs)) !==
-        JSON.stringify(canonicalJson(reuseRequest.validationInputs))
+      JSON.stringify(sortReleaseJsonValueKeys(manifest.validationInputs)) !==
+        JSON.stringify(sortReleaseJsonValueKeys(reuseRequest.validationInputs))
     ) {
       throw new Error(
         "ineligible reuse candidate: requires a direct full run with matching profile, soak, and inputs",
@@ -2323,8 +2312,8 @@ export async function validateReleaseRunEvidence(
     if (
       rootEvidence.manifestJson.executionPlanSha256 !== executionPlan.sha256 ||
       Number(rootEvidence.manifestJson.sourceParentRunAttempt) !== executionPlan.parentRunAttempt ||
-      JSON.stringify(canonicalJson(rootEvidence.manifest.candidateBinding)) !==
-        JSON.stringify(canonicalJson(executionPlan.candidate))
+      JSON.stringify(sortReleaseJsonValueKeys(rootEvidence.manifest.candidateBinding)) !==
+        JSON.stringify(sortReleaseJsonValueKeys(executionPlan.candidate))
     ) {
       throw new Error("release validation manifest differs from its immutable execution plan");
     }
@@ -2430,7 +2419,7 @@ export async function validateReleaseRunEvidence(
   const childConclusions = Object.fromEntries(
     children.map((child) => [child.role, child.conclusion]),
   );
-  return canonicalJson({
+  return sortReleaseJsonValueKeys({
     children,
     conclusions: {
       allRequiredSucceeded: children.every((child) => child.policyPassed),

--- a/test/scripts/canonical-json.test.ts
+++ b/test/scripts/canonical-json.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { sortJsonValueKeys } from "../../scripts/lib/canonical-json.mjs";
+
+describe("sortJsonValueKeys", () => {
+  it("sorts nested keys without mutating the input", () => {
+    const input = { z: { d: 1, c: 2 }, a: [{ b: 3, a: 4 }] };
+
+    const result = sortJsonValueKeys(input) as Record<string, unknown>;
+
+    expect(Object.keys(result)).toEqual(["a", "z"]);
+    expect(Object.keys((result.z as Record<string, unknown>) ?? {})).toEqual(["c", "d"]);
+    expect(input).toEqual({ z: { d: 1, c: 2 }, a: [{ b: 3, a: 4 }] });
+  });
+
+  it("uses the runtime locale ordering", () => {
+    const keys = ["z", "ä", "a"];
+    const result = sortJsonValueKeys(Object.fromEntries(keys.map((key) => [key, key])));
+
+    expect(Object.keys(result as object)).toEqual(
+      keys.toSorted((left, right) => left.localeCompare(right)),
+    );
+  });
+
+  it("preserves sparse arrays and permissive leaf values", () => {
+    const fn = () => "value";
+    const symbol = Symbol("value");
+    const input = new Array(3);
+    input[1] = { z: undefined, y: -0, x: Number.NaN, w: 1n, v: fn, u: symbol };
+
+    const result = sortJsonValueKeys(input) as unknown[];
+    const entry = result[1] as Record<string, unknown>;
+
+    expect(result).toHaveLength(3);
+    expect(0 in result).toBe(false);
+    expect(2 in result).toBe(false);
+    expect(Object.keys(entry)).toEqual(["u", "v", "w", "x", "y", "z"]);
+    expect(entry).toMatchObject({ u: symbol, v: fn, w: 1n, x: Number.NaN, z: undefined });
+    expect(Object.is(entry.y, -0)).toBe(true);
+  });
+
+  it("uses Object.entries projection and getter evaluation order", () => {
+    const reads: string[] = [];
+    const input = Object.create({ inherited: true }) as Record<string | symbol, unknown>;
+    Object.defineProperty(input, "hidden", { enumerable: false, value: true });
+    Object.defineProperty(input, "z", {
+      enumerable: true,
+      get: () => (reads.push("z"), 1),
+    });
+    Object.defineProperty(input, "a", {
+      enumerable: true,
+      get: () => (reads.push("a"), 2),
+    });
+    input[Symbol("ignored")] = true;
+
+    const result = sortJsonValueKeys(input);
+
+    expect(reads).toEqual(["z", "a"]);
+    expect(result).toEqual({ a: 2, z: 1 });
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+  });
+
+  it("retains natural cycle failure", () => {
+    const input: Record<string, unknown> = {};
+    input.self = input;
+
+    expect(() => sortJsonValueKeys(input)).toThrow(RangeError);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Release validation had two byte-identical implementations for recursively sorting JSON-like object keys. Keeping the same comparison contract in separate release scripts made future drift likely.

## Why This Change Was Made

This maintainer-requested refactor moves the permissive sorter into the existing scripts-private canonical JSON module while keeping it distinct from strict JSON validation. Both release consumers now use that single implementation without changing ordering, array, getter, or leaf-value behavior.

## User Impact

No user-visible behavior changes. Release evidence comparisons and fingerprints keep their existing semantics through one shared implementation.

## Evidence

- `pnpm test test/scripts/canonical-json.test.ts test/scripts/full-release-validation-state.test.ts test/scripts/release-ci-summary.test.ts` (355 passed)
- `pnpm test test/scripts/ci-workflow-guards.test.ts test/scripts/package-acceptance-workflow.test.ts test/scripts/release-plan-producer.test.ts` (540 passed, 2 skipped)
- `pnpm check:changed -- scripts/lib/canonical-json.mjs scripts/lib/canonical-json.d.mts scripts/full-release-validation-state.mjs scripts/release-ci-summary.mjs test/scripts/canonical-json.test.ts`
- `pnpm check:import-cycles` (0 runtime value cycles)
- Exact local Codex autoreview with `gpt-5.6-sol` / high: scoped clean, no accepted or actionable findings
- Tooling production: `+42/-50`, net `-8`; tests: `+68`
- `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870` inspected; unrelated completion/debug CLI plumbing
