### PR TITLE
fix(codex): name the dynamic-tool loading replacement operation

### DIFF
--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -11,6 +11,7 @@ import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createLazyCodexAppServerBindingStore } from "./session-binding-store.js";
 import {
+  assertCodexBindingMayBeReplaced,
   bindingStoreKey,
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
   createCodexAppServerBindingStore,
@@ -18,6 +19,7 @@ import {
   hashCodexAppServerBindingFingerprint,
   readCodexAppServerThreadBinding,
   reclaimCurrentCodexSessionGeneration,
+  type CodexAppServerThreadBinding,
   type StoredCodexAppServerBinding,
 } from "./session-binding.js";
 
@@ -1859,6 +1861,22 @@ describe("Codex app-server binding store", () => {
     expect(() =>
       bindingStoreKey({ kind: "session", agentId: " ", sessionId: "session-1" }),
     ).toThrow("requires an agent id");
+  });
+
+  it("names the specific lifecycle operation in supervised replacement refusals", () => {
+    const supervised = {
+      connectionScope: "supervision",
+      threadId: "thread-supervised",
+    } as CodexAppServerThreadBinding;
+    expect(() =>
+      assertCodexBindingMayBeReplaced(supervised, "changing the dynamic tool loading mode"),
+    ).toThrow("while changing the dynamic tool loading mode");
+    expect(() =>
+      assertCodexBindingMayBeReplaced(
+        { threadId: "thread-plain" } as CodexAppServerThreadBinding,
+        "changing the dynamic tool loading mode",
+      ),
+    ).not.toThrow();
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/codex/src/app-server/thread-lifecycle-run.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-run.ts
@@ -332,7 +332,7 @@ export async function startOrResumeThread(
         threadId: binding.threadId,
         connectionClass: params.appServer.connectionClass,
       });
-      await clearCurrentBinding("rotating a stale thread binding");
+      await clearCurrentBinding("changing the app-server runtime identity");
       binding = undefined;
     }
     if (
@@ -451,7 +451,7 @@ export async function startOrResumeThread(
         embeddedAgentLog.debug("codex app-server MCP config changed; starting a new thread", {
           threadId: binding.threadId,
         });
-        await clearCurrentBinding("rotating a stale thread binding");
+        await clearCurrentBinding("changing MCP configuration");
       }
       binding = undefined;
     }
@@ -485,7 +485,7 @@ export async function startOrResumeThread(
             threadId: binding.threadId,
           },
         );
-        await clearCurrentBinding("rotating a stale thread binding");
+        await clearCurrentBinding("changing web-search configuration");
       }
       binding = undefined;
     }
@@ -529,7 +529,7 @@ export async function startOrResumeThread(
             previousPolicyFingerprint: binding.contextEngine?.policyFingerprint,
           },
         );
-        await clearCurrentBinding("rotating a stale thread binding");
+        await clearCurrentBinding("changing the context-engine binding");
         binding = undefined;
         rotatedContextEngineBinding = true;
       }
@@ -545,7 +545,7 @@ export async function startOrResumeThread(
       embeddedAgentLog.debug("codex app-server user MCP config changed; starting a new thread", {
         threadId: binding.threadId,
       });
-      await clearCurrentBinding("rotating a stale thread binding");
+      await clearCurrentBinding("changing the user MCP servers");
       binding = undefined;
     }
     if (
@@ -559,7 +559,7 @@ export async function startOrResumeThread(
           threadId: binding.threadId,
         },
       );
-      await clearCurrentBinding("rotating a stale thread binding");
+      await clearCurrentBinding("changing the network proxy configuration");
       binding = undefined;
     }
     if (binding?.threadId) {
@@ -577,7 +577,7 @@ export async function startOrResumeThread(
             threadId: binding.threadId,
           },
         );
-        await clearCurrentBinding("rotating a stale thread binding");
+        await clearCurrentBinding("changing the plugin app configuration");
         binding = undefined;
       }
     }
@@ -628,7 +628,7 @@ export async function startOrResumeThread(
               threadId: binding.threadId,
             },
           );
-          await clearCurrentBinding("rotating a stale thread binding");
+          await clearCurrentBinding("changing the dynamic tool catalog");
         }
       } else if (incognito) {
         if (

--- a/extensions/codex/src/app-server/thread-lifecycle-run.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-run.ts
@@ -594,7 +594,7 @@ export async function startOrResumeThread(
             threadId: binding.threadId,
           },
         );
-        await clearCurrentBinding("rotating a stale thread binding");
+        await clearCurrentBinding("changing the dynamic tool loading mode");
         binding = undefined;
       }
     }


### PR DESCRIPTION
Closes #135310

## What Problem This Solves

Supervised Codex threads were correctly refused whenever a persisted lifecycle fingerprint drifted from the prepared config, but every refusal reported the same generic `Refusing to replace supervised Codex thread <id> while rotating a stale thread binding`, hiding which setting actually changed. This PR gives each of the nine lifecycle checks its own cause-specific operation so the refusal names the real mismatch.

## Why This Change Was Made

`startOrResumeThread` reuses one generic `"rotating a stale thread binding"` operation string at several distinct lifecycle checks. This PR replaces that generic string with a cause-specific operation at each site:

- `changing the app-server runtime identity`
- `changing MCP configuration`
- `changing web-search configuration`
- `changing the context-engine binding`
- `changing the user MCP servers`
- `changing the network proxy configuration`
- `changing the plugin app configuration`
- `changing the dynamic tool loading mode`
- `changing the dynamic tool catalog`

The fail-closed ownership guard (`assertCodexBindingMayBeReplaced`) and the binding mutation order are unchanged; only the operator-visible operation text is narrowed. Checks that already passed a specific operation (configured MCP ownership, native-tool/delegation-restricted turns, ring-zero, GPT-5.6 multi-agent, ephemeral/plugin-app warm-rotate) are left as-is.

## User Impact

Operators and maintainers can now see exactly which configuration drifted (e.g. web search vs. dynamic tools) instead of a generic stale-binding message, without any change to the supervised-binding safety guarantee.

## Evidence

Exact head: `3d34631288a61bbcbaefc86e5d5581a8167a46ed`.

- `extensions/codex/src/app-server/session-binding.test.ts` — new focused regression proving the specific operation is interpolated into the supervised refusal (`while changing the dynamic tool loading mode`) and that a non-supervised binding is not refused. 55 passed.
- `extensions/codex/src/app-server/thread-lifecycle.binding.test.ts` — 136 passed (fail-closed supervised-binding behavior preserved).
- Production typecheck and `check:changed` pass for the changed files.

## AI Assistance

AI-assisted implementation. I manually verified each lifecycle-check site, the cause-specific operation strings, the unchanged fail-closed guard, the new focused regression, and the changed-file gates.