### PR TITLE
docs(memory): preserve session history during index recovery

### DIFF
--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -68,6 +68,13 @@ both groups without reindexing their retained transcripts. Ordinary retained,
 reset, and deleted user-session archives remain eligible until explicitly
 targeted.
 
+<Warning>
+The default `openclaw-agent.sqlite` database also contains session history and
+other durable agent state. Do not delete it or its `-wal`, `-shm`, or `-journal`
+sidecars to reset memory. Use `memory index --force` to rebuild the index; see
+[Safe index recovery](/concepts/memory-builtin#safe-index-recovery).
+</Warning>
+
 ## `memory search`
 
 ```bash

--- a/docs/concepts/memory-builtin.md
+++ b/docs/concepts/memory-builtin.md
@@ -213,6 +213,30 @@ unavailable` points at sqlite-vec loading while `Embeddings: unavailable`
 points at provider/auth or model readiness. Check logs for the specific load
 error.
 
+### Safe index recovery
+
+To rebuild after stale results or an embedding-provider change, select the
+affected agent explicitly:
+
+```bash
+openclaw memory status --agent <agent-id> --deep
+openclaw memory index --agent <agent-id> --force --verbose
+openclaw memory status --agent <agent-id> --deep
+```
+
+The index shares `openclaw-agent.sqlite` with session history and other durable
+agent state. A full reindex replaces only the memory tables; it does not
+replace the agent database file. Deleting that database, its WAL, or its
+journal can remove conversation history and other state that memory indexing
+cannot reconstruct. Do not treat the agent database as a disposable cache.
+
+If indexing fails or the database grows unexpectedly, keep the database and
+its sidecars, retain the verbose error, and [create and verify a backup](/cli/backup)
+before manual recovery. A large database alone does not show which tables are
+responsible. Reindexing is not a session-history restore: if history is missing
+after moving or deleting the database, recover from a verified backup using
+the [restore workflow](/install/backups#restore-a-full-archive).
+
 ## Configuration
 
 For embedding provider setup, search result limits and thresholds, batch


### PR DESCRIPTION
Related: #135347. Complements the cache-publication repair in #135373.

## What Problem This Solves

Fixes a recovery-documentation gap for operators rebuilding memory after stale results or an embedding-provider change. The default memory index shares the agent database with canonical session history. The incident in #135347 shows the consequence of treating that file as a disposable index: removing it also removes the active session history.

## Why This Change Was Made

Put the database-preservation warning next to `memory index --force`, and document a per-agent status/reindex/status sequence. Explain that full reindexing publishes only memory-owned tables, and route manual recovery to verified backups and the existing staged restore workflow.

## User Impact

Operators and support agents can rebuild memory without deleting the session-bearing database or its SQLite sidecars. The guidance distinguishes index rebuilding from restoring missing conversation history. It does not claim to explain or shrink the reported 35 GB database; that incident remains open.

## Evidence

- Source checked: memory CLI index flow, shadow reindex lifecycle, `publishMemoryDatabaseTables`, canonical database ownership documentation, and backup restore semantics.
- Existing memory publication and reindex recovery tests: 18 passed on Node 24.19.0 with temporary SQLite fixtures.
- `pnpm docs:list`; targeted MDX validation: 2 files passed; internal-link audit: 7,193 checked, zero broken links.
- Targeted `oxfmt` and `git diff --check` passed.
- Fresh managed Codex autoreview: no accepted/actionable findings at the configured P0 threshold.

Documentation only: +31 lines; no production or test changes. The original large corpus and live embedding provider were not reproduced by this documentation validation.
