### PR TITLE
refactor(agents): release tool catalogs with their runs

### DIFF
--- a/src/agents/tool-search-catalog.ts
+++ b/src/agents/tool-search-catalog.ts
@@ -1,5 +1,4 @@
 import { stableStringify } from "@openclaw/normalization-core";
-import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { generateSecureHex } from "../infra/secure-random.js";
 import { getPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tool-metadata.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
@@ -27,30 +26,9 @@ import {
 } from "./tool-search-types.js";
 import { ToolInputError, type AnyAgentTool } from "./tools/common.js";
 
-const MAX_REUSABLE_CATALOG_SNAPSHOTS = 256;
-type ReusableCatalogDescriptor = Readonly<Omit<ToolSearchCatalogEntry, "tool">>;
-const reusableCatalogSnapshots = new Map<
-  string,
-  { descriptors: readonly ReusableCatalogDescriptor[]; fingerprint: string }
->();
 const catalogFingerprints = new WeakMap<ToolSearchCatalogSession, string>();
 const untrustedSchemaIdentities = new WeakMap<object, number>();
 let nextUntrustedSchemaIdentity = 1;
-
-function reusableCatalogKey(input: {
-  sessionId?: string;
-  sessionKey?: string;
-  agentId?: string;
-}): string | undefined {
-  if (input.sessionId?.trim()) {
-    return `session:${input.sessionId.trim()}`;
-  }
-  if (input.sessionKey?.trim()) {
-    return `key:${input.sessionKey.trim()}`;
-  }
-  const agentId = input.agentId?.trim();
-  return agentId ? `agent:${agentId}` : undefined;
-}
 
 function catalogEntriesFingerprint(entries: readonly ToolSearchCatalogEntry[]): string {
   return entries
@@ -91,18 +69,18 @@ function untrustedSchemaFingerprint(schema: unknown): string {
 }
 
 function rebindCatalogExecutors(
-  descriptors: readonly ReusableCatalogDescriptor[],
+  existingEntries: readonly ToolSearchCatalogEntry[],
   currentEntries: readonly ToolSearchCatalogEntry[],
 ): ToolSearchCatalogEntry[] | undefined {
   const currentTools = new Map(currentEntries.map((entry) => [entry.id, entry.tool]));
-  if (currentTools.size !== currentEntries.length || currentTools.size !== descriptors.length) {
+  if (currentTools.size !== currentEntries.length || currentTools.size !== existingEntries.length) {
     return undefined;
   }
-  const rebound = descriptors.map((descriptor) => {
+  const rebound = existingEntries.map((entry) => {
     // Catalog ids are the callable identity. Every hit binds that exact entry to
     // this run's closure; a missing id must miss instead of retaining stale authority.
-    const tool = currentTools.get(descriptor.id);
-    return tool ? { ...descriptor, tool } : undefined;
+    const tool = currentTools.get(entry.id);
+    return tool ? { ...entry, tool } : undefined;
   });
   return rebound.every((entry): entry is ToolSearchCatalogEntry => entry !== undefined)
     ? rebound
@@ -114,44 +92,6 @@ function rebindCatalogExecutors(
 // so tool-payload redaction leaves persisted results embedding the scope intact.
 function generateCounterScope(): string {
   return generateSecureHex(12);
-}
-
-function restoreToolSearchCatalog(params: {
-  catalogRef: ToolSearchCatalogRef;
-  entries: ToolSearchCatalogEntry[];
-  fingerprint: string;
-}): void {
-  const next = {
-    entries: params.entries,
-    counterScope: generateCounterScope(),
-    searchCount: 0,
-    describeCount: 0,
-    callCount: 0,
-  };
-  params.catalogRef.current = next;
-  delete params.catalogRef.closedTelemetry;
-  catalogFingerprints.set(next, params.fingerprint);
-  params.catalogRef.onChange?.();
-}
-
-function rememberReusableCatalog(key: string | undefined, catalog: ToolSearchCatalogSession): void {
-  if (!key) {
-    return;
-  }
-  const fingerprint = catalogFingerprints.get(catalog);
-  if (!fingerprint) {
-    return;
-  }
-  if (reusableCatalogSnapshots.has(key)) {
-    reusableCatalogSnapshots.delete(key);
-  }
-  reusableCatalogSnapshots.set(key, {
-    descriptors: Object.freeze(
-      catalog.entries.map(({ tool: _tool, ...descriptor }) => Object.freeze(descriptor)),
-    ),
-    fingerprint,
-  });
-  pruneMapToMaxSize(reusableCatalogSnapshots, MAX_REUSABLE_CATALOG_SNAPSHOTS);
 }
 
 function classifyTool(tool: CatalogTool): {
@@ -296,7 +236,7 @@ function registerToolSearchCatalog(params: {
   entries: ToolSearchCatalogEntry[];
   append?: boolean;
   fingerprint?: string;
-}): ToolSearchCatalogSession {
+}): void {
   const prior = params.append ? params.catalogRef.current : undefined;
   const byId = new Map((prior?.entries ?? []).map((entry) => [entry.id, entry]));
   for (const entry of params.entries) {
@@ -321,7 +261,6 @@ function registerToolSearchCatalog(params: {
   params.catalogRef.current = next;
   delete params.catalogRef.closedTelemetry;
   params.catalogRef.onChange?.();
-  return next;
 }
 
 export function clearToolSearchCatalog(params: {
@@ -343,12 +282,6 @@ export function clearToolSearchCatalog(params: {
     delete params.catalogRef.onChange;
     delete params.catalogRef.disposeObserver;
     delete params.catalogRef.onDispose;
-  }
-  if (!params.runId?.trim()) {
-    const snapshotKey = reusableCatalogKey(params);
-    if (snapshotKey) {
-      reusableCatalogSnapshots.delete(snapshotKey);
-    }
   }
 }
 
@@ -480,7 +413,6 @@ export function applyToolCatalogCompaction(
 
   const visible: AnyAgentTool[] = [];
   const catalog: ToolSearchCatalogEntry[] = [];
-  let hasPrewrappedInput = false;
   const shouldCatalog = (tool: AnyAgentTool) =>
     shouldCatalogTool(tool) && (params.shouldCatalogTool?.(tool) ?? true);
   for (const tool of params.tools) {
@@ -492,7 +424,6 @@ export function applyToolCatalogCompaction(
       continue;
     }
     if (shouldCatalog(tool)) {
-      hasPrewrappedInput ||= isToolWrappedWithBeforeToolCallHook(tool);
       catalog.push(toCatalogEntry(tool, undefined, params.toolHookContext));
       if (!params.isVisibleCatalogTool?.(tool)) {
         continue;
@@ -500,12 +431,8 @@ export function applyToolCatalogCompaction(
     }
     visible.push(tool);
   }
-  // Prewrapped inputs already close over a run's hook and abort state. Only
-  // wrappers created during cataloging are safe to reuse through executor rebinding.
-  const reusableKey = hasPrewrappedInput ? undefined : reusableCatalogKey(params);
   const existingCatalog = catalogRef.current;
-  const incomingFingerprint =
-    existingCatalog || reusableKey ? catalogEntriesFingerprint(catalog) : undefined;
+  const incomingFingerprint = existingCatalog ? catalogEntriesFingerprint(catalog) : undefined;
   if (existingCatalog && catalogFingerprints.get(existingCatalog) === incomingFingerprint) {
     const reboundEntries = rebindCatalogExecutors(existingCatalog.entries, catalog);
     if (reboundEntries) {
@@ -524,36 +451,11 @@ export function applyToolCatalogCompaction(
     }
   }
 
-  const reusableSnapshot = reusableKey ? reusableCatalogSnapshots.get(reusableKey) : undefined;
-  const reboundEntries =
-    reusableSnapshot && reusableSnapshot.fingerprint === incomingFingerprint
-      ? rebindCatalogExecutors(reusableSnapshot.descriptors, catalog)
-      : undefined;
-  if (reusableSnapshot && reboundEntries) {
-    restoreToolSearchCatalog({
-      catalogRef,
-      entries: reboundEntries,
-      fingerprint: reusableSnapshot.fingerprint,
-    });
-    if (reusableKey) {
-      reusableCatalogSnapshots.delete(reusableKey);
-      reusableCatalogSnapshots.set(reusableKey, reusableSnapshot);
-    }
-    return {
-      tools: visible,
-      compacted: catalog.length > 0,
-      catalogToolCount: catalog.length,
-      catalogRegistered: true,
-      catalogReused: true,
-    };
-  }
-
-  const registered = registerToolSearchCatalog({
+  registerToolSearchCatalog({
     catalogRef,
     entries: catalog,
     fingerprint: incomingFingerprint,
   });
-  rememberReusableCatalog(reusableKey, registered);
   return {
     tools: visible,
     compacted: catalog.length > 0,

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -3666,7 +3666,7 @@ describe("Tool Search", () => {
     expect(abortCount).toBe(1);
   });
 
-  it("reuses an unchanged catalog within the same run", () => {
+  it("reuses an unchanged catalog only on the same ref", () => {
     const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
     const alpha = pluginTool("fake_reuse_alpha", "Alpha tool");
     const beta = pluginTool("fake_reuse_beta", "Beta tool");
@@ -3706,7 +3706,7 @@ describe("Tool Search", () => {
       sessionKey: "agent:main:tool-search-reuse",
       catalogRef: laterRef,
     });
-    expect(later.catalogReused).toBe(true);
+    expect(later.catalogReused).toBe(false);
     expect(laterRef.current).not.toBe(catalogAfterFirst);
     expect(laterRef.current?.entries).not.toBe(catalogAfterFirst.entries);
     expect(laterRef.current?.entries).toEqual(catalogAfterFirst.entries);
@@ -3733,7 +3733,7 @@ describe("Tool Search", () => {
   });
 
   it.each(["fresh", "same"] as const)(
-    "restores an unchanged catalog after run cleanup on a %s ref",
+    "registers a fresh catalog after run cleanup on a %s ref",
     async (refMode) => {
       const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
       const alpha = pluginTool("fake_xrun_alpha", "Alpha tool");
@@ -3774,49 +3774,49 @@ describe("Tool Search", () => {
       expect(firstRef.current).toBeUndefined();
       expect(firstRuntime.telemetry()).toMatchObject(firstCounters);
 
-      const restoredRef = refMode === "same" ? firstRef : createToolSearchCatalogRef();
+      const nextRef = refMode === "same" ? firstRef : createToolSearchCatalogRef();
       const second = applyToolSearchCatalog({
         tools: [codeTool, alpha, beta],
         config,
         sessionId,
         runId: "run-2",
-        catalogRef: restoredRef,
+        catalogRef: nextRef,
       });
       expect(second.catalogRegistered).toBe(true);
-      expect(second.catalogReused).toBe(true);
-      const restoredCatalog = expectDefined(restoredRef.current, "restored run catalog");
-      const restoredAlphaEntry = expectDefined(
-        restoredCatalog.entries.find((entry) => entry.name === alpha.name),
-        "restored alpha entry",
+      expect(second.catalogReused).toBe(false);
+      const nextCatalog = expectDefined(nextRef.current, "next run catalog");
+      const nextAlphaEntry = expectDefined(
+        nextCatalog.entries.find((entry) => entry.name === alpha.name),
+        "next run alpha entry",
       );
-      expect(restoredAlphaEntry).not.toBe(firstAlphaEntry);
-      expect(restoredAlphaEntry).toEqual(firstAlphaEntry);
-      expect(restoredAlphaEntry.tool).toBe(alpha);
-      expect(restoredCatalog.counterScope).not.toBe(firstCatalog.counterScope);
-      expect(restoredCatalog.searchCount).toBe(0);
-      const restoredRuntime = new ToolSearchRuntime(
-        { catalogRef: restoredRef },
+      expect(nextAlphaEntry).not.toBe(firstAlphaEntry);
+      expect(nextAlphaEntry).toEqual(firstAlphaEntry);
+      expect(nextAlphaEntry.tool).toBe(alpha);
+      expect(nextCatalog.counterScope).not.toBe(firstCatalog.counterScope);
+      expect(nextCatalog.searchCount).toBe(0);
+      const nextRuntime = new ToolSearchRuntime(
+        { catalogRef: nextRef },
         resolveToolSearchConfig(config),
       );
-      const restoredCounters = {
-        counterScope: restoredCatalog.counterScope,
+      const nextCounters = {
+        counterScope: nextCatalog.counterScope,
         searchCount: 0,
         describeCount: 0,
         callCount: 0,
       };
       for (const phase of ["active", "closed"] as const) {
         if (phase === "closed") {
-          clearToolSearchCatalog({ sessionId, catalogRef: restoredRef });
+          clearToolSearchCatalog({ sessionId, catalogRef: nextRef });
         }
-        expect(restoredRuntime.telemetry(), phase).toMatchObject(restoredCounters);
+        expect(nextRuntime.telemetry(), phase).toMatchObject(nextCounters);
         expect(firstRuntime.telemetry(), phase).toMatchObject(
-          refMode === "same" ? restoredCounters : firstCounters,
+          refMode === "same" ? nextCounters : firstCounters,
         );
       }
     },
   );
 
-  it("notifies catalog-ref lifecycle hooks across snapshot restore and disposal", () => {
+  it("notifies catalog-ref lifecycle hooks across registration and disposal", () => {
     const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
     const alpha = pluginTool("fake_lifecycle_alpha", "Alpha tool");
     const config = { tools: { toolSearch: true } } as never;
@@ -3851,14 +3851,14 @@ describe("Tool Search", () => {
       runId: "run-lifecycle-2",
       catalogRef: secondRef,
     });
-    expect(second.catalogReused).toBe(true);
+    expect(second.catalogReused).toBe(false);
     expect(secondChange).toHaveBeenCalledOnce();
   });
 
-  it("applies Code Mode projection filtering to restored catalogs", async () => {
+  it("applies Code Mode projection filtering to a newly registered catalog", async () => {
     const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
     // The unprojected tool is the stronger match for the query; only projection
-    // filtering can keep it out of a one-result search on the restored catalog.
+    // filtering can keep it out of a one-result search on the next run's catalog.
     const shadowing = pluginTool("fake_projection_probe", "Projection probe projection probe");
     shadowing.execute = vi.fn(async () => jsonResult({ marker: "shadowing" }));
     const projected = pluginTool("fake_projection_secondary", "Projection probe secondary");
@@ -3884,11 +3884,11 @@ describe("Tool Search", () => {
       runId: "run-projection-2",
       catalogRef: secondRef,
     });
-    expect(second.catalogReused).toBe(true);
-    const restored = expectDefined(secondRef.current, "restored projection catalog");
+    expect(second.catalogReused).toBe(false);
+    const nextCatalog = expectDefined(secondRef.current, "next projection catalog");
     const projectedId = expectDefined(
-      restored.entries.find((entry) => entry.name === projected.name),
-      "restored projected entry",
+      nextCatalog.entries.find((entry) => entry.name === projected.name),
+      "next projected entry",
     ).id;
 
     const runtime = new ToolSearchRuntime(
@@ -3908,7 +3908,7 @@ describe("Tool Search", () => {
     expect(shadowing.execute).not.toHaveBeenCalled();
   });
 
-  it("does not reuse snapshots for prewrapped input tools across runs", async () => {
+  it("binds prewrapped input tools to their current run", async () => {
     const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
     const config = { tools: { toolSearch: true } } as never;
     const sessionId = "session-prewrapped-tool";
@@ -4029,7 +4029,7 @@ describe("Tool Search", () => {
     ]);
   });
 
-  it("reuses fresh MCP wrappers while executing the current run wrapper", async () => {
+  it("registers fresh MCP wrappers and executes the current run wrapper", async () => {
     const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
     const config = { tools: { toolSearch: true } } as never;
     const sessionId = "session-mcp-wrapper-reuse";
@@ -4113,7 +4113,7 @@ describe("Tool Search", () => {
       catalogRef: secondRef,
       toolHookContext: { sessionId, runId: "run-mcp-2" },
     });
-    expect(second.catalogReused).toBe(true);
+    expect(second.catalogReused).toBe(false);
 
     const runtime = new ToolSearchRuntime(
       { catalogRef: secondRef },
@@ -4182,7 +4182,7 @@ describe("Tool Search", () => {
     expect(second.catalogReused).toBe(false);
   });
 
-  it("degrades to a miss when a tool disappears from the current run", () => {
+  it("registers only tools present in the current run", () => {
     const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
     const config = { tools: { toolSearch: true } } as never;
     const sessionId = "session-tool-removed";


### PR DESCRIPTION
## What Problem This Solves

Closing an agent run releases its live tool catalog but leaves descriptor snapshots and full schema fingerprints in a separate process-wide cache. Up to 256 session keys can keep that data resident after the runs finish.

## Why This Change Was Made

Remove the cross-run cache and register each new run's catalog through the existing canonical path. A cache hit already rebuilt current entries and executors, so the deleted cache saved only deduplication and ordering. Repeated application to the same live catalog still preserves counters, catalog identity, and current-executor rebinding. Run cleanup still disposes observers and keeps bounded aggregate telemetry.

## User Impact

Closed runs release catalog descriptors and schema fingerprint strings. Tool schemas, search results, Code Mode projection, and current-run execution stay unchanged. Fresh runs now report fresh catalog registration in the existing diagnostic log. Production LOC: +8/-106, net -98. Test LOC: +34/-34, net zero; no tests or assertions removed.

## Evidence

- 261 existing tests pass before and after across Tool Search, its runtime, Code Mode lifecycle, client tools, and attempt planning. They preserve same-ref reuse, fresh counter scopes, current MCP and hook executors, last-wins duplicate IDs, remote-schema nontraversal, projection filtering, and disposal.
- A complete-owner probe using real production dependencies created 128 synthetic sessions with two runs, 48 tools and 32 schema properties each. After cleanup, retained cross-run snapshots fell from 128 to zero, descriptors from 6,144 to zero, and fingerprint characters from 25,443,200 to zero.
- In that workload, post-GC JavaScript heap growth was 54,041,816→137,120 bytes. This is a synthetic owner-retention result, not a whole-Gateway RSS claim. The descriptive elapsed samples were comparable (369.6→367.2 ms).
- Focused test command wall time was 19.84→17.66 seconds; maximum RSS was 1,778,876,416→1,779,531,776 bytes, effectively unchanged. This is validation context, not a claimed test performance improvement.
- Isolated Codex autoreview passed. A clean build of this commit completed three real OpenAI turns: one ordinary reply and two consecutive Code Mode web_fetch calls in the same session. Durable history paired both nested calls with HTTP 200 results; the two runs had distinct counter scopes and one call each. The Gateway exited cleanly. The first probe run needed its telemetry parser corrected for the network-content security envelope; the successful rerun kept the same production build and strict assertions.
