### PR TITLE
perf: avoid copying outbound node duplex fragments

### DIFF
--- a/src/infra/node-duplex-framing.test.ts
+++ b/src/infra/node-duplex-framing.test.ts
@@ -17,7 +17,10 @@ function dataFrame(overrides: Record<string, unknown> = {}): string {
 }
 
 describe("node duplex message framing", () => {
-  it("transfers binary messages larger than transport frames in both directions", async () => {
+  it.each([
+    ["ArrayBuffer", ArrayBuffer],
+    ["SharedArrayBuffer", SharedArrayBuffer],
+  ] as const)("transfers exact %s views in both directions", async (_name, BackingBuffer) => {
     const outboundFrames: string[] = [];
     const inboundFrames: string[] = [];
     const leftMessages: Uint8Array[] = [];
@@ -41,13 +44,17 @@ describe("node duplex message framing", () => {
       rightMessages.push(message);
     });
 
-    const outbound = Uint8Array.from({ length: 40_000 }, (_, index) => index % 251);
-    const inbound = Uint8Array.from({ length: 25_000 }, (_, index) => 255 - (index % 251));
+    const outboundBacking = new Uint8Array(new BackingBuffer(40_032)).fill(0xa5);
+    const outbound = outboundBacking.subarray(17, 40_017);
+    outbound.set(Uint8Array.from({ length: 40_000 }, (_, index) => index % 251));
+    const inboundBacking = new Uint8Array(new BackingBuffer(25_032)).fill(0x5a);
+    const inbound = Buffer.from(inboundBacking.buffer, 11, 25_000);
+    inbound.set(Uint8Array.from({ length: 25_000 }, (_, index) => 255 - (index % 251)));
     await left.send(outbound);
     await right.send(inbound);
 
     expect(rightMessages).toEqual([outbound]);
-    expect(leftMessages).toEqual([inbound]);
+    expect(leftMessages).toEqual([new Uint8Array(inbound)]);
     expect(outboundFrames.length).toBeGreaterThan(2);
     expect(inboundFrames.length).toBeGreaterThan(2);
     expect([...outboundFrames, ...inboundFrames]).toSatisfy((frames: string[]) =>

--- a/src/infra/node-duplex-framing.ts
+++ b/src/infra/node-duplex-framing.ts
@@ -167,7 +167,9 @@ export function createNodeDuplexEndpoint(options: {
               message: messageId,
               index,
               last: index === fragments - 1,
-              data: Buffer.from(fragment).toString("base64"),
+              data: Buffer.from(fragment.buffer, fragment.byteOffset, fragment.byteLength).toString(
+                "base64",
+              ),
             }),
           );
           assertOpen();


### PR DESCRIPTION
## What Problem This Solves

Each outbound node duplex fragment copies its bytes into a new Buffer immediately before converting them to a base64 string. The existing queued fragment and source message already own those bytes during the synchronous conversion.

## Why This Change Was Made

Use Node's exact-range Buffer view over the fragment's backing store, byte offset and length. The transport still receives the same immutable JSON string, and inbound decoding, complete-message ownership, backpressure and cleanup retain their existing behavior.

## User Impact

Framed plugin Gateway/node traffic avoids a redundant outbound payload copy. An 8 MiB ordinary ArrayBuffer transfer removes 1,024 copying calls and 8,388,608 copied bytes while producing identical wire output. This is not an end-to-end zero-copy or Gateway RSS claim; base64, inbound assembly and native shared-memory handling still allocate.

## Evidence

Independent real WebSocket tests passed 21 before/after/mixed-version roundtrips and 42 complete deliveries, including nonzero-offset Uint8Array and Buffer views, pooled buffers, SharedArrayBuffer, empty messages and a fragmented payload with a short final fragment. Controlled mutation and held-listener cases preserve queued serialization and delivery lifetime. Wrong-offset negative controls fail the expanded existing test.

All 172 focused framing, node-host and Gateway plugin tests pass, as do production and test type checks, typed lint, formatting and configured autoreview. The changed expression preserves the inspected Node Buffer contract and the framed Codex complete-message contract; this change does not alter the separate raw terminal path.

Both immutable builds also passed the real Gateway/headless-node flow: normal one-use pairing, authenticated operator RPC, explicit command allowlisting, and a synthetic plugin using the actual `openDuplex`/`io.frames` transport. Fragmented messages at offsets 17 and 31 and a true empty message at offset 9 preserved IDs, hashes and order. Closure waited for a held asynchronous receiver in both builds. All task-owned processes, state and exact coordinator files were cleaned up. This proves the shared framed transport; it does not claim a native Codex process was executed.

Production +3/-1 (net +2), entirely formatter wrapping of the replacement expression. Tests +11/-4 (net +7), extending the existing bidirectional case rather than adding a new test seam.
