### PR TITLE
refactor(scripts): centralize boundary inventory sorting

### DIFF
--- a/scripts/check-plugin-extension-import-boundary.mts
+++ b/scripts/check-plugin-extension-import-boundary.mts
@@ -28,15 +28,6 @@ type PluginExtensionInventoryEntry = {
   resolvedPath: string | null;
   reason: string;
 };
-function compareEntries(left: PluginExtensionInventoryEntry, right: PluginExtensionInventoryEntry) {
-  return (
-    left.file.localeCompare(right.file) ||
-    left.line - right.line ||
-    left.kind.localeCompare(right.kind) ||
-    left.specifier.localeCompare(right.specifier) ||
-    left.reason.localeCompare(right.reason)
-  );
-}
 
 function classifyResolvedExtensionReason(kind: string, resolvedPath: string | null) {
   const verb =
@@ -75,7 +66,6 @@ const boundaryChecker = createExtensionImportBoundaryChecker({
       };
     });
   },
-  compareEntries,
 });
 
 /** Rejects retired core registries whose ownership now comes from plugin manifests. */
@@ -98,10 +88,10 @@ export function collectRetiredWebSearchCorePathEntries(
 
 /** Inventory of src/plugins extension imports and retired core web-search ownership paths. */
 async function collectPluginExtensionImportBoundaryInventory() {
-  return [
+  return boundaryChecker.sortInventory([
     ...(await boundaryChecker.collectInventory()),
     ...collectRetiredWebSearchCorePathEntries(),
-  ].toSorted(compareEntries);
+  ]);
 }
 
 const ruleText =

--- a/scripts/lib/extension-import-boundary-checker.mts
+++ b/scripts/lib/extension-import-boundary-checker.mts
@@ -180,6 +180,12 @@ export function createExtensionImportBoundaryChecker<Entry = BoundaryViolation>(
   const repoRoot = path.resolve(params.repoRoot ?? DEFAULT_REPO_ROOT);
   const scanRoots = resolveSourceRoots(repoRoot, params.roots);
   const maxSourceBytes = normalizeMaxSourceBytes(params.maxSourceBytes);
+  const compareInventoryEntries =
+    params.compareEntries ??
+    ((left: Entry, right: Entry) =>
+      compareEntries(left as BoundaryViolation, right as BoundaryViolation));
+  const sortInventory = (inventory: readonly Entry[]): Entry[] =>
+    inventory.toSorted(compareInventoryEntries);
 
   const collectInventory = createCachedAsync(async () => {
     const files = (await collectTypeScriptFilesFromRoots(scanRoots, params.sourceOptions))
@@ -221,11 +227,7 @@ export function createExtensionImportBoundaryChecker<Entry = BoundaryViolation>(
       { concurrency: 32, stopOnError: true },
     );
     const inventory = entriesByFile.flat() as Entry[];
-    const compare =
-      params.compareEntries ??
-      ((left: Entry, right: Entry) =>
-        compareEntries(left as BoundaryViolation, right as BoundaryViolation));
-    return inventory.toSorted(compare);
+    return sortInventory(inventory);
   }) as () => Promise<Entry[]>;
 
   async function main(
@@ -248,5 +250,5 @@ export function createExtensionImportBoundaryChecker<Entry = BoundaryViolation>(
     return inventory.length === 0 ? 0 : 1;
   }
 
-  return { collectInventory, main };
+  return { collectInventory, main, sortInventory };
 }


### PR DESCRIPTION
## What Problem This Solves

This maintainer-requested refactor removes duplicate inventory-ordering policy from the plugin extension import boundary guard. Keeping the same comparator in both the shared checker and one caller created a drift risk for deterministic diagnostics.

## Why This Change Was Made

The shared boundary checker now captures its effective comparator once and returns a narrow `sortInventory` closure. The checker uses that closure internally, and the plugin boundary caller uses it when combining scanned entries with retired-path entries. Custom comparator support remains unchanged for callers that need it.

No runtime, SDK, configuration, protocol, generated-output, documentation, or user-visible behavior changes.

## User Impact

No user-visible impact. Maintainers keep the same deterministic guard output with one canonical owner for inventory sorting.

## Evidence

- Runtime production LOC: `0`
- Tooling LOC: `+10/-18` (net `-8`)
- Test LOC: `0`
- Test-audit decision: no committed test was added because a sorter-specific test would preserve a private implementation seam. Existing boundary tests cover the public behavior.
- Disposable mixed fixture proof used an untracked retired `src/plugins/web-search-providers.ts` entry and an untracked scanned `src/plugins/z.ts` entry. Pre-change and post-change stdout and stderr were byte-identical, and the retired path remained ordered before `z.ts`. Fixtures were removed before commit.
- `node scripts/run-vitest.mjs test/scripts/extension-import-boundary-checker.test.ts test/plugin-extension-import-boundary.test.ts test/extension-import-boundaries.test.ts test/test-helper-extension-import-boundary.test.ts` (`30` tests passed)
- `pnpm lint:plugins:no-extension-imports`
- `node scripts/check-changed.mjs --dry-run -- scripts/check-plugin-extension-import-boundary.mts scripts/lib/extension-import-boundary-checker.mts`
- The actual changed-file gate selected formatting, script erasability, `tsgo:scripts`, coercion checks, targeted oxlint, and tooling boundary guards. Every selected check passed. The first `tsgo:scripts` attempt exposed a sparse-worktree omission of tracked `ui/config/*`; after adding that directory to the sparse checkout, the failed typecheck and the remaining selected checks passed.
- `git diff --check`
- Structured Codex autoreview with `gpt-5.6-sol` at high reasoning: scoped clean, no actionable findings
- No Crabbox or native landing run yet; this PR is intentionally left draft for exact-head coordinator review.
