### PR TITLE
fix(firecrawl): report an unresolvable self-hosted baseUrl as a DNS failure

### DIFF
--- a/extensions/firecrawl/src/firecrawl-client.test.ts
+++ b/extensions/firecrawl/src/firecrawl-client.test.ts
@@ -1,4 +1,5 @@
 // Focused parser contracts; public Firecrawl execution lives in firecrawl-tools.test.ts.
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { beforeAll, describe, expect, it } from "vitest";
 
 let firecrawlClient: typeof import("./firecrawl-client.js").testing;
@@ -212,5 +213,41 @@ describe("Firecrawl scrape payloads", () => {
         maxChars: 1_000,
       }),
     ).toThrow("Firecrawl scrape returned no content.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveEndpoint self-hosted classification
+// ---------------------------------------------------------------------------
+describe("resolveEndpoint self-hosted classification", () => {
+  const publicLookup: LookupFn = async () => [{ address: "93.184.216.34", family: 4 }];
+  const privateLookup: LookupFn = async () => [{ address: "192.168.8.19", family: 4 }];
+
+  it("reports an unresolvable self-hosted host as a DNS failure, not a policy violation", async () => {
+    const unresolvable: LookupFn = async () => {
+      throw new Error("getaddrinfo ENOTFOUND firecrawl.lan");
+    };
+    await expect(
+      firecrawlClient.resolveEndpoint("http://firecrawl.lan:3002", "/v2/scrape", unresolvable),
+    ).rejects.toThrow("Unable to resolve Firecrawl baseUrl host: firecrawl.lan");
+  });
+
+  it("reports an empty DNS answer as a resolution failure", async () => {
+    const empty: LookupFn = async () => [];
+    await expect(
+      firecrawlClient.resolveEndpoint("http://raspberrypi:3002", "/v2/scrape", empty),
+    ).rejects.toThrow("Unable to resolve Firecrawl baseUrl host: raspberrypi");
+  });
+
+  it("keeps the public-endpoint rejection for a resolvable public host", async () => {
+    await expect(
+      firecrawlClient.resolveEndpoint("https://attacker.example", "/v2/search", publicLookup),
+    ).rejects.toThrow("Firecrawl custom baseUrl must target a private or internal");
+  });
+
+  it("classifies a host that resolves to a private address as self-hosted", async () => {
+    await expect(
+      firecrawlClient.resolveEndpoint("http://firecrawl.lan:3002", "/v2/scrape", privateLookup),
+    ).resolves.toEqual({ url: "http://firecrawl.lan:3002/v2/scrape", mode: "selfHosted" });
   });
 });

--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -126,24 +126,6 @@ function isOfficialFirecrawlEndpoint(url: URL): boolean {
   return url.protocol === "https:" && ALLOWED_FIRECRAWL_HOSTS.has(url.hostname);
 }
 
-async function firecrawlEndpointTargetsPrivateNetwork(
-  url: URL,
-  lookupFn?: LookupFn,
-): Promise<boolean> {
-  if (isBlockedHostnameOrIp(url.hostname)) {
-    return true;
-  }
-  try {
-    const pinned = await resolvePinnedHostnameWithPolicy(url.hostname, {
-      lookupFn,
-      policy: { allowPrivateNetwork: true },
-    });
-    return pinned.addresses.every((address) => isPrivateIpAddress(address));
-  } catch {
-    return false;
-  }
-}
-
 async function validateFirecrawlBaseUrl(
   baseUrl: string,
   lookupFn?: LookupFn,
@@ -162,8 +144,19 @@ async function validateFirecrawlBaseUrl(
     return "strict";
   }
 
-  const isPrivateTarget = await firecrawlEndpointTargetsPrivateNetwork(url, lookupFn);
-  if (isPrivateTarget) {
+  if (isBlockedHostnameOrIp(url.hostname)) {
+    return "selfHosted";
+  }
+  // Private addresses are allowed during resolution; a lookup failure must not
+  // become a public-endpoint policy error.
+  const pinned = await resolvePinnedHostnameWithPolicy(url.hostname, {
+    lookupFn,
+    policy: { allowPrivateNetwork: true },
+  }).catch((reason: unknown) => {
+    const cause = reason instanceof Error ? reason.message : String(reason);
+    throw new Error(`Unable to resolve Firecrawl baseUrl host: ${url.hostname} (${cause})`);
+  });
+  if (pinned.addresses.every((address) => isPrivateIpAddress(address))) {
     return "selfHosted";
   }
   if (url.protocol === "http:") {

--- a/extensions/firecrawl/src/firecrawl-dns.test.ts
+++ b/extensions/firecrawl/src/firecrawl-dns.test.ts
@@ -1,0 +1,51 @@
+import { lookup } from "node:dns/promises";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createFirecrawlWebFetchProvider } from "../web-fetch-provider.js";
+import { createFirecrawlFreeWebSearchProvider } from "../web-search-provider.js";
+
+const unresolvableHost = "openclaw-firecrawl-proof.invalid";
+
+beforeAll(async () => {
+  // .invalid must fail in the real resolver before any provider request can be sent.
+  await expect(lookup(unresolvableHost, { all: true })).rejects.toMatchObject({
+    code: "ENOTFOUND",
+  });
+});
+
+beforeEach(() => {
+  vi.stubEnv("FIRECRAWL_API_KEY", undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe.each(["search", "scrape"] as const)("Firecrawl %s DNS diagnostics", (operation) => {
+  it.each(["http", "https"])("preserves the real resolver failure for %s", async (scheme) => {
+    const baseUrl = `${scheme}://${unresolvableHost}:3002`;
+    const config: OpenClawConfig = {
+      plugins: {
+        entries: {
+          firecrawl: { config: { webSearch: { baseUrl }, webFetch: { baseUrl } } },
+        },
+      },
+    };
+    const provider =
+      operation === "search"
+        ? createFirecrawlFreeWebSearchProvider()
+        : createFirecrawlWebFetchProvider();
+    const tool = provider.createTool({ config });
+    if (!tool) {
+      throw new Error("Expected Firecrawl provider tool");
+    }
+    const args =
+      operation === "search"
+        ? { query: "synthetic DNS proof" }
+        : { url: "https://example.com/proof", extractMode: "text" };
+
+    await expect(tool.execute(args)).rejects.toThrow(
+      /Unable to resolve Firecrawl baseUrl host: openclaw-firecrawl-proof\.invalid.*ENOTFOUND/,
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes the DNS-diagnostic bug reported in #135333, following the self-hosted Firecrawl work discussed in #63877.

When a configured self-hosted `baseUrl` cannot resolve, Firecrawl currently reports a private-network policy violation. For example, `http://firecrawl.lan:3002` produces advice to use HTTPS for public hosts, even when the actual error is `getaddrinfo ENOTFOUND`. That sends operators toward the wrong configuration change.

## Why This Change Was Made

`firecrawlEndpointTargetsPrivateNetwork()` caught hostname-resolution failures and returned `false`. Its caller could no longer distinguish an unresolved host from a host that resolved to a public address.

The fix folds that one-use helper into `validateFirecrawlBaseUrl()`. Lookup failures now retain the hostname and underlying resolver error. Resolved addresses still pass through the same private-address classification. This keeps the decision in the Firecrawl endpoint owner shared by search and scrape, without adding a new configuration option or changing the shared SSRF policy.

The follow-up adds a permanent regression through the public search and fetch provider entrypoints using the real operating-system resolver, and shortens the explanatory comment.

## User Impact

An unresolved configured endpoint now reports:

```text
Unable to resolve Firecrawl baseUrl host: firecrawl.lan (getaddrinfo ENOTFOUND firecrawl.lan)
```

The operator can check the hostname and DNS configuration directly. Public custom endpoints remain rejected; private endpoints, existing local/internal-name shortcuts, and the official HTTPS endpoint retain their behavior. The separate restriction on private scrape-page targets also remains in place.

## Evidence

### Rebase onto current main (no code change)

The PR was rebased onto `e789c56ecd7f` (current main) to resolve the reported merge conflicts with the test-file consolidation in #137603. The production fix and both regression files keep their exact bytes; the only relocation is the `resolveEndpoint` regression block, which now appends unchanged to the consolidated `firecrawl-client.test.ts` parser-contract file. Current head: `9b8085eb634d7f36231ac1befb572f62ad646488`.

Re-validation of the rebased candidate: `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` both pass, and the full Firecrawl suite passes 103 tests plus 4 skips — every file except `firecrawl-dns.test.ts`, whose `beforeAll` real-resolver precondition cannot fail in the local sandbox because its DNS resolver sinkholes every name, including `.invalid`, to a local address. That file is byte-identical to the reviewed version below and is validated by CI's real resolver on the new head.

**Current candidate:** `09c28d2ad1684b197f7b4e6365a16f64e9f89d9e`. [CI for this updated head](https://github.com/openclaw/openclaw/actions/runs/33608108267) is green. Its [changed-plugin job](https://github.com/openclaw/openclaw/actions/runs/33608108267/job/100176867250) passed all four real-DNS cases and the full Firecrawl suite: 4 files / 139 tests, without skips. The enclosing shard passed 73 files / 1,405 tests. The tested merge `c29c4665fec357089371f2146d3f50987d2e7d1c` contains the published head and unchanged regression bytes; its log records Secret source: None.

### Independent reproduction on trusted main

The exact new `extensions/firecrawl/src/firecrawl-dns.test.ts` was run against main `1b5dc72557c5c0bdabd95cf0f4068f5cddcd041d`:

```sh
node scripts/run-vitest.mjs extensions/firecrawl/src/firecrawl-dns.test.ts --reporter=verbose
```

Result: **1 failed file / 4 failed tests**, all at the intended DNS-diagnostic assertion. The real resolver precondition returned `ENOTFOUND`; HTTP and HTTPS calls through both the search and fetch providers instead produced the old policy messages. The test ran with a fresh HOME and no provider credentials. Its SHA-256 is `208456f9e242e814b22e4de95fdbd7ea2425cc4c0d18655f2cdf05309b37a9fe`.

A separate production-entrypoint harness on trusted main `a204853a43b76183bd892b37d3df25a8143ab069` reproduced those four failures and passed seven controls: HTTP/HTTPS public endpoints were rejected for both providers, native loopback search and scrape requests succeeded, and a private scrape-page target was rejected. Exactly two requests reached the task-owned HTTP server, with no Authorization header. The implicated client, both provider owners and shared resolver were byte-identical across the two baselines.

### Existing candidate CI

[CI run 33559338038](https://github.com/openclaw/openclaw/actions/runs/33559338038) passed for the previous head `7b1c2121183501748868a541ab9a438d8937485c`. Its [changed-plugin test job](https://github.com/openclaw/openclaw/actions/runs/33559338038/job/100028041017) passed **72 files / 1,387 tests**, including the four original injected-resolver cases and existing hosted/private routing controls. The log records `Secret source: None`.

That run tested GitHub merge tree `b1e10a8c5e97cecf20498cdf08611e301d9a7e54`, combining the previous PR head with base `9101e7cc9de17bb661e2eb694090cc6a07c1752a`. It establishes earlier candidate evidence for the original fix; the current head additionally passes the real-DNS cases above.

### Regression coverage and remaining validation

The original tests cover resolver rejection, an empty DNS answer, a resolved public host and a resolved private host. The new 51-line test adds four public-provider cases: search and scrape, each over HTTP and HTTPS, using a reserved `.invalid` hostname with the real resolver. It introduces no production test seam, mock resolver, retry or timeout extension. The `beforeAll` precondition makes a resolver-environment failure visible separately from the diagnostic assertions.

Formatting passed for the new test. Independent Codex review found no blocking defect in the final change. Exact-head CI is green. The latest available ClawSweeper comment is the initial acknowledgement; no completed review or Rank-up list was available from current bounded reads. Independent source, behavior and Codex review are complete.

Production LOC: **+13/-20, net −7**. Tests: **+88/-0**.

## Scope and credit

The separate keyless self-hosted provider-selection UX described in #135333 remains a named follow-up: `firecrawl-free` honors the configured self-hosted `baseUrl`, while its label describes the hosted free tier. This change repairs DNS diagnostics; it does not alter credential requirements or provider selection.

Original fix and injected-resolver regression coverage by @ruel225; issue report by @guidoffm. The follow-up preserves contributor credit in the commit trailer.

