### PR TITLE
perf(state): reduce repeated schema reads during database opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **State database performance:** reuse table metadata within each startup read transaction to reduce database-open overhead while preserving schema, integrity, and repair checks.
-
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.
 
 - **macOS AI setup:** show confirmed capability-review cancellation and retry guidance directly instead of a misleading Gateway failure headline. (#134573)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **State database performance:** reuse table metadata within each startup read transaction to reduce database-open overhead while preserving schema, integrity, and repair checks.
+
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.
 
 - **macOS AI setup:** show confirmed capability-review cancellation and retry guidance directly instead of a misleading Gateway failure headline. (#134573)

--- a/src/infra/sqlite-schema-contract.ts
+++ b/src/infra/sqlite-schema-contract.ts
@@ -79,6 +79,8 @@ type SqliteTableContract = {
 
 type SqliteSchemaContract = Map<string, SqliteTableContract>;
 
+export type SqliteTableContractReader = (tableName: string) => SqliteTableContract | undefined;
+
 export type CanonicalSqliteNamedIndexContract = {
   definition: string;
   fingerprint: SqliteIndexContract;
@@ -89,6 +91,17 @@ export type CanonicalSqliteNamedIndexContract = {
 
 const schemaContractCache = new Map<string, SqliteSchemaContract>();
 
+/** Reuse actual table facts only within one unchanged read transaction on this connection. */
+export function createSqliteTableContractReader(database: DatabaseSync): SqliteTableContractReader {
+  const tables = new Map<string, SqliteTableContract | undefined>();
+  return (tableName) => {
+    if (!tables.has(tableName)) {
+      tables.set(tableName, collectSqliteTableContract(database, tableName));
+    }
+    return tables.get(tableName);
+  };
+}
+
 /**
  * Require every object from one committed schema while allowing unrelated
  * tables and indexes that do not replace a canonical object.
@@ -98,8 +111,9 @@ export function assertSqliteSchemaContains(
   databaseLabel: string,
   schemaSql: string,
   compatibility: SqliteSchemaCompatibility = {},
+  readTable?: SqliteTableContractReader,
 ): void {
-  const issues = collectSqliteSchemaIssues(database, schemaSql, compatibility);
+  const issues = collectSqliteSchemaIssues(database, schemaSql, compatibility, readTable);
   if (issues.length > 0) {
     throwSqliteSchemaMismatches(databaseLabel, legacySqliteSchemaIssueMessages(issues));
   }
@@ -110,6 +124,7 @@ export function collectSqliteSchemaIssues(
   database: DatabaseSync,
   schemaSql: string,
   compatibility: SqliteSchemaCompatibility = {},
+  readTable?: SqliteTableContractReader,
 ): SqliteSchemaIssue[] {
   const expected = getSqliteSchemaContract(schemaSql);
   const allowedMissingTables = new Set(compatibility.allowedMissingTables ?? []);
@@ -120,7 +135,9 @@ export function collectSqliteSchemaIssues(
     issues.push(createSqliteSchemaIssue(code, objectName, message));
   };
   for (const [tableName, expectedTable] of expected) {
-    const actualTable = collectSqliteTableContract(database, tableName);
+    const actualTable = readTable
+      ? readTable(tableName)
+      : collectSqliteTableContract(database, tableName);
     if (!actualTable) {
       if (allowedMissingTables.has(tableName)) {
         continue;

--- a/src/state/openclaw-state-db-fast-path.ts
+++ b/src/state/openclaw-state-db-fast-path.ts
@@ -1,6 +1,10 @@
 import type { DatabaseSync } from "node:sqlite";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
-import { collectSqliteSchemaIssues } from "../infra/sqlite-schema-contract.js";
+import {
+  collectSqliteSchemaIssues,
+  createSqliteTableContractReader,
+  type SqliteTableContractReader,
+} from "../infra/sqlite-schema-contract.js";
 import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import { hasLegacyCronRunLogs } from "../infra/state-migrations.cron-run-logs.js";
@@ -17,9 +21,13 @@ import {
   STATE_PERSISTENT_SCHEMA_COMPATIBILITY,
 } from "./openclaw-state-schema-compatibility.js";
 
-export function assertCurrentStateRuntimeSchema(database: DatabaseSync, pathname: string): void {
+export function assertCurrentStateRuntimeSchema(
+  database: DatabaseSync,
+  pathname: string,
+  readTable?: SqliteTableContractReader,
+): void {
   assertCanonicalStateSchemaShape(database, pathname);
-  assertOpenClawStateDatabaseForMaintenance(database, { pathname });
+  assertOpenClawStateDatabaseForMaintenance(database, { pathname }, readTable);
 }
 
 export function isOpenClawStateSchemaFastPathEligible(
@@ -32,11 +40,14 @@ export function isOpenClawStateSchemaFastPathEligible(
       return false;
     }
     assertSqliteIntegrity(database, pathname);
-    assertCurrentStateRuntimeSchema(database, pathname);
+    // Both policies see this read transaction; repair must collect fresh facts after it ends.
+    const readTable = createSqliteTableContractReader(database);
+    assertCurrentStateRuntimeSchema(database, pathname, readTable);
     const startupRepairRequired = collectSqliteSchemaIssues(
       database,
       getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: false }),
       STATE_PERSISTENT_SCHEMA_COMPATIBILITY,
+      readTable,
     ).some(isOpenClawStateStartupRepairableSchemaIssue);
     if (startupRepairRequired) {
       return false;

--- a/src/state/openclaw-state-db-maintenance.ts
+++ b/src/state/openclaw-state-db-maintenance.ts
@@ -3,6 +3,7 @@ import type { DatabaseSync } from "node:sqlite";
 import {
   assertSqliteSchemaContains,
   assertSqliteSchemaTablesPresent,
+  type SqliteTableContractReader,
 } from "../infra/sqlite-schema-contract.js";
 import {
   createNewerSqliteSchemaVersionError,
@@ -112,6 +113,7 @@ export function assertOpenClawStateDatabaseOwner(
 export function assertOpenClawStateDatabaseForMaintenance(
   database: DatabaseSync,
   options: { pathname: string },
+  readTable?: SqliteTableContractReader,
 ): void {
   const userVersion = readSqliteUserVersion(database);
   if (userVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
@@ -144,6 +146,7 @@ export function assertOpenClawStateDatabaseForMaintenance(
     options.pathname,
     OPENCLAW_STATE_SCHEMA_SQL,
     OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
+    readTable,
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Opening an existing shared-state database repeats the same table-metadata reads for two startup validation policies. This adds avoidable work to cold database handles, including opens made while a WAL writer is active.

## Why This Change Was Made

Reuse the actual table facts inside the existing deferred read transaction, on the same connection. Both policies still run with their own compatibility rules. The reader is discarded when that transaction ends; repairs and subsequent opens collect fresh facts. Integrity checks, schema versions, migrations, and configuration are unchanged.

A process-wide cache would cross transaction and DDL boundaries, while removing either validator would lose policy-specific checks. The explicit reader is a small shared mechanism that preserves both boundaries. Production LOC: +37/-6 (net +31); test LOC unchanged. The added lines provide the transaction-scoped reader and typed plumbing, without adding persistent state or a second validation flow.

## User Impact

Less work when opening the shared-state database. Existing corruption refusal, repair behavior, optional-table policies, and read-only inspection remain unchanged.

## Evidence

Measured complete public operations on Node 26.8.1/macOS arm64, with fresh native database handles and copied, OS-warm fixture files. Fixed before/candidate/candidate/before order; 12 workloads, 1 first observation, 8 warm-ups, and 22 measured observations per workload in each process: 1,056 measured samples. Imports, fixture copying, output verification, and cleanup were outside each operation's clock; the public open/read/close lifecycle was inside it. These are database-operation measurements, not end-to-end Gateway or model latency.

| Public operation | Before → after median, forward | Before → after median, reverse |
| --- | --- | --- |
| Minimal existing database | 28.49 → 20.53 ms (-27.9%) | 28.57 → 20.58 ms (-28.0%) |
| 64 deliveries / 256 diagnostics | 30.99 → 20.47 ms (-33.9%) | 27.94 → 20.21 ms (-27.7%) |
| Full canonical tables | 34.91 → 25.68 ms (-26.5%) | 33.32 → 25.33 ms (-24.0%) |
| Open while a WAL writer holds its transaction | 27.68 → 19.69 ms (-28.9%) | 27.52 → 19.40 ms (-29.5%) |

All predeclared criteria passed. No control regressed in both orders. The two adverse medians are retained: an already-open lookup increased 0.56 µs (+2.67%) in one order, and unique-index refusal increased 0.24 ms (+0.92%) in one order; both improved in the other order. Two adverse first observations were also retained (+2.79% read-only snapshot, +4.03% preflight). No causal memory-saving claim is made.

Both whole-source variants passed 31 native schema, repair, corruption, DDL, connection-isolation, and WAL-snapshot cases, with identical results for those cases and all 12 public-operation oracles. A separate fixture run exercised the actual read-only snapshot worker and verified that its source database stayed unchanged. All experiment processes, worker generations, temporary runtimes, and exact task-owned coordinator files were closed or removed.

Existing canonical suites: 361 passed, 9 existing skips across 10 files covering schema contracts, public state opens, read-only paths, runtime fences, additive schema, permissions, corruption recovery, transactions, snapshots, and WAL maintenance. No new test duplicates implementation details. Codex autoreview found no accepted/actionable blocking findings in its selected scope.

The same committed candidate also passed the full changed-file check (formatting, types, lint, schema/dependency guards, and dead exports) and a fresh runtime build. An isolated built Gateway then completed four real OpenAI turns, local-file reading, tool discovery, two sequential live web fetches (Markdown and text, both HTTP 200), system-event/status checks, and 12 session-list requests. Gateway readiness was 3.78 s; this single smoke run is behavior evidence, not a comparative latency result. Main-thread and worker CPU profiles were retained, the Gateway exited cleanly, and task credentials/config and fetch spill files were removed.

The first CI attempt hit 120-second Git-history fetch timeouts in security-fast and check-guards. No source failure was reported by those jobs; their completed logs are retained and the failed checks will be rerun without weakening the checks.

Review follow-up: removed the direct CHANGELOG.md edit because release generation owns that file. Release context remains in this PR body. The final production diff is unchanged, and no table definitions, SQLite schema version, migration, or persisted data shape are modified; the automated SQLite-table-change warning does not describe this patch. The current tip contains only the three measured source changes relative to its base.

The review's suggested rebase is unnecessary after removing the sole conflicting file: GitHub now reports the exact tip as MERGEABLE. The native prepare/merge flow will still validate the current main merge result and exact-head CI. No history rewrite or check bypass is being used to avoid the conflict.
