### PR TITLE
refactor(agents): reuse MCP metadata during inventory reads

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime-config.ts
+++ b/src/agents/agent-bundle-mcp-runtime-config.ts
@@ -150,34 +150,24 @@ export function resolveSessionMcpConfigSummary(params: {
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
   toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
 }): { fingerprint: string; serverNames: string[] } {
-  const { loaded, fingerprint } = loadSessionMcpConfig({
-    workspaceDir: params.workspaceDir,
-    cfg: params.cfg,
-    logDiagnostics: false,
-    manifestRegistry: params.manifestRegistry,
-    toolOverrides: params.toolOverrides,
-  });
-  const serverNames = Object.keys(loaded.mcpServers).toSorted((a, b) => a.localeCompare(b));
-  if (serverNames.length === 0) {
-    return { fingerprint, serverNames };
-  }
+  const loaded = loadEmbeddedAgentMcpConfig(params);
+  const declaredServerNames = Object.keys(loaded.mcpServers);
+  const serverNames = declaredServerNames.toSorted((a, b) => a.localeCompare(b));
   // Mirror getOrCreate: the bare-keyed runtime folds full-set safe names into
   // its fingerprint and excludes requester-scoped servers from its partition.
   // Compare apples-to-apples or tools.effective reports stale-config forever.
-  const safeServerNamesByServer = assignSafeServerNames(Object.keys(loaded.mcpServers));
+  const safeServerNamesByServer = assignSafeServerNames(declaredServerNames);
   const { requesterScopedServerNames } = partitionMcpServersByConnectionScope(loaded.mcpServers);
-  const { fingerprint: bareRuntimeFingerprint } = loadSessionMcpConfig({
-    workspaceDir: params.workspaceDir,
-    cfg: params.cfg,
+  const { fingerprint } = loadSessionMcpConfig({
+    ...params,
+    loaded,
     logDiagnostics: false,
-    manifestRegistry: params.manifestRegistry,
-    toolOverrides: params.toolOverrides,
     ...(requesterScopedServerNames.length > 0
       ? { excludeServerNames: new Set(requesterScopedServerNames) }
       : {}),
     safeServerNamesByServer,
   });
-  return { fingerprint: bareRuntimeFingerprint, serverNames };
+  return { fingerprint, serverNames };
 }
 
 /** Reads the enabled static MCP server set without opening transports or listing tools. */

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -3604,6 +3604,30 @@ describe("requester-scoped MCP connection resolution", () => {
     const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
     const { resolveSessionMcpConfigSummary } = await import("./agent-bundle-mcp-tools.js");
     const manager = testing.createSessionMcpRuntimeManager();
+    const expectBareRuntimeParity = async (params: {
+      sessionId: string;
+      cfg: NonNullable<RuntimeParams["cfg"]>;
+      expectedServerNames: string[];
+      toolOverrides?: RuntimeParams["toolOverrides"];
+      requesterSenderId?: string;
+    }) => {
+      const summary = resolveSessionMcpConfigSummary({
+        workspaceDir: "/workspace",
+        cfg: params.cfg,
+        ...(params.toolOverrides ? { toolOverrides: params.toolOverrides } : {}),
+      });
+      await manager.getOrCreate({
+        sessionId: params.sessionId,
+        workspaceDir: "/workspace",
+        cfg: params.cfg,
+        ...(params.toolOverrides ? { toolOverrides: params.toolOverrides } : {}),
+        ...(params.requesterSenderId ? { requesterSenderId: params.requesterSenderId } : {}),
+      });
+      expect(summary.serverNames).toEqual(params.expectedServerNames);
+      expect(summary.fingerprint).toBe(
+        manager.peekSession({ sessionId: params.sessionId })?.configFingerprint,
+      );
+    };
     const cfg = {
       mcp: {
         servers: {
@@ -3611,48 +3635,66 @@ describe("requester-scoped MCP connection resolution", () => {
           "user-mail": { transport: "streamable-http", url: "https://static.example.test" },
         },
       },
-    };
+    } satisfies NonNullable<RuntimeParams["cfg"]>;
 
-    // Static-only config: the summary must match the bare runtime byte-for-byte.
-    const staticRuntime = await manager.getOrCreate({
+    await expectBareRuntimeParity({
       sessionId: "session-parity-static",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
+      cfg,
+      expectedServerNames: ["shared", "user-mail"],
     });
-    expect(
-      resolveSessionMcpConfigSummary({ workspaceDir: "/workspace", cfg: cfg as never }).fingerprint,
-    ).toBe(staticRuntime.configFingerprint);
 
     const toolOverrides = { mcpServers: { shared: false } };
-    const overriddenSummary = resolveSessionMcpConfigSummary({
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      toolOverrides,
-    });
-    const overriddenRuntime = await manager.getOrCreate({
+    await expectBareRuntimeParity({
       sessionId: "session-parity-overridden",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
+      cfg,
+      expectedServerNames: ["user-mail"],
       toolOverrides,
     });
-    expect(overriddenSummary.serverNames).toEqual(["user-mail"]);
-    expect(overriddenSummary.fingerprint).toBe(overriddenRuntime.configFingerprint);
+
+    await expectBareRuntimeParity({
+      sessionId: "session-parity-denials",
+      cfg,
+      expectedServerNames: ["shared", "user-mail"],
+      toolOverrides: { mcpToolsDeny: { shared: ["private", "private"] } },
+    });
+
+    await expectBareRuntimeParity({
+      sessionId: "session-parity-empty",
+      cfg: {},
+      expectedServerNames: [],
+    });
+
+    // Full-set declaration order owns safe-name collision suffixes even though
+    // requester-scoped OAuth servers stay out of the bare runtime partition.
+    await expectBareRuntimeParity({
+      sessionId: "session-parity-oauth",
+      cfg: {
+        mcp: {
+          servers: {
+            "shared name": { command: "true" },
+            "shared-name": {
+              transport: "streamable-http",
+              auth: "oauth",
+              oauth: { identity: "per-requester" },
+              url: "https://scoped.example.test",
+            },
+          },
+        },
+      },
+      expectedServerNames: ["shared name", "shared-name"],
+    });
 
     // With a resolver registered, tools.effective peeks the bare static-partition
     // runtime; summary parity keeps it from reporting stale-config forever.
     resolverTesting.setMcpServerConnectionResolversForTest([
       { serverName: "user-mail", resolve: async () => null },
     ]);
-    await manager.getOrCreate({
+    await expectBareRuntimeParity({
       sessionId: "session-parity-scoped",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
+      cfg,
+      expectedServerNames: ["shared", "user-mail"],
       requesterSenderId: "sender-a",
     });
-    const peeked = manager.peekSession({ sessionId: "session-parity-scoped" });
-    expect(peeked?.configFingerprint).toBe(
-      resolveSessionMcpConfigSummary({ workspaceDir: "/workspace", cfg: cfg as never }).fingerprint,
-    );
 
     await manager.disposeAll();
   });


### PR DESCRIPTION
## What Problem This Solves

Reading a session's MCP tool inventory prepares and clones the same configuration twice before returning its fingerprint and server names. That adds avoidable allocation and metadata work to a read-only inventory request.

## Why This Change Was Made

Load the enabled MCP metadata once and pass that snapshot into the canonical session configuration owner for partitioning and fingerprinting. Keep the session-owned clone at that boundary, safe-name assignment, requester-scoped exclusions, tool denials, and diagnostic policy intact. The duplicate preparation path is removed.

## User Impact

MCP inventory needs less configuration work while returning the same server names and matching the active runtime's catalog fingerprint. Inspecting inventory still does not start servers, connect transports, or list remote tools.

## Evidence

- 150 focused MCP checks pass before and after the refactor, including runtime/summary fingerprint parity and isolation of caller configuration. Typed lint and isolated Codex autoreview pass.
- Full `pnpm build` passes with the declaration repair now landed in #135360. The PR was mechanically rebased onto main; both changed files remain byte-identical to the live-tested build.
- A real OpenAI `gpt-5.6-luna` dev-Gateway turn exercised the complete lifecycle: create an idle session; inspect cold inventory without starting the synthetic MCP server; discover and call its tool through Code Mode; verify one matching tool-call/result pair in durable history; inspect warm inventory with the discovered tool and no stale-catalog notice.
- The actual MCP SDK server observed initialization, tool listing, and exactly one tool call. Its process exited with the Gateway. Provider/model/API identity was verified in the assistant history.

Production: +8/-18, net -10 lines. Tests: +67/-25, net +42 lines, expanding existing parity coverage. No protocol, configuration, dependency, or persistence surface changes. No whole-Gateway memory or latency percentage is attributed to this isolated refactor.
