### PR TITLE
fix: stabilize real Gateway state guard checks

### DIFF
--- a/src/cli/state-dir-gateway-check.server-fixture.test-support.ts
+++ b/src/cli/state-dir-gateway-check.server-fixture.test-support.ts
@@ -10,6 +10,10 @@ const server = await startGatewayServer(port, {
   controlUiEnabled: false,
 });
 await server.startupSettled;
+// Minimal startup skips maintenance, including its initial health refresh. Settle
+// that real work before readiness so it cannot starve the next test handshake.
+const { refreshGatewayHealthSnapshot } = await import("../gateway/server/health-state.js");
+await refreshGatewayHealthSnapshot({ probe: false });
 process.send?.({ port });
 
 const close = async () => {

--- a/src/cli/state-dir-gateway-check.server.test.ts
+++ b/src/cli/state-dir-gateway-check.server.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getFreePort } from "../test-utils/ports.js";
 import { checkCliGatewayStateDir } from "./state-dir-gateway-check.js";
 
@@ -69,11 +69,14 @@ describe("state-dir guard with a real token Gateway", () => {
         reject(new Error(`Gateway fixture exited early: ${code}\n${childStderr}`));
       });
     });
+  }, 120_000);
+
+  beforeEach(() => {
     vi.stubEnv("HOME", path.join(root, "cli-home"));
     setCliStateDir(cliStateDir);
     vi.stubEnv("OPENCLAW_GATEWAY_PORT", String(port));
     vi.stubEnv("OPENCLAW_SYSTEMD_UNIT", `openclaw-state-dir-server-${process.pid}`);
-  }, 120_000);
+  });
 
   afterAll(async () => {
     vi.unstubAllEnvs();
@@ -95,7 +98,6 @@ describe("state-dir guard with a real token Gateway", () => {
         config: { gateway: { mode: "local", port, auth: { mode: "token", token } } },
       }),
     ).resolves.toEqual({ kind: "allow" });
-    setCliStateDir(cliStateDir);
   });
 
   it("refuses mismatched authenticated hello paths", async () => {


### PR DESCRIPTION
## What Problem This Solves

The real-Gateway state-directory suite can authenticate its first client, then time out the next handshake and incorrectly observe an allowed write. Its minimal server announces readiness before the omitted initial health refresh has completed. The suite also installs environment stubs in beforeAll even though Vitest restores them before every test.

## Why This Change Was Made

The fixture now awaits the real passive health refresh before its IPC readiness signal. Existing client environment stubs move into beforeEach. Production refusal logic, authentication, timeouts and assertions are unchanged.

## User Impact

This repairs test readiness and isolation so the suite consistently exercises authenticated matching paths, mismatched-path refusal and tokenless warnings. It does not change production behavior.

## Evidence

The original failure reproduced in file order on a frozen copy of the failing CI head; running the mismatch case first passed. Pass-through tracing captured a correct authenticated hello followed by a 9.1-second synchronous cold plugin-presence load. That work blocked the second handshake. An environment-only repair still failed; waiting for actual health readiness passed all three cases. Independent and maintainer five-file runs each passed all 15 tests, including a real CLI refusal before credential writes. The maintainer run also passed the test type shard, typed lint and configured autoreview.

The cold plugin-presence loader cost is a separate production follow-up; this patch does not hide it or claim a runtime performance fix. The unrelated stdin TTY type error is already fixed by #135407 and is not duplicated here.

Production: 0 lines changed. Tests: +5/-3; test support: +4. No configuration, dependency, schema, protocol or production policy changes.
