### PR TITLE
fix(browser): separate tab enumeration budget from CDP handshake timeout

### DIFF
--- a/extensions/browser/src/browser-tool.routing.ts
+++ b/extensions/browser/src/browser-tool.routing.ts
@@ -117,6 +117,7 @@ const EXISTING_SESSION_MANAGE_ACTIONS = new Set([
   "focus",
   "close",
 ]);
+const PERSISTENT_TAB_ACTIONS = new Set(["profiles", "tabs", "open", "focus", "close"]);
 
 function hasExistingSessionProfile(resolved: ReturnType<typeof resolveBrowserConfig>) {
   return Object.keys(resolved.profiles).some((name) => {
@@ -149,17 +150,9 @@ export function resolveBrowserToolTimeoutMs({
   ) {
     return DEFAULT_EXISTING_SESSION_MANAGE_TIMEOUT_MS;
   }
-  // Persistent-Playwright profiles (e.g. extension relay) enumerate tabs over a
-  // scoped connection that can legitimately take longer than the 3s client
-  // default. Carry the action-level budget so the client does not abort before
-  // the server-side enumeration finishes. A browser-node proxy clears the
-  // profile so the node resolves its own default; the Gateway cannot know
-  // whether that default is persistent-Playwright, so conservatively carry the
-  // action budget for tab-enumeration actions to avoid a 20-second proxy
-  // deadline killing a healthy 20-60s enumeration on the node.
-  const isTabEnumerationAction =
-    action === "tabs" || action === "open" || action === "focus" || action === "close";
-  if (usesPersistentPlaywright || (isNodeProxy && isTabEnumerationAction)) {
+  // A node proxy resolves the profile on its execution host, so the Gateway
+  // must budget tab operations for the possible persistent Playwright path.
+  if (PERSISTENT_TAB_ACTIONS.has(action) && (usesPersistentPlaywright || isNodeProxy)) {
     return resolvedBrowser.actionTimeoutMs;
   }
   return undefined;

--- a/extensions/browser/src/browser-tool.routing.ts
+++ b/extensions/browser/src/browser-tool.routing.ts
@@ -129,18 +129,38 @@ export function resolveBrowserToolTimeoutMs({
   requestedTimeoutMs,
   action,
   isUserBrowserProfile,
+  usesPersistentPlaywright,
+  isNodeProxy,
   resolvedBrowser,
 }: {
   requestedTimeoutMs?: number;
   action: string;
   isUserBrowserProfile: boolean;
+  usesPersistentPlaywright: boolean;
+  isNodeProxy: boolean;
   resolvedBrowser: ReturnType<typeof resolveBrowserConfig>;
 }) {
-  return (
-    requestedTimeoutMs ??
-    (EXISTING_SESSION_MANAGE_ACTIONS.has(action) &&
+  if (requestedTimeoutMs !== undefined) {
+    return requestedTimeoutMs;
+  }
+  if (
+    EXISTING_SESSION_MANAGE_ACTIONS.has(action) &&
     (isUserBrowserProfile || (action === "profiles" && hasExistingSessionProfile(resolvedBrowser)))
-      ? DEFAULT_EXISTING_SESSION_MANAGE_TIMEOUT_MS
-      : undefined)
-  );
+  ) {
+    return DEFAULT_EXISTING_SESSION_MANAGE_TIMEOUT_MS;
+  }
+  // Persistent-Playwright profiles (e.g. extension relay) enumerate tabs over a
+  // scoped connection that can legitimately take longer than the 3s client
+  // default. Carry the action-level budget so the client does not abort before
+  // the server-side enumeration finishes. A browser-node proxy clears the
+  // profile so the node resolves its own default; the Gateway cannot know
+  // whether that default is persistent-Playwright, so conservatively carry the
+  // action budget for tab-enumeration actions to avoid a 20-second proxy
+  // deadline killing a healthy 20-60s enumeration on the node.
+  const isTabEnumerationAction =
+    action === "tabs" || action === "open" || action === "focus" || action === "close";
+  if (usesPersistentPlaywright || (isNodeProxy && isTabEnumerationAction)) {
+    return resolvedBrowser.actionTimeoutMs;
+  }
+  return undefined;
 }

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -5,6 +5,7 @@ import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveBrowserToolTimeoutMs } from "./browser-tool.routing.js";
 import type { BrowserActionPathResult } from "./browser/client-actions-types.js";
+import { resolveBrowserConfig } from "./browser/config.js";
 
 const browserClientMocks = vi.hoisted(() => ({
   browserCloseTab: vi.fn(async (..._args: unknown[]) => ({})),
@@ -5350,27 +5351,7 @@ describe("browser observation actions and tab previews", () => {
 });
 
 describe("resolveBrowserToolTimeoutMs", () => {
-  const resolvedBrowser = {
-    enabled: true,
-    controlPort: 18791,
-    profiles: {},
-    defaultProfile: "openclaw",
-    actionTimeoutMs: 60_000,
-  } as unknown as Parameters<typeof resolveBrowserToolTimeoutMs>[0]["resolvedBrowser"];
-
-  it("gives persistent-Playwright tab listings the action-level budget", () => {
-    // Extension-relay profiles enumerate tabs over a scoped persistent-Playwright
-    // connection; the 3s client default would abort before enumeration finishes.
-    const timeoutMs = resolveBrowserToolTimeoutMs({
-      requestedTimeoutMs: undefined,
-      action: "tabs",
-      isUserBrowserProfile: false,
-      usesPersistentPlaywright: true,
-      isNodeProxy: false,
-      resolvedBrowser,
-    });
-    expect(timeoutMs).toBe(60_000);
-  });
+  const resolvedBrowser = resolveBrowserConfig({ enabled: true });
 
   it("keeps the caller-supplied deadline even for persistent-Playwright profiles", () => {
     const timeoutMs = resolveBrowserToolTimeoutMs({
@@ -5384,59 +5365,23 @@ describe("resolveBrowserToolTimeoutMs", () => {
     expect(timeoutMs).toBe(45_000);
   });
 
-  it("leaves non-persistent-Playwright tab listings on the client default", () => {
-    // Managed/CDP profiles keep the legacy undefined -> 3s client fallback.
-    const timeoutMs = resolveBrowserToolTimeoutMs({
-      requestedTimeoutMs: undefined,
-      action: "tabs",
-      isUserBrowserProfile: false,
-      usesPersistentPlaywright: false,
-      isNodeProxy: false,
-      resolvedBrowser,
-    });
-    expect(timeoutMs).toBeUndefined();
-  });
-
-  it("still resolves existing-session manage actions to the 45s budget", () => {
-    const timeoutMs = resolveBrowserToolTimeoutMs({
-      requestedTimeoutMs: undefined,
-      action: "status",
-      isUserBrowserProfile: true,
-      usesPersistentPlaywright: false,
-      isNodeProxy: false,
-      resolvedBrowser,
-    });
-    expect(timeoutMs).toBe(45_000);
-  });
-
-  it("carries the action budget through a browser-node proxy even when the Gateway default is not persistent-Playwright", () => {
-    // A node proxy clears the profile so the node resolves its own default.
-    // The Gateway cannot know whether that default is persistent-Playwright,
-    // so conservatively carry the action budget to avoid a 20s proxy deadline
-    // killing a healthy 20-60s enumeration on the node.
-    const timeoutMs = resolveBrowserToolTimeoutMs({
-      requestedTimeoutMs: undefined,
-      action: "tabs",
-      isUserBrowserProfile: false,
-      usesPersistentPlaywright: false,
-      isNodeProxy: true,
-      resolvedBrowser,
-    });
-    expect(timeoutMs).toBe(60_000);
-  });
-
-  it("does not extend the proxy budget for non-enumeration actions like status", () => {
-    // Only tab-enumeration actions (tabs, open, focus, close) get the
-    // conservative action budget through a node proxy; status and other
-    // actions keep the legacy 20-second proxy default.
-    const timeoutMs = resolveBrowserToolTimeoutMs({
-      requestedTimeoutMs: undefined,
-      action: "status",
-      isUserBrowserProfile: false,
-      usesPersistentPlaywright: false,
-      isNodeProxy: true,
-      resolvedBrowser,
-    });
-    expect(timeoutMs).toBeUndefined();
-  });
+  it.each([
+    ["persistent tab listing", "tabs", true, false, 60_000],
+    ["persistent lifecycle action", "status", true, false, undefined],
+    ["proxied profile listing", "profiles", false, true, 60_000],
+    ["managed tab listing", "tabs", false, false, undefined],
+  ] as const)(
+    "resolves the %s budget",
+    (_label, action, usesPersistentPlaywright, isNodeProxy, expected) => {
+      const timeoutMs = resolveBrowserToolTimeoutMs({
+        requestedTimeoutMs: undefined,
+        action,
+        isUserBrowserProfile: false,
+        usesPersistentPlaywright,
+        isNodeProxy,
+        resolvedBrowser,
+      });
+      expect(timeoutMs).toBe(expected);
+    },
+  );
 });

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveBrowserToolTimeoutMs } from "./browser-tool.routing.js";
 import type { BrowserActionPathResult } from "./browser/client-actions-types.js";
 
 const browserClientMocks = vi.hoisted(() => ({
@@ -1422,13 +1423,13 @@ describe("browser tool snapshot maxChars", () => {
       "host-tab-compensate",
       {
         profile: "work-actual",
-        timeoutMs: undefined,
+        timeoutMs: 60_000,
       },
     );
     expect(toolCommonMocks.fetchBrowserJson).toHaveBeenLastCalledWith("/tabs/open?profile=work", {
       method: "POST",
       body: JSON.stringify({ url: "https://example.com" }),
-      timeoutMs: undefined,
+      timeoutMs: 60_000,
       signal: controller.signal,
     });
   });
@@ -5345,5 +5346,97 @@ describe("browser observation actions and tab previews", () => {
       refs: 0,
       stats: { chars: 5, refs: 0 },
     });
+  });
+});
+
+describe("resolveBrowserToolTimeoutMs", () => {
+  const resolvedBrowser = {
+    enabled: true,
+    controlPort: 18791,
+    profiles: {},
+    defaultProfile: "openclaw",
+    actionTimeoutMs: 60_000,
+  } as unknown as Parameters<typeof resolveBrowserToolTimeoutMs>[0]["resolvedBrowser"];
+
+  it("gives persistent-Playwright tab listings the action-level budget", () => {
+    // Extension-relay profiles enumerate tabs over a scoped persistent-Playwright
+    // connection; the 3s client default would abort before enumeration finishes.
+    const timeoutMs = resolveBrowserToolTimeoutMs({
+      requestedTimeoutMs: undefined,
+      action: "tabs",
+      isUserBrowserProfile: false,
+      usesPersistentPlaywright: true,
+      isNodeProxy: false,
+      resolvedBrowser,
+    });
+    expect(timeoutMs).toBe(60_000);
+  });
+
+  it("keeps the caller-supplied deadline even for persistent-Playwright profiles", () => {
+    const timeoutMs = resolveBrowserToolTimeoutMs({
+      requestedTimeoutMs: 45_000,
+      action: "tabs",
+      isUserBrowserProfile: false,
+      usesPersistentPlaywright: true,
+      isNodeProxy: false,
+      resolvedBrowser,
+    });
+    expect(timeoutMs).toBe(45_000);
+  });
+
+  it("leaves non-persistent-Playwright tab listings on the client default", () => {
+    // Managed/CDP profiles keep the legacy undefined -> 3s client fallback.
+    const timeoutMs = resolveBrowserToolTimeoutMs({
+      requestedTimeoutMs: undefined,
+      action: "tabs",
+      isUserBrowserProfile: false,
+      usesPersistentPlaywright: false,
+      isNodeProxy: false,
+      resolvedBrowser,
+    });
+    expect(timeoutMs).toBeUndefined();
+  });
+
+  it("still resolves existing-session manage actions to the 45s budget", () => {
+    const timeoutMs = resolveBrowserToolTimeoutMs({
+      requestedTimeoutMs: undefined,
+      action: "status",
+      isUserBrowserProfile: true,
+      usesPersistentPlaywright: false,
+      isNodeProxy: false,
+      resolvedBrowser,
+    });
+    expect(timeoutMs).toBe(45_000);
+  });
+
+  it("carries the action budget through a browser-node proxy even when the Gateway default is not persistent-Playwright", () => {
+    // A node proxy clears the profile so the node resolves its own default.
+    // The Gateway cannot know whether that default is persistent-Playwright,
+    // so conservatively carry the action budget to avoid a 20s proxy deadline
+    // killing a healthy 20-60s enumeration on the node.
+    const timeoutMs = resolveBrowserToolTimeoutMs({
+      requestedTimeoutMs: undefined,
+      action: "tabs",
+      isUserBrowserProfile: false,
+      usesPersistentPlaywright: false,
+      isNodeProxy: true,
+      resolvedBrowser,
+    });
+    expect(timeoutMs).toBe(60_000);
+  });
+
+  it("does not extend the proxy budget for non-enumeration actions like status", () => {
+    // Only tab-enumeration actions (tabs, open, focus, close) get the
+    // conservative action budget through a node proxy; status and other
+    // actions keep the legacy 20-second proxy default.
+    const timeoutMs = resolveBrowserToolTimeoutMs({
+      requestedTimeoutMs: undefined,
+      action: "status",
+      isUserBrowserProfile: false,
+      usesPersistentPlaywright: false,
+      isNodeProxy: true,
+      resolvedBrowser,
+    });
+    expect(timeoutMs).toBeUndefined();
   });
 });

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -346,6 +346,8 @@ export function createBrowserTool(
         requestedTimeoutMs,
         action,
         isUserBrowserProfile,
+        usesPersistentPlaywright: profileCapabilities?.usesPersistentPlaywright === true,
+        isNodeProxy: proxyRequest !== null,
         resolvedBrowser,
       });
       const sessionTabs = createBrowserToolSessionTabs({

--- a/extensions/browser/src/browser/pw-session-actions.ts
+++ b/extensions/browser/src/browser/pw-session-actions.ts
@@ -411,49 +411,53 @@ export async function listPagesViaPlaywright(opts: {
     typeof opts.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
       ? Math.max(1, Math.floor(opts.timeoutMs))
       : undefined;
-  if (timeoutMs === undefined) {
-    const enumeration = await readPagesViaPlaywright(opts);
-    if (enumeration.status === "unavailable") {
-      throw new Error("Playwright page target identities are temporarily unavailable.");
-    }
-    return enumeration.pages;
-  }
-
   let timer: ReturnType<typeof setTimeout> | undefined;
   let timeoutError: Error | undefined;
   const attempt = { cancelled: false };
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      attempt.cancelled = true;
-      timeoutError = new Error(`Playwright page enumeration timed out after ${timeoutMs}ms`);
-      reject(timeoutError);
-    }, timeoutMs);
-    timer.unref?.();
-  });
+  const operations: Array<Promise<PlaywrightPageEnumeration>> = [
+    readPagesViaPlaywright(opts, attempt),
+  ];
+  if (timeoutMs !== undefined) {
+    operations.push(
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          attempt.cancelled = true;
+          timeoutError = new Error(`Playwright page enumeration timed out after ${timeoutMs}ms`);
+          reject(timeoutError);
+        }, timeoutMs);
+        timer.unref?.();
+      }),
+    );
+  }
   let abortError: Error | undefined;
   let abortListener: (() => void) | undefined;
-  const abort = opts.signal
-    ? new Promise<never>((_, reject) => {
-        if (opts.signal!.aborted) {
+  const signal = opts.signal;
+  if (signal) {
+    operations.push(
+      new Promise<never>((_, reject) => {
+        if (signal.aborted) {
           attempt.cancelled = true;
-          abortError = new Error("Playwright page enumeration was aborted.");
+          abortError =
+            signal.reason instanceof Error
+              ? signal.reason
+              : new Error("Playwright page enumeration was aborted.");
           reject(abortError);
           return;
         }
         abortListener = () => {
           attempt.cancelled = true;
-          abortError = new Error("Playwright page enumeration was aborted.");
+          abortError =
+            signal.reason instanceof Error
+              ? signal.reason
+              : new Error("Playwright page enumeration was aborted.");
           reject(abortError);
         };
-        opts.signal!.addEventListener("abort", abortListener, { once: true });
-      })
-    : null;
-  try {
-    const enumeration = await Promise.race(
-      abort
-        ? [readPagesViaPlaywright(opts, attempt), timeout, abort]
-        : [readPagesViaPlaywright(opts, attempt), timeout],
+        signal.addEventListener("abort", abortListener, { once: true });
+      }),
     );
+  }
+  try {
+    const enumeration = await Promise.race(operations);
     if (enumeration.status === "unavailable") {
       throw new Error("Playwright page target identities are temporarily unavailable.");
     }
@@ -471,8 +475,8 @@ export async function listPagesViaPlaywright(opts: {
     if (timer) {
       clearTimeout(timer);
     }
-    if (abortListener && opts.signal) {
-      opts.signal.removeEventListener("abort", abortListener);
+    if (abortListener && signal) {
+      signal.removeEventListener("abort", abortListener);
     }
   }
 }
@@ -488,6 +492,7 @@ export async function createPageViaPlaywright(
     cdpUrl: string;
     url: string;
     cdpPolicy?: SsrFPolicy;
+    signal?: AbortSignal;
   } & BrowserNavigationPolicyOptions,
 ): Promise<{
   targetId: string;
@@ -495,14 +500,26 @@ export async function createPageViaPlaywright(
   url: string;
   type: string;
 }> {
+  opts.signal?.throwIfAborted();
   const { browser } = await connectBrowser(opts.cdpUrl, opts.cdpPolicy ?? opts.ssrfPolicy);
+  opts.signal?.throwIfAborted();
   const context = browser.contexts()[0] ?? (await browser.newContext());
+  opts.signal?.throwIfAborted();
   ensureContextState(context);
 
   const page = await context.newPage();
+  const throwIfCreationAborted = async () => {
+    try {
+      opts.signal?.throwIfAborted();
+    } catch (error) {
+      await page.close().catch(() => {});
+      throw error;
+    }
+  };
   ensurePageState(page);
   clearBlockedPageRef(opts.cdpUrl, page);
   const createdTargetId = (await pageTargetInfo(page).catch(() => null))?.targetId ?? null;
+  await throwIfCreationAborted();
   clearBlockedTarget(opts.cdpUrl, createdTargetId ?? undefined);
 
   const targetUrl = opts.url.trim() || "about:blank";
@@ -525,6 +542,7 @@ export async function createPageViaPlaywright(
         browserProxyMode: opts.browserProxyMode,
         targetId: createdTargetId ?? undefined,
       });
+      opts.signal?.throwIfAborted();
     } catch (err) {
       if (!isPolicyDenyNavigationError(err) && !(err instanceof BlockedBrowserTargetError)) {
         // This call owns the new page; best-effort cleanup must not replace its navigation error.
@@ -556,16 +574,13 @@ export async function createPageViaPlaywright(
   }
 
   const tid = createdTargetId ?? (await pageTargetInfo(page).catch(() => null))?.targetId ?? null;
+  await throwIfCreationAborted();
   if (!tid) {
     throw new Error("Failed to get targetId for new page");
   }
-
-  return {
-    targetId: tid,
-    title: await page.title().catch(() => ""),
-    url: page.url(),
-    type: "page",
-  };
+  const title = await page.title().catch(() => "");
+  await throwIfCreationAborted();
+  return { targetId: tid, title, url: page.url(), type: "page" };
 }
 
 /**
@@ -576,8 +591,10 @@ export async function closePageByTargetIdViaPlaywright(opts: {
   cdpUrl: string;
   targetId: string;
   ssrfPolicy?: SsrFPolicy;
+  signal?: AbortSignal;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
+  opts.signal?.throwIfAborted();
   await page.close();
 }
 
@@ -589,7 +606,9 @@ export async function focusPageByTargetIdViaPlaywright(opts: {
   cdpUrl: string;
   targetId: string;
   ssrfPolicy?: SsrFPolicy;
+  signal?: AbortSignal;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
+  opts.signal?.throwIfAborted();
   await page.bringToFront();
 }

--- a/extensions/browser/src/browser/pw-session-actions.ts
+++ b/extensions/browser/src/browser/pw-session-actions.ts
@@ -405,6 +405,7 @@ export async function listPagesViaPlaywright(opts: {
   ssrfPolicy?: SsrFPolicy;
   timeoutMs?: number;
   requireCompleteTargetList?: boolean;
+  signal?: AbortSignal;
 }) {
   const timeoutMs =
     typeof opts.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
@@ -429,14 +430,36 @@ export async function listPagesViaPlaywright(opts: {
     }, timeoutMs);
     timer.unref?.();
   });
+  let abortError: Error | undefined;
+  let abortListener: (() => void) | undefined;
+  const abort = opts.signal
+    ? new Promise<never>((_, reject) => {
+        if (opts.signal!.aborted) {
+          attempt.cancelled = true;
+          abortError = new Error("Playwright page enumeration was aborted.");
+          reject(abortError);
+          return;
+        }
+        abortListener = () => {
+          attempt.cancelled = true;
+          abortError = new Error("Playwright page enumeration was aborted.");
+          reject(abortError);
+        };
+        opts.signal!.addEventListener("abort", abortListener, { once: true });
+      })
+    : null;
   try {
-    const enumeration = await Promise.race([readPagesViaPlaywright(opts, attempt), timeout]);
+    const enumeration = await Promise.race(
+      abort
+        ? [readPagesViaPlaywright(opts, attempt), timeout, abort]
+        : [readPagesViaPlaywright(opts, attempt), timeout],
+    );
     if (enumeration.status === "unavailable") {
       throw new Error("Playwright page target identities are temporarily unavailable.");
     }
     return enumeration.pages;
   } catch (err) {
-    if (err === timeoutError) {
+    if (err === timeoutError || err === abortError) {
       await forceDisconnectPlaywrightForTarget({
         cdpUrl: opts.cdpUrl,
         ssrfPolicy: opts.ssrfPolicy,
@@ -447,6 +470,9 @@ export async function listPagesViaPlaywright(opts: {
   } finally {
     if (timer) {
       clearTimeout(timer);
+    }
+    if (abortListener && opts.signal) {
+      opts.signal.removeEventListener("abort", abortListener);
     }
   }
 }

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -249,6 +249,36 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
     expect(pageGoto).not.toHaveBeenCalled();
   });
 
+  it("closes a new page when cancellation wins target resolution", async () => {
+    const { pageClose, sessionSend } = installBrowserMocks();
+    let releaseTargetInfo: (() => void) | undefined;
+    let markTargetInfoStarted: (() => void) | undefined;
+    const targetInfoStarted = new Promise<void>((resolve) => {
+      markTargetInfoStarted = resolve;
+    });
+    const targetInfoReleased = new Promise<void>((resolve) => {
+      releaseTargetInfo = resolve;
+    });
+    sessionSend.mockImplementationOnce(async () => {
+      markTargetInfoStarted?.();
+      await targetInfoReleased;
+      return { targetInfo: { targetId: "TARGET_1" } };
+    });
+    const controller = new AbortController();
+
+    const creation = createPageViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      url: "about:blank",
+      signal: controller.signal,
+    });
+    await targetInfoStarted;
+    controller.abort(new Error("cancelled page creation"));
+    releaseTargetInfo?.();
+
+    await expect(creation).rejects.toThrow("cancelled page creation");
+    expect(pageClose).toHaveBeenCalledOnce();
+  });
+
   it("blocks hostname navigation when strict SSRF policy is configured", async () => {
     const { pageGoto } = installBrowserMocks();
     getChromeWebSocketEndpointSpy.mockResolvedValue({

--- a/extensions/browser/src/browser/pw-session.enumeration.test.ts
+++ b/extensions/browser/src/browser/pw-session.enumeration.test.ts
@@ -8,7 +8,11 @@ import {
 const { connectOverCdpSpy, getChromeWebSocketUrlSpy, markPageRefBlocked, markTargetBlocked, pwAi } =
   setupPwSessionConnectionTest();
 
-const { listPagesViaPlaywright } = pwAi;
+const {
+  closePageByTargetIdViaPlaywright,
+  focusPageByTargetIdViaPlaywright,
+  listPagesViaPlaywright,
+} = pwAi;
 
 function makePageEnumerationBrowser(
   specs: Array<{
@@ -399,26 +403,72 @@ describe("pw-session page enumeration", () => {
     }
   });
 
-  it("removes the abort listener after successful enumeration", async () => {
+  it("aborts enumeration without a timeout and retires its connection", async () => {
     const fixture = makePageEnumerationBrowser([
-      { targetId: "T1", title: "Tab 1", url: "https://example.com" },
+      {
+        targetId: "T1",
+        title: "Tab 1",
+        url: "https://example.com",
+        readTargetInfo: () => new Promise(() => {}),
+      },
     ]);
     connectOverCdpSpy.mockResolvedValue(fixture.browser);
     getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     const controller = new AbortController();
-    const addSpy = vi.spyOn(controller.signal, "addEventListener");
-    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
-
-    await listPagesViaPlaywright({
+    const listing = listPagesViaPlaywright({
       cdpUrl: "http://127.0.0.1:9222",
-      timeoutMs: 60_000,
       signal: controller.signal,
     });
+    controller.abort(new Error("cancelled enumeration"));
 
-    const abortAddCalls = addSpy.mock.calls.filter((c) => c[0] === "abort");
-    expect(abortAddCalls).toHaveLength(1);
-    const abortRemoveCalls = removeSpy.mock.calls.filter((c) => c[0] === "abort");
-    expect(abortRemoveCalls).toHaveLength(1);
+    await expect(listing).rejects.toThrow("cancelled enumeration");
+    await vi.waitFor(() => expect(fixture.browserClose).toHaveBeenCalledOnce());
   });
+
+  it.each([
+    ["focus", focusPageByTargetIdViaPlaywright, "bringToFront"],
+    ["close", closePageByTargetIdViaPlaywright, "close"],
+  ] as const)(
+    "does not %s after cancellation during target resolution",
+    async (_name, run, method) => {
+      let releaseTargetInfo: (() => void) | undefined;
+      let markTargetInfoStarted: (() => void) | undefined;
+      const targetInfoStarted = new Promise<void>((resolve) => {
+        markTargetInfoStarted = resolve;
+      });
+      const targetInfoReleased = new Promise<void>((resolve) => {
+        releaseTargetInfo = resolve;
+      });
+      const fixture = makePageEnumerationBrowser([
+        {
+          targetId: "T1",
+          title: "Tab 1",
+          url: "https://example.com",
+          readTargetInfo: async () => {
+            markTargetInfoStarted?.();
+            await targetInfoReleased;
+            return { targetInfo: { targetId: "T1", title: "Tab 1" } };
+          },
+        },
+      ]);
+      const finalIo = vi.fn(async () => {});
+      Object.assign(fixture.pages[0]!, { [method]: finalIo });
+      connectOverCdpSpy.mockResolvedValue(fixture.browser);
+      getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+      const controller = new AbortController();
+      const operation = run({
+        cdpUrl: "http://127.0.0.1:9222",
+        targetId: "T1",
+        signal: controller.signal,
+      });
+      await targetInfoStarted;
+      controller.abort(new Error("cancelled target resolution"));
+      releaseTargetInfo?.();
+
+      await expect(operation).rejects.toThrow("cancelled target resolution");
+      expect(finalIo).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/extensions/browser/src/browser/pw-session.enumeration.test.ts
+++ b/extensions/browser/src/browser/pw-session.enumeration.test.ts
@@ -398,4 +398,27 @@ describe("pw-session page enumeration", () => {
       expect(fixture.newCDPSession).not.toHaveBeenCalledWith(blockedPage);
     }
   });
+
+  it("removes the abort listener after successful enumeration", async () => {
+    const fixture = makePageEnumerationBrowser([
+      { targetId: "T1", title: "Tab 1", url: "https://example.com" },
+    ]);
+    connectOverCdpSpy.mockResolvedValue(fixture.browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    const controller = new AbortController();
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+
+    await listPagesViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      timeoutMs: 60_000,
+      signal: controller.signal,
+    });
+
+    const abortAddCalls = addSpy.mock.calls.filter((c) => c[0] === "abort");
+    expect(abortAddCalls).toHaveLength(1);
+    const abortRemoveCalls = removeSpy.mock.calls.filter((c) => c[0] === "abort");
+    expect(abortRemoveCalls).toHaveLength(1);
+  });
 });

--- a/extensions/browser/src/browser/routes/tabs.test.ts
+++ b/extensions/browser/src/browser/routes/tabs.test.ts
@@ -322,6 +322,10 @@ describe("browser tab routes", () => {
 
     expect(response.statusCode).toBe(500);
     expect(response.body).toEqual({ error: String(navigationError) });
+    expect(profileCtx.openTab).toHaveBeenCalledWith("https://unresolved.example", {
+      label: undefined,
+      signal: expect.any(AbortSignal),
+    });
   });
 
   it("returns browser-not-running for close when the browser is not reachable", async () => {
@@ -771,23 +775,22 @@ describe("browser tab routes", () => {
 
   it("does not focus a tab after cancellation during target resolution", async () => {
     const abort = new AbortController();
+    let markListStarted: (() => void) | undefined;
+    const listStarted = new Promise<void>((resolve) => {
+      markListStarted = resolve;
+    });
     const listTabs = vi.fn(async (options?: { signal?: AbortSignal }) => {
-      // Simulate slow target resolution (e.g. 76-tab relay enumeration).
-      // The route must propagate the abort signal into listTabs so a cancelled
-      // request does not proceed to the focus mutation.
       const signal = options?.signal;
-      if (signal && !signal.aborted) {
-        await new Promise<void>((resolve, reject) => {
-          signal.addEventListener(
-            "abort",
-            () => {
-              const reason = signal.reason;
-              reject(reason instanceof Error ? reason : new Error("aborted"));
-            },
-            { once: true },
-          );
-          // Safety timeout so the test does not hang if abort never fires.
-          setTimeout(resolve, 5_000);
+      markListStarted?.();
+      if (signal) {
+        await new Promise<void>((_resolve, reject) => {
+          const rejectAbort = () =>
+            reject(signal.reason instanceof Error ? signal.reason : new Error("aborted"));
+          if (signal.aborted) {
+            rejectAbort();
+            return;
+          }
+          signal.addEventListener("abort", rejectAbort, { once: true });
         });
       }
       return [
@@ -803,7 +806,7 @@ describe("browser tab routes", () => {
       signal: abort.signal,
     });
 
-    // Abort while listTabs is still resolving the target.
+    await listStarted;
     abort.abort(new Error("cancelled"));
     const response = await pending;
 

--- a/extensions/browser/src/browser/routes/tabs.test.ts
+++ b/extensions/browser/src/browser/routes/tabs.test.ts
@@ -251,6 +251,7 @@ async function callTabsFocus(params: {
   profileCtx: ProfileContext;
   body: Record<string, unknown>;
   ssrfPolicy?: unknown;
+  signal?: AbortSignal;
 }) {
   return await callTabsRoute({ ...params, method: "post", path: "/tabs/focus" });
 }
@@ -259,6 +260,7 @@ async function callTabsDelete(params: {
   profileCtx: ProfileContext;
   targetId: string;
   query?: Record<string, unknown>;
+  signal?: AbortSignal;
 }) {
   const { app, deleteHandlers } = createBrowserRouteApp();
   registerBrowserTabRoutes(app, createRouteContext(params.profileCtx) as never);
@@ -271,6 +273,7 @@ async function callTabsDelete(params: {
       params: { targetId: params.targetId },
       query: params.query ?? {},
       body: {},
+      ...(params.signal ? { signal: params.signal } : {}),
     },
     response.res,
   );
@@ -340,7 +343,10 @@ describe("browser tab routes", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toEqual({ ok: true, targetId: "T1" });
-    expect(profileCtx.closeTab).toHaveBeenCalledWith("T1", { exactTargetId: true });
+    expect(profileCtx.closeTab).toHaveBeenCalledWith("T1", {
+      exactTargetId: true,
+      signal: expect.any(AbortSignal),
+    });
   });
 
   it("returns the canonical target id resolved behind a friendly close reference", async () => {
@@ -355,7 +361,7 @@ describe("browser tab routes", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toEqual({ ok: true, targetId: "T1_RAW" });
-    expect(profileCtx.closeTab).toHaveBeenCalledWith("docs", undefined);
+    expect(profileCtx.closeTab).toHaveBeenCalledWith("docs", { signal: expect.any(AbortSignal) });
   });
 
   it("rejects unknown target id modes before mutating a tab", async () => {
@@ -388,7 +394,10 @@ describe("browser tab routes", () => {
 
       expect(response.statusCode).toBe(200);
       expect(isReachable).toHaveBeenCalledTimes(2);
-      expect(profileCtx.closeTab).toHaveBeenCalledWith("T1", { exactTargetId: true });
+      expect(profileCtx.closeTab).toHaveBeenCalledWith("T1", {
+        exactTargetId: true,
+        signal: expect.any(AbortSignal),
+      });
     } finally {
       vi.useRealTimers();
     }
@@ -647,9 +656,11 @@ describe("browser tab routes", () => {
     expect(tabIdResponse.statusCode).toBe(200);
     expect(profileCtx.focusTab).toHaveBeenNthCalledWith(1, "T1_RAW", {
       exactTargetId: true,
+      signal: expect.any(AbortSignal),
     });
     expect(profileCtx.focusTab).toHaveBeenNthCalledWith(2, "T1_RAW", {
       exactTargetId: true,
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -681,7 +692,10 @@ describe("browser tab routes", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toEqual({ ok: true, targetId: "T2" });
-    expect(profileCtx.focusTab).toHaveBeenCalledWith("T2", { exactTargetId: true });
+    expect(profileCtx.focusTab).toHaveBeenCalledWith("T2", {
+      exactTargetId: true,
+      signal: expect.any(AbortSignal),
+    });
     expect(profileCtx.ensureTabAvailable).not.toHaveBeenCalled();
     expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).not.toHaveBeenCalled();
   });
@@ -698,7 +712,10 @@ describe("browser tab routes", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.body).toEqual({ ok: true, targetId: "T2" });
-    expect(profileCtx.focusTab).toHaveBeenCalledWith("T2", { exactTargetId: true });
+    expect(profileCtx.focusTab).toHaveBeenCalledWith("T2", {
+      exactTargetId: true,
+      signal: expect.any(AbortSignal),
+    });
     expect(navigationGuardMocks.assertBrowserNavigationResultAllowed).not.toHaveBeenCalled();
   });
 
@@ -750,5 +767,65 @@ describe("browser tab routes", () => {
       },
     });
     expect(profileCtx.labelTab).toHaveBeenCalledWith("t1", "meet");
+  });
+
+  it("does not focus a tab after cancellation during target resolution", async () => {
+    const abort = new AbortController();
+    const listTabs = vi.fn(async (options?: { signal?: AbortSignal }) => {
+      // Simulate slow target resolution (e.g. 76-tab relay enumeration).
+      // The route must propagate the abort signal into listTabs so a cancelled
+      // request does not proceed to the focus mutation.
+      const signal = options?.signal;
+      if (signal && !signal.aborted) {
+        await new Promise<void>((resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              const reason = signal.reason;
+              reject(reason instanceof Error ? reason : new Error("aborted"));
+            },
+            { once: true },
+          );
+          // Safety timeout so the test does not hang if abort never fires.
+          setTimeout(resolve, 5_000);
+        });
+      }
+      return [
+        { targetId: "T1", title: "Tab 1", url: "https://example.com", type: "page" as const },
+      ];
+    });
+    const focusTab = vi.fn(async () => {});
+    const profileCtx = createProfileContext({ listTabs, focusTab });
+
+    const pending = callTabsFocus({
+      profileCtx,
+      body: { targetId: "T1" },
+      signal: abort.signal,
+    });
+
+    // Abort while listTabs is still resolving the target.
+    abort.abort(new Error("cancelled"));
+    const response = await pending;
+
+    expect(response.statusCode).toBe(500);
+    expect(focusTab).not.toHaveBeenCalled();
+  });
+
+  it("does not close a tab after cancellation before the mutation", async () => {
+    // A pre-aborted signal must fence the close mutation so a cancelled request
+    // does not change the browser.
+    const closeTab = vi.fn(async (targetId: string) => targetId);
+    const profileCtx = createProfileContext({ closeTab });
+    const preAborted = new AbortController();
+    preAborted.abort(new Error("pre-cancelled"));
+
+    const response = await callTabsDelete({
+      profileCtx,
+      targetId: "T1",
+      signal: preAborted.signal,
+    });
+
+    expect(closeTab).not.toHaveBeenCalled();
+    expect(response.statusCode).toBe(500);
   });
 });

--- a/extensions/browser/src/browser/routes/tabs.ts
+++ b/extensions/browser/src/browser/routes/tabs.ts
@@ -267,7 +267,7 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
           ...browserNavigationPolicyForProfile(ctx, profileCtx),
         });
         await profileCtx.ensureBrowserAvailable({ signal });
-        const opened = await profileCtx.openTab(url, { label });
+        const opened = await profileCtx.openTab(url, { label, signal });
         return { ...opened, resolvedProfile: profileCtx.profile.name };
       },
     });
@@ -393,7 +393,7 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
 
         if (action === "new") {
           await profileCtx.ensureBrowserAvailable({ signal });
-          const tab = await profileCtx.openTab("about:blank", { label });
+          const tab = await profileCtx.openTab("about:blank", { label, signal });
           return { ok: true, tab };
         }
 

--- a/extensions/browser/src/browser/routes/tabs.ts
+++ b/extensions/browser/src/browser/routes/tabs.ts
@@ -237,7 +237,7 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
           return { running: false, tabs: [] as unknown[] };
         }
         const tabs = await redactBlockedTabUrls({
-          tabs: await profileCtx.listTabs(),
+          tabs: await profileCtx.listTabs({ signal }),
           navigationPolicy: browserNavigationPolicyForProfile(ctx, profileCtx),
         });
         signal.throwIfAborted();
@@ -286,8 +286,8 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
       res,
       ctx,
       targetId,
-      mutate: async (profileCtx, id) => {
-        const tabs = await profileCtx.listTabs();
+      mutate: async (profileCtx, id, signal) => {
+        const tabs = await profileCtx.listTabs({ signal });
         const resolved = resolveTargetIdFromTabs(id, tabs);
         if (!resolved.ok) {
           if (resolved.reason === "ambiguous") {
@@ -306,7 +306,8 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
             ...ssrfPolicyOpts,
           });
         }
-        await profileCtx.focusTab(resolved.targetId, { exactTargetId: true });
+        signal.throwIfAborted();
+        await profileCtx.focusTab(resolved.targetId, { exactTargetId: true, signal });
         return resolved.targetId;
       },
     });
@@ -326,11 +327,12 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
       res,
       ctx,
       targetId,
-      mutate: async (profileCtx, id) => {
-        const canonicalTargetId = await profileCtx.closeTab(
-          id,
-          targetIdMode === "raw" ? { exactTargetId: true } : undefined,
-        );
+      mutate: async (profileCtx, id, signal) => {
+        signal.throwIfAborted();
+        const canonicalTargetId = await profileCtx.closeTab(id, {
+          ...(targetIdMode === "raw" ? { exactTargetId: true } : {}),
+          signal,
+        });
         clearSnapshotKeysForTab(ctx, profileCtx.profile.name, canonicalTargetId);
         return canonicalTargetId;
       },
@@ -382,7 +384,7 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
             return { ok: true, tabs: [] as unknown[] };
           }
           const tabs = await redactBlockedTabUrls({
-            tabs: await profileCtx.listTabs(),
+            tabs: await profileCtx.listTabs({ signal }),
             navigationPolicy: browserNavigationPolicyForProfile(ctx, profileCtx),
           });
           signal.throwIfAborted();
@@ -403,18 +405,19 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
 
         if (action === "close") {
           await ensureBrowserRunning(ctx, profileCtx, signal);
-          const tabs = await profileCtx.listTabs();
+          const tabs = await profileCtx.listTabs({ signal });
           const target = resolveIndexedTab(tabs, index);
           if (!target) {
             throw new BrowserTabNotFoundError();
           }
-          await profileCtx.closeTab(target.targetId, { exactTargetId: true });
+          signal.throwIfAborted();
+          await profileCtx.closeTab(target.targetId, { exactTargetId: true, signal });
           clearSnapshotKeysForTab(ctx, profileCtx.profile.name, target.targetId);
           return { ok: true, targetId: target.targetId };
         }
 
         await ensureBrowserRunning(ctx, profileCtx, signal);
-        const tabs = await profileCtx.listTabs();
+        const tabs = await profileCtx.listTabs({ signal });
         const target = tabs[index!];
         if (!target) {
           throw new BrowserTabNotFoundError();
@@ -426,7 +429,8 @@ export function registerBrowserTabRoutes(app: BrowserRouteRegistrar, ctx: Browse
             ...ssrfPolicyOpts,
           });
         }
-        await profileCtx.focusTab(target.targetId, { exactTargetId: true });
+        signal.throwIfAborted();
+        await profileCtx.focusTab(target.targetId, { exactTargetId: true, signal });
         return { ok: true, targetId: target.targetId };
       },
     });

--- a/extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts
+++ b/extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts
@@ -281,48 +281,6 @@ describe("browser remote profile tab ops via Playwright", () => {
     expect(exactFocusCall?.targetId).toBe("B");
   });
 
-  it("does not focus a tab after cancellation before final I/O", async () => {
-    const listPagesViaPlaywright = vi.fn(async () => [page("A", "https://example.com")]);
-    const focusPageByTargetIdViaPlaywright = vi.fn(async () => {
-      await new Promise<void>(() => {});
-    });
-    vi.spyOn(deps.pwAiModule, "getPwAiModule").mockResolvedValue({
-      listPagesViaPlaywright,
-      focusPageByTargetIdViaPlaywright,
-    } as unknown as Awaited<ReturnType<typeof deps.pwAiModule.getPwAiModule>>);
-
-    const { remote } = deps.createRemoteRouteHarness();
-
-    const controller = new AbortController();
-    const focusing = remote.focusTab("A", { exactTargetId: true, signal: controller.signal });
-
-    controller.abort(new Error("cancelled mid-selection"));
-
-    await expect(focusing).rejects.toThrow(/cancelled/);
-    expect(focusPageByTargetIdViaPlaywright).not.toHaveBeenCalled();
-  });
-
-  it("does not close a tab after cancellation before final I/O", async () => {
-    const listPagesViaPlaywright = vi.fn(async () => [page("A", "https://example.com")]);
-    const closePageByTargetIdViaPlaywright = vi.fn(async () => {
-      await new Promise<void>(() => {});
-    });
-    vi.spyOn(deps.pwAiModule, "getPwAiModule").mockResolvedValue({
-      listPagesViaPlaywright,
-      closePageByTargetIdViaPlaywright,
-    } as unknown as Awaited<ReturnType<typeof deps.pwAiModule.getPwAiModule>>);
-
-    const { remote } = deps.createRemoteRouteHarness();
-
-    const controller = new AbortController();
-    const closing = remote.closeTab("A", { exactTargetId: true, signal: controller.signal });
-
-    controller.abort(new Error("cancelled mid-selection"));
-
-    await expect(closing).rejects.toThrow(/cancelled/);
-    expect(closePageByTargetIdViaPlaywright).not.toHaveBeenCalled();
-  });
-
   it("transfers stable aliases across a high-confidence target replacement", async () => {
     let currentPages = [page("A", "https://app.example/form")];
     const listPagesViaPlaywright = vi.fn(async () => currentPages);

--- a/extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts
+++ b/extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts
@@ -68,10 +68,12 @@ describe("browser remote profile tab ops via Playwright", () => {
 
     const tabs = await remote.listTabs();
     expect(tabs.map((t) => t.targetId)).toEqual(["T1"]);
+    // Enumeration budget falls back to the action-level timeout, not the
+    // CDP handshake, so a tab-heavy session is not mistaken for a dead relay.
     expect(listPagesViaPlaywright).toHaveBeenCalledWith({
       cdpUrl: "https://1.1.1.1:9222/chrome?token=abc",
       ssrfPolicy: permissiveRemoteCdpPolicy,
-      timeoutMs: 3000,
+      timeoutMs: 60_000,
     });
 
     const opened = await remote.openTab("http://127.0.0.1:3000");
@@ -97,6 +99,61 @@ describe("browser remote profile tab ops via Playwright", () => {
       ssrfPolicy: permissiveRemoteCdpPolicy,
     });
     expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("forwards a caller-supplied enumeration deadline instead of the handshake timeout", async () => {
+    const listPagesViaPlaywright = vi.fn(async () => [
+      { targetId: "T1", title: "Tab 1", url: "https://example.com", type: "page" },
+    ]);
+    vi.spyOn(deps.pwAiModule, "getPwAiModule").mockResolvedValue({
+      listPagesViaPlaywright,
+    } as unknown as Awaited<ReturnType<typeof deps.pwAiModule.getPwAiModule>>);
+    const fetchMock = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => ({
+            webSocketDebuggerUrl:
+              "wss://1.1.1.1:9222/devtools/browser/REMOTE-BROWSER?auth=fixture-value",
+          }),
+        }) as unknown as Response,
+    );
+    const { remote } = deps.createRemoteRouteHarness(fetchMock);
+
+    await remote.listTabs({ timeoutMs: 45_000 });
+
+    expect(listPagesViaPlaywright).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 45_000 }),
+    );
+  });
+
+  it("keeps the enumeration budget at or above the handshake timeout", async () => {
+    const listPagesViaPlaywright = vi.fn(async () => [
+      { targetId: "T1", title: "Tab 1", url: "https://example.com", type: "page" },
+    ]);
+    vi.spyOn(deps.pwAiModule, "getPwAiModule").mockResolvedValue({
+      listPagesViaPlaywright,
+    } as unknown as Awaited<ReturnType<typeof deps.pwAiModule.getPwAiModule>>);
+    const fetchMock = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => ({
+            webSocketDebuggerUrl:
+              "wss://1.1.1.1:9222/devtools/browser/REMOTE-BROWSER?auth=fixture-value",
+          }),
+        }) as unknown as Response,
+    );
+    const { state, remote } = deps.createRemoteRouteHarness(fetchMock);
+    // A caller deadline below the handshake must not shrink enumeration below
+    // the time needed to establish the connection in the first place.
+    state.resolved.remoteCdpHandshakeTimeoutMs = 5_000;
+
+    await remote.listTabs({ timeoutMs: 1_000 });
+
+    expect(listPagesViaPlaywright).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 5_000 }),
+    );
   });
 
   it("uses the remote HTTP timeout for the ownership version probe", async () => {
@@ -222,6 +279,48 @@ describe("browser remote profile tab ops via Playwright", () => {
       | { targetId?: unknown }
       | undefined;
     expect(exactFocusCall?.targetId).toBe("B");
+  });
+
+  it("does not focus a tab after cancellation before final I/O", async () => {
+    const listPagesViaPlaywright = vi.fn(async () => [page("A", "https://example.com")]);
+    const focusPageByTargetIdViaPlaywright = vi.fn(async () => {
+      await new Promise<void>(() => {});
+    });
+    vi.spyOn(deps.pwAiModule, "getPwAiModule").mockResolvedValue({
+      listPagesViaPlaywright,
+      focusPageByTargetIdViaPlaywright,
+    } as unknown as Awaited<ReturnType<typeof deps.pwAiModule.getPwAiModule>>);
+
+    const { remote } = deps.createRemoteRouteHarness();
+
+    const controller = new AbortController();
+    const focusing = remote.focusTab("A", { exactTargetId: true, signal: controller.signal });
+
+    controller.abort(new Error("cancelled mid-selection"));
+
+    await expect(focusing).rejects.toThrow(/cancelled/);
+    expect(focusPageByTargetIdViaPlaywright).not.toHaveBeenCalled();
+  });
+
+  it("does not close a tab after cancellation before final I/O", async () => {
+    const listPagesViaPlaywright = vi.fn(async () => [page("A", "https://example.com")]);
+    const closePageByTargetIdViaPlaywright = vi.fn(async () => {
+      await new Promise<void>(() => {});
+    });
+    vi.spyOn(deps.pwAiModule, "getPwAiModule").mockResolvedValue({
+      listPagesViaPlaywright,
+      closePageByTargetIdViaPlaywright,
+    } as unknown as Awaited<ReturnType<typeof deps.pwAiModule.getPwAiModule>>);
+
+    const { remote } = deps.createRemoteRouteHarness();
+
+    const controller = new AbortController();
+    const closing = remote.closeTab("A", { exactTargetId: true, signal: controller.signal });
+
+    controller.abort(new Error("cancelled mid-selection"));
+
+    await expect(closing).rejects.toThrow(/cancelled/);
+    expect(closePageByTargetIdViaPlaywright).not.toHaveBeenCalled();
   });
 
   it("transfers stable aliases across a high-confidence target replacement", async () => {

--- a/extensions/browser/src/browser/server-context.selection.ts
+++ b/extensions/browser/src/browser/server-context.selection.ts
@@ -272,6 +272,7 @@ export function createProfileSelectionOps({
           cdpUrl: profile.cdpUrl,
           targetId: resolvedTargetId,
           ssrfPolicy: getCdpControlPolicy(),
+          ...(options?.signal ? { signal: options.signal } : {}),
         });
         runtime.lastTargetId = resolvedTargetId;
         return;
@@ -282,7 +283,7 @@ export function createProfileSelectionOps({
     await fetchOk(
       appendCdpPath(cdpHttpBase, `/json/activate/${resolvedTargetId}`),
       undefined,
-      undefined,
+      options?.signal ? { signal: options.signal } : undefined,
       getCdpControlPolicy(),
     );
     runtime.lastTargetId = resolvedTargetId;
@@ -309,6 +310,7 @@ export function createProfileSelectionOps({
             cdpUrl: profile.cdpUrl,
             targetId: resolvedTargetId,
             ssrfPolicy: getCdpControlPolicy(),
+            ...(options?.signal ? { signal: options.signal } : {}),
           });
           closedViaPlaywright = true;
         }
@@ -319,7 +321,7 @@ export function createProfileSelectionOps({
         await fetchOk(
           appendCdpPath(cdpHttpBase, `/json/close/${resolvedTargetId}`),
           undefined,
-          undefined,
+          options?.signal ? { signal: options.signal } : undefined,
           getCdpControlPolicy(),
         );
       }

--- a/extensions/browser/src/browser/server-context.selection.ts
+++ b/extensions/browser/src/browser/server-context.selection.ts
@@ -256,6 +256,7 @@ export function createProfileSelectionOps({
     if (capabilities.usesChromeMcp) {
       assertChromeMcpCdpTransportAllowed(profile, getCdpControlPolicy());
       const { focusChromeMcpTab } = await getChromeMcpModule();
+      options?.signal?.throwIfAborted();
       await focusChromeMcpTab(profile.name, resolvedTargetId, profile, options);
       runtime.lastTargetId = resolvedTargetId;
       return;
@@ -266,6 +267,7 @@ export function createProfileSelectionOps({
       const focusPageByTargetIdViaPlaywright = (mod as Partial<PwAiModule> | null)
         ?.focusPageByTargetIdViaPlaywright;
       if (typeof focusPageByTargetIdViaPlaywright === "function") {
+        options?.signal?.throwIfAborted();
         await focusPageByTargetIdViaPlaywright({
           cdpUrl: profile.cdpUrl,
           targetId: resolvedTargetId,
@@ -276,6 +278,7 @@ export function createProfileSelectionOps({
       }
     }
 
+    options?.signal?.throwIfAborted();
     await fetchOk(
       appendCdpPath(cdpHttpBase, `/json/activate/${resolvedTargetId}`),
       undefined,
@@ -291,6 +294,7 @@ export function createProfileSelectionOps({
     if (capabilities.usesChromeMcp) {
       assertChromeMcpCdpTransportAllowed(profile, getCdpControlPolicy());
       const { closeChromeMcpTab } = await getChromeMcpModule();
+      options?.signal?.throwIfAborted();
       await closeChromeMcpTab(profile.name, resolvedTargetId, profile, options);
     } else {
       let closedViaPlaywright = false;
@@ -300,6 +304,7 @@ export function createProfileSelectionOps({
         const closePageByTargetIdViaPlaywright = (mod as Partial<PwAiModule> | null)
           ?.closePageByTargetIdViaPlaywright;
         if (typeof closePageByTargetIdViaPlaywright === "function") {
+          options?.signal?.throwIfAborted();
           await closePageByTargetIdViaPlaywright({
             cdpUrl: profile.cdpUrl,
             targetId: resolvedTargetId,
@@ -310,6 +315,7 @@ export function createProfileSelectionOps({
       }
 
       if (!closedViaPlaywright) {
+        options?.signal?.throwIfAborted();
         await fetchOk(
           appendCdpPath(cdpHttpBase, `/json/close/${resolvedTargetId}`),
           undefined,

--- a/extensions/browser/src/browser/server-context.tab-ops.ts
+++ b/extensions/browser/src/browser/server-context.tab-ops.ts
@@ -130,10 +130,15 @@ export function createProfileTabOps({ profile, state, runtime }: TabOpsDeps): Pr
       if (typeof listPagesViaPlaywright === "function") {
         const ssrfPolicy = getCdpControlPolicy();
         const resolved = state().resolved;
-        const timeoutMs = Math.max(
-          resolved.remoteCdpTimeoutMs,
-          resolved.remoteCdpHandshakeTimeoutMs,
-        );
+        // Enumeration budget must reflect the work of listing all tabs, not the
+        // CDP handshake. Prefer a caller-supplied deadline, fall back to the
+        // action-level timeout, and keep it no smaller than the handshake so a
+        // healthy but slow enumeration is not mistaken for a dead connection.
+        const enumerationBudgetMs =
+          typeof options?.timeoutMs === "number" && Number.isFinite(options.timeoutMs)
+            ? options.timeoutMs
+            : resolved.actionTimeoutMs;
+        const timeoutMs = Math.max(enumerationBudgetMs, resolved.remoteCdpHandshakeTimeoutMs);
         await assertCdpEndpointAllowed(profile.cdpUrl, ssrfPolicy);
         const pages = await listPagesViaPlaywright({
           cdpUrl: profile.cdpUrl,
@@ -142,6 +147,7 @@ export function createProfileTabOps({ profile, state, runtime }: TabOpsDeps): Pr
           ...(capabilities.requiresCompleteTargetEnumeration
             ? { requireCompleteTargetList: true }
             : {}),
+          ...(options?.signal ? { signal: options.signal } : {}),
         });
         return pages.filter(isSelectableCdpBrowserTarget).map((p) => ({
           targetId: p.targetId,

--- a/extensions/browser/src/browser/server-context.tab-ops.ts
+++ b/extensions/browser/src/browser/server-context.tab-ops.ts
@@ -308,6 +308,7 @@ export function createProfileTabOps({ profile, state, runtime }: TabOpsDeps): Pr
             cdpUrl: profile.cdpUrl,
             url,
             cdpPolicy,
+            ...(opts?.signal ? { signal: opts.signal } : {}),
             ...ssrfPolicyOpts,
           });
           createdTargetId = page.targetId;


### PR DESCRIPTION
Closes #132452

## What Problem This Solves

`openclaw browser tabs --browser-profile chrome --json` reused the 3-second CDP handshake timeout for complete Playwright tab enumeration. A healthy extension relay could therefore fail on a tab-heavy browser session.

## Root cause

The persistent Playwright profile owner treated connection setup and complete target enumeration as one timeout domain. Browser-tool and node-proxy requests could also expire before the server-side tab operation finished.

## Fix

- Use the existing browser action timeout for persistent Playwright enumeration while keeping the handshake timeout unchanged.
- Carry that budget through persistent and proxied tab operations only.
- Propagate request cancellation through tab list, open, focus, and close paths.
- Recheck cancellation immediately before final Playwright or CDP browser I/O.
- Retire the scoped Playwright connection when enumeration times out or is cancelled.

## Evidence

The proof used the shipped CLI through a real Gateway, Chrome-extension relay, and Chromium session with 76 allowed tabs.

| Revision | Controlled 3.2-second target-list delay | Result |
| --- | --- | --- |
| `main` at `4adab734` | Yes | Failed after 4603 ms with `Playwright page enumeration timed out after 3000ms` |
| Head `7c6cbac8` | Yes | Returned all 76 tabs in 4750 ms |

Anti-cheat removed the delay on the same sessions. Both revisions returned all 76 tabs normally.

## Validation

- 389 focused browser tests passed.
- Changed gate passed extension production/test type checks, formatting, lint, plugin boundaries, dead exports, database/media/runtime guards, and import-cycle checks.
- Production delta: +79 net lines.
- Test delta: +278 net lines.

## AI assistance

AI tooling assisted investigation, repair, and test authoring. Real-path and automated proof verified the final result.
