### PR TITLE
refactor(build): compose shared profile phases

### DIFF
--- a/scripts/build-all.mts
+++ b/scripts/build-all.mts
@@ -166,96 +166,60 @@ export const BUILD_ALL_STEPS: BuildAllStep[] = [
   },
 ];
 
-const FULL_BUILD_STEP_LABELS = [
+const RUNTIME_SETUP_STEP_LABELS = [
+  "external-plugins:local-dist",
+  "check-cli-bootstrap-imports",
+] as const;
+const RUNTIME_FINALIZE_STEP_LABELS = [
+  "runtime-postbuild",
+  "build-stamp",
+  "runtime-postbuild-stamp",
+] as const;
+const RUNTIME_STEP_LABELS = [...RUNTIME_SETUP_STEP_LABELS, ...RUNTIME_FINALIZE_STEP_LABELS];
+const ASSET_RUNTIME_STEP_LABELS = [
   "plugins:assets:build",
+  "tsdown",
+  ...RUNTIME_SETUP_STEP_LABELS,
+  // Copy after compiler cleanup, before postbuild records the generated asset inventory.
+  "plugins:assets:copy",
+  ...RUNTIME_FINALIZE_STEP_LABELS,
+];
+const BUILD_METADATA_STEP_LABELS = ["write-build-info", "write-cli-startup-metadata"] as const;
+const FINAL_BUILD_ARTIFACTS_STEP_LABELS = [
+  "write-plugin-sdk-entry-dts",
+  "check-plugin-sdk-exports",
+  "ui:build",
+  ...BUILD_METADATA_STEP_LABELS,
+] as const;
+const CI_ARTIFACT_STEP_LABELS = [
+  ...ASSET_RUNTIME_STEP_LABELS,
+  ...FINAL_BUILD_ARTIFACTS_STEP_LABELS,
+];
+const FULL_COMPILER_STEP_LABELS = [
   "tsdown-ai",
   "tsdown-packages",
   "tsdown-unified",
   "write-unified-entry-dts",
-  "external-plugins:local-dist",
-  "check-cli-bootstrap-imports",
-  "plugins:assets:copy",
-  "runtime-postbuild",
-  "build-stamp",
-  "runtime-postbuild-stamp",
-  "write-plugin-sdk-entry-dts",
-  "check-plugin-sdk-exports",
-  "ui:build",
-  "write-build-info",
-  "write-cli-startup-metadata",
 ] as const;
+// Full and package builds cache declaration groups separately from the runtime graph.
+const FULL_BUILD_STEP_LABELS = CI_ARTIFACT_STEP_LABELS.flatMap((step) =>
+  step === "tsdown" ? FULL_COMPILER_STEP_LABELS : [step],
+);
 
 export const BUILD_ALL_PROFILES: Record<string, string[]> = {
   full: [...FULL_BUILD_STEP_LABELS],
   package: ["clean:dist", ...FULL_BUILD_STEP_LABELS],
-  ciArtifacts: [
-    "plugins:assets:build",
-    "tsdown",
-    "external-plugins:local-dist",
-    "check-cli-bootstrap-imports",
-    "plugins:assets:copy",
-    "runtime-postbuild",
-    "build-stamp",
-    "runtime-postbuild-stamp",
-    "write-plugin-sdk-entry-dts",
-    "check-plugin-sdk-exports",
-    "ui:build",
-    "write-build-info",
-    "write-cli-startup-metadata",
-  ],
-  gatewayWatch: [
-    "tsdown",
-    "external-plugins:local-dist",
-    "check-cli-bootstrap-imports",
-    "runtime-postbuild",
-    "build-stamp",
-    "runtime-postbuild-stamp",
-  ],
-  qaRuntime: [
-    "plugins:assets:build",
-    "tsdown",
-    "external-plugins:local-dist",
-    "check-cli-bootstrap-imports",
-    "plugins:assets:copy",
-    "runtime-postbuild",
-    "build-stamp",
-    "runtime-postbuild-stamp",
-  ],
-  sourcePerformance: [
-    "plugins:assets:build",
-    "tsdown",
-    "external-plugins:local-dist",
-    "check-cli-bootstrap-imports",
-    "plugins:assets:copy",
-    "runtime-postbuild",
-    "build-stamp",
-    "runtime-postbuild-stamp",
-    "write-build-info",
-    "write-cli-startup-metadata",
-  ],
-  cliStartup: [
-    "tsdown",
-    "external-plugins:local-dist",
-    "check-cli-bootstrap-imports",
-    "runtime-postbuild",
-    "build-stamp",
-    "runtime-postbuild-stamp",
-    "write-cli-startup-metadata",
-  ],
+  ciArtifacts: [...CI_ARTIFACT_STEP_LABELS],
+  gatewayWatch: ["tsdown", ...RUNTIME_STEP_LABELS],
+  qaRuntime: [...ASSET_RUNTIME_STEP_LABELS],
+  sourcePerformance: [...ASSET_RUNTIME_STEP_LABELS, ...BUILD_METADATA_STEP_LABELS],
+  cliStartup: ["tsdown", ...RUNTIME_STEP_LABELS, "write-cli-startup-metadata"],
 };
 
 const FULL_RUNTIME_ONLY_STEPS = [
-  "plugins:assets:build",
-  "tsdown",
-  "external-plugins:local-dist",
-  "check-cli-bootstrap-imports",
-  "plugins:assets:copy",
-  "runtime-postbuild",
-  "build-stamp",
-  "runtime-postbuild-stamp",
+  ...ASSET_RUNTIME_STEP_LABELS,
   "ui:build",
-  "write-build-info",
-  "write-cli-startup-metadata",
+  ...BUILD_METADATA_STEP_LABELS,
 ];
 
 export const BUILD_ALL_PROFILE_STEP_ENV: Record<string, Record<string, NodeJS.ProcessEnv>> = {


### PR DESCRIPTION
Build profiles now compose named setup, runtime, asset and metadata phases instead of repeating their inventories. The full compiler sequence replaces the same generic compiler slot, and each of the seven exported profiles still owns an independent mutable array. Step execution, caches, declaration writers, environment selection, cleanup and output ordering stay with their existing owners.

Production is **+37/−73 = −36 physical and nonblank lines**, including every new private group and spread. Tests are unchanged. No new option, dependency or public surface is introduced, and no performance improvement is claimed.

Validation:

- Complete actual-owner observations match after removing only the observation revision label: seven profiles, 126 selector combinations, 21 allocation comparisons, seven mutation cases and 11 success/failure/cache/heap orchestration cases. Four real CLI help/error invocations preserve stdout, stderr and exit status exactly.
- 332 maintained tests passed across the build, compiler, artifact-ownership and managed-process suites; one Linux-only case was skipped on macOS. Selected changed-file checks and a fresh managed high/P2 review passed.
- Normal full cold and warm builds passed on both baseline and candidate, including declaration writers, all 147 SDK exports, native plugin checks, UI and startup metadata. The original controller expired while the cold build remained alive; the original child completed normally and its real exit receipt is retained. No healthy build was restarted.
- 8,517 non-UI/non-declaration output files match exactly across all four builds. Declaration filenames/content vary between unchanged builds; raw differences are retained. The warm UI core chunk differs only in advisory Git dirty metadata (`null` versus `true`), with corresponding generated hash references. The exact cause of the earlier advisory Git read is unproven. Total artifact byte equality is not claimed. All 806 compressed sidecars pass the canonical check, and actual built CLI help/version match the baseline.

Named follow-ups: the legacy Docker build's separate asset order, repeat-build declaration/chunk variation, and advisory UI Git metadata reads. These are outside the profile inventory change. Partial profiles have owner/orchestration and maintained test coverage; the real build evidence covers full cold/warm builds.


Landing verification: all170 jobs in CI33525766138 passed or intentionally skipped on head54390bd0b8a2a5861c05b9889516fbec031cf7a1. The latest ClawSweeper review reports no code/security finding; its CI step is satisfied. The automatic stored-data-model note is not applicable: the changed hunk composes build-profile string arrays, with unchanged execution and persisted-data owners. Production+37/-73=-36; tests0. Actual profile, mutable-array, orchestration and cold/warm build proof is qualified above; no speedup or full UI/declaration byte-identity claim is made.
