### PR TITLE
refactor(cli): centralize repeatable option collection

### DIFF
--- a/src/cli/claws-cli.ts
+++ b/src/cli/claws-cli.ts
@@ -1,6 +1,7 @@
 // Commander registration for experimental Claws inspection and add previews.
 import type { Command } from "commander";
 import { isExperimentalClawsEnabled } from "../claws/experimental.js";
+import { collectOption } from "./program/helpers.js";
 import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
 
 export type ClawsInspectOptions = {
@@ -43,10 +44,6 @@ export type ClawsRemoveOptions = {
   json?: boolean;
 };
 export type ClawsExportOptions = { out: string; bootstrap?: string; json?: boolean };
-
-function collectOption(value: string, previous: string[]): string[] {
-  return [...previous, value];
-}
 
 export function registerClawsCli(program: Command) {
   if (!isExperimentalClawsEnabled()) {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -42,6 +42,7 @@ import { isConfigMachineOutput, isConfigSetJsonParseOnly } from "./config-output
 import { parseConfigSetCurrentExpectation, type ConfigSetOptions } from "./config-set-input.js";
 import { formatCliJsonFailure } from "./failure-output.js";
 import { exitCliAfterOutput } from "./one-shot-exit.js";
+import { collectOption } from "./program/helpers.js";
 import { setCommandJsonMode } from "./program/json-mode.js";
 import { quoteCliArg } from "./quote-cli-arg.js";
 
@@ -303,10 +304,6 @@ async function runConfigValidate(opts: { json?: boolean; runtime?: RuntimeEnv } 
     }
     exitCliAfterOutput(runtime, 1);
   }
-}
-
-function collectOption(value: string, previous: string[]): string[] {
-  return [...previous, value];
 }
 
 export function registerConfigCli(program: Command) {

--- a/src/cli/cron-cli/register.cron-options.ts
+++ b/src/cli/cron-cli/register.cron-options.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { THINKING_LEVELS_HELP } from "../../auto-reply/thinking.shared.js";
+import { collectOption } from "../program/helpers.js";
 import { getCronChannelOptions } from "./shared.js";
 
 export function registerCronMutationOptions(command: Command, mode: "add" | "edit"): Command {
@@ -51,7 +52,7 @@ export function registerCronMutationOptions(command: Command, mode: "add" | "edi
     .option(
       "--command-env <KEY=VALUE>",
       "Environment override for command payloads (repeatable)",
-      (value: string, previous: string[] | undefined) => [...(previous ?? []), value],
+      collectOption,
     )
     .option("--command-input <text>", "stdin for command payloads")
     .option("--thinking <level>", `Thinking level for agent jobs (${THINKING_LEVELS_HELP})`)

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -46,6 +46,7 @@ import { formatCliCommand } from "./command-format.js";
 import { formatCliJsonFailure } from "./failure-output.js";
 import { resolveGatewayAuthOptions } from "./gateway-secret-options.js";
 import { requestExitAfterOneShotOutput } from "./one-shot-exit.js";
+import { collectOption } from "./program/helpers.js";
 import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
 
 const createSessionMcpRuntime = createLazyRuntimeMethod(
@@ -82,10 +83,6 @@ function parseCsvList(value: string | undefined): string[] | undefined {
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
   return entries.length > 0 ? entries : undefined;
-}
-
-function collectOption(value: string, previous: string[] = []): string[] {
-  return [...previous, value];
 }
 
 function parseKeyValueEntries(values: readonly string[] | undefined, label: string) {

--- a/src/cli/program/register.agent-turn.ts
+++ b/src/cli/program/register.agent-turn.ts
@@ -7,10 +7,7 @@ import { THINKING_LEVELS_HELP } from "../../auto-reply/thinking.shared.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { measureCliCommandStartup } from "../command-startup-timing.js";
 import { formatHelpExamples } from "../help-format.js";
-
-function collectFallback(value: string, previous: string[]): string[] {
-  return [...previous, value];
-}
+import { collectOption } from "./helpers.js";
 
 /** Register `openclaw agent` for one Gateway-backed agent turn. */
 export function registerAgentTurnCommand(
@@ -126,7 +123,7 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
     .option(
       "--fallback <provider/model>",
       "Add an ordered fallback model (repeatable; requires --model)",
-      collectFallback,
+      collectOption,
       [],
     )
     .option("--auth-env-only", "Use provider credentials from environment variables only", false)

--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -23,7 +23,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { addGatewayClientOptions } from "../gateway-rpc.js";
 import { formatHelpExamples } from "../help-format.js";
-import { parseStrictPositiveIntOption } from "./helpers.js";
+import { collectOption, parseStrictPositiveIntOption } from "./helpers.js";
 
 /** Register backup create/verify subcommands. */
 export function registerBackupCommand(program: Command) {
@@ -143,10 +143,6 @@ export function registerBackupCommand(program: Command) {
   registerBackupScheduleCommands(backup);
 }
 
-function collectAgent(value: string, previous: string[]): string[] {
-  return [...previous, value];
-}
-
 function registerBackupScheduleCommands(backup: Command): void {
   addGatewayClientOptions(
     backup
@@ -209,7 +205,7 @@ function registerBackupGitCommands(backup: Command): void {
     .requiredOption("--repository <path>", "Git backup repository directory")
     .option("--all", "Back up the shared database and every registered agent database", false)
     .option("--global", "Back up the shared OpenClaw state database", false)
-    .option("--agent <id>", "Back up an agent database (repeatable)", collectAgent, [])
+    .option("--agent <id>", "Back up an agent database (repeatable)", collectOption, [])
     .option("--push", "Push the current branch to origin", false)
     .option("--exclude-secrets", "Omit credential-bearing database tables", false)
     .option("--json", "Output JSON", false)

--- a/src/cli/program/register.configure.ts
+++ b/src/cli/program/register.configure.ts
@@ -4,6 +4,7 @@ import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { CONFIGURE_WIZARD_SECTIONS } from "../../commands/configure.shared.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
+import { collectOption } from "./helpers.js";
 
 /** Register the interactive `configure` command and section filter flag. */
 export function registerConfigureCommand(program: Command): void {
@@ -18,7 +19,7 @@ export function registerConfigureCommand(program: Command): void {
     .option(
       "--section <section>",
       `Configuration sections (repeatable). Options: ${CONFIGURE_WIZARD_SECTIONS.join(", ")}`,
-      (value: string, previous: string[]) => [...previous, value],
+      collectOption,
       [] as string[],
     )
     .action(async (opts) => {

--- a/src/cli/program/register.migrate.ts
+++ b/src/cli/program/register.migrate.ts
@@ -11,18 +11,7 @@ import {
 import { defaultRuntime } from "../../runtime.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { formatHelpExamples } from "../help-format.js";
-
-function collectMigrationSkill(value: string, previous: string[] | undefined): string[] {
-  return [...(previous ?? []), value];
-}
-
-function collectMigrationPlugin(value: string, previous: string[] | undefined): string[] {
-  return [...(previous ?? []), value];
-}
-
-function collectMigrationItem(value: string, previous: string[] | undefined): string[] {
-  return [...(previous ?? []), value];
-}
+import { collectOption } from "./helpers.js";
 
 function readMigrationItems(value: unknown, command?: Command): string[] | undefined {
   const selected = Array.isArray(value) ? value : command?.parent?.opts().item;
@@ -33,7 +22,7 @@ function addMigrationSkillOption(command: Command): Command {
   return command.option(
     "--skill <name>",
     "Select one skill to migrate by name or item id; repeat for multiple skills",
-    collectMigrationSkill,
+    collectOption,
   );
 }
 
@@ -41,7 +30,7 @@ function addMigrationPluginOption(command: Command): Command {
   return command.option(
     "--plugin <name>",
     "Select one Codex plugin to migrate by name or item id; repeat for multiple plugins",
-    collectMigrationPlugin,
+    collectOption,
   );
 }
 
@@ -57,7 +46,7 @@ function addMigrationItemOption(command: Command): Command {
   return command.option(
     "--item <id>",
     "Select one exact migration item id; repeat for multiple items",
-    collectMigrationItem,
+    collectOption,
   );
 }
 
@@ -112,17 +101,17 @@ export function registerMigrateCommand(program: Command) {
       .option(
         "--skill <name>",
         "Select one skill to migrate by name or item id; repeat for multiple skills",
-        collectMigrationSkill,
+        collectOption,
       )
       .option(
         "--plugin <name>",
         "Select one Codex plugin to migrate by name or item id; repeat for multiple plugins",
-        collectMigrationPlugin,
+        collectOption,
       )
       .option(
         "--item <id>",
         "Select one exact migration item id; repeat for multiple items",
-        collectMigrationItem,
+        collectOption,
       )
       .option("--backup-output <path>", "Pre-migration backup archive path or directory")
       .option("--no-backup", "Skip the pre-migration OpenClaw backup")

--- a/src/cli/proxy-cli.ts
+++ b/src/cli/proxy-cli.ts
@@ -3,6 +3,7 @@ import { parseStrictInteger } from "@openclaw/normalization-core/number-coercion
 import { InvalidArgumentError, type Command } from "commander";
 import type { CaptureQueryPreset } from "../proxy-capture/types.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import { collectOption } from "./program/helpers.js";
 import { setCommandJsonMode } from "./program/json-mode.js";
 import { isProxyMachineOutput } from "./proxy-output-mode.js";
 
@@ -39,10 +40,6 @@ function parsePositiveIntegerOption(value: string | undefined, flag: string): nu
     throw new InvalidArgumentError(`${flag} must be a positive integer.`);
   }
   return parsed;
-}
-
-function collectOption(value: string, previous: string[] | undefined): string[] {
-  return [...(previous ?? []), value];
 }
 
 export function registerProxyCli(program: Command) {


### PR DESCRIPTION
## What Problem This Solves

Repeatable Commander options used several equivalent local collectors across CLI registration modules, making a simple parsing invariant unnecessarily duplicated.

## Why This Change Was Made

Reuse the existing `collectOption` helper across the reviewed claws, config, MCP, agent, backup, proxy, migrate, configure, and cron registrations. Explicit defaults and omitted defaults remain unchanged, preserving option ordering, forwarding, fresh-array behavior, and lazy registration.

## User Impact

No user-visible behavior or public API changes. This is a mechanical consolidation of repeatable-option collection.

## Evidence

- Signed replay onto current `main` parent `93d54163ca85e0fa6f5602379a4e114cf8a9ae50`; later `main` movement through `64f4cdac86ee917d116ea6c9bb0be3d190d3267a` did not touch the reviewed CLI owner surface.
- Focused exact-head validation: 9 test files, 340 tests passed.
- Commander 15 differential proof covered omitted values, explicit empty defaults, repeated ordering, and fresh-array behavior.
- Formatting passed for all 9 changed files.
- Import-cycle check: 0 runtime value cycles.
- Exact-head autoreview: scoped clean, no accepted or actionable P0-P2 findings; patch correctness 0.98.
- Changed-file gate passed every check through the core typecheck. Typecheck and three additional claws/MCP suites were blocked by the shared checkout missing `mdast-util-from-markdown`, `mdast-util-gfm-table`, `micromark-extension-gfm-table`, `markdown-it-cjk-friendly`, and `libphonenumber-js/min`; repository policy forbids dependency reconciliation inside this linked worktree.
- Production delta: 9 files, +19/-47, net -28. Tests: 0.

Out-of-scope follow-up: `migrate --skill/--plugin ... plan|apply` parent-before-leaf values do not currently inherit like `--item` and `--agent`. This PR intentionally does not widen into that behavior fix.
