### PR TITLE
fix(discord): honor reply visibility for session-busy notices

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -257,6 +257,8 @@ Once DMs work, you can turn your server into a full workspace where each channel
 
     If Discord shows typing and the logs show token usage but no posted message, check whether the turn was configured as an ambient room event or opted into message-tool visible replies.
 
+    Session-busy notices also respect this reply policy. For ambient events and message-tool replies, Discord records the failure and suppressed notice in Gateway logs without posting to the room.
+
     <Tabs>
       <Tab title="Ask your agent">
         > "Allow my agent to respond on this server without having to be @mentioned"

--- a/extensions/discord/src/monitor/message-handler.process.abort-retry.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.abort-retry.test.ts
@@ -4,11 +4,13 @@ import {
   BASE_CHANNEL_ROUTE,
   createAutomaticSourceDeliveryContext,
   createBaseContext,
+  createDirectMessageContextOverrides,
   createNoQueuedDispatchResult,
   deliverDiscordReply,
   dispatchInboundMessageForTest as dispatchInboundMessage,
   formatDiscordReplySkip,
   getLastDispatchCtx,
+  getLastDispatchReplyOptions,
   logVerboseForTest as logVerbose,
   recordInboundSessionForTest as recordInboundSession,
   runProcessDiscordMessage,
@@ -115,12 +117,53 @@ describe("processDiscordMessage reply session init conflict retry", () => {
     sleepSpy.mockRestore();
   });
 
-  it("commits replay ownership after a visible terminal failure notice", async () => {
+  it.each([
+    {
+      name: "an automatic group request",
+      visibleReplies: "automatic",
+      inboundEventKind: "user_request",
+      direct: false,
+      expectedMode: "automatic",
+      expectedSends: 1,
+    },
+    {
+      name: "an ambient room event",
+      visibleReplies: "automatic",
+      inboundEventKind: "room_event",
+      direct: false,
+      expectedMode: "message_tool_only",
+      expectedSends: 0,
+    },
+    {
+      name: "a group request requiring the message tool",
+      visibleReplies: "message_tool",
+      inboundEventKind: "user_request",
+      direct: false,
+      expectedMode: "message_tool_only",
+      expectedSends: 0,
+    },
+    {
+      name: "a direct request despite the group message-tool policy",
+      visibleReplies: "message_tool",
+      inboundEventKind: "user_request",
+      direct: true,
+      expectedMode: "automatic",
+      expectedSends: 1,
+    },
+  ] as const)("completes $name with a recorded terminal notice outcome", async (scenario) => {
     const sleepSpy = vi.mocked(sleepWithAbort).mockResolvedValue(undefined);
     const originalError = conflictError();
     dispatchInboundMessage.mockRejectedValue(originalError);
+    const errorLog = vi.fn();
 
-    const ctx = await createBaseContext();
+    const ctx = await createBaseContext({
+      ...(scenario.direct ? createDirectMessageContextOverrides() : {}),
+      inboundEventKind: scenario.inboundEventKind,
+      shouldRequireMention: false,
+      effectiveWasMentioned: scenario.inboundEventKind !== "room_event",
+      cfg: { messages: { groupChat: { visibleReplies: scenario.visibleReplies } } },
+      runtime: { log: vi.fn(), error: errorLog },
+    });
     await expect(runProcessDiscordMessage(ctx)).resolves.toBeUndefined();
 
     expect(dispatchInboundMessage).toHaveBeenCalledTimes(4);
@@ -128,10 +171,33 @@ describe("processDiscordMessage reply session init conflict retry", () => {
     expect(sleepSpy).toHaveBeenNthCalledWith(1, 250, undefined);
     expect(sleepSpy).toHaveBeenNthCalledWith(2, 1_000, undefined);
     expect(sleepSpy).toHaveBeenNthCalledWith(3, 2_500, undefined);
-    expectFreshFinalText(
-      "⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.",
+    expect(getLastDispatchReplyOptions()?.sourceReplyDeliveryMode).toBe(scenario.expectedMode);
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(scenario.expectedSends);
+    expect(errorLog).toHaveBeenCalledExactlyOnceWith(
+      expect.stringContaining(
+        `terminal notice ${scenario.expectedSends === 1 ? "delivered" : "suppressed"}`,
+      ),
     );
+    if (scenario.expectedSends === 1) {
+      expectFreshFinalText(
+        "⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.",
+      );
+    }
     sleepSpy.mockRestore();
+  });
+
+  it("records downstream suppression without claiming its terminal notice was delivered", async () => {
+    dispatchInboundMessage.mockRejectedValue(conflictError());
+    deliverDiscordReply.mockResolvedValueOnce({ visibleReplySent: false });
+    const errorLog = vi.fn();
+    const ctx = await createBaseContext({ runtime: { log: vi.fn(), error: errorLog } });
+
+    await expect(runProcessDiscordMessage(ctx)).resolves.toBeUndefined();
+
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(errorLog).toHaveBeenCalledExactlyOnceWith(
+      expect.stringContaining("terminal notice suppressed"),
+    );
   });
 
   it("keeps exhaustion retryable when the visible failure notice cannot land", async () => {
@@ -157,8 +223,7 @@ describe("processDiscordMessage reply session init conflict retry", () => {
 
   it("rebuilds a released replay without duplicating its pending history", async () => {
     const sleepSpy = vi.mocked(sleepWithAbort).mockResolvedValue(undefined);
-    dispatchInboundMessage.mockRejectedValue(conflictError());
-    deliverDiscordReply.mockRejectedValueOnce(new Error("Discord unavailable"));
+    dispatchInboundMessage.mockRejectedValueOnce(new Error("dispatch failed before completion"));
     const guildHistories = new Map();
     const createReplayContext = () =>
       createBaseContext({

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -693,8 +693,9 @@ async function processDiscordMessageInner(
       return;
     }
     dispatchError = true;
-    const conflictCompleted = await completeDiscordSessionConflict(
+    const conflictOutcome = await completeDiscordSessionConflict(
       err,
+      sourceReplyDeliveryMode,
       (payload, info) =>
         deliverDiscordPayload(payload, {
           ...info,
@@ -703,8 +704,12 @@ async function processDiscordMessageInner(
         }),
       onDiscordDeliveryError,
     );
-    if (conflictCompleted) {
-      // The visible terminal notice owns this event, so replay can commit.
+    if (conflictOutcome) {
+      runtime.error(
+        `discord: reply session init conflict exhausted; terminal notice ${conflictOutcome} ` +
+          `(sourceReplyDeliveryMode=${sourceReplyDeliveryMode}, message=${message.id}, session=${persistedSessionKey})`,
+      );
+      // Both a delivered notice and recorded policy suppression consume the event.
       return;
     }
     throw err;

--- a/extensions/discord/src/monitor/message-handler.retry.ts
+++ b/extensions/discord/src/monitor/message-handler.retry.ts
@@ -1,3 +1,5 @@
+import type { SourceReplyDeliveryMode } from "openclaw/plugin-sdk/reply-runtime";
+
 const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /^reply session initialization conflicted for \S+$/u;
 const DISCORD_SESSION_CONFLICT_FAILURE_TEXT =
   "⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.";
@@ -5,28 +7,28 @@ const DISCORD_SESSION_CONFLICT_FAILURE_TEXT =
 type TerminalFailureDelivery = (
   payload: { text: string; isError: true },
   info: { kind: "final" },
-) => Promise<unknown>;
+) => Promise<{ visibleReplySent: boolean }>;
 type DeliveryErrorHandler = (error: unknown, info: { kind: string }) => void;
-
-function isReplySessionInitConflictError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(message);
-}
 
 export async function completeDiscordSessionConflict(
   error: unknown,
+  sourceReplyDeliveryMode: SourceReplyDeliveryMode,
   deliver: TerminalFailureDelivery,
   onDeliveryError: DeliveryErrorHandler,
-): Promise<boolean> {
-  if (!isReplySessionInitConflictError(error)) {
-    return false;
+): Promise<"delivered" | "suppressed" | undefined> {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(message)) {
+    return undefined;
+  }
+  if (sourceReplyDeliveryMode === "message_tool_only") {
+    return "suppressed";
   }
   try {
-    await deliver(
+    const result = await deliver(
       { text: DISCORD_SESSION_CONFLICT_FAILURE_TEXT, isError: true },
       { kind: "final" },
     );
-    return true;
+    return result.visibleReplySent ? "delivered" : "suppressed";
   } catch (deliveryError) {
     // Keep the conflict retryable when its visible terminal notice cannot land.
     onDeliveryError(deliveryError, { kind: "final" });


### PR DESCRIPTION
Closes #135442

## What Problem This Solves

Fixes an issue where operators using Discord ambient room events or message-tool visible replies could receive unsolicited session-busy warnings after session initialization exhausted its retries. The normal reply path respected the selected visibility policy, but the terminal conflict notice bypassed it.

## Why This Change Was Made

The existing Discord conflict-completion owner now consumes the prepared source reply mode and returns a delivered or suppressed outcome. Its caller records the exhausted conflict and outcome before the ingress owner settles the event. A failed allowed notice still throws so the existing ingress retry can recover it; downstream suppression is recorded accurately too.

This removes the one-use conflict-classification wrapper and replaces the old boolean completion assumption with an explicit outcome. Production changes are +21/-14 (net +7), covering the policy input and terminal outcome record; tests are +71/-6 and docs +2. The repair adds no configuration, schema, or retry policy.

## User Impact

Ambient and message-tool-only turns remain quiet when their session stays busy, with an explicit failure and suppression record in Gateway logs. Automatic replies retain the existing visible session-busy warning. Both handled outcomes complete ingress processing, while an allowed notice that fails to send remains retryable.

## Evidence

- Pre-fix source probe: two automatic controls passed; ambient and configured message-tool-only groups each incorrectly posted one notice (two failures). The relevant production files were byte-identical at the implementation base.
- Focused owner and sibling coverage: 47 distinct cases passed across abort/retry, room events, run-queue behavior, and durable ingress recovery. The corrected abort/retry file passed 11/11 with wrapper exit 0. Its original replay-history assertions remain intact, using a dispatch failure to release the quiet event.
- Mock-Gateway channel proof: all five scenarios passed, wrapper exit 0 in 169.624s. An actual built ephemeral Gateway connected to Crabline's local Discord REST/WebSocket server and the QA mock provider. A test-only, hash-pinned Node load hook forced the existing session-initialization CAS conflict for named synthetic sessions; error creation, bounded retries, Discord delivery, and durable ingress stayed real. Both quiet cases completed with zero posts. The direct control posted once. Three injected HTTP 503s left the failed notice pending; the existing ingress retry then posted exactly once. A later normal provider turn replied successfully. All owned services stopped cleanly, and source hashes matched before and after.
- Fixture isolation uses the existing `joinIntro: false` option to keep the separate fresh-guild welcome turn out of the provider-count assertion. Test-only endpoint adapters route Discord REST and the WebSocket handshake to loopback; the fixture rejects other TCP destinations. The production Gateway build is unchanged by the harness.
- Canonical private QA runtime build passed: `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build sourcePerformance` (exit 0). The reviewed working-tree patch was tested on base `91067e340a1811f94a3f119fae329542c3f23872`; its diff SHA-256 is `5b2ce2bbc72d6b5124b5bbc072d878de091c639b21c51979e5c5e534c773b51e`.
- Canonical changed-code gate passed (exit 0): production/test extension types, focused lint and formatting, five Doctor-contract tests, plugin boundaries, unused exports, storage/media/sidecar guards, and zero runtime import cycles. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33544104488) passed at `86e273da9ddcbad764efb9eb89c5944844aae3dd`.
- Independent Codex review through P1: clean, no actionable findings.

```json
{
  "kind": "discord-conflict-visibility-mock-gateway",
  "status": "pass",
  "gateway": "actual ephemeral built Gateway",
  "channel": { "driver": "crabline", "live": false },
  "provider": { "fixture": "mock-openai", "live": false },
  "cases": [
    { "name": "ambient-room-event", "casConflicts": 40, "messagePosts": 0, "outcome": "suppressed", "ingress": "completed" },
    { "name": "mentioned-message-tool-group", "casConflicts": 40, "messagePosts": 0, "outcome": "suppressed", "ingress": "completed" },
    { "name": "direct-automatic-notice", "casConflicts": 40, "messagePosts": 1, "outcome": "delivered", "ingress": "completed" },
    { "name": "failed-direct-notice-retry", "casConflicts": 80, "failedPosts": 3, "retryPendingObserved": true, "messagePosts": 1, "ingress": "completed" },
    { "name": "normal-provider-turn-after-conflicts", "providerRequests": 1, "reply": "DISCORD_CONFLICT_RECOVERED", "ingress": "completed" }
  ],
  "cleanup": "all owned services confirmed stopped",
  "sourceHashesUnchanged": true
}
```

Related work: #109902 addresses the shared conflict classifier; #121204 addresses stale ambient backlog ordering. Neither changes this terminal-notice visibility boundary.
