### PR TITLE
fix(doctor): explain workspace state conflicts

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -277,6 +277,15 @@ the container normally.
 
 `openclaw doctor --fix` is the only owner for persistent file-to-SQLite migrations. It validates and claims each recognized source, writes and verifies canonical rows, records a migration receipt, then removes the retired source. Runtime code does not perform lazy imports or fallback reads.
 
+When Doctor reports a conflict between canonical SQLite workspace setup state and
+a retained legacy setup file, inspect both records before choosing a source. If
+the legacy file is authoritative, rerun the repair with
+`openclaw doctor --fix --accept-legacy-workspace-state`. This option is repair-
+only, preserves the higher-priority recognized legacy source when multiple
+legacy files are present, verifies the resulting SQLite record, and removes
+only sources whose migration is verified. Without the option, Doctor preserves
+the canonical row and retained legacy source and exits with the conflict.
+
 Doctor reports interrupted auth-profile archive recovery even when no new migration remains or you decline another migration. If recovery cannot finish, its warning includes the failure cause and leaves the pending source for recovery; do not delete it to silence the warning.
 
 For malformed legacy `exec-approvals.json`, Doctor preserves the original bytes and reports the first validation problem, for example `agents entry #2.allowlist[1].lastUsedAt: expected a finite number`. Agent entries are numbered from 1 in JavaScript `Object.keys` order; allowlist indices start at 0. This can differ from JSON text order, especially for numeric keys. To locate entry #2 locally, use `Object.keys(JSON.parse(raw).agents)[1]`, where `raw` is the file contents. Diagnostics omit agent keys and policy values, and migration receipts contain no diagnostic detail. JSON syntax and invalid UTF-8 receive separate reasons.

--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -180,6 +180,28 @@ describe("registerMaintenanceCommands doctor action", () => {
     expect(options.repair).toBe(true);
   });
 
+  it("requires repair mode before accepting legacy workspace state", async () => {
+    await runMaintenanceCli(["doctor", "--accept-legacy-workspace-state"]);
+
+    expect(doctorCommand).not.toHaveBeenCalled();
+    expect(runtime.writeJson).toHaveBeenCalledWith(
+      jsonFailure("doctor --accept-legacy-workspace-state requires --repair or --fix."),
+    );
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).toHaveBeenCalledWith(2);
+  });
+
+  it("passes legacy workspace acceptance only with repair mode", async () => {
+    doctorCommand.mockResolvedValue(undefined);
+
+    await runMaintenanceCli(["doctor", "--accept-legacy-workspace-state", "--repair"]);
+
+    expect(doctorCommand).toHaveBeenCalledTimes(1);
+    const [, options] = commandCall(doctorCommand);
+    expect(options.acceptLegacyWorkspaceState).toBe(true);
+    expect(options.repair).toBe(true);
+  });
+
   it("passes session sqlite options to doctor command", async () => {
     doctorCommand.mockResolvedValue(undefined);
 

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -59,7 +59,7 @@ export function registerMaintenanceCommands(program: Command) {
     .option("--fix", "Apply recommended repairs (alias for --repair)", false)
     .option(
       "--accept-legacy-workspace-state",
-      "Use the legacy workspace setup state when it conflicts with SQLite",
+      "Use the legacy workspace setup state during --repair/--fix when it conflicts with SQLite",
       false,
     )
     .option("--force", "Apply aggressive repairs (overwrites custom service config)", false)
@@ -128,6 +128,16 @@ export function registerMaintenanceCommands(program: Command) {
           opts.json === true || (opts.lint === true && !process.stdout.isTTY),
         );
       }
+      if (
+        opts.acceptLegacyWorkspaceState === true &&
+        opts.repair !== true &&
+        opts.fix !== true
+      ) {
+        return exitDoctorError(
+          "doctor --accept-legacy-workspace-state requires --repair or --fix.",
+          opts.json === true || !process.stdout.isTTY,
+        );
+      }
       const jsonImpliesLint =
         opts.json === true &&
         opts.lint !== true &&
@@ -138,15 +148,13 @@ export function registerMaintenanceCommands(program: Command) {
       const mutationOption =
         opts.repair === true || opts.fix === true || opts.force === true
           ? "--repair, --fix, or --force"
-          : opts.acceptLegacyWorkspaceState === true
-            ? "--accept-legacy-workspace-state"
-            : opts.yes === true
-              ? "--yes"
-              : opts.generateGatewayToken === true
-                ? "--generate-gateway-token"
-                : typeof opts.sessionSqlite === "string"
-                  ? `--session-sqlite ${opts.sessionSqlite}`
-                  : undefined;
+          : opts.yes === true
+            ? "--yes"
+            : opts.generateGatewayToken === true
+              ? "--generate-gateway-token"
+              : typeof opts.sessionSqlite === "string"
+                ? `--session-sqlite ${opts.sessionSqlite}`
+                : undefined;
       if (lintMode && mutationOption) {
         return exitDoctorError(
           `doctor ${lintMode} runs read-only lint checks and cannot be combined with ${mutationOption}.`,

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -14,6 +14,7 @@ const STATE_SQLITE_CONFLICTING_OPTION_NAMES = [
   "workspaceSuggestions",
   "yes",
   "repair",
+  "acceptLegacyWorkspaceState",
   "fix",
   "force",
   "nonInteractive",
@@ -56,6 +57,11 @@ export function registerMaintenanceCommands(program: Command) {
     .option("--yes", "Accept defaults without prompting", false)
     .option("--repair", "Apply recommended repairs without prompting", false)
     .option("--fix", "Apply recommended repairs (alias for --repair)", false)
+    .option(
+      "--accept-legacy-workspace-state",
+      "Use the legacy workspace setup state when it conflicts with SQLite",
+      false,
+    )
     .option("--force", "Apply aggressive repairs (overwrites custom service config)", false)
     .option("--non-interactive", "Run without prompts (safe migrations only)", false)
     .option("--generate-gateway-token", "Generate and configure a gateway token", false)
@@ -132,13 +138,15 @@ export function registerMaintenanceCommands(program: Command) {
       const mutationOption =
         opts.repair === true || opts.fix === true || opts.force === true
           ? "--repair, --fix, or --force"
-          : opts.yes === true
-            ? "--yes"
-            : opts.generateGatewayToken === true
-              ? "--generate-gateway-token"
-              : typeof opts.sessionSqlite === "string"
-                ? `--session-sqlite ${opts.sessionSqlite}`
-                : undefined;
+          : opts.acceptLegacyWorkspaceState === true
+            ? "--accept-legacy-workspace-state"
+            : opts.yes === true
+              ? "--yes"
+              : opts.generateGatewayToken === true
+                ? "--generate-gateway-token"
+                : typeof opts.sessionSqlite === "string"
+                  ? `--session-sqlite ${opts.sessionSqlite}`
+                  : undefined;
       if (lintMode && mutationOption) {
         return exitDoctorError(
           `doctor ${lintMode} runs read-only lint checks and cannot be combined with ${mutationOption}.`,
@@ -183,6 +191,7 @@ export function registerMaintenanceCommands(program: Command) {
             workspaceSuggestions: opts.workspaceSuggestions,
             yes: Boolean(opts.yes),
             repair: Boolean(opts.repair) || Boolean(opts.fix),
+            acceptLegacyWorkspaceState: Boolean(opts.acceptLegacyWorkspaceState),
             force: Boolean(opts.force),
             nonInteractive: Boolean(opts.nonInteractive),
             generateGatewayToken: Boolean(opts.generateGatewayToken),

--- a/src/commands/doctor.types.ts
+++ b/src/commands/doctor.types.ts
@@ -5,6 +5,7 @@ export type DoctorOptions = {
   nonInteractive?: boolean;
   deep?: boolean;
   repair?: boolean;
+  acceptLegacyWorkspaceState?: boolean;
   force?: boolean;
   generateGatewayToken?: boolean;
   allowExec?: boolean;

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -323,8 +323,7 @@ async function runLegacyStateHealth(ctx: DoctorHealthFlowContext): Promise<void>
   const legacySessionSurfaces = prepareLegacySessionSurfaces({ config: ctx.cfg });
   const doctorOnlyStateMigrations =
     ctx.options.repair === true ||
-    ctx.options.yes === true ||
-    ctx.options.acceptLegacyWorkspaceState === true;
+    ctx.options.yes === true;
   const legacyState = await detectLegacyStateMigrations({
     cfg: ctx.cfg,
     ...(doctorOnlyStateMigrations ? { doctorOnlyStateMigrations: true } : {}),

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -321,7 +321,10 @@ async function runLegacyStateHealth(ctx: DoctorHealthFlowContext): Promise<void>
   await runCoreContributionHealth(ctx, ["core/doctor/removed-workspaces-state"]);
   const { prepareLegacySessionSurfaces } = await import("../plugins/legacy-session-surfaces.js");
   const legacySessionSurfaces = prepareLegacySessionSurfaces({ config: ctx.cfg });
-  const doctorOnlyStateMigrations = ctx.options.repair === true || ctx.options.yes === true;
+  const doctorOnlyStateMigrations =
+    ctx.options.repair === true ||
+    ctx.options.yes === true ||
+    ctx.options.acceptLegacyWorkspaceState === true;
   const legacyState = await detectLegacyStateMigrations({
     cfg: ctx.cfg,
     ...(doctorOnlyStateMigrations ? { doctorOnlyStateMigrations: true } : {}),
@@ -347,6 +350,7 @@ async function runLegacyStateHealth(ctx: DoctorHealthFlowContext): Promise<void>
         detected: legacyState,
         config: ctx.cfg,
         ...(doctorOnlyStateMigrations ? { doctorOnlyStateMigrations: true } : {}),
+        ...(ctx.options.acceptLegacyWorkspaceState ? { acceptLegacyWorkspaceState: true } : {}),
         recoverCorruptTargetStore: ctx.options.repair === true || ctx.options.yes === true,
         legacySessionSurfaces,
       });

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -872,6 +872,7 @@ type LegacyStateMigrationPlan = {
   pluginSessionStoreAgentIds?: readonly string[];
   recoverCorruptTargetStore?: boolean;
   doctorOnlyStateMigrations?: boolean;
+  acceptLegacyWorkspaceState?: boolean;
   skipAgentScopedMigrations?: boolean;
   legacySessionSurfaces: PreparedLegacySessionSurfaces;
 };
@@ -996,7 +997,14 @@ function buildLegacyStateMigrationSteps(
 
   const doctorFinalSteps: LegacyStateMigrationStep[] = isDoctor
     ? [
-        ownerStep(detected.workspace, migrateLegacyWorkspaceState),
+        finalStep(() =>
+          migrateLegacyWorkspaceState({
+            detected: detected.workspace,
+            env,
+            stateDir,
+            ...(params.acceptLegacyWorkspaceState ? { acceptLegacyWorkspaceState: true } : {}),
+          }),
+        ),
         ownerStep(detected.webPush, migrateLegacyWebPush),
         ownerStep(detected.nodeHost, migrateLegacyNodeHostConfig),
         ownerStep(detected.subagentRegistry, migrateLegacySubagentRegistry),
@@ -1103,6 +1111,7 @@ export async function runLegacyStateMigrations(params: {
   now?: () => number;
   recoverCorruptTargetStore?: boolean;
   doctorOnlyStateMigrations?: boolean;
+  acceptLegacyWorkspaceState?: boolean;
   legacySessionSurfaces: PreparedLegacySessionSurfaces;
 }): Promise<MigrationMessages> {
   const detected = params.detected;
@@ -1123,6 +1132,7 @@ export async function runLegacyStateMigrations(params: {
       now: params.now,
       recoverCorruptTargetStore: params.recoverCorruptTargetStore,
       doctorOnlyStateMigrations: params.doctorOnlyStateMigrations,
+      acceptLegacyWorkspaceState: params.acceptLegacyWorkspaceState,
       legacySessionSurfaces,
     }),
   );

--- a/src/infra/state-migrations.workspace-setup-store.ts
+++ b/src/infra/state-migrations.workspace-setup-store.ts
@@ -177,9 +177,11 @@ function canonicalFingerprint(value: unknown): string {
 function workspaceSetupConflictError(params: {
   source: LegacyWorkspaceStateSource;
   differences: string[];
+  conflictPath?: string;
 }): Error {
+  const sourcePath = params.conflictPath ?? params.source.sourcePath;
   return new Error(
-    `legacy workspace setup at ${params.source.sourcePath} conflicts with canonical SQLite state (${params.differences.join("; ")}). Canonical state was preserved and the legacy source remains in place, so workspace use stays blocked. Verify the canonical row, then move ${params.source.sourcePath} aside if it is stale and rerun Doctor.`,
+    `legacy workspace setup at ${sourcePath} conflicts with canonical SQLite state (${params.differences.join("; ")}). Canonical state was preserved and the legacy source remains in place, so workspace use stays blocked. Verify both records. If the legacy source is authoritative, rerun Doctor with --fix --accept-legacy-workspace-state; if it is stale, move ${sourcePath} aside and rerun Doctor.`,
   );
 }
 
@@ -353,6 +355,8 @@ export function importAndRecordReceipt(params: {
   parsed: ParsedSource;
   env: NodeJS.ProcessEnv;
   replaceRemovedReceipt?: boolean;
+  acceptLegacyWorkspaceState?: boolean;
+  conflictPath?: string;
 }): { sourceKey: string; imported: boolean } {
   const key = resolveWorkspaceMigrationSourceKey(params.source);
   const runId = `${key}:${params.snapshot.sha256.slice(0, 16)}`;
@@ -403,34 +407,22 @@ export function importAndRecordReceipt(params: {
                   ]
                 : []),
             ];
-            throw workspaceSetupConflictError({ source: params.source, differences });
-          }
-          const existingFingerprint = setupFingerprint({
-            workspacePath: existing.workspace_path,
-            bootstrapSeededAt: existing.bootstrap_seeded_at,
-            setupCompletedAt: existing.setup_completed_at,
-          });
-          const sourceBootstrapSeededAt = params.parsed.value.bootstrapSeededAt ?? null;
-          const sourceSetupCompletedAt = params.parsed.value.setupCompletedAt ?? null;
-          const coversSource =
-            (sourceBootstrapSeededAt === null ||
-              existing.bootstrap_seeded_at === sourceBootstrapSeededAt) &&
-            (sourceSetupCompletedAt === null ||
-              existing.setup_completed_at === sourceSetupCompletedAt);
-          const authority = findMigrationAuthority({
-            db,
-            kysely,
-            source: params.source,
-            fingerprint: existingFingerprint,
-          });
-          if (authority && params.source.priority < authority.priority) {
+            if (!params.acceptLegacyWorkspaceState) {
+              throw workspaceSetupConflictError({
+                source: params.source,
+                differences,
+                conflictPath: params.conflictPath,
+              });
+            }
             executeSqliteQuerySync(
               db,
               kysely
                 .updateTable("workspace_setup_state")
                 .set({
-                  bootstrap_seeded_at: sourceBootstrapSeededAt,
-                  setup_completed_at: sourceSetupCompletedAt,
+                  workspace_path: params.source.workspaceDir,
+                  version: WORKSPACE_SETUP_STATE_VERSION,
+                  bootstrap_seeded_at: params.parsed.value.bootstrapSeededAt ?? null,
+                  setup_completed_at: params.parsed.value.setupCompletedAt ?? null,
                   updated_at: now,
                 })
                 .where("workspace_key", "=", params.source.workspaceKey),
@@ -438,59 +430,119 @@ export function importAndRecordReceipt(params: {
             imported = true;
             resolution = "replaced";
             verifiedFingerprint = incomingFingerprint;
-          } else if (coversSource) {
-            resolution = "verified";
-            verifiedFingerprint = existingFingerprint;
-          } else if (!authority) {
-            const mergedBootstrapSeededAt = existing.bootstrap_seeded_at ?? sourceBootstrapSeededAt;
-            const mergedSetupCompletedAt = existing.setup_completed_at ?? sourceSetupCompletedAt;
-            const hasConflictingMilestone =
-              (sourceBootstrapSeededAt !== null &&
-                existing.bootstrap_seeded_at !== null &&
-                sourceBootstrapSeededAt !== existing.bootstrap_seeded_at) ||
-              (sourceSetupCompletedAt !== null &&
-                existing.setup_completed_at !== null &&
-                sourceSetupCompletedAt !== existing.setup_completed_at);
-            if (hasConflictingMilestone) {
-              const differences = [
-                ...(sourceBootstrapSeededAt !== null &&
-                existing.bootstrap_seeded_at !== null &&
-                sourceBootstrapSeededAt !== existing.bootstrap_seeded_at
-                  ? [
-                      `bootstrapSeededAt canonical=${JSON.stringify(existing.bootstrap_seeded_at)} legacy=${JSON.stringify(sourceBootstrapSeededAt)}`,
-                    ]
-                  : []),
-                ...(sourceSetupCompletedAt !== null &&
-                existing.setup_completed_at !== null &&
-                sourceSetupCompletedAt !== existing.setup_completed_at
-                  ? [
-                      `setupCompletedAt canonical=${JSON.stringify(existing.setup_completed_at)} legacy=${JSON.stringify(sourceSetupCompletedAt)}`,
-                    ]
-                  : []),
-              ];
-              throw workspaceSetupConflictError({ source: params.source, differences });
-            }
-            executeSqliteQuerySync(
-              db,
-              kysely
-                .updateTable("workspace_setup_state")
-                .set({
-                  bootstrap_seeded_at: mergedBootstrapSeededAt,
-                  setup_completed_at: mergedSetupCompletedAt,
-                  updated_at: now,
-                })
-                .where("workspace_key", "=", params.source.workspaceKey),
-            );
-            imported = true;
-            resolution = "merged";
-            verifiedFingerprint = setupFingerprint({
-              workspacePath: existing.workspace_path,
-              bootstrapSeededAt: mergedBootstrapSeededAt,
-              setupCompletedAt: mergedSetupCompletedAt,
-            });
           } else {
-            resolution = "superseded";
-            verifiedFingerprint = existingFingerprint;
+            const existingFingerprint = setupFingerprint({
+              workspacePath: existing.workspace_path,
+              bootstrapSeededAt: existing.bootstrap_seeded_at,
+              setupCompletedAt: existing.setup_completed_at,
+            });
+            const sourceBootstrapSeededAt = params.parsed.value.bootstrapSeededAt ?? null;
+            const sourceSetupCompletedAt = params.parsed.value.setupCompletedAt ?? null;
+            const coversSource =
+              (sourceBootstrapSeededAt === null ||
+                existing.bootstrap_seeded_at === sourceBootstrapSeededAt) &&
+              (sourceSetupCompletedAt === null ||
+                existing.setup_completed_at === sourceSetupCompletedAt);
+            const authority = findMigrationAuthority({
+              db,
+              kysely,
+              source: params.source,
+              fingerprint: existingFingerprint,
+            });
+            if (
+              params.acceptLegacyWorkspaceState ||
+              (authority && params.source.priority < authority.priority)
+            ) {
+              executeSqliteQuerySync(
+                db,
+                kysely
+                  .updateTable("workspace_setup_state")
+                  .set({
+                    bootstrap_seeded_at: sourceBootstrapSeededAt,
+                    setup_completed_at: sourceSetupCompletedAt,
+                    updated_at: now,
+                  })
+                  .where("workspace_key", "=", params.source.workspaceKey),
+              );
+              imported = true;
+              resolution = "replaced";
+              verifiedFingerprint = incomingFingerprint;
+            } else if (coversSource) {
+              resolution = "verified";
+              verifiedFingerprint = existingFingerprint;
+            } else if (!authority) {
+              const mergedBootstrapSeededAt =
+                existing.bootstrap_seeded_at ?? sourceBootstrapSeededAt;
+              const mergedSetupCompletedAt = existing.setup_completed_at ?? sourceSetupCompletedAt;
+              const hasConflictingMilestone =
+                (sourceBootstrapSeededAt !== null &&
+                  existing.bootstrap_seeded_at !== null &&
+                  sourceBootstrapSeededAt !== existing.bootstrap_seeded_at) ||
+                (sourceSetupCompletedAt !== null &&
+                  existing.setup_completed_at !== null &&
+                  sourceSetupCompletedAt !== existing.setup_completed_at);
+              if (hasConflictingMilestone) {
+                const differences = [
+                  ...(sourceBootstrapSeededAt !== null &&
+                  existing.bootstrap_seeded_at !== null &&
+                  sourceBootstrapSeededAt !== existing.bootstrap_seeded_at
+                    ? [
+                        `bootstrapSeededAt canonical=${JSON.stringify(existing.bootstrap_seeded_at)} legacy=${JSON.stringify(sourceBootstrapSeededAt)}`,
+                      ]
+                    : []),
+                  ...(sourceSetupCompletedAt !== null &&
+                  existing.setup_completed_at !== null &&
+                  sourceSetupCompletedAt !== existing.setup_completed_at
+                    ? [
+                        `setupCompletedAt canonical=${JSON.stringify(existing.setup_completed_at)} legacy=${JSON.stringify(sourceSetupCompletedAt)}`,
+                      ]
+                    : []),
+                ];
+                if (!params.acceptLegacyWorkspaceState) {
+                  throw workspaceSetupConflictError({
+                    source: params.source,
+                    differences,
+                    conflictPath: params.conflictPath,
+                  });
+                }
+                executeSqliteQuerySync(
+                  db,
+                  kysely
+                    .updateTable("workspace_setup_state")
+                    .set({
+                      bootstrap_seeded_at: sourceBootstrapSeededAt,
+                      setup_completed_at: sourceSetupCompletedAt,
+                      updated_at: now,
+                    })
+                    .where("workspace_key", "=", params.source.workspaceKey),
+                );
+                imported = true;
+                resolution = "replaced";
+                verifiedFingerprint = incomingFingerprint;
+              } else {
+                executeSqliteQuerySync(
+                  db,
+                  kysely
+                    .updateTable("workspace_setup_state")
+                    .set({
+                      bootstrap_seeded_at: mergedBootstrapSeededAt,
+                      setup_completed_at: mergedSetupCompletedAt,
+                      updated_at: now,
+                    })
+                    .where("workspace_key", "=", params.source.workspaceKey),
+                );
+                imported = true;
+                resolution = "merged";
+                verifiedFingerprint = setupFingerprint({
+                  workspacePath: existing.workspace_path,
+                  bootstrapSeededAt: mergedBootstrapSeededAt,
+                  setupCompletedAt: mergedSetupCompletedAt,
+                });
+              }
+            } else {
+              resolution = "superseded";
+              verifiedFingerprint = existingFingerprint;
+            }
           }
         } else {
           // Missing row, or an attestation-only merged row (NULL version) that
@@ -499,12 +551,15 @@ export function importAndRecordReceipt(params: {
             existing?.workspace_path != null &&
             existing.workspace_path !== params.source.workspaceDir
           ) {
-            throw workspaceSetupConflictError({
-              source: params.source,
-              differences: [
-                `workspace path canonical=${JSON.stringify(existing.workspace_path)} legacy=${JSON.stringify(params.source.workspaceDir)}`,
-              ],
-            });
+            if (!params.acceptLegacyWorkspaceState) {
+              throw workspaceSetupConflictError({
+                source: params.source,
+                differences: [
+                  `workspace path canonical=${JSON.stringify(existing.workspace_path)} legacy=${JSON.stringify(params.source.workspaceDir)}`,
+                ],
+                conflictPath: params.conflictPath,
+              });
+            }
           }
           const setupColumns = {
             workspace_path: params.source.workspaceDir,

--- a/src/infra/state-migrations.workspace-setup-store.ts
+++ b/src/infra/state-migrations.workspace-setup-store.ts
@@ -450,10 +450,10 @@ export function importAndRecordReceipt(params: {
               source: params.source,
               fingerprint: existingFingerprint,
             });
-            if (
-              params.acceptLegacyWorkspaceState ||
-              (authority && params.source.priority < authority.priority)
-            ) {
+            const shouldReplace = authority
+              ? params.source.priority < authority.priority
+              : params.acceptLegacyWorkspaceState;
+            if (shouldReplace) {
               executeSqliteQuerySync(
                 db,
                 kysely

--- a/src/infra/state-migrations.workspace-setup-store.ts
+++ b/src/infra/state-migrations.workspace-setup-store.ts
@@ -1,4 +1,5 @@
 // SQLite import and receipt semantics for retired workspace state.
+/* eslint-disable max-lines -- migration store keeps its transaction semantics together. */
 import { createHash } from "node:crypto";
 import { safeParseJsonRecord } from "@openclaw/normalization-core/json-coercion";
 import { LEGACY_WORKSPACE_ATTESTATION_HEADER } from "../agents/workspace-legacy-state.js";

--- a/src/infra/state-migrations.workspace-setup-store.ts
+++ b/src/infra/state-migrations.workspace-setup-store.ts
@@ -174,6 +174,15 @@ function canonicalFingerprint(value: unknown): string {
   return createHash("sha256").update(JSON.stringify(value)).digest("hex");
 }
 
+function workspaceSetupConflictError(params: {
+  source: LegacyWorkspaceStateSource;
+  differences: string[];
+}): Error {
+  return new Error(
+    `legacy workspace setup at ${params.source.sourcePath} conflicts with canonical SQLite state (${params.differences.join("; ")}). Canonical state was preserved and the legacy source remains in place, so workspace use stays blocked. Verify the canonical row, then move ${params.source.sourcePath} aside if it is stale and rerun Doctor.`,
+  );
+}
+
 function setupFingerprint(params: {
   workspacePath: string;
   bootstrapSeededAt: string | null;
@@ -382,7 +391,19 @@ export function importAndRecordReceipt(params: {
             existing.workspace_path !== params.source.workspaceDir ||
             existing.version !== WORKSPACE_SETUP_STATE_VERSION
           ) {
-            throw new Error("legacy workspace setup conflicts with canonical SQLite state");
+            const differences = [
+              ...(existing.workspace_path !== params.source.workspaceDir
+                ? [
+                    `workspace path canonical=${JSON.stringify(existing.workspace_path)} legacy=${JSON.stringify(params.source.workspaceDir)}`,
+                  ]
+                : []),
+              ...(existing.version !== WORKSPACE_SETUP_STATE_VERSION
+                ? [
+                    `version canonical=${String(existing.version)} legacy=${String(WORKSPACE_SETUP_STATE_VERSION)}`,
+                  ]
+                : []),
+            ];
+            throw workspaceSetupConflictError({ source: params.source, differences });
           }
           const existingFingerprint = setupFingerprint({
             workspacePath: existing.workspace_path,
@@ -431,7 +452,23 @@ export function importAndRecordReceipt(params: {
                 existing.setup_completed_at !== null &&
                 sourceSetupCompletedAt !== existing.setup_completed_at);
             if (hasConflictingMilestone) {
-              throw new Error("legacy workspace setup conflicts with canonical SQLite state");
+              const differences = [
+                ...(sourceBootstrapSeededAt !== null &&
+                existing.bootstrap_seeded_at !== null &&
+                sourceBootstrapSeededAt !== existing.bootstrap_seeded_at
+                  ? [
+                      `bootstrapSeededAt canonical=${JSON.stringify(existing.bootstrap_seeded_at)} legacy=${JSON.stringify(sourceBootstrapSeededAt)}`,
+                    ]
+                  : []),
+                ...(sourceSetupCompletedAt !== null &&
+                existing.setup_completed_at !== null &&
+                sourceSetupCompletedAt !== existing.setup_completed_at
+                  ? [
+                      `setupCompletedAt canonical=${JSON.stringify(existing.setup_completed_at)} legacy=${JSON.stringify(sourceSetupCompletedAt)}`,
+                    ]
+                  : []),
+              ];
+              throw workspaceSetupConflictError({ source: params.source, differences });
             }
             executeSqliteQuerySync(
               db,
@@ -462,7 +499,12 @@ export function importAndRecordReceipt(params: {
             existing?.workspace_path != null &&
             existing.workspace_path !== params.source.workspaceDir
           ) {
-            throw new Error("legacy workspace setup conflicts with canonical SQLite state");
+            throw workspaceSetupConflictError({
+              source: params.source,
+              differences: [
+                `workspace path canonical=${JSON.stringify(existing.workspace_path)} legacy=${JSON.stringify(params.source.workspaceDir)}`,
+              ],
+            });
           }
           const setupColumns = {
             workspace_path: params.source.workspaceDir,

--- a/src/infra/state-migrations.workspace-setup.precedence.test.ts
+++ b/src/infra/state-migrations.workspace-setup.precedence.test.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { migrateLegacyWorkspaceState } from "./state-migrations.workspace-setup.js";
+import { useWorkspaceMigrationTestFixture } from "./state-migrations.workspace-setup.test-support.js";
+
+describe("legacy workspace source precedence", () => {
+  const { detect, setup } = useWorkspaceMigrationTestFixture();
+
+  it("preserves the higher-priority setup source during legacy acceptance", async () => {
+    const context = setup();
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const rootPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
+    const nestedPath = path.join(context.workspaceDir, ".openclaw", "workspace-state.json");
+    const rootSeededAt = "2026-07-16T00:00:00.000Z";
+    const nestedSeededAt = "2026-07-14T00:00:00.000Z";
+    await fsp.mkdir(path.dirname(nestedPath), { recursive: true });
+    await fsp.writeFile(
+      rootPath,
+      JSON.stringify({ version: 1, bootstrapSeededAt: rootSeededAt }),
+      "utf8",
+    );
+    await fsp.writeFile(
+      nestedPath,
+      JSON.stringify({ version: 1, bootstrapSeededAt: nestedSeededAt }),
+      "utf8",
+    );
+
+    const result = await migrateLegacyWorkspaceState({
+      detected: detect(context),
+      env: context.env,
+      stateDir: context.stateDir,
+      acceptLegacyWorkspaceState: true,
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toContain("Migrated workspace setup state to SQLite.");
+    expect(fs.existsSync(rootPath)).toBe(false);
+    expect(fs.existsSync(nestedPath)).toBe(false);
+    expect(
+      openOpenClawStateDatabase({ env: context.env })
+        .db.prepare("SELECT bootstrap_seeded_at FROM workspace_setup_state WHERE workspace_key = ?")
+        .get(identity.workspaceKey),
+    ).toEqual({ bootstrap_seeded_at: rootSeededAt });
+  });
+});

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -848,6 +848,7 @@ describe("legacy workspace Doctor migration", () => {
       'bootstrapSeededAt canonical="2026-07-15T00:00:00.000Z" legacy="2026-07-16T00:00:00.000Z"',
     );
     expect(result.warnings[0]).toContain("move");
+    expect(result.warnings[0]).toContain("--accept-legacy-workspace-state");
     expect(fs.existsSync(setupPath)).toBe(true);
     expect(fs.existsSync(`${setupPath}.doctor-importing`)).toBe(false);
     expect(
@@ -855,6 +856,67 @@ describe("legacy workspace Doctor migration", () => {
         .prepare("SELECT bootstrap_seeded_at FROM workspace_setup_state WHERE workspace_key = ?")
         .get(identity.workspaceKey),
     ).toEqual({ bootstrap_seeded_at: "2026-07-15T00:00:00.000Z" });
+  });
+
+  it("explicitly accepts legacy setup state when the operator selects it", async () => {
+    const context = setup();
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const db = openOpenClawStateDatabase({ env: context.env }).db;
+    db.prepare(
+      `INSERT INTO workspace_setup_state (
+         workspace_key, workspace_path, version, bootstrap_seeded_at, setup_completed_at, updated_at
+       ) VALUES (?, ?, 1, ?, NULL, 1)`,
+    ).run(identity.workspaceKey, identity.workspacePath, "2026-07-15T00:00:00.000Z");
+    const setupPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
+    const legacySeededAt = "2026-07-16T00:00:00.000Z";
+    await fsp.writeFile(
+      setupPath,
+      JSON.stringify({ version: 1, bootstrapSeededAt: legacySeededAt }),
+      "utf8",
+    );
+
+    const result = await migrateLegacyWorkspaceState({
+      detected: detect(context),
+      env: context.env,
+      stateDir: context.stateDir,
+      acceptLegacyWorkspaceState: true,
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toContain("Migrated workspace setup state to SQLite.");
+    expect(fs.existsSync(setupPath)).toBe(false);
+    expect(
+      db
+        .prepare("SELECT bootstrap_seeded_at FROM workspace_setup_state WHERE workspace_key = ?")
+        .get(identity.workspaceKey),
+    ).toEqual({ bootstrap_seeded_at: legacySeededAt });
+  });
+
+  it("names a retained claim when a claimed setup source conflicts", async () => {
+    const context = setup();
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const db = openOpenClawStateDatabase({ env: context.env }).db;
+    db.prepare(
+      `INSERT INTO workspace_setup_state (
+         workspace_key, workspace_path, version, bootstrap_seeded_at, setup_completed_at, updated_at
+       ) VALUES (?, ?, 1, ?, NULL, 1)`,
+    ).run(identity.workspaceKey, identity.workspacePath, "2026-07-15T00:00:00.000Z");
+    const setupPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
+    const claimPath = `${setupPath}.doctor-importing`;
+    await fsp.writeFile(
+      claimPath,
+      JSON.stringify({ version: 1, bootstrapSeededAt: "2026-07-16T00:00:00.000Z" }),
+      "utf8",
+    );
+
+    const result = await migrate(context);
+
+    expect(result.warnings[0]).toContain(claimPath);
+    expect(result.warnings[0]).not.toContain(
+      `at ${setupPath} conflicts with canonical SQLite state`,
+    );
+    expect(fs.existsSync(claimPath)).toBe(true);
+    expect(fs.existsSync(setupPath)).toBe(false);
   });
 
   it("merges complementary legacy milestones into unowned SQLite setup state", async () => {

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -892,6 +892,43 @@ describe("legacy workspace Doctor migration", () => {
     ).toEqual({ bootstrap_seeded_at: legacySeededAt });
   });
 
+  it("preserves the higher-priority setup source during legacy acceptance", async () => {
+    const context = setup();
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const rootPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
+    const nestedPath = path.join(context.workspaceDir, ".openclaw", "workspace-state.json");
+    const rootSeededAt = "2026-07-16T00:00:00.000Z";
+    const nestedSeededAt = "2026-07-14T00:00:00.000Z";
+    await fsp.mkdir(path.dirname(nestedPath), { recursive: true });
+    await fsp.writeFile(
+      rootPath,
+      JSON.stringify({ version: 1, bootstrapSeededAt: rootSeededAt }),
+      "utf8",
+    );
+    await fsp.writeFile(
+      nestedPath,
+      JSON.stringify({ version: 1, bootstrapSeededAt: nestedSeededAt }),
+      "utf8",
+    );
+
+    const result = await migrateLegacyWorkspaceState({
+      detected: detect(context),
+      env: context.env,
+      stateDir: context.stateDir,
+      acceptLegacyWorkspaceState: true,
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toContain("Migrated workspace setup state to SQLite.");
+    expect(fs.existsSync(rootPath)).toBe(false);
+    expect(fs.existsSync(nestedPath)).toBe(false);
+    expect(
+      openOpenClawStateDatabase({ env: context.env })
+        .db.prepare("SELECT bootstrap_seeded_at FROM workspace_setup_state WHERE workspace_key = ?")
+        .get(identity.workspaceKey),
+    ).toEqual({ bootstrap_seeded_at: rootSeededAt });
+  });
+
   it("names a retained claim when a claimed setup source conflicts", async () => {
     const context = setup();
     const identity = resolveWorkspaceStateIdentity(context.workspaceDir);

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -843,6 +843,11 @@ describe("legacy workspace Doctor migration", () => {
     const result = await migrate(context);
 
     expect(result.warnings[0]).toContain("conflicts with canonical SQLite state");
+    expect(result.warnings[0]).toContain(setupPath);
+    expect(result.warnings[0]).toContain(
+      'bootstrapSeededAt canonical="2026-07-15T00:00:00.000Z" legacy="2026-07-16T00:00:00.000Z"',
+    );
+    expect(result.warnings[0]).toContain("move");
     expect(fs.existsSync(setupPath)).toBe(true);
     expect(fs.existsSync(`${setupPath}.doctor-importing`)).toBe(false);
     expect(

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -892,43 +892,6 @@ describe("legacy workspace Doctor migration", () => {
     ).toEqual({ bootstrap_seeded_at: legacySeededAt });
   });
 
-  it("preserves the higher-priority setup source during legacy acceptance", async () => {
-    const context = setup();
-    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
-    const rootPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
-    const nestedPath = path.join(context.workspaceDir, ".openclaw", "workspace-state.json");
-    const rootSeededAt = "2026-07-16T00:00:00.000Z";
-    const nestedSeededAt = "2026-07-14T00:00:00.000Z";
-    await fsp.mkdir(path.dirname(nestedPath), { recursive: true });
-    await fsp.writeFile(
-      rootPath,
-      JSON.stringify({ version: 1, bootstrapSeededAt: rootSeededAt }),
-      "utf8",
-    );
-    await fsp.writeFile(
-      nestedPath,
-      JSON.stringify({ version: 1, bootstrapSeededAt: nestedSeededAt }),
-      "utf8",
-    );
-
-    const result = await migrateLegacyWorkspaceState({
-      detected: detect(context),
-      env: context.env,
-      stateDir: context.stateDir,
-      acceptLegacyWorkspaceState: true,
-    });
-
-    expect(result.warnings).toEqual([]);
-    expect(result.changes).toContain("Migrated workspace setup state to SQLite.");
-    expect(fs.existsSync(rootPath)).toBe(false);
-    expect(fs.existsSync(nestedPath)).toBe(false);
-    expect(
-      openOpenClawStateDatabase({ env: context.env })
-        .db.prepare("SELECT bootstrap_seeded_at FROM workspace_setup_state WHERE workspace_key = ?")
-        .get(identity.workspaceKey),
-    ).toEqual({ bootstrap_seeded_at: rootSeededAt });
-  });
-
   it("names a retained claim when a claimed setup source conflicts", async () => {
     const context = setup();
     const identity = resolveWorkspaceStateIdentity(context.workspaceDir);

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -421,6 +421,7 @@ async function cleanupReceiptSource(params: {
 async function migrateOneSource(params: {
   source: LegacyWorkspaceStateSource;
   env: NodeJS.ProcessEnv;
+  acceptLegacyWorkspaceState?: boolean;
   beforeClaim?: (source: LegacyWorkspaceStateSource) => void;
   removeSource?: (sourcePath: string) => Promise<void> | void;
 }): Promise<MigrationMessages> {
@@ -513,6 +514,10 @@ async function migrateOneSource(params: {
         snapshot,
         parsed,
         env: params.env,
+        ...(params.acceptLegacyWorkspaceState ? { acceptLegacyWorkspaceState: true } : {}),
+        conflictPath: hasSource
+          ? params.source.sourcePath
+          : `${params.source.sourcePath}${CLAIM_SUFFIX}`,
         replaceRemovedReceipt: receipt?.removedSource === true,
       });
     }
@@ -568,6 +573,7 @@ export async function migrateLegacyWorkspaceState(params: {
   detected?: LegacyWorkspaceStateDetection;
   stateDir: string;
   env?: NodeJS.ProcessEnv;
+  acceptLegacyWorkspaceState?: boolean;
   beforeClaim?: (source: LegacyWorkspaceStateSource) => void;
   removeSource?: (sourcePath: string) => Promise<void> | void;
 }): Promise<MigrationMessages> {
@@ -589,6 +595,7 @@ export async function migrateLegacyWorkspaceState(params: {
         const result = await migrateOneSource({
           source,
           env,
+          ...(params.acceptLegacyWorkspaceState ? { acceptLegacyWorkspaceState: true } : {}),
           ...(params.beforeClaim ? { beforeClaim: params.beforeClaim } : {}),
           ...(params.removeSource ? { removeSource: params.removeSource } : {}),
         });


### PR DESCRIPTION
## What Problem This Solves

Addresses the unresolved workspace-state conflict diagnostic and recovery path from #134331. Doctor remains fail-closed by default while allowing an operator who has verified the legacy record to explicitly select it.

## Implementation

`openclaw doctor --fix --accept-legacy-workspace-state` imports the validated legacy workspace setup state, verifies the resulting SQLite fingerprint, records the replacement receipt, and removes only the verified retired source. The option is repair-only; a bare or read-only Doctor invocation cannot activate migration.

Legacy source precedence is preserved during acceptance: a lower-priority nested source can no longer overwrite an already accepted higher-priority root source before both files are removed. Documentation now describes the explicit command, its repair-only guard, and the fail-closed default.

## Evidence

- Exact pushed head: `d6940c8193998c77d72f7fb6f9aee54a2d1c6337`.
- Focused workspace migration suites on this head: `src/infra/state-migrations.workspace-setup.test.ts` and `src/infra/state-migrations.workspace-setup.precedence.test.ts` — 36/36 passed.
- The new regression test seeds newer higher-priority root state and older nested state, enables explicit legacy acceptance, and proves SQLite retains the higher-priority record while both verified source files are removed.
- Existing migration coverage continues to verify default conflict preservation, explicit legacy-wins behavior, `.doctor-importing` claim reporting, cleanup receipts, and the repair-only option guard.
- `docs/cli/doctor.md` documents `--accept-legacy-workspace-state` and its safety boundary.
- Targeted formatting and `git diff --check` passed.

The full real disposable CLI conflict fixture was previously exercised on the predecessor implementation head; this update’s new source regression specifically covers the remaining precedence defect. Broader CI remains authoritative for the full Doctor matrix.
