### PR TITLE
refactor(logging): reduce work for ordinary log records

### DIFF
--- a/src/logging/parse-log-line.ts
+++ b/src/logging/parse-log-line.ts
@@ -1,8 +1,6 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-// Log line parsing helpers convert text log entries into structured records.
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 
-// Parser for JSON LogTape lines emitted by the OpenClaw logger.
 export type ParsedLogLine = {
   time?: string;
   level?: string;
@@ -31,7 +29,7 @@ function extractMessage(value: Record<string, unknown>): string {
 }
 
 function parseMetaName(raw?: unknown): LogContext {
-  if (typeof raw !== "string") {
+  if (typeof raw !== "string" || !raw.trimStart().startsWith("{")) {
     return {};
   }
   try {


### PR DESCRIPTION
## What Problem This Solves

Ordinary log names and messages are repeatedly parsed as JSON metadata, creating and catching syntax errors while reading log tails. A plain record performs three JSON parses even though only its outer record is JSON.

## Why This Change Was Made

Only attempt the inner metadata parse when the string can start a JSON object. Parse the original string so valid JSON whitespace, malformed objects, BOM rejection, and per-field fallback retain their existing behavior. Keep the separate filtering and post-redaction parses at the log-tail owner. Remove two stale comments beside the imports.

## User Impact

Log readers do less work for ordinary messages and retain identical context fields, filtering, and redacted output.

## Evidence

- 27 focused tests across parser, file-tail, and redaction suites pass before and after. Typed lint, independent source review, and isolated Codex autoreview pass.
- 888 complete-parser differential cases produce identical results, including whitespace, BOM, malformed metadata, arrays, primitives, and field-wise fallback.
- Plain records require one JSON parse instead of three, eliminating two caught syntax errors per record. Mixed structured/plain records require two instead of three. Fully structured records retain all three parses.
- Actual OpenClaw logging through its asynchronous file transport and parsed-tail reader produces identical normalized output before and after: four transported records, one explicitly injected synthetic raw-tail record, five unfiltered records, two plugin-filtered records, and six boundary checks. Producer and tail redaction both remain effective.

Production: +1/-3, net -2 lines. Tests and dependencies unchanged. Operation counts describe the parser; no whole-Gateway memory or latency percentage is claimed.
