### PR TITLE
fix: bot shows typing then never replies after /new or daily reset on a fresh session

### DIFF
--- a/src/agents/sessions/session-manager-core.ts
+++ b/src/agents/sessions/session-manager-core.ts
@@ -120,6 +120,13 @@ export class SessionManagerCore {
       return;
     }
     const header = partitioned.fileEntries.find((entry) => entry.type === "session");
+    // Runtime never rebuilds a missing header in place: silently replacing malformed
+    // history would hide the corruption. Doctor owns the repair.
+    if (target && !header) {
+      throw new Error(
+        'Persisted session transcript has no session header row; run "openclaw doctor --fix" to repair it',
+      );
+    }
     if (target && (header?.version ?? 1) < CURRENT_SESSION_VERSION) {
       throw new Error(
         "Persisted legacy session transcripts require doctor/import migration before runtime use",

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -151,57 +151,8 @@ describe("SessionManager.open", () => {
     );
   });
 
-  it("rejects persisted legacy transcripts until doctor or import migrates them", async () => {
-    const dir = tempDirs.make("openclaw-session-manager-");
-    const storePath = path.join(dir, "sessions.json");
-    const sessionId = "legacy-persisted-session";
-    const sessionKey = "agent:main:legacy-persisted-session";
-    const scope = { agentId: "main", sessionId, sessionKey, storePath };
-    await upsertSessionEntryCore(scope, { sessionId, updatedAt: 1 });
-    replaceTranscriptEventsSync(scope, [
-      {
-        type: "session",
-        version: 1,
-        id: sessionId,
-        timestamp: "2026-01-01T00:00:00.000Z",
-        cwd: dir,
-      },
-      {
-        type: "message",
-        message: { role: "user", content: "legacy message" },
-      },
-    ]);
-
-    expect(() => SessionManager.open(scope, dir)).toThrow(
-      "require doctor/import migration before runtime use",
-    );
-    const existingManager = SessionManager.inMemory("/original-workspace");
-    expect(() => existingManager.setSessionTarget(scope)).toThrow(
-      "require doctor/import migration before runtime use",
-    );
-    expect(existingManager.getCwd()).toBe("/original-workspace");
-
-    const currentScope = {
-      agentId: "main",
-      sessionId: "current-persisted-session",
-      sessionKey: "agent:main:current-persisted-session",
-      storePath,
-    };
-    await upsertSessionEntryCore(currentScope, { sessionId: currentScope.sessionId, updatedAt: 2 });
-    const currentManager = SessionManager.open(currentScope, dir);
-    expect(() => currentManager.setSessionTarget(scope)).toThrow(
-      "require doctor/import migration before runtime use",
-    );
-    currentManager.appendModelChange("test-provider", "test-model");
-    await expect(loadTranscriptEvents(currentScope)).resolves.toEqual([
-      expect.objectContaining({
-        type: "session",
-        version: CURRENT_SESSION_VERSION,
-        id: currentScope.sessionId,
-      }),
-      expect.objectContaining({ type: "model_change" }),
-    ]);
-  });
+  // Legacy and headerless load-gate rejection coverage lives in
+  // session-manager.transcript-repair-gate.test.ts.
 
   it("skips malformed null rows while opening a persisted transcript", async () => {
     const dir = tempDirs.make("openclaw-session-manager-");

--- a/src/agents/sessions/session-manager.transcript-repair-gate.test.ts
+++ b/src/agents/sessions/session-manager.transcript-repair-gate.test.ts
@@ -1,0 +1,89 @@
+// Persisted transcripts that need repair or migration are rejected at load with
+// an actionable error; runtime never rebuilds legacy or headerless history in place.
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  loadTranscriptEvents,
+  replaceTranscriptEventsSync,
+  upsertSessionEntryCore,
+} from "../../config/sessions/session-accessor.js";
+import { CURRENT_SESSION_VERSION, SessionManager } from "./session-manager.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("SessionManager persisted transcript repair gate", () => {
+  it("rejects persisted legacy transcripts until doctor or import migrates them", async () => {
+    const dir = tempDirs.make("openclaw-session-manager-");
+    const storePath = path.join(dir, "sessions.json");
+    const sessionId = "legacy-persisted-session";
+    const sessionKey = "agent:main:legacy-persisted-session";
+    const scope = { agentId: "main", sessionId, sessionKey, storePath };
+    await upsertSessionEntryCore(scope, { sessionId, updatedAt: 1 });
+    replaceTranscriptEventsSync(scope, [
+      {
+        type: "session",
+        version: 1,
+        id: sessionId,
+        timestamp: "2026-01-01T00:00:00.000Z",
+        cwd: dir,
+      },
+      {
+        type: "message",
+        message: { role: "user", content: "legacy message" },
+      },
+    ]);
+
+    expect(() => SessionManager.open(scope, dir)).toThrow(
+      "require doctor/import migration before runtime use",
+    );
+    const existingManager = SessionManager.inMemory("/original-workspace");
+    expect(() => existingManager.setSessionTarget(scope)).toThrow(
+      "require doctor/import migration before runtime use",
+    );
+    expect(existingManager.getCwd()).toBe("/original-workspace");
+
+    const currentScope = {
+      agentId: "main",
+      sessionId: "current-persisted-session",
+      sessionKey: "agent:main:current-persisted-session",
+      storePath,
+    };
+    await upsertSessionEntryCore(currentScope, { sessionId: currentScope.sessionId, updatedAt: 2 });
+    const currentManager = SessionManager.open(currentScope, dir);
+    expect(() => currentManager.setSessionTarget(scope)).toThrow(
+      "require doctor/import migration before runtime use",
+    );
+    currentManager.appendModelChange("test-provider", "test-model");
+    await expect(loadTranscriptEvents(currentScope)).resolves.toEqual([
+      expect.objectContaining({
+        type: "session",
+        version: CURRENT_SESSION_VERSION,
+        id: currentScope.sessionId,
+      }),
+      expect.objectContaining({ type: "model_change" }),
+    ]);
+  });
+
+  it("rejects headerless persisted transcripts with a doctor repair hint", async () => {
+    const dir = tempDirs.make("openclaw-session-manager-");
+    const storePath = path.join(dir, "sessions.json");
+    const sessionId = "headerless-persisted-session";
+    const sessionKey = "agent:main:headerless-persisted-session";
+    const scope = { agentId: "main", sessionId, sessionKey, storePath };
+    await upsertSessionEntryCore(scope, { sessionId, updatedAt: 1 });
+    replaceTranscriptEventsSync(scope, [
+      {
+        type: "reset",
+        id: "orphan-reset",
+        parentId: null,
+        timestamp: "2026-01-01T00:00:00.000Z",
+        reason: "new",
+      },
+    ]);
+
+    expect(() => SessionManager.open(scope, dir)).toThrow(
+      'no session header row; run "openclaw doctor --fix"',
+    );
+  });
+});

--- a/src/auto-reply/reply/agent-runner-failure-reply.test.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.test.ts
@@ -6,6 +6,7 @@ import {
   buildEmptyInteractiveReplyPayload,
   buildExternalRunFailureReply,
   buildPreflightCompactionFailureText,
+  resolveExternalRunFailureTextForConversation,
 } from "./agent-runner-failure-reply.js";
 
 const EMPTY_INTERACTIVE_REPLY_TEXT =
@@ -101,5 +102,39 @@ describe("buildPreflightCompactionFailureText", () => {
       "⚠️ Context is too large and auto-compaction timed out before it could finish. " +
         "Try again, use /compact, or use /new to start a fresh session.",
     );
+  });
+});
+
+// Session-hydration failures must stay visible in group chats: the group
+// silent-reply policy deletes generic failure text, so a wedged session would
+// otherwise fail every turn with no user-visible outcome.
+describe("session transcript repair failure classification", () => {
+  const HEADERLESS_TRANSCRIPT_ERROR =
+    'Persisted session transcript has no session header row; run "openclaw doctor --fix" to repair it';
+  const LEGACY_TRANSCRIPT_ERROR =
+    "Persisted legacy session transcripts require doctor/import migration before runtime use";
+
+  it.each([
+    { name: "headerless transcript", message: HEADERLESS_TRANSCRIPT_ERROR },
+    { name: "legacy transcript", message: LEGACY_TRANSCRIPT_ERROR },
+  ])("classifies the $name load failure as actionable, not generic", ({ message }) => {
+    const reply = buildExternalRunFailureReply(message);
+    expect(reply.isGenericRunnerFailure).toBe(false);
+    expect(reply.text).toContain("openclaw doctor --fix");
+  });
+
+  it("keeps the repair notice visible in group conversations", () => {
+    const reply = buildExternalRunFailureReply(HEADERLESS_TRANSCRIPT_ERROR);
+    const visibleText = resolveExternalRunFailureTextForConversation({
+      text: reply.text,
+      sessionCtx: {
+        ChatType: "group",
+        Provider: "telegram",
+        SessionKey: "agent:main:telegram:group:example",
+        Surface: "telegram",
+      },
+      isGenericRunnerFailure: reply.isGenericRunnerFailure,
+    });
+    expect(visibleText).toBe(reply.text);
   });
 });

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -144,6 +144,18 @@ export function resolveExternalRunFailureTextForConversation(params: {
   return silentPolicy === "disallow" ? params.text : SILENT_REPLY_TOKEN;
 }
 
+const SESSION_TRANSCRIPT_REPAIR_REQUIRED_RE =
+  /\b(?:transcript has no session header row|Persisted legacy session transcripts require doctor\/import migration)\b/iu;
+
+// Session-hydration failures are permanent until repaired; classifying them as
+// generic would let group silent-reply policy hide the turn's failure entirely.
+function buildSessionTranscriptRepairFailureText(message: string): string | null {
+  if (!SESSION_TRANSCRIPT_REPAIR_REQUIRED_RE.test(collapseRepeatedFailureDetail(message))) {
+    return null;
+  }
+  return "⚠️ This chat's stored session history needs repair before I can reply. Run `openclaw doctor --fix` on the gateway, then send your message again.";
+}
+
 const CODEX_APP_SERVER_CLIENT_CLOSED_BEFORE_REPLY_RE =
   /\bcodex app-server client closed before turn completed\b/iu;
 const CODEX_APP_SERVER_TURN_COMPLETION_IDLE_TIMEOUT_RE =
@@ -316,6 +328,10 @@ export function buildExternalRunFailureReply(
   const codexAppServerFailure = buildCodexAppServerFailureText(normalizedMessage);
   if (codexAppServerFailure) {
     return { text: codexAppServerFailure, isGenericRunnerFailure: false };
+  }
+  const sessionTranscriptRepairFailure = buildSessionTranscriptRepairFailureText(normalizedMessage);
+  if (sessionTranscriptRepairFailure) {
+    return { text: sessionTranscriptRepairFailure, isGenericRunnerFailure: false };
   }
   const classifiedFailure = renderAssistantRequestFailureCopy(failoverFacts);
   if (classifiedFailure) {

--- a/src/auto-reply/reply/agent-runner-session-reset.test.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.test.ts
@@ -578,7 +578,7 @@ describe("resetReplyRunSession", () => {
     ).toMatchObject({ reason: "reset", firstKeptEntryId: expect.any(String) });
   });
 
-  it("migrates an unreadable legacy transcript target to the SQLite reset boundary", async () => {
+  it("migrates an unreadable legacy transcript target without minting a headerless boundary", async () => {
     const storePath = path.join(rootDir, "sessions.json");
     const unreadableReplaySource = path.join(rootDir, "previous-transcript-dir");
     await fs.mkdir(unreadableReplaySource);
@@ -609,6 +609,8 @@ describe("resetReplyRunSession", () => {
     });
 
     expect(activeSessionEntry).not.toHaveProperty("sessionFile");
+    // The never-materialized SQLite transcript must stay empty: a reset boundary at
+    // seq 0 would have no session header, and every later load rejects that shape.
     await expect(
       loadTranscriptEvents({
         agentId: "main",
@@ -616,7 +618,7 @@ describe("resetReplyRunSession", () => {
         sessionKey,
         storePath,
       }),
-    ).resolves.toEqual(expect.arrayContaining([expect.objectContaining({ type: "reset" })]));
+    ).resolves.toEqual([]);
   });
 
   it("replaces a SQLite marker for a different transcript target", async () => {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3675,6 +3675,12 @@ describe("initSessionState reset authorization", () => {
             }
           : {}),
       });
+      // Materialize the existing transcript so an allowed reset appends a durable
+      // boundary; a never-materialized transcript correctly gets none.
+      await appendTranscriptMessage(
+        { storePath, sessionId: existingSessionId, sessionKey },
+        { message: { role: "user", content: "existing turn" } },
+      );
       setActivePluginRegistry(
         createTestRegistry([
           {

--- a/src/commands/doctor-session-transcript-headers.test.ts
+++ b/src/commands/doctor-session-transcript-headers.test.ts
@@ -129,7 +129,7 @@ describe("doctor SQLite session transcript header repair", () => {
     }, databaseOptions);
 
     expect(() => SessionManager.open(scope, state.workspaceDir)).toThrow(
-      "require doctor/import migration before runtime use",
+      'no session header row; run "openclaw doctor --fix"',
     );
 
     await expect(
@@ -270,7 +270,7 @@ describe("doctor SQLite session transcript header repair", () => {
 
     expect(readTranscriptStorageRows(database, SESSION_ID)).toEqual(before);
     expect(() => SessionManager.open(scope, state.workspaceDir)).toThrow(
-      "require doctor/import migration before runtime use",
+      'no session header row; run "openclaw doctor --fix"',
     );
     expect(loadTranscriptEventsSync(scope)).toHaveLength(2);
     expect(note).not.toHaveBeenCalled();
@@ -317,7 +317,7 @@ describe("doctor SQLite session transcript header repair", () => {
 
     expect(readTranscriptStorageRows(database, SESSION_ID)).toEqual(before);
     expect(() => SessionManager.open(scope, state.workspaceDir)).toThrow(
-      "require doctor/import migration before runtime use",
+      'no session header row; run "openclaw doctor --fix"',
     );
     expect(note).not.toHaveBeenCalled();
   });

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -55,7 +55,6 @@ import {
 } from "./session-accessor.sqlite-lifecycle-state.js";
 import { refreshSqliteSessionPlannerStatisticsBestEffort } from "./session-accessor.sqlite-maintenance.js";
 import { deleteSessionDeliveryArtifacts } from "./session-accessor.sqlite-node-artifacts.js";
-import { loadTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
 import {
   cloneSessionEntry,
   getSessionKysely,
@@ -65,12 +64,11 @@ import {
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
 } from "./session-accessor.sqlite-scope.js";
-import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
+import { appendSessionResetBoundaryEventInTransaction } from "./session-accessor.sqlite-transcript-store.js";
 import {
   collectAdmissionProtectedSessionIds,
   kickSessionHistoryDiskBudgetMaintenance,
 } from "./session-history-eviction.js";
-import { buildSessionResetBoundaryEvent } from "./session-reset-boundary-event.js";
 import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
 // Single-target lifecycle owner: cleanup, reset, guarded delete, and trusted rollback.
@@ -223,24 +221,15 @@ export async function resetSessionEntryLifecycle(
       runOpenClawAgentWriteTransaction((transactionDb) => {
         assertLifecycleTargetUnchanged(transactionDb, params.target, current?.entry, "reset");
         if (shouldAppendResetBoundary && current?.entry.sessionId && params.resetBoundary) {
-          const event = buildSessionResetBoundaryEvent({
-            events: loadTranscriptEventsFromDatabase(transactionDb, current.entry.sessionId, {
-              projection: "reset-boundary",
-            }),
-            ...params.resetBoundary,
-          });
-          const appended = appendTranscriptEventsInTransaction(
+          appendSessionResetBoundaryEventInTransaction(
             transactionDb,
             {
               ...resolved,
               sessionId: current.entry.sessionId,
               sessionKey: current.sessionKey,
             },
-            [event],
+            params.resetBoundary,
           );
-          if (appended !== 1) {
-            throw new Error(`Failed to append reset boundary for ${current.sessionKey}`);
-          }
         }
         writeSessionEntry(transactionDb, params.target.canonicalKey, nextEntry, {
           previousEntry: current?.entry ?? null,

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -71,7 +71,6 @@ import {
   applySessionEntryMaintenance,
   finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort,
 } from "./session-accessor.sqlite-maintenance.js";
-import { loadTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
 import { applySessionEntryExactReplacements } from "./session-accessor.sqlite-replacement-projection.js";
 import {
   cloneSessionEntry,
@@ -81,8 +80,7 @@ import {
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
 } from "./session-accessor.sqlite-scope.js";
-import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
-import { buildSessionResetBoundaryEvent } from "./session-reset-boundary-event.js";
+import { appendSessionResetBoundaryEventInTransaction } from "./session-accessor.sqlite-transcript-store.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import type { ResolvedSessionMaintenanceConfig } from "./store-maintenance.js";
 import type { SessionEntry } from "./types.js";
@@ -400,20 +398,11 @@ export async function applySessionEntryLifecycleMutation(params: {
           throw new Error(`SQLite session entry has stale lifecycle state for ${sessionKey}`);
         }
         if (resetBoundary && expectedEntry?.sessionId) {
-          const event = buildSessionResetBoundaryEvent({
-            events: loadTranscriptEventsFromDatabase(transactionDb, expectedEntry.sessionId, {
-              projection: "reset-boundary",
-            }),
-            ...resetBoundary,
-          });
-          const appended = appendTranscriptEventsInTransaction(
+          appendSessionResetBoundaryEventInTransaction(
             transactionDb,
             { ...resolved, sessionId: expectedEntry.sessionId, sessionKey },
-            [event],
+            resetBoundary,
           );
-          if (appended !== 1) {
-            throw new Error(`Failed to append reset boundary for ${sessionKey}`);
-          }
         }
         writeSessionEntry(transactionDb, sessionKey, entry, {
           allowStoredAliases: params.allowCanonicalRepair === true,

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -20,6 +20,7 @@ import type {
 import {
   createTranscriptIdentityReader,
   findTranscriptEventInDatabase,
+  loadTranscriptEventsFromDatabase,
   readTranscriptEventId,
   readTranscriptEventMessage,
   readTranscriptIdentityByEventId,
@@ -36,6 +37,10 @@ import {
   rotateTranscriptGenerationInTransaction,
   touchTranscriptMutationInTransaction,
 } from "./session-accessor.sqlite-transcript-state.js";
+import {
+  buildSessionResetBoundaryEvent,
+  type SessionResetBoundaryRequest,
+} from "./session-reset-boundary-event.js";
 import {
   createTranscriptIndexAppenderInTransaction,
   deleteSessionTranscriptIndexInTransaction,
@@ -266,6 +271,26 @@ export function appendTranscriptEventsInTransaction(
     );
   }
   return appended;
+}
+
+/** Appends one reset boundary to the session's transcript; a transcript with nothing to reset gets none. */
+export function appendSessionResetBoundaryEventInTransaction(
+  database: OpenClawAgentDatabase,
+  scope: ResolvedTranscriptScope,
+  request: SessionResetBoundaryRequest,
+): void {
+  const boundary = buildSessionResetBoundaryEvent({
+    events: loadTranscriptEventsFromDatabase(database, scope.sessionId, {
+      projection: "reset-boundary",
+    }),
+    ...request,
+  });
+  if (!boundary) {
+    return;
+  }
+  if (appendTranscriptEventsInTransaction(database, scope, [boundary]) !== 1) {
+    throw new Error(`Failed to append reset boundary for ${scope.sessionKey}`);
+  }
 }
 
 function appendTranscriptEventRowInTransaction(

--- a/src/config/sessions/session-accessor.transcript-header-invariant.test.ts
+++ b/src/config/sessions/session-accessor.transcript-header-invariant.test.ts
@@ -1,0 +1,91 @@
+// A transcript's first persisted row must be the canonical session header. Reset
+// boundaries against a never-materialized transcript used to land at seq 0 without
+// one, permanently wedging every later session load.
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import {
+  applySessionEntryLifecycleMutation,
+  loadTranscriptEvents,
+  resetSessionEntryLifecycle,
+  upsertSessionEntryCore,
+} from "./session-accessor.js";
+import { appendTranscriptMessageSync } from "./session-accessor.sqlite-transcript-write.js";
+
+describe("transcript header invariant", () => {
+  const tempDirs: string[] = [];
+  let storePath: string;
+
+  beforeEach(() => {
+    storePath = path.join(makeTempDir(tempDirs, "openclaw-transcript-header-"), "sessions.json");
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    cleanupTempDirs(tempDirs);
+  });
+
+  function makeScope(name: string) {
+    return {
+      agentId: "main",
+      sessionId: `${name}-session`,
+      sessionKey: `agent:main:${name}`,
+      storePath,
+    };
+  }
+
+  it("appends no reset boundary to a never-materialized transcript on single reset", async () => {
+    const scope = makeScope("single-reset-empty");
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 10 });
+
+    await resetSessionEntryLifecycle({
+      buildNextEntry: () => ({ sessionId: scope.sessionId, updatedAt: 20 }),
+      resetBoundary: { context: "clear", reason: "new" },
+      storePath,
+      target: { canonicalKey: scope.sessionKey, storeKeys: [scope.sessionKey] },
+    });
+
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([]);
+  });
+
+  it("appends no reset boundary to a never-materialized transcript on bulk lifecycle reset", async () => {
+    const scope = makeScope("bulk-reset-empty");
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 10 });
+
+    await applySessionEntryLifecycleMutation({
+      skipMaintenance: true,
+      storePath,
+      upserts: [
+        {
+          entry: { sessionId: scope.sessionId, updatedAt: 20 },
+          resetBoundary: { context: "preserve-tail", reason: "daily" },
+          sessionKey: scope.sessionKey,
+        },
+      ],
+    });
+
+    await expect(loadTranscriptEvents(scope)).resolves.toEqual([]);
+  });
+
+  it("still appends a reset boundary once the transcript has real entries", async () => {
+    const scope = makeScope("materialized-reset");
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 10 });
+    appendTranscriptMessageSync(scope, {
+      eventId: "first-message",
+      message: { role: "user", content: "hello" },
+      parentId: null,
+    });
+
+    await resetSessionEntryLifecycle({
+      buildNextEntry: () => ({ sessionId: scope.sessionId, updatedAt: 20 }),
+      resetBoundary: { context: "clear", reason: "new" },
+      storePath,
+      target: { canonicalKey: scope.sessionKey, storeKeys: [scope.sessionKey] },
+    });
+
+    const events = await loadTranscriptEvents(scope);
+    expect(events[0]).toMatchObject({ type: "session" });
+    expect(events.at(-1)).toMatchObject({ type: "reset", reason: "new" });
+  });
+});

--- a/src/config/sessions/session-reset-boundary-event.test.ts
+++ b/src/config/sessions/session-reset-boundary-event.test.ts
@@ -18,6 +18,27 @@ function message(params: {
 }
 
 describe("reset boundary planning", () => {
+  it("builds no boundary for a transcript with nothing to reset", () => {
+    expect(
+      buildSessionResetBoundaryEvent({ context: "clear", events: [], reason: "new" }),
+    ).toBeUndefined();
+    expect(
+      buildSessionResetBoundaryEvent({
+        context: "preserve-tail",
+        events: [
+          {
+            type: "session",
+            version: 3,
+            id: "session-id",
+            timestamp: "2026-07-22T00:00:00.000Z",
+            cwd: "/workspace",
+          },
+        ],
+        reason: "daily",
+      }),
+    ).toBeUndefined();
+  });
+
   it.each(["new", "reset"] as const)(
     "cuts prior conversation context for explicit %s boundaries",
     async (reason) => {

--- a/src/config/sessions/session-reset-boundary-event.ts
+++ b/src/config/sessions/session-reset-boundary-event.ts
@@ -73,7 +73,7 @@ export function buildSessionResetBoundaryEvent(
   params: {
     events: readonly unknown[];
   } & SessionResetBoundaryRequest,
-): SessionResetBoundaryEvent {
+): SessionResetBoundaryEvent | undefined {
   const entries = params.events.filter(
     (event) =>
       event !== null &&
@@ -81,6 +81,12 @@ export function buildSessionResetBoundaryEvent(
       !Array.isArray(event) &&
       (event as { type?: unknown }).type !== "session",
   );
+  // A transcript with no boundary-relevant entries has nothing to reset. Appending a
+  // boundary anyway would materialize a headerless transcript, which every later
+  // load rejects until doctor repairs it.
+  if (entries.length === 0) {
+    return undefined;
+  }
   const activeEntries = selectSessionTranscriptLeafControlledPath(entries) ?? entries;
   const keptEntries =
     params.context === "preserve-tail"


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Telegram (or any channel) group agent would permanently stop replying: every message showed a typing indicator, then nothing — no reply, no error, forever. `/new` did not help.

Two defects combine into that outcome:

1. **A `/new` or daily reset against a session whose SQLite transcript was never materialized poisons the transcript.** `resetSessionEntryLifecycle` and `applySessionEntryLifecycleMutation` append the reset boundary via `appendTranscriptEventsInTransaction`, bypassing SessionManager's pending-header flush. When the session entry has a `sessionId` but zero `transcript_events` rows (durable resets reuse the sessionId, so a never-run session hits this), the boundary lands at seq 0 with no `{"type":"session"}` header. `ensureTranscriptHeader` is a first-row guard, not a header guard, so no later write can repair it. Every subsequent load in `SessionManagerCore.setLoadedSessionTarget` then defaults the missing header to version 1 and throws `Persisted legacy session transcripts require doctor/import migration before runtime use` — on every turn. #115080 added the doctor repair for this state but not the producer fix, so new corruption is still minted on `main`.

2. **The per-turn failure is invisible to the user.** The session-lane throw is classified as a generic runner failure, and the group silent-reply policy replaces generic failure text with `NO_REPLY` (`resolveExternalRunFailureTextForConversation`); the dispatch-level no-visible-reply fallback is directedness-gated and also stays silent for an unmentioned group turn. The turn ends with `visible channel turn dispatched with no queued reply payloads` in the logs and nothing in the chat.

Observed on a live gateway (2026.7.2-beta.5): one bot wedged mid-conversation, and a scan found **11 headerless transcripts across 4 agents** — every one starts with a reset boundary written by `/new`/daily resets against an empty transcript, with daily resets appending further boundaries to the already-poisoned transcripts each night.

## Why This Change Was Made

Repairing at the producer and making the failure visible, rather than compensating downstream:

- `buildSessionResetBoundaryEvent` now returns `undefined` when the transcript has no boundary-relevant entries — a reset of nothing is a no-op, not a seq-0 poison row. Both call sites collapse into one owner helper, `appendSessionResetBoundaryEventInTransaction` (removes the duplicated load/build/append/assert block).
- `SessionManagerCore.setLoadedSessionTarget` distinguishes a **headerless** transcript from a genuinely **legacy-versioned** one: headerless now throws `Persisted session transcript has no session header row; run "openclaw doctor --fix" to repair it` — naming the doctor rule (`session-transcript-headers`, from #115080) that actually repairs that exact state. Runtime still fails closed; doctor stays the repair owner.
- `buildExternalRunFailureReply` classifies both transcript-repair load failures as actionable (`isGenericRunnerFailure: false`) with copy naming `openclaw doctor --fix`, so the failure is visible in group chats instead of being silenced to `NO_REPLY` — same pattern as the existing OAuth/CLI-timeout/Codex classifiers.

Accepted tradeoffs, named:

- No hard header guard was added inside `appendTranscriptEventInTransaction`: bulk writers (archives, imports, doctor rewrites, forks) legitimately stream raw rows through it, and a prototype guard there broke 29 owner-suite tests. The two remaining stray side-append writers (`feedback-reflection`, `conversation-turn-capture`) can only run after a delivered turn, i.e. on an already-materialized transcript.
- The dispatch-level no-visible-reply fallback stays directedness-gated (it carries an explicit design comment). A turn admitted **without** an explicit mention that terminally fails with zero visible output still ends silent for *other* failure classes — flagged as a follow-up for maintainer judgment rather than flipped here.

## User Impact

- `/new` and daily resets no longer permanently wedge sessions that have not produced a turn yet (and no longer grow boundary-spam transcripts night after night).
- An already-poisoned session now tells the chat exactly what to do: run `openclaw doctor --fix` — instead of showing typing and going silent.
- Gateway logs for this state now name the actual repair command instead of pointing at import migration, which does not handle it.

## Evidence

- Every new regression test was verified to fail on pre-fix code for the intended reason, including the group-visibility test whose pre-fix output is literally `NO_REPLY`, and the invariant tests that observe the poisoned seq-0 boundary row.
- Suites: full `src/config/sessions` owner suite (105 files / 1255 tests), `session-manager.test.ts`, `agent-runner-failure-reply.test.ts`, `agent-runner-session-reset.test.ts`, `doctor-session-transcript-headers.test.ts` (doctor repair still detects and repairs the seeded corrupt state), `run-session-state.test.ts` — all green.
- `pnpm check:changed`, `pnpm tsgo:core`, `pnpm tsgo:test:src`, `pnpm check:import-cycles`, `pnpm build` — green.
- Codex autoreview (gpt-5.6-sol, high): clean, no accepted findings.
- Two pre-existing tests protected the corrupting behavior: `agent-runner-session-reset.test.ts` asserted the boundary lands in the empty migrated transcript, and `session.test.ts`'s reset-authorization cases asserted it lands in a zero-row existing session — both exactly the headerless seq-0 poison. The first now asserts the transcript stays empty; the second seeds one message first so an allowed reset still proves a durable boundary on a real conversation.
- Live-flow proof note: after the producer fix, the corrupt state is not reachable through any real channel flow, so channel-visible proof of the error copy uses the classifier/visibility unit tests plus direct-DB seeding at the `SessionManager.open` and doctor boundaries; the pre-fix silent behavior is additionally documented by live gateway logs (`lane task error` + `visible channel turn dispatched with no queued reply payloads` with zero deliveries).

Production LOC: +58 / −25 (net +33; the classifier and the split error message are the growth — new user-facing failure surface; the boundary path itself is net negative via the shared helper). Tests: +~100.
