### PR TITLE
fix: unblock trusted plugin publication config loading

### DIFF
--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -1552,6 +1552,9 @@ jobs:
         run: |
           set -euo pipefail
           unset NODE_AUTH_TOKEN NPM_TOKEN NODE_OPTIONS
+          # npm requires distinct user and global config sources, even when both are empty.
+          npmrc="$(mktemp "${RUNNER_TEMP}/plugin-npm-oidc.XXXXXX")"
+          trap 'rm -f "$npmrc"' EXIT
           # Publish the attested bytes; rebuilding here loses the candidate's patched install.
           node scripts/release-tooling-identity.mjs verify \
             --repository "$OPENCLAW_RELEASE_TOOLING_REPOSITORY" \
@@ -1564,7 +1567,7 @@ jobs:
             --release-publish-full-ref "$OPENCLAW_RELEASE_PUBLISH_FULL_REF" \
             --release-publish-parent-state-policy "$OPENCLAW_RELEASE_PUBLISH_PARENT_STATE_POLICY" \
             --allow-prevalidated-ref
-          NPM_CONFIG_USERCONFIG=/dev/null \
+          NPM_CONFIG_USERCONFIG="$npmrc" \
             NPM_CONFIG_GLOBALCONFIG=/dev/null \
             NPM_CONFIG_REGISTRY=https://registry.npmjs.org/ \
             timeout --signal=TERM --kill-after=10s 300s npm publish "$TARBALL_PATH" \

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -1,7 +1,15 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { PLUGIN_NPM_RELEASE_AUTHORITY_PATHS } from "../../scripts/lib/plugin-publication-candidates.ts";
@@ -181,6 +189,10 @@ describe("plugin npm extended-stable workflow", () => {
             `#!${process.execPath}
 const fs = require("node:fs");
 const args = process.argv.slice(2);
+if (${JSON.stringify(command)} === "npm") {
+  const result = require("node:child_process").spawnSync(process.execPath, [process.env.NPM_CLI, "config", "get", "registry"], { env: process.env, encoding: "utf8", timeout: 10_000 });
+  if (result.status !== 0) { process.stderr.write(result.stderr); process.exit(result.status ?? 1); }
+}
 fs.appendFileSync(process.env.EVENTS, JSON.stringify({ command: ${JSON.stringify(command)}, args, ...( ${JSON.stringify(command)} === "npm" ? { bytes: fs.readFileSync(args[1], "utf8"), token: Boolean(process.env.NPM_TOKEN || process.env.NODE_AUTH_TOKEN) } : {}) }) + "\\n");
 process.exit(${JSON.stringify(command)} === "node" ? Number(process.env.IDENTITY_EXIT) : 0);
 `,
@@ -206,10 +218,13 @@ process.exit(${JSON.stringify(command)} === "node" ? Number(process.env.IDENTITY
           {
             cwd: root,
             encoding: "utf8",
+            timeout: 15_000,
             env: {
               PATH: `${bin}:/usr/bin:/bin`,
               ...publish.env,
               EVENTS: events,
+              NPM_CLI: realpathSync(join(dirname(process.execPath), "npm")),
+              RUNNER_TEMP: root,
               IDENTITY_EXIT: String(identityExit),
               TARBALL_PATH: tarball,
               PUBLISH_TAG: publishTag,
@@ -219,6 +234,7 @@ process.exit(${JSON.stringify(command)} === "node" ? Number(process.env.IDENTITY
           },
         );
         expect(result.status, result.stderr).toBe(identityExit);
+        expect(readdirSync(root).filter((name) => name.startsWith("plugin-npm-oidc."))).toEqual([]);
         const calls = readFileSync(events, "utf8")
           .trim()
           .split("\n")
@@ -564,7 +580,7 @@ process.exit(${JSON.stringify(command)} === "node" ? Number(process.env.IDENTITY
     const parsed = workflow();
     const publish = step(parsed.jobs?.publish_plugins_npm, "Publish with trusted publisher");
     expect(publish.run).toContain("unset NODE_AUTH_TOKEN NPM_TOKEN NODE_OPTIONS");
-    expect(publish.run).toContain("NPM_CONFIG_USERCONFIG=/dev/null");
+    expect(publish.run).toContain('NPM_CONFIG_USERCONFIG="$npmrc"');
     expect(publish.env?.NODE_AUTH_TOKEN).toBeUndefined();
     expect(publish.env?.NPM_TOKEN).toBeUndefined();
     const bootstrapCheck = step(


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where trusted plugin publication stopped before uploading the verified tarball because npm rejected the same `/dev/null` path as both its user and global configuration. This affected the Matrix publication attempt in [run 33526882355](https://github.com/openclaw/openclaw/actions/runs/33526882355).

## Why This Change Was Made

The publication workflow now gives npm an empty, private temporary user configuration and keeps `/dev/null` for global configuration. The temporary file is removed when the step exits, including when the final tooling identity check fails. The existing tarball, provenance, dist-tag, and token isolation contracts remain in place.

The regression executes npm's real configuration loader inside the existing publication fixture. The previous fixture mocked npm completely and could not detect npm rejecting its configuration before publication. Production delta: +3 lines for separate config ownership and cleanup; test delta: +16 lines.

## User Impact

Maintainers can publish verified plugin packages through the trusted publisher without this configuration error. There is no runtime product change.

## Evidence

- Before the fix, the executable regression failed for all three publication tags with `double-loading config "/dev/null" as "global", previously loaded as "user"`; identity rejection continued to pass.
- After the fix, all 17 tests in `test/scripts/plugin-npm-extended-stable-workflow.test.ts` pass, including latest, beta, extended-stable, and cleanup after identity rejection. Focused lint and formatting pass.
- npm 11.17.0 accepted the isolated configuration and completed a real `npm publish --dry-run --ignore-scripts --provenance` of the sealed `@openclaw/matrix@2026.8.2` tarball, with its exact integrity preserved. This dry run uploaded nothing and used `--force` only to inspect the already-published version. It does not claim an OIDC attestation.
- Scoped Codex autoreview completed with no accepted or actionable findings.
