### PR TITLE
perf(replies): reduce work when preparing explicit replies

### DIFF
--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -28,7 +28,7 @@ const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]
 const INLINE_DIRECTIVE_TAG_WITH_PADDING_RE =
   /(?:\s*(?:\[\[\s*audio_as_voice\s*\]\]|\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\])\s*|^[\t ]*\[\[\s*(?:reply_to_current(?:[\t ]*\](?!\])|(?=[\t ]+\S)|[\t ]*$)|reply_to\s*:\s*(?:[^\]\r\n]*\](?!\])|[\t ]*$))[\t ]*)/giu;
 const MAX_REPLY_DIRECTIVE_ID_LENGTH = 256;
-const UNSAFE_REPLY_DIRECTIVE_CHARS_RE = /[\p{Cc}\[\]]/gu;
+const UNSAFE_REPLY_DIRECTIVE_CHARS_RE = /[\p{Cc}[\]]/gu;
 const NO_INLINE_DIRECTIVES = {
   audioAsVoice: false,
   replyToCurrent: false,

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -28,6 +28,7 @@ const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]
 const INLINE_DIRECTIVE_TAG_WITH_PADDING_RE =
   /(?:\s*(?:\[\[\s*audio_as_voice\s*\]\]|\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\])\s*|^[\t ]*\[\[\s*(?:reply_to_current(?:[\t ]*\](?!\])|(?=[\t ]+\S)|[\t ]*$)|reply_to\s*:\s*(?:[^\]\r\n]*\](?!\])|[\t ]*$))[\t ]*)/giu;
 const MAX_REPLY_DIRECTIVE_ID_LENGTH = 256;
+const UNSAFE_REPLY_DIRECTIVE_CHARS_RE = /[\p{Cc}\[\]]/gu;
 const NO_INLINE_DIRECTIVES = {
   audioAsVoice: false,
   replyToCurrent: false,
@@ -118,38 +119,19 @@ export function stripInlineDirectiveTagsForDisplay(text: string): StripInlineDir
   };
 }
 
-function stripUnsafeReplyDirectiveChars(value: string): string {
-  const chars: string[] = [];
-  for (const ch of value) {
-    const code = ch.charCodeAt(0);
-    if (
-      (code >= 0 && code <= 31) ||
-      code === 127 ||
-      (code >= 0x80 && code <= 0x9f) ||
-      ch === "[" ||
-      ch === "]"
-    ) {
-      continue;
-    }
-    chars.push(ch);
-  }
-  return chars.join("");
-}
-
 export function sanitizeReplyDirectiveId(rawReplyToId?: string): string | undefined {
   const trimmed = rawReplyToId?.trim();
   if (!trimmed) {
     return undefined;
   }
-  const sanitized = stripUnsafeReplyDirectiveChars(trimmed).trim();
+  const sanitized = trimmed.replace(UNSAFE_REPLY_DIRECTIVE_CHARS_RE, "").trim();
   if (!sanitized) {
     return undefined;
   }
-  const chars = Array.from(sanitized);
-  if (chars.length > MAX_REPLY_DIRECTIVE_ID_LENGTH) {
-    return chars.slice(0, MAX_REPLY_DIRECTIVE_ID_LENGTH).join("");
-  }
-  return sanitized;
+  // UTF-16 length is an upper bound on the number of code points.
+  return sanitized.length <= MAX_REPLY_DIRECTIVE_ID_LENGTH
+    ? sanitized
+    : Array.from(sanitized).slice(0, MAX_REPLY_DIRECTIVE_ID_LENGTH).join("");
 }
 
 export function stripInlineDirectiveTagsForDelivery(text: string): StripInlineDirectiveTagsResult {


### PR DESCRIPTION
## What Problem This Solves

Explicit reply directives do unnecessary character-by-character work on ordinary short message IDs. That work repeats in reply parsing, payload normalization, streaming, and transcript preparation.

## Why This Change Was Made

The shared directive owner now removes the same control characters and brackets with one Unicode regular expression, then uses UTF-16 length as a safe upper bound before allocating a code-point array for long IDs. Both trims and the 256-code-point limit remain unchanged, including lone surrogates and the existing non-idempotent truncation boundary. The separate current-message-ID contract is untouched.

The old character-loop helper and unconditional array conversion are deleted. Production **+6/−24 (net −18)**; no test, dependency, configuration, schema, or public API change. Existing tests already protect the changed behavior; the broader preservation corpus remains experiment evidence rather than a new permanent test framework.

## User Impact

Lower local CPU work while preparing explicit replies. The fixed experiment measured normal explicit-reply parsing **20.7% and 29.5% faster**, with the two complete reply-payload paths **13.9–25.1% faster** across baseline/candidate and candidate/baseline orders. This is not a claim about model response time or overall Gateway latency.

## Evidence

- Existing canonical owner and sibling suites: **411 passed, one existing skip**, eight files covering directive parsing, SDK payloads, stream fragments, Gateway replies, media, and automatic reply payloads.
- Paired real Node before/candidate proof: 20 composite correctness groups and 16 complete output oracles, without module mocks. Native Chromium also passed all 80 sanitizer cases, four display/delivery cases, UI imports, and preamble handling on both variants.
- Candidate production UI build passed asset verification and size budgets; its source map contains the exact candidate owner. The owned browser lease, processes, listeners, and task credentials are closed/removed.
- Fixed timing protocol: four sequential hosts, 64 retained first calls, 512 warmup blocks, 704 measured blocks, **311,360 complete operations**. Every output in all 1,280 vectors was retained and independently checked. Native clock minimum step was 41 ns; ordinary measurements use 256-operation blocks. No concurrent task product tests/builds ran; source/receipt readers remained active, so this is not an exclusive-machine benchmark.
- Tradeoffs retained: the all-invalid-ID leaf was about **6–12 ns slower**; no-directive parsing measured +9.0%/+1.1% across orders. Neither violates the frozen protected-row rule. Five adverse medians and 19 adverse first calls remain in the evidence; first calls are not claimed improvements. Candidate RSS was higher in both timing orders, so there is no memory-reduction claim.
- Independent structured Codex review: no actionable findings in the selected scope/priority. Separate subagent audits reproduced correctness, raw timing, and resource closure.
- Final committed candidate built with `pnpm build qaRuntime` and completed five isolated real OpenAI Gateway turns: readiness, an explicit reply directive, tool discovery, a file read, and web fetching. The reply rendered as `DIRECTIVE_READY` and persisted the correct reply target. Both web fetches returned HTTP 200. Seventeen other RPCs also completed. This is candidate integration proof, not an end-to-end latency comparison.
- The first changed-gate run passed type, guard, formatting and dead-code stages but caught a redundant regex escape. Removing that one backslash passed typed lint and the repeated 411-test set. Historical benchmark/browser/UI evidence retains the original equivalent regex bytes; it was not retimed or relabeled. The final committed source was used by the real Gateway proof.
- Live process/group/listener closure and removal of the credential FIFO, temporary configs, tool spills and exact task-owned SQLite coordinators were checked. Raw CPU profiles remain private evidence; no provider credentials are in this PR.

[Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33511152366) on the final committed candidate. The earlier run was cancelled after the lint correction. Release-note context: faster explicit-reply preparation with unchanged ID sanitization and Unicode boundaries.
