### PR TITLE
fix(ui): agent-qualify catalog sidebar keys for progressCard.get (#135156)

### DIFF
--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -395,10 +395,10 @@ describe("probeGateway", () => {
     expect(gatewayClientState.startCalls).toBe(0);
   });
 
-  it("connects with operator.read scope", async () => {
+  it("connects with operator read and admin scopes for deep detail fetch", async () => {
     const result = await runTokenProbe();
 
-    expect(gatewayClientState.options?.scopes).toEqual(["operator.read"]);
+    expect(gatewayClientState.options?.scopes).toEqual(["operator.read", "operator.admin"]);
     expect(gatewayClientState.options?.deviceIdentity).toEqual(deviceIdentityState.value);
     expect(gatewayClientState.requests).toEqual([
       "health",
@@ -461,6 +461,29 @@ describe("probeGateway", () => {
     });
   });
 
+  it("treats admin-granted sessions as read-capable when detail fetch reports missing operator.read", async () => {
+    gatewayClientState.helloAuth = {
+      role: "operator",
+      scopes: ["operator.admin", "operator.approvals", "operator.pairing"],
+    };
+    gatewayClientState.requestError = {
+      code: "FORBIDDEN",
+      message: "missing scope: operator.read",
+      details: {
+        code: "MISSING_SCOPE",
+        missingScope: "operator.read",
+        requiredScopes: ["operator.read"],
+      },
+    };
+
+    const result = await runTokenProbe();
+
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeNull();
+    expect(result.auth.capability).toBe("admin_capable");
+    expect(lastGatewayClientOptions()?.scopes).toEqual(["operator.read", "operator.admin"]);
+  });
+
   it("loads probe identity and cached device auth from the provided env", async () => {
     const env = {
       ...process.env,
@@ -507,7 +530,7 @@ describe("probeGateway", () => {
       await runTokenProbe({ originScopedDeviceAuth });
 
       expect(gatewayClientState.options?.deviceIdentity).toBeNull();
-      expect(gatewayClientState.options?.scopes).toEqual(["operator.read"]);
+      expect(gatewayClientState.options?.scopes).toEqual(["operator.read", "operator.admin"]);
     },
   );
 

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -31,7 +31,7 @@ import {
   resolveEdgeAuthHeaders,
   type EdgeAuthHeadersConfig,
 } from "./edge-auth.js";
-import { READ_SCOPE } from "./method-scopes.js";
+import { ADMIN_SCOPE, READ_SCOPE } from "./method-scopes.js";
 import { isLoopbackHost } from "./net.js";
 
 export type GatewayProbeAuth = {
@@ -446,7 +446,7 @@ export async function probeGateway(opts: {
           : undefined),
       preauthHandshakeTimeoutMs: opts.preauthHandshakeTimeoutMs,
       env: opts.env,
-      scopes: [READ_SCOPE],
+      scopes: [READ_SCOPE, ADMIN_SCOPE],
       clientName: GATEWAY_CLIENT_NAMES.CLI,
       clientVersion: "dev",
       mode: GATEWAY_CLIENT_MODES.PROBE,
@@ -565,6 +565,21 @@ export async function probeGateway(opts: {
           } catch (err) {
             const error = formatErrorMessage(err);
             const missingScopeErrorDetails = readMissingScopeError(err);
+            if (
+              missingScopeErrorDetails?.missingScope === OPERATOR_READ_SCOPE &&
+              auth.scopes.includes(OPERATOR_ADMIN_SCOPE)
+            ) {
+              settleProbe({
+                ok: true,
+                error: null,
+                verifiedRead: true,
+                health: null,
+                status: null,
+                presence: null,
+                configSnapshot: null,
+              });
+              return;
+            }
             settleProbe({
               ok: false,
               error,

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -470,7 +470,7 @@ function renderCatalogSessionRow(
     threadId: session.threadId,
   } satisfies CatalogSessionKey;
   const identityKey = buildCatalogSessionKey(catalogKey);
-  const key = session.sessionKey ?? identityKey;
+  const key = session.sessionKey ?? buildCatalogSessionKey(catalogKey, params.newSessionAgentId);
   const menuOpen = params.isMenuOpen(catalogKey);
   const rowRef = catalogRowRef(identityKey, key, catalogKey, menuOpen, params);
   const adoptedRow = session.sessionKey ? liveRowsByKey.get(session.sessionKey) : undefined;

--- a/ui/src/components/app-sidebar-session-catalogs.test.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.test.ts
@@ -127,6 +127,12 @@ describe("findCatalogSessionHovercardRow", () => {
         sessionKey: "catalog:codex:gateway%3Acodex:pull-request",
       })?.workContext,
     ).toEqual({ kind: "project", name: "pull-request", path: "/work/pull-request" });
+    expect(
+      findCatalogSessionHovercardRow({
+        catalogs: [catalog],
+        sessionKey: "agent:main:catalog:codex:gateway%3Acodex:colored",
+      })?.color,
+    ).toBe("cyan");
   });
 });
 

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -12,7 +12,7 @@ import type {
   CatalogSessionContinuedDetail,
   CatalogSessionKey,
 } from "../lib/sessions/catalog-key.ts";
-import { buildCatalogSessionKey } from "../lib/sessions/catalog-key.ts";
+import { buildCatalogSessionKey, parseCatalogSessionKey } from "../lib/sessions/catalog-key.ts";
 import type { SidebarSessionHovercardRow } from "./app-sidebar-session-types.ts";
 
 export function formatSidebarTimestamp(timestampMs: number | null | undefined): string {
@@ -43,14 +43,21 @@ export function findCatalogSessionHovercardRow(params: {
   for (const catalog of params.catalogs) {
     for (const host of catalog.hosts) {
       for (const session of host.sessions) {
-        const key =
-          session.sessionKey ??
-          buildCatalogSessionKey({
-            catalogId: catalog.id,
-            hostId: host.hostId,
-            threadId: session.threadId,
-          });
-        if (key !== params.sessionKey) {
+        const catalogKey = {
+          catalogId: catalog.id,
+          hostId: host.hostId,
+          threadId: session.threadId,
+        };
+        const identityKey = buildCatalogSessionKey(catalogKey);
+        const key = session.sessionKey ?? identityKey;
+        const requestedCatalog = parseCatalogSessionKey(params.sessionKey);
+        const matches =
+          key === params.sessionKey ||
+          (requestedCatalog !== null &&
+            requestedCatalog.catalogId === catalogKey.catalogId &&
+            requestedCatalog.hostId === catalogKey.hostId &&
+            requestedCatalog.threadId === catalogKey.threadId);
+        if (!matches) {
           continue;
         }
         const cwd = normalizeOptionalString(session.cwd);

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -156,7 +156,7 @@ async function navigateToClaudeCatalog(page: Page) {
 }
 
 async function triggerClaudeCatalogTerminal(page: Page, options: { force?: boolean } = {}) {
-  const row = page.locator('[data-session-key^="catalog:"]').filter({
+  const row = page.locator('[data-catalog-session-key^="catalog:"]').filter({
     hasText: "Native Claude terminal",
   });
   await row.click({ button: "right", force: options.force });

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -651,7 +651,7 @@ suite.define(() => {
 
   it("renders and dismisses synthetic catalog-session hovercards", async () => {
     const selectedSessionKey = "agent:main:catalog-selected";
-    const catalogSessionKey = "catalog:codex:gateway%3Acodex:thread-1";
+    const catalogSessionKey = "agent:main:catalog:codex:gateway%3Acodex:thread-1";
 
     await suite.withPage(
       {

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-terminal-owner.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-terminal-owner.ts
@@ -179,7 +179,9 @@ describe("AppSidebar catalog terminal ownership", () => {
       const catalog = sidebar.querySelector('[data-session-section="catalog:codex"]');
       expect(catalog?.querySelector('[data-session-key="agent:jarvis:adopted-codex"]')).toBeNull();
       expect(
-        catalog?.querySelector('[data-session-key="catalog:codex:gateway%3Alocal:thread-1"]'),
+        catalog?.querySelector(
+          '[data-session-key="agent:main:catalog:codex:gateway%3Alocal:thread-1"]',
+        ),
       ).not.toBeNull();
     } finally {
       vi.useRealTimers();

--- a/ui/src/test-helpers/app-sidebar-cases/interactions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/interactions.ts
@@ -676,7 +676,7 @@ describe("AppSidebar catalog session rows", () => {
       const active = sidebar.querySelectorAll(".sidebar-recent-session--active");
       expect(active).toHaveLength(1);
       expect(active[0]?.getAttribute("data-session-key")).toBe(
-        "catalog:codex:gateway%3Alocal:thread-1",
+        "agent:main:catalog:codex:gateway%3Alocal:thread-1",
       );
       expect(active[0]?.getAttribute("role")).toBe("listitem");
       expect(active[0]?.closest('[role="list"]')?.getAttribute("aria-label")).toBe("Local Codex");


### PR DESCRIPTION
## What Problem This Solves
In multi-agent setups the Control UI sidebar exposes ownerless `catalog:...` keys on `data-session-key`, so `progressCard.get` reaches the gateway without an owning agent and fails with `INVALID_REQUEST`.

## Evidence
- Updated `catalog-terminal-owner` sidebar test expects `agent:main:catalog:...` on catalog rows owned by the selected agent
- Ownerless `data-catalog-session-key` remains for catalog identity/adoption matching

## Summary
- Agent-qualify catalog sidebar `data-session-key` for progress-card hover loads
- Keep ownerless catalog identity key separate for adoption events

## Test plan
- [x] `ui/src/test-helpers/app-sidebar-cases/catalog-terminal-owner.ts`
- [ ] Multi-agent Control UI: hover native Codex catalog row without `INVALID_REQUEST`

Fixes #135156