### PR TITLE
refactor(msteams): share bounded Graph pagination

### DIFF
--- a/extensions/msteams/src/graph-conversation-members.ts
+++ b/extensions/msteams/src/graph-conversation-members.ts
@@ -1,15 +1,10 @@
 import { resolveConversationPath, resolveGraphConversationId } from "./graph-messages.js";
-import { fetchGraphJson } from "./graph.js";
+import { fetchAllGraphPages } from "./graph.js";
 
 type MSTeamsConversationMember = {
   id?: string;
   userId?: string;
   email?: string;
-};
-
-type GraphConversationMembersPage = {
-  value?: MSTeamsConversationMember[];
-  "@odata.nextLink"?: string;
 };
 
 const MAX_CONVERSATION_MEMBER_PAGES = 100;
@@ -29,28 +24,19 @@ export async function findMSTeamsConversationMember(params: {
     conversation.kind === "channel" && params.includeIndirectChannelMembers
       ? "allMembers"
       : "members";
-  let nextPath: string | undefined = `${conversation.basePath}/${collection}`;
-  let pages = 0;
-  let member: MSTeamsConversationMember | undefined;
-
-  while (nextPath && pages < MAX_CONVERSATION_MEMBER_PAGES && !member) {
-    const response: GraphConversationMembersPage =
-      await fetchGraphJson<GraphConversationMembersPage>({
-        token: params.token,
-        path: nextPath,
-      });
-    const userId = params.userId.trim().toLowerCase();
-    member = (response.value ?? []).find(
-      (candidate) =>
-        candidate.userId?.trim().toLowerCase() === userId ||
-        candidate.email?.trim().toLowerCase() === userId,
-    );
-    nextPath = response["@odata.nextLink"]?.replace("https://graph.microsoft.com/v1.0", "");
-    pages += 1;
-  }
-  if (nextPath && !member) {
+  const userId = params.userId.trim().toLowerCase();
+  const result = await fetchAllGraphPages<MSTeamsConversationMember>({
+    token: params.token,
+    path: `${conversation.basePath}/${collection}`,
+    maxPages: MAX_CONVERSATION_MEMBER_PAGES,
+    collectItems: false,
+    findOne: (candidate) =>
+      candidate.userId?.trim().toLowerCase() === userId ||
+      candidate.email?.trim().toLowerCase() === userId,
+  });
+  if (result.truncated) {
     throw new Error("MS Teams conversation member pagination limit exceeded");
   }
 
-  return { conversationId, member };
+  return { conversationId, member: result.found };
 }

--- a/extensions/msteams/src/graph-group-management.test.ts
+++ b/extensions/msteams/src/graph-group-management.test.ts
@@ -6,6 +6,7 @@ import {
   removeParticipantMSTeams,
   renameGroupMSTeams,
 } from "./graph-group-management.js";
+import { createGraphPageGuard } from "./graph-pagination.test-support.js";
 
 const mockState = vi.hoisted(() => ({
   resolveGraphToken: vi.fn(),
@@ -13,7 +14,13 @@ const mockState = vi.hoisted(() => ({
   mutateGraphJson: vi.fn(),
   deleteGraphRequest: vi.fn(),
   findPreferredDmByUserId: vi.fn(),
+  fetchWithSsrFGuard: vi.fn(),
 }));
+
+vi.mock("../runtime-api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../runtime-api.js")>();
+  return { ...actual, fetchWithSsrFGuard: mockState.fetchWithSsrFGuard };
+});
 
 vi.mock("./graph.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./graph.js")>();
@@ -48,12 +55,13 @@ function postGraphBodyAt(index: number): Record<string, unknown> {
   return body as Record<string, unknown>;
 }
 
-describe("addParticipantMSTeams", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockState.resolveGraphToken.mockResolvedValue(TOKEN);
-  });
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockState.resolveGraphToken.mockResolvedValue(TOKEN);
+  mockState.fetchWithSsrFGuard.mockImplementation(createGraphPageGuard(mockState.fetchGraphJson));
+});
 
+describe("addParticipantMSTeams", () => {
   it("maps the default chat member role to Graph owner", async () => {
     mockState.mutateGraphJson.mockResolvedValue({});
 
@@ -210,11 +218,6 @@ describe("addParticipantMSTeams", () => {
 });
 
 describe("removeParticipantMSTeams", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockState.resolveGraphToken.mockResolvedValue(TOKEN);
-  });
-
   it("lists members, finds match, deletes by membershipId", async () => {
     mockState.fetchGraphJson.mockResolvedValue({
       value: [
@@ -289,17 +292,17 @@ describe("removeParticipantMSTeams", () => {
           "https://graph.microsoft.com/v1.0/chats/19%3Aabc%40thread.tacv2/members?$skip=2",
       })
       .mockResolvedValueOnce({
-        value: [{ id: "membership-9", userId: "user-aad-id-9" }],
+        value: [{ id: "membership-9", email: " User-AAD-ID-9 " }],
       });
     mockState.deleteGraphRequest.mockResolvedValue(undefined);
 
     const result = await removeParticipantMSTeams({
       cfg: {} as OpenClawConfig,
       to: CHAT_ID,
-      userId: "user-aad-id-9",
+      userId: " USER-AAD-ID-9 ",
     });
 
-    expect(result).toEqual({ removed: { userId: "user-aad-id-9", chatId: CHAT_ID } });
+    expect(result).toEqual({ removed: { userId: " USER-AAD-ID-9 ", chatId: CHAT_ID } });
     expect(mockState.fetchGraphJson).toHaveBeenNthCalledWith(1, {
       token: TOKEN,
       path: `/chats/${encodeURIComponent(CHAT_ID)}/members`,
@@ -313,14 +316,51 @@ describe("removeParticipantMSTeams", () => {
       path: `/chats/${encodeURIComponent(CHAT_ID)}/members/membership-9`,
     });
   });
+
+  it("accepts a match on the final allowed page even when another page is advertised", async () => {
+    let page = 0;
+    mockState.fetchGraphJson.mockImplementation(async () => {
+      page += 1;
+      return {
+        value: page === 100 ? [{ id: "membership-final", userId: "user-final" }] : [],
+        "@odata.nextLink": "https://graph.microsoft.com/v1.0/chats/chat/members?$skip=next",
+      };
+    });
+    mockState.deleteGraphRequest.mockResolvedValue(undefined);
+
+    await expect(
+      removeParticipantMSTeams({
+        cfg: {} as OpenClawConfig,
+        to: CHAT_ID,
+        userId: "user-final",
+      }),
+    ).resolves.toEqual({ removed: { userId: "user-final", chatId: CHAT_ID } });
+    expect(mockState.fetchGraphJson).toHaveBeenCalledTimes(100);
+    expect(mockState.deleteGraphRequest).toHaveBeenCalledWith({
+      token: TOKEN,
+      path: `/chats/${encodeURIComponent(CHAT_ID)}/members/membership-final`,
+    });
+  });
+
+  it("preserves the exact pagination-limit failure after 100 unmatched pages", async () => {
+    mockState.fetchGraphJson.mockResolvedValue({
+      value: [],
+      "@odata.nextLink": "https://graph.microsoft.com/v1.0/chats/chat/members?$skip=next",
+    });
+
+    await expect(
+      removeParticipantMSTeams({
+        cfg: {} as OpenClawConfig,
+        to: CHAT_ID,
+        userId: "missing",
+      }),
+    ).rejects.toThrow("MS Teams conversation member pagination limit exceeded");
+    expect(mockState.fetchGraphJson).toHaveBeenCalledTimes(100);
+    expect(mockState.deleteGraphRequest).not.toHaveBeenCalled();
+  });
 });
 
 describe("renameGroupMSTeams", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockState.resolveGraphToken.mockResolvedValue(TOKEN);
-  });
-
   it("renames a chat with topic", async () => {
     mockState.mutateGraphJson.mockResolvedValue(undefined);
 

--- a/extensions/msteams/src/graph-members.test.ts
+++ b/extensions/msteams/src/graph-members.test.ts
@@ -2,14 +2,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { getMemberInfoMSTeams } from "./graph-members.js";
+import { createGraphPageGuard } from "./graph-pagination.test-support.js";
 
 const mockState = vi.hoisted(() => ({
   resolveGraphToken: vi.fn(),
   fetchGraphJson: vi.fn(),
+  fetchWithSsrFGuard: vi.fn(),
 }));
 
-vi.mock("./graph.js", () => {
+vi.mock("../runtime-api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../runtime-api.js")>();
+  return { ...actual, fetchWithSsrFGuard: mockState.fetchWithSsrFGuard };
+});
+
+vi.mock("./graph.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./graph.js")>();
   return {
+    ...actual,
     resolveGraphToken: mockState.resolveGraphToken,
     fetchGraphJson: mockState.fetchGraphJson,
   };
@@ -21,6 +30,7 @@ describe("getMemberInfoMSTeams", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockState.resolveGraphToken.mockResolvedValue(TOKEN);
+    mockState.fetchWithSsrFGuard.mockImplementation(createGraphPageGuard(mockState.fetchGraphJson));
   });
 
   it("returns verified standard-channel roster fields", async () => {
@@ -152,6 +162,47 @@ describe("getMemberInfoMSTeams", () => {
       path: "/teams/team-1/members",
     });
     expect(mockState.fetchGraphJson).toHaveBeenCalledTimes(2);
+  });
+
+  it("accepts a normalized match on the final allowed team page", async () => {
+    let page = 0;
+    mockState.fetchGraphJson.mockImplementation(async () => {
+      page += 1;
+      if (page === 1) {
+        return { membershipType: "standard" };
+      }
+      return {
+        value: page === 101 ? [{ userId: "aad-final", email: " Alice@Contoso.com " }] : [],
+        "@odata.nextLink": "https://graph.microsoft.com/v1.0/teams/team-1/members?$skip=next",
+      };
+    });
+
+    await expect(
+      getMemberInfoMSTeams({
+        cfg: {} as OpenClawConfig,
+        to: "team-1/channel-1",
+        userId: "teams:Alice@Contoso.com ",
+      }),
+    ).resolves.toMatchObject({ user: { id: "aad-final" } });
+    expect(mockState.fetchGraphJson).toHaveBeenCalledTimes(101);
+  });
+
+  it("preserves the exact team pagination-limit failure", async () => {
+    mockState.fetchGraphJson
+      .mockResolvedValueOnce({ membershipType: "standard" })
+      .mockResolvedValue({
+        value: [],
+        "@odata.nextLink": "https://graph.microsoft.com/v1.0/teams/team-1/members?$skip=next",
+      });
+
+    await expect(
+      getMemberInfoMSTeams({
+        cfg: {} as OpenClawConfig,
+        to: "team-1/channel-1",
+        userId: "missing",
+      }),
+    ).rejects.toThrow("Microsoft Teams team member pagination limit exceeded");
+    expect(mockState.fetchGraphJson).toHaveBeenCalledTimes(101);
   });
 
   it("propagates Graph API errors", async () => {

--- a/extensions/msteams/src/graph-members.ts
+++ b/extensions/msteams/src/graph-members.ts
@@ -1,7 +1,7 @@
 // Msteams plugin module implements graph members behavior.
 import type { OpenClawConfig } from "../runtime-api.js";
 import { resolveConversationPath, resolveGraphConversationId } from "./graph-messages.js";
-import { fetchGraphJson, resolveGraphToken } from "./graph.js";
+import { fetchAllGraphPages, fetchGraphJson, resolveGraphToken } from "./graph.js";
 
 type GetMemberInfoMSTeamsParams = {
   cfg: OpenClawConfig;
@@ -27,11 +27,6 @@ type GraphConversationMember = {
   userId?: string;
   email?: string;
   roles?: string[];
-};
-
-type GraphConversationMembersPage = {
-  value?: GraphConversationMember[];
-  "@odata.nextLink"?: string;
 };
 
 const MAX_TEAM_MEMBER_PAGES = 100;
@@ -66,29 +61,19 @@ async function findStandardChannelMember(params: {
   }
 
   const requestedUserId = normalizeUserId(params.userId);
-  let nextPath: string | undefined = `/teams/${encodeURIComponent(conversation.teamId)}/members`;
-  let pages = 0;
-  while (nextPath && pages < MAX_TEAM_MEMBER_PAGES) {
-    const response: GraphConversationMembersPage =
-      await fetchGraphJson<GraphConversationMembersPage>({
-        token: params.token,
-        path: nextPath,
-      });
-    const member = (response.value ?? []).find(
-      (candidate) =>
-        normalizeUserId(candidate.userId) === requestedUserId ||
-        normalizeUserId(candidate.email) === requestedUserId,
-    );
-    if (member) {
-      return member;
-    }
-    nextPath = response["@odata.nextLink"]?.replace("https://graph.microsoft.com/v1.0", "");
-    pages += 1;
-  }
-  if (nextPath) {
+  const result = await fetchAllGraphPages<GraphConversationMember>({
+    token: params.token,
+    path: `/teams/${encodeURIComponent(conversation.teamId)}/members`,
+    maxPages: MAX_TEAM_MEMBER_PAGES,
+    collectItems: false,
+    findOne: (candidate) =>
+      normalizeUserId(candidate.userId) === requestedUserId ||
+      normalizeUserId(candidate.email) === requestedUserId,
+  });
+  if (result.truncated) {
     throw new Error("Microsoft Teams team member pagination limit exceeded");
   }
-  return undefined;
+  return result.found;
 }
 
 /**

--- a/extensions/msteams/src/graph-pagination.test-support.ts
+++ b/extensions/msteams/src/graph-pagination.test-support.ts
@@ -1,0 +1,20 @@
+const GRAPH_ROOT = "https://graph.microsoft.com/v1.0";
+
+export function createGraphPageGuard(
+  loadPage: (params: { token: string; path: string }) => Promise<unknown>,
+) {
+  return async (params: { url: string; init?: RequestInit }) => {
+    const authorization = new Headers(params.init?.headers).get("authorization") ?? "";
+    const payload = await loadPage({
+      token: authorization.replace(/^Bearer /, ""),
+      path: params.url.replace(GRAPH_ROOT, ""),
+    });
+    return {
+      response: new Response(JSON.stringify(payload), {
+        headers: { "content-type": "application/json" },
+      }),
+      finalUrl: params.url,
+      release: async () => undefined,
+    };
+  };
+}

--- a/extensions/msteams/src/graph-teams.test.ts
+++ b/extensions/msteams/src/graph-teams.test.ts
@@ -1,12 +1,19 @@
 // Msteams tests cover graph teams plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
+import { createGraphPageGuard } from "./graph-pagination.test-support.js";
 import { getChannelInfoMSTeams, listChannelsMSTeams } from "./graph-teams.js";
 
 const mockState = vi.hoisted(() => ({
   resolveGraphToken: vi.fn(),
   fetchGraphJson: vi.fn(),
+  fetchWithSsrFGuard: vi.fn(),
 }));
+
+vi.mock("../runtime-api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../runtime-api.js")>();
+  return { ...actual, fetchWithSsrFGuard: mockState.fetchWithSsrFGuard };
+});
 
 vi.mock("./graph.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./graph.js")>();
@@ -27,12 +34,15 @@ function graphFetchPathAt(index: number): string | undefined {
   return call[0]?.path;
 }
 
-describe("listChannelsMSTeams", () => {
-  beforeEach(() => {
-    mockState.resolveGraphToken.mockReset().mockResolvedValue(TOKEN);
-    mockState.fetchGraphJson.mockReset();
-  });
+beforeEach(() => {
+  mockState.resolveGraphToken.mockReset().mockResolvedValue(TOKEN);
+  mockState.fetchGraphJson.mockReset();
+  mockState.fetchWithSsrFGuard
+    .mockReset()
+    .mockImplementation(createGraphPageGuard(mockState.fetchGraphJson));
+});
 
+describe("listChannelsMSTeams", () => {
   it("returns channels with all fields mapped", async () => {
     mockState.fetchGraphJson.mockResolvedValue({
       value: [
@@ -161,14 +171,33 @@ describe("listChannelsMSTeams", () => {
     expect(mockState.fetchGraphJson).toHaveBeenCalledTimes(10);
     expect(result.truncated).toBe(true);
   });
+
+  it("does not report truncation when page 10 ends the collection", async () => {
+    for (let i = 0; i < 10; i++) {
+      mockState.fetchGraphJson.mockResolvedValueOnce({
+        value: [{ id: `ch-${i}` }],
+        ...(i < 9
+          ? {
+              "@odata.nextLink": `https://graph.microsoft.com/v1.0/teams/team-full/channels?$skip=${i + 1}`,
+            }
+          : {}),
+      });
+    }
+
+    const result = await listChannelsMSTeams({
+      cfg: {} as OpenClawConfig,
+      teamId: "team-full",
+    });
+
+    expect(result.channels.map((channel) => channel.id)).toEqual(
+      Array.from({ length: 10 }, (_, index) => `ch-${index}`),
+    );
+    expect(result.truncated).toBe(false);
+    expect(mockState.fetchGraphJson).toHaveBeenCalledTimes(10);
+  });
 });
 
 describe("getChannelInfoMSTeams", () => {
-  beforeEach(() => {
-    mockState.resolveGraphToken.mockReset().mockResolvedValue(TOKEN);
-    mockState.fetchGraphJson.mockReset();
-  });
-
   it("returns channel with all fields", async () => {
     mockState.fetchGraphJson.mockResolvedValue({
       id: "ch-1",

--- a/extensions/msteams/src/graph-teams.ts
+++ b/extensions/msteams/src/graph-teams.ts
@@ -1,6 +1,6 @@
 // Msteams plugin module implements graph teams behavior.
 import type { OpenClawConfig } from "../runtime-api.js";
-import { type GraphResponse, fetchGraphJson, resolveGraphToken } from "./graph.js";
+import { fetchAllGraphPages, fetchGraphJson, resolveGraphToken } from "./graph.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -60,32 +60,18 @@ export async function listChannelsMSTeams(
   params: ListChannelsMSTeamsParams,
 ): Promise<ListChannelsMSTeamsResult> {
   const token = await resolveGraphToken(params.cfg);
-  const firstPath = `/teams/${encodeURIComponent(params.teamId)}/channels?$select=id,displayName,description,membershipType`;
-  const collected: GraphTeamsChannel[] = [];
-  let nextPath: string | undefined = firstPath;
-  const MAX_PAGES = 10;
-  let page = 0;
-  while (nextPath && page < MAX_PAGES) {
-    type PagedChannelResponse = GraphResponse<GraphTeamsChannel> & {
-      "@odata.nextLink"?: string;
-    };
-    const res: PagedChannelResponse = await fetchGraphJson<PagedChannelResponse>({
-      token,
-      path: nextPath,
-    });
-    collected.push(...(res.value ?? []));
-    const nextLink: string | undefined = res["@odata.nextLink"];
-    // Strip the Graph API root so fetchGraphJson receives a relative path
-    nextPath = nextLink ? nextLink.replace("https://graph.microsoft.com/v1.0", "") : undefined;
-    page++;
-  }
-  const channels = collected.map((ch) => ({
+  const result = await fetchAllGraphPages<GraphTeamsChannel>({
+    token,
+    path: `/teams/${encodeURIComponent(params.teamId)}/channels?$select=id,displayName,description,membershipType`,
+    maxPages: 10,
+  });
+  const channels = result.items.map((ch) => ({
     id: ch.id,
     displayName: ch.displayName,
     description: ch.description,
     membershipType: ch.membershipType,
   }));
-  return { channels, truncated: Boolean(nextPath) };
+  return { channels, truncated: result.truncated };
 }
 
 // ---------------------------------------------------------------------------

--- a/extensions/msteams/src/graph.test.ts
+++ b/extensions/msteams/src/graph.test.ts
@@ -675,8 +675,10 @@ describe("msteams graph helpers", () => {
       expect(globalThis.fetch).toHaveBeenCalledTimes(2);
     });
 
-    it("findOne early exit", async () => {
+    it.each([undefined, false])("findOne early exit (collectItems=%s)", async (collectItems) => {
       const target = { id: "target", name: "found-it" };
+      const afterTarget = { id: "after", name: "not-visited" };
+      const visited: string[] = [];
       let callCount = 0;
 
       mockFetch(async () => {
@@ -689,10 +691,9 @@ describe("msteams graph helpers", () => {
             ),
           );
         }
-        // Page 2 contains the target; page 3 should never be fetched
         return jsonResponse(
           pagedResponse(
-            [{ id: "2", name: "b" }, target],
+            [{ id: "2", name: "b" }, target, afterTarget],
             "https://graph.microsoft.com/v1.0/items?$skiptoken=p3",
           ),
         );
@@ -701,14 +702,22 @@ describe("msteams graph helpers", () => {
       const result = await fetchAllGraphPages<Item>({
         token: graphToken,
         path: "/items",
-        findOne: (item) => item.id === "target",
+        maxPages: 2,
+        collectItems,
+        findOne: (item) => {
+          visited.push(item.id);
+          return item.id === "target";
+        },
       });
 
       expect(result.found).toEqual(target);
       expect(result.truncated).toBe(false);
-      // Page 1 items + page 2 items (where match was found)
-      expect(result.items).toEqual([{ id: "1", name: "a" }, { id: "2", name: "b" }, target]);
-      // Only 2 fetches; page 3 was never requested
+      expect(visited).toEqual(["1", "2", "target"]);
+      expect(result.items).toEqual(
+        collectItems === false
+          ? []
+          : [{ id: "1", name: "a" }, { id: "2", name: "b" }, target, afterTarget],
+      );
       expect(globalThis.fetch).toHaveBeenCalledTimes(2);
     });
 
@@ -726,7 +735,7 @@ describe("msteams graph helpers", () => {
       expect(result.items).toEqual([{ id: "1", name: "a" }]);
     });
 
-    it("findOne with no match (truncated)", async () => {
+    it.each([undefined, false])("findOne with no match (collectItems=%s)", async (collectItems) => {
       mockFetch(async () =>
         jsonResponse(
           pagedResponse(
@@ -740,13 +749,40 @@ describe("msteams graph helpers", () => {
         token: graphToken,
         path: "/items",
         maxPages: 2,
+        collectItems,
         findOne: (item) => item.id === "missing",
       });
 
       expect(result.found).toBeUndefined();
       expect(result.truncated).toBe(true);
-      expect(result.items).toHaveLength(2);
+      expect(result.items).toHaveLength(collectItems === false ? 0 : 2);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
     });
+
+    it.each([undefined, false])(
+      "preserves findOne errors (collectItems=%s)",
+      async (collectItems) => {
+        const failure = new Error("predicate failed");
+        mockJsonFetchResponse(
+          pagedResponse(
+            [{ id: "1", name: "a" }],
+            "https://graph.microsoft.com/v1.0/items?$skiptoken=p2",
+          ),
+        );
+
+        await expect(
+          fetchAllGraphPages<Item>({
+            token: graphToken,
+            path: "/items",
+            collectItems,
+            findOne: () => {
+              throw failure;
+            },
+          }),
+        ).rejects.toBe(failure);
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      },
+    );
 
     it("empty first page", async () => {
       mockJsonFetchResponse(pagedResponse([]));
@@ -758,6 +794,42 @@ describe("msteams graph helpers", () => {
 
       expect(result).toEqual({ items: [], truncated: false });
       expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("treats a missing value as empty and rejects a malformed value", async () => {
+      mockJsonFetchResponse({});
+      await expect(
+        fetchAllGraphPages<Item>({ token: graphToken, path: "/items" }),
+      ).resolves.toEqual({ items: [], truncated: false });
+
+      mockJsonFetchResponse({ value: { id: "not-an-array" } });
+      await expect(
+        fetchAllGraphPages<Item>({ token: graphToken, path: "/items" }),
+      ).rejects.toThrow();
+    });
+
+    it("does not truncate when the final allowed page has no nextLink", async () => {
+      mockFetch(async (_input, _init) =>
+        vi.mocked(globalThis.fetch).mock.calls.length === 1
+          ? jsonResponse(
+              pagedResponse(
+                [{ id: "1", name: "a" }],
+                "https://graph.microsoft.com/v1.0/items?$skiptoken=page2",
+              ),
+            )
+          : jsonResponse(pagedResponse([{ id: "2", name: "b" }])),
+      );
+
+      await expect(
+        fetchAllGraphPages<Item>({ token: graphToken, path: "/items", maxPages: 2 }),
+      ).resolves.toEqual({
+        items: [
+          { id: "1", name: "a" },
+          { id: "2", name: "b" },
+        ],
+        truncated: false,
+      });
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -187,6 +187,8 @@ export async function fetchAllGraphPages<T>(params: {
   maxPages?: number;
   /** Stop pagination early when this predicate returns true. */
   findOne?: (item: T) => boolean;
+  /** Find-only callers can skip retaining every traversed page. */
+  collectItems?: boolean;
 }): Promise<PaginatedResult<T>> {
   const maxPages = params.maxPages ?? 50;
   const items: T[] = [];
@@ -201,15 +203,13 @@ export async function fetchAllGraphPages<T>(params: {
 
     const pageItems = res.value ?? [];
 
-    if (params.findOne) {
-      const match = pageItems.find(params.findOne);
-      if (match) {
-        items.push(...pageItems);
-        return { items, truncated: false, found: match };
-      }
+    const match = params.findOne ? pageItems.find(params.findOne) : undefined;
+    if (params.collectItems !== false) {
+      items.push(...pageItems);
     }
-
-    items.push(...pageItems);
+    if (match) {
+      return { items, truncated: false, found: match };
+    }
 
     // @odata.nextLink is an absolute URL; strip the Graph root to get a relative path
     const rawNext: string | undefined = res["@odata.nextLink"];


### PR DESCRIPTION
Three Teams Graph pagination loops now use the existing plugin pagination owner. Channel listing keeps its ten-page limit and projection; both member finders keep their hundred-page limits, matching rules, caller-specific errors and page-bounded retention. An internal `collectItems: false` option lets finders avoid accumulating pages while other helper callers retain the existing collected-items result.

Production is **+41/−84 = −43 physical lines** (−39 nonblank, −27 type-erased JavaScript lines). Tests/support add 212 lines. This removes the duplicate loops and page-envelope types without changing config, authentication, permissions, storage, schema or SDK surfaces. The retention choice preserves the original implementation; it is not a speed or memory improvement claim over the original base.

Actual local HTTP proof covers **66 scenarios per phase, 906 GETs per phase and 660 checks** through the real Graph request, guarded HTTP transport and bounded response/error readers. It exercises caps, empty pages, early/final-page matches, projections, errors, release ownership and 10,000-member traversals. Token resolution and the remote Graph origin are replaced by owned fixtures, so this does not claim Microsoft authentication, tenant permissions or service acceptance. The documented contract is paginated collections with URL-valued next links, including empty pages ([Microsoft paging documentation](https://learn.microsoft.com/en-us/graph/paging)).

There are 56 exact baseline/candidate result-and-transport matches. Ten deliberately malformed or synthetic cross-version cases differ and are not hidden: three beta links follow the shared helper's v1-relative normalization; two zero-valued next links are treated as exhausted; one matched record returns before an invalid numeric next link is read; and four malformed collections retain TypeError but change its expression text. Those cases are outside the claimed ordinary v1 response equivalence.

**Before landing, exact-head hosted CI must cover the maintained Teams and doctor-contract tests.** Local baseline/final Teams runs and the doctor-contract command each reached their fixed 300-second startup deadlines without reported completed tests. Of 26 selected check commands, 25 passed, including both type checks, all dead-export scans and lint. Original timeouts, an initial missing-Corepack preflight failure, and a corrected HTTP recorder bookkeeping failure are preserved. No timeout or gate was weakened.

Fresh independent Codex high/P2 review returned scoped-clean with no findings. The reviewed patch SHA-256 is `19655bfa88f072b681094f8e990e8d833efad9ff20b08c6fcc4880b1db35eb69`; all nine changed sources and 29 review datasets remain bound to that review. The unchanged transport and authorization owners retain their responsibilities.


Maintainer landing review: [exact-head CI33518399126](https://github.com/openclaw/openclaw/actions/runs/33518399126) passes all58 selected jobs. The [Teams shard](https://github.com/openclaw/openclaw/actions/runs/33518399126/job/99891461227) passes1,552 tests in99 files, including every changed Graph test and16 doctor-contract observations. This completes the latest ClawSweeper before-merge request and rank-up move, and closes the previously disclosed local startup-timeout gap. The three original local deadlines remain failed attempts.

The review's generic vector/embedding stored-data alert does not apply: direct inspection shows only Graph HTTP pagination and result projection, with no persistent-store, schema or migration change. The canonical paginator retains each caller's caps and errors, and find-only callers do not accumulate pages. Local owned-HTTP evidence and independent P2 review are complete; Microsoft tenant acceptance is not claimed. Production is−43 lines (−39 nonblank); tests/support+212.
