### PR TITLE
refactor(qa): share Mantis report rendering and summary fields

### DIFF
--- a/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/desktop-browser-smoke.runtime.ts
@@ -17,6 +17,7 @@ import {
   stopCrabbox,
   warmupCrabbox,
 } from "./crabbox-runtime.js";
+import { renderMantisCrabboxReport, type MantisCrabboxReportSummary } from "./report.js";
 
 export type MantisDesktopBrowserSmokeOptions = {
   browserProfileArchiveEnv?: string;
@@ -47,30 +48,10 @@ type MantisDesktopBrowserSmokeResult = {
   videoPath?: string;
 };
 
-type MantisDesktopBrowserSmokeSummary = {
-  artifacts: {
-    reportPath: string;
-    screenshotPath?: string;
-    summaryPath: string;
-    videoPath?: string;
-  };
+type MantisDesktopBrowserSmokeSummary = MantisCrabboxReportSummary & {
   browserUrl: string;
   htmlFile?: string;
-  crabbox: {
-    bin: string;
-    createdLease: boolean;
-    id: string;
-    provider: string;
-    slug?: string;
-    state?: string;
-    vncCommand: string;
-  };
-  error?: string;
-  finishedAt: string;
-  outputDir: string;
   remoteOutputDir: string;
-  startedAt: string;
-  status: "pass" | "fail";
 };
 
 const DEFAULT_BROWSER_URL = "https://openclaw.ai";
@@ -246,39 +227,20 @@ test -s "$out/desktop-browser-smoke.png"
 }
 
 function renderReport(summary: MantisDesktopBrowserSmokeSummary) {
-  const lines = [
-    "# Mantis Desktop Browser Smoke",
-    "",
-    `Status: ${summary.status}`,
-    `Browser URL: ${summary.browserUrl}`,
-    summary.htmlFile ? `HTML file: ${summary.htmlFile}` : undefined,
-    `Output: ${summary.outputDir}`,
-    `Started: ${summary.startedAt}`,
-    `Finished: ${summary.finishedAt}`,
-    "",
-    "## Crabbox",
-    "",
-    `- Provider: ${summary.crabbox.provider}`,
-    `- Lease: ${summary.crabbox.id}${summary.crabbox.slug ? ` (${summary.crabbox.slug})` : ""}`,
-    `- Created by run: ${summary.crabbox.createdLease}`,
-    `- State: ${summary.crabbox.state ?? "unknown"}`,
-    `- VNC: \`${summary.crabbox.vncCommand}\``,
-    "",
-    "## Artifacts",
-    "",
-    summary.artifacts.screenshotPath
-      ? `- Screenshot: \`${path.basename(summary.artifacts.screenshotPath)}\``
-      : "- Screenshot: missing",
-    summary.artifacts.videoPath
-      ? `- Video: \`${path.basename(summary.artifacts.videoPath)}\``
-      : "- Video: missing",
-    "- Remote metadata: `remote-metadata.json`",
-    "- FFmpeg log: `ffmpeg.log`",
-    "- Chrome log: `chrome.log`",
-    summary.error ? `- Error: ${summary.error}` : undefined,
-    "",
-  ].filter((line) => line !== undefined);
-  return `${lines.join("\n")}\n`;
+  return renderMantisCrabboxReport({
+    artifactRows: [
+      "- Remote metadata: `remote-metadata.json`",
+      "- FFmpeg log: `ffmpeg.log`",
+      "- Chrome log: `chrome.log`",
+      summary.error ? `- Error: ${summary.error}` : undefined,
+    ],
+    headerRows: [
+      `Browser URL: ${summary.browserUrl}`,
+      summary.htmlFile ? `HTML file: ${summary.htmlFile}` : undefined,
+    ],
+    summary,
+    title: "Mantis Desktop Browser Smoke",
+  });
 }
 
 export async function runMantisDesktopBrowserSmoke(

--- a/extensions/qa-lab/src/mantis/report.ts
+++ b/extensions/qa-lab/src/mantis/report.ts
@@ -1,0 +1,71 @@
+import path from "node:path";
+
+type MantisReportLine = string | undefined;
+
+export type MantisCrabboxReportSummary = {
+  artifacts: {
+    reportPath: string;
+    screenshotPath?: string;
+    summaryPath: string;
+    videoPath?: string;
+  };
+  crabbox: {
+    bin: string;
+    createdLease: boolean;
+    id: string;
+    provider: string;
+    slug?: string;
+    state?: string;
+    vncCommand: string;
+  };
+  error?: string;
+  finishedAt: string;
+  outputDir: string;
+  startedAt: string;
+  status: "pass" | "fail";
+};
+
+export function renderMantisCrabboxReport(params: {
+  afterArtifacts?: MantisReportLine[];
+  artifactRows: MantisReportLine[];
+  beforeArtifacts?: MantisReportLine[];
+  crabboxRows?: MantisReportLine[];
+  headerRows: MantisReportLine[];
+  summary: MantisCrabboxReportSummary;
+  title: string;
+}) {
+  const { summary } = params;
+  const { crabbox } = summary;
+  const lines = [
+    `# ${params.title}`,
+    "",
+    `Status: ${summary.status}`,
+    ...params.headerRows,
+    `Output: ${summary.outputDir}`,
+    `Started: ${summary.startedAt}`,
+    `Finished: ${summary.finishedAt}`,
+    "",
+    "## Crabbox",
+    "",
+    `- Provider: ${crabbox.provider}`,
+    `- Lease: ${crabbox.id}${crabbox.slug ? ` (${crabbox.slug})` : ""}`,
+    `- Created by run: ${crabbox.createdLease}`,
+    `- State: ${crabbox.state ?? "unknown"}`,
+    `- VNC: \`${crabbox.vncCommand}\``,
+    ...(params.crabboxRows ?? []),
+    "",
+    ...(params.beforeArtifacts ?? []),
+    "## Artifacts",
+    "",
+    summary.artifacts.screenshotPath
+      ? `- Screenshot: \`${path.basename(summary.artifacts.screenshotPath)}\``
+      : "- Screenshot: missing",
+    summary.artifacts.videoPath
+      ? `- Video: \`${path.basename(summary.artifacts.videoPath)}\``
+      : "- Video: missing",
+    ...params.artifactRows,
+    "",
+    ...(params.afterArtifacts ?? []),
+  ].filter((line) => line !== undefined);
+  return `${lines.join("\n")}\n`;
+}

--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
@@ -23,6 +23,7 @@ import {
   stopCrabbox,
   warmupCrabbox,
 } from "./crabbox-runtime.js";
+import { renderMantisCrabboxReport, type MantisCrabboxReportSummary } from "./report.js";
 
 export type MantisSlackDesktopSmokeOptions = {
   alternateModel?: string;
@@ -76,32 +77,14 @@ type SlackGatewayCredentialLease = Awaited<
 >;
 type SlackGatewayCredentialHeartbeat = ReturnType<typeof startQaCredentialLeaseHeartbeat>;
 
-type MantisSlackDesktopSmokeSummary = {
-  artifacts: {
+type MantisSlackDesktopSmokeSummary = MantisCrabboxReportSummary & {
+  artifacts: MantisCrabboxReportSummary["artifacts"] & {
     approvalCheckpoints?: MantisApprovalCheckpointArtifacts;
-    reportPath: string;
-    screenshotPath?: string;
     slackQaDir?: string;
-    summaryPath: string;
-    videoPath?: string;
   };
-  crabbox: {
-    bin: string;
-    createdLease: boolean;
-    id: string;
-    provider: string;
-    slug?: string;
-    state?: string;
-    vncCommand: string;
-  };
-  error?: string;
-  finishedAt: string;
   hydrateMode: MantisSlackDesktopHydrateMode;
-  outputDir: string;
   remoteOutputDir: string;
   slackUrl?: string;
-  startedAt: string;
-  status: "pass" | "fail";
   timings: MantisPhaseTimings;
   warning?: string;
 };
@@ -1184,57 +1167,38 @@ exit 0
 }
 
 function renderReport(summary: MantisSlackDesktopSmokeSummary) {
-  const lines = [
-    "# Mantis Slack Desktop Smoke",
-    "",
-    `Status: ${summary.status}`,
-    summary.slackUrl ? `Slack URL: ${summary.slackUrl}` : undefined,
-    `Output: ${summary.outputDir}`,
-    `Started: ${summary.startedAt}`,
-    `Finished: ${summary.finishedAt}`,
-    "",
-    "## Crabbox",
-    "",
-    `- Provider: ${summary.crabbox.provider}`,
-    `- Lease: ${summary.crabbox.id}${summary.crabbox.slug ? ` (${summary.crabbox.slug})` : ""}`,
-    `- Created by run: ${summary.crabbox.createdLease}`,
-    `- State: ${summary.crabbox.state ?? "unknown"}`,
-    `- VNC: \`${summary.crabbox.vncCommand}\``,
-    `- Hydrate mode: ${summary.hydrateMode}`,
-    "",
-    "## Timings",
-    "",
-    `- Total: ${Math.round(summary.timings.totalMs / 100) / 10}s`,
-    ...summary.timings.phases.map(
-      (phase) => `- ${phase.name}: ${Math.round(phase.durationMs / 100) / 10}s (${phase.status})`,
-    ),
-    "",
-    "## Artifacts",
-    "",
-    summary.artifacts.screenshotPath
-      ? `- Screenshot: \`${path.basename(summary.artifacts.screenshotPath)}\``
-      : "- Screenshot: missing",
-    summary.artifacts.videoPath
-      ? `- Video: \`${path.basename(summary.artifacts.videoPath)}\``
-      : "- Video: missing",
-    summary.artifacts.slackQaDir ? "- Slack QA artifacts: `slack-qa/`" : undefined,
-    summary.artifacts.approvalCheckpoints
-      ? "- Approval checkpoints: `approval-checkpoints/`"
-      : undefined,
-    ...(summary.artifacts.approvalCheckpoints?.screenshots.map(
-      (screenshot) =>
-        `- Approval checkpoint ${screenshot.scenarioId} ${screenshot.state}: \`approval-checkpoints/${path.basename(
-          screenshot.screenshotPath,
-        )}\``,
-    ) ?? []),
-    "- Remote metadata: `remote-metadata.json`",
-    "- Remote command log: `slack-desktop-command.log`",
-    "- FFmpeg log: `ffmpeg.log`",
-    "- Chrome log: `chrome.log`",
-    summary.error ? `- Error: ${summary.error}` : undefined,
-    "",
-  ].filter((line) => line !== undefined);
-  return `${lines.join("\n")}\n`;
+  return renderMantisCrabboxReport({
+    artifactRows: [
+      summary.artifacts.slackQaDir ? "- Slack QA artifacts: `slack-qa/`" : undefined,
+      summary.artifacts.approvalCheckpoints
+        ? "- Approval checkpoints: `approval-checkpoints/`"
+        : undefined,
+      ...(summary.artifacts.approvalCheckpoints?.screenshots.map(
+        (screenshot) =>
+          `- Approval checkpoint ${screenshot.scenarioId} ${screenshot.state}: \`approval-checkpoints/${path.basename(
+            screenshot.screenshotPath,
+          )}\``,
+      ) ?? []),
+      "- Remote metadata: `remote-metadata.json`",
+      "- Remote command log: `slack-desktop-command.log`",
+      "- FFmpeg log: `ffmpeg.log`",
+      "- Chrome log: `chrome.log`",
+      summary.error ? `- Error: ${summary.error}` : undefined,
+    ],
+    beforeArtifacts: [
+      "## Timings",
+      "",
+      `- Total: ${Math.round(summary.timings.totalMs / 100) / 10}s`,
+      ...summary.timings.phases.map(
+        (phase) => `- ${phase.name}: ${Math.round(phase.durationMs / 100) / 10}s (${phase.status})`,
+      ),
+      "",
+    ],
+    crabboxRows: [`- Hydrate mode: ${summary.hydrateMode}`],
+    headerRows: [summary.slackUrl ? `Slack URL: ${summary.slackUrl}` : undefined],
+    summary,
+    title: "Mantis Slack Desktop Smoke",
+  });
 }
 
 export async function runMantisSlackDesktopSmoke(

--- a/extensions/qa-lab/src/mantis/visual-task.runtime.ts
+++ b/extensions/qa-lab/src/mantis/visual-task.runtime.ts
@@ -16,6 +16,7 @@ import {
   stopCrabbox,
   warmupCrabbox,
 } from "./crabbox-runtime.js";
+import { renderMantisCrabboxReport, type MantisCrabboxReportSummary } from "./report.js";
 
 export type MantisVisualTaskVisionMode = "image-describe" | "metadata";
 
@@ -96,34 +97,16 @@ type VisionAssertion = {
   visible?: boolean;
 };
 
-type MantisVisualTaskSummary = {
-  artifacts: {
+type MantisVisualTaskSummary = MantisCrabboxReportSummary & {
+  artifacts: MantisCrabboxReportSummary["artifacts"] & {
     driverResultPath: string;
-    reportPath: string;
-    screenshotPath?: string;
-    summaryPath: string;
-    videoPath?: string;
   };
   browserUrl: string;
-  crabbox: {
-    bin: string;
-    createdLease: boolean;
-    id: string;
-    provider: string;
-    slug?: string;
-    state?: string;
-    vncCommand: string;
-  };
   driver?: MantisVisualDriverResult;
-  error?: string;
-  finishedAt: string;
-  outputDir: string;
   recording: {
     error?: string;
     required: boolean;
   };
-  startedAt: string;
-  status: "pass" | "fail";
   visionMode: MantisVisualTaskVisionMode;
 };
 
@@ -396,53 +379,31 @@ function browserLaunchScript() {
 }
 
 function renderReport(summary: MantisVisualTaskSummary) {
-  const lines = [
-    "# Mantis Visual Task",
-    "",
-    `Status: ${summary.status}`,
-    `Browser URL: ${summary.browserUrl}`,
-    `Vision mode: ${summary.visionMode}`,
-    `Output: ${summary.outputDir}`,
-    `Started: ${summary.startedAt}`,
-    `Finished: ${summary.finishedAt}`,
-    "",
-    "## Crabbox",
-    "",
-    `- Provider: ${summary.crabbox.provider}`,
-    `- Lease: ${summary.crabbox.id}${summary.crabbox.slug ? ` (${summary.crabbox.slug})` : ""}`,
-    `- Created by run: ${summary.crabbox.createdLease}`,
-    `- State: ${summary.crabbox.state ?? "unknown"}`,
-    `- VNC: \`${summary.crabbox.vncCommand}\``,
-    "",
-    "## Artifacts",
-    "",
-    summary.artifacts.screenshotPath
-      ? `- Screenshot: \`${path.basename(summary.artifacts.screenshotPath)}\``
-      : "- Screenshot: missing",
-    summary.artifacts.videoPath
-      ? `- Video: \`${path.basename(summary.artifacts.videoPath)}\``
-      : "- Video: missing",
-    `- Driver result: \`${path.basename(summary.artifacts.driverResultPath)}\``,
-    "",
-    "## Vision",
-    "",
-    summary.driver?.vision.text ? summary.driver.vision.text : "No vision text recorded.",
-    summary.driver?.expectText ? `Expected text: ${summary.driver.expectText}` : undefined,
-    summary.driver?.vision.assertion?.visible !== undefined
-      ? `Visible: ${summary.driver.vision.assertion.visible}`
-      : undefined,
-    summary.driver?.vision.assertion?.evidence
-      ? `Evidence: ${summary.driver.vision.assertion.evidence}`
-      : undefined,
-    summary.driver?.vision.assertion?.reason
-      ? `Reason: ${summary.driver.vision.assertion.reason}`
-      : undefined,
-    summary.driver?.matched !== undefined ? `Matched: ${summary.driver.matched}` : undefined,
-    summary.recording.error ? `Recording error: ${summary.recording.error}` : undefined,
-    summary.error ? `Error: ${summary.error}` : undefined,
-    "",
-  ].filter((line) => line !== undefined);
-  return `${lines.join("\n")}\n`;
+  return renderMantisCrabboxReport({
+    afterArtifacts: [
+      "## Vision",
+      "",
+      summary.driver?.vision.text ? summary.driver.vision.text : "No vision text recorded.",
+      summary.driver?.expectText ? `Expected text: ${summary.driver.expectText}` : undefined,
+      summary.driver?.vision.assertion?.visible !== undefined
+        ? `Visible: ${summary.driver.vision.assertion.visible}`
+        : undefined,
+      summary.driver?.vision.assertion?.evidence
+        ? `Evidence: ${summary.driver.vision.assertion.evidence}`
+        : undefined,
+      summary.driver?.vision.assertion?.reason
+        ? `Reason: ${summary.driver.vision.assertion.reason}`
+        : undefined,
+      summary.driver?.matched !== undefined ? `Matched: ${summary.driver.matched}` : undefined,
+      summary.recording.error ? `Recording error: ${summary.recording.error}` : undefined,
+      summary.error ? `Error: ${summary.error}` : undefined,
+      "",
+    ],
+    artifactRows: [`- Driver result: \`${path.basename(summary.artifacts.driverResultPath)}\``],
+    headerRows: [`Browser URL: ${summary.browserUrl}`, `Vision mode: ${summary.visionMode}`],
+    summary,
+    title: "Mantis Visual Task",
+  });
 }
 
 export async function runMantisVisualDriver(


### PR DESCRIPTION
The Mantis desktop, Slack desktop, and visual-task runners repeated the same report shell and summary fields. A private Mantis report owner now renders the common title, status, timestamps, Crabbox facts, and screenshot/video rows. Each runner keeps its own additional rows and ordering.

Production changes are +150/−192 (**−42 lines**, −45 nonblank); tests are unchanged. This includes consolidating TypeScript summary declarations: using the same compiler with types/comments erased gives −20 emitted runtime lines. The reduction is not claimed as 42 executable lines. No report content, verdict, artifact production, command execution, lease lifecycle, or public contract changes.

Validation:

- All 32 maintained tests across the three runtime owners passed before and after the change. The 24 selected checks also passed, including both typecheck lanes, dead exports, loader boundaries, lint, five doctor-contract tests, and zero runtime import cycles.
- Actual runtime owners with synthetic command runners wrote six success/failure reports to the filesystem. All 5,009 bytes match the hashes recorded before editing. The comparison covers omitted fields, zero-duration text, optional vision rows, error placement, artifact names, section ordering, and final newlines.
- The supported `qaRuntime` build with `OPENCLAW_BUILD_PRIVATE_QA=1` passed, including both runtime bundles, 63 external-plugin builds, CLI bootstrap validation, and all 12 postbuild phases. All four source hashes remained unchanged.
- Independent managed Codex review at P2/high is scoped-clean, with no actionable findings.

The artifact proof uses local synthetic runners. It does not claim an external Crabbox lease, Slack/browser session, or vision service was exercised. The existing Discord smoke and before/after comparison reports retain their separate formats.


Maintainer landing review: A private Mantis formatter owns the repeated report shell while each of the three runners retains its scenario-specific content and ordering.

Desktop-browser, visual-task and Slack reports preserve exact Markdown bytes, timing/vision row positions, artifact ordering, successful and failed outcomes, and the final newline.

32 maintained tests across three files pass on baseline and final source. Six reports totaling5009 bytes were generated by the actual runtime owners and filesystem writers using synthetic command runners. Root compared final hashes directly with immutable pre-edit worker output, rather than mutable fixture aliases; all six match. All24 selected checks and fresh managed P2/high review pass. Exact-source canonical qaRuntime build with OPENCLAW_BUILD_PRIVATE_QA=1 exits0, retaining all four source hashes and completing both bundles, external plugins, CLI bootstrap and postbuild steps.

The11:40 UTC ClawSweeper review has no correctness/security finding or rank-up move. Root completed the requested maintainer review, and exact-head CI33503207085 is green.

Production +150/-192 = -42 physical and-45 nonblank, including shared TypeScript declarations; erased runtime output shrinks20 lines. Tests unchanged. No move-only or formatting-only savings are counted.

Proof limits: Synthetic command runners and actual local report writes are exercised; no external Crabbox, Slack, browser or vision execution is claimed. The qaRuntime build intentionally skips declaration emission; separate type checks passed.
