### PR TITLE
perf: avoid terminal replay stalls during bulk eviction

### DIFF
--- a/src/shared/bounded-buffer.test.ts
+++ b/src/shared/bounded-buffer.test.ts
@@ -25,12 +25,13 @@ describe("BoundedBuffer", () => {
       overflowCalls: 0,
     },
     {
-      name: "drops oldest values until the buffer fits",
-      capacity: 2,
+      name: "drops every oldest value needed to fit a larger append",
+      capacity: 8,
+      measure: (value) => value.length,
       overflow: () => ({ mode: "drop-oldest" }),
-      values: ["a", "b", "c"],
-      accepted: [true, true, true],
-      drained: ["b", "c"],
+      values: ["a", "bb", "ccc", "dddd"],
+      accepted: [true, true, true, true],
+      drained: ["ccc", "dddd"],
       overflowCalls: 0,
     },
     {

--- a/src/shared/bounded-buffer.ts
+++ b/src/shared/bounded-buffer.ts
@@ -24,22 +24,26 @@ export class BoundedBuffer<T> {
       this.size += valueSize;
       return true;
     }
-    if (this.overflow.mode === "latch") {
+    if (this.overflow.mode !== "drop-oldest") {
       this.closed = true;
-      return false;
-    }
-    if (this.overflow.mode === "fail-closed") {
-      this.values = [];
-      this.size = 0;
-      this.closed = true;
-      this.overflow.onOverflow();
+      if (this.overflow.mode === "fail-closed") {
+        this.drain();
+        this.overflow.onOverflow();
+      }
       return false;
     }
     this.values.push(value);
     this.size += valueSize;
-    while (this.size > this.capacity && this.values.length > 1) {
-      this.size -= this.measure(this.values.shift()!);
+    let dropped = 0;
+    // Leave the newest value for fitting; preserve the > comparison for NaN capacities.
+    for (const oldest of this.values) {
+      if (!(this.size > this.capacity) || dropped === this.values.length - 1) {
+        break;
+      }
+      this.size -= this.measure(oldest);
+      dropped += 1;
     }
+    this.values.splice(0, dropped);
     if (this.size > this.capacity) {
       const fitted = this.overflow.fit?.(value, this.capacity);
       this.values = fitted === undefined ? [] : [fitted];


### PR DESCRIPTION
## What Problem This Solves

Terminal replay can stall the Gateway when a full output buffer contains many small chunks and a larger append evicts thousands of them. The shared buffer repeatedly shifted the remaining array for every discarded chunk.

## Why This Change Was Made

The buffer now measures the oldest prefix once and removes it with one splice. It retains the newest chunk for the existing oversized-value fitting path. Latch and fail-closed handling share their terminal transition, and fail-closed cleanup uses the existing drain owner.

This keeps the current buffer representation and all three overflow modes. A ring/deque redesign would add state and change drain ownership unnecessarily. A measured copyWithin alternative avoided the temporary deleted-prefix array but was substantially slower for small-prefix eviction.

## User Impact

Burst output no longer incurs repeated whole-array shifts before terminal replay can continue. Capacity, byte ordering, fitting, and overflow behavior remain unchanged.

## Evidence

- Actual TerminalOutputRing, three alternating fresh-process pairs: fill its 256 KiB capacity with one-character chunks, then append 16 KiB. Baseline median 3,168.405 ms (range 523.273–3,183.879); candidate median 0.470 ms (range 0.423–0.494). Every result retained the same 262,144 characters and SHA-256. These are stress-case eviction timings, not ordinary PTY latency claims.
- A real PTY produced 32 KiB plus an emoji and a suffix through the actual adapter and output ring; the process exited successfully, bounded replay preserved the suffix and surrogate boundary, and the adapter was disposed.
- All 37 focused tests passed across the shared buffer, terminal output ring, node relay, and node-host runtime. The existing drop-oldest table row now covers multiple variable-sized evictions. No timing assertion was added to unit tests.
- The complete `pnpm check:changed` plan and fresh Codex autoreview passed.
- Independent differential proof matched 220 sequences / 60,155 operations, including every overflow mode, fitting, drains, undefined values, callback order, and unusual capacities. The three production callers use pure length/byte-length measures.
- Memory tradeoff measured explicitly: a 16 KiB prefix eviction adds about 131 KiB of collectible removed-reference storage through splice, with no added retained heap observed after collection. This is a latency optimization, not a heap-allocation reduction.

Production LOC: +14/-10, net +4; tests: +6/-5, net +1. The extra prefix counter and early-stop loop remove quadratic work; shared closure/drain handling absorbs the surrounding duplication. No configuration, protocol, dependency, or persistence change.
