### PR TITLE
refactor(sessions): share visible message row decoder

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2651,7 +2651,7 @@ src/config/sessions/metadata.ts	1
 src/config/sessions/restart-recovery-state.ts	6
 src/config/sessions/session-accessor.entry-mutation.ts	2
 src/config/sessions/session-accessor.entry.ts	1
-src/config/sessions/session-accessor.sqlite-active-events.ts	3
+src/config/sessions/session-accessor.sqlite-active-events.ts	1
 src/config/sessions/session-accessor.sqlite-archive-store.ts	1
 src/config/sessions/session-accessor.sqlite-archive.ts	3
 src/config/sessions/session-accessor.sqlite-archive.worker.ts	7

--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -15,6 +15,7 @@ import type {
   TranscriptEvent,
 } from "./session-accessor.sqlite-contract.js";
 import {
+  decodeVisibleMessageRow,
   readTranscriptProjectionGeneration,
   readVisibleMessageMetadata,
   readVisibleMessageRange,
@@ -73,23 +74,6 @@ export type SessionTranscriptBoundedMessageTailPage = SessionTranscriptMessageEv
     indexedSeq: number;
   };
 };
-
-function parseMessageEventRow(row: {
-  event_seq: number;
-  event_json: string;
-  message_position: number | null;
-}): SessionTranscriptMessageEvent {
-  if (row.message_position === null) {
-    throw new Error("Active transcript message row is missing its message position");
-  }
-  return {
-    event: JSON.parse(row.event_json) as TranscriptEvent,
-    eventSeq: row.event_seq,
-    // Gateway cursors use the visible-message ordinal, matching the JSONL index.
-    // Raw event seq includes headers/control rows and would make pages overlap.
-    seq: row.message_position + 1,
-  };
-}
 
 /** Reads every message event on the active path. Full callers remain intentionally O(output). */
 export function readSessionTranscriptMessageEvents(
@@ -329,14 +313,12 @@ export function readSessionTranscriptVisibleMessageDeltaCore(
               .where("active.message_position", "<=", lastMessagePosition)
               .orderBy("active.message_position", "asc"),
           ).rows.map((row) => {
-            if (row.message_position === null) {
-              throw new Error("Active transcript message row is missing its message position");
-            }
+            const decoded = decodeVisibleMessageRow(row);
             return {
-              event: JSON.parse(row.event_json) as TranscriptEvent,
-              eventSeq: row.event_seq,
+              event: decoded.event,
+              eventSeq: decoded.eventSeq,
               parentId: row.parent_id,
-              seq: row.message_position + 1,
+              seq: decoded.seq,
             };
           });
     const requiredBytes =
@@ -498,7 +480,7 @@ export function readSessionTranscriptBoundedMessageTailPage(
               .where("active.session_id", "=", projection.resolved.sessionId)
               .where("active.message_position", "in", selectedPositions)
               .orderBy("active.message_position", "asc"),
-          ).rows.map(parseMessageEventRow);
+          ).rows.map(decodeVisibleMessageRow);
     return {
       activeLeafEntryId: projection.state.leafEventId,
       events,

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -86,6 +86,8 @@ export function decodeVisibleMessageRow(row: {
   return {
     event: JSON.parse(row.event_json) as TranscriptEvent,
     eventSeq: row.event_seq,
+    // Visible cursors use one-based message positions; raw event sequences include
+    // control rows and would make adjacent pages overlap.
     seq: row.message_position + 1,
   };
 }

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -75,7 +75,7 @@ function getResetWindowKysely(database: OpenClawAgentDatabase) {
   return getNodeSqliteKysely<ResetWindowDatabase>(database.db);
 }
 
-function parseMessageEventRow(row: {
+export function decodeVisibleMessageRow(row: {
   event_seq: number;
   event_json: string;
   message_position: number | null;
@@ -391,7 +391,7 @@ export function readVisibleMessageRange(
     executeSqliteQuerySync(
       projection.database.db,
       range.query.select(["active.event_seq", "active.message_position", "event.event_json"]),
-    ).rows.map(parseMessageEventRow),
+    ).rows.map(decodeVisibleMessageRow),
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

The SQLite session readers maintained duplicate visible-message row decoding logic, creating unnecessary drift risk between active-event and reset-window paths.

## Why This Change Was Made

This exports the existing reset-window decoder and reuses it for active-event range, bounded-tail, and visible-delta reads. The delta result is reconstructed explicitly in observable `event`, `eventSeq`, `parentId`, `seq` property order. SQL, schema, store, cursor, JSON parsing, error, sequence, and parent normalization behavior remain unchanged.

The assertion-safety baseline entry for `src/config/sessions/session-accessor.sqlite-active-events.ts` shrinks mechanically from `3` to `1` because the two duplicate `as TranscriptEvent` assertions were removed.

## User Impact

No user-visible behavior change. Session transcript decoding now has one canonical implementation with less production code.

## Evidence

- Focused Vitest: 5 files, 52 tests passed across runtime-config and plugin-sdk shards.
- Changed checks: aggregate checks passed compositionally with `OPENCLAW_TSGO_SPARSE_SKIP=1 OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1`; the standalone dead-export scan passed with 0 script, full-tree, and production entries. The sparse core-test typecheck reported only the expected partial `ui/config` omissions.
- Remaining post-aggregate guards passed individually: native state schema version, database-first legacy stores, media download helpers, runtime sidecar loaders, import cycles, webhook body ordering, pairing store groups, and pairing account scope.
- `git diff --check` passed.
- Import-cycle check reported 0 runtime value cycles.
- Autoreview with Codex `gpt-5.6-sol` at high reasoning was scoped-clean with no accepted or actionable findings.
- LOC: production `+8/-26` (net `-18`), tests `0/0`, assertion baseline metadata `+1/-1`.
