### PR TITLE
fix: preserve explicit fleet diagnostic ownership

### DIFF
--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -67,6 +67,9 @@ and `openclaw memory status --deep`.
   until cleared.
 - Output includes per-agent session stores when multiple agents are
   configured.
+- Fleet status works without a System Agent owner. Pending events include each
+  agent's main queue; a shared global queue is counted once. `--agent` selects
+  credentials only for `--usage`.
 
 ## Usage and quota
 

--- a/src/agents/tools/system-agent-tool.ts
+++ b/src/agents/tools/system-agent-tool.ts
@@ -26,6 +26,8 @@ import { stringEnum } from "../schema/typebox.js";
 import { textResult, ToolInputError, readToolStringParam, type AnyAgentTool } from "./common.js";
 
 export type SystemAgentToolOptions = {
+  /** Verified inference owner, distinct from the internal OpenClaw execution agent. */
+  agentId?: string;
   /** Where setup side effects run; the gateway surface never manages its own daemon. */
   surface: "cli" | "gateway";
   /** Delegated proposals require operator UI approval, never a chat reply. */
@@ -482,7 +484,13 @@ export function createSystemAgentTool(options: SystemAgentToolOptions): AnyAgent
       try {
         await executeSystemAgentOperation(operation, capture, {
           approved: false,
-          deps: { setupSurface: options.surface },
+          deps: {
+            setupSurface: options.surface,
+            loadOverview: async () =>
+              (await import("../../system-agent/overview.js")).loadSystemAgentOverview({
+                agentId: options.agentId,
+              }),
+          },
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -55,25 +55,7 @@ const statusSummaryMocks = vi.hoisted(() => ({
   getInspectableTaskRegistrySummary: vi.fn(
     (_tasks?: TaskRecord[]) => statusSummaryMocks.taskRegistrySummary,
   ),
-  taskAuditFindings: [
-    {
-      severity: "warn",
-      code: "delivery_failed",
-      detail: "terminal update delivery failed",
-      task: {
-        taskId: "task-delivery",
-        runtime: "subagent",
-        ownerKey: "agent:main:main",
-        requesterSessionKey: "agent:main:main",
-        scopeKind: "session",
-        task: "Deliver update",
-        status: "failed",
-        deliveryStatus: "failed",
-        notifyPolicy: "done_only",
-        createdAt: 1,
-      },
-    },
-  ] as TaskAuditFinding[],
+  taskAuditFindings: [] as TaskAuditFinding[],
   getInspectableTaskAuditFindings: vi.fn(
     (_tasks?: TaskRecord[]) => statusSummaryMocks.taskAuditFindings,
   ),
@@ -236,6 +218,7 @@ vi.mock("../status/link-channel.js", () => ({
 const { buildChannelSummary } = await import("../infra/channel-summary.js");
 const { resolveSessionStorePathCore } = await import("../config/sessions/paths.js");
 const { listGatewayAgentsBasic } = await import("../gateway/agent-list.js");
+const { peekSystemEvents } = await import("../infra/system-events.js");
 const { resolveLinkChannelContext } = await import("../status/link-channel.js");
 let getStatusSummary: typeof import("../status/summary.js").getStatusSummary;
 let statusSummaryRuntime: typeof import("../status/summary.runtime.js").statusSummaryRuntime;
@@ -287,6 +270,7 @@ describe("getStatusSummary", () => {
           : undefined,
     );
     statusSummaryMocks.listSessionEntriesCore.mockReturnValue([]);
+    vi.mocked(peekSystemEvents).mockReset().mockReturnValue([]);
     statusSummaryMocks.loadExactSessionEntryReadOnly.mockImplementation(({ sessionKey }) => {
       const entry = statusSummaryMocks
         .listSessionEntriesCore()
@@ -318,6 +302,42 @@ describe("getStatusSummary", () => {
     setSessions: (store) =>
       statusSummaryMocks.listSessionEntriesCore.mockReturnValue(toSessionEntrySummaries(store)),
   });
+
+  it.each(["per-sender", "global"] as const)(
+    "summarizes every configured agent's pending events without an ambient owner (%s)",
+    async (scope) => {
+      const agents = [{ id: "research" }, { id: "ops" }];
+      vi.mocked(listGatewayAgentsBasic).mockReturnValue({
+        defaultId: "research",
+        mainKey: "inbox",
+        scope,
+        agents,
+        ownership: "explicit",
+        selectionRequired: true,
+      });
+      vi.mocked(peekSystemEvents).mockImplementation((key) => [`pending: ${key}`]);
+
+      const summary = await getStatusSummary({
+        config: {
+          agents: {
+            ownership: "explicit",
+            entries: { research: {}, ops: {} },
+            defaults: { heartbeat: { agentId: "ops", every: "0m" } },
+          },
+          session: { scope, mainKey: "inbox" },
+        },
+        includeSensitive: false,
+        includeChannelSummary: false,
+      });
+
+      expect(summary.sessions.byAgent.map((agent) => agent.agentId)).toEqual(["research", "ops"]);
+      expect(summary.queuedSystemEvents).toEqual(
+        scope === "global"
+          ? ["pending: global"]
+          : ["pending: agent:research:inbox", "pending: agent:ops:inbox"],
+      );
+    },
+  );
 
   it.each([true, false])(
     "keeps public summary fields with includeSensitive=%s",

--- a/src/mcp/openclaw-tools-serve-config.ts
+++ b/src/mcp/openclaw-tools-serve-config.ts
@@ -134,7 +134,9 @@ export function buildSystemAgentToolsMcpServerConfig(
     mcpServers: {
       openclaw: {
         command: entry.command,
-        args: entry.args,
+        args: options.agentId
+          ? [...entry.args, "--openclaw-agent-id", options.agentId]
+          : entry.args,
         env: {
           [OPENCLAW_TOOLS_MCP_TOOLS_ENV]: "openclaw" satisfies OpenClawToolsMcpToolId,
           [OPENCLAW_TOOLS_MCP_SYSTEM_AGENT_SURFACE_ENV]: options.surface,

--- a/src/mcp/openclaw-tools-serve.test.ts
+++ b/src/mcp/openclaw-tools-serve.test.ts
@@ -1,6 +1,7 @@
 // OpenClaw MCP tools tests cover core tool server startup and registration.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { hashSystemAgentOperation } from "../system-agent/operator-approval.js";
+import { resolveToolsMcpAgentId } from "./agent-session-env.js";
 import {
   buildSystemAgentToolsMcpServerConfig,
   OPENCLAW_TOOLS_MCP_SYSTEM_AGENT_APPROVAL_ARMED_ENV,
@@ -16,6 +17,45 @@ import {
   resolveOpenClawToolsMcpAgentSessionKey,
 } from "./openclaw-tools-serve.js";
 import { createPluginToolsMcpHandlers } from "./plugin-tools-handlers.js";
+
+vi.mock("../system-agent/overview.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../system-agent/overview.js")>();
+  const config = {
+    agents: {
+      ownership: "explicit" as const,
+      entries: {
+        work: { model: "openai/gpt-5.6-luna" },
+        other: { model: "example/other" },
+      },
+    },
+    gateway: { port: 1 },
+  };
+  return {
+    ...actual,
+    loadSystemAgentOverview: (options?: Parameters<typeof actual.loadSystemAgentOverview>[0]) =>
+      actual.loadSystemAgentOverview({
+        ...options,
+        deps: {
+          readConfigFileSnapshot: async () => ({
+            path: "/tmp/openclaw-mcp-owner.json",
+            exists: true,
+            valid: true,
+            raw: null,
+            parsed: config,
+            sourceConfig: config,
+            resolved: config,
+            runtimeConfig: config,
+            config,
+            issues: [],
+            warnings: [],
+            legacyIssues: [],
+          }),
+          probeLocalCommand: async (command) => ({ command, found: false }),
+          probeGatewayUrl: async (url) => ({ url, reachable: false }),
+        },
+      }),
+  };
+});
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -73,6 +113,23 @@ describe("OpenClaw tools MCP server", () => {
 
     const listed = await handlers.listTools();
     expect(listed.tools.map((tool) => tool.name)).toEqual(["openclaw"]);
+  });
+
+  it("keeps the generated helper owner through MCP diagnostic actions", async () => {
+    const config = buildSystemAgentToolsMcpServerConfig({ surface: "gateway", agentId: "work" });
+    const server = config.mcpServers.openclaw as { args: string[] };
+    const handlers = createPluginToolsMcpHandlers(
+      resolveOpenClawToolsForMcp({
+        tools: ["openclaw"],
+        systemAgentSurface: "gateway",
+        agentId: resolveToolsMcpAgentId(server.args),
+      }),
+    );
+
+    const result = await handlers.callTool({ name: "openclaw", arguments: { action: "models" } });
+
+    expect(JSON.stringify(result)).toContain("Default model: openai/gpt-5.6-luna");
+    expect(result.isError).not.toBe(true);
   });
 
   it("returns approved CLI MCP mutations to the host instead of applying them", async () => {

--- a/src/mcp/openclaw-tools-serve.ts
+++ b/src/mcp/openclaw-tools-serve.ts
@@ -54,6 +54,7 @@ export function resolveOpenClawToolsForMcp(
   return selection.map((tool) => {
     if (tool === "openclaw") {
       return createSystemAgentTool({
+        agentId: params.agentId,
         surface: params.systemAgentSurface ?? resolveOpenClawToolsMcpSystemAgentSurface(),
         ...resolveOpenClawToolsMcpSystemAgentApproval(),
       });

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -6,7 +6,7 @@ import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agen
 import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveProjectedSessionContextTokens } from "../config/sessions/context-token-provenance.js";
-import { resolveSystemMainSessionKey } from "../config/sessions/main-session.js";
+import { resolveCanonicalMainSessionKey } from "../config/sessions/main-session-key.js";
 import {
   hasSessionActiveAutoModelFallback,
   hasUserPinnedModelSelection,
@@ -448,8 +448,18 @@ export async function getStatusSummary(
         }),
       )
     : [];
-  const mainSessionKey = resolveSystemMainSessionKey(cfg);
-  const queuedSystemEvents = peekSystemEvents(mainSessionKey);
+  // Fleet status reads every main queue without selecting an ambient execution owner.
+  // Global session scope shares one queue, so include it only once.
+  const mainSessionKeys = new Set(
+    agentList.agents.map(({ id: agentId }) =>
+      resolveCanonicalMainSessionKey({
+        agentId,
+        mainKey: cfg.session?.mainKey,
+        sessionScope: cfg.session?.scope,
+      }),
+    ),
+  );
+  const queuedSystemEvents = [...mainSessionKeys].flatMap(peekSystemEvents);
   const taskMaintenanceModule = await taskRegistryMaintenanceModuleLoader.load();
   // Status may overlap a live Gateway, so task inspection must not initialize
   // the writable process registry or its schema-owning shared-state handle.

--- a/src/system-agent/agent-turn.test.ts
+++ b/src/system-agent/agent-turn.test.ts
@@ -807,6 +807,7 @@ describe("runSystemAgentTurn", () => {
     expect(call).toMatchObject({
       provider: "openai",
       model: "gpt-5.4",
+      systemAgentTool: { agentId: "ops" },
       agentDir,
       authProfileId: "openai:ops",
       authProfileIdSource: "user",

--- a/src/system-agent/agent-turn.ts
+++ b/src/system-agent/agent-turn.ts
@@ -333,6 +333,7 @@ async function runSystemAgentTurnWithDeps(
   // and the engine executes it after the reply.
   const directiveRef: { current?: SystemAgentTurnDirective } = {};
   const systemAgentTool = {
+    agentId: plan.agentId,
     surface: params.surface,
     approvalArmed: params.approvalArmed,
     ...(params.operatorApprovalOnly ? { operatorApprovalOnly: true } : {}),

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -11,8 +11,44 @@ import {
   type OpenClawConfig,
   type SystemAgentChatEngineOptions,
 } from "./chat-engine.test-support.js";
+import { loadSystemAgentOverview } from "./overview.js";
 
 describe("SystemAgentChatEngine facade", () => {
+  it("uses the verified inference owner for a delegated fleet overview", async () => {
+    useTempStateDir();
+    const config: OpenClawConfig = {
+      agents: {
+        ownership: "explicit",
+        entries: { main: { model: "openai/gpt-5.6-luna" }, work: {} },
+      },
+      gateway: { port: 1 },
+    };
+    const engine = new SystemAgentChatEngine({
+      requesterAgentId: "main",
+      deps: {
+        loadOverview: async (options?: { agentId?: string }) =>
+          loadSystemAgentOverview({
+            ...options,
+            deps: {
+              readConfigFileSnapshot: async () => configSnapshot(config),
+              probeLocalCommand: async (command) => ({ command, found: false }),
+              probeGatewayUrl: async (url) => ({ url, reachable: false }),
+            },
+          }),
+      },
+    });
+    try {
+      const overview = await engine.loadOverview();
+      expect(overview.defaultAgentId).toBe("main");
+      expect(overview.agents.map(({ id, isDefault }) => ({ id, isDefault }))).toEqual([
+        { id: "main", isDefault: true },
+        { id: "work", isDefault: false },
+      ]);
+    } finally {
+      await engine.dispose();
+    }
+  });
+
   it("rejects a seeded approval when its binding changes during classification", async () => {
     const baseConfig = {
       agents: { defaults: { model: "openai/gpt-5.5" } },

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -215,9 +215,9 @@ export class SystemAgentChatEngine {
 
   async loadOverview(): Promise<SystemAgentOverview> {
     const route = await this.requireVerifiedInference();
-    const overview = this.options.deps?.loadOverview
-      ? await this.options.deps.loadOverview()
-      : await loadSystemAgentOverview();
+    const overview = await (this.options.deps?.loadOverview ?? loadSystemAgentOverview)({
+      agentId: route.agentId,
+    });
     return { ...overview, defaultModel: route.modelLabel };
   }
 

--- a/src/system-agent/chat-turn-router.operations.test.ts
+++ b/src/system-agent/chat-turn-router.operations.test.ts
@@ -780,6 +780,7 @@ describe("SystemAgentChatEngine CLI loop backends", () => {
     expect(call.provider).toBe("claude-cli");
     expect(call.model).toBe("claude-opus-4-8");
     expect(call.systemAgentTool).toEqual({
+      agentId: "main",
       surface: "cli",
       approvalArmed: false,
       proposalRef: {},

--- a/src/system-agent/chat-turn-router.ts
+++ b/src/system-agent/chat-turn-router.ts
@@ -631,12 +631,10 @@ export class ChatTurnRouter {
     };
   }
 
-  private commandDeps(): SystemAgentCommandDeps | undefined {
-    if (!this.options.deps && !this.options.surface) {
-      return undefined;
-    }
+  private commandDeps(): SystemAgentCommandDeps {
     return {
       ...this.options.deps,
+      loadOverview: this.callbacks.loadOverview,
       ...(this.options.surface ? { setupSurface: this.options.surface } : {}),
     };
   }

--- a/src/system-agent/operations-parse.ts
+++ b/src/system-agent/operations-parse.ts
@@ -16,10 +16,10 @@ import {
 } from "./config-redaction.js";
 import type { SystemAgentOperation } from "./operation-types.js";
 import { INVALID_CONFIG_SET_MESSAGE } from "./operations-internal.js";
-import type { SystemAgentOverview } from "./overview.js";
+import type { loadSystemAgentOverview, SystemAgentOverview } from "./overview.js";
 import { validateSystemAgentPluginInstallSpec } from "./plugin-install-spec.js";
 
-type SystemAgentOverviewLoader = () => Promise<SystemAgentOverview>;
+type SystemAgentOverviewLoader = typeof loadSystemAgentOverview;
 type SystemAgentOverviewFormatter = (overview: SystemAgentOverview) => string;
 
 export type { SystemAgentOperation };

--- a/src/system-agent/overview.ts
+++ b/src/system-agent/overview.ts
@@ -139,14 +139,14 @@ function resolveFastTestReferences(env: NodeJS.ProcessEnv): OpenClawReferencePat
 }
 
 export async function loadSystemAgentOverview(
-  opts: { env?: NodeJS.ProcessEnv; deps?: SystemAgentOverviewDependencies } = {},
+  opts: { agentId?: string; env?: NodeJS.ProcessEnv; deps?: SystemAgentOverviewDependencies } = {},
 ): Promise<SystemAgentOverview> {
   const env = opts.env ?? process.env;
   const deps = opts.deps ?? {};
   const readSnapshot = deps.readConfigFileSnapshot ?? readConfigFileSnapshot;
   const snapshot = await readSnapshot();
   const cfg = snapshot.runtimeConfig ?? snapshot.sourceConfig ?? {};
-  const defaultAgentId = resolveAmbientOwnerAgentId(cfg);
+  const defaultAgentId = resolveAmbientOwnerAgentId(cfg, opts.agentId);
   const defaultModel =
     resolveAgentEffectiveModelPrimary(cfg, defaultAgentId) ??
     resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model);


### PR DESCRIPTION
Related: #134421 ([2026.8.2 diagnostics report](https://github.com/openclaw/openclaw/issues/134421#issuecomment-5497732802))

Thanks @Hansen1018 for the diagnostics reproduction and @abacha for the original report.

## What Problem This Solves

Fixes an issue where users checking fleet status or asking the internal OpenClaw tool for system diagnostics receive an explicit-owner error in a multi-agent configuration. Plain `openclaw status` fails without a System Agent owner, and the internal MCP tool can fail even when its caller already has a bound agent.

## Why This Change Was Made

Fleet status now reads the canonical main event queue for each configured agent and counts a shared global queue once. System Agent diagnostics retain the verified inference owner through overview loading, typed operations, embedded tools, and the existing private MCP helper argument. The generic ambiguous-owner resolver stays strict; this repair changes neither configuration nor stored data nor the public tool schema.

The production change is +36/-16 lines (net +20), with +134/-19 test lines (net +115) and +3 documentation lines. The added code carries the existing owner across process boundaries and enumerates fleet event queues; the old single-owner status lookup and unbound command-loader branch are removed. The status test fixture now initializes task audit findings once per test instead of duplicating its initial contents.

## User Impact

Operators can inspect an explicit fleet without configuring an unrelated System Agent owner. Bound internal tools report the model belonging to their selected inference owner, including when that owner differs from the fleet's other agents.

Release note: Fix fleet status and internal OpenClaw diagnostics for explicit multi-agent ownership, preserving the selected owner across embedded and MCP tool calls.

Companion #135505 repairs the channel login/logout path from #134421. The issue remains open while both repairs are reviewed.

## Evidence

- Reproduced the status failure, bound overview failure, and MCP diagnostics failure independently before changing their production paths. The status and overview defects are also present on stable `v2026.8.2` (`0965053fe6b9341776df147a6934b7485c60b5ca`).
- All 110 focused tests pass across seven files, including per-agent/global event queues, verified overview ownership, embedded tool options, and helper configuration → owner argument parsing → real MCP operation dispatch → real overview owner resolution.
- Built the runtime with `pnpm build qaRuntime`. Ran the built CLI against an isolated explicit two-agent configuration with only a heartbeat owner: `status --timeout 500` and `status --json --timeout 500` both exit 0, and JSON contains both agent stores.
- Connected through actual built MCP stdio transport, initialized the client, listed tools, and called `openclaw` with `action: "models"`. Binding `research` returns `example/research-model`; binding `ops` returns `example/operations-model`. Both return successful text results. The temporary configuration/state and local probe endpoint were removed afterward; no live user Gateway was involved.
- Personally inspected Codex's MCP forwarding and process launch contract at `94cbbddafc1776d5e377bca1b05932c697e82238`: `codex-rs/core/src/mcp_tool_call.rs:120`, `codex-rs/rmcp-client/src/rmcp_client.rs:438`, and `codex-rs/rmcp-client/src/stdio_server_launcher.rs:263`. Configured helper arguments are preserved, so the existing OpenClaw owner argument is sufficient.
- The full changed-file gate passes after refreshing onto main containing #135407, which fixed the unrelated test typing failure from the first run. All 110 focused tests pass again on that base.
- CI then found a strict CLI-loop fixture that omitted the newly carried owner. The test-only correction keeps exact option equality and adds `agentId: "main"`; all 48 routing/CLI-loop tests pass, bringing focused coverage to 158 tests across eight files. That correction also passed a fresh managed review, and [hosted CI passed](https://github.com/openclaw/openclaw/actions/runs/33545713050) on the published head.
- Independent managed review is scoped clean at P0. The maintainer also reviewed the owner, callers, siblings, changed tests, and actual CLI/MCP proof directly; no actionable findings remain.

Focused commands:

```sh
node scripts/run-vitest.mjs \
  src/commands/status.summary.test.ts \
  src/system-agent/chat-engine.test.ts \
  src/system-agent/overview.test.ts \
  src/system-agent/agent-turn.test.ts \
  src/agents/tools/system-agent-tool.test.ts \
  src/mcp/openclaw-tools-serve.test.ts \
  src/mcp/agent-session-owner.test.ts

node scripts/run-vitest.mjs src/system-agent/chat-turn-router.operations.test.ts
```
