### PR TITLE
refactor(scripts): centralize process signal registration

### DIFF
--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -36,6 +36,7 @@ import {
   type TranslationBatchItem,
 } from "./lib/control-ui-i18n-sync-plan.ts";
 import { toErrorObject as toLintErrorObject } from "./lib/error-format.mts";
+import { registerProcessSignalHandlers } from "./lib/managed-child-process.mts";
 import { sleep } from "./lib/sleep.mjs";
 import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
 
@@ -558,13 +559,7 @@ export async function runProcess(
     let parentSignalPending: NodeJS.Signals | null = null;
     const parentSignalState: RunProcessParentSignalState = { done: false, signal: null };
     activeRunProcessParentSignals.add(parentSignalState);
-    const parentSignalHandlers: { handler: () => void; signal: NodeJS.Signals }[] = [];
-    const cleanupParentSignalHandlers = () => {
-      for (const { signal, handler } of parentSignalHandlers) {
-        process.off(signal, handler);
-      }
-      parentSignalHandlers.length = 0;
-    };
+    let cleanupParentSignalHandlers = () => {};
     const signalWindowsProcessTree = (force: boolean): boolean => {
       if (process.platform !== "win32" || typeof child.pid !== "number") {
         return false;
@@ -599,8 +594,11 @@ export async function runProcess(
       }
       child.kill(signal);
     };
-    const relayParentSignal = (signal: NodeJS.Signals) => {
-      const handler = () => {
+    cleanupParentSignalHandlers = registerProcessSignalHandlers({
+      signals:
+        process.platform === "win32" ? ["SIGINT", "SIGTERM"] : ["SIGINT", "SIGTERM", "SIGHUP"],
+      mode: "once",
+      onSignal(signal) {
         parentSignalPending = signal;
         parentSignalState.signal = signal;
         signalChild(signal);
@@ -623,15 +621,8 @@ export async function runProcess(
           parentSignalState.done = true;
           maybeReraiseRunProcessParentSignal(signal);
         }, killGraceMs);
-      };
-      parentSignalHandlers.push({ handler, signal });
-      process.once(signal, handler);
-    };
-    const relayedSignals: NodeJS.Signals[] =
-      process.platform === "win32" ? ["SIGINT", "SIGTERM"] : ["SIGINT", "SIGTERM", "SIGHUP"];
-    for (const signal of relayedSignals) {
-      relayParentSignal(signal);
-    }
+      },
+    });
     const processGroupIsAlive = () => {
       if (!useProcessGroup || typeof child.pid !== "number") {
         return false;

--- a/scripts/deadcode-knip-runner.mts
+++ b/scripts/deadcode-knip-runner.mts
@@ -1,4 +1,5 @@
 import { spawn, type SpawnOptions } from "node:child_process";
+import { registerProcessSignalHandlers } from "./lib/managed-child-process.mts";
 import { createPnpmRunnerSpawnSpec } from "./pnpm-runner.mts";
 
 const KNIP_VERSION = "6.32.2";
@@ -164,28 +165,20 @@ export async function runKnip(knipArgs: string[], params: KnipRunParams = {}) {
       detached: process.platform !== "win32",
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const parentSignalHandlers: Array<{ signal: KnipSignal; handler: () => void }> = [];
-    const cleanupParentSignalHandlers = () => {
-      for (const { signal, handler } of parentSignalHandlers) {
-        process.off(signal, handler);
-      }
-      parentSignalHandlers.length = 0;
-    };
-    const relayParentSignal = (signal: KnipSignal) => {
-      const handler = () => {
+    let cleanupParentSignalHandlers = () => {};
+    cleanupParentSignalHandlers = registerProcessSignalHandlers({
+      signals:
+        process.platform === "win32"
+          ? []
+          : (["SIGINT", "SIGTERM", "SIGHUP"] satisfies readonly KnipSignal[]),
+      mode: "once",
+      onSignal(signal) {
         signalProcessTree(child, signal);
         signalProcessTree(child, "SIGKILL");
         cleanupParentSignalHandlers();
         process.kill(process.pid, signal);
-      };
-      parentSignalHandlers.push({ signal, handler });
-      process.once(signal, handler);
-    };
-    if (process.platform !== "win32") {
-      relayParentSignal("SIGINT");
-      relayParentSignal("SIGTERM");
-      relayParentSignal("SIGHUP");
-    }
+      },
+    });
 
     const heartbeatTimer = setInterval(() => {
       writeStatus(

--- a/scripts/lib/managed-child-process.mts
+++ b/scripts/lib/managed-child-process.mts
@@ -73,7 +73,29 @@ type ManagedCommandOutcome =
   | { type: "signal"; signal: NodeJS.Signals };
 
 const managedChildren = new Set<(signal: NodeJS.Signals) => void>();
-const signalHandlers = new Map<NodeJS.Signals, () => void>();
+let disposeSignalHandlers: (() => void) | undefined;
+
+export function registerProcessSignalHandlers<const TSignal extends NodeJS.Signals>({
+  signals,
+  mode,
+  onSignal,
+}: {
+  signals: readonly TSignal[];
+  mode: "once" | "on";
+  onSignal: (signal: TSignal) => void;
+}): () => void {
+  const registrations: Array<readonly [TSignal, () => void]> = [];
+  for (const signal of signals) {
+    const handler = () => onSignal(signal);
+    registrations.push([signal, handler]);
+    if (mode === "once") {
+      process.once(signal, handler);
+    } else {
+      process.on(signal, handler);
+    }
+  }
+  return () => registrations.splice(0).forEach(([signal, handler]) => process.off(signal, handler));
+}
 
 /** Return the conventional shell exit code for a signal. */
 export function signalExitCode(signal: NodeJS.Signals) {
@@ -581,24 +603,19 @@ function createManagedCommandCleanupError(
 }
 
 function installSignalHandlers() {
-  for (const signal of FORWARDED_SIGNALS) {
-    if (signalHandlers.has(signal)) {
-      continue;
-    }
-    const handler = () => forwardSignalToManagedChildren(signal);
-    signalHandlers.set(signal, handler);
-    process.on(signal, handler);
-  }
+  disposeSignalHandlers ??= registerProcessSignalHandlers({
+    signals: FORWARDED_SIGNALS,
+    mode: "on",
+    onSignal: forwardSignalToManagedChildren,
+  });
 }
 
 function removeSignalHandlersIfIdle() {
   if (managedChildren.size > 0) {
     return;
   }
-  for (const [signal, handler] of signalHandlers) {
-    process.off(signal, handler);
-  }
-  signalHandlers.clear();
+  disposeSignalHandlers?.();
+  disposeSignalHandlers = undefined;
 }
 
 function forwardSignalToManagedChildren(signal: NodeJS.Signals) {

--- a/scripts/test-group-report.mts
+++ b/scripts/test-group-report.mts
@@ -17,6 +17,7 @@ import {
 import { coerceErrorMessage } from "./lib/error-format.mts";
 import {
   inspectManagedProcessGroup,
+  registerProcessSignalHandlers,
   terminateManagedChild,
   waitForManagedProcessGroupExit,
 } from "./lib/managed-child-process.mts";
@@ -334,31 +335,21 @@ export function spawnText(command: string, args: readonly string[], options: Spa
         },
         taskkillTimeoutMs: null,
       });
-    const parentSignalHandlers: { signal: ProcessSignal; handler: () => void }[] = [];
-    const cleanupParentSignalHandlers = () => {
-      for (const { signal, handler } of parentSignalHandlers) {
-        process.off(signal, handler);
-      }
-      parentSignalHandlers.length = 0;
-    };
-    const relayParentSignal = (signal: ProcessSignal) => {
-      const handler = () => {
-        signalChild(signal);
+    let cleanupParentSignalHandlers = () => {};
+    cleanupParentSignalHandlers = registerProcessSignalHandlers({
+      signals: useProcessGroup
+        ? ["SIGINT", "SIGTERM", "SIGHUP"]
+        : process.platform === "win32"
+          ? ["SIGINT", "SIGTERM"]
+          : [],
+      mode: "once",
+      onSignal(signal) {
+        signalChild(signal as ProcessSignal);
         signalChild("SIGKILL");
         cleanupParentSignalHandlers();
-        process.kill(process.pid, signal as NodeJS.Signals);
-      };
-      parentSignalHandlers.push({ signal, handler });
-      process.once(signal, handler);
-    };
-    if (useProcessGroup) {
-      relayParentSignal("SIGINT");
-      relayParentSignal("SIGTERM");
-      relayParentSignal("SIGHUP");
-    } else if (process.platform === "win32") {
-      relayParentSignal("SIGINT");
-      relayParentSignal("SIGTERM");
-    }
+        process.kill(process.pid, signal);
+      },
+    });
     const processGroupIsAlive = () =>
       inspectManagedProcessGroup(child, { errorPolicy: "alive-on-eperm" }) === "live";
     const finishAfterProcessGroupCleanup = async (result: SpawnTextResult) => {

--- a/scripts/tsdown-build.mts
+++ b/scripts/tsdown-build.mts
@@ -24,6 +24,7 @@ import {
 import { toErrorObject } from "./lib/error-format.mts";
 import {
   inspectManagedProcessGroup,
+  registerProcessSignalHandlers,
   signalExitCode,
   terminateManagedChild,
   waitForManagedProcessGroupExit,
@@ -1657,29 +1658,15 @@ export async function runTsdownBuildInvocation(
     });
   }
 
-  const parentSignalHandlers: { signal: NodeJS.Signals; handler: () => void }[] = [];
-  function cleanupParentSignalHandlers() {
-    for (const { signal, handler } of parentSignalHandlers) {
-      process.off(signal, handler);
-    }
-    parentSignalHandlers.length = 0;
-  }
-
-  function relayParentSignal(signal: NodeJS.Signals) {
-    const handler = () => {
+  const cleanupParentSignalHandlers = registerProcessSignalHandlers({
+    signals: useProcessGroup ? ["SIGINT", "SIGTERM", "SIGHUP"] : [],
+    mode: "once",
+    onSignal(signal) {
       parentSignal ??= signal;
       signalChild(signal);
       signalChild("SIGKILL");
-    };
-    parentSignalHandlers.push({ signal, handler });
-    process.once(signal, handler);
-  }
-
-  if (useProcessGroup) {
-    relayParentSignal("SIGINT");
-    relayParentSignal("SIGTERM");
-    relayParentSignal("SIGHUP");
-  }
+    },
+  });
 
   const processTreeAlive = () =>
     inspectManagedProcessGroup(child, {


### PR DESCRIPTION
## What Problem This Solves

Process signal registration and disposal were duplicated across the managed child-process owner and four script callers. Each copy manually paired listeners with cleanup, making exact-listener removal and lifecycle ownership harder to verify.

## Why This Change Was Made

`scripts/lib/managed-child-process.mts` now owns the canonical internal API:

`registerProcessSignalHandlers({ signals, mode, onSignal }): () => void`

The helper creates one distinct closure per input signal, preserves input order and duplicates, uses per-signal Node `once`/`on` semantics, and returns an idempotent disposer that removes those exact closures with `process.off`.

The migration removes the managed-child private handler map plus local registration/disposal arrays or loops in:

- `scripts/control-ui-i18n.ts`
- `scripts/deadcode-knip-runner.mts`
- `scripts/test-group-report.mts`
- `scripts/tsdown-build.mts`

Caller policy remains local and unchanged:

- managed children share one `on` listener per signal until the managed set becomes idle
- Control UI i18n keeps Windows/POSIX selection, process-group state, grace timing, explicit disposal, and delayed re-raise
- deadcode and test-group reporting keep original signal, `SIGKILL`, disposal, then re-raise ordering
- tsdown keeps POSIX-only `once` registration, first-signal `??=`, repeated/different signal behavior, settlement-only cleanup, exit mapping, and no re-raise

## User Impact

No intended behavior change. Signal listener ownership is centralized while each script retains its existing forwarding, cleanup, and exit policy.

Production diff: `+71/-92` (net `-21`). Test diff: `0`.

## Evidence

- Focused command: `node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts test/scripts/control-ui-i18n.test.ts test/scripts/check-deadcode-unused-files.test.ts test/scripts/test-group-report.test.ts test/scripts/tsdown-build.test.ts`
  - all changed listener-count concurrency, forwarding, cleanup/re-raise, and repeated-signal cases passed
  - one unrelated nested timeout cleanup case failed; the exact case fails identically on untouched base `dbddc382eceaf74dd09d3e5dc5b81de90eace68a`
- `pnpm lint:scripts`: pass
- `pnpm check:import-cycles`: pass, zero runtime value cycles
- script TypeScript check: pass after adding tracked `ui/config` inputs omitted by the sparse worktree profile
- changed-gate constituent checks: pass; the wrapper rerun was operator-interrupted after its unique checks were covered
- `pnpm build`: blocked at runtime postbuild by the shared worktree install resolving stale `@openclaw/ai/diagnostics` from the canonical checkout; the worktree build artifact contains the required export
- exact autoreview policy command: clean, no accepted/actionable findings, correctness `0.97`

Overlap recheck:

- https://github.com/openclaw/openclaw/pull/119450 touches translation context only, not the signal block
- https://github.com/openclaw/openclaw/pull/62063 touches locale selection only, not the signal block
- https://github.com/openclaw/openclaw/pull/126724 touches tsdown output-root selection only, not the signal block

OpenAI Codex source was inspected in sibling `openai/codex` at `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; those CLI dispatch/completion paths do not affect this Node signal-registration owner.
