### PR TITLE
docs(doctor): warn about explicit external repair paths

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -56,6 +56,15 @@ This maintenance window also applies when repair ultimately finds no changes.
 Diagnostic runs without `--fix`, `--repair`, or `--yes` do not enter maintenance.
 Custom state directories remain runtime-only and do not adopt a native service.
 
+<Warning>
+  `doctor --fix` follows explicitly configured workspace and store paths, including
+  paths outside `OPENCLAW_STATE_DIR`. Setting `OPENCLAW_STATE_DIR` and
+  `OPENCLAW_CONFIG_PATH` to a copy does not redirect those paths. Before rehearsing
+  repairs on copied state, copy the external workspaces and stores too, then rewrite
+  their paths in the copied config to point to the copies. Otherwise, Doctor can
+  modify the originals.
+</Warning>
+
 When an updater supplies an explicit Gateway activation policy, Doctor leaves
 stop and restart ownership with that updater. The native manager must confirm
 the service is already offline before repair. If `openclaw update --no-restart`


### PR DESCRIPTION
Related: #134257

## What Problem This Solves

Operators rehearsing `doctor --fix` on copied state can still modify their original workspaces or stores when the copied configuration explicitly points to those originals. The Doctor reference did not make that distinction clear beside its repair guidance. Thanks to @vdruts for reporting the rehearsal surprise.

## Why This Change Was Made

Document the intended config precedence: `OPENCLAW_STATE_DIR` selects state, but does not override explicitly configured external workspace or store paths. Add a warning before the repair examples explaining that rehearsals must copy those locations and rewrite the copied config to point to the copies.

This is the maintainer-approved documentation outcome for #134257. No runtime behavior, config option, schema, protocol, or general migration dry-run is added or changed. The issue will be closed separately as not planned after this lands, rather than automatically marked fixed.

## User Impact

Operators get the safe rehearsal procedure before running repairs: copy state, external workspaces, and stores, and remap the explicit paths in the copied configuration first. Existing external-workspace and external-store installations keep their intended behavior.

## Evidence

The accepted live A/B proof is recorded at https://github.com/openclaw/openclaw/issues/134257#issuecomment-5490009361. It used the real built CLI with synthetic files and two fresh temporary state/home fixtures:

```text
OPENCLAW_STATE_DIR=A OPENCLAW_CONFIG_PATH=A/openclaw.json node openclaw.mjs doctor --fix --non-interactive

A: config workspace points inside A
   exit 0; A's legacy short-term-recall source migrated and archived
   B's source and the temporary default-workspace source stayed byte-identical
B: copied config explicitly points to B's workspace
   exit 0; B's source migrated and archived; archive inspected
   A's source and the temporary default-workspace source stayed byte-identical
```

This reuses the accepted live proof, not a new gateway run. This PR changes documentation only. Source rechecked on current main and v2026.8.1: `src/agents/agent-scope-config.ts` gives explicit workspace paths precedence; Memory Core's `doctor-workspaces.ts` and `doctor-dreaming-state.ts` consume that selection. `src/infra/state-migrations.media-persistence-targets.ts` skips foreign databases unless they match configured stores. Existing tests distinguish foreign registry paths from configured out-of-tree stores.

Production LOC: +0/-0. Tests: +0/-0. Documentation: +9/-0. No regression test added because runtime behavior is unchanged.

NO-FOLLOW-UP: the warning closes the approved documentation gap; a runtime refactor would change the intentionally preserved path-precedence contract.

Validation:
- `pnpm docs:list` — passed; confirmed the Doctor CLI reference is the repair entry point.
- `node scripts/check-changed.mjs -- docs/cli/doctor.md` — passed (docs-only lane, including changed-file formatting).
- `pnpm docs:check-mdx` — passed, 751 files.
- `pnpm docs:check-links` — passed, 7,173 internal links, zero broken.
- `pnpm docs:check-i18n-glossary` — passed.
- `git diff --check` — passed.
- Autoreview (uncommitted, then branch mode after rebase) — scoped-clean; no accepted/actionable findings.
