### PR TITLE
fix: preserve context-free harness policy reasons

### DIFF
--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -193,18 +193,43 @@ describe("harness runtime plugins", () => {
     expect(formatForLog((error as Error).message)).toContain('Run "openclaw doctor --fix"');
   });
 
-  it("reports explicit library policy without a prepared registry context", async () => {
+  it.each([
+    {
+      name: "global disablement",
+      plugins: { enabled: false },
+      expectedReason: "plugins disabled",
+    },
+    {
+      name: "a restrictive allowlist",
+      plugins: { allow: ["telegram"] },
+      expectedReason: "not in allowlist",
+    },
+    {
+      name: "a denylist",
+      plugins: { deny: ["codex"] },
+      expectedReason: "blocked by denylist",
+    },
+    {
+      name: "an explicitly disabled owner",
+      plugins: { entries: { codex: { enabled: false } } },
+      expectedReason: "disabled in config",
+    },
+  ] satisfies Array<{
+    name: string;
+    plugins: NonNullable<OpenClawConfig["plugins"]>;
+    expectedReason: string;
+  }>)("reports $name without a prepared registry context", async ({ plugins, expectedReason }) => {
     const error = await ensureSelectedAgentHarnessPlugin({
       provider: "openai",
       modelId: "gpt-5.5",
-      config: { plugins: { enabled: false } },
+      config: { plugins },
       agentHarnessRuntimeOverride: "codex",
       workspaceDir: "/tmp/workspace",
       pluginRegistry: undefined,
     }).catch((cause: unknown) => cause);
 
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain("plugins disabled");
+    expect((error as Error).message).toContain(expectedReason);
     expect((error as Error).message).not.toContain("absent from this prepared plugin generation");
   });
 

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -94,21 +94,20 @@ function describeMissingHarnessRegistration(
       continue;
     }
     const plugin = context?.metadataSnapshot?.byPluginId.get(pluginId);
-    if (!plugin) {
-      blockers.push(`Owner plugin "${pluginId}" is absent from this prepared plugin generation`);
-      continue;
-    }
     const activation = resolveEffectivePluginActivationState({
       id: pluginId,
-      origin: plugin.origin,
+      // Codex's fallback owner is external; global exposes policy blockers without inventing defaults.
+      origin: plugin?.origin ?? "global",
       config: plugins,
       rootConfig: activationSourceConfig,
-      enabledByDefault: isPluginEnabledByDefaultForPlatform(plugin),
+      enabledByDefault: plugin ? isPluginEnabledByDefaultForPlatform(plugin) : undefined,
     });
     if (!activation.activated) {
       blockers.push(
         `Owner plugin "${pluginId}" is not activatable${activation.reason ? ` (${activation.reason})` : ""}`,
       );
+    } else if (!plugin) {
+      blockers.push(`Owner plugin "${pluginId}" is absent from this prepared plugin generation`);
     }
   }
   const ownerField = ownerPluginIds.length === 1 ? "ownerPluginId" : "ownerPluginIds";


### PR DESCRIPTION
Related: #135118. Refs #134304.

## What Problem This Solves

The context-free library form of the final harness guard accepted explicit plugin config but reported an owner as absent before reading `plugins.allow`, `plugins.deny`, or `plugins.entries.<id>.enabled=false`. That made the new recovery message point at installation even when the config already named the real blocker.

## Why This Change Was Made

The guard now evaluates the existing activation policy before its prepared-generation absence fallback. When owner metadata is unavailable, the known Codex fallback uses the external/global owner semantics: explicit policy blockers remain authoritative, while an otherwise unblocked missing owner still reports absence.

This does not install, enable, trust, or probe a plugin. Prepared-registry owners retain their manifest origin and default-enablement rules; loaded and failed owner precedence is unchanged.

## User Impact

Context-free callers now receive `not in allowlist`, `blocked by denylist`, or `disabled in config` when those facts are already present. Operators no longer get misleading reinstall guidance for those cases.

## Evidence

- Red on fresh `caf1a67dd30a2e04df93a8b240504fb485bcdca0`: all three explicit-policy cases reported `absent from this prepared plugin generation`.
- Green on `1525daffad6b408b0139ae0861c21b4d5452801a`: the same calls report their exact policy reason; the unblocked negative control still reports prepared-generation absence.
- `node scripts/run-vitest.mjs src/agents/harness/runtime-plugin.test.ts`: 43/43 passed.
- `node scripts/check-changed.mjs -- src/agents/harness/runtime-plugin.ts src/agents/harness/runtime-plugin.test.ts`: passed on the final head.
- P3 branch autoreview: no actionable findings.

Production is +5/-6 (net -1); tests are +28/-3 (net +25).