### PR TITLE
refactor(gateway): derive session projections from protocol types

### DIFF
--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -2,22 +2,13 @@
 // Keeps server methods and Control UI payloads aligned.
 import type { FastMode } from "@openclaw/normalization-core/string-coerce";
 import type {
-  SessionCreatedActor,
-  SessionClassification,
-  SessionPeerKind,
-  SessionOwner,
   SessionPlacement,
   SessionPlacementMove,
   SessionRow,
-  SessionRunStatus,
-  SessionSharingRole,
-  SessionVisibility,
 } from "../../packages/gateway-protocol/src/index.js";
 import type { QueueMode } from "../../packages/gateway-protocol/src/schema/logs-chat.js";
-import type { SessionParticipant } from "../../packages/gateway-protocol/src/schema/session-participant.js";
 import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
 import type { StickyModelSelectionTarget } from "../agents/sticky-model-selection.js";
-import type { ChatType } from "../channels/chat-type.js";
 import type {
   SessionCompactionCheckpoint,
   SessionEntry,
@@ -31,7 +22,6 @@ import type {
   GatewayAgentRow as SharedGatewayAgentRow,
   GatewayContextWindowOption,
   GatewayThinkingLevelOption,
-  SessionBoardFace,
   SessionsListResultBase,
   SessionsPatchResultBase,
 } from "../shared/session-types.js";
@@ -61,90 +51,24 @@ type SessionCompactionCheckpointPreview = Pick<
   "checkpointId" | "createdAt" | "reason"
 >;
 
-export type GatewaySessionRow = {
-  key: string;
-  /** Optional display metadata; never authoritative for session access or lifecycle. */
-  classification?: SessionClassification;
-  agentId?: string;
-  accountId?: string;
-  peerKind?: SessionPeerKind;
-  isMain?: boolean;
-  isBackground?: boolean;
-  /** Additive collaboration state; absent on older gateways. */
-  visibility?: SessionVisibility;
-  /** Caller-relative role used by Control UI participation controls. */
-  sharingRole?: SessionSharingRole;
-  incognito?: true;
-  spawnedBy?: string;
-  /** Current runtime controller, falling back to the durable spawning session. */
-  controlOwnerSessionKey?: string;
-  /** Collector swarm group that owns this child session, when applicable. */
-  swarmGroupId?: string;
-  spawnedWorkspaceDir?: string;
-  spawnedCwd?: string;
-  permissionMode?: SessionEntry["permissionMode"];
-  permissionModePending?: boolean;
-  sessionRoot?: string;
-  /** Managed worktree bound to this session (repo checkout + branch). */
+export type GatewaySessionRow = Omit<SessionRow, "archivedBy" | "updatedAt" | "worktree"> & {
   worktree?: SessionEntry["worktree"];
-  /** Session-scoped exec node binding (exec host=node routing). */
-  execNode?: string;
-  /** Working directory interpreted only by the bound exec node. */
-  execCwd?: string;
-  forkedFromParent?: boolean;
-  spawnDepth?: number;
-  subagentRole?: SessionEntry["subagentRole"];
-  subagentControlScope?: SessionEntry["subagentControlScope"];
-  createdVia?: SessionEntry["createdVia"];
-  createdActor?: SessionCreatedActor;
-  owner?: SessionOwner;
-  participants?: SessionParticipant[];
-  participantCount?: number;
-  createdAt?: SessionEntry["createdAt"];
-  forkSource?: SessionEntry["forkSource"];
-  previousSessionId?: SessionEntry["previousSessionId"];
-  kind: "direct" | "group" | "global" | "unknown";
-  label?: string;
-  icon?: string;
-  /** Named sidebar tint (SESSION_COLOR_IDS). */
-  color?: string;
-  channelAvatarUrl?: string;
-  /** User-defined organization bucket; unrelated to chat-group kind/groupChannel. */
   category?: string;
-  /** Preferred Control UI face for generic session navigation. */
-  boardFace?: SessionBoardFace;
-  displayName?: string;
-  derivedTitle?: string;
-  lastMessagePreview?: string;
-  channel?: string;
   subject?: string;
   groupChannel?: string;
   space?: string;
-  chatType?: ChatType;
   origin?: Omit<SessionOrigin, "avatar">;
   updatedAt: number | null;
-  archived?: boolean;
-  archivedAt?: number;
   archivedBy?: SessionEntry["archivedBy"];
-  pinned?: boolean;
-  pinnedAt?: number;
-  unread?: boolean;
-  lastReadAt?: number;
-  markedUnreadAt?: number;
   agentStatus?: SessionEntry["agentStatus"];
   observerDigest?: Pick<
     SessionObserverDigest,
     "agentId" | "runId" | "headline" | "health" | "updatedAt" | "revision"
   >;
-  /** Last real user/channel interaction; background work does not advance it. */
-  lastInteractionAt?: number;
-  lastActivityAt?: number;
-  sessionId?: string;
   placement?: SessionPlacement;
   placementMove?: SessionPlacementMove;
   systemSent?: boolean;
   abortedLastRun?: boolean;
-  restartRecoveryStatus?: "tombstoned";
   thinkingLevel?: string;
   contextWindow?: string;
   contextWindows?: GatewayContextWindowOption[];
@@ -153,7 +77,6 @@ export type GatewaySessionRow = {
   thinkingOptions?: string[];
   thinkingDefault?: string;
   fastMode?: FastMode;
-  toolOverrides?: SessionEntry["toolOverrides"];
   effectiveFastMode?: FastMode;
   effectiveFastModeSource?: FastModeSource;
   fastAutoOnSeconds?: number;
@@ -162,44 +85,21 @@ export type GatewaySessionRow = {
   reasoningLevel?: string;
   elevatedLevel?: string;
   sendPolicy?: "allow" | "deny";
-  inputTokens?: number;
-  outputTokens?: number;
-  totalTokens?: number;
-  totalTokensFresh?: boolean;
   goal?: SessionGoal;
-  estimatedCostUsd?: number;
-  status?: SessionRunStatus;
-  /** Compact user-facing reason for the latest failed or timed-out run. */
-  lastRunError?: string;
-  /** Exact run that produced the latest terminal lifecycle projection. */
-  lastRunId?: string;
   hasActiveRun?: boolean;
-  /** Complete exact active set when present; omitted for active owners without exact identities. */
   activeRunIds?: string[];
-  /** Active transcript-branch leaf for history rendered from this row. */
-  activeLeafEntryId?: string | null;
-  /** An enabled cron job is bound to this session (runs in it or delivers to it). */
   hasAutomation?: boolean;
   subagentRunState?: SubagentRunState;
   hasActiveSubagentRun?: boolean;
   startedAt?: number;
   endedAt?: number;
   runtimeMs?: number;
-  parentSessionKey?: string;
-  childSessions?: string[];
   responseUsage?: "on" | "off" | "tokens" | "full";
-  /** Resolved effective usage mode (session override → channel config → default → off). Populated by surfaces that have config access; absent from the raw session store row. */
   effectiveResponseUsage?: "on" | "off" | "tokens" | "full";
-  /** Explicit per-session queue override, before channel/global defaults. */
   queueMode?: QueueMode;
-  /** Queue mode for Control UI sends (session override → webchat config → global default). */
   effectiveQueueMode?: QueueMode;
-  modelProvider?: string;
-  model?: string;
-  modelOverrideSource?: "user" | "auto" | null;
   modelSelectionLocked?: boolean;
   agentRuntime?: GatewayAgentRuntime;
-  contextTokens?: number;
   contextBudgetStatus?: SessionEntry["contextBudgetStatus"];
   deliveryContext?: DeliveryContext;
   lastChannel?: string;

--- a/src/shared/session-types.ts
+++ b/src/shared/session-types.ts
@@ -1,59 +1,20 @@
 import type {
-  GatewayAgentRuntime as ProtocolGatewayAgentRuntime,
+  AgentSummary,
+  ModelChoice,
   SessionCreatedActor,
   SessionPerson,
-  SessionPermissionMode,
   SessionsAssignOwnerParams,
-  WorkerExecutionMode,
 } from "../../packages/gateway-protocol/src/index.js";
 
-/** Agent identity fields returned by gateway session listing APIs. */
-type GatewayAgentIdentity = {
-  name?: string;
-  theme?: string;
-  emoji?: string;
-  avatar?: string;
-  avatarUrl?: string;
-};
-
-/** Model summary returned for an agent/session row. */
-type GatewayAgentModel = {
-  primary?: string;
-  fallbacks?: string[];
-};
-
 /** Runtime selection metadata for an agent row. */
-export type GatewayAgentRuntime = {
-  id: string;
-  fallback?: "openclaw" | "none";
-  cloudPlacementSupported?: boolean;
-  cloudPlacementExecutionMode?: WorkerExecutionMode;
-  devicePlacement?: ProtocolGatewayAgentRuntime["devicePlacement"];
-  devicePlacementSupported?: boolean;
-  source:
-    | "env"
-    | "agent"
-    | "defaults"
-    | "model"
-    | "provider"
-    | "implicit"
-    | "session"
-    | "session-key";
-};
+export type GatewayAgentRuntime = NonNullable<AgentSummary["agentRuntime"]>;
 
 /** Thinking-level option exposed to UI clients. */
-export type GatewayThinkingLevelOption = {
-  id: string;
-  label: string;
-};
+export type GatewayThinkingLevelOption = NonNullable<AgentSummary["thinkingLevels"]>[number];
 
-export type GatewayContextWindowOption = {
-  id: string;
-  label: string;
-  contextWindow: number;
-};
+export type GatewayContextWindowOption = NonNullable<ModelChoice["contextWindows"]>[number];
 
-export type GatewayAgentKind = "agent" | "system";
+export type GatewayAgentKind = NonNullable<AgentSummary["kind"]>;
 
 /** Assignable identity returned by the complete session-owner facet. */
 export type SessionOwnerFacetIdentity = SessionsAssignOwnerParams["owner"] &
@@ -63,21 +24,21 @@ export type SessionOwnerFacetIdentity = SessionsAssignOwnerParams["owner"] &
 export type SessionBoardFace = "chat" | "dashboard";
 
 /** Common agent row shape used by session list responses. */
-export type GatewayAgentRow = {
-  id: string;
-  kind?: GatewayAgentKind;
-  name?: string;
-  identity?: GatewayAgentIdentity;
-  workspace?: string;
-  workspaceGit?: boolean;
-  model?: GatewayAgentModel;
-  agentRuntime?: GatewayAgentRuntime;
-  thinkingLevels?: GatewayThinkingLevelOption[];
-  thinkingOptions?: string[];
-  thinkingDefault?: string;
-  /** Configured posture label only; never an authorization decision. */
-  defaultPermissionMode?: SessionPermissionMode;
-};
+export type GatewayAgentRow = Pick<
+  AgentSummary,
+  | "id"
+  | "kind"
+  | "name"
+  | "identity"
+  | "workspace"
+  | "workspaceGit"
+  | "model"
+  | "agentRuntime"
+  | "thinkingLevels"
+  | "thinkingOptions"
+  | "thinkingDefault"
+  | "defaultPermissionMode"
+>;
 
 /** Generic base for paged session-list responses. */
 export type SessionsListResultBase<TDefaults, TRow> = {


### PR DESCRIPTION
Gateway session and agent projections repeated shapes already owned by the Gateway protocol. They now derive those declarations from the canonical protocol types while retaining the internal refinements used by their producers. This removes 139 net production lines (137 nonblank; 114 excluding comments), with no test changes and byte-identical emitted JavaScript.

The agent row uses an explicit twelve-key selection, so protocol creation metadata does not silently widen that projection. The session row keeps its required nullable `updatedAt`, internal worktree metadata and narrower archived actor, along with the six-field observer digest, context budget and plugin extensions. The existing value-level schema drift guard is unchanged. No protocol schema, persistence behavior or runtime projection changes.

Validation:

- An immutable compiler characterization passes against the original and final owners, checking assignability in both directions, exact keys, optionality, readonly fields and nested refinements.
- Pinned compiler emission is byte-identical for both modules, including the unchanged drift guard.
- All 231 maintained Gateway tests and 45 protocol tests pass. Core and core-test type checks, the UI type check, all three unused-export scans and selected repository checks pass.
- After removing the final redundant type property, the narrow compiler, equivalence, emission, formatting and diff checks pass. Final isolated Codex P2 review is clean.

Initial external characterization setup failures are retained: direct-file compilation needed the repository's project mappings, root and ambient declarations, and declaration emission was disabled for the temporary assertion fixture. The final fixture preserves the original assertions and is identical for baseline and candidate. This is a declaration-only refactor; no runtime or external-service performance claim is made.


The full 14:59 UTC ClawSweeper review has no correctness or security findings. Its remaining CI request and rank-up move are now satisfied: the eligible exact-head CI run33521419479 was rerun once after its initial cancellation and all243 jobs passed or were appropriately skipped, including the required gate. Root verified the canonical protocol/schema/producer boundary and source-bound compiler/runtime evidence. This removes139 physical production declaration lines (137 nonblank), with zero emitted JavaScript or test delta.
