### PR TITLE
fix(github): report missing CLI before Connect starts

### DIFF
--- a/src/gateway/server-methods/tools-github.test.ts
+++ b/src/gateway/server-methods/tools-github.test.ts
@@ -11,6 +11,7 @@ const github = vi.hoisted(() => ({
   updateConfig: vi.fn(),
 }));
 const secrets = vi.hoisted(() => ({ consumeHandoff: vi.fn() }));
+const binaries = vi.hoisted(() => ({ detect: vi.fn() }));
 const oauth = {
   startAuthorization: vi.fn(),
   pollAuthorization: vi.fn(),
@@ -32,6 +33,7 @@ vi.mock("../github-tool-identity-config.js", () => ({
 vi.mock("../../secrets/store/secret-store.js", () => ({
   consumeGitHubSetupHandoff: secrets.consumeHandoff,
 }));
+vi.mock("../../infra/detect-binary.js", () => ({ detectBinary: binaries.detect }));
 vi.mock("../../agents/agent-scope.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../agents/agent-scope.js")>()),
   listAgentIds: vi.fn(() => ["main", "reviewer"]),
@@ -101,6 +103,7 @@ describe("tools.github handlers", () => {
     github.configured.mockReturnValue(undefined);
     github.status.mockResolvedValue(status);
     github.updateConfig.mockResolvedValue({ next: true });
+    binaries.detect.mockReset().mockResolvedValue(true);
     oauth.startAuthorization.mockReset();
     oauth.pollAuthorization.mockReset();
     oauth.cancelAuthorization.mockReset();
@@ -287,6 +290,7 @@ describe("tools.github handlers", () => {
     const cancel = await invoke("tools.github.authorize.cancel", { requestId });
 
     expect(oauth.startAuthorization).toHaveBeenCalledWith({ scope: "agent", agentId: "main" });
+    expect(binaries.detect).toHaveBeenCalledWith("gh");
     expect(oauth.pollAuthorization).toHaveBeenCalledWith(requestId);
     expect(oauth.cancelAuthorization).toHaveBeenCalledWith(requestId);
     expect(start.mock.calls[0]?.[1]).toEqual({
@@ -300,6 +304,38 @@ describe("tools.github handlers", () => {
     expect(cancel).toHaveBeenCalledWith(true, { cancelled: true });
     expect(JSON.stringify(start.mock.calls)).not.toContain("device_code");
     expect(JSON.stringify(start.mock.calls)).not.toContain("access_token");
+  });
+
+  it("rejects device authorization before code issuance when GitHub CLI is unavailable", async () => {
+    binaries.detect.mockResolvedValue(false);
+
+    const respond = await invoke("tools.github.authorize.start", {
+      scope: "system",
+      agentId: "main",
+    });
+
+    expect(binaries.detect).toHaveBeenCalledWith("gh");
+    expect(oauth.startAuthorization).not.toHaveBeenCalled();
+    expect(respond.mock.calls[0]?.[0]).toBe(false);
+    expect(JSON.stringify(respond.mock.calls)).toContain(
+      "GitHub CLI (gh) is required on the Gateway host. Install it from https://cli.github.com/ and retry.",
+    );
+  });
+
+  it("keeps unrelated authorization-start failures bounded", async () => {
+    oauth.startAuthorization.mockRejectedValue(
+      new Error("device_code=private access_token=private upstream failure"),
+    );
+
+    const respond = await invoke("tools.github.authorize.start", {
+      scope: "system",
+      agentId: "main",
+    });
+
+    expect(respond.mock.calls[0]?.[0]).toBe(false);
+    expect(JSON.stringify(respond.mock.calls)).toContain("GitHub authorization could not start");
+    expect(JSON.stringify(respond.mock.calls)).not.toContain("device_code");
+    expect(JSON.stringify(respond.mock.calls)).not.toContain("access_token");
   });
 
   it("returns bounded authorization failures without forwarding diagnostics", async () => {

--- a/src/gateway/server-methods/tools-github.ts
+++ b/src/gateway/server-methods/tools-github.ts
@@ -15,6 +15,7 @@ import {
   resolveGitHubToolIdentityStatus,
   resolveManagedGitHubProfileDir,
 } from "../../agents/github-tool-identity.js";
+import { detectBinary } from "../../infra/detect-binary.js";
 import { consumeGitHubSetupHandoff } from "../../secrets/store/secret-store.js";
 import { updateGitHubToolIdentityConfig } from "../github-tool-identity-config.js";
 import { resolveAgentIdOrRespondError } from "./agent-id-shared.js";
@@ -169,6 +170,17 @@ export const toolsGitHubHandlers: GatewayRequestHandlers = {
       const service = context.githubOAuthService;
       if (!service) {
         throw new Error("GitHub authorization lifecycle is unavailable.");
+      }
+      if (!(await detectBinary("gh"))) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.UNAVAILABLE,
+            "GitHub CLI (gh) is required on the Gateway host. Install it from https://cli.github.com/ and retry.",
+          ),
+        );
+        return;
       }
       respond(
         true,

--- a/ui/src/pages/agents/github-identity-controller.test.ts
+++ b/ui/src/pages/agents/github-identity-controller.test.ts
@@ -586,6 +586,24 @@ describe("GitHubIdentityController", () => {
     expect(controller.authorization).toEqual({ phase: "idle" });
   });
 
+  it("surfaces actionable authorization-start failures from the Gateway", async () => {
+    const message =
+      "GitHub CLI (gh) is required on the Gateway host. Install it from https://cli.github.com/ and retry.";
+    const request = vi.fn(async (method: string) => {
+      if (method === "tools.github.authorize.start") {
+        throw new Error(message);
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const controller = createStatusOnlyController(client);
+    sync(controller, client);
+
+    await controller.startAuthorization();
+
+    expect(controller.authorization).toEqual({ phase: "failed", message });
+  });
+
   it.each([
     { label: "selected agent changes", overrides: { agentId: "reviewer" } },
     { label: "connection generation changes", overrides: { clientRevision: 2 } },


### PR DESCRIPTION
Closes #135028

## What Problem This Solves

Fixes an issue where operators using **Agents → Tools → GitHub Identity → Connect GitHub** could complete a device-code flow on a Gateway host without `gh`, only to receive a generic failure after authorization.

## Why This Change Was Made

The Gateway now reuses the canonical binary detector before issuing a device code. A missing GitHub CLI returns one bounded, actionable `UNAVAILABLE` response; the existing OAuth lifecycle, UI error propagation, and redaction behavior remain unchanged for every other outcome.

## User Impact

Operators immediately learn that GitHub CLI is required on the Gateway host and can install it before retrying, instead of spending a device authorization on a flow that cannot finish.

## Evidence

### Exact-head proof receipt

- Product head SHA: `89a2d1453be3ab7883367ad537670aacbd19b9c0`
- Production entry: Control UI **Connect GitHub** → Gateway RPC `tools.github.authorize.start`
- Canonical owner exercised: `src/gateway/server-methods/tools-github.ts` at the device-authorization admission boundary
- Recorder/readback boundary: mocked OAuth lifecycle calls plus the Gateway `respond` envelope; UI controller state is read back after the RPC error
- Acceptance-red observation: on the unchanged pre-fix current-main surfaces, the new handler assertions produced `11 passed / 2 failed`; the missing-`gh` case still invoked `startAuthorization`
- Acceptance-green observation: exact product head produced `13/13` Gateway tests and `26/26` UI-controller tests passing
- Legal controls: when `gh` is present, start/poll/cancel delegation remains intact; unrelated start failures remain generic and do not expose `device_code` or `access_token`
- Real resolver readback: an isolated host PATH returned `{"gh":false}` from the production `detectBinary("gh")` implementation
- Inspectable output: the missing-binary test records `startAuthorization` as not called and the actionable `UNAVAILABLE` response as returned
- Cleanup/limitations: no device code, token, profile, config, or live GitHub account was created; full repository CI is left to the PR merge ref

Focused exact-head command:

```bash
node scripts/run-vitest.mjs src/gateway/server-methods/tools-github.test.ts ui/src/pages/agents/github-identity-controller.test.ts
```

Result:

```text
Gateway: 1 file passed, 13 tests passed
UI:      1 file passed, 26 tests passed
```

Production resolver control:

```bash
PATH=/usr/bin:/bin /media/vdc/0668001470/home/.cache/pr122200-android/node24/bin/node --import tsx --input-type=module -e 'const { detectBinary } = await import("./src/infra/detect-binary.ts"); console.log(JSON.stringify({gh: await detectBinary("gh")}));'
```

```json
{"gh":false}
```

Additional gates:

- Fresh branch autoreview: `scoped-clean`, patch correct `0.99`, no actionable findings
- Formatting: `oxfmt --check` passed
- Patch hygiene: `git diff --check` passed
- Latest upstream increment changed only duration-formatting surfaces; target surfaces were unchanged and the merge tree was clean

### Scope and risk accounting

- Files: 3
- Production LOC: `+12/-0`
- Test LOC: `+54/-0`
- Existing-solutions preflight: reused OpenClaw's existing `detectBinary` helper and existing UI error rendering; no new dependency, config, workflow, or custom subsystem
- Sibling coverage: successful device start, polling, cancellation, PAT setup, bounded unrelated failures, and UI error readback
- Not retested live: successful GitHub device authorization against a real account; existing lifecycle tests cover that path, and this proof intentionally created no external authorization state
- Config/default impact: none
- Protocol/schema/migration impact: none
- Security/upgrade impact: no new credential surface; raw subprocess and OAuth diagnostics remain redacted
