### PR TITLE
fix(release): publish frozen 2026.8.2 with approved Codex pin

### DIFF
--- a/.github/workflows/plugin-clawhub-new.yml
+++ b/.github/workflows/plugin-clawhub-new.yml
@@ -196,6 +196,14 @@ jobs:
           git checkout --detach "${TARGET_REF}"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout trusted planning tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+          path: .release-tooling
+          fetch-depth: 1
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
@@ -205,6 +213,7 @@ jobs:
 
       - name: Validate publishable plugin metadata
         env:
+          TSX_TSCONFIG_PATH: ${{ github.workspace }}/.release-tooling/tsconfig.json
           RELEASE_PLUGINS: ${{ inputs.plugins }}
         run: |
           set -euo pipefail
@@ -212,17 +221,18 @@ jobs:
             echo "Plugin ClawHub bootstrap requires at least one package name in plugins." >&2
             exit 1
           fi
-          pnpm release:plugins:clawhub:check -- --selection-mode selected --plugins "${RELEASE_PLUGINS}"
+          node --import tsx .release-tooling/scripts/plugin-clawhub-release-check.ts --selection-mode selected --plugins "${RELEASE_PLUGINS}"
 
       - name: Resolve plugin bootstrap plan
         id: plan
         env:
+          TSX_TSCONFIG_PATH: ${{ github.workspace }}/.release-tooling/tsconfig.json
           RELEASE_PLUGINS: ${{ inputs.plugins }}
           CLAWHUB_REGISTRY: ${{ env.CLAWHUB_REGISTRY }}
         run: |
           set -euo pipefail
           mkdir -p .local
-          node --import tsx scripts/plugin-clawhub-release-plan.ts \
+          node --import tsx .release-tooling/scripts/plugin-clawhub-release-plan.ts \
             --selection-mode selected \
             --plugins "${RELEASE_PLUGINS}" > .local/plugin-clawhub-release-plan.json
 

--- a/.github/workflows/plugin-clawhub-release.yml
+++ b/.github/workflows/plugin-clawhub-release.yml
@@ -276,6 +276,14 @@ jobs:
           raise SystemExit(1)
           PYTHON
 
+      - name: Checkout trusted planning tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+          path: .release-tooling
+          fetch-depth: 1
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
@@ -285,6 +293,7 @@ jobs:
 
       - name: Validate publishable plugin metadata
         env:
+          TSX_TSCONFIG_PATH: ${{ github.workspace }}/.release-tooling/tsconfig.json
           PUBLISH_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_scope || '' }}
           RELEASE_PLUGINS: ${{ github.event_name == 'workflow_dispatch' && inputs.plugins || '' }}
           BASE_REF: ${{ github.event_name != 'workflow_dispatch' && github.event.before || '' }}
@@ -296,16 +305,17 @@ jobs:
             if [[ -n "${RELEASE_PLUGINS}" ]]; then
               release_args+=(--plugins "${RELEASE_PLUGINS}")
             fi
-            pnpm release:plugins:clawhub:check -- "${release_args[@]}"
+            node --import tsx .release-tooling/scripts/plugin-clawhub-release-check.ts "${release_args[@]}"
           elif [[ -n "${BASE_REF}" ]]; then
-            pnpm release:plugins:clawhub:check -- --base-ref "${BASE_REF}" --head-ref "${HEAD_REF}"
+            node --import tsx .release-tooling/scripts/plugin-clawhub-release-check.ts --base-ref "${BASE_REF}" --head-ref "${HEAD_REF}"
           else
-            pnpm release:plugins:clawhub:check
+            node --import tsx .release-tooling/scripts/plugin-clawhub-release-check.ts
           fi
 
       - name: Resolve plugin release plan
         id: plan
         env:
+          TSX_TSCONFIG_PATH: ${{ github.workspace }}/.release-tooling/tsconfig.json
           PUBLISH_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_scope || '' }}
           RELEASE_PLUGINS: ${{ github.event_name == 'workflow_dispatch' && inputs.plugins || '' }}
           BASE_REF: ${{ github.event_name != 'workflow_dispatch' && github.event.before || '' }}
@@ -319,11 +329,11 @@ jobs:
             if [[ -n "${RELEASE_PLUGINS}" ]]; then
               plan_args+=(--plugins "${RELEASE_PLUGINS}")
             fi
-            node --import tsx scripts/plugin-clawhub-release-plan.ts "${plan_args[@]}" > .local/plugin-clawhub-release-plan.json
+            node --import tsx .release-tooling/scripts/plugin-clawhub-release-plan.ts "${plan_args[@]}" > .local/plugin-clawhub-release-plan.json
           elif [[ -n "${BASE_REF}" ]]; then
-            node --import tsx scripts/plugin-clawhub-release-plan.ts --base-ref "${BASE_REF}" --head-ref "${HEAD_REF}" > .local/plugin-clawhub-release-plan.json
+            node --import tsx .release-tooling/scripts/plugin-clawhub-release-plan.ts --base-ref "${BASE_REF}" --head-ref "${HEAD_REF}" > .local/plugin-clawhub-release-plan.json
           else
-            node --import tsx scripts/plugin-clawhub-release-plan.ts > .local/plugin-clawhub-release-plan.json
+            node --import tsx .release-tooling/scripts/plugin-clawhub-release-plan.ts > .local/plugin-clawhub-release-plan.json
           fi
 
           cat .local/plugin-clawhub-release-plan.json

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -123,18 +123,13 @@ jobs:
           fetch-depth: 0
           filter: blob:none
 
-      - name: Checkout trusted preflight tooling
-        if: github.event_name == 'workflow_dispatch' && inputs.preflight_only
+      - name: Checkout trusted planning tooling
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           ref: ${{ github.workflow_sha }}
           path: .release-tooling
           fetch-depth: 1
-          sparse-checkout: |
-            scripts/lib/record-shared.mjs
-            scripts/release-tooling-identity.mjs
-          sparse-checkout-cone-mode: false
 
       - name: Resolve checked-out ref
         id: ref
@@ -329,6 +324,7 @@ jobs:
 
       - name: Validate publishable plugin metadata
         env:
+          TSX_TSCONFIG_PATH: ${{ github.workspace }}/.release-tooling/tsconfig.json
           PUBLISH_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_scope || '' }}
           RELEASE_PLUGINS: ${{ github.event_name == 'workflow_dispatch' && inputs.plugins || '' }}
           BASE_REF: ${{ github.event_name != 'workflow_dispatch' && github.event.before || '' }}
@@ -344,16 +340,17 @@ jobs:
             if [[ "${NPM_DIST_TAG}" == "extended-stable" ]]; then
               release_args+=(--npm-dist-tag "${NPM_DIST_TAG}")
             fi
-            pnpm release:plugins:npm:check -- "${release_args[@]}"
+            node --import tsx .release-tooling/scripts/plugin-npm-release-check.ts "${release_args[@]}"
           elif [[ -n "${BASE_REF}" ]]; then
-            pnpm release:plugins:npm:check -- --base-ref "${BASE_REF}" --head-ref "${HEAD_REF}"
+            node --import tsx .release-tooling/scripts/plugin-npm-release-check.ts --base-ref "${BASE_REF}" --head-ref "${HEAD_REF}"
           else
-            pnpm release:plugins:npm:check
+            node --import tsx .release-tooling/scripts/plugin-npm-release-check.ts
           fi
 
       - name: Resolve plugin release plan
         id: plan
         env:
+          TSX_TSCONFIG_PATH: ${{ github.workspace }}/.release-tooling/tsconfig.json
           PUBLISH_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_scope || '' }}
           RELEASE_PLUGINS: ${{ github.event_name == 'workflow_dispatch' && inputs.plugins || '' }}
           BASE_REF: ${{ github.event_name != 'workflow_dispatch' && github.event.before || '' }}
@@ -371,11 +368,11 @@ jobs:
             if [[ "${NPM_DIST_TAG}" == "extended-stable" ]]; then
               plan_args+=(--npm-dist-tag "${NPM_DIST_TAG}")
             fi
-            node --import tsx scripts/plugin-npm-release-plan.ts "${plan_args[@]}" > .local/plugin-npm-release-plan.json
+            node --import tsx .release-tooling/scripts/plugin-npm-release-plan.ts "${plan_args[@]}" > .local/plugin-npm-release-plan.json
           elif [[ -n "${BASE_REF}" ]]; then
-            node --import tsx scripts/plugin-npm-release-plan.ts --base-ref "${BASE_REF}" --head-ref "${HEAD_REF}" > .local/plugin-npm-release-plan.json
+            node --import tsx .release-tooling/scripts/plugin-npm-release-plan.ts --base-ref "${BASE_REF}" --head-ref "${HEAD_REF}" > .local/plugin-npm-release-plan.json
           else
-            node --import tsx scripts/plugin-npm-release-plan.ts > .local/plugin-npm-release-plan.json
+            node --import tsx .release-tooling/scripts/plugin-npm-release-plan.ts > .local/plugin-npm-release-plan.json
           fi
 
           cat .local/plugin-npm-release-plan.json

--- a/scripts/lib/plugin-npm-release.ts
+++ b/scripts/lib/plugin-npm-release.ts
@@ -420,6 +420,29 @@ function resolveNpmLatestVersion(packageName: string): string {
   return parsed.trim();
 }
 
+function hasApprovedReleaseDependencyException(
+  plugin: PublishablePluginPackage,
+  dependency: { packageName: string; version: string },
+): boolean {
+  if (
+    plugin.packageName !== "@openclaw/codex" ||
+    plugin.version !== "2026.8.2" ||
+    dependency.packageName !== "@openai/codex" ||
+    dependency.version !== "0.151.0"
+  ) {
+    return false;
+  }
+  // The maintainer-approved frozen release keeps its tested pin; later releases remain strict.
+  try {
+    return (
+      resolveGitCommitSha(plugin.packageDir, "HEAD", "release dependency exception target") ===
+      "0965053fe6b9341776df147a6934b7485c60b5ca"
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function collectPluginReleaseDependencyFreshnessErrors(
   plugins: readonly PublishablePluginPackage[],
   resolveLatestVersion: NpmLatestVersionResolver = resolveNpmLatestVersion,
@@ -444,6 +467,12 @@ export function collectPluginReleaseDependencyFreshnessErrors(
         }
       }
       if (dependency.version !== latestVersion) {
+        if (hasApprovedReleaseDependencyException(plugin, dependency)) {
+          console.warn(
+            `${plugin.packageName}@${plugin.version}: approved release dependency exception for 0965053fe6b9341776df147a6934b7485c60b5ca retains ${dependency.packageName} "${dependency.version}"; npm latest is "${latestVersion}".`,
+          );
+          continue;
+        }
         errors.push(
           `${plugin.packageName}@${plugin.version}: ${dependency.packageName} must match npm latest for release; found "${dependency.version}", latest is "${latestVersion}".`,
         );

--- a/scripts/release-candidate-checklist.mts
+++ b/scripts/release-candidate-checklist.mts
@@ -32,6 +32,7 @@ import {
   validateReleasePreflightTagIdentity,
 } from "./npm-preflight-tooling-identity.mjs";
 import { validatePluginSdkApiReleaseEvidence } from "./plugin-sdk-api-release-evidence.mjs";
+import { verifyReleaseToolingIdentity } from "./release-tooling-identity.mjs";
 import {
   dedicatedSectionVersionForTag,
   extractChangelogReleaseSections,
@@ -108,6 +109,7 @@ const RELEASE_CANDIDATE_STATE_KEYS = [
   "targetSha",
   "toolingSha",
   "workflowRef",
+  "publishWorkflowRef",
   "provider",
   "mode",
   "releaseProfile",
@@ -145,6 +147,7 @@ Options:
   --tag <tag>                         Planned release tag. The tag must not exist yet.
   --target-sha <sha>                  Frozen release SHA. Defaults to the current HEAD.
   --workflow-ref <ref>                Trusted workflow ref. Default: main; matching Tideclaw branch required for alpha.
+  --publish-workflow-ref <tag>         Protected publication tooling tag matching the trusted helper checkout.
   --repo <owner/repo>                 GitHub repo. Default: ${DEFAULT_REPO}
   --full-release-run <id>             Reuse successful Full Release Validation run.
   --npm-preflight-run <id>            Reuse successful OpenClaw NPM Release preflight run.
@@ -207,6 +210,7 @@ export function parseArgs(argv: string[]) {
     tag: "",
     targetSha: "",
     workflowRef: "",
+    publishWorkflowRef: "",
     fullReleaseRunId: "",
     npmPreflightRunId: "",
     pluginSdkApiAcknowledgement: "",
@@ -224,6 +228,7 @@ export function parseArgs(argv: string[]) {
           ["--tag", "tag"],
           ["--target-sha", "targetSha"],
           ["--workflow-ref", "workflowRef"],
+          ["--publish-workflow-ref", "publishWorkflowRef"],
           ["--repo", "repo"],
           ["--full-release-run", "fullReleaseRunId"],
           ["--npm-preflight-run", "npmPreflightRunId"],
@@ -285,6 +290,15 @@ export function parseArgs(argv: string[]) {
   }
   if (!options.tag.includes("-alpha.") && options.workflowRef !== "main") {
     throw new Error("--workflow-ref must be main for regular beta and stable release candidates");
+  }
+  if (
+    options.publishWorkflowRef &&
+    (options.tag.includes("-alpha.") ||
+      !/^release-publish\/[a-f0-9]{12}-[1-9][0-9]*$/u.test(options.publishWorkflowRef))
+  ) {
+    throw new Error(
+      "--publish-workflow-ref must name a protected release-publish tag for a regular release",
+    );
   }
   options.releaseProfile ||=
     options.tag.includes("-alpha.") || options.tag.includes("-beta.") ? "beta" : "stable";
@@ -451,6 +465,7 @@ export function buildReleaseCandidateState(
     targetSha,
     toolingSha,
     workflowRef: options.workflowRef,
+    publishWorkflowRef: options.publishWorkflowRef,
     provider: options.provider,
     mode: options.mode,
     releaseProfile: options.releaseProfile,
@@ -1461,7 +1476,9 @@ function pluginPlanArgs(options: ReturnType<typeof parseArgs>) {
 
 function collectPluginPlan(script: string, options: ReturnType<typeof parseArgs>): unknown {
   return JSON.parse(
-    run("node", ["--import", "tsx", script, ...pluginPlanArgs(options)], { capture: true }),
+    run("node", ["--import", "tsx", join(TOOLING_ROOT, script), ...pluginPlanArgs(options)], {
+      capture: true,
+    }),
   );
 }
 
@@ -1505,7 +1522,8 @@ export function buildPublishCommand(
   npmPreflightSource?: Awaited<ReturnType<typeof validateNpmPreflightRunSource>>,
 ) {
   const workflowRef =
-    npmPreflightSource?.workflowRef ??
+    options.publishWorkflowRef ||
+    npmPreflightSource?.workflowRef ||
     (options.tag.includes("-alpha.") ? options.workflowRef : "main");
   if (options.tag.includes("-alpha.") && !TIDECLAW_ALPHA_WORKFLOW_REF_PATTERN.test(workflowRef)) {
     throw new Error(
@@ -1872,6 +1890,15 @@ async function main() {
     toolingTrackedStatus: gitTrackedStatus(TOOLING_ROOT),
     workflowRef: options.workflowRef,
   });
+  // Publication may use repaired tooling while the prepared tarball retains its original producer.
+  const publishWorkflowIdentity = options.publishWorkflowRef
+    ? verifyReleaseToolingIdentity({
+        repository: options.repo,
+        workflowRef: options.publishWorkflowRef,
+        workflowFullRef: `refs/tags/${options.publishWorkflowRef}`,
+        workflowSha: toolingSha,
+      })
+    : undefined;
   options.parallelsRegistryPackageArtifacts = options.parallelsRegistryPackageArtifactDirs.map(
     (artifactDir) =>
       validateParallelsRegistryPackageArtifact(artifactDir, {
@@ -2148,6 +2175,7 @@ async function main() {
     tag: options.tag,
     targetSha,
     workflowRef: options.workflowRef,
+    publishWorkflowIdentity,
     npmDistTag: options.npmDistTag,
     fullReleaseValidationRunId: options.fullReleaseRunId,
     fullReleaseValidationRunAttempt: fullRun.runAttempt,

--- a/test/plugin-npm-release.test.ts
+++ b/test/plugin-npm-release.test.ts
@@ -432,6 +432,93 @@ describe("collectPluginReleaseDependencyFreshnessErrors", () => {
     ],
   };
 
+  const approvedPlugin: PublishablePluginPackage = {
+    ...plugin,
+    version: "2026.8.2",
+    requiredLatestDependencies: [{ packageName: "@openai/codex", version: "0.151.0" }],
+  };
+  const approvedSha = "0965053fe6b9341776df147a6934b7485c60b5ca";
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each(["0.152.0", "0.153.0"])(
+    "retains the approved frozen pin while reporting actual npm latest %s",
+    (latest) => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      childProcessMock.execFileSyncOverride = ((
+        command: string,
+        args: readonly string[],
+        options: unknown,
+      ) => {
+        expect(command).toBe("git");
+        expect(args).toEqual(["rev-parse", "--verify", "--quiet", "HEAD^{commit}"]);
+        expect(options).toMatchObject({ cwd: approvedPlugin.packageDir });
+        return approvedSha;
+      }) as unknown as ExecFileSync;
+      const resolveLatest = vi.fn(() => latest);
+      expect(
+        collectPluginReleaseDependencyFreshnessErrors([approvedPlugin], resolveLatest),
+      ).toEqual([]);
+      expect(resolveLatest).toHaveBeenCalledWith("@openai/codex");
+      expect(warn).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining(`npm latest is "${latest}"`),
+      );
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(approvedSha));
+    },
+  );
+
+  it.each(["another checkout", "missing git"])("keeps the pin strict for %s", (scenario) => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    childProcessMock.execFileSyncOverride = (() => {
+      if (scenario === "missing git") throw new Error("not a git repository");
+      return "8fc5024659a9915406aed0d5d0ad2f368c8557e4";
+    }) as unknown as ExecFileSync;
+    expect(
+      collectPluginReleaseDependencyFreshnessErrors([approvedPlugin], () => "0.152.0"),
+    ).toHaveLength(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { packageName: "@openclaw/other" },
+    { version: "2026.8.3" },
+    { requiredLatestDependencies: [{ packageName: "another-runtime", version: "0.151.0" }] },
+    { requiredLatestDependencies: [{ packageName: "@openai/codex", version: "0.150.0" }] },
+  ])("does not broaden the approved package tuple %j", (change) => {
+    const git = vi.fn(() => approvedSha);
+    childProcessMock.execFileSyncOverride = git as unknown as ExecFileSync;
+    expect(
+      collectPluginReleaseDependencyFreshnessErrors(
+        [{ ...approvedPlugin, ...change }],
+        () => "0.152.0",
+      ),
+    ).toHaveLength(1);
+    expect(git).not.toHaveBeenCalled();
+  });
+
+  it("retains unrelated failures after the approved exception", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    childProcessMock.execFileSyncOverride = (() => approvedSha) as unknown as ExecFileSync;
+    expect(
+      collectPluginReleaseDependencyFreshnessErrors([approvedPlugin, plugin], () => "0.152.0"),
+    ).toEqual([
+      '@openclaw/codex@2026.6.11: @openai/codex must match npm latest for release; found "0.139.0", latest is "0.152.0".',
+    ]);
+  });
+
+  it("never uses the approved exception when the live registry lookup fails", () => {
+    const git = vi.fn(() => approvedSha);
+    childProcessMock.execFileSyncOverride = git as unknown as ExecFileSync;
+    expect(
+      collectPluginReleaseDependencyFreshnessErrors([approvedPlugin], () => {
+        throw new Error("registry unavailable");
+      }),
+    ).toEqual([
+      "@openclaw/codex@2026.8.2: could not resolve npm latest for @openai/codex: registry unavailable",
+    ]);
+    expect(git).not.toHaveBeenCalled();
+  });
+
   it("rejects release dependencies older than the npm latest dist-tag", () => {
     expect(collectPluginReleaseDependencyFreshnessErrors([plugin], () => "0.142.5")).toEqual([
       '@openclaw/codex@2026.6.11: @openai/codex must match npm latest for release; found "0.139.0", latest is "0.142.5".',

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2100,7 +2100,7 @@ describe("package acceptance workflow", () => {
     for (const [name, script] of [
       ["Validate publishable plugin metadata", "plugin-npm-release-check.ts"],
       ["Resolve plugin release plan", "plugin-npm-release-plan.ts"],
-    ]) {
+    ] as const) {
       const planner = workflowStep(job, name);
       expect(planner.run).toContain(`node --import tsx .release-tooling/scripts/${script}`);
       expect(planner.env?.TSX_TSCONFIG_PATH).toBe(

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2085,19 +2085,29 @@ describe("package acceptance workflow", () => {
 
   it("runs plugin npm preflight trust from the exact workflow tooling checkout", () => {
     const job = workflowJob(PLUGIN_NPM_RELEASE_WORKFLOW, "preview_plugins_npm");
-    const checkout = workflowStep(job, "Checkout trusted preflight tooling");
+    const checkout = workflowStep(job, "Checkout trusted planning tooling");
     const identity = workflowStep(job, "Verify trusted preflight tooling identity");
     const target = workflowStep(job, "Validate ref is on a trusted publish branch");
 
-    expect(checkout.if).toBe("github.event_name == 'workflow_dispatch' && inputs.preflight_only");
+    expect(checkout.if).toBeUndefined();
     expect(checkout.with).toMatchObject({
       "fetch-depth": 1,
       path: ".release-tooling",
       "persist-credentials": false,
       ref: "${{ github.workflow_sha }}",
-      "sparse-checkout": "scripts/lib/record-shared.mjs\nscripts/release-tooling-identity.mjs\n",
-      "sparse-checkout-cone-mode": false,
     });
+    expect(checkout.with?.["sparse-checkout"]).toBeUndefined();
+    for (const [name, script] of [
+      ["Validate publishable plugin metadata", "plugin-npm-release-check.ts"],
+      ["Resolve plugin release plan", "plugin-npm-release-plan.ts"],
+    ]) {
+      const planner = workflowStep(job, name);
+      expect(planner.run).toContain(`node --import tsx .release-tooling/scripts/${script}`);
+      expect(planner.env?.TSX_TSCONFIG_PATH).toBe(
+        "${{ github.workspace }}/.release-tooling/tsconfig.json",
+      );
+      expect(planner["working-directory"]).toBeUndefined();
+    }
     expect(identity.if).toBe("github.event_name == 'workflow_dispatch' && inputs.preflight_only");
     expect(identity.env).toMatchObject({
       GH_TOKEN: "${{ github.token }}",

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -182,7 +182,7 @@ describe("plugin npm extended-stable workflow", () => {
     expect(previewSteps.slice(0, 7).map((candidate) => candidate.name)).toEqual([
       "Prepare Git owner",
       "Checkout",
-      "Checkout trusted preflight tooling",
+      "Checkout trusted planning tooling",
       "Resolve checked-out ref",
       "Verify trusted preflight tooling identity",
       "Validate ref is on a trusted publish branch",

--- a/test/scripts/release-candidate-checklist.test.ts
+++ b/test/scripts/release-candidate-checklist.test.ts
@@ -60,6 +60,68 @@ async function withGithubApiTimeoutEnv<T>(value: string, fn: () => Promise<T>): 
 }
 
 describe("release candidate checklist", () => {
+  it("runs plugin planners from trusted tooling while retaining candidate inputs", () => {
+    const source = readFileSync("scripts/release-candidate-checklist.mts", "utf8");
+    const owner = source.match(/^function collectPluginPlan\([\s\S]*?^\}/mu)?.[0];
+    expect(owner).toBeDefined();
+    const runPlanner = vi.fn((_command, args, options) => JSON.stringify({ args, options }));
+    const result = runInNewContext(
+      stripTypeScriptTypes(`${owner}\ncollectPluginPlan("scripts/plugin-npm-release-plan.ts", {})`),
+      {
+        TOOLING_ROOT: "/trusted/tooling",
+        join,
+        pluginPlanArgs: () => ["--selection-mode", "all-publishable"],
+        run: runPlanner,
+      },
+    );
+    expect(result.args).toEqual([
+      "--import",
+      "tsx",
+      "/trusted/tooling/scripts/plugin-npm-release-plan.ts",
+      "--selection-mode",
+      "all-publishable",
+    ]);
+    expect(result.options).not.toHaveProperty("cwd");
+  });
+
+  it("routes a repaired publisher independently from immutable preflight evidence", () => {
+    const publishWorkflowRef = "release-publish/bbbbbbbbbbbb-123";
+    const options = parseArgs([
+      "--tag",
+      "v2026.8.2-beta.1",
+      "--publish-workflow-ref",
+      publishWorkflowRef,
+    ]);
+    const producer = {
+      status: "passed",
+      headSha: "a".repeat(40),
+      workflowRef: "release-publish/aaaaaaaaaaaa-122",
+    };
+    const command = buildPublishCommand(options, producer);
+    expect(command).toContain(`'--ref' '${publishWorkflowRef}'`);
+    expect(producer.headSha).toBe("a".repeat(40));
+    const saved = buildReleaseCandidateState(options, {
+      targetSha: "c".repeat(40),
+      toolingSha: "b".repeat(40),
+    });
+    expect(saved.publishWorkflowRef).toBe(publishWorkflowRef);
+    expect(() =>
+      reconcileReleaseCandidateState(saved, {
+        ...saved,
+        publishWorkflowRef: "release-publish/bbbbbbbbbbbb-124",
+      }),
+    ).toThrow("state mismatch for publishWorkflowRef");
+  });
+
+  it.each(["main", "refs/tags/release-publish/bbbbbbbbbbbb-123", "release-publish/bbbbbbbbbbbb-0"])(
+    "rejects an unprotected publisher selector %s",
+    (ref) => {
+      expect(() => parseArgs(["--tag", "v2026.8.2-beta.1", "--publish-workflow-ref", ref])).toThrow(
+        "protected release-publish tag",
+      );
+    },
+  );
+
   it("recognizes direct execution through a symlinked temporary root", () => {
     const realpath = vi.fn((value: string) => value.replace(/^\/tmp\//u, "/private/tmp/"));
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where publishing the validated 2026.8.2 release stops because npm's Codex `latest` moved from `0.151.0` to `0.152.0` after the candidate was frozen. The npm and ClawHub planners also execute policy from the frozen candidate, so a trusted tooling repair cannot currently reach every publication path.

## Why This Change Was Made

The maintainer explicitly approved retaining `@openai/codex@0.151.0` for `@openclaw/codex@2026.8.2` at commit `0965053fe6b9341776df147a6934b7485c60b5ca`. The shared freshness check permits only that package/version/pin at the actual checked-out commit. It still queries npm and reports the exception and current latest version; other releases, dependencies, missing Git identity, and registry failures retain normal enforcement.

The candidate helper and npm, ClawHub, and ClawHub bootstrap workflows execute workflow-owned planning tools with the candidate as their working directory. An explicit protected publication-tooling ref lets the helper select repaired tooling while preserving the original npm artifact producer. The protected tag must resolve to the helper's actual trusted commit. Candidate source, package bytes, artifact digests, and provenance are unchanged.

## User Impact

Allows the approved 2026.8.2 release to publish the package already validated, without introducing an unvalidated Codex upgrade or repeating completed product validation. Future releases keep the existing latest-dependency requirement. This changes release tooling only.

## Evidence

- The unchanged candidate passed [npm preflight and tarball installation](https://github.com/openclaw/openclaw/actions/runs/33490056617) and [full release validation](https://github.com/openclaw/openclaw/actions/runs/33479039101).
- Freshness regression: 3 intended failures before the fix; 14 focused cases pass afterward, including wrong commit/version/pin, registry failure, future latest, and unrelated dependency failures.
- Candidate helper and canonical tooling-identity suites: 165 tests pass, including protected ref binding and preserving the older npm producer.
- ClawHub bootstrap workflow suite: 11 tests pass. All three changed workflow documents parse, and their changed shell steps pass `bash -n`.
- Real npm and ClawHub metadata checker CLIs, executed from the unchanged candidate with trusted tooling, both pass and explicitly report retained `0.151.0` against npm latest `0.152.0`.
- Product source and the release candidate were not changed. The added release policy and routing represent the approved exception and separate publication tooling from artifact provenance.
