### PR TITLE
fix: Windows send fails when workspace bootstrap hits EPERM

### DIFF
--- a/src/agents/workspace-bootstrap-publish.test.ts
+++ b/src/agents/workspace-bootstrap-publish.test.ts
@@ -57,6 +57,27 @@ async function listTempSiblings(dir: string): Promise<string[]> {
   return names.filter((name) => name.startsWith("openclaw-bootstrap-")).toSorted();
 }
 
+function injectExclusiveLinkError(
+  targetPath: string,
+  code: string,
+  opts?: { existingContent?: string },
+) {
+  const realLink = syncFs.linkSync.bind(syncFs);
+  const resolvedTarget = path.resolve(targetPath);
+  const linkSpy = vi.spyOn(syncFs, "linkSync").mockImplementation((source, target) => {
+    if (path.resolve(String(target)) === resolvedTarget) {
+      if (opts?.existingContent !== undefined) {
+        syncFs.writeFileSync(targetPath, opts.existingContent);
+      }
+      throw Object.assign(new Error(`${code}: exclusive link failed`), { code });
+    }
+    return realLink(source, target);
+  });
+  return () => {
+    linkSpy.mockRestore();
+  };
+}
+
 describe("bootstrap publication atomicity", () => {
   it("does not publish a partial AGENTS.md when the first write fails", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
@@ -233,6 +254,56 @@ describe("bootstrap publication atomicity", () => {
       await expectPathMissing(agentsPath);
     } finally {
       linkSpy.mockRestore();
+    }
+  });
+
+  it.each(["EPERM", "EACCES"] as const)(
+    "keeps a raced existing bootstrap file when exclusive link reports %s",
+    async (code) => {
+      const tempDir = await fs.realpath(await makeTempWorkspace("openclaw-workspace-"));
+      const agentsPath = path.join(tempDir, DEFAULT_AGENTS_FILENAME);
+      const existing = "existing operator agents\n";
+      const restore = injectExclusiveLinkError(agentsPath, code, { existingContent: existing });
+
+      try {
+        await expect(workspace.publishBootstrapFile(agentsPath, "replacement\n")).resolves.toBe(
+          false,
+        );
+        expect(await fs.readFile(agentsPath, "utf8")).toBe(existing);
+      } finally {
+        restore();
+      }
+    },
+  );
+
+  it("still reports unsupported hardlinks when exclusive link reports EPERM and the target is missing", async () => {
+    const tempDir = await fs.realpath(await makeTempWorkspace("openclaw-workspace-"));
+    const agentsPath = path.join(tempDir, DEFAULT_AGENTS_FILENAME);
+    const restore = injectExclusiveLinkError(agentsPath, "EPERM");
+
+    try {
+      await expect(workspace.publishBootstrapFile(agentsPath, "complete\n")).rejects.toThrow(
+        /filesystem does not support atomic bootstrap publication/u,
+      );
+      await expectPathMissing(agentsPath);
+    } finally {
+      restore();
+    }
+  });
+
+  it("still fails exclusive publish when a raced existing target hits a non-collision link error", async () => {
+    const tempDir = await fs.realpath(await makeTempWorkspace("openclaw-workspace-"));
+    const agentsPath = path.join(tempDir, DEFAULT_AGENTS_FILENAME);
+    const existing = "existing operator agents\n";
+    const restore = injectExclusiveLinkError(agentsPath, "ENOSPC", { existingContent: existing });
+
+    try {
+      await expect(
+        workspace.publishBootstrapFile(agentsPath, "replacement\n"),
+      ).rejects.toMatchObject({ code: "ENOSPC" });
+      expect(await fs.readFile(agentsPath, "utf8")).toBe(existing);
+    } finally {
+      restore();
     }
   });
 

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -354,7 +354,23 @@ export async function publishBootstrapFile(
       syncFs.unlinkSync(staging.path);
       outcome = { kind: "created" };
     } catch (error) {
-      if (!linked && hasErrnoCode(error, "EEXIST")) {
+      // Windows can deny CreateHardLink with EPERM/EACCES when the name
+      // already exists or is delete-pending. isHardlinkFallbackError also
+      // matches EPERM, so a present target must be classified as exists.
+      let collisionExists = !linked && hasErrnoCode(error, "EEXIST");
+      const collisionDenied =
+        !linked && (hasErrnoCode(error, "EPERM") || hasErrnoCode(error, "EACCES"));
+      if (!collisionExists && collisionDenied) {
+        try {
+          syncFs.lstatSync(targetPath);
+          collisionExists = true;
+        } catch (existsError) {
+          if (!hasErrnoCode(existsError, "ENOENT")) {
+            throw existsError;
+          }
+        }
+      }
+      if (collisionExists) {
         outcome = { kind: "exists" };
       } else if (!linked && isHardlinkFallbackError(error)) {
         outcome = {


### PR DESCRIPTION
Closes #135230

## What Problem This Solves

Fixes an issue where users sending a chat message on Windows would see the send fail when workspace bootstrap tried to publish `AGENTS.md` (or another bootstrap file) that already existed or was briefly delete-pending. The gateway threw `EPERM: operation not permitted` and the turn never started.

## Why This Change Was Made

`main` already replaced the old `wx` helper with `publishBootstrapFile`: established files return after `lstat`, and a first-time write stages then hardlinks. That removes the original idle-file `wx` path.

The remaining hole is the exclusive **link**. Windows can deny `CreateHardLink` with `EPERM`/`EACCES` instead of `EEXIST` when the name is occupied or delete-pending. `isHardlinkFallbackError` also treats `EPERM` as "hardlinks unsupported", so a present file became a false filesystem-capability error and still broke send.

This change classifies a present target as already published before the hardlink-unsupported path. A missing target still fails closed. Unrelated link failures such as `ENOSPC` stay visible. Dev workspace seeding already uses the same owner.

Non-goals: no new config/env, no SQLite/schema change, no restore of `writeFileIfMissing`.

## User Impact

Windows operators can send messages against an already-seeded or briefly held workspace file. A bootstrap path that is actually missing, or that fails for a non-collision reason, still errors.

## Evidence

Pre-fix, a raced existing `AGENTS.md` plus exclusive-link `EPERM` threw:

```
Error: Workspace filesystem does not support atomic bootstrap publication. Use a workspace on a filesystem with hard-link support.
  caused by EPERM: exclusive link failed
  at publishBootstrapFile src/agents/workspace.ts
```

After-fix owner proof (same injection, Node v22.23.2):

```
PASS EPERM raced existing keeps file
PASS missing-target EPERM stays unsupported hardlinks
PASS ENOSPC raced existing still fails
PROOF_OK
```

Regression coverage in `src/agents/workspace-bootstrap-publish.test.ts`:

- `keeps a raced existing bootstrap file when exclusive link reports EPERM`
- `keeps a raced existing bootstrap file when exclusive link reports EACCES`
- `still reports unsupported hardlinks when exclusive link reports EPERM and the target is missing`
- `still fails exclusive publish when a raced existing target hits a non-collision link error`

The EPERM raced-existing case fails on current `main` for the unsupported-hardlink reason above, and passes after this owner change.

Earlier Windows QA on the retired `wx` helper: idle existing-file `wx` on Node v22.23.2 / NTFS was `EEXIST`; the reporter's intermittent `EPERM` was delete-pending while another handle still held `AGENTS.md`. That established-file case is already covered by `lstat`-first on `main`. This PR keeps the remaining link-collision case from being misread as an unsupported filesystem.

Reshaped onto current `main` (`3dcc8ef96a3`). Autoreview was not available on this machine (`codex` missing).
