### PR TITLE
refactor: centralize assistant text content recognition

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -28,6 +28,7 @@ import { hasReplyPayloadContent } from "../../../interactive/payload.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import {
   extractAssistantTextForPhase,
+  isAssistantTextContentType,
   parseAssistantTextSignature,
 } from "../../../shared/chat-message-content.js";
 import {
@@ -57,9 +58,6 @@ import type { ToolErrorSummary } from "../../tool-error-summary.js";
 import { buildSourceReplyPayloadState } from "./source-reply-payloads.js";
 import { buildFailureWarning } from "./tool-error-warning.js";
 
-function isAssistantTextContentBlockType(value: unknown): boolean {
-  return value === "text" || value === "input_text" || value === "output_text";
-}
 function resolveRawAssistantAnswerText(lastAssistant: AssistantMessage | undefined): string {
   if (!lastAssistant) {
     return "";
@@ -78,7 +76,7 @@ function resolveRawAssistantAnswerText(lastAssistant: AssistantMessage | undefin
       }
       const record = block as { type?: unknown; textSignature?: unknown };
       return (
-        isAssistantTextContentBlockType(record.type) &&
+        isAssistantTextContentType(record.type) &&
         Boolean(parseAssistantTextSignature(record)?.phase)
       );
     });
@@ -91,7 +89,7 @@ function resolveRawAssistantAnswerText(lastAssistant: AssistantMessage | undefin
           const record = block as { type?: unknown; text?: unknown; textSignature?: unknown };
           const signature = parseAssistantTextSignature(record);
           if (
-            !isAssistantTextContentBlockType(record.type) ||
+            !isAssistantTextContentType(record.type) ||
             typeof record.text !== "string" ||
             !signature?.id ||
             signature.phase

--- a/src/agents/embedded-agent-utils.ts
+++ b/src/agents/embedded-agent-utils.ts
@@ -7,6 +7,7 @@ import { stripCompactionReplayCheckpointInPlace } from "@openclaw/ai/transports"
 import type { AssistantMessage } from "../llm/types.js";
 import { extractTextFromChatContent } from "../shared/chat-content.js";
 import {
+  isAssistantTextContentType,
   normalizeAssistantPhase,
   parseAssistantTextSignature,
   type AssistantPhase,
@@ -36,10 +37,6 @@ function sanitizeAssistantText(text: string, phase?: AssistantPhase, streaming =
     phase === "final_answer" ? "final-answer-delivery" : "delivery",
     streaming && phase === "final_answer",
   );
-}
-
-function isAssistantTextContentBlockType(value: unknown): boolean {
-  return value === "text" || value === "input_text" || value === "output_text";
 }
 
 export function sanitizeAssistantVisibleStreamText(text: string, phase?: AssistantPhase): string {
@@ -103,7 +100,7 @@ function extractEmbeddedAssistantTextForPhase(
       continue;
     }
     const record = block as { type?: unknown; text?: unknown; textSignature?: unknown };
-    if (!isAssistantTextContentBlockType(record.type)) {
+    if (!isAssistantTextContentType(record.type)) {
       continue;
     }
     const phase = parseAssistantTextSignature(record)?.phase;
@@ -126,7 +123,7 @@ function extractEmbeddedAssistantTextForPhase(
       continue;
     }
     const record = block as { type?: unknown; text?: unknown; textSignature?: unknown };
-    if (!isAssistantTextContentBlockType(record.type) || typeof record.text !== "string") {
+    if (!isAssistantTextContentType(record.type) || typeof record.text !== "string") {
       continue;
     }
     const signature = parseAssistantTextSignature(record);

--- a/src/gateway/chat-display-projection.core.ts
+++ b/src/gateway/chat-display-projection.core.ts
@@ -8,12 +8,12 @@ import {
   nestedToolActivityContent,
 } from "../sessions/nested-tool-activity.js";
 import { formatProviderRefusalText } from "../shared/assistant-error-format.js";
+import { isAssistantTextContentType } from "../shared/chat-message-content.js";
 import {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
   extractAssistantTextForSilentCheck,
   hasAssistantDisplayableNonTextContent,
   hasAssistantNonTextContent,
-  isAssistantTextContentType,
 } from "./chat-display-projection.helpers.js";
 import {
   filterVisibleProjectedHistoryMessages,

--- a/src/gateway/chat-display-projection.helpers.ts
+++ b/src/gateway/chat-display-projection.helpers.ts
@@ -3,6 +3,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { isMeaningfulMediaFact, readPersistedMediaFacts } from "../media/media-facts.js";
 import { isRelativeAssistantMediaReference, splitMediaFromOutput } from "../media/parse.js";
 import { normalizeInputProvenance } from "../sessions/input-provenance.js";
+import { isAssistantTextContentType } from "../shared/chat-message-content.js";
 import { isSuppressedControlReplyText } from "./control-reply-text.js";
 
 export type RoleContentMessage = {
@@ -118,10 +119,6 @@ export function extractAssistantTextForSilentCheck(message: unknown): string | u
     texts.push(typed.text);
   }
   return texts.length > 0 ? texts.join("\n") : undefined;
-}
-
-export function isAssistantTextContentType(type: unknown): boolean {
-  return type === "text" || type === "input_text" || type === "output_text";
 }
 
 function isAssistantInternalReasoningContentType(type: unknown): boolean {

--- a/src/gateway/chat-display-projection.sanitize.ts
+++ b/src/gateway/chat-display-projection.sanitize.ts
@@ -3,6 +3,7 @@ import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
 import { parseInboundMediaUri, buildInboundMediaUriFromPath } from "../media/media-reference.js";
 import {
+  isAssistantTextContentType,
   parseAssistantTextSignature,
   resolveAssistantMessagePhase,
 } from "../shared/chat-message-content.js";
@@ -16,7 +17,6 @@ import {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
   extractAssistantTextForSilentCheck,
   hasAssistantDisplayableNonTextContent,
-  isAssistantTextContentType,
   isProjectedSessionsSendForwardedMessage,
   shouldPreserveAssistantControlReplyText,
   stripAssistantMediaDirectivesForDisplay,

--- a/src/shared/chat-message-content.ts
+++ b/src/shared/chat-message-content.ts
@@ -33,7 +33,8 @@ const assistantTextSignatureCache = new WeakMap<
   { text: unknown; result: AssistantTextSignature }
 >();
 
-function isAssistantTextContentBlockType(value: unknown): boolean {
+/** Keeps native and persisted Responses blocks on one assistant-text type contract. */
+export function isAssistantTextContentType(value: unknown): boolean {
   return value === "text" || value === "input_text" || value === "output_text";
 }
 
@@ -95,7 +96,7 @@ export function resolveAssistantMessagePhase(message: unknown): AssistantPhase |
       continue;
     }
     const record = block as { type?: unknown; textSignature?: unknown };
-    if (!isAssistantTextContentBlockType(record.type)) {
+    if (!isAssistantTextContentType(record.type)) {
       continue;
     }
     const phase = parseAssistantTextSignature(record)?.phase;
@@ -181,7 +182,7 @@ export function extractAssistantTextForPhase(
       return false;
     }
     const record = block as { type?: unknown; textSignature?: unknown };
-    if (!isAssistantTextContentBlockType(record.type)) {
+    if (!isAssistantTextContentType(record.type)) {
       return false;
     }
     return Boolean(parseAssistantTextSignature(record)?.phase);
@@ -198,7 +199,7 @@ export function extractAssistantTextForPhase(
         return null;
       }
       const record = block as { type?: unknown; text?: unknown; textSignature?: unknown };
-      if (!isAssistantTextContentBlockType(record.type) || typeof record.text !== "string") {
+      if (!isAssistantTextContentType(record.type) || typeof record.text !== "string") {
         return null;
       }
       const signature = parseAssistantTextSignature(record);


### PR DESCRIPTION
## What Problem This Solves

Assistant text-content recognition was owned separately by shared message parsing, embedded-agent extraction, payload fallback handling, and Gateway display projection. The duplicated `"text" | "input_text" | "output_text"` policy could drift between native and persisted Responses content.

## Why This Change Was Made

`src/shared/chat-message-content.ts` now owns the canonical `isAssistantTextContentType` discriminator beside assistant phase and signature parsing. The embedded-agent and Gateway callers import that owner directly; three duplicate predicates and the Gateway re-export path are removed.

The narrower mutable-block predicate in `packages/ai/src/utils/assistant-text-phase.ts` remains intentionally separate because it validates a full `"text"` block, not this discriminator contract. No alias, re-export shim, barrel, Plugin SDK, protocol, config, storage, dependency, test, or changelog surface changed.

## User Impact

No intended user-visible behavior change. Native and persisted assistant text blocks continue to recognize exactly `text`, `input_text`, and `output_text`, now through one owner.

Production LOC: +14/-21 (net -7) | Tests: +0/-0

## Evidence

- Exact semantic replay onto current `main`; six production files only.
- Shared owner suite: 17 tests passed, including persisted Responses `input_text` and `output_text` behavior.
- The four broader requested suites could not collect because the shared checkout is missing existing markdown dependencies. No worktree install was performed.
- `pnpm check:changed` passed its focused guards through the core typecheck, which stopped on the same missing markdown packages plus `libphonenumber-js`.
- `pnpm build` stopped during bundled viewer asset setup because the shared checkout is missing `@pierre/diffs` and Shiki language packages.
- Formatting and `git diff --check` passed.
- Import-cycle check passed with 0 runtime value cycles.
- Changed-path dry run classified only `core` and `coreTests`.
- Test-audit: no test was added because existing shared, embedded-agent, payload, and Gateway boundary suites own the observable behavior; a predicate-only test would freeze source organization.
- Sol-high autoreview completed scoped-clean with 0.99 confidence and no accepted/actionable findings.
- Mandatory Codex source inspection completed at `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; those CLI/config surfaces impose no additional content discriminator contract.

