### PR TITLE
refactor(agents): centralize compaction model-provider projection

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-runtime-preparation.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-preparation.ts
@@ -8,12 +8,8 @@ import { resolveAgentHarnessPolicy } from "../harness/policy.js";
 import {
   selectAgentHarness,
   selectAgentHarnessForPreparedModelProviders,
-  type AgentHarnessPreparedModelProvider,
 } from "../harness/selection.js";
-import {
-  resolveAgentHarnessPreparedAuthSupport,
-  resolveAgentHarnessPreparedRouteSupport,
-} from "../harness/support.js";
+import { projectPreparedModelProvider } from "../harness/support.js";
 import type { AgentHarness } from "../harness/types.js";
 import {
   ensureAuthProfileStore,
@@ -131,27 +127,6 @@ export function resolveCompactionRuntimeSelection(params: {
   };
 }
 
-function buildCompactionHarnessModelProvider(params: {
-  model?: ProviderRuntimeModel;
-  plan?: AgentRuntimeAuthPlan;
-  attempt?: PreparedAgentRuntimeAuthAttempt;
-}): AgentHarnessPreparedModelProvider {
-  const route = params.plan?.modelRoute;
-  return {
-    api: route?.api ?? params.model?.api,
-    baseUrl: route?.baseUrl ?? params.model?.baseUrl,
-    ...resolveAgentHarnessPreparedRouteSupport(params.plan),
-    ...(params.plan
-      ? {
-          preparedAuth: resolveAgentHarnessPreparedAuthSupport({
-            plan: params.plan,
-            source: params.attempt?.kind === "implicit" ? undefined : params.attempt?.kind,
-          }),
-        }
-      : {}),
-  };
-}
-
 /** Prepares one ordered auth-attempt set and converges it on a single compaction harness. */
 export async function prepareCompactionHarnessAuth(params: {
   config?: OpenClawConfig;
@@ -188,7 +163,11 @@ export async function prepareCompactionHarnessAuth(params: {
       provider: params.provider,
       modelId: params.modelId,
       modelProviders: attempts.map((attempt) =>
-        buildCompactionHarnessModelProvider({ model: params.model, plan: attempt.plan, attempt }),
+        projectPreparedModelProvider({
+          model: params.model,
+          plan: attempt.plan,
+          attemptKind: attempt.kind,
+        }),
       ),
       config: params.config,
       agentId: params.runtimePolicyAgentId,
@@ -201,7 +180,7 @@ export async function prepareCompactionHarnessAuth(params: {
     : selectAgentHarness({
         provider: params.provider,
         modelId: params.modelId,
-        modelProvider: buildCompactionHarnessModelProvider({ model: params.model }),
+        modelProvider: projectPreparedModelProvider({ model: params.model }),
         config: params.config,
         agentId: params.runtimePolicyAgentId,
         sessionKey: params.runtimePolicySessionKey ?? undefined,

--- a/src/agents/harness/compaction.ts
+++ b/src/agents/harness/compaction.ts
@@ -40,12 +40,8 @@ import {
   resolveAgentHarnessNativeToolPolicyRestricted,
   selectAgentHarness,
   selectAgentHarnessForPreparedModelProviders,
-  type AgentHarnessPreparedModelProvider,
 } from "./selection.js";
-import {
-  resolveAgentHarnessPreparedAuthSupport,
-  resolveAgentHarnessPreparedRouteSupport,
-} from "./support.js";
+import { projectPreparedModelProvider } from "./support.js";
 import type { AgentHarness, AgentHarnessNativeCompactionRequest } from "./types.js";
 
 /**
@@ -89,27 +85,6 @@ function stripHarnessOwnedAuthInputs(
   delete result.resolvedApiKey;
   delete result.runtimeModel;
   return result;
-}
-
-function buildHarnessCompactionModelProvider(params: {
-  model?: Model;
-  plan?: AgentRuntimeAuthPlan;
-  attempt?: PreparedAgentRuntimeAuthAttempt;
-}): AgentHarnessPreparedModelProvider {
-  const route = params.plan?.modelRoute;
-  return {
-    api: route?.api ?? params.model?.api,
-    baseUrl: route?.baseUrl ?? params.model?.baseUrl,
-    ...resolveAgentHarnessPreparedRouteSupport(params.plan),
-    ...(params.plan
-      ? {
-          preparedAuth: resolveAgentHarnessPreparedAuthSupport({
-            plan: params.plan,
-            source: params.attempt?.kind === "implicit" ? undefined : params.attempt?.kind,
-          }),
-        }
-      : {}),
-  };
 }
 
 async function resolveHarnessCompactApiKey(params: {
@@ -170,10 +145,10 @@ async function resolveHarnessCompactApiKey(params: {
       provider,
       modelId,
       modelProviders: attempts.map((attempt) =>
-        buildHarnessCompactionModelProvider({
+        projectPreparedModelProvider({
           model: preparedModel,
           plan: attempt.plan,
-          attempt,
+          attemptKind: attempt.kind,
         }),
       ),
       config: compactParams.config,
@@ -434,7 +409,7 @@ export async function maybeCompactAgentHarnessSession(
     ? selectAgentHarnessForPreparedModelProviders({
         ...harnessSelectionParams,
         modelProviders: [
-          buildHarnessCompactionModelProvider({
+          projectPreparedModelProvider({
             model: params.runtimeModel,
             plan: runtimeAuthPlan,
           }),

--- a/src/agents/harness/support.ts
+++ b/src/agents/harness/support.ts
@@ -16,6 +16,7 @@ import { resolveProviderModelRoutes } from "../../plugins/provider-model-routes.
 import { resolveSessionAgentIds } from "../agent-scope.js";
 import { hasAuthoredProviderRequestParams } from "../model-extra-params.js";
 import { canonicalizeProviderModelId } from "../provider-model-route.js";
+import type { PreparedAgentRuntimeAuthAttempt } from "../runtime-plan/prepare-auth.js";
 import type { AgentRuntimeAuthPlan } from "../runtime-plan/types.js";
 import { resolveAgentHarnessAutoSelectionHint } from "./auto-selection.js";
 import { listRegisteredAgentHarnesses } from "./registry.js";
@@ -69,6 +70,28 @@ export function resolveAgentHarnessPreparedRouteSupport(
         runtimePolicy: support.runtimePolicy,
       }
     : {};
+}
+
+/** Projects one prepared compaction attempt into secret-free harness support facts. */
+export function projectPreparedModelProvider(params: {
+  model?: Pick<NonNullable<AgentHarnessSupportContext["modelProvider"]>, "api" | "baseUrl">;
+  plan?: AgentRuntimeAuthPlan;
+  attemptKind?: PreparedAgentRuntimeAuthAttempt["kind"];
+}): NonNullable<AgentHarnessSupportContext["modelProvider"]> {
+  const route = params.plan?.modelRoute;
+  return {
+    api: route?.api ?? params.model?.api,
+    baseUrl: route?.baseUrl ?? params.model?.baseUrl,
+    ...resolveAgentHarnessPreparedRouteSupport(params.plan),
+    ...(params.plan
+      ? {
+          preparedAuth: resolveAgentHarnessPreparedAuthSupport({
+            plan: params.plan,
+            source: params.attemptKind === "implicit" ? undefined : params.attemptKind,
+          }),
+        }
+      : {}),
+  };
 }
 
 /** Builds the provider/model facts passed to registered harness support probes. */


### PR DESCRIPTION
## What Problem This Solves

Resolves duplicated ownership of the secret-free model-provider projection used by direct and queued compaction harness selection. The two copies were identical but could drift in route precedence, deferred route support, or prepared-auth source handling.

## Why This Change Was Made

The harness support owner now exposes one internal `projectPreparedModelProvider` projection. Both compaction paths call it directly, preserving route `api`/`baseUrl` precedence, concrete or deferred route support, and explicit profile/direct versus implicit auth-source semantics.

The run-specific builder in `src/agents/embedded-agent-runner/run/model-harness.ts` remains separate because request-scoped `requestStreamTransportOverrides` must override route-plan support there. No SDK/barrel, configuration, storage, dependency, generated, documentation, or changelog surface changed.

## User Impact

No intended user-visible behavior change. Compaction harness selection keeps the same route and auth facts while the projection has one architectural owner.

## Evidence

- Exact head: `429aaa8f45ddae89b8f633c63d07ab9feeb02faa`
- Parent: `4e34f4621d274085a050f5822cf01d9cf1b578be`
- Production LOC: `+34/-57` (net `-23`); tests: `+0/-0`
- Differential projection matrix: 84/84 route, model, and auth-attempt combinations equivalent
- `pnpm check:import-cycles`: 0 runtime value cycles
- `git diff --check`: passed
- Changed-file classification: `core`, `coreTests`; formatting and the initial changed-file gates passed
- `pnpm check:changed` reached the existing plugin-boundary compatibility ledger and stopped because five unrelated compatibility records are eligible for removal; this PR does not touch plugin boundaries
- Focused agent suites were attempted but no tests collected because the shared install is missing `@openclaw/fs-safe/dist/native`; no dependency install was run in the worktree
- Fresh Sol-high autoreview: scoped clean, correctness 0.99
- Test-audit: no new test added because existing boundary suites cover both callers and the intentionally distinct run-specific precedence; a helper-only test would couple coverage to source organization
- Required Codex source inspection completed at `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those CLI surfaces are unrelated to this projection

The previously linked Testbox run `33513026742` was cancelled and tested the parent SHA, so it is not evidence for this PR head.
