### PR TITLE
feat(browser): show attachOnly mode in status output

### DIFF
--- a/extensions/browser/src/cli/browser-cli-manage.test.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.test.ts
@@ -71,8 +71,42 @@ describe("browser manage output", () => {
     const output = lastRuntimeLog();
     expect(output).toContain("transport: chrome-mcp");
     expect(output).toContain("headless: false (default)");
+    expect(output).toContain("attachOnly: true");
     expect(output).not.toContain("cdpPort:");
     expect(output).not.toContain("cdpUrl:");
+  });
+
+  it("shows attachOnly: false in status output for managed browser profiles", async () => {
+    getBrowserManageCallBrowserRequestMock().mockImplementation(async (_opts: unknown, req) =>
+      req.path === "/"
+        ? {
+            enabled: true,
+            profile: "openclaw",
+            driver: "openclaw",
+            transport: "cdp",
+            running: true,
+            cdpReady: true,
+            cdpHttp: true,
+            pid: 4321,
+            cdpPort: 18800,
+            cdpUrl: "http://127.0.0.1:18800",
+            chosenBrowser: "chromium",
+            userDataDir: null,
+            color: "#00AA00",
+            headless: false,
+            headlessSource: "default",
+            noSandbox: false,
+            executablePath: null,
+            attachOnly: false,
+          }
+        : {},
+    );
+
+    const program = createBrowserManageProgram();
+    await program.parseAsync(["browser", "status"], { from: "user" });
+
+    const output = lastRuntimeLog();
+    expect(output).toContain("attachOnly: false");
   });
 
   it("shows configured userDataDir for existing-session status", async () => {

--- a/extensions/browser/src/cli/browser-cli-manage.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.ts
@@ -385,6 +385,7 @@ export function registerBrowserManageCommands(
             `headless: ${status.headless}${
               status.headlessSource ? ` (${status.headlessSource})` : ""
             }`,
+            `attachOnly: ${status.attachOnly}`,
             `profileColor: ${status.color}`,
             ...(status.graphics
               ? [`graphics: ${formatBrowserGraphicsSummary(status.graphics)}`]


### PR DESCRIPTION
Fixes #133179

This change adds `attachOnly: true|false` to the human-readable browser status output, so operators can see whether a profile is in attach-only mode.

Changes:
- Added `attachOnly: ${status.attachOnly}` to the status output in `extensions/browser/src/cli/browser-cli-manage.ts`
- Added two test assertions in `extensions/browser/src/cli/browser-cli-manage.test.ts`:
  - `expect(output).toContain("attachOnly: true")`
  - New test for `attachOnly: false` with mock data

Acceptance criteria:
- [x] Shows attachOnly: true|false in the default status output
- [x] Existing tests pass (21 pass with the new assertion)
- [x] No changes to browser profile configuration or defaults