### PR TITLE
refactor(cron): derive output types from protocol schema

### DIFF
--- a/src/cron/run-diagnostics-normalize.ts
+++ b/src/cron/run-diagnostics-normalize.ts
@@ -2,25 +2,11 @@
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { CronRunDiagnostic, CronRunDiagnostics } from "./types.js";
 
 const MAX_ENTRIES = 10;
 const MAX_ENTRY_CHARS = 1_000;
 const MAX_SUMMARY_CHARS = 2_000;
-
-type NormalizedCronRunDiagnostic = {
-  ts: number;
-  source: ReturnType<typeof normalizeSource>;
-  severity: ReturnType<typeof normalizeSeverity>;
-  message: string;
-  toolName?: string;
-  exitCode?: number | null;
-  truncated?: boolean;
-};
-
-type NormalizedCronRunDiagnostics = {
-  summary?: string;
-  entries: NormalizedCronRunDiagnostic[];
-};
 
 type CronRunDiagnosticsNormalizeOptions = {
   nowMs?: () => number;
@@ -28,20 +14,11 @@ type CronRunDiagnosticsNormalizeOptions = {
   redactText?: (value: string) => string;
 };
 
-function normalizeSeverity(value: unknown): "info" | "warn" | "error" {
+function normalizeSeverity(value: unknown): CronRunDiagnostic["severity"] {
   return value === "info" || value === "warn" || value === "error" ? value : "error";
 }
 
-function normalizeSource(
-  value: unknown,
-):
-  | "cron-preflight"
-  | "cron-setup"
-  | "model-preflight"
-  | "agent-run"
-  | "tool"
-  | "exec"
-  | "delivery" {
+function normalizeSource(value: unknown): CronRunDiagnostic["source"] {
   switch (value) {
     case "cron-preflight":
     case "cron-setup":
@@ -122,7 +99,7 @@ export function normalizeCronRunDiagnosticSummary(value: string | undefined): st
 export function normalizeCronRunDiagnosticsCore(
   value: unknown,
   opts?: CronRunDiagnosticsNormalizeOptions,
-): NormalizedCronRunDiagnostics | undefined {
+): CronRunDiagnostics | undefined {
   if (!value || typeof value !== "object") {
     return undefined;
   }
@@ -130,12 +107,12 @@ export function normalizeCronRunDiagnosticsCore(
   const nowMs = opts?.nowMs ?? Date.now;
   const redactText = opts?.redactText ?? ((text: string) => text);
   const entriesRaw = Array.isArray(record.entries) ? record.entries : [];
-  const entries: NormalizedCronRunDiagnostic[] = [];
+  const entries: CronRunDiagnostic[] = [];
   for (const item of entriesRaw) {
     if (!item || typeof item !== "object") {
       continue;
     }
-    const entry = item as Partial<NormalizedCronRunDiagnostic>;
+    const entry = item as Partial<CronRunDiagnostic>;
     const normalized = normalizeDiagnosticMessage(entry.message, redactText);
     if (!normalized.message) {
       continue;

--- a/src/cron/run-diagnostics-normalize.ts
+++ b/src/cron/run-diagnostics-normalize.ts
@@ -2,7 +2,10 @@
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import type { CronRunDiagnostic, CronRunDiagnostics } from "./types.js";
+import type { CronRunLogEntry as CronRunLogWireEntry } from "../../packages/gateway-protocol/src/schema/cron.types.js";
+
+type CronRunDiagnostics = NonNullable<CronRunLogWireEntry["diagnostics"]>;
+type CronRunDiagnostic = CronRunDiagnostics["entries"][number];
 
 const MAX_ENTRIES = 10;
 const MAX_ENTRY_CHARS = 1_000;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -1,3 +1,4 @@
+import type { CronRunLogEntry as CronRunLogWireEntry } from "../../packages/gateway-protocol/src/schema/cron.types.js";
 import type { EmbeddedAgentExecutionPhase } from "../agents/embedded-agent-runner/execution-phase.js";
 /** Cron scheduling, delivery, diagnostics, and store data contracts. */
 import type { FailoverReason } from "../agents/failover/signal.js";
@@ -125,30 +126,15 @@ export type CronRunStatus = "ok" | "error" | "skipped";
 export type CronDeliveryStatus = "delivered" | "not-delivered" | "unknown" | "not-requested";
 
 /** Delivery target snapshot recorded for audit/debug output. */
-export type CronDeliveryTraceTarget = {
-  channel?: string;
-  to?: string | null;
-  accountId?: string;
-  threadId?: string | number;
-  source?: "explicit" | "last";
-};
+export type CronDeliveryTraceTarget = NonNullable<CronDeliveryTrace["intended"]>;
 
 /** Message-tool target that already sent to the cron delivery destination. */
-export type CronDeliveryTraceMessageTarget = {
-  channel: string;
-  to?: string;
-  accountId?: string;
-  threadId?: string;
-};
+export type CronDeliveryTraceMessageTarget = NonNullable<
+  CronDeliveryTrace["messageToolSentTo"]
+>[number];
 
 /** Trace of intended, resolved, and already-sent delivery decisions for one run. */
-export type CronDeliveryTrace = {
-  intended?: CronDeliveryTraceTarget;
-  resolved?: CronDeliveryTraceTarget & { ok: boolean; error?: string };
-  messageToolSentTo?: CronDeliveryTraceMessageTarget[];
-  fallbackUsed?: boolean;
-  delivered?: boolean;
-};
+export type CronDeliveryTrace = NonNullable<CronRunLogWireEntry["delivery"]>;
 
 /** Last failed-run notification delivery state stored on job state and run logs. */
 export type CronFailureNotificationDelivery = {
@@ -173,51 +159,20 @@ export type CronDeliveryPreview = {
   detail: string;
 };
 
-/** Token usage summary copied from the agent runner when available. */
-type CronUsageSummary = {
-  input_tokens?: number;
-  output_tokens?: number;
-  total_tokens?: number;
-  cache_read_tokens?: number;
-  cache_write_tokens?: number;
-};
-
 /** Model/provider/usage telemetry attached to cron run results and logs. */
-export type CronRunTelemetry = {
-  model?: string;
-  provider?: string;
-  usage?: CronUsageSummary;
-};
+export type CronRunTelemetry = Pick<CronRunLogWireEntry, "model" | "provider" | "usage">;
 
 /** Severity level for persisted cron run diagnostics. */
-export type CronRunDiagnosticSeverity = "info" | "warn" | "error";
+export type CronRunDiagnosticSeverity = CronRunDiagnostic["severity"];
 
 /** Subsystem that produced a cron run diagnostic entry. */
-export type CronRunDiagnosticSource =
-  | "cron-preflight"
-  | "cron-setup"
-  | "model-preflight"
-  | "agent-run"
-  | "tool"
-  | "exec"
-  | "delivery";
+export type CronRunDiagnosticSource = CronRunDiagnostic["source"];
 
 /** Timestamped diagnostic entry preserved for cron run troubleshooting. */
-export type CronRunDiagnostic = {
-  ts: number;
-  source: CronRunDiagnosticSource;
-  severity: CronRunDiagnosticSeverity;
-  message: string;
-  toolName?: string;
-  exitCode?: number | null;
-  truncated?: boolean;
-};
+export type CronRunDiagnostic = CronRunDiagnostics["entries"][number];
 
 /** Bounded diagnostic bundle stored on the run outcome. */
-export type CronRunDiagnostics = {
-  summary?: string;
-  entries: CronRunDiagnostic[];
-};
+export type CronRunDiagnostics = NonNullable<CronRunLogWireEntry["diagnostics"]>;
 
 /** Explicit execution-error disposition used consistently by retry, history, and alerts. */
 export type CronRunErrorClassification =


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Cron diagnostics, delivery traces and usage telemetry duplicated output shapes already defined by the protocol schema. This internal cleanup gives those types one canonical owner without changing intended user-visible behavior.

## Why This Change Was Made

Core keeps its existing exported type names but derives their shapes from the leaf Cron run-log wire type. The diagnostics normalizer uses that same leaf directly, avoiding the broad core-type dependency that caused a cycle in the first candidate.

Normalization, redaction injection, diagnostic bounds, delivery decisions, serialization and stored representations are unchanged. No protocol schema, configuration, dependency or persistence change is introduced. The complete two-file production diff is **+20/−85 (net −65)**; tests are unchanged.

## User Impact

No intended behavior change. Cron execution, history and troubleshooting keep their existing behavior while output-shape maintenance has one canonical type owner.

## Evidence

- All **81 existing cases** passed across diagnostics, task-run history and protocol tests, with case identities and within-suite order preserved.
- Source and emitted-declaration compatibility checks passed with `exactOptionalPropertyTypes` both disabled and enabled. Source consumers retain `skipLibCheck: true`; emitted consumers use `skipLibCheck: false` and the same **646 compiler inputs**. This proves type/declaration compatibility, not packaged-JavaScript equivalence.
- The normal **28-check changed gate** and **16-stage standard build** passed with normal cache/deadline policy. Source, dependency and generated-output checks completed afterward.
- The first candidate's Madge CI failure was repaired by using the canonical leaf type, not by hiding type edges. A subsequent stale-base gate failure came from an upstream worker fixture importing `sharp`; the rebase inherited the already-landed canonical fixture repair without adding a dependency or a second fix.
- Fresh Codex review completed two normal evidence passes with **no P0 findings**. Review was limited to supplied material and P0 scope; it is not all-priority certification.
- Tested candidate: `3f003da4c32ffe5bcb23bb9d45e90fad2d27aa1e`, based on `60c5793325d0931038307aaefbb0d8b944eba733`. Hosted exact-head CI and normal landing checks remain pending.
