### PR TITLE
refactor(cli): reuse lazy runtime module loader

### DIFF
--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -2,16 +2,11 @@
 import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
+import { createLazyRuntimeModule as createModuleLoader } from "../shared/lazy-runtime.js";
 import { isModelsStatusJsonOutput } from "./models-output-mode.js";
 import { setCommandJsonMode } from "./program/json-mode.js";
 
 type ModelsCliRuntime = typeof import("./models-cli.runtime.js");
-
-function createModuleLoader<T>(load: () => Promise<T>): () => Promise<T> {
-  // Model subcommands are heavy; load each implementation once on first use.
-  let promise: Promise<T> | undefined;
-  return () => (promise ??= load());
-}
 
 const loadModelsRuntime = createModuleLoader<ModelsCliRuntime>(
   () => import("./models-cli.runtime.js"),

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -20,6 +20,7 @@ import { resolvePluginInstallSources } from "../plugins/install-channel-specs.js
 import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import { tracePluginLifecyclePhaseAsync } from "../plugins/plugin-lifecycle-trace.js";
 import { defaultRuntime } from "../runtime.js";
+import { createLazyRuntimeModule as createModuleLoader } from "../shared/lazy-runtime.js";
 import { shortenHomeInString } from "../utils.js";
 import { formatMissingPluginMessage } from "./error-format.js";
 import { ExpectedCliError, formatCliJsonFailure } from "./failure-output.js";
@@ -41,11 +42,6 @@ type PluginInstallActionOptions = {
   pin?: boolean;
   marketplace?: string;
 };
-
-function createModuleLoader<T>(load: () => Promise<T>): () => Promise<T> {
-  let promise: Promise<T> | undefined;
-  return () => (promise ??= load());
-}
 
 const loadPluginsConfigState = createModuleLoader(() => import("../plugins/config-state.js"));
 const loadPluginsStatus = createModuleLoader(() => import("../plugins/status.js"));

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -2,6 +2,7 @@
 import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
+import { createLazyRuntimeModule as createModuleLoader } from "../shared/lazy-runtime.js";
 import type { PluginInspectOptions } from "./plugins-inspect-command.js";
 import type { PluginsListOptions } from "./plugins-list-command.js";
 import { parseStrictPositiveIntOption } from "./program/helpers.js";
@@ -72,12 +73,6 @@ type PluginAuthoringInitOptions = {
   force?: boolean;
   type?: string;
 };
-
-function createModuleLoader<T>(load: () => Promise<T>): () => Promise<T> {
-  // Plugin runtime modules are heavy; load each command surface once on first use.
-  let promise: Promise<T> | undefined;
-  return () => (promise ??= load());
-}
 
 const loadPluginsRuntime = createModuleLoader(() => import("./plugins-cli.runtime.js"));
 const loadPluginsAuthoringCommands = createModuleLoader(

--- a/src/cli/program/register.tasks.ts
+++ b/src/cli/program/register.tasks.ts
@@ -2,6 +2,7 @@
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import type { Command } from "commander";
 import { defaultRuntime } from "../../runtime.js";
+import { createLazyRuntimeModule as createModuleLoader } from "../../shared/lazy-runtime.js";
 import { TASK_FLOW_STATUSES } from "../../tasks/task-flow-registry.types.js";
 import {
   TASK_RUNTIMES,
@@ -33,11 +34,6 @@ const TASKS_LEAF_OPTION_SUPPORT = {
   "flow cancel": [],
 } satisfies Record<string, readonly TasksParentOption[]>;
 type TasksLeaf = keyof typeof TASKS_LEAF_OPTION_SUPPORT;
-
-function createModuleLoader<T>(load: () => Promise<T>): () => Promise<T> {
-  let promise: Promise<T> | undefined;
-  return () => (promise ??= load());
-}
 
 const loadTasksCommands = createModuleLoader(() => import("../../commands/tasks.js"));
 const loadFlowsCommands = createModuleLoader(() => import("../../commands/flows.js"));


### PR DESCRIPTION
## What Problem This Solves

Four CLI modules independently implemented the same sticky dynamic-import cache. That duplicated a shared lazy-runtime contract across 15 private module loaders and created avoidable drift risk.

## Why This Change Was Made

The models, plugins, plugin runtime, and task-registration modules now reuse `createLazyRuntimeModule` from `src/shared/lazy-runtime.ts`.

The loaders remain private and every production caller immediately awaits them. The observable behavior remains:

- lazy module activation before command work uses the module
- one in-flight import shared by concurrent callers
- the same resolved module value
- cached import rejection
- one importer invocation

The PR-only CLI helper and its implementation-detail test were removed. The canonical shared helper and its existing boundary tests remain unchanged.

Production LOC: `+4/-22`, net `-18`. Tests: `0`.

## User Impact

No user-visible behavior change. CLI command modules still load lazily and only once, with one existing shared owner instead of four local copies.

## Evidence

- Differential probe matched resolved value, single-flight behavior, sticky rejection, and importer call count.
- Focused tests: 71 passed across `src/shared/lazy-runtime.test.ts`, `src/cli/models-cli.lazy.test.ts`, `src/cli/plugins-cli.lazy.test.ts`, and `src/cli/program/register.tasks.test.ts`.
- Formatting and `git diff --check`: passed.
- Import-cycle check: 0 runtime value cycles.
- `check:changed` passed its guards through the core typecheck, which could not resolve existing shared-install packages including `markdown-it-cjk-friendly`, `mdast-util-from-markdown`, and `libphonenumber-js`.
- Full build reached bundled plugin assets, then stopped because the shared install lacks `@pierre/diffs` and Shiki language packages.
- Fresh autoreview: scoped clean, 0.99 confidence, no P0-P2 findings.
