### PR TITLE
fix(cli): guide shell quote-stripped strict JSON values to config patch --file

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -163,6 +163,14 @@ openclaw config set channels.whatsapp.groups '{"*":{"requireMention":true}}' --s
 
 For structured values that are awkward to quote in your shell, put a config-shaped JSON5 object in a file and use [`config patch --file <path> --dry-run`](/cli/config#config-patch). The file contains config keys and their values, not a bare array.
 
+<Note>
+Windows PowerShell can remove the inner quotes of a single-quoted JSON argument
+before OpenClaw receives it, so a command like
+`openclaw config set commands.ownerAllowFrom '["telegram:123"]' --strict-json`
+can fail with a JSON parse error. Put structured values in a JSON5 patch file
+and apply it with `openclaw config patch --file ./openclaw.patch.json5` instead.
+</Note>
+
 `config get <path> --json` prints the redacted value as JSON instead of terminal-formatted text.
 
 When a write changes `agents.defaults.model` or a per-agent `agents.entries.*.model`, OpenClaw resolves each changed primary or fallback through the configured catalogs and the selected provider's model resolver before writing. Provider-supported exact `provider/model` pins are accepted even when absent from the curated picker; validation does not replace the selected model. Unknown model references are rejected without changing the active config. Run `openclaw models list` to browse the picker, or check the provider's documentation for an exact model ID. Successful validation does not prove that your account can call the model.

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2029,6 +2029,9 @@ describe("config cli", () => {
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
       expectErrorIncludes('Could not parse "{bad" as JSON for --strict-json.');
       expectErrorIncludes("For plain strings, omit --strict-json.");
+      expect(mockError.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain(
+        "JSON array or object without string quotes",
+      );
     });
 
     it("keeps --json as a strict parsing alias", async () => {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2047,6 +2047,17 @@ describe("config cli", () => {
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
     });
 
+    it("suggests config patch --file when strict parsing receives a quote-stripped array", async () => {
+      await expect(
+        runConfigSet("commands.ownerAllowFrom", "[telegram:123456]", "--strict-json"),
+      ).rejects.toThrow(ExitError);
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes('Could not parse "[telegram:123456]" as JSON for --strict-json.');
+      expectErrorIncludes("Windows PowerShell");
+      expectErrorIncludes("openclaw config patch --file");
+    });
+
     it("accepts --strict-json with batch mode and applies batch payload", async () => {
       const resolved: OpenClawConfig = { gateway: { port: 18789 } };
       setSnapshot(resolved, resolved);

--- a/src/cli/error-format.test.ts
+++ b/src/cli/error-format.test.ts
@@ -41,6 +41,20 @@ describe("formatStrictJsonParseFailure", () => {
     const message = formatStrictJsonParseFailure({ value: "{mode:'token'}", cause: "bad token" });
 
     expect(message).not.toContain("Windows PowerShell");
-    expect(message).not.toContain("openclaw config patch --file");
+    expect(message).not.toContain("JSON array or object without string quotes");
+  });
+
+  it("does not suggest a shell hint for incomplete JSON", () => {
+    const message = formatStrictJsonParseFailure({ value: "{bad", cause: "bad token" });
+
+    expect(message).not.toContain("Windows PowerShell");
+    expect(message).not.toContain("JSON array or object without string quotes");
+  });
+
+  it("does not suggest a shell hint for a value missing its closing delimiter", () => {
+    const message = formatStrictJsonParseFailure({ value: "[telegram:123456", cause: "bad token" });
+
+    expect(message).not.toContain("Windows PowerShell");
+    expect(message).not.toContain("JSON array or object without string quotes");
   });
 });

--- a/src/cli/error-format.test.ts
+++ b/src/cli/error-format.test.ts
@@ -20,4 +20,27 @@ describe("formatStrictJsonParseFailure", () => {
     expect(message).toContain(`${"x".repeat(44)}...`);
     expect(message).not.toContain("\uD83D");
   });
+
+  it("suggests config patch --file for quote-stripped array values", () => {
+    const message = formatStrictJsonParseFailure({
+      value: "[telegram:123456]",
+      cause: "Unexpected token 't', ...",
+    });
+
+    expect(message).toContain("Windows PowerShell");
+    expect(message).toContain("openclaw config patch --file");
+  });
+
+  it("suggests config patch --file for quote-stripped object values", () => {
+    const message = formatStrictJsonParseFailure({ value: "{mode:token}", cause: "bad token" });
+
+    expect(message).toContain("openclaw config patch --file");
+  });
+
+  it("does not suggest a shell hint when the value still contains quotes", () => {
+    const message = formatStrictJsonParseFailure({ value: "{mode:'token'}", cause: "bad token" });
+
+    expect(message).not.toContain("Windows PowerShell");
+    expect(message).not.toContain("openclaw config patch --file");
+  });
 });

--- a/src/cli/error-format.ts
+++ b/src/cli/error-format.ts
@@ -58,12 +58,16 @@ export function formatUnsupportedChannelActionMessage(params: {
 /** Detect a structured value whose inner quotes were likely removed by the shell. */
 function looksShellStrippedJson(value: string): boolean {
   const trimmed = value.trim();
-  if (!trimmed.startsWith("[") && !trimmed.startsWith("{")) {
+  const balanced =
+    (trimmed.startsWith("[") && trimmed.endsWith("]")) ||
+    (trimmed.startsWith("{") && trimmed.endsWith("}"));
+  if (!balanced) {
     return false;
   }
-  // Valid JSON strings always carry quotes; a bare array/object without any
-  // quote characters reaching the parser is the classic Windows PowerShell
-  // single-quoted-argument handoff failure.
+  // Valid JSON strings always carry quotes; a bare, complete array/object
+  // without any quote character reaching the parser is the classic Windows
+  // PowerShell single-quoted-argument handoff failure. Incomplete values
+  // (e.g. "{bad") are ordinary JSON typos, not shell damage.
   return !/["']/.test(trimmed);
 }
 

--- a/src/cli/error-format.ts
+++ b/src/cli/error-format.ts
@@ -55,20 +55,40 @@ export function formatUnsupportedChannelActionMessage(params: {
   )} to inspect supported actions.`;
 }
 
+/** Detect a structured value whose inner quotes were likely removed by the shell. */
+function looksShellStrippedJson(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("[") && !trimmed.startsWith("{")) {
+    return false;
+  }
+  // Valid JSON strings always carry quotes; a bare array/object without any
+  // quote characters reaching the parser is the classic Windows PowerShell
+  // single-quoted-argument handoff failure.
+  return !/["']/.test(trimmed);
+}
+
 /** Format strict JSON parsing failures without exposing long untrusted input verbatim. */
 export function formatStrictJsonParseFailure(params: { value: string; cause: unknown }): string {
   const rawCause = params.cause instanceof Error ? params.cause.message : String(params.cause);
   const cause = rawCause.trim().replace(/[.。]+$/u, "");
   const preview =
     params.value.length > 48 ? `${truncateUtf16Safe(params.value, 45).trimEnd()}...` : params.value;
-  return [
+  const parts = [
     `Could not parse ${JSON.stringify(preview)} as JSON for --strict-json.`,
     `${cause}.`,
     `Use valid JSON. For structured changes, use a JSON5 config patch object file with ${formatInlineCliCommand(
       "openclaw config patch --file <path> --dry-run",
     )}.`,
     "For plain strings, omit --strict-json.",
-  ].join(" ");
+  ];
+  if (looksShellStrippedJson(params.value)) {
+    parts.push(
+      `The value looks like a JSON array or object without string quotes; Windows PowerShell often removes inner quotes before OpenClaw receives the argument. Put structured values in a JSON5 patch file and apply it with ${formatInlineCliCommand(
+        "openclaw config patch --file ./openclaw.patch.json5",
+      )}.`,
+    );
+  }
+  return parts.join(" ");
 }
 
 /** Normalize gateway failure text and attach the deep-status recovery command. */


### PR DESCRIPTION
Fixes #135164

## What Problem This Solves

On Windows 11 PowerShell, `openclaw config set commands.ownerAllowFrom '["telegram:<ID>"]' --strict-json` fails: PowerShell removes the inner quotes before OpenClaw receives argv, so the strict JSON parser sees `[telegram:<ID>]` and reports a generic parse error with no recovery path. Without `--strict-json` the value lands as a string and fails schema validation. The file-backed `config patch --file` path works but is never surfaced where the failure occurs (#135164).

## Why This Change Was Made

The process cannot recover quotes that were removed before argv reached Node, and no portable direct PowerShell syntax was verified, so per the maintainer review guidance on the issue the narrow repair is:

- Detect the quote-stripped shape in the strict-JSON parse failure and append a recovery hint that names the PowerShell quoting behavior and points at the existing `openclaw config patch --file ./openclaw.patch.json5` route.
- The detection requires a **balanced** bare array/object (matching closing delimiter) that contains no quote characters at all, so ordinary incomplete JSON typos such as `{bad` keep the original generic error with no shell-specific hint.
- Document the same guidance in the CLI reference (`docs/cli/config.md`, Values section).

Parsing and config mutation behavior are unchanged; guidance is added only on the failure path.

## User Impact

Windows PowerShell users who hit this failure now see why the quotes disappeared and get a concrete, already-supported recovery command instead of a dead end. Users on other shells see no change unless they pass a bare, quote-free array/object literal, where the extra hint is still accurate. Scalar and incomplete-JSON parse failures (`{bad`, numbers, strings) keep the existing message unchanged, verified by no-hint regression tests.

## Evidence

Real environment tested: Yes — real OpenClaw CLI process (no mocks, `src/entry.ts` under tsx on the PR head) reproducing the exact argv a Windows PowerShell 5.1 handoff produces when inner quotes are stripped, plus the full recovery path.

Exact steps or commands run after this patch (redacted transcript saved at `aispace/evidence/issue-135164-evidence/real-cli-transcript.txt`):

1. Quote-stripped argv reaching the real CLI:
   `openclaw config set commands.ownerAllowFrom '[telegram:12345678]' --strict-json --dry-run` → exit 1, no write, error now includes: `The value looks like a JSON array or object without string quotes; Windows PowerShell often removes inner quotes before OpenClaw receives the argument. Put structured values in a JSON5 patch file and apply it with `openclaw config patch --file ./openclaw.patch.json5`.`
2. Incomplete JSON stays generic (no false-positive hint): `openclaw config set gateway.auth.mode "{bad" --strict-json --dry-run` → exit 1, original message only, no PowerShell hint.
3. Recovery path end-to-end: `openclaw config patch --file ./openclaw.patch.json5 --dry-run` → `Dry run successful: 1 update(s) validated`; apply → `Applied 1 config update(s)`; `openclaw config get commands.ownerAllowFrom` → `["telegram:12345678"]` (stored as a real array, matching the issue's expected behavior).

Test/type evidence:
- RED: `node scripts/run-vitest.mjs run src/cli/error-format.test.ts src/cli/config-cli.test.ts` with the implementation reverted — regression tests fail.
- GREEN: same command on the PR head — all tests in both files pass (including new no-hint regressions for `{bad` and unclosed `[telegram:123456`).
- `pnpm tsgo:core` — pass. `oxfmt --check` / `oxlint` on changed files — clean. `format-docs --check` (738 files), `check-docs-mdx docs/cli/config.md`, `docs-link-audit` — clean.

CI note: the `checks-node-changed-extensions-config-61` failure is in `extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts` (media-group buffering, timing-related). This PR does not touch `extensions/`. Re-run locally on the PR head: 42/42 tests pass, so the shard failure is not branch-caused. The `openclaw/ci-gate` failure is downstream of that shard.

Observed result after fix: the strict-JSON failure for the PowerShell-shaped value now explains the cause and gives a working, file-backed recovery command; the recovery command demonstrably stores the intended array; ordinary JSON typos are unaffected.

What was not tested: a native Windows host terminal session (no Windows machine available; the local transcript reproduces the identical quote-stripped argv that Windows PowerShell delivers, which is the boundary the fix targets). Full CI lanes re-run is pending on Actions after the follow-up commit.

