### PR TITLE
fix(memory): keep custom embedding auth explicit

### DIFF
--- a/scripts/repro-134700.mts
+++ b/scripts/repro-134700.mts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-const repoRoot = process.env.OPENCLAW_PROOF_REPO?.trim() || path.resolve(import.meta.dirname, "..");
+const repoRoot = path.resolve(import.meta.dirname, "..");
 const { openAICompatibleEmbeddingProviderAdapter } = await import(
   pathToFileURL(path.join(repoRoot, "src/plugins/openai-compatible-embedding-provider.ts")).href
 );
@@ -18,17 +18,15 @@ const { closeOpenClawAgentDatabases } = await import(
 
 const profileId = "tenant-embeddings:profile-only";
 const profileKey = "synthetic-profile-only-key";
-const negativeControl = process.env.OPENCLAW_PROOF_MODE === "explicit-empty";
-const expectedAuthorization = process.env.OPENCLAW_PROOF_EXPECTED?.trim() || "profile";
 let server: Server | undefined;
-let receivedHeaders: IncomingHttpHeaders | undefined;
+const requests: Array<{ headers: IncomingHttpHeaders }> = [];
 const agentDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-repro-134700-"));
 
 try {
   server = createServer((request, response) => {
     request.resume();
     request.once("end", () => {
-      receivedHeaders = request.headers;
+      requests.push({ headers: request.headers });
       response.writeHead(200, { "content-type": "application/json" });
       response.end(JSON.stringify({ data: [{ index: 0, embedding: [0.25, 0.5, 0.75] }] }));
     });
@@ -55,7 +53,7 @@ try {
     agentDir,
   );
 
-  const result = await openAICompatibleEmbeddingProviderAdapter.create({
+  const createOptions = (apiKey?: string) => ({
     config: {
       auth: {
         profiles: { [profileId]: { provider: "tenant-embeddings", mode: "api_key" } },
@@ -66,7 +64,7 @@ try {
           "tenant-embeddings": {
             api: "openai-completions",
             baseUrl,
-            ...(negativeControl ? { apiKey: "" } : {}),
+            ...(apiKey === undefined ? {} : { apiKey }),
             models: [],
           },
         },
@@ -76,24 +74,38 @@ try {
     provider: "tenant-embeddings",
     model: "tenant-embeddings/fixture-model",
   });
-  const embedding = await result.provider?.embed("hello");
-  const authorization = receivedHeaders?.authorization;
-  const authorizationClass =
-    authorization === `Bearer ${profileKey}` ? "profile" : authorization ? "other" : "missing";
-  const observation = `mode=${negativeControl ? "explicit-empty" : "profile-only"} authorization=${authorizationClass} embedding=${embedding?.length ?? 0}`;
-  console.log(observation);
-  if (authorizationClass !== expectedAuthorization) {
-    console.error(`${observation} expected=${expectedAuthorization}`);
-    process.exitCode = 1;
+
+  const omittedKey = await openAICompatibleEmbeddingProviderAdapter.create(createOptions());
+  await omittedKey.provider.embed("hello");
+
+  const explicitProfile = await openAICompatibleEmbeddingProviderAdapter.create(
+    createOptions(profileId),
+  );
+  await explicitProfile.provider.embed("hello");
+
+  const omittedAuthorization = requests[0]?.headers.authorization;
+  const explicitAuthorization = requests[1]?.headers.authorization;
+  console.log(`omitted-apiKey authorization=${omittedAuthorization ? "present" : "missing"}`);
+  console.log(
+    `explicit-profile-reference authorization=${
+      explicitAuthorization === `Bearer ${profileKey}` ? "profile" : "other"
+    }`,
+  );
+  if (omittedAuthorization !== undefined) {
+    throw new Error("omitted apiKey unexpectedly sent Authorization");
+  }
+  if (explicitAuthorization !== `Bearer ${profileKey}`) {
+    throw new Error("explicit profile reference did not send its stored credential");
   }
 } finally {
   closeAuthProfileReadPool({ kind: "root", rootPath: agentDir });
   closeOpenClawAgentDatabases(agentDir);
   await rm(agentDir, { force: true, recursive: true });
   server?.closeAllConnections();
-  if (server) {
+  const runningServer = server;
+  if (runningServer) {
     await new Promise<void>((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
+      runningServer.close((error) => (error ? reject(error) : resolve()));
     });
   }
 }

--- a/scripts/repro-134700.mts
+++ b/scripts/repro-134700.mts
@@ -1,0 +1,99 @@
+import { once } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = process.env.OPENCLAW_PROOF_REPO?.trim() || path.resolve(import.meta.dirname, "..");
+const { openAICompatibleEmbeddingProviderAdapter } = await import(
+  pathToFileURL(path.join(repoRoot, "src/plugins/openai-compatible-embedding-provider.ts")).href
+);
+const { closeAuthProfileReadPool, writePersistedAuthProfileStoreRaw } = await import(
+  pathToFileURL(path.join(repoRoot, "src/agents/auth-profiles/sqlite.ts")).href
+);
+const { closeOpenClawAgentDatabases } = await import(
+  pathToFileURL(path.join(repoRoot, "src/state/openclaw-agent-db.ts")).href
+);
+
+const profileId = "tenant-embeddings:profile-only";
+const profileKey = "synthetic-profile-only-key";
+const negativeControl = process.env.OPENCLAW_PROOF_MODE === "explicit-empty";
+const expectedAuthorization = process.env.OPENCLAW_PROOF_EXPECTED?.trim() || "profile";
+let server: Server | undefined;
+let receivedHeaders: IncomingHttpHeaders | undefined;
+const agentDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-repro-134700-"));
+
+try {
+  server = createServer((request, response) => {
+    request.resume();
+    request.once("end", () => {
+      receivedHeaders = request.headers;
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ data: [{ index: 0, embedding: [0.25, 0.5, 0.75] }] }));
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("repro fixture did not expose a TCP address");
+  }
+  const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+
+  writePersistedAuthProfileStoreRaw(
+    {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "api_key",
+          provider: "tenant-embeddings",
+          key: profileKey,
+        },
+      },
+    },
+    agentDir,
+  );
+
+  const result = await openAICompatibleEmbeddingProviderAdapter.create({
+    config: {
+      auth: {
+        profiles: { [profileId]: { provider: "tenant-embeddings", mode: "api_key" } },
+        order: { "tenant-embeddings": [profileId] },
+      },
+      models: {
+        providers: {
+          "tenant-embeddings": {
+            api: "openai-completions",
+            baseUrl,
+            ...(negativeControl ? { apiKey: "" } : {}),
+            models: [],
+          },
+        },
+      },
+    },
+    agentDir,
+    provider: "tenant-embeddings",
+    model: "tenant-embeddings/fixture-model",
+  });
+  const embedding = await result.provider?.embed("hello");
+  const authorization = receivedHeaders?.authorization;
+  const authorizationClass =
+    authorization === `Bearer ${profileKey}` ? "profile" : authorization ? "other" : "missing";
+  const observation = `mode=${negativeControl ? "explicit-empty" : "profile-only"} authorization=${authorizationClass} embedding=${embedding?.length ?? 0}`;
+  console.log(observation);
+  if (authorizationClass !== expectedAuthorization) {
+    console.error(`${observation} expected=${expectedAuthorization}`);
+    process.exitCode = 1;
+  }
+} finally {
+  closeAuthProfileReadPool({ kind: "root", rootPath: agentDir });
+  closeOpenClawAgentDatabases(agentDir);
+  await rm(agentDir, { force: true, recursive: true });
+  server?.closeAllConnections();
+  if (server) {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}

--- a/src/plugins/openai-compatible-embedding-provider.integration.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.integration.test.ts
@@ -429,7 +429,7 @@ describe("OpenAI-compatible embedding destination credential ownership", () => {
     }
   });
 
-  it("uses a profile-only credential for a provider-owned embedding destination", async () => {
+  it("does not select a profile when a provider-owned destination omits apiKey", async () => {
     const agentDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-embedding-profile-only-"));
     const profileId = "tenant-embeddings:profile-only";
     try {
@@ -469,7 +469,7 @@ describe("OpenAI-compatible embedding destination credential ownership", () => {
 
       await expect(result.provider?.embed("hello")).resolves.toEqual(vector);
       expect(requests).toHaveLength(1);
-      expect(requests[0]?.headers.authorization).toBe("Bearer synthetic-profile-only-key");
+      expect(requests[0]?.headers.authorization).toBeUndefined();
     } finally {
       closeAuthProfileReadPool({ kind: "root", rootPath: agentDir });
       closeOpenClawAgentDatabases(agentDir);

--- a/src/plugins/openai-compatible-embedding-provider.integration.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.integration.test.ts
@@ -429,6 +429,54 @@ describe("OpenAI-compatible embedding destination credential ownership", () => {
     }
   });
 
+  it("uses a profile-only credential for a provider-owned embedding destination", async () => {
+    const agentDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-embedding-profile-only-"));
+    const profileId = "tenant-embeddings:profile-only";
+    try {
+      writePersistedAuthProfileStoreRaw(
+        {
+          version: 1,
+          profiles: {
+            [profileId]: {
+              type: "api_key",
+              provider: "tenant-embeddings",
+              key: "synthetic-profile-only-key",
+            },
+          },
+        },
+        agentDir,
+      );
+      const result = await openAICompatibleEmbeddingProviderAdapter.create({
+        config: {
+          auth: {
+            profiles: { [profileId]: { provider: "tenant-embeddings", mode: "api_key" } },
+            order: { "tenant-embeddings": [profileId] },
+          },
+          models: {
+            providers: {
+              "tenant-embeddings": {
+                api: "openai-completions",
+                baseUrl,
+                models: [],
+              },
+            },
+          },
+        },
+        agentDir,
+        provider: "tenant-embeddings",
+        model: "tenant-embeddings/fixture-model",
+      });
+
+      await expect(result.provider?.embed("hello")).resolves.toEqual(vector);
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.headers.authorization).toBe("Bearer synthetic-profile-only-key");
+    } finally {
+      closeAuthProfileReadPool({ kind: "root", rootPath: agentDir });
+      closeOpenClawAgentDatabases(agentDir);
+      await rm(agentDir, { force: true, recursive: true });
+    }
+  });
+
   it.each([
     {
       name: "profile reference",

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -197,39 +197,17 @@ async function resolveConfiguredProviderApiKey(params: {
     value: params.configuredProvider?.apiKey,
     path: `models.providers.${params.providerId}.apiKey`,
   });
-  const hasConfiguredApiKey = Object.hasOwn(params.configuredProvider ?? {}, "apiKey");
+  if (!apiKey) {
+    // An omitted or empty provider key does not opt this destination into profile discovery.
+    // Profile credentials require an explicit provider-entry binding below.
+    return undefined;
+  }
   const { resolveAgentDir, tryResolveAmbientOwnerAgentId } =
     await import("../agents/agent-scope-config.js");
   const agentId = tryResolveAmbientOwnerAgentId(params.options.config);
   const agentDir =
     params.options.agentDir?.trim() ||
     (agentId ? resolveAgentDir(params.options.config, agentId) : undefined);
-  if (!apiKey) {
-    // A present-but-empty field intentionally disables profile discovery.
-    if (
-      hasConfiguredApiKey ||
-      !agentDir ||
-      (!params.options.config.auth?.profiles && !params.options.config.auth?.order)
-    ) {
-      return undefined;
-    }
-    const { resolveApiKeyForProviderCore } = await import("../agents/model-auth-provider.js");
-    const { isProviderAuthError } = await import("../agents/model-auth-runtime-shared.js");
-    try {
-      const auth = await resolveApiKeyForProviderCore({
-        provider: params.providerId,
-        cfg: params.options.config,
-        agentDir,
-        modelApi: params.configuredProvider?.api,
-      });
-      return auth.apiKey;
-    } catch (error) {
-      if (isProviderAuthError(error, "missing-provider-auth")) {
-        return undefined;
-      }
-      throw error;
-    }
-  }
   // Without an owned auth store, a configured string retains its literal meaning.
   if (!agentDir) {
     return apiKey;

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -197,15 +197,39 @@ async function resolveConfiguredProviderApiKey(params: {
     value: params.configuredProvider?.apiKey,
     path: `models.providers.${params.providerId}.apiKey`,
   });
-  if (!apiKey) {
-    return undefined;
-  }
+  const hasConfiguredApiKey = Object.hasOwn(params.configuredProvider ?? {}, "apiKey");
   const { resolveAgentDir, tryResolveAmbientOwnerAgentId } =
     await import("../agents/agent-scope-config.js");
   const agentId = tryResolveAmbientOwnerAgentId(params.options.config);
   const agentDir =
     params.options.agentDir?.trim() ||
     (agentId ? resolveAgentDir(params.options.config, agentId) : undefined);
+  if (!apiKey) {
+    // A present-but-empty field intentionally disables profile discovery.
+    if (
+      hasConfiguredApiKey ||
+      !agentDir ||
+      (!params.options.config.auth?.profiles && !params.options.config.auth?.order)
+    ) {
+      return undefined;
+    }
+    const { resolveApiKeyForProviderCore } = await import("../agents/model-auth-provider.js");
+    const { isProviderAuthError } = await import("../agents/model-auth-runtime-shared.js");
+    try {
+      const auth = await resolveApiKeyForProviderCore({
+        provider: params.providerId,
+        cfg: params.options.config,
+        agentDir,
+        modelApi: params.configuredProvider?.api,
+      });
+      return auth.apiKey;
+    } catch (error) {
+      if (isProviderAuthError(error, "missing-provider-auth")) {
+        return undefined;
+      }
+      throw error;
+    }
+  }
   // Without an owned auth store, a configured string retains its literal meaning.
   if (!agentDir) {
     return apiKey;


### PR DESCRIPTION
Related: #134700

## What Problem This Solves

Resolves a credential-boundary problem where an OpenAI-compatible embedding destination could start receiving a saved auth profile without an explicit provider credential binding.

## Why This Change Was Made

Keep profile selection explicit through `models.providers.<id>.apiKey`. An omitted or empty provider key remains unauthenticated, while the existing explicit profile-reference path continues to resolve stored credentials.

## User Impact

Custom embedding endpoints do not receive saved credentials merely because a matching profile exists; users who want profile-backed authentication must name that profile in the provider entry.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/openai-compatible-embedding-provider.integration.test.ts`
- The integration test exercises a real loopback HTTP endpoint with an auth profile configured but `models.providers.<id>.apiKey` omitted, and verifies that no Authorization header is sent. Existing cases in the same suite verify that an explicit profile reference still sends the stored credential.

```text
$ node --import ./scripts/tsx.mjs scripts/repro-134700.mts
omitted-apiKey authorization=missing
explicit-profile-reference authorization=profile
```

AI-assisted: built with Codex
