### PR TITLE
fix(discord): stop error replies after voice consult cancellation

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1463,6 +1463,8 @@ In `agent-proxy` mode the bot joins the configured voice channel, but OpenClaw a
 
 While a delegated OpenClaw run is active, new Discord voice transcripts are treated as live run control before starting another agent turn. Phrases such as "status", "cancel that", "use the smaller fix", or "when you're done also check tests" are classified as status, cancel, steering, or follow-up input for the active session. Status, cancel, accepted steering, and follow-up outcomes are spoken back into the voice channel so the caller knows whether OpenClaw handled the request.
 
+When OpenClaw cancels a delegated consult, Discord records cancellation rather than a failure and does not play the generic error fallback. Matching late provider tool calls receive the same terminal cancellation instead of restarting the work. The voice session remains available for the next request; timeouts and genuine failures keep their normal error handling.
+
 Useful target forms:
 
 - `target: "channel:123456789012345678"` routes through a Discord text channel session.

--- a/extensions/discord/src/voice/realtime-consults.host-cancellation.test.ts
+++ b/extensions/discord/src/voice/realtime-consults.host-cancellation.test.ts
@@ -1,0 +1,309 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
+
+type AgentResult = { payloads: Array<{ text: string }> };
+
+const cancelledResult = {
+  status: "cancelled",
+  message: "OpenClaw cancelled this consult before completion. Do not restart it.",
+};
+
+defineDiscordVoiceTests(
+  ({
+    expect,
+    it,
+    vi,
+    agentCommandMock,
+    loggerWarnMock,
+    realtimeSessionMock,
+    beginSpeakerTurn,
+    agentCommandArgsAt,
+    createJoinedAgentProxyFixture,
+    createJoinedBidiFixture,
+    emitFinalRealtimeUserTranscript,
+    flushRealtimeForcedConsultTimers,
+    getSessionEntry,
+    lastRealtimeBridgeParams,
+  }) => {
+    const drainConsultWork = () =>
+      new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+
+    async function createPendingConsultFixture(mode: "bidi" | "agent-proxy" = "agent-proxy") {
+      const hostTurn = createDeferred<AgentResult>();
+      agentCommandMock.mockReturnValueOnce(hostTurn.promise);
+      const fixture =
+        mode === "bidi"
+          ? await createJoinedBidiFixture({ voice: { realtime: { consultPolicy: "always" } } })
+          : await createJoinedAgentProxyFixture();
+      const submissions: Array<Promise<PromiseSettledResult<void>>> = [];
+      const consult = (callId: string, bridgeParams = fixture.bridgeParams) => {
+        const submission = Promise.resolve(
+          bridgeParams.onToolCall!(
+            {
+              itemId: `item-${callId}`,
+              callId,
+              name: "openclaw_agent_consult",
+              args: { question: "shared question" },
+            },
+            realtimeSessionMock,
+          ),
+        ).then(
+          (): PromiseFulfilledResult<void> => ({ status: "fulfilled", value: undefined }),
+          (reason: unknown): PromiseRejectedResult => ({ status: "rejected", reason }),
+        );
+        submissions.push(submission);
+        return submission;
+      };
+      return {
+        ...fixture,
+        hostTurn,
+        consult,
+        async close() {
+          fixture.entry.stop();
+          hostTurn.resolve({ payloads: [] });
+          await Promise.all(submissions);
+          // Forced consult timers launch work without returning its promise. Drain its
+          // rejection/delivery continuations before the shared mocks are reset.
+          await drainConsultWork();
+          await fixture.manager.destroy();
+        },
+      };
+    }
+
+    it.each([
+      { mode: "bidi", path: "native", abort: "signal", suppression: true, rejectDelivery: false },
+      {
+        mode: "agent-proxy",
+        path: "native",
+        abort: "named",
+        suppression: false,
+        rejectDelivery: false,
+      },
+      {
+        mode: "agent-proxy",
+        path: "late",
+        abort: "signal",
+        suppression: true,
+        rejectDelivery: false,
+      },
+      {
+        mode: "agent-proxy",
+        path: "joined",
+        abort: "signal",
+        suppression: true,
+        rejectDelivery: false,
+      },
+      {
+        mode: "agent-proxy",
+        path: "joined",
+        abort: "named",
+        suppression: false,
+        rejectDelivery: false,
+      },
+      {
+        mode: "agent-proxy",
+        path: "joined",
+        abort: "named",
+        suppression: false,
+        rejectDelivery: true,
+      },
+    ] as const)(
+      "terminally cancels $mode $path host $abort abort (suppression=$suppression, delivery rejection=$rejectDelivery)",
+      async ({ mode, path, abort, suppression, rejectDelivery }) => {
+        const fixture = await createPendingConsultFixture(mode);
+        const { bridgeParams, entry, hostTurn, consult } = fixture;
+        const deliveryError = new Error("native delivery rejected");
+        const pending: Array<ReturnType<typeof consult>> = [];
+        const callIds: string[] = [];
+        realtimeSessionMock.bridge.supportsToolResultSuppression = suppression;
+        try {
+          beginSpeakerTurn(entry, { extraSystemPrompt: "owner context" });
+          if (path === "native") {
+            callIds.push("call-native", "call-joined");
+            pending.push(consult("call-native"), consult("call-joined"));
+          } else {
+            await emitFinalRealtimeUserTranscript(bridgeParams, "shared question");
+            if (path === "joined") {
+              callIds.push("call-joined");
+              pending.push(consult("call-joined"));
+            }
+          }
+          await vi.waitFor(() => expect(agentCommandMock).toHaveBeenCalledTimes(1));
+          expect(agentCommandArgsAt(0)).toMatchObject({
+            senderIsOwner: true,
+            extraSystemPrompt: "owner context",
+          });
+          if (rejectDelivery) {
+            realtimeSessionMock.submitToolResult.mockRejectedValueOnce(deliveryError);
+          }
+          hostTurn.reject(
+            abort === "signal"
+              ? AbortSignal.abort().reason
+              : Object.assign(new Error("host turn cancelled"), { name: "AbortError" }),
+          );
+          const outcomes = await Promise.all(pending);
+          expect(outcomes).toEqual(
+            pending.map(() =>
+              rejectDelivery
+                ? { status: "rejected", reason: deliveryError }
+                : { status: "fulfilled", value: undefined },
+            ),
+          );
+          await drainConsultWork();
+
+          // The provider stays connected: host cancellation must not request error speech.
+          expect.soft(entry.realtimeLifecycle.status).toBe("active");
+          expect.soft(realtimeSessionMock.close).not.toHaveBeenCalled();
+          expect.soft(realtimeSessionMock.sendUserMessage).not.toHaveBeenCalled();
+          expect.soft(loggerWarnMock).not.toHaveBeenCalled();
+
+          callIds.push("call-late", "call-deduped");
+          await consult("call-late");
+          await consult("call-deduped");
+          expect.soft(agentCommandMock).toHaveBeenCalledTimes(1);
+          expect
+            .soft(realtimeSessionMock.submitToolResult.mock.calls)
+            .toEqual(
+              callIds.map((callId) =>
+                suppression
+                  ? [callId, cancelledResult, { suppressResponse: true }]
+                  : [callId, cancelledResult],
+              ),
+            );
+          expect.soft(realtimeSessionMock.sendUserMessage).not.toHaveBeenCalled();
+          expect.soft(loggerWarnMock).not.toHaveBeenCalled();
+
+          if (path === "late") {
+            agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "guest answer" }] });
+            beginSpeakerTurn(entry, { senderIsOwner: false, extraSystemPrompt: "guest context" });
+            await flushRealtimeForcedConsultTimers(async () => {
+              bridgeParams.onTranscript?.("user", "shared question", true);
+              await consult("call-guest");
+            });
+            expect(agentCommandMock).toHaveBeenCalledTimes(2);
+            expect(agentCommandArgsAt(1)).toMatchObject({
+              senderIsOwner: false,
+              extraSystemPrompt: "guest context",
+            });
+            expect(realtimeSessionMock.submitToolResult.mock.calls.at(-1)).toEqual([
+              "call-guest",
+              { text: "guest answer" },
+            ]);
+          }
+        } finally {
+          await fixture.close();
+        }
+      },
+    );
+
+    it.each(["success", "failure"] as const)(
+      "waits for every native delivery before handing forced %s playback back",
+      async (outcome) => {
+        const fixture = await createPendingConsultFixture();
+        const { bridgeParams, entry, hostTurn, consult } = fixture;
+        const firstDelivery = createDeferred<void>();
+        const deliveryError = Object.assign(new Error("provider delivery aborted"), {
+          name: "AbortError",
+        });
+        realtimeSessionMock.bridge.supportsToolResultSuppression = false;
+        try {
+          beginSpeakerTurn(entry);
+          await emitFinalRealtimeUserTranscript(bridgeParams, "shared question");
+          realtimeSessionMock.submitToolResult
+            .mockReturnValueOnce(firstDelivery.promise)
+            .mockRejectedValueOnce(deliveryError);
+          const first = consult("call-first");
+          const second = consult("call-second");
+          if (outcome === "success") {
+            hostTurn.resolve({ payloads: [{ text: "shared answer" }] });
+          } else {
+            hostTurn.reject(new Error("host failed"));
+          }
+          expect(await second).toEqual({ status: "rejected", reason: deliveryError });
+          await drainConsultWork();
+          expect.soft(realtimeSessionMock.sendUserMessage).not.toHaveBeenCalled();
+
+          firstDelivery.resolve();
+          expect(await first).toEqual({ status: "fulfilled", value: undefined });
+          await drainConsultWork();
+          expect(realtimeSessionMock.sendUserMessage).not.toHaveBeenCalled();
+          expect(agentCommandMock).toHaveBeenCalledOnce();
+          const result =
+            outcome === "success" ? { text: "shared answer" } : { error: "host failed" };
+          expect(realtimeSessionMock.submitToolResult.mock.calls).toEqual([
+            ["call-first", result],
+            ["call-second", result],
+          ]);
+        } finally {
+          firstDelivery.resolve();
+          await fixture.close();
+        }
+      },
+    );
+
+    it.each([
+      { transition: "reset", path: "native" },
+      { transition: "reset", path: "joined" },
+      { transition: "teardown", path: "native" },
+      { transition: "teardown", path: "joined" },
+    ] as const)(
+      "isolates stale $path host cancellation after $transition from the next speaker's same question",
+      async ({ transition, path }) => {
+        const fixture = await createPendingConsultFixture();
+        const { manager, hostTurn, consult } = fixture;
+        let { bridgeParams, entry } = fixture;
+        const freshTurn = createDeferred<AgentResult>();
+        agentCommandMock.mockReturnValueOnce(freshTurn.promise);
+        realtimeSessionMock.bridge.supportsToolResultSuppression = false;
+        try {
+          beginSpeakerTurn(entry);
+          if (path === "joined") {
+            await emitFinalRealtimeUserTranscript(bridgeParams, "shared question");
+          }
+          const oldSubmission = consult("call-old");
+          await vi.waitFor(() => expect(agentCommandMock).toHaveBeenCalledTimes(1));
+
+          if (transition === "teardown") {
+            entry.stop();
+            await manager.join({ guildId: "g1", channelId: "1001" });
+            entry = getSessionEntry(manager);
+            bridgeParams = lastRealtimeBridgeParams();
+          } else {
+            bridgeParams.onEvent?.({ direction: "client", type: "session.continuity.reset" });
+            bridgeParams.onReady?.();
+          }
+          beginSpeakerTurn(entry, { senderIsOwner: false, extraSystemPrompt: "fresh guest" });
+          const freshSubmission = consult("call-fresh", bridgeParams);
+          await vi.waitFor(() => expect(agentCommandMock).toHaveBeenCalledTimes(2));
+
+          hostTurn.reject(AbortSignal.abort().reason);
+          await oldSubmission;
+          await drainConsultWork();
+          expect(realtimeSessionMock.submitToolResult).not.toHaveBeenCalled();
+          expect(realtimeSessionMock.sendUserMessage).not.toHaveBeenCalled();
+          expect(loggerWarnMock).not.toHaveBeenCalled();
+
+          freshTurn.resolve({ payloads: [{ text: "fresh answer" }] });
+          await freshSubmission;
+          await consult("call-fresh-deduped", bridgeParams);
+          expect(agentCommandMock).toHaveBeenCalledTimes(2);
+          expect(agentCommandArgsAt(1)).toMatchObject({
+            senderIsOwner: false,
+            extraSystemPrompt: "fresh guest",
+          });
+          expect(realtimeSessionMock.submitToolResult.mock.calls).toEqual([
+            ["call-fresh", { text: "fresh answer" }],
+            ["call-fresh-deduped", { text: "fresh answer" }],
+          ]);
+          expect(realtimeSessionMock.sendUserMessage).not.toHaveBeenCalled();
+          expect(loggerWarnMock).not.toHaveBeenCalled();
+        } finally {
+          freshTurn.resolve({ payloads: [] });
+          await fixture.close();
+        }
+      },
+    );
+  },
+);

--- a/extensions/discord/src/voice/realtime-consults.test.ts
+++ b/extensions/discord/src/voice/realtime-consults.test.ts
@@ -1,4 +1,5 @@
 import type { PassThrough } from "node:stream";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { RealtimeVoiceSessionHarness } from "openclaw/plugin-sdk/realtime-voice";
 import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
 
@@ -11,6 +12,7 @@ defineDiscordVoiceTests(
     createAudioResourceMock,
     resolveAgentRouteMock,
     agentCommandMock,
+    loggerWarnMock,
     resolveRealtimeBootstrapContextInstructionsMock,
     realtimeSessionMock,
     createClient,
@@ -428,42 +430,75 @@ defineDiscordVoiceTests(
       await vi.waitFor(() => expectUserMessageIncludes("local retry answer"));
     });
 
-    it("suppresses late forced agent-proxy tool calls when the forced consult rejects", async () => {
-      let rejectAgentTurn: ((error: unknown) => void) | undefined;
-      agentCommandMock.mockReturnValueOnce(
-        new Promise((_, reject) => {
-          rejectAgentTurn = reject;
-        }),
-      );
-      const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
+    it.each(
+      ["Error", "TimeoutError"].flatMap((name) =>
+        ["native", "forced-suppressed", "forced-unsuppressed"].map((delivery) => ({
+          name,
+          delivery,
+        })),
+      ),
+    )(
+      "preserves $name failure reporting through $delivery consult delivery",
+      async ({ name, delivery }) => {
+        const hostTurn = createDeferred<{ payloads: Array<{ text: string }> }>();
+        agentCommandMock.mockReturnValueOnce(hostTurn.promise);
+        const { bridgeParams, entry, manager } = await createJoinedAgentProxyFixture();
+        let submission: Promise<void> | void = undefined;
+        try {
+          beginSpeakerTurn(entry);
+          if (delivery !== "native") {
+            await emitFinalRealtimeUserTranscript(bridgeParams, "late question");
+          }
+          realtimeSessionMock.bridge.supportsToolResultSuppression =
+            delivery !== "forced-unsuppressed";
+          submission = bridgeParams.onToolCall?.(
+            {
+              itemId: "item-late",
+              callId: "call-late",
+              name: "openclaw_agent_consult",
+              args: { question: "late question" },
+            },
+            realtimeSessionMock,
+          );
+          await vi.waitFor(() => expect(agentCommandMock).toHaveBeenCalledTimes(1));
+          hostTurn.reject(Object.assign(new Error("agent broke"), { name }));
+          await submission;
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
 
-      beginSpeakerTurn(entry);
-      await emitFinalRealtimeUserTranscript(bridgeParams, "late question");
-
-      void bridgeParams?.onToolCall?.(
-        {
-          itemId: "item-late",
-          callId: "call-late",
-          name: "openclaw_agent_consult",
-          args: { question: "late question" },
-        },
-        realtimeSessionMock,
-      );
-      rejectAgentTurn?.(new Error("agent broke"));
-      await vi.waitFor(() =>
-        expect(realtimeSessionMock.submitToolResult).toHaveBeenCalledWith(
-          "call-late",
-          {
-            status: "already_delivered",
-            message: "OpenClaw already delivered this answer to Discord voice. Do not repeat it.",
-          },
-          { suppressResponse: true },
-        ),
-      );
-
-      expect(agentCommandMock).toHaveBeenCalledTimes(1);
-      expectUserMessageIncludes("I hit an error while checking that. Please try again.");
-    });
+          expect(agentCommandMock).toHaveBeenCalledTimes(1);
+          expect(loggerWarnMock).toHaveBeenCalledWith(expect.stringContaining("consult failed"));
+          expect(realtimeSessionMock.submitToolResult.mock.calls).toEqual([
+            delivery === "forced-suppressed"
+              ? [
+                  "call-late",
+                  {
+                    status: "already_delivered",
+                    message:
+                      "OpenClaw already delivered this answer to Discord voice. Do not repeat it.",
+                  },
+                  { suppressResponse: true },
+                ]
+              : ["call-late", { error: "agent broke" }],
+          ]);
+          if (delivery === "forced-suppressed") {
+            expectUserMessageIncludes("I hit an error while checking that. Please try again.");
+            expect(realtimeSessionMock.sendUserMessage).toHaveBeenCalledOnce();
+          } else {
+            expect(realtimeSessionMock.sendUserMessage).not.toHaveBeenCalled();
+          }
+        } finally {
+          entry.stop();
+          hostTurn.resolve({ payloads: [] });
+          await submission;
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+          await manager.destroy();
+        }
+      },
+    );
 
     it("does not reuse recent agent-proxy answers over newer speaker audio", async () => {
       agentCommandMock

--- a/extensions/discord/src/voice/realtime-consults.ts
+++ b/extensions/discord/src/voice/realtime-consults.ts
@@ -1,4 +1,6 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import {
+  buildRealtimeVoiceAgentErrorProviderResult,
   classifyRealtimeVoiceConsultToolCall,
   classifySkippableRealtimeVoiceConsultTranscript,
   controlRealtimeVoiceAgentRun,
@@ -33,24 +35,34 @@ const DISCORD_REALTIME_FORCED_CONSULT_FALLBACK_DELAY_MS = 200;
 const DISCORD_REALTIME_FORCED_CONSULT_REASON =
   "provider_final_transcript_without_openclaw_agent_consult";
 
-type RecentAgentProxyConsultResult =
-  | { status: "fulfilled"; text: string }
-  | { status: "rejected"; error: string };
+const CANCELLED_CONSULT_RESULT = {
+  status: "cancelled",
+  message: "OpenClaw cancelled this consult before completion. Do not restart it.",
+};
+
+type AgentProxyConsultResult =
+  | { text: string }
+  | ReturnType<typeof buildRealtimeVoiceAgentErrorProviderResult>;
+
+type AgentProxyProviderDelivery = ReturnType<typeof createDeferred<void>>;
 
 export type AgentProxyConsultState = {
   speaker: DiscordRealtimeSpeakerContext;
   providerEpoch: number;
   handledByForcedPlayback?: boolean;
-  providerDelivery?: Promise<void>;
-  settleProviderDelivery?: () => void;
-  promise?: Promise<string>;
-  result?: RecentAgentProxyConsultResult;
+  promise?: Promise<AgentProxyConsultResult>;
+  result?: AgentProxyConsultResult;
 };
 
 type AgentProxyConsultHandle = RealtimeVoiceForcedConsultHandle<AgentProxyConsultState>;
 
 export class DiscordRealtimeConsults {
   private talkback: RealtimeVoiceAgentTalkbackQueue;
+  // Pending deliveries outlive the coordinator's recent-result dedupe window.
+  private readonly providerDeliveries = new Map<
+    AgentProxyConsultState,
+    Set<AgentProxyProviderDelivery>
+  >();
 
   constructor(
     private readonly params: {
@@ -134,10 +146,7 @@ export class DiscordRealtimeConsults {
       nativeConsult.kind === "already_delivered" &&
       this.params.harness.forcedConsults.isCancelled(nativeConsult.handle)
     ) {
-      await this.submitTerminalRealtimeToolResult(callId, session, {
-        status: "cancelled",
-        message: "OpenClaw cancelled this consult before completion. Do not restart it.",
-      });
+      await this.submitTerminalRealtimeToolResult(callId, session, CANCELLED_CONSULT_RESULT);
       return;
     }
     const pendingConsult = nativeConsult.kind === "pending" ? nativeConsult.handle : undefined;
@@ -183,29 +192,21 @@ export class DiscordRealtimeConsults {
       await session.submitToolResult(callId, { error: "No Discord speaker context available" });
       return;
     }
-    const promise = this.runAgentTurn({ context, message: consultMessage });
-    if (recent) {
-      this.setRecentAgentProxyConsultPromise(recent, promise);
-    }
-    let text: string;
-    try {
-      text = await promise;
-    } catch (error) {
-      if (providerEpoch !== this.params.providerEpoch()) {
-        return;
-      }
-      const message = formatErrorMessage(error);
-      logger.warn(`discord voice: realtime consult failed call=${callId || "unknown"}: ${message}`);
-      await session.submitToolResult(callId, { error: message });
-      return;
-    }
+    const result = await this.trackAgentProxyConsult(
+      recent,
+      this.runAgentTurn({ context, message: consultMessage }),
+    );
     if (providerEpoch !== this.params.providerEpoch()) {
       return;
     }
-    logger.info(
-      `discord voice: realtime consult answer (${text.length} chars) voiceSession=${this.params.entry.voiceSessionKey} supervisorSession=${this.params.entry.route.sessionKey} agent=${this.params.entry.route.agentId} speaker=${context.speakerLabel} owner=${context.senderIsOwner}: ${formatVoiceLogPreview(text)}`,
-    );
-    await session.submitToolResult(callId, { text });
+    if ("text" in result) {
+      logger.info(
+        `discord voice: realtime consult answer (${result.text.length} chars) voiceSession=${this.params.entry.voiceSessionKey} supervisorSession=${this.params.entry.route.sessionKey} agent=${this.params.entry.route.agentId} speaker=${context.speakerLabel} owner=${context.senderIsOwner}: ${formatVoiceLogPreview(result.text)}`,
+      );
+    } else if ("error" in result) {
+      logger.warn(`discord voice: realtime consult failed call=${callId}: ${result.error}`);
+    }
+    await this.submitAgentProxyConsultResult(callId, session, result);
   }
 
   async handleAcceptedTranscript(
@@ -414,31 +415,27 @@ export class DiscordRealtimeConsults {
       );
     }
     state.handledByForcedPlayback = true;
-    try {
-      const promise = this.runAgentTurn({ context, message: question });
-      this.setRecentAgentProxyConsultPromise(pending, promise);
-      const text = await promise;
-      await state.providerDelivery;
-      if (state.providerEpoch !== this.params.providerEpoch()) {
-        return;
-      }
+    const result = await this.trackAgentProxyConsult(
+      pending,
+      this.runAgentTurn({ context, message: question }),
+    );
+    const deliveries = this.providerDeliveries.get(state);
+    await Promise.all(Array.from(deliveries ?? [], (delivery) => delivery.promise));
+    if (state.providerEpoch !== this.params.providerEpoch() || "status" in result) {
+      return;
+    }
+    if ("text" in result) {
       logger.info(
-        `discord voice: realtime forced agent consult answer (${text.length} chars) elapsedMs=${Date.now() - startedAt} voiceSession=${this.params.entry.voiceSessionKey} supervisorSession=${this.params.entry.route.sessionKey} agent=${this.params.entry.route.agentId}: ${formatVoiceLogPreview(text)}`,
+        `discord voice: realtime forced agent consult answer (${result.text.length} chars) elapsedMs=${Date.now() - startedAt} voiceSession=${this.params.entry.voiceSessionKey} supervisorSession=${this.params.entry.route.sessionKey} agent=${this.params.entry.route.agentId}: ${formatVoiceLogPreview(result.text)}`,
       );
-      if (text.trim() && state.handledByForcedPlayback) {
-        this.params.playback.enqueueExactSpeechMessage(text);
-      }
-    } catch (error) {
-      await state.providerDelivery;
-      if (state.providerEpoch !== this.params.providerEpoch()) {
-        return;
-      }
+    } else {
       logger.warn(
-        `discord voice: realtime forced agent consult failed elapsedMs=${Date.now() - startedAt}: ${formatErrorMessage(error)}`,
+        `discord voice: realtime forced agent consult failed elapsedMs=${Date.now() - startedAt}: ${result.error}`,
       );
-      if (state.handledByForcedPlayback) {
-        this.params.playback.enqueueExactSpeechMessage(DISCORD_REALTIME_FALLBACK_TEXT);
-      }
+    }
+    const text = "text" in result ? result.text : DISCORD_REALTIME_FALLBACK_TEXT;
+    if (text.trim() && state.handledByForcedPlayback) {
+      this.params.playback.enqueueExactSpeechMessage(text);
     }
   }
 
@@ -460,31 +457,32 @@ export class DiscordRealtimeConsults {
     return handle;
   }
 
-  private setRecentAgentProxyConsultPromise(
-    recent: AgentProxyConsultHandle,
+  private trackAgentProxyConsult(
+    recent: AgentProxyConsultHandle | undefined,
     promise: Promise<string>,
-  ): void {
-    const state = recent.context;
-    if (!state) {
-      return;
+  ): Promise<AgentProxyConsultResult> {
+    const state = recent?.context;
+    if (recent) {
+      this.params.harness.forcedConsults.markStarted(recent);
     }
-    this.params.harness.forcedConsults.markStarted(recent);
-    state.promise = promise;
-    void promise
-      .then((text) => {
-        if (state.providerEpoch !== this.params.providerEpoch()) {
-          return;
+    const tracked = promise
+      .then((text) => ({ text }), buildRealtimeVoiceAgentErrorProviderResult)
+      .then((result) => {
+        if (recent && state && state.providerEpoch === this.params.providerEpoch()) {
+          state.result = result;
+          // Cancellation must reach the coordinator before delivery closes that transition.
+          if ("status" in result) {
+            this.params.harness.forcedConsults.markCancelled(recent);
+          } else {
+            this.params.harness.forcedConsults.markDelivered(recent);
+          }
         }
-        state.result = { status: "fulfilled", text };
-        this.params.harness.forcedConsults.markDelivered(recent);
-      })
-      .catch((error: unknown) => {
-        if (state.providerEpoch !== this.params.providerEpoch()) {
-          return;
-        }
-        state.result = { status: "rejected", error: formatErrorMessage(error) };
-        this.params.harness.forcedConsults.markDelivered(recent);
+        return result;
       });
+    if (state) {
+      state.promise = tracked;
+    }
+    return tracked;
   }
 
   private findRecentAgentProxyConsultContext(
@@ -519,100 +517,80 @@ export class DiscordRealtimeConsults {
     if (state.providerEpoch !== this.params.providerEpoch()) {
       return true;
     }
-    const providerOwnsDelivery = Boolean(
-      state.handledByForcedPlayback &&
-      state.promise &&
-      !state.result &&
-      session.bridge.supportsToolResultSuppression === false,
-    );
-    let resolveProviderDelivery: (() => void) | undefined;
-    if (providerOwnsDelivery) {
-      // Forced playback waits for native acceptance so a failed delivery can restore
-      // the local success/fallback path instead of losing the answer entirely.
-      state.providerDelivery = new Promise<void>((resolve) => {
-        resolveProviderDelivery = resolve;
-        state.settleProviderDelivery = resolve;
-      });
-    }
-    const submitAlreadyDelivered = async (): Promise<void> => {
-      if (state.providerEpoch !== this.params.providerEpoch()) {
-        return;
-      }
-      await this.submitTerminalRealtimeToolResult(callId, session, {
-        status: "already_delivered",
-        message: "OpenClaw already delivered this answer to Discord voice. Do not repeat it.",
-      });
-    };
-    const submitResult = async (result: RecentAgentProxyConsultResult): Promise<void> => {
-      if (state.providerEpoch !== this.params.providerEpoch()) {
-        return;
-      }
-      if (state.handledByForcedPlayback && !providerOwnsDelivery) {
-        await submitAlreadyDelivered();
-        return;
-      }
-      if (result.status === "fulfilled") {
-        await session.submitToolResult(callId, { text: result.text });
-        return;
-      }
-      await session.submitToolResult(callId, { error: result.error });
-    };
-    if (state.result) {
-      logger.info(
-        `discord voice: realtime consult reused recent agent result call=${callId || "unknown"} speaker=${state.speaker.speakerLabel} owner=${state.speaker.senderIsOwner}`,
-      );
-      await submitResult(state.result);
-      return true;
-    }
-    if (!state.promise) {
+    const pendingResult = state.result ?? state.promise;
+    if (!pendingResult) {
       return false;
     }
+    const providerDelivery =
+      state.handledByForcedPlayback &&
+      !state.result &&
+      session.bridge.supportsToolResultSuppression === false
+        ? createDeferred<void>()
+        : undefined;
+    if (providerDelivery) {
+      // Keep every native attempt until settlement: one failed joiner cannot hand
+      // playback back while another may still accept the answer.
+      const deliveries =
+        this.providerDeliveries.get(state) ?? new Set<AgentProxyProviderDelivery>();
+      deliveries.add(providerDelivery);
+      this.providerDeliveries.set(state, deliveries);
+    }
     logger.info(
-      `discord voice: realtime consult joined in-flight agent result call=${callId || "unknown"} speaker=${state.speaker.speakerLabel} owner=${state.speaker.senderIsOwner}`,
+      `discord voice: realtime consult ${state.result ? "reused recent" : "joined in-flight"} agent result call=${callId} speaker=${state.speaker.speakerLabel} owner=${state.speaker.senderIsOwner}`,
     );
-    if (state.handledByForcedPlayback && !providerOwnsDelivery) {
-      await state.promise.catch(() => undefined);
+    try {
+      const result = await pendingResult;
       if (state.providerEpoch !== this.params.providerEpoch()) {
         return true;
       }
-      await submitAlreadyDelivered();
-      return true;
-    }
-    let result: RecentAgentProxyConsultResult;
-    try {
-      result = { status: "fulfilled", text: await state.promise };
-    } catch (error) {
-      result = { status: "rejected", error: formatErrorMessage(error) };
-    }
-    if (state.providerEpoch !== this.params.providerEpoch()) {
-      return true;
-    }
-    try {
-      await submitResult(result);
-      if (providerOwnsDelivery) {
+      await this.submitAgentProxyConsultResult(
+        callId,
+        session,
+        result,
+        Boolean(state.handledByForcedPlayback && !providerDelivery),
+      );
+      if (providerDelivery && state.providerEpoch === this.params.providerEpoch()) {
         state.handledByForcedPlayback = false;
-        state.settleProviderDelivery = undefined;
-        resolveProviderDelivery?.();
       }
-    } catch (error) {
-      state.settleProviderDelivery = undefined;
-      resolveProviderDelivery?.();
-      throw error;
+    } finally {
+      if (providerDelivery) {
+        providerDelivery.resolve();
+        const deliveries = this.providerDeliveries.get(state);
+        deliveries?.delete(providerDelivery);
+        if (deliveries?.size === 0) {
+          this.providerDeliveries.delete(state);
+        }
+      }
     }
     return true;
   }
 
-  private clearProviderConsultState(): void {
-    for (const handle of this.params.harness.forcedConsults.handles()) {
-      const state = handle.context;
-      if (!state) {
-        continue;
-      }
-      state.handledByForcedPlayback = false;
-      state.settleProviderDelivery?.();
-      state.settleProviderDelivery = undefined;
-      state.providerDelivery = undefined;
+  private async submitAgentProxyConsultResult(
+    callId: string,
+    session: RealtimeVoiceBridgeSession,
+    result: AgentProxyConsultResult,
+    alreadyDelivered = false,
+  ): Promise<void> {
+    if ("status" in result) {
+      await this.submitTerminalRealtimeToolResult(callId, session, CANCELLED_CONSULT_RESULT);
+    } else if (alreadyDelivered) {
+      await this.submitTerminalRealtimeToolResult(callId, session, {
+        status: "already_delivered",
+        message: "OpenClaw already delivered this answer to Discord voice. Do not repeat it.",
+      });
+    } else {
+      await session.submitToolResult(callId, result);
     }
+  }
+
+  private clearProviderConsultState(): void {
+    for (const [state, deliveries] of this.providerDeliveries) {
+      state.handledByForcedPlayback = false;
+      for (const delivery of deliveries) {
+        delivery.resolve();
+      }
+    }
+    this.providerDeliveries.clear();
     this.params.harness.forcedConsults.clear();
   }
 }

--- a/scripts/lib/vitest-build-prerequisites.mts
+++ b/scripts/lib/vitest-build-prerequisites.mts
@@ -25,12 +25,14 @@ const runtimeConsumers = [
     mode: "private-qa",
     dir: "extensions",
   },
-  {
-    file: "src/cli/update-dry-run-state.process.test.ts",
-    configs: ["test/vitest/vitest.cli-process.config.ts"],
-    mode: "runtime",
-    dir: "",
-  },
+  ...["src/cli/acp-cli-exit.process.test.ts", "src/cli/update-dry-run-state.process.test.ts"].map(
+    (file) => ({
+      file,
+      configs: ["test/vitest/vitest.cli-process.config.ts"],
+      mode: "runtime" as const,
+      dir: "",
+    }),
+  ),
   ...[
     "src/commands/doctor-config-preflight.process.test.ts",
     "src/commands/doctor-config-preflight.v17-atomicity.process.test.ts",

--- a/src/cli/acp-cli-exit.process.test.ts
+++ b/src/cli/acp-cli-exit.process.test.ts
@@ -125,7 +125,7 @@ describe("ACP CLI process exit", () => {
     try {
       const result = spawnSync(
         process.execPath,
-        ["--import", "tsx", "src/entry.ts", "acp", "--require-existing"],
+        [path.resolve("openclaw.mjs"), "acp", "--require-existing"],
         {
           cwd: path.resolve("."),
           encoding: "utf8",
@@ -204,9 +204,7 @@ describe("ACP CLI process exit", () => {
       child = spawn(
         process.execPath,
         [
-          "--import",
-          "tsx",
-          "src/entry.ts",
+          path.resolve("openclaw.mjs"),
           "acp",
           "--require-existing",
           "--url",

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -753,19 +753,26 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
             includePatterns: ["src/cli/gateway-backed-exit.process.test.ts"],
           }),
         ]);
-        expect(cliProcessJobs.filter((shard) => shard.pretestBuildMode)).toEqual([
-          expect.objectContaining({
-            pretestBuildMode: "runtime",
-            groups: expect.arrayContaining([
+        const runtimeCliJobs = cliProcessJobs.filter((shard) => shard.pretestBuildMode);
+        expect(runtimeCliJobs).toHaveLength(2);
+        expect(runtimeCliJobs).toEqual(
+          expect.arrayContaining(
+            [
+              "src/cli/acp-cli-exit.process.test.ts",
+              "src/cli/update-dry-run-state.process.test.ts",
+            ].map((file) =>
               expect.objectContaining({
                 pretestBuildMode: "runtime",
-                includePatterns: expect.arrayContaining([
-                  "src/cli/update-dry-run-state.process.test.ts",
+                groups: expect.arrayContaining([
+                  expect.objectContaining({
+                    pretestBuildMode: "runtime",
+                    includePatterns: expect.arrayContaining([file]),
+                  }),
                 ]),
               }),
-            ]),
-          }),
-        ]);
+            ),
+          ),
+        );
         for (const shard of cliProcessJobs) {
           // The indivisible gateway file takes 200s. Hosted runtime preparation
           // alone costs 160s; other groups retain the 150s admission budget.

--- a/test/scripts/test-projects-build-admission.test.ts
+++ b/test/scripts/test-projects-build-admission.test.ts
@@ -86,6 +86,8 @@ describe("CLI runtime admission", () => {
         "test/vitest/vitest.cli-process.config.ts",
         "--exclude",
         "src/cli/update-dry-run-state.process.test.ts",
+        "--exclude",
+        "src/cli/acp-cli-exit.process.test.ts",
       ],
     ],
     [
@@ -123,7 +125,9 @@ syncBuiltinESMExports();\n`,
     try {
       await expect(waitForChildClose(child)).resolves.toEqual({ code: 0, signal: null });
     } finally {
-      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+      }
     }
   });
   posixIt.each([
@@ -144,6 +148,18 @@ syncBuiltinESMExports();\n`,
       "CLI process",
       "scripts/run-vitest.mts",
       ["run", "--config", "test/vitest/vitest.cli-process.config.ts"],
+      "runtime",
+    ],
+    [
+      "CLI process selective exclusion",
+      "scripts/run-vitest.mts",
+      [
+        "run",
+        "--config",
+        "test/vitest/vitest.cli-process.config.ts",
+        "--exclude",
+        "src/cli/update-dry-run-state.process.test.ts",
+      ],
       "runtime",
     ],
     [
@@ -268,8 +284,11 @@ syncBuiltinESMExports();\n`,
             try {
               buildPid = await waitForPidFile(pidFile, 5_000);
               expect(fs.existsSync(readersFile), `outcome=${outcome}`).toBe(false);
-              if (outcome === "SIGTERM") child.kill("SIGTERM");
-              else child.stdin.end("finish\n");
+              if (outcome === "SIGTERM") {
+                child.kill("SIGTERM");
+              } else {
+                child.stdin.end("finish\n");
+              }
               expect(await closed, `outcome=${outcome}\n${output}`).toEqual({
                 code: outcome === "SIGTERM" ? 143 : outcome,
                 signal: null,
@@ -283,7 +302,9 @@ syncBuiltinESMExports();\n`,
               ).toHaveLength(1);
               await waitForDead(buildPid, 5_000);
             } finally {
-              if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+              if (child.exitCode === null && child.signalCode === null) {
+                child.kill("SIGKILL");
+              }
               if (!buildPid && fs.existsSync(pidFile)) {
                 buildPid = await waitForPidFile(pidFile, 5_000);
               }
@@ -297,7 +318,9 @@ syncBuiltinESMExports();\n`,
               try {
                 await withTestTimeout(stopped.promise, 5_000, `outcome=${outcome}: CLI cleanup`);
               } finally {
-                if (buildPid) await waitForDead(buildPid, 5_000);
+                if (buildPid) {
+                  await waitForDead(buildPid, 5_000);
+                }
               }
             }
           } finally {
@@ -318,7 +341,9 @@ syncBuiltinESMExports();\n`,
 async function start(args: string[]) {
   process.argv = [process.execPath, "scripts/test-projects.mts", ...args];
   // Replay the command entry while retaining its immutable planner dependencies.
-  await import(`${testProjectsUrl}?case=${startCount++}`);
+  const entryUrl = `${testProjectsUrl}?case=${startCount}`;
+  startCount += 1;
+  await import(entryUrl);
 }
 
 describe("test-projects build admission", () => {
@@ -468,16 +493,23 @@ describe("test-projects build admission", () => {
   it.each(["build", "failed build", "prebuilt"])(
     "admits the built native-host integration after %s",
     async (mode) => {
-      if (mode === "prebuilt") vi.stubEnv("OPENCLAW_E2E_USE_PREBUILT_DIST", "1");
+      if (mode === "prebuilt") {
+        vi.stubEnv("OPENCLAW_E2E_USE_PREBUILT_DIST", "1");
+      }
       const preparation = createDeferred<NodeJS.ProcessEnv>();
       commands.prepareE2e.mockReturnValue(preparation.promise);
-      if (mode === "prebuilt") preparation.resolve({});
+      if (mode === "prebuilt") {
+        preparation.resolve({});
+      }
       await start([nativeHostTarget]);
       if (mode !== "prebuilt") {
         expect(commands.reader).not.toHaveBeenCalled();
         expect(commands.prepareE2e).toHaveBeenCalledOnce();
-        if (mode === "failed build") preparation.reject(new Error("build failed"));
-        else preparation.resolve({ OPENCLAW_E2E_USE_PREBUILT_DIST: "1" });
+        if (mode === "failed build") {
+          preparation.reject(new Error("build failed"));
+        } else {
+          preparation.resolve({ OPENCLAW_E2E_USE_PREBUILT_DIST: "1" });
+        }
       }
       await terminal.promise;
       expect(commands.prepare).not.toHaveBeenCalled();
@@ -499,7 +531,9 @@ describe("test-projects build admission", () => {
   it.each(["", "OPENCLAW_E2E_SKIP_BUILD", "OPENCLAW_E2E_USE_PREBUILT_DIST"])(
     "prepares an ordinary runtime reader independently of E2E flag %s",
     async (key) => {
-      if (key) vi.stubEnv(key, "1");
+      if (key) {
+        vi.stubEnv(key, "1");
+      }
       commands.prepare.mockResolvedValue(0);
       await start(["test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts"]);
       await terminal.promise;
@@ -580,7 +614,9 @@ describe("plugin batch build admission", () => {
         runGroup: reader,
       });
       try {
-        await new Promise<void>((resolve) => setImmediate(resolve));
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
         expect(reader).not.toHaveBeenCalled();
         expect(commands.prepare).toHaveBeenCalledExactlyOnceWith(
           expect.objectContaining({
@@ -608,7 +644,9 @@ describe("plugin batch build admission", () => {
     const { resolveExtensionBatchPlan } = await import("../../scripts/lib/extension-test-plan.mts");
     const { runExtensionBatchPlan } = await import("../../scripts/test-extension-batch.mts");
     commands.prepare.mockImplementation(async () => {
-      if (outcome === "throw") throw new Error("build spawn failed");
+      if (outcome === "throw") {
+        throw new Error("build spawn failed");
+      }
       return outcome;
     });
     const reader = vi.fn().mockResolvedValue(0);
@@ -619,8 +657,11 @@ describe("plugin batch build admission", () => {
         env: { OPENCLAW_EXTENSION_BATCH_PARALLEL: "2" },
       },
     );
-    if (outcome === "throw") await expect(running).rejects.toThrow("build spawn failed");
-    else await expect(running).resolves.toBe(outcome);
+    if (outcome === "throw") {
+      await expect(running).rejects.toThrow("build spawn failed");
+    } else {
+      await expect(running).resolves.toBe(outcome);
+    }
     expect(reader).not.toHaveBeenCalled();
     expect(commands.prepare).toHaveBeenCalledOnce();
   });

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -61,6 +61,7 @@ describe("test runtime prerequisites", () => {
       ["test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts"],
       "runtime",
     ],
+    ["ACP CLI process", ["src/cli/acp-cli-exit.process.test.ts"], "runtime"],
     ["update CLI process", ["src/cli/update-dry-run-state.process.test.ts"], "runtime"],
     ["CLI directory", ["src/cli"], "runtime"],
     ["CLI config", ["test/vitest/vitest.cli.config.ts"], undefined],


### PR DESCRIPTION
Closes #135340

Related: #134924 (phone cancellation repair and the already-landed shared helper).

## What Problem This Solves

Fixes an issue where Discord realtime voice users hear a generic failure after OpenClaw cancels a delegated consult while the voice provider remains connected. Joined and late matching provider tool calls can also report an error or `already_delivered` instead of terminal cancellation.

## Why This Change Was Made

Discord now records one normalized host result, marks cancellation before completing the coordinator lifecycle, and uses that result for native, forced, joined, and cached consult delivery. Each outstanding native delivery owns its own settlement: one rejected attempt cannot return forced playback ownership while another attempt can still accept the answer.

The repair belongs to Discord's consult/delivery owner. It reuses the shared error projection already landed by #134924 without changing core, the SDK, or the phone/native Talk flows. It removes separate rejected-result reconstruction and the single overwritten delivery promise. No configuration, dependency, storage, schema, or protocol changes. Production +129/-151 (net -22); tests +380/-36 (net +344); docs +2.

## User Impact

Cancelled consults do not trigger Discord's generic error fallback or restart through matching late calls. The voice session stays available for the next request. Real failures and timeouts retain error handling, and successful native delivery still owns speech without duplicate forced playback. Speaker authority, provider-epoch fencing, and bounded recent-result dedupe remain intact.

## Evidence

- Before the repair, six independent host-cancellation cases and two multi-native-delivery ordering cases failed in the joined-voice fixture. The implicated Discord owner is unchanged between reproduction base `2881127d3623ac1db43c91db12b5c5fbaf28fdb2` and reconciliation base `1e93009a9659ea88ca410c13ad11842afbd8770b`.
- On candidate `4d003c7a43d29345216df22a9550a60c745a289f`, `node scripts/run-vitest.mjs extensions/discord/src/voice/realtime-consults.test.ts extensions/discord/src/voice/realtime-consults.host-cancellation.test.ts` passes all 35 cases. Coverage includes native/forced/joined/late cancellation, both suppression capabilities, rejected native delivery, success/error delivery ordering, reset/teardown, a subsequent guest request, and Error/TimeoutError controls.
- The four Discord blobs remain byte-identical to the previously reviewed candidate; the fresh full-candidate review is recorded below.
- Reconciled sibling proof passes 111 tests across 10 files, covering coordinator/control/talkback, Discord speaker turns, playback, ingress, and terminal-session cleanup (146 tests across 12 files including the consult fixtures). Both extension type lanes, formatting, doctor-contract tests, plugin/dependency boundaries, and code guards passed. The changed-file aggregate stopped before lint on unrelated protocol declaration error TS7056. After #135360 merged, this branch was rebased onto `91067e340a1811f94a3f119fae329542c3f23872`: all four changed files and the stable patch ID are unchanged. The normal extension lint wrapper, 35 consult cases, both extension type lanes, and formatting then passed on the new head. The four remaining storage/media/sidecar/import-cycle guards also passed separately. This is compositional evidence, not a claim that the original aggregate exited successfully. The original nine-file candidate had 197 focused/sibling tests and a full runtime/SDK/Control UI build pass; that build is historical evidence, not a build of this reconciled head.

**Proof limitation:** the operator explicitly prohibited live Discord/phone calls, credential retrieval, production-state copies, and service restarts. This is deterministic joined-voice boundary-fixture evidence with injected host/provider outcomes, not a live Discord call or a full ephemeral-Gateway harness. No screenshots or recordings of a live call were taken. Source inspection also confirms the old unconditional failure projection in stable tag `v2026.8.2`; no live stable-package call was made. Production frequency and the introducing commit are not established.

## Bounded ACP landing-gate repair

The original hosted CI attempt hit a 30-second ACP CLI child timeout; an unchanged-head retry passed, but a later local source run still failed both cases after dependency installation (child ETIMEDOUT and initialize-response timeout). That local run took 283.30s overall, including 177.83s of Vitest imports. These failures are retained, not waived.

An isolated source diagnostic sent initialize plus EOF immediately and observed ACP server module evaluation at 22.995s, followed by clean exit at 23.266s. This supports substantial source-loading/transform cost inside the lifecycle deadline; it is not a pure CPU benchmark or proof excluding every lifecycle defect. The maintainer reviewed the entrypoint and preparation contracts and approved this bounded test-harness repair.

Both existing cases now launch the actual `openclaw.mjs` CLI. The canonical runtime-consumer registry prepares a fresh source-matching runtime before Vitest workers, as it already does for update dry-run coverage. No custom builder, ACP production change, dependency change, timeout increase, assertion weakening, import warmup, or resource override. Both 30-second deadlines, the Vitest deadline, exit/stderr/protocol assertions, initialize-before-hello and initialize-plus-EOF-before-startup orderings, environment isolation, and cleanup are unchanged.

Observed proof:

- The added ACP prerequisite-selection case failed against the old registry: expected `runtime`, received `undefined` (5.87s wrapper). After repair, 35 selected prerequisite/routing cases passed (11.11s wrapper).
- `node scripts/run-vitest.mjs src/cli/acp-cli-exit.process.test.ts`: 2/2 pass. Early initialize+EOF: 3.306s; buffered initialize before hello: 2.189s. Test time 5.53s; Vitest 23.65s; wrapper including normal fresh build and preparation 80.97s. These are observations, not cross-host performance guarantees.
- Nine selected runner/admission/CI-plan cases passed, including failed-build and cancellation cleanup (19.69s wrapper).
- `node scripts/check-changed.mjs -- src/cli/acp-cli-exit.process.test.ts scripts/lib/vitest-build-prerequisites.mts test/scripts/test-projects.test.ts`: exit 0; formatting, core-test/scripts/root-test types, all planned guards and targeted lint passed.
- Fresh isolated Codex review of the complete nine-file candidate: scoped-clean at P0, no findings, confidence 0.95.

### Admission-suite follow-up

The first ACP registry change missed a connected negative admission case: excluding only update dry-run still left ACP selected, so a build was correctly requested and the old no-build expectation exited 91 instead of 0. The existing case failed before repair (24 other CLI-admission cases passed; wrapper 7.56s). It now excludes both runtime consumers. A new row in the existing preparation table proves that excluding only update dry-run still requires preparation for ACP, covering successful build, failure and SIGTERM without new helpers or weaker assertions.

Targeted lint also exposed 15 existing diagnostics in the touched admission file. The approved cleanup adds braces and uses a block Promise executor without returning the setImmediate handle. The startCount unused-variable diagnostic was a false positive: its value supplies a fresh ESM query identity on each CLI replay. URL construction, counter increment and import are now separate, preserving case 0,1,2 progression, increment-before-import ordering, and retained planner dependencies. No cache-busting removal, suppression or dependency change.

Final proof: node scripts/run-vitest.mjs test/scripts/test-projects-build-admission.test.ts passed all 77 tests (8.79s tests, 11.59s Vitest, 14.14s wrapper). Matching root-test tsgo, targeted oxlint, formatting and git diff --check passed. The earlier 77-case pass before lint cleanup (10.45s) and the failing lint run remain history. Earlier ACP runtime proof remains valid and was not rebuilt for this test-only follow-up. The original four Discord blobs and the prior three-file ACP patch are unchanged.

### Compact-plan expectation follow-up

The previous CI run also exposed an outdated single-runtime-job expectation in test/scripts/ci-node-test-plan.test.ts. Registering ACP correctly creates a second prepared-runtime job. The existing case failed locally before repair (15.07s wrapper). Its assertion now requires exactly two jobs and explicit ACP/update-dry-run membership at both job and group preparation levels, without depending on ordering. Runner assignments, workload/time budgets, job-count limits, concurrency and planner code are unchanged.

All 47 tests in the owning compact-plan file passed (40.70s tests, 44.28s Vitest, 48.95s wrapper), including Blacksmith, GitHub-hosted and hybrid profiles. Matching root-test types, targeted lint, formatting and diff checks passed. Fresh isolated review of the full nine-file candidate is scoped-clean at P0 with no findings, confidence 0.95.

ACP repair totals across five files: tooling +8/-6 (net +2), tests +75/-28 (net +47), total +49. Discord remains production -22, tests +344, docs +2. Entire PR: nine files, net +373. No changelog edit.

## Verified merged result

[PR #135380](https://github.com/openclaw/openclaw/pull/135380) merged via the native immediate squash route at 2026-09-01 19:27:42 UTC as [bfe2884ceab69db1442044307f6ae81d65eb7221](https://github.com/openclaw/openclaw/commit/bfe2884ceab69db1442044307f6ae81d65eb7221). The exact approved source head was `b8522bdbaa1838e344f8414def13665b3e3cb631`. [Issue #135340](https://github.com/openclaw/openclaw/issues/135340) auto-closed at 19:27:43 UTC.

Fresh native/server gates passed immediately before dispatch: exact-head hosted CI, required `openclaw/ci-gate`, current ClawSweeper review, pinned head and mergeability admission. [CI run 33545751321, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33545751321) succeeded with 128 successful jobs and 16 skipped. One ancillary ClawSweeper Dispatch was cancelled; it was not a required gate. Fresh isolated full-candidate Codex review was scoped-clean at P0, no findings, confidence 0.95. ClawSweeper's wait-for-CI Rank-up move was satisfied.

`OPENCLAW_TESTBOX=1 scripts/pr prepare-run 135380` and `OPENCLAW_TESTBOX=1 scripts/pr merge-run 135380` both completed successfully. The [native provenance comment](https://github.com/openclaw/openclaw/pull/135380#issuecomment-5499253471) records prepared and landed SHAs. No admin bypass, auto-merge, queue request, rebase or candidate change was used. Native receipt and cleanup completed.

The landed tree was independently reconstructed from the actual landing parent `aaa7dd39e6430e28eadb62c603ca28b831bf7848` and the approved head, and matched exactly. All eight non-documentation blobs match the approved candidate. Discord documentation retains intervening main edits plus the intended two-line cancellation addition. The landed delta remains nine files, +594/-221: runtime -22, tests +391, tooling +2, docs +2. The squash message preserves `Closes #135340`, user behavior and the related phone helper.

Historical failures remain recorded: the original ACP source-startup timeouts, the two connected obsolete sibling expectations in [CI run 33543661288](https://github.com/openclaw/openclaw/actions/runs/33543661288), and the first native preparation attempt's transient publication-policy fetch/validation error. Documented stale-lock recovery followed by one normal preparation retry succeeded; no gate or policy was bypassed. Merge itself succeeded on its first invocation.

The operator's no-live restriction remains: proof is synthetic joined-voice boundary/process fixtures, not a live Discord/phone/provider call or full ephemeral-Gateway demonstration. No release or package publication was performed.
