### PR TITLE
refactor(http): avoid discarded body buffers

### DIFF
--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -111,12 +111,6 @@ type RequestBodyLimitValues = {
   timeoutMs: number;
 };
 
-type RequestBodyChunkProgress = {
-  buffer: Buffer;
-  totalBytes: number;
-  exceeded: boolean;
-};
-
 function resolveRequestBodyLimitValues(options: {
   maxBytes: number;
   timeoutMs?: number;
@@ -133,20 +127,6 @@ function resolveRequestBodyLimitValues(options: {
 
 export const testApi = { resolveRequestBodyLimitValues };
 export { testApi as __test__ };
-
-function advanceRequestBodyChunk(
-  chunk: Buffer | string,
-  totalBytes: number,
-  maxBytes: number,
-): RequestBodyChunkProgress {
-  const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-  const nextTotalBytes = totalBytes + buffer.length;
-  return {
-    buffer,
-    totalBytes: nextTotalBytes,
-    exceeded: nextTotalBytes > maxBytes,
-  };
-}
 
 function stopRequestBodyAfterLimit(req: IncomingMessage, destroyOnLimit: boolean): void {
   if (req.destroyed) {
@@ -410,15 +390,15 @@ export async function readRequestBodyWithLimit(
       if (done) {
         return;
       }
-      const progress = advanceRequestBodyChunk(chunk, totalBytes, maxBytes);
-      totalBytes = progress.totalBytes;
-      if (progress.exceeded) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += buffer.length;
+      if (totalBytes > maxBytes) {
         const error = new RequestBodyLimitError({ code: "PAYLOAD_TOO_LARGE" });
         stopRequestBodyAfterLimit(req, destroyOnLimit);
         fail(error);
         return;
       }
-      chunks.push(progress.buffer);
+      chunks.push(buffer);
     };
 
     const onEnd = () => {
@@ -568,9 +548,8 @@ export function installRequestBodyLimitGuard(
     if (done) {
       return;
     }
-    const progress = advanceRequestBodyChunk(chunk, totalBytes, maxBytes);
-    totalBytes = progress.totalBytes;
-    if (progress.exceeded) {
+    totalBytes += typeof chunk === "string" ? Buffer.byteLength(chunk) : chunk.length;
+    if (totalBytes > maxBytes) {
       trip(new RequestBodyLimitError({ code: "PAYLOAD_TOO_LARGE" }));
     }
   };


### PR DESCRIPTION
## What Problem This Solves

Request-body size guards encode string chunks into temporary buffers solely to read their length. Both the guard and the reader also allocate a shared progress record that they immediately unpack.

## Why This Change Was Made

Keep normalized chunks directly in the reader, which needs them, and count UTF-8 bytes directly in the guard, which does not. Delete the private progress adapter while retaining the shared limit normalization and rejection lifecycle.

## User Impact

Less allocation work during uploads, with the same byte limits, timeout handling, response framing and connection cleanup. No configuration or API changes.

## Evidence

- All 95 existing body, response, request-lifecycle and webhook-guard tests pass before and after. Typed lint and isolated Codex autoreview pass.
- Independent before/after execution of the complete owners through real Node HTTP/TCP passes 40 scenarios per variant, including Unicode string chunks, invalid UTF-8, exact/oversize bodies, timeouts, aborts, concurrent guards/readers, and ordered rejection of pipelined requests. Recorded semantic outcomes match. Eight additional Bun HTTP executions also pass.
- A controlled size-guard workload reduces 10,000 string encodings (6,400,000 encoded bytes) to zero. Buffer-input copies remain zero. These are owner-level operation counts, not measured whole-Gateway memory savings.
- Full source build passes. An isolated Gateway on the committed build accepts chunked Unicode input and an exact 2 MiB tool request, returns a complete 413 for one additional streamed byte, returns 400 for malformed JSON, and successfully handles a subsequent tool request. The same Gateway completes real OpenAI inference plus Code Mode web/file calls and exits cleanly. A first HTTP probe requested a file tool that this surface does not expose; that run is excluded and the successful probe uses its supported web-fetch tool.

Production: +6/-27, net -21 lines. Tests: unchanged. Existing contract coverage is retained; no implementation-shape test replaces the deleted helper. Transport ownership, limits and response-body handling are unchanged.
