### PR TITLE
refactor(plugin-state): consolidate validation errors

### DIFF
--- a/src/plugin-state/plugin-state-store.ts
+++ b/src/plugin-state/plugin-state-store.ts
@@ -85,14 +85,16 @@ function invalidInput(
   });
 }
 
+const validationErrors = (operation: PluginStateStoreOperation) => ({
+  invalid: (message: string) => invalidInput(message, operation),
+  limit: (message: string) => invalidInput(message, operation),
+});
+
 function validateNamespace(value: string, operation: PluginStateStoreOperation = "open"): string {
   return validatePluginStoreNamespace({
     value,
     label: "plugin state",
-    errors: {
-      invalid: (message) => invalidInput(message, operation),
-      limit: (message) => invalidInput(message, operation),
-    },
+    errors: validationErrors(operation),
   });
 }
 
@@ -100,10 +102,7 @@ function validateKey(value: string, operation: PluginStateStoreOperation = "regi
   return validatePluginStoreKey({
     value,
     label: "plugin state",
-    errors: {
-      invalid: (message) => invalidInput(message, operation),
-      limit: (message) => invalidInput(message, operation),
-    },
+    errors: validationErrors(operation),
   });
 }
 
@@ -126,10 +125,7 @@ function validateOptionalTtlMs(
   return validateOptionalPluginStoreTtlMs({
     value,
     label: "plugin state ttlMs",
-    errors: {
-      invalid: (message) => invalidInput(message, operation),
-      limit: (message) => invalidInput(message, operation),
-    },
+    errors: validationErrors(operation),
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

The plugin-state facade repeated the same validation error adapter for namespaces, keys, and TTLs. That duplication made operation attribution and error-code policy easier to drift independently.

## Why This Change Was Made

The plugin-state facade owns translation from shared store validators into `PluginStateStoreError`. This change adds one local `validationErrors(operation)` factory and uses it only for namespace, key, and TTL validation.

The serialized-value overflow handler remains distinct because it intentionally emits `PLUGIN_STATE_LIMIT_EXCEEDED`; this change does not alter its message or `register` operation attribution.

No SDK, schema, SQLite, configuration, protocol, or persistence behavior changes.

## User Impact

No user-visible behavior change. Validation errors retain the same codes, messages, and operation attribution with one canonical callback construction path.

## Evidence

- Production LOC: `+8/-12`, net `-4`; tests: `+0/-0`.
- Local focused tests after rebase: 3 files, 61 tests passed.
- Blacksmith Testbox focused tests: 3 files, 61 tests passed.
  - Provider: `blacksmith-testbox`
  - Lease: `tbx_01m1f4zwyxnv66295r2eqx7c0r`
  - Run: https://github.com/openclaw/openclaw/actions/runs/33546118674
- Import-cycle check: 0 runtime value cycles.
- `git diff --check`: passed.
- Changed-surface checks passed formatting, boundary guards, core typecheck, and the other production lanes reached before the broad core-test typecheck. A prior full Testbox attempt stopped on the unrelated `src/cli/models-cli.auth-login.integration.test.ts:63` error fixed by #135407, which is included in this branch's parent.
- Autoreview: `gpt-5.6-sol`, high reasoning, scoped clean with no accepted/actionable findings (`0.98`).
- Codex hard gate: inspected `openai/codex` commit `5f49aba876922d6f2f55caa153bbb0ed1b46feba`, `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; no relevant runtime or protocol dependency.
- Overlap:
  - #133910 exact remote head has no `src/plugin-state/**` changes.
  - #87434 changes `plugin-state-store.sqlite.ts` and its test, not this facade source.
