### PR TITLE
fix(auth): recover credentials stranded by completed migrations

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -279,6 +279,8 @@ the container normally.
 
 Doctor reports interrupted auth-profile archive recovery even when no new migration remains or you decline another migration. If recovery cannot finish, its warning includes the failure cause and leaves the pending source for recovery; do not delete it to silence the warning.
 
+`doctor --fix` also repairs an inconsistent completed auth migration only when its old receipt has no credential fingerprints, none of the migrated credentials remain in the current canonical store, and the preserved archive still matches the recorded source hash. Doctor reimports through the normal verified migration flow. Completed receipts with fingerprints, surviving migrated credentials, or no archive remain untouched, so removing credentials after a verified migration does not restore them from backup.
+
 For malformed legacy `exec-approvals.json`, Doctor preserves the original bytes and reports the first validation problem, for example `agents entry #2.allowlist[1].lastUsedAt: expected a finite number`. Agent entries are numbered from 1 in JavaScript `Object.keys` order; allowlist indices start at 0. This can differ from JSON text order, especially for numeric keys. To locate entry #2 locally, use `Object.keys(JSON.parse(raw).agents)[1]`, where `raw` is the file contents. Diagnostics omit agent keys and policy values, and migration receipts contain no diagnostic detail. JSON syntax and invalid UTF-8 receive separate reasons.
 
 Repair the preserved file locally, then rerun `openclaw doctor --fix` with the same `OPENCLAW_STATE_DIR` setting (leave it unset if it was unset before). Exec approvals remain blocked until migration succeeds. Do not delete the file or broaden its policy to bypass validation.

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -15,6 +15,7 @@ import {
 import { clearRuntimeAuthProfileStoreSnapshots } from "../agents/auth-profiles/runtime-snapshots.js";
 import {
   readPersistedAuthProfileStoreRaw,
+  readPersistedSharedAuthProfileStoreRaw,
   writePersistedAuthProfileStateRaw,
   writePersistedAuthProfileStoreRaw,
 } from "../agents/auth-profiles/sqlite.js";
@@ -211,6 +212,133 @@ afterEach(async () => {
 });
 
 describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
+  it.each(
+    (["legacy-main", "state-db"] as const).flatMap((location) =>
+      (
+        [
+          "recover",
+          "restored-source",
+          "interrupted-recovery",
+          "fingerprinted",
+          "empty-fingerprints",
+          "credential-present",
+          "partial-row",
+          "malformed-row",
+          "no-archive",
+          "declined",
+          "tampered-archive",
+          "legacy-id",
+        ] as const
+      ).map((scenario) => ({ location, scenario })),
+    ),
+  )("completed receipt recovery: $location / $scenario", async ({ location, scenario }) => {
+    const state = await makeTestState();
+    if (location === "state-db") {
+      writeConfigMachineState("auth.sharedStore", { location }, { env: state.env });
+    }
+    const credential = { type: "api_key", provider: "openai", key: "synthetic-archive-key" };
+    const profileId = scenario === "legacy-id" ? "openai-codex:default" : "openai:default";
+    const authPath = await writeLegacyAuthProfilesJson(state, {
+      version: 1,
+      profiles: { [profileId]: credential },
+    });
+    const migrate = (repair = true) =>
+      maybeMigrateAuthProfileJsonStoresToSqlite({
+        cfg: {},
+        prompter: makePrompter(repair),
+        env: state.env,
+      });
+    await migrate();
+    const db = openOpenClawStateDatabase({ env: state.env }).db;
+    const receipt = db
+      .prepare("SELECT report_json FROM migration_sources WHERE source_path = ?")
+      .get(authPath) as { report_json: string };
+    const report = JSON.parse(receipt.report_json);
+    if (scenario !== "fingerprinted") delete report.expectedProfileSha256;
+    if (scenario === "empty-fingerprints") report.expectedProfileSha256 = {};
+    db.prepare("UPDATE migration_sources SET report_json = ? WHERE source_path = ?").run(
+      JSON.stringify(report),
+      authPath,
+    );
+    const profiles: Record<string, unknown> = {
+      "anthropic:unrelated": {
+        type: "api_key",
+        provider: "anthropic",
+        key: "synthetic-unrelated-key",
+      },
+    };
+    if (scenario === "credential-present" || scenario === "legacy-id")
+      profiles["openai:default"] = credential;
+    if (scenario === "partial-row")
+      profiles["openai:default"] = {
+        type: "oauth",
+        provider: "openai",
+        refresh: "synthetic-current-refresh",
+      };
+    if (scenario === "malformed-row")
+      profiles["openai:default"] = { type: "unknown", key: "synthetic-current-key" };
+    const writeTarget = () =>
+      location === "state-db"
+        ? writeConfigMachineState(
+            "authProfiles.store",
+            { version: 1, profiles },
+            { env: state.env },
+          )
+        : writePersistedAuthProfileStoreRaw({ version: 1, profiles }, state.agentDir());
+    writeTarget();
+    const archiveBytes = fs.readFileSync(report.archivePath);
+    if (scenario === "restored-source") fs.writeFileSync(authPath, archiveBytes);
+    if (scenario === "no-archive") fs.unlinkSync(report.archivePath);
+    if (scenario === "tampered-archive") fs.appendFileSync(report.archivePath, " ");
+    const before = db
+      .prepare("SELECT * FROM migration_sources WHERE source_path = ?")
+      .get(authPath);
+    if (scenario === "interrupted-recovery") {
+      const link = fs.linkSync;
+      const fault = vi.spyOn(fs, "linkSync").mockImplementation((...args) => {
+        link(...args);
+        if (args[1] === authPath) throw new Error("simulated recovery interruption");
+      });
+      try {
+        expect((await migrate()).warnings).toEqual([
+          expect.stringContaining("simulated recovery interruption"),
+        ]);
+      } finally {
+        fault.mockRestore();
+      }
+      expect(fs.readFileSync(report.archivePath)).toEqual(archiveBytes);
+    }
+    const repaired = await migrate(scenario !== "declined");
+    expect(repaired.warnings).toEqual([]);
+    const recovers =
+      scenario === "recover" ||
+      scenario === "restored-source" ||
+      scenario === "interrupted-recovery";
+    expect(readPersistedSharedAuthProfileStoreRaw(state.env)).toMatchObject({
+      profiles: recovers ? { ...profiles, "openai:default": credential } : profiles,
+    });
+    if (recovers) {
+      expect(repaired.changes).toContain(
+        "Reset an inconsistent completed auth migration receipt for retry.",
+      );
+      expect(fs.readFileSync(report.archivePath)).toEqual(archiveBytes);
+      expect((await migrate()).changes).toEqual([]);
+      // Successful recovery must itself become non-replayable after deletion.
+      writeTarget();
+      expect((await migrate()).changes).toEqual([]);
+      expect(readPersistedSharedAuthProfileStoreRaw(state.env)).toMatchObject({ profiles });
+      expect(
+        loadPersistedSharedAuthProfileStore(state.env)?.profiles["openai:default"],
+      ).toBeUndefined();
+    } else {
+      expect(
+        db.prepare("SELECT * FROM migration_sources WHERE source_path = ?").get(authPath),
+      ).toEqual(before);
+      expect(repaired.changes).toEqual([]);
+    }
+    expect(fs.existsSync(authPath)).toBe(false);
+  });
+
   it("keeps JSON-era ownership through shared writes until Doctor imports the credential", async () => {
     const state = await makeTestState();
     const authPath = await writeLegacyAuthProfilesJson(state, {

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -254,8 +254,12 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
       .prepare("SELECT report_json FROM migration_sources WHERE source_path = ?")
       .get(authPath) as { report_json: string };
     const report = JSON.parse(receipt.report_json);
-    if (scenario !== "fingerprinted") delete report.expectedProfileSha256;
-    if (scenario === "empty-fingerprints") report.expectedProfileSha256 = {};
+    if (scenario !== "fingerprinted") {
+      delete report.expectedProfileSha256;
+    }
+    if (scenario === "empty-fingerprints") {
+      report.expectedProfileSha256 = {};
+    }
     db.prepare("UPDATE migration_sources SET report_json = ? WHERE source_path = ?").run(
       JSON.stringify(report),
       authPath,
@@ -267,16 +271,19 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
         key: "synthetic-unrelated-key",
       },
     };
-    if (scenario === "credential-present" || scenario === "legacy-id")
+    if (scenario === "credential-present" || scenario === "legacy-id") {
       profiles["openai:default"] = credential;
-    if (scenario === "partial-row")
+    }
+    if (scenario === "partial-row") {
       profiles["openai:default"] = {
         type: "oauth",
         provider: "openai",
         refresh: "synthetic-current-refresh",
       };
-    if (scenario === "malformed-row")
+    }
+    if (scenario === "malformed-row") {
       profiles["openai:default"] = { type: "unknown", key: "synthetic-current-key" };
+    }
     const writeTarget = () =>
       location === "state-db"
         ? writeConfigMachineState(
@@ -287,9 +294,15 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
         : writePersistedAuthProfileStoreRaw({ version: 1, profiles }, state.agentDir());
     writeTarget();
     const archiveBytes = fs.readFileSync(report.archivePath);
-    if (scenario === "restored-source") fs.writeFileSync(authPath, archiveBytes);
-    if (scenario === "no-archive") fs.unlinkSync(report.archivePath);
-    if (scenario === "tampered-archive") fs.appendFileSync(report.archivePath, " ");
+    if (scenario === "restored-source") {
+      fs.writeFileSync(authPath, archiveBytes);
+    }
+    if (scenario === "no-archive") {
+      fs.unlinkSync(report.archivePath);
+    }
+    if (scenario === "tampered-archive") {
+      fs.appendFileSync(report.archivePath, " ");
+    }
     const before = db
       .prepare("SELECT * FROM migration_sources WHERE source_path = ?")
       .get(authPath);
@@ -297,7 +310,9 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
       const link = fs.linkSync;
       const fault = vi.spyOn(fs, "linkSync").mockImplementation((...args) => {
         link(...args);
-        if (args[1] === authPath) throw new Error("simulated recovery interruption");
+        if (args[1] === authPath) {
+          throw new Error("simulated recovery interruption");
+        }
       });
       try {
         expect((await migrate()).warnings).toEqual([

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -500,16 +500,13 @@ function mergeImportedAuthProfiles(params: {
 }): AuthProfileStore {
   const profiles = { ...params.store.profiles };
   for (const [profileId, credential] of Object.entries(params.profiles)) {
-    if (!params.existingProfileIds.has(profileId)) {
-      profiles[profileId] = credential;
-      continue;
-    }
     const existing = profiles[profileId];
     if (
-      params.replaceExistingWithoutCredential &&
-      existing &&
-      !hasUsableAuthProfileCredential(existing) &&
-      hasUsableAuthProfileCredential(credential)
+      !params.existingProfileIds.has(profileId) ||
+      (params.replaceExistingWithoutCredential &&
+        existing &&
+        !hasUsableAuthProfileCredential(existing) &&
+        hasUsableAuthProfileCredential(credential))
     ) {
       profiles[profileId] = credential;
     }
@@ -551,19 +548,11 @@ function formatMissingAuthProfileSqliteVerification(params: {
     (profileId) => !params.loaded?.profiles[profileId],
   );
   const missingStateFields: string[] = [];
-  for (const [provider, profileIds] of Object.entries(params.expected.order ?? {})) {
-    const loadedProfileIds = params.loaded?.order?.[provider];
-    if (
-      !loadedProfileIds ||
-      loadedProfileIds.length !== profileIds.length ||
-      loadedProfileIds.some((profileId, index) => profileId !== profileIds[index])
-    ) {
-      missingStateFields.push(`order.${provider}`);
-    }
-  }
-  for (const [provider, profileId] of Object.entries(params.expected.lastGood ?? {})) {
-    if (params.loaded?.lastGood?.[provider] !== profileId) {
-      missingStateFields.push(`lastGood.${provider}`);
+  for (const field of ["order", "lastGood"] as const) {
+    for (const [provider, expected] of Object.entries(params.expected[field] ?? {})) {
+      if (!isDeepStrictEqual(params.loaded?.[field]?.[provider], expected)) {
+        missingStateFields.push(`${field}.${provider}`);
+      }
     }
   }
   for (const profileId of Object.keys(params.expected.usageStats ?? {})) {
@@ -606,14 +595,6 @@ function hasImportableAuthProfileStore(store: AuthProfileStore | null): store is
   return Boolean(store && (Object.keys(store.profiles).length > 0 || hasAuthProfileState(store)));
 }
 
-function hasLegacyAuthProfileSource(candidate: AuthProfileSqliteMigrationCandidate): boolean {
-  return (
-    fs.existsSync(candidate.authPath) ||
-    fs.existsSync(candidate.statePath) ||
-    fs.existsSync(candidate.legacyPath)
-  );
-}
-
 function prepareAuthProfileSourceReceipt(params: {
   pathname: string;
   targetDatabasePath: string;
@@ -640,14 +621,6 @@ function prepareAuthProfileSourceReceipt(params: {
     now: new Date(params.now()),
     ...(params.env ? { env: params.env } : {}),
   });
-}
-
-function archiveVerifiedAuthProfileSource(
-  receipt: AuthProfileMigrationSourceReceipt,
-  sourceLocked = false,
-): string {
-  finalizeAuthProfileMigrationSource(receipt, "completed", { sourceLocked });
-  return receipt.archivePath;
 }
 
 function assertAuthProfileMigrationSourcesUnchanged(
@@ -903,54 +876,96 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
   const env = params.env ?? process.env;
   const loadMigratedStore =
     params.deps?.loadPersistedAuthProfileStore ?? loadPersistedAuthProfileStore;
-  let resumedChanges: string[] = [];
-  let resumeWarning: string | undefined;
-  try {
-    resumedChanges = resumePendingAuthProfileMigrationArchives(env);
-  } catch (err) {
-    resumeWarning = `Could not finalize an interrupted auth profile archive; legacy sources were left for recovery: ${String(err)}`;
-  }
   const candidates = listAuthProfileSqliteMigrationCandidates(params.cfg, env);
-  const configStore = coerceLegacyConfigAuthProfileStore(params.cfg);
   const oauthPath = resolveLegacyOAuthPath(env);
-  const hasLegacyOAuth = fs.existsSync(oauthPath);
-  const detected = candidates.filter(
-    (candidate) =>
-      hasLegacyAuthProfileSource(candidate) ||
-      (configStore && isDefaultAgentCandidate(candidate, params.cfg, env)),
-  );
+  const recoverableSources = new Set<string>();
+  let recoveryApproved = false;
+  const recoverCompleted = (receipt: AuthProfileMigrationSourceReceipt): boolean => {
+    const candidate = candidates.find((entry) =>
+      [
+        entry.authPath,
+        entry.legacyPath,
+        ...(entry.agentDir === undefined ? [oauthPath] : []),
+      ].includes(receipt.sourcePath),
+    );
+    if (!candidate) {
+      return false;
+    }
+    const raw = parseAuthProfileMigrationSource(receipt);
+    normalizeLegacyApiKeyAliasesForImport(raw);
+    const imported =
+      receipt.sourcePath === oauthPath
+        ? coerceLegacyOAuthFile(raw).store
+        : (coercePersistedAuthProfileStore(raw) ?? coerceLegacyFlatAuthProfileStore(raw));
+    if (!imported || !Object.values(imported.profiles).some(hasUsableAuthProfileCredential)) {
+      return false;
+    }
+    // Current ownership wins over the receipt's historical database path.
+    // Legacy provider aliases are ambiguous without fingerprints; any surviving
+    // credential for that provider prevents replay under a newly allocated id.
+    const inspection = candidate.agentDir
+      ? inspectPersistedAuthProfileStoreRaw(candidate.agentDir)
+      : inspectPersistedSharedAuthProfileStoreRaw(env);
+    const rawTarget =
+      inspection.status === "missing"
+        ? { profiles: {} }
+        : inspection.status === "readable"
+          ? inspection.raw
+          : null;
+    if (!isRecord(rawTarget) || !isRecord(rawTarget.profiles)) {
+      return false;
+    }
+    const existing = rawTarget.profiles;
+    if (
+      Object.entries(imported.profiles).some(
+        ([id, credential]) =>
+          Object.hasOwn(existing, id) ||
+          ((isLegacyOpenAICodexProfileId(id) || isLegacyOpenAICodexProvider(credential.provider)) &&
+            Object.entries(existing).some(
+              ([key, entry]) =>
+                key.startsWith("openai:") ||
+                (isRecord(entry) && entry.provider === OPENAI_PROVIDER_ID),
+            )),
+      )
+    ) {
+      return false;
+    }
+    recoverableSources.add(receipt.sourcePath);
+    return recoveryApproved;
+  };
+  const warnings: string[] = [];
+  const resume = () => {
+    try {
+      return resumePendingAuthProfileMigrationArchives(env, recoverCompleted);
+    } catch (err) {
+      warnings.push(
+        `Could not finalize an interrupted auth profile archive; legacy sources were left for recovery: ${String(err)}`,
+      );
+      return [];
+    }
+  };
+  const resumedChanges = resume();
+  const configStore = coerceLegacyConfigAuthProfileStore(params.cfg);
+  const hasLegacyOAuth = fs.existsSync(oauthPath) || recoverableSources.has(oauthPath);
+  const candidateSources = (candidate: AuthProfileSqliteMigrationCandidate) =>
+    [candidate.authPath, candidate.statePath, candidate.legacyPath].filter(
+      (pathname) =>
+        fs.existsSync(pathname) ||
+        recoverableSources.has(pathname) ||
+        (configStore &&
+          isDefaultAgentCandidate(candidate, params.cfg, env) &&
+          pathname === candidate.authPath),
+    );
+  const detected = candidates.filter((candidate) => candidateSources(candidate).length > 0);
   const result: LegacyFlatAuthProfileRepairResult = {
-    detected: [
-      ...detected.flatMap((candidate) =>
-        [
-          candidate.authPath,
-          candidate.statePath,
-          candidate.legacyPath,
-          ...(configStore && isDefaultAgentCandidate(candidate, params.cfg, env)
-            ? [candidate.authPath]
-            : []),
-        ]
-          .filter((pathname, index, entries) => entries.indexOf(pathname) === index)
-          .filter(
-            (pathname) =>
-              fs.existsSync(pathname) ||
-              (configStore &&
-                isDefaultAgentCandidate(candidate, params.cfg, env) &&
-                pathname === candidate.authPath),
-          ),
-      ),
-      ...(hasLegacyOAuth ? [oauthPath] : []),
-    ],
+    detected: [...detected.flatMap(candidateSources), ...(hasLegacyOAuth ? [oauthPath] : [])],
     changes: resumedChanges,
     configOwnerMigrationApplied: false,
-    warnings: resumeWarning ? [resumeWarning] : [],
+    warnings,
   };
-  if (resumeWarning) {
+  if (warnings.length > 0 || (detected.length === 0 && !hasLegacyOAuth)) {
     // A pending imported receipt owns its source until recovery succeeds.
     // Starting a new hash-based run would orphan that crash-recovery record.
-    return result;
-  }
-  if (detected.length === 0 && !hasLegacyOAuth) {
     return result;
   }
 
@@ -972,6 +987,13 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
   });
   if (!shouldRepair) {
     return result;
+  }
+  if (recoverableSources.size > 0) {
+    recoveryApproved = true;
+    result.changes.push(...resume());
+    if (warnings.length > 0) {
+      return result;
+    }
   }
 
   // Config, credential import, and session repair must share one collision
@@ -1112,64 +1134,41 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
       let next: AuthProfileStore = { ...existing };
       let verifiedStore = existing;
       const importedProfileIds = new Set<string>();
+      const legacyAsStore: AuthProfileStore = { version: AUTH_STORE_VERSION, profiles: {} };
       if (legacyStore) {
-        const legacyAsStore: AuthProfileStore = { version: AUTH_STORE_VERSION, profiles: {} };
         applyLegacyAuthStore(legacyAsStore, legacyStore);
-        for (const profileId of Object.keys(legacyAsStore.profiles)) {
-          importedProfileIds.add(profileId);
-        }
-        next = mergeImportedAuthProfiles({
-          store: next,
-          profiles: legacyAsStore.profiles,
-          existingProfileIds,
-        });
       }
-      if (canonicalStore) {
-        for (const profileId of Object.keys(canonicalStore.profiles)) {
-          importedProfileIds.add(profileId);
+      for (const imported of [legacyAsStore, canonicalStore, configCanonicalStore]) {
+        if (!imported) {
+          continue;
         }
-        next = {
-          ...next,
-          version: Math.max(next.version, canonicalStore.version),
-        };
+        Object.keys(imported.profiles).forEach((id) => importedProfileIds.add(id));
+        const fromConfig = imported === configCanonicalStore;
+        // Config fills missing credentials; canonical JSON overrides auth.json,
+        // but neither replaces credentials already held by SQLite.
         next = mergeImportedAuthProfiles({
           store: next,
-          profiles: canonicalStore.profiles,
-          existingProfileIds,
+          profiles: imported.profiles,
+          existingProfileIds: fromConfig ? new Set(Object.keys(next.profiles)) : existingProfileIds,
+          replaceExistingWithoutCredential: fromConfig,
         });
-        next = mergeImportedAuthProfileState({
-          store: next,
-          state: coerceAuthProfileState(canonicalStore),
-          existingState,
-        });
-      }
-      if (configCanonicalStore) {
-        for (const profileId of Object.keys(configCanonicalStore.profiles)) {
-          importedProfileIds.add(profileId);
+        if (imported === canonicalStore) {
+          next.version = Math.max(next.version, imported.version);
+          next = mergeImportedAuthProfileState({
+            store: next,
+            state: coerceAuthProfileState(imported),
+            existingState,
+          });
         }
-        // Config imports fill missing SQLite credentials only; when both exist,
-        // the canonical per-agent SQLite store wins over legacy config secrets.
-        next = mergeImportedAuthProfiles({
-          store: next,
-          profiles: configCanonicalStore.profiles,
-          existingProfileIds: new Set(Object.keys(next.profiles)),
-          replaceExistingWithoutCredential: true,
-        });
       }
       if (hasAuthProfileState(state)) {
         next = mergeImportedAuthProfileState({ store: next, state, existingState });
       }
 
       if (canonicalStore || configCanonicalStore || legacyStore || hasAuthProfileState(state)) {
-        const stateProfileIds = [
-          ...collectAuthProfileStateProfileIds(state),
-          ...(canonicalStore
-            ? collectAuthProfileStateProfileIds(coerceAuthProfileState(canonicalStore))
-            : []),
-          ...(configCanonicalStore
-            ? collectAuthProfileStateProfileIds(coerceAuthProfileState(configCanonicalStore))
-            : []),
-        ];
+        const stateProfileIds = [state, canonicalStore, configCanonicalStore].flatMap((store) =>
+          store ? collectAuthProfileStateProfileIds(coerceAuthProfileState(store)) : [],
+        );
         try {
           assertAuthProfileMigrationSourcesUnchanged(candidate, sourceReceipts);
           verifiedStore = runAuthProfileWriteTransaction(
@@ -1295,9 +1294,10 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         }
       }
       assertAuthProfileMigrationSourcesUnchanged(candidate, sourceReceipts);
-      const archives = sourceReceipts.map((receipt) =>
-        archiveVerifiedAuthProfileSource(receipt, true),
-      );
+      const archives = sourceReceipts.map((receipt) => {
+        finalizeAuthProfileMigrationSource(receipt, "completed", { sourceLocked: true });
+        return receipt.archivePath;
+      });
       const archiveText =
         archives.length > 0
           ? `archive${archives.length === 1 ? "" : "s"}: ${archives.map(shortenHomePath).join(", ")}`

--- a/src/commands/doctor-auth-migration-receipts.ts
+++ b/src/commands/doctor-auth-migration-receipts.ts
@@ -25,8 +25,8 @@ type MigrationDatabase = Pick<OpenClawStateDatabase, "migration_runs" | "migrati
 type AuthProfileTargetDatabase = Pick<
   OpenClawAgentKyselyDatabase,
   "auth_profile_store" | "auth_profile_state"
->;
-type SharedAuthProfileTargetDatabase = Pick<OpenClawStateDatabase, "config_machine_state">;
+> &
+  Pick<OpenClawStateDatabase, "config_machine_state">;
 
 export type AuthProfileMigrationSourceReceipt = {
   sourceKey: string;
@@ -153,6 +153,7 @@ function recordAuthProfileMigrationImported(
 function retirePendingAuthProfileMigrationReceipt(
   receipt: AuthProfileMigrationSourceReceipt,
   status: "retryable" | "superseded",
+  previousStatus: "imported" | "completed" = "imported",
   now = Date.now(),
 ): void {
   runOpenClawStateWriteTransaction(
@@ -164,7 +165,7 @@ function retirePendingAuthProfileMigrationReceipt(
           .updateTable("migration_runs")
           .set({ status, finished_at: now })
           .where("id", "=", receipt.runId)
-          .where("status", "=", "imported"),
+          .where("status", "=", previousStatus),
       );
       executeSqliteQuerySync(
         db,
@@ -173,7 +174,7 @@ function retirePendingAuthProfileMigrationReceipt(
           .set({ status })
           .where("source_key", "=", receipt.sourceKey)
           .where("last_run_id", "=", receipt.runId)
-          .where("status", "=", "imported"),
+          .where("status", "=", previousStatus),
       );
     },
     { env: receipt.env },
@@ -260,75 +261,42 @@ export function acquireAuthProfileMigrationSourceLocks(sourcePaths: readonly str
   };
 }
 
-// Shared auth payloads moved to config_machine_state at v13; project the KV
-// cell back to the receipt-era row shape for sha comparison.
-function projectSharedStoreCell(
-  row: { value_json: string } | undefined,
-): { store_json: string } | undefined {
-  return row ? { store_json: row.value_json } : undefined;
-}
-
-function projectSharedStateCell(
-  row: { value_json: string } | undefined,
-): { state_json: string } | undefined {
-  return row ? { state_json: row.value_json } : undefined;
-}
-
 function verifyAuthProfileMigrationTarget(receipt: AuthProfileMigrationSourceReceipt): void {
-  const hasExpectedProfiles = Object.keys(receipt.expectedProfileSha256 ?? {}).length > 0;
-  if (!hasExpectedProfiles && !receipt.expectedStateSha256) {
+  const expectedProfiles = Object.entries(receipt.expectedProfileSha256 ?? {});
+  if (expectedProfiles.length === 0 && !receipt.expectedStateSha256) {
     return;
   }
   const db = openNodeSqliteDatabase(receipt.targetDatabasePath, { readOnly: true });
   try {
-    const targetStoreKey = receipt.targetStoreKey ?? "primary";
-    if (hasExpectedProfiles && receipt.expectedProfileSha256) {
-      const row =
-        targetStoreKey === "shared"
-          ? projectSharedStoreCell(
-              executeSqliteQueryTakeFirstSync(
-                db,
-                getNodeSqliteKysely<SharedAuthProfileTargetDatabase>(db)
-                  .selectFrom("config_machine_state")
-                  .select("value_json")
-                  .where("state_key", "=", "authProfiles.store"),
-              ),
-            )
-          : executeSqliteQueryTakeFirstSync(
-              db,
-              getNodeSqliteKysely<AuthProfileTargetDatabase>(db)
+    const kysely = getNodeSqliteKysely<AuthProfileTargetDatabase>(db);
+    const readTarget = (kind: "store" | "state") => {
+      // v13 shared KV cells and agent rows contain the same receipt payload.
+      const query =
+        receipt.targetStoreKey === "shared"
+          ? kysely
+              .selectFrom("config_machine_state")
+              .select("value_json as json")
+              .where("state_key", "=", `authProfiles.${kind}`)
+          : kind === "store"
+            ? kysely
                 .selectFrom("auth_profile_store")
-                .select("store_json")
-                .where("store_key", "=", "primary"),
-            );
-      const store = typeof row?.store_json === "string" ? JSON.parse(row.store_json) : null;
-      for (const [profileId, expectedSha256] of Object.entries(receipt.expectedProfileSha256)) {
-        if (digestAuthProfileMigrationValue(store?.profiles?.[profileId]) !== expectedSha256) {
-          throw new Error("auth profile migration target verification failed");
-        }
+                .select("store_json as json")
+                .where("store_key", "=", "primary")
+            : kysely
+                .selectFrom("auth_profile_state")
+                .select("state_json as json")
+                .where("state_key", "=", "primary");
+      const row = executeSqliteQueryTakeFirstSync(db, query);
+      return typeof row?.json === "string" ? JSON.parse(row.json) : null;
+    };
+    const store = expectedProfiles.length > 0 ? readTarget("store") : null;
+    for (const [profileId, expectedSha256] of expectedProfiles) {
+      if (digestAuthProfileMigrationValue(store?.profiles?.[profileId]) !== expectedSha256) {
+        throw new Error("auth profile migration target verification failed");
       }
     }
     if (receipt.expectedStateSha256) {
-      const row =
-        targetStoreKey === "shared"
-          ? projectSharedStateCell(
-              executeSqliteQueryTakeFirstSync(
-                db,
-                getNodeSqliteKysely<SharedAuthProfileTargetDatabase>(db)
-                  .selectFrom("config_machine_state")
-                  .select("value_json")
-                  .where("state_key", "=", "authProfiles.state"),
-              ),
-            )
-          : executeSqliteQueryTakeFirstSync(
-              db,
-              getNodeSqliteKysely<AuthProfileTargetDatabase>(db)
-                .selectFrom("auth_profile_state")
-                .select("state_json")
-                .where("state_key", "=", "primary"),
-            );
-      const state = typeof row?.state_json === "string" ? JSON.parse(row.state_json) : null;
-      if (digestAuthProfileMigrationValue(state) !== receipt.expectedStateSha256) {
+      if (digestAuthProfileMigrationValue(readTarget("state")) !== receipt.expectedStateSha256) {
         throw new Error("auth profile migration target verification failed");
       }
     }
@@ -356,7 +324,10 @@ export function finalizeAuthProfileMigrationSource(
   }
 }
 
-export function resumePendingAuthProfileMigrationArchives(env?: NodeJS.ProcessEnv): string[] {
+export function resumePendingAuthProfileMigrationArchives(
+  env?: NodeJS.ProcessEnv,
+  recoverCompleted?: (receipt: AuthProfileMigrationSourceReceipt) => boolean,
+): string[] {
   const changes: string[] = [];
   const database = openOpenClawStateDatabase({ env });
   const kysely = getNodeSqliteKysely<MigrationDatabase>(database.db);
@@ -374,13 +345,31 @@ export function resumePendingAuthProfileMigrationArchives(env?: NodeJS.ProcessEn
         "source.target_table",
         "source.last_run_id",
         "source.report_json",
+        "source.status",
       ])
       .where("source.migration_kind", "=", MIGRATION_KIND)
-      .where("source.status", "=", "imported")
-      .where("source.removed_source", "=", 0),
+      .where((eb) =>
+        eb.or([
+          eb.and([eb("source.status", "=", "imported"), eb("source.removed_source", "=", 0)]),
+          eb.and([eb("source.status", "=", "completed"), eb("source.removed_source", "=", 1)]),
+        ]),
+      ),
   ).rows;
   for (const row of rows) {
     const report = JSON.parse(row.report_json) as Record<string, unknown>;
+    const completed = row.status === "completed";
+    // A present fingerprint field (even empty) proves the modern producer ran.
+    // Completed receipts remain terminal unless Doctor proves the legacy hole.
+    if (
+      completed &&
+      (!recoverCompleted ||
+        Object.hasOwn(report, "expectedProfileSha256") ||
+        row.target_table === "auth_profile_state" ||
+        typeof report.archivePath !== "string" ||
+        !fs.existsSync(report.archivePath))
+    ) {
+      continue;
+    }
     if (
       typeof row.source_sha256 !== "string" ||
       typeof row.source_size_bytes !== "number" ||
@@ -421,20 +410,35 @@ export function resumePendingAuthProfileMigrationArchives(env?: NodeJS.ProcessEn
     const release = acquireFileLockSyncWithRetry(lockTarget);
     try {
       const sourceExists = fs.existsSync(receipt.sourcePath);
-      if (sourceExists) {
-        const sourceBytes = fs.readFileSync(receipt.sourcePath);
-        if (digestBytes(sourceBytes) !== receipt.sourceSha256) {
-          // The imported receipt describes different bytes. Retire its claim so
-          // Doctor can process the current source under a new hash-owned run.
-          retirePendingAuthProfileMigrationReceipt(receipt, "superseded");
-          changes.push("Retired an interrupted auth migration receipt for a changed source.");
+      if (completed) {
+        receipt.sourceBytes = fs.readFileSync(receipt.archivePath);
+        if (
+          digestBytes(receipt.sourceBytes) !== receipt.sourceSha256 ||
+          (sourceExists &&
+            digestBytes(fs.readFileSync(receipt.sourcePath)) !== receipt.sourceSha256) ||
+          !recoverCompleted?.(receipt)
+        ) {
           continue;
         }
-      } else {
-        const archiveBytes = fs.readFileSync(receipt.archivePath);
-        if (digestBytes(archiveBytes) !== receipt.sourceSha256) {
+        if (!sourceExists) {
+          // Keep the recorded archive until the receipt is retryable, including
+          // across a crash between restoring the source and updating SQLite.
+          fs.linkSync(receipt.archivePath, receipt.sourcePath);
+        }
+        retirePendingAuthProfileMigrationReceipt(receipt, "retryable", "completed");
+        changes.push("Reset an inconsistent completed auth migration receipt for retry.");
+        continue;
+      }
+      const bytes = fs.readFileSync(sourceExists ? receipt.sourcePath : receipt.archivePath);
+      if (digestBytes(bytes) !== receipt.sourceSha256) {
+        if (!sourceExists) {
           throw new Error("legacy auth archive verification failed");
         }
+        // A changed live source gets its own hash-owned run; a changed archive
+        // cannot prove the original credentials and must never be restored.
+        retirePendingAuthProfileMigrationReceipt(receipt, "superseded");
+        changes.push("Retired an interrupted auth migration receipt for a changed source.");
+        continue;
       }
       try {
         verifyAuthProfileMigrationTarget(receipt);
@@ -461,11 +465,7 @@ export function resumePendingAuthProfileMigrationArchives(env?: NodeJS.ProcessEn
         continue;
       }
       archiveAuthProfileMigrationSource(receipt);
-      recordAuthProfileMigrationCompleted(
-        receipt,
-        Date.now(),
-        receipt.completionStatus ?? "completed",
-      );
+      recordAuthProfileMigrationCompleted(receipt, Date.now(), receipt.completionStatus);
     } finally {
       release();
     }


### PR DESCRIPTION
Related: #134608 — credentials stranded behind completed migration receipts, reported by @erameson. Completes the approved historical-receipt recovery scope following #134952.

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --fix` could not recover archived credentials after an older migration left a completed receipt but no corresponding credentials in canonical storage.

## Why This Change Was Made

The v2026.8.1 shared-store receipt producer omitted credential fingerprints. #134952 corrected new receipts; this change reopens only the approved historical case: a completed receipt **without a fingerprint field**, no surviving migration profile rows in the **current canonical owner**, and a retained archive whose bytes match the recorded hash. The existing terminal replay guard remains intact. Present fingerprint fields (including empty maps), surviving or malformed rows, unreadable stores, ambiguous legacy OpenAI aliases, missing archives, and modified archives do not authorize recovery.

Doctor discovers eligible archived sources before asking for repair, revalidates after confirmation, restores without clobbering another source, and retains the recorded archive across interruption. It then uses the existing import, canonical readback, fingerprint, and completion flow. No runtime fallback, configuration, environment variable, schema, protocol, or dependency change.

The repair absorbs duplicated source discovery, credential merge, and receipt target-reading code. Production **+206/-206 (net 0)**; tests **+143/-0**; docs **+2/-0**.

## User Impact

An affected operator can run `openclaw doctor --fix` to recover without manually changing receipt tables or restoring the whole installation. Unrelated credentials remain untouched. A recovered migration receives modern fingerprints, so subsequent deliberate credential removal remains non-replayable. See the [Doctor migration contract](https://docs.openclaw.ai/cli/doctor#legacy-state-migration).

Thanks @erameson for the report. The original incident's damaged disk artifacts were lost during rollback, so this patch does not claim a complete forensic reconstruction of that installation.

## Evidence

Before production changes, the recovery regression failed on both legacy-main and shared-state layouts because the archived profile remained missing. On the final rebased head, all **25 focused tests passed**: 24 recovery/non-recovery cases plus the existing terminal OAuth replay guard. Cases cover all three required conditions, unrelated profiles, empty fingerprint maps, partial/malformed rows, legacy IDs, tampering, declined repair, restored source bytes, interruption during restoration, convergence, and deletion after recovery.

```sh
node scripts/run-vitest.mjs src/commands/doctor-auth-flat-profiles.test.ts -t 'completed receipt recovery|archives restored OAuth bytes'
```

The final five-file owner/sibling run passed **123 tests** (100 command tests and 23 shared-store migration tests). The earlier cold run hit one 120-second relocation-test timeout while the host was congested; the warm rerun passed without changing the timeout. An earlier three-file run also passed 77 tests.

```sh
node scripts/run-vitest.mjs src/commands/doctor-auth-flat-profiles.test.ts src/commands/doctor-auth-migration-receipts.test.ts src/commands/doctor-auth-shared-receipt.test.ts src/commands/doctor-auth-migration-inherited-oauth.test.ts src/infra/state-migrations.shared-auth-store.test.ts
```

The changed-file gate passed core and core-test typechecks, then found missing braces in nine new test conditionals. Those test-only lint errors were corrected; all 25 focused tests and the matching targeted core lint invocation passed again. The full changed-file rerun passed formatting, core/core-test typechecks, guards, dead-export scans, and lint, then was stopped at the maintainer-decision checkpoint while its database-first scan was still running; a complete pass is not claimed.

**Landing blocker:** CI run 33532507822 independently fails its lint preparation and extension package-boundary jobs on TS7056 in unchanged `packages/gateway-protocol/src/schema/protocol-schemas.ts:20`. A narrow declaration reproduction passes before #133799 and fails afterward. A separate, verified type-only repair is preserved on `fix/protocol-registry-declaration` at `dfc8940320c87ca13151c6afb6b3dc043fea0a8a` without a PR. It requires 17 added declaration lines, so it is held pending an explicit exception to this assignment’s net-zero production rule; this auth PR does not include it. No merge or issue closure is claimed.

Independent Codex autoreview passed in both uncommitted and branch modes with no accepted/actionable findings at its configured P0 threshold. Direct dependency inspection included Codex `codex-rs/login/src/auth/storage.rs` and `codex-rs/login/src/token_data.rs`; external Codex authentication is unchanged.

The initial full build was intentionally stopped during declaration-only generation after the last safety correction. The final `gatewayWatch` runtime profile passed, including all 53 built control-plane modules and 12 postbuild phases. The generated Doctor chunk was inspected to confirm the final archive-preserving hard-link operation before live proof.

### Live fault-injection proof

Built runtime head `dd35e230094758a2220ee58ad64bc5934f3f7ae5`; the subsequent commit changes test braces only, with byte-identical production sources. The real CLI used a disposable home/state/config directory, a scrubbed environment, synthetic credentials, external service-repair ownership, and free loopback port 64863 (not 18789). No operator gateway or state was used. The preloader performed the real archive rename, then exited 86 before receipt completion. The fixture removed its canonical credential row and wrote the pre-fingerprint completed receipt shape.

```text
$ node openclaw.mjs doctor --fix --non-interactive --no-workspace-suggestions
bootstrap: exit=0
$ node --import <fault-preloader> openclaw.mjs doctor --fix --non-interactive --no-workspace-suggestions
interrupted: exit=86
fixture: completed receipt without fingerprints; archived source; no destination credentials
$ node openclaw.mjs doctor --fix --non-interactive --no-workspace-suggestions
recovery: exit=0; credential restored; fingerprinted completion
repeat: exit=0; converged
$ node openclaw.mjs models auth list --provider openai --json
credential-readback: exit=0; openai:default present
$ node openclaw.mjs gateway run --port 64863
isolated gateway: healthy; stopped after verification
fixture: deliberately remove canonical credential after fingerprinted completion
$ node openclaw.mjs doctor --fix --non-interactive --no-workspace-suggestions
modern-deletion: exit=0; credential stays absent; receipt unchanged
AUTH_COMPLETED_RECEIPT_RECOVERY_PASS
```

Credential values were never printed. Local-only detailed logs were inspected through the fixture's assertions; the transcript above contains only commands and verified outcomes.

### Follow-up pass

NO-FOLLOW-UP: the useful nearby source-discovery, import-merge, and shared/agent receipt-reader simplifications are included; a separate module split would add scope without strengthening this recovery invariant.
