### PR TITLE
fix(sessions): bound SQLite transcript archive filenames

### DIFF
--- a/extensions/memory-core/src/session-ingestion.ts
+++ b/extensions/memory-core/src/session-ingestion.ts
@@ -118,7 +118,7 @@ export function sessionIngestionSourceFromCorpus(
   const scope =
     entry.transcriptSource === "sqlite"
       ? `${entry.agentId}:${sessionPath}`
-      : buildSessionScope(entry.agentId, path.basename(entry.sessionFile));
+      : buildSessionScope(entry.agentId, entry.sessionId);
   return {
     agentId: entry.agentId,
     absolutePath: entry.sessionFile,

--- a/extensions/memory-core/src/session-search-reset-recall-visibility.test.ts
+++ b/extensions/memory-core/src/session-search-reset-recall-visibility.test.ts
@@ -29,6 +29,7 @@ vi.mock("openclaw/plugin-sdk/memory-core-host-engine-sessions", async (importOri
   return {
     ...actual,
     buildSessionEntry: vi.fn(async () => entryWithCutoff({ state: "absent" })),
+    loadArchivedSessions: vi.fn(() => []),
   };
 });
 
@@ -51,7 +52,49 @@ describe("reset-generation session search visibility", () => {
     vi.mocked(engineSessions.buildSessionEntry).mockResolvedValue(
       entryWithCutoff({ state: "absent" }) as never,
     );
+    vi.mocked(engineSessions.loadArchivedSessions).mockReset();
+    vi.mocked(engineSessions.loadArchivedSessions).mockReturnValue([]);
     combinedSessionStore = {};
+  });
+
+  it("resolves bounded archive filenames through canonical SQLite identity", async () => {
+    const sessionId = `oversized-${"x".repeat(300)}`;
+    const sessionKey = "agent:main:telegram:direct:owner";
+    const archiveName =
+      "session-aa13e98ac2c9f443812f1871d56ffcb3.jsonl.reset.2026-08-11T08-00-00.000Z.zst";
+    combinedSessionStore = {
+      [sessionKey]: {
+        sessionId,
+        updatedAt: 2,
+        sessionFile: `/tmp/sessions/${sessionId}.jsonl`,
+        chatType: "direct",
+      },
+    };
+    vi.mocked(engineSessions.loadArchivedSessions).mockReturnValue([
+      { archiveName, sessionId, sessionKey, createdAt: 1 },
+    ]);
+    const hit: MemorySearchResult = {
+      path: `sessions/main/${archiveName}`,
+      source: "sessions",
+      score: 1,
+      snippet: "retained context",
+      startLine: 1,
+      endLine: 2,
+    };
+
+    await expect(
+      filterMemorySearchHitsBySessionVisibility({
+        cfg: asOpenClawConfig({ tools: { sessions: { visibility: "self" } } }),
+        agentId: "main",
+        requesterSessionKey: sessionKey,
+        sandboxed: false,
+        hits: [hit],
+      }),
+    ).resolves.toEqual([hit]);
+    expect(engineSessions.loadArchivedSessions).toHaveBeenCalledWith({
+      agentId: "main",
+      archiveNames: [archiveName],
+    });
   });
 
   it.each([

--- a/extensions/memory-core/src/session-search-visibility.ts
+++ b/extensions/memory-core/src/session-search-visibility.ts
@@ -1,6 +1,9 @@
 import { resolveSessionAgentIdStrict } from "openclaw/plugin-sdk/agent-scope-runtime";
 // Memory Core plugin module implements session search visibility behavior.
-import { buildSessionEntry } from "openclaw/plugin-sdk/memory-core-host-engine-sessions";
+import {
+  buildSessionEntry,
+  loadArchivedSessions,
+} from "openclaw/plugin-sdk/memory-core-host-engine-sessions";
 import {
   resolveCanonicalMainSessionKey,
   type OpenClawConfig,
@@ -373,9 +376,15 @@ export async function filterMemorySearchHitsBySessionVisibility(params: {
     const archivedOwnerAgentId = archivedOwnerMatchesScope
       ? (identity.ownerAgentId ?? scopedAgentId)
       : undefined;
+    const canonicalArchive = identity.archived
+      ? loadArchivedSessions({
+          agentId: identity.ownerAgentId ?? scopedAgentId,
+          archiveNames: [hit.path.replace(/\\/g, "/").split("/").at(-1) ?? ""],
+        })[0]
+      : undefined;
     const resolvedKeys = resolveTranscriptStemToSessionKeys({
       store: combinedSessionStore,
-      stem: identity.stem,
+      stem: canonicalArchive?.sessionId ?? identity.stem,
       ...(archivedOwnerAgentId ? { archivedOwnerAgentId } : {}),
     });
     const keys = filterSessionKeysByScopedAgent({

--- a/packages/memory-host-sdk/src/host/openclaw-runtime-session.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime-session.ts
@@ -27,6 +27,7 @@ export {
 export { materializeSessionArchiveForRead } from "../../../../src/config/sessions/archive-compression.js";
 export { canonicalizeMainSessionAlias } from "../../../../src/config/sessions/main-session.js";
 export {
+  listSessionTranscriptArchivesReadOnly,
   listSessionTranscriptInstances,
   type SessionTranscriptInstance,
 } from "../../../../src/config/sessions/session-history.js";

--- a/packages/memory-host-sdk/src/host/session-transcript-corpus.ts
+++ b/packages/memory-host-sdk/src/host/session-transcript-corpus.ts
@@ -11,6 +11,7 @@ import {
   isSessionArchiveArtifactName,
   isUsageCountedSessionTranscriptFileName,
   listSessionEntries,
+  listSessionTranscriptArchivesReadOnly,
   listSessionTranscriptInstances,
   parseUsageCountedSessionIdFromFileName,
   readTranscriptContentRevisionSync,
@@ -351,6 +352,13 @@ export function listSessionTranscriptCorpusEntriesForAgentSync(
         storePath,
       })
     : [];
+  const archivedIdentitiesByName = new Map(
+    listSessionTranscriptArchivesReadOnly({
+      agentId: normalizedAgentId,
+      includeAll: true,
+      storePath,
+    }).map((archive) => [archive.archiveName, archive]),
+  );
   const cronGeneratedSessionKeys = collectCronGeneratedSessionKeys([
     ...retainedInstances.map(({ entry, sessionKey }) => ({ entry, sessionKey })),
     ...sessionEntries,
@@ -424,7 +432,10 @@ export function listSessionTranscriptCorpusEntriesForAgentSync(
         continue;
       }
       scannedArtifactPaths.add(normalizedArtifactPath);
-      const primarySessionId = parseUsageCountedSessionIdFromFileName(path.basename(artifactPath));
+      const artifactName = path.basename(artifactPath);
+      const archivedIdentity = archivedIdentitiesByName.get(artifactName);
+      const primarySessionId =
+        archivedIdentity?.sessionId ?? parseUsageCountedSessionIdFromFileName(artifactName);
       if (!primarySessionId) {
         continue;
       }
@@ -436,9 +447,11 @@ export function listSessionTranscriptCorpusEntriesForAgentSync(
       if (!primaryOwner && !includeUnownedArtifacts) {
         continue;
       }
-      corpusEntries.push(
-        toArtifactCorpusEntry(normalizedAgentId, artifactPath, primarySessionId, primaryEntry),
-      );
+      corpusEntries.push({
+        ...toArtifactCorpusEntry(normalizedAgentId, artifactPath, primarySessionId, primaryEntry),
+        ...(archivedIdentity?.sessionKey ? { sessionKey: archivedIdentity.sessionKey } : {}),
+        ...(archivedIdentity ? { storePath } : {}),
+      });
     }
   }
   return corpusEntries;

--- a/src/config/sessions/session-accessor.sqlite-archive.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.ts
@@ -90,7 +90,7 @@ export type TranscriptArchivePublishWorkerMessage = {
   results: TranscriptArchivePublishResult[];
 };
 
-function resolveSqliteTranscriptArchivePath(params: {
+export function resolveSqliteTranscriptArchivePath(params: {
   archiveDirectory: string;
   generation?: string;
   reason: SessionArchiveReason;

--- a/src/config/sessions/session-accessor.sqlite-archive.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.ts
@@ -61,6 +61,15 @@ export type TranscriptArchiveWorkerMessage = {
 
 export const MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES = 256 * 1024 * 1024;
 
+const MAX_ARCHIVE_SESSION_ID_BYTES = 96;
+
+function resolveArchiveSessionIdComponent(sessionId: string): string {
+  if (Buffer.byteLength(sessionId, "utf8") <= MAX_ARCHIVE_SESSION_ID_BYTES) {
+    return sessionId;
+  }
+  return `session-${createHash("sha256").update(sessionId).digest("hex").slice(0, 32)}`;
+}
+
 export type TranscriptArchivePublishPlan = {
   agentId: string;
   archiveDirectory: string;
@@ -92,7 +101,7 @@ function resolveSqliteTranscriptArchivePath(params: {
   const generationSuffix = params.generation ? `.${params.generation}` : "";
   const archivePath = path.resolve(
     archiveDirectory,
-    `${params.sessionId}.jsonl.${params.reason}.${formatSessionArchiveTimestamp(params.nowMs)}${generationSuffix}`,
+    `${resolveArchiveSessionIdComponent(params.sessionId)}.jsonl.${params.reason}.${formatSessionArchiveTimestamp(params.nowMs)}${generationSuffix}`,
   );
   if (path.dirname(archivePath) !== archiveDirectory) {
     throw new Error(`Cannot archive SQLite transcript outside ${archiveDirectory}`);

--- a/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
@@ -22,7 +22,10 @@ import {
   loadTranscriptEvents,
   replaceSessionEntry,
 } from "./session-accessor.js";
-import { materializeSessionStateDeletePlans } from "./session-accessor.sqlite-archive.js";
+import {
+  materializeSessionStateDeletePlans,
+  publishEncodedSessionTranscriptArchive,
+} from "./session-accessor.sqlite-archive.js";
 import {
   deleteMaterializedSessionStatePlans,
   planSessionStateDeleteIfUnreferenced,
@@ -58,6 +61,32 @@ describe("SQLite transcript archive worker", () => {
     });
     closeOpenClawAgentDatabasesForTest();
     fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("bounds archive filenames for oversized session IDs", async () => {
+    const sessionId = `oversized-${"x".repeat(300)}`;
+    const sessionKey = "agent:main:oversized-archive-session";
+    await replaceSessionEntry({ sessionKey, storePath }, { sessionId, updatedAt: Date.now() });
+    await replaceTranscriptEvents({ sessionKey, sessionId, storePath }, [
+      createTranscriptEvent("oversized-event", "archive me"),
+    ]);
+
+    const database = openLifecycleTestDatabase(storePath);
+    const plan = planArchiveWorker(database, path.dirname(storePath), sessionId);
+    const materialized = await materializeSessionStateDeletePlans([plan]);
+    const archive = materialized[0]?.archive;
+    expect(archive).toBeTruthy();
+
+    const archivedPath = publishEncodedSessionTranscriptArchive({
+      archiveDirectory: plan.archiveDirectory,
+      archiveName: archive?.archiveName ?? "",
+      bytes: archive?.bytes ?? new Uint8Array(),
+      sha256: archive?.sha256 ?? "",
+    });
+
+    expect(Buffer.byteLength(path.basename(archivedPath), "utf8")).toBeLessThan(256);
+    expect(path.basename(archivedPath)).toMatch(/^session-[a-f0-9]{32}\.jsonl\.deleted\./);
+    expect(readSessionArchiveContentSync(archivedPath)).toContain("oversized-event");
   });
 
   it("keeps the event loop responsive while a transcript archive is built", async () => {

--- a/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { recordAcpParentStreamEvents } from "../../agents/subagents/spawn/acp-parent-stream-store.sqlite.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import { listUsageCountedTranscriptStats } from "../../infra/session-cost-usage-collection.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -22,10 +23,7 @@ import {
   loadTranscriptEvents,
   replaceSessionEntry,
 } from "./session-accessor.js";
-import {
-  materializeSessionStateDeletePlans,
-  publishEncodedSessionTranscriptArchive,
-} from "./session-accessor.sqlite-archive.js";
+import { materializeSessionStateDeletePlans } from "./session-accessor.sqlite-archive.js";
 import {
   deleteMaterializedSessionStatePlans,
   planSessionStateDeleteIfUnreferenced,
@@ -71,22 +69,26 @@ describe("SQLite transcript archive worker", () => {
       createTranscriptEvent("oversized-event", "archive me"),
     ]);
 
-    const database = openLifecycleTestDatabase(storePath);
-    const plan = planArchiveWorker(database, path.dirname(storePath), sessionId);
-    const materialized = await materializeSessionStateDeletePlans([plan]);
-    const archive = materialized[0]?.archive;
-    expect(archive).toBeTruthy();
-
-    const archivedPath = publishEncodedSessionTranscriptArchive({
-      archiveDirectory: plan.archiveDirectory,
-      archiveName: archive?.archiveName ?? "",
-      bytes: archive?.bytes ?? new Uint8Array(),
-      sha256: archive?.sha256 ?? "",
+    const result = await deleteSessionEntryLifecycle({
+      archiveTranscript: true,
+      storePath,
+      target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
     });
+    const archivedPath = result.archivedTranscripts[0]?.archivedPath ?? "";
 
     expect(Buffer.byteLength(path.basename(archivedPath), "utf8")).toBeLessThan(256);
     expect(path.basename(archivedPath)).toMatch(/^session-[a-f0-9]{32}\.jsonl\.deleted\./);
     expect(readSessionArchiveContentSync(archivedPath)).toContain("oversized-event");
+    expect(
+      openLifecycleTestDatabase(storePath)
+        .db.prepare(
+          "SELECT session_id, session_key FROM session_transcript_archives WHERE archive_name = ?",
+        )
+        .get(path.basename(archivedPath)),
+    ).toEqual({ session_id: sessionId, session_key: sessionKey });
+    await expect(
+      listUsageCountedTranscriptStats("main", { sessionsDir: path.dirname(storePath) }),
+    ).resolves.toEqual([expect.objectContaining({ sessionId })]);
   });
 
   it("keeps the event loop responsive while a transcript archive is built", async () => {

--- a/src/config/sessions/session-accessor.sqlite-archive.worker.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.ts
@@ -1,13 +1,18 @@
 /** Worker entrypoint for SQLite transcript archive materialization off the gateway event loop. */
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { pipeline } from "node:stream/promises";
 import { parentPort, workerData } from "node:worker_threads";
+import zlib from "node:zlib";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
-  encodeMaterializedSessionTranscriptArchive,
   hashSessionArchiveBytes,
   MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES,
   publishEncodedSessionTranscriptArchive,
+  resolveSqliteTranscriptArchivePath,
   type TranscriptArchivePublishPlan,
   type TranscriptArchivePublishResult,
   type TranscriptArchivePublishWorkerMessage,
@@ -20,7 +25,6 @@ import {
   sqliteSessionStateDeleteSnapshotsEqual,
 } from "./session-accessor.sqlite-delete-snapshot.js";
 import type { SessionStateDeleteSnapshot } from "./session-accessor.sqlite-delete-snapshot.types.js";
-import { serializeJsonlLines } from "./transcript-jsonl.js";
 
 type TranscriptArchiveDatabase = Pick<
   OpenClawAgentKyselyDatabase,
@@ -134,72 +138,142 @@ function parseWorkerPlans(value: unknown): TranscriptArchiveWorkerPlan[] | undef
   return parsed;
 }
 
-function readTranscriptArchiveContent(
+function stageTranscriptArchiveContent(
   database: import("node:sqlite").DatabaseSync,
   sessionId: string,
-): string {
-  const db = getNodeSqliteKysely<TranscriptArchiveDatabase>(database);
-  const lines = executeSqliteQuerySync(
-    database,
-    db
-      .selectFrom("transcript_events")
-      .select("event_json")
-      .where("session_id", "=", sessionId)
-      .orderBy("seq", "asc"),
-  ).rows.map((row) => row.event_json);
-  return serializeJsonlLines(lines);
+  stagedPath: string,
+): number {
+  const fd = fs.openSync(stagedPath, "wx", 0o600);
+  let rowCount = 0;
+  try {
+    const rows = database
+      .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? ORDER BY seq ASC")
+      .iterate(sessionId);
+    for (const row of rows) {
+      if (typeof row.event_json !== "string") {
+        throw new Error(`Invalid transcript event row for ${sessionId}`);
+      }
+      fs.writeSync(fd, row.event_json);
+      fs.writeSync(fd, "\n");
+      rowCount += 1;
+    }
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  return rowCount;
 }
 
-export function materializeTranscriptArchiveInWorker(
+async function encodeStagedTranscriptArchive(params: {
+  archiveDirectory: string;
+  generation: string;
+  reason: "deleted" | "reset";
+  sessionId: string;
+  stagedPath: string;
+}): Promise<NonNullable<TranscriptArchiveWorkerResult["archive"]>> {
+  const createdAt = Date.now();
+  const optionalZlib: Partial<typeof zlib> = zlib;
+  const createZstdCompress = optionalZlib.createZstdCompress;
+  const compressed = typeof createZstdCompress === "function";
+  const archivePath = `${resolveSqliteTranscriptArchivePath({
+    archiveDirectory: params.archiveDirectory,
+    generation: params.generation,
+    reason: params.reason,
+    sessionId: params.sessionId,
+    nowMs: createdAt,
+  })}${compressed ? ".zst" : ""}`;
+  const encodedPath = `${archivePath}.${randomUUID()}.stage`;
+  try {
+    if (compressed) {
+      await pipeline(
+        fs.createReadStream(params.stagedPath),
+        createZstdCompress.call(zlib),
+        fs.createWriteStream(encodedPath, { flags: "wx", mode: 0o600 }),
+      );
+    } else {
+      fs.copyFileSync(params.stagedPath, encodedPath, fs.constants.COPYFILE_EXCL);
+    }
+    const size = fs.statSync(encodedPath).size;
+    if (size > MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES) {
+      throw new Error(
+        `Archive exceeds ${MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES} bytes after encoding`,
+      );
+    }
+    const bytes = fs.readFileSync(encodedPath);
+    return {
+      archiveName: path.basename(archivePath),
+      bytes,
+      createdAt,
+      encoding: compressed ? "zstd" : "identity",
+      sha256: hashSessionArchiveBytes(bytes),
+    };
+  } finally {
+    fs.rmSync(encodedPath, { force: true });
+  }
+}
+
+export async function materializeTranscriptArchiveInWorker(
   plan: TranscriptArchiveWorkerPlan,
-): TranscriptArchiveWorkerResult {
-  const opened = withOpenClawAgentDatabaseReadOnly(
-    (database) => {
-      let transactionOpen = false;
-      try {
-        // sqlite-allow-raw: metadata and transcript rows must come from one read snapshot.
-        database.db.exec("BEGIN");
-        transactionOpen = true;
-        const snapshot = readSessionStateDeleteSnapshot(database.db, plan.sessionId);
-        if (!sqliteSessionStateDeleteSnapshotsEqual(snapshot, plan.snapshot)) {
-          throw new Error(
-            `SQLite session state changed before archive materialization for ${plan.sessionId}`,
-          );
+): Promise<TranscriptArchiveWorkerResult> {
+  fs.mkdirSync(plan.archiveDirectory, { recursive: true, mode: 0o700 });
+  const stagedPath = `${resolveSqliteTranscriptArchivePath({
+    archiveDirectory: plan.archiveDirectory,
+    generation: plan.snapshot.generation ?? undefined,
+    reason: plan.reason,
+    sessionId: plan.sessionId,
+  })}.${randomUUID()}.jsonl-stage`;
+  try {
+    const opened = withOpenClawAgentDatabaseReadOnly(
+      (database) => {
+        let transactionOpen = false;
+        try {
+          // sqlite-allow-raw: metadata and transcript rows must come from one read snapshot.
+          database.db.exec("BEGIN");
+          transactionOpen = true;
+          const snapshot = readSessionStateDeleteSnapshot(database.db, plan.sessionId);
+          if (!sqliteSessionStateDeleteSnapshotsEqual(snapshot, plan.snapshot)) {
+            throw new Error(
+              `SQLite session state changed before archive materialization for ${plan.sessionId}`,
+            );
+          }
+          const rowCount = stageTranscriptArchiveContent(database.db, plan.sessionId, stagedPath);
+          database.db.exec("COMMIT"); // sqlite-allow-raw: closes the consistent read snapshot.
+          transactionOpen = false;
+          return { rowCount, snapshot };
+        } catch (error) {
+          if (transactionOpen) {
+            database.db.exec("ROLLBACK"); // sqlite-allow-raw: releases a failed read snapshot.
+          }
+          throw error;
         }
-        const content = readTranscriptArchiveContent(database.db, plan.sessionId);
-        database.db.exec("COMMIT"); // sqlite-allow-raw: closes the consistent read snapshot.
-        transactionOpen = false;
-        return { content, snapshot };
-      } catch (error) {
-        if (transactionOpen) {
-          database.db.exec("ROLLBACK"); // sqlite-allow-raw: releases a failed read snapshot.
-        }
-        throw error;
-      }
-    },
-    { agentId: plan.agentId, path: plan.databasePath },
-  );
-  if (!opened.found) {
-    throw new Error(
-      `Cannot archive SQLite transcript ${plan.sessionId}: ${opened.reason.replaceAll("-", " ")}`,
+      },
+      { agentId: plan.agentId, path: plan.databasePath },
     );
+    if (!opened.found) {
+      throw new Error(
+        `Cannot archive SQLite transcript ${plan.sessionId}: ${opened.reason.replaceAll("-", " ")}`,
+      );
+    }
+    const generation = plan.snapshot.generation;
+    if (opened.value.rowCount > 0 && !generation) {
+      throw new Error(
+        `Cannot archive SQLite transcript without a generation for ${plan.sessionId}`,
+      );
+    }
+    const archive =
+      opened.value.rowCount > 0 && generation
+        ? await encodeStagedTranscriptArchive({
+            archiveDirectory: plan.archiveDirectory,
+            generation,
+            reason: plan.reason,
+            sessionId: plan.sessionId,
+            stagedPath,
+          })
+        : null;
+    return { archive, sessionId: plan.sessionId };
+  } finally {
+    fs.rmSync(stagedPath, { force: true });
   }
-  const { content } = opened.value;
-  const generation = plan.snapshot.generation;
-  if (content.length > 0 && !generation) {
-    throw new Error(`Cannot archive SQLite transcript without a generation for ${plan.sessionId}`);
-  }
-  const archive =
-    content.length > 0 && generation
-      ? encodeMaterializedSessionTranscriptArchive({
-          archiveDirectory: plan.archiveDirectory,
-          content,
-          generation,
-          reason: plan.reason,
-          sessionId: plan.sessionId,
-        })
-      : null;
-  return { archive, sessionId: plan.sessionId };
 }
 
 export function publishTranscriptArchiveInWorker(
@@ -245,13 +319,13 @@ export function publishTranscriptArchiveInWorker(
   }
 }
 
-function runWorkerPort(
+async function runWorkerPort(
   port: NonNullable<typeof parentPort>,
   plans: readonly TranscriptArchiveWorkerPlan[],
-): void {
+): Promise<void> {
   let materializedBytes = 0;
   for (const plan of plans) {
-    const result = materializeTranscriptArchiveInWorker(plan);
+    const result = await materializeTranscriptArchiveInWorker(plan);
     materializedBytes += result.archive?.bytes.byteLength ?? 0;
     if (materializedBytes > MAX_MATERIALIZED_ARCHIVE_BATCH_BYTES) {
       throw new Error(
@@ -282,7 +356,7 @@ if (isSqliteTranscriptArchiveWorkerData(workerData)) {
     if (!plans) {
       throw new Error("SQLite transcript archive worker requires valid materialization data");
     }
-    runWorkerPort(parentPort, plans);
+    await runWorkerPort(parentPort, plans);
   } else if (operation === "publish") {
     const plans = parsePublishWorkerPlans(workerData);
     if (!plans) {

--- a/src/config/sessions/session-accessor.sqlite-history.ts
+++ b/src/config/sessions/session-accessor.sqlite-history.ts
@@ -106,34 +106,42 @@ export function listTranscriptInstancesFromDatabase(params: {
 /** Read retained archive identities through the same physical and logical session owner. */
 export function listSessionTranscriptArchivesReadOnly(
   scope: Pick<SessionAccessScope, "agentId" | "env" | "storePath"> & {
-    sessionIds: readonly string[];
+    archiveNames?: readonly string[];
+    includeAll?: boolean;
+    sessionIds?: readonly string[];
   },
 ) {
-  const selectors = [...new Set(scope.sessionIds)];
-  if (selectors.length === 0) {
+  const selectors = [...new Set(scope.sessionIds ?? [])];
+  const archiveNames = [...new Set(scope.archiveNames ?? [])];
+  if (selectors.length === 0 && archiveNames.length === 0 && !scope.includeAll) {
     return [];
   }
   const resolved = resolveSqliteReadScope(scope);
   const result = withOpenClawAgentDatabaseReadOnly(({ db, agentId }) => {
-    const rows = executeSqliteQuerySync(
-      db,
-      getSessionKysely(db)
-        .selectFrom("session_transcript_archives")
-        .select([
-          "archive_name as archiveName",
-          "session_id as sessionId",
-          "session_key as sessionKey",
-          "created_at as createdAt",
-        ])
-        .where((expression) =>
-          expression.or([
-            expression("session_id", "in", selectors),
-            expression("session_key", "in", selectors),
-          ]),
-        )
-        .orderBy("created_at")
-        .orderBy("session_id"),
-    ).rows;
+    let query = getSessionKysely(db)
+      .selectFrom("session_transcript_archives")
+      .select([
+        "archive_name as archiveName",
+        "session_id as sessionId",
+        "session_key as sessionKey",
+        "created_at as createdAt",
+      ])
+      .orderBy("created_at")
+      .orderBy("session_id");
+    if (!scope.includeAll) {
+      query = query.where((expression) =>
+        expression.or([
+          ...(selectors.length > 0
+            ? [
+                expression("session_id", "in", selectors),
+                expression("session_key", "in", selectors),
+              ]
+            : []),
+          ...(archiveNames.length > 0 ? [expression("archive_name", "in", archiveNames)] : []),
+        ]),
+      );
+    }
+    const rows = executeSqliteQuerySync(db, query).rows;
     return rows.filter(
       (row) => resolveAgentIdFromSessionKey(row.sessionKey, agentId) === resolved.agentId,
     );

--- a/src/infra/session-cost-usage-collection.ts
+++ b/src/infra/session-cost-usage-collection.ts
@@ -23,6 +23,7 @@ import {
   resolveSessionTranscriptsDirForAgent,
 } from "../config/sessions/paths.js";
 import {
+  listSessionTranscriptArchivesReadOnly,
   listSessionTranscriptInstances,
   loadSessionEntry,
   loadTranscriptEventsSync,
@@ -61,7 +62,11 @@ function resolveUsageCostSessionStorePath(params: {
 
 async function listUsageCountedTranscriptFileStats(
   agentId: string,
-  params?: { minMtimeMs?: number; sessionsDir?: string },
+  params?: {
+    archiveSessionIds?: ReadonlyMap<string, string>;
+    minMtimeMs?: number;
+    sessionsDir?: string;
+  },
 ): Promise<UsageCostTranscriptFile[]> {
   const sessionsDir = params?.sessionsDir ?? resolveSessionTranscriptsDirForAgent(agentId);
   let entries: fs.Dirent[];
@@ -100,6 +105,7 @@ async function listUsageCountedTranscriptFileStats(
           return {
             filePath: materialized,
             kind: "jsonl",
+            sessionId: params?.archiveSessionIds?.get(entry.name),
             size: materializedStats.size,
             mtimeMs: stats.mtimeMs,
             device: materializedStats.dev,
@@ -115,6 +121,7 @@ async function listUsageCountedTranscriptFileStats(
       return {
         filePath,
         kind: "jsonl",
+        sessionId: params?.archiveSessionIds?.get(entry.name),
         size: stats.size,
         mtimeMs: stats.mtimeMs,
         device: stats.dev,
@@ -179,11 +186,22 @@ export async function listUsageCountedTranscriptStats(
   agentId: string,
   params?: { minMtimeMs?: number; sessionsDir?: string },
 ): Promise<UsageCostTranscriptFile[]> {
-  const fileBacked = await listUsageCountedTranscriptFileStats(agentId, params);
+  const archiveSessionIds = new Map(
+    listSessionTranscriptArchivesReadOnly({
+      agentId,
+      includeAll: true,
+      ...(params?.sessionsDir ? { storePath: path.join(params.sessionsDir, "sessions.json") } : {}),
+    }).map((archive) => [archive.archiveName, archive.sessionId]),
+  );
+  const fileBacked = await listUsageCountedTranscriptFileStats(agentId, {
+    ...params,
+    archiveSessionIds,
+  });
   const sqliteBacked = listUsageCountedSqliteTranscriptStats(agentId, params);
   const sqliteSessionIds = new Set(sqliteBacked.map((file) => file.sessionId).filter(Boolean));
   const canonicalFileBacked = fileBacked.filter((file) => {
-    const sessionId = parseUsageCountedSessionIdFromFileName(path.basename(file.filePath));
+    const sessionId =
+      file.sessionId ?? parseUsageCountedSessionIdFromFileName(path.basename(file.filePath));
     return !sessionId || !sqliteSessionIds.has(sessionId);
   });
   return [...canonicalFileBacked, ...sqliteBacked];

--- a/src/infra/session-cost-usage-reporting.ts
+++ b/src/infra/session-cost-usage-reporting.ts
@@ -66,7 +66,8 @@ export async function discoverAllSessions(params: {
     const fileName = path.basename(filePath);
     const sqliteMarker = parseSqliteSessionFileMarker(filePath);
 
-    const sessionId = sqliteMarker?.sessionId ?? parseUsageCountedSessionIdFromFileName(fileName);
+    const sessionId =
+      sqliteMarker?.sessionId ?? file.sessionId ?? parseUsageCountedSessionIdFromFileName(fileName);
     if (!sessionId) {
       continue;
     }


### PR DESCRIPTION
## Summary
- bound oversized SQLite transcript archive filenames without changing short-ID filenames
- stream transcript rows through a mode-`0600` staging file and streaming Zstandard encoder instead of materializing the transcript and compressed payload repeatedly in memory
- preserve the original session identity through the canonical `session_transcript_archives` mapping and teach usage, memory corpus, ingestion, and visibility readers to resolve bounded archive names through that mapping
- add lifecycle regressions for long session IDs across archive publication, readback, usage discovery, memory scope, and visibility

## What Problem This Solves
The original archive filename embedded `sessionId` verbatim and could exceed the filesystem component limit (`ENAMETOOLONG`). The first version of this PR bounded the filename, but that exposed a second pre-existing problem: the archive worker loaded all rows, joined the entire JSONL transcript, created a second UTF-8 buffer, synchronously compressed it into another buffer, structured-cloned that payload to the parent, inserted it as a SQLite BLOB, and read it back. A highly compressible multi-gigabyte transcript could therefore pass the 256 MiB compressed-output limit only after producing extreme transient RAM usage.

Hashing the filename also made basename-derived consumers mistake the bounded hash for the real session ID. The SQLite archive registry already stores the authoritative `archive_name -> session_id/session_key` relationship, so this change uses that canonical mapping instead of introducing sidecars or attempting to reverse a hash.

## Implementation
- iterate SQLite rows and write JSONL incrementally to a private temporary file
- stream that file through Zstandard into a second temporary file
- check the encoded file size before loading the final bounded archive BLOB
- remove staging files in `finally` paths
- retain legacy empty-selector behavior in archive history reads; explicit callers use `includeAll`
- propagate mapped session identity through compressed usage discovery and memory archive resolution

## Evidence
- observed after the fix: a 300-character session ID completed the real delete/archive lifecycle, produced a bounded archive filename, and resolved back to the exact original session identity through usage and memory readers
- focused regression shards: **139/139 passed**
- post-semantics-fix rerun: **72/72 passed**
- scoped `oxlint` across all 11 changed files: passed
- `git diff --check`: passed
- real long-ID delete/archive lifecycle: bounded filename, archive content readback, exact registry mapping, usage identity, and memory visibility verified
- archive byte-limit lifecycle under `NODE_OPTIONS=--max-old-space-size=512`: passed; `/usr/bin/time -v` reported **1,927,536 KiB** maximum RSS for the entire Vitest/compiler process tree, well below the observed ~18 GiB incident footprint (this is deliberately not represented as archive-worker-only RSS)

## Environment notes
- repository preflight checks passed, but the full typecheck/lint wrapper could not acquire `.artifacts/dist-artifacts.lock`: `@openclaw/fs-safe` returned `rename without replacement: Invalid argument (os error 22)` on this filesystem
- the required local autoreview invocation produced no review report because its isolated Codex connection repeatedly returned HTTP 401; the code/test evidence above is independent of that unavailable reviewer

Fix commit: `8d81e97532ae6f2a87e9ea5be4cf0797a136d2f4`.
