### PR TITLE
refactor(protocol): centralize schema signatures

### DIFF
--- a/scripts/lib/protocol-schema-signature.mts
+++ b/scripts/lib/protocol-schema-signature.mts
@@ -1,0 +1,18 @@
+function projectProtocolSchema(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(projectProtocolSchema);
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .toSorted()
+        .map((key) => [key, projectProtocolSchema(record[key])]),
+    );
+  }
+  return value;
+}
+
+export function protocolSchemaSignature(schema: unknown): string {
+  return JSON.stringify(projectProtocolSchema(schema));
+}

--- a/scripts/protocol-gen-kotlin.ts
+++ b/scripts/protocol-gen-kotlin.ts
@@ -9,6 +9,7 @@ import {
 } from "../packages/gateway-protocol/src/version.js";
 import { listCoreGatewayMethodNames } from "../src/gateway/methods/core-descriptors.js";
 import { extractGatewayEventNames } from "./check-protocol-event-coverage.mts";
+import { protocolSchemaSignature } from "./lib/protocol-schema-signature.mts";
 
 type JsonSchema = {
   type?: string | string[];
@@ -192,25 +193,6 @@ function lowerCamel(value: string): string {
   return name[0]!.toLowerCase() + name.slice(1);
 }
 
-function stableJson(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(stableJson);
-  }
-  if (value && typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    return Object.fromEntries(
-      Object.keys(record)
-        .toSorted()
-        .map((key) => [key, stableJson(record[key])]),
-    );
-  }
-  return value;
-}
-
-function schemaSignature(schema: JsonSchema): string {
-  return JSON.stringify(stableJson(schema));
-}
-
 function literalValue(schema: JsonSchema): boolean | number | string | null | undefined {
   if ("const" in schema) {
     return schema.const;
@@ -251,7 +233,7 @@ function emitWireModels(): string[] {
       throw new Error(`Missing ProtocolSchemas.${schemaName}`);
     }
     selectedSchemas.set(schema, kotlinName);
-    selectedSignatures.set(schemaSignature(schema), kotlinName);
+    selectedSignatures.set(protocolSchemaSignature(schema), kotlinName);
   }
 
   const nestedModels = new Map<string, JsonSchema>();
@@ -276,7 +258,7 @@ function emitWireModels(): string[] {
     }
     discriminatedUnions.set(kotlinName, discriminator);
     for (const branch of branches) {
-      const signature = schemaSignature(branch);
+      const signature = protocolSchemaSignature(branch);
       const literal = literalValue(branch.properties?.[discriminator] ?? {}) as string;
       if (!selectedSignatures.has(signature)) {
         throw new Error(
@@ -291,7 +273,8 @@ function emitWireModels(): string[] {
     }
   }
   const kotlinType = (schema: JsonSchema, nestedName: string): string => {
-    const selected = selectedSchemas.get(schema) ?? selectedSignatures.get(schemaSignature(schema));
+    const selected =
+      selectedSchemas.get(schema) ?? selectedSignatures.get(protocolSchemaSignature(schema));
     if (selected) {
       return selected;
     }
@@ -330,7 +313,7 @@ function emitWireModels(): string[] {
       throw new Error(`${name} must remain an object schema for Kotlin generation`);
     }
     const required = new Set(schema.required ?? []);
-    const variant = unionVariants.get(schemaSignature(schema));
+    const variant = unionVariants.get(protocolSchemaSignature(schema));
     const properties = Object.entries(schema.properties)
       .filter(([wireName]) => wireName !== variant?.discriminator)
       .map(([wireName, propertySchema]) => {

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -10,6 +10,7 @@ import {
   PROTOCOL_VERSION,
 } from "../packages/gateway-protocol/src/version.js";
 import { writeGeneratedOutput } from "./lib/generated-output-utils.mts";
+import { protocolSchemaSignature } from "./lib/protocol-schema-signature.mts";
 
 type JsonSchema = {
   type?: string | string[];
@@ -136,28 +137,9 @@ const schemaNameByObject = new Map<object, string>();
 const schemaNameBySignature = new Map<string, string>();
 const duplicateSchemaSignatures = new Set<string>();
 
-function stableJson(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(stableJson);
-  }
-  if (value && typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    return Object.fromEntries(
-      Object.keys(record)
-        .toSorted()
-        .map((key) => [key, stableJson(record[key])]),
-    );
-  }
-  return value;
-}
-
-function schemaSignature(schema: JsonSchema): string {
-  return JSON.stringify(stableJson(schema));
-}
-
 function registerNamedSchema(name: string, schema: JsonSchema): void {
   schemaNameByObject.set(schema as object, name);
-  const signature = schemaSignature(schema);
+  const signature = protocolSchemaSignature(schema);
   if (duplicateSchemaSignatures.has(signature)) {
     return;
   }
@@ -172,7 +154,9 @@ function registerNamedSchema(name: string, schema: JsonSchema): void {
 function namedSchema(schema: JsonSchema, allowStructuralFallback = false): string | undefined {
   return (
     schemaNameByObject.get(schema as object) ??
-    (allowStructuralFallback ? schemaNameBySignature.get(schemaSignature(schema)) : undefined)
+    (allowStructuralFallback
+      ? schemaNameBySignature.get(protocolSchemaSignature(schema))
+      : undefined)
   );
 }
 

--- a/test/scripts/protocol-schema-signature.test.ts
+++ b/test/scripts/protocol-schema-signature.test.ts
@@ -1,0 +1,10 @@
+import { expect, it } from "vitest";
+import { protocolSchemaSignature } from "../../scripts/lib/protocol-schema-signature.mts";
+
+it("projects protocol schema keys recursively before stringifying", () => {
+  const sparse: unknown[] = [];
+  sparse.length = 2;
+  sparse[1] = { b: 2, a: 1 };
+
+  expect(protocolSchemaSignature({ a: 0, Z: sparse })).toBe('{"Z":[null,{"a":1,"b":2}],"a":0}');
+});


### PR DESCRIPTION
## What Problem This Solves

The Kotlin and Swift protocol generators independently owned the same deterministic schema-signature algorithm, so future fixes could drift between generated clients.

## Why This Change Was Made

Moves the existing recursive projection and native JSON serialization into one narrow tooling owner, then routes both generators through it. The helper preserves `Object.keys(record).toSorted()` recursion and native `JSON.stringify` behavior exactly.

The rebase conflict was resolved by retaining current main's Kotlin union validation unchanged: `Map<string, string>`, the branch loop, selected-signature guard and error, literal handling, and `emitUnion`. Only the four Kotlin and two Swift signature call sites now use `protocolSchemaSignature`.

No generated files, protocol schemas, SDK surfaces, package scripts, configuration, or runtime behavior changed.

## User Impact

No user-visible behavior change. Protocol generator maintenance now has one canonical signature implementation.

## Evidence

- Rebased onto current `origin/main` `e4100aca8ee919083eaaa3108c8832ec9709031c`; signed head `c37ed5d96f76a74f6b88ec322310df7627e668fc`.
- `node scripts/run-vitest.mjs test/scripts/protocol-schema-signature.test.ts`: 1 test passed.
- Test audit: the focused test independently protects recursive native key ordering and sparse-array JSON behavior; both are credible drift points in a shared generator contract and are not implementation-shape assertions.
- `pnpm protocol:check`: passed, including registry, Swift, Kotlin, protocol-since, and generated-diff checks.
- `node scripts/check-changed.mjs --dry-run -- scripts/lib/protocol-schema-signature.mts scripts/protocol-gen-kotlin.ts scripts/protocol-gen-swift.ts test/scripts/protocol-schema-signature.test.ts`: passed.
- `node scripts/check-changed.mjs -- scripts/lib/protocol-schema-signature.mts scripts/protocol-gen-kotlin.ts scripts/protocol-gen-swift.ts test/scripts/protocol-schema-signature.test.ts`: passed, including format, script erasability, script/root-test typechecks, import-boundary guards, and targeted lint.
- `git diff --check`: passed.
- Required high-reasoning Codex autoreview completed `scoped-clean` at 0.99 with no accepted or actionable findings.
- Generated artifacts are byte-identical to the rebased parent:
  - `apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`: `e357ea5444f456846056af482a717a9db61def7699fee6c71b6754b486eaa3c3`
  - `apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt`: `fe77fa2b9f1677cd7af7c4a8863d0f32f094344f89f3ebe37c9cf3ce0df1351e`
  - `apps/android/app/src/main/java/ai/openclaw/app/protocol/OpenClawProtocolConstants.kt`: `dfee75658d53f7b284dc8d5ed3c4e2bb3f3922bd5390f277069f46e42e7eeb9e`
- Personally inspected `openai/codex@5f49aba876922d6f2f55caa153bbb0ed1b46feba` at `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; those CLI completion and interactive-option paths are unrelated.
- Live overlap recheck: https://github.com/openclaw/openclaw/pull/134068 remains open and touches `scripts/protocol-gen-swift.ts`, but its schema-registration work is separate from this helper extraction.

## Change Surface

- Tooling: `+29/-44`, net `-15`.
- Tests: `+10/-0`.
- Total: `+39/-44`, net `-5`.
- Exactly four changed paths.
