### PR TITLE
fix(native): share invoke timeout ownership and gate callbacks

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/AsyncTimeoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AsyncTimeoutTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OpenClawKit
+import Synchronization
 import Testing
 
 private struct ExpectedTimeout: Error {}
@@ -112,6 +113,7 @@ struct AsyncTimeoutTests {
     @Test func `timeout returns when operation ignores cancellation`() async {
         let operation = CancellationIgnoringOperation()
         let cancellation = CancellationProbe()
+        let timeoutCallbacks = Mutex(0)
         let watchdog = Task {
             do {
                 try await Task.sleep(for: .seconds(1))
@@ -122,7 +124,10 @@ struct AsyncTimeoutTests {
         await #expect(throws: ExpectedTimeout.self) {
             try await AsyncTimeout.withTimeout(
                 seconds: 0.05,
-                onTimeout: { ExpectedTimeout() },
+                onTimeout: {
+                    timeoutCallbacks.withLock { $0 += 1 }
+                    return ExpectedTimeout()
+                },
                 operation: {
                     await withTaskCancellationHandler {
                         await operation.run()
@@ -138,12 +143,16 @@ struct AsyncTimeoutTests {
         await operation.release()
         await operation.waitUntilFinished()
         watchdog.cancel()
+        #expect(timeoutCallbacks.withLock { $0 } == 1)
     }
 
     @Test func `successful operation wins`() async throws {
         let result = try await AsyncTimeout.withTimeout(
             seconds: 1,
-            onTimeout: { ExpectedTimeout() },
+            onTimeout: {
+                Issue.record("A successful operation must not invoke the timeout callback")
+                return ExpectedTimeout()
+            },
             operation: { "ready" })
 
         #expect(result == "ready")
@@ -152,7 +161,10 @@ struct AsyncTimeoutTests {
     @Test func `zero timeout preserves unbounded operation semantics`() async throws {
         let result = try await AsyncTimeout.withTimeout(
             seconds: 0,
-            onTimeout: { ExpectedTimeout() },
+            onTimeout: {
+                Issue.record("An unbounded operation must not invoke the timeout callback")
+                return ExpectedTimeout()
+            },
             operation: { "unbounded" })
 
         #expect(result == "unbounded")
@@ -162,7 +174,10 @@ struct AsyncTimeoutTests {
         await #expect(throws: ExpectedOperationFailure.self) {
             try await AsyncTimeout.withTimeout(
                 seconds: 1,
-                onTimeout: { ExpectedTimeout() },
+                onTimeout: {
+                    Issue.record("An operation error must not invoke the timeout callback")
+                    return ExpectedTimeout()
+                },
                 operation: { throw ExpectedOperationFailure() })
         }
     }
@@ -174,7 +189,10 @@ struct AsyncTimeoutTests {
         let task = Task {
             try await AsyncTimeout.withTimeout(
                 seconds: seconds,
-                onTimeout: { ExpectedTimeout() },
+                onTimeout: {
+                    Issue.record("Caller cancellation must not invoke the timeout callback")
+                    return ExpectedTimeout()
+                },
                 operation: {
                     await withTaskCancellationHandler {
                         await operation.run()
@@ -210,7 +228,10 @@ struct AsyncTimeoutTests {
             await entryGate.wait()
             return try await AsyncTimeout.withTimeout(
                 seconds: 1,
-                onTimeout: { ExpectedTimeout() },
+                onTimeout: {
+                    Issue.record("A pre-cancelled caller must not invoke the timeout callback")
+                    return ExpectedTimeout()
+                },
                 operation: {
                     await operationState.markStarted()
                     return "unexpected"

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/AsyncTimeout.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/AsyncTimeout.swift
@@ -21,8 +21,10 @@ private actor AsyncTimeoutRace<T: Sendable> {
         }
     }
 
-    private func resolve(_ outcome: Outcome) {
+    private func resolve(_ outcome: @autoclosure () -> Outcome) {
+        // Timeout factories can log; only evaluate the winner's outcome.
         guard self.outcome == nil else { return }
+        let outcome = outcome()
         self.outcome = outcome
         self.tasks.forEach { $0.cancel() }
         self.tasks.removeAll()
@@ -36,8 +38,8 @@ private actor AsyncTimeoutRace<T: Sendable> {
         self.resolve(.success(value))
     }
 
-    func resolveFailure(_ error: any Error) {
-        self.resolve(.failure(error))
+    func resolveFailure(_ error: @autoclosure @Sendable () -> any Error) {
+        self.resolve(.failure(error()))
     }
 
     private func resume(_ continuation: CheckedContinuation<T, any Error>, with outcome: Outcome) {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession+InvokeTimeout.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession+InvokeTimeout.swift
@@ -1,4 +1,3 @@
-import Foundation
 import OSLog
 
 extension GatewayNodeSession {
@@ -9,76 +8,33 @@ extension GatewayNodeSession {
         onOperationSettled: (@Sendable () async -> Void)? = nil) async -> BridgeInvokeResponse
     {
         let timeoutLogger = Logger(subsystem: "ai.openclaw", category: "node.gateway")
-        let timeout: Int = {
-            if let timeoutMs {
-                return min(max(0, timeoutMs), Self.maxInvokeTimeoutMs)
-            }
-            return Self.defaultInvokeTimeoutMs
-        }()
+        let timeout = timeoutMs.map { min(max(0, $0), Self.maxInvokeTimeoutMs) } ?? Self.defaultInvokeTimeoutMs
         guard timeout > 0 else {
             let response = await onInvoke(request)
             await onOperationSettled?()
             return response
         }
 
-        // Use an explicit latch so timeouts win even if onInvoke blocks (e.g., permission prompts).
-        final class InvokeLatch: @unchecked Sendable {
-            private let lock = NSLock()
-            private var continuation: CheckedContinuation<BridgeInvokeResponse, Never>?
-            private var resumed = false
-
-            func setContinuation(_ continuation: CheckedContinuation<BridgeInvokeResponse, Never>) {
-                self.lock.lock()
-                defer { self.lock.unlock() }
-                self.continuation = continuation
-            }
-
-            func resume(_ response: BridgeInvokeResponse) {
-                let cont: CheckedContinuation<BridgeInvokeResponse, Never>?
-                self.lock.lock()
-                if self.resumed {
-                    self.lock.unlock()
-                    return
-                }
-                self.resumed = true
-                cont = self.continuation
-                self.continuation = nil
-                self.lock.unlock()
-                cont?.resume(returning: response)
-            }
-        }
-
-        let latch = InvokeLatch()
-        var onInvokeTask: Task<Void, Never>?
-        var timeoutTask: Task<Void, Never>?
-        defer {
-            onInvokeTask?.cancel()
-            timeoutTask?.cancel()
-        }
-        let response = await withCheckedContinuation { (cont: CheckedContinuation<BridgeInvokeResponse, Never>) in
-            latch.setContinuation(cont)
-            onInvokeTask = Task.detached {
-                let result = await onInvoke(request)
-                await onOperationSettled?()
-                latch.resume(result)
-            }
-            timeoutTask = Task.detached {
-                do {
-                    try await Task.sleep(nanoseconds: UInt64(timeout) * 1_000_000)
-                } catch {
-                    // Expected when invoke finishes first and cancels the timeout task.
-                    return
-                }
-                guard !Task.isCancelled else { return }
-                timeoutLogger.info("node invoke timeout fired id=\(request.id, privacy: .public)")
-                latch.resume(BridgeInvokeResponse(
-                    id: request.id,
-                    ok: false,
-                    error: OpenClawNodeError(
-                        code: .unavailable,
-                        message: "node invoke timed out")))
-            }
-        }
+        // Keep the wrapper detached: this nonthrowing API historically lets the invoke/timeout
+        // race settle even when its caller is cancelled.
+        let response = await Task.detached {
+            await (try? AsyncTimeout.withTimeoutMs(
+                timeoutMs: timeout,
+                onTimeout: {
+                    timeoutLogger.info("node invoke timeout fired id=\(request.id, privacy: .public)")
+                    return CancellationError()
+                },
+                operation: {
+                    let response = await onInvoke(request)
+                    await onOperationSettled?()
+                    return response
+                })) ?? BridgeInvokeResponse(
+                id: request.id,
+                ok: false,
+                error: OpenClawNodeError(
+                    code: .unavailable,
+                    message: "node invoke timed out"))
+        }.value
         timeoutLogger
             .info("node invoke race resolved id=\(request.id, privacy: .public) ok=\(response.ok, privacy: .public)")
         return response

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -3357,6 +3357,30 @@ struct GatewayNodeSessionTests {
     }
 
     @Test
+    func `positive invoke timeout admits work from a pre cancelled caller`() async {
+        let entry = AsyncGate()
+        let task = Task {
+            await entry.wait()
+            return await GatewayNodeSession.invokeWithTimeout(
+                request: BridgeInvokeRequest(id: "isolated", command: "x", paramsJSON: nil),
+                timeoutMs: 2000,
+                onInvoke: { _ in
+                    BridgeInvokeResponse(
+                        id: "isolated-response",
+                        ok: true,
+                        payloadJSON: #"{"settled":true}"#)
+                })
+        }
+
+        task.cancel()
+        await entry.release()
+        let response = await task.value
+
+        #expect(response.id == "isolated-response")
+        #expect(response.payloadJSON == #"{"settled":true}"#)
+    }
+
+    @Test
     func `invoke with timeout zero disables timeout`() async {
         let request = BridgeInvokeRequest(id: "1", command: "x", paramsJSON: nil)
         let response = await GatewayNodeSession.invokeWithTimeout(


### PR DESCRIPTION
Native Gateway invocation duplicated the shared AsyncTimeout race with a private latch, lock, continuation and racer handles. Delegate that lifecycle to AsyncTimeout while retaining the detached boundary that isolates admitted invocation from caller cancellation.

The review found a real shared-owner defect: onTimeout was evaluated before the actor decided whether timeout won. A losing timer could therefore log a false timeout after success. Keep failure construction lazy through the actor's existing winner check. Public timeout APIs, operation-owned responses, nonpositive timeout behavior and late settlement remain unchanged.

The shared timeout actor now evaluates the error factory only after its existing winner check. A losing timer therefore cannot emit the Gateway's timeout diagnostic. The invoke wrapper still runs detached, preserves exact responses, and retains late operation settlement.

A compiled Swift fixture uses the exact production owner and its existing methods. Both versions compile; the baseline executable exits 1 on the callback assertions, and the repaired executable exits 0.

| Actor ordering | Baseline factory calls | Repaired factory calls | Returned result |
| --- | ---: | ---: | --- |
| Success settles, then timeout contender arrives | 1 | 0 | Original success |
| Operation error settles, then timeout contender arrives | 1 | 0 | Original operation error |
| Timeout settles before success | 1 | 1 | Timeout error |

The 12-case Gateway executable also produces byte-identical baseline and repaired results for ordinary success, timeout limits, operation errors, cancellation before/during/after invocation, and late settlement. This is local owner-level proof with minimal bridge type stand-ins; it does not claim a live Gateway connection or externally scheduled app race.

Production delta: **−42 physical lines** across the complete refactor and fix. Tests: **+45 physical lines**. Shared/macOS test targets compile, and unsigned iOS Debug and Release builds pass with the installed Xcode 27 beta. The closed desktop sandbox prevents SwiftPM's nested test bootstrap, so **exact-head hosted native test execution remains required before merge**. Earlier green CI predates the repair and is not used as proof for its changed tests.

The complete four-file changed gate passes, including Swift lint and1,036 script-test executions; those script tests are not presented as native Swift execution. Fresh managed high/P2 review completed two clean passes with source and evidence guards unchanged. The final runtime probe and both iOS builds bind the final source bytes. Earlier shared/macOS test-target builds precede a comment-only placement correction.

Xcode regenerated the ignored shared Package.resolved from its standalone graph to the app graph. All five shared versions/revisions match the retained workspace state; tracked dependency declarations and source remained unchanged. The Debug and overlapping changed-gate receipts retain that generated-file difference, and no byte-identical dependency claim is made for them. Release and final review guards remained unchanged. No unsigned build was launched.

Disposition of the latest ClawSweeper finding and rank-up moves: callback evaluation now occurs in the atomic winning transition; the exact-source deterministic fixture proves losing factories are not called; maintained public tests additionally assert callback counts; hosted native CI must pass on the repaired head before landing. Earlier green CI predates the repair. No extra public API, test-only production seam, timeout increase or sandbox relaxation was added.


Final landing proof: the repaired head `c19305cd2e08e7e53ea022c1a2a771401d0f9ff7` passed all39 CI jobs (19 success,20 intentional skips) in [CI33534427351](https://github.com/openclaw/openclaw/actions/runs/33534427351), including the required aggregate gate. Root read the actual [native test log](https://github.com/openclaw/openclaw/actions/runs/33534427351/job/99945332462): all six shared timeout declarations, both parameterized cancellation cases, Gateway response/timeout/operation cancellation/pre-cancelled caller/zero and hostile timeout cases, and late receipt settlement passed. Native release and iOS builds also passed. This closes the earlier local sandbox execution gap without weakening isolation. The latest17:01UTC ClawSweeper review reports the callback-race finding fixed; its remaining CI condition and rank-up move are now satisfied. Production net−42; tests+45. No external Gateway connection or live-device run is claimed.
