### PR TITLE
perf(agents): avoid cloning credentials for presence checks

### DIFF
--- a/src/agents/auth-profiles/runtime-snapshots.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.ts
@@ -255,17 +255,18 @@ export function hasRuntimeAuthProfileStoreSnapshot(agentDir?: string): boolean {
   return runtimeAuthStoreSnapshots.has(resolveRuntimeStoreKey(agentDir));
 }
 
+/** Checks the owned profile keys without copying private credential data out of the owner. */
+export function hasRuntimeAuthProfileStoreSource(agentDir?: string): boolean {
+  const store = runtimeAuthStoreSnapshots.get(resolveRuntimeStoreKey(agentDir))?.store;
+  return Boolean(store && Object.keys(store.profiles).length > 0);
+}
+
 /** Returns true when requested or main runtime snapshots contain profiles. */
 export function hasAnyRuntimeAuthProfileStoreSource(agentDir?: string): boolean {
-  const requestedStore = getRuntimeAuthProfileStoreSnapshotCore(agentDir);
-  if (requestedStore && Object.keys(requestedStore.profiles).length > 0) {
-    return true;
-  }
-  if (!agentDir) {
-    return false;
-  }
-  const mainStore = getRuntimeAuthProfileStoreSnapshotCore();
-  return Boolean(mainStore && Object.keys(mainStore.profiles).length > 0);
+  return (
+    hasRuntimeAuthProfileStoreSource(agentDir) ||
+    (Boolean(agentDir) && hasRuntimeAuthProfileStoreSource())
+  );
 }
 
 /** Replaces all runtime auth profile snapshots with cloned entries. */

--- a/src/agents/auth-profiles/source-check.ts
+++ b/src/agents/auth-profiles/source-check.ts
@@ -9,6 +9,7 @@ import { coercePersistedAuthProfileStore } from "./persisted.js";
 import {
   getRuntimeAuthProfileStoreSnapshotCore,
   hasAnyRuntimeAuthProfileStoreSource,
+  hasRuntimeAuthProfileStoreSource,
 } from "./runtime-snapshots.js";
 import {
   inspectPersistedAuthProfileStoreRaw,
@@ -119,8 +120,7 @@ export function hasAnyAuthProfileStoreSource(agentDir?: string): boolean {
 
 /** Returns true when the requested agent dir has a local auth profile source. */
 export function hasLocalAuthProfileStoreSource(agentDir?: string): boolean {
-  const runtimeStore = getRuntimeAuthProfileStoreSnapshotCore(agentDir);
-  if (runtimeStore && Object.keys(runtimeStore.profiles).length > 0) {
+  if (hasRuntimeAuthProfileStoreSource(agentDir)) {
     return true;
   }
   if (hasLegacyAuthProfileCredentialSource(agentDir)) {


### PR DESCRIPTION
Presence checks currently clone runtime credential stores just to ask whether they contain profiles. Add a boolean query at the snapshot owner and reuse it in the two presence-only paths. Getters that return credentials still return defensive copies. Local runtime, legacy, durable store, shared runtime and shared persisted-source precedence—including failure ordering—stays unchanged.

The direct runtime-backed check fell from 5.58 µs to 3.33/3.79 µs in the two fixed run orders (32–40%, or 1.8–2.3 µs saved). The complete fallback fixtures also recorded 5–28% lower medians, but unchanged controls moved substantially, so those numbers are observations rather than a claimed end-to-end improvement. Reverse persisted-only/retired-file controls rose 21.46%/12.27%; persisted-only first calls rose about 6% in both orders. All firsts and adverse results remain in the evidence.

The predeclared numerical gate passed. Four fresh processes ran the fixed before/candidate/candidate/before sequence: 528 measured observations, 192 warmups, 48 first observations and 896 public calls. Both variants matched all 32 native output/ordering/mutation cases and passed the same 189 existing tests across five whole suites. Independent audit checked all observations, full producer objects, publication sequences and transformed owners. These measurements use the frozen `dea48baf` checkout; current-main integration on `d17027cf` has identical owner bytes and again passes all 189 tests. Structured Codex review found no actionable correctness or security issue.

Production: +12/−11, net +1. No test changes, cache, public SDK, configuration, schema or persistence change. The small increase centralizes an owner-held boolean query while deleting duplicate clone-and-check branches. This is separate from the earlier prepared-snapshot getter optimization. Build and real Gateway compatibility passed at the final commit. Exact-head CI [33548273404](https://github.com/openclaw/openclaw/actions/runs/33548273404) is green, including the required gate; final structured Codex review is clean. Canonical hosted preparation completed without source changes.

Current-head validation at `434992ca2e07d8ce43875787c1b8b108424c4d03`: `pnpm build` passed. An isolated built Gateway completed four real OpenAI turns, two sequential `web_fetch` requests (HTTP 200, Markdown and text), and two health plus two status requests. Readiness was 3.72 s, the plain turns 1.42–2.20 s, and the two-fetch turn 6.27 s. The authoritative closed transcript, full spill contents, unchanged before/after build inventory and Gateway CPU profiles were retained; owned processes, port, coordinator files and provider-key FIFO were verified closed. This is compatibility evidence, not a paired Gateway speedup or proof that the positive snapshot branch ran on those turns.
