### PR TITLE
fix(agents): reject sessions_yield for cron automation turns

### DIFF
--- a/src/agents/openclaw-tools.registration.test.ts
+++ b/src/agents/openclaw-tools.registration.test.ts
@@ -105,6 +105,16 @@ describe("openclaw-tools progress_card gating", () => {
     ).toEqual([]);
   });
 
+  it("omits sessions_yield for cron requester sessions", () => {
+    const tools = createTestOpenClawTools({
+      runSessionKey: "agent:main:cron:isolated",
+      agentSessionKey: "agent:main:cron:isolated",
+      runId: "run-1",
+    });
+
+    expect(tools.find((candidate) => candidate.name === "sessions_yield")).toBeUndefined();
+  });
+
   it("enables progress_card by default", () => {
     expectProgressCardEnabled({ config: {} as OpenClawConfig }, true);
   });

--- a/src/agents/openclaw-tools.requester-yield.test.ts
+++ b/src/agents/openclaw-tools.requester-yield.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { createRequesterYieldCallback } from "./openclaw-tools.requester-yield.js";
+
+describe("createRequesterYieldCallback", () => {
+  it("rejects yield for a cron requester before any intent is recorded", () => {
+    const claim = createRequesterYieldCallback({
+      requesterSessionKey: "agent:main:cron:isolated",
+      requesterAgentId: "main",
+      requesterTurnRunId: "run-1",
+      claimYieldCompletion: () => true,
+    });
+
+    expect(claim).toBeUndefined();
+  });
+
+  it("returns a claim for a non-cron requester", () => {
+    const claim = createRequesterYieldCallback({
+      requesterSessionKey: "agent:main:main",
+      requesterAgentId: "main",
+      requesterTurnRunId: "run-1",
+    });
+
+    expect(claim).toBeTypeOf("function");
+  });
+});

--- a/src/agents/openclaw-tools.requester-yield.ts
+++ b/src/agents/openclaw-tools.requester-yield.ts
@@ -1,4 +1,4 @@
-import { isSubagentSessionKey } from "../sessions/session-key-utils.js";
+import { isCronSessionKey, isSubagentSessionKey } from "../sessions/session-key-utils.js";
 
 type YieldCompletionClaim = () => boolean | Promise<boolean>;
 
@@ -8,6 +8,13 @@ export function createRequesterYieldCallback(params: {
   requesterTurnRunId?: string;
   claimYieldCompletion?: YieldCompletionClaim;
 }): YieldCompletionClaim | undefined {
+  // Cron automations have no durable continuation owner for a yielded turn; the
+  // completion wake is deliberately skipped for them. Reject the yield before any
+  // intent is recorded so the automation never reports success while its required
+  // child work remains unresolved.
+  if (isCronSessionKey(params.requesterSessionKey)) {
+    return undefined;
+  }
   const selfClaimed = isSubagentSessionKey(params.requesterSessionKey);
   const hasRegistryClaim = Boolean(params.requesterSessionKey && params.requesterTurnRunId);
   if (!params.claimYieldCompletion && !selfClaimed && !hasRegistryClaim) {

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -6,7 +6,7 @@ import { resolveControlUiSessionLinkBase } from "../config/control-ui-link-base.
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../secrets/runtime-state.js";
 import { getActiveRuntimeWebToolsMetadataFromState } from "../secrets/runtime-web-tools-state.js";
-import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import { isCronRunSessionKey, isCronSessionKey } from "../sessions/session-key-utils.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentIds } from "./agent-scope.js";
 import { bindAssembledAgentToolActionDescriptor } from "./agent-tool-metadata.js";
 import {
@@ -78,7 +78,10 @@ import { createSessionsSearchTool } from "./tools/sessions-search-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
 import { createSessionsTool } from "./tools/sessions-tool.js";
-import { createSessionsYieldTool } from "./tools/sessions-yield-tool.js";
+import {
+  createSessionsYieldTool,
+  UNSUPPORTED_CRON_YIELD_ERROR,
+} from "./tools/sessions-yield-tool.js";
 import { createConfiguredSkillWorkshopTool } from "./tools/skill-workshop-tool-factory.js";
 import { createSubagentsTool } from "./tools/subagents-tool.js";
 import { createTaskSuggestionTools } from "./tools/task-suggestion-tools.js";
@@ -584,6 +587,9 @@ export function createOpenClawTools(options?: OpenClawToolsOptions): AnyAgentToo
         claimYieldCompletion: options?.claimYieldCompletion,
       }),
       onYield: options?.onYield,
+      ...(isCronSessionKey(trimmedRunSessionKey || options?.agentSessionKey)
+        ? { unsupportedError: UNSUPPORTED_CRON_YIELD_ERROR }
+        : {}),
     }),
     createSubagentsTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -78,10 +78,7 @@ import { createSessionsSearchTool } from "./tools/sessions-search-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
 import { createSessionsTool } from "./tools/sessions-tool.js";
-import {
-  createSessionsYieldTool,
-  UNSUPPORTED_CRON_YIELD_ERROR,
-} from "./tools/sessions-yield-tool.js";
+import { createSessionsYieldTool } from "./tools/sessions-yield-tool.js";
 import { createConfiguredSkillWorkshopTool } from "./tools/skill-workshop-tool-factory.js";
 import { createSubagentsTool } from "./tools/subagents-tool.js";
 import { createTaskSuggestionTools } from "./tools/task-suggestion-tools.js";
@@ -578,19 +575,20 @@ export function createOpenClawTools(options?: OpenClawToolsOptions): AnyAgentToo
         ]
       : []),
     ...swarmToolGroups.agentsWait,
-    createSessionsYieldTool({
-      sessionId: options?.sessionId,
-      claimYield: createRequesterYieldCallback({
-        requesterSessionKey: trimmedRunSessionKey || options?.agentSessionKey,
-        requesterAgentId: sessionAgentId,
-        requesterTurnRunId: options?.runId,
-        claimYieldCompletion: options?.claimYieldCompletion,
-      }),
-      onYield: options?.onYield,
-      ...(isCronSessionKey(trimmedRunSessionKey || options?.agentSessionKey)
-        ? { unsupportedError: UNSUPPORTED_CRON_YIELD_ERROR }
-        : {}),
-    }),
+    ...(isCronSessionKey(trimmedRunSessionKey || options?.agentSessionKey)
+      ? []
+      : [
+          createSessionsYieldTool({
+            sessionId: options?.sessionId,
+            claimYield: createRequesterYieldCallback({
+              requesterSessionKey: trimmedRunSessionKey || options?.agentSessionKey,
+              requesterAgentId: sessionAgentId,
+              requesterTurnRunId: options?.runId,
+              claimYieldCompletion: options?.claimYieldCompletion,
+            }),
+            onYield: options?.onYield,
+          }),
+        ]),
     createSubagentsTool({
       agentSessionKey: options?.agentSessionKey,
       agentId: sessionAgentId,

--- a/src/agents/tools/sessions-yield-tool.test.ts
+++ b/src/agents/tools/sessions-yield-tool.test.ts
@@ -111,9 +111,14 @@ describe("sessions_yield tool", () => {
   });
 
   it.each([
-    { name: "the claim callback is unavailable" },
-    { name: "the turn owns no pending child completion", claimYield: () => false },
-  ])("keeps the turn active when $name", async ({ claimYield }) => {
+    { name: "the claim callback is unavailable", error: "Yield not supported in this context" },
+    {
+      name: "the turn owns no pending child completion",
+      claimYield: () => false,
+      error:
+        "No pending child completion is owned by this turn. Continue working because independent background operations complete separately.",
+    },
+  ])("keeps the turn active when $name", async ({ claimYield, error }) => {
     const onYield = vi.fn();
     const tool = createSessionsYieldTool({
       sessionId: "test-session",
@@ -123,10 +128,23 @@ describe("sessions_yield tool", () => {
 
     const result = await tool.execute("call-1", {});
 
+    expect(result.details).toMatchObject({ status: "error", error });
+    expect(onYield).not.toHaveBeenCalled();
+  });
+
+  it("returns the dedicated unsupported error for a cron automation", async () => {
+    const onYield = vi.fn();
+    const tool = createSessionsYieldTool({
+      sessionId: "test-session",
+      onYield,
+      unsupportedError: "Yield is not supported in isolated automation turns.",
+    });
+
+    const result = await tool.execute("call-1", {});
+
     expect(result.details).toMatchObject({
       status: "error",
-      error:
-        "No pending child completion is owned by this turn. Continue working because independent background operations complete separately.",
+      error: "Yield is not supported in isolated automation turns.",
     });
     expect(onYield).not.toHaveBeenCalled();
   });

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -10,6 +10,11 @@ import { jsonResult, readToolStringParam } from "./common.js";
 const NO_PENDING_CHILD_COMPLETION_ERROR =
   "No pending child completion is owned by this turn. Continue working because independent background operations complete separately.";
 
+const UNSUPPORTED_CRON_YIELD_ERROR =
+  "Yield is not supported in isolated automation turns; continue working because a spawned child cannot resume this session.";
+
+export { UNSUPPORTED_CRON_YIELD_ERROR };
+
 const SessionsYieldToolSchema = Type.Object({
   message: Type.Optional(
     Type.String({ description: "Private context for the resumed turn; not sent to the user." }),
@@ -26,6 +31,8 @@ export function createSessionsYieldTool(opts?: {
   sessionId?: string;
   claimYield?: () => boolean | Promise<boolean>;
   onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
+  /** Dedicated rejection when a claim callback is unavailable (e.g. cron automation). */
+  unsupportedError?: string;
 }): AnyAgentTool {
   return {
     label: "Yield",
@@ -46,7 +53,13 @@ export function createSessionsYieldTool(opts?: {
       if (!opts?.onYield) {
         return jsonResult({ status: "error", error: "Yield not supported in this context" });
       }
-      if (!(await opts.claimYield?.())) {
+      if (!opts?.claimYield) {
+        return jsonResult({
+          status: "error",
+          error: opts?.unsupportedError ?? "Yield not supported in this context",
+        });
+      }
+      if (!(await opts.claimYield())) {
         return jsonResult({
           status: "error",
           error: NO_PENDING_CHILD_COMPLETION_ERROR,


### PR DESCRIPTION
Closes #135282

## What Problem This Solves

Fixes an isolated-automation false-success bug. An isolated `agentTurn` automation could spawn a native child, call `sessions_yield`, and be immediately finalized as `status: ok` — even though the child had not completed and the cron continuation wake is deliberately skipped. The automation then reported success before its required work completed, and its session could later be persisted as `killed` instead of resumed.

## Why This Change Was Made

`createRequesterYieldCallback` accepted an owned-child yield for any requester, recorded the yield intent, and returned `status: yielded`. But cron sessions have no durable continuation owner — `subagent-announce.requester-settle-wake` explicitly skips waking cron requesters, and `run-finalize` still reports `ok` without treating `meta.yielded` as pending work. This change rejects `sessions_yield` for cron requester sessions before any yield intent is recorded, so the automation cannot report success while its descendant work remains unresolved.

## User Impact

Isolated cron automations no longer record `status: ok` after a `sessions_yield` that leaves required child work unresolved; the yield is rejected so the automation keeps working instead of reporting a false success.

## Evidence

Exact head: `8afca1bff6c3ce5ada7118cca2b8679986f6cb7c`.

- `src/agents/openclaw-tools.requester-yield.test.ts` — 2 passed: a cron requester returns no claim (yield rejected) while a non-cron requester still returns a claim.
- `src/agents/tools/sessions-yield-tool.test.ts` — 9 passed.
- `src/agents/openclaw-tools.registration.test.ts` — 60 passed; `src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts` — 37 passed.
- Production typecheck and `check:changed` pass; the only local lane failure is unchanged `ui/vite.config.ts` missing a `pako` declaration in the reused dependency tree.

## AI Assistance

AI-assisted implementation. I manually verified the requester-yield boundary, the cron-session rejection, the focused regression, and the changed-file gates.
