### PR TITLE
perf: reduce memory used to decode command output

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -1,5 +1,4 @@
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
-// Exec helpers run subprocesses with normalized output, timeout, and abort handling.
 import { danger, shouldLogVerbose } from "../globals.js";
 import {
   decodeWindowsOutputBuffer,
@@ -30,7 +29,13 @@ export type RunExecOptions = {
   signal?: AbortSignal;
 };
 
-// Simple promise-wrapped execFile with optional verbosity logging.
+function decodeExecOutput(buffer: Uint8Array, windowsEncoding: string | null): string {
+  return decodeWindowsOutputBuffer({
+    buffer: Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength),
+    windowsEncoding,
+  });
+}
+
 export async function runExec(
   command: string,
   args: string[],
@@ -73,14 +78,8 @@ export async function runExec(
     const releaseOutput = releaseChildProcessOutputAfterExit(subprocess.nodeChildProcess);
     const { stdout, stderr } = await subprocess.finally(releaseOutput);
     const windowsEncoding = resolveWindowsConsoleEncoding();
-    const decodedStdout = decodeWindowsOutputBuffer({
-      buffer: Buffer.from(stdout),
-      windowsEncoding,
-    });
-    const decodedStderr = decodeWindowsOutputBuffer({
-      buffer: Buffer.from(stderr),
-      windowsEncoding,
-    });
+    const decodedStdout = decodeExecOutput(stdout, windowsEncoding);
+    const decodedStderr = decodeExecOutput(stderr, windowsEncoding);
     if (resolvedOptions?.logOutput !== false && shouldLogVerbose()) {
       if (decodedStdout.trim()) {
         logDebug(decodedStdout.trim());
@@ -103,16 +102,10 @@ export async function runExec(
         errorWithOutput.code = errorWithOutput.exitCode;
       }
       if (errorWithOutput.stdout instanceof Uint8Array) {
-        errorWithOutput.stdout = decodeWindowsOutputBuffer({
-          buffer: Buffer.from(errorWithOutput.stdout),
-          windowsEncoding,
-        });
+        errorWithOutput.stdout = decodeExecOutput(errorWithOutput.stdout, windowsEncoding);
       }
       if (errorWithOutput.stderr instanceof Uint8Array) {
-        errorWithOutput.stderr = decodeWindowsOutputBuffer({
-          buffer: Buffer.from(errorWithOutput.stderr),
-          windowsEncoding,
-        });
+        errorWithOutput.stderr = decodeExecOutput(errorWithOutput.stderr, windowsEncoding);
       }
     }
     if (resolvedOptions?.logOutput !== false && shouldLogVerbose()) {


### PR DESCRIPTION
## What Problem This Solves

Collecting command output allocated another full byte buffer immediately before decoding it. This affected both successful output and stderr/stdout carried by failed commands, increasing temporary memory usage for large responses.

## Why This Change Was Made

The Execa boundary now converts its completed Uint8Array output into an exact-range Buffer view and passes that view to the existing decoder. One private helper replaces four repeated conversion blocks; the shared Windows decoder and its existing Buffer callers retain their contracts. Two stale comments are removed, including a reference to the retired execFile implementation.

The pinned Execa/get-stream implementation owns the completed backing array. Node's Buffer view constructor shares that storage with the supplied byte offset and length, so synchronous decoding needs no additional byte copy. Widening the shared decoder would add wrappers to unrelated Buffer callers and is unnecessary.

## User Impact

Command output uses less temporary memory while preserving decoded text, exit/error details, output limits, environment handling, and Windows encoding behavior.

## Evidence

- Actual `runExec` calls with 8 MiB successful stdout and 8 MiB failed stderr: copied output bytes decrease from 16,777,216 to zero; both decoded outputs remain 8,388,608 characters. The owner file is unchanged between the frozen baseline and this PR's base. These are measured avoided byte copies, not an RSS claim.
- An independent real-Execa allocation probe retained sixteen conversions of a 16 MiB result: copies added 256 MiB of ArrayBuffer storage, while views added none.
- Offset/length, UTF-8, GBK fallback, UTF-16 BOM, malformed UTF-8 fallback, real command success, and rejected-command normalization all pass the boundary probe.
- 91 focused tests pass across command execution and Windows encoding. Three Windows-only cases are skipped on this macOS host and remain in the hosted Windows lane. No new implementation-mirroring allocation or timing test was added.
- Independent source and dependency-contract review accepts this private owner-boundary shape. Full local changed checks and fresh Codex autoreview passed.

Production LOC: +11/-18, net -7; tests: unchanged. No dependency, configuration, protocol, or persistence change.
