### PR TITLE
fix(talk): keep internal consult prompts out of later model context

### DIFF
--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -38,6 +38,13 @@ their current ephemeral-token and WebRTC data-channel flow.
 
 Finalized realtime user and assistant utterances are always appended live to the active agent session, so later chat and voice turns share one history. Client-owned transports report their finalized transcripts with stable entry ids; Gateway relay and Gateway-controlled WebRTC sessions append the same events server-side. Provider sessions also receive the bounded realtime profile context used by Discord voice.
 
+Generated agent-consult prompts are internal input, not spoken user turns. New
+consult records are hidden from chat and excluded from later model context, while
+the active consult still receives the full question, context, and response style.
+Raw archives and [session exports](/tools/slash-commands) remain lossless. Existing
+consult records without the exclusion flag are not rewritten and remain eligible
+for model context.
+
 OpenAI GA browser Talk keeps provider conversation order even when an assistant
 reply finishes before the user's transcription or item announcements arrive out
 of order. Text streams immediately in the call view; late predecessor metadata

--- a/src/agents/embedded-agent-runner/run/attempt-session-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-boundary.test.ts
@@ -589,65 +589,77 @@ describe("prepareEmbeddedAttemptSessionBoundary", () => {
     },
   );
 
-  it("repairs a durable user leaf that does not match the admitted current user", async () => {
-    const currentUser = {
-      role: "user" as const,
-      content: "current prompt",
-      idempotencyKey: "current-run:user",
-      timestamp: 2,
-    };
-    const repairedMessages: AgentMessage[] = [currentUser];
-    const { activeSession } = createActiveSession([]);
-    const branch = vi.fn();
-    const clearNextUserMessagePersistenceSuppression = vi.fn();
-    const onUserMessagePersistenceInvalidated = vi.fn();
-    const sessionManager = createSessionManager({
-      getLeafEntry: () => ({
-        id: "orphan-user",
-        parentId: "previous-assistant",
-        timestamp: "2026-07-13T00:00:00.000Z",
-        type: "message",
-        message: {
-          role: "user",
-          content: "old prompt",
-          idempotencyKey: "previous-run:user",
-          timestamp: 1,
+  it.each([false, true])(
+    "handles a different durable user leaf with current-turn exclusion %s",
+    async (excludeFromContext) => {
+      const currentUser = {
+        role: "user" as const,
+        content: "current prompt",
+        idempotencyKey: "current-run:user",
+        excludeFromContext,
+        timestamp: 2,
+      };
+      const repairedMessages: AgentMessage[] = [currentUser];
+      const { activeSession } = createActiveSession([]);
+      const branch = vi.fn();
+      const clearNextUserMessagePersistenceSuppression = vi.fn();
+      const onUserMessagePersistenceInvalidated = vi.fn();
+      const sessionManager = createSessionManager({
+        getLeafEntry: () => ({
+          id: "orphan-user",
+          parentId: "previous-assistant",
+          timestamp: "2026-07-13T00:00:00.000Z",
+          type: "message",
+          message: {
+            role: "user",
+            content: "old prompt",
+            idempotencyKey: "previous-run:user",
+            timestamp: 1,
+          },
+        }),
+        branch,
+        clearNextUserMessagePersistenceSuppression,
+        buildSessionContext: () => ({ messages: repairedMessages }),
+      });
+      const recorder = {
+        getPersistedMessage: () => currentUser,
+        hasPersisted: () => true,
+      } as unknown as NonNullable<
+        Parameters<
+          typeof prepareEmbeddedAttemptSessionBoundary
+        >[0]["attempt"]["userTurnTranscriptRecorder"]
+      >;
+
+      const boundary = await prepareEmbeddedAttemptSessionBoundary({
+        activeSession,
+        attempt: {
+          onUserMessagePersistenceInvalidated,
+          prompt: "current prompt",
+          trigger: "user",
+          userTurnTranscriptRecorder: recorder,
         },
-      }),
-      branch,
-      clearNextUserMessagePersistenceSuppression,
-      buildSessionContext: () => ({ messages: repairedMessages }),
-    });
-    const recorder = {
-      getPersistedMessage: () => currentUser,
-      hasPersisted: () => true,
-    } as unknown as NonNullable<
-      Parameters<
-        typeof prepareEmbeddedAttemptSessionBoundary
-      >[0]["attempt"]["userTurnTranscriptRecorder"]
-    >;
+        getUserTranscriptContexts: () => undefined,
+        isRawModelRun: false,
+        preparedUserTurnMessage: undefined,
+        sessionManager,
+        setActiveSessionSystemPrompt: vi.fn(),
+      });
 
-    const boundary = await prepareEmbeddedAttemptSessionBoundary({
-      activeSession,
-      attempt: {
-        onUserMessagePersistenceInvalidated,
-        prompt: "current prompt",
-        trigger: "user",
-        userTurnTranscriptRecorder: recorder,
-      },
-      getUserTranscriptContexts: () => undefined,
-      isRawModelRun: false,
-      preparedUserTurnMessage: undefined,
-      sessionManager,
-      setActiveSessionSystemPrompt: vi.fn(),
-    });
-
-    expect(boundary.orphanRepair?.removeLeaf).toBe(true);
-    expect(branch).toHaveBeenCalledWith("previous-assistant");
-    expect(clearNextUserMessagePersistenceSuppression).toHaveBeenCalledOnce();
-    expect(onUserMessagePersistenceInvalidated).toHaveBeenCalledOnce();
-    expect(activeSession.agent.state.messages).toBe(repairedMessages);
-  });
+      if (excludeFromContext) {
+        expect(boundary.orphanRepair).toBeUndefined();
+        expect(branch).not.toHaveBeenCalled();
+        expect(clearNextUserMessagePersistenceSuppression).not.toHaveBeenCalled();
+        expect(onUserMessagePersistenceInvalidated).not.toHaveBeenCalled();
+        expect(activeSession.agent.state.messages).toEqual([]);
+      } else {
+        expect(boundary.orphanRepair?.removeLeaf).toBe(true);
+        expect(branch).toHaveBeenCalledWith("previous-assistant");
+        expect(clearNextUserMessagePersistenceSuppression).toHaveBeenCalledOnce();
+        expect(onUserMessagePersistenceInvalidated).toHaveBeenCalledOnce();
+        expect(activeSession.agent.state.messages).toBe(repairedMessages);
+      }
+    },
+  );
 
   it("repairs an orphaned user leaf before rebuilding active session messages", async () => {
     const repairedMessages: AgentMessage[] = [

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -2908,71 +2908,87 @@ describe("runEmbeddedAttempt tool-result guard budget wiring", () => {
     ).toBe(1_000_000);
   });
 
-  it("submits a pre-persisted current user turn exactly once to the provider", async () => {
-    const admittedMessage = {
-      role: "user" as const,
-      content: "durable current turn",
-      idempotencyKey: "restart-safe-run:user",
-      timestamp: 1,
-      __openclaw: { senderId: "alice-id", senderName: "Alice" },
-    };
-    const recorder = createUserTurnTranscriptRecorder({
-      message: admittedMessage,
-      target: () => undefined,
-    });
-    recorder.markRuntimePersisted(admittedMessage);
-    let submittedMessages: AgentMessage[] = [];
+  it.each([false, true])(
+    "submits a persisted current turn once with context exclusion %s",
+    async (excludeFromContext) => {
+      const admittedMessage = {
+        role: "user" as const,
+        content: "durable current turn",
+        idempotencyKey: "restart-safe-run:user",
+        ...(excludeFromContext ? { excludeFromContext: true as const } : {}),
+        timestamp: 1,
+        __openclaw: { senderId: "alice-id", senderName: "Alice" },
+      };
+      const recorder = createUserTurnTranscriptRecorder({
+        message: admittedMessage,
+        target: () => undefined,
+      });
+      recorder.markRuntimePersisted(admittedMessage);
+      if (excludeFromContext) {
+        hoisted.sessionManager.getLeafEntry.mockReturnValueOnce({
+          id: "speech",
+          parentId: "previous-assistant",
+          type: "message",
+          message: { role: "user", content: "spoken predecessor", timestamp: 0 },
+        });
+      }
+      let submittedMessages: AgentMessage[] = [];
+      const initialMessages = excludeFromContext ? [] : [admittedMessage];
 
-    await createContextEngineAttemptRunner({
-      contextEngine: createContextEngineBootstrapAndAssemble(),
-      sessionKey,
-      tempPaths,
-      sessionMessages: [admittedMessage],
-      attemptOverrides: {
-        prompt: admittedMessage.content,
-        transcriptPrompt: admittedMessage.content,
-        suppressNextUserMessagePersistence: true,
-        userTurnTranscriptRecorder: recorder,
-      },
-      createSession: () => {
-        const session = createDefaultEmbeddedSession({ initialMessages: [admittedMessage] });
-        session.agent.convertToLlm = vi.fn(async (messages) => messages as never);
-        const baseStreamFn = session.agent.streamFn;
-        session.agent.streamFn = async (...args) => {
-          const context = args[1] as { messages?: AgentMessage[] } | undefined;
-          submittedMessages =
-            ((await session.agent.convertToLlm?.(context?.messages ?? [])) as AgentMessage[]) ?? [];
-          return await baseStreamFn?.(...args);
-        };
-        session.prompt = async (prompt, options) => {
-          session.messages = [
-            ...session.messages,
-            {
-              role: "user",
-              content: prompt,
-              idempotencyKey: admittedMessage.idempotencyKey,
-              timestamp: admittedMessage.timestamp,
-            },
-          ];
-          options?.preflightResult?.(true);
-          await session.agent.streamFn?.(
-            {} as never,
-            { messages: session.messages } as never,
-            {} as never,
-          );
-          session.messages = [...session.messages, doneMessage];
-        };
-        return session;
-      },
-    });
+      const result = await createContextEngineAttemptRunner({
+        contextEngine: createContextEngineBootstrapAndAssemble(),
+        sessionKey,
+        tempPaths,
+        sessionMessages: initialMessages,
+        attemptOverrides: {
+          prompt: admittedMessage.content,
+          transcriptPrompt: admittedMessage.content,
+          suppressNextUserMessagePersistence: true,
+          userTurnTranscriptRecorder: recorder,
+        },
+        createSession: () => {
+          const session = createDefaultEmbeddedSession({ initialMessages });
+          session.agent.convertToLlm = vi.fn(async (messages) => messages as never);
+          const baseStreamFn = session.agent.streamFn;
+          session.agent.streamFn = async (...args) => {
+            const context = args[1] as { messages?: AgentMessage[] } | undefined;
+            submittedMessages =
+              ((await session.agent.convertToLlm?.(context?.messages ?? [])) as AgentMessage[]) ??
+              [];
+            return await baseStreamFn?.(...args);
+          };
+          session.prompt = async (prompt, options) => {
+            session.messages = [
+              ...session.messages,
+              {
+                role: "user",
+                content: prompt,
+                idempotencyKey: admittedMessage.idempotencyKey,
+                timestamp: admittedMessage.timestamp,
+              },
+            ];
+            options?.preflightResult?.(true);
+            await session.agent.streamFn?.(
+              {} as never,
+              { messages: session.messages } as never,
+              {} as never,
+            );
+            session.messages = [...session.messages, doneMessage];
+          };
+          return session;
+        },
+      });
 
-    expect(submittedMessages.filter((message) => message.role === "user")).toEqual([
-      expect.objectContaining({
-        content: expect.stringContaining('"name":"Alice"'),
-        role: "user",
-      }),
-    ]);
-  });
+      expect(result.finalPromptText).toBe(admittedMessage.content);
+      expect(result.messagesSnapshot).toContainEqual(doneMessage);
+      expect(submittedMessages.filter((message) => message.role === "user")).toEqual([
+        expect.objectContaining({
+          content: expect.stringContaining('"name":"Alice"'),
+          role: "user",
+        }),
+      ]);
+    },
+  );
 
   it("passes context engines the message budget after reserve and rendered prompt pressure", async () => {
     const contextEngine = createContextEngineBootstrapAndAssemble();

--- a/src/agents/embedded-agent-runner/run/pre-persisted-user-turn.ts
+++ b/src/agents/embedded-agent-runner/run/pre-persisted-user-turn.ts
@@ -5,9 +5,7 @@ export function sessionMessagesContainIdempotencyKey(
   idempotencyKey: string,
 ): boolean {
   return messages.some(
-    (message) =>
-      typeof (message as { idempotencyKey?: unknown }).idempotencyKey === "string" &&
-      (message as { idempotencyKey?: unknown }).idempotencyKey === idempotencyKey,
+    (message) => (message as { idempotencyKey?: unknown }).idempotencyKey === idempotencyKey,
   );
 }
 
@@ -35,7 +33,11 @@ export function reconcilePrePersistedCurrentUserTurn(params: {
   const tail = messages.at(-1) as (AgentMessage & { idempotencyKey?: unknown }) | undefined;
   const activeTailMatches = tail?.role === "user" && tail.idempotencyKey === idempotencyKey;
   if (!activeTailMatches && !durableTurnMatches) {
-    return false;
+    // Excluded turns deliberately lack a model-context copy; writes still validate admission.
+    return (
+      (params.currentUserTurnMessage as { excludeFromContext?: unknown }).excludeFromContext ===
+      true
+    );
   }
   if (activeTailMatches) {
     // Persistence is recorder-owned; either synchronized representation can

--- a/src/agents/session-tool-result-guard.transcript-events.test.ts
+++ b/src/agents/session-tool-result-guard.transcript-events.test.ts
@@ -135,48 +135,55 @@ describe("guardSessionManager transcript updates", () => {
     }
   });
 
-  it("records the admission anchor when adopting an ingress-persisted user", async () => {
-    const { root, target } = await openPersistedSessionManager();
-    const message = {
-      role: "user" as const,
-      content: "canonical prompt",
-      idempotencyKey: "canonical-run:user",
-      timestamp: Date.now(),
-    };
-    await appendTranscriptMessage(target, {
-      cwd: root,
-      eventId: "ingress-persisted-user",
-      message,
-      now: message.timestamp,
-    });
-    const recorder = createUserTurnTranscriptRecorder({
-      message,
-      target: {
-        ...target,
-        sessionEntry: { sessionId: target.sessionId, updatedAt: message.timestamp },
-      },
-    });
-    const guarded = guardSessionManager(SessionManager.open(target, root), {
-      agentId: target.agentId,
-      sessionKey: target.sessionKey,
-      preparedUserTurnMessage: message,
-      preparedUserTurnTranscriptRecorder: recorder,
-    });
+  it.each([false, true])(
+    "records the admission anchor when adopting an ingress-persisted user (excluded: %s)",
+    async (excludeFromContext) => {
+      const { root, target } = await openPersistedSessionManager();
+      const message = {
+        role: "user" as const,
+        content: "canonical prompt",
+        idempotencyKey: "canonical-run:user",
+        ...(excludeFromContext ? { excludeFromContext: true as const } : {}),
+        timestamp: Date.now(),
+      };
+      await appendTranscriptMessage(target, {
+        cwd: root,
+        eventId: "ingress-persisted-user",
+        message,
+        now: message.timestamp,
+      });
+      const recorder = createUserTurnTranscriptRecorder({
+        message,
+        target: {
+          ...target,
+          sessionEntry: { sessionId: target.sessionId, updatedAt: message.timestamp },
+        },
+      });
+      const guarded = guardSessionManager(
+        SessionManager.openBounded(target, { cwd: root, maxBytes: 100_000, maxEvents: 100 }),
+        {
+          agentId: target.agentId,
+          sessionKey: target.sessionKey,
+          preparedUserTurnMessage: message,
+          preparedUserTurnTranscriptRecorder: recorder,
+        },
+      );
 
-    expect(recorder.getAdmissionReceipt()).toBeUndefined();
-    guarded.appendMessage({ ...message });
+      expect(recorder.getAdmissionReceipt()).toBeUndefined();
+      guarded.appendMessage({ ...message });
 
-    expect(recorder.hasPersisted()).toBe(true);
-    expect(recorder.getAdmissionReceipt()).toMatchObject({
-      agentId: target.agentId,
-      sessionId: target.sessionId,
-      sessionKey: target.sessionKey,
-      storePath: target.storePath,
-      entryId: "ingress-persisted-user",
-      idempotencyKey: message.idempotencyKey,
-      role: "user",
-    });
-  });
+      expect(recorder.hasPersisted()).toBe(true);
+      expect(recorder.getAdmissionReceipt()).toMatchObject({
+        agentId: target.agentId,
+        sessionId: target.sessionId,
+        sessionKey: target.sessionKey,
+        storePath: target.storePath,
+        entryId: "ingress-persisted-user",
+        idempotencyKey: message.idempotencyKey,
+        role: "user",
+      });
+    },
+  );
 
   it.each(["active", "side", "setup-metadata"] as const)(
     "adopts an ingress-persisted %s-branch user without broadcasting a duplicate",

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -714,7 +714,11 @@ export function installSessionToolResultGuard(
     copyCodeModeSourceAppend(message, runOwnedMessage, sourceAppend);
     const parentEntryId = sessionManager.getLeafId();
     const appendParentEntryId = sessionManager.getAppendParentId();
-    const { entryId, anchor } = withRuntimeUserTurnTranscriptRecorder(runOwnedMessage, () =>
+    const {
+      entryId,
+      anchor,
+      message: persistedMessage,
+    } = withRuntimeUserTurnTranscriptRecorder(runOwnedMessage, () =>
       originalAppendWithTranscriptAnchor(
         runOwnedMessage as never,
         sourceAppend
@@ -722,11 +726,6 @@ export function installSessionToolResultGuard(
           : options,
       ),
     );
-    const entry = sessionManager.getEntry(entryId);
-    if (entry?.type !== "message") {
-      throw new Error(`Appended transcript message is unavailable: ${entryId}`);
-    }
-    const persistedMessage = entry.message;
     // Destructive tool-side state commits only after this exact result is durable.
     acknowledgeInternalToolResult(acknowledgementSource);
     const persistedId =

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -39,12 +39,12 @@ import type {
 } from "./session-manager-types.js";
 
 export class SessionManagerEntries extends SessionManagerPersistence {
-  protected appendEntry(
-    entry: SessionEntry,
+  protected appendEntry<T extends SessionEntry>(
+    entry: T,
     options?: AppendPersistenceOptions,
-  ): TranscriptEntryAnchor | undefined {
+  ): { entry: T; anchor?: TranscriptEntryAnchor } {
     // oxlint-disable-next-line unicorn/prefer-structured-clone -- Match the persisted JSON/toJSON shape exactly.
-    const canonicalEntry = JSON.parse(JSON.stringify(entry)) as SessionEntry;
+    const canonicalEntry = JSON.parse(JSON.stringify(entry)) as T;
     if (!isIndexedSessionEntry(canonicalEntry)) {
       throw new Error(`Invalid session transcript entry: ${entry.type}`);
     }
@@ -67,84 +67,56 @@ export class SessionManagerEntries extends SessionManagerPersistence {
         ...(activeBranchAppend ? { appendIntent: "active-branch" as const } : {}),
       }),
     );
-    if (persistenceResult && typeof persistenceResult === "object") {
-      if (persistenceResult.adoptedMessageId) {
-        this.reloadPersistedTranscript();
-        const adoptedMessageId =
-          canonicalEntry.type === "message"
-            ? this.resolveCurrentKeyedUserId(canonicalEntry.message)
-            : undefined;
-        if (adoptedMessageId !== persistenceResult.adoptedMessageId) {
-          throw new Error(
-            `Session transcript keyed user is outside the current turn: ${persistenceResult.adoptedMessageId}`,
-          );
-        }
-        this.pendingDeliberateAppend = false;
-        return persistenceResult.anchor;
+    if (persistenceResult?.adoptedMessageId) {
+      this.reloadPersistedTranscript();
+      // Context-excluded users have no payload in byId. The exact SQLite replay
+      // anchors their identity; physical ancestry still closes older turns.
+      if (this.resolveCurrentTurnEntryId() !== persistenceResult.adoptedMessageId) {
+        throw new Error(
+          `Session transcript keyed user is outside the current turn: ${persistenceResult.adoptedMessageId}`,
+        );
+      }
+      canonicalEntry.id = persistenceResult.adoptedMessageId;
+    } else if (
+      persistenceResult?.effectiveParentId !== undefined &&
+      persistenceResult.effectiveParentId !== canonicalEntry.parentId
+    ) {
+      this.reloadPersistedTranscript();
+    } else {
+      if (
+        !isSessionTranscriptSideAppendEntry(canonicalEntry) &&
+        canonicalEntry.parentId === this.appendParentId &&
+        this.leafId !== this.appendParentId
+      ) {
+        this.logicalParentsById.set(canonicalEntry.id, this.leafId);
+      }
+      this.fileEntries.push(canonicalEntry);
+      this.byId.set(canonicalEntry.id, canonicalEntry);
+      this.appendParentId = canonicalEntry.id;
+      if (isSessionTranscriptSideAppendEntry(canonicalEntry)) {
+        this.appendMode = "side";
+      } else {
+        this.leafId = canonicalEntry.id;
+        this.appendMode = undefined;
       }
     }
-    const effectiveParentId =
-      persistenceResult && typeof persistenceResult === "object"
-        ? persistenceResult.effectiveParentId
-        : persistenceResult;
-    if (effectiveParentId !== undefined && effectiveParentId !== canonicalEntry.parentId) {
-      this.reloadPersistedTranscript();
-      this.pendingDeliberateAppend = false;
-      return persistenceResult && typeof persistenceResult === "object"
-        ? persistenceResult.anchor
-        : undefined;
-    }
-    if (
-      !isSessionTranscriptSideAppendEntry(canonicalEntry) &&
-      canonicalEntry.parentId === this.appendParentId &&
-      this.leafId !== this.appendParentId
-    ) {
-      this.logicalParentsById.set(canonicalEntry.id, this.leafId);
-    }
-    this.fileEntries.push(canonicalEntry);
-    this.byId.set(canonicalEntry.id, canonicalEntry);
-    this.appendParentId = canonicalEntry.id;
     this.pendingDeliberateAppend = false;
-    if (isSessionTranscriptSideAppendEntry(canonicalEntry)) {
-      this.appendMode = "side";
-    } else {
-      this.leafId = canonicalEntry.id;
-      this.appendMode = undefined;
-    }
-    return persistenceResult && typeof persistenceResult === "object"
-      ? persistenceResult.anchor
-      : undefined;
+    return { entry: canonicalEntry, anchor: persistenceResult?.anchor };
   }
 
-  private resolveCurrentKeyedUserId(message: SessionMessageEntry["message"]): string | undefined {
-    if (
-      message.role !== "user" ||
-      !("idempotencyKey" in message) ||
-      typeof message.idempotencyKey !== "string" ||
-      message.idempotencyKey.length === 0
-    ) {
-      return undefined;
-    }
-    let parent = this.appendParentId ? this.byId.get(this.appendParentId) : undefined;
+  private resolveCurrentTurnEntryId(): string | null {
+    let parentId = this.appendParentId;
     let remainingAncestors = this.byId.size;
     // Compaction rewrites context without consuming the current user turn.
     // Stop at message and reset boundaries so old keyed turns stay closed.
-    while (
-      parent &&
-      remainingAncestors-- > 0 &&
-      (isSessionContextMetadataEntry(parent) || parent.type === "compaction")
-    ) {
-      parent = parent.parentId ? this.byId.get(parent.parentId) : undefined;
+    while (parentId && remainingAncestors-- > 0) {
+      const parent = this.byId.get(parentId);
+      if (!parent || (!isSessionContextMetadataEntry(parent) && parent.type !== "compaction")) {
+        break;
+      }
+      parentId = parent.parentId;
     }
-    if (
-      parent?.type === "message" &&
-      parent.message.role === "user" &&
-      "idempotencyKey" in parent.message &&
-      parent.message.idempotencyKey === message.idempotencyKey
-    ) {
-      return parent.id;
-    }
-    return undefined;
+    return parentId;
   }
 
   appendMessage(
@@ -157,23 +129,32 @@ export class SessionManagerEntries extends SessionManagerPersistence {
   appendMessageWithTranscriptAnchor(
     message: Message | CustomMessage | BashExecutionMessage,
     options?: AppendPersistenceOptions,
-  ): { entryId: string; anchor?: TranscriptEntryAnchor } {
+  ): { entryId: string; message: SessionMessageEntry["message"]; anchor?: TranscriptEntryAnchor } {
     if (message.role === "assistant") {
       applyAssistantDeliveryDirectives(message);
     }
-    if (options?.idempotencyLookup !== "caller-checked") {
-      const currentUserId = this.resolveCurrentKeyedUserId(message);
-      if (currentUserId) {
+    if (
+      options?.idempotencyLookup !== "caller-checked" &&
+      message.role === "user" &&
+      "idempotencyKey" in message &&
+      typeof message.idempotencyKey === "string" &&
+      message.idempotencyKey.length > 0
+    ) {
+      const currentTurnId = this.resolveCurrentTurnEntryId();
+      const current = currentTurnId ? this.byId.get(currentTurnId) : undefined;
+      if (
+        current?.type === "message" &&
+        current.message.role === "user" &&
+        "idempotencyKey" in current.message &&
+        current.message.idempotencyKey === message.idempotencyKey
+      ) {
         const anchor = this.persistenceTarget
-          ? readActiveTranscriptEntryAnchor({
-              ...this.persistenceTarget,
-              entryId: currentUserId,
-            })
+          ? readActiveTranscriptEntryAnchor({ ...this.persistenceTarget, entryId: current.id })
           : undefined;
         if (this.persistenceTarget && !anchor) {
-          throw new Error(`Session transcript anchor was not returned: ${currentUserId}`);
+          throw new Error(`Session transcript anchor was not returned: ${current.id}`);
         }
-        return { entryId: currentUserId, ...(anchor ? { anchor } : {}) };
+        return { entryId: current.id, message: current.message, ...(anchor ? { anchor } : {}) };
       }
     }
     const entry: SessionMessageEntry = {
@@ -183,9 +164,10 @@ export class SessionManagerEntries extends SessionManagerPersistence {
       timestamp: new Date().toISOString(),
       message,
     };
-    const anchor = this.appendEntry(entry, options);
+    const { entry: persisted, anchor } = this.appendEntry(entry, options);
     return {
-      entryId: this.resolveCurrentKeyedUserId(message) ?? entry.id,
+      entryId: persisted.id,
+      message: persisted.message,
       ...(anchor ? { anchor } : {}),
     };
   }

--- a/src/agents/sessions/session-manager-persistence.ts
+++ b/src/agents/sessions/session-manager-persistence.ts
@@ -16,8 +16,6 @@ import { SessionManagerCore } from "./session-manager-core.js";
 import type { AppendPersistenceOptions, SessionEntry } from "./session-manager-types.js";
 
 type PersistRecordResult =
-  | string
-  | null
   | undefined
   | {
       anchor?: TranscriptEntryAnchor;
@@ -255,6 +253,8 @@ export class SessionManagerPersistence extends SessionManagerCore {
     if (!result) {
       throw new Error(`Session transcript message was not persisted: ${entry.id}`);
     }
+    // Carry the canonical storage bytes even when adopting a context-excluded row.
+    entry.message = result.message;
     if (result.messageId !== entry.id) {
       const idempotencyKey =
         entry.message.role === "user" &&
@@ -286,9 +286,6 @@ export class SessionManagerPersistence extends SessionManagerCore {
     if (result.effectiveParentId === undefined) {
       throw new Error(`Session transcript append parent was not returned: ${entry.id}`);
     }
-    // appendEntry owns this JSON copy. Cache the final storage projection: a
-    // second credential mask can differ from the guard's diagnostic hint.
-    entry.message = result.message;
     return {
       ...(result.anchor ? { anchor: result.anchor } : {}),
       effectiveParentId: result.effectiveParentId,

--- a/src/agents/sessions/session-manager.user-idempotency.test.ts
+++ b/src/agents/sessions/session-manager.user-idempotency.test.ts
@@ -63,53 +63,64 @@ describe("SessionManager user idempotency", () => {
     );
   });
 
-  it("rejects a keyed user collision outside the current SQLite append parent", async () => {
-    const dir = tempDirs.make("openclaw-session-manager-user-idempotency-");
-    const scope = {
-      agentId: "main",
-      sessionId: "sqlite-runtime-user-ancestor",
-      sessionKey: "agent:main:dashboard:sqlite-runtime-user-ancestor",
-      storePath: path.join(dir, "sessions.json"),
-    };
-    const userMessage = {
-      role: "user" as const,
-      content: "question",
-      idempotencyKey: "runtime-user-ancestor:user",
-      timestamp: 1,
-    };
-    await upsertSessionEntryCore(scope, {
-      sessionFile: formatSqliteSessionFileMarker(scope),
-      sessionId: scope.sessionId,
-      updatedAt: 1,
-    });
-    await appendTranscriptMessage(scope, {
-      cwd: dir,
-      eventId: "pre-persisted-user",
-      message: userMessage,
-      now: 1,
-    });
-    await appendTranscriptMessage(scope, {
-      cwd: dir,
-      eventId: "persisted-assistant",
-      message: buildAssistantMessage("answer"),
-      parentId: "pre-persisted-user",
-    });
-    const sessionManager = SessionManager.open(scope, dir);
+  it.each([false, true])(
+    "rejects a keyed user collision outside the current SQLite append parent (excluded: %s)",
+    async (excludeFromContext) => {
+      const dir = tempDirs.make("openclaw-session-manager-user-idempotency-");
+      const scope = {
+        agentId: "main",
+        sessionId: "sqlite-runtime-user-ancestor",
+        sessionKey: "agent:main:dashboard:sqlite-runtime-user-ancestor",
+        storePath: path.join(dir, "sessions.json"),
+      };
+      const userMessage = {
+        role: "user" as const,
+        content: "question",
+        idempotencyKey: "runtime-user-ancestor:user",
+        ...(excludeFromContext ? { excludeFromContext: true } : {}),
+        timestamp: 1,
+      };
+      await upsertSessionEntryCore(scope, {
+        sessionFile: formatSqliteSessionFileMarker(scope),
+        sessionId: scope.sessionId,
+        updatedAt: 1,
+      });
+      await appendTranscriptMessage(scope, {
+        cwd: dir,
+        eventId: "pre-persisted-user",
+        message: userMessage,
+        now: 1,
+      });
+      await appendTranscriptMessage(scope, {
+        cwd: dir,
+        eventId: "persisted-assistant",
+        message: {
+          ...buildAssistantMessage("answer"),
+          ...(excludeFromContext ? { excludeFromContext: true } : {}),
+        },
+        parentId: "pre-persisted-user",
+      });
+      const sessionManager = SessionManager.openBounded(scope, {
+        cwd: dir,
+        maxBytes: 100_000,
+        maxEvents: 100,
+      });
 
-    expect(() => sessionManager.appendMessage(userMessage)).toThrow(
-      "Session transcript keyed user is outside the current turn",
-    );
-    expect(sessionManager.getLeafId()).toBe("persisted-assistant");
-    expect(
-      (await loadTranscriptEvents(scope)).filter(
-        (event) =>
-          (event as { message?: { role?: string; idempotencyKey?: string } }).message?.role ===
-            "user" &&
-          (event as { message?: { idempotencyKey?: string } }).message?.idempotencyKey ===
-            userMessage.idempotencyKey,
-      ),
-    ).toHaveLength(1);
-  });
+      expect(() => sessionManager.appendMessage(userMessage)).toThrow(
+        "Session transcript keyed user is outside the current turn",
+      );
+      expect(sessionManager.getAppendParentId()).toBe("persisted-assistant");
+      expect(
+        (await loadTranscriptEvents(scope)).filter(
+          (event) =>
+            (event as { message?: { role?: string; idempotencyKey?: string } }).message?.role ===
+              "user" &&
+            (event as { message?: { idempotencyKey?: string } }).message?.idempotencyKey ===
+              userMessage.idempotencyKey,
+        ),
+      ).toHaveLength(1);
+    },
+  );
 
   it("adopts a keyed user persisted after the manager loaded", async () => {
     const dir = tempDirs.make("openclaw-session-manager-user-idempotency-");
@@ -180,59 +191,73 @@ describe("SessionManager user idempotency", () => {
     ).toHaveLength(1);
   });
 
-  it("adopts a persisted user across context-free session setup metadata", async () => {
-    const dir = tempDirs.make("openclaw-session-manager-user-idempotency-");
-    const scope = {
-      agentId: "main",
-      sessionId: "sqlite-runtime-user-setup-metadata",
-      sessionKey: "agent:main:dashboard:sqlite-runtime-user-setup-metadata",
-      storePath: path.join(dir, "sessions.json"),
-    };
-    const userMessage = {
-      role: "user" as const,
-      content: "question",
-      idempotencyKey: "runtime-user-setup-metadata:user",
-      timestamp: 1,
-    };
-    await upsertSessionEntryCore(scope, {
-      sessionFile: formatSqliteSessionFileMarker(scope),
-      sessionId: scope.sessionId,
-      updatedAt: 1,
-    });
-    await appendTranscriptMessage(scope, {
-      cwd: dir,
-      eventId: "pre-persisted-user",
-      message: userMessage,
-      now: 1,
-    });
+  it.each([false, true])(
+    "adopts a persisted user across context-free session setup metadata (excluded: %s)",
+    async (excludeFromContext) => {
+      const dir = tempDirs.make("openclaw-session-manager-user-idempotency-");
+      const scope = {
+        agentId: "main",
+        sessionId: "sqlite-runtime-user-setup-metadata",
+        sessionKey: "agent:main:dashboard:sqlite-runtime-user-setup-metadata",
+        storePath: path.join(dir, "sessions.json"),
+      };
+      const userMessage = {
+        role: "user" as const,
+        content: "question",
+        idempotencyKey: "runtime-user-setup-metadata:user",
+        ...(excludeFromContext ? { excludeFromContext: true } : {}),
+        timestamp: 1,
+      };
+      await upsertSessionEntryCore(scope, {
+        sessionFile: formatSqliteSessionFileMarker(scope),
+        sessionId: scope.sessionId,
+        updatedAt: 1,
+      });
+      await appendTranscriptMessage(scope, {
+        cwd: dir,
+        eventId: "pre-persisted-user",
+        message: userMessage,
+        now: 1,
+      });
 
-    const sessionManager = SessionManager.open(scope, dir);
-    sessionManager.appendModelChange("openai", "gpt-5.5");
-    sessionManager.appendThinkingLevelChange("off");
-    const metadataId = sessionManager.appendCustomEntry("model-snapshot", {
-      modelApi: "openai-responses",
-      modelId: "gpt-5.5",
-      provider: "openai",
-    });
+      const sessionManager = SessionManager.openBounded(scope, {
+        cwd: dir,
+        maxBytes: 100_000,
+        maxEvents: 100,
+      });
+      sessionManager.appendModelChange("openai", "gpt-5.5");
+      sessionManager.appendThinkingLevelChange("off");
+      const metadataId = sessionManager.appendCustomEntry("model-snapshot", {
+        modelApi: "openai-responses",
+        modelId: "gpt-5.5",
+        provider: "openai",
+      });
 
-    expect(sessionManager.appendMessage(userMessage)).toBe("pre-persisted-user");
-    expect(sessionManager.getAppendParentId()).toBe(metadataId);
+      expect(
+        sessionManager.appendMessageWithTranscriptAnchor({ ...userMessage, timestamp: 2 }),
+      ).toMatchObject({
+        entryId: "pre-persisted-user",
+        message: userMessage,
+        anchor: { entryId: "pre-persisted-user", idempotencyKey: userMessage.idempotencyKey },
+      });
+      expect(sessionManager.getAppendParentId()).toBe(metadataId);
 
-    const assistantId = sessionManager.appendMessage(buildAssistantMessage("answer"));
-    const events = await loadTranscriptEvents(scope);
-    expect(events.find((event) => (event as { id?: string }).id === assistantId)).toMatchObject({
-      parentId: metadataId,
-    });
-    expect(
-      events.filter(
-        (event) =>
-          (event as { message?: { role?: string; idempotencyKey?: string } }).message?.role ===
-            "user" &&
-          (event as { message?: { idempotencyKey?: string } }).message?.idempotencyKey ===
-            userMessage.idempotencyKey,
-      ),
-    ).toHaveLength(1);
-  });
+      const assistantId = sessionManager.appendMessage(buildAssistantMessage("answer"));
+      const events = await loadTranscriptEvents(scope);
+      expect(events.find((event) => (event as { id?: string }).id === assistantId)).toMatchObject({
+        parentId: metadataId,
+      });
+      expect(
+        events.filter(
+          (event) =>
+            (event as { message?: { role?: string; idempotencyKey?: string } }).message?.role ===
+              "user" &&
+            (event as { message?: { idempotencyKey?: string } }).message?.idempotencyKey ===
+              userMessage.idempotencyKey,
+        ),
+      ).toHaveLength(1);
+    },
+  );
 
   it("adopts the current keyed user across a compaction boundary", async () => {
     const dir = tempDirs.make("openclaw-session-manager-user-idempotency-");

--- a/src/config/sessions/session-accessor.pending-inputs.test.ts
+++ b/src/config/sessions/session-accessor.pending-inputs.test.ts
@@ -477,39 +477,49 @@ describe("accepted input custody", () => {
     },
   );
 
-  it("rejects retained custody on an inactive branch without changing ordinary historical replay", async () => {
-    const receipt = await stage("terminal-off-path");
-    let replacementId: string;
-    await receipt.run(async () => {
-      await appendTranscriptMessage(scope(), { message: receipt.message });
-      const replacement = await appendTranscriptMessage(scope(), {
-        message: message("replacement"),
-        parentId: null,
+  it.each([false, true])(
+    "rejects retained custody on an inactive branch with context exclusion %s",
+    async (excludeFromContext) => {
+      const receipt = await stage("terminal-off-path", {
+        message: {
+          ...message("terminal-off-path"),
+          ...(excludeFromContext ? { excludeFromContext: true } : {}),
+        },
       });
-      replacementId = replacement.messageId;
-      expect(replacement.effectiveParentId).toBeNull();
+      let replacementId: string;
+      await receipt.run(async () => {
+        await appendTranscriptMessage(scope(), { message: receipt.message });
+        const replacement = await appendTranscriptMessage(scope(), {
+          message: message("replacement"),
+          parentId: null,
+        });
+        replacementId = replacement.messageId;
+        expect(replacement.effectiveParentId).toBeNull();
+        expect(
+          readActiveTranscriptEntryAnchor({ ...scope(), entryId: receipt.inputId }),
+        ).toBeUndefined();
+        expect(
+          readActiveTranscriptEntryAnchor({ ...scope(), entryId: replacementId }),
+        ).toBeUndefined();
+        receipt.finish("cancelled");
+        await expect(
+          appendTranscriptMessage(scope(), { message: receipt.message }),
+        ).rejects.toThrow("no longer active");
+      });
+      await waitForSessionTranscriptProjection(scope());
       expect(
         readActiveTranscriptEntryAnchor({ ...scope(), entryId: receipt.inputId }),
       ).toBeUndefined();
       expect(
-        readActiveTranscriptEntryAnchor({ ...scope(), entryId: replacementId }),
-      ).toBeUndefined();
-      receipt.finish("cancelled");
-      await expect(appendTranscriptMessage(scope(), { message: receipt.message })).rejects.toThrow(
-        "no longer active",
-      );
-    });
-    await waitForSessionTranscriptProjection(scope());
-    expect(
-      readActiveTranscriptEntryAnchor({ ...scope(), entryId: receipt.inputId }),
-    ).toBeUndefined();
-    expect(readActiveTranscriptEntryAnchor({ ...scope(), entryId: replacementId! })).toMatchObject({
-      entryId: replacementId!,
-    });
-    expect(await appendTranscriptMessage(scope(), { message: receipt.message })).toMatchObject({
-      appended: false,
-    });
-  });
+        readActiveTranscriptEntryAnchor({ ...scope(), entryId: replacementId! }),
+      ).toMatchObject({
+        entryId: replacementId!,
+      });
+      expect(await appendTranscriptMessage(scope(), { message: receipt.message })).toMatchObject({
+        appended: false,
+      });
+    },
+  );
 
   it("retains repaired pending input as interrupted and never transfers live custody", async () => {
     const receipt = await stage("repair");

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -54,7 +54,7 @@ import type { GatewayRequestHandlerOptions } from "./types.js";
 type ChatSendInternalOptions = {
   goalResume?: SessionGoalOperation & { action: "resume" };
   trustedSystemInput?: boolean;
-  display?: false;
+  transcript?: Parameters<typeof createGatewayChatUserTurnController>[0]["transcript"];
   toolsAllow?: string[];
   skillWorkshopProposalRevision?: SkillWorkshopProposalRevisionConstraint;
 };
@@ -173,7 +173,7 @@ async function handleChatSendWithOptions(
       client,
       request: normalizedRequest.value,
       session: preparedSession.value,
-      display: options?.display,
+      transcript: options?.transcript,
       startedAt: admissionStartedAt,
       warn: (message) => context.logGateway.warn(message),
       assertGoalCurrent: () => {
@@ -525,7 +525,7 @@ export async function handleChatSendWithSkillWorkshopProposalRevision(
 export async function handleTrustedInternalChatSend(
   options: GatewayRequestHandlerOptions,
   onAdmissionOwned?: () => Promise<boolean>,
-  inputOptions?: Pick<ChatSendInternalOptions, "display" | "toolsAllow">,
+  inputOptions?: Pick<ChatSendInternalOptions, "transcript" | "toolsAllow">,
 ): Promise<void> {
   await handleChatSendWithOptions(options, onAdmissionOwned, undefined, {
     ...inputOptions,

--- a/src/gateway/server-methods/chat-user-turn-recorder.ts
+++ b/src/gateway/server-methods/chat-user-turn-recorder.ts
@@ -34,7 +34,7 @@ export function createGatewayChatUserTurnController(params: {
   client: GatewayClient | null;
   request: NormalizedChatSendRequest;
   session: PreparedChatSendSession;
-  display?: false;
+  transcript?: Pick<UserTurnInput, "display" | "excludeFromContext">;
   startedAt: number;
   warn: (message: string) => void;
   assertGoalCurrent?: () => void;
@@ -45,9 +45,8 @@ export function createGatewayChatUserTurnController(params: {
       ? undefined
       : gatewayClientSenderFields(params.client).sender;
   const baseInput: UserTurnInput = {
-    ...(params.display === false || request.goalOperation?.action === "resume"
-      ? { display: false }
-      : {}),
+    ...params.transcript,
+    ...(request.goalOperation?.action === "resume" ? { display: false } : {}),
     text: request.rawMessage,
     timestamp: session.now,
     idempotencyKey: buildRunUserTurnIdempotencyKey(session.clientRunId),

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -2844,7 +2844,7 @@ describe("talk.client.toolCall handler", () => {
     expect(chatInput.params?.idempotencyKey).toMatch(/^talk-call-1-/);
     expect(mockCallArg(mocks.chatSend, 0, 2)).toEqual({
       toolsAllow: ["read", "web_search", "web_fetch", "x_search", "memory_search", "memory_get"],
-      display: false,
+      transcript: { display: false, excludeFromContext: true },
     });
     const response = expectRespondOk(respond, { runId: "run-voice-1" }) as Record<string, unknown>;
     expect(response.idempotencyKey).toMatch(/^talk-call-1-/);
@@ -2970,7 +2970,10 @@ describe("talk.client.toolCall handler", () => {
       thinking: "low",
       fastMode: true,
     });
-    expect(mockCallArg(mocks.chatSend, 0, 2)).toEqual({ toolsAllow: undefined, display: false });
+    expect(mockCallArg(mocks.chatSend, 0, 2)).toEqual({
+      toolsAllow: undefined,
+      transcript: { display: false, excludeFromContext: true },
+    });
     expectRespondOk(respond, { runId: "run-voice-1" });
   });
 

--- a/src/gateway/server.talk-consult-history.test.ts
+++ b/src/gateway/server.talk-consult-history.test.ts
@@ -6,6 +6,7 @@ import { createDeferred } from "../../test/helpers/promise.js";
 import { extractText } from "../../ui/src/lib/chat/message-extract.ts";
 import { buildChatMarkdown } from "../../ui/src/pages/chat/export.ts";
 import * as embeddedAgent from "../agents/embedded-agent.js";
+import { SessionManager } from "../agents/sessions/session-manager.js";
 import { getReplyFromConfig } from "../auto-reply/reply/get-reply.js";
 import { clearConfigCache, getRuntimeConfig, setRuntimeConfigSnapshot } from "../config/config.js";
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
@@ -424,7 +425,7 @@ describe("Browser Talk consult input custody", () => {
       tools: ["read", "web_search", "web_fetch", "x_search", "memory_search", "memory_get"],
     },
   ])(
-    "keeps $name consult scaffolding out of live, reloaded, and exported chat",
+    "keeps $name consult scaffolding out of chat and later context but in the raw archive",
     async ({ scopes, tools }) => {
       client.connect.scopes = scopes;
       await rpc("talk.client.transcript", {
@@ -486,6 +487,7 @@ describe("Browser Talk consult input custody", () => {
       expect.soft(generated[0]).toMatchObject({
         role: "user",
         display: false,
+        excludeFromContext: true,
         provenance: { kind: "internal_system" },
       });
       const metadata = asOptionalRecord(generated[0]?.["__openclaw"]);
@@ -502,7 +504,17 @@ describe("Browser Talk consult input custody", () => {
       expect(closeOpenClawAgentDatabaseByPath(databasePath)).toBe(true);
       clearSessionStoreCacheForTest();
       expectVisibleSpeechOnly(await historyMessages(), "reopened chat.history", true);
-      expect(loadTranscriptEventsSync(scope())).not.toEqual([]);
+      for (const manager of [
+        SessionManager.open(scope()),
+        SessionManager.openModelContext(scope()),
+      ]) {
+        const messages = manager.buildSessionContext().messages;
+        expectNoGeneratedInput(messages, "reopened model context");
+        expect(messages.map(extractText)).toEqual(expect.arrayContaining([spoken, answer]));
+      }
+      expect(loadTranscriptEventsSync(scope())).toEqual(
+        expect.arrayContaining([expect.objectContaining({ message: generated[0] })]),
+      );
     },
   );
 });

--- a/src/gateway/talk-agent-consult.ts
+++ b/src/gateway/talk-agent-consult.ts
@@ -149,11 +149,10 @@ export async function startTalkRealtimeAgentConsult(
         );
       },
     } satisfies GatewayRequestHandlerOptions;
-    // Keep the caller's tool boundary while hiding generated consult input;
-    // the finalized speech already owns the human transcript.
+    // Speech owns reusable history; keep consult scaffolding only in the lossless archive.
     const chatSendResult = handleTrustedInternalChatSend(chatSendOptions, undefined, {
       toolsAllow: authority.toolsAllow,
-      display: false,
+      transcript: { display: false, excludeFromContext: true },
     });
     void Promise.resolve(chatSendResult).then(
       () => {

--- a/src/sessions/user-turn-transcript.message.ts
+++ b/src/sessions/user-turn-transcript.message.ts
@@ -109,6 +109,7 @@ export function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedU
   const message: PersistedUserTurnMessage = {
     role: "user",
     ...(params.display === false ? { display: false } : {}),
+    ...(params.excludeFromContext ? { excludeFromContext: true } : {}),
     content: text,
     timestamp: params.timestamp ?? Date.now(),
     ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -37,15 +37,14 @@ export type PersistedUserTurnMediaInput = Pick<
 
 export type PersistedUserTurnMessage = Extract<AgentMessage, { role: "user" }> & {
   display?: false;
+  excludeFromContext?: true;
   /** Private transcript correlation; never authorizes an execution. */
   idempotencyKey?: string;
   provenance?: InputProvenance;
   __openclaw?: Record<string, unknown>;
 };
 
-export type UserTurnInput = {
-  /** Internal continuation input stays in model history without impersonating a human chat row. */
-  display?: false;
+export type UserTurnInput = Pick<PersistedUserTurnMessage, "display" | "excludeFromContext"> & {
   text?: string | null;
   media?: readonly PersistedUserTurnMediaInput[] | null;
   /** Restart-safe native image placement; model-visible prompt bytes remain separate. */


### PR DESCRIPTION
Related: #133855

## What Problem This Solves

Fixes an issue where Browser Talk users could have generated consultation questions, context, and spoken-style instructions replayed to the model on later turns. The visible speech transcript was already correct, but hiding the internal prompt from chat did not exclude it from model context.

Reported by @Conan-Scott. This implements the maintainer-approved retention decision recorded on September 1, 2026; it does not decide assistant-answer presentation.

## Why This Change Was Made

The Talk producer now records both visibility and context eligibility through the existing private user-turn recorder. The existing transcript projection and session-context builder consume `excludeFromContext`; neither receives a Talk-specific filter. The active consult still receives its complete prompt. The embedded runner now treats an explicitly excluded, already-admitted turn as a deliberate non-participant in historical context, not an orphan. SessionManager validates keyed adoption against physical current-turn ancestry and the authoritative SQLite append anchor, and returns the canonical persisted message directly to the persistence guard. It no longer re-reads that acknowledgment from the filtered model-history view.

Raw archives and HTML/JSONL exports remain lossless, as documented at https://docs.openclaw.ai/tools/slash-commands. No export/archive reader, SQLite schema, migration, configuration option, environment variable, or public RPC changes. Existing stale-input and historical-key fences remain intact; exclusion does not authorize an inactive turn.

**Historical-record tradeoff:** pre-existing consult records without the explicit exclusion flag remain context-eligible. This change does not rewrite history or infer eligibility from provenance/text. Retroactively identifying and changing old records would be a separate migration decision, not part of this repair.

## User Impact

New internal Talk consult prompts no longer enter later session model context, while actual speech and assistant results remain available. Raw diagnostic/export records keep the full internal prompt and its provenance. Other hidden input, including Goal resumes and recovery continuations, keeps its existing context behavior.

The agent-consult answer and the provider's finalized spoken answer are not hidden or deduplicated. They have distinct owners; the separate investigation found that speech failure can leave the consult answer as the only completed result. #133855 remains open for the assistant-presentation decision.

## Evidence

Real repaired-flow proof used the built Gateway on an ephemeral loopback port, a fresh isolated state directory, synthetic provider credentials, real Talk/chat RPCs, and a real headless Chromium Control UI. This is not live microphone/WebRTC or authenticated OpenAI-provider proof. The Gateway and temporary state were cleaned up successfully.

```text
talk.client.transcript: genuine speech admitted
talk.client.toolCall: consult reaches provider; question/context/style all present
consult final: CONSULT_RESULT_133855
provider transcript final: SPOKEN_RESULT_133855
later chat.send: one model request; all consult markers absent; genuine speech retained
/export-session consult-retention.html: complete original consult text retained once
embedded HTML archive: excludeFromContext=true
cleanup: confirmed-stopped; errors=[]; isolated state removed
```

The initial real Gateway reproduction failed before the provider: filtered context caused orphan detachment and the active pending-input fence rejected the detached consult. After fixing admission, the live flow exposed the second projected-history dependency in keyed append acknowledgment. Both owner defects are now covered by failure-first regressions and the successful flow above.

Focused owner/sibling runs cover 419 tests across 16 distinct files (151 transcript/Talk, 105 admission/pending-input, 163 SessionManager/guard/Code Mode). The final integrated admission/provider/guard rerun passed all 95 tests in three files. The regression cases fail on pre-fix code; historical-key collision, inactive-branch custody, redaction, callback ordering, and canonical persisted-message tests pass.

- Full `pnpm build`: passed. Runtime-only rebuild after the append repair: passed, including all 53 built native control-plane modules.
- Final `node scripts/check-changed.mjs -- <17 changed paths>` passed: formatting, production/test types, lint, three dead-export scans, and all selected architecture/persistence guards. One widened test literal was corrected before this final passing run.
- Fresh pre-commit and explicit branch-mode Codex autoreviews: scoped-clean at the configured P0 threshold, with no accepted/actionable findings.
- Separate duplicate-answer boundary instrumentation: 69 existing UI tests plus three temporary marker/fault cases passed; temporary instrumentation was removed. Real UI adapters with synthetic Gateway/WebRTC peers, not live audio.
- Direct Codex source inspected at `0ae94fdd49b05ee7faa4d984d06a68492cb32b54`: `codex-rs/rollout/src/policy.rs:42`, `codex-rs/core/src/context_manager/history.rs:186,535`. Source-contract evidence, not authenticated live Codex-provider proof.
- Production +90/-112, net **−22**. Tests +373/-288, net **+85**. Docs +7. Removed display-only forwarding, obsolete scalar persistence-result branches, and projected-history acknowledgment recovery.

Best-fix judgment: producer-owned explicit eligibility uses the existing canonical context mechanism. Filtering all hidden messages or adding Talk/provenance detection in the projection would change sibling semantics and misplace the decision. Removing archived rows would violate the approved lossless-export contract.


Duplicate-answer observations (investigation only):

```text
success: Gateway final CONSULT_RESULT_MARKER_133855
      -> provider function_call_output CONSULT_RESULT_MARKER_133855
      -> separate assistant transcript SPOKEN_PROVIDER_MARKER_133855
provider failure before speech final: consult result retained; no invented speech transcript; visible provider error
playback failure after speech final: spoken transcript retained; visible playback error
```

The consult answer is owned by `src/gateway/server-methods/chat-send-reply-finalization.ts:329` (runtime-owned transcript or gateway append plus final broadcast); the provider answer is submitted separately by `ui/src/pages/chat/realtime-talk.ts:573` and persisted with voice-event identity. Equal prose does not imply a retried write. The proposed disposition is to keep #133855 open only for the remaining presentation decision; deleting either result could erase useful evidence, including the only completed answer after a speech failure.

Follow-up pass: the separate behavior-neutral refactor #135411 removes the unused singleton message-merge strategy adapter and invokes the canonical orphan-merge helper directly (candidate production net −54). It is intentionally not bundled with this repair. Named tooling follow-up: investigate checkout-local Vitest cache creation invalidating declaration resolution-topology snapshots during concurrent validation; this PR does not change build tooling.

![Synthetic speech before the consult](https://github.com/user-attachments/assets/7550be8c-3399-4b28-9758-0e15a0c852df)

![Completed consult and separate spoken result](https://github.com/user-attachments/assets/bea23aaf-f9c0-4257-a9bb-368fe152e377)

![Later turn retains speech without exposing internal consult input](https://github.com/user-attachments/assets/5b6e28d6-ec19-4db9-8315-e5e429584620)

### Maintainer response to ClawSweeper

The September 1 review found no actionable patch defect; its rank-up/pre-merge action is fresh exact-head CI. Main's TS2790 repair #135407 has landed. CI [33543326550](https://github.com/openclaw/openclaw/actions/runs/33543326550) on refreshed head `2664388b356a30caa2e8bfbfb47c78ac5b76b18b` failed only the CLI shard and aggregate gate: the pre-existing real-Gateway fixture returned `allow` instead of `refuse` in `src/cli/state-dir-gateway-check.server.test.ts:107`. The same failure was reproduced locally in the original full CLI shard before editing. A missing CLI-process test-catalog entry was confirmed, but routing the unchanged test to its isolated owner still failed; that candidate is not being claimed as the CI repair. The authentication/startup boundary is under investigation, coordinated with #134068. This PR remains held for fresh green CI. The base refresh has the same stable patch ID and no behavioral changes. Refreshed branch review, complete changed-file checks, runtime build, and the full live context/HTML-export flow all passed again (isolated port 57759).

The automatic stored-data-model notice does not indicate a new schema or format: `excludeFromContext` is an existing per-message field, already honored by `packages/agent-core/src/harness/session/session.ts:20` in stable tag `v2026.8.1` and by its SQLite context eligibility/projection code. This PR opts new Talk consult records into that contract and fixes their runtime admission/append handling. It does not change table DDL, projections, schema versions, stored identifier representations, archive retention, or migration behavior. Existing unflagged records remain eligible by the approved no-history-rewrite decision. Source inspection is not a claim of a separate downgraded-runtime live run.
