### PR TITLE
refactor(tasks): use canonical state database owner

### DIFF
--- a/src/tasks/task-flow-registry.store.sqlite.ts
+++ b/src/tasks/task-flow-registry.store.sqlite.ts
@@ -51,8 +51,6 @@ type FlowRegistryDatabase = {
 };
 
 // SQLite-backed task-flow store mirrors the in-process registry into openclaw-state.db.
-let cachedDatabase: FlowRegistryDatabase | null = null;
-
 function serializeJson(value: unknown): string | null {
   return value === undefined ? null : JSON.stringify(value);
 }
@@ -225,31 +223,15 @@ function upsertFlowRow(db: DatabaseSync, row: Insertable<FlowRunsTable>): void {
   );
 }
 
-function openFlowRegistryDatabase(): FlowRegistryDatabase {
-  const database = openOpenClawStateDatabase();
-  const pathname = database.path;
-  if (cachedDatabase && cachedDatabase.path === pathname && cachedDatabase.db.isOpen) {
-    return cachedDatabase;
-  }
-  if (cachedDatabase && !cachedDatabase.db.isOpen) {
-    cachedDatabase = null;
-  }
-  cachedDatabase = {
-    db: database.db,
-    path: pathname,
-  };
-  return cachedDatabase;
-}
-
 function withWriteTransaction(write: (database: FlowRegistryDatabase) => void) {
-  const database = openFlowRegistryDatabase();
+  const database = openOpenClawStateDatabase();
   runOpenClawStateWriteTransaction(() => {
     write(database);
   });
 }
 
 export function loadTaskFlowRegistryStateFromSqlite(): TaskFlowRegistryStoreSnapshot {
-  const { db } = openFlowRegistryDatabase();
+  const { db } = openOpenClawStateDatabase();
   const rows = selectFlowRows(db);
   return {
     flows: new Map(rows.map((row) => [row.flow_id, rowToFlowRecord(row)])),
@@ -337,6 +319,5 @@ export function deleteTaskFlowRegistryRecordFromSqlite(flowId: string) {
 }
 
 export function closeTaskFlowRegistryDatabase() {
-  cachedDatabase = null;
   closeOpenClawStateDatabase();
 }

--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -112,8 +112,6 @@ type TaskRegistryReadOnlyLoadResult = {
   snapshot: TaskRegistryStoreSnapshot;
 };
 
-let cachedDatabase: TaskRegistryDatabase | null = null;
-
 function serializeJson(value: unknown): string | null {
   return value === undefined ? null : (JSON.stringify(value) ?? null);
 }
@@ -358,25 +356,9 @@ function deleteTaskRowsWithDeliveryState(db: DatabaseSync, taskId: string): void
   deleteExecutionOwnerLifecycleMetadata({ db, ownerKind: "task", ownerIds: [taskId] });
 }
 
-function openTaskRegistryDatabase(): TaskRegistryDatabase {
-  const database = openOpenClawStateDatabase();
-  const pathname = database.path;
-  if (cachedDatabase && cachedDatabase.path === pathname && cachedDatabase.db.isOpen) {
-    return cachedDatabase;
-  }
-  if (cachedDatabase && !cachedDatabase.db.isOpen) {
-    cachedDatabase = null;
-  }
-  cachedDatabase = {
-    db: database.db,
-    path: pathname,
-  };
-  return cachedDatabase;
-}
-
 function withWriteTransaction(write: (database: OpenClawStateDatabase) => void) {
   // Open once before BEGIN; the callback receives that exact shared-state owner.
-  openTaskRegistryDatabase();
+  openOpenClawStateDatabase();
   runOpenClawStateWriteTransaction((database) => write(database));
 }
 
@@ -396,7 +378,7 @@ function readTaskRegistrySnapshot({ db, path }: TaskRegistryDatabase): TaskRegis
 }
 
 export function loadTaskRegistryStateFromSqlite(): TaskRegistryStoreSnapshot {
-  return readTaskRegistrySnapshot(openTaskRegistryDatabase());
+  return readTaskRegistrySnapshot(openOpenClawStateDatabase());
 }
 
 /** Loads task records without creating or migrating shared state. */
@@ -434,7 +416,7 @@ export function listTaskRegistryRecordsByOwnerKeyFromSqlite(ownerKey: string): T
   if (!key) {
     return [];
   }
-  const { db } = openTaskRegistryDatabase();
+  const { db } = openOpenClawStateDatabase();
   return selectTaskRowsByOwnerKey(db, key).map(rowToTaskRecord);
 }
 
@@ -584,6 +566,5 @@ export function deleteTaskDeliveryStateFromSqlite(taskId: string) {
 }
 
 export function closeTaskRegistryDatabase() {
-  cachedDatabase = null;
   closeOpenClawStateDatabase();
 }


### PR DESCRIPTION
## What Problem This Solves

The task and task-flow SQLite stores retained local mirror caches around the shared OpenClaw state database. Those wrappers duplicated handle identity and reopen policy already owned by the canonical state database cache.

## Why This Change Was Made

The five lazy task-store call sites now open the shared state database directly. The redundant local caches and wrapper functions are removed, while the exported close functions still delegate to the canonical close owner.

This is a behavior-neutral ownership cleanup. It does not change schemas, versions, paths, pragmas, transactions, read-only behavior, errors, tests, documentation, or public APIs.

## User Impact

No user-visible behavior changes. Task persistence now has one canonical database handle and reopen owner instead of task-local mirror caches.

## Evidence

- Base: `8361f3704dd5e151ff1325e62ff5de658b6c62e6`
- Signed head: `8e4795c9b177f4dc9c4801bd5e91215e71cb5e66`
- Focused tests: 72 passed across task registry, task-flow registry, shared-state runtime fencing, and database permission hardening
- `pnpm tsgo:core`: passed
- `pnpm check:import-cycles`: passed with 0 runtime value cycles
- Changed-file dry run: `core, coreTests`
- Changed-file full gate: all lanes passed except the dead-export scan initially lacked tracked `ui/config` files in the sparse checkout; after adding that tracked sparse path, the exact failed scan passed with 0 script, full-tree, or production unused exports
- Exact Sol autoreview: scoped clean, 0.93
- `git diff --check`: passed
- Raw Git numstat: production `+5/-43` across 2 files; excluding four removed separator lines, the reviewed wrapper scope is `+5/-39` (net `-34`)
- Tests: `+0/-0`
- Schema/docs diff: empty
- Live `main` advanced to `2cedaddb5e23848d4358faddcd609afb6570fa94` before push with no changes to either target file
- #123107 remains open and adds future task-store callers; it has not landed, so this branch retains the approved five-call scope
- #119585 remains open and changes only the read-only helper path in these files; no read-only behavior is changed here
- Required Codex source inspection completed at `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those CLI surfaces are unrelated to this state-database ownership refactor
