### PR TITLE
fix(scripts): handle Windows direct-entry URLs

### DIFF
--- a/scripts/check-memory-fd-repro.mts
+++ b/scripts/check-memory-fd-repro.mts
@@ -7,13 +7,13 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { pathToFileURL } from "node:url";
 import { safeParseJson } from "../packages/normalization-core/src/json-coercion.ts";
 import { resolveTimerTimeoutMs } from "../packages/normalization-core/src/number-coercion.ts";
 import { asNullableRecord as asRecord } from "../packages/normalization-core/src/record-coerce.ts";
 import { readNonBlankString } from "../packages/normalization-core/src/string-coerce.ts";
 import { stripLeadingPackageManagerSeparator } from "./lib/arg-utils.mts";
 import { readBoundedResponseText } from "./lib/bounded-response.mjs";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import { parseStrictNonNegativeDecimal as parseNonNegativeInteger } from "./lib/numeric-options.mjs";
 
 const ISSUE_FILE_COUNTS = [
@@ -897,12 +897,7 @@ async function main() {
   }
 }
 
-function isMainModule() {
-  const entrypoint = process.argv[1];
-  return Boolean(entrypoint && import.meta.url === pathToFileURL(path.resolve(entrypoint)).href);
-}
-
-if (isMainModule()) {
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   main().catch((error: unknown) => {
     console.error(
       `[memory-fd-repro] failed: ${error instanceof Error ? error.message : String(error)}`,

--- a/scripts/code-mode-model-matrix.ts
+++ b/scripts/code-mode-model-matrix.ts
@@ -6,7 +6,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import {
   buildScriptEvidenceSummary,
@@ -18,6 +17,7 @@ import {
 import type { AgentExecEnvelope } from "../src/commands/agent-exec-result.ts";
 import { requireOptionArgument } from "./lib/arg-utils.mts";
 import { previewForDevToolLog, redactJsonValueForDevToolLog } from "./lib/dev-tooling-safety.ts";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
 
 export { validateQaEvidenceSummaryJson };
 
@@ -1440,11 +1440,6 @@ async function main(): Promise<void> {
   }
 }
 
-function isCliEntrypoint(): boolean {
-  const entrypoint = process.argv[1];
-  return Boolean(entrypoint && import.meta.url === pathToFileURL(path.resolve(entrypoint)).href);
-}
-
-if (isCliEntrypoint()) {
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   await main();
 }

--- a/scripts/control-ui-i18n-report.ts
+++ b/scripts/control-ui-i18n-report.ts
@@ -2,7 +2,8 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
 
 const ROOT = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const I18N_ASSETS_DIR = path.join(ROOT, "ui/src/i18n/.i18n");
@@ -354,12 +355,7 @@ function usage() {
   ].join("\n");
 }
 
-function isCliEntrypoint() {
-  const entrypoint = process.argv[1];
-  return Boolean(entrypoint && import.meta.url === pathToFileURL(path.resolve(entrypoint)).href);
-}
-
-if (isCliEntrypoint()) {
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   const cliArgs = process.argv.slice(2);
   if (cliArgs.includes("--help") || cliArgs.includes("-h")) {
     process.stdout.write(`${usage()}\n`);

--- a/scripts/control-ui-i18n-verify.ts
+++ b/scripts/control-ui-i18n-verify.ts
@@ -12,6 +12,7 @@ import {
 } from "./lib/control-ui-i18n-catalog.ts";
 import { CONTROL_UI_LOCALE_ENTRIES } from "./lib/control-ui-i18n-config.ts";
 import { syncControlUiRawCopyBaseline } from "./lib/control-ui-i18n-raw-copy.ts";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import { collectSourceFileContents } from "./lib/source-file-scan-cache.mts";
 
 export type CatalogFallbackBaseline = {
@@ -342,12 +343,7 @@ async function main() {
   });
 }
 
-function isCliEntrypoint() {
-  const entrypoint = process.argv[1];
-  return Boolean(entrypoint && import.meta.url === pathToFileURL(path.resolve(entrypoint)).href);
-}
-
-if (isCliEntrypoint()) {
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   await main().catch((error: unknown) => {
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);

--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { completeSimple, type AssistantMessage, type Model } from "openclaw/plugin-sdk/llm";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { sliceUtf16Safe } from "../packages/normalization-core/src/utf16-slice.ts";
@@ -35,6 +35,7 @@ import {
   type LocaleMeta,
   type TranslationBatchItem,
 } from "./lib/control-ui-i18n-sync-plan.ts";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import { toErrorObject as toLintErrorObject } from "./lib/error-format.mts";
 import { sleep } from "./lib/sleep.mjs";
 import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
@@ -1325,12 +1326,7 @@ async function main() {
   }
 }
 
-function isCliEntrypoint() {
-  const entrypoint = process.argv[1];
-  return Boolean(entrypoint && import.meta.url === pathToFileURL(path.resolve(entrypoint)).href);
-}
-
-if (isCliEntrypoint()) {
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   await main().catch((error: unknown) => {
     console.error(formatErrorMessage(error));
     process.exit(1);

--- a/scripts/lib/direct-run.mjs
+++ b/scripts/lib/direct-run.mjs
@@ -31,5 +31,9 @@ export function isDirectRunPath(directPath, modulePath, platform = process.platf
  * @returns {boolean}
  */
 export function isDirectRunUrl(directPath, moduleUrl, platform = process.platform) {
-  return isDirectRunPath(directPath, fileURLToPath(moduleUrl), platform);
+  return isDirectRunPath(
+    directPath,
+    fileURLToPath(moduleUrl, platform === "win32" ? { windows: true } : undefined),
+    platform,
+  );
 }

--- a/scripts/lib/ts-guard-utils.mts
+++ b/scripts/lib/ts-guard-utils.mts
@@ -2,8 +2,8 @@
 import { promises as fs } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import type ts from "typescript";
+import { isDirectRunUrl } from "./direct-run.mjs";
 
 const require = createRequire(import.meta.url);
 let tsCache: typeof ts | undefined;
@@ -223,11 +223,7 @@ export function collectCallExpressionLines(
 }
 
 function isDirectExecution(importMetaUrl: string) {
-  const entry = process.argv[1];
-  if (!entry) {
-    return false;
-  }
-  return path.resolve(entry) === fileURLToPath(importMetaUrl);
+  return isDirectRunUrl(process.argv[1], importMetaUrl);
 }
 
 /**

--- a/test/scripts/direct-run-entrypoints.test.ts
+++ b/test/scripts/direct-run-entrypoints.test.ts
@@ -14,7 +14,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { detectChangedScope } from "../../scripts/ci-changed-scope.mjs";
-import { isDirectRunPath } from "../../scripts/lib/direct-run.mjs";
+import { isDirectRunPath, isDirectRunUrl } from "../../scripts/lib/direct-run.mjs";
 import * as managedChild from "../../scripts/lib/managed-child-process.mts";
 import { isProcessAlive, waitForDead, waitForPidFile } from "../helpers/process-wait.js";
 import { createDeferred } from "../helpers/promise.js";
@@ -473,6 +473,21 @@ process.exitCode = child.status ?? 1;
         "win32",
       ),
     ).toBe(true);
+  });
+
+  it.each([
+    [
+      "drive",
+      "C:\\repo\\scripts\\android-app-i18n.ts",
+      "file:///C:/repo/scripts/android-app-i18n.ts",
+    ],
+    [
+      "UNC",
+      "\\\\server\\share\\scripts\\android-app-i18n.ts",
+      "file://server/share/scripts/android-app-i18n.ts",
+    ],
+  ])("matches Windows %s module URLs", (_kind, directPath, moduleUrl) => {
+    expect(isDirectRunUrl(directPath, moduleUrl, "win32")).toBe(true);
   });
 
   it.each(DIRECT_RUN_SCRIPTS)("uses the canonical guard in %s", (script) => {


### PR DESCRIPTION
## What Problem This Solves

Several repository scripts duplicated direct-entry checks, while the shared URL comparison did not correctly model Windows drive-letter, UNC, and path-case behavior when verification ran from another host platform.

## Why This Change Was Made

`scripts/lib/direct-run.mjs` now owns URL conversion and path comparison. Six script consumers reuse the helper while preserving their existing await, catch, logging, exit, and POSIX behavior.

The helper uses Windows URL conversion only for Windows-style comparisons. `scripts/control-ui-i18n-verify.ts` keeps its independent `pathToFileURL` use, and `scripts/ui.mts` remains unchanged because its realpath-aware symlink behavior is a separate contract.

## Scope

Exact eight-file scope:

- `scripts/lib/direct-run.mjs`
- `scripts/check-memory-fd-repro.mts`
- `scripts/code-mode-model-matrix.ts`
- `scripts/control-ui-i18n-report.ts`
- `scripts/control-ui-i18n-verify.ts`
- `scripts/control-ui-i18n.ts`
- `scripts/lib/ts-guard-utils.mts`
- `test/scripts/direct-run-entrypoints.test.ts`

No core, zero-install, trusted GitHub, release, GitHub-read, QA E2E, or native-i18n boundary changes.

## Rebase And Patch Evidence

- Tested/rebased base: `b1d6628564bac67a20232710a7896f59f9f9d3e2`
- Signed head: `c315d0dc3688456d403ba87a0e0a47b707008657`
- Live `main` had advanced to `5a2de4cccd042887da48b29c65ca61822891bab2` at the final uncached PR read; the patch remains conflict-free and was not repeatedly rebased to chase moving `main`.
- Stable patch ID: `d9c8024e4fb124a353fa0f9c97d9e8a4857c4ea9`
- Range-diff: identical single commit after rebase.
- Tooling LOC: `+19/-41` (net `-22`)
- Test LOC: `+16/-1` (net `+15`)
- Total: net `-7`; product runtime LOC: `0`

## Verification

Passed at exact head:

- 50/50 focused direct-entry tests
- Six import-without-side-effects probes
- Five direct CLI probes with expected help/usage exits
- `pnpm tsgo:scripts`
- `pnpm lint:scripts`
- `node scripts/check-changed.mjs -- <exact eight files>`
- `pnpm check:import-cycles`
- `pnpm check:madge-import-cycles`
- `git diff --check`
- Mandated `gpt-5.6-sol` high autoreview: scoped-clean, no actionable findings, correctness `0.98`

Pre-fix proof reproduced both Windows failures: drive URLs returned false and UNC URLs threw `ERR_INVALID_FILE_URL_HOST`.

## Native Windows

Exact lease: `cbx_86750d83ecb7` (Azure native Windows).

The initial hydration failure was isolated once: Corepack prepared pnpm `12.1.0`, then pnpm's native `win32-x64` executable exited `0xC0000135` because the image lacked its Microsoft VC++ runtime. After installing the signed Microsoft x64 redistributable, the persisted Node `24.20.0` / Corepack pnpm shim reported pnpm `12.1.0`.

On exact head `c315d0dc3688456d403ba87a0e0a47b707008657`:

- Full dependency hydration passed in 10m10s with the repository Windows workflow's lifecycle settings.
- `pnpm test:windows:ci` started unchanged.
- The isolated Windows migration test passed: 1/1.
- The main unit slice recorded 76/76 passing with four configured skips.
- Crabbox then lost workspace-owner renewal during the tooling slice. The remote child was left untouched and later exited, but Crabbox recorded neither part 2 nor a terminal exit code. This is an infrastructure blocker, not a test pass or test failure.
- Run: `run_16db46a8ad89`.
- The exact lease was released afterward and verified `state=released`, `ready=false`.

The earlier Testbox and Windows workflow runs were against the pre-rebase head and are not claimed as exact-head proof here. The hydration workflow at https://github.com/openclaw/openclaw/actions/runs/33592950658 also failed before tests at the original pnpm native-runtime bootstrap.

## Prepare Gate

`OPENCLAW_TESTBOX=1 scripts/pr prepare-run 135370` validated the exact-head review artifacts, then stopped because no successful recent hosted CI workflow exists for `c315d0dc3688456d403ba87a0e0a47b707008657`. The observed CI run `33591085764` is `completed/skipped`. No queue mutation or merge was requested.

## Overlap Recheck

Rechecked before push; all overlaps are hunk-disjoint from this direct-entry change:

- https://github.com/openclaw/openclaw/pull/120823
- https://github.com/openclaw/openclaw/pull/135344
- https://github.com/openclaw/openclaw/pull/119450
- https://github.com/openclaw/openclaw/pull/62063

## Codex Contract Check

Personally inspected `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`. No Codex CLI/runtime contract changes are required for this script-only fix.
