### PR TITLE
fix(plugins): sanitize public verification diagnostics

### DIFF
--- a/src/plugins/runtime-degraded-state.test.ts
+++ b/src/plugins/runtime-degraded-state.test.ts
@@ -2,7 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withTempDirSync } from "../test-helpers/temp-dir.js";
-import { pluginInstallPathMatchesRoot } from "./runtime-degraded-state.js";
+import {
+  pluginInstallPathMatchesRoot,
+  toPublicPluginVerificationDiagnostic,
+} from "./runtime-degraded-state.js";
 
 describe("pluginInstallPathMatchesRoot", () => {
   it("matches an existing plugin root through a symlink alias", () => {
@@ -30,5 +33,30 @@ describe("pluginInstallPathMatchesRoot", () => {
         false,
       );
     });
+  });
+});
+
+describe("toPublicPluginVerificationDiagnostic", () => {
+  it("redacts credentials before bounding public detail", () => {
+    const secret = "sk-proj-public-diagnostic-secret";
+    const diagnostic = toPublicPluginVerificationDiagnostic({
+      kind: "plugin-verification",
+      reason: "invalid-package-json",
+      detail: `api_key=${secret} ${"x".repeat(1_200)}`,
+    });
+
+    expect(diagnostic.detail).not.toContain(secret);
+    expect(diagnostic.detail.length).toBeLessThanOrEqual(1_000);
+  });
+
+  it("does not split a surrogate pair at the public detail limit", () => {
+    const diagnostic = toPublicPluginVerificationDiagnostic({
+      kind: "plugin-verification",
+      reason: "invalid-package-json",
+      detail: `${"x".repeat(999)}😀`,
+    });
+
+    expect(diagnostic.detail).toHaveLength(999);
+    expect(diagnostic.detail).not.toMatch(/[\uD800-\uDFFF]$/u);
   });
 });

--- a/src/plugins/runtime-degraded-state.test.ts
+++ b/src/plugins/runtime-degraded-state.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { withTempDirSync } from "../test-helpers/temp-dir.js";
 import {
   pluginInstallPathMatchesRoot,
@@ -38,14 +39,15 @@ describe("pluginInstallPathMatchesRoot", () => {
 
 describe("toPublicPluginVerificationDiagnostic", () => {
   it("redacts credentials before bounding public detail", () => {
-    const secret = "sk-proj-public-diagnostic-secret";
+    const fixtureCredential = "fixture-only-public-diagnostic-value";
+    registerSecretValueForRedaction(fixtureCredential);
     const diagnostic = toPublicPluginVerificationDiagnostic({
       kind: "plugin-verification",
       reason: "invalid-package-json",
-      detail: `api_key=${secret} ${"x".repeat(1_200)}`,
+      detail: `${fixtureCredential} ${"x".repeat(1_200)}`,
     });
 
-    expect(diagnostic.detail).not.toContain(secret);
+    expect(diagnostic.detail).not.toContain(fixtureCredential);
     expect(diagnostic.detail.length).toBeLessThanOrEqual(1_000);
   });
 

--- a/src/plugins/runtime-degraded-state.test.ts
+++ b/src/plugins/runtime-degraded-state.test.ts
@@ -1,12 +1,17 @@
 import fs from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
 import { withTempDirSync } from "../test-helpers/temp-dir.js";
 import {
   pluginInstallPathMatchesRoot,
   toPublicPluginVerificationDiagnostic,
 } from "./runtime-degraded-state.js";
+
+afterEach(() => {
+  resetSecretRedactionRegistryForTest();
+});
 
 describe("pluginInstallPathMatchesRoot", () => {
   it("matches an existing plugin root through a symlink alias", () => {

--- a/src/plugins/runtime-degraded-state.test.ts
+++ b/src/plugins/runtime-degraded-state.test.ts
@@ -39,15 +39,15 @@ describe("pluginInstallPathMatchesRoot", () => {
 
 describe("toPublicPluginVerificationDiagnostic", () => {
   it("redacts credentials before bounding public detail", () => {
-    const fixtureCredential = "fixture-only-public-diagnostic-value";
-    registerSecretValueForRedaction(fixtureCredential);
+    const registeredFixture = "fixture-only-public-diagnostic-value";
+    registerSecretValueForRedaction(registeredFixture);
     const diagnostic = toPublicPluginVerificationDiagnostic({
       kind: "plugin-verification",
       reason: "invalid-package-json",
-      detail: `${fixtureCredential} ${"x".repeat(1_200)}`,
+      detail: `${registeredFixture} ${"x".repeat(1_200)}`,
     });
 
-    expect(diagnostic.detail).not.toContain(fixtureCredential);
+    expect(diagnostic.detail).not.toContain(registeredFixture);
     expect(diagnostic.detail.length).toBeLessThanOrEqual(1_000);
   });
 

--- a/src/plugins/runtime-degraded-state.ts
+++ b/src/plugins/runtime-degraded-state.ts
@@ -1,4 +1,6 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveRealpathOrAbsolute } from "../infra/boundary-path.js";
+import { redactToolPayloadText } from "../logging/redact.js";
 
 /** Boot-stable quarantine state for configured plugins whose payload failed verification. */
 
@@ -112,7 +114,7 @@ export function degradedPluginMatchesRoot(plugin: DegradedPlugin, rootDir: strin
 export function toPublicPluginVerificationDiagnostic(
   diagnostic: PluginVerificationDiagnostic,
 ): PublicPluginVerificationDiagnostic {
-  const detail =
+  const privatePathRedactedDetail =
     diagnostic.reason === "missing-openclaw-peer-link"
       ? 'Plugin declares peerDependency "openclaw", but its host peer link is missing or invalid.'
       : diagnostic.installPath
@@ -121,7 +123,7 @@ export function toPublicPluginVerificationDiagnostic(
   return {
     kind: diagnostic.kind,
     reason: diagnostic.reason,
-    detail,
+    detail: truncateUtf16Safe(redactToolPayloadText(privatePathRedactedDetail), 1_000),
   };
 }
 


### PR DESCRIPTION
Related: #135082

## What Problem This Solves

Fixes an issue where plugin verification details exposed through public health and status surfaces could include credential-like text or grow without a public payload bound.

## Why This Change Was Made

The existing public diagnostic projection now removes private install paths, applies the canonical tool-payload redactor, and then truncates to 1,000 UTF-16 code units without splitting surrogate pairs.

## User Impact

Public plugin health diagnostics remain useful while avoiding accidental credential disclosure and oversized detail payloads.

## Evidence

- Production-boundary probe called `collectGatewayHealthSnapshot({ audience: "admin", probe: false })` with an empty runtime registry and a synthetic degraded-plugin diagnostic containing a synthetic Bearer value, 1,200 ASCII units, and a trailing astral character.
- The observed public `plugins.unavailable[0].diagnostic` reported `reason: invalid-package-json`, `containsSyntheticCredential: false`, `detailLength: 1000`, and `endsWithLoneSurrogate: false`. No real credential or private path was used.
- Exact-head focused Vitest on `df53ed0e52e915dd2ae73539014979de0931aad2`: 2 passed, 2 skipped in `src/plugins/runtime-degraded-state.test.ts` for registry-backed masking, the 1,000-unit bound, and surrogate-safe truncation.
- The branch was rebased onto current main, which includes the unrelated `models-cli.auth-login.integration.test.ts` TS2790 repair that caused the prior `check-test-types-core-4` failure.
- Targeted `oxfmt --check`, `oxlint`, and `git diff --check` passed.
- Follow-up `20d6abfe671c49164c3c4df77dde9ed0eee0e6f4` resets the process-global secret-redaction registry after each test, preventing leakage under serial `isolate: false` execution.
- Fresh exact-head GPT-5.5 autoreview is clean on `20d6abfe671c49164c3c4df77dde9ed0eee0e6f4` (confidence 0.86).