### PR TITLE
fix(markdown): preserve task lists across chunk boundaries

### DIFF
--- a/.agents/skills/telegram-e2e-userbot/scripts/user-driver.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-driver.py
@@ -690,11 +690,6 @@ def normalize_message(message, users=None):
     sender_id = sender.get("user_id") or sender.get("chat_id")
     sender_user = users.get(int(sender_id or 0), {}) if sender_id else {}
     content = message.get("content") or {}
-    text = ""
-    if content.get("@type") == "messageText":
-        text = (content.get("text") or {}).get("text", "")
-    elif "caption" in content:
-        text = (content.get("caption") or {}).get("text", "")
     reply_to_message_id = message.get("reply_to_message_id") or (message.get("reply_to") or {}).get("message_id")
     return {
         "messageId": message.get("id"),
@@ -704,7 +699,7 @@ def normalize_message(message, users=None):
         "date": message.get("date"),
         "replyToMessageId": reply_to_message_id,
         "threadId": message.get("message_thread_id"),
-        "text": text,
+        **message_content(content),
         "contentType": content.get("@type"),
         "raw": message,
     }
@@ -999,7 +994,8 @@ def serve_message(message, users):
         "senderUsername": normalized.get("senderUsername"),
         "replyToMessageId": normalized.get("replyToMessageId"),
         "timestamp": int(message.get("date") or 0) * 1000,
-        "text": normalized.get("text", ""),
+        "text": normalized["text"],
+        "entities": normalized["entities"],
     }
 
 
@@ -1018,17 +1014,17 @@ def serve_update(update, users, known_messages):
     if not known:
         return None
     content = update.get("new_content") or {}
-    normalized = {**known, "text": message_content_text(content)}
+    normalized = {**known, **message_content(content)}
     known_messages[message_id] = normalized
     return {"kind": "edit", **normalized}
 
 
-def message_content_text(content):
-    for key in ("text", "caption"):
-        formatted = content.get(key)
-        if isinstance(formatted, dict) and isinstance(formatted.get("text"), str):
-            return formatted["text"]
-    return ""
+def message_content(content):
+    key = "text" if content.get("@type") == "messageText" else "caption"
+    formatted = content.get(key)
+    if isinstance(formatted, dict) and isinstance(formatted.get("text"), str):
+        return {"text": formatted["text"], "entities": formatted["entities"]}
+    return {"text": "", "entities": []}
 
 
 def write_ndjson(payload):

--- a/.agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py
@@ -95,6 +95,15 @@ class PhotoContentTest(unittest.TestCase):
     def test_normalizes_serve_messages_and_edits(self):
         known = {}
         message_id = 42 << 20
+        text = "😀 a   b x"
+        entities = [
+            {"offset": 3, "length": 5, "type": {"@type": "textEntityTypeCode"}},
+            {
+                "offset": 9,
+                "length": 1,
+                "type": {"@type": "textEntityTypeTextUrl", "url": "https://example.com/qa"},
+            },
+        ]
         message = {
             "id": message_id,
             "chat_id": -1001,
@@ -103,36 +112,119 @@ class PhotoContentTest(unittest.TestCase):
             "reply_to": {"message_id": 7},
             "content": {
                 "@type": "messageText",
-                "text": {"@type": "formattedText", "text": "first", "entities": []},
+                "text": {"@type": "formattedText", "text": text, "entities": entities},
             },
         }
         users = {101: {"username": "sut_bot"}}
-
         created = driver.serve_update(
             {"@type": "updateNewMessage", "message": message}, users, known
         )
-        edited = driver.serve_update(
-            {
-                "@type": "updateMessageContent",
-                "chat_id": -1001,
-                "message_id": message_id,
-                "new_content": {
-                    "@type": "messageText",
-                    "text": {"@type": "formattedText", "text": "final", "entities": []},
-                },
-            },
-            users,
-            known,
-        )
-
         self.assertEqual(created["kind"], "message")
         self.assertEqual(created["botApiMessageId"], 42)
         self.assertEqual(created["senderUsername"], "sut_bot")
         self.assertEqual(created["replyToMessageId"], 7)
         self.assertEqual(created["timestamp"], 123000)
-        self.assertEqual(edited["kind"], "edit")
-        self.assertEqual(edited["text"], "final")
-        self.assertEqual(edited["senderId"], 101)
+        self.assertEqual(created["text"], text)
+        self.assertEqual(created["entities"], entities)
+
+        for edited_text, edited_entities in [
+            (text, [{"offset": 3, "length": 5, "type": {"@type": "textEntityTypeBold"}}]),
+            (text, []),
+            ("final", [{"offset": 0, "length": 5, "type": {"@type": "textEntityTypePre"}}]),
+        ]:
+            with self.subTest(text=edited_text, entities=edited_entities):
+                edited = driver.serve_update(
+                    {
+                        "@type": "updateMessageContent",
+                        "chat_id": -1001,
+                        "message_id": message_id,
+                        "new_content": {
+                            "@type": "messageText",
+                            "text": {
+                                "@type": "formattedText",
+                                "text": edited_text,
+                                "entities": edited_entities,
+                            },
+                        },
+                    },
+                    users,
+                    known,
+                )
+                self.assertEqual(edited["kind"], "edit")
+                self.assertEqual(edited["text"], edited_text)
+                self.assertEqual(edited["entities"], edited_entities)
+                self.assertEqual(edited["senderId"], 101)
+                self.assertEqual(known[message_id]["entities"], edited_entities)
+
+    def test_preserves_caption_entities_in_messages_and_edits(self):
+        entities = [{"offset": 3, "length": 5, "type": {"@type": "textEntityTypeCode"}}]
+        message = {
+            "id": 43 << 20,
+            "chat_id": -1001,
+            "sender_id": {"user_id": 101},
+            "date": 123,
+            "content": {
+                "@type": "messagePhoto",
+                "caption": {"@type": "formattedText", "text": "😀 a   b", "entities": entities},
+            },
+        }
+        known = {}
+        created = driver.serve_update(
+            {"@type": "updateNewMessage", "message": message}, {}, known
+        )
+        normalized = driver.normalize_message(message)
+        self.assertEqual(created["text"], "😀 a   b")
+        self.assertEqual(created["entities"], entities)
+        self.assertEqual(normalized["entities"], entities)
+        self.assertIs(normalized["raw"], message)
+        edited = driver.serve_update(
+            {
+                "@type": "updateMessageContent",
+                "message_id": message["id"],
+                "new_content": {
+                    "@type": "messagePhoto",
+                    "caption": {"@type": "formattedText", "text": "😀 a   b", "entities": []},
+                },
+            },
+            {},
+            known,
+        )
+        self.assertEqual(edited["text"], "😀 a   b")
+        self.assertEqual(edited["entities"], [])
+
+    def test_requires_explicit_entity_vectors_for_text_and_captions(self):
+        for content_type, field in [("messageText", "text"), ("messagePhoto", "caption")]:
+            for kind in ("message", "edit"):
+                with self.subTest(content_type=content_type, kind=kind):
+                    formatted = {"@type": "formattedText", "text": "plain", "entities": []}
+                    content = {"@type": content_type, field: formatted}
+                    message = {
+                        "id": 44 << 20,
+                        "chat_id": -1001,
+                        "sender_id": {"user_id": 101},
+                        "content": content,
+                    }
+                    known = {}
+                    created = driver.serve_update(
+                        {"@type": "updateNewMessage", "message": message}, {}, known
+                    )
+                    self.assertEqual(created["text"], "plain")
+                    self.assertEqual(created["entities"], [])
+
+                    del formatted["entities"]
+                    update = (
+                        {"@type": "updateNewMessage", "message": message}
+                        if kind == "message"
+                        else {
+                            "@type": "updateMessageContent",
+                            "chat_id": -1001,
+                            "message_id": message["id"],
+                            "new_content": content,
+                        }
+                    )
+                    with self.assertRaisesRegex(KeyError, "entities"):
+                        driver.serve_update(update, {}, known)
+                    self.assertEqual(known[message["id"]]["entities"], [])
 
     def test_ignores_unknown_edit_in_serve_mode(self):
         event = driver.serve_update(

--- a/extensions/googlechat/src/api.fetchok.transport.test.ts
+++ b/extensions/googlechat/src/api.fetchok.transport.test.ts
@@ -1,4 +1,4 @@
-// Exercise Google Chat status-only requests through a real guarded HTTP transport.
+// Exercise Google Chat requests through a real guarded HTTP transport.
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -23,6 +23,9 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
     fetchWithSsrFGuard: async (...args: Parameters<typeof actual.fetchWithSsrFGuard>) => {
       fetchWithSsrFGuardMock(...args);
       const [params] = args;
+      if (!loopback.baseUrl || new URL(params.url).origin !== "https://chat.googleapis.com") {
+        throw new Error("Unexpected request in Google Chat transport fixture");
+      }
       const guarded = await actual.fetchWithSsrFGuard({
         ...params,
         url: params.url.replace("https://chat.googleapis.com", loopback.baseUrl),
@@ -59,7 +62,8 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   };
 });
 
-vi.mock("./auth.js", () => ({
+vi.mock("./auth.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./auth.js")>()),
   getGoogleChatAccessToken: vi.fn(async () => proofToken),
 }));
 
@@ -116,7 +120,7 @@ async function withinDeadline<T>(promise: Promise<T>, timeoutMs = 2_000): Promis
   }
 }
 
-describe("deleteGoogleChatMessage real guarded transport", () => {
+describe("Google Chat real guarded transport", () => {
   beforeAll(async () => {
     ({ deleteGoogleChatMessage, sendGoogleChatMessage } = await import("./api.js"));
   });
@@ -132,6 +136,86 @@ describe("deleteGoogleChatMessage real guarded transport", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("delivers task-list fallback at the default chunk limit through the SDK", async () => {
+    const { withOpenClawTestState } = await import("openclaw/plugin-sdk/test-state");
+    await withOpenClawTestState(
+      { label: "googlechat-markdown-delivery", layout: "state-only" },
+      async () => {
+        const [
+          { sendDurableMessageBatch },
+          { createTestRegistry, withPluginRuntimeRegistryScope },
+          { googlechatPlugin },
+        ] = await Promise.all([
+          import("openclaw/plugin-sdk/channel-outbound"),
+          import("openclaw/plugin-sdk/channel-test-helpers"),
+          import("../api.js"),
+        ]);
+        const requests: Array<{
+          method: string | undefined;
+          path: string | undefined;
+          body: string;
+        }> = [];
+        const server = createServer((request, response) => {
+          let body = "";
+          request.setEncoding("utf8");
+          request.on("data", (chunk: string) => {
+            body += chunk;
+          });
+          request.on("end", () => {
+            requests.push({ method: request.method, path: request.url, body });
+            response.writeHead(200, { "Content-Type": "application/json" });
+            response.end(JSON.stringify({ name: `spaces/AAA/messages/${requests.length}` }));
+          });
+        });
+
+        try {
+          loopback.baseUrl = await listen(server);
+          const paragraph = "A".repeat(31_998);
+          const result = await withPluginRuntimeRegistryScope(
+            createTestRegistry([
+              { pluginId: "googlechat", plugin: googlechatPlugin, source: "test" },
+            ]),
+            () =>
+              sendDurableMessageBatch({
+                cfg: {
+                  channels: {
+                    googlechat: {
+                      serviceAccount: {
+                        client_email: "transport@example.test",
+                        private_key: "not-a-real-key",
+                      },
+                    },
+                  },
+                },
+                channel: "googlechat",
+                accountId: "default",
+                to: "spaces/AAA",
+                payloads: [{ text: `**${paragraph}**\n\n- [x] done` }],
+              }),
+          );
+          expect(result).toMatchObject({
+            status: "sent",
+            deliveryIntent: { queuePolicy: "required" },
+            receipt: {
+              platformMessageIds: ["spaces/AAA/messages/1", "spaces/AAA/messages/2"],
+            },
+          });
+          expect(requests.map(({ method, path }) => ({ method, path }))).toEqual([
+            { method: "POST", path: "/v1/spaces/AAA/messages" },
+            { method: "POST", path: "/v1/spaces/AAA/messages" },
+          ]);
+          const messages: Array<{ text: string }> = requests.map(({ body }) => JSON.parse(body));
+          expect(messages).toEqual([{ text: `*${paragraph}*` }, { text: "\n\n[x] done" }]);
+          expect(messages.every(({ text }) => Buffer.byteLength(text, "utf8") <= 32_000)).toBe(
+            true,
+          );
+        } finally {
+          await closeServer(server);
+        }
+      },
+    );
   });
 
   it("rejects malformed UTF-8 JSON through the real guarded transport", async () => {

--- a/extensions/googlechat/src/format.test.ts
+++ b/extensions/googlechat/src/format.test.ts
@@ -215,3 +215,26 @@ describe("formatGoogleChatText", () => {
     });
   });
 });
+
+describe("Google Chat semantic whitespace", () => {
+  it.each([
+    { name: "standalone fenced block", prefix: "", expected: ["```\n \n```"] },
+    {
+      name: "fenced block after a full default-limit paragraph",
+      prefix: "A".repeat(32_000) + "\n\n",
+      expected: ["A".repeat(32_000), "\n\n```\n \n```"],
+    },
+  ])("preserves semantic whitespace: $name", ({ prefix, expected }) => {
+    const chunks = formatGoogleChatTextChunks(prefix + "```\n \n```");
+    expect(chunks).toEqual(expected);
+    expect(chunks.every((chunk) => Buffer.byteLength(chunk, "utf8") <= 32_000)).toBe(true);
+  });
+});
+
+it("preserves task-list fallback when semantic whitespace joins the next chunk", () => {
+  const paragraph = "A".repeat(31_998);
+  const chunks = formatGoogleChatTextChunks(`**${paragraph}**\n\n- [x] done`);
+
+  expect(chunks).toEqual([`*${paragraph}*`, "\n\n[x] done"]);
+  expect(chunks.every((chunk) => Buffer.byteLength(chunk, "utf8") <= 32_000)).toBe(true);
+});

--- a/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts
@@ -60,6 +60,32 @@ const credential = {
   tdlibVersion: "1.8.67",
 } as const;
 
+async function prepareMessageReader(
+  adapter: Awaited<ReturnType<typeof createTelegramQaTransportAdapter>>,
+) {
+  const stateRoot = mocks.createStateRoot.mock.results.at(-1)?.value;
+  const prepared = await adapter.prepareFlow?.({
+    config: {},
+    scenarioId: "telegram-entities",
+    scenarioTitle: "Telegram native entities",
+    gateway: {
+      baseUrl: "http://127.0.0.1:1234",
+      tempRoot: stateRoot,
+      workspaceDir: stateRoot,
+      runtimeEnv: {},
+      call: vi.fn(),
+    },
+    waitForConfigRestartSettle: vi.fn(),
+    outputDir: stateRoot,
+    timeoutMs: 30_000,
+  });
+  const read = prepared?.readTelegramMessages;
+  if (typeof read !== "function") {
+    throw new Error("Telegram flow did not expose native message observations");
+  }
+  return read;
+}
+
 describe("Telegram QA transport adapter", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -158,7 +184,7 @@ describe("Telegram QA transport adapter", () => {
     await adapter.cleanupAfterGatewayStop?.();
   });
 
-  it("maps sends, replies, messages, and edits through one userbot process", async () => {
+  it("maps sends, replies, messages, and formatting edits through one userbot process", async () => {
     let onUpdate: ((update: unknown) => Promise<void>) | undefined;
     mocks.userbotStart.mockImplementation(async (params) => {
       onUpdate = params.onUpdate;
@@ -168,18 +194,21 @@ describe("Telegram QA transport adapter", () => {
         send: mocks.userbotSend,
       };
     });
+    const preview = {
+      kind: "message",
+      chatId: -100123,
+      messageId: 11,
+      botApiMessageId: 11,
+      senderId: 200,
+      senderUsername: "sut_bot",
+      replyToMessageId: 10,
+      timestamp: 100_000,
+      text: "😀 a   b",
+      entities: [{ offset: 3, length: 5, type: { "@type": "textEntityTypeCode" } }],
+    };
     mocks.userbotSend
       .mockImplementationOnce(async () => {
-        await onUpdate?.({
-          kind: "message",
-          chatId: -100123,
-          messageId: 11,
-          senderId: 200,
-          senderUsername: "sut_bot",
-          replyToMessageId: 10,
-          timestamp: 100_000,
-          text: "preview",
-        });
+        await onUpdate?.(preview);
         return { messageId: 10 };
       })
       .mockResolvedValueOnce({ messageId: 12 });
@@ -190,56 +219,71 @@ describe("Telegram QA transport adapter", () => {
       adapterOptions: {},
       messages: { addInboundMessage, addOutboundMessage, editMessage },
     } as never);
+    try {
+      await adapter.sendInbound?.({
+        conversation: { id: "logical-room", kind: "group" },
+        senderId: "driver",
+        text: "@openclaw reply exactly: QA-MARKER",
+      });
+      expect(mocks.userbotSend).toHaveBeenCalledWith({
+        text: "@sut_bot reply exactly: QA-MARKER",
+        replyToMessageId: undefined,
+      });
+      expect(addInboundMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ accountId: "sut", senderId: "100" }),
+      );
+      expect(addOutboundMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: "group:logical-room",
+          text: preview.text,
+          replyToId: "in-1",
+        }),
+      );
+      const readMessages = await prepareMessageReader(adapter);
+      const firstSnapshot = readMessages();
+      expect(firstSnapshot).toEqual([preview]);
+      firstSnapshot[0].entities[0].type["@type"] = "textEntityTypeBold";
+      expect(readMessages()).toEqual([preview]);
 
-    await adapter.sendInbound?.({
-      conversation: { id: "logical-room", kind: "group" },
-      senderId: "driver",
-      text: "@openclaw reply exactly: QA-MARKER",
-    });
-    expect(mocks.userbotSend).toHaveBeenCalledWith({
-      text: "@sut_bot reply exactly: QA-MARKER",
-      replyToMessageId: undefined,
-    });
-    expect(addInboundMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ accountId: "sut", senderId: "100" }),
-    );
+      await adapter.sendInbound?.({
+        conversation: { id: "logical-room", kind: "group" },
+        senderId: "driver",
+        text: "follow-up",
+        replyToId: "out-1",
+      });
+      expect(mocks.userbotSend).toHaveBeenLastCalledWith({
+        text: "follow-up",
+        replyToMessageId: 11,
+      });
+      const edited = {
+        ...preview,
+        kind: "edit",
+        timestamp: 101_000,
+        entities: [{ offset: 3, length: 5, type: { "@type": "textEntityTypeBold" } }],
+      };
+      await onUpdate?.(edited);
+      expect(editMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ messageId: "out-1", text: preview.text, timestamp: 101_000 }),
+      );
+      expect(readMessages()).toEqual([edited]);
+      await onUpdate?.({ ...edited, text: "final", entities: [] });
+      expect(readMessages()).toEqual([{ ...edited, text: "final", entities: [] }]);
 
-    expect(addOutboundMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: "group:logical-room",
-        text: "preview",
-        replyToId: "in-1",
-      }),
-    );
-
-    await adapter.sendInbound?.({
-      conversation: { id: "logical-room", kind: "group" },
-      senderId: "driver",
-      text: "follow-up",
-      replyToId: "out-1",
-    });
-    expect(mocks.userbotSend).toHaveBeenLastCalledWith({
-      text: "follow-up",
-      replyToMessageId: 11,
-    });
-
-    await onUpdate?.({
-      kind: "edit",
-      chatId: -100123,
-      messageId: 11,
-      senderId: 200,
-      timestamp: 101_000,
-      text: "final",
-    });
-    expect(editMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ messageId: "out-1", text: "final", timestamp: 101_000 }),
-    );
-
-    await adapter.cleanup?.();
-    await adapter.cleanupAfterGatewayStop?.();
+      mocks.heartbeatThrowIfFailed.mockImplementationOnce(() => {
+        throw new Error("lease revoked");
+      });
+      expect(() => readMessages()).toThrow("lease revoked");
+      mocks.userbotAssertHealthy.mockImplementationOnce(() => {
+        throw new Error("Telegram userbot is closed.");
+      });
+      expect(() => readMessages()).toThrow("Telegram userbot is closed.");
+    } finally {
+      await adapter.cleanup?.();
+      await adapter.cleanupAfterGatewayStop?.();
+    }
   });
 
-  it("filters other updates and resets diagnostics without native values", async () => {
+  it("filters other updates and resets diagnostics and native observations", async () => {
     let onUpdate: ((update: unknown) => Promise<void>) | undefined;
     mocks.userbotStart.mockImplementation(async (params) => {
       onUpdate = params.onUpdate;
@@ -254,35 +298,36 @@ describe("Telegram QA transport adapter", () => {
       adapterOptions: {},
       messages: { addOutboundMessage },
     } as never);
+    try {
+      const matched = {
+        kind: "edit",
+        chatId: -100123,
+        messageId: 78,
+        senderId: 200,
+        timestamp: 101_000,
+        text: "matched",
+        entities: [{ offset: 0, length: 7, type: { "@type": "textEntityTypeBold" } }],
+      };
+      await onUpdate?.({ ...matched, kind: "message", chatId: -100999, messageId: 77 });
+      await onUpdate?.({ ...matched, kind: "message", senderId: 201, messageId: 79 });
+      await onUpdate?.(matched);
 
-    await onUpdate?.({
-      kind: "message",
-      chatId: -100999,
-      messageId: 77,
-      senderId: 200,
-      timestamp: 100_000,
-      text: "wrong chat",
-    });
-    await onUpdate?.({
-      kind: "edit",
-      chatId: -100123,
-      messageId: 78,
-      senderId: 200,
-      timestamp: 101_000,
-      text: "matched",
-    });
+      const diagnostics = adapter.describeTransportState?.() ?? "";
+      expect(diagnostics).toContain("updates=3");
+      expect(diagnostics).toContain("filtered=2");
+      expect(diagnostics).toContain("matched=1");
+      expect(diagnostics).toContain("update kinds=[message,edit]");
+      expect(diagnostics).not.toMatch(/-100123|77|78|79/u);
+      const readMessages = await prepareMessageReader(adapter);
+      expect(readMessages()).toEqual([matched]);
 
-    const diagnostics = adapter.describeTransportState?.() ?? "";
-    expect(diagnostics).toContain("updates=2");
-    expect(diagnostics).toContain("filtered=1");
-    expect(diagnostics).toContain("matched=1");
-    expect(diagnostics).toContain("update kinds=[message,edit]");
-    expect(diagnostics).not.toMatch(/-100123|77|78|wrong chat/u);
-
-    await adapter.resetTransport?.();
-    expect(adapter.describeTransportState?.()).toContain("updates=0");
-    await adapter.cleanup?.();
-    await adapter.cleanupAfterGatewayStop?.();
+      await adapter.resetTransport?.();
+      expect(adapter.describeTransportState?.()).toContain("updates=0");
+      expect(readMessages()).toEqual([]);
+    } finally {
+      await adapter.cleanup?.();
+      await adapter.cleanupAfterGatewayStop?.();
+    }
   });
 
   it("releases the lease when userbot startup fails", async () => {

--- a/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
@@ -115,19 +115,20 @@ export async function createTelegramQaTransportAdapter(
   let logicalConversationId = credentialLease.payload.groupId;
   let logicalConversationKind: "channel" | "direct" | "group" = "channel";
   const nativeMessageIds = new Map<string, number>();
-  const busMessageIds = new Map<number, string>();
+  const busMessages = new Map<number, { id: string; update?: TelegramUserbotUpdate }>();
   let sendsInFlight = 0;
   let deferredReplies: TelegramUserbotUpdate[] = [];
 
   const publishUpdate = async (update: TelegramUserbotUpdate) => {
-    const existingMessageId = busMessageIds.get(update.messageId);
-    if (update.kind === "edit" && existingMessageId) {
+    const existing = busMessages.get(update.messageId);
+    if (update.kind === "edit" && existing) {
       await context.messages.editMessage({
         accountId,
-        messageId: existingMessageId,
+        messageId: existing.id,
         text: update.text,
         timestamp: update.timestamp,
       });
+      existing.update = update;
       return;
     }
     const outbound = await context.messages.addOutboundMessage({
@@ -137,10 +138,10 @@ export async function createTelegramQaTransportAdapter(
       senderName: update.senderUsername,
       text: update.text,
       timestamp: update.timestamp,
-      replyToId: update.replyToMessageId ? busMessageIds.get(update.replyToMessageId) : undefined,
+      replyToId: update.replyToMessageId ? busMessages.get(update.replyToMessageId)?.id : undefined,
     });
     nativeMessageIds.set(outbound.id, update.messageId);
-    busMessageIds.set(update.messageId, outbound.id);
+    busMessages.set(update.messageId, { id: outbound.id, update });
   };
 
   const observeUpdate = async (update: TelegramUserbotUpdate) => {
@@ -154,11 +155,7 @@ export async function createTelegramQaTransportAdapter(
       return;
     }
     observerState.matchedCount += 1;
-    if (
-      sendsInFlight > 0 &&
-      update.replyToMessageId &&
-      !busMessageIds.has(update.replyToMessageId)
-    ) {
+    if (sendsInFlight > 0 && update.replyToMessageId && !busMessages.has(update.replyToMessageId)) {
       deferredReplies.push(update);
       return;
     }
@@ -239,9 +236,9 @@ export async function createTelegramQaTransportAdapter(
           senderId: credentialLease.payload.testerUserId,
         });
         nativeMessageIds.set(message.id, sent.messageId);
-        busMessageIds.set(sent.messageId, message.id);
+        busMessages.set(sent.messageId, { id: message.id });
         const readyReplies = deferredReplies.filter(
-          (update) => update.replyToMessageId && busMessageIds.has(update.replyToMessageId),
+          (update) => update.replyToMessageId && busMessages.has(update.replyToMessageId),
         );
         deferredReplies = deferredReplies.filter((update) => !readyReplies.includes(update));
         for (const update of readyReplies) {
@@ -256,12 +253,24 @@ export async function createTelegramQaTransportAdapter(
       logicalConversationId = credentialLease.payload.groupId;
       logicalConversationKind = "channel";
       nativeMessageIds.clear();
-      busMessageIds.clear();
+      busMessages.clear();
       deferredReplies = [];
       observerState.updateCount = 0;
       observerState.filteredCount = 0;
       observerState.matchedCount = 0;
       observerState.relevantUpdateKinds.clear();
+    },
+    async prepareFlow() {
+      return {
+        readTelegramMessages: () => {
+          activeUserbot.assertHealthy();
+          heartbeat.throwIfFailed();
+          // Share the existing message lifetime; readers cannot mutate a later snapshot.
+          return [...busMessages.values()].flatMap(({ update }) =>
+            update ? [structuredClone(update)] : [],
+          );
+        },
+      };
     },
     createGatewayConfig: () =>
       buildTelegramQaConfig({} as OpenClawConfig, {

--- a/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.test.ts
@@ -20,20 +20,35 @@ afterEach(() => {
 });
 
 describe("Telegram userbot driver runtime", () => {
-  it("keeps one process for commands and streamed updates", async () => {
+  it("keeps one process for commands and streamed formatting edits", async () => {
     const scriptPath = path.join(tempRoot(), "fake-user-driver.py");
+    const text = "😀 a   b x";
+    const entities = [
+      { offset: 3, length: 5, type: { "@type": "textEntityTypeCode" } },
+      {
+        offset: 9,
+        length: 1,
+        type: { "@type": "textEntityTypeTextUrl", url: "https://example.com/qa" },
+      },
+    ];
+    const editedEntities = [{ offset: 3, length: 5, type: { "@type": "textEntityTypeBold" } }];
     fs.writeFileSync(
       scriptPath,
       [
         "import json",
         "import sys",
+        `entities = json.loads(${JSON.stringify(JSON.stringify(entities))})`,
+        `edited_entities = json.loads(${JSON.stringify(JSON.stringify(editedEntities))})`,
         "print(json.dumps({'type':'ready','chatId':-1001,'user':{'id':100}}), flush=True)",
         "for line in sys.stdin:",
         "    request = json.loads(line)",
         "    message_id = 10 + int(request['id'])",
-        "    update = {'kind':'message','chatId':-1001,'messageId':message_id + 1,'senderId':200,'timestamp':1000,'text':'reply'}",
+        "    update = {'kind':'message','chatId':-1001,'messageId':message_id + 1,'senderId':200,'timestamp':1000,'text':request['text'],'entities':entities}",
         "    print(json.dumps({'type':'update','update':update}), flush=True)",
-        "    result = {'chatId':-1001,'messageId':message_id,'senderId':100,'timestamp':1000,'text':request['text']}",
+        "    for replacement in [edited_entities, []]:",
+        "        update = {**update, 'kind':'edit', 'entities':replacement}",
+        "        print(json.dumps({'type':'update','update':update}), flush=True)",
+        "    result = {'chatId':-1001,'messageId':message_id,'senderId':100,'timestamp':1000,'text':request['text'],'entities':entities}",
         "    print(json.dumps({'type':'response','id':request['id'],'result':result}), flush=True)",
       ].join("\n"),
     );
@@ -48,17 +63,106 @@ describe("Telegram userbot driver runtime", () => {
         updates.push(update);
       },
     });
+    try {
+      await expect(driver.send({ text })).resolves.toMatchObject({
+        messageId: 11,
+        senderId: 100,
+        text,
+        entities,
+      });
+      await vi.waitFor(() => expect(updates).toHaveLength(3));
+      expect(updates).toMatchObject([
+        { kind: "message", messageId: 12, senderId: 200, text, entities },
+        { kind: "edit", messageId: 12, text, entities: editedEntities },
+        { kind: "edit", messageId: 12, text, entities: [] },
+      ]);
+      expect(() => driver.assertHealthy()).not.toThrow();
+    } finally {
+      await driver.close();
+    }
+  });
 
-    await expect(driver.send({ text: "hello" })).resolves.toMatchObject({
+  it.each([
+    { name: "missing entities", entities: undefined, streamed: false },
+    { name: "non-array entities", entities: {}, streamed: false },
+    { name: "non-object entity", entities: [null], streamed: false },
+    {
+      name: "negative offset",
+      entities: [{ offset: -1, length: 1, type: { "@type": "textEntityTypeCode" } }],
+      streamed: false,
+    },
+    {
+      name: "fractional length",
+      entities: [{ offset: 3, length: 1.5, type: { "@type": "textEntityTypeCode" } }],
+      streamed: false,
+    },
+    {
+      name: "empty range",
+      entities: [{ offset: 3, length: 0, type: { "@type": "textEntityTypeCode" } }],
+      streamed: false,
+    },
+    {
+      name: "range past the text",
+      entities: [{ offset: 3, length: 8, type: { "@type": "textEntityTypeCode" } }],
+      streamed: true,
+    },
+    {
+      name: "start inside a surrogate pair",
+      entities: [{ offset: 1, length: 1, type: { "@type": "textEntityTypeCode" } }],
+      streamed: true,
+    },
+    {
+      name: "end inside a surrogate pair",
+      entities: [{ offset: 0, length: 1, type: { "@type": "textEntityTypeCode" } }],
+      streamed: false,
+    },
+    {
+      name: "missing entity type",
+      entities: [{ offset: 3, length: 1, type: {} }],
+      streamed: true,
+    },
+  ])("rejects $name at the child protocol boundary", async ({ entities, streamed }) => {
+    const scriptPath = path.join(tempRoot(), "invalid-entity-driver.py");
+    const message = {
+      chatId: -1001,
       messageId: 11,
       senderId: 100,
-      text: "hello",
+      timestamp: 1000,
+      text: "😀 a   b x",
+      entities,
+    };
+    fs.writeFileSync(
+      scriptPath,
+      [
+        "import json",
+        "import sys",
+        `result = json.loads(${JSON.stringify(JSON.stringify(message))})`,
+        "print(json.dumps({'type':'ready','chatId':-1001,'user':{'id':100}}), flush=True)",
+        "for line in sys.stdin:",
+        "    request = json.loads(line)",
+        ...(streamed
+          ? [
+              "    print(json.dumps({'type':'update','update':{**result, 'kind':'message'}}), flush=True)",
+              "    result = {**result, 'entities':[]}",
+            ]
+          : []),
+        "    print(json.dumps({'type':'response','id':request['id'],'result':result}), flush=True)",
+      ].join("\n"),
+    );
+    const onUpdate = vi.fn();
+    const driver = await TelegramUserbotDriver.start({
+      chatId: "-1001",
+      driverEnv: {},
+      leaseHealth: { assertHealthy() {}, whenUnhealthy: new Promise<Error>(() => {}) },
+      userDriverPath: scriptPath,
+      onUpdate,
     });
-    await vi.waitFor(() => expect(updates).toHaveLength(1));
-    expect(updates[0]).toMatchObject({ messageId: 12, senderId: 200, text: "reply" });
-    expect(() => driver.assertHealthy()).not.toThrow();
-
-    await driver.close();
+    try {
+      await expect(driver.send({ text: message.text })).rejects.toThrow(/invalid entit/u);
+      expect(onUpdate).not.toHaveBeenCalled();
+    } finally {
+      await driver.close();
+    }
   });
 
   it("stops a delayed TDLib send before its final effect after lease loss", async () => {

--- a/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.ts
@@ -3,7 +3,14 @@ import readline from "node:readline";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
+type TelegramTextEntity = {
+  offset: number;
+  length: number;
+  type: Record<string, unknown> & { "@type": string };
+};
+
 export type TelegramUserbotUpdate = {
+  entities: TelegramTextEntity[];
   botApiMessageId?: number;
   chatId: number;
   kind: "edit" | "message";
@@ -14,6 +21,42 @@ export type TelegramUserbotUpdate = {
   text: string;
   timestamp: number;
 };
+
+function isUtf16Boundary(text: string, offset: number) {
+  const before = text.charCodeAt(offset - 1);
+  const after = text.charCodeAt(offset);
+  return !(before >= 0xd800 && before <= 0xdbff && after >= 0xdc00 && after <= 0xdfff);
+}
+
+function parseTextEntities(value: unknown, text: string): TelegramTextEntity[] {
+  if (!Array.isArray(value)) {
+    throw new Error("Telegram userbot update has invalid entities.");
+  }
+  return value.map((entity: unknown) => {
+    if (!isRecord(entity)) {
+      throw new Error("Telegram userbot update has an invalid entity.");
+    }
+    const { offset, length, type } = entity;
+    // TDLib counts UTF-16 units; accepting a split surrogate would corrupt the observed range.
+    if (
+      typeof offset !== "number" ||
+      !Number.isInteger(offset) ||
+      offset < 0 ||
+      typeof length !== "number" ||
+      !Number.isInteger(length) ||
+      length <= 0 ||
+      offset + length > text.length ||
+      !isUtf16Boundary(text, offset) ||
+      !isUtf16Boundary(text, offset + length) ||
+      !isRecord(type) ||
+      typeof type["@type"] !== "string" ||
+      !type["@type"]
+    ) {
+      throw new Error("Telegram userbot update has an invalid entity.");
+    }
+    return { offset, length, type: { ...type, "@type": type["@type"] } };
+  });
+}
 
 function parseUserbotUpdate(value: unknown): TelegramUserbotUpdate {
   if (!isRecord(value)) {
@@ -42,6 +85,7 @@ function parseUserbotUpdate(value: unknown): TelegramUserbotUpdate {
     senderId,
     timestamp,
     text: value.text,
+    entities: parseTextEntities(value.entities, value.text),
     ...(typeof value.botApiMessageId === "number"
       ? { botApiMessageId: value.botApiMessageId }
       : {}),

--- a/packages/markdown-core/src/construct-fallbacks.ts
+++ b/packages/markdown-core/src/construct-fallbacks.ts
@@ -7,7 +7,7 @@ import {
   type MarkdownStyle,
   type MarkdownStyleSpan,
 } from "./ir-spans.js";
-import { sliceMarkdownIR, type MarkdownIR } from "./ir.js";
+import { appendMarkdownIR, sliceMarkdownIR, type MarkdownIR } from "./ir.js";
 
 type TextEdit = { start: number; end: number; text: string };
 
@@ -101,29 +101,6 @@ function collectListFallbacks(ir: MarkdownIR, profile: FormatCapabilityProfile):
   return edits;
 }
 
-// sliceMarkdownIR owns the spans passed here; transfer them without another copy.
-function appendSpans<T extends { start: number; end: number }>(
-  into: T[],
-  spans: T[],
-  offset: number,
-): void {
-  for (const span of spans) {
-    span.start = offset + span.start;
-    span.end = offset + span.end;
-    into.push(span);
-  }
-}
-
-function appendSlice(target: MarkdownIR, source: MarkdownIR): void {
-  const offset = target.text.length;
-  target.text += source.text;
-  appendSpans(target.styles, source.styles, offset);
-  appendSpans(target.links, source.links, offset);
-  if (source.annotations?.length) {
-    appendSpans((target.annotations ??= []), source.annotations, offset);
-  }
-}
-
 function applyTextEdits(ir: MarkdownIR, edits: TextEdit[]): MarkdownIR {
   if (edits.length === 0) {
     return ir;
@@ -144,11 +121,11 @@ function applyTextEdits(ir: MarkdownIR, edits: TextEdit[]): MarkdownIR {
   const result: MarkdownIR = { text: "", styles: [], links: [] };
   let cursor = 0;
   for (const edit of ordered) {
-    appendSlice(result, sliceMarkdownIR(content, cursor, edit.start));
+    appendMarkdownIR(result, sliceMarkdownIR(content, cursor, edit.start));
     result.text += edit.text;
     cursor = edit.end;
   }
-  appendSlice(result, sliceMarkdownIR(content, cursor, ir.text.length));
+  appendMarkdownIR(result, sliceMarkdownIR(content, cursor, ir.text.length));
   result.styles = mergeStyleSpans(result.styles);
   if (result.annotations) {
     result.annotations = mergeAnnotationSpans(result.annotations);

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -1495,6 +1495,51 @@ function closeRemainingStyles(target: RenderTarget) {
   target.openStyles = [];
 }
 
+function appendSpans<T extends { start: number; end: number }>(
+  into: T[],
+  spans: T[],
+  offset: number,
+): void {
+  for (const span of spans) {
+    span.start += offset;
+    span.end += offset;
+    into.push(span);
+  }
+}
+
+/** Transfers a separately owned IR slice, including its metadata, into an accumulator. */
+export function appendMarkdownIR(target: MarkdownIR, source: MarkdownIR): void {
+  const offset = target.text.length;
+  target.text += source.text;
+  appendSpans(target.styles, source.styles, offset);
+  appendSpans(target.links, source.links, offset);
+  if (source.annotations?.length) {
+    appendSpans((target.annotations ??= []), source.annotations, offset);
+  }
+  for (const item of (source.listItems ?? []) as MarkdownListItemWithMetadata[]) {
+    for (const marker of [item.listMarker, item.taskMarker]) {
+      if (marker) {
+        marker.start += offset;
+        marker.end += offset;
+      }
+    }
+    // Source-coordinate metadata stays anchored to the authored Markdown.
+    for (const key of ["start", "end", "contentStart", "contentEnd"] as const) {
+      const value = item[key];
+      if (value !== undefined) {
+        item[key] = value + offset;
+      }
+    }
+    (target.listItems ??= []).push(item);
+  }
+  const sourceBlocks = (source as MarkdownIRWithMetadata).blocks;
+  if (sourceBlocks?.length) {
+    const blocks = (target as MarkdownIRWithMetadata).blocks ?? [];
+    appendSpans(blocks, sourceBlocks, offset);
+    attachBlockMetadata(target, blocks);
+  }
+}
+
 function sliceListMarker(
   marker: { start: number; end: number },
   start: number,

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -1516,7 +1516,8 @@ export function appendMarkdownIR(target: MarkdownIR, source: MarkdownIR): void {
   if (source.annotations?.length) {
     appendSpans((target.annotations ??= []), source.annotations, offset);
   }
-  for (const item of (source.listItems ?? []) as MarkdownListItemWithMetadata[]) {
+  const listItems: MarkdownListItemWithMetadata[] = source.listItems ?? [];
+  for (const item of listItems) {
     for (const marker of [item.listMarker, item.taskMarker]) {
       if (marker) {
         marker.start += offset;
@@ -1532,10 +1533,11 @@ export function appendMarkdownIR(target: MarkdownIR, source: MarkdownIR): void {
     }
     (target.listItems ??= []).push(item);
   }
-  const sourceBlocks = (source as MarkdownIRWithMetadata).blocks;
-  if (sourceBlocks?.length) {
-    const blocks = (target as MarkdownIRWithMetadata).blocks ?? [];
-    appendSpans(blocks, sourceBlocks, offset);
+  const sourceWithMetadata: MarkdownIRWithMetadata = source;
+  if (sourceWithMetadata.blocks?.length) {
+    const targetWithMetadata: MarkdownIRWithMetadata = target;
+    const blocks = targetWithMetadata.blocks ?? [];
+    appendSpans(blocks, sourceWithMetadata.blocks, offset);
     attachBlockMetadata(target, blocks);
   }
 }

--- a/packages/markdown-core/src/render-aware-chunking.test.ts
+++ b/packages/markdown-core/src/render-aware-chunking.test.ts
@@ -361,3 +361,67 @@ it("suppresses semantic whitespace when attributed rendering trims it away", () 
     }),
   ).toEqual([]);
 });
+
+describe("authored links across coalesced whitespace", () => {
+  const href = "https://example.test";
+  const paragraph = "A".repeat(78);
+  const attributedProfile = FormatCapabilityProfile.define({
+    mechanism: "ranges",
+    constructs: { linkLabel: "fallback" },
+    chunk: { limit: 80, unit: "chars" },
+  });
+
+  it.each([
+    {
+      name: "one authored link across retained whitespace",
+      markdown: `[alpha${" ".repeat(80)}omega](${href})`,
+      attributed: false,
+      expected: [
+        `<a href="${href}">alpha${" ".repeat(40)}</a>`,
+        `<a href="${href}">${" ".repeat(40)}omega</a>`,
+      ],
+      linkCounts: [1, 1],
+    },
+    {
+      name: "two adjacent authored links with the same URL",
+      markdown: `**${paragraph}**\n\n[a](${href})[b](${href})`,
+      attributed: false,
+      expected: [`*${paragraph}*`, `\n\n<a href="${href}">a</a><a href="${href}">b</a>`],
+      linkCounts: [0, 2],
+    },
+    {
+      name: "one authored link across trimmed whitespace",
+      markdown: `[alpha${" ".repeat(240)}omega](${href})`,
+      attributed: true,
+      expected: [`alpha (${href})`, `omega (${href})`],
+      linkCounts: [1, 1],
+    },
+  ])("preserves $name", ({ markdown, attributed, expected, linkCounts }) => {
+    const chunks = renderMarkdownIRChunksWithinLimit({
+      ir: markdownToIR(markdown),
+      limit: 80,
+      renderChunk: (chunk) =>
+        attributed
+          ? renderMarkdownWithAttributedRanges(
+              chunk,
+              { styleMap: {}, trimEnd: true },
+              attributedProfile,
+            ).text
+          : renderMarkdownWithMarkers(chunk, {
+              styleMarkers: { bold: { open: "*", close: "*" } },
+              escapeText: (text) => text,
+              buildLink: (link) => ({
+                start: link.start,
+                end: link.end,
+                open: `<a href="${link.href}">`,
+                close: "</a>",
+              }),
+            }),
+      measureRendered: (rendered) => rendered.length,
+    });
+
+    expect(chunks.map((chunk) => chunk.rendered)).toEqual(expected);
+    expect(chunks.map((chunk) => chunk.source.links.length)).toEqual(linkCounts);
+    expect(chunks.every((chunk) => chunk.rendered.length <= 80)).toBe(true);
+  });
+});

--- a/packages/markdown-core/src/render-aware-chunking.test.ts
+++ b/packages/markdown-core/src/render-aware-chunking.test.ts
@@ -1,7 +1,8 @@
 // Markdown Core tests cover render aware chunking behavior.
 import { describe, expect, it } from "vitest";
+import { FormatCapabilityProfile } from "./format-capabilities.js";
 import type { MarkdownIR } from "./ir.js";
-import { markdownToIR } from "./ir.js";
+import { markdownToIR, sliceMarkdownIR } from "./ir.js";
 import { renderMarkdownWithAttributedRanges } from "./render-attributed.js";
 import { renderMarkdownIRChunksWithinLimit } from "./render-aware-chunking.js";
 import { renderMarkdownWithMarkers } from "./render.js";
@@ -177,4 +178,186 @@ describe("renderMarkdownIRChunksWithinLimit", () => {
     expect(chunks).toHaveLength(1);
     expect(chunks[0]?.source.text).toBe(text);
   });
+});
+
+describe("rendered semantic whitespace", () => {
+  it.each([
+    {
+      name: "standalone fenced code",
+      source: () => markdownToIR("```\n \n```"),
+      expectedSource: {
+        text: " \n",
+        styles: [{ start: 0, end: 2, style: "code_block" }],
+        links: [],
+      },
+      expectedRendered: ["<pre><code> \n</code></pre>"],
+    },
+    {
+      name: "sliced bold content",
+      source: () => sliceMarkdownIR(markdownToIR("**a b**"), 1, 2),
+      expectedSource: { text: " ", styles: [{ start: 0, end: 1, style: "bold" }], links: [] },
+      expectedRendered: ["<b> </b>"],
+    },
+    {
+      name: "sliced authored link",
+      source: () => sliceMarkdownIR(markdownToIR("[a b](https://example.com)"), 1, 2),
+      expectedSource: {
+        text: " ",
+        styles: [],
+        links: [{ start: 0, end: 1, href: "https://example.com" }],
+      },
+      expectedRendered: ['<a href="https://example.com"> </a>'],
+    },
+    {
+      name: "sliced transcript annotation",
+      source: () =>
+        sliceMarkdownIR(
+          markdownToIR("user[Thu 2026]", { assistantTranscriptRoleHeaders: true }),
+          8,
+          9,
+        ),
+      expectedSource: {
+        text: " ",
+        styles: [],
+        links: [],
+        annotations: [
+          {
+            start: 0,
+            end: 1,
+            type: "assistant_transcript_role",
+            kind: "role_timestamp_bracket",
+            role: "user",
+          },
+        ],
+      },
+      expectedRendered: ["<code> </code>"],
+    },
+    {
+      name: "unstyled separator control",
+      source: (): MarkdownIR => ({ text: " \n", styles: [], links: [] }),
+      expectedSource: { text: " \n", styles: [], links: [] },
+      expectedRendered: [],
+    },
+    {
+      name: "nonempty fenced code control",
+      source: () => markdownToIR("```\nx\n```"),
+      expectedSource: {
+        text: "x\n",
+        styles: [{ start: 0, end: 2, style: "code_block" }],
+        links: [],
+      },
+      expectedRendered: ["<pre><code>x\n</code></pre>"],
+    },
+  ])("preserves semantic whitespace: $name", ({ source, expectedSource, expectedRendered }) => {
+    const ir = source();
+    expect(ir).toEqual(expectedSource);
+    const chunks = renderMarkdownIRChunksWithinLimit({
+      ir,
+      limit: 64,
+      renderChunk: (chunk) =>
+        renderMarkdownWithMarkers(chunk, {
+          styleMarkers: {
+            bold: { open: "<b>", close: "</b>" },
+            code_block: { open: "<pre><code>", close: "</code></pre>" },
+          },
+          annotationMarkers: { assistant_transcript_role: { open: "<code>", close: "</code>" } },
+          escapeText: (text) => text,
+          buildLink: (link) => ({
+            start: link.start,
+            end: link.end,
+            open: `<a href="${link.href}">`,
+            close: "</a>",
+          }),
+        }),
+      measureRendered: (rendered) => rendered.length,
+    });
+    expect(chunks.map((chunk) => chunk.rendered)).toEqual(expectedRendered);
+    expect(chunks.map((chunk) => chunk.source)).toEqual(
+      expectedRendered.length ? [expectedSource] : [],
+    );
+    expect(chunks.every((chunk) => chunk.rendered.length <= 64)).toBe(true);
+  });
+});
+
+it("coalesces semantic whitespace into neighboring rendered chunks", () => {
+  const text = `alpha${" ".repeat(19)}\nomega\n`;
+  const ir = markdownToIR(`\`\`\`\n${text}\`\`\``);
+  expect(ir.text).toBe(text);
+
+  const chunks = renderMarkdownIRChunksWithinLimit({
+    ir,
+    limit: 20,
+    renderChunk: (chunk) =>
+      renderMarkdownWithAttributedRanges(chunk, { styleMap: { code_block: "MONOSPACE" } }),
+    measureRendered: (rendered) => rendered.text.length,
+  });
+
+  expect(chunks.map((chunk) => chunk.rendered)).toEqual([
+    {
+      text: `alpha${" ".repeat(15)}`,
+      ranges: [{ start: 0, length: 20, style: "MONOSPACE" }],
+    },
+    {
+      text: `    \nomega\n`,
+      ranges: [{ start: 0, length: 11, style: "MONOSPACE" }],
+    },
+  ]);
+  expect(chunks.map((chunk) => chunk.source.text).join("")).toBe(text);
+});
+
+it("preserves task-list fallback while coalescing semantic whitespace", () => {
+  const paragraph = "A".repeat(18);
+  const profile = FormatCapabilityProfile.define({
+    mechanism: "markdown",
+    constructs: { taskList: "fallback" },
+    chunk: { limit: 20, unit: "chars" },
+  });
+  const chunks = renderMarkdownIRChunksWithinLimit({
+    ir: markdownToIR(`**${paragraph}**\n\n- [x] done`, { enableTaskLists: true }),
+    limit: profile.chunk.limit,
+    renderChunk: (chunk) =>
+      renderMarkdownWithMarkers(
+        chunk,
+        {
+          styleMarkers: { bold: { open: "*", close: "*" } },
+          escapeText: (text) => text,
+        },
+        profile,
+      ),
+    measureRendered: (rendered) => rendered.length,
+  });
+
+  expect(chunks.map((chunk) => chunk.rendered)).toEqual([`*${paragraph}*`, "\n\n[x] done"]);
+  expect(chunks.every((chunk) => chunk.rendered.length <= profile.chunk.limit)).toBe(true);
+});
+
+it("coalesces semantic whitespace after an earlier separator was dropped", () => {
+  const chunks = renderMarkdownIRChunksWithinLimit({
+    ir: { text: `alpha${" ".repeat(59)}\nomega`, styles: [], links: [] },
+    limit: 20,
+    renderChunk: (chunk) => chunk.text,
+    measureRendered: (rendered) => rendered.length,
+  });
+
+  expect(chunks.map((chunk) => chunk.rendered)).toEqual([`alpha${" ".repeat(15)}`, "    \nomega"]);
+});
+
+it("suppresses semantic whitespace when attributed rendering trims it away", () => {
+  const ir = markdownToIR("```\n \n```");
+  const renderChunk = (chunk: MarkdownIR) =>
+    renderMarkdownWithAttributedRanges(chunk, {
+      styleMap: { code_block: "MONOSPACE" },
+      trimEnd: true,
+    });
+
+  expect(renderChunk(ir)).toEqual({ text: "", ranges: [] });
+  expect(
+    renderMarkdownIRChunksWithinLimit({
+      ir,
+      limit: 4_000,
+      assistantTranscriptRoleMessageBoundaries: true,
+      renderChunk,
+      measureRendered: (rendered) => rendered.text.length,
+    }),
+  ).toEqual([]);
 });

--- a/packages/markdown-core/src/render-aware-chunking.test.ts
+++ b/packages/markdown-core/src/render-aware-chunking.test.ts
@@ -331,17 +331,6 @@ it("preserves task-list fallback while coalescing semantic whitespace", () => {
   expect(chunks.every((chunk) => chunk.rendered.length <= profile.chunk.limit)).toBe(true);
 });
 
-it("coalesces semantic whitespace after an earlier separator was dropped", () => {
-  const chunks = renderMarkdownIRChunksWithinLimit({
-    ir: { text: `alpha${" ".repeat(59)}\nomega`, styles: [], links: [] },
-    limit: 20,
-    renderChunk: (chunk) => chunk.text,
-    measureRendered: (rendered) => rendered.length,
-  });
-
-  expect(chunks.map((chunk) => chunk.rendered)).toEqual([`alpha${" ".repeat(15)}`, "    \nomega"]);
-});
-
 it("suppresses semantic whitespace when attributed rendering trims it away", () => {
   const ir = markdownToIR("```\n \n```");
   const renderChunk = (chunk: MarkdownIR) =>

--- a/packages/markdown-core/src/render-aware-chunking.ts
+++ b/packages/markdown-core/src/render-aware-chunking.ts
@@ -284,8 +284,8 @@ function coalesceWhitespaceOnlyMarkdownIRChunks<TRendered>(
   const coalesced: Array<RenderedCandidate<TRendered> & { ranges: SourceRange[] }> = [];
 
   pending.forEach((chunk, index) => {
-    const range = { start: chunk.start, end: chunk.end };
-    const current = { ...chunk, ranges: [range] };
+    const currentRange = { start: chunk.start, end: chunk.end };
+    const current = { ...chunk, ranges: [currentRange] };
     if (chunk.rawSource.text.trim().length > 0) {
       coalesced.push(current);
       return;
@@ -322,7 +322,7 @@ function coalesceWhitespaceOnlyMarkdownIRChunks<TRendered>(
     };
 
     if (prev) {
-      const mergedPrev = renderIfFits([...prev.ranges, range]);
+      const mergedPrev = renderIfFits([...prev.ranges, currentRange]);
       if (mergedPrev) {
         coalesced[coalesced.length - 1] = mergedPrev;
         return;

--- a/packages/markdown-core/src/render-aware-chunking.ts
+++ b/packages/markdown-core/src/render-aware-chunking.ts
@@ -2,18 +2,8 @@ import { resolveIntegerOption } from "@openclaw/normalization-core/number-coerci
 import { avoidTrailingHighSurrogateBreak } from "./chunk-text.js";
 // Markdown Core module implements render aware chunking behavior.
 import { annotateAssistantTranscriptRoleMessageBoundary } from "./ir-annotations.js";
-import {
-  copyMarkdownLinkSpan,
-  isAutoLinkedMarkdownLink,
-  mergeAnnotationSpans,
-  type MarkdownAnnotationSpan,
-} from "./ir-spans.js";
-import {
-  sliceMarkdownIR,
-  type MarkdownIR,
-  type MarkdownLinkSpan,
-  type MarkdownStyleSpan,
-} from "./ir.js";
+import { mergeAnnotationSpans, mergeStyleSpans } from "./ir-spans.js";
+import { appendMarkdownIR, sliceMarkdownIR, type MarkdownIR } from "./ir.js";
 
 /** A rendered chunk paired with the Markdown IR slice that produced it. */
 export type RenderedMarkdownChunk<TRendered> = {
@@ -277,148 +267,101 @@ function splitMarkdownIRPreserveWhitespace(ir: MarkdownIR, limit: number): Markd
   return chunks;
 }
 
-function mergeAdjacentStyleSpans(styles: MarkdownStyleSpan[]): MarkdownStyleSpan[] {
-  const merged: MarkdownStyleSpan[] = [];
-  for (const span of styles) {
-    const last = merged.at(-1);
-    if (
-      last &&
-      last.style === span.style &&
-      last.language === span.language &&
-      span.start <= last.end
-    ) {
-      last.end = Math.max(last.end, span.end);
-      continue;
-    }
-    merged.push({ ...span });
-  }
-  return merged;
-}
-
-function mergeAdjacentLinkSpans(links: MarkdownLinkSpan[]): MarkdownLinkSpan[] {
-  const merged: MarkdownLinkSpan[] = [];
-  for (const link of links) {
-    const last = merged.at(-1);
-    if (
-      last &&
-      last.href === link.href &&
-      isAutoLinkedMarkdownLink(last) === isAutoLinkedMarkdownLink(link) &&
-      link.start <= last.end
-    ) {
-      last.end = Math.max(last.end, link.end);
-      continue;
-    }
-    merged.push(copyMarkdownLinkSpan(link));
-  }
-  return merged;
-}
-
-function mergeMarkdownIRChunks(left: MarkdownIR, right: MarkdownIR): MarkdownIR {
-  const offset = left.text.length;
-  const shiftedAnnotations: MarkdownAnnotationSpan[] = [];
-  for (const annotation of right.annotations ?? []) {
-    shiftedAnnotations.push({
-      ...annotation,
-      start: annotation.start + offset,
-      end: annotation.end + offset,
-    });
-  }
-  const shiftedStyles: MarkdownStyleSpan[] = [];
-  for (const span of right.styles) {
-    shiftedStyles.push({
-      ...span,
-      start: span.start + offset,
-      end: span.end + offset,
-    });
-  }
-  const shiftedLinks: MarkdownLinkSpan[] = [];
-  for (const link of right.links) {
-    shiftedLinks.push(
-      copyMarkdownLinkSpan(link, {
-        start: link.start + offset,
-        end: link.end + offset,
-      }),
-    );
-  }
-  const annotations = mergeAnnotationSpans([...(left.annotations ?? []), ...shiftedAnnotations]);
-  return {
-    text: left.text + right.text,
-    styles: mergeAdjacentStyleSpans([...left.styles, ...shiftedStyles]),
-    links: mergeAdjacentLinkSpans([...left.links, ...shiftedLinks]),
-    ...(annotations.length > 0 ? { annotations } : {}),
-  };
-}
+type SourceRange = { start: number; end: number };
 
 function coalesceWhitespaceOnlyMarkdownIRChunks<TRendered>(
   chunks: RenderedCandidate<TRendered>[],
   renderedLimit: number,
   options: RenderMarkdownIRChunksWithinLimitOptions<TRendered>,
 ): RenderedCandidate<TRendered>[] {
-  const coalesced: RenderedCandidate<TRendered>[] = [];
-  let index = 0;
+  // Finalized slices partition the source; only coalescing can discard separators.
+  let offset = 0;
+  const pending = chunks.map((chunk) => {
+    const start = offset;
+    offset += chunk.rawSource.text.length;
+    return { ...chunk, start, end: offset };
+  });
+  const coalesced: Array<RenderedCandidate<TRendered> & { ranges: SourceRange[] }> = [];
 
-  while (index < chunks.length) {
-    const chunk = chunks[index];
-    if (!chunk) {
-      index += 1;
-      continue;
-    }
+  pending.forEach((chunk, index) => {
+    const range = { start: chunk.start, end: chunk.end };
+    const current = { ...chunk, ranges: [range] };
     if (chunk.rawSource.text.trim().length > 0) {
-      coalesced.push(chunk);
-      index += 1;
-      continue;
+      coalesced.push(current);
+      return;
     }
 
     const prev = coalesced.at(-1);
-    const next = chunks[index + 1];
+    const next = pending[index + 1];
     const chunkLength = chunk.rawSource.text.length;
 
-    // Keep raw IR for merges: a new boundary annotation may no longer apply
-    // after whitespace joins neighbors. Retain the exact measured output pair.
-    const renderIfFits = (source: MarkdownIR) => {
+    const renderIfFits = (ranges: SourceRange[]) => {
+      const retained: SourceRange[] = [];
+      for (const range of ranges) {
+        const last = retained.at(-1);
+        if (last?.end === range.start) {
+          last.end = range.end;
+        } else {
+          retained.push({ ...range });
+        }
+      }
+      // Slice contiguous source once, but never restore a discarded separator gap.
+      // Raw source also excludes annotations introduced only by a message boundary.
+      const source: MarkdownIR = { text: "", styles: [], links: [] };
+      for (const range of retained) {
+        appendMarkdownIR(source, sliceMarkdownIR(options.ir, range.start, range.end));
+      }
+      source.styles = mergeStyleSpans(source.styles);
+      if (source.annotations) {
+        source.annotations = mergeAnnotationSpans(source.annotations);
+      }
       const candidate = renderCandidate(options, source);
       return options.measureRendered(candidate.output.rendered) <= renderedLimit
-        ? candidate
+        ? { ...candidate, ranges: retained }
         : undefined;
     };
 
     if (prev) {
-      const mergedPrev = renderIfFits(mergeMarkdownIRChunks(prev.rawSource, chunk.rawSource));
+      const mergedPrev = renderIfFits([...prev.ranges, range]);
       if (mergedPrev) {
         coalesced[coalesced.length - 1] = mergedPrev;
-        index += 1;
-        continue;
+        return;
       }
     }
 
     if (next) {
-      const mergedNext = renderIfFits(mergeMarkdownIRChunks(chunk.rawSource, next.rawSource));
+      const mergedNext = renderIfFits([{ start: chunk.start, end: next.end }]);
       if (mergedNext) {
-        chunks[index + 1] = mergedNext;
-        index += 1;
-        continue;
+        pending[index + 1] = { ...mergedNext, start: chunk.start, end: next.end };
+        return;
       }
     }
 
     if (prev && next) {
-      // Split pure whitespace between neighbors before dropping it so list,
-      // paragraph, and quote spacing survives when both sides still fit.
+      // Split whitespace between neighbors when neither can retain the whole range.
       for (let prefixLength = chunkLength - 1; prefixLength >= 1; prefixLength -= 1) {
-        const prefix = sliceMarkdownIR(chunk.rawSource, 0, prefixLength);
-        const suffix = sliceMarkdownIR(chunk.rawSource, prefixLength, chunkLength);
-        const mergedPrev = renderIfFits(mergeMarkdownIRChunks(prev.rawSource, prefix));
-        const mergedNext =
-          mergedPrev && renderIfFits(mergeMarkdownIRChunks(suffix, next.rawSource));
+        const boundary = chunk.start + prefixLength;
+        const mergedPrev = renderIfFits([...prev.ranges, { start: chunk.start, end: boundary }]);
+        const mergedNext = mergedPrev && renderIfFits([{ start: boundary, end: next.end }]);
         if (mergedPrev && mergedNext) {
           coalesced[coalesced.length - 1] = mergedPrev;
-          chunks[index + 1] = mergedNext;
-          break;
+          pending[index + 1] = { ...mergedNext, start: boundary, end: next.end };
+          return;
         }
       }
     }
 
-    index += 1;
-  }
+    // Preserve zero chunks when a renderer trims semantic whitespace away.
+    if (
+      options.measureRendered(chunk.output.rendered) > 0 &&
+      (chunk.rawSource.styles.length > 0 ||
+        chunk.rawSource.links.length > 0 ||
+        chunk.rawSource.annotations?.length ||
+        chunk.rawSource.listItems?.length)
+    ) {
+      coalesced.push(current);
+    }
+  });
 
   return coalesced;
 }

--- a/qa/scenarios/channels/telegram-semantic-formatting-boundaries.yaml
+++ b/qa/scenarios/channels/telegram-semantic-formatting-boundaries.yaml
@@ -1,0 +1,127 @@
+title: Telegram native semantic formatting boundaries
+
+scenario:
+  id: telegram-semantic-formatting-boundaries
+  surface: channels
+  coverage:
+    primary:
+      - telegram.conversation-routing-and-delivery
+  objective: Preserve semantic whitespace and formatting ranges across real Telegram message boundaries.
+  successCriteria:
+    - Actual Test Server messages match the literal text, chunk count, and UTF-16 entity ranges.
+    - Code indentation and internal whitespace survive, and each visible checkbox stays with its bold label.
+    - Plain-text fallback cannot satisfy the required native formatting entities.
+  docsRefs:
+    - docs/channels/telegram.md
+    - docs/concepts/markdown-formatting.md
+  codeRefs:
+    - packages/markdown-core/src/render-aware-chunking.ts
+    - extensions/telegram/src/format.ts
+    - extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
+  execution:
+    kind: flow
+    channel: telegram
+    retryCount: 0
+    timeoutMs: 180000
+    suiteIsolation: isolated
+    isolationReason: Native receive cursors and default formatting assertions belong to this proof.
+    summary: Send literal Markdown through the normal Gateway and inspect TDLib text and entities.
+    config:
+      requiredProviderMode: live-frontier
+      requiredChannelDriver: live
+
+flow:
+  steps:
+    - name: receives exact native text and formatting for each boundary case
+      actions:
+        - assert:
+            expr: "transport.id === 'telegram' && env.providerMode === config.requiredProviderMode && typeof readTelegramMessages === 'function'"
+            message: this scenario requires the real Telegram adapter and its native observation reader
+        - assert:
+            expr: "env.cfg.channels?.telegram?.richMessages !== true && env.cfg.channels?.telegram?.accounts?.[transport.accountId]?.richMessages !== true && (env.cfg.channels?.telegram?.accounts?.[transport.accountId]?.textChunkLimit ?? env.cfg.channels?.telegram?.textChunkLimit ?? 4000) === 4000"
+            message: this scenario requires the default Telegram formatter and its unchanged 4000-character limit
+        - call: waitForGatewayHealthy
+          args: [{ ref: env }, 60000]
+        - call: waitForTransportReady
+          args: [{ ref: env }, 60000]
+        - resetTransport: true
+        - set: delivery
+          value:
+            expr: "transport.buildAgentDelivery({ target: 'group' })"
+        - call: randomUUID
+          saveAs: runId
+        - set: proofs
+          value: []
+        - set: fixtures
+          value:
+            expr: |
+              [
+                {
+                  id: "inline-code-utf16-and-link",
+                  markdown: "😀 `a   b` [x](https://example.com/qa)",
+                  expectedChunks: [{
+                    text: "😀 a   b x",
+                    entities: [
+                      { offset: 3, length: 5, type: { "@type": "textEntityTypeCode" } },
+                      { offset: 9, length: 1, type: { "@type": "textEntityTypeTextUrl", url: "https://example.com/qa" } }
+                    ]
+                  }]
+                },
+                {
+                  id: "fenced-code-rendered-boundary",
+                  markdown: "```\n" + "A".repeat(3977) + "\n  x  \n \ny\n```",
+                  expectedChunks: [
+                    { text: "A".repeat(3976), entities: [{ offset: 0, length: 3976, type: { "@type": "textEntityTypePre" } }] },
+                    { text: "A\n  x  \n \ny", entities: [{ offset: 0, length: 11, type: { "@type": "textEntityTypePre" } }] }
+                  ]
+                },
+                {
+                  id: "task-marker-boundary",
+                  markdown: "- [ ] **" + "A".repeat(1988) + "**\n- [x] **" + "B".repeat(1988) + "**",
+                  expectedChunks: [
+                    { text: "• [ ] " + "A".repeat(1988), entities: [{ offset: 6, length: 1988, type: { "@type": "textEntityTypeBold" } }] },
+                    { text: "• [x] " + "B".repeat(1988), entities: [{ offset: 6, length: 1988, type: { "@type": "textEntityTypeBold" } }] }
+                  ]
+                }
+              ]
+        - forEach:
+            items: { ref: fixtures }
+            item: fixture
+            actions:
+              - set: startIndex
+                value:
+                  expr: "readTelegramMessages().length"
+              - call: env.gateway.call
+                saveAs: receipt
+                args:
+                  - send
+                  - channel: telegram
+                    accountId: { ref: transport.accountId }
+                    to: { ref: delivery.to }
+                    message: { ref: fixture.markdown }
+                    idempotencyKey:
+                      expr: "`${runId}:${fixture.id}`"
+                  - timeoutMs: 30000
+              - assert:
+                  expr: "Number.isSafeInteger(Number(receipt.messageId)) && Number(receipt.messageId) > 0"
+                  message: the canonical send must return a native Telegram message ID
+              - call: waitForCondition
+                args:
+                  - lambda:
+                      params: []
+                      expr: "readTelegramMessages().slice(startIndex).some((message) => String(message.botApiMessageId) === String(receipt.messageId))"
+                  - 30000
+              - set: received
+                value:
+                  expr: "readTelegramMessages().slice(startIndex)"
+              - set: actual
+                value:
+                  expr: "received.map(({ text, entities }) => ({ text, entities: entities.map(({ offset, length, type }) => ({ offset, length, type: { '@type': type['@type'], ...(type['@type'] === 'textEntityTypeTextUrl' ? { url: type.url } : {}), ...(type['@type'] === 'textEntityTypePreCode' ? { language: type.language } : {}) } })) }))"
+              - assert:
+                  expr: "String(received.at(-1)?.botApiMessageId) === String(receipt.messageId) && JSON.stringify(actual) === JSON.stringify(fixture.expectedChunks)"
+                  message:
+                    expr: "JSON.stringify({ case: fixture.id, expected: fixture.expectedChunks, observed: actual.map((message, index) => ({ text: message.text === fixture.expectedChunks[index]?.text ? message.text : message.text.replace(/\\S/gu, '?'), nonWhitespaceRedacted: message.text !== fixture.expectedChunks[index]?.text, entities: message.entities.map((entity) => ({ offset: entity.offset, length: entity.length, type: entity.type['@type'], expectedTypePayload: JSON.stringify(entity.type) === JSON.stringify(fixture.expectedChunks[index]?.entities.find((expected) => expected.offset === entity.offset && expected.length === entity.length)?.type) })) })) })"
+              - set: proofs
+                value:
+                  expr: "proofs.concat([{ case: fixture.id, chunks: actual }])"
+      detailsExpr: "JSON.stringify({ transport: 'Telegram Test Server', topology: 'leased group', operation: 'Gateway send', modelInvocation: false, cases: proofs })"

--- a/src/infra/outbound/message-plan.test.ts
+++ b/src/infra/outbound/message-plan.test.ts
@@ -151,39 +151,3 @@ describe("outbound message planning", () => {
     ]);
   });
 });
-
-describe("Google Chat semantic whitespace planning", () => {
-  it.each([
-    { name: "standalone fallback control", prefix: "", expected: ["```\n \n```"] },
-    {
-      name: "fenced block after a full default-limit paragraph",
-      prefix: "A".repeat(32_000) + "\n\n",
-      expected: ["A".repeat(32_000), "\n\n```\n \n```"],
-    },
-  ])("plans semantic whitespace: $name", async ({ prefix, expected }) => {
-    const { googlechatPlugin } = await import("../../../extensions/googlechat/api.js");
-    const outbound = googlechatPlugin.outbound;
-    if (!outbound?.chunker || !outbound.sanitizeText) {
-      throw new Error("Google Chat outbound formatter is unavailable");
-    }
-    const payload = { text: prefix + "```\n \n```" };
-    const text = outbound.sanitizeText({ text: payload.text, payload, cfg: {} });
-    expect(text).toBe(payload.text);
-    expect(outbound.textChunkLimit).toBe(32_000);
-    const units = planOutboundTextMessageUnits({
-      text,
-      overrides: {},
-      chunker: outbound.chunker,
-      chunkerMode: outbound.chunkerMode,
-      textLimit: outbound.textChunkLimit,
-      chunkMode: "length",
-    });
-    expect(units).toEqual(
-      expected.map((value, index) => ({
-        kind: "text",
-        text: value,
-        overrides: { deliveryPartIndex: index, deliveryPartCount: expected.length },
-      })),
-    );
-  });
-});

--- a/src/infra/outbound/message-plan.test.ts
+++ b/src/infra/outbound/message-plan.test.ts
@@ -151,3 +151,39 @@ describe("outbound message planning", () => {
     ]);
   });
 });
+
+describe("Google Chat semantic whitespace planning", () => {
+  it.each([
+    { name: "standalone fallback control", prefix: "", expected: ["```\n \n```"] },
+    {
+      name: "fenced block after a full default-limit paragraph",
+      prefix: "A".repeat(32_000) + "\n\n",
+      expected: ["A".repeat(32_000), "\n\n```\n \n```"],
+    },
+  ])("plans semantic whitespace: $name", async ({ prefix, expected }) => {
+    const { googlechatPlugin } = await import("../../../extensions/googlechat/api.js");
+    const outbound = googlechatPlugin.outbound;
+    if (!outbound?.chunker || !outbound.sanitizeText) {
+      throw new Error("Google Chat outbound formatter is unavailable");
+    }
+    const payload = { text: prefix + "```\n \n```" };
+    const text = outbound.sanitizeText({ text: payload.text, payload, cfg: {} });
+    expect(text).toBe(payload.text);
+    expect(outbound.textChunkLimit).toBe(32_000);
+    const units = planOutboundTextMessageUnits({
+      text,
+      overrides: {},
+      chunker: outbound.chunker,
+      chunkerMode: outbound.chunkerMode,
+      textLimit: outbound.textChunkLimit,
+      chunkMode: "length",
+    });
+    expect(units).toEqual(
+      expected.map((value, index) => ({
+        kind: "text",
+        text: value,
+        overrides: { deliveryPartIndex: index, deliveryPartCount: expected.length },
+      })),
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where task-list messages gain an extra bullet when a rendered chunk boundary falls immediately before the item. At Google Chat's default 32,000-byte limit, the second delivered message could become `\n\n* [x] done` instead of `\n\n[x] done`.

## Why This Change Was Made

Whitespace coalescing rebuilt Markdown IR from only text, styles, and links, discarding list and block metadata that later renderers need. Contiguous chunks now reuse the canonical source slicer; disjoint chunks and fallback edits share one append operation that preserves semantic metadata and authored coordinates. The duplicate partial append and span-merging paths are removed.

Meaningful whitespace is retained only when its rendered output is nonempty. Existing suppression of plain separators and empty attributed output remains intact, including Signal's fallback behavior. Production: **+111/−144 (net −33)**. Tests: **+702/−118 (net +584)**. Private QA support: **+77/−28 (net +49)**; scenario: **+127**. QA support is excluded from the published package.

## User Impact

Chunked messages retain their task-list structure, code and annotation content, and authored link boundaries. The change adds no configuration, dependency, or channel-specific production rule.

Related: #128615 and #127655 discuss lossless raw whitespace after unsuccessful coalescing. This repair also covers semantic whitespace, but its demonstrated task-list defect occurs during successful coalescing. It deliberately retains the existing treatment of unformatted separators and does not claim to resolve that broader raw-whitespace contract. The earlier trailing-inline-code fix in #134451 is preserved.

## Evidence

The task-list regression failed before the repair with the extra bullet and passed afterward. The real guarded HTTP fixture exercises SDK dispatch, the required outbound queue, planning, formatting, the Google Chat adapter, and two captured POST bodies. Both exact bodies and the 32,000-byte bound pass. All eight transport cases pass together, including cancellation, dispatcher/socket cleanup, malformed UTF-8, and token-safe errors.

The earlier owner-sweep snapshot passed 192 tests across 16 Markdown suites. After CI exposed lint and test-boundary problems, the repair replaced three unnecessary type assertions with checked assignments, renamed a shadowed local, and removed a redundant Google Chat test from core infrastructure; the plugin-owned formatter and HTTP proofs remain. The 20 chunker and 40 formatter cases pass again, as do scoped type-aware lint, the assertion ratchet, and the core type-boundary check. Independent Codex review is clean.

The fixtures use loopback HTTP and synthetic authentication; this is not a hosted Google API or model-provider run. The initial CI also timed out in the unchanged ACP source-CLI exit test. That timeout remains unexplained and is not waived or addressed by increasing its deadline; the corrected head must pass required CI before landing.

The ClawSweeper link-boundary rank-up was checked with three additional real-parser/renderer tests: one authored link spanning retained whitespace, one spanning whitespace trimmed by attributed rendering, and two distinct adjacent authored links sharing a URL. All three pass. The requested link-merging change is not applied: contiguous source ranges are already coalesced before canonical slicing, so a spanning source link remains continuous within each output chunk. Merging by URL would instead fuse separately authored links. The new tests retain this distinction and verify each rendered payload stays within its limit. Independent Codex review of this test-only addition is clean; production code is unchanged.

The latest ClawSweeper finding about raw-whitespace loss is addressed: the assertion requiring dropped unformatted spaces was removed. The complete final 22-case chunker file passes, including semantic whitespace, task lists, attributed-output suppression, and the three authored-link cases. Scoped formatting and independent Codex review pass; production is unchanged.

The Telegram QA observer now preserves native text and formatting entities together through messages and edits, validates UTF-16 ranges, and exposes isolated snapshots for the registered `telegram-semantic-formatting-boundaries` scenario. The scenario checks literal whitespace, fenced-code chunk boundaries, checkbox labels, and native formatting entities through the normal Gateway send path. This QA addition changes no shipped production code.

Local validation passed: 9 Python cases, 21 TypeScript cases, 7 catalog/profile-selection cases, scoped formatting, the normal plugin source and test type checks, scoped lint, and independent managed Codex review with no actionable P0–P2 findings. **Native Telegram Test Server proof passed on `da56b8ca8263df6c445d879fbe7188515dbfba82`** in [workflow 33561650273](https://github.com/openclaw/openclaw/actions/runs/33561650273/job/100037021346). The leased-group Gateway send scenario completed with 1 passed, 0 failed, and 0 skipped scenarios. It observed exact native text and TDLib entity vectors for inline-code whitespace plus an emoji and link (UTF-16 offsets 3 and 9), two fenced-code chunks (3976 and 11 characters, with Pre entities), and two checkbox chunks (1994 characters each, Bold offset 6/length 1988). This uses the default 4000-character Telegram chunk limit. No model invocation is claimed. The redacted [native evidence artifact](https://github.com/openclaw/openclaw/actions/runs/33561650273/artifacts/9822155115) contains the synthetic text and entity observations. All PR-head checks completed: 238 successful, 49 skipped, and 1 neutral, with no failures. This supplies the native-delivery evidence and green-CI rank-up requested in the latest ClawSweeper review.

The broader live-transport workflow also ran the default non-Telegram lanes and finished with failures; it is not an all-lanes-green result. Telegram and mock parity passed. The retained failures are Slack's disabled-channel log warning, Discord's missing reserved QA voice-channel ID, Matrix's CLI encryption-owner verification, and exhausted WhatsApp credential capacity. Inspection of the failing branches places each before the changed Markdown formatter runs; they remain separate follow-ups. The native Telegram evidence above refers specifically to the successful Telegram job and its exact-head artifact.
