### PR TITLE
fix(gateway): show actual session-observer failure causes instead of empty error objects

### DIFF
--- a/src/gateway/session-observer.logging.test.ts
+++ b/src/gateway/session-observer.logging.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { setLoggerOverride } from "../logging/logger.js";
+import { loggingState } from "../logging/state.js";
+import {
+  createHarness,
+  event,
+  persistedLiveDigest,
+  startAndAddToolNotes,
+} from "./session-observer.test-utils.js";
+
+const cases = [
+  ["persistence", "session observer digest persistence failed"],
+  ["terminal", "session observer terminal digest synthesis failed"],
+  ["model", "session observer disabled after consecutive failures"],
+] as const;
+
+describe("session observer JSON diagnostics", () => {
+  it.each(cases)("preserves the cause of a %s failure", async (kind, message) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const previousConsole = loggingState.rawConsole;
+    const previousOverride = loggingState.overrideSettings;
+    const lines: string[] = [];
+    const capture = (line: unknown) => lines.push(String(line));
+    const cause = new Error(`${kind} failed`);
+    const harness = createHarness({
+      subscribe: kind !== "terminal",
+      completeModel: vi.fn(async () => {
+        throw cause;
+      }),
+      persistDigest: vi.fn(async () => {
+        throw cause;
+      }),
+      ...(kind === "terminal"
+        ? {
+            readSession: vi.fn(() => ({
+              sessionId: "session-id",
+              updatedAt: 0,
+              observerDigest: persistedLiveDigest(),
+            })),
+          }
+        : {}),
+    });
+    try {
+      setLoggerOverride({ level: "silent", consoleLevel: "warn", consoleStyle: "json" });
+      loggingState.rawConsole = { log: capture, info: capture, warn: capture, error: capture };
+      if (kind === "terminal") {
+        harness.observer.handleEvent(event({ stream: "lifecycle", data: { phase: "end" } }));
+      } else if (kind === "persistence") {
+        harness.observer.handleEvent(event({ stream: "lifecycle", data: { phase: "start" } }));
+        harness.observer.handleEvent(
+          event({
+            stream: "item",
+            data: { kind: "preamble", phase: "update", progressText: "Inspecting the output" },
+          }),
+        );
+      } else {
+        startAndAddToolNotes(harness.observer);
+      }
+      await vi.advanceTimersByTimeAsync(kind === "model" ? 24_000 : 0);
+      const diagnostic = lines
+        .map((line) => JSON.parse(line))
+        .find((line) => line.message === message);
+      expect(diagnostic).toMatchObject({
+        level: "warn",
+        subsystem: "gateway/session-observer",
+        runId: "run-1",
+        error: `${kind} failed`,
+      });
+    } finally {
+      harness.observer.dispose();
+      loggingState.rawConsole = previousConsole;
+      setLoggerOverride(previousOverride as Parameters<typeof setLoggerOverride>[0]);
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/gateway/session-observer.test.ts
+++ b/src/gateway/session-observer.test.ts
@@ -1,18 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-
-const observerLoggerMocks = vi.hoisted(() => ({
-  debug: vi.fn(),
-  info: vi.fn(),
-  warn: vi.fn(),
-  error: vi.fn(),
-}));
-
-vi.mock("../logging/subsystem.js", () => ({
-  createSubsystemLogger: () => observerLoggerMocks,
-}));
-
 import {
   createHarness,
   declareObserverVisibility,
@@ -27,9 +15,6 @@ import {
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
-  for (const loggerMock of Object.values(observerLoggerMocks)) {
-    loggerMock.mockClear();
-  }
   resetSessionObserverEventSequence();
 });
 
@@ -634,33 +619,6 @@ describe("session observer", () => {
     expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
       headline: "Continuing without model",
     });
-    harness.observer.dispose();
-  });
-
-  it("logs the underlying error message when disabling after consecutive failures", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    const completeModel = vi.fn(async () => {
-      throw new Error("model unavailable");
-    });
-    const harness = createHarness({ completeModel });
-    startAndAddToolNotes(harness.observer);
-
-    await vi.advanceTimersByTimeAsync(24_000);
-    await flushObserver();
-    expect(completeModel).toHaveBeenCalledTimes(2);
-
-    const disabledWarn = observerLoggerMocks.warn.mock.calls.find(
-      (call) => call[0] === "session observer disabled after consecutive failures",
-    );
-    expect(disabledWarn).toBeDefined();
-    expect(disabledWarn?.[1]).toMatchObject({
-      sessionKey: "agent:main:session-1",
-      runId: "run-1",
-    });
-    // A raw Error serializes as {} in the JSON console envelope because Error's
-    // own properties are non-enumerable; the warn must carry the message.
-    expect(disabledWarn?.[1]?.error).toBe("model unavailable");
     harness.observer.dispose();
   });
 

--- a/src/gateway/session-observer.test.ts
+++ b/src/gateway/session-observer.test.ts
@@ -1,6 +1,18 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+const observerLoggerMocks = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => observerLoggerMocks,
+}));
+
 import {
   createHarness,
   declareObserverVisibility,
@@ -15,6 +27,9 @@ import {
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
+  for (const loggerMock of Object.values(observerLoggerMocks)) {
+    loggerMock.mockClear();
+  }
   resetSessionObserverEventSequence();
 });
 
@@ -619,6 +634,33 @@ describe("session observer", () => {
     expect(harness.broadcastToConnIds.mock.calls.at(-1)?.[1]).toMatchObject({
       headline: "Continuing without model",
     });
+    harness.observer.dispose();
+  });
+
+  it("logs the underlying error message when disabling after consecutive failures", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const completeModel = vi.fn(async () => {
+      throw new Error("model unavailable");
+    });
+    const harness = createHarness({ completeModel });
+    startAndAddToolNotes(harness.observer);
+
+    await vi.advanceTimersByTimeAsync(24_000);
+    await flushObserver();
+    expect(completeModel).toHaveBeenCalledTimes(2);
+
+    const disabledWarn = observerLoggerMocks.warn.mock.calls.find(
+      (call) => call[0] === "session observer disabled after consecutive failures",
+    );
+    expect(disabledWarn).toBeDefined();
+    expect(disabledWarn?.[1]).toMatchObject({
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+    });
+    // A raw Error serializes as {} in the JSON console envelope because Error's
+    // own properties are non-enumerable; the warn must carry the message.
+    expect(disabledWarn?.[1]?.error).toBe("model unavailable");
     harness.observer.dispose();
   });
 

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -117,15 +117,13 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       // An unpersistable session must not re-bill the utility model every cycle.
       disableModelForRun(state);
     },
-    onError: (state, error) => {
-      // Native Error properties are non-enumerable; a raw Error serializes as {}
-      // in the JSON console envelope, hiding the actual failure cause.
+    // JSON logging drops Error's non-enumerable fields; format before serializing.
+    onError: (state, error) =>
       observerLog.warn("session observer digest persistence failed", {
         sessionKey: state.sessionKey,
         runId: state.runId,
         error: formatErrorMessage(error),
-      });
-    },
+      }),
   });
   const preamblePublisher = createSessionObserverPreamblePublisher({
     now,
@@ -173,8 +171,6 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
         broadcastDigest(digest, audience.recipients(digest.sessionKey, agentId), agentId);
       }
     } catch (error) {
-      // Native Error properties are non-enumerable; a raw Error serializes as {}
-      // in the JSON console envelope, hiding the actual failure cause.
       observerLog.warn("session observer terminal digest synthesis failed", {
         runId,
         error: formatErrorMessage(error),
@@ -421,8 +417,6 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
           observerLog.warn("session observer disabled after consecutive failures", {
             sessionKey: state.sessionKey,
             runId: state.runId,
-            // Native Error properties are non-enumerable; a raw Error serializes as
-            // {} in the JSON console envelope, hiding the actual failure cause.
             error: formatErrorMessage(error),
           });
           if (final || state.finalPending || state.terminalHealth) {

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -12,6 +12,7 @@ import {
 } from "../agents/session-activity-notes.js";
 import { resolveUtilityModelRefForAgent } from "../agents/utility-model.js";
 import { getAgentRunContext } from "../infra/agent-run-registry.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   createSessionObserverAudience,
@@ -90,6 +91,17 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     getConfig: deps.getConfig,
   });
   type ObservedAudience = ReturnType<typeof audience.classify>;
+  const broadcastDigest = (
+    digest: SessionObserverDigest,
+    connIds: ReadonlySet<string>,
+    agentId: string,
+  ) =>
+    deps.broadcastToConnIds(
+      "session.observer",
+      digest,
+      connIds,
+      audience.deliveryOptions(digest.sessionKey, agentId),
+    );
   // Narrow run-identity guard shared by persist paths: a digest may still land
   // while its session is unwatched, but never after a newer run replaces it.
   const runStillCurrent = (runId: string, sessionKey: string, agentId: string) => () =>
@@ -106,10 +118,12 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       disableModelForRun(state);
     },
     onError: (state, error) => {
+      // Native Error properties are non-enumerable; a raw Error serializes as {}
+      // in the JSON console envelope, hiding the actual failure cause.
       observerLog.warn("session observer digest persistence failed", {
         sessionKey: state.sessionKey,
         runId: state.runId,
-        error,
+        error: formatErrorMessage(error),
       });
     },
   });
@@ -119,12 +133,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     clearTimeoutFn,
     isCurrent: (state) => audienceLifecycle.stateIsCurrent(state),
     publish: (state, digest) => {
-      deps.broadcastToConnIds(
-        "session.observer",
-        digest,
-        audience.recipients(state.sessionKey, state.agentId),
-        audience.deliveryOptions(state.sessionKey, state.agentId),
-      );
+      broadcastDigest(digest, audience.recipients(state.sessionKey, state.agentId), state.agentId);
       void persistAcceptedDigest(state, digest, false, "preamble");
     },
   });
@@ -161,15 +170,15 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       if (digest && stillCurrent()) {
         // Live subscribers already saw the in-progress digest over this event;
         // the synthesized terminal correction must reach them the same way.
-        deps.broadcastToConnIds(
-          "session.observer",
-          digest,
-          audience.recipients(digest.sessionKey, agentId),
-          audience.deliveryOptions(digest.sessionKey, agentId),
-        );
+        broadcastDigest(digest, audience.recipients(digest.sessionKey, agentId), agentId);
       }
     } catch (error) {
-      observerLog.warn("session observer terminal digest synthesis failed", { runId, error });
+      // Native Error properties are non-enumerable; a raw Error serializes as {}
+      // in the JSON console envelope, hiding the actual failure cause.
+      observerLog.warn("session observer terminal digest synthesis failed", {
+        runId,
+        error: formatErrorMessage(error),
+      });
     }
   }
 
@@ -394,12 +403,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
         const recipients = criticalTransition
           ? audience.criticalRecipients(state.sessionKey, state.agentId)
           : audience.recipients(state.sessionKey, state.agentId);
-        deps.broadcastToConnIds(
-          "session.observer",
-          digest,
-          recipients,
-          audience.deliveryOptions(state.sessionKey, state.agentId),
-        );
+        broadcastDigest(digest, recipients, state.agentId);
         await persistAcceptedDigest(state, digest, final);
         if (final) {
           dormantRuns.delete(state.runId);
@@ -417,7 +421,9 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
           observerLog.warn("session observer disabled after consecutive failures", {
             sessionKey: state.sessionKey,
             runId: state.runId,
-            error,
+            // Native Error properties are non-enumerable; a raw Error serializes as
+            // {} in the JSON console envelope, hiding the actual failure cause.
+            error: formatErrorMessage(error),
           });
           if (final || state.finalPending || state.terminalHealth) {
             retireTerminalState(state);


### PR DESCRIPTION
## What Problem This Solves

Session observer failures currently appear as error:{} in JSON logs because Error messages are not enumerable. Operators cannot see why digest persistence, terminal synthesis, or repeated model calls failed. This repair records the formatted cause in each warning.

## Why This Change Was Made

The observer owns these warnings. Reuse its existing error formatter so non-enumerable Error messages survive JSON serialization and sensitive text is redacted. Consolidate the three identical broadcast envelopes while preserving delivery and persistence order.

## User Impact

Operators can read the underlying persistence, terminal-synthesis, or model error instead of an empty object.

## Evidence

The production observer and actual JSON console logger reproduced error:{} for persistence, terminal synthesis and repeated model failures. After the fix, all three warnings retain their synthetic cause. Three regression cases failed on baseline, then all 34 observer tests passed. Core/gateway test types, scoped lint, format and diff checks passed. The restored source exactly matches both original tested hashes; a fresh complete P0 review is scoped-clean at 0.98.

Production: +24/−24, net +0. Tests: +77. No changelog change.

Real JSON envelopes cover the requested proof. This repairs diagnostics; the Slack delivery and reset behavior reported in #135305 remain unresolved.

Related #135305.

Observed synthetic proof:

```json
{"sessionKey":"agent:proof:observer-log-proof","runId":"persistence-proof","error":"synthetic persistence failure","time":"2026-09-01T12:01:27.911-07:00","level":"warn","subsystem":"gateway/session-observer","message":"session observer digest persistence failed"}
{"runId":"terminal-proof","error":"synthetic terminal failure","time":"2026-09-01T12:01:27.962-07:00","level":"warn","subsystem":"gateway/session-observer","message":"session observer terminal digest synthesis failed"}
{"sessionKey":"agent:proof:observer-log-proof","runId":"model-proof","error":"synthetic model failure","time":"2026-09-01T12:01:40.016-07:00","level":"warn","subsystem":"gateway/session-observer","message":"session observer disabled after consecutive failures"}
{"result":"PASS","surface":"actual session observer + JSON console logger","warningBranches":3}
```


Thanks @LiuwqGit for reporting and repairing the missing diagnostics.
