### PR TITLE
perf(secrets): reuse prepared provider auth environment candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Credential environment preparation:** reuse provider auth metadata when building scrub lists for shell, ACP, and host execution, preserving credential coverage and key order.
 - **Release validation:** defer beta candidate Parallels smoke to postpublish `release:beta-smoke` by default, keep stable/full prepublish coverage, and bound nested release workflow monitors with explicit job timeouts.
 - **Developer workflow:** remove the obsolete scoped-commit helper and use standard Git commands in isolated worktrees.
 - Fixed Crabbox hydration on unprivileged cloud sandboxes by falling back to a user-writable pnpm store when the shared `/var/cache/crabbox` cache is unavailable, preserving the hardlink import mode after hydration, and making Docker an explicit routed capability instead of an implicit install requirement.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Credential environment preparation:** reuse provider auth metadata when building scrub lists for shell, ACP, and host execution, preserving credential coverage and key order.
 - **Release validation:** defer beta candidate Parallels smoke to postpublish `release:beta-smoke` by default, keep stable/full prepublish coverage, and bound nested release workflow monitors with explicit job timeouts.
 - **Developer workflow:** remove the obsolete scoped-commit helper and use standard Git commands in isolated worktrees.
 - Fixed Crabbox hydration on unprivileged cloud sandboxes by falling back to a user-writable pnpm store when the shared `/var/cache/crabbox` cache is unavailable, preserving the hardlink import mode after hydration, and making Docker an explicit routed capability instead of an implicit install requirement.

--- a/src/cli/models-cli.auth-login.integration.test.ts
+++ b/src/cli/models-cli.auth-login.integration.test.ts
@@ -53,14 +53,14 @@ vi.mock("../plugins/providers.runtime.js", () => ({
 }));
 
 function makeStdinInteractive(): () => void {
-  const stdin = process.stdin as Omit<NodeJS.ReadStream, "isTTY"> & { isTTY?: boolean };
+  const stdin = process.stdin;
   const descriptor = Object.getOwnPropertyDescriptor(stdin, "isTTY");
   Object.defineProperty(stdin, "isTTY", { configurable: true, get: () => true });
   return () => {
     if (descriptor) {
       Object.defineProperty(stdin, "isTTY", descriptor);
     } else {
-      delete stdin.isTTY;
+      Reflect.deleteProperty(stdin, "isTTY");
     }
   };
 }

--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -725,7 +725,21 @@ describe("provider env vars dynamic manifest metadata", () => {
     ).toEqual(["WHISPERX_API_KEY"]);
   });
 
-  it("only loads plugin metadata snapshot once when resolving env var candidates, avoiding duplicate snapshot loads", () => {
+  it.each([
+    {
+      name: "auth candidates",
+      resolve: () => resolveProviderAuthEnvVarCandidates({ config: {} }).fireworks,
+      metadataLoads: 1,
+    },
+    {
+      name: "auth scrub keys",
+      resolve: () =>
+        listKnownProviderAuthEnvVarNames({ config: {} }).filter((key) =>
+          key.startsWith("FIREWORKS_"),
+        ),
+      metadataLoads: 2,
+    },
+  ])("resolves $name without repeated metadata discovery", ({ resolve, metadataLoads }) => {
     useInstalledSetupPlugin(
       "external-fireworks",
       "global",
@@ -735,10 +749,10 @@ describe("provider env vars dynamic manifest metadata", () => {
 
     pluginRegistryMocks.loadPluginMetadataSnapshot.mockClear();
 
-    resolveProviderAuthEnvVarCandidates({ config: {} });
-
-    // Verify it was only called once, proving alias resolution reused the snapshot and did not perform a second cold load!
-    expect(pluginRegistryMocks.loadPluginMetadataSnapshot).toHaveBeenCalledTimes(1);
+    expect(resolve()).toEqual(["FIREWORKS_ALT_API_KEY"]);
+    expect(pluginRegistryMocks.loadPluginMetadataSnapshot.mock.calls.length).toBeLessThanOrEqual(
+      metadataLoads,
+    );
   });
 
   it("resolves auth maps with policy work bounded to contributing plugins", () => {

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -274,7 +274,6 @@ function resolveManifestRuntimeAuthFacts(
   };
 }
 
-/** Resolves provider env-var candidates used by generic auth lookup. */
 /** Resolves provider auth env-var candidates from core fallbacks and plugin metadata. */
 export function resolveProviderAuthEnvVarCandidates(
   params?: ProviderEnvVarLookupParams,
@@ -306,11 +305,11 @@ export function resolveProviderAuthLookupMaps(
 }
 
 /** Resolves env vars used by setup, default SecretRefs, and broad secret scrubbing. */
-function resolveProviderEnvVars(
-  params?: ProviderEnvVarLookupParams,
+function withSetupEnvOverrides(
+  authCandidates: Readonly<Record<string, readonly string[]>>,
 ): Record<string, readonly string[]> {
   return {
-    ...resolveProviderAuthEnvVarCandidates(params),
+    ...authCandidates,
     ...CORE_PROVIDER_SETUP_ENV_VAR_OVERRIDES,
   };
 }
@@ -364,14 +363,18 @@ function createLazyReadonlyRecord(
  * is only for true core/non-plugin providers and a few setup-specific ordering
  * overrides where generic onboarding wants a different preferred env var.
  */
-const PROVIDER_ENV_VARS = createLazyReadonlyRecord(() => resolveProviderEnvVars());
+const PROVIDER_ENV_VARS = createLazyReadonlyRecord(() =>
+  withSetupEnvOverrides(resolveProviderAuthEnvVarCandidates()),
+);
 
 /** Returns known env var candidates for a provider id or alias. */
 export function getProviderEnvVars(
   providerId: string,
   params?: ProviderEnvVarLookupParams,
 ): string[] {
-  const providerEnvVars = params ? resolveProviderEnvVars(params) : PROVIDER_ENV_VARS;
+  const providerEnvVars = params
+    ? withSetupEnvOverrides(resolveProviderAuthEnvVarCandidates(params))
+    : PROVIDER_ENV_VARS;
   const envVars = Object.hasOwn(providerEnvVars, providerId)
     ? providerEnvVars[providerId]
     : undefined;
@@ -382,9 +385,11 @@ export function getProviderEnvVars(
 // remain available to child bridge/runtime processes.
 /** Lists known provider auth env vars without bridge-only env vars. */
 export function listKnownProviderAuthEnvVarNames(params?: ProviderEnvVarLookupParams): string[] {
+  const authCandidates = resolveProviderAuthEnvVarCandidates(params);
+  // Keep auth-only candidates before setup overrides, then append usage-only hints.
   return uniqueStrings([
-    ...Object.values(resolveProviderAuthEnvVarCandidates(params)).flat(),
-    ...Object.values(resolveProviderEnvVars(params)).flat(),
+    ...Object.values(authCandidates).flat(),
+    ...Object.values(withSetupEnvOverrides(authCandidates)).flat(),
     ...resolveManifestProviderUsageAuthEnvVarNames(params),
   ]);
 }
@@ -392,7 +397,7 @@ export function listKnownProviderAuthEnvVarNames(params?: ProviderEnvVarLookupPa
 /** Lists env vars that may contain provider secrets for broad scrubbing. */
 export function listKnownSecretEnvVarNames(params?: ProviderEnvVarLookupParams): string[] {
   return uniqueStrings([
-    ...Object.values(resolveProviderEnvVars(params)).flat(),
+    ...Object.values(withSetupEnvOverrides(resolveProviderAuthEnvVarCandidates(params))).flat(),
     ...resolveManifestProviderUsageAuthEnvVarNames(params),
   ]);
 }

--- a/test/vitest/vitest.ui-isolated-paths.mjs
+++ b/test/vitest/vitest.ui-isolated-paths.mjs
@@ -25,6 +25,7 @@ export const uiIsolatedTestFiles = [
   "ui/src/pages/chat/chat-pane.read-marker.test.ts",
   "ui/src/pages/chat/chat-pane.session-discussion.test.ts",
   "ui/src/pages/chat/chat-pane.test.ts",
+  "ui/src/pages/chat/components/chat-picker-overlay.test.ts",
   "ui/src/pages/chat/components/chat-transcript-controller.test.ts",
   "ui/src/pages/chat/components/chat-transcript-invalidation.test.ts",
   "ui/src/pages/chat/components/chat-transcript-render.test.ts",


### PR DESCRIPTION
Building provider credential scrub lists resolves the same auth candidates twice: once for auth-only keys and again while applying setup overrides. That repeats provider metadata discovery and alias expansion in shell, ACP, and host-execution environment preparation.

Resolve the auth map once and pass it to the existing setup projection. Auth-only keys still precede setup overrides, usage credentials remain separate, and workspace trust, bridge credentials, casing, lazy default lookup, and output ordering stay unchanged. The old private resolver is replaced, with no new cache, public API, configuration, or persistence behavior. Production delta: +14/−9 (+5); tests/routing: +22/−7 (+15), including the CI cleanups; no changelog edit.

Measured complete preparation operations on Node 26.8.1, using real metadata/config producers and fixed before/candidate/candidate/before process order:

| Operation | Forward median improvement | Reverse median improvement |
| --- | ---: | ---: |
| Shell expected-key composition | 23.39% | 27.18% |
| ACP strip-list and spawn environment | 25.84% | 29.94% |
| Host-exec inherited-env scope and sanitization | 21.30% | 24.97% |
| Workspace dotenv read/filter/apply | 9.35% | 10.06% |

All 768 observations were retained: 48 first blocks, 192 warmups, 528 measured blocks, and 45,568 calls. Each ordinary row's eleven candidate samples beat every baseline sample in both orders. This measures preparation, not provider latency, process startup, or total Gateway latency.

**Measurement limits:** the predeclared numerical gate remains **FAIL** for two forward control medians. Cached lookup rose 3.66% (12.375 ns/call), versus −0.72% in reverse; explicit lookup rose 11.47% (2.237 µs/call), versus −8.34% in reverse. The override-heavy first 64-call blocks also slowed 28.41%/41.12% (+2.016/+2.855 ms), although subsequent medians improved about 32%. No samples were discarded, no timing reruns were selected, and those losses are not relabeled as passes. The integration judgment accepts this narrow repeated-preparation improvement with those limits; it makes no universal first-use speedup claim.

Validation: 32 unmocked native output/control cases matched; seven existing canonical files passed 115 tests per original variant across six owning Vitest projects. The focused final regression reports 29 passes and only the expected duplicate-discovery failure on baseline, then all 30 pass on the candidate; exact outputs and an upper-bound discovery count are checked. `pnpm check:changed` passed (232 s, before the final test-only upper-bound refinement), final formatting and regression passed, and the committed `sourcePerformance` build passed (30.66 s). Independent source, raw measurement, and integration reviews completed; Codex autoreview found no actionable P0–P2 findings in the admitted diff/callers. Its managed evidence filter excluded complete `src/secrets` files; the full owner was reviewed locally.

Live compatibility passed on commit `2ba886f73b5371401765cf485871be0aec207bd9`: four real OpenAI turns, two sequential web fetches returning HTTP 200 in Markdown/text modes, and two health plus two status requests. Readiness was 3.57 s; the plain turns took 1.27–1.36 s, and the two-fetch turn 6.56 s. The built runtime stayed unchanged, the Gateway CPU profile was retained, both processes/groups closed, and owned lifecycle files were cleaned up. This smoke does not enable the conditional shell-env import path; changed-helper coverage comes from the native whole-operation proofs.

Follow-up validation at `dea48bafad2f2241bb54a491e9c27e1c57b3f7aa`: rebased onto `4a49cebb37d44f74b201ad03c05de7f800df5e4d` to repair the failing CI merge checkout. The new main auth-login integration test intersected an optional `isTTY` field with Node’s required property, so deleting it failed TS2790. Restore its temporary descriptor with the existing `Reflect.deleteProperty` pattern and remove the unnecessary type assertion. The exact core4/5 compiler stripe failed before this cleanup and passes after it; all eight auth/CLI/caller files pass 117 tests on the refreshed branch. The measured resolver and regression test are byte-identical to `4164cbf`; historical timing/live results above are not represented as fresh measurements of every intervening main change. Independent review and scoped Codex autoreview found no actionable cleanup issue. ClawSweeper’s release-owned changelog finding is applied; release-note context remains here. That intermediate head is superseded by the current-head validation below.

The full native preparation run on `dea48baf` passed build/check and then exposed a shared UI-worker failure unrelated to auth. The existing session-controls suite leaves a window listener holding the previous Tooltip class after the runner resets modules and custom elements. Running those two whole suites in that order reproduced 25 passes and the same failure at `chat-picker-overlay.test.ts:68`. Commit `cb12a49eae12e07da91baac796feefc3499d787d` adds only that test to the existing isolated UI roster; normal explicit-path routing now passes all 26 unchanged tests (23 shared, three isolated). Both root and UI package configs consume the roster. Independent source review and scoped Codex review are clean. No production UI code or assertion changed; this test-routing repair has no claimed performance gain. The current-head outcome is recorded below.

Current head `6a442dbdf8fea4beae76643ea33b891940df191c` rebases those changes onto `d17027cfdc5e1be1d8fcabc50aa13e6a13b83e4c`; all four PR files remain byte-identical to the validated `cb12a49` versions. Five whole auth/CLI/UI suites pass 60 tests, and [required CI](https://github.com/openclaw/openclaw/actions/runs/33545362115) is green on this exact head. Local build and full static checks also passed. The redundant local full-suite run was stopped when switching to the current canonical hosted-verification workflow; all owned processes closed and its partial results remain recorded, not a completed full-suite pass. Native hosted preparation passed, including exact branch readback. One transient Octopool policy-fetch/read failure interrupted its first attempt; the unchanged native path succeeded on retry without bypassing policy or changing authentication. Final scoped Codex review of the complete branch is clean. Historical timing and live results retain their original commit identities.
