### PR TITLE
fix(ui): distinguish undeclared node commands from unauthorized ones

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -919,6 +919,8 @@ export const en: TranslationMap = {
     deviceNoSlots: "No worker slots are available. Wait for a slot or pick another device.",
     nodeUpdateRequired:
       "Update required: run {updateCommand}, then reconnect. For a headless node, run {restartCommand}.",
+    nodeCommandNotDeclared:
+      "This device does not declare the required command ({command}). Declare it on the node or pick another device.",
     capabilityCamera: "Camera",
     capabilityLocation: "Location",
     capabilityTalk: "Talk",

--- a/ui/src/pages/new-session/device-placement.test.ts
+++ b/ui/src/pages/new-session/device-placement.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { i18n } from "../../i18n/index.ts";
 import { projectDevicePlacements } from "./device-placement.ts";
 import type { DraftEnvironment } from "./discovery.ts";
 
@@ -25,6 +26,10 @@ function node(overrides: Partial<DraftEnvironment>): DraftEnvironment {
 }
 
 describe("device placement projection", () => {
+  beforeEach(async () => {
+    await i18n.setLocale("en");
+  });
+
   it.each([
     {
       name: "available host",
@@ -160,14 +165,14 @@ describe("device placement projection", () => {
       reason: /enable|approv/i,
     },
     {
-      name: "missing command authority fails closed even when worker slots are free",
+      name: "an undeclared command fails closed even when worker slots are free",
       requirement: {
         requiredNodeCommands: ["codex.exec-server.stdio.v1"],
         consumesWorkerSlot: false,
       },
       environment: { invocableCommands: ["camera.snap"] },
       selectable: false,
-      reason: /enable|approv/i,
+      reason: /declare|command/i,
     },
   ])("$name", ({ requirement, environment, selectable, reason }) => {
     const [device] = projectDevicePlacements([node(environment)], requirement);

--- a/ui/src/pages/new-session/device-placement.ts
+++ b/ui/src/pages/new-session/device-placement.ts
@@ -45,7 +45,13 @@ function unavailableReason(
     (command) => !environment.invocableCommands?.includes(command),
   );
   if (unavailableCommand) {
-    return `${t("pluginsPage.enableAction")} ${unavailableCommand}: gateway.nodes.commands.allow.`;
+    // A missing command has two causes: the node never declared it, or the
+    // Gateway allowlist did not authorize it. Name the right one instead of
+    // always pointing at gateway.nodes.commands.allow.
+    const declared = environment.capabilities?.includes(unavailableCommand);
+    return declared
+      ? `${t("pluginsPage.enableAction")} ${unavailableCommand}: gateway.nodes.commands.allow.`
+      : t("newSession.nodeCommandNotDeclared", { command: unavailableCommand });
   }
   if (!requirement.consumesWorkerSlot) {
     return undefined;


### PR DESCRIPTION
Closes #135378

## What Problem This Solves

Fixes the Session host picker's misleading disabled reason. Every required node command absent from `invocableCommands` was projected as "enable `gateway.nodes.commands.allow`", even when the node had never declared that command — so the hint named an already-satisfied config key instead of the actual missing prerequisite.

## Why This Change Was Made

Gateway environment summaries expose both declared capabilities and authorized commands, but the picker's `unavailableReason` collapsed the two distinct causes into one hint. This change checks the node's declared `capabilities` first: a declared-but-unauthorized command still points at `gateway.nodes.commands.allow`, while an undeclared command now reports that the device does not declare it.

## User Impact

The picker now names the real prerequisite (declare the command on the node vs. authorize it in the Gateway), so operators can act on the correct config instead of a misleading hint.

## Evidence

Exact head: `76df64b4efbaf72ddf38f87fea9578f2f0c14a3a`.

- `ui/src/pages/new-session/device-placement.test.ts` — 12 passed, including a renamed "undeclared command" regression asserting the new reason, plus a `beforeEach` locale reset to keep the assertions deterministic.
- `ui/src/i18n/locales/en.ts` — new `newSession.nodeCommandNotDeclared` string.
- Production typecheck and `check:changed` pass (including the Control UI i18n catalog); the only local lane failure is unchanged `ui/vite.config.ts` missing a `pako` declaration in the reused dependency tree.

## AI Assistance

AI-assisted implementation. I manually verified the picker reason projection, the declared-vs-unauthorized split, the i18n string, the focused regression, and the changed-file gates.
