### PR TITLE
fix: publish verified plugin npm artifacts without rebuilding

### DIFF
--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -1513,24 +1513,6 @@ jobs:
           esac
 
       - name: Setup trusted publication dependencies
-        if: steps.publication_evidence.outputs.publish_route == 'npm-token-bootstrap' || steps.publication_evidence.outputs.publish_route == 'npm-readback'
-        uses: ./.github/actions/setup-node-env
-        with:
-          cache-mode: restore
-          node-version: ${{ env.NODE_VERSION }}
-          install-bun: "false"
-
-      - name: Checkout OIDC publication target
-        if: steps.publication_evidence.outputs.publish_route == 'npm-oidc'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          ref: ${{ needs.preview_plugins_npm.outputs.ref_revision }}
-          path: .publication-target
-          fetch-depth: 1
-
-      - name: Setup trusted OIDC packaging dependencies
-        if: steps.publication_evidence.outputs.publish_route == 'npm-oidc'
         uses: ./.github/actions/setup-node-env
         with:
           cache-mode: restore
@@ -1556,20 +1538,40 @@ jobs:
         if: steps.publication_evidence.outputs.publish_route == 'npm-oidc' && steps.npm_package_version.outputs.already_published != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          OPENCLAW_NPM_PUBLISH_AUTH_MODE: trusted-publisher
-          OPENCLAW_PLUGIN_NPM_PUBLISH_TAG: ${{ inputs.npm_dist_tag == 'extended-stable' && inputs.npm_dist_tag || '' }}
+          TARBALL_PATH: ${{ steps.publication_evidence.outputs.tarball_path }}
+          PUBLISH_TAG: ${{ steps.publication_evidence.outputs.publish_tag }}
           OPENCLAW_RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}
           OPENCLAW_RELEASE_PUBLISH_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
           OPENCLAW_RELEASE_PUBLISH_REF: ${{ inputs.release_publish_branch }}
           OPENCLAW_RELEASE_PUBLISH_FULL_REF: ${{ inputs.release_publish_full_ref }}
           OPENCLAW_RELEASE_PUBLISH_PARENT_STATE_POLICY: ${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active-or-failure' || 'manual-recovery') || '' }}
-          OPENCLAW_RELEASE_TOOLING_ALLOW_PREVALIDATED_REF: "true"
           OPENCLAW_RELEASE_TOOLING_FULL_REF: ${{ github.ref }}
-          OPENCLAW_RELEASE_TOOLING_IDENTITY_REQUIRED: "true"
           OPENCLAW_RELEASE_TOOLING_REF: ${{ github.ref_name }}
           OPENCLAW_RELEASE_TOOLING_REPOSITORY: ${{ github.repository }}
           OPENCLAW_RELEASE_TOOLING_SHA: ${{ github.workflow_sha }}
-        run: bash scripts/plugin-npm-publish.sh --repo-root .publication-target --publish "${{ matrix.plugin.packageDir }}"
+        run: |
+          set -euo pipefail
+          unset NODE_AUTH_TOKEN NPM_TOKEN NODE_OPTIONS
+          # Publish the attested bytes; rebuilding here loses the candidate's patched install.
+          node scripts/release-tooling-identity.mjs verify \
+            --repository "$OPENCLAW_RELEASE_TOOLING_REPOSITORY" \
+            --workflow-ref "$OPENCLAW_RELEASE_TOOLING_REF" \
+            --workflow-full-ref "$OPENCLAW_RELEASE_TOOLING_FULL_REF" \
+            --workflow-sha "$OPENCLAW_RELEASE_TOOLING_SHA" \
+            --release-publish-run-id "$OPENCLAW_RELEASE_PUBLISH_RUN_ID" \
+            --release-publish-run-attempt "$OPENCLAW_RELEASE_PUBLISH_RUN_ATTEMPT" \
+            --release-publish-ref "$OPENCLAW_RELEASE_PUBLISH_REF" \
+            --release-publish-full-ref "$OPENCLAW_RELEASE_PUBLISH_FULL_REF" \
+            --release-publish-parent-state-policy "$OPENCLAW_RELEASE_PUBLISH_PARENT_STATE_POLICY" \
+            --allow-prevalidated-ref
+          NPM_CONFIG_USERCONFIG=/dev/null \
+            NPM_CONFIG_GLOBALCONFIG=/dev/null \
+            NPM_CONFIG_REGISTRY=https://registry.npmjs.org/ \
+            timeout --signal=TERM --kill-after=10s 300s npm publish "$TARBALL_PATH" \
+              --access public \
+              --ignore-scripts \
+              --provenance \
+              --tag "$PUBLISH_TAG"
 
       - name: Verify OIDC published runtime
         if: steps.publication_evidence.outputs.publish_route == 'npm-oidc'

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2305,13 +2305,21 @@ describe("package acceptance workflow", () => {
       OPENCLAW_RELEASE_PUBLISH_FULL_REF: "${{ inputs.release_publish_full_ref }}",
       OPENCLAW_RELEASE_PUBLISH_PARENT_STATE_POLICY:
         "${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active-or-failure' || 'manual-recovery') || '' }}",
-      OPENCLAW_RELEASE_TOOLING_ALLOW_PREVALIDATED_REF: "true",
       OPENCLAW_RELEASE_TOOLING_FULL_REF: "${{ github.ref }}",
-      OPENCLAW_RELEASE_TOOLING_IDENTITY_REQUIRED: "true",
       OPENCLAW_RELEASE_TOOLING_REF: "${{ github.ref_name }}",
       OPENCLAW_RELEASE_TOOLING_REPOSITORY: "${{ github.repository }}",
       OPENCLAW_RELEASE_TOOLING_SHA: "${{ github.workflow_sha }}",
     });
+
+    expect(oidcPublish.env).toMatchObject({
+      TARBALL_PATH: "${{ steps.publication_evidence.outputs.tarball_path }}",
+      PUBLISH_TAG: "${{ steps.publication_evidence.outputs.publish_tag }}",
+    });
+    expect(oidcPublish.run).toContain("node scripts/release-tooling-identity.mjs verify");
+    expect(oidcPublish.run).toContain(
+      '--release-publish-parent-state-policy "$OPENCLAW_RELEASE_PUBLISH_PARENT_STATE_POLICY"',
+    );
+    expect(oidcPublish.run).not.toContain("plugin-npm-publish.sh");
 
     const bootstrapPublish = workflowStep(pluginPublishJob, "Publish approved bootstrap tarball");
     expect(bootstrapPublish.env).toMatchObject({
@@ -2476,10 +2484,14 @@ describe("package acceptance workflow", () => {
       const script = releasePublishOrchestration(
         workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish"),
       ).run;
-      if (!script) throw new Error("Missing publish orchestration");
+      if (!script) {
+        throw new Error("Missing publish orchestration");
+      }
       const start = script.indexOf('openclaw_result=""');
       const end = script.indexOf('if [[ ( -n "${openclaw_npm_run_id}"', start);
-      if (start < 0 || end < start) throw new Error("Missing native publication stage");
+      if (start < 0 || end < start) {
+        throw new Error("Missing native publication stage");
+      }
       const root = tempDirs.make("android-detached-publish-");
       const result = spawnSync(
         "bash",
@@ -2538,7 +2550,9 @@ printf 'core_failed=%s\n' "$failed"
         expect(summary).toContain("completion not awaited");
         expect(summary).toContain("https://github.com/openclaw/openclaw/actions/runs/456");
       }
-      if (!assetsVerified) expect(summary).not.toContain("releases/download");
+      if (!assetsVerified) {
+        expect(summary).not.toContain("releases/download");
+      }
     },
   );
 
@@ -6784,7 +6798,9 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
           jobName === "run_slack_desktop",
         );
       }
-      if (jobName === "run_web_ui_chat") continue;
+      if (jobName === "run_web_ui_chat") {
+        continue;
+      }
       const install = workflowStep(job, "Install Crabbox CLI").run ?? "";
       const gitCalls = install
         .split("\n")

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -1,4 +1,7 @@
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { PLUGIN_NPM_RELEASE_AUTHORITY_PATHS } from "../../scripts/lib/plugin-publication-candidates.ts";
@@ -118,21 +121,10 @@ describe("plugin npm extended-stable workflow", () => {
     expect(raw.match(/--npm-dist-tag "\$\{NPM_DIST_TAG\}"/gu)).toHaveLength(2);
     const expectedOverride =
       "${{ inputs.npm_dist_tag == 'extended-stable' && inputs.npm_dist_tag || '' }}";
-    for (const name of [
-      "Preview publish command",
-      "Preview npm pack contents",
-      "Publish with trusted publisher",
-    ]) {
-      expect(
-        step(
-          parsed.jobs?.[
-            name === "Publish with trusted publisher"
-              ? "publish_plugins_npm"
-              : "preview_plugin_pack"
-          ],
-          name,
-        ).env,
-      ).toMatchObject({ OPENCLAW_PLUGIN_NPM_PUBLISH_TAG: expectedOverride });
+    for (const name of ["Preview publish command", "Preview npm pack contents"]) {
+      expect(step(parsed.jobs?.preview_plugin_pack, name).env).toMatchObject({
+        OPENCLAW_PLUGIN_NPM_PUBLISH_TAG: expectedOverride,
+      });
     }
   });
 
@@ -155,10 +147,112 @@ describe("plugin npm extended-stable workflow", () => {
     ).toContain(".release-tooling/scripts/plugin-npm-publish.sh");
 
     const publish = step(parsed.jobs?.publish_plugins_npm, "Publish with trusted publisher");
-    expect(publish.run).toContain("scripts/plugin-npm-publish.sh");
-    expect(publish.run).toContain("--repo-root .publication-target");
+    expect(publish.env).toMatchObject({
+      TARBALL_PATH: "${{ steps.publication_evidence.outputs.tarball_path }}",
+      PUBLISH_TAG: "${{ steps.publication_evidence.outputs.publish_tag }}",
+    });
+    expect(publish.run).not.toContain("plugin-npm-publish.sh");
     expect(publish["working-directory"]).toBeUndefined();
   });
+
+  it.each([
+    { publishTag: "latest", identityExit: 0 },
+    { publishTag: "beta", identityExit: 0 },
+    { publishTag: "extended-stable", identityExit: 0 },
+    { publishTag: "latest", identityExit: 17 },
+  ])(
+    "publishes the sealed artifact without a source install: $publishTag / identity $identityExit",
+    ({ publishTag, identityExit }) => {
+      const root = mkdtempSync(join(tmpdir(), "plugin-oidc-artifact-"));
+      try {
+        const bin = join(root, "bin");
+        mkdirSync(bin);
+        mkdirSync(join(root, "scripts"));
+        writeFileSync(
+          join(root, "scripts/plugin-npm-publish.sh"),
+          '#!/bin/bash\necho "source rebuild requires an uninstalled candidate dependency tree" >&2\nexit 93\n',
+        );
+        const events = join(root, "events.jsonl");
+        const tarball = join(root, "verified artifact.tgz");
+        writeFileSync(tarball, "sealed preflight bytes");
+        for (const command of ["node", "npm"]) {
+          writeFileSync(
+            join(bin, command),
+            `#!${process.execPath}
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.EVENTS, JSON.stringify({ command: ${JSON.stringify(command)}, args, ...( ${JSON.stringify(command)} === "npm" ? { bytes: fs.readFileSync(args[1], "utf8"), token: Boolean(process.env.NPM_TOKEN || process.env.NODE_AUTH_TOKEN) } : {}) }) + "\\n");
+process.exit(${JSON.stringify(command)} === "node" ? Number(process.env.IDENTITY_EXIT) : 0);
+`,
+            { mode: 0o755 },
+          );
+        }
+        writeFileSync(join(bin, "timeout"), '#!/bin/bash\nshift 3\nexec "$@"\n', {
+          mode: 0o755,
+        });
+        const publish = step(
+          workflow().jobs?.publish_plugins_npm,
+          "Publish with trusted publisher",
+        );
+        const result = spawnSync(
+          "/bin/bash",
+          [
+            "-e",
+            "-o",
+            "pipefail",
+            "-c",
+            publish.run!.replaceAll("${{ matrix.plugin.packageDir }}", "extensions/fixture"),
+          ],
+          {
+            cwd: root,
+            encoding: "utf8",
+            env: {
+              PATH: `${bin}:/usr/bin:/bin`,
+              ...publish.env,
+              EVENTS: events,
+              IDENTITY_EXIT: String(identityExit),
+              TARBALL_PATH: tarball,
+              PUBLISH_TAG: publishTag,
+              NPM_TOKEN: "fixture-token-must-not-reach-npm",
+              NODE_AUTH_TOKEN: "fixture-token-must-not-reach-npm",
+            },
+          },
+        );
+        expect(result.status, result.stderr).toBe(identityExit);
+        const calls = readFileSync(events, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        expect(calls[0].command).toBe("node");
+        expect(calls[0].args.slice(0, 2)).toEqual([
+          "scripts/release-tooling-identity.mjs",
+          "verify",
+        ]);
+        if (identityExit) {
+          expect(calls).toHaveLength(1);
+        } else {
+          expect(calls).toHaveLength(2);
+          expect(calls[1]).toEqual({
+            command: "npm",
+            args: [
+              "publish",
+              tarball,
+              "--access",
+              "public",
+              "--ignore-scripts",
+              "--provenance",
+              "--tag",
+              publishTag,
+            ],
+            bytes: "sealed preflight bytes",
+            token: false,
+          });
+        }
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("trusts only the canonical monthly branch at the exact checked-out SHA", () => {
     const trusted = step(
@@ -263,7 +357,7 @@ describe("plugin npm extended-stable workflow", () => {
     expect(prepare.run).toContain(
       "fs.writeFileSync(process.argv[3], `${JSON.stringify(pack, null, 2)}\\n`)",
     );
-    expect(prepare.run).toContain('path.join(process.env.ARTIFACT_DIR, "preflight-manifest.json")');
+    expect(prepare.run).toContain('join(process.env.ARTIFACT_DIR, "preflight-manifest.json")');
     expect(prepare.run).toContain('kind: "openclaw-plugin-npm-preflight"');
     expect(prepare.run).toContain('mode: "preflight-only"');
     expect(prepare.run).toContain("source_package_json_sha256=");
@@ -460,17 +554,17 @@ describe("plugin npm extended-stable workflow", () => {
       /timeout[^\n]*git|(?:^|\s)git (?:fetch|rev-parse|merge-base|for-each-ref|show)\b/mu,
     );
     expect(source.match(/timeout=120/gu)).toHaveLength(5);
-    expect(npmPublishLines).toEqual([
-      '            timeout --signal=TERM --kill-after=10s 300s npm publish "$TARBALL_PATH" \\',
-    ]);
+    expect(npmPublishLines).toHaveLength(2);
+    expect(
+      npmPublishLines.every((line) => line.includes("timeout --signal=TERM --kill-after=10s 300s")),
+    ).toBe(true);
   });
 
   it("publishes extended-stable with OIDC only and verifies every package tag", () => {
     const parsed = workflow();
     const publish = step(parsed.jobs?.publish_plugins_npm, "Publish with trusted publisher");
-    expect(publish.env).toMatchObject({
-      OPENCLAW_NPM_PUBLISH_AUTH_MODE: "trusted-publisher",
-    });
+    expect(publish.run).toContain("unset NODE_AUTH_TOKEN NPM_TOKEN NODE_OPTIONS");
+    expect(publish.run).toContain("NPM_CONFIG_USERCONFIG=/dev/null");
     expect(publish.env?.NODE_AUTH_TOKEN).toBeUndefined();
     expect(publish.env?.NPM_TOKEN).toBeUndefined();
     const bootstrapCheck = step(
@@ -537,20 +631,16 @@ describe("plugin npm extended-stable workflow", () => {
       path: ".release-tooling",
     });
     expect(
-      step(parsed.jobs?.publish_plugins_npm, "Setup trusted publication dependencies").if,
-    ).toContain("npm-token-bootstrap");
-    expect(
-      step(parsed.jobs?.publish_plugins_npm, "Setup trusted publication dependencies").if,
-    ).toContain("npm-readback");
-    expect(step(parsed.jobs?.publish_plugins_npm, "Checkout OIDC publication target").if).toContain(
-      "npm-oidc",
-    );
-    expect(
-      step(parsed.jobs?.publish_plugins_npm, "Checkout OIDC publication target").with?.path,
-    ).toBe(".publication-target");
-    expect(
-      step(parsed.jobs?.publish_plugins_npm, "Setup trusted OIDC packaging dependencies").uses,
+      step(parsed.jobs?.publish_plugins_npm, "Setup trusted publication dependencies").uses,
     ).toBe("./.github/actions/setup-node-env");
+    expect(
+      step(parsed.jobs?.publish_plugins_npm, "Setup trusted publication dependencies").if,
+    ).toBeUndefined();
+    expect(
+      parsed.jobs?.publish_plugins_npm?.steps?.some(
+        (entry) => entry.with?.path === ".publication-target",
+      ),
+    ).toBe(false);
     expect(parsed.jobs?.reconcile_plugins_npm).toBeUndefined();
     expect(readFileSync(workflowPath, "utf8")).not.toContain(
       'npm dist-tag add "${PACKAGE_NAME}@${PACKAGE_VERSION}" extended-stable',


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Matrix plugin publication fails after successful preflight because the npm publisher rebuilds the package in a checkout without its pnpm dependency metadata. The observed release job failed opening `.publication-target/node_modules/.modules.yaml` before publishing.

## Why This Change Was Made

The OIDC publisher now publishes the immutable tarball already verified by the publication-evidence owner. This keeps the exact patched dependency bytes from preflight and removes the redundant candidate checkout and rebuild. Artifact verification continues to bind the candidate SHA, source package hash, publisher policy, successful producer job, archive digest, package identity, and tarball inventory.

The final tooling identity check remains immediately before publication, with OIDC authentication, ignored lifecycle scripts, provenance, and the attested dist-tag. Token bootstrap and registry readback retain their existing routes. Ahead beta tags are untouched; this OIDC route does not acquire token-based tag-repair authority. npm provenance records the trusted workflow identity and the tarball digest; the separate immutable evidence binds the release source identity.

## User Impact

Release maintainers can publish plugins with workspace-patched dependencies from the package that passed preflight. Product source and the frozen release candidate are unchanged.

## Evidence

- Hosted failure: [Matrix npm publisher](https://github.com/openclaw/openclaw/actions/runs/33522549393/job/99907801319), following successful runtime build and package-lock validation.
- Executable regression fails before the fix when the publisher attempts a source rebuild; after the fix it publishes the exact sealed tarball with `latest`, `beta`, and `extended-stable`, clears token environment variables, and refuses publication when the final identity check fails.
- Both owning workflow test files pass: 281 tests. Focused formatting, lint, and diff checks pass.
- The actual Matrix artifact has 4,532 inventory entries verified against the sealed manifest. Its 7,734,602-byte tarball passes byte-for-byte through installed npm's `libnpmpack`; SHA-256 `d295140a6869fe7fae60abf019a6f80f20d61210202e8e36dea6cf3d346c8754` remains unchanged. npm `publish`, `libnpmpack`, and `libnpmpublish` source were inspected for tarball and provenance behavior.
- Authenticated publication is intentionally reserved for the canonical release recovery after this tooling change lands; no test published a package.
- Structured autoreview reported scoped-clean with no findings in the requested scope. Workflow delta is +25/-23 lines; tests also receive four mechanical pre-existing missing-brace lint fixes.
