### PR TITLE
fix(doctor): never persist unresolved env-template placeholders as API keys

### DIFF
--- a/src/commands/doctor-model-catalog-credentials.test.ts
+++ b/src/commands/doctor-model-catalog-credentials.test.ts
@@ -279,4 +279,36 @@ describe("doctor model catalog credential migration", () => {
       key: "child-secret",
     });
   });
+
+  it("never persists unresolved env-template placeholders as API keys", async () => {
+    const state = createState();
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          braced: provider("${CUSTOM_API_KEY}"),
+          shorthand: provider("$OTHER_API_KEY"),
+          literal: provider("sk-real-secret"),
+        },
+      },
+    };
+
+    const result = await maybeMigrateModelCatalogCredentials(migrationParams(state, cfg));
+
+    expect(result).toMatchObject({ detected: 1, migrated: 1, warnings: [] });
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = state.stateDir;
+    let profiles: Record<string, unknown>;
+    try {
+      profiles = loadPersistedAuthProfileStore(undefined)?.profiles ?? {};
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+    expect(profiles["literal:default"]).toMatchObject({ key: "sk-real-secret" });
+    expect(profiles["braced:default"]).toBeUndefined();
+    expect(profiles["shorthand:default"]).toBeUndefined();
+  });
 });

--- a/src/commands/doctor-model-catalog-credentials.test.ts
+++ b/src/commands/doctor-model-catalog-credentials.test.ts
@@ -311,4 +311,34 @@ describe("doctor model catalog credential migration", () => {
     expect(profiles["braced:default"]).toBeUndefined();
     expect(profiles["shorthand:default"]).toBeUndefined();
   });
+
+  it("skips bare catalog env markers that match an authored provider SecretRef", async () => {
+    const state = createState();
+    const { agentDir } = state;
+    const cfg: OpenClawConfig = {
+      models: { providers: { example: provider("${CUSTOM_API_KEY}") } },
+    };
+    // A generated catalog stores the same SecretRef as a bare env id.
+    fs.writeFileSync(
+      path.join(agentDir, "models.json"),
+      `${JSON.stringify({ providers: { example: provider("CUSTOM_API_KEY") } }, null, 2)}\n`,
+    );
+
+    const result = await maybeMigrateModelCatalogCredentials(migrationParams(state, cfg));
+
+    expect(result).toMatchObject({ detected: 0, migrated: 0, warnings: [] });
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = state.stateDir;
+    let profiles: Record<string, unknown>;
+    try {
+      profiles = loadPersistedAuthProfileStore(undefined)?.profiles ?? {};
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+    expect(profiles["example:default"]).toBeUndefined();
+  });
 });

--- a/src/commands/doctor-model-catalog-credentials.test.ts
+++ b/src/commands/doctor-model-catalog-credentials.test.ts
@@ -341,4 +341,35 @@ describe("doctor model catalog credential migration", () => {
     }
     expect(profiles["example:default"]).toBeUndefined();
   });
+
+  it("keeps a same-string literal from a different provider when SecretRefs are provider-bound", async () => {
+    const state = createState();
+    const { agentDir } = state;
+    const cfg: OpenClawConfig = {
+      models: { providers: { example: provider("${CUSTOM_API_KEY}") } },
+    };
+    // A different provider uses the same string as a literal catalog credential.
+    fs.writeFileSync(
+      path.join(agentDir, "models.json"),
+      `${JSON.stringify({ providers: { other: provider("CUSTOM_API_KEY") } }, null, 2)}\n`,
+    );
+
+    const result = await maybeMigrateModelCatalogCredentials(migrationParams(state, cfg));
+
+    expect(result).toMatchObject({ detected: 1, migrated: 1, warnings: [] });
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = state.stateDir;
+    let profiles: Record<string, unknown>;
+    try {
+      profiles = loadPersistedAuthProfileStore(undefined)?.profiles ?? {};
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+    expect(profiles["example:default"]).toBeUndefined();
+    expect(profiles["other:default"]).toMatchObject({ key: "CUSTOM_API_KEY" });
+  });
 });

--- a/src/commands/doctor-model-catalog-credentials.ts
+++ b/src/commands/doctor-model-catalog-credentials.ts
@@ -22,6 +22,7 @@ import {
 } from "../agents/plugin-model-catalog.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { parseEnvTemplateSecretRef } from "../config/types.secrets.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { listAgentModelsJsonPaths } from "../secrets/storage-scan.js";
 import { shortenHomePath } from "../utils.js";
@@ -67,6 +68,7 @@ function collectCredentials(
     const credential = { provider, key };
     if (
       !key.trim() ||
+      parseEnvTemplateSecretRef(key) !== null ||
       isNonSecretApiKeyMarker(key) ||
       store.profiles[key] !== undefined ||
       findMatchingProfileId(store, credential, blockedStores) !== undefined

--- a/src/commands/doctor-model-catalog-credentials.ts
+++ b/src/commands/doctor-model-catalog-credentials.ts
@@ -52,28 +52,31 @@ function credentialMatches(
   );
 }
 
-function collectAuthoredEnvApiKeyIds(providers: unknown): Set<string> {
+function collectAuthoredEnvApiKeyIds(providers: unknown): Map<string, Set<string>> {
+  const byProvider = new Map<string, Set<string>>();
   if (!isRecord(providers)) {
-    return new Set();
+    return byProvider;
   }
-  const ids = new Set<string>();
-  for (const entry of Object.values(providers)) {
+  for (const [provider, entry] of Object.entries(providers)) {
     if (!isRecord(entry) || typeof entry.apiKey !== "string") {
       continue;
     }
     const ref = parseEnvTemplateSecretRef(entry.apiKey);
     if (ref?.source === "env") {
+      const providerKey = normalizeProviderId(provider);
+      const ids = byProvider.get(providerKey) ?? new Set<string>();
       ids.add(ref.id);
+      byProvider.set(providerKey, ids);
     }
   }
-  return ids;
+  return byProvider;
 }
 
 function collectCredentials(
   providers: unknown,
   store: AuthProfileStore,
   blockedStores: readonly AuthProfileStore[] = [],
-  authoredEnvApiKeyIds: ReadonlySet<string> = new Set(),
+  authoredEnvApiKeyIds: ReadonlyMap<string, ReadonlySet<string>> = new Map(),
 ): PlaintextCredential[] {
   if (!isRecord(providers)) {
     return [];
@@ -87,7 +90,7 @@ function collectCredentials(
     if (
       !key.trim() ||
       parseEnvTemplateSecretRef(key) !== null ||
-      authoredEnvApiKeyIds.has(key) ||
+      authoredEnvApiKeyIds.get(normalizeProviderId(provider))?.has(key) === true ||
       isNonSecretApiKeyMarker(key) ||
       store.profiles[key] !== undefined ||
       findMatchingProfileId(store, credential, blockedStores) !== undefined

--- a/src/commands/doctor-model-catalog-credentials.ts
+++ b/src/commands/doctor-model-catalog-credentials.ts
@@ -52,10 +52,28 @@ function credentialMatches(
   );
 }
 
+function collectAuthoredEnvApiKeyIds(providers: unknown): Set<string> {
+  if (!isRecord(providers)) {
+    return new Set();
+  }
+  const ids = new Set<string>();
+  for (const entry of Object.values(providers)) {
+    if (!isRecord(entry) || typeof entry.apiKey !== "string") {
+      continue;
+    }
+    const ref = parseEnvTemplateSecretRef(entry.apiKey);
+    if (ref?.source === "env") {
+      ids.add(ref.id);
+    }
+  }
+  return ids;
+}
+
 function collectCredentials(
   providers: unknown,
   store: AuthProfileStore,
   blockedStores: readonly AuthProfileStore[] = [],
+  authoredEnvApiKeyIds: ReadonlySet<string> = new Set(),
 ): PlaintextCredential[] {
   if (!isRecord(providers)) {
     return [];
@@ -69,6 +87,7 @@ function collectCredentials(
     if (
       !key.trim() ||
       parseEnvTemplateSecretRef(key) !== null ||
+      authoredEnvApiKeyIds.has(key) ||
       isNonSecretApiKeyMarker(key) ||
       store.profiles[key] !== undefined ||
       findMatchingProfileId(store, credential, blockedStores) !== undefined
@@ -258,6 +277,7 @@ export async function maybeMigrateModelCatalogCredentials(params: {
   const childStores = catalogs
     .filter((catalog) => catalog.agentDir !== mainAgentDir)
     .map((catalog) => catalog.localStore);
+  const authoredEnvApiKeyIds = collectAuthoredEnvApiKeyIds(params.cfg.models?.providers);
   const configCredentials = collectCredentials(
     params.cfg.models?.providers,
     mainStore,
@@ -266,7 +286,12 @@ export async function maybeMigrateModelCatalogCredentials(params: {
   const catalogCredentials = catalogs.map((catalog, index) =>
     uniqueCredentials(
       catalog.providers.flatMap((providers) =>
-        collectCredentials(providers, effectiveStores[index] ?? mainStore),
+        collectCredentials(
+          providers,
+          effectiveStores[index] ?? mainStore,
+          [],
+          authoredEnvApiKeyIds,
+        ),
       ),
     ),
   );


### PR DESCRIPTION
Closes #135079

## What Problem This Solves

Fixes a Doctor migration that persisted unresolved environment-reference placeholders as literal API keys. After upgrading to 2026.8.1, `openclaw doctor` could copy `${CUSTOM_API_KEY}` (and `$CUSTOM_API_KEY`) into the SQLite auth-profile store as if they were real secrets, causing the stored profiles to take precedence over the correctly resolved provider credential at runtime and produce a deterministic 401/403 → rotation → HTTP 200 sequence.

## Why This Change Was Made

`collectCredentials()` treats any string `apiKey` as secret material unless `isNonSecretApiKeyMarker()` recognizes a built-in marker. That check does not recognize arbitrary custom-provider env names or the `${VAR}` / `$VAR` env-template shorthand, so the migration persisted the raw placeholder without consulting the authored SecretRef resolution facts.

The fix reuses `parseEnvTemplateSecretRef()` — the same resolver the config layer uses for `$NAME` / `${NAME}` env-secret shorthand — to skip any `apiKey` that names an env reference before it can be persisted.

## User Impact

`openclaw doctor` no longer creates auth profiles from unresolved `${VAR}` / `$VAR` placeholders, and the documented provider SecretRef remains the authoritative route instead of being shadowed by a stale stored profile.

## Evidence

Exact head: `d853ed1bd8958d0f784d8d5347f6d90c869ae1d5`.

- `src/commands/doctor-model-catalog-credentials.test.ts` — 7 passed, including a new regression that configures `apiKey: "${CUSTOM_API_KEY}"`, `apiKey: "$OTHER_API_KEY"`, and a real literal key, then asserts only the literal key creates a profile and the placeholder providers create none.
- Production typecheck and `check:changed` pass; the only local lane failure is unchanged `ui/vite.config.ts` missing a `pako` declaration in the reused dependency tree.

## AI Assistance

AI-assisted implementation. I manually verified the collector boundary, the env-template resolver reuse, the focused regression, and the changed-file gates.
