### PR TITLE
test(llama-cpp): avoid hard-link archive fixture races

### DIFF
--- a/extensions/llama-cpp/src/llama-server-extract.test.ts
+++ b/extensions/llama-cpp/src/llama-server-extract.test.ts
@@ -33,7 +33,8 @@ async function createTarArchive(
   await fs.mkdir(buildDir, { recursive: true });
   await build(buildDir);
   const archivePath = path.join(root, "asset.tar.gz");
-  await tar.c({ file: archivePath, cwd: stageDir, gzip: true }, [TEST_ARCHIVE_ROOT]);
+  // Keep tiny fixtures synchronous: node-tar's async hard-link queue can close gzip twice.
+  tar.c({ file: archivePath, cwd: stageDir, gzip: true, sync: true }, [TEST_ARCHIVE_ROOT]);
   const destDir = path.join(root, "dest");
   await fs.mkdir(destDir, { recursive: true });
   return { archivePath, destDir };


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent CI failure while the llama.cpp extraction tests create a gzip archive containing hard links. All test assertions can pass while the fixture producer emits an unhandled `ZlibError: zlib: stream error`.

Observed in the [changed plugin test job](https://github.com/openclaw/openclaw/actions/runs/33501003781/job/99834310317) for #134931, which reported 80 passing files and 1,059 passing tests before failing on the unhandled error.

## Why This Change Was Made

Use node-tar's synchronous packer for these small extraction fixtures. The asynchronous pending-hard-link queue in node-tar 7.5.22 can re-enter gzip finalization; synchronous packing avoids that producer lifecycle race while retaining real gzip archives, filesystem links, and extraction behavior.

No dependency, extraction code, assertion, timeout, retry, or error handling changes. Related: #129035 (managed llama.cpp archive extraction).

## User Impact

Developers get reliable extraction tests. Runtime behavior is unchanged.

## Evidence

- A standalone reproduction using the installed `tar@7.5.22`, two real hard-linked files, and no OpenClaw imports crashed with the same unhandled stack after 40 completed asynchronous packs. The same bounded reproduction completed 200 synchronous packs without errors on Node 24.20.0.
- `node scripts/run-vitest.mjs extensions/llama-cpp/src/llama-server-extract.test.ts extensions/llama-cpp/src/llama-server-install.test.ts` — 19 tests passed, including real symlink/hard-link extraction and archive limits.
- `node scripts/check-changed.mjs -- extensions/llama-cpp/src/llama-server-extract.test.ts` — passed, including extension test types, formatting, lint, and guards.
- Independent Codex review: no actionable P0–P2 findings. Production LOC: 0; tests: +2/−1.

## Maintainer review follow-up

ClawSweeper reported no code findings and noted that its environment could not inspect the dependency. The maintainer review inspected the installed `tar@7.5.22` source map directly: `create.ts` routes synchronous file creation through `PackSync` and `WriteStreamSync`; `pack.ts` supplies the synchronous filesystem operations. This is the dependency's supported fixture producer. The standalone failing/passing reproduction and existing hard-link extraction assertions cover that boundary. Exact-head CI run 33503441812 passed, including the originally failing `changed-extensions-config-1` lane. No separate repair job or broader dependency/runtime change is needed.
