### PR TITLE
refactor(cron): centralize default agent resolution

### DIFF
--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -45,17 +45,18 @@ import {
   registerPendingCronSessionCleanup,
 } from "./locked.js";
 import { normalizeOptionalAgentId } from "./normalize.js";
-import { resolveCurrentDefaultAgentId, resolveEffectiveJobAgentId } from "./ops-shared.js";
+import { resolveEffectiveJobAgentId } from "./ops-shared.js";
 import { cronRunReceiptOwnerMutationHooks } from "./run-receipts.js";
-import type {
-  CronAddResult,
-  CronAddOptions,
-  CronServiceState,
-  CronUpdateOptions,
-  CronUpdatePrecondition,
-  DeferredCronNotifications,
+import {
+  emit,
+  resolveCronServiceDefaultAgentId,
+  type CronAddResult,
+  type CronAddOptions,
+  type CronServiceState,
+  type CronUpdateOptions,
+  type CronUpdatePrecondition,
+  type DeferredCronNotifications,
 } from "./state.js";
-import { emit } from "./state.js";
 import {
   ensureLoaded,
   persist,
@@ -223,7 +224,7 @@ async function persistUpdatedJob(params: {
     }
   }
 
-  const defaultAgentId = resolveCurrentDefaultAgentId(state);
+  const defaultAgentId = resolveCronServiceDefaultAgentId(state);
   const ownerChanged =
     resolveEffectiveJobAgentId(previousJob, defaultAgentId) !==
     resolveEffectiveJobAgentId(nextJob, defaultAgentId);
@@ -313,7 +314,7 @@ export async function add(
       );
     }
     await ensureLoaded(state, { skipRecompute: true });
-    const agentId = resolveEffectiveJobAgentId(input, resolveCurrentDefaultAgentId(state));
+    const agentId = resolveEffectiveJobAgentId(input, resolveCronServiceDefaultAgentId(state));
     if (state.deps.isAgentAvailable?.(agentId) === false) {
       throw new Error(`cron job agent is unavailable: ${agentId}`);
     }
@@ -505,7 +506,7 @@ async function updateLoadedJob(params: {
     configuredChannels,
   });
   if (patch.agentId !== undefined) {
-    const agentId = resolveEffectiveJobAgentId(nextJob, resolveCurrentDefaultAgentId(state));
+    const agentId = resolveEffectiveJobAgentId(nextJob, resolveCronServiceDefaultAgentId(state));
     if (state.deps.isAgentAvailable?.(agentId) === false) {
       throw new Error(`cron job agent is unavailable: ${agentId}`);
     }
@@ -608,7 +609,7 @@ export async function remove(
       suppressScheduledJobId: id,
     });
     const activeMarker = noteActiveCronJobRemoval(id);
-    const agentId = resolveEffectiveJobAgentId(removedJob, resolveCurrentDefaultAgentId(state));
+    const agentId = resolveEffectiveJobAgentId(removedJob, resolveCronServiceDefaultAgentId(state));
     const sessionStorePath =
       state.deps.resolveSessionStorePath?.(agentId) ?? state.deps.sessionStorePath;
     if (
@@ -679,7 +680,7 @@ export async function removeAgentJobsTransactional<T>(
     if (!id || !state.store) {
       return await commit();
     }
-    const defaultAgentId = resolveCurrentDefaultAgentId(state);
+    const defaultAgentId = resolveCronServiceDefaultAgentId(state);
     const removedJobs = state.store.jobs.filter(
       (job) => resolveEffectiveJobAgentId(job, defaultAgentId) === id,
     );

--- a/src/cron/service/ops-read.ts
+++ b/src/cron/service/ops-read.ts
@@ -24,14 +24,13 @@ import type {
 import { locked } from "./locked.js";
 import { normalizeOptionalAgentId } from "./normalize.js";
 import { emitCronRunFinished } from "./ops-run-preparation.js";
-import {
-  ensureLoadedForRead,
-  ownsStreamSource,
-  resolveCurrentDefaultAgentId,
-  resolveEffectiveJobAgentId,
-} from "./ops-shared.js";
+import { ensureLoadedForRead, ownsStreamSource, resolveEffectiveJobAgentId } from "./ops-shared.js";
 import { applyCronRuntimeRowsToState, commitCronRuntimeRows } from "./runtime-store.js";
-import type { CronServiceState, DeferredCronNotifications } from "./state.js";
+import {
+  resolveCronServiceDefaultAgentId,
+  type CronServiceState,
+  type DeferredCronNotifications,
+} from "./state.js";
 import { ensureLoaded, runPostPersistCronNotifications } from "./store.js";
 import { applyJobResult, armTimer } from "./timer.js";
 
@@ -341,7 +340,8 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
       }
       if (
         requestedAgentId &&
-        resolveEffectiveJobAgentId(job, resolveCurrentDefaultAgentId(state)) !== requestedAgentId
+        resolveEffectiveJobAgentId(job, resolveCronServiceDefaultAgentId(state)) !==
+          requestedAgentId
       ) {
         return false;
       }

--- a/src/cron/service/ops-shared.ts
+++ b/src/cron/service/ops-shared.ts
@@ -69,11 +69,6 @@ export async function ensureLoadedForRead(state: CronServiceState) {
   applyCronRuntimeRowsToState(state, maintenance.jobs);
 }
 
-/** Resolves the current configured default agent without caching reloadable state. */
-export function resolveCurrentDefaultAgentId(state: CronServiceState): string | undefined {
-  return state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId;
-}
-
 /** Returns whether a stream event still belongs to the job's current logical source. */
 export function ownsStreamSource(
   job: CronJob,

--- a/src/cron/service/run-receipts.ts
+++ b/src/cron/service/run-receipts.ts
@@ -20,16 +20,12 @@ import {
 } from "../store/run-receipt-store.js";
 import type { CronStoreTransactionHooks } from "../store/transaction-hooks.js";
 import type { CronJob, CronRunStatus } from "../types.js";
-import type { CronServiceState } from "./state.js";
+import { resolveCronServiceDefaultAgentId, type CronServiceState } from "./state.js";
 
 export type CronRunReceiptSettlementDisposition = "owner-unavailable";
 
-function currentDefaultAgentId(state: CronServiceState): string | undefined {
-  return state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId;
-}
-
 function resolveCronRunReceiptAgentId(state: CronServiceState, job: CronJob): string {
-  return resolveCronJobEffectiveAgentId(job, currentDefaultAgentId(state));
+  return resolveCronJobEffectiveAgentId(job, resolveCronServiceDefaultAgentId(state));
 }
 
 function resolveAgentId(state: CronServiceState) {

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -365,6 +365,11 @@ export type CronServiceState = {
   storeLoadedAtMs: number | null;
 };
 
+/** Resolves the current configured default agent without caching reloadable state. */
+export function resolveCronServiceDefaultAgentId(state: CronServiceState) {
+  return state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId;
+}
+
 /** Creates mutable cron service state with a concrete clock dependency. */
 export function createCronServiceState(deps: CronServiceDeps): CronServiceState {
   // The public CronService constructor shipped before roster-aware callers.

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -49,7 +49,12 @@ import type {
   CronRunStatus,
 } from "../types.js";
 import { normalizeCronRunErrorText } from "./execution-errors.js";
-import type { CronEvent, CronExecutionIdentityAdmission, CronServiceState } from "./state.js";
+import {
+  resolveCronServiceDefaultAgentId,
+  type CronEvent,
+  type CronExecutionIdentityAdmission,
+  type CronServiceState,
+} from "./state.js";
 import { CRON_TASK_RUNNING_PROGRESS_SUMMARY } from "./task-ledger.js";
 
 function requireCronAgentId(agentId: string | undefined): string {
@@ -57,10 +62,6 @@ function requireCronAgentId(agentId: string | undefined): string {
     throw new Error(CRON_AGENT_SELECTION_REQUIRED_MESSAGE);
   }
   return normalizeAgentId(agentId);
-}
-
-function resolveCurrentDefaultAgentId(state: CronServiceState): string | undefined {
-  return state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId;
 }
 
 /** Carries exact admission into the first post-admission owner lifecycle phase. */
@@ -291,7 +292,7 @@ function tryCreateCronTaskRunRecord(params: {
   try {
     const childSessionKey = params.childSessionKey;
     const effectiveJobAgentId = params.job
-      ? resolveCronJobEffectiveAgentId(params.job, resolveCurrentDefaultAgentId(params.state))
+      ? resolveCronJobEffectiveAgentId(params.job, resolveCronServiceDefaultAgentId(params.state))
       : undefined;
     const task = createRunningTaskRunCore({
       runtime: "cron",
@@ -305,9 +306,9 @@ function tryCreateCronTaskRunRecord(params: {
         (childSessionKey
           ? resolveAgentIdFromSessionKey(
               childSessionKey,
-              resolveCurrentDefaultAgentId(params.state),
+              resolveCronServiceDefaultAgentId(params.state),
             )
-          : requireCronAgentId(resolveCurrentDefaultAgentId(params.state))),
+          : requireCronAgentId(resolveCronServiceDefaultAgentId(params.state))),
       runId: params.runId,
       label: params.job?.name,
       task: params.job?.name || params.jobId,

--- a/src/cron/service/timer-execution-timeout.ts
+++ b/src/cron/service/timer-execution-timeout.ts
@@ -19,7 +19,7 @@ import type {
   CronRunTelemetry,
 } from "../types.js";
 import type { CronRunReceiptSettlementDisposition } from "./run-receipts.js";
-import type { CronServiceState } from "./state.js";
+import { resolveCronServiceDefaultAgentId, type CronServiceState } from "./state.js";
 
 export const MAX_CRON_TIMER_DELAY_MS = 60_000;
 
@@ -162,10 +162,7 @@ export function resolveMainSessionCronDeliveryContext(
   const explicitAgentId = job.agentId?.trim();
   const agentId = normalizeAgentId(
     explicitAgentId ||
-      resolveAgentIdFromSessionKey(
-        targetSessionKey,
-        state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId,
-      ),
+      resolveAgentIdFromSessionKey(targetSessionKey, resolveCronServiceDefaultAgentId(state)),
   );
   const storePath = state.deps.resolveSessionStorePath?.(agentId) ?? state.deps.sessionStorePath;
   if (!storePath) {

--- a/src/cron/service/timer-execution.ts
+++ b/src/cron/service/timer-execution.ts
@@ -29,7 +29,7 @@ import type {
 } from "../types.js";
 import { abortErrorMessage, timeoutErrorMessage } from "./execution-errors.js";
 import { resolveJobPayloadTextForMain } from "./jobs-scheduling.js";
-import type { CronServiceState } from "./state.js";
+import { resolveCronServiceDefaultAgentId, type CronServiceState } from "./state.js";
 import {
   type CronTriggerEvalOutcome,
   type ExecuteJobCoreOptions,
@@ -196,7 +196,7 @@ export async function executeJobCore(
       ? await state.deps.runSkillCollectionReview({
           agentId: resolveCronJobEffectiveAgentId(
             effectiveJob,
-            state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId,
+            resolveCronServiceDefaultAgentId(state),
           ),
           ...(abortSignal ? { abortSignal } : {}),
         })
@@ -305,10 +305,7 @@ async function executeMainSessionCronJob(
           : 'main job requires payload.kind="systemEvent"',
     };
   }
-  const agentId = resolveCronJobEffectiveAgentId(
-    job,
-    state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId,
-  );
+  const agentId = resolveCronJobEffectiveAgentId(job, resolveCronServiceDefaultAgentId(state));
   const deliveryContext = resolveMainSessionCronDeliveryContext(state, job);
   const queuedSystemEvent = normalizeQueuedSystemEventHandle(
     enqueueCronSystemEvent(state, text, {
@@ -572,10 +569,7 @@ async function executeScriptCronJob(
 
   const notify = result.notify?.trim() ? result.notify : undefined;
   if ((job.sessionTarget === "main" && notify) || result.wake) {
-    const agentId = resolveCronJobEffectiveAgentId(
-      job,
-      state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId,
-    );
+    const agentId = resolveCronJobEffectiveAgentId(job, resolveCronServiceDefaultAgentId(state));
     const deliveryContext =
       job.sessionTarget === "main" ? resolveMainSessionCronDeliveryContext(state, job) : undefined;
     const eventOptions = { agentId, ...(deliveryContext ? { deliveryContext } : {}) };

--- a/src/cron/service/timer-scheduler.ts
+++ b/src/cron/service/timer-scheduler.ts
@@ -34,7 +34,7 @@ import {
   recoverNonTerminalCronRunReceipts,
 } from "./run-recovery.js";
 import { applyCronRuntimeRowsToState, commitCronRuntimeRows } from "./runtime-store.js";
-import type { CronServiceState } from "./state.js";
+import { resolveCronServiceDefaultAgentId, type CronServiceState } from "./state.js";
 import { ensureLoaded, runPostPersistCronNotifications } from "./store.js";
 import { resolveCronJobTimeoutMs } from "./timeout-policy.js";
 import { createCronCapacityRecheckTracker } from "./timer-capacity-recheck.js";
@@ -502,9 +502,7 @@ async function onAdmittedTimer(state: CronServiceState) {
       // Reaper discovery is maintenance: failure must never strand the timer
       // or leave the scheduler's execution slot permanently occupied.
       if (state.deps.resolveSessionStorePath || state.deps.sessionStorePath) {
-        const configuredDefaultAgentId = (
-          state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId
-        )?.trim();
+        const configuredDefaultAgentId = resolveCronServiceDefaultAgentId(state)?.trim();
         const defaultAgentId = configuredDefaultAgentId
           ? normalizeAgentId(configuredDefaultAgentId)
           : undefined;


### PR DESCRIPTION
## What Problem This Solves

Cron service internals resolved the live default agent through duplicate helpers and inline expressions across operation, receipt, task, execution, timeout, and reaper paths. That duplicated one reload-sensitive policy and created drift risk between ownership decisions.

## Why This Change Was Made

The cron service state owner now exposes one internal `resolveCronServiceDefaultAgentId(state)` function with the existing nullish fallback semantics. Every byte-equivalent caller uses it at the original call site, so resolution timing remains unchanged.

The public static getter, notification normalization in `wake.ts`, static validation, configuration, protocol, SDK, and persistence behavior are unchanged.

## User Impact

No user-visible behavior changes. Cron ownership paths now share one canonical live default-agent resolution policy.

## Evidence

- Rebased onto `f7e62978f463ac58e5ef7a826a806818c791bd52`; signed head `d794bb33289ab877d009eeb07c80fcade05b8dac`.
- Rebase preserved the patch byte-for-byte: stable patch ID `36fe364ad9386f7afe0f4ff47883814661b4c621` and binary diff SHA-256 `eb1cde7d412fbd96c9ed4b16c0cfd3c47471012e425de36fe042d8ef64c75d1d` are unchanged from the prior head.
- Local focused Cron coverage: 22 affected test files, 395/395 tests passed.
- Exact-head Blacksmith Testbox: provider `blacksmith-testbox`, lease `tbx_01m1f5xvjgd8bhtrpqrqfsxy3b`, 395/395 focused tests passed. Run: https://github.com/openclaw/openclaw/actions/runs/33547703119
- The same exact-head Testbox lease ran the complete changed-file gate successfully, including core and core-test typechecks, changed-file formatting and lint, dead-export scans, database-first/native-schema guards, and import-cycle checks.
- Local import-cycle check passed with 0 runtime value cycles; `git diff --check` passed.
- Exact Sol autoreview: scoped-clean, no accepted or actionable findings; overall correctness 0.99.
- The required sibling Codex source ranges were inspected at `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; no relevant runtime or protocol dependency.
- ClawSweeper rank-up move resolved: focused tests and TypeScript/check results are now visible for the exact rebased head.
- Production LOC: +47/-60 (net -13). Tests: +0/-0.
