### PR TITLE
fix(media): recognize UTF-8 attachments across sniff boundaries

### DIFF
--- a/packages/media-core/src/attachment-classify.test.ts
+++ b/packages/media-core/src/attachment-classify.test.ts
@@ -38,6 +38,16 @@ describe("classifyAttachmentBytes", () => {
       expectedClass: "binary",
     },
     {
+      name: "an invalid continuation after the sniff boundary",
+      buffer: Buffer.concat([completeUtf8.subarray(0, 4095), Buffer.from([0xe2, 0x28])]),
+      expectedClass: "binary",
+    },
+    {
+      name: "an incomplete sequence at the actual 4,097-byte EOF",
+      buffer: Buffer.concat([completeUtf8.subarray(0, 4095), Buffer.from([0xe2, 0x82])]),
+      expectedClass: "binary",
+    },
+    {
       name: "an invalid byte before the sniff boundary",
       buffer: Buffer.concat([
         completeUtf8.subarray(0, 1200),
@@ -48,6 +58,62 @@ describe("classifyAttachmentBytes", () => {
     },
     { name: "empty input", buffer: Buffer.alloc(0), expectedClass: "binary" },
   ] as const)("classifies $name", async ({ buffer, expectedClass }) => {
+    await expect(classifyAttachmentBytes({ buffer, name: "notes" })).resolves.toEqual({
+      mime: expectedClass === "text" ? "text/plain" : undefined,
+      class: expectedClass,
+    });
+  });
+
+  it.each([
+    { name: "two-byte sequence", prefixLength: 4095, bytes: [0xc2, 0xa3], expectedClass: "text" },
+    {
+      name: "three-byte sequence",
+      prefixLength: 4095,
+      bytes: [0xe2, 0x82, 0xac],
+      expectedClass: "text",
+    },
+    {
+      name: "four-byte sequence after its first byte",
+      prefixLength: 4095,
+      bytes: [0xf0, 0x9f, 0xa6, 0x80],
+      expectedClass: "text",
+    },
+    {
+      name: "four-byte sequence after its second byte",
+      prefixLength: 4094,
+      bytes: [0xf0, 0x9f, 0xa6, 0x80],
+      expectedClass: "text",
+    },
+    {
+      name: "four-byte sequence after its third byte",
+      prefixLength: 4093,
+      bytes: [0xf0, 0x9f, 0xa6, 0x80],
+      expectedClass: "text",
+    },
+    {
+      name: "overlong sequence crossing the boundary",
+      prefixLength: 4095,
+      bytes: [0xe0, 0x80, 0x80],
+      expectedClass: "binary",
+    },
+    {
+      name: "new sequence outside a complete sample",
+      prefixLength: 4096,
+      bytes: [0xf0, 0x9f, 0xa6, 0x80],
+      expectedClass: "text",
+    },
+    {
+      name: "invalid byte outside a complete sample",
+      prefixLength: 4096,
+      bytes: [0xff],
+      expectedClass: "text",
+    },
+  ])("bounds UTF-8 completion for a $name", async ({ prefixLength, bytes, expectedClass }) => {
+    const buffer = Buffer.concat([
+      completeUtf8.subarray(0, 4092),
+      Buffer.alloc(prefixLength - 4092, 0x61),
+      Buffer.from(bytes),
+    ]);
     await expect(classifyAttachmentBytes({ buffer, name: "notes" })).resolves.toEqual({
       mime: expectedClass === "text" ? "text/plain" : undefined,
       class: expectedClass,

--- a/packages/media-core/src/attachment-classify.test.ts
+++ b/packages/media-core/src/attachment-classify.test.ts
@@ -19,6 +19,41 @@ describe("attachmentClassFromMime", () => {
 });
 
 describe("classifyAttachmentBytes", () => {
+  const completeUtf8 = Buffer.from("验证".repeat(700), "utf8");
+
+  it.each([
+    {
+      name: "complete 4,092-byte UTF-8 text",
+      buffer: completeUtf8.subarray(0, 4092),
+      expectedClass: "text",
+    },
+    {
+      name: "complete 4,200-byte UTF-8 text with a split sniff prefix",
+      buffer: completeUtf8,
+      expectedClass: "text",
+    },
+    {
+      name: "a complete input truncated mid-character at 4,096 bytes",
+      buffer: completeUtf8.subarray(0, 4096),
+      expectedClass: "binary",
+    },
+    {
+      name: "an invalid byte before the sniff boundary",
+      buffer: Buffer.concat([
+        completeUtf8.subarray(0, 1200),
+        Buffer.from([0xff]),
+        completeUtf8.subarray(1200),
+      ]),
+      expectedClass: "binary",
+    },
+    { name: "empty input", buffer: Buffer.alloc(0), expectedClass: "binary" },
+  ] as const)("classifies $name", async ({ buffer, expectedClass }) => {
+    await expect(classifyAttachmentBytes({ buffer, name: "notes" })).resolves.toEqual({
+      mime: expectedClass === "text" ? "text/plain" : undefined,
+      class: expectedClass,
+    });
+  });
+
   it("infers delimited text from otherwise untyped bytes", async () => {
     await expect(
       classifyAttachmentBytes({ buffer: Buffer.from("name,value\nopenclaw,1"), name: "data.bin" }),

--- a/packages/media-core/src/attachment-classify.ts
+++ b/packages/media-core/src/attachment-classify.ts
@@ -100,12 +100,12 @@ function textRatios(text: string, includeWordish: boolean): [printable: number, 
 }
 
 function looksLikeText(buffer: Buffer): boolean {
-  if (buffer.length === 0) {
-    return false;
-  }
-  const sample = buffer.subarray(0, Math.min(buffer.length, 4096));
+  const sample = buffer.subarray(0, 4096);
+  const stream = sample.length < buffer.length;
   try {
-    return textRatios(new TextDecoder("utf-8", { fatal: true }).decode(sample), false)[0] > 0.85;
+    // Only a bounded prefix may leave an incomplete UTF-8 code point buffered.
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(sample, { stream });
+    return textRatios(text, false)[0] > 0.85;
   } catch {
     const [printable, wordish] = textRatios(new TextDecoder("windows-1252").decode(sample), true);
     return printable > 0.95 && wordish > 0.3;

--- a/packages/media-core/src/attachment-classify.ts
+++ b/packages/media-core/src/attachment-classify.ts
@@ -81,30 +81,30 @@ function resolveUtf16Charset(buffer: Buffer): AttachmentCharset | undefined {
 
 function textRatios(text: string, includeWordish: boolean): [printable: number, wordish: number] {
   let printable = 0;
-  let control = 0;
   let wordish = 0;
+  let total = 0;
   for (const char of text) {
     const code = char.codePointAt(0) ?? 0;
-    if (code === 9 || code === 10 || code === 13 || code === 32) {
-      printable += 1;
-      wordish += 1;
-    } else if (code < 32 || (code >= 0x7f && code <= 0x9f)) {
-      control += 1;
-    } else {
-      printable += 1;
-      wordish += includeWordish ? Number(WORDISH_CHAR.test(char)) : 0;
-    }
+    const whitespace = code === 9 || code === 10 || code === 13 || code === 32;
+    const isControl = !whitespace && (code < 32 || (code >= 0x7f && code <= 0x9f));
+    total += 1;
+    printable += Number(!isControl);
+    wordish += Number(whitespace || (!isControl && includeWordish && WORDISH_CHAR.test(char)));
   }
-  const total = printable + control;
   return total === 0 ? [0, 0] : [printable / total, wordish / total];
 }
 
 function looksLikeText(buffer: Buffer): boolean {
   const sample = buffer.subarray(0, 4096);
-  const stream = sample.length < buffer.length;
+  // Finish the last sampled UTF-8 sequence without starting a new one outside the window.
+  // Its lead is within the final four bytes; completion needs at most three more.
+  const tail = sample.subarray(-4);
+  const leadIndex = tail.findLastIndex((byte) => (byte & 0xc0) !== 0x80);
+  const lead = tail[leadIndex] ?? 0;
+  const width = lead >= 0xf0 ? 4 : lead >= 0xe0 ? 3 : lead >= 0xc2 ? 2 : 1;
+  const end = sample.length + Math.max(0, leadIndex + width - tail.length);
   try {
-    // Only a bounded prefix may leave an incomplete UTF-8 code point buffered.
-    const text = new TextDecoder("utf-8", { fatal: true }).decode(sample, { stream });
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(buffer.subarray(0, end));
     return textRatios(text, false)[0] > 0.85;
   } catch {
     const [printable, wordish] = textRatios(new TextDecoder("windows-1252").decode(sample), true);

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -2107,6 +2107,23 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toContain("hello from utf16 text");
   });
 
+  it("extracts untyped UTF-8 attachments across the sniff boundary", async () => {
+    const text = "验证".repeat(700);
+    const mediaPath = await createTempMediaFile({
+      fileName: "notes.bin",
+      content: text,
+    });
+
+    const { ctx } = await applyWithDisabledMedia({
+      body: "<media:file>",
+      mediaPath,
+      selfServeLocalPaths: false,
+    });
+
+    expect(ctx.agentText).toContain(text);
+    expect(ctx.Body).toContain('<file name="notes.bin" mime="text/plain">');
+  });
+
   it("extracts inbound files above the 5MB OpenResponses default up to the managed-media cap", async () => {
     // #90096: inbound extraction sizes to the agent media cap (default 20MB),
     // not the OpenResponses input_file default (5MB). A ~6MB managed document

--- a/src/media-understanding/attachments.cache.test.ts
+++ b/src/media-understanding/attachments.cache.test.ts
@@ -42,22 +42,39 @@ describe("media understanding attachment cache", () => {
     readRemoteMediaBufferMock.mockReset();
   });
 
-  it("prefers local attachment bytes over conflicting declared MIME", async () => {
+  it.each([
+    {
+      name: "prefers local attachment bytes over conflicting declared MIME",
+      fileName: "photo.jpg",
+      buffer: PNG_1X1,
+      declaredMime: "application/pdf",
+      expected: { mime: "image/png", class: "image" },
+    },
+    {
+      name: "infers long UTF-8 text from a generically typed local attachment",
+      fileName: "notes",
+      buffer: Buffer.from("验证".repeat(700), "utf8"),
+      declaredMime: "application/octet-stream",
+      expected: { mime: "text/plain", class: "text" },
+    },
+  ])("$name", async (testCase) => {
     await withTestDir({ prefix: "openclaw-media-cache-mime-local-" }, async (base) => {
-      const attachmentPath = path.join(base, "photo.jpg");
-      await fs.writeFile(attachmentPath, PNG_1X1);
+      const attachmentPath = path.join(base, testCase.fileName);
+      await fs.writeFile(attachmentPath, testCase.buffer);
       const cache = new MediaAttachmentCache(
-        [{ index: 0, path: attachmentPath, mime: "application/pdf" }],
+        [{ index: 0, path: attachmentPath, mime: testCase.declaredMime }],
         { localPathRoots: [base] },
       );
 
       const result = await cache.getBuffer({
         attachmentIndex: 0,
-        maxBytes: 1024,
+        maxBytes: testCase.buffer.byteLength,
         timeoutMs: 1000,
       });
 
-      expect(result.mime).toBe("image/png");
+      expect(result.mime).toBe(testCase.expected.mime);
+      expect(result.classification).toEqual(testCase.expected);
+      expect(result.buffer).toEqual(testCase.buffer);
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes valid UTF-8 attachments being classified as binary when a multibyte character crosses the 4,096-byte sniff boundary. A 4,200-byte Chinese attachment with a generic filename could produce an unsupported-document marker instead of its text in the agent's context.

## Why This Change Was Made

The byte classifier finalized a bounded prefix as if it were the complete input. Fatal UTF-8 decoding rejected its incomplete final character even when the remaining bytes existed in the attachment. The classifier now completes only the sequence that starts inside the sample, reading at most three additional bytes, and then performs a final fatal decode. It neither starts another out-of-window sequence nor silently discards an incomplete character at actual EOF.

The canonical text-ratio calculation is simplified, and redundant empty-input and length checks are removed to absorb the repair. Production **+16/−16 (net 0)**; tests **+141/−6 (net +135)**. The existing ratio calculation rejects empty text. No configuration, dependency, full-file validation, or downstream workaround is added.

## User Impact

Untyped UTF-8 text survives local classification, caching, and extraction with its complete contents. Existing MIME handling and Windows-1252 fallback policy remain; that fallback still receives the original 4 KiB sample. Bytes after an already complete sample remain outside this bounded heuristic.

The earlier classifier consolidation in #122168 and performance repair in #133424 both retained the prefix-finalization behavior. This does not resolve outbound validation in #120229 or document interception in #129539. Charset propagation for Windows-1252 remains a named follow-up; this repair makes no claim to fix its downstream decoding.

## Evidence

The original classifier and real local-cache regressions failed before repair. After ClawSweeper identified that streaming decode could ignore a malformed boundary sequence, two additional cases failed on the reviewed PR head: an invalid continuation and an incomplete sequence at actual 4,097-byte EOF. The final implementation completes and validates that sequence instead of leaving it buffered.

All **35 classifier tests and 12 cache tests pass**, including two-, three-, and four-byte boundary splits, overlong encoding, actual EOF, signature/MIME precedence, complete-buffer preservation, and the bounded treatment of bytes outside a completed sample. The named attachment-application case also passes with all 700 Chinese repetitions in prepared agent text and a `text/plain` file wrapper. It uses a real file with local self-service disabled and exercises classification, caching, extraction, and context preparation. The other 85 application cases were filtered. Total focused AFTER coverage: **48 passing cases**.

Scoped formatting and Git diff checks pass. Formatting changed only two test-expression layouts; tested production bytes are unchanged. Independent Codex review is clean. The ClawSweeper boundary finding is addressed, with its failing cases retained as regressions. This is local attachment-flow proof, not a Gateway, provider, or live-channel run. Required exact-head CI remains the landing gate.
