### PR TITLE
fix(tlon): preserve parser progress and unify outbound preparation

### DIFF
--- a/extensions/tlon/src/channel.runtime.ts
+++ b/extensions/tlon/src/channel.runtime.ts
@@ -1,33 +1,25 @@
 // Tlon plugin module implements channel behavior.
 import crypto from "node:crypto";
-import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
+import type {
+  ChannelAccountSnapshot,
+  ChannelOutboundContext,
+} from "openclaw/plugin-sdk/channel-contract";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
-import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
 import { runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { monitorTlonProvider } from "./monitor/index.js";
 import { tlonSetupWizard } from "./setup-surface.js";
-import {
-  formatTargetHint,
-  normalizeShip,
-  parseTlonTarget,
-  resolveTlonOutboundTarget,
-} from "./targets.js";
+import { formatTargetHint, normalizeShip, parseTlonTarget } from "./targets.js";
 import { configureClient } from "./tlon-api.js";
 import { resolveTlonAccount } from "./types.js";
 import { authenticate } from "./urbit/auth.js";
 import { ssrfPolicyFromDangerouslyAllowPrivateNetwork } from "./urbit/context.js";
 import { urbitFetch } from "./urbit/fetch.js";
-import {
-  buildMediaStory,
-  sendDm,
-  sendDmWithStory,
-  sendGroupMessage,
-  sendGroupMessageWithStory,
-} from "./urbit/send.js";
+import { buildMediaStory, sendDmWithStory, sendGroupMessageWithStory } from "./urbit/send.js";
+import { markdownToStory } from "./urbit/story.js";
 import { uploadImageFromUrl } from "./urbit/upload.js";
 
 type ResolvedTlonAccount = ReturnType<typeof resolveTlonAccount>;
@@ -89,9 +81,6 @@ async function createHttpPokeApi(params: {
         await release();
       }
     },
-    delete: async () => {
-      // No-op for HTTP-only client
-    },
   };
 }
 
@@ -117,68 +106,13 @@ function resolveReplyId(replyToId?: string | null, threadId?: string | number | 
   return (replyToId ?? threadId) ? String(replyToId ?? threadId) : undefined;
 }
 
-async function withHttpPokeAccountApi<T>(
-  account: ConfiguredTlonAccount,
-  run: (api: Awaited<ReturnType<typeof createHttpPokeApi>>) => Promise<T>,
-) {
-  const api = await createHttpPokeApi({
-    url: account.url,
-    ship: account.ship,
-    code: account.code,
-    dangerouslyAllowPrivateNetwork: account.dangerouslyAllowPrivateNetwork ?? undefined,
-  });
+async function sendTlonOutbound(params: ChannelOutboundContext, kind: "text" | "media") {
+  const { cfg, to, text, accountId, replyToId, threadId } = params;
+  const { account, parsed } = resolveOutboundContext({ cfg, accountId, to });
 
-  try {
-    return await run(api);
-  } finally {
-    try {
-      await api.delete();
-    } catch {
-      // ignore cleanup errors
-    }
-  }
-}
-
-export const tlonRuntimeOutbound: ChannelOutboundAdapter = {
-  deliveryMode: "direct",
-  chunker: chunkTextForOutbound,
-  chunkerMode: "markdown",
-  textChunkLimit: 10000,
-  resolveTarget: ({ to }) => resolveTlonOutboundTarget(to),
-  deliveryCapabilities: {
-    durableFinal: {
-      text: true,
-      media: true,
-      replyTo: true,
-      thread: true,
-      messageSendingHooks: true,
-    },
-  },
-  sendText: async ({ cfg, to, text, accountId, replyToId, threadId }) => {
-    const { account, parsed } = resolveOutboundContext({ cfg, accountId, to });
-    return withHttpPokeAccountApi(account, async (api) => {
-      const fromShip = normalizeShip(account.ship);
-      if (parsed.kind === "dm") {
-        return await sendDm({
-          api,
-          fromShip,
-          toShip: parsed.ship,
-          text,
-        });
-      }
-      return await sendGroupMessage({
-        api,
-        fromShip,
-        hostShip: parsed.hostShip,
-        channelName: parsed.channelName,
-        text,
-        replyToId: resolveReplyId(replyToId, threadId),
-      });
-    });
-  },
-  sendMedia: async ({ cfg, to, text, mediaUrl, accountId, replyToId, threadId }) => {
-    const { account, parsed } = resolveOutboundContext({ cfg, accountId, to });
-
+  let uploadedUrl: string | undefined;
+  if (kind === "media") {
+    const { mediaUrl } = params;
     configureClient({
       shipUrl: account.url,
       shipName: account.ship.replace(/^~/, ""),
@@ -186,34 +120,40 @@ export const tlonRuntimeOutbound: ChannelOutboundAdapter = {
       getCode: async () => account.code,
       dangerouslyAllowPrivateNetwork: account.dangerouslyAllowPrivateNetwork ?? undefined,
     });
+    uploadedUrl = mediaUrl ? await uploadImageFromUrl(mediaUrl, account.mediaMaxBytes) : undefined;
+  }
 
-    const uploadedUrl = mediaUrl
-      ? await uploadImageFromUrl(mediaUrl, account.mediaMaxBytes)
-      : undefined;
-    return withHttpPokeAccountApi(account, async (api) => {
-      const fromShip = normalizeShip(account.ship);
-      const story = buildMediaStory(text, uploadedUrl);
-
-      if (parsed.kind === "dm") {
-        return await sendDmWithStory({
-          api,
-          fromShip,
-          toShip: parsed.ship,
-          story,
-          kind: "media",
-        });
-      }
-      return await sendGroupMessageWithStory({
-        api,
-        fromShip,
-        hostShip: parsed.hostShip,
-        channelName: parsed.channelName,
-        story,
-        replyToId: resolveReplyId(replyToId, threadId),
-        kind: "media",
-      });
+  const api = await createHttpPokeApi({
+    url: account.url,
+    ship: account.ship,
+    code: account.code,
+    dangerouslyAllowPrivateNetwork: account.dangerouslyAllowPrivateNetwork ?? undefined,
+  });
+  const fromShip = normalizeShip(account.ship);
+  const story = kind === "media" ? buildMediaStory(text, uploadedUrl) : markdownToStory(text);
+  if (parsed.kind === "dm") {
+    return await sendDmWithStory({
+      api,
+      fromShip,
+      toShip: parsed.ship,
+      story,
+      kind,
     });
-  },
+  }
+  return await sendGroupMessageWithStory({
+    api,
+    fromShip,
+    hostShip: parsed.hostShip,
+    channelName: parsed.channelName,
+    story,
+    replyToId: resolveReplyId(replyToId, threadId),
+    kind,
+  });
+}
+
+export const tlonRuntimeOutbound: Pick<ChannelOutboundAdapter, "sendText" | "sendMedia"> = {
+  sendText: (params) => sendTlonOutbound(params, "text"),
+  sendMedia: (params) => sendTlonOutbound(params, "media"),
 };
 
 export async function probeTlonAccount(account: ConfiguredTlonAccount, timeoutMs?: number) {

--- a/extensions/tlon/src/urbit/story.test.ts
+++ b/extensions/tlon/src/urbit/story.test.ts
@@ -191,6 +191,23 @@ const listRenderingFixtures: ListRenderingFixture[] = [
   },
 ];
 
+describe("markdownToStory paragraph boundaries", () => {
+  it.each(["#", "#tag", "##tag", "####### heading", "# "])(
+    "preserves non-heading %j as ordinary text",
+    (markdown) => {
+      expect(markdownToStory(markdown)).toEqual([{ inline: [markdown] }]);
+    },
+  );
+
+  it("continues past a hashtag and still separates the next heading", () => {
+    expect(markdownToStory("intro\n#tag\n## Heading\ntail")).toEqual([
+      { inline: ["intro", { break: null }, "#tag"] },
+      { block: { header: { tag: "h2", content: ["Heading"] } } },
+      { inline: ["tail"] },
+    ]);
+  });
+});
+
 describe("markdownToStory list rendering", () => {
   it.each(listRenderingFixtures)("$name", ({ markdown, before, after }) => {
     expect(before).not.toEqual(after);

--- a/extensions/tlon/src/urbit/story.ts
+++ b/extensions/tlon/src/urbit/story.ts
@@ -645,17 +645,14 @@ export function markdownToStory(markdown: string): Story {
     // preserve the whole block in the existing plain paragraph path.
     let preserveListText = preservesLooseList || MARKDOWN_LIST_ITEM_PATTERN.test(line);
 
-    // Regular paragraph - collect consecutive non-empty lines
+    // Only interrupt for blocks consumed above; plain hashtags must advance the cursor.
     const paragraphLines: string[] = [];
     while (true) {
       const paragraphLine = lines.at(i);
       if (
         paragraphLine === undefined ||
         paragraphLine.trim() === "" ||
-        paragraphLine.startsWith("#") ||
-        paragraphLine.startsWith("```") ||
-        paragraphLine.startsWith("> ") ||
-        /^(-{3,}|\*{3,})$/.test(paragraphLine.trim())
+        startsTopLevelStoryBlock(paragraphLine)
       ) {
         break;
       }


### PR DESCRIPTION
Tlon messages containing ordinary hash-prefixed text such as `#tag` could hang before sending. Paragraph parsing stopped at every `#` line, while the heading branch consumed only valid headings, leaving the cursor unchanged. Reusing the existing top-level block predicate makes those two decisions agree: hashtags remain literal text and real headings keep their existing output.

The same outbound owner now shares text/media account, target, authentication, story selection and receipt preparation. It removes duplicated private adapter metadata and a `finally` that only awaited an empty cleanup method. Actual HTTP response release remains in the request owner. Text and media retain their distinct whitespace, upload and caption behavior; account validation still precedes target validation and I/O, and thread/reply precedence is unchanged.

Production is +47/-110, **net -63 lines** (-61 nonblank; -46 executable lines after type erasure and consistent formatting). The six parser regressions add 17 test lines. There are no public API, configuration, dependency, protocol or storage changes.

Before the parser edit, an actual-source `#tag` probe reached the parser and failed to return within its 8-second process deadline; a valid heading control returned. All seven final actual-parser cases return the expected stories. Four final sends through the public adapter, real authentication/request code and owned HTTP servers produce the expected DM/group/caption/message-adapter payloads and native receipts, including a hashtag followed by a real heading.

The original outbound-only baseline and candidate additionally matched all 40 observations: ordered requests and logs, result/error own properties, undefined fields, account selection, chunking, uploads and refusal cases. Each phase exercised 94 real local HTTP requests and five S3 uploads using the installed AWS SDK. All five signatures per phase were independently validated before normalizing ephemeral endpoint ports. These earlier media runs precede the parser repair; the four final hashtag sends have no media URL and do not claim to repeat the upload coverage.

Validation: formatting and diff checks pass; fresh managed Codex high/P2 review of the full combined patch is clean. Local native validation is incomplete: 11 selected checks passed, the doctor-contract step was interrupted at the fixed aggregate deadline, and 12 later checks were not reached. The focused maintained parser suite also timed out during startup before reporting assertions. Earlier timed-out runs are retained as failures, not suite passes. Exact-head hosted required CI must pass before landing.

The acting maintainer directly inspected the changed owners, public adapter and sibling send paths, docs, actual media/auth/request owners, installed AWS presigner/SignatureV4 source, and proof harness/comparator. This proves actual adapter and HTTP behavior with synthetic endpoints; it does not claim acceptance by a deployed Urbit ship, which was unavailable for a disposable live test.

Named follow-ups: fractional configured media caps can produce a pre-existing `RangeError` instead of the intended size error; module-global upload configuration may race across concurrent accounts (unexecuted hypothesis). Neither is changed or claimed fixed here. No release changelog entry is added for this unreleased maintainer repair.


Maintainer landing review: The Tlon story parser shares its actual top-level block predicate so ordinary hash-prefixed text advances the cursor. Text and media sends use one private runtime preparation owner, removing duplicated account, target and send paths.

Literal hash text becomes paragraph content while valid headings retain their existing form. Static adapter policy, target/reply/thread precedence, upload preparation, DM/group selection, authentication and native receipt handling remain at their existing owners.

The original #tag probe exceeded its unchanged eight-second deadline; all seven final parser cases complete. Four actual public-adapter hashtag sends and five metadata observations pass through the real owned HTTP transport on the final source. Forty baseline/candidate public-adapter observations match SHA256 2bb6fa8065aa5ccbf44c871b3407ea5d854c03675ae1f7306ffe075f69b5fccb. Each phase uses94 actual HTTP requests,38 logins,29 pokes and five S3 uploads; independent SigV4 checks precede ephemeral-port/signature normalization. Fresh managed Codex high/P2 review is scoped-clean at0.99 with40 complete datasets and unchanged source hashes. Eleven local gates and final formatting pass; exact-head CI33507118352 and required gate99855506232 complete successfully. Root directly read the complete runtime/parser/transport/media owners, public caller, regression and transport tests, complete proof programs, relevant docs/history, actual Urbit/AWS upload dependencies, and AWS/Smithy signing source.

The12:26 UTC ClawSweeper review of exact head2d449fe05f5a95217ab61de8830fe555ae8feb21 found no blocking correctness/security issue or rank-up move. Its remaining exact-head CI and maintainer-review conditions are now satisfied by successful CI33507118352 and this direct maintainer review under the explicit landing request.

Production +47/-110 = -63 physical, -61 nonblank and -46 erased-runtime lines; tests+17. Complete canonical helper and caller cost is included, with no moved or generated code credited.

Proof limits: Owned loopback Urbit/S3 transport and actual SDK signing are exercised; no external Urbit deployment or vendor acknowledgement is claimed. The final four hashtag sends do not include media; the separate40-case transport comparison covers media. Local test/gate timeouts and unrun checks remain explicitly recorded, and the complete final hosted CI is green. Pre-existing fractional mediaCap behavior and a module-global upload configuration race hypothesis remain separate follow-ups.

Local gaps: Local nine-file Vitest run hit300seconds after43 story tests passed; subsequent runtime120second and final story180second attempts ended before assertions. None is represented as a complete local pass. Exact-head hosted CI is successful. The local doctor gate was interrupted at1800seconds and12 remaining local checks were not run. Eleven completed local gates, final formatting, scoped managed review and exact-head hosted required CI supply the recorded final evidence.
