### PR TITLE
fix(link-understanding): parse complete markdown links

### DIFF
--- a/packages/markdown-core/src/link-spans.ts
+++ b/packages/markdown-core/src/link-spans.ts
@@ -1,0 +1,35 @@
+import { fromMarkdown } from "mdast-util-from-markdown";
+
+type PositionedMarkdownNode = {
+  type: string;
+  position?: { start?: { offset?: number }; end?: { offset?: number } };
+  children?: PositionedMarkdownNode[];
+};
+
+/** Returns parser-owned source spans for inline links, autolinks, and images. */
+export function findMarkdownLinkSourceSpans(markdown: string): Array<[number, number]> {
+  const spans: Array<[number, number]> = [];
+  const tree: PositionedMarkdownNode = fromMarkdown(markdown);
+  const pending = [tree];
+
+  while (pending.length > 0) {
+    const node = pending.pop();
+    if (!node) {
+      continue;
+    }
+    if (node.type === "link" || node.type === "image") {
+      const start = node.position?.start?.offset;
+      const end = node.position?.end?.offset;
+      if (start !== undefined && end !== undefined) {
+        spans.push([start, end]);
+      }
+      // The outer link owns nested image source, so overlapping spans are not useful to callers.
+      continue;
+    }
+    for (const child of node.children ?? []) {
+      pending.push(child);
+    }
+  }
+
+  return spans.toSorted((left, right) => left[0] - right[0]);
+}

--- a/src/gateway/link-understanding.product.test.ts
+++ b/src/gateway/link-understanding.product.test.ts
@@ -1,0 +1,220 @@
+import fs from "node:fs/promises";
+import { createServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
+import { clearSessionStoreCacheForTest } from "../config/sessions/store-writer-state.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
+import { buildMockOpenAiResponsesProvider } from "./test-openai-responses-model.js";
+
+vi.mock("../infra/net/fetch-guard.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/net/fetch-guard.js")>(
+    "../infra/net/fetch-guard.js",
+  );
+  return {
+    ...actual,
+    fetchWithSsrFGuard: async (params: Parameters<typeof actual.fetchWithSsrFGuard>[0]) =>
+      actual.fetchWithSsrFGuard({
+        ...params,
+        lookupFn: async () => [{ address: "127.0.0.1", family: 4 }],
+        policy: { ...params.policy, allowPrivateNetwork: true },
+      }),
+  };
+});
+
+const envKeys = [
+  "HOME",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_GATEWAY_TOKEN",
+  "OPENCLAW_TEST_FAST",
+  "OPENCLAW_SKIP_CHANNELS",
+  "OPENCLAW_SKIP_GMAIL_WATCHER",
+  "OPENCLAW_SKIP_CRON",
+  "OPENCLAW_SKIP_CANVAS_HOST",
+  "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+  "OPENCLAW_SKIP_PROVIDERS",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+] as const;
+
+async function listen(server: ReturnType<typeof createServer>): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("test server did not bind a loopback port");
+  }
+  return address.port;
+}
+
+async function close(server: ReturnType<typeof createServer> | undefined): Promise<void> {
+  if (!server?.listening) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    server.close(() => {
+      resolve();
+    });
+  });
+}
+
+describe("Gateway link understanding", () => {
+  let tempHome: string | undefined;
+
+  afterEach(async () => {
+    if (tempHome) {
+      await fs.rm(tempHome, { recursive: true, force: true });
+      tempHome = undefined;
+    }
+  });
+
+  it(
+    "fetches bare URLs but not titled markdown links sent through chat.send",
+    { timeout: 90_000 },
+    async () => {
+      const envSnapshot = captureEnv([...envKeys]);
+      const providerBodies: string[] = [];
+      const linkRequests: string[] = [];
+      let providerServer: ReturnType<typeof createServer> | undefined;
+      let linkServer: ReturnType<typeof createServer> | undefined;
+      let gateway: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+
+      try {
+        tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-link-gateway-"));
+        const stateDir = path.join(tempHome, ".openclaw");
+        const workspaceDir = path.join(tempHome, "workspace");
+        const configPath = path.join(stateDir, "openclaw.json");
+        const bundledPluginsDir = path.join(tempHome, "bundled-plugins");
+        await Promise.all([
+          fs.mkdir(workspaceDir, { recursive: true }),
+          fs.mkdir(bundledPluginsDir, { recursive: true }),
+          fs.mkdir(path.dirname(configPath), { recursive: true }),
+        ]);
+        for (const [key, value] of Object.entries({
+          HOME: tempHome,
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_GATEWAY_TOKEN: "link-understanding-gateway-token",
+          OPENCLAW_TEST_FAST: "0",
+          OPENCLAW_SKIP_CHANNELS: "1",
+          OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+          OPENCLAW_SKIP_CRON: "1",
+          OPENCLAW_SKIP_CANVAS_HOST: "1",
+          OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+          OPENCLAW_SKIP_PROVIDERS: "1",
+          OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        })) {
+          setTestEnvValue(key, value);
+        }
+
+        linkServer = createServer((request, response) => {
+          const requestPath = request.url ?? "";
+          linkRequests.push(requestPath);
+          response.end(requestPath === "/citation" ? "CITATION_PAGE" : "BARE_PAGE");
+        });
+        const linkPort = await listen(linkServer);
+
+        providerServer = createServer((request, response) => {
+          let body = "";
+          request.setEncoding("utf8");
+          request.on("data", (chunk) => {
+            body += String(chunk);
+          });
+          request.on("end", () => {
+            providerBodies.push(body);
+            response.writeHead(200, { "content-type": "text/event-stream" });
+            const message = {
+              type: "message",
+              id: "link-understanding-gateway-message",
+              role: "assistant",
+              status: "completed",
+              content: [{ type: "output_text", text: "LINK_GATEWAY_OK", annotations: [] }],
+            };
+            response.end(
+              [
+                {
+                  type: "response.output_item.added",
+                  output_index: 0,
+                  item: { ...message, status: "in_progress", content: [] },
+                },
+                { type: "response.output_item.done", output_index: 0, item: message },
+                { type: "response.completed", response: { status: "completed" } },
+              ]
+                .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+                .concat("data: [DONE]\n\n")
+                .join(""),
+            );
+          });
+        });
+        const providerPort = await listen(providerServer);
+        const provider = buildMockOpenAiResponsesProvider(`http://127.0.0.1:${providerPort}/v1`);
+        const cfg = {
+          agents: {
+            defaults: {
+              workspace: workspaceDir,
+              skipBootstrap: true,
+              model: { primary: provider.modelRef },
+              models: {
+                [provider.modelRef]: { params: { transport: "sse", openaiWsWarmup: false } },
+              },
+            },
+            entries: { main: { default: true } },
+          },
+          models: { mode: "replace", providers: { [provider.providerId]: provider.config } },
+          tools: {
+            links: {
+              enabled: true,
+              models: [{ type: "cli", command: "curl", args: ["{{LinkUrl}}"] }],
+            },
+          },
+          gateway: { auth: { mode: "token", token: "link-understanding-gateway-token" } },
+        };
+        gateway = await startGatewayWithClient({
+          cfg,
+          configPath,
+          token: "link-understanding-gateway-token",
+          clientDisplayName: "link-understanding-gateway",
+        });
+        const linkBase = `http://loopback.test:${linkPort}`;
+        const started = await gateway.client.request<{ runId?: string; status?: string }>(
+          "chat.send",
+          {
+            sessionKey: "agent:main:link-understanding-gateway",
+            message: `[citation](${linkBase}/citation "Citation") ${linkBase}/bare`,
+            deliver: false,
+            idempotencyKey: "link-understanding-gateway-run",
+          },
+        );
+        expect(started).toMatchObject({ status: "started", runId: expect.any(String) });
+        await expect(
+          gateway.client.request(
+            "agent.wait",
+            { runId: started.runId, timeoutMs: 30_000 },
+            { timeoutMs: 35_000 },
+          ),
+        ).resolves.toMatchObject({ status: "ok" });
+
+        expect(linkRequests).toEqual(["/bare"]);
+        expect(providerBodies.join("\n")).toContain("BARE_PAGE");
+        expect(providerBodies.join("\n")).not.toContain("CITATION_PAGE");
+      } finally {
+        if (gateway) {
+          await disconnectGatewayClient(gateway.client).catch(() => undefined);
+          await gateway.server.close().catch(() => undefined);
+        }
+        await close(providerServer);
+        await close(linkServer);
+        envSnapshot.restore();
+        clearRuntimeConfigSnapshot();
+        clearConfigCache();
+        clearSessionStoreCacheForTest();
+      }
+    },
+  );
+});

--- a/src/link-understanding/detect.test.ts
+++ b/src/link-understanding/detect.test.ts
@@ -40,6 +40,25 @@ describe("extractLinksFromMessage", () => {
     ).toStrictEqual(["https://bare.example"]);
   });
 
+  it("ignores markdown links whose title escapes its own delimiter", () => {
+    // A title may backslash-escape its own delimiter. Stopping at the escaped
+    // delimiter aborts the match and leaks the destination to BARE_LINK_RE.
+    expect(
+      extractLinksFromMessage(
+        '[doc](https://docs.example "A \\"quoted\\" title") https://bare.example',
+      ),
+    ).toStrictEqual(["https://bare.example"]);
+    expect(
+      extractLinksFromMessage("[doc](https://docs.example 'A \\'quoted\\' title')"),
+    ).toStrictEqual([]);
+    expect(
+      extractLinksFromMessage("[doc](https://docs.example (a \\(paren\\) title))"),
+    ).toStrictEqual([]);
+    // An unpaired backslash right before the closing delimiter still ends the title,
+    // so an input the old pattern stripped does not start leaking instead.
+    expect(extractLinksFromMessage('[doc](https://docs.example "t\\")')).toStrictEqual([]);
+  });
+
   it("blocks 127.0.0.1", () => {
     const links = extractLinksFromMessage("http://127.0.0.1/test https://ok.test");
     expect(links).toEqual(["https://ok.test"]);

--- a/src/link-understanding/detect.test.ts
+++ b/src/link-understanding/detect.test.ts
@@ -29,34 +29,28 @@ describe("extractLinksFromMessage", () => {
     expect(links).toStrictEqual([]);
   });
 
-  it("ignores markdown links that carry a title", () => {
-    // CommonMark allows a title after the destination. Without it the link text
-    // is display-only, so the URL must not become a fetchable bare link.
-    expect(
-      extractLinksFromMessage('[doc](https://docs.example "Docs") https://bare.example'),
-    ).toStrictEqual(["https://bare.example"]);
-    expect(
-      extractLinksFromMessage("[doc](https://docs.example 'Docs') https://bare.example"),
-    ).toStrictEqual(["https://bare.example"]);
+  it.each([
+    ["double-quoted title", '[doc](https://docs.example "Docs")'],
+    ["single-quoted title", "[doc](https://docs.example 'Docs')"],
+    ["parenthesized title", "[doc](https://docs.example (Docs))"],
+    ["escaped double quote", '[doc](https://docs.example "A \\"quoted\\" title")'],
+    ["escaped single quote", "[doc](https://docs.example 'A \\'quoted\\' title')"],
+    ["escaped parenthesis", "[doc](https://docs.example (a \\(paren\\) title))"],
+    ["title line break", '[doc](https://docs.example "line one\nline two")'],
+    ["angle destination", '[doc](<https://docs.example/a b> "Docs")'],
+    ["balanced destination parentheses", "[doc](https://docs.example/a_(b))"],
+    ["escaped destination parenthesis", String.raw`[doc](https://docs.example/a\)b)`],
+  ])("ignores markdown links with a %s", (_name, markdownLink) => {
+    expect(extractLinksFromMessage(`${markdownLink} https://bare.example`)).toStrictEqual([
+      "https://bare.example",
+    ]);
   });
 
-  it("ignores markdown links whose title escapes its own delimiter", () => {
-    // A title may backslash-escape its own delimiter. Stopping at the escaped
-    // delimiter aborts the match and leaks the destination to BARE_LINK_RE.
-    expect(
-      extractLinksFromMessage(
-        '[doc](https://docs.example "A \\"quoted\\" title") https://bare.example',
-      ),
-    ).toStrictEqual(["https://bare.example"]);
-    expect(
-      extractLinksFromMessage("[doc](https://docs.example 'A \\'quoted\\' title')"),
-    ).toStrictEqual([]);
-    expect(
-      extractLinksFromMessage("[doc](https://docs.example (a \\(paren\\) title))"),
-    ).toStrictEqual([]);
-    // An unpaired backslash right before the closing delimiter still ends the title,
-    // so an input the old pattern stripped does not start leaking instead.
-    expect(extractLinksFromMessage('[doc](https://docs.example "t\\")')).toStrictEqual([]);
+  it.each([
+    ["unterminated title", '[doc](https://docs.example "Docs)'],
+    ["escaped closing delimiter", '[doc](https://docs.example "t\\")'],
+  ])("does not strip a link with an %s", (_name, message) => {
+    expect(extractLinksFromMessage(message)).toStrictEqual(["https://docs.example"]);
   });
 
   it("blocks 127.0.0.1", () => {

--- a/src/link-understanding/detect.test.ts
+++ b/src/link-understanding/detect.test.ts
@@ -29,6 +29,17 @@ describe("extractLinksFromMessage", () => {
     expect(links).toStrictEqual([]);
   });
 
+  it("ignores markdown links that carry a title", () => {
+    // CommonMark allows a title after the destination. Without it the link text
+    // is display-only, so the URL must not become a fetchable bare link.
+    expect(
+      extractLinksFromMessage('[doc](https://docs.example "Docs") https://bare.example'),
+    ).toStrictEqual(["https://bare.example"]);
+    expect(
+      extractLinksFromMessage("[doc](https://docs.example 'Docs') https://bare.example"),
+    ).toStrictEqual(["https://bare.example"]);
+  });
+
   it("blocks 127.0.0.1", () => {
     const links = extractLinksFromMessage("http://127.0.0.1/test https://ok.test");
     expect(links).toEqual(["https://ok.test"]);

--- a/src/link-understanding/detect.ts
+++ b/src/link-understanding/detect.ts
@@ -6,7 +6,10 @@ import { DEFAULT_MAX_LINKS } from "./defaults.js";
 // The link-text portion allows "]" that is not the closing "](" boundary so
 // markdown links whose label contains brackets (e.g. "[my notes [v2]](...)")
 // are still stripped instead of leaking their URL to BARE_LINK_RE.
-const MARKDOWN_LINK_RE = /\[(?:[^\]]|](?!\())*]\((https?:\/\/\S+?)\)/gi;
+// The destination may be followed by a CommonMark title ("[doc](url \"Docs\")"),
+// which must be consumed too or the URL leaks out as a bare link.
+const MARKDOWN_LINK_RE =
+  /\[(?:[^\]]|](?!\())*]\((https?:\/\/\S+?)(?:\s+(?:"[^"]*"|'[^']*'|\([^()]*\)))?\s*\)/gi;
 const BARE_LINK_RE = /https?:\/\/\S+/gi;
 
 function stripMarkdownLinks(message: string): string {

--- a/src/link-understanding/detect.ts
+++ b/src/link-understanding/detect.ts
@@ -7,9 +7,13 @@ import { DEFAULT_MAX_LINKS } from "./defaults.js";
 // markdown links whose label contains brackets (e.g. "[my notes [v2]](...)")
 // are still stripped instead of leaking their URL to BARE_LINK_RE.
 // The destination may be followed by a CommonMark title ("[doc](url \"Docs\")"),
-// which must be consumed too or the URL leaks out as a bare link.
+// which must be consumed too or the URL leaks out as a bare link. A title may
+// contain backslash-escaped delimiters, so each alternative pairs a backslash with
+// the character after it ("s" lets that be a newline) and tolerates one unpaired
+// backslash before the closing delimiter. The escape and non-escape branches never
+// start on the same character, so the alternation stays linear on hostile input.
 const MARKDOWN_LINK_RE =
-  /\[(?:[^\]]|](?!\())*]\((https?:\/\/\S+?)(?:\s+(?:"[^"]*"|'[^']*'|\([^()]*\)))?\s*\)/gi;
+  /\[(?:[^\]]|](?!\())*]\((https?:\/\/\S+?)(?:\s+(?:"(?:[^"\\]|\\.)*\\?"|'(?:[^'\\]|\\.)*\\?'|\((?:[^()\\]|\\.)*\\?\)))?\s*\)/gis;
 const BARE_LINK_RE = /https?:\/\/\S+/gi;
 
 function stripMarkdownLinks(message: string): string {

--- a/src/link-understanding/detect.ts
+++ b/src/link-understanding/detect.ts
@@ -1,23 +1,19 @@
 // Link detection extracts unique safe bare HTTP(S) URLs from inbound text while filtering SSRF targets.
+import { findMarkdownLinkSourceSpans } from "../../packages/markdown-core/src/link-spans.js";
 import { isBlockedHostnameOrIp } from "../infra/net/ssrf.js";
 import { DEFAULT_MAX_LINKS } from "./defaults.js";
 
-// Remove markdown link syntax so only bare URLs are considered.
-// The link-text portion allows "]" that is not the closing "](" boundary so
-// markdown links whose label contains brackets (e.g. "[my notes [v2]](...)")
-// are still stripped instead of leaking their URL to BARE_LINK_RE.
-// The destination may be followed by a CommonMark title ("[doc](url \"Docs\")"),
-// which must be consumed too or the URL leaks out as a bare link. A title may
-// contain backslash-escaped delimiters, so each alternative pairs a backslash with
-// the character after it ("s" lets that be a newline) and tolerates one unpaired
-// backslash before the closing delimiter. The escape and non-escape branches never
-// start on the same character, so the alternation stays linear on hostile input.
-const MARKDOWN_LINK_RE =
-  /\[(?:[^\]]|](?!\())*]\((https?:\/\/\S+?)(?:\s+(?:"(?:[^"\\]|\\.)*\\?"|'(?:[^'\\]|\\.)*\\?'|\((?:[^()\\]|\\.)*\\?\)))?\s*\)/gis;
 const BARE_LINK_RE = /https?:\/\/\S+/gi;
 
 function stripMarkdownLinks(message: string): string {
-  return message.replace(MARKDOWN_LINK_RE, " ");
+  const chunks: string[] = [];
+  let cursor = 0;
+  for (const [start, end] of findMarkdownLinkSourceSpans(message)) {
+    chunks.push(message.slice(cursor, start), " ");
+    cursor = end;
+  }
+  chunks.push(message.slice(cursor));
+  return chunks.join("");
 }
 
 function resolveMaxLinks(value?: number): number {

--- a/src/link-understanding/runner.transport.test.ts
+++ b/src/link-understanding/runner.transport.test.ts
@@ -225,6 +225,43 @@ it("skips a timed-out streaming link and processes the next link", async () => {
   );
 });
 
+it("fetches only bare URLs from messages that also contain titled markdown links", async () => {
+  const requests: string[] = [];
+  await withServer(
+    (req, res) => {
+      const requestPath = req.url ?? "";
+      requests.push(requestPath);
+      res.end(requestPath);
+    },
+    async (base) => {
+      const firstBare = `${base}/bare-one`;
+      const secondBare = `${base}/bare-two`;
+      const ctx: MsgContext = {
+        Body: [
+          `[quoted](${base}/quoted "Docs")`,
+          `[parenthesized](${base}/parenthesized (Docs))`,
+          `[escaped](${base}/escaped "A \\"quoted\\" title")`,
+          firstBare,
+          `[angle](<${base}/angle> 'Docs')`,
+          secondBare,
+        ].join(" "),
+      };
+
+      const result = await applyLinkUnderstanding({
+        cfg: config(["-e", "process.stdin.pipe(process.stdout)"]),
+        ctx,
+      });
+
+      expect(requests).toEqual(["/bare-one", "/bare-two"]);
+      expect(result).toEqual({
+        urls: [firstBare, secondBare],
+        outputs: ["/bare-one", "/bare-two"],
+      });
+      expect(ctx.LinkUnderstanding).toEqual(["/bare-one", "/bare-two"]);
+    },
+  );
+});
+
 it("stops processor descendants after caller cancellation", async () => {
   await withTempDir("openclaw-link-cancel-", async (dir) => {
     const pidPath = path.join(dir, "worker.pid");


### PR DESCRIPTION
## What Problem This Solves

Link Understanding removed Markdown links only when `)` followed the destination immediately. A valid CommonMark title left the whole link in the message, so the bare-URL scan found and fetched the citation destination.

## Why This Change Was Made

The extraction owner now asks the existing Markdown parser for exact source spans of inline links, autolinks, and images. It removes those spans before the existing single bare-URL scan.

This keeps URL ordering, the per-message cap, safety filtering, and one dedupe set unchanged. It also handles both CommonMark destination forms, balanced and escaped destination parentheses, all three title delimiters, escaped title delimiters, and title line breaks without title-specific replacement rules.

The incoming regex also treated an unclosed escaped title as valid Markdown. The parser now leaves malformed input for the normal bare-URL policy.

## User Impact

A Markdown citation stays a citation. Link Understanding fetches separately pasted bare URLs, not destinations embedded in valid Markdown links.

## Evidence

The shipped product path used a built Gateway and the documented `openclaw gateway call chat.send` command. The message contained a titled link to the OpenClaw license and a separate bare link to Example Domain. The model request shows which pages Link Understanding fetched:

| Revision | Titled citation page | Bare page |
| --- | --- | --- |
| Current main `daffac35063ce045fbfabab90880691dc5c82676` | Present | Present |
| Exact head `511401ae93a9447615309dbe7189f66a421ff0ba` | Absent | Present |

Both runs used an isolated Gateway, state directory, mock model endpoint, and real guarded public HTTPS fetches. Current main therefore proves the user path red, and the exact head proves it green.

The narrower grammar probe also confirmed that quoted, parenthesized, and escaped-title citations each entered `runLinkUnderstanding` on current main. An ordinary Markdown link stayed suppressed and a separate bare URL still fetched.

The committed Gateway regression drives `chat.send` through the same guarded HTTP and model-request path. It fails on current main because the link server receives `[/citation, /bare]`; it passes on the repaired head with only `[/bare]`.

The repaired content passed:

```console
node scripts/run-vitest.mjs src/link-understanding/detect.test.ts src/link-understanding/runner.test.ts src/link-understanding/runner.transport.test.ts
Test Files  3 passed (3)
Tests       47 passed (47)

node scripts/run-vitest.mjs src/gateway/link-understanding.product.test.ts
Test Files  1 passed (1)
Tests       1 passed (1)

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json packages/markdown-core/src/link-spans.ts src/link-understanding/detect.test.ts src/link-understanding/detect.ts src/link-understanding/runner.transport.test.ts
Found 0 warnings and 0 errors.

node scripts/run-tsgo.mjs -p tsconfig.core.json
exit 0
```

The transport regression uses the real guarded HTTP path. It receives requests only for two separate bare URLs and no request for quoted, parenthesized, escaped-title, or angle-destination citations.
