### PR TITLE
fix(tts): inherit request timeouts for local CLI synthesis

### DIFF
--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -8,9 +8,9 @@ title: "Text-to-speech"
 sidebarTitle: "Text to speech (TTS)"
 ---
 
-OpenClaw converts outbound replies into audio across **14 speech providers**:
-native voice messages on Feishu, Matrix, Telegram, and WhatsApp; audio
-attachments everywhere else; and PCM/Ulaw streams for telephony and Talk.
+OpenClaw converts outbound replies into native voice messages on Feishu, Matrix,
+Telegram, and WhatsApp; audio attachments everywhere else; and PCM/Ulaw streams
+for telephony and Talk.
 
 TTS is the speech-output half of Talk's `stt-tts` mode (`talk.speak` calls this
 same synthesis path). Provider-native `realtime` Talk sessions synthesize
@@ -1006,7 +1006,7 @@ and resolved values still fail startup or reject the update.
     <ParamField path="command" type="string">Local executable or command string for CLI TTS.</ParamField>
     <ParamField path="args" type="string[]">Command arguments. Supports `{{Text}}`, `{{OutputPath}}`, `{{OutputDir}}`, `{{OutputBase}}` placeholders.</ParamField>
     <ParamField path="outputFormat" type='"mp3" | "opus" | "wav"'>Expected CLI output format. Default `mp3` for audio attachments.</ParamField>
-    <ParamField path="timeoutMs" type="number">Command timeout in milliseconds. Default `120000`.</ParamField>
+    <ParamField path="timeoutMs" type="number">Command timeout in milliseconds. Overrides the resolved TTS request timeout when set. When omitted, follows the request timeout; the plugin default is `120000`.</ParamField>
     <ParamField path="cwd" type="string">Optional command working directory.</ParamField>
     <ParamField path="env" type="Record<string, string>">Optional environment overrides for the command.</ParamField>
 

--- a/extensions/tts-local-cli/speech-provider.live.test.ts
+++ b/extensions/tts-local-cli/speech-provider.live.test.ts
@@ -3,7 +3,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveFfmpegBin, runFfmpeg } from "openclaw/plugin-sdk/media-runtime";
-import type { SpeechProviderConfig } from "openclaw/plugin-sdk/speech-core";
+import type { SpeechProviderConfig, SpeechSynthesisRequest } from "openclaw/plugin-sdk/speech-core";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 import { buildCliSpeechProvider } from "./speech-provider.js";
@@ -45,20 +45,26 @@ copyFileSync(${JSON.stringify(wavPath)}, process.argv[outIndex + 1]);
         timeoutMs: 30_000,
       };
 
-      const result = await buildCliSpeechProvider().synthesize({
+      const provider = buildCliSpeechProvider();
+      const request: SpeechSynthesisRequest = {
         text: "hello world",
         cfg: {} as OpenClawConfig,
         providerConfig,
         providerOverrides: {},
         timeoutMs: 30_000,
         target: "voice-note",
-      });
+      };
+      const result = await provider.synthesize(request);
 
       expect(result.outputFormat).toBe("opus");
       expect(result.fileExtension).toBe(".ogg");
       expect(result.voiceCompatible).toBe(true);
       expect(result.audioBuffer.byteLength).toBeGreaterThan(0);
       expect(readFileSync(wavPath).byteLength).toBeGreaterThan(0);
+
+      const telephony = await provider.synthesizeTelephony?.(request);
+      expect(telephony).toMatchObject({ outputFormat: "pcm", sampleRate: 16_000 });
+      expect(telephony?.audioBuffer.byteLength).toBeGreaterThan(0);
     });
   }, 30_000);
 

--- a/extensions/tts-local-cli/speech-provider.test.ts
+++ b/extensions/tts-local-cli/speech-provider.test.ts
@@ -1,5 +1,12 @@
 // Tts Local Cli tests cover speech provider plugin behavior.
-import { mkdtempSync, rmSync, truncateSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  truncateSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -98,6 +105,25 @@ function createOggFirstPage(firstPacket: Buffer): Buffer {
   return Buffer.concat([header, Buffer.from([firstPacket.length]), firstPacket]);
 }
 
+function createTimeoutCliFixture() {
+  const fixture = createCliFixture();
+  const lifecyclePath = path.join(fixture.dir, "lifecycle.json");
+  writeFileSync(
+    fixture.script,
+    `
+import { writeFileSync } from "node:fs";
+const outputPath = process.argv[process.argv.indexOf("--out") + 1];
+const lifecyclePath = ${JSON.stringify(lifecyclePath)};
+const lifecycle = { pid: process.pid, outputPath, completed: false };
+writeFileSync(lifecyclePath, JSON.stringify(lifecycle));
+await new Promise((resolve) => setTimeout(resolve, 3_000));
+writeFileSync(outputPath, Buffer.from("UklGRmQBAABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YUABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==", "base64"));
+writeFileSync(lifecyclePath, JSON.stringify({ ...lifecycle, completed: true }));
+`,
+  );
+  return { ...fixture, lifecyclePath };
+}
+
 function baseProviderConfig(
   script: string,
   overrides: SpeechProviderConfig = {},
@@ -192,6 +218,78 @@ describe("buildCliSpeechProvider", () => {
         timeoutMs: 1000,
       }),
     ).toEqual({ command: "canonical-command" });
+  });
+
+  describe("CLI timeout ownership", () => {
+    it("advertises the existing command timeout as its provider default", () => {
+      expect(buildCliSpeechProvider().defaultTimeoutMs).toBe(120_000);
+    });
+
+    it.each([
+      { method: "synthesize", providerTimeoutMs: undefined },
+      { method: "synthesizeTelephony", providerTimeoutMs: undefined },
+      { method: "synthesize", providerTimeoutMs: 8_000 },
+      { method: "synthesizeTelephony", providerTimeoutMs: 8_000 },
+    ] as const)(
+      "$method honors timeout precedence with provider timeout $providerTimeoutMs",
+      async ({ method, providerTimeoutMs }) => {
+        const fixture = createTimeoutCliFixture();
+        try {
+          const provider = buildCliSpeechProvider();
+          const providerConfig = baseProviderConfig(fixture.script, {
+            args: [fixture.script, "--out", "{{OutputPath}}"],
+            outputFormat: "wav",
+          });
+          if (providerTimeoutMs === undefined) {
+            delete providerConfig.timeoutMs;
+          } else {
+            providerConfig.timeoutMs = providerTimeoutMs;
+          }
+          const request = {
+            text: "timeout contract",
+            cfg: TEST_CFG,
+            providerConfig,
+            providerOverrides: {},
+            timeoutMs: 1_000,
+            target: "audio-file" as const,
+          };
+          const pending =
+            method === "synthesize"
+              ? provider.synthesize(request)
+              : provider.synthesizeTelephony?.(request);
+          if (!pending) {
+            throw new Error("Local CLI telephony synthesis is unavailable");
+          }
+          const outcome = await pending.then(
+            (value) => ({ ok: true as const, value }),
+            (error: unknown) => ({ ok: false as const, error }),
+          );
+          const lifecycle = JSON.parse(readFileSync(fixture.lifecyclePath, "utf8")) as {
+            outputPath: string;
+            completed: boolean;
+          };
+          expect(existsSync(path.dirname(lifecycle.outputPath))).toBe(false);
+          if (providerTimeoutMs === undefined) {
+            expect(outcome.ok).toBe(false);
+            if (!outcome.ok) {
+              expect(outcome.error).toMatchObject({
+                message: "CLI TTS timed out after 1000ms",
+              });
+            }
+            expect(lifecycle.completed).toBe(false);
+          } else {
+            expect(outcome.ok).toBe(true);
+            if (outcome.ok) {
+              expect(outcome.value.audioBuffer.byteLength).toBeGreaterThan(0);
+            }
+            expect(lifecycle.completed).toBe(true);
+          }
+        } finally {
+          rmSync(fixture.dir, { recursive: true, force: true });
+        }
+      },
+      10_000,
+    );
   });
 
   it("passes text through stdin when args omit the text template", async () => {

--- a/extensions/tts-local-cli/speech-provider.ts
+++ b/extensions/tts-local-cli/speech-provider.ts
@@ -58,7 +58,10 @@ function resolveCliProviderConfig(rawConfig: Record<string, unknown>): SpeechPro
   return asOptionalRecord(providers?.["tts-local-cli"]) ?? asOptionalRecord(providers?.cli) ?? {};
 }
 
-function getConfig(cfg: SpeechProviderConfig): CliConfig | null {
+function getConfig(
+  cfg: SpeechProviderConfig,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): CliConfig | null {
   const command = typeof cfg.command === "string" ? cfg.command.trim() : "";
   if (!command) {
     return null;
@@ -67,7 +70,7 @@ function getConfig(cfg: SpeechProviderConfig): CliConfig | null {
     command,
     args: asStringArray(cfg.args) ?? [],
     outputFormat: normalizeOutputFormat(cfg.outputFormat),
-    timeoutMs: typeof cfg.timeoutMs === "number" ? cfg.timeoutMs : DEFAULT_TIMEOUT_MS,
+    timeoutMs: typeof cfg.timeoutMs === "number" ? cfg.timeoutMs : timeoutMs,
     cwd: typeof cfg.cwd === "string" ? cfg.cwd : undefined,
     env: filterStringRecord(cfg.env),
   };
@@ -193,19 +196,7 @@ function detectAudioFormat(buffer: Buffer): SourceFormat | null {
 }
 
 function getFileExt(format: SourceFormat): string {
-  if (format === "opus") {
-    return ".opus";
-  }
-  if (format === "ogg") {
-    return ".ogg";
-  }
-  if (format === "m4a") {
-    return ".m4a";
-  }
-  if (format === "wav") {
-    return ".wav";
-  }
-  return ".mp3";
+  return `.${format}`;
 }
 
 function readAudioFile(filePath: string): Buffer {
@@ -358,6 +349,7 @@ export function buildCliSpeechProvider(): SpeechProviderPlugin {
     aliases: ["cli"],
     label: "Local CLI",
     autoSelectOrder: 1000,
+    defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
 
     resolveConfig(ctx): SpeechProviderConfig {
       return resolveCliProviderConfig(ctx.rawConfig);
@@ -368,7 +360,7 @@ export function buildCliSpeechProvider(): SpeechProviderPlugin {
     },
 
     async synthesize(req: SpeechSynthesisRequest) {
-      const config = getConfig(req.providerConfig);
+      const config = getConfig(req.providerConfig, req.timeoutMs);
       if (!config) {
         throw new Error("CLI TTS not configured");
       }
@@ -414,7 +406,7 @@ export function buildCliSpeechProvider(): SpeechProviderPlugin {
     },
 
     async synthesizeTelephony(req: SpeechTelephonySynthesisRequest) {
-      const config = getConfig(req.providerConfig);
+      const config = getConfig(req.providerConfig, req.timeoutMs);
       if (!config) {
         throw new Error("CLI TTS not configured");
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Local CLI speech synthesis ignores the resolved TTS request timeout unless a provider-specific timeout is configured. A command that takes three seconds could finish successfully despite a one-second request timeout, in both ordinary and telephony synthesis.

## Why This Change Was Made

The plugin's configuration owner now receives the request timeout. An explicit provider timeout still takes precedence, and the plugin advertises its existing 120-second default through the existing provider contract. Both synthesis paths use that same resolution; no new setting or cancellation path is introduced.

The closed set of detected audio formats already matches its file suffixes, so the redundant suffix-selection branches are removed. Production: **+9/−17 (net −8)**. Tests: **+108/−4 (net +104)**. Documentation is line-neutral and explains the precedence; its stale fixed provider count is also removed.

## User Impact

Local speech commands respect the selected request limit when no provider override is present. Existing explicit overrides and default behavior remain available. This does not change the separate transcoding deadline, provider routing, or channel delivery.

## Evidence

The five timeout/default cases failed in three places before the repair and all pass afterward; 34 provider and stream-error tests pass. The tests exercise real child commands and verify that timed-out commands do not finish writing audio and that their workspaces are removed, including both synthesis entry points.

After a normal build, the public `infer tts convert --local --provider tts-local-cli --json` path passes four controls: the one-second request produces the expected timeout JSON and no audio; the explicit eight-second override, existing default, and immediate command produce the original WAV. The failure also emits the CLI's normal diagnostic on stderr. Native process closure was verified without retrying or suppressing that output.

Two additional public CLI conversions pass with real FFmpeg, and the public media SDK's ffprobe confirms the results: MP3 stdout becomes WAV/PCM s16le; Ogg/Vorbis stdout becomes Ogg/Opus. Temporary workspaces are removed. These are local synthesis and codec proofs, not live channel or telephony delivery.

The dedicated live test command could not collect tests because its standard read-only authentication staging rejected a pre-existing operator database schema. That failure is retained; no operator database was migrated and no staging guard was bypassed. Scoped formatting and independent Codex review are clean. Required exact-head CI remains the landing gate.
