### PR TITLE
fix(agents): Anthropic refusals stop without resending requests

### DIFF
--- a/src/agents/embedded-agent-helpers.ts
+++ b/src/agents/embedded-agent-helpers.ts
@@ -7,6 +7,7 @@ export {
 } from "./embedded-agent-helpers/bootstrap.js";
 export {
   classifyAssistantFailoverReason,
+  findProviderRefusal,
   isAuthAssistantError,
   isBillingAssistantError,
   isFailoverAssistantError,

--- a/src/agents/embedded-agent-helpers/assistant-message-failures.ts
+++ b/src/agents/embedded-agent-helpers/assistant-message-failures.ts
@@ -1,4 +1,4 @@
-import type { AssistantMessage } from "../../llm/types.js";
+import type { AssistantMessage, AssistantMessageDiagnostic } from "../../llm/types.js";
 import { isReplayUnsafeAssistantError } from "../../llm/utils/retry.js";
 import { extractErrorHttpStatus } from "../../shared/assistant-error-format.js";
 import {
@@ -11,6 +11,14 @@ import type { PreparedProviderFailoverOwner } from "../failover/provider-pattern
 import { resolveRetryAfterMs } from "../failover/retry-evidence.js";
 import { extractFailoverSignalDetails } from "../failover/signal-details.js";
 import type { FailoverReason, FailoverSignal } from "../failover/signal.js";
+
+/** Returns the provider-owned terminal refusal diagnostic, when present. */
+export function findProviderRefusal(
+  msg: Pick<AssistantMessage, "diagnostics"> | null | undefined,
+): AssistantMessageDiagnostic | undefined {
+  return msg?.diagnostics?.find((diagnostic) => diagnostic.type === "provider_refusal");
+}
+
 export function buildAssistantFailoverSignal(
   msg: AssistantMessage,
   opts?: { provider?: string },

--- a/src/agents/embedded-agent-helpers/error-text.test.ts
+++ b/src/agents/embedded-agent-helpers/error-text.test.ts
@@ -57,6 +57,50 @@ describe("formatAssistantErrorText streaming JSON parse classification", () => {
     },
   );
 
+  it("surfaces only the bounded category from a structured provider refusal", () => {
+    const msg = makeAssistantMessageFixture({
+      errorMessage: "HTTP 503: private provider explanation",
+      content: [],
+      diagnostics: [
+        {
+          type: "provider_refusal",
+          timestamp: 1,
+          details: {
+            provider: "anthropic",
+            category: "policy_safety-2",
+            explanation: "private provider explanation",
+          },
+        },
+      ],
+    });
+
+    expect(formatAssistantErrorText(msg)).toBe(
+      "The provider refused this request (category: policy_safety-2).",
+    );
+    expect(formatUserFacingAssistantErrorText(msg)).toBe(
+      "The provider refused this request (category: policy_safety-2).",
+    );
+  });
+
+  it.each(["unsafe category!", "a".repeat(65)])(
+    "omits an unsafe provider refusal category %j",
+    (category) => {
+      const msg = makeAssistantMessageFixture({
+        errorMessage: "Anthropic refusal: private provider explanation",
+        content: [],
+        diagnostics: [
+          {
+            type: "provider_refusal",
+            timestamp: 1,
+            details: { category, explanation: "private provider explanation" },
+          },
+        ],
+      });
+
+      expect(formatUserFacingAssistantErrorText(msg)).toBe("The provider refused this request.");
+    },
+  );
+
   it("keeps non-streaming provider request-validation syntax diagnostics", () => {
     const msg = makeAssistantError(
       '{"type":"error","error":{"type":"invalid_request_error","message":"Expected value in JSON at position 12 for messages.0.content"}}',

--- a/src/agents/embedded-agent-helpers/error-text.ts
+++ b/src/agents/embedded-agent-helpers/error-text.ts
@@ -32,7 +32,7 @@ import {
   renderRateLimitOrOverloadedCopy,
 } from "../failover/user-copy.js";
 import { formatSandboxToolPolicyBlockedMessage } from "../sandbox/runtime-status.js";
-import { buildAssistantFailoverSignal } from "./assistant-message-failures.js";
+import { buildAssistantFailoverSignal, findProviderRefusal } from "./assistant-message-failures.js";
 import { classifyProviderRuntimeFailureKind } from "./provider-runtime-failure.js";
 const log = createSubsystemLogger("errors");
 const sandboxToolPolicyAuditMessages = new WeakSet<AssistantMessage>();
@@ -61,6 +61,18 @@ type ClassifiedAssistantErrorFacts = {
   reason: FailoverReason | null;
   status?: number;
 };
+
+function formatProviderRefusalText(msg: AssistantMessage): string | undefined {
+  const refusal = findProviderRefusal(msg);
+  if (!refusal) {
+    return undefined;
+  }
+  const category = refusal.details?.category;
+  const safeCategory =
+    typeof category === "string" && /^[a-z0-9_-]{1,64}$/i.test(category) ? category : undefined;
+  return `The provider refused this request${safeCategory ? ` (category: ${safeCategory})` : ""}.`;
+}
+
 function classifyAssistantErrorFacts(
   msg: AssistantMessage,
   opts?: AssistantErrorTextOptions,
@@ -99,6 +111,10 @@ export function formatAssistantErrorText(
   const raw = (msg.errorMessage ?? "").trim();
   if (msg.stopReason !== "error" && !raw) {
     return undefined;
+  }
+  const providerRefusalText = formatProviderRefusalText(msg);
+  if (providerRefusalText) {
+    return providerRefusalText;
   }
   const formatCopy = renderFormatErrorCopy(raw);
   const classifiedFacts = facts ?? classifyAssistantErrorFacts(msg, opts);

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.owner-test-support.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.owner-test-support.ts
@@ -113,6 +113,30 @@ describe("silent assistant-error retry owner", () => {
     });
   });
 
+  it("keeps a structured provider refusal terminal", async () => {
+    const assistant = makeAssistant({
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      errorMessage: "HTTP 503: provider overloaded",
+      diagnostics: [
+        {
+          type: "provider_refusal",
+          timestamp: 1,
+          details: { provider: "anthropic", category: "policy" },
+        },
+      ],
+    });
+    const input = makeInput({ assistant });
+    input.maybeRetryTransient = vi.fn(async () => true);
+
+    const outcome = await handleEmbeddedAssistantFailure(input);
+
+    expect(outcome).toMatchObject({ action: "proceed", emptyErrorRetries: 0 });
+    expect(input.maybeRetryTransient).not.toHaveBeenCalled();
+    expect(input.advanceAuthProfile).not.toHaveBeenCalled();
+  });
+
   it("does not retry an error attempt after replay-unsafe tool activity", async () => {
     const outcome = await handleEmbeddedAssistantFailure(
       makeInput({

--- a/src/agents/embedded-agent-runner/run/assistant-failure.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.ts
@@ -5,6 +5,7 @@ import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome
 import type { AuthProfileFailureReason, AuthProfileStore } from "../../auth-profiles.js";
 import {
   classifyAssistantFailoverReason,
+  findProviderRefusal,
   type FailoverReason,
   isAuthAssistantError,
   isBillingAssistantError,
@@ -123,12 +124,12 @@ export async function handleEmbeddedAssistantFailure(input: {
     },
   );
   const replayUnsafeAssistantError = isReplayUnsafeAssistantError(input.attemptAssistant);
-  if (replayUnsafeAssistantError || !isCurrentAttemptReplaySafe(input.attempt)) {
+  const providerRefusal = findProviderRefusal(input.attemptAssistant);
+  if (replayUnsafeAssistantError || providerRefusal || !isCurrentAttemptReplaySafe(input.attempt)) {
     return buildOutcome(input, {
       action: "proceed",
-      assistantProfileFailureReason: replayUnsafeAssistantError
-        ? null
-        : assistantProfileFailureReason,
+      assistantProfileFailureReason:
+        replayUnsafeAssistantError || providerRefusal ? null : assistantProfileFailureReason,
     });
   }
   if (fallbackThinking && !terminalInterrupted) {

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-resolution.test.ts
@@ -54,6 +54,63 @@ describe("incomplete-turn terminal metadata", () => {
     ).toContain("couldn't generate a response");
   });
 
+  it("surfaces a sanitized structured provider refusal", () => {
+    const assistant = buildEmbeddedRunnerAssistant({
+      stopReason: "error",
+      errorMessage: "Anthropic refusal (category: policy): private provider explanation",
+      diagnostics: [
+        {
+          type: "provider_refusal",
+          timestamp: 1,
+          details: { category: "policy", explanation: "private provider explanation" },
+        },
+      ],
+    });
+    const attempt = makeEmbeddedRunnerAttempt({
+      lastAssistant: assistant,
+      currentAttemptAssistant: assistant,
+    });
+
+    expect(
+      resolveIncompleteTurnPayloadText({
+        payloadCount: 0,
+        aborted: false,
+        externalAbort: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toBe("The provider refused this request (category: policy).");
+  });
+
+  it("keeps the side-effect warning ahead of a structured provider refusal", () => {
+    const assistant = buildEmbeddedRunnerAssistant({
+      stopReason: "error",
+      errorMessage: "Anthropic refusal: private provider explanation",
+      diagnostics: [
+        {
+          type: "provider_refusal",
+          timestamp: 1,
+          details: { category: "policy", explanation: "private provider explanation" },
+        },
+      ],
+    });
+    const attempt = makeEmbeddedRunnerAttempt({
+      lastAssistant: assistant,
+      currentAttemptAssistant: assistant,
+      replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+    });
+
+    expect(
+      resolveIncompleteTurnPayloadText({
+        payloadCount: 0,
+        aborted: false,
+        externalAbort: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toContain("some tool actions may have already been executed");
+  });
+
   it("emits a silent cron reply from the trailing current-attempt tool result", () => {
     const attempt = makeEmbeddedRunnerAttempt({
       toolMetas: [{ toolName: "exec" }],

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-resolution.ts
@@ -8,6 +8,8 @@ import {
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
 import type { AuthProfileFailureReason } from "../../auth-profiles.js";
 import { collectTextContentBlocks } from "../../content-blocks.js";
+import { findProviderRefusal } from "../../embedded-agent-helpers/assistant-message-failures.js";
+import { formatUserFacingAssistantErrorText } from "../../embedded-agent-helpers/error-text.js";
 import type { MessagingToolSend } from "../../embedded-agent-messaging.types.js";
 import { renderAuthProfileFailoverCopy } from "../../failover/user-copy.js";
 import { buildProviderAuthRecoveryHint } from "../../provider-auth-recovery-hint.js";
@@ -132,6 +134,9 @@ export function resolveIncompleteTurnPayloadText(params: {
 
   if (params.hadPotentialSideEffects || params.attempt.replayMetadata.hadPotentialSideEffects) {
     return "⚠️ Agent couldn't generate a response. Note: some tool actions may have already been executed — please verify before retrying.";
+  }
+  if (assistant && findProviderRefusal(assistant)) {
+    return formatUserFacingAssistantErrorText(assistant);
   }
   const authFailure = params.terminalAuthFailure;
   const reason = authFailure?.assistantProfileFailureReason;

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
@@ -316,6 +316,58 @@ describe("terminal resolution", () => {
     expect(armPostCompactionGuard).toHaveBeenCalledTimes(1);
   });
 
+  it("completes a structured refusal after Anthropic compaction without retrying", async () => {
+    const assistant = emptyAssistant({
+      stopReason: "error",
+      errorMessage: "HTTP 503: private provider explanation",
+      diagnostics: [
+        {
+          type: "provider_refusal",
+          timestamp: 1,
+          details: { category: "policy", explanation: "private provider explanation" },
+        },
+      ],
+      providerReplay: {
+        v: 1,
+        type: "anthropic-compaction",
+        data: "summary",
+        provider: "anthropic",
+        api: "anthropic-messages",
+        model: "claude-sonnet-4-6",
+        baseUrlHash: "route-a",
+      },
+    } as never);
+    const attempt = makeEmbeddedRunnerAttempt({
+      assistantTexts: [],
+      lastAssistant: assistant,
+      currentAttemptAssistant: assistant,
+      currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+    });
+    const input = makeTerminalInput({
+      attempt,
+      attemptAssistant: assistant,
+      maxEmptyResponseRetryAttempts: 1,
+    });
+
+    const resolved = await resolveEmbeddedRunTerminal(input);
+
+    expect(resolved.action).toBe("complete");
+    if (resolved.action !== "complete") {
+      return;
+    }
+    expect(resolved.result.payloads).toEqual([
+      { text: "The provider refused this request (category: policy).", isError: true },
+    ]);
+    expect(resolved.result.meta.error).toMatchObject({
+      kind: "incomplete_turn",
+      fallbackSafe: false,
+    });
+    expect(input.activateInternalPrompt).not.toHaveBeenCalled();
+    expect(input.armPostCompactionGuard).not.toHaveBeenCalled();
+    expect(input.retryState.emptyResponseAttempts).toBe(0);
+    expect(input.retryState.compactionContinuationAttempts).toBe(0);
+  });
+
   it("completes an explicit silent reply without retrying", async () => {
     const assistant = buildEmbeddedRunnerAssistant({
       content: [{ type: "text", text: SILENT_REPLY_TOKEN }],

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -10,6 +10,7 @@ import {
   projectAgentRunAttemptTerminal,
 } from "../../agent-run-terminal-outcome.js";
 import type { AuthProfileFailureReason, AuthProfileStore } from "../../auth-profiles.js";
+import { findProviderRefusal } from "../../embedded-agent-helpers/assistant-message-failures.js";
 import type { ResolvedProviderAuth } from "../../model-auth.js";
 import { log } from "../logger.js";
 import type { EmbeddedRunReplayState } from "../replay-state.js";
@@ -272,8 +273,12 @@ export async function resolveEmbeddedRunTerminal(input: {
     timedOut: terminalTimedOut,
     attempt,
   });
+  const providerRefusal =
+    findProviderRefusal(attempt.currentAttemptAssistant) ??
+    findProviderRefusal(input.attemptAssistant) ??
+    findProviderRefusal(attempt.lastAssistant);
   const nextReasoningOnlyRetryInstruction =
-    emptyAssistantReplyIsSilent || settledTurnFinalizationAttempted
+    emptyAssistantReplyIsSilent || settledTurnFinalizationAttempted || providerRefusal
       ? null
       : resolveReasoningOnlyRetryInstruction({
           provider: input.activeErrorContext.provider,
@@ -285,7 +290,7 @@ export async function resolveEmbeddedRunTerminal(input: {
           attempt,
         });
   const nextEmptyResponseRetryInstruction =
-    emptyAssistantReplyIsSilent || settledTurnFinalizationAttempted
+    emptyAssistantReplyIsSilent || settledTurnFinalizationAttempted || providerRefusal
       ? null
       : resolveEmptyResponseRetryInstruction({
           provider: input.activeErrorContext.provider,
@@ -369,6 +374,7 @@ export async function resolveEmbeddedRunTerminal(input: {
     !promptError &&
     !attempt.lastToolError &&
     !hasAttemptTerminalState(attempt) &&
+    !providerRefusal &&
     !input.replayState.hadPotentialSideEffects,
   );
   const terminalToolPresentation = incompleteTurnFallbackSafe
@@ -386,6 +392,7 @@ export async function resolveEmbeddedRunTerminal(input: {
     !attempt.yieldDetected &&
     !attempt.didSendDeterministicApprovalPrompt &&
     !attempt.lastToolError &&
+    !providerRefusal &&
     !input.replayState.hadPotentialSideEffects &&
     retryState.compactionContinuationAttempts < 1
   ) {


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Closes #134968

Fixes an issue where users running an embedded Anthropic turn could have the same request sent again after the provider returned a structured hard refusal. The refusal was hidden behind empty-response recovery, so the user did not receive the provider's terminal decision.

## Why This Change Was Made

The Anthropic transport already records a `provider_refusal` diagnostic at the boundary that owns the terminal decision. The embedded runner now gives that structured evidence precedence over text-based transient classification across same-model retry, profile rotation, fallback presentation, and post-compaction continuation, while preserving the existing side-effect warning as the higher-priority user safety message.

This is a root-cause fix at the runner terminality boundary. Generic empty errors keep their existing retry behavior; this does not change provider wire handling, public configuration, persistence formats, or the shared SDK retry policy. User-visible refusal copy includes only a bounded category token and never the provider explanation.

## User Impact

Anthropic hard refusals now stop the turn after one provider request and surface a clear refusal message. Transient empty responses still recover as before, and turns with possible tool side effects still tell users to verify those actions before retrying.

## Evidence

Pre-fix regressions demonstrated both failure layers: a structured refusal returned `action: "retry"` with `emptyErrorRetries: 1`, and an HTTP 503-looking refusal still retried through transient handling after a predicate-only guard.

An isolated real Gateway then exercised `chat.send` through the production Anthropic HTTP/SSE transport and embedded runner. The loopback provider returned a structured refusal first and kept a successful second response queued as a retry trap:

```text
ISSUE_134968_GATEWAY_PROOF=PASS
gateway_wait_status=error
provider_request_count=1
provider_request_path=/v1/messages
visible_terminal=The provider refused this request (category: policy).
provider_explanation_visible=false
queued_retry_trap_visible=false
history_message_count=2
```

The provider response was injected, but the Gateway, transport, runner, WebSocket RPC, and persisted chat history were real. No external Anthropic credentials were used; this matches the issue's deterministic synthetic-transport reproduction.

Focused and sibling validation:

- assistant-failure owner: 15 tests passed
- terminal resolution: 47 tests passed
- incomplete-turn presentation: 7 tests passed
- focused refusal formatting: 10 tests passed
- Anthropic provider and transport: 93 + 131 tests passed
- structured provider-signal and broader error-formatting suites: 50 + 102 tests passed
- `pnpm check:changed` passed core/core-test type checks, lint, dead-export, import-cycle, formatting, and repository guards

Impact-surface sweep: the producer diagnostic shape remains unchanged; all downstream consumers that decide retry, presentation, fallback safety, or compaction continuation were searched and exercised. Other providers change only if they intentionally emit the same structured terminal diagnostic. No visual evidence is applicable because this is a provider/runtime behavior change with no UI layout change.
