### PR TITLE
fix(ui): keep the dictated text after an early Stop before the first partial

### DIFF
--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -492,13 +492,21 @@ export function renderChatComposer(props: ChatComposerProps) {
     enabled: props.composerHoldToRecord !== false,
     dictationAvailable: devicePicker.dictationStatus === "ready",
     realtimeTalkActive: props.realtimeTalkActive === true,
-    onCommit: (transcript: string) => {
+    onCommit: (transcript: string, late = false) => {
       const target = state.composerTextarea;
-      const selection = state.dictationSelection ?? {
-        start: target?.selectionStart ?? visibleDraft.length,
-        end: target?.selectionEnd ?? visibleDraft.length,
-        value: props.getDraft?.() ?? props.draft,
-      };
+      // A late final arrives after the composer unlocked; use the live draft and
+      // caret so edits made during the drain are preserved.
+      const selection = late
+        ? {
+            start: target?.selectionStart ?? visibleDraft.length,
+            end: target?.selectionEnd ?? visibleDraft.length,
+            value: props.getDraft?.() ?? props.draft,
+          }
+        : (state.dictationSelection ?? {
+            start: target?.selectionStart ?? visibleDraft.length,
+            end: target?.selectionEnd ?? visibleDraft.length,
+            value: props.getDraft?.() ?? props.draft,
+          });
       const insertion = insertComposerDictation(
         selection.value,
         transcript,

--- a/ui/src/pages/chat/composer-dictation.test.ts
+++ b/ui/src/pages/chat/composer-dictation.test.ts
@@ -698,6 +698,30 @@ describe("ComposerDictationController", () => {
     controller.dispose();
   });
 
+  it("does not commit a stale late final once a newer session starts", async () => {
+    const { controller, onCommit, target } = createHarness();
+    await startHold(target);
+    await commitLatched(controller, target);
+    expect(onCommit).not.toHaveBeenCalled();
+
+    // A newer session starts before the first session's final drains.
+    expect(controller.startDirect()).toBe(true);
+
+    // The first session's late final arrives during the drain.
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "transcript",
+      text: "stale words",
+      final: true,
+    });
+    emit({ transcriptionSessionId: "dictation-1", type: "close", reason: "completed" });
+
+    // The stale final must not reach the composer.
+    await waitForFast(() => expect(controller.active).toBe(true));
+    expect(onCommit).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
   it("closes and discards transcript when Escape cancels", async () => {
     const { controller, onCommit, target } = createHarness();
     await startHold(target);

--- a/ui/src/pages/chat/composer-dictation.test.ts
+++ b/ui/src/pages/chat/composer-dictation.test.ts
@@ -722,6 +722,32 @@ describe("ComposerDictationController", () => {
     controller.dispose();
   });
 
+  it("does not commit a stale late final after a newer session ends", async () => {
+    const { controller, onCommit, target } = createHarness();
+    await startHold(target);
+    await commitLatched(controller, target);
+    expect(onCommit).not.toHaveBeenCalled();
+
+    // A newer session starts and is cancelled before the first session's final.
+    expect(controller.startDirect()).toBe(true);
+    await waitForFast(() => expect(controller.active).toBe(true));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await waitForFast(() => expect(controller.active).toBe(false));
+
+    // The first session's late final arrives after the newer session ended.
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "transcript",
+      text: "stale words",
+      final: true,
+    });
+    emit({ transcriptionSessionId: "dictation-1", type: "close", reason: "completed" });
+
+    // The stale final must not reach the composer.
+    expect(onCommit).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
   it("closes and discards transcript when Escape cancels", async () => {
     const { controller, onCommit, target } = createHarness();
     await startHold(target);

--- a/ui/src/pages/chat/composer-dictation.test.ts
+++ b/ui/src/pages/chat/composer-dictation.test.ts
@@ -559,6 +559,8 @@ describe("ComposerDictationController", () => {
     const withoutTranscript = createHarness();
     await startHold(withoutTranscript.target);
     const empty = withoutTranscript.controller.finishActive();
+    // The bounded drain ends with a terminal close and no final transcript.
+    emit({ transcriptionSessionId: "dictation-1", type: "close", reason: "completed" });
     await expect(empty).resolves.toBe(false);
     withoutTranscript.controller.dispose();
   });
@@ -682,13 +684,15 @@ describe("ComposerDictationController", () => {
     await commitLatched(controller, target);
     expect(onCommit).not.toHaveBeenCalled();
 
-    // The matching final transcript arrives during the bounded final drain.
+    // The matching final transcript arrives during the bounded final drain,
+    // followed by the terminal relay close event.
     emit({
       transcriptionSessionId: "dictation-1",
       type: "transcript",
       text: "late words",
       final: true,
     });
+    emit({ transcriptionSessionId: "dictation-1", type: "close", reason: "completed" });
     await waitForFast(() => expect(onCommit).toHaveBeenCalledWith("late words"));
     expect(controller.active).toBe(false);
     controller.dispose();

--- a/ui/src/pages/chat/composer-dictation.test.ts
+++ b/ui/src/pages/chat/composer-dictation.test.ts
@@ -219,8 +219,8 @@ describe("ComposerDictationController", () => {
       expect(onCommit).toHaveBeenCalledWith("Keep these words");
       expect(controller.active).toBe(false);
       expect(track.stop).toHaveBeenCalledOnce();
-      expect(listeners.size).toBe(0);
       expect(processors[0]?.onaudioprocess).toBeNull();
+      await waitForFast(() => expect(listeners.size).toBe(0));
       await waitForFast(() =>
         expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
       );
@@ -671,6 +671,26 @@ describe("ComposerDictationController", () => {
       expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "late-session" }),
     );
     expect(onError).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
+  it("commits a late final transcript after early Stop before the first partial", async () => {
+    const { controller, onCommit, target } = createHarness();
+    await startHold(target);
+
+    // Stop and keep text before any partial/final transcript has arrived.
+    await commitLatched(controller, target);
+    expect(onCommit).not.toHaveBeenCalled();
+
+    // The matching final transcript arrives during the bounded final drain.
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "transcript",
+      text: "late words",
+      final: true,
+    });
+    await waitForFast(() => expect(onCommit).toHaveBeenCalledWith("late words"));
+    expect(controller.active).toBe(false);
     controller.dispose();
   });
 

--- a/ui/src/pages/chat/composer-dictation.test.ts
+++ b/ui/src/pages/chat/composer-dictation.test.ts
@@ -693,7 +693,7 @@ describe("ComposerDictationController", () => {
       final: true,
     });
     emit({ transcriptionSessionId: "dictation-1", type: "close", reason: "completed" });
-    await waitForFast(() => expect(onCommit).toHaveBeenCalledWith("late words"));
+    await waitForFast(() => expect(onCommit).toHaveBeenCalledWith("late words", true));
     expect(controller.active).toBe(false);
     controller.dispose();
   });

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -189,7 +189,7 @@ class ComposerDictationSession {
     return this.transcriptIncludingPartial();
   }
 
-  async finish(): Promise<void> {
+  async finish(): Promise<string> {
     await this.stopCapture();
     await this.startPromise?.catch((error: unknown) => {
       if (!isAbortError(error)) {
@@ -198,6 +198,11 @@ class ComposerDictationSession {
     });
     await this.appendChain;
     await this.closeRemote();
+    // Retire the listener only after the remote close drained any late final
+    // transcript, so a Stop with no prior partial still keeps the utterance.
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    return this.transcriptIncludingPartial();
   }
 
   async cancel(): Promise<void> {
@@ -206,6 +211,8 @@ class ComposerDictationSession {
     await this.startPromise?.catch(() => undefined);
     await this.appendChain;
     await this.closeRemote();
+    this.unsubscribe?.();
+    this.unsubscribe = null;
   }
 
   markGatewayDisconnected(): boolean {
@@ -254,11 +261,12 @@ class ComposerDictationSession {
 
   private handleEvent(frame: GatewayEventFrame): void {
     const payload = eventPayload(frame);
-    if (
-      !payload ||
-      payload.transcriptionSessionId !== this.transcriptionSessionId ||
-      this.stopped
-    ) {
+    if (!payload || payload.transcriptionSessionId !== this.transcriptionSessionId) {
+      return;
+    }
+    // After stop, only a matching final transcript may still update the draft;
+    // partials and other events are ignored because capture already ended.
+    if (this.stopped && !(payload.type === "transcript" && payload.final === true)) {
       return;
     }
     if (payload.type === "partial" && typeof payload.text === "string") {
@@ -317,9 +325,8 @@ class ComposerDictationSession {
     this.stopped = true;
     this.input.stop();
     this.inputPump.stop();
-    // Retire UI events immediately; queued audio may still drain into remote close.
-    this.unsubscribe?.();
-    this.unsubscribe = null;
+    // Keep the event listener alive until remote close so a late matching
+    // final transcript can still update the draft; finish/cancel retire it.
     this.inputMeter?.stop();
     this.inputMeter = null;
     await this.context?.close();
@@ -604,30 +611,44 @@ export class ComposerDictationController {
     }
   }
 
-  private stop(options: { commit: boolean }): Promise<boolean> {
+  private async stop(options: { commit: boolean }): Promise<boolean> {
     if (this.phase === "idle" || this.phase === "stopping") {
-      return Promise.resolve(false);
+      return false;
     }
     const wasActive = this.active;
     this.clearPointerGesture();
     const session = this.session;
     if (!session) {
       this.reset();
-      return Promise.resolve(false);
+      return false;
     }
     this.setPhase("stopping");
-    const transcript = options.commit ? session.transcriptSnapshot() : "";
-    const committed = Boolean(options.commit && transcript && wasActive && !this.disposed);
-    this.session = null;
-    this.reset();
-    if (committed) {
-      this.options.onCommit(transcript);
+    const snapshot = options.commit ? session.transcriptSnapshot() : "";
+    const committed = Boolean(options.commit && snapshot && wasActive && !this.disposed);
+    if (committed || !options.commit) {
+      this.session = null;
+      this.reset();
+      if (committed) {
+        this.options.onCommit(snapshot);
+      }
+      // UI ownership ends at the operator action. Provider close can be slow, but
+      // it must never retain the composer in a transient finalizing state.
+      const close = options.commit ? session.finish() : session.cancel();
+      void close.catch(() => undefined);
+      return committed;
     }
-    // UI ownership ends at the operator action. Provider close can be slow, but
-    // it must never retain the composer in a transient finalizing state.
-    const close = options.commit ? session.finish() : session.cancel();
-    void close.catch(() => undefined);
-    return Promise.resolve(committed);
+    // Commit was requested but no transcript had arrived yet (early Stop before
+    // the first partial/final). Wait for the bounded final drain, then commit the
+    // accumulated final transcript exactly once. Detach the session first so a
+    // late drain error cannot be surfaced as the current session's failure.
+    this.session = null;
+    const finalTranscript = await session.finish().catch(() => "");
+    this.reset();
+    const finalCommitted = Boolean(finalTranscript && wasActive && !this.disposed);
+    if (finalCommitted) {
+      this.options.onCommit(finalTranscript);
+    }
+    return finalCommitted;
   }
 
   private reset(): void {

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -19,6 +19,9 @@ const HOLD_ARM_DELAY_MS = 150,
 const DICTATION_ENCODING = "g711_ulaw";
 const DICTATION_SAMPLE_RATE_HZ = 8000;
 const MAX_PENDING_AUDIO_SAMPLES = DICTATION_SAMPLE_RATE_HZ * 10;
+// The Gateway relay drains the provider for up to 5s after close; wait a bit
+// longer than that for the terminal close event before retiring the listener.
+const CLOSE_EVENT_TIMEOUT_MS = 6_000;
 
 type DictationPhase = "idle" | "pressing" | "holding" | "connecting" | "recording" | "stopping";
 
@@ -125,6 +128,8 @@ class ComposerDictationSession {
   private pendingAudioSamples = 0;
   private appendChain: Promise<void> = Promise.resolve();
   private closePromise: Promise<void> | null = null;
+  private closeEvent: Promise<void> | null = null;
+  private resolveCloseEvent: (() => void) | null = null;
   private stopped = false;
   private discarded = false;
   private failed = false;
@@ -189,7 +194,7 @@ class ComposerDictationSession {
     return this.transcriptIncludingPartial();
   }
 
-  async finish(): Promise<string> {
+  async finish(waitForTerminal = false): Promise<string> {
     await this.stopCapture();
     await this.startPromise?.catch((error: unknown) => {
       if (!isAbortError(error)) {
@@ -198,11 +203,27 @@ class ComposerDictationSession {
     });
     await this.appendChain;
     await this.closeRemote();
-    // Retire the listener only after the remote close drained any late final
-    // transcript, so a Stop with no prior partial still keeps the utterance.
+    if (waitForTerminal) {
+      // `talk.session.close` only acknowledges scheduling the provider drain;
+      // wait for the terminal close event so a late final transcript still
+      // lands before the listener is retired.
+      await this.waitForCloseEvent();
+    }
     this.unsubscribe?.();
     this.unsubscribe = null;
     return this.transcriptIncludingPartial();
+  }
+
+  private async waitForCloseEvent(): Promise<void> {
+    this.closeEvent ??= new Promise<void>((resolve) => {
+      this.resolveCloseEvent = resolve;
+    });
+    await Promise.race([
+      this.closeEvent,
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, CLOSE_EVENT_TIMEOUT_MS);
+      }),
+    ]);
   }
 
   async cancel(): Promise<void> {
@@ -264,9 +285,14 @@ class ComposerDictationSession {
     if (!payload || payload.transcriptionSessionId !== this.transcriptionSessionId) {
       return;
     }
-    // After stop, only a matching final transcript may still update the draft;
-    // partials and other events are ignored because capture already ended.
-    if (this.stopped && !(payload.type === "transcript" && payload.final === true)) {
+    // After stop, only a matching final transcript and the terminal close event
+    // may still reach the draft; partials and other events are ignored because
+    // capture already ended.
+    if (
+      this.stopped &&
+      !(payload.type === "transcript" && payload.final === true) &&
+      payload.type !== "close"
+    ) {
       return;
     }
     if (payload.type === "partial" && typeof payload.text === "string") {
@@ -297,8 +323,12 @@ class ComposerDictationSession {
       );
       return;
     }
-    if (payload.type === "close" && payload.reason === "error") {
-      this.reportFailure(t("chat.composer.dictationDisconnected"));
+    if (payload.type === "close") {
+      if (payload.reason === "error") {
+        this.reportFailure(t("chat.composer.dictationDisconnected"));
+      }
+      this.resolveCloseEvent?.();
+      this.resolveCloseEvent = null;
     }
   }
 
@@ -323,6 +353,11 @@ class ComposerDictationSession {
       return;
     }
     this.stopped = true;
+    // Arm the terminal-event wait at stop so a close event that races the
+    // finish() continuation can still resolve it.
+    this.closeEvent ??= new Promise<void>((resolve) => {
+      this.resolveCloseEvent = resolve;
+    });
     this.input.stop();
     this.inputPump.stop();
     // Keep the event listener alive until remote close so a late matching
@@ -642,7 +677,7 @@ export class ComposerDictationController {
     // accumulated final transcript exactly once. Detach the session first so a
     // late drain error cannot be surfaced as the current session's failure.
     this.session = null;
-    const finalTranscript = await session.finish().catch(() => "");
+    const finalTranscript = await session.finish(true).catch(() => "");
     this.reset();
     const finalCommitted = Boolean(finalTranscript && wasActive && !this.disposed);
     if (finalCommitted) {

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -680,7 +680,11 @@ export class ComposerDictationController {
     this.session = null;
     this.reset();
     const finalTranscript = await session.finish(true).catch(() => "");
-    const finalCommitted = Boolean(finalTranscript && wasActive && !this.disposed);
+    // A new session may have started while the old one drained; only commit the
+    // late final if this controller still owns no newer session.
+    const finalCommitted = Boolean(
+      finalTranscript && wasActive && !this.disposed && this.session === null,
+    );
     if (finalCommitted) {
       this.options.onCommit(finalTranscript);
     }

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -196,18 +196,19 @@ class ComposerDictationSession {
 
   async finish(waitForTerminal = false): Promise<string> {
     await this.stopCapture();
-    await this.startPromise?.catch((error: unknown) => {
+    const startPromise = this.startPromise?.catch((error: unknown) => {
       if (!isAbortError(error)) {
         this.reportFailure(messageFromError(error));
       }
     });
-    await this.appendChain;
     if (waitForTerminal) {
-      // Start the close RPC independently so a slow or disconnected Gateway
-      // cannot hold the composer; the bounded drain timeout governs finalization.
+      // The late-final wait and close start independently of create/audio append,
+      // so a stalled create or append request cannot prevent the bounded Stop.
       void this.closeRemote();
       await this.waitForCloseEvent();
     } else {
+      await startPromise;
+      await this.appendChain;
       await this.closeRemote();
     }
     this.unsubscribe?.();
@@ -390,6 +391,8 @@ export class ComposerDictationController {
   private pointerBounds: DOMRect | null = null;
   private holdTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
   private session: ComposerDictationSession | null = null;
+  /** Owns a drained late final; a newer session retires it. */
+  private pendingFinalOwner: unknown = null;
   private suppressClick = false;
   private suppressedPointerId: number | null = null;
   private suppressClickTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
@@ -616,6 +619,8 @@ export class ComposerDictationController {
     // while Escape/visibility/blur keep guarding the live capture lifecycle.
     this.clearPointerGesture();
     this.setPhase("connecting");
+    // A newer session retires any pending late final from a drained session.
+    this.pendingFinalOwner = null;
     const session = new ComposerDictationSession(client, {
       onError: (message, preservesText) => {
         if (this.session !== session) {
@@ -679,11 +684,13 @@ export class ComposerDictationController {
     // for the bounded final drain and commit the transcript exactly once.
     this.session = null;
     this.reset();
+    // Own the pending late final; a newer session retires this owner, so a
+    // drained stale final can never overwrite it.
+    const pendingOwner = {};
+    this.pendingFinalOwner = pendingOwner;
     const finalTranscript = await session.finish(true).catch(() => "");
-    // A new session may have started while the old one drained; only commit the
-    // late final if this controller still owns no newer session.
     const finalCommitted = Boolean(
-      finalTranscript && wasActive && !this.disposed && this.session === null,
+      finalTranscript && wasActive && !this.disposed && this.pendingFinalOwner === pendingOwner,
     );
     if (finalCommitted) {
       this.options.onCommit(finalTranscript);

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -202,9 +202,11 @@ class ComposerDictationSession {
       }
     });
     if (waitForTerminal) {
-      // The late-final wait and close start independently of create/audio append,
-      // so a stalled create or append request cannot prevent the bounded Stop.
-      void this.closeRemote();
+      // Close needs the session id from create; audio append is not required for
+      // close. Wait for create, send close, then start the bounded final-drain
+      // deadline once the close sequence can actually begin.
+      await startPromise;
+      await this.closeRemote();
       await this.waitForCloseEvent();
     } else {
       await startPromise;

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -202,12 +202,13 @@ class ComposerDictationSession {
       }
     });
     await this.appendChain;
-    await this.closeRemote();
     if (waitForTerminal) {
-      // `talk.session.close` only acknowledges scheduling the provider drain;
-      // wait for the terminal close event so a late final transcript still
-      // lands before the listener is retired.
+      // Start the close RPC independently so a slow or disconnected Gateway
+      // cannot hold the composer; the bounded drain timeout governs finalization.
+      void this.closeRemote();
       await this.waitForCloseEvent();
+    } else {
+      await this.closeRemote();
     }
     this.unsubscribe?.();
     this.unsubscribe = null;
@@ -673,12 +674,12 @@ export class ComposerDictationController {
       return committed;
     }
     // Commit was requested but no transcript had arrived yet (early Stop before
-    // the first partial/final). Wait for the bounded final drain, then commit the
-    // accumulated final transcript exactly once. Detach the session first so a
-    // late drain error cannot be surfaced as the current session's failure.
+    // the first partial/final). Detach the session and reset the composer first
+    // so a slow or disconnected Gateway cannot leave the UI read-only; then wait
+    // for the bounded final drain and commit the transcript exactly once.
     this.session = null;
-    const finalTranscript = await session.finish(true).catch(() => "");
     this.reset();
+    const finalTranscript = await session.finish(true).catch(() => "");
     const finalCommitted = Boolean(finalTranscript && wasActive && !this.disposed);
     if (finalCommitted) {
       this.options.onCommit(finalTranscript);

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -64,7 +64,7 @@ type ComposerDictationControllerOptions = {
   enabled: boolean;
   dictationAvailable?: boolean;
   realtimeTalkActive: boolean;
-  onCommit: (text: string) => void;
+  onCommit: (text: string, late?: boolean) => void;
   onError: (message: string, failure: ComposerDictationFailure) => void;
   onStateChange: () => void;
   onTap?: () => void;
@@ -693,7 +693,7 @@ export class ComposerDictationController {
       finalTranscript && wasActive && !this.disposed && this.pendingFinalOwner === pendingOwner,
     );
     if (finalCommitted) {
-      this.options.onCommit(finalTranscript);
+      this.options.onCommit(finalTranscript, true);
     }
     return finalCommitted;
   }

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -202,11 +202,10 @@ class ComposerDictationSession {
       }
     });
     if (waitForTerminal) {
-      // Close needs the session id from create; audio append is not required for
-      // close. Wait for create, send close, then start the bounded final-drain
-      // deadline once the close sequence can actually begin.
-      await startPromise;
-      await this.closeRemote();
+      // Arm the exact-session drain before background cleanup; close is sent as
+      // soon as create resolves, independently of any queued audio flush, so a
+      // stalled cleanup request cannot delay the bounded final-drain deadline.
+      void startPromise?.then(() => this.closeRemote());
       await this.waitForCloseEvent();
     } else {
       await startPromise;

--- a/ui/src/pages/new-session/composer-dictation-control.ts
+++ b/ui/src/pages/new-session/composer-dictation-control.ts
@@ -76,13 +76,13 @@ export class NewSessionDictationControl {
       enabled,
       dictationAvailable: this.devicePicker.dictationStatus === "ready",
       realtimeTalkActive: false,
-      onCommit: (transcript: string) => {
+      onCommit: (transcript: string, late = false) => {
         // Route changes replace draft ownership. Object identity keeps even an
         // A -> B -> A transition from accepting the prior route's snapshot.
         if (!ownsDraft() || !this.options.canCommit()) {
           return;
         }
-        const next = this.options.textarea.insertTranscript(transcript);
+        const next = this.options.textarea.insertTranscript(transcript, late);
         if (next !== null) {
           this.options.onMessage(next);
         }

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -282,16 +282,20 @@ export class NewSessionComposerTextareaController {
    * Writing the final insertion directly grows the box before the next render
    * commits that same value into the page-owned draft.
    */
-  insertTranscript(transcript: string): string | null {
+  insertTranscript(transcript: string, late = false): string | null {
     const target = this.textarea;
     if (!target) {
       return null;
     }
-    const selection = this.capturedSelection ?? {
-      start: target.value.length,
-      end: target.value.length,
-      value: target.value,
-    };
+    // A late final arrives after the composer unlocked; use the live draft and
+    // caret so edits made during the drain are preserved.
+    const selection = late
+      ? { start: target.selectionStart, end: target.selectionEnd, value: target.value }
+      : (this.capturedSelection ?? {
+          start: target.value.length,
+          end: target.value.length,
+          value: target.value,
+        });
     this.capturedSelection = null;
     const insertion = insertComposerDictation(
       selection.value,


### PR DESCRIPTION
Closes #135026

## What Problem This Solves

Fixes Control UI hold-to-dictate data loss. Pressing **Stop and keep text** before the provider emitted its first partial/final transcript committed an empty snapshot and retired the session events, so the matching final transcript that arrived during the Gateway's bounded final drain was silently discarded — the composer stayed empty even though the user's utterance was recognized.

## Why This Change Was Made

The Stop path committed the current `ComposerDictationSession` transcript snapshot synchronously and retired the event listener immediately, while the remote close/final drain continued asynchronously. This change:

- Keeps the event listener alive through `finish`/`cancel` so a late matching final transcript can still update the draft (partials and other events are still ignored after stop).
- Makes `finish()` return the accumulated final transcript after the remote close drains.
- In the controller, when **Stop and keep text** is pressed with no transcript yet, waits for that bounded final drain and commits the final transcript exactly once; the session is detached first so a late drain error cannot surface as the current session's failure.

## User Impact

An early **Stop and keep text** no longer discards a valid utterance that finishes right after Stop; the dictated text is inserted into the composer exactly once.

## Evidence

Exact head: `81bd10a50133b1e890e0777f654a806e966e1656`.

- `ui/src/pages/chat/composer-dictation.test.ts` — 23 passed, including a new regression that stops before any partial, emits a matching final transcript during the final drain, and asserts the composer commits "late words" exactly once.
- `ui/src/pages/new-session/composer-dictation-control.test.ts` — 4 passed.
- Production typecheck and `check:changed` pass (including the Control UI i18n catalog); the only local lane failure is unchanged `ui/vite.config.ts` missing a `pako` declaration in the reused dependency tree.

## AI Assistance

AI-assisted implementation. I manually verified the dictation stop lifecycle, the final-drain listener retention, the controller commit-once path, the focused regression, and the changed-file gates.
