### PR TITLE
fix(media): preserve attachment types when streamed chunks are reused

### DIFF
--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -341,10 +341,6 @@ describe("media store", () => {
     });
   }
 
-  async function expectTempStoreCase(run: () => Promise<void>) {
-    await run();
-  }
-
   it.each([
     {
       name: "creates and returns media directory",
@@ -424,22 +420,25 @@ describe("media store", () => {
     {
       name: "saves streams with detected extension without buffering first",
       run: async () => {
-        await withTempStore(async (storeLocal12) => {
-          const saved = await storeLocal12.saveMediaStream(
-            Readable.from([Buffer.from([0xff, 0xd8, 0xff, 0x00])]),
-            undefined,
-            "stream-inbound",
-            1024,
-            "photo.bin",
-          );
+        const chunk = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
+        const stream = (async function* () {
+          yield chunk;
+          chunk.fill(0);
+        })();
+        const saved = await store.saveMediaStream(
+          stream,
+          undefined,
+          "stream-inbound",
+          1024,
+          "photo.bin",
+        );
 
-          expect(saved.id).toMatch(/^photo---[a-f0-9-]{36}\.jpg$/);
-          expect(saved.size).toBe(4);
-          expect(saved.contentType).toBe("image/jpeg");
-          await expect(fs.readFile(saved.path)).resolves.toEqual(
-            Buffer.from([0xff, 0xd8, 0xff, 0x00]),
-          );
-        });
+        expect(saved.id).toMatch(/^photo---[a-f0-9-]{36}\.jpg$/);
+        expect(saved.size).toBe(4);
+        expect(saved.contentType).toBe("image/jpeg");
+        await expect(fs.readFile(saved.path)).resolves.toEqual(
+          Buffer.from([0xff, 0xd8, 0xff, 0x00]),
+        );
       },
     },
     {
@@ -645,7 +644,7 @@ describe("media store", () => {
       },
     },
   ] as const)("$name", async ({ run }) => {
-    await expectTempStoreCase(run);
+    await run();
   });
 
   it.each([

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -474,7 +474,7 @@ async function writeMediaStreamToFile(params: {
   maxBytes: number;
 }): Promise<{ sniffBuffer: Buffer; size: number }> {
   const handle = await fs.open(params.tempPath, "wx", MEDIA_FILE_MODE);
-  const sniffChunks: Buffer[] = [];
+  const sniffBuffer = Buffer.allocUnsafe(16384);
   let sniffLen = 0;
   let total = 0;
   try {
@@ -498,15 +498,14 @@ async function writeMediaStreamToFile(params: {
       if (total > params.maxBytes) {
         throw new Error(`Media exceeds ${formatMediaLimitMb(params.maxBytes)} limit`);
       }
-      if (sniffLen < 16384) {
-        const remaining = 16384 - sniffLen;
-        sniffChunks.push(buffer.byteLength > remaining ? buffer.subarray(0, remaining) : buffer);
-        sniffLen += Math.min(buffer.byteLength, remaining);
+      if (sniffLen < sniffBuffer.length) {
+        // The next pull may reuse the chunk; retain only the prefix we own.
+        sniffLen += buffer.copy(sniffBuffer, sniffLen);
       }
       await handle.writeFile(buffer);
     }
     return {
-      sniffBuffer: Buffer.concat(sniffChunks, sniffLen),
+      sniffBuffer: sniffBuffer.subarray(0, sniffLen),
       size: total,
     };
   } finally {


### PR DESCRIPTION
## What Problem This Solves

Streamed attachments can receive the wrong file type when their producer reuses a chunk after it has been written. The media store retains a view into that chunk for later MIME detection, so it can sniff overwritten bytes even though the saved file is correct. A short sniff view can also keep a much larger source allocation alive until the stream ends.

## Why This Change Was Made

The stream writer copies only the first 16 KiB into one owned prefix buffer before requesting another chunk. MIME detection receives only the initialized prefix. This replaces retained source views and the final concatenation without changing sequential writes, byte limits, temporary-file cleanup, or atomic publication.

Production LOC is +5/-6 (net -1); tests +19/-20 (net -1). The existing JPEG test now uses a producer that overwrites its yielded chunk. Two no-op test wrappers are removed while preserving the assertions. Whole-buffer storage has a different ownership contract and remains covered by the existing suite.

## User Impact

Attachments retain the file type of the bytes actually saved. Streaming no longer pins a large source allocation solely to retain its sniff prefix. The fixed prefix allocation is bounded; no configuration, dependency, public API, or persistent-storage contract changes.

## Evidence

- The strengthened existing test fails against the original writer: 48 cases pass and the reused-chunk JPEG case incorrectly produces `.bin`. The repaired writer passes all 138 store, retry, and fetch tests. After the final test-only wrapper cleanup, all 49 store cases pass again.
- Actual-source filesystem probe, three fresh processes per revision: while a stream is paused before EOF after a 64 MiB chunk and a subsequent byte, live ArrayBuffer growth is 67,108,864 bytes before and zero afterward. Every run saves exactly 67,108,865 bytes with an identical hash. This proves release of the source backing store; it does not claim lower RSS, which remained similar.
- The actual guarded HTTPS download path saves `https://example.com` as HTML: 559 bytes with the expected SHA-256. Temporary runtime state is removed afterward.
- Complete changed-file checks, a full build, and fresh Codex autoreview pass. Independent review covers producer reuse, offset views, size limits, initialized-prefix bounds, filesystem cleanup, and the inspected MIME/tokenizer contract.

The Node Buffer view and copy contracts were checked directly: [subarray ownership](https://nodejs.org/api/buffer.html#bufsubarraystart-end) and [bounded copying](https://nodejs.org/api/buffer.html#bufcopytarget-targetstart-sourcestart-sourceend). Only the initialized prefix escapes the unsafe allocation.
