### PR TITLE
refactor(ios): carry Watch inbound events through one owner

### DIFF
--- a/apps/ios/Sources/Services/WatchConnectivityTransport.swift
+++ b/apps/ios/Sources/Services/WatchConnectivityTransport.swift
@@ -4,11 +4,7 @@ import OSLog
 
 private struct WatchConnectivityTransportCallbacks {
     var statusUpdateHandler: (@Sendable (WatchMessagingStatus) -> Void)?
-    var replyHandler: (@Sendable (WatchQuickReplyEvent) -> Void)?
-    var execApprovalResolveHandler: (@Sendable (WatchExecApprovalResolveEvent) -> Void)?
-    var execApprovalSnapshotRequestHandler: (@Sendable (WatchExecApprovalSnapshotRequestEvent) -> Void)?
-    var appSnapshotRequestHandler: (@Sendable (WatchAppSnapshotRequestEvent) -> Void)?
-    var appCommandHandler: (@Sendable (WatchAppCommandEvent) -> Void)?
+    var inboundEventHandler: (@Sendable (WatchMessagingInboundEvent) -> Void)?
 }
 
 final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
@@ -57,26 +53,8 @@ final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
         self.updateCallbacks { $0.statusUpdateHandler = handler }
     }
 
-    func setReplyHandler(_ handler: (@Sendable (WatchQuickReplyEvent) -> Void)?) {
-        self.updateCallbacks { $0.replyHandler = handler }
-    }
-
-    func setExecApprovalResolveHandler(_ handler: (@Sendable (WatchExecApprovalResolveEvent) -> Void)?) {
-        self.updateCallbacks { $0.execApprovalResolveHandler = handler }
-    }
-
-    func setExecApprovalSnapshotRequestHandler(
-        _ handler: (@Sendable (WatchExecApprovalSnapshotRequestEvent) -> Void)?)
-    {
-        self.updateCallbacks { $0.execApprovalSnapshotRequestHandler = handler }
-    }
-
-    func setAppSnapshotRequestHandler(_ handler: (@Sendable (WatchAppSnapshotRequestEvent) -> Void)?) {
-        self.updateCallbacks { $0.appSnapshotRequestHandler = handler }
-    }
-
-    func setAppCommandHandler(_ handler: (@Sendable (WatchAppCommandEvent) -> Void)?) {
-        self.updateCallbacks { $0.appCommandHandler = handler }
+    func setInboundEventHandler(_ handler: (@Sendable (WatchMessagingInboundEvent) -> Void)?) {
+        self.updateCallbacks { $0.inboundEventHandler = handler }
     }
 
     func activate() {
@@ -198,44 +176,8 @@ final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
         }
     }
 
-    private func emitReply(_ event: WatchQuickReplyEvent) {
-        guard let handler = self.callbacksSnapshot().replyHandler else {
-            return
-        }
-        Task { @MainActor in
-            handler(event)
-        }
-    }
-
-    private func emitExecApprovalResolve(_ event: WatchExecApprovalResolveEvent) {
-        guard let handler = self.callbacksSnapshot().execApprovalResolveHandler else {
-            return
-        }
-        Task { @MainActor in
-            handler(event)
-        }
-    }
-
-    private func emitExecApprovalSnapshotRequest(_ event: WatchExecApprovalSnapshotRequestEvent) {
-        guard let handler = self.callbacksSnapshot().execApprovalSnapshotRequestHandler else {
-            return
-        }
-        Task { @MainActor in
-            handler(event)
-        }
-    }
-
-    private func emitAppSnapshotRequest(_ event: WatchAppSnapshotRequestEvent) {
-        guard let handler = self.callbacksSnapshot().appSnapshotRequestHandler else {
-            return
-        }
-        Task { @MainActor in
-            handler(event)
-        }
-    }
-
-    private func emitAppCommand(_ event: WatchAppCommandEvent) {
-        guard let handler = self.callbacksSnapshot().appCommandHandler else {
+    private func emitInboundEvent(_ event: WatchMessagingInboundEvent) {
+        guard let handler = self.callbacksSnapshot().inboundEventHandler else {
             return
         }
         Task { @MainActor in
@@ -312,36 +254,11 @@ extension WatchConnectivityTransport: WCSessionDelegate {
     func session(_: WCSession, didReceiveMessage message: [String: Any]) {
         let type = (message["type"] as? String) ?? "unknown"
         GatewayDiagnostics.log("watch messaging: didReceiveMessage type=\(type)")
-        if let event = WatchMessagingPayloadCodec.parseQuickReplyPayload(message, transport: "sendMessage") {
-            self.emitReply(event)
-            return
-        }
-        if let event = WatchMessagingPayloadCodec.parseExecApprovalResolvePayload(
+        if let event = WatchMessagingPayloadCodec.parseInboundPayload(
             message,
             transport: "sendMessage")
         {
-            self.emitExecApprovalResolve(event)
-            return
-        }
-        if let event = WatchMessagingPayloadCodec.parseExecApprovalSnapshotRequestPayload(
-            message,
-            transport: "sendMessage")
-        {
-            self.emitExecApprovalSnapshotRequest(event)
-            return
-        }
-        if let event = WatchMessagingPayloadCodec.parseAppSnapshotRequestPayload(
-            message,
-            transport: "sendMessage")
-        {
-            self.emitAppSnapshotRequest(event)
-            return
-        }
-        if let event = WatchMessagingPayloadCodec.parseAppCommandPayload(
-            message,
-            transport: "sendMessage")
-        {
-            self.emitAppCommand(event)
+            self.emitInboundEvent(event)
         }
     }
 
@@ -352,82 +269,25 @@ extension WatchConnectivityTransport: WCSessionDelegate {
     {
         let type = (message["type"] as? String) ?? "unknown"
         GatewayDiagnostics.log("watch messaging: didReceiveMessageWithReply type=\(type)")
-        if let event = WatchMessagingPayloadCodec.parseQuickReplyPayload(message, transport: "sendMessage") {
-            replyHandler(["ok": true])
-            self.emitReply(event)
-            return
-        }
-        if let event = WatchMessagingPayloadCodec.parseExecApprovalResolvePayload(
+        guard let event = WatchMessagingPayloadCodec.parseInboundPayload(
             message,
             transport: "sendMessage")
-        {
-            replyHandler(["ok": true])
-            self.emitExecApprovalResolve(event)
+        else {
+            replyHandler(["ok": false, "error": "unsupported_payload"])
             return
         }
-        if let event = WatchMessagingPayloadCodec.parseExecApprovalSnapshotRequestPayload(
-            message,
-            transport: "sendMessage")
-        {
-            replyHandler(["ok": true])
-            self.emitExecApprovalSnapshotRequest(event)
-            return
-        }
-        if let event = WatchMessagingPayloadCodec.parseAppSnapshotRequestPayload(
-            message,
-            transport: "sendMessage")
-        {
-            replyHandler(["ok": true])
-            self.emitAppSnapshotRequest(event)
-            return
-        }
-        if let event = WatchMessagingPayloadCodec.parseAppCommandPayload(
-            message,
-            transport: "sendMessage")
-        {
-            replyHandler(["ok": true])
-            self.emitAppCommand(event)
-            return
-        }
-        replyHandler(["ok": false, "error": "unsupported_payload"])
+        replyHandler(["ok": true])
+        self.emitInboundEvent(event)
     }
 
     func session(_: WCSession, didReceiveUserInfo userInfo: [String: Any]) {
         let type = (userInfo["type"] as? String) ?? "unknown"
         GatewayDiagnostics.log("watch messaging: didReceiveUserInfo type=\(type)")
-        if let event = WatchMessagingPayloadCodec.parseQuickReplyPayload(
+        if let event = WatchMessagingPayloadCodec.parseInboundPayload(
             userInfo,
             transport: "transferUserInfo")
         {
-            self.emitReply(event)
-            return
-        }
-        if let event = WatchMessagingPayloadCodec.parseExecApprovalResolvePayload(
-            userInfo,
-            transport: "transferUserInfo")
-        {
-            self.emitExecApprovalResolve(event)
-            return
-        }
-        if let event = WatchMessagingPayloadCodec.parseExecApprovalSnapshotRequestPayload(
-            userInfo,
-            transport: "transferUserInfo")
-        {
-            self.emitExecApprovalSnapshotRequest(event)
-            return
-        }
-        if let event = WatchMessagingPayloadCodec.parseAppSnapshotRequestPayload(
-            userInfo,
-            transport: "transferUserInfo")
-        {
-            self.emitAppSnapshotRequest(event)
-            return
-        }
-        if let event = WatchMessagingPayloadCodec.parseAppCommandPayload(
-            userInfo,
-            transport: "transferUserInfo")
-        {
-            self.emitAppCommand(event)
+            self.emitInboundEvent(event)
         }
     }
 

--- a/apps/ios/Sources/Services/WatchMessagingPayloadCodec.swift
+++ b/apps/ios/Sources/Services/WatchMessagingPayloadCodec.swift
@@ -1,6 +1,14 @@
 import Foundation
 import OpenClawKit
 
+enum WatchMessagingInboundEvent {
+    case reply(WatchQuickReplyEvent)
+    case execApprovalResolve(WatchExecApprovalResolveEvent)
+    case execApprovalSnapshotRequest(WatchExecApprovalSnapshotRequestEvent)
+    case appSnapshotRequest(WatchAppSnapshotRequestEvent)
+    case appCommand(WatchAppCommandEvent)
+}
+
 enum WatchMessagingPayloadCodec {
     private static let durableSnapshotTypes = [
         OpenClawWatchPayloadType.appSnapshot.rawValue,
@@ -306,6 +314,31 @@ enum WatchMessagingPayloadCodec {
     private static func truncatedCompletedChatReplyText(_ text: String) -> String {
         guard text.count > self.completedChatReplyTextLimit else { return text }
         return "\(text.prefix(self.completedChatReplyTextLimit - 3))..."
+    }
+
+    static func parseInboundPayload(
+        _ payload: [String: Any],
+        transport: String) -> WatchMessagingInboundEvent?
+    {
+        switch payload["type"] as? String {
+        case OpenClawWatchPayloadType.reply.rawValue:
+            self.parseQuickReplyPayload(payload, transport: transport)
+                .map(WatchMessagingInboundEvent.reply)
+        case OpenClawWatchPayloadType.execApprovalResolve.rawValue:
+            self.parseExecApprovalResolvePayload(payload, transport: transport)
+                .map(WatchMessagingInboundEvent.execApprovalResolve)
+        case OpenClawWatchPayloadType.execApprovalSnapshotRequest.rawValue:
+            self.parseExecApprovalSnapshotRequestPayload(payload, transport: transport)
+                .map(WatchMessagingInboundEvent.execApprovalSnapshotRequest)
+        case OpenClawWatchPayloadType.appSnapshotRequest.rawValue:
+            self.parseAppSnapshotRequestPayload(payload, transport: transport)
+                .map(WatchMessagingInboundEvent.appSnapshotRequest)
+        case OpenClawWatchPayloadType.appCommand.rawValue:
+            self.parseAppCommandPayload(payload, transport: transport)
+                .map(WatchMessagingInboundEvent.appCommand)
+        default:
+            nil
+        }
     }
 
     static func parseQuickReplyPayload(

--- a/apps/ios/Sources/Services/WatchMessagingService.swift
+++ b/apps/ios/Sources/Services/WatchMessagingService.swift
@@ -47,18 +47,10 @@ enum WatchMessagingError: LocalizedError {
 
 @MainActor
 final class WatchMessagingService: @preconcurrency WatchMessagingServicing {
-    private enum StartupEvent {
-        case reply(WatchQuickReplyEvent)
-        case execApprovalResolve(WatchExecApprovalResolveEvent)
-        case execApprovalSnapshotRequest(WatchExecApprovalSnapshotRequestEvent)
-        case appSnapshotRequest(WatchAppSnapshotRequestEvent)
-        case appCommand(WatchAppCommandEvent)
-    }
-
     private static let maxStartupEvents = 64
 
     private let transport: WatchConnectivityTransport
-    private var startupEvents = WatchMessagingStartupBuffer<StartupEvent>(
+    private var startupEvents = WatchMessagingStartupBuffer<WatchMessagingInboundEvent>(
         maxCount: WatchMessagingService.maxStartupEvents)
     private var statusHandler: (@Sendable (WatchMessagingStatus) -> Void)?
     private var lastEmittedStatus: WatchMessagingStatus?
@@ -76,29 +68,9 @@ final class WatchMessagingService: @preconcurrency WatchMessagingServicing {
                 self?.emitStatusIfChanged(snapshot)
             }
         }
-        self.transport.setReplyHandler { [weak self] event in
+        self.transport.setInboundEventHandler { [weak self] event in
             Task { @MainActor [weak self] in
-                self?.receiveStartupEvent(.reply(event))
-            }
-        }
-        self.transport.setExecApprovalResolveHandler { [weak self] event in
-            Task { @MainActor [weak self] in
-                self?.receiveStartupEvent(.execApprovalResolve(event))
-            }
-        }
-        self.transport.setExecApprovalSnapshotRequestHandler { [weak self] event in
-            Task { @MainActor [weak self] in
-                self?.receiveStartupEvent(.execApprovalSnapshotRequest(event))
-            }
-        }
-        self.transport.setAppSnapshotRequestHandler { [weak self] event in
-            Task { @MainActor [weak self] in
-                self?.receiveStartupEvent(.appSnapshotRequest(event))
-            }
-        }
-        self.transport.setAppCommandHandler { [weak self] event in
-            Task { @MainActor [weak self] in
-                self?.receiveStartupEvent(.appCommand(event))
+                self?.receiveStartupEvent(event)
             }
         }
         self.transport.activate()
@@ -260,7 +232,7 @@ final class WatchMessagingService: @preconcurrency WatchMessagingServicing {
         self.appCommandHandler?(event)
     }
 
-    private func receiveStartupEvent(_ event: StartupEvent) {
+    private func receiveStartupEvent(_ event: WatchMessagingInboundEvent) {
         for event in self.startupEvents.receive(event) {
             self.dispatchStartupEvent(event)
         }
@@ -280,7 +252,7 @@ final class WatchMessagingService: @preconcurrency WatchMessagingServicing {
         }
     }
 
-    private func dispatchStartupEvent(_ event: StartupEvent) {
+    private func dispatchStartupEvent(_ event: WatchMessagingInboundEvent) {
         switch event {
         case let .reply(event):
             self.emitReply(event)

--- a/apps/ios/Tests/WatchSessionActivationGateTests.swift
+++ b/apps/ios/Tests/WatchSessionActivationGateTests.swift
@@ -1,5 +1,7 @@
 import Foundation
+import OpenClawKit
 import Testing
+@preconcurrency import WatchConnectivity
 @testable import OpenClaw
 
 struct WatchSessionActivationGateTests {
@@ -150,8 +152,140 @@ struct WatchSessionActivationGateTests {
             "acknowledgment: WatchMessageAcknowledgment? = nil) -> Bool"))
         #expect(receiverSource.contains("guard activationState == .activated else { return }"))
         let callbackRegistration = try #require(
-            serviceSource.range(of: "self.transport.setAppCommandHandler"))
+            serviceSource.range(of: "self.transport.setInboundEventHandler"))
         let activation = try #require(serviceSource.range(of: "self.transport.activate()"))
         #expect(callbackRegistration.lowerBound < activation.lowerBound)
+    }
+}
+
+@MainActor
+struct WatchMessagingInboundTransportTests {
+    private final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [String] = []
+
+        func append(_ value: String) {
+            self.lock.withLock { self.values.append(value) }
+        }
+
+        func snapshot() -> [String] {
+            self.lock.withLock { self.values }
+        }
+    }
+
+    @Test func `inbound payload families cross every delegate boundary once`() async throws {
+        let transport = WatchConnectivityTransport()
+        let service = WatchMessagingService(transport: transport)
+        let events = Recorder()
+        let order = Recorder()
+        service.setReplyHandler { event in
+            order.append("callback")
+            events.append("reply|\(event.replyId)|\(event.transport)")
+        }
+        service.setExecApprovalResolveHandler { event in
+            order.append("callback")
+            events.append("resolve|\(event.approvalId)|\(event.transport)")
+        }
+        service.setExecApprovalSnapshotRequestHandler { event in
+            order.append("callback")
+            events.append("approvalSnapshot|\(event.requestId)|\(event.transport)")
+        }
+        service.setAppSnapshotRequestHandler { event in
+            order.append("callback")
+            events.append("appSnapshot|\(event.requestId)|\(event.transport)")
+        }
+        service.setAppCommandHandler { event in
+            order.append("callback")
+            events.append("appCommand|\(event.commandId)|\(event.transport)")
+        }
+
+        let opaqueApprovalID = "approval.e\u{301}/opaque"
+        let cases: [([String: Any], String, String)] = [
+            ([
+                "type": OpenClawWatchPayloadType.reply.rawValue,
+                "replyId": "reply/opaque",
+                "actionId": "approve",
+            ], "reply", "reply/opaque"),
+            ([
+                "type": OpenClawWatchPayloadType.execApprovalResolve.rawValue,
+                "replyId": "resolve/opaque",
+                "approvalId": opaqueApprovalID,
+                "decision": OpenClawWatchExecApprovalDecision.allowOnce.rawValue,
+            ], "resolve", opaqueApprovalID),
+            ([
+                "type": OpenClawWatchPayloadType.execApprovalSnapshotRequest.rawValue,
+                "requestId": "approval-snapshot/opaque",
+                "heldApprovals": [],
+            ], "approvalSnapshot", "approval-snapshot/opaque"),
+            ([
+                "type": OpenClawWatchPayloadType.appSnapshotRequest.rawValue,
+                "requestId": "app-snapshot/opaque",
+            ], "appSnapshot", "app-snapshot/opaque"),
+            ([
+                "type": OpenClawWatchPayloadType.appCommand.rawValue,
+                "command": OpenClawWatchAppCommand.refresh.rawValue,
+                "commandId": "app-command/opaque",
+            ], "appCommand", "app-command/opaque"),
+        ]
+
+        for ingress in 0..<3 {
+            let transportLabel = ingress == 2 ? "transferUserInfo" : "sendMessage"
+            for item in cases {
+                let before = events.snapshot().count
+                switch ingress {
+                case 0:
+                    transport.session(WCSession.default, didReceiveMessage: item.0)
+                case 1:
+                    var reply: [String: Any]?
+                    order.append("reply-pending")
+                    transport.session(
+                        WCSession.default,
+                        didReceiveMessage: item.0,
+                        replyHandler: {
+                            reply = $0
+                            order.append("reply")
+                        })
+                    #expect(reply?.count == 1)
+                    #expect(reply?["ok"] as? Bool == true)
+                default:
+                    transport.session(WCSession.default, didReceiveUserInfo: item.0)
+                }
+                try await Self.waitForCount(before + 1, in: events)
+                #expect(events.snapshot().last == "\(item.1)|\(item.2)|\(transportLabel)")
+                #expect(events.snapshot().count == before + 1)
+                if ingress == 1 {
+                    #expect(Array(order.snapshot().suffix(3)) == ["reply-pending", "reply", "callback"])
+                }
+            }
+        }
+
+        let countBeforeInvalid = events.snapshot().count
+        for payload: [String: Any] in [
+            [:],
+            ["type": "watch.unknown"],
+            ["type": OpenClawWatchPayloadType.reply.rawValue],
+        ] {
+            transport.session(WCSession.default, didReceiveMessage: payload)
+            transport.session(WCSession.default, didReceiveUserInfo: payload)
+            var reply: [String: Any]?
+            transport.session(
+                WCSession.default,
+                didReceiveMessage: payload,
+                replyHandler: { reply = $0 })
+            #expect(reply?.count == 2)
+            #expect(reply?["ok"] as? Bool == false)
+            #expect(reply?["error"] as? String == "unsupported_payload")
+        }
+        transport.session(WCSession.default, didReceiveMessage: cases[0].0)
+        try await Self.waitForCount(countBeforeInvalid + 1, in: events)
+        #expect(events.snapshot().count == countBeforeInvalid + 1)
+    }
+
+    private static func waitForCount(_ count: Int, in recorder: Recorder) async throws {
+        let deadline = ContinuousClock.now + .seconds(5)
+        while recorder.snapshot().count < count, ContinuousClock.now < deadline {
+            await Task.yield()
+        }
+        try #require(recorder.snapshot().count == count)
     }
 }


### PR DESCRIPTION
Watch input was represented three times: five codec results, five parallel transport callbacks repeated across three delegate methods, and another five-case startup union. The codec now returns one closed inbound event, which the transport carries through one locked callback and the service buffers and dispatches directly.

The five app-facing handlers, all leaf parsers and outgoing payloads remain unchanged. Reply acknowledgments still happen before callbacks; invalid input retains the same error envelope. Callback delivery remains weak and on the main actor. Registration still precedes activation, and startup retains its 64-entry drop-oldest FIFO. Approval ownership, identifiers, persistence and protocol behavior are unchanged.

**Production: +52 / −187, net −135 physical lines (−128 nonblank; −83 after excluding comments and punctuation-only lines). Tests: +135 / −1, net +134.** The added boundary matrix covers all five event families across the three actual `WCSessionDelegate` ingress methods, callback count, transport labels, invalid input and acknowledgment order.

Validation:

- An immutable simulator probe compiled the actual codec, transport, service, activation gate and identifier owners before and after the change. Both runs exercised 15 delegate events and the 64-entry startup flow, producing byte-identical results (`6b10881244aaae97b60d31f4d52b1e04c83044a0647c86f9fbc9a933bfd159d7`). This is local real-framework callback evidence, not a paired physical Watch test.
- The initial probe support declared its event DTOs `Sendable`. A separate follow-up copied the production declarations byte-for-byte, without added conformances, and verified inferred sendability and the callback crossing under Swift 6, complete strict concurrency and warnings-as-errors. That check passed.
- The added test source typechecked; canonical SwiftFormat and SwiftLint passed. The changed-file command completed its first ten checks, then stopped because SourceKit was unavailable under the default Command Line Tools developer directory. The same canonical Swift lint command passed with an explicit Xcode developer directory. The failed attempt is retained.
- Independent managed Codex P2/high review returned scoped-clean with no actionable findings.

Full-app limitation: the first focused test attempt stopped at a missing generated project. After generating it with the repository-pinned XcodeGen, the normal focused `xcodebuild test` stopped during dependency resolution: this branch's baseline pins WebRTC 151.0.0, whose binary release URL returns 404. It exited 74 before compilation, with **zero tests executed**. The available local toolchain was Xcode 27; the project documents Xcode 26. These attempts are not claimed as full-app proof. Main already fixes the dependency pin in [#134942](https://github.com/openclaw/openclaw/pull/134942); the PR's hosted iOS validation must be checked before landing. No dependency change is included here.

The three baseline owners also match stable `v2026.8.1`. Their contents are unchanged on current main before this refactor. The existing Swift 6.4 deprecation warning in `WatchSessionActivationGate.swift` remains a separate follow-up; it is unchanged by this patch.


## Landing validation

The latest ClawSweeper review has no actionable correctness or security finding. Its two before-merge items and rank-up move request successful exact-head native CI. [CI33515145330](https://github.com/openclaw/openclaw/actions/runs/33515145330) now completes successfully across all31 selected jobs, including the required gate, Debug/Release builds, focused iOS lifecycle and Apple Watch operation simulator tests, and iPhone/iPad/Watch screenshot evidence. Native validation uses Xcode26. The original failed local dependency-resolution attempt remains disclosed above; it executed zero tests and is not counted as proof.

Direct owner review confirms one closed event carries the five existing payload families from the codec through transport and the startup FIFO to the unchanged application handlers. Acknowledgment order, weak main-actor callbacks, exactly-once dispatch, activation ordering and the 64-entry drop-oldest bound are retained. The immutable real-framework baseline/final probe and separate strict-concurrency check of actual production declarations pass. The managed high/P2 review is clean. No paired physical Watch test is claimed.

Production delta remains **+52/-187 = -135 physical lines** (-128 nonblank; -83 excluding comments and punctuation); tests **+134**. The unchanged Swift6.4 deprecation warning in the activation gate remains a separate follow-up.
