### PR TITLE
fix: stale group updates revoke valid browser commands

### DIFF
--- a/extensions/browser/chrome-extension/modules/tab-access-events.js
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.js
@@ -164,7 +164,6 @@ export function registerTabAccessEvents({
       if (eventRevision !== groupEventRevision) {
         return;
       }
-      let newerTabEventOwnsAccess = false;
       for (const [tabId, generation, epoch] of generations) {
         if (!selected.has(tabId) || attachments.get(tabId) !== generation) {
           continue;
@@ -174,8 +173,8 @@ export function registerTabAccessEvents({
           return;
         }
         if (!policy.epochIsCurrent(tabId, epoch)) {
-          // A newer tab event owns this attachment's revision.
-          newerTabEventOwnsAccess = true;
+          // The newer tab event owns validation. Replaying this old group event
+          // would revoke commands admitted after that validation completed.
           continue;
         }
         if (state.accessible) {
@@ -186,12 +185,6 @@ export function registerTabAccessEvents({
             return;
           }
         }
-      }
-      if (eventRevision !== groupEventRevision) {
-        return;
-      }
-      if (newerTabEventOwnsAccess) {
-        onGroupChanged();
       }
     });
   };

--- a/extensions/browser/chrome-extension/modules/tab-access-events.navigation.test.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.navigation.test.ts
@@ -400,6 +400,49 @@ describe("Chrome navigation event access", () => {
     expect(harness.send).not.toHaveBeenCalled();
   });
 
+  it("preserves commands admitted after a newer tab event when an older group lookup completes", async () => {
+    const harness = await createNavigationHarness("selected");
+    let release = () => {};
+    const pending = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let observed = () => {};
+    const started = new Promise<void>((resolve) => {
+      observed = resolve;
+    });
+    const get = harness.chromeApi.tabs.get.getMockImplementation()!;
+    harness.chromeApi.tabs.get.mockImplementationOnce(async (tabId) => {
+      observed();
+      await pending;
+      return await get(tabId);
+    });
+
+    harness.chromeApi.tabGroups.onUpdated.emit({ id: 11, title: "OpenClaw" });
+    await started;
+    try {
+      harness.update({ url: "https://destination.example/" });
+      await vi.waitFor(() => {
+        harness.send.mockClear();
+        harness.emitNavigation();
+        expect(harness.send).toHaveBeenCalledTimes(navigationEvents.length);
+      });
+      const commandEpoch = harness.policy.capture(7, "Page.navigate");
+      await expect(harness.policy.requireTab(7, commandEpoch)).resolves.toMatchObject({ id: 7 });
+      release();
+      // Drain the superseded lookup without introducing a second Chrome event.
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      await expect(harness.policy.requireTab(7, commandEpoch)).resolves.toMatchObject({
+        id: 7,
+        url: "https://destination.example/",
+      });
+      expect(harness.detachDebugger).not.toHaveBeenCalled();
+    } finally {
+      release();
+    }
+  });
+
   it("does not retain file permission across a recreated extension policy", async () => {
     for (const fileAccessAllowed of [true, false]) {
       const harness = await createNavigationHarness("all", { fileAccessAllowed });

--- a/extensions/browser/chrome-extension/modules/tab-access-events.test.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.test.ts
@@ -281,28 +281,6 @@ describe("tab access event epochs", () => {
     });
   });
 
-  it("lets a newer eligible tab event own stale group-wide reconciliation", async () => {
-    const harness = createHarness("selected");
-    const groupInspection = deferred<{ accessible: boolean }>();
-    harness.policy.inspectTab
-      .mockImplementationOnce(async () => await groupInspection.promise)
-      .mockResolvedValueOnce({ accessible: true });
-
-    harness.groupUpdatedListener();
-    harness.debuggerEventListener({ tabId: 7 }, "Page.frameNavigated", {});
-    expect(harness.send).not.toHaveBeenCalled();
-    await vi.waitFor(() => expect(harness.policy.inspectTab).toHaveBeenCalledTimes(1));
-
-    harness.tabsUpdatedListener(7, { url: "https://two.example" });
-    await vi.waitFor(() => {
-      expect(harness.attachments.get(7)?.epoch).toEqual({ revision: 2, tabRevision: 0 });
-    });
-    groupInspection.resolve({ accessible: false });
-    await Promise.resolve();
-
-    expect(harness.detachDebugger).not.toHaveBeenCalled();
-  });
-
   it("does not refresh epochs from a stale group-wide access snapshot", async () => {
     vi.stubGlobal("chrome", { tabGroups: { get: vi.fn() } });
     const harness = createHarness();


### PR DESCRIPTION
Closes #135176

## What Problem This Solves

Fixes an issue where selected-tab browser commands could fail as revoked when an older group lookup completed after a newer allowed tab update. This was investigated while diagnosing the Chromium failure blocking the Usage daylight-saving fix, #135153.

## Why This Change Was Made

The stale group callback already recognized that a newer tab event owned validation, but then recursively replayed the group event. That invented another global access change and revoked newly admitted commands. Remove the replay and leave validation with the newer event; genuine Chrome group changes still invalidate access synchronously.

Replace the older mocked no-detach test with a real-policy regression that verifies an already-admitted command remains valid after the superseded lookup completes. Production is +2/−9 lines; tests are +43/−22.

## User Impact

Selected-tab automation retains valid command authority across this event ordering. Pause, removal, group membership, attachment generation and document checks remain in their existing owners. No configuration, protocol or storage changes.

## Evidence

- Deterministic regression: original owner rejects the admitted command; candidate passes.
- 157 tests across access events, navigation, document provenance, relay commands and physical creation pass.
- Linux Node 24.19.0 / Chromium 151: unchanged production fails on the seventh selected-tab creation; candidate passes all 40 alternating all/selected creations with same-target snapshots and cleanup. The original unmodified Chromium bootstrap case also passes on the final three-file candidate.
- Managed Codex review: scoped-clean, no actionable P0 findings. The candidate was then rebased onto `6b5f877db1eb`; the full browser plugin and all three reviewed afterimages are unchanged from the tested source.
- All 25 configured changed checks passed on the rebased candidate ([Linux run](https://github.com/openclaw/openclaw/actions/runs/33506895073)); the one-shot Testbox stopped normally. An initial preparation run used an old inherited tracking ref and failed the suppression baseline check; correcting the comparison base resolved it without baseline edits.

The stress trace reproduces the CI symptom but does not instrument internal epochs, so the deterministic owner test supplies the causal proof. A separate early reconnect run once returned an empty target inventory before creation began; that is a named follow-up and is not claimed fixed here.
