### PR TITLE
fix(plugins): detect native loading regressions in tests

### DIFF
--- a/src/plugins/loader.native-module-loader.test.ts
+++ b/src/plugins/loader.native-module-loader.test.ts
@@ -1,13 +1,15 @@
 /** Verifies plugin loader behavior for native module loading and resolver hooks. */
 import fs from "node:fs";
 import path from "node:path";
-import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { loadOpenClawPlugins } from "./loader.js";
+import { resetPluginCache } from "./plugin-cache.js";
+import { getPluginModuleLoaderStats } from "./plugin-module-loader-cache.js";
 
 const tempDirs = createTempDirTracker();
 
-function writeBundledPluginFixture(id: string) {
+function writeJavaScriptPluginFixture(id: string) {
   const pluginRoot = tempDirs.make("openclaw-plugin-loader-");
   fs.writeFileSync(
     path.join(pluginRoot, "openclaw.plugin.json"),
@@ -34,7 +36,7 @@ function writeBundledPluginFixture(id: string) {
 }
 
 function writePackagedPluginFixture(id: string) {
-  const pluginRoot = tempDirs.make("openclaw-plugin-loader-");
+  const pluginRoot = writeJavaScriptPluginFixture(id);
   fs.writeFileSync(
     path.join(pluginRoot, "package.json"),
     JSON.stringify(
@@ -48,27 +50,6 @@ function writePackagedPluginFixture(id: string) {
       null,
       2,
     ),
-    "utf-8",
-  );
-  fs.writeFileSync(
-    path.join(pluginRoot, "openclaw.plugin.json"),
-    JSON.stringify(
-      {
-        id,
-        configSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: {},
-        },
-      },
-      null,
-      2,
-    ),
-    "utf-8",
-  );
-  fs.writeFileSync(
-    path.join(pluginRoot, "index.cjs"),
-    `module.exports = { id: ${JSON.stringify(id)}, register() {} };`,
     "utf-8",
   );
   return pluginRoot;
@@ -143,48 +124,18 @@ function writePreSplitSdkBridgeConsumerFixture() {
 }
 
 afterEach(() => {
-  vi.resetModules();
-  vi.doUnmock("./plugin-module-loader-cache.js");
-  delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+  resetPluginCache();
+  vi.unstubAllEnvs();
   tempDirs.cleanup();
 });
 
-function mockSourceLoaderCalls() {
-  const sourceLoaderCalls: Array<{ modulePath: string; loaderFilename?: string }> = [];
-  vi.doMock("./plugin-module-loader-cache.js", async (importOriginal) => {
-    const actual = await importOriginal<typeof import("./plugin-module-loader-cache.js")>();
-    return {
-      ...actual,
-      getCachedPluginSourceModuleLoader: vi.fn((params) => {
-        sourceLoaderCalls.push({
-          modulePath: params.modulePath,
-          loaderFilename: params.loaderFilename,
-        });
-        return vi.fn(() => ({
-          default: {
-            id: "source-fallback",
-            register() {},
-          },
-        }));
-      }),
-    };
-  });
-  return sourceLoaderCalls;
-}
-
 describe("createPluginModuleLoader", () => {
-  it("loads bundled JavaScript without creating a module loader", async () => {
-    const sourceLoaderCalls = mockSourceLoaderCalls();
+  it("loads bundled JavaScript natively without source transformation", () => {
+    const pluginRoot = writeJavaScriptPluginFixture("demo");
+    vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", pluginRoot);
 
-    const { loadOpenClawPlugins } = await importFreshModule<typeof import("./loader.js")>(
-      import.meta.url,
-      "./loader.js?scope=native-module-loader",
-    );
-
-    const pluginRoot = writeBundledPluginFixture("demo");
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = pluginRoot;
-
-    loadOpenClawPlugins({
+    const before = getPluginModuleLoaderStats();
+    const registry = loadOpenClawPlugins({
       cache: false,
       installRecords: {},
       workspaceDir: pluginRoot,
@@ -200,20 +151,21 @@ describe("createPluginModuleLoader", () => {
       },
     });
 
-    expect(sourceLoaderCalls).toStrictEqual([]);
+    const after = getPluginModuleLoaderStats();
+    expect(registry.plugins.find((plugin) => plugin.id === "demo")).toMatchObject({
+      status: "loaded",
+      origin: "bundled",
+    });
+    expect(after.nativeHits).toBeGreaterThan(before.nativeHits);
+    expect(after.sourceTransformForced).toBe(before.sourceTransformForced);
+    expect(after.sourceTransformFallbacks).toBe(before.sourceTransformFallbacks);
   });
 
-  it("loads packaged JavaScript without creating a module loader", async () => {
-    const sourceLoaderCalls = mockSourceLoaderCalls();
-
-    const { loadOpenClawPlugins } = await importFreshModule<typeof import("./loader.js")>(
-      import.meta.url,
-      "./loader.js?scope=packaged-native-module-loader",
-    );
-
+  it("loads packaged JavaScript natively without source transformation", () => {
     const pluginRoot = writePackagedPluginFixture("npm-demo");
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = tempDirs.make("openclaw-plugin-loader-");
+    vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", tempDirs.make("openclaw-plugin-loader-"));
 
+    const before = getPluginModuleLoaderStats();
     const registry = loadOpenClawPlugins({
       cache: false,
       installRecords: {},
@@ -234,17 +186,16 @@ describe("createPluginModuleLoader", () => {
       },
     });
 
+    const after = getPluginModuleLoaderStats();
     expect(registry.plugins.find((plugin) => plugin.id === "npm-demo")?.status).toBe("loaded");
-    expect(sourceLoaderCalls).toStrictEqual([]);
+    expect(after.nativeHits).toBeGreaterThan(before.nativeHits);
+    expect(after.sourceTransformForced).toBe(before.sourceTransformForced);
+    expect(after.sourceTransformFallbacks).toBe(before.sourceTransformFallbacks);
   });
 
-  it("loads published pre-split SDK bridge imports (doctor repair, WhatsApp ack, Slack render)", async () => {
-    const { loadOpenClawPlugins } = await importFreshModule<typeof import("./loader.js")>(
-      import.meta.url,
-      "./loader.js?scope=sdk-bridge-upgrade-compat",
-    );
+  it("loads published pre-split SDK bridge imports (doctor repair, WhatsApp ack, Slack render)", () => {
     const pluginRoot = writePreSplitSdkBridgeConsumerFixture();
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = tempDirs.make("openclaw-plugin-loader-");
+    vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", tempDirs.make("openclaw-plugin-loader-"));
 
     const registry = loadOpenClawPlugins({
       cache: false,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the native JavaScript loader tests could pass even when both bundled and packaged plugins entered the source-transform fallback. That false-positive coverage could let native-loading regressions go unnoticed.

Maintainer-requested follow-up to #135077 (source-Gateway compiled-plugin loading), discovered during investigation of #134864. This PR does not reopen or claim to fix that already-resolved preload issue.

## Why This Change Was Made

The removed mock watched `getCachedPluginSourceModuleLoader`, but the actual runtime entry calls `getCachedPluginModuleLoader` directly and constructs its Jiti fallback internally. Both cases now read the existing production loader diagnostics around real registry loading: native hits must increase, and forced/fallback source-transform counters must remain unchanged. The bundled case also asserts loaded status and bundled provenance; the packaged loaded-status assertion remains independent.

No production seam or export was added. With no loader mocks remaining, the tests share the real module graph rather than resetting and cache-busting imports between cases. Production plugin-cache disposal and tracked environment restoration isolate fixtures. Duplicate native fixture setup is consolidated. The published SDK-bridge fixture and its actual registration/export assertions are retained.

## User Impact

No runtime behavior, configuration, SDK API, dependency version, or persistence change. Maintainers get tests that detect native fast-path bypass rather than asserting that an unrelated mock stayed unused.

Production LOC: **+0/-0**. Tests: **+29/-78** (net **-49**).

## Evidence

**Negative control:** forcing the existing native-require dependency seam to decline, while keeping the real source fallback/Jiti and successful plugin registration, left the old tests passing with `nativeHits=0`, `nativeMisses=1`, `sourceTransformFallbacks=1`, and an empty mock array. The repaired assertions failed that same control. Jiti may internally native-load CJS after entering its fallback pipeline, so this proves fast-path bypass/fallback detection, not a claim that Babel transformed those CJS bytes.

**Clean Linux comparison:** Blacksmith Testbox `tbx_01m1f1vwwsrh7mjyxjbk2b250r`, Node 24.19.0, [Actions run 33540751065](https://github.com/openclaw/openclaw/actions/runs/33540751065). Separate detached baseline and candidate worktrees used base `f6db44b4293c8f6c32ea1cef459f383915451202`; the candidate changed only this test file, SHA-256 `0aa462906d366b444fd7c013256fbc87c648b909e9631eaf2d864cf8113f7de5`.

- Original file: **3/3 passed**; retained bridge 70.604 seconds.
- Candidate plus native/cache/alias siblings: **70/70 passed**, four files; retained bridge 68.880 seconds.
- Both test commands exited 0. The outer comparison shell subsequently exited 128 because cleanup refused to remove the intentionally modified candidate scratch worktree. The lease was stopped and independently confirmed `completed`; this is not presented as a green outer-wrapper result.

Commands (the remote comparison used the existing serial worker setting and unchanged test timeouts):

```bash
node scripts/run-vitest.mjs src/plugins/loader.native-module-loader.test.ts
```

```bash
node scripts/run-vitest.mjs src/plugins/loader.native-module-loader.test.ts src/plugins/native-module-require.test.ts src/plugins/plugin-module-loader-cache.test.ts src/plugins/loader.lazy-alias.test.ts
```

```bash
node scripts/check-changed.mjs -- src/plugins/loader.native-module-loader.test.ts
```

Changed-file checks passed locally, including plugin-platform test types, targeted formatting/lint, boundary/ratchet guards, and dead-export scans. Fresh isolated Codex autoreview found no accepted/actionable findings at its default P0 threshold. Direct owner/caller/sibling and installed Jiti/Vitest/Node contract inspection supplemented review.

**Local timing caveat:** the Mac runs passed both repaired native cases and all 67 siblings, but the retained bridge exceeded its unchanged 120-second limit. A later diagnostic also found an incomplete local `minimatch` installation; `pnpm install --frozen-lockfile` repaired that package, but did not eliminate the Mac timeout. Phase/CPU sampling locates expensive Jiti source evaluation, and host contention was observed; neither establishes the full cause of the earlier delays. No assertions, source coverage, pool policy, or timeout were relaxed, and no performance improvement is claimed. The clean Linux baseline/candidate comparison above is the complete passing behavior proof.

History: the earliest locally available revision already contains the obsolete mock/call-graph mismatch. The shallow boundary prevents exact introduction attribution; no contributor is blamed.

Follow-up: investigate the SDK bridge's broad cold-source import cost separately, retaining the measured Mac failures. This test-observability repair does not hide or attempt to compensate for that cost. 

**Landing validation:** refreshed head `ba5772c76d2940abceba4995bf70ed8454423911` passed [CI run 33543462822](https://github.com/openclaw/openclaw/actions/runs/33543462822), and the repository CI watcher returned `GREEN` (exit 0). The first [CI run 33542292089](https://github.com/openclaw/openclaw/actions/runs/33542292089) failed only on the shared main-branch `TS2790` error in the auth-login test. After the existing fix #135407 merged, this PR was rebased onto it without changing the native-loader patch or file hash. No duplicate CI workaround was added. Native hosted preparation passed. The required [ClawSweeper review completed on this exact head](https://github.com/openclaw/openclaw/pull/135425#issuecomment-5499448942) at 2026-09-01T19:41:28Z, with no actionable findings and no code repair requested. Its remaining checklist item is ordinary maintainer review/handling; that review is complete. Earlier review-generation runs 33545770270 and 33547037250 failed before publication, and an initial retry supplied no record; the durable queue eventually produced the valid completion. No code, CI, or review gate was bypassed.
