### PR TITLE
fix(gateway): make probe SSH tunnel abortable and handle SIGINT/SIGTERM

### DIFF
--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -1007,12 +1007,16 @@ describe("gateway-status command", () => {
       | {
           auth?: { token?: string };
           originScopedDeviceAuth?: boolean;
+          signal?: AbortSignal;
           suppressStoredDeviceAuth?: boolean;
         }
       | undefined;
     expect(tunnelCall?.auth?.token).toBe("rtok");
     expect(tunnelCall?.originScopedDeviceAuth).toBeUndefined();
     expect(tunnelCall?.suppressStoredDeviceAuth).toBe(true);
+    const tunnelSignal = requireSshForwardCall().signal;
+    expect(tunnelSignal).toBeInstanceOf(AbortSignal);
+    expect(tunnelCall?.signal).toBe(tunnelSignal);
     expect(sshStop).toHaveBeenCalledTimes(1);
 
     const parsed = JSON.parse(runtimeLogs.join("\n")) as Record<string, unknown>;

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -109,56 +109,56 @@ export async function gatewayStatusCommand(
         )
       : undefined;
 
-  // Bounded SIGINT/SIGTERM handling: abort the probe, await tunnel
-  // cleanup in probe-run's finally, remove handlers, and exit with the
-  // conventional shell codes (130 for SIGINT, 143 for SIGTERM).
   const controller = new AbortController();
-  let abortSignal: NodeJS.Signals | null = null;
+  let abortSignal: "SIGINT" | "SIGTERM" | undefined;
   const onSigInt = () => {
-    abortSignal = "SIGINT";
-    controller.abort();
+    if (!abortSignal) {
+      abortSignal = "SIGINT";
+      controller.abort();
+    }
   };
   const onSigTerm = () => {
-    abortSignal = "SIGTERM";
-    controller.abort();
+    if (!abortSignal) {
+      abortSignal = "SIGTERM";
+      controller.abort();
+    }
   };
   process.on("SIGINT", onSigInt);
   process.on("SIGTERM", onSigTerm);
-  let probePass!: Awaited<ReturnType<typeof runGatewayStatusProbePass>>;
-  try {
-    probePass = await withProgress(
-      {
-        label: "Inspecting gateways…",
-        indeterminate: true,
-        enabled: opts.json !== true,
-      },
-      async () =>
-        await runGatewayStatusProbePass({
-          cfg,
-          opts,
-          overallTimeoutMs,
-          discoveryTimeoutMs,
-          wideAreaDomain,
-          baseTargets,
-          remotePort,
-          sshTarget,
-          sshIdentity,
-          loadSshTunnelModule,
-          localTlsFingerprint: localCertificate?.ok
-            ? localCertificate.value.fingerprintSha256
-            : undefined,
-          signal: controller.signal,
-        }),
-    );
-  } finally {
-    process.off("SIGINT", onSigInt);
-    process.off("SIGTERM", onSigTerm);
-    if (controller.signal.aborted) {
-      // Give probe-run's finally a tick to stop the exact child and remove
-      // listeners before exiting. The tunnel's stop() is awaited there.
-      await new Promise<void>((resolve) => setImmediate(resolve));
-      process.exit(abortSignal === "SIGINT" ? 130 : 143);
+  const probePass = await (async () => {
+    try {
+      return await withProgress(
+        {
+          label: "Inspecting gateways…",
+          indeterminate: true,
+          enabled: opts.json !== true,
+        },
+        async () =>
+          await runGatewayStatusProbePass({
+            cfg,
+            opts,
+            overallTimeoutMs,
+            discoveryTimeoutMs,
+            wideAreaDomain,
+            baseTargets,
+            remotePort,
+            sshTarget,
+            sshIdentity,
+            loadSshTunnelModule,
+            localTlsFingerprint: localCertificate?.ok
+              ? localCertificate.value.fingerprintSha256
+              : undefined,
+            signal: controller.signal,
+          }),
+      );
+    } finally {
+      process.off("SIGINT", onSigInt);
+      process.off("SIGTERM", onSigTerm);
     }
+  })();
+  if (abortSignal) {
+    runtime.exit(abortSignal === "SIGINT" ? 130 : 143);
+    return;
   }
 
   const warnings = buildGatewayStatusWarnings({

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -109,29 +109,57 @@ export async function gatewayStatusCommand(
         )
       : undefined;
 
-  const probePass = await withProgress(
-    {
-      label: "Inspecting gateways…",
-      indeterminate: true,
-      enabled: opts.json !== true,
-    },
-    async () =>
-      await runGatewayStatusProbePass({
-        cfg,
-        opts,
-        overallTimeoutMs,
-        discoveryTimeoutMs,
-        wideAreaDomain,
-        baseTargets,
-        remotePort,
-        sshTarget,
-        sshIdentity,
-        loadSshTunnelModule,
-        localTlsFingerprint: localCertificate?.ok
-          ? localCertificate.value.fingerprintSha256
-          : undefined,
-      }),
-  );
+  // Bounded SIGINT/SIGTERM handling: abort the probe, await tunnel
+  // cleanup in probe-run's finally, remove handlers, and exit with the
+  // conventional shell codes (130 for SIGINT, 143 for SIGTERM).
+  const controller = new AbortController();
+  let abortSignal: NodeJS.Signals | null = null;
+  const onSigInt = () => {
+    abortSignal = "SIGINT";
+    controller.abort();
+  };
+  const onSigTerm = () => {
+    abortSignal = "SIGTERM";
+    controller.abort();
+  };
+  process.on("SIGINT", onSigInt);
+  process.on("SIGTERM", onSigTerm);
+  let probePass!: Awaited<ReturnType<typeof runGatewayStatusProbePass>>;
+  try {
+    probePass = await withProgress(
+      {
+        label: "Inspecting gateways…",
+        indeterminate: true,
+        enabled: opts.json !== true,
+      },
+      async () =>
+        await runGatewayStatusProbePass({
+          cfg,
+          opts,
+          overallTimeoutMs,
+          discoveryTimeoutMs,
+          wideAreaDomain,
+          baseTargets,
+          remotePort,
+          sshTarget,
+          sshIdentity,
+          loadSshTunnelModule,
+          localTlsFingerprint: localCertificate?.ok
+            ? localCertificate.value.fingerprintSha256
+            : undefined,
+          signal: controller.signal,
+        }),
+    );
+  } finally {
+    process.off("SIGINT", onSigInt);
+    process.off("SIGTERM", onSigTerm);
+    if (controller.signal.aborted) {
+      // Give probe-run's finally a tick to stop the exact child and remove
+      // listeners before exiting. The tunnel's stop() is awaited there.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      process.exit(abortSignal === "SIGINT" ? 130 : 143);
+    }
+  }
 
   const warnings = buildGatewayStatusWarnings({
     probed: probePass.probed,

--- a/src/commands/gateway-status/probe-run.ts
+++ b/src/commands/gateway-status/probe-run.ts
@@ -5,6 +5,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.js";
 import { probeGateway } from "../../gateway/probe.js";
+import { isAbortError } from "../../infra/abort-signal.js";
 import {
   discoverGatewayBeacons,
   type GatewayBonjourBeacon,
@@ -84,7 +85,7 @@ export async function runGatewayStatusProbePass(params: {
       sshTunnelStarted = true;
       return tunnel;
     } catch (err) {
-      if ((err as Error)?.name === "AbortError") {
+      if (isAbortError(err)) {
         sshTunnelError = "Aborted";
         return null;
       }
@@ -158,6 +159,7 @@ export async function runGatewayStatusProbePass(params: {
               ? params.localTlsFingerprint
               : undefined,
           timeoutMs: resolveProbeBudgetMs(params.overallTimeoutMs, target),
+          signal: params.signal,
         });
         return {
           target,

--- a/src/commands/gateway-status/probe-run.ts
+++ b/src/commands/gateway-status/probe-run.ts
@@ -46,6 +46,7 @@ export async function runGatewayStatusProbePass(params: {
   sshIdentity: string | null;
   loadSshTunnelModule: () => Promise<typeof import("../../infra/ssh-tunnel.js")>;
   localTlsFingerprint?: string;
+  signal?: AbortSignal;
 }): Promise<{
   discovery: GatewayBonjourBeacon[];
   probed: GatewayStatusProbedTarget[];
@@ -66,6 +67,10 @@ export async function runGatewayStatusProbePass(params: {
     if (!sshTarget) {
       return null;
     }
+    if (params.signal?.aborted) {
+      sshTunnelError = "Aborted";
+      return null;
+    }
     try {
       const { startSshPortForward } = await params.loadSshTunnelModule();
       const tunnel = await startSshPortForward({
@@ -74,10 +79,15 @@ export async function runGatewayStatusProbePass(params: {
         localPortPreferred: params.remotePort,
         remotePort: params.remotePort,
         timeoutMs: Math.min(1500, params.overallTimeoutMs),
+        signal: params.signal,
       });
       sshTunnelStarted = true;
       return tunnel;
     } catch (err) {
+      if ((err as Error)?.name === "AbortError") {
+        sshTunnelError = "Aborted";
+        return null;
+      }
       sshTunnelError = formatErrorMessage(err);
       return null;
     }

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -11,7 +11,12 @@ const gatewayClientState = vi.hoisted(() => ({
   options: null as Record<string, unknown> | null,
   requests: [] as string[],
   startCalls: 0,
-  startMode: "hello" as "hello" | "close" | "connect-error-close" | "startup-retry-then-hello",
+  startMode: "hello" as
+    | "hello"
+    | "close"
+    | "connect-error-close"
+    | "startup-retry-then-hello"
+    | "defer",
   socketOpened: true,
   transportValidated: true,
   close: { code: 1008, reason: "pairing required" },
@@ -103,6 +108,9 @@ class MockGatewayClient {
 
   start(): void {
     gatewayClientState.startCalls += 1;
+    if (gatewayClientState.startMode === "defer") {
+      return;
+    }
     void Promise.resolve()
       .then(async () => {
         if (gatewayClientState.startMode === "close") {
@@ -393,6 +401,21 @@ describe("probeGateway", () => {
     expect(eventLoopReadyState.calls[0]?.maxWaitMs).toBe(250);
     expect(gatewayClientState.options?.url).toBe("ws://127.0.0.1:18789");
     expect(gatewayClientState.startCalls).toBe(0);
+  });
+
+  it("stops an active probe when its owner aborts", async () => {
+    gatewayClientState.startMode = "defer";
+    const controller = new AbortController();
+    const probe = runTokenLightweightProbe({
+      timeoutMs: 5_000,
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => expect(gatewayClientState.startCalls).toBe(1));
+
+    controller.abort();
+
+    await expect(probe).resolves.toMatchObject({ ok: false, error: "aborted" });
+    expect(gatewayClientState.stopAndWaitCalls).toEqual([{ timeoutMs: 1_000 }]);
   });
 
   it("connects with operator.read scope", async () => {

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -275,6 +275,7 @@ export async function probeGateway(opts: {
   detailLevel?: GatewayProbeDetailLevel;
   tlsFingerprint?: string;
   env?: NodeJS.ProcessEnv;
+  signal?: AbortSignal;
 }): Promise<GatewayProbeResult> {
   const startedAt = Date.now();
   const instanceId = randomUUID();
@@ -347,6 +348,7 @@ export async function probeGateway(opts: {
   return await new Promise<GatewayProbeResult>((resolve) => {
     let settled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
+    let onAbort: (() => void) | undefined;
     const startAbort = new AbortController();
     const clearProbeTimer = () => {
       if (timer) {
@@ -367,6 +369,10 @@ export async function probeGateway(opts: {
         return;
       }
       settled = true;
+      if (onAbort) {
+        opts.signal?.removeEventListener("abort", onAbort);
+        onAbort = undefined;
+      }
       startAbort.abort();
       clearProbeTimer();
       void (async () => {
@@ -578,6 +584,26 @@ export async function probeGateway(opts: {
         })();
       },
     });
+
+    if (opts.signal) {
+      onAbort = () => {
+        settleProbe({
+          ok: false,
+          error: "aborted",
+          health: null,
+          status: null,
+          presence: null,
+          configSnapshot: null,
+        });
+      };
+      opts.signal.addEventListener("abort", onAbort, { once: true });
+      if (opts.signal.aborted) {
+        onAbort();
+      }
+    }
+    if (settled) {
+      return;
+    }
 
     armProbeTimer(() => {
       const error = connectError ? `connect failed: ${connectError}` : "timeout";

--- a/src/infra/ssh-tunnel.test.ts
+++ b/src/infra/ssh-tunnel.test.ts
@@ -255,6 +255,60 @@ describe("startSshPortForward", () => {
     },
   );
 
+  it("stops an established tunnel when its owner aborts", async () => {
+    spawnFakeSshListening();
+    const controller = new AbortController();
+    const tunnel = await startSshPortForward({
+      target: "me@example.com:2222",
+      localPortPreferred: await getFreePort(),
+      remotePort: 18789,
+      timeoutMs: 1000,
+      signal: controller.signal,
+    });
+    const child = mocks.spawn.mock.results[0]?.value as EventEmitter & { killed: boolean };
+
+    controller.abort();
+
+    await vi.waitFor(() => expect(child.killed).toBe(true));
+    await expect(tunnel.stop()).resolves.toBeUndefined();
+  });
+
+  it("keeps startup abort pending until the SSH child exits", async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      pid: number;
+      stderr: EventEmitter & { setEncoding: (enc: string) => void };
+      kill: (signal?: string) => boolean;
+    };
+    child.pid = 4242;
+    child.stderr = Object.assign(new EventEmitter(), { setEncoding: () => {} });
+    child.kill = vi.fn(() => true);
+    mocks.spawn.mockReturnValue(child);
+    const controller = new AbortController();
+    const forwarding = startSshPortForward({
+      target: "me@example.com:2222",
+      localPortPreferred: await getFreePort(),
+      remotePort: 18789,
+      timeoutMs: 1000,
+      signal: controller.signal,
+    });
+    let settled = false;
+    void forwarding
+      .finally(() => {
+        settled = true;
+      })
+      .catch(() => {});
+
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledTimes(1));
+    controller.abort();
+    await vi.waitFor(() => expect(child.kill).toHaveBeenCalledWith("SIGTERM"));
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(child.kill).toHaveBeenCalledTimes(1);
+
+    child.emit("exit", null, "SIGTERM");
+    await expect(forwarding).rejects.toMatchObject({ name: "AbortError" });
+  });
+
   it("rejects with the spawn error when ssh binary is missing", async () => {
     vi.useFakeTimers();
     const spawnError = new Error("ENOENT: no such file or directory, spawn /usr/bin/ssh");

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import net from "node:net";
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { createAbortError, isAbortError, racePromiseWithAbortSignal } from "./abort-signal.js";
 import { formatErrorMessage, isErrno } from "./errors.js";
 import { ensurePortAvailable, PortInUseError } from "./ports.js";
 import { resolveSshClient } from "./ssh-client.js";
@@ -195,7 +196,7 @@ export async function startSshPortForward(opts: {
   args.push("--", userHost);
 
   if (opts.signal?.aborted) {
-    throw new DOMException("Aborted", "AbortError");
+    throw createAbortError("SSH tunnel start aborted", { cause: opts.signal.reason });
   }
 
   const stderr: string[] = [];
@@ -216,9 +217,17 @@ export async function startSshPortForward(opts: {
     child.once("exit", () => resolve());
     child.once("close", () => resolve());
   });
+  let onAbort: (() => void) | undefined;
+  const detachAbort = () => {
+    if (onAbort) {
+      opts.signal?.removeEventListener("abort", onAbort);
+      onAbort = undefined;
+    }
+  };
   let stopping: Promise<void> | undefined;
   const stop = () =>
     (stopping ??= (async () => {
+      detachAbort();
       // Sending a signal is not exit; every caller must await the same child lifetime.
       const timer = setTimeout(() => child.kill("SIGKILL"), 1500);
       try {
@@ -229,44 +238,40 @@ export async function startSshPortForward(opts: {
       }
     })());
 
-  // AbortSignal owns the tunnel lifetime — abort races listener readiness
-  // and ensures the exact child is stopped during startup/active use.
-  let onAbort: (() => void) | undefined;
-  const abortPromise = opts.signal
-    ? new Promise<never>((_, reject) => {
-        onAbort = () => {
-          try {
-            child.kill("SIGTERM");
-          } catch {}
-          reject(new DOMException("Aborted", "AbortError"));
-        };
-        opts.signal!.addEventListener("abort", onAbort, { once: true });
-      })
-    : null;
-
   try {
-    await Promise.race([
-      waitForLocalListener(localPort, Math.max(250, opts.timeoutMs)),
-      new Promise<void>((_, reject) => {
-        child.once("error", (err) => reject(err));
-        child.once("exit", (code, signal) => {
-          reject(new Error(`ssh exited (${code ?? "null"}${signal ? `/${signal}` : ""})`));
-        });
-      }),
-      ...(abortPromise ? [abortPromise] : []),
-    ]);
+    await racePromiseWithAbortSignal(
+      Promise.race([
+        waitForLocalListener(localPort, Math.max(250, opts.timeoutMs)),
+        new Promise<void>((_, reject) => {
+          child.once("error", (err) => reject(err));
+          child.once("exit", (code, signal) => {
+            reject(new Error(`ssh exited (${code ?? "null"}${signal ? `/${signal}` : ""})`));
+          });
+        }),
+      ]),
+      opts.signal,
+    );
   } catch (err) {
     await stop();
-    if (onAbort) {
-      opts.signal?.removeEventListener("abort", onAbort);
+    if (isAbortError(err)) {
+      throw err;
     }
     const suffix = stderr.length > 0 ? `\n${stderr.join("\n")}` : "";
     throw new Error(`${formatErrorMessage(err)}${suffix}`, { cause: err });
-  } finally {
-    if (onAbort) {
-      opts.signal?.removeEventListener("abort", onAbort);
+  }
+
+  if (opts.signal) {
+    // Keep cancellation attached until this exact child exits. Removing it at
+    // listener readiness would let a later command signal orphan the tunnel.
+    onAbort = () => void stop().catch(() => {});
+    opts.signal.addEventListener("abort", onAbort, { once: true });
+    if (opts.signal.aborted) {
+      onAbort();
+      await stop();
+      throw createAbortError("SSH tunnel start aborted", { cause: opts.signal.reason });
     }
   }
+  void exited.then(detachAbort);
 
   return {
     parsedTarget: parsed,

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -143,6 +143,7 @@ export async function startSshPortForward(opts: {
   localPortPreferred: number;
   remotePort: number;
   timeoutMs: number;
+  signal?: AbortSignal;
 }): Promise<SshTunnel> {
   const parsed = parseSshTarget(opts.target);
   if (!parsed) {
@@ -193,6 +194,10 @@ export async function startSshPortForward(opts: {
   // Security: Use '--' to prevent userHost from being interpreted as an option
   args.push("--", userHost);
 
+  if (opts.signal?.aborted) {
+    throw new DOMException("Aborted", "AbortError");
+  }
+
   const stderr: string[] = [];
   const child = spawn(sshPath, args, {
     stdio: ["ignore", "ignore", "pipe"],
@@ -224,6 +229,21 @@ export async function startSshPortForward(opts: {
       }
     })());
 
+  // AbortSignal owns the tunnel lifetime — abort races listener readiness
+  // and ensures the exact child is stopped during startup/active use.
+  let onAbort: (() => void) | undefined;
+  const abortPromise = opts.signal
+    ? new Promise<never>((_, reject) => {
+        onAbort = () => {
+          try {
+            child.kill("SIGTERM");
+          } catch {}
+          reject(new DOMException("Aborted", "AbortError"));
+        };
+        opts.signal!.addEventListener("abort", onAbort, { once: true });
+      })
+    : null;
+
   try {
     await Promise.race([
       waitForLocalListener(localPort, Math.max(250, opts.timeoutMs)),
@@ -233,11 +253,19 @@ export async function startSshPortForward(opts: {
           reject(new Error(`ssh exited (${code ?? "null"}${signal ? `/${signal}` : ""})`));
         });
       }),
+      ...(abortPromise ? [abortPromise] : []),
     ]);
   } catch (err) {
     await stop();
+    if (onAbort) {
+      opts.signal?.removeEventListener("abort", onAbort);
+    }
     const suffix = stderr.length > 0 ? `\n${stderr.join("\n")}` : "";
     throw new Error(`${formatErrorMessage(err)}${suffix}`, { cause: err });
+  } finally {
+    if (onAbort) {
+      opts.signal?.removeEventListener("abort", onAbort);
+    }
   }
 
   return {


### PR DESCRIPTION
## What Problem This Solves

Resolves #127591.

`openclaw gateway probe --ssh` started a long-lived `ssh -N -L` child and stopped it only from an async `finally`. A PID-only `SIGINT` or `SIGTERM` terminated the inner OpenClaw command before that cleanup ran. The SSH process and forwarded listener then remained active.

## Why This Change Was Made

The command now owns one abort signal for the complete probe lifetime. It passes that signal to both the SSH tunnel and every Gateway probe.

The SSH owner keeps cancellation attached after listener readiness and removes it only when the exact child stops. Startup abort and normal cleanup share the existing memoized stop fence from #133847, so all callers wait for child exit.

Gateway probes now stop their client and timer when their owner aborts. The command removes its signal handlers and exits through the runtime with code 130 for `SIGINT` or 143 for `SIGTERM` only after cleanup completes.

## User Impact

A supervisor can signal only the OpenClaw command PID without leaving an SSH process or local forwarded port behind.

## Evidence

The real CLI ran on an isolated Linux runner with a real OpenSSH server and client. Each case waited for the `ssh -N -L` listener, resolved its parent OpenClaw command PID, and signalled only that PID.

| Case | Current main `dfa8b7df9e6f58dd7baab29ee7e2e238c74580a8` | Head `8d2ddff23a0866b54e3dd2cc105d083933039069` |
| --- | --- | --- |
| `SIGTERM` | SSH child and listener remained active | exit 143; SSH child gone; listener closed |
| `SIGINT` | SSH child and listener remained active | exit 130; SSH child gone; listener closed |

Anti-cheat: the second signal used different remote and forwarded ports and produced the same before/after result.

Validation:

- `node scripts/run-vitest.mjs src/infra/ssh-tunnel.test.ts src/gateway/probe.test.ts src/commands/gateway-status.test.ts` — 92 tests passed.
- The same three regression changes failed on the exact pre-fix main for the intended missing-abort reasons.
- Exact-head tree `24452effdb9430cf1d4e27b56c810c9a6baab536` built successfully before the real CLI proof.
- Oxfmt, Oxlint, the max-lines ratchet, `git diff --check`, and pre-commit Autoreview passed.

Diff classification: production +99 net lines; tests +81 net lines. The production growth adds the missing command, tunnel, and Gateway-client cancellation ownership. It reuses the existing abort helper and canonical child-reaping stop path instead of adding a second cleanup path.

Codex lifecycle contract checked in `codex-rs/cli/src/remote_control_cmd.rs` and signal exit identity checked in `codex-rs/cli/src/exit_status.rs`.
