### PR TITLE
refactor(codex): deduplicate command display text

### DIFF
--- a/extensions/codex/src/command-diagnostics-support.ts
+++ b/extensions/codex/src/command-diagnostics-support.ts
@@ -8,6 +8,7 @@ import {
   type CodexDiagnosticsTarget,
   type PendingCodexDiagnosticsConfirmation,
 } from "./command-diagnostics-state.js";
+import { escapeCodexChatText, formatCodexTextForDisplay } from "./command-display-text.js";
 import { splitArgs } from "./command-handler-args.js";
 
 type ParsedDiagnosticsArgs =
@@ -331,33 +332,6 @@ function formatCodexDiagnosticsTargetLine(target: CodexDiagnosticsTarget): strin
   return `- ${parts.join(", ")}`;
 }
 
-export function escapeCodexChatText(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll("@", "\uff20")
-    .replaceAll("`", "\uff40")
-    .replaceAll("[", "\uff3b")
-    .replaceAll("]", "\uff3d")
-    .replaceAll("(", "\uff08")
-    .replaceAll(")", "\uff09")
-    .replaceAll("*", "\u2217")
-    .replaceAll("_", "\uff3f")
-    .replaceAll("~", "\uff5e")
-    .replaceAll("|", "\uff5c");
-}
-
-export function formatCodexTextForDisplay(value: string): string {
-  let safe = "";
-  for (const character of value) {
-    const codePoint = character.codePointAt(0);
-    safe += codePoint != null && isUnsafeDisplayCodePoint(codePoint) ? "?" : character;
-  }
-  safe = safe.trim();
-  return safe || "<unknown>";
-}
-
 export function readCodexDiagnosticsTargetsCooldownMessage(
   targets: readonly CodexDiagnosticsTarget[],
   ctx: PluginCommandContext,
@@ -524,22 +498,6 @@ function formatCodexResumeCommandForDisplay(threadId: string): string {
     return "run codex resume and paste the thread id shown above";
   }
   return `\`codex resume ${safeThreadId}\``;
-}
-
-function isUnsafeDisplayCodePoint(codePoint: number): boolean {
-  return (
-    codePoint <= 0x001f ||
-    (codePoint >= 0x007f && codePoint <= 0x009f) ||
-    codePoint === 0x00ad ||
-    codePoint === 0x061c ||
-    codePoint === 0x180e ||
-    (codePoint >= 0x200b && codePoint <= 0x200f) ||
-    (codePoint >= 0x202a && codePoint <= 0x202e) ||
-    (codePoint >= 0x2060 && codePoint <= 0x206f) ||
-    codePoint === 0xfeff ||
-    (codePoint >= 0xfff9 && codePoint <= 0xfffb) ||
-    (codePoint >= 0xe0000 && codePoint <= 0xe007f)
-  );
 }
 
 function normalizeCodexDiagnosticsScopeField(value: string | undefined): string | undefined {

--- a/extensions/codex/src/command-diagnostics.ts
+++ b/extensions/codex/src/command-diagnostics.ts
@@ -16,10 +16,8 @@ import {
   codexDiagnosticsTargetsMatch,
   createCodexDiagnosticsConfirmation,
   deletePendingCodexDiagnosticsConfirmation,
-  escapeCodexChatText,
   formatCodexDiagnosticsTargetLines,
   formatCodexDiagnosticsUploadResult,
-  formatCodexTextForDisplay,
   formatDiagnosticsUsage,
   normalizeDiagnosticsReason,
   parseDiagnosticsArgs,
@@ -30,6 +28,7 @@ import {
   readPendingCodexDiagnosticsConfirmation,
   recordCodexDiagnosticsUpload,
 } from "./command-diagnostics-support.js";
+import { escapeCodexChatText, formatCodexTextForDisplay } from "./command-display-text.js";
 import { CODEX_CONTROL_METHODS, type CodexCommandDeps } from "./command-handler-deps.js";
 import { resolveControlTarget } from "./command-handler-scope.js";
 

--- a/extensions/codex/src/command-display-text.test.ts
+++ b/extensions/codex/src/command-display-text.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  escapeCodexChatText,
+  formatCodexTextForDisplay,
+  sanitizeCodexTextForDisplay,
+} from "./command-display-text.js";
+
+const fromCodePoints = (codePoints: readonly number[]) =>
+  codePoints.map((codePoint) => String.fromCodePoint(codePoint)).join("");
+
+describe("Codex command display text", () => {
+  it("escapes chat formatting and mention characters in order", () => {
+    expect(escapeCodexChatText("&<>@\\`[]()*_~|")).toBe(
+      "&amp;&lt;&gt;\uff20\\\uff40\uff3b\uff3d\uff08\uff09\u2217\uff3f\uff5e\uff5c",
+    );
+  });
+
+  it("replaces every unsafe display range endpoint", () => {
+    const unsafe = [
+      0x0000, 0x001f, 0x007f, 0x009f, 0x00ad, 0x061c, 0x180e, 0x200b, 0x200f, 0x202a, 0x202e,
+      0x2060, 0x206f, 0xfeff, 0xfff9, 0xfffb, 0xe0000, 0xe007f,
+    ];
+    expect(sanitizeCodexTextForDisplay(fromCodePoints(unsafe))).toBe("?".repeat(unsafe.length));
+  });
+
+  it("preserves code points adjacent to unsafe ranges", () => {
+    const safe = [
+      0x0020, 0x007e, 0x00a0, 0x00ac, 0x00ae, 0x061b, 0x061d, 0x180d, 0x180f, 0x200a, 0x2010,
+      0x2029, 0x202f, 0x205f, 0x2070, 0xfefe, 0xff00, 0xfff8, 0xfffc, 0xdffff, 0xe0080,
+    ];
+    const value = fromCodePoints(safe);
+    expect(sanitizeCodexTextForDisplay(value)).toBe(value);
+  });
+
+  it("preserves safe astral text and replaces one tag code point once", () => {
+    expect(sanitizeCodexTextForDisplay(`A😀${String.fromCodePoint(0xe0001)}B`)).toBe("A😀?B");
+  });
+
+  it("trims display text, supplies the fallback, and neutralizes at signs", () => {
+    expect(formatCodexTextForDisplay("  value  ")).toBe("value");
+    expect(formatCodexTextForDisplay(" \u00a0 ")).toBe("<unknown>");
+    expect(escapeCodexChatText(formatCodexTextForDisplay(" user@example.com "))).toBe(
+      "user\uff20example.com",
+    );
+  });
+});

--- a/extensions/codex/src/command-display-text.ts
+++ b/extensions/codex/src/command-display-text.ts
@@ -1,0 +1,49 @@
+/** Escapes Codex-originated text so it is safe to render in chat command output. */
+export function escapeCodexChatText(value: string): string {
+  // Command output is public chat text. Escape markdown/control triggers and
+  // mention characters so Codex data cannot ping users or inject formatting.
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("@", "\uff20")
+    .replaceAll("`", "\uff40")
+    .replaceAll("[", "\uff3b")
+    .replaceAll("]", "\uff3d")
+    .replaceAll("(", "\uff08")
+    .replaceAll(")", "\uff09")
+    .replaceAll("*", "\u2217")
+    .replaceAll("_", "\uff3f")
+    .replaceAll("~", "\uff5e")
+    .replaceAll("|", "\uff5c");
+}
+
+export function formatCodexTextForDisplay(value: string): string {
+  const safe = sanitizeCodexTextForDisplay(value).trim();
+  return safe || "<unknown>";
+}
+
+export function sanitizeCodexTextForDisplay(value: string): string {
+  let safe = "";
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    safe += codePoint != null && isUnsafeDisplayCodePoint(codePoint) ? "?" : character;
+  }
+  return safe;
+}
+
+function isUnsafeDisplayCodePoint(codePoint: number): boolean {
+  return (
+    codePoint <= 0x001f ||
+    (codePoint >= 0x007f && codePoint <= 0x009f) ||
+    codePoint === 0x00ad ||
+    codePoint === 0x061c ||
+    codePoint === 0x180e ||
+    (codePoint >= 0x200b && codePoint <= 0x200f) ||
+    (codePoint >= 0x202a && codePoint <= 0x202e) ||
+    (codePoint >= 0x2060 && codePoint <= 0x206f) ||
+    codePoint === 0xfeff ||
+    (codePoint >= 0xfff9 && codePoint <= 0xfffb) ||
+    (codePoint >= 0xe0000 && codePoint <= 0xe007f)
+  );
+}

--- a/extensions/codex/src/command-formatters.ts
+++ b/extensions/codex/src/command-formatters.ts
@@ -12,6 +12,11 @@ import {
   summarizeCodexRateLimits,
 } from "./app-server/rate-limits.js";
 import type { CodexAccountAuthOverview } from "./command-account.js";
+import {
+  escapeCodexChatText,
+  formatCodexTextForDisplay,
+  sanitizeCodexTextForDisplay,
+} from "./command-display-text.js";
 import type { SafeValue } from "./command-rpc.js";
 
 type CodexStatusProbes = {
@@ -301,39 +306,6 @@ function formatCodexAccountSummary(value: JsonValue | undefined): string {
     : escapeCodexChatText(safe);
 }
 
-function formatCodexTextForDisplay(value: string): string {
-  const safe = sanitizeCodexTextForDisplay(value).trim();
-  return safe || "<unknown>";
-}
-
-function sanitizeCodexTextForDisplay(value: string): string {
-  let safe = "";
-  for (const character of value) {
-    const codePoint = character.codePointAt(0);
-    safe += codePoint != null && isUnsafeDisplayCodePoint(codePoint) ? "?" : character;
-  }
-  return safe;
-}
-
-function escapeCodexChatText(value: string): string {
-  // Command output is public chat text. Escape markdown/control triggers and
-  // mention characters so Codex data cannot ping users or inject formatting.
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll("@", "\uff20")
-    .replaceAll("`", "\uff40")
-    .replaceAll("[", "\uff3b")
-    .replaceAll("]", "\uff3d")
-    .replaceAll("(", "\uff08")
-    .replaceAll(")", "\uff09")
-    .replaceAll("*", "\u2217")
-    .replaceAll("_", "\uff3f")
-    .replaceAll("~", "\uff5e")
-    .replaceAll("|", "\uff5c");
-}
-
 function escapeCodexChatTextPreservingAt(value: string): string {
   return escapeCodexChatText(value).replaceAll("\uff20", "@");
 }
@@ -361,22 +333,6 @@ function formatCodexAccountLine(value: string): string {
 
 function isLikelyEmailAddress(value: string): boolean {
   return /^[^\s@<>()[\]`]+@[^\s@<>()[\]`]+\.[^\s@<>()[\]`]+$/.test(value);
-}
-
-function isUnsafeDisplayCodePoint(codePoint: number): boolean {
-  return (
-    codePoint <= 0x001f ||
-    (codePoint >= 0x007f && codePoint <= 0x009f) ||
-    codePoint === 0x00ad ||
-    codePoint === 0x061c ||
-    codePoint === 0x180e ||
-    (codePoint >= 0x200b && codePoint <= 0x200f) ||
-    (codePoint >= 0x202a && codePoint <= 0x202e) ||
-    (codePoint >= 0x2060 && codePoint <= 0x206f) ||
-    codePoint === 0xfeff ||
-    (codePoint >= 0xfff9 && codePoint <= 0xfffb) ||
-    (codePoint >= 0xe0000 && codePoint <= 0xe007f)
-  );
 }
 
 /** Builds the portable `/codex` command help text. */


### PR DESCRIPTION
## What Problem This Solves

Codex command display-text escaping and Unicode sanitization had multiple local implementations. The duplicated policy could drift between account/status formatting and diagnostics output even though both surfaces require byte-identical rendering behavior.

## Why This Change Was Made

The Codex plugin now owns this policy in one private leaf module. Formatters and diagnostics import the canonical escape/format helpers directly; the formatter also imports sanitization, while validated account-email rendering keeps its existing local `@` restoration.

Removed duplicates:

- diagnostics-local escape, format, and unsafe-code-point policy
- formatter-local escape, format, sanitize, and unsafe-code-point policy

No core, SDK, barrel, protocol, dependency, config, generated, Copilot, or changelog surface changed.

## User Impact

No intended user-visible behavior change. Replacement order, markup/mention neutralization, Unicode ranges, astral handling, trimming, `<unknown>`, and email-only `@` restoration remain unchanged.

## Evidence

Owner and LOC:

- production: +56 / -94, net -38
- tests: +46 / -0
- total: +102 / -94 across exactly five files

Sibling coverage:

- existing Codex command tests retain validated account-email `@` restoration and display-boundary coverage
- full Codex extension suite passed
- Copilot remains local and unchanged

Exact checks:

- `node scripts/run-vitest.mjs extensions/codex/src/command-display-text.test.ts extensions/codex/src/commands.test.ts` - 2 files, 210 tests passed
- `pnpm test:extension codex` - 205 test files passed
- `pnpm check:import-cycles` - 0 runtime value cycles
- `pnpm check:madge-import-cycles` - 0 cycles
- `node scripts/check-changed.mjs --dry-run -- <five paths>` - passed
- `node scripts/check-changed.mjs -- <five paths>` - passed
- `pnpm build` - passed
- `git diff --check` - passed
- local autoreview with Codex `gpt-5.6-sol` at high reasoning - scoped clean, no accepted/actionable findings

Codex hard gate:

- personally inspected `../codex/codex-rs/cli/src/main.rs:220-245`
- personally inspected `../codex/codex-rs/cli/src/main.rs:2840-2870`
- those CLI dispatch/completion and prompt-normalization paths are separate from OpenClaw's plugin-local chat display-text ownership

No changelog entry: this is an internal behavior-preserving deduplication with no shipped user-visible change.
