### PR TITLE
refactor(daemon): consolidate system ownership formatting

### DIFF
--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -14,6 +14,7 @@ import { parseLaunchdPlistLabel } from "./launchd-plist.js";
 import { readLaunchDaemonPlistLabel } from "./launchd-system.js";
 import { resolveDaemonHomeDir } from "./paths.js";
 import { execSchtasks } from "./schtasks-exec.js";
+import { quotePosixShellArgument } from "./system-ownership-format.js";
 import { parseSystemdExecStart } from "./systemd-unit.js";
 
 export type ExtraGatewayService = {
@@ -44,10 +45,6 @@ const SYSTEMD_REFERENCE_ONLY_KEYS = new Set([
   "wants",
 ]);
 
-function quotePosixCleanupArgument(value: string): string {
-  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
-}
-
 export function renderGatewayServiceCleanupHints(
   services: readonly ExtraGatewayService[] = [],
 ): string[] {
@@ -67,24 +64,24 @@ export function renderGatewayServiceCleanupHints(
             : "gui/$UID";
         const launchctlCommand = domain === "system" ? "sudo launchctl" : "launchctl";
         hints.push(
-          `${launchctlCommand} bootout ${domain}/${quotePosixCleanupArgument(service.label)}`,
+          `${launchctlCommand} bootout ${domain}/${quotePosixShellArgument(service.label)}`,
         );
         if (plistPath) {
           const removeCommand = service.scope === "system" ? "sudo rm" : "rm";
-          hints.push(`${removeCommand} ${quotePosixCleanupArgument(plistPath)}`);
+          hints.push(`${removeCommand} ${quotePosixShellArgument(plistPath)}`);
         }
         break;
       }
       case "linux": {
         const systemctlCommand = service.scope === "user" ? "systemctl --user" : "sudo systemctl";
         hints.push(
-          `${systemctlCommand} disable --now -- ${quotePosixCleanupArgument(service.label)}`,
+          `${systemctlCommand} disable --now -- ${quotePosixShellArgument(service.label)}`,
         );
         if (service.detail.startsWith("unit:")) {
           const unitPath = service.detail.slice("unit:".length).trim();
           if (unitPath) {
             const removeCommand = service.scope === "system" ? "sudo rm" : "rm";
-            hints.push(`${removeCommand} ${quotePosixCleanupArgument(unitPath)}`);
+            hints.push(`${removeCommand} ${quotePosixShellArgument(unitPath)}`);
           }
         }
         break;

--- a/src/daemon/launchd-system.ts
+++ b/src/daemon/launchd-system.ts
@@ -1,8 +1,6 @@
 /** Detects system-domain launchd ownership before mutating a user LaunchAgent. */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { isMissingPathError } from "../infra/errors.js";
 import { execFileUtf8 } from "./exec-file.js";
 import {
@@ -11,6 +9,10 @@ import {
   isLaunchctlNotLoaded,
   type LaunchctlResult,
 } from "./launchd-exec.js";
+import {
+  formatSystemOwnershipFailureDetail,
+  quotePosixShellArgument,
+} from "./system-ownership-format.js";
 
 const SYSTEM_LAUNCH_DAEMON_DIR = "/Library/LaunchDaemons";
 const PLUTIL_PATH = "/usr/bin/plutil";
@@ -28,15 +30,6 @@ type SystemLaunchDaemonOwnership =
 
 type SystemLaunchDaemonConflict = Exclude<SystemLaunchDaemonOwnership, { status: "absent" }>;
 
-function formatUnknownError(error: unknown): string {
-  const raw = error instanceof Error ? error.message : String(error);
-  return truncateUtf16Safe(sanitizeForLog(raw), 500);
-}
-
-function quotePosixArgument(value: string): string {
-  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
-}
-
 /**
  * Renders the package-independent ownership probe used by detached restart helpers.
  * The caller must refuse activation when `openclaw_system_launchd_conflict` is non-empty.
@@ -45,9 +38,9 @@ export function renderSystemLaunchDaemonOwnershipShellProbe(label: string): stri
   const serviceTarget = `system/${label}`;
   return `openclaw_system_launchd_conflict=""
 openclaw_system_launchd_detail=""
-openclaw_system_launchd_target=${quotePosixArgument(serviceTarget)}
-openclaw_system_launchd_dir=${quotePosixArgument(SYSTEM_LAUNCH_DAEMON_DIR)}
-openclaw_system_launchd_label=${quotePosixArgument(label)}
+openclaw_system_launchd_target=${quotePosixShellArgument(serviceTarget)}
+openclaw_system_launchd_dir=${quotePosixShellArgument(SYSTEM_LAUNCH_DAEMON_DIR)}
+openclaw_system_launchd_label=${quotePosixShellArgument(label)}
 openclaw_query_system_launchd() {
   openclaw_system_launchd_probe=$(launchctl print "$openclaw_system_launchd_target" 2>&1)
   openclaw_system_launchd_probe_status=$?
@@ -138,7 +131,7 @@ export async function readLaunchDaemonPlistLabel(
         ? { status: "ok", label }
         : { status: "unlabeled" };
     } catch (error) {
-      return { status: "unverifiable", detail: formatUnknownError(error) };
+      return { status: "unverifiable", detail: formatSystemOwnershipFailureDetail(error) };
     }
   }
   try {
@@ -151,7 +144,7 @@ export async function readLaunchDaemonPlistLabel(
     if (code === "EACCES" || code === "EPERM") {
       return { status: "unreadable" };
     }
-    return { status: "unverifiable", detail: formatUnknownError(error) };
+    return { status: "unverifiable", detail: formatSystemOwnershipFailureDetail(error) };
   }
   return {
     status: "unverifiable",
@@ -174,7 +167,7 @@ async function findInstalledSystemLaunchDaemon(
     if (isMissingPathError(error)) {
       return { status: "absent" };
     }
-    return { status: "unverifiable", detail: formatUnknownError(error) };
+    return { status: "unverifiable", detail: formatSystemOwnershipFailureDetail(error) };
   }
 
   for (const entry of entries.filter((candidate) => candidate.endsWith(".plist")).toSorted()) {
@@ -275,7 +268,7 @@ function formatSystemLaunchDaemonOwnershipError(ownership: SystemLaunchDaemonCon
     ownership.status === "loaded"
       ? `Keep it as the sole gateway manager, or unload it with \`sudo launchctl bootout ${ownership.serviceTarget}\` and remove its plist before retrying.`
       : ownership.status === "installed"
-        ? `Keep it as the sole gateway manager, or remove or relocate ${quotePosixArgument(ownership.plistPath)} before retrying.`
+        ? `Keep it as the sole gateway manager, or remove or relocate ${quotePosixShellArgument(ownership.plistPath)} before retrying.`
         : "Fix the reported launchctl or filesystem access error, then retry.";
   return [
     formatSystemLaunchDaemonOwnershipSummary(ownership),

--- a/src/daemon/service-layout.ts
+++ b/src/daemon/service-layout.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { pathExists } from "../infra/fs-safe.js";
 import { readPackageName, readPackageVersion } from "../infra/package-json.js";
 import type { GatewayServiceCommandConfig } from "./service-types.js";
+import { quotePosixShellArgument } from "./system-ownership-format.js";
 
 /** Summary of the installed gateway service command and package layout. */
 export type GatewayServiceLayoutSummary = {
@@ -19,15 +20,8 @@ export type GatewayServiceLayoutSummary = {
   entrypointSourceCheckout?: boolean;
 };
 
-function shellQuoteArg(value: string): string {
-  if (/^[A-Za-z0-9_./:@%+=,-]+$/u.test(value)) {
-    return value;
-  }
-  return `'${value.replaceAll("'", "'\\''")}'`;
-}
-
 function formatExecStart(programArguments: readonly string[]): string {
-  return programArguments.map(shellQuoteArg).join(" ");
+  return programArguments.map(quotePosixShellArgument).join(" ");
 }
 
 function resolveSystemdScopeFromServicePath(

--- a/src/daemon/system-ownership-format.ts
+++ b/src/daemon/system-ownership-format.ts
@@ -1,0 +1,11 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
+
+export function quotePosixShellArgument(value: string): string {
+  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+export function formatSystemOwnershipFailureDetail(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  return truncateUtf16Safe(sanitizeForLog(raw), 500);
+}

--- a/src/daemon/systemd-system.ts
+++ b/src/daemon/systemd-system.ts
@@ -1,9 +1,11 @@
 /** Detects system-scope systemd ownership before mutating a user gateway unit. */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { isMissingPathError } from "../infra/errors.js";
+import {
+  formatSystemOwnershipFailureDetail,
+  quotePosixShellArgument,
+} from "./system-ownership-format.js";
 import { execSystemctl, readSystemctlDetail } from "./systemd-exec.js";
 
 type SystemSystemdOwnership =
@@ -18,15 +20,6 @@ type SystemSystemdOwnership =
     };
 
 type SystemSystemdConflict = Exclude<SystemSystemdOwnership, { status: "absent" }>;
-
-function formatUnknownError(error: unknown): string {
-  const raw = error instanceof Error ? error.message : String(error);
-  return truncateUtf16Safe(sanitizeForLog(raw), 500);
-}
-
-function quotePosixArgument(value: string): string {
-  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
-}
 
 function unverifiableSystemOwnership(
   unitName: string,
@@ -88,7 +81,7 @@ async function findInstalledSystemUnit(
       if (isMissingPathError(error)) {
         continue;
       }
-      const detail = `${unitPath}: ${formatUnknownError(error)}`;
+      const detail = `${unitPath}: ${formatSystemOwnershipFailureDetail(error)}`;
       return unverifiableSystemOwnership(unitName, detail, "filesystem");
     }
   }
@@ -132,7 +125,7 @@ function isRunningAsRoot(): boolean {
 
 function formatSystemSystemdOwnershipError(ownership: SystemSystemdConflict): string {
   const privilegePrefix = isRunningAsRoot() ? "" : "sudo ";
-  const unitName = quotePosixArgument(ownership.unitName);
+  const unitName = quotePosixShellArgument(ownership.unitName);
   const summary =
     ownership.status === "loaded"
       ? `System systemd unit ${ownership.unitName} already owns this gateway unit name.`
@@ -147,9 +140,9 @@ function formatSystemSystemdOwnershipError(ownership: SystemSystemdConflict): st
     ownership.status === "loaded"
       ? `Keep it as the sole gateway manager, or inspect it with \`${privilegePrefix}systemctl cat ${unitName}\`, then disable it and uninstall or reconfigure the package, generator, or administrator unit that owns it before retrying.`
       : installedInAdministratorPath
-        ? `Keep it as the sole gateway manager, or run \`${privilegePrefix}systemctl disable --now ${unitName}\`, \`${privilegePrefix}rm ${quotePosixArgument(ownership.unitPath)}\`, and \`${privilegePrefix}systemctl daemon-reload\` before retrying.`
+        ? `Keep it as the sole gateway manager, or run \`${privilegePrefix}systemctl disable --now ${unitName}\`, \`${privilegePrefix}rm ${quotePosixShellArgument(ownership.unitPath)}\`, and \`${privilegePrefix}systemctl daemon-reload\` before retrying.`
         : ownership.status === "installed"
-          ? `Keep it as the sole gateway manager, or inspect it with \`${privilegePrefix}systemctl cat ${unitName}\`, then uninstall or reconfigure the package, generator, or runtime owner of ${quotePosixArgument(ownership.unitPath)} before retrying.`
+          ? `Keep it as the sole gateway manager, or inspect it with \`${privilegePrefix}systemctl cat ${unitName}\`, then uninstall or reconfigure the package, generator, or runtime owner of ${quotePosixShellArgument(ownership.unitPath)} before retrying.`
           : "Fix the reported systemctl or filesystem access error, then retry.";
   return [
     summary,


### PR DESCRIPTION
## What Problem This Solves

Resolves duplicated daemon-owned formatting policy for POSIX shell arguments and bounded system-ownership failure details. The copies spanned launchd, systemd, cleanup hints, and service layout output, creating avoidable drift risk.

## Why This Change Was Made

One private daemon leaf module now owns the existing shell-quoting and failure-detail formatting contracts. Launchd, systemd, inspection, and service-layout callers reuse it without changing Windows behavior, public APIs, SDK surfaces, dependencies, or persistence.

## User Impact

No user-visible behavior changes. Operator-pasteable commands and system-ownership diagnostics retain their existing quoting, sanitization, truncation, and recovery text.

## Evidence

- Focused daemon suites: 84 passed, 5 platform-specific skips.
- Changed-file dry run selected only core production and core tests. Every selected gate before dead-export scanning passed; after adding the omitted tracked UI config paths to the sparse checkout, the exact dead-export lane passed with zero entries.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `pnpm check:madge-import-cycles`: 0 cycles.
- `pnpm build` completed compilation and artifact generation, then the shared checkout's linked `@openclaw/ai` artifact failed runtime postbuild because it predated a current diagnostics export. Re-running the exact native-require verifier against the freshly built task-local package passed all 53 built plugin control-plane modules and doctor closures.
- Exact Codex autoreview with `gpt-5.6-sol` at high reasoning: scoped clean, no accepted or actionable findings, correctness confidence 0.99.
- Production LOC: +37/-49, net -12. Tests: +0/-0.
- Overlap checked against main snapshots `ae24725490eed59d55c290a42b33c6d1081791b5` and `ef44eab5ed8320cd5a5f34d790cedceffaefc36f`; neither changed the affected daemon paths. Open PRs #131786 and #133215 touch separate `inspect.ts` regions.
