### PR TITLE
perf(media): avoid intermediate multipart upload copies

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -927,6 +927,12 @@ catalog, API-key auth, and dynamic model resolution.
         `openclaw/plugin-sdk/provider-http`. The helper normalizes upload
         filenames, including AAC uploads that need an M4A-style filename for
         compatible transcription APIs.
+
+        Official plugins can use the private `blob-runtime` helper
+        `bufferToBlobPart(buffer)` for other multipart uploads. Pass it directly to
+        `new Blob(...)` to preserve the Buffer range without an intermediate copy;
+        shared backing is copied when needed. Construct the Blob before awaiting
+        other work so it snapshots the bytes immediately.
       </Tab>
       <Tab title="Realtime voice">
         Consumers can pass candidate provider IDs as the optional second argument

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -343,6 +343,7 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | `plugin-sdk/fetch-runtime` | Private-local after July 2026; Wrapped fetch, proxy, EnvHttpProxyAgent option, and pinned lookup helpers |
     | `plugin-sdk/proxy-capture` | Debug proxy capture configuration, SQLite-backed capture storage, HTTP/WebSocket capture events, and capture lifecycle helpers |
     | `plugin-sdk/runtime-fetch` | Private-local after July 2026; Dispatcher-aware runtime fetch without proxy/guarded-fetch imports |
+    | `plugin-sdk/blob-runtime` | Private official-plugin runtime; Exact Buffer views for synchronous Blob construction |
     | `plugin-sdk/inline-image-data-url-runtime` | Private-local after July 2026; Inline image data URL sanitizer and signature sniffing helpers without the broad media runtime surface |
     | `plugin-sdk/response-limit-runtime` | Private-local after July 2026; Byte-, idle-, and deadline-bounded response-body readers without the broad media runtime surface |
     | `plugin-sdk/session-binding-runtime` | Private-local after July 2026; Current conversation binding state without configured binding routing or pairing stores |

--- a/extensions/clickclack/src/http-client.ts
+++ b/extensions/clickclack/src/http-client.ts
@@ -2,6 +2,7 @@
  * Thin ClickClack REST/websocket client used by gateway, resolver, and outbound
  * delivery code.
  */
+import { bufferToBlobPart } from "openclaw/plugin-sdk/blob-runtime";
 import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import {
   readProviderJsonResponse,
@@ -474,10 +475,7 @@ export function createClickClackClient(options: ClientOptions) {
       nonce?: string;
     }): Promise<ClickClackUpload> => {
       const form = new FormData();
-      const bytes: Uint8Array<ArrayBuffer> =
-        params.buffer.buffer instanceof ArrayBuffer
-          ? new Uint8Array(params.buffer.buffer, params.buffer.byteOffset, params.buffer.byteLength)
-          : Uint8Array.from(params.buffer);
+      const bytes = bufferToBlobPart(params.buffer);
       form.append("file", new Blob([bytes], { type: params.contentType }), params.filename);
       const query = new URLSearchParams({ workspace_id: params.workspaceId });
       if (params.nonce) {

--- a/extensions/comfy/workflow-runtime.ts
+++ b/extensions/comfy/workflow-runtime.ts
@@ -1,6 +1,7 @@
 // Comfy plugin module implements workflow runtime behavior.
 import { randomInt } from "node:crypto";
 import fs from "node:fs/promises";
+import { bufferToBlobPart } from "openclaw/plugin-sdk/blob-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveGeneratedMediaMaxBytes } from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
@@ -390,12 +391,6 @@ function resolveFileExtension(params: { fileName?: string; mimeType?: string }):
   return fileName.slice(dotIndex + 1);
 }
 
-function toBlobBytes(buffer: Buffer): ArrayBuffer {
-  const arrayBuffer = new ArrayBuffer(buffer.byteLength);
-  new Uint8Array(arrayBuffer).set(buffer);
-  return arrayBuffer;
-}
-
 async function uploadInputImage(params: {
   baseUrl: string;
   headers: Headers;
@@ -409,7 +404,7 @@ async function uploadInputImage(params: {
   const form = new FormData();
   form.set(
     "image",
-    new Blob([toBlobBytes(params.image.buffer)], { type: params.image.mimeType }),
+    new Blob([bufferToBlobPart(params.image.buffer)], { type: params.image.mimeType }),
     normalizeOptionalString(params.image.fileName) ||
       `input.${resolveFileExtension({ mimeType: params.image.mimeType })}`,
   );

--- a/extensions/deepinfra/image-generation-provider.ts
+++ b/extensions/deepinfra/image-generation-provider.ts
@@ -1,4 +1,5 @@
 // Deepinfra provider module implements model/runtime integration.
+import { bufferToBlobPart } from "openclaw/plugin-sdk/blob-runtime";
 import {
   createOpenAiCompatibleImageGenerationProvider,
   imageSourceUploadFileName,
@@ -82,7 +83,7 @@ export function buildDeepInfraImageGenerationProvider(options?: {
       const mimeType = normalizeOptionalString(image.mimeType) ?? "image/png";
       form.append(
         "image",
-        new Blob([new Uint8Array(image.buffer)], { type: mimeType }),
+        new Blob([bufferToBlobPart(image.buffer)], { type: mimeType }),
         imageSourceUploadFileName({ image, index: 0 }),
       );
       return { kind: "multipart", form };

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -2,6 +2,7 @@
 import type { Agent } from "node:https";
 import { createRequire } from "node:module";
 import * as Lark from "@larksuiteoapi/node-sdk";
+import { bufferToBlobPart } from "openclaw/plugin-sdk/blob-runtime";
 import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import {
   readPluginPackageVersion,
@@ -128,12 +129,6 @@ function stringifyMultipartFieldValue(value: unknown): string | undefined {
     default:
       return undefined;
   }
-}
-
-function bufferToBlobPart(value: Buffer): Uint8Array<ArrayBuffer> {
-  const bytes = new Uint8Array(value.byteLength);
-  bytes.set(value);
-  return bytes;
 }
 
 function normalizeMultipartUploadData<D>(

--- a/extensions/line/src/rich-menu.ts
+++ b/extensions/line/src/rich-menu.ts
@@ -1,5 +1,6 @@
 // Line plugin module implements rich menu behavior.
 import { messagingApi } from "@line/bot-sdk";
+import { bufferToBlobPart } from "openclaw/plugin-sdk/blob-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-local-roots";
 import { mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-mime";
@@ -124,9 +125,8 @@ export async function uploadRichMenuImage(
         ? "image/png"
         : "image/jpeg";
 
-  const imageBytes = new ArrayBuffer(media.buffer.byteLength);
-  new Uint8Array(imageBytes).set(media.buffer);
-  await blobClient.setRichMenuImage(richMenuId, new Blob([imageBytes], { type: contentType }));
+  const blob = new Blob([bufferToBlobPart(media.buffer)], { type: contentType });
+  await blobClient.setRichMenuImage(richMenuId, blob);
 
   if (opts.verbose) {
     logVerbose(`line: uploaded image to rich menu ${richMenuId}`);

--- a/extensions/litellm/image-generation-provider.ts
+++ b/extensions/litellm/image-generation-provider.ts
@@ -1,4 +1,5 @@
 import { isIP } from "node:net";
+import { bufferToBlobPart } from "openclaw/plugin-sdk/blob-runtime";
 // Litellm provider module implements model/runtime integration.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -135,7 +136,7 @@ export function buildLitellmImageGenerationProvider(): ImageGenerationProvider {
         const mimeType = normalizeOptionalString(image.mimeType) ?? "image/png";
         form.append(
           partName,
-          new Blob([new Uint8Array(image.buffer)], { type: mimeType }),
+          new Blob([bufferToBlobPart(image.buffer)], { type: mimeType }),
           imageSourceUploadFileName({ image, index }),
         );
       }

--- a/extensions/mattermost/src/channel.send-loopback.test.ts
+++ b/extensions/mattermost/src/channel.send-loopback.test.ts
@@ -198,7 +198,7 @@ describe("Mattermost send action loopback", () => {
         setMattermostRuntime(createPluginRuntimeMock());
         loadOutboundMediaFromUrl.mockReset();
         loadOutboundMediaFromUrl.mockResolvedValueOnce({
-          buffer: Buffer.from("unnamed-image"),
+          buffer: Buffer.from("!unnamed-image?").subarray(1, -1),
           contentType: "image/png",
           kind: "image",
         });
@@ -233,5 +233,6 @@ describe("Mattermost send action loopback", () => {
     expect(uploads).toHaveLength(1);
     expect(uploads[0]).toContain('filename="upload.png"');
     expect(uploads[0]).toContain("Content-Type: image/png");
+    expect(uploads[0]).toContain("\r\n\r\nunnamed-image\r\n");
   });
 });

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -1,4 +1,5 @@
 // Mattermost plugin module implements client behavior.
+import { bufferToBlobPart } from "openclaw/plugin-sdk/blob-runtime";
 import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { collectErrorGraphCandidates } from "openclaw/plugin-sdk/error-runtime";
 import { buildTimeoutAbortSignal } from "openclaw/plugin-sdk/extension-shared";
@@ -694,10 +695,7 @@ export async function uploadMattermostFile(
 ): Promise<MattermostFileInfo> {
   const form = new FormData();
   const fileName = normalizeOptionalString(params.fileName) ?? "upload";
-  const bytes = Uint8Array.from(params.buffer);
-  const blob = params.contentType
-    ? new Blob([bytes], { type: params.contentType })
-    : new Blob([bytes]);
+  const blob = new Blob([bufferToBlobPart(params.buffer)], { type: params.contentType });
   form.append("files", blob, fileName);
   form.append("channel_id", params.channelId);
 

--- a/extensions/microsoft-foundry/image-generation-provider.ts
+++ b/extensions/microsoft-foundry/image-generation-provider.ts
@@ -1,3 +1,4 @@
+import { bufferToBlobPart } from "openclaw/plugin-sdk/blob-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/core";
 // Microsoft Foundry image provider routes MAI image deployments to the MAI API.
@@ -223,7 +224,7 @@ function buildEditFormData(params: {
   form.set("prompt", params.req.prompt);
   form.set(
     "image",
-    new Blob([new Uint8Array(params.image.buffer)], {
+    new Blob([bufferToBlobPart(params.image.buffer)], {
       type: mimeType === "image/jpg" ? "image/jpeg" : mimeType,
     }),
     imageSourceUploadFileName({

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -1,5 +1,6 @@
 // Openai provider module implements model/runtime integration.
 import path from "node:path";
+import { bufferToBlobPart } from "openclaw/plugin-sdk/blob-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type {
   ImageGenerationOutputFormat,
@@ -1044,7 +1045,7 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
               const mimeType = image.mimeType?.trim() || DEFAULT_OUTPUT_MIME;
               form.append(
                 "image[]",
-                new Blob([new Uint8Array(image.buffer)], { type: mimeType }),
+                new Blob([bufferToBlobPart(image.buffer)], { type: mimeType }),
                 inferImageUploadFileName({
                   fileName: image.fileName,
                   mimeType,

--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -635,13 +635,15 @@ describe("openai video generation provider", () => {
       });
 
     const provider = buildOpenAIVideoGenerationProvider();
+    const input = Buffer.from("!png-bytes?").subarray(1, -1);
     await provider.generateVideo({
       provider: "openai",
       model: "sora-2",
       prompt: "Animate this frame",
       cfg: {},
-      inputImages: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }],
+      inputImages: [{ buffer: input, mimeType: "image/png" }],
     });
+    input.fill(0);
 
     const createRequest = postMultipartRequest();
     expect(createRequest.url).toBe("https://api.openai.com/v1/videos");
@@ -924,13 +926,15 @@ describe("openai video generation provider", () => {
       });
 
     const provider = buildOpenAIVideoGenerationProvider();
+    const input = Buffer.from("!mp4-bytes?").subarray(1, -1);
     await provider.generateVideo({
       provider: "openai",
       model: "sora-2",
       prompt: "Remix this clip",
       cfg: {},
-      inputVideos: [{ buffer: Buffer.from("mp4-bytes"), mimeType: "video/mp4" }],
+      inputVideos: [{ buffer: input, mimeType: "video/mp4" }],
     });
+    input.fill(0);
 
     expect(postJsonRequestMock).not.toHaveBeenCalled();
     const createRequest = postMultipartRequest();
@@ -940,6 +944,9 @@ describe("openai video generation provider", () => {
     expect(form.get("prompt")).toBe("Remix this clip");
     expect(form.get("model")).toBeNull();
     expect(form.get("video")).toBeInstanceOf(File);
+    expect(Buffer.from(await (form.get("video") as File).arrayBuffer())).toEqual(
+      Buffer.from("mp4-bytes"),
+    );
     expect(form.get("input_reference")).toBeNull();
     expect(createRequest.timeoutMs).toBe(120000);
     expect(createRequest.fetchFn).toBe(fetch);

--- a/extensions/openai/video-generation-provider.ts
+++ b/extensions/openai/video-generation-provider.ts
@@ -1,4 +1,5 @@
 // Openai provider module implements model/runtime integration.
+import { bufferToBlobPart } from "openclaw/plugin-sdk/blob-runtime";
 import {
   downloadGeneratedVideoAsset,
   resolveGeneratedMediaMaxBytes,
@@ -68,12 +69,6 @@ function readOpenAIVideoFailureMessage(payload: OpenAIVideoResponse): string | u
     : undefined;
 }
 
-function toBlobBytes(buffer: Buffer): ArrayBuffer {
-  const arrayBuffer = new ArrayBuffer(buffer.byteLength);
-  new Uint8Array(arrayBuffer).set(buffer);
-  return arrayBuffer;
-}
-
 function resolveDurationSeconds(durationSeconds: number | undefined): "4" | "8" | "12" | undefined {
   if (typeof durationSeconds !== "number" || !Number.isFinite(durationSeconds)) {
     return undefined;
@@ -139,7 +134,7 @@ function resolveReferenceAsset(req: VideoGenerationRequest): OpenAIReferenceAsse
     `${kind === "video" ? "reference-video" : "reference-image"}.${extension}`;
   return {
     kind,
-    file: new File([toBlobBytes(asset.buffer)], fileName, { type: mimeType }),
+    file: new File([bufferToBlobPart(asset.buffer)], fileName, { type: mimeType }),
   };
 }
 

--- a/extensions/pixverse/video-generation-provider.ts
+++ b/extensions/pixverse/video-generation-provider.ts
@@ -1,5 +1,6 @@
 // Pixverse provider module implements model/runtime integration.
 import { randomUUID } from "node:crypto";
+import { bufferToBlobPart } from "openclaw/plugin-sdk/blob-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -231,9 +232,8 @@ function buildUploadImageForm(asset: VideoGenerationSourceAsset): FormData {
   const mimeType = normalizeOptionalString(asset.mimeType) ?? "image/png";
   const extension = extensionForMime(mimeType)?.slice(1) ?? "png";
   const fileName = normalizeOptionalString(asset.fileName) ?? `image.${extension}`;
-  const bytes = new Uint8Array(asset.buffer.byteLength);
-  bytes.set(asset.buffer);
-  form.set("image", new File([bytes], fileName, { type: mimeType }));
+  const file = new File([bufferToBlobPart(asset.buffer)], fileName, { type: mimeType });
+  form.set("image", file);
   return form;
 }
 

--- a/extensions/tlon/src/urbit/upload.ts
+++ b/extensions/tlon/src/urbit/upload.ts
@@ -1,6 +1,7 @@
 /**
  * Upload an image from a URL to Tlon storage.
  */
+import { bufferToBlobPart } from "openclaw/plugin-sdk/blob-runtime";
 import { MAX_IMAGE_BYTES, readRemoteMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
 import { TLON_MEDIA_FETCH_TIMEOUTS } from "../media-fetch-timeouts.js";
 import { uploadFile } from "../tlon-api.js";
@@ -30,7 +31,7 @@ export async function uploadImageFromUrl(imageUrl: string, maxBytes?: number): P
     sourceSizeVerified = true;
 
     const contentType = fetched.contentType || "image/png";
-    const blob = new Blob([new Uint8Array(fetched.buffer)], { type: contentType });
+    const blob = new Blob([bufferToBlobPart(fetched.buffer)], { type: contentType });
 
     // Extract filename from URL or use a default
     const urlPath = new URL(imageUrl).pathname;

--- a/extensions/tsconfig.package-boundary.paths.json
+++ b/extensions/tsconfig.package-boundary.paths.json
@@ -897,6 +897,9 @@
       ],
       "openclaw/plugin-sdk/model-catalog-pricing": [
         "../packages/plugin-sdk/dist/src/plugin-sdk/model-catalog-pricing.d.ts"
+      ],
+      "openclaw/plugin-sdk/blob-runtime": [
+        "../packages/plugin-sdk/dist/src/plugin-sdk/blob-runtime.d.ts"
       ]
     }
   }

--- a/extensions/xai/tsconfig.json
+++ b/extensions/xai/tsconfig.json
@@ -881,6 +881,9 @@
       ],
       "openclaw/plugin-sdk/model-catalog-pricing": [
         "../../packages/plugin-sdk/dist/src/plugin-sdk/model-catalog-pricing.d.ts"
+      ],
+      "openclaw/plugin-sdk/blob-runtime": [
+        "../../packages/plugin-sdk/dist/src/plugin-sdk/blob-runtime.d.ts"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -392,7 +392,8 @@
     "scripts/lib/recommended-tool-installs.json",
     "scripts/postinstall-bundled-plugins.mjs",
     "scripts/windows-cmd-helpers.mjs",
-    "!dist/plugin-sdk/model-catalog-pricing.d.ts"
+    "!dist/plugin-sdk/model-catalog-pricing.d.ts",
+    "!dist/plugin-sdk/blob-runtime.d.ts"
   ],
   "type": "module",
   "main": "dist/index.js",
@@ -478,6 +479,9 @@
     "./plugin-sdk/archive": {
       "types": "./dist/plugin-sdk/archive.d.ts",
       "default": "./dist/plugin-sdk/archive.js"
+    },
+    "./plugin-sdk/blob-runtime": {
+      "default": "./dist/plugin-sdk/blob-runtime.js"
     },
     "./plugin-sdk/root-walk": {
       "types": "./dist/plugin-sdk/root-walk.d.ts",

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -22,6 +22,7 @@
   "channel-streaming-config",
   "setup-tools",
   "archive",
+  "blob-runtime",
   "root-walk",
   "secret-file",
   "approval-auth-runtime",

--- a/scripts/lib/plugin-sdk-private-local-only-subpaths.json
+++ b/scripts/lib/plugin-sdk-private-local-only-subpaths.json
@@ -14,6 +14,7 @@
   "approval-reaction-runtime",
   "approval-reference-runtime",
   "async-lock-runtime",
+  "blob-runtime",
   "browser-cdp",
   "browser-config",
   "bundled-channel-config-schema",

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -25,6 +25,7 @@ import type { GuardedFetchMode, GuardedFetchResult } from "../infra/net/fetch-gu
 import { fetchWithSsrFGuard, GUARDED_FETCH_MODE } from "../infra/net/fetch-guard.js";
 import { shouldUseEnvHttpProxyForUrl } from "../infra/net/proxy-env.js";
 import type { LookupFn, PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
+import { bufferToBlobPart } from "../plugin-sdk/blob-runtime.js";
 import {
   executeProviderOperationWithRetry,
   isTransientProviderHttpStatus,
@@ -69,8 +70,7 @@ export function buildAudioTranscriptionFormData(params: {
   fields?: Record<string, string | number | boolean | undefined>;
 }): FormData {
   const form = new FormData();
-  const bytes = new Uint8Array(params.buffer);
-  const blob = new Blob([bytes], {
+  const blob = new Blob([bufferToBlobPart(params.buffer)], {
     type: params.mime ?? "application/octet-stream",
   });
   for (const [name, value] of Object.entries(params.fields ?? {})) {

--- a/src/plugin-sdk/blob-runtime.ts
+++ b/src/plugin-sdk/blob-runtime.ts
@@ -1,0 +1,6 @@
+/** Use immediately in a Blob constructor, which snapshots this exact byte range. */
+export function bufferToBlobPart(buffer: Buffer): Uint8Array<ArrayBuffer> {
+  return buffer.buffer instanceof ArrayBuffer
+    ? new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+    : Uint8Array.from(buffer);
+}


### PR DESCRIPTION
## What Problem This Solves

Upload builders copy each Buffer into a new typed array before Blob or File immediately snapshots it again. Large audio, image, video, workflow and attachment uploads therefore hold an avoidable second full-size copy during construction.

## Why This Change Was Made

Use one dependency-free `bufferToBlobPart` implementation for the core audio adapter and eleven official plugins (thirteen upload owners). Ordinary ArrayBuffer-backed Buffers become exact offset/length views; SharedArrayBuffer backing is copied into an ordinary ArrayBuffer. Every caller constructs its Blob or File synchronously, preserving the existing snapshot boundary. Delete the duplicate Comfy, Feishu and OpenAI video conversion helpers and the other intermediate copies.

The implementation lives directly in the private `blob-runtime` SDK entrypoint. Importing broader provider/fetch facades added unrelated runtime dependencies in measured plugin imports, so this leaf has no imports. Its built runtime closure is two files totaling 451 bytes. Canonical SDK generation adds its JavaScript-only package export and local declaration aliases; the typed public SDK counts remain 147 entrypoints, 4,359 exports and 2,594 callables, with no budget changes.

## User Impact

A controlled 32 MiB upload through the actual core multipart builder reduces ArrayBuffer growth during Blob construction from 67,111,808 to 33,557,376 bytes: one 33,554,432-byte intermediate copy removed. The wire bytes, filename, MIME type, form-field order and mutation-after-construction behavior remain identical. This measures upload-construction allocation, not a whole-Gateway resident-memory reduction.

Production source is net -8 lines; the two maintained SDK classification entries bring production plus maintained metadata to net -6. Generated package/path metadata is +10, documentation +7 and tests +8. Existing OpenAI video tests now protect offset Buffers and snapshot timing; the existing Mattermost HTTP loopback test also asserts exact uploaded bytes.

## Evidence

- Actual-source baseline/candidate probes cover nonzero-offset Buffers, sentinels outside their visible ranges, Blob/File snapshots and SharedArrayBuffer input. A normalized multipart comparison produces identical 466-byte wire payloads. The extracted OpenAI video reference owner independently drops ArrayBuffer growth from 64 MiB to 32 MiB for a 32 MiB input; both image and video metadata/validation remain identical. Source-extracted LINE, Mattermost, PixVerse and Tlon owners preserve bytes and metadata while removing each adapter allocation.
- A real OpenAI `gpt-4o-mini-transcribe` request through the core audio adapter uploaded a synthetic 91,244-byte WAV from an offset Buffer and returned “Memory probe complete.” The request completed in 1,047 ms; this is functional live proof, not a latency benchmark.
- The initial 341 focused tests pass across audio, image providers, ClickClack, Comfy, DeepInfra, Feishu and SDK package contracts. All 164 follow-up tests pass across OpenAI video, ClickClack, LINE, Mattermost (including actual HTTP multipart), PixVerse and Tlon. The full build, SDK surface check and complete changed-check plan pass.
- An isolated built-package fixture resolves the exact generated export from a plugin-local peer link with no checkout dependency. Five cold imports have a 1.358 ms median and preserve byte-view/snapshot contracts. This is a built-package fixture, not an npm tarball or complete installer run. A built Feishu import profile remains approximately 129.7 MiB maximum RSS, within the baseline's 129.5 MiB process variation.
- The existing official-plugin version sync was exercised against isolated copies of all eight separately published affected plugin manifests. It raises their plugin API floor to the target host release; the actual installer compatibility check rejects the older host and accepts that target. Publishing these plugins must retain the normal release version-sync flow so older hosts cannot receive an artifact importing the new private subpath.
- Direct Node Blob implementation/documentation inspection confirms synchronous copying of an exact typed-array range. Independent source, package-resolution and compatibility review plus fresh Codex autoreview found no accepted findings within the selected scope and priority.

Other provider services were covered by their existing tests and shared multipart contract proof; no live Feishu, Comfy or non-OpenAI image-service call is claimed. [Node Blob contract](https://nodejs.org/api/buffer.html#new-bufferblobsources-options).
