### PR TITLE
perf: reuse accepted tool-result transcript snapshots

### DIFF
--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -605,14 +605,20 @@ export class ToolSearchRuntime {
         return await params.acceptResultBeforeProjection(result);
       });
     let preExecutionBlocked = false;
+    // Reuse only this call's accepted snapshot; outer schema validation must still run.
+    let acceptedSnapshot: AgentToolResult<unknown> | undefined;
     const acceptResultBeforeProjection = async (candidate: AgentToolResult<unknown>) => {
       if (isPreExecutionBlockedToolResult(candidate)) {
         // The JSON-safe snapshot drops the private blocked-result marker.
         preExecutionBlocked = true;
         await assertCatalogOutputMatchesSchema(entry, candidate);
       }
-      const snapshot = snapshotToolSearchTargetTranscriptResult(candidate);
+      const snapshot =
+        candidate === acceptedSnapshot
+          ? candidate
+          : snapshotToolSearchTargetTranscriptResult(candidate);
       await assertCatalogOutputMatchesSchema(entry, snapshot);
+      acceptedSnapshot = snapshot;
       return snapshot;
     };
     const validateInput = this.options.validateInput && entry.source === "openclaw";

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -1475,6 +1475,34 @@ describe("Tool Search", () => {
     );
   });
 
+  it("revalidates accepted snapshots after executor-side schema mutation", async () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const target = pluginTool("orchard_mutated_schema", "Return a mutable orchard schema");
+    const idSchema = { type: "string" };
+    target.outputSchema = {
+      type: "object",
+      properties: { id: idSchema },
+      required: ["id"],
+      additionalProperties: false,
+    } as never;
+    registerHeadlessToolSearchCatalog({ catalogRef, tools: [target] });
+    const runtime = new ToolSearchRuntime(
+      {
+        catalogRef,
+        executeTool: async (params) => {
+          const accepted = await params.acceptResultBeforeProjection(jsonResult({ id: "P-1" }));
+          idSchema.type = "number";
+          return accepted;
+        },
+      },
+      resolveToolSearchConfig({ tools: { toolSearch: { mode: "tools" } } } as never),
+    );
+
+    await expect(runtime.callValue("orchard_mutated_schema")).rejects.toThrow(
+      "returned details that do not match its declared outputSchema",
+    );
+  });
+
   it("rejects policy blocks outside a declared success output schema", async () => {
     const execute = vi.fn(async () => jsonResult({ id: "should-not-run" }));
     initializeGlobalHookRunner(


### PR DESCRIPTION
## What Problem This Solves

Code Mode and discovered tools can serialize and parse an already accepted result a second time before returning it. Large results pay for duplicate transcript snapshots even though the executor returns the exact frozen object that this call already accepted.

## Why This Change Was Made

The tool-search runtime remembers its own accepted snapshot for the duration of one call. Returning that exact object reuses it; new executor results still get a detached, frozen snapshot. Outer output-schema validation still runs, including when an executor changes the trusted schema between acceptance and return. Inner acceptance remains before lifecycle observation and durable projection.

This removes the duplicate JSON snapshot on the accepted-result path. Production LOC is +7/-1 (net +6), tests +28: the small call-local identity state preserves two required acceptance boundaries without weakening validation or introducing a global cache. The new test guards schema revalidation; it passes the old implementation and rejects the unsafe early-return optimization.

## User Impact

Tools keep the same validated results, effect receipts, provenance, blocked-call behavior, and durable history while allocating fewer temporary snapshots. No public API, configuration, dependency, or persistence contract changes.

## Evidence

- Actual-source probe: 1,000 calls with an 82,796-character result require 2,000 stringify/parse pairs before and 1,000 afterward. A separate uninstrumented warm loop took 196.99 ms before and 128.37 ms after. These are owner-workload observations, not whole-Gateway RSS or stable end-to-end latency claims.
- Frozen results, exact accepted-object reuse, receipt/provenance preservation, MCP guest result identity, detached replacement results, blocked network execution, and executor-side schema mutation all pass. The complete owner, lifecycle executor, projection, bridge, and relevant Codex tool-result protocol paths were inspected independently.
- 358 focused tests across 11 tool-search, MCP-error, stream-error, Code Mode bridge/lifecycle, attempt-preparation, and catalog-abort suites pass. Complete changed-file checks, full build, and fresh Codex autoreview pass.
- A fresh isolated Gateway running the built candidate completed health/provider RPC, a real OpenAI response, and one Code Mode web call. Structured history proves an outer `exec` with code, its successful result, and exactly one same-parent nested `web_fetch` call/result for `https://example.com` with HTTP 200. The Gateway stopped normally and its temporary state was removed. History proves accepted durable bytes; the separate identity probe proves in-memory reuse.

Live build identity: base `f61666a6fa655d14d048b16338b1d49943399dea` plus candidate patch SHA-256 `1535a52be68f6f4e15bcae972ec1dce08e159d943abd11896532c487ff45cc4f` (the committed change). Live response timings were 2.013 s for the plain turn and 3.203 s for Code Mode web; neither is presented as a benchmark.
