### PR TITLE
refactor(plugins): share effective catalog model projection

### DIFF
--- a/src/plugins/provider-catalog.ts
+++ b/src/plugins/provider-catalog.ts
@@ -6,6 +6,7 @@ import type {
   ModelCatalogMediaInputConfig,
   ModelCatalogModel,
   ModelCatalogTieredCost,
+  NormalizedModelCatalogRow,
 } from "@openclaw/model-catalog-core/model-catalog-types";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeConfiguredProviderCatalogModelId } from "@openclaw/model-catalog-core/provider-model-id-normalization";
@@ -147,8 +148,11 @@ function cloneManifestCatalogCost(cost: ModelCatalogCost): ModelDefinitionConfig
   };
 }
 
-function buildManifestCatalogModelInput(model: ModelCatalogModel): ModelDefinitionConfig["input"] {
-  if (model.input?.includes("document")) {
+function buildManifestCatalogModelInput(
+  model: ModelCatalogModel,
+  filterDocument = false,
+): ModelDefinitionConfig["input"] {
+  if (!filterDocument && model.input?.includes("document")) {
     throw new Error(
       `Manifest modelCatalog row ${model.id} uses unsupported runtime input document`,
     );
@@ -168,8 +172,8 @@ function cloneManifestCatalogMediaInput(
 }
 
 function buildManifestCatalogModel(
-  providerId: string,
   model: ModelCatalogModel,
+  options: { providerId?: string; filterDocument?: boolean } = {},
 ): ModelDefinitionConfig {
   if (model.contextWindow === undefined) {
     throw new Error(`Manifest modelCatalog row ${model.id} is missing contextWindow`);
@@ -177,14 +181,16 @@ function buildManifestCatalogModel(
   if (model.maxTokens === undefined) {
     throw new Error(`Manifest modelCatalog row ${model.id} is missing maxTokens`);
   }
-  const id = normalizeConfiguredProviderCatalogModelId(providerId, model.id, new Map());
+  const id = options.providerId
+    ? normalizeConfiguredProviderCatalogModelId(options.providerId, model.id, new Map())
+    : model.id;
   return {
     id,
     name: model.name ?? id,
     ...(model.api ? { api: model.api } : {}),
     ...(model.baseUrl ? { baseUrl: model.baseUrl } : {}),
     reasoning: model.reasoning ?? false,
-    input: buildManifestCatalogModelInput(model),
+    input: buildManifestCatalogModelInput(model, options.filterDocument),
     cost: cloneManifestCatalogCost(model.cost ?? {}),
     contextWindow: model.contextWindow,
     ...(model.contextTokens !== undefined ? { contextTokens: model.contextTokens } : {}),
@@ -223,8 +229,26 @@ export function buildManifestModelProviderConfig(params: {
     baseUrl: catalog.baseUrl,
     ...(catalog.api ? { api: catalog.api } : {}),
     ...(catalog.headers ? { headers: { ...catalog.headers } } : {}),
-    models: catalog.models.map((model) => buildManifestCatalogModel(params.providerId, model)),
+    models: catalog.models.map((model) =>
+      buildManifestCatalogModel(model, { providerId: params.providerId }),
+    ),
   };
+}
+
+/** Builds runtime provider config from planner-normalized manifest rows. */
+export function buildEffectiveManifestProviderConfig(
+  rows: readonly NormalizedModelCatalogRow[],
+): ModelProviderConfig | undefined {
+  const firstRow = rows[0];
+  if (!firstRow?.baseUrl || !firstRow.api) {
+    return undefined;
+  }
+  const models = rows.flatMap((row) =>
+    !row.contextWindow || !row.maxTokens
+      ? []
+      : [buildManifestCatalogModel(row, { filterDocument: true })],
+  );
+  return models.length > 0 ? { baseUrl: firstRow.baseUrl, api: firstRow.api, models } : undefined;
 }
 
 export type ManifestProviderCatalogSurface = {

--- a/src/plugins/provider-discovery.runtime.ts
+++ b/src/plugins/provider-discovery.runtime.ts
@@ -1,8 +1,6 @@
 // Runtime boundary for provider discovery through plugin entrypoints.
-import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { sortUniqueStrings } from "../../packages/normalization-core/src/string-normalization.js";
-import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { planEffectiveModelCatalogRows } from "../model-catalog/index.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
@@ -12,6 +10,7 @@ import { withProfile } from "./plugin-load-profile.js";
 import type { PluginMetadataRegistryView } from "./plugin-metadata-snapshot.types.js";
 import { getCachedPluginModuleLoader, preparePluginModule } from "./plugin-module-loader-cache.js";
 import { resolvePluginRuntimeArtifact } from "./plugin-runtime-artifact-resolution.js";
+import { buildEffectiveManifestProviderConfig } from "./provider-catalog.js";
 import { resolveDiscoveredProviderPluginIds } from "./providers.js";
 import { resolvePluginProvidersCore } from "./providers.runtime.js";
 import { getPluginRuntimeGenerationRegistry } from "./runtime/generation-scope.js";
@@ -123,67 +122,6 @@ function hasProviderAuthEnvCredential(
   });
 }
 
-function modelDefinitionCostFromManifestRow(
-  row: NormalizedModelCatalogRow,
-): ModelDefinitionConfig["cost"] {
-  const cost = row.cost;
-  return {
-    input: cost?.input ?? 0,
-    output: cost?.output ?? 0,
-    cacheRead: cost?.cacheRead ?? 0,
-    cacheWrite: cost?.cacheWrite ?? 0,
-    ...(cost?.tieredPricing ? { tieredPricing: cost.tieredPricing } : {}),
-  };
-}
-
-function modelDefinitionFromManifestRow(
-  row: NormalizedModelCatalogRow,
-): ModelDefinitionConfig | undefined {
-  const cost = modelDefinitionCostFromManifestRow(row);
-  if (!row.contextWindow || !row.maxTokens) {
-    return undefined;
-  }
-  const input: ModelDefinitionConfig["input"] = row.input.filter(
-    (value): value is "text" | "image" => value === "text" || value === "image",
-  );
-  return {
-    id: row.id,
-    name: row.name || row.id,
-    ...(row.api ? { api: row.api } : {}),
-    ...(row.baseUrl ? { baseUrl: row.baseUrl } : {}),
-    reasoning: row.reasoning,
-    input,
-    cost,
-    contextWindow: row.contextWindow,
-    ...(row.contextTokens ? { contextTokens: row.contextTokens } : {}),
-    maxTokens: row.maxTokens,
-    ...(row.thinkingLevelMap ? { thinkingLevelMap: { ...row.thinkingLevelMap } } : {}),
-    ...(row.headers ? { headers: row.headers } : {}),
-    ...(row.compat ? { compat: row.compat } : {}),
-    ...(row.mediaInput ? { mediaInput: row.mediaInput } : {}),
-  };
-}
-
-function providerConfigFromManifestRows(
-  rows: readonly NormalizedModelCatalogRow[],
-): ModelProviderConfig | undefined {
-  const firstRow = rows[0];
-  if (!firstRow?.baseUrl || !firstRow.api) {
-    return undefined;
-  }
-  const models = rows
-    .map((row) => modelDefinitionFromManifestRow(row))
-    .filter((model): model is ModelDefinitionConfig => Boolean(model));
-  if (models.length === 0) {
-    return undefined;
-  }
-  return {
-    baseUrl: firstRow?.baseUrl ?? "",
-    ...(firstRow?.api ? { api: firstRow.api } : {}),
-    models,
-  };
-}
-
 function prepareManifestCatalogDiscovery(
   pluginRecords: readonly PluginManifestRecord[],
   config: OpenClawConfig,
@@ -220,7 +158,7 @@ function prepareManifestCatalogDiscovery(
       if (!includeProviders || entry.rows.length === 0) {
         continue;
       }
-      const providerConfig = providerConfigFromManifestRows(entry.rows);
+      const providerConfig = buildEffectiveManifestProviderConfig(entry.rows);
       if (!providerConfig) {
         continue;
       }


### PR DESCRIPTION
Provider discovery maintained a second model-row projector beside the manifest catalog constructor. This refactor reuses the existing constructor and deletes the duplicated model, cost, and provider projection code. Raw manifests still normalize provider-specific IDs, reject document input, require token limits, and retain top-level headers. Planner-produced discovery rows keep their already-normalized IDs, filter document input, omit incomplete models, and validate the first row's transport before traversal.

The helper stays inside the plugin implementation layer; no SDK export, model manifest, config/default, credential, persistence, or fallback contract changes. Production is **+32/-70, net -38 physical lines and -36 nonblank lines**; tests are unchanged. The planner already creates fresh model metadata and merged headers before projection, so the shared constructor's copies replace private intermediate objects without changing caller-visible sharing. Prepared static catalogs retain their existing lifetime and repeated-call identity.

Validation: 127 maintained tests across normalization, planning, raw construction, discovery, and SDK entry ownership; the complete changed-file gate and SDK surface check; final formatting, lint and core types; and a normal full build of the final source with an actual zero exit. A 13-case probe through the real normalizer, planner, raw builder and public discovery produced byte-identical baseline/final descriptor and returned-reference graphs (496,201 bytes), including callback order and error outcomes. Its fixture hash is not presented as a production-source hash. An isolated, credential-free Kimi CLI listing returned four static rows with network access denied; the final probe and build also cover the later mechanical call-syntax cleanup.

Fresh managed Codex P2 review found no actionable issue. The first harness launch failed before baseline capture on module transformation and was corrected. An earlier final build was interrupted by its enclosing controller deadline during declaration generation; after proving that all task-owned processes were gone, the documented artifact-owner recovery allowed the normal build to finish. Both failures and all source/dependency hashes remain in the evidence. No speedup claim is made. Exact-head CI remains required before landing.


Maintainer landing review: the existing catalog owner is the appropriate home for normalized discovery projection. Root read the full latest ClawSweeper review and accepts this behavior-preserving internal refactor under the authorized maintainer campaign. There is no public API, configuration or persistence change. All243 exact-head CI jobs pass or are intentionally skipped in run33527733980, including the required gate. The127 maintained tests,13-case actual-flow comparison, final normal build and clean managed P2 review are recorded above. Production delta is−38 physical/−36 nonblank lines; tests0.
