### PR TITLE
fix(backup): --no-include-workspace still archives nested workspace links

### DIFF
--- a/src/commands/backup-resource-inventory.ts
+++ b/src/commands/backup-resource-inventory.ts
@@ -101,6 +101,7 @@ export async function createBackupResourceInventory(params: {
   configPath: string;
   oauthDir: string;
   workspaceDirs: readonly string[];
+  excludedWorkspaceDirs?: readonly string[];
   agentRoots: readonly BackupAgentRoot[];
   pluginResources: readonly ResolvedPluginBackupResource[];
   pluginRoots: readonly string[];
@@ -180,10 +181,17 @@ export async function createBackupResourceInventory(params: {
       }),
   );
   const protectedPaths = Object.freeze([...protectedPathSet].toSorted());
+  // Excluded workspace trees stay out of the walk; nested agent roots stay
+  // protected and traversable. Do not weaken the archive symlink guard —
+  // that would hide unsafe links in included content.
+  const excludedWorkspacePaths = Object.freeze([
+    ...new Set((params.excludedWorkspaceDirs ?? []).map((dir) => path.resolve(dir))),
+  ]);
   const excludedPaths = Object.freeze(
-    uniqueRegenerableRoots
-      .map((resource) => resource.sourcePath)
-      .toSorted((left, right) => right.length - left.length || left.localeCompare(right)),
+    [
+      ...uniqueRegenerableRoots.map((resource) => resource.sourcePath),
+      ...excludedWorkspacePaths,
+    ].toSorted((left, right) => right.length - left.length || left.localeCompare(right)),
   );
 
   const isIncluded = (sourcePath: string): boolean => {

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -207,12 +207,15 @@ async function resolveBackupPlanFromPaths(params: {
     // Walker sees lexical state-tree names. A workspace-root symlink's
     // canonical target does not contain that entry; keep both so
     // --no-include-workspace still excludes it before the symlink guard.
+    // Drop any alias that is the state root or contains it — otherwise
+    // ordinary state/config/credential files disappear from the archive.
     excludedWorkspaceDirs: (
       await Promise.all(
-        excludedWorkspaceDirs.map(async (workspaceDir) => [
-          path.resolve(workspaceDir),
-          await canonicalizePathForContainment(workspaceDir),
-        ]),
+        excludedWorkspaceDirs.map(async (workspaceDir) =>
+          [path.resolve(workspaceDir), await canonicalizePathForContainment(workspaceDir)].filter(
+            (dir) => dir !== canonicalStateDir && !isPathWithin(canonicalStateDir, dir),
+          ),
+        ),
       )
     ).flat(),
     agentRoots,

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { listAgentIds, resolveAgentDir } from "../agents/agent-scope-config.js";
+import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace-default.js";
 import {
   readConfigFileSnapshot,
   resolveConfigPath,
@@ -189,7 +190,9 @@ async function resolveBackupPlanFromPaths(params: {
   const configPath = params.configPath;
   const oauthDir = params.oauthDir;
   const archiveRoot = buildBackupArchiveRoot(params.nowMs);
-  const workspaceDirs = includeWorkspace ? (params.workspaceDirs ?? []) : [];
+  const requestedWorkspaceDirs = params.workspaceDirs ?? [];
+  const workspaceDirs = includeWorkspace ? requestedWorkspaceDirs : [];
+  const excludedWorkspaceDirs = includeWorkspace ? [] : requestedWorkspaceDirs;
   const agentRoots = onlyConfig ? [] : (params.agentRoots ?? []);
   const configInsideState = params.configInsideState ?? false;
   const oauthInsideState = params.oauthInsideState ?? false;
@@ -200,6 +203,9 @@ async function resolveBackupPlanFromPaths(params: {
     oauthDir: await canonicalizePathForContainment(oauthDir),
     workspaceDirs: await Promise.all(
       workspaceDirs.map((workspaceDir) => canonicalizePathForContainment(workspaceDir)),
+    ),
+    excludedWorkspaceDirs: await Promise.all(
+      excludedWorkspaceDirs.map((workspaceDir) => canonicalizePathForContainment(workspaceDir)),
     ),
     agentRoots,
     pluginResources: params.pluginInventory?.resources ?? [],
@@ -555,14 +561,17 @@ export async function resolveBackupPlanFromDisk(
   const agentRoots = unresolvedOwnership
     ? []
     : await resolveBackupAgentRoots(discoverySnapshot.config);
-  const workspaceDirs = includeWorkspace ? cleanupPlan.workspaceDirs : [];
+  const discoveredWorkspaceDirs = cleanupPlan.workspaceDirs;
+  const workspaceDirs = includeWorkspace
+    ? discoveredWorkspaceDirs
+    : [...discoveredWorkspaceDirs, resolveDefaultAgentWorkspaceDir()];
   const pluginInventory = unresolvedOwnership
     ? undefined
     : resolveActivatedPluginBackupInventory({
         config: discoverySnapshot.config,
         env: process.env,
         stateDir,
-        workspaceDirs,
+        workspaceDirs: includeWorkspace ? discoveredWorkspaceDirs : [],
       });
   return await resolveBackupPlanFromPaths({
     stateDir,

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -204,9 +204,17 @@ async function resolveBackupPlanFromPaths(params: {
     workspaceDirs: await Promise.all(
       workspaceDirs.map((workspaceDir) => canonicalizePathForContainment(workspaceDir)),
     ),
-    excludedWorkspaceDirs: await Promise.all(
-      excludedWorkspaceDirs.map((workspaceDir) => canonicalizePathForContainment(workspaceDir)),
-    ),
+    // Walker sees lexical state-tree names. A workspace-root symlink's
+    // canonical target does not contain that entry; keep both so
+    // --no-include-workspace still excludes it before the symlink guard.
+    excludedWorkspaceDirs: (
+      await Promise.all(
+        excludedWorkspaceDirs.map(async (workspaceDir) => [
+          path.resolve(workspaceDir),
+          await canonicalizePathForContainment(workspaceDir),
+        ]),
+      )
+    ).flat(),
     agentRoots,
     pluginResources: params.pluginInventory?.resources ?? [],
     pluginRoots: params.pluginInventory?.pluginRoots ?? [],

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -2,7 +2,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { listAgentIds, resolveAgentDir } from "../agents/agent-scope-config.js";
-import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace-default.js";
 import {
   readConfigFileSnapshot,
   resolveConfigPath,
@@ -573,9 +572,6 @@ export async function resolveBackupPlanFromDisk(
     ? []
     : await resolveBackupAgentRoots(discoverySnapshot.config);
   const discoveredWorkspaceDirs = cleanupPlan.workspaceDirs;
-  const workspaceDirs = includeWorkspace
-    ? discoveredWorkspaceDirs
-    : [...discoveredWorkspaceDirs, resolveDefaultAgentWorkspaceDir()];
   const pluginInventory = unresolvedOwnership
     ? undefined
     : resolveActivatedPluginBackupInventory({
@@ -588,7 +584,7 @@ export async function resolveBackupPlanFromDisk(
     stateDir,
     configPath,
     oauthDir,
-    workspaceDirs,
+    workspaceDirs: discoveredWorkspaceDirs,
     agentRoots,
     pluginInventory,
     unresolvedOwnership,

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -865,6 +865,43 @@ describe("createBackupArchive", () => {
     );
   });
 
+  it("omits an absolute workspace-root symlink under the state directory", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-workspace-root-symlink-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const realWorkspace = state.path("real-workspace");
+        const lexicalWorkspace = state.statePath("workspace");
+        await fs.mkdir(realWorkspace, { recursive: true });
+        await fs.writeFile(path.join(realWorkspace, "notes.md"), "workspace notes\n", "utf8");
+        await fs.symlink(realWorkspace, lexicalWorkspace, "dir");
+        await state.writeConfig({
+          agents: {
+            defaults: { workspace: lexicalWorkspace },
+          },
+        });
+
+        const archive = await createBackupArchive({
+          output: state.path("backup.tar.gz"),
+          includeWorkspace: false,
+          nowMs: Date.UTC(2026, 8, 1, 12, 0, 0),
+        });
+        const entries = await listArchiveEntries(archive.archivePath);
+
+        expect(archive.assets.map((asset) => asset.kind)).not.toContain("workspace");
+        expect(entries.some((entry) => entry.includes("/workspace"))).toBe(false);
+        expect(entries.some((entry) => entry.endsWith("/notes.md"))).toBe(false);
+      },
+    );
+  });
+
   it("includes a configured external agent directory when workspaces are excluded", async () => {
     await withOpenClawTestState(
       {

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -916,7 +916,11 @@ describe("createBackupArchive", () => {
         },
         async (state) => {
           const sentinel = state.statePath("sentinel-state.json");
+          const nestedStateDir = state.statePath("workspace");
+          const nestedState = path.join(nestedStateDir, "durable-state.json");
+          await fs.mkdir(nestedStateDir, { recursive: true });
           await fs.writeFile(sentinel, '{"ok":true}\n', "utf8");
+          await fs.writeFile(nestedState, '{"nested":true}\n', "utf8");
           await state.writeConfig({
             agents: {
               defaults: { workspace: resolveWorkspace(state) },
@@ -932,6 +936,9 @@ describe("createBackupArchive", () => {
 
           expect(archive.assets.map((asset) => asset.kind)).not.toContain("workspace");
           expect(entries.some((entry) => entry.endsWith("/sentinel-state.json"))).toBe(true);
+          expect(entries.some((entry) => entry.endsWith("/workspace/durable-state.json"))).toBe(
+            true,
+          );
         },
       );
     },

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -820,6 +820,51 @@ describe("createBackupArchive", () => {
     },
   );
 
+  it("omits a nested workspace absolute symlink without dropping a nested agent root", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-nested-workspace-symlink-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const nestedWorkspace = state.statePath("workspace");
+        const agentDir = path.join(nestedWorkspace, "custom-agent");
+        const outsideTarget = state.path("outside-build");
+        await fs.mkdir(nestedWorkspace, { recursive: true });
+        await fs.mkdir(agentDir, { recursive: true });
+        await fs.mkdir(outsideTarget, { recursive: true });
+        await fs.writeFile(path.join(nestedWorkspace, "notes.md"), "workspace notes\n", "utf8");
+        await fs.writeFile(path.join(agentDir, "durable-agent-state.json"), "{}\n", "utf8");
+        await fs.symlink(outsideTarget, path.join(nestedWorkspace, ".build"), "dir");
+        await state.writeConfig({
+          agents: {
+            defaults: { workspace: nestedWorkspace },
+            entries: { main: { default: true, agentDir } },
+          },
+        });
+
+        const archive = await createBackupArchive({
+          output: state.path("backup.tar.gz"),
+          includeWorkspace: false,
+          nowMs: Date.UTC(2026, 8, 1, 12, 0, 0),
+        });
+        const entries = await listArchiveEntries(archive.archivePath);
+
+        expect(archive.assets.map((asset) => asset.kind)).not.toContain("workspace");
+        expect(entries.some((entry) => entry.includes("/workspace/.build"))).toBe(false);
+        expect(entries.some((entry) => entry.endsWith("/workspace/notes.md"))).toBe(false);
+        expect(
+          entries.some((entry) => entry.endsWith("/custom-agent/durable-agent-state.json")),
+        ).toBe(true);
+      },
+    );
+  });
+
   it("includes a configured external agent directory when workspaces are excluded", async () => {
     await withOpenClawTestState(
       {

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -902,6 +902,41 @@ describe("createBackupArchive", () => {
     );
   });
 
+  it.each([
+    ["the state directory", (state: OpenClawTestState) => state.stateDir],
+    ["a parent of the state directory", (state: OpenClawTestState) => path.dirname(state.stateDir)],
+  ] as const)(
+    "keeps ordinary state files when the excluded workspace is %s",
+    async (_label, resolveWorkspace) => {
+      await withOpenClawTestState(
+        {
+          layout: "state-only",
+          prefix: "openclaw-backup-workspace-contains-state-",
+          scenario: "minimal",
+        },
+        async (state) => {
+          const sentinel = state.statePath("sentinel-state.json");
+          await fs.writeFile(sentinel, '{"ok":true}\n', "utf8");
+          await state.writeConfig({
+            agents: {
+              defaults: { workspace: resolveWorkspace(state) },
+            },
+          });
+
+          const archive = await createBackupArchive({
+            output: state.path("backup.tar.gz"),
+            includeWorkspace: false,
+            nowMs: Date.UTC(2026, 8, 1, 12, 0, 0),
+          });
+          const entries = await listArchiveEntries(archive.archivePath);
+
+          expect(archive.assets.map((asset) => asset.kind)).not.toContain("workspace");
+          expect(entries.some((entry) => entry.endsWith("/sentinel-state.json"))).toBe(true);
+        },
+      );
+    },
+  );
+
   it("includes a configured external agent directory when workspaces are excluded", async () => {
     await withOpenClawTestState(
       {


### PR DESCRIPTION
Closes #135218

## What Problem This Solves

Fixes an issue where users running `openclaw backup create --no-include-workspace` would get no verified archive when the default workspace lived under the state directory and was itself an absolute symlink, or contained one (for example a build cache). The command aborted with `Archive symbolic link target must be relative` even though workspace content was supposed to be omitted.

## Why This Change Was Made

`--no-include-workspace` now keeps those workspace roots as inventory exclusions instead of leaving the default `stateDir/workspace` reachable through the state asset. Each excluded workspace contributes both its lexical pathname (`path.resolve`) and its canonical target, so a workspace-root symlink under the state tree is omitted before the archive walker reaches it. A workspace that is the state directory, or a parent of it, is not excluded, so ordinary state, config, and credential files stay in the archive, including files under `stateDir/workspace` when that directory is not the configured workspace. Disabled-workspace exclusions come only from the cleanup plan; that resolver already supplies the default when configuration cannot resolve one. Configured agent directories nested inside an excluded workspace stay included. The archive symlink guard is unchanged, so absolute links in content that is still being backed up still fail closed.

Non-goal: this does not relax symlink policy for included trees, and it does not change Chromium/sandbox or Codex scratch handling (#124769, #134508).

## User Impact

State and config backups with `--no-include-workspace` succeed when the omitted workspace is a state-tree symlink to an external directory, or when it contains ordinary files or absolute symlinks. If the configured workspace is the state directory or an ancestor of it, the state payload — including `stateDir/workspace` when that path is not the configured workspace — is still archived. Nested configured agent directories are still archived. Included workspace or state content with an absolute symlink still rejects the archive.

## Evidence

Pre-fix (workspace-root absolute symlink under the state directory):

```
Backup archive write failed: Archive symbolic link target must be relative
```

Pre-fix (workspace configured as a parent of the state directory, durable file under `stateDir/workspace`):

```
# archive verified, but workspace/durable-state.json was omitted
```

Post-fix tests:

```
node scripts/run-vitest.mjs src/infra/backup-create.test.ts -t "omits an absolute workspace-root symlink"
# pass; failed pre-fix with the symlink-guard error above

node scripts/run-vitest.mjs src/infra/backup-create.test.ts -t "keeps ordinary state files"
# pass (state directory and parent); both failed pre-fix because workspace/durable-state.json was omitted

node scripts/run-vitest.mjs src/infra/backup-create.test.ts -t "omits a nested workspace absolute symlink"
# pass

node scripts/run-vitest.mjs src/infra/backup-create.test.ts -t "rejects an absolute symlink"
# pass — included content still fail-closed

node scripts/run-vitest.mjs src/commands/backup.test.ts
# 18 passed
```

Exact-head real create+verify (2026-09-02, owner head `75a27f04d93`; current tip `98c8cb67f88` is an empty CI retrigger): isolated `OPENCLAW_STATE_DIR` with `agents.defaults.workspace` set to the parent of the state directory, plus `sentinel-state.json` and `workspace/durable-state.json` under state. The checkout `openclaw.mjs` launcher cannot stamp `dist` here (broken local `pnpm` wrapper). The run used the production `backupCreateCommand` owner that `openclaw backup create --no-include-workspace --verify` calls:

```json
{
  "ok": true,
  "includeWorkspace": false,
  "verified": true,
  "hasWorkspaceAsset": false,
  "hasSentinel": true,
  "hasNestedState": true
}
```

Prior workspace-root symlink proof on `d77202296d04` remains valid (`verified: true`, lexical `workspace` and notes omitted). Prior nested-workspace proof on `af594d838d52` remains valid for the reported `.build` + nested-agent case.

`oxfmt` + `node scripts/run-oxlint.mjs` on the touched files: pass. Autoreview was not available on this machine (`codex` missing). Production delta is the planner/inventory exclusion only, now net-negative after removing the unconfigured default fallback.


CI on `75a27f04d93` failed two compact shards unrelated to backup exclusion: `checks-node-compact-small-3` timed out in `doctor-session-sqlite.memory.test.ts` (180s), and `checks-node-compact-large-30` failed a Control UI sidebar marquee assertion. Empty commit `98c8cb67f88` retriggers those jobs only. Exclusion geometry is unchanged.

