### PR TITLE
refactor(testing): share grouped report argument parsing

### DIFF
--- a/scripts/test-group-report.mts
+++ b/scripts/test-group-report.mts
@@ -6,7 +6,14 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import pMap from "p-map";
-import { requireOptionArgument } from "./lib/arg-utils.mts";
+import {
+  booleanFlag,
+  parseFlagArgs,
+  requireOptionArgument,
+  stringFlag,
+  stringListFlag,
+  type FlagSpec,
+} from "./lib/arg-utils.mts";
 import { coerceErrorMessage } from "./lib/error-format.mts";
 import {
   inspectManagedProcessGroup,
@@ -133,9 +140,50 @@ function usage() {
   ].join("\n");
 }
 
-function readPositiveIntValue(argv: string[], index: number, flag: string) {
-  return parsePositiveInt(requireOptionArgument(argv, index, flag), flag);
+type PositiveIntArgKey =
+  | "concurrency"
+  | "killGraceMs"
+  | "limit"
+  | "maxTestMs"
+  | "timeoutMs"
+  | "topFiles";
+
+const splitStringFlagOptions = { allowInline: false, rejectShortOptions: true } as const;
+
+function positiveIntFlag(flag: string, key: PositiveIntArgKey): FlagSpec<TestGroupReportArgs> {
+  return {
+    consume(argv, index) {
+      if (argv[index] !== flag) {
+        return null;
+      }
+      const value = parsePositiveInt(requireOptionArgument(argv, index, flag), flag);
+      return {
+        flag,
+        nextIndex: index + 1,
+        apply(args) {
+          args[key] = value;
+        },
+      };
+    },
+  };
 }
+
+const compareFlag: FlagSpec<TestGroupReportArgs> = {
+  consume(argv, index) {
+    if (argv[index] !== "--compare") {
+      return null;
+    }
+    const before = requireOptionArgument(argv, index, "--compare");
+    const after = requireOptionArgument(argv, index + 1, "--compare");
+    return {
+      flag: "--compare",
+      nextIndex: index + 2,
+      apply(args) {
+        args.compare = { before, after };
+      },
+    };
+  },
+};
 
 /**
  * Parses report, compare, and Vitest-run options for grouped test reports.
@@ -158,122 +206,36 @@ export function parseTestGroupReportArgs(argv: string[]) {
     topFiles: 25,
     vitestArgs: [],
   };
-  const seenSingleValueFlags = new Set<string>();
-  const setSingleValueFlag = (flag: string, apply: () => void) => {
-    if (seenSingleValueFlags.has(flag)) {
-      throw new Error(`${flag} was provided more than once`);
-    }
-    seenSingleValueFlags.add(flag);
-    apply();
-  };
+  const separatorIndex = argv.indexOf("--");
+  const cliArgs = separatorIndex === -1 ? argv : argv.slice(0, separatorIndex);
+  args.vitestArgs = separatorIndex === -1 ? [] : argv.slice(separatorIndex + 1);
 
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === "--") {
-      args.vitestArgs = argv.slice(index + 1);
-      break;
-    }
-    if (arg === "--help") {
-      args.help = true;
-      continue;
-    }
-    if (arg === "--allow-failures") {
-      args.allowFailures = true;
-      continue;
-    }
-    if (arg === "--full-suite") {
-      args.fullSuite = true;
-      continue;
-    }
-    if (arg === "--no-rss") {
-      args.rss = false;
-      continue;
-    }
-    if (arg === "--config") {
-      args.configs.push(requireOptionArgument(argv, index, "--config"));
-      index += 1;
-      continue;
-    }
-    if (arg === "--compare") {
-      const before = requireOptionArgument(argv, index, "--compare");
-      const after = requireOptionArgument(argv, index + 1, "--compare");
-      setSingleValueFlag(arg, () => {
-        args.compare = { before, after };
-      });
-      index += 2;
-      continue;
-    }
-    if (arg === "--report") {
-      args.reports.push(requireOptionArgument(argv, index, "--report"));
-      index += 1;
-      continue;
-    }
-    if (arg === "--group-by") {
-      const value = requireOptionArgument(argv, index, "--group-by");
-      setSingleValueFlag(arg, () => {
-        args.groupBy = value;
-      });
-      index += 1;
-      continue;
-    }
-    if (arg === "--output") {
-      const value = requireOptionArgument(argv, index, "--output");
-      setSingleValueFlag(arg, () => {
-        args.output = value;
-      });
-      index += 1;
-      continue;
-    }
-    if (arg === "--limit") {
-      const value = readPositiveIntValue(argv, index, "--limit");
-      setSingleValueFlag(arg, () => {
-        args.limit = value;
-      });
-      index += 1;
-      continue;
-    }
-    if (arg === "--max-test-ms") {
-      const value = readPositiveIntValue(argv, index, "--max-test-ms");
-      setSingleValueFlag(arg, () => {
-        args.maxTestMs = value;
-      });
-      index += 1;
-      continue;
-    }
-    if (arg === "--timeout-ms") {
-      const value = readPositiveIntValue(argv, index, "--timeout-ms");
-      setSingleValueFlag(arg, () => {
-        args.timeoutMs = value;
-      });
-      index += 1;
-      continue;
-    }
-    if (arg === "--kill-grace-ms") {
-      const value = readPositiveIntValue(argv, index, "--kill-grace-ms");
-      setSingleValueFlag(arg, () => {
-        args.killGraceMs = value;
-      });
-      index += 1;
-      continue;
-    }
-    if (arg === "--concurrency") {
-      const value = readPositiveIntValue(argv, index, "--concurrency");
-      setSingleValueFlag(arg, () => {
-        args.concurrency = value;
-      });
-      index += 1;
-      continue;
-    }
-    if (arg === "--top-files") {
-      const value = readPositiveIntValue(argv, index, "--top-files");
-      setSingleValueFlag(arg, () => {
-        args.topFiles = value;
-      });
-      index += 1;
-      continue;
-    }
-    throw new Error(`Unknown option: ${arg}`);
-  }
+  parseFlagArgs(
+    cliArgs,
+    args,
+    [
+      booleanFlag("--help", "help", true, { repeatable: true }),
+      booleanFlag("--allow-failures", "allowFailures", true, { repeatable: true }),
+      booleanFlag("--full-suite", "fullSuite", true, { repeatable: true }),
+      booleanFlag("--no-rss", "rss", false, { repeatable: true }),
+      stringListFlag("--config", "configs", splitStringFlagOptions),
+      compareFlag,
+      stringListFlag("--report", "reports", splitStringFlagOptions),
+      stringFlag("--group-by", "groupBy", splitStringFlagOptions),
+      stringFlag("--output", "output", splitStringFlagOptions),
+      positiveIntFlag("--limit", "limit"),
+      positiveIntFlag("--max-test-ms", "maxTestMs"),
+      positiveIntFlag("--timeout-ms", "timeoutMs"),
+      positiveIntFlag("--kill-grace-ms", "killGraceMs"),
+      positiveIntFlag("--concurrency", "concurrency"),
+      positiveIntFlag("--top-files", "topFiles"),
+    ],
+    {
+      onUnhandledArg(arg) {
+        throw new Error(`Unknown option: ${arg}`);
+      },
+    },
+  );
 
   if (!["area", "folder", "top"].includes(args.groupBy)) {
     throw new Error(`Unsupported --group-by value: ${args.groupBy}`);

--- a/test/scripts/test-group-report.test.ts
+++ b/test/scripts/test-group-report.test.ts
@@ -728,6 +728,9 @@ describe("scripts/test-group-report arg parsing", () => {
         "--allow-failures",
         "--",
         "--maxWorkers=1",
+        "--",
+        "--limit",
+        "99",
       ]),
     ).toStrictEqual({
       allowFailures: true,
@@ -744,7 +747,7 @@ describe("scripts/test-group-report arg parsing", () => {
       rss: process.platform !== "win32",
       timeoutMs: 1800000,
       topFiles: 25,
-      vitestArgs: ["--maxWorkers=1"],
+      vitestArgs: ["--maxWorkers=1", "--", "--limit", "99"],
     });
   });
 
@@ -797,6 +800,51 @@ describe("scripts/test-group-report arg parsing", () => {
       killGraceMs: 250,
       timeoutMs: 5000,
     });
+  });
+
+  it("keeps repeated boolean controls idempotent", () => {
+    expect(
+      parseTestGroupReportArgs([
+        "--help",
+        "--help",
+        "--allow-failures",
+        "--allow-failures",
+        "--full-suite",
+        "--full-suite",
+        "--no-rss",
+        "--no-rss",
+      ]),
+    ).toMatchObject({
+      allowFailures: true,
+      fullSuite: true,
+      help: true,
+      rss: false,
+    });
+  });
+
+  it.each([
+    "--config=a.ts",
+    "--compare=before.json",
+    "--report=a.json",
+    "--group-by=area",
+    "--output=report.json",
+    "--limit=5",
+    "--max-test-ms=100",
+    "--timeout-ms=1000",
+    "--kill-grace-ms=100",
+    "--concurrency=2",
+    "--top-files=5",
+  ])("rejects split-option inline form %s", (arg) => {
+    expect(() => parseTestGroupReportArgs([arg])).toThrow(`Unknown option: ${arg}`);
+  });
+
+  it("does not let help short-circuit later parse errors", () => {
+    expect(() => parseTestGroupReportArgs(["--help", "--unknown"])).toThrow(
+      "Unknown option: --unknown",
+    );
+    expect(() => parseTestGroupReportArgs(["--help", "--limit"])).toThrow(
+      "--limit requires a value",
+    );
   });
 
   it("rejects malformed positive integer flags", () => {
@@ -883,6 +931,31 @@ describe("scripts/test-group-report arg parsing", () => {
       "a.json",
       "b.json",
     ]);
+  });
+
+  it("validates a repeated value before reporting a duplicate", () => {
+    for (const flag of [
+      "--limit",
+      "--top-files",
+      "--max-test-ms",
+      "--timeout-ms",
+      "--kill-grace-ms",
+      "--concurrency",
+    ]) {
+      expect(() => parseTestGroupReportArgs([flag, "5", flag])).toThrow(`${flag} requires a value`);
+      expect(() => parseTestGroupReportArgs([flag, "5", flag, "20x"])).toThrow(
+        `${flag} must be a positive integer`,
+      );
+    }
+    expect(() =>
+      parseTestGroupReportArgs([
+        "--compare",
+        "before.json",
+        "after.json",
+        "--compare",
+        "second-before.json",
+      ]),
+    ).toThrow("--compare requires a value");
   });
 });
 


### PR DESCRIPTION
The grouped test-report CLI duplicated common flag parsing in thirteen branches. It now uses the existing argument parser for flag grammar and duplicate tracking, while keeping report-specific validation in the report owner. This preserves behavior and removes 38 net production lines (41 nonblank; 49 after TypeScript erasure), including all new helper overhead. Tests add 73 lines.

The two custom consumers preserve a subtle ordering contract: an invalid or missing second scalar value is diagnosed before the duplicate flag. Repeated booleans, split-only options, help followed by an error, ordered config/report lists, and the verbatim Vitest tail after the first `--` retain their existing behavior. The handwritten parser is removed; no parallel path remains.

Validation:

- Twenty baseline/candidate parser observations and side-effect order match exactly.
- Seven actual executable cases cover help, errors, report generation, comparison, and a real grouped Vitest run. Both real grouped runs pass 79 existing argument-parser tests. Comparison normalizes only generated paths, timestamps, and duration values, preserving property presence and exit status.
- All 55 maintained report tests pass; the final parser-focused check passes 22 tests. Selected scripts/root-test type checks, lint, formatting, and repository guards pass.
- Independent final Codex P2 review is clean. The original reviewer claim that omitted `repeatable` is a type error was checked against the helper's optional declaration and its `!== true` runtime rule, then a fresh review with those sources confirmed the final implementation.

Two initial proof attempts selected configurations that excluded the existing test file; the successful run uses its actual unit-fast owner. Initial formatter and package-manager launcher setup failures are retained as failed attempts. No timeout or product behavior was changed. No full build was needed because this reuses an already-loaded static script import; no emitted packaging boundary changed.


## Landing validation

[Exact-head CI33520811762](https://github.com/openclaw/openclaw/actions/runs/33520811762) passes all165 selected jobs and the required gate. Root read the full14:58UTC ClawSweeper review: no code/security finding or separate rank-up move; its normal maintainer review request is complete.

Direct inspection confirms shared grammar owns flag scanning while report-specific comparison/value validation stays local. The first separator, verbatim Vitest tail, repeated booleans, duplicate/value error ordering and help behavior are preserved. The immutable20-case parser oracle,7 actual CLI fixtures, maintained report/argument tests, selected gates and final managed P2 pass. The original optional-repeatable review concern is resolved by the shared type/runtime contract, not by changing behavior.

Production is **-38 physical lines (-41 nonblank; -49 erased runtime)** and tests **+73**. Actual CLI comparison normalizes only owned paths, timestamps and durations.
