### PR TITLE
fix: apply Discord model picker choices without false failures

### DIFF
--- a/extensions/discord/src/monitor/native-command-agent-reply.ts
+++ b/extensions/discord/src/monitor/native-command-agent-reply.ts
@@ -79,7 +79,7 @@ export async function dispatchDiscordNativeAgentReply(params: {
         if (params.suppressReplies) {
           return {
             visibleReplySent: false,
-            suppression: { reason: "no_visible_result" as const },
+            suppression: { reason: "channel_transform" as const },
           };
         }
         const payloadDelivered = await deliverDiscordInteractionReply({
@@ -111,7 +111,7 @@ export async function dispatchDiscordNativeAgentReply(params: {
         if (
           params.suppressReplies &&
           info.kind === "final" &&
-          result?.suppression?.reason === "no_visible_result" &&
+          result?.suppression?.reason === "channel_transform" &&
           payload.text?.trim()
         ) {
           hiddenFinalReply = payload;

--- a/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
+++ b/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
@@ -1268,12 +1268,12 @@ describe("Discord native plugin command dispatch", () => {
     expect(interaction.deleteReply).toHaveBeenCalledTimes(1);
   });
 
-  it("preserves a hidden error final and its metadata without sending it to Discord", async () => {
+  it.each([false, true])("preserves a hidden final and metadata (isError=%s)", async (isError) => {
     const cfg = createConfig();
     const interaction = createInteraction();
     interaction.responseState = "deferred";
     const finalReply = setReplyPayloadMetadata(
-      { text: "scope-aware model selection result", isError: true },
+      { text: "scope-aware model selection result", isError },
       { assistantMessageIndex: 3 },
     );
     nativeCommandRuntime.dispatchChannelInboundTurn = async (plan) => {
@@ -1282,6 +1282,10 @@ describe("Discord native plugin command dispatch", () => {
       }
       const info = { kind: "final" as const };
       const deliveryResult = await plan.delivery.deliver(finalReply, info);
+      expect(deliveryResult).toEqual({
+        visibleReplySent: false,
+        suppression: { reason: "channel_transform" },
+      });
       await plan.delivery.onDelivered?.(finalReply, info, deliveryResult);
       return {
         admission: { kind: "dispatch" },
@@ -1315,7 +1319,7 @@ describe("Discord native plugin command dispatch", () => {
     });
 
     expect(result.hiddenFinalReply).toBe(finalReply);
-    expect(result.hiddenFinalReply?.isError).toBe(true);
+    expect(result.hiddenFinalReply?.isError).toBe(isError);
     expect(interaction.followUp).not.toHaveBeenCalled();
     expect(interaction.reply).not.toHaveBeenCalled();
     expect(interaction.deleteReply).toHaveBeenCalledTimes(1);
@@ -1330,6 +1334,11 @@ describe("Discord native plugin command dispatch", () => {
     {
       label: "empty final",
       payload: { text: "  " },
+      suppression: { reason: "channel_transform" as const },
+    },
+    {
+      label: "ordinary invisible result",
+      payload: { text: "uncaptured fallback" },
       suppression: { reason: "no_visible_result" as const },
     },
   ])("does not capture a hidden final for $label", async ({ payload, suppression }) => {

--- a/src/agents/prepared-model-catalog.scoped-thinking.test.ts
+++ b/src/agents/prepared-model-catalog.scoped-thinking.test.ts
@@ -1,5 +1,6 @@
 // Turn-path thinking reuses published facts before manifest/scoped discovery fallback.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
 
 const manifestCatalogMock = vi.fn((..._args: unknown[]): Array<Record<string, unknown>> => []);
 const scopedStaticMock = vi.fn(
@@ -93,6 +94,38 @@ describe("loadProviderScopedThinkingCatalog", () => {
     expect(scopedStaticMock).not.toHaveBeenCalled();
     expect(scopedLiveMock).not.toHaveBeenCalled();
   });
+
+  it.each(["thinking", "input"] as const)(
+    "reuses completed owner catalogs for runtime-only %s capabilities",
+    async (capability) => {
+      const entry: ModelCatalogEntry = {
+        ...ollamaEntry,
+        api: "ollama",
+        baseUrl: "https://ollama.invalid",
+        input: ["text", "image"],
+      };
+      const completed: ModelCatalogSnapshot = { entries: [entry], routeVariants: [entry] };
+      publishedSnapshotMock.mockImplementation((input: unknown) => ({
+        config: (input as { config: unknown }).config,
+        modelCatalog: { entries: [], routeVariants: [] },
+        readFullModelCatalog: () => completed,
+      }));
+      const { loadProviderScopedThinkingCatalog } = await import("./prepared-model-catalog.js");
+      const catalog = await loadProviderScopedThinkingCatalog({
+        config: {},
+        provider: entry.provider,
+        model: entry.id,
+        ...(capability === "input"
+          ? { requiredInputRoute: { api: entry.api, baseUrl: entry.baseUrl } }
+          : {}),
+      });
+
+      expect(catalog).toEqual([expect.objectContaining(entry)]);
+      expect(manifestCatalogMock).not.toHaveBeenCalled();
+      expect(scopedStaticMock).not.toHaveBeenCalled();
+      expect(scopedLiveMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("resolves manifest-backed models without any scoped catalog build", async () => {
     manifestCatalogMock.mockReturnValue([

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -396,7 +396,7 @@ export async function loadProviderScopedThinkingCatalog(params: {
     const entries = normalizeThinkingCatalogProviders(augmented.entries);
     return params.requiredInputRoute !== undefined && !entryResolved(entries) ? [] : entries;
   };
-  const publishedCatalog = getPreparedModelCatalogSnapshot(scopedParams);
+  const publishedCatalog = getAvailablePreparedModelCatalogSnapshot(scopedParams);
   if (publishedCatalog && entryResolved(publishedCatalog.entries)) {
     return await augmentHarnessCatalog(publishedCatalog);
   }

--- a/src/auto-reply/reply/dispatch-from-config.delivery-and-tts.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.delivery-and-tts.test-utils.ts
@@ -93,6 +93,74 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
+  it.each([
+    { name: "channel-owned final", outcomes: ["channel_transform"], fallback: false },
+    { name: "ordinary invisible final", outcomes: ["no_visible_result"], fallback: true },
+    {
+      name: "later invisible final",
+      outcomes: ["channel_transform", "no_visible_result"],
+      fallback: true,
+    },
+    {
+      name: "later cancelled final",
+      outcomes: ["channel_transform", "cancelled"],
+      fallback: true,
+    },
+    {
+      name: "later pre-send failure",
+      outcomes: ["channel_transform", "failed"],
+      fallback: true,
+    },
+  ])("preserves post-hook suppression without masking $name", async ({ outcomes, fallback }) => {
+    setNoAbort();
+    const delivered: ReplyPayload[] = [];
+    const dispatcher = createReplyDispatcher({
+      beforeDeliver: (payload) => {
+        if (payload.text === "cancelled") {
+          return null;
+        }
+        if (payload.text === "failed") {
+          throw new Error("pre-send failure");
+        }
+        return { ...payload, text: `checked:${payload.text}` };
+      },
+      deliver: async (payload) => {
+        delivered.push(payload);
+        return {
+          visibleReplySent: false,
+          suppression: {
+            reason:
+              payload.text === "checked:channel_transform"
+                ? "channel_transform"
+                : "no_visible_result",
+          },
+        };
+      },
+    });
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "discord",
+        Surface: "discord",
+        SessionKey: "agent:main:discord:direct:owner",
+        CommandSource: "native",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: vi.fn(async () => outcomes.map((text) => ({ text }))),
+    });
+    dispatcher.markComplete();
+    const receipt = await dispatcher.waitForIdle();
+
+    expect(
+      delivered.filter((payload) => payload.text === "checked:channel_transform"),
+    ).toHaveLength(outcomes.includes("channel_transform") ? 1 : 0);
+    expect(delivered.some((payload) => payload.text?.includes("No reply was generated"))).toBe(
+      fallback,
+    );
+    expect(result.noVisibleReplyFallbackEligible === true).toBe(fallback);
+    expect(receipt?.anyVisibleDelivered).toBe(false);
+  });
+
   it("does not dispatch a settled final reply after its session writer is replaced", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.final-outcome-counts.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.final-outcome-counts.test.ts
@@ -1,9 +1,41 @@
 // Tests settled dispatcher outcome accounting for dispatch-from-config runs.
 import { describe, expect, it } from "vitest";
 import { PlatformMessageNotDispatchedError } from "../../infra/outbound/deliver-types.js";
-import { createReplyDispatcher } from "./reply-dispatcher.js";
+import {
+  attachReplyDispatchUndeliveredFallback,
+  captureReplyDispatchDeliveryOutcome,
+  createReplyDispatcher,
+} from "./reply-dispatcher.js";
 
 describe("settled dispatcher final outcomes", () => {
+  it.each(["channel_transform", "no_visible_result"])(
+    "keeps %s distinct when a payload has an undelivered alternative",
+    async (reason) => {
+      const delivered: string[] = [];
+      const payload = { text: "primary" };
+      const outcome = captureReplyDispatchDeliveryOutcome(payload);
+      attachReplyDispatchUndeliveredFallback(payload, { text: "alternative" });
+      const dispatcher = createReplyDispatcher({
+        deliver: async (reply) => {
+          delivered.push(reply.text ?? "");
+          return reply.text === "primary"
+            ? { visibleReplySent: false, suppression: { reason } }
+            : { visibleReplySent: true };
+        },
+      });
+
+      dispatcher.sendFinalReply(payload);
+      dispatcher.markComplete();
+      const receipt = await dispatcher.waitForIdle();
+
+      const suppressed = reason === "channel_transform";
+      expect(delivered).toEqual(suppressed ? ["primary"] : ["primary", "alternative"]);
+      await expect(outcome.promise).resolves.toBe(suppressed ? "channel-transform" : "delivered");
+      expect(receipt?.anyVisibleDelivered).toBe(!suppressed);
+      expect(receipt?.counts.final.deliveredNotVisible).toBe(suppressed ? 1 : 0);
+    },
+  );
+
   it("rethrows an opted-in proven no-send failure when nothing was visible", async () => {
     const error = new PlatformMessageNotDispatchedError("offline before dispatch", {
       cause: new Error("offline"),

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -91,8 +91,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   let acceptedFinal = false;
   let sessionWriterDeliveryRevoked = false;
   let channelTransformSuppressedFinal = false;
-  const finalDeliveries: Promise<ReplyDispatchDeliveryOutcome>[] = [];
-  let allQueuedFinalsObserved = true;
+  const finalDeliveries: Array<Promise<ReplyDispatchDeliveryOutcome> | undefined> = [];
   const sentFinalPayloadDedupeKeys = new Set<string>();
   let deferredTtsTextPending = state.progressState.accumulatedBlockTtsText;
   for (const [replyIndex, reply] of replies.entries()) {
@@ -196,11 +195,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       queuedFinal = finalReply.queuedFinal || queuedFinal;
       routedFinalCount += finalReply.routedFinalCount;
       if (finalReply.queuedFinal) {
-        if (finalReply.dispatcherOutcome) {
-          finalDeliveries.push(finalReply.dispatcherOutcome);
-        } else {
-          allQueuedFinalsObserved = false;
-        }
+        finalDeliveries.push(finalReply.dispatcherOutcome);
       }
       if (continuationSettlement) {
         if (finalReply.queuedFinal) {
@@ -222,13 +217,13 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       throw error;
     }
   }
-  const channelTransformSuppressed =
+  let channelTransformSuppressed =
     (state.progressState.channelTransformSuppressed || channelTransformSuppressedFinal) &&
     !state.progressState.acceptedReplyPayload &&
     !acceptedFinal;
 
   if (attemptedFinalDelivery) {
-    if (queuedFinal && allQueuedFinalsObserved) {
+    if (queuedFinal && finalDeliveries.every((outcome) => outcome !== undefined)) {
       // Delivery observers run from the queue itself, so direct low-level callers
       // reconcile too; the settle task only makes lifecycle owners await it.
       const reconcilePendingFinal = Promise.all(finalDeliveries)
@@ -361,6 +356,12 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     queuedSettleResult = await turnLedger.settleQueued(getDispatchAbortSignal());
   }
   if (queuedSettleResult === "settled") {
+    // Adapter-owned presentation may capture a final after sending hooks. Keep that
+    // intentional suppression distinct from invisible, cancelled, or failed delivery.
+    channelTransformSuppressed ||=
+      noVisibleReplyFallbackAllowed() &&
+      finalDeliveries.length > 0 &&
+      (await Promise.all(finalDeliveries)).every((outcome) => outcome === "channel-transform");
     sessionWriterDeliveryRevoked ||= replies.some(
       (reply) => !state.isSessionWriterDeliveryAuthorized(reply),
     );

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -361,6 +361,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     channelTransformSuppressed ||=
       noVisibleReplyFallbackAllowed() &&
       finalDeliveries.length > 0 &&
+      finalDeliveries.every((outcome) => outcome !== undefined) &&
       (await Promise.all(finalDeliveries)).every((outcome) => outcome === "channel-transform");
     sessionWriterDeliveryRevoked ||= replies.some(
       (reply) => !state.isSessionWriterDeliveryAuthorized(reply),

--- a/src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts
@@ -33,6 +33,7 @@ describe("requireQueuedReplyDelivery", () => {
   it.each([
     ["delivered", true],
     ["delivered-not-visible", false],
+    ["channel-transform", false],
     ["cancelled", false],
     ["failed-before-deliver", false],
     ["failed-deliver", false],

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
@@ -114,7 +114,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
     body: string,
     config?: OpenClawConfig,
     response: { shouldContinue: boolean; reply?: { text: string } } = { shouldContinue: true },
-    preparedModelCatalog?: ModelCatalogSnapshot,
+    preparedCatalog?: ModelCatalogSnapshot,
   ) {
     handleCommandsMock.mockResolvedValue(response);
     const commandName = body.slice(1).split(/\s+/, 1)[0] ?? "";
@@ -152,7 +152,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
       agentCfg: config?.agents?.defaults,
       commandAuthorized: true,
       typing,
-      preparedModelCatalog,
+      preparedModelCatalog: preparedCatalog,
     });
 
     return { result, typing, storePath: resolvedConfig.session?.store };

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
+import type { ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
 import * as preparedModelCatalog from "../../agents/prepared-model-catalog.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
@@ -113,6 +114,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
     body: string,
     config?: OpenClawConfig,
     response: { shouldContinue: boolean; reply?: { text: string } } = { shouldContinue: true },
+    preparedModelCatalog?: ModelCatalogSnapshot,
   ) {
     handleCommandsMock.mockResolvedValue(response);
     const commandName = body.slice(1).split(/\s+/, 1)[0] ?? "";
@@ -150,6 +152,7 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
       agentCfg: config?.agents?.defaults,
       commandAuthorized: true,
       typing,
+      preparedModelCatalog,
     });
 
     return { result, typing, storePath: resolvedConfig.session?.store };
@@ -260,6 +263,42 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
       expect(sessionEntry).toMatchObject({ agentRuntimeOverride: "codex" });
     },
   );
+
+  it("applies native model selections using the admitted catalog without rediscovery", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "0");
+    const storePath = path.join(tempDirs.make("openclaw-native-prepared-model-"), "sessions.json");
+    vi.mocked(preparedModelCatalog.loadPreparedModelCatalogSnapshot).mockRejectedValue(
+      new Error("native selection must not rediscover the prepared catalog"),
+    );
+    const { result } = await resolveNativeDirectiveCommand(
+      "/model ollama/picker-secondary -s",
+      { session: { store: storePath } },
+      { shouldContinue: true },
+      {
+        entries: [
+          {
+            provider: "ollama",
+            id: "picker-secondary",
+            name: "Picker secondary",
+            api: "ollama",
+            baseUrl: "http://127.0.0.1:11434",
+            reasoning: false,
+            contextWindow: 32768,
+          },
+        ],
+        routeVariants: [],
+      },
+    );
+
+    expect(result).toMatchObject({
+      handled: true,
+      reply: { text: expect.stringContaining("ollama/picker-secondary") },
+    });
+    expect(
+      loadExactSessionEntry({ sessionKey: "agent:main:telegram:123", storePath })?.entry,
+    ).toMatchObject({ providerOverride: "ollama", modelOverride: "picker-secondary" });
+    expect(preparedModelCatalog.loadPreparedModelCatalogSnapshot).not.toHaveBeenCalled();
+  });
 
   it("marks native /compact terminal replies for delivery under message_tool_only (#90185)", async () => {
     const reply = {

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -1,6 +1,7 @@
 // Handles native slash commands before full get-reply pipeline execution.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { QueueMode } from "../../../packages/gateway-protocol/src/schema/logs-chat.js";
+import type { ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
 import {
   resolveModelRefFromString,
   resolveThinkingDefaultWithRuntimeCatalogCore,
@@ -53,18 +54,6 @@ const skillCommandsRuntimeLoader = createLazyImportLoader<SkillCommandsRuntime>(
   () => import("../../skills/discovery/chat-commands.runtime.js"),
 );
 const statusCommandRuntimeLoader = createLazyImportLoader(() => import("./commands-status.js"));
-
-function loadCommandsRuntime() {
-  return commandsRuntimeLoader.load();
-}
-
-function loadSkillCommandsRuntime() {
-  return skillCommandsRuntimeLoader.load();
-}
-
-function loadStatusCommandRuntime() {
-  return statusCommandRuntimeLoader.load();
-}
 
 function resolveNativeSlashCommandName(ctx: MsgContext): string | undefined {
   const commandTurn = resolveCommandTurnContext(ctx);
@@ -141,6 +130,7 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
   model: string;
   workspaceDir: string;
   typing: ReturnType<typeof createTypingController>;
+  preparedModelCatalog?: ModelCatalogSnapshot;
   opts?: GetReplyOptions;
   skillFilter?: string[];
 }): Promise<
@@ -300,7 +290,7 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
       workspaceDir: params.workspaceDir,
       readOnly: true,
     });
-    const { buildStatusReply } = await loadStatusCommandRuntime();
+    const { buildStatusReply } = await statusCommandRuntimeLoader.load();
     return {
       handled: true,
       reply: markCommandReplyForDelivery(
@@ -332,14 +322,16 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
 
   let loadedSkillCommands: SkillCommandSpec[] | undefined;
   const loadNativeSkillCommands = async () => {
-    loadedSkillCommands ??= (await loadSkillCommandsRuntime()).listSkillCommandsForWorkspace({
-      workspaceDir: params.workspaceDir,
-      cfg: params.cfg,
-      agentId: params.agentId,
-      skillFilter: params.skillFilter,
-      sessionEntry: sessionState.sessionEntry,
-      sessionKey: sessionState.sessionKey,
-    });
+    loadedSkillCommands ??= (await skillCommandsRuntimeLoader.load()).listSkillCommandsForWorkspace(
+      {
+        workspaceDir: params.workspaceDir,
+        cfg: params.cfg,
+        agentId: params.agentId,
+        skillFilter: params.skillFilter,
+        sessionEntry: sessionState.sessionEntry,
+        sessionKey: sessionState.sessionKey,
+      },
+    );
     return loadedSkillCommands;
   };
 
@@ -351,7 +343,7 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
   const commandResult = compactNeedsModelSelection
     ? { shouldContinue: true, reply: undefined }
     : await (
-        await loadCommandsRuntime()
+        await commandsRuntimeLoader.load()
       ).handleCommands({
         ctx: sessionState.sessionCtx,
         rootCtx: params.ctx,
@@ -431,6 +423,8 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
     provider: params.provider,
     model: params.model,
     hasResolvedHeartbeatModelOverride: false,
+    // Native selections reuse the admitted catalog just like ordinary turns.
+    preparedModelCatalog: params.preparedModelCatalog,
     typing: params.typing,
     opts: params.opts,
     skillFilter: params.skillFilter,

--- a/src/auto-reply/reply/get-reply.config-override.test.ts
+++ b/src/auto-reply/reply/get-reply.config-override.test.ts
@@ -30,6 +30,9 @@ vi.mock("../../sessions/session-diff.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../sessions/session-diff.js")>()),
   captureSessionDiffBaseline: mocks.captureSessionDiffBaseline,
 }));
+vi.mock("./commands.runtime.js", () => ({
+  handleCommands: vi.fn(async () => ({ shouldContinue: true })),
+}));
 registerGetReplyRuntimeOverrides(mocks);
 
 let getReplyFromConfig: typeof import("../../plugin-sdk/reply-runtime.js").getReplyFromConfig;
@@ -252,25 +255,44 @@ describe("getReplyFromConfig configOverride", () => {
     );
   });
 
-  it("uses one request-scoped prepared runtime through the raw Plugin SDK resolver", async () => {
-    const preparedRuntime = createPreparedDispatchRuntime();
-    vi.mocked(loadConfigMock).mockImplementation(() => {
-      throw new Error("getRuntimeConfig should not be called for a prepared Gateway dispatch");
-    });
+  it.each([false, true])(
+    "uses the admitted catalog through the SDK resolver (native=%s)",
+    async (native) => {
+      const preparedRuntime = createPreparedDispatchRuntime();
+      vi.mocked(loadConfigMock).mockImplementation(() => {
+        throw new Error("getRuntimeConfig should not be called for a prepared Gateway dispatch");
+      });
 
-    await bindPreparedReplyDispatchRuntime(preparedRuntime, getReplyFromConfig)(buildGetReplyCtx());
+      await bindPreparedReplyDispatchRuntime(
+        preparedRuntime,
+        getReplyFromConfig,
+      )(
+        buildGetReplyCtx(
+          native
+            ? {
+                Body: "/model ollama/picker-secondary -s",
+                RawBody: "/model ollama/picker-secondary -s",
+                CommandBody: "/model ollama/picker-secondary -s",
+                CommandSource: "native",
+                CommandAuthorized: true,
+                CommandTargetSessionKey: "agent:main:telegram:123",
+              }
+            : {},
+        ),
+      );
 
-    expect(loadConfigMock).not.toHaveBeenCalled();
-    expectResolvedTelegramTimezone(mocks.resolveReplyDirectives);
-    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
-      expect.objectContaining({
-        agentId: "main",
-        agentDir: "/tmp/prepared-model-owner",
-        workspaceDir: "/tmp/prepared-model-workspace",
-        preparedModelCatalog: preparedRuntime.modelCatalog,
-      }),
-    );
-  });
+      expect(loadConfigMock).not.toHaveBeenCalled();
+      expectResolvedTelegramTimezone(mocks.resolveReplyDirectives);
+      expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: "main",
+          agentDir: "/tmp/prepared-model-owner",
+          workspaceDir: "/tmp/prepared-model-workspace",
+          preparedModelCatalog: preparedRuntime.modelCatalog,
+        }),
+      );
+    },
+  );
 
   it("rejects a prepared dispatch runtime that crosses the admitted session agent", async () => {
     const preparedRuntime = createPreparedDispatchRuntime({

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -512,6 +512,7 @@ export async function getReplyFromConfig(
         provider,
         model,
         workspaceDir: workspaceDirForNativeCommand,
+        preparedModelCatalog,
         typing,
         opts: optsWithSkillFilter,
         skillFilter: mergedSkillFilter,

--- a/src/auto-reply/reply/reply-dispatch-outcome.ts
+++ b/src/auto-reply/reply/reply-dispatch-outcome.ts
@@ -3,12 +3,15 @@ import type { ReplyDispatchSettledCounts } from "./reply-dispatcher.types.js";
 
 const REPLY_DISPATCH_DELIVERY_ERROR_CODE = "REPLY_DISPATCH_DELIVERY_ERROR";
 
-export type ReplyDispatchDeliveryOutcome =
-  | "delivered"
-  | "delivered-not-visible"
-  | "cancelled"
-  | "failed-before-deliver"
-  | "failed-deliver";
+export const REPLY_DISPATCH_OUTCOME_COUNTS = {
+  delivered: "delivered",
+  "delivered-not-visible": "deliveredNotVisible",
+  "channel-transform": "deliveredNotVisible",
+  cancelled: "cancelled",
+  "failed-before-deliver": "failedBeforeSend",
+  "failed-deliver": "failedAfterSend",
+} as const satisfies Record<string, keyof ReplyDispatchSettledCounts>;
+export type ReplyDispatchDeliveryOutcome = keyof typeof REPLY_DISPATCH_OUTCOME_COUNTS;
 
 export class ReplyDispatchDeliveryError extends Error {
   readonly code = REPLY_DISPATCH_DELIVERY_ERROR_CODE;
@@ -23,20 +26,26 @@ export function isReplyDispatchDeliveryError(error: unknown): error is ReplyDisp
   return (
     isRecord(error) &&
     error.code === REPLY_DISPATCH_DELIVERY_ERROR_CODE &&
-    (error.outcome === "delivered" ||
-      error.outcome === "delivered-not-visible" ||
-      error.outcome === "cancelled" ||
-      error.outcome === "failed-before-deliver" ||
-      error.outcome === "failed-deliver")
+    typeof error.outcome === "string" &&
+    Object.hasOwn(REPLY_DISPATCH_OUTCOME_COUNTS, error.outcome)
   );
 }
 
-export function isReplyDispatchProvenInvisible(outcome: ReplyDispatchDeliveryOutcome): boolean {
-  return outcome !== "delivered" && outcome !== "failed-deliver";
+export function shouldRetryReplyDispatch(outcome: ReplyDispatchDeliveryOutcome): boolean {
+  return (
+    outcome === "delivered-not-visible" ||
+    outcome === "cancelled" ||
+    outcome === "failed-before-deliver"
+  );
 }
 
-export function isExplicitlyNonVisibleDelivery(result: unknown): boolean {
-  return isRecord(result) && result.visibleReplySent === false;
+export function resolveReplyDispatchDeliveryOutcome(result: unknown): ReplyDispatchDeliveryOutcome {
+  if (!isRecord(result) || result.visibleReplySent !== false) {
+    return "delivered";
+  }
+  return isRecord(result.suppression) && result.suppression.reason === "channel_transform"
+    ? "channel-transform"
+    : "delivered-not-visible";
 }
 
 export function createReplyDispatchSettledCounts(): ReplyDispatchSettledCounts {

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -34,8 +34,9 @@ import {
 import { getHumanDelay, getHumanDelayMax } from "./reply-dispatch-delay.js";
 import {
   createReplyDispatchSettledCounts,
-  isExplicitlyNonVisibleDelivery,
-  isReplyDispatchProvenInvisible,
+  REPLY_DISPATCH_OUTCOME_COUNTS,
+  resolveReplyDispatchDeliveryOutcome,
+  shouldRetryReplyDispatch,
   type ReplyDispatchDeliveryOutcome,
 } from "./reply-dispatch-outcome.js";
 import {
@@ -446,7 +447,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
               finalization && isRecord(result) && isRecord(finalized)
                 ? { ...result, ...finalized, finalization: undefined }
                 : result;
-            return isExplicitlyNonVisibleDelivery(outcome) ? "delivered-not-visible" : "delivered";
+            return resolveReplyDispatchDeliveryOutcome(outcome);
           } catch {
             await settleCustody("unknown");
             return "failed-deliver";
@@ -547,7 +548,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
       try {
         const attempt = await delivery;
         deliveryOutcome = await attempt.settlement;
-        if (deliveryFallback && isReplyDispatchProvenInvisible(deliveryOutcome)) {
+        if (deliveryFallback && shouldRetryReplyDispatch(deliveryOutcome)) {
           const fallbackAttempt = await startSerializedDelivery(
             deliveryFallback,
             dispatchInfo,
@@ -555,18 +556,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           );
           deliveryOutcome = await fallbackAttempt.settlement;
         }
-        const counts = settledCounts[kind];
-        if (deliveryOutcome === "delivered") {
-          counts.delivered += 1;
-        } else if (deliveryOutcome === "delivered-not-visible") {
-          counts.deliveredNotVisible += 1;
-        } else if (deliveryOutcome === "cancelled") {
-          counts.cancelled += 1;
-        } else if (deliveryOutcome === "failed-before-deliver") {
-          counts.failedBeforeSend += 1;
-        } else {
-          counts.failedAfterSend += 1;
-        }
+        settledCounts[kind][REPLY_DISPATCH_OUTCOME_COUNTS[deliveryOutcome]] += 1;
       } catch (err: unknown) {
         settledCounts[kind].failedBeforeSend += 1;
         try {


### PR DESCRIPTION
Closes #133550. Related: #134731 (already fixed by #135095).

## What Problem This Solves

Fixes an issue where Discord users selecting a model could hit the picker's timeout or see “No reply was generated” even though the chosen session model eventually persisted. Reported by @Call44.

The paired Control UI Ollama-row issue was already fixed by @obviyus in #135095 (`e4cf6f59756c28f5a9b26f0f7be786aa47fae032`). This change does not duplicate that repair; a fresh browser click/reload check confirms it. Thanks to @BoatAngle for that report.

## Why This Change Was Made

The native-command fast path dropped the admitted model catalog while ordinary replies preserved it, forcing selection to rebuild catalog state. Forward the same snapshot and reuse completed, same-generation capability metadata before scoped discovery. The shared session-selection writer and its conflict/lock checks remain unchanged.

Discord intentionally captures the command's final reply after sending hooks so the picker can present it. Its suppression reason was lost at settlement, causing generic recovery to overwrite the real acknowledgement. Preserve that existing channel-owned suppression through the shared dispatcher; suppress recovery only when every queued final was intentionally captured. Real invisible results, hook cancellation, errors, and mixed outcomes remain recoverable. Hidden output is never counted as visible, and hooks are not bypassed.

## User Impact

Discord picker choices apply promptly and display their actual success or rejection result. Native model selections reuse prepared catalog facts, including already-discovered thinking/input capabilities. No timeout increase, retries, new configuration, environment variables, schemas, protocol versions, or dependency changes.

Production: +61/-65 (**net -4**). Tests/test support: +225/-21 (**net +204**). Removed redundant private loader wrappers and consolidated duplicate outcome/count bookkeeping.

## Evidence

Regression tests failed before the corresponding repairs: missing native catalog handoff, missing completed thinking/input metadata, and a spurious generic fallback after intentional post-hook capture. The ordinary invisible-result and mixed cancellation/failure controls passed before and after. The focused wrapper run passes 437 tests across shared selection, native replies, catalog projection, dispatch settlement, and Discord picker/plugin dispatch.

Real-flow proof used the built CLI, fresh isolated state, free loopback ports (never 18789), synthetic credentials, and a local Discord Gateway/REST fixture driving the actual native interaction handlers. No operator state or real Discord account was used.

```text
Before, main 3ce74e3004f:
  Discord /model -> choose picker-secondary -> Submit
  catalog-loaded: 10,902 ms; native reply: 11,299 ms
  separate run exceeded unchanged 12-second picker timeout
  later persistence succeeded, but final notice: “No reply was generated ...”

After, candidate on main 6abc3adf10bf:
  isolated Gateway :55282, synthetic Ollama route :55281
  Discord /model -> choose picker-secondary -> Submit
  catalog-loaded: 1 ms
  reply: “Model set to ollama/picker-secondary for this session. Configured default update requested.”
  /status: ollama/picker-secondary, pinned session, OpenClaw Default runtime
  Submit through status verification: 1,698 ms

Control UI, fresh isolated Gateway :56250, Ollama route :56249:
  enabled Ollama row -> click picker-secondary
  sessions.patch observed -> selected model updated
  full page reload -> ollama/picker-secondary retained
```

The exact implicit/empty local-provider projection and remote/explicit-auth rejection variants remain covered by the catalog tests; the browser proof uses a configured isolated local route. Public Discord authentication/network latency is outside the synthetic-only proof.

The unrelated current-main TS7056 build blocker was repaired canonically in #135360 before this branch was refreshed. Runtime/UI rebuilds pass. One combined proof attempt had mismatched runtime/UI build identities due to concurrent builds; rebuilding the UI against the completed runtime identity resolved it, and the fresh UI replay passed. No production workaround was added.

The first CI run reported a shadowed test binding and an un-narrowed optional promise in aggregation. Both were corrected; targeted lint and 278 reply regressions pass after that follow-up.

Final post-lint runtime replay also passed: submit through `/status` confirmation in 1,311 ms, with the same selection retained on a second `/status` read after 20 seconds. The completed-catalog stage remained 1 ms.

Independent Codex autoreview of the final committed branch: scoped-clean, no accepted/actionable findings. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33537696096) and `openclaw/ci-gate` are green. The two cancelled auxiliary workflows were rerun successfully. Native prepare/merge gates follow.

Pre-land ClawSweeper review (final head, 17:51 UTC): no actionable correctness/security findings. Both requested next steps are addressed: the complete exact-head rollup and required gate are green, and this PR proceeds through the ordinary native review/prepare/merge workflow, not a separate repair lane. The full local `node scripts/check-changed.mjs --timed` run also passed. No Rank-up moves or safeguards are being skipped.

NO-FOLLOW-UP: the useful nearby cleanup is already absorbed into the canonical catalog and outcome owners; no additional standalone refactor is justified by this repair.
