### PR TITLE
fix(system-agent): preserve the redacted owner-drift cause in managed control

### DIFF
--- a/src/system-agent/setup-inference-verify.ts
+++ b/src/system-agent/setup-inference-verify.ts
@@ -8,6 +8,7 @@ import { loadAuthProfileStoreForRuntime } from "../agents/auth-profiles/store.js
 import type { AgentExecutionAuthBinding } from "../agents/execution-auth-binding.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import type { ProviderAuthResult } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
@@ -434,12 +435,13 @@ export async function verifySetupInferenceConfig(params: {
             deps,
           });
           params.onVerifiedExecution?.(test.auth, binding);
-        } catch {
+        } catch (error) {
           return {
             ok: false,
             status: "auth",
-            error:
-              "The verified inference owner changed before validation completed. Retry the inference check.",
+            error: await redactSetupInferenceError(
+              `The verified inference owner changed before validation completed. Retry the inference check. (${formatErrorMessage(error)})`,
+            ),
             ...(authProfiles ? { authProfiles } : {}),
           };
         }

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -2445,6 +2445,10 @@ describe("activateSetupInference", () => {
       status: "auth",
       error: expect.stringContaining("verified inference owner changed"),
     });
+    // The specific owner failure cause is preserved (redacted) for diagnosis.
+    expect(result.error).toContain(
+      "The successful inference credential is no longer the active route owner.",
+    );
     expect(configHarness.current()).toEqual({});
   });
 

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -2452,6 +2452,33 @@ describe("activateSetupInference", () => {
     expect(configHarness.current()).toEqual({});
   });
 
+  it("preserves the redacted revalidation cause through bound verification", async () => {
+    const config: OpenClawConfig = {
+      agents: { entries: { main: { default: true, model: "openai/gpt-5.6-sol" } } },
+    };
+    const result = await verifySetupInferenceConfig({
+      config,
+      requireExecutionOwner: true,
+      deps: {
+        runEmbeddedAgent: vi.fn(successfulRunner("openai", "gpt-5.6-sol")) as never,
+        createSystemAgentVerifiedInferenceBinding: vi.fn(async () => {
+          throw new Error(
+            "The successful inference credential is no longer the active route owner.",
+          );
+        }) as never,
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: "auth",
+      error: expect.stringContaining("verified inference owner changed"),
+    });
+    expect(result.error).toContain(
+      "The successful inference credential is no longer the active route owner.",
+    );
+  });
+
   it("revalidates a stable CLI runtime owner at the config commit boundary", async () => {
     const configHarness = createPreRosterConfigTransformHarness();
     const resolveCliRuntimeOwnerFingerprint = vi.fn(async () => "test-runtime-owner");


### PR DESCRIPTION
Closes #134471

## What Problem This Solves

Fixes a managed-control diagnostic gap. When a healthy Codex/OpenAI route failed managed configuration writes with `OpenClaw requires working inference: The verified inference owner changed before validation completed`, the surfaced error hid the underlying owner/harness failure, leaving no actionable local diagnosis.

## Why This Change Was Made

`revalidateStableSetupInferenceOwner` already wraps the underlying revalidation failure in a `SetupInferenceOwnerDriftError` that carries the redacted specific cause (for example, "The successful inference credential is no longer the active route owner."). But the verify ladder caught that error with a bare `catch {}` and replaced it wholesale with a generic string. This change propagates the already-redacted specific cause through `formatErrorMessage` + `redactSetupInferenceError` while keeping the fail-closed `status: "auth"` result unchanged.

## User Impact

Managed-control failures now surface the specific owner/harness cause (still redacted) alongside the generic drift message, so a healthy route's post-restart failure can be diagnosed instead of showing a generic owner-drift error.

## Evidence

Exact head: `0e709d518d304d82371a85ca9358accf8ed161fa`.

- `src/system-agent/setup-inference.test.ts` — 147 passed, including an updated regression asserting the specific owner-failure cause ("The successful inference credential is no longer the active route owner.") is preserved in the result while still failing closed.
- Production typecheck and `check:changed` pass; the only local lane failure is unchanged `ui/vite.config.ts` missing a `pako` declaration in the reused dependency tree.

## AI Assistance

AI-assisted implementation. I manually verified the verify ladder catch, the redaction path, the focused regression, and the changed-file gates.
