### PR TITLE
fix(update): fail finalization on unresolved plugin consent

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -164,7 +164,10 @@ Plugin artifacts that require capability consent are not installed without an
 interactive review or explicit `--accept-capabilities`. `--yes` alone does not
 accept capability changes, and JSON mode does not prompt. An unresolved review
 preserves the previous plugin, exits non-zero, and blocks any requested Gateway
-restart.
+restart. This also applies when a bundled plugin moves to an external package or
+a missing configured plugin has no install record yet. Automatic repair can
+report a deferred replacement as a notice when a usable, enabled artifact remains
+installed; that retained artifact still undergoes payload validation.
 
 If the core package has already changed, run `openclaw update repair` in an
 interactive terminal to review plugin capabilities. After reviewing the changes,

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -31,6 +31,7 @@ import { cleanupStaleManagedServiceUpdateHandoffs } from "../infra/update-manage
 import type { UpdateRunResult } from "../infra/update-runner.js";
 import { runUpdateFailureTriage } from "../infra/update-triage.js";
 import { CLAWHUB_INSTALL_ERROR_CODE } from "../plugins/clawhub-error-codes.js";
+import { ManagedPluginLifecycleError } from "../plugins/management-lifecycle-error.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
 import { VERSION } from "../version.js";
 import { createCliRuntimeCapture, getMockCallOutput } from "./test-runtime-capture.js";
@@ -1141,7 +1142,10 @@ describe("update-cli", () => {
   const pluginSyncResult = (
     config: OpenClawConfig,
     changed = false,
-    overrides: { warnings?: string[]; errors?: string[] } = {},
+    overrides: {
+      warnings?: string[];
+      errors?: Array<{ pluginId: string; message: string; code?: string }>;
+    } = {},
   ) => ({
     changed,
     config,
@@ -3718,43 +3722,79 @@ describe("update-cli", () => {
     expect(getLogOutput()).toContain("Plugin update aborted");
   });
 
-  it("blocks restart when a plugin update awaits capability consent", async () => {
-    mockOwnedGitService();
-    mockGitUpdateAfterMutation();
-    serviceLoaded.mockResolvedValue(true);
-    mockNpmPluginOutcomes([
-      {
-        pluginId: "consent-fixture",
-        status: "error",
-        code: PLUGIN_CAPABILITY_CONSENT_REQUIRED,
-        message: "Operator review token changed.",
-      },
-    ]);
-
-    await updateCommand({ yes: true, json: true });
-
-    const jsonOutput = lastWriteJsonCall() as UpdateRunResult | undefined;
-    expect(jsonOutput?.status).toBe("error");
-    expect(jsonOutput?.reason).toBe("post-update-plugins");
-    expect(jsonOutput?.postUpdate?.plugins?.status).toBe("error");
-    expect(lastWriteJsonCall()).toMatchObject({
-      postUpdate: {
-        plugins: {
-          npm: {
-            outcomes: [
-              {
-                pluginId: "consent-fixture",
-                status: "error",
-                code: PLUGIN_CAPABILITY_CONSENT_REQUIRED,
-              },
+  it.each(
+    (["installed", "bridge"] as const).flatMap((source) =>
+      (["update", "finalize"] as const).map((mode) => ({ source, mode })),
+    ),
+  )(
+    "fails $mode without restarting when $source awaits capability consent",
+    async ({ source, mode }) => {
+      const pluginId = "consent-fixture";
+      const config = stableConfig({ plugins: { entries: { [pluginId]: { enabled: true } } } });
+      vi.mocked(readConfigFileSnapshot).mockResolvedValue(configSnapshot(config));
+      mockOwnedGitService();
+      mockGitUpdateAfterMutation();
+      serviceLoaded.mockResolvedValue(true);
+      if (source === "bridge") {
+        const install = await import("../plugins/install.js");
+        vi.spyOn(install, "installPluginFromNpmSpec").mockRejectedValueOnce(
+          new ManagedPluginLifecycleError("Operator review token changed.", {
+            capabilityConsent: { pluginId, reviewToken: "operator-review" },
+          }),
+        );
+        const actual = await vi.importActual<typeof import("../plugins/update-channel.js")>(
+          "../plugins/update-channel.js",
+        );
+        syncPluginsForUpdateChannel.mockImplementationOnce((params) =>
+          actual.syncPluginsForUpdateChannel({
+            ...params,
+            externalizedBundledPluginBridges: [
+              { bundledPluginId: pluginId, npmSpec: "@example/companion" },
             ],
+          }),
+        );
+      } else {
+        mockNpmPluginOutcomes([
+          {
+            pluginId,
+            status: "error",
+            code: PLUGIN_CAPABILITY_CONSENT_REQUIRED,
+            message: "Operator review token changed.",
           },
-        },
-      },
-    });
-    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
-    expectNoSideEffects(serviceRestart, runRestartScript, runDaemonRestart);
-  });
+        ]);
+      }
+
+      if (mode === "finalize") {
+        vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(
+          FRESH_POST_UPDATE_ENTRYPOINT,
+        );
+        await updateFinalizeCommand({ yes: true, json: true, restart: false });
+      } else {
+        await updateCommand({ yes: true, json: true });
+      }
+
+      const jsonOutput = lastWriteJsonCall() as UpdateRunResult | undefined;
+      expect(jsonOutput?.status).toBe("error");
+      if (mode === "update") {
+        expect(jsonOutput?.reason).toBe("post-update-plugins");
+      }
+      expect(jsonOutput?.postUpdate?.plugins?.status).toBe("error");
+      expect(jsonOutput?.postUpdate?.plugins?.npm.outcomes).toEqual([
+        expect.objectContaining({
+          pluginId,
+          status: "error",
+          code: PLUGIN_CAPABILITY_CONSENT_REQUIRED,
+        }),
+      ]);
+      if (source === "bridge") {
+        expect(jsonOutput?.postUpdate?.plugins?.sync.errors).toEqual([
+          "Failed to update consent-fixture: Operator review token changed.",
+        ]);
+      }
+      expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+      expectNoSideEffects(serviceRestart, runRestartScript, runDaemonRestart);
+    },
+  );
 
   it("keeps json update output successful when post-core plugin updates warn", async () => {
     updateNpmInstalledPlugins.mockImplementationOnce(
@@ -3911,7 +3951,7 @@ describe("update-cli", () => {
     syncPluginsForUpdateChannel.mockResolvedValueOnce(
       pluginSyncResult(baseConfig, false, {
         warnings: [trustWarning],
-        errors: [clawHubSyncRiskError],
+        errors: [{ pluginId: "demo", message: clawHubSyncRiskError }],
       }),
     );
     vi.mocked(defaultRuntime.writeJson).mockClear();
@@ -3931,7 +3971,7 @@ describe("update-cli", () => {
         params.logger?.warn?.(trustWarning);
         return pluginSyncResult(params.config, false, {
           warnings: [trustWarning],
-          errors: [clawHubSyncRiskError],
+          errors: [{ pluginId: "demo", message: clawHubSyncRiskError }],
         });
       },
     );

--- a/src/cli/update-cli/update-command-plugins.ts
+++ b/src/cli/update-cli/update-command-plugins.ts
@@ -221,6 +221,15 @@ export async function updatePluginsAfterCoreUpdate(params: {
   });
   const integrityDrifts: PostCorePluginUpdateResult["integrityDrifts"] = [];
   const pluginUpdateOutcomes: PluginUpdateOutcome[] = [];
+  const collectPluginOutcome = (rawOutcome: PluginUpdateOutcome) => {
+    const includeWarningInReason =
+      params.json || !rawOutcome.warning || !hasLoggedPluginWarning(rawOutcome.warning);
+    const guided = createGuidedPostUpdatePluginOutcome(rawOutcome, { includeWarningInReason });
+    pluginUpdateOutcomes.push(guided.outcome);
+    if (guided.warning) {
+      warnings.push(guided.warning);
+    }
+  };
 
   const onPluginIntegrityDrift = async (drift: PluginUpdateIntegrityDriftParams) => {
     integrityDrifts.push({
@@ -261,7 +270,7 @@ export async function updatePluginsAfterCoreUpdate(params: {
     ...capabilityConsent,
   });
   for (const error of cohort.sync.summary.errors) {
-    warnings.push(createPostUpdatePluginWarning({ reason: error }));
+    collectPluginOutcome({ ...error, status: "error" });
   }
   let pluginConfig = cohort.config;
   let pluginsChanged = cohort.changed || params.configChanged === true;
@@ -283,13 +292,7 @@ export async function updatePluginsAfterCoreUpdate(params: {
   }
   pluginUpdateOutcomes.push(...cohort.repairOutcomes);
   for (const rawOutcome of cohort.updateOutcomes) {
-    const includeWarningInReason =
-      params.json || !rawOutcome.warning || !hasLoggedPluginWarning(rawOutcome.warning);
-    const guided = createGuidedPostUpdatePluginOutcome(rawOutcome, { includeWarningInReason });
-    pluginUpdateOutcomes.push(guided.outcome);
-    if (guided.warning) {
-      warnings.push(guided.warning);
-    }
+    collectPluginOutcome(rawOutcome);
   }
 
   pluginUpdateOutcomes.push(
@@ -309,17 +312,8 @@ export async function updatePluginsAfterCoreUpdate(params: {
       }),
   );
 
-  // Mandatory post-core convergence: repair any configured plugin install
-  // records that are still missing payloads on disk and run a static smoke
-  // check that the repaired payloads are at least loadable. Failures here
-  // escalate `status` to `"error"`, which the caller maps to exit 1 BEFORE
-  // restarting the gateway. See `post-core-plugin-convergence.ts`.
-  //
-  // We pass `baselineInstallRecords: pluginConfig.plugins?.installs ?? {}`
-  // so that convergence layers its mutations on top of the latest
-  // *in-memory* sync/npm record state — not on the stale pre-update disk
-  // snapshot. The merged map convergence returns is the single source of
-  // truth for the subsequent commit block.
+  // Convergence checks activation before restart. Seed it from the current
+  // sync/npm records so repair cannot overwrite them with an older disk snapshot.
   const convergenceBaselineRecords = pluginConfig.plugins?.installs ?? {};
   const convergence = await runPostCorePluginConvergence({
     cfg: pluginConfig,
@@ -345,12 +339,8 @@ export async function updatePluginsAfterCoreUpdate(params: {
   }
   pluginUpdateOutcomes.push(...convergenceFolded.outcomes);
   const convergenceErrored = convergenceFolded.errored;
-  // Reseed `pluginConfig` from convergence's authoritative post-merge
-  // record map. This is unconditional because convergence is what
-  // reconciled the baseline (sync/npm in-memory state) with disk and any
-  // new repairs, and convergence already persisted that exact map. If
-  // we did not adopt it here, the commit block below would overwrite the
-  // disk with `convergenceBaselineRecords` (no repairs included).
+  // Repair already persisted this authoritative map; the commit below must not
+  // restore the pre-convergence records and discard successful repairs.
   pluginConfig = withPluginInstallRecords(pluginConfig, convergence.installRecords);
   if (convergence.changes.length > 0) {
     pluginsChanged = true;
@@ -414,7 +404,7 @@ export async function updatePluginsAfterCoreUpdate(params: {
       switchedToBundled: cohort.sync.summary.switchedToBundled,
       switchedToNpm: cohort.sync.summary.switchedToNpm,
       warnings: cohort.sync.summary.warnings,
-      errors: cohort.sync.summary.errors,
+      errors: cohort.sync.summary.errors.map((error) => error.message),
     },
     npm: {
       changed: npmPluginsChanged,
@@ -451,10 +441,6 @@ export async function updatePluginsAfterCoreUpdate(params: {
       runtime.log(formatPluginUpdateWarning(warning));
     }
   }
-  for (const error of cohort.sync.summary.errors) {
-    runtime.log(theme.warn(createPostUpdatePluginWarning({ reason: error }).message));
-  }
-
   const updated = pluginUpdateOutcomes.filter((entry) => entry.status === "updated").length;
   const unchanged = pluginUpdateOutcomes.filter((entry) => entry.status === "unchanged").length;
   const failed = pluginUpdateOutcomes.filter((entry) => entry.status === "error").length;

--- a/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
@@ -48,6 +48,8 @@ type RepairMissingPluginInstallsResult = {
   /** User-facing notices from successful repairs that still need operator review. */
   notices?: string[];
   warnings: string[];
+  /** Consent blocked activation; a retained usable enabled artifact only emits a notice. */
+  capabilityConsentRequired?: true;
   /** Plugin ids successfully repaired from current configuration. */
   repairedPluginIds?: string[];
   /** Successful install-record or package repairs that invalidate retained metadata. */
@@ -175,6 +177,7 @@ async function repairMissingPluginInstallsWithLease(
   const repairedPluginIds = new Set<string>();
   const deferredPluginIds = new Set<string>();
   const preferNpmInstalls = isLegacyPackageUpdateDoctorPass(env);
+  const consentBlockedPluginIds = new Set<string>();
   let nextRecords = records;
   const normalizedPluginConfig = normalizePluginsConfig(params.cfg.plugins);
   const recordFailure = (pluginId: string, messages: string[], code?: string) => {
@@ -198,6 +201,9 @@ async function repairMissingPluginInstallsWithLease(
       );
     } else {
       warnings.push(...messages);
+      if (code === PLUGIN_CAPABILITY_CONSENT_REQUIRED) {
+        consentBlockedPluginIds.add(pluginId);
+      }
     }
     failedPluginIds.add(pluginId);
   };
@@ -406,6 +412,8 @@ async function repairMissingPluginInstallsWithLease(
     notices.push(...installed.notices);
     if (!installed.failedPluginId && installed.records[candidate.pluginId]) {
       repairedPluginIds.add(candidate.pluginId);
+      // Catalog recovery can succeed after the recorded-package attempt refused consent.
+      consentBlockedPluginIds.delete(candidate.pluginId);
     }
     if (installed.failedPluginId) {
       recordFailure(installed.failedPluginId, installed.warnings, installed.code);
@@ -425,6 +433,7 @@ async function repairMissingPluginInstallsWithLease(
   return {
     changes,
     warnings,
+    ...(consentBlockedPluginIds.size > 0 ? { capabilityConsentRequired: true as const } : {}),
     ...(notices.length > 0 ? { notices } : {}),
     ...(deferredRepairDetails.length > 0 ? { deferredRepairDetails } : {}),
     ...(repairedPluginIds.size > 0

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -457,9 +457,11 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       if (previousState === "legacy" || previousState === "accepted") {
         expect(result.warnings).toEqual([]);
         expect(result.notices).toEqual([expect.stringContaining("--accept-capabilities")]);
+        expect(result.capabilityConsentRequired).toBeUndefined();
       } else {
         expect(result.warnings).toEqual([expect.stringContaining("--accept-capabilities")]);
         expect(result.notices).toBeUndefined();
+        expect(result.capabilityConsentRequired).toBe(true);
       }
     },
   );
@@ -520,6 +522,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       );
       expect(result.warnings).toEqual(["Review replacement capabilities."]);
       expect(result.notices).toBeUndefined();
+      expect(result.capabilityConsentRequired).toBe(true);
       if (siblingSucceeded) {
         expect(mocks.writePersistedInstalledPluginIndexInstallRecords).toHaveBeenCalledWith(
           result.records,
@@ -628,6 +631,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       expect(fs.existsSync(fixture.runtimeMarker)).toBe(false);
       if (accepted) {
         expect(consent).toHaveBeenCalledOnce();
+        expect(result.capabilityConsentRequired).toBeUndefined();
         expect(result.warnings).toEqual([]);
         expect(result.records.matrix).toMatchObject({
           acceptedSurface: { tools: ["matrix.write"] },
@@ -652,6 +656,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         expect(result.records).toEqual({});
         expect(result.failedPluginIds).toEqual(["matrix"]);
         expect(result.warnings.join("\n")).toMatch(/capabilit/i);
+        expect(result.capabilityConsentRequired).toBe(true);
         expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
       }
     },
@@ -3721,86 +3726,152 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expect(result.changes).toEqual(['Repaired broken installed plugin "demo".']);
   });
 
-  it("reinstalls a known configured plugin from the catalog when its recorded install path is missing", async () => {
-    const records = installedRecords("discord", {
-      spec: "@openclaw/discord",
-      installPath: "/tmp/openclaw-missing-discord-install-record",
-    });
-    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
-    mocks.loadPluginMetadataSnapshot.mockReturnValue({
-      plugins: [
-        {
-          id: "discord",
-          channels: ["discord"],
-        },
-      ],
-      diagnostics: [],
-    });
-    mocks.listChannelPluginCatalogEntries.mockReturnValue([
-      channelPluginEntry({
-        id: "discord",
-        npmSpec: "@openclaw/discord",
-        label: "Discord",
-        trustedSourceLinkedOfficialInstall: true,
-      }),
-    ]);
-    mocks.installPluginFromNpmSpec.mockResolvedValueOnce(
-      successfulInstall({
+  it.each([
+    { recordedConsentRequired: false, siblingConsentRequired: false },
+    { recordedConsentRequired: true, siblingConsentRequired: false },
+    { recordedConsentRequired: true, siblingConsentRequired: true },
+  ])(
+    "reinstalls a known configured plugin from the catalog when its recorded install path is missing (recorded consent=$recordedConsentRequired, sibling consent=$siblingConsentRequired)",
+    async ({ recordedConsentRequired, siblingConsentRequired }) => {
+      const actual = await vi.importActual<typeof import("../../../plugins/capability-consent.js")>(
+        "../../../plugins/capability-consent.js",
+      );
+      prepareManagedPluginArtifactConsentHandler.mockImplementation(
+        actual.prepareManagedPluginArtifactConsentHandler,
+      );
+      const root = tempDirs.make("openclaw-doctor-catalog-recovery-");
+      const artifactDir = path.join(root, "artifact");
+      fs.mkdirSync(artifactDir);
+      createColdPluginFixture({
+        rootDir: artifactDir,
         pluginId: "discord",
-        npmSpec: "@openclaw/discord",
-        version: "1.2.3",
-      }),
-    );
-    mocks.updateNpmInstalledPlugins.mockResolvedValue({
-      changed: false,
-      config: {
-        plugins: {
-          installs: records,
+        packageName: "@openclaw/discord",
+        packageVersion: "1.2.3",
+        manifest: { contracts: { tools: ["fixture.write"] } },
+      });
+      const records = installedRecords("discord", {
+        spec: "@openclaw/discord",
+        installPath: path.join(root, "missing-discord"),
+      });
+      if (siblingConsentRequired) {
+        records.sibling = {
+          source: "npm",
+          spec: "@example/sibling",
+          installPath: path.join(root, "missing-sibling"),
+        };
+      }
+      mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+      mocks.loadPluginMetadataSnapshot.mockReturnValue({
+        index: { plugins: [] },
+        plugins: [
+          {
+            id: "discord",
+            channels: ["discord"],
+          },
+        ],
+        diagnostics: [],
+      });
+      mocks.listChannelPluginCatalogEntries.mockReturnValue([
+        channelPluginEntry({
+          id: "discord",
+          npmSpec: "@openclaw/discord",
+          label: "Discord",
+          trustedSourceLinkedOfficialInstall: true,
+        }),
+      ]);
+      mocks.installPluginFromNpmSpec.mockImplementationOnce(
+        async (params: { onBeforePluginArtifactCommit: PluginInstallArtifactConsentHandler }) => {
+          await params.onBeforePluginArtifactCommit({
+            pluginId: "discord",
+            stagedArtifactDir: artifactDir,
+            mode: "install",
+          });
+          return successfulInstall({
+            pluginId: "discord",
+            npmSpec: "@openclaw/discord",
+            version: "1.2.3",
+            targetDir: artifactDir,
+          });
         },
-      },
-      outcomes: [
-        {
-          pluginId: "discord",
-          status: "skipped",
-          message: "No update applied.",
+      );
+      mocks.updateNpmInstalledPlugins.mockResolvedValue({
+        changed: false,
+        config: {
+          plugins: {
+            installs: records,
+          },
         },
-      ],
-    });
+        outcomes: [
+          {
+            pluginId: "discord",
+            status: recordedConsentRequired ? "error" : "skipped",
+            ...(recordedConsentRequired ? { code: PLUGIN_CAPABILITY_CONSENT_REQUIRED } : {}),
+            message: recordedConsentRequired
+              ? "Review recorded capabilities."
+              : "No update applied.",
+          },
+          ...(siblingConsentRequired
+            ? [
+                {
+                  pluginId: "sibling",
+                  status: "error",
+                  code: PLUGIN_CAPABILITY_CONSENT_REQUIRED,
+                  message: "Review sibling capabilities.",
+                },
+              ]
+            : []),
+        ],
+      });
 
-    const result = await repairConfiguredPlugins({
-      plugins: {
-        entries: {
-          discord: { enabled: true },
+      const onCapabilityConsent = vi.fn<PluginCapabilityConsentHandler>(async (review) => ({
+        reviewToken: review.reviewToken,
+      }));
+      const { repairMissingConfiguredPluginInstalls } =
+        await import("./missing-configured-plugin-install.js");
+      const result = await repairMissingConfiguredPluginInstalls({
+        cfg: {
+          plugins: {
+            entries: {
+              discord: { enabled: true },
+              ...(siblingConsentRequired ? { sibling: { enabled: true } } : {}),
+            },
+          },
+          channels: {
+            discord: { enabled: true },
+          },
         },
-      },
-      channels: {
-        discord: { enabled: true },
-      },
-    });
+        env: { OPENCLAW_STATE_DIR: path.join(root, "state") },
+        onCapabilityConsent,
+      });
 
-    const updateArg = expectRecordFields(mockCallArg(mocks.updateNpmInstalledPlugins), {
-      pluginIds: ["discord"],
-    });
-    const updateConfig = updateArg.config as Record<string, unknown>;
-    expectRecordFields(updateConfig.plugins, { installs: records });
-    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
-      spec: expectedNpmInstallSpec("@openclaw/discord"),
-      expectedPluginId: "discord",
-      trustedSourceLinkedOfficialInstall: true,
-    });
-    const persistedRecords = mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords);
-    expectRecordFields((persistedRecords as Record<string, unknown>).discord, {
-      spec: "@openclaw/discord",
-      installPath: "/tmp/openclaw-plugins/discord",
-    });
-    expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords, 0, 1)).toEqual({
-      config: expect.any(Object),
-      env: {},
-    });
-    expect(result.changes).toEqual([
-      `Installed missing configured plugin "discord" from ${expectedNpmInstallSpec("@openclaw/discord")}.`,
-    ]);
-  });
+      const updateArg = expectRecordFields(mockCallArg(mocks.updateNpmInstalledPlugins), {
+        pluginIds: siblingConsentRequired ? ["discord", "sibling"] : ["discord"],
+      });
+      const updateConfig = updateArg.config as Record<string, unknown>;
+      expectRecordFields(updateConfig.plugins, { installs: records });
+      expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
+        spec: expectedNpmInstallSpec("@openclaw/discord"),
+        expectedPluginId: "discord",
+        trustedSourceLinkedOfficialInstall: true,
+      });
+      const persistedRecords = mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords);
+      expectRecordFields((persistedRecords as Record<string, unknown>).discord, {
+        spec: "@openclaw/discord",
+        installPath: artifactDir,
+      });
+      expect(mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords, 0, 1)).toEqual({
+        config: expect.any(Object),
+        env: { OPENCLAW_STATE_DIR: path.join(root, "state") },
+      });
+      expect(result.changes).toEqual([
+        `Installed missing configured plugin "discord" from ${expectedNpmInstallSpec("@openclaw/discord")}.`,
+      ]);
+      expect(onCapabilityConsent).toHaveBeenCalledOnce();
+      expect(result.records.discord?.acceptedSurface?.tools).toEqual(["fixture.write"]);
+      expect(result.repairedPluginIds).toEqual(["discord"]);
+      expect(result.capabilityConsentRequired).toBe(siblingConsentRequired ? true : undefined);
+    },
+  );
 
   it("updates a known configured plugin when its installed manifest path still exists", async () => {
     const records = installedRecords("discord", {

--- a/src/commands/doctor/shared/post-core-plugin-convergence.test.ts
+++ b/src/commands/doctor/shared/post-core-plugin-convergence.test.ts
@@ -471,6 +471,28 @@ describe("runPostCorePluginConvergence", () => {
     });
   });
 
+  it("blocks convergence when a missing plugin cannot activate without capability consent", async () => {
+    mocks.repairMissingConfiguredPluginInstalls.mockResolvedValue({
+      changes: [],
+      warnings: ['Plugin "consent-fixture" requires capability consent.'],
+      failedPluginIds: ["consent-fixture"],
+      capabilityConsentRequired: true,
+      records: {},
+    });
+
+    const result = await runPostCorePluginConvergence({
+      cfg: { plugins: { entries: { "consent-fixture": { enabled: true } } } },
+      env: {},
+    });
+
+    expect(result.errored).toBe(true);
+    expect(result.warnings).toEqual([
+      expect.objectContaining({ message: 'Plugin "consent-fixture" requires capability consent.' }),
+    ]);
+    expect(result.smokeFailures).toEqual([]);
+    expect(result.installRecords).toEqual({});
+  });
+
   it("keeps inactive repair failures nonblocking", async () => {
     mocks.repairMissingConfiguredPluginInstalls.mockResolvedValue({
       changes: [],

--- a/src/commands/doctor/shared/post-core-plugin-convergence.ts
+++ b/src/commands/doctor/shared/post-core-plugin-convergence.ts
@@ -143,12 +143,10 @@ function formatPeerLinkPackageReadWarning(failure: { error: unknown }): PostCore
 /**
  * Mandatory post-core convergence pass. Runs AFTER the core package files
  * are swapped and the in-update doctor pass has already returned, but BEFORE
- * the gateway is restarted. Missing-plugin repair failures stay nonblocking:
- * an external package fetch may be transient, and failing the core update
- * would strand the user. Explicit `openclaw update` callers keep reporting
- * payload smoke failures as errors. Gateway startup consumes the same typed
- * failures by quarantining each known plugin owner before any module import,
- * then boots with that plugin marked configured-unavailable.
+ * the gateway is restarted. Transient repair fetch failures stay nonblocking;
+ * consent that prevents activation and payload smoke failures are errors.
+ * Gateway startup quarantines known payload failures before any module import,
+ * then boots with those plugins marked configured-unavailable.
  */
 export async function runPostCorePluginConvergence(params: {
   cfg: OpenClawConfig;
@@ -274,7 +272,7 @@ export async function runPostCorePluginConvergence(params: {
     ],
     notices,
     warnings,
-    errored: smoke.failures.length > 0,
+    errored: repair.capabilityConsentRequired === true || smoke.failures.length > 0,
     smokeFailures: smoke.failures,
     installRecords: records,
   };
@@ -290,8 +288,8 @@ export async function runPostCorePluginConvergence(params: {
  *    warnings that name a `pluginId` produce per-plugin error outcomes; the
  *    rest are surfaced via `warnings`.
  *  - `errored` boolean that callers translate into `status: "error"`.
- *    Repair warnings are nonblocking; smoke failures remain errors on the
- *    explicit update path even though Gateway startup can quarantine them.
+ *    Pending activation consent and smoke failures remain errors on the
+ *    explicit update path; ordinary repair warnings are nonblocking.
  */
 export function convergenceWarningsToOutcomes(convergence: PostCoreConvergenceResult): {
   warnings: PostCoreConvergenceWarning[];

--- a/src/plugins/update-channel.consent.test.ts
+++ b/src/plugins/update-channel.consent.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../packages/gateway-protocol/src/capability-consent-error-details.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolvePluginArtifactDeclaredSurface } from "./capability-artifact.js";
 import { computeDeclaredSurfaceHash } from "./capability-summary.js";
@@ -170,7 +171,9 @@ describe("channel migration artifact consent", () => {
         expect(result.summary.errors).toEqual([]);
       } else {
         expect(result.config).toEqual(originalConfig);
-        expect(result.summary.errors.join("\n")).toMatch(/capabilit/i);
+        expect(result.summary.errors).toEqual([
+          expect.objectContaining({ pluginId, code: PLUGIN_CAPABILITY_CONSENT_REQUIRED }),
+        ]);
       }
     }
     expect(committed).toBe(review === "accept");

--- a/src/plugins/update-channel.ts
+++ b/src/plugins/update-channel.ts
@@ -1,3 +1,4 @@
+import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../packages/gateway-protocol/src/capability-consent-error-details.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { readInstalledPackageVersion } from "../infra/package-update-utils.js";
@@ -42,6 +43,7 @@ import {
   isTrustedSourceLinkedOfficialBridgeNpmInstall,
   resolveNpmSpecPackageName,
   type PluginUpdateLogger,
+  type PluginUpdateOutcome,
 } from "./update-source.js";
 
 type PluginChannelSyncSummary = {
@@ -49,7 +51,7 @@ type PluginChannelSyncSummary = {
   switchedToClawHub: string[];
   switchedToNpm: string[];
   warnings: string[];
-  errors: string[];
+  errors: Pick<PluginUpdateOutcome, "pluginId" | "message" | "code">[];
 };
 
 export type PluginChannelSyncResult = {
@@ -189,7 +191,7 @@ export async function syncPluginsForUpdateChannel(params: {
       let installSpec = preferredSource === "clawhub" ? clawhubSpec : effectiveNpmSpec;
       if (!installSpec) {
         const message = `Failed to update ${targetPluginId}: missing ${preferredSource} install spec for externalized bundled plugin.`;
-        summary.errors.push(message);
+        summary.errors.push({ pluginId: targetPluginId, message });
         logger.error?.(message);
         continue;
       }
@@ -230,7 +232,14 @@ export async function syncPluginsForUpdateChannel(params: {
           if (!(error instanceof ManagedPluginLifecycleError)) {
             throw error;
           }
-          result = { ok: false, error: error.message };
+          return {
+            result: {
+              ok: false as const,
+              error: error.message,
+              code: error.capabilityConsent ? PLUGIN_CAPABILITY_CONSENT_REQUIRED : undefined,
+            },
+            capabilityConsent,
+          };
         }
         consent.rethrowCallbackError();
         return { result, capabilityConsent };
@@ -276,7 +285,7 @@ export async function syncPluginsForUpdateChannel(params: {
                 phase: "update",
                 result,
               });
-        summary.errors.push(message);
+        summary.errors.push({ pluginId: targetPluginId, message, code: result.code });
         logger.error?.(message);
         continue;
       }

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -5653,7 +5653,12 @@ describe("syncPluginsForUpdateChannel", () => {
     expect(result.summary.switchedToNpm).toStrictEqual([]);
     expect(result.summary.warnings).toStrictEqual([]);
     expect(result.summary.errors).toEqual([
-      "Failed to update legacy-chat: Package not found on ClawHub. (ClawHub clawhub:legacy-chat@2026.5.1-beta.2).",
+      {
+        pluginId: "legacy-chat",
+        code: "package_not_found",
+        message:
+          "Failed to update legacy-chat: Package not found on ClawHub. (ClawHub clawhub:legacy-chat@2026.5.1-beta.2).",
+      },
     ]);
   });
 
@@ -5750,7 +5755,12 @@ describe("syncPluginsForUpdateChannel", () => {
     expect(result.config).toBe(config);
     expect(result.summary.warnings).toEqual(["WARNING\nSecurity scan: suspicious"]);
     expect(result.summary.errors).toEqual([
-      "Failed to update legacy-chat: ClawHub ClawPack integrity mismatch. (ClawHub clawhub:legacy-chat@2026.5.1-beta.2).",
+      {
+        pluginId: "legacy-chat",
+        code: "archive_integrity_mismatch",
+        message:
+          "Failed to update legacy-chat: ClawHub ClawPack integrity mismatch. (ClawHub clawhub:legacy-chat@2026.5.1-beta.2).",
+      },
     ]);
   });
 
@@ -5819,7 +5829,9 @@ describe("syncPluginsForUpdateChannel", () => {
 
     expect(result.changed).toBe(false);
     expect(result.config).toBe(config);
-    expect(result.summary.errors).toEqual(["Failed to update legacy-chat: package unavailable"]);
+    expect(result.summary.errors).toEqual([
+      { pluginId: "legacy-chat", message: "Failed to update legacy-chat: package unavailable" },
+    ]);
   });
 
   it("does not externalize custom local path installs that only share the old plugin id", async () => {


### PR DESCRIPTION
Related: #134353; [openclaw/ocm#132](https://github.com/openclaw/ocm/issues/132).

Thanks @hannesrudolph for the upgrade report.

## What Problem This Solves

Fixes an issue where `openclaw update` or `openclaw update finalize` could report successful or warning-only finalization after a companion plugin's capability changes were refused. [OCM checks the finalizer's process exit](https://github.com/openclaw/ocm/blob/a5a8269abace54d5afaf0a751f8c7ddcb1c901c7/src/cli/upgrade.rs#L3802) before publishing the replacement binding and checking Gateway readiness, so losing that refusal can defer discovery of an unavailable plugin until activation.

## Why This Change Was Made

Plugin migration retains each failure's plugin ID and consent code through the canonical `src/plugins/update-cohort.ts` flow and common guided outcome collector; `src/commands/doctor/shared/post-core-plugin-convergence.ts` also consumes unresolved activation consent from the repair owner when no install record exists to inspect. A later accepted catalog installation clears only that plugin's blocker, while retained usable artifacts remain subject to payload validation and transient fetch warnings remain nonblocking.

## User Impact

Unresolved activation consent now causes a nonzero exit before a requested restart, allowing external managers to stop activation. Operators can review capability changes with `openclaw update repair`; `--yes` still does not grant capability consent. The existing `sync.errors` string array, capability-acceptance mechanism, configuration and Gateway protocol remain unchanged.

## Evidence

- The regression was reproduced against main `9101e7cc9de1` through its extracted cohort flow: bridge `update` returned `ok` and bridge `finalize` returned `warning`, producing two failing error assertions. Both installed-plugin refusal controls passed. All four cases pass with the integrated repair.
- **156 fresh tests passed:** 18 CLI cases covering both entrypoints, consent forwarding, resume behavior and warning output; 104 configured-plugin repair cases; and 34 shared Doctor convergence/retirement cases. Coverage includes missing install records, actual staged-artifact acknowledgement, accepted recovery for the same plugin, unresolved sibling consent, and retained-artifact controls. All 18 recorded candidate/caller input hashes remained unchanged across validation. Formatting for all ten changed files and the diff whitespace check passed.
- The CLI fixtures exercise the actual migration/finalization owners with mocked package and service ports. Repair fixtures exercise filesystem and install-record preservation. The reporter's full OCM transaction was not replayed because the original source installation and profile snapshot are unavailable. Direct inspection of the pinned OCM source confirms both runtime and launcher callers reject a nonzero finalizer exit before publishing their replacement binding.
- Production: four files, **+45/−43, net +2**; tests: five files, +264/−116; docs: +4/−1. The common collector removes the separate text-only error path and duplicate printer. Invocation-local pending consent is needed to distinguish recovered plugins from unresolved siblings.
- [ClawSweeper disposition](https://github.com/openclaw/openclaw/pull/135460#issuecomment-5499501550): the nonzero result until consent is resolved is intentional compatibility behavior. The pending set is in memory only; it changes no schema, persistent representation or store semantics. No separate dispatch is needed for this repair; validation follows the existing PR workflow.
- Fresh managed Codex P0 review passed for the integrated source; the maintainer also reviewed the new cohort owner, consumer, moved convergence path, callers and regression evidence directly. The integrated commit is `567ca72863396c786b7a2081b6aa47f63b8d6c0f`; [hosted CI 33560722801](https://github.com/openclaw/openclaw/actions/runs/33560722801) passed on that exact head (204 successful jobs, 16 skipped).

The earlier `Unable to resolve Codex doctor health API` target-validation failure precedes finalization. Durable companion preparation across the source-to-npm transition remains follow-up work in the linked reports; this PR does not close the entire migration report.
