### PR TITLE
fix(plugins): preserve bundle capabilities in CLI inventory

### DIFF
--- a/src/cli/plugins-list-command.ts
+++ b/src/cli/plugins-list-command.ts
@@ -169,7 +169,7 @@ export async function runPluginsListCommand(
 
   const lines: string[] = [];
   for (const plugin of list) {
-    lines.push(formatPluginLine(plugin, true));
+    lines.push(formatPluginLine(plugin));
     lines.push("");
   }
   runtime.log(lines.join("\n").trim());

--- a/src/cli/plugins-list-format.test.ts
+++ b/src/cli/plugins-list-format.test.ts
@@ -1,4 +1,4 @@
-// Plugin list format tests cover installed plugin table and JSON formatting.
+// Plugin list format tests cover verbose installed plugin details.
 import { describe, expect, it } from "vitest";
 import { createPluginRecord } from "../plugins/status.test-fixtures.js";
 import { formatPluginLine } from "./plugins-list-format.js";
@@ -9,6 +9,7 @@ describe("formatPluginLine", () => {
 
     expect(output).toContain("enabled");
     expect(output).not.toContain("loaded");
+    expect(output).not.toContain("bundle capabilities:");
   });
 
   it("shows imported state in verbose output", () => {
@@ -20,7 +21,6 @@ describe("formatPluginLine", () => {
         activated: true,
         explicitlyEnabled: false,
       }),
-      true,
     );
 
     expect(output).toContain("activated: yes");
@@ -28,17 +28,18 @@ describe("formatPluginLine", () => {
     expect(output).toContain("explicitly enabled: no");
   });
 
-  it("labels portable bundle records as Agent Plugins", () => {
+  it("shows bundle subtype and detected capabilities", () => {
     const output = formatPluginLine(
       createPluginRecord({
         id: "portable",
         format: "bundle",
         bundleFormat: "agent",
+        bundleCapabilities: ["skills", "mcpServers"],
       }),
-      true,
     );
 
     expect(output).toContain("bundle format: agent (Agent Plugins)");
+    expect(output).toContain("bundle capabilities: skills, mcpServers");
   });
 
   it("sanitizes activation reasons in verbose output", () => {
@@ -50,18 +51,10 @@ describe("formatPluginLine", () => {
         activationSource: "auto",
         activationReason: "\u001B[31mconfigured\nnext\tstep",
       }),
-      true,
     );
 
     expect(output).toContain("activation reason: configured\\nnext\\tstep");
     expect(output).not.toContain("\u001B[31m");
     expect(output.match(/activation reason:/g)).toHaveLength(1);
-  });
-
-  it("keeps truncated descriptions free of lone surrogates", () => {
-    const output = formatPluginLine(
-      createPluginRecord({ id: "demo", description: `${"a".repeat(56)}😀tail` }),
-    );
-    expect(Buffer.from(output).toString()).toBe(output);
   });
 });

--- a/src/cli/plugins-list-format.ts
+++ b/src/cli/plugins-list-format.ts
@@ -1,5 +1,4 @@
 // Text formatter for plugin list rows and verbose plugin details.
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import type { PluginBundleFormat } from "../plugins/manifest-types.js";
@@ -10,7 +9,7 @@ export function formatPluginBundleFormat(bundleFormat: PluginBundleFormat): stri
   return bundleFormat === "agent" ? "agent (Agent Plugins)" : bundleFormat;
 }
 
-export function formatPluginLine(plugin: PluginRecord, verbose = false): string {
+export function formatPluginLine(plugin: PluginRecord): string {
   const status =
     plugin.status === "error"
       ? theme.error("error")
@@ -19,18 +18,7 @@ export function formatPluginLine(plugin: PluginRecord, verbose = false): string 
         : theme.warn("disabled");
   const name = theme.command(plugin.name || plugin.id);
   const idSuffix = plugin.name && plugin.name !== plugin.id ? theme.muted(` (${plugin.id})`) : "";
-  const desc = plugin.description
-    ? theme.muted(
-        plugin.description.length > 60
-          ? `${truncateUtf16Safe(plugin.description, 57)}...`
-          : plugin.description,
-      )
-    : theme.muted("(no description)");
   const format = plugin.format ?? "openclaw";
-
-  if (!verbose) {
-    return `${name}${idSuffix} ${status} ${theme.muted(`[${format}]`)} - ${desc}`;
-  }
 
   const parts = [
     `${name}${idSuffix} ${status}`,
@@ -40,6 +28,9 @@ export function formatPluginLine(plugin: PluginRecord, verbose = false): string 
   ];
   if (plugin.bundleFormat) {
     parts.push(`  bundle format: ${formatPluginBundleFormat(plugin.bundleFormat)}`);
+  }
+  if (plugin.bundleCapabilities?.length) {
+    parts.push(`  bundle capabilities: ${plugin.bundleCapabilities.join(", ")}`);
   }
   if (plugin.version) {
     parts.push(`  version: ${plugin.version}`);

--- a/src/plugins/status-snapshot.ts
+++ b/src/plugins/status-snapshot.ts
@@ -124,6 +124,7 @@ function buildPluginRecordFromInstalledIndex(
     ...(manifest?.description ? { description: manifest.description } : {}),
     format,
     ...(bundleFormat ? { bundleFormat } : {}),
+    bundleCapabilities: manifest?.bundleCapabilities,
     ...(manifest?.kind ? { kind: manifest.kind } : {}),
     source: plugin.source ?? plugin.manifestPath,
     rootDir: plugin.rootDir,

--- a/src/plugins/status.registry-snapshot.bundles.test.ts
+++ b/src/plugins/status.registry-snapshot.bundles.test.ts
@@ -1,0 +1,79 @@
+// Covers detected bundle capabilities in derived and persisted plugin inventory.
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import { refreshPluginRegistry } from "./plugin-registry-refresh.js";
+import { buildPluginRegistrySnapshotReport } from "./status.js";
+import { createColdPluginHermeticEnv } from "./test-helpers/cold-plugin-fixtures.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+import { createBundleInstallFixtureFactory } from "./test-helpers/install-fixtures.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir() {
+  return makeTrackedTempDir("openclaw-plugin-status", tempDirs);
+}
+
+const setupBundleInstallFixture = createBundleInstallFixtureFactory(makeTempDir);
+
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  cleanupTrackedTempDirs(tempDirs);
+});
+
+describe("buildPluginRegistrySnapshotReport", () => {
+  it.each([
+    {
+      bundleFormat: "agent",
+      enabled: true,
+      registrySource: "derived",
+      capabilities: ["skills"],
+    },
+    {
+      bundleFormat: "claude",
+      enabled: false,
+      registrySource: "persisted",
+      capabilities: ["skills"],
+    },
+    {
+      bundleFormat: "cursor",
+      enabled: true,
+      registrySource: "persisted",
+      capabilities: ["skills", "commands"],
+    },
+  ] as const)(
+    "preserves $bundleFormat bundle capabilities in $registrySource inventory (enabled=$enabled)",
+    async ({ bundleFormat, enabled, registrySource, capabilities }) => {
+      const name = `${bundleFormat}-capability-fixture`;
+      const { pluginDir, extensionsDir } = setupBundleInstallFixture({ bundleFormat, name });
+      const stateDir = path.dirname(extensionsDir);
+      const workspaceDir = path.dirname(stateDir);
+      const params = {
+        config: {
+          plugins: {
+            load: { paths: [pluginDir] },
+            entries: { [name]: { enabled } },
+          },
+        },
+        workspaceDir,
+        env: {
+          ...createColdPluginHermeticEnv(workspaceDir, { bundledPluginsDir: makeTempDir() }),
+          OPENCLAW_STATE_DIR: stateDir,
+        },
+      };
+      if (registrySource === "persisted") {
+        await refreshPluginRegistry({ ...params, stateDir, reason: "manual" });
+      }
+
+      const report = buildPluginRegistrySnapshotReport(params);
+
+      expect(report.plugins.find((plugin) => plugin.id === name)).toMatchObject({
+        format: "bundle",
+        bundleFormat,
+        bundleCapabilities: capabilities,
+        enabled,
+      });
+      expect(report.registrySource).toBe(registrySource);
+    },
+  );
+});

--- a/src/plugins/status.registry-snapshot.test.ts
+++ b/src/plugins/status.registry-snapshot.test.ts
@@ -26,6 +26,7 @@ import {
   isColdPluginRuntimeLoaded,
 } from "./test-helpers/cold-plugin-fixtures.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+import { createBundleInstallFixtureFactory } from "./test-helpers/install-fixtures.js";
 import { writeManagedNpmPlugin } from "./test-helpers/managed-npm-plugin.js";
 
 const tempDirs: string[] = [];
@@ -33,6 +34,8 @@ const tempDirs: string[] = [];
 function makeTempDir() {
   return makeTrackedTempDir("openclaw-plugin-status", tempDirs);
 }
+
+const setupBundleInstallFixture = createBundleInstallFixtureFactory(makeTempDir);
 
 function createWorkspacePluginFixture(workspaceDir: string, pluginId: string) {
   const rootDir = path.join(workspaceDir, ".openclaw", "extensions", pluginId);
@@ -96,6 +99,61 @@ function expectFields(actual: Record<string, unknown>, expected: Record<string, 
 }
 
 describe("buildPluginRegistrySnapshotReport", () => {
+  it.each([
+    {
+      bundleFormat: "agent",
+      enabled: true,
+      registrySource: "derived",
+      capabilities: ["skills"],
+    },
+    {
+      bundleFormat: "claude",
+      enabled: false,
+      registrySource: "persisted",
+      capabilities: ["skills"],
+    },
+    {
+      bundleFormat: "cursor",
+      enabled: true,
+      registrySource: "persisted",
+      capabilities: ["skills", "commands"],
+    },
+  ] as const)(
+    "preserves $bundleFormat bundle capabilities in $registrySource inventory (enabled=$enabled)",
+    async ({ bundleFormat, enabled, registrySource, capabilities }) => {
+      const name = `${bundleFormat}-capability-fixture`;
+      const { pluginDir, extensionsDir } = setupBundleInstallFixture({ bundleFormat, name });
+      const stateDir = path.dirname(extensionsDir);
+      const workspaceDir = path.dirname(stateDir);
+      const params = {
+        config: {
+          plugins: {
+            load: { paths: [pluginDir] },
+            entries: { [name]: { enabled } },
+          },
+        },
+        workspaceDir,
+        env: {
+          ...createColdPluginHermeticEnv(workspaceDir, { bundledPluginsDir: makeTempDir() }),
+          OPENCLAW_STATE_DIR: stateDir,
+        },
+      };
+      if (registrySource === "persisted") {
+        await refreshPluginRegistry({ ...params, stateDir, reason: "manual" });
+      }
+
+      const report = buildPluginRegistrySnapshotReport(params);
+
+      expectFields(requirePlugin(report.plugins, name), {
+        format: "bundle",
+        bundleFormat,
+        bundleCapabilities: capabilities,
+        enabled,
+      });
+      expect(report.registrySource).toBe(registrySource);
+    },
+  );
+
   it("uses the configured system owner for ambient plugin inventory", () => {
     const tempRoot = makeTempDir();
     const mainWorkspace = path.join(tempRoot, "main-workspace");

--- a/src/plugins/status.registry-snapshot.test.ts
+++ b/src/plugins/status.registry-snapshot.test.ts
@@ -26,7 +26,6 @@ import {
   isColdPluginRuntimeLoaded,
 } from "./test-helpers/cold-plugin-fixtures.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
-import { createBundleInstallFixtureFactory } from "./test-helpers/install-fixtures.js";
 import { writeManagedNpmPlugin } from "./test-helpers/managed-npm-plugin.js";
 
 const tempDirs: string[] = [];
@@ -34,8 +33,6 @@ const tempDirs: string[] = [];
 function makeTempDir() {
   return makeTrackedTempDir("openclaw-plugin-status", tempDirs);
 }
-
-const setupBundleInstallFixture = createBundleInstallFixtureFactory(makeTempDir);
 
 function createWorkspacePluginFixture(workspaceDir: string, pluginId: string) {
   const rootDir = path.join(workspaceDir, ".openclaw", "extensions", pluginId);
@@ -99,61 +96,6 @@ function expectFields(actual: Record<string, unknown>, expected: Record<string, 
 }
 
 describe("buildPluginRegistrySnapshotReport", () => {
-  it.each([
-    {
-      bundleFormat: "agent",
-      enabled: true,
-      registrySource: "derived",
-      capabilities: ["skills"],
-    },
-    {
-      bundleFormat: "claude",
-      enabled: false,
-      registrySource: "persisted",
-      capabilities: ["skills"],
-    },
-    {
-      bundleFormat: "cursor",
-      enabled: true,
-      registrySource: "persisted",
-      capabilities: ["skills", "commands"],
-    },
-  ] as const)(
-    "preserves $bundleFormat bundle capabilities in $registrySource inventory (enabled=$enabled)",
-    async ({ bundleFormat, enabled, registrySource, capabilities }) => {
-      const name = `${bundleFormat}-capability-fixture`;
-      const { pluginDir, extensionsDir } = setupBundleInstallFixture({ bundleFormat, name });
-      const stateDir = path.dirname(extensionsDir);
-      const workspaceDir = path.dirname(stateDir);
-      const params = {
-        config: {
-          plugins: {
-            load: { paths: [pluginDir] },
-            entries: { [name]: { enabled } },
-          },
-        },
-        workspaceDir,
-        env: {
-          ...createColdPluginHermeticEnv(workspaceDir, { bundledPluginsDir: makeTempDir() }),
-          OPENCLAW_STATE_DIR: stateDir,
-        },
-      };
-      if (registrySource === "persisted") {
-        await refreshPluginRegistry({ ...params, stateDir, reason: "manual" });
-      }
-
-      const report = buildPluginRegistrySnapshotReport(params);
-
-      expectFields(requirePlugin(report.plugins, name), {
-        format: "bundle",
-        bundleFormat,
-        bundleCapabilities: capabilities,
-        enabled,
-      });
-      expect(report.registrySource).toBe(registrySource);
-    },
-  );
-
   it("uses the configured system owner for ambient plugin inventory", () => {
     const tempRoot = makeTempDir();
     const mainWorkspace = path.join(tempRoot, "main-workspace");


### PR DESCRIPTION
## What Problem This Solves

Fixes compatible bundle capabilities disappearing from cold plugin inventory and verbose CLI output. A discovered Cursor bundle containing skills and commands appears enabled in `plugins list`, but its JSON record omits those detected capabilities and `--verbose` never displays them.

## Why This Change Was Made

The installed-index projection now carries the manifest's existing capability field into its plugin record, matching the loaded-runtime path. The verbose formatter displays that field. All production callers already use the verbose formatter; removing its unused compact branch and boolean argument keeps one formatting path.

Production **+6/−14 (net −8)**; tests **+84/−12 (net +72)**. There is no new configuration, dependency, persistence format, activation, or execution behavior. Existing documentation already promises bundle capability output.

## User Impact

Operators can see what an installed compatible bundle contains in both JSON and verbose inventory, including disabled bundles and inventory rebuilt from manifests. Ordinary table output and other plugin metadata remain unchanged.

Related: #119132 contains earlier capability-projection work by @ssaade01, submitted by @tayoun. This focused repair credits that contribution and completes the existing inventory/verbose contract without adopting the larger agent-template inspection feature. It does not supersede or close that PR.

## Evidence

Three maintained inventory regressions failed before the repair and pass afterward: derived Agent Plugins inventory, persisted disabled Claude inventory, and persisted enabled Cursor inventory. The formatter capability assertion also failed before and now passes. All **34 inventory tests and four formatter tests pass**, along with scoped formatting and a normal build.

The real public `plugins list --json` and `plugins list --verbose` commands were run before and after against the same literal Cursor fixture, configuration, and naturally created state. JSON adds only `bundleCapabilities: ["skills", "commands"]`; every other field across all 152 records is unchanged. The entire verbose output differs by exactly one added line: `bundle capabilities: skills, commands`. Both stderr streams are empty, and the fixture, config, and retained database bytes are unchanged.

Normal metadata snapshots freeze their capability arrays, existing loaded reports already share that canonical reference, and the checked consumers read or copy it. No speculative clone or new immutable API is added. Independent Codex review is clean. Required exact-head CI remains the landing gate.

CI exposed the snapshot test file's 1,000-line limit after the three bundle cases were added. Those cases now live in a dedicated companion file, and the original 31-case snapshot file is restored byte-for-byte. All 38 cases pass again, along with type-aware lint across all six changed paths and formatting. This correction changes no production code and preserves the assertions and lint limits. Independent Codex review of the split is clean.

Current-base verification closes the latest ClawSweeper partial-clone gap: all six relevant baseline paths, including the restored inventory test and absent companion file, are unchanged between `c884a081dd64048e033274371c72d5cfe5644849` and freshly fetched main `2cedaddb5e23848d4358faddcd609afb6570fa94`. All five changed head files match the reviewed, tested checkout. Required CI is green on `d58ff0a4aad713e66581c32eacbeed6e431b4ab4`; the completed ClawSweeper review on that head has no actionable source finding.
