### PR TITLE
fix(test): keep test wrappers responsive during shutdown

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -236,8 +236,9 @@ Vitest and watch runs retain source execution: compilation, verification, and ar
 deletion require the repository runner's ownership.
 A lost owner or failed build fails the run.
 Disposal cancels pending compilation and joins it, every borrower, and outstanding
-preparation requests before removing the directory. Borrower completion does not
-wait for compilation, so an early child exit can reach that cancellation path. An uncertain compiler or borrower join retains the
+preparation requests before asynchronously removing the directory. Signal handlers
+remain active through removal, even when large generations take time to delete.
+Borrower completion does not wait for compilation, so an early child exit can reach that cancellation path. An uncertain compiler or borrower join retains the
 generation and fails the run. Abnormal termination can also leave an unused
 directory; later runs never adopt it.
 

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -227,12 +227,17 @@ Node or Bun compiler child and joins it before returning the verified manifest t
 borrowers. The compiler module graph lives in that child, not the long-lived runner
 or Vitest worker. No shard can select a different build graph or adopt another invocation's output. The outer
 runner retains the generation until child close and process-group cleanup
-finish, then verifies it before reporting success. Standalone Vitest and watch runs retain
-source execution: its public close hooks run concurrently with pool shutdown,
-so compilation and artifact deletion require the repository runner's ownership.
+finish, then verifies it before reporting success. Verification reads every recorded
+input and output with bounded asynchronous I/O, keeping the runner responsive during
+large shutdown scans. The invocation owner verifies each borrower's preparation
+before replying and verifies again after all borrowers close; Vitest does not repeat
+these scans inside each shard or during its concurrent pool shutdown. Standalone
+Vitest and watch runs retain source execution: compilation, verification, and artifact
+deletion require the repository runner's ownership.
 A lost owner or failed build fails the run.
-Disposal cancels pending compilation and joins it and every borrower before
-removing the directory. An uncertain compiler or borrower join retains the
+Disposal cancels pending compilation and joins it, every borrower, and outstanding
+preparation requests before removing the directory. Borrower completion does not
+wait for compilation, so an early child exit can reach that cancellation path. An uncertain compiler or borrower join retains the
 generation and fails the run. Abnormal termination can also leave an unused
 directory; later runs never adopt it.
 

--- a/scripts/lib/vitest-worker-artifacts.mts
+++ b/scripts/lib/vitest-worker-artifacts.mts
@@ -41,19 +41,43 @@ const declarations = new Map(
 export const VITEST_WORKER_PREPARE_REQUEST = "openclaw:prepare-test-subprocesses";
 export const VITEST_WORKER_PREPARE_REPLY = "openclaw:test-subprocesses-prepared";
 
-export function verifyVitestWorkerArtifacts(directory: string, manifest?: VitestWorkerManifest) {
+export async function verifyVitestWorkerArtifacts(
+  directory: string,
+  manifest?: VitestWorkerManifest,
+) {
   const completed: VitestWorkerManifest =
-    manifest ?? JSON.parse(fs.readFileSync(path.join(directory, "manifest.json"), "utf8"));
-  for (const [filename, expected] of Object.entries(completed.inputs)) {
-    if (hashVitestWorkerArtifact(fs.readFileSync(filename)) !== expected) {
-      throw new Error(`Source changed during compiled subprocess invocation: ${filename}`);
-    }
-  }
-  for (const [name, expected] of Object.entries(completed.outputs)) {
-    if (
-      hashVitestWorkerArtifact(fs.readFileSync(path.join(directory, "dist", name))) !== expected
-    ) {
-      throw new Error(`Compiled subprocess artifact changed: ${name}`);
+    manifest ??
+    JSON.parse(await fs.promises.readFile(path.join(directory, "manifest.json"), "utf8"));
+  const groups = [
+    {
+      files: completed.inputs,
+      root: undefined,
+      changed: "Source changed during compiled subprocess invocation",
+    },
+    {
+      files: completed.outputs,
+      root: path.join(directory, "dist"),
+      changed: "Compiled subprocess artifact changed",
+    },
+  ];
+  const batchSize = 32;
+  for (const { files, root: baseDir, changed } of groups) {
+    const entries = Object.entries(files);
+    for (let offset = 0; offset < entries.length; offset += batchSize) {
+      // Native batches keep pre-install planning dependency-free and signals responsive.
+      // Drain every started read before rejection: the owner may delete files next.
+      const settled = await Promise.allSettled(
+        entries.slice(offset, offset + batchSize).map(async ([name, expected]) => {
+          const filename = baseDir ? path.join(baseDir, name) : name;
+          if (hashVitestWorkerArtifact(await fs.promises.readFile(filename)) !== expected) {
+            throw new Error(`${changed}: ${name}`);
+          }
+        }),
+      );
+      const failed = settled.find((result) => result.status === "rejected");
+      if (failed?.status === "rejected") {
+        throw failed.reason;
+      }
     }
   }
 }

--- a/scripts/lib/vitest-worker-compiler.mts
+++ b/scripts/lib/vitest-worker-compiler.mts
@@ -135,7 +135,8 @@ async function compileVitestWorkerArtifacts(directory: string): Promise<void> {
     outputs: sortedOutputs,
     durationMs: performance.now() - started,
   };
-  verifyVitestWorkerArtifacts(directory, manifest);
+  await verifyVitestWorkerArtifacts(directory, manifest);
+  manifest.durationMs = performance.now() - started;
   fs.writeFileSync(path.join(directory, "manifest.json"), `${JSON.stringify(manifest)}\n`, {
     flag: "wx",
   });

--- a/scripts/lib/vitest-worker-run.mts
+++ b/scripts/lib/vitest-worker-run.mts
@@ -71,7 +71,6 @@ export function createVitestWorkerRun() {
       const manifest: VitestWorkerManifest = JSON.parse(
         fs.readFileSync(path.join(directory, "manifest.json"), "utf8"),
       );
-      verifyVitestWorkerArtifacts(directory, manifest);
       console.error(
         `[vitest-workers] prepared ${manifest.identity.slice(0, 12)} in ${Math.round(manifest.durationMs)}ms (${Object.keys(manifest.inputs).length} inputs, ${Object.keys(manifest.outputs).length} outputs)`,
       );
@@ -81,16 +80,16 @@ export function createVitestWorkerRun() {
   return {
     descriptor: { directory } satisfies VitestWorkerDescriptor,
     borrow<T>(child: ChildProcess, completion: Promise<T>): Promise<T> {
-      let requested = false;
+      let request: Promise<void> | undefined;
       const onMessage = (message: unknown) => {
-        if (message !== VITEST_WORKER_PREPARE_REQUEST || requested) {
+        if (message !== VITEST_WORKER_PREPARE_REQUEST || request) {
           return;
         }
-        requested = true;
-        void (async () => {
+        request = (async () => {
           let reply: { type: string; error?: string } = { type: VITEST_WORKER_PREPARE_REPLY };
           try {
-            await prepare();
+            const manifest = await prepare();
+            await verifyVitestWorkerArtifacts(directory, manifest);
             if (disposal) {
               throw new Error("Compiled subprocess owner is closing");
             }
@@ -118,8 +117,17 @@ export function createVitestWorkerRun() {
           child.off("message", onMessage);
         }
       })();
-      borrowers.push(joined);
-      void joined.catch(() => {});
+      // Child completion must let callers reach disposal to cancel compilation.
+      // The owner still joins admission reads before releasing their generation.
+      const ownedCompletion = (async () => {
+        try {
+          await joined;
+        } finally {
+          await request;
+        }
+      })();
+      borrowers.push(ownedCompletion);
+      void ownedCompletion.catch(() => {});
       return joined;
     },
     dispose(): Promise<void> {
@@ -136,7 +144,8 @@ export function createVitestWorkerRun() {
             throw channelError;
           }
           if (fs.existsSync(path.join(directory, "manifest.json"))) {
-            verifyVitestWorkerArtifacts(directory);
+            console.error("[vitest-workers] verifying completed generation before cleanup");
+            await verifyVitestWorkerArtifacts(directory);
           }
         } finally {
           if (uncertain || !compilerJoined) {

--- a/scripts/lib/vitest-worker-run.mts
+++ b/scripts/lib/vitest-worker-run.mts
@@ -153,7 +153,8 @@ export function createVitestWorkerRun() {
               `[vitest-workers] retaining ${directory}: ${!compilerJoined ? "compiler" : "borrower"} join failed`,
             );
           } else {
-            fs.rmSync(directory, { recursive: true, force: true });
+            // Large generations must not block signal delivery during final cleanup.
+            await fs.promises.rm(directory, { recursive: true, force: true });
           }
         }
       })());

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -15,7 +15,6 @@ import { boundaryTestFiles } from "../test/vitest/vitest.unit-paths.mjs";
 import { parsePermissiveBooleanToken } from "./lib/arg-utils.mts";
 import { resolveExtensionTestConfig } from "./lib/extension-test-plan.mts";
 import { createGatewayServerTestTargetChunks } from "./lib/gateway-server-test-plan.mts";
-import { signalExitCode } from "./lib/managed-child-process.mts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import { spawnTestProjectsRunner } from "./lib/test-projects-delegation.mts";
 import {
@@ -51,7 +50,6 @@ type VitestFs = {
   symlinkSync?(target: string, path: string, type: "dir" | "junction"): void;
 };
 type VitestPathFs = Pick<typeof fs, "existsSync" | "statSync">;
-type VitestProcessHandle = Omit<ReturnType<typeof spawnWatchedVitestProcess>, "teardown">;
 type WatchdogStream = {
   on(event: string, listener: (...args: unknown[]) => void): unknown;
   off(event: string, listener: (...args: unknown[]) => void): unknown;
@@ -1324,32 +1322,6 @@ export function spawnWatchedVitestProcess({
   };
 }
 
-async function finishVitestProcess({
-  completion,
-  getForwardedSignal,
-  beforeSignal,
-  exitBySignal,
-}: Pick<VitestProcessHandle, "completion" | "getForwardedSignal"> & {
-  beforeSignal?: () => void | Promise<void>;
-  exitBySignal: typeof exitVitestBySignal;
-}): Promise<number> {
-  const { code, signal } = await completion;
-  const exitSignal = getForwardedSignal() ?? signal;
-  if (exitSignal) {
-    try {
-      await beforeSignal?.();
-    } catch (error) {
-      console.error(error);
-    } finally {
-      await exitBySignal(exitSignal);
-    }
-    return signalExitCode(exitSignal);
-  }
-  const exitCode = code ?? 1;
-  process.exitCode = exitCode;
-  return exitCode;
-}
-
 export async function runVitest(
   exitBySignal: typeof exitVitestBySignal,
   argv: string[] = process.argv.slice(2),
@@ -1375,7 +1347,13 @@ export async function runVitest(
 
   const delegatedArgs = resolveTestProjectsDelegationArgs(argv);
   if (delegatedArgs) {
-    await finishVitestProcess({ ...spawnTestProjectsRunner(delegatedArgs, env), exitBySignal });
+    const handle = spawnTestProjectsRunner(delegatedArgs, env);
+    const { code, signal } = await handle.completion;
+    const exitSignal = handle.getForwardedSignal() ?? signal;
+    if (exitSignal) {
+      await exitBySignal(exitSignal);
+    }
+    process.exitCode = code ?? 1;
     return;
   }
 
@@ -1425,6 +1403,14 @@ export async function runVitest(
   const sourceMode =
     resolveExplicitVitestMode(vitestArgs) === "watch" || isVitestWorkerMetadataRequest(vitestArgs);
   const workers = sourceMode ? undefined : createVitestWorkerRun();
+  let interrupted: NodeJS.Signals | undefined;
+  const onSignal = (signal: NodeJS.Signals) => {
+    interrupted ??= signal;
+  };
+  // The invocation outlives child-scoped handlers when admission or final
+  // verification is still reading. Retain signal ownership through disposal.
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
   try {
     let failedExitCode = 0;
     for (const [index, invocation] of invocations.entries()) {
@@ -1445,25 +1431,31 @@ export async function runVitest(
         spawnParams: resolveVitestSpawnParams(spawnEnv),
         env: spawnEnv,
       });
-      const exitCode = await finishVitestProcess({
-        ...handle,
-        exitBySignal,
-        beforeSignal: () => workers?.dispose(),
-      });
-      // Ordinary test failures must not hide later files. Signals are forwarded by
-      // finishVitestProcess and stop this owner before another child is admitted.
-      if (
-        handle.getForwardedSignal() ||
-        handle.child.signalCode ||
-        (exitCode !== 0 && exitCode !== 1)
-      ) {
+      const { code, signal } = await handle.completion;
+      interrupted ??= handle.getForwardedSignal() ?? signal ?? undefined;
+      const exitCode = code ?? 1;
+      // Ordinary test failures must not hide later files; interruptions stop
+      // admission and are re-raised only after the invocation has been disposed.
+      if (interrupted || (exitCode !== 0 && exitCode !== 1)) {
+        process.exitCode = exitCode;
         return;
       }
       failedExitCode ||= exitCode;
     }
     process.exitCode = failedExitCode;
   } finally {
-    await workers?.dispose();
+    try {
+      await workers?.dispose().catch((error: unknown) => {
+        process.exitCode ||= 1;
+        console.error(error);
+      });
+    } finally {
+      process.off("SIGINT", onSignal);
+      process.off("SIGTERM", onSignal);
+      if (interrupted) {
+        await exitBySignal(interrupted);
+      }
+    }
   }
 }
 

--- a/test/scripts/vitest-worker-artifacts.test.ts
+++ b/test/scripts/vitest-worker-artifacts.test.ts
@@ -879,7 +879,7 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
         const directory = workerArtifacts.fixtureDirectory();
         const { config } = workerProbe(directory, true);
         const owner = createVitestWorkerRun();
-        // Node26 parent-side child.disconnect() omits ChildProcess.close. Close the
+        // Node parent-side child.disconnect() can omit ChildProcess.close. Close the
         // fixture endpoint so the owner receives EOF and retains its real join contract.
         const disconnect = writeFixture(
           directory,
@@ -1241,14 +1241,14 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
         });
         const changedSource = fs.readFileSync(dependency, "utf8");
         fs.appendFileSync(dependency, "\n// changed after preparation\n");
-        expect(() => verifyVitestWorkerArtifacts(directories[1]!)).toThrow(
+        await expect(verifyVitestWorkerArtifacts(directories[1]!)).rejects.toThrow(
           "Source changed during compiled subprocess invocation",
         );
         fs.writeFileSync(dependency, changedSource);
         const tuiDeclaration = path.join(fixture, "src/tui/tui-pty-runtime-test-support.ts");
         const originalDeclaration = fs.readFileSync(tuiDeclaration, "utf8");
         fs.appendFileSync(tuiDeclaration, "\n// declaration changed after preparation\n");
-        expect(() => verifyVitestWorkerArtifacts(directories[1]!)).toThrow(
+        await expect(verifyVitestWorkerArtifacts(directories[1]!)).rejects.toThrow(
           "Source changed during compiled subprocess invocation",
         );
         fs.writeFileSync(tuiDeclaration, originalDeclaration);

--- a/test/scripts/vitest-worker-artifacts.verification.test.ts
+++ b/test/scripts/vitest-worker-artifacts.verification.test.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs";
+import path from "node:path";
+import { setImmediate as nextTurn } from "node:timers/promises";
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  hashVitestWorkerArtifact,
+  verifyVitestWorkerArtifacts,
+  type VitestWorkerManifest,
+} from "../../scripts/lib/vitest-worker-artifacts.mts";
+import { createVitestWorkerRun } from "../../scripts/lib/vitest-worker-run.mts";
+import { createDeferred, withTestTimeout } from "../helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+it("keeps the runner event loop responsive while verifying a completed generation", async () => {
+  const directory = tempDirs.make("vitest-worker-verification-");
+  fs.mkdirSync(path.join(directory, "dist"));
+  const manifest: VitestWorkerManifest = {
+    identity: "verification-fixture",
+    inputs: {},
+    outputs: {},
+    durationMs: 0,
+  };
+  const source = "export const value = 1;\n";
+  const hash = hashVitestWorkerArtifact(source);
+  for (let index = 0; index < 64; index++) {
+    const input = path.join(directory, `input-${index}.ts`);
+    const output = `output-${index}.js`;
+    fs.writeFileSync(input, source);
+    fs.writeFileSync(path.join(directory, "dist", output), source);
+    manifest.inputs[input] = hash;
+    manifest.outputs[output] = hash;
+  }
+
+  let completed = false;
+  // Supply the manifest so an asynchronous manifest read alone cannot satisfy
+  // the assertion: the source/artifact traversal itself must yield to I/O.
+  const verification = Promise.resolve(verifyVitestWorkerArtifacts(directory, manifest)).then(
+    () => {
+      completed = true;
+    },
+  );
+  try {
+    await nextTurn();
+    expect(completed, "verification blocked the runner until every file was hashed").toBe(false);
+  } finally {
+    await verification;
+  }
+});
+
+it.each(["inputs", "outputs"] as const)(
+  "drains active %s reads before failed verification releases the generation",
+  async (group) => {
+    const owner = createVitestWorkerRun();
+    const directory = owner.descriptor.directory;
+    const files = group === "inputs" ? directory : path.join(directory, "dist");
+    fs.mkdirSync(files, { recursive: true });
+    const bad = path.join(files, "changed.js");
+    const held = path.join(files, "held.js");
+    fs.writeFileSync(bad, "changed");
+    fs.writeFileSync(held, "expected");
+    const hash = hashVitestWorkerArtifact("expected");
+    const manifest: VitestWorkerManifest = {
+      identity: "drain-fixture",
+      durationMs: 0,
+      inputs: {},
+      outputs: {},
+    };
+    manifest[group] = Object.fromEntries(
+      [bad, held].map((filename) => [
+        group === "inputs" ? filename : path.basename(filename),
+        hash,
+      ]),
+    );
+    fs.writeFileSync(path.join(directory, "manifest.json"), JSON.stringify(manifest));
+    const started = createDeferred();
+    const failedRead = createDeferred();
+    const release = createDeferred();
+    const readFile = fs.promises.readFile.bind(fs.promises);
+    const reader = vi.spyOn(fs.promises, "readFile").mockImplementation(async (...args) => {
+      if (args[0] === held) {
+        started.resolve();
+        await release.promise;
+      }
+      const bytes = await readFile(...args);
+      if (args[0] === bad) {
+        failedRead.resolve();
+      }
+      return bytes;
+    });
+    let completed = false;
+    let failure: unknown;
+    const disposal = owner
+      .dispose()
+      .catch((error: unknown) => {
+        failure = error;
+      })
+      .finally(() => {
+        completed = true;
+      });
+    try {
+      await withTestTimeout(
+        Promise.all([started.promise, failedRead.promise]),
+        5_000,
+        "verification did not admit both reads",
+      );
+      await nextTurn();
+      expect(completed).toBe(false);
+      expect(fs.readFileSync(held, "utf8")).toBe("expected");
+    } finally {
+      release.resolve();
+      await disposal;
+      reader.mockRestore();
+    }
+    const diagnostic =
+      group === "inputs"
+        ? "Source changed during compiled subprocess invocation"
+        : "Compiled subprocess artifact changed";
+    expect(failure).toMatchObject({ message: expect.stringContaining(diagnostic) });
+    expect(fs.existsSync(directory)).toBe(false);
+  },
+);

--- a/test/scripts/vitest-worker-shutdown.test.ts
+++ b/test/scripts/vitest-worker-shutdown.test.ts
@@ -52,7 +52,10 @@ it
       const compilerCanceled = path.join(root, "compiler-canceled");
       const admitted = path.join(root, "verification-ready");
       const borrowerClosed = path.join(root, "borrower-closed");
-      const signaled = path.join(root, "signal-observed");
+      const borrowerExit = path.join(root, "borrower-exit");
+      const ownerIdle = path.join(root, "owner-idle");
+      const loopRequest = path.join(root, "loop-request");
+      const responsive = path.join(root, "loop-responsive");
       const abort = new AbortController();
       const release = () => fs.writeFileSync(released, "release");
       const compiler = writeFixture(
@@ -89,13 +92,17 @@ fs.writeFileSync(path.join(directory,'manifest.json'),JSON.stringify({
         root,
         "borrower.mjs",
         `
+import fs from 'node:fs';
 import {requestVitestWorkerArtifacts} from ${JSON.stringify(pathToFileURL(path.join(repoRoot, "scripts/lib/vitest-worker-artifacts.mts")).href)};
+const exitWatcher=${JSON.stringify(phase)}==='admission' ? fs.watch(${JSON.stringify(root)},()=>{
+  if(fs.existsSync(${JSON.stringify(borrowerExit)})) process.exit(1);
+}) : undefined;
 try {
   await requestVitestWorkerArtifacts();
   console.log('fixture borrower completed');
 } catch(error) {
   console.error(error);process.exitCode=1;
-} finally {process.disconnect();}
+} finally {exitWatcher?.close();process.disconnect();}
 `,
       );
       const preload = writeFixture(
@@ -125,13 +132,20 @@ cp.spawn=(bin,args,options)=>{
   const bootstrap=args.indexOf(${JSON.stringify(path.join(repoRoot, "scripts/lib/vitest-worker-bootstrap.mts"))});
   if(bootstrap<0) return spawn(bin,args,options);
   const child=spawn(bin,[${JSON.stringify(borrower)}],options);
-  child.once('close',()=>{borrowerClosed=true;publish('borrower-closed',{pid:child.pid});});
+  child.once('close',(code,signal)=>{borrowerClosed=true;publish('borrower-closed',{pid:child.pid,code,signal});});
   generation=args[bootstrap+1];
   publish('owner.json',{owner:process.pid,borrower:child.pid,generation});
   return child;
 };
+// Node can cache process.emit before a preload replaces it. Probe held I/O
+// directly; adding a signal listener could rescue a broken wrapper instead.
 const waitForRelease=()=>new Promise(resolve=>{
+  let idle=false, responsive=false;
   const check=()=>{
+    if(borrowerClosed && !idle) {idle=true;publish('owner-idle',{owner:process.pid});}
+    if(!responsive && fs.existsSync(${JSON.stringify(loopRequest)})) {
+      responsive=true;publish('loop-responsive',{owner:process.pid});
+    }
     if(fs.existsSync(${JSON.stringify(released)})) {watcher.close();resolve();}
   };
   const watcher=fs.watch(root,check);
@@ -163,14 +177,6 @@ fs.rmSync=(filename,...args)=>{
     while(!fs.existsSync(${JSON.stringify(released)})) Atomics.wait(wait,0,0,10);
   }
   return rmSync(filename,...args);
-};
-// Observe delivery without adding a signal listener: a missing wrapper handler
-// must still take Node's default termination path, not be rescued by this fixture.
-const emit=process.emit;
-process.emit=function(event,...args) {
-  const result=emit.call(this,event,...args);
-  if(event===${JSON.stringify(shutdownSignal)} && borrowerClosed) publish('signal-observed',{owner:process.pid});
-  return result;
 };
 syncBuiltinESMExports();
 `,
@@ -242,16 +248,24 @@ syncBuiltinESMExports();
         } else {
           expect(JSON.parse(fs.readFileSync(admitted, "utf8"))).toEqual({ owner: owner.owner });
           if (phase === "admission") {
-            process.kill(owner.borrower, shutdownSignal);
+            // An ordinary borrower failure cannot supply the owner's signal status.
+            // Observe a loop turn after close before interrupting the retained owner.
+            fs.writeFileSync(borrowerExit, "exit");
             await waitForReceipt(borrowerClosed);
+            expect(JSON.parse(fs.readFileSync(borrowerClosed, "utf8"))).toMatchObject({
+              code: 1,
+              signal: null,
+            });
+            await waitForReceipt(ownerIdle);
           }
           expect(isProcessAlive(owner.borrower)).toBe(false);
           expect(isProcessAlive(compilerPid)).toBe(false);
           expect(fs.existsSync(path.join(owner.generation, "manifest.json"))).toBe(true);
 
           process.kill(owner.owner, shutdownSignal);
-          await waitForReceipt(signaled);
-          expect(JSON.parse(fs.readFileSync(signaled, "utf8"))).toEqual({ owner: owner.owner });
+          fs.writeFileSync(loopRequest, "probe");
+          await waitForReceipt(responsive);
+          expect(JSON.parse(fs.readFileSync(responsive, "utf8"))).toEqual({ owner: owner.owner });
           expect(isProcessAlive(owner.owner)).toBe(true);
           expect(fs.existsSync(owner.generation)).toBe(true);
           expect(fs.existsSync(released)).toBe(false);

--- a/test/scripts/vitest-worker-shutdown.test.ts
+++ b/test/scripts/vitest-worker-shutdown.test.ts
@@ -28,6 +28,8 @@ const shutdownCases = [
   { route: "direct", phase: "admission" },
   { route: "direct", phase: "compilation" },
   { route: "serial", phase: "compilation" },
+  { route: "direct", phase: "deletion" },
+  { route: "serial", phase: "deletion" },
 ] as const;
 
 it
@@ -113,7 +115,7 @@ const publish=(name,value)=>{
 };
 const spawn=cp.spawn;
 const phase=${JSON.stringify(phase)};
-let borrowerClosed=false, held=false;
+let borrowerClosed=false, held=false, generation;
 cp.spawn=(bin,args,options)=>{
   if(args[0]===${JSON.stringify(path.join(repoRoot, "scripts/lib/vitest-worker-compiler.mts"))}) {
     const child=spawn(bin,[${JSON.stringify(compiler)},args[1]],options);
@@ -124,23 +126,43 @@ cp.spawn=(bin,args,options)=>{
   if(bootstrap<0) return spawn(bin,args,options);
   const child=spawn(bin,[${JSON.stringify(borrower)}],options);
   child.once('close',()=>{borrowerClosed=true;publish('borrower-closed',{pid:child.pid});});
-  publish('owner.json',{owner:process.pid,borrower:child.pid,generation:args[bootstrap+1]});
+  generation=args[bootstrap+1];
+  publish('owner.json',{owner:process.pid,borrower:child.pid,generation});
   return child;
 };
+const waitForRelease=()=>new Promise(resolve=>{
+  const check=()=>{
+    if(fs.existsSync(${JSON.stringify(released)})) {watcher.close();resolve();}
+  };
+  const watcher=fs.watch(root,check);
+  check();
+});
 const readFile=fsp.readFile;
 fsp.readFile=async(filename,...args)=>{
-  if(filename===input && !held && (phase==='admission' || borrowerClosed)) {
+  if(filename===input && !held && (phase==='admission' || (phase==='disposal' && borrowerClosed))) {
     held=true;
     publish('verification-ready',{owner:process.pid});
-    await new Promise(resolve=>{
-      const check=()=>{
-        if(fs.existsSync(${JSON.stringify(released)})) {watcher.close();resolve();}
-      };
-      const watcher=fs.watch(root,check);
-      check();
-    });
+    await waitForRelease();
   }
   return readFile(filename,...args);
+};
+// The same delayed deletion blocks synchronous callers but lets async callers
+// process signals. Neither path may finish until the external fixture releases it.
+const rm=fsp.rm, rmSync=fs.rmSync;
+fsp.rm=async(filename,...args)=>{
+  if(phase==='deletion' && filename===generation) {
+    publish('verification-ready',{owner:process.pid});
+    await waitForRelease();
+  }
+  return rm(filename,...args);
+};
+fs.rmSync=(filename,...args)=>{
+  if(phase==='deletion' && filename===generation) {
+    publish('verification-ready',{owner:process.pid});
+    const wait=new Int32Array(new SharedArrayBuffer(4));
+    while(!fs.existsSync(${JSON.stringify(released)})) Atomics.wait(wait,0,0,10);
+  }
+  return rmSync(filename,...args);
 };
 // Observe delivery without adding a signal listener: a missing wrapper handler
 // must still take Node's default termination path, not be rescued by this fixture.
@@ -164,7 +186,7 @@ syncBuiltinESMExports();
               "test/scripts/vitest-worker-shutdown.test.ts",
             ];
       // Keep the wrappers, IPC and process owners real; only expensive child
-      // executables and one verification read are controlled by the fixture.
+      // executables and one verification read or deletion are controlled by the fixture.
       const command = workerArtifacts.fixtureLifetime.track(
         runNodeScript(
           args,
@@ -238,7 +260,9 @@ syncBuiltinESMExports();
         const result = await command;
         expect(result.error, result.stderr).toBeUndefined();
         expect(result.status, result.stderr).toBe(expectedExitCode);
-        expect(result.stdout.includes("fixture borrower completed")).toBe(phase === "disposal");
+        expect(result.stdout.includes("fixture borrower completed")).toBe(
+          phase === "disposal" || phase === "deletion",
+        );
         const trailer = `[test] FAILED (exit ${expectedExitCode})`;
         expect(result.stderr.match(/^\[.*\] FAILED \(exit \d+\)$/gmu)).toEqual([trailer]);
         expect(result.stderr.trim().split("\n").at(-1)).toBe(trailer);

--- a/test/scripts/vitest-worker-shutdown.test.ts
+++ b/test/scripts/vitest-worker-shutdown.test.ts
@@ -1,0 +1,369 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { setImmediate as nextTurn } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+import { expect, vi } from "vitest";
+import { inspectManagedProcessGroup } from "../../scripts/lib/managed-child-process.mts";
+import type { VitestWorkerManifest } from "../../scripts/lib/vitest-worker-artifacts.mts";
+import { createVitestWorkerRun } from "../../scripts/lib/vitest-worker-run.mts";
+import { createVitestProcessCompletion } from "../../scripts/vitest-process-group.mts";
+import { isProcessAlive, waitForDead } from "../helpers/process-wait.js";
+import { createDeferred, withTestTimeout } from "../helpers/promise.js";
+import { runNodeScript } from "../helpers/run-node-script.js";
+import {
+  createWorkerArtifactTest,
+  preparationClient,
+  waitForFixtureFile,
+  writeFixture,
+} from "./vitest-worker-artifacts.test-support.js";
+
+const it = createWorkerArtifactTest();
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+type OwnerReceipt = { owner: number; borrower: number; generation: string };
+
+const shutdownCases = [
+  { route: "direct", phase: "disposal" },
+  { route: "serial", phase: "disposal" },
+  { route: "direct", phase: "admission" },
+  { route: "direct", phase: "compilation" },
+  { route: "serial", phase: "compilation" },
+] as const;
+
+it
+  .runIf(process.platform !== "win32")
+  .for(
+    shutdownCases.flatMap(({ route, phase }) =>
+      (["SIGINT", "SIGTERM"] as const).map((shutdownSignal) => ({ route, phase, shutdownSignal })),
+    ),
+  )(
+  "$route wrapper joins $phase work before honoring $shutdownSignal",
+  ({ route, phase, shutdownSignal }, { workerArtifacts, signal, onTestFinished }) =>
+    workerArtifacts.fixtureLifetime.run(async () => {
+      const expectedExitCode = shutdownSignal === "SIGINT" ? 130 : 143;
+      const root = workerArtifacts.fixtureDirectory();
+      const input = writeFixture(root, "input", "owned verification input");
+      const released = path.join(root, "release");
+      const ownerFile = path.join(root, "owner.json");
+      const compilerFile = path.join(root, "compiler.json");
+      const compiling = path.join(root, "compiler-ready");
+      const compilerCanceled = path.join(root, "compiler-canceled");
+      const admitted = path.join(root, "verification-ready");
+      const borrowerClosed = path.join(root, "borrower-closed");
+      const signaled = path.join(root, "signal-observed");
+      const abort = new AbortController();
+      const release = () => fs.writeFileSync(released, "release");
+      const compiler = writeFixture(
+        root,
+        "compiler.mjs",
+        `
+import fs from 'node:fs';
+import path from 'node:path';
+import {createHash} from 'node:crypto';
+const directory=process.argv[2];
+if(${JSON.stringify(phase)}==='compilation') {
+  const keepAlive=setInterval(()=>{},1000);
+  await new Promise(resolve=>{
+    process.once('SIGTERM',()=>{
+      fs.writeFileSync(${JSON.stringify(compilerCanceled)},'canceled');
+      clearInterval(keepAlive);resolve();
+    });
+    fs.writeFileSync(${JSON.stringify(compiling)},'ready');
+  });
+  process.exit(0);
+}
+const hash=bytes=>createHash('sha256').update(bytes).digest('hex');
+const output='export const fixture = true;';
+fs.mkdirSync(path.join(directory,'dist'));
+fs.writeFileSync(path.join(directory,'dist','worker.js'),output);
+const inputs={ [${JSON.stringify(input)}]:hash(fs.readFileSync(${JSON.stringify(input)})) };
+const outputs={'worker.js':hash(output)};
+fs.writeFileSync(path.join(directory,'manifest.json'),JSON.stringify({
+  identity:hash(JSON.stringify([inputs,outputs])),inputs,outputs,durationMs:0,
+}));
+`,
+      );
+      const borrower = writeFixture(
+        root,
+        "borrower.mjs",
+        `
+import {requestVitestWorkerArtifacts} from ${JSON.stringify(pathToFileURL(path.join(repoRoot, "scripts/lib/vitest-worker-artifacts.mts")).href)};
+try {
+  await requestVitestWorkerArtifacts();
+  console.log('fixture borrower completed');
+} catch(error) {
+  console.error(error);process.exitCode=1;
+} finally {process.disconnect();}
+`,
+      );
+      const preload = writeFixture(
+        root,
+        "preload.mjs",
+        `
+import cp from 'node:child_process';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import {syncBuiltinESMExports} from 'node:module';
+const root=${JSON.stringify(root)}, input=${JSON.stringify(input)};
+const publish=(name,value)=>{
+  const filename=path.join(root,name);
+  fs.writeFileSync(filename+'.tmp',JSON.stringify(value));
+  fs.renameSync(filename+'.tmp',filename);
+};
+const spawn=cp.spawn;
+const phase=${JSON.stringify(phase)};
+let borrowerClosed=false, held=false;
+cp.spawn=(bin,args,options)=>{
+  if(args[0]===${JSON.stringify(path.join(repoRoot, "scripts/lib/vitest-worker-compiler.mts"))}) {
+    const child=spawn(bin,[${JSON.stringify(compiler)},args[1]],options);
+    publish('compiler.json',{pid:child.pid});
+    return child;
+  }
+  const bootstrap=args.indexOf(${JSON.stringify(path.join(repoRoot, "scripts/lib/vitest-worker-bootstrap.mts"))});
+  if(bootstrap<0) return spawn(bin,args,options);
+  const child=spawn(bin,[${JSON.stringify(borrower)}],options);
+  child.once('close',()=>{borrowerClosed=true;publish('borrower-closed',{pid:child.pid});});
+  publish('owner.json',{owner:process.pid,borrower:child.pid,generation:args[bootstrap+1]});
+  return child;
+};
+const readFile=fsp.readFile;
+fsp.readFile=async(filename,...args)=>{
+  if(filename===input && !held && (phase==='admission' || borrowerClosed)) {
+    held=true;
+    publish('verification-ready',{owner:process.pid});
+    await new Promise(resolve=>{
+      const check=()=>{
+        if(fs.existsSync(${JSON.stringify(released)})) {watcher.close();resolve();}
+      };
+      const watcher=fs.watch(root,check);
+      check();
+    });
+  }
+  return readFile(filename,...args);
+};
+// Observe delivery without adding a signal listener: a missing wrapper handler
+// must still take Node's default termination path, not be rescued by this fixture.
+const emit=process.emit;
+process.emit=function(event,...args) {
+  const result=emit.call(this,event,...args);
+  if(event===${JSON.stringify(shutdownSignal)} && borrowerClosed) publish('signal-observed',{owner:process.pid});
+  return result;
+};
+syncBuiltinESMExports();
+`,
+      );
+      const config = writeFixture(root, "vitest.config.mjs", "export default {};\n");
+      const args =
+        route === "direct"
+          ? ["scripts/run-vitest.mjs", "run", "--config", config]
+          : [
+              "--import",
+              "./scripts/tsx.mjs",
+              "scripts/test-projects-serial.mts",
+              "test/scripts/vitest-worker-shutdown.test.ts",
+            ];
+      // Keep the wrappers, IPC and process owners real; only expensive child
+      // executables and one verification read are controlled by the fixture.
+      const command = workerArtifacts.fixtureLifetime.track(
+        runNodeScript(
+          args,
+          {
+            PATH: process.env.PATH,
+            HOME: root,
+            USERPROFILE: root,
+            TMPDIR: root,
+            TMP: root,
+            TEMP: root,
+            NODE_OPTIONS: `--import=${pathToFileURL(preload).href}`,
+          },
+          20_000,
+          {
+            cwd: repoRoot,
+            signal: AbortSignal.any([signal, abort.signal]),
+            maxBuffer: 2 * 1024 * 1024,
+            requireProcessTreeExit: true,
+          },
+        ),
+      );
+      onTestFinished(async () => {
+        release();
+        abort.abort();
+        await command;
+      });
+      const waitForReceipt = (filename: string) =>
+        withTestTimeout(
+          waitForFixtureFile(filename, command),
+          10_000,
+          `Missing shutdown receipt: ${filename}`,
+        );
+      let owner: OwnerReceipt | undefined;
+      try {
+        // Child readiness can beat the parent's PID receipts. Join every required
+        // receipt within the command's existing startup deadline before reading them.
+        const ready = phase === "compilation" ? compiling : admitted;
+        await Promise.all(
+          [ready, ownerFile, compilerFile].map((filename) => waitForFixtureFile(filename, command)),
+        );
+        owner = JSON.parse(fs.readFileSync(ownerFile, "utf8")) as OwnerReceipt;
+        const compilerPid = (JSON.parse(fs.readFileSync(compilerFile, "utf8")) as { pid: number })
+          .pid;
+        if (phase === "compilation") {
+          expect(isProcessAlive(compilerPid)).toBe(true);
+          expect(fs.existsSync(path.join(owner.generation, "manifest.json"))).toBe(false);
+          // Only the borrower dies. Its completion must let the invocation cancel
+          // the compiler, rather than waiting for that compiler before disposal.
+          process.kill(owner.borrower, shutdownSignal);
+          await waitForReceipt(compilerCanceled);
+          expect(fs.readFileSync(compilerCanceled, "utf8")).toBe("canceled");
+          expect(fs.existsSync(released)).toBe(false);
+        } else {
+          expect(JSON.parse(fs.readFileSync(admitted, "utf8"))).toEqual({ owner: owner.owner });
+          if (phase === "admission") {
+            process.kill(owner.borrower, shutdownSignal);
+            await waitForReceipt(borrowerClosed);
+          }
+          expect(isProcessAlive(owner.borrower)).toBe(false);
+          expect(isProcessAlive(compilerPid)).toBe(false);
+          expect(fs.existsSync(path.join(owner.generation, "manifest.json"))).toBe(true);
+
+          process.kill(owner.owner, shutdownSignal);
+          await waitForReceipt(signaled);
+          expect(JSON.parse(fs.readFileSync(signaled, "utf8"))).toEqual({ owner: owner.owner });
+          expect(isProcessAlive(owner.owner)).toBe(true);
+          expect(fs.existsSync(owner.generation)).toBe(true);
+          expect(fs.existsSync(released)).toBe(false);
+          release();
+        }
+        const result = await command;
+        expect(result.error, result.stderr).toBeUndefined();
+        expect(result.status, result.stderr).toBe(expectedExitCode);
+        expect(result.stdout.includes("fixture borrower completed")).toBe(phase === "disposal");
+        const trailer = `[test] FAILED (exit ${expectedExitCode})`;
+        expect(result.stderr.match(/^\[.*\] FAILED \(exit \d+\)$/gmu)).toEqual([trailer]);
+        expect(result.stderr.trim().split("\n").at(-1)).toBe(trailer);
+        expect(fs.existsSync(owner.generation)).toBe(false);
+      } finally {
+        release();
+        abort.abort();
+        const result = await command;
+        if (result.error) {
+          console.error(result.error, result.stderr);
+        }
+        owner ??= fs.existsSync(ownerFile)
+          ? (JSON.parse(fs.readFileSync(ownerFile, "utf8")) as OwnerReceipt)
+          : undefined;
+        if (owner) {
+          const compilerPid = fs.existsSync(compilerFile)
+            ? (JSON.parse(fs.readFileSync(compilerFile, "utf8")) as { pid: number }).pid
+            : undefined;
+          for (const pid of [owner.owner, owner.borrower, compilerPid]) {
+            if (pid === undefined) {
+              continue;
+            }
+            await waitForDead(pid, 5_000);
+            await expect
+              .poll(() =>
+                inspectManagedProcessGroup(
+                  { pid, exitCode: expectedExitCode },
+                  { errorPolicy: "indeterminate" },
+                ),
+              )
+              .toBe("dead");
+          }
+          fs.rmSync(owner.generation, { recursive: true, force: true });
+        }
+      }
+    }),
+);
+
+it("rejects a live borrower when its owner closes during verification", ({
+  workerArtifacts,
+  signal,
+}) =>
+  workerArtifacts.fixtureLifetime.run(async () => {
+    const { observeChild } = workerArtifacts.createFixtureCommands();
+    const owner = createVitestWorkerRun();
+    const directory = owner.descriptor.directory;
+    const manifestFile = path.join(directory, "manifest.json");
+    const started = createDeferred();
+    const release = createDeferred();
+    const readFile = fs.promises.readFile.bind(fs.promises);
+    let held = false;
+    const reader = vi.spyOn(fs.promises, "readFile").mockImplementation(async (...args) => {
+      const filename = args[0];
+      if (
+        !held &&
+        typeof filename === "string" &&
+        filename !== manifestFile &&
+        fs.existsSync(manifestFile)
+      ) {
+        const manifest: VitestWorkerManifest = JSON.parse(fs.readFileSync(manifestFile, "utf8"));
+        if (Object.hasOwn(manifest.inputs, filename)) {
+          held = true;
+          started.resolve();
+          await release.promise;
+        }
+      }
+      return readFile(...args);
+    });
+    const stop = () => {
+      release.resolve();
+      // Disposal must also start when a broken fixture times out before admission.
+      void owner.dispose().catch(() => {});
+    };
+    signal.addEventListener("abort", stop, { once: true });
+    try {
+      const child = spawn(process.execPath, ["--input-type=module", "--eval", preparationClient], {
+        detached: process.platform !== "win32",
+        stdio: ["ignore", "ignore", "pipe", "ipc"],
+      });
+      let stderr = "";
+      child.stderr!.on("data", (chunk) => {
+        stderr += String(chunk);
+      });
+      const completion = observeChild(
+        child,
+        owner.borrow(
+          child,
+          createVitestProcessCompletion({
+            child,
+            detached: process.platform !== "win32",
+          }),
+        ),
+      );
+      void workerArtifacts.fixtureLifetime.verifyCleanup(async () => {
+        await completion;
+      });
+      await Promise.race([
+        started.promise,
+        completion.then(() => {
+          throw new Error("Borrower exited before verification was held");
+        }),
+      ]);
+      let disposed = false;
+      const disposal = workerArtifacts.fixtureLifetime.track(
+        owner.dispose().then(() => {
+          disposed = true;
+        }),
+      );
+      await nextTurn();
+      expect(disposed).toBe(false);
+      expect(child.exitCode).toBeNull();
+      expect(child.signalCode).toBeNull();
+      expect(fs.existsSync(directory)).toBe(true);
+      release.resolve();
+      expect(await completion, stderr).toEqual({ code: 1, signal: null });
+      expect(stderr).toContain("owner is closing");
+      await disposal;
+      expect(fs.existsSync(directory)).toBe(false);
+    } finally {
+      signal.removeEventListener("abort", stop);
+      release.resolve();
+      try {
+        await owner.dispose();
+      } finally {
+        reader.mockRestore();
+      }
+    }
+  }));

--- a/test/scripts/vitest-worker-shutdown.test.ts
+++ b/test/scripts/vitest-worker-shutdown.test.ts
@@ -94,15 +94,18 @@ fs.writeFileSync(path.join(directory,'manifest.json'),JSON.stringify({
         `
 import fs from 'node:fs';
 import {requestVitestWorkerArtifacts} from ${JSON.stringify(pathToFileURL(path.join(repoRoot, "scripts/lib/vitest-worker-artifacts.mts")).href)};
-const exitWatcher=${JSON.stringify(phase)}==='admission' ? fs.watch(${JSON.stringify(root)},()=>{
-  if(fs.existsSync(${JSON.stringify(borrowerExit)})) process.exit(1);
-}) : undefined;
+const exitFile=${JSON.stringify(borrowerExit)};
+const exitCheck=()=>{if(fs.existsSync(exitFile)) process.exit(1);};
+if(${JSON.stringify(phase)}==='admission') {
+  fs.watchFile(exitFile,{interval:50},exitCheck);
+  exitCheck();
+}
 try {
   await requestVitestWorkerArtifacts();
   console.log('fixture borrower completed');
 } catch(error) {
   console.error(error);process.exitCode=1;
-} finally {exitWatcher?.close();process.disconnect();}
+} finally {fs.unwatchFile(exitFile,exitCheck);process.disconnect();}
 `,
       );
       const preload = writeFixture(
@@ -115,6 +118,13 @@ import fsp from 'node:fs/promises';
 import path from 'node:path';
 import {syncBuiltinESMExports} from 'node:module';
 const root=${JSON.stringify(root)}, input=${JSON.stringify(input)};
+// CI workspaces need not provide native directory notifications. Control-file
+// readiness must remain observable without that optional filesystem facility.
+const nativeWatch=fs.watch;
+fs.watch=(directory,...args)=>{
+  if(directory===root) throw new Error('Native fixture notifications unavailable');
+  return nativeWatch(directory,...args);
+};
 const publish=(name,value)=>{
   const filename=path.join(root,name);
   fs.writeFileSync(filename+'.tmp',JSON.stringify(value));
@@ -141,14 +151,18 @@ cp.spawn=(bin,args,options)=>{
 // directly; adding a signal listener could rescue a broken wrapper instead.
 const waitForRelease=()=>new Promise(resolve=>{
   let idle=false, responsive=false;
+  const controls=${JSON.stringify([borrowerClosed, loopRequest, released])};
   const check=()=>{
     if(borrowerClosed && !idle) {idle=true;publish('owner-idle',{owner:process.pid});}
     if(!responsive && fs.existsSync(${JSON.stringify(loopRequest)})) {
       responsive=true;publish('loop-responsive',{owner:process.pid});
     }
-    if(fs.existsSync(${JSON.stringify(released)})) {watcher.close();resolve();}
+    if(fs.existsSync(${JSON.stringify(released)})) {
+      for(const filename of controls) fs.unwatchFile(filename,check);
+      resolve();
+    }
   };
-  const watcher=fs.watch(root,check);
+  for(const filename of controls) fs.watchFile(filename,{interval:50},check);
   check();
 });
 const readFile=fsp.readFile;

--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -138,6 +138,16 @@ describe("unit-fast vitest lane", () => {
         }
         return originalReadFileSync.apply(this, args);
       };
+      const paths = await import("./test/vitest/vitest.unit-fast-paths.mjs");
+      const membership = selectedTests.map((file) => [
+        paths.isUnitFastTestFile(file),
+        paths.isUnitFastIsolatedTestFile(file),
+        paths.isUnitFastTimerTestFile(file),
+      ]);
+      console.log("UNIT_FAST_MEMBERSHIP_PROBE", JSON.stringify({ membership, unselectedFileReads }));
+      hookFileReads = 0;
+      outsideFileReads = 0;
+      unselectedFileReads = 0;
       await import("./test/vitest/vitest.hooks.config.ts?scope-probe=" + Date.now());
       const scopedHookFileReads = hookFileReads;
       const scopedOutsideFileReads = outsideFileReads;
@@ -197,6 +207,17 @@ describe("unit-fast vitest lane", () => {
 
   it("classifies only selected config sources without truncating later full ownership", () => {
     expect(configProbeResult.status, configProbeResult.stderr).toBe(0);
+    const membership = configProbeResult.stdout.match(/UNIT_FAST_MEMBERSHIP_PROBE (.+)/u);
+    expect(membership, configProbeResult.stdout).not.toBeNull();
+    expect(JSON.parse(membership?.[1] ?? "null")).toEqual({
+      membership: [
+        [true, false, false],
+        [true, true, false],
+        [true, false, true],
+        [false, false, false],
+      ],
+      unselectedFileReads: 0,
+    });
     const probeMatch = configProbeResult.stdout.match(
       /UNIT_FAST_IO_PROBE (\d+) (\d+) (\d+) (\d+) (\d+)/u,
     );
@@ -232,7 +253,7 @@ describe("unit-fast vitest lane", () => {
     const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-untracked-")));
     const pure = "src/hooks/pure.test.ts";
     const stateful = "src/hooks/stateful.test.ts";
-    const quoted = "src/hooks/quoted-é.test.ts";
+    const quoted = "src/hooks/quoted-[é].test.ts";
     const ignored = "src/hooks/ignored.test.ts";
     const moduleUrl = (file: string) => JSON.stringify(pathToFileURL(path.resolve(file)).href);
     try {
@@ -283,6 +304,7 @@ describe("unit-fast vitest lane", () => {
             excluded: createScopedVitestConfig(["src/hooks/**/*.test.ts"], { env: {} }).test.exclude
               .filter((file) => file.startsWith("src/hooks/")),
             ignored: paths.resolveUnitFastTestIncludePattern(${JSON.stringify(ignored)}),
+            literalMembership: paths.isUnitFastTestFile(${JSON.stringify(quoted)}),
           }));
         } finally {
           for (const spec of specs) fs.rmSync(spec.includeFilePath, { force: true });
@@ -300,6 +322,7 @@ describe("unit-fast vitest lane", () => {
         ],
         excluded: [pure, quoted, stateful],
         ignored: null,
+        literalMembership: true,
       });
     } finally {
       fs.rmSync(cwd, { recursive: true, force: true });

--- a/test/vitest/vitest.unit-fast-paths.mjs
+++ b/test/vitest/vitest.unit-fast-paths.mjs
@@ -559,11 +559,8 @@ export function collectUnitFastTestFileAnalysis(cwd = process.cwd(), options = {
 }
 
 let cachedUnitFastTestFiles = null;
-let cachedUnitFastTestFileSet = null;
 let cachedUnitFastIsolatedTestFiles = null;
-let cachedUnitFastIsolatedTestFileSet = null;
 let cachedUnitFastTimerTestFiles = null;
-let cachedUnitFastTimerTestFileSet = null;
 const scopedUnitFastTestFilesByKey = new Map();
 
 export function getUnitFastTestFilesForIncludePatterns(includePatterns, options = {}) {
@@ -630,12 +627,24 @@ function selectedUnitFastAnalysis(includePatterns) {
     : collectUnitFastTestFileAnalysis();
 }
 
+function isUnitFastTimerAnalysis(entry) {
+  return entry.unitFast && entry.reasons.includes("fake-timers");
+}
+
+function isUnitFastIsolatedAnalysis(entry) {
+  return (
+    entry.unitFast &&
+    !entry.reasons.includes("fake-timers") &&
+    (entry.forced || entry.reasons.includes("stateful-test-helper"))
+  );
+}
+
 export function getUnitFastTimerTestFiles(includePatterns) {
   if (!includePatterns && cachedUnitFastTimerTestFiles !== null) {
     return cachedUnitFastTimerTestFiles;
   }
   const files = selectedUnitFastAnalysis(includePatterns)
-    .filter((entry) => entry.unitFast && entry.reasons.includes("fake-timers"))
+    .filter(isUnitFastTimerAnalysis)
     .map((entry) => entry.file);
   return includePatterns ? files : (cachedUnitFastTimerTestFiles = files);
 }
@@ -645,50 +654,34 @@ export function getUnitFastIsolatedTestFiles(includePatterns) {
     return cachedUnitFastIsolatedTestFiles;
   }
   const files = selectedUnitFastAnalysis(includePatterns)
-    .filter(
-      (entry) =>
-        entry.unitFast &&
-        !entry.reasons.includes("fake-timers") &&
-        (entry.forced || entry.reasons.includes("stateful-test-helper")),
-    )
+    .filter(isUnitFastIsolatedAnalysis)
     .map((entry) => entry.file);
   return includePatterns ? files : (cachedUnitFastIsolatedTestFiles = files);
 }
 
-function getUnitFastTestFileSet() {
-  if (cachedUnitFastTestFileSet !== null) {
-    return cachedUnitFastTestFileSet;
-  }
-  cachedUnitFastTestFileSet = new Set(getUnitFastTestFiles());
-  return cachedUnitFastTestFileSet;
-}
-
-function getUnitFastTimerTestFileSet() {
-  if (cachedUnitFastTimerTestFileSet !== null) {
-    return cachedUnitFastTimerTestFileSet;
-  }
-  cachedUnitFastTimerTestFileSet = new Set(getUnitFastTimerTestFiles());
-  return cachedUnitFastTimerTestFileSet;
-}
-
-function getUnitFastIsolatedTestFileSet() {
-  if (cachedUnitFastIsolatedTestFileSet !== null) {
-    return cachedUnitFastIsolatedTestFileSet;
-  }
-  cachedUnitFastIsolatedTestFileSet = new Set(getUnitFastIsolatedTestFiles());
-  return cachedUnitFastIsolatedTestFileSet;
+function getUnitFastTestFileAnalysis(file) {
+  const normalized = normalizeRepoPath(file);
+  const cwd = process.cwd();
+  // Exact routing must not analyze every source before admitting one test.
+  // Retain inventory membership, including ignored-file and forced-owner rules.
+  return isUnitFastCandidateFile(normalized) &&
+    collectUnitFastCandidateInventory(cwd).includes(normalized)
+    ? analyzeUnitFastTestFile(cwd, normalized)
+    : undefined;
 }
 
 export function isUnitFastTestFile(file) {
-  return getUnitFastTestFileSet().has(normalizeRepoPath(file));
+  return getUnitFastTestFileAnalysis(file)?.unitFast ?? false;
 }
 
 export function isUnitFastTimerTestFile(file) {
-  return getUnitFastTimerTestFileSet().has(normalizeRepoPath(file));
+  const entry = getUnitFastTestFileAnalysis(file);
+  return entry ? isUnitFastTimerAnalysis(entry) : false;
 }
 
 export function isUnitFastIsolatedTestFile(file) {
-  return getUnitFastIsolatedTestFileSet().has(normalizeRepoPath(file));
+  const entry = getUnitFastTestFileAnalysis(file);
+  return entry ? isUnitFastIsolatedAnalysis(entry) : false;
 }
 
 export function resolveUnitFastTestIncludePattern(file) {

--- a/test/vitest/vitest.worker-artifacts.ts
+++ b/test/vitest/vitest.worker-artifacts.ts
@@ -6,7 +6,6 @@ import {
   isVitestWorkerDeclaration,
   requestVitestWorkerArtifacts,
   resolveVitestWorkerDeclaration,
-  verifyVitestWorkerArtifacts,
   vitestWorkerDeclarationEntries,
 } from "../../scripts/lib/vitest-worker-artifacts.mts";
 import { getVitestWorkerDescriptor } from "../../scripts/lib/vitest-worker-bootstrap.mts";
@@ -60,8 +59,10 @@ export function compiledSubprocessesPlugin(): Plugin {
         instance[ownerKey] = {
           acquire() {
             return (preparation ??= (async () => {
-              await requestVitestWorkerArtifacts();
-              verifyVitestWorkerArtifacts(directory);
+              await requestVitestWorkerArtifacts().catch((error: unknown) => {
+                failure = error;
+                throw error;
+              });
               return directory;
             })());
           },
@@ -71,19 +72,10 @@ export function compiledSubprocessesPlugin(): Plugin {
             process.exitCode = 1;
           }
         });
-        // Vitest closes its pool concurrently with this hook. Verification is
-        // safe here; deletion belongs to the outer runner after actual child close.
-        vitest.onClose(async () => {
+        // The outer owner verifies before lending and after every borrower closes.
+        // Rechecking here races pool shutdown and consumes Vitest's teardown deadline.
+        vitest.onClose(() => {
           process.off("disconnect", ownerDisconnected);
-          if (preparation) {
-            try {
-              verifyVitestWorkerArtifacts(await preparation);
-            } catch (error) {
-              failure = error;
-              process.exitCode = 1;
-              throw error;
-            }
-          }
         });
       }
       owner = instance[ownerKey];


### PR DESCRIPTION
Closes #135365 — test wrappers stalling during subprocess artifact verification.

<details>
<summary>Additional instructions</summary>

Maintainer edits are available on this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where developers could see passing Vitest summaries but wait substantially longer for the repository wrapper to finish. Large compiled-subprocess generations were checked synchronously after the child exited, preventing the wrapper from promptly processing signals. Focused serial runs also did unnecessary repository-wide source analysis before starting their selected test.

## Why This Change Was Made

The invocation owner now verifies artifacts with bounded asynchronous reads, retains outstanding preparation requests until safe disposal, and allows native child completion to reach compiler cancellation. It also awaits asynchronous generation removal so a slow delete cannot block signal delivery. Redundant Vitest-side scans and the old finish helper are removed while preserving one final public failure line. Exact-file routing reuses the existing per-file classification owner instead of populating three whole-repository membership sets, retaining forced ownership, ignored-file rules, timer isolation, and literal filename handling.

## User Impact

Repository test runs remain responsive during integrity checks, preserve native interruption status, and release generated artifacts only after owned work has settled. Exact-file runs avoid reading unrelated test sources. No OpenClaw product runtime, public configuration, dependency version, watchdog deadline, or test timeout changes.

The [testing guide](https://docs.openclaw.ai/reference/test) documents the ownership and verification behavior.

## Evidence

**Control-file observation follow-up:** [CI run 33580833119](https://github.com/openclaw/openclaw/actions/runs/33580833119/job/100094763987) still failed two heartbeat receipts after the emitter-observer repair. The internal release/heartbeat and borrower-exit gates retained native directory-watch dependencies even though the shared readiness helper already observes persistent file state with `fs.watchFile`. All fixture control waits now use that same state-based mechanism and remove their watchers on completion. A fault injection rejects native notifications for the fixture control directory; the old fixture exits prematurely under that injection, while the revised 14 signal and 3 verifier cases pass. This proves independence from native notifications, not a definitive explanation of every prior CI miss.

The revised fixture still rejects genuine owner defects: synchronous cleanup fails all four deletion heartbeat cases, and removing invocation signal handlers fails direct-disposal SIGINT. Both temporary production changes were restored byte-for-byte before the final positive run. Native status, footer, artifact, PID/process-group, case-order, and deadline assertions are unchanged. This follow-up adds no production code or test-only product seam. [Final exact-head CI 33583266421](https://github.com/openclaw/openclaw/actions/runs/33583266421) completed successfully on `1df652fbe71d6a47f278af8ca3ba718b222e3a16`. Native prepare passed using that hosted proof without rebasing or changing the head; [land-ready evidence](https://github.com/openclaw/openclaw/pull/135439#issuecomment-5503502237) records the final checks and limits.

**Earlier signal-probe CI repair:** [run 33578192404](https://github.com/openclaw/openclaw/actions/runs/33578192404/job/100086813137) distinguished a test-observer failure from a lost signal: its disposal borrower exited normally, and the wrapper emitted exit 130 despite the missing `process.emit`-hook receipt. Node binds the emitter when creating its signal watcher; a standalone contract probe reproduced real delivery bypassing a later emitter override. The fixture now probes event-loop responsiveness through the existing held-I/O file watcher, without adding signal listeners. Admission's borrower exits with ordinary code 1, so final 130/143 must independently come from the owner's signal. Native status, footer, generation, PID/group, and deadline assertions remain intact.

The revised signal/verifier scope passed **17 tests** (one compiler case filtered), and its changed gate passed. Negative controls still fail: synchronous removal fails all four deletion probes, and removing invocation signal handlers fails the direct-disposal probe. Both production files were restored byte-for-byte; this follow-up changes only the test. Fresh isolated Codex review returned scoped-clean at P0. No timeout, retry, environment exemption, or production workaround was added.

**Final integration scope:** rebased onto `ab6726b5d8d27f2e7940f6fdbf3eacd2f20ccb72`, preserving main's new native-home admission/isolation and node-host worker declaration. The first repair is unchanged by range-diff; the cleanup follow-up drops only the superseded sidebar hunk. Main now owns the row-scoped sidebar fix. Its CI refit also makes the temporary capacity-priority layer unnecessary: all nine current-inventory normal/stressed comparisons produced identical counts with and without that layer, within the existing caps and with complete split/build ownership. The CI commit, `docs/ci.md` change, and UI hunk are removed. The final diff is 11 wrapper/test/docs files.

Post-rebase proof passed **87** shutdown, verification, home-admission, footer, and pre-install-closure cases (277 intentionally filtered), **61** planner/routing cases, and the focused changed gate for all 11 files. The first scoped attempt had one existing max-runner signal case report a terminated residual process group; an unchanged rerun with an external owned-process census passed all 87 and did not reproduce it. This is a separate passing receipt, not a claim that an unproven race was fixed. Earlier failed receipts and Mac timing limits remain recorded. Fresh isolated Codex review of the complete final branch returned scoped-clean at the requested P0 threshold. Final published-head CI is still a separate gate.

**Cleanup investigation and earlier CI follow-up:** the Mac investigation separated verification from removal on one fresh generation: the old synchronous verifier took 770 ms, the async verifier 704 ms, but disposal took 94,964 ms. The remaining synchronous deletion could still block signal delivery. The owner now awaits native asynchronous removal under the existing disposal lifetime. Four appended direct/serial × SIGINT/SIGTERM deletion cases failed before this repair on absent signal delivery; all four passed in the clean Linux candidate. The original ten signal cases retain their order, and no deadlines or assertions changed.

[CI run 33567784638](https://github.com/openclaw/openclaw/actions/runs/33567784638) also exposed a main-side sidebar test-selector regression: a new marquee header became the first `.hover-marquee`, so the test no longer selected its renamed session row. A row-scoped fix with before/after text checks, retaining all prior identity, class, and style assertions, subsequently landed on main. The final branch preserves it without carrying a duplicate UI change.

The earlier admission SIGINT receipt failure could not independently establish owner delivery because the borrower had already selected exit 130. Three bounded diagnostic baseline invocations on Node 24.19.0 each passed 499 tests; the first baseline and the candidate matched CI's full 17-file execution order, while the warm repetitions reordered files. In-file signal-case order was retained throughout. Diagnostics showed continuous invocation signal ownership in the successful runs; no speculative owner patch or weaker exit-code-only assertion was substituted.

On the exact CI merge `26d29cce55ed91145678a8126cd36a5214392e26` plus the verified follow-up code patch, the original CI group passed **503 tests** (110 existing exclusions), the focused artifact/lifecycle/verifier/routing/planner suite passed **112**, and sidebar/marquee suites passed **330**. The shutdown fixture carried diagnostic-only emission/listener tracing without changing listeners, assertions, or deadlines; this instrumentation is not part of the PR. These are CI-merge-aligned receipts, not a replacement for the final published-head CI gate. [Testbox run 33570225313](https://github.com/openclaw/openclaw/actions/runs/33570225313), lease `tbx_01m1fm42y4ehwf0x7m0sh3xgnx`, exited zero and was verified stopped/completed.

The Mac remains unsuitable for a full green timing claim: native compilation alone reached 134 seconds, and even async removal took 70 seconds in one profile. Three new deletion cases passed locally; one exceeded its unchanged 20-second command deadline despite observing the expected signal/footer. Those failures remain recorded. Native Node and Bun separately verified successful removal and rejection-plus-removal after artifact tampering.

The complete local changed gate passed for all 14 touched files, including typechecks, unused-export scans, formatting, lint, and guards. Fresh isolated Codex review of the staged follow-up returned scoped-clean at the requested P0 threshold.

```bash
node scripts/check-changed.mjs -- docs/ci.md docs/reference/test.md scripts/lib/ci-node-test-plan.mts scripts/lib/vitest-worker-artifacts.mts scripts/lib/vitest-worker-compiler.mts scripts/lib/vitest-worker-run.mts scripts/run-vitest.mts test/scripts/vitest-worker-artifacts.test.ts test/scripts/vitest-worker-artifacts.verification.test.ts test/scripts/vitest-worker-shutdown.test.ts test/vitest-unit-fast-config.test.ts test/vitest/vitest.unit-fast-paths.mjs test/vitest/vitest.worker-artifacts.ts ui/src/test-helpers/app-sidebar-cases/catalog-row-lifecycle.ts
```

**Rebase checkpoint:** `8c8ddfaa863cab12cbc0e40004768faa5a138908` integrates main `9a70559beb29001b16b446fe312719790f0a4c53`. It retains upstream's external fs-safe package ownership, its new installed-package test, the new worker declaration, and the measured isolated-tooling timing hint. Range-diff shows only the removal of our conversions of now-deleted native-copy assertions; the capacity repair is unchanged. No duplicate binary-copy path was restored.

A fresh Linux checkout with its own frozen dependency install passed **108 focused tests**: **61** artifact-owner, verification, shutdown, and exact-routing tests, plus **47** unchanged planner tests. The complete candidate Git tree (`a07873fbdf3ce10e77f87b2537d22a8c748f26f8`) matched before installation, before tests, and afterward. Blacksmith Testbox `tbx_01m1fh33ext46kb13e0rjnmfz8`, [run 33566018621](https://github.com/openclaw/openclaw/actions/runs/33566018621), returned exit zero and was verified stopped/completed. This is exact-tree clean-Linux proof, not a substitute for the required exact-head PR CI gate.

```bash
node scripts/run-vitest.mjs test/scripts/vitest-worker-artifacts.test.ts test/scripts/vitest-worker-artifacts.verification.test.ts test/scripts/vitest-worker-shutdown.test.ts test/vitest-unit-fast-config.test.ts
```

```bash
node scripts/run-vitest.mjs test/scripts/ci-node-test-plan.test.ts
```

The rebased Mac candidate separately passed **47 planner tests**, **41 public-footer/import-closure tests** (241 unrelated cases filtered), and the changed formatting, script/test-root typechecks, lint, and guards. A fresh whole-PR isolated Codex review returned scoped-clean at the requested P0 threshold. The first Mac artifact aggregate exceeded unchanged compiler-case deadlines and was interrupted; the retained sample shows the compiler waiting in filesystem `open`, and residual owned fixture groups were stopped and checked. That aggregate is not reported as green. Focused Mac reruns passed 27 shutdown/routing/verifier cases and three compiler cases, but the live-borrower compiler case and the unchanged installed-package case still exceeded 120 seconds (native preparation alone took 61–73 seconds). These two local failures remain an explicit proof limitation, not passing Mac receipts; both pass in the exact-tree clean-Linux run. No timeout, assertion, or test environment was changed to obtain a pass.

**Earlier reproduction and proof checkpoints:** Both defects were reproduced before repair. A real serial doctor run printed five passing assertions; Vitest reported 401.52 seconds while the wrapper took 656.12 seconds, and the retained wrapper was sampled doing synchronous file reads and SHA-256 work over 7,422 inputs and 2,791 outputs. The supplied-manifest event-loop regression also failed on the pinned main baseline. The cold-planner regression preserved the expected classification matrix but read 124 unrelated sources; a native exact-target measurement read 5,333 sources before repair versus two afterward.

A clean Linux checkout at base `911b8e7dde52c4ab43a46a467681ddcd334e0c04`, with the candidate patch applied and verified and its own frozen pnpm install, passed **317 focused tests**:

- Planner and new lifecycle/verifier tests: **28 passed**.
- CLI, report, diagnostic, and final-outcome suites: **254 passed**.
- Existing compiled-subprocess artifact-owner suite: **34 passed**.
- Pre-install planner import-closure guard: **1 passed**, 231 unrelated guard cases intentionally filtered.

These ran on Blacksmith Testbox `tbx_01m1f1etbdzgb68snr542k2k17`, hosted by [run 33540062537](https://github.com/openclaw/openclaw/actions/runs/33540062537). The command receipts exited zero; the task-owned lease was stopped after proof. This is focused Testbox evidence, not the PR's exact-head CI gate.

```bash
node scripts/run-vitest.mjs test/vitest-unit-fast-config.test.ts test/scripts/vitest-worker-artifacts.verification.test.ts test/scripts/vitest-worker-shutdown.test.ts
```

```bash
node scripts/run-vitest.mjs test/scripts/run-vitest-bounded.test.ts test/scripts/vitest-report-owner.test.ts test/scripts/vitest-process-diagnostics.test.ts test/scripts/run-vitest.test.ts
```

```bash
node scripts/run-vitest.mjs test/scripts/vitest-worker-artifacts.test.ts
```

```bash
node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts --testNamePattern 'keeps the preflight manifest import closure dependency-free'
```

The Mac run exposed a fixture publication race: compiler readiness could precede the parent's PID receipt. Waiting for every required receipt under the existing deadline repaired that test; **all 13 local signal/verifier cases passed**, with the real-compiler case deliberately filtered. All **14 lifecycle/verifier cases** passed again on the pinned Linux candidate after that receipt fix. Subsequent edits only made matrix fields explicit and added required braces for lint.

```bash
node scripts/run-vitest.mjs test/scripts/vitest-worker-shutdown.test.ts test/scripts/vitest-worker-artifacts.verification.test.ts --testNamePattern 'wrapper joins|keeps the runner event loop|drains active'
```

Native Node 24.20.0 and Bun 1.4.0 each passed four integrity/error probes. The final staged formatting, scripts/test-root typechecks, lint, and selected guards passed:

```bash
node scripts/check-changed.mjs --staged
```

Fresh isolated Codex review of the final staged tree returned no actionable findings at the requested P0 threshold. The clean rebase produced `57ec84311e14eff9a6cdc980df3025195056aa91` on main `01129d7bbe06ba05f1e4850d6b6a38c4f2a2c22b`; range-diff was unchanged, all reviewed implementation files retained their hashes, and the rebased launcher/signal/pre-install smoke passed **54 tests** (241 cases intentionally filtered).

```bash
node scripts/run-vitest.mjs test/scripts/vitest-worker-shutdown.test.ts test/scripts/vitest-worker-artifacts.verification.test.ts test/scripts/run-vitest-bounded.test.ts test/scripts/ci-workflow-guards.test.ts --testNamePattern 'wrapper joins|keeps the runner event loop|drains active|reports .* after its owners settle|keeps the preflight manifest import closure dependency-free'
```

The rebased Mac candidate also passed the real-compiler live-borrower closure case in **11.63 seconds**, including an 8.16-second build over 7,433 inputs and 2,812 outputs, with the original deadline unchanged:

```bash
node scripts/run-vitest.mjs test/scripts/vitest-worker-shutdown.test.ts --testNamePattern 'rejects a live borrower'
```

**Proof limits and earlier failures:** no full-repository or native Windows run is claimed. Earlier Mac attempts exceeded the unchanged 120-second compiler-case deadline while a separate native probe measured roughly 0.3–1.5 seconds per tiny file write, including outside the checkout. Those failed aggregates remain failures and are not relabeled green; the final focused reruns are separate passing receipts. The repair does not claim to fix generic host filesystem stalls.

**Earlier CI capacity repair, now superseded and removed:** [the first exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33543711422/job/99976265147) exposed a deterministic planner failure: the existing slow-GitHub regression planned 113 jobs against the unchanged 112-job cap. Either new two-second test file could move the mandatory-large-runner compiler fixture into an underfilled hosted child; consolidating the new files or changing bin-packing heuristics would not fix it. The intermediate repair considered the existing capacity requirement before file-weight balancing, reusing the same predicate for final runner assignment. No tests, assertions, duration estimates, runner classes, worker limits, or job caps were changed by that repair. The later main refit made it redundant; it is not part of the final diff.

All **47 unchanged planner tests passed** after this owner-side repair. The native nine-scenario check retains every tooling file exactly once, all 16 parents, large-compiler/small-sibling placement, build ownership, and isolation. The previously failing scenario now fits 112 jobs; normal GitHub and hybrid PR plans use one fewer job, while push counts stay unchanged.

```bash
node scripts/run-vitest.mjs test/scripts/ci-node-test-plan.test.ts
```

The capacity follow-up also passed the staged checks and a fresh whole-PR Codex review at the requested P0 threshold. The original verification/shutdown implementation is unchanged; the additional nine tooling lines only carry the existing capacity requirement into CI stripe formation.

**Migration assessment:** the artifact manifest fields and invocation-directory contract are unchanged. These are disposable, invocation-owned build outputs, not persistent OpenClaw user state; no SQLite schema, durable store, or migration behavior changes.

**Scope and size:** product runtime unchanged; script tooling +27 lines, test-support −15, regression tests +567, docs +6. The remaining tooling growth implements bounded asynchronous reads and distinct native-child versus preparation-request lifetimes, with awaited asynchronous deletion; removing the finish helper, duplicate Vitest scans, global membership caches, and superseded CI layer absorbs the surrounding ownership cleanup.
