### PR TITLE
fix(auth): report order update failure after login

### DIFF
--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -62,11 +62,14 @@ To reduce that, OpenClaw treats the auth profile store as a **token sink**:
 
 ## Storage (where tokens live)
 
-Secrets and auth-routing state live in each agent's canonical SQLite database:
+Credentials use a shared read-through base, while each agent owns its local
+credential overrides and auth-routing state:
 
-- `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite`
-- Credential rows: `auth_profile_store`
-- Order, last-good, cooldown, and usage rows: `auth_profile_state`
+- Shared credentials: `~/.openclaw/state/openclaw.sqlite`
+- Agent-local credentials and state:
+  `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite`
+- Agent credential rows: `auth_profile_store`
+- Agent order, last-good, cooldown, and usage rows: `auth_profile_state`
 
 Older installations may still contain `auth-profiles.json`, `auth-state.json`,
 per-agent `auth.json`, or shared `credentials/oauth.json`. Run
@@ -91,12 +94,12 @@ The database and migration sources respect `$OPENCLAW_STATE_DIR`. Full reference
 
 For static secret refs and runtime snapshot activation behavior, see [Secrets Management](/gateway/secrets).
 
-When a secondary agent has no local auth profile, OpenClaw uses read-through
-inheritance from the default/main agent store; it does not clone the main
-agent's store on read. OAuth refresh tokens are especially sensitive: normal
-copy flows skip them by default because some providers rotate or invalidate
-refresh tokens after use. Configure a separate OAuth login for an agent when
-it needs an independent account.
+When an agent has no local auth profile, OpenClaw reads the shared auth store;
+it does not clone shared credentials into the agent database. OAuth refresh
+tokens are especially sensitive: normal copy flows skip them by default
+because some providers rotate or invalidate refresh tokens after use.
+Configure a separate OAuth login for an agent when it needs an independent
+account.
 
 ## Anthropic Claude CLI reuse
 
@@ -176,10 +179,11 @@ Wizard path is `openclaw onboard` → auth choice `openai`.
 Profiles store an `expires` timestamp. At runtime:
 
 - if `expires` is in the future, use the stored access token
-- if expired, refresh (under a file lock) and overwrite the stored credentials
-- if a secondary agent reads an inherited main-agent OAuth profile, the
-  refresh writes back to the main agent store instead of copying the refresh
-  token into the secondary agent store
+- if expired, refresh under the owning SQLite write transaction and overwrite
+  the stored credentials
+- if an agent reads an OAuth profile from the shared store, the refresh writes
+  back to that shared owner instead of copying the refresh token into the
+  agent store
 - externally managed CLI credentials (Claude CLI, narrow Codex CLI bootstrap;
   see [The token sink](#the-token-sink-why-it-exists)) are re-read instead of
   spending a copied refresh token. If a managed refresh fails, OpenClaw

--- a/docs/help/faq-models.md
+++ b/docs/help/faq-models.md
@@ -477,7 +477,8 @@ Related: [/concepts/oauth](/concepts/oauth) (OAuth flows, token storage, multi-a
     sibling model on the same provider; billing/disabled windows block the
     whole profile.
 
-    Set a per-agent order override (stored in that agent's `auth-state.json`):
+    Set a per-agent order override (stored in that agent's
+    `openclaw-agent.sqlite` database):
 
     ```bash
     # Defaults to the configured default agent (omit --agent)

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -1354,7 +1354,10 @@ describe("promoteAuthProfileInOrder", () => {
         createIfMissing: true,
       });
 
-      expect(updated?.order?.["openai"]).toEqual([newProfileId, staleProfileId]);
+      expect(updated).toMatchObject({
+        ok: true,
+        value: { order: { openai: [newProfileId, staleProfileId] } },
+      });
       expect(loadAuthProfileStoreForRuntime(agentDir).order?.["openai"]).toEqual([
         newProfileId,
         staleProfileId,
@@ -1414,7 +1417,10 @@ describe("promoteAuthProfileInOrder", () => {
         createFromOrder: [backupProfileId, primaryProfileId],
       });
 
-      expect(updated?.order?.["openai"]).toEqual([newProfileId, backupProfileId, primaryProfileId]);
+      expect(updated).toMatchObject({
+        ok: true,
+        value: { order: { openai: [newProfileId, backupProfileId, primaryProfileId] } },
+      });
       expect(loadAuthProfileStoreForRuntime(agentDir).order?.["openai"]).toEqual([
         newProfileId,
         backupProfileId,
@@ -1500,7 +1506,8 @@ describe("promoteAuthProfileInOrder", () => {
         profileId: newProfileId,
       });
 
-      expect(updated?.order?.["openai"]).toBeUndefined();
+      expect(updated).toMatchObject({ ok: true });
+      expect(updated.ok && updated.value.order?.["openai"]).toBeUndefined();
       expect(loadAuthProfileStoreForRuntime(agentDir).order?.["openai"]).toBeUndefined();
     });
   });

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -5,6 +5,7 @@
  */
 import { isDeepStrictEqual } from "node:util";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
@@ -132,10 +133,10 @@ export async function promoteAuthProfileInOrder(params: {
   profileId: string;
   createIfMissing?: boolean;
   createFromOrder?: string[];
-}): Promise<AuthProfileStore | null> {
+}): Promise<Result<AuthProfileStore, "lock-contention">> {
   const providerKey = resolveProviderIdForAuth(params.provider);
   const effectiveStore = ensureAuthProfileStoreForLocalUpdate(params.agentDir);
-  return await updateAuthProfileStoreWithLock({
+  const updated = await updateAuthProfileStoreWithLock({
     agentDir: params.agentDir,
     saveOptions: { preserveOrderProfileIds: [params.profileId, ...(params.createFromOrder ?? [])] },
     updater: (store) => {
@@ -177,6 +178,7 @@ export async function promoteAuthProfileInOrder(params: {
       return true;
     },
   });
+  return updated === null ? err("lock-contention") : ok(updated);
 }
 
 /** Upserts an auth profile immediately into the local store. */

--- a/src/cli/models-cli.auth-login.integration.test.ts
+++ b/src/cli/models-cli.auth-login.integration.test.ts
@@ -1,14 +1,21 @@
 // Exercises the shipped models auth login command across shared credential and local order owners.
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
+import { setAuthProfileOrder } from "../agents/auth-profiles/profiles.js";
+import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
 import { loadAuthProfileStoreForRuntime } from "../agents/auth-profiles/store.js";
+import { testing as authStoreTesting } from "../agents/auth-profiles/store.test-support.js";
 import type { ProviderPlugin } from "../plugins/types.js";
 import { writeConfigMachineState } from "../state/config-machine-state.js";
 import { runRegisteredCli } from "../test-utils/command-runner.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { registerModelsCli } from "./models-cli.js";
+import { defaultRuntime } from "./models-cli.runtime.js";
 
 const FRESH_PROFILE_ID = "openai:fresh-login";
+const ORDER_BUSY_MESSAGE =
+  "The auth profile was saved, but its order could not be updated because the auth store is busy. Wait a moment, then retry the login.";
 const STALE_PROFILE_ID = "openai:stale-login";
 
 const mocks = vi.hoisted(() => ({
@@ -67,8 +74,21 @@ function makeStdinInteractive(): () => void {
 
 describe("models auth login owner integration", () => {
   let restoreStdin: (() => void) | undefined;
+  let lock: DatabaseSync | undefined;
+
+  const releaseLock = () => {
+    authStoreTesting.resetRuntimeSnapshotPublisherForTest();
+    if (lock?.isOpen) {
+      if (lock.isTransaction) {
+        lock.exec("ROLLBACK");
+      }
+      lock.close();
+    }
+    lock = undefined;
+  };
 
   afterEach(() => {
+    releaseLock();
     restoreStdin?.();
     restoreStdin = undefined;
     vi.clearAllMocks();
@@ -102,6 +122,68 @@ describe("models auth login owner integration", () => {
           FRESH_PROFILE_ID,
           STALE_PROFILE_ID,
         ]);
+      },
+    );
+  });
+
+  it("reports partial success when the local order owner is busy", async () => {
+    await withOpenClawTestState(
+      { label: "models-auth-login-order-busy", scenario: "minimal" },
+      async (state) => {
+        await state.writeConfig({
+          agents: { list: [{ id: "main" }] },
+          auth: { order: { openai: [STALE_PROFILE_ID] } },
+        });
+        writeConfigMachineState("auth.sharedStore", { location: "state-db" }, { env: state.env });
+        expect(
+          await setAuthProfileOrder({
+            agentDir: state.agentDir(),
+            provider: "openai",
+            order: [STALE_PROFILE_ID],
+          }),
+        ).not.toBeNull();
+        restoreStdin = makeStdinInteractive();
+        const error = vi.spyOn(defaultRuntime, "error").mockImplementation(() => undefined);
+        const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
+        const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation((code) => {
+          throw new Error(`exit:${code}`);
+        });
+        authStoreTesting.setRuntimeSnapshotPublisherForTest((publish) => {
+          publish();
+          if (lock) {
+            return;
+          }
+          lock = new DatabaseSync(resolveAuthProfileDatabasePath(state.agentDir()));
+          lock.exec("PRAGMA busy_timeout = 0; BEGIN IMMEDIATE;");
+        });
+
+        try {
+          await expect(
+            runRegisteredCli({
+              register: registerModelsCli,
+              argv: ["models", "auth", "login", "--provider", "openai", "--agent", "main"],
+            }),
+          ).rejects.toThrow("exit:1");
+
+          expect(error).toHaveBeenCalledWith(ORDER_BUSY_MESSAGE);
+          expect(exit).toHaveBeenCalledWith(1);
+          expect(log).not.toHaveBeenCalledWith(
+            expect.stringContaining(`Auth profile: ${FRESH_PROFILE_ID}`),
+          );
+          expect(mocks.callGateway).not.toHaveBeenCalled();
+          expect(loadPersistedAuthProfileStore()?.profiles[FRESH_PROFILE_ID]).toMatchObject({
+            type: "oauth",
+            provider: "openai",
+          });
+          expect(loadPersistedAuthProfileStore(state.agentDir())?.order?.openai).toEqual([
+            STALE_PROFILE_ID,
+          ]);
+        } finally {
+          releaseLock();
+          error.mockRestore();
+          log.mockRestore();
+          exit.mockRestore();
+        }
       },
     );
   });

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -498,6 +498,35 @@ describe("modelsAuthLoginCommand", () => {
     });
   });
 
+  it("fails visibly when login cannot update the auth profile order", async () => {
+    const runtime = createRuntime();
+    currentConfig = {
+      auth: {
+        order: {
+          openai: ["openai:old-login"],
+        },
+      },
+    };
+    mocks.promoteAuthProfileInOrder.mockResolvedValueOnce(null);
+
+    await expect(modelsAuthLoginCommand({ provider: "openai" }, runtime)).rejects.toThrow(
+      "The auth profile was saved, but its order could not be updated because the auth store is busy. Wait a moment, then retry the login.",
+    );
+
+    expect(mocks.upsertAuthProfileAfterLoginWithLock).toHaveBeenCalledOnce();
+    expect(mocks.promoteAuthProfileInOrder).toHaveBeenCalledWith({
+      agentDir: "/tmp/openclaw/agents/main",
+      provider: "openai",
+      profileId: "openai:user@example.com",
+      createIfMissing: true,
+      createFromOrder: ["openai:old-login"],
+    });
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalledWith(
+      expect.stringContaining("Auth profile: openai:user@example.com"),
+    );
+  });
+
   it("persists a provider-minted Copilot token through the protected store", async () => {
     const runtime = createRuntime();
     runProviderAuth.mockResolvedValueOnce({

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -383,6 +383,10 @@ describe("modelsAuthLoginCommand", () => {
     mocks.upsertAuthProfileAfterLoginWithLock.mockReset();
     mocks.upsertAuthProfileAfterLoginWithLock.mockResolvedValue(undefined);
     mocks.promoteAuthProfileInOrder.mockReset();
+    mocks.promoteAuthProfileInOrder.mockResolvedValue({
+      ok: true,
+      value: { version: 1, profiles: {} },
+    });
     mocks.removeProviderAuthProfilesWithLock.mockReset();
     mocks.removeProviderAuthProfilesWithLock.mockResolvedValue({ version: 1, profiles: {} });
 
@@ -496,35 +500,6 @@ describe("modelsAuthLoginCommand", () => {
       params: { refresh: true, agentId: "main" },
       timeoutMs: 3000,
     });
-  });
-
-  it("fails visibly when login cannot update the auth profile order", async () => {
-    const runtime = createRuntime();
-    currentConfig = {
-      auth: {
-        order: {
-          openai: ["openai:old-login"],
-        },
-      },
-    };
-    mocks.promoteAuthProfileInOrder.mockResolvedValueOnce(null);
-
-    await expect(modelsAuthLoginCommand({ provider: "openai" }, runtime)).rejects.toThrow(
-      "The auth profile was saved, but its order could not be updated because the auth store is busy. Wait a moment, then retry the login.",
-    );
-
-    expect(mocks.upsertAuthProfileAfterLoginWithLock).toHaveBeenCalledOnce();
-    expect(mocks.promoteAuthProfileInOrder).toHaveBeenCalledWith({
-      agentDir: "/tmp/openclaw/agents/main",
-      provider: "openai",
-      profileId: "openai:user@example.com",
-      createIfMissing: true,
-      createFromOrder: ["openai:old-login"],
-    });
-    expect(mocks.callGateway).not.toHaveBeenCalled();
-    expect(runtime.log).not.toHaveBeenCalledWith(
-      expect.stringContaining("Auth profile: openai:user@example.com"),
-    );
   });
 
   it("persists a provider-minted Copilot token through the protected store", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -452,14 +452,14 @@ async function persistProviderAuthResult(params: {
       throw error;
     }
     persistedProfiles.push(profile);
-    const promoted = await promoteAuthProfileInOrder({
+    const promotion = await promoteAuthProfileInOrder({
       agentDir: params.agentDir,
       provider: profile.credential.provider,
       profileId: profile.profileId,
       createIfMissing: configuredSelection.createIfMissing,
       ...(configuredSelection.order ? { createFromOrder: configuredSelection.order } : {}),
     });
-    if (promoted === null) {
+    if (!promotion.ok) {
       throw new Error(
         "The auth profile was saved, but its order could not be updated because the auth store is busy. Wait a moment, then retry the login.",
       );

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -452,13 +452,18 @@ async function persistProviderAuthResult(params: {
       throw error;
     }
     persistedProfiles.push(profile);
-    await promoteAuthProfileInOrder({
+    const promoted = await promoteAuthProfileInOrder({
       agentDir: params.agentDir,
       provider: profile.credential.provider,
       profileId: profile.profileId,
       createIfMissing: configuredSelection.createIfMissing,
       ...(configuredSelection.order ? { createFromOrder: configuredSelection.order } : {}),
     });
+    if (promoted === null) {
+      throw new Error(
+        "The auth profile was saved, but its order could not be updated because the auth store is busy. Wait a moment, then retry the login.",
+      );
+    }
   }
 
   // Auth login owns the credential store. Keep openclaw.json untouched unless


### PR DESCRIPTION
## What Problem This Solves

Provider login could report success after it saved a credential even when the separate profile-order write lost SQLite lock contention. A stale explicit order could then keep selecting the previous profile.

## Why This Change Was Made

The profile-order owner now returns an explicit binary result. Login treats lock contention as visible partial success before Gateway refresh or final success output.

The valid credential remains saved because the shared credential owner and agent-local order owner use separate SQLite transactions. This change adds no retry, fallback, configuration, schema, protocol, or auth-policy surface.

The same storage review found stale docs that still named retired files and main-agent inheritance. They now describe the shared credential base and agent-local SQLite order owner.

## User Impact

Operators now see that the credential was saved but its order was not updated. The message tells them to wait and retry the login. OpenClaw no longer claims that the new profile is ready while stale order remains active.

## Evidence

- Current-main red at `06f897f562d7e5622d6208ea2819d7e2982832e6`: a real `BEGIN IMMEDIATE` lock held the agent-local database while the shared credential owner stayed writable. Login resolved and printed success, both profiles persisted, and order stayed on the stale profile.
- Exact-head green at `918b316dcff795a3d600208f43b0b400cff45ea7`: the same production login flow retained both profiles, left order unchanged, emitted no success line or Gateway refresh, and returned the actionable partial-success error.
- Anti-cheat retry: after releasing the lock, the same exact-head flow succeeded and persisted the new profile first.
- Regression red/green: the real registered CLI test failed without the result check because the promise resolved. It passes with the fix and verifies the shared credential, unchanged local order, CLI error, and no Gateway refresh.
- Focused tests: CLI `2/2`; auth command `47/47`; auth-profile owner `35/35`.
- Local guards: conflict markers, max-lines ratchet, assertion-safety ratchet, Oxfmt, test temp-path policy, Oxlint, and `git diff --check` pass.
- Codex source check confirmed its CLI prints login success only after credential persistence succeeds. OpenClaw owns the later profile-order phase added here.
- Pre-commit structured Autoreview: clean, no P0 findings.
- The full local changed gate was not run because this host forbids local `tsgo`; exact-head CI owns type-check.
