### PR TITLE
refactor(scripts): centralize tsgo output path normalization

### DIFF
--- a/scripts/check-tsgo-core-boundary.mts
+++ b/scripts/check-tsgo-core-boundary.mts
@@ -12,18 +12,10 @@ import {
   TSGO_CORE_GRAPHS,
   TSGO_CORE_TEST_SHARDS,
 } from "./lib/tsgo-core-test-shards.mts";
+import { normalizeTsgoPath } from "./lib/tsgo-output-path.mts";
 const repoRoot = resolveRepoRoot(import.meta.url);
 const tsgoPath = resolveRepoToolBinPath("tsgo", { cwd: repoRoot });
 const canonicalCoreTestConfig = "test/tsconfig/tsconfig.core.test.json";
-
-function normalizeFilePath(filePath: string) {
-  const normalized = filePath.trim().replaceAll("\\", "/");
-  const normalizedRoot = repoRoot.replaceAll("\\", "/");
-  if (normalized.startsWith(`${normalizedRoot}/`)) {
-    return normalized.slice(normalizedRoot.length + 1);
-  }
-  return normalized;
-}
 
 export class CoreTsgoBoundaryInterruptedError extends Error {
   readonly exitCode: number;
@@ -107,7 +99,7 @@ export type CoreTsgoGraph = {
 export async function checkCoreTsgoGraphBoundary(): Promise<CoreTsgoGraph[]> {
   const testRootPattern = /\.test\.(?:ts|tsx)$/u;
   const canonicalRoots = ((await readGraphConfig(canonicalCoreTestConfig)).files ?? [])
-    .map(normalizeFilePath)
+    .map((file) => normalizeTsgoPath(repoRoot, file))
     .filter((file) => testRootPattern.test(file));
   const shardConfigs = [];
   for (const shard of TSGO_CORE_TEST_SHARDS) {
@@ -118,7 +110,7 @@ export async function checkCoreTsgoGraphBoundary(): Promise<CoreTsgoGraph[]> {
     shards: shardConfigs.map((shard) => ({
       name: shard.name,
       roots: (shard.expanded.files ?? [])
-        .map(normalizeFilePath)
+        .map((file) => normalizeTsgoPath(repoRoot, file))
         .filter((file) => testRootPattern.test(file)),
     })),
   });
@@ -157,13 +149,15 @@ export async function checkCoreTsgoGraphBoundary(): Promise<CoreTsgoGraph[]> {
       await runTsgoQuery(graph.config, "--listFilesOnly", `${graph.name} file listing`)
     )
       .split(/\r?\n/u)
-      .map(normalizeFilePath)
+      .map((file) => normalizeTsgoPath(repoRoot, file))
       .filter(Boolean);
     graphs.push({
       ...graph,
       files,
       roots: (shardConfigs.find((shard) => shard.config === graph.config)?.expanded.files ?? [])
-        .map((file) => normalizeFilePath(path.resolve(repoRoot, path.dirname(graph.config), file)))
+        .map((file) =>
+          normalizeTsgoPath(repoRoot, path.resolve(repoRoot, path.dirname(graph.config), file)),
+        )
         .filter((file) => testRootPattern.test(file)),
     });
     const extensionFiles = files.filter((file) => file.startsWith("extensions/"));

--- a/scripts/lib/tsgo-output-path.mts
+++ b/scripts/lib/tsgo-output-path.mts
@@ -1,0 +1,7 @@
+export function normalizeTsgoPath(repoRoot: string, filePath: string): string {
+  const normalized = filePath.trim().replaceAll("\\", "/");
+  const normalizedRoot = repoRoot.replaceAll("\\", "/");
+  return normalized.startsWith(`${normalizedRoot}/`)
+    ? normalized.slice(normalizedRoot.length + 1)
+    : normalized;
+}

--- a/scripts/profile-tsgo.mts
+++ b/scripts/profile-tsgo.mts
@@ -10,6 +10,7 @@ import { applyLocalTsgoPolicy, resolveRepoToolBinPath } from "./lib/local-check-
 import { createManagedCommandInvocation } from "./lib/managed-child-process.mts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import { TSGO_CORE_TEST_SHARDS, type TsgoCoreTestShard } from "./lib/tsgo-core-test-shards.mts";
+import { normalizeTsgoPath } from "./lib/tsgo-output-path.mts";
 const repoRoot = resolveRepoRoot(import.meta.url);
 const artifactRoot = path.resolve(repoRoot, ".artifacts/tsgo-profile");
 const tsgoPath = resolveRepoToolBinPath("tsgo", { cwd: repoRoot });
@@ -207,15 +208,6 @@ function parseDiagnostics(output: string): Diagnostics {
   return diagnostics;
 }
 
-function normalizeFilePath(filePath: string): string {
-  const normalized = filePath.trim().replaceAll("\\", "/");
-  const normalizedRoot = repoRoot.replaceAll("\\", "/");
-  if (normalized.startsWith(`${normalizedRoot}/`)) {
-    return normalized.slice(normalizedRoot.length + 1);
-  }
-  return normalized;
-}
-
 function packageNameFromNodeModule(parts: string[], startIndex: number): string {
   const first = parts[startIndex + 1];
   if (!first) {
@@ -269,7 +261,7 @@ function countBy<T>(values: T[], keyFn: (value: T) => string) {
 function summarizeFiles(stdout: string) {
   const files = stdout
     .split(/\r?\n/u)
-    .map(normalizeFilePath)
+    .map((file) => normalizeTsgoPath(repoRoot, file))
     .filter(Boolean)
     .filter((line) => !line.startsWith("Files:"));
 


### PR DESCRIPTION
## What Problem This Solves

The core tsgo boundary checker and tsgo profiler maintained identical output-path normalization functions. That duplicated ordering-sensitive handling for whitespace, path separators, and repository-root stripping across two tooling entry points.

## Why This Change Was Made

One private scripts helper now owns the existing normalization contract. Both callers import it directly and use explicit unary callbacks, preserving the original operation order and keeping `path.resolve(...)` before normalization in the boundary checker.

This is a maintainer-requested tooling refactor. It does not change runtime behavior, dependencies, tests, documentation, compiler snapshots, or public APIs.

## User Impact

No user-visible behavior changes. Maintainers get one canonical normalization policy for tsgo output paths.

## Evidence

- Implementation base: `60c5793325d0931038307aaefbb0d8b944eba733`
- Signed head: `b2e24e13dbd0cce8d35aa18d04b549b6fb0188ed`
- Tooling LOC: `+16/-23` (net `-7`); tests: `+0/-0`
- Focused tooling test: `test/scripts/tsgo-core-test-shards.test.ts` — 21 passed
- Full changed-file gates passed for the three changed scripts, including formatting, core tsgo boundary, script erasability, script typecheck, coercion declarations, and script lint
- Platform equivalence matrix passed for Unix, Windows, exact-root, sibling-root, relative, surrounding-whitespace, and external-drive paths
- Baseline/current byte comparison matched for boundary exit/stdout/stderr and profiler help/error output
- Baseline/current profiler comparison matched across 11,536 normalized file-list entries and the complete file summary
- Exact-base Sol autoreview: scoped clean, 0.99
- PR #135263 remains separate and touches four different script guards
- Required Codex source inspection completed at `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; those CLI paths are unrelated to this tooling contract
