### PR TITLE
refactor(agents): centralize tool model config predicate

### DIFF
--- a/src/agents/openclaw-tools.media-factory-plan.ts
+++ b/src/agents/openclaw-tools.media-factory-plan.ts
@@ -2,6 +2,7 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import { findCapabilityProviderById } from "../../packages/media-generation-core/src/capability-model-ref.js";
 import { normalizeMediaProviderId } from "../../packages/media-understanding-common/src/provider-id.js";
 import {
+  hasToolModelConfig,
   resolveAgentModelFallbackValues,
   resolveAgentModelPrimaryValue,
 } from "../config/model-input.js";
@@ -39,12 +40,6 @@ function coerceFactoryToolModelConfig(model?: AgentModelConfig): ToolModelConfig
     ...(primary?.trim() ? { primary: primary.trim() } : {}),
     ...(fallbacks.length > 0 ? { fallbacks } : {}),
   };
-}
-
-function hasToolModelConfig(model: ToolModelConfig | undefined): boolean {
-  return Boolean(
-    model?.primary?.trim() || (model?.fallbacks ?? []).some((entry) => entry.trim().length > 0),
-  );
 }
 
 function hasExplicitToolModelConfig(modelConfig: AgentModelConfig | undefined): boolean {

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -2,6 +2,7 @@ import { resolve, isAbsolute } from "node:path";
 import { Type } from "typebox";
 import { findCapabilityProviderById } from "../../../packages/media-generation-core/src/capability-model-ref.js";
 import { normalizeMediaProviderId } from "../../../packages/media-understanding-common/src/provider-id.js";
+import { hasToolModelConfig } from "../../config/model-input.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { MediaUnderstandingModelConfig } from "../../config/types.tools.js";
 import {
@@ -71,7 +72,6 @@ import {
 } from "./media-tool-shared.js";
 import {
   buildToolModelConfigFromCandidates,
-  hasToolModelConfig,
   resolveDefaultModelRef,
   resolveOpenAiImageMediaCandidate,
 } from "./model-config.helpers.js";

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -10,6 +10,7 @@ import {
   findCapabilityProviderById,
   resolveCapabilityModelRefForProviders,
 } from "../../../packages/media-generation-core/src/capability-model-ref.js";
+import { hasToolModelConfig } from "../../config/model-input.js";
 import type { AgentModelConfig } from "../../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { safeFileURLToPath } from "../../infra/local-file-access.js";
@@ -47,7 +48,6 @@ import {
   buildToolModelConfigFromCandidates,
   coerceToolModelConfig,
   hasProviderAuthForTool,
-  hasToolModelConfig,
   resolveDefaultModelRef,
   type ToolModelConfig,
 } from "./model-config.helpers.js";

--- a/src/agents/tools/model-config.helpers.ts
+++ b/src/agents/tools/model-config.helpers.ts
@@ -5,6 +5,7 @@
  * whether candidate providers have usable auth before exposing defaults.
  */
 import {
+  hasToolModelConfig,
   resolveAgentModelFallbackValues,
   resolveAgentModelPrimaryValue,
   resolveAgentModelTimeoutMsValue,
@@ -42,13 +43,6 @@ type OpenAiImageMediaCandidateDecision =
   | { kind: "keep"; ref: string }
   | { kind: "substitute"; ref: string; provider: string }
   | { kind: "drop" };
-
-/** Returns whether a tool model config contains a primary or fallback model ref. */
-export function hasToolModelConfig(model: ToolModelConfig | undefined): boolean {
-  return Boolean(
-    model?.primary?.trim() || (model?.fallbacks ?? []).some((entry) => entry.trim().length > 0),
-  );
-}
 
 /** Resolves the configured default model ref, falling back to OpenClaw defaults. */
 export function resolveDefaultModelRef(cfg?: OpenClawConfig): { provider: string; model: string } {

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -8,6 +8,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { Type } from "typebox";
+import { hasToolModelConfig } from "../../config/model-input.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { bindModelLlmRuntime } from "../../llm/model-runtime-binding.js";
 import { complete } from "../../llm/stream.js";
@@ -44,7 +45,6 @@ import {
   resolveRemoteMediaSsrfPolicy,
   type MediaToolSandbox,
 } from "./media-tool-shared.js";
-import { hasToolModelConfig } from "./model-config.helpers.js";
 import { anthropicAnalyzePdf, geminiAnalyzePdf } from "./pdf-native-providers.js";
 import {
   coercePdfAssistantText,

--- a/src/config/model-input.ts
+++ b/src/config/model-input.ts
@@ -19,6 +19,15 @@ type AgentModelListLike = {
 
 type AgentModelInput = AgentModelConfig | AgentToolModelConfig;
 
+/** Returns whether a tool model config contains a primary or fallback model ref. */
+export function hasToolModelConfig(
+  model: Exclude<AgentToolModelConfig, string> | undefined,
+): boolean {
+  return Boolean(
+    model?.primary?.trim() || (model?.fallbacks ?? []).some((entry) => entry.trim().length > 0),
+  );
+}
+
 /** Returns the primary model ref from either string or object-style agent model config. */
 export function resolveAgentModelPrimaryValue(model?: AgentModelInput): string | undefined {
   return resolvePrimaryStringValue(model);


### PR DESCRIPTION
## What Problem This Solves

Media tool model configuration used two local copies of the same primary/fallback presence predicate. That duplicated policy between lightweight factory planning and the broader tool-model helper module.

## Why This Change Was Made

Move the predicate to the existing lightweight `src/config/model-input.ts` owner, then import it directly from planner, image, shared media, PDF, and model helper callers. Factory coercion remains local, `timeoutMs` alone remains insufficient, and no SDK or configuration surface changes.

## User Impact

No intended behavior change. Tool registration and model selection now share one canonical primary/fallback presence check without pulling heavyweight tool helpers into factory planning.

## Evidence

- Initial exact base: `ef44eab5ed8320cd5a5f34d790cedceffaefc36f`
- Rebased PR base: `bbbcb8b3ff48646983278a1c91e498617faed812`
- Signed head: `8a689b1ef14f4f088784f1c99cd4548951a81996`
- Focused tests: 215 passed across planner, image, shared media, PDF, and model-config helper suites; repeated after rebase.
- Predicate matrix: 17/17 cases passed, including blank primary/fallback values and `timeoutMs`-only false.
- Changed-file gates: formatting, core typecheck, core test typecheck, coercion/deprecation/dead-export guards, plugin boundaries, dependency guards, native-state schema, database-first, media-download, runtime-sidecar, oxlint, auth guards, and import cycles passed.
- Import cycles: 0 runtime value cycles.
- Exact-base planner bundle: 1,018 modules before and after; source input delta +141 bytes; emitted bundle delta -11,690 bytes.
- Autoreview: scoped clean, no accepted/actionable findings, overall 0.97.
- Codex contract check: inspected `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; unrelated to this internal predicate refactor.
- Production LOC: +14/-16 across 6 files (net -2). Tests: +0/-0.
- Current-main overlap: none across the six touched paths immediately before push.

Known proof gap: `pnpm build` completed compilation and reached the final plugin control-plane load probe, which failed because the required shared worktree `node_modules` symlink resolved a stale canonical `@openclaw/ai` dist missing `hasRetryableConnectionErrorCode`. The changed source, typechecks, focused tests, and all directly relevant gates passed; clean CI should own the isolated full-build result.
