### PR TITLE
fix(macos): avoid rebuilding speech recognizers between voice captures

### DIFF
--- a/apps/macos/Sources/OpenClaw/QuickChatDictation.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatDictation.swift
@@ -74,7 +74,7 @@ final class QuickChatDictation: @unchecked Sendable {
     typealias UpdateHandler = @MainActor @Sendable (Event) -> Void
 
     private let queue = DispatchQueue(label: "ai.openclaw.quickchat.dictation")
-    private var recognizer: SFSpeechRecognizer?
+    private var recognizerCache = SpeechRecognizerCache()
     private var audioEngine: AVAudioEngine?
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
@@ -106,15 +106,13 @@ final class QuickChatDictation: @unchecked Sendable {
         let sessionID = UUID()
         self.sessionID = sessionID
 
-        let recognizer = SFSpeechRecognizer(locale: Locale(identifier: Locale.current.identifier))
+        let recognizer = self.recognizerCache.recognizer(localeID: Locale.current.identifier)
         guard let recognizer, recognizer.isAvailable else {
             throw NSError(
                 domain: "QuickChatDictation",
                 code: 1,
                 userInfo: [NSLocalizedDescriptionKey: "Recognizer unavailable"])
         }
-        self.recognizer = recognizer
-
         let request = SFSpeechAudioBufferRecognitionRequest()
         SpeechRecognitionRequestPolicy.configureInteractiveTranscription(request)
         self.recognitionRequest = request
@@ -171,7 +169,6 @@ final class QuickChatDictation: @unchecked Sendable {
         self.recognitionTask?.cancel()
         self.recognitionTask = nil
         self.recognitionRequest = nil
-        self.recognizer = nil
         if self.audioEngine?.isRunning == true {
             self.audioEngine?.stop()
             self.audioEngine?.reset()

--- a/apps/macos/Sources/OpenClaw/SpeechRecognizerCache.swift
+++ b/apps/macos/Sources/OpenClaw/SpeechRecognizerCache.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Speech
+
+struct SpeechRecognizerCache {
+    private var cached: SFSpeechRecognizer?
+
+    mutating func recognizer(localeID: String?) -> SFSpeechRecognizer? {
+        // Reuse explicit locale matches only: automatic or fallback dictation languages can change.
+        guard let localeID else { return SFSpeechRecognizer() }
+        let locale = Locale(identifier: localeID)
+        if self.cached?.locale != locale {
+            self.cached = SFSpeechRecognizer(locale: locale)
+        }
+        return self.cached
+    }
+}

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -50,7 +50,7 @@ actor TalkModeRuntime {
         }
     }
 
-    private var recognizer: SFSpeechRecognizer?
+    private var recognizerCache = SpeechRecognizerCache()
     private var audioEngine: AVAudioEngine?
     private var audioInputObserver: AudioInputDeviceObserver?
     private var activeInputResolution: AudioInputDeviceResolution?
@@ -319,9 +319,7 @@ actor TalkModeRuntime {
                 Locale.autoupdatingCurrent.identifier,
             ],
             supportedLocaleIDs: supportedLocaleIDs)
-        let recognizer = localeID
-            .map { SFSpeechRecognizer(locale: Locale(identifier: $0)) }
-            ?? SFSpeechRecognizer()
+        let recognizer = self.recognizerCache.recognizer(localeID: localeID)
         guard let recognizer, recognizer.isAvailable else {
             self.logger.error("talk recognizer unavailable")
             return false
@@ -355,7 +353,6 @@ actor TalkModeRuntime {
             },
             discard: { $0.discard() },
             publish: { preparedCapture in
-                self.recognizer = recognizer
                 self.recognitionRequest = preparedCapture.request
                 self.audioEngine = preparedCapture.engine
                 self.activeInputResolution = preparedCapture.activeInputResolution
@@ -418,7 +415,6 @@ actor TalkModeRuntime {
         self.audioEngine?.stop()
         self.audioEngine = nil
         self.activeInputResolution = nil
-        self.recognizer = nil
         self.rmsTask?.cancel()
         self.rmsTask = nil
     }

--- a/apps/macos/Sources/OpenClaw/VoicePushToTalk.swift
+++ b/apps/macos/Sources/OpenClaw/VoicePushToTalk.swift
@@ -109,13 +109,13 @@ final class VoicePushToTalkHotkey: @unchecked Sendable {
     }
 }
 
-/// Short-lived speech recognizer that records while the hotkey is held.
+/// Records speech while the hotkey is held.
 actor VoicePushToTalk {
     static let shared = VoicePushToTalk()
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "voicewake.ptt")
 
-    private var recognizer: SFSpeechRecognizer?
+    private var recognizerCache = SpeechRecognizerCache()
     // Lazily created on begin() to avoid creating an AVAudioEngine at app launch, which can switch Bluetooth
     // headphones into the low-quality headset profile even if push-to-talk is never used.
     private var audioEngine: AVAudioEngine?
@@ -228,8 +228,7 @@ actor VoicePushToTalk {
     // MARK: - Private
 
     private func startRecognition(localeID: String?, sessionID: UUID) async throws {
-        let locale = localeID.flatMap { Locale(identifier: $0) } ?? Locale(identifier: Locale.current.identifier)
-        self.recognizer = SFSpeechRecognizer(locale: locale)
+        let recognizer = self.recognizerCache.recognizer(localeID: localeID ?? Locale.current.identifier)
         guard let recognizer, recognizer.isAvailable else {
             throw NSError(
                 domain: "VoicePushToTalk",

--- a/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
@@ -26,7 +26,7 @@ actor VoiceWakeRuntime {
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "voicewake.runtime")
 
-    private var recognizer: SFSpeechRecognizer?
+    private var recognizerCache = SpeechRecognizerCache()
     // Lazily created on start to avoid creating an AVAudioEngine at app launch, which can switch Bluetooth
     // headphones into the low-quality headset profile even if Voice Wake is disabled.
     private var audioEngine: AVAudioEngine?
@@ -157,7 +157,7 @@ actor VoiceWakeRuntime {
             self.recognitionGeneration &+= 1
             let generation = self.recognitionGeneration
 
-            self.configureSession(localeID: config.localeID)
+            let recognizer = self.recognizerCache.recognizer(localeID: config.localeID ?? Locale.current.identifier)
 
             guard let recognizer, recognizer.isAvailable else {
                 self.logger.error("voicewake runtime: speech recognizer unavailable")
@@ -260,7 +260,6 @@ actor VoiceWakeRuntime {
         self.triggerOnlyTask?.cancel()
         self.triggerOnlyTask = nil
         self.haltRecognitionPipeline()
-        self.recognizer = nil
         self.currentConfig = nil
         self.activeTriggerEndTime = nil
         self.activeTriggerWord = nil
@@ -277,12 +276,6 @@ actor VoiceWakeRuntime {
                 VoiceWakeOverlayController.shared.dismiss()
             }
         }
-    }
-
-    private func configureSession(localeID: String?) {
-        let locale = localeID.flatMap { Locale(identifier: $0) } ?? Locale(identifier: Locale.current.identifier)
-        self.recognizer = SFSpeechRecognizer(locale: locale)
-        self.recognizer?.defaultTaskHint = .dictation
     }
 
     private func handleRecognition(_ update: RecognitionUpdate, config: RuntimeConfig) async {

--- a/apps/macos/Tests/OpenClawIPCTests/SpeechRecognizerCacheTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/SpeechRecognizerCacheTests.swift
@@ -1,0 +1,43 @@
+import Speech
+import Testing
+@testable import OpenClaw
+
+struct SpeechRecognizerCacheTests {
+    @Test func `repeated captures reuse one recognizer for the requested locale`() throws {
+        let localeID = try #require(SFSpeechRecognizer.supportedLocales().first?.identifier)
+        var cache = SpeechRecognizerCache()
+        let initial = cache.recognizer(localeID: localeID)
+        let first = try #require(initial)
+
+        for _ in 0..<40 {
+            #expect(cache.recognizer(localeID: localeID) === first)
+        }
+    }
+
+    @Test func `changing language replaces the recognizer and retains the new selection`() throws {
+        let localeIDs = SFSpeechRecognizer.supportedLocales().map(\.identifier).sorted()
+        try #require(localeIDs.count >= 2)
+        var cache = SpeechRecognizerCache()
+        let initial = cache.recognizer(localeID: localeIDs[0])
+        let first = try #require(initial)
+        let changed = cache.recognizer(localeID: localeIDs[1])
+        let second = try #require(changed)
+
+        #expect(first !== second)
+        #expect(second.locale.identifier == localeIDs[1])
+        #expect(cache.recognizer(localeID: localeIDs[1]) === second)
+    }
+
+    @Test func `automatic selection is resolved afresh for each capture`() throws {
+        let defaultRecognizer = try #require(SFSpeechRecognizer())
+        var cache = SpeechRecognizerCache()
+        let selected = cache.recognizer(localeID: defaultRecognizer.locale.identifier)
+        let explicit = try #require(selected)
+        let selectedDefault = cache.recognizer(localeID: nil)
+        let automatic = try #require(selectedDefault)
+
+        #expect(automatic !== explicit)
+        #expect(automatic.locale == defaultRecognizer.locale)
+        #expect(cache.recognizer(localeID: nil) !== automatic)
+    }
+}

--- a/docs/platforms/mac/voicewake.md
+++ b/docs/platforms/mac/voicewake.md
@@ -26,7 +26,7 @@ Voice Wake requires Apple Speech to support on-device recognition for the select
 - Hard stop: 120s (`captureHardStop`) to prevent runaway sessions.
 - Debounce between sessions: 350ms (`debounceAfterSend`) after a send.
 - The overlay is driven via `VoiceWakeOverlayController`, with committed/volatile text coloring.
-- After send, the recognizer restarts cleanly to listen for the next trigger.
+- After send, a fresh recognition task listens for the next trigger. Talk, Voice Wake, push-to-talk, and Quick Chat dictation reuse their recognizer while the selected language is unchanged; stopping capture still releases the microphone and cancels the task.
 
 ## Lifecycle invariants
 


### PR DESCRIPTION
Related: #133486. Supersedes the recognizer-lifetime implementation in #133487, with credit to @opspot-business.

## What Problem This Solves

Repeated native speech captures on macOS created another Apple speech recognizer each time, even when the language did not change. The report in #133486 traced sustained speech-service memory and CPU growth to an OpenClaw session and identified this repeated construction. This change removes that application-side churn; it does not establish that every cause of the reported 42 GB service growth is resolved.

## Why This Change Was Made

Talk, Voice Wake, push-to-talk, and Quick Chat dictation now retain one recognizer per runtime and replace it when the requested language changes. One shared acquisition path replaces the four constructors. The cache is the sole recognizer slot, rather than a second reference alongside the original field.

Only an explicit matching locale is reused. Automatic selection always uses Apple's default initializer again; a different fallback locale is likewise resolved again on the next capture, preserving system and keyboard-dictation language changes. Every capture still checks availability, creates a new request/task, and preserves its existing cancellation, stale-callback fencing, audio-tap removal, and engine cleanup. Voice Wake still requires on-device recognition. Its redundant recognizer task hint was removed because the shared request policy already sets dictation on each request.

## User Impact

Repeated voice captures avoid rebuilding the same recognizer. Changing languages still replaces it, and stopping a capture still releases the microphone. No new setting, dependency, model route, or storage change is introduced.

Production: +25/-24, net +1; tests: +43/-0. One shared cache replaces four constructor paths and removes duplicate Voice Wake request setup. The remaining line adds the explicit-language reuse boundary without new state beyond one retained recognizer per runtime.

## Evidence

- A Developer ID-signed native SDK probe replayed the exact original Talk construction expression: 40 requests produced 39 recognizer replacements. The same probe using the actual new cache produced zero replacements.
- Three Swift Testing cases passed against the actual Apple Speech SDK, covering repeated acquisition, language replacement, and fresh automatic selection. The original construction-expression replay failed the reuse invariant before editing, and the automatic-selection regression failed against the first cache implementation before its correction. With the final tests held constant, restoring unconditional construction failed two tests with 41 assertions; restoring the final cache passed all three tests.
- Independent Codex review found no actionable defects after correcting automatic-language reuse.
- The changed-file check passed its static gates, including SwiftLint with zero violations across 376 files. The broader local macOS installer suite hit a 120-second timeout in `never restores a CUA-bearing current elevation job after explicit recovery fails`; the run was stopped and is not counted as passing. The same installer suite and all three macOS script-test shards passed in hosted CI.
- The changed Swift owners passed parsing and the repository-pinned SwiftFormat/SwiftLint checks. Documentation formatting and whitespace checks passed.
- [CI on the exact PR head](https://github.com/openclaw/openclaw/actions/runs/33539830171/attempts/2) passed, including the release build, native app test job, all macOS script-test shards, and `openclaw/ci-gate`. The native app Swift Testing run passed 1,910 tests in 197 suites, including `SpeechRecognizerCacheTests`; OpenClawKit passed 1,547 Swift Testing tests. The first CI attempt was cancelled by a later skipped draft-event run; the retry passed without changing code.
- The SDK-only probe and tests do not use a microphone, an authenticated provider, or saved OpenClaw state. CI validates native application integration, not physical microphone capture or sustained speech-service memory.

The Apple SDK header and current documentation distinguish [the default and explicit locale initializers](https://developer.apple.com/documentation/speech/sfspeechrecognizer) and place cancellation on the recognition task. This repair preserves those boundaries. VoiceWakeTester already retains its recognizer; iOS has related allocation paths but no equivalent service-leak reproduction, so that remains a separate follow-up.

Physical microphone capture and a sustained before/after speech-service RSS/XPC trace have not been obtained. Speech permission was granted only to the isolated signed test app; no operator OpenClaw account state was used and global Siri/Dictation settings were left unchanged. The full native test launcher is restricted to disposable CI because it changes the test keychain, so it was not run on the operator desktop. The issue remains open for that end-to-end confirmation rather than treating factory reuse as proof that the full memory leak is fixed. The Talk allocation path is present in the original [Talk implementation](https://github.com/openclaw/openclaw/commit/20d7882033a00c44529e2b257e12b004ce2823c1): its per-capture start constructs a recognizer unconditionally. That commit was authored and committed by Peter Steinberger; no separate merge event has been established. The later locale-selection and realtime-relay changes retained that allocation behavior. This provenance establishes application-side allocation history, not the onset of the reported Apple service leak.


ClawSweeper follow-through: the exact-head macOS integration lane is green. A Developer ID-signed native harness compiled this commit's actual cache and request-policy source and exercised Apple's interactive Speech service with a synthetic audio fixture. It completed a transcript, cancelled the next task after receiving a non-final partial transcript, and immediately restarted and completed transcription on the same retained recognizer. Each phase created a new buffer request/task and released the previous request/task. The harness required both expected fixture words in the completed transcripts and failed on recognizer replacement, recognition errors, or timeout.

```text
speech_authorization=3
capture=1 final_transcript_matched=true reused=false
capture=2 partial_received=true cancel=true
capture=3 final_transcript_matched=true reused=true
PASS complete_cancel_restart; physical_microphone=false; on_device=false
```

The passive/on-device variant could not start on this host: Apple returned `kLSRErrorDomain:201`, “Siri and Dictation are disabled.” The interactive Talk policy above passed. This is real Apple Speech cancellation/restart proof using synthetic buffers, not physical microphone, complete app UI, passive Voice Wake, or sustained RSS proof. The exact-head native CI covers application integration; #133486 remains open for the longer memory investigation.
