### PR TITLE
refactor(google-meet): derive shared meeting types from the canonical owner

### DIFF
--- a/extensions/google-meet/src/transports/types.ts
+++ b/extensions/google-meet/src/transports/types.ts
@@ -1,29 +1,13 @@
 // Google Meet type declarations define plugin contracts.
+import type { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import type {
-  MeetingBrowserHealth,
-  MeetingBrowserTab,
-  MeetingSessionRecord,
-  MeetingTranscriptSnapshot,
-} from "openclaw/plugin-sdk/meeting-runtime";
-import type { GoogleMeetMode, GoogleMeetModeInput, GoogleMeetTransport } from "../config.js";
+  GoogleMeetConfig,
+  GoogleMeetMode,
+  GoogleMeetModeInput,
+  GoogleMeetTransport,
+} from "../config.js";
 
 export const GOOGLE_MEET_TRANSCRIPT_MAX_LINES = 2_000;
-
-export type GoogleMeetTranscriptSnapshot = MeetingTranscriptSnapshot;
-
-export type GoogleMeetJoinRequest = {
-  url: string;
-  transport?: GoogleMeetTransport;
-  mode?: GoogleMeetModeInput;
-  message?: string;
-  requesterSessionKey?: string;
-  /** Agent selected by the calling tool context. */
-  agentId?: string;
-  timeoutMs?: number;
-  dialInNumber?: string;
-  pin?: string;
-  dtmfSequence?: string;
-};
 
 type GoogleMeetManualActionReason =
   | "google-login-required"
@@ -41,108 +25,84 @@ type GoogleMeetSpeechBlockedReason =
   | "audio-bridge-unavailable"
   | "meet-microphone-muted";
 
-export type GoogleMeetChromeHealth = MeetingBrowserHealth<
-  GoogleMeetManualActionReason,
-  GoogleMeetSpeechBlockedReason
-> & {
-  inCall?: boolean;
-  micMuted?: boolean;
-  lobbyWaiting?: boolean;
-  leaveReason?: string;
-  captioning?: boolean;
-  captionsEnabledAttempted?: boolean;
-  transcriptLines?: number;
-  lastCaptionAt?: string;
-  lastCaptionSpeaker?: string;
-  lastCaptionText?: string;
-  recentTranscript?: Array<{
-    at?: string;
-    speaker?: string;
-    text: string;
-  }>;
-  realtimeTranscriptLines?: number;
-  lastRealtimeTranscriptAt?: string;
-  lastRealtimeTranscriptRole?: "user" | "assistant";
-  lastRealtimeTranscriptText?: string;
-  recentRealtimeTranscript?: Array<{
-    at: string;
-    role: "user" | "assistant";
-    text: string;
-  }>;
-  lastRealtimeEventAt?: string;
-  lastRealtimeEventType?: string;
-  lastRealtimeEventDetail?: string;
-  recentRealtimeEvents?: Array<{
-    at: string;
-    direction: "client" | "server";
-    type: string;
-    detail?: string;
-  }>;
-  recentTalkEvents?: Array<{
-    id: string;
-    type: string;
-    sessionId: string;
-    turnId?: string;
-    seq: number;
-    timestamp: string;
-    final?: boolean;
-  }>;
-  speechReady?: boolean;
-  speechBlockedReason?: GoogleMeetSpeechBlockedReason;
-  speechBlockedMessage?: string;
-  providerConnected?: boolean;
-  realtimeReady?: boolean;
-  audioInputActive?: boolean;
-  audioInputRouted?: boolean;
-  audioInputDeviceLabel?: string;
-  audioInputRouteError?: string;
-  audioOutputActive?: boolean;
-  audioOutputRouted?: boolean;
-  audioOutputDeviceLabel?: string;
-  audioOutputRouteError?: string;
-  lastInputAt?: string;
-  lastOutputAt?: string;
-  lastSuppressedInputAt?: string;
-  lastClearAt?: string;
-  lastInputBytes?: number;
-  lastOutputBytes?: number;
-  suppressedInputBytes?: number;
-  consecutiveInputErrors?: number;
-  lastInputError?: string;
-  clearCount?: number;
-  queuedInputChunks?: number;
-  browserUrl?: string;
-  browserTitle?: string;
-  bridgeClosed?: boolean;
-  status?: string;
-  notes?: string[];
+type GoogleMeetPluginConfig = GoogleMeetConfig & {
+  chrome: GoogleMeetConfig["chrome"] & {
+    audioInputCommand: string[];
+    audioOutputCommand: string[];
+  };
 };
 
-export type GoogleMeetBrowserTab = MeetingBrowserTab;
+type GoogleMeetPluginTypes = ReturnType<
+  typeof MeetingPlatformAdapter.pluginTypes<
+    GoogleMeetPluginConfig,
+    GoogleMeetTransport,
+    GoogleMeetModeInput,
+    GoogleMeetManualActionReason,
+    GoogleMeetSpeechBlockedReason,
+    {
+      leaveReason?: string;
+      realtimeTranscriptLines?: number;
+      lastRealtimeTranscriptAt?: string;
+      lastRealtimeTranscriptRole?: "user" | "assistant";
+      lastRealtimeTranscriptText?: string;
+      recentRealtimeTranscript?: Array<{
+        at: string;
+        role: "user" | "assistant";
+        text: string;
+      }>;
+      lastRealtimeEventAt?: string;
+      lastRealtimeEventType?: string;
+      lastRealtimeEventDetail?: string;
+      recentRealtimeEvents?: Array<{
+        at: string;
+        direction: "client" | "server";
+        type: string;
+        detail?: string;
+      }>;
+      recentTalkEvents?: Array<{
+        id: string;
+        type: string;
+        sessionId: string;
+        turnId?: string;
+        seq: number;
+        timestamp: string;
+        final?: boolean;
+      }>;
+      lastSuppressedInputAt?: string;
+      lastClearAt?: string;
+      suppressedInputBytes?: number;
+      consecutiveInputErrors?: number;
+      lastInputError?: string;
+      clearCount?: number;
+      queuedInputChunks?: number;
+    }
+  >
+>;
 
-export type GoogleMeetSession = MeetingSessionRecord<
-  GoogleMeetTransport,
-  GoogleMeetMode,
-  {
-    enabled: boolean;
-    strategy?: string;
-    provider?: string;
-    model?: string;
-    transcriptionProvider?: string;
-    toolPolicy: string;
-  }
-> & {
-  /** Canonical agent owner and shared fields retain their byte-compatible wire names. */
-  chrome?: {
-    audioBackend?: "blackhole-2ch" | "pipewire-pulse";
-    launched: boolean;
-    nodeId?: string;
-    browserProfile?: string;
-    /** Exact joined tab and whether OpenClaw may close it on leave. */
-    browserTab?: GoogleMeetBrowserTab;
-    audioBridge?: {
-      type: "command-pair" | "node-command-pair" | "external-command";
-      provider?: string;
+export type GoogleMeetTranscriptSnapshot = GoogleMeetPluginTypes["TranscriptSnapshot"];
+
+export type GoogleMeetJoinRequest = GoogleMeetPluginTypes["JoinRequest"] & {
+  dialInNumber?: string;
+  pin?: string;
+  dtmfSequence?: string;
+};
+
+export type GoogleMeetChromeHealth = Omit<
+  GoogleMeetPluginTypes["ChromeHealth"],
+  "cameraOff" | "captionCaptureRequested" | "audioOutputRouteRetryable"
+>;
+
+export type GoogleMeetBrowserTab = GoogleMeetPluginTypes["BrowserTab"];
+
+type GoogleMeetPluginSession = GoogleMeetPluginTypes["Session"];
+type GoogleMeetPluginChrome = NonNullable<GoogleMeetPluginSession["chrome"]>;
+type GoogleMeetPluginAudioBridge = NonNullable<GoogleMeetPluginChrome["audioBridge"]>;
+
+export type GoogleMeetSession = Omit<GoogleMeetPluginSession, "chrome" | "mode"> & {
+  mode: GoogleMeetMode;
+  chrome?: Omit<GoogleMeetPluginChrome, "audioBridge" | "health"> & {
+    audioBridge?: Omit<GoogleMeetPluginAudioBridge, "type"> & {
+      type: GoogleMeetPluginAudioBridge["type"] | "external-command";
     };
     health?: GoogleMeetChromeHealth;
   };
@@ -156,7 +116,6 @@ export type GoogleMeetSession = MeetingSessionRecord<
   };
 };
 
-export type GoogleMeetJoinResult = {
+export type GoogleMeetJoinResult = Omit<GoogleMeetPluginTypes["JoinResult"], "session"> & {
   session: GoogleMeetSession;
-  spoken?: boolean;
 };


### PR DESCRIPTION
Google Meet now derives its shared internal declarations from the same `MeetingPlatformAdapter.pluginTypes` owner used by the Teams and Zoom meeting plugins. Google-specific join fields, stored-mode narrowing, health omissions, the external-command audio bridge and Twilio state remain local.

Production is **+82/−123 = −41 physical lines** (−44 nonblank); tests are unchanged. This is a declaration-only refactor: independently emitted JavaScript is byte-identical, with **zero executable LOC reduction**.

All six exported type names remain. An external compile-time probe passed on the original and final owners, checking bidirectional assignability, keys, optional/readonly members and the Google-specific refinements. Actual config resolver values also match; the internal audio-command constraint does not narrow the public config type.

The three focused owner/setup test files passed all seven tests. The complete classifier-selected changed-file gate passed, including production/test type checks, five doctor-contract tests, lint, plugin boundaries and all three dead-export scans. Fresh independent Codex high/P2 review returned scoped-clean with no findings.

Six initial probe setup failures and one review-output preflight failure are preserved in local evidence; they occurred before successful proof and are not represented as product failures. No live meeting or provider run is claimed: the runtime output does not change. The reviewed patch SHA-256 is `622088567ddb59ec290b2bcc0c232a347729d1f8c4120d1d0f8cc51c6bd45762`.


Maintainer landing review: the complete 14:27 UTC ClawSweeper review has no actionable finding or rank-up move. Its request for maintainer handling after CI is satisfied by direct review of the shared factory, Google refinements and sibling Teams/Zoom declarations, plus [successful exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33518374746) with all 63 selected jobs successful or skipped and the required gate green.

The final type characterization and emitted-JavaScript comparison preserve the existing contract. Seven maintained tests, five doctor tests, selected checks and independent Codex P2 review pass. The initial external proof setup failures remain recorded. This removes 41 net production lines (44 nonblank), with zero emitted-JavaScript change and no test-line change.
