### PR TITLE
fix: retain discovered models across hot reload

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -86,6 +86,11 @@ Other selection rules:
 - The Control UI starts from the Gateway's prepared configured model view, so opening chat does not start provider discovery. Opening or refreshing a model picker may discover models required by a trailing `provider/*` policy entry. Default and configured picker views hide catalog rows marked `deprecated` or `disabled` unless that exact model is configured as a primary, fallback, utility/tool model, alias/settings key, or exact policy entry. Hidden rows remain selectable by exact `provider/model` ref. The full built-in catalog, including hidden rows, is reserved for explicit browse views (`models.list` with `view: "all"`, or `openclaw models list --all`).
 - Provider inventory UIs use `models.list` with `view: "provider-config"` to show source-authored `models.providers.*.models` rows without applying picker allowlists.
 
+Once the Gateway has discovered a provider inventory, model-selection hot reloads
+retain it without running discovery again. Aliases, policy, and runtime capabilities
+use the new configuration. Explicit catalog refresh replaces that inventory;
+changes to its provider, plugin, auth, environment, or workspace scope invalidate it.
+
 Full mechanics: [Model failover](/concepts/model-failover).
 
 ## Quick model policy

--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -54,7 +54,7 @@ import {
   loadPreparedModelRuntimeAuth,
   setPreparedModelRuntimeAuthLoader,
 } from "./prepared-model-runtime-auth.js";
-import { startSerializedSnapshotBuild } from "./prepared-model-runtime.build.js";
+import { startSerializedSnapshotBuildBatch } from "./prepared-model-runtime.build.js";
 import type { PreparedModelRuntimeAgentFacts } from "./prepared-model-runtime.catalog-contract.js";
 import {
   getPreparedModelRuntimeSnapshot,
@@ -208,18 +208,23 @@ async function createStaticSnapshot(
     options?.provideMetadataToWorker && loadedMetadataSnapshot
       ? markPluginMetadataSnapshotProvided(loadedMetadataSnapshot)
       : loadedMetadataSnapshot;
-  const build = await startSerializedSnapshotBuild(
-    {
-      input,
-      catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
-      isGenerationCurrent: isCurrent,
-      prepareInboundPluginRegistry: options?.prepareInboundPluginRegistry,
-    },
+  const results = await startSerializedSnapshotBuildBatch(
+    [
+      {
+        input,
+        catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
+        isGenerationCurrent: isCurrent,
+        isBuildCurrent: isCurrent,
+        prepareInboundPluginRegistry: options?.prepareInboundPluginRegistry,
+      },
+    ],
     new Map(),
     30_000,
     "static",
+    undefined,
     providedMetadataSnapshot,
   ).pending;
+  const build = results[0]!;
   return {
     ...fixture,
     pluginMetadataSnapshot: build.pluginGeneration.pluginMetadataSnapshot,
@@ -316,20 +321,24 @@ describe("prepared model catalog worker boundary", () => {
       current = false;
     };
     retireAfterTest(supersede);
-    const build = startSerializedSnapshotBuild(
-      {
-        input,
-        catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
-        isGenerationCurrent: () => current,
-      },
+    const isCurrent = () => current;
+    const build = startSerializedSnapshotBuildBatch(
+      [
+        {
+          input,
+          catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
+          isGenerationCurrent: isCurrent,
+          isBuildCurrent: isCurrent,
+        },
+      ],
       new Map(),
       30_000,
       "static",
     );
-    let snapshot: Awaited<typeof build.pending>["snapshot"] | undefined;
+    let snapshot: Awaited<typeof build.pending>[number]["snapshot"] | undefined;
     let driftedAgentDir: string | undefined;
     try {
-      snapshot = (await build.pending).snapshot;
+      snapshot = (await build.pending)[0]!.snapshot;
       const modelCatalog = await snapshot.loadFullModelCatalog!();
       expect(modelCatalog.entries).toContainEqual(
         expect.objectContaining({ provider: PROVIDER_ID, id: "plugin-generation-v1" }),

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -28,11 +28,15 @@ import type {
 import { PreparedModelRuntimePublicationSupersededError } from "./prepared-model-runtime.errors.js";
 import {
   fingerprintPreparedRuntimeFacts,
+  preparedModelInventoryKey,
   prepareAgentCatalogSource,
   prepareConfiguredRuntimeFactsBatch,
   prepareWorkspaceBuildGroup,
 } from "./prepared-model-runtime.facts.js";
-import { prepareFullCatalogFacts } from "./prepared-model-runtime.full-catalog.js";
+import {
+  materializePreparedModelCatalog,
+  prepareFullCatalogFacts,
+} from "./prepared-model-runtime.full-catalog.js";
 import {
   createPreparedInboundRegistryLoader,
   preparedModelRuntimeWorkspaceFactsKey,
@@ -42,6 +46,7 @@ import type {
   PreparedModelRuntimeBuildStats,
   PreparedModelRuntimeCatalogMode,
   PreparedModelRuntimeInput,
+  PreparedModelRuntimeOwner,
   PreparedModelRuntimePluginGeneration,
   PreparedModelRuntimeSnapshot,
   PreparedModelRuntimeStores,
@@ -60,6 +65,7 @@ type PreparedModelRuntimeCatalogAccess = Readonly<{
 export type PreparedModelRuntimeBuildCandidate = Readonly<{
   input: PreparedModelRuntimeInput;
   catalogOwner: PreparedModelRuntimeSnapshot["catalogOwner"];
+  inventoryOwner?: Pick<PreparedModelRuntimeOwner, "catalogInventory">;
   pluginGeneration?: PreparedModelRuntimePluginGeneration;
   prepareInboundPluginRegistry?: boolean;
   isGenerationCurrent?: () => boolean;
@@ -126,15 +132,43 @@ function assertPreparedModelRuntimeCandidatesCurrent(
   }
 }
 
+function groupBuildCandidates<K>(
+  candidates: readonly PreparedModelRuntimeBuildCandidate[],
+  keyOf: (candidate: PreparedModelRuntimeBuildCandidate) => K,
+): Map<K, PreparedModelRuntimeBuildCandidate[]> {
+  const groups = new Map<K, PreparedModelRuntimeBuildCandidate[]>();
+  for (const candidate of candidates) {
+    const key = keyOf(candidate);
+    const group = groups.get(key) ?? [];
+    group.push(candidate);
+    groups.set(key, group);
+  }
+  return groups;
+}
+
 function createFullModelCatalogAccess(params: {
   agentFacts: PreparedModelRuntimeAgentFacts;
   pluginGeneration: PreparedModelRuntimePluginGeneration;
   agentBuildCompletions: Map<string, Promise<void>>;
   isCurrent: () => boolean;
+  inventoryOwner: Pick<PreparedModelRuntimeOwner, "catalogInventory">;
 }): PreparedModelRuntimeCatalogAccess {
-  // The completed catalog is generation-owned. Explicit refresh replaces it only after a
-  // successful build, so failed refreshes cannot discard the last verified inventory.
-  let fullCatalog: ModelCatalogSnapshot | undefined;
+  // Retain discovery, not the retired worker or its runtime capability projection.
+  const project = (catalog: ModelCatalogSnapshot) => {
+    const projected = materializePreparedModelCatalog(
+      catalog,
+      params.agentFacts.runtimeCapabilityModels,
+    );
+    prepareModelCatalogThinkingPolicies({
+      catalog: projected,
+      metadataSnapshot: params.pluginGeneration.pluginMetadataSnapshot,
+      providers: params.pluginGeneration.pluginRegistry?.providers,
+    });
+    return projected;
+  };
+  const inventoryKey = preparedModelInventoryKey(params.agentFacts.input);
+  const inventory = params.inventoryOwner.catalogInventory;
+  let fullCatalog = inventory?.key === inventoryKey ? project(inventory.catalog) : undefined;
   let pending: Promise<ModelCatalogSnapshot> | undefined;
   let pendingAuth:
     | {
@@ -142,13 +176,8 @@ function createFullModelCatalogAccess(params: {
         promise: Promise<PreparedModelRuntimeAuth>;
       }
     | undefined;
-  const assertCurrent = () => {
-    if (!params.isCurrent()) {
-      throw new PreparedModelRuntimePublicationSupersededError(
-        `prepared model runtime catalog generation was superseded for ${params.agentFacts.input.agentDir}`,
-      );
-    }
-  };
+  const assertCurrent = () =>
+    assertPreparedModelRuntimeInputCurrent(params.agentFacts.input, params.isCurrent);
   // Construction is lazy: automatic prepared reads do not start a thread. The first explicit
   // request initializes one registry and reuses that exact plugin generation until retirement.
   const worker = createPreparedModelCatalogWorker({
@@ -161,13 +190,11 @@ function createFullModelCatalogAccess(params: {
   });
   return {
     loadAuth: ({ providerIds, profileIds }) => {
-      const key = [...new Set(providerIds)]
-        .toSorted((left, right) => left.localeCompare(right))
-        .join("\0");
-      const profileKey = [...new Set(profileIds ?? [])]
-        .toSorted((left, right) => left.localeCompare(right))
-        .join("\0");
-      const cacheKey = `${key}\0\0${profileKey}`;
+      const cacheKey = [providerIds, profileIds ?? []]
+        .map((ids) =>
+          [...new Set(ids)].toSorted((left, right) => left.localeCompare(right)).join("\0"),
+        )
+        .join("\0\0");
       if (pendingAuth?.key === cacheKey) {
         return pendingAuth.promise;
       }
@@ -195,14 +222,10 @@ function createFullModelCatalogAccess(params: {
       assertCurrent();
       return fullCatalog;
     },
-    loadFullModelCatalog: (options) => {
-      try {
-        assertCurrent();
-      } catch (error) {
-        return Promise.reject(toStringifiedError(error));
-      }
+    loadFullModelCatalog: async (options) => {
+      assertCurrent();
       if (!options?.refresh && fullCatalog) {
-        return Promise.resolve(fullCatalog);
+        return fullCatalog;
       }
       if (!pending) {
         const build = runSerializedPreparedModelRuntimeTask({
@@ -221,14 +244,11 @@ function createFullModelCatalogAccess(params: {
         });
         pending = build
           .then((catalog) => {
-            prepareModelCatalogThinkingPolicies({
-              catalog,
-              metadataSnapshot: params.pluginGeneration.pluginMetadataSnapshot,
-              providers: params.pluginGeneration.pluginRegistry?.providers,
-            });
-            fullCatalog = catalog;
+            assertCurrent();
+            fullCatalog = project(catalog);
+            params.inventoryOwner.catalogInventory = { catalog, key: inventoryKey };
             notifyPreparedModelRuntimePublication({ phase: "catalog-published" });
-            return catalog;
+            return fullCatalog;
           })
           .finally(() => {
             pending = undefined;
@@ -249,8 +269,11 @@ function createSnapshot(
   const { credentials, input } = agentFacts;
   const { mediaCapabilityProviders, messageToolCatalog, pluginMetadataSnapshot, pluginRegistry } =
     pluginGeneration;
-  const { configuredRuntimeModels, inlineProviderModels, modelCatalog, templateModelRegistry } =
-    catalogFacts;
+  const { configuredRuntimeModels, inlineProviderModels, templateModelRegistry } = catalogFacts;
+  const modelCatalog = materializePreparedModelCatalog(
+    catalogFacts.modelCatalog,
+    agentFacts.runtimeCapabilityModels,
+  );
   prepareModelCatalogThinkingPolicies({
     catalog: modelCatalog,
     metadataSnapshot: pluginMetadataSnapshot,
@@ -300,51 +323,34 @@ async function buildSnapshotBatch(
   onBuildStats?: (stats: PreparedModelRuntimeBuildStats) => void,
   includeCredentialProviders = catalogMode === "live",
 ): Promise<PreparedModelRuntimeBuildResult[]> {
-  const freshGroups = new Map<string, PreparedModelRuntimeBuildCandidate[]>();
-  const reusableGroups = new Map<
-    PreparedModelRuntimePluginGeneration,
-    Map<string, PreparedModelRuntimeBuildCandidate[]>
-  >();
-  for (const candidate of candidates) {
-    const { input, pluginGeneration: reusablePluginGeneration } = candidate;
-    if (reusablePluginGeneration) {
-      const workspaceGroups = reusableGroups.get(reusablePluginGeneration) ?? new Map();
-      const key = preparedModelRuntimeWorkspaceFactsKey(input);
-      const group = workspaceGroups.get(key);
-      if (group) {
-        group.push(candidate);
-      } else {
-        workspaceGroups.set(key, [candidate]);
-      }
-      reusableGroups.set(reusablePluginGeneration, workspaceGroups);
-      continue;
-    }
-    const ownerKind = candidate.prepareInboundPluginRegistry ? "configured" : "dynamic";
-    const key = `${ownerKind}\0${preparedModelRuntimeWorkspaceFactsKey(input)}`;
-    const group = freshGroups.get(key);
-    if (group) {
-      group.push(candidate);
-    } else {
-      freshGroups.set(key, [candidate]);
-    }
-  }
-  const groups: Array<{
-    groupCandidates: PreparedModelRuntimeBuildCandidate[];
-    pluginGeneration?: PreparedModelRuntimePluginGeneration;
-  }> = [
-    ...[...reusableGroups].flatMap(([pluginGeneration, workspaceGroups]) =>
-      [...workspaceGroups.values()].map((groupCandidates) => ({
-        groupCandidates,
-        pluginGeneration,
-      })),
-    ),
-    ...[...freshGroups.values()].map((groupCandidates) => ({ groupCandidates })),
-  ];
-  const preparedInputs = new Map<PreparedModelRuntimeInput, PreparedModelRuntimeAgentFacts>();
-  const pluginGenerations = new Map<
+  const generations = groupBuildCandidates(candidates, (candidate) => candidate.pluginGeneration);
+  const fresh = generations.get(undefined) ?? [];
+  // Reusable generations precede fresh ones; preserve first-seen order within each group.
+  generations.delete(undefined);
+  generations.set(undefined, fresh);
+  const groups = [...generations].flatMap(([pluginGeneration, generationCandidates]) =>
+    [
+      ...groupBuildCandidates(generationCandidates, (candidate) => {
+        const workspace = preparedModelRuntimeWorkspaceFactsKey(candidate.input);
+        const kind = candidate.prepareInboundPluginRegistry ? "configured" : "dynamic";
+        return pluginGeneration ? workspace : `${kind}\0${workspace}`;
+      }).values(),
+    ].map((groupCandidates) => ({ groupCandidates, pluginGeneration })),
+  );
+  const preparedInputs = new Map<
     PreparedModelRuntimeInput,
-    PreparedModelRuntimePluginGeneration
+    {
+      agentFacts: PreparedModelRuntimeAgentFacts;
+      pluginGeneration: PreparedModelRuntimePluginGeneration;
+    }
   >();
+  const requirePreparedInput = (input: PreparedModelRuntimeInput) => {
+    const prepared = preparedInputs.get(input);
+    if (!prepared) {
+      throw new Error(`prepared model runtime facts missing for ${input.agentDir}`);
+    }
+    return prepared;
+  };
   const loadInboundPluginRegistry = createPreparedInboundRegistryLoader();
   let runtimePluginMs = 0;
   let pluginMetadataMs = 0;
@@ -383,24 +389,20 @@ async function buildSnapshotBatch(
     agentFactsMs += prepared.buildStats.agentFactsMs;
     configuredProjectionMs += prepared.buildStats.configuredProjectionMs;
     for (const agentFacts of prepared.agentFacts) {
-      preparedInputs.set(agentFacts.input, agentFacts);
-      pluginGenerations.set(agentFacts.input, prepared.pluginGeneration);
+      preparedInputs.set(agentFacts.input, {
+        agentFacts,
+        pluginGeneration: prepared.pluginGeneration,
+      });
     }
   }
   const workspaceFactsMs = performance.now() - workspaceFactsStartedAt;
   const catalogSourceStartedAt = performance.now();
   const catalogSources = new Map<PreparedModelRuntimeInput, PreparedModelRuntimeCatalogSource>();
   if (catalogMode === "live") {
-    const sourceCandidatesByAgentDir = new Map<string, PreparedModelRuntimeBuildCandidate[]>();
-    for (const candidate of candidates) {
-      const { input } = candidate;
-      const group = sourceCandidatesByAgentDir.get(input.agentDir);
-      if (group) {
-        group.push(candidate);
-      } else {
-        sourceCandidatesByAgentDir.set(input.agentDir, [candidate]);
-      }
-    }
+    const sourceCandidatesByAgentDir = groupBuildCandidates(
+      candidates,
+      ({ input }) => input.agentDir,
+    );
     const sourceErrors: unknown[] = [];
     const sourceBuild = await runTasksWithConcurrency({
       limit: MAX_CONCURRENT_MODEL_RUNTIME_AGENT_SOURCE_BUILDS,
@@ -413,21 +415,12 @@ async function buildSnapshotBatch(
         // directory while allowing bounded progress across distinct agents.
         for (const candidate of sourceCandidates) {
           const { input } = candidate;
-          const prepared = preparedInputs.get(input);
-          const pluginGeneration = pluginGenerations.get(input);
-          if (!prepared) {
-            throw new Error(`prepared model runtime agent facts missing for ${input.agentDir}`);
-          }
-          if (!pluginGeneration) {
-            throw new Error(
-              `prepared model runtime plugin generation missing for ${input.agentDir}`,
-            );
-          }
+          const { agentFacts, pluginGeneration } = requirePreparedInput(input);
           // A replacement waits for this batch's completion. Stop the stale batch before another
           // same-directory write so a superseded generation cannot overwrite catalog state.
           assertPreparedModelRuntimeInputCurrent(input, candidate.isBuildCurrent);
           const catalogSource = await prepareAgentCatalogSource(
-            prepared,
+            agentFacts,
             pluginGeneration,
             catalogMode,
           );
@@ -455,11 +448,7 @@ async function buildSnapshotBatch(
     // instead of multiplying heap and GC pressure when a command names several agents.
     for (const candidate of candidates) {
       const { input } = candidate;
-      const agentFacts = preparedInputs.get(input);
-      const pluginGeneration = pluginGenerations.get(input);
-      if (!agentFacts || !pluginGeneration) {
-        throw new Error(`prepared model runtime facts missing for ${input.agentDir}`);
-      }
+      const { agentFacts, pluginGeneration } = requirePreparedInput(input);
       const catalogSource = catalogSources.get(input);
       if (!catalogSource) {
         throw new Error(`prepared model runtime catalog source missing for ${input.agentDir}`);
@@ -475,18 +464,9 @@ async function buildSnapshotBatch(
   } else {
     for (const { groupCandidates } of groups) {
       assertPreparedModelRuntimeCandidatesCurrent(groupCandidates);
-      const pluginGeneration = pluginGenerations.get(groupCandidates[0]!.input);
-      if (!pluginGeneration) {
-        throw new Error("prepared model runtime plugin generation is missing");
-      }
+      const { pluginGeneration } = requirePreparedInput(groupCandidates[0]!.input);
       const batch = prepareConfiguredRuntimeFactsBatch({
-        agentFacts: groupCandidates.map(({ input }) => {
-          const agentFacts = preparedInputs.get(input);
-          if (!agentFacts) {
-            throw new Error(`prepared model runtime facts missing for ${input.agentDir}`);
-          }
-          return agentFacts;
-        }),
+        agentFacts: groupCandidates.map(({ input }) => requirePreparedInput(input).agentFacts),
         pluginGeneration,
       });
       runtimeRegistryCount += batch.registryCount;
@@ -497,7 +477,7 @@ async function buildSnapshotBatch(
     }
   }
   const registryMs = performance.now() - registryStartedAt;
-  const preparedAgentFacts = [...preparedInputs.values()];
+  const preparedAgentFacts = [...preparedInputs.values()].map(({ agentFacts }) => agentFacts);
   const configuredRuntimeModelCount = [...preparedCatalogs.values()].reduce(
     (count, facts) => count + facts.configuredRuntimeModels.length,
     0,
@@ -514,13 +494,9 @@ async function buildSnapshotBatch(
     workspaceGroupCount: groups.length,
     configuredFactsGroupCount: groups.length,
     catalogSourceCount:
-      catalogMode === "live"
-        ? [...preparedInputs.values()].filter(({ input }) => !input.readOnly).length
-        : 0,
+      catalogMode === "live" ? preparedAgentFacts.filter(({ input }) => !input.readOnly).length : 0,
     credentialGroupCount: new Set(
-      [...preparedInputs.values()].map((agentFacts) =>
-        fingerprintPreparedRuntimeFacts(agentFacts.credentials),
-      ),
+      preparedAgentFacts.map(({ credentials }) => fingerprintPreparedRuntimeFacts(credentials)),
     ).size,
     catalogGroupCount: catalogMode === "live" ? candidates.length : 0,
     runtimeRegistryCount,
@@ -542,10 +518,9 @@ async function buildSnapshotBatch(
   assertPreparedModelRuntimeCandidatesCurrent(candidates);
   return candidates.map((candidate) => {
     const { input } = candidate;
-    const agentFacts = preparedInputs.get(input);
-    const pluginGeneration = pluginGenerations.get(input);
+    const { agentFacts, pluginGeneration } = requirePreparedInput(input);
     const catalogFacts = preparedCatalogs.get(input);
-    if (!agentFacts || !pluginGeneration || !catalogFacts) {
+    if (!catalogFacts) {
       throw new Error(`prepared model runtime snapshot facts missing for ${input.agentDir}`);
     }
     return {
@@ -559,6 +534,7 @@ async function buildSnapshotBatch(
           pluginGeneration,
           agentBuildCompletions,
           isCurrent: candidate.isGenerationCurrent ?? (() => false),
+          inventoryOwner: candidate.inventoryOwner ?? {},
         }),
       ),
       pluginGeneration,
@@ -579,13 +555,9 @@ export function startSerializedSnapshotBuildBatch(
   completion: Promise<void>;
 } {
   const agentDirs = [...new Set(candidates.map(({ input }) => input.agentDir))];
-  const previousBuildCompletions = [
-    ...new Set(
-      agentDirs
-        .map((agentDir) => agentBuildCompletions.get(agentDir))
-        .filter((completion): completion is Promise<void> => completion !== undefined),
-    ),
-  ];
+  const previousBuildCompletions = agentDirs
+    .map((agentDir) => agentBuildCompletions.get(agentDir))
+    .filter((completion) => completion !== undefined);
   // Lifecycle events may overlap. The timeout covers queueing plus this build, while completion
   // follows the real work so a timed-out generation can never overlap a replacement.
   const startBuild = (async () => {
@@ -604,7 +576,7 @@ export function startSerializedSnapshotBuildBatch(
     };
   })();
   const completion = startBuild
-    .then(async ({ actualBuild }) => await actualBuild)
+    .then(({ actualBuild }) => actualBuild)
     .then(
       () => undefined,
       () => undefined,
@@ -619,45 +591,10 @@ export function startSerializedSnapshotBuildBatch(
   }
   return {
     pending: runAbortableTimeout(
-      async () => {
-        const { actualBuild } = await startBuild;
-        return await actualBuild;
-      },
+      async () => (await startBuild).actualBuild,
       buildTimeoutMs,
       "prepared model runtime publication",
     ),
     completion,
-  };
-}
-
-export function startSerializedSnapshotBuild(
-  candidate: PreparedModelRuntimeBuildCandidate,
-  agentBuildCompletions: Map<string, Promise<void>>,
-  buildTimeoutMs: number,
-  catalogMode: PreparedModelRuntimeCatalogMode = "live",
-  pluginMetadataSnapshot?: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"],
-): {
-  pending: Promise<PreparedModelRuntimeBuildResult>;
-  completion: Promise<void>;
-} {
-  // Direct builds are current by default; batch callbacks require explicit generation authority.
-  const isGenerationCurrent = candidate.isGenerationCurrent ?? (() => true);
-  const build = startSerializedSnapshotBuildBatch(
-    [
-      {
-        ...candidate,
-        isGenerationCurrent,
-        isBuildCurrent: candidate.isBuildCurrent ?? isGenerationCurrent,
-      },
-    ],
-    agentBuildCompletions,
-    buildTimeoutMs,
-    catalogMode,
-    undefined,
-    pluginMetadataSnapshot,
-  );
-  return {
-    pending: build.pending.then((results) => results[0]!),
-    completion: build.completion,
   };
 }

--- a/src/agents/prepared-model-runtime.catalog-owner.test.ts
+++ b/src/agents/prepared-model-runtime.catalog-owner.test.ts
@@ -22,10 +22,7 @@ import {
   resolvePublishedModelCatalogOwner,
 } from "./prepared-model-catalog-owner.js";
 import * as runtimeBuild from "./prepared-model-runtime.build.js";
-import {
-  startSerializedSnapshotBuild,
-  startSerializedSnapshotBuildBatch,
-} from "./prepared-model-runtime.build.js";
+import { startSerializedSnapshotBuildBatch } from "./prepared-model-runtime.build.js";
 import {
   activateStandalonePreparedModelRuntime,
   loadPublishedGatewayReplyDispatchRuntime,
@@ -247,7 +244,7 @@ describe("prepared build candidate lifetime", () => {
     const source = createDeferred<{ agentDir: string; wrote: false }>();
     mocks.ensureOpenClawModelsJson.mockImplementationOnce(async () => await source.promise);
     const input = { config: {}, agentDir: state.agentDir("timeout") };
-    const builds = vi.spyOn(runtimeBuild, "startSerializedSnapshotBuild");
+    const builds = vi.spyOn(runtimeBuild, "startSerializedSnapshotBuildBatch");
     try {
       await expect(publishPreparedModelRuntimeSnapshot(input)).rejects.toThrow(
         "prepared model runtime publication timed out",
@@ -370,44 +367,16 @@ describe("prepared build candidate lifetime", () => {
     }
   });
 
-  it("allows a direct serialized build without a lifecycle generation guard", async () => {
-    const input = {
-      config: {},
-      agentDir: state.agentDir("direct-prepared-model-runtime-build"),
-      readOnly: true,
-    };
-    const build = startSerializedSnapshotBuild(
-      { input, catalogOwner: preparePublishedModelCatalogOwnerIdentity(input) },
-      new Map(),
-      1_000,
-      "static",
-    );
-
-    try {
-      await expect(build.pending).resolves.toMatchObject({
-        snapshot: {
-          agentDir: input.agentDir,
-          config: input.config,
-        },
-        pluginGeneration: expect.any(Object),
-      });
-    } finally {
-      await build.completion;
-    }
-  });
-
   it.each([
     {
-      name: "single default",
-      single: true,
-      generation: undefined,
-      build: undefined,
+      name: "batch explicit generation",
+      generation: true,
+      build: true,
       allowed: true,
       callbacks: true,
     },
     {
       name: "batch default",
-      single: false,
       generation: undefined,
       build: undefined,
       allowed: true,
@@ -415,7 +384,6 @@ describe("prepared build candidate lifetime", () => {
     },
     {
       name: "batch build-only",
-      single: false,
       generation: undefined,
       build: true,
       allowed: true,
@@ -423,7 +391,6 @@ describe("prepared build candidate lifetime", () => {
     },
     {
       name: "batch missing build predicate",
-      single: false,
       generation: false,
       build: undefined,
       allowed: true,
@@ -431,13 +398,12 @@ describe("prepared build candidate lifetime", () => {
     },
     {
       name: "batch inherited generation predicate",
-      single: false,
       generation: false,
       build: false,
       allowed: false,
       callbacks: false,
     },
-  ])("preserves $name semantics", async ({ single, generation, build, allowed, callbacks }) => {
+  ])("preserves $name semantics", async ({ generation, build, allowed, callbacks }) => {
     const input = { config: {}, agentDir: state.agentDir("candidate-lifetime"), readOnly: true };
     const candidate = {
       input,
@@ -445,15 +411,12 @@ describe("prepared build candidate lifetime", () => {
       ...(generation === undefined ? {} : { isGenerationCurrent: () => generation }),
       ...(build === undefined ? {} : { isBuildCurrent: () => build }),
     };
-    const started = single
-      ? startSerializedSnapshotBuild(candidate, new Map(), 1_000, "static")
-      : startSerializedSnapshotBuildBatch([candidate], new Map(), 1_000, "static");
+    const started = startSerializedSnapshotBuildBatch([candidate], new Map(), 1_000, "static");
     try {
       if (!allowed) {
         await expect(started.pending).rejects.toThrow("superseded");
       } else {
-        const result = await started.pending;
-        const { snapshot } = Array.isArray(result) ? result[0]! : result;
+        const { snapshot } = (await started.pending)[0]!;
         if (callbacks) {
           await expect(snapshot.loadFullModelCatalog!()).resolves.toMatchObject({ entries: [] });
         } else {

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -9,6 +9,7 @@ import {
 import { stableStringify } from "@openclaw/normalization-core";
 import { sha256Base64Url } from "../infra/crypto-digest.js";
 import { prepareMediaCapabilityProviders } from "../plugins/capability-provider-runtime.js";
+import { normalizePluginsConfig } from "../plugins/config-state.js";
 import {
   getPreparedMessageToolCatalog,
   getPreparedMessageToolCatalogForRegistry,
@@ -25,6 +26,10 @@ import {
   discoverAuthStorageFacts,
   discoverModelsFromCapturedSources,
 } from "./agent-model-discovery.js";
+import {
+  getPreparedRuntimeAuthProfileStoreSnapshotCore,
+  getRuntimeAuthProfileStoreCredentialsRevision,
+} from "./auth-profiles/runtime-snapshots.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { buildInlineProviderModels } from "./embedded-agent-runner/model.inline-provider.js";
 import {
@@ -475,6 +480,25 @@ function captureModelsJsonContents(agentDir: string): string | null {
 }
 export const fingerprintPreparedRuntimeFacts = (value: unknown): string =>
   sha256Base64Url(stableStringify(value));
+
+/** Record discovery scope before config projection or auth-owner publication can replace it. */
+export function preparedModelInventoryKey(input: PreparedModelRuntimeInput): string {
+  const { models, auth, env } = input.config;
+  const plugins = normalizePluginsConfig(input.config.plugins);
+  for (const entry of Object.values(plugins.entries)) {
+    entry.config ??= {};
+  }
+  return fingerprintPreparedRuntimeFacts({
+    ...input,
+    config: { models, auth, env, plugins },
+    env: input.env ?? process.env,
+    runtimePluginSelections: undefined,
+    credentials: getRuntimeAuthProfileStoreCredentialsRevision(),
+    order:
+      getPreparedRuntimeAuthProfileStoreSnapshotCore(input.agentDir, input.inheritedAuthDir)
+        ?.order ?? {},
+  });
+}
 function hasSameOAuthProviderGeneration(
   left: ReturnType<AuthStorage["getOAuthProviders"]>,
   right: ReturnType<AuthStorage["getOAuthProviders"]>,

--- a/src/agents/prepared-model-runtime.full-catalog.ts
+++ b/src/agents/prepared-model-runtime.full-catalog.ts
@@ -1,15 +1,24 @@
-import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
+import { dedupeByKey } from "../shared/dedupe-by-key.js";
 import { discoverModels } from "./agent-model-discovery.js";
 import { loadBundledProviderStaticCatalogContextModels } from "./embedded-agent-runner/model.static-catalog.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
+import {
+  getPreparedModelFullCatalogAuth,
+  setPreparedModelFullCatalogAuth,
+} from "./prepared-model-runtime-auth.js";
 import type {
   PreparedModelRuntimeAgentFacts,
   PreparedModelRuntimeCatalogFacts,
   PreparedModelRuntimeCatalogSource,
 } from "./prepared-model-runtime.catalog-contract.js";
-import { materializeRuntimeCapabilities } from "./prepared-model-runtime.configured-catalog.js";
-import { toStaticCatalogEntry } from "./prepared-model-runtime.configured.js";
+import {
+  materializeRuntimeCapabilities,
+  modelCatalogEntryKey,
+} from "./prepared-model-runtime.configured-catalog.js";
+import {
+  toStaticCatalogEntry,
+  type PreparedRuntimeCapabilityModel,
+} from "./prepared-model-runtime.configured.js";
 import { buildPreparedPluginModelCatalog } from "./prepared-model-runtime.plugin-generation.js";
 import type {
   PreparedModelRuntimeCatalogMode,
@@ -18,7 +27,7 @@ import type {
 
 const fullModelCatalogSnapshots = new WeakSet<ModelCatalogSnapshot>();
 
-/** Builds the complete prepared catalog, including concrete runtime capabilities. */
+/** Builds complete inventory before generation-specific runtime capability projection. */
 export async function prepareFullCatalogFacts(
   agentFacts: PreparedModelRuntimeAgentFacts,
   pluginGeneration: PreparedModelRuntimePluginGeneration,
@@ -40,23 +49,12 @@ export async function prepareFullCatalogFacts(
         }
       : {}),
   });
-  const discoveredCatalog = await buildPreparedPluginModelCatalog({
+  const modelCatalog = await buildPreparedPluginModelCatalog({
     agentFacts,
     catalogMode,
     modelRegistry: templateModelRegistry,
     pluginGeneration,
   });
-  const modelCatalog = {
-    ...discoveredCatalog,
-    entries: materializeRuntimeCapabilities(
-      discoveredCatalog.entries,
-      agentFacts.runtimeCapabilityModels,
-    ),
-    routeVariants: materializeRuntimeCapabilities(
-      discoveredCatalog.routeVariants,
-      agentFacts.runtimeCapabilityModels,
-    ),
-  };
   const providerStaticModels =
     pluginGeneration.providerStaticModels ??
     (await loadBundledProviderStaticCatalogContextModels({
@@ -66,24 +64,14 @@ export async function prepareFullCatalogFacts(
       ...(preparedStaticProviderCatalog ? { preparedStaticProviderCatalog } : {}),
       ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
     }));
-  const staticModels = new Map<string, ProviderRuntimeModel>();
-  for (const model of [
+  const staticModels = [
     ...agentFacts.configuredRuntimeModels.map((configured) => configured.model),
     ...providerStaticModels,
-  ]) {
-    const modelKey = `${normalizeProviderId(model.provider)}\0${model.id.trim().toLowerCase()}`;
-    if (!staticModels.has(modelKey)) {
-      staticModels.set(modelKey, model);
-    }
-  }
-  const staticEntries = materializeRuntimeCapabilities(
-    [...staticModels.values()].map(toStaticCatalogEntry),
-    agentFacts.runtimeCapabilityModels,
-  );
+  ];
   const providerOutcomes = catalogSource?.providerOutcomes ?? [];
   const completeModelCatalog = {
     ...modelCatalog,
-    staticEntries,
+    staticEntries: dedupeByKey(staticModels, modelCatalogEntryKey).map(toStaticCatalogEntry),
     ...(providerOutcomes.length > 0 ? { providerOutcomes } : {}),
   };
   if (catalogMode === "live") {
@@ -95,6 +83,29 @@ export async function prepareFullCatalogFacts(
     configuredRuntimeModels: agentFacts.configuredRuntimeModels,
     inlineProviderModels: pluginGeneration.inlineProviderModels,
   };
+}
+
+/** Reprojects retained inventory without carrying capabilities from a retired runtime. */
+export function materializePreparedModelCatalog(
+  snapshot: ModelCatalogSnapshot,
+  runtimeCapabilityModels: readonly PreparedRuntimeCapabilityModel[],
+): ModelCatalogSnapshot {
+  const project = (entries: ModelCatalogSnapshot["entries"]) =>
+    materializeRuntimeCapabilities(entries, runtimeCapabilityModels);
+  const materialized = {
+    ...snapshot,
+    entries: project(snapshot.entries),
+    routeVariants: project(snapshot.routeVariants),
+    ...(snapshot.staticEntries ? { staticEntries: project(snapshot.staticEntries) } : {}),
+  };
+  if (isPreparedModelCatalogFull(snapshot)) {
+    markPreparedModelCatalogFull(materialized);
+  }
+  const auth = getPreparedModelFullCatalogAuth(snapshot);
+  if (auth) {
+    setPreparedModelFullCatalogAuth(materialized, auth);
+  }
+  return materialized;
 }
 
 /** Reports whether a catalog came from the complete prepared-catalog build path. */

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -22,7 +22,6 @@ import { resolveConfiguredModelFallbacks } from "./model-selection-resolve.js";
 import { preparePublishedModelCatalogOwnerIdentity } from "./prepared-model-catalog-owner.js";
 import { copyPreparedModelRuntimeAuthBindings } from "./prepared-model-runtime-auth.js";
 import {
-  startSerializedSnapshotBuild,
   startSerializedSnapshotBuildBatch,
   type PreparedModelRuntimeBuildResult,
 } from "./prepared-model-runtime.build.js";
@@ -505,6 +504,7 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
       catalogMode: owner.catalogMode,
       input,
       catalogOwner: owner.catalogOwner,
+      inventoryOwner: owner,
       pluginGeneration: owner.pendingPluginGeneration,
       prepareInboundPluginRegistry: owner.provenance === "configured",
       isGenerationCurrent,
@@ -652,17 +652,23 @@ export async function publishModelRuntimeSnapshot(
   owner.pluginGeneration = undefined;
   owner.pendingPluginGeneration = reusablePluginGeneration;
   const generation = owner.generation;
-  const build = startSerializedSnapshotBuild(
-    {
-      input,
-      catalogOwner: owner.catalogOwner,
-      isGenerationCurrent: () => owner.generation === generation && owners.get(key) === owner,
-      prepareInboundPluginRegistry: provenance === "configured",
-      pluginGeneration: reusablePluginGeneration,
-    },
+  const isGenerationCurrent = () => owner.generation === generation && owners.get(key) === owner;
+  const build = startSerializedSnapshotBuildBatch(
+    [
+      {
+        input,
+        catalogOwner: owner.catalogOwner,
+        inventoryOwner: owner,
+        isGenerationCurrent,
+        isBuildCurrent: isGenerationCurrent,
+        prepareInboundPluginRegistry: provenance === "configured",
+        pluginGeneration: reusablePluginGeneration,
+      },
+    ],
     agentBuildCompletions,
     buildTimeoutMs,
     catalogMode,
+    undefined,
     pluginMetadataSnapshot,
   );
   owner.buildCompletion = build.completion;
@@ -674,7 +680,7 @@ export async function publishModelRuntimeSnapshot(
   owners.set(key, owner);
   const publication = (async () => {
     try {
-      const result = await build.pending;
+      const result = (await build.pending)[0]!;
       if (owner.generation !== generation || owners.get(key) !== owner) {
         throw new PreparedModelRuntimePublicationSupersededError(
           `prepared model runtime publication was superseded for ${input.agentDir}`,

--- a/src/agents/prepared-model-runtime.scoped-catalog.ts
+++ b/src/agents/prepared-model-runtime.scoped-catalog.ts
@@ -9,7 +9,10 @@ import {
   prepareAgentCatalogSource,
   prepareWorkspaceBuildGroup,
 } from "./prepared-model-runtime.facts.js";
-import { prepareFullCatalogFacts } from "./prepared-model-runtime.full-catalog.js";
+import {
+  materializePreparedModelCatalog,
+  prepareFullCatalogFacts,
+} from "./prepared-model-runtime.full-catalog.js";
 import {
   listPreparedSyntheticAuthProviderRefs,
   resolvePreparedSyntheticAuth,
@@ -46,9 +49,13 @@ async function prepareScopedReadOnlyModelCatalogWithMode(
     false,
     catalogMode === "live" ? { providerDiscoveryProviderIds } : {},
   );
-  return (
-    await prepareFullCatalogFacts(agentFactsForInput, pluginGeneration, catalogMode, catalogSource)
-  ).modelCatalog;
+  const { modelCatalog } = await prepareFullCatalogFacts(
+    agentFactsForInput,
+    pluginGeneration,
+    catalogMode,
+    catalogSource,
+  );
+  return materializePreparedModelCatalog(modelCatalog, agentFactsForInput.runtimeCapabilityModels);
 }
 
 /** Resolves provider-scoped, secret-free auth modes without live model discovery. */

--- a/src/agents/prepared-model-runtime.scoped-refresh.test.ts
+++ b/src/agents/prepared-model-runtime.scoped-refresh.test.ts
@@ -7,11 +7,17 @@ import {
 } from "./prepared-model-runtime.test-harness.js";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { loadPreparedGatewayModelCatalogSnapshot } from "../gateway/server-model-catalog.js";
+import { refreshModelRuntimeAfterHotReload } from "../gateway/server-reload-model-runtime-scope.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
-import { getPreparedModelRuntimeAuthStore } from "./prepared-model-runtime-auth.js";
+import {
+  getPreparedModelRuntimeAuthStore,
+  setPreparedModelFullCatalogAuth,
+} from "./prepared-model-runtime-auth.js";
+import { markPreparedModelCatalogFull } from "./prepared-model-runtime.full-catalog.js";
 import {
   getPreparedModelRuntimeSnapshot,
   refreshPreparedModelRuntimeSnapshots,
@@ -25,6 +31,91 @@ describe("prepared model runtime scoped refresh", () => {
     state = await createOpenClawTestState({ label: "prepared-model-runtime" });
     resetPreparedModelRuntimeHarness(state);
   });
+
+  it.each([undefined, new Set(["pro"])])(
+    "carries completed discovery across hot reload without rediscovery (scope: %j)",
+    async (agentIds) => {
+      mocks.configuredAgentIds = ["pro"];
+      const config: OpenClawConfig = {
+        agents: { entries: { pro: {} } },
+        plugins: { entries: { fixture: { enabled: true } } },
+      };
+      const discovered = {
+        provider: "discovered-provider",
+        id: "discovered-model",
+        name: "Discovered",
+      };
+      const catalog = markPreparedModelCatalogFull({
+        entries: [discovered],
+        routeVariants: [discovered],
+      });
+      const auth = {
+        authModes: { "discovered-provider": "api_key" as const },
+        authStore: { version: 1 as const, profiles: {} },
+      };
+      setPreparedModelFullCatalogAuth(catalog, auth);
+      mocks.runPreparedModelCatalogWorker.mockResolvedValueOnce(catalog);
+      await refreshPreparedModelRuntimeSnapshots(config, {
+        gatewayLifecycle: true,
+        catalogMode: "static",
+        allowGatewaySubagentBinding: true,
+      });
+      const input = { agentId: "pro", agentDir: state.agentDir("pro"), config };
+      const original = getPreparedModelRuntimeSnapshot(input)!;
+      await original.loadFullModelCatalog!();
+      expect(
+        await loadPreparedGatewayModelCatalogSnapshot({ agentId: "pro", getConfig: () => config }),
+      ).toMatchObject({ entries: [discovered], authModes: auth.authModes });
+
+      let currentConfig = config;
+      for (const alias of ["First alias", "Second alias"]) {
+        mocks.mutationListener?.({ affectsInheritedStores: true, profileSetChanged: false });
+        const nextConfig: OpenClawConfig = {
+          meta: { lastTouchedVersion: alias },
+          plugins: { entries: { fixture: { enabled: true, config: {} } } },
+          agents: {
+            ...config.agents,
+            defaults: {
+              model: alias === "First alias" ? undefined : "discovered-provider/discovered-model",
+              models: { "custom/configured": { alias } },
+            },
+          },
+        };
+        await refreshModelRuntimeAfterHotReload({
+          config: nextConfig,
+          agentIds,
+          pluginMetadataSnapshot: undefined,
+        });
+        currentConfig = nextConfig;
+        expect(
+          await loadPreparedGatewayModelCatalogSnapshot({
+            agentId: "pro",
+            getConfig: () => nextConfig,
+          }),
+        ).toMatchObject({ config: nextConfig, entries: [discovered], authModes: auth.authModes });
+        expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
+      }
+      expect(() => original.readFullModelCatalog!()).toThrow("superseded");
+      await expect(original.loadFullModelCatalog!()).rejects.toThrow("superseded");
+      const replacement = getPreparedModelRuntimeSnapshot(input)!;
+      const refreshed = markPreparedModelCatalogFull({ entries: [], routeVariants: [] });
+      setPreparedModelFullCatalogAuth(refreshed, auth);
+      mocks.runPreparedModelCatalogWorker.mockResolvedValueOnce(refreshed);
+      const refreshedCatalog = await replacement.loadFullModelCatalog!({ refresh: true });
+      expect(refreshedCatalog).toMatchObject(refreshed);
+      expect(replacement.readFullModelCatalog!()).toBe(refreshedCatalog);
+      expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledTimes(2);
+      mocks.credentialsRevision += 1;
+      mocks.mutationListener?.({ agentDir: input.agentDir, affectsInheritedStores: false });
+      const afterAuth = await loadPreparedGatewayModelCatalogSnapshot({
+        agentId: "pro",
+        getConfig: () => currentConfig,
+      });
+      expect(afterAuth.entries).not.toContainEqual(discovered);
+      expect(afterAuth.authModes).not.toHaveProperty("discovered-provider");
+      expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledTimes(2);
+    },
+  );
 
   it.each([false, true])(
     "retains catalog callbacks across scoped exec reloads (warmed: %s)",
@@ -104,6 +195,76 @@ describe("prepared model runtime scoped refresh", () => {
       expect(buildCounts).toEqual([2, 1, 1]);
     },
   );
+
+  it("reprojects retained discovery when a runtime override is added and removed", async () => {
+    mocks.configuredAgentIds = ["pro"];
+    mocks.resolveStaticCatalogModel.mockImplementation(({ provider, modelId }) => ({
+      provider,
+      id: modelId,
+      name: modelId,
+      api: "openai-responses",
+      baseUrl: "https://synthetic.invalid/v1",
+      reasoning: provider === "fixture-runtime",
+      input: ["text"],
+      contextWindow: 32000,
+      maxTokens: 4096,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      compat: { supportsTools: provider === "fixture-runtime" },
+    }));
+    const discovered = {
+      provider: "custom",
+      id: "discovered-model",
+      name: "Discovered",
+      reasoning: false,
+    };
+    const catalog = markPreparedModelCatalogFull({
+      entries: [discovered],
+      routeVariants: [discovered],
+    });
+    setPreparedModelFullCatalogAuth(catalog, {
+      authModes: { custom: "api_key" },
+      authStore: { version: 1, profiles: {} },
+    });
+    mocks.runPreparedModelCatalogWorker.mockResolvedValueOnce(catalog);
+    const input = { agentId: "pro", agentDir: state.agentDir("pro"), config: {} };
+    for (const runtime of ["openclaw", "fixture-runtime", "openclaw"]) {
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: "custom/discovered-model",
+            models: { "custom/discovered-model": { agentRuntime: { id: runtime } } },
+          },
+          entries: { pro: {} },
+        },
+      };
+      await refreshModelRuntimeAfterHotReload({
+        config,
+        agentIds: undefined,
+        pluginMetadataSnapshot: undefined,
+      });
+      const snapshot = getPreparedModelRuntimeSnapshot(input)!;
+      if (!snapshot.readFullModelCatalog!()) {
+        await snapshot.loadFullModelCatalog!();
+      }
+      const projected = await loadPreparedGatewayModelCatalogSnapshot({
+        agentId: "pro",
+        getConfig: () => config,
+      });
+      expect(projected.entries).toMatchObject([
+        {
+          provider: "custom",
+          id: "discovered-model",
+          reasoning: runtime === "fixture-runtime",
+        },
+      ]);
+      expect(projected.entries[0]?.compat?.supportsTools).toBe(
+        runtime === "fixture-runtime" ? true : undefined,
+      );
+      expect(projected.authModes).toEqual({ custom: "api_key" });
+      expect(projected.catalogComplete).toBe(true);
+      expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
+    }
+  });
 
   it("falls back to full refresh when an out-of-scope owner dependency changes", async () => {
     mocks.configuredAgentIds = ["pro", "free"];

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -180,6 +180,7 @@ vi.mock("./agent-scope-config.js", async (importOriginal) => ({
 
 vi.mock("./auth-profiles/runtime-snapshots.js", () => ({
   getPreparedRuntimeAuthProfileStoreSnapshotCore: () => undefined,
+  getRuntimeAuthProfileStoreCredentialsRevision: () => 0,
   registerRuntimeAuthProfileStoreMutationListener: (
     listener: (event: { agentDir?: string; affectsInheritedStores: boolean }) => void,
   ) => {

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -31,6 +31,7 @@ const preparedModelRuntimeMocks = vi.hoisted(() => ({
     },
   },
   preparedAuthStore: undefined as import("./auth-profiles/types.js").AuthProfileStore | undefined,
+  credentialsRevision: 0,
   preparedAuthMaterializations:
     [] as import("./auth-profiles/runtime-materializations.js").RuntimeAuthMaterialization[],
   authStorage: {
@@ -312,6 +313,8 @@ vi.mock("./auth-profiles/runtime-snapshots.js", () => ({
   getPreparedRuntimeAuthProfileStoreSnapshotCore: () => preparedModelRuntimeMocks.preparedAuthStore,
   getRuntimeAuthProfileStoreSnapshot: () => preparedModelRuntimeMocks.preparedAuthStore,
   getRuntimeAuthProfileStoreSnapshotRevision: () => 0,
+  getRuntimeAuthProfileStoreCredentialsRevision: () =>
+    preparedModelRuntimeMocks.credentialsRevision,
   registerRuntimeAuthProfileStoreMutationListener: (
     listener: (event: { agentDir?: string; affectsInheritedStores: boolean }) => void,
   ) => {
@@ -390,6 +393,7 @@ export function resetPreparedModelRuntimeHarness(state: OpenClawTestState): void
   });
   preparedModelRuntimeMocks.authStorage.getOAuthProviders.mockReset().mockReturnValue([]);
   preparedModelRuntimeMocks.preparedAuthStore = undefined;
+  preparedModelRuntimeMocks.credentialsRevision = 0;
   preparedModelRuntimeMocks.preparedAuthMaterializations = [];
   preparedModelRuntimeMocks.modelRegistry.fork
     .mockReset()

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -14,6 +14,7 @@ import {
   configuredOwnersAreRequestVisible,
   registerPreparedRuntimeAuthMaterializationPublisher,
 } from "./prepared-model-runtime-materializations.js";
+import { preparedModelInventoryKey } from "./prepared-model-runtime.facts.js";
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
   PreparedModelRuntimeOwnerRetention,
@@ -458,6 +459,13 @@ async function refreshPreparedModelRuntimeSnapshotsNow(
   const catalogMode = options.catalogMode ?? "live";
   gatewayLifecycleActive ||= options.gatewayLifecycle === true;
   const staleError = new Error("prepared model runtime owner is stale after config publication");
+  const inventories = new Map(
+    [...owners.values()].flatMap((owner) =>
+      owner.provenance === "configured" && owner.catalogInventory
+        ? [[owner.catalogInventory.key, owner.catalogInventory] as const]
+        : [],
+    ),
+  );
   updateOwnersForScopedRefresh(owners, options.agentIds, staleError, {
     retainedConfig: config,
   });
@@ -493,6 +501,7 @@ async function refreshPreparedModelRuntimeSnapshotsNow(
       catalogMode,
       existing?.provenance === "configured" ? existing : undefined,
     );
+    owner.catalogInventory = inventories.get(preparedModelInventoryKey(input));
     return { input, owner };
   });
   await publishPreparedModelRuntimeOwnerBatch({

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -157,6 +157,8 @@ export type PreparedModelRuntimeOwner = {
   generation: number;
   needsRefresh: boolean;
   catalogStale: boolean;
+  /** Completed discovery facts; runtime capability projection belongs to each generation. */
+  catalogInventory?: { catalog: ModelCatalogSnapshot; key: string };
   refreshError?: Error;
   snapshot?: PreparedModelRuntimeSnapshot;
   pluginGeneration?: PreparedModelRuntimePluginGeneration;


### PR DESCRIPTION
Related: #134544

## What Problem This Solves

Fixes an issue where users listing models would lose already-discovered providers after a model-selection hot reload, until they explicitly refreshed the catalog. Reported by @goslingmanagment.

## Why This Change Was Made

Completed discovery belonged to a replaceable generation-local closure. Keep inventory and its recorded discovery scope on the configured lifecycle owner, then apply the current generation's runtime capabilities and thinking policy without repeating discovery. Preserve paired auth facts and keep retired workers fenced.

Real Gateway proof also exposed equivalent auth-owner republication and an omitted-versus-empty plugin config changing across reload. The scope uses the existing credential revision, prepared auth order, and normalized effective plugin config: equivalent publication keeps inventory; actual credential, provider, plugin, environment, or workspace changes invalidate it.

This implements the maintainer-approved contract while preserving #112262's static-reload performance choice and #135046's paired catalog/auth gates. Single-owner publication now uses the guarded batch path; the obsolete wrapper and duplicate grouping code are removed.

## User Impact

Alias and selected-model hot reloads preserve discovered models in ordinary and configured lists. Explicit refresh still performs discovery and replaces old inventory. No new config options, environment knobs, persistence/schema changes, dependencies, or protocol changes.

## Evidence

Baseline at `2cedaddb5e23848d4358faddcd609afb6570fa94`: a real isolated Gateway lists a synthetic discovered LiteLLM model after one discovery request, then loses it after an alias hot reload with no new request. The global/scoped regression tests also failed before repair.

Candidate live proof: uninstrumented Linux Gateway built at exact commit `35f99ff21460b2e039b38df8a24b5798acfcabb3`, full tree `c8bb1da8f67d3bf075a24e220a477bca9c904afc`, with all 13 changed-file hashes checked before and after build. It used a synthetic provider, temporary HOME/state/workspace, and loopback port 35469. Both default and configured `models.list` views were exercised. [Testbox execution](https://github.com/openclaw/openclaw/actions/runs/33536049627) is a leased live-proof session, not the PR's CI result.

```text
explicit discovery:    alpha, contextWindow=424242; hook calls=1; HTTP requests=1
alias hot reload:      alpha retained in default/configured; hook calls=1; requests=1
primary-model reload:  alpha retained in default/configured; hook calls=1; requests=1
explicit refresh:      beta replaces alpha in all/default/configured; hook calls=2; requests=2
```

The fixture counts every discovery-hook invocation as well as every HTTP request; no discovery call was logged during either reload. The isolated Gateway was terminated after proof.

57 focused tests pass across scoped-refresh (7), startup-static (11), catalog-owner and real catalog-worker integration (39). Coverage includes repeated reload, selected-model owner replacement, runtime override addition/removal, paired auth retention, equivalent auth publication, empty plugin config normalization, retired callbacks, explicit refresh, durable auth changes, and native catalog routes. All 18 scoped/startup tests passed again on the rebased head. The complete changed-file check (types, formatting/lint, Knip, and architecture guards) passed on the unchanged repair patch before rebase; patch identity was verified with range-diff. Precommit and fresh rebased-branch Codex autoreview passed at the required threshold. Earlier fixture-only type errors were corrected without weakening assertions.

Initial CI hit an inherited gateway-protocol declaration-generation failure (`protocol-schemas.ts:20`, TS7056), repaired upstream by #135360. This branch was rebased onto that repair with an unchanged patch, then rebuilt and live-tested. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33535950517) is green at `35f99ff21460b2e039b38df8a24b5798acfcabb3` after retrying a timed-out ACP CLI process shard. Assertions and timeouts were unchanged. The same ACP cases had passed on the patch-identical pre-rebase head; local Node 26 source-loaded runs also exceeded the deadline under heavy compilation load, so those local runs are recorded as failures, not passing proof. No failing gate was bypassed. Follow-up: ACP source-startup timing remains a separate test-infrastructure concern; no catalog defect was demonstrated by the timeout.

ClawSweeper identified no introduced defect; its published rank-up move is green exact-head CI. That move is now satisfied by the green exact-head CI run. The latest published review is less than 12 hours old, and the rebase preserved the reviewed patch.

NO-FOLLOW-UP: the canonical guarded batch-build refactor and duplicate-grouping removal were absorbed into this owner repair; no separate coherent cleanup remains.

Production LOC: +210/-214 (**net -4**). Tests/test-support: +200/-62 (**net +138**). Docs: +5. Test support is classified separately even where the changed-check router calls it core production.

Direct dependency inspection: openai/codex source `0ae94fdd49b05ee7faa4d984d06a68492cb32b54`, `codex-rs/app-server/src/models.rs:19` and `codex-rs/models-manager/src/manager.rs:375-426`. No Codex protocol changes.
