### PR TITLE
refactor(qa): share evidence builder execution context

### DIFF
--- a/extensions/qa-lab/src/evidence-summary.ts
+++ b/extensions/qa-lab/src/evidence-summary.ts
@@ -254,16 +254,9 @@ function buildQaEvidenceRefs(params: {
   docsRefs?: readonly string[];
   codeRefs?: readonly string[];
 }) {
-  const buildRef = (kind: "docs" | "code", refPath: string) => {
-    const ref = {
-      kind,
-      path: refPath,
-    };
-    return ref;
-  };
   const refs = [
-    ...(params.docsRefs ?? []).map((path) => buildRef("docs", path)),
-    ...(params.codeRefs ?? []).map((path) => buildRef("code", path)),
+    ...(params.docsRefs ?? []).map((path) => ({ kind: "docs" as const, path })),
+    ...(params.codeRefs ?? []).map((path) => ({ kind: "code" as const, path })),
   ];
   return [...new Map(refs.map((ref) => [`${ref.kind}:${ref.path}`, ref])).values()];
 }
@@ -272,17 +265,15 @@ function buildQaEvidenceCoverage(params: {
   primaryCoverageIds?: readonly string[];
   secondaryCoverageIds?: readonly string[];
 }) {
-  const buildCoverage = (id: string, role: "primary" | "secondary") => ({
-    id,
-    role,
-  });
   return [
-    ...normalizeSortedUniqueTrimmedStringList(params.primaryCoverageIds ?? []).map((id) =>
-      buildCoverage(id, "primary"),
-    ),
-    ...normalizeSortedUniqueTrimmedStringList(params.secondaryCoverageIds ?? []).map((id) =>
-      buildCoverage(id, "secondary"),
-    ),
+    ...normalizeSortedUniqueTrimmedStringList(params.primaryCoverageIds ?? []).map((id) => ({
+      id,
+      role: "primary" as const,
+    })),
+    ...normalizeSortedUniqueTrimmedStringList(params.secondaryCoverageIds ?? []).map((id) => ({
+      id,
+      role: "secondary" as const,
+    })),
   ];
 }
 
@@ -321,10 +312,6 @@ export function resolveQaEvidenceProfile(params: {
   return undefined;
 }
 
-function resolveQaEvidenceRunner(params: { env?: NodeJS.ProcessEnv; fallback?: string }) {
-  return params.env?.OPENCLAW_QA_RUNNER?.trim() || params.fallback || "host";
-}
-
 function resolveQaEvidencePackageSource(env: NodeJS.ProcessEnv | undefined) {
   const spec = env?.OPENCLAW_QA_PACKAGE_SOURCE?.trim() || undefined;
   const sha = env?.OPENCLAW_QA_PACKAGE_SOURCE_SHA?.trim() || undefined;
@@ -337,10 +324,6 @@ function resolveQaEvidencePackageSource(env: NodeJS.ProcessEnv | undefined) {
     spec,
     sha,
   };
-}
-
-function resolveQaEvidenceBuildPackageSource(params: QaEvidenceBuildBase) {
-  return params.packageSource ?? resolveQaEvidencePackageSource(params.env);
 }
 
 function buildQaEvidenceProvider(params: { providerMode: QaProviderMode; primaryModel: string }) {
@@ -371,6 +354,18 @@ function buildQaEvidenceProvider(params: { providerMode: QaProviderMode; primary
     id: mockProviderId,
     live: false,
     fixture: params.providerMode,
+  };
+}
+
+function resolveQaEvidenceBuildContext(params: QaEvidenceBuildBase, defaultRunner?: string) {
+  return {
+    profile: resolveQaEvidenceProfile({ env: params.env, explicit: params.profile }),
+    executionBase: {
+      runner: params.env?.OPENCLAW_QA_RUNNER?.trim() || (params.runner ?? defaultRunner) || "host",
+      environment: resolveQaEvidenceEnvironment({ env: params.env, repoRoot: params.repoRoot }),
+      provider: buildQaEvidenceProvider(params),
+    },
+    packageSource: params.packageSource ?? resolveQaEvidencePackageSource(params.env),
   };
 }
 
@@ -507,17 +502,7 @@ export function buildQaSuiteEvidenceSummary(
     scenarioResults: readonly QaEvidenceScenarioResultInput[];
   },
 ): QaEvidenceSummaryJson {
-  const provider = buildQaEvidenceProvider(params);
-  const environment = resolveQaEvidenceEnvironment({
-    env: params.env,
-    repoRoot: params.repoRoot,
-  });
-  const packageSource = resolveQaEvidenceBuildPackageSource(params);
-  const runner = resolveQaEvidenceRunner({ env: params.env, fallback: params.runner });
-  const profile = resolveQaEvidenceProfile({
-    env: params.env,
-    explicit: params.profile,
-  });
+  const { executionBase, packageSource, profile } = resolveQaEvidenceBuildContext(params);
   const channelDriver = params.channelDriver?.trim() || undefined;
   const entries = params.scenarioResults.map((result, index): QaEvidenceSummaryEntry => {
     const scenario = params.scenarioDefinitions[index];
@@ -551,9 +536,7 @@ export function buildQaSuiteEvidenceSummary(
       refs: refs.length > 0 ? refs : undefined,
       runtimePairLane,
       execution: {
-        runner,
-        environment,
-        provider,
+        ...executionBase,
         channel: {
           id: params.channelId,
           live: channelDriver === "live",
@@ -575,26 +558,16 @@ export function buildQaSuiteEvidenceSummary(
 
 function buildTestRunnerEvidenceSummary(
   params: QaEvidenceBuildBase & {
-    defaultRunner: string;
-    testKind: string;
     targets: readonly QaEvidenceTestTargetInput[];
     results: readonly QaEvidenceTestResultInput[];
   },
+  defaultRunner: string,
+  testKind: string,
 ): QaEvidenceSummaryJson {
-  const provider = buildQaEvidenceProvider(params);
-  const environment = resolveQaEvidenceEnvironment({
-    env: params.env,
-    repoRoot: params.repoRoot,
-  });
-  const packageSource = resolveQaEvidenceBuildPackageSource(params);
-  const runner = resolveQaEvidenceRunner({
-    env: params.env,
-    fallback: params.runner ?? params.defaultRunner,
-  });
-  const profile = resolveQaEvidenceProfile({
-    env: params.env,
-    explicit: params.profile,
-  });
+  const { executionBase, packageSource, profile } = resolveQaEvidenceBuildContext(
+    params,
+    defaultRunner,
+  );
   const targetById = new Map(params.targets.map((target) => [target.id, target]));
   const targetByPath = new Map(params.targets.map((target) => [target.sourcePath, target]));
   const entries = params.results.map((result, index): QaEvidenceSummaryEntry => {
@@ -612,7 +585,7 @@ function buildTestRunnerEvidenceSummary(
     const timing = timingForTestResult(result);
     return {
       test: {
-        kind: params.testKind,
+        kind: testKind,
         id: target?.id ?? fallbackId,
         title: target?.title ?? result.title ?? fallbackId,
         source: sourcePath ? { path: sourcePath } : undefined,
@@ -623,11 +596,9 @@ function buildTestRunnerEvidenceSummary(
       }),
       refs: refs.length > 0 ? refs : undefined,
       execution: {
-        runner,
-        environment,
-        provider,
+        ...executionBase,
         packageSource,
-        artifacts: buildQaEvidenceArtifacts(params.artifactPaths, runner),
+        artifacts: buildQaEvidenceArtifacts(params.artifactPaths, executionBase.runner),
       },
       result: resultForEvidence(result, timing),
     };
@@ -646,12 +617,7 @@ export function buildVitestEvidenceSummary(
     results: readonly QaEvidenceTestResultInput[];
   },
 ): QaEvidenceSummaryJson {
-  return buildTestRunnerEvidenceSummary({
-    ...params,
-    defaultRunner: "vitest",
-    testKind: "vitest-test",
-    runner: params.runner ?? "vitest",
-  });
+  return buildTestRunnerEvidenceSummary(params, "vitest", "vitest-test");
 }
 
 export function buildPlaywrightEvidenceSummary(
@@ -660,12 +626,7 @@ export function buildPlaywrightEvidenceSummary(
     results: readonly QaEvidenceTestResultInput[];
   },
 ): QaEvidenceSummaryJson {
-  return buildTestRunnerEvidenceSummary({
-    ...params,
-    defaultRunner: "playwright",
-    testKind: "playwright-test",
-    runner: params.runner ?? "playwright",
-  });
+  return buildTestRunnerEvidenceSummary(params, "playwright", "playwright-test");
 }
 
 export function buildScriptEvidenceSummary(
@@ -674,10 +635,5 @@ export function buildScriptEvidenceSummary(
     results: readonly QaEvidenceTestResultInput[];
   },
 ): QaEvidenceSummaryJson {
-  return buildTestRunnerEvidenceSummary({
-    ...params,
-    defaultRunner: "script",
-    testKind: "script-test",
-    runner: params.runner ?? "script",
-  });
+  return buildTestRunnerEvidenceSummary(params, "script", "script-test");
 }


### PR DESCRIPTION
QA-suite and test-runner evidence builders independently resolved the same execution context, while the Vitest, Playwright, and script adapters copied their entire parameter objects to attach two fixed descriptors. Resolve that context once through the evidence owner and pass the adapter descriptors directly. Delete the duplicate resolution paths and one-use reference/coverage constructors.

Production changes are +36/−80, net **−44 lines** (−43 excluding blank lines); tests are unchanged. Exported signatures and schema v2 remain intact. The change preserves explicit and environment profile precedence, runner defaults including empty-string handling, package-source selection, reference deduplication, sorted coverage roles, entry order, and zero/undefined timing fields.

Validation on the final source:

- `node scripts/run-vitest.mjs extensions/qa-lab/src/evidence-summary.test.ts extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts` — 46 tests passed before and after, including a real child-process producer and artifact import.
- All five builder entrypoints, including the public API script export, produced byte-identical JSON and recursive own-property shapes for 15 evidence entries. Output SHA-256: `8e76abaad9015659893f0a0fe9a1dcaab71a9613531a301b46e111e1a06326ab`.
- The public script API wrote and validated actual evidence/log/latest-run artifacts. Direct installed Zod and canonical normalization source inspection confirms optional-property and normalization contracts.
- `node scripts/check-changed.mjs -- extensions/qa-lab/src/evidence-summary.ts` — all 24 selected checks passed, including both extension typecheck lanes and the production export scan. Fresh managed Codex review through P2 is scoped-clean.

The proof exercises local evidence production and import with synthetic inputs. No external provider or channel execution is claimed; those owners and the public package boundary are unchanged.


Maintainer landing review: The existing evidence owner resolves execution context once and receives each adapter descriptor directly, removing repeated resolution and one-use constructors.

The five public builders retain signatures, schema-v2 output, runner/profile/package-source precedence, empty-runner fallback, optional own-property distinctions, entry order, reference normalization and coverage deduplication.

46 baseline and candidate tests across two files pass, including actual child-process producer evidence and filesystem artifact import. Five public builders and15 entries produce identical JSON and own-property shapes, SHA256 8e76abaad9015659893f0a0fe9a1dcaab71a9613531a301b46e111e1a06326ab. All24 selected local checks and fresh managed P2/high review pass. Root personally read complete builders, callers, provider/environment owners, tests and the Zod optional-object implementation.

The11:41 UTC ClawSweeper review has no code/security finding. Root resolves its unavailable-current-main evidence gap with direct owner/callee blob comparison during native preparation. A live open-PR title search for evidence returned this PR plus distinct runtime-evidence and release work, with no equivalent builder-context cleanup. Exact-head CI33503106219 is green. The explicit user landing request supplies the maintainer decision.

Production +36/-80 = -44 physical and-43 nonblank; tests unchanged. Complete helper and call-site cost included.

Proof limits: Proof uses synthetic builder inputs and actual local child-process/filesystem artifact flow; no external provider or channel execution is claimed. There is no new import or package boundary.
