### PR TITLE
refactor(cli): share message payload projections

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2546,8 +2546,8 @@ src/commands/export-trajectory.ts	1
 src/commands/gateway-health-auth-diagnostic.ts	1
 src/commands/gateway-presence.ts	1
 src/commands/gateway-status/helpers.ts	11
-src/commands/message-format.ts	20
-src/commands/message.ts	4
+src/commands/message-format.ts	17
+src/commands/message.ts	2
 src/commands/models/fallbacks-shared.ts	2
 src/commands/models/list.model-projection.ts	1
 src/commands/models/list.persisted-catalog.ts	2

--- a/src/commands/message-format.test.ts
+++ b/src/commands/message-format.test.ts
@@ -243,6 +243,25 @@ describe("renderPaginationHint", () => {
 });
 
 describe("formatMessageCliText send results", () => {
+  it("prefers and trims a direct plugin payload message ID", () => {
+    const result = {
+      kind: "send",
+      action: "send",
+      channel: "directchat",
+      to: "room-1",
+      handledBy: "plugin",
+      payload: {
+        messageId: " direct-id ",
+        result: { messageId: "nested-id" },
+      },
+      dryRun: false,
+    } satisfies MessageActionResult;
+
+    expect(formatMessageCliText(result)).toEqual([
+      "✅ Sent via Direct Chat. Message ID: direct-id",
+    ]);
+  });
+
   it.each([
     {
       status: "suppressed" as const,
@@ -292,6 +311,74 @@ describe("formatMessageCliText send results", () => {
       }
     },
   );
+});
+
+describe("formatMessageCliText payload scalars", () => {
+  it("keeps alias reads lazy after the first nonempty string", () => {
+    const reads: string[] = [];
+    const message = Object.create(null) as Record<string, unknown>;
+    Object.defineProperties(message, {
+      id: {
+        enumerable: true,
+        get: () => {
+          reads.push("id");
+          return reads.length === 1 ? "first-id" : "second-id";
+        },
+      },
+      ts: {
+        enumerable: true,
+        get: () => {
+          reads.push("ts");
+          throw new Error("later alias must not be read");
+        },
+      },
+      authorTag: { enumerable: true, value: "alice" },
+      timestamp: { enumerable: true, value: "now" },
+      content: { enumerable: true, value: "hello" },
+    });
+
+    const output = textJoined(formatMessageCliText(readResultPayload({ messages: [message] })));
+    expect(output).toContain("second-id");
+    expect(output).not.toContain("first-id");
+    expect(reads).toEqual(["id", "id"]);
+  });
+
+  it("preserves generic object primitive summaries", () => {
+    const result = {
+      kind: "action",
+      channel: "directchat",
+      action: "channel-info",
+      handledBy: "plugin",
+      payload: {
+        undef: undefined,
+        nil: null,
+        array: [1, 2],
+        object: {},
+        function: () => undefined,
+        bigint: 42n,
+        symbol: Symbol("proof"),
+        string: "  keep  ",
+        number: -3,
+        boolean: false,
+      },
+      dryRun: false,
+    } satisfies MessageActionResult;
+
+    const output = textJoined(formatMessageCliText(result));
+    for (const expected of [
+      "null",
+      "2 items",
+      "object",
+      "function",
+      "42",
+      "Symbol(proof)",
+      "keep",
+      "-3",
+      "false",
+    ]) {
+      expect(output).toContain(expected);
+    }
+  });
 });
 
 describe("formatMessageCliText provider-reported failures", () => {

--- a/src/commands/message-format.ts
+++ b/src/commands/message-format.ts
@@ -1,5 +1,4 @@
 /** Human-readable formatter for `openclaw message` action results. */
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
@@ -8,6 +7,7 @@ import type { ChannelId } from "../channels/plugins/types.public.js";
 import type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
 import { formatGatewaySummary, formatOutboundDeliverySummary } from "../infra/outbound/format.js";
 import {
+  resolveMessageActionMessageId,
   resolveMessageActionOutcome,
   type MessageActionResult,
 } from "../infra/outbound/message-action-contracts.js";
@@ -17,24 +17,17 @@ import { shortenText } from "./text-format.js";
 const resolveChannelLabel = (channel: ChannelId) =>
   getLoadedChannelPlugin(channel)?.meta.label ?? channel;
 
-function extractMessageId(payload: unknown): string | null {
-  if (!payload || typeof payload !== "object") {
-    return null;
-  }
-  const direct = (payload as { messageId?: unknown }).messageId;
-  const directId = normalizeOptionalString(direct);
-  if (directId) {
-    return directId;
-  }
-  const result = (payload as { result?: unknown }).result;
-  if (result && typeof result === "object") {
-    const nested = (result as { messageId?: unknown }).messageId;
-    const nestedId = normalizeOptionalString(nested);
-    if (nestedId) {
-      return nestedId;
+function firstNonemptyString(
+  record: Record<string, unknown> | undefined,
+  ...keys: string[]
+): string {
+  for (const key of keys) {
+    const value = typeof record?.[key] === "string" && record?.[key];
+    if (value) {
+      return value as string; // SAFETY: Preserve the old second accessor read after its string check.
     }
   }
-  return null;
+  return "";
 }
 
 type FormatOpts = {
@@ -42,6 +35,25 @@ type FormatOpts = {
   /** Max rows to render. Defaults to 25 when omitted. */
   displayLimit?: number;
 };
+
+function renderSummaryValue(value: unknown): string {
+  if (value == null) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return `${value.length} items`;
+  }
+  switch (typeof value) {
+    case "string":
+    case "number":
+    case "boolean":
+    case "bigint":
+    case "symbol":
+      return String(value);
+    default:
+      return typeof value;
+  }
+}
 
 function renderObjectSummary(payload: unknown, opts: FormatOpts): string {
   if (!payload || typeof payload !== "object") {
@@ -54,29 +66,7 @@ function renderObjectSummary(payload: unknown, opts: FormatOpts): string {
   }
 
   const rows = keys.slice(0, 20).map((k) => {
-    const v = obj[k];
-    const value =
-      v == null
-        ? "null"
-        : Array.isArray(v)
-          ? `${v.length} items`
-          : typeof v === "object"
-            ? "object"
-            : typeof v === "string"
-              ? v
-              : typeof v === "number"
-                ? String(v)
-                : typeof v === "boolean"
-                  ? v
-                    ? "true"
-                    : "false"
-                  : typeof v === "bigint"
-                    ? v.toString()
-                    : typeof v === "symbol"
-                      ? v.toString()
-                      : typeof v === "function"
-                        ? "function"
-                        : "unknown";
+    const value = renderSummaryValue(obj[k]);
     return { Key: k, Value: shortenText(value, 96) };
   });
   return renderTable({
@@ -93,25 +83,14 @@ function renderMessageList(messages: unknown[], opts: FormatOpts, emptyLabel: st
   const cap = opts.displayLimit ?? 25;
   const rows = messages.slice(0, cap).map((m) => {
     const msg = m as Record<string, unknown>;
-    const id =
-      (typeof msg.id === "string" && msg.id) ||
-      (typeof msg.ts === "string" && msg.ts) ||
-      (typeof msg.messageId === "string" && msg.messageId) ||
-      "";
+    const id = firstNonemptyString(msg, "id", "ts", "messageId");
     const authorObj = msg.author as Record<string, unknown> | undefined;
     const author =
-      (typeof msg.authorTag === "string" && msg.authorTag) ||
-      (typeof authorObj?.username === "string" && authorObj.username) ||
-      (typeof msg.user === "string" && msg.user) ||
-      "";
-    const time =
-      (typeof msg.timestamp === "string" && msg.timestamp) ||
-      (typeof msg.ts === "string" && msg.ts) ||
-      "";
-    const text =
-      (typeof msg.content === "string" && msg.content) ||
-      (typeof msg.text === "string" && msg.text) ||
-      "";
+      firstNonemptyString(msg, "authorTag") ||
+      firstNonemptyString(authorObj, "username") ||
+      firstNonemptyString(msg, "user");
+    const time = firstNonemptyString(msg, "timestamp", "ts");
+    const text = firstNonemptyString(msg, "content", "text");
     return {
       Time: shortenText(time, 28),
       Author: shortenText(author, 22),
@@ -169,10 +148,7 @@ function renderReactions(payload: unknown, opts: FormatOpts): string | null {
     const entry = r as Record<string, unknown>;
     const emojiObj = entry.emoji as Record<string, unknown> | undefined;
     const emoji =
-      (typeof emojiObj?.raw === "string" && emojiObj.raw) ||
-      (typeof entry.name === "string" && entry.name) ||
-      (typeof entry.emoji === "string" && entry.emoji) ||
-      "";
+      firstNonemptyString(emojiObj, "raw") || firstNonemptyString(entry, "name", "emoji");
     const count = typeof entry.count === "number" ? String(entry.count) : "";
     const userList = Array.isArray(entry.users)
       ? (entry.users as unknown[])
@@ -185,12 +161,7 @@ function renderReactions(payload: unknown, opts: FormatOpts): string | null {
               return "";
             }
             const user = u as Record<string, unknown>;
-            return (
-              (typeof user.tag === "string" && user.tag) ||
-              (typeof user.username === "string" && user.username) ||
-              (typeof user.id === "string" && user.id) ||
-              ""
-            );
+            return firstNonemptyString(user, "tag", "username", "id");
           })
           .filter(Boolean)
       : [];
@@ -309,7 +280,7 @@ export function formatMessageCliText(
     }
 
     const label = resolveChannelLabel(result.channel);
-    const msgId = extractMessageId(result.payload);
+    const msgId = resolveMessageActionMessageId(result.payload);
     return [ok(`✅ Sent via ${label}.${msgId ? ` Message ID: ${msgId}` : ""}`)];
   }
 
@@ -350,7 +321,7 @@ export function formatMessageCliText(
     }
 
     const label = resolveChannelLabel(result.channel);
-    const msgId = extractMessageId(result.payload);
+    const msgId = resolveMessageActionMessageId(result.payload);
     return [ok(`✅ Poll sent via ${label}.${msgId ? ` Message ID: ${msgId}` : ""}`)];
   }
 

--- a/src/commands/message.test.ts
+++ b/src/commands/message.test.ts
@@ -576,20 +576,51 @@ describe("messageCommand", () => {
     expect(actionCall.params.pollQuestion).toBe("Ship it?");
   });
 
-  it("includes a stable top-level messageId in JSON output", async () => {
-    runMessageActionMock.mockResolvedValueOnce({
-      kind: "send",
-      channel: "discord",
-      action: "send",
-      to: "channel:general",
-      handledBy: "plugin",
+  it.each([
+    {
+      name: "nested",
       payload: {
         ok: true,
         result: {
           messageId: "msg-json-1",
           channelId: "general",
         },
-      } as { ok: boolean } & Record<string, unknown>,
+      },
+      expectedMessageId: "msg-json-1",
+      expectedPayload: {
+        ok: true,
+        result: {
+          messageId: "msg-json-1",
+          channelId: "general",
+        },
+      },
+    },
+    {
+      name: "direct-before-nested",
+      payload: {
+        messageId: " direct-id ",
+        result: { messageId: "nested-id" },
+      },
+      expectedMessageId: "direct-id",
+      expectedPayload: {
+        messageId: " direct-id ",
+        result: { messageId: "nested-id" },
+      },
+    },
+    {
+      name: "array object",
+      payload: Object.assign([], { messageId: " array-id " }),
+      expectedMessageId: "array-id",
+      expectedPayload: [],
+    },
+  ])("includes a stable top-level messageId from a $name payload", async (testCase) => {
+    runMessageActionMock.mockResolvedValueOnce({
+      kind: "send",
+      channel: "discord",
+      action: "send",
+      to: "channel:general",
+      handledBy: "plugin",
+      payload: testCase.payload,
       dryRun: false,
     });
 
@@ -600,14 +631,8 @@ describe("messageCommand", () => {
 
     const output = vi.mocked(runtime.log).mock.calls[0]?.[0];
     const json = JSON.parse(String(output)) as { messageId?: string; payload?: unknown };
-    expect(json.messageId).toBe("msg-json-1");
-    expect(json.payload).toEqual({
-      ok: true,
-      result: {
-        messageId: "msg-json-1",
-        channelId: "general",
-      },
-    });
+    expect(json.messageId).toBe(testCase.expectedMessageId);
+    expect(json.payload).toEqual(testCase.expectedPayload);
     expect(json).not.toHaveProperty("ok");
   });
 

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -24,31 +24,15 @@ import {
   resolveMessageBroadcastAccountPlan,
   validateExplicitMessageAccountSelection,
 } from "../infra/outbound/message-account-selection.js";
-import { resolveMessageActionOutcome } from "../infra/outbound/message-action-contracts.js";
+import {
+  resolveMessageActionMessageId,
+  resolveMessageActionOutcome,
+} from "../infra/outbound/message-action-contracts.js";
 import { runMessageAction } from "../infra/outbound/message-action-runner.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 
-function extractMessageId(payload: unknown): string | undefined {
-  if (!payload || typeof payload !== "object") {
-    return undefined;
-  }
-  const record = payload as Record<string, unknown>;
-  const direct = normalizeOptionalString(record.messageId);
-  if (direct) {
-    return direct;
-  }
-  const result = record.result;
-  if (result && typeof result === "object") {
-    const nested = normalizeOptionalString((result as Record<string, unknown>).messageId);
-    if (nested) {
-      return nested;
-    }
-  }
-  return undefined;
-}
-
 function buildMessageCliJson(result: Awaited<ReturnType<typeof runMessageAction>>) {
-  const messageId = extractMessageId(result.payload);
+  const messageId = resolveMessageActionMessageId(result.payload);
   const sendResult = result.kind === "send" ? result.sendResult : undefined;
   const outcome = resolveMessageActionOutcome(result);
   return {

--- a/src/infra/outbound/message-action-contracts.ts
+++ b/src/infra/outbound/message-action-contracts.ts
@@ -235,6 +235,24 @@ export function resolveMessageActionOutcome(
   return { ok: false, error };
 }
 
+export function resolveMessageActionMessageId(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object") {
+    return undefined;
+  }
+  // SAFETY: The object check intentionally keeps array and prototype-backed payloads readable.
+  const record = payload as Record<string, unknown>;
+  const direct = normalizeOptionalString(record.messageId);
+  if (direct) {
+    return direct;
+  }
+  const result = record.result;
+  if (!result || typeof result !== "object") {
+    return undefined;
+  }
+  // SAFETY: The nested object check preserves the same permissive payload contract.
+  return normalizeOptionalString((result as Record<string, unknown>).messageId);
+}
+
 export type ResolvedActionContext = {
   cfg: OpenClawConfig;
   params: Record<string, unknown>;


### PR DESCRIPTION
Message JSON and terminal output repeated payload-ID projection, alias selection and primitive summarization. They now share the payload projector and use smaller formatting helpers, retaining direct-before-nested IDs, trimming, table output and delivery outcomes.

The alias helper preserves the original short-circuit behavior, including returning a getter's second truthy read. An initial review caught a candidate regression here; the final implementation and maintained changing-getter test preserve the original behavior. Transport, authorization and stored data are unchanged.

**Production: +65/-92 = -27 lines, including assertion-baseline bookkeeping. Tests: +128/-16 = +112 lines.**

Validation: all56 final maintained message/formatter tests pass. Two additional immutable-corpus tests reproduce31,875 baseline bytes across14 JSON cases,29 formatter cases and3 getter scenarios. Those tests supply action results at the command boundary; they do not claim live provider I/O. Final type, lint, format and assertion checks pass, and a fresh isolated Codex high/P2 review is clean.

The actual source CLI rebuilt the dirty source and completed `message send --channel telegram --target 1 --message probe --dry-run --json` with networking denied. Exit0 and all222 output bytes match baseline:

```json
{"action":"send","channel":"telegram","dryRun":true,"handledBy":"core","payload":{"channel":"telegram","to":"telegram:1","via":"direct","mediaUrl":null,"dryRun":true}}
```

The earlier full selected gate, including all three dead-code scans, and full normal build passed before the final getter/formatter correction. Fresh final checks and the source CLI rebuild cover the final bytes; exact-head hosted CI is required before landing. Failed setup/lint attempts and the original review finding are retained. Random terminal startup banners are not claimed byte-identical.


Maintainer landing review: retain the shared outbound-result projection and separate JSON/terminal presentation owners. Root read the full latest ClawSweeper review; its pending-CI risk is resolved by all216 exact-head jobs passing or intentionally skipping in33529478269, including the required gate. The final getter-order correction passes the baseline corpus and56 maintained tests; the actual source CLI rebuilt and returned the exact222-byte dry-run JSON under network denial. Production−27, assertion metadata net0, tests+112. No transport, authorization or persistence behavior changes.
