### PR TITLE
fix(skills): carry the workspace-skills approval owner

### DIFF
--- a/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
+++ b/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
@@ -179,6 +179,23 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
     expect(receiptAuthority).toHaveBeenCalledOnce();
   });
 
+  it("routes skill_workshop lifecycle approvals through the workspace-skills owner", async () => {
+    setRuntimeConfigSnapshot({
+      skills: { workshop: { approvalPolicy: "pending" } },
+    } as never);
+    mockCallGatewayTool.mockResolvedValueOnce({ id: "server-id-1", status: "accepted" });
+    mockCallGatewayTool.mockResolvedValueOnce({ id: "server-id-1", decision: "allow-once" });
+
+    const result = await runBeforeToolCallHook({
+      toolName: "skill_workshop",
+      params: { action: "apply", name: "Weather Helper" },
+    });
+
+    expect(result.blocked).toBe(false);
+    expect(mockCallGatewayTool).toHaveBeenCalled();
+    expect(mockCallGatewayTool.mock.calls[0]?.[0]).toBe("plugin.approval.request");
+  });
+
   it("blocks approval-required tools in embedded mode when no gateway approval route exists", async () => {
     setEmbeddedMode(true);
     const onResolution = vi.fn();

--- a/src/skills/workshop/policy.test.ts
+++ b/src/skills/workshop/policy.test.ts
@@ -63,6 +63,7 @@ describe("resolveSkillWorkshopToolApproval", () => {
       severity: "warning",
       timeoutMs: 70_000,
       allowedDecisions: ["allow-once", "deny"],
+      pluginId: "workspace-skills",
     });
     expect(result?.requireApproval?.description).toContain(`Proposal ID: ${proposal.record.id}`);
     expect(result?.requireApproval?.description).toContain("Target skill: Weather Helper");

--- a/src/skills/workshop/policy.ts
+++ b/src/skills/workshop/policy.ts
@@ -214,6 +214,9 @@ export async function resolveSkillWorkshopToolApproval(params: {
         });
   return {
     requireApproval: {
+      // Core-generated workshop approvals carry the workspace-skills owner so
+      // the Gateway's fail-closed authority check can sign the request.
+      pluginId: "workspace-skills",
       ...text,
       description: approvalDescription.description,
       timeoutMs: SKILL_WORKSHOP_APPROVAL_TIMEOUT_MS,


### PR DESCRIPTION
Closes #135291

## What Problem This Solves

Fixes a 2026.8.1 regression where a Skill Workshop lifecycle approval (`approvalPolicy: "pending"`) requested from a Telegram group produced a proposal but no approval/rejection buttons were delivered to the authorized owner DM, because the Gateway rejected the request with `signed plugin approval owner is unavailable`.

## Why This Change Was Made

`resolveSkillWorkshopToolApproval` built a `requireApproval` object without a `pluginId`. The approval transport then called `withGatewayToolApprovalOwner(undefined, ...)`, leaving `approvalOwnerPluginId` unset, and the Gateway's intentional fail-closed authority check rejected the ownerless request before Telegram delivery. This change carries the core `workspace-skills` owner on the approval so the signed request reaches the delivery path; the Gateway fail-closed validation is unchanged.

## User Impact

Skill Workshop lifecycle approvals initiated in a Telegram group now reach the authorized owner's DM with approval/rejection buttons, so pending proposals can be approved or rejected instead of silently stalling.

## Evidence

Exact head: `7c97cef9d5c1421a6a9fd92804839e7ef1ef9a8e`.

- `src/skills/workshop/policy.test.ts` — 9 passed, including a `pluginId: "workspace-skills"` assertion on the pending approval result.
- `src/agents/agent-tools.before-tool-call.embedded-mode.test.ts` — new boundary regression "routes skill_workshop lifecycle approvals through the workspace-skills owner": with `approvalPolicy: "pending"`, a real `skill_workshop` `apply` call reaches `plugin.approval.request` through the production approval path (not a mocked hook result). 26 passed across both files.
- Production typecheck and `check:changed` pass; the only local lane failure is unchanged `ui/vite.config.ts` missing a `pako` declaration in the reused dependency tree.

## AI Assistance

AI-assisted implementation. I manually verified the approval registration boundary, the owner propagation, the focused producer and boundary regressions, and the changed-file gates.