### PR TITLE
fix(ci): run Android tests for shared Talk config changes

### DIFF
--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -64,6 +64,7 @@ const ANDROID_NATIVE_RE = /^(apps\/android\/|apps\/shared\/)/;
 // Native bundling reads the root aliases and this shared coercion dependency.
 const MERMAID_ASSET_INPUT_RE =
   /^(?:packages\/(?:mermaid-renderer\/|normalization-core\/(?:package\.json|src\/record-coerce\.ts)$)|tsconfig\.json$)/;
+const ANDROID_TALK_CONTRACT_FIXTURE_RE = /^test\/fixtures\/talk-config-contract\.json$/;
 const NODE_SCOPE_RE =
   /^(src\/|test\/|extensions\/|packages\/|scripts\/|ui\/|\.github\/|openclaw\.mjs$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig.*\.json$|vitest.*\.ts$|tsdown\.config\.ts$|\.oxlintrc\.json$|\.oxfmtrc\.jsonc$)/;
 const WINDOWS_SQLITE_SCOPE_RE = /^src\/(?:state\/|.*sqlite.*\.ts$)/;
@@ -237,7 +238,9 @@ export function detectChangedScope(changedPaths) {
 
     if (
       !NATIVE_PROTOCOL_GEN_RE.test(path) &&
-      (ANDROID_NATIVE_RE.test(path) || MERMAID_ASSET_INPUT_RE.test(path))
+      (ANDROID_NATIVE_RE.test(path) ||
+        ANDROID_TALK_CONTRACT_FIXTURE_RE.test(path) ||
+        MERMAID_ASSET_INPUT_RE.test(path))
     ) {
       runAndroid = true;
     }

--- a/src/scripts/ci-changed-scope.contract-fixtures.test.ts
+++ b/src/scripts/ci-changed-scope.contract-fixtures.test.ts
@@ -1,17 +1,31 @@
 import { describe, expect, it } from "vitest";
 import { detectChangedScope } from "../../scripts/ci-changed-scope.mjs";
 
-describe("shared Apple contract fixture CI scope", () => {
-  it.each([
-    "test/fixtures/device-identity-coordinator-contract.json",
-    "test/fixtures/talk-config-contract.json",
-  ])("runs macOS contract tests for %s", (fixturePath) => {
+describe("shared native contract fixture CI scope", () => {
+  it("runs macOS contract tests for the device identity fixture", () => {
+    const fixturePath = "test/fixtures/device-identity-coordinator-contract.json";
     expect(detectChangedScope([fixturePath])).toEqual({
       runNode: true,
       runMacos: true,
       runMacosNode: true,
       runIosBuild: false,
       runAndroid: false,
+      runWindows: false,
+      runSkillsPython: false,
+      runChangedSmoke: false,
+      runControlUiI18n: false,
+      runUiTests: false,
+    });
+  });
+
+  it("runs Android and macOS contract tests for the shared Talk fixture", () => {
+    const fixturePath = "test/fixtures/talk-config-contract.json";
+    expect(detectChangedScope([fixturePath])).toEqual({
+      runNode: true,
+      runMacos: true,
+      runMacosNode: true,
+      runIosBuild: false,
+      runAndroid: true,
       runWindows: false,
       runSkillsPython: false,
       runChangedSmoke: false,

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -1032,7 +1032,10 @@ describe("detectChangedScope", () => {
             (key === "run_android" &&
               changedPath === "test/fixtures/talk-config-contract.json") ||
             (key === "run_macos_node" &&
-              changedPath === "test/scripts/mac-script-fixture.test-support.ts") ||
+              (changedPath === "test/scripts/mac-script-fixture.test-support.ts" ||
+                changedPath === "test/fixtures/talk-config-contract.json")) ||
+            (key === "run_macos" &&
+              changedPath === "test/fixtures/talk-config-contract.json") ||
             (key === "run_windows" &&
               changedPath === "src/process/exec.windows.integration.test.ts");
           expect(value, key).toBe(String(selected));

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -954,6 +954,7 @@ describe("detectChangedScope", () => {
     ["empty diff without a manifest", "", "missing", false],
     ["declared native test", "src/process/exec.windows.integration.test.ts", "valid", false],
     ["Mac fixture helper", "test/scripts/mac-script-fixture.test-support.ts", "valid", false],
+    ["shared Talk fixture", "test/fixtures/talk-config-contract.json", "valid", false],
     ["unrelated process test", "src/process/exec.test.ts", "valid", false],
     ["missing manifest", "src/process/exec.test.ts", "missing", true],
     ["invalid manifest", "src/process/exec.test.ts", "invalid", true],
@@ -1010,6 +1011,11 @@ describe("detectChangedScope", () => {
       );
 
       const output = parseGitHubOutput(fs.readFileSync(outputPath, "utf8"));
+      if (changedPath === "test/fixtures/talk-config-contract.json") {
+        console.log(
+          `REAL_CI_CHANGED_SCOPE_OUTPUT run_android=${output.run_android} run_macos=${output.run_macos} run_node=${output.run_node}`,
+        );
+      }
       expect(Object.keys(output).toSorted()).toEqual(
         "changed_paths_json run_android run_changed_smoke run_control_ui_i18n run_fast_install_smoke run_full_install_smoke run_ios_build run_ios_screenshots run_macos run_macos_node run_native_i18n run_node run_node_fast_ci_routing run_node_fast_only run_node_fast_plugin_contracts run_skills_python run_ui_tests run_windows strict_control_ui_i18n strict_native_i18n".split(
           " ",
@@ -1023,6 +1029,8 @@ describe("detectChangedScope", () => {
           const selected =
             (failSafe && !key.startsWith("run_node_fast")) ||
             (key === "run_node" && Boolean(changedPath)) ||
+            (key === "run_android" &&
+              changedPath === "test/fixtures/talk-config-contract.json") ||
             (key === "run_macos_node" &&
               changedPath === "test/scripts/mac-script-fixture.test-support.ts") ||
             (key === "run_windows" &&


### PR DESCRIPTION
<!-- Source-first CI bug fix; no public issue is linked. -->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Changing the shared Talk configuration contract fixture did not run Android CI, even though Android's `TalkModeConfigParsingTest` reads that fixture directly. Such changes could therefore update the cross-platform contract without exercising Android parsing.

## Why This Change Was Made

The CI changed-scope owner now routes `test/fixtures/talk-config-contract.json` to the Android lane while preserving its existing macOS and Node coverage. The regression coverage distinguishes this shared Talk fixture from the device-identity fixture, which remains macOS-owned.

## User Impact

Future changes to the shared Talk configuration contract will run the Android unit-test lane, preventing Android parser drift from being hidden by scope selection.

## Evidence

- Before the fix, a synthetic diff containing only `test/fixtures/talk-config-contract.json` produced `run_android=false`.
- On the exact current head `03cf20a87e821f1388d302862e2499e13c188da3`, the real zero-install CLI test created a fixture-only Git diff, invoked `scripts/ci-changed-scope.mjs` with `GITHUB_OUTPUT`, and captured:

  ```text
  REAL_CI_CHANGED_SCOPE_OUTPUT run_android=true run_macos=true run_node=true
  ```

  This output is from the successful [`checks-fast-ci-routing` job](https://github.com/openclaw/openclaw/actions/runs/33593031855/job/100131036778).
- The same current-head job passed 1,323 tests across 12 test files, including the fixture-specific routing assertions.
- All required checks for this head passed, including [`openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/33593031855/job/100131622324), [`checks-fast-ci-routing`](https://github.com/openclaw/openclaw/actions/runs/33593031855/job/100131036778), and [`PR context and evidence`](https://github.com/openclaw/openclaw/actions/runs/33593028973/job/100130740132).
- Rebased onto current `main`; the existing Mermaid asset Android routing remains intact alongside the Talk fixture route.

Proof boundary: the final proof exercises the repository's real changed-scope CLI boundary and the `GITHUB_OUTPUT` file consumed by GitHub Actions for a fixture-only diff. It proves that the selector emits Android, macOS, and Node lane decisions. The Android Gradle test itself is owned by the Android CI lane and is not executed by this selector test.

Worked on by: @IWhatsskill

AI-assisted: yes.