### PR TITLE
fix(slack): keep steered replies below their messages

### DIFF
--- a/extensions/slack/src/delivery-trace.test.ts
+++ b/extensions/slack/src/delivery-trace.test.ts
@@ -24,7 +24,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
-import { noteSlackDraftConversationMessage } from "./draft-message-boundaries.js";
+import { noteSlackConversationMessage } from "./draft-message-boundaries.js";
 import type { PreparedSlackMessage } from "./monitor/message-handler/types.js";
 import { setSlackSessionStatus } from "./session-status.js";
 import { markSlackStreamsStopped } from "./streaming.js";
@@ -870,6 +870,110 @@ describe("slack delivery trace goldens", () => {
     expect(traceRuntimeError).not.toHaveBeenCalled();
   });
 
+  it("seals native progress before answering a later human message", async () => {
+    const followupText = "Please also check the rollout guard.";
+    const events = await runDeliveryTraceScenario({
+      scenario: {
+        name: "progress-native-intervening-message",
+        steps: [
+          { kind: "reply-start" },
+          { kind: "partial", text: NATIVE_PROGRESS_NARRATION },
+          { kind: "tool-progress", name: "write", phase: "start" },
+          { kind: "advance", ms: 2000 },
+          { kind: "partial", text: followupText },
+          { kind: "final", text: "The rollout guard is enabled." },
+          { kind: "idle" },
+        ],
+      },
+      setup: async (recorder) => {
+        const dispatch = await setupSlackTrace(recorder, "progress-native-unified");
+        return async (step) => {
+          if (step.kind === "partial" && step.text === followupText) {
+            traceState.tsCounter += 1;
+            noteSlackConversationMessage({
+              accountId: "default",
+              channelId: CHANNEL_ID,
+              threadTs: INBOUND_TS,
+              messageTs: `1767225601.${String(traceState.tsCounter).padStart(6, "0")}`,
+              userId: "U_SECOND",
+              botUserId: "UBOT",
+            });
+            return;
+          }
+          await dispatch(step);
+        };
+      },
+      normalize: createSlackTsNormalizer(),
+    });
+
+    const starts = events.filter((event) => event.kind === "chat.startStream");
+    expect(starts).toHaveLength(1);
+    expect(starts[0]?.data).toMatchObject({ payload: { thread_ts: "ts#1" } });
+    const stopIndex = events.findIndex((event) => event.kind === "chat.stopStream");
+    const followupIndex = events.findIndex(
+      (event) =>
+        event.kind === "chat.postMessage" &&
+        JSON.stringify(event.data).includes("The rollout guard is enabled."),
+    );
+    expect(stopIndex).toBeGreaterThan(-1);
+    expect(stopIndex).toBeLessThan(followupIndex);
+    expect(events.filter((event) => event.kind === "chat.stopStream")).toHaveLength(1);
+    expect(
+      events
+        .filter((event) => event.kind === "chat.appendStream" || event.kind === "chat.stopStream")
+        .some((event) => JSON.stringify(event.data).includes("The rollout guard is enabled.")),
+    ).toBe(false);
+    expect(collectSlackWireTexts(events)).toContain("The rollout guard is enabled.");
+  });
+
+  it("routes partial-stream output below a later human message", async () => {
+    const followupAnswer = "The follow-up audit is complete.";
+    const events = await runDeliveryTraceScenario({
+      scenario: {
+        name: "partial-native-intervening-message",
+        steps: [
+          { kind: "reply-start" },
+          { kind: "final", text: NATIVE_FINAL_TEXT },
+          { kind: "partial", text: "Please audit the follow-up too." },
+          { kind: "final", text: followupAnswer },
+          { kind: "idle" },
+        ],
+      },
+      setup: async (recorder) => {
+        const dispatch = await setupSlackTrace(recorder, "streaming-happy-native");
+        return async (step) => {
+          if (step.kind === "partial") {
+            traceState.tsCounter += 1;
+            noteSlackConversationMessage({
+              accountId: "default",
+              channelId: CHANNEL_ID,
+              threadTs: INBOUND_TS,
+              messageTs: `1767225601.${String(traceState.tsCounter).padStart(6, "0")}`,
+              userId: "U_SECOND",
+              botUserId: "UBOT",
+            });
+            return;
+          }
+          await dispatch(step);
+        };
+      },
+      normalize: createSlackTsNormalizer(),
+    });
+
+    expect(events.filter((event) => event.kind === "chat.startStream")).toHaveLength(1);
+    expect(
+      events.some(
+        (event) =>
+          event.kind === "chat.postMessage" && JSON.stringify(event.data).includes(followupAnswer),
+      ),
+    ).toBe(true);
+    expect(
+      events
+        .filter((event) => event.kind === "chat.appendStream" || event.kind === "chat.stopStream")
+        .some((event) => JSON.stringify(event.data).includes(followupAnswer)),
+    ).toBe(false);
+  });
+
   it("removes a progress card detached by a later human message", async () => {
     const events = await runDeliveryTraceScenario({
       scenario: {
@@ -889,7 +993,7 @@ describe("slack delivery trace goldens", () => {
         return async (step) => {
           if (step.kind === "partial") {
             traceState.tsCounter += 1;
-            noteSlackDraftConversationMessage({
+            noteSlackConversationMessage({
               accountId: "default",
               channelId: CHANNEL_ID,
               threadTs: INBOUND_TS,

--- a/extensions/slack/src/delivery-trace.test.ts
+++ b/extensions/slack/src/delivery-trace.test.ts
@@ -24,7 +24,8 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
-import { noteSlackConversationMessage } from "./draft-message-boundaries.js";
+import { registerSlackMessageEvents } from "./monitor/events/messages.js";
+import { createSlackSystemEventTestHarness } from "./monitor/events/system-event-test-harness.js";
 import type { PreparedSlackMessage } from "./monitor/message-handler/types.js";
 import { setSlackSessionStatus } from "./session-status.js";
 import { markSlackStreamsStopped } from "./streaming.js";
@@ -763,6 +764,28 @@ function collectSlackWireTexts(events: readonly TraceEvent[]): string[] {
   return texts;
 }
 
+function createTopLevelSlackMessageIngress() {
+  const harness = createSlackSystemEventTestHarness({ dmPolicy: "open" });
+  registerSlackMessageEvents({ ctx: harness.ctx, handleSlackMessage: async () => {} });
+  const handler = harness.getHandler("message");
+  if (!handler) {
+    throw new Error("expected Slack message ingress handler");
+  }
+  return async (messageTs: string) => {
+    await handler({
+      event: {
+        type: "message",
+        channel: CHANNEL_ID,
+        channel_type: "channel",
+        user: "U_SECOND",
+        text: "Please audit the follow-up too.",
+        ts: messageTs,
+      },
+      body: {},
+    });
+  };
+}
+
 function buildSlackDeliveryProofVerdict(params: {
   scenario: SlackTraceScenarioName;
   events: readonly TraceEvent[];
@@ -872,6 +895,7 @@ describe("slack delivery trace goldens", () => {
 
   it("seals native progress before answering a later human message", async () => {
     const followupText = "Please also check the rollout guard.";
+    const emitTopLevelMessage = createTopLevelSlackMessageIngress();
     const events = await runDeliveryTraceScenario({
       scenario: {
         name: "progress-native-intervening-message",
@@ -890,14 +914,9 @@ describe("slack delivery trace goldens", () => {
         return async (step) => {
           if (step.kind === "partial" && step.text === followupText) {
             traceState.tsCounter += 1;
-            noteSlackConversationMessage({
-              accountId: "default",
-              channelId: CHANNEL_ID,
-              threadTs: INBOUND_TS,
-              messageTs: `1767225601.${String(traceState.tsCounter).padStart(6, "0")}`,
-              userId: "U_SECOND",
-              botUserId: "UBOT",
-            });
+            await emitTopLevelMessage(
+              `1767225601.${String(traceState.tsCounter).padStart(6, "0")}`,
+            );
             return;
           }
           await dispatch(step);
@@ -926,8 +945,9 @@ describe("slack delivery trace goldens", () => {
     expect(collectSlackWireTexts(events)).toContain("The rollout guard is enabled.");
   });
 
-  it("routes partial-stream output below a later human message", async () => {
+  it("routes partial-stream output below a later top-level message from Slack ingress", async () => {
     const followupAnswer = "The follow-up audit is complete.";
+    const emitTopLevelMessage = createTopLevelSlackMessageIngress();
     const events = await runDeliveryTraceScenario({
       scenario: {
         name: "partial-native-intervening-message",
@@ -944,14 +964,9 @@ describe("slack delivery trace goldens", () => {
         return async (step) => {
           if (step.kind === "partial") {
             traceState.tsCounter += 1;
-            noteSlackConversationMessage({
-              accountId: "default",
-              channelId: CHANNEL_ID,
-              threadTs: INBOUND_TS,
-              messageTs: `1767225601.${String(traceState.tsCounter).padStart(6, "0")}`,
-              userId: "U_SECOND",
-              botUserId: "UBOT",
-            });
+            await emitTopLevelMessage(
+              `1767225601.${String(traceState.tsCounter).padStart(6, "0")}`,
+            );
             return;
           }
           await dispatch(step);
@@ -960,13 +975,24 @@ describe("slack delivery trace goldens", () => {
       normalize: createSlackTsNormalizer(),
     });
 
-    expect(events.filter((event) => event.kind === "chat.startStream")).toHaveLength(1);
-    expect(
-      events.some(
-        (event) =>
-          event.kind === "chat.postMessage" && JSON.stringify(event.data).includes(followupAnswer),
-      ),
-    ).toBe(true);
+    const starts = events.filter((event) => event.kind === "chat.startStream");
+    expect(starts).toHaveLength(1);
+    expect(starts[0]?.data).toMatchObject({ payload: { thread_ts: "ts#1" } });
+    const followupPosts = events.filter(
+      (event) =>
+        event.kind === "chat.postMessage" && JSON.stringify(event.data).includes(followupAnswer),
+    );
+    expect(followupPosts).toHaveLength(1);
+    const followupPayload = followupPosts[0]?.data as
+      | { payload?: { thread_ts?: string } }
+      | undefined;
+    expect(followupPayload?.payload?.thread_ts).toBeDefined();
+    expect(followupPayload?.payload?.thread_ts).not.toBe("ts#1");
+    const stopIndex = events.findIndex((event) => event.kind === "chat.stopStream");
+    const followupIndex = events.indexOf(followupPosts[0] as TraceEvent);
+    expect(stopIndex).toBeGreaterThan(-1);
+    expect(stopIndex).toBeLessThan(followupIndex);
+    expect(events.filter((event) => event.kind === "chat.stopStream")).toHaveLength(1);
     expect(
       events
         .filter((event) => event.kind === "chat.appendStream" || event.kind === "chat.stopStream")
@@ -975,6 +1001,7 @@ describe("slack delivery trace goldens", () => {
   });
 
   it("removes a progress card detached by a later human message", async () => {
+    const emitTopLevelMessage = createTopLevelSlackMessageIngress();
     const events = await runDeliveryTraceScenario({
       scenario: {
         name: "progress-session-card-detached",
@@ -993,14 +1020,9 @@ describe("slack delivery trace goldens", () => {
         return async (step) => {
           if (step.kind === "partial") {
             traceState.tsCounter += 1;
-            noteSlackConversationMessage({
-              accountId: "default",
-              channelId: CHANNEL_ID,
-              threadTs: INBOUND_TS,
-              messageTs: `1767225601.${String(traceState.tsCounter).padStart(6, "0")}`,
-              userId: "U_SECOND",
-              botUserId: "UBOT",
-            });
+            await emitTopLevelMessage(
+              `1767225601.${String(traceState.tsCounter).padStart(6, "0")}`,
+            );
             // A changed authored status moves progress below the human message;
             // ordinary tool activity intentionally leaves the summary unchanged.
             await traceState.turn?.replyOptions.onItemEvent?.({

--- a/extensions/slack/src/delivery-trace.test.ts
+++ b/extensions/slack/src/delivery-trace.test.ts
@@ -943,6 +943,10 @@ describe("slack delivery trace goldens", () => {
         .some((event) => JSON.stringify(event.data).includes("The rollout guard is enabled.")),
     ).toBe(false);
     expect(collectSlackWireTexts(events)).toContain("The rollout guard is enabled.");
+    const followupPost = events[followupIndex];
+    expect(
+      (followupPost?.data as { payload?: { thread_ts?: string } } | undefined)?.payload?.thread_ts,
+    ).toBe("ts#3");
   });
 
   it("routes partial-stream output below a later top-level message from Slack ingress", async () => {

--- a/extensions/slack/src/draft-message-boundaries.ts
+++ b/extensions/slack/src/draft-message-boundaries.ts
@@ -7,8 +7,13 @@ type SlackDraftConversation = {
 
 type ActiveSlackReply = {
   messageTs?: string;
-  latestHumanMessageTs?: string;
-  onInterveningMessage: () => void;
+  latestHumanMessage?: SlackConversationMessageBoundary;
+  onInterveningMessage: (boundary: SlackConversationMessageBoundary) => void;
+};
+
+export type SlackConversationMessageBoundary = {
+  messageTs: string;
+  threadTs?: string;
 };
 
 export type SlackMessageBoundaryTracker = {
@@ -62,10 +67,10 @@ export function trackSlackConversationMessage(
     setMessageTs: (messageTs) => {
       activeReply.messageTs = messageTs;
       if (
-        activeReply.latestHumanMessageTs &&
-        isLaterSlackMessage(activeReply.latestHumanMessageTs, messageTs)
+        activeReply.latestHumanMessage &&
+        isLaterSlackMessage(activeReply.latestHumanMessage.messageTs, messageTs)
       ) {
-        activeReply.onInterveningMessage();
+        activeReply.onInterveningMessage(activeReply.latestHumanMessage);
       }
     },
     stop,
@@ -98,18 +103,22 @@ export function noteSlackConversationMessage(
   }
 
   for (const reply of replies) {
+    const boundary: SlackConversationMessageBoundary = {
+      messageTs: conversation.messageTs,
+      ...(conversation.threadTs ? { threadTs: conversation.threadTs } : {}),
+    };
     if (!reply.messageTs) {
       if (
-        !reply.latestHumanMessageTs ||
-        isLaterSlackMessage(conversation.messageTs, reply.latestHumanMessageTs)
+        !reply.latestHumanMessage ||
+        isLaterSlackMessage(conversation.messageTs, reply.latestHumanMessage.messageTs)
       ) {
         // Slack can deliver the next message before chat.postMessage returns its timestamp.
-        reply.latestHumanMessageTs = conversation.messageTs;
+        reply.latestHumanMessage = boundary;
       }
       continue;
     }
     if (isLaterSlackMessage(conversation.messageTs, reply.messageTs)) {
-      reply.onInterveningMessage();
+      reply.onInterveningMessage(boundary);
     }
   }
 }

--- a/extensions/slack/src/draft-message-boundaries.ts
+++ b/extensions/slack/src/draft-message-boundaries.ts
@@ -5,18 +5,18 @@ type SlackDraftConversation = {
   threadTs?: string;
 };
 
-type ActiveSlackDraft = {
+type ActiveSlackReply = {
   messageTs?: string;
   latestHumanMessageTs?: string;
   onInterveningMessage: () => void;
 };
 
-type SlackDraftMessageTracker = {
+export type SlackMessageBoundaryTracker = {
   setMessageTs: (messageTs: string) => void;
   stop: () => void;
 };
 
-const activeDraftsByConversation = new Map<string, Set<ActiveSlackDraft>>();
+const activeRepliesByConversation = new Map<string, Set<ActiveSlackReply>>();
 
 function conversationKey(conversation: SlackDraftConversation): string {
   return [
@@ -37,35 +37,35 @@ function isLaterSlackMessage(candidate: string, current: string): boolean {
   );
 }
 
-/** Keeps a live preview attached to its actual place in the Slack conversation. */
-export function trackSlackDraftMessage(
-  conversation: SlackDraftConversation & ActiveSlackDraft,
-): SlackDraftMessageTracker {
+/** Keeps an in-flight reply attached to its actual place in the Slack conversation. */
+export function trackSlackConversationMessage(
+  conversation: SlackDraftConversation & ActiveSlackReply,
+): SlackMessageBoundaryTracker {
   const key = conversationKey(conversation);
-  const activeDraft: ActiveSlackDraft = {
+  const activeReply: ActiveSlackReply = {
     messageTs: conversation.messageTs,
     onInterveningMessage: conversation.onInterveningMessage,
   };
-  const drafts = activeDraftsByConversation.get(key) ?? new Set<ActiveSlackDraft>();
-  drafts.add(activeDraft);
-  activeDraftsByConversation.set(key, drafts);
+  const replies = activeRepliesByConversation.get(key) ?? new Set<ActiveSlackReply>();
+  replies.add(activeReply);
+  activeRepliesByConversation.set(key, replies);
 
   const stop = () => {
-    const currentDrafts = activeDraftsByConversation.get(key);
-    currentDrafts?.delete(activeDraft);
-    if (currentDrafts?.size === 0) {
-      activeDraftsByConversation.delete(key);
+    const currentReplies = activeRepliesByConversation.get(key);
+    currentReplies?.delete(activeReply);
+    if (currentReplies?.size === 0) {
+      activeRepliesByConversation.delete(key);
     }
   };
 
   return {
     setMessageTs: (messageTs) => {
-      activeDraft.messageTs = messageTs;
+      activeReply.messageTs = messageTs;
       if (
-        activeDraft.latestHumanMessageTs &&
-        isLaterSlackMessage(activeDraft.latestHumanMessageTs, messageTs)
+        activeReply.latestHumanMessageTs &&
+        isLaterSlackMessage(activeReply.latestHumanMessageTs, messageTs)
       ) {
-        activeDraft.onInterveningMessage();
+        activeReply.onInterveningMessage();
       }
     },
     stop,
@@ -73,7 +73,7 @@ export function trackSlackDraftMessage(
 }
 
 /** A later human message means subsequent assistant output belongs below it. */
-export function noteSlackDraftConversationMessage(
+export function noteSlackConversationMessage(
   conversation: SlackDraftConversation & {
     messageTs?: string;
     userId?: string;
@@ -92,24 +92,24 @@ export function noteSlackDraftConversationMessage(
     return;
   }
 
-  const drafts = activeDraftsByConversation.get(conversationKey(conversation));
-  if (!drafts) {
+  const replies = activeRepliesByConversation.get(conversationKey(conversation));
+  if (!replies) {
     return;
   }
 
-  for (const draft of drafts) {
-    if (!draft.messageTs) {
+  for (const reply of replies) {
+    if (!reply.messageTs) {
       if (
-        !draft.latestHumanMessageTs ||
-        isLaterSlackMessage(conversation.messageTs, draft.latestHumanMessageTs)
+        !reply.latestHumanMessageTs ||
+        isLaterSlackMessage(conversation.messageTs, reply.latestHumanMessageTs)
       ) {
         // Slack can deliver the next message before chat.postMessage returns its timestamp.
-        draft.latestHumanMessageTs = conversation.messageTs;
+        reply.latestHumanMessageTs = conversation.messageTs;
       }
       continue;
     }
-    if (isLaterSlackMessage(conversation.messageTs, draft.messageTs)) {
-      draft.onInterveningMessage();
+    if (isLaterSlackMessage(conversation.messageTs, reply.messageTs)) {
+      reply.onInterveningMessage();
     }
   }
 }

--- a/extensions/slack/src/draft-stream.test.ts
+++ b/extensions/slack/src/draft-stream.test.ts
@@ -1,7 +1,7 @@
 // Slack tests cover draft stream plugin behavior.
 import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import { describe, expect, it, vi } from "vitest";
-import { noteSlackDraftConversationMessage } from "./draft-message-boundaries.js";
+import { noteSlackConversationMessage } from "./draft-message-boundaries.js";
 import { createSlackDraftStream } from "./draft-stream.js";
 
 type DraftStreamParams = Parameters<typeof createSlackDraftStream>[0];
@@ -243,7 +243,7 @@ describe("createSlackDraftStream", () => {
 
     stream.update("_first card_");
     await stream.flush();
-    noteSlackDraftConversationMessage({
+    noteSlackConversationMessage({
       accountId,
       channelId: "C123",
       threadTs: "100.000",
@@ -258,7 +258,7 @@ describe("createSlackDraftStream", () => {
 
     stream.update("_second card_");
     await stream.flush();
-    noteSlackDraftConversationMessage({
+    noteSlackConversationMessage({
       accountId,
       channelId: "C123",
       threadTs: "100.000",
@@ -337,7 +337,7 @@ describe("createSlackDraftStream", () => {
     stream.update("_looking into the original question_");
     await stream.flush();
 
-    noteSlackDraftConversationMessage({
+    noteSlackConversationMessage({
       accountId,
       channelId: "C123",
       threadTs: "100.000",
@@ -379,7 +379,7 @@ describe("createSlackDraftStream", () => {
 
     stream.update("_first update_");
     await stream.flush();
-    noteSlackDraftConversationMessage({
+    noteSlackConversationMessage({
       accountId,
       channelId: "C123",
       threadTs: "100.000",
@@ -389,7 +389,7 @@ describe("createSlackDraftStream", () => {
 
     stream.update("_second update_");
     await stream.flush();
-    noteSlackDraftConversationMessage({
+    noteSlackConversationMessage({
       accountId,
       channelId: "C123",
       threadTs: "100.000",
@@ -428,7 +428,7 @@ describe("createSlackDraftStream", () => {
       expect(send).toHaveBeenCalledOnce();
     });
 
-    noteSlackDraftConversationMessage({
+    noteSlackConversationMessage({
       accountId,
       channelId: "C123",
       threadTs: "100.000",
@@ -459,7 +459,7 @@ describe("createSlackDraftStream", () => {
 
     stream.update("_looking into this_");
     await stream.flush();
-    noteSlackDraftConversationMessage({
+    noteSlackConversationMessage({
       accountId,
       channelId: "C123",
       messageTs: "100.200",
@@ -491,7 +491,7 @@ describe("createSlackDraftStream", () => {
 
     stream.update("_first workspace_");
     await stream.flush();
-    noteSlackDraftConversationMessage({
+    noteSlackConversationMessage({
       accountId,
       teamId: "T_SECOND",
       channelId: "C123",
@@ -505,7 +505,7 @@ describe("createSlackDraftStream", () => {
     expect(send).toHaveBeenCalledOnce();
     expect(edit).toHaveBeenCalledOnce();
 
-    noteSlackDraftConversationMessage({
+    noteSlackConversationMessage({
       accountId,
       teamId: "T_FIRST",
       channelId: "C123",
@@ -550,7 +550,7 @@ describe("createSlackDraftStream", () => {
         botId: "B_OTHER",
       },
     ]) {
-      noteSlackDraftConversationMessage({ accountId, ...event });
+      noteSlackConversationMessage({ accountId, ...event });
     }
 
     stream.update("_latest update_");
@@ -579,7 +579,7 @@ describe("createSlackDraftStream", () => {
       await finalEdit;
     });
 
-    noteSlackDraftConversationMessage({
+    noteSlackConversationMessage({
       accountId,
       channelId: "C123",
       threadTs: "100.000",
@@ -607,7 +607,7 @@ describe("createSlackDraftStream", () => {
     stream.update("_nearly finished_");
     await stream.flush();
     await stream.seal();
-    noteSlackDraftConversationMessage({
+    noteSlackConversationMessage({
       accountId,
       channelId: "C123",
       threadTs: "100.000",
@@ -629,7 +629,7 @@ describe("createSlackDraftStream", () => {
     await stream.seal();
     await stream.finalizeMessage("111.222", async () => {});
 
-    noteSlackDraftConversationMessage({
+    noteSlackConversationMessage({
       accountId,
       channelId: "C123",
       threadTs: "100.000",

--- a/extensions/slack/src/draft-stream.test.ts
+++ b/extensions/slack/src/draft-stream.test.ts
@@ -33,6 +33,7 @@ function createDraftStreamHarness(
     accountId?: string;
     maxChars?: number;
     threadTs?: string;
+    conversationThreadTs?: string;
     send?: DraftSendFn;
     edit?: DraftEditFn;
     eventScope?: DraftStreamParams["eventScope"];
@@ -50,6 +51,9 @@ function createDraftStreamHarness(
     token: "xoxb-test",
     accountId: params.accountId,
     conversationChannelId: "C123",
+    conversationThreadTs: Object.hasOwn(params, "conversationThreadTs")
+      ? params.conversationThreadTs
+      : params.threadTs,
     throttleMs: 250,
     maxChars: params.maxChars,
     eventScope: params.eventScope,
@@ -362,6 +366,28 @@ describe("createSlackDraftStream", () => {
       expect.objectContaining({ accountId }),
     );
     expect(stream.messageId()).toBe("100.300");
+  });
+
+  it("keys a top-level conversation separately from its threaded outbound reply", async () => {
+    const accountId = "top-level-threaded-reply";
+    const send = vi.fn<DraftSendFn>(async () => slackDraftSendResult("100.100"));
+    const { stream } = createDraftStreamHarness({
+      accountId,
+      threadTs: "100.000",
+      conversationThreadTs: undefined,
+      send,
+    });
+
+    stream.update("_working on the first message_");
+    await stream.flush();
+    noteSlackConversationMessage({
+      accountId,
+      channelId: "C123",
+      messageTs: "100.200",
+      userId: "U_OWNER",
+    });
+
+    expect(stream.messageId()).toBeUndefined();
   });
 
   it("keeps moving below repeated interruptions from different participants", async () => {

--- a/extensions/slack/src/draft-stream.ts
+++ b/extensions/slack/src/draft-stream.ts
@@ -41,6 +41,7 @@ export function createSlackDraftStream(params: {
   token: string;
   accountId?: string;
   conversationChannelId?: string;
+  conversationThreadTs?: string;
   eventScope?: SlackEventScope;
   identity?: SlackSendIdentity;
   maxChars?: number;
@@ -109,7 +110,7 @@ export function createSlackDraftStream(params: {
             accountId: params.accountId,
             teamId: params.eventScope?.teamId,
             channelId: params.conversationChannelId,
-            threadTs,
+            threadTs: params.conversationThreadTs,
             onInterveningMessage: forceNewMessage,
           })
         : undefined;
@@ -140,7 +141,7 @@ export function createSlackDraftStream(params: {
           accountId: params.accountId,
           teamId: params.eventScope?.teamId,
           channelId: streamMessage.channelId,
-          threadTs,
+          threadTs: params.conversationThreadTs,
           messageTs: streamMessage.messageId,
           onInterveningMessage: forceNewMessage,
         });

--- a/extensions/slack/src/draft-stream.ts
+++ b/extensions/slack/src/draft-stream.ts
@@ -4,7 +4,7 @@ import type { Block, KnownBlock } from "@slack/web-api";
 import { createFinalizableDraftStreamControlsForState } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { deleteSlackMessage, editSlackMessage } from "./actions.js";
-import { trackSlackDraftMessage } from "./draft-message-boundaries.js";
+import { trackSlackConversationMessage } from "./draft-message-boundaries.js";
 import { formatSlackError } from "./errors.js";
 import { SLACK_TEXT_LIMIT } from "./limits.js";
 import type { SlackEventScope } from "./monitor/event-scope.js";
@@ -105,7 +105,7 @@ export function createSlackDraftStream(params: {
       }
       const threadTs = params.resolveThreadTs?.();
       const pendingBoundary = params.conversationChannelId
-        ? trackSlackDraftMessage({
+        ? trackSlackConversationMessage({
             accountId: params.accountId,
             teamId: params.eventScope?.teamId,
             channelId: params.conversationChannelId,
@@ -136,7 +136,7 @@ export function createSlackDraftStream(params: {
         pendingBoundary.setMessageTs(streamMessage.messageId);
       } else {
         stopTrackingConversationBoundary();
-        const tracker = trackSlackDraftMessage({
+        const tracker = trackSlackConversationMessage({
           accountId: params.accountId,
           teamId: params.eventScope?.teamId,
           channelId: streamMessage.channelId,

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -19,7 +19,7 @@ const { messageQueueMock, messageAllowMock, inboundInfoSpy, noteConversationMess
   }));
 
 vi.mock("../../draft-message-boundaries.js", () => ({
-  noteSlackDraftConversationMessage: (...args: unknown[]) => noteConversationMessageMock(...args),
+  noteSlackConversationMessage: (...args: unknown[]) => noteConversationMessageMock(...args),
 }));
 
 vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -12,7 +12,7 @@ import {
   normalizeOptionalString as asString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
-import { noteSlackDraftConversationMessage } from "../../draft-message-boundaries.js";
+import { noteSlackConversationMessage } from "../../draft-message-boundaries.js";
 import type { SlackAppMentionEvent, SlackMessageEvent } from "../../types.js";
 import { normalizeSlackChannelType } from "../channel-type.js";
 import type { SlackMonitorContext } from "../context.js";
@@ -212,7 +212,7 @@ export function registerSlackMessageEvents(params: {
     message: SlackMessageEvent | SlackAppMentionEvent,
     eventScope?: SlackEventScope,
   ) => {
-    noteSlackDraftConversationMessage({
+    noteSlackConversationMessage({
       accountId: ctx.accountId,
       teamId: eventScope?.teamId,
       channelId: message.channel,

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress-native.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress-native.ts
@@ -8,12 +8,11 @@ import type { SlackStreamingDeliveryRuntime } from "./dispatch-streaming.js";
 export function createSlackNativeProgressTransport(params: {
   setup: Pick<
     SlackDispatchSetup,
-    "ctx" | "message" | "replyPlan" | "slackClient" | "slackIdentity" | "slackStreamFallbackTeamId"
+    "ctx" | "message" | "slackClient" | "slackIdentity" | "slackStreamFallbackTeamId"
   >;
   delivery: SlackStreamingDeliveryRuntime;
 }) {
-  const { ctx, message, replyPlan, slackClient, slackIdentity, slackStreamFallbackTeamId } =
-    params.setup;
+  const { ctx, message, slackClient, slackIdentity, slackStreamFallbackTeamId } = params.setup;
   const { delivery } = params;
 
   const markDelivered = (threadTs?: string) => {
@@ -43,7 +42,7 @@ export function createSlackNativeProgressTransport(params: {
   };
 
   const start = async (update: { text?: string; chunks?: AnyChunk[] }): Promise<boolean> => {
-    const streamThreadTs = replyPlan.nextThreadTs();
+    const streamThreadTs = delivery.nextStreamThreadTs();
     if (!streamThreadTs) {
       logVerbose(
         "slack-stream: no reply thread target for native progress stream start, falling back",
@@ -52,7 +51,7 @@ export function createSlackNativeProgressTransport(params: {
       return false;
     }
     delivery.nativeProgressStreamThreadTs = streamThreadTs;
-    delivery.startStreamBoundaryTracking(streamThreadTs);
+    delivery.startStreamBoundaryTracking();
     const startPromise = (async () => {
       const session = await startSlackStream({
         client: slackClient,

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress-native.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress-native.ts
@@ -52,6 +52,7 @@ export function createSlackNativeProgressTransport(params: {
       return false;
     }
     delivery.nativeProgressStreamThreadTs = streamThreadTs;
+    delivery.startStreamBoundaryTracking(streamThreadTs);
     const startPromise = (async () => {
       const session = await startSlackStream({
         client: slackClient,
@@ -70,6 +71,7 @@ export function createSlackNativeProgressTransport(params: {
         userId: message.user,
       });
       delivery.streamSession = session;
+      delivery.syncStreamBoundaryMessageTs(session);
       return session;
     })();
     delivery.nativeProgressStreamStartPromise = startPromise;
@@ -97,6 +99,7 @@ export function createSlackNativeProgressTransport(params: {
       ...(update.text ? { text: update.text } : {}),
       ...(update.chunks?.length ? { chunks: update.chunks } : {}),
     });
+    delivery.syncStreamBoundaryMessageTs(session);
     const delivered = markDelivered(delivery.nativeProgressStreamThreadTs);
     return update.chunks?.length ? delivered : true;
   };

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -71,6 +71,7 @@ export function createSlackProgressRuntime(runtimeParams: {
         token: ctx.botToken,
         accountId: account.accountId,
         conversationChannelId: message.channel,
+        conversationThreadTs: message.thread_ts,
         eventScope: prepared.eventScope,
         // Impersonated Slack messages cannot be deleted. Keep the temporary
         // preview app-authored and apply custom identity only to final delivery.
@@ -650,7 +651,7 @@ export function createSlackProgressRuntime(runtimeParams: {
       ? () => {
           void withNativeStreamOrder(async () => {
             await beginNewProgressTurn({ force: true });
-          }).catch((err) => {
+          }).catch((err: unknown) => {
             runtime.error?.(
               danger(`slack-stream: failed to rotate after human reply: ${formatSlackError(err)}`),
             );

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -452,6 +452,7 @@ export function createSlackProgressRuntime(runtimeParams: {
       await delivery.nativeProgressStreamStartPromise.catch(() => null);
     }
     const session = delivery.streamSession;
+    delivery.stopStreamBoundaryTracking();
     if (session && !session.stopped) {
       try {
         if (completionChunks?.length) {
@@ -644,6 +645,19 @@ export function createSlackProgressRuntime(runtimeParams: {
     delivery.resetDeliveryTracker();
     return true;
   };
+  delivery.setInterveningMessageHandler(
+    useNativeProgressStreaming
+      ? () => {
+          void withNativeStreamOrder(async () => {
+            await beginNewProgressTurn({ force: true });
+          }).catch((err) => {
+            runtime.error?.(
+              danger(`slack-stream: failed to rotate after human reply: ${formatSlackError(err)}`),
+            );
+          });
+        }
+      : undefined,
+  );
   const onDraftBoundary =
     !shouldUseDraftStream && !useNativeProgressStreaming
       ? undefined

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -387,7 +387,7 @@ export function createSlackProgressRuntime(runtimeParams: {
   const deliverNativeFinalNow = async (payload: ReplyPayload, kind: ReplyDispatchKind) => {
     progressDraft.markFinalReplyStarted();
     const streamReady = await nativeTransport.waitForStart();
-    const finalThreadTs = delivery.streamSession?.threadTs ?? delivery.nativeProgressStreamThreadTs;
+    const finalThreadTs = delivery.resolvePostBoundaryThreadTs();
     // A short narration leaves the session buffered locally (`delivered` false)
     // because `stop` can be its first network call. Requiring delivery here
     // sent the final normally and then finalized the stream anyway, which is

--- a/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
@@ -4,6 +4,7 @@ import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import {
   trackSlackConversationMessage,
+  type SlackConversationMessageBoundary,
   type SlackMessageBoundaryTracker,
 } from "../../draft-message-boundaries.js";
 import { formatSlackError } from "../../errors.js";
@@ -50,6 +51,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     streamSession: null as SlackStreamSession | null,
     nativeProgressStreamStartPromise: null as Promise<SlackStreamSession | null> | null,
     nativeProgressStreamThreadTs: undefined as string | undefined,
+    interveningReplyThreadTs: undefined as string | undefined,
     streamFailed: false,
     usedReplyThreadTs: undefined as string | undefined,
     usedBlockReplyThreadTs: undefined as string | undefined,
@@ -57,22 +59,26 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     observedFinalReplyDelivery: false,
   };
   let streamBoundaryTracker: SlackMessageBoundaryTracker | null = null;
+  let interveningStreamStopPromise: Promise<void> | null = null;
   let onInterveningMessage: (() => void) | undefined;
 
   const stopStreamBoundaryTracking = () => {
     streamBoundaryTracker?.stop();
     streamBoundaryTracker = null;
   };
-  const startStreamBoundaryTracking = (threadTs: string) => {
+  const startStreamBoundaryTracking = () => {
     stopStreamBoundaryTracking();
     streamBoundaryTracker = trackSlackConversationMessage({
       accountId: account.accountId,
       teamId: prepared.eventScope?.teamId,
       channelId: message.channel,
-      threadTs,
-      onInterveningMessage: () => {
+      // Boundary ownership follows the inbound conversation. The outbound
+      // reply target may be the top-level message ts when replyToMode=all.
+      threadTs: message.thread_ts,
+      onInterveningMessage: (boundary: SlackConversationMessageBoundary) => {
         // Once a human reply overtakes this stream, no later payload may be
         // appended to it. Progress mode additionally seals its task card.
+        state.interveningReplyThreadTs = boundary.threadTs ?? boundary.messageTs;
         state.streamFailed = true;
         onInterveningMessage?.();
       },
@@ -401,6 +407,52 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     return true;
   };
 
+  const settleIntervenedStream = async () => {
+    if (onInterveningMessage) {
+      return;
+    }
+    if (interveningStreamStopPromise) {
+      await interveningStreamStopPromise;
+      return;
+    }
+    const session = state.streamSession;
+    if (!session || session.stopped) {
+      return;
+    }
+    const stopPromise = (async () => {
+      try {
+        const stopResult = await stopSlackStream({
+          session,
+          ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
+        });
+        acknowledgeStoppedStreamedDeliveries(session, stopResult.messageId);
+        state.observedReplyDelivery = true;
+        state.usedReplyThreadTs ??= session.threadTs;
+      } catch (err) {
+        if (err instanceof SlackStreamNotDeliveredError) {
+          await deliverPendingStreamFallback(session, err);
+        } else {
+          const error = formatSlackError(err);
+          emitAcknowledgedStreamedDeliveries();
+          emitFailedPendingStreamedDeliveries(error);
+          runtime.error?.(danger(`slack-stream: failed to seal before human reply: ${error}`));
+        }
+      } finally {
+        if (state.streamSession === session) {
+          state.streamSession = null;
+        }
+      }
+    })();
+    interveningStreamStopPromise = stopPromise;
+    try {
+      await stopPromise;
+    } finally {
+      if (interveningStreamStopPromise === stopPromise) {
+        interveningStreamStopPromise = null;
+      }
+    }
+  };
+
   const isStreamingEligible = (payload: ReplyPayload, options?: { maxTextBytes?: number }) => {
     const reply = resolveSendableOutboundReplyParts(payload);
     const renderPlan = resolveSlackReplyRenderPlan(payload);
@@ -430,10 +482,16 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     }
     const reply = resolveSendableOutboundReplyParts(params.payload);
     if (!isStreamingEligible(params.payload)) {
+      if (state.streamFailed) {
+        await settleIntervenedStream();
+      }
       await deliverNormally({
         payload: params.payload,
         kind: params.kind,
-        forcedThreadTs: state.streamSession?.threadTs ?? state.nativeProgressStreamThreadTs,
+        forcedThreadTs:
+          state.interveningReplyThreadTs ??
+          state.streamSession?.threadTs ??
+          state.nativeProgressStreamThreadTs,
       });
       return;
     }
@@ -453,15 +511,19 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
         return;
       }
       if (state.streamFailed) {
+        await settleIntervenedStream();
         await deliverNormally({
           payload: params.payload,
           kind: params.kind,
-          forcedThreadTs: state.streamSession?.threadTs ?? state.nativeProgressStreamThreadTs,
+          forcedThreadTs:
+            state.interveningReplyThreadTs ??
+            state.streamSession?.threadTs ??
+            state.nativeProgressStreamThreadTs,
         });
         return;
       }
       if (!state.streamSession) {
-        const streamThreadTs = replyPlan.nextThreadTs();
+        const streamThreadTs = state.interveningReplyThreadTs ?? replyPlan.nextThreadTs();
         plannedThreadTs = streamThreadTs;
         if (!streamThreadTs) {
           logVerbose(
@@ -486,7 +548,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
           return;
         }
 
-        startStreamBoundaryTracking(streamThreadTs);
+        startStreamBoundaryTracking();
         state.streamSession = await startSlackStream({
           client: slackClient,
           channel: message.channel,
@@ -653,6 +715,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     setInterveningMessageHandler: (handler?: () => void) => {
       onInterveningMessage = handler;
     },
+    nextStreamThreadTs: () => state.interveningReplyThreadTs ?? replyPlan.nextThreadTs(),
     startStreamBoundaryTracking,
     stopStreamBoundaryTracking,
     syncStreamBoundaryMessageTs,

--- a/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
@@ -2,6 +2,10 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import {
+  trackSlackConversationMessage,
+  type SlackMessageBoundaryTracker,
+} from "../../draft-message-boundaries.js";
 import { formatSlackError } from "../../errors.js";
 import { emitSlackMessageSentHooks } from "../../message-sent-hook.js";
 import { resolveSlackReplyRenderPlan } from "../../reply-blocks.js";
@@ -51,6 +55,34 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     usedBlockReplyThreadTs: undefined as string | undefined,
     observedReplyDelivery: false,
     observedFinalReplyDelivery: false,
+  };
+  let streamBoundaryTracker: SlackMessageBoundaryTracker | null = null;
+  let onInterveningMessage: (() => void) | undefined;
+
+  const stopStreamBoundaryTracking = () => {
+    streamBoundaryTracker?.stop();
+    streamBoundaryTracker = null;
+  };
+  const startStreamBoundaryTracking = (threadTs: string) => {
+    stopStreamBoundaryTracking();
+    streamBoundaryTracker = trackSlackConversationMessage({
+      accountId: account.accountId,
+      teamId: prepared.eventScope?.teamId,
+      channelId: message.channel,
+      threadTs,
+      onInterveningMessage: () => {
+        // Once a human reply overtakes this stream, no later payload may be
+        // appended to it. Progress mode additionally seals its task card.
+        state.streamFailed = true;
+        onInterveningMessage?.();
+      },
+    });
+  };
+  const syncStreamBoundaryMessageTs = (session: SlackStreamSession) => {
+    const messageTs = session.streamer?.ts;
+    if (messageTs) {
+      streamBoundaryTracker?.setMessageTs(messageTs);
+    }
   };
   // Reply payloads routed through the native text stream. Track Slack
   // acknowledgement separately because a later buffered suffix can fall back
@@ -454,6 +486,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
           return;
         }
 
+        startStreamBoundaryTracking(streamThreadTs);
         state.streamSession = await startSlackStream({
           client: slackClient,
           channel: message.channel,
@@ -477,6 +510,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
           acknowledgeStoppedStreamedDeliveries(state.streamSession);
           return;
         }
+        syncStreamBoundaryMessageTs(state.streamSession);
         refreshStreamedAcknowledgements(state.streamSession);
         // startSlackStream may only buffer locally. Count delivery only after
         // the SDK reports a real Slack response.
@@ -530,6 +564,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
         acknowledgeStoppedStreamedDeliveries(state.streamSession);
         return;
       }
+      syncStreamBoundaryMessageTs(state.streamSession);
       refreshStreamedAcknowledgements(state.streamSession);
       // appendSlackStream also buffers locally below the SDK threshold; avoid
       // optimistic "done" status until Slack acknowledges a flush.
@@ -615,6 +650,12 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     isStreamingEligible,
     markPreviewPayloadDelivered,
     rememberDeliveredThreadTs,
+    setInterveningMessageHandler: (handler?: () => void) => {
+      onInterveningMessage = handler;
+    },
+    startStreamBoundaryTracking,
+    stopStreamBoundaryTracking,
+    syncStreamBoundaryMessageTs,
     resetDeliveryTracker: () => {
       deliveryTracker = createSlackEventDeliveryTracker();
     },

--- a/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
@@ -51,7 +51,6 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     streamSession: null as SlackStreamSession | null,
     nativeProgressStreamStartPromise: null as Promise<SlackStreamSession | null> | null,
     nativeProgressStreamThreadTs: undefined as string | undefined,
-    interveningReplyThreadTs: undefined as string | undefined,
     streamFailed: false,
     usedReplyThreadTs: undefined as string | undefined,
     usedBlockReplyThreadTs: undefined as string | undefined,
@@ -60,6 +59,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
   };
   let streamBoundaryTracker: SlackMessageBoundaryTracker | null = null;
   let interveningStreamStopPromise: Promise<void> | null = null;
+  let interveningReplyThreadTs: string | undefined;
   let onInterveningMessage: (() => void) | undefined;
 
   const stopStreamBoundaryTracking = () => {
@@ -78,7 +78,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
       onInterveningMessage: (boundary: SlackConversationMessageBoundary) => {
         // Once a human reply overtakes this stream, no later payload may be
         // appended to it. Progress mode additionally seals its task card.
-        state.interveningReplyThreadTs = boundary.threadTs ?? boundary.messageTs;
+        interveningReplyThreadTs = boundary.threadTs ?? boundary.messageTs;
         state.streamFailed = true;
         onInterveningMessage?.();
       },
@@ -204,8 +204,10 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     kind: ReplyDispatchKind;
     forcedThreadTs?: string;
   }): string | undefined => {
-    const plannedThreadTs = params.forcedThreadTs ? undefined : replyPlan.nextThreadTs();
+    const plannedThreadTs =
+      interveningReplyThreadTs || params.forcedThreadTs ? undefined : replyPlan.nextThreadTs();
     return (
+      interveningReplyThreadTs ??
       params.forcedThreadTs ??
       plannedThreadTs ??
       (params.kind === "block" ? state.usedBlockReplyThreadTs : undefined)
@@ -468,6 +470,8 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
       (!options?.maxTextBytes || countSlackTextUtf8Bytes(reply.trimmedText) <= options.maxTextBytes)
     );
   };
+  const resolvePostBoundaryThreadTs = () =>
+    interveningReplyThreadTs ?? state.streamSession?.threadTs ?? state.nativeProgressStreamThreadTs;
 
   const deliverWithStreaming = async (params: {
     payload: ReplyPayload;
@@ -488,10 +492,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
       await deliverNormally({
         payload: params.payload,
         kind: params.kind,
-        forcedThreadTs:
-          state.interveningReplyThreadTs ??
-          state.streamSession?.threadTs ??
-          state.nativeProgressStreamThreadTs,
+        forcedThreadTs: resolvePostBoundaryThreadTs(),
       });
       return;
     }
@@ -515,15 +516,12 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
         await deliverNormally({
           payload: params.payload,
           kind: params.kind,
-          forcedThreadTs:
-            state.interveningReplyThreadTs ??
-            state.streamSession?.threadTs ??
-            state.nativeProgressStreamThreadTs,
+          forcedThreadTs: resolvePostBoundaryThreadTs(),
         });
         return;
       }
       if (!state.streamSession) {
-        const streamThreadTs = state.interveningReplyThreadTs ?? replyPlan.nextThreadTs();
+        const streamThreadTs = interveningReplyThreadTs ?? replyPlan.nextThreadTs();
         plannedThreadTs = streamThreadTs;
         if (!streamThreadTs) {
           logVerbose(
@@ -695,8 +693,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
       await deliverNormally({
         payload: params.payload,
         kind: params.kind,
-        forcedThreadTs:
-          state.streamSession?.threadTs ?? state.nativeProgressStreamThreadTs ?? plannedThreadTs,
+        forcedThreadTs: resolvePostBoundaryThreadTs() ?? plannedThreadTs,
       });
     }
   };
@@ -712,10 +709,11 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     isStreamingEligible,
     markPreviewPayloadDelivered,
     rememberDeliveredThreadTs,
+    resolvePostBoundaryThreadTs,
     setInterveningMessageHandler: (handler?: () => void) => {
       onInterveningMessage = handler;
     },
-    nextStreamThreadTs: () => state.interveningReplyThreadTs ?? replyPlan.nextThreadTs(),
+    nextStreamThreadTs: () => interveningReplyThreadTs ?? replyPlan.nextThreadTs(),
     startStreamBoundaryTracking,
     stopStreamBoundaryTracking,
     syncStreamBoundaryMessageTs,

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -196,8 +196,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           await delivery.deliverNormally({
             payload,
             kind: info.kind,
-            forcedThreadTs:
-              delivery.streamSession?.threadTs ?? delivery.nativeProgressStreamThreadTs,
+            forcedThreadTs: delivery.resolvePostBoundaryThreadTs(),
           });
           return;
         }
@@ -208,7 +207,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       await delivery.deliverNormally({
         payload,
         kind: info.kind,
-        forcedThreadTs: delivery.streamSession?.threadTs ?? delivery.nativeProgressStreamThreadTs,
+        forcedThreadTs: delivery.resolvePostBoundaryThreadTs(),
       });
       return;
     }

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -564,6 +564,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   // Finalize the stream if one was started
   // -----------------------------------------------------------------------
   let streamFallbackDelivered = false;
+  delivery.stopStreamBoundaryTracking();
   const finalStream = delivery.streamSession as SlackStreamSession | null;
   if (finalStream && !finalStream.stopped) {
     try {


### PR DESCRIPTION
Closes #134644

## What Problem This Solves

Fixes an issue where a Slack user who sends a second top-level message while a native-streamed answer is still running could see the later answer continue inside the earlier assistant stream. The visible order could become `message A -> message B -> answer(A+B)` instead of keeping each answer below the message that owns it.

## Why This Change Was Made

The previous patch tracked the outbound reply thread. That is not the conversation identity used by Slack ingress: with `replyToMode=all`, a top-level message A can produce an outbound stream under A's timestamp, while a later top-level message B arrives with no `thread_ts`. The keys therefore did not match.

This revision separates the two identities:

- inbound conversation scope (`message.thread_ts`) owns the later-human-message boundary;
- outbound thread timestamps remain delivery targets only;
- a qualifying later message seals the overtaken stream once and records B's timestamp as the next reply target;
- the Slack delivery owner now resolves one canonical target with `later B > caller fallback > original A`, so final, error, media, blocks, oversized text, and streaming-error fallbacks cannot bypass the boundary;
- native progress rotates through its serialized transition, while native partial streaming falls back to a separate stream/message under B.

The repair stays in the Slack delivery owner. It does not change generic steering, provider behavior, Gateway protocol, config, defaults, schemas, security policy, or compatibility behavior.

## User Impact

Slack conversations preserve chronological ownership during mid-turn steering: a later answer is delivered below the later human message and is never appended to the earlier native stream.

## Evidence

### Exact-head proof receipt

- Product head SHA: `4c92fb20b2c3aeaa58f1f258ef8c7c0ece275800`
- Integrated main snapshot (merge-base): `41419be40bbb17e5eed318992c8e3bf1aee6199b`
- Production entry: signed Slack Events API webhook -> Slack message ingress -> `dispatchPreparedSlackMessage` -> native progress/partial delivery -> Slack `ChatStreamer`.
- Canonical owner exercised: Slack conversation-message boundary tracker, native progress serialization, native partial fallback, and outbound reply targeting.
- Acceptance red: the reviewed head `ea1e458` keyed the tracker with the outbound stream target while top-level B ingress supplied no `thread_ts`; the actual-ingress regression reproduces that mismatch.
- Acceptance green: current-head registered Slack ingress tests pass for both native progress and native partial streaming. Each trace observes one `startStream.thread_ts=ts#1` for A, one stop of A before later output, then exactly one `postMessage.thread_ts=ts#3` for B. No B text occurs in A's append/stop payloads.
- Must-not-fire controls: bot/self messages, Slack subtypes, unrelated channels, unrelated threads, unrelated workspaces, and the no-intervening-message native stream remain green.
- Cleanup: the proof-only E2E fixture was removed after producing the verdict. No proof asset or temporary harness is committed, and no production Slack workspace, token, channel, or message was touched.

### Qualified mock-Gateway baseline

The preceding reviewed head `575890c` was exercised through an isolated ephemeral Gateway, mock OpenAI provider, signed Slack webhook ingress, real Slack plugin/dispatch/ChatStreamer code, and a recording loopback Slack Web API implementing `chat.startStream`, `chat.appendStream`, and `chat.stopStream`. The first `startStream` response was held until top-level B had entered through the signed webhook, preventing a natural-completion false positive. This receipt covers the actual Gateway/Slack ingress seam and partial-stream path; the exact-head native-progress readback below covers the P1 fallback correction requested by review.

```json
{
  "kind": "mock-gateway",
  "status": "pass",
  "headSha": "575890cba8a4a8c799cc5daca1888c5356fe97e4",
  "channel": "slack",
  "streamingMode": "partial",
  "ingress": "signed Slack Events API webhook into isolated Gateway",
  "provider": "mock-openai",
  "slackApi": "recording loopback Web API implementing native stream methods",
  "firstMessageTs": "1700000000.000100",
  "laterMessageTs": "1700000000.000101",
  "stopBeforeSteeredReply": true,
  "oldStreamTs": "1800000000.000011",
  "oldStreamStopCount": 1,
  "steeredReplyThreadTs": "1700000000.000101",
  "steeredReplyInOldStream": false
}
```

Readback chronology: A `chat.startStream(thread_ts=A)` -> signed top-level B webhook acknowledged -> one A `chat.stopStream` -> B `chat.startStream(thread_ts=B)` -> B `chat.stopStream` containing only `GATEWAY_REPEATED_REQUEST_QUEUED_OK`.

### Exact-head registered-ingress readbacks

Command: Node 24.15.0, `OPENCLAW_DELIVERY_PROOF=1 OPENCLAW_DELIVERY_PROOF_SHA=4c92fb20b2c3aeaa58f1f258ef8c7c0ece275800 npx --yes node@24.15.0 scripts/run-vitest.mjs extensions/slack/src/delivery-trace.test.ts -t 'seals native progress before answering a later human message|routes partial-stream output below a later top-level message from Slack ingress' --reporter=verbose`.

```json
[
  {
    "kind": "slack-native-progress-registered-ingress",
    "status": "pass",
    "headSha": "4c92fb20b2c3aeaa58f1f258ef8c7c0ece275800",
    "ingress": "registered Slack message event handler",
    "delivery": "dispatchPreparedSlackMessage -> Slack delivery runtime -> ChatStreamer -> recording WebClient",
    "oldStreamStartThreadTs": "ts#1",
    "laterMessageThreadTs": "ts#3",
    "oldStreamStartCount": 1,
    "oldStreamStopCount": 1,
    "stopBeforeLaterOutput": true,
    "laterOutputInOldStream": false,
    "laterOutputWireCount": 1,
    "wireOrder": [
      "seq=6 at=1500 chat.startStream(thread_ts=ts#1)",
      "seq=8 at=2000 chat.stopStream(ts=ts#2)",
      "seq=10 at=2000 chat.postMessage(thread_ts=ts#3)"
    ]
  },
  {
    "kind": "slack-partial-stream-registered-ingress",
    "status": "pass",
    "headSha": "4c92fb20b2c3aeaa58f1f258ef8c7c0ece275800",
    "ingress": "registered Slack message event handler",
    "delivery": "dispatchPreparedSlackMessage -> Slack delivery runtime -> ChatStreamer -> recording WebClient",
    "oldStreamStartThreadTs": "ts#1",
    "laterMessageThreadTs": "ts#3",
    "oldStreamStartCount": 1,
    "oldStreamStopCount": 1,
    "stopBeforeLaterOutput": true,
    "laterOutputInOldStream": false,
    "laterOutputWireCount": 1,
    "wireOrder": [
      "seq=5 at=0 chat.startStream(thread_ts=ts#1)",
      "seq=8 at=0 chat.stopStream(ts=ts#2)",
      "seq=9 at=0 chat.postMessage(thread_ts=ts#3)"
    ]
  }
]
```

Both scenarios enter through the registered Slack message event handler. Downstream production dispatch and the real Slack SDK `ChatStreamer` run unchanged; the loopback `WebClient` records the ordered Slack API boundary. The initial `startStream` is the positive recorder control; `laterOutputInOldStream=false` is the must-not-fire control. The same owner resolver is used by native final, non-streamable final, non-final/error native-progress, and streaming-error normal fallbacks. Buffered A text remains on A's existing stream fallback; only post-boundary B output uses B.

### Verification

- Exact-head registered-ingress acceptance: 2/2 passed in `delivery-trace.test.ts` (native progress and partial stream).
- Exact-head focused owner/sibling regression: 91/91 passed across `delivery-trace.test.ts`, `draft-stream.test.ts`, and `monitor/events/messages.test.ts`.
- Earlier full focused Slack suite: 310/310 passed across the boundary, ingress, draft, dispatch, and progress-native siblings.
- Qualified mock-Gateway baseline: 1/1 passed on Node 24.15.0 through `test/vitest/vitest.e2e.config.ts`; three unrelated matrix cases were filtered/skipped.
- Exact-head CI: 54 checks passed and 44 were intentionally skipped; no pending or failed check at receipt time. `openclaw/ci-gate` and `checks-fast-baseline-ratchets` are green.
- `oxfmt`, `oxlint --deny-warnings`, and `git diff --check` passed.
- Fresh exact-head autoreview against merge-base `41419be40bbb17e5eed318992c8e3bf1aee6199b`: scoped clean through P1; `Findings=[]`, patch correct, confidence 0.91.

### Scope and risk

- Changed files: 10.
- Production LOC: +181 / -52 (net +129).
- Test LOC: +180 / -24 (net +156).
- Positive production delta justification: the old draft-only tracker could not own native stream lifecycle or distinguish inbound conversation scope from outbound target. The added state is the bounded owner-level capability needed to serialize one stop/rotation and route the overtaken reply without a parallel delivery path.
- Existing-solutions preflight: reuses the repository's Slack boundary tracker, serialized progress transition, SDK `ChatStreamer`, and QA Gateway harness; no dependency, plugin, config surface, or alternate system was added.
- Sibling coverage: native progress, native partial streaming, draft preview, top-level and threaded ingress identity, no-intervening native streaming, eligibility controls, and tracker cleanup.
- Not tested: a real Slack workspace send. The isolated Gateway proof uses synthetic credentials, signed local webhooks, and a loopback Slack API so it cannot affect real channels.
- Config/default/protocol/schema/security/upgrade impact: none.
