### PR TITLE
refactor(gateway): share idempotency key normalization

### DIFF
--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -3,6 +3,8 @@
 import { isDeepStrictEqual } from "node:util";
 import { expectDefined } from "@openclaw/normalization-core";
 import { asPositiveSafeInteger } from "@openclaw/normalization-core/number-coercion";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
 import type { SessionEntry } from "../config/sessions.js";
 import {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
@@ -77,14 +79,6 @@ type SessionHistoryStateSnapshot = SessionHistoryRawSnapshot & {
   limit?: number;
   cursor?: string;
 };
-
-function readMessageIdempotencyKey(message: unknown): string | undefined {
-  if (!message || typeof message !== "object" || Array.isArray(message)) {
-    return undefined;
-  }
-  const value = (message as Record<string, unknown>).idempotencyKey;
-  return typeof value === "string" && value.trim() ? value : undefined;
-}
 
 /** Owns both complete history snapshots and bounded visible-message pages. */
 export async function readSessionHistoryRawSnapshotAsync(
@@ -325,7 +319,7 @@ export class SessionHistorySseState {
     } else {
       this.rawTranscriptSeq += 1;
     }
-    const idempotencyKey = readMessageIdempotencyKey(update.message);
+    const idempotencyKey = readNonBlankString(asOptionalRecord(update.message)?.idempotencyKey);
     const nextMessage = attachOpenClawTranscriptMeta(update.message, {
       ...(typeof update.messageId === "string" ? { id: update.messageId } : {}),
       ...(idempotencyKey ? { idempotencyKey } : {}),

--- a/src/gateway/session-transcript-message.ts
+++ b/src/gateway/session-transcript-message.ts
@@ -1,4 +1,5 @@
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
 import type { TranscriptDisplayPosition } from "../chat/transcript-display-position.js";
 import {
   createCurrentUserProfileMessageProjector,
@@ -36,14 +37,6 @@ export function attachOpenClawTranscriptMeta(
   };
 }
 
-function readTranscriptMessageIdempotencyKey(message: unknown): string | undefined {
-  if (!message || typeof message !== "object" || Array.isArray(message)) {
-    return undefined;
-  }
-  const value = (message as Record<string, unknown>).idempotencyKey;
-  return typeof value === "string" && value.trim() ? value : undefined;
-}
-
 function readTranscriptMessageSenderIsOwner(message: unknown): boolean | undefined {
   const openclaw = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
   const value = openclaw?.senderIsOwner;
@@ -63,7 +56,7 @@ export function projectSessionMessagePayload(params: {
   sessionKey: string;
   sessionSnapshot?: Record<string, unknown>;
 }): { payload?: Record<string, unknown>; projectionState: SessionMessageProjectionState } {
-  const idempotencyKey = readTranscriptMessageIdempotencyKey(params.message);
+  const idempotencyKey = readNonBlankString(asOptionalRecord(params.message)?.idempotencyKey);
   const senderIsOwner = readTranscriptMessageSenderIsOwner(params.message);
   const rawMessage = attachOpenClawTranscriptMeta(params.message, {
     // Placement comes from the selected reader snapshot, never persisted/imported metadata.
@@ -125,7 +118,7 @@ export function projectTranscriptEntryMessage(
         : typeof record.timestamp === "number"
           ? record.timestamp
           : Number.NaN;
-    const idempotencyKey = readTranscriptMessageIdempotencyKey(record.message);
+    const idempotencyKey = readNonBlankString(asOptionalRecord(record.message)?.idempotencyKey);
     return attachOpenClawTranscriptMeta(record.message, {
       ...(typeof record.id === "string" ? { id: record.id } : {}),
       ...(idempotencyKey ? { idempotencyKey } : {}),


### PR DESCRIPTION
## What Problem This Solves

Gateway session projections had two local copies of the same idempotency-key reader. Keeping whitespace-preserving nonblank-string policy in multiple owners creates drift risk across SSE history, `session.message`, and stored transcript projection.

## Why This Change Was Made

The normalization core already owns the exact required coercion semantics. This change uses `asOptionalRecord` plus `readNonBlankString` at the three projection call sites and removes both local readers.

Architectural owner: `@openclaw/normalization-core`.

Removed paths:

- `readMessageIdempotencyKey`
- `readTranscriptMessageIdempotencyKey`

The intentionally trimming SQLite projection in `src/gateway/session-transcript-readers.ts` is unchanged. No SDK/public seam, config, protocol, SQLite schema, or material store behavior changes.

## User Impact

No user-visible behavior change. Nonblank idempotency keys continue to preserve their original bytes across all three projections, while blank and non-string values remain absent.

Production LOC: +6/-19 (net -13) | Tests: +0/-0

## Evidence

- Pre- and post-change focused validation: 93 tests passed (10 normalization-core tests and 83 Gateway tests across session history, transcript projection/readers, and session events).
- Direct probe preserved `"  exact-key  "` byte-for-byte across SSE history, `session.message`, and stored transcript projection.
- Semantic parity probe passed for primitives, arrays, blank strings, inherited fields, accessors, and a throwing proxy.
- `pnpm tsgo:core`, formatting, targeted oxlint, coercion-helper guard, both import-cycle guards, deadcode scans, plugin boundary, database-first, native schema, dependency, deprecation, wrapper-shadowing, and related changed-file guards passed.
- Exact autoreview: scoped clean, no accepted/actionable findings, confidence 0.98.
- `pnpm build` completed compilation and failed only in runtime postbuild because the shared checkout's stale `@openclaw/ai/diagnostics` artifact lacks `hasRetryableConnectionErrorCode`.
- `pnpm tsgo:core:test` reached typechecking and was blocked by the shared checkout missing the `mermaid` dependency. Per worktree policy, no install or shared dependency mutation was performed.
- `pnpm check:changed` passed conflict-marker and max-lines checks, then stopped because deleting the two local type assertions requires shrinking `config/assertion-safety-baseline.txt` from 3 to 2 and 4 to 3. That third-file baseline edit is intentionally omitted to preserve the explicitly approved two-file scope.
- Worktree creation itself completed, but the task-owned `gwt new` wrapper hung in its post-create `tt sync` hook. The exact wrapper was stopped after the clean worktree, base SHA, and `node_modules` symlink were verified.

Required Codex source inspection completed at:

- `../codex/codex-rs/cli/src/main.rs:220-245`
- `../codex/codex-rs/cli/src/main.rs:2840-2870`

Those ranges cover unrelated CLI debug/completion handling and impose no contract on this projection refactor.
