### PR TITLE
fix(memory): prevent cache overflow during forced reindex publication

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -754,7 +754,7 @@ extensions/memory-core/src/memory/manager-source-state.ts	2
 extensions/memory-core/src/memory/manager-sync-base.ts	5
 extensions/memory-core/src/memory/manager-vector-rebuild-state.ts	1
 extensions/memory-core/src/memory/manager-watch-ops.ts	4
-extensions/memory-core/src/memory/manager.ts	3
+extensions/memory-core/src/memory/manager.ts	2
 extensions/memory-core/src/memory/project-ranking.ts	1
 extensions/memory-core/src/memory/search-deadline.ts	1
 extensions/memory-core/src/migration/doctor-host-event-sources.ts	1

--- a/docs/concepts/memory-builtin.md
+++ b/docs/concepts/memory-builtin.md
@@ -117,7 +117,14 @@ which support selective deletion after promotion. For coverage and limits, see
 
 Full reindexes build a replacement in a temporary database and publish the
 memory tables atomically. Concurrent searches and status reads keep using the
-published index; a failed rebuild leaves that index intact.
+published index; a failed rebuild leaves that index intact. The embedding cache
+is bounded before publication, not after copying excess entries into the
+shared database.
+
+`openclaw memory status` reports stored chunk text and JSON embedding bytes
+for each source (`sourceCounts[].chunkBytes` in JSON). These are payload sizes,
+not total disk usage: embedding cache, FTS/vector tables, SQLite overhead, and
+WAL/free pages are excluded.
 
 After an upgrade, automatic project and trigger recall may need to repair
 legacy provenance. That repair runs in the background. Replies continue while

--- a/extensions/memory-core/src/cli-status.runtime.ts
+++ b/extensions/memory-core/src/cli-status.runtime.ts
@@ -6,6 +6,7 @@ import {
   resolveMemoryLightDreamingConfig,
   resolveMemoryRemDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
+import { formatByteSize } from "openclaw/plugin-sdk/number-runtime";
 import { asNullableRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   formatAuditCounts,
@@ -373,7 +374,16 @@ export async function runMemoryStatus(
           total === null
             ? `${entry.files}/? files · ${entry.chunks} chunks`
             : `${entry.files}/${total} files · ${entry.chunks} chunks`;
-        lines.push(`  ${accent(entry.source)} ${muted("·")} ${muted(counts)}`);
+        const payload =
+          entry.chunkBytes === undefined
+            ? ""
+            : ` · ${formatByteSize(entry.chunkBytes, {
+                style: "iec",
+                maxUnit: "tera",
+                separator: " ",
+                fractionDigits: 1,
+              })} text + embeddings`;
+        lines.push(`  ${accent(entry.source)} ${muted("·")} ${muted(counts + payload)}`);
       }
     }
     if (status.fallback) {

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -710,6 +710,7 @@ describe("memory cli", () => {
         makeMemoryStatus({
           files: 2,
           chunks: 5,
+          sourceCounts: [{ source: "memory", files: 2, chunks: 5, chunkBytes: 2048 }],
           cache: { enabled: true, entries: 123, maxEntries: 50000 },
           fts: { enabled: true, available: true },
           vector: {
@@ -735,6 +736,7 @@ describe("memory cli", () => {
     expectLogged(log, "Vector dims: 1024");
     expectLogged(log, "Vector path: /opt/sqlite-vec.dylib");
     expectLogged(log, "FTS: ready");
+    expectLogged(log, "2.0 KiB text + embeddings");
     expectLogged(log, "Embedding cache: enabled (123 entries)");
     expect(close).toHaveBeenCalled();
   });

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -109,6 +109,7 @@ describe("memory index", () => {
           source: "memory",
           files: status.files,
           chunks: status.chunks,
+          chunkBytes: 52,
         },
       ]);
     } finally {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -109,7 +109,6 @@ describe("memory index", () => {
           source: "memory",
           files: status.files,
           chunks: status.chunks,
-          chunkBytes: 52,
         },
       ]);
     } finally {
@@ -2299,6 +2298,38 @@ describe("memory index", () => {
     } finally {
       await diagnosticStatus.close?.();
     }
+  });
+
+  it("refreshes diagnostic byte totals after indexing without changing the serving manager", async () => {
+    const cfg = createCfg({ provider: "none" });
+    const serving = await getPersistentManager(cfg);
+    await serving.sync({ reason: "test", force: true });
+    const diagnostic = await getFreshManager(cfg, "cli", true);
+    try {
+      expect(diagnostic).not.toBe(serving);
+      const previousBytes = diagnostic.status().sourceCounts?.[0]?.chunkBytes;
+      expect(previousBytes).toBeGreaterThan(0);
+      await fs.writeFile(
+        path.join(fixture.paths.memory, "2026-01-12.md"),
+        "# Reindexed diagnostic\n\nFresh expedition notes 🦞 with a different stored payload size.\n",
+      );
+
+      await diagnostic.sync({ reason: "cli", force: true });
+
+      const db = Reflect.get(diagnostic, "db") as DatabaseSync;
+      const storedBytes = db
+        .prepare(
+          "SELECT SUM(length(CAST(text AS BLOB)) + length(CAST(embedding AS BLOB))) AS bytes FROM memory_index_chunks WHERE source = 'memory'",
+        )
+        .get()?.bytes;
+      const refreshedBytes = diagnostic.status().sourceCounts?.[0]?.chunkBytes;
+      expect(refreshedBytes).toBe(storedBytes);
+      expect(refreshedBytes).not.toBe(previousBytes);
+    } finally {
+      await diagnostic.close();
+    }
+    expect((await getMemorySearchManager({ cfg, agentId: "main" })).manager).toBe(serving);
+    expect(serving.status().sourceCounts?.[0]?.chunkBytes).toBeUndefined();
   });
 
   it("reports vector availability after probe", async () => {

--- a/extensions/memory-core/src/memory/manager-status-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-status-state.test.ts
@@ -74,6 +74,44 @@ describe("memory manager status state", () => {
     expect(resolveStatusProviderInfo(params)).toEqual(expected);
   });
 
+  it("counts ordinary status without evaluating stored payload columns", () => {
+    const db = new DatabaseSync(":memory:");
+    let payloadReads = 0;
+    try {
+      db.function("read_payload", { deterministic: true }, (source) => {
+        payloadReads += 1;
+        return `${String(source)} payload`;
+      });
+      db.exec(`
+        CREATE TABLE memory_index_sources (source TEXT);
+        CREATE TABLE memory_index_chunks (
+          source TEXT,
+          text TEXT GENERATED ALWAYS AS (read_payload(source)) VIRTUAL,
+          embedding TEXT GENERATED ALWAYS AS (read_payload(source)) VIRTUAL
+        );
+        CREATE INDEX sources_by_source ON memory_index_sources(source);
+        CREATE INDEX chunks_by_source ON memory_index_chunks(source);
+        INSERT INTO memory_index_sources VALUES ('memory'), ('sessions');
+        INSERT INTO memory_index_chunks(source) VALUES ('memory'), ('sessions');
+      `);
+      payloadReads = 0;
+
+      const status = collectMemoryStatusAggregate({ db, sources: ["memory", "sessions"] });
+
+      expect(payloadReads).toBe(0);
+      expect(status).toEqual({
+        files: 2,
+        chunks: 2,
+        sourceCounts: [
+          { source: "memory", files: 1, chunks: 1 },
+          { source: "sessions", files: 1, chunks: 1 },
+        ],
+      });
+    } finally {
+      db.close();
+    }
+  });
+
   it("reports stored payload bytes by source without counting characters or other sources", () => {
     const db = new DatabaseSync(":memory:");
     try {
@@ -88,6 +126,7 @@ describe("memory manager status state", () => {
       expect(
         collectMemoryStatusAggregate({
           db,
+          includeChunkBytes: true,
           sources: ["memory", "sessions"],
         }),
       ).toEqual({
@@ -101,6 +140,7 @@ describe("memory manager status state", () => {
       expect(
         collectMemoryStatusAggregate({
           db,
+          includeChunkBytes: true,
           sources: ["memory"],
           sourceFilterSql: " AND source IN (?)",
           sourceFilterParams: ["memory"],
@@ -111,7 +151,9 @@ describe("memory manager status state", () => {
         sourceCounts: [{ source: "memory", files: 2, chunks: 2, chunkBytes: 14 }],
       });
       db.exec("DELETE FROM memory_index_sources; DELETE FROM memory_index_chunks;");
-      expect(collectMemoryStatusAggregate({ db, sources: ["memory"] })).toEqual({
+      expect(
+        collectMemoryStatusAggregate({ db, sources: ["memory"], includeChunkBytes: true }),
+      ).toEqual({
         files: 0,
         chunks: 0,
         sourceCounts: [{ source: "memory", files: 0, chunks: 0, chunkBytes: 0 }],

--- a/extensions/memory-core/src/memory/manager-status-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-status-state.test.ts
@@ -1,5 +1,5 @@
 // Memory Core tests cover manager status state plugin behavior.
-import type { SQLInputValue } from "node:sqlite";
+import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 import {
   collectMemoryStatusAggregate,
@@ -74,37 +74,50 @@ describe("memory manager status state", () => {
     expect(resolveStatusProviderInfo(params)).toEqual(expected);
   });
 
-  it("uses one aggregation query for status counts and source breakdowns", () => {
-    const calls: Array<{ sql: string; params: SQLInputValue[] }> = [];
-    const aggregate = collectMemoryStatusAggregate({
-      db: {
-        prepare: (sql) => ({
-          all: (...params) => {
-            calls.push({ sql, params });
-            return [
-              { kind: "files" as const, source: "memory" as const, c: 2 },
-              { kind: "chunks" as const, source: "memory" as const, c: 5 },
-              { kind: "files" as const, source: "sessions" as const, c: 1 },
-              { kind: "chunks" as const, source: "sessions" as const, c: 3 },
-            ];
-          },
+  it("reports stored payload bytes by source without counting characters or other sources", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      db.exec(`
+        CREATE TABLE memory_index_sources (source TEXT);
+        CREATE TABLE memory_index_chunks (source TEXT, text TEXT, embedding TEXT);
+        INSERT INTO memory_index_sources VALUES ('memory'), ('memory'), ('sessions');
+        INSERT INTO memory_index_chunks VALUES
+          ('memory', '🦞', '[1,2]'), ('memory', 'abc', '[]'),
+          ('sessions', 'session', '[3]');
+      `);
+      expect(
+        collectMemoryStatusAggregate({
+          db,
+          sources: ["memory", "sessions"],
         }),
-      },
-      sources: ["memory", "sessions"],
-      sourceFilterSql: " AND source IN (?, ?)",
-      sourceFilterParams: ["memory", "sessions"],
-    });
-
-    expect(calls).toHaveLength(1);
-    expect(calls[0]?.sql).toContain("source IN (?, ?)");
-    expect(calls[0]?.params).toEqual(["memory", "sessions", "memory", "sessions"]);
-    expect(aggregate).toEqual({
-      files: 3,
-      chunks: 8,
-      sourceCounts: [
-        { source: "memory", files: 2, chunks: 5 },
-        { source: "sessions", files: 1, chunks: 3 },
-      ],
-    });
+      ).toEqual({
+        files: 3,
+        chunks: 3,
+        sourceCounts: [
+          { source: "memory", files: 2, chunks: 2, chunkBytes: 14 },
+          { source: "sessions", files: 1, chunks: 1, chunkBytes: 10 },
+        ],
+      });
+      expect(
+        collectMemoryStatusAggregate({
+          db,
+          sources: ["memory"],
+          sourceFilterSql: " AND source IN (?)",
+          sourceFilterParams: ["memory"],
+        }),
+      ).toEqual({
+        files: 2,
+        chunks: 2,
+        sourceCounts: [{ source: "memory", files: 2, chunks: 2, chunkBytes: 14 }],
+      });
+      db.exec("DELETE FROM memory_index_sources; DELETE FROM memory_index_chunks;");
+      expect(collectMemoryStatusAggregate({ db, sources: ["memory"] })).toEqual({
+        files: 0,
+        chunks: 0,
+        sourceCounts: [{ source: "memory", files: 0, chunks: 0, chunkBytes: 0 }],
+      });
+    } finally {
+      db.close();
+    }
   });
 });

--- a/extensions/memory-core/src/memory/manager-status-state.ts
+++ b/extensions/memory-core/src/memory/manager-status-state.ts
@@ -11,14 +11,8 @@ type StatusAggregateRow = {
   kind: "files" | "chunks";
   source: MemorySource;
   c: number;
-  bytes: number;
+  bytes: number | null;
 };
-
-// octet_length reads record lengths, not large text/vector payloads from disk.
-const MEMORY_STATUS_AGGREGATE_SQL =
-  `SELECT 'files' AS kind, source, COUNT(*) as c, 0 AS bytes FROM memory_index_sources WHERE 1=1__FILTER__ GROUP BY source\n` +
-  `UNION ALL\n` +
-  `SELECT 'chunks' AS kind, source, COUNT(*) as c, COALESCE(SUM(octet_length(text) + octet_length(embedding)), 0) AS bytes FROM memory_index_chunks WHERE 1=1__FILTER__ GROUP BY source`;
 
 export function resolveInitialMemoryDirty(params: {
   hasMemorySource: boolean;
@@ -68,40 +62,42 @@ export function collectMemoryStatusAggregate(params: {
   sources: Iterable<MemorySource>;
   sourceFilterSql?: string;
   sourceFilterParams?: MemorySource[];
+  includeChunkBytes?: boolean;
 }): {
   files: number;
   chunks: number;
-  sourceCounts: Array<{ source: MemorySource; files: number; chunks: number; chunkBytes: number }>;
+  sourceCounts: Array<{ source: MemorySource; files: number; chunks: number; chunkBytes?: number }>;
 } {
-  const sources = Array.from(params.sources);
-  const bySource = new Map<MemorySource, { files: number; chunks: number; chunkBytes: number }>();
-  for (const source of sources) {
-    bySource.set(source, { files: 0, chunks: 0, chunkBytes: 0 });
-  }
+  const totals = { files: 0, chunks: 0 };
+  const emptyCounts = { ...totals, ...(params.includeChunkBytes ? { chunkBytes: 0 } : {}) };
+  const bySource = new Map<MemorySource, typeof emptyCounts>();
+  // Ordinary status uses covering indexes; payload-byte inspection is diagnostic.
+  const chunkBytes = params.includeChunkBytes
+    ? "COALESCE(SUM(octet_length(text) + octet_length(embedding)), 0)"
+    : "NULL";
   const sourceFilterSql = params.sourceFilterSql ?? "";
-  const sourceFilterParams = params.sourceFilterParams ?? [];
-  const aggregateRows = params.db
-    .prepare(MEMORY_STATUS_AGGREGATE_SQL.replaceAll("__FILTER__", sourceFilterSql))
-    // SAFETY: Both UNION branches return the declared kind/source and numeric count/byte aggregates.
-    .all(...sourceFilterParams, ...sourceFilterParams) as StatusAggregateRow[];
-  let files = 0;
-  let chunks = 0;
-  for (const row of aggregateRows) {
-    const count = row.c ?? 0;
-    const entry = bySource.get(row.source) ?? { files: 0, chunks: 0, chunkBytes: 0 };
-    if (row.kind === "files") {
-      entry.files = count;
-      files += count;
-    } else {
-      entry.chunks = count;
+  const query =
+    `SELECT 'files' AS kind, source, COUNT(*) as c, 0 AS bytes FROM memory_index_sources WHERE 1=1${sourceFilterSql} GROUP BY source\n` +
+    `UNION ALL\n` +
+    `SELECT 'chunks' AS kind, source, COUNT(*) as c, ${chunkBytes} AS bytes FROM memory_index_chunks WHERE 1=1${sourceFilterSql} GROUP BY source`;
+  const filterParams = params.sourceFilterParams ?? [];
+  const rows = params.db
+    .prepare(query)
+    // SAFETY: Both UNION branches return the declared kind/source, count, and nullable byte total.
+    .all(...filterParams, ...filterParams) as StatusAggregateRow[];
+  for (const row of rows) {
+    const entry = bySource.get(row.source) ?? { ...emptyCounts };
+    entry[row.kind] = row.c;
+    totals[row.kind] += row.c;
+    if (row.kind === "chunks" && row.bytes !== null) {
       entry.chunkBytes = row.bytes;
-      chunks += count;
     }
     bySource.set(row.source, entry);
   }
   return {
-    files,
-    chunks,
-    sourceCounts: sources.map((source) => Object.assign({ source }, bySource.get(source)!)),
+    ...totals,
+    sourceCounts: Array.from(params.sources, (source) =>
+      Object.assign({ source, ...emptyCounts }, bySource.get(source)),
+    ),
   };
 }

--- a/extensions/memory-core/src/memory/manager-status-state.ts
+++ b/extensions/memory-core/src/memory/manager-status-state.ts
@@ -1,5 +1,5 @@
 // Memory Core plugin module implements manager status state behavior.
-import type { SQLInputValue } from "node:sqlite";
+import type { DatabaseSync } from "node:sqlite";
 import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 
 type StatusProvider = {
@@ -11,18 +11,14 @@ type StatusAggregateRow = {
   kind: "files" | "chunks";
   source: MemorySource;
   c: number;
+  bytes: number;
 };
 
-type StatusAggregateDb = {
-  prepare: (sql: string) => {
-    all: (...args: SQLInputValue[]) => StatusAggregateRow[];
-  };
-};
-
+// octet_length reads record lengths, not large text/vector payloads from disk.
 const MEMORY_STATUS_AGGREGATE_SQL =
-  `SELECT 'files' AS kind, source, COUNT(*) as c FROM memory_index_sources WHERE 1=1__FILTER__ GROUP BY source\n` +
+  `SELECT 'files' AS kind, source, COUNT(*) as c, 0 AS bytes FROM memory_index_sources WHERE 1=1__FILTER__ GROUP BY source\n` +
   `UNION ALL\n` +
-  `SELECT 'chunks' AS kind, source, COUNT(*) as c FROM memory_index_chunks WHERE 1=1__FILTER__ GROUP BY source`;
+  `SELECT 'chunks' AS kind, source, COUNT(*) as c, COALESCE(SUM(octet_length(text) + octet_length(embedding)), 0) AS bytes FROM memory_index_chunks WHERE 1=1__FILTER__ GROUP BY source`;
 
 export function resolveInitialMemoryDirty(params: {
   hasMemorySource: boolean;
@@ -68,35 +64,37 @@ export function resolveStatusProviderInfo(params: {
 }
 
 export function collectMemoryStatusAggregate(params: {
-  db: StatusAggregateDb;
+  db: Pick<DatabaseSync, "prepare">;
   sources: Iterable<MemorySource>;
   sourceFilterSql?: string;
   sourceFilterParams?: MemorySource[];
 }): {
   files: number;
   chunks: number;
-  sourceCounts: Array<{ source: MemorySource; files: number; chunks: number }>;
+  sourceCounts: Array<{ source: MemorySource; files: number; chunks: number; chunkBytes: number }>;
 } {
   const sources = Array.from(params.sources);
-  const bySource = new Map<MemorySource, { files: number; chunks: number }>();
+  const bySource = new Map<MemorySource, { files: number; chunks: number; chunkBytes: number }>();
   for (const source of sources) {
-    bySource.set(source, { files: 0, chunks: 0 });
+    bySource.set(source, { files: 0, chunks: 0, chunkBytes: 0 });
   }
   const sourceFilterSql = params.sourceFilterSql ?? "";
   const sourceFilterParams = params.sourceFilterParams ?? [];
   const aggregateRows = params.db
     .prepare(MEMORY_STATUS_AGGREGATE_SQL.replaceAll("__FILTER__", sourceFilterSql))
-    .all(...sourceFilterParams, ...sourceFilterParams);
+    // SAFETY: Both UNION branches return the declared kind/source and numeric count/byte aggregates.
+    .all(...sourceFilterParams, ...sourceFilterParams) as StatusAggregateRow[];
   let files = 0;
   let chunks = 0;
   for (const row of aggregateRows) {
     const count = row.c ?? 0;
-    const entry = bySource.get(row.source) ?? { files: 0, chunks: 0 };
+    const entry = bySource.get(row.source) ?? { files: 0, chunks: 0, chunkBytes: 0 };
     if (row.kind === "files") {
       entry.files = count;
       files += count;
     } else {
       entry.chunks = count;
+      entry.chunkBytes = row.bytes;
       chunks += count;
     }
     bySource.set(row.source, entry);

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -482,25 +482,10 @@ describe("session startup catch-up", () => {
   ];
 
   it.each(cacheBoundSyncs)("bounds the embedding cache on a %s sync", async (_label, params) => {
-    // Enforcement first lived inside runInPlaceReindex's shadow rebuild, bounding a throwaway
-    // database and never the live one; moving it into the incremental branch then skipped the
-    // paths that return early. Long-running databases stayed unbounded (openclaw/openclaw#114612).
-    await writeSessionFile("thread.jsonl");
+    await writeSqliteSession();
     const harness = new SessionStartupCatchupHarness([]);
 
     await harness.runSyncForTest(params);
-
-    expect(harness.embeddingCachePrunes).toBeGreaterThan(0);
-  });
-
-  it("bounds the embedding cache when the sync pass aborts", async () => {
-    // The full-reindex branch returns before the incremental code and cannot complete against
-    // this harness, so it stands in for every early or failed exit: enforcement inside any one
-    // branch skips them, a finally around the pass does not.
-    await writeSessionFile("thread.jsonl");
-    const harness = new SessionStartupCatchupHarness([]);
-
-    await expect(harness.runSyncForTest({ reason: "cli", force: true })).rejects.toThrow();
 
     expect(harness.embeddingCachePrunes).toBeGreaterThan(0);
   });

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -155,124 +155,124 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
   }
 
   protected async runSync(params?: MemorySyncParams) {
-    // Guard: if an embedding provider is configured but currently unavailable,
-    // abort sync to prevent silently degrading an existing semantic vector index
-    // to fts-only and wiping existing semantic vectors.
-    // This only protects existing semantic indexes; fresh or already-fts-only
-    // indexes can safely sync without an embedding provider.
-    this.assertFtsOnlySyncAllowed();
-
-    const syncProvider = this.syncProviderGeneration
-      ? this.syncProviderGeneration.provider
-      : this.provider;
-
-    const progress = params?.progress ? this.createSyncProgress(params.progress) : undefined;
-    if (progress) {
-      progress.report({
-        completed: progress.completed,
-        total: progress.total,
-        label: "Loading vector extension…",
-      });
-    }
-    // Keyword-only generations never write vectors, so they must not wait for
-    // the vector extension before text and FTS indexing can proceed.
-    const vectorReady = syncProvider ? await this.ensureVectorReady() : false;
-    const meta = this.readMeta();
-    // Resolve and index a targeted session against one corpus snapshot. A reset
-    // between separate enumerations could otherwise replace the chosen identity.
-    const targetSessionSync = this.hasRequestedTargetSessionSync(params)
-      ? await this.resolveTargetSessionSyncPlan({
-          sessions: params?.sessions,
-          archiveFiles: params?.archiveFiles,
-        })
-      : null;
-    const targetArchiveFiles = targetSessionSync?.targetArchiveFiles ?? null;
-    const hasTargetArchiveFiles = targetArchiveFiles !== null;
-    if (this.hasRequestedTargetSessionSync(params) && !hasTargetArchiveFiles) {
-      return;
-    }
-    if (params?.reason === "cli" && !params.force && !hasTargetArchiveFiles) {
-      await this.markSessionStartupCatchupDirtyFiles();
-    }
-    const syncProviderKey = this.syncProviderGeneration
-      ? this.syncProviderGeneration.providerKey
-      : this.providerKey;
-    const syncProviderIdentities =
-      this.syncProviderGeneration?.identities ?? this.resolveProviderIndexIdentities();
-    const indexIdentity = resolveMemoryIndexIdentityState({
-      meta,
-      // Also detects provider→FTS-only transitions so orphaned old-model FTS rows are cleaned up.
-      provider: syncProvider ? { id: syncProvider.id, model: syncProvider.model } : null,
-      providerKey: syncProviderKey ?? undefined,
-      providerAliases: syncProviderIdentities.slice(1),
-      configuredSources: resolveConfiguredSourcesForMeta(this.sources),
-      configuredScopeHash: resolveConfiguredScopeHash({
-        workspaceDir: this.workspaceDir,
-        extraPaths: this.settings.extraPaths,
-        multimodal: {
-          enabled: this.settings.multimodal.enabled,
-          modalities: this.settings.multimodal.modalities,
-          maxFileBytes: this.settings.multimodal.maxFileBytes,
-        },
-      }),
-      chunkTokens: this.settings.chunking.tokens,
-      chunkOverlap: this.settings.chunking.overlap,
-      vectorReady,
-      hasIndexedChunks: this.hasIndexedChunks(),
-      ftsTokenizer: this.settings.store.fts.tokenizer,
-    });
-    const hasIndexedChunks = this.hasIndexedChunks();
-    const needsInitialIndex = indexIdentity.status !== "valid" && !hasIndexedChunks;
-    // Missing metadata cannot prove whether existing chunks were semantic.
-    // Wait for the configured provider before replacing them with a rebuilt index,
-    // unless every existing chunk is FTS-only — in that case rebuilding as
-    // FTS-only is safe even without a provider because no semantic data is lost.
-    // Gate the chunk-model scan: only compute when identity is missing,
-    // chunks exist, and the provider is unavailable (no target session files
-    // is already checked by needsMissingIdentityReindex below).
-    const needsFtsOnlyClassification =
-      indexIdentity.status === "missing" &&
-      hasIndexedChunks &&
-      syncProvider === null &&
-      Boolean(this.settings.provider) &&
-      this.settings.provider !== "none";
-    const hasOnlyFtsChunks = needsFtsOnlyClassification && !this.hasSemanticChunks();
-    const canRebuildMissingIdentity =
-      syncProvider !== null ||
-      !this.settings.provider ||
-      this.settings.provider === "none" ||
-      hasOnlyFtsChunks;
-    const needsMissingIdentityReindex =
-      indexIdentity.status === "missing" && !hasTargetArchiveFiles && canRebuildMissingIdentity;
-    const needsExplicitIdentityReindex =
-      params?.reason === "cli" && indexIdentity.status !== "valid" && !hasTargetArchiveFiles;
-    // Source hashes do not reflect chunk boundaries, so an implementation
-    // upgrade must rebuild the shadow index instead of attempting dirty sync.
-    const needsChunkingVersionReindex =
-      meta !== null && meta.chunkingVersion !== MEMORY_CHUNKING_VERSION && !hasTargetArchiveFiles;
-    const canRunRetryFullReindex =
-      indexIdentity.status !== "missing" || needsInitialIndex || canRebuildMissingIdentity;
-    const needsFullReindex =
-      (params?.force && !hasTargetArchiveFiles) ||
-      needsInitialIndex ||
-      needsMissingIdentityReindex ||
-      needsExplicitIdentityReindex ||
-      needsChunkingVersionReindex ||
-      (this.memoryFullRetryDirty && canRunRetryFullReindex) ||
-      (this.sessionsFullRetryDirty && indexIdentity.status !== "valid" && canRunRetryFullReindex);
-    const needsFullSessionReindex = needsFullReindex || this.sessionsFullRetryDirty;
-    if (indexIdentity.status !== "valid" && !needsFullReindex) {
-      this.dirty = true;
-      const sessionsDirty = markMemoryTargetArchiveFilesDirty({
-        sessionsDirtyFiles: this.sessionsDirtyFiles,
-        targetArchiveFiles,
-      });
-      if (sessionsDirty) {
-        this.sessionsDirty = true;
-      }
-      return;
-    }
+    const hasTargetSessionRequest = this.hasRequestedTargetSessionSync(params);
+    let needsFullReindex = Boolean(params?.force && !hasTargetSessionRequest);
     try {
+      // An unavailable configured provider must not replace semantic vectors
+      // with FTS-only rows; fresh and already-FTS-only indexes remain safe.
+      this.assertFtsOnlySyncAllowed();
+
+      const syncProvider = this.syncProviderGeneration
+        ? this.syncProviderGeneration.provider
+        : this.provider;
+
+      const progress = params?.progress ? this.createSyncProgress(params.progress) : undefined;
+      if (progress) {
+        progress.report({
+          completed: progress.completed,
+          total: progress.total,
+          label: "Loading vector extension…",
+        });
+      }
+      // Keyword-only generations never write vectors, so they must not wait for
+      // the vector extension before text and FTS indexing can proceed.
+      const vectorReady = syncProvider ? await this.ensureVectorReady() : false;
+      const meta = this.readMeta();
+      // Resolve and index a targeted session against one corpus snapshot. A reset
+      // between separate enumerations could otherwise replace the chosen identity.
+      const targetSessionSync = hasTargetSessionRequest
+        ? await this.resolveTargetSessionSyncPlan({
+            sessions: params?.sessions,
+            archiveFiles: params?.archiveFiles,
+          })
+        : null;
+      const targetArchiveFiles = targetSessionSync?.targetArchiveFiles ?? null;
+      const hasTargetArchiveFiles = targetArchiveFiles !== null;
+      if (hasTargetSessionRequest && !hasTargetArchiveFiles) {
+        return;
+      }
+      if (params?.reason === "cli" && !params.force && !hasTargetArchiveFiles) {
+        await this.markSessionStartupCatchupDirtyFiles();
+      }
+      const syncProviderKey = this.syncProviderGeneration
+        ? this.syncProviderGeneration.providerKey
+        : this.providerKey;
+      const syncProviderIdentities =
+        this.syncProviderGeneration?.identities ?? this.resolveProviderIndexIdentities();
+      const indexIdentity = resolveMemoryIndexIdentityState({
+        meta,
+        // Also detects provider→FTS-only transitions so orphaned old-model FTS rows are cleaned up.
+        provider: syncProvider ? { id: syncProvider.id, model: syncProvider.model } : null,
+        providerKey: syncProviderKey ?? undefined,
+        providerAliases: syncProviderIdentities.slice(1),
+        configuredSources: resolveConfiguredSourcesForMeta(this.sources),
+        configuredScopeHash: resolveConfiguredScopeHash({
+          workspaceDir: this.workspaceDir,
+          extraPaths: this.settings.extraPaths,
+          multimodal: {
+            enabled: this.settings.multimodal.enabled,
+            modalities: this.settings.multimodal.modalities,
+            maxFileBytes: this.settings.multimodal.maxFileBytes,
+          },
+        }),
+        chunkTokens: this.settings.chunking.tokens,
+        chunkOverlap: this.settings.chunking.overlap,
+        vectorReady,
+        hasIndexedChunks: this.hasIndexedChunks(),
+        ftsTokenizer: this.settings.store.fts.tokenizer,
+      });
+      const hasIndexedChunks = this.hasIndexedChunks();
+      const needsInitialIndex = indexIdentity.status !== "valid" && !hasIndexedChunks;
+      // Missing metadata cannot prove whether existing chunks were semantic.
+      // Wait for the configured provider before replacing them with a rebuilt index,
+      // unless every existing chunk is FTS-only — in that case rebuilding as
+      // FTS-only is safe even without a provider because no semantic data is lost.
+      // Gate the chunk-model scan: only compute when identity is missing,
+      // chunks exist, and the provider is unavailable (no target session files
+      // is already checked by needsMissingIdentityReindex below).
+      const needsFtsOnlyClassification =
+        indexIdentity.status === "missing" &&
+        hasIndexedChunks &&
+        syncProvider === null &&
+        Boolean(this.settings.provider) &&
+        this.settings.provider !== "none";
+      const hasOnlyFtsChunks = needsFtsOnlyClassification && !this.hasSemanticChunks();
+      const canRebuildMissingIdentity =
+        syncProvider !== null ||
+        !this.settings.provider ||
+        this.settings.provider === "none" ||
+        hasOnlyFtsChunks;
+      const needsMissingIdentityReindex =
+        indexIdentity.status === "missing" && !hasTargetArchiveFiles && canRebuildMissingIdentity;
+      const needsExplicitIdentityReindex =
+        params?.reason === "cli" && indexIdentity.status !== "valid" && !hasTargetArchiveFiles;
+      // Source hashes do not reflect chunk boundaries, so an implementation
+      // upgrade must rebuild the shadow index instead of attempting dirty sync.
+      const needsChunkingVersionReindex =
+        meta !== null && meta.chunkingVersion !== MEMORY_CHUNKING_VERSION && !hasTargetArchiveFiles;
+      const canRunRetryFullReindex =
+        indexIdentity.status !== "missing" || needsInitialIndex || canRebuildMissingIdentity;
+      needsFullReindex = Boolean(
+        (params?.force && !hasTargetArchiveFiles) ||
+        needsInitialIndex ||
+        needsMissingIdentityReindex ||
+        needsExplicitIdentityReindex ||
+        needsChunkingVersionReindex ||
+        (this.memoryFullRetryDirty && canRunRetryFullReindex) ||
+        (this.sessionsFullRetryDirty && indexIdentity.status !== "valid" && canRunRetryFullReindex),
+      );
+      const needsFullSessionReindex = needsFullReindex || this.sessionsFullRetryDirty;
+      if (indexIdentity.status !== "valid" && !needsFullReindex) {
+        this.dirty = true;
+        const sessionsDirty = markMemoryTargetArchiveFilesDirty({
+          sessionsDirtyFiles: this.sessionsDirtyFiles,
+          targetArchiveFiles,
+        });
+        if (sessionsDirty) {
+          this.sessionsDirty = true;
+        }
+        return;
+      }
       if (!needsFullSessionReindex) {
         const targetedSessionSync = await runMemoryTargetedSessionSync({
           hasSessionSource: this.sources.has("sessions"),
@@ -376,8 +376,8 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
         throw err;
       }
     } finally {
-      // Incremental work may have committed before failure. Full rebuilds prune
-      // only their shadow, so failure never mutates the published cache.
+      // Ordinary sync exits retain live cleanup, including preflight/no-op exits.
+      // Full rebuild failures (including forced preflight) leave the primary alone.
       if (!needsFullReindex) {
         this.pruneEmbeddingCacheIfNeeded();
       }

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -252,15 +252,14 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
         meta !== null && meta.chunkingVersion !== MEMORY_CHUNKING_VERSION && !hasTargetArchiveFiles;
       const canRunRetryFullReindex =
         indexIdentity.status !== "missing" || needsInitialIndex || canRebuildMissingIdentity;
-      needsFullReindex = Boolean(
+      needsFullReindex =
         (params?.force && !hasTargetArchiveFiles) ||
         needsInitialIndex ||
         needsMissingIdentityReindex ||
         needsExplicitIdentityReindex ||
         needsChunkingVersionReindex ||
         (this.memoryFullRetryDirty && canRunRetryFullReindex) ||
-        (this.sessionsFullRetryDirty && indexIdentity.status !== "valid" && canRunRetryFullReindex),
-      );
+        (this.sessionsFullRetryDirty && indexIdentity.status !== "valid" && canRunRetryFullReindex);
       const needsFullSessionReindex = needsFullReindex || this.sessionsFullRetryDirty;
       if (indexIdentity.status !== "valid" && !needsFullReindex) {
         this.dirty = true;

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -155,16 +155,6 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
   }
 
   protected async runSync(params?: MemorySyncParams) {
-    try {
-      await this.runSyncPass(params);
-    } finally {
-      // Run after every sync path and after any shadow reindex scope has ended,
-      // so the cap is enforced once against the published live database.
-      this.pruneEmbeddingCacheIfNeeded?.();
-    }
-  }
-
-  private async runSyncPass(params?: MemorySyncParams) {
     // Guard: if an embedding provider is configured but currently unavailable,
     // abort sync to prevent silently degrading an existing semantic vector index
     // to fts-only and wiping existing semantic vectors.
@@ -282,109 +272,115 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
       }
       return;
     }
-    if (!needsFullSessionReindex) {
-      const targetedSessionSync = await runMemoryTargetedSessionSync({
-        hasSessionSource: this.sources.has("sessions"),
-        targetArchiveFiles,
-        reason: params?.reason,
-        progress: progress ?? undefined,
-        sessionsFullRetryDirty: this.sessionsFullRetryDirty,
-        sessionsReconcileDirty: this.sessionsReconcileDirty,
-        sessionsDirtyFiles: this.sessionsDirtyFiles,
-        syncArchiveFiles: async (targetedParams) => {
-          await this.syncArchiveFiles({
-            ...targetedParams,
-            corpusEntries: targetSessionSync?.corpusEntries,
-          });
-        },
-        shouldFallbackOnError: (err) => this.shouldFallbackOnError(err),
-        activateFallbackProvider: async (reason) => {
-          this.endSyncProviderGeneration();
-          return await this.activateFallbackProvider(reason);
-        },
-      });
-      if (targetedSessionSync.handled) {
-        this.sessionsDirty = targetedSessionSync.sessionsDirty;
-        if (targetedSessionSync.failure) {
-          this.syncOutcomes.recordActiveFailure(targetedSessionSync.failure.error);
-        }
-        return;
-      }
-    }
     try {
-      if (needsFullReindex) {
-        await this.runInPlaceReindex({
+      if (!needsFullSessionReindex) {
+        const targetedSessionSync = await runMemoryTargetedSessionSync({
+          hasSessionSource: this.sources.has("sessions"),
+          targetArchiveFiles,
           reason: params?.reason,
-          force: params?.force,
           progress: progress ?? undefined,
+          sessionsFullRetryDirty: this.sessionsFullRetryDirty,
+          sessionsReconcileDirty: this.sessionsReconcileDirty,
+          sessionsDirtyFiles: this.sessionsDirtyFiles,
+          syncArchiveFiles: async (targetedParams) => {
+            await this.syncArchiveFiles({
+              ...targetedParams,
+              corpusEntries: targetSessionSync?.corpusEntries,
+            });
+          },
+          shouldFallbackOnError: (err) => this.shouldFallbackOnError(err),
+          activateFallbackProvider: async (reason) => {
+            this.endSyncProviderGeneration();
+            return await this.activateFallbackProvider(reason);
+          },
         });
-        return;
+        if (targetedSessionSync.handled) {
+          this.sessionsDirty = targetedSessionSync.sessionsDirty;
+          if (targetedSessionSync.failure) {
+            this.syncOutcomes.recordActiveFailure(targetedSessionSync.failure.error);
+          }
+          return;
+        }
       }
-
-      const shouldSyncMemory =
-        this.sources.has("memory") &&
-        ((!hasTargetArchiveFiles && params?.force) || needsFullReindex || this.dirty);
-      const shouldSyncSessions = this.shouldSyncSessions(params, needsFullReindex);
-
-      if (this.shouldDeferSourceWideBatch()) {
-        await this.executeSourceWideSync({
-          shouldSyncMemory,
-          shouldSyncSessions,
-          needsFullReindex,
-          needsFullSessionReindex,
-          targetArchiveFiles: targetArchiveFiles ? Array.from(targetArchiveFiles) : undefined,
-          progress: progress ?? undefined,
-        });
-        if (shouldSyncMemory) {
-          this.clearMemoryRetryState();
-        }
-        if (shouldSyncSessions) {
-          this.clearSessionRetryState();
-        } else {
-          this.refreshSessionDirtyFlag();
-        }
-      } else {
-        if (shouldSyncMemory) {
-          await this.syncMemoryFiles({ needsFullReindex, progress: progress ?? undefined });
-          this.clearMemoryRetryState();
+      try {
+        if (needsFullReindex) {
+          await this.runInPlaceReindex({
+            reason: params?.reason,
+            force: params?.force,
+            progress: progress ?? undefined,
+          });
+          return;
         }
 
-        if (shouldSyncSessions) {
-          await this.syncArchiveFiles({
-            needsFullReindex: needsFullSessionReindex,
+        const shouldSyncMemory = this.sources.has("memory") && this.dirty;
+        const shouldSyncSessions = this.shouldSyncSessions(params, needsFullReindex);
+
+        if (this.shouldDeferSourceWideBatch()) {
+          await this.executeSourceWideSync({
+            shouldSyncMemory,
+            shouldSyncSessions,
+            needsFullReindex,
+            needsFullSessionReindex,
             targetArchiveFiles: targetArchiveFiles ? Array.from(targetArchiveFiles) : undefined,
             progress: progress ?? undefined,
           });
-          this.clearSessionRetryState();
+          if (shouldSyncMemory) {
+            this.clearMemoryRetryState();
+          }
+          if (shouldSyncSessions) {
+            this.clearSessionRetryState();
+          } else {
+            this.refreshSessionDirtyFlag();
+          }
         } else {
-          this.refreshSessionDirtyFlag();
+          if (shouldSyncMemory) {
+            await this.syncMemoryFiles({ needsFullReindex, progress: progress ?? undefined });
+            this.clearMemoryRetryState();
+          }
+
+          if (shouldSyncSessions) {
+            await this.syncArchiveFiles({
+              needsFullReindex: needsFullSessionReindex,
+              targetArchiveFiles: targetArchiveFiles ? Array.from(targetArchiveFiles) : undefined,
+              progress: progress ?? undefined,
+            });
+            this.clearSessionRetryState();
+          } else {
+            this.refreshSessionDirtyFlag();
+          }
         }
-      }
-    } catch (err) {
-      const reason = formatErrorMessage(err);
-      const shouldFallback = this.shouldFallbackOnError(err);
-      if (shouldFallback) {
-        // A failed generation cannot wait on its own sync lease while activating fallback.
-        this.endSyncProviderGeneration();
-      }
-      const activated = shouldFallback && (await this.activateFallbackProvider(reason));
-      if (activated) {
-        if (needsFullReindex && !hasTargetArchiveFiles) {
-          this.beginSyncProviderGeneration();
-          await this.runInPlaceReindex({
-            reason: params?.reason ?? "fallback",
-            force: true,
-            progress: progress ?? undefined,
-          });
+      } catch (err) {
+        const reason = formatErrorMessage(err);
+        const shouldFallback = this.shouldFallbackOnError(err);
+        if (shouldFallback) {
+          // A failed generation cannot wait on its own sync lease while activating fallback.
+          this.endSyncProviderGeneration();
         }
-        return;
+        const activated = shouldFallback && (await this.activateFallbackProvider(reason));
+        if (activated) {
+          if (needsFullReindex && !hasTargetArchiveFiles) {
+            this.beginSyncProviderGeneration();
+            await this.runInPlaceReindex({
+              reason: params?.reason ?? "fallback",
+              force: true,
+              progress: progress ?? undefined,
+            });
+          }
+          return;
+        }
+        if (!this.provider && this.fts.enabled && this.shouldFallbackOnError(err)) {
+          this.syncOutcomes.recordActiveFailure(err);
+          log.warn(`memory embeddings unavailable; leaving memory index dirty: ${reason}`);
+          return;
+        }
+        throw err;
       }
-      if (!this.provider && this.fts.enabled && this.shouldFallbackOnError(err)) {
-        this.syncOutcomes.recordActiveFailure(err);
-        log.warn(`memory embeddings unavailable; leaving memory index dirty: ${reason}`);
-        return;
+    } finally {
+      // Incremental work may have committed before failure. Full rebuilds prune
+      // only their shadow, so failure never mutates the published cache.
+      if (!needsFullReindex) {
+        this.pruneEmbeddingCacheIfNeeded();
       }
-      throw err;
     }
   }
 
@@ -614,6 +610,9 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
           }
 
           this.writeMeta(nextMeta);
+          // Bound the cache before copying it into the shared agent database;
+          // deleting overflow afterward does not undo primary-file growth.
+          this.pruneEmbeddingCacheIfNeeded();
           return { nextMeta, vectorIndexComplete };
         } finally {
           // Escaped continuations must fail closed, never write to the live DB.

--- a/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
+++ b/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
@@ -21,6 +21,7 @@ type ReindexHarness = {
   syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
   syncArchiveFiles: (params: SyncArchiveParams) => Promise<unknown>;
   db: DatabaseSync;
+  cache: { enabled: boolean; maxEntries?: number };
   writeMeta: (meta: MemoryIndexMeta) => void;
   providerKey: string | null;
   dirty: boolean;
@@ -64,6 +65,7 @@ describe("memory manager reindex recovery", () => {
   function createCfg(params: {
     provider?: string;
     sources?: Array<"memory" | "sessions">;
+    cacheEnabled?: boolean;
   }): OpenClawConfig {
     return {
       memory: {
@@ -71,7 +73,7 @@ describe("memory manager reindex recovery", () => {
           provider: params.provider ?? "openai",
           model: "mock-embed",
           store: { vector: {} },
-          cache: { enabled: false },
+          cache: { enabled: params.cacheEnabled ?? false },
           sources: params.sources,
           rememberAcrossConversations: params.sources?.includes("sessions") ?? false,
         },
@@ -191,6 +193,86 @@ describe("memory manager reindex recovery", () => {
         .prepare("SELECT path, text FROM memory_index_chunks ORDER BY path, start_line")
         .all(),
     ).toEqual(publishedRows);
+  });
+
+  it("bounds the shadow cache before any entries reach the primary", async () => {
+    const memoryManager = await openManager(createCfg({ sources: ["memory"], cacheEnabled: true }));
+    const harness = memoryManager as unknown as ReindexHarness;
+    harness.cache.maxEntries = 2;
+    for (let i = 0; i < 4; i += 1) {
+      await fs.writeFile(path.join(memoryDir, `${i}.md`), `unique cache content ${i}`);
+    }
+    // Reject transient overflow too: checking only the final row count misses
+    // primary-file high-water growth followed by post-publication deletion.
+    harness.db.exec(`
+      CREATE TEMP TRIGGER reject_cache_overflow BEFORE INSERT ON memory_embedding_cache
+      WHEN (SELECT COUNT(*) FROM memory_embedding_cache) >= 2
+      BEGIN SELECT RAISE(ABORT, 'primary cache overflow'); END;
+    `);
+
+    await memoryManager.sync({ reason: "cli", force: true });
+
+    expect(
+      harness.db.prepare("SELECT COUNT(*) AS count FROM memory_embedding_cache").get(),
+    ).toEqual({ count: 2 });
+    expect(harness.db.prepare("SELECT COUNT(*) AS count FROM memory_index_sources").get()).toEqual({
+      count: 4,
+    });
+  });
+
+  it("leaves even an oversized published cache untouched when a full rebuild fails", async () => {
+    const memoryManager = await openManager(createCfg({ sources: ["memory"], cacheEnabled: true }));
+    await fs.writeFile(path.join(memoryDir, "alpha.md"), "published alpha");
+    await memoryManager.sync({ reason: "cli", force: true });
+    const harness = memoryManager as unknown as ReindexHarness;
+    const insert = harness.db.prepare(`
+      INSERT INTO memory_embedding_cache
+        (provider, model, provider_key, hash, embedding, dims, updated_at)
+      VALUES ('previous-provider', 'previous-model', 'previous-key', ?, '[0,1,0]', 3, 1)
+    `);
+    insert.run("old-a");
+    insert.run("old-b");
+    harness.cache.maxEntries = 1;
+    const before = harness.db.prepare("SELECT * FROM memory_embedding_cache ORDER BY hash").all();
+    harness.writeMeta = () => {
+      throw new Error("failed shadow metadata");
+    };
+
+    await expect(memoryManager.sync({ reason: "cli", force: true })).rejects.toThrow(
+      "failed shadow metadata",
+    );
+
+    expect(harness.db.prepare("SELECT * FROM memory_embedding_cache ORDER BY hash").all()).toEqual(
+      before,
+    );
+  });
+
+  it("still bounds committed incremental work when its progress callback fails", async () => {
+    const memoryManager = await openManager(createCfg({ sources: ["memory"], cacheEnabled: true }));
+    await fs.writeFile(path.join(memoryDir, "alpha.md"), "published alpha");
+    await memoryManager.sync({ reason: "cli", force: true });
+    const harness = memoryManager as unknown as ReindexHarness;
+    harness.cache.maxEntries = 1;
+    harness.dirty = true;
+    await fs.writeFile(path.join(memoryDir, "alpha.md"), "incremental beta");
+
+    await expect(
+      memoryManager.sync({
+        reason: "session-delta",
+        progress: ({ completed }) => {
+          if (completed > 0) {
+            throw new Error("failed progress callback");
+          }
+        },
+      }),
+    ).rejects.toThrow("failed progress callback");
+
+    expect(
+      harness.db.prepare("SELECT COUNT(*) AS count FROM memory_embedding_cache").get(),
+    ).toEqual({ count: 1 });
+    expect(harness.db.prepare("SELECT text FROM memory_index_chunks").get()).toEqual({
+      text: "incremental beta",
+    });
   });
 
   it("rejects a full reindex while another process owns the build lock", async () => {

--- a/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
+++ b/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
@@ -24,6 +24,7 @@ type ReindexHarness = {
   cache: { enabled: boolean; maxEntries?: number };
   writeMeta: (meta: MemoryIndexMeta) => void;
   providerKey: string | null;
+  provider: null;
   dirty: boolean;
   memoryFullRetryDirty: boolean;
   sessionsDirty: boolean;
@@ -221,7 +222,24 @@ describe("memory manager reindex recovery", () => {
   });
 
   it("leaves even an oversized published cache untouched when a full rebuild fails", async () => {
-    const memoryManager = await openManager(createCfg({ sources: ["memory"], cacheEnabled: true }));
+    const { memoryManager, harness, before } = await createOversizedPublishedCache();
+    harness.writeMeta = () => {
+      throw new Error("failed shadow metadata");
+    };
+
+    await expect(memoryManager.sync({ reason: "cli", force: true })).rejects.toThrow(
+      "failed shadow metadata",
+    );
+
+    expect(harness.db.prepare("SELECT * FROM memory_embedding_cache ORDER BY hash").all()).toEqual(
+      before,
+    );
+  });
+
+  async function createOversizedPublishedCache() {
+    const memoryManager = await openManager(
+      createCfg({ sources: ["memory", "sessions"], cacheEnabled: true }),
+    );
     await fs.writeFile(path.join(memoryDir, "alpha.md"), "published alpha");
     await memoryManager.sync({ reason: "cli", force: true });
     const harness = memoryManager as unknown as ReindexHarness;
@@ -234,16 +252,50 @@ describe("memory manager reindex recovery", () => {
     insert.run("old-b");
     harness.cache.maxEntries = 1;
     const before = harness.db.prepare("SELECT * FROM memory_embedding_cache ORDER BY hash").all();
-    harness.writeMeta = () => {
-      throw new Error("failed shadow metadata");
-    };
+    expect(before).toHaveLength(3);
+    const newest = harness.db
+      .prepare("SELECT * FROM memory_embedding_cache ORDER BY updated_at DESC LIMIT 1")
+      .all();
+    return { memoryManager, harness, before, newest };
+  }
 
-    await expect(memoryManager.sync({ reason: "cli", force: true })).rejects.toThrow(
-      "failed shadow metadata",
+  it.each([
+    { force: false, outcome: "bounds the published cache" },
+    { force: true, outcome: "preserves the published cache" },
+  ])("$outcome on unavailable-provider preflight (force=$force)", async ({ force }) => {
+    const { memoryManager, harness, before, newest } = await createOversizedPublishedCache();
+    // Model runtime provider loss after successful initialization; keep the
+    // real sync admission, provider preflight, and SQLite cache cleanup intact.
+    harness.provider = null;
+
+    await expect(memoryManager.sync({ reason: "cli", force })).rejects.toThrow(
+      /Memory sync unavailable: embedding provider "openai" is configured but unavailable\./,
     );
 
     expect(harness.db.prepare("SELECT * FROM memory_embedding_cache ORDER BY hash").all()).toEqual(
-      before,
+      force ? before : newest,
+    );
+  });
+
+  it.each([false, true])("bounds unresolved targeted sync cache when force=%s", async (force) => {
+    const { memoryManager, harness, newest } = await createOversizedPublishedCache();
+    const publishedChunks = harness.db
+      .prepare("SELECT * FROM memory_index_chunks ORDER BY id")
+      .all();
+
+    await memoryManager.sync({
+      reason: "queued-sessions",
+      force,
+      sessions: [
+        { agentId: "main", sessionId: "missing-session", sessionKey: "agent:main:missing-session" },
+      ],
+    });
+
+    expect(harness.db.prepare("SELECT * FROM memory_embedding_cache ORDER BY hash").all()).toEqual(
+      newest,
+    );
+    expect(harness.db.prepare("SELECT * FROM memory_index_chunks ORDER BY id").all()).toEqual(
+      publishedChunks,
     );
   });
 

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -15,7 +15,6 @@ import {
   type MemoryReadResult,
   type MemorySearchManager,
   type MemorySessionSyncTarget,
-  type MemorySource,
   type MemorySyncParams,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -479,6 +479,8 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       sources: this.sources,
       sourceFilterSql: sourceFilter.sql,
       sourceFilterParams: sourceFilter.params,
+      // Source inspection is explicit; routine query status must stay count-only.
+      includeChunkBytes: this.sourceInspections.size > 0,
     });
 
     // Status projects the effective keyword-only search mode while degraded.

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -476,16 +476,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
     }
     const sourceFilter = this.buildSourceFilter();
     const aggregateState = collectMemoryStatusAggregate({
-      db: {
-        prepare: (sql) => ({
-          all: (...args) =>
-            this.db.prepare(sql).all(...args) as Array<{
-              kind: "files" | "chunks";
-              source: MemorySource;
-              c: number;
-            }>,
-        }),
-      },
+      db: this.db,
       sources: this.sources,
       sourceFilterSql: sourceFilter.sql,
       sourceFilterParams: sourceFilter.params,

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -143,9 +143,7 @@ describe("memory_search real manager", () => {
 
     const manager = await fixture.getFreshManager(cfg);
     await manager.sync({ reason: "test", force: true });
-    expect(manager.status().sourceCounts).toEqual([
-      { source: "sessions", files: 5, chunks: 4, chunkBytes: 200 },
-    ]);
+    expect(manager.status().sourceCounts).toEqual([{ source: "sessions", files: 5, chunks: 4 }]);
 
     const ranked = await manager.search("alpha", {
       maxResults: 4,

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -143,7 +143,9 @@ describe("memory_search real manager", () => {
 
     const manager = await fixture.getFreshManager(cfg);
     await manager.sync({ reason: "test", force: true });
-    expect(manager.status().sourceCounts).toEqual([{ source: "sessions", files: 5, chunks: 4 }]);
+    expect(manager.status().sourceCounts).toEqual([
+      { source: "sessions", files: 5, chunks: 4, chunkBytes: 200 },
+    ]);
 
     const ranked = await manager.search("alpha", {
       maxResults: 4,

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -158,6 +158,8 @@ export type MemoryProviderStatus = {
     source: MemorySource;
     files: number;
     chunks: number;
+    /** Stored chunk text and JSON embedding bytes, excluding cache and index overhead. */
+    chunkBytes?: number;
     eligible?: number | null;
     issues?: string[];
   }>;


### PR DESCRIPTION
Related: #135347

## What Problem This Solves

Fixes an issue where users rebuilding memory after a provider or corpus change could copy an oversized embedding cache into the shared agent database before the cache limit was enforced. A failed full rebuild could also prune the existing primary cache even though the replacement was never published. Thanks Alexis for reporting the 2026.8.1 database-growth and session-loss incident.

## Why This Change Was Made

Enforce the existing cache policy in the shadow before publishing memory-owned tables. Keep live-cache cleanup around all ordinary sync exits, including preflight failures, unresolved targets, and partially committed incremental failures. An explicitly forced non-targeted rebuild preserves the primary even if preflight fails. The existing shadow database, publication transaction, revision fence, and shared session-store ownership remain unchanged. Remove the thin sync wrapper and the status database adapter; explicit diagnostic status now reads actual SQLite aggregates and reports per-source chunk payload bytes; ordinary serving-manager status stays count-only.

## User Impact

Full reindex publication never copies cache rows beyond the existing 50,000-entry limit; failed shadow rebuilds no longer mutate the primary cache. `memory status` and JSON status report stored text-plus-JSON-embedding bytes by source. This is payload size, not physical file allocation: cache, FTS/vector tables, SQLite overhead, WAL, and free pages are excluded.

This is a bounded repair, not a claim that the entire reported 35 GB is explained or that a large legitimate corpus is capped. It does not shrink previously allocated primary files or recover deleted canonical sessions.

## Evidence

The two new owner-boundary regressions fail against unchanged production code: a primary-only SQLite trigger rejects transient cache overflow inside publication, and a failed shadow build removes existing primary cache rows. Both pass after the repair. A real incremental-write/progress-failure regression preserves live cleanup. The earlier targeted-sync test was corrected to use an eligible canonical SQLite session; its loose transcript file had exercised a no-op instead.

Focused tests: 224 cases passed across reindex recovery, targeted sync, startup catch-up, real memory-search tools, SQLite status aggregation, and the memory CLI. Three additional early-exit regressions failed on the reviewed head and now pass; a fourth verifies forced-preflight preservation. Diagnostic-scoping regressions failed before the refactor and now prove ordinary status does not evaluate payload columns and diagnostic bytes refresh after indexing without changing the serving manager. The status tests exercise real SQLite with Unicode byte sizes, filtering, and empty sources rather than asserting mocked query text.

Commands:

```text
node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.reindex-recovery.test.ts extensions/memory-core/src/memory/manager-targeted-sync.test.ts extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts extensions/memory-core/src/memory/manager-status-state.test.ts extensions/memory-core/src/cli.test.ts extensions/memory-core/src/memory/index.test.ts extensions/memory-core/src/tools.real-manager.test.ts
```

### Live proof (isolated real Gateway and built CLI)

PASS on the rebuilt runtime stamped `b514778a7dd6057324b51d378a1c393a60627bab`, after addressing pre-land review (2026-09-01 18:19–18:21 UTC). The run used a fresh state/home/workspace, free loopback ports, synthetic tokens, a deterministic local HTTP embedding endpoint, 1,200 generated memory files plus one bootstrap file, 12 retained reset artifacts, and three real Gateway-created sessions. Gateway memory search was disabled so the CLI was the sole index writer; this is not a foreground chat/recall or live external-provider claim.

The successful rebuild indexed 1,201 memory chunks and 15 session chunks. With the embedding request held, the primary memory digest stayed unchanged while real Gateway `sessions.list`, `sessions.patch`, `chat.inject`, and health calls succeeded. A synthetic transaction-level cache observer was installed only after normal CLI schema validation and those RPCs, immediately before embedding release, then removed before the next CLI startup. It would abort any transient primary cache overflow: observed publication peak and final count were both exactly 50,000. The concurrent session write survived publication.

```text
node openclaw.mjs memory index --agent main --force
  bootstrap: exit 0
node openclaw.mjs gateway run --port <free loopback port> --bind loopback
  health, sessions.create, chat.inject: succeeded
node openclaw.mjs memory index --agent main --force
  shadow built; concurrent Gateway session mutations succeeded
  publication: exit 0; cache peak=50000, final=50000
node openclaw.mjs memory status --agent main --json
  memory: 1201 chunks, chunkBytes=2934847
  sessions: 15 chunks, chunkBytes=22875
node openclaw.mjs memory index --agent main --force
  synthetic preexisting cache=50001; partial shadow committed 13 chunks
  controlled HTTP embedding failure: exit 1 (not timeout)
  primary cache=50001 unchanged; all memory/revision/FTS/vector/session hashes unchanged
  primary DB=84828160 bytes before/after; WAL=0 before/after
  no shadow files left; final Gateway health and sessions.list succeeded
cleanup: 0 owned processes remaining
```

Successful publication grew the primary file from 75,284,480 to 84,828,160 bytes for the larger corpus. Sampled peak primary plus sidecars was 169,721,344 bytes (transactional WAL included); peak shadow plus sidecars was 90,816,096 bytes. These are observed bounds for this corpus, not a global disk-size cap. The failure phase explicitly seeded one excess legacy cache row; all 50,001 survived, with identical primary DB/WAL/SHM sizes and no changes to any non-memory owner table.

Per-source byte values matched independent SQL byte counts. On this 1,216-chunk corpus, 32 alternating warm runs measured median aggregate time 0.104 ms count-only versus 2.225 ms with diagnostic byte reporting (+2.121 ms; 21.3x). Ordinary memory-search status does not run that byte aggregate; the row-header work is restricted to explicit source diagnostics. [SQLite `octet_length`](https://www.sqlite.org/lang_corefunc.html#octet_length) avoids reading overflow payloads, but adds row-header reads; large-corpus/cold-disk latency is not established. FTS and sqlite-vec logical rows were hashed, not private FTS posting-list bytes.

Two earlier harness-only attempts were retained: normal schema validation rejected prematurely installed synthetic observer triggers; then a benchmark compared SQLite null-prototype rows with plain objects. The harness lifecycle and symmetric count projection were corrected without changing product code or weakening assertions.

### Diagnostic freshness live proof

A second isolated real Gateway/CLI run passed on the same committed runtime (2026-09-01 18:21–18:22 UTC). Initial memory status reported 8 files, 8 chunks, and 14,369 payload bytes; the canonical session source reported 1 file, 1 chunk, and 1,431 bytes. After corpus edits, ordinary diagnostic status preserved those stored index facts. `memory status --index --json` then reported 11 files, 22 chunks, and 58,368 memory bytes, exactly matching independent SQL BLOB-byte totals. Canonical session-owner digests remained unchanged by indexing, and subsequent Gateway session reads/writes and health calls succeeded. Both proof runs ended with zero owned processes. Ordinary memory-search query scoping is covered by real-manager tests and the SQLite payload-evaluation regression, not claimed as Gateway memory-search RPC coverage.

### Checks

All 224 focused cases passed together after both ClawSweeper findings were addressed. The first full hosted memory lane caught two exact-shape status expectations; the final diagnostic-scoped implementation restores the ordinary consumer shapes, and both real-manager suites pass. The earlier head had complete green CI. Run33541484671 caught the now-corrected redundant Boolean conversion and an unrelated main-branch TS2790 error in the auth-login fixture introduced by #135355. Existing repair #135407 landed as `01129d7bbe06ba05f1e4850d6b6a38c4f2a2c22b`; its ancestry and corrected source were verified on origin/main before the final CI push. Fresh [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33543345535) is green for `b514778a7dd6057324b51d378a1c393a60627bab`.

The full native CLI build succeeded after the existing declaration repair #135360 landed; the revised runtime was rebuilt with the native QA profile and canonical build-provenance step. Candidate and committed-branch autoreviews are clean at the configured P0 threshold. The original changed-surface checks completed through native retries after a transient canonical-dependency snapshot ENOENT. The diagnostic pass caught a test-only template-expression lint error, and the final pass caught a redundant Boolean conversion; both are corrected. The failed plugin-lint phase and all remaining native guards were rerun successfully. Final owner-focused rerun: 50/50 passed. No gate is skipped.

Source trace: memory CLI index → `MemoryIndexManager.sync` → `MemoryManagerSyncOps.runSync` → shadow rebuild → `publishMemoryDatabaseTables` → existing SQLite transaction. Incremental, targeted, provider-fallback, and source-wide batch paths retain their owners. Status reads remain on the published handle. The same agent file holds `session_nodes`, `session_windows`, and `transcript_events`; it must not be replaced wholesale.

History: raw-parent diff for `053ff9e399f` (#131121), which is an ancestor of v2026.8.1, shows pruning moved out of the shadow and into the outer finalizer. The new tests prove both consequences. No schema, codec, retention limit, configuration, environment variable, dependency, or protocol change is included.

Production: +255/-259 (net -4). Tests: +257/-49 (net +208). Docs: +8/-1. Assertion baseline: one existing allowance removed to match the deleted status adapter cast; no gate was weakened.

### Remaining maintainer decisions and support guidance

Proposed docs/support correction: never delete `agents/<agentId>/agent/openclaw-agent.sqlite` as a memory-index recovery action. It also owns canonical session history and transcripts. Preserve the complete database and sidecars before owner-approved recovery. Deleting it is not an index reset.

Separate derived-index storage, embedding codecs, a total corpus-size/retention policy, and “from now onward” source enablement remain material store/product decisions. This PR does not implement them. #131085 and #114612 retain those broader questions; #135347 remains open for the incident's unresolved attribution and safe-recovery follow-up.

NO-FOLLOW-UP: the rent-paying diagnostic-query refactor was absorbed to resolve pre-land review; no further bounded cleanup is justified beyond the explicitly gated store/corpus decisions.

Pre-land ClawSweeper review: both actionable findings and all three Rank-up moves are addressed—ordinary early-exit cleanup, diagnostic-only byte aggregation, and refreshed focused/live proof. The first review execution failed without an actionable diagnostic; normal re-review completed. Native merge previously stopped without a completed review; no gate was bypassed. The reviewed-head findings, their failing reproductions, and the resolution are recorded in the review thread.

Latest pre-land review: the completed ClawSweeper review at 2026-09-01 18:19 UTC reports no remaining source-backed finding and sufficient real-runtime proof. Its remaining Rank-up move—wait for exact-head CI—is satisfied. The reviewer could not hydrate current main; the maintainer checkout independently compared the affected owner files against main `59bcbd156fa` and found no intervening changes.
