### PR TITLE
fix(protocol): restore schema declaration checks after registry growth

### DIFF
--- a/packages/gateway-protocol/src/schema/protocol-schemas.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schemas.ts
@@ -16,8 +16,25 @@ import { SessionCoreProtocolSchemas } from "./protocol-schema-fragment-sessions-
 import { SessionLifecycleProtocolSchemas } from "./protocol-schema-fragment-sessions-lifecycle.js";
 import { TransportProtocolSchemas } from "./protocol-schema-fragment-transport.js";
 
+type ProtocolSchemaRegistry = typeof BoardProtocolSchemas &
+  typeof ProgressCardProtocolSchemas &
+  typeof TransportProtocolSchemas &
+  typeof AgentControlProtocolSchemas &
+  typeof NodeProtocolSchemas &
+  typeof IntegrationProtocolSchemas &
+  typeof SessionCoreProtocolSchemas &
+  typeof SessionCollaborationProtocolSchemas &
+  typeof SessionLifecycleProtocolSchemas &
+  typeof OperationsProtocolSchemas &
+  typeof ChannelProtocolSchemas &
+  typeof AgentSkillProtocolSchemas &
+  typeof SchedulerProtocolSchemas &
+  typeof ApprovalProtocolSchemas &
+  typeof PluginLifecycleProtocolSchemas &
+  typeof PortalProtocolSchemas;
+
 /** Public schema registry keyed by stable protocol schema name. */
-export const ProtocolSchemas = composeProtocolSchemaFragments([
+export const ProtocolSchemas: ProtocolSchemaRegistry = composeProtocolSchemaFragments([
   BoardProtocolSchemas,
   ProgressCardProtocolSchemas,
   TransportProtocolSchemas,

--- a/scripts/check-protocol-registry.mts
+++ b/scripts/check-protocol-registry.mts
@@ -39,7 +39,7 @@ check(
 );
 
 const composition = registrySource.match(
-  /export const ProtocolSchemas = composeProtocolSchemaFragments\(\[([\s\S]*?)\]\s+as const\);/u,
+  /export const ProtocolSchemas(?:: ProtocolSchemaRegistry)? = composeProtocolSchemaFragments\(\[([\s\S]*?)\]\s+as const\);/u,
 );
 const composedBindings = (composition?.[1] ?? "")
   .split("\n")


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where pull requests rebased onto current `main` fail `check-lint` and `check-additional-extension-package-boundary` with TS7056 at `packages/gateway-protocol/src/schema/protocol-schemas.ts:20`. The failure prevents the plugin SDK declaration graph from being emitted and leaves `main`'s normal validation path red.

## Why This Change Was Made

Commit `4c0588d783c776ed111b8e3e3bf7620a1ab356b4` added enough schemas to the inferred `ProtocolSchemas` registry type to cross TypeScript's declaration serialization limit. The registry now has an explicit type expressed as the exact intersection of its existing owner fragments, so declaration emit references those fragment types instead of serializing one oversized anonymous type. The runtime composition, schema instances, key order, duplicate detection, and protocol contract are unchanged. The protocol registry guard accepts this specific explicit annotation while retaining its complete ordered-fragment checks.

## User Impact

Contributors can rebase onto `main` and run the lint and extension package-boundary checks without the schema registry declaration emit failing. There is no protocol or runtime behavior change.

## Evidence

Before the fix, the package-boundary declaration lane failed with:

```text
packages/gateway-protocol/src/schema/protocol-schemas.ts(20,14): error TS7056: The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.
```

A source bisect using the current `tsgo` compiler identified `4c0588d783c776ed111b8e3e3bf7620a1ab356b4` as the first commit producing this TS7056; its parent passed the same focused probe. `7170a6231a4a831a91881fead4e799e816dabb2d` and its parent both pass when compiled at their own revisions.

Passing local validation:

- `node --import ./scripts/tsx.mjs scripts/prepare-extension-package-boundary-artifacts.mts --mode=package-boundary`
- `node scripts/run-tsgo.mjs -p packages/plugin-sdk/tsconfig.json --declaration true --emitDeclarationOnly true --noEmit false --outDir .artifacts/ts7056-final --rootDir . --incremental --tsBuildInfoFile .artifacts/ts7056-final/.tsbuildinfo`
- `pnpm check:changed`
- `pnpm protocol:check`
- `pnpm --dir packages/gateway-protocol build`
- `git diff --check HEAD^ HEAD`
