### PR TITLE
fix(agents): keep agents_wait deadlines monotonic

### DIFF
--- a/src/agents/tools/agents-wait-tool.test.ts
+++ b/src/agents/tools/agents-wait-tool.test.ts
@@ -154,6 +154,25 @@ describe("agents_wait", () => {
     });
   });
 
+  it("does not extend a bounded wait when the wall clock rolls back", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "performance"] });
+    vi.setSystemTime(1_000);
+    records.set("clock-rollback", collectorRun("clock-rollback", "agent:main:main"));
+    const tool = createAgentsWaitTool({
+      agentSessionKey: "agent:main:main",
+      agentId: "main",
+      config: { tools: { swarm: true } },
+    });
+    const wait = tool.execute("call", { ids: ["clock-rollback"], timeoutSeconds: 0.1 });
+
+    await vi.advanceTimersByTimeAsync(50);
+    vi.setSystemTime(0);
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(wait).resolves.toMatchObject({ details: { pending: ["clock-rollback"] } });
+    vi.useRealTimers();
+  });
+
   it("projects an authorized collector failure without failing a mixed batch", async () => {
     const failed = collectorRun("failed", "agent:main:main", {
       status: "failed",

--- a/src/agents/tools/agents-wait-tool.test.ts
+++ b/src/agents/tools/agents-wait-tool.test.ts
@@ -154,25 +154,6 @@ describe("agents_wait", () => {
     });
   });
 
-  it("does not extend a bounded wait when the wall clock rolls back", async () => {
-    vi.useFakeTimers({ toFake: ["Date", "performance"] });
-    vi.setSystemTime(1_000);
-    records.set("clock-rollback", collectorRun("clock-rollback", "agent:main:main"));
-    const tool = createAgentsWaitTool({
-      agentSessionKey: "agent:main:main",
-      agentId: "main",
-      config: { tools: { swarm: true } },
-    });
-    const wait = tool.execute("call", { ids: ["clock-rollback"], timeoutSeconds: 0.1 });
-
-    await vi.advanceTimersByTimeAsync(50);
-    vi.setSystemTime(0);
-    await vi.advanceTimersByTimeAsync(50);
-
-    await expect(wait).resolves.toMatchObject({ details: { pending: ["clock-rollback"] } });
-    vi.useRealTimers();
-  });
-
   it("projects an authorized collector failure without failing a mixed batch", async () => {
     const failed = collectorRun("failed", "agent:main:main", {
       status: "failed",
@@ -211,6 +192,39 @@ describe("agents_wait", () => {
     });
     expect(isToolResultError(result)).toBe(false);
   });
+
+  it.each([-60_000, 60_000])(
+    "keeps its elapsed deadline after a %d ms clock step",
+    async (step) => {
+      vi.useFakeTimers({ toFake: ["Date", "performance", "setTimeout", "clearTimeout"] });
+      vi.setSystemTime(100_000);
+      const controller = new AbortController();
+      records.set("clock-step", collectorRun("clock-step", "agent:main:main"));
+      const tool = createAgentsWaitTool({
+        agentSessionKey: "agent:main:main",
+        agentId: "main",
+        config: { tools: { swarm: true } },
+      });
+      let result: unknown;
+      const waiting = tool
+        .execute("clock", { ids: ["clock-step"], timeoutSeconds: 0.1 }, controller.signal)
+        .then((value) => {
+          result = value.details;
+        });
+      try {
+        await vi.advanceTimersByTimeAsync(25);
+        vi.setSystemTime(Date.now() + step);
+        await vi.advanceTimersByTimeAsync(74);
+        expect(result).toBeUndefined();
+        await vi.advanceTimersByTimeAsync(1);
+        expect(result).toEqual({ completed: [], pending: ["clock-step"] });
+      } finally {
+        controller.abort();
+        await waiting.catch(() => {});
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("orders completions by their durable capture time instead of input order", async () => {
     const later = collectorRun("later", "agent:main:main", { status: "done" });

--- a/src/agents/tools/agents-wait-tool.ts
+++ b/src/agents/tools/agents-wait-tool.ts
@@ -218,7 +218,7 @@ async function waitForCollector(params: {
   timeoutMs: number;
   signal?: AbortSignal;
 }) {
-  const deadline = Date.now() + params.timeoutMs;
+  const deadline = performance.now() + params.timeoutMs;
   for (;;) {
     if (params.signal?.aborted) {
       throw createAbortError("agents_wait aborted.");
@@ -231,7 +231,7 @@ async function waitForCollector(params: {
       params.currentAgentId,
       params.config,
     );
-    if (state.completed.length > 0 || state.pending.length === 0 || Date.now() >= deadline) {
+    if (state.completed.length > 0 || state.pending.length === 0 || performance.now() >= deadline) {
       return state;
     }
     await new Promise<void>((resolve, reject) => {
@@ -245,7 +245,7 @@ async function waitForCollector(params: {
         resolve();
       };
       const onAbort = () => finish(createAbortError("agents_wait aborted."));
-      const timer = setTimeout(finish, Math.min(25, Math.max(0, deadline - Date.now())));
+      const timer = setTimeout(finish, Math.min(25, Math.max(0, deadline - performance.now())));
       params.signal?.addEventListener("abort", onAbort, { once: true });
       // Abort can race listener registration; never turn that cancellation into a successful poll.
       if (params.signal?.aborted) {

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -240,6 +240,7 @@ function modelRegistryOptions(index = 0): Record<string, unknown> {
 
 let modelsListCommand: typeof import("./list.list-command.js").modelsListCommand;
 let listRowsModule: typeof import("./list.rows.js");
+let cliBackendsTesting: typeof import("../../agents/cli-backends.test-support.js").testing;
 
 function installModelsListCommandForwardCompatMocks() {
   const suppressOpenAiSpark = ({
@@ -389,6 +390,7 @@ function installModelsListCommandForwardCompatMocks() {
 
 beforeAll(async () => {
   installModelsListCommandForwardCompatMocks();
+  ({ testing: cliBackendsTesting } = await import("../../agents/cli-backends.test-support.js"));
   listRowsModule = await import("./list.rows.js");
   ({ modelsListCommand } = await import("./list.list-command.js"));
 });
@@ -434,9 +436,21 @@ async function buildAllOpenAiCodexRows(opts: { supplementCatalog?: boolean } = {
 beforeEach(() => {
   vi.clearAllMocks();
   resetMocks();
+  // These command cases own their backend fixture; setup loading has separate coverage.
+  cliBackendsTesting.setDepsForTest({
+    resolveRuntimeCliBackends: () => [
+      {
+        id: "claude-cli",
+        modelProvider: "anthropic",
+        pluginId: "anthropic",
+        config: { command: "claude" },
+      },
+    ],
+  });
 });
 
 afterEach(() => {
+  cliBackendsTesting.resetDepsForTest();
   vi.unstubAllEnvs();
 });
 


### PR DESCRIPTION
## What Problem This Solves

A system clock change can extend or prematurely finish agents_wait. Use performance.now consistently for deadline creation, expiry and remaining delay while preserving collector ownership, replacement and abort handling.

## Why This Change Was Made

A bounded wait measures elapsed time. All three deadline calculations now use the existing monotonic clock, while durable completion timestamps continue to retain their existing meaning.

## User Impact

Clock corrections no longer lengthen or prematurely complete agents_wait. Ownership, replacement and cancellation behavior remain intact.

## Evidence

The actual tool plus production collector registry and SQLite returned pending at 101 ms in the healthy baseline; a backward clock step hit the 500 ms watchdog. The restored fix returned pending at 101 ms for unchanged, backward and forward clocks. Two deterministic clock-step cases failed on baseline; all 20 tests passed with the fix. Core/test types, scoped lint, format and diff checks passed.

Production: +3/−3, net +0. Tests: +47. No changelog change.

The latest ClawSweeper timer-cleanup finding is addressed: the regression aborts and joins its waiter and restores real timers in finally.

Observed synthetic proof:

```json
{"result":"PASS","surface":"agents_wait + real collector registry","outcomes":[{"step":0,"elapsedMs":101,"result":{"completed":[],"pending":["clock-proof"]}},{"step":-60000,"elapsedMs":101,"result":{"completed":[],"pending":["clock-proof"]}},{"step":60000,"elapsedMs":101,"result":{"completed":[],"pending":["clock-proof"]}}]}
```


Thanks @qingminglong for the original repair.

CI also exposed a slow pre-existing model-list fixture: it loaded the Anthropic setup tree while testing forward-compatible model rows. The fixture now registers its existing synthetic CLI backend through the established test seam and resets that ownership afterward. All 54 cases passed in the original order before and after; the affected case fell from 29 seconds to 3.36 seconds without changing its five-second auth deadline or assertions. The full combined changed-file gate and independent review passed. Production code remains net-neutral.

The separate browser cancellation failure did not reproduce in all 42 cases, so no browser patch is included. The measured cold Anthropic setup/source-loading cost remains a named performance follow-up; this fixture change does not claim to repair that runtime cost.
