### PR TITLE
fix(perplexity): preserve prepared credential source routing

### DIFF
--- a/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
@@ -25,11 +25,13 @@ import {
 } from "openclaw/plugin-sdk/provider-web-search";
 import { normalizeOptionalString, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
+  hasPerplexityLegacyOverride,
   isDirectPerplexityBaseUrl,
   resolvePerplexityConfig,
   resolvePerplexityRuntime,
   type PerplexityAuth,
   type PerplexityConfig,
+  type PerplexityTransport,
 } from "./perplexity-web-search-provider.shared.js";
 
 const PERPLEXITY_SEARCH_ENDPOINT = "https://api.perplexity.ai/search";
@@ -76,6 +78,22 @@ function resolvePerplexityApiKey(perplexity?: PerplexityConfig): PerplexityAuth 
     return { apiKey: fromOpenRouterEnv, source: "openrouter_env" };
   }
   return { apiKey: undefined, source: "none" };
+}
+
+function alignPerplexityAuthWithPreparedTransport(
+  perplexity: PerplexityConfig,
+  auth: PerplexityAuth,
+  preparedTransport?: PerplexityTransport,
+): PerplexityAuth {
+  if (!preparedTransport || hasPerplexityLegacyOverride(perplexity)) {
+    return auth;
+  }
+  // Credential preparation materializes env/SecretRef values into config. Preserve the
+  // already-resolved endpoint decision instead of reclassifying that value as config-owned.
+  return {
+    ...auth,
+    source: preparedTransport === "search_api" ? "perplexity_env" : "openrouter_env",
+  };
 }
 
 function resolvePerplexityRequestModel(baseUrl: string, model: string): string {
@@ -254,11 +272,16 @@ export async function executePerplexitySearch(
   args: Record<string, unknown>,
   searchConfig?: SearchConfigRecord,
   signal?: AbortSignal,
+  preparedTransport?: PerplexityTransport,
 ): Promise<Record<string, unknown>> {
   const perplexityConfig = resolvePerplexityConfig(searchConfig);
   const runtime = resolvePerplexityRuntime(
     perplexityConfig,
-    resolvePerplexityApiKey(perplexityConfig),
+    alignPerplexityAuthWithPreparedTransport(
+      perplexityConfig,
+      resolvePerplexityApiKey(perplexityConfig),
+      preparedTransport,
+    ),
   );
   if (!runtime.apiKey) {
     return {

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -533,11 +533,11 @@ describe("perplexity web search provider", () => {
         [perplexityApiKeyEnv]:
           fallbackEnvVar === perplexityApiKeyEnv && source === "env"
             ? key
-            : "pplx-ambient-distractor",
+            : "ambient-perplexity-distractor",
         [openRouterApiKeyEnv]:
           fallbackEnvVar === openRouterApiKeyEnv && source === "env"
             ? key
-            : "sk-or-ambient-distractor",
+            : "ambient-openrouter-distractor",
       },
       async () => {
         const provider = createPerplexityWebSearchProvider();

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -563,9 +563,8 @@ describe("perplexity web search provider", () => {
         });
         const chat = "model" in entry;
         expect(metadata).toEqual({ perplexityTransport: chat ? "chat_completions" : "search_api" });
-        if (source === "secretRef") {
-          provider.setConfiguredCredentialValue?.(config, key);
-        }
+        // Runtime credential preparation materializes every resolved source into config.
+        provider.setConfiguredCredentialValue?.(config, key);
         const tool = provider.createTool({
           config,
           runtimeMetadata: { providerSource: "configured", diagnostics: [], ...metadata },

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -530,11 +530,14 @@ describe("perplexity web search provider", () => {
     const fallbackEnvVar = "fallbackEnvVar" in entry ? entry.fallbackEnvVar : undefined;
     await withEnvAsync(
       {
-        [perplexityApiKeyEnv]: undefined,
-        [openRouterApiKeyEnv]: undefined,
-        ...(fallbackEnvVar
-          ? { [fallbackEnvVar]: source === "env" ? key : directPerplexityApiKey }
-          : {}),
+        [perplexityApiKeyEnv]:
+          fallbackEnvVar === perplexityApiKeyEnv && source === "env"
+            ? key
+            : "pplx-ambient-distractor",
+        [openRouterApiKeyEnv]:
+          fallbackEnvVar === openRouterApiKeyEnv && source === "env"
+            ? key
+            : "sk-or-ambient-distractor",
       },
       async () => {
         const provider = createPerplexityWebSearchProvider();

--- a/extensions/perplexity/src/perplexity-web-search-provider.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.ts
@@ -11,6 +11,7 @@ import {
   hasPerplexityLegacyOverride,
   resolvePerplexityConfig,
   resolvePerplexityWebSearchRuntimeMetadata,
+  type PerplexityTransport,
 } from "./perplexity-web-search-provider.shared.js";
 
 const loadPerplexityWebSearchRuntime = createLazyRuntimeModule(
@@ -78,7 +79,7 @@ function createPerplexityParameters(transport?: string): Record<string, unknown>
 
 function createPerplexityToolDefinition(
   searchConfig?: Record<string, unknown>,
-  runtimeTransport?: string,
+  runtimeTransport?: PerplexityTransport,
 ): WebSearchProviderToolDefinition {
   const schemaTransport =
     runtimeTransport ??
@@ -95,7 +96,7 @@ function createPerplexityToolDefinition(
     execute: async (args, context) => {
       context?.signal?.throwIfAborted();
       const { executePerplexitySearch } = await loadPerplexityWebSearchRuntime();
-      return await executePerplexitySearch(args, searchConfig, context?.signal);
+      return await executePerplexitySearch(args, searchConfig, context?.signal, runtimeTransport);
     },
   };
 }


### PR DESCRIPTION
Related: #135159

## What Problem This Solves

Fixes an issue where a resolved Perplexity or OpenRouter environment credential could be routed to the wrong endpoint after credential preparation materialized its value into plugin config.

## Why This Change Was Made

Perplexity execution now carries forward the already-resolved transport decision used by metadata and schema generation. Legacy base URL and model overrides keep their existing behavior, and no new SDK field is introduced.

## User Impact

Perplexity and OpenRouter environment credentials keep their intended endpoint even when a key prefix resembles the other provider.

## Evidence

- Exact-head focused Vitest passed on `be2634c8a3da6990e7923e520fe78fc394e28a8b`: 12 passed, 39 skipped (`extensions/perplexity/src/perplexity-web-search-provider.test.ts`, routing matrix only).
- The routing matrix keeps both ambient provider env vars populated with distinct distractor values, materializes the selected credential as runtime preparation does, and asserts the resulting endpoint, Authorization value, schema, and request body for config, env, SecretRef, and legacy-override cases.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` pass.
- GPT-5.5 exact-head branch autoreview is clean on `be2634c8a3da6990e7923e520fe78fc394e28a8b` (confidence 0.78).
- No real Perplexity/OpenRouter credentials are available locally, so an authenticated live-provider call was not claimed.
### Remaining validation and contributor plan (2026-09-05)

Current source remains `be2634c8a3da6990e7923e520fe78fc394e28a8b`. No additional implementation change is proposed while the real-provider evidence gate remains unresolved.

The supplied 12-case focused matrix proves metadata/materialized-credential/request-construction behavior with a mocked HTTP boundary. It does not prove authenticated Perplexity or OpenRouter execution. Neither real provider credential is currently available to this contributor, and Crabbox authorization is unavailable. These are validation limitations, not a claim that Crabbox is a runtime dependency or the only possible proof backend.

The requested trace must start at actual Gateway credential preparation, retain the selected transport through lazy execution, and record the public endpoint and response outcome without exposing credential values. Both provider routes must be accounted for. An ordinary successful request with an unchanged key prefix alone would not establish coverage of the provenance-loss regression; the controlled regression matrix and live-path evidence must be distinguished.

Latest review: https://github.com/openclaw/openclaw/pull/135422#issuecomment-5498972748. It reports no actionable source finding and asks for authenticated behavior evidence. Further code expansion or additional mocks would not satisfy that gate. Implementation work is paused pending an authorized real-provider validation path or maintainer-assisted proof; the PR remains open and no proof waiver is assumed.

The outstanding exact-head CI lint job is https://github.com/openclaw/openclaw/actions/runs/33554949621/job/100013672574. Its observed failure is the harness argument error `--extension-stripe requires a non-empty extension-only shard selection`, not a reported lint diagnostic in this provider change. It remains unresolved; no green aggregate is claimed.