### PR TITLE
fix(tools): release terminal summaries after nested calls settle

### DIFF
--- a/src/agents/agent-tools.before-tool-call.diagnostics.ts
+++ b/src/agents/agent-tools.before-tool-call.diagnostics.ts
@@ -63,59 +63,68 @@ const MAX_PENDING_TERMINAL_PRESENTATIONS = 1024;
 const LOOP_WARNING_BUCKET_SIZE = 10;
 const MAX_LOOP_WARNING_KEYS = 256;
 const MAX_TERMINAL_PRESENTATION_CHARS = 2_000;
-const pendingTerminalPresentationByToolCall = new Map<
-  string,
-  {
-    observer: ToolOutcomeObserver;
-    tool: AnyAgentTool;
-    toolParams: unknown;
-    toolCallOrdinal?: number;
-  }
->();
+type ToolTerminalPresentationProjector = (
+  result: Awaited<ReturnType<AnyAgentTool["execute"]>>,
+) => string | undefined;
+type PreparedToolTerminalPresentation = {
+  observer?: ToolOutcomeObserver;
+  toolName: string;
+  project?: ToolTerminalPresentationProjector;
+  toolCallOrdinal?: number;
+};
+const pendingTerminalPresentationByToolCall = new Map<string, PreparedToolTerminalPresentation>();
 
-export function resolveToolTerminalPresentation(params: {
-  tool: AnyAgentTool;
-  toolParams: unknown;
-  result: Awaited<ReturnType<AnyAgentTool["execute"]>>;
-}): string | undefined {
-  try {
-    const presentationTool = getBeforeToolCallSourceTool(params.tool) ?? params.tool;
-    const text = getToolTerminalPresentation(presentationTool)?.(
-      params.toolParams,
-      params.result,
-    )?.text.trim();
-    if (!text) {
-      return undefined;
-    }
-    return truncateUtf16Safe(redactToolDetail(text), MAX_TERMINAL_PRESENTATION_CHARS);
-  } catch (err) {
-    log.warn(
-      `terminal tool presentation failed: tool=${params.tool.name || "tool"} error=${String(err)}`,
-    );
-    return undefined;
-  }
-}
-
-export function rememberPendingTerminalPresentation(params: {
+export function prepareToolTerminalPresentation({
+  ctx,
+  tool,
+  toolParams,
+  toolCallId,
+  toolCallOrdinal,
+}: {
   ctx?: HookContext;
   tool: AnyAgentTool;
   toolParams: unknown;
   toolCallId?: string;
   toolCallOrdinal?: number;
-}): void {
-  if (!params.toolCallId || !params.ctx?.onToolOutcome) {
+}): PreparedToolTerminalPresentation | undefined {
+  const toolName = tool.name;
+  const observer = toolCallId ? ctx?.onToolOutcome : undefined;
+  const formatter = getToolTerminalPresentation(getBeforeToolCallSourceTool(tool) ?? tool);
+  if (!formatter && !observer) {
+    return undefined;
+  }
+  let project: ToolTerminalPresentationProjector | undefined;
+  if (formatter) {
+    // Retain isolated formatter inputs, not the executable tool or its hook context.
+    const formatterParams = observer ? structuredClone(toolParams) : toolParams;
+    project = (result) => {
+      try {
+        const text = formatter(formatterParams, result)?.text.trim();
+        return text
+          ? truncateUtf16Safe(redactToolDetail(text), MAX_TERMINAL_PRESENTATION_CHARS)
+          : undefined;
+      } catch (err) {
+        log.warn(
+          `terminal tool presentation failed: tool=${toolName || "tool"} error=${String(err)}`,
+        );
+        return undefined;
+      }
+    };
+  }
+  return { observer, toolName, project, toolCallOrdinal };
+}
+
+export function rememberPendingTerminalPresentation(
+  prepared: PreparedToolTerminalPresentation | undefined,
+  runId: string | undefined,
+  toolCallId: string | undefined,
+): void {
+  if (!prepared?.observer || !toolCallId) {
     return;
   }
-  const key = buildAdjustedParamsKey({
-    runId: params.ctx.runId,
-    toolCallId: params.toolCallId,
-  });
-  pendingTerminalPresentationByToolCall.set(key, {
-    observer: params.ctx.onToolOutcome,
-    tool: params.tool,
-    toolParams: structuredClone(params.toolParams),
-    toolCallOrdinal: params.toolCallOrdinal,
-  });
+  // Publish after raw observation succeeds so failed observers own no pending result.
+  const key = buildAdjustedParamsKey({ runId, toolCallId });
+  pendingTerminalPresentationByToolCall.set(key, prepared);
   pruneMapToMaxSize(pendingTerminalPresentationByToolCall, MAX_PENDING_TERMINAL_PRESENTATIONS);
 }
 
@@ -141,19 +150,11 @@ export function finalizeToolTerminalPresentation(params: {
   }
   const toolCallOrdinal = pending?.toolCallOrdinal ?? params.toolCallOrdinal;
   observer({
-    toolName: pending?.tool.name || params.toolName || "tool",
+    toolName: pending?.toolName || params.toolName || "tool",
     argsHash: "",
     resultHash: "",
     ...(toolCallOrdinal !== undefined ? { toolCallOrdinal } : {}),
-    terminalPresentation: params.isError
-      ? undefined
-      : pending
-        ? resolveToolTerminalPresentation({
-            tool: pending.tool,
-            toolParams: pending.toolParams,
-            result: params.result,
-          })
-        : undefined,
+    terminalPresentation: params.isError ? undefined : pending?.project?.(params.result),
     presentationOnly: true,
   });
 }

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -1766,47 +1766,99 @@ describe("before_tool_call hook deduplication (#15502)", () => {
     expect(beforeToolCallHook).toHaveBeenCalledTimes(1);
   });
 
-  it("emits a tool-authored terminal presentation with the recorded outcome", async () => {
+  it("isolates terminal presentation arguments while using the final middleware result", async () => {
     const onToolOutcome = vi.fn();
+    let executedParams: { request: { url: string } } | undefined;
     const sourceTool = setToolTerminalPresentation(
       asAgentTool({
         name: "web_fetch",
         description: "fetch",
         parameters: {},
         resultContentSource: "network",
-        execute: vi.fn().mockResolvedValue({
-          content: [],
-          details: { status: 200 },
+        execute: vi.fn(async (_id, params: { request: { url: string } }) => {
+          executedParams = params;
+          return { content: [], details: { status: 200 } };
         }),
       }),
-      (_params, result) => ({
-        text: `Fetched with status ${(result.details as { status: number }).status}`,
-      }),
+      (params, result) => {
+        const url = (params as { request: { url: string } }).request.url;
+        return {
+          text: `Fetched ${url} with status ${(result.details as { status: number }).status}`,
+        };
+      },
     );
     const tool = expectDefined(
       wrapToolWithBeforeToolCallHook(
         normalizeToolParameters(sourceTool, { modelProvider: "openai" }),
         {
           sessionId: "session-terminal-presentation",
+          runId: "run-terminal-presentation",
           onToolOutcome,
         },
       ),
       "wrapToolWithBeforeToolCallHook( normalizeToolParameters(sourceTool, {... test invariant",
     );
     await tool.execute("call-terminal-presentation", {
-      url: "https://example.com",
+      request: { url: "https://example.com" },
     });
 
     expect(onToolOutcome).toHaveBeenCalledWith(
       expect.objectContaining({
         toolName: "web_fetch",
         resultContentSource: "network",
-        terminalPresentation: "Fetched with status 200",
+        terminalPresentation: "Fetched https://example.com with status 200",
+      }),
+    );
+
+    expectDefined(executedParams, "executed formatter arguments").request.url =
+      "https://changed.example";
+    finalizeToolTerminalPresentation({
+      toolCallId: "call-terminal-presentation",
+      runId: "run-terminal-presentation",
+      result: { content: [], details: { status: 201 } },
+      isError: false,
+    });
+    expect(onToolOutcome).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        presentationOnly: true,
+        terminalPresentation: "Fetched https://example.com with status 201",
       }),
     );
   });
 
-  it("keeps the later model-ordered result when parallel tools finish out of order", async () => {
+  it("does not publish terminal presentation state when raw outcome observation fails", async () => {
+    const observerError = new Error("observer failed");
+    const onToolOutcome = vi.fn(() => {
+      throw observerError;
+    });
+    const tool = wrapToolWithBeforeToolCallHook(
+      asAgentTool({
+        name: "read_file",
+        description: "read",
+        parameters: {},
+        execute: vi.fn().mockResolvedValue({ content: [], details: { ok: true } }),
+      }),
+      {
+        sessionId: "session-terminal-observer-error",
+        runId: "run-terminal-observer-error",
+        onToolOutcome,
+      },
+    );
+
+    await expect(tool.execute("call-terminal-observer-error", {})).rejects.toBe(observerError);
+    const callsBeforeFinalization = onToolOutcome.mock.calls.length;
+    expect(() =>
+      finalizeToolTerminalPresentation({
+        toolCallId: "call-terminal-observer-error",
+        runId: "run-terminal-observer-error",
+        result: { content: [], details: { ok: true } },
+        isError: false,
+      }),
+    ).not.toThrow();
+    expect(onToolOutcome).toHaveBeenCalledTimes(callsBeforeFinalization);
+  });
+
+  it("clears a prior summary for large uncloneable plain-tool input and fences stale finalizers", async () => {
     type ToolResult = { content: []; details: { ok?: boolean; status?: number } };
     let resolvePresentation!: (result: ToolResult) => void;
     let resolvePlain!: (result: ToolResult) => void;
@@ -1816,7 +1868,7 @@ describe("before_tool_call hook deduplication (#15502)", () => {
     const plainExecution = new Promise<ToolResult>((resolve) => {
       resolvePlain = resolve;
     });
-    let terminalPresentation: string | undefined;
+    let terminalPresentation: string | undefined = "Previous tool summary";
     let latestOrdinal = -1;
     const onToolOutcome = vi.fn(
       (outcome: { toolCallOrdinal?: number; terminalPresentation?: string }) => {
@@ -1847,12 +1899,19 @@ describe("before_tool_call hook deduplication (#15502)", () => {
       hookContext,
     );
     const plainTool = wrapToolWithBeforeToolCallHook(
-      asAgentTool({
-        name: "read_file",
-        description: "read",
-        parameters: {},
-        execute: vi.fn(() => plainExecution),
-      }),
+      {
+        ...asAgentTool({
+          name: "read_file",
+          description: "read",
+          parameters: {},
+          execute: vi.fn(() => plainExecution),
+        }),
+        // Tool-owned preparation can carry private, non-JSON execution state.
+        finalizeBeforeToolCallParams: () => ({
+          content: Array.from({ length: 16_384 }, (_, index) => index),
+          privateCallback: () => undefined,
+        }),
+      },
       hookContext,
     );
 

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -29,13 +29,13 @@ import {
   emitSkillUsedDiagnostic,
   emitToolBlockedSecurityEvent,
   findSkillUsageMatch,
+  prepareToolTerminalPresentation,
   reconcileLoopCallExecutionParams,
   recordLoopOutcome,
   rememberPendingTerminalPresentation,
   resolveToolDiagnosticIdentity,
   resolveToolErrorDiagnostic,
   resolveToolResultTerminalDiagnostic,
-  resolveToolTerminalPresentation,
   summarizeToolParams,
 } from "./agent-tools.before-tool-call.diagnostics.js";
 import {
@@ -553,10 +553,12 @@ export function wrapToolWithBeforeToolCallHook(
             : error;
         }
         const durationMs = Date.now() - startedAt;
-        const terminalPresentation = resolveToolTerminalPresentation({
+        const preparedTerminalPresentation = prepareToolTerminalPresentation({
+          ctx,
           tool,
           toolParams: executeParams,
-          result,
+          toolCallId,
+          toolCallOrdinal,
         });
         await recordLoopOutcome({
           ctx,
@@ -566,15 +568,12 @@ export function wrapToolWithBeforeToolCallHook(
           result,
           resultContentSource: tool.resultContentSource,
           toolCallOrdinal,
-          terminalPresentation,
+          terminalPresentation: preparedTerminalPresentation?.project?.(result),
         });
-        rememberPendingTerminalPresentation({
-          ctx,
-          tool,
-          toolParams: executeParams,
-          toolCallId,
-          toolCallOrdinal,
-        });
+        // A harness abort can settle before a cancellation-ignoring source returns.
+        if (!signal?.aborted) {
+          rememberPendingTerminalPresentation(preparedTerminalPresentation, ctx?.runId, toolCallId);
+        }
         const skillMatch = findSkillUsageMatch({
           toolName: normalizedToolName,
           toolParams: executeParams,

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -6,6 +6,7 @@ import {
 import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import { levenshteinDistance } from "../shared/levenshtein-distance.js";
 import {
+  finalizeToolTerminalPresentation,
   getBeforeToolCallFailureDisposition,
   isPreExecutionBlockedToolResult,
 } from "./agent-tools.before-tool-call.js";
@@ -14,6 +15,7 @@ import { getChannelAgentToolMeta } from "./channel-tool-metadata.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { isAgentToolReplaySafe } from "./tool-replay-safety.js";
 import {
+  isToolResultError,
   isTrustedToolExecutionPreflightError,
   protectNetworkToolExecutionError,
 } from "./tool-result-error.js";
@@ -670,22 +672,33 @@ export class ToolSearchRuntime {
         }
       }
     };
-    const result = validateInput
-      ? await runWithToolExecutionValidation(
-          toolCallId,
-          async (finalInput) => await assertCatalogInputMatchesSchema(entry, finalInput),
-          runExecution,
-        )
-      : await runExecution();
-    const acceptedResult = await acceptResultBeforeProjection(result);
-    if (options?.parentToolCallId) {
-      this.terminalTargetBatchByParent.set(
-        options.parentToolCallId,
-        this.terminalTargetBatchByParent.get(options.parentToolCallId) !== false &&
-          acceptedResult.terminate === true,
-      );
+    let acceptedResult: AgentToolResult<unknown> | undefined;
+    try {
+      const result = validateInput
+        ? await runWithToolExecutionValidation(
+            toolCallId,
+            async (finalInput) => await assertCatalogInputMatchesSchema(entry, finalInput),
+            runExecution,
+          )
+        : await runExecution();
+      acceptedResult = await acceptResultBeforeProjection(result);
+      if (options?.parentToolCallId) {
+        this.terminalTargetBatchByParent.set(
+          options.parentToolCallId,
+          this.terminalTargetBatchByParent.get(options.parentToolCallId) !== false &&
+            acceptedResult.terminate === true,
+        );
+      }
+      return { tool: compactToolSearchCatalogEntry(entry), result: acceptedResult };
+    } finally {
+      // Nested executors can reject after raw success; only outer acceptance owns the summary.
+      finalizeToolTerminalPresentation({
+        toolCallId,
+        runId: this.ctx.runId,
+        result: acceptedResult ?? { content: [] },
+        isError: acceptedResult === undefined || isToolResultError(acceptedResult),
+      });
     }
-    return { tool: compactToolSearchCatalogEntry(entry), result: acceptedResult };
   };
 
   telemetry() {

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -695,7 +695,7 @@ export class ToolSearchRuntime {
       finalizeToolTerminalPresentation({
         toolCallId,
         runId: this.ctx.runId,
-        result: acceptedResult ?? { content: [] },
+        result: acceptedResult ?? { content: [], details: undefined },
         isError: acceptedResult === undefined || isToolResultError(acceptedResult),
       });
     }

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -14,9 +14,11 @@ import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 import { materializeBundleMcpToolsForRun } from "./agent-bundle-mcp-materialize.js";
 import type { McpToolCatalog, SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
 import { toToolDefinitions } from "./agent-tool-definition-adapter.js";
-import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
+import { raceWithAbortSignal, wrapToolWithAbortSignal } from "./agent-tools.abort.js";
 import {
+  finalizeToolTerminalPresentation,
   isToolWrappedWithBeforeToolCallHook,
+  type ToolOutcomeObservation,
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
 import { resetAdjustedParamsByToolCallIdForTests } from "./agent-tools.before-tool-call.state.js";
@@ -48,6 +50,7 @@ import {
   type ToolSearchCatalogRef,
 } from "./tool-search.js";
 import { testing } from "./tool-search.test-support.js";
+import { setToolTerminalPresentation } from "./tool-terminal-presentation.js";
 import { jsonResult, type AnyAgentTool } from "./tools/common.js";
 import { createGatewayTool } from "./tools/gateway-tool.js";
 import { createOpenClawDelegateToolsForRun } from "./tools/openclaw-delegate-tool.js";
@@ -181,6 +184,45 @@ function mockCall(mock: { mock: { calls: unknown[][] } }, index = 0): unknown[] 
     throw new Error(`Expected mock call ${index}`);
   }
   return call;
+}
+
+function observedRuntimeFixture(params: {
+  name: string;
+  ordinal: number;
+  execute?: AnyAgentTool["execute"];
+  executeTool?: NonNullable<ConstructorParameters<typeof ToolSearchRuntime>[0]["executeTool"]>;
+  formatter?: Parameters<typeof setToolTerminalPresentation>[1];
+}) {
+  const catalogRef = createToolSearchCatalogRef();
+  const outcomes: ToolOutcomeObservation[] = [];
+  const runId = `run-${params.name}`;
+  const target = fakeTool(params.name, params.name);
+  if (params.execute) {
+    target.execute = params.execute;
+  }
+  if (params.formatter) {
+    setToolTerminalPresentation(target, params.formatter);
+  }
+  registerHeadlessToolSearchCatalog({
+    catalogRef,
+    tools: [target],
+    hookContext: {
+      runId,
+      sessionId: `session-${params.name}`,
+      onToolOutcome: (outcome) => outcomes.push(outcome),
+      allocateToolOutcomeOrdinal: () => params.ordinal,
+    },
+  });
+  const runtime = new ToolSearchRuntime(
+    {
+      catalogRef,
+      runId,
+      sessionId: `session-${params.name}`,
+      ...(params.executeTool ? { executeTool: params.executeTool } : {}),
+    },
+    resolveToolSearchConfig(),
+  );
+  return { outcomes, runId, runtime };
 }
 
 describe("Tool Search", () => {
@@ -1425,6 +1467,152 @@ describe("Tool Search", () => {
     const call = await runtime.call("orchard_empty_details");
     expect(Object.hasOwn(call.result, "details")).toBe(true);
     await expect(runtime.callValue("orchard_empty_details")).resolves.toBeUndefined();
+  });
+
+  it("finalizes a direct target once with its original model-call ordinal", async () => {
+    let toolCallId: string | undefined;
+    const fixture = observedRuntimeFixture({
+      name: "orchard_direct_terminal",
+      ordinal: 4,
+      execute: async (id) => {
+        toolCallId = id;
+        return jsonResult({ ok: true });
+      },
+    });
+
+    const call = await fixture.runtime.call("orchard_direct_terminal");
+
+    expect(fixture.outcomes).toHaveLength(2);
+    expect(fixture.outcomes[1]).toEqual(
+      expect.objectContaining({
+        toolCallOrdinal: 4,
+        terminalPresentation: undefined,
+        presentationOnly: true,
+      }),
+    );
+    finalizeToolTerminalPresentation({
+      toolCallId: expectDefined(toolCallId, "direct terminal tool call"),
+      runId: fixture.runId,
+      result: call.result,
+      isError: false,
+    });
+    expect(fixture.outcomes).toHaveLength(2);
+  });
+
+  it("formats the result accepted by a supplied executor", async () => {
+    const fixture = observedRuntimeFixture({
+      name: "orchard_accepted_terminal",
+      ordinal: 6,
+      execute: async () => jsonResult({ status: 200 }),
+      formatter: (_params, result) => ({
+        text: `Status ${(result.details as { status: number }).status}`,
+      }),
+      executeTool: async (params) => {
+        await params.tool.execute(params.toolCallId, params.input, params.signal, params.onUpdate);
+        return await params.acceptResultBeforeProjection(jsonResult({ status: 201 }));
+      },
+    });
+
+    await fixture.runtime.call("orchard_accepted_terminal");
+
+    expect(fixture.outcomes.map((outcome) => outcome.terminalPresentation)).toEqual([
+      "Status 200",
+      "Status 201",
+    ]);
+    expect(fixture.outcomes.map((outcome) => outcome.toolCallOrdinal)).toEqual([6, 6]);
+  });
+
+  it("clears a raw summary when a supplied executor rejects after source success", async () => {
+    const executorError = new Error("synthetic post-source rejection");
+    const fixture = observedRuntimeFixture({
+      name: "orchard_rejected_terminal",
+      ordinal: 8,
+      execute: async () => jsonResult({ ok: true }),
+      formatter: () => ({ text: "Source completed" }),
+      executeTool: async (params) => {
+        const raw = await params.tool.execute(
+          params.toolCallId,
+          params.input,
+          params.signal,
+          params.onUpdate,
+        );
+        await params.acceptResultBeforeProjection(raw);
+        throw executorError;
+      },
+    });
+
+    await expect(fixture.runtime.call("orchard_rejected_terminal")).rejects.toBe(executorError);
+    expect(fixture.outcomes).toHaveLength(2);
+    expect(fixture.outcomes[0]?.terminalPresentation).toBe("Source completed");
+    expect(fixture.outcomes[1]).toEqual(
+      expect.objectContaining({
+        toolCallOrdinal: 8,
+        terminalPresentation: undefined,
+        presentationOnly: true,
+      }),
+    );
+  });
+
+  it("does not publish terminal state after an aborted cancellation-ignoring source", async () => {
+    const sourceResult = jsonResult({ ok: true });
+    let resolveSource!: (result: typeof sourceResult) => void;
+    let notifySourceStarted!: () => void;
+    const sourceStarted = new Promise<void>((resolve) => {
+      notifySourceStarted = resolve;
+    });
+    const source = new Promise<typeof sourceResult>((resolve) => {
+      resolveSource = resolve;
+    });
+    let toolCallId: string | undefined;
+    let sourceCompletion: Promise<unknown> | undefined;
+    const fixture = observedRuntimeFixture({
+      name: "orchard_aborted_late_terminal",
+      ordinal: 13,
+      execute: async (id) => {
+        toolCallId = id;
+        notifySourceStarted();
+        return await source;
+      },
+      executeTool: async (params) => {
+        const execution = params.tool.execute(
+          params.toolCallId,
+          params.input,
+          params.signal,
+          params.onUpdate,
+        );
+        sourceCompletion = execution;
+        return await raceWithAbortSignal(
+          execution.then(params.acceptResultBeforeProjection),
+          expectDefined(params.signal, "abort-race signal"),
+        );
+      },
+    });
+    const controller = new AbortController();
+    const call = fixture.runtime.call(
+      "orchard_aborted_late_terminal",
+      {},
+      { signal: controller.signal },
+    );
+    await sourceStarted;
+    controller.abort();
+
+    await expect(call).rejects.toMatchObject({ name: "AbortError" });
+    expect(fixture.outcomes).toHaveLength(0);
+    resolveSource(sourceResult);
+    await expectDefined(sourceCompletion, "late source completion");
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(fixture.outcomes).toHaveLength(1);
+    expect(fixture.outcomes[0]?.toolCallOrdinal).toBe(13);
+
+    finalizeToolTerminalPresentation({
+      toolCallId: expectDefined(toolCallId, "aborted late terminal tool call"),
+      runId: fixture.runId,
+      result: sourceResult,
+      isError: false,
+    });
+    expect(fixture.outcomes).toHaveLength(1);
   });
 
   it("rejects final catalog details that drift from a declared output schema", async () => {

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -1508,7 +1508,13 @@ describe("Tool Search", () => {
         text: `Status ${(result.details as { status: number }).status}`,
       }),
       executeTool: async (params) => {
-        await params.tool.execute(params.toolCallId, params.input, params.signal, params.onUpdate);
+        await params.tool.execute(
+          params.toolCallId,
+          params.input,
+          params.signal,
+          params.onUpdate,
+          undefined as never,
+        );
         return await params.acceptResultBeforeProjection(jsonResult({ status: 201 }));
       },
     });
@@ -1535,6 +1541,7 @@ describe("Tool Search", () => {
           params.input,
           params.signal,
           params.onUpdate,
+          undefined as never,
         );
         await params.acceptResultBeforeProjection(raw);
         throw executorError;
@@ -1579,6 +1586,7 @@ describe("Tool Search", () => {
           params.input,
           params.signal,
           params.onUpdate,
+          undefined as never,
         );
         sourceCompletion = execution;
         return await raceWithAbortSignal(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a completed tool could fail while recording its terminal summary when private execution arguments could not be cloned. Completed nested Tool Search calls also retained their terminal observer, keeping run state reachable after settlement. Cancellation could finish cleanup before a slow tool returned and registered more retained state.

## Why This Change Was Made

Prepare terminal formatting once, snapshot arguments only when a formatter needs them, and retain only the observer metadata required to clear an older summary for plain tools. Publish after raw observation succeeds; consume the record at Tool Search's final result-acceptance boundary; prevent late publication after abort. Raw outcome recording, middleware results, redaction, text bounds and model-call ordering remain intact.

## User Impact

Plain tools complete successfully with private uncloneable arguments, and completed or cancelled nested calls release terminal presentation state. Later plain or failed calls clear older summaries without an out-of-order completion restoring stale text.

## Evidence

- Before the fix, the real wrapper regression threw `DataCloneError` after tool execution. The candidate passes all 75 before-tool-call integration cases.
- Four new Tool Search owner cases fail before the lifecycle repair and pass afterward: direct completion and at-most-once finalization; accepted replacement result; rejection after raw success; and a cancellation-ignoring late source. The complete Tool Search suite passes 148 tests, including after rebase onto current main. All 162 native Codex dynamic-tool checks pass; 68 embedded terminal/middleware checks also pass.
- Actual-owner retention proof shows a synthetic observer capture remaining reachable after completed Tool Search and catalog disposal before the fix, and becoming collectable afterward. Late explicit finalization becomes a no-op. The cancellation proof preserves the late raw observation while eliminating the late pending record.
- In a separate controlled 256-call plain-tool workload, cloned argument snapshots fall from 256 to zero and median retained heap falls from 33,670,928 to 78,112 bytes across three processes. This probe stubs logging/redaction/text truncation and is not a whole-Gateway measurement.
- Typed lint, isolated Codex autoreview and the full source build pass.
- Two isolated dev Gateways on this exact build each passed real OpenAI turns with `openai/gpt-5.6-luna`: the embedded runtime executed an HTTP-200 `web_fetch` followed by a successful file `read` within one Code Mode call; native Codex executed the same two tools directly. Durable history verifies the selected runtime, paired results, execution order and final response marker. Both Gateways exited cleanly. An earlier probe supplied an ambiguous test-file location and failed; it is excluded, and the successful probes specify the exact synthetic path.

Production: +93/-80, net +13 lines. Tests: +265/-18, net +247. The additional production lines establish the missing success/error/cancellation cleanup boundary; the obsolete unconditional snapshot and executable-tool retention paths are removed. No public protocol, configuration, dependency or persistence surface changes.

CI follow-up: hosted typechecking caught a missing required `details` field on the empty error-cleanup result. The field is now explicit; core typechecking and all 148 Tool Search tests pass after the correction. It is ignored on the error branch and does not change terminal behavior. Fresh exact-head CI is required.
