### PR TITLE
refactor(packaging): reuse canonical Docker CLI flag parser

### DIFF
--- a/scripts/package-openclaw-for-docker.mts
+++ b/scripts/package-openclaw-for-docker.mts
@@ -7,7 +7,12 @@ import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { requireOptionArgument } from "./lib/arg-utils.runtime.mjs";
+import {
+  booleanFlag,
+  parseFlagArgs,
+  stringFlag,
+  stringListFlag,
+} from "./lib/arg-utils.runtime.mjs";
 import { DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV } from "./lib/bundled-plugin-build-entries.mjs";
 import { toErrorObject } from "./lib/error-format.mts";
 import { terminateManagedChild } from "./lib/managed-child-process.mts";
@@ -186,13 +191,6 @@ function resolveOptionalTimerTimeoutMs(valueMs: unknown) {
   return resolvePackageBuildTimeoutMs(valueMs, 1);
 }
 
-function readEqualsOptionValue(value: string, optionName: string) {
-  if (value === "" || value.startsWith("-")) {
-    throw new Error(`${optionName} requires a value`);
-  }
-  return value;
-}
-
 function validateOutputName(value: string) {
   if (!/^[A-Za-z0-9][A-Za-z0-9._-]*\.t(?:ar\.)?gz$/u.test(value)) {
     throw new Error(`--output-name must be a tarball filename, not a path: ${value}`);
@@ -222,84 +220,35 @@ function resolvePackedOpenClawFileName(value: string) {
 }
 
 export function parseArgs(argv: string[]) {
-  const args = argv;
-  const options = {
-    bundlePlugins: [] as string[],
-    allowUnreleasedChangelog: false,
-    outputDir: "",
-    outputName: "",
-    packJson: "",
-    pnpmPack: false,
-    skipBuild: false,
-    sourceDir: ROOT_DIR,
-  };
-  const seen = new Set<string>();
-  const setOnce = <Key extends keyof typeof options>(
-    flag: string,
-    key: Key,
-    value: (typeof options)[Key],
-  ): void => {
-    if (seen.has(flag)) {
-      throw new Error(`${flag} was provided more than once`);
-    }
-    seen.add(flag);
-    options[key] = value;
-  };
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (arg === "--allow-unreleased-changelog") {
-      setOnce(arg, "allowUnreleasedChangelog", true);
-    } else if (arg === "--bundle-plugin") {
-      options.bundlePlugins.push(requireOptionArgument(args, index, arg));
-      index += 1;
-    } else if (arg?.startsWith("--bundle-plugin=")) {
-      options.bundlePlugins.push(
-        readEqualsOptionValue(arg.slice("--bundle-plugin=".length), "--bundle-plugin"),
-      );
-    } else if (arg === "--output-dir") {
-      setOnce("--output-dir", "outputDir", requireOptionArgument(args, index, arg));
-      index += 1;
-    } else if (arg?.startsWith("--output-dir=")) {
-      setOnce(
-        "--output-dir",
-        "outputDir",
-        readEqualsOptionValue(arg.slice("--output-dir=".length), "--output-dir"),
-      );
-    } else if (arg === "--output-name") {
-      setOnce("--output-name", "outputName", requireOptionArgument(args, index, arg));
-      index += 1;
-    } else if (arg?.startsWith("--output-name=")) {
-      setOnce(
-        "--output-name",
-        "outputName",
-        readEqualsOptionValue(arg.slice("--output-name=".length), "--output-name"),
-      );
-    } else if (arg === "--pack-json") {
-      setOnce("--pack-json", "packJson", requireOptionArgument(args, index, arg));
-      index += 1;
-    } else if (arg?.startsWith("--pack-json=")) {
-      setOnce(
-        "--pack-json",
-        "packJson",
-        readEqualsOptionValue(arg.slice("--pack-json=".length), "--pack-json"),
-      );
-    } else if (arg === "--pnpm-pack") {
-      setOnce(arg, "pnpmPack", true);
-    } else if (arg === "--skip-build") {
-      setOnce(arg, "skipBuild", true);
-    } else if (arg === "--source-dir") {
-      setOnce("--source-dir", "sourceDir", requireOptionArgument(args, index, arg));
-      index += 1;
-    } else if (arg?.startsWith("--source-dir=")) {
-      setOnce(
-        "--source-dir",
-        "sourceDir",
-        readEqualsOptionValue(arg.slice("--source-dir=".length), "--source-dir"),
-      );
-    } else {
-      throw new Error(`unknown argument: ${arg}`);
-    }
-  }
+  const options = parseFlagArgs(
+    argv,
+    {
+      bundlePlugins: [] as string[],
+      allowUnreleasedChangelog: false,
+      outputDir: "",
+      outputName: "",
+      packJson: "",
+      pnpmPack: false,
+      skipBuild: false,
+      sourceDir: ROOT_DIR,
+    },
+    [
+      booleanFlag("--allow-unreleased-changelog", "allowUnreleasedChangelog"),
+      stringListFlag("--bundle-plugin", "bundlePlugins", { rejectShortOptions: true }),
+      stringFlag("--output-dir", "outputDir", { rejectShortOptions: true }),
+      stringFlag("--output-name", "outputName", { rejectShortOptions: true }),
+      stringFlag("--pack-json", "packJson", { rejectShortOptions: true }),
+      booleanFlag("--pnpm-pack", "pnpmPack"),
+      booleanFlag("--skip-build", "skipBuild"),
+      stringFlag("--source-dir", "sourceDir", { rejectShortOptions: true }),
+    ],
+    {
+      ignoreDoubleDash: false,
+      onUnhandledArg(arg: string) {
+        throw new Error(`unknown argument: ${arg}`);
+      },
+    },
+  );
   if (options.outputName) {
     validateOutputName(options.outputName);
   }

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -394,7 +394,13 @@ describe("package-openclaw-for-docker", () => {
   });
 
   it("rejects missing package artifact option values", () => {
-    for (const flag of ["--output-dir", "--output-name", "--source-dir", "--bundle-plugin"]) {
+    for (const flag of [
+      "--output-dir",
+      "--output-name",
+      "--pack-json",
+      "--source-dir",
+      "--bundle-plugin",
+    ]) {
       expect(() => parseArgs([flag])).toThrow(`${flag} requires a value`);
       expect(() => parseArgs([flag, "--skip-build"])).toThrow(`${flag} requires a value`);
       expect(() => parseArgs([flag, "-h"])).toThrow(`${flag} requires a value`);
@@ -408,6 +414,33 @@ describe("package-openclaw-for-docker", () => {
       "demo",
       "other",
     ]);
+  });
+
+  it.each([
+    {
+      args: ["--output-dir=one", "--output-dir"],
+      message: "--output-dir requires a value",
+    },
+    {
+      args: ["--output-name=../bad.tgz", "--invalid"],
+      message: "unknown argument: --invalid",
+    },
+    {
+      args: ["--output-name=../bad.tgz", "--output-name=valid.tgz"],
+      message: "--output-name was provided more than once",
+    },
+    {
+      args: ["--output-name=../bad.tgz", "--pack-json=pack.json", "--pnpm-pack"],
+      message: "--output-name must be a tarball filename, not a path: ../bad.tgz",
+    },
+    {
+      args: ["--pack-json=pack.json", "--pnpm-pack", "--invalid"],
+      message: "unknown argument: --invalid",
+    },
+    { args: ["--"], message: "unknown argument: --" },
+    { args: ["--skip-build=true"], message: "unknown argument: --skip-build=true" },
+  ])("preserves argument error precedence for $args", ({ args, message }) => {
+    expect(() => parseArgs(args)).toThrow(new Error(message));
   });
 
   it("builds explicit plugin selections through the canonical build environment", async () => {


### PR DESCRIPTION
The Docker packer repeated flag consumption and duplicate detection already owned by `scripts/lib/arg-utils.runtime.mjs`. Use that existing parser and delete the local loop and inline-value reader, preserving the dependency-free trusted-harness import path.

Flag spellings, defaults, repeatable plugin order, exact CLI error messages and validation precedence are unchanged. Filename validation still follows argument parsing and precedes the pack-tool conflict; packaging and child-process lifecycle remain with their existing owners. Production changes are **+35/−86, net −51 lines** (−50 nonblank); tests are +33 lines. No new flags, dependencies, configuration or public type surface.

Validation:

- Captured the original owner before editing, then compared 440 dense-string argv cases and 3,630 invariants against the candidate. All six real `.mjs` CLI cases preserve exact stdout, stderr and exit status, with no output directories created on failure.
- 138 applicable maintained cases pass across the full run and focused recovery; three Windows-only cases are skipped. The initial run had three failures because npm was absent from PATH and one unchanged 2-second child-readiness failure. Using the existing npm executable, all four pass on the sole targeted retry with original deadlines; three exercise actual npm packing. The pnpm case verifies command selection with an injected runner, not a successful real pnpm pack.
- All 16 selected changed-file checks pass, including formatting, script and root-test types, lint, dependency and import boundaries. Managed Codex review is scoped-clean at P2 with no findings in either pass. Exact-head hosted CI is required before landing.

Equivalence covers the actual dense-string process-argv contract. Separately recorded sparse/undefined JavaScript arrays differ because the shared parser skips undefined entries; no observed caller passes those inputs. Internal Error stack locations change, while error shape and CLI-visible text are preserved. No performance improvement is claimed. The unchanged child-readiness timing sensitivity is a recorded test-harness follow-up.


Maintainer validation is complete. The13:04UTC ClawSweeper review has no implementation finding; its before-merge items and sole rank-up move are satisfied by [exact-head CI33510560934](https://github.com/openclaw/openclaw/actions/runs/33510560934), including the successful required gate. The head is `d0101fd46201cb5708c45b9b48270f33d4fc4b1e`.

The parser owner, canonical helper, real entrypoint/callers and complete tests were read directly. All109 retained proof artifacts and final source hashes were verified. The documented dense-argv limitation, three local Windows skips and initial failures remain disclosed above. Production deletion is51 physical/50 nonblank lines; tests grow33 lines. Native preparation rechecks current-main owner/callee drift and exact-head gates before landing.
