### PR TITLE
fix(cli): make the auth-login test's isTTY override actually optional

### DIFF
--- a/src/cli/models-cli.auth-login.integration.test.ts
+++ b/src/cli/models-cli.auth-login.integration.test.ts
@@ -53,7 +53,7 @@ vi.mock("../plugins/providers.runtime.js", () => ({
 }));
 
 function makeStdinInteractive(): () => void {
-  const stdin = process.stdin as NodeJS.ReadStream & { isTTY?: boolean };
+  const stdin = process.stdin as Omit<NodeJS.ReadStream, "isTTY"> & { isTTY?: boolean };
   const descriptor = Object.getOwnPropertyDescriptor(stdin, "isTTY");
   Object.defineProperty(stdin, "isTTY", { configurable: true, get: () => true });
   return () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the core CLI test-type check fails on PR merge refs with TS2790 in `src/cli/models-cli.auth-login.integration.test.ts:63`, blocking otherwise unrelated changes.

The auth-login integration test temporarily makes stdin interactive and restores the original property descriptor afterward. When stdin had no own `isTTY` property, restoration deletes the temporary override.

## Why This Change Was Made

`NodeJS.ReadStream & { isTTY?: boolean }` retains the required `isTTY` member from `ReadStream`, so TypeScript rejects that deletion. Omitting that member before reintroducing it as optional describes the test-owned temporary property correctly. This is a one-line type-only repair; setup, cleanup, and runtime behavior are unchanged.

## User Impact

No production or Gateway behavior changes. Maintainers and contributors can complete the core test-type gate again without weakening the test or changing its cleanup behavior.

## Evidence

- Baseline [main CI run 33538868877](https://github.com/openclaw/openclaw/actions/runs/33538868877) reports `TS2790: The operand of a 'delete' operator must be optional` at `src/cli/models-cli.auth-login.integration.test.ts:63`; its failed-job log was inspected.
- Exact head `0a9a78be98342938993d8d2d577c2a1f5e18a1b6` passed [CI run 33540220477](https://github.com/openclaw/openclaw/actions/runs/33540220477), including [check-test-types-core-4](https://github.com/openclaw/openclaw/actions/runs/33540220477/job/99964542553) and the aggregate `openclaw/ci-gate`.
- Diff scope: production +0/-0; one existing integration test +1/-1. No configuration, dependency, schema, protocol, or runtime changes.

This proof is compile-time CI evidence, not a live Gateway test; a Gateway run does not exercise the changed TypeScript declaration.

Original fix by Youssef Hemimy (@itsuzef). The contributor states that this change was developed with AI assistance (Claude Code), reviewed and driven by the submitter.
