### PR TITLE
fix(memory): preserve wiki results in combined search under load

### DIFF
--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -397,11 +397,14 @@ Contract notes:
 
 Memory prompt supplement builders receive optional `agentId`,
 `agentSessionKey`, and `sandboxed` context. Memory corpus supplement `search`
-and `get` calls receive optional `agentId` and `sandboxed` context. Plugins with
-agent-owned storage should resolve that storage for each call instead of
-capturing one global path during registration. If an agent id is required but
-missing in a multi-agent operation, fail closed rather than choosing an
-arbitrary agent.
+and `get` calls receive optional `agentId`, `agentSessionKey`, `sandboxed`, and
+caller-owned `signal` context. Supplements that perform I/O should check the
+signal before starting new work and reject with its reason after cancellation;
+the host keeps the existing per-corpus timeout warning when a deadline wins.
+Plugins with agent-owned storage should resolve that storage for each call
+instead of capturing one global path during registration. If an agent id is
+required but missing in a multi-agent operation, fail closed rather than
+choosing an arbitrary agent.
 
 Use `registerMemoryPromptPreparation(...)` when prompt text depends on async
 plugin state. The callback runs once before each full agent prompt and receives

--- a/extensions/memory-core/src/memory-corpus.ts
+++ b/extensions/memory-core/src/memory-corpus.ts
@@ -214,10 +214,9 @@ export async function searchMemoryCorpusSupplements(params: {
   sandboxed?: boolean;
   signal: AbortSignal;
 }): Promise<MemoryCorpusAttempt<MemoryCorpusSearchResult[]>> {
-  const { signal, ...query } = params;
   return await settleMemorySupplements({
-    signal,
-    run: async ({ supplement }) => await supplement.search(query),
+    signal: params.signal,
+    run: async ({ supplement }) => await supplement.search(params),
     merge: (results) =>
       results
         .flat()
@@ -235,11 +234,10 @@ export async function readMemoryCorpusSupplements(params: {
   sandboxed?: boolean;
   signal: AbortSignal;
 }): Promise<MemoryCorpusAttempt<MemorySupplementReadResult | null>> {
-  const { signal, ...query } = params;
   return await settleMemorySupplements({
-    signal,
+    signal: params.signal,
     run: async ({ supplement }) => {
-      const result = await supplement.get(query);
+      const result = await supplement.get(params);
       if (!result) {
         return null;
       }

--- a/extensions/memory-core/src/memory-get-corpus.test.ts
+++ b/extensions/memory-core/src/memory-get-corpus.test.ts
@@ -300,6 +300,7 @@ describe("memory_get corpus outcomes", () => {
         agentId: "marketing-agent",
         agentSessionKey: "agent:marketing-agent:main",
         sandboxed: true,
+        signal: expect.any(AbortSignal),
       });
     },
   );

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -447,6 +447,7 @@ describe("memory tools", () => {
         agentId: "marketing-agent",
         agentSessionKey: "agent:marketing-agent:main",
         sandboxed: true,
+        signal: expect.any(AbortSignal),
       });
     },
   );
@@ -614,6 +615,7 @@ describe("memory tools", () => {
     vi.useFakeTimers();
     try {
       let searchCalls = 0;
+      let supplementSignal: AbortSignal | undefined;
       setMemorySearchImpl(async () => {
         searchCalls += 1;
         return [
@@ -628,7 +630,10 @@ describe("memory tools", () => {
         ];
       });
       registerMemoryCorpusSupplement("memory-wiki", {
-        search: async () => await new Promise(() => {}),
+        search: async (input) => {
+          supplementSignal = (input as typeof input & { signal?: AbortSignal }).signal;
+          return await new Promise(() => {});
+        },
         get: async () => null,
       });
 
@@ -651,6 +656,7 @@ describe("memory tools", () => {
         ],
         warning: expect.stringContaining("Wiki corpus unavailable"),
       });
+      expect(supplementSignal?.aborted).toBe(true);
 
       const memoryResult = await tool.execute("call_memory_after_stalled_wiki", {
         query: "alpha",

--- a/extensions/memory-wiki/src/bounded-walk.ts
+++ b/extensions/memory-wiki/src/bounded-walk.ts
@@ -10,6 +10,7 @@ const MEMORY_WIKI_WALK_MAX_ENTRIES = 20_000;
 type MemoryWikiWalkLimits = {
   maxDepth?: number;
   maxEntries?: number;
+  signal?: AbortSignal;
   entryFilter?: RootWalkOptions["entryFilter"];
   onDirectoryError?: RootWalkOptions["onDirectoryError"];
 };
@@ -26,12 +27,14 @@ export async function walkMemoryWikiDirectory(
       maxEntries: limits.maxEntries ?? MEMORY_WIKI_WALK_MAX_ENTRIES,
       symlinkPolicy: "skip",
       limitBehavior: "throw",
+      ...(limits.signal ? { signal: limits.signal } : {}),
       ...(limits.entryFilter ? { entryFilter: limits.entryFilter } : {}),
       ...(limits.onDirectoryError ? { onDirectoryError: limits.onDirectoryError } : {}),
     })) {
       entries.push(entry);
     }
   } catch (error) {
+    limits.signal?.throwIfAborted();
     const code = (error as NodeJS.ErrnoException).code;
     if (code === "not-file" || code === "not-found") {
       return [];

--- a/extensions/memory-wiki/src/compiled-cache.integration.test.ts
+++ b/extensions/memory-wiki/src/compiled-cache.integration.test.ts
@@ -193,6 +193,45 @@ describe("Memory Wiki compiled cache lifecycle", () => {
     blobStoreEnv = {};
   });
 
+  it("stops source-generation reads after the caller deadline (#104719)", async () => {
+    const { rootDir } = await createPersistentVault({ initialize: true });
+    const pageCount = 64;
+    await Promise.all(
+      Array.from({ length: pageCount }, (_, index) =>
+        fs.writeFile(
+          path.join(rootDir, "sources", `generation-pad-${String(index).padStart(2, "0")}.md`),
+          `# Generation Pad ${index}\n`,
+          "utf8",
+        ),
+      ),
+    );
+    const controller = new AbortController();
+    const deadlineError = new Error("test source-generation deadline");
+    const originalReadFile = fs.readFile.bind(fs);
+    let sourceReads = 0;
+    const readFile = vi
+      .spyOn(fs, "readFile")
+      .mockImplementation(async (...args: Parameters<typeof fs.readFile>) => {
+        const target = typeof args[0] === "string" ? path.basename(args[0]) : "";
+        if (target.startsWith("generation-pad-")) {
+          sourceReads += 1;
+          if (sourceReads === 8) {
+            controller.abort(deadlineError);
+          }
+        }
+        return await originalReadFile(...args);
+      });
+
+    try {
+      await expect(resolveMemoryWikiVaultSourceGeneration(rootDir, controller.signal)).rejects.toBe(
+        deadlineError,
+      );
+      expect(sourceReads).toBeLessThan(pageCount);
+    } finally {
+      readFile.mockRestore();
+    }
+  });
+
   it("round-trips compile through async preparation and claim query after restart", async () => {
     const { rootDir, config } = await createPersistentVault({
       initialize: true,

--- a/extensions/memory-wiki/src/corpus-supplement.test.ts
+++ b/extensions/memory-wiki/src/corpus-supplement.test.ts
@@ -38,6 +38,7 @@ describe("memory-wiki corpus supplement", () => {
     );
     const getAppConfig = vi.fn(() => appConfig);
     const supplement = createWikiCorpusSupplement({ resolveConfig, getAppConfig });
+    const controller = new AbortController();
 
     await supplement.search({
       query: "support handbook",
@@ -45,6 +46,7 @@ describe("memory-wiki corpus supplement", () => {
       agentId: "support",
       agentSessionKey: "agent:support:main",
       sandboxed: true,
+      signal: controller.signal,
     });
     await supplement.get({
       lookup: "marketing-plan",
@@ -53,6 +55,7 @@ describe("memory-wiki corpus supplement", () => {
       agentId: "marketing",
       agentSessionKey: "agent:marketing:main",
       sandboxed: false,
+      signal: controller.signal,
     });
 
     expect(resolveConfig).toHaveBeenNthCalledWith(1, "support", appConfig);
@@ -72,6 +75,7 @@ describe("memory-wiki corpus supplement", () => {
       maxResults: 4,
       searchBackend: "local",
       searchCorpus: "wiki",
+      signal: controller.signal,
     });
     expect(queryMocks.getMemoryWikiPage).toHaveBeenCalledWith({
       config: expect.objectContaining({
@@ -89,6 +93,7 @@ describe("memory-wiki corpus supplement", () => {
       lineCount: 8,
       searchBackend: "local",
       searchCorpus: "wiki",
+      signal: controller.signal,
     });
   });
 

--- a/extensions/memory-wiki/src/corpus-supplement.ts
+++ b/extensions/memory-wiki/src/corpus-supplement.ts
@@ -14,6 +14,7 @@ export function createWikiCorpusSupplement(params: {
       agentId?: string;
       agentSessionKey?: string;
       sandboxed?: boolean;
+      signal?: AbortSignal;
     }) => {
       const appConfig = params.getAppConfig();
       const config = params.resolveConfig(input.agentId, appConfig);
@@ -27,6 +28,7 @@ export function createWikiCorpusSupplement(params: {
         maxResults: input.maxResults,
         searchBackend: "local",
         searchCorpus: "wiki",
+        ...(input.signal ? { signal: input.signal } : {}),
       });
     },
     get: async (input: {
@@ -36,6 +38,7 @@ export function createWikiCorpusSupplement(params: {
       agentId?: string;
       agentSessionKey?: string;
       sandboxed?: boolean;
+      signal?: AbortSignal;
     }) => {
       const appConfig = params.getAppConfig();
       const config = params.resolveConfig(input.agentId, appConfig);
@@ -50,6 +53,7 @@ export function createWikiCorpusSupplement(params: {
         lineCount: input.lineCount,
         searchBackend: "local",
         searchCorpus: "wiki",
+        ...(input.signal ? { signal: input.signal } : {}),
       });
     },
   };

--- a/extensions/memory-wiki/src/log.ts
+++ b/extensions/memory-wiki/src/log.ts
@@ -46,11 +46,16 @@ export async function appendMemoryWikiLog(
 
 export async function loadMemoryWikiVaultIdentity(
   vaultRoot: string,
+  signal?: AbortSignal,
 ): Promise<MemoryWikiVaultIdentity> {
   let raw: string;
   try {
-    raw = await fs.readFile(path.join(vaultRoot, ".openclaw-wiki", "log.jsonl"), "utf8");
+    raw = await fs.readFile(path.join(vaultRoot, ".openclaw-wiki", "log.jsonl"), {
+      encoding: "utf8",
+      signal,
+    });
   } catch (error) {
+    signal?.throwIfAborted();
     if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       return {
         vaultGeneration: null,
@@ -124,11 +129,14 @@ export async function loadMemoryWikiVaultIdentity(
   };
 }
 
-export async function resolveMemoryWikiVaultSourceGeneration(vaultRoot: string): Promise<string> {
+export async function resolveMemoryWikiVaultSourceGeneration(
+  vaultRoot: string,
+  signal?: AbortSignal,
+): Promise<string> {
   const files = (
     await Promise.all(
       COMPILED_SOURCE_DIRECTORIES.map(async (relativeDir) => {
-        const entries = await walkMemoryWikiDirectory(vaultRoot, relativeDir);
+        const entries = await walkMemoryWikiDirectory(vaultRoot, relativeDir, { signal });
         return entries
           .filter((entry) => entry.kind === "file" && entry.relativePath.endsWith(".md"))
           .map((entry) => {
@@ -145,26 +153,34 @@ export async function resolveMemoryWikiVaultSourceGeneration(vaultRoot: string):
     .toSorted((left, right) => left.relativePath.localeCompare(right.relativePath));
   const hash = createHash("sha256");
   for (const file of files) {
+    signal?.throwIfAborted();
     const relativePath = Buffer.from(file.relativePath);
     const pathLength = Buffer.allocUnsafe(4);
     pathLength.writeUInt32BE(relativePath.byteLength);
-    const contentDigest = createHash("sha256")
-      .update(await fs.readFile(file.absolutePath))
-      .digest();
+    let content: Buffer;
+    try {
+      content = await fs.readFile(file.absolutePath, { signal });
+    } catch (error) {
+      signal?.throwIfAborted();
+      throw error;
+    }
+    const contentDigest = createHash("sha256").update(content).digest();
     hash.update(pathLength).update(relativePath).update(contentDigest);
   }
+  signal?.throwIfAborted();
   return hash.digest("hex");
 }
 
 export async function loadMemoryWikiValidatedVaultIdentity(
   vaultRoot: string,
+  signal?: AbortSignal,
 ): Promise<MemoryWikiVaultIdentity> {
-  const identity = await loadMemoryWikiVaultIdentity(vaultRoot);
+  const identity = await loadMemoryWikiVaultIdentity(vaultRoot, signal);
   if (!identity.compiledCachePublicationId || !identity.compiledCacheSourceGeneration) {
     return identity;
   }
   if (
-    (await resolveMemoryWikiVaultSourceGeneration(vaultRoot)) ===
+    (await resolveMemoryWikiVaultSourceGeneration(vaultRoot, signal)) ===
     identity.compiledCacheSourceGeneration
   ) {
     return identity;
@@ -176,12 +192,12 @@ export async function loadMemoryWikiValidatedVaultIdentity(
   };
 }
 
-async function loadMemoryWikiVaultGeneration(vaultRoot: string): Promise<string | null> {
-  return (await loadMemoryWikiVaultIdentity(vaultRoot)).vaultGeneration;
-}
-
-export async function ensureMemoryWikiVaultGeneration(vaultRoot: string): Promise<string> {
-  const existing = await loadMemoryWikiVaultGeneration(vaultRoot);
+export async function ensureMemoryWikiVaultGeneration(
+  vaultRoot: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  signal?.throwIfAborted();
+  const existing = (await loadMemoryWikiVaultIdentity(vaultRoot, signal)).vaultGeneration;
   if (existing) {
     return existing;
   }
@@ -191,7 +207,8 @@ export async function ensureMemoryWikiVaultGeneration(vaultRoot: string): Promis
     timestamp: new Date().toISOString(),
     details: { [VAULT_GENERATION_FIELD]: candidate },
   });
+  signal?.throwIfAborted();
   // Concurrent initialization can append two candidates. The first durable
   // audit entry owns the vault generation, so every caller converges on it.
-  return (await loadMemoryWikiVaultGeneration(vaultRoot)) ?? candidate;
+  return (await loadMemoryWikiVaultIdentity(vaultRoot, signal)).vaultGeneration ?? candidate;
 }

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { filterMemorySearchHitsBySessionVisibility } from "@openclaw/memory-core/api.js";
 import type { MemoryReadResult } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import YAML from "yaml";
 import type { OpenClawConfig } from "../api.js";
 import { compileMemoryWikiVault } from "./compile.js";
 import type { MemoryWikiPluginConfig } from "./config.js";
@@ -240,6 +241,104 @@ describe("searchMemoryWiki", () => {
     expect(results[0]?.corpus).toBe("wiki");
     expect(results[0]?.path).toBe("sources/alpha.md");
     expect(getActiveMemorySearchManagerMock).not.toHaveBeenCalled();
+  });
+
+  it("bounds full-vault parsing to raw query candidates (#104719)", async () => {
+    const { rootDir, config } = await createQueryVault({ initialize: true });
+    await Promise.all(
+      Array.from({ length: 64 }, (_, index) =>
+        fs.writeFile(
+          path.join(rootDir, "sources", `padding-${String(index).padStart(2, "0")}.md`),
+          renderWikiMarkdown({
+            frontmatter: {
+              pageType: "source",
+              id: `source.padding-${index}`,
+              title: `Padding ${index}`,
+            },
+            body: `# Padding ${index}\n\nUnrelated body ${index}.\n`,
+          }),
+          "utf8",
+        ),
+      ),
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "late-hit.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.late-hit",
+          title: "Late Hit",
+        },
+        body: "# Late Hit\n\ncombined-timeout-needle-104719\n",
+      }),
+      "utf8",
+    );
+    // The full-vault fallback may read raw bytes, but unrelated pages must not
+    // enter the YAML/Markdown parser that pushed combined recall past 15 seconds.
+    const parse = vi.spyOn(YAML, "parse");
+
+    try {
+      const results = await searchMemoryWiki({
+        config,
+        query: "combined-timeout-needle-104719",
+        maxResults: 10,
+      });
+
+      expect(collectWikiResultPaths(results)).toEqual(["sources/late-hit.md"]);
+      expect(parse.mock.calls.length).toBeLessThanOrEqual(4);
+    } finally {
+      parse.mockRestore();
+    }
+  });
+
+  it("stops starting page reads after the caller deadline (#104719)", async () => {
+    const { rootDir, config } = await createQueryVault({ initialize: true });
+    const pageCount = 160;
+    await Promise.all(
+      Array.from({ length: pageCount }, (_, index) =>
+        fs.writeFile(
+          path.join(rootDir, "sources", `deadline-pad-${String(index).padStart(3, "0")}.md`),
+          renderWikiMarkdown({
+            frontmatter: {
+              pageType: "source",
+              id: `source.deadline-pad-${index}`,
+              title: `Deadline Pad ${index}`,
+            },
+            body: `# Deadline Pad ${index}\n\nUnrelated deadline body ${index}.\n`,
+          }),
+          "utf8",
+        ),
+      ),
+    );
+    const controller = new AbortController();
+    const deadlineError = new Error("test wiki deadline");
+    const originalReadFile = fs.readFile.bind(fs);
+    let pageReads = 0;
+    const readFile = vi
+      .spyOn(fs, "readFile")
+      .mockImplementation(async (...args: Parameters<typeof fs.readFile>) => {
+        const target = typeof args[0] === "string" ? path.basename(args[0]) : "";
+        if (target.startsWith("deadline-pad-")) {
+          pageReads += 1;
+          if (pageReads === 16) {
+            controller.abort(deadlineError);
+          }
+        }
+        return await originalReadFile(...args);
+      });
+
+    try {
+      await expect(
+        searchMemoryWiki({
+          config,
+          query: "absent-deadline-needle-104719",
+          signal: controller.signal,
+        }),
+      ).rejects.toBe(deadlineError);
+      expect(pageReads).toBeLessThan(pageCount);
+    } finally {
+      readFile.mockRestore();
+    }
   });
 
   it("skips malformed pages while searching the rest of the vault (#96125)", async () => {

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -207,11 +207,11 @@ function mergeWikiSearchCorpusResults(params: {
   return sortWikiSearchResults(selected).slice(0, params.maxResults);
 }
 
-async function listWikiMarkdownFiles(rootDir: string): Promise<string[]> {
+async function listWikiMarkdownFiles(rootDir: string, signal?: AbortSignal): Promise<string[]> {
   const files = (
     await Promise.all(
       QUERY_DIRS.map(async (relativeDir) => {
-        const entries = await walkMemoryWikiDirectory(rootDir, relativeDir);
+        const entries = await walkMemoryWikiDirectory(rootDir, relativeDir, { signal });
         return entries
           .filter(
             (entry) =>
@@ -223,36 +223,63 @@ async function listWikiMarkdownFiles(rootDir: string): Promise<string[]> {
       }),
     )
   ).flat();
+  signal?.throwIfAborted();
   return files.toSorted((left, right) => left.localeCompare(right));
 }
 
-export async function readQueryableWikiPages(rootDir: string): Promise<QueryableWikiPage[]> {
-  const files = await listWikiMarkdownFiles(rootDir);
-  return readQueryableWikiPagesByPaths(rootDir, files);
+export async function readQueryableWikiPages(
+  rootDir: string,
+  signal?: AbortSignal,
+): Promise<QueryableWikiPage[]> {
+  const files = await listWikiMarkdownFiles(rootDir, signal);
+  return await readQueryableWikiPagesByPaths(rootDir, files, { signal });
 }
+
+type QueryableWikiPageReadOptions = {
+  signal?: AbortSignal;
+  shouldParseRaw?: (relativePath: string, raw: string) => boolean;
+};
 
 async function readQueryableWikiPagesByPaths(
   rootDir: string,
   files: string[],
+  options: QueryableWikiPageReadOptions = {},
 ): Promise<QueryableWikiPage[]> {
-  const { results } = await runTasksWithConcurrency({
+  const { results, firstError, hasError } = await runTasksWithConcurrency({
     tasks: files.map((relativePath) => async () => {
+      options.signal?.throwIfAborted();
       const absolutePath = path.join(rootDir, relativePath);
-      const raw = await fs.readFile(absolutePath, "utf8");
+      const raw = await fs.readFile(absolutePath, {
+        encoding: "utf8",
+        signal: options.signal,
+      });
+      options.signal?.throwIfAborted();
+      if (options.shouldParseRaw && !options.shouldParseRaw(relativePath, raw)) {
+        return null;
+      }
+      options.signal?.throwIfAborted();
       const summary = toWikiPageSummary({ absolutePath, relativePath, raw });
+      options.signal?.throwIfAborted();
       return summary ? { ...summary, raw } : null;
     }),
     limit: QUERY_PAGE_READ_CONCURRENCY,
     errorMode: "stop",
-    throwOnError: true,
   });
+  if (hasError) {
+    options.signal?.throwIfAborted();
+    throw firstError;
+  }
+  options.signal?.throwIfAborted();
   return results.filter((page): page is QueryableWikiPage => page !== null);
 }
 
 async function readQueryDigestBundle(
   config: ResolvedMemoryWikiConfig,
+  signal?: AbortSignal,
 ): Promise<QueryDigestBundle | null> {
+  signal?.throwIfAborted();
   const snapshot = await loadMemoryWikiCompiledCache(config);
+  signal?.throwIfAborted();
   return snapshot ? { pages: snapshot.digest.pages, claims: snapshot.claims } : null;
 }
 
@@ -358,6 +385,28 @@ function buildRouteQuestionTokens(queryLower: string): string[] {
   const tokens = buildQueryTokens(queryLower);
   const routedTokens = tokens.filter((token) => !ROUTE_QUESTION_STOP_WORDS.has(token));
   return routedTokens.length > 0 ? routedTokens : tokens;
+}
+
+function createRawWikiSearchCandidateFilter(
+  query: string,
+  mode: WikiSearchMode,
+): (relativePath: string, raw: string) => boolean {
+  const queryLower = normalizeLowercaseStringOrEmpty(query);
+  const queryTokens = buildQueryTokens(queryLower);
+  const routeTokens = mode === "route-question" ? buildRouteQuestionTokens(queryLower) : [];
+  return (relativePath, raw) => {
+    const rawSearchText = normalizeLowercaseStringOrEmpty(`${relativePath}
+${raw}`);
+    if (lineMatchesQuery(rawSearchText, queryLower, queryTokens)) {
+      return true;
+    }
+    if (mode === "route-question" && lineMatchesQuery(rawSearchText, "", routeTokens)) {
+      return true;
+    }
+    // Non-ASCII-only queries may have no lexical tokens. Parse them unless the
+    // exact raw representation matched so YAML folding cannot create a false negative.
+    return queryTokens.length === 0;
+  };
 }
 
 function lineMatchesQuery(lineLower: string, queryLower: string, queryTokens: string[]): boolean {
@@ -1186,8 +1235,10 @@ async function searchWikiCorpus(params: {
   maxResults: number;
   mode: WikiSearchMode;
   canReadPage: (page: QueryableWikiPage) => boolean;
+  signal?: AbortSignal;
 }): Promise<WikiSearchResult[]> {
-  const digest = await readQueryDigestBundle(params.config);
+  params.signal?.throwIfAborted();
+  const digest = await readQueryDigestBundle(params.config, params.signal);
   const rootDir = params.config.vault.path;
   const candidatePaths = digest
     ? buildDigestCandidatePaths({
@@ -1197,15 +1248,18 @@ async function searchWikiCorpus(params: {
         mode: params.mode,
       })
     : [];
-  const seenPaths = new Set<string>();
-  const candidatePages =
+  const shouldParseRaw = createRawWikiSearchCandidateFilter(params.query, params.mode);
+  const candidateFiles =
     candidatePaths.length > 0
-      ? await readQueryableWikiPagesByPaths(rootDir, candidatePaths)
-      : await readQueryableWikiPages(rootDir);
-  for (const page of candidatePages) {
-    seenPaths.add(page.relativePath);
-  }
-
+      ? candidatePaths
+      : await listWikiMarkdownFiles(rootDir, params.signal);
+  // Full-vault recall still reads every page, but raw text can reject non-matches
+  // before expensive YAML and Markdown parsing without changing result completeness.
+  const candidatePages = await readQueryableWikiPagesByPaths(rootDir, candidateFiles, {
+    signal: params.signal,
+    ...(candidatePaths.length === 0 ? { shouldParseRaw } : {}),
+  });
+  const seenPaths = new Set(candidatePages.map((page) => page.relativePath));
   const results = candidatePages
     .filter(params.canReadPage)
     .map((page) => toWikiSearchResult(page, params.query, params.mode))
@@ -1214,12 +1268,16 @@ async function searchWikiCorpus(params: {
     return results;
   }
 
-  const remainingPaths = (await listWikiMarkdownFiles(rootDir)).filter(
+  params.signal?.throwIfAborted();
+  const remainingPaths = (await listWikiMarkdownFiles(rootDir, params.signal)).filter(
     (relativePath) => !seenPaths.has(relativePath),
   );
-  const remainingPages = (await readQueryableWikiPagesByPaths(rootDir, remainingPaths)).filter(
-    params.canReadPage,
-  );
+  const remainingPages = (
+    await readQueryableWikiPagesByPaths(rootDir, remainingPaths, {
+      signal: params.signal,
+      shouldParseRaw,
+    })
+  ).filter(params.canReadPage);
   return [
     ...results,
     ...remainingPages
@@ -1263,6 +1321,7 @@ export async function searchMemoryWiki(input: {
   searchBackend?: WikiSearchBackend;
   searchCorpus?: WikiSearchCorpus;
   mode?: WikiSearchMode;
+  signal?: AbortSignal;
 }): Promise<WikiSearchResult[]> {
   const agentId = resolveActiveMemoryAgentId(input);
   const params = agentId ? { ...input, agentId } : input;
@@ -1282,7 +1341,11 @@ export async function searchMemoryWiki(input: {
     sandboxed: params.sandboxed,
     operation: "wiki_search",
   });
-  await initializeMemoryWikiVault(effectiveConfig);
+  params.signal?.throwIfAborted();
+  await initializeMemoryWikiVault(
+    effectiveConfig,
+    params.signal ? { signal: params.signal } : undefined,
+  );
   const maxResults = normalizePositiveInteger(params.maxResults, 10);
   const mode = params.mode ?? "auto";
 
@@ -1293,6 +1356,7 @@ export async function searchMemoryWiki(input: {
         maxResults,
         mode,
         canReadPage: createWikiPageVisibilityFilter(params),
+        signal: params.signal,
       })
     : [];
 
@@ -1312,8 +1376,10 @@ export async function searchMemoryWiki(input: {
         ...(protectedSessionRecall
           ? { sources: ["sessions" as const], sessionKey: params.agentSessionKey }
           : {}),
+        ...(params.signal ? { signal: params.signal } : {}),
       })
     : [];
+  params.signal?.throwIfAborted();
   if (
     params.appConfig &&
     shouldEnforceSessionVisibility(params) &&
@@ -1329,6 +1395,7 @@ export async function searchMemoryWiki(input: {
       trustedAgentScope: !params.agentSessionKey && Boolean(params.agentId?.trim()),
     });
   }
+  params.signal?.throwIfAborted();
   const memoryResults = rawMemoryResults.map((result) => toMemoryWikiSearchResult(result, mode));
 
   return mergeWikiSearchCorpusResults({
@@ -1351,6 +1418,7 @@ export async function getMemoryWikiPage(input: {
   lineCount?: number;
   searchBackend?: WikiSearchBackend;
   searchCorpus?: WikiSearchCorpus;
+  signal?: AbortSignal;
 }): Promise<WikiGetResult | null> {
   const agentId = resolveActiveMemoryAgentId(input);
   const params = agentId ? { ...input, agentId } : input;
@@ -1363,22 +1431,30 @@ export async function getMemoryWikiPage(input: {
     sandboxed: params.sandboxed,
     operation: "wiki_get",
   });
-  await initializeMemoryWikiVault(effectiveConfig);
+  params.signal?.throwIfAborted();
+  await initializeMemoryWikiVault(
+    effectiveConfig,
+    params.signal ? { signal: params.signal } : undefined,
+  );
   const fromLine = normalizePositiveInteger(params.fromLine, 1);
   const lineCount = normalizePositiveInteger(params.lineCount, 200);
 
   if (shouldSearchWiki(effectiveConfig)) {
     const canReadPage = createWikiPageVisibilityFilter(params);
-    const digest = await readQueryDigestBundle(effectiveConfig);
+    const digest = await readQueryDigestBundle(effectiveConfig, params.signal);
     const digestClaimPagePath = digest ? resolveDigestClaimLookup(digest, params.lookup) : null;
     const digestLookupPage = digestClaimPagePath
       ? ((
-          await readQueryableWikiPagesByPaths(effectiveConfig.vault.path, [digestClaimPagePath])
+          await readQueryableWikiPagesByPaths(effectiveConfig.vault.path, [digestClaimPagePath], {
+            signal: params.signal,
+          })
         ).find(canReadPage) ?? null)
       : null;
     const pages = digestLookupPage
       ? [digestLookupPage]
-      : (await readQueryableWikiPages(effectiveConfig.vault.path)).filter(canReadPage);
+      : (await readQueryableWikiPages(effectiveConfig.vault.path, params.signal)).filter(
+          canReadPage,
+        );
     const page = digestLookupPage ?? resolveQueryableWikiPageByLookup(pages, params.lookup);
     if (page) {
       const parsed = parseWikiMarkdown(page.raw);
@@ -1406,6 +1482,7 @@ export async function getMemoryWikiPage(input: {
     return null;
   }
 
+  params.signal?.throwIfAborted();
   const manager = await resolveActiveMemoryManager({
     appConfig: params.appConfig,
     agentId: params.agentId,
@@ -1448,6 +1525,7 @@ export async function getMemoryWikiPage(input: {
       : null;
 
   for (const relPath of lookupCandidates) {
+    params.signal?.throwIfAborted();
     // Raw session candidates still need visibility checks; memory readers accept Markdown only.
     if (
       !relPath.endsWith(".md") ||
@@ -1461,6 +1539,7 @@ export async function getMemoryWikiPage(input: {
       from: fromLine,
       lines: lineCount,
     });
+    params.signal?.throwIfAborted();
     if (result.status === "not_found") {
       continue;
     }

--- a/extensions/memory-wiki/src/tool.ts
+++ b/extensions/memory-wiki/src/tool.ts
@@ -178,6 +178,7 @@ export function createWikiSearchTool(
         ...(params.backend ? { searchBackend: params.backend } : {}),
         ...(params.corpus ? { searchCorpus: params.corpus } : {}),
         ...(params.mode ? { mode: params.mode } : {}),
+        ...(memoryContext.signal ? { signal: memoryContext.signal } : {}),
       });
       const text =
         results.length === 0
@@ -301,6 +302,7 @@ export function createWikiGetTool(
         lineCount: params.lineCount,
         ...(params.backend ? { searchBackend: params.backend } : {}),
         ...(params.corpus ? { searchCorpus: params.corpus } : {}),
+        ...(memoryContext.signal ? { signal: memoryContext.signal } : {}),
       });
       if (!result) {
         return textResult(`Wiki page not found: ${lookup}`, { found: false });

--- a/extensions/memory-wiki/src/vault.ts
+++ b/extensions/memory-wiki/src/vault.ts
@@ -157,7 +157,7 @@ export async function initializeMemoryWikiVault(
       },
     });
   }
-  await ensureMemoryWikiVaultGeneration(rootDir);
+  await ensureMemoryWikiVaultGeneration(rootDir, options?.signal);
   options?.signal?.throwIfAborted();
   await activateExistingMemoryWikiVault(config, options?.signal);
 
@@ -175,7 +175,7 @@ export async function activateExistingMemoryWikiVault(
 ): Promise<void> {
   signal?.throwIfAborted();
   const rootDir = config.vault.path;
-  const identity = await loadMemoryWikiValidatedVaultIdentity(rootDir);
+  const identity = await loadMemoryWikiValidatedVaultIdentity(rootDir, signal);
   if (!identity.vaultGeneration) {
     throw new Error(`Memory Wiki vault generation is missing: ${rootDir}`);
   }
@@ -189,7 +189,7 @@ export async function activateExistingMemoryWikiVault(
   // runs again only when its path, generation, or publication identity changes.
   if (needsReconcile) {
     await reconcileMemoryWikiCompiledCacheOwner(config, () =>
-      loadMemoryWikiValidatedVaultIdentity(rootDir),
+      loadMemoryWikiValidatedVaultIdentity(rootDir, signal),
     );
   }
   signal?.throwIfAborted();

--- a/src/plugins/registry-contribution-types.ts
+++ b/src/plugins/registry-contribution-types.ts
@@ -170,6 +170,8 @@ export type MemoryCorpusSupplement = {
     agentId?: string;
     agentSessionKey?: string;
     sandboxed?: boolean;
+    /** Caller-owned cancellation/deadline signal. Stop new work and reject with its reason. */
+    signal?: AbortSignal;
   }): Promise<MemoryCorpusSearchResult[]>;
   get(params: {
     lookup: string;
@@ -178,6 +180,8 @@ export type MemoryCorpusSupplement = {
     agentId?: string;
     agentSessionKey?: string;
     sandboxed?: boolean;
+    /** Caller-owned cancellation/deadline signal. Stop new work and reject with its reason. */
+    signal?: AbortSignal;
   }): Promise<MemoryCorpusGetResult | null>;
 };
 


### PR DESCRIPTION
Closes #104719

## What Problem This Solves

Fixes an issue where `memory_search` with `corpus: "all"` could return memory hits plus a false Wiki-unavailable warning on large compiled vaults, even though the same Wiki query completed successfully on its own. The timed-out Wiki scan also kept reading files after the tool had already returned.

## Why This Change Was Made

The existing 15-second tool deadline remains unchanged. The repair forwards its cancellation signal through the public corpus-supplement contract, Memory Wiki activation and source validation, digest/fallback lookup, directory walks, and page reads. Exhaustive body recall is still preserved while the call is on-budget; a raw-text candidate filter avoids expensive YAML/Markdown parsing for pages that cannot match.

## User Impact

Combined memory + Wiki recall can return healthy Wiki hits from large vaults without a false timeout caused by parse overhead. Genuine stalls still fail closed with the existing per-corpus warning, and cancellation now stops later Wiki I/O instead of leaving orphan work behind.

## Evidence

- Read-only real-vault proof on 5,784 Markdown pages / 62,999,844 bytes, forcing the exhaustive fallback path with the issue query. Baseline: 11,712 / 10,094 / 11,690 ms. Candidate on the current rebased head: 5,763 / 2,818 / 3,181 ms. All six runs returned 10 results with the same ordered-path digest (`429438066d6f0b9a`).
- `node scripts/run-vitest.mjs extensions/memory-core/src/tools.citations.test.ts extensions/memory-core/src/memory-get-corpus.test.ts extensions/memory-wiki/src/corpus-supplement.test.ts extensions/memory-wiki/src/query.test.ts extensions/memory-wiki/src/compiled-cache.integration.test.ts` — 122 passed.
- `pnpm build` — passed, including all 147 public Plugin SDK subpaths.
- `pnpm test:contracts:plugins` — passed on the current head (46 files / 1,111 tests); the broader channel + plugin contract suite also passed before the mechanical current-main rebase.
- `node scripts/check-changed.mjs -- <changed paths>` — passed all selected core, plugin, docs, typecheck, lint, boundary, dead-export, and guard lanes.
- Plugin SDK surface check and source/plugin import-boundary check — passed.
- Fresh `autoreview --mode branch --base origin/main` — scoped clean.

The operator Gateway remains on the pre-fix runtime; loading this unmerged candidate there would require replacing and restarting that production Gateway. Candidate runtime proof therefore used the same real vault through a read-only source driver, alongside the bounded owner tests above.
