### PR TITLE
fix(cli): suggest config patch --file when shell strips JSON quotes

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -161,6 +161,10 @@ openclaw config set gateway.port 19001 --strict-json
 openclaw config set channels.whatsapp.groups '["*"]' --strict-json
 ```
 
+<Note>
+Windows PowerShell can remove the inner quotes of a single-quoted JSON argument before OpenClaw receives it, so a command like `openclaw config set commands.ownerAllowFrom '["telegram:123"]' --strict-json` can fail with a JSON parse error. Put structured values in a JSON5 patch file and apply it with `openclaw config patch --file ./openclaw.patch.json5` instead.
+</Note>
+
 `config get <path> --json` prints the redacted value as JSON instead of terminal-formatted text.
 
 When a write changes `agents.defaults.model` or a per-agent `agents.entries.*.model`, OpenClaw resolves each changed primary or fallback through the configured catalogs and the selected provider's model resolver before writing. Provider-supported exact `provider/model` pins are accepted even when absent from the curated picker; validation does not replace the selected model. Unknown model references are rejected without changing the active config. Run `openclaw models list` to browse the picker, or check the provider's documentation for an exact model ID. Successful validation does not prove that your account can call the model.

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -161,9 +161,7 @@ openclaw config set gateway.port 19001 --strict-json
 openclaw config set channels.whatsapp.groups '["*"]' --strict-json
 ```
 
-<Note>
-Windows PowerShell can remove the inner quotes of a single-quoted JSON argument before OpenClaw receives it, so a command like `openclaw config set commands.ownerAllowFrom '["telegram:123"]' --strict-json` can fail with a JSON parse error. Put structured values in a JSON5 patch file and apply it with `openclaw config patch --file ./openclaw.patch.json5` instead.
-</Note>
+For structured values that are awkward to quote in your shell, put a config-shaped JSON5 object in a file and use [`config patch --file <path> --dry-run`](/cli/config#config-patch). The file contains config keys and their values, not a bare array.
 
 `config get <path> --json` prints the redacted value as JSON instead of terminal-formatted text.
 

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1885,20 +1885,6 @@ describe("config cli", () => {
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
       expectErrorIncludes('Could not parse "{bad" as JSON for --strict-json.');
       expectErrorIncludes("For plain strings, omit --strict-json.");
-      expect(mockError.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain(
-        "openclaw config patch --file",
-      );
-    });
-
-    it("suggests config patch --file for shell-stripped strict JSON values", async () => {
-      await expect(
-        runConfigSet("commands.ownerAllowFrom", "[telegram:123]", "--strict-json"),
-      ).rejects.toThrow(ExitError);
-
-      expect(mockWriteConfigFile).not.toHaveBeenCalled();
-      expectErrorIncludes('Could not parse "[telegram:123]" as JSON for --strict-json.');
-      expectErrorIncludes("Windows PowerShell");
-      expectErrorIncludes("config patch --file");
     });
 
     it("keeps --json as a strict parsing alias", async () => {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1885,6 +1885,20 @@ describe("config cli", () => {
       expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
       expectErrorIncludes('Could not parse "{bad" as JSON for --strict-json.');
       expectErrorIncludes("For plain strings, omit --strict-json.");
+      expect(mockError.mock.calls.map((call) => String(call[0])).join("\n")).not.toContain(
+        "openclaw config patch --file",
+      );
+    });
+
+    it("suggests config patch --file for shell-stripped strict JSON values", async () => {
+      await expect(
+        runConfigSet("commands.ownerAllowFrom", "[telegram:123]", "--strict-json"),
+      ).rejects.toThrow(ExitError);
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes('Could not parse "[telegram:123]" as JSON for --strict-json.');
+      expectErrorIncludes("Windows PowerShell");
+      expectErrorIncludes("config patch --file");
     });
 
     it("keeps --json as a strict parsing alias", async () => {

--- a/src/cli/error-format.test.ts
+++ b/src/cli/error-format.test.ts
@@ -10,4 +10,42 @@ describe("formatStrictJsonParseFailure", () => {
     expect(message).toContain(`${"x".repeat(44)}...`);
     expect(message).not.toContain("\uD83D");
   });
+
+  it.each([
+    { raw: "[telegram:123]", label: "stripped array" },
+    { raw: "{key:value}", label: "stripped object" },
+    { raw: "  [1,2]", label: "leading-whitespace array" },
+    { raw: "[[1,2]]", label: "nested stripped" },
+    { raw: "{owner:O'Brien}", label: "apostrophe in content" },
+    { raw: "['valid']", label: "single-quoted array content" },
+  ])(
+    "suggests config patch --file when value is a balanced bracket/brace with no double quotes ($label)",
+    ({ raw }) => {
+      const message = formatStrictJsonParseFailure({ value: raw, cause: "invalid token" });
+
+      expect(message).toContain("config patch --file");
+      expect(message).toContain("Windows PowerShell");
+      expect(message).toContain("./openclaw.patch.json5");
+    },
+  );
+
+  it.each([
+    { raw: "not-json", label: "plain text" },
+    { raw: "42", label: "number" },
+    { raw: "true", label: "boolean" },
+    { raw: "", label: "empty string" },
+    { raw: "   ", label: "whitespace only" },
+    { raw: "{bad", label: "incomplete object" },
+    { raw: "[telegram:123", label: "unclosed array" },
+    { raw: "[", label: "bare open bracket" },
+    { raw: '["valid"]', label: "array with double quotes" },
+    { raw: '{"key":"val"}', label: "object with double quotes" },
+  ])(
+    "does not suggest config patch for incomplete, quoted, or non-structured values ($label)",
+    ({ raw }) => {
+      const message = formatStrictJsonParseFailure({ value: raw, cause: "invalid token" });
+
+      expect(message).not.toContain("config patch --file");
+    },
+  );
 });

--- a/src/cli/error-format.test.ts
+++ b/src/cli/error-format.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from "vitest";
 import { formatStrictJsonParseFailure } from "./error-format.js";
 
 describe("formatStrictJsonParseFailure", () => {
+  it.each(["[telegram:123456]", "{bad", "not-json"])(
+    "offers file-based recovery for invalid JSON %j",
+    (value) => {
+      const message = formatStrictJsonParseFailure({ value, cause: "invalid token" });
+
+      expect(message).toContain("openclaw config patch --file <path> --dry-run");
+      expect(message).toContain("JSON5 config patch object");
+      expect(message).toContain("For plain strings, omit --strict-json.");
+    },
+  );
   it("keeps the bounded JSON preview UTF-16 well-formed", () => {
     const value = `${"x".repeat(44)}🚀tail`;
 
@@ -10,42 +20,4 @@ describe("formatStrictJsonParseFailure", () => {
     expect(message).toContain(`${"x".repeat(44)}...`);
     expect(message).not.toContain("\uD83D");
   });
-
-  it.each([
-    { raw: "[telegram:123]", label: "stripped array" },
-    { raw: "{key:value}", label: "stripped object" },
-    { raw: "  [1,2]", label: "leading-whitespace array" },
-    { raw: "[[1,2]]", label: "nested stripped" },
-  ])(
-    "suggests config patch --file when value is a balanced bracket/brace with no quotes ($label)",
-    ({ raw }) => {
-      const message = formatStrictJsonParseFailure({ value: raw, cause: "invalid token" });
-
-      expect(message).toContain("config patch --file");
-      expect(message).toContain("Windows PowerShell");
-      expect(message).toContain("./openclaw.patch.json5");
-    },
-  );
-
-  it.each([
-    { raw: "not-json", label: "plain text" },
-    { raw: "42", label: "number" },
-    { raw: "true", label: "boolean" },
-    { raw: "", label: "empty string" },
-    { raw: "   ", label: "whitespace only" },
-    { raw: "{bad", label: "incomplete object" },
-    { raw: "[telegram:123", label: "unclosed array" },
-    { raw: "[", label: "bare open bracket" },
-    { raw: '["valid"]', label: "array with double quotes" },
-    { raw: '{"key":"val"}', label: "object with double quotes" },
-    { raw: "{owner:O'Brien}", label: "apostrophe in content" },
-    { raw: "['valid']", label: "array with single quotes" },
-  ])(
-    "does not suggest config patch for incomplete, quoted, or non-structured values ($label)",
-    ({ raw }) => {
-      const message = formatStrictJsonParseFailure({ value: raw, cause: "invalid token" });
-
-      expect(message).not.toContain("config patch --file");
-    },
-  );
 });

--- a/src/cli/error-format.test.ts
+++ b/src/cli/error-format.test.ts
@@ -10,4 +10,42 @@ describe("formatStrictJsonParseFailure", () => {
     expect(message).toContain(`${"x".repeat(44)}...`);
     expect(message).not.toContain("\uD83D");
   });
+
+  it.each([
+    { raw: "[telegram:123]", label: "stripped array" },
+    { raw: "{key:value}", label: "stripped object" },
+    { raw: "  [1,2]", label: "leading-whitespace array" },
+    { raw: "[[1,2]]", label: "nested stripped" },
+  ])(
+    "suggests config patch --file when value is a balanced bracket/brace with no quotes ($label)",
+    ({ raw }) => {
+      const message = formatStrictJsonParseFailure({ value: raw, cause: "invalid token" });
+
+      expect(message).toContain("config patch --file");
+      expect(message).toContain("Windows PowerShell");
+      expect(message).toContain("./openclaw.patch.json5");
+    },
+  );
+
+  it.each([
+    { raw: "not-json", label: "plain text" },
+    { raw: "42", label: "number" },
+    { raw: "true", label: "boolean" },
+    { raw: "", label: "empty string" },
+    { raw: "   ", label: "whitespace only" },
+    { raw: "{bad", label: "incomplete object" },
+    { raw: "[telegram:123", label: "unclosed array" },
+    { raw: "[", label: "bare open bracket" },
+    { raw: '["valid"]', label: "array with double quotes" },
+    { raw: '{"key":"val"}', label: "object with double quotes" },
+    { raw: "{owner:O'Brien}", label: "apostrophe in content" },
+    { raw: "['valid']", label: "array with single quotes" },
+  ])(
+    "does not suggest config patch for incomplete, quoted, or non-structured values ($label)",
+    ({ raw }) => {
+      const message = formatStrictJsonParseFailure({ value: raw, cause: "invalid token" });
+
+      expect(message).not.toContain("config patch --file");
+    },
+  );
 });

--- a/src/cli/error-format.ts
+++ b/src/cli/error-format.ts
@@ -55,44 +55,20 @@ export function formatUnsupportedChannelActionMessage(params: {
   )} to inspect supported actions.`;
 }
 
-/** Detect a structured value whose inner quotes were likely removed by the shell. */
-function looksShellStrippedJson(value: string): boolean {
-  const trimmed = value.trim();
-  const balanced =
-    (trimmed.startsWith("[") && trimmed.endsWith("]")) ||
-    (trimmed.startsWith("{") && trimmed.endsWith("}"));
-  if (!balanced) {
-    return false;
-  }
-  // Valid JSON strings always carry quotes; a bare, complete array or object
-  // without any quote character reaching the parser is the classic Windows
-  // PowerShell single-quoted-argument handoff failure. Incomplete values
-  // (e.g. "{bad") are ordinary JSON typos, not shell damage.
-  return !/["']/.test(trimmed);
-}
-
 /** Format strict JSON parsing failures without exposing long untrusted input verbatim. */
 export function formatStrictJsonParseFailure(params: { value: string; cause: unknown }): string {
   const rawCause = params.cause instanceof Error ? params.cause.message : String(params.cause);
   const cause = rawCause.trim().replace(/[.。]+$/u, "");
   const preview =
     params.value.length > 48 ? `${truncateUtf16Safe(params.value, 45).trimEnd()}...` : params.value;
-  const parts = [
+  return [
     `Could not parse ${JSON.stringify(preview)} as JSON for --strict-json.`,
     `${cause}.`,
-    `Use valid JSON, for example ${formatInlineCliCommand(
-      "openclaw config set gateway.port 18789 --strict-json",
+    `Use valid JSON. For structured changes, use a JSON5 config patch object file with ${formatInlineCliCommand(
+      "openclaw config patch --file <path> --dry-run",
     )}.`,
     "For plain strings, omit --strict-json.",
-  ];
-  if (looksShellStrippedJson(params.value)) {
-    parts.push(
-      `The value looks like a JSON array or object without string quotes; Windows PowerShell often removes inner quotes before OpenClaw receives the argument. Put structured values in a JSON5 patch file and apply it with ${formatInlineCliCommand(
-        "openclaw config patch --file ./openclaw.patch.json5",
-      )}.`,
-    );
-  }
-  return parts.join(" ");
+  ].join(" ");
 }
 
 /** Normalize gateway failure text and attach the deep-status recovery command. */

--- a/src/cli/error-format.ts
+++ b/src/cli/error-format.ts
@@ -55,20 +55,44 @@ export function formatUnsupportedChannelActionMessage(params: {
   )} to inspect supported actions.`;
 }
 
+/** Detect a structured value whose inner quotes were likely removed by the shell. */
+function looksShellStrippedJson(value: string): boolean {
+  const trimmed = value.trim();
+  const balanced =
+    (trimmed.startsWith("[") && trimmed.endsWith("]")) ||
+    (trimmed.startsWith("{") && trimmed.endsWith("}"));
+  if (!balanced) {
+    return false;
+  }
+  // Valid JSON strings always carry quotes; a bare, complete array or object
+  // without any quote character reaching the parser is the classic Windows
+  // PowerShell single-quoted-argument handoff failure. Incomplete values
+  // (e.g. "{bad") are ordinary JSON typos, not shell damage.
+  return !/["']/.test(trimmed);
+}
+
 /** Format strict JSON parsing failures without exposing long untrusted input verbatim. */
 export function formatStrictJsonParseFailure(params: { value: string; cause: unknown }): string {
   const rawCause = params.cause instanceof Error ? params.cause.message : String(params.cause);
   const cause = rawCause.trim().replace(/[.。]+$/u, "");
   const preview =
     params.value.length > 48 ? `${truncateUtf16Safe(params.value, 45).trimEnd()}...` : params.value;
-  return [
+  const parts = [
     `Could not parse ${JSON.stringify(preview)} as JSON for --strict-json.`,
     `${cause}.`,
     `Use valid JSON, for example ${formatInlineCliCommand(
       "openclaw config set gateway.port 18789 --strict-json",
     )}.`,
     "For plain strings, omit --strict-json.",
-  ].join(" ");
+  ];
+  if (looksShellStrippedJson(params.value)) {
+    parts.push(
+      `The value looks like a JSON array or object without string quotes; Windows PowerShell often removes inner quotes before OpenClaw receives the argument. Put structured values in a JSON5 patch file and apply it with ${formatInlineCliCommand(
+        "openclaw config patch --file ./openclaw.patch.json5",
+      )}.`,
+    );
+  }
+  return parts.join(" ");
 }
 
 /** Normalize gateway failure text and attach the deep-status recovery command. */

--- a/src/cli/error-format.ts
+++ b/src/cli/error-format.ts
@@ -55,20 +55,45 @@ export function formatUnsupportedChannelActionMessage(params: {
   )} to inspect supported actions.`;
 }
 
+/** Detect a structured value whose inner quotes were likely removed by the shell. */
+function looksShellStrippedJson(value: string): boolean {
+  const trimmed = value.trim();
+  const balanced =
+    (trimmed.startsWith("[") && trimmed.endsWith("]")) ||
+    (trimmed.startsWith("{") && trimmed.endsWith("}"));
+  if (!balanced) {
+    return false;
+  }
+  // Valid JSON strings always carry double quotes; a bare, complete array or
+  // object without any double-quote character reaching the parser is the
+  // classic Windows PowerShell single-quoted-argument handoff failure.
+  // Single quotes are content (e.g. ["O'Brien"]), not evidence of surviving
+  // JSON quoting. Incomplete values (e.g. "{bad") are ordinary JSON typos.
+  return !trimmed.includes('"');
+}
+
 /** Format strict JSON parsing failures without exposing long untrusted input verbatim. */
 export function formatStrictJsonParseFailure(params: { value: string; cause: unknown }): string {
   const rawCause = params.cause instanceof Error ? params.cause.message : String(params.cause);
   const cause = rawCause.trim().replace(/[.。]+$/u, "");
   const preview =
     params.value.length > 48 ? `${truncateUtf16Safe(params.value, 45).trimEnd()}...` : params.value;
-  return [
+  const parts = [
     `Could not parse ${JSON.stringify(preview)} as JSON for --strict-json.`,
     `${cause}.`,
     `Use valid JSON, for example ${formatInlineCliCommand(
       "openclaw config set gateway.port 18789 --strict-json",
     )}.`,
     "For plain strings, omit --strict-json.",
-  ].join(" ");
+  ];
+  if (looksShellStrippedJson(params.value)) {
+    parts.push(
+      `The value looks like a JSON array or object without string quotes; Windows PowerShell often removes inner quotes before OpenClaw receives the argument. Put structured values in a JSON5 patch file and apply it with ${formatInlineCliCommand(
+        "openclaw config patch --file ./openclaw.patch.json5",
+      )}.`,
+    );
+  }
+  return parts.join(" ");
 }
 
 /** Normalize gateway failure text and attach the deep-status recovery command. */


### PR DESCRIPTION
## What Problem This Solves

Point strict-JSON parse errors to the existing `config patch --file <path> --dry-run` workflow for structured changes. The diagnostic now names the required config-shaped JSON5 object instead of offering only a scalar numeric example. Parsing, the bounded input preview, the original cause and the plain-string hint are unchanged; the docs explain that the file is a config object, not a bare array.

## Why This Change Was Made

Replace the scalar-only example with a config-shaped JSON5 object file example. This gives generic recovery guidance without guessing which shell changed the input.

## User Impact

Users can recover from structured-value quoting errors through the existing file input and dry-run workflow.

## Evidence

Validation: all four formatter tests passed, including three regressions that failed before the fix. Seven built CLI commands exercised malformed array/object inputs, file dry-run without mutation, file application and readback, plus valid strict scalar/array controls. All isolated state was removed. Full changed-file gates and individual Codex P0 review passed.

Runtime proof used one build of four disjoint CLI repairs on `f74dde80b6c951124d9f8c7038d8391945296e79`, with separate patch/source hashes. Production is net-neutral; tests +10, docs +2 lines. The rewrite supplies generic recovery guidance without guessing the shell or platform, so the earlier optional Windows-specific proof suggestion does not apply to the revised behavior.

Fixes #135164. Thanks @SunnyShu0925 for identifying the problem and contributing the original fix.

The same 121 owner tests also passed in Blacksmith Testbox with all 12 candidate file hashes checked before execution and after the tests. The lease was stopped after completion.

The latest review identified an apostrophe false negative in the proposed shell detector. This rewrite removes the detector and emits the same recovery hint for every strict-JSON parse error, so quote characters cannot suppress it. Detector-specific formatter/Commander cases are replaced by the generic recovery coverage; no separate apostrophe CLI trace is claimed. Parsing and config writes remain unchanged, and this diagnostic-only change introduces no stored-data model.
