### PR TITLE
fix(models): reject unavailable harness directive selections

### DIFF
--- a/extensions/telegram/src/bot-handlers.agent.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.agent.runtime.ts
@@ -1,2 +1,6 @@
 // Telegram plugin module implements bot handlers.agent behavior.
-export { resolveAgentDir, resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
+export {
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveDefaultModelForAgent,
+} from "openclaw/plugin-sdk/agent-runtime";

--- a/extensions/telegram/src/bot-handlers.callback-router.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router.ts
@@ -13,7 +13,11 @@ import {
   hasTelegramApprovalCallbackPrefix,
   parseTelegramApprovalCallbackData,
 } from "./approval-callback-data.js";
-import { resolveAgentDir, resolveDefaultModelForAgent } from "./bot-handlers.agent.runtime.js";
+import {
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveDefaultModelForAgent,
+} from "./bot-handlers.agent.runtime.js";
 import {
   createTelegramCallbackMessageActions,
   handleTelegramQuestionCallback,
@@ -651,6 +655,7 @@ async function handleTelegramModelCallback(params: {
       applySessionModelSelection({
         cfg: runtimeCfg,
         agentId: sessionState.agentId,
+        workspaceDir: resolveAgentWorkspaceDir(runtimeCfg, sessionState.agentId),
         sessionKey: sessionState.sessionKey,
         storePath,
         sessionEntry,

--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -312,6 +312,28 @@ export function requiresAgentHarnessPluginSelection(
   );
 }
 
+/** Returns the selected plugin-owned runtime when no activatable owner provides it. */
+export function resolveMissingAgentHarnessRuntime(params: {
+  selection: AgentHarnessPluginSelection;
+  config?: OpenClawConfig;
+  workspaceDir: string;
+  metadataSnapshot?: PluginMetadataSnapshot;
+}): string | undefined {
+  if (!requiresAgentHarnessPluginSelection(params.selection, params.config)) {
+    return undefined;
+  }
+  const runtime = resolveSelectedAgentHarnessRuntime(params.selection, params.config);
+  return resolveAgentHarnessOwnerPluginIds({
+    runtime,
+    provider: params.selection.provider,
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    metadataSnapshot: params.metadataSnapshot,
+  }).length === 0
+    ? runtime
+    : undefined;
+}
+
 /** Folds selected harness, memory, and context-engine owners into one deterministic load plan. */
 export function resolveAgentRuntimePluginLoadPlan(params: {
   config?: OpenClawConfig;

--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -296,7 +296,7 @@ export function resolveSelectedAgentHarnessRuntime(
 }
 
 // Returns whether a selection needs a plugin-owned harness in its prepared generation.
-export function requiresAgentHarnessPluginSelection(
+function requiresAgentHarnessPluginSelection(
   selection: AgentHarnessPluginSelection,
   config?: OpenClawConfig,
 ): boolean {

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -181,6 +181,7 @@ export async function handleDirectiveOnly(
       catalog: thinkingCatalog ?? [],
       rawRuntime: directives.rawModelRuntime,
       workspaceDir: params.workspaceDir ?? resolveAgentWorkspaceDir(params.cfg, activeAgentId),
+      sessionKey: params.sessionKey,
       sessionEntry,
     });
     if (prepared.status === "rejected") {

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -1,6 +1,5 @@
 /** Applies directive-only command state changes without running the agent. */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { renderExecTargetLabel } from "../../agents/bash-tools.exec-runtime.js";
 import { resolveExecDefaults } from "../../agents/exec-defaults.js";
 import {
@@ -58,6 +57,8 @@ import {
   prepareModelSelectionRuntime,
 } from "./model-runtime-normalization.js";
 import { refreshQueuedFollowupSession } from "./queue.js";
+
+type ModelRuntimeResolution = Parameters<typeof applyModelRuntimeDirective>[1];
 
 /** Handles inline directives that can be acknowledged without a model turn. */
 export async function handleDirectiveOnly(
@@ -161,17 +162,14 @@ export async function handleDirectiveOnly(
   if (modelResolution.errorText) {
     return rejectModelTransaction(modelResolution.errorText);
   }
-  const modelSelection = modelResolution.modelSelection;
-  const profileOverride = modelResolution.profileOverride;
+  const { modelSelection, profileOverride } = modelResolution;
   if (modelSelection && isModelSelectionLocked(sessionEntry)) {
     return rejectModelTransaction(MODEL_SELECTION_LOCKED_MESSAGE);
   }
 
   const resolvedProvider = modelSelection?.provider ?? provider;
   const resolvedModel = modelSelection?.model ?? model;
-  let modelRuntimeResolution: Parameters<typeof applyModelRuntimeDirective>[1] = {
-    kind: "unchanged",
-  };
+  let modelRuntimeResolution: ModelRuntimeResolution = { kind: "unchanged" };
   if (modelSelection) {
     const prepared = await prepareModelSelectionRuntime({
       cfg: params.cfg,
@@ -180,7 +178,7 @@ export async function handleDirectiveOnly(
       model: resolvedModel,
       catalog: thinkingCatalog ?? [],
       rawRuntime: directives.rawModelRuntime,
-      workspaceDir: params.workspaceDir ?? resolveAgentWorkspaceDir(params.cfg, activeAgentId),
+      workspaceDir: params.workspaceDir,
       sessionKey: params.sessionKey,
       sessionEntry,
     });

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -179,6 +179,7 @@ export async function handleDirectiveOnly(
       model: resolvedModel,
       catalog: thinkingCatalog ?? [],
       rawRuntime: directives.rawModelRuntime,
+      workspaceDir: params.workspaceDir,
       sessionEntry,
     });
     if (prepared.status === "rejected") {

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -1,5 +1,6 @@
 /** Applies directive-only command state changes without running the agent. */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { renderExecTargetLabel } from "../../agents/bash-tools.exec-runtime.js";
 import { resolveExecDefaults } from "../../agents/exec-defaults.js";
 import {
@@ -179,7 +180,7 @@ export async function handleDirectiveOnly(
       model: resolvedModel,
       catalog: thinkingCatalog ?? [],
       rawRuntime: directives.rawModelRuntime,
-      workspaceDir: params.workspaceDir,
+      workspaceDir: params.workspaceDir ?? resolveAgentWorkspaceDir(params.cfg, activeAgentId),
       sessionEntry,
     });
     if (prepared.status === "rejected") {

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -1673,6 +1673,29 @@ describe("/model chat UX", () => {
     expect(persisted.directiveAck?.text).toContain("Runtime set to codex for this session.");
   });
 
+  it("rejects model directives when the selected harness is denied", async () => {
+    const sessionEntry = createSessionEntry({
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-6",
+      modelOverrideSource: "user",
+    });
+    const initialSessionEntry = { ...sessionEntry };
+    const { persisted } = await persistModelDirectiveForTest({
+      command: "/model openai/gpt-4o --runtime codex hello",
+      allowedModelKeys: ["openai/gpt-4o"],
+      sessionEntry,
+      cfg: {
+        ...baseConfig(),
+        plugins: { deny: ["codex"] },
+      },
+    });
+
+    expect(persisted.errorText).toBe(
+      'Model openai/gpt-4o requires agent harness "codex", but no enabled plugin provides it. Install and enable its plugin, restart the Gateway, then select the model again.',
+    );
+    expect(sessionEntry).toEqual(initialSessionEntry);
+  });
+
   it("normalizes legacy Codex app-server runtime overrides during persistence", async () => {
     const { sessionEntry } = await persistModelDirectiveForTest({
       command: "/model openai/gpt-4o --runtime codex-app-server hello",

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -1705,9 +1705,9 @@ describe("/model chat UX", () => {
     expect(sessionEntry).toEqual(initialSessionEntry);
   });
 
-  it("preserves harness selection for an existing ACP session", async () => {
+  it("preserves harness selection when an ACP backend owns the session", async () => {
     acpSessionMetaMock.readForEntry.mockReturnValue({
-      backend: "codex",
+      backend: "acpx",
       agent: "main",
       runtimeSessionName: "agent:main:dm:1",
       mode: "persistent",

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -27,12 +27,20 @@ const modelsCommandMock = vi.hoisted(() => ({
 const stickyModelMock = vi.hoisted(() => ({
   persistBestEffort: vi.fn(),
 }));
+const acpSessionMetaMock = vi.hoisted(() => ({
+  readForEntry: vi.fn(),
+}));
 const pluginPolicyMock = vi.hoisted(() => ({
   channels: new Map<string, Pick<ChannelPlugin, "id" | "commands">>(),
   thinkingProfiles: new Map<
     string,
     (context: ProviderDefaultThinkingPolicyContext) => ProviderThinkingProfile | null | undefined
   >(),
+}));
+
+vi.mock("../../acp/runtime/session-meta.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../acp/runtime/session-meta.js")>()),
+  readAcpSessionMetaForEntry: acpSessionMetaMock.readForEntry,
 }));
 
 function defaultModelsCommandReply() {
@@ -486,6 +494,7 @@ function setOpenAiRuntimeScopedUltraProvider(): void {
 
 beforeEach(() => {
   vi.useRealTimers();
+  acpSessionMetaMock.readForEntry.mockReset().mockReturnValue(undefined);
   setDirectiveTestProviders([]);
   pluginPolicyMock.channels.clear();
   modelsCommandMock.resolveModelsCommandReply
@@ -1694,6 +1703,36 @@ describe("/model chat UX", () => {
       'Model openai/gpt-4o requires agent harness "codex", but no enabled plugin provides it. Install and enable its plugin, restart the Gateway, then select the model again.',
     );
     expect(sessionEntry).toEqual(initialSessionEntry);
+  });
+
+  it("preserves harness selection for an existing ACP session", async () => {
+    acpSessionMetaMock.readForEntry.mockReturnValue({
+      backend: "codex",
+      agent: "main",
+      runtimeSessionName: "agent:main:dm:1",
+      mode: "persistent",
+      state: "idle",
+      lastActivityAt: 1,
+    });
+    const sessionEntry = createSessionEntry();
+    const { persisted } = await persistModelDirectiveForTest({
+      command: "/model openai/gpt-4o --runtime codex hello",
+      allowedModelKeys: ["openai/gpt-4o"],
+      sessionEntry,
+      cfg: {
+        ...baseConfig(),
+        plugins: { deny: ["codex"] },
+      },
+    });
+
+    expect(persisted.errorText).toBeUndefined();
+    expect(sessionEntry.agentRuntimeOverride).toBe("codex");
+    expect(acpSessionMetaMock.readForEntry).toHaveBeenCalledWith({
+      sessionKey: "agent:main:dm:1",
+      agentId: "main",
+      cfg: expect.objectContaining({ plugins: { deny: ["codex"] } }),
+      entry: sessionEntry,
+    });
   });
 
   it("normalizes legacy Codex app-server runtime overrides during persistence", async () => {

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -435,6 +435,7 @@ export async function applyInlineDirectiveOverrides(params: {
         ).applySessionModelSelection({
           cfg,
           agentId,
+          workspaceDir,
           sessionKey,
           storePath,
           sessionEntry,

--- a/src/auto-reply/reply/model-runtime-normalization.ts
+++ b/src/auto-reply/reply/model-runtime-normalization.ts
@@ -1,4 +1,5 @@
 /** Prepared plugin metadata handoff for runtime model normalization. */
+import { resolveMissingAgentHarnessRuntime } from "../../agents/harness/runtime-plugin-load-plan.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import {
   findNormalizedProviderKey,
@@ -74,7 +75,11 @@ type ModelSelectionPreparation =
       catalog: ModelCatalogEntry[];
       runtime: Exclude<ReturnType<typeof resolveModelRuntimeDirective>, { kind: "invalid" }>;
     }
-  | { status: "rejected"; reason: "invalid-runtime" | "unknown-provider"; message: string };
+  | {
+      status: "rejected";
+      reason: "invalid-runtime" | "unknown-provider" | "missing-harness";
+      message: string;
+    };
 
 /** Prepare runtime and capabilities for the selected route before any session mutation. */
 export async function prepareModelSelectionRuntime(params: {
@@ -84,6 +89,7 @@ export async function prepareModelSelectionRuntime(params: {
   model: string;
   catalog: readonly ModelCatalogEntry[];
   rawRuntime?: string;
+  workspaceDir: string;
   sessionEntry?: Pick<SessionEntry, "agentRuntimeOverride">;
 }): Promise<ModelSelectionPreparation> {
   const runtime = resolveModelRuntimeDirective(params);
@@ -96,6 +102,28 @@ export async function prepareModelSelectionRuntime(params: {
       status: "rejected",
       reason: "unknown-provider",
       message: `Unknown provider "${params.provider}". Use /models to list providers.`,
+    };
+  }
+  const missingHarnessRuntime = resolveMissingAgentHarnessRuntime({
+    selection: {
+      provider: params.provider,
+      modelId: params.model,
+      runtime:
+        runtime.kind === "set"
+          ? runtime.runtime
+          : runtime.kind === "unchanged"
+            ? params.sessionEntry?.agentRuntimeOverride
+            : undefined,
+      agentId: params.agentId,
+    },
+    config: params.cfg,
+    workspaceDir: params.workspaceDir,
+  });
+  if (missingHarnessRuntime) {
+    return {
+      status: "rejected",
+      reason: "missing-harness",
+      message: `Model ${params.provider}/${params.model} requires agent harness "${missingHarnessRuntime}", but no enabled plugin provides it. Install and enable its plugin, restart the Gateway, then select the model again.`,
     };
   }
   if (selected?.reasoning !== undefined) {

--- a/src/auto-reply/reply/model-runtime-normalization.ts
+++ b/src/auto-reply/reply/model-runtime-normalization.ts
@@ -90,7 +90,7 @@ export async function prepareModelSelectionRuntime(params: {
   model: string;
   catalog: readonly ModelCatalogEntry[];
   rawRuntime?: string;
-  workspaceDir: string;
+  workspaceDir?: string;
   sessionKey: string;
   sessionEntry?: SessionEntry;
 }): Promise<ModelSelectionPreparation> {
@@ -106,21 +106,23 @@ export async function prepareModelSelectionRuntime(params: {
       message: `Unknown provider "${params.provider}". Use /models to list providers.`,
     };
   }
-  const missingHarnessRuntime = resolveMissingAgentHarnessRuntime({
-    selection: {
-      provider: params.provider,
-      modelId: params.model,
-      runtime:
-        runtime.kind === "set"
-          ? runtime.runtime
-          : runtime.kind === "unchanged"
-            ? params.sessionEntry?.agentRuntimeOverride
-            : undefined,
-      agentId: params.agentId,
-    },
-    config: params.cfg,
-    workspaceDir: params.workspaceDir,
-  });
+  const missingHarnessRuntime = params.workspaceDir
+    ? resolveMissingAgentHarnessRuntime({
+        selection: {
+          provider: params.provider,
+          modelId: params.model,
+          runtime:
+            runtime.kind === "set"
+              ? runtime.runtime
+              : runtime.kind === "unchanged"
+                ? params.sessionEntry?.agentRuntimeOverride
+                : undefined,
+          agentId: params.agentId,
+        },
+        config: params.cfg,
+        workspaceDir: params.workspaceDir,
+      })
+    : undefined;
   // Existing ACP metadata owns this session's concrete backend. Model selection may update
   // policy, but it must not require a separate plugin harness while that binding is active.
   if (

--- a/src/auto-reply/reply/model-runtime-normalization.ts
+++ b/src/auto-reply/reply/model-runtime-normalization.ts
@@ -1,4 +1,5 @@
 /** Prepared plugin metadata handoff for runtime model normalization. */
+import { readAcpSessionMetaForEntry } from "../../acp/runtime/session-meta.js";
 import { resolveMissingAgentHarnessRuntime } from "../../agents/harness/runtime-plugin-load-plan.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import {
@@ -90,7 +91,8 @@ export async function prepareModelSelectionRuntime(params: {
   catalog: readonly ModelCatalogEntry[];
   rawRuntime?: string;
   workspaceDir: string;
-  sessionEntry?: Pick<SessionEntry, "agentRuntimeOverride">;
+  sessionKey: string;
+  sessionEntry?: SessionEntry;
 }): Promise<ModelSelectionPreparation> {
   const runtime = resolveModelRuntimeDirective(params);
   if (runtime.kind === "invalid") {
@@ -119,7 +121,15 @@ export async function prepareModelSelectionRuntime(params: {
     config: params.cfg,
     workspaceDir: params.workspaceDir,
   });
-  if (missingHarnessRuntime) {
+  if (
+    missingHarnessRuntime &&
+    !readAcpSessionMetaForEntry({
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      cfg: params.cfg,
+      entry: params.sessionEntry,
+    })
+  ) {
     return {
       status: "rejected",
       reason: "missing-harness",

--- a/src/auto-reply/reply/model-runtime-normalization.ts
+++ b/src/auto-reply/reply/model-runtime-normalization.ts
@@ -121,6 +121,8 @@ export async function prepareModelSelectionRuntime(params: {
     config: params.cfg,
     workspaceDir: params.workspaceDir,
   });
+  // Existing ACP metadata owns this session's concrete backend. Model selection may update
+  // policy, but it must not require a separate plugin harness while that binding is active.
   if (
     missingHarnessRuntime &&
     !readAcpSessionMetaForEntry({

--- a/src/gateway/chat-auth-readiness.integration.test.ts
+++ b/src/gateway/chat-auth-readiness.integration.test.ts
@@ -87,6 +87,7 @@ it("refreshes a retained pane from a persisted profile-only selection through th
         applySessionModelSelection({
           cfg: getRuntimeConfig(),
           agentId: "main",
+          workspaceDir: process.cwd(),
           sessionKey,
           storePath: resolveSessionStorePathCore(undefined, { agentId: "main" }),
           sessionEntry: entry,

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -13,10 +13,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
-import {
-  requiresAgentHarnessPluginSelection,
-  resolveAgentHarnessOwnerPluginIds,
-} from "../agents/harness/runtime-plugin-load-plan.js";
+import { resolveMissingAgentHarnessRuntime } from "../agents/harness/runtime-plugin-load-plan.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import {
@@ -522,21 +519,20 @@ export async function projectSessionsPatchEntry(params: {
         runtime: resolveThinkingRuntime(selection.provider, selection.model, next),
         agentId: sessionAgentId,
       };
-      if (
-        !readAcpSessionMetaForEntry({
-          sessionKey: storeKey,
-          agentId: sessionAgentId,
-          entry: next,
-        }) &&
-        requiresAgentHarnessPluginSelection(harnessSelection, cfg) &&
-        resolveAgentHarnessOwnerPluginIds({
-          ...harnessSelection,
-          config: cfg,
-          workspaceDir: resolveAgentWorkspaceDir(cfg, sessionAgentId),
-        }).length === 0
-      ) {
+      const missingHarnessRuntime = readAcpSessionMetaForEntry({
+        sessionKey: storeKey,
+        agentId: sessionAgentId,
+        entry: next,
+      })
+        ? undefined
+        : resolveMissingAgentHarnessRuntime({
+            selection: harnessSelection,
+            config: cfg,
+            workspaceDir: resolveAgentWorkspaceDir(cfg, sessionAgentId),
+          });
+      if (missingHarnessRuntime) {
         return invalid(
-          `Model ${selection.provider}/${selection.model} requires agent harness "${harnessSelection.runtime}", but no enabled plugin provides it. Install and enable its plugin, restart the Gateway, then select the model again.`,
+          `Model ${selection.provider}/${selection.model} requires agent harness "${missingHarnessRuntime}", but no enabled plugin provides it. Install and enable its plugin, restart the Gateway, then select the model again.`,
         );
       }
       applyModelOverrideWithAuthProfileCompatibility({

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -522,6 +522,7 @@ export async function projectSessionsPatchEntry(params: {
       const missingHarnessRuntime = readAcpSessionMetaForEntry({
         sessionKey: storeKey,
         agentId: sessionAgentId,
+        cfg,
         entry: next,
       })
         ? undefined

--- a/src/model-picker/apply-session-model-selection.test.ts
+++ b/src/model-picker/apply-session-model-selection.test.ts
@@ -88,6 +88,7 @@ function createParams(overrides: Partial<ApplySessionModelSelectionParams> = {})
   return {
     cfg: {},
     agentId: "main",
+    workspaceDir: "/tmp/workspace",
     sessionKey,
     sessionEntry,
     sessionStore: { [sessionKey]: sessionEntry },

--- a/src/model-picker/apply-session-model-selection.ts
+++ b/src/model-picker/apply-session-model-selection.ts
@@ -1,4 +1,8 @@
-import { resolveAgentDir, type AgentModelPrimaryWriteTarget } from "../agents/agent-scope.js";
+import {
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  type AgentModelPrimaryWriteTarget,
+} from "../agents/agent-scope.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import { modelKey } from "../agents/model-selection.js";
 import {
@@ -90,7 +94,7 @@ export type ApplySessionModelSelectionResult =
     }
   | {
       status: "rejected";
-      reason: "locked" | "not-allowed" | "invalid-runtime" | "unknown-provider";
+      reason: "locked" | "not-allowed" | "invalid-runtime" | "unknown-provider" | "missing-harness";
       message: string;
     }
   | { status: "conflict"; message: string };
@@ -184,6 +188,7 @@ export async function applySessionModelSelection(
     provider: request.provider,
     model: request.model,
     catalog: params.thinkingCatalog ?? params.modelCatalog,
+    workspaceDir: resolveAgentWorkspaceDir(params.cfg, params.agentId),
     rawRuntime:
       request.runtime.kind === "set"
         ? request.runtime.runtime

--- a/src/model-picker/apply-session-model-selection.ts
+++ b/src/model-picker/apply-session-model-selection.ts
@@ -1,8 +1,4 @@
-import {
-  resolveAgentDir,
-  resolveAgentWorkspaceDir,
-  type AgentModelPrimaryWriteTarget,
-} from "../agents/agent-scope.js";
+import { resolveAgentDir, type AgentModelPrimaryWriteTarget } from "../agents/agent-scope.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import { modelKey } from "../agents/model-selection.js";
 import {
@@ -54,6 +50,7 @@ export type SessionModelSelectionRequest = {
 export type ApplySessionModelSelectionParams = {
   cfg: OpenClawConfig;
   agentId: string;
+  workspaceDir: string;
   sessionKey: string;
   storePath?: string;
   sessionEntry: SessionEntry;
@@ -188,7 +185,7 @@ export async function applySessionModelSelection(
     provider: request.provider,
     model: request.model,
     catalog: params.thinkingCatalog ?? params.modelCatalog,
-    workspaceDir: resolveAgentWorkspaceDir(params.cfg, params.agentId),
+    workspaceDir: params.workspaceDir,
     sessionKey: params.sessionKey,
     rawRuntime:
       request.runtime.kind === "set"

--- a/src/model-picker/apply-session-model-selection.ts
+++ b/src/model-picker/apply-session-model-selection.ts
@@ -189,6 +189,7 @@ export async function applySessionModelSelection(
     model: request.model,
     catalog: params.thinkingCatalog ?? params.modelCatalog,
     workspaceDir: resolveAgentWorkspaceDir(params.cfg, params.agentId),
+    sessionKey: params.sessionKey,
     rawRuntime:
       request.runtime.kind === "set"
         ? request.runtime.runtime


### PR DESCRIPTION
Related: #134837

## What Problem This Solves

Fixes an issue where a chat `/model` directive or picker action could persist a model selection whose harness runtime owner was missing or disabled, leaving the session unable to run.

## Why This Change Was Made

Model-selection preparation now applies the same canonical harness-owner admission check used by Gateway session patching before mutating session state. Callers carry their prepared workspace into that check, and existing ACP-owned sessions retain their exemption.

## User Impact

Users get an actionable rejection immediately instead of saving a model selection that cannot execute.

## Evidence

- Focused exact-head Vitest passed: 4 tests across `directive-handling.model.test.ts` and `directive-handling.mixed-inline.test.ts`, including denied-owner rejection, unchanged ACP behavior, and both previously failing mixed-inline paths.
- The Telegram model-callback integration exercised its callback/model-selection path on `dc5dc3f2fd9130494d054b3fc47bc07958f16a59`; the only reported failure was Windows cleanup (`EBUSY` unlinking the temporary `openclaw-agent.sqlite`) after the behavior path.
- Targeted `oxlint`, `oxfmt`, and `git diff --check` pass, including the Telegram callback caller added after CI identified its missing `workspaceDir`.
- CI-discovered caller coverage was repaired by passing `resolveAgentWorkspaceDir(runtimeCfg, agentId)` through Telegram's existing public SDK boundary.
- GPT-5.5 exact-head branch autoreview is clean on `dc5dc3f2fd9130494d054b3fc47bc07958f16a59` (high reasoning, confidence 0.86).
- A real exact-head Gateway trace for denied, enabled-owner, and ACP-owned selections remains the external proof requested by ClawSweeper; no live-runtime claim is made here.