### PR TITLE
fix(doctor): recover stale npm plugins during update repair

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2526,7 +2526,6 @@ src/commands/doctor/shared/legacy-config-record-shared.ts	1
 src/commands/doctor/shared/legacy-config-state-migration-input.ts	2
 src/commands/doctor/shared/legacy-talk-config-normalizer.ts	2
 src/commands/doctor/shared/legacy-web-tools-migrate.ts	1
-src/commands/doctor/shared/missing-configured-plugin-install.install.ts	1
 src/commands/doctor/shared/open-policy-allowfrom.ts	2
 src/commands/doctor/shared/plugin-dependency-cleanup.ts	1
 src/commands/doctor/shared/plugin-registry-migration.ts	1

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -193,8 +193,10 @@ It does not install a new core package and does not restart the Gateway.
 Human output ends with a finalization result that distinguishes completion,
 completion with warnings, and failure.
 
-Managed npm package directories without an install record are reinstalled from
-the selected registry source, using the active channel or exact version pin.
+When repair finds a configured npm plugin payload but cannot recover its install
+record, it reinstalls from the selected registry source, using the active channel
+or exact version pin. This requires registry access; if verification fails, repair
+preserves the existing payload and does not publish a new install record.
 Registry verification and any required capability review finish before the
 repaired install record is published.
 

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -193,6 +193,11 @@ It does not install a new core package and does not restart the Gateway.
 Human output ends with a finalization result that distinguishes completion,
 completion with warnings, and failure.
 
+Managed npm package directories without an install record are reinstalled from
+the selected registry source, using the active channel or exact version pin.
+Registry verification and any required capability review finish before the
+repaired install record is published.
+
 With `--json`, stdout contains one JSON document. Doctor panels and other
 diagnostics go to stderr, so stdout can be parsed directly. Failed doctor or
 plugin finalization steps still exit non-zero.

--- a/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
@@ -1,6 +1,4 @@
 import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
-import path from "node:path";
 import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../../../packages/gateway-protocol/src/capability-consent-error-details.js";
 import { stripAnsi } from "../../../../packages/terminal-core/src/ansi.js";
 import { sanitizeTerminalText } from "../../../../packages/terminal-core/src/safe-text.js";
@@ -45,7 +43,6 @@ import {
   resolveLegacyNpmPackageInstallPath,
   resolveNpmPackageInstallPath,
 } from "./missing-configured-plugin-install.records.js";
-import { isPostCoreConvergencePass } from "./update-phase.js";
 
 export function isActionableClawHubSkippedOutcome(outcome: {
   status: string;
@@ -207,38 +204,6 @@ async function installCandidatePackage(
   const existingNpmPackagePath = npmInstallSpec
     ? resolveExistingCandidateNpmPackagePath({ candidate, npmDir })
     : null;
-  const existingNpmPackageVersion = existingNpmPackagePath
-    ? await readNpmPackageVersion(existingNpmPackagePath)
-    : undefined;
-  if (
-    recordedSource !== "clawhub" &&
-    existingNpmPackagePath &&
-    existingNpmPackageVersion &&
-    npmInstallSpec &&
-    params.mode !== "update" &&
-    isPostCoreConvergencePass(params.env)
-  ) {
-    const capabilityConsent = await prepareConsent(
-      "npm",
-      npmInstallSpec,
-      candidate.expectedIntegrity,
-    );
-    await capabilityConsent.onBeforePluginArtifactCommit({
-      pluginId: candidate.pluginId,
-      stagedArtifactDir: existingNpmPackagePath,
-      mode: "install",
-    });
-    return await adoptExistingNpmPackage({
-      candidate,
-      capabilityConsent,
-      records: params.records,
-      npmInstallSpec,
-      npmRecordSpec: npmSpecs?.recordSpec ?? npmInstallSpec,
-      pinResolvedRegistrySpec: pinResolvedSpecForStaleRepair,
-      packagePath: existingNpmPackagePath,
-      version: existingNpmPackageVersion,
-    });
-  }
   const sources = resolvePluginInstallSources(candidate, recordedSource);
   if (sources.length === 0) {
     return {
@@ -413,73 +378,6 @@ function resolveExistingCandidateClawHubPackagePath(params: {
   } catch {
     return null;
   }
-}
-
-async function readNpmPackageVersion(packagePath: string): Promise<string | undefined> {
-  try {
-    const parsed = JSON.parse(await readFile(path.join(packagePath, "package.json"), "utf-8")) as {
-      version?: unknown;
-    };
-    return typeof parsed.version === "string" && parsed.version.trim()
-      ? parsed.version.trim()
-      : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-async function adoptExistingNpmPackage(params: {
-  candidate: DownloadableInstallCandidate;
-  capabilityConsent: Awaited<ReturnType<typeof prepareManagedPluginArtifactConsentHandler>>;
-  records: Record<string, PluginInstallRecord>;
-  npmInstallSpec: string;
-  npmRecordSpec: string;
-  pinResolvedRegistrySpec: boolean;
-  packagePath: string;
-  version: string;
-}): Promise<{
-  records: Record<string, PluginInstallRecord>;
-  changes: string[];
-  notices: string[];
-  warnings: string[];
-}> {
-  const npmName = parseRegistryNpmSpec(params.npmInstallSpec)?.name;
-  const npmResolution = npmName
-    ? {
-        name: npmName,
-        version: params.version,
-        resolvedSpec: `${npmName}@${params.version}`,
-      }
-    : undefined;
-  return {
-    records: {
-      ...params.records,
-      [params.candidate.pluginId]: params.capabilityConsent.applyAcceptedSurface(
-        params.candidate.pluginId,
-        {
-          source: "npm",
-          // Adoption discovers local bytes; only a registry reinstall can establish official trust.
-          sourcePath: params.packagePath,
-          spec: resolveNpmInstallRecordSpec({
-            requestedSpec: params.npmRecordSpec,
-            resolution: npmResolution,
-            pinResolvedRegistrySpec: params.pinResolvedRegistrySpec,
-          }),
-          installPath: params.packagePath,
-          installedAt: new Date().toISOString(),
-          version: params.version,
-          resolvedVersion: params.version,
-          ...(npmName ? { resolvedName: npmName } : {}),
-          ...(npmResolution ? { resolvedSpec: npmResolution.resolvedSpec } : {}),
-        },
-      ),
-    },
-    changes: [
-      `Repaired missing configured plugin "${params.candidate.pluginId}" from existing npm payload ${params.npmInstallSpec}.`,
-    ],
-    notices: [],
-    warnings: [],
-  };
 }
 
 export function resolveCandidateInstallSpec(params: {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -3,9 +3,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../../../packages/gateway-protocol/src/capability-consent-error-details.js";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { withIsolatedTestHome } from "../../../../test/test-env.js";
 import type { OpenClawConfig, PluginsConfig } from "../../../config/types.js";
 import { resolveRegistryUpdateChannel } from "../../../infra/update-channels.js";
 import { resolvePluginArtifactDeclaredSurface } from "../../../plugins/capability-artifact.js";
@@ -20,6 +21,8 @@ import { resolveInstalledPluginIndexPolicyHash } from "../../../plugins/installe
 import { isTrustedOfficialPluginInstallRecord } from "../../../plugins/official-external-install-records.js";
 import type { BundledProviderPolicySurface } from "../../../plugins/provider-policy-surface.js";
 import { createColdPluginFixture } from "../../../plugins/test-helpers/cold-plugin-fixtures.js";
+import { closeOpenClawStateDatabaseByPath } from "../../../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
 import { VERSION } from "../../../version.js";
 import { applyLegacyDoctorMigrations } from "./legacy-config-compat.js";
 import {
@@ -147,6 +150,16 @@ const mocks = vi.hoisted(() => ({
   writePersistedInstalledPluginIndexInstallRecords: vi.fn(),
 }));
 
+const testHome = withIsolatedTestHome({ mode: "hermetic" });
+const testEnv: NodeJS.ProcessEnv = {
+  HOME: testHome.tempHome,
+  OPENCLAW_HOME: testHome.tempHome,
+  OPENCLAW_STATE_DIR: path.join(testHome.tempHome, ".openclaw"),
+};
+afterAll(() => {
+  closeOpenClawStateDatabaseByPath(resolveOpenClawStateSqlitePath(testEnv));
+  testHome.cleanup();
+});
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const prepareManagedPluginArtifactConsentHandler = vi.hoisted(() =>
@@ -190,7 +203,7 @@ async function repairConfiguredPlugins(
 ) {
   const { repairMissingConfiguredPluginInstalls } =
     await import("./missing-configured-plugin-install.js");
-  return repairMissingConfiguredPluginInstalls({ cfg, env });
+  return repairMissingConfiguredPluginInstalls({ cfg, env: { ...testEnv, ...env } });
 }
 
 function useManifestCatalogResolvers(): void {
@@ -344,7 +357,6 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       );
       const installDir = tempDirs.make("openclaw-doctor-retained-consent-");
       const stageDir = tempDirs.make("openclaw-doctor-staged-consent-");
-      const stateDir = tempDirs.make("openclaw-doctor-consent-state-");
       for (const [rootDir, widened] of [
         [installDir, false],
         [stageDir, true],
@@ -428,7 +440,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       const result = await repairMissingPluginInstallsForIds({
         cfg,
         pluginIds: ["codex"],
-        env: { OPENCLAW_STATE_DIR: stateDir },
+        env: testEnv,
       });
 
       expect(committed).toBe(false);
@@ -717,7 +729,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
   });
 
   it.each(
-    (["npm", "npm-retry", "clawhub", "adopt"] as const).flatMap((source) =>
+    (["npm", "npm-retry", "clawhub", "npm-existing"] as const).flatMap((source) =>
       [false, true].map((accepted) => ({ source, accepted })),
     ),
   )(
@@ -731,12 +743,9 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       );
       const root = tempDirs.make("openclaw-doctor-consent-");
       const npmRoot = path.join(root, "npm");
-      const packageName = source === "adopt" ? "@openclaw/matrix" : "@example/matrix";
-      if (source === "adopt") {
-        useManifestCatalogResolvers();
-      }
+      const packageName = "@example/matrix";
       const artifactDir =
-        source === "adopt"
+        source === "npm-existing"
           ? path.join(npmRoot, "node_modules", ...packageName.split("/"))
           : path.join(root, "artifact");
       fs.mkdirSync(artifactDir, { recursive: true });
@@ -800,15 +809,13 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       const result = await repairMissingConfiguredPluginInstalls({
         cfg,
         env: {
-          OPENCLAW_STATE_DIR: path.join(root, "state"),
-          ...(source === "adopt" ? { OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1" } : {}),
+          ...testEnv,
+          ...(source === "npm-existing" ? { OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1" } : {}),
         },
         ...(accepted ? { onCapabilityConsent: consent } : {}),
       });
 
-      if (source !== "adopt") {
-        expect(committed).toBe(accepted);
-      }
+      expect(committed).toBe(accepted);
       expect(fs.existsSync(fixture.runtimeMarker)).toBe(false);
       if (accepted) {
         expect(consent).toHaveBeenCalledOnce();
@@ -819,16 +826,6 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           acceptedSurfaceHash: expect.stringMatching(/^[a-f\d]{64}$/),
           acceptedSurfaceAt: expect.any(String),
         });
-        if (source === "adopt") {
-          expect(result.records.matrix?.sourcePath).toBe(artifactDir);
-          expect(
-            isTrustedOfficialPluginInstallRecord({
-              pluginId: "matrix",
-              packageName,
-              record: expectDefined(result.records.matrix, "adopted install record"),
-            }),
-          ).toBe(false);
-        }
         expect(mocks.writePersistedInstalledPluginIndexInstallRecords).toHaveBeenCalledWith(
           result.records,
           expect.any(Object),
@@ -1028,7 +1025,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           matrix: { enabled: true, homeserver: "https://matrix.example.org" },
         },
       },
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
@@ -1095,6 +1092,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         },
       },
       env: {
+        ...testEnv,
         OPENCLAW_UPDATE_IN_PROGRESS: "1",
         OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
       },
@@ -1159,7 +1157,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           discord: { enabled: true },
         },
       },
-      env: {},
+      env: testEnv,
     });
 
     expect(issues).toEqual([
@@ -1191,7 +1189,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     const result = await repairMissingPluginInstallsForIds({
       cfg,
       pluginIds: [],
-      env: {},
+      env: testEnv,
       baselineRecords,
     });
 
@@ -1200,7 +1198,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       baselineRecords,
       {
         config: cfg,
-        env: {},
+        env: testEnv,
       },
     );
     expect(result.records).toBe(baselineRecords);
@@ -1230,7 +1228,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       await import("./missing-configured-plugin-install.js");
     const result = await repairMissingConfiguredPluginInstalls({
       cfg,
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
@@ -1251,7 +1249,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
     expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords, 0, 1)).toEqual({
       config: cfg,
-      env: {},
+      env: testEnv,
     });
     expect(result.changes).toEqual([
       'Installed missing configured plugin "matrix" from @openclaw/plugin-matrix@1.2.3.',
@@ -1284,7 +1282,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
 
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");
-    const result = await repairMissingConfiguredPluginInstalls({ cfg, env: {} });
+    const result = await repairMissingConfiguredPluginInstalls({ cfg, env: testEnv });
 
     expect(mockCallArg(mocks.installPluginFromNpmSpec, 0)).toMatchObject({
       spec: "@openclaw/plugin-matrix@beta",
@@ -1344,7 +1342,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
 
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");
-    const result = await repairMissingConfiguredPluginInstalls({ cfg, env: {} });
+    const result = await repairMissingConfiguredPluginInstalls({ cfg, env: testEnv });
 
     expect(mockCallArg(mocks.installPluginFromClawHub, 0)).toMatchObject({
       spec: "clawhub:@openclaw/plugin-matrix@beta",
@@ -1411,7 +1409,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       await import("./missing-configured-plugin-install.js");
     const result = await repairMissingConfiguredPluginInstalls({
       cfg,
-      env: {},
+      env: testEnv,
     });
 
     const clawHubCall = expectRecordFields(mockCallArg(mocks.installPluginFromClawHub), {
@@ -1467,7 +1465,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           },
         },
       },
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.updateNpmInstalledPlugins).toHaveBeenCalledWith(
@@ -1505,7 +1503,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       await import("./missing-configured-plugin-install.js");
     const result = await repairMissingConfiguredPluginInstalls({
       cfg: {},
-      env: { MATRIX_HOMESERVER: "https://matrix.example.org" },
+      env: { ...testEnv, MATRIX_HOMESERVER: "https://matrix.example.org" },
     });
 
     expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
@@ -1523,7 +1521,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
     expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords, 0, 1)).toEqual({
       config: {},
-      env: { MATRIX_HOMESERVER: "https://matrix.example.org" },
+      env: { ...testEnv, MATRIX_HOMESERVER: "https://matrix.example.org" },
     });
     expect(result.changes).toEqual([
       'Installed missing configured plugin "matrix" from @openclaw/plugin-matrix@1.2.3.',
@@ -1551,7 +1549,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       cfg: {},
       pluginIds: [],
       channelIds: ["matrix"],
-      env: {},
+      env: testEnv,
     });
 
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
@@ -1589,7 +1587,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       cfg: {},
       pluginIds: [],
       channelIds: ["matrix"],
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
@@ -1626,7 +1624,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       cfg: {},
       pluginIds: [],
       channelIds: ["twitch"],
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
@@ -1666,7 +1664,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         update: { channel: "extended-stable" },
         plugins: { entries: { "diagnostics-otel": { enabled: true } } },
       },
-      env: {},
+      env: testEnv,
     });
 
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
@@ -1705,7 +1703,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           },
         },
       },
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
@@ -1752,7 +1750,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       await import("./missing-configured-plugin-install.js");
     const result = await repairMissingConfiguredPluginInstalls({
       cfg,
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
@@ -1799,7 +1797,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           matrix: { enabled: true, homeserver: "https://matrix.example.org" },
         },
       },
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
@@ -1860,7 +1858,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           matrix: { enabled: true, homeserver: "https://matrix.example.org" },
         },
       },
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
@@ -1870,7 +1868,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       {},
       {
         config: expect.any(Object),
-        env: {},
+        env: testEnv,
       },
     );
     expect(result).toEqual({
@@ -1924,7 +1922,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           },
         },
       },
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
@@ -1932,7 +1930,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       {},
       {
         config: expect.any(Object),
-        env: {},
+        env: testEnv,
       },
     );
     expect(result).toEqual({
@@ -2013,7 +2011,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       await import("./missing-configured-plugin-install.js");
     const result = await repairMissingConfiguredPluginInstalls({
       cfg: {},
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
@@ -2021,7 +2019,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       {},
       {
         config: {},
-        env: {},
+        env: testEnv,
       },
     );
     expect(result).toEqual({
@@ -2099,7 +2097,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
             matrix: { enabled: true, homeserver: "https://matrix.example.org" },
           },
         },
-        env: {},
+        env: testEnv,
       });
 
       expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
@@ -2144,6 +2142,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         },
       },
       env: {
+        ...testEnv,
         OPENCLAW_UPDATE_IN_PROGRESS: "1",
         OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
       },
@@ -2207,9 +2206,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           discord: { enabled: true },
         },
       },
-      env: {
-        OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
-      },
+      env: { ...testEnv, OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1" },
     });
 
     expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
@@ -2271,9 +2268,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       await import("./missing-configured-plugin-install.js");
     const result = await repairMissingConfiguredPluginInstalls({
       cfg,
-      env: {
-        OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
-      },
+      env: { ...testEnv, OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1" },
     });
 
     expect(mocks.installPluginFromNpmSpec).toHaveBeenCalledTimes(2);
@@ -2293,75 +2288,146 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expect(result.records.discord?.installPath).toBe(packageDir);
   });
 
-  it("prefers an existing npm payload over ClawHub during post-core repair", async () => {
-    const npmRoot = tempDirs.make("openclaw-plugin-stub-repair-");
-    const packageDir = path.join(npmRoot, "node_modules", "@openclaw", "matrix");
-    fs.mkdirSync(packageDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(packageDir, "package.json"),
-      JSON.stringify({ name: "@openclaw/matrix", version: "1.2.3" }),
-    );
-    mocks.resolveDefaultPluginNpmDir.mockReturnValue(npmRoot);
-    mocks.listChannelPluginCatalogEntries.mockReturnValue([
-      {
-        id: "matrix",
-        pluginId: "matrix",
-        meta: { label: "Matrix" },
-        install: {
-          clawhubSpec: "clawhub:@openclaw/matrix",
-          npmSpec: "@openclaw/matrix",
+  it.each([
+    {
+      layout: "legacy",
+      channel: "stable",
+      coreVersion: "2026.8.2",
+      npmSpec: "@openclaw/codex",
+      version: "2026.8.2",
+    },
+    {
+      layout: "project",
+      channel: "stable",
+      coreVersion: "2026.8.2",
+      npmSpec: "@openclaw/codex",
+      version: "2026.8.2",
+    },
+    {
+      layout: "project",
+      channel: "beta",
+      coreVersion: "2026.8.2-beta.2",
+      npmSpec: "@openclaw/codex",
+      version: "2026.8.2-beta.2",
+    },
+    {
+      layout: "legacy",
+      channel: "stable",
+      coreVersion: "2026.8.2",
+      npmSpec: "@openclaw/codex@2026.7.9",
+      version: "2026.7.9",
+    },
+  ] as const)(
+    "converges orphaned $layout npm payloads to the verified $channel target $version",
+    async ({ layout, channel, coreVersion, npmSpec, version }) => {
+      const actual = await vi.importActual<typeof import("../../../plugins/capability-consent.js")>(
+        "../../../plugins/capability-consent.js",
+      );
+      prepareManagedPluginArtifactConsentHandler.mockImplementation(
+        actual.prepareManagedPluginArtifactConsentHandler,
+      );
+      useManifestCatalogResolvers();
+      const root = tempDirs.make("openclaw-orphaned-plugin-repair-");
+      const npmRoot = path.join(root, "npm");
+      const packageName = "@openclaw/codex";
+      const packageDir =
+        layout === "legacy"
+          ? path.join(npmRoot, "node_modules", ...packageName.split("/"))
+          : mocks.resolvePluginNpmPackageDir({ npmDir: npmRoot, packageName });
+      const stageDir = path.join(root, "verified-artifact");
+      const fixtures = (
+        [
+          [packageDir, "2026.7.1"],
+          [stageDir, version],
+        ] as const
+      ).map(([rootDir, packageVersion]) => {
+        fs.mkdirSync(rootDir, { recursive: true });
+        return createColdPluginFixture({
+          rootDir,
+          pluginId: "codex",
+          packageName,
+          packageVersion,
+          manifest: { contracts: { tools: ["fixture.read"] } },
+        });
+      });
+      mocks.resolveDefaultPluginNpmDir.mockReturnValue(npmRoot);
+      mocks.resolveDefaultPluginExtensionsDir.mockReturnValue(path.join(root, "extensions"));
+      mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+        officialPluginEntry({ id: "codex", npmSpec }),
+      ]);
+      const integrity = "sha512-verified-codex";
+      mocks.installPluginFromNpmSpec.mockImplementation(
+        async (params: {
+          spec: string;
+          onBeforePluginArtifactCommit: PluginInstallArtifactConsentHandler;
+        }) => {
+          await params.onBeforePluginArtifactCommit({
+            pluginId: "codex",
+            stagedArtifactDir: stageDir,
+            mode: "update",
+            sourceRecord: {
+              source: "npm",
+              spec: params.spec,
+              resolvedName: packageName,
+              resolvedVersion: version,
+              resolvedSpec: `${packageName}@${version}`,
+              integrity,
+            },
+          });
+          return successfulInstall({
+            pluginId: "codex",
+            npmSpec: packageName,
+            targetDir: stageDir,
+            version,
+            resolution: { integrity },
+          });
         },
-      },
-    ]);
-    mocks.installPluginFromClawHub.mockResolvedValue({
-      ok: false,
-      error: 'Plugin "@openclaw/matrix" requires plugin API >=2026.5.18.',
-    });
-    mocks.installPluginFromNpmSpec.mockResolvedValue({
-      ok: true,
-      pluginId: "matrix",
-      targetDir: packageDir,
-      version: "1.2.3",
-      npmResolution: {
-        name: "@openclaw/matrix",
-        version: "1.2.3",
-        resolvedSpec: "@openclaw/matrix@1.2.3",
-        integrity: "sha512-matrix",
-        resolvedAt: "2026-05-01T00:00:00.000Z",
-      },
-    });
+      );
+      const consent = vi.fn<PluginCapabilityConsentHandler>(async (review) => ({
+        reviewToken: review.reviewToken,
+      }));
+      const { repairMissingConfiguredPluginInstalls } =
+        await import("./missing-configured-plugin-install.js");
+      const result = await repairMissingConfiguredPluginInstalls({
+        cfg: { update: { channel }, plugins: { entries: { codex: { enabled: true } } } },
+        env: {
+          ...testEnv,
+          OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
+          OPENCLAW_COMPATIBILITY_HOST_VERSION: coreVersion,
+        },
+        onCapabilityConsent: consent,
+      });
 
-    const { repairMissingConfiguredPluginInstalls } =
-      await import("./missing-configured-plugin-install.js");
-    const result = await repairMissingConfiguredPluginInstalls({
-      cfg: {
-        plugins: {
-          entries: {
-            matrix: { enabled: true },
-          },
-        },
-        channels: {
-          matrix: { enabled: true },
-        },
-      },
-      env: {
-        OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
-      },
-    });
-
-    expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
-    expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
-    expect(result.warnings).toEqual([]);
-    expectRecordFields(result.records.matrix, {
-      source: "npm",
-      spec: "@openclaw/matrix",
-      installPath: packageDir,
-      version: "1.2.3",
-      resolvedName: "@openclaw/matrix",
-      resolvedVersion: "1.2.3",
-      resolvedSpec: "@openclaw/matrix@1.2.3",
-    });
-  });
+      expect(result.records.codex).toMatchObject({
+        source: "npm",
+        spec: npmSpec,
+        installPath: stageDir,
+        version,
+        resolvedVersion: version,
+        resolvedSpec: `${packageName}@${version}`,
+        integrity,
+      });
+      expect(result.records.codex?.sourcePath).toBeUndefined();
+      expect(result.records.codex?.acceptedSurface).toBeUndefined();
+      expect(
+        isTrustedOfficialPluginInstallRecord({
+          pluginId: "codex",
+          packageName,
+          record: expectDefined(result.records.codex, "verified install record"),
+        }),
+      ).toBe(true);
+      expect(mocks.installPluginFromNpmSpec).toHaveBeenCalledOnce();
+      expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
+        spec: `${packageName}@${version}`,
+        mode: "update",
+        trustedSourceLinkedOfficialInstall: true,
+      });
+      expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
+      expect(consent).not.toHaveBeenCalled();
+      expect(result.warnings).toEqual([]);
+      expect(fixtures.every((fixture) => !fs.existsSync(fixture.runtimeMarker))).toBe(true);
+    },
+  );
 
   it("passes the post-core compatibility host version to ClawHub repair", async () => {
     const npmRoot = tempDirs.make("openclaw-plugin-stub-repair-");
@@ -2411,6 +2477,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         },
       },
       env: {
+        ...testEnv,
         OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.5.19",
         OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
       },
@@ -2419,6 +2486,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expectRecordFields(mockCallArg(mocks.installPluginFromClawHub), {
       spec: expectedClawHubInstallSpec("clawhub:@openclaw/whatsapp"),
       env: {
+        ...testEnv,
         OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.5.19",
         OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
       },
@@ -2473,6 +2541,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         },
       },
       env: {
+        ...testEnv,
         OPENCLAW_UPDATE_IN_PROGRESS: "1",
         OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
       },
@@ -2516,6 +2585,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         },
       },
       env: {
+        ...testEnv,
         OPENCLAW_UPDATE_IN_PROGRESS: "1",
         OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
       },
@@ -2558,6 +2628,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         },
       },
       env: {
+        ...testEnv,
         OPENCLAW_UPDATE_IN_PROGRESS: "1",
         OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
       },
@@ -2600,9 +2671,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           discord: { enabled: true, token: "secret" },
         },
       },
-      env: {
-        OPENCLAW_UPDATE_IN_PROGRESS: "1",
-      },
+      env: { ...testEnv, OPENCLAW_UPDATE_IN_PROGRESS: "1" },
     });
 
     expect(mocks.installPluginFromNpmSpec).toHaveBeenCalledTimes(1);
@@ -2647,9 +2716,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           whatsapp: { enabled: true, allowFrom: ["+15555550123"] },
         },
       },
-      env: {
-        OPENCLAW_UPDATE_IN_PROGRESS: "1",
-      },
+      env: { ...testEnv, OPENCLAW_UPDATE_IN_PROGRESS: "1" },
     });
 
     expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
@@ -2687,9 +2754,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           matrix: { enabled: true, homeserver: "https://matrix.example.org" },
         },
       },
-      env: {
-        OPENCLAW_UPDATE_IN_PROGRESS: "1",
-      },
+      env: { ...testEnv, OPENCLAW_UPDATE_IN_PROGRESS: "1" },
     });
 
     expectRecordFields(mockCallArg(mocks.installPluginFromClawHub), {
@@ -2779,7 +2844,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           },
         },
       },
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.updateNpmInstalledPlugins).toHaveBeenCalledWith(
@@ -2802,7 +2867,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           allow: ["codex"],
         },
       },
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
@@ -2838,7 +2903,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       cfg: {},
       pluginIds: [],
       channelIds: ["wecom"],
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
@@ -2938,7 +3003,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     const result = await repairMissingPluginInstallsForIds({
       cfg,
       pluginIds: ["codex"],
-      env: {},
+      env: testEnv,
       baselineRecords: {},
     });
 
@@ -2959,7 +3024,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
     expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords, 0, 1)).toEqual({
       config: cfg,
-      env: {},
+      env: testEnv,
     });
     expect(result.changes).toEqual([
       `Installed missing configured plugin "codex" from ${expectedCodexInstallSpec()}.`,
@@ -3000,7 +3065,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         },
       },
       pluginIds: ["codex"],
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.resolveProviderInstallCatalogEntries).toHaveBeenCalled();
@@ -3018,7 +3083,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
     expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords, 0, 1)).toEqual({
       config: expect.any(Object),
-      env: {},
+      env: testEnv,
     });
     expect(result.changes).toEqual([
       `Installed missing configured plugin "codex" from ${expectedCodexInstallSpec()}.`,
@@ -3112,7 +3177,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
             },
           },
         },
-        env: {},
+        env: testEnv,
       });
 
       expect(mocks.resolveDirectBundledProviderPolicySurface).toHaveBeenCalledWith("openai");
@@ -3222,7 +3287,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       await import("./missing-configured-plugin-install.js");
     const firstPass = await repairMissingConfiguredPluginInstalls({
       cfg,
-      env: {},
+      env: testEnv,
     });
 
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
@@ -3270,7 +3335,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
 
     const secondPass = await repairMissingConfiguredPluginInstalls({
       cfg,
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
@@ -3328,7 +3393,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           },
         },
       },
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
@@ -3430,7 +3495,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       await import("./missing-configured-plugin-install.js");
     const result = await repairMissingConfiguredPluginInstalls({
       cfg,
-      env,
+      env: { ...testEnv, ...env },
     });
 
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
@@ -3447,7 +3512,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
     expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords, 0, 1)).toEqual({
       config: cfg,
-      env,
+      env: { ...testEnv, ...env },
     });
     expect(result.changes).toEqual([
       `Installed missing configured plugin "codex" from ${expectedCodexInstallSpec()}.`,
@@ -3505,7 +3570,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       await import("./missing-configured-plugin-install.js");
     const result = await repairMissingConfiguredPluginInstalls({
       cfg,
-      env,
+      env: { ...testEnv, ...env },
     });
 
     expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
@@ -3532,7 +3597,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       pluginIds: [],
       channelIds: ["matrix"],
       blockedPluginIds: ["matrix"],
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
@@ -3612,7 +3677,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           feishu: { footer: { model: false } },
         },
       },
-      env: {},
+      env: testEnv,
     });
 
     expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
@@ -3673,7 +3738,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           },
         },
       },
-      env: {},
+      env: testEnv,
     });
 
     const updateArg = expectRecordFields(mockCallArg(mocks.updateNpmInstalledPlugins), {
@@ -3687,7 +3752,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
     expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords, 0, 1)).toEqual({
       config: expect.any(Object),
-      env: {},
+      env: testEnv,
     });
     expect(result.changes).toEqual(['Repaired missing configured plugin "demo".']);
   });
@@ -3737,7 +3802,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           },
         },
       },
-      env: {},
+      env: testEnv,
       onCapabilityConsent,
     });
 
@@ -3801,7 +3866,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           },
         },
       },
-      env: {},
+      env: testEnv,
     });
 
     expect(result.warnings).toContain(repairWarning);
@@ -3863,7 +3928,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           },
         },
       },
-      env: {},
+      env: testEnv,
     });
 
     expect(result.notices).toContain(reviewNotice);
@@ -3920,7 +3985,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       await import("./missing-configured-plugin-install.js");
     const result = await repairMissingConfiguredPluginInstalls({
       cfg: {},
-      env: {},
+      env: testEnv,
     });
 
     const updateArg = expectRecordFields(mockCallArg(mocks.updateNpmInstalledPlugins), {
@@ -4137,7 +4202,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
     expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords, 0, 1)).toEqual({
       config: expect.any(Object),
-      env: {},
+      env: testEnv,
     });
     expect(result.changes).toEqual(['Repaired missing configured plugin "discord".']);
   });
@@ -4205,7 +4270,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expectRecordFields(persistedRecords.discord, { installPath: process.cwd() });
     expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords, 0, 1)).toEqual({
       config: expect.any(Object),
-      env: {},
+      env: testEnv,
     });
     expect(result).toEqual({
       changes: ['Repaired missing configured plugin "discord".'],
@@ -4265,7 +4330,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expectRecordFields(persistedRecords.brave, { installPath: process.cwd() });
     expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords, 0, 1)).toEqual({
       config: expect.any(Object),
-      env: {},
+      env: testEnv,
     });
     expect(result.changes).toEqual(['Repaired missing configured plugin "brave".']);
   });
@@ -4731,7 +4796,10 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     const env = { GROQ_API_KEY: "groq-key" };
     const result = await repairConfiguredPlugins({}, env);
 
-    expect(mocks.resolveOfficialExternalProviderPluginIdsForEnv).toHaveBeenCalledWith(env);
+    expect(mocks.resolveOfficialExternalProviderPluginIdsForEnv).toHaveBeenCalledWith({
+      ...testEnv,
+      ...env,
+    });
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
       spec: expectedNpmInstallSpec("@openclaw/groq-provider"),
       expectedPluginId: "groq",
@@ -4787,7 +4855,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
     expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords, 0, 1)).toEqual({
       config: expect.any(Object),
-      env: {},
+      env: testEnv,
     });
     expect(result.changes).toEqual([
       'Installed missing configured plugin "brave" from @openclaw/brave-plugin@beta.',
@@ -4880,7 +4948,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
 
     expect(mocks.resolveOfficialExternalWebProviderContractPluginIdsForEnv).toHaveBeenCalledWith({
       contract: "webFetchProviders",
-      env,
+      env: { ...testEnv, ...env },
     });
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
       spec: expectedNpmInstallSpec("@openclaw/firecrawl-plugin"),


### PR DESCRIPTION
Closes #135450

## What Problem This Solves

Post-update repair could keep a stale npm plugin when package files existed but its install record could not be recovered. The post-core adoption shortcut read the local package version and published a record without installing the channel-selected or pinned target or establishing registry integrity.

## Why This Change Was Made

Delete that alternate path and its two helpers. Missing-record recovery now follows the existing npm installer and Doctor publication flow: selected source/version, registry verification, capability consent, staging and rollback, then successful install-record publication. Main's source-selection and consent recovery changes are preserved.

Production: +0/-102. Tests: +228/-160. Docs: +7/-0. The only baseline change removes the one assertion violation deleted with the old helper; no budget, inventory, snapshot, configuration, or schema surface is added.

## User Impact

Recovery converges to the selected stable, beta, or explicitly pinned package in legacy and project npm layouts. If no install record can be recovered, this path requires registry access. Verification failure preserves the old payload and publishes no new record; third-party capability refusal remains terminal and explicit. This verified-only recovery tradeoff is intentional and documented in `docs/cli/update.md`.

## Evidence

- Pre-fix reproduction: ran the current regression fixtures with the pre-fix install owner in a temporary copy, without stashing or replacing the worktree source. Five intended failures: the four `converges orphaned ...` cases returned stale `2026.7.1` without selected integrity, and accepted `npm-existing` consent bypassed the verified installer commit (`expected false to be true`). Refusal control passed.
- Exact candidate `7360279c395bfcb99ea216e8436d56db8c28dd67`, tree `038853f53142634f091e6296ce6e97facbcae84d`, on Linux Blacksmith Testbox: `pnpm test src/commands/doctor/shared/missing-configured-plugin-install.test.ts` passed **108 tests**; normal `pnpm build` exited 0. [Proof run 33577330608](https://github.com/openclaw/openclaw/actions/runs/33577330608).
- Freshly built normal CLI with real npm, isolated synthetic state and a loopback registry: `update repair --yes --json` refused unaccepted capabilities (exit 1, old payload retained, no record); adding `--accept-capabilities` installed `1.0.0` from stale `0.1.0` (exit 0, matching tarball integrity and persisted accepted surface); repeat repair exited 0 with `changed:false` and `unchanged` version/integrity/consent. Each stdout was one JSON document. No live credentials were passed to the CLI. Receipt confirms all observed owned processes exited and registry socket closed; the Testbox lease is stopped.
- Exact-head [CI run 33577238741](https://github.com/openclaw/openclaw/actions/runs/33577238741) is green. The native watcher finished `STATUS state=SUCCESS pending=0 superseded=0` / `GREEN`.
- The original failing [compact-large-18 job](https://github.com/openclaw/openclaw/actions/runs/33567384637/job/100053739431) was the unrelated sidebar marquee selector, already repaired on main by #135597. A real source-selection conflict required rebasing the old synchronization merges; no UI changes are part of this PR.
- Formatting and diff checks passed. Managed Codex uncommitted review passed before commit, and final branch P0–P2 review finished: `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority`.

A later native merge preflight required the prescribed wrapper-recovery rebase onto current main. Both commits replayed unchanged (`git range-diff` equality); the refreshed head passed a fresh P0–P2 autoreview, clean Testbox build/CLI proof, and exact-head CI. The preflight had stopped before merge dispatch.

ClawSweeper's rank-up move to investigate the failing job and complete exact-head CI is addressed. The existing verified-only recovery risk is accepted as described above; no new persistent representation or migration version is introduced.

Named follow-ups outside this repair: the consent/recovered-record owner should review provenance of records reconstructed from surviving npm dependency metadata (`src/plugins/installed-plugin-index-record-reader.ts`) before this orphaned-payload path runs. The synthetic retained legacy declaration also still emits a stale legacy-declaration warning after successful repair; this proof establishes payload/install-record convergence, not legacy descriptor cleanup. Neither path is changed here.
