### PR TITLE
refactor(scripts): share SQLite reliability state assertion

### DIFF
--- a/scripts/lib/sqlite-reliability-compaction.ts
+++ b/scripts/lib/sqlite-reliability-compaction.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import type { SnapshotDatabaseIdentity } from "../../src/snapshot/snapshot-provider.js";
 import {
   assertSameCompactionPayload,
+  assertSameReliabilityState,
   formatReliabilityStderr,
   type CompactionPayloadProof,
   type ReliabilityReport,
@@ -32,22 +33,6 @@ function fileSize(filePath: string): number {
       return 0;
     }
     throw error;
-  }
-}
-
-function assertSameState(
-  actual: ReliabilityStateProof,
-  expected: ReliabilityStateProof,
-  label: string,
-): void {
-  if (
-    actual.batches !== expected.batches ||
-    actual.rows !== expected.rows ||
-    actual.sha256 !== expected.sha256
-  ) {
-    throw new Error(
-      `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
-    );
   }
 }
 
@@ -212,7 +197,7 @@ export async function runVacuumInterruptionProof(params: {
     assertForcedExit(exit);
 
     const stateAfterRecovery = params.recoverAndVerifyDatabase();
-    assertSameState(stateAfterRecovery, params.expectedState, "vacuum crash recovery");
+    assertSameReliabilityState(stateAfterRecovery, params.expectedState, "vacuum crash recovery");
     const autoVacuumAfterRecovery = params.readAutoVacuum();
     if (autoVacuumAfterRecovery !== params.expectedAutoVacuum) {
       throw new Error(

--- a/scripts/lib/sqlite-reliability-contract.ts
+++ b/scripts/lib/sqlite-reliability-contract.ts
@@ -43,6 +43,22 @@ export type ReliabilityStateProof = {
   sha256: string;
 };
 
+export function assertSameReliabilityState(
+  actual: ReliabilityStateProof,
+  expected: ReliabilityStateProof,
+  label: string,
+): void {
+  if (
+    actual.batches !== expected.batches ||
+    actual.rows !== expected.rows ||
+    actual.sha256 !== expected.sha256
+  ) {
+    throw new Error(
+      `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
+    );
+  }
+}
+
 export function formatReliabilityStderr(stderr: string): string {
   const text = stderr.trim();
   return text ? ` stderr=${JSON.stringify(text)}` : "";

--- a/scripts/lib/sqlite-reliability-publication.ts
+++ b/scripts/lib/sqlite-reliability-publication.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import { createVerifiedSqliteSnapshot } from "../../src/infra/sqlite-snapshot.js";
-import type { ReliabilityReport, ReliabilityStateProof } from "./sqlite-reliability-contract.js";
+import {
+  assertSameReliabilityState,
+  type ReliabilityReport,
+  type ReliabilityStateProof,
+} from "./sqlite-reliability-contract.js";
 
 type PublicationCrashPoint = "after-publish" | "before-publish";
 type PublicationExit = ReliabilityReport["publicationInterruptionProof"]["beforePublish"]["exit"];
@@ -22,22 +26,6 @@ const PUBLICATION_WORKER_PATH = fileURLToPath(
   new URL("./sqlite-reliability-publication-worker.ts", import.meta.url),
 );
 const CRASH_POINT_TIMEOUT_MS = 120_000;
-
-function assertSameState(
-  actual: ReliabilityStateProof,
-  expected: ReliabilityStateProof,
-  label: string,
-): void {
-  if (
-    actual.batches !== expected.batches ||
-    actual.rows !== expected.rows ||
-    actual.sha256 !== expected.sha256
-  ) {
-    throw new Error(
-      `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
-    );
-  }
-}
 
 function assertNoSqliteSidecars(targetPath: string): void {
   for (const suffix of ["-journal", "-shm", "-wal"]) {
@@ -132,12 +120,12 @@ async function runCrashPoint(params: {
     }
 
     const sourceState = params.verifyDatabase(params.sourcePath);
-    assertSameState(sourceState, params.expectedState, `${params.crashPoint} source`);
+    assertSameReliabilityState(sourceState, params.expectedState, `${params.crashPoint} source`);
     let targetState: ReliabilityStateProof | null = null;
     if (targetVisibleAfterCrash) {
       assertNoSqliteSidecars(targetPath);
       targetState = params.verifyDatabase(targetPath);
-      assertSameState(targetState, params.expectedState, `${params.crashPoint} target`);
+      assertSameReliabilityState(targetState, params.expectedState, `${params.crashPoint} target`);
     }
 
     if (params.crashPoint === "before-publish") {
@@ -147,7 +135,7 @@ async function runCrashPoint(params: {
       });
       assertNoSqliteSidecars(targetPath);
       const retryState = params.verifyDatabase(targetPath);
-      assertSameState(retryState, params.expectedState, `${params.crashPoint} retry`);
+      assertSameReliabilityState(retryState, params.expectedState, `${params.crashPoint} retry`);
     } else {
       const targetHash = hashFile(targetPath);
       let retryError: unknown;
@@ -169,7 +157,11 @@ async function runCrashPoint(params: {
         throw new Error("SQLite retry changed the already-published target.");
       }
       const preservedState = params.verifyDatabase(targetPath);
-      assertSameState(preservedState, params.expectedState, `${params.crashPoint} retry`);
+      assertSameReliabilityState(
+        preservedState,
+        params.expectedState,
+        `${params.crashPoint} retry`,
+      );
     }
     for (const entry of crashStagingEntries) {
       if (!fs.existsSync(path.join(params.scratchPath, entry))) {

--- a/scripts/lib/sqlite-reliability-repository.ts
+++ b/scripts/lib/sqlite-reliability-repository.ts
@@ -10,6 +10,7 @@ import {
 } from "../../src/snapshot/snapshot-provider.js";
 import {
   assertSameCompactionPayload,
+  assertSameReliabilityState,
   formatReliabilityStderr,
   type CompactionPayloadProof,
   type ReliabilityReport,
@@ -34,22 +35,6 @@ const REPOSITORY_WORKER_PATH = fileURLToPath(
   new URL("./sqlite-reliability-repository-worker.ts", import.meta.url),
 );
 const REPOSITORY_TIMEOUT_MS = 120_000;
-
-function assertSameState(
-  actual: ReliabilityStateProof,
-  expected: ReliabilityStateProof,
-  label: string,
-): void {
-  if (
-    actual.batches !== expected.batches ||
-    actual.rows !== expected.rows ||
-    actual.sha256 !== expected.sha256
-  ) {
-    throw new Error(
-      `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
-    );
-  }
-}
 
 async function waitForCrashPoint(params: {
   child: ChildProcess;
@@ -150,7 +135,7 @@ async function verifySnapshot(params: {
 }): Promise<void> {
   await params.provider.verify(params.snapshot.ref);
   const artifactPath = path.join(params.snapshot.ref.path, SNAPSHOT_SQLITE_FILENAME);
-  assertSameState(params.verifyState(artifactPath), params.expectedState, artifactPath);
+  assertSameReliabilityState(params.verifyState(artifactPath), params.expectedState, artifactPath);
   assertSameCompactionPayload(
     params.verifyPayload(artifactPath),
     params.expectedPayload,
@@ -233,7 +218,7 @@ async function runCrashPoint(params: {
     }
 
     const sourceState = params.verifyState(params.sourcePath);
-    assertSameState(sourceState, params.expectedState, `${params.crashPoint} source`);
+    assertSameReliabilityState(sourceState, params.expectedState, `${params.crashPoint} source`);
     const sourcePayload = params.verifyPayload(params.sourcePath);
     assertSameCompactionPayload(
       sourcePayload,

--- a/scripts/lib/sqlite-reliability-restore.ts
+++ b/scripts/lib/sqlite-reliability-restore.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { createLocalSqliteSnapshotProvider } from "../../src/snapshot/local-repository.js";
 import {
   assertSameCompactionPayload,
+  assertSameReliabilityState,
   formatReliabilityStderr,
   type CompactionPayloadProof,
   type ReliabilityReport,
@@ -36,22 +37,6 @@ const MIN_STAGED_RESTORE_BYTES = 1024 * 1024;
 
 function hashFile(filePath: string): string {
   return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
-}
-
-function assertSameState(
-  actual: ReliabilityStateProof,
-  expected: ReliabilityStateProof,
-  label: string,
-): void {
-  if (
-    actual.batches !== expected.batches ||
-    actual.rows !== expected.rows ||
-    actual.sha256 !== expected.sha256
-  ) {
-    throw new Error(
-      `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
-    );
-  }
 }
 
 function assertNoSqliteSidecars(targetPath: string): void {
@@ -351,7 +336,11 @@ async function runCrashPoint(params: {
 
     assertNoSqliteSidecars(targetPath);
     const stateAfterRecovery = params.verifyState(targetPath);
-    assertSameState(stateAfterRecovery, params.expectedState, `${params.crashPoint} restore`);
+    assertSameReliabilityState(
+      stateAfterRecovery,
+      params.expectedState,
+      `${params.crashPoint} restore`,
+    );
     const payloadAfterRecovery = params.verifyPayload(targetPath);
     assertSameCompactionPayload(
       payloadAfterRecovery,

--- a/scripts/lib/sqlite-reliability-runner.ts
+++ b/scripts/lib/sqlite-reliability-runner.ts
@@ -20,6 +20,7 @@ import {
 } from "../../src/state/openclaw-state-db.js";
 import { runVacuumInterruptionProof } from "./sqlite-reliability-compaction.js";
 import {
+  assertSameReliabilityState,
   COMMITTED_WAL_SENTINEL,
   PROFILES,
   STRESS_TABLE_SQL,
@@ -204,22 +205,6 @@ function readReliabilityState(database: DatabaseSync, rowsPerBatch: number): Rel
     rows,
     sha256: hash.digest("hex"),
   };
-}
-
-function assertSameReliabilityState(
-  actual: ReliabilityStateProof,
-  expected: ReliabilityStateProof,
-  label: string,
-): void {
-  if (
-    actual.batches !== expected.batches ||
-    actual.rows !== expected.rows ||
-    actual.sha256 !== expected.sha256
-  ) {
-    throw new Error(
-      `${label} changed reliability state: expected batches=${expected.batches} rows=${expected.rows} sha256=${expected.sha256}, got batches=${actual.batches} rows=${actual.rows} sha256=${actual.sha256}`,
-    );
-  }
 }
 
 function verifyRestoredDatabase(params: {


### PR DESCRIPTION
## What Problem This Solves

The SQLite reliability harness maintained five identical state-proof assertions across its runner and crash scenario modules. That duplicated the comparison policy and diagnostic text, making future scenario changes vulnerable to silent drift.

## Why This Change Was Made

The existing reliability contract module now owns `assertSameReliabilityState`, and all nine state-proof checks use it. The helper preserves the direct `batches`, `rows`, and `sha256` comparisons plus the exact existing error text.

The distinct index-repair assertion remains local because it compares a different state shape and diagnostic contract. This does not change SQLite schemas, stores, runtime behavior, APIs, dependencies, or test coverage.

## User Impact

No user-visible behavior changes. Maintainers get one canonical assertion policy across the SQLite reliability proof scenarios.

## Evidence

- Based and verified against `ef44eab5ed8320cd5a5f34d790cedceffaefc36f` (`main` on September 1, 2026). The requested checkpoint `ae24725490eed59d55c290a42b33c6d1081791b5` is an ancestor.
- `node scripts/run-vitest.mjs test/scripts/bench-sqlite-reliability.test.ts` - 7/7 passed, including the real snapshot/crash/recovery round trip.
- `node scripts/check-changed.mjs --dry-run -- <six changed files>` - classified only `scripts` and `tooling`.
- `node scripts/check-changed.mjs -- <six changed files>` - passed.
- `pnpm check:import-cycles` - 0 runtime value cycles.
- Formatter, script oxlint, TypeScript erasability/typecheck, `git diff --check`, and duplicate-policy grep passed.
- Exact `gpt-5.6-sol` autoreview reported no accepted/actionable findings.
- Tooling LOC: `+41/-89` (net `-48`). Tests: `+0/-0`.
- Open overlap check: https://github.com/openclaw/openclaw/pull/122612 changes only the runner's compaction fixture constant/comment and does not overlap this assertion consolidation.
- Required Codex source gate inspected at `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those CLI completion/config paths do not affect this tooling-only refactor.
