### PR TITLE
refactor: simplify transcript reads and recovery state

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2650,7 +2650,7 @@ src/config/sessions/metadata.ts	1
 src/config/sessions/restart-recovery-state.ts	6
 src/config/sessions/session-accessor.entry-mutation.ts	2
 src/config/sessions/session-accessor.entry.ts	1
-src/config/sessions/session-accessor.sqlite-active-events.ts	3
+src/config/sessions/session-accessor.sqlite-active-events.ts	2
 src/config/sessions/session-accessor.sqlite-archive-store.ts	1
 src/config/sessions/session-accessor.sqlite-archive.ts	3
 src/config/sessions/session-accessor.sqlite-archive.worker.ts	7
@@ -2665,7 +2665,7 @@ src/config/sessions/session-accessor.sqlite-message-cut.ts	1
 src/config/sessions/session-accessor.sqlite-parent-fork.ts	1
 src/config/sessions/session-accessor.sqlite-read.ts	12
 src/config/sessions/session-accessor.sqlite-recovery.ts	1
-src/config/sessions/session-accessor.sqlite-reset-window.ts	3
+src/config/sessions/session-accessor.sqlite-reset-window.ts	2
 src/config/sessions/session-accessor.sqlite-title-probes.ts	2
 src/config/sessions/session-accessor.sqlite-transcript-message-append.ts	1
 src/config/sessions/session-accessor.sqlite-transcript-mirror.ts	1
@@ -2988,7 +2988,6 @@ src/gateway/session-sharing.ts	1
 src/gateway/session-transcript-derived-readers.ts	2
 src/gateway/session-transcript-files.fs.ts	2
 src/gateway/session-transcript-message.ts	4
-src/gateway/session-transcript-readers.ts	3
 src/gateway/session-transcript-title-reader.ts	1
 src/gateway/session-utils-core.ts	1
 src/gateway/session-utils-row.ts	1

--- a/src/cli/models-cli.auth-login.integration.test.ts
+++ b/src/cli/models-cli.auth-login.integration.test.ts
@@ -53,14 +53,15 @@ vi.mock("../plugins/providers.runtime.js", () => ({
 }));
 
 function makeStdinInteractive(): () => void {
-  const stdin = process.stdin;
+  // Piped stdin has no own isTTY property; the fixture owns only its temporary override.
+  const stdin: { isTTY?: boolean } = process.stdin;
   const descriptor = Object.getOwnPropertyDescriptor(stdin, "isTTY");
   Object.defineProperty(stdin, "isTTY", { configurable: true, get: () => true });
   return () => {
     if (descriptor) {
       Object.defineProperty(stdin, "isTTY", descriptor);
     } else {
-      Reflect.deleteProperty(stdin, "isTTY");
+      delete stdin.isTTY;
     }
   };
 }

--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -1,12 +1,14 @@
 import { sql } from "kysely";
-import type { TranscriptDisplayPosition } from "../../chat/transcript-display-position.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
 } from "../../infra/kysely-sync.js";
 import {
   getActiveTranscriptKysely,
+  parseActiveTranscriptMessageRow,
+  readTranscriptProjectionGeneration,
   withCurrentProjectionSnapshot,
+  type SessionTranscriptMessageEvent,
 } from "./session-accessor.sqlite-active-projection.js";
 import type {
   SessionTranscriptVisibleMessageDeltaLimits,
@@ -16,7 +18,6 @@ import type {
 } from "./session-accessor.sqlite-contract.js";
 import {
   iterateVisibleMessageRange,
-  readTranscriptProjectionGeneration,
   readVisibleMessageMetadata,
   readVisibleMessageRange,
   readVisibleTranscriptStats,
@@ -41,13 +42,7 @@ export {
   isSessionTranscriptProjectionUnavailableError,
   SessionTranscriptProjectionUnavailableError,
 } from "./session-transcript-projection-error.js";
-
-export type SessionTranscriptMessageEvent = {
-  event: TranscriptEvent;
-  eventSeq: number;
-  seq: number;
-  displayPosition?: TranscriptDisplayPosition;
-};
+export type { SessionTranscriptMessageEvent } from "./session-accessor.sqlite-active-projection.js";
 
 export type SessionTranscriptMessageEventPage = {
   activeLeafEntryId?: string | null;
@@ -74,23 +69,6 @@ export type SessionTranscriptBoundedMessageTailPage = SessionTranscriptMessageEv
     indexedSeq: number;
   };
 };
-
-function parseMessageEventRow(row: {
-  event_seq: number;
-  event_json: string;
-  message_position: number | null;
-}): SessionTranscriptMessageEvent {
-  if (row.message_position === null) {
-    throw new Error("Active transcript message row is missing its message position");
-  }
-  return {
-    event: JSON.parse(row.event_json) as TranscriptEvent,
-    eventSeq: row.event_seq,
-    // Gateway cursors use the visible-message ordinal, matching the JSONL index.
-    // Raw event seq includes headers/control rows and would make pages overlap.
-    seq: row.message_position + 1,
-  };
-}
 
 /** Reads every message event on the active path. Full callers remain intentionally O(output). */
 export function readSessionTranscriptMessageEvents(
@@ -206,13 +184,7 @@ export function readSessionTranscriptVisibleMessageDeltaCore(
       database: projection.database,
       ...projection.resolved,
     });
-    const generation = executeSqliteQueryTakeFirstSync(
-      projection.database.db,
-      db
-        .selectFrom("transcript_rewrite_watermarks")
-        .select("generation")
-        .where("session_id", "=", projection.resolved.sessionId),
-    )?.generation;
+    const generation = readTranscriptProjectionGeneration(projection);
     if (!generation) {
       return { kind: "missing" };
     }
@@ -513,7 +485,7 @@ export function readSessionTranscriptBoundedMessageTailPage(
               .where("active.session_id", "=", projection.resolved.sessionId)
               .where("active.message_position", "in", selectedPositions)
               .orderBy("active.message_position", "asc"),
-          ).rows.map(parseMessageEventRow);
+          ).rows.map(parseActiveTranscriptMessageRow);
     return {
       activeLeafEntryId: projection.state.leafEventId,
       events,

--- a/src/config/sessions/session-accessor.sqlite-active-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-projection.ts
@@ -1,3 +1,4 @@
+import type { TranscriptDisplayPosition } from "../../chat/transcript-display-position.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
@@ -5,7 +6,10 @@ import {
   openOpenClawAgentDatabase,
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
-import type { SessionTranscriptReadScope } from "./session-accessor.sqlite-contract.js";
+import type {
+  SessionTranscriptReadScope,
+  TranscriptEvent,
+} from "./session-accessor.sqlite-contract.js";
 import {
   resolveSqliteTranscriptReadScope,
   toDatabaseOptions,
@@ -30,6 +34,13 @@ export type CurrentTranscriptProjection = {
   state: SessionTranscriptProjectionState;
 };
 
+export type SessionTranscriptMessageEvent = {
+  event: TranscriptEvent;
+  eventSeq: number;
+  seq: number;
+  displayPosition?: TranscriptDisplayPosition;
+};
+
 const EMPTY_PROJECTION_STATE: SessionTranscriptProjectionState = {
   activeEventCount: 0,
   activeMessageCount: 0,
@@ -40,6 +51,36 @@ const EMPTY_PROJECTION_STATE: SessionTranscriptProjectionState = {
 
 export function getActiveTranscriptKysely(database: OpenClawAgentDatabase) {
   return getNodeSqliteKysely<ActiveTranscriptDatabase>(database.db);
+}
+
+export function parseActiveTranscriptMessageRow(row: {
+  event_seq: number;
+  event_json: string;
+  message_position: number | null;
+}): SessionTranscriptMessageEvent {
+  if (row.message_position === null) {
+    throw new Error("Active transcript message row is missing its message position");
+  }
+  return {
+    // SAFETY: The active projection indexes serialized TranscriptEvent rows.
+    event: JSON.parse(row.event_json) as TranscriptEvent,
+    eventSeq: row.event_seq,
+    // Gateway cursors use the visible-message ordinal, matching the JSONL index.
+    // Raw event seq includes headers/control rows and would make pages overlap.
+    seq: row.message_position + 1,
+  };
+}
+
+export function readTranscriptProjectionGeneration(
+  projection: CurrentTranscriptProjection,
+): string | undefined {
+  return executeSqliteQueryTakeFirstSync(
+    projection.database.db,
+    getActiveTranscriptKysely(projection.database)
+      .selectFrom("transcript_rewrite_watermarks")
+      .select("generation")
+      .where("session_id", "=", projection.resolved.sessionId),
+  )?.generation;
 }
 
 function readProjectionSnapshot(

--- a/src/config/sessions/session-accessor.sqlite-display-position.ts
+++ b/src/config/sessions/session-accessor.sqlite-display-position.ts
@@ -8,10 +8,10 @@ import {
 } from "../../sessions/transcript-display-position.js";
 import {
   getActiveTranscriptKysely,
+  readTranscriptProjectionGeneration,
   type CurrentTranscriptProjection,
 } from "./session-accessor.sqlite-active-projection.js";
 import type { TranscriptEvent } from "./session-accessor.sqlite-contract.js";
-import { readTranscriptProjectionGeneration } from "./session-accessor.sqlite-reset-window.js";
 import { resolveSqliteSessionTranscriptReadFence } from "./session-transcript-read-fence.js";
 
 export function readTranscriptDisplaySource(

--- a/src/config/sessions/session-accessor.sqlite-history-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.ts
@@ -6,13 +6,14 @@ import {
 } from "../../infra/kysely-sync.js";
 import type {
   SessionTranscriptMessageAnchorPage,
-  SessionTranscriptMessageEvent,
   SessionTranscriptMessageEventPage,
 } from "./session-accessor.sqlite-active-events.js";
 import {
   getActiveTranscriptKysely,
+  readTranscriptProjectionGeneration,
   withCurrentProjectionSnapshot,
   type CurrentTranscriptProjection,
+  type SessionTranscriptMessageEvent,
 } from "./session-accessor.sqlite-active-projection.js";
 import type {
   SessionTranscriptRawDeltaLimits,
@@ -29,7 +30,6 @@ import {
   readTranscriptDisplaySource,
 } from "./session-accessor.sqlite-display-position.js";
 import {
-  readTranscriptProjectionGeneration,
   readVisibleMessageMetadata,
   readVisibleMessageRange,
   resolveVisibleMessagePositions,

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -5,30 +5,17 @@ import { selectResetKeptEntries } from "../../../packages/agent-core/src/harness
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
-  getNodeSqliteKysely,
   iterateSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
-import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
-import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
-import type { TranscriptEvent } from "./session-accessor.sqlite-contract.js";
-import { resolveSqliteTranscriptReadScope } from "./session-accessor.sqlite-scope.js";
+import {
+  getActiveTranscriptKysely,
+  parseActiveTranscriptMessageRow,
+  readTranscriptProjectionGeneration,
+  type CurrentTranscriptProjection,
+  type SessionTranscriptMessageEvent,
+} from "./session-accessor.sqlite-active-projection.js";
 import { projectModelContextNavigationSql } from "./session-model-context-projection.js";
-import type { SessionTranscriptProjectionState } from "./session-transcript-index.js";
-
-type ResetWindowDatabase = Pick<
-  OpenClawAgentKyselyDatabase,
-  | "session_transcript_active_events"
-  | "transcript_rewrite_watermarks"
-  | "transcript_event_identities"
-  | "transcript_events"
->;
-
-type ResetWindowProjection = {
-  database: OpenClawAgentDatabase;
-  resolved: ReturnType<typeof resolveSqliteTranscriptReadScope>;
-  state: SessionTranscriptProjectionState;
-};
 
 type VisibleMessagePositions = {
   kept: number[];
@@ -36,16 +23,8 @@ type VisibleMessagePositions = {
   total: number;
 };
 
-type ResetWindowMessageEvent = {
-  event: TranscriptEvent;
-  eventSeq: number;
-  seq: number;
-};
-
 type ResetMessageWindow = {
   boundarySeq: number;
-  generation: string | undefined;
-  indexedSeq: number;
   contextPrefixEventCount: number;
   keptMessagePositions: number[];
   contextPrefixSizeBytes: number;
@@ -71,27 +50,8 @@ function isWindowBoundary(eventType: unknown, scope: BoundaryWindowScope): boole
 const resetMessageWindowCache = new Map<string, ResetMessageWindowCacheEntry>();
 const MAX_RESET_MESSAGE_WINDOW_CACHE = 64;
 
-function getResetWindowKysely(database: OpenClawAgentDatabase) {
-  return getNodeSqliteKysely<ResetWindowDatabase>(database.db);
-}
-
-function parseMessageEventRow(row: {
-  event_seq: number;
-  event_json: string;
-  message_position: number | null;
-}): ResetWindowMessageEvent {
-  if (row.message_position === null) {
-    throw new Error("Active transcript message row is missing its message position");
-  }
-  return {
-    event: JSON.parse(row.event_json) as TranscriptEvent,
-    eventSeq: row.event_seq,
-    seq: row.message_position + 1,
-  };
-}
-
-function selectMessageRows(projection: ResetWindowProjection) {
-  return getResetWindowKysely(projection.database)
+function selectMessageRows(projection: CurrentTranscriptProjection) {
+  return getActiveTranscriptKysely(projection.database)
     .selectFrom("session_transcript_active_events as active")
     .innerJoin("transcript_events as event", (join) =>
       join
@@ -103,22 +63,6 @@ function selectMessageRows(projection: ResetWindowProjection) {
     .orderBy("active.message_position", "asc");
 }
 
-function resetMessageWindowCacheKey(projection: ResetWindowProjection): string {
-  return `${projection.database.path}\0${projection.resolved.sessionId}`;
-}
-
-export function readTranscriptProjectionGeneration(
-  projection: ResetWindowProjection,
-): string | undefined {
-  return executeSqliteQueryTakeFirstSync(
-    projection.database.db,
-    getResetWindowKysely(projection.database)
-      .selectFrom("transcript_rewrite_watermarks")
-      .select("generation")
-      .where("session_id", "=", projection.resolved.sessionId),
-  )?.generation;
-}
-
 function cacheResetMessageWindow(key: string, entry: ResetMessageWindowCacheEntry): void {
   resetMessageWindowCache.delete(key);
   resetMessageWindowCache.set(key, entry);
@@ -126,10 +70,10 @@ function cacheResetMessageWindow(key: string, entry: ResetMessageWindowCacheEntr
 }
 
 function readLatestActiveBoundaryMetadataByType(
-  projection: ResetWindowProjection,
+  projection: CurrentTranscriptProjection,
   eventType: "compaction" | "reset",
 ) {
-  const db = getResetWindowKysely(projection.database);
+  const db = getActiveTranscriptKysely(projection.database);
   return executeSqliteQueryTakeFirstSync(
     projection.database.db,
     db
@@ -148,7 +92,7 @@ function readLatestActiveBoundaryMetadataByType(
 }
 
 function readLatestActiveBoundaryMetadata(
-  projection: ResetWindowProjection,
+  projection: CurrentTranscriptProjection,
   scope: BoundaryWindowScope,
 ) {
   const reset = readLatestActiveBoundaryMetadataByType(projection, "reset");
@@ -160,13 +104,13 @@ function readLatestActiveBoundaryMetadata(
 }
 
 function readBoundaryWindowFacts(
-  projection: ResetWindowProjection,
+  projection: CurrentTranscriptProjection,
   seq: number,
   scope: BoundaryWindowScope,
 ) {
   const row = executeSqliteQueryTakeFirstSync(
     projection.database.db,
-    getResetWindowKysely(projection.database)
+    getActiveTranscriptKysely(projection.database)
       .selectFrom("transcript_events")
       .select((eb) => [
         projectModelContextNavigationSql(eb.ref("event_json")).as("event_json"),
@@ -188,11 +132,10 @@ function readBoundaryWindowFacts(
 }
 
 function findLatestResetMessageWindow(
-  projection: ResetWindowProjection,
-  generation: string | undefined,
+  projection: CurrentTranscriptProjection,
   scope: BoundaryWindowScope,
 ): ResetMessageWindow | null {
-  const db = getResetWindowKysely(projection.database);
+  const db = getActiveTranscriptKysely(projection.database);
   const latestBoundary = readLatestActiveBoundaryMetadata(projection, scope);
   if (!latestBoundary) {
     return null;
@@ -287,8 +230,6 @@ function findLatestResetMessageWindow(
   }
   return {
     boundarySeq: latestBoundary.seq,
-    generation,
-    indexedSeq: projection.state.indexedSeq,
     contextPrefixEventCount,
     keptMessagePositions,
     contextPrefixSizeBytes,
@@ -298,10 +239,10 @@ function findLatestResetMessageWindow(
 }
 
 function resolveResetMessageWindow(
-  projection: ResetWindowProjection,
+  projection: CurrentTranscriptProjection,
   scope: BoundaryWindowScope = "history",
 ): ResetMessageWindow | null {
-  const key = `${resetMessageWindowCacheKey(projection)}\0${scope}`;
+  const key = `${projection.database.path}\0${projection.resolved.sessionId}\0${scope}`;
   const cached = resetMessageWindowCache.get(key);
   const generation = readTranscriptProjectionGeneration(projection);
   if (cached) {
@@ -311,13 +252,12 @@ function resolveResetMessageWindow(
     if (cached.generation === generation && cached.window) {
       const latestBoundary = readLatestActiveBoundaryMetadata(projection, scope);
       if (latestBoundary?.seq === cached.window.boundarySeq) {
-        const window = { ...cached.window, indexedSeq: projection.state.indexedSeq };
-        cacheResetMessageWindow(key, { generation, indexedSeq: window.indexedSeq, window });
-        return window;
+        cacheResetMessageWindow(key, { ...cached, indexedSeq: projection.state.indexedSeq });
+        return cached.window;
       }
     }
   }
-  const window = findLatestResetMessageWindow(projection, generation, scope);
+  const window = findLatestResetMessageWindow(projection, scope);
   cacheResetMessageWindow(key, {
     generation,
     indexedSeq: projection.state.indexedSeq,
@@ -327,7 +267,7 @@ function resolveResetMessageWindow(
 }
 
 export function resolveVisibleMessagePositions(
-  projection: ResetWindowProjection,
+  projection: CurrentTranscriptProjection,
 ): VisibleMessagePositions {
   const window = resolveResetMessageWindow(projection);
   if (!window) {
@@ -343,7 +283,7 @@ export function resolveVisibleMessagePositions(
 }
 
 function selectVisibleMessageRanges(
-  projection: ResetWindowProjection,
+  projection: CurrentTranscriptProjection,
   start: number,
   endExclusive: number,
 ) {
@@ -383,31 +323,31 @@ function selectVisibleMessageRanges(
 }
 
 export function readVisibleMessageRange(
-  projection: ResetWindowProjection,
+  projection: CurrentTranscriptProjection,
   start: number,
   endExclusive: number,
-): ResetWindowMessageEvent[] {
+): SessionTranscriptMessageEvent[] {
   return Array.from(iterateVisibleMessageRange(projection, start, endExclusive));
 }
 
 export function* iterateVisibleMessageRange(
-  projection: ResetWindowProjection,
+  projection: CurrentTranscriptProjection,
   start: number,
   endExclusive: number,
-): IterableIterator<ResetWindowMessageEvent> {
+): IterableIterator<SessionTranscriptMessageEvent> {
   for (const range of selectVisibleMessageRanges(projection, start, endExclusive)) {
     for (const row of iterateSqliteQuerySync(
       projection.database.db,
       range.query.select(["active.event_seq", "active.message_position", "event.event_json"]),
     )) {
-      yield parseMessageEventRow(row);
+      yield parseActiveTranscriptMessageRow(row);
     }
   }
 }
 
 /** Sizes the same logical ranges without fetching or parsing excluded payloads. */
 export function readVisibleMessageMetadata(
-  projection: ResetWindowProjection,
+  projection: CurrentTranscriptProjection,
   start: number,
   endExclusive: number,
 ) {
@@ -431,12 +371,12 @@ export function readVisibleMessageMetadata(
 }
 
 /** Reads logical transcript bytes, reusing cached retained-tail facts after resets. */
-export function readVisibleTranscriptStats(projection: ResetWindowProjection): {
+export function readVisibleTranscriptStats(projection: CurrentTranscriptProjection): {
   eventCount: number;
   sizeBytes: number;
 } {
   const window = resolveResetMessageWindow(projection, "context");
-  const db = getResetWindowKysely(projection.database);
+  const db = getActiveTranscriptKysely(projection.database);
   const base = db
     .selectFrom("session_transcript_active_events as active")
     .innerJoin("transcript_events as event", (join) =>

--- a/src/gateway/mcp-app-reconstruction.ts
+++ b/src/gateway/mcp-app-reconstruction.ts
@@ -266,11 +266,7 @@ async function reconstructMcpAppView(params: {
     sessionEntry: loaded.entry,
   };
   const data = await findMcpAppReconstructionDataByVisit(async (visit) => {
-    await visitSessionMessagesAsync(transcriptScope, (message) => visit(message), {
-      mode: "full",
-      reason: "MCP App restart reconstruction",
-      cache: "reuse",
-    });
+    await visitSessionMessagesAsync(transcriptScope, visit);
   }, params.lookup);
   if (!data) {
     return undefined;

--- a/src/gateway/server-methods/artifacts.test.ts
+++ b/src/gateway/server-methods/artifacts.test.ts
@@ -189,7 +189,6 @@ describe("artifacts RPC handlers", () => {
         storePath: "/tmp/sessions.json",
       },
       expect.any(Function),
-      expect.objectContaining({ cache: "skip" }),
     );
   });
 

--- a/src/gateway/server-methods/artifacts.ts
+++ b/src/gateway/server-methods/artifacts.ts
@@ -349,11 +349,6 @@ async function loadArtifacts(
         downloadArtifactId: opts.downloadArtifactId,
       });
     },
-    {
-      mode: "full",
-      reason: "artifact query transcript scan",
-      cache: "skip",
-    },
   );
   return {
     sessionKey,

--- a/src/gateway/session-transcript-readers.markers.test.ts
+++ b/src/gateway/session-transcript-readers.markers.test.ts
@@ -175,13 +175,8 @@ describe("session transcript reader marker projection", () => {
     }
     const visited: Array<{ message: unknown; seq: number }> = [];
     await expect(
-      visitSessionMessagesAsync(
-        scope,
-        (entryMessage, seq) => visited.push({ message: entryMessage, seq }),
-        {
-          mode: "full",
-          reason: `${fixture.name} visitor projection test`,
-        },
+      visitSessionMessagesAsync(scope, (entryMessage, seq) =>
+        visited.push({ message: entryMessage, seq }),
       ),
     ).resolves.toBe(expectedVisits.length);
     expect(visited).toEqual(expectedVisits);

--- a/src/gateway/session-transcript-readers.test.ts
+++ b/src/gateway/session-transcript-readers.test.ts
@@ -99,10 +99,7 @@ describe("session transcript reader facade", () => {
     ).resolves.toMatchObject([{ content: "root prompt" }, { content: "active answer" }]);
     const visited: Array<{ message: unknown; seq: number }> = [];
     await expect(
-      visitSessionMessagesAsync(scope, (message, seq) => visited.push({ message, seq }), {
-        mode: "full",
-        reason: "visitor active branch test",
-      }),
+      visitSessionMessagesAsync(scope, (message, seq) => visited.push({ message, seq })),
     ).resolves.toBe(2);
     expect(visited).toEqual([
       { message: { role: "user", content: "root prompt" }, seq: 1 },
@@ -162,17 +159,13 @@ describe("session transcript reader facade", () => {
         .run(sessionId, sessionId);
       const stopped = new Error("visitor stopped");
       const visited: Array<{ message: unknown; seq: number }> = [];
-      const traversal = visitSessionMessagesAsync(
-        scope,
-        (message, seq) => {
-          expect(database.db.isTransaction).toBe(true);
-          visited.push({ message, seq });
-          if (failure === "visitor") {
-            throw stopped;
-          }
-        },
-        { mode: "full", reason: "incremental acquisition test" },
-      );
+      const traversal = visitSessionMessagesAsync(scope, (message, seq) => {
+        expect(database.db.isTransaction).toBe(true);
+        visited.push({ message, seq });
+        if (failure === "visitor") {
+          throw stopped;
+        }
+      });
       if (failure === "visitor") {
         await expect(traversal).rejects.toBe(stopped);
       } else {
@@ -505,10 +498,7 @@ describe("session transcript reader facade", () => {
 
     const visited: unknown[] = [];
     await expect(
-      visitSessionMessagesAsync(scope, (message) => visited.push(message), {
-        mode: "full",
-        reason: "visitor unavailable projection test",
-      }),
+      visitSessionMessagesAsync(scope, (message) => visited.push(message)),
     ).rejects.toBeInstanceOf(SessionTranscriptProjectionUnavailableError);
     expect(visited).toEqual([]);
     await expect(readSessionMessageCountAsync(scope)).resolves.toBe(2);

--- a/src/gateway/session-transcript-readers.ts
+++ b/src/gateway/session-transcript-readers.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { parseDateFirstTimestampMs } from "@openclaw/normalization-core/number-coercion";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   isSessionTranscriptProjectionUnavailableError,
   readRecentSessionTranscriptMessageEvents,
@@ -21,10 +21,7 @@ import {
 } from "../config/sessions/session-accessor.sqlite-history-events.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { aggregateSessionTranscriptUsage } from "./session-transcript-derived-readers.js";
-import {
-  attachOpenClawTranscriptMeta,
-  projectTranscriptEntryMessage,
-} from "./session-transcript-message.js";
+import { projectTranscriptEntryMessage } from "./session-transcript-message.js";
 import type {
   ReadRecentSessionMessagesOptions,
   ReadSessionMessagesAsyncOptions,
@@ -107,48 +104,8 @@ function archivedTranscriptReader(target: ResolvedTranscriptReadTarget): Archive
   });
 }
 
-function readTranscriptRecordTimestampMs(event: Record<string, unknown>): number | undefined {
-  return parseDateFirstTimestampMs(event.timestamp);
-}
-
-function extractMessageRecord(
-  event: unknown,
-): { id?: string; message: unknown; recordTimestampMs?: number } | undefined {
-  if (!event || typeof event !== "object" || Array.isArray(event)) {
-    return undefined;
-  }
-  const record = event as { id?: unknown; message?: unknown };
-  if (record.message === undefined) {
-    return undefined;
-  }
-  const recordTimestampMs = readTranscriptRecordTimestampMs(event as Record<string, unknown>);
-  return {
-    ...(typeof record.id === "string" ? { id: record.id } : {}),
-    message: record.message,
-    ...(recordTimestampMs !== undefined ? { recordTimestampMs } : {}),
-  };
-}
-
-type SqliteMessageRecord = {
-  id?: string;
-  message: unknown;
-  recordTimestampMs?: number;
-  seq: number;
-};
-
-function extractMessageRecordsFromEventEntries(
-  entries: readonly SessionTranscriptMessageEvent[],
-): SqliteMessageRecord[] {
-  return entries.flatMap((entry) => {
-    const record = extractMessageRecord(entry.event);
-    return record ? [{ ...record, seq: entry.seq }] : [];
-  });
-}
-
-function readSqliteMessageRecords(target: ResolvedTranscriptReadTarget): SqliteMessageRecord[] {
-  return extractMessageRecordsFromEventEntries(
-    readSessionTranscriptMessageEvents(toTranscriptReadScope(target)),
-  );
+function extractMessagePayloads(entries: readonly SessionTranscriptMessageEvent[]): unknown[] {
+  return entries.map((entry) => asOptionalRecord(entry.event)?.message);
 }
 
 function projectSqliteHistoryEvents(entries: readonly SessionTranscriptMessageEvent[]): unknown[] {
@@ -156,10 +113,6 @@ function projectSqliteHistoryEvents(entries: readonly SessionTranscriptMessageEv
     const message = projectTranscriptEntryMessage(entry.event, entry.seq, entry.displayPosition);
     return message ? [message] : [];
   });
-}
-
-function readSqliteMessagesSync(target: ResolvedTranscriptReadTarget): unknown[] {
-  return readSqliteMessageRecords(target).map(sqliteRecordMessageWithSeq);
 }
 
 function normalizeRecentSqliteReadOptions(opts?: Partial<ReadRecentSessionMessagesOptions>) {
@@ -201,50 +154,10 @@ async function readRecentSqliteMessageRecords(
   };
 }
 
-function readRecentSqliteUsageMessages(
-  target: ResolvedTranscriptReadTarget,
-  maxBytes: number,
-): unknown[] {
-  const page = readRecentSessionTranscriptMessageEvents(toTranscriptReadScope(target), {
-    maxBytes: Math.max(1024, Math.floor(Number.isFinite(maxBytes) ? maxBytes : 8 * 1024 * 1024)),
-    maxLines: 1000,
-    maxMessages: 1000,
-  });
-  return extractMessageRecordsFromEventEntries(page.events).map((record) => record.message);
-}
-
-function sqliteRecordMessageWithSeq(record: {
-  id?: string;
-  message: unknown;
-  recordTimestampMs?: number;
-  seq: number;
-}): unknown {
-  const rawIdempotencyKey = (record.message as { idempotencyKey?: unknown } | undefined)
-    ?.idempotencyKey;
-  const idempotencyKey =
-    typeof rawIdempotencyKey === "string" && rawIdempotencyKey.trim()
-      ? rawIdempotencyKey.trim()
-      : undefined;
-  return attachOpenClawTranscriptMeta(record.message, {
-    ...(record.id ? { id: record.id } : {}),
-    ...(idempotencyKey ? { idempotencyKey } : {}),
-    ...(record.recordTimestampMs !== undefined
-      ? { recordTimestampMs: record.recordTimestampMs }
-      : {}),
-    seq: record.seq,
-  });
-}
-
 export function sqliteMessageEventWithSeq(
   entry: Pick<SessionTranscriptMessageEvent, "event" | "seq" | "displayPosition">,
 ): unknown {
   return projectTranscriptEntryMessage(entry.event, entry.seq, entry.displayPosition);
-}
-
-function readSqliteAggregateUsageSnapshot(
-  target: ResolvedTranscriptReadTarget,
-): SessionTranscriptUsageSnapshot | null {
-  return aggregateSessionTranscriptUsage(readSqliteMessagesSync(target));
 }
 
 function buildSqlitePreviewItems(
@@ -262,11 +175,7 @@ function buildSqlitePreviewItems(
       maxMessages: maxEvents,
     });
     return {
-      items: buildSessionPreviewItems(
-        extractMessageRecordsFromEventEntries(page.events).map(sqliteRecordMessageWithSeq),
-        maxItems,
-        maxChars,
-      ),
+      items: buildSessionPreviewItems(extractMessagePayloads(page.events), maxItems, maxChars),
       hasOlderEvents: page.totalMessages > page.events.length,
     };
   };
@@ -342,18 +251,17 @@ export async function readSessionMessageByIdAsync(
   return { found: false, oversized: false };
 }
 
-/** Visits display messages asynchronously through the reader seam. */
+/** Visits raw message payloads within the SQLite read snapshot. */
 export async function visitSessionMessagesAsync(
   scope: SessionTranscriptReadScope,
   visit: (message: unknown, seq: number) => void,
-  _opts: { mode: "full"; reason: string; cache?: "reuse" | "skip" },
 ): Promise<number> {
   const target = resolveTranscriptReadTarget(scope);
   let count = 0;
   visitSessionTranscriptMessageEvents(toTranscriptReadScope(target), (entry) => {
-    const record = extractMessageRecord(entry.event);
-    if (record) {
-      visit(record.message, entry.seq);
+    const message = asOptionalRecord(entry.event)?.message;
+    if (message !== undefined) {
+      visit(message, entry.seq);
       count += 1;
     }
   });
@@ -456,7 +364,9 @@ export async function readLatestSessionUsageFromTranscriptAsync(
     );
   }
   const target = resolveTranscriptReadTarget(scope);
-  return readSqliteAggregateUsageSnapshot(target);
+  return aggregateSessionTranscriptUsage(
+    extractMessagePayloads(readSessionTranscriptMessageEvents(toTranscriptReadScope(target))),
+  );
 }
 
 /** Reads aggregate usage from a bounded transcript tail synchronously through the reader seam. */
@@ -465,7 +375,12 @@ export function readRecentSessionUsageFromTranscript(
   maxBytes: number,
 ): SessionTranscriptUsageSnapshot | null {
   const target = resolveTranscriptReadTarget(scope);
-  return aggregateSessionTranscriptUsage(readRecentSqliteUsageMessages(target, maxBytes));
+  const page = readRecentSessionTranscriptMessageEvents(toTranscriptReadScope(target), {
+    maxBytes: Math.max(1024, Math.floor(Number.isFinite(maxBytes) ? maxBytes : 8 * 1024 * 1024)),
+    maxLines: 1000,
+    maxMessages: 1000,
+  });
+  return aggregateSessionTranscriptUsage(extractMessagePayloads(page.events));
 }
 
 /** Reads compact session preview items through the reader seam. */

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -45,7 +45,7 @@ type RenderChatItem = ReturnType<typeof buildChatItems>[number];
 const chatItemsByPane = new Map<string, Map<string, CachedChatItems>>();
 const expandedToolCardsBySession = new Map<string, Map<string, boolean>>();
 const expandedUserMessagesBySession = new Map<string, Map<string, boolean>>();
-const expandedBooleanMapVersions = new WeakMap<ReadonlyMap<string, boolean>, number>();
+const expansionMapVersions = new WeakMap<ReadonlyMap<string, unknown>, number>();
 const initializedToolCardsBySession = new Map<string, Set<string>>();
 const lastAutoExpandPrefBySession = new Map<string, boolean>();
 // This memo only skips repeated work. Keeping its transcript strongly would
@@ -353,21 +353,21 @@ export function buildCachedChatItems(
   return items;
 }
 
-export function getExpansionStateVersion(values: ReadonlyMap<string, boolean>): number {
-  return expandedBooleanMapVersions.get(values) ?? 0;
+export function getExpansionStateVersion(values: ReadonlyMap<string, unknown>): number {
+  return expansionMapVersions.get(values) ?? 0;
 }
 
-export function setExpansionState(values: Map<string, boolean>, key: string, value: boolean): void {
+export function setExpansionState<T>(values: Map<string, T>, key: string, value: T): void {
   if (values.has(key) && values.get(key) === value) {
     return;
   }
   values.set(key, value);
-  expandedBooleanMapVersions.set(values, getExpansionStateVersion(values) + 1);
+  expansionMapVersions.set(values, getExpansionStateVersion(values) + 1);
 }
 
-function deleteExpansionState(values: Map<string, boolean>, key: string): void {
+export function deleteExpansionState<T>(values: Map<string, T>, key: string): void {
   if (values.delete(key)) {
-    expandedBooleanMapVersions.set(values, getExpansionStateVersion(values) + 1);
+    expansionMapVersions.set(values, getExpansionStateVersion(values) + 1);
   }
 }
 
@@ -402,15 +402,6 @@ export type AssistantMessageExpansionState =
   | { status: "loading"; revision: number }
   | { status: "error"; revision: number }
   | { status: "loaded"; markdown: string; revision: number };
-
-export function assistantMessageExpansionSignature(
-  values: ReadonlyMap<string, AssistantMessageExpansionState>,
-): string {
-  return Array.from(values)
-    .toSorted(([left], [right]) => left.localeCompare(right))
-    .map(([key, value]) => `${key}:${value.revision}`)
-    .join("\u0000");
-}
 
 function getInitializedToolCards(sessionKey: string): Set<string> {
   return getOrCreateSessionCacheValue(initializedToolCardsBySession, sessionKey, () => new Set());

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -16,13 +16,13 @@ import { readChatThreadMessageIdentity } from "../chat-thread-items.ts";
 import {
   assistantGroupCanOwnActiveRunStatus,
   agentRunFrameGroups,
-  assistantMessageExpansionSignature,
   buildCachedChatItems,
   collectToolTitleCandidates,
   coalesceAgentRunFrames,
   coalesceActivityRuns,
   coalesceStreamRuns,
   collapseCompletedTurnWork,
+  deleteExpansionState,
   getExpansionStateVersion,
   getExpandedToolCards,
   getExpandedUserMessages,
@@ -171,7 +171,7 @@ export function projectChatTranscript(
     );
     for (const key of expandedAssistantMessages.keys()) {
       if (!retainedKeys.has(key)) {
-        expandedAssistantMessages.delete(key);
+        deleteExpansionState(expandedAssistantMessages, key);
       }
     }
   }
@@ -195,7 +195,7 @@ export function projectChatTranscript(
     }
     const revision = (current?.revision ?? 0) + 1;
     const pending = { status: "loading", revision } as const;
-    expandedAssistantMessages.set(key, pending);
+    setExpansionState(expandedAssistantMessages, key, pending);
     requestUpdate();
     const completeLoad = (result: Awaited<ReturnType<typeof loader>>) => {
       // A reset or source replacement can reuse both message id and revision.
@@ -207,7 +207,8 @@ export function projectChatTranscript(
         result?.ok && result.message && typeof result.message === "object"
           ? extractTextCached(result.message)
           : null;
-      expandedAssistantMessages.set(
+      setExpansionState(
+        expandedAssistantMessages,
         key,
         markdown === null
           ? { status: "error", revision: revision + 1 }
@@ -603,7 +604,8 @@ export function projectChatTranscript(
     getExpansionStateVersion(expandedToolCards),
     expandedUserMessages,
     getExpansionStateVersion(expandedUserMessages),
-    assistantMessageExpansionSignature(expandedAssistantMessages),
+    expandedAssistantMessages,
+    getExpansionStateVersion(expandedAssistantMessages),
     getChatMediaRenderVersion(),
     // The host minute poll requests an update; this key crosses row guard() memoization.
     Math.floor(Date.now() / 60_000),

--- a/ui/src/pages/chat/components/chat-transcript-recovery.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-recovery.test.ts
@@ -35,6 +35,7 @@ function fullMessage(content: string): FullMessageResult {
 
 class RecoveryTranscriptElement extends LitElement {
   props: ChatThreadProps = threadProps("recovery-pane");
+  resetPresentationOnDisconnect = true;
   private readonly transcript = new ChatTranscriptController(this);
 
   override createRenderRoot() {
@@ -51,7 +52,9 @@ class RecoveryTranscriptElement extends LitElement {
 
   override disconnectedCallback() {
     // Match the pane-specific production reset before Lit disconnects controllers.
-    resetChatViewState(this.props.paneId);
+    if (this.resetPresentationOnDisconnect) {
+      resetChatViewState(this.props.paneId);
+    }
     super.disconnectedCallback();
   }
 }
@@ -109,14 +112,63 @@ describe("chat transcript full-message recovery", () => {
     expect(load).toHaveBeenCalledOnce();
   });
 
-  it("keeps the transport preview when full content is unavailable", async () => {
+  it("keeps the preview through bounded retries and recovers on manual retry", async () => {
     const load = vi.fn<SidebarFullMessageLoader>().mockRejectedValue(new Error("offline"));
     const pane = mountTranscript("recovery-unavailable", load);
     await vi.waitFor(() => expect(pane.textContent).toContain("Could not load the full message."));
+    expect(load).toHaveBeenCalledTimes(3);
     expect(pane.textContent).toContain("Preview");
     expect(pane.textContent).toContain("...(truncated)...");
     expect(pane.querySelector(".chat-message-disclosure__toggle")).toBeNull();
+
+    load.mockResolvedValue(fullMessage("Available after retry."));
+    expectDefined(
+      pane.querySelector<HTMLButtonElement>(".chat-message-load-error__retry"),
+      "full-message retry",
+    ).click();
+    await vi.waitFor(() => expect(pane.textContent).toContain("Available after retry."));
+    expect(load).toHaveBeenCalledTimes(4);
   });
+
+  it.each(["loading", "loaded"] as const)(
+    "retires %s recovery when the same Lit controller reconnects",
+    async (phase) => {
+      const retired = createDeferred<FullMessageResult>();
+      const current = createDeferred<FullMessageResult>();
+      const load = vi
+        .fn<SidebarFullMessageLoader>()
+        .mockImplementationOnce(() => retired.promise)
+        .mockImplementationOnce(() => current.promise);
+      const pane = mountTranscript("recovery-reconnect", load);
+      await vi.waitFor(() => expect(load).toHaveBeenCalledOnce());
+      if (phase === "loaded") {
+        retired.resolve(fullMessage("Retired body."));
+        await vi.waitFor(() => expect(pane.textContent).toContain("Retired body."));
+      }
+
+      // Keep Lit's guarded rows and pane state so only the controller owns invalidation.
+      pane.resetPresentationOnDisconnect = false;
+      pane.remove();
+      document.body.append(pane);
+      pane.requestUpdate();
+      await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
+      await pane.updateComplete;
+      await flushDeferredRowPrune();
+      expect(pane.textContent).not.toContain("Retired body.");
+
+      if (phase === "loading") {
+        const updates = vi.spyOn(pane, "requestUpdate");
+        retired.resolve(fullMessage("Retired body."));
+        await flushDeferredRowPrune();
+        expect(updates).not.toHaveBeenCalled();
+        expect(pane.textContent).not.toContain("Retired body.");
+      }
+
+      current.resolve(fullMessage("Current body."));
+      await vi.waitFor(() => expect(pane.textContent).toContain("Current body."));
+      expect(load).toHaveBeenCalledTimes(2);
+    },
+  );
 
   it("retires a disconnected pane's bodies without invalidating a surviving split pane", async () => {
     const load = vi

--- a/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
+++ b/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
@@ -54,7 +54,7 @@ import {
 } from "./chat-transcript-session.ts";
 
 export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscriptSession {
-  readonly expandedAssistantMessages = new Map<string, AssistantMessageExpansionState>();
+  expandedAssistantMessages = new Map<string, AssistantMessageExpansionState>();
   private readonly controllers = new Set<ReactiveController>();
   private readonly virtualizerController: VirtualizerController<HTMLDivElement, HTMLElement>;
   private threadInnerElement: HTMLDivElement | null = null;
@@ -355,9 +355,10 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
   }
 
   disconnect(): void {
-    // Full bodies belong to this presentation, not the session-key cache.
-    // Clearing also retires pending loads before this owner can reconnect.
+    // Clear retires bodies and pending loads; replacement invalidates guarded
+    // rows when this presentation reconnects with the same source messages.
     this.expandedAssistantMessages.clear();
+    this.expandedAssistantMessages = new Map();
     this.scrollCommand = null;
     if (this.pendingRowMeasureFrame !== null) {
       cancelAnimationFrame(this.pendingRowMeasureFrame);


### PR DESCRIPTION
Related: #135326

## What Problem This Solves

Maintainer-requested cleanup around the large-transcript memory work. Session reads and full-message recovery had overlapping representations and cache bookkeeping that made their ownership harder to maintain.

## Why This Change Was Made

Use the active SQLite projection's canonical type, row parser, and generation reader across transcript readers. Usage and previews consume the raw payloads they actually need, removing redundant metadata projection and the private visitor's ignored options. Reset-window validity now lives only on its cache entry.

Control UI recovery reuses the existing map-version mechanism instead of sorting and joining a signature on each render. Disconnect clears the captured map before replacing it: the clear fences pending completions, while the new identity invalidates guarded rows on reconnect. Per-message revisions retain their existing retry budget.

The CLI login fixture also uses a checked view of the optional TTY property it temporarily owns, avoiding a type assertion while retaining exact descriptor restoration and typed deletion.

## User Impact

No intended behavior change. Streaming scans remain inside the SQLite read snapshot, full-message recovery keeps its three automatic attempts plus manual retry, and recovered bodies remain owned by the presentation that uses them. Cursor/reset semantics, display metadata, config, and persistent storage are unchanged.

## Evidence

- **464 tests passed across 15 files**, covering active/history/byte-size readers, reset/compaction markers, visitor and parse failure cleanup, usage/previews, artifact RPCs, MCP reconstruction, and UI recovery/render invalidation. Added same-controller reconnect coverage for both pending and loaded messages, and exercised automatic retry exhaustion followed by manual recovery.
- **Full changed checks passed**, including core/test/UI typechecks, formatting, lint, unused exports, database guards, and runtime import cycles. Fresh Codex review was scoped-clean at the configured P0 threshold.
- **CI regression reproduced and repaired:** the exact core test-type stripe failed with TS2790 before the fixture repair and passed afterward. Another 133 auth/CLI tests passed, including the real registered login command. After #135407 independently fixed the same fixture on `main`, the required rebase retained this branch's checked property view. All 51 focused artifact/auth integration tests passed again on the refreshed candidate.
- **Runtime and Control UI builds passed** on Node 24.19.0. The built UI passed its asset-budget checks.
- **Real Gateway + Chromium replay:** 64 messages of roughly 400 KB each, all 64 full-message requests completed, then navigation through three other sessions and away from chat. Both before and after retained **0 large recovered bodies / 0 body bytes** after teardown; no browser errors. The before run used the retained #135326 build, whose affected production modules match this branch's base; the after run used the rebuilt candidate.
- **Six real CLI calls passed:** enriched session listing, bounded previews, a 25.6 MB transcript artifact scan, and artifact list/get/download. The downloaded synthetic file matched its original eight bytes. Separate reader probes preserved full usage totals of 64 input / 64 output and bounded-tail totals of 20 / 20, with three bounded previews.
- **Current-main integration verified:** rebased onto `ee9e22b5215`, including main's attachment-only reply fix. All core reader production files and PR test files remain byte-identical to the preceding candidate. **125 focused tests in seven files and four real-browser reply scenarios passed** on `e6c2c88f97e`; fresh Codex autoreview was scoped-clean at the configured P0 threshold. Earlier integration also rebuilt the Gateway and passed six real CLI calls using an artifact stored only in `openclawDisplayContent`; list/get/download returned the original eight bytes.

| Scope | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 119 | 266 | **−147** |
| Tests | 68 | 31 | +37 |
| Assertion baseline | 2 | 3 | −1 |
| Total | 189 | 300 | **−111** |

Before, with the memory fix already present:

![Before refactor: recovered full messages](https://github.com/user-attachments/assets/3450f30b-0247-4acd-8c3a-3b0469d2f562)

After:

![After refactor: recovered full messages](https://github.com/user-attachments/assets/6e401ad2-1a7a-4848-90af-78b8cd5976e9)

After leaving chat, with every chat pane disconnected:

![After refactor: chat panes disconnected](https://github.com/user-attachments/assets/47b87e0e-f8f9-4eb3-9629-b91210076784)

Recorded candidate replay:

https://github.com/user-attachments/assets/5601865e-9d0d-4fea-aeeb-7230af8c0253
