### PR TITLE
perf(plugins): speed up plugin catalog management

### DIFF
--- a/src/plugins/management-service-featured.test.ts
+++ b/src/plugins/management-service-featured.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { recordInstalledPluginIndexInstallOwner } from "./installed-plugin-index-install-owner.js";
 import { recordPluginManifestInstallOwner } from "./manifest-install-owner.js";
+import type { OfficialExternalPluginCatalogEntry } from "./official-external-plugin-catalog.js";
 
 const mocks = vi.hoisted(() => ({
   metadata: vi.fn(),
   officialCatalog: vi.fn(),
+  bundledEntries: undefined as OfficialExternalPluginCatalogEntry[] | undefined,
 }));
 
 vi.mock("./plugin-metadata-snapshot.js", () => ({
@@ -12,11 +14,16 @@ vi.mock("./plugin-metadata-snapshot.js", () => ({
   resolvePluginMetadataSnapshot: (...args: unknown[]) => mocks.metadata(...args),
 }));
 
-vi.mock("./official-external-plugin-catalog.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./official-external-plugin-catalog.js")>()),
-  loadConfiguredHostedOfficialExternalPluginCatalogEntries: (...args: unknown[]) =>
-    mocks.officialCatalog(...args),
-}));
+vi.mock("./official-external-plugin-catalog.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./official-external-plugin-catalog.js")>();
+  return {
+    ...actual,
+    listOfficialExternalPluginCatalogEntries: () =>
+      mocks.bundledEntries ?? actual.listOfficialExternalPluginCatalogEntries(),
+    loadConfiguredHostedOfficialExternalPluginCatalogEntries: (...args: unknown[]) =>
+      mocks.officialCatalog(...args),
+  };
+});
 
 const { clearManagedPluginOfficialCatalogCache, listManagedPlugins, resolveManagedPluginIconUrl } =
   await import("./management-service.js");
@@ -144,6 +151,22 @@ function hostedFeedEntry(params: {
   };
 }
 
+// Composition fixtures preserve array occurrences that the native catalog producer deduplicates.
+function compositionEntry(
+  id: string,
+  install: { clawhubSpec?: string; npmSpec?: string; localPath?: string } = {},
+  { order = 7 }: { order?: number } = {},
+) {
+  return {
+    featured: true,
+    openclaw: {
+      plugin: { id, label: id },
+      catalog: { featured: true, order },
+      install,
+    },
+  };
+}
+
 const hostedFeedDiffsEntry = hostedFeedEntry({
   packageName: "@openclaw/diffs",
   title: "Diffs",
@@ -195,6 +218,7 @@ describe("plugin management Featured authority", () => {
   });
 
   beforeEach(() => {
+    mocks.bundledEntries = undefined;
     clearManagedPluginOfficialCatalogCache();
     mocks.metadata.mockReset();
     mocks.officialCatalog.mockReset();
@@ -658,4 +682,277 @@ describe("plugin management Featured authority", () => {
       }),
     ]);
   });
+
+  it.each([
+    { mode: "one dual-source occurrence", expectedId: "bundled" },
+    { mode: "split source occurrences", expectedId: "remote" },
+    { mode: "repeated object occurrence", expectedId: "remote" },
+    { mode: "cloned occurrence", expectedId: "remote" },
+    { mode: "different source", expectedId: "remote" },
+    { mode: "different ClawHub case", expectedId: "remote" },
+  ])("preserves overlay identity for $mode", async ({ mode, expectedId }) => {
+    const both = { clawhubSpec: "clawhub:@acme/shared", npmSpec: "@acme/shared" };
+    const bundled = compositionEntry("bundled", both, { order: 41 });
+    const hosted = compositionEntry("remote", both);
+    let bundledEntries = [bundled];
+    if (mode === "split source occurrences") {
+      bundledEntries = [
+        compositionEntry("bundled-clawhub", { clawhubSpec: both.clawhubSpec }),
+        compositionEntry("bundled-npm", { npmSpec: both.npmSpec }),
+      ];
+    } else if (mode === "repeated object occurrence") {
+      bundledEntries = [bundled, bundled];
+    } else if (mode === "cloned occurrence") {
+      bundledEntries = [bundled, { ...bundled }];
+    } else if (mode === "different source") {
+      hosted.openclaw.install = { clawhubSpec: both.clawhubSpec };
+      bundled.openclaw.install = { npmSpec: both.npmSpec };
+    } else if (mode === "different ClawHub case") {
+      hosted.openclaw.install = { clawhubSpec: "clawhub:@acme/Shared" };
+      bundled.openclaw.install = { clawhubSpec: both.clawhubSpec };
+    }
+    mocks.bundledEntries = bundledEntries;
+    mocks.metadata.mockReturnValue(emptyMetadataSnapshot());
+    mocks.officialCatalog.mockResolvedValue(hostedCatalog([hosted]));
+
+    const catalog = await listManagedPlugins({ config: {}, env: {} });
+
+    expect(catalog.plugins).toEqual([
+      expect.objectContaining({
+        id: expectedId,
+        featured: true,
+        order: expectedId === "bundled" ? 41 : 7,
+      }),
+    ]);
+  });
+
+  it.each(["one", "repeated object", "clone", "npm source only"])(
+    "preserves installed identity and package suppression for %s hosted occurrence",
+    async (mode) => {
+      const localIcon = "https://cdn.example.test/local.png";
+      const hostedIcon = "https://cdn.example.test/hosted.png";
+      mocks.metadata.mockReturnValue(
+        metadataSnapshot({
+          id: "installed",
+          name: "Local",
+          packageName: "@acme/installed",
+          icon: localIcon,
+        }),
+      );
+      mocks.bundledEntries = [
+        {
+          ...compositionEntry("catalog-runtime", {
+            clawhubSpec: "clawhub:@acme/shared",
+            npmSpec: "@acme/installed",
+          }),
+          name: "@acme/installed",
+        },
+      ];
+      const hosted = {
+        ...compositionEntry(
+          "remote",
+          mode === "npm source only"
+            ? { npmSpec: "@acme/installed" }
+            : { clawhubSpec: "clawhub:@acme/shared" },
+        ),
+        title: "Remote",
+        icon: hostedIcon,
+      };
+      // The name arrives from the overlay. Its npm fallback must participate in suppression.
+      const entries =
+        mode === "repeated object"
+          ? [hosted, hosted]
+          : mode === "clone"
+            ? [hosted, { ...hosted }]
+            : [hosted];
+      mocks.officialCatalog.mockResolvedValue(hostedCatalog(entries));
+
+      const catalog = await listManagedPlugins({ config: {}, env: {} });
+      const icon = await resolveManagedPluginIconUrl({
+        config: {},
+        env: {},
+        pluginId: "installed",
+      });
+
+      expect(catalog.plugins).toEqual([
+        expect.objectContaining({
+          id: "installed",
+          installed: true,
+          name: mode === "one" ? "Remote" : "Local",
+          featured: mode === "one",
+          hasIcon: true,
+        }),
+      ]);
+      expect(icon).toBe(mode === "one" ? hostedIcon : localIcon);
+    },
+  );
+
+  it.each([
+    { mode: "first hosted icon", firstIcon: "https://cdn.example.test/first.png" },
+    { mode: "first missing icon", firstIcon: undefined },
+    {
+      mode: "normalized manifest fallback",
+      firstIcon: undefined,
+      fallbackIcon: "https://cdn.example.test/normalized.png",
+    },
+  ])("retains normalized first-record selection for $mode", async ({ firstIcon, fallbackIcon }) => {
+    const first = metadataSnapshot({
+      id: "Alias",
+      name: "First",
+      origin: "global",
+      packageName: "@acme/first",
+      icon: "https://cdn.example.test/raw-first.png",
+      installRecord: {
+        source: "clawhub",
+        clawhubUrl: "https://clawhub.ai",
+        clawhubChannel: "official",
+        clawhubPackage: "@acme/first",
+      },
+    });
+    const second = metadataSnapshot({
+      id: "ALIAS",
+      name: "Second",
+      origin: "global",
+      packageName: "@acme/second",
+      installRecord: {
+        source: "clawhub",
+        clawhubUrl: "https://clawhub.ai",
+        clawhubChannel: "official",
+        clawhubPackage: "@acme/second",
+      },
+    });
+    const normalizedManifest = {
+      ...first.plugins[0]!,
+      id: "alias",
+      icon: fallbackIcon,
+    };
+    mocks.metadata.mockReturnValue({
+      ...first,
+      index: {
+        plugins: [...first.index.plugins, ...second.index.plugins],
+        installRecords: { ...first.index.installRecords, ...second.index.installRecords },
+      },
+      plugins: [...first.plugins, ...second.plugins],
+      byPluginId: new Map([
+        ...first.byPluginId,
+        ...second.byPluginId,
+        ["alias", normalizedManifest],
+      ]),
+      normalizePluginId: (id: string) => id.trim().toLowerCase(),
+    });
+    const officialCatalog = {
+      entries: [
+        { ...compositionEntry("first", { clawhubSpec: "clawhub:@acme/first" }), icon: firstIcon },
+        {
+          ...compositionEntry("second", { clawhubSpec: "clawhub:@acme/second" }),
+          icon: "https://cdn.example.test/second.png",
+        },
+      ],
+    };
+    const expected = firstIcon ?? fallbackIcon;
+
+    const catalog = await listManagedPlugins({ config: {}, env: {}, officialCatalog });
+    const icon = await resolveManagedPluginIconUrl({
+      config: {},
+      env: {},
+      pluginId: "ALIAS",
+      officialCatalog,
+    });
+
+    expect(catalog.plugins).toHaveLength(2);
+    for (const plugin of catalog.plugins) {
+      expect(plugin.hasIcon).toBe(expected ? true : undefined);
+    }
+    expect(icon).toBe(expected);
+  });
+
+  it.each([undefined, "https://cdn.example.test/first.png"])(
+    "resolves the first uninstalled duplicate catalog ID with icon %s",
+    async (firstIcon) => {
+      mocks.metadata.mockReturnValue(emptyMetadataSnapshot());
+      const officialCatalog = {
+        entries: [
+          { ...compositionEntry("duplicate"), icon: firstIcon },
+          { ...compositionEntry("duplicate"), icon: "https://cdn.example.test/second.png" },
+        ],
+      };
+
+      const catalog = await listManagedPlugins({ config: {}, env: {}, officialCatalog });
+      const icon = await resolveManagedPluginIconUrl({
+        config: {},
+        env: {},
+        pluginId: "duplicate",
+        officialCatalog,
+      });
+
+      expect(catalog.plugins.map((plugin) => plugin.hasIcon)).toEqual([
+        firstIcon ? true : undefined,
+        true,
+      ]);
+      expect(icon).toBe(firstIcon);
+    },
+  );
+
+  it.each([
+    {
+      name: "unversioned ClawHub",
+      install: { clawhubSpec: "clawhub:@acme/action" },
+      source: "clawhub",
+    },
+    {
+      name: "pinned ClawHub",
+      install: { clawhubSpec: "clawhub:@acme/action@1.2.3" },
+      source: "official",
+    },
+    { name: "npm", install: { npmSpec: "@acme/action@1.2.3" }, source: "official" },
+    { name: "local", install: { localPath: "./plugin" }, source: "official" },
+    { name: "malformed ClawHub", install: { clawhubSpec: "clawhub:" }, source: "official" },
+    {
+      name: "malformed npm selector",
+      install: { npmSpec: "@acme/action@^1.2.3" },
+      source: "official",
+    },
+    { name: "no install", install: {}, source: undefined },
+    {
+      name: "rejected state",
+      install: { npmSpec: "@acme/action" },
+      source: undefined,
+      state: "rejected",
+      publisher: { trust: "official" },
+    },
+    {
+      name: "rejected publisher",
+      install: { npmSpec: "@acme/action" },
+      source: undefined,
+      state: "available",
+      publisher: { trust: "community" },
+    },
+    {
+      name: "incomplete authority",
+      install: { npmSpec: "@acme/action" },
+      source: undefined,
+      state: "available",
+    },
+  ])(
+    "preserves the public install action for $name",
+    async ({ install, source, state, publisher }) => {
+      mocks.metadata.mockReturnValue(emptyMetadataSnapshot());
+      const entry = { ...compositionEntry("action", install), state, publisher };
+
+      const catalog = await listManagedPlugins({
+        config: {},
+        env: {},
+        officialCatalog: { entries: [entry] },
+      });
+
+      expect(catalog.plugins).toHaveLength(1);
+      expect(catalog.plugins[0]?.install).toEqual(
+        source === "clawhub"
+          ? { source: "clawhub", packageName: "@acme/action" }
+          : source === "official"
+            ? { source: "official", pluginId: "action" }
+            : undefined,
+      );
+    },
+  );
 });

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -422,36 +422,23 @@ function mergeCatalogMetadata(
   };
 }
 
-type CatalogPackageSourceIdentity = {
-  source: "clawhub" | "npm";
-  packageName: string;
-};
-
-function resolveCatalogPackageSourceIdentities(
-  entry: OfficialExternalPluginCatalogEntry,
-): CatalogPackageSourceIdentity[] {
+function prepareCatalogEntry(entry: OfficialExternalPluginCatalogEntry) {
   const install = resolveOfficialExternalPluginInstall(entry);
-  const clawhubPackage = install?.clawhubSpec
-    ? parseClawHubPluginSpec(install.clawhubSpec)?.name
-    : undefined;
-  const npmPackage = install?.npmSpec ? parseRegistryNpmSpec(install.npmSpec)?.name : undefined;
-  return [
-    ...(clawhubPackage ? [{ source: "clawhub" as const, packageName: clawhubPackage }] : []),
-    ...(npmPackage ? [{ source: "npm" as const, packageName: npmPackage }] : []),
-  ];
+  return {
+    entry,
+    install,
+    clawhub: install?.clawhubSpec ? parseClawHubPluginSpec(install.clawhubSpec) : undefined,
+    npmPackage: install?.npmSpec ? parseRegistryNpmSpec(install.npmSpec)?.name : undefined,
+  };
 }
 
-function matchesBundledCatalogIdentity(params: {
-  hosted: OfficialExternalPluginCatalogEntry;
-  bundled: OfficialExternalPluginCatalogEntry;
-}): boolean {
-  const hostedSources = resolveCatalogPackageSourceIdentities(params.hosted);
-  const bundledSources = resolveCatalogPackageSourceIdentities(params.bundled);
-  return hostedSources.some((hosted) =>
-    bundledSources.some(
-      (bundled) => bundled.source === hosted.source && bundled.packageName === hosted.packageName,
-    ),
-  );
+type PreparedCatalogEntry = ReturnType<typeof prepareCatalogEntry>;
+
+function prepareCatalogEntries(entries: readonly OfficialExternalPluginCatalogEntry[]) {
+  let prepared: PreparedCatalogEntry[] | undefined;
+  // Unknown local installs never need package identities from the official catalog.
+  // Resolve each collection only when provenance admits a lookup, then reuse its facts.
+  return () => (prepared ??= entries.map(prepareCatalogEntry));
 }
 
 /**
@@ -465,11 +452,15 @@ function overlayBundledOfficialPluginCatalogMetadata(
     hostedFeaturedAuthoritative: false,
   },
 ): OfficialExternalPluginCatalogEntry[] {
+  const bundledFacts = entries.length > 0 ? bundledEntries.map(prepareCatalogEntry) : [];
   return entries.map((entry) => {
-    const matches = bundledEntries.filter((bundled) =>
-      matchesBundledCatalogIdentity({ hosted: entry, bundled }),
+    const { clawhub, npmPackage } = prepareCatalogEntry(entry);
+    const matches = bundledFacts.filter(
+      (bundled) =>
+        (clawhub && bundled.clawhub?.name === clawhub.name) ||
+        (npmPackage && bundled.npmPackage === npmPackage),
     );
-    const bundled = matches.length === 1 ? matches[0] : undefined;
+    const bundled = matches.length === 1 ? matches[0]?.entry : undefined;
     if (bundled) {
       return mergeCatalogMetadata(entry, bundled, options);
     }
@@ -547,18 +538,6 @@ function normalizeFeaturedAt(value: unknown): number | undefined {
   return asSafeIntegerInRange(value, { min: 0 });
 }
 
-function resolveCatalogInstallAction(params: {
-  entry: OfficialExternalPluginCatalogEntry;
-  pluginId: string;
-}): ManagedPluginCatalogEntry["install"] {
-  const install = resolveOfficialExternalPluginInstall(params.entry);
-  const clawhub = install?.clawhubSpec ? parseClawHubPluginSpec(install.clawhubSpec) : undefined;
-  if (clawhub && !clawhub.version) {
-    return { source: "clawhub", packageName: clawhub.name };
-  }
-  return install ? { source: "official", pluginId: params.pluginId } : undefined;
-}
-
 /** Coarse manifest-derived grouping so catalog UIs can shelve a large inventory. */
 function derivePluginCategory(manifest: PluginManifestRecord | undefined): string | undefined {
   if (!manifest) {
@@ -634,30 +613,20 @@ function compareCatalogEntries(
 }
 
 function resolveInstalledOfficialCatalogEntry(params: {
-  entries: readonly OfficialExternalPluginCatalogEntry[];
+  entries: ReturnType<typeof prepareCatalogEntries>;
   packageName?: string;
-  source: CatalogPackageSourceIdentity["source"];
-}): OfficialExternalPluginCatalogEntry | undefined {
+  source: "clawhub" | "npm";
+}): PreparedCatalogEntry | undefined {
   if (!params.packageName) {
     return undefined;
   }
-  const matches = params.entries.filter((entry) =>
-    resolveCatalogPackageSourceIdentities(entry).some(
-      (identity) =>
-        identity.source === params.source && identity.packageName === params.packageName,
-    ),
-  );
+  const matches = params
+    .entries()
+    .filter(
+      ({ clawhub, npmPackage }) =>
+        (params.source === "clawhub" ? clawhub?.name : npmPackage) === params.packageName,
+    );
   return matches.length === 1 ? matches[0] : undefined;
-}
-
-function resolveOfficialCatalogIconUrl(
-  entries: readonly OfficialExternalPluginCatalogEntry[],
-  pluginId: string,
-): string | undefined {
-  const entry = entries.find(
-    (candidate) => resolveOfficialExternalPluginId(candidate) === pluginId,
-  );
-  return resolveCatalogEntryIcon(entry);
 }
 
 type PluginIndexRecord = PluginMetadataSnapshot["index"]["plugins"][number];
@@ -693,8 +662,8 @@ function resolveInstalledHostedOfficialEntry(params: {
   record: PluginIndexRecord;
   installOwner?: string;
   installRecord?: PluginInstallRecord;
-  officialEntries: readonly OfficialExternalPluginCatalogEntry[];
-  bundledOfficialEntries: readonly OfficialExternalPluginCatalogEntry[];
+  officialEntries: ReturnType<typeof prepareCatalogEntries>;
+  bundledOfficialEntries: ReturnType<typeof prepareCatalogEntries>;
 }): {
   entry?: OfficialExternalPluginCatalogEntry;
   hasPublishedIdentity: boolean;
@@ -756,48 +725,16 @@ function resolveInstalledHostedOfficialEntry(params: {
     });
   const hostedPackageName =
     installedOfficialIdentity?.source === "npm"
-      ? (bundledOfficialEntry
-          ? resolveCatalogPackageSourceIdentities(bundledOfficialEntry)
-          : []
-        ).find((identity) => identity.source === "clawhub")?.packageName
+      ? bundledOfficialEntry?.clawhub?.name
       : installedOfficialIdentity?.packageName;
   return {
     entry: resolveInstalledOfficialCatalogEntry({
       entries: params.officialEntries,
       packageName: hasInstalledOfficialProvenance ? hostedPackageName : undefined,
       source: "clawhub",
-    }),
+    })?.entry,
     hasPublishedIdentity: Boolean(hasInstalledOfficialProvenance && hostedPackageName),
   };
-}
-
-function resolvePluginIconUrlFromCatalogFacts(params: {
-  metadata: PluginMetadataSnapshot;
-  officialEntries: readonly OfficialExternalPluginCatalogEntry[];
-  bundledOfficialEntries?: readonly OfficialExternalPluginCatalogEntry[];
-  pluginId: string;
-}): string | undefined {
-  const normalizedPluginId = params.metadata.normalizePluginId(params.pluginId);
-  const record = params.metadata.index.plugins.find(
-    (candidate) => params.metadata.normalizePluginId(candidate.pluginId) === normalizedPluginId,
-  );
-  const localIcon = normalizeOptionalString(
-    params.metadata.byPluginId.get(normalizedPluginId)?.icon,
-  );
-  if (!record) {
-    return resolveOfficialCatalogIconUrl(params.officialEntries, normalizedPluginId);
-  }
-  const ownership = resolveInstalledPluginPackageOwnership(params.metadata.index, record.pluginId);
-  const installOwner = ownership.ok ? ownership.value.installOwner : undefined;
-  const { entry: officialEntry } = resolveInstalledHostedOfficialEntry({
-    record,
-    ...(installOwner ? { installOwner } : {}),
-    installRecord: installOwner ? params.metadata.index.installRecords[installOwner] : undefined,
-    officialEntries: params.officialEntries,
-    bundledOfficialEntries:
-      params.bundledOfficialEntries ?? listOfficialExternalPluginCatalogEntries(),
-  });
-  return resolveCatalogEntryIcon(officialEntry) ?? localIcon;
 }
 
 function resolveManagedPluginMetadataParams(config: OpenClawConfig, env: NodeJS.ProcessEnv) {
@@ -855,12 +792,30 @@ export const resolveManagedPluginIconUrl = withManagedPluginCache(
     const env = params.env ?? process.env;
     const metadata = resolveManagedPluginMetadata(params.config, env);
     const officialCatalog = params.officialCatalog ?? (await loadOfficialCatalog());
-    return resolvePluginIconUrlFromCatalogFacts({
-      metadata,
-      officialEntries: officialCatalog.entries,
-      bundledOfficialEntries: listOfficialExternalPluginCatalogEntries(),
-      pluginId: params.pluginId,
+    const normalizedPluginId = metadata.normalizePluginId(params.pluginId);
+    const record = metadata.index.plugins.find(
+      (candidate) => metadata.normalizePluginId(candidate.pluginId) === normalizedPluginId,
+    );
+    if (!record) {
+      return resolveCatalogEntryIcon(
+        officialCatalog.entries.find(
+          (candidate) => resolveOfficialExternalPluginId(candidate) === normalizedPluginId,
+        ),
+      );
+    }
+    const ownership = resolveInstalledPluginPackageOwnership(metadata.index, record.pluginId);
+    const installOwner = ownership.ok ? ownership.value.installOwner : undefined;
+    const { entry: officialEntry } = resolveInstalledHostedOfficialEntry({
+      record,
+      ...(installOwner ? { installOwner } : {}),
+      installRecord: installOwner ? metadata.index.installRecords[installOwner] : undefined,
+      officialEntries: prepareCatalogEntries(officialCatalog.entries),
+      bundledOfficialEntries: prepareCatalogEntries(listOfficialExternalPluginCatalogEntries()),
     });
+    return (
+      resolveCatalogEntryIcon(officialEntry) ??
+      normalizeOptionalString(metadata.byPluginId.get(normalizedPluginId)?.icon)
+    );
   },
 );
 
@@ -917,7 +872,12 @@ export const listManagedPlugins = withManagedPluginCache(
     const metadata = params.metadata ?? resolveManagedPluginMetadata(params.config, env);
     const pluginDiagnostics = resolveManagedPluginDiagnostics(metadata, params.config);
     const officialCatalog = params.officialCatalog ?? (await loadOfficialCatalog());
-    const bundledOfficialEntries = listOfficialExternalPluginCatalogEntries();
+    // Overlay can backfill the name used by legacy npm identity; prepare the merged entry.
+    const officialEntries = prepareCatalogEntries(officialCatalog.entries);
+    const bundledOfficialEntries = prepareCatalogEntries(
+      listOfficialExternalPluginCatalogEntries(),
+    );
+    const installedIconsById = new Map<string, string | undefined>();
     const capabilityConsentDiagnostics: PluginDiagnostic[] = [];
     const plugins = metadata.index.plugins.map((record): ManagedPluginCatalogEntry => {
       const enabled = isInstalledPluginEnabled(metadata.index, record.pluginId, params.config, env);
@@ -946,17 +906,16 @@ export const listManagedPlugins = withManagedPluginCache(
         record,
         ...(installOwner ? { installOwner } : {}),
         installRecord,
-        officialEntries: officialCatalog.entries,
+        officialEntries,
         bundledOfficialEntries,
       });
-      const hasHostedOfficialIdentity = hasPublishedIdentity;
       const officialCatalogMetadata = officialEntry
         ? normalizeCatalogMetadata(getOfficialExternalPluginCatalogManifest(officialEntry)?.catalog)
         : undefined;
       // Published plugin curation follows the live feed even after install, including
       // omission. Private bundled plugins without an exact package/source match stay local.
       const catalog =
-        hasHostedOfficialIdentity && officialCatalog.hostedFeaturedAuthoritative
+        hasPublishedIdentity && officialCatalog.hostedFeaturedAuthoritative
           ? {
               ...localCatalog,
               ...officialCatalogMetadata,
@@ -971,7 +930,7 @@ export const listManagedPlugins = withManagedPluginCache(
       // Only externally installed plugins (tracked install record, non-bundled) can be removed.
       const removable = record.origin !== "bundled" && Boolean(installOwner);
       const hostedListingAuthoritative =
-        hasHostedOfficialIdentity && officialCatalog.hostedFeaturedAuthoritative === true;
+        hasPublishedIdentity && officialCatalog.hostedFeaturedAuthoritative === true;
       const featuredAt =
         hostedListingAuthoritative && catalog?.featured === true
           ? normalizeFeaturedAt(officialEntry?.featuredAt)
@@ -1014,14 +973,16 @@ export const listManagedPlugins = withManagedPluginCache(
       if (catalog?.order !== undefined) {
         plugin.order = catalog.order;
       }
-      if (
-        resolvePluginIconUrlFromCatalogFacts({
-          metadata,
-          officialEntries: officialCatalog.entries,
-          bundledOfficialEntries,
-          pluginId: record.pluginId,
-        })
-      ) {
+      const normalizedPluginId = metadata.normalizePluginId(record.pluginId);
+      // Icon lookup uses the first normalized record, even when that record has no icon.
+      if (!installedIconsById.has(normalizedPluginId)) {
+        installedIconsById.set(
+          normalizedPluginId,
+          resolveCatalogEntryIcon(officialEntry) ??
+            normalizeOptionalString(metadata.byPluginId.get(normalizedPluginId)?.icon),
+        );
+      }
+      if (installedIconsById.get(normalizedPluginId)) {
         plugin.hasIcon = true;
       }
       if (error) {
@@ -1038,11 +999,8 @@ export const listManagedPlugins = withManagedPluginCache(
     );
     // Hosted rows without a declared runtime id fall back to their package name,
     // so id matching alone would keep them visible after a successful install.
-    const entryPackageInstalled = (entry: OfficialExternalPluginCatalogEntry) =>
-      resolveCatalogPackageSourceIdentities(entry).some((identity) =>
-        installedPackageNames.has(identity.packageName),
-      );
-    for (const entry of officialCatalog.entries) {
+    for (const facts of officialEntries()) {
+      const { entry, clawhub, npmPackage } = facts;
       const pluginId = resolveOfficialExternalPluginId(entry);
       const manifest = getOfficialExternalPluginCatalogManifest(entry);
       const manifestCatalog = normalizeCatalogMetadata(manifest?.catalog);
@@ -1055,14 +1013,22 @@ export const listManagedPlugins = withManagedPluginCache(
                 : {}),
             }
           : undefined;
-      if (!pluginId || !catalog || installedIds.has(pluginId) || entryPackageInstalled(entry)) {
+      if (
+        !pluginId ||
+        !catalog ||
+        installedIds.has(pluginId) ||
+        (clawhub && installedPackageNames.has(clawhub.name)) ||
+        (npmPackage && installedPackageNames.has(npmPackage))
+      ) {
         continue;
       }
       const kind = normalizeKinds(entry.kind);
-      const install = resolveCatalogInstallAction({ entry, pluginId });
-      const clawhubPackageName = resolveCatalogPackageSourceIdentities(entry).find(
-        (identity) => identity.source === "clawhub",
-      )?.packageName;
+      const install: ManagedPluginCatalogEntry["install"] =
+        clawhub && !clawhub.version
+          ? { source: "clawhub", packageName: clawhub.name }
+          : facts.install
+            ? { source: "official", pluginId }
+            : undefined;
       const description = normalizeOptionalString(entry.description);
       const version = normalizeOptionalString(entry.version);
       const featuredAt =
@@ -1070,7 +1036,7 @@ export const listManagedPlugins = withManagedPluginCache(
       plugins.push({
         id: pluginId,
         name: resolveOfficialExternalPluginLabel(entry),
-        ...(clawhubPackageName ? { packageName: clawhubPackageName } : {}),
+        ...(clawhub ? { packageName: clawhub.name } : {}),
         ...(description ? { description } : {}),
         ...(version ? { version } : {}),
         ...(kind ? { kind } : {}),
@@ -1147,8 +1113,8 @@ export const inspectManagedPlugin = withManagedPluginCache(
         record,
         ...(installOwner ? { installOwner } : {}),
         installRecord,
-        officialEntries: officialCatalog.entries,
-        bundledOfficialEntries: listOfficialExternalPluginCatalogEntries(),
+        officialEntries: prepareCatalogEntries(officialCatalog.entries),
+        bundledOfficialEntries: prepareCatalogEntries(listOfficialExternalPluginCatalogEntries()),
       });
       const spec = installRecord?.resolvedSpec ?? installRecord?.spec;
       const packageName = installRecord?.clawhubPackage ?? record.packageName;
@@ -1206,8 +1172,8 @@ export const inspectManagedPlugin = withManagedPluginCache(
       });
     }
     const manifest = getOfficialExternalPluginCatalogManifest(entry);
-    const install = resolveOfficialExternalPluginInstall(entry);
-    const packageName = resolveCatalogPackageSourceIdentities(entry)[0]?.packageName;
+    const { install, clawhub, npmPackage } = prepareCatalogEntry(entry);
+    const packageName = clawhub?.name ?? npmPackage;
     const spec = install?.clawhubSpec ?? install?.npmSpec;
     const description = normalizeOptionalString(entry.description);
     const version = normalizeOptionalString(entry.version);


### PR DESCRIPTION
## What Problem This Solves

Plugin management repeatedly parses the same package identities while joining installed plugins with the official catalog. Larger plugin inventories pay for that work in listing, inspection, and icon lookup.

## Why This Change Was Made

Prepare package/source facts once per collection and reuse them within the operation. Preparation stays lazy so unknown local installs with an empty feed do not parse the bundled catalog unnecessarily. Listing also reuses the presentation facts it already resolved instead of resolving every installed icon a second time.

The management service remains the owner. This removes duplicate parsing and icon helper paths without introducing a process cache, dependency, setting, schema change, or alternate policy path. Duplicate catalog occurrences still make identity ambiguous; hosted Featured authority, npm-to-ClawHub provenance, package suppression, install actions, and first-normalized-record icon selection are preserved.

Production: **+96 / −130, net −34**. Tests: **+302 / −5, net +297**. The 25 added composition cases cover duplicate occurrences, overlay-derived identities, normalized icon precedence, and install authority; they pass with both the original and changed implementation.

## User Impact

The same plugin catalog and actions require less repeated work. There is no intended visual, configuration, install-policy, or plugin API change.

## Evidence

A fixed 17-scenario experiment measures complete awaited management operations using native metadata, SQLite/Kysely, provenance resolution, and the default catalog loader. The catalog HTTP transport returns deterministic real Response objects; these are **not network latency measurements**. Each of four fresh processes runs one first observation, four warmups, and 11 measured observations per row: **1,088 operations**, in before/candidate then candidate/before order. Imports, setup, and output comparison are outside the operation clock. All complete public outputs and native state evidence match across 17 before/candidate proof pairs.

The two ordinary list workloads improved in both orders:

| Installed / hosted entries | Before → candidate, first order | Before → candidate, reverse order |
|---|---:|---:|
| 8 / 32 | 7.374 → 2.152 ms (70.8% less) | 7.545 → 2.160 ms (71.4% less) |
| 32 / 64 | 64.906 → 28.489 ms (56.1% less) | 63.229 → 28.092 ms (55.6% less) |

The fixed gate required at least 3% improvement on each ordinary workload in both orders, and rejected any other row regressing more than 3% in both orders. All rows passed. An earlier eager preparation candidate failed the empty-feed controls and was discarded; this lazy version was measured as a separate candidate.

<details>
<summary>All median changes, including adverse observations</summary>

Negative percentages mean less elapsed time. These are initialized-operation medians, not startup or whole-Gateway claims.

| Scenario | First order | Reverse order |
|---|---:|---:|
| empty | +4.89% | +0.18% |
| minimal private and hosted | -37.59% | -45.22% |
| ordinary8installed32hosted | -70.82% | -71.38% |
| ordinary32installed64hosted | -56.11% | -55.57% |
| stress128installed256hosted | -51.59% | -51.20% |
| no installed | -95.56% | -95.80% |
| feed omission | -50.41% | -50.75% |
| bundled fallback | -56.66% | -57.09% |
| hosted snapshot304 | -56.00% | -55.96% |
| cross-source installed suppression | -75.04% | -74.79% |
| installed published icon | -82.91% | -81.48% |
| unproven global icon | -82.19% | -80.81% |
| unproven global icon empty feed | -0.85% | -2.77% |
| uninstalled exact-ID icon | -97.65% | -97.64% |
| installed published inspect | -81.92% | -82.32% |
| unproven global inspect empty feed | +0.60% | +1.02% |
| hosted32bundled0 | -24.09% | -22.85% |

The empty-list control rose 7.54 µs in the first order and 0.29 µs in reverse. Empty-feed local inspection rose 0.58 / 1.04 µs. All first observations were retained: local empty-feed icon lookup rose 1.53 ms in one order (1.93 → 3.46 ms) and fell 0.11 ms in reverse; empty-list first use rose 0.30 ms in reverse; empty-feed inspection first use rose 0.085 ms in the first order. No universal first-use, startup, memory, or end-to-end speedup is claimed.

</details>

Measurement base: `5b23a451d50f928e52ee0b9f2767d2ae5a3eba61`. Integration base: `9d10dcb5d39d09be94f48a1bfce1dbfd7a256903`. The selected runtime/dependency inputs remained byte-identical; only a selected guide changed. Production formatting and a test optional-access correction followed measurement. This is selected-input correspondence, not a full dependency-graph identity claim.

Final candidate validation (tests and checks before committing; build and live proof on the committed head):

- All **81 canonical tests** passed across Featured, general management, inspection, and lifecycle-cache suites; test titles match the original baseline.
- `pnpm check:changed` passed. Initial formatting and test type-check failures were fixed, then the complete check passed.
- `pnpm build qaRuntime` passed; an isolated Codex review found no blocking defects. Root reviewed the final test-only correction and complete diff.
- A real isolated Gateway completed **five OpenAI turns**, including tool search, file read, and sequential Markdown/text web fetches (both HTTP 200).
- Real default `plugins.list` returned 165 rows without diagnostics; `plugins.inspect` succeeded for an actual installed row. Its authenticated icon GET and HEAD both returned 200 with matching representation headers (562-byte SVG, empty HEAD body).
- Twelve session-list requests, five system/status observations, and native trajectory metadata for all five completed runs succeeded. Late metadata truncation is retained rather than presented as complete redaction coverage.
- The live run finished in 32.88 seconds. All 12,457 built entries remained unchanged; owned processes, groups, temporary credential FIFO, and eight exact coordinator paths were closed/removed. Private logs and databases remain local.

Independent source and raw-measurement audits found no accepted findings. Retained timing result SHA-256: `50542e4cdf7a03d589bd3227f867e40284ab093cdd829179c6095b343d18004f`; final canonical evidence seal: `cfdea160974864bc6e796c8fdd4488d516c98d81e2bf51ede79fd8cd9e317c16`.
