### PR TITLE
fix(ui): qualify catalog progress-card session keys

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -543,6 +543,7 @@ function renderCatalogSessionRow(
       style=${color ? `--session-color: var(--session-color-${color})` : nothing}
       data-session-key=${key}
       data-catalog-session-key=${identityKey}
+      data-progress-session-key=${paneKey}
       data-session-row-action-count="1"
       role="listitem"
       @contextmenu=${openMenuFromEvent}

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -53,6 +53,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   private activeTarget: HTMLElement | null = null;
   private activeTrigger: HTMLElement | null = null;
   private activeSessionKey: string | null = null;
+  private activeProgressSessionKey: string | null = null;
   private activePullRequestKey: string | null = null;
   private suppressFocusOpen = false;
   private open = false;
@@ -176,11 +177,11 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   }
 
   private readonly handleProgressCardUpdate = () => {
-    const sessionKey = this.activeSessionKey;
-    if (!sessionKey || !this.open || !this.hovercard.held) {
+    const progressSessionKey = this.activeProgressSessionKey;
+    if (!progressSessionKey || !this.open || !this.hovercard.held) {
       return;
     }
-    const card = this.progressCards?.get(sessionKey);
+    const card = this.progressCards?.get(progressSessionKey);
     if (card !== undefined) {
       this.lastProgressCard = card;
     }
@@ -285,7 +286,12 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     if (!sessionKey) {
       return;
     }
-    if (target === this.activeTarget && sessionKey === this.activeSessionKey) {
+    const progressSessionKey = target.dataset.progressSessionKey ?? sessionKey;
+    if (
+      target === this.activeTarget &&
+      sessionKey === this.activeSessionKey &&
+      progressSessionKey === this.activeProgressSessionKey
+    ) {
       if (trigger !== this.activeTrigger) {
         this.hovercard.reset();
         this.activeTrigger = trigger;
@@ -295,7 +301,10 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
         } else {
           this.animateNextOpen = animateEntry;
           const generation = ++this.loadGeneration;
-          this.hovercard.scheduleOpen(delay, () => void this.loadAndShow(sessionKey, generation));
+          this.hovercard.scheduleOpen(
+            delay,
+            () => void this.loadAndShow(sessionKey, progressSessionKey, generation),
+          );
         }
       }
       return;
@@ -304,10 +313,11 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.activeTarget = target;
     this.activeTrigger = trigger;
     this.activeSessionKey = sessionKey;
+    this.activeProgressSessionKey = progressSessionKey;
     this.open = false;
     this.animateNextOpen = animateEntry;
     this.lastProgressCard = null;
-    this.progressCards?.watch(this, [sessionKey]);
+    this.progressCards?.watch(this, [progressSessionKey]);
     this.hovercard.markTrigger(trigger);
     this.activeTargetObserver.observe(this, {
       attributes: true,
@@ -316,10 +326,17 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       subtree: true,
     });
     const generation = ++this.loadGeneration;
-    this.hovercard.scheduleOpen(delay, () => void this.loadAndShow(sessionKey, generation));
+    this.hovercard.scheduleOpen(
+      delay,
+      () => void this.loadAndShow(sessionKey, progressSessionKey, generation),
+    );
   }
 
-  private async loadAndShow(sessionKey: string, generation: number): Promise<void> {
+  private async loadAndShow(
+    sessionKey: string,
+    progressSessionKey: string,
+    generation: number,
+  ): Promise<void> {
     const target = this.activeTarget;
     if (target instanceof HTMLAnchorElement && target.dataset.sessionKey === sessionKey) {
       void this.sessionLinkTitler.decorate(target, true);
@@ -327,6 +344,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     if (
       generation !== this.loadGeneration ||
       this.activeSessionKey !== sessionKey ||
+      this.activeProgressSessionKey !== progressSessionKey ||
       !target ||
       sessionHovercardMenuOpen(this) ||
       !this.hovercard.held
@@ -339,13 +357,14 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.watchPullRequests(sessionKey);
     this.showCurrent();
     try {
-      await this.progressCards?.load(sessionKey);
+      await this.progressCards?.load(progressSessionKey);
     } catch {
       // Session facts and the last successful card remain useful when refresh fails.
     }
     if (
       generation === this.loadGeneration &&
       this.activeSessionKey === sessionKey &&
+      this.activeProgressSessionKey === progressSessionKey &&
       this.hovercard.held
     ) {
       this.showCurrent();
@@ -376,7 +395,8 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   private showCurrent(): void {
     const target = this.activeTarget;
     const sessionKey = this.activeSessionKey;
-    if (!target || !sessionKey || !this.open) {
+    const progressSessionKey = this.activeProgressSessionKey;
+    if (!target || !sessionKey || !progressSessionKey || !this.open) {
       return;
     }
     const sidebarRow =
@@ -386,7 +406,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     const pullRequests = this.activePullRequestKey
       ? this.pullRequests?.get(this.activePullRequestKey)
       : undefined;
-    const currentProgressCard = this.progressCards?.get(sessionKey);
+    const currentProgressCard = this.progressCards?.get(progressSessionKey);
     if (currentProgressCard !== undefined) {
       this.lastProgressCard = currentProgressCard;
     }
@@ -580,6 +600,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.activeTarget = null;
     this.activeTrigger = null;
     this.activeSessionKey = null;
+    this.activeProgressSessionKey = null;
     if (wasOpen) {
       this.clearSkipDelayTimer();
       this.skipDelayTimer = window.setTimeout(() => {

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -652,6 +652,7 @@ suite.define(() => {
   it("renders and dismisses synthetic catalog-session hovercards", async () => {
     const selectedSessionKey = "agent:main:catalog-selected";
     const catalogSessionKey = "catalog:codex:gateway%3Acodex:thread-1";
+    const catalogProgressSessionKey = `agent:main:${catalogSessionKey}`;
 
     await suite.withPage(
       {
@@ -662,7 +663,7 @@ suite.define(() => {
       },
       async ({ page }) => {
         const nowSeconds = Math.floor(Date.now() / 1000);
-        await installMockGateway(page, {
+        const gateway = await installMockGateway(page, {
           featureMethods: [
             "chat.metadata",
             "chat.startup",
@@ -670,7 +671,21 @@ suite.define(() => {
             "sessions.catalog.list",
           ],
           methodResponses: {
-            "progressCard.get": { card: null },
+            "progressCard.get": {
+              cases: [
+                { match: { sessionKey: selectedSessionKey }, response: { card: null } },
+                {
+                  match: { sessionKey: catalogSessionKey },
+                  response: {
+                    __mockError: {
+                      code: "INVALID_REQUEST",
+                      message: "ownerless catalog session key rejected",
+                    },
+                  },
+                },
+                { match: { sessionKey: catalogProgressSessionKey }, response: { card: null } },
+              ],
+            },
             "sessions.list": chatSessionListResponse([
               { key: selectedSessionKey, kind: "direct", label: "Selected", updatedAt: 1 },
             ]),
@@ -712,9 +727,27 @@ suite.define(() => {
         await page.goto(controlUiSessionUrl(suite.server.baseUrl, selectedSessionKey));
         const row = page.locator(`[data-session-key="${catalogSessionKey}"]`);
         await row.waitFor({ state: "visible" });
+        expect(await row.getAttribute("data-session-key")).toBe(catalogSessionKey);
+        expect(await row.getAttribute("data-progress-session-key")).toBe(catalogProgressSessionKey);
         await row.hover();
         const card = page.locator(".session-progress-hovercard");
         await card.waitFor({ state: "visible" });
+        await expect
+          .poll(
+            async () =>
+              (await gateway.getRequests("progressCard.get")).filter(
+                (request) =>
+                  isRecord(request.params) &&
+                  request.params.sessionKey === catalogProgressSessionKey,
+              ).length,
+          )
+          .toBe(1);
+        expect(
+          (await gateway.getRequests("progressCard.get")).filter(
+            (request) =>
+              isRecord(request.params) && request.params.sessionKey === catalogSessionKey,
+          ),
+        ).toHaveLength(0);
         expect(await card.locator(".session-hovercard__title").textContent()).toBe(
           "Catalog release review",
         );


### PR DESCRIPTION
Fixes #135156

## What Problem This Solves

In explicit multi-agent setups, the Control UI sidebar can expose an ownerless native catalog key such as `catalog:codex:...`. The session progress hovercard was reusing that source/catalog identity for `progressCard.get`, so the Gateway correctly rejected the request because no owning agent was encoded.

The fix keeps the ownerless catalog identity for sidebar lookup/navigation/adoption, but gives progress-card RPCs a separate agent-qualified key derived from the existing `paneKey`.

## Summary

- preserve `data-session-key` and `data-catalog-session-key` for sidebar lookup, navigation, titling, adoption, and PR subscription behavior
- add `data-progress-session-key` from the already-established agent-qualified `paneKey`
- use the qualified progress key only for progress-card `watch`, `load`, and `get`
- keep the original source key for catalog-row lookup and all non-progress behavior

This avoids the catalog-hovercard lookup regression identified on #135223, where changing `data-session-key` itself breaks lookup against the ownerless catalog identity.

No Gateway ownership policy, probe scopes, configuration, schema, storage, or Codex behavior is changed.

## Evidence

- focused catalog-key + route-navigation unit tests: **17/17 passed**
- `ui/src/e2e/session-progress-hovercard.e2e.test.ts`: **8/8 passed**
- the catalog hovercard E2E asserts the row's source `data-session-key` remains ownerless
- the same E2E asserts `data-progress-session-key` is `agent:main:catalog:...`
- the same E2E records one qualified `progressCard.get` request and **zero** ownerless `progressCard.get` requests
- the same E2E verifies the catalog hovercard still renders its row title/context
- Control UI production build passed
- `pnpm check:changed` passed on the refreshed source tree in a native Linux Docker volume, including core-test typecheck, UI typecheck, dead-export scans, lint, i18n, formatting, dependency/patch guards, and graph-boundary checks
- `git diff --check` passed

## Real Behavior Proof

A real built Control UI was exercised in headless Chromium against a real isolated Gateway using explicit multi-agent ownership with agents `main` and `writer`, on the exact PR head `b9f05f406fc6120f946789995dc3f43488bd1896`.

Observed real-Gateway behavior:

```text
[ws] webchat connected ... client=openclaw-control-ui ... build=2026.8.1-b9f05f406fc6-2026-09-01T17-28-11.628Z
[ws] ⇄ res ✓ sessions.catalog.list ...
[ws] ⇄ res ✓ progressCard.get ...

Test Files  1 passed (1)
Tests       1 passed (1)

HEAD=b9f05f406fc6120f946789995dc3f43488bd1896
HOST_REPO_TRACKED_TREE=UNCHANGED
QUALIFIED_PROGRESS_GET_COUNT=1
OWNERLESS_PROGRESS_GET_COUNT=0
HOVERCARD_VISIBLE=True
HOVERCARD_TITLE=Catalog release review
QUALIFIED_PROGRESS_GET_OK=True
```

The proof harness also validated:

- Gateway ownership mode: `explicit`
- agent roster: `main`, `writer`
- source catalog identity remained `catalog:codex:gateway%3Acodex:thread-1`
- progress key was `agent:main:catalog:codex:gateway%3Acodex:thread-1`
- the real Gateway successfully answered the qualified `progressCard.get`
- no ownerless `progressCard.get` was emitted
- the real browser hovercard remained visible with title `Catalog release review`
- the tracked PR checkout remained unchanged during proof

Validated head: `b9f05f406fc6120f946789995dc3f43488bd1896`

Validated base before push: `2cedaddb5e23848d4358faddcd609afb6570fa94`