### PR TITLE
fix(gateway): prevent long temp paths from breaking desktop tunnels

### DIFF
--- a/src/gateway/worker-environments/desktop-tunnel.test.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.test.ts
@@ -1,4 +1,4 @@
-import fs, { access } from "node:fs/promises";
+import { access, mkdir, mkdtemp, rm, stat } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WorkerDesktopEndpoint, WorkerSshEndpoint } from "../../plugins/types.js";
@@ -132,6 +132,44 @@ async function waitForStarts(starts: unknown[], count: number) {
 afterEach(() => vi.useRealTimers());
 
 describe("worker desktop tunnels", () => {
+  it.skipIf(process.platform === "win32")(
+    "keeps the socket and credentials in one short private directory despite a long temp root",
+    async ({ onTestFinished }) => {
+      const root = await mkdtemp("/tmp/oc-desktop-test-");
+      const ambient = path.join(root, "long-temporary-root-" + "x".repeat(120));
+      const fake = fakeRunner();
+      const manager = createWorkerDesktopTunnels({ runner: fake.runner });
+      onTestFinished(async () => {
+        await manager.stopAll();
+        vi.unstubAllEnvs();
+        await rm(root, { recursive: true, force: true });
+      });
+      await mkdir(ambient);
+      vi.stubEnv("TMPDIR", ambient);
+      const starting = manager.acquire({
+        environmentId: "worker:long-path",
+        ownerEpoch: 1,
+        ssh: SSH,
+        desktop: { protocol: "rfb", port: 5900 },
+        resolveIdentity: async () => ({ kind: "material", contents: "synthetic-identity" }),
+      });
+      await waitForStarts(fake.starts, 1);
+      fake.starts[0]!.process.becomeReady();
+      const { attachment } = await starting;
+      if (attachment.kind !== "unix-socket") {
+        throw new Error("expected an SSH desktop socket");
+      }
+      expect(Buffer.byteLength(attachment.socketPath)).toBeLessThanOrEqual(103);
+      const directory = path.dirname(attachment.socketPath);
+      expect((await stat(directory)).mode & 0o777).toBe(0o700);
+      for (const name of ["identity", "known_hosts"]) {
+        expect((await stat(path.join(directory, name))).mode & 0o777).toBe(0o600);
+      }
+      await manager.stopAll();
+      await expect(access(directory)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
   it("creates one pinned local forward per epoch and caches the password", async () => {
     const fake = fakeRunner();
     const manager = createWorkerDesktopTunnels({ runner: fake.runner });
@@ -142,10 +180,9 @@ describe("worker desktop tunnels", () => {
     expect(start.argv).toContain("StreamLocalBindMask=0177");
     expect(start.argv).toContain("ServerAliveInterval=15");
     expect(start.argv).toContain("ServerAliveCountMax=3");
-    const forward = start.argv[start.argv.indexOf("-L") + 1]!;
-    expect(forward).toMatch(/^\/tmp\/oc-wd-.+\/desktop\.sock:127\.0\.0\.1:5900$/u);
-    const socketPath = forward.slice(0, forward.indexOf(":127.0.0.1:"));
-    expect(Buffer.byteLength(socketPath)).toBeLessThan(104);
+    expect(start.argv[start.argv.indexOf("-L") + 1]).toMatch(
+      /openclaw-worker-desktop-.+\/desktop\.sock:127\.0\.0\.1:5900$/u,
+    );
     expect(start.options.input).toContain("OPENCLAW_WORKER_TUNNEL_READY");
     start.process.becomeReady();
     const result = await starting;
@@ -183,64 +220,6 @@ describe("worker desktop tunnels", () => {
     expect(fake.starts[0]!.process.stopCount).toBe(1);
     await manager.stopAll();
     await expect(access(identityDirectory)).rejects.toMatchObject({ code: "ENOENT" });
-  });
-
-  it("removes the short socket directory when tunnel startup fails", async () => {
-    let forward = "";
-    const runner: WorkerSshRunner = {
-      start(argv) {
-        forward = argv[argv.indexOf("-L") + 1] ?? "";
-        throw new Error("synthetic SSH startup failure");
-      },
-      async run() {
-        return success();
-      },
-    };
-    const manager = createWorkerDesktopTunnels({ runner, platform: "linux" });
-
-    await expect(acquire(manager)).rejects.toThrow("synthetic SSH startup failure");
-    const socketPath = forward.slice(0, forward.indexOf(":127.0.0.1:"));
-    expect(socketPath).toMatch(/^\/tmp\/oc-wd-.+\/desktop\.sock$/u);
-    await vi.waitFor(async () => {
-      await expect(access(path.dirname(socketPath))).rejects.toMatchObject({ code: "ENOENT" });
-    });
-  });
-
-  it("does not start SSH after stop wins during socket setup", async ({ onTestFinished }) => {
-    const fake = fakeRunner();
-    const chmodStarted = deferred<void>();
-    const continueChmod = deferred<void>();
-    let socketDirectory = "";
-    const manager = createWorkerDesktopTunnels({
-      runner: fake.runner,
-      platform: "linux",
-      filesystem: {
-        async mkdtemp(prefix) {
-          socketDirectory = await fs.mkdtemp(prefix);
-          return socketDirectory;
-        },
-        rm: fs.rm.bind(fs),
-        async chmod(target, mode) {
-          await fs.chmod(target, mode);
-          chmodStarted.resolve();
-          await continueChmod.promise;
-        },
-      },
-    });
-    onTestFinished(async () => {
-      continueChmod.resolve();
-      await manager.stopAll();
-    });
-
-    const starting = acquire(manager);
-    await chmodStarted.promise;
-    const stopping = manager.stop("worker:one", 1);
-    continueChmod.resolve();
-
-    await expect(starting).rejects.toThrow("stopped before connecting");
-    await stopping;
-    expect(fake.starts).toEqual([]);
-    await expect(access(socketDirectory)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("fences an older epoch before starting its replacement", async () => {

--- a/src/gateway/worker-environments/desktop-tunnel.test.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.test.ts
@@ -185,6 +185,27 @@ describe("worker desktop tunnels", () => {
     await expect(access(identityDirectory)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("removes the short socket directory when tunnel startup fails", async () => {
+    let forward = "";
+    const runner: WorkerSshRunner = {
+      start(argv) {
+        forward = argv[argv.indexOf("-L") + 1] ?? "";
+        throw new Error("synthetic SSH startup failure");
+      },
+      async run() {
+        return success();
+      },
+    };
+    const manager = createWorkerDesktopTunnels({ runner, platform: "linux" });
+
+    await expect(acquire(manager)).rejects.toThrow("synthetic SSH startup failure");
+    const socketPath = forward.slice(0, forward.indexOf(":127.0.0.1:"));
+    expect(socketPath).toMatch(/^\/tmp\/oc-wd-.+\/desktop\.sock$/u);
+    await vi.waitFor(async () => {
+      await expect(access(path.dirname(socketPath))).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
   it("fences an older epoch before starting its replacement", async () => {
     const fake = fakeRunner();
     const manager = createWorkerDesktopTunnels({ runner: fake.runner });

--- a/src/gateway/worker-environments/desktop-tunnel.test.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.test.ts
@@ -1,4 +1,4 @@
-import { access } from "node:fs/promises";
+import fs, { access } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WorkerDesktopEndpoint, WorkerSshEndpoint } from "../../plugins/types.js";
@@ -204,6 +204,43 @@ describe("worker desktop tunnels", () => {
     await vi.waitFor(async () => {
       await expect(access(path.dirname(socketPath))).rejects.toMatchObject({ code: "ENOENT" });
     });
+  });
+
+  it("does not start SSH after stop wins during socket setup", async ({ onTestFinished }) => {
+    const fake = fakeRunner();
+    const chmodStarted = deferred<void>();
+    const continueChmod = deferred<void>();
+    let socketDirectory = "";
+    const manager = createWorkerDesktopTunnels({
+      runner: fake.runner,
+      platform: "linux",
+      filesystem: {
+        async mkdtemp(prefix) {
+          socketDirectory = await fs.mkdtemp(prefix);
+          return socketDirectory;
+        },
+        rm: fs.rm.bind(fs),
+        async chmod(target, mode) {
+          await fs.chmod(target, mode);
+          chmodStarted.resolve();
+          await continueChmod.promise;
+        },
+      },
+    });
+    onTestFinished(async () => {
+      continueChmod.resolve();
+      await manager.stopAll();
+    });
+
+    const starting = acquire(manager);
+    await chmodStarted.promise;
+    const stopping = manager.stop("worker:one", 1);
+    continueChmod.resolve();
+
+    await expect(starting).rejects.toThrow("stopped before connecting");
+    await stopping;
+    expect(fake.starts).toEqual([]);
+    await expect(access(socketDirectory)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("fences an older epoch before starting its replacement", async () => {

--- a/src/gateway/worker-environments/desktop-tunnel.test.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.test.ts
@@ -142,9 +142,10 @@ describe("worker desktop tunnels", () => {
     expect(start.argv).toContain("StreamLocalBindMask=0177");
     expect(start.argv).toContain("ServerAliveInterval=15");
     expect(start.argv).toContain("ServerAliveCountMax=3");
-    expect(start.argv[start.argv.indexOf("-L") + 1]).toMatch(
-      /openclaw-worker-desktop-.+\/desktop\.sock:127\.0\.0\.1:5900$/u,
-    );
+    const forward = start.argv[start.argv.indexOf("-L") + 1]!;
+    expect(forward).toMatch(/^\/tmp\/oc-wd-.+\/desktop\.sock:127\.0\.0\.1:5900$/u);
+    const socketPath = forward.slice(0, forward.indexOf(":127.0.0.1:"));
+    expect(Buffer.byteLength(socketPath)).toBeLessThan(104);
     expect(start.options.input).toContain("OPENCLAW_WORKER_TUNNEL_READY");
     start.process.becomeReady();
     const result = await starting;

--- a/src/gateway/worker-environments/desktop-tunnel.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.ts
@@ -48,7 +48,14 @@ type DesktopAcquireRequest = {
 };
 
 type DesktopAcquireResult = { attachment: DesktopRfbAttachment; vncPassword?: string };
-type WorkerDesktopTunnelFileSystem = Pick<typeof fs, "chmod" | "mkdtemp" | "rm">;
+type WorkerDesktopTunnelFileSystem = {
+  mkdtemp: (prefix: string) => Promise<string>;
+  chmod: (
+    target: Parameters<typeof fs.chmod>[0],
+    mode: Parameters<typeof fs.chmod>[1],
+  ) => Promise<void>;
+  rm: (target: Parameters<typeof fs.rm>[0], options: Parameters<typeof fs.rm>[1]) => Promise<void>;
+};
 
 type DesktopAppLaunchEntry = {
   environmentId: string;

--- a/src/gateway/worker-environments/desktop-tunnel.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { withTimeout } from "../../infra/fs-safe.js";
 import { registerSecretValueForRedaction } from "../../logging/secret-redaction-registry.js";
@@ -30,6 +31,7 @@ import {
 
 const PASSWORD_READ_TIMEOUT_MS = 20_000;
 const APP_LAUNCH_TIMEOUT_MS = 30_000;
+const WORKER_DESKTOP_SOCKET_ROOT = "/tmp";
 
 const REMOTE_DESKTOP_READY_SCRIPT = String.raw`set -eu
 printf '%s\n' '${WORKER_TUNNEL_READY_MARKER}'
@@ -120,6 +122,7 @@ export function createWorkerDesktopTunnels(deps: {
     let prepared: PreparedWorkerSsh | undefined;
     let child: WorkerSshProcess | undefined;
     let stoppedChild: WorkerSshProcess | undefined;
+    let socketDirectory: string | undefined;
     let startSettled = false;
 
     const start = async (isCurrent: () => boolean): Promise<DesktopAcquireResult> => {
@@ -135,7 +138,9 @@ export function createWorkerDesktopTunnels(deps: {
           prepared = undefined;
           throw new Error("Worker desktop tunnel stopped before connecting");
         }
-        const localSocketPath = path.join(path.dirname(prepared.knownHostsPath), "desktop.sock");
+        socketDirectory = await fs.mkdtemp(path.join(WORKER_DESKTOP_SOCKET_ROOT, "oc-wd-"));
+        await fs.chmod(socketDirectory, 0o700);
+        const localSocketPath = path.join(socketDirectory, "desktop.sock");
         child = deps.runner.start(
           [
             "ssh",
@@ -219,6 +224,10 @@ export function createWorkerDesktopTunnels(deps: {
       if (child && child !== stoppedChild) {
         stoppedChild = child;
         await child?.stop().catch(() => undefined);
+      }
+      if (socketDirectory) {
+        await fs.rm(socketDirectory, { recursive: true, force: true }).catch(() => undefined);
+        socketDirectory = undefined;
       }
       await prepared?.dispose().catch(() => undefined);
       prepared = undefined;

--- a/src/gateway/worker-environments/desktop-tunnel.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.ts
@@ -143,8 +143,14 @@ export function createWorkerDesktopTunnels(deps: {
         }
         socketDirectory = await filesystem.mkdtemp(path.join(WORKER_DESKTOP_SOCKET_ROOT, "oc-wd-"));
         await filesystem.chmod(socketDirectory, 0o700);
-        // Socket setup yields to Stop/replacement; recheck ownership before publishing SSH.
+        // Socket setup yields to Stop/replacement; clean late allocations before publishing SSH.
         if (!isCurrent()) {
+          await filesystem
+            .rm(socketDirectory, { recursive: true, force: true })
+            .catch(() => undefined);
+          socketDirectory = undefined;
+          await prepared.dispose().catch(() => undefined);
+          prepared = undefined;
           throw new Error("Worker desktop tunnel stopped before connecting");
         }
         const localSocketPath = path.join(socketDirectory, "desktop.sock");

--- a/src/gateway/worker-environments/desktop-tunnel.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.ts
@@ -48,6 +48,7 @@ type DesktopAcquireRequest = {
 };
 
 type DesktopAcquireResult = { attachment: DesktopRfbAttachment; vncPassword?: string };
+type WorkerDesktopTunnelFileSystem = Pick<typeof fs, "chmod" | "mkdtemp" | "rm">;
 
 type DesktopAppLaunchEntry = {
   environmentId: string;
@@ -76,8 +77,10 @@ export function createWorkerDesktopTunnels(deps: {
   registry?: DesktopSessionRegistry;
   lingerMs?: number;
   platform?: NodeJS.Platform;
+  filesystem?: WorkerDesktopTunnelFileSystem;
 }) {
   const platform = deps.platform ?? process.platform;
+  const filesystem = deps.filesystem ?? fs;
   const sessions = deps.registry ?? createDesktopSessionRegistry({ lingerMs: deps.lingerMs });
   const appLaunches = new Map<string, DesktopAppLaunchEntry>();
 
@@ -138,8 +141,12 @@ export function createWorkerDesktopTunnels(deps: {
           prepared = undefined;
           throw new Error("Worker desktop tunnel stopped before connecting");
         }
-        socketDirectory = await fs.mkdtemp(path.join(WORKER_DESKTOP_SOCKET_ROOT, "oc-wd-"));
-        await fs.chmod(socketDirectory, 0o700);
+        socketDirectory = await filesystem.mkdtemp(path.join(WORKER_DESKTOP_SOCKET_ROOT, "oc-wd-"));
+        await filesystem.chmod(socketDirectory, 0o700);
+        // Socket setup yields to Stop/replacement; recheck ownership before publishing SSH.
+        if (!isCurrent()) {
+          throw new Error("Worker desktop tunnel stopped before connecting");
+        }
         const localSocketPath = path.join(socketDirectory, "desktop.sock");
         child = deps.runner.start(
           [
@@ -226,7 +233,9 @@ export function createWorkerDesktopTunnels(deps: {
         await child?.stop().catch(() => undefined);
       }
       if (socketDirectory) {
-        await fs.rm(socketDirectory, { recursive: true, force: true }).catch(() => undefined);
+        await filesystem
+          .rm(socketDirectory, { recursive: true, force: true })
+          .catch(() => undefined);
         socketDirectory = undefined;
       }
       await prepared?.dispose().catch(() => undefined);

--- a/src/gateway/worker-environments/desktop-tunnel.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import { withTimeout } from "../../infra/fs-safe.js";
 import { registerSecretValueForRedaction } from "../../logging/secret-redaction-registry.js";
@@ -31,7 +30,6 @@ import {
 
 const PASSWORD_READ_TIMEOUT_MS = 20_000;
 const APP_LAUNCH_TIMEOUT_MS = 30_000;
-const WORKER_DESKTOP_SOCKET_ROOT = "/tmp";
 
 const REMOTE_DESKTOP_READY_SCRIPT = String.raw`set -eu
 printf '%s\n' '${WORKER_TUNNEL_READY_MARKER}'
@@ -48,14 +46,6 @@ type DesktopAcquireRequest = {
 };
 
 type DesktopAcquireResult = { attachment: DesktopRfbAttachment; vncPassword?: string };
-type WorkerDesktopTunnelFileSystem = {
-  mkdtemp: (prefix: string) => Promise<string>;
-  chmod: (
-    target: Parameters<typeof fs.chmod>[0],
-    mode: Parameters<typeof fs.chmod>[1],
-  ) => Promise<void>;
-  rm: (target: Parameters<typeof fs.rm>[0], options: Parameters<typeof fs.rm>[1]) => Promise<void>;
-};
 
 type DesktopAppLaunchEntry = {
   environmentId: string;
@@ -84,10 +74,8 @@ export function createWorkerDesktopTunnels(deps: {
   registry?: DesktopSessionRegistry;
   lingerMs?: number;
   platform?: NodeJS.Platform;
-  filesystem?: WorkerDesktopTunnelFileSystem;
 }) {
   const platform = deps.platform ?? process.platform;
-  const filesystem = deps.filesystem ?? fs;
   const sessions = deps.registry ?? createDesktopSessionRegistry({ lingerMs: deps.lingerMs });
   const appLaunches = new Map<string, DesktopAppLaunchEntry>();
 
@@ -132,7 +120,6 @@ export function createWorkerDesktopTunnels(deps: {
     let prepared: PreparedWorkerSsh | undefined;
     let child: WorkerSshProcess | undefined;
     let stoppedChild: WorkerSshProcess | undefined;
-    let socketDirectory: string | undefined;
     let startSettled = false;
 
     const start = async (isCurrent: () => boolean): Promise<DesktopAcquireResult> => {
@@ -141,26 +128,15 @@ export function createWorkerDesktopTunnels(deps: {
           ssh: request.ssh,
           pinnedHostKey: request.ssh.hostKey,
           resolveIdentity: request.resolveIdentity,
-          temporaryDirectoryPrefix: "openclaw-worker-desktop-",
+          // macOS Unix sockets allow 103 bytes; share one short private directory with SSH credentials.
+          temporaryDirectoryPrefix: "/tmp/openclaw-worker-desktop-",
         });
         if (!isCurrent()) {
           await prepared.dispose();
           prepared = undefined;
           throw new Error("Worker desktop tunnel stopped before connecting");
         }
-        socketDirectory = await filesystem.mkdtemp(path.join(WORKER_DESKTOP_SOCKET_ROOT, "oc-wd-"));
-        await filesystem.chmod(socketDirectory, 0o700);
-        // Socket setup yields to Stop/replacement; clean late allocations before publishing SSH.
-        if (!isCurrent()) {
-          await filesystem
-            .rm(socketDirectory, { recursive: true, force: true })
-            .catch(() => undefined);
-          socketDirectory = undefined;
-          await prepared.dispose().catch(() => undefined);
-          prepared = undefined;
-          throw new Error("Worker desktop tunnel stopped before connecting");
-        }
-        const localSocketPath = path.join(socketDirectory, "desktop.sock");
+        const localSocketPath = path.join(path.dirname(prepared.knownHostsPath), "desktop.sock");
         child = deps.runner.start(
           [
             "ssh",
@@ -244,12 +220,6 @@ export function createWorkerDesktopTunnels(deps: {
       if (child && child !== stoppedChild) {
         stoppedChild = child;
         await child?.stop().catch(() => undefined);
-      }
-      if (socketDirectory) {
-        await filesystem
-          .rm(socketDirectory, { recursive: true, force: true })
-          .catch(() => undefined);
-        socketDirectory = undefined;
       }
       await prepared?.dispose().catch(() => undefined);
       prepared = undefined;

--- a/src/gateway/worker-environments/ssh.ts
+++ b/src/gateway/worker-environments/ssh.ts
@@ -151,7 +151,7 @@ export async function prepareWorkerSsh(params: {
     )
     .join("");
   const temporaryDir = await fs.mkdtemp(
-    path.join(os.tmpdir(), params.temporaryDirectoryPrefix ?? "openclaw-worker-ssh-"),
+    path.resolve(os.tmpdir(), params.temporaryDirectoryPrefix ?? "openclaw-worker-ssh-"),
   );
   try {
     const identity = await params.resolveIdentity(params.ssh.keyRef);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where observing an SSH worker desktop fails when the Gateway host has a long temporary-directory path. OpenSSH rejects the local Unix-socket forwarding argument before the desktop connects. The same owner code is present in v2026.8.2.

## Why This Change Was Made

Keep the socket and SSH credentials in the existing private preparation directory, choosing a short absolute prefix for desktop tunnels. The shared SSH preparer resolves that prefix, while its other callers retain their ambient temporary roots. Existing preparation, owner revalidation, replacement and disposal remain the sole lifecycle. This removes the need for the incoming patch’s separate socket directory and cleanup state.

Production: +3/−2, net +1; tests: +39/−1, net +38. The one net production line documents the macOS socket-length contract. No configuration, protocol or stored-data shape changes are involved.

## User Impact

SSH worker desktops connect even when the host’s normal temporary directory is too long for a Unix socket. Windows Gateway desktop tunneling keeps its existing unsupported-platform behavior.

## Evidence

A real Linux OpenSSH server and client exercised the production tunnel manager, SSH preparation, SSH runner and desktop attachment connector using synthetic desktop bytes. On the same trusted source baseline, the old 213-byte socket failed and the repaired 48-byte socket transferred the payload. The regression test failed on baseline with `212 > 103`; the fixed candidate passed all 26 focused desktop/SSH tests.

Real execution also verified 0700 directory and 0600 credential modes, replacement cleanup, stale-owner rejection without another SSH spawn, failure cleanup, stop during pending identity preparation, generic SSH temporary-root behavior and the Windows guard. Every owned SSH daemon, socket, key and prepared directory was removed. This supplies the latest ClawSweeper real-SSH proof and rank-up request; its stored-data-model warning does not apply to these ephemeral files.

[Dedicated Testbox execution](https://github.com/openclaw/openclaw/actions/runs/33566752841), trusted baseline `45be2a2ed06889541212c0a419acec92a8ecfb39`. This is candidate proof, not a claim about the eventual published head’s CI. Complete three-file independent review found no P0 findings (confidence 0.97). The complete changed-files gate passed: core and core-test types, scoped lint/format, dependency and boundary guards, dead-export and import-cycle checks. The wrapper completed with exit 0; a subsequent external-portal sync timeout affected publication of the run summary only.

Observed synthetic receipts:

```json
{"label":"baseline","sourceHashes":{"desktop-tunnel.ts":"65388dc6129917c631ebd7c62f3c8b21b9e306b0803581643bbb0a942416e542","ssh.ts":"a2659f1c2d5ae799da1c06e18dff01f7ccf9d3dac4cf3121d5071b1bfbbf1fa4","tunnel-ssh-runner.ts":"9df4afbdbef635fb84ee70afa6e73ae4838b53acea2abec43abfc5b729b36ea7"},"reproduced":true,"error":"Worker desktop tunnel stopped before connecting","sshError":"Bad local forwarding specification '/tmp/oc-desktop-proof-1bcoNv/long-temporary-root-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/openclaw-worker-desktop-ezV9hu/desktop.sock:127.0.0.1:34651'","socketPathBytes":213,"cleanup":true}
{"label":"fixed","sourceHashes":{"desktop-tunnel.ts":"b92df5c0c8f301005b7345e8ec9ca9f1348fcf90d7eb9f541398351cd8fcdeb1","ssh.ts":"e1fcc460fc74a02f6d597054b6a3646f8594426d72e13b1d9de0570441298831","tunnel-ssh-runner.ts":"9df4afbdbef635fb84ee70afa6e73ae4838b53acea2abec43abfc5b729b36ea7"},"payload":"synthetic-desktop-payload","socketPathBytes":48,"directoryMode":"0700","fileModes":"0600","checks":["real SSH forwarding","owner replacement","stale owner fenced","generic tmpdir retained","startup failure cleanup","stop during preparation without spawn","Windows rejected before preparation"],"allPreparedDirectoriesRemoved":true}
```

Related: #132965. That merged fixture fix identified this separate production path.

Named follow-up: startup child exit can race readiness and mask the SSH diagnostic with “stopped before connecting”; the baseline trace records both layers. That diagnostic race is separate from this socket placement repair.
