### PR TITLE
fix(plugins): fall back to /v1/models when the root /models response is unusable

### DIFF
--- a/src/plugins/provider-self-hosted-discovery.test.ts
+++ b/src/plugins/provider-self-hosted-discovery.test.ts
@@ -57,6 +57,38 @@ describe("discoverOpenAICompatibleLocalModels raw discovery", () => {
     ]);
   });
 
+  it("falls back to /v1/models when the root /models response is unusable", async () => {
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce(
+        guarded(new Response(JSON.stringify({ llama: "server" }), { status: 200 })),
+      )
+      .mockResolvedValueOnce(
+        guarded(
+          new Response(JSON.stringify({ data: [{ id: "model", object: "model" }] }), {
+            status: 200,
+          }),
+        ),
+      );
+
+    await expect(
+      discoverOpenAICompatibleLocalModels({
+        baseUrl: "http://127.0.0.1:8080/v1",
+        serverBaseUrl: "http://127.0.0.1:8080",
+        label: "llama-server",
+        modelsPathOrder: "server-first",
+        discoverRuntimeContext: false,
+        rawResult: true,
+      }),
+    ).resolves.toMatchObject({
+      kind: "success",
+      rows: [{ model: { id: "model" } }],
+    });
+    expect(fetchWithSsrFGuardMock.mock.calls.map(([call]) => call.url)).toEqual([
+      "http://127.0.0.1:8080/models",
+      "http://127.0.0.1:8080/v1/models",
+    ]);
+  });
+
   it("separates transport, HTTP, and invalid model-list responses", async () => {
     fetchWithSsrFGuardMock.mockRejectedValueOnce(new Error("connection refused"));
     await expect(

--- a/src/plugins/provider-self-hosted-discovery.ts
+++ b/src/plugins/provider-self-hosted-discovery.ts
@@ -234,13 +234,27 @@ async function discoverOpenAICompatibleModelRows(params: {
       readBody: true,
       label: params.label,
     });
-    if (
-      modelsResult.kind !== "response" ||
-      modelsResult.status !== 404 ||
-      index === modelCandidates.length - 1
-    ) {
+    if (modelsResult.kind !== "response") {
       break;
     }
+    const isLastCandidate = index === modelCandidates.length - 1;
+    if (modelsResult.status === 404 && !isLastCandidate) {
+      continue;
+    }
+    if (!modelsResult.ok) {
+      break;
+    }
+    // A successful server-first root response may still be unusable (e.g.
+    // Unsloth's non-OpenAI /models shape). Fall back to /v1/models instead of
+    // failing discovery.
+    if (params.modelsPathOrder === "server-first" && !isLastCandidate) {
+      try {
+        readDiscoveryRows(modelsResult.body);
+      } catch {
+        continue;
+      }
+    }
+    break;
   }
   if (!modelsResult || modelsResult.kind === "unreachable") {
     return modelsResult ?? { kind: "unreachable", error: new Error("missing model response") };


### PR DESCRIPTION
Closes #135361

## What Problem This Solves

Fixes a regression that broke onboarding for Unsloth-hosted llama-cpp. After a clean install, `openclaw onboard` refused the provider with `llama-server returned an invalid response from /models`, because Unsloth's root `/models` endpoint returns a successful but non-OpenAI response and discovery stopped there instead of falling back to the documented `/v1/models` endpoint.

## Why This Change Was Made

`discoverOpenAICompatibleLocalModels` with `modelsPathOrder: "server-first"` only fell back from root `/models` on HTTP 404. A 200 response whose body could not be parsed into an OpenAI `data[]` model list returned `invalid-response` immediately, never trying `/v1/models`. This change treats an unusable successful server-first root response the same as a 404 and falls back to `/v1/models`, while still preserving valid root llama-server discovery.

## User Impact

Unsloth-managed llama-cpp providers can onboard again; model discovery now falls back to `/v1/models` when the root `/models` response is unusable instead of failing.

## Evidence

Exact head: `43ed533fd65d02aa9731aae03303f66b94554acf`.

- `src/plugins/provider-self-hosted-discovery.test.ts` — 8 passed, including a new regression that returns a 200 non-OpenAI root `/models` body and asserts discovery falls back to `/v1/models` and succeeds.
- Production typecheck and `check:changed` pass; the only local lane failure is unchanged `ui/vite.config.ts` missing a `pako` declaration in the reused dependency tree.

## AI Assistance

AI-assisted implementation. I manually verified the discovery fallback loop, the unusable-response path, the focused regression, and the changed-file gates.
