### PR TITLE
fix(macos): restore app builds with Xcode 27

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardLinkBrowserTabBar.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardLinkBrowserTabBar.swift
@@ -182,13 +182,7 @@ private final class DashboardLinkBrowserTabItemView: NSView {
 
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
-        // SDK 27 restores AppKit's "Color" suffix; older Swift importers expose
-        // the same API as quinaryLabel.
-        #if compiler(>=6.4)
-        let hoverColor = NSColor.quinaryLabelColor
-        #else
         let hoverColor = NSColor.quinaryLabel
-        #endif
         let color: NSColor? = if self.isActive {
             .quaternaryLabelColor
         } else if self.isHovered {

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -154,21 +154,12 @@ helper_bin_for_arch() {
 
 build_mlx_tts_helper() {
   local arch="$1"
-  local swift_path
-  local toolchain_metal
-  local swift_args=(build)
-
-  swift_path="$(xcrun --find swift)"
-  toolchain_metal="$(dirname "$swift_path")/metal"
-
-  if [[ -x "$toolchain_metal" ]] &&
-    ! "$toolchain_metal" --version >/dev/null 2>&1 &&
-    xcrun metal --version >/dev/null 2>&1; then
-    echo "⚠️  Xcode's default Metal shim cannot use the installed toolchain; using the native SwiftPM backend"
-    swift_args+=(--build-system native)
+  if ! xcrun metal --version >/dev/null 2>&1; then
+    echo "ERROR: MLX TTS requires the Xcode Metal Toolchain. Install it with: xcodebuild -downloadComponent MetalToolchain" >&2
+    return 1
   fi
 
-  swift "${swift_args[@]}" \
+  swift build \
     --package-path "$MLX_TTS_HELPER_ROOT" \
     -c "$BUILD_CONFIG" \
     --product "$MLX_TTS_HELPER_PRODUCT" \
@@ -942,14 +933,19 @@ fi
 
 echo "📦 Copying SwiftPM resource bundles"
 SWIFTPM_BUILD_PRODUCTS="$(build_path_for_arch "$PRIMARY_ARCH")/$BUILD_CONFIG"
-# Generated Bundle.module accessors resolve from Bundle.main.bundleURL. In a packaged app,
-# that is the .app root, not Contents/Resources; placing a bundle there traps on first access.
-for resource_bundle_src in "$SWIFTPM_BUILD_PRODUCTS"/*.bundle; do
-  [[ -d "$resource_bundle_src" ]] || continue
-  resource_bundle="${resource_bundle_src##*/}"
-  rm -rf "$APP_ROOT/Contents/Resources/$resource_bundle"
-  cp -R "$resource_bundle_src" "$APP_ROOT/Contents/Resources/$resource_bundle"
-done
+copy_swiftpm_resource_bundles() {
+  local build_products="$1"
+  local resource_bundle_src resource_bundle
+  for resource_bundle_src in "$build_products"/*.bundle; do
+    [[ -d "$resource_bundle_src" ]] || continue
+    resource_bundle="${resource_bundle_src##*/}"
+    rm -rf "$APP_ROOT/Contents/Resources/$resource_bundle"
+    cp -R "$resource_bundle_src" "$APP_ROOT/Contents/Resources/$resource_bundle"
+  done
+}
+
+# Generated Bundle.module accessors resolve from Bundle.main.resourceURL in a packaged app.
+copy_swiftpm_resource_bundles "$SWIFTPM_BUILD_PRODUCTS"
 REQUIRED_SWIFTPM_RESOURCE_BUNDLES=(
   "GRDB_GRDB.bundle"
   "KeyboardShortcuts_KeyboardShortcuts.bundle"
@@ -957,12 +953,28 @@ REQUIRED_SWIFTPM_RESOURCE_BUNDLES=(
   "OpenClawKit_OpenClawKit.bundle"
   "SwiftMath_SwiftMath.bundle"
 )
+if [[ "$SKIP_MLX_TTS" != "1" ]]; then
+  MLX_TTS_SWIFTPM_BUILD_PRODUCTS="$(helper_build_path_for_arch "$PRIMARY_ARCH")/$BUILD_CONFIG"
+  copy_swiftpm_resource_bundles "$MLX_TTS_SWIFTPM_BUILD_PRODUCTS"
+  REQUIRED_SWIFTPM_RESOURCE_BUNDLES+=(
+    "mlx-swift_Cmlx.bundle"
+    "swift-crypto_Crypto.bundle"
+    "swift-transformers_Hub.bundle"
+  )
+fi
 for resource_bundle in "${REQUIRED_SWIFTPM_RESOURCE_BUNDLES[@]}"; do
   if [[ ! -d "$APP_ROOT/Contents/Resources/$resource_bundle" ]]; then
-    echo "ERROR: Required SwiftPM resource bundle not found at $SWIFTPM_BUILD_PRODUCTS/$resource_bundle" >&2
+    echo "ERROR: Required SwiftPM resource bundle not found at $APP_ROOT/Contents/Resources/$resource_bundle" >&2
     exit 1
   fi
 done
+if [[ "$SKIP_MLX_TTS" != "1" ]]; then
+  MLX_METAL_LIBRARY="$APP_ROOT/Contents/Resources/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib"
+  if [[ ! -f "$MLX_METAL_LIBRARY" ]]; then
+    echo "ERROR: Required MLX Metal library not found at $MLX_METAL_LIBRARY" >&2
+    exit 1
+  fi
+fi
 
 running_packaged_app_pids() {
   command -v pgrep >/dev/null 2>&1 || return 0

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -523,6 +523,12 @@ const swiftPMResourceBundles = [
   "SwiftMath_SwiftMath.bundle",
 ] as const;
 
+const mlxTTSResourceBundles = [
+  "mlx-swift_Cmlx.bundle",
+  "swift-crypto_Crypto.bundle",
+  "swift-transformers_Hub.bundle",
+] as const;
+
 function runSwiftPMResourceBundleHarness(missingBundle?: string) {
   const root = tempDirs.make("openclaw-package-resources-root-");
   const buildRoot = path.join(root, "build");
@@ -545,8 +551,59 @@ function runSwiftPMResourceBundleHarness(missingBundle?: string) {
     APP_ROOT=${JSON.stringify(appRoot)}
     PRIMARY_ARCH=arm64
     BUILD_CONFIG=debug
+    SKIP_MLX_TTS=1
     build_path_for_arch() {
       echo "$BUILD_ROOT/$1"
+    }
+    ${getSwiftPMResourceBundleBlock()}
+  `);
+
+  return { appRoot, result };
+}
+
+function runMLXTTSResourceBundleHarness(options?: {
+  missingBundle?: string;
+  omitMetallib?: boolean;
+  skipHelper?: boolean;
+}) {
+  const root = tempDirs.make("openclaw-package-mlx-resources-root-");
+  const buildRoot = path.join(root, "main-build");
+  const helperBuildRoot = path.join(root, "helper-build");
+  const appRoot = path.join(root, "OpenClaw.app");
+  const mainBuildProducts = path.join(buildRoot, "arm64", "debug");
+  const helperBuildProducts = path.join(helperBuildRoot, "arm64", "debug");
+
+  mkdirSync(path.join(appRoot, "Contents", "Resources"), { recursive: true });
+  for (const bundle of swiftPMResourceBundles) {
+    const source = path.join(mainBuildProducts, bundle);
+    mkdirSync(source, { recursive: true });
+    writeFileSync(path.join(source, "marker"), bundle, "utf8");
+  }
+  for (const bundle of mlxTTSResourceBundles) {
+    if (bundle === options?.missingBundle) {
+      continue;
+    }
+    const source = path.join(helperBuildProducts, bundle);
+    mkdirSync(path.join(source, "Contents", "Resources"), { recursive: true });
+    writeFileSync(path.join(source, "marker"), bundle, "utf8");
+    if (bundle === "mlx-swift_Cmlx.bundle" && !options?.omitMetallib) {
+      writeFileSync(path.join(source, "Contents", "Resources", "default.metallib"), "metal");
+    }
+  }
+
+  const result = runHelper(`
+    set -euo pipefail
+    BUILD_ROOT=${JSON.stringify(buildRoot)}
+    MLX_TTS_HELPER_BUILD_ROOT=${JSON.stringify(helperBuildRoot)}
+    APP_ROOT=${JSON.stringify(appRoot)}
+    PRIMARY_ARCH=arm64
+    BUILD_CONFIG=debug
+    SKIP_MLX_TTS=${options?.skipHelper ? "1" : "0"}
+    build_path_for_arch() {
+      echo "$BUILD_ROOT/$1"
+    }
+    helper_build_path_for_arch() {
+      echo "$MLX_TTS_HELPER_BUILD_ROOT/$1"
     }
     ${getSwiftPMResourceBundleBlock()}
   `);
@@ -1042,18 +1099,17 @@ describe("package-mac-app plist stamping", () => {
   );
 
   it.each([
-    { title: "keeps the default backend when Xcode's Metal shim works", shimExit: 0, xcrunExit: 0 },
     {
-      title: "uses the native backend when xcrun can run Metal but Xcode's shim is broken",
-      shimExit: 1,
+      title: "uses the default backend when the Metal Toolchain is installed",
       xcrunExit: 0,
+      expectedBackend: "default",
     },
     {
-      title: "keeps the default backend when no working Metal compiler is installed",
-      shimExit: 1,
+      title: "fails with installation guidance when the Metal Toolchain is unavailable",
       xcrunExit: 1,
+      expectedBackend: null,
     },
-  ])("$title", ({ shimExit, xcrunExit }) => {
+  ])("$title", ({ xcrunExit, expectedBackend }) => {
     const helperBlock = getMLXTTSHelperBuildBlock();
     const tempRoot = tempDirs.make("openclaw-package-mlx-metal-");
     const toolsDir = path.join(tempRoot, "tools");
@@ -1081,7 +1137,6 @@ describe("package-mac-app plist stamping", () => {
         '#!/usr/bin/env bash\nprintf "%s\\n" "$@" > "$MOCK_SWIFT_ARGS"\n',
       ],
       [path.join(toolchainDir, "swift"), "#!/usr/bin/env bash\nexit 0\n"],
-      [path.join(toolchainDir, "metal"), `#!/usr/bin/env bash\nexit ${shimExit}\n`],
     ];
 
     for (const [toolPath, contents] of tools) {
@@ -1106,17 +1161,20 @@ describe("package-mac-app plist stamping", () => {
       "/bin/bash",
     );
 
+    if (expectedBackend === null) {
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("xcodebuild -downloadComponent MetalToolchain");
+      expect(existsSync(invocationPath)).toBe(false);
+      return;
+    }
+
     expect(result.status, result.stderr).toBe(0);
     const swiftArgs = readFileSync(invocationPath, "utf8").trim().split("\n");
     expect(swiftArgs[0]).toBe("build");
     expect(swiftArgs).toContain("--package-path");
     expect(swiftArgs).toContain("--arch");
     expect(swiftArgs).toContain("arm64");
-    if (shimExit === 0 || xcrunExit !== 0) {
-      expect(swiftArgs).not.toContain("--build-system");
-    } else {
-      expect(swiftArgs.slice(1, 3)).toEqual(["--build-system", "native"]);
-    }
+    expect(swiftArgs).not.toContain("--build-system");
   });
 
   it("skips the MLX TTS helper build and copy when OPENCLAW_SKIP_MLX_TTS=1", () => {
@@ -1549,6 +1607,54 @@ describe("package-mac-app plist stamping", () => {
     }
   });
 
+  it("copies every MLX TTS resource bundle and requires its default Metal library", () => {
+    const { appRoot, result } = runMLXTTSResourceBundleHarness();
+
+    expect(result.status, result.stderr).toBe(0);
+    for (const bundle of mlxTTSResourceBundles) {
+      expect(
+        readFileSync(path.join(appRoot, "Contents", "Resources", bundle, "marker"), "utf8"),
+      ).toBe(bundle);
+    }
+    expect(
+      readFileSync(
+        path.join(
+          appRoot,
+          "Contents",
+          "Resources",
+          "mlx-swift_Cmlx.bundle",
+          "Contents",
+          "Resources",
+          "default.metallib",
+        ),
+        "utf8",
+      ),
+    ).toBe("metal");
+  });
+
+  it("fails when an MLX TTS resource bundle or default Metal library is missing", () => {
+    for (const missingBundle of mlxTTSResourceBundles) {
+      const { result } = runMLXTTSResourceBundleHarness({ missingBundle });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("ERROR: Required SwiftPM resource bundle not found at");
+      expect(result.stderr).toContain(missingBundle);
+    }
+
+    const { result } = runMLXTTSResourceBundleHarness({ omitMetallib: true });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("ERROR: Required MLX Metal library not found at");
+  });
+
+  it("does not require MLX TTS resources when the helper is explicitly skipped", () => {
+    const { result } = runMLXTTSResourceBundleHarness({
+      missingBundle: "mlx-swift_Cmlx.bundle",
+      skipHelper: true,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+  });
+
   it("routes dependency resource lookups into signed app resources and restores sources", () => {
     const { fixtures, result } = runSwiftPMResourcePatchHarness();
 
@@ -1578,13 +1684,18 @@ describe("package-mac-app plist stamping", () => {
       'node --import tsx "$ROOT_DIR/scripts/apple-app-i18n.ts" compile-macos',
     );
     expect(script).toContain('--output "$APP_ROOT/Contents/Resources"');
-    expect(resourceBlock).toContain(
-      'for resource_bundle_src in "$SWIFTPM_BUILD_PRODUCTS"/*.bundle',
-    );
+    expect(resourceBlock).toContain('for resource_bundle_src in "$build_products"/*.bundle');
     expect(resourceBlock).toContain(
       'cp -R "$resource_bundle_src" "$APP_ROOT/Contents/Resources/$resource_bundle"',
     );
+    expect(resourceBlock).toContain('copy_swiftpm_resource_bundles "$SWIFTPM_BUILD_PRODUCTS"');
+    expect(resourceBlock).toContain(
+      'copy_swiftpm_resource_bundles "$MLX_TTS_SWIFTPM_BUILD_PRODUCTS"',
+    );
     for (const bundle of swiftPMResourceBundles) {
+      expect(resourceBlock).toContain(`"${bundle}"`);
+    }
+    for (const bundle of mlxTTSResourceBundles) {
       expect(resourceBlock).toContain(`"${bundle}"`);
     }
     expect(resourceBlock).toContain("ERROR: Required SwiftPM resource bundle not found");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers building the macOS app with Xcode 27 would hit an AppKit compile error, and where MLX TTS packages built through the fallback backend could omit the resource bundles and Metal library required at runtime.

## Why This Change Was Made

Use AppKit's importer-stable `quinaryLabel` spelling on both Xcode 26 and 27. Require the Xcode Metal Toolchain for MLX TTS, keep SwiftPM's default build backend, and copy plus verify every helper resource bundle and its compiled Metal library in the app package.

This removes the incomplete native-backend fallback instead of keeping two packaging paths. The explicit `OPENCLAW_SKIP_MLX_TTS=1` developer path remains unchanged.

## User Impact

Developers can build the current macOS app with Xcode 27 without patching AppKit source locally. Packaged MLX TTS helpers now include the resources needed to synthesize speech instead of producing an app that builds but fails when MLX loads its default Metal library.

## Evidence

- Reproduced the Xcode 27 compiler failure for `NSColor.quinaryLabelColor`; the same compiler accepts `NSColor.quinaryLabel`.
- Before the fix, the native SwiftPM fallback produced the helper executable without the MLX, Hub, or Crypto bundles. The pinned MLX runtime throws when it cannot find `default.metallib`.
- With the Xcode Metal Toolchain installed, the default SwiftPM backend built the helper plus all three required bundles and a 3.7 MiB `default.metallib`.
- A packaged-layout smoke test copied that executable and those bundles into an `.app` and completed a real MLX TTS request: 32 kHz mono PCM, 151,552 bytes.
- Regression proof: the new backend-guidance test and resource-copy test fail against the old script and pass with this change.
- `node scripts/run-vitest.mjs test/scripts/package-mac-app.test.ts`: 75 tests passed.
- `node scripts/check-changed.mjs -- apps/macos/Sources/OpenClaw/DashboardLinkBrowserTabBar.swift scripts/package-mac-app.sh test/scripts/package-mac-app.test.ts`: passed after rebasing onto current `main`.
- Independent structured review: clean at the blocker threshold.

The full local package wrapper could not complete in the isolated worktree because its intentionally symlinked dependency tree failed the existing package-integrity gate. The gate was not weakened. Hosted macOS CI is the clean-install package proof and also provides the required Xcode 26 compatibility check.

Production delta is +6 lines net (28 added, 22 removed after excluding tests); tests are +111 lines net. The production growth centralizes resource copying and makes the three helper bundles plus Metal library explicit package invariants.
