### PR TITLE
fix: select Doctor readiness owners before loading health APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Update readiness:** select declared health-check owners before loading plugin APIs, preventing unrelated optional Doctor checks from interrupting upgrades while retaining mandatory readiness failures.
+
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.
 
 - **macOS AI setup:** show confirmed capability-review cancellation and retry guidance directly instead of a misleading Gateway failure headline. (#134573)

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -291,6 +291,9 @@ After plugin convergence, the updated CLI also runs any plugin-owned
 post-update readiness checks against an isolated state snapshot. An error keeps
 the Gateway stopped and returns the check's remediation before restart; this
 gate does not run interactive setup, download models, or change config.
+It selects readiness owners before loading their health APIs, so an unrelated
+optional Doctor check cannot interrupt the gate. Selected readiness checks
+remain mandatory, including when their required artifact is unavailable.
 Package-manager updates additionally verify the restarted Gateway reports the
 expected package version; git-checkout updates verify gateway health and
 service readiness after the rebuild.

--- a/extensions/memory-core/src/doctor-health.test.ts
+++ b/extensions/memory-core/src/doctor-health.test.ts
@@ -73,7 +73,6 @@ describe("managed local embedding setup health check", () => {
   it("stays opt-in outside an explicit pre-cutover selection", () => {
     expect(captureCheck()).toMatchObject({
       defaultEnabled: false,
-      updateReadiness: "post-plugin",
     });
   });
 

--- a/extensions/memory-core/src/doctor-health.ts
+++ b/extensions/memory-core/src/doctor-health.ts
@@ -40,7 +40,6 @@ type MemoryCoreDoctorRegistrationState = Pick<
 
 type MemoryCoreDoctorCheck = HealthCheck & {
   readonly defaultEnabled: false;
-  readonly updateReadiness: "post-plugin";
 };
 
 const registrationsByHost = new WeakMap<
@@ -75,7 +74,6 @@ function createManagedLocalEmbeddingSetupCheck(
     kind: "plugin",
     source: "memory-core",
     defaultEnabled: false,
-    updateReadiness: "post-plugin",
     description: "Checks existing semantic indexes for required managed local embedding setup.",
     async detect(ctx) {
       if (!state.memoryCoreActive) {

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -720,6 +720,7 @@ describe("runDoctorLintCli", () => {
     const configPath = path.join(stateDir, "openclaw.json");
     const config = {
       gateway: { mode: "local" },
+      agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
       memory: { search: { provider: "local", fallback: "none" } },
     } satisfies OpenClawConfig;
     fs.mkdirSync(stateDir, { recursive: true });

--- a/src/commands/doctor-lint.ts
+++ b/src/commands/doctor-lint.ts
@@ -218,6 +218,7 @@ async function executeDoctorLint(
     cwd: ctx.cwd,
     env: stateView.pluginMetadataEnv,
     runWithPluginStateSnapshot: stateView.runWithPluginStateSnapshot,
+    updateReadiness: opts.updateReadiness,
   });
   const registeredExtensionChecks = listExtensionHealthChecksForDoctor([]);
   const onlyRegisteredExtensionChecks =

--- a/src/flows/bundled-health-checks.test.ts
+++ b/src/flows/bundled-health-checks.test.ts
@@ -12,7 +12,12 @@ import {
   registerBundledHealthChecks,
   resolveBundledHealthCheckPluginStateMode,
 } from "./bundled-health-checks.js";
-import { clearHealthChecksForTest, getHealthCheck } from "./health-check-registry.js";
+import { runDoctorLintChecks, selectUpdateReadinessChecks } from "./doctor-lint-flow.js";
+import {
+  clearHealthChecksForTest,
+  getHealthCheck,
+  listHealthChecks,
+} from "./health-check-registry.js";
 
 const STATE_DEFERRED_CHECK_ID = "memory-core/managed-local-embedding-setup";
 
@@ -379,6 +384,79 @@ describe("registerBundledHealthChecks", () => {
       },
     },
   };
+
+  it("registers update readiness without loading unselected runtime health APIs", () => {
+    registerBundledHealthChecks({
+      cfg: {
+        ...codexConfig,
+        plugins: {
+          entries: { policy: { enabled: true }, "cua-computer": { enabled: true } },
+        },
+        cloudWorkers: { profiles: { aws: { provider: "crabbox" } } },
+      },
+      cwd: workspaceDir,
+      updateReadiness: "post-plugin",
+    });
+
+    expect(mocks.registerMemoryCoreDoctorChecks).toHaveBeenCalledOnce();
+    expect(mocks.loadPluginManifestRegistryForPluginRegistry).not.toHaveBeenCalled();
+    expect(mocks.registerPolicyDoctorChecks).not.toHaveBeenCalled();
+    expect(mocks.registerCuaDriverDoctorChecks).not.toHaveBeenCalled();
+    expect(mocks.loadBundledPluginManifestRegistry).not.toHaveBeenCalled();
+  });
+
+  it("retains owner identities and blocking findings across readiness registration", async () => {
+    const finding = {
+      checkId: STATE_DEFERRED_CHECK_ID,
+      severity: "error" as const,
+      message: "not ready",
+    };
+    const check = {
+      id: STATE_DEFERRED_CHECK_ID,
+      kind: "plugin" as const,
+      description: "Readiness owner",
+      defaultEnabled: false,
+      detect: vi.fn(async () => [finding]),
+    };
+    for (const updateReadiness of [undefined, "post-plugin", "post-plugin"] as const) {
+      mocks.registerMemoryCoreDoctorChecks.mockImplementationOnce((host) => {
+        if (host.getHealthCheck(check.id) !== check) {
+          host.registerHealthCheck(check);
+        }
+      });
+      registerBundledHealthChecks({ cfg: {}, cwd: workspaceDir, updateReadiness });
+      expect(getHealthCheck(check.id)).toBe(check);
+    }
+    const callbacks = mocks.registerMemoryCoreDoctorChecks.mock.calls.map(
+      ([host]) => host.registerHealthCheck,
+    );
+    expect(new Set(callbacks).size).toBe(1);
+    const ctx = {
+      cfg: {},
+      mode: "lint" as const,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    };
+    await expect(runDoctorLintChecks(ctx)).resolves.toMatchObject({ checksRun: 0, findings: [] });
+    await expect(
+      runDoctorLintChecks(ctx, {
+        checks: selectUpdateReadinessChecks(listHealthChecks(), "post-plugin"),
+        includeAllChecks: true,
+      }),
+    ).resolves.toMatchObject({ checksRun: 1, findings: [finding] });
+  });
+
+  it("fails when the selected readiness owner cannot load its artifact", () => {
+    mocks.loadBundledPluginPublicArtifactModuleSync.mockImplementationOnce(() => {
+      throw new MissingPublicSurfaceError("selected readiness artifact unavailable");
+    });
+    expect(() =>
+      registerBundledHealthChecks({
+        cfg: codexConfig,
+        cwd: workspaceDir,
+        updateReadiness: "post-plugin",
+      }),
+    ).toThrow("selected readiness artifact unavailable");
+  });
 
   function codexRecord(
     origin: "bundled" | "global",

--- a/src/flows/bundled-health-checks.ts
+++ b/src/flows/bundled-health-checks.ts
@@ -62,6 +62,39 @@ type BundledHealthCheckSelection = {
 
 type BundledHealthCheckPluginStateMode = "direct" | "deferred" | "isolated";
 
+type BundledHealthCheckParams = {
+  cfg: OpenClawConfig;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  runWithPluginStateSnapshot?: <T>(
+    run: (pluginMetadataEnv: NodeJS.ProcessEnv) => Promise<T>,
+  ) => Promise<T>;
+};
+
+function defineHealthCheckRegistration(
+  register: (params: BundledHealthCheckParams, registerCheck: typeof registerHealthCheck) => void,
+  updateReadiness?: "post-plugin",
+) {
+  // Owners retain callback and check identities when refreshing their registration state.
+  // Declare phase ownership before loading their implementation, then carry it onto each check.
+  const registerCheck = updateReadiness
+    ? (check: Parameters<typeof registerHealthCheck>[0]) =>
+        registerHealthCheck(Object.assign(check, { updateReadiness }))
+    : registerHealthCheck;
+  return {
+    updateReadiness,
+    register: (params: BundledHealthCheckParams) => register(params, registerCheck),
+  };
+}
+
+const HEALTH_CHECK_REGISTRATIONS = [
+  defineHealthCheckRegistration(registerMemoryCoreHealthChecks, "post-plugin"),
+  defineHealthCheckRegistration(registerCodexHealthChecks),
+  defineHealthCheckRegistration(registerPolicyHealthChecks),
+  defineHealthCheckRegistration(registerCuaHealthChecks),
+  defineHealthCheckRegistration(registerBundledWorkerProviderHealthChecks),
+];
+
 function loadMemoryCoreHealthApi(): BundledHealthApi {
   return loadBundledPluginPublicArtifactModuleSync<BundledHealthApi>({
     dirName: "memory-core",
@@ -100,18 +133,28 @@ export function resolveBundledHealthCheckPluginStateMode(
 }
 
 /** Registers bundled health checks that are explicitly enabled by config and owner policy. */
-export function registerBundledHealthChecks(params: {
-  cfg: OpenClawConfig;
-  cwd?: string;
-  env?: NodeJS.ProcessEnv;
-  runWithPluginStateSnapshot?: <T>(
-    run: (pluginMetadataEnv: NodeJS.ProcessEnv) => Promise<T>,
-  ) => Promise<T>;
-}): void {
+export function registerBundledHealthChecks(
+  params: BundledHealthCheckParams & { updateReadiness?: "post-plugin" },
+): void {
+  for (const registration of HEALTH_CHECK_REGISTRATIONS) {
+    if (
+      params.updateReadiness !== undefined &&
+      registration.updateReadiness !== params.updateReadiness
+    ) {
+      continue;
+    }
+    registration.register(params);
+  }
+}
+
+function registerMemoryCoreHealthChecks(
+  params: BundledHealthCheckParams,
+  registerCheck: typeof registerHealthCheck,
+): void {
   const env = params.env ?? process.env;
   loadMemoryCoreHealthApi().registerMemoryCoreDoctorChecks?.({
     getHealthCheck,
-    registerHealthCheck,
+    registerHealthCheck: registerCheck,
     async inspectEmbeddingProviderSetup(providerParams) {
       const inspect = async (pluginMetadataEnv: NodeJS.ProcessEnv) => {
         const manifestRegistry: PluginManifestRegistry =
@@ -133,6 +176,13 @@ export function registerBundledHealthChecks(params: {
     },
     memoryCoreActive: isMemoryCoreActive(params.cfg),
   });
+}
+
+function registerCodexHealthChecks(
+  params: BundledHealthCheckParams,
+  registerCheck: typeof registerHealthCheck,
+): void {
+  const env = params.env ?? process.env;
   if (shouldRegisterCodexManagedHealth(params.cfg)) {
     const registry = loadPluginManifestRegistryForPluginRegistry({
       config: params.cfg,
@@ -157,28 +207,43 @@ export function registerBundledHealthChecks(params: {
         pluginRoot: owner.rootDir,
         artifactBasename: "api.js",
         origin: owner.origin === "bundled" ? "bundled" : "global",
-      }).registerCodexManagedAppServerDoctorChecks({ getHealthCheck, registerHealthCheck });
+      }).registerCodexManagedAppServerDoctorChecks({
+        getHealthCheck,
+        registerHealthCheck: registerCheck,
+      });
     }
   }
+}
+
+function registerPolicyHealthChecks(
+  params: BundledHealthCheckParams,
+  registerCheck: typeof registerHealthCheck,
+): void {
   if (shouldRegisterPolicyHealth(params)) {
     loadBundledPluginPublicArtifactModuleSync<BundledHealthApi>({
       dirName: "policy",
       artifactBasename: "api.js",
-    }).registerPolicyDoctorChecks?.({ registerHealthCheck });
+    }).registerPolicyDoctorChecks?.({ registerHealthCheck: registerCheck });
   }
+}
+
+function registerCuaHealthChecks(
+  params: BundledHealthCheckParams,
+  registerCheck: typeof registerHealthCheck,
+): void {
   if (shouldRegisterPluginHealth(params.cfg, "cua-computer")) {
     loadBundledPluginPublicArtifactModuleSync<BundledHealthApi>({
       dirName: "cua-computer",
       artifactBasename: "api.js",
-    }).registerCuaDriverDoctorChecks?.({ registerHealthCheck });
+    }).registerCuaDriverDoctorChecks?.({ registerHealthCheck: registerCheck });
   }
-  registerBundledWorkerProviderHealthChecks(params, env);
 }
 
 function registerBundledWorkerProviderHealthChecks(
-  params: { cfg: OpenClawConfig; cwd?: string },
-  env: NodeJS.ProcessEnv,
+  params: BundledHealthCheckParams,
+  registerCheck: typeof registerHealthCheck,
 ): void {
+  const env = params.env ?? process.env;
   const providerIds = collectConfiguredWorkerProviderIds(params.cfg);
   if (providerIds.length === 0) {
     return;
@@ -191,7 +256,10 @@ function registerBundledWorkerProviderHealthChecks(
     loadBundledPluginPublicArtifactModuleFromCandidatesSync<WorkerProviderHealthApi>({
       dirName: pluginId,
       artifactCandidates: ["doctor-health-api.js"],
-    })?.registerWorkerProviderDoctorChecks?.({ getHealthCheck, registerHealthCheck });
+    })?.registerWorkerProviderDoctorChecks?.({
+      getHealthCheck,
+      registerHealthCheck: registerCheck,
+    });
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

The post-plugin update readiness gate registers every configured optional Doctor integration before filtering checks for that phase. A configured but unavailable Codex health API therefore throws before the selected memory readiness check can run. The updater receives a CLI error envelope instead of the expected readiness report, obscuring the failure as an invalid readiness result.

## Why This Change Was Made

Declare phase membership at the existing bundled health-registration owner and select registration groups before loading their implementations. Carry that declaration onto the original check object through one stable registration callback. This preserves the memory check's identity and refresh lifecycle and makes the registration owner the single source of phase membership.

Ordinary Doctor default/all/only paths preserve existing registrar order, configuration policy, trusted-install checks, and missing advertised API failures. Update readiness still fails if its selected health artifact cannot load or the selected check reports an error. This does not disable configured integrations, download missing artifacts, change runtime model selection, or add a config, manifest, or SDK option.

## Evidence

The new missing-unselected-owner reproduction failed before the repair with MissingPublicSurfaceError. After the repair, four focused owner/Doctor/memory suites passed 97 tests. Coverage includes stable check and callback identity across repeated registration, default-disabled behavior, blocking readiness findings, selected-artifact failure, and the real isolated-state Doctor flow with a configured OpenAI model and required memory readiness failure. Existing ordinary Codex trust and registration coverage remains intact.

The original root-managed upgrade failure was reproduced through the actual Docker fixture, capturing the missing Codex health API error before the readiness parser. See the [raw before-fix evidence](https://github.com/openclaw/openclaw/pull/135161#issuecomment-5493455790). The published baseline was explicitly pinned to 2026.8.1 because the historical mutable latest resolution was unavailable. This does not certify the original package or a full release run.

Production delta: +67 lines, from extracting the existing five registration owners and selecting them before API execution. This owner boundary requires phase metadata to be available before loading code, while stable callbacks and original check identities preserve existing registration lifecycle contracts. The old executable-only memory phase declaration is removed. Tests and docs are counted separately; no production fallback or retry is added.

The full local changed-file gate and managed Codex review passed on unchanged patch SHA256 `9e3ccda2ae28b6fe58a64ec83f8f4b975a7ac323604ecdbc487e01390b06e904`. The initial static run stopped on a missing Mermaid dependency in the borrowed local dependency tree; a task-owned link to the identical declared dependency resolved it, and the full gate then passed without source changes or omitted checks. Exact-head CI [33503217895](https://github.com/openclaw/openclaw/actions/runs/33503217895) passed: 201 successful jobs, 16 skipped, and required gate 99843890971 successful.

## Exact package behavior

[Isolated native worker 33504709466](https://github.com/openclaw/openclaw/actions/runs/33504709466) built and normally installed the canonical package from exact head `e63c0d19ef2964e3281f5c4e2061721a3f89b172`. Packaging took 289.694 seconds and installation 12.904 seconds. The tarball was 64,690,386 bytes, SHA256 `950d876f84e94cec27adc8ed5721f739ab5518cd112bb15385e59d63d0bbcc7c`; embedded build identity matched the source head.

With the normal updater markers, the real installed `doctor --lint --json --severity-min error` completed in 1.017 seconds with `{"ok":true,"checksRun":1,"checksSkipped":0,"findings":[]}`. In a separate fresh home without those markers, ordinary Doctor selecting `codex/managed-app-server` retained the expected nonzero structured missing-official-plugin error (0.969 seconds). The package naturally excludes Codex; no plugin was manually deleted or disabled and no runtime override was added. Configuration and SQLite-family state stayed unchanged; no provider calls or operator service were used. All source paths were unchanged and the owned worker, processes and temporary state were cleaned up.

The initial CI artifact was not reused: its embedded identity was GitHub's merge-ref commit, not the exact PR head. That artifact is retained only as rejected provenance evidence; the proof above used a fresh canonical build.

## Maintainer review disposition

The latest ClawSweeper finding and rank-up request concern only removing the changelog entry. Skipped under the active maintainer instruction for this task requiring a changelog entry for user-facing fixes; the entry is retained deliberately. No version, release publication, or generated release section is being created. The stored-data warning is a path-based classification, not a schema or migration change: this diff changes registration ownership and selection only, with unchanged-state proof above. There are no table, index, retention, recovery, or persistence-semantic changes.

The repair is entirely before optional API loading. Direct Codex contract inspection included `codex-rs/app-server/src/message_processor.rs:847-890` and the app-server initialization contract: this change does not initialize, alter, or bypass a Codex server, its handshake, authentication, or protocol. Ordinary selected-owner trust and missing-API failure remain intact.
