### PR TITLE
refactor(codex): centralize Computer Use errno checks

### DIFF
--- a/extensions/codex/src/app-server/computer-use-errors.ts
+++ b/extensions/codex/src/app-server/computer-use-errors.ts
@@ -1,0 +1,3 @@
+export function hasNodeErrorCode(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === code);
+}

--- a/extensions/codex/src/app-server/computer-use-marketplace.ts
+++ b/extensions/codex/src/app-server/computer-use-marketplace.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { hasNodeErrorCode } from "./computer-use-errors.js";
 import {
   assertDirectoryIdentityStable,
   assertNotSymlink,
@@ -235,8 +236,4 @@ async function wrapperMatchesAnySource(
     }
   }
   return false;
-}
-
-function hasNodeErrorCode(error: unknown, code: string): error is NodeJS.ErrnoException {
-  return Boolean(error && typeof error === "object" && "code" in error && error.code === code);
 }

--- a/extensions/codex/src/app-server/computer-use-service-path.ts
+++ b/extensions/codex/src/app-server/computer-use-service-path.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { assertNoSymlinkParents } from "openclaw/plugin-sdk/security-runtime";
+import { hasNodeErrorCode } from "./computer-use-errors.js";
 
 type OwnedServiceParent = {
   logicalPath: string;
@@ -211,8 +212,4 @@ function assertPathAtOrInside(rootPath: string, candidatePath: string, label: st
   if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
     throw new Error(`${label} must remain inside ${path.resolve(rootPath)}.`);
   }
-}
-
-function hasNodeErrorCode(error: unknown, code: string): error is NodeJS.ErrnoException {
-  return Boolean(error && typeof error === "object" && "code" in error && error.code === code);
 }

--- a/extensions/codex/src/app-server/desktop-generation-fingerprint.ts
+++ b/extensions/codex/src/app-server/desktop-generation-fingerprint.ts
@@ -3,6 +3,7 @@ import { constants as fsConstants } from "node:fs";
 import type { BigIntStats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { hasNodeErrorCode } from "./computer-use-errors.js";
 import {
   resolveMacOSDesktopCodexAppPathCandidates,
   type MacOSDesktopCodexAppPathCandidate,
@@ -73,7 +74,7 @@ async function directoryTreeFingerprint(root: string): Promise<string> {
   try {
     rootStat = await fs.lstat(root, { bigint: true });
   } catch (error) {
-    if (isNodeError(error, "ENOENT") || isNodeError(error, "ENOTDIR")) {
+    if (hasNodeErrorCode(error, "ENOENT") || hasNodeErrorCode(error, "ENOTDIR")) {
       return "missing";
     }
     throw error;
@@ -136,7 +137,7 @@ async function statFingerprint(filePath: string): Promise<string> {
     const content = target.isFile() ? await readFileFingerprint(filePath, target, true) : "";
     return `${type}:${own}:${link}:${realPath}:${statTuple(target)}:${content}`;
   } catch (error) {
-    if (isNodeError(error, "ENOENT") || isNodeError(error, "ENOTDIR")) {
+    if (hasNodeErrorCode(error, "ENOENT") || hasNodeErrorCode(error, "ENOTDIR")) {
       return "missing";
     }
     throw error;
@@ -177,8 +178,4 @@ function sameStat(left: BigIntStats, right: BigIntStats): boolean {
 
 function statTuple(stat: BigIntStats): string {
   return [stat.dev, stat.ino, stat.mode, stat.size, stat.mtimeNs, stat.ctimeNs].join(":");
-}
-
-function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
-  return Boolean(error && typeof error === "object" && "code" in error && error.code === code);
 }


### PR DESCRIPTION
## What Problem This Solves

The Codex Computer Use app-server repeated the same Node errno predicate in marketplace publication, service-path ownership, and desktop generation fingerprinting. Keeping three copies made filesystem boundary behavior easier to drift during future maintenance.

## Why This Change Was Made

The bundled Codex plugin now owns one private `hasNodeErrorCode` predicate in `computer-use-errors.ts`, and the three existing consumers import it directly. The exact runtime expression and type guard are preserved. This adds no Plugin SDK or barrel surface and does not alter filesystem ownership, marketplace selection, or fingerprint behavior.

## User Impact

No user-visible behavior changes. Computer Use keeps the same missing-path, non-directory, and concurrent-creation handling with one canonical plugin-private implementation.

## Evidence

- Local focused tests after rebasing onto `origin/main`: 3 files, 35 tests passed.
- `pnpm test:extensions:package-boundary:compile`: all 123 plugins compiled.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- Hydrated Testbox repeated the 35 focused tests and the complete changed-file gate successfully.
  - Provider: `blacksmith-testbox`
  - Lease: `tbx_01m1f3ar5kmms4601mftzfytzs`
  - Run: https://github.com/openclaw/openclaw/actions/runs/33543251982
  - Result: succeeded, exit 0
- Local sparse-worktree `check-changed` reached the dead-export scan before omitted `ui/config` files prevented module resolution; the hydrated Testbox changed gate covered that exact gap and passed all deadcode, lint, typecheck, database-first, sidecar, and import-cycle lanes.
- Final autoreview completed `scoped-clean` with no accepted or actionable findings against `origin/main`.
- `git diff --check` passed.

The existing marketplace, service ownership, and desktop generation suites already exercise the meaningful `ENOENT`, `ENOTDIR`, and `EEXIST` behavior at filesystem boundaries. No tests were added because predicate-only tests would couple coverage to JavaScript property mechanics without protecting additional product behavior.

Codex source checked directly:

- `codex-rs/cli/src/main.rs:220-245`
- `codex-rs/cli/src/main.rs:2840-2870`
- `codex-rs/cli/src/plugin_cmd.rs:780-845`

Those surfaces confirm bundled marketplace ownership is upstream CLI/plugin plumbing and impose no competing JavaScript errno contract.

Production LOC: `+8/-14`, net `-6`. Test LOC: `0`.

No changelog entry: this is an internal behavior-neutral refactor with no user-visible or operational change.

Overlap recheck found no exact-file conflict. Live `ghx` checks covered the previously identified adjacent PRs #115049, #120887, #123525, and #134755; exact pull-ref diffs also covered every PR ref created after the audit anchor through #135426. None modify the four files in this PR.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

```text
source: [LOCAL_SESSION]
redaction: local paths, account details, raw tool output, credentials, and unrelated turns omitted

[user]
Execute the reviewed scope exactly: create a shared worktree from fresh main, centralize the three Computer Use errno predicates in one plugin-private module, run focused/local/Testbox proof and autoreview, then create a signed draft PR. Do not add tests, SDK exports, a changelog entry, or adjacent cleanup.

[assistant]
Verified the worktree and dependency symlink, inspected root and extension policy plus the relevant Codex CLI and bundled marketplace source, and found no exact target-file overlap.

[assistant]
Applied the four-file refactor. The exact predicate expression and type guard are unchanged; no public surface or behavior changed.

[assistant]
Local proof passed: 35 focused tests, all 123 plugin package-boundary compiles, and zero import cycles. The sparse checkout could not load omitted UI config during the final dead-export lane, so the exact focused tests and full changed gate were repeated on hydrated Testbox.

[assistant]
Testbox passed with exit 0. Fresh autoreview found no accepted or actionable findings. The commit was rebased onto current main, re-signed, and the focused tests plus autoreview passed again.
```

</details>
<!-- agent-transcript:end -->
