### PR TITLE
fix(ui): keep selected agent on native progress cards

### DIFF
--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -10,6 +10,7 @@ const uiE2eRealGatewayTestFiles = [
   "ui/src/e2e/control-ui-auth-transports.e2e.test.ts",
   "ui/src/e2e/logs-lifecycle.e2e.test.ts",
   "ui/src/e2e/mcp-app-conformance.e2e.test.ts",
+  "ui/src/e2e/session-progress-hovercard.real-gateway.e2e.test.ts",
   "ui/src/e2e/usage-sessions-owner-attribution.e2e.test.ts",
 ];
 

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -470,7 +470,7 @@ function renderCatalogSessionRow(
     threadId: session.threadId,
   } satisfies CatalogSessionKey;
   const identityKey = buildCatalogSessionKey(catalogKey);
-  const key = session.sessionKey ?? identityKey;
+  const key = session.sessionKey ?? buildCatalogSessionKey(catalogKey, params.newSessionAgentId);
   const menuOpen = params.isMenuOpen(catalogKey);
   const rowRef = catalogRowRef(identityKey, key, catalogKey, menuOpen, params);
   const adoptedRow = session.sessionKey ? liveRowsByKey.get(session.sessionKey) : undefined;
@@ -494,9 +494,7 @@ function renderCatalogSessionRow(
     mainKey: params.mainKey,
   });
   const { href, options: navigation } = target;
-  const paneKey =
-    session.sessionKey ?? buildCatalogSessionKey(catalogKey, params.newSessionAgentId);
-  const active = paneKey === params.routeSessionKey;
+  const active = key === params.routeSessionKey;
   const running = session.status === "active" || session.status === "running";
   const stateDescription = running ? t("sessionsView.activeRun") : "";
   const stateId = running ? sidebarSessionStateId(key) : undefined;

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -12,7 +12,7 @@ import type {
   CatalogSessionContinuedDetail,
   CatalogSessionKey,
 } from "../lib/sessions/catalog-key.ts";
-import { buildCatalogSessionKey } from "../lib/sessions/catalog-key.ts";
+import { buildCatalogSessionKey, parseCatalogSessionKey } from "../lib/sessions/catalog-key.ts";
 import type { SidebarSessionHovercardRow } from "./app-sidebar-session-types.ts";
 
 export function formatSidebarTimestamp(timestampMs: number | null | undefined): string {
@@ -40,6 +40,7 @@ export function findCatalogSessionHovercardRow(params: {
   sessionKey: string;
   liveRow?: SidebarSessionHovercardRow;
 }): SidebarSessionHovercardRow | undefined {
+  const catalogKey = parseCatalogSessionKey(params.sessionKey);
   for (const catalog of params.catalogs) {
     for (const host of catalog.hosts) {
       for (const session of host.sessions) {
@@ -50,7 +51,12 @@ export function findCatalogSessionHovercardRow(params: {
             hostId: host.hostId,
             threadId: session.threadId,
           });
-        if (key !== params.sessionKey) {
+        const matchesCatalogKey =
+          // Routed catalog keys keep agent ownership; source lookup ignores only that prefix.
+          catalogKey?.catalogId === catalog.id &&
+          catalogKey.hostId === host.hostId &&
+          catalogKey.threadId === session.threadId;
+        if (key !== params.sessionKey && !matchesCatalogKey) {
           continue;
         }
         const cwd = normalizeOptionalString(session.cwd);

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -156,7 +156,7 @@ async function navigateToClaudeCatalog(page: Page) {
 }
 
 async function triggerClaudeCatalogTerminal(page: Page, options: { force?: boolean } = {}) {
-  const row = page.locator('[data-session-key^="catalog:"]').filter({
+  const row = page.locator('[data-catalog-session-key^="catalog:"]').filter({
     hasText: "Native Claude terminal",
   });
   await row.click({ button: "right", force: options.force });

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -651,7 +651,7 @@ suite.define(() => {
 
   it("renders and dismisses synthetic catalog-session hovercards", async () => {
     const selectedSessionKey = "agent:main:catalog-selected";
-    const catalogSessionKey = "catalog:codex:gateway%3Acodex:thread-1";
+    const catalogSessionKey = "agent:main:catalog:codex:gateway%3Acodex:thread-1";
 
     await suite.withPage(
       {

--- a/ui/src/e2e/session-progress-hovercard.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.real-gateway.e2e.test.ts
@@ -1,0 +1,207 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import type { GatewayServer } from "../../../src/gateway/server-public.ts";
+import { getActivePluginRegistry } from "../../../src/plugins/runtime.ts";
+import type { SessionCatalogProvider } from "../../../src/plugins/session-catalog.ts";
+import { createOpenClawTestState } from "../../../src/test-utils/openclaw-test-state.ts";
+import { getFreePort } from "../../../src/test-utils/ports.ts";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+declare global {
+  interface Window {
+    catalogProgressRequests?: Array<{ outcome: "error" | "ok"; sessionKey: string }>;
+  }
+}
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI catalog progress hovercard with a real Gateway",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}`,
+});
+
+const threadId = "00000000-0000-0000-0000-000000135156";
+const routeAgentId = "writer";
+const catalogSessionKey = `agent:${routeAgentId}:catalog:codex:gateway%3Alocal:${threadId}`;
+
+suite.define(() => {
+  it("keeps the selected agent on native catalog progress-card requests", async () => {
+    const port = await getFreePort();
+    const state = await createOpenClawTestState({
+      label: "control-ui-catalog-progress",
+      layout: "home",
+      env: {
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+        OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+        VITEST: "1",
+      },
+    });
+    let gateway: GatewayServer | undefined;
+    let removeCatalogRegistration: (() => void) | undefined;
+    try {
+      const mainWorkspace = state.path("workspace-main");
+      const writerWorkspace = state.path("workspace-writer");
+      await Promise.all([
+        mkdir(mainWorkspace, { recursive: true }),
+        mkdir(writerWorkspace, { recursive: true }),
+      ]);
+      await state.writeConfig({
+        agents: {
+          defaults: { workspace: mainWorkspace },
+          ownership: "explicit",
+          entries: {
+            main: { name: "Main", workspace: mainWorkspace },
+            [routeAgentId]: { name: "Writer", workspace: writerWorkspace },
+          },
+        },
+        gateway: {
+          auth: { mode: "none" },
+          controlUi: {
+            allowedOrigins: [new URL(suite.server.baseUrl).origin],
+            enabled: false,
+          },
+          port,
+        },
+      });
+      state.applyEnv();
+      const { startGatewayServer } = await import("../../../src/gateway/server.js");
+      gateway = await startGatewayServer(port, {
+        auth: { mode: "none" },
+        bind: "loopback",
+        controlUiEnabled: false,
+        sidecarStartup: "start",
+      });
+      const provider: SessionCatalogProvider = {
+        id: "codex",
+        label: "Codex",
+        list: async () => [
+          {
+            hostId: "gateway:local",
+            label: "Local Codex",
+            kind: "gateway",
+            connected: true,
+            sessions: [
+              {
+                threadId,
+                name: "Native catalog progress",
+                cwd: writerWorkspace,
+                status: "idle",
+                archived: false,
+                canContinue: false,
+                canArchive: false,
+              },
+            ],
+          },
+        ],
+        read: async ({ hostId, threadId: requestedThreadId }) => ({
+          hostId,
+          threadId: requestedThreadId,
+          items: [],
+        }),
+      };
+      const activeRegistry = getActivePluginRegistry();
+      if (!activeRegistry) {
+        throw new Error("Gateway plugin registry is unavailable");
+      }
+      // The real Gateway advertises catalog methods from this startup-owned registry object.
+      const registration = { pluginId: "codex", provider, source: import.meta.url };
+      activeRegistry.sessionCatalogs.push(registration);
+      removeCatalogRegistration = () => {
+        const index = activeRegistry.sessionCatalogs.indexOf(registration);
+        if (index >= 0) {
+          activeRegistry.sessionCatalogs.splice(index, 1);
+        }
+      };
+
+      const artifactDir = process.env.OPENCLAW_UI_E2E_CAPTURE === "1" ? suite.artifactDir : null;
+      await suite.withPage(
+        {
+          hasTouch: false,
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { height: 900, width: 1440 },
+        },
+        async ({ page }) => {
+          const url = new URL(`chat/${routeAgentId}`, suite.server.baseUrl);
+          url.searchParams.set("gatewayUrl", `ws://127.0.0.1:${port}`);
+          await page.goto(url.toString());
+          const confirmation = page.locator("openclaw-gateway-url-confirmation");
+          await confirmation.waitFor();
+          await confirmation.getByRole("button", { name: "Confirm", exact: true }).click();
+
+          const row = page.locator(
+            '[data-session-section="catalog:codex"] .sidebar-recent-session',
+            {
+              hasText: "Native catalog progress",
+            },
+          );
+          await row.waitFor({ state: "visible", timeout: 30_000 });
+          if (artifactDir) {
+            await page.screenshot({
+              animations: "disabled",
+              fullPage: true,
+              path: path.join(artifactDir, "01-native-catalog-row.png"),
+            });
+          }
+          expect(await row.getAttribute("data-session-key")).toBe(catalogSessionKey);
+          await page.evaluate(() => {
+            const app = document.querySelector("openclaw-app") as HTMLElement & {
+              runtime: {
+                context: { gateway: { snapshot: { client: GatewayBrowserClient | null } } };
+              };
+            };
+            const client = app.runtime.context.gateway.snapshot.client;
+            if (!client) {
+              throw new Error("Control UI Gateway client is unavailable");
+            }
+            const request = client.request.bind(client);
+            const observed: Array<{ outcome: "error" | "ok"; sessionKey: string }> = [];
+            window.catalogProgressRequests = observed;
+            client.request = async <T>(method: string, params?: unknown): Promise<T> => {
+              if (method !== "progressCard.get") {
+                return await request<T>(method, params);
+              }
+              const sessionKey = (params as { sessionKey: string }).sessionKey;
+              try {
+                const result = await request<T>(method, params);
+                observed.push({ outcome: "ok", sessionKey });
+                return result;
+              } catch (error) {
+                observed.push({ outcome: "error", sessionKey });
+                throw error;
+              }
+            };
+          });
+          await row.locator("a.sidebar-recent-session__link").focus();
+          const card = page.locator(".session-progress-hovercard");
+          await card.waitFor({ state: "visible" });
+          await expect
+            .poll(() => page.evaluate(() => window.catalogProgressRequests))
+            .toEqual([{ outcome: "ok", sessionKey: catalogSessionKey }]);
+          await expect.poll(() => card.textContent()).toContain("Native catalog progress");
+          if (artifactDir) {
+            await page.screenshot({
+              animations: "disabled",
+              fullPage: true,
+              path: path.join(artifactDir, "02-qualified-progress-card.png"),
+            });
+          }
+        },
+      );
+    } finally {
+      removeCatalogRegistration?.();
+      try {
+        await gateway?.close({ reason: "catalog progress hovercard e2e cleanup" });
+      } finally {
+        await state.cleanup();
+      }
+    }
+  });
+});

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-terminal-owner.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-terminal-owner.ts
@@ -179,7 +179,9 @@ describe("AppSidebar catalog terminal ownership", () => {
       const catalog = sidebar.querySelector('[data-session-section="catalog:codex"]');
       expect(catalog?.querySelector('[data-session-key="agent:jarvis:adopted-codex"]')).toBeNull();
       expect(
-        catalog?.querySelector('[data-session-key="catalog:codex:gateway%3Alocal:thread-1"]'),
+        catalog?.querySelector(
+          '[data-session-key="agent:main:catalog:codex:gateway%3Alocal:thread-1"]',
+        ),
       ).not.toBeNull();
     } finally {
       vi.useRealTimers();

--- a/ui/src/test-helpers/app-sidebar-cases/interactions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/interactions.ts
@@ -676,7 +676,7 @@ describe("AppSidebar catalog session rows", () => {
       const active = sidebar.querySelectorAll(".sidebar-recent-session--active");
       expect(active).toHaveLength(1);
       expect(active[0]?.getAttribute("data-session-key")).toBe(
-        "catalog:codex:gateway%3Alocal:thread-1",
+        "agent:main:catalog:codex:gateway%3Alocal:thread-1",
       );
       expect(active[0]?.getAttribute("role")).toBe("listitem");
       expect(active[0]?.closest('[role="list"]')?.getAttribute("aria-label")).toBe("Local Codex");


### PR DESCRIPTION
Closes #135156

Supersedes #135223. The replacement keeps @rwinkelman's UI fix and removes the unrelated Gateway changes. Reported by @Synthetic2802.

## What Problem This Solves

Fixes an issue where operators using explicit multi-agent ownership could lose the selected agent when the Control UI loaded a native catalog session progress card. The Gateway then rejected the ownerless session key with `INVALID_REQUEST`, so the hovercard did not load.

## Why This Change Was Made

The catalog sidebar now uses the selected-agent-qualified session key for routed row actions such as `progressCard.get`. It keeps the ownerless catalog identity separately for source lookup and adoption matching.

The repair stays at the Control UI session-identity producer. It does not relax Gateway ownership checks or change configuration, storage, or protocol contracts.

## User Impact

Operators can select a non-default agent and open a native Codex catalog hovercard without an internal ownership error. The hovercard keeps its native title and workspace context.

## Evidence

- Exact-main red: `790bab7e300c03e1872fd4f644a9730a64957a32` sent `catalog:codex:...` from the real Control UI to a real isolated Gateway. Explicit ownership rejected it with `INVALID_REQUEST`.
- Exact-head green: `a68b895a3175172681b883ed94485cd661cf7659` sent `agent:writer:catalog:codex:...`; the real Gateway returned `progressCard.get` successfully.
- Anti-cheat probe: the route selected the non-default `writer` agent and the native catalog row came from the real Gateway catalog registry.
- `node scripts/run-vitest.mjs run ui/src/components/app-sidebar.test.ts ui/src/components/app-sidebar-session-catalogs.test.ts` — 330 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-progress-hovercard.e2e.test.ts` — 8 passed.
- Claude native-session E2E — 7 passed after its source-row selector moved to the preserved catalog identity attribute.
- Real Control UI/Gateway E2E — 1 passed on the exact head.
- Autoreview — clean, no accepted or actionable P0 findings.
- Production LOC: +10/-6, net +4. Tests and test support: +214/-4.

| Before: ownerless catalog row | After: selected-agent hovercard |
| --- | --- |
| ![Ownerless native catalog row](https://github.com/user-attachments/assets/80b4cddc-7473-4e95-8c43-f9d63a7129e0) | ![Native progress hovercard for the selected agent](https://github.com/user-attachments/assets/770b02fa-a7f9-4d43-b915-65a80ea4c9bc) |

https://github.com/user-attachments/assets/2cfc4c69-33d3-4e70-a674-8cafc99ca249
