### PR TITLE
refactor(codex): reuse command display sanitization

### DIFF
--- a/extensions/codex/src/command-diagnostics-support.ts
+++ b/extensions/codex/src/command-diagnostics-support.ts
@@ -8,6 +8,12 @@ import {
   type CodexDiagnosticsTarget,
   type PendingCodexDiagnosticsConfirmation,
 } from "./command-diagnostics-state.js";
+import {
+  CODEX_RESUME_SAFE_THREAD_ID_PATTERN,
+  escapeCodexChatText,
+  formatCodexDisplayText,
+  formatCodexTextForDisplay,
+} from "./command-formatters.js";
 import { splitArgs } from "./command-handler-args.js";
 
 type ParsedDiagnosticsArgs =
@@ -26,8 +32,6 @@ const CODEX_DIAGNOSTICS_CONFIRMATION_TTL_MS = 5 * 60_000;
 const CODEX_DIAGNOSTICS_CONFIRMATION_MAX_REQUESTS_PER_SCOPE = 100;
 const CODEX_DIAGNOSTICS_CONFIRMATION_MAX_SCOPES = 100;
 const CODEX_DIAGNOSTICS_SCOPE_FIELD_MAX_CHARS = 128;
-const CODEX_RESUME_SAFE_THREAD_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
-
 const {
   lastUploadByThread: lastCodexDiagnosticsUploadByThread,
   lastUploadByScope: lastCodexDiagnosticsUploadByScope,
@@ -305,7 +309,7 @@ function formatCodexDiagnosticsTargetBlock(
 ): string[] {
   const lines = [`Session ${index + 1}`];
   if (target.channel) {
-    lines.push(`Channel: ${formatCodexValueForDisplay(target.channel)}`);
+    lines.push(`Channel: ${formatCodexDisplayText(target.channel)}`);
   }
   if (target.sessionKey) {
     lines.push(`OpenClaw session key: ${formatCodexCopyableValueForDisplay(target.sessionKey)}`);
@@ -321,41 +325,14 @@ function formatCodexDiagnosticsTargetBlock(
 function formatCodexDiagnosticsTargetLine(target: CodexDiagnosticsTarget): string {
   const parts: string[] = [];
   if (target.channel) {
-    parts.push(`channel ${formatCodexValueForDisplay(target.channel)}`);
+    parts.push(`channel ${formatCodexDisplayText(target.channel)}`);
   }
   const sessionLabel = target.sessionId || target.sessionKey;
   if (sessionLabel) {
-    parts.push(`OpenClaw session ${formatCodexValueForDisplay(sessionLabel)}`);
+    parts.push(`OpenClaw session ${formatCodexDisplayText(sessionLabel)}`);
   }
-  parts.push(`Codex thread ${formatCodexThreadIdForDisplay(target.threadId)}`);
+  parts.push(`Codex thread ${formatCodexDisplayText(target.threadId)}`);
   return `- ${parts.join(", ")}`;
-}
-
-export function escapeCodexChatText(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll("@", "\uff20")
-    .replaceAll("`", "\uff40")
-    .replaceAll("[", "\uff3b")
-    .replaceAll("]", "\uff3d")
-    .replaceAll("(", "\uff08")
-    .replaceAll(")", "\uff09")
-    .replaceAll("*", "\u2217")
-    .replaceAll("_", "\uff3f")
-    .replaceAll("~", "\uff5e")
-    .replaceAll("|", "\uff5c");
-}
-
-export function formatCodexTextForDisplay(value: string): string {
-  let safe = "";
-  for (const character of value) {
-    const codePoint = character.codePointAt(0);
-    safe += codePoint != null && isUnsafeDisplayCodePoint(codePoint) ? "?" : character;
-  }
-  safe = safe.trim();
-  return safe || "<unknown>";
 }
 
 export function readCodexDiagnosticsTargetsCooldownMessage(
@@ -372,7 +349,7 @@ export function readCodexDiagnosticsTargetsCooldownMessage(
           cooldownMs / 1000,
         )}s.`;
       }
-      const displayThreadId = formatCodexThreadIdForDisplay(target.threadId);
+      const displayThreadId = formatCodexDisplayText(target.threadId);
       return `Codex diagnostics were already sent for thread ${displayThreadId} recently. Try again in ${Math.ceil(
         cooldownMs / 1000,
       )}s.`;
@@ -437,14 +414,6 @@ function addTag(tags: Record<string, string>, key: string, value: unknown): void
   if (typeof value === "string" && value.trim()) {
     tags[key] = value.trim();
   }
-}
-
-function formatCodexThreadIdForDisplay(threadId: string): string {
-  return escapeCodexChatText(formatCodexTextForDisplay(threadId));
-}
-
-function formatCodexValueForDisplay(value: string): string {
-  return escapeCodexChatText(formatCodexTextForDisplay(value));
 }
 
 function formatCodexCopyableValueForDisplay(value: string): string {
@@ -524,22 +493,6 @@ function formatCodexResumeCommandForDisplay(threadId: string): string {
     return "run codex resume and paste the thread id shown above";
   }
   return `\`codex resume ${safeThreadId}\``;
-}
-
-function isUnsafeDisplayCodePoint(codePoint: number): boolean {
-  return (
-    codePoint <= 0x001f ||
-    (codePoint >= 0x007f && codePoint <= 0x009f) ||
-    codePoint === 0x00ad ||
-    codePoint === 0x061c ||
-    codePoint === 0x180e ||
-    (codePoint >= 0x200b && codePoint <= 0x200f) ||
-    (codePoint >= 0x202a && codePoint <= 0x202e) ||
-    (codePoint >= 0x2060 && codePoint <= 0x206f) ||
-    codePoint === 0xfeff ||
-    (codePoint >= 0xfff9 && codePoint <= 0xfffb) ||
-    (codePoint >= 0xe0000 && codePoint <= 0xe007f)
-  );
 }
 
 function normalizeCodexDiagnosticsScopeField(value: string | undefined): string | undefined {

--- a/extensions/codex/src/command-diagnostics.ts
+++ b/extensions/codex/src/command-diagnostics.ts
@@ -16,10 +16,8 @@ import {
   codexDiagnosticsTargetsMatch,
   createCodexDiagnosticsConfirmation,
   deletePendingCodexDiagnosticsConfirmation,
-  escapeCodexChatText,
   formatCodexDiagnosticsTargetLines,
   formatCodexDiagnosticsUploadResult,
-  formatCodexTextForDisplay,
   formatDiagnosticsUsage,
   normalizeDiagnosticsReason,
   parseDiagnosticsArgs,
@@ -30,6 +28,7 @@ import {
   readPendingCodexDiagnosticsConfirmation,
   recordCodexDiagnosticsUpload,
 } from "./command-diagnostics-support.js";
+import { formatCodexDisplayText } from "./command-formatters.js";
 import { CODEX_CONTROL_METHODS, type CodexCommandDeps } from "./command-handler-deps.js";
 import { resolveControlTarget } from "./command-handler-scope.js";
 
@@ -120,7 +119,7 @@ async function requestCodexDiagnosticsFeedbackApproval(
   });
   const confirmCommand = `${commandPrefix} confirm ${token}`;
   const cancelCommand = `${commandPrefix} cancel ${token}`;
-  const displayReason = reason ? escapeCodexChatText(formatCodexTextForDisplay(reason)) : undefined;
+  const displayReason = reason ? formatCodexDisplayText(reason) : undefined;
   const lines = [
     targets.length === 1 ? "Codex runtime thread detected." : "Codex runtime threads detected.",
     `Codex diagnostics can send ${targets.length === 1 ? "this thread's feedback bundle" : "these threads' feedback bundles"} to OpenAI servers.`,
@@ -180,7 +179,7 @@ async function previewCodexDiagnosticsFeedbackApproval(
     return cooldownMessage;
   }
   const reason = normalizeDiagnosticsReason(note);
-  const displayReason = reason ? escapeCodexChatText(formatCodexTextForDisplay(reason)) : undefined;
+  const displayReason = reason ? formatCodexDisplayText(reason) : undefined;
   return [
     targets.length === 1 ? "Codex runtime thread detected." : "Codex runtime threads detected.",
     `Approving diagnostics will also send ${targets.length === 1 ? "this thread's feedback bundle" : "these threads' feedback bundles"} to OpenAI servers.`,

--- a/extensions/codex/src/command-formatters.ts
+++ b/extensions/codex/src/command-formatters.ts
@@ -279,7 +279,7 @@ function formatCodexSkillEntry(entry: JsonValue): string {
   return `\`${formatCodexDisplayText(name)}\``;
 }
 
-const CODEX_RESUME_SAFE_THREAD_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+export const CODEX_RESUME_SAFE_THREAD_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
 
 function formatCodexResumeHint(threadId: string): string {
   const safe = formatCodexTextForDisplay(threadId);
@@ -301,7 +301,7 @@ function formatCodexAccountSummary(value: JsonValue | undefined): string {
     : escapeCodexChatText(safe);
 }
 
-function formatCodexTextForDisplay(value: string): string {
+export function formatCodexTextForDisplay(value: string): string {
   const safe = sanitizeCodexTextForDisplay(value).trim();
   return safe || "<unknown>";
 }
@@ -315,7 +315,7 @@ function sanitizeCodexTextForDisplay(value: string): string {
   return safe;
 }
 
-function escapeCodexChatText(value: string): string {
+export function escapeCodexChatText(value: string): string {
   // Command output is public chat text. Escape markdown/control triggers and
   // mention characters so Codex data cannot ping users or inject formatting.
   return value


### PR DESCRIPTION
Codex diagnostics duplicated the existing command formatter's trimming, chat escaping and copyable-identifier logic. Diagnostics now imports those three primitives from the canonical formatter, deleting the duplicate implementations and local wrappers.

Replacement order, control and bidi handling, UTF-16 truncation and the separate email display path are preserved. Display formatting stays separate from raw feedback request, cooldown and resume identity. This changes no command, auth, feedback policy or protocol contract.

**Production: +17/-65 = -48 physical lines across three owners. Tests: 0 changed lines.**

Validation:

- Both original escaping owners were compared over all1,112,064 Unicode scalar values, alone and combined with the13 markup replacements. The final canonical helper reproduces the same digest across2,224,128 cases. The original helpers also match across169 replacement pairs; the final pair loop only invokes/counts these pairs, so it is not claimed as an independent pair-output assertion.
- The actual registered command handler is exercised with local request capture. Baseline/final observations agree for preview/no-request, raw UUID request parameters, disabled feedback, and the2,047-code-unit reason boundary. The final probe also verifies successful cooldown uses the raw thread ID. No feedback is submitted to a vendor.
- All205 maintained command tests pass before and after. Selected changed-file gates, doctor checks, import-cycle checks and the normal full build pass.
- A fresh isolated managed Codex high/P2 review is clean with full production owners/callers, upstream protocol contracts and complete smaller probe datasets. The oversized maintained test file was omitted after the review helper's size guard rejected it; it was separately read and remains hash guarded. No scanner restriction was bypassed.

The acting maintainer directly inspected sibling Codex at94cbbddafc1776d5e377bca1b05932c697e82238: `codex-rs/app-server-protocol/src/protocol/v2/feedback.rs:11`, `codex-rs/app-server/src/request_processors/feedback_processor.rs:73`, and `codex-rs/protocol/src/thread_id.rs:41`. Feedback keeps its original raw string thread ID, which the upstream processor validates as a UUID.

Source, dependency, baseline Git and evidence hashes were rechecked. Lone-surrogate probe values are preserved as UTF-16 code-unit arrays in the strict JSON artifact. The initial shell-quoting attempt and review size rejection are retained as setup failures; corrected runs passed.


Landing verification: all75 jobs in CI33524029304 passed or were intentionally skipped on the exact head8e2b0be5de060a230e32b3d4e0ff4f779c609163, including the required gate. The latest ClawSweeper review has no code/security findings; its CI step and rank-up are satisfied. Production+17/-65=-48; tests0. Direct owner and upstream Codex contract inspection,205 tests, normal build, scalar differential and captured registered-command observations support unchanged behavior. The baseline pair comparison and final raw-ID cooldown are qualified in the proof above.
