### PR TITLE
perf: remove unused Gateway metadata scope hashing

### DIFF
--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -172,7 +172,7 @@ export function createAgentRuntimeMetadataPluginIdScope(params: {
   workspaceDir: string;
   selections: readonly AgentHarnessPluginSelection[];
   shorthandModelIds?: readonly string[];
-}): PluginMetadataSnapshotPluginIdScope {
+}): PluginMetadataSnapshotPluginIdScope & { key: string } {
   return {
     key: hashJson({
       kind: "agent-runtime",

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -680,7 +680,6 @@ describe("current plugin metadata snapshot", () => {
   it("requires exact plugin scope when the caller derives scope from the current index", () => {
     const config = { plugins: { allow: ["demo", "other"] } };
     const pluginIdScope = {
-      key: "test-scope",
       resolve: () => ["demo", "other"],
     };
     const unscoped = createSnapshot({ config });

--- a/src/plugins/gateway-startup-plugin-metadata.ts
+++ b/src/plugins/gateway-startup-plugin-metadata.ts
@@ -16,7 +16,6 @@ import {
   resolveMemorySlotStartupPluginId,
 } from "./gateway-startup-plugin-config.js";
 import { sortUniquePluginIds } from "./gateway-startup-plugin-contracts.js";
-import { hashJson } from "./installed-plugin-index-hash.js";
 import { createInstalledPluginIndexScopeLookup } from "./installed-plugin-index-scope-lookup.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import type { PluginMetadataSnapshotPluginIdScope } from "./plugin-metadata-snapshot.types.js";
@@ -171,24 +170,8 @@ export function createGatewayStartupMetadataPluginIdScope(params: {
   platform?: NodeJS.Platform;
   ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }): PluginMetadataSnapshotPluginIdScope {
-  const configuredChannelIds = collectConfiguredStartupChannelIds({
-    config: params.config,
-    activationSourceConfig: params.activationSourceConfig ?? params.config,
-    env: params.env,
-    ambientEnvTriggers: params.ambientEnvTriggers,
-    includePersistedAuthState: false,
-  });
   const workerProviderIds = normalizeWorkerProviderIds(params.workerProviderIds ?? []);
   return {
-    key: hashJson({
-      kind: "gateway-startup",
-      config: params.config,
-      activationSourceConfig: params.activationSourceConfig ?? null,
-      configuredChannelIds,
-      workerProviderIds,
-      platform: params.platform ?? null,
-      ambientEnvTriggers: params.ambientEnvTriggers ?? "allow",
-    }),
     resolve: ({ index }) =>
       resolveGatewayStartupMetadataPluginIds({
         config: params.config,

--- a/src/plugins/plugin-metadata-snapshot.types.ts
+++ b/src/plugins/plugin-metadata-snapshot.types.ts
@@ -14,7 +14,6 @@ import type {
 } from "./plugin-registry-snapshot.types.js";
 
 export type PluginMetadataSnapshotPluginIdScope = {
-  key: string;
   resolve: (params: { index: InstalledPluginIndex }) => readonly string[] | undefined;
 };
 


### PR DESCRIPTION
## What Problem This Solves

Offline plugin inspection builds a startup metadata scope that serializes and hashes the full configuration and eagerly scans configured channels, even though nothing reads that scope's key.

## Why This Change Was Made

Remove the unused Gateway key and its eager collection. The existing resolver still selects plugins from the canonical metadata snapshot. Keep the agent runtime's key explicitly required on its owning return type because utility-model re-resolution compares it. Remove the obsolete key from the generic scope fixture as well.

## User Impact

Plugin inspection preserves selection, activation and fallback behavior with less configuration hashing and channel collection. Production +1/-19 (net -18); tests -1. No configuration, public API, persistence or protocol change.

## Evidence

The actual built `hooks list --agent fixture-agent --json` command returned the same six ordered hook records before and after, including the registered synthetic plugin. V8 coverage in both real CLI processes recorded the startup planner and changed scope factory. An explicit unavailable Gateway URL instead returned `ECONNREFUSED` with zero fallback-owner coverage. Both immutable builds passed.

Independent owner checks preserve 23 selection scenarios and show one unused hash and eager channel collection removed per scope construction. The separate agent-key negative control fails if its still-required key is removed. All 134 focused repository tests, core and plugin-test type checks, typed lint, formatting and configured autoreview pass. These results establish removed work and preserved behavior; no Gateway RSS or universal latency reduction is claimed.
