### PR TITLE
refactor(twitch): consolidate inbound and outbound sending

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3451,14 +3451,14 @@ jobs:
                   root_covered=true
                 fi
               fi
-              if pnpm run --silent 2>/dev/null | grep -q '^  tsgo:scripts$'; then
+              if has_package_script "tsgo:scripts"; then
                 pnpm tsgo:scripts
               elif [[ "$HISTORICAL_TARGET" != "true" ]]; then
                 echo "Current CI targets must provide the tsgo:scripts package script." >&2
                 exit 1
               fi
               if [ "$root_covered" != "true" ]; then
-                if pnpm run --silent 2>/dev/null | grep -q '^  tsgo:test:root$'; then
+                if has_package_script "tsgo:test:root"; then
                   pnpm tsgo:test:root
                 elif [[ "$HISTORICAL_TARGET" != "true" ]]; then
                   echo "Current CI targets must provide the tsgo:test:root package script." >&2

--- a/extensions/twitch/src/client-manager-registry.test.ts
+++ b/extensions/twitch/src/client-manager-registry.test.ts
@@ -6,7 +6,7 @@ import {
   getOrCreateClientManager,
   removeClientManager,
 } from "./client-manager-registry.js";
-import { sendMessageTwitchInternal } from "./send.js";
+import { twitchOutbound } from "./outbound.js";
 import { BASE_TWITCH_TEST_ACCOUNT, makeTwitchTestConfig } from "./test-fixtures.js";
 import type { ChannelLogSink, TwitchAccountConfig } from "./types.js";
 
@@ -108,33 +108,30 @@ describe("client manager registry", () => {
     const removal = removeClientManager("default");
 
     try {
-      const whileRetiring = await sendMessageTwitchInternal(
-        "#testchannel",
-        "while retiring",
-        config,
-        "default",
-        false,
+      await expect(
+        twitchOutbound.sendText!({
+          to: "#testchannel",
+          text: "while retiring",
+          cfg: config,
+          accountId: "default",
+        }),
+      ).rejects.toThrow(
+        "Client manager not found for account: default. Please start the Twitch gateway first.",
       );
-
-      expect(whileRetiring).toMatchObject({
-        ok: false,
-        error:
-          "Client manager not found for account: default. Please start the Twitch gateway first.",
-      });
       expect(reconnect).not.toHaveBeenCalled();
       expect(first.transport.say).not.toHaveBeenCalled();
 
       const replacement = getOrCreateClientManager("default", makeLogger());
       const { transport } = attachFakeTransport(replacement);
-      const afterRestart = await sendMessageTwitchInternal(
-        "#testchannel",
-        "after restart",
-        config,
-        "default",
-        false,
-      );
+      const afterRestart = await twitchOutbound.sendText!({
+        to: "#testchannel",
+        text: "after restart",
+        cfg: config,
+        accountId: "default",
+      });
 
-      expect(afterRestart.ok).toBe(true);
+      expect(afterRestart.messageId).toEqual(expect.any(String));
+      expect(afterRestart.receipt?.platformMessageIds).toEqual([afterRestart.messageId]);
       expect(transport.say).toHaveBeenCalledWith("testchannel", "after restart");
 
       cleanup.resolve();

--- a/extensions/twitch/src/monitor.test.ts
+++ b/extensions/twitch/src/monitor.test.ts
@@ -129,9 +129,6 @@ describe("monitorTwitchProvider", () => {
           resolveStorePath: vi.fn(() => "/tmp/sessions.json"),
           recordInboundSession: vi.fn(),
         },
-        text: {
-          resolveMarkdownTableMode: vi.fn(() => "off"),
-        },
       },
     });
   });

--- a/extensions/twitch/src/monitor.ts
+++ b/extensions/twitch/src/monitor.ts
@@ -7,7 +7,7 @@
 
 import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import { createChannelInboundEnvelopeBuilder } from "openclaw/plugin-sdk/channel-inbound";
-import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { resolveOutboundMediaUrls } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
@@ -15,9 +15,9 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { checkTwitchAccessControl } from "./access-control.js";
 import { getOrCreateClientManager } from "./client-manager-registry.js";
 import { getTwitchRuntime } from "./runtime.js";
+import { sendMessageTwitchInternal } from "./send.js";
 import { createTwitchIngress } from "./twitch-ingress.js";
 import type { TwitchAccountConfig, TwitchChatMessage } from "./types.js";
-import { stripMarkdownForTwitch } from "./utils/markdown.js";
 
 type TwitchRuntimeEnv = {
   log?: (message: string) => void;
@@ -145,11 +145,6 @@ async function processTwitchMessage(params: {
             commandBody: input.textForCommands,
           },
         });
-        const tableMode = channelRuntime.text.resolveMarkdownTableMode({
-          cfg,
-          channel: "twitch",
-          accountId,
-        });
         return {
           cfg,
           channel: "twitch",
@@ -167,7 +162,6 @@ async function processTwitchMessage(params: {
                 account,
                 accountId,
                 config,
-                tableMode,
                 runtime,
               });
             },
@@ -201,7 +195,6 @@ async function deliverTwitchReply(params: {
   account: TwitchAccountConfig;
   accountId: string;
   config: unknown;
-  tableMode: MarkdownTableMode;
   runtime: TwitchRuntimeEnv;
 }): Promise<{ visibleReplySent: boolean }> {
   const { payload, channel, account, accountId, config, runtime } = params;
@@ -214,22 +207,17 @@ async function deliverTwitchReply(params: {
       debug: (msg) => runtime.log?.(msg),
     });
 
-    const textToSend = stripMarkdownForTwitch(
-      [payload.text, ...resolveOutboundMediaUrls(payload)].filter(Boolean).join(" "),
-    );
-    if (!textToSend) {
+    const result = await sendMessageTwitchInternal({
+      channel,
+      text: [payload.text, ...resolveOutboundMediaUrls(payload)].filter(Boolean).join(" "),
+      cfg: config as OpenClawConfig,
+      account,
+      accountId,
+      clientManager,
+    });
+    if (result.outcome === "not_sent") {
       runtime.error?.(`No text to send in reply payload`);
       return { visibleReplySent: false };
-    }
-    const result = await clientManager.sendMessage(
-      account,
-      channel,
-      textToSend,
-      config as Parameters<typeof clientManager.sendMessage>[3],
-      accountId,
-    );
-    if (!result.ok) {
-      throw new Error(result.error ?? "Send failed");
     }
     return { visibleReplySent: true };
   } catch (err) {

--- a/extensions/twitch/src/outbound.test.ts
+++ b/extensions/twitch/src/outbound.test.ts
@@ -86,6 +86,7 @@ describe("outbound", () => {
 
   function setupAccountContext(params?: {
     account?: typeof mockAccount | null;
+    configured?: boolean;
     availableAccountIds?: string[];
   }) {
     const account = params?.account === undefined ? mockAccount : params.account;
@@ -93,7 +94,7 @@ describe("outbound", () => {
       accountId: accountId?.trim() || "default",
       account,
       tokenResolution: { source: "config", token: account?.accessToken ?? "" },
-      configured: account !== null,
+      configured: account ? (params?.configured ?? true) : false,
       availableAccountIds: params?.availableAccountIds ?? ["default"],
     }));
   }
@@ -148,7 +149,6 @@ describe("outbound", () => {
       setupAccountContext();
       const receipt = twitchTestReceipt("twitch-msg-123");
       vi.mocked(sendMessageTwitchInternal).mockResolvedValue({
-        ok: true,
         messageId: "twitch-msg-123",
         receipt,
       });
@@ -184,14 +184,14 @@ describe("outbound", () => {
               timestamp: expect.any(Number),
             });
             expect(result?.receipt.parts.map((part) => part.kind)).toEqual(["text"]);
-            expect(sendMessageTwitchInternal).toHaveBeenLastCalledWith(
-              "testchannel",
-              "image https://example.com/image.png",
-              mockConfig,
-              "default",
-              true,
-              console,
-            );
+            expect(sendMessageTwitchInternal).toHaveBeenLastCalledWith({
+              channel: "testchannel",
+              text: "image https://example.com/image.png",
+              cfg: mockConfig,
+              account: mockAccount,
+              accountId: "default",
+              clientManager: undefined,
+            });
           },
           messageSendingHooks: () => {
             expect(twitchMessageAdapter.durableFinal?.capabilities?.messageSendingHooks).toBe(true);
@@ -343,7 +343,6 @@ describe("outbound", () => {
       const { sendMessageTwitchInternal } = await import("./send.js");
       setupAccountContext();
       vi.mocked(sendMessageTwitchInternal).mockResolvedValue({
-        ok: true,
         outcome: "not_sent",
         messageId: "",
         receipt: createMessageReceiptFromOutboundResults({ results: [] }),
@@ -368,7 +367,6 @@ describe("outbound", () => {
 
       setupAccountContext();
       vi.mocked(sendMessageTwitchInternal).mockResolvedValue({
-        ok: true,
         messageId: "twitch-msg-123",
         receipt: twitchTestReceipt("twitch-msg-123"),
       });
@@ -383,14 +381,14 @@ describe("outbound", () => {
       expect(result.channel).toBe("twitch");
       expect(result.messageId).toBe("twitch-msg-123");
       expect(result.receipt?.platformMessageIds).toEqual(["twitch-msg-123"]);
-      expect(sendMessageTwitchInternal).toHaveBeenCalledWith(
-        "testchannel",
-        "Hello Twitch!",
-        mockConfig,
-        "default",
-        true,
-        console,
-      );
+      expect(sendMessageTwitchInternal).toHaveBeenCalledWith({
+        channel: "testchannel",
+        text: "Hello Twitch!",
+        cfg: mockConfig,
+        account: mockAccount,
+        accountId: "default",
+        clientManager: undefined,
+      });
       expect(result.timestamp).toBeGreaterThan(0);
     });
 
@@ -421,12 +419,28 @@ describe("outbound", () => {
       ).rejects.toThrow("No channel specified");
     });
 
+    it("rejects an unconfigured account before attempting delivery", async () => {
+      const { sendMessageTwitchInternal } = await import("./send.js");
+      setupAccountContext({ configured: false });
+
+      await expect(
+        twitchOutbound.sendText!({
+          cfg: mockConfig,
+          to: "#testchannel",
+          text: "Hello!",
+          accountId: "default",
+        }),
+      ).rejects.toThrow(
+        "Account default is not properly configured. Required: username, clientId, and token (config or env for default account).",
+      );
+      expect(sendMessageTwitchInternal).not.toHaveBeenCalled();
+    });
+
     it("should use account channel when target not provided", async () => {
       const { sendMessageTwitchInternal } = await import("./send.js");
 
       setupAccountContext();
       vi.mocked(sendMessageTwitchInternal).mockResolvedValue({
-        ok: true,
         messageId: "msg-456",
         receipt: twitchTestReceipt("msg-456"),
       });
@@ -438,14 +452,14 @@ describe("outbound", () => {
         accountId: "default",
       });
 
-      expect(sendMessageTwitchInternal).toHaveBeenCalledWith(
-        "testchannel",
-        "Hello!",
-        mockConfig,
-        "default",
-        true,
-        console,
-      );
+      expect(sendMessageTwitchInternal).toHaveBeenCalledWith({
+        channel: "testchannel",
+        text: "Hello!",
+        cfg: mockConfig,
+        account: mockAccount,
+        accountId: "default",
+        clientManager: undefined,
+      });
     });
 
     it("uses configured defaultAccount when accountId is omitted", async () => {
@@ -473,7 +487,6 @@ describe("outbound", () => {
           availableAccountIds: ["default", "secondary"],
         }));
       vi.mocked(sendMessageTwitchInternal).mockResolvedValue({
-        ok: true,
         messageId: "msg-secondary",
         receipt: twitchTestReceipt("msg-secondary"),
       });
@@ -492,26 +505,21 @@ describe("outbound", () => {
         text: "Hello!",
       });
 
-      expect(sendMessageTwitchInternal).toHaveBeenCalledWith(
-        "secondary-channel",
-        "Hello!",
-        defaultAccountConfig,
-        "secondary",
-        true,
-        console,
-      );
+      expect(sendMessageTwitchInternal).toHaveBeenCalledWith({
+        channel: "secondary-channel",
+        text: "Hello!",
+        cfg: defaultAccountConfig,
+        account: { ...mockAccount, channel: "secondary-channel" },
+        accountId: "secondary",
+        clientManager: undefined,
+      });
     });
 
     it("should throw on send failure", async () => {
       const { sendMessageTwitchInternal } = await import("./send.js");
 
       setupAccountContext();
-      vi.mocked(sendMessageTwitchInternal).mockResolvedValue({
-        ok: false,
-        messageId: "failed-msg",
-        receipt: createMessageReceiptFromOutboundResults({ results: [] }),
-        error: "Connection lost",
-      });
+      vi.mocked(sendMessageTwitchInternal).mockRejectedValue(new Error("Connection lost"));
 
       await expect(
         twitchOutbound.sendText!({
@@ -530,7 +538,6 @@ describe("outbound", () => {
 
       setupAccountContext();
       vi.mocked(sendMessageTwitchInternal).mockResolvedValue({
-        ok: true,
         messageId: "media-msg-123",
         receipt: twitchTestReceipt("media-msg-123"),
       });
@@ -546,14 +553,14 @@ describe("outbound", () => {
       expect(result.channel).toBe("twitch");
       expect(result.messageId).toBe("media-msg-123");
       expect(result.receipt?.platformMessageIds).toEqual(["media-msg-123"]);
-      expect(sendMessageTwitchInternal).toHaveBeenCalledWith(
-        "testchannel",
-        "Check this: https://example.com/image.png",
-        mockConfig,
-        "default",
-        true,
-        console,
-      );
+      expect(sendMessageTwitchInternal).toHaveBeenCalledWith({
+        channel: "testchannel",
+        text: "Check this: https://example.com/image.png",
+        cfg: mockConfig,
+        account: mockAccount,
+        accountId: "default",
+        clientManager: undefined,
+      });
     });
 
     it("should send media URL only when no text", async () => {
@@ -561,7 +568,6 @@ describe("outbound", () => {
 
       setupAccountContext();
       vi.mocked(sendMessageTwitchInternal).mockResolvedValue({
-        ok: true,
         messageId: "media-only-msg",
         receipt: twitchTestReceipt("media-only-msg"),
       });
@@ -574,14 +580,14 @@ describe("outbound", () => {
         accountId: "default",
       });
 
-      expect(sendMessageTwitchInternal).toHaveBeenCalledWith(
-        "testchannel",
-        "https://example.com/image.png",
-        mockConfig,
-        "default",
-        true,
-        console,
-      );
+      expect(sendMessageTwitchInternal).toHaveBeenCalledWith({
+        channel: "testchannel",
+        text: "https://example.com/image.png",
+        cfg: mockConfig,
+        account: mockAccount,
+        accountId: "default",
+        clientManager: undefined,
+      });
     });
   });
 });

--- a/extensions/twitch/src/outbound.ts
+++ b/extensions/twitch/src/outbound.ts
@@ -8,6 +8,7 @@
 import { createChannelMessageAdapterFromOutbound } from "openclaw/plugin-sdk/channel-outbound";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
+import { getClientManager } from "./client-manager-registry.js";
 import { resolveTwitchAccountContext } from "./config.js";
 import { TWITCH_CHAT_MESSAGE_LIMIT } from "./constants.js";
 import { sendMessageTwitchInternal } from "./send.js";
@@ -101,7 +102,7 @@ export const twitchOutbound: ChannelOutboundAdapter = {
   /**
    * Send a text message to a Twitch channel.
    *
-   * Strips markdown if enabled, validates account configuration,
+   * Strips Markdown, validates account configuration,
    * and sends the message via the Twitch client.
    *
    * @param params - Send parameters including target, text, and config
@@ -124,7 +125,12 @@ export const twitchOutbound: ChannelOutboundAdapter = {
     }
 
     const resolvedAccountId = accountId ?? resolveTwitchAccountContext(cfg).accountId;
-    const { account, availableAccountIds } = resolveTwitchAccountContext(cfg, resolvedAccountId);
+    const {
+      account,
+      accountId: normalizedAccountId,
+      availableAccountIds,
+      configured,
+    } = resolveTwitchAccountContext(cfg, resolvedAccountId);
     if (!account) {
       throw new Error(
         `Twitch account not found: ${resolvedAccountId}. ` +
@@ -137,18 +143,25 @@ export const twitchOutbound: ChannelOutboundAdapter = {
       throw new Error("No channel specified and no default channel in account config");
     }
 
-    const result = await sendMessageTwitchInternal(
-      normalizeTwitchChannel(channel),
+    if (!configured) {
+      throw new Error(
+        `Account ${normalizedAccountId} is not properly configured. ` +
+          "Required: username, clientId, and token (config or env for default account).",
+      );
+    }
+    // A target that normalizes to empty still uses the account's default channel.
+    const deliveryChannel = normalizeTwitchChannel(channel) || account.channel;
+    if (!deliveryChannel) {
+      throw new Error("No channel specified and no default channel in account config");
+    }
+    const result = await sendMessageTwitchInternal({
+      channel: normalizeTwitchChannel(deliveryChannel),
       text,
       cfg,
-      resolvedAccountId,
-      true, // stripMarkdown
-      console,
-    );
-
-    if (!result.ok) {
-      throw new Error(result.error ?? "Send failed");
-    }
+      account,
+      accountId: normalizedAccountId,
+      clientManager: getClientManager(normalizedAccountId),
+    });
 
     return {
       channel: "twitch",

--- a/extensions/twitch/src/send.test.ts
+++ b/extensions/twitch/src/send.test.ts
@@ -1,351 +1,134 @@
-/**
- * Tests for send.ts module
- *
- * Tests cover:
- * - Message sending with valid configuration
- * - Account resolution and validation
- * - Channel normalization
- * - Markdown stripping
- * - Error handling for missing/invalid accounts
- * - Registry integration
- */
-
-import { describe, expect, it, vi } from "vitest";
-import { getClientManager } from "./client-manager-registry.js";
-import { resolveTwitchAccountContext } from "./config.js";
+import { beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 import { sendMessageTwitchInternal } from "./send.js";
 import {
   BASE_TWITCH_TEST_ACCOUNT,
   installTwitchTestHooks,
   makeTwitchTestConfig,
 } from "./test-fixtures.js";
-import { stripMarkdownForTwitch } from "./utils/markdown.js";
+import { TwitchClientManager } from "./twitch-client.js";
 
-// Mock dependencies
-vi.mock("./config.js", () => ({
-  DEFAULT_ACCOUNT_ID: "default",
-  resolveTwitchAccountContext: vi.fn(),
-}));
-
-vi.mock("./utils/twitch.js", () => ({
-  generateMessageId: vi.fn(() => "test-msg-id"),
-  normalizeTwitchChannel: (channel: string) => channel.toLowerCase().replace(/^#/, ""),
-}));
-
-vi.mock("./utils/markdown.js", () => ({
-  stripMarkdownForTwitch: vi.fn((text: string) => text.replace(/\*\*/g, "")),
-}));
-
-vi.mock("./client-manager-registry.js", () => ({
-  getClientManager: vi.fn(),
-}));
-
-describe("send", () => {
-  const mockLogger = {
+describe("sendMessageTwitchInternal", () => {
+  const logger = {
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
     debug: vi.fn(),
   };
-
-  const mockAccount = {
-    ...BASE_TWITCH_TEST_ACCOUNT,
-    accessToken: "test123",
+  const account = { ...BASE_TWITCH_TEST_ACCOUNT, accessToken: "test123" };
+  const cfg = makeTwitchTestConfig(account);
+  const clientManager = new TwitchClientManager(logger);
+  let sendMessageSpy: MockInstance<TwitchClientManager["sendMessage"]>;
+  const params = {
+    channel: "testchannel",
+    text: "Hello Twitch!",
+    cfg,
+    account,
+    accountId: "default",
+    clientManager,
   };
-
-  const mockConfig = makeTwitchTestConfig(mockAccount);
   installTwitchTestHooks();
+  beforeEach(() => {
+    sendMessageSpy = vi
+      .spyOn(clientManager, "sendMessage")
+      .mockResolvedValue({ ok: true, messageId: "twitch-msg-123" });
+  });
 
-  describe("sendMessageTwitchInternal", () => {
-    function setupAccountContext(params?: {
-      account?: typeof mockAccount | null;
-      configured?: boolean;
-      availableAccountIds?: string[];
-    }) {
-      const account = params?.account === undefined ? mockAccount : params.account;
-      vi.mocked(resolveTwitchAccountContext).mockImplementation((_cfg, accountId) => ({
-        accountId: accountId?.trim() || "default",
-        account,
-        tokenResolution: { source: "config", token: account?.accessToken ?? "" },
-        configured: account ? (params?.configured ?? true) : false,
-        availableAccountIds: params?.availableAccountIds ?? ["default"],
-      }));
-    }
+  it("returns a receipt for the delivered message", async () => {
+    const result = await sendMessageTwitchInternal(params);
 
-    async function mockSuccessfulSend(params: {
-      messageId: string;
-      stripMarkdown?: (text: string) => string;
-    }) {
-      setupAccountContext();
-      vi.mocked(getClientManager).mockReturnValue({
-        sendMessage: vi.fn().mockResolvedValue({
-          ok: true,
-          messageId: params.messageId,
-        }),
-      } as unknown as ReturnType<typeof getClientManager>);
-      vi.mocked(stripMarkdownForTwitch).mockImplementation(
-        params.stripMarkdown ?? ((text) => text),
-      );
-
-      return { stripMarkdownForTwitch };
-    }
-
-    it("should send a message successfully", async () => {
-      await mockSuccessfulSend({ messageId: "twitch-msg-123" });
-
-      const result = await sendMessageTwitchInternal(
-        "#testchannel",
-        "Hello Twitch!",
-        mockConfig,
-        "default",
-        false,
-        mockLogger as unknown as Console,
-      );
-
-      expect(result.ok).toBe(true);
-      expect(result.messageId).toBe("twitch-msg-123");
-      expect(typeof result.receipt.sentAt).toBe("number");
-      expect({ ...result.receipt, sentAt: 0 }).toEqual({
-        primaryPlatformMessageId: "twitch-msg-123",
-        platformMessageIds: ["twitch-msg-123"],
-        parts: [
-          {
-            platformMessageId: "twitch-msg-123",
-            kind: "text",
-            index: 0,
-            raw: {
-              channel: "twitch",
-              conversationId: "testchannel",
-              messageId: "twitch-msg-123",
-            },
-          },
-        ],
-        raw: [
-          {
+    expect(result.messageId).toBe("twitch-msg-123");
+    expect(typeof result.receipt.sentAt).toBe("number");
+    expect({ ...result.receipt, sentAt: 0 }).toEqual({
+      primaryPlatformMessageId: "twitch-msg-123",
+      platformMessageIds: ["twitch-msg-123"],
+      parts: [
+        {
+          platformMessageId: "twitch-msg-123",
+          kind: "text",
+          index: 0,
+          raw: {
             channel: "twitch",
             conversationId: "testchannel",
             messageId: "twitch-msg-123",
           },
-        ],
-        sentAt: 0,
+        },
+      ],
+      raw: [
+        {
+          channel: "twitch",
+          conversationId: "testchannel",
+          messageId: "twitch-msg-123",
+        },
+      ],
+      sentAt: 0,
+    });
+    expect(sendMessageSpy).toHaveBeenCalledExactlyOnceWith(
+      account,
+      "testchannel",
+      "Hello Twitch!",
+      cfg,
+      "default",
+    );
+  });
+
+  it.each([
+    ["**Bold** text", "Bold text"],
+    ["[link](https://example.com)", "link (https://example.com)"],
+    ["`---`", "---"],
+  ])("strips Markdown once from %s", async (text, expected) => {
+    await sendMessageTwitchInternal({ ...params, text });
+
+    expect(sendMessageSpy).toHaveBeenCalledExactlyOnceWith(
+      account,
+      "testchannel",
+      expected,
+      cfg,
+      "default",
+    );
+  });
+
+  it.each([true, false])(
+    "keeps empty Markdown unsent with a manager present: %s",
+    async (hasManager) => {
+      const result = await sendMessageTwitchInternal({
+        ...params,
+        text: "---",
+        clientManager: hasManager ? clientManager : undefined,
       });
-    });
 
-    it("should strip markdown when enabled", async () => {
-      const { stripMarkdownForTwitch: stripMarkdownForTwitchLocal } = await mockSuccessfulSend({
-        messageId: "twitch-msg-456",
-        stripMarkdown: (text) => text.replace(/\*\*/g, ""),
-      });
-
-      await sendMessageTwitchInternal(
-        "#testchannel",
-        "**Bold** text",
-        mockConfig,
-        "default",
-        true,
-        mockLogger as unknown as Console,
-      );
-
-      expect(stripMarkdownForTwitchLocal).toHaveBeenCalledWith("**Bold** text");
-    });
-
-    it("should return error when account not found", async () => {
-      setupAccountContext({ account: null });
-
-      const result = await sendMessageTwitchInternal(
-        "#testchannel",
-        "Hello!",
-        mockConfig,
-        "nonexistent",
-        false,
-        mockLogger as unknown as Console,
-      );
-
-      expect(result.ok).toBe(false);
-      expect(result.error).toContain("Account not found: nonexistent");
-    });
-
-    it("should return error when account not configured", async () => {
-      setupAccountContext({ configured: false });
-
-      const result = await sendMessageTwitchInternal(
-        "#testchannel",
-        "Hello!",
-        mockConfig,
-        "default",
-        false,
-        mockLogger as unknown as Console,
-      );
-
-      expect(result.ok).toBe(false);
-      expect(result.error).toContain("not properly configured");
-    });
-
-    it("should return error when no channel specified", async () => {
-      // Set channel to undefined to trigger the error (bypassing type check)
-      const accountWithoutChannel = {
-        ...mockAccount,
-        channel: undefined as unknown as string,
-      };
-      setupAccountContext({ account: accountWithoutChannel });
-
-      const result = await sendMessageTwitchInternal(
-        "",
-        "Hello!",
-        mockConfig,
-        "default",
-        false,
-        mockLogger as unknown as Console,
-      );
-
-      expect(result.ok).toBe(false);
-      expect(result.error).toContain("No channel specified");
-    });
-
-    it("should skip sending empty message after markdown stripping", async () => {
-      setupAccountContext();
-      const sendMessage = vi.fn();
-      vi.mocked(getClientManager).mockReturnValue({
-        sendMessage,
-      } as unknown as ReturnType<typeof getClientManager>);
-      vi.mocked(stripMarkdownForTwitch).mockReturnValue("");
-
-      const result = await sendMessageTwitchInternal(
-        "#testchannel",
-        "**Only markdown**",
-        mockConfig,
-        "default",
-        true,
-        mockLogger as unknown as Console,
-      );
-
-      expect(result.ok).toBe(true);
-      expect(result.outcome).toBe("not_sent");
-      expect(result.messageId).toBe("");
+      expect(result).toMatchObject({ outcome: "not_sent", messageId: "" });
       expect(result.receipt.platformMessageIds).toStrictEqual([]);
       expect(result.receipt.parts).toStrictEqual([]);
-      // A no-send disposition must stay upstream of the platform client: reporting
-      // "not_sent" while still hitting sendMessage would emit an untracked Twitch
-      // message that the delivery receipt claims never happened.
-      expect(sendMessage).not.toHaveBeenCalled();
-    });
+      expect(sendMessageSpy).not.toHaveBeenCalled();
+    },
+  );
 
-    it("should return error when client manager not found", async () => {
-      setupAccountContext();
-      vi.mocked(getClientManager).mockReturnValue(undefined);
+  it("rejects a visible send when the caller has no manager", async () => {
+    await expect(
+      sendMessageTwitchInternal({ ...params, clientManager: undefined }),
+    ).rejects.toThrow(
+      "Client manager not found for account: default. Please start the Twitch gateway first.",
+    );
+  });
 
-      const result = await sendMessageTwitchInternal(
-        "#testchannel",
-        "Hello!",
-        mockConfig,
-        "default",
-        false,
-        mockLogger as unknown as Console,
-      );
+  it("uses the caller's prepared account when config no longer contains it", async () => {
+    await sendMessageTwitchInternal({ ...params, cfg: {} });
 
-      expect(result.ok).toBe(false);
-      expect(result.error).toContain("Client manager not found");
-    });
+    expect(sendMessageSpy).toHaveBeenCalledExactlyOnceWith(
+      account,
+      "testchannel",
+      "Hello Twitch!",
+      {},
+      "default",
+    );
+  });
 
-    it("should handle send errors gracefully", async () => {
-      setupAccountContext();
-      vi.mocked(getClientManager).mockReturnValue({
-        sendMessage: vi.fn().mockRejectedValue(new Error("Connection lost")),
-      } as unknown as ReturnType<typeof getClientManager>);
+  it("exposes the manager's formatted failure without a cause or another log", async () => {
+    sendMessageSpy.mockResolvedValue({ ok: false, error: "Connection lost" });
+    const failure = sendMessageTwitchInternal(params);
 
-      const result = await sendMessageTwitchInternal(
-        "#testchannel",
-        "Hello!",
-        mockConfig,
-        "default",
-        false,
-        mockLogger as unknown as Console,
-      );
-
-      expect(result.ok).toBe(false);
-      expect(result.error).toBe("Connection lost");
-      expect(mockLogger.error).toHaveBeenCalled();
-    });
-
-    it("should use account channel when channel parameter is empty", async () => {
-      setupAccountContext();
-      const mockSend = vi.fn().mockResolvedValue({
-        ok: true,
-        messageId: "twitch-msg-789",
-      });
-      vi.mocked(getClientManager).mockReturnValue({
-        sendMessage: mockSend,
-      } as unknown as ReturnType<typeof getClientManager>);
-
-      await sendMessageTwitchInternal(
-        "",
-        "Hello!",
-        mockConfig,
-        "default",
-        false,
-        mockLogger as unknown as Console,
-      );
-
-      expect(mockSend).toHaveBeenCalledWith(
-        mockAccount,
-        "testchannel", // normalized account channel
-        "Hello!",
-        mockConfig,
-        "default",
-      );
-    });
-
-    it("uses the configured default account when accountId is omitted", async () => {
-      const secondaryAccount = {
-        ...mockAccount,
-        username: "secondary-user",
-        channel: "secondary-channel",
-      };
-      vi.mocked(resolveTwitchAccountContext).mockImplementation((_cfg, accountId) => ({
-        accountId: accountId?.trim() || "secondary",
-        account: secondaryAccount,
-        tokenResolution: { source: "config", token: secondaryAccount.accessToken ?? "" },
-        configured: true,
-        availableAccountIds: ["default", "secondary"],
-      }));
-      const mockSend = vi.fn().mockResolvedValue({
-        ok: true,
-        messageId: "twitch-msg-secondary",
-      });
-      vi.mocked(getClientManager).mockReturnValue({
-        sendMessage: mockSend,
-      } as unknown as ReturnType<typeof getClientManager>);
-
-      const result = await sendMessageTwitchInternal(
-        "",
-        "Hello!",
-        {
-          channels: {
-            twitch: {
-              defaultAccount: "secondary",
-            },
-          },
-        } as never,
-        undefined,
-        false,
-        mockLogger as unknown as Console,
-      );
-
-      expect(result.ok).toBe(true);
-      expect(getClientManager).toHaveBeenCalledWith("secondary");
-      expect(mockSend).toHaveBeenCalledWith(
-        secondaryAccount,
-        "secondary-channel",
-        "Hello!",
-        {
-          channels: {
-            twitch: {
-              defaultAccount: "secondary",
-            },
-          },
-        },
-        "secondary",
-      );
-    });
+    await expect(failure).rejects.toThrow("Connection lost");
+    await expect(failure).rejects.not.toHaveProperty("cause");
+    expect(logger.error).not.toHaveBeenCalled();
   });
 });

--- a/extensions/twitch/src/send.ts
+++ b/extensions/twitch/src/send.ts
@@ -1,35 +1,21 @@
-/**
- * Twitch message sending functions with dependency injection support.
- *
- * These functions are the primary interface for sending messages to Twitch.
- * They support dependency injection via the `deps` parameter for testability.
- */
-
 import {
   createMessageReceiptFromOutboundResults,
   type MessageReceipt,
-  type MessageReceiptSourceResult,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { getClientManager as getRegistryClientManager } from "./client-manager-registry.js";
-import { resolveTwitchAccountContext } from "./config.js";
+import type { TwitchClientManager } from "./twitch-client.js";
+import type { TwitchAccountConfig } from "./types.js";
 import { stripMarkdownForTwitch } from "./utils/markdown.js";
-import { generateMessageId, normalizeTwitchChannel } from "./utils/twitch.js";
 
 /**
  * Result from sending a message to Twitch.
  */
 interface SendMessageResult {
-  outcome?: MessageReceiptSourceResult["outcome"];
-  /** Whether the send was successful */
-  ok: boolean;
+  outcome?: "not_sent";
   /** The message ID (generated for tracking) */
   messageId: string;
   /** Receipt for visible sends; empty when no Twitch message was sent */
   receipt: MessageReceipt;
-  /** Error message if the send failed */
-  error?: string;
 }
 
 function createTwitchSendReceipt(messageId?: string, channel?: string): MessageReceipt {
@@ -39,129 +25,43 @@ function createTwitchSendReceipt(messageId?: string, channel?: string): MessageR
   });
 }
 
-/**
- * Internal send function used by the outbound adapter.
- *
- * This function has access to the full OpenClaw config and handles
- * account resolution, markdown stripping, and actual message sending.
- *
- * @param channel - The channel name
- * @param text - The message text
- * @param cfg - Full OpenClaw configuration
- * @param accountId - Account ID to use
- * @param stripMarkdown - Whether to strip markdown (default: true)
- * @param logger - Logger instance
- * @returns Result with message ID and status
- *
- * @example
- * const result = await sendMessageTwitchInternal(
- *   "#mychannel",
- *   "Hello Twitch!",
- *   openclawConfig,
- *   "default",
- *   true,
- *   console,
- * );
- */
-export async function sendMessageTwitchInternal(
-  channel: string,
-  text: string,
-  cfg: OpenClawConfig,
-  accountId?: string,
-  stripMarkdown = true,
-  logger: Console = console,
-): Promise<SendMessageResult> {
-  const {
-    account,
-    configured,
-    availableAccountIds,
-    accountId: resolvedAccountId,
-  } = resolveTwitchAccountContext(cfg, accountId);
-  if (!account) {
-    return {
-      ok: false,
-      messageId: generateMessageId(),
-      receipt: createTwitchSendReceipt(),
-      error: `Account not found: ${accountId ?? "(default)"}. Available accounts: ${availableAccountIds.join(", ") || "none"}`,
-    };
-  }
-
-  if (!configured) {
-    return {
-      ok: false,
-      messageId: generateMessageId(),
-      receipt: createTwitchSendReceipt(),
-      error:
-        `Account ${resolvedAccountId} is not properly configured. ` +
-        "Required: username, clientId, and token (config or env for default account).",
-    };
-  }
-
-  const normalizedChannel = channel || account.channel;
-  if (!normalizedChannel) {
-    return {
-      ok: false,
-      messageId: generateMessageId(),
-      receipt: createTwitchSendReceipt(),
-      error: "No channel specified and no default channel in account config",
-    };
-  }
-  const deliveryChannel = normalizeTwitchChannel(normalizedChannel);
-
-  const cleanedText = stripMarkdown ? stripMarkdownForTwitch(text) : text;
+// Callers retain their account and manager lifecycle; strip Markdown once before chunking.
+export async function sendMessageTwitchInternal(params: {
+  channel: string;
+  text: string;
+  cfg: OpenClawConfig;
+  account: TwitchAccountConfig;
+  accountId: string;
+  clientManager: TwitchClientManager | undefined;
+}): Promise<SendMessageResult> {
+  const cleanedText = stripMarkdownForTwitch(params.text);
   if (!cleanedText) {
     return {
-      ok: true,
       outcome: "not_sent",
       messageId: "",
       receipt: createTwitchSendReceipt(),
     };
   }
 
-  const clientManager = getRegistryClientManager(resolvedAccountId);
-  if (!clientManager) {
-    return {
-      ok: false,
-      messageId: generateMessageId(),
-      receipt: createTwitchSendReceipt(),
-      error: `Client manager not found for account: ${resolvedAccountId}. Please start the Twitch gateway first.`,
-    };
-  }
-
-  try {
-    const result = await clientManager.sendMessage(
-      account,
-      deliveryChannel,
-      cleanedText,
-      cfg,
-      resolvedAccountId,
+  if (!params.clientManager) {
+    throw new Error(
+      `Client manager not found for account: ${params.accountId}. Please start the Twitch gateway first.`,
     );
-
-    if (!result.ok) {
-      const messageId = result.messageId ?? generateMessageId();
-      return {
-        ok: false,
-        messageId,
-        receipt: createTwitchSendReceipt(),
-        error: result.error ?? "Send failed",
-      };
-    }
-
-    const messageId = result.messageId ?? generateMessageId();
-    return {
-      ok: true,
-      messageId,
-      receipt: createTwitchSendReceipt(messageId, deliveryChannel),
-    };
-  } catch (error) {
-    const errorMsg = formatErrorMessage(error);
-    const messageId = generateMessageId();
-    logger.error(`Failed to send message: ${errorMsg}`);
-    return {
-      ok: false,
-      messageId,
-      receipt: createTwitchSendReceipt(),
-      error: errorMsg,
-    };
   }
+  const result = await params.clientManager.sendMessage(
+    params.account,
+    params.channel,
+    cleanedText,
+    params.cfg,
+    params.accountId,
+  );
+  if (!result.ok) {
+    // The public boundary keeps the formatted message and omits the raw SDK cause.
+    throw new Error(result.error);
+  }
+  const { messageId } = result;
+  return {
+    messageId,
+    receipt: createTwitchSendReceipt(messageId, params.channel),
+  };
 }

--- a/extensions/twitch/src/twitch-client.test.ts
+++ b/extensions/twitch/src/twitch-client.test.ts
@@ -11,7 +11,7 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveTwitchToken } from "./token.js";
 import { TwitchClientManager } from "./twitch-client.js";
 import type {
@@ -28,7 +28,7 @@ const mockConnect = vi.fn(() => {
   }
 });
 const mockJoin = vi.fn().mockResolvedValue(undefined);
-const mockSay = vi.fn().mockResolvedValue({ messageId: "test-msg-123" });
+const mockSay = vi.fn().mockResolvedValue(undefined);
 const mockQuit = vi.fn();
 const mockUnbind = vi.fn();
 
@@ -170,11 +170,6 @@ describe("TwitchClientManager", () => {
     // Create manager instance
     statusSink = vi.fn<(patch: Omit<ChannelAccountSnapshot, "accountId">) => void>();
     manager = new TwitchClientManager(mockLogger, statusSink);
-  });
-
-  afterEach(() => {
-    // Clean up manager to avoid side effects
-    manager.clearForTest();
   });
 
   describe("getClient", () => {
@@ -687,19 +682,21 @@ describe("TwitchClientManager", () => {
 
     it("should send message successfully", async () => {
       const result = await manager.sendMessage(testAccount, "testchannel", "Hello, world!");
-      const { messageId, ...resultRest } = result;
 
-      expect(resultRest).toEqual({ ok: true });
-      expect(messageId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+      expect(result).toEqual({
+        ok: true,
+        messageId: expect.stringMatching(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+        ),
+      });
       expect(mockSay).toHaveBeenCalledWith("testchannel", "Hello, world!");
     });
 
     it("should keep surrogate pairs intact when pre-chunking long messages", async () => {
       const prefix = "a".repeat(499);
 
-      const result = await manager.sendMessage(testAccount, "testchannel", `${prefix}😀b`);
+      await manager.sendMessage(testAccount, "testchannel", `${prefix}😀b`);
 
-      expect(result.ok).toBe(true);
       expect(mockSay.mock.calls).toEqual([
         ["testchannel", prefix],
         ["testchannel", "😀b"],
@@ -710,38 +707,43 @@ describe("TwitchClientManager", () => {
       const result1 = await manager.sendMessage(testAccount, "testchannel", "First message");
       const result2 = await manager.sendMessage(testAccount, "testchannel", "Second message");
 
-      expect(result1.messageId).not.toBe(result2.messageId);
+      expect(result1.ok).toBe(true);
+      expect(result2.ok).toBe(true);
+      expect(result1).not.toEqual(result2);
     });
 
     it("should handle sending to account's default channel", async () => {
-      const result = await manager.sendMessage(
+      await manager.sendMessage(
         testAccount,
         testAccount.channel || testAccount.username,
         "Test message",
       );
 
-      // Should use the account's channel or username
-      expect(result.ok).toBe(true);
-      expect(mockSay).toHaveBeenCalled();
+      expect(mockSay).toHaveBeenCalledWith("testchannel", "Test message");
     });
 
-    it("should return error on send failure", async () => {
+    it("should log and return a formatted send failure", async () => {
       mockSay.mockRejectedValueOnce(new Error("Rate limited"));
 
-      const result = await manager.sendMessage(testAccount, "testchannel", "Test message");
-
-      expect(result.ok).toBe(false);
-      expect(result.error).toBe("Rate limited");
+      await expect(
+        manager.sendMessage(testAccount, "testchannel", "Test message"),
+      ).resolves.toEqual({
+        ok: false,
+        error: "Rate limited",
+      });
       expect(mockLogger.error).toHaveBeenCalledWith("Failed to send message: Rate limited");
     });
 
     it("should handle unknown error types", async () => {
       mockSay.mockRejectedValueOnce("String error");
 
-      const result = await manager.sendMessage(testAccount, "testchannel", "Test message");
-
-      expect(result.ok).toBe(false);
-      expect(result.error).toBe("String error");
+      await expect(
+        manager.sendMessage(testAccount, "testchannel", "Test message"),
+      ).resolves.toEqual({
+        ok: false,
+        error: "String error",
+      });
+      expect(mockLogger.error).toHaveBeenCalledWith("Failed to send message: String error");
     });
 
     it("should create client if not already connected", async () => {
@@ -751,9 +753,8 @@ describe("TwitchClientManager", () => {
       // Reset connect call count for this specific test
       const connectCallCountBefore = mockConnect.mock.calls.length;
 
-      const result = await manager.sendMessage(testAccount, "testchannel", "Test message");
+      await manager.sendMessage(testAccount, "testchannel", "Test message");
 
-      expect(result.ok).toBe(true);
       expect(mockConnect.mock.calls.length).toBeGreaterThan(connectCallCountBefore);
     });
   });

--- a/extensions/twitch/src/twitch-client.ts
+++ b/extensions/twitch/src/twitch-client.ts
@@ -424,7 +424,7 @@ export class TwitchClientManager {
     message: string,
     cfg?: OpenClawConfig,
     accountId?: string,
-  ): Promise<{ ok: boolean; error?: string; messageId?: string }> {
+  ): Promise<{ ok: true; messageId: string } | { ok: false; error: string }> {
     try {
       const client = await this.getClient(account, cfg, accountId);
 
@@ -438,11 +438,9 @@ export class TwitchClientManager {
 
       return { ok: true, messageId };
     } catch (error) {
-      this.logger.error(`Failed to send message: ${formatErrorMessage(error)}`);
-      return {
-        ok: false,
-        error: formatErrorMessage(error),
-      };
+      const errorMessage = formatErrorMessage(error);
+      this.logger.error(`Failed to send message: ${errorMessage}`);
+      return { ok: false, error: errorMessage };
     }
   }
 
@@ -451,15 +449,5 @@ export class TwitchClientManager {
    */
   public getAccountKey(account: TwitchAccountConfig): string {
     return `${account.username}:${account.channel}`;
-  }
-
-  /**
-   * Clear all clients and handlers (for testing)
-   */
-  clearForTest(): void {
-    this.clients.clear();
-    this.pendingClients.clear();
-    this.connectionPromises.clear();
-    this.messageHandlers.clear();
   }
 }

--- a/extensions/twitch/src/utils/twitch.ts
+++ b/extensions/twitch/src/utils/twitch.ts
@@ -1,5 +1,4 @@
 // Twitch plugin module implements twitch behavior.
-import { randomUUID } from "node:crypto";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 /**
@@ -33,18 +32,6 @@ export function normalizeTwitchChannel(channel: string): string {
  */
 export function missingTargetError(provider: string, hint?: string): Error {
   return new Error(`Delivering to ${provider} requires target${hint ? ` ${hint}` : ""}`);
-}
-
-/**
- * Generate a unique message ID for Twitch messages.
- *
- * Twurple's say() doesn't return the message ID, so we generate one
- * for tracking purposes.
- *
- * @returns A unique message ID
- */
-export function generateMessageId(): string {
-  return `${Date.now()}-${randomUUID()}`;
 }
 
 /**

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1336,7 +1336,11 @@ function runProtocolSinceFixture(checkout: string, baseSha: string) {
   );
 }
 
-function runGuardCheckFixture(options: { frozenTarget: boolean; scripts: string[] }): {
+function runCheckShardFixture(options: {
+  frozenTarget: boolean;
+  scripts: string[];
+  task?: "guards" | "test-types";
+}): {
   calls: string[];
   output: string;
   status: number | null;
@@ -1345,6 +1349,10 @@ function runGuardCheckFixture(options: { frozenTarget: boolean; scripts: string[
   const fakeBin = path.join(root, "bin");
   const callsPath = path.join(root, "pnpm-calls.txt");
   mkdirSync(fakeBin);
+  if (options.task === "test-types") {
+    mkdirSync(path.join(root, "scripts"));
+    writeFileSync(path.join(root, "scripts/run-tsgo-core-test-shards.mts"), "// --stripe\n");
+  }
   writeFileSync(
     path.join(root, "package.json"),
     `${JSON.stringify({
@@ -1354,6 +1362,7 @@ function runGuardCheckFixture(options: { frozenTarget: boolean; scripts: string[
   writeExecutable(path.join(fakeBin, "pnpm"), [
     "#!/usr/bin/env bash",
     "set -euo pipefail",
+    'if [ "$*" = "run --silent" ]; then exit 1; fi',
     'printf "%s\\n" "$*" >> "$PNPM_CALLS"',
   ]);
   const checkShardRun = readCiWorkflow().jobs["check-shard"].steps.find(
@@ -1367,10 +1376,11 @@ function runGuardCheckFixture(options: { frozenTarget: boolean; scripts: string[
       FROZEN_TARGET: options.frozenTarget ? "true" : "false",
       FORMAT_CHECK: "false",
       HISTORICAL_TARGET: options.frozenTarget ? "true" : "false",
+      HOSTED_RUNNER_STRIPES: "true",
       PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
       PNPM_CALLS: callsPath,
       PR_BASE_SHA: "",
-      TASK: "guards",
+      TASK: options.task ?? "guards",
     },
   });
   return {
@@ -7965,7 +7975,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
 
   it("runs temp path guardrails in the hosted guard shard", () => {
     const requiredScripts = ["check:doctor-deprecation-registry", "check:coercion-helpers"];
-    const current = runGuardCheckFixture({
+    const current = runCheckShardFixture({
       frozenTarget: false,
       scripts: [...requiredScripts, "check:temp-path-guardrails"],
     });
@@ -7975,7 +7985,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       current.calls.indexOf("dup:check"),
     );
 
-    const frozenMissing = runGuardCheckFixture({
+    const frozenMissing = runCheckShardFixture({
       frozenTarget: true,
       scripts: requiredScripts,
     });
@@ -7986,7 +7996,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       "[skip] frozen target predates the temp path guardrails",
     );
 
-    const currentMissing = runGuardCheckFixture({
+    const currentMissing = runCheckShardFixture({
       frozenTarget: false,
       scripts: requiredScripts,
     });
@@ -8006,6 +8016,46 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       preflightGuards.indexOf("pnpm dup:check"),
     );
   });
+
+  it.each([
+    {
+      scripts: ["tsgo:scripts", "tsgo:test:root"],
+      frozenTarget: false,
+      status: 0,
+      calls: ["tsgo:extensions:test", "tsgo:scripts", "tsgo:test:root"],
+    },
+    {
+      scripts: ["tsgo:scripts"],
+      frozenTarget: false,
+      status: 1,
+      calls: ["tsgo:extensions:test", "tsgo:scripts"],
+    },
+    {
+      scripts: [],
+      frozenTarget: false,
+      status: 1,
+      calls: ["tsgo:extensions:test"],
+    },
+    {
+      scripts: [],
+      frozenTarget: true,
+      status: 0,
+      calls: ["tsgo:extensions:test"],
+    },
+    {
+      scripts: ["tsgo:test:root"],
+      frozenTarget: true,
+      status: 0,
+      calls: ["tsgo:extensions:test", "tsgo:test:root"],
+    },
+  ])(
+    "runs declared typechecks for scripts=$scripts frozen=$frozenTarget",
+    ({ scripts, frozenTarget, status, calls }) => {
+      const result = runCheckShardFixture({ scripts, frozenTarget, task: "test-types" });
+      expect(result.status, result.output).toBe(status);
+      expect(result.calls).toEqual(calls);
+    },
+  );
 
   it("rejects ambiguous zero-before main pushes and preserves concrete bases", () => {
     const zeroSha = "0".repeat(40);


### PR DESCRIPTION
Twitch outbound and inbound delivery now share one sender. The outbound adapter keeps account and target validation, the sender owns Markdown conversion and receipts, and the client manager keeps transport, chunking, logging and its existing success/error envelope. This removes repeated preparation and error plumbing while preserving the public error shape, including the absence of a cause.

Production is **+72/−196 = −124 physical lines**, or **−114 operational lines after excluding deletion of a test-only clearing method**. Tests are net −166 lines, including the CI regression coverage below. There are no configuration, dependency, public API, storage or protocol changes.

Validation:

- The actual owner corpus preserves 75 outcomes and 72 target cases, including validation order, partial chunk failure, attachment joins, intentional no-send, receipts and registry lifecycle. Normalization is limited to generated IDs and clocks.
- Actual Twurple 8.1.4 runs against a local WebSocket IRC server: ten outcomes, seven PRIVMSG messages and parsed echoes match the baseline. This proves the installed SDK/local protocol flow; it does not claim Twitch authentication or remote acceptance.
- All 16 public exception shapes match the baseline, excluding source-dependent stacks. **146 maintained tests across ten files passed** on the final source.
- Production/test type checks, formatting, changed-file lint and the remaining selected guards passed. Fresh independent Codex high/P2 review returned scoped-clean. The managed reviewer excluded the unchanged token source after its sensitive-filename preflight; it was inspected locally without bypassing that restriction.
- A normal full build passed. Emitted-file inspection confirms the plugin still loads its monitor dynamically and both use the same sender chunk, with zero ineffective-dynamic-import diagnostics. The SDK exports, bootstrap guard, runtime post-processing and UI build checks also passed.

**Before landing:** exact-head CI must pass the production/full-tree dead-code gate. Both local attempts reached the existing 600-second limit on an earlier revision; those failures are retained, and the aggregate changed-file command is not claimed as passed. Earlier lint failures were repaired in the final source and rechecked.

The final patch SHA-256 is `9efed5f57efe83b093f4b8cc6874f479d9a93dd615e8a9d650a54fc2c4639556`. The original production files match stable v2026.8.1. No runtime bug or speedup is claimed for this refactor.

Named follow-ups: the Twitch README and missing-token diagnostic still say `token` where the schema and resolver use `accessToken`; a pre-existing rapid-client-creation test comment also contradicts the creation-promise owner. These are recorded separately from this frozen delivery change.


The hosted typecheck shard exposed a separate CI defect: package-script presence was inferred from formatted `pnpm run` output, and the job reported a declared root script as absent. Both remaining listing-based probes now use the step's existing manifest-based `has_package_script` helper. Current targets still fail when a required script is genuinely missing; historical targets retain their optional-script behavior. Workflow production delta is zero (two lines replaced).

Five behavioral cases execute the actual workflow shell with current/historical package manifests and an unavailable listing command. The old workflow fails three cases; the repaired workflow passes all five plus the existing guard fixture. All 14 selected checks pass. A fresh managed high/P2 review of the combined Twitch and CI change is clean. The exact hosted cause of the listing failure (including any pipe behavior) was not reproduced locally; no such mechanism is asserted. New-head hosted CI, including the full-tree dead-code gate, is still required before landing.


Landing verification: the latest ClawSweeper review (15:34 UTC) has no introduced correctness or security finding. Its CI requests and rank-up are now satisfied by all187 successful/skipped jobs in CI33525719241 on019d3fb1b39c; the hosted dependency checks also close the earlier local dead-code deadlines. A clean three-way merge against current main2cedaddb5e23 retains the independent CI changes and introduces exactly the two reviewed script lookups plus their fixture coverage. The shared sender retains monitor/outbound account and lifecycle ownership; operational production decreases114 lines after excluding10 deleted test-seam lines, and tests decrease166 lines.
