### PR TITLE
refactor(copilot): share attempt user identity

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -263,9 +263,9 @@ extensions/copilot-proxy/index.ts	1
 extensions/copilot/harness.ts	8
 extensions/copilot/src/attempt-config.ts	16
 extensions/copilot/src/attempt-execution.ts	4
-extensions/copilot/src/attempt-finalize.ts	5
+extensions/copilot/src/attempt-finalize.ts	2
 extensions/copilot/src/attempt-prepare.ts	4
-extensions/copilot/src/attempt-transcript-journal.ts	25
+extensions/copilot/src/attempt-transcript-journal.ts	22
 extensions/copilot/src/byok-proxy.ts	1
 extensions/copilot/src/event-bridge-transcript.ts	4
 extensions/copilot/src/event-bridge.ts	3

--- a/extensions/copilot/src/attempt-finalize.ts
+++ b/extensions/copilot/src/attempt-finalize.ts
@@ -6,6 +6,7 @@ import {
 import { finalizeCopilotAttempt } from "./attempt-cleanup.js";
 import { createResult } from "./attempt-config.js";
 import type { AttemptTranscriptJournal } from "./attempt-transcript-journal.js";
+import { matchesAttemptUser } from "./attempt-transcript-replay.js";
 import { withPromptFailure } from "./attempt-types.js";
 import type {
   AgentHarnessAttemptResult,
@@ -189,7 +190,7 @@ function includePreparedUser(
     message: prepared,
   }) as Extract<AgentMessage, { role: "user" }>;
   const tail = messages.at(-1);
-  if (isSamePreparedUser(tail, projected, currentRunUserKey)) {
+  if (matchesAttemptUser(tail, projected, currentRunUserKey)) {
     return [...messages.slice(0, -1), projected];
   }
   return [...messages, projected];
@@ -200,51 +201,7 @@ function removePreparedUser(
   prepared: Extract<AgentMessage, { role: "user" }> | undefined,
   currentRunUserKey: string,
 ): AgentMessage[] {
-  return prepared && isSamePreparedUser(messages.at(-1), prepared, currentRunUserKey)
+  return prepared && matchesAttemptUser(messages.at(-1), prepared, currentRunUserKey)
     ? messages.slice(0, -1)
     : messages;
-}
-
-function isSamePreparedUser(
-  candidate: AgentMessage | undefined,
-  prepared: Extract<AgentMessage, { role: "user" }>,
-  currentRunUserKey: string,
-): boolean {
-  if (candidate?.role !== "user") {
-    return false;
-  }
-  if (candidate === prepared) {
-    return true;
-  }
-  const candidateKey = (candidate as { idempotencyKey?: unknown }).idempotencyKey;
-  const preparedKey = (prepared as { idempotencyKey?: unknown }).idempotencyKey;
-  if (typeof candidateKey === "string" || typeof preparedKey === "string") {
-    if (typeof candidateKey === "string" && typeof preparedKey === "string") {
-      return candidateKey === preparedKey;
-    }
-    if (
-      typeof candidateKey !== "string" ||
-      typeof preparedKey === "string" ||
-      (!candidateKey.startsWith("copilot:") && candidateKey !== currentRunUserKey)
-    ) {
-      return false;
-    }
-  }
-  return (
-    candidate.timestamp === prepared.timestamp &&
-    userText(candidate.content) === userText(prepared.content)
-  );
-}
-
-function userText(content: unknown): string {
-  if (typeof content === "string") {
-    return content;
-  }
-  if (Array.isArray(content) && content.length === 1) {
-    const part = content[0] as { text?: unknown; type?: unknown };
-    if (part?.type === "text" && typeof part.text === "string") {
-      return part.text;
-    }
-  }
-  return JSON.stringify(content) ?? "";
 }

--- a/extensions/copilot/src/attempt-transcript-journal.test.ts
+++ b/extensions/copilot/src/attempt-transcript-journal.test.ts
@@ -250,6 +250,23 @@ describe("Copilot attempt transcript journal", () => {
     expect(journal.snapshot().replayInvalid).toBe(true);
   });
 
+  it("validates an initial SDK string against a persisted single text block", async () => {
+    const { journal, recorder, session } = await createFixture();
+    recorder.resolveMessage.mockResolvedValue({
+      role: "user",
+      content: [{ type: "text", text: "inspect both files" }],
+      timestamp: 1,
+    });
+    await journal.persistInitialUser();
+    session.emit(event("user.message", "initial-user", { content: "inspect both files" }));
+    await journal.barrier("equivalent initial user");
+
+    expect(journal.snapshot()).toMatchObject({
+      initialSdkUserValidated: true,
+      replayInvalid: false,
+    });
+  });
+
   it("marks non-interactive SDK user modes replay-incomplete", async () => {
     const { journal, session } = await createFixture();
     await journal.persistInitialUser();

--- a/extensions/copilot/src/attempt-transcript-journal.ts
+++ b/extensions/copilot/src/attempt-transcript-journal.ts
@@ -17,7 +17,9 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import {
   isCompatibleSingletonRewrite,
   isCompleteToolGroup,
+  matchesAttemptUser,
   projectReplayPayload,
+  projectUserContentIdentity,
   type AttemptTranscriptMessage as TranscriptMessage,
 } from "./attempt-transcript-replay.js";
 import type { AttemptParamsLike } from "./attempt-types.js";
@@ -105,7 +107,10 @@ export function createAttemptTranscriptJournal(params: {
     current: Extract<AgentMessage, { role: "user" }> | undefined,
     next?: AgentMessage,
   ) => {
-    if (isSameUserTurn(messagesSnapshot.at(-1), current, `${params.attempt.runId}:user`)) {
+    if (
+      current &&
+      matchesAttemptUser(messagesSnapshot.at(-1), current, `${params.attempt.runId}:user`)
+    ) {
       const removed = messagesSnapshot.pop();
       const removedKey = removed ? readIdempotencyKey(removed) : undefined;
       if (removedKey && isCurrentJournalIdentity(removedKey, params)) {
@@ -470,7 +475,8 @@ export function createAttemptTranscriptJournal(params: {
         initialSdkUserObserved = true;
         if (
           !persistedInitialUser ||
-          userText(persistedInitialUser.content) !== userText(input.message.content)
+          projectUserContentIdentity(persistedInitialUser.content) !==
+            projectUserContentIdentity(input.message.content)
         ) {
           replayInvalid = true;
         } else {
@@ -650,50 +656,4 @@ function isCurrentJournalIdentity(
   return (
     key === `${params.attempt.runId}:user` || key.startsWith(`copilot-sdk:${params.sdkSessionId}:`)
   );
-}
-
-function isSameUserTurn(
-  candidate: AgentMessage | undefined,
-  current: Extract<AgentMessage, { role: "user" }> | undefined,
-  currentRunUserKey: string,
-): boolean {
-  if (candidate?.role !== "user" || !current) {
-    return false;
-  }
-  if (candidate === current) {
-    return true;
-  }
-  const candidateKey = (candidate as { idempotencyKey?: unknown }).idempotencyKey;
-  const currentKey = (current as { idempotencyKey?: unknown }).idempotencyKey;
-  if (typeof candidateKey === "string" || typeof currentKey === "string") {
-    if (typeof candidateKey === "string" && typeof currentKey === "string") {
-      return candidateKey === currentKey;
-    }
-    if (
-      typeof candidateKey !== "string" ||
-      typeof currentKey === "string" ||
-      (!candidateKey.startsWith("copilot:") && candidateKey !== currentRunUserKey)
-    ) {
-      return false;
-    }
-  }
-  // The embedded-runner boundary identifies the active user as the last user
-  // and stamps it with this recorder timestamp; historical turns are ineligible.
-  return (
-    candidate.timestamp === current.timestamp &&
-    userText(candidate.content) === userText(current.content)
-  );
-}
-
-function userText(content: unknown): string {
-  if (typeof content === "string") {
-    return content;
-  }
-  if (Array.isArray(content) && content.length === 1) {
-    const part = content[0] as { text?: unknown; type?: unknown };
-    if (part?.type === "text" && typeof part.text === "string") {
-      return part.text;
-    }
-  }
-  return JSON.stringify(content) ?? "";
 }

--- a/extensions/copilot/src/attempt-transcript-replay.ts
+++ b/extensions/copilot/src/attempt-transcript-replay.ts
@@ -2,14 +2,64 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { AttemptParamsLike } from "./attempt-types.js";
 
 type TranscriptRecorder = NonNullable<AttemptParamsLike["userTurnTranscriptRecorder"]>;
+type AttemptUserMessage = NonNullable<TranscriptRecorder["message"]>;
 export type AttemptTranscriptMessage =
-  | NonNullable<TranscriptRecorder["message"]>
+  | AttemptUserMessage
   | Extract<AgentMessage, { role: "assistant" | "toolResult" }>;
 
 function readAssistantToolCallIds(message: AttemptTranscriptMessage): string[] {
   return message.role === "assistant"
     ? message.content.flatMap((part) => (part.type === "toolCall" ? [part.id] : []))
     : [];
+}
+
+export function matchesAttemptUser(
+  candidate: AgentMessage | undefined,
+  expected: AttemptUserMessage,
+  currentRunUserKey: string,
+): boolean {
+  if (candidate?.role !== "user") {
+    return false;
+  }
+  if (candidate === expected) {
+    return true;
+  }
+  // SAFETY: AgentMessage variants may carry the journal's optional private identity field.
+  const candidateKey = (candidate as { idempotencyKey?: unknown }).idempotencyKey;
+  // SAFETY: Recorder-owned user messages may carry the same private identity field.
+  const expectedKey = (expected as { idempotencyKey?: unknown }).idempotencyKey;
+  if (typeof candidateKey === "string" || typeof expectedKey === "string") {
+    if (typeof candidateKey === "string" && typeof expectedKey === "string") {
+      return candidateKey === expectedKey;
+    }
+    if (
+      typeof candidateKey !== "string" ||
+      typeof expectedKey === "string" ||
+      (!candidateKey.startsWith("copilot:") && candidateKey !== currentRunUserKey)
+    ) {
+      return false;
+    }
+  }
+  // The embedded-runner boundary stamps the active user with this recorder
+  // timestamp, so historical turns with the same content remain ineligible.
+  return (
+    candidate.timestamp === expected.timestamp &&
+    projectUserContentIdentity(candidate.content) === projectUserContentIdentity(expected.content)
+  );
+}
+
+export function projectUserContentIdentity(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content) && content.length === 1) {
+    // SAFETY: The array guard establishes the single unknown content part read below.
+    const part = content[0] as { text?: unknown; type?: unknown };
+    if (part?.type === "text" && typeof part.text === "string") {
+      return part.text;
+    }
+  }
+  return JSON.stringify(content) ?? "";
 }
 
 export function isCompatibleSingletonRewrite(


### PR DESCRIPTION
## What Problem This Solves

Copilot attempt-user identity rules were duplicated between transcript finalization and the transcript journal. Keeping object identity, idempotency-key, timestamp, and content projection policy in two places made replay behavior vulnerable to drift.

## Why This Change Was Made

This centralizes the existing private identity matcher and content projection in the attempt transcript replay owner, then removes both consumer-local copies. The behavior remains unchanged, including legacy/current key fallback and native `JSON.stringify` semantics.

## User Impact

No user-visible behavior changes. Copilot transcript replay and pre-journal finalization now share one canonical attempt-user identity policy.

## Evidence

- Focused journal and attempt tests: 189 passed.
- Full Copilot plugin suite: 631 passed.
- Changed-file gates passed; the dead-export lane passed after materializing tracked UI config files omitted by the sparse worktree profile.
- Import-cycle check: 0 runtime value cycles.
- Targeted formatting and `git diff --check` passed.
- Autoreview (`gpt-5.6-sol`, high): clean, 0.98.
- Production: `+62/-95`, net `-33`; tests: `+17`; assertion baseline maintenance: `+2/-2`.
- `pnpm build` completed source compilation and failed in runtime postbuild because the shared linked `@openclaw/ai/diagnostics` artifact lacks the current `hasRetryableConnectionErrorCode` export. The worktree dependency tree was intentionally not mutated.
- Required sibling Codex CLI ranges were inspected and are unrelated completion/debug plumbing.
