### PR TITLE
fix(progress): preserve words at Unicode truncation boundaries

### DIFF
--- a/docs/concepts/progress-drafts.md
+++ b/docs/concepts/progress-drafts.md
@@ -345,8 +345,8 @@ Limit how many lines stay visible (default 8):
 Progress lines are compacted automatically to reduce chat-bubble reflow while
 the draft is edited, and OpenClaw truncates long lines so repeated draft edits
 do not wrap differently on every update. The default per-line budget is 120
-characters; prose cuts at a word boundary, while long details such as paths or
-raw commands are shortened with a middle ellipsis so the suffix stays visible.
+Unicode code points; prose uses word-aware truncation, while long details such as
+paths or raw commands use a middle ellipsis so the suffix stays visible.
 
 Tune the per-line budget:
 

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -367,12 +367,12 @@ Supported surfaces:
 Progress-mode drafts (`streaming.progress.*`) are bounded and configurable per
 channel:
 
-| Key                               | Default       | Behavior                                                       |
-| --------------------------------- | ------------- | -------------------------------------------------------------- |
-| `streaming.progress.maxLines`     | `8`           | Max compact progress lines kept below the draft label          |
-| `streaming.progress.maxLineChars` | `120`         | Max characters per compact line before truncation (word-aware) |
-| `streaming.progress.label`        | `"auto"`      | Draft title; a custom string, or `false` to hide it            |
-| `streaming.progress.labels`       | built-in pool | Candidate labels used when `label: "auto"`                     |
+| Key                               | Default       | Behavior                                                |
+| --------------------------------- | ------------- | ------------------------------------------------------- |
+| `streaming.progress.maxLines`     | `8`           | Max compact progress lines kept below the draft label   |
+| `streaming.progress.maxLineChars` | `120`         | Max Unicode code points per line; word-aware truncation |
+| `streaming.progress.label`        | `"auto"`      | Draft title; a custom string, or `false` to hide it     |
+| `streaming.progress.labels`       | built-in pool | Candidate labels used when `label: "auto"`              |
 
 Slack always renders progress mode as its fixed session-card layout; these
 limits still bound the activity rows and plan text inside that card.

--- a/extensions/discord/src/monitor/message-handler.draft-preview.rest.test.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.rest.test.ts
@@ -1,4 +1,5 @@
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 import { RequestClient } from "../internal/discord.js";
 import { createDiscordDraftPreviewController } from "./message-handler.draft-preview.js";
@@ -21,6 +22,65 @@ function createPreviewController(rest: RequestClient) {
 }
 
 describe("Discord draft preview REST lifecycle", () => {
+  it.each([
+    {
+      lane: "narration",
+      input: "review ".repeat(38) + "manifest.json next",
+      expected: "review ".repeat(38) + "manifest.json…",
+    },
+    {
+      lane: "reasoning",
+      input: "𠮷".repeat(40) + " " + "x".repeat(100),
+      expected: "𠮷".repeat(40) + " " + "x".repeat(76) + "…",
+    },
+  ])("posts $lane progress through loopback HTTP", async ({ lane, input, expected }) => {
+    const writes: Array<{ method: string; route: string; body: string }> = [];
+    await withServer(
+      (request, response) => {
+        const chunks: Buffer[] = [];
+        request.on("data", (chunk: Buffer) => chunks.push(chunk));
+        request.on("end", () => {
+          writes.push({
+            method: request.method ?? "GET",
+            route: request.url ?? "/",
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+          const deleting = request.method === "DELETE";
+          response.writeHead(deleting ? 204 : 200, {
+            "content-type": "application/json",
+            connection: "close",
+          });
+          response.end(deleting ? undefined : JSON.stringify({ id: "preview-progress" }));
+        });
+      },
+      async (baseUrl) => {
+        const controller = createPreviewController(new RequestClient("test-token", { baseUrl }));
+        try {
+          if (lane === "narration") {
+            await controller.pushNarrationProgress(input);
+          } else {
+            await controller.pushReasoningProgress(input, { snapshot: true });
+          }
+          await controller.pushPlanProgress([
+            { step: "Check retained context", status: "in_progress" },
+          ]);
+          await controller.flush();
+
+          const messages = writes
+            .filter(
+              (write) => write.method === "POST" && write.route === "/v10/channels/c1/messages",
+            )
+            .map((write) => JSON.parse(write.body));
+          expect(messages).toEqual([
+            expect.objectContaining({ content: expect.stringContaining(expected) }),
+          ]);
+        } finally {
+          await controller.cleanup();
+        }
+      },
+    );
+  });
+
   it("retains the progress draft after an error final is delivered", async () => {
     const requests: string[] = [];
     const rest = new RequestClient("test-token", {

--- a/extensions/discord/src/monitor/message-handler.process.draft-reasoning.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.draft-reasoning.test.ts
@@ -246,7 +246,7 @@ describe("processDiscordMessage draft streaming reasoning", () => {
     const lastUpdate = draftStream.update.mock.calls.at(-1)?.[0];
     const reasoningLine = lastUpdate?.split("\n").at(-1);
 
-    expect(reasoningLine).toBe("Thinking through a very…");
+    expect(reasoningLine).toBe("Thinking through a very detailed…");
   });
 
   it("replaces reasoning snapshots instead of appending duplicates", async () => {

--- a/qa/scenarios/channels/telegram-progress-astral-label.yaml
+++ b/qa/scenarios/channels/telegram-progress-astral-label.yaml
@@ -1,0 +1,139 @@
+title: Telegram astral progress label
+
+scenario:
+  id: telegram-progress-astral-label
+  surface: channels
+  coverage:
+    primary:
+      - telegram.conversation-routing-and-delivery
+    secondary:
+      - agent-runtime.streaming-replies-delivery
+  objective: Preserve complete words and Unicode code points in Telegram progress labels bound to the current ingress under first-reply routing.
+  gatewayConfigPatch:
+    channels:
+      telegram:
+        accounts:
+          $selectedAccount:
+            replyToMode: first
+            streaming:
+              mode: progress
+              progress:
+                label: "𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  successCriteria:
+    - A native Telegram progress message or edit replies to this ingress and contains the exact expected 120-code-point label before the final answer.
+    - A successful tool reads an unpredictable value from the owned workspace and the ordinary final reply delivers that value.
+    - The turn settles; draft deletion is outside the current QA adapter observation contract.
+  regressionRefs:
+    - openclaw/openclaw#135277
+  docsRefs:
+    - docs/channels/telegram.md
+    - docs/concepts/streaming.md
+  codeRefs:
+    - src/shared/text-truncate.ts
+    - src/channels/streaming.ts
+    - extensions/telegram/src/bot-message-dispatch-progress.ts
+    - extensions/telegram/src/progress-draft-preview.ts
+  execution:
+    kind: flow
+    channel: telegram
+    providerMode: live-frontier
+    retryCount: 0
+    suiteIsolation: isolated
+    isolationReason: Each case needs its own progress label, first-reply routing, workspace, and Telegram session.
+    config:
+      conversationId: "telegram-progress-astral-label"
+      expectedLabel: "𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷𠮷 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx…"
+      expectedUtf16Units: 160
+flow:
+  steps:
+    - name: shows the bounded label before the tool-backed final
+      actions:
+        - assert:
+            expr: "env.providerMode === 'live-frontier' && transport.id === 'telegram'"
+            message: this scenario requires the live Telegram Test Server adapter and provider
+        - resetTransport: true
+        - set: sinceCursor
+          value:
+            expr: "state.getSnapshot().events.at(-1)?.cursor ?? 0"
+        - set: finalMarker
+          value:
+            expr: "'QA-TELEGRAM-PROGRESS-' + randomUUID()"
+        - set: fixturePath
+          value:
+            expr: "path.join(env.gateway.workspaceDir, scenario.id + '.txt')"
+        - set: delivery
+          value:
+            expr: "transport.buildAgentDelivery({ target: 'group:' + config.conversationId })"
+        - set: sessionKey
+          value:
+            expr: "buildAgentSessionKey({ agentId: 'qa', channel: delivery.channel, accountId: transport.accountId, peer: { kind: 'group', id: delivery.replyTo }, dmScope: env.cfg.session?.dmScope, identityLinks: env.cfg.session?.identityLinks })"
+        - call: fs.writeFile
+          args:
+            - ref: fixturePath
+            - expr: "finalMarker + '\\n'"
+            - utf8
+        - try:
+            actions:
+              - sendInbound:
+                  conversation:
+                    id: { ref: config.conversationId }
+                    kind: group
+                    title: QA Progress Label
+                  senderId: "100001"
+                  senderName: QA Progress Operator
+                  text:
+                    expr: "'@openclaw Read the file ' + fixturePath + ' using a file or shell tool. Reply directly with its exact contents and nothing else. Do not use a message tool.'"
+                saveAs: inbound
+              - call: waitForOutboundMessage
+                saveAs: outbound
+                args:
+                  - ref: state
+                  - lambda:
+                      params: [candidate]
+                      expr: "candidate.direction === 'outbound' && candidate.accountId === transport.accountId && candidate.conversation.id === config.conversationId && candidate.text.trim() === finalMarker"
+                  - expr: "liveTurnTimeoutMs(env, 60000)"
+              - call: waitForCondition
+                args:
+                  - lambda:
+                      async: true
+                      params: []
+                      expr: "env.gateway.call('sessions.list', {}, { timeoutMs: 30000 }).then((result) => result.sessions?.find((session) => session.key === sessionKey && session.hasActiveRun === false))"
+                  - expr: "liveTurnTimeoutMs(env, 60000)"
+              - call: readSessionTranscriptSummary
+                saveAs: transcriptSummary
+                args: [{ ref: env }, { ref: sessionKey }]
+              - assert:
+                  expr: "Object.values(transcriptSummary.successfulToolCallCounts).some((count) => count > 0) && !transcriptSummary.successfulToolCallCounts.message && transcriptSummary.finalText.trim() === finalMarker"
+                  message: the agent must read the unknown fixture contents with a successful tool and return them through its final reply
+              - waitForOutboundSequence:
+                  conversationId: { ref: config.conversationId }
+                  sinceCursor: { ref: sinceCursor }
+                  finalTextIncludes: { ref: finalMarker }
+                  minimumPreviewEvents: 1
+                  timeoutMs: { expr: "liveTurnTimeoutMs(env, 60000)" }
+                saveAs: sequence
+              - assert:
+                  expr: "sequence.final.text.trim() === finalMarker"
+                  message: the native final must still contain only the fixture contents after the turn settles
+              - set: finalEvent
+                value:
+                  expr: "sequence.events.find((event) => event.kind !== 'deleted' && event.message.id === sequence.final.id && event.message.text.trim() === finalMarker)"
+              - set: labelEvent
+                value:
+                  expr: "sequence.events.find((event) => event.kind !== 'deleted' && event.cursor < finalEvent.cursor && event.message.replyToId === inbound.id && event.message.text.split('\\n')[0] === config.expectedLabel)"
+              - assert:
+                  expr: "Boolean(labelEvent)"
+                  message:
+                    expr: "'Expected native label replying to this ingress before final: ' + JSON.stringify({ inboundBusMessageId: inbound.id, expected: config.expectedLabel, events: sequence.events.map((event) => ({ cursor: event.cursor, kind: event.kind, replyToId: event.message.replyToId, text: event.message.text })) })"
+              - assert:
+                  expr: "Array.from(labelEvent.message.text.split('\\n')[0]).length === 120 && labelEvent.message.text.split('\\n')[0].length === config.expectedUtf16Units"
+                  message: the visible label must respect its code-point cap without treating astral UTF-16 units as separate characters
+            finally:
+              - call: fs.rm
+                args: [{ ref: fixturePath }, { force: true }]
+              - call: fs.writeFile
+                args:
+                  - expr: "path.join(env.outputDir, scenario.id + '-native-timeline.json')"
+                  - expr: "JSON.stringify({ scenarioId: scenario.id, observer: 'Telegram Test Server TDLib message/edit bus', replyToMode: 'first', inboundBusMessageId: typeof inbound === 'undefined' ? null : inbound.id, expectedLabel: config.expectedLabel, expectedFinal: finalMarker, draftDeletionObserved: null, events: state.getSnapshot().events.filter((event) => event.cursor > sinceCursor && ['outbound-message', 'message-edited'].includes(event.kind) && event.message.accountId === transport.accountId && event.message.conversation.id === config.conversationId).map((event) => ({ cursor: event.cursor, kind: event.kind, busMessageId: event.message.id, replyToId: event.message.replyToId ?? null, timestamp: event.message.timestamp, text: event.message.text, firstLineCodePoints: Array.from(event.message.text.split('\\n')[0]).length, firstLineUtf16Units: event.message.text.split('\\n')[0].length })) }, null, 2) + '\\n'"
+                  - utf8
+      detailsExpr: "JSON.stringify({ nativeObserver: 'Telegram TDLib', replyToMode: 'first', inboundBusMessageId: inbound.id, progressBusMessageId: labelEvent.message.id, progressReplyToId: labelEvent.message.replyToId, label: labelEvent.message.text.split('\\n')[0], codePoints: 120, utf16Units: config.expectedUtf16Units, final: sequence.final.text, successfulToolCallCounts: transcriptSummary.successfulToolCallCounts, turnSettled: true, deletion: 'not exposed by the QA adapter' })"

--- a/qa/scenarios/channels/telegram-progress-complete-word-label.yaml
+++ b/qa/scenarios/channels/telegram-progress-complete-word-label.yaml
@@ -1,0 +1,139 @@
+title: Telegram complete-word progress label
+
+scenario:
+  id: telegram-progress-complete-word-label
+  surface: channels
+  coverage:
+    primary:
+      - telegram.conversation-routing-and-delivery
+    secondary:
+      - agent-runtime.streaming-replies-delivery
+  objective: Preserve complete words and Unicode code points in Telegram progress labels bound to the current ingress under first-reply routing.
+  gatewayConfigPatch:
+    channels:
+      telegram:
+        accounts:
+          $selectedAccount:
+            replyToMode: first
+            streaming:
+              mode: progress
+              progress:
+                label: "review review review review review review review review review review review review review review review important.json next"
+  successCriteria:
+    - A native Telegram progress message or edit replies to this ingress and contains the exact expected 120-code-point label before the final answer.
+    - A successful tool reads an unpredictable value from the owned workspace and the ordinary final reply delivers that value.
+    - The turn settles; draft deletion is outside the current QA adapter observation contract.
+  regressionRefs:
+    - openclaw/openclaw#135277
+  docsRefs:
+    - docs/channels/telegram.md
+    - docs/concepts/streaming.md
+  codeRefs:
+    - src/shared/text-truncate.ts
+    - src/channels/streaming.ts
+    - extensions/telegram/src/bot-message-dispatch-progress.ts
+    - extensions/telegram/src/progress-draft-preview.ts
+  execution:
+    kind: flow
+    channel: telegram
+    providerMode: live-frontier
+    retryCount: 0
+    suiteIsolation: isolated
+    isolationReason: Each case needs its own progress label, first-reply routing, workspace, and Telegram session.
+    config:
+      conversationId: "telegram-progress-complete-word-label"
+      expectedLabel: "review review review review review review review review review review review review review review review important.json…"
+      expectedUtf16Units: 120
+flow:
+  steps:
+    - name: shows the bounded label before the tool-backed final
+      actions:
+        - assert:
+            expr: "env.providerMode === 'live-frontier' && transport.id === 'telegram'"
+            message: this scenario requires the live Telegram Test Server adapter and provider
+        - resetTransport: true
+        - set: sinceCursor
+          value:
+            expr: "state.getSnapshot().events.at(-1)?.cursor ?? 0"
+        - set: finalMarker
+          value:
+            expr: "'QA-TELEGRAM-PROGRESS-' + randomUUID()"
+        - set: fixturePath
+          value:
+            expr: "path.join(env.gateway.workspaceDir, scenario.id + '.txt')"
+        - set: delivery
+          value:
+            expr: "transport.buildAgentDelivery({ target: 'group:' + config.conversationId })"
+        - set: sessionKey
+          value:
+            expr: "buildAgentSessionKey({ agentId: 'qa', channel: delivery.channel, accountId: transport.accountId, peer: { kind: 'group', id: delivery.replyTo }, dmScope: env.cfg.session?.dmScope, identityLinks: env.cfg.session?.identityLinks })"
+        - call: fs.writeFile
+          args:
+            - ref: fixturePath
+            - expr: "finalMarker + '\\n'"
+            - utf8
+        - try:
+            actions:
+              - sendInbound:
+                  conversation:
+                    id: { ref: config.conversationId }
+                    kind: group
+                    title: QA Progress Label
+                  senderId: "100001"
+                  senderName: QA Progress Operator
+                  text:
+                    expr: "'@openclaw Read the file ' + fixturePath + ' using a file or shell tool. Reply directly with its exact contents and nothing else. Do not use a message tool.'"
+                saveAs: inbound
+              - call: waitForOutboundMessage
+                saveAs: outbound
+                args:
+                  - ref: state
+                  - lambda:
+                      params: [candidate]
+                      expr: "candidate.direction === 'outbound' && candidate.accountId === transport.accountId && candidate.conversation.id === config.conversationId && candidate.text.trim() === finalMarker"
+                  - expr: "liveTurnTimeoutMs(env, 60000)"
+              - call: waitForCondition
+                args:
+                  - lambda:
+                      async: true
+                      params: []
+                      expr: "env.gateway.call('sessions.list', {}, { timeoutMs: 30000 }).then((result) => result.sessions?.find((session) => session.key === sessionKey && session.hasActiveRun === false))"
+                  - expr: "liveTurnTimeoutMs(env, 60000)"
+              - call: readSessionTranscriptSummary
+                saveAs: transcriptSummary
+                args: [{ ref: env }, { ref: sessionKey }]
+              - assert:
+                  expr: "Object.values(transcriptSummary.successfulToolCallCounts).some((count) => count > 0) && !transcriptSummary.successfulToolCallCounts.message && transcriptSummary.finalText.trim() === finalMarker"
+                  message: the agent must read the unknown fixture contents with a successful tool and return them through its final reply
+              - waitForOutboundSequence:
+                  conversationId: { ref: config.conversationId }
+                  sinceCursor: { ref: sinceCursor }
+                  finalTextIncludes: { ref: finalMarker }
+                  minimumPreviewEvents: 1
+                  timeoutMs: { expr: "liveTurnTimeoutMs(env, 60000)" }
+                saveAs: sequence
+              - assert:
+                  expr: "sequence.final.text.trim() === finalMarker"
+                  message: the native final must still contain only the fixture contents after the turn settles
+              - set: finalEvent
+                value:
+                  expr: "sequence.events.find((event) => event.kind !== 'deleted' && event.message.id === sequence.final.id && event.message.text.trim() === finalMarker)"
+              - set: labelEvent
+                value:
+                  expr: "sequence.events.find((event) => event.kind !== 'deleted' && event.cursor < finalEvent.cursor && event.message.replyToId === inbound.id && event.message.text.split('\\n')[0] === config.expectedLabel)"
+              - assert:
+                  expr: "Boolean(labelEvent)"
+                  message:
+                    expr: "'Expected native label replying to this ingress before final: ' + JSON.stringify({ inboundBusMessageId: inbound.id, expected: config.expectedLabel, events: sequence.events.map((event) => ({ cursor: event.cursor, kind: event.kind, replyToId: event.message.replyToId, text: event.message.text })) })"
+              - assert:
+                  expr: "Array.from(labelEvent.message.text.split('\\n')[0]).length === 120 && labelEvent.message.text.split('\\n')[0].length === config.expectedUtf16Units"
+                  message: the visible label must respect its code-point cap without treating astral UTF-16 units as separate characters
+            finally:
+              - call: fs.rm
+                args: [{ ref: fixturePath }, { force: true }]
+              - call: fs.writeFile
+                args:
+                  - expr: "path.join(env.outputDir, scenario.id + '-native-timeline.json')"
+                  - expr: "JSON.stringify({ scenarioId: scenario.id, observer: 'Telegram Test Server TDLib message/edit bus', replyToMode: 'first', inboundBusMessageId: typeof inbound === 'undefined' ? null : inbound.id, expectedLabel: config.expectedLabel, expectedFinal: finalMarker, draftDeletionObserved: null, events: state.getSnapshot().events.filter((event) => event.cursor > sinceCursor && ['outbound-message', 'message-edited'].includes(event.kind) && event.message.accountId === transport.accountId && event.message.conversation.id === config.conversationId).map((event) => ({ cursor: event.cursor, kind: event.kind, busMessageId: event.message.id, replyToId: event.message.replyToId ?? null, timestamp: event.message.timestamp, text: event.message.text, firstLineCodePoints: Array.from(event.message.text.split('\\n')[0]).length, firstLineUtf16Units: event.message.text.split('\\n')[0].length })) }, null, 2) + '\\n'"
+                  - utf8
+      detailsExpr: "JSON.stringify({ nativeObserver: 'Telegram TDLib', replyToMode: 'first', inboundBusMessageId: inbound.id, progressBusMessageId: labelEvent.message.id, progressReplyToId: labelEvent.message.replyToId, label: labelEvent.message.text.split('\\n')[0], codePoints: 120, utf16Units: config.expectedUtf16Units, final: sequence.final.text, successfulToolCallCounts: transcriptSummary.successfulToolCallCounts, turnSettled: true, deletion: 'not exposed by the QA adapter' })"

--- a/src/auto-reply/reply/progress-narrator-model.test.ts
+++ b/src/auto-reply/reply/progress-narrator-model.test.ts
@@ -64,3 +64,29 @@ describe("progress narration completion cancellation", () => {
     },
   );
 });
+
+describe("progress narration request context", () => {
+  it.each([
+    {
+      name: "retains the complete filename at the request limit",
+      userMessage: "review ".repeat(70) + "file.conf next",
+      expected: "review ".repeat(70) + "file.conf…",
+    },
+    {
+      name: "measures the word-backoff threshold in code points",
+      userMessage: "𠮷".repeat(160) + " " + "x".repeat(400),
+      expected: "𠮷".repeat(160) + " " + "x".repeat(338) + "…",
+    },
+  ])("$name", async ({ userMessage, expected }) => {
+    await generateNarrationWithUtilityModel({
+      cfg: {},
+      prepared,
+      input: { userMessage, activityNotes: [], previousText: "" },
+    });
+
+    expect(complete).toHaveBeenCalledOnce();
+    expect(complete.mock.calls[0]?.[0].context.messages[0].content).toContain(
+      `Request:\n${expected}\n\n`,
+    );
+  });
+});

--- a/src/auto-reply/reply/progress-narrator-model.ts
+++ b/src/auto-reply/reply/progress-narrator-model.ts
@@ -6,6 +6,7 @@ import {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import type { TextContent } from "../../llm/types.js";
+import { truncateCodePointsAtWordBoundary } from "../../shared/text-truncate.js";
 
 const NARRATION_TIMEOUT_MS = 10_000;
 const NOTES_IN_PROMPT = 15;
@@ -33,24 +34,8 @@ function isTextContentBlock(block: { type: string }): block is TextContent {
   return block.type === "text";
 }
 
-export function truncateAtWordBoundary(text: string, maxChars: number): string {
-  const chars = Array.from(text);
-  if (chars.length <= maxChars) {
-    return text;
-  }
-  const head = chars
-    .slice(0, maxChars - 1)
-    .join("")
-    .trimEnd();
-  const boundary = head.search(/\s+\S*$/u);
-  if (boundary > Math.floor(maxChars * 0.6)) {
-    return `${head.slice(0, boundary).trimEnd()}…`;
-  }
-  return `${head}…`;
-}
-
 function buildNarrationUserPrompt(input: ProgressNarrationInput): string {
-  const request = truncateAtWordBoundary(
+  const request = truncateCodePointsAtWordBoundary(
     input.userMessage.replace(/\s+/g, " ").trim(),
     USER_MESSAGE_PROMPT_CHARS,
   );

--- a/src/auto-reply/reply/progress-narrator.ts
+++ b/src/auto-reply/reply/progress-narrator.ts
@@ -13,12 +13,12 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import type { AgentEventPayload, AgentEventStream } from "../../infra/agent-events.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { truncateCodePointsAtWordBoundary } from "../../shared/text-truncate.js";
 import type { InternalGetReplyOptions } from "./get-reply.types.js";
 import {
   generateNarrationWithUtilityModel,
   prepareNarrationModel,
   type ProgressNarrationInput,
-  truncateAtWordBoundary,
 } from "./progress-narrator-model.js";
 
 const narratorLog = createSubsystemLogger("auto-reply/progress-narrator");
@@ -46,7 +46,7 @@ function normalizeNarrationText(raw: string): string {
   if (!collapsed) {
     return "";
   }
-  return truncateAtWordBoundary(collapsed, NARRATION_MAX_CHARS);
+  return truncateCodePointsAtWordBoundary(collapsed, NARRATION_MAX_CHARS);
 }
 
 function createProgressNarrator(params: {

--- a/src/channels/progress-draft-compositor.reasoning.test.ts
+++ b/src/channels/progress-draft-compositor.reasoning.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { createChannelProgressDraftCompositor } from "./progress-draft-compositor.js";
+
+describe("progress draft reasoning truncation", () => {
+  it.each([
+    {
+      name: "retains a complete filename in the reasoning body",
+      input: "review ".repeat(15) + "important.json next",
+      expected: "review ".repeat(15) + "important.json…",
+    },
+    {
+      name: "uses code-point positions for reasoning word backoff",
+      input: "𠮷".repeat(40) + " " + "x".repeat(100),
+      expected: "𠮷".repeat(40) + " " + "x".repeat(78) + "…",
+    },
+  ])("$name", async ({ input, expected }) => {
+    const update = vi.fn();
+    const progress = createChannelProgressDraftCompositor({
+      mode: "progress",
+      active: true,
+      seed: "test",
+      entry: {
+        streaming: { mode: "progress", progress: { label: false, maxLineChars: 122 } },
+      },
+      update,
+    });
+    try {
+      await progress.start();
+      await progress.pushReasoningProgress(input, { snapshot: true });
+
+      expect(update.mock.lastCall?.[0]).toBe(`• _${expected}_`);
+    } finally {
+      progress.cancel();
+    }
+  });
+});

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -23,6 +23,35 @@ function createTestProgressDraftCompositor(
 const DEFAULT_PROGRESS_DRAFT_INITIAL_DELAY_MS = 1_500;
 
 describe("createChannelProgressDraftCompositor", () => {
+  it.each([
+    {
+      name: "retains a complete filename in the reasoning body",
+      input: "review ".repeat(15) + "important.json next",
+      expected: "review ".repeat(15) + "important.json…",
+    },
+    {
+      name: "uses code-point positions for reasoning word backoff",
+      input: "𠮷".repeat(40) + " " + "x".repeat(100),
+      expected: "𠮷".repeat(40) + " " + "x".repeat(78) + "…",
+    },
+  ])("$name", async ({ input, expected }) => {
+    const update = vi.fn();
+    const progress = createTestProgressDraftCompositor({
+      entry: {
+        streaming: { mode: "progress", progress: { label: false, maxLineChars: 122 } },
+      },
+      update,
+    });
+    try {
+      await progress.start();
+      await progress.pushReasoningProgress(input, { snapshot: true });
+
+      expect(update.mock.lastCall?.[0]).toBe(`• _${expected}_`);
+    } finally {
+      progress.cancel();
+    }
+  });
+
   it("keeps summary presentation stable across tool activity and uses plain milestones", async () => {
     const update = vi.fn();
     const progress = createTestProgressDraftCompositor({

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -23,35 +23,6 @@ function createTestProgressDraftCompositor(
 const DEFAULT_PROGRESS_DRAFT_INITIAL_DELAY_MS = 1_500;
 
 describe("createChannelProgressDraftCompositor", () => {
-  it.each([
-    {
-      name: "retains a complete filename in the reasoning body",
-      input: "review ".repeat(15) + "important.json next",
-      expected: "review ".repeat(15) + "important.json…",
-    },
-    {
-      name: "uses code-point positions for reasoning word backoff",
-      input: "𠮷".repeat(40) + " " + "x".repeat(100),
-      expected: "𠮷".repeat(40) + " " + "x".repeat(78) + "…",
-    },
-  ])("$name", async ({ input, expected }) => {
-    const update = vi.fn();
-    const progress = createTestProgressDraftCompositor({
-      entry: {
-        streaming: { mode: "progress", progress: { label: false, maxLineChars: 122 } },
-      },
-      update,
-    });
-    try {
-      await progress.start();
-      await progress.pushReasoningProgress(input, { snapshot: true });
-
-      expect(update.mock.lastCall?.[0]).toBe(`• _${expected}_`);
-    } finally {
-      progress.cancel();
-    }
-  });
-
   it("keeps summary presentation stable across tool activity and uses plain milestones", async () => {
     const update = vi.fn();
     const progress = createTestProgressDraftCompositor({

--- a/src/channels/progress-draft-status-text.ts
+++ b/src/channels/progress-draft-status-text.ts
@@ -1,5 +1,6 @@
 // Progress-draft status text normalization for reasoning, preamble, and commentary lanes.
 import { formatReasoningMessage } from "../agents/embedded-agent-utils.js";
+import { truncateCodePointsAtWordBoundary } from "../shared/text-truncate.js";
 import { findCodeRegions, isInsideCode } from "../shared/text/code-regions.js";
 import { stripInlineDirectiveTagsForDelivery } from "../utils/directive-tags.js";
 
@@ -120,23 +121,7 @@ export function formatReasoningProgressDisplayLine(text: string, maxChars: numbe
 }
 
 function compactReasoningProgressDisplayLine(text: string, maxChars: number): string {
-  const normalized = text.replace(/\s+/g, " ").trim();
-  const chars = Array.from(normalized);
-  if (chars.length <= maxChars) {
-    return normalized;
-  }
-  if (maxChars <= 1) {
-    return "…";
-  }
-  const head = chars
-    .slice(0, maxChars - 1)
-    .join("")
-    .trimEnd();
-  const boundary = head.search(/\s+\S*$/u);
-  if (boundary > Math.floor(maxChars * 0.6)) {
-    return `${head.slice(0, boundary).trimEnd()}…`;
-  }
-  return `${head}…`;
+  return truncateCodePointsAtWordBoundary(text.replace(/\s+/g, " ").trim(), maxChars);
 }
 
 export function sanitizeProgressStatusText(text: string): string {

--- a/src/channels/streaming.test.ts
+++ b/src/channels/streaming.test.ts
@@ -339,6 +339,56 @@ describe("streaming config resolution", () => {
 });
 
 describe("progress narration", () => {
+  it.each([
+    {
+      name: "retains a complete filename at the line limit",
+      line: "review ".repeat(15) + "important.json next",
+      expected: "review ".repeat(15) + "important.json…",
+    },
+    {
+      name: "measures the word-backoff threshold in code points",
+      line: "𠮷".repeat(40) + " " + "x".repeat(100),
+      expected: "𠮷".repeat(40) + " " + "x".repeat(78) + "…",
+    },
+    {
+      name: "keeps a hard cut at the exact backoff threshold",
+      line: "a".repeat(72) + " " + "x".repeat(70),
+      expected: "a".repeat(72) + " " + "x".repeat(46) + "…",
+    },
+    {
+      name: "backs off beyond the threshold",
+      line: "a".repeat(73) + " " + "x".repeat(70),
+      expected: "a".repeat(73) + "…",
+    },
+    {
+      name: "hard-cuts CJK text without whitespace",
+      line: "界".repeat(130),
+      expected: "界".repeat(119) + "…",
+    },
+    {
+      name: "hard-cuts an unbroken ASCII word",
+      line: "x".repeat(130),
+      expected: "x".repeat(119) + "…",
+    },
+    {
+      name: "continues to count combining marks as code points",
+      line: "e\u0301".repeat(70),
+      expected: "e\u0301".repeat(59) + "e…",
+    },
+    {
+      name: "keeps short text unchanged",
+      line: "Keep café and 𠮷.",
+      expected: "Keep café and 𠮷.",
+    },
+  ])("$name", ({ line, expected }) => {
+    expect(
+      formatChannelProgressDraftText({
+        entry: { streaming: { mode: "progress", progress: { label: false } } },
+        lines: [line],
+      }),
+    ).toBe(`• ${expected}`);
+  });
+
   it("renders plan markers and keeps the checklist under narration", () => {
     const plan = [
       { step: "Inspect", status: "completed" as const },
@@ -465,17 +515,25 @@ describe("progress narration", () => {
     expect(text).toBe("Counting lines in the workspace files.");
   });
 
-  it("compacts narration at a word boundary instead of line width", () => {
-    const narration = Array.from({ length: 60 }, (_value, index) => `word${index}`).join(" ");
-    const text = formatChannelProgressDraftText({
-      entry: { streaming: { mode: "progress", progress: { label: false } } },
-      lines: [],
-      narration,
-    });
-
-    expect(text.endsWith("…")).toBe(true);
-    expect(Array.from(text).length).toBeLessThanOrEqual(280);
-    expect(text).not.toContain("\n");
+  it.each([
+    {
+      name: "retains the complete filename at the narration limit",
+      narration: "review ".repeat(38) + "manifest.json next",
+      expected: "review ".repeat(38) + "manifest.json…",
+    },
+    {
+      name: "uses code-point positions for narration word backoff",
+      narration: "𠮷".repeat(90) + " " + "x".repeat(300),
+      expected: "𠮷".repeat(90) + " " + "x".repeat(188) + "…",
+    },
+  ])("$name", ({ narration, expected }) => {
+    expect(
+      formatChannelProgressDraftText({
+        entry: { streaming: { mode: "progress", progress: { label: false } } },
+        lines: [],
+        narration,
+      }),
+    ).toBe(expected);
   });
 
   it("honors the caller's mode when resolving commentary", () => {

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -19,6 +19,7 @@ import type {
   TextChunkMode,
 } from "../config/types.base.js";
 import { DEFAULT_PROGRESS_DRAFT_LABELS, selectProgressLabel } from "../shared/progress-labels.js";
+import { truncateCodePointsAtWordBoundary } from "../shared/text-truncate.js";
 import { asBoolean } from "../utils/boolean.js";
 import {
   getChannelStreamingConfigObject,
@@ -969,10 +970,6 @@ export function resolveChannelProgressDraftMaxLineChars(
   return configured && configured > 0 ? configured : defaultValue;
 }
 
-function sliceCodePoints(value: string, start: number, end?: number): string {
-  return Array.from(value).slice(start, end).join("");
-}
-
 function compactProgressLineDetail(detail: string, maxChars: number): string {
   const chars = Array.from(detail);
   if (chars.length <= maxChars) {
@@ -1015,20 +1012,10 @@ function repairCompactedProgressMarkdown(value: string): string {
 }
 
 function compactChannelProgressDraftNarration(text: string): string {
-  const normalized = text.replace(/\s+/g, " ").trim();
-  if (Array.from(normalized).length <= PROGRESS_DRAFT_NARRATION_MAX_CHARS) {
-    return normalized;
-  }
-  return compactPlainProgressLine(normalized, PROGRESS_DRAFT_NARRATION_MAX_CHARS);
-}
-
-function compactPlainProgressLine(line: string, maxChars: number): string {
-  const head = sliceCodePoints(line, 0, maxChars - 1).trimEnd();
-  const boundary = head.search(/\s+\S*$/u);
-  if (boundary > Math.floor(maxChars * 0.6)) {
-    return `${head.slice(0, boundary).trimEnd()}…`;
-  }
-  return `${head}…`;
+  return truncateCodePointsAtWordBoundary(
+    text.replace(/\s+/g, " ").trim(),
+    PROGRESS_DRAFT_NARRATION_MAX_CHARS,
+  );
 }
 
 function compactChannelProgressDraftLine(line: string, maxChars: number): string {
@@ -1075,7 +1062,7 @@ function compactChannelProgressDraftLine(line: string, maxChars: number): string
     }
   }
 
-  return repairCompactedProgressMarkdown(compactPlainProgressLine(normalized, maxChars));
+  return repairCompactedProgressMarkdown(truncateCodePointsAtWordBoundary(normalized, maxChars));
 }
 
 export function formatPlanChecklistLines(

--- a/src/shared/text-truncate.ts
+++ b/src/shared/text-truncate.ts
@@ -9,3 +9,18 @@ export function truncateUtf16WithEllipsis(value: string, maxLength: number): str
   }
   return truncateWithMarker(value, maxLength, { marker: "…", reserve: 1, trimEnd: false });
 }
+
+export function truncateCodePointsAtWordBoundary(text: string, maxChars: number): string {
+  const chars = Array.from(text);
+  if (chars.length <= maxChars) {
+    return text;
+  }
+  if (maxChars <= 1) {
+    return "…";
+  }
+  // Include the first omitted code point so a complete final word is retained.
+  // Keep the whitespace position in code points, matching maxChars.
+  const boundary = chars.slice(0, maxChars).findLastIndex((char) => /\s/u.test(char));
+  const end = boundary > Math.floor(maxChars * 0.6) ? boundary : maxChars - 1;
+  return `${chars.slice(0, end).join("").trimEnd()}…`;
+}

--- a/test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts
@@ -285,10 +285,11 @@ function progressConfig(
   config: OpenClawConfig,
   channel: "discord" | "slack",
   native: boolean,
+  label: string,
 ): OpenClawConfig {
   const streaming = {
     mode: "progress" as const,
-    progress: { label: HEADLINE },
+    progress: { label },
   };
   return {
     ...config,
@@ -366,12 +367,44 @@ describe("channel progress presentation through an isolated Gateway", () => {
   });
 
   it.each([
-    { channel: "discord" as const, native: false },
-    { channel: "slack" as const, native: true },
-    { channel: "slack" as const, native: false },
+    {
+      channel: "discord" as const,
+      native: false,
+      labelCase: "short",
+      label: HEADLINE,
+      expectedLabel: HEADLINE,
+    },
+    {
+      channel: "slack" as const,
+      native: true,
+      labelCase: "short",
+      label: HEADLINE,
+      expectedLabel: HEADLINE,
+    },
+    {
+      channel: "slack" as const,
+      native: false,
+      labelCase: "short",
+      label: HEADLINE,
+      expectedLabel: HEADLINE,
+    },
+    {
+      channel: "discord" as const,
+      native: false,
+      labelCase: "complete-word",
+      label: "review ".repeat(15) + "important.json next",
+      expectedLabel: "review ".repeat(15) + "important.json…",
+    },
+    {
+      channel: "discord" as const,
+      native: false,
+      labelCase: "astral",
+      label: "𠮷".repeat(40) + " " + "x".repeat(100),
+      expectedLabel: "𠮷".repeat(40) + " " + "x".repeat(78) + "…",
+    },
   ])(
-    "keeps $channel progress quiet (native=$native)",
-    async ({ channel, native }) => {
+    "keeps $channel progress quiet (native=$native, label=$labelCase)",
+    async ({ channel, native, labelCase, label, expectedLabel }) => {
       const directory = await fs.mkdtemp(
         path.join(await fs.realpath(os.tmpdir()), "channel-progress-"),
       );
@@ -409,7 +442,7 @@ describe("channel progress presentation through an isolated Gateway", () => {
         },
         runtimeEnvPatch: environment,
         mutateConfig: (config) => {
-          const configured = progressConfig(config, channel, native);
+          const configured = progressConfig(config, channel, native, label);
           if (channel === "discord") {
             configured.channels!.discord!.proxy = api.proxyUrl;
           }
@@ -503,7 +536,6 @@ describe("channel progress presentation through an isolated Gateway", () => {
                 .join("\n"),
         )
         .join("\n");
-      expect(progressText).toContain(HEADLINE);
       expect(progressText).not.toMatch(synthesizedDecoration);
       const reactionAdds = writes.filter((write) =>
         channel === "discord"
@@ -519,9 +551,12 @@ describe("channel progress presentation through an isolated Gateway", () => {
       );
       expect([...reactionNames]).toEqual([channel === "discord" ? "👀" : "eyes"]);
       const evidenceDir = path.join(process.cwd(), ".artifacts", "channel-progress-presentation");
+      const artifactName =
+        `${channel}-${native ? "native" : "draft"}` +
+        (labelCase === "short" ? "" : `-${labelCase}`);
       await fs.mkdir(evidenceDir, { recursive: true });
       await fs.writeFile(
-        path.join(evidenceDir, `${channel}-${native ? "native" : "draft"}-diagnostic.json`),
+        path.join(evidenceDir, `${artifactName}-diagnostic.json`),
         JSON.stringify(
           {
             writes: writes.slice(-80).map(({ at, method, route, body, accepted }) => ({
@@ -552,6 +587,7 @@ describe("channel progress presentation through an isolated Gateway", () => {
           2,
         ),
       );
+      expect(progressText).toContain(expectedLabel);
       expect(finalWrites()).toHaveLength(1);
       expect(finalMessages()).toHaveLength(1);
       const tasks = writes
@@ -563,12 +599,14 @@ describe("channel progress presentation through an isolated Gateway", () => {
         expect(tasks.at(-1)?.status).toBe("complete");
       }
       await fs.writeFile(
-        path.join(evidenceDir, `${channel}-${native ? "native" : "draft"}.json`),
+        path.join(evidenceDir, `${artifactName}.json`),
         JSON.stringify(
           {
             kind: "mock-gateway",
             channel,
             native,
+            labelCase,
+            expectedLabel,
             status: "pass",
             progressWrites: progressWrites.length,
             finalWrites: finalWrites().length,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where progress narration, reasoning drafts, and custom draft labels dropped a complete final word even when it fit the configured limit. Text containing astral Unicode characters could be shortened much more than necessary: a 120-code-point draft became only 41 code points.

## Why This Change Was Made

Three truncation paths mixed code-point limits with UTF-16 whitespace offsets and searched only the already-cut prefix. One shared word-boundary helper now includes the first omitted code point when deciding whether the last word fits. Narration requests, summaries, draft lines, and reasoning all use that owner; the duplicate implementations and slicing wrapper are removed.

Production is **+27/−55, net −28**. Tests are +518/−22; documentation is net neutral. The existing 500/280/120 budgets, reasoning-marker allowance, and middle truncation for paths and commands are unchanged. This counts Unicode code points, not grapheme clusters, and adds no configuration or dependency.

## User Impact

Progress text retains useful filenames and uses the available character budget consistently. For example, a 120-code-point label now retains `important.json` instead of dropping the entire filename. Documentation names the existing code-point unit explicitly.

## Evidence

The original source produced nine failures across the owner suites, two failures through real loopback Discord REST requests, and two failures through the maintained Gateway/Discord fixture. The repaired source passes **158 owner/REST tests plus both Gateway cases**. The Gateway command also completed its normal runtime build and prerequisites. Three unrelated short-label cases were filtered, not counted as passing.

```sh
pnpm test:e2e:gateway test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts -t "label='(complete-word|astral)'"
```

Both Gateway scenarios use the real isolated Gateway and Discord plugin with a mock provider and channel API. Accepted progress payloads changed from 105→120 and 41→120 code points; each flow delivered exactly one final reply and deleted the progress draft. This is mock-Gateway evidence, not a live Discord account test.

```json
{"kind":"mock-gateway","channel":"discord","cases":2,"status":"pass","progressPostsPerCase":1,"finalRepliesPerCase":1,"draftDeletedPerCase":true}
```

Focused coverage includes narration request context, reasoning, shared draft composition, complete-word boundaries, astral text, CJK, combining marks, and unchanged short text. Formatting, scoped diff checks, and independent Codex review passed. An initial Gateway filter selected zero cases; that attempt is excluded from the proof above, which uses the corrected command and actual executed cases.

CI exposed the compositor test file’s size limit. The two new reasoning cases now live in a focused companion file, preserving their inputs, assertions, canonical constructor defaults, and cancellation cleanup. The original compositor test file is restored to its baseline; all 49 cases across both files pass, as do core lint, formatting, and independent Codex review. Production code is unchanged. [The preceding CI run](https://github.com/openclaw/openclaw/actions/runs/33522251628) also failed a compact test group whose cause remains unproved; no timeout or assertion was relaxed, and the updated head must pass the required CI gate.

## Telegram regression coverage

Two isolated Telegram Test Server scenarios exercise complete-word and astral progress labels through a tool-backed agent turn. Each requires the exact progress label to reply to the current inbound message before the unique final response, then verifies the completed transcript and settled session. These scenarios observe native messages and edits; they do not claim draft-deletion coverage or default reply-routing behavior. The two files add 278 test lines and no production code.

Independent Codex review completed two passes with no actionable findings. Native review verification confirmed unchanged source and staged entries. The additional local wrapper check rejected a changed raw Git index checksum; that wrapper result is retained separately from the completed source review.

Local catalog/profile validation is **not green**: seven assertions passed (56 filtered), but the normal command did not finish before its 300-second deadline. A separate diagnostic through the canonical child runner passed five profile assertions before the normal 120-second watchdog fired; it produced no complete report. Neither attempt is counted as successful validation, and no timeout, assertion, or runtime policy was relaxed.

The new Telegram scenarios have not run yet. Landing still requires completed exact-head CI, successful catalog-owner validation, and both native Telegram scenarios.

### Exact-head CI and native Telegram result

[CI run 33577213062](https://github.com/openclaw/openclaw/actions/runs/33577213062) passed for head `c655af0758109c5ed1ce8db49fd33d2f310e5544`. Its normal PR merge checkout `f52b528babffc96dc550b3a12dcfb9110e0de0bd` combines that head with `3699b5006e91fbbed2900f7524f97aad8579eaad`. [QA shard 3/3](https://github.com/openclaw/openclaw/actions/runs/33577213062/job/100083900523) explicitly passed the two targeted catalog cases and all five profile-selection cases; the complete shard finished with 77 files and 733 tests passing. All six QA smoke profiles also passed. This completes catalog-owner validation; the earlier incomplete local attempts remain recorded above.

The [native Telegram run](https://github.com/openclaw/openclaw/actions/runs/33577357161/job/100084952074) selected the same `c655af0758109c5ed1ce8db49fd33d2f310e5544` candidate, as recorded in both scenario evidence entries. Both scenarios stopped at the first real-user send with `sendMessage failed (400): Have no write access to the chat`. Their native timelines contain no inbound message and no events, so this is not label-rendering or finalization proof. The shared adapter sends to the leased native group; logical scenario IDs do not choose a different Telegram chat. No retry, altered assertion, or configuration fallback has been used to hide the failure.

The remaining landing gate is successful native Telegram ingress, progress-label, reply-binding, and finalization evidence. The failed artifact is retained while the QA-user group-access prerequisite is investigated. No changes to the shared credential pool or its membership have been made.
