### PR TITLE
refactor(ai): centralize Responses web search detection

### DIFF
--- a/packages/ai/src/package.e2e.test.ts
+++ b/packages/ai/src/package.e2e.test.ts
@@ -138,6 +138,7 @@ const compatibility = {
       "readResponsesToolCallItemIdentity",
       "createResponsesToolCallTracker",
       "mapOpenAIStopReason",
+      "hasResponsesWebSearchTool",
       "projectOpenAITools",
       "reconcileOpenAIResponsesToolChoice",
       "reconcileOpenAICompletionsToolChoice",

--- a/packages/ai/src/providers/openai-tool-projection.test.ts
+++ b/packages/ai/src/providers/openai-tool-projection.test.ts
@@ -1,11 +1,41 @@
 import { describe, expect, it } from "vitest";
 import {
+  hasResponsesWebSearchTool,
   projectOpenAITools,
   reconcileOpenAICompletionsToolChoice,
   reconcileOpenAIResponsesToolChoice,
 } from "./openai-tool-projection.js";
 
 describe("OpenAI tool projection", () => {
+  it.each([
+    ["native tool", [{ type: "web_search" }], true],
+    ["function tool", [{ type: "function", name: "web_search" }], true],
+    ["nested function", [{ type: "file_search", function: { name: "web_search" } }], true],
+    ["preview tool", [{ type: "web_search_preview" }], false],
+    ["dated tool", [{ type: "web_search_2025_08_26" }], false],
+    ["direct name", [{ name: "web_search" }], false],
+    ["non-array inventory", { type: "web_search" }, false],
+    ["nested array", [[{ type: "web_search" }]], false],
+  ])("detects Responses web search for %s", (_label, tools, expected) => {
+    expect(hasResponsesWebSearchTool(tools)).toBe(expected);
+  });
+
+  it("preserves inherited reads and throwing getters", () => {
+    expect(hasResponsesWebSearchTool([Object.create({ type: "web_search" })])).toBe(true);
+    expect(hasResponsesWebSearchTool([Object.create({ function: { name: "web_search" } })])).toBe(
+      true,
+    );
+    expect(() =>
+      hasResponsesWebSearchTool([
+        {
+          get type(): never {
+            throw new Error("type exploded");
+          },
+        },
+      ]),
+    ).toThrow("type exploded");
+  });
+
   it("keeps healthy tools when sibling descriptors or schemas are unreadable", () => {
     const projection = projectOpenAITools([
       {

--- a/packages/ai/src/providers/openai-tool-projection.ts
+++ b/packages/ai/src/providers/openai-tool-projection.ts
@@ -51,6 +51,25 @@ function unreadableToolDiagnostic(toolIndex: number): OpenAIToolProjectionDiagno
   };
 }
 
+export function hasResponsesWebSearchTool(tools: unknown): boolean {
+  if (!Array.isArray(tools)) {
+    return false;
+  }
+  return tools.some((tool) => {
+    if (!isRecord(tool)) {
+      return false;
+    }
+    if (tool.type === "web_search") {
+      return true;
+    }
+    if (tool.type === "function" && tool.name === "web_search") {
+      return true;
+    }
+    const fn = tool.function;
+    return isRecord(fn) && fn.name === "web_search";
+  });
+}
+
 /** Snapshots direct/custom tool descriptors before OpenAI payload construction. */
 export function projectOpenAITools(tools: readonly OpenAIToolDescriptor[]): OpenAIToolProjection {
   let inputToolCount: number;

--- a/packages/ai/src/transports/openai-responses-params-internal.ts
+++ b/packages/ai/src/transports/openai-responses-params-internal.ts
@@ -1,5 +1,4 @@
 import type { Context, Model } from "@openclaw/llm-core";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type {
   FunctionTool,
   ResponseFormatTextConfig,
@@ -12,6 +11,7 @@ import {
   type OpenAIApiReasoningEffort,
 } from "../providers/openai-reasoning-effort.js";
 import {
+  hasResponsesWebSearchTool,
   projectOpenAITools,
   reconcileOpenAIResponsesToolChoice,
   type OpenAIToolProjection,
@@ -100,25 +100,6 @@ function resolveOpenAIReasoningEffort(
   return normalizeOpenAIReasoningEffort(
     options?.reasoningEffort ?? options?.reasoning ?? "high",
   ) as OpenAIApiReasoningEffort;
-}
-
-function hasResponsesWebSearchTool(tools: unknown): boolean {
-  if (!Array.isArray(tools)) {
-    return false;
-  }
-  return tools.some((tool) => {
-    if (!isRecord(tool)) {
-      return false;
-    }
-    if (tool.type === "web_search") {
-      return true;
-    }
-    if (tool.type === "function" && tool.name === "web_search") {
-      return true;
-    }
-    const fn = tool.function;
-    return isRecord(fn) && fn.name === "web_search";
-  });
 }
 
 function raiseMinimalReasoningForResponsesWebSearch(params: {

--- a/src/llm/providers/stream-wrappers/openai.ts
+++ b/src/llm/providers/stream-wrappers/openai.ts
@@ -1,5 +1,6 @@
 import {
   codeModeToolSurfaceObserver,
+  hasResponsesWebSearchTool,
   type CodeModeToolSurfaceObservation,
   resolveOpenAIReasoningEffortForModel,
   supportsOpenAIReasoningEffort,
@@ -211,25 +212,6 @@ function shouldStripOpenAICompletionMessageKeys(model: {
       ? (model.compat as { strictMessageKeys?: unknown })
       : undefined;
   return model.api === "openai-completions" && compat?.strictMessageKeys === true;
-}
-
-function hasResponsesWebSearchTool(tools: unknown): boolean {
-  if (!Array.isArray(tools)) {
-    return false;
-  }
-  return tools.some((tool) => {
-    if (!isRecord(tool)) {
-      return false;
-    }
-    if (tool.type === "web_search") {
-      return true;
-    }
-    if (tool.type === "function" && tool.name === "web_search") {
-      return true;
-    }
-    const fn = tool.function;
-    return isRecord(fn) && fn.name === "web_search";
-  });
 }
 
 function resolveOpenAIThinkingPayloadEffort(params: {


### PR DESCRIPTION
## What Problem This Solves

OpenAI Responses web-search detection was duplicated in the package transport and the core stream wrapper. The copies had to remain behavior-identical across native, function-shaped, nested, inherited, and malformed tool payloads.

## Why This Change Was Made

Moves the exact predicate into the existing private OpenAI tool-projection owner and reuses it through `@openclaw/ai/internal/openai`. Both local copies are deleted. This does not change adjacent Responses behavior, add a public transports export, or add a plugin SDK surface.

Preserved detection:

- `{ type: "web_search" }`
- `{ type: "function", name: "web_search" }`
- `{ function: { name: "web_search" } }` regardless of outer type
- non-array and array-element rejection
- inherited-property reads and throwing getters
- rejection of preview, dated, and unrelated direct-name shapes

## User Impact

No user-visible behavior change. The two OpenAI Responses paths now share one private contract instead of carrying duplicate policy.

## Evidence

- Pre-fix owner test: 9 new contract cases failed because the canonical export did not exist; the existing 17 projection tests passed.
- Post-fix focused tests: 113 passed across:
  - `packages/ai/src/providers/openai-tool-projection.test.ts`
  - `src/agents/openai-transport-stream.replay-and-tools.test.ts`
  - `src/llm/providers/stream-wrappers/openai.test.ts`
- Changed gates passed: formatting, core typecheck, assertion safety, coercion helpers, package/plugin boundaries, dead exports, oxlint, import cycles, auth/body-order guards, native schema, database-first storage, media helpers, and runtime sidecar loaders.
- Private source export probe passed for `@openclaw/ai/internal/openai`.
- Package E2E/build setup could not start because the shared checkout's stale `@openclaw/ai/diagnostics` artifact lacks `hasRetryableConnectionErrorCode`; failure occurred before Vitest and is unrelated to this diff. No install or dependency mutation was performed in the worktree.
- Autoreview: clean, 0.99, no accepted/actionable findings.
- Production LOC: +21/-39, net -18.
- Test LOC: +31/-0.
- Required Codex source inspected: `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; both ranges are unrelated CLI/completion behavior.

Overlap was rechecked immediately before publication on September 1, 2026. These open PRs touch adjacent hunks in `openai-responses-params-internal.ts` but do not edit `hasResponsesWebSearchTool`, `openai-tool-projection.ts`, or the private export:

- https://github.com/openclaw/openclaw/pull/134815
- https://github.com/openclaw/openclaw/pull/121442
- https://github.com/openclaw/openclaw/pull/130067
- https://github.com/openclaw/openclaw/pull/114204
- https://github.com/openclaw/openclaw/pull/128282
- https://github.com/openclaw/openclaw/pull/115869
