### PR TITLE
refactor(scripts): reuse POSIX path normalizer

### DIFF
--- a/scripts/check-export-name-collisions.mts
+++ b/scripts/check-export-name-collisions.mts
@@ -3,6 +3,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import ts from "typescript";
+import { toPosixPath } from "./check-file-utils.ts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import {
   collectTypeScriptFilesFromRoots,
@@ -59,12 +60,8 @@ export type ModuleExports = {
 const failurePrefix = "check-export-name-collisions";
 const extraExcludedFileSuffixes = [".test-support.ts", ".test-helpers.ts", ".d.ts"];
 
-function normalizeRelativePath(filePath: string) {
-  return filePath.replaceAll(path.sep, "/");
-}
-
 export function isExcludedExportCollisionSource(filePath: string) {
-  const normalized = normalizeRelativePath(filePath);
+  const normalized = toPosixPath(filePath);
   const segments = normalized.split("/");
   return (
     segments.includes("test") ||
@@ -620,7 +617,7 @@ function analyzeExportNames(modules: SourceModule[]) {
   for (const sourceModule of modules.toSorted((left, right) =>
     left.path.localeCompare(right.path),
   )) {
-    const relativePath = normalizeRelativePath(sourceModule.path);
+    const relativePath = toPosixPath(sourceModule.path);
     const moduleExports = collectModuleExportNames(sourceModule.content, relativePath);
     modulesByPath.set(relativePath, moduleExports);
     if (sourceModule.includeDefinitions !== false && !relativePath.startsWith("src/plugin-sdk/")) {
@@ -713,7 +710,7 @@ async function collectRepositoryModules(repoRoot: string) {
     ].map(async ({ filePath, includeDefinitions }) => ({
       content: await fs.readFile(filePath, "utf8"),
       includeDefinitions,
-      path: normalizeRelativePath(path.relative(repoRoot, filePath)),
+      path: toPosixPath(path.relative(repoRoot, filePath)),
     })),
   );
   return modules;

--- a/scripts/check-session-accessor-boundary.mts
+++ b/scripts/check-session-accessor-boundary.mts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import ts from "typescript";
 import { z } from "zod";
+import { toPosixPath } from "./check-file-utils.ts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import {
   collectFileViolations,
@@ -294,12 +295,8 @@ type BoundaryViolation = { line: number; reason: string };
 const sessionAccessorDebtCountsSchema = z.record(z.string(), z.record(z.string(), z.number()));
 type SessionAccessorDebtCounts = z.infer<typeof sessionAccessorDebtCountsSchema>;
 
-function normalizeRelativePath(filePath: string) {
-  return filePath.replaceAll(path.sep, "/");
-}
-
 function legacyNamesForFile(fileName: string) {
-  const normalized = normalizeRelativePath(fileName);
+  const normalized = toPosixPath(fileName);
   if (
     fileName === "source.ts" ||
     [...migratedBundledPluginSessionAccessorFiles].some((filePath) => normalized.endsWith(filePath))
@@ -800,12 +797,12 @@ async function collectSessionAccessorDebtCounts(repoRoot: string) {
       // Inverse of the enforcement skip: migrated files are held at zero by the
       // boundary checks, so the ratchet tracks only the unmigrated rest.
       skipFile: (filePath) =>
-        concern.migratedFiles.has(normalizeRelativePath(path.relative(repoRoot, filePath))),
+        concern.migratedFiles.has(toPosixPath(path.relative(repoRoot, filePath))),
       findViolations: concern.findViolations,
     });
     const fileCounts: Record<string, number> = {};
     for (const violation of violations) {
-      const relativePath = normalizeRelativePath(violation.path);
+      const relativePath = toPosixPath(violation.path);
       fileCounts[relativePath] = (fileCounts[relativePath] ?? 0) + 1;
     }
     counts[key] = sortRecordByKey(fileCounts);

--- a/scripts/check-session-transcript-reader-boundary.mts
+++ b/scripts/check-session-transcript-reader-boundary.mts
@@ -2,6 +2,7 @@
 
 import path from "node:path";
 import ts from "typescript";
+import { toPosixPath } from "./check-file-utils.ts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import {
   collectFileViolations,
@@ -102,10 +103,6 @@ export const migratedSessionTranscriptReaderFiles = new Set([
   "src/tui/embedded-backend.test.ts",
   "src/tui/embedded-backend.ts",
 ]);
-
-function normalizeRelativePath(filePath: string) {
-  return filePath.replaceAll(path.sep, "/");
-}
 
 function importedModuleName(node: ts.ImportDeclaration | ts.ExportDeclaration) {
   return node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)
@@ -264,9 +261,7 @@ export async function main() {
     sourceRoots,
     includeTests: true,
     skipFile: (filePath) =>
-      !migratedSessionTranscriptReaderFiles.has(
-        normalizeRelativePath(path.relative(repoRoot, filePath)),
-      ),
+      !migratedSessionTranscriptReaderFiles.has(toPosixPath(path.relative(repoRoot, filePath))),
     findViolations: findSessionTranscriptReaderBoundaryViolations,
   });
 

--- a/scripts/check-wrapper-shadowing.mts
+++ b/scripts/check-wrapper-shadowing.mts
@@ -9,6 +9,7 @@ import {
   type ModuleExports,
   type SourceModule,
 } from "./check-export-name-collisions.mts";
+import { toPosixPath } from "./check-file-utils.ts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import {
   collectTypeScriptFilesFromRoots,
@@ -25,12 +26,8 @@ export type WrapperShadowingViolation = {
 
 const failurePrefix = "check-wrapper-shadowing";
 
-function normalizeRelativePath(filePath: string) {
-  return filePath.replaceAll(path.sep, "/");
-}
-
 export function isExcludedWrapperShadowingSource(filePath: string) {
-  const normalized = normalizeRelativePath(filePath);
+  const normalized = toPosixPath(filePath);
   const segments = normalized.split("/");
   return (
     isExcludedExportCollisionSource(normalized) ||
@@ -113,7 +110,7 @@ export function findWrapperShadowingViolations(modules: SourceModule[]) {
   for (const sourceModule of modules.toSorted((left, right) =>
     left.path.localeCompare(right.path),
   )) {
-    const modulePath = normalizeRelativePath(sourceModule.path);
+    const modulePath = toPosixPath(sourceModule.path);
     modulesByPath.set(modulePath, collectModuleExportNames(sourceModule.content, modulePath));
   }
 
@@ -159,7 +156,7 @@ export async function collectRepositoryWrapperShadowing(repoRoot: string) {
   const modules = await Promise.all(
     files.map(async (filePath) => ({
       content: await fs.readFile(filePath, "utf8"),
-      path: normalizeRelativePath(path.relative(repoRoot, filePath)),
+      path: toPosixPath(path.relative(repoRoot, filePath)),
     })),
   );
   return findWrapperShadowingViolations(modules);


### PR DESCRIPTION
## What Problem This Solves

Resolves duplicated POSIX path normalization across four repository guard scripts. Keeping identical separator conversion helpers in each guard makes tooling behavior easier to drift and obscures the existing canonical scripts utility.

## Why This Change Was Made

The four guards now import `toPosixPath` from `scripts/check-file-utils.ts`, and their local `normalizeRelativePath` copies are removed. All `node:path` imports remain because each script still uses other path operations.

## User Impact

No user-visible behavior changes. There is no SDK, configuration, storage, protocol, or runtime impact; this is scripts-only tooling deduplication.

## Evidence

- Implementation base: `ec6809571d8be837eff10cef886206df924f2c65`
- Signed head: `280903f156022ededec80e30d4dce0082b962751`
- Diff: 4 tooling files, `+14/-28` (net `-14`); tests `+0/-0`
- Focused Vitest: 5 requested files, 77 tests passed
- Direct guards passed:
  - `pnpm lint:tmp:export-name-collisions`
  - `pnpm lint:tmp:session-accessor-boundary`
  - `pnpm lint:tmp:session-transcript-reader-boundary`
  - `pnpm check:wrapper-shadowing`
- `pnpm check:import-cycles`: 0 runtime value cycles
- Exact-path `check-changed` dry run completed; actual planned lanes passed after restoring tracked `ui/config` files omitted by the worktree's sparse profile
- Formatting, diff check, scripts typecheck, targeted oxlint, and remaining changed-file guards passed
- Sol-high autoreview against `origin/main`: scoped clean, correctness 0.99
- Commit signature verified

No Crabbox or native prepare run yet because https://github.com/openclaw/openclaw/pull/135167 owns the active heavy Testbox lane.
