### PR TITLE
refactor(config): remove refresh error formatter plumbing

### DIFF
--- a/src/config/io.runtime.ts
+++ b/src/config/io.runtime.ts
@@ -324,7 +324,6 @@ export async function writeConfigFile(
         runtimePreflightResult = await preflightRuntimeSnapshotWrite({
           nextSourceConfig: sourceConfig,
           refreshOptions: options.runtimeRefresh,
-          formatRefreshError: (error) => formatErrorMessage(error),
           createRefreshError: (detail, cause) =>
             new ConfigRuntimeRefreshError(
               `Config write blocked before committing ${io.configPath}: active SecretRef resolution failed: ${detail}`,
@@ -484,7 +483,6 @@ async function finalizeCommittedConfigWrite(params: {
       hadBothSnapshots: params.hadBothSnapshots,
       loadFreshConfig: () => io.loadConfig(),
       notifyCommittedWrite,
-      formatRefreshError: (error) => formatErrorMessage(error),
       preflightResult: params.runtimePreflightResult,
       deferRuntimeActivation,
       createRefreshError: (detail, cause) =>

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -430,7 +430,6 @@ export async function writeConfigFileFromContext(
       await preflightRuntimeSnapshotWrite({
         nextSourceConfig: sourceConfig,
         refreshOptions: options.runtimeRefresh,
-        formatRefreshError: (error) => formatErrorMessage(error),
         createRefreshError: (detail, cause) =>
           new ConfigRuntimeRefreshError(
             `Config write blocked before committing ${configPath}: active SecretRef resolution failed: ${detail}`,

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -819,7 +819,6 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
     runtimePreflightResult = await preflightRuntimeSnapshotWrite({
       nextSourceConfig: runtimeConfigToWrite,
       refreshOptions: params.writeOptions?.runtimeRefresh,
-      formatRefreshError: (error) => formatErrorMessage(error),
       createRefreshError: (detail, cause) =>
         new Error(
           `Config write blocked before committing ${includePath}: active SecretRef resolution failed: ${detail}`,
@@ -941,7 +940,6 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
       notifyCommittedWrite,
       preflightResult: runtimePreflightResult,
       deferRuntimeActivation,
-      formatRefreshError: (error) => formatErrorMessage(error),
       createRefreshError: (detail, cause) =>
         new Error(
           `Config was written to ${params.snapshot.path}, but runtime snapshot refresh failed: ${detail}`,
@@ -1065,7 +1063,6 @@ async function replaceConfigFileUnlocked(params: {
         await preflightRuntimeSnapshotWrite({
           nextSourceConfig: sourceConfig,
           refreshOptions: fallbackWriteOptions.runtimeRefresh,
-          formatRefreshError: (error) => formatErrorMessage(error),
           createRefreshError: (detail, cause) =>
             new Error(
               `Config write blocked before committing ${snapshot.path}: active SecretRef resolution failed: ${detail}`,

--- a/src/config/runtime-snapshot.test.ts
+++ b/src/config/runtime-snapshot.test.ts
@@ -213,7 +213,6 @@ describe("runtime snapshot state", () => {
       hadBothSnapshots: true,
       loadFreshConfig,
       notifyCommittedWrite,
-      formatRefreshError: (error) => String(error),
       createRefreshError: (detail, cause) => new Error(detail, { cause }),
     });
 
@@ -235,7 +234,6 @@ describe("runtime snapshot state", () => {
       hadBothSnapshots: false,
       loadFreshConfig,
       notifyCommittedWrite,
-      formatRefreshError: (error) => String(error),
       createRefreshError: (detail, cause) => new Error(detail, { cause }),
     });
 
@@ -276,7 +274,6 @@ describe("runtime snapshot state", () => {
       hadBothSnapshots: true,
       loadFreshConfig,
       notifyCommittedWrite,
-      formatRefreshError: (error) => String(error),
       createRefreshError: (detail, cause) => new Error(detail, { cause }),
     });
 
@@ -380,7 +377,6 @@ describe("runtime snapshot state", () => {
       loadFreshConfig,
       notifyCommittedWrite,
       deferRuntimeActivation: true,
-      formatRefreshError: (error) => String(error),
       createRefreshError: (detail, cause) => new Error(detail, { cause }),
     });
 

--- a/src/config/runtime-snapshot.ts
+++ b/src/config/runtime-snapshot.ts
@@ -1,5 +1,6 @@
 // Produces redacted runtime config snapshots for diagnostics and UI surfaces.
 import { sha256Base64Url } from "../infra/crypto-digest.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { clearExecutablePathCache } from "../infra/executable-path.js";
 import {
   resetPublishedConfigRuntimeEnv,
@@ -414,7 +415,6 @@ export async function preflightRuntimeSnapshotWrite(params: {
   nextSourceConfig: OpenClawConfig;
   refreshOptions?: RuntimeConfigSnapshotRefreshOptions;
   createRefreshError: (detail: string, cause: unknown) => Error;
-  formatRefreshError: (error: unknown) => string;
 }): Promise<unknown> {
   const refreshHandler = getRuntimeConfigSnapshotRefreshHandler();
   if (!refreshHandler?.preflight) {
@@ -426,7 +426,7 @@ export async function preflightRuntimeSnapshotWrite(params: {
       ...params.refreshOptions,
     });
   } catch (error) {
-    throw params.createRefreshError(params.formatRefreshError(error), error);
+    throw params.createRefreshError(formatErrorMessage(error), error);
   }
 }
 
@@ -438,7 +438,6 @@ export async function finalizeRuntimeSnapshotWrite(params: {
   loadFreshConfig: () => OpenClawConfig;
   notifyCommittedWrite: () => void;
   createRefreshError: (detail: string, cause: unknown) => Error;
-  formatRefreshError: (error: unknown) => string;
   preflightResult?: unknown;
   deferRuntimeActivation?: boolean;
 }): Promise<void> {
@@ -464,7 +463,7 @@ export async function finalizeRuntimeSnapshotWrite(params: {
       } catch {
         // Keep the original refresh failure as the surfaced error.
       }
-      throw params.createRefreshError(params.formatRefreshError(error), error);
+      throw params.createRefreshError(formatErrorMessage(error), error);
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Runtime config snapshot refresh errors were formatted through a caller-supplied callback even though every production caller supplied the same canonical `formatErrorMessage` implementation. This left duplicated plumbing across the config write and mutation paths and obscured ownership of refresh error formatting.

## Why This Change Was Made

The runtime snapshot owner now formats caught refresh and preflight errors directly with `formatErrorMessage`. The caller-owned `createRefreshError` factories remain unchanged, preserving each path's exact error class, message, config path, and `{ cause: error }`.

Removed path: `formatRefreshError` from `preflightRuntimeSnapshotWrite`, `finalizeRuntimeSnapshotWrite`, all production call sites, and their behavior-level test setup. No config, SDK, protocol, persistence, or error-contract surface changed.

Judged LOC:

- production: +3 / -10, net -7
- tests: +0 / -4, net -4

## User Impact

No user-visible behavior changes. Config write failures retain the same messages, error classes, causes, rollback behavior, and owner-specific context with less duplicated internal plumbing.

## Evidence

- Local focused behavior: 240 tests passed across `src/config/runtime-snapshot.test.ts`, `src/config/io.write-config.test.ts`, `src/config/io.write-reread.test.ts`, `src/config/mutate.test.ts`, and `src/infra/errors.test.ts`.
- Local import-cycle check: 0 runtime value cycles.
- Local formatting and `git diff --check`: passed.
- Blacksmith Testbox via Crabbox: `tbx_01m1f39k0j1p8hrp1zta2byccx`, https://github.com/openclaw/openclaw/actions/runs/33543191306
  - The same focused behavior passed: 240 tests.
  - Import-cycle check passed: 0 runtime value cycles.
  - The later `check-changed` core-test typecheck failed in unchanged `src/cli/models-cli.auth-login.integration.test.ts:63`; that failure was fixed by #135407 and this branch was then rebased onto the fixing `main` commit.
- Autoreview: scoped-clean, patch correct at 0.99 confidence, no accepted/actionable findings.
- Codex hard gate personally inspected at sibling Codex `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; no protocol or runtime dependency applies.
- Test audit: the changed test file only removes obsolete constructor arguments; no assertion, fixture, behavior coverage, or test-only production seam was added.
