### PR TITLE
fix(feishu): detect "not exists" reply error and fall back to direct send

### DIFF
--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -482,4 +482,64 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
 
     expect(createMock).not.toHaveBeenCalled();
   });
+
+  it("falls back to create for 99992354 not-exists reply (fulfilled response)", async () => {
+    // Reproduction: Feishu's reply API returns feishu_code 99992354 with
+    // msg "... or not exists ..." when the supplied open_message_id does
+    // not resolve. The pre-fix classifier only matched "not found", so
+    // the error bubbled up and the agent response was never delivered.
+    // After the fix, code 99992354 is in WITHDRAWN_REPLY_ERROR_CODES and
+    // the msg also matches "not exists", so the reply path falls back
+    // to a direct create-message send.
+    replyMock.mockResolvedValue({
+      code: 99992354,
+      msg: "The request you send is not a valid {open_message_id} or not exists, ...",
+    });
+    createMock.mockResolvedValue({
+      code: 0,
+      data: { message_id: "om_99992354_fallback" },
+    });
+
+    await expectFallbackResult(
+      () =>
+        sendMessageFeishu({
+          cfg: {} as never,
+          to: "user:ou_target",
+          text: "hello",
+          replyToMessageId: "om_parent",
+        }),
+      "om_99992354_fallback",
+    );
+  });
+
+  it("falls back to create when reply throws a 99992354 not-exists AxiosError", async () => {
+    // Same as above, but via the thrown AxiosError shape: the SDK
+    // sometimes rejects before returning a fulfilled response, so the
+    // classifier must also recognize the code on err.response.data.
+    const axiosError = Object.assign(new Error("Request failed with status code 400"), {
+      response: {
+        status: 400,
+        data: {
+          code: 99992354,
+          msg: "The request you send is not a valid {open_message_id} or not exists, ...",
+        },
+      },
+    });
+    replyMock.mockRejectedValue(axiosError);
+    createMock.mockResolvedValue({
+      code: 0,
+      data: { message_id: "om_99992354_axios_fallback" },
+    });
+
+    await expectFallbackResult(
+      () =>
+        sendMessageFeishu({
+          cfg: {} as never,
+          to: "user:ou_target",
+          text: "hello",
+          replyToMessageId: "om_parent",
+        }),
+      "om_99992354_axios_fallback",
+    );
+  });
 });

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -27,13 +27,25 @@ import type { FeishuChatType, FeishuMessageInfo, FeishuSendResult } from "./type
 
 export { resolveFeishuCardTemplate };
 
-const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003]);
+// Feishu reply API error codes for "target is gone" — message withdrawn, deleted, or never existed.
+// Keep the set in sync with the Feishu Open Platform's reply/recall semantics.
+const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003, 99992354]);
 function shouldFallbackFromReplyTarget(response: { code?: number; msg?: string }): boolean {
   if (response.code !== undefined && WITHDRAWN_REPLY_ERROR_CODES.has(response.code)) {
     return true;
   }
   const msg = normalizeLowercaseStringOrEmpty(response.msg);
-  return msg.includes("withdrawn") || msg.includes("not found");
+  // Feishu's reply API returns different phrasings for "target is unavailable":
+  //   - "message has been withdrawn" (withdrawn)
+  //   - "message not found" (not found)
+  //   - "open_message_id ... or not exists" (not exists)
+  //   - "invalid message id" (invalid)
+  return (
+    msg.includes("withdrawn") ||
+    msg.includes("not found") ||
+    msg.includes("not exists") ||
+    msg.includes("invalid message id")
+  );
 }
 
 /** Check whether a thrown error indicates a withdrawn/not-found reply target. */


### PR DESCRIPTION
## Problem

When the Feishu reply target is gone (e.g. a session message id that does not resolve to a real `om_…` id), `sendReplyOrFallbackDirect` should fall back to a direct create-message send, but currently it throws.

## Root cause

`shouldFallbackFromReplyTarget` in `extensions/feishu/src/send.ts` only matches the substring `"not found"` in the API error message. Feishu's actual error for an unknown reply target is:

```
feishu_code: 99992354
msg: "The request you send is not a valid {open_message_id} or not exists, ..."
```

with the literal phrase `"not exists"` — which the current matcher does not include, so the fallback path is never taken and the error bubbles up.

## Fix

- Add `99992354` to `WITHDRAWN_REPLY_ERROR_CODES` so the code-based check catches it even before string matching.
- Broaden the message-based fallback to also match `"not exists"` and `"invalid message id"` so future phrasing variations are caught too.

## Reproduction

Trigger any send path that exercises the Feishu reply API with an id that is not a valid `open_message_id`. Observed response:

```
http_status: 400
feishu_code: 99992354
feishu_msg: "The request you send is not a valid {open_message_id} or not exists, ..."
```

Result: error bubbles up; the call does **not** fall back to `sendFallbackDirect`.

After this patch, the same reply response is detected by the code-based check (via `99992354`) and the call falls back to a direct `client.im.message.create`, succeeding.

## Risk

Low. Only widens the fallback condition; behavior on healthy replies (code 0) is unchanged.
