### PR TITLE
refactor(session): centralize access scope projection

### DIFF
--- a/src/config/sessions/session-accessor.scope.test.ts
+++ b/src/config/sessions/session-accessor.scope.test.ts
@@ -1,0 +1,45 @@
+import { expect, it } from "vitest";
+import { toSessionAccessScope } from "./session-accessor.scope.js";
+
+it("projects only caller-facing scope fields", () => {
+  const env = { OPENCLAW_STATE_DIR: "/tmp/openclaw-state" };
+  const inheritedParams = Object.assign(Object.create({ agentId: "ops" }), {
+    env,
+    hydrateSkillPromptRefs: false,
+    readConsistency: "latest" as const,
+    sessionKey: "",
+    storePath: "",
+  });
+
+  expect(toSessionAccessScope(inheritedParams)).toStrictEqual({
+    sessionKey: "",
+    agentId: "ops",
+    env,
+    hydrateSkillPromptRefs: false,
+    readConsistency: "latest",
+    storePath: "",
+  });
+
+  const forbiddenReads: PropertyKey[] = [];
+  const proxyValues = { agentId: "worker", hydrateSkillPromptRefs: false } as const;
+  const proxyParams = new Proxy(
+    { clone: false, defaultAgentId: "main", extra: "private", sessionKey: "session" },
+    {
+      get(target, property, receiver) {
+        if (property === "clone" || property === "defaultAgentId" || property === "extra") {
+          forbiddenReads.push(property);
+        }
+        return property in proxyValues
+          ? proxyValues[property as keyof typeof proxyValues]
+          : Reflect.get(target, property, receiver);
+      },
+    },
+  );
+
+  expect(toSessionAccessScope(proxyParams)).toStrictEqual({
+    sessionKey: "session",
+    agentId: "worker",
+    hydrateSkillPromptRefs: false,
+  });
+  expect(forbiddenReads).toStrictEqual([]);
+});

--- a/src/config/sessions/session-accessor.scope.ts
+++ b/src/config/sessions/session-accessor.scope.ts
@@ -1,0 +1,21 @@
+import type { SessionAccessScope } from "./session-accessor.types.js";
+
+type SessionAccessScopeInput = Pick<
+  SessionAccessScope,
+  "agentId" | "env" | "hydrateSkillPromptRefs" | "readConsistency" | "sessionKey" | "storePath"
+>;
+
+export function toSessionAccessScope(params: SessionAccessScopeInput): SessionAccessScope {
+  // Keep caller-facing read options separate from accessor-only controls so
+  // new internal fields cannot leak across this owner boundary automatically.
+  return {
+    sessionKey: params.sessionKey,
+    ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
+    ...(params.env !== undefined ? { env: params.env } : {}),
+    ...(params.hydrateSkillPromptRefs !== undefined
+      ? { hydrateSkillPromptRefs: params.hydrateSkillPromptRefs }
+      : {}),
+    ...(params.readConsistency !== undefined ? { readConsistency: params.readConsistency } : {}),
+    ...(params.storePath !== undefined ? { storePath: params.storePath } : {}),
+  };
+}

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -5,6 +5,7 @@
  * Runtime callers import this barrel instead of storage-specific modules.
  */
 export * from "./session-history.js";
+export { toSessionAccessScope } from "./session-accessor.scope.js";
 export {
   bindSessionPendingInputSources,
   listSessionPendingInputReceipts,

--- a/src/plugin-sdk/session-store-runtime-internal.ts
+++ b/src/plugin-sdk/session-store-runtime-internal.ts
@@ -1,5 +1,4 @@
 import { MAIN_SESSION_RECOVERY_CLEAR_PATCH } from "../agents/main-session-recovery/main-session-recovery-clear.js";
-import type { SessionAccessScope } from "../config/sessions/session-accessor.js";
 import {
   projectPublicSessionEntry,
   projectPublicSessionEntryPatch,
@@ -15,20 +14,6 @@ export type SessionStoreReadParams = {
   sessionKey: string;
   storePath?: string;
 };
-
-export function toSessionAccessScope(params: SessionStoreReadParams): SessionAccessScope {
-  // Keep plugin-facing options separate from internal accessor-only controls.
-  return {
-    sessionKey: params.sessionKey,
-    ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
-    ...(params.env !== undefined ? { env: params.env } : {}),
-    ...(params.hydrateSkillPromptRefs !== undefined
-      ? { hydrateSkillPromptRefs: params.hydrateSkillPromptRefs }
-      : {}),
-    ...(params.readConsistency !== undefined ? { readConsistency: params.readConsistency } : {}),
-    ...(params.storePath !== undefined ? { storePath: params.storePath } : {}),
-  };
-}
 
 export function projectPluginSessionEntry(entry: InternalSessionEntry): SessionEntry {
   const publicEntry = projectPublicSessionEntry(entry);

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -28,6 +28,7 @@ import {
   readSessionUpdatedAtCore as readAccessorSessionUpdatedAt,
   readTranscriptStatsSync as readAccessorTranscriptStatsSync,
   resolveTranscriptSessionKeyBySessionId as resolveAccessorTranscriptSessionKeyBySessionId,
+  toSessionAccessScope,
   updateSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
@@ -49,7 +50,6 @@ import {
   projectPluginSessionStore,
   reconcilePluginSessionStore,
   type SessionStoreReadParams,
-  toSessionAccessScope,
 } from "./session-store-runtime-internal.js";
 import type { SessionTranscriptEvent } from "./session-transcript-runtime.js";
 export { SessionStoreAgentIdRequiredError } from "../config/sessions/paths.js";

--- a/src/plugins/runtime/runtime-agent.ts
+++ b/src/plugins/runtime/runtime-agent.ts
@@ -27,7 +27,7 @@ import {
   replaceSessionEntry,
   rollbackAgentHarnessSessionEntryLifecycle,
   rollbackPluginOwnedSessionEntryLifecycle,
-  type SessionAccessScope,
+  toSessionAccessScope,
   updateSessionEntry,
 } from "../../config/sessions/session-accessor.js";
 import { normalizeResolvedMaintenanceConfigInput } from "../../config/sessions/store-maintenance.js";
@@ -103,21 +103,6 @@ const loadAgentCommandRuntime = createLazyRuntimeModule(async () => {
   ]);
   return { command, identity };
 });
-
-function toSessionAccessScope(params: RuntimeSessionStoreReadParams): SessionAccessScope {
-  // Keep plugin runtime parameters aligned with the public SDK wrapper while
-  // avoiding direct exposure of internal accessor-only options.
-  return {
-    sessionKey: params.sessionKey,
-    ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
-    ...(params.env !== undefined ? { env: params.env } : {}),
-    ...(params.hydrateSkillPromptRefs !== undefined
-      ? { hydrateSkillPromptRefs: params.hydrateSkillPromptRefs }
-      : {}),
-    ...(params.readConsistency !== undefined ? { readConsistency: params.readConsistency } : {}),
-    ...(params.storePath !== undefined ? { storePath: params.storePath } : {}),
-  };
-}
 
 function getSessionEntry(params: RuntimeSessionStoreReadParams): SessionEntry | undefined {
   return loadSessionEntryReadOnly(toSessionAccessScope(params));


### PR DESCRIPTION
## What Problem This Solves

The plugin runtime facade and Plugin SDK session wrapper independently owned the same session-access whitelist. That duplicated owner policy could drift or accidentally expose new internal accessor controls when either copy changed.

## Why This Change Was Made

Moves the storage-neutral projection into the session accessor owner and routes both existing callers through that canonical helper. An explicit `Pick` keeps the six accepted read parameters fixed instead of inheriting future internal fields automatically.

No package-exported Plugin SDK surface, API baseline, schema, query, persistence, configuration, compatibility, or list-scope behavior changes.

## User Impact

No user-visible behavior change. Session reads and mutations preserve the same scope projection with one canonical owner.

## Evidence

- Root cause/history: both copies originated in `f1cab04966f`; the SDK copy later moved during `0a868179e4c`, leaving duplicated whitelist policy across owners.
- Exact behavior preserved: `agentId`, `env`, `hydrateSkillPromptRefs`, `readConsistency`, `sessionKey`, and `storePath` are projected; inherited and proxy-provided values remain readable; `false` and empty strings are retained; explicit `undefined` is omitted; `clone`, `defaultAgentId`, and arbitrary extras are neither read nor copied.
- Production LOC: `+24/-32`, net `-8`. Tests: `+45/-0`.
- Focused four-suite run passed 61 tests. The final consolidated scope test reran and passed after test-only formatting cleanup.
- `pnpm test:contracts:plugins`: 46 files, 1,111 tests passed.
- Session-accessor boundary, export-name collision, Plugin SDK surface, import-cycle, Madge cycle, extension lint, dead-export, database-first, native-state schema, media helper, runtime-sidecar, webhook, auth, formatting, oxlint, and diff checks passed.
- Exact six-path `check-changed` dry-run passed. The full run passed every reached gate through core and extension typechecks, then the sparse checkout lacked tracked UI config for deadcode; after adding only the missing tracked sparse paths, deadcode and every not-yet-reached gate passed individually.
- `pnpm build` completed compilation, package, plugin, and CLI bootstrap phases. Runtime postbuild then found the shared installed `@openclaw/ai/diagnostics` artifact stale: current source exports `hasRetryableConnectionErrorCode`, while the installed artifact does not. No changed file imports or modifies that package.
- Sol-high autoreview: scoped clean, no accepted/actionable findings or exposed credentials.
- Codex hard gate inspected directly at `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those CLI command and prompt-normalization paths are unrelated to this storage-neutral projection.
- No changelog entry: behavior-neutral internal refactor.
