### PR TITLE
test(cua): synchronize transport and recording fixtures

### DIFF
--- a/extensions/cua-computer/src/mcp-driver-client.test.ts
+++ b/extensions/cua-computer/src/mcp-driver-client.test.ts
@@ -294,6 +294,22 @@ describe.runIf(process.platform !== "win32")("CUA MCP proxy transport", () => {
         fake.respond(request, sessionState("window"));
       } else if (request.method === "tools/call" && request.params?.name === "list_windows") {
         held.push(request);
+        if (held.length !== 2) {
+          return;
+        }
+        const firstRequest = held.find((call) => call.params?.arguments?.marker === "first");
+        const secondRequest = held.find((call) => call.params?.arguments?.marker === "second");
+        if (!firstRequest || !secondRequest) {
+          throw new Error("fixture did not receive both tagged requests");
+        }
+        const framed = Buffer.from(
+          `${JSON.stringify({ jsonrpc: "2.0", id: secondRequest.id, result: toolResult({ marker: "second", text: "β雪" }) })}\n\n${JSON.stringify({ jsonrpc: "2.0", id: firstRequest.id, result: toolResult({ marker: "first" }) })}\n`,
+        );
+        const split = framed.indexOf(Buffer.from("雪")) + 1;
+        expect(split).toBeGreaterThan(0);
+        // Receiving both requests owns the response; cold proxy startup is not a polling deadline.
+        fake.writeRaw(secondRequest, framed.subarray(0, split));
+        setImmediate(() => fake.writeRaw(secondRequest, framed.subarray(split)));
       } else if (request.method === "tools/call" && request.params?.name === "end_session") {
         fake.respond(request, toolResult({ session: "openclaw-test", active: false }));
       }
@@ -309,24 +325,6 @@ describe.runIf(process.platform !== "win32")("CUA MCP proxy transport", () => {
       settlement.push("second");
       return result;
     });
-    await vi.waitFor(() => expect(held).toHaveLength(2));
-    const firstRequest = held.find((request) => request.params?.arguments?.marker === "first");
-    const secondRequest = held.find((request) => request.params?.arguments?.marker === "second");
-    if (!firstRequest || !secondRequest) {
-      throw new Error("fixture did not receive both tagged requests");
-    }
-
-    const framed = Buffer.from(
-      `${JSON.stringify({ jsonrpc: "2.0", id: secondRequest.id, result: toolResult({ marker: "second", text: "β雪" }) })}\n\n${JSON.stringify({ jsonrpc: "2.0", id: firstRequest.id, result: toolResult({ marker: "first" }) })}\n`,
-    );
-    const split = framed.indexOf(Buffer.from("雪")) + 1;
-    expect(split).toBeGreaterThan(0);
-    endpoint.writeRaw(secondRequest, framed.subarray(0, split));
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
-    endpoint.writeRaw(secondRequest, framed.subarray(split));
-
     const [first, second] = await Promise.all([firstCall, secondCall]);
     expect(JSON.parse(first.structuredJson!)).toEqual({ marker: "first" });
     expect(JSON.parse(second.structuredJson!)).toEqual({ marker: "second", text: "β雪" });

--- a/extensions/cua-computer/src/recording-actions.test.ts
+++ b/extensions/cua-computer/src/recording-actions.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, describe, expect, it, onTestFinished } from "vitest";
 import { driver, execution } from "./commands.test-helpers.js";
 import {
   CUA_DRIVER_CONTRACT_FIXTURES,
@@ -159,28 +160,29 @@ describe("cua-computer recording actions", () => {
   it("finalizes an in-flight recording once on every execution close", async () => {
     const active = driver();
     let nativeRecordingRoot = "";
-    let releaseStart: (() => void) | undefined;
-    const startGate = new Promise<void>((resolve) => {
-      releaseStart = resolve;
-    });
+    const startEntered = createDeferred<void>();
+    const startGate = createDeferred<void>();
     active.callTool.mockImplementation(async (name, args) => {
       if (name === "start_recording") {
         nativeRecordingRoot = String(args.output_dir);
-        await startGate;
+        startEntered.resolve();
+        await startGate.promise;
         return cuaToolResult(CUA_DRIVER_CONTRACT_FIXTURES.recordingActive);
       }
       return cuaToolResult(CUA_DRIVER_CONTRACT_FIXTURES.recordingStopped);
     });
     const computer = await execution(active.session);
+    onTestFinished(async () => {
+      startGate.resolve();
+      await computer.close("cancel");
+    });
 
     const start = computer.act(JSON.stringify({ action: "start_recording" }));
-    await vi.waitFor(() =>
-      expect(active.callTool).toHaveBeenCalledWith("start_recording", expect.anything(), undefined),
-    );
+    // Close only after the driver is in flight, regardless of resource-creation latency.
+    await Promise.race([startEntered.promise, start]);
     const close = computer.close("cancel");
-    releaseStart?.();
-    await start;
-    await close;
+    startGate.resolve();
+    await Promise.all([start, close]);
     await computer.close("cancel");
 
     expect(active.callTool.mock.calls.map(([name]) => name)).toEqual([


### PR DESCRIPTION
Related: #135094, #134903, #134911

## What Problem This Solves

Resolves a problem where CUA stress tests fail before their fixture has reached the state under test. The fragmented MCP response test used a one-second polling deadline while its real proxy child was still starting; the recording close test used the same deadline while its resource directory was still being created. The MCP polling failure also left both tool promises unobserved during cleanup.

## Why This Change Was Made

The fake MCP endpoint sends its reversed, byte-fragmented responses when both tagged requests arrive, and the test immediately awaits both calls. The recording fixture signals entry into the driver call, then queues close while that call remains held. A finalization hook releases the hold and closes the execution if the test fails. Existing UTF-8, response ordering, exactly-once stop/dispose, and directory cleanup assertions remain intact.

This changes two tests only: production +0/-0; tests +30/-30 (net zero). No runtime timeout, retry, schema, configuration or production API change.

## User Impact

No runtime behavior change. Developers get synchronization tied to the events being tested, without an additional one-second startup or filesystem deadline.

## Evidence

Both original failures were observed in repeated runs of all CUA plugin suites together with node computer and desktop-stream contracts. The two changed test files subsequently passed all seven focused tests. A fresh managed Codex review found no actionable findings.

Three complete passes of the same 15-file scope passed with `OPENCLAW_VITEST_MAX_WORKERS=4`: 135 tests per cycle (112 across all 13 CUA plugin test files plus 23 node computer/desktop-stream tests), zero unhandled rejections. Durations: 27.84s, 16.45s, and 15.21s. The scheduling budget is declared; no assertion or runtime deadline was relaxed.

Focused reproduction/verification command: `node scripts/run-vitest.mjs extensions/cua-computer/src/mcp-driver-client.test.ts extensions/cua-computer/src/recording-actions.test.ts`.

The complete changed-file gate passed: extension test types, lint, formatting, plugin boundaries, dependency pins/patches, coercion/deprecation checks and dead export scans. `node scripts/check-changed.mjs -- extensions/cua-computer/src/mcp-driver-client.test.ts extensions/cua-computer/src/recording-actions.test.ts` exited 0 in 258.00s.

One later unrestricted run timed out in the unchanged proxy initialization test at the existing 10-second production deadline. Both repaired tests passed in that run, with no unhandled rejections. The initialization timeout remains a separate unresolved stress observation; this PR does not increase its deadline or claim to repair it.

The native landing helper requires creating a newly registered PR worktree and cannot reuse this existing ordinary checkout. To honor the explicit no-new-worktree instruction, this PR uses the existing checkout, managed review, exact-head required CI, latest review findings, and the normal protected GitHub merge with an exact head guard. No administrator override, automatic merge, or branch-protection bypass is used.

Verified source commit: `af20ccaabb4ee200b32d5a9b02b9a272622bcf33`. The final committed patch is identical to the reviewed and stress-tested candidate.

CI follow-through: the initial run33533933298 failed in both lint and package-boundary preparation on the existing protocol declaration TS7056. Main repair #135360 landed as `6abc3adf10bf17121c10cb347654e895cce261c3`; this branch was mechanically refreshed onto main `91067e340a1811f94a3f119fae329542c3f23872`. The complete two-file patch remains byte-identical to the reviewed and stress-tested candidate. Exact-head CI is being rerun; no failed gate was bypassed.
