### PR TITLE
fix(llama-cpp): discover models behind web app endpoints

### DIFF
--- a/extensions/llama-cpp/src/external-server/discovery.test.ts
+++ b/extensions/llama-cpp/src/external-server/discovery.test.ts
@@ -91,6 +91,48 @@ describe("llama-server discovery projection", () => {
   });
 
   it.each([
+    { name: "HTML app shell", body: "<!doctype html><html><body>Local model app</body></html>" },
+    { name: "non-model JSON", body: JSON.stringify({ app: "local-models" }) },
+  ])("discovers an existing server behind a root $name response", async ({ body }) => {
+    const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/provider-setup")>(
+      "openclaw/plugin-sdk/provider-setup",
+    );
+    discoverRowsMock.mockImplementation(actual.discoverOpenAICompatibleLocalModels);
+    const requests: string[] = [];
+    const server = createServer((request, response) => {
+      requests.push(request.url ?? "");
+      if (request.url === "/models") {
+        response.end(body);
+      } else if (request.url === "/v1/models") {
+        response.setHeader("Content-Type", "application/json");
+        response.end(JSON.stringify({ data: [{ id: "local-model", object: "model" }] }));
+      } else {
+        response.end("{}");
+      }
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected a listening TCP server");
+      }
+      await expect(
+        discoverLlamaServer({ baseUrl: `http://127.0.0.1:${address.port}`, cacheTtlMs: 0 }),
+      ).resolves.toMatchObject({
+        kind: "success",
+        models: [{ config: { id: "local-model" } }],
+      });
+      expect(requests).toEqual(["/health", "/models", "/v1/models", "/props"]);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it.each([
     { name: "API key", access: { apiKey: "endpoint-key" } },
     { name: "authorization header", access: { headers: { Authorization: "Bearer endpoint-key" } } },
     { name: "explicit refresh", access: { cacheTtlMs: 0 } },

--- a/src/plugins/provider-self-hosted-discovery.test.ts
+++ b/src/plugins/provider-self-hosted-discovery.test.ts
@@ -80,6 +80,7 @@ describe("discoverOpenAICompatibleLocalModels raw discovery", () => {
 
     fetchWithSsrFGuardMock
       .mockResolvedValueOnce(guarded(new Response(null, { status: 200 })))
+      .mockResolvedValueOnce(guarded(new Response("<html></html>", { status: 200 })))
       .mockResolvedValueOnce(guarded(new Response("{", { status: 200 })));
     await expect(
       discoverOpenAICompatibleLocalModels({
@@ -89,7 +90,21 @@ describe("discoverOpenAICompatibleLocalModels raw discovery", () => {
         modelsPathOrder: "server-first",
         rawResult: true,
       }),
-    ).resolves.toMatchObject({ kind: "invalid-response", path: "/models" });
+    ).resolves.toMatchObject({ kind: "invalid-response", path: "/v1/models" });
+  });
+
+  it.each([401, 403, 503])("keeps root model-list HTTP %s failures terminal", async (status) => {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce(guarded(new Response(null, { status })));
+
+    await expect(
+      discoverOpenAICompatibleLocalModels({
+        baseUrl: "http://127.0.0.1:8080/v1",
+        label: "llama-server",
+        modelsPathOrder: "server-first",
+        rawResult: true,
+      }),
+    ).resolves.toEqual({ kind: "http-error", path: "/models", status });
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
   });
 
   it("probes only available router models without autoloading", async () => {

--- a/src/plugins/provider-self-hosted-discovery.ts
+++ b/src/plugins/provider-self-hosted-discovery.ts
@@ -1,4 +1,4 @@
-import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { asOptionalRecord, isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { isNonSecretApiKeyMarker } from "../agents/model-auth-markers.js";
 import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
@@ -143,10 +143,7 @@ function readDiscoveryRows(body: unknown): Record<string, unknown>[] {
   if (!Array.isArray(bodyRecord?.data)) {
     throw new Error("model list must contain data[]");
   }
-  return bodyRecord.data.flatMap((entry) => {
-    const row = asOptionalRecord(entry);
-    return row ? [row] : [];
-  });
+  return bodyRecord.data.filter(isRecord);
 }
 
 function shouldProbeRuntimeProps(model: Record<string, unknown>): boolean {
@@ -219,11 +216,12 @@ async function discoverOpenAICompatibleModelRows(params: {
           { path: "/v1/models", url: `${inferenceBaseUrl}/models` },
         ]
       : [{ path: "/v1/models", url: `${inferenceBaseUrl}/models` }];
-  let modelsPath = modelCandidates[0]?.path ?? "/v1/models";
-  let modelsResult: DiscoveryResponse | undefined;
-  for (const [index, candidate] of modelCandidates.entries()) {
-    modelsPath = candidate.path;
-    modelsResult = await fetchSelfHostedDiscoveryJson({
+  let modelList:
+    | { kind: "success"; models: Record<string, unknown>[] }
+    | Exclude<OpenAICompatibleModelDiscoveryResult, { kind: "success" }>
+    | undefined;
+  for (const candidate of modelCandidates) {
+    const result = await fetchSelfHostedDiscoveryJson({
       url: candidate.url,
       origin,
       apiKey: params.apiKey,
@@ -234,30 +232,33 @@ async function discoverOpenAICompatibleModelRows(params: {
       readBody: true,
       label: params.label,
     });
+    if (result.kind === "unreachable") {
+      return result;
+    }
+    if (result.kind === "invalid-response") {
+      modelList = { ...result, path: candidate.path };
+    } else if (!result.ok) {
+      modelList = { kind: "http-error", path: candidate.path, status: result.status };
+    } else {
+      try {
+        modelList = { kind: "success", models: readDiscoveryRows(result.body) };
+      } catch (error) {
+        modelList = { kind: "invalid-response", path: candidate.path, error };
+      }
+    }
+    // A root endpoint may serve a web app instead of a model list. Try the
+    // inference endpoint, while keeping auth and service failures terminal.
     if (
-      modelsResult.kind !== "response" ||
-      modelsResult.status !== 404 ||
-      index === modelCandidates.length - 1
+      modelList.kind === "success" ||
+      (modelList.kind === "http-error" && modelList.status !== 404)
     ) {
       break;
     }
   }
-  if (!modelsResult || modelsResult.kind === "unreachable") {
-    return modelsResult ?? { kind: "unreachable", error: new Error("missing model response") };
+  if (!modelList || modelList.kind !== "success") {
+    return modelList ?? { kind: "unreachable", error: new Error("missing model response") };
   }
-  if (modelsResult.kind === "invalid-response") {
-    return { ...modelsResult, path: modelsPath };
-  }
-  if (!modelsResult.ok) {
-    return { kind: "http-error", path: modelsPath, status: modelsResult.status };
-  }
-
-  let models: Record<string, unknown>[];
-  try {
-    models = readDiscoveryRows(modelsResult.body);
-  } catch (error) {
-    return { kind: "invalid-response", path: modelsPath, error };
-  }
+  const { models } = modelList;
   const rows: OpenAICompatibleModelDiscoveryRow[] = models.map((model) => ({ model }));
   if (params.discoverRuntimeContext !== false) {
     const routerMode =


### PR DESCRIPTION
Closes #135361.

Completes the repair proposed in #135376. Thanks @gaoanze888 for the initial model-discovery fix and @Bloodis94 for reporting the setup failure.

## What Problem This Solves

Fixes an issue where users connecting an existing llama.cpp-compatible server could not finish model discovery when the server's root `/models` URL served a web frontend or another non-model response. A working OpenAI-compatible `/v1/models` endpoint was never reached.

## Why This Change Was Made

The shared discovery owner now validates each candidate before selecting it. Both invalid JSON, including HTML app shells, and JSON without a model list advance to the existing `/v1/models` candidate. Transport failures and HTTP errors other than 404 remain terminal. Each response is parsed once, and the existing bounded reader, credential precedence, and SSRF policy are preserved.

This is a maintainer-owned replacement for #135376: that candidate handled valid JSON without `data[]`, but still stopped before retrying when root `/models` returned HTML. The historical Unsloth frontend actually served that HTML shape. No new configuration or provider-specific branch is added.

## User Impact

Existing-server discovery can select the configured endpoint's models even when its root URL belongs to a web app. Valid native llama-server catalogs continue to take precedence, and authorization or service errors remain visible instead of being bypassed.

## Evidence

- Pre-fix real HTTP regression: both new plugin-boundary cases failed with `invalid-response` at `/models`; the other five plugin cases passed.
- Focused owner, generic self-hosted, and llama.cpp discovery coverage: `node scripts/run-vitest.mjs src/plugins/provider-self-hosted-discovery.test.ts src/plugins/provider-self-hosted-setup.test.ts extensions/llama-cpp/src/external-server/discovery.test.ts` — 60 passed. Coverage includes root 404, valid root catalogs, 401/403/503 termination, malformed final responses, response-size limits, credential precedence, and router-property probe bounds.
- Upstream route proof used the unchanged `setup_frontend` function from [Unsloth's pre-fix source](https://github.com/unslothai/unsloth/blob/da3c85c05f990f2cfab6cceefcf51ba1f6c0d762/studio/backend/main.py#L2475) in an isolated FastAPI 0.141.1 / Starlette 1.6.0 / Uvicorn 0.52.4 server with a synthetic `/v1/models` catalog. Before: `/health` and `/models` returned HTML 200; discovery stopped at `/models`. After: discovery requested `/v1/models`, received JSON 200, and returned `local-model`. The real llama.cpp `prepareLlamaServerSetup` entry point then returned `llama-cpp/local-model` and its provider configuration.
- That proof exercises the upstream frontend route and OpenClaw's actual HTTP/discovery/setup boundaries. It is not a full Unsloth installation or model inference test, and the reporter's exact Unsloth build was not supplied. Upstream subsequently changed these root probes to 404 in [Unsloth #10037](https://github.com/unslothai/unsloth/commit/640f0dbe225d28e91c7837b62537dea482d222c2).
- Production delta: +29/-28, net +1; tests: +58/-1. Response validation moves into the existing selection loop; the small remainder represents the typed validated-or-error selection state.
- `git diff --check`, formatting, and the complete changed-file gate pass, including core/extension test types, lint, unused-export scans, and runtime import checks. The first run stopped on an unrelated test typing error; after refreshing onto main containing merged #135407, the full gate and all 60 focused tests pass with identical repair source.
- Independent managed review: scoped clean at P0. The maintainer also inspected the shared owner, plugin caller/model/endpoint code, changed tests, upstream route and before/after receipts directly; no actionable findings remain.
