### PR TITLE
refactor(plugins): remove unused web runtime facades

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3546,7 +3546,7 @@ src/plugins/runtime/runtime-llm-isolated.ts	3
 src/plugins/runtime/runtime-llm.runtime.ts	4
 src/plugins/runtime/runtime-plugin-boundary.ts	2
 src/plugins/runtime/runtime-taskflow.ts	1
-src/plugins/runtime/runtime-web-channel-plugin.ts	3
+src/plugins/runtime/runtime-web-channel-plugin.ts	1
 src/plugins/schema-validator.ts	6
 src/plugins/sdk-alias.ts	3
 src/plugins/services.ts	1

--- a/src/plugins/runtime/runtime-web-channel-plugin.test.ts
+++ b/src/plugins/runtime/runtime-web-channel-plugin.test.ts
@@ -1,4 +1,4 @@
-// Runtime web-channel plugin tests cover web channel plugin activation and runtime behavior.
+// Runtime web-channel plugin tests cover the public monitor facade and plugin lifecycle.
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -6,91 +6,99 @@ import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 
 const tempDirs = createTempDirTracker();
 
-afterEach(() => {
+afterEach(async () => {
+  const { clearPluginMetadataLifecycleCaches } = await import("../plugin-metadata-lifecycle.js");
+  clearPluginMetadataLifecycleCaches();
   tempDirs.cleanup();
   vi.doUnmock("./runtime-plugin-boundary.js");
   vi.resetModules();
 });
 
 describe("runtime web channel plugin", () => {
-  it("resolves the default auth dir through the light runtime on each call", async () => {
-    let authDir = "/tmp/openclaw-default-auth";
-    const resolveDefaultWebAuthDir = vi.fn(() => authDir);
-    const resolvePluginRuntimeRecordByEntryBaseNames = vi.fn(() => ({
-      origin: "bundled",
-      source: "test",
-    }));
-
+  it("forwards library monitor calls lazily with exact arguments and runtime receiver", async () => {
+    const result = { marker: "complete" };
+    const monitorWebChannel = vi.fn(async (..._args: unknown[]) => result);
+    const runtimeModule = { monitorWebChannel };
+    const loadPluginBoundaryModule = vi.fn(() => runtimeModule);
     vi.doMock("./runtime-plugin-boundary.js", () => ({
-      loadPluginBoundaryModule: () => ({ resolveDefaultWebAuthDir }),
-      resolvePluginRuntimeModulePath: () => "/tmp/light-runtime-api.js",
-      resolvePluginRuntimeRecordByEntryBaseNames,
+      loadPluginBoundaryModule,
+      resolvePluginRuntimeModulePath: () => "/tmp/runtime-api.js",
+      resolvePluginRuntimeRecordByEntryBaseNames: () => ({
+        origin: "bundled",
+        source: "test",
+      }),
     }));
 
-    const { resolveWebChannelAuthDir } = await import("./runtime-web-channel-plugin.js");
+    const library = await import("../../library.js");
+    expect(loadPluginBoundaryModule).not.toHaveBeenCalled();
+    const args = [
+      true,
+      vi.fn(),
+      false,
+      vi.fn(),
+      { log: vi.fn() },
+      new AbortController().signal,
+      { accountId: "work" },
+    ];
+    await expect(library.monitorWebChannel(...args)).resolves.toBe(result);
+    expect(monitorWebChannel).toHaveBeenCalledOnce();
+    expect(monitorWebChannel.mock.contexts[0]).toBe(runtimeModule);
+    const [receivedArgs] = monitorWebChannel.mock.calls;
+    expect(receivedArgs).toHaveLength(args.length);
+    for (const [index, arg] of args.entries()) {
+      expect(receivedArgs?.[index]).toBe(arg);
+    }
 
-    expect(resolveWebChannelAuthDir()).toBe("/tmp/openclaw-default-auth");
-    authDir = "/tmp/openclaw-profile-auth";
-    expect(resolveWebChannelAuthDir()).toBe("/tmp/openclaw-profile-auth");
-    expect(resolveDefaultWebAuthDir).toHaveBeenCalledTimes(2);
+    const monitorError = new Error("monitor failed");
+    monitorWebChannel.mockRejectedValueOnce(monitorError);
+    await expect(library.monitorWebChannel(...args)).rejects.toBe(monitorError);
   });
 
-  it.each(["light", "heavy"] as const)(
-    "reloads replaced %s runtime artifacts and dependencies after plugin lifecycle clears",
-    async (kind) => {
-      const pluginRoot = fs.realpathSync(tempDirs.make("openclaw-web-runtime-replacement-"));
-      const modulePath = path.join(
-        pluginRoot,
-        kind === "light" ? "light-runtime-api.js" : "runtime-api.js",
+  it("reloads replaced monitor artifacts and dependencies after plugin lifecycle clears", async () => {
+    const pluginRoot = fs.realpathSync(tempDirs.make("openclaw-web-runtime-replacement-"));
+    const modulePath = path.join(pluginRoot, "runtime-api.js");
+    const dependencyPath = path.join(pluginRoot, "dependency.js");
+    fs.writeFileSync(path.join(pluginRoot, "package.json"), '{"type":"commonjs"}\n', "utf8");
+
+    const writeRuntime = (marker: string) => {
+      fs.writeFileSync(dependencyPath, `module.exports = ${JSON.stringify(marker)};\n`, "utf8");
+      fs.writeFileSync(
+        modulePath,
+        `module.exports = { monitorWebChannel: () => ${JSON.stringify(marker)} + ":" + require("./dependency.js") };\n`,
+        "utf8",
       );
-      const dependencyPath = path.join(pluginRoot, "dependency.js");
-      fs.writeFileSync(path.join(pluginRoot, "package.json"), '{"type":"commonjs"}\n', "utf8");
+    };
+    writeRuntime("retired");
 
-      const writeRuntime = (marker: string) => {
-        fs.writeFileSync(dependencyPath, `module.exports = ${JSON.stringify(marker)};\n`, "utf8");
-        const exportName = kind === "light" ? "resolveDefaultWebAuthDir" : "startWebLoginWithQr";
-        fs.writeFileSync(
-          modulePath,
-          `module.exports = { ${exportName}: () => ${JSON.stringify(marker)} + ":" + require("./dependency.js") };\n`,
-          "utf8",
-        );
-      };
-      writeRuntime("retired");
+    vi.doMock("./runtime-plugin-boundary.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./runtime-plugin-boundary.js")>()),
+      resolvePluginRuntimeRecordByEntryBaseNames: () => ({
+        origin: "global",
+        rootDir: pluginRoot,
+        source: path.join(pluginRoot, "index.js"),
+      }),
+      resolvePluginRuntimeModulePath: () => modulePath,
+    }));
 
-      vi.doMock("./runtime-plugin-boundary.js", async (importOriginal) => ({
-        ...(await importOriginal<typeof import("./runtime-plugin-boundary.js")>()),
-        resolvePluginRuntimeRecordByEntryBaseNames: () => ({
-          origin: "global",
-          rootDir: pluginRoot,
-          source: path.join(pluginRoot, "index.js"),
-        }),
-        resolvePluginRuntimeModulePath: () => modulePath,
-      }));
+    const runtime = await import("./runtime-web-channel-plugin.js");
+    const { clearPluginMetadataLifecycleCaches } = await import("../plugin-metadata-lifecycle.js");
+    await expect(runtime.monitorWebChannel()).resolves.toBe("retired:retired");
+    writeRuntime("replacement");
+    await expect(runtime.monitorWebChannel()).resolves.toBe("retired:retired");
 
-      const runtime = await import("./runtime-web-channel-plugin.js");
-      const { clearPluginMetadataLifecycleCaches } =
-        await import("../plugin-metadata-lifecycle.js");
-      const invoke = () =>
-        kind === "light"
-          ? Promise.resolve(runtime.resolveWebChannelAuthDir())
-          : runtime.startWebLoginWithQr();
+    clearPluginMetadataLifecycleCaches();
 
-      await expect(invoke()).resolves.toBe("retired:retired");
-      writeRuntime("replacement");
-      await expect(invoke()).resolves.toBe("retired:retired");
-
-      clearPluginMetadataLifecycleCaches();
-
-      await expect(invoke()).resolves.toBe("replacement:replacement");
-      await expect(invoke()).resolves.toBe("replacement:replacement");
-    },
-  );
+    await expect(runtime.monitorWebChannel()).resolves.toBe("replacement:replacement");
+    await expect(runtime.monitorWebChannel()).resolves.toBe("replacement:replacement");
+  });
 
   it("reports heavy runtime load failures as promise rejections", async () => {
+    const loadError = new Error("runtime unavailable");
+    const loadPluginBoundaryModule = vi.fn(() => {
+      throw loadError;
+    });
     vi.doMock("./runtime-plugin-boundary.js", () => ({
-      loadPluginBoundaryModule: () => {
-        throw new Error("runtime unavailable");
-      },
+      loadPluginBoundaryModule,
       resolvePluginRuntimeModulePath: () => "/tmp/runtime-api.js",
       resolvePluginRuntimeRecordByEntryBaseNames: () => ({
         origin: "bundled",
@@ -99,41 +107,7 @@ describe("runtime web channel plugin", () => {
     }));
     const runtime = await import("./runtime-web-channel-plugin.js");
 
-    await expect(runtime.loginWeb(false)).rejects.toThrow("runtime unavailable");
-    await expect(runtime.monitorWebChannel()).rejects.toThrow("runtime unavailable");
-  });
-
-  it("falls back to the older WhatsApp light runtime auth dir export", async () => {
-    vi.doMock("./runtime-plugin-boundary.js", () => ({
-      loadPluginBoundaryModule: () => ({ WA_WEB_AUTH_DIR: "/tmp/openclaw-legacy-auth" }),
-      resolvePluginRuntimeModulePath: () => "/tmp/light-runtime-api.js",
-      resolvePluginRuntimeRecordByEntryBaseNames: () => ({
-        origin: "external",
-        source: "test",
-      }),
-    }));
-
-    const { resolveWebChannelAuthDir } = await import("./runtime-web-channel-plugin.js");
-
-    expect(resolveWebChannelAuthDir()).toBe("/tmp/openclaw-legacy-auth");
-  });
-
-  it("rejects non-string legacy auth dir exports", async () => {
-    vi.doMock("./runtime-plugin-boundary.js", () => ({
-      loadPluginBoundaryModule: () => ({
-        WA_WEB_AUTH_DIR: Object("/tmp/openclaw-string-object-auth"),
-      }),
-      resolvePluginRuntimeModulePath: () => "/tmp/light-runtime-api.js",
-      resolvePluginRuntimeRecordByEntryBaseNames: () => ({
-        origin: "external",
-        source: "test",
-      }),
-    }));
-
-    const { resolveWebChannelAuthDir } = await import("./runtime-web-channel-plugin.js");
-
-    expect(() => resolveWebChannelAuthDir()).toThrow(
-      "web channel plugin runtime is missing export 'resolveDefaultWebAuthDir'",
-    );
+    expect(loadPluginBoundaryModule).not.toHaveBeenCalled();
+    await expect(runtime.monitorWebChannel()).rejects.toBe(loadError);
   });
 });

--- a/src/plugins/runtime/runtime-web-channel-plugin.ts
+++ b/src/plugins/runtime/runtime-web-channel-plugin.ts
@@ -1,6 +1,5 @@
 // Runtime web-channel plugin helpers expose web-channel tools through activated plugin runtimes.
 import path from "node:path";
-import { getDefaultLocalRootsCore } from "../../media/web-media.js";
 import type { PluginOrigin } from "../plugin-origin.types.js";
 import {
   loadPluginBoundaryModule,
@@ -14,39 +13,8 @@ type WebChannelPluginRecord = {
   source: string;
 };
 
-type WebChannelLightRuntimeModule = {
-  getActiveWebListener: (accountId?: string | null) => unknown;
-  getWebAuthAgeMs: (authDir?: string) => number | null;
-  logWebSelfId: (authDir?: string, runtime?: unknown, includeChannelPrefix?: boolean) => void;
-  logoutWeb: (params: {
-    authDir?: string;
-    isLegacyAuthDir?: boolean;
-    runtime?: unknown;
-  }) => Promise<boolean>;
-  readWebSelfId: (authDir?: string) => {
-    e164: string | null;
-    jid: string | null;
-    lid: string | null;
-  };
-  webAuthExists: (authDir?: string) => Promise<boolean>;
-  getStatusCode: (error: unknown) => number | undefined;
-  pickWebChannel: (pref: string, authDir?: string) => Promise<string>;
-  resolveDefaultWebAuthDir?: () => string;
-  WA_WEB_AUTH_DIR?: string;
-};
-
 type WebChannelHeavyRuntimeModule = {
-  loginWeb: (
-    verbose: boolean,
-    waitForConnection?: (sock: unknown) => Promise<void>,
-    runtime?: unknown,
-    accountId?: string,
-  ) => Promise<void>;
   monitorWebChannel: (...args: unknown[]) => Promise<unknown>;
-  monitorWebInbox: (...args: unknown[]) => Promise<unknown>;
-  startWebLoginWithQr: (...args: unknown[]) => Promise<unknown>;
-  waitForWebLogin: (...args: unknown[]) => Promise<unknown>;
-  extractText: (...args: unknown[]) => unknown;
 };
 
 /** Resolves the active web-channel plugin record that provides runtime APIs. */
@@ -71,15 +39,6 @@ function resolveWebChannelRuntimeModulePath(
   return modulePath;
 }
 
-function loadWebChannelLightModule(): WebChannelLightRuntimeModule {
-  const record = resolveWebChannelPluginRecord();
-  const modulePath = resolveWebChannelRuntimeModulePath(record, "light-runtime-api");
-  return loadPluginBoundaryModule<WebChannelLightRuntimeModule>(modulePath, {
-    origin: record.origin,
-    rootDir: record.rootDir ?? path.dirname(record.source),
-  });
-}
-
 function loadWebChannelHeavyModuleSync(): WebChannelHeavyRuntimeModule {
   const record = resolveWebChannelPluginRecord();
   const modulePath = resolveWebChannelRuntimeModulePath(record, "runtime-api");
@@ -93,143 +52,9 @@ async function loadWebChannelHeavyModule(): Promise<WebChannelHeavyRuntimeModule
   return loadWebChannelHeavyModuleSync();
 }
 
-function getLightExport<K extends keyof WebChannelLightRuntimeModule>(
-  exportName: K,
-): NonNullable<WebChannelLightRuntimeModule[K]> {
-  const loaded = loadWebChannelLightModule();
-  const value = loaded[exportName];
-  if (value == null) {
-    throw new Error(`web channel plugin runtime is missing export '${exportName}'`);
-  }
-  return value as NonNullable<WebChannelLightRuntimeModule[K]>;
-}
-
-async function getHeavyExport<K extends keyof WebChannelHeavyRuntimeModule>(
-  exportName: K,
-): Promise<NonNullable<WebChannelHeavyRuntimeModule[K]>> {
-  const loaded = await loadWebChannelHeavyModule();
-  const value = loaded[exportName];
-  if (value == null) {
-    throw new Error(`web channel plugin runtime is missing export '${exportName}'`);
-  }
-  return value as NonNullable<WebChannelHeavyRuntimeModule[K]>;
-}
-
-/** Returns the active web channel listener from the light runtime API. */
-export function getActiveWebListener(
-  ...args: Parameters<WebChannelLightRuntimeModule["getActiveWebListener"]>
-): ReturnType<WebChannelLightRuntimeModule["getActiveWebListener"]> {
-  return getLightExport("getActiveWebListener")(...args);
-}
-
-/** Returns web-auth age from the light runtime API. */
-export function getWebAuthAgeMs(
-  ...args: Parameters<WebChannelLightRuntimeModule["getWebAuthAgeMs"]>
-): ReturnType<WebChannelLightRuntimeModule["getWebAuthAgeMs"]> {
-  return getLightExport("getWebAuthAgeMs")(...args);
-}
-
-/** Logs the active web account self id through the light runtime API. */
-export function logWebSelfId(
-  ...args: Parameters<WebChannelLightRuntimeModule["logWebSelfId"]>
-): ReturnType<WebChannelLightRuntimeModule["logWebSelfId"]> {
-  return getLightExport("logWebSelfId")(...args);
-}
-
-/** Starts web-channel login through the heavy runtime API. */
-export function loginWeb(
-  ...args: Parameters<WebChannelHeavyRuntimeModule["loginWeb"]>
-): ReturnType<WebChannelHeavyRuntimeModule["loginWeb"]> {
-  return loadWebChannelHeavyModule().then((loaded) => loaded.loginWeb(...args));
-}
-
-/** Logs out the web-channel account through the light runtime API. */
-export function logoutWeb(
-  ...args: Parameters<WebChannelLightRuntimeModule["logoutWeb"]>
-): ReturnType<WebChannelLightRuntimeModule["logoutWeb"]> {
-  return getLightExport("logoutWeb")(...args);
-}
-
-/** Reads the web-channel self id through the light runtime API. */
-export function readWebSelfId(
-  ...args: Parameters<WebChannelLightRuntimeModule["readWebSelfId"]>
-): ReturnType<WebChannelLightRuntimeModule["readWebSelfId"]> {
-  return getLightExport("readWebSelfId")(...args);
-}
-
-/** Checks whether web-channel auth exists through the light runtime API. */
-export function webAuthExists(
-  ...args: Parameters<WebChannelLightRuntimeModule["webAuthExists"]>
-): ReturnType<WebChannelLightRuntimeModule["webAuthExists"]> {
-  return getLightExport("webAuthExists")(...args);
-}
-
-/** Reads a web-channel status code from the light runtime API. */
-export function getStatusCode(
-  ...args: Parameters<WebChannelLightRuntimeModule["getStatusCode"]>
-): ReturnType<WebChannelLightRuntimeModule["getStatusCode"]> {
-  return getLightExport("getStatusCode")(...args);
-}
-
-/** Picks the active web channel through the light runtime API. */
-export function pickWebChannel(
-  ...args: Parameters<WebChannelLightRuntimeModule["pickWebChannel"]>
-): ReturnType<WebChannelLightRuntimeModule["pickWebChannel"]> {
-  return getLightExport("pickWebChannel")(...args);
-}
-
-/** Resolves the default web-channel auth directory from the light runtime API. */
-export function resolveWebChannelAuthDir(): ReturnType<
-  NonNullable<WebChannelLightRuntimeModule["resolveDefaultWebAuthDir"]>
-> {
-  const loaded = loadWebChannelLightModule();
-  if (loaded.resolveDefaultWebAuthDir) {
-    return loaded.resolveDefaultWebAuthDir();
-  }
-  // Older light runtimes expose the default auth dir as a primitive string.
-  // Do not accept string-like objects here; Node path APIs reject them before
-  // coercion.
-  if (typeof loaded.WA_WEB_AUTH_DIR === "string") {
-    return loaded.WA_WEB_AUTH_DIR;
-  }
-  throw new Error("web channel plugin runtime is missing export 'resolveDefaultWebAuthDir'");
-}
-
 /** Starts web-channel monitoring through the heavy runtime API. */
 export function monitorWebChannel(
   ...args: Parameters<WebChannelHeavyRuntimeModule["monitorWebChannel"]>
 ): ReturnType<WebChannelHeavyRuntimeModule["monitorWebChannel"]> {
   return loadWebChannelHeavyModule().then((loaded) => loaded.monitorWebChannel(...args));
-}
-
-/** Starts web inbox monitoring through the heavy runtime API. */
-export async function monitorWebInbox(
-  ...args: Parameters<WebChannelHeavyRuntimeModule["monitorWebInbox"]>
-): ReturnType<WebChannelHeavyRuntimeModule["monitorWebInbox"]> {
-  return (await getHeavyExport("monitorWebInbox"))(...args);
-}
-
-/** Starts QR login through the heavy runtime API. */
-export async function startWebLoginWithQr(
-  ...args: Parameters<WebChannelHeavyRuntimeModule["startWebLoginWithQr"]>
-): ReturnType<WebChannelHeavyRuntimeModule["startWebLoginWithQr"]> {
-  return (await getHeavyExport("startWebLoginWithQr"))(...args);
-}
-
-/** Waits for web-channel login through the heavy runtime API. */
-export async function waitForWebLogin(
-  ...args: Parameters<WebChannelHeavyRuntimeModule["waitForWebLogin"]>
-): ReturnType<WebChannelHeavyRuntimeModule["waitForWebLogin"]> {
-  return (await getHeavyExport("waitForWebLogin"))(...args);
-}
-
-/** Extracts text through the heavy runtime API. */
-export const extractText = (...args: Parameters<WebChannelHeavyRuntimeModule["extractText"]>) =>
-  loadWebChannelHeavyModuleSync().extractText(...args);
-
-/** Returns default local media roots through the core media helper. */
-export function getDefaultLocalRoots(
-  ...args: Parameters<typeof getDefaultLocalRootsCore>
-): ReturnType<typeof getDefaultLocalRootsCore> {
-  return getDefaultLocalRootsCore(...args);
 }


### PR DESCRIPTION
## What Problem This Solves

The private web-channel runtime facade still carried unused light-runtime, login, inbox, and media wrappers even though the package-root library only needs its monitor entry point. Those unused entry points duplicated loading paths and kept tests and assertion-baseline entries alive without production callers.

## Why This Change Was Made

Remove those unused private facade exports and keep `monitorWebChannel` on its existing runtime boundary. The plugin discriminator still requires both light and heavy runtime artifacts; lazy asynchronous failure, method receiver and argument forwarding, native loading, and module-cache invalidation keep their existing owners.

Production changes are 175 lines removed with no replacement production lines. Tests decrease by 26 lines; the assertion baseline updates the remaining cast count from three to one. No public SDK, configuration, schema, protocol, dependency, or authorization contract changes.

## User Impact

No intentional user-visible behavior change. The package-root monitor export remains available; operators do not need to change their configuration.

## Evidence

- Tests-first characterization and the candidate each passed the same eight cases across three suites, preserving case identities and within-file order. Coverage includes monitor forwarding and lazy rejection, the dual-artifact selector, real CommonJS module invalidation, and the library caller.
- The normal changed-file gate passed all 30 selected checks through the configured Testbox route: [workflow run](https://github.com/openclaw/openclaw/actions/runs/33500462649). This was the prepared source-tree gate, not exact-head PR CI; independent remote installed-file hashes were not captured.
- The ordinary full build completed all 16 stages, including unified entry declarations.
- Three isolated synthetic projects imported the actual built package root: complete plugin plus decoy, runtime-only rejection, and ambiguous-plugin rejection. These passed with the real configuration/discovery/native-loading path. This is built-output synthetic proof, not a clean-install, official-plugin trust, live-channel, or live-authentication test.
- The first package probe stopped before package import on a Darwin environment-bookkeeping assertion. A separate clean-environment Node diagnostic qualified that single observed key; a fresh second run preserved all other environment and product assertions and passed all three scenarios. The first run's fixtures and receipts were retained.
- Fixture-root and known-process cleanup were verified. Six empty ordinary global database coordinator files attributable to the synthetic run were retained; no pre-run inventory established that they were newly created, and global filesystem cleanup is not claimed.
- The precommit review and a separate review of exact commit `00a356e8801d5cc8987d150faa107e8053447b7d` each completed two Codex passes with no actionable P0 findings. These are scoped P0 reviews, not all-priority certification. The exact-head review's single live observer raced removal of an ephemeral workspace, so effective reviewer-engine flags were not attested by that observation.
