### PR TITLE
perf(plugins): build only the requested provider index

### DIFF
--- a/src/media-generation/provider-registry.ts
+++ b/src/media-generation/provider-registry.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import * as capabilityProviderRuntime from "../plugins/capability-provider-runtime.js";
 import {
-  buildCapabilityProviderMaps,
+  buildCapabilityProviderIndex,
   normalizeCapabilityProviderId,
 } from "../plugins/provider-registry-shared.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
@@ -21,19 +21,24 @@ export function createMediaProviderRegistry<TKey extends MediaProviderRegistryKe
   key: TKey,
   options: { directLookup?: boolean } = {},
 ) {
-  const buildProviderMaps = (cfg?: OpenClawConfig, additionalProviderIds?: readonly string[]) =>
-    buildCapabilityProviderMaps(
+  const buildProviderIndex = (
+    mode: "canonical" | "aliases",
+    cfg?: OpenClawConfig,
+    additionalProviderIds?: readonly string[],
+  ) =>
+    buildCapabilityProviderIndex(
       // The capability runtime's private provider type uses this same registry mapping.
       capabilityProviderRuntime.resolvePluginCapabilityProviders({
         key,
         cfg,
         additionalProviderIds,
       }) as MediaProvider<TKey>[],
+      mode,
     );
 
   return {
     listProviders: (cfg?: OpenClawConfig, additionalProviderIds?: readonly string[]) => [
-      ...buildProviderMaps(cfg, additionalProviderIds).canonical.values(),
+      ...buildProviderIndex("canonical", cfg, additionalProviderIds).values(),
     ],
     getProvider: (providerId: string | undefined, cfg?: OpenClawConfig) => {
       const normalized = normalizeCapabilityProviderId(providerId);
@@ -46,7 +51,7 @@ export function createMediaProviderRegistry<TKey extends MediaProviderRegistryKe
             providerId: normalized,
             cfg,
           })
-        : buildProviderMaps(cfg).aliases.get(normalized);
+        : buildProviderIndex("aliases", cfg).get(normalized);
     },
   };
 }

--- a/src/plugins/provider-registry-shared.test.ts
+++ b/src/plugins/provider-registry-shared.test.ts
@@ -1,30 +1,40 @@
 // Verifies shared provider registry helper behavior.
 import { describe, expect, it } from "vitest";
-import { buildCapabilityProviderMaps } from "./provider-registry-shared.js";
+import { buildCapabilityProviderIndex } from "./provider-registry-shared.js";
 
 describe("provider registry shared", () => {
   it("normalizes provider ids case-insensitively", () => {
-    const { canonical } = buildCapabilityProviderMaps([{ id: "  OpenAI  " }, { id: "   " }]);
+    const canonical = buildCapabilityProviderIndex(
+      [{ id: "  OpenAI  " }, { id: "   " }],
+      "canonical",
+    );
     expect([...canonical.keys()]).toEqual(["openai"]);
   });
 
   it("indexes providers by id and alias", () => {
-    const { canonical, aliases } = buildCapabilityProviderMaps([
-      { id: "Microsoft", aliases: [" EDGE ", "ms"] },
-      { id: "OpenAI" },
-    ]);
+    const microsoft = { id: "Microsoft", aliases: [" EDGE ", "ms"] };
+    const openai = { id: "OpenAI" };
+    const replacement = { id: " microsoft ", aliases: ["azure"] };
+    const providers = [microsoft, openai, replacement];
+    const canonical = buildCapabilityProviderIndex(providers, "canonical");
+    const aliases = buildCapabilityProviderIndex(providers, "aliases");
 
     expect([...canonical.keys()]).toEqual(["microsoft", "openai"]);
-    expect(aliases.get("edge")?.id).toBe("Microsoft");
-    expect(aliases.get("ms")?.id).toBe("Microsoft");
-    expect(aliases.get("openai")?.id).toBe("OpenAI");
+    expect(canonical.get("microsoft")).toBe(replacement);
+    expect(aliases.get("microsoft")).toBe(replacement);
+    expect(aliases.get("edge")).toBe(microsoft);
+    expect(aliases.get("ms")).toBe(microsoft);
+    expect(aliases.get("azure")).toBe(replacement);
+    expect(aliases.get("openai")).toBe(openai);
   });
 
   it("ignores prototype-like ids and aliases", () => {
-    const { canonical, aliases } = buildCapabilityProviderMaps([
+    const providers = [
       { id: "__proto__", aliases: ["constructor", "prototype"] },
       { id: "safe", aliases: ["safe-alias", "constructor"] },
-    ]);
+    ];
+    const canonical = buildCapabilityProviderIndex(providers, "canonical");
+    const aliases = buildCapabilityProviderIndex(providers, "aliases");
 
     expect([...canonical.keys()]).toEqual(["safe"]);
     expect(aliases.get("__proto__")).toBeUndefined();

--- a/src/plugins/provider-registry-shared.ts
+++ b/src/plugins/provider-registry-shared.ts
@@ -23,33 +23,29 @@ export function matchesProviderPluginRef(
   );
 }
 
-/** Builds canonical and alias lookup maps for capability providers. */
-export function buildCapabilityProviderMaps<T extends { id: string; aliases?: readonly string[] }>(
+/** Preserves ordered alias overrides, including aliases of replaced canonical entries. */
+export function buildCapabilityProviderIndex<T extends { id: string; aliases?: readonly string[] }>(
   providers: readonly T[],
-  normalizeId: (
-    providerId: string | undefined,
-  ) => string | undefined = normalizeCapabilityProviderId,
-): {
-  canonical: Map<string, T>;
-  aliases: Map<string, T>;
-} {
-  const canonical = new Map<string, T>();
-  const aliases = new Map<string, T>();
+  mode: "canonical" | "aliases",
+): Map<string, T> {
+  const index = new Map<string, T>();
 
   for (const provider of providers) {
-    const id = normalizeId(provider.id);
+    const id = normalizeCapabilityProviderId(provider.id);
     if (!id) {
       continue;
     }
-    canonical.set(id, provider);
-    aliases.set(id, provider);
+    index.set(id, provider);
+    if (mode === "canonical") {
+      continue;
+    }
     for (const alias of provider.aliases ?? []) {
-      const normalizedAlias = normalizeId(alias);
+      const normalizedAlias = normalizeCapabilityProviderId(alias);
       if (normalizedAlias) {
-        aliases.set(normalizedAlias, provider);
+        index.set(normalizedAlias, provider);
       }
     }
   }
 
-  return { canonical, aliases };
+  return index;
 }

--- a/src/talk/provider-registry.ts
+++ b/src/talk/provider-registry.ts
@@ -5,7 +5,7 @@ import {
   resolvePluginCapabilityProviders,
 } from "../plugins/capability-provider-runtime.js";
 import {
-  buildCapabilityProviderMaps,
+  buildCapabilityProviderIndex,
   normalizeCapabilityProviderId,
 } from "../plugins/provider-registry-shared.js";
 import type { RealtimeVoiceProviderPlugin } from "../plugins/types.js";
@@ -32,7 +32,7 @@ export function listRealtimeVoiceProviders(
     cfg,
     additionalProviderIds,
   });
-  return [...buildCapabilityProviderMaps(providers).canonical.values()];
+  return [...buildCapabilityProviderIndex(providers, "canonical").values()];
 }
 
 /**

--- a/src/tts/provider-registry-core.ts
+++ b/src/tts/provider-registry-core.ts
@@ -1,13 +1,13 @@
 // TTS provider registry core stores provider factories and defaults.
 import type { OpenClawConfig } from "../config/types.js";
 import {
-  buildCapabilityProviderMaps,
+  buildCapabilityProviderIndex,
   normalizeCapabilityProviderId,
 } from "../plugins/provider-registry-shared.js";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
 import type { SpeechProviderId } from "./provider-types.js";
 
-/** Resolver contract used by default and loaded-only speech provider registries. */
+/** Resolver contract for configured speech provider discovery and lookup. */
 export type SpeechProviderRegistryResolver = {
   getProvider: (providerId: string, cfg?: OpenClawConfig) => SpeechProviderPlugin | undefined;
   listProviders: (cfg?: OpenClawConfig) => SpeechProviderPlugin[];
@@ -35,11 +35,11 @@ export function compareSpeechProviderOrder(
 
 /** Create a registry facade with canonical listing, alias lookup, and ID canonicalization. */
 export function createSpeechProviderRegistry(resolver: SpeechProviderRegistryResolver) {
-  const buildResolvedProviderMaps = (cfg?: OpenClawConfig) =>
-    buildCapabilityProviderMaps(resolver.listProviders(cfg));
+  const buildAliasIndex = (cfg?: OpenClawConfig) =>
+    buildCapabilityProviderIndex(resolver.listProviders(cfg), "aliases");
 
   const listProviders = (cfg?: OpenClawConfig): SpeechProviderPlugin[] => [
-    ...buildResolvedProviderMaps(cfg).canonical.values(),
+    ...buildCapabilityProviderIndex(resolver.listProviders(cfg), "canonical").values(),
   ];
 
   const getProvider = (
@@ -50,10 +50,7 @@ export function createSpeechProviderRegistry(resolver: SpeechProviderRegistryRes
     if (!normalized) {
       return undefined;
     }
-    return (
-      resolver.getProvider(normalized, cfg) ??
-      buildResolvedProviderMaps(cfg).aliases.get(normalized)
-    );
+    return resolver.getProvider(normalized, cfg) ?? buildAliasIndex(cfg).get(normalized);
   };
 
   const canonicalizeProviderId = (

--- a/src/tts/provider-registry.ts
+++ b/src/tts/provider-registry.ts
@@ -5,6 +5,7 @@ import {
   resolvePluginCapabilityProvider,
   resolvePluginCapabilityProviders,
 } from "../plugins/capability-provider-runtime.js";
+import { buildCapabilityProviderIndex } from "../plugins/provider-registry-shared.js";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
 import {
   createSpeechProviderRegistry,
@@ -18,10 +19,6 @@ function resolveSpeechProviderPluginEntries(cfg?: OpenClawConfig): SpeechProvide
     key: "speechProviders",
     cfg,
   });
-}
-
-function resolveLoadedSpeechProviderPluginEntries(): SpeechProviderPlugin[] {
-  return (getActiveRuntimePluginRegistry()?.speechProviders ?? []).map((entry) => entry.provider);
 }
 
 const defaultSpeechProviderRegistryResolver: SpeechProviderRegistryResolver = {
@@ -39,22 +36,15 @@ const defaultSpeechProviderRegistry = createSpeechProviderRegistry(
   defaultSpeechProviderRegistryResolver,
 );
 
-/** Loaded-only registry for runtime paths that must not rediscover plugin manifests. */
-const loadedSpeechProviderRegistry = createSpeechProviderRegistry({
-  getProvider: (providerId) =>
-    resolveLoadedSpeechProviderPluginEntries().find((provider) => {
-      if (provider.id === providerId) {
-        return true;
-      }
-      return provider.aliases?.includes(providerId) ?? false;
-    }),
-  listProviders: () => resolveLoadedSpeechProviderPluginEntries(),
-});
-
 /** List configured speech providers using manifest/capability discovery. */
 export const listSpeechProviders = defaultSpeechProviderRegistry.listSpeechProviders;
 /** List currently loaded speech providers from the active runtime registry. */
-export const listLoadedSpeechProviders = loadedSpeechProviderRegistry.listSpeechProviders;
+export function listLoadedSpeechProviders(_cfg?: OpenClawConfig): SpeechProviderPlugin[] {
+  const providers = (getActiveRuntimePluginRegistry()?.speechProviders ?? []).map(
+    (entry) => entry.provider,
+  );
+  return [...buildCapabilityProviderIndex(providers, "canonical").values()];
+}
 /** Resolve a configured speech provider by canonical ID or alias. */
 export const getSpeechProvider = defaultSpeechProviderRegistry.getSpeechProvider;
 /** Resolve an input provider ID or alias to the provider's canonical ID. */


### PR DESCRIPTION
## What Problem This Solves

Capability-provider listing and alias lookup both build two Maps even though each call uses only one. Loaded speech listing also creates a complete registry facade whose lookup path is never exposed.

## Why This Change Was Made

Have the existing shared owner build one explicitly requested canonical or alias index. Update speech, realtime Talk and media registries together, and replace the unused loaded-speech facade with its actual listing operation. Remove the unused custom-normalizer parameter.

Keep alias insertion in original provider order, including aliases belonging to an earlier record whose canonical ID is replaced. Preserve normalization, blocked-key filtering, exact provider identity, fresh result arrays, the public optional config argument and per-call observation of mutable IDs/aliases. No cache or discovery policy is added.

## User Impact

An actual loaded-inventory call with the collision fixture constructs one Map and performs three sets, down from two Maps and nine sets. Alias fallback constructs one Map and performs six sets, down from two and nine. These are transient per-call allocation reductions; no retained-heap or Gateway RSS claim is made.

Production is net -12 lines and tests net +10. The existing alias test now also protects canonical replacement order and aliases retained from the displaced record.

## Evidence

- Actual-source before/after probes compare provider identity, aliases, insertion order, blocked keys, public function arity, fresh detached result arrays and post-registration ID/alias mutation.
- Independent differential review compares 10,000 deterministic inventories containing 57,734 provider records, before and after mutation: all 40,000 canonical/alias comparisons match.
- The rebuilt isolated Gateway returns a byte-equivalent parsed `tts.providers` response before and after: xAI and OpenAI retain the same order, metadata and configured state, with OpenAI selected.
- All 38 focused owner/sibling tests, the complete required changed-check plan, full build and live Gateway comparison pass. Fresh Codex autoreview is scoped-clean at the requested P0 priority.
