### PR TITLE
refactor(gateway): prepare Control UI encoding preferences once

### DIFF
--- a/src/gateway/control-ui-static.ts
+++ b/src/gateway/control-ui-static.ts
@@ -56,9 +56,9 @@ export function isControlUiPrecompressedAssetExtension(extension: string): boole
 }
 
 type ControlUiContentEncoding = "br" | "gzip";
-type ControlUiEncodingSelection = ControlUiContentEncoding | "identity" | "not-acceptable";
+type ControlUiRepresentationEncoding = ControlUiContentEncoding | "identity";
+type ControlUiEncodingSelection = ControlUiRepresentationEncoding | "not-acceptable";
 
-const CONTROL_UI_DYNAMIC_ENCODINGS = new Set<ControlUiContentEncoding>(["br", "gzip"]);
 const CONTROL_UI_QVALUE_PATTERN = /^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/;
 const controlUiHtmlCompressionCache = new Map<string, Promise<Buffer>>();
 
@@ -104,12 +104,16 @@ function normalizedAcceptEncoding(req: IncomingMessage): string {
   return Array.isArray(value) ? value.join(",") : (value ?? "");
 }
 
-function resolveControlUiContentEncoding(
+function resolveControlUiContentEncodings(
   req: IncomingMessage,
-  availableEncodings: ReadonlySet<ControlUiContentEncoding>,
-): ControlUiEncodingSelection {
+  includeCompressed: boolean,
+): ControlUiRepresentationEncoding[] {
+  const acceptEncoding = normalizedAcceptEncoding(req);
+  if (!acceptEncoding.trim()) {
+    return ["identity"];
+  }
   const qualities = new Map<string, number>();
-  for (const entry of normalizedAcceptEncoding(req).split(",")) {
+  for (const entry of acceptEncoding.split(",")) {
     const [rawName, ...rawParams] = entry.split(";");
     const name = rawName?.trim().toLowerCase();
     if (!name) {
@@ -130,38 +134,24 @@ function resolveControlUiContentEncoding(
     qualities.set(name, Math.max(qualities.get(name) ?? 0, quality));
   }
 
-  const hasAcceptEncoding = normalizedAcceptEncoding(req).trim().length > 0;
-  if (!hasAcceptEncoding) {
-    return "identity";
-  }
-
   const wildcardQuality = qualities.get("*");
-  const qualityFor = (name: ControlUiContentEncoding) =>
-    qualities.has(name) ? (qualities.get(name) ?? 0) : (wildcardQuality ?? 0);
   // RFC 9110 keeps identity acceptable unless identity or a rejecting wildcard
   // explicitly disables it. This distinction is required to return 406 rather
   // than silently violate identity;q=0.
-  const identityQuality = qualities.has("identity")
-    ? (qualities.get("identity") ?? 0)
-    : wildcardQuality === 0
-      ? 0
-      : 1;
-  const candidates: Array<{ encoding: ControlUiEncodingSelection; quality: number; rank: number }> =
-    [{ encoding: "identity", quality: identityQuality, rank: 0 }];
-  if (availableEncodings.has("gzip")) {
-    candidates.push({ encoding: "gzip", quality: qualityFor("gzip"), rank: 1 });
-  }
-  if (availableEncodings.has("br")) {
-    candidates.push({ encoding: "br", quality: qualityFor("br"), rank: 2 });
-  }
-  const selected = candidates
-    .filter((candidate) => candidate.quality > 0)
-    .toSorted((left, right) => right.quality - left.quality || right.rank - left.rank)[0];
-  return selected?.encoding ?? "not-acceptable";
+  const identityQuality = qualities.get("identity") ?? (wildcardQuality === 0 ? 0 : 1);
+  const qualityFor = (name: ControlUiRepresentationEncoding) =>
+    name === "identity" ? identityQuality : (qualities.get(name) ?? wildcardQuality ?? 0);
+  // Stable sorting preserves the server's br/gzip/identity preference for equal quality.
+  const encodings: ControlUiRepresentationEncoding[] = includeCompressed
+    ? ["br", "gzip", "identity"]
+    : ["identity"];
+  return encodings
+    .filter((encoding) => qualityFor(encoding) > 0)
+    .toSorted((left, right) => qualityFor(right) - qualityFor(left));
 }
 
 export function resolveControlUiHtmlEncoding(req: IncomingMessage): ControlUiEncodingSelection {
-  return resolveControlUiContentEncoding(req, CONTROL_UI_DYNAMIC_ENCODINGS);
+  return resolveControlUiContentEncodings(req, true)[0] ?? "not-acceptable";
 }
 
 type OpenedControlUiRepresentation = {
@@ -178,16 +168,12 @@ export function resolveOpenedControlUiRepresentation(params: {
 }): OpenedControlUiRepresentation | null {
   const { req, sourceFile, precompressed, openPrecompressedFile } = params;
   const extension = path.extname(sourceFile.path).toLowerCase();
-  const availableEncodings =
-    precompressed && isControlUiCompressibleExtension(extension)
-      ? new Set(CONTROL_UI_DYNAMIC_ENCODINGS)
-      : new Set<ControlUiContentEncoding>();
-  for (;;) {
-    const selected = resolveControlUiContentEncoding(req, availableEncodings);
-    if (selected === "not-acceptable") {
-      fs.closeSync(sourceFile.fd);
-      return null;
-    }
+  const encodings = resolveControlUiContentEncodings(
+    req,
+    precompressed && isControlUiCompressibleExtension(extension),
+  );
+  // A missing sidecar changes availability, not this request's encoding preferences.
+  for (const selected of encodings) {
     if (selected === "identity") {
       return { bodyFile: sourceFile, contentPath: sourceFile.path };
     }
@@ -204,17 +190,15 @@ export function resolveOpenedControlUiRepresentation(params: {
       fs.closeSync(sourceFile.fd);
       return { bodyFile: compressedFile, contentPath: sourceFile.path, encoding: selected };
     }
-
-    // Generated builds have both variants, but a stale or partial local build
-    // can miss one. Retry the remaining representation before identity/406.
-    availableEncodings.delete(selected);
   }
+  fs.closeSync(sourceFile.fd);
+  return null;
 }
 
 function setControlUiEncodingHeaders(
   res: ServerResponse,
   extension: string,
-  encoding: ControlUiContentEncoding | "identity",
+  encoding: ControlUiRepresentationEncoding,
 ) {
   res.setHeader("Vary", "Accept-Encoding");
   if (!CONTROL_UI_COMPRESSIBLE_EXTENSIONS.has(extension)) {


### PR DESCRIPTION
## What Problem This Solves

Control UI asset requests allocate and parse the same encoding preferences again when a precompressed asset is missing. Requests without an encoding header also build collections they do not need.

## Why This Change Was Made

Prepare the acceptable representations once at the HTTP owner, preserving quality ordering and the existing Brotli/gzip/identity tie preference. Walk that list as sidecars are opened, removing the mutable availability set and repeated parser path. Source-file cleanup and 406 behavior remain owned by the same function.

## User Impact

Lower allocation while serving the Control UI, with identical response bytes, headers, and fallback behavior. No configuration or protocol changes. Production LOC: +30/-46, net -16; tests unchanged.

## Evidence

- Existing Control UI HTTP suite: 161 tests pass before and after, including compression, HEAD, rejection, and safe file handling.
- Real Node HTTP server using the production handler: 64 GET/HEAD requests before and after produced identical status/header/wire hashes across HTML and complete, partial, and missing sidecars.
- Complete-owner differential probe: 96 combinations preserved selection, attempted sidecar order, and source descriptor ownership.
- At 50,000 requests per case, the no-header path went from 50,000 Maps and 50,000 Sets to zero of either; the missing-both-sidecars path went from 150,000 Maps and 50,000 Sets to 50,000 Maps and zero Sets. These are constructor counts, not process RSS measurements.
- Scoped guards, core and test typechecks, dead-export scan, formatting, and final changed-file lint passed. Isolated Codex autoreview and a separate full-priority review passed on the final source.
