### PR TITLE
fix(ui): widen default normal Chat transcript frame

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -879,7 +879,8 @@ Messages forwarded by `sessions_send` render as left-aligned speech bubbles with
 
 ## Chat message width
 
-Wide-monitor users can override the transcript width under **Settings → Chat →
+Normal Chat defaults to a centered transcript and message frame capped at
+`1280px`. Wide-monitor users can override that width under **Settings → Chat →
 Message width**. The preference stays in that browser's local storage. Supported
 forms include plain lengths and percentages such as `960px` or `82%`, plus
 constrained `min(...)`, `max(...)`, `clamp(...)`, `calc(...)`, and

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -187,7 +187,7 @@ export const UI_APPEARANCE_DEFAULTS = {
   themeMode: "system",
   textScale: 100,
   sidebarLiveActivity: true,
-  chatMessageMaxWidth: "48rem",
+  chatMessageMaxWidth: "min(1280px, 100%)",
   chatCollapseTaskProgress: false,
   chatSendShortcut: "enter",
   catalogOpenTarget: "viewer",

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1733,14 +1733,15 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
-  it("applies configured chat width to tool rows and composer without changing defaults", async () => {
+  it("inherits configured chat width for tool rows and composer without changing defaults", async () => {
     const page = await openBrowserPage(1600, 900);
     const renderFixture = async (configured: boolean) => {
       const style = configured
         ? 'style="--chat-thread-max-width: 82%; --chat-message-max-width: 100%"'
         : "";
       await page.setContent(`<!doctype html><html><head><style>${readUiCss()}</style></head><body>
-        <section class="card chat" ${style}>
+        <openclaw-chat-page ${style}>
+        <section class="card chat">
           <div class="chat-thread chat-thread--direct" role="log">
             <div class="chat-thread-inner">
               <div class="chat-group tool">
@@ -1767,6 +1768,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             <div class="agent-chat__input">Composer</div>
           </div>
         </section>
+        </openclaw-chat-page>
       </body></html>`);
       return await page.evaluate(() => {
         const rect = (selector: string) => {

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1733,15 +1733,14 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
-  it("inherits configured chat width for tool rows and composer without changing defaults", async () => {
+  it("keeps normal Chat lanes on a centered 1280px default frame and honors a direct override", async () => {
     const page = await openBrowserPage(1600, 900);
     const renderFixture = async (configured: boolean) => {
       const style = configured
-        ? 'style="--chat-thread-max-width: 82%; --chat-message-max-width: 100%"'
+        ? 'style="--chat-thread-max-width: 960px; --chat-message-max-width: 100%"'
         : "";
       await page.setContent(`<!doctype html><html><head><style>${readUiCss()}</style></head><body>
-        <openclaw-chat-page ${style}>
-        <section class="card chat">
+        <section class="card chat" ${style}>
           <div class="chat-thread chat-thread--direct" role="log">
             <div class="chat-thread-inner">
               <div class="chat-group tool">
@@ -1768,7 +1767,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             <div class="agent-chat__input">Composer</div>
           </div>
         </section>
-        </openclaw-chat-page>
       </body></html>`);
       return await page.evaluate(() => {
         const rect = (selector: string) => {
@@ -1789,24 +1787,33 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
 
     try {
       const defaults = await renderFixture(false);
-      expect(defaults.thread.width).toBeCloseTo(768, 0);
-      expect(defaults.composer.width).toBeCloseTo(defaults.thread.width, 0);
-      expect(defaults.prs.width).toBeCloseTo(defaults.thread.width, 0);
-      expect(defaults.tool.width).toBeCloseTo(defaults.thread.width, 0);
-      expect(defaults.shell.width).toBeCloseTo(760, 0);
-      expect(defaults.activity.width).toBeCloseTo(760, 0);
-      expect(defaults.framedActivity.width).toBeCloseTo(defaults.activity.width, 0);
+      expect(defaults.thread.width).toBeCloseTo(1280, 0);
+      for (const key of [
+        "activity",
+        "composer",
+        "framedActivity",
+        "prs",
+        "shell",
+        "tool",
+      ] as const) {
+        expect(defaults[key].width).toBeCloseTo(defaults.thread.width, 0);
+        expect(defaults[key].center).toBeCloseTo(defaults.thread.center, 0);
+      }
 
       const configured = await renderFixture(true);
-      for (const key of ["activity", "framedActivity", "shell", "tool"] as const) {
+      expect(configured.thread.width).toBeCloseTo(960, 0);
+      for (const key of [
+        "activity",
+        "composer",
+        "framedActivity",
+        "prs",
+        "shell",
+        "tool",
+      ] as const) {
         expect(configured[key].width).toBeCloseTo(configured.thread.width, 0);
+        expect(configured[key].center).toBeCloseTo(configured.thread.center, 0);
       }
-      expect(configured.composer.width).toBeCloseTo(configured.prs.width, 0);
-      for (const rect of Object.values(configured)) {
-        expect(rect.center).toBeCloseTo(configured.thread.center, 0);
-      }
-      expect(configured.thread.width).toBeGreaterThan(defaults.thread.width);
-      expect(configured.composer.width).toBeGreaterThan(defaults.composer.width);
+      expect(configured.thread.width).toBeLessThan(defaults.thread.width);
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1418,14 +1418,14 @@ describe("cloud worker disk-space notice", () => {
 });
 
 describe("chat conversation width", () => {
-  it("applies a configured width once to the centered transcript frame", () => {
+  it("writes configured width variables directly on the normal Chat surface", () => {
     const container = renderChatView({
-      chatMessageMaxWidth: "82%",
+      chatMessageMaxWidth: "960px",
       messages: [{ role: "assistant", content: "hello", timestamp: 1 }],
     });
     const chat = container.querySelector<HTMLElement>(".chat");
 
-    expect(chat?.style.getPropertyValue("--chat-thread-max-width")).toBe("82%");
+    expect(chat?.style.getPropertyValue("--chat-thread-max-width")).toBe("960px");
     expect(chat?.style.getPropertyValue("--chat-message-max-width")).toBe("100%");
   });
 });

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -1925,7 +1925,7 @@ describe("config view", () => {
       "Using default: Claw",
       "Using default: 100%",
       "Using default: Enabled",
-      "Using default: 48rem",
+      "Using default: min(1280px, 100%)",
       "Using default: Enter",
       "Using default: OpenClaw viewer",
       "Using default: Disabled",

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -54,7 +54,7 @@ function renderAppearance(props: ConfigProps) {
         data-settings-chat-message-width
         type="text"
         spellcheck="false"
-        placeholder="48rem"
+        placeholder="min(1280px, 100%)"
         .value=${props.chatMessageMaxWidth ?? ""}
         @change=${(event: Event) => {
           const input = event.currentTarget as HTMLInputElement;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -11,7 +11,6 @@ openclaw-chat-page {
 }
 
 .chat {
-  --chat-thread-max-width: 48rem;
   /* Keep overlays clear of the edge-hugging scrollbar and add room on wide screens. */
   --chat-thread-gutter: 18px;
   /* Composer box insets. The docked progress card derives its own edge from
@@ -673,14 +672,14 @@ openclaw-chat-page {
      .chat-thread's horizontal padding (moved off the scroll container so
      overlay scrollbars sit flush at the pane edge). */
   width: calc(100% - 2 * var(--chat-thread-gutter) - 2 * var(--chat-thread-side-inset));
-  max-width: var(--chat-thread-max-width);
+  max-width: var(--chat-thread-max-width, 48rem);
   margin-inline: auto;
 }
 
 .chat-inline-approval {
   flex: 0 0 auto;
   width: calc(100% - 2 * var(--chat-thread-gutter) - 2 * var(--chat-thread-side-inset));
-  max-width: var(--chat-thread-max-width);
+  max-width: var(--chat-thread-max-width, 48rem);
   margin: 8px auto;
 }
 

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -11,6 +11,8 @@ openclaw-chat-page {
 }
 
 .chat {
+  --chat-thread-max-width: min(1280px, 100%);
+  --chat-message-max-width: 100%;
   /* Keep overlays clear of the edge-hugging scrollbar and add room on wide screens. */
   --chat-thread-gutter: 18px;
   /* Composer box insets. The docked progress card derives its own edge from
@@ -672,14 +674,14 @@ openclaw-chat-page {
      .chat-thread's horizontal padding (moved off the scroll container so
      overlay scrollbars sit flush at the pane edge). */
   width: calc(100% - 2 * var(--chat-thread-gutter) - 2 * var(--chat-thread-side-inset));
-  max-width: var(--chat-thread-max-width, 48rem);
+  max-width: var(--chat-thread-max-width);
   margin-inline: auto;
 }
 
 .chat-inline-approval {
   flex: 0 0 auto;
   width: calc(100% - 2 * var(--chat-thread-gutter) - 2 * var(--chat-thread-side-inset));
-  max-width: var(--chat-thread-max-width, 48rem);
+  max-width: var(--chat-thread-max-width);
   margin: 8px auto;
 }
 


### PR DESCRIPTION
## Problem

Normal Control UI Chat defaults to a `48rem` transcript frame, which remains
visibly narrow on wide displays.

This reproduces on a real OpenClaw 2026.9.1 installation: the shipped CSS
contains `--chat-thread-max-width: 48rem`, and normal Chat remains narrow.
Changing the chat thread/message width to a bounded 1280px value immediately
widens the UI as intended.

## Change

Set Normal Chat's unset/default frame to:

~~css
--chat-thread-max-width: min(1280px, 100%);
--chat-message-max-width: 100%;
~~

The transcript, composer, tool lanes, activity rows, and adjacent rows now
share the same centered bounded frame. Explicit Message width preferences still
write directly to `.chat` and override the default.

Settings copy, the input placeholder, and Control UI documentation now describe
the new default.

## Scope

Normal Control UI Chat only.

Custodian is unchanged and does not consume this browser-local Chat preference.

Users who explicitly saved `48rem` retain that explicit override.

## Validation

- `git diff --check`
- formatting check for modified files
- `pnpm lint:ui:styles`
- `pnpm test ui/src/pages/chat/chat-view.test.ts`
- `pnpm test ui/src/pages/chat/chat-responsive.browser.test.ts`
- Chromium config-view test: 61 passing
- `pnpm ui:build`

The browser layout test verifies the default 1280px desktop frame and a direct
960px Message width override across transcript, composer, tool, activity, and
adjacent rows.
