### PR TITLE
refactor(gateway): centralize typed invalid request errors

### DIFF
--- a/src/gateway/server-methods/agents-workspace.ts
+++ b/src/gateway/server-methods/agents-workspace.ts
@@ -13,6 +13,7 @@ import {
 import { listAgentIds, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeAgentIdStrict } from "../../routing/session-key.js";
+import { typedInvalidRequest } from "./typed-invalid-request.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 import {
@@ -56,15 +57,6 @@ const SUPPORTED_IMAGE_MIME_TYPES = new Set([
   "image/webp",
 ]);
 
-function workspaceError(type: string, message: string, details?: Record<string, unknown>) {
-  return errorShape(ErrorCodes.INVALID_REQUEST, message, {
-    details: {
-      type,
-      ...details,
-    },
-  });
-}
-
 function resolveWorkspaceScopeOrRespond(
   params: { agentId: string; path?: string },
   cfg: OpenClawConfig,
@@ -87,7 +79,7 @@ function resolveWorkspaceScopeOrRespond(
     respond(
       false,
       undefined,
-      workspaceError("workspace_path_invalid", "path must be workspace-relative", {
+      typedInvalidRequest("workspace_path_invalid", "path must be workspace-relative", {
         path: rawPath,
       }),
     );
@@ -98,7 +90,7 @@ function resolveWorkspaceScopeOrRespond(
     respond(
       false,
       undefined,
-      workspaceError("workspace_path_invalid", "path escapes the agent workspace", {
+      typedInvalidRequest("workspace_path_invalid", "path escapes the agent workspace", {
         path: params.path ?? "",
       }),
     );
@@ -134,7 +126,7 @@ export const agentsWorkspaceHandlers: GatewayRequestHandlers = {
       respond(
         false,
         undefined,
-        workspaceError("workspace_path_not_found", "workspace directory not found", {
+        typedInvalidRequest("workspace_path_not_found", "workspace directory not found", {
           path: browserPath,
         }),
       );
@@ -185,7 +177,7 @@ export const agentsWorkspaceHandlers: GatewayRequestHandlers = {
       respond(
         false,
         undefined,
-        workspaceError("workspace_file_not_found", "workspace file not found", {
+        typedInvalidRequest("workspace_file_not_found", "workspace file not found", {
           path: browserPath,
         }),
       );
@@ -209,7 +201,7 @@ export const agentsWorkspaceHandlers: GatewayRequestHandlers = {
       respond(
         false,
         undefined,
-        workspaceError("workspace_file_too_large", "workspace file is too large to preview", {
+        typedInvalidRequest("workspace_file_too_large", "workspace file is too large to preview", {
           maxBytes,
           path: browserPath,
           size: stat.size,
@@ -225,7 +217,7 @@ export const agentsWorkspaceHandlers: GatewayRequestHandlers = {
       respond(
         false,
         undefined,
-        workspaceError(
+        typedInvalidRequest(
           "workspace_file_unsupported",
           "workspace file is not UTF-8 text or a supported image",
           { path: browserPath },

--- a/src/gateway/server-methods/artifacts-session-resolution.test.ts
+++ b/src/gateway/server-methods/artifacts-session-resolution.test.ts
@@ -78,7 +78,8 @@ describe("artifact session authorization", () => {
           throw new Error("expected incognito artifact selector to be denied");
         } catch (error) {
           expect(error).toBeInstanceOf(ArtifactSessionResolutionError);
-          expect((error as ArtifactSessionResolutionError).shape).toMatchObject({
+          expect((error as ArtifactSessionResolutionError).shape).toEqual({
+            code: "INVALID_REQUEST",
             message: "no session found for artifact query",
             details: { type: "artifact_scope_not_found" },
           });

--- a/src/gateway/server-methods/artifacts-session-resolution.ts
+++ b/src/gateway/server-methods/artifacts-session-resolution.ts
@@ -1,5 +1,5 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import type { ErrorShape } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolvePersistedSessionStoreOwnerForKey } from "../../config/sessions/session-store-owner.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -22,6 +22,7 @@ import {
   resolveSessionStoreAgentId,
   resolveStoredSessionKeyForAgentStore,
 } from "../session-store-key.js";
+import { typedInvalidRequest } from "./typed-invalid-request.js";
 import type { GatewayClient } from "./types.js";
 
 export type ArtifactQuery = {
@@ -157,7 +158,7 @@ function resolveQuerySession(
 }
 
 export class ArtifactSessionResolutionError extends Error {
-  constructor(readonly shape: ReturnType<typeof errorShape>) {
+  constructor(readonly shape: ErrorShape) {
     super(shape.message);
   }
 }
@@ -193,8 +194,6 @@ export function resolveAuthorizedArtifactSession(
   throw new ArtifactSessionResolutionError(
     query.sessionKey && error
       ? error
-      : errorShape(ErrorCodes.INVALID_REQUEST, "no session found for artifact query", {
-          details: { type: "artifact_scope_not_found" },
-        }),
+      : typedInvalidRequest("artifact_scope_not_found", "no session found for artifact query"),
   );
 }

--- a/src/gateway/server-methods/artifacts.ts
+++ b/src/gateway/server-methods/artifacts.ts
@@ -41,6 +41,7 @@ import {
   type ArtifactQuery,
   resolveAuthorizedArtifactSession,
 } from "./artifacts-session-resolution.js";
+import { typedInvalidRequest } from "./typed-invalid-request.js";
 import type { GatewayClient, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -71,15 +72,6 @@ function admitArtifactQuery<T extends ArtifactQuery>(
     return undefined;
   }
   return { ...query, agentId: owner.agentId };
-}
-
-function artifactError(type: string, message: string, details?: Record<string, unknown>) {
-  return errorShape(ErrorCodes.INVALID_REQUEST, message, {
-    details: {
-      type,
-      ...details,
-    },
-  });
 }
 
 function normalizeArtifactType(value: string): string {
@@ -367,7 +359,7 @@ function requireQueryable(params: ArtifactQuery, respond: RespondFn): boolean {
   respond(
     false,
     undefined,
-    artifactError(
+    typedInvalidRequest(
       "artifact_query_unsupported",
       "artifacts require one of sessionKey, runId, or taskId",
     ),
@@ -379,7 +371,7 @@ function respondArtifactNotFound(respond: RespondFn, requestedArtifactId: string
   respond(
     false,
     undefined,
-    artifactError("artifact_not_found", "artifact not found", {
+    typedInvalidRequest("artifact_not_found", "artifact not found", {
       artifactId: requestedArtifactId,
     }),
   );
@@ -450,7 +442,7 @@ export const artifactsHandlers: GatewayRequestHandlers = {
       respond(
         false,
         undefined,
-        artifactError("artifact_scope_not_found", "no session found for artifact query"),
+        typedInvalidRequest("artifact_scope_not_found", "no session found for artifact query"),
       );
       return;
     }
@@ -554,7 +546,7 @@ export const artifactsHandlers: GatewayRequestHandlers = {
       respond(
         false,
         undefined,
-        artifactError("artifact_download_unsupported", "artifact download is unsupported", {
+        typedInvalidRequest("artifact_download_unsupported", "artifact download is unsupported", {
           artifactId: artifact.id,
         }),
       );

--- a/src/gateway/server-methods/sessions-files.ts
+++ b/src/gateway/server-methods/sessions-files.ts
@@ -5,8 +5,6 @@ import { detectMime } from "@openclaw/media-core/mime";
 import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
-  ErrorCodes,
-  errorShape,
   isCloudWorkerPlacementState,
   type SessionFileBrowserEntry,
   type SessionFileBrowserResult,
@@ -42,6 +40,7 @@ import {
   resolveOpenPathCommand,
   sanitizePathForLog,
 } from "./open-path.js";
+import { typedInvalidRequest } from "./typed-invalid-request.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 import {
@@ -140,15 +139,6 @@ function writeTouchedFilesCache(key: string, entry: TouchedFilesCacheEntry): voi
   touchedFilesCache.delete(key);
   touchedFilesCache.set(key, entry);
   pruneMapToMaxSize(touchedFilesCache, TOUCHED_FILES_CACHE_LIMIT);
-}
-
-function sessionFilesError(type: string, message: string, details?: Record<string, unknown>) {
-  return errorShape(ErrorCodes.INVALID_REQUEST, message, {
-    details: {
-      type,
-      ...details,
-    },
-  });
 }
 
 function readPathArg(args: Record<string, unknown>): string | undefined {
@@ -833,7 +823,7 @@ function respondSessionFileNotFound(respond: RespondFn, filePath: string) {
   respond(
     false,
     undefined,
-    sessionFilesError("session_file_not_found", "session file not found", { path: filePath }),
+    typedInvalidRequest("session_file_not_found", "session file not found", { path: filePath }),
   );
 }
 
@@ -841,7 +831,7 @@ function respondSessionFileTooLarge(respond: RespondFn, file: SessionFileEntry, 
   respond(
     false,
     undefined,
-    sessionFilesError("session_file_too_large", "session file is too large to preview", {
+    typedInvalidRequest("session_file_too_large", "session file is too large to preview", {
       maxPreviewBytes: MAX_PREVIEW_BYTES,
       path: file.path || filePath,
       size: file.size,
@@ -853,7 +843,7 @@ function respondSessionFileUnsafe(respond: RespondFn, filePath: string) {
   respond(
     false,
     undefined,
-    sessionFilesError("session_file_unsafe", "session file could not be written safely", {
+    typedInvalidRequest("session_file_unsafe", "session file could not be written safely", {
       path: filePath,
     }),
   );
@@ -952,7 +942,7 @@ export const sessionsFilesHandlers: GatewayRequestHandlers = {
       respond(
         false,
         undefined,
-        sessionFilesError("session_file_too_large", "session file content is too large", {
+        typedInvalidRequest("session_file_too_large", "session file content is too large", {
           maxPreviewBytes: MAX_PREVIEW_BYTES,
           path: params.path,
           size: contentSize,
@@ -1012,7 +1002,7 @@ export const sessionsFilesHandlers: GatewayRequestHandlers = {
       respond(
         false,
         undefined,
-        sessionFilesError("session_file_conflict", "session file changed since it was read", {
+        typedInvalidRequest("session_file_conflict", "session file changed since it was read", {
           path: params.path,
           currentHash: update.currentHash,
         }),

--- a/src/gateway/server-methods/typed-invalid-request.ts
+++ b/src/gateway/server-methods/typed-invalid-request.ts
@@ -1,0 +1,18 @@
+import {
+  ErrorCodes,
+  errorShape,
+  type ErrorShape,
+} from "../../../packages/gateway-protocol/src/index.js";
+
+export function typedInvalidRequest(
+  type: string,
+  message: string,
+  details?: Record<string, unknown>,
+): ErrorShape {
+  return errorShape(ErrorCodes.INVALID_REQUEST, message, {
+    details: {
+      type,
+      ...details,
+    },
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

Gateway server methods had four copies of the same typed `INVALID_REQUEST` error construction. Keeping the error shape synchronized required editing multiple owners and made accidental response drift easier.

## Why This Change Was Made

Centralizes the private typed error constructor within Gateway server methods and migrates all 16 matching emissions. The helper preserves fresh objects and the existing `{ type, ...details }` ordering; protocol, SDK, schema, configuration, and public API surfaces are unchanged.

## User Impact

No user-visible behavior changes. Operators and clients receive the same error codes, messages, and structured details.

## Evidence

- Focused Gateway suites: 4 files, 104 tests passed.
- Lazy core handler boundary: 3 tests passed.
- Import-cycle guard: 0 runtime value cycles.
- Clean Blacksmith Testbox build passed: https://github.com/openclaw/openclaw/actions/runs/33536747709
- Exact-file Blacksmith Testbox `check:changed` passed on lease `tbx_01m1ezgwmrh00xa6m850a95edm`.
- Autoreview: scoped clean, no actionable findings, score 0.98.
- Production delta: +40/-49 (net -9). Tests: +2/-1.
