### PR TITLE
fix(gateway): retain terminal timeout reasons in sidebar

### DIFF
--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -167,6 +167,12 @@ drain grace. Neither window resets on progress. These cleanup limits still
 apply when the execution budget is unlimited. See
 [Codex timeouts](/plugins/codex-harness-reference#timeouts).
 
+When a runtime reports a definitive timeout, the Gateway records its terminal
+status and error for the session sidebar immediately, without waiting for
+provider retry grace. Opening the failed session dismisses its sidebar attention
+as usual. A later successful turn clears the previous error and is not replaced
+by an older delayed failure.
+
 ### Stuck session diagnostics
 
 With diagnostics enabled, a built-in two-minute threshold classifies long `processing` sessions with no observed reply, tool, status, block, or ACP progress:

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1,11 +1,13 @@
 // Server chat agent-event tests protect event fanout, heartbeat visibility,
 // session lifecycle persistence, and subscriber registry behavior.
 
+import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatEventSchema } from "../../packages/gateway-protocol/src/schema/logs-chat.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { buildAgentRunTerminalOutcome } from "../agents/agent-run-terminal-outcome.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import {
@@ -21,6 +23,10 @@ import {
 } from "../agents/internal-runtime-context.js";
 import { createAgentLifecycleTerminalBackstop } from "../auto-reply/reply/agent-lifecycle-terminal.js";
 import { formatChannelProgressDraftLine } from "../channels/streaming.js";
+import {
+  loadSessionEntry as loadStoredSessionEntry,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import {
   emitAgentEvent as emitRuntimeAgentEvent,
   emitAgentEventForOwner,
@@ -109,6 +115,7 @@ import {
   type AgentEventHandlerOptions,
 } from "./server-chat.js";
 import { broadcastChatError } from "./server-methods/chat-broadcast.js";
+import { persistGatewaySessionLifecycleEvent } from "./session-lifecycle-state.js";
 import { loadSessionEntry } from "./session-utils.js";
 
 function waitForFast<T>(
@@ -119,6 +126,7 @@ function waitForFast<T>(
 }
 
 describe("agent event handler", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   beforeEach(() => {
     resetAgentEventsForTest({ preserveListeners: true });
     vi.mocked(getRuntimeConfig).mockReturnValue({});
@@ -4251,39 +4259,96 @@ describe("agent event handler", () => {
     expect(agentRunSeq.has("run-terminal-error")).toBe(false);
   });
 
-  it("finalizes fallback-exhausted lifecycle errors without waiting for retry grace", () => {
+  it.each([
+    {
+      name: "fallback-exhausted failure",
+      terminal: {
+        error: "LLM request failed: network connection error.",
+        fallbackExhaustedFailure: true,
+      },
+      status: "failed",
+    },
+    {
+      name: "provider timeout after a tool error",
+      terminal: {
+        error:
+          "Request timed out before a response was generated. Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
+        aborted: false,
+        timeoutPhase: "provider",
+        providerStarted: true,
+      },
+      status: "timeout",
+    },
+  ])("persists $name without waiting for retry grace", async ({ terminal, status }) => {
+    const sessionKey = "session-terminal-error";
+    const storePath = path.join(tempDirs.make("openclaw-terminal-projection-"), "sessions.json");
+    const target = { storePath, sessionKey };
+    const read = () => loadStoredSessionEntry({ ...target, readConsistency: "latest" });
+    await replaceSessionEntry(target, {
+      sessionId: "session-terminal",
+      updatedAt: 1_000,
+      status: "running",
+      startedAt: 1_000,
+    });
+    vi.mocked(loadSessionEntry).mockImplementation(() => ({
+      cfg: {},
+      agentId: "main",
+      storePath,
+      store: {},
+      entry: read(),
+      canonicalKey: sessionKey,
+      storeKeys: [sessionKey],
+      legacyKey: undefined,
+    }));
+    loadGatewaySessionRow.mockImplementation(() => ({
+      ...OWNED_SESSION_ROW,
+      ...read(),
+      key: sessionKey,
+    }));
+    persistGatewaySessionLifecycleEventMock.mockImplementation(persistGatewaySessionLifecycleEvent);
     vi.useFakeTimers();
-    const { broadcast, clearAgentRunContext, agentRunSeq, handler } = createHarness({
-      resolveSessionKeyForRun: () => "session-terminal-error",
-      lifecycleErrorRetryGraceMs: 100,
+    vi.setSystemTime(2_000);
+    const { broadcast, broadcastToConnIds, sessionEventSubscribers, handler } = createHarness({
+      resolveSessionKeyForRun: () => sessionKey,
     });
+    sessionEventSubscribers.subscribe("conn-session");
     registerAgentRunContext("run-terminal-final-failure", {
-      sessionKey: "session-terminal-error",
+      sessionKey,
     });
 
-    emitAgentEvent(handler, "run-terminal-final-failure", "lifecycle", {
-      phase: "error",
-      error: "LLM request failed: network connection error.",
-      fallbackExhaustedFailure: true,
-    });
+    emitAgentEvents(handler, "run-terminal-final-failure", [
+      ["lifecycle", { phase: "error", error: "Retryable provider failure." }],
+      ["tool", { phase: "result", name: "read", isError: true, result: "An earlier tool failed." }],
+      ["lifecycle", { phase: "error", startedAt: 1_000, endedAt: 2_000, ...terminal }],
+    ]);
+    await Promise.all(
+      persistGatewaySessionLifecycleEventMock.mock.results.map((result) => result.value),
+    );
 
-    const finalPayload = chatBroadcastCalls(broadcast).at(-1)?.[1] as {
-      state?: string;
-      runId?: string;
-      errorMessage?: string;
-    };
-    expect(finalPayload.state).toBe("error");
-    expect(finalPayload.runId).toBe("run-terminal-final-failure");
-    expect(finalPayload.errorMessage).toContain("network connection error");
-    expect(clearAgentRunContext).toHaveBeenCalledWith("run-terminal-final-failure");
-    expect(agentRunSeq.has("run-terminal-final-failure")).toBe(false);
+    expect(read()).toMatchObject({ status, lastRunError: terminal.error, endedAt: 2_000 });
     expect(
-      persistGatewaySessionLifecycleEventMock.mock.calls.some(
-        ([params]) =>
-          (params as { event?: { data?: { fallbackExhaustedFailure?: boolean } } }).event?.data
-            ?.fallbackExhaustedFailure === true,
-      ),
-    ).toBe(true);
+      broadcastToConnIds.mock.calls.find(([event]) => event === "sessions.changed")?.[1],
+    ).toMatchObject({
+      status,
+      lastRunError: terminal.error,
+    });
+
+    vi.setSystemTime(3_000);
+    emitAgentEvents(handler, "run-recovered", [
+      ["lifecycle", { phase: "start", startedAt: 3_000 }],
+      ["lifecycle", { phase: "end", startedAt: 3_000, endedAt: 4_000 }],
+    ]);
+    await Promise.all(
+      persistGatewaySessionLifecycleEventMock.mock.results.map((result) => result.value),
+    );
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(read()).toMatchObject({ status: "done", startedAt: 3_000, endedAt: 4_000 });
+    expect(read()?.lastRunError).toBeUndefined();
+    expect(chatBroadcastCalls(broadcast).map(([, payload]) => payload.state)).toEqual([
+      "error",
+      "final",
+    ]);
+    handler.dispose();
   });
 
   it("keeps deferred lifecycle-error cleanup across later non-terminal events", () => {

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1,13 +1,11 @@
 // Server chat agent-event tests protect event fanout, heartbeat visibility,
 // session lifecycle persistence, and subscriber registry behavior.
 
-import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatEventSchema } from "../../packages/gateway-protocol/src/schema/logs-chat.js";
-import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { buildAgentRunTerminalOutcome } from "../agents/agent-run-terminal-outcome.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import {
@@ -41,6 +39,7 @@ import {
   releaseAgentRunContext,
 } from "../infra/agent-run-registry.js";
 import { subscribePluginSessionsChanged } from "../plugins/gateway-events.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 
 const persistGatewaySessionLifecycleEventMock = vi.fn();
 const loadGatewaySessionLifecycleSnapshotMock = vi.hoisted(() => vi.fn());
@@ -126,7 +125,6 @@ function waitForFast<T>(
 }
 
 describe("agent event handler", () => {
-  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   beforeEach(() => {
     resetAgentEventsForTest({ preserveListeners: true });
     vi.mocked(getRuntimeConfig).mockReturnValue({});
@@ -1506,8 +1504,9 @@ describe("agent event handler", () => {
 
     emitAgentEvent(handler, "run-flush", "assistant", { text: "Hello" });
 
-    now = 10_100;
+    now = 10_050;
     emitAgentEvent(handler, "run-flush", "assistant", { text: "Hello world" });
+    expect(chatDeltaTexts(broadcast)).toEqual(["Hello"]);
 
     emitLifecycleEnd(handler, "run-flush");
 
@@ -1538,8 +1537,9 @@ describe("agent event handler", () => {
 
     emitAgentEvent(handler, "run-err-flush", "assistant", { text: "Hello" });
 
-    now = 10_100;
+    now = 10_050;
     emitAgentEvent(handler, "run-err-flush", "assistant", { text: "Hello world" });
+    expect(chatDeltaTexts(broadcast)).toEqual(["Hello"]);
 
     emitAgentEvent(
       handler,
@@ -1573,8 +1573,9 @@ describe("agent event handler", () => {
 
     emitAgentEvent(handler, "run-err-grace", "assistant", { text: "Hello" });
 
-    now = 10_100;
+    now = 10_050;
     emitAgentEvent(handler, "run-err-grace", "assistant", { text: "Hello world" });
+    expect(chatDeltaTexts(broadcast)).toEqual(["Hello"]);
 
     emitAgentEvent(
       handler,
@@ -1605,8 +1606,9 @@ describe("agent event handler", () => {
 
     emitAgentEvent(handler, "run-err-cancel", "assistant", { text: "Hello" });
 
-    now = 10_100;
+    now = 10_050;
     emitAgentEvent(handler, "run-err-cancel", "assistant", { text: "Hello world" });
+    expect(chatDeltaTexts(broadcast)).toEqual(["Hello"]);
 
     emitAgentEvent(
       handler,
@@ -1969,7 +1971,7 @@ describe("agent event handler", () => {
 
     emitAgentEvent(handler, "run-tool-flush", "assistant", { text: "Before tool" });
 
-    // Throttled assistant update (within 150ms window).
+    // Keep the second update inside the live-text pacing window.
     now = 12_050;
     emitAgentEvent(
       handler,
@@ -2000,8 +2002,15 @@ describe("agent event handler", () => {
     expect(sessionChatCalls(nodeSendToSession)).toHaveLength(2);
 
     expect(broadcastToConnIds).toHaveBeenCalledTimes(1);
-    const flushCallOrder = broadcast.mock.invocationCallOrder[1] ?? 0;
-    const toolCallOrder = broadcastToConnIds.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER;
+    const flushCallIndex = broadcast.mock.calls.findIndex((call) => call === chatCalls[1]);
+    const flushCallOrder = expectDefined(
+      broadcast.mock.invocationCallOrder[flushCallIndex],
+      "flushed chat delta invocation",
+    );
+    const toolCallOrder = expectDefined(
+      broadcastToConnIds.mock.invocationCallOrder[0],
+      "tool start invocation",
+    );
     expect(flushCallOrder).toBeLessThan(toolCallOrder);
     nowSpy.mockRestore();
   });
@@ -4279,77 +4288,83 @@ describe("agent event handler", () => {
       },
       status: "timeout",
     },
-  ])("persists $name without waiting for retry grace", async ({ terminal, status }) => {
-    const sessionKey = "session-terminal-error";
-    const storePath = path.join(tempDirs.make("openclaw-terminal-projection-"), "sessions.json");
-    const target = { storePath, sessionKey };
-    const read = () => loadStoredSessionEntry({ ...target, readConsistency: "latest" });
-    await replaceSessionEntry(target, {
-      sessionId: "session-terminal",
-      updatedAt: 1_000,
-      status: "running",
-      startedAt: 1_000,
-    });
-    vi.mocked(loadSessionEntry).mockImplementation(() => ({
-      cfg: {},
-      agentId: "main",
-      storePath,
-      store: {},
-      entry: read(),
-      canonicalKey: sessionKey,
-      storeKeys: [sessionKey],
-      legacyKey: undefined,
-    }));
-    loadGatewaySessionRow.mockImplementation(() => ({
-      ...OWNED_SESSION_ROW,
-      ...read(),
-      key: sessionKey,
-    }));
-    persistGatewaySessionLifecycleEventMock.mockImplementation(persistGatewaySessionLifecycleEvent);
-    vi.useFakeTimers();
-    vi.setSystemTime(2_000);
-    const { broadcast, broadcastToConnIds, sessionEventSubscribers, handler } = createHarness({
-      resolveSessionKeyForRun: () => sessionKey,
-    });
-    sessionEventSubscribers.subscribe("conn-session");
-    registerAgentRunContext("run-terminal-final-failure", {
-      sessionKey,
-    });
+  ])("persists $name without waiting for retry grace", ({ terminal, status }) =>
+    withOpenClawTestState({ label: "terminal-projection" }, async (state) => {
+      const sessionKey = "session-terminal-error";
+      const storePath = state.statePath("agents", "main", "sessions", "sessions.json");
+      const target = { storePath, sessionKey };
+      const read = () => loadStoredSessionEntry({ ...target, readConsistency: "latest" });
+      await replaceSessionEntry(target, {
+        sessionId: "session-terminal",
+        updatedAt: 1_000,
+        status: "running",
+        startedAt: 1_000,
+      });
+      vi.mocked(loadSessionEntry).mockImplementation(() => ({
+        cfg: {},
+        agentId: "main",
+        storePath,
+        store: {},
+        entry: read(),
+        canonicalKey: sessionKey,
+        storeKeys: [sessionKey],
+        legacyKey: undefined,
+      }));
+      loadGatewaySessionRow.mockImplementation(() => ({
+        ...OWNED_SESSION_ROW,
+        ...read(),
+        key: sessionKey,
+      }));
+      persistGatewaySessionLifecycleEventMock.mockImplementation(
+        persistGatewaySessionLifecycleEvent,
+      );
+      const { broadcast, broadcastToConnIds, sessionEventSubscribers, handler } = createHarness({
+        resolveSessionKeyForRun: () => sessionKey,
+      });
+      try {
+        vi.useFakeTimers();
+        vi.setSystemTime(2_000);
+        sessionEventSubscribers.subscribe("conn-session");
+        registerAgentRunContext("run-terminal-final-failure", { sessionKey });
 
-    emitAgentEvents(handler, "run-terminal-final-failure", [
-      ["lifecycle", { phase: "error", error: "Retryable provider failure." }],
-      ["tool", { phase: "result", name: "read", isError: true, result: "An earlier tool failed." }],
-      ["lifecycle", { phase: "error", startedAt: 1_000, endedAt: 2_000, ...terminal }],
-    ]);
-    await Promise.all(
-      persistGatewaySessionLifecycleEventMock.mock.results.map((result) => result.value),
-    );
+        emitAgentEvents(handler, "run-terminal-final-failure", [
+          ["lifecycle", { phase: "error", error: "Retryable provider failure." }],
+          [
+            "tool",
+            { phase: "result", name: "read", isError: true, result: "An earlier tool failed." },
+          ],
+          ["lifecycle", { phase: "error", startedAt: 1_000, endedAt: 2_000, ...terminal }],
+        ]);
+        await Promise.all(
+          persistGatewaySessionLifecycleEventMock.mock.results.map((result) => result.value),
+        );
 
-    expect(read()).toMatchObject({ status, lastRunError: terminal.error, endedAt: 2_000 });
-    expect(
-      broadcastToConnIds.mock.calls.find(([event]) => event === "sessions.changed")?.[1],
-    ).toMatchObject({
-      status,
-      lastRunError: terminal.error,
-    });
+        expect(read()).toMatchObject({ status, lastRunError: terminal.error, endedAt: 2_000 });
+        expect(
+          broadcastToConnIds.mock.calls.find(([event]) => event === "sessions.changed")?.[1],
+        ).toMatchObject({ status, lastRunError: terminal.error });
 
-    vi.setSystemTime(3_000);
-    emitAgentEvents(handler, "run-recovered", [
-      ["lifecycle", { phase: "start", startedAt: 3_000 }],
-      ["lifecycle", { phase: "end", startedAt: 3_000, endedAt: 4_000 }],
-    ]);
-    await Promise.all(
-      persistGatewaySessionLifecycleEventMock.mock.results.map((result) => result.value),
-    );
-    await vi.advanceTimersByTimeAsync(15_000);
-    expect(read()).toMatchObject({ status: "done", startedAt: 3_000, endedAt: 4_000 });
-    expect(read()?.lastRunError).toBeUndefined();
-    expect(chatBroadcastCalls(broadcast).map(([, payload]) => payload.state)).toEqual([
-      "error",
-      "final",
-    ]);
-    handler.dispose();
-  });
+        vi.setSystemTime(3_000);
+        emitAgentEvents(handler, "run-recovered", [
+          ["lifecycle", { phase: "start", startedAt: 3_000 }],
+          ["lifecycle", { phase: "end", startedAt: 3_000, endedAt: 4_000 }],
+        ]);
+        await Promise.all(
+          persistGatewaySessionLifecycleEventMock.mock.results.map((result) => result.value),
+        );
+        await vi.advanceTimersByTimeAsync(15_000);
+        expect(read()).toMatchObject({ status: "done", startedAt: 3_000, endedAt: 4_000 });
+        expect(read()?.lastRunError).toBeUndefined();
+        expect(chatBroadcastCalls(broadcast).map(([, payload]) => payload.state)).toEqual([
+          "error",
+          "final",
+        ]);
+      } finally {
+        handler.dispose();
+        vi.useRealTimers();
+      }
+    }),
+  );
 
   it("keeps deferred lifecycle-error cleanup across later non-terminal events", () => {
     vi.useFakeTimers();

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -8,8 +8,10 @@ import {
 } from "../../packages/gateway-protocol/src/schema/logs-chat.js";
 import { isAgentLifecycleYieldedWaiting } from "../agents/agent-lifecycle-parent-state.js";
 import {
+  AGENT_RUN_TERMINAL_RETRY_GRACE_MS,
   buildAgentRunTerminalOutcomeFromLifecycleEvent,
   classifyAgentRunTerminalOutcome,
+  isDefinitiveRunLifecycle,
 } from "../agents/agent-run-terminal-outcome.js";
 import { isActiveEmbeddedRunId } from "../agents/embedded-agent-runner/runs.js";
 import { isTimeoutError, resolveFailoverReasonFromError } from "../agents/failover-error.js";
@@ -218,11 +220,6 @@ function normalizeHeartbeatChatFinalText(params: {
   return { suppress: false, text: stripped.text };
 }
 
-/**
- * Keep this aligned with the agent.wait lifecycle-error grace so chat surfaces
- * do not finalize a run before fallback or retry reuses the same runId.
- */
-const AGENT_LIFECYCLE_ERROR_RETRY_GRACE_MS = 15_000;
 const LIVE_TEXT_PACING_MS = 75;
 
 export type ChatEventBroadcast = GatewayBroadcastFn;
@@ -448,7 +445,7 @@ export function createAgentEventHandler({
   sessionMessageSubscribers,
   loadGatewaySessionLifecycleSnapshotForEvent = loadGatewaySessionLifecycleSnapshot,
   persistGatewaySessionLifecycleEventForEvent = persistGatewaySessionLifecycleEvent,
-  lifecycleErrorRetryGraceMs = AGENT_LIFECYCLE_ERROR_RETRY_GRACE_MS,
+  lifecycleErrorRetryGraceMs = AGENT_RUN_TERMINAL_RETRY_GRACE_MS,
   isChatSendRunActive = () => false,
   clearTrackedActiveRun,
   settleTrackedTerminal,
@@ -1714,11 +1711,14 @@ export function createAgentEventHandler({
 
     if (lifecyclePhase === "error") {
       const skipChatErrorFinal = isChatSendRunActive(evt.runId) && !chatLink;
-      const isFallbackExhaustedFailure = evt.data?.fallbackExhaustedFailure === true;
-      // Per-attempt provider errors keep the retry grace so fallback can reuse
-      // the runId. Once the runner marks fallback as exhausted, clear chat state
-      // immediately so webchat sessions do not stay in progress until the timer.
-      if (isAborted || isFallbackExhaustedFailure || lifecycleErrorRetryGraceMs <= 0) {
+      const definitiveTerminal = isDefinitiveRunLifecycle({
+        phase: lifecyclePhase,
+        data: evt.data,
+      });
+      // Only retryable errors get grace. Definitive timeouts must persist their
+      // reason before dispatch closes the run and the sidebar reads its status.
+      if (isAborted || definitiveTerminal || lifecycleErrorRetryGraceMs <= 0) {
+        clearPendingTerminalLifecycleError(evt.runId);
         // finalizeLifecycleEvent clears the buffer itself, after emitChatTerminal
         // has flushed the throttled tail and resolved the terminal message.
         finalizeLifecycleEvent(evt, { skipChatErrorFinal, restartRecoveryState });


### PR DESCRIPTION
## What Problem This Solves

A definitive runtime timeout could leave the sidebar showing `Run failed: Unknown error` despite chat having the explanation. An older retry-error timer could also overwrite a subsequent successful run with stale failure state.

## Why This Change Was Made

The Gateway lifecycle owner now uses the canonical definitive-terminal classifier and shared retry-grace constant, clears any older pending error timer, and immediately persists definitive results. Ordinary retryable errors retain their grace. This fixes the canonical session state, not the sidebar renderer; no tool-payload inference, new timeout copy, configuration option, schema, dependency, or public API.

**Production +11/−11, net 0; tests +120/−40; docs +6/−0.** Ordered SQLite/session-event regressions cover both failures. The fixture owns SQLite/WAL/timer cleanup, and adjacent buffered-output tests now establish actual throttling and compare the correct invocation order.

Related: [PR #134755 — quiet-native-work and lifecycle repair](https://github.com/openclaw/openclaw/pull/134755), landed as [03e4bc05af66](https://github.com/openclaw/openclaw/commit/03e4bc05af6695095c9b8e7b3cc562d067d3e56e). That merge occurred during this PR's final admission and caused a docs-only conflict. Rebased onto `5fe22a7d88919f260e7999fc775733feff3cb1fa`, preserving both documentation updates. Range-diff changes only insertion context; this PR's production and test files remain byte-identical to the prior reviewed candidate.

## User Impact

The unread sidebar promptly shows the timeout reason recorded by the runtime. Opening the failed session dismisses attention normally. A later successful turn clears the prior error, and an obsolete retry timer cannot restore it. This PR does not change execution-budget defaults or provider timing.

## Evidence

**Verified current head: 386f6ddd537c27ff22fffa51f97b82484b3225c0.** [Exact-head CI run 33587282078](https://github.com/openclaw/openclaw/actions/runs/33587282078) completed successfully. Fresh independent Codex autoreview is **scoped-clean at P0**, not an all-priority audit. Native main-baseline inspection at `db8694548f0` found no intervening change in the affected handler/classifier/persistence owner.

### Real Gateway / Control UI / native Codex — PASS

Run `native-execution-timeout-SoQ4XF` used actual SQLite, normal dashboard handoff/UI controls, real managed **Codex 0.151.0**, and a synthetic local Responses provider. The fresh fixture configured the existing public `agents.defaults.timeoutSeconds: 45` setting. It did not manipulate the clock, inject lifecycle events, override native/provider watchdogs or cleanup limits, or use user Stop. The provider continued bookkeeping until the execution deadline.

The native lifecycle reported `phase: error`, `stopReason: timeout`, `timeoutPhase: provider`, `providerStarted: true`, `aborted: false`, and `fallbackExhaustedFailure: false`. The session recorded `status: timeout` and the exact owner reason **`codex app-server execution budget timed out`** in **27 ms**. The unread sidebar showed the same reason in **276 ms**, rather than waiting for the 15-second retry grace. Opening the failed session showed the full diagnostic and dismissed attention.

A new explicit user turn succeeded. The session remained `done` with no prior error for **16,079 ms**. Real page reload returned a fresh `chat.startup.sessionInfo` with `status: done`, the successful run ID, and no `lastRunError` field; the successful reply and clear sidebar remained visible.

The exact source/build/native/config integrity checks passed; build fingerprint `9dcd1a647fe6ce90eaef781b7f51ea8de2992e68cd372d6f5726bc880863a304`. All screenshots and the full-span video contact sheets were inspected. Synthetic conversations and credentials only; no operator service, existing conversation, account library, or production state was changed. Both task-owned proof services were stopped and their ports verified closed.

**Historical before image — original symptom, not current-head proof:**

![Before: chat has actionable timeout details while the sidebar says Unknown error](https://github.com/user-attachments/assets/74df863a-4582-48b6-a0d1-c6207dfaa4f7)

**Current-head after images and complete recording are attached below:** unread sidebar reason, full inline timeout, and successful follow-up after reload. The timeout transition is around 0:47.

### Regression and local validation

Both ordered regressions fail with pre-fix production for the intended causes and pass fixed. The UI scenario does not inject an earlier retry error; cancellation of that timer is proved by the ordered real-persistence regression.

```bash
node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts -t 'persists .* without waiting for retry grace' --reporter=dot
```

The **585-test owner/sibling suite passed again on the rebased head**:

```bash
node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts src/gateway/session-lifecycle-state.test.ts src/gateway/session-lifecycle-state.persistence.test.ts src/agents/agent-run-terminal-outcome.test.ts ui/src/components/app-sidebar.test.ts --reporter=dot
```

The complete changed-check plan passed again, including core/test types, format/lint, storage/SDK guards, dead-export checks, and import cycles:

```bash
node scripts/check-changed.mjs -- src/gateway/server-chat.ts src/gateway/server-chat.agent-events.test.ts docs/concepts/agent-loop.md
```

```bash
pnpm build sourcePerformance
```

```bash
pnpm ui:build
```

The build above is the runtime/assets/provenance profile, not a full declaration/package profile. [Timeout documentation](https://docs.openclaw.ai/concepts/agent-loop#timeouts) documents the Gateway behavior conditional on a definitive runtime timeout.

### Diagnostics and proof history

Zero browser page errors, network failures, or dropped diagnostics. Three expected `/__openclaw__/workspace-icon/[redacted]` 404s generated matching console entries: the synthetic workspace has no project icon, and the existing component deliberately displays a folder glyph. The console is not claimed to be error-free. This is real local runtime/UI proof with a synthetic provider, **not authenticated external model inference**.

The earlier five-minute idle-guard recording on `28b83112a821` is historical. The landed parent intentionally removed that inferred guard; the current proof above uses its execution-deadline owner. Failed early recorder attempts remain retained and were not relabeled. The first merge attempt stopped before intent/dispatch at the newly introduced conflict; its exact operation lock was recovered natively after verifying no merge process or outcome record remained.

The [ClawSweeper exact-head evidence/rank-up request](https://github.com/openclaw/openclaw/pull/135466#issuecomment-5499496886) is satisfied by the refreshed flow. No proof waiver is used.

![04-unread-sidebar-exact-timeout](https://github.com/user-attachments/assets/98d7c676-363a-4d9c-825e-fa793bcf2bc3)

![05-native-timeout-details](https://github.com/user-attachments/assets/5817c784-41c0-4db4-8812-8d8ad875bd8e)

![07-reloaded-persisted-success](https://github.com/user-attachments/assets/393a54e2-527f-478d-a51e-8650291ae95b)

https://github.com/user-attachments/assets/37a09b1c-ef1c-4413-a841-71cef95364a0