### PR TITLE
refactor(text): avoid full-string encoding for bounded prefixes

### DIFF
--- a/src/utils/utf8-truncate.test.ts
+++ b/src/utils/utf8-truncate.test.ts
@@ -6,6 +6,7 @@ describe("UTF-8 byte truncation", () => {
     { value: "abcé", maxBytes: 4, expected: "abc" },
     { value: "abc✓", maxBytes: 5, expected: "abc" },
     { value: "abc😀", maxBytes: 6, expected: "abc" },
+    { value: "abc😀", maxBytes: 4, expected: "abc" },
     { value: "😀", maxBytes: 4, expected: "😀" },
   ])("keeps a valid prefix for $value at $maxBytes bytes", ({ value, maxBytes, expected }) => {
     const result = truncateUtf8Prefix(value, maxBytes);
@@ -32,4 +33,21 @@ describe("UTF-8 byte truncation", () => {
     expect(truncateUtf8Prefix("value", 0)).toBe("");
     expect(truncateUtf8Suffix("value", -1)).toBe("");
   });
+
+  it.each([
+    { value: "abc😀", maxBytes: 4.5, prefix: "abc�", suffix: "c😀" },
+    { value: "\ud800x", maxBytes: 4, prefix: "\ud800x", suffix: "\ud800x" },
+    { value: "\ud800x", maxBytes: 3, prefix: "�", suffix: "x" },
+    { value: "\ud800x", maxBytes: Number.NaN, prefix: "", suffix: "�x" },
+    { value: "\udc00", maxBytes: Infinity, prefix: "\udc00", suffix: "\udc00" },
+    { value: "aj", maxBytes: 2 ** -52, prefix: "", suffix: "j" },
+    { value: "éj", maxBytes: 2 ** -52, prefix: "", suffix: "" },
+    { value: "abcdefghij", maxBytes: 1 + 2 ** -51, prefix: "a", suffix: "j" },
+  ])(
+    "preserves conversion and fractional limits for $value at $maxBytes bytes",
+    ({ value, maxBytes, prefix, suffix }) => {
+      expect(truncateUtf8Prefix(value, maxBytes)).toBe(prefix);
+      expect(truncateUtf8Suffix(value, maxBytes)).toBe(suffix);
+    },
+  );
 });

--- a/src/utils/utf8-truncate.ts
+++ b/src/utils/utf8-truncate.ts
@@ -9,10 +9,11 @@ export function truncateUtf8Prefix(value: string, maxBytes: number): string {
   if (maxBytes <= 0) {
     return "";
   }
-  const bytes = Buffer.from(value);
-  if (bytes.byteLength <= maxBytes) {
+  if (value.length <= maxBytes && Buffer.byteLength(value) <= maxBytes) {
     return value;
   }
+  // Only this many UTF-16 units can contribute to the retained UTF-8 prefix.
+  const bytes = Buffer.from(value.slice(0, maxBytes));
   let end = maxBytes;
   while (end > 0 && isContinuationByte(bytes[end])) {
     end -= 1;
@@ -25,10 +26,11 @@ export function truncateUtf8Suffix(value: string, maxBytes: number): string {
   if (maxBytes <= 0) {
     return "";
   }
-  const bytes = Buffer.from(value);
-  if (bytes.byteLength <= maxBytes) {
+  if (value.length <= maxBytes && Buffer.byteLength(value) <= maxBytes) {
     return value;
   }
+  // Full length matters: fractional subtraction rounds before index conversion.
+  const bytes = Buffer.from(value);
   let start = bytes.byteLength - maxBytes;
   while (start < bytes.byteLength && isContinuationByte(bytes[start])) {
     start += 1;


### PR DESCRIPTION
## What Problem This Solves

Splitting large output into bounded progress frames repeatedly encodes the whole remaining string. Even strings that already fit allocate a buffer just to discover their byte length.

## Why This Change Was Made

The canonical UTF-8 helper checks fitting strings without creating a buffer, then encodes only the prefix window needed for truncation. Suffix truncation retains its full-length subtraction because narrowing that window changes observable fractional-limit results. Two short comments preserve those invariants.

## User Impact

Less temporary allocation work for progress chunks, terminal frames and bounded tool results, with existing string results preserved.

## Evidence

- All 89 focused utility, progress-writer, terminal-session, close-reason and output-tail tests pass. The expanded 18-case utility suite passes before and after, including surrogate window edges, fitting malformed UTF-16, fractional limits and nonfinite values. Typed lint and isolated Codex autoreview pass.
- Independent review confirms 3,584,354 before/after cases on each of Node and Bun with no output mismatch. The rejected suffix-window approach fails 61,491 cases per runtime; it is not part of this patch.
- Complete progress-writer source with a synthetic transport sink emits identical frames while a 4 MiB ASCII workload reduces encoded buffer bytes from 538,968,064 to 4,177,920. Seven additional terminal-coalescer scenarios preserve frame boundaries and output. These count encoded bytes, not retained heap or whole-process RSS.
- Full source build passes. An isolated Gateway built from this exact head completed real OpenAI turns with `openai/gpt-5.6-luna`: an ordinary reply, sequential `web_fetch` (HTTP 200) and synthetic-file `read`, and a large Unicode Code Mode result. Durable history verifies the paired execution, completed status, valid UTF-8 prefix within 64 KiB, exact omitted-byte count and final reply. Gateway cleanup exits 0. This is changed-caller behavior proof, not a whole-process memory comparison.

Production: +6/-4, net +2 lines, entirely from the invariant comments. Tests: +18. No new configuration, public API, dependency or persistence surface.
