### PR TITLE
ci: preserve compiler caches across helper checkouts

### DIFF
--- a/scripts/lib/compiler-input-snapshot.mts
+++ b/scripts/lib/compiler-input-snapshot.mts
@@ -114,8 +114,9 @@ export class CompilerInputSnapshot {
           const file = path.join(directory, entry.name);
           const canonicalFile = path.join(realDirectory, entry.name);
           const id = portableRelativePath(this.rootDir, file);
-          // Native PR checkouts are separate roots; aliases retain their own paths.
+          // Native PR and workflow helper checkouts are separate roots; aliases retain their paths.
           if (
+            id === ".ci-harness" ||
             id === ".worktrees" ||
             (!installed &&
               [".git", ".artifacts", ".claude", ".agents", ".local", "dist"].includes(entry.name))

--- a/test/scripts/build-artifact-cache.test.ts
+++ b/test/scripts/build-artifact-cache.test.ts
@@ -339,6 +339,26 @@ describe("native owner content records", () => {
     expect(compiled.stdout).toContain("TS2322");
   });
 
+  it("ignores root CI helper churn while retaining explicit and nested inputs", () => {
+    const f = fixture(true);
+    const declaredInput = ".ci-harness/declared/value.ts";
+    f.write(declaredInput, "export const value = 1;");
+    const signature = () =>
+      new BoundaryInputSnapshot(f.root).signature(f.config, f.args, [declaredInput]);
+    const first = signature();
+
+    f.write(".ci-harness/.github/actions/setup-node-env/helper.mjs", "export default {};");
+    expect(signature()).toBe(first);
+
+    f.write(declaredInput, "export const value = 2;");
+    expect(signature()).not.toBe(first);
+    f.write(declaredInput, "export const value = 1;");
+    expect(signature()).toBe(first);
+
+    f.write("nested/.ci-harness/candidate.ts", "export {};");
+    expect(signature()).not.toBe(first);
+  });
+
   it("propagates non-ENOENT link resolution errors", () => {
     const f = fixture(true);
     fs.symlinkSync("loop", path.join(f.root, "loop"));


### PR DESCRIPTION
Normal CI adds a root `.ci-harness` checkout for trusted workflow helpers, while the protected cache warmer builds only the selected source checkout. `CompilerInputSnapshot.namespace()` included the helper filenames, so otherwise matching compiler inputs produced different signatures. In [the artifact CI run](https://github.com/openclaw/openclaw/actions/runs/33513456621/job/99880555985), the exact build-all archive restored successfully but SDK declarations rebuilt for 49.6 seconds.

Exclude only the reserved root `.ci-harness` from resolution topology, alongside the existing root `.worktrees` exclusion. Explicit and compiler-discovered input bytes remain part of the signature; ordinary nested directories and dependency aliases retain their logical paths. Cache authority, receipts, output validation, compiler execution, and writer sequencing are unchanged.

The regression fails on the previous implementation and passes with this change. It covers unrelated helper additions, a real declared input under the helper root, and an ordinary nested `.ci-harness`. The existing native-PR checkout test continues to prove aliased dependency invalidation. The two focused tests passed in the normal checkout, and formatting passed. The diff is one net tooling line plus 20 test lines; no product-runtime changes.

A new protected warmer generation is required before measuring the native cache hit: this file is itself a generator input, so old cache records should still miss after the fix. A subsequent ordinary CI consumer must prove reuse; no end-to-end time saving is claimed yet.
