### PR TITLE
fix(channels): omit explicitly disabled manifest accounts

### DIFF
--- a/src/channels/plugins/read-only.test.ts
+++ b/src/channels/plugins/read-only.test.ts
@@ -521,7 +521,7 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
       resolveEnabled({
         "external-chat": {
           enabled: true,
-          accounts: { ops: { enabled: false, token: "disabled" } },
+          accounts: { ops: { enabled: false } },
         },
       }),
     ).toBe(false);
@@ -529,7 +529,7 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
       resolveEnabled({
         "external-chat": {
           enabled: false,
-          accounts: { ops: { enabled: true, token: "enabled" } },
+          accounts: { ops: { enabled: true } },
         },
       }),
     ).toBe(true);
@@ -537,7 +537,7 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
       resolveEnabled({
         "external-chat": {
           enabled: false,
-          accounts: { ops: { token: "inherits-disabled" } },
+          accounts: { ops: {} },
         },
       }),
     ).toBe(false);

--- a/src/channels/plugins/read-only.test.ts
+++ b/src/channels/plugins/read-only.test.ts
@@ -528,7 +528,7 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
     expect(
       resolveEnabled({
         "external-chat": {
-          enabled: false,
+          enabled: true,
           accounts: { ops: { enabled: true } },
         },
       }),
@@ -536,11 +536,11 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
     expect(
       resolveEnabled({
         "external-chat": {
-          enabled: false,
+          enabled: true,
           accounts: { ops: {} },
         },
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("reevaluates persisted auth without replacing manifest adapters or loading channel runtime", () => {

--- a/src/channels/plugins/read-only.test.ts
+++ b/src/channels/plugins/read-only.test.ts
@@ -499,6 +499,49 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
     expect(fs.existsSync(fullMarker)).toBe(false);
   });
 
+  it("honors named account enablement in manifest-only inventory", () => {
+    const { pluginDir } = writeExternalSetupChannelPlugin({
+      manifestChannelConfig: true,
+    });
+    const metadataSnapshot = resolvePluginMetadataSnapshot({
+      config: createExternalChannelTestConfig({ pluginDir }),
+    });
+    const resolveEnabled = (channels: Record<string, Record<string, unknown>>) => {
+      const cfg = createExternalChannelTestConfig({ pluginDir, channels });
+      const plugin = listReadOnlyChannelPluginsForConfig(cfg, { metadataSnapshot }).find(
+        (entry) => entry.id === "external-chat",
+      );
+      expect(plugin).toBeDefined();
+      const account = plugin!.config.resolveAccount(cfg, "ops");
+      return plugin!.config.isEnabled(account, cfg);
+    };
+
+    expect(
+      resolveEnabled({
+        "external-chat": {
+          enabled: true,
+          accounts: { ops: { enabled: false, token: "disabled" } },
+        },
+      }),
+    ).toBe(false);
+    expect(
+      resolveEnabled({
+        "external-chat": {
+          enabled: false,
+          accounts: { ops: { enabled: true, token: "enabled" } },
+        },
+      }),
+    ).toBe(true);
+    expect(
+      resolveEnabled({
+        "external-chat": {
+          enabled: false,
+          accounts: { ops: { token: "inherits-disabled" } },
+        },
+      }),
+    ).toBe(false);
+  });
+
   it("reevaluates persisted auth without replacing manifest adapters or loading channel runtime", () => {
     const stateDir = makePluginLoaderTempDir();
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);

--- a/src/channels/plugins/read-only.test.ts
+++ b/src/channels/plugins/read-only.test.ts
@@ -513,7 +513,8 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
       );
       expect(plugin).toBeDefined();
       const account = plugin!.config.resolveAccount(cfg, "ops");
-      return plugin!.config.isEnabled(account, cfg);
+      expect(plugin!.config.isEnabled).toBeDefined();
+      return plugin!.config.isEnabled!(account, cfg);
     };
 
     expect(

--- a/src/channels/plugins/read-only.test.ts
+++ b/src/channels/plugins/read-only.test.ts
@@ -487,6 +487,25 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
       accountId: "ops",
       config: { token: "changed" },
     });
+    for (const [channelEnabled, accountEnabled, expected] of [
+      [true, false, false],
+      [true, true, true],
+      [true, undefined, true],
+      [false, true, false],
+      [undefined, false, false],
+    ] as const) {
+      const current = createExternalChannelTestConfig({
+        pluginDir,
+        channels: {
+          "external-chat": {
+            enabled: channelEnabled,
+            accounts: { ops: { enabled: accountEnabled } },
+          },
+        },
+      });
+      const account = second?.config.resolveAccount(current, "ops");
+      expect(second?.config.isEnabled?.(account, current)).toBe(expected);
+    }
     expect(
       pluginIds(
         listReadOnlyChannelPluginsForConfig(
@@ -497,50 +516,6 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
     ).not.toContain("external-chat");
     expect(fs.existsSync(setupMarker)).toBe(false);
     expect(fs.existsSync(fullMarker)).toBe(false);
-  });
-
-  it("honors named account enablement in manifest-only inventory", () => {
-    const { pluginDir } = writeExternalSetupChannelPlugin({
-      manifestChannelConfig: true,
-    });
-    const metadataSnapshot = resolvePluginMetadataSnapshot({
-      config: createExternalChannelTestConfig({ pluginDir }),
-    });
-    const resolveEnabled = (channels: Record<string, Record<string, unknown>>) => {
-      const cfg = createExternalChannelTestConfig({ pluginDir, channels });
-      const plugin = listReadOnlyChannelPluginsForConfig(cfg, { metadataSnapshot }).find(
-        (entry) => entry.id === "external-chat",
-      );
-      expect(plugin).toBeDefined();
-      const account = plugin!.config.resolveAccount(cfg, "ops");
-      expect(plugin!.config.isEnabled).toBeDefined();
-      return plugin!.config.isEnabled!(account, cfg);
-    };
-
-    expect(
-      resolveEnabled({
-        "external-chat": {
-          enabled: true,
-          accounts: { ops: { enabled: false } },
-        },
-      }),
-    ).toBe(false);
-    expect(
-      resolveEnabled({
-        "external-chat": {
-          enabled: true,
-          accounts: { ops: { enabled: true } },
-        },
-      }),
-    ).toBe(true);
-    expect(
-      resolveEnabled({
-        "external-chat": {
-          enabled: true,
-          accounts: { ops: {} },
-        },
-      }),
-    ).toBe(true);
   });
 
   it("reevaluates persisted auth without replacing manifest adapters or loading channel runtime", () => {

--- a/src/channels/plugins/read-only.ts
+++ b/src/channels/plugins/read-only.ts
@@ -221,17 +221,6 @@ function resolveManifestChannelAccountConfig(params: {
   return channelConfig;
 }
 
-function isManifestChannelAccountEnabled(params: {
-  account: { config: Record<string, unknown> };
-  cfg: OpenClawConfig;
-  channelId: string;
-}): boolean {
-  return (
-    getChannelConfigRecord(params.cfg, params.channelId).enabled !== false &&
-    params.account.config.enabled !== false
-  );
-}
-
 function buildManifestChannelPlugin(params: {
   record: PluginManifestRecord;
   channelId: string;
@@ -328,11 +317,8 @@ function createManifestChannelPlugin(params: {
         }),
       }),
       isEnabled: (account, cfg) =>
-        isManifestChannelAccountEnabled({
-          account,
-          cfg,
-          channelId: params.channelId,
-        }),
+        getChannelConfigRecord(cfg, params.channelId).enabled !== false &&
+        account.config.enabled !== false,
       isConfigured: (_account, cfg) =>
         hasExplicitChannelConfig({
           config: cfg,

--- a/src/channels/plugins/read-only.ts
+++ b/src/channels/plugins/read-only.ts
@@ -221,6 +221,17 @@ function resolveManifestChannelAccountConfig(params: {
   return channelConfig;
 }
 
+function isManifestChannelAccountEnabled(params: {
+  account: { config: Record<string, unknown> };
+  cfg: OpenClawConfig;
+  channelId: string;
+}): boolean {
+  const accountEnabled = params.account.config.enabled;
+  return typeof accountEnabled === "boolean"
+    ? accountEnabled
+    : getChannelConfigRecord(params.cfg, params.channelId).enabled !== false;
+}
+
 function buildManifestChannelPlugin(params: {
   record: PluginManifestRecord;
   channelId: string;
@@ -316,7 +327,12 @@ function createManifestChannelPlugin(params: {
           accountId,
         }),
       }),
-      isEnabled: (_account, cfg) => getChannelConfigRecord(cfg, params.channelId).enabled !== false,
+      isEnabled: (account, cfg) =>
+        isManifestChannelAccountEnabled({
+          account,
+          cfg,
+          channelId: params.channelId,
+        }),
       isConfigured: (_account, cfg) =>
         hasExplicitChannelConfig({
           config: cfg,

--- a/src/channels/plugins/read-only.ts
+++ b/src/channels/plugins/read-only.ts
@@ -226,10 +226,10 @@ function isManifestChannelAccountEnabled(params: {
   cfg: OpenClawConfig;
   channelId: string;
 }): boolean {
-  const accountEnabled = params.account.config.enabled;
-  return typeof accountEnabled === "boolean"
-    ? accountEnabled
-    : getChannelConfigRecord(params.cfg, params.channelId).enabled !== false;
+  return (
+    getChannelConfigRecord(params.cfg, params.channelId).enabled !== false &&
+    params.account.config.enabled !== false
+  );
 }
 
 function buildManifestChannelPlugin(params: {


### PR DESCRIPTION
## What Problem This Solves

Manifest-only channel inventory ignored a named account's `enabled: false`, so channel capabilities could report a disabled account as enabled. The manifest adapter already resolves that account's configuration; its existing `isEnabled` predicate now consumes the resolved flag as well as the parent channel flag.

## Why This Change Was Made

The predicate stays inline, replacing the proposed one-use helper. The regression extends the existing cached-adapter test with account-disabled, account-enabled, inherited, parent-disabled, and omitted-parent cases. This keeps metadata caching separate from the current account settings and preserves parent disablement.

## User Impact

A named account disabled in configuration is reported as disabled by manifest-only channel capabilities, while enabled and inherited accounts keep their existing behavior.

## Evidence

The full focused read-only suite passed all 41 tests on Linux. The new assertion first failed on unchanged production code (`true` instead of `false`). The real source CLI was then run against an isolated synthetic plugin whose entrypoint registers no runtime channel adapter, ensuring inventory uses the manifest adapter:

```text
node --import tsx src/entry.ts channels capabilities --json
before: {"disabled":true,"enabled":true,"inherited":true}
after:  {"disabled":false,"enabled":true,"inherited":true}
```

These are the three named accounts' reported `enabled` values. CLI bootstrap loads the synthetic no-op plugin entrypoint; no channel runtime adapter or network probe is involved.

Production +3/-1 (net +2); tests +19/-0. The two production lines add the missing account fact directly to the owning predicate; there is no extra helper, account lookup, configuration option, schema, or fallback. Scoped formatting passed and an independent P0 review returned no accepted findings. Proof ran through Crabbox's managed Blacksmith Testbox, associated with [the prepared Linux run](https://github.com/openclaw/openclaw/actions/runs/33563324116), and all frozen candidate hashes were unchanged afterward. The successful command and before/after CLI trace address the latest ClawSweeper proof request. Required exact-head PR checks remain part of the normal landing gate.

Contributor credit: @ly85206559.

