### PR TITLE
perf: skip empty tool-result planning branches

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1838,7 +1838,7 @@ src/agents/embedded-agent-runner/thinking.ts	25
 src/agents/embedded-agent-runner/tool-call-argument-decoding.ts	5
 src/agents/embedded-agent-runner/tool-result-char-estimator.ts	9
 src/agents/embedded-agent-runner/tool-result-context-guard.ts	13
-src/agents/embedded-agent-runner/tool-result-truncation.ts	23
+src/agents/embedded-agent-runner/tool-result-truncation.ts	22
 src/agents/embedded-agent-runner/tool-schema-runtime.ts	1
 src/agents/embedded-agent-runner/transcript-rewrite.ts	2
 src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts	4

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -651,11 +651,7 @@ export function truncateOversizedToolResultsInMessages(
     maxCharsOverride,
     aggregateMaxCharsOverride,
   });
-  const sourceBranch = messages.map((message, index) => ({
-    id: `message-${index}`,
-    type: "message",
-    message,
-  }));
+  const sourceBranch = buildToolResultPlanningBranch(messages);
   const projection = projectionState
     ? projectToolResultBranch({
         branch: sourceBranch,
@@ -663,10 +659,8 @@ export function truncateOversizedToolResultsInMessages(
         recordSources: true,
       })
     : undefined;
-  const branch = projection?.branch ?? sourceBranch;
-  const projectionKeys = projection?.keys ?? [];
   const plan = buildToolResultReplacementPlan({
-    branch,
+    branch: projection?.branch ?? sourceBranch,
     maxChars,
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
@@ -674,9 +668,9 @@ export function truncateOversizedToolResultsInMessages(
   });
   const replacedBranch = plan.branch;
   if (projectionState) {
-    for (const [index, originalMessage] of messages.entries()) {
+    for (const [index, { message: originalMessage }] of sourceBranch.entries()) {
       const projectedMessage = replacedBranch[index]?.message;
-      const projectionKey = projectionKeys[index];
+      const projectionKey = projection?.keys[index];
       if (projectionKey) {
         projectionState.frozen.add(projectionKey);
         if (
@@ -738,6 +732,17 @@ type ToolResultBranchEntry = {
   message?: AgentMessage;
   aggregateEligible?: boolean;
 };
+
+type ToolResultMessageBranchEntry = ToolResultBranchEntry & { message: AgentMessage };
+// Non-tool messages cannot affect a plan; avoid allocating a full branch for that common path.
+function buildToolResultPlanningBranch(messages: AgentMessage[]): ToolResultMessageBranchEntry[] {
+  const sourceMessages = messages.some((message) => message.role === "toolResult") ? messages : [];
+  return sourceMessages.map((message, index) => ({
+    id: `message-${index}`,
+    type: "message",
+    message,
+  }));
+}
 
 type ToolResultReplacement = {
   entryId: string;
@@ -1218,18 +1223,13 @@ export function estimateToolResultReductionPotential(params: {
   maxCharsOverride?: number;
   aggregateMaxCharsOverride?: number;
 }): ToolResultReductionPotential {
-  const { messages } = params;
   const { maxChars, aggregateBudgetChars } = resolveToolResultBudgets(params);
-  const branch = messages.map((message, index) => ({
-    id: `message-${index}`,
-    type: "message",
-    message,
-  }));
+  const branch = buildToolResultPlanningBranch(params.messages);
 
   let toolResultCount = 0;
   let totalToolResultChars = 0;
-  for (const msg of messages) {
-    if ((msg as { role?: string }).role !== "toolResult") {
+  for (const { message: msg } of branch) {
+    if (msg.role !== "toolResult") {
       continue;
     }
     const textLength = getToolResultTextBudget(msg);


### PR DESCRIPTION
## What Problem This Solves

Context preflight and tool-result truncation allocate planning records for every message even when a history contains no tool results. Repeated passes over ordinary user/assistant history create large temporary branches and projections that cannot produce a replacement.

## Why This Change Was Made

Share one planning-branch builder between the estimator and truncator. Histories with no tool result yield an empty planning branch; histories with a tool result retain the complete original sequence and the same message-index identifiers. Keep the canonical budget, replacement-plan, projection, and result paths. Iterate the actual planning branch when freezing projection keys, and remove single-use aliases.

This leaves returned histories, message identities, projection maps/sets, frozen entries, mixed histories, and all public budgets unchanged. Production is +18/-18 (net zero); tests are unchanged. The assertion-safety baseline shrinks from 23 to 22 for the removed assertion.

## User Impact

For an actual-source 10,000-message user/assistant history with seeded projection state, the median immediate heap allocation before collection falls from 6,700,448 to 4,800 bytes for an estimate-and-truncate pair. Its median time falls from 1.020 to 0.090 ms. Estimation alone falls from 2,079,112 to 2,608 bytes; truncation falls from 4,811,040 to 3,392 bytes.

These are repeated owner-probe results, not retained-memory or whole-Gateway RSS savings. Mixed histories intentionally retain their original planning behavior.

## Evidence

- An independent differential probe and a root rerun compare 960 no-tool truncation cases, 480 estimator/predicate cases, and 250 mixed-tool histories: all 1,690 cases match, including object identities and seeded projection state.
- All 150 focused tests pass across truncation, Code Mode budgets, preflight, context recovery, replay, and preemptive compaction.
- The full required changed-check plan and fresh Codex autoreview pass.
- A fresh built Gateway completes health, provider RPC, a real OpenAI turn, and a real web-fetch turn. The returned assistant markers are checked in the CLI JSON, and structured session history independently records one successful web_fetch call/result. The Gateway exits cleanly and its ephemeral state is removed.
