### PR TITLE
fix(routing): keep empty-id peers out of the peerless route cache slot

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -1546,10 +1546,26 @@ describe("resolved route cache keys", () => {
     );
   });
 
-  test("does not reuse a peerless cached route for the unknown direct-message route", () => {
+  test("keeps peer presence, kind, and id distinct across cached route tiers", () => {
     const cfg: OpenClawConfig = {
-      agents: { list: [{ id: "channel-wide" }, { id: "any-direct" }] },
+      agents: {
+        list: [
+          { id: "channel-wide" },
+          { id: "account-wide" },
+          { id: "any-direct" },
+          { id: "any-group" },
+          { id: "known-direct" },
+        ],
+      },
       bindings: [
+        {
+          agentId: "known-direct",
+          match: {
+            channel: "telegram",
+            accountId: "default",
+            peer: { kind: "direct", id: "known" },
+          },
+        },
         {
           agentId: "any-direct",
           match: {
@@ -1559,14 +1575,58 @@ describe("resolved route cache keys", () => {
           },
         },
         {
+          agentId: "any-group",
+          match: {
+            channel: "telegram",
+            accountId: "default",
+            peer: { kind: "group", id: "*" },
+          },
+        },
+        {
+          agentId: "account-wide",
+          match: { channel: "telegram", accountId: "work" },
+        },
+        {
           agentId: "channel-wide",
           match: { channel: "telegram", accountId: "*" },
         },
       ],
     };
 
-    // Channel route targets resolve a peerless route for every configured
-    // channel/account before anything asks for the unknown-sender DM route.
+    expectResolvedRoute(resolveAgentRoute({ cfg, channel: "telegram", accountId: "default" }), {
+      agentId: "channel-wide",
+      matchedBy: "binding.channel",
+    });
+    expectResolvedRoute(
+      resolveUnknownDirectMessageRoute({ cfg, channel: "telegram", accountId: "default" }),
+      { agentId: "any-direct", matchedBy: "binding.peer.wildcard" },
+    );
+    expectResolvedRoute(
+      resolveAgentRoute({
+        cfg,
+        channel: "telegram",
+        accountId: "default",
+        peer: { kind: "group", id: "" },
+      }),
+      {
+        agentId: "any-group",
+        matchedBy: "binding.peer.wildcard",
+        sessionKey: "agent:any-group:telegram:group:unknown",
+      },
+    );
+    expectResolvedRoute(
+      resolveAgentRoute({
+        cfg,
+        channel: "telegram",
+        accountId: "default",
+        peer: { kind: "direct", id: "known" },
+      }),
+      { agentId: "known-direct", matchedBy: "binding.peer" },
+    );
+    expectResolvedRoute(resolveAgentRoute({ cfg, channel: "telegram", accountId: "work" }), {
+      agentId: "account-wide",
+      matchedBy: "binding.account",
+    });
     expectResolvedRoute(resolveAgentRoute({ cfg, channel: "telegram", accountId: "default" }), {
       agentId: "channel-wide",
       matchedBy: "binding.channel",

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -1545,6 +1545,37 @@ describe("resolved route cache keys", () => {
       { agentId: "hyphen-guild", matchedBy: "binding.guild" },
     );
   });
+
+  test("does not reuse a peerless cached route for the unknown direct-message route", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "channel-wide" }, { id: "any-direct" }] },
+      bindings: [
+        {
+          agentId: "any-direct",
+          match: {
+            channel: "telegram",
+            accountId: "default",
+            peer: { kind: "direct", id: "*" },
+          },
+        },
+        {
+          agentId: "channel-wide",
+          match: { channel: "telegram", accountId: "*" },
+        },
+      ],
+    };
+
+    // Channel route targets resolve a peerless route for every configured
+    // channel/account before anything asks for the unknown-sender DM route.
+    expectResolvedRoute(resolveAgentRoute({ cfg, channel: "telegram", accountId: "default" }), {
+      agentId: "channel-wide",
+      matchedBy: "binding.channel",
+    });
+    expectResolvedRoute(
+      resolveUnknownDirectMessageRoute({ cfg, channel: "telegram", accountId: "default" }),
+      { agentId: "any-direct", matchedBy: "binding.peer.wildcard" },
+    );
+  });
 });
 
 describe("binding evaluation cache scalability", () => {

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -560,7 +560,10 @@ function resolveRouteCacheForConfig(cfg: OpenClawConfig): Map<string, ResolvedAg
 }
 
 function formatRouteCachePeer(peer: RoutePeer | null): string {
-  if (!peer || !peer.id) {
+  // An empty peer id is not the same route as having no peer: it still enables
+  // the peer and peer-wildcard tiers and produces a different session key, so
+  // keep the kind rather than collapsing onto the peerless sentinel.
+  if (!peer) {
     return "-";
   }
   return `${peer.kind}:${peer.id}`;

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -1,4 +1,3 @@
-// Route resolution helpers map user targets to configured channel routes.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import {
   AgentSelectionRequiredError,
@@ -560,9 +559,7 @@ function resolveRouteCacheForConfig(cfg: OpenClawConfig): Map<string, ResolvedAg
 }
 
 function formatRouteCachePeer(peer: RoutePeer | null): string {
-  // An empty peer id is not the same route as having no peer: it still enables
-  // the peer and peer-wildcard tiers and produces a different session key, so
-  // keep the kind rather than collapsing onto the peerless sentinel.
+  // Empty IDs still enable kind-specific wildcard routing, so only a missing peer is peerless.
   if (!peer) {
     return "-";
   }


### PR DESCRIPTION
## What Problem This Solves

Route-cache identity treated a missing peer and a present peer with an empty ID as the same peerless route.

That is incorrect because a present peer still enables kind-specific wildcard bindings. A peerless route-target lookup could therefore poison a later unknown direct-message lookup on the same configuration object. The reverse call order could poison the peerless route instead.

## Why This Change Was Made

The cache-key owner now reserves the peerless sentinel for a missing peer only. Every present peer keeps its normalized kind and ID in the existing JSON cache tuple.

This is channel-neutral. It adds no fallback lookup, cache bypass, or parallel routing path.

The regression uses one configuration object and covers:

- no peer through `binding.channel`;
- an empty direct peer through `binding.peer.wildcard`;
- an empty group peer through its own wildcard kind;
- a non-empty direct ID through `binding.peer`;
- a second account through `binding.account`;
- repeated lookups to prove stable cache identity.

## User Impact

Unknown direct-message senders now use the configured wildcard peer binding regardless of whether diagnostics first resolved a peerless channel route.

## Evidence

Current main `93f1bb84f9522e357c9709ff717b4642fc5485ec` fails an independent trace through `collectChannelRouteTargets`, `resolveUnknownDirectMessageRoute`, and `resolveAgentRoute`:

| Order | Wrong result on main |
| --- | --- |
| peerless, then empty direct/group | both empty peers reuse `binding.account` |
| empty direct, then peerless/group | both later routes reuse the direct `binding.peer.wildcard` result |

Exact head `d34a953cd812b667ea4c9c4639c011c106196eb9` passes both orders:

- peerless: `account-wide` / `binding.account`;
- empty direct: `any-direct` / `binding.peer.wildcard`;
- empty group: `any-group` / `binding.peer.wildcard`;
- known direct: `known-direct` / `binding.peer`;
- repeated peerless and empty-direct lookups stay stable.

Validation:

```console
$ node scripts/run-vitest.mjs src/routing
Test Files  7 passed (7)
Tests      215 passed (215)

$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/routing/resolve-route.test.ts src/routing/resolve-route.ts
# passed

$ git diff --check
# passed
```

Local type checking was not run because this host's policy forbids OpenClaw typecheck commands. Exact-head CI owns that gate.

AI-assisted. Maintainer-verified.
