### PR TITLE
refactor(browser): share first request header value

### DIFF
--- a/extensions/browser/src/browser/csrf.ts
+++ b/extensions/browser/src/browser/csrf.ts
@@ -7,10 +7,7 @@
 import type { NextFunction, Request, Response } from "express";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { isLoopbackHost } from "../gateway/net.js";
-
-function firstHeader(value: string | string[] | undefined): string {
-  return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
-}
+import { firstHeaderValue } from "./request-header.js";
 
 function isMutatingMethod(method: string): boolean {
   const m = (method || "").trim().toUpperCase();
@@ -75,9 +72,9 @@ export function browserMutationGuardMiddleware(): (
       return next();
     }
 
-    const origin = firstHeader(req.headers.origin);
-    const referer = firstHeader(req.headers.referer);
-    const secFetchSite = firstHeader(req.headers["sec-fetch-site"]);
+    const origin = firstHeaderValue(req.headers.origin);
+    const referer = firstHeaderValue(req.headers.referer);
+    const secFetchSite = firstHeaderValue(req.headers["sec-fetch-site"]);
 
     if (
       shouldRejectBrowserMutation({

--- a/extensions/browser/src/browser/extension-relay/relay-request.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-request.ts
@@ -1,14 +1,11 @@
 import type { IncomingMessage } from "node:http";
+import { firstHeaderValue } from "../request-header.js";
 
 export const LEGACY_EXTENSION_RELAY_PROTOCOL = "openclaw-extension-relay";
 const LEGACY_EXTENSION_RELAY_TOKEN_PROTOCOL_PREFIX = "openclaw-extension-token.";
 
-export function firstHeader(value: string | string[] | undefined): string {
-  return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
-}
-
 export function requestProtocols(req: IncomingMessage): string[] {
-  return firstHeader(req.headers["sec-websocket-protocol"])
+  return firstHeaderValue(req.headers["sec-websocket-protocol"])
     .split(",")
     .map((value) => value.trim())
     .filter(Boolean);
@@ -26,6 +23,6 @@ export function requestExtensionProtocolToken(req: IncomingMessage): string {
 }
 
 export function isAllowedExtensionOrigin(req: IncomingMessage): boolean {
-  const origin = firstHeader(req.headers.origin);
+  const origin = firstHeaderValue(req.headers.origin);
   return origin === "" || origin.startsWith("chrome-extension://");
 }

--- a/extensions/browser/src/browser/extension-relay/relay-server.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.ts
@@ -12,6 +12,7 @@ import {
 import { WebSocketServer, type WebSocket } from "ws";
 import { isLoopbackHost } from "../../gateway/net.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { firstHeaderValue } from "../request-header.js";
 import { randomRelayId } from "./auth-v2-crypto.js";
 import { authenticateExtensionWebSocket } from "./auth-v2-websocket.js";
 import {
@@ -34,7 +35,6 @@ import { readExtensionRelayToken } from "./relay-auth.js";
 import { ExtensionRelayBridge } from "./relay-bridge.js";
 import { parseExtensionMessage } from "./relay-protocol.js";
 import {
-  firstHeader,
   isAllowedExtensionOrigin,
   requestExtensionProtocolToken,
   requestProtocols,
@@ -80,7 +80,7 @@ export type ExtensionRelayHandle = {
 };
 
 function decodeBasic(req: IncomingMessage): { username: string; password: string } | null {
-  const auth = firstHeader(req.headers.authorization);
+  const auth = firstHeaderValue(req.headers.authorization);
   if (!auth.startsWith("Basic ")) {
     return null;
   }
@@ -110,7 +110,7 @@ function isAuthorizedLegacy(
   if (!allowLegacyAuth) {
     return false;
   }
-  const auth = firstHeader(req.headers.authorization);
+  const auth = firstHeaderValue(req.headers.authorization);
   if (auth.startsWith("Bearer ") && safeEqualSecret(token, auth.slice("Bearer ".length).trim())) {
     return true;
   }
@@ -123,7 +123,7 @@ function isAuthorizedLegacy(
 }
 
 function hasLoopbackHostHeader(req: IncomingMessage): boolean {
-  const host = firstHeader(req.headers.host);
+  const host = firstHeaderValue(req.headers.host);
   if (!host) {
     return true;
   }

--- a/extensions/browser/src/browser/http-auth.ts
+++ b/extensions/browser/src/browser/http-auth.ts
@@ -7,10 +7,7 @@
 import type { IncomingMessage } from "node:http";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-
-function firstHeaderValue(value: string | string[] | undefined): string {
-  return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
-}
+import { firstHeaderValue } from "./request-header.js";
 
 function parseBearerToken(authorization: string): string | undefined {
   if (!normalizeLowercaseStringOrEmpty(authorization).startsWith("bearer ")) {

--- a/extensions/browser/src/browser/request-header.ts
+++ b/extensions/browser/src/browser/request-header.ts
@@ -1,0 +1,4 @@
+/** Projects a Node request header value to one string without additional normalization. */
+export function firstHeaderValue(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
+}


### PR DESCRIPTION
## What Problem This Solves

Resolves duplicated request-header value selection across Browser CSRF, HTTP authentication, and extension relay paths. Keeping the same `string | string[] | undefined` projection in three places risks accidental drift at security-sensitive request boundaries.

## Why This Change Was Made

The Browser plugin now owns one private `firstHeaderValue` helper that projects a Node request header value to one string without additional normalization. CSRF, bearer/password authentication, relay protocol parsing, origin checks, and relay server authentication import it directly.

Normalization and security policy remain in the callers: this helper does not trim, join, case-fold, parse, validate, or compare header values. No SDK, barrel, config, storage, protocol, dependency, test, or changelog surface changed.

## User Impact

No intended user-visible behavior change. Browser request authentication and CSRF checks keep their existing semantics while sharing one canonical header-value projection.

## Evidence

- Base: `d17027cfdc5e1be1d8fcabc50aa13e6a13b83e4c`
- Signed head: `836e6d25f65247f908d296dc86fbd8608ac22d86`
- Production diff: 5 files, `+16/-21`, net `-5`; tests unchanged
- Five focused Browser suites: 47 tests passed; the remaining test failed before changed code ran because this macOS host cannot bind `127.0.0.2` (`EADDRNOTAVAIL`)
- Blacksmith Testbox `tbx_01m1f55kxs4j0zh81q7sb8bgvd`: full Browser extension lane passed, 222 files and 3,623 tests; 5 files and 25 tests skipped as designed
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/33546416820
- Extension package-boundary compile: all 123 plugins passed
- Exact five-path `check:changed`: passed
- `pnpm check:import-cycles`: 0 runtime value cycles
- Sol-high autoreview: scoped clean, correctness 0.99
- No new helper unit test: existing CSRF, HTTP auth, relay route, relay protocol, and relay auth-v2 boundary suites exercise the protected behavior; a direct helper test would only restate the one-line projection
