### PR TITLE
perf: reuse sorted ranges while rendering context maps

### DIFF
--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -28,9 +28,8 @@ import type { ReplyPayload } from "../types.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 import { renderContextTreemapPng } from "./context-treemap.js";
 
-function formatInt(n: number): string {
-  return new Intl.NumberFormat("en-US").format(n);
-}
+const numberFormat = new Intl.NumberFormat("en-US");
+const formatInt = (value: number) => numberFormat.format(value);
 
 function formatCharsAndTokens(chars: number): string {
   return `${formatInt(chars)} chars (~${formatInt(estimateTokensFromChars(chars))} tok)`;
@@ -50,7 +49,7 @@ function formatListTop(
   entries: Array<{ name: string; value: number }>,
   cap: number,
 ): { lines: string[]; omitted: number } {
-  const sorted = [...entries].toSorted((a, b) => b.value - a.value);
+  const sorted = entries.toSorted((a, b) => b.value - a.value);
   const top = sorted.slice(0, cap);
   const omitted = Math.max(0, sorted.length - top.length);
   const lines = top.map((e) => `- ${e.name}: ${formatCharsAndTokens(e.value)}`);

--- a/src/auto-reply/reply/context-treemap.ts
+++ b/src/auto-reply/reply/context-treemap.ts
@@ -112,9 +112,8 @@ function mixColor(a: Rgba, b: Rgba, amount: number): Rgba {
   );
 }
 
-function formatInt(value: number): string {
-  return new Intl.NumberFormat("en-US").format(value);
-}
+const numberFormat = new Intl.NumberFormat("en-US");
+const formatInt = (value: number) => numberFormat.format(value);
 
 function formatSize(value: number): string {
   return `${formatInt(value)} CH / ~${formatInt(estimateTokensFromChars(value))} TOK`;
@@ -145,50 +144,49 @@ function truncateLabel(value: string, maxChars: number): string {
   return value.slice(0, maxChars - 1);
 }
 
-function layoutBinary<T extends { value: number }>(rawItems: T[], rect: Rect): PositionedItem<T>[] {
+function layoutBinary<T extends { value: number }>(
+  rawItems: T[],
+  bounds: Rect,
+): PositionedItem<T>[] {
   const items = rawItems.filter((item) => item.value > 0).toSorted((a, b) => b.value - a.value);
-  if (items.length === 0 || rect.width <= 0 || rect.height <= 0) {
-    return [];
-  }
-  if (items.length === 1) {
-    return [{ item: expectDefined(items[0], "items entry at 0"), rect }];
-  }
-  const total = totalValue(items);
-  let splitIndex = 1;
-  let splitSum = items[0]?.value ?? 0;
-  for (let i = 1; i < items.length - 1; i += 1) {
-    const next = splitSum + expectDefined(items[i], "items entry at i").value;
-    if (Math.abs(total / 2 - next) > Math.abs(total / 2 - splitSum)) {
-      break;
+  const positioned: PositionedItem<T>[] = [];
+  // Child ranges retain the stable descending order; sum each range from zero
+  // to preserve floating-point split decisions and pixel boundaries.
+  function visit(start: number, end: number, rect: Rect): void {
+    if (start === end || rect.width <= 0 || rect.height <= 0) {
+      return;
     }
-    splitSum = next;
-    splitIndex = i + 1;
+    if (end - start === 1) {
+      positioned.push({ item: expectDefined(items[start], "items entry at start"), rect });
+      return;
+    }
+    let total = 0;
+    for (let i = start; i < end; i += 1) {
+      total += expectDefined(items[i], "items entry at i").value;
+    }
+    let splitIndex = start + 1;
+    let splitSum = items[start]?.value ?? 0;
+    for (let i = start + 1; i < end - 1; i += 1) {
+      const next = splitSum + expectDefined(items[i], "items entry at i").value;
+      if (Math.abs(total / 2 - next) > Math.abs(total / 2 - splitSum)) {
+        break;
+      }
+      splitSum = next;
+      splitIndex = i + 1;
+    }
+    const ratio = splitSum / total;
+    const dimension = rect.width >= rect.height ? "width" : "height";
+    const position = dimension === "width" ? "x" : "y";
+    const firstSize = rect[dimension] * ratio;
+    visit(start, splitIndex, { ...rect, [dimension]: firstSize });
+    visit(splitIndex, end, {
+      ...rect,
+      [position]: rect[position] + firstSize,
+      [dimension]: rect[dimension] - firstSize,
+    });
   }
-  const first = items.slice(0, splitIndex);
-  const second = items.slice(splitIndex);
-  const ratio = splitSum / total;
-  if (rect.width >= rect.height) {
-    const firstWidth = rect.width * ratio;
-    return [
-      ...layoutBinary(first, { ...rect, width: firstWidth }),
-      ...layoutBinary(second, {
-        x: rect.x + firstWidth,
-        y: rect.y,
-        width: rect.width - firstWidth,
-        height: rect.height,
-      }),
-    ];
-  }
-  const firstHeight = rect.height * ratio;
-  return [
-    ...layoutBinary(first, { ...rect, height: firstHeight }),
-    ...layoutBinary(second, {
-      x: rect.x,
-      y: rect.y + firstHeight,
-      width: rect.width,
-      height: rect.height - firstHeight,
-    }),
-  ];
+  visit(0, items.length, bounds);
+  return positioned;
 }
 
 /** Tiny in-process RGBA canvas used to avoid runtime image dependencies. */
@@ -371,8 +369,7 @@ function drawTreemap(canvas: PngCanvas, groups: TreemapGroup[], rect: Rect): voi
       },
       0,
     );
-    const leaves = group.leaves.filter((leaf) => leaf.value > 0);
-    const leafRects = layoutBinary(leaves, childRect);
+    const leafRects = layoutBinary(group.leaves, childRect);
     leafRects.forEach(({ item: leaf, rect: leafRect }, leafIndex) => {
       const shade = (leafIndex % 7) / 10 + (groupIndex % 2) * 0.08;
       const fill = mixColor(group.color, rgba(255, 255, 255), shade);


### PR DESCRIPTION
## What Problem This Solves

Context maps repeatedly sort and copy subsets while laying out the same entries. Rendering a medium map creates hundreds of temporary arrays and repeatedly prepares identical number formatters.

## Why This Change Was Made

Sort the valid leaves once, traverse index ranges into that immutable order, and write rectangles into one output array. Preserve each range's original left-to-right sum so floating-point geometry, split ties and labels remain identical. Reuse the existing number format and remove redundant filtering and report-list copies.

## User Impact

`/context map` and context reports keep their existing output with less allocation and sorting work. Production +46/-50 (net -4); tests unchanged.

## Evidence

Independent review and the final implementation match across 41,342 geometry cases, 10,017 number-format cases and 10 exact PNG/RGBA comparisons. The 64-leaf layout reduces explicit temporary arrays from 506 to 2 and sorts from 127 to 1. The medium full render reduces temporary arrays from 889 to 12. These are allocation-operation counts, not retained heap or Gateway RSS estimates.

All 20 focused integration tests, type checking, typed lint, formatting, configured autoreview and the full build pass. An isolated real OpenAI Gateway run completed an ordinary reply, Code Mode `web_fetch` with HTTP 200, and `/context map`. The command generated a valid 1280×860 PNG with verified chunk checksums and emitted its final context caption; the Gateway exited cleanly. The observed chat event contained the caption, so this proof does not claim image delivery to a channel.

The synthetic before/after fixtures are byte-identical:

| Before | After |
| --- | --- |
| ![Context map before](https://github.com/user-attachments/assets/bc57c57e-8062-4357-ba1d-8ae68a0c2612) | ![Context map after](https://github.com/user-attachments/assets/f61f4e46-41ba-4832-b876-ca01b42eb15c) |
