### PR TITLE
improve(ui): reduce session-switch sidebar work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI session switching:** reuse prepared sidebar rows for PR badges and prepare menu data only when opened, reducing work when navigating large session lists.
 - **Update readiness:** select declared health-check owners before loading plugin APIs, preventing unrelated optional Doctor checks from interrupting upgrades while retaining mandatory readiness failures.
 
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI session switching:** reuse prepared sidebar rows for PR badges and prepare menu data only when opened, reducing work when navigating large session lists.
 - **Update readiness:** select declared health-check owners before loading plugin APIs, preventing unrelated optional Doctor checks from interrupting upgrades while retaining mandatory readiness failures.
 
 - **Apple chat:** make queued messages immediately retryable after session-settings failures, while keeping retries bound to the exact failed attempt.

--- a/src/gateway/server-methods/chat-origin-routing.ts
+++ b/src/gateway/server-methods/chat-origin-routing.ts
@@ -3,7 +3,7 @@ import {
   GATEWAY_CLIENT_NAMES,
 } from "../../../packages/gateway-protocol/src/client-info.js";
 import type { ErrorShape } from "../../../packages/gateway-protocol/src/index.js";
-import { CHAT_SEND_SESSION_KEY_MAX_LENGTH } from "../../../packages/gateway-protocol/src/schema.js";
+import { CHAT_SEND_SESSION_KEY_MAX_LENGTH } from "../../../packages/gateway-protocol/src/schema/primitives.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";

--- a/src/gateway/server-methods/commands-list-result.ts
+++ b/src/gateway/server-methods/commands-list-result.ts
@@ -17,7 +17,7 @@ import {
   COMMAND_DESCRIPTION_MAX_LENGTH,
   COMMAND_LIST_MAX_ITEMS,
   COMMAND_NAME_MAX_LENGTH,
-} from "../../../packages/gateway-protocol/src/schema.js";
+} from "../../../packages/gateway-protocol/src/schema/commands.js";
 import { listChatCommandsForConfig } from "../../auto-reply/commands-registry.js";
 import type {
   ChatCommandDefinition,

--- a/src/gateway/server-methods/system.ts
+++ b/src/gateway/server-methods/system.ts
@@ -15,7 +15,7 @@ import {
 import {
   SYSTEM_PRESENCE_CLEAR_LAST_INPUT_TAG,
   validateSystemEventParams,
-} from "../../../packages/gateway-protocol/src/schema.js";
+} from "../../../packages/gateway-protocol/src/schema/system-event.js";
 import { listAgentIds } from "../../agents/agent-scope.js";
 import {
   readUtilityModelSetting,

--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -173,7 +173,7 @@ type AgentMenuAgent = {
 };
 
 type SidebarAgentMenuParams = {
-  position: { x: number; top: number } | null;
+  position: { x: number; top: number };
   basePath: string;
   activeId: string;
   activeName: string;
@@ -194,7 +194,7 @@ type SidebarAgentMenuParams = {
 };
 
 type SidebarIdentityMenuParams = {
-  position: { x: number; bottom: number; width: number } | null;
+  position: { x: number; bottom: number; width: number };
   canPairDevice: boolean;
   basePath: string;
   gatewayVersion: string | null;
@@ -297,9 +297,6 @@ function renderIdentityMenuHelpSubmenu() {
 
 export function renderSidebarAgentMenu(params: SidebarAgentMenuParams) {
   const position = params.position;
-  if (!position) {
-    return nothing;
-  }
   const { activeId, activeName, agents } = params;
   const rows = sidebarAgentMenuRows(params);
   return html`
@@ -417,9 +414,6 @@ export function renderSidebarAgentMenu(params: SidebarAgentMenuParams) {
 
 export function renderSidebarIdentityMenu(params: SidebarIdentityMenuParams) {
   const position = params.position;
-  if (!position) {
-    return nothing;
-  }
   const profileName = params.profileViewer?.name ?? params.profileViewer?.email;
   const profileEmail =
     params.profileViewer?.email && params.profileViewer.email !== profileName

--- a/ui/src/components/app-sidebar-nav-menus.ts
+++ b/ui/src/components/app-sidebar-nav-menus.ts
@@ -125,7 +125,7 @@ type SidebarMenuNavigationHandlers = {
 };
 
 type SidebarMoreMenuParams = SidebarMenuNavigationHandlers & {
-  position: SidebarMenuPosition | null;
+  position: SidebarMenuPosition;
   basePath: string;
   activeRouteId: NavigationRouteId | undefined;
   sidebarEntries: readonly string[];
@@ -165,9 +165,6 @@ function renderMoreMenuRoute(params: SidebarMoreMenuParams, routeId: SidebarNavR
 
 export function renderSidebarMoreMenu(params: SidebarMoreMenuParams) {
   const position = params.position;
-  if (!position) {
-    return nothing;
-  }
   const moreRoutes = sidebarMoreRoutes(params.sidebarEntries).filter((routeId) =>
     params.isRouteEnabled(routeId),
   );
@@ -216,7 +213,7 @@ export function renderSidebarMoreMenu(params: SidebarMoreMenuParams) {
 }
 
 type SidebarCustomizeMenuParams = {
-  position: SidebarMenuPosition | null;
+  position: SidebarMenuPosition;
   sidebarEntries: readonly string[];
   preferencesBrowserOnly: boolean;
   isRouteEnabled: (routeId: NavigationRouteId) => boolean;
@@ -231,9 +228,6 @@ type SidebarCustomizeMenuParams = {
 
 export function renderSidebarCustomizeMenu(params: SidebarCustomizeMenuParams) {
   const position = params.position;
-  if (!position) {
-    return nothing;
-  }
   return html`
     <wa-dropdown
       class="sidebar-customize-menu sidebar-pin-editor-menu"

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -166,7 +166,7 @@ export function renderAppSidebarBrand(host: AppSidebarRenderHost) {
 
 /** Home: the first page. Opens the rolling main session on its saved face. */
 export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
-  const agentId = host.activeChipAgent().activeId;
+  const agentId = host.expandedAgentId();
   const mainKey = host.selectedAgentMainSessionKey(agentId);
   const mainRow = host.mainSessionRow(agentId);
   const attention = host.resolveHomeSessionAttention(mainKey, mainRow);

--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -100,7 +100,7 @@ function renderSidebarOwnerFilter(
 }
 
 export function renderSidebarSessionGroupMenu(params: {
-  menu: SidebarSessionGroupMenuState | null;
+  menu: SidebarSessionGroupMenuState;
   trigger: HTMLElement | null;
   connected: boolean;
   groupDefaultsUnavailable?: boolean;
@@ -109,9 +109,6 @@ export function renderSidebarSessionGroupMenu(params: {
   onClose: (restoreFocus: boolean) => void;
 }) {
   const menu = params.menu;
-  if (!menu) {
-    return nothing;
-  }
   return keyed(
     menu,
     html`
@@ -188,7 +185,7 @@ export function renderSidebarSessionGroupMenu(params: {
 }
 
 export function renderSidebarCatalogViewMenu(params: {
-  position: { x: number; y: number } | null;
+  position: { x: number; y: number };
   trigger: HTMLElement | null;
   grouping: CatalogProjectGrouping;
   owners: readonly SessionOwnerOption[];
@@ -201,9 +198,6 @@ export function renderSidebarCatalogViewMenu(params: {
   onClose: (restoreFocus: boolean) => void;
 }) {
   const position = params.position;
-  if (!position) {
-    return nothing;
-  }
   const groupingOptions = [
     { grouping: "project", label: t("chat.sidebar.catalogGroupByProject") },
     { grouping: "person", label: t("chat.sidebar.catalogGroupByPerson") },
@@ -260,7 +254,7 @@ export function renderSidebarCatalogViewMenu(params: {
 }
 
 export function renderSidebarSessionSortMenu(params: {
-  position: { x: number; y: number } | null;
+  position: { x: number; y: number };
   trigger: HTMLElement | null;
   grouping: SidebarSessionsGrouping;
   sortMode: SidebarSessionSortMode;
@@ -285,9 +279,6 @@ export function renderSidebarSessionSortMenu(params: {
   onClose: (restoreFocus: boolean) => void;
 }) {
   const position = params.position;
-  if (!position) {
-    return nothing;
-  }
   const groupingOptions = [
     { grouping: "category", label: t("sessionsView.groupByCategory") },
     { grouping: "project", label: t("chat.sidebar.catalogGroupByProject") },

--- a/ui/src/components/app-sidebar-session-pr-indicators.test.ts
+++ b/ui/src/components/app-sidebar-session-pr-indicators.test.ts
@@ -1,9 +1,15 @@
-import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { html, LitElement, type ReactiveController, type ReactiveControllerHost } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gateway/control-ui-contract.js";
+import {
+  CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT,
+  CONTROL_UI_SESSION_PULL_REQUESTS_MAX_KEYS,
+} from "../../../src/gateway/control-ui-contract.js";
 import type { GatewayBrowserClient, GatewayEventListener } from "../api/gateway.ts";
 import type { ApplicationGateway } from "../app/gateway.ts";
-import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
+import {
+  SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
+  sessionPullRequestsForGateway,
+} from "../lib/session-pull-requests.ts";
 import type { SessionCapability } from "../lib/sessions/index.ts";
 import { SessionPullRequestIndicatorsController } from "./app-sidebar-session-pr-indicators.ts";
 import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
@@ -20,6 +26,52 @@ class TestHost implements ReactiveControllerHost {
   removeController(controller: ReactiveController): void {
     this.controllers.splice(this.controllers.indexOf(controller), 1);
   }
+}
+
+type IndicatorOptions = ConstructorParameters<typeof SessionPullRequestIndicatorsController>[1];
+const LIFECYCLE_HOST_TAG = "test-session-pr-indicators";
+
+class LifecycleTestHost extends LitElement {
+  rows: readonly SidebarRecentSession[] = [];
+  readRows: IndicatorOptions["getRows"] = () => [];
+  controller!: SessionPullRequestIndicatorsController;
+
+  protected override willUpdate(): void {
+    // The sidebar prepares row summaries before controller hooks run.
+    this.rows = this.readRows();
+  }
+
+  protected override render() {
+    return this.rows.map(
+      (row) => html`<span data-session-key=${row.key}>
+        ${this.controller
+          .summary(row.key, row.worktreeId ?? "", row.pullRequest)
+          ?.numbers.join(",")}
+      </span>`,
+    );
+  }
+}
+
+if (!customElements.get(LIFECYCLE_HOST_TAG)) {
+  customElements.define(LIFECYCLE_HOST_TAG, LifecycleTestHost);
+}
+
+function mountLifecycleHost(
+  gateway: ApplicationGateway,
+  readRows: IndicatorOptions["getRows"],
+  getSessions: IndicatorOptions["getSessions"] = () => undefined,
+): LifecycleTestHost {
+  const host = document.createElement(LIFECYCLE_HOST_TAG) as LifecycleTestHost;
+  host.readRows = readRows;
+  host.controller = new SessionPullRequestIndicatorsController(host, {
+    getConnected: () => true,
+    getRows: () => host.rows,
+    getSelectedAgentId: () => "main",
+    getGateway: () => gateway,
+    getSessions,
+  });
+  document.body.append(host);
+  return host;
 }
 
 function createGatewayHarness() {
@@ -68,30 +120,28 @@ function createGatewayHarness() {
 }
 
 afterEach(() => {
+  document.querySelectorAll(LIFECYCLE_HOST_TAG).forEach((host) => host.remove());
   vi.useRealTimers();
 });
 
 describe("SessionPullRequestIndicatorsController", () => {
   it("does not invalidate the host when no rows are eligible", async () => {
     vi.useFakeTimers();
-    const host = new TestHost();
     const harness = createGatewayHarness();
     const getRows = vi.fn(() => []);
-    const controller = new SessionPullRequestIndicatorsController(host, {
-      getConnected: () => true,
-      getRows,
-      getSelectedAgentId: () => "main",
-      getGateway: () => harness.gateway,
-      getSessions: () => undefined,
-    });
+    const host = mountLifecycleHost(harness.gateway, getRows);
+    await host.updateComplete;
+    await vi.advanceTimersByTimeAsync(0);
+    getRows.mockClear();
+    const requestUpdate = vi.spyOn(host, "requestUpdate");
 
-    controller.hostConnected();
-    controller.hostUpdated();
-    controller.hostUpdated();
+    host.requestUpdate();
+    host.requestUpdate();
+    expect(await host.updateComplete).toBe(true);
     await vi.advanceTimersByTimeAsync(0);
 
     expect(getRows).toHaveBeenCalledOnce();
-    expect(host.requestUpdate).not.toHaveBeenCalled();
+    expect(requestUpdate).toHaveBeenCalledTimes(2);
   });
 
   it.each(["open", "draft", "merged", "closed"] as const)(
@@ -265,5 +315,126 @@ describe("SessionPullRequestIndicatorsController", () => {
 
     expect(controller.summary(row.key, row.worktreeId ?? "")).toBeUndefined();
     expect(setPullRequestSummary).toHaveBeenCalledExactlyOnceWith(row.key, undefined, epoch);
+  });
+});
+
+describe("SessionPullRequestIndicatorsController Lit lifecycle", () => {
+  it("synchronizes visible subscriptions by updateComplete without advancing timers", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const harness = createGatewayHarness();
+    const row = {
+      key: "agent:main:demo",
+      isChild: false,
+      worktreeId: "wt-demo",
+    } as SidebarRecentSession;
+    const host = mountLifecycleHost(harness.gateway, () => [row]);
+
+    await host.updateComplete;
+    await Promise.resolve();
+
+    expect(harness.request).toHaveBeenCalledExactlyOnceWith(
+      SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
+      { sessionKeys: [row.key] },
+    );
+  });
+
+  it("clears a rendered fallback after the visible snapshot leaves the bounded watch union", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const harness = createGatewayHarness();
+    const key = "agent:main:demo";
+    let fallback: SidebarRecentSession["pullRequest"] = { numbers: [7], state: "open" };
+    const epoch = {};
+    const setPullRequestSummary = vi.fn(
+      (_key: string, summary: SidebarRecentSession["pullRequest"]) => {
+        fallback = summary;
+      },
+    );
+    const host = mountLifecycleHost(
+      harness.gateway,
+      () => [
+        {
+          key,
+          isChild: false,
+          worktreeId: "wt-demo",
+          pullRequest: fallback,
+        } as SidebarRecentSession,
+      ],
+      () =>
+        ({
+          capturePullRequestEpoch: () => epoch,
+          setPullRequestSummary,
+        }) as unknown as SessionCapability,
+    );
+    await host.updateComplete;
+    await vi.advanceTimersByTimeAsync(0);
+    harness.emit({
+      sessions: {
+        [key]: {
+          pullRequests: [{ number: 7, state: "open" }],
+          rateLimited: false,
+          status: "ready",
+        },
+      },
+    });
+    await host.updateComplete;
+    expect(host.shadowRoot?.textContent?.trim()).toBe("7");
+
+    const store = sessionPullRequestsForGateway(harness.gateway);
+    const foregroundOwner = {};
+    try {
+      store.watch(
+        foregroundOwner,
+        Array.from(
+          { length: CONTROL_UI_SESSION_PULL_REQUESTS_MAX_KEYS },
+          (_, index) => `agent:main:foreground-${index}`,
+        ),
+        { foreground: true },
+      );
+      expect(store.get(key)).toBeUndefined();
+      host.requestUpdate();
+      await host.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      await host.updateComplete;
+
+      expect(setPullRequestSummary).toHaveBeenCalledExactlyOnceWith(key, undefined, epoch);
+      expect(fallback).toBeUndefined();
+      expect(host.shadowRoot?.textContent?.trim()).toBe("");
+    } finally {
+      store.unwatch(foregroundOwner);
+    }
+  });
+
+  it("does not restore a watch from an update pending at disconnect and resumes on reconnect", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const harness = createGatewayHarness();
+    const row = {
+      key: "agent:main:demo",
+      isChild: false,
+      worktreeId: "wt-demo",
+    } as SidebarRecentSession;
+    const host = mountLifecycleHost(harness.gateway, () => [row]);
+    await host.updateComplete;
+    await vi.advanceTimersByTimeAsync(0);
+    expect(harness.request).toHaveBeenLastCalledWith(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD, {
+      sessionKeys: [row.key],
+    });
+
+    host.requestUpdate();
+    host.remove();
+    await host.updateComplete;
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(harness.request).toHaveBeenLastCalledWith(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD, {
+      sessionKeys: [],
+    });
+
+    document.body.append(host);
+    host.requestUpdate();
+    await host.updateComplete;
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(harness.request).toHaveBeenLastCalledWith(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD, {
+      sessionKeys: [row.key],
+    });
   });
 });

--- a/ui/src/components/app-sidebar-session-pr-indicators.ts
+++ b/ui/src/components/app-sidebar-session-pr-indicators.ts
@@ -36,7 +36,6 @@ export class SessionPullRequestIndicatorsController implements ReactiveControlle
   private store: SessionPullRequestSnapshotStore | null = null;
   private stopStoreUpdates: (() => void) | null = null;
   private connected = false;
-  private refreshScheduled = false;
 
   constructor(
     private readonly host: ReactiveControllerHost,
@@ -50,7 +49,11 @@ export class SessionPullRequestIndicatorsController implements ReactiveControlle
   }
 
   hostUpdated(): void {
-    this.scheduleRefresh();
+    // Reuse the projection before the host releases it in updated(). Changes
+    // here can still schedule a follow-up render to clear stale PR summaries.
+    if (this.connected) {
+      this.refreshVisible();
+    }
   }
 
   hostDisconnected(): void {
@@ -67,19 +70,6 @@ export class SessionPullRequestIndicatorsController implements ReactiveControlle
     const entry = this.states.get(sessionKey);
     // A ready empty snapshot is authoritative; only seed a row before its first snapshot.
     return entry?.worktreeId === worktreeId ? entry.summary : initial;
-  }
-
-  private scheduleRefresh(): void {
-    if (this.refreshScheduled) {
-      return;
-    }
-    this.refreshScheduled = true;
-    globalThis.setTimeout(() => {
-      this.refreshScheduled = false;
-      if (this.connected) {
-        this.refreshVisible();
-      }
-    }, 0);
   }
 
   private releaseStore(): void {

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -193,13 +193,12 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
     this.sessionNavigationState = super.getSessionNavigationState();
     this.projectedSessionRows = super.selectedAgentSessionRows(this.sessionNavigationState);
     this.projectedSessionSections = super.zonedVisibleSections(this.projectedSessionRows);
-    const chip = this.activeChipAgent();
     // An open switcher tracks roster/reconnect updates; otherwise only hydrate
     // the active card and avoid background RPCs for every configured agent.
     const identityIds =
       this.sidebarMenus.agentMenuPosition === null
-        ? [chip.activeId]
-        : chip.agents.map((agent) => agent.id);
+        ? [this.expandedAgentId()]
+        : this.activeChipAgent().agents.map((agent) => agent.id);
     this.ensureAgentIdentities(identityIds);
   }
 

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -43,6 +43,9 @@ import type { SidebarMenusController } from "./sidebar-menus-controller.ts";
 export function renderSidebarCustomizeMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
   const position = controller.customizeMenuPosition;
+  if (!position) {
+    return nothing;
+  }
   const trigger = controller.customizeMenuTrigger;
   return renderSidebarCustomizeMenu({
     position,
@@ -89,6 +92,9 @@ export function renderSidebarCustomizeMenuForController(controller: SidebarMenus
 export function renderSidebarAgentMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
   const position = controller.agentMenuPosition;
+  if (!position) {
+    return nothing;
+  }
   const trigger = controller.agentMenuTrigger;
   const { activeId, agent, agents, identity, identities } = host.activeChipAgent();
   return renderSidebarAgentMenu({
@@ -121,6 +127,9 @@ export function renderSidebarAgentMenuForController(controller: SidebarMenusCont
 export function renderSidebarIdentityMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
   const position = controller.identityMenuPosition;
+  if (!position) {
+    return nothing;
+  }
   const trigger = controller.identityMenuTrigger;
   const selfUser = resolveCurrentSelfUser({
     snapshotUser: host.sessionDataContext?.gateway.snapshot.selfUser,
@@ -160,7 +169,7 @@ export function renderSidebarIdentityMenuForController(controller: SidebarMenusC
     profileViewer: selfUser ? { ...selfUser, watchedSessions: [] } : undefined,
     offline: host.offline,
     themeMode: host.themeMode,
-    triggerWidth: position?.width ?? 0,
+    triggerWidth: position.width,
     onTabAway: () => trigger?.focus(),
     onClose: (restoreFocus) => {
       if (controller.identityMenuPosition !== position) {
@@ -372,6 +381,9 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusCo
 export function renderSidebarSessionGroupMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
   const menu = controller.sessionGroupMenu;
+  if (!menu) {
+    return nothing;
+  }
   const groupDefaultsStatus = host.sessionDataContext?.sessions.groupsStatus() ?? "idle";
   const groupActionAccess = {
     "group-defaults": readSessionMethodAccess(host.sessionDataContext?.gateway.snapshot, {
@@ -442,6 +454,9 @@ export function renderSidebarSessionGroupMenuForController(controller: SidebarMe
 export function renderSidebarSessionSortMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
   const position = controller.sessionSortMenuPosition;
+  if (!position) {
+    return nothing;
+  }
   return renderSidebarSessionSortMenu({
     position,
     trigger: controller.sessionSortMenuTrigger,
@@ -501,6 +516,9 @@ export function renderSidebarSessionSortMenuForController(controller: SidebarMen
 export function renderSidebarCatalogViewMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
   const position = controller.catalogViewMenuPosition;
+  if (!position) {
+    return nothing;
+  }
   return renderSidebarCatalogViewMenu({
     position,
     trigger: controller.catalogViewMenuTrigger,
@@ -514,7 +532,7 @@ export function renderSidebarCatalogViewMenuForController(controller: SidebarMen
       controller.closeCatalogViewMenu({ restoreFocus: true });
     },
     onHide: () => {
-      if (!position || controller.catalogViewMenuPosition !== position) {
+      if (controller.catalogViewMenuPosition !== position) {
         return;
       }
       host.hideSessionCatalog(position.catalogId);
@@ -536,6 +554,9 @@ export function renderSidebarCatalogViewMenuForController(controller: SidebarMen
 export function renderSidebarMoreMenuForController(controller: SidebarMenusController) {
   const { host } = controller;
   const position = controller.moreMenuPosition;
+  if (!position) {
+    return nothing;
+  }
   const trigger = controller.moreMenuTrigger;
   return renderSidebarMoreMenu({
     position,


### PR DESCRIPTION
Related: #135021

## What Problem This Solves

Switching between retained Control UI sessions still repeats sidebar preparation, especially with large session lists. This follow-up reduces that work while preserving selection, scroll position, badges, and menu behavior.

## Why This Change Was Made

The pull-request indicator controller refreshed on a timer after the sidebar had released its render-time navigation and row projection. Refreshing in Lit's `hostUpdated` lifecycle reuses that prepared data and still allows a follow-up render when a watch-set change clears stale badges. Closed menus now return before preparing their input, and callers that only need the selected agent ID no longer build the full navigation model.

This removes the timer and redundant renderer guards without adding caches, settings, dependencies, or protocol changes. Production LOC: **+41/-52 (net -11)**. Tests: **+186/-15 (net +171)**.

## User Impact

Large session lists do less repeated work during navigation. The measured improvement is modest: the pooled 500-session median dropped by **2.70 ms (about 4.5%)**. The 50-session result was flat within run-to-run noise; this is not a claim of faster provider responses or network requests.

Release-note context: Control UI session switching reuses prepared sidebar rows for PR badges and prepares menu data only when opened.

The landing CI also exposed a current-main SDK declaration failure (`TS7056`). Three Gateway imports pulled the full protocol generator registry into SDK compilation. Those imports now take the same constants and validator directly from their existing owner modules, preserving their values and public types while removing the unnecessary dependency.

## Evidence

Three before/after browser timing runs, each with 32 retained switches per roster size (96 samples per variant and size). These use immutable production UI bundles, trusted browser clicks, and an isolated synthetic Mock Gateway. Each scenario also has six separate warmup switches. No retained samples were excluded.

| Session roster | Before median / p95 | After median / p95 |
| --- | --- | --- |
| 50 | 45.20 / 59.30 ms | 45.55 / 62.20 ms |
| 500 | 59.55 / 78.40 ms | 56.85 / 75.50 ms |

Separate diagnostic runs consistently reduced uncached navigation getters from **4 to 1** and uncached row projections from **1 to 0** per retained switch. These counters exclude the direct render preparation; they are not total projection counts. Retained switches kept one expected PR subscription update and did not add history/startup reloads. No page errors, native WebSocket attempts, or external HTTP attempts were observed.

- **429 focused UI tests passed**, covering sidebar behavior, navigation/projection, PR indicators, and PR state/store behavior.
- **3 real Chromium checks passed**: retained-session scroll/history and selection/sort behavior, plus identity/keyboard interaction.
- The new lifecycle readiness regression fails against the old timer-based controller before timers advance and passes against this change. Additional real-Lit coverage verifies watch-set eviction clears a rendered badge and disconnect/reconnect keeps subscriptions correct.
- Production builds and bundle budgets passed. All **20 selected `check:changed` gates** passed, including UI/core-test types, formatting, lint, and dependency checks.
- **Codex autoreview: scoped-clean at the default P0 threshold** on the final production and test diff; no accepted findings at that threshold.

The first [hosted CI run](https://github.com/openclaw/openclaw/actions/runs/33531165999) passed all three UI test shards, all 14 UI E2E shards, and the real-Gateway browser lane. Its lint and plugin compile failures had the same `ProtocolSchemas` declaration error. That error was reproduced on unchanged main `1e93009a9659ea88ca410c13ad11842afbd8770b`; the three import-path changes made all **123 plugin compiles pass**. The same **40 focused Gateway tests passed before and after** the import change (commands, chat origin routing, system info, and system events). Final-head hosted CI remains the landing gate.

The final-head run subsequently hit a 120-second subprocess timeout in the pre-existing Matrix account-state Doctor fixture. The unchanged isolated case passed locally in 22.95 seconds; the exact CI merge commit (`c5cbe711a19d2adfcc4c32d1250bde002e205864`) then passed all 35 files / 386 tests from that shard using the same CI runner and include inventory with two workers (59.06 seconds total; Doctor 24.64 seconds). The single targeted retry passed, and [final-head CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33533896477/attempts/2) completed successfully, including `openclaw/ci-gate`. Assertions and time limits are unchanged.

Follow-up: investigate the Matrix Doctor process fixture's sensitivity to cold source-CLI startup (`extensions/matrix/doctor-contract-api.account-state.test.ts`). Its raw TypeScript launch disables the compile cache; moving this proof to the existing built-CLI test path merits a separate harness change. Cold compilation is a hypothesis, not a proven cause of this CI timeout.

Maintainer dependency verification for the ClawSweeper review: installed `lit@3.3.3`, `lit-element@4.2.2`, and `@lit/reactive-element@2.1.2` were inspected directly. In the latter's `development/reactive-element.js`, `performUpdate` calls `willUpdate` and controller `hostUpdate` before `update`; `_$didUpdate` calls controller `hostUpdated` before element `updated`. The completed update clears `isUpdatePending` first, allowing the corrective follow-up render. This source inspection and the real-Lit regressions cover the review's dependency-source gap.

The browser proof uses a mocked Gateway, not an authenticated live Gateway/provider. The live Gateway browser route was unavailable in this environment. No external API behavior changes here. Timing is noisy, and a separate latency benefit from the closed-menu cleanup was not established.

The synthetic before/after captures are visually identical, as expected:

| Before | After |
| --- | --- |
| ![Before: retained session B selected in a 500-session synthetic roster](https://github.com/user-attachments/assets/6114d045-0e93-4fec-8e1b-311d5568f4d2) | ![After: retained session B selected in a 500-session synthetic roster](https://github.com/user-attachments/assets/538130c5-b769-4bdb-9fbf-8271a9da9b7f) |
