### PR TITLE
refactor(media): avoid PNG checksum buffer copies

### DIFF
--- a/src/media/png-encode.ts
+++ b/src/media/png-encode.ts
@@ -1,36 +1,12 @@
 // PNG encode helpers build small PNG files without external image dependencies.
-import { deflateSync } from "node:zlib";
-import { expectDefined } from "@openclaw/normalization-core";
-
-const CRC_TABLE = (() => {
-  const table = new Uint32Array(256);
-  for (let i = 0; i < 256; i += 1) {
-    let c = i;
-    for (let k = 0; k < 8; k += 1) {
-      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
-    }
-    table[i] = c >>> 0;
-  }
-  return table;
-})();
-
-/** Compute CRC32 checksum for a buffer (used in PNG chunk encoding). */
-function crc32(buf: Buffer): number {
-  let crc = 0xffffffff;
-  for (const byte of buf) {
-    crc =
-      expectDefined(CRC_TABLE[(crc ^ byte) & 0xff], "crc table entry at (crc ^ byte) & 0xff") ^
-      (crc >>> 8);
-  }
-  return (crc ^ 0xffffffff) >>> 0;
-}
+import { crc32, deflateSync } from "node:zlib";
 
 /** Create a PNG chunk with type, data, and CRC. */
 function pngChunk(type: string, data: Buffer): Buffer {
   const typeBuf = Buffer.from(type, "ascii");
   const len = Buffer.alloc(4);
   len.writeUInt32BE(data.length, 0);
-  const crc = crc32(Buffer.concat([typeBuf, data]));
+  const crc = crc32(data, crc32(typeBuf));
   const crcBuf = Buffer.alloc(4);
   crcBuf.writeUInt32BE(crc, 0);
   return Buffer.concat([len, typeBuf, data, crcBuf]);


### PR DESCRIPTION
## What Problem This Solves

Generating context-map PNGs makes a second copy of every compressed chunk just to checksum it, then runs a JavaScript CRC loop over those bytes.

## Why This Change Was Made

Use the supported runtime's incremental `node:zlib.crc32` operation for the chunk type and payload. This removes the local CRC table, byte loop, and checksum-only concatenation while retaining the existing PNG encoder and output format. Node has provided this API since 22.2; the repository's supported Node versions include it. Bun 1.4.0, the version used by CI, was verified directly.

## User Impact

Less temporary memory and CPU work when producing PNGs, including `/context map`. Encoded bytes remain identical. Production LOC: +2/-26, net -24; tests unchanged.

## Evidence

- 222 existing tests pass across context reports, web media, and image tools. The context-map case verifies chunk CRCs, dimensions, decompression, and pixels.
- Eight actual-owner RGB/RGBA cases, including offset pixel views and 1280×860 images, produced identical complete PNG bytes on Node 26.8.1 and Bun 1.4.0.
- The high-entropy 1280×860 RGBA probe reduced Buffer.concat materialization from 17,621,775 to 13,216,339 bytes: 4,405,436 checksum-only bytes removed. This counts concatenation outputs, not process RSS.
- Twelve alternating local encode calls had medians of 87.29→62.34 ms on Node and 68.19→47.07 ms on Bun. These describe this input and host, not general latency guarantees.
- Isolated Codex autoreview passed. A rebuilt isolated Gateway completed real OpenAI model and Code Mode HTTPS fetch turns, then `/context map` produced its final caption and a valid 1280×860 PNG. The generated PNG write was observed in that Gateway PID, all CRCs and decompressed dimensions were checked, and the task Gateway exited cleanly.
