### PR TITLE
docs: list database CLI in command index

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -22,7 +22,7 @@ Setup commands by intent:
 | Area                         | Commands                                                                                                                                                                                                                              |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Setup and onboarding         | [`openclaw`](/cli/openclaw) · [`setup`](/cli/setup) · [`onboard`](/cli/onboard) · [`configure`](/cli/configure) · [`config`](/cli/config) · [`completion`](/cli/completion) · [`doctor`](/cli/doctor) · [`dashboard`](/cli/dashboard) |
-| Reset, backup, and migration | [`backup`](/cli/backup) · [`migrate`](/cli/migrate) · [`reset`](/cli/reset) · [`uninstall`](/cli/uninstall) · [`update`](/cli/update)                                                                                                 |
+| Reset, backup, and migration | [`backup`](/cli/backup) · [`database`](/reference/database-schemas) · [`migrate`](/cli/migrate) · [`reset`](/cli/reset) · [`uninstall`](/cli/uninstall) · [`update`](/cli/update)                                                     |
 | Messaging and agents         | [`message`](/cli/message) · [`agent`](/cli/agent) · [`agents`](/cli/agents) · [`attach`](/cli/attach) · [`acp`](/cli/acp) · [`mcp`](/cli/mcp)                                                                                         |
 | Health and sessions          | [`status`](/cli/status) · [`health`](/cli/health) · [`triage`](/cli/triage) · [`sessions`](/cli/sessions) · [`resume`](/cli/resume) · [`audit`](/cli/audit)                                                                           |
 | Gateway and logs             | [`fleet`](/cli/fleet) · [`gateway`](/cli/gateway) · [`logs`](/cli/logs) · [`system`](/cli/system)                                                                                                                                     |
@@ -124,6 +124,11 @@ openclaw [--dev] [--profile <name>] <command>
     file
     schema
     validate
+  database
+    preflight
+    ownership
+      status
+      claim
   completion
   doctor
   triage


### PR DESCRIPTION
<!-- Source-first documentation bug; no public issue. -->

## What Problem This Solves

Fixes an issue where users looking up the CLI command index could not find the active `openclaw database` command, even though the command and its `preflight` and `ownership` subcommands are available.

## Why This Change Was Made

Adds `database` to the CLI command index and full command tree, linking it to the existing database schema reference. The implementation and command contract are unchanged.

## User Impact

Users can discover the shared-state database inspection and ownership commands from the main CLI reference and follow the linked schema documentation.

## Evidence

- Final command contract: `pnpm openclaw database --help` reports `ownership` and `preflight` and links to the database schema reference.
- Documentation checks: `pnpm docs:list`; `pnpm docs:check-mdx` (751 files); `pnpm docs:check-links` (7,174 internal links, 0 broken); target-file `oxfmt --check`; target-file markdownlint; and `git diff --check`.
- Autoreview: scoped-clean with no accepted/actionable findings.
- Proof boundary: this is a documentation discoverability fix; the CLI implementation is unchanged.
- Exact head: `75add615f42e6d7a9fb74267a8de2e0d30dc5a04`
