### PR TITLE
fix(cli): improve strict JSON shell quoting guidance

### DIFF
--- a/src/cli/error-format.test.ts
+++ b/src/cli/error-format.test.ts
@@ -10,4 +10,26 @@ describe("formatStrictJsonParseFailure", () => {
     expect(message).toContain(`${"x".repeat(44)}...`);
     expect(message).not.toContain("\uD83D");
   });
+
+  it("suggests shell-safe quoting for structured JSON values", () => {
+    const message = formatStrictJsonParseFailure({
+      value: '[telegram:user-id]',
+      cause: new SyntaxError("Unexpected token t in JSON at position 1"),
+    });
+
+    expect(message).toContain("If your shell stripped quotes from the JSON value");
+    expect(message).toContain("in PowerShell, use single quotes around the JSON");
+    expect(message).toContain(
+      `openclaw config set commands.ownerAllowFrom '["telegram:user-id"]' --strict-json`,
+    );
+  });
+
+  it("does not add shell quoting guidance for scalar JSON", () => {
+    const message = formatStrictJsonParseFailure({
+      value: "not-json",
+      cause: new SyntaxError("Unexpected token o in JSON at position 1"),
+    });
+
+    expect(message).not.toContain("If your shell stripped quotes");
+  });
 });

--- a/src/cli/error-format.test.ts
+++ b/src/cli/error-format.test.ts
@@ -11,7 +11,7 @@ describe("formatStrictJsonParseFailure", () => {
     expect(message).not.toContain("\uD83D");
   });
 
-  it("suggests shell-safe quoting for structured JSON values", () => {
+  it("suggests shell-safe quoting for structured JSON values without naming a mutable config target", () => {
     const message = formatStrictJsonParseFailure({
       value: '[telegram:user-id]',
       cause: new SyntaxError("Unexpected token t in JSON at position 1"),
@@ -20,8 +20,9 @@ describe("formatStrictJsonParseFailure", () => {
     expect(message).toContain("If your shell stripped quotes from the JSON value");
     expect(message).toContain("in PowerShell, use single quotes around the JSON");
     expect(message).toContain(
-      `openclaw config set commands.ownerAllowFrom '["telegram:user-id"]' --strict-json`,
+      `openclaw config set <path> '["telegram:user-id"]' --strict-json`,
     );
+    expect(message).not.toContain("commands.ownerAllowFrom");
   });
 
   it("does not add shell quoting guidance for scalar JSON", () => {

--- a/src/cli/error-format.ts
+++ b/src/cli/error-format.ts
@@ -61,10 +61,10 @@ export function formatStrictJsonParseFailure(params: { value: string; cause: unk
   const cause = rawCause.trim().replace(/[.。]+$/u, "");
   const preview =
     params.value.length > 48 ? `${truncateUtf16Safe(params.value, 45).trimEnd()}...` : params.value;
-  const looksLikeStructuredJson = /^[\[{]/u.test(params.value.trim());
+  const looksLikeStructuredJson = /^(?:\[|\{)/u.test(params.value.trim());
   const shellHint = looksLikeStructuredJson
     ? `If your shell stripped quotes from the JSON value, pass the entire JSON argument as one quoted argument; in PowerShell, use single quotes around the JSON, for example ${formatInlineCliCommand(
-        `openclaw config set commands.ownerAllowFrom '["telegram:user-id"]' --strict-json`,
+        "openclaw config set <path> '[\"telegram:user-id\"]' --strict-json",
       )}.`
     : "";
   return [

--- a/src/cli/error-format.ts
+++ b/src/cli/error-format.ts
@@ -61,6 +61,12 @@ export function formatStrictJsonParseFailure(params: { value: string; cause: unk
   const cause = rawCause.trim().replace(/[.。]+$/u, "");
   const preview =
     params.value.length > 48 ? `${truncateUtf16Safe(params.value, 45).trimEnd()}...` : params.value;
+  const looksLikeStructuredJson = /^[\[{]/u.test(params.value.trim());
+  const shellHint = looksLikeStructuredJson
+    ? `If your shell stripped quotes from the JSON value, pass the entire JSON argument as one quoted argument; in PowerShell, use single quotes around the JSON, for example ${formatInlineCliCommand(
+        `openclaw config set commands.ownerAllowFrom '["telegram:user-id"]' --strict-json`,
+      )}.`
+    : "";
   return [
     `Could not parse ${JSON.stringify(preview)} as JSON for --strict-json.`,
     `${cause}.`,
@@ -68,7 +74,10 @@ export function formatStrictJsonParseFailure(params: { value: string; cause: unk
       "openclaw config set gateway.port 18789 --strict-json",
     )}.`,
     "For plain strings, omit --strict-json.",
-  ].join(" ");
+    shellHint,
+  ]
+    .filter(Boolean)
+    .join(" ");
 }
 
 /** Normalize gateway failure text and attach the deep-status recovery command. */


### PR DESCRIPTION
Closes #135164

## What this fixes

When `openclaw config set ... --strict-json` receives a structured value whose quotes were stripped by the invoking shell, the current error only reports the JSON parser failure. This is particularly confusing for Windows PowerShell users because the intended value can look like `[telegram:user-id]` by the time it reaches the JSON parser.

This change keeps parsing behavior unchanged and improves the failure guidance when the rejected value looks like a JSON object or array:

- explains that shell argument quoting may have stripped JSON quotes;
- gives a PowerShell-safe single-quoted example;
- keeps the existing generic JSON guidance for scalar values;
- does not alter valid JSON parsing or config mutation behavior.

## Scope

- `src/cli/error-format.ts`
- `src/cli/error-format.test.ts`

No configuration schema, runtime behavior, or dependencies changed.

## Tests

Added regression coverage for:

- structured JSON parse failures receiving shell-safe guidance;
- scalar JSON failures not receiving the structured-value hint;
- the existing bounded UTF-16 preview behavior.

I could not execute the repository test suite in this environment because the available GitHub integration can modify/read repository files but does not provide a local checkout/runtime. The tests are included for CI validation.

This is intentionally a narrow follow-up to #135164: it satisfies the issue's requested clear PowerShell-specific guidance without pretending OpenClaw can recover quotes that a shell has already removed before the process receives its arguments.