### PR TITLE
refactor(github): simplify publication and connection lifecycles

### DIFF
--- a/src/gateway/github-publication-coordinator-methods.ts
+++ b/src/gateway/github-publication-coordinator-methods.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type {
+  GitHubPublicationPublisher,
   SessionGitHubPublicationResult,
   SessionGitHubPublishParams,
 } from "../../packages/gateway-protocol/src/schema/session-github-publication.js";
@@ -25,7 +26,9 @@ import {
   ensureGitHubPublicationStore as ensureSchema,
   githubPublicationDatabase as publicationDb,
   hasGitHubPublicationStore as schemaExists,
+  listGitHubPublicationsForClaim,
   projectGitHubPublicationResult as publicationResult,
+  readGitHubPublicationRequest,
   type GitHubPublicationRow as PublicationRow,
 } from "./github-publication-store.js";
 import { loadGatewaySessionEntryReadOnly } from "./session-utils.js";
@@ -34,7 +37,7 @@ import type {
   WorkerSessionTurnClaim,
 } from "./worker-environments/placement-store.js";
 
-type ClaimRequest = {
+export type GitHubPublicationClaimRequest = {
   claim: WorkerSessionTurnClaim;
   sessionKey: string;
   agentId: string;
@@ -42,7 +45,7 @@ type ClaimRequest = {
   title?: string;
   body?: string;
   assertCurrent?: () => void;
-  expectedPublisher?: import("../../packages/gateway-protocol/src/schema/session-github-publication.js").GitHubPublicationPublisher;
+  expectedPublisher?: GitHubPublicationPublisher;
 };
 
 function exactClaimForPlacement(
@@ -88,7 +91,9 @@ function exactClaimForPlacement(
 export function createGitHubPublicationCoordinatorMethods(params: {
   placements: WorkerSessionPlacementStore;
   readById: (requestId: string) => PublicationRow | undefined;
-  requestForClaim: (request: ClaimRequest) => Promise<SessionGitHubPublicationResult>;
+  requestForClaim: (
+    request: GitHubPublicationClaimRequest,
+  ) => Promise<SessionGitHubPublicationResult>;
   sameWorktree: (
     row: PublicationRow,
     worktree: ReturnType<typeof resolveGitHubPublicationWorktreeOwner>["worktree"],
@@ -195,14 +200,10 @@ export function createGitHubPublicationCoordinatorMethods(params: {
         body: input.body,
       });
       const database = openOpenClawStateDatabase().db;
-      const existing = executeSqliteQuerySync(
-        database,
-        publicationDb(database)
-          .selectFrom("github_publication_requests")
-          .selectAll()
-          .where("session_id", "=", sessionId)
-          .where("idempotency_key", "=", input.idempotencyKey),
-      ).rows[0];
+      const existing = readGitHubPublicationRequest(database, {
+        sessionId,
+        idempotencyKey: input.idempotencyKey,
+      });
       if (existing) {
         if (existing.request_digest !== requestDigest || !sameWorktree(existing, worktree)) {
           throw new Error("GitHub publication idempotency key was reused.");
@@ -323,16 +324,7 @@ export function createGitHubPublicationCoordinatorMethods(params: {
     async processClaim(claim: WorkerSessionTurnClaim): Promise<SessionGitHubPublicationResult[]> {
       ensureSchema();
       const db = openOpenClawStateDatabase().db;
-      const rows = executeSqliteQuerySync(
-        db,
-        publicationDb(db)
-          .selectFrom("github_publication_requests")
-          .selectAll()
-          .where("session_id", "=", claim.sessionId)
-          .where("claim_id", "=", claim.claimId)
-          .where("run_id", "=", claim.runId)
-          .orderBy("created_at_ms"),
-      ).rows;
+      const rows = listGitHubPublicationsForClaim(claim);
       const missingSnapshots = rows.filter(
         (row) => !row.source_head_commit || !row.source_index_tree || !row.workspace_tree,
       );

--- a/src/gateway/github-publication-executor.ts
+++ b/src/gateway/github-publication-executor.ts
@@ -33,6 +33,7 @@ import {
   assertSafeGitPublicationWorkspace,
   assertGitHubPublicationBranchRef,
   captureGitHubPublicationWorkspaceSnapshot,
+  createGitHubPublicationCommandRunner,
   githubPublicationPushArgs,
   githubPublicationRemoteHeadArgs,
   githubPublicationUpdateRefArgs,
@@ -140,18 +141,11 @@ export async function executeGitHubPublication<Row extends PublicationRow>(param
       throw new Error("GitHub publication identity changed.");
     }
   };
-  const step = async <T>(operation: () => Promise<T>): Promise<T> => {
-    assertAuthority();
-    const value = await operation();
-    assertAuthority();
-    return value;
-  };
+  const { step, run, require: command } = createGitHubPublicationCommandRunner(assertAuthority);
   try {
     const { loaded, worktree } = currentWorktree();
-    await step(async () => await assertSafeGitPublicationWorkspace(worktree.path, runCommand));
-    await step(
-      async () => await recoverGitHubPublicationWorkspace(initial, requireCommand, assertAuthority),
-    );
+    await step(() => assertSafeGitPublicationWorkspace(worktree.path, runCommand));
+    await step(() => recoverGitHubPublicationWorkspace(initial, requireCommand, assertAuthority));
     let row = initial;
     let sourceHeadCommit = row.source_head_commit;
     let sourceIndexTree = row.source_index_tree;
@@ -191,17 +185,13 @@ export async function executeGitHubPublication<Row extends PublicationRow>(param
         );
       }
     }
-    let headCommit = await step(
-      async () =>
-        await requireCommand(["git", "rev-parse", "--verify", "HEAD^{commit}"], {
-          cwd: worktree.path,
-        }),
-    );
+    let headCommit = await command(["git", "rev-parse", "--verify", "HEAD^{commit}"], {
+      cwd: worktree.path,
+    });
     const refreshIdentity = async (): Promise<PreparedGitHubPublicationIdentity> => {
       const identity = await step(
-        async () =>
-          await (params.identity?.prepare() ??
-            prepareCurrentGitHubPublicationIdentity(initial.agent_id)),
+        () =>
+          params.identity?.prepare() ?? prepareCurrentGitHubPublicationIdentity(initial.agent_id),
       );
       if (!matchesGitHubPublicationIdentityRow(initial, identity)) {
         throw new Error("GitHub publication identity changed.");
@@ -223,12 +213,9 @@ export async function executeGitHubPublication<Row extends PublicationRow>(param
         "GitHub publication accepted repository target changed.",
       );
     }
-    const remoteBaseResult = await step(
-      async () =>
-        await runCommand(githubPublicationBaseLookupArgs(repository, baseBranch), {
-          env: identity.env,
-        }),
-    );
+    const remoteBaseResult = await run(githubPublicationBaseLookupArgs(repository, baseBranch), {
+      env: identity.env,
+    });
     if (remoteBaseResult.code !== 0) {
       throw new Error("GitHub publication workspace base branch could not be verified.");
     }
@@ -236,55 +223,40 @@ export async function executeGitHubPublication<Row extends PublicationRow>(param
       remoteBaseResult.stdout.toString("utf8"),
       baseBranch,
     );
-    await step(async () => await assertSafeGitPublicationWorkspace(worktree.path, runCommand));
+    await step(() => assertSafeGitPublicationWorkspace(worktree.path, runCommand));
     identity = await refreshIdentity();
     const baseTransportEnv = {
       ...identity.env,
       GIT_CONFIG_GLOBAL: os.devNull,
       GIT_CONFIG_SYSTEM: os.devNull,
     };
-    const baseFetched = await step(
-      async () =>
-        await runCommand(githubPublicationBaseFetchArgs(repository, remoteBaseSha), {
-          cwd: worktree.path,
-          env: baseTransportEnv,
-        }),
-    );
+    const baseFetched = await run(githubPublicationBaseFetchArgs(repository, remoteBaseSha), {
+      cwd: worktree.path,
+      env: baseTransportEnv,
+    });
     if (baseFetched.code !== 0) {
       throw new Error("GitHub publication workspace base could not be materialized.");
     }
-    const creation = await step(
-      async () =>
-        await runCommand(githubPublicationBranchCreationArgs(branch), {
-          cwd: worktree.path,
-        }),
-    );
+    const creation = await run(githubPublicationBranchCreationArgs(branch), { cwd: worktree.path });
     const creationEntries = creation.stdout.toString("utf8").trim().split(/\r?\n/u);
     const creationBase = creationEntries.at(-1) ?? "";
     if (creation.code !== 0 || !/^[a-f0-9]{40}(?:[a-f0-9]{24})?$/iu.test(creationBase)) {
       throw new Error("GitHub publication workspace creation base could not be verified.");
     }
-    const creationOwnsRemote = await step(
-      async () =>
-        await runCommand(githubPublicationBaseLineageArgs(creationBase, remoteBaseSha), {
-          cwd: worktree.path,
-        }),
+    const creationOwnsRemote = await run(
+      githubPublicationBaseLineageArgs(creationBase, remoteBaseSha),
+      { cwd: worktree.path },
     );
-    const creationOwnsSource = await step(
-      async () =>
-        await runCommand(githubPublicationBaseLineageArgs(creationBase, sourceHeadCommit), {
-          cwd: worktree.path,
-        }),
+    const creationOwnsSource = await run(
+      githubPublicationBaseLineageArgs(creationBase, sourceHeadCommit),
+      { cwd: worktree.path },
     );
     if (creationOwnsRemote.code !== 0 || creationOwnsSource.code !== 0) {
       throw new Error("GitHub publication workspace base lineage could not be verified.");
     }
-    const baseTree = await step(
-      async () =>
-        await requireCommand(["git", "rev-parse", `${remoteBaseSha}^{tree}`], {
-          cwd: worktree.path,
-        }),
-    );
+    const baseTree = await command(["git", "rev-parse", `${remoteBaseSha}^{tree}`], {
+      cwd: worktree.path,
+    });
     if (baseTree === workspaceTree) {
       throw new GitHubPublicationKnownFailure("GitHub publication has no changes to publish.", {
         code: "no_changes",
@@ -346,20 +318,13 @@ export async function executeGitHubPublication<Row extends PublicationRow>(param
 
       return found?.url;
     };
-    const currentMessage = await step(
-      async () =>
-        await requireCommand(["git", "show", "-s", "--format=%B", "HEAD"], {
-          cwd: worktree.path,
-        }),
-    );
+    const currentMessage = await command(["git", "show", "-s", "--format=%B", "HEAD"], {
+      cwd: worktree.path,
+    });
     const markerPresent = currentMessage.split(/\r?\n/u).includes(marker);
-    const currentTree = await step(
-      async () => await requireCommand(["git", "rev-parse", "HEAD^{tree}"], { cwd: worktree.path }),
-    );
+    const currentTree = await command(["git", "rev-parse", "HEAD^{tree}"], { cwd: worktree.path });
     if (markerPresent) {
-      const markerParent = await step(
-        async () => await requireCommand(["git", "rev-parse", "HEAD^"], { cwd: worktree.path }),
-      );
+      const markerParent = await command(["git", "rev-parse", "HEAD^"], { cwd: worktree.path });
       if (markerParent !== sourceHeadCommit || currentTree !== workspaceTree) {
         throw new GitHubPublicationWorkspaceChangedError(
           "GitHub publication workspace changed after its accepted snapshot.",
@@ -393,10 +358,8 @@ export async function executeGitHubPublication<Row extends PublicationRow>(param
     const previousBranchHead = headCommit;
     let updateBranchRef: (() => Promise<void>) | undefined;
     if (!markerPresent) {
-      await step(async () => {
-        await requireCommand(["git", "cat-file", "-e", `${workspaceTree}^{tree}`], {
-          cwd: worktree.path,
-        });
+      await command(["git", "cat-file", "-e", `${workspaceTree}^{tree}`], {
+        cwd: worktree.path,
       });
       const title = row.title?.trim() || `Publish ${branch}`;
       const commitBody = contributorCredit
@@ -417,20 +380,14 @@ export async function executeGitHubPublication<Row extends PublicationRow>(param
         GIT_AUTHOR_DATE: timestamp,
         GIT_COMMITTER_DATE: timestamp,
       };
-      const commit = await step(
-        async () =>
-          await requireCommand(
-            ["git", "commit-tree", "--no-gpg-sign", workspaceTree, "-p", headCommit],
-            {
-              cwd: worktree.path,
-              env: authorEnv,
-              input: `${message}\n`,
-            },
-          ),
+      const commit = await command(
+        ["git", "commit-tree", "--no-gpg-sign", workspaceTree, "-p", headCommit],
+        { cwd: worktree.path, env: authorEnv, input: `${message}\n` },
       );
-      await assertGitHubPublicationBranchRef(branch, async (argv) => {
-        return (await step(async () => await runCommand(argv, { cwd: worktree.path }))).code ?? -1;
-      });
+      await assertGitHubPublicationBranchRef(
+        branch,
+        async (argv) => (await run(argv, { cwd: worktree.path })).code ?? -1,
+      );
       const previousHead = headCommit;
       updateBranchRef = async () => {
         const result = await runCommand(
@@ -451,7 +408,7 @@ export async function executeGitHubPublication<Row extends PublicationRow>(param
       headCommit,
       env: identity.env,
       assertCurrent: assertAuthority,
-      run: async (argv, options) => await step(async () => await requireCommand(argv, options)),
+      run: command,
       ...(updateBranchRef ? { updateRef: updateBranchRef } : {}),
     });
     row = params.updatePublishingFacts({
@@ -464,7 +421,7 @@ export async function executeGitHubPublication<Row extends PublicationRow>(param
       headCommit,
     });
 
-    await step(async () => await assertSafeGitPublicationWorkspace(worktree.path, runCommand));
+    await step(() => assertSafeGitPublicationWorkspace(worktree.path, runCommand));
     const httpsRemote = `https://github.com/${pushRepository}.git`;
     identity = await refreshIdentity();
     let transportEnv = {

--- a/src/gateway/github-publication-git-transport.ts
+++ b/src/gateway/github-publication-git-transport.ts
@@ -40,6 +40,24 @@ export async function requirePublicationCommand(
   return result.stdout.toString("utf8").trim();
 }
 
+// Guard ordinary steps on both sides of the await. Effects whose observations
+// must survive revocation use the raw transport and record before rechecking.
+export function createGitHubPublicationCommandRunner(assertCurrent?: () => void) {
+  const step = async <T>(operation: () => Promise<T>): Promise<T> => {
+    assertCurrent?.();
+    const result = await operation();
+    assertCurrent?.();
+    return result;
+  };
+  return {
+    step,
+    run: (...args: Parameters<typeof runPublicationCommand>) =>
+      step(() => runPublicationCommand(...args)),
+    require: (...args: Parameters<typeof requirePublicationCommand>) =>
+      step(() => requirePublicationCommand(...args)),
+  };
+}
+
 // A recursive tree listing scales with repository size (openclaw itself is
 // ~3.3MB), far past the default per-command cap above. Without this explicit
 // bound the attribute scan dies as an output-limit "verification" failure on
@@ -186,26 +204,17 @@ export async function captureGitHubPublicationWorkspaceSnapshot(params: {
   cwd: string;
   assertCurrent?: () => void;
 }): Promise<{ sourceHeadCommit: string; sourceIndexTree: string; workspaceTree: string }> {
-  const step = async <T>(operation: () => Promise<T>): Promise<T> => {
-    params.assertCurrent?.();
-    const result = await operation();
-    params.assertCurrent?.();
-    return result;
-  };
+  const { step, require: command } = createGitHubPublicationCommandRunner(params.assertCurrent);
+  const git = (args: string[], env?: NodeJS.ProcessEnv) =>
+    command(["git", "-c", `core.hooksPath=${os.devNull}`, "-c", "core.fsmonitor=false", ...args], {
+      cwd: params.cwd,
+      env,
+    });
   await step(() => assertSafeGitPublicationWorkspace(params.cwd, runPublicationCommand));
-  const sourceHeadCommit = await step(
-    async () =>
-      await requirePublicationCommand(["git", "rev-parse", "--verify", "HEAD^{commit}"], {
-        cwd: params.cwd,
-      }),
-  );
-  const sourceIndexTree = await step(
-    async () =>
-      await requirePublicationCommand(
-        ["git", "-c", `core.hooksPath=${os.devNull}`, "-c", "core.fsmonitor=false", "write-tree"],
-        { cwd: params.cwd },
-      ),
-  );
+  const sourceHeadCommit = await command(["git", "rev-parse", "--verify", "HEAD^{commit}"], {
+    cwd: params.cwd,
+  });
+  const sourceIndexTree = await git(["write-tree"]);
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-github-snapshot-"));
   try {
     const env: NodeJS.ProcessEnv = {
@@ -214,43 +223,9 @@ export async function captureGitHubPublicationWorkspaceSnapshot(params: {
       GIT_CONFIG_SYSTEM: os.devNull,
       GIT_INDEX_FILE: path.join(tempDir, "index"),
     };
-    await step(async () => {
-      await requirePublicationCommand(
-        [
-          "git",
-          "-c",
-          `core.hooksPath=${os.devNull}`,
-          "-c",
-          "core.fsmonitor=false",
-          "read-tree",
-          sourceHeadCommit,
-        ],
-        { cwd: params.cwd, env },
-      );
-    });
-    await step(async () => {
-      await requirePublicationCommand(
-        [
-          "git",
-          "-c",
-          `core.attributesFile=${os.devNull}`,
-          "-c",
-          `core.hooksPath=${os.devNull}`,
-          "-c",
-          "core.fsmonitor=false",
-          "add",
-          "-A",
-        ],
-        { cwd: params.cwd, env },
-      );
-    });
-    const workspaceTree = await step(
-      async () =>
-        await requirePublicationCommand(
-          ["git", "-c", `core.hooksPath=${os.devNull}`, "-c", "core.fsmonitor=false", "write-tree"],
-          { cwd: params.cwd, env },
-        ),
-    );
+    await git(["read-tree", sourceHeadCommit], env);
+    await git(["-c", `core.attributesFile=${os.devNull}`, "add", "-A"], env);
+    const workspaceTree = await git(["write-tree"], env);
     await step(() =>
       assertGitHubPublicationTreeHasNoFilters(params.cwd, workspaceTree, runPublicationCommand),
     );

--- a/src/gateway/github-publication-store.ts
+++ b/src/gateway/github-publication-store.ts
@@ -55,6 +55,39 @@ export function hasGitHubPublicationStore(): boolean {
   return tableExists(openOpenClawStateDatabase().db, "github_publication_requests");
 }
 
+export function readGitHubPublicationRequest(
+  db: Parameters<typeof getNodeSqliteKysely>[0],
+  request: { requestId: string } | { sessionId: string; idempotencyKey: string },
+): GitHubPublicationRow | undefined {
+  const query = githubPublicationDatabase(db).selectFrom("github_publication_requests").selectAll();
+  return executeSqliteQueryTakeFirstSync(
+    db,
+    "requestId" in request
+      ? query.where("request_id", "=", request.requestId)
+      : query
+          .where("session_id", "=", request.sessionId)
+          .where("idempotency_key", "=", request.idempotencyKey),
+  );
+}
+
+export function listGitHubPublicationsForClaim(
+  claim: WorkerSessionTurnClaim,
+  options: { pendingOnly?: boolean } = {},
+): GitHubPublicationRow[] {
+  const db = openOpenClawStateDatabase().db;
+  let query = githubPublicationDatabase(db)
+    .selectFrom("github_publication_requests")
+    .selectAll()
+    .where("session_id", "=", claim.sessionId)
+    .where("claim_id", "=", claim.claimId)
+    .where("run_id", "=", claim.runId)
+    .orderBy("created_at_ms");
+  if (options.pendingOnly) {
+    query = query.where("status", "in", ["requested", "publishing"]);
+  }
+  return executeSqliteQuerySync(db, query).rows;
+}
+
 export function claimGitHubPublicationExecution(
   requestId: string,
   gatewayInstanceId: string,
@@ -62,13 +95,7 @@ export function claimGitHubPublicationExecution(
   return runOpenClawStateWriteTransaction(
     ({ db }) => {
       const query = githubPublicationDatabase(db);
-      const current = executeSqliteQuerySync(
-        db,
-        query
-          .selectFrom("github_publication_requests")
-          .selectAll()
-          .where("request_id", "=", requestId),
-      ).rows[0];
+      const current = readGitHubPublicationRequest(db, { requestId });
       if (!current) {
         throw new Error("GitHub publication request disappeared.");
       }
@@ -175,14 +202,10 @@ export function insertGitHubPublicationRequest(
       })
       .onConflict((conflict) => conflict.columns(["session_id", "idempotency_key"]).doNothing()),
   );
-  const stored = executeSqliteQueryTakeFirstSync(
-    db,
-    query
-      .selectFrom("github_publication_requests")
-      .selectAll()
-      .where("session_id", "=", input.sessionId)
-      .where("idempotency_key", "=", request.idempotencyKey),
-  );
+  const stored = readGitHubPublicationRequest(db, {
+    sessionId: input.sessionId,
+    idempotencyKey: request.idempotencyKey,
+  });
   if (
     !stored ||
     stored.request_digest !== input.requestDigest ||
@@ -383,23 +406,23 @@ export function projectGitHubPublicationResult(
           },
         }
       : {};
-  const publisher = {
-    source:
-      row.identity_source === "personal"
-        ? ("personal" as const)
-        : row.identity_source === "agent-override"
-          ? ("agent-override" as const)
-          : row.identity_source === "system-configured"
-            ? ("system-configured" as const)
-            : ("system-detected" as const),
-    accountId: row.identity_account_id,
-    login: row.identity_login,
-  };
+  const common = {
+    requestId: row.request_id,
+    publisher: {
+      source:
+        row.identity_source === "personal" ||
+        row.identity_source === "agent-override" ||
+        row.identity_source === "system-configured"
+          ? row.identity_source
+          : "system-detected",
+      accountId: row.identity_account_id,
+      login: row.identity_login,
+    },
+    ...effect,
+  } satisfies Pick<SessionGitHubPublicationResult, "requestId" | "publisher" | "effect">;
   if (row.status === "published" && row.pull_request_url && row.repository && row.branch) {
     return {
-      requestId: row.request_id,
-      publisher,
-      ...effect,
+      ...common,
       status: "published",
       url: row.pull_request_url,
       repository: row.repository,
@@ -409,9 +432,7 @@ export function projectGitHubPublicationResult(
   }
   if (row.status === "failed" && row.error_code && row.next_action) {
     return {
-      requestId: row.request_id,
-      publisher,
-      ...effect,
+      ...common,
       status: "failed",
       code: publicationFailureCode(row.error_code),
       message: "GitHub publication failed.",
@@ -420,18 +441,14 @@ export function projectGitHubPublicationResult(
   }
   if (row.status === "needs_confirmation") {
     return {
-      requestId: row.request_id,
-      publisher,
-      ...effect,
+      ...common,
       status: "needs_confirmation",
       message:
         "Confirm the original My GitHub account, target, and workspace to continue this interrupted publication. Already-dispatched GitHub effects may have completed; confirmation checks them before retrying.",
     };
   }
   return {
-    requestId: row.request_id,
-    publisher,
-    ...effect,
+    ...common,
     status: row.status === "publishing" ? "publishing" : "requested",
     message:
       row.status === "publishing"

--- a/src/gateway/github-publication.ts
+++ b/src/gateway/github-publication.ts
@@ -17,7 +17,10 @@ import {
   prepareCurrentGitHubPublicationIdentity,
   resolveGitHubPublicationWorktreeOwner,
 } from "./github-publication-availability.js";
-import { createGitHubPublicationCoordinatorMethods } from "./github-publication-coordinator-methods.js";
+import {
+  createGitHubPublicationCoordinatorMethods,
+  type GitHubPublicationClaimRequest,
+} from "./github-publication-coordinator-methods.js";
 import { executeGitHubPublication } from "./github-publication-executor.js";
 import { captureGitHubPublicationWorkspaceSnapshot } from "./github-publication-git-transport.js";
 import {
@@ -29,7 +32,9 @@ import {
   ensureGitHubPublicationStore as ensureSchema,
   githubPublicationDatabase as publicationDb,
   isGitHubPublicationExecutionOwner as ownsExecution,
+  listGitHubPublicationsForClaim,
   projectGitHubPublicationResult as publicationResult,
+  readGitHubPublicationRequest,
   type GitHubPublicationRow as PublicationRow,
 } from "./github-publication-store.js";
 import type {
@@ -117,25 +122,12 @@ export function createGitHubPublicationCoordinator(params: {
   const readById = (requestId: string): PublicationRow | undefined => {
     ensureSchema();
     const db = openOpenClawStateDatabase().db;
-    return executeSqliteQuerySync(
-      db,
-      publicationDb(db)
-        .selectFrom("github_publication_requests")
-        .selectAll()
-        .where("request_id", "=", requestId),
-    ).rows[0];
+    return readGitHubPublicationRequest(db, { requestId });
   };
 
-  const requestForClaim = async (request: {
-    claim: WorkerSessionTurnClaim;
-    sessionKey: string;
-    agentId: string;
-    idempotencyKey: string;
-    title?: string;
-    body?: string;
-    assertCurrent?: () => void;
-    expectedPublisher?: import("../../packages/gateway-protocol/src/schema/session-github-publication.js").GitHubPublicationPublisher;
-  }): Promise<SessionGitHubPublicationResult> => {
+  const requestForClaim = async (
+    request: GitHubPublicationClaimRequest,
+  ): Promise<SessionGitHubPublicationResult> => {
     ensureSchema();
     request.assertCurrent?.();
     if (!params.placements.validateTurnClaim(request.claim)) {
@@ -219,13 +211,7 @@ export function createGitHubPublicationCoordinator(params: {
           agentId: input.row.agent_id,
         });
         const query = publicationDb(db);
-        const current = executeSqliteQuerySync(
-          db,
-          query
-            .selectFrom("github_publication_requests")
-            .selectAll()
-            .where("request_id", "=", input.row.request_id),
-        ).rows[0];
+        const current = readGitHubPublicationRequest(db, { requestId: input.row.request_id });
         if (
           !current ||
           current.claim_id !== input.claim.claimId ||
@@ -320,18 +306,7 @@ export function createGitHubPublicationCoordinator(params: {
   const prepareClaimWorkspace = async (claim: WorkerSessionTurnClaim): Promise<void> => {
     ensureSchema();
     params.placements.closeWorkerTurnToolAdmission(claim);
-    const db = openOpenClawStateDatabase().db;
-    const rows = executeSqliteQuerySync(
-      db,
-      publicationDb(db)
-        .selectFrom("github_publication_requests")
-        .selectAll()
-        .where("session_id", "=", claim.sessionId)
-        .where("claim_id", "=", claim.claimId)
-        .where("run_id", "=", claim.runId)
-        .where("status", "in", ["requested", "publishing"])
-        .orderBy("created_at_ms"),
-    ).rows;
+    const rows = listGitHubPublicationsForClaim(claim, { pendingOnly: true });
     if (rows.length === 0) {
       return;
     }
@@ -389,18 +364,7 @@ export function createGitHubPublicationCoordinator(params: {
 
   const deferClaimPreparation = (claim: WorkerSessionTurnClaim): void => {
     ensureSchema();
-    const db = openOpenClawStateDatabase().db;
-    const rows = executeSqliteQuerySync(
-      db,
-      publicationDb(db)
-        .selectFrom("github_publication_requests")
-        .selectAll()
-        .where("session_id", "=", claim.sessionId)
-        .where("claim_id", "=", claim.claimId)
-        .where("run_id", "=", claim.runId)
-        .where("status", "in", ["requested", "publishing"])
-        .orderBy("created_at_ms"),
-    ).rows;
+    const rows = listGitHubPublicationsForClaim(claim, { pendingOnly: true });
     deferRequests(rows.map((row) => row.request_id));
   };
 

--- a/src/gateway/server-methods/github-personal-authorization.ts
+++ b/src/gateway/server-methods/github-personal-authorization.ts
@@ -6,7 +6,10 @@ import {
   resolveOperatorRolePolicy,
   resolveOperatorRolePolicyForProfile,
 } from "../operator-role-policy.js";
-import { resolveSessionMutationAuthorization } from "../session-sharing.js";
+import {
+  createSessionListEntryFilter,
+  resolveSessionMutationAuthorization,
+} from "../session-sharing.js";
 import { loadGatewaySessionEntryReadOnly } from "../session-utils.js";
 import { isGatewayClientProfilePending } from "./gateway-client-identity.js";
 import type { GatewayClient, GatewayRequestHandlerOptions } from "./types.js";
@@ -83,7 +86,7 @@ type PersonalEligibility =
   | { kind: "absent" | "ineligible" };
 
 /** Shared reads do not require a person; absence never substitutes for failed authentication. */
-export function prepareGitHubPublicationOptionsRead(options: Request) {
+export function prepareGitHubPublicationOptionsRead(options: Request, sessionKey: string) {
   const resolveEligibility = (): PersonalEligibility => {
     currentGitHubClient(options, "operator.read");
     const client = options.client;
@@ -96,23 +99,49 @@ export function prepareGitHubPublicationOptionsRead(options: Request) {
     return { kind: "eligible", action: preparePersonalGitHubAction(options) };
   };
   const personal = resolveEligibility();
+  const currentClient = () => {
+    const current = resolveEligibility();
+    if (
+      current.kind !== personal.kind ||
+      (current.kind === "eligible" &&
+        personal.kind === "eligible" &&
+        current.action.owner !== personal.action.owner)
+    ) {
+      throw new Error("GitHub profile changed; retry publication options.");
+    }
+    return currentGitHubClient(
+      options,
+      "operator.read",
+      current.kind === "eligible" ? current.action.owner : undefined,
+    );
+  };
+  const readSession = (key: string, agentId?: string) => {
+    const loaded = loadGatewaySessionEntryReadOnly(key, agentId ? { agentId } : undefined);
+    const filter = createSessionListEntryFilter({
+      cfg: options.context.getRuntimeConfig(),
+      client: currentClient(),
+    });
+    return loaded.entry && filter?.(loaded.canonicalKey, loaded.entry) !== false
+      ? {
+          sessionId: loaded.entry.sessionId,
+          sessionKey: loaded.canonicalKey,
+          agentId: loaded.agentId,
+        }
+      : null;
+  };
+  const session = readSession(sessionKey);
+  if (!session) {
+    throw new Error("GitHub publication session was not found.");
+  }
   return {
     personal,
-    currentClient: () => {
-      const current = resolveEligibility();
-      if (
-        current.kind !== personal.kind ||
-        (current.kind === "eligible" &&
-          personal.kind === "eligible" &&
-          current.action.owner !== personal.action.owner)
-      ) {
-        throw new Error("GitHub profile changed; retry publication options.");
+    session,
+    currentSession: () => {
+      const current = readSession(session.sessionKey, session.agentId);
+      if (!current || current.sessionId !== session.sessionId) {
+        throw new Error("GitHub publication session access changed; select the session again.");
       }
-      return currentGitHubClient(
-        options,
-        "operator.read",
-        current.kind === "eligible" ? current.action.owner : undefined,
-      );
+      return session;
     },
   };
 }
@@ -127,11 +156,8 @@ export function preparePersonalGitHubAction(
     if (
       !client?.connId ||
       client.connect?.role !== "operator" ||
-      client.internal?.syntheticClient ||
-      client.internal?.agentToolCaller ||
-      client.internal?.agentRuntimeIdentity ||
+      isSyntheticCaller(client) ||
       client.internal?.operatorRoleActor ||
-      getGatewayToolCallerIdentity() ||
       options.signal?.aborted ||
       !context.getClientConnIds?.((current) => current === client).has(client.connId)
     ) {

--- a/src/gateway/server-methods/sessions-github.ts
+++ b/src/gateway/server-methods/sessions-github.ts
@@ -8,10 +8,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { getGatewayToolCallerIdentity } from "../../agents/tools/gateway-caller-context.js";
 import { prepareCurrentGitHubPublicationIdentity } from "../github-publication-availability.js";
-import {
-  createSessionListEntryFilter,
-  SessionMutationAuthorizationChangedError,
-} from "../session-sharing.js";
+import { SessionMutationAuthorizationChangedError } from "../session-sharing.js";
 import { loadGatewaySessionEntryReadOnly } from "../session-utils.js";
 import {
   preparePersonalGitHubAction,
@@ -104,18 +101,10 @@ export const sessionsGitHubHandlers: GatewayRequestHandlers = {
     validateSessionGitHubOptionsParams,
     async (options) => {
       try {
-        const read = prepareGitHubPublicationOptionsRead(options);
-        const loaded = loadGatewaySessionEntryReadOnly(options.params.sessionKey);
-        const filter = createSessionListEntryFilter({
-          cfg: options.context.getRuntimeConfig(),
-          client: read.currentClient(),
-        });
-        if (!loaded.entry || filter?.(loaded.canonicalKey, loaded.entry) === false) {
-          throw new Error("GitHub publication session was not found.");
-        }
+        const read = prepareGitHubPublicationOptionsRead(options, options.params.sessionKey);
         let shared = null;
         try {
-          const identity = await prepareCurrentGitHubPublicationIdentity(loaded.agentId);
+          const identity = await prepareCurrentGitHubPublicationIdentity(read.session.agentId);
           shared = {
             source: identity.source,
             accountId: identity.account.accountId,
@@ -133,29 +122,12 @@ export const sessionsGitHubHandlers: GatewayRequestHandlers = {
         }
         const action = read.personal.kind === "eligible" ? read.personal.action : null;
         const personal = action ? await service!.status(action) : null;
-        const current = loadGatewaySessionEntryReadOnly(loaded.canonicalKey, {
-          agentId: loaded.agentId,
-        });
-        const currentFilter = createSessionListEntryFilter({
-          cfg: options.context.getRuntimeConfig(),
-          client: read.currentClient(),
-        });
-        if (
-          !current.entry ||
-          current.entry.sessionId !== loaded.entry.sessionId ||
-          currentFilter?.(current.canonicalKey, current.entry) === false
-        ) {
-          throw new Error("GitHub publication session access changed; select the session again.");
-        }
+        const session = read.currentSession();
         options.respond(true, {
           personal,
           shared,
           pendingPersonal: action
-            ? options.context.githubPublicationService!.personalPending(action, {
-                sessionKey: loaded.canonicalKey,
-                agentId: loaded.agentId,
-                sessionId: current.entry.sessionId,
-              })
+            ? options.context.githubPublicationService!.personalPending(action, session)
             : null,
         });
       } catch (error) {
@@ -176,31 +148,12 @@ export const sessionsGitHubHandlers: GatewayRequestHandlers = {
     (options) => {
       try {
         const action = preparePersonalGitHubAction(options);
-        const read = prepareGitHubPublicationOptionsRead(options);
-        const loaded = loadGatewaySessionEntryReadOnly(options.params.sessionKey);
-        const filter = createSessionListEntryFilter({
-          cfg: options.context.getRuntimeConfig(),
-          client: read.currentClient(),
-        });
-        if (!loaded.entry || filter?.(loaded.canonicalKey, loaded.entry) === false) {
-          throw new Error("GitHub publication session was not found.");
-        }
+        const { session } = prepareGitHubPublicationOptionsRead(options, options.params.sessionKey);
         const service = options.context.githubPublicationService;
         if (!service) {
           throw new Error("GitHub publication is unavailable.");
         }
-        options.respond(
-          true,
-          service.personalStatus(
-            action,
-            {
-              sessionKey: loaded.canonicalKey,
-              agentId: loaded.agentId,
-              sessionId: loaded.entry.sessionId,
-            },
-            options.params.requestId,
-          ),
-        );
+        options.respond(true, service.personalStatus(action, session, options.params.requestId));
       } catch (error) {
         options.respond(
           false,

--- a/ui/src/features/github-connections/github-connections.test.ts
+++ b/ui/src/features/github-connections/github-connections.test.ts
@@ -99,7 +99,7 @@ it("uses explicit unbound admin context for System without probing personal stat
   expect(element.textContent).not.toContain("@agent-account");
 });
 
-it("shows an identified status failure without substituting a System mutation route", async () => {
+it("shows an identified status failure once while opening personal setup", async () => {
   const request = vi.fn(async () => {
     throw new Error("GitHub status temporarily unavailable");
   });
@@ -112,4 +112,9 @@ it("shows an identified status failure without substituting a System mutation ro
   expect(request.mock.calls).toEqual([["users.github.status", {}]]);
   expect(element.textContent).not.toContain("Change System GitHub");
   expect(element.textContent).toContain("Retry");
+  Array.from(element.querySelectorAll("button"))
+    .find((button) => button.textContent?.trim() === "Connect GitHub")
+    ?.click();
+  await waitForFast(() => expect(element.querySelector("[data-github-setup]")).not.toBeNull());
+  expect(element.querySelectorAll('[role="alert"]')).toHaveLength(1);
 });

--- a/ui/src/features/github-connections/github-connections.ts
+++ b/ui/src/features/github-connections/github-connections.ts
@@ -20,6 +20,7 @@ import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { PROFILE_SETTINGS_TARGET_IDS } from "../../pages/config/settings-targets.ts";
 import { GitHubIdentityController } from "./github-identity-controller.ts";
 import {
+  renderGitHubConnectionError,
   renderGitHubConnectionSetup,
   renderGitHubDetails,
   renderGitHubHealth,
@@ -258,24 +259,19 @@ export class GitHubConnections extends OpenClawLightDomElement {
                 : renderSettingsValue(t("githubConnections.adminManaged"))}`,
             })}
           </div>
-          ${this.personal.error || this.system.error
-            ? renderSettingsRow({
-                title: t("agentTools.githubErrorTitle"),
-                description: html`<span role="alert"
-                  >${this.personal.error ?? this.system.error}</span
-                >`,
-                control: html`<button
-                  class="btn btn--sm"
-                  ?disabled=${this.locked}
-                  @click=${() => {
-                    void this.personal.verify();
-                    void this.system.verify();
-                  }}
-                >
-                  ${t("common.retry")}
-                </button>`,
-              })
-            : nothing}
+          ${renderGitHubConnectionError(
+            this.personal.error ?? this.system.error,
+            html`<button
+              class="btn btn--sm"
+              ?disabled=${this.locked}
+              @click=${() => {
+                void this.personal.verify();
+                void this.system.verify();
+              }}
+            >
+              ${t("common.retry")}
+            </button>`,
+          )}
           ${showSetup
             ? html`<div class="settings-subrows" data-github-setup>
                 ${renderSettingsRow({

--- a/ui/src/features/github-connections/github-identity-controller-authorization.ts
+++ b/ui/src/features/github-connections/github-identity-controller-authorization.ts
@@ -165,10 +165,6 @@ export class GitHubDeviceAuthorizationController {
       }
       operation.cancelTooLate = true;
       this.present(operation, "finishing");
-      // A cancellation made during start has no poll timer yet.
-      if (operation.timer === undefined && !operation.pollInFlight) {
-        this.schedule(operation, operation.start!.pollAfterMs);
-      }
     } catch (error) {
       if (!this.isCurrent(operation)) {
         return;
@@ -176,11 +172,12 @@ export class GitHubDeviceAuthorizationController {
       operation.cancelRequested = false;
       operation.cancelError = formatUiError(error);
       this.present(operation, "cancel_error");
-      if (operation.timer === undefined && !operation.pollInFlight) {
-        this.schedule(operation, operation.start!.pollAfterMs);
-      }
     } finally {
       operation.cancelInFlight = false;
+    }
+    // A cancellation made during start has no poll timer yet.
+    if (operation.timer === undefined && !operation.pollInFlight) {
+      this.schedule(operation, operation.start!.pollAfterMs);
     }
   }
 

--- a/ui/src/features/github-connections/github-identity-controller.ts
+++ b/ui/src/features/github-connections/github-identity-controller.ts
@@ -315,6 +315,21 @@ export class GitHubIdentityController {
     }
   }
 
+  private async runMutation(owner: RequestOwner, run: () => Promise<boolean>): Promise<boolean> {
+    this.beginMutation(owner);
+    let succeeded = false;
+    try {
+      succeeded = await run();
+    } catch (error) {
+      if (this.isCurrent(owner)) {
+        this.error = formatUiError(error);
+      }
+    } finally {
+      this.finishMutation(owner, succeeded);
+    }
+    return succeeded;
+  }
+
   private acceptSharedStatus(owner: SharedRequestOwner, status: ToolsGitHubStatusResult) {
     if (
       status.agentId !== owner.target.agentId ||
@@ -413,22 +428,14 @@ export class GitHubIdentityController {
     if (!owner) {
       return;
     }
-    this.beginMutation(owner);
-    let succeeded = false;
-    try {
+    const succeeded = await this.runMutation(owner, async () => {
       await owner.client.request("users.github.disconnect", {});
       if (!this.isCurrent(owner)) {
-        return;
+        return false;
       }
       this.personal = null;
-      succeeded = true;
-    } catch (error) {
-      if (this.isCurrent(owner)) {
-        this.error = formatUiError(error);
-      }
-    } finally {
-      this.finishMutation(owner, succeeded);
-    }
+      return true;
+    });
     if (succeeded && this.isCurrent(owner)) {
       await this.verify();
     }
@@ -458,55 +465,48 @@ export class GitHubIdentityController {
     const owner = { ...captured, target: captured.target };
     const name = draft.name.trim();
     const email = draft.email.trim();
-    this.beginMutation(owner);
-    let stored = false;
-    let secretName = "";
-    let succeeded = false;
-    const deleteSetupHandoff = () =>
-      owner.client.request("secrets.store.delete", { name: secretName }).catch(() => undefined);
-    try {
-      secretName = `github-setup-${generateUUID().replaceAll("-", "").toLowerCase()}`;
-      await owner.client.request("secrets.store.set", {
-        name: secretName,
-        value: draft.token,
-        kind: "secret",
-        allowedHosts: [],
-      });
-      stored = true;
-      if (!this.isCurrent(owner)) {
-        await deleteSetupHandoff();
-        return;
+    await this.runMutation(owner, async () => {
+      const secretName = `github-setup-${generateUUID().replaceAll("-", "").toLowerCase()}`;
+      let stored = false;
+      try {
+        await owner.client.request("secrets.store.set", {
+          name: secretName,
+          value: draft.token,
+          kind: "secret",
+          allowedHosts: [],
+        });
+        stored = true;
+        if (!this.isCurrent(owner)) {
+          return false;
+        }
+        const result = await this.runConfigureMutation(owner, runExternalMutation, {
+          scope: owner.target.scope,
+          agentId: owner.target.agentId,
+          mode: "managed",
+          secretName,
+          ...(name || email
+            ? { gitAuthor: { ...(name ? { name } : {}), ...(email ? { email } : {}) } }
+            : {}),
+        });
+        if (!result.ok) {
+          throw new Error(result.error);
+        }
+        stored = false;
+        this.applyMutationStatus(
+          owner,
+          result.value,
+          { ...draft, token: "" },
+          result.refresh.ok ? null : result.refresh.error,
+        );
+        return true;
+      } finally {
+        if (stored) {
+          await owner.client
+            .request("secrets.store.delete", { name: secretName })
+            .catch(() => undefined);
+        }
       }
-      const result = await this.runConfigureMutation(owner, runExternalMutation, {
-        scope: owner.target.scope,
-        agentId: owner.target.agentId,
-        mode: "managed",
-        secretName,
-        ...(name || email
-          ? { gitAuthor: { ...(name ? { name } : {}), ...(email ? { email } : {}) } }
-          : {}),
-      });
-      if (!result.ok) {
-        throw new Error(result.error);
-      }
-      stored = false;
-      this.applyMutationStatus(
-        owner,
-        result.value,
-        { ...draft, token: "" },
-        result.refresh.ok ? null : result.refresh.error,
-      );
-      succeeded = true;
-    } catch (error) {
-      if (stored) {
-        await deleteSetupHandoff();
-      }
-      if (this.isCurrent(owner)) {
-        this.error = formatUiError(error);
-      }
-    } finally {
-      this.finishMutation(owner, succeeded);
-    }
+    });
   }
 
   async inherit() {
@@ -557,9 +557,7 @@ export class GitHubIdentityController {
     ) {
       return;
     }
-    this.beginMutation(owner);
-    let succeeded = false;
-    try {
+    await this.runMutation(owner, async () => {
       const result = await this.runConfigureMutation(owner, runExternalMutation, {
         scope,
         agentId: owner.target.agentId,
@@ -575,15 +573,10 @@ export class GitHubIdentityController {
           { token: "", name: "", email: "" },
           result.refresh.ok ? null : result.refresh.error,
         );
-        succeeded = true;
+        return true;
       }
-    } catch (error) {
-      if (this.isCurrent(owner)) {
-        this.error = formatUiError(error);
-      }
-    } finally {
-      this.finishMutation(owner, succeeded);
-    }
+      return false;
+    });
   }
   private runConfigureMutation(
     owner: SharedRequestOwner,

--- a/ui/src/features/github-connections/github-identity-view.ts
+++ b/ui/src/features/github-connections/github-identity-view.ts
@@ -38,6 +38,15 @@ const GITHUB_REFRESH_STATE = {
   not_applicable: "common.na",
 } as const;
 
+const GITHUB_AUTHORIZATION_LABEL = {
+  code: "agentTools.githubCodeReady",
+  pending: "agentTools.githubWaiting",
+  cancelling: "agentTools.githubCancelling",
+  finishing: "agentTools.githubFinishing",
+  cancel_error: "agentTools.githubCancelFailed",
+  network_error: "agentTools.githubNetworkRetry",
+} as const;
+
 export function renderGitHubHealth(identity: GitHubIdentityFacts | null) {
   const status = identity ? GITHUB_CREDENTIAL_STATUS[identity.credentialState] : null;
   return renderSettingsStatus({
@@ -128,32 +137,13 @@ function renderGitHubAuthorization(controller: GitHubIdentityController) {
       `,
     });
   }
-  if (
-    authorization.phase === "code" ||
-    authorization.phase === "pending" ||
-    authorization.phase === "network_error" ||
-    authorization.phase === "cancelling" ||
-    authorization.phase === "finishing" ||
-    authorization.phase === "cancel_error"
-  ) {
-    if (!("userCode" in authorization)) {
-      return nothing;
-    }
+  if ("userCode" in authorization) {
     const copyLabel = t("agentTools.githubCopyCode");
-    const stateLabel =
-      authorization.phase === "code"
-        ? t("agentTools.githubCodeReady")
-        : authorization.phase === "cancelling"
-          ? t("agentTools.githubCancelling")
-          : authorization.phase === "finishing"
-            ? t("agentTools.githubFinishing")
-            : authorization.phase === "cancel_error"
-              ? t("agentTools.githubCancelFailed")
-              : authorization.phase === "network_error"
-                ? t("agentTools.githubNetworkRetry")
-                : authorization.slowedDown
-                  ? t("agentTools.githubSlowDown")
-                  : t("agentTools.githubWaiting");
+    const stateLabel = t(
+      authorization.phase === "pending" && authorization.slowedDown
+        ? "agentTools.githubSlowDown"
+        : GITHUB_AUTHORIZATION_LABEL[authorization.phase],
+    );
     return html`
       ${renderSettingsRow({
         title: t("agentTools.githubAuthorization"),
@@ -226,6 +216,18 @@ function renderGitHubAuthorization(controller: GitHubIdentityController) {
   if (controller.patVisible) {
     return nothing;
   }
+  const authorizeButton = html`<button
+    class="btn primary"
+    @click=${() => void controller.startAuthorization()}
+  >
+    ${t("githubConnections.continue")}
+  </button>`;
+  const patButton =
+    controller.scope !== "personal"
+      ? html`<button class="btn" @click=${() => controller.showPatFallback()}>
+          ${t("agentTools.githubUsePat")}
+        </button>`
+      : nothing;
   if (
     authorization.phase === "access_denied" ||
     authorization.phase === "expired" ||
@@ -246,37 +248,20 @@ function renderGitHubAuthorization(controller: GitHubIdentityController) {
         label: t("agentTools.githubAuthorizationFailed"),
       }),
       description: formatUiExternalText(description),
-      control: html`
-        <button class="btn primary" @click=${() => void controller.startAuthorization()}>
-          ${t("githubConnections.continue")}
-        </button>
-        ${controller.scope !== "personal"
-          ? html`<button class="btn" @click=${() => controller.showPatFallback()}>
-              ${t("agentTools.githubUsePat")}
-            </button>`
-          : nothing}
-      `,
+      control: html`${authorizeButton}${patButton}`,
     });
   }
   return html`
     ${renderSettingsRow({
       title: t("agentTools.githubAuthorization"),
       description: t("agentTools.githubConnectHint"),
-      control: html`
-        <button class="btn primary" @click=${() => void controller.startAuthorization()}>
-          ${t("githubConnections.continue")}
-        </button>
-      `,
+      control: authorizeButton,
     })}
     ${controller.scope !== "personal"
       ? renderSettingsRow({
           title: t("agentTools.githubPatFallback"),
           description: t("agentTools.githubPatFallbackHint"),
-          control: html`
-            <button class="btn" @click=${() => controller.showPatFallback()}>
-              ${t("agentTools.githubUsePat")}
-            </button>
-          `,
+          control: patButton,
         })
       : nothing}
   `;

--- a/ui/src/features/github-connections/github-identity-view.ts
+++ b/ui/src/features/github-connections/github-identity-view.ts
@@ -1,4 +1,4 @@
-import { html, nothing } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import type { GitHubIdentityFacts } from "../../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import { handleCopyButton } from "../../components/copy-button.ts";
 import { icons } from "../../components/icons.ts";
@@ -267,6 +267,16 @@ function renderGitHubAuthorization(controller: GitHubIdentityController) {
   `;
 }
 
+export function renderGitHubConnectionError(error: string | null, control?: TemplateResult) {
+  return error
+    ? renderSettingsRow({
+        title: t("agentTools.githubErrorTitle"),
+        description: html`<span role="alert">${formatUiExternalText(error)}</span>`,
+        control,
+      })
+    : nothing;
+}
+
 export function renderGitHubConnectionSetup(controller: GitHubIdentityController) {
   const draft = controller.draft;
   const disabled = controller.busy || !controller.configurable || controller.authorizationActive;
@@ -287,12 +297,6 @@ export function renderGitHubConnectionSetup(controller: GitHubIdentityController
       />`,
     });
   return html`
-    ${controller.error
-      ? renderSettingsRow({
-          title: t("agentTools.githubErrorTitle"),
-          description: html`<span role="alert">${formatUiExternalText(controller.error)}</span>`,
-        })
-      : nothing}
     ${renderGitHubAuthorization(controller)}
     ${controller.patVisible
       ? html`
@@ -370,6 +374,7 @@ export function renderGitHubIdentity(
             ${t("githubConnections.manageCommon")}
           </button>`,
       })}
+      ${renderGitHubConnectionError(controller.error)}
       ${controller.configurable
         ? html`<details class="settings-row settings-row--stacked">
             <summary class="settings-row__title">


### PR DESCRIPTION
## What Problem This Solves

GitHub publication and connection management repeated authority checks, request queries, and cleanup across personal, System, and agent paths. This follow-up to #133799 consolidates those lifecycles. Live testing also exposed duplicate credential errors in Profile settings: the connection panel and its embedded setup form both displayed the same failure.

## Why This Change Was Made

Ordinary Git command guards now share the existing lightweight transport; request and claim queries stay with their store owner; session-option authorization and connection mutation cleanup use common paths. Irreversible push and PR observations are still recorded before authority is rechecked. Each connection panel now owns one error display, including the agent override panel when its advanced details are collapsed.

Production LOC: **+333 / −473, net −140** across eleven files. Tests: **+6 / −1** in one existing test. No schema, configuration, protocol, credential ownership, or publication policy changes.

## User Impact

Credential failures appear once and remain visible outside collapsed setup controls. Personal and shared accounts keep their existing separation, and publication retains its accepted account, workspace, and recovery behavior.

## Evidence

- The full final changed-file gate passed on Linux through the configured Testbox route (exit 0); the one-shot lease and temporary source worktree were cleaned up.

- 180 Gateway tests passed, covering shared/personal publication, revocation, restart recovery, worktree/index integrity, and Git hooks. Those Gateway files are unchanged in the final branch.
- All 49 UI unit tests and four Chromium flows passed after the error-display fix. The extended regression fails before the fix with two alerts and passes afterward with one.
- The full build passed. The runtime and UI were rebuilt from the final source after refreshing onto the already-landed CLI test-type fix in #135407. The earlier protocol declaration-build failure was resolved by #135360.
- Codex reviewed the lifecycle refactor and the subsequent error-display repair; both reviews are clean through P2. The mechanical refresh preserved every reviewed cleanup file byte-for-byte.
- A running Gateway created this PR through real Git and authenticated GitHub operations. The published tree matched the reviewed tree, and replay returned the same PR and commit. A prior Git remote-read timeout remained a recorded failure; a new request completed without a duplicate publication.
- Real GitHub device-code issuance, pending polling, and cancellation passed. A real browser also verified rejected-token cleanup, setup with the active credential, and confirmed restoration to the native System identity. The temporary setup store was empty after failure and success; My GitHub stayed disconnected. OAuth consent/token exchange was not performed.
- [CI on the final head](https://github.com/openclaw/openclaw/actions/runs/33544068502) passed. The final runtime and UI were built together using the standard CI artifact profile, with matching build identifiers verified before the live browser run.

### Synthetic UI captures

These before/after authorization states use fixture accounts and a synthetic device code; they are separate from the live GitHub checks above.

| Before authorization completes | After authorization completes |
| --- | --- |
| ![Synthetic authorization code](https://github.com/user-attachments/assets/233d65da-dd36-45eb-bc28-17eb7fe99013) | ![Verified synthetic System identity](https://github.com/user-attachments/assets/c6b5e1b2-1762-4866-997b-832270d59cd4) |

<!-- openclaw-publication:5fa368ca-967c-4b63-ad7c-0073a562ced3 -->
