### PR TITLE
fix(auth): relogin repairs stale profile order after upgrade

### DIFF
--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -125,7 +125,7 @@ export async function setAuthProfileOrder(params: {
   });
 }
 
-/** Promotes one auth profile to the front of a provider order. */
+/** Promotes across shared-credential/local-order owners; otherwise relogin leaves stale order. */
 export async function promoteAuthProfileInOrder(params: {
   agentDir?: string;
   provider: string;
@@ -134,13 +134,12 @@ export async function promoteAuthProfileInOrder(params: {
   createFromOrder?: string[];
 }): Promise<AuthProfileStore | null> {
   const providerKey = resolveProviderIdForAuth(params.provider);
+  const effectiveStore = ensureAuthProfileStoreForLocalUpdate(params.agentDir);
   return await updateAuthProfileStoreWithLock({
     agentDir: params.agentDir,
-    ...(params.createFromOrder
-      ? { saveOptions: { preserveOrderProfileIds: params.createFromOrder } }
-      : {}),
+    saveOptions: { preserveOrderProfileIds: [params.profileId, ...(params.createFromOrder ?? [])] },
     updater: (store) => {
-      const profile = store.profiles[params.profileId];
+      const profile = store.profiles[params.profileId] ?? effectiveStore.profiles[params.profileId];
       if (!profile || resolveProviderIdForAuth(profile.provider) !== providerKey) {
         return false;
       }

--- a/src/cli/models-cli.auth-login.integration.test.ts
+++ b/src/cli/models-cli.auth-login.integration.test.ts
@@ -1,0 +1,108 @@
+// Exercises the shipped models auth login command across shared credential and local order owners.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
+import { loadAuthProfileStoreForRuntime } from "../agents/auth-profiles/store.js";
+import type { ProviderPlugin } from "../plugins/types.js";
+import { writeConfigMachineState } from "../state/config-machine-state.js";
+import { runRegisteredCli } from "../test-utils/command-runner.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { registerModelsCli } from "./models-cli.js";
+
+const FRESH_PROFILE_ID = "openai:fresh-login";
+const STALE_PROFILE_ID = "openai:stale-login";
+
+const mocks = vi.hoisted(() => ({
+  callGateway: vi.fn(async () => ({})),
+  runAuth: vi.fn(async () => ({
+    profiles: [
+      {
+        profileId: "openai:fresh-login",
+        credential: {
+          type: "oauth" as const,
+          provider: "openai" as const,
+          access: "fresh-access",
+          refresh: "fresh-refresh",
+          expires: Date.now() + 60_000,
+        },
+      },
+    ],
+  })),
+}));
+
+vi.mock("../gateway/call.js", () => ({ callGateway: mocks.callGateway }));
+vi.mock("../plugins/setup-registry.js", () => ({
+  resolvePluginSetupProviderCore: () => undefined,
+  resolvePluginSetupRegistry: () => ({ providers: [] }),
+}));
+vi.mock("../plugins/providers.runtime.js", () => ({
+  resolvePluginProvidersCore: () =>
+    [
+      {
+        id: "openai",
+        label: "OpenAI",
+        auth: [
+          {
+            id: "oauth",
+            label: "OAuth",
+            kind: "oauth",
+            run: mocks.runAuth,
+          },
+        ],
+      },
+    ] satisfies ProviderPlugin[],
+}));
+
+function makeStdinInteractive(): () => void {
+  const stdin = process.stdin as NodeJS.ReadStream & { isTTY?: boolean };
+  const descriptor = Object.getOwnPropertyDescriptor(stdin, "isTTY");
+  Object.defineProperty(stdin, "isTTY", { configurable: true, get: () => true });
+  return () => {
+    if (descriptor) {
+      Object.defineProperty(stdin, "isTTY", descriptor);
+    } else {
+      delete stdin.isTTY;
+    }
+  };
+}
+
+describe("models auth login owner integration", () => {
+  let restoreStdin: (() => void) | undefined;
+
+  afterEach(() => {
+    restoreStdin?.();
+    restoreStdin = undefined;
+    vi.clearAllMocks();
+  });
+
+  it("promotes a relocated shared login through the shipped CLI command", async () => {
+    await withOpenClawTestState(
+      { label: "models-auth-login-owner", scenario: "minimal" },
+      async (state) => {
+        await state.writeConfig({
+          agents: { list: [{ id: "main" }] },
+          auth: { order: { openai: [STALE_PROFILE_ID] } },
+        });
+        writeConfigMachineState("auth.sharedStore", { location: "state-db" }, { env: state.env });
+        restoreStdin = makeStdinInteractive();
+
+        await runRegisteredCli({
+          register: registerModelsCli,
+          argv: ["models", "auth", "login", "--provider", "openai", "--agent", "main"],
+        });
+
+        expect(mocks.runAuth).toHaveBeenCalledOnce();
+        expect(loadPersistedAuthProfileStore()?.profiles[FRESH_PROFILE_ID]).toMatchObject({
+          type: "oauth",
+          provider: "openai",
+        });
+        expect(
+          loadPersistedAuthProfileStore(state.agentDir())?.profiles[FRESH_PROFILE_ID],
+        ).toBeUndefined();
+        expect(loadAuthProfileStoreForRuntime(state.agentDir()).order?.openai).toEqual([
+          FRESH_PROFILE_ID,
+          STALE_PROFILE_ID,
+        ]);
+      },
+    );
+  });
+});


### PR DESCRIPTION
Closes #135140

Reported by @mattcbianco.

## What Problem This Solves

Fixes an issue where users who signed in to OpenAI again after shared auth-store relocation could still get `Explicit auth order for openai has no usable profiles.` before a model request started.

## Why This Change Was Made

Login credentials and per-agent profile order have separate SQLite owners after relocation. Profile promotion now reads the effective credential view before it updates the agent-local order, and it preserves the inherited profile ID when it saves that order.

This keeps explicit order fail-closed behavior unchanged. It does not add a dispatch fallback or copy shared OAuth credentials into the agent database.

## User Impact

A successful OpenAI relogin now places the new usable profile before stale entries, so the next `openai/*` model call can start with the login that just succeeded.

## Evidence

- Current-main baseline: `2e3f734017b9b1a5a32ba11d844d1fa7a5141de9`.
- Before: Codex reported a healthy ChatGPT login and OpenClaw listed a healthy OAuth profile, but the selected Codex runtime had no effective profile. Real Luna and Sol turns stopped before provider dispatch with `Explicit auth order for openai has no usable profiles.`
- After: OpenClaw device login stored the fresh OAuth profile, agent-local order became `[fresh, stale]`, and status reported a usable Codex runtime route.
- Live exact-head result: a real `openclaw agent --local` Luna turn returned exactly `ISSUE_135140_EXACT_HEAD_GREEN_2` through provider `openai`.
- Shipped CLI regression: `models auth login --provider openai --agent main` failed on the baseline because local order stayed absent; passed after the fix with `[fresh, stale]`.
- Focused CLI, owner, and sibling tests: 131 passed across login promotion, auth upsert/rollback, shared-store relocation, and runtime auth planning.
- Oxfmt, Oxlint, and `git diff --check`: passed.
- Autoreview P0: clean.

Production delta: `+4/-5` (net `-1`). Test delta: `+108/-0`.
