### PR TITLE
fix(cli): keep agent exec run errors when cleanup fails

### DIFF
--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -63,6 +63,8 @@ openclaw agent exec "Inspect this repository" \
 
 The timeout defaults to 600 seconds for `agent exec`; this does not change the existing embedded `agent --local` default. A successful run exits `0`, any model or result error exits `1`, and a timeout exits `2`. Failure includes `meta.error`, aborted runs, exhausted model fallbacks, an error stop reason, and any error payload.
 
+If cleanup fails after a run error or timeout, the original result and exit code are preserved and the cleanup failure is reported on stderr. A cleanup failure after a successful run exits `1`.
+
 Plain output writes only the final assistant text to stdout. Diagnostics use stderr. `--json` reserves stdout for this stable envelope:
 
 ```json

--- a/src/commands/agent-exec-result.ts
+++ b/src/commands/agent-exec-result.ts
@@ -36,9 +36,6 @@ export type AgentExecEnvelope = {
     message: string;
     kind: string;
   };
-  cleanupError?: {
-    message: string;
-  };
 };
 
 function projectAgentExecPayload(payload: AgentExecRawPayload): AgentExecPayload {

--- a/src/commands/agent-exec-result.ts
+++ b/src/commands/agent-exec-result.ts
@@ -36,6 +36,9 @@ export type AgentExecEnvelope = {
     message: string;
     kind: string;
   };
+  cleanupError?: {
+    message: string;
+  };
 };
 
 function projectAgentExecPayload(payload: AgentExecRawPayload): AgentExecPayload {

--- a/src/commands/agent-exec.test.ts
+++ b/src/commands/agent-exec.test.ts
@@ -570,6 +570,46 @@ describe("agent exec command composition", () => {
     });
   });
 
+  it.each([
+    { kind: "exception", status: "error", exitCode: 1, thrown: true },
+    { kind: "timeout", status: "timeout", exitCode: 2, thrown: true },
+    { kind: "context_overflow", status: "error", exitCode: 1, thrown: false },
+  ] as const)("preserves $kind when temporary-state cleanup also fails", async (failure) => {
+    const { runtime, log, error } = createRuntime();
+    let observedStateDir = "";
+    vi.spyOn(fs, "rm").mockRejectedValueOnce(new Error("cleanup denied"));
+
+    const result = await agentExecCommand("inspect", { json: true }, runtime, {
+      runAgent: async () => {
+        observedStateDir = process.env.OPENCLAW_STATE_DIR ?? "";
+        if (failure.thrown) {
+          throw Object.assign(new Error("original run failure"), {
+            name: failure.kind === "timeout" ? "TimeoutError" : "Error",
+          });
+        }
+        return {
+          ...successResult("partial answer"),
+          meta: { durationMs: 25, error: { kind: failure.kind, message: "original run failure" } },
+        };
+      },
+    });
+    externalTempDirs.push(observedStateDir);
+
+    expect(result).toMatchObject({
+      exitCode: failure.exitCode,
+      envelope: {
+        status: failure.status,
+        final: failure.thrown ? "" : "partial answer",
+        payloads: failure.thrown ? [] : [{ text: "partial answer" }],
+        error: { kind: failure.kind, message: "original run failure" },
+      },
+    });
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual(result.envelope);
+    expect(error).toHaveBeenCalledWith("original run failure");
+    expect(error).toHaveBeenCalledWith("Agent exec cleanup failed: cleanup denied");
+  });
+
   it("classifies cleanup failures before emitting the JSON envelope", async () => {
     const { runtime, log } = createRuntime();
     let observedStateDir = "";
@@ -597,38 +637,6 @@ describe("agent exec command composition", () => {
       status: "error",
       error: { message: "Agent exec cleanup failed: cleanup denied" },
     });
-  });
-
-  it("keeps a failed run envelope when later cleanup also fails", async () => {
-    const { runtime, log, error } = createRuntime();
-    let observedStateDir = "";
-    vi.spyOn(fs, "rm").mockRejectedValueOnce(new Error("cleanup denied"));
-
-    const result = await agentExecCommand("inspect", { json: true }, runtime, {
-      runAgent: vi.fn(async () => {
-        observedStateDir = process.env.OPENCLAW_STATE_DIR ?? "";
-        throw new Error("model refused the prompt");
-      }),
-    });
-    externalTempDirs.push(observedStateDir);
-
-    expect(result).toMatchObject({
-      exitCode: 1,
-      envelope: {
-        ok: false,
-        status: "error",
-        error: { kind: "exception", message: "model refused the prompt" },
-        cleanupError: { message: "Agent exec cleanup failed: cleanup denied" },
-      },
-    });
-    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
-      ok: false,
-      status: "error",
-      error: { message: "model refused the prompt" },
-      cleanupError: { message: "Agent exec cleanup failed: cleanup denied" },
-    });
-    expect(error).toHaveBeenCalledWith("model refused the prompt");
-    expect(error).toHaveBeenCalledWith("Agent exec cleanup failed: cleanup denied");
   });
 
   it("threads --cwd to both workspace and tool cwd", async () => {

--- a/src/commands/agent-exec.test.ts
+++ b/src/commands/agent-exec.test.ts
@@ -599,6 +599,38 @@ describe("agent exec command composition", () => {
     });
   });
 
+  it("keeps a failed run envelope when later cleanup also fails", async () => {
+    const { runtime, log, error } = createRuntime();
+    let observedStateDir = "";
+    vi.spyOn(fs, "rm").mockRejectedValueOnce(new Error("cleanup denied"));
+
+    const result = await agentExecCommand("inspect", { json: true }, runtime, {
+      runAgent: vi.fn(async () => {
+        observedStateDir = process.env.OPENCLAW_STATE_DIR ?? "";
+        throw new Error("model refused the prompt");
+      }),
+    });
+    externalTempDirs.push(observedStateDir);
+
+    expect(result).toMatchObject({
+      exitCode: 1,
+      envelope: {
+        ok: false,
+        status: "error",
+        error: { kind: "exception", message: "model refused the prompt" },
+        cleanupError: { message: "Agent exec cleanup failed: cleanup denied" },
+      },
+    });
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+      ok: false,
+      status: "error",
+      error: { message: "model refused the prompt" },
+      cleanupError: { message: "Agent exec cleanup failed: cleanup denied" },
+    });
+    expect(error).toHaveBeenCalledWith("model refused the prompt");
+    expect(error).toHaveBeenCalledWith("Agent exec cleanup failed: cleanup denied");
+  });
+
   it("threads --cwd to both workspace and tool cwd", async () => {
     const root = tempDirs.make("openclaw-agent-exec-cwd-");
     const { runtime } = createRuntime();

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -188,9 +188,6 @@ function writeAgentExecOutput(
   if (!envelope.ok && envelope.error) {
     runtime.error(envelope.error.message);
   }
-  if (envelope.cleanupError) {
-    runtime.error(envelope.cleanupError.message);
-  }
 }
 
 /** Run one isolated embedded agent turn and project its stable CLI result. */
@@ -441,17 +438,12 @@ export async function agentExecCommand(
   if (cleanupError) {
     const cleanupFailure = new Error(
       `Agent exec cleanup failed: ${formatErrorMessage(cleanupError)}`,
-      { cause: cleanupError },
     );
-    const cleanupMessage = formatErrorMessage(cleanupFailure);
     if (commandResult.envelope.ok) {
       const envelope = errorEnvelope(cleanupFailure, sessionId);
       commandResult = { envelope, exitCode: exitCodeForEnvelope(envelope) };
     } else {
-      commandResult.envelope = {
-        ...commandResult.envelope,
-        cleanupError: { message: cleanupMessage },
-      };
+      runtime.error(cleanupFailure.message);
     }
   }
 

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -188,6 +188,9 @@ function writeAgentExecOutput(
   if (!envelope.ok && envelope.error) {
     runtime.error(envelope.error.message);
   }
+  if (envelope.cleanupError) {
+    runtime.error(envelope.cleanupError.message);
+  }
 }
 
 /** Run one isolated embedded agent turn and project its stable CLI result. */
@@ -438,9 +441,18 @@ export async function agentExecCommand(
   if (cleanupError) {
     const cleanupFailure = new Error(
       `Agent exec cleanup failed: ${formatErrorMessage(cleanupError)}`,
+      { cause: cleanupError },
     );
-    const envelope = errorEnvelope(cleanupFailure, sessionId);
-    commandResult = { envelope, exitCode: exitCodeForEnvelope(envelope) };
+    const cleanupMessage = formatErrorMessage(cleanupFailure);
+    if (commandResult.envelope.ok) {
+      const envelope = errorEnvelope(cleanupFailure, sessionId);
+      commandResult = { envelope, exitCode: exitCodeForEnvelope(envelope) };
+    } else {
+      commandResult.envelope = {
+        ...commandResult.envelope,
+        cleanupError: { message: cleanupMessage },
+      };
+    }
   }
 
   const receivedSignal = signalBridge?.getReceivedSignal();


### PR DESCRIPTION
## What Problem This Solves

Keep the primary `agent exec` error and exit code when cleanup also fails. The cleanup handler previously replaced the completed result, hiding the original failure and changing timeout classification. Secondary cleanup errors now use existing stderr diagnostics; cleanup failure after a successful run still returns an error. The JSON result shape stays unchanged, and the CLI docs describe the precedence.

## Why This Change Was Made

Keep the completed run result authoritative through cleanup. This also removes the proposed extra JSON field and preserves the documented result shape. The four additional production lines distinguish cleanup failure after success from cleanup failure after an existing error. Reusing the classified result and the existing stderr diagnostic avoids a second result field or cleanup path; collapsing those two outcomes would lose the original failure again.

## User Impact

Automation receives the original failure and exit code, with secondary cleanup problems on stderr.

## Evidence

Validation: all 53 agent-exec owner tests passed, including regressions for thrown failure, timeout and a returned error with partial output that failed before the fix. A built isolated CLI under a real filesystem EPERM cleanup condition preserved the original usage error in JSON and printed both diagnostics on stderr. The immutable test flag and all temporary state were cleaned up. Full changed-file gates and individual Codex P0 review passed.

Runtime proof used one build of four disjoint CLI repairs on `f74dde80b6c951124d9f8c7038d8391945296e79`; it does not claim a live model timeout. Timeout exit-code preservation is covered by the owner regression. Production +4, tests +40, docs +2 lines. The rewrite removes the proposed extra cleanup-error JSON field, so the earlier request to document that field is superseded by the documented existing stderr contract.

Thanks @SebTardif for identifying the bug and contributing the original fix.

The same 121 owner tests also passed in Blacksmith Testbox with all 12 candidate file hashes checked before execution and after the tests. The lease was stopped after completion.
