### PR TITLE
perf(packaging): remove redundant npm install payload

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
@@ -112,24 +112,28 @@ struct MacNodeCodexThreadCatalogTests {
             body: body)
     }
 
-    private func makeBlockedRequestServer(warmup: Bool = false) throws -> FakeCodex {
+    private func makeBlockedRequestServer(warmup: Bool = false, requestGate: Bool = false) throws -> FakeCodex {
         let warmupResponse = warmup ? #"""
         id=$(printf '%s\n' "$request" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
         printf '{"id":%s,"result":{"data":[]}}\n' "$id"
         IFS= read -r request || exit 5
         """# : ""
+        let createRequestGate = requestGate ? #"[ "$count" != 1 ] || mkfifo "${0}.request-gate""# : ""
+        let awaitRequestGate = requestGate ? #"IFS= read -r _ < "${0}.request-gate" || exit 0"# : ""
         return try self.makeAppServer(
             preamble: #"""
             count=0
             [ ! -f "${0}.processes" ] || count=$(cat "${0}.processes")
             count=$((count + 1))
             printf '%s\n' "$count" > "${0}.processes"
+            \#(createRequestGate)
             """#,
             body: #"""
             IFS= read -r request || exit 4
             if [ "$count" = 1 ]; then
               \#(warmupResponse)
               printf '%s\n' "$request" > "${0}.request-started"
+              \#(awaitRequestGate)
               IFS= read -r unexpected || exit 0
               printf '%s\n' "$unexpected" > "${0}.unexpected-request"
               exit 6
@@ -1355,7 +1359,7 @@ extension MacNodeCodexThreadCatalogTests {
     }
 
     @Test func `queued request consumes its wall-clock deadline`() async throws {
-        let fake = try makeBlockedRequestServer(warmup: true)
+        let fake = try makeBlockedRequestServer(warmup: true, requestGate: true)
         let client = CodexAppServerThreadClient(idleTimeoutSeconds: 10)
         do {
             // Complete the real handshake before exercising an active or queued deadline.
@@ -1365,15 +1369,31 @@ extension MacNodeCodexThreadCatalogTests {
             throw error
         }
 
+        let readiness = Task {
+            try await self.openFIFOForWriting(
+                URL(fileURLWithPath: fake.executable.path + ".request-gate"))
+        }
         let first = Task {
-            try await self.requestEmptyList(
+            defer { readiness.cancel() }
+            return try await self.requestEmptyList(
                 client: client,
                 executable: fake.executable,
                 timeoutSeconds: MacNodeCodexThreadCatalog.defaultTimeoutSeconds)
         }
         do {
-            try #require(await self.waitForFile(
-                URL(fileURLWithPath: fake.executable.path + ".request-started")))
+            // The writer witnesses request receipt; readiness shares the first
+            // request's lifetime instead of racing an independent polling deadline.
+            let requestGate: FileHandle
+            do {
+                requestGate = try await readiness.value
+            } catch is CancellationError {
+                _ = try await first.value
+                throw CancellationError()
+            }
+            defer { try? requestGate.close() }
+            try #require(FileManager.default.fileExists(atPath: fake.executable.path + ".request-started"))
+            try requestGate.write(contentsOf: Data("ready\n".utf8))
+            try requestGate.close()
             let second = Task {
                 try await self.requestEmptyList(
                     client: client,
@@ -1392,8 +1412,10 @@ extension MacNodeCodexThreadCatalogTests {
             #expect(try self.readTrimmed(
                 URL(fileURLWithPath: fake.executable.path + ".processes")) == "1")
         } catch {
+            readiness.cancel()
             first.cancel()
             _ = await first.result
+            _ = await readiness.result
             await client.shutdown()
             throw error
         }

--- a/docs/gateway/security/dependency-locking.md
+++ b/docs/gateway/security/dependency-locking.md
@@ -39,6 +39,8 @@ Published OpenClaw plugin packages bundle their runtime dependency files in the 
 
 Native-heavy plugins opt out of runtime dependency bundling because their dependency trees contain platform-specific or large native artifacts. Those plugins resolve dependencies at install time from exact-pinned direct dependencies. The root `openclaw` package also resolves dependencies at install time and does not bundle its full dependency tree.
 
+The bundled Anthropic plugin carries the official Claude Agent SDK transport as build-time package assets, preserving its package layout and license. It uses the separately installed `claude` executable selected by OpenClaw, so those assets omit the SDK's optional native CLI packages. The source SDK remains pinned in the plugin manifest and root development dependencies; installing OpenClaw does not install a second Claude executable through the SDK.
+
 Neither path publishes a lockfile:
 
 - root and plugin tarballs contain neither `npm-shrinkwrap.json` nor `package-lock.json`;

--- a/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
@@ -3,6 +3,7 @@ import crypto, { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { gzipSync } from "node:zlib";
 import * as tar from "tar";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { DIR_FETCH_HARD_MAX_BYTES, FILE_TRANSFER_SUBDIR } from "./descriptors.js";
@@ -60,9 +61,59 @@ async function createTarBuffer(params: {
   return Buffer.concat(chunks);
 }
 
+type RawTarEntry = {
+  path: string;
+  contents?: string;
+  type?: tar.Header["type"];
+  linkpath?: string;
+};
+
+function createRawTarBuffer(entries: RawTarEntry[]): Buffer {
+  const blocks = entries.flatMap(({ path: entryPath, contents = "", type = "File", linkpath }) => {
+    const payload = Buffer.from(contents);
+    const block = Buffer.alloc(512);
+    const header = new tar.Header({
+      path: entryPath,
+      type,
+      linkpath,
+      size: payload.byteLength,
+      mode: 0o644,
+      uid: 0,
+      gid: 0,
+      mtime: new Date(0),
+    });
+    // Bypass tar.c and filesystem naming rules without letting the header encoder
+    // truncate, split, or normalize the raw path these security cases exercise.
+    expect(Buffer.byteLength(entryPath)).toBeLessThan(100);
+    expect(header.encode(block)).toBe(false);
+    expect(block.subarray(0, 100).toString("utf8").replace(/\0.*$/u, "")).toBe(entryPath);
+    return [block, payload, Buffer.alloc((512 - (payload.byteLength % 512)) % 512)];
+  });
+  return gzipSync(Buffer.concat([...blocks, Buffer.alloc(1024)]));
+}
+
+function pathOverrideEntries(
+  format: "PAX" | "GNU",
+  rawPath: string,
+  effectivePath: string,
+): RawTarEntry[] {
+  return [
+    format === "PAX"
+      ? {
+          path: "PaxHeader",
+          type: "ExtendedHeader",
+          contents: new tar.Pax({ path: effectivePath }).encodeBody(),
+        }
+      : { path: "././@LongLink", type: "NextFileHasLongPath", contents: `${effectivePath}\0` },
+    { path: rawPath, contents: "normalized" },
+  ];
+}
+
 function prepareArchive(tarBuffer: Buffer) {
-  const archivePath = path.join(tmpRoot, `archive-${randomUUID()}.tar.gz`);
+  const mediaDir = path.join(tmpRoot, "media");
+  const archivePath = path.join(mediaDir, `archive-${randomUUID()}.tar.gz`);
   saveMediaBuffer.mockImplementation(async () => {
+    await fs.mkdir(mediaDir, { recursive: true });
     await fs.writeFile(archivePath, tarBuffer);
     return { path: archivePath };
   });
@@ -79,7 +130,7 @@ function prepareArchive(tarBuffer: Buffer) {
     },
     startedAt: Date.now(),
   }));
-  return archivePath;
+  return { archivePath, mediaDir };
 }
 
 async function executeDirFetch() {
@@ -87,6 +138,23 @@ async function executeDirFetch() {
     node: "node-1",
     path: "/tmp/project",
   });
+}
+
+async function expectUnsafeArchive(
+  entries: RawTarEntry[],
+  causeCode: "entry-path" | "entry-filtered" = "entry-path",
+  message = /^dir\.fetch UNSAFE_ARCHIVE:/u,
+) {
+  const { archivePath, mediaDir } = prepareArchive(createRawTarBuffer(entries));
+  await expect(executeDirFetch()).rejects.toMatchObject({
+    message: expect.stringMatching(message),
+    cause: { name: "ArchiveSecurityError", code: causeCode },
+  });
+  await expect(fs.access(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
+  await expect(fs.readdir(mediaDir)).resolves.toEqual([]);
+  expect(appendFileTransferAudit).toHaveBeenLastCalledWith(
+    expect.objectContaining({ decision: "error", errorCode: "UNSAFE_ARCHIVE" }),
+  );
 }
 
 describe("dir.fetch archive extraction", () => {
@@ -151,41 +219,49 @@ describe("dir.fetch archive extraction", () => {
     );
   });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects a Fleet-shaped archive containing a symlink",
-    async () => {
-      const tarBuffer = await createTarBuffer({
-        entries: ["data", "auth"],
-        setup: async (sourceDir) => {
-          await fs.mkdir(path.join(sourceDir, "data"));
-          await fs.mkdir(path.join(sourceDir, "auth"));
-          await fs.writeFile(path.join(sourceDir, "data", "state.json"), "{}");
-          await fs.writeFile(path.join(sourceDir, "auth", "token"), "secret");
-          await fs.symlink("../auth/token", path.join(sourceDir, "data", "token-link"));
-        },
-      });
-      const archivePath = prepareArchive(tarBuffer);
-
+  it.each(["SymbolicLink", "Link", "CharacterDevice", "BlockDevice", "FIFO"] as const)(
+    "rejects a Fleet-shaped archive containing a %s",
+    async (type) => {
       // A symlink entry used to hang extraction instead of rejecting; the test
-      // timeout bounds settling, so a hang regression fails without a wall-clock race.
-      await expect(executeDirFetch()).rejects.toThrow(/dir\.fetch UNSAFE_ARCHIVE:.*link/iu);
-      await expect(fs.access(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
-      expect(appendFileTransferAudit).toHaveBeenLastCalledWith(
-        expect.objectContaining({ decision: "error", errorCode: "UNSAFE_ARCHIVE" }),
+      // timeout bounds settling without a wall-clock race, including on Windows.
+      await expectUnsafeArchive(
+        [
+          { path: "data", type: "Directory" },
+          { path: "data/state.json", contents: "{}" },
+          { path: "auth", type: "Directory" },
+          { path: "auth/token", contents: "secret" },
+          {
+            path: "data/token-link",
+            type,
+            ...(type === "SymbolicLink" || type === "Link" ? { linkpath: "../auth/token" } : {}),
+          },
+        ],
+        "entry-filtered",
+        /dir\.fetch UNSAFE_ARCHIVE:.*link/iu,
       );
     },
   );
 
-  it.runIf(process.platform !== "win32")(
-    "extracts canonical backslash-separated names beneath the destination",
-    async () => {
-      const tarBuffer = await createTarBuffer({
-        entries: ["dir\\note.txt"],
-        setup: async (sourceDir) => {
-          await fs.writeFile(path.join(sourceDir, "dir\\note.txt"), "normalized");
-        },
-      });
-      prepareArchive(tarBuffer);
+  it.each([
+    {
+      name: "backslash",
+      entries: [{ path: "dir\\note.txt", contents: "normalized" }],
+      expectedPath: ["dir", "note.txt"],
+    },
+    {
+      name: "mixed separators and dots",
+      entries: [{ path: "./pkg//dir\\note.txt", contents: "normalized" }],
+      expectedPath: ["pkg", "dir", "note.txt"],
+    },
+    ...(["PAX", "GNU"] as const).map((format) => ({
+      name: `${format} override`,
+      entries: pathOverrideEntries(format, "raw.txt", "./pkg//dir\\note.txt"),
+      expectedPath: ["pkg", "dir", "note.txt"],
+    })),
+  ])(
+    "extracts canonical $name names beneath the destination",
+    async ({ entries, expectedPath }) => {
+      const { mediaDir } = prepareArchive(createRawTarBuffer(entries));
       const result = await executeDirFetch();
       const details = result.details as {
         rootDir: string;
@@ -193,28 +269,53 @@ describe("dir.fetch archive extraction", () => {
       };
       expect(details.files).toMatchObject([
         {
-          relPath: path.join("dir", "note.txt"),
-          localPath: path.join(details.rootDir, "dir", "note.txt"),
+          relPath: path.join(...expectedPath),
+          localPath: path.join(details.rootDir, ...expectedPath),
         },
       ]);
+      expect(path.dirname(details.rootDir)).toBe(mediaDir);
       await expect(fs.readFile(details.files[0]!.localPath, "utf8")).resolves.toBe("normalized");
+      expect(appendFileTransferAudit).toHaveBeenLastCalledWith(
+        expect.objectContaining({ decision: "allowed" }),
+      );
     },
   );
 
-  it.runIf(process.platform !== "win32")("rejects backslash-hidden parent traversal", async () => {
-    const tarBuffer = await createTarBuffer({
-      entries: ["dir\\..\\escape.txt"],
-      setup: async (sourceDir) => {
-        await fs.writeFile(path.join(sourceDir, "dir\\..\\escape.txt"), "blocked");
-      },
-    });
-    const archivePath = prepareArchive(tarBuffer);
-    await expect(executeDirFetch()).rejects.toThrow(/dir\.fetch UNSAFE_ARCHIVE:/iu);
-    await expect(fs.access(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
-    expect(appendFileTransferAudit).toHaveBeenLastCalledWith(
-      expect.objectContaining({ decision: "error", errorCode: "UNSAFE_ARCHIVE" }),
-    );
+  it.each([
+    "../escape.txt",
+    "..\\escape.txt",
+    "dir/../escape.txt",
+    "dir\\..\\escape.txt",
+    "dir/..\\escape.txt",
+    "dir\\../escape.txt",
+    "a/b\\..\\escape.txt",
+    "/escape.txt",
+    "\\escape.txt",
+    "\\\\server\\share\\escape.txt",
+    "C:/escape.txt",
+    "C:\\escape.txt",
+    "C:escape.txt",
+    "dir/C:escape.txt",
+  ])("rejects unsafe raw path %j", async (entryPath) => {
+    await expectUnsafeArchive([{ path: entryPath, contents: "blocked" }]);
   });
+
+  it.each(["PAX", "GNU"] as const)(
+    "does not let a safe %s override hide an unsafe raw name",
+    async (format) => {
+      await expectUnsafeArchive(pathOverrideEntries(format, "dir\\..\\escape.txt", "safe.txt"));
+    },
+  );
+
+  it.each(["dir\\note.txt", "./dir//note.txt"])(
+    "rejects canonical collision with %j",
+    async (entryPath) => {
+      await expectUnsafeArchive([
+        { path: "dir/note.txt", contents: "first" },
+        { path: entryPath, contents: "second" },
+      ]);
+    },
+  );
 
   it("maps single-entry expansion limits to TREE_TOO_LARGE", async () => {
     const tarBuffer = await createTarBuffer({
@@ -223,11 +324,13 @@ describe("dir.fetch archive extraction", () => {
         await fs.writeFile(path.join(sourceDir, "large.bin"), Buffer.alloc(16 * 1024 * 1024 + 1));
       },
     });
-    prepareArchive(tarBuffer);
+    const { archivePath, mediaDir } = prepareArchive(tarBuffer);
 
     await expect(executeDirFetch()).rejects.toThrow(
       /dir\.fetch UNCOMPRESSED_TOO_LARGE: archive entry extracted size exceeds limit/iu,
     );
+    await expect(fs.access(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readdir(mediaDir)).resolves.toEqual([]);
     expect(appendFileTransferAudit).toHaveBeenLastCalledWith(
       expect.objectContaining({ decision: "error", errorCode: "TREE_TOO_LARGE" }),
     );

--- a/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
@@ -177,23 +177,44 @@ describe("dir.fetch archive extraction", () => {
   );
 
   it.runIf(process.platform !== "win32")(
-    "extracts canonical paths from backslash-separated archive names",
+    "extracts canonical backslash-separated names beneath the destination",
     async () => {
       const tarBuffer = await createTarBuffer({
         entries: ["dir\\note.txt"],
         setup: async (sourceDir) => {
-          await fs.writeFile(path.join(sourceDir, "dir\\note.txt"), "canonical content");
+          await fs.writeFile(path.join(sourceDir, "dir\\note.txt"), "normalized");
         },
       });
       prepareArchive(tarBuffer);
-
       const result = await executeDirFetch();
-      const files = (result.details as { files: Array<{ relPath: string; localPath: string }> })
-        .files;
-      expect(files).toMatchObject([{ relPath: path.join("dir", "note.txt") }]);
-      await expect(fs.readFile(files[0]!.localPath, "utf8")).resolves.toBe("canonical content");
+      const details = result.details as {
+        rootDir: string;
+        files: Array<{ relPath: string; localPath: string }>;
+      };
+      expect(details.files).toMatchObject([
+        {
+          relPath: path.join("dir", "note.txt"),
+          localPath: path.join(details.rootDir, "dir", "note.txt"),
+        },
+      ]);
+      await expect(fs.readFile(details.files[0]!.localPath, "utf8")).resolves.toBe("normalized");
     },
   );
+
+  it.runIf(process.platform !== "win32")("rejects backslash-hidden parent traversal", async () => {
+    const tarBuffer = await createTarBuffer({
+      entries: ["dir\\..\\escape.txt"],
+      setup: async (sourceDir) => {
+        await fs.writeFile(path.join(sourceDir, "dir\\..\\escape.txt"), "blocked");
+      },
+    });
+    const archivePath = prepareArchive(tarBuffer);
+    await expect(executeDirFetch()).rejects.toThrow(/dir\.fetch UNSAFE_ARCHIVE:/iu);
+    await expect(fs.access(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(appendFileTransferAudit).toHaveBeenLastCalledWith(
+      expect.objectContaining({ decision: "error", errorCode: "UNSAFE_ARCHIVE" }),
+    );
+  });
 
   it("maps single-entry expansion limits to TREE_TOO_LARGE", async () => {
     const tarBuffer = await createTarBuffer({

--- a/extensions/file-transfer/src/tools/dir-fetch-tool.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.ts
@@ -7,7 +7,6 @@ import {
   ARCHIVE_LIMIT_ERROR_CODE,
   ArchiveLimitError,
   extractArchive,
-  type ArchiveEntryKind,
 } from "openclaw/plugin-sdk/archive";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
 import { appendFileTransferAudit } from "../shared/audit.js";
@@ -40,10 +39,6 @@ const TAR_UNPACK_MAX_ENTRIES = 5000;
 // enforced by fs-safe while extracting.
 const DIR_FETCH_MAX_UNCOMPRESSED_BYTES = 64 * 1024 * 1024;
 const DIR_FETCH_MAX_SINGLE_FILE_BYTES = 16 * 1024 * 1024;
-
-function filterDirFetchArchiveEntry(entry: { kind: ArchiveEntryKind }): "extract" | "skip" {
-  return entry.kind === "file" || entry.kind === "directory" ? "extract" : "skip";
-}
 
 function classifyArchiveFailure(error: unknown): {
   auditCode: "TREE_TOO_LARGE" | "UNSAFE_ARCHIVE";
@@ -182,7 +177,8 @@ export function createDirFetchTool(): AnyAgentTool {
           tarGzip: true,
           timeoutMs: TAR_UNPACK_TIMEOUT_MS,
           entryModes: "clamp",
-          entryFilter: filterDirFetchArchiveEntry,
+          // fs-safe validates raw paths before supplying canonical pre-strip names.
+          entryFilter: ({ kind }) => (kind === "file" || kind === "directory" ? "extract" : "skip"),
           onFiltered: "reject-archive",
           limits: {
             maxArchiveBytes: DIR_FETCH_HARD_MAX_BYTES,

--- a/package.json
+++ b/package.json
@@ -2069,7 +2069,6 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "1.4.0",
-    "@anthropic-ai/claude-agent-sdk": "0.3.241",
     "@anthropic-ai/sdk": "0.120.0",
     "@clack/core": "1.4.3",
     "@clack/prompts": "1.7.0",
@@ -2138,6 +2137,7 @@
   "devDependencies": {
     "@a2ui/lit": "0.10.3",
     "@a2ui/web_core": "0.10.6",
+    "@anthropic-ai/claude-agent-sdk": "0.3.241",
     "@copilotkit/aimock": "1.39.0",
     "@lit-labs/signals": "0.3.0",
     "@lit/context": "1.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,9 +159,6 @@ importers:
       '@agentclientprotocol/sdk':
         specifier: 1.4.0
         version: 1.4.0(zod@4.4.3)
-      '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.241
-        version: 0.3.241(@anthropic-ai/sdk@0.120.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)
       '@anthropic-ai/sdk':
         specifier: 0.120.0
         version: 0.120.0(zod@4.4.3)
@@ -361,6 +358,9 @@ importers:
       '@a2ui/web_core':
         specifier: 0.10.6
         version: 0.10.6
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: 0.3.241
+        version: 0.3.241(@anthropic-ai/sdk@0.120.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)
       '@copilotkit/aimock':
         specifier: 1.39.0
         version: 1.39.0(vitest@4.1.11)

--- a/scripts/build-all.mts
+++ b/scripts/build-all.mts
@@ -348,6 +348,12 @@ export function resolveBuildAllSteps(
         return step;
       }
       const mergedEnv = Object.assign({}, "env" in step ? step.env : undefined, env);
+      // Source-run rebuilds share qaRuntime but retain the caller's explicit
+      // declaration choice. The other partial profiles remain runtime-only.
+      if (profile === "qaRuntime" && step.label === "tsdown") {
+        mergedEnv[RUN_NODE_SKIP_DTS_BUILD_ENV] =
+          buildEnv[RUN_NODE_SKIP_DTS_BUILD_ENV] ?? mergedEnv[RUN_NODE_SKIP_DTS_BUILD_ENV];
+      }
       const merged: BuildAllStep = Object.assign({}, step, { env: mergedEnv });
       return merged;
     });

--- a/scripts/build-external-plugin-local-dist.mts
+++ b/scripts/build-external-plugin-local-dist.mts
@@ -4,19 +4,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { pathToFileURL } from "node:url";
-import {
-  collectBundledPluginBuildEntries,
-  collectRootPackageExcludedExtensionDirs,
-  DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV,
-  NON_PACKAGED_BUNDLED_PLUGIN_DIRS,
-} from "./lib/bundled-plugin-build-entries.mjs";
-import { shouldBuildBundledCluster } from "./lib/optional-bundled-clusters.mjs";
+import { collectSourceCheckoutPluginBuildEntries } from "./lib/bundled-plugin-build-entries.mjs";
 import { assertRealOutputRoot } from "./lib/output-root-guard.mjs";
-import {
-  buildPluginNpmRuntime,
-  listPublishablePluginPackageDirs,
-  type PluginPackageJson,
-} from "./lib/plugin-npm-runtime-build.mts";
+import { buildPluginNpmRuntime } from "./lib/plugin-npm-runtime-build.mts";
 
 type ExternalPluginLocalDistParams = {
   repoRoot?: string;
@@ -24,37 +14,14 @@ type ExternalPluginLocalDistParams = {
   logLevel?: "silent" | "warn";
 };
 
-function readPluginPackageJson(repoRoot: string, packageDir: string): PluginPackageJson {
-  return JSON.parse(fs.readFileSync(path.join(repoRoot, packageDir, "package.json"), "utf8"));
-}
-
 /** Lists external first-party packages that need source-checkout dist output. */
 export function listExternalPluginLocalDistPackageDirs(
   params: Pick<ExternalPluginLocalDistParams, "repoRoot" | "env"> = {},
 ): string[] {
   const repoRoot = path.resolve(params.repoRoot ?? ".");
-  const env = params.env ?? process.env;
-  if (env[DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV]?.trim()) {
-    return [];
-  }
-  const excludedPluginIds = collectRootPackageExcludedExtensionDirs({ cwd: repoRoot });
-  const excludedBuildableDirs = collectBundledPluginBuildEntries({ cwd: repoRoot, env })
-    .filter(({ id }) => excludedPluginIds.has(id) && !NON_PACKAGED_BUNDLED_PLUGIN_DIRS.has(id))
+  return collectSourceCheckoutPluginBuildEntries({ cwd: repoRoot, env: params.env })
+    .filter(({ isolated }) => isolated)
     .map(({ id }) => `extensions/${id}`);
-  const candidates = new Set([
-    ...listPublishablePluginPackageDirs({ repoRoot }),
-    ...excludedBuildableDirs,
-  ]);
-  return [...candidates]
-    .filter((packageDir) => {
-      const packageJson = readPluginPackageJson(repoRoot, packageDir);
-      return (
-        (packageJson.openclaw?.build?.bundledDist === false ||
-          excludedBuildableDirs.includes(packageDir)) &&
-        shouldBuildBundledCluster(path.basename(packageDir), env, { packageJson })
-      );
-    })
-    .toSorted();
 }
 
 /** Builds isolated plugin graphs, then stages every output below its excluded root dist path. */

--- a/scripts/build-external-plugin-local-dist.mts
+++ b/scripts/build-external-plugin-local-dist.mts
@@ -4,7 +4,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { pathToFileURL } from "node:url";
-import { DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV } from "./lib/bundled-plugin-build-entries.mjs";
+import {
+  collectBundledPluginBuildEntries,
+  collectRootPackageExcludedExtensionDirs,
+  DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV,
+  NON_PACKAGED_BUNDLED_PLUGIN_DIRS,
+} from "./lib/bundled-plugin-build-entries.mjs";
 import { shouldBuildBundledCluster } from "./lib/optional-bundled-clusters.mjs";
 import { assertRealOutputRoot } from "./lib/output-root-guard.mjs";
 import {
@@ -32,13 +37,24 @@ export function listExternalPluginLocalDistPackageDirs(
   if (env[DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV]?.trim()) {
     return [];
   }
-  return listPublishablePluginPackageDirs({ repoRoot }).filter((packageDir) => {
-    const packageJson = readPluginPackageJson(repoRoot, packageDir);
-    return (
-      packageJson.openclaw?.build?.bundledDist === false &&
-      shouldBuildBundledCluster(path.basename(packageDir), env, { packageJson })
-    );
-  });
+  const excludedPluginIds = collectRootPackageExcludedExtensionDirs({ cwd: repoRoot });
+  const excludedBuildableDirs = collectBundledPluginBuildEntries({ cwd: repoRoot, env })
+    .filter(({ id }) => excludedPluginIds.has(id) && !NON_PACKAGED_BUNDLED_PLUGIN_DIRS.has(id))
+    .map(({ id }) => `extensions/${id}`);
+  const candidates = new Set([
+    ...listPublishablePluginPackageDirs({ repoRoot }),
+    ...excludedBuildableDirs,
+  ]);
+  return [...candidates]
+    .filter((packageDir) => {
+      const packageJson = readPluginPackageJson(repoRoot, packageDir);
+      return (
+        (packageJson.openclaw?.build?.bundledDist === false ||
+          excludedBuildableDirs.includes(packageDir)) &&
+        shouldBuildBundledCluster(path.basename(packageDir), env, { packageJson })
+      );
+    })
+    .toSorted();
 }
 
 /** Builds isolated plugin graphs, then stages every output below its excluded root dist path. */

--- a/scripts/check-built-plugin-control-plane-modules.mts
+++ b/scripts/check-built-plugin-control-plane-modules.mts
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import ts from "typescript";
+import { collectSourceCheckoutPluginBuildEntries } from "./lib/bundled-plugin-build-entries.mjs";
 import { isRecord } from "./lib/record-shared.mjs";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 
@@ -26,11 +27,12 @@ type BuiltDoctorContractClosureViolation = BuiltPluginControlPlaneModule & {
 
 type ProbeParams = {
   rootDir?: string;
+  env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
 };
 
 const ROOT = resolveRepoRoot(import.meta.url);
-const DIRECT_CONTRACT_FILES = ["contract-api.js", "doctor-contract-api.js"];
+const DIRECT_CONTRACT_ENTRIES = ["contract-api", "doctor-contract-api"];
 const LEGACY_SETUP_PROPERTIES = new Map<string, string>([
   ["legacyStateMigrations", "channel-legacy-state-migrations"],
   ["legacySessionSurface", "channel-legacy-session-surface"],
@@ -98,12 +100,20 @@ function listLegacySetupModuleSpecifiers(setupEntryPath: string) {
 }
 
 /** Lists exact built doctor, contract, and channel legacy migration artifacts. */
-export function listBuiltPluginControlPlaneModules(params: { rootDir?: string } = {}) {
+export function listBuiltPluginControlPlaneModules(
+  params: Pick<ProbeParams, "rootDir" | "env"> = {},
+) {
   const rootDir = path.resolve(params.rootDir ?? ROOT);
   const extensionsDir = path.join(rootDir, "dist", "extensions");
   if (!fs.existsSync(extensionsDir)) {
     return [];
   }
+  const sourceEntries = new Map(
+    (fs.existsSync(path.join(rootDir, "extensions"))
+      ? collectSourceCheckoutPluginBuildEntries({ cwd: rootDir, env: params.env })
+      : []
+    ).map((entry) => [entry.id, entry]),
+  );
   const modules = new Map<string, BuiltPluginControlPlaneModule>();
   for (const entry of fs
     .readdirSync(extensionsDir, { withFileTypes: true })
@@ -111,18 +121,22 @@ export function listBuiltPluginControlPlaneModules(params: { rootDir?: string } 
     .toSorted((left, right) => left.name.localeCompare(right.name))) {
     const pluginId = entry.name;
     const pluginDir = path.join(extensionsDir, pluginId);
-    for (const fileName of DIRECT_CONTRACT_FILES) {
+    // Packaged core artifacts use ESM; isolated source-checkout plugins use
+    // the same selected format as their builder and generated metadata.
+    const extension = sourceEntries.get(pluginId)?.runtimeExtension ?? ".js";
+    for (const entryName of DIRECT_CONTRACT_ENTRIES) {
+      const fileName = `${entryName}${extension}`;
       const modulePath = path.join(pluginDir, fileName);
       if (fs.existsSync(modulePath)) {
         const relativePath = path.relative(rootDir, modulePath).split(path.sep).join("/");
         modules.set(relativePath, {
           pluginId,
-          kind: fileName === "doctor-contract-api.js" ? "doctor-contract" : "contract",
+          kind: entryName === "doctor-contract-api" ? "doctor-contract" : "contract",
           relativePath,
         });
       }
     }
-    const setupEntryPath = path.join(pluginDir, "setup-entry.js");
+    const setupEntryPath = path.join(pluginDir, `setup-entry${extension}`);
     if (!fs.existsSync(setupEntryPath)) {
       continue;
     }
@@ -184,30 +198,36 @@ export function probeBuiltPluginControlPlaneModules(
   );
 }
 
-// Built chunks are plain ESM, so static edges are exactly the import/export
-// declarations. Dynamic `import()` is excluded by construction: a lazy edge is
-// never paid at enumeration time.
+// Follow ESM declarations and eager CJS require calls emitted by isolated builds.
+// Dynamic imports and requires inside functions are lazy, not enumeration costs.
 function parseStaticModuleSpecifiers(source: string, filePath: string): string[] {
   const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true);
   const specifiers: string[] = [];
-  for (const statement of sourceFile.statements) {
+  const visit = (node: ts.Node): void => {
+    if (ts.isFunctionLike(node)) {
+      return;
+    }
     const moduleSpecifier =
-      ts.isImportDeclaration(statement) || ts.isExportDeclaration(statement)
-        ? statement.moduleSpecifier
-        : undefined;
+      ts.isImportDeclaration(node) || ts.isExportDeclaration(node)
+        ? node.moduleSpecifier
+        : ts.isCallExpression(node) &&
+            ts.isIdentifier(node.expression) &&
+            /^(?:require|_+require\d*)$/u.test(node.expression.text)
+          ? node.arguments[0]
+          : undefined;
     if (moduleSpecifier && ts.isStringLiteralLike(moduleSpecifier)) {
       specifiers.push(moduleSpecifier.text);
     }
-  }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
   return specifiers;
 }
 
 function resolveBuiltChunkPath(importerPath: string, specifier: string): string | undefined {
   const target = path.resolve(path.dirname(importerPath), specifier);
-  const candidates = [target, `${target}.js`, `${target}.mjs`, path.join(target, "index.js")];
-  return candidates.find(
-    (candidate) => fs.existsSync(candidate) && fs.statSync(candidate).isFile(),
-  );
+  // Generated chunk edges carry their exact output suffix, including CJS.
+  return fs.existsSync(target) && fs.statSync(target).isFile() ? target : undefined;
 }
 
 /** Collects the bare dependencies a built artifact reaches through static imports. */

--- a/scripts/check-gateway-watch-regression.mts
+++ b/scripts/check-gateway-watch-regression.mts
@@ -918,6 +918,7 @@ export function collectGatewayWatchFindings(params: {
   cpuMs: number;
   distRuntimeByteGrowth: number;
   distRuntimeFileGrowth: number;
+  removedPaths: number;
   options: Pick<
     WatchOptions,
     "cpuFailMs" | "cpuWarnMs" | "distRuntimeByteGrowthMax" | "distRuntimeFileGrowthMax" | "windowMs"
@@ -930,6 +931,7 @@ export function collectGatewayWatchFindings(params: {
     cpuMs,
     distRuntimeByteGrowth,
     distRuntimeFileGrowth,
+    removedPaths,
     options,
     watchBuildReason,
     watchResult,
@@ -963,6 +965,13 @@ export function collectGatewayWatchFindings(params: {
     failures.push(
       "gateway:watch invalid local run: dirty watched source tree forced a rebuild during the watch window",
     );
+  } else if (watchTriggeredBuild) {
+    failures.push(
+      `gateway:watch unexpectedly rebuilt prebuilt artifacts (${watchBuildReason ?? "unknown reason"})`,
+    );
+  }
+  if (removedPaths > 0) {
+    failures.push(`gateway:watch removed ${removedPaths} prebuilt artifact paths`);
   }
   if (distRuntimeFileGrowth > options.distRuntimeFileGrowthMax) {
     failures.push(
@@ -1042,16 +1051,13 @@ async function main() {
     writeBuildAndRuntimePostBuildStamps();
     preflightBuildRequirement = resolveBuildRequirement(buildRunNodeDeps(process.env));
   }
-  if (
-    preflightBuildRequirement.shouldBuild &&
-    preflightBuildRequirement.reason === "dirty_watched_tree"
-  ) {
+  if (preflightBuildRequirement.shouldBuild) {
     const summary = {
       windowMs: options.windowMs,
       invalidated: true,
       invalidationReason: preflightBuildRequirement.reason,
       invalidationMessage:
-        "gateway-watch-regression cannot run on a dirty watched tree because run-node will intentionally rebuild during the watch window.",
+        "gateway-watch-regression requires a complete, current prebuilt artifact set; run-node would rebuild during the watch window.",
     };
     fs.writeFileSync(
       path.join(options.outputDir, "summary.json"),
@@ -1059,7 +1065,7 @@ async function main() {
     );
     console.log(JSON.stringify(summary, null, 2));
     fail(
-      "gateway-watch-regression invalid local run: dirty watched source tree would force a rebuild inside the watch window",
+      `gateway-watch-regression invalid local run: ${preflightBuildRequirement.reason} would force a rebuild inside the watch window`,
     );
     process.exit(1);
   }
@@ -1107,7 +1113,9 @@ async function main() {
     distRuntimeByteGrowthMax: options.distRuntimeByteGrowthMax,
     distRuntimeAddedPaths,
     addedPaths: diff.added.length,
-    removedPaths: diff.removed.length,
+    // A previously absent tree becoming present removes only the snapshot's
+    // diagnostic sentinel, not an artifact (for example during metadata sync).
+    removedPaths: diff.removed.filter((entry) => !entry.endsWith(" (missing)")).length,
     watchExit: watchResult.exit,
     spawnError: watchResult.spawnError,
     stdoutPath: watchResult.stdoutPath,
@@ -1126,6 +1134,7 @@ async function main() {
     cpuMs,
     distRuntimeByteGrowth,
     distRuntimeFileGrowth,
+    removedPaths: summary.removedPaths,
     options,
     watchBuildReason,
     watchResult,

--- a/scripts/copy-bundled-plugin-metadata.mts
+++ b/scripts/copy-bundled-plugin-metadata.mts
@@ -2,12 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { listExternalPluginLocalDistPackageDirs } from "./build-external-plugin-local-dist.mts";
-import {
-  collectBundledPluginBuildEntries,
-  NON_PACKAGED_BUNDLED_PLUGIN_DIRS,
-} from "./lib/bundled-plugin-build-entries.mjs";
-import { shouldBuildBundledCluster } from "./lib/optional-bundled-clusters.mjs";
+import { collectSourceCheckoutPluginBuildEntries } from "./lib/bundled-plugin-build-entries.mjs";
 import { assertRealOutputRoot } from "./lib/output-root-guard.mjs";
 import {
   mergeGeneratedChannelConfigs,
@@ -32,20 +27,6 @@ type SkillPathParams = {
   repoRoot: string;
 };
 
-function shouldCopyBundledPluginMetadata(
-  id: string,
-  env: NodeJS.ProcessEnv,
-  buildablePluginDirs: Set<string>,
-): boolean {
-  if (!buildablePluginDirs.has(id)) {
-    return false;
-  }
-  if (!NON_PACKAGED_BUNDLED_PLUGIN_DIRS.has(id)) {
-    return true;
-  }
-  return env.OPENCLAW_BUILD_PRIVATE_QA === "1";
-}
-
 function rewritePackageExtensions(entries: unknown, extension: string): string[] | undefined {
   if (!Array.isArray(entries)) {
     return undefined;
@@ -58,53 +39,6 @@ function rewritePackageExtensions(entries: unknown, extension: string): string[]
       const rewritten = normalized.replace(/\.[^.]+$/u, extension);
       return `./${rewritten}`;
     });
-}
-
-function collectTopLevelPublicSurfaceEntries(pluginDir: string): string[] {
-  if (!fs.existsSync(pluginDir)) {
-    return [];
-  }
-
-  return fs
-    .readdirSync(pluginDir, { withFileTypes: true })
-    .flatMap((dirent) => {
-      if (!dirent.isFile()) {
-        return [];
-      }
-
-      if (!/\.(?:[cm]?[jt]s)$/u.test(dirent.name) || dirent.name.endsWith(".d.ts")) {
-        return [];
-      }
-
-      const normalizedName = dirent.name.toLowerCase();
-      if (
-        /^config-api\.(?:[cm]?[jt]s)$/u.test(normalizedName) ||
-        normalizedName.includes(".test.") ||
-        normalizedName.includes(".spec.") ||
-        normalizedName.includes(".fixture.") ||
-        normalizedName.includes(".snap")
-      ) {
-        return [];
-      }
-
-      return [dirent.name];
-    })
-    .toSorted((left, right) => left.localeCompare(right));
-}
-
-function isManifestlessBundledRuntimeSupportPackage(params: {
-  dirName: string;
-  packageJson: unknown;
-  topLevelPublicSurfaceEntries: string[];
-}): boolean {
-  const packageName =
-    isRecord(params.packageJson) && typeof params.packageJson.name === "string"
-      ? params.packageJson.name
-      : "";
-  if (packageName !== `@openclaw/${params.dirName}`) {
-    return false;
-  }
-  return params.topLevelPublicSurfaceEntries.length > 0;
 }
 
 function rewritePackageEntry(entry: unknown, extension: string): string | undefined {
@@ -272,10 +206,12 @@ export function copyBundledPluginMetadata(params: CopyMetadataParams = {}): void
   // would redirect recursive deletes into the link target.
   assertRealOutputRoot(path.join(repoRoot, "dist"));
 
-  const buildablePluginDirs = new Set(
-    collectBundledPluginBuildEntries({ cwd: repoRoot, env }).map((entry) => entry.id),
+  const buildEntries = new Map(
+    collectSourceCheckoutPluginBuildEntries({ cwd: repoRoot, env }).map((entry) => [
+      entry.id,
+      entry,
+    ]),
   );
-  const externalLocalDistDirs = new Set(listExternalPluginLocalDistPackageDirs({ repoRoot, env }));
   const generatedChannelConfigsByPlugin = readGeneratedBundledChannelConfigs(repoRoot);
   const sourcePluginDirs = new Set<string>();
   for (const dirent of fs.readdirSync(extensionsRoot, { withFileTypes: true })) {
@@ -291,49 +227,25 @@ export function copyBundledPluginMetadata(params: CopyMetadataParams = {}): void
       ? JSON.parse(fs.readFileSync(packageJsonPath, "utf8"))
       : undefined;
     const packageJson = isRecord(parsedPackageJson) ? parsedPackageJson : undefined;
-    const topLevelPublicSurfaceEntries = collectTopLevelPublicSurfaceEntries(pluginDir);
-    const hasExternalLocalDist =
-      isRecord(packageJson?.openclaw) &&
-      isRecord(packageJson.openclaw.build) &&
-      packageJson.openclaw.build.bundledDist === false &&
-      fs.existsSync(distPluginDir);
-    if (
-      !hasExternalLocalDist &&
-      !shouldCopyBundledPluginMetadata(dirent.name, env, buildablePluginDirs)
-    ) {
+    const buildEntry = buildEntries.get(dirent.name);
+    if (!buildEntry) {
       removePathIfExists(distPluginDir);
       continue;
     }
-    if (!shouldBuildBundledCluster(dirent.name, env, { packageJson })) {
-      removePathIfExists(distPluginDir);
-      continue;
-    }
-
     const distNodeModules = path.join(distPluginDir, "node_modules");
     // Metadata cleanup must never traverse a previous source-dependency link.
     if (
-      hasExternalLocalDist &&
+      buildEntry.isolated &&
       fs.lstatSync(distNodeModules, { throwIfNoEntry: false })?.isSymbolicLink()
     ) {
       fs.unlinkSync(distNodeModules);
     }
 
-    const isManifestlessSupportPackage =
-      !fs.existsSync(manifestPath) &&
-      isManifestlessBundledRuntimeSupportPackage({
-        dirName: dirent.name,
-        packageJson,
-        topLevelPublicSurfaceEntries,
-      });
 
     sourcePluginDirs.add(dirent.name);
 
     const distManifestPath = path.join(distPluginDir, "openclaw.plugin.json");
     const distPackageJsonPath = path.join(distPluginDir, "package.json");
-    if (!fs.existsSync(manifestPath) && !isManifestlessSupportPackage) {
-      removePathIfExists(distPluginDir);
-      continue;
-    }
 
     if (fs.existsSync(manifestPath)) {
       const manifest: unknown = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
@@ -366,14 +278,7 @@ export function copyBundledPluginMetadata(params: CopyMetadataParams = {}): void
       continue;
     }
     if (packageJson && isRecord(packageJson.openclaw) && "extensions" in packageJson.openclaw) {
-      // Isolated local builds retain the plugin's format; Docker's unified graph
-      // still emits ESM even when the standalone package uses CommonJS.
-      const extension =
-        externalLocalDistDirs.has(`extensions/${dirent.name}`) &&
-        isRecord(packageJson.openclaw.build) &&
-        packageJson.openclaw.build.runtimeFormat === "cjs"
-          ? ".cjs"
-          : ".js";
+      const extension = buildEntry.runtimeExtension;
       packageJson.openclaw = {
         ...packageJson.openclaw,
         extensions: rewritePackageExtensions(packageJson.openclaw.extensions, extension),
@@ -386,7 +291,7 @@ export function copyBundledPluginMetadata(params: CopyMetadataParams = {}): void
     writeTextFileIfChanged(distPackageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
     const sourceNodeModules = path.resolve(pluginDir, "node_modules");
     if (
-      hasExternalLocalDist &&
+      buildEntry.isolated &&
       fs.existsSync(sourceNodeModules) &&
       !fs.existsSync(distNodeModules)
     ) {

--- a/scripts/copy-bundled-plugin-metadata.mts
+++ b/scripts/copy-bundled-plugin-metadata.mts
@@ -191,6 +191,29 @@ function copyDeclaredPluginSkillPaths(params: SkillPathParams): string[] {
   return copiedSkills;
 }
 
+function linkSourcePluginDependencies(pluginDir: string, distNodeModules: string) {
+  const sourceModules = path.join(pluginDir, "node_modules");
+  if (!fs.existsSync(sourceModules)) {
+    return;
+  }
+  const packages = fs.readdirSync(sourceModules).flatMap((name) => {
+    if (name.startsWith(".") && name !== ".bin") {
+      return [];
+    }
+    return name.startsWith("@")
+      ? fs.readdirSync(path.join(sourceModules, name)).map((child) => path.join(name, child))
+      : [name];
+  });
+  // An outer node_modules junction misresolves pnpm's relative links on Windows.
+  // Link canonical package roots individually; keep scopes real and payloads source-owned.
+  // Preserve .bin for managed launchers that resolve the plugin's private CLI shim.
+  for (const name of packages) {
+    const target = path.join(distNodeModules, name);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.symlinkSync(fs.realpathSync(path.join(sourceModules, name)), target, "junction");
+  }
+}
+
 /**
  * Copies bundled plugin metadata and package extension files.
  */
@@ -233,11 +256,9 @@ export function copyBundledPluginMetadata(params: CopyMetadataParams = {}): void
       continue;
     }
     const distNodeModules = path.join(distPluginDir, "node_modules");
-    // Cleanup must not traverse an old source-dependency link, even when
-    // switching from an isolated build to a unified profile.
-    if (fs.lstatSync(distNodeModules, { throwIfNoEntry: false })?.isSymbolicLink()) {
-      fs.unlinkSync(distNodeModules);
-    }
+    // Remove only dist-owned entries, including an old directory link itself,
+    // before skill cleanup or an isolated/unified profile transition.
+    fs.rmSync(distNodeModules, { recursive: true, force: true });
 
     sourcePluginDirs.add(dirent.name);
 
@@ -286,19 +307,8 @@ export function copyBundledPluginMetadata(params: CopyMetadataParams = {}): void
     }
 
     writeTextFileIfChanged(distPackageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
-    const sourceNodeModules = path.resolve(pluginDir, "node_modules");
-    if (
-      buildEntry.isolated &&
-      fs.existsSync(sourceNodeModules) &&
-      !fs.existsSync(distNodeModules)
-    ) {
-      // Published source builds move as a complete checkout; POSIX links must
-      // keep each plugin's dependency owner without retaining the build path.
-      const target =
-        process.platform === "win32"
-          ? sourceNodeModules
-          : path.relative(distPluginDir, sourceNodeModules);
-      fs.symlinkSync(target, distNodeModules, process.platform === "win32" ? "junction" : "dir");
+    if (buildEntry.isolated) {
+      linkSourcePluginDependencies(pluginDir, distNodeModules);
     }
   }
 

--- a/scripts/copy-bundled-plugin-metadata.mts
+++ b/scripts/copy-bundled-plugin-metadata.mts
@@ -210,7 +210,13 @@ function linkSourcePluginDependencies(pluginDir: string, distNodeModules: string
   for (const name of packages) {
     const target = path.join(distNodeModules, name);
     fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.symlinkSync(fs.realpathSync(path.join(sourceModules, name)), target, "junction");
+    const canonical = fs.realpathSync(path.join(sourceModules, name));
+    // POSIX release checkouts relocate as a unit; Windows junctions require absolute targets.
+    fs.symlinkSync(
+      process.platform === "win32" ? canonical : path.relative(path.dirname(target), canonical),
+      target,
+      "junction",
+    );
   }
 }
 

--- a/scripts/copy-bundled-plugin-metadata.mts
+++ b/scripts/copy-bundled-plugin-metadata.mts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { listExternalPluginLocalDistPackageDirs } from "./build-external-plugin-local-dist.mts";
 import {
   collectBundledPluginBuildEntries,
   NON_PACKAGED_BUNDLED_PLUGIN_DIRS,
@@ -45,7 +46,7 @@ function shouldCopyBundledPluginMetadata(
   return env.OPENCLAW_BUILD_PRIVATE_QA === "1";
 }
 
-function rewritePackageExtensions(entries: unknown): string[] | undefined {
+function rewritePackageExtensions(entries: unknown, extension: string): string[] | undefined {
   if (!Array.isArray(entries)) {
     return undefined;
   }
@@ -54,7 +55,7 @@ function rewritePackageExtensions(entries: unknown): string[] | undefined {
     .filter((entry) => typeof entry === "string" && entry.trim().length > 0)
     .map((entry) => {
       const normalized = entry.replace(/^\.\//, "");
-      const rewritten = normalized.replace(/\.[^.]+$/u, ".js");
+      const rewritten = normalized.replace(/\.[^.]+$/u, extension);
       return `./${rewritten}`;
     });
 }
@@ -106,12 +107,12 @@ function isManifestlessBundledRuntimeSupportPackage(params: {
   return params.topLevelPublicSurfaceEntries.length > 0;
 }
 
-function rewritePackageEntry(entry: unknown): string | undefined {
+function rewritePackageEntry(entry: unknown, extension: string): string | undefined {
   if (typeof entry !== "string" || entry.trim().length === 0) {
     return undefined;
   }
   const normalized = entry.replace(/^\.\//, "");
-  const rewritten = normalized.replace(/\.[^.]+$/u, ".js");
+  const rewritten = normalized.replace(/\.[^.]+$/u, extension);
   return `./${rewritten}`;
 }
 
@@ -274,6 +275,7 @@ export function copyBundledPluginMetadata(params: CopyMetadataParams = {}): void
   const buildablePluginDirs = new Set(
     collectBundledPluginBuildEntries({ cwd: repoRoot, env }).map((entry) => entry.id),
   );
+  const externalLocalDistDirs = new Set(listExternalPluginLocalDistPackageDirs({ repoRoot, env }));
   const generatedChannelConfigsByPlugin = readGeneratedBundledChannelConfigs(repoRoot);
   const sourcePluginDirs = new Set<string>();
   for (const dirent of fs.readdirSync(extensionsRoot, { withFileTypes: true })) {
@@ -364,11 +366,19 @@ export function copyBundledPluginMetadata(params: CopyMetadataParams = {}): void
       continue;
     }
     if (packageJson && isRecord(packageJson.openclaw) && "extensions" in packageJson.openclaw) {
+      // Isolated local builds retain the plugin's format; Docker's unified graph
+      // still emits ESM even when the standalone package uses CommonJS.
+      const extension =
+        externalLocalDistDirs.has(`extensions/${dirent.name}`) &&
+        isRecord(packageJson.openclaw.build) &&
+        packageJson.openclaw.build.runtimeFormat === "cjs"
+          ? ".cjs"
+          : ".js";
       packageJson.openclaw = {
         ...packageJson.openclaw,
-        extensions: rewritePackageExtensions(packageJson.openclaw.extensions),
+        extensions: rewritePackageExtensions(packageJson.openclaw.extensions, extension),
         ...(typeof packageJson.openclaw.setupEntry === "string"
-          ? { setupEntry: rewritePackageEntry(packageJson.openclaw.setupEntry) }
+          ? { setupEntry: rewritePackageEntry(packageJson.openclaw.setupEntry, extension) }
           : {}),
       };
     }

--- a/scripts/copy-bundled-plugin-metadata.mts
+++ b/scripts/copy-bundled-plugin-metadata.mts
@@ -233,14 +233,11 @@ export function copyBundledPluginMetadata(params: CopyMetadataParams = {}): void
       continue;
     }
     const distNodeModules = path.join(distPluginDir, "node_modules");
-    // Metadata cleanup must never traverse a previous source-dependency link.
-    if (
-      buildEntry.isolated &&
-      fs.lstatSync(distNodeModules, { throwIfNoEntry: false })?.isSymbolicLink()
-    ) {
+    // Cleanup must not traverse an old source-dependency link, even when
+    // switching from an isolated build to a unified profile.
+    if (fs.lstatSync(distNodeModules, { throwIfNoEntry: false })?.isSymbolicLink()) {
       fs.unlinkSync(distNodeModules);
     }
-
 
     sourcePluginDirs.add(dirent.name);
 

--- a/scripts/lib/bundled-plugin-build-entries-types.d.ts
+++ b/scripts/lib/bundled-plugin-build-entries-types.d.ts
@@ -16,6 +16,10 @@ export const NON_PACKAGED_BUNDLED_PLUGIN_DIRS: Set<string>;
 export const DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV: string;
 export function parseDockerSelectedPluginBuildIdFilter(env?: NodeJS.ProcessEnv): Set<string> | null;
 export function collectPluginSourceEntries(packageJson: unknown): string[];
+export function collectPluginDeclarationSourceEntries(
+  packageJson: unknown,
+  sourceEntries: string[],
+): string[];
 export function collectTopLevelPublicSurfaceEntries(pluginDir: string): string[];
 export function collectRootPackageExcludedExtensionDirs(
   params?: BundledPluginBuildEntryParams,

--- a/scripts/lib/bundled-plugin-build-entries.mjs
+++ b/scripts/lib/bundled-plugin-build-entries.mjs
@@ -93,6 +93,18 @@ function shouldBuildBundledDistEntry(packageJson) {
   return packageJson?.openclaw?.build?.bundledDist !== false;
 }
 
+/**
+ * Standalone and isolated source-checkout builds retain the package's declared format.
+ * @returns {"cjs" | "esm"}
+ */
+export function resolvePluginRuntimeFormat(packageJson) {
+  return packageJson?.openclaw?.build?.runtimeFormat === "cjs" ? "cjs" : "esm";
+}
+
+export function pluginRuntimeExtension(runtimeFormat) {
+  return runtimeFormat === "cjs" ? ".cjs" : ".js";
+}
+
 function isExcludedTopLevelPublicSurfaceFile(fileName) {
   const normalizedName = fileName.toLowerCase();
   return (
@@ -276,7 +288,15 @@ export function collectBundledPluginBuildEntries(params = {}) {
     if (!shouldBuildBundledCluster(dirName, env, { packageJson })) {
       continue;
     }
-    if (!shouldBuildBundledDistEntry(packageJson) && !dockerSelectedBuildIds?.has(dirName)) {
+    const externalSourceEntry =
+      params.includeExternalSourceEntries === true &&
+      (packageJson?.openclaw?.release?.publishToNpm === true ||
+        packageJson?.openclaw?.release?.publishToClawHub === true);
+    if (
+      !shouldBuildBundledDistEntry(packageJson) &&
+      !dockerSelectedBuildIds?.has(dirName) &&
+      !externalSourceEntry
+    ) {
       continue;
     }
 
@@ -320,6 +340,35 @@ export function collectBundledPluginBuildEntries(params = {}) {
     );
   }
   return entries.filter((entry) => filteredBuildIds.has(entry.id));
+}
+
+/** One source-checkout output plan for compilation, metadata, and readiness checks. */
+export function collectSourceCheckoutPluginBuildEntries(params = {}) {
+  const env = params.env ?? process.env;
+  const dockerSelected = parseDockerSelectedPluginBuildIdFilter(env);
+  const excluded = collectRootPackageExcludedExtensionDirs(params);
+  return collectBundledPluginBuildEntries({
+    ...params,
+    includeExternalSourceEntries: !dockerSelected,
+  })
+    .filter(({ id }) =>
+      NON_PACKAGED_BUNDLED_PLUGIN_DIRS.has(id)
+        ? env.OPENCLAW_BUILD_PRIVATE_QA === "1"
+        : !dockerSelected || !excluded.has(id) || dockerSelected.has(id),
+    )
+    .map((entry) => {
+      const isolated =
+        !dockerSelected &&
+        !NON_PACKAGED_BUNDLED_PLUGIN_DIRS.has(entry.id) &&
+        (excluded.has(entry.id) || !shouldBuildBundledDistEntry(entry.packageJson));
+      // Docker-selected plugins belong to the unified ESM graph, irrespective
+      // of their standalone format. Never infer ownership from files left on disk.
+      const runtimeFormat = isolated ? resolvePluginRuntimeFormat(entry.packageJson) : "esm";
+      return Object.assign(entry, {
+        isolated,
+        runtimeExtension: pluginRuntimeExtension(runtimeFormat),
+      });
+    });
 }
 
 /** Retain channel config migrations with core schemas, independently of plugin installation. */

--- a/scripts/lib/bundled-plugin-build-entries.mjs
+++ b/scripts/lib/bundled-plugin-build-entries.mjs
@@ -122,6 +122,25 @@ export function collectPluginSourceEntries(packageJson) {
   return packageEntries.length > 0 ? packageEntries : ["./index.ts"];
 }
 
+/** Select typed plugin contracts, not runtime loader sidecars or implementation helpers. */
+export function collectPluginDeclarationSourceEntries(packageJson, sourceEntries) {
+  const entryName = (entry) =>
+    entry.replace(/^\.\/(?:dist\/)?/u, "").replace(/(?:\.d)?\.[cm]?[jt]s$/u, "");
+  const publicNames = new Set(["api", "runtime-api", "contract-api"]);
+  function collectExports(value) {
+    if (typeof value === "string") {
+      publicNames.add(entryName(value));
+    } else if (value && typeof value === "object") {
+      for (const entry of Object.values(value)) {
+        collectExports(entry);
+      }
+    }
+  }
+  collectExports(packageJson?.exports);
+  collectExports(packageJson?.types ?? packageJson?.typings);
+  return sourceEntries.filter((entry) => publicNames.has(entryName(entry)));
+}
+
 /** Collect top-level public plugin surface files that should be built. */
 export function collectTopLevelPublicSurfaceEntries(pluginDir) {
   if (!fs.existsSync(pluginDir)) {

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -2398,9 +2398,9 @@ function splitOversizedCompactGroup(
   }
   const includePatterns =
     group.includePatterns ?? WHOLE_CONFIG_SPLIT_FILE_LISTERS.get(group.shard_name)?.();
-  const weightForFile = /^core-tooling-\d+$/u.test(group.shard_name)
-    ? toolingFileWeight
-    : stripeFileWeight;
+  const isTooling = /^core-tooling-\d+$/u.test(group.shard_name);
+  const packTooling = isTooling && runnerBackend === "github";
+  const weightForFile = isTooling ? toolingFileWeight : stripeFileWeight;
   const totalWeight =
     includePatterns?.reduce((seconds, file) => seconds + weightForFile(file), 0) ?? 0;
   // A measured whole-config parent can lag newly cataloged files. Its old
@@ -2419,15 +2419,10 @@ function splitOversizedCompactGroup(
     return [{ group, seconds: profileSeconds }];
   }
 
-  // An empty include list falls back to the whole config in the shard runner.
-  let stripeCount = Math.min(
-    includePatterns.length,
-    Math.ceil(splitSeconds / COMPACT_GITHUB_MAX_PREDICTED_SECONDS),
-  );
   // The prerequisite is charged once per emitted job. Include it in placement
   // so a balanced test stripe still leaves room for its runtime build.
   const buildModes = new Map(
-    isCliProcess
+    isCliProcess || packTooling
       ? includePatterns.map(
           (file) =>
             [
@@ -2437,24 +2432,41 @@ function splitOversizedCompactGroup(
         )
       : [],
   );
-  const cliProcessBatchWeight = (patterns: string[]) => {
-    const mode = mergeVitestPretestBuildModes(patterns.map((file) => buildModes.get(file)));
-    return (
-      patterns.reduce((seconds, file) => seconds + weightForFile(file), 0) +
-      (mode ? VITEST_PRETEST_BUILD_SECONDS[mode] : 0)
+  const createStripes = (seconds: number) => {
+    const batchWeight = (patterns: readonly string[]) => {
+      const mode = mergeVitestPretestBuildModes(patterns.map((file) => buildModes.get(file)));
+      const weight = patterns.reduce((sum, file) => sum + weightForFile(file), 0);
+      return (
+        (packTooling ? Math.ceil((seconds * weight) / totalWeight) : weight) +
+        Math.round(
+          (mode ? VITEST_PRETEST_BUILD_SECONDS[mode] : 0) *
+            (packTooling ? COMPACT_GITHUB_GROUP_SECONDS_SCALE : 1),
+        )
+      );
+    };
+    const weightForValue =
+      isCliProcess || packTooling ? (file: string) => batchWeight([file]) : weightForFile;
+    if (packTooling) {
+      // Balanced thirds of a ~301s parent each consume a 150s job. Fill the
+      // budget first so unrelated families can share the small remainder.
+      // Hybrid retains balanced children for its faster Blacksmith admission.
+      const discoveryOrder = (a: string, b: string) =>
+        includePatterns.indexOf(a) - includePatterns.indexOf(b);
+      return packNodeTestGroups(
+        includePatterns.toSorted(
+          (a, b) => weightForValue(b) - weightForValue(a) || discoveryOrder(a, b),
+        ),
+        (bin, file) => batchWeight([...bin, file]) <= COMPACT_EXCLUSIVE_JOB_SECONDS,
+      ).map((patterns) => patterns.toSorted(discoveryOrder));
+    }
+    return createStripedBatches(
+      includePatterns,
+      Math.min(includePatterns.length, Math.ceil(seconds / COMPACT_GITHUB_MAX_PREDICTED_SECONDS)),
+      weightForValue,
+      isCliProcess ? batchWeight : undefined,
     );
   };
-  const weightForValue = isCliProcess
-    ? (file: string) => cliProcessBatchWeight([file])
-    : weightForFile;
-  const createStripes = (count: number) =>
-    createStripedBatches(
-      includePatterns,
-      count,
-      weightForValue,
-      isCliProcess ? cliProcessBatchWeight : undefined,
-    );
-  let stripes = createStripes(stripeCount);
+  let stripes = createStripes(splitSeconds);
   let timingGeneration = createCompactSplitTimingGeneration({
     configs: group.configs,
     env: group.env,
@@ -2479,11 +2491,7 @@ function splitOversizedCompactGroup(
     return [{ group, seconds: profileSeconds }];
   }
   if (completeMeasuredSeconds > splitSeconds) {
-    stripeCount = Math.min(
-      includePatterns.length,
-      Math.ceil(completeMeasuredSeconds / COMPACT_GITHUB_MAX_PREDICTED_SECONDS),
-    );
-    stripes = createStripes(stripeCount);
+    stripes = createStripes(completeMeasuredSeconds);
     timingGeneration = createCompactSplitTimingGeneration({
       configs: group.configs,
       env: group.env,

--- a/scripts/lib/claude-agent-sdk-assets.mts
+++ b/scripts/lib/claude-agent-sdk-assets.mts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
-import type { Plugin } from "rolldown";
+import type { TsdownPlugin } from "tsdown";
 import { isRecord } from "./record-shared.mjs";
 
 const SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
@@ -10,7 +10,7 @@ const NATIVE_SDK_PACKAGE =
   /^@anthropic-ai\/claude-agent-sdk-(?:(?:darwin|win32)-(?:x64|arm64)|linux-(?:x64|arm64)(?:-musl)?)$/u;
 
 /** Preserve the official SDK package without installing its redundant native Claude executable. */
-export function createClaudeAgentSdkAssetPlugin(rootDir = process.cwd()): Plugin {
+export function createClaudeAgentSdkAssetPlugin(rootDir = process.cwd()): TsdownPlugin {
   const require = createRequire(path.join(rootDir, "extensions/anthropic/package.json"));
   const sdkEntry = require.resolve(SDK_PACKAGE);
   const sdkDir = path.dirname(sdkEntry);

--- a/scripts/lib/claude-agent-sdk-assets.mts
+++ b/scripts/lib/claude-agent-sdk-assets.mts
@@ -5,7 +5,7 @@ import type { Plugin } from "rolldown";
 import { isRecord } from "./record-shared.mjs";
 
 const SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
-const SDK_ASSET_DIR = "extensions/anthropic/agent-sdk";
+export const CLAUDE_AGENT_SDK_ASSET_DIR = "extensions/anthropic/agent-sdk";
 const NATIVE_SDK_PACKAGE =
   /^@anthropic-ai\/claude-agent-sdk-(?:(?:darwin|win32)-(?:x64|arm64)|linux-(?:x64|arm64)(?:-musl)?)$/u;
 
@@ -61,7 +61,7 @@ export function createClaudeAgentSdkAssetPlugin(rootDir = process.cwd()): Plugin
           // An absolute external id plus this output-root path lets Rolldown rebase
           // both root hashed chunks and nested entries without relocating the SDK itself.
           if (id === sdkEntry) {
-            return `./${SDK_ASSET_DIR}/${path.basename(sdkEntry)}`;
+            return `./${CLAUDE_AGENT_SDK_ASSET_DIR}/${path.basename(sdkEntry)}`;
           }
           return typeof previousPaths === "function"
             ? previousPaths(id)
@@ -75,7 +75,7 @@ export function createClaudeAgentSdkAssetPlugin(rootDir = process.cwd()): Plugin
         this.addWatchFile(sourcePath);
         this.emitFile({
           type: "asset",
-          fileName: `${SDK_ASSET_DIR}/${file}`,
+          fileName: `${CLAUDE_AGENT_SDK_ASSET_DIR}/${file}`,
           source:
             file === "package.json"
               ? `${JSON.stringify(packagedManifest, null, 2)}\n`

--- a/scripts/lib/claude-agent-sdk-assets.mts
+++ b/scripts/lib/claude-agent-sdk-assets.mts
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import type { Plugin } from "rolldown";
+import { isRecord } from "./record-shared.mjs";
+
+const SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
+const SDK_ASSET_DIR = "extensions/anthropic/agent-sdk";
+const NATIVE_SDK_PACKAGE =
+  /^@anthropic-ai\/claude-agent-sdk-(?:(?:darwin|win32)-(?:x64|arm64)|linux-(?:x64|arm64)(?:-musl)?)$/u;
+
+/** Preserve the official SDK package without installing its redundant native Claude executable. */
+export function createClaudeAgentSdkAssetPlugin(rootDir = process.cwd()): Plugin {
+  const require = createRequire(path.join(rootDir, "extensions/anthropic/package.json"));
+  const sdkEntry = require.resolve(SDK_PACKAGE);
+  const sdkDir = path.dirname(sdkEntry);
+  const manifestPath = path.join(sdkDir, "package.json");
+  const manifest: unknown = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  if (
+    !isRecord(manifest) ||
+    manifest.name !== SDK_PACKAGE ||
+    !Array.isArray(manifest.files) ||
+    !isRecord(manifest.optionalDependencies) ||
+    Object.entries(manifest.optionalDependencies).some(
+      ([name, version]) => !NATIVE_SDK_PACKAGE.test(name) || version !== manifest.version,
+    ) ||
+    (isRecord(manifest.dependencies) && Object.keys(manifest.dependencies).length > 0)
+  ) {
+    throw new Error(
+      "Claude Agent SDK dependency layout changed; review its packaged runtime closure.",
+    );
+  }
+  const { optionalDependencies: _nativeCli, ...packagedManifest } = manifest;
+  const files: unknown[] = [
+    ...new Set([...manifest.files, "package.json", "LICENSE.md", "README.md"]),
+  ];
+  if (
+    !files.every(
+      (file): file is string =>
+        typeof file === "string" && file !== "." && file !== ".." && path.basename(file) === file,
+    )
+  ) {
+    throw new Error("Claude Agent SDK asset layout changed; review its package-relative files.");
+  }
+
+  return {
+    name: "openclaw:claude-agent-sdk-assets",
+    resolveId: {
+      // tsdown's dependency proxy forwards this.resolve(), which collapses
+      // external: "relative" to true and loses chunk-relative rebasing.
+      order: "pre",
+      handler(id) {
+        return id === SDK_PACKAGE ? { id: sdkEntry, external: "relative" } : null;
+      },
+    },
+    outputOptions(options) {
+      const previousPaths = options.paths;
+      return {
+        ...options,
+        paths(id) {
+          // An absolute external id plus this output-root path lets Rolldown rebase
+          // both root hashed chunks and nested entries without relocating the SDK itself.
+          if (id === sdkEntry) {
+            return `./${SDK_ASSET_DIR}/${path.basename(sdkEntry)}`;
+          }
+          return typeof previousPaths === "function"
+            ? previousPaths(id)
+            : (previousPaths?.[id] ?? id);
+        },
+      };
+    },
+    generateBundle() {
+      for (const file of files) {
+        const sourcePath = path.join(sdkDir, file);
+        this.addWatchFile(sourcePath);
+        this.emitFile({
+          type: "asset",
+          fileName: `${SDK_ASSET_DIR}/${file}`,
+          source:
+            file === "package.json"
+              ? `${JSON.stringify(packagedManifest, null, 2)}\n`
+              : fs.readFileSync(sourcePath),
+        });
+      }
+    },
+  };
+}

--- a/scripts/lib/plugin-npm-runtime-build.mts
+++ b/scripts/lib/plugin-npm-runtime-build.mts
@@ -315,7 +315,7 @@ function resolvePluginNpmRuntimePackagePeerMetadata(plan: {
   };
 }
 
-/** Resolve the package-local runtime build plan for one publishable plugin package. */
+/** Resolve the package-local runtime build plan for one plugin package. */
 export function resolvePluginNpmRuntimeBuildPlan(params: PluginNpmRuntimeBuildParams) {
   const repoRoot = path.resolve(params.repoRoot ?? ".");
   const packageDir = resolvePackageDir(repoRoot, params.packageDir);
@@ -328,7 +328,9 @@ export function resolvePluginNpmRuntimeBuildPlan(params: PluginNpmRuntimeBuildPa
   const rootPackageJson = fs.existsSync(rootPackageJsonPath)
     ? readJsonFile(rootPackageJsonPath)
     : undefined;
-  if (!isPublishablePluginPackage(packageJson)) {
+  // Compilation also serves private source-checkout plugins. Publication selection
+  // belongs to listPublishablePluginPackageDirs, not the runtime graph builder.
+  if (!Array.isArray(packageJson.openclaw?.extensions)) {
     return null;
   }
 
@@ -386,7 +388,7 @@ export type PluginNpmRuntimeBuildPlan = NonNullable<
 >;
 
 /**
- * Build package-local runtime files and static assets for one plugin package.
+ * Build isolated runtime files and static assets for publication or source-checkout use.
  * @internal Shared repository-script contract.
  */
 export async function buildPluginNpmRuntime(params: PluginNpmRuntimeBuildParams) {

--- a/scripts/lib/plugin-npm-runtime-build.mts
+++ b/scripts/lib/plugin-npm-runtime-build.mts
@@ -5,6 +5,8 @@ import { pathToFileURL } from "node:url";
 import {
   collectPluginSourceEntries,
   collectTopLevelPublicSurfaceEntries,
+  pluginRuntimeExtension,
+  resolvePluginRuntimeFormat,
 } from "./bundled-plugin-build-entries.mjs";
 import { assertRealOutputRoot } from "./output-root-guard.mjs";
 import {
@@ -64,17 +66,9 @@ function isTypeScriptEntry(entry: string) {
   return /\.(?:c|m)?ts$/u.test(entry);
 }
 
-function resolveRuntimeBuildFormat(packageJson: PluginPackageJson): RuntimeBuildFormat {
-  return packageJson.openclaw?.build?.runtimeFormat === "cjs" ? "cjs" : "esm";
-}
-
-function runtimeBuildExtension(runtimeFormat: RuntimeBuildFormat) {
-  return runtimeFormat === "cjs" ? ".cjs" : ".js";
-}
-
 function toPackageRuntimeEntry(entry: string, runtimeFormat: RuntimeBuildFormat = "esm") {
   const normalized = normalizePackageEntry(entry).replace(/^\.\//u, "");
-  return `./dist/${normalized.replace(/\.[^.]+$/u, runtimeBuildExtension(runtimeFormat))}`;
+  return `./dist/${normalized.replace(/\.[^.]+$/u, pluginRuntimeExtension(runtimeFormat))}`;
 }
 
 function collectExternalDependencyNames(packageJson: PluginPackageJson) {
@@ -197,7 +191,7 @@ export function listPluginNpmRuntimeBuildOutputs(plan: {
   runtimeFormat: RuntimeBuildFormat;
   entry: Record<string, string>;
 }) {
-  const extension = runtimeBuildExtension(plan.runtimeFormat);
+  const extension = pluginRuntimeExtension(plan.runtimeFormat);
   return Object.keys(plan.entry)
     .map((entryKey) => `./dist/${entryKey}${extension}`)
     .toSorted((left, right) => left.localeCompare(right));
@@ -334,7 +328,7 @@ export function resolvePluginNpmRuntimeBuildPlan(params: PluginNpmRuntimeBuildPa
     return null;
   }
 
-  const runtimeFormat = resolveRuntimeBuildFormat(packageJson);
+  const runtimeFormat = resolvePluginRuntimeFormat(packageJson);
   const packageEntries = collectPluginSourceEntries(packageJson).map(normalizePackageEntry);
   const requiresRuntimeBuild = packageEntries.some(isTypeScriptEntry);
   if (!requiresRuntimeBuild) {
@@ -490,7 +484,7 @@ async function preparePluginNativeImport(params: PluginNpmRuntimeBuildParams) {
   ) {
     throw new Error("Host SDK output is missing; build OpenClaw before preparing native imports.");
   }
-  const runtimeFormat = resolveRuntimeBuildFormat(manifest.value);
+  const runtimeFormat = resolvePluginRuntimeFormat(manifest.value);
   const outDir = path.join(packageDir, "dist");
   for (const entry of collectPluginSourceEntries(manifest.value)) {
     const output = path.resolve(packageDir, toPackageRuntimeEntry(entry, runtimeFormat));

--- a/scripts/run-node.mts
+++ b/scripts/run-node.mts
@@ -11,10 +11,7 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
-import {
-  collectBundledPluginBuildEntries,
-  NON_PACKAGED_BUNDLED_PLUGIN_DIRS,
-} from "./lib/bundled-plugin-build-entries.mjs";
+import { collectSourceCheckoutPluginBuildEntries } from "./lib/bundled-plugin-build-entries.mjs";
 import {
   BUNDLED_PLUGIN_PATH_PREFIX,
   BUNDLED_PLUGIN_ROOT_DIR,
@@ -23,7 +20,6 @@ import {
   BUILD_STAMP_FILE,
   RUNTIME_POSTBUILD_STAMP_FILE,
   resolveGitHead,
-  writeBuildStamp as writeDistBuildStamp,
   writeRuntimePostBuildStamp as writeDistRuntimePostBuildStamp,
 } from "./lib/local-build-metadata.mts";
 import { sleep } from "./lib/sleep.mjs";
@@ -112,7 +108,9 @@ type RunNodeLogDeps = Pick<RunNodeDeps, "env" | "stderr"> &
 type RunNodeLockDeps = Pick<RunNodeDeps, "cwd" | "env" | "fs" | "process" | "stderr"> & {
   args: readonly string[];
 };
-type BundledPluginBuildEntry = ReturnType<typeof collectBundledPluginBuildEntries>[number] & {
+type BundledPluginBuildEntry = ReturnType<
+  typeof collectSourceCheckoutPluginBuildEntries
+>[number] & {
   hasManifest: boolean;
 };
 type BuildRequirement = { shouldBuild: boolean; reason: keyof typeof BUILD_REASON_LABELS };
@@ -135,16 +133,7 @@ function asRunNodeChild(value: unknown): RunNodeChild {
 
 export { runNodeWatchedPaths };
 
-const buildScript = "scripts/tsdown-build.mts";
-const bundledPluginAssetsScript = "scripts/bundled-plugin-assets.mts";
-const compilerArgs = ["--import", "tsx", buildScript, "--no-clean"];
-const bundledPluginAssetBuildArgs = [
-  "--import",
-  "tsx",
-  bundledPluginAssetsScript,
-  "--phase",
-  "build",
-];
+const runtimeBuildArgs = ["--import", "tsx", "scripts/build-all.mts", "qaRuntime"];
 const RUN_NODE_SIGNAL_FORCE_KILL_AFTER_MS = 5_000;
 
 const runtimePostBuildWatchedPaths = [
@@ -185,11 +174,6 @@ const resolvePrivateQaRequiredDistEntries = (distRoot: string) => [
   path.join(distRoot, "plugin-sdk", "qa-lab.js"),
   path.join(distRoot, "plugin-sdk", "qa-runtime.js"),
 ];
-const shouldRequireBundledPluginRuntimeOutput = (
-  pluginId: string,
-  env: NodeJS.ProcessEnv = process.env,
-) => env.OPENCLAW_BUILD_PRIVATE_QA === "1" || !NON_PACKAGED_BUNDLED_PLUGIN_DIRS.has(pluginId);
-
 const isExcludedSource = (filePath: string, sourceRoot: string, sourceRootName: string) => {
   const relativePath = normalizePath(path.relative(sourceRoot, filePath));
   if (relativePath.startsWith("..")) {
@@ -412,19 +396,20 @@ const collectRunNodeBundledPluginBuildEntries = (deps: RunNodeRequirementDeps) =
   if (!deps.fs.existsSync(path.join(deps.cwd, BUNDLED_PLUGIN_ROOT_DIR))) {
     return [];
   }
-  return collectBundledPluginBuildEntries({ cwd: deps.cwd, env: deps.env });
+  return collectSourceCheckoutPluginBuildEntries({ cwd: deps.cwd, env: deps.env });
 };
 
 const resolveBuiltBundledPluginRuntimeEntryPath = (
   distRoot: string,
   pluginId: string,
   sourceEntry: string,
+  runtimeExtension: string,
 ) =>
   path.join(
     distRoot,
     "extensions",
     pluginId,
-    sourceEntry.replace(/^\.\//, "").replace(/\.[^.]+$/u, ".js"),
+    sourceEntry.replace(/^\.\//, "").replace(/\.[^.]+$/u, runtimeExtension),
   );
 
 const listBundledPluginRuntimeEntryPaths = (
@@ -434,7 +419,12 @@ const listBundledPluginRuntimeEntryPaths = (
   const distRoot = deps.distRoot;
   return pluginEntry.sourceEntries
     .map((sourceEntry) =>
-      resolveBuiltBundledPluginRuntimeEntryPath(distRoot, pluginEntry.id, sourceEntry),
+      resolveBuiltBundledPluginRuntimeEntryPath(
+        distRoot,
+        pluginEntry.id,
+        sourceEntry,
+        pluginEntry.runtimeExtension,
+      ),
     )
     .toSorted((left, right) => left.localeCompare(right));
 };
@@ -447,7 +437,7 @@ const isDirtyBundledPluginPackageEntryChangeWithoutBuiltOutputs = (
     return false;
   }
   const [, pluginId] = normalizedPath.split("/");
-  if (!pluginId || !shouldRequireBundledPluginRuntimeOutput(pluginId, deps.env)) {
+  if (!pluginId) {
     return false;
   }
   const pluginEntry = collectRunNodeBundledPluginBuildEntries(deps).find(
@@ -462,17 +452,14 @@ const isDirtyBundledPluginPackageEntryChangeWithoutBuiltOutputs = (
 };
 
 const hasMissingBuiltBundledPluginRuntimeEntryOutput = (deps: RunNodeRequirementDeps) => {
-  return collectRunNodeBundledPluginBuildEntries(deps)
-    .filter(({ id }) => shouldRequireBundledPluginRuntimeOutput(id, deps.env))
-    .some((pluginEntry) => {
-      const entryPaths = listBundledPluginRuntimeEntryPaths(pluginEntry, deps);
-      return entryPaths.some((filePath) => !deps.fs.existsSync(filePath));
-    });
+  return collectRunNodeBundledPluginBuildEntries(deps).some((pluginEntry) => {
+    const entryPaths = listBundledPluginRuntimeEntryPaths(pluginEntry, deps);
+    return entryPaths.some((filePath) => !deps.fs.existsSync(filePath));
+  });
 };
 
 const listBuiltBundledPluginEntries = (deps: RunNodeRequirementDeps) => {
   return collectRunNodeBundledPluginBuildEntries(deps)
-    .filter(({ id }) => shouldRequireBundledPluginRuntimeOutput(id, deps.env))
     .filter((pluginEntry) =>
       listBundledPluginRuntimeEntryPaths(pluginEntry, deps).some((filePath) =>
         deps.fs.existsSync(filePath),
@@ -1498,19 +1485,6 @@ const syncRuntimeArtifactsAndStamp = async (deps: RunNodeDeps) => {
   return synced;
 };
 
-const writeBuildStamp = (deps: RunNodeDeps) => {
-  try {
-    writeDistBuildStamp({
-      cwd: deps.cwd,
-      fs: deps.fs,
-      spawnSync: deps.spawnSync,
-    });
-  } catch (error) {
-    // Best-effort stamp; still allow the runner to start.
-    logRunner(`Failed to write build stamp: ${getErrorMessage(error)}`, deps);
-  }
-};
-
 const shouldSkipWatchRuntimeSync = (deps: RunNodeDeps, requirement: RuntimePostBuildRequirement) =>
   deps.env.OPENCLAW_WATCH_MODE === "1" &&
   requirement.reason === "missing_runtime_postbuild_stamp" &&
@@ -1707,63 +1681,22 @@ export async function runNodeMain(params: RunNodeMainParams = {}): Promise<numbe
         `Building TypeScript (dist is stale: ${lockedBuildRequirement.reason} - ${formatBuildReason(lockedBuildRequirement.reason)}).`,
         deps,
       );
-      logRunner("Building bundled plugin assets.", deps);
-      const buildCmd = deps.execPath;
-      const compileExitCode = await withRunNodeProgress(
-        deps,
-        "Building local CLI artifacts",
-        async () => {
-          const assetBuild = asRunNodeChild(
-            deps.spawn(buildCmd, bundledPluginAssetBuildArgs, {
-              cwd: deps.cwd,
-              detached: shouldUseRunNodeChildProcessGroup(deps),
-              env: deps.env,
-              stdio: ["inherit", "pipe", "pipe"],
-            }),
-          );
-          pipeSpawnedOutput(assetBuild, deps, { stdoutTarget: "stderr" });
-          const assetBuildRes = await waitForSpawnedProcess(assetBuild, deps);
-          const assetBuildInterruptedExitCode = getInterruptedSpawnExitCode(assetBuildRes);
-          if (assetBuildInterruptedExitCode !== null) {
-            return assetBuildInterruptedExitCode;
-          }
-          if (assetBuildRes.exitCode !== 0 && assetBuildRes.exitCode !== null) {
-            return assetBuildRes.exitCode;
-          }
-
-          const build = asRunNodeChild(
-            deps.spawn(buildCmd, compilerArgs, {
-              cwd: deps.cwd,
-              detached: shouldUseRunNodeChildProcessGroup(deps),
-              env: {
-                ...deps.env,
-                [RUN_NODE_SKIP_DTS_BUILD_ENV]: deps.env[RUN_NODE_SKIP_DTS_BUILD_ENV] ?? "1",
-              },
-              stdio: ["inherit", "pipe", "pipe"],
-            }),
-          );
-          pipeSpawnedOutput(build, deps, { stdoutTarget: "stderr" });
-
-          const buildRes = await waitForSpawnedProcess(build, deps);
-          const interruptedExitCode = getInterruptedSpawnExitCode(buildRes);
-          if (interruptedExitCode !== null) {
-            return interruptedExitCode;
-          }
-          if (buildRes.exitCode !== 0 && buildRes.exitCode !== null) {
-            return buildRes.exitCode;
-          }
-          return 0;
-        },
-      );
-      if (compileExitCode !== 0) {
-        return compileExitCode;
-      }
-      if (!(await syncRuntimeArtifacts(deps))) {
-        return 1;
-      }
-      writeBuildStamp(deps);
-      writeRuntimePostBuildStamp(deps);
-      return 0;
+      return await withRunNodeProgress(deps, "Building local CLI artifacts", async () => {
+        const build = asRunNodeChild(
+          deps.spawn(deps.execPath, runtimeBuildArgs, {
+            cwd: deps.cwd,
+            detached: shouldUseRunNodeChildProcessGroup(deps),
+            env: {
+              ...deps.env,
+              [RUN_NODE_SKIP_DTS_BUILD_ENV]: deps.env[RUN_NODE_SKIP_DTS_BUILD_ENV] ?? "1",
+            },
+            stdio: ["inherit", "pipe", "pipe"],
+          }),
+        );
+        pipeSpawnedOutput(build, deps, { stdoutTarget: "stderr" });
+        const result = await waitForSpawnedProcess(build, deps);
+        return getInterruptedSpawnExitCode(result) ?? result.exitCode ?? 1;
+      });
     });
     if (buildExitCode !== 0) {
       return await closeRunNodeOutputTee(deps, buildExitCode);

--- a/scripts/tsdown-build.mts
+++ b/scripts/tsdown-build.mts
@@ -16,6 +16,7 @@ import { isPathInside } from "@openclaw/fs-safe/path";
 import { decodeMountInfoPath } from "../packages/normalization-core/src/mountinfo-path.ts";
 import { BUNDLED_PLUGIN_BUILD_ENV_NAMES } from "./lib/bundled-plugin-build-entries.mjs";
 import { BUNDLED_PLUGIN_PATH_PREFIX } from "./lib/bundled-plugin-paths.mjs";
+import { CLAUDE_AGENT_SDK_ASSET_DIR } from "./lib/claude-agent-sdk-assets.mts";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import {
   resolveDistArtifactLockPath,
@@ -268,7 +269,7 @@ export function cleanTsdownOutputRoots(params: OutputRootParams = {}) {
   const rootPaths = assertTsdownCleanOutputRoots({ cwd, fs: fsImpl, pathImpl, roots });
   const protectedDeclarationPaths =
     env[RUN_NODE_SKIP_DTS_BUILD_ENV] === "1"
-      ? listExistingDeclarationOutputPaths(cwd, fsImpl, roots)
+      ? listExistingGeneratedDeclarationOutputPaths(cwd, fsImpl, roots)
       : new Set<string>();
   const protectedPaths = new Set([
     ...protectedDeclarationPaths,
@@ -324,12 +325,25 @@ function cleanOutputRootExcept(rootPath: string, protectedPaths: Set<string>, fs
   }
 }
 
-function listExistingDeclarationOutputPaths(cwd: string, fsImpl: typeof fs, roots: string[]) {
+function listExistingGeneratedDeclarationOutputPaths(
+  cwd: string,
+  fsImpl: typeof fs,
+  roots: string[],
+) {
   const protectedPaths = new Set<string>();
   for (const root of roots) {
     collectDeclarationOutputPaths(path.resolve(cwd, root), protectedPaths, fsImpl);
   }
-  return protectedPaths;
+  // Copied SDK types belong to the runtime package: JS builds replace them,
+  // while declaration publication (including cache restores) must leave them intact.
+  const runtimeAssetRoots = roots.map((root) =>
+    path.resolve(cwd, root, CLAUDE_AGENT_SDK_ASSET_DIR),
+  );
+  return new Set(
+    [...protectedPaths].filter(
+      (file) => !runtimeAssetRoots.some((root) => isPathInside(root, file)),
+    ),
+  );
 }
 
 function listExistingPreservedOutputPaths(cwd: string, env: NodeJS.ProcessEnv, fsImpl: typeof fs) {
@@ -371,7 +385,7 @@ function listExistingPreservedOutputPaths(cwd: string, env: NodeJS.ProcessEnv, f
   return protectedPaths;
 }
 
-/** Full declaration publication shares the runtime cleaner's protected subtrees. */
+/** Publish generated declarations without claiming runtime assets or protected subtrees. */
 export function listReplaceableTsdownDeclarationOutputs(params: OutputRootParams = {}) {
   const cwd = path.resolve(params.cwd ?? process.cwd());
   const fsImpl = params.fs ?? fs;
@@ -380,7 +394,7 @@ export function listReplaceableTsdownDeclarationOutputs(params: OutputRootParams
   const protectedPaths = [
     ...listExistingPreservedOutputPaths(cwd, params.env ?? process.env, fsImpl),
   ];
-  return [...listExistingDeclarationOutputPaths(cwd, fsImpl, roots)]
+  return [...listExistingGeneratedDeclarationOutputPaths(cwd, fsImpl, roots)]
     .filter(
       (file) =>
         !protectedPaths.some(

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -1,4 +1,5 @@
 // Tests node process runner lifecycle and captured output.
+import type { SpawnOptions } from "node:child_process";
 import { EventEmitter } from "node:events";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
@@ -188,18 +189,7 @@ async function writeRuntimePostBuildScaffold(tmp: string): Promise<void> {
 }
 
 function expectedBuildSpawn() {
-  return [process.execPath, "--import", "tsx", "scripts/tsdown-build.mts", "--no-clean"];
-}
-
-function expectedBundledPluginAssetBuildSpawn() {
-  return [
-    process.execPath,
-    "--import",
-    "tsx",
-    "scripts/bundled-plugin-assets.mts",
-    "--phase",
-    "build",
-  ];
+  return [process.execPath, "--import", "tsx", "scripts/build-all.mts", "qaRuntime"];
 }
 
 function statusCommandSpawn() {
@@ -416,90 +406,54 @@ async function expectManifestId(tmp: string, relativePath: string, id: string) {
 }
 
 describe("run-node script", () => {
-  it("copies bundled plugin metadata after rebuilding from a clean dist", async ({ tmp }) => {
-    await writeRuntimePostBuildScaffold(tmp);
-    await writeProjectFiles(tmp, {
-      [EXTENSION_MANIFEST]: '{"id":"demo","configSchema":{"type":"object"}}\n',
-      [EXTENSION_PACKAGE]:
-        JSON.stringify(
-          {
-            name: "demo",
-            openclaw: {
-              extensions: ["./src/index.ts", "./nested/entry.mts"],
-            },
-          },
-          null,
-          2,
-        ) + "\n",
-    });
-
-    const spawnCalls: string[][] = [];
-    const spawn = (cmd: string, args: string[]) => {
-      spawnCalls.push([cmd, ...args]);
-      return createExitedProcess(0);
-    };
-
-    const exitCode = await runStatusCommand({
-      tmp,
+  it("starts the CLI only after the canonical runtime build completes", async ({ tmp }) => {
+    const build = new EventEmitter();
+    const spawn = vi.fn((_cmd: string, args: string[]) =>
+      isTsxScriptArgs(args, "scripts/build-all.mts") ? build : createExitedProcess(0),
+    );
+    const runRuntimePostBuild = vi.fn();
+    const result = runNodeCommand(tmp, {
       spawn,
       env: { OPENCLAW_FORCE_BUILD: "1" },
-      runRuntimePostBuild: syncBundledPluginMetadata,
+      runRuntimePostBuild,
     });
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce());
+    const lockDir = path.join(tmp, ".artifacts", "run-node-build.lock");
+    expect(fsSync.existsSync(lockDir)).toBe(true);
+    build.emit("exit", 0, null);
 
-    expect(exitCode).toBe(0);
-    expect(spawnCalls).toEqual([
-      expectedBundledPluginAssetBuildSpawn(),
+    expect(await result).toBe(0);
+    expect(spawn.mock.calls.map(([cmd, args]) => [cmd].concat(args))).toEqual([
       expectedBuildSpawn(),
       statusCommandSpawn(),
     ]);
-
-    await expectManifestId(tmp, DIST_EXTENSION_MANIFEST, "demo");
-    await expect(fs.readFile(resolvePath(tmp, DIST_EXTENSION_PACKAGE), "utf-8")).resolves.toContain(
-      '"extensions": [\n      "./src/index.js",\n      "./nested/entry.js"\n    ]',
-    );
+    // The canonical profile owns metadata and both stamps; the local runner
+    // only invokes postbuild directly on its separate metadata-only path.
+    expect(runRuntimePostBuild).not.toHaveBeenCalled();
+    expect(fsSync.existsSync(lockDir)).toBe(false);
   });
 
-  it("skips DTS generation only for launcher-triggered local builds", async ({ tmp }) => {
-    await writeRuntimePostBuildScaffold(tmp);
-    const spawnCalls: Array<{
-      args: string[];
-      env: Record<string, string | undefined>;
-    }> = [];
-    const spawn = (_cmd: string, args: string[], options?: unknown) => {
-      const opts = options as { env?: NodeJS.ProcessEnv } | undefined;
-      spawnCalls.push({
-        args,
-        env: { ...opts?.env },
+  it.for([undefined, "0", "1"])(
+    "defaults DTS off only for the canonical build child (override: %s)",
+    async (skipDts, { tmp }) => {
+      const spawnCalls: Array<{ args: string[]; env: NodeJS.ProcessEnv }> = [];
+      const spawn = (_cmd: string, args: string[], options: SpawnOptions) => {
+        spawnCalls.push({ args, env: { ...options.env } });
+        return createExitedProcess(0);
+      };
+      const exitCode = await runNodeCommand(tmp, {
+        env: { OPENCLAW_FORCE_BUILD: "1", OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: skipDts },
+        spawn,
       });
-      return createExitedProcess(0);
-    };
-
-    const exitCode = await runNodeCommand(tmp, {
-      env: { OPENCLAW_FORCE_BUILD: "1" },
-      spawn,
-      runRuntimePostBuild: skipRuntimePostBuild,
-    });
-
-    expect(exitCode).toBe(0);
-    expect(spawnCalls).toHaveLength(3);
-    expect(spawnCalls[0]?.args).toEqual([
-      "--import",
-      "tsx",
-      "scripts/bundled-plugin-assets.mts",
-      "--phase",
-      "build",
-    ]);
-    expect(spawnCalls[1]?.args).toEqual([
-      "--import",
-      "tsx",
-      "scripts/tsdown-build.mts",
-      "--no-clean",
-    ]);
-    expect(spawnCalls[2]?.args).toEqual(["openclaw.mjs", "status"]);
-    expect(spawnCalls[0]?.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD).toBeUndefined();
-    expect(spawnCalls[1]?.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD).toBe("1");
-    expect(spawnCalls[2]?.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD).toBeUndefined();
-  });
+      expect(exitCode).toBe(0);
+      expect(spawnCalls.map(({ args }) => args)).toEqual([
+        expectedBuildSpawn().slice(1),
+        ["openclaw.mjs", "status"],
+      ]);
+      expect(spawnCalls[0]?.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD).toBe(skipDts ?? "1");
+      expect(spawnCalls[1]?.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD).toBe(skipDts);
+    },
+  );
 
   it("tees launcher output into the requested generic output log", async ({ tmp }) => {
     await setupTrackedProject(tmp);
@@ -550,16 +504,10 @@ describe("run-node script", () => {
     await writeRuntimePostBuildScaffold(tmp);
     const outputPath = path.join(tmp, ".artifacts", "run-node", "output.log");
     const spawn = (_cmd: string, args: string[]) => {
-      if (isTsxScriptArgs(args, "scripts/bundled-plugin-assets.mts")) {
+      if (isTsxScriptArgs(args, "scripts/build-all.mts")) {
         return createPipedExitedProcess({
-          stdout: "asset stdout\n",
-          stderr: "asset stderr\n",
-        });
-      }
-      if (isTsxScriptArgs(args, "scripts/tsdown-build.mts")) {
-        return createPipedExitedProcess({
-          stdout: "build stdout\n",
-          stderr: "build stderr\n",
+          stdout: "asset stdout\nbuild stdout\n",
+          stderr: "asset stderr\nbuild stderr\n",
         });
       }
       return createPipedExitedProcess({ stdout: '{"plugins":[]}\n' });
@@ -901,7 +849,6 @@ describe("run-node script", () => {
 
     expect(exitCode).toBe(0);
     expect(spawnCalls).toEqual([
-      expectedBundledPluginAssetBuildSpawn(),
       expectedBuildSpawn(),
       [
         process.execPath,
@@ -916,49 +863,58 @@ describe("run-node script", () => {
     ]);
   });
 
-  it("passes the synthesized private QA env into runtime postbuild staging", async ({ tmp }) => {
-    await setupStampedProject(tmp, {
-      files: { [QA_LAB_PLUGIN_SDK_ENTRY]: "export const qaLab = true;\n" },
-      oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE, QA_LAB_PLUGIN_SDK_ENTRY],
-    });
-
-    const runRuntimePostBuild = vi.fn();
-    const { spawn, spawnSync } = createCurrentGitSpawnRecorder();
-    const exitCode = await runQaCommand({ tmp, spawn, spawnSync, runRuntimePostBuild });
-
-    expect(exitCode).toBe(0);
-    expect(runRuntimePostBuild).toHaveBeenCalledTimes(1);
-    const postBuildParams = firstMockCall(runRuntimePostBuild)?.[0] as
-      | { cwd?: string; env?: Record<string, string | undefined> }
-      | undefined;
-    expect(postBuildParams?.cwd).toBe(tmp);
-    expect(postBuildParams?.env?.OPENCLAW_BUILD_PRIVATE_QA).toBe("1");
-    expect(postBuildParams?.env?.OPENCLAW_ENABLE_PRIVATE_QA_CLI).toBe("1");
-    expect(postBuildParams?.env?.OPENCLAW_DISABLE_BUNDLED_PLUGINS).toBe("0");
-  });
-
-  it("preserves an explicit bundled plugin disable flag for QA runs", async ({ tmp }) => {
-    await setupStampedProject(tmp, {
-      files: { [QA_LAB_PLUGIN_SDK_ENTRY]: "export const qaLab = true;\n" },
-      oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE, QA_LAB_PLUGIN_SDK_ENTRY],
-    });
-
-    const runRuntimePostBuild = vi.fn();
-    const { spawn, spawnSync } = createCurrentGitSpawnRecorder();
-    const exitCode = await runQaCommand({
-      tmp,
-      spawn,
-      spawnSync,
-      runRuntimePostBuild,
-      env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
-    });
-
-    expect(exitCode).toBe(0);
-    const postBuildParams = firstMockCall(runRuntimePostBuild)?.[0] as
-      | { cwd?: string; env?: Record<string, string | undefined> }
-      | undefined;
-    expect(postBuildParams?.env?.OPENCLAW_DISABLE_BUNDLED_PLUGINS).toBe("1");
-  });
+  it.for([
+    { mode: "build", disable: undefined },
+    { mode: "build", disable: "1" },
+    { mode: "metadata", disable: undefined },
+    { mode: "metadata", disable: "1" },
+  ])(
+    "carries private QA policy through $mode (disable: $disable)",
+    async ({ mode, disable }, { tmp }) => {
+      await setupStampedProject(tmp, {
+        files: {
+          [QA_LAB_PLUGIN_SDK_ENTRY]: "export const qaLab = true;\n",
+          ...(mode === "metadata"
+            ? { [QA_RUNTIME_PLUGIN_SDK_ENTRY]: "export const qaRuntime = true;\n" }
+            : {}),
+        },
+        oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE],
+      });
+      const runRuntimePostBuild = vi.fn();
+      const spawn = vi.fn((_cmd: string, _args: string[], _options: SpawnOptions) =>
+        createExitedProcess(0),
+      );
+      const { spawnSync } = createCurrentGitSpawnRecorder();
+      const exitCode = await runNodeCommand(tmp, {
+        args: ["qa", "suite"],
+        spawn,
+        spawnSync,
+        runRuntimePostBuild,
+        env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: disable },
+      });
+      expect(exitCode).toBe(0);
+      expect(spawn.mock.calls.map(([, args]) => args)).toEqual([
+        ...(mode === "build" ? [expectedBuildSpawn().slice(1)] : []),
+        ["openclaw.mjs", "qa", "suite"],
+      ]);
+      const expectedEnv = {
+        OPENCLAW_BUILD_PRIVATE_QA: "1",
+        OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1",
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: disable ?? "0",
+      };
+      for (const call of spawn.mock.calls) {
+        expect(call[2].env).toMatchObject(expectedEnv);
+      }
+      if (mode === "metadata") {
+        expect(runRuntimePostBuild).toHaveBeenCalledExactlyOnceWith({
+          cwd: tmp,
+          env: expect.objectContaining(expectedEnv),
+        });
+      } else {
+        expect(runRuntimePostBuild).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   it("derives private QA facade checks from distRoot for direct freshness checks", async ({
     tmp,
@@ -1273,24 +1229,26 @@ describe("run-node script", () => {
     expect(fsSync.existsSync(path.join(tmp, ".artifacts", "run-node-build.lock"))).toBe(false);
   });
 
-  it("returns the build exit code when the compiler step fails", async ({ tmp }) => {
-    const spawn = (cmd: string, args: string[] = []) => {
-      if (cmd === process.execPath && isTsxScriptArgs(args, "scripts/tsdown-build.mts")) {
+  it("returns the canonical build failure without starting the CLI", async ({ tmp }) => {
+    const spawn = vi.fn((cmd: string, args: string[] = []) => {
+      if (cmd === process.execPath && isTsxScriptArgs(args, "scripts/build-all.mts")) {
         return createExitedProcess(23);
       }
       return createExitedProcess(0);
-    };
+    });
 
     const exitCode = await runNodeCommand(tmp, { env: { OPENCLAW_FORCE_BUILD: "1" }, spawn });
 
     expect(exitCode).toBe(23);
+    expect(spawn).toHaveBeenCalledOnce();
+    expect(fsSync.existsSync(path.join(tmp, ".artifacts", "run-node-build.lock"))).toBe(false);
   });
 
-  it("returns failure and releases the build lock when the compiler spawn errors", async ({
+  it("returns failure and releases the build lock when the canonical build spawn errors", async ({
     tmp,
   }) => {
-    const spawn = (cmd: string, args: string[] = []) => {
-      if (cmd === process.execPath && isTsxScriptArgs(args, "scripts/tsdown-build.mts")) {
+    const spawn = vi.fn((cmd: string, args: string[] = []) => {
+      if (cmd === process.execPath && isTsxScriptArgs(args, "scripts/build-all.mts")) {
         const events = new EventEmitter();
         queueMicrotask(() => events.emit("error", new Error("spawn failed")));
         return {
@@ -1301,74 +1259,82 @@ describe("run-node script", () => {
         };
       }
       return createExitedProcess(0);
-    };
+    });
 
     const exitCode = await runNodeCommand(tmp, { env: { OPENCLAW_FORCE_BUILD: "1" }, spawn });
 
     expect(exitCode).toBe(1);
+    expect(spawn).toHaveBeenCalledOnce();
     expect(fsSync.existsSync(path.join(tmp, ".artifacts", "run-node-build.lock"))).toBe(false);
   });
 
-  it("forwards wrapper SIGTERM to the active openclaw child and returns 143", async ({ tmp }) => {
-    await setupStampedProject(tmp, { oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE] });
+  it.for([false, true])(
+    "forwards SIGTERM to the active child and returns 143 (rebuild: %s)",
+    async (rebuild, { tmp }) => {
+      await setupStampedProject(tmp, { oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE] });
 
-    const fakeProcess = Object.assign(createFakeProcess(), {
-      stdin: {
-        isTTY: true,
-      },
-    });
-    const child = Object.assign(new EventEmitter(), {
-      kill: vi.fn((signal: string) => {
-        queueMicrotask(() => child.emit("exit", 0, null));
-        return signal;
-      }),
-    });
-    const spawn = vi.fn<
-      (
-        cmd: string,
-        args: string[],
-        options: unknown,
-      ) => {
-        kill: (signal?: string) => boolean;
-        on: (event: "exit", cb: (code: number | null, signal: string | null) => void) => void;
-      }
-    >(() => ({
-      kill: (signal) => {
-        child.kill(signal ?? "SIGTERM");
-        return true;
-      },
-      on: (event, cb) => {
-        child.on(event, cb);
-      },
-    }));
+      const fakeProcess = Object.assign(createFakeProcess(), {
+        stdin: {
+          isTTY: true,
+        },
+      });
+      const child = Object.assign(new EventEmitter(), {
+        kill: vi.fn((signal: string) => {
+          queueMicrotask(() => child.emit("exit", 0, null));
+          return signal;
+        }),
+      });
+      const spawn = vi.fn<
+        (
+          cmd: string,
+          args: string[],
+          options: unknown,
+        ) => {
+          kill: (signal?: string) => boolean;
+          on: (event: "exit", cb: (code: number | null, signal: string | null) => void) => void;
+        }
+      >(() => ({
+        kill: (signal) => {
+          child.kill(signal ?? "SIGTERM");
+          return true;
+        },
+        on: (event, cb) => {
+          child.on(event, cb);
+        },
+      }));
 
-    const exitCodePromise = runNodeCommand(tmp, {
-      process: fakeProcess,
-      spawn,
-      runRuntimePostBuild: skipRuntimePostBuild,
-    });
+      const exitCodePromise = runNodeCommand(tmp, {
+        env: { OPENCLAW_FORCE_BUILD: rebuild ? "1" : "0" },
+        process: fakeProcess,
+        spawn,
+        runRuntimePostBuild: skipRuntimePostBuild,
+      });
 
-    await vi.waitFor(() => {
-      expect(spawn).toHaveBeenCalled();
-    });
-    fakeProcess.emit("SIGTERM");
-    const exitCode = await exitCodePromise;
+      await vi.waitFor(() => {
+        expect(spawn).toHaveBeenCalled();
+      });
+      fakeProcess.emit("SIGTERM");
+      const exitCode = await exitCodePromise;
 
-    expect(exitCode).toBe(143);
-    expect(spawn).toHaveBeenCalledTimes(1);
-    const spawnCall = firstMockCall(spawn) as [string, string[], { stdio?: unknown }] | undefined;
-    expect(spawnCall?.[0]).toBe(process.execPath);
-    expect(spawnCall?.[1]).toEqual(["openclaw.mjs", "status"]);
-    expect(spawnCall?.[2].stdio).toBe("inherit");
-    expect(spawnCall?.[2]).toMatchObject({ detached: false });
-    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
-    expect(fakeProcess.listenerCount("SIGINT")).toBe(0);
-    expect(fakeProcess.listenerCount("SIGTERM")).toBe(0);
-  });
+      expect(exitCode).toBe(143);
+      expect(spawn).toHaveBeenCalledTimes(1);
+      const spawnCall = firstMockCall(spawn) as [string, string[], { stdio?: unknown }] | undefined;
+      expect(spawnCall?.[0]).toBe(process.execPath);
+      expect(spawnCall?.[1]).toEqual(
+        rebuild ? expectedBuildSpawn().slice(1) : ["openclaw.mjs", "status"],
+      );
+      expect(spawnCall?.[2].stdio).toEqual(rebuild ? ["inherit", "pipe", "pipe"] : "inherit");
+      expect(spawnCall?.[2]).toMatchObject({ detached: false });
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(fsSync.existsSync(path.join(tmp, ".artifacts", "run-node-build.lock"))).toBe(false);
+      expect(fakeProcess.listenerCount("SIGINT")).toBe(0);
+      expect(fakeProcess.listenerCount("SIGTERM")).toBe(0);
+    },
+  );
 
-  it.runIf(process.platform !== "win32")(
-    "force-cleans the active openclaw child process group after forwarded SIGTERM",
-    async ({ tmp }) => {
+  it.runIf(process.platform !== "win32").for([false, true])(
+    "force-cleans the active child process group after SIGTERM (rebuild: %s)",
+    async (rebuild, { tmp }) => {
       await setupStampedProject(tmp, { oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE] });
 
       const fakeProcess = Object.assign(createFakeProcess(), {
@@ -1403,6 +1369,7 @@ describe("run-node script", () => {
       }));
 
       const exitCodePromise = runNodeCommand(tmp, {
+        env: { OPENCLAW_FORCE_BUILD: rebuild ? "1" : "0" },
         platform: "darwin",
         process: fakeProcess,
         signalProcess: (pid: number, signal?: string | number) => {
@@ -1426,8 +1393,15 @@ describe("run-node script", () => {
       const spawnCall = firstMockCall(spawn) as
         | [string, string[], { detached?: boolean; stdio?: unknown }]
         | undefined;
-      expect(spawnCall?.[1]).toEqual(["openclaw.mjs", "status"]);
-      expect(spawnCall?.[2]).toMatchObject({ detached: true, stdio: "inherit" });
+      expect(spawnCall?.[1]).toEqual(
+        rebuild ? expectedBuildSpawn().slice(1) : ["openclaw.mjs", "status"],
+      );
+      expect(spawnCall?.[2]).toMatchObject({
+        detached: true,
+        stdio: rebuild ? ["inherit", "pipe", "pipe"] : "inherit",
+      });
+      expect(spawn).toHaveBeenCalledOnce();
+      expect(fsSync.existsSync(path.join(tmp, ".artifacts", "run-node-build.lock"))).toBe(false);
       expect(groupSignals).toEqual([
         [-42_420, "SIGTERM"],
         [-42_420, "SIGKILL"],
@@ -1457,11 +1431,7 @@ describe("run-node script", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(spawnCalls).toEqual([
-      expectedBundledPluginAssetBuildSpawn(),
-      expectedBuildSpawn(),
-      statusCommandSpawn(),
-    ]);
+    expect(spawnCalls).toEqual([expectedBuildSpawn(), statusCommandSpawn()]);
   });
 
   it("shows tty progress while rebuilding source-checkout artifacts", async ({ tmp }) => {
@@ -1504,11 +1474,7 @@ describe("run-node script", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(spawnCalls).toEqual([
-      expectedBundledPluginAssetBuildSpawn(),
-      expectedBuildSpawn(),
-      statusCommandSpawn(),
-    ]);
+    expect(spawnCalls).toEqual([expectedBuildSpawn(), statusCommandSpawn()]);
   });
 
   it("skips rebuilding when extension package metadata is newer than the build stamp", async ({
@@ -2290,11 +2256,7 @@ describe("run-node script", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(spawnCalls).toEqual([
-      expectedBundledPluginAssetBuildSpawn(),
-      expectedBuildSpawn(),
-      statusCommandSpawn(),
-    ]);
+    expect(spawnCalls).toEqual([expectedBuildSpawn(), statusCommandSpawn()]);
   });
 
   describe("acquireRunNodeBuildLock", () => {

--- a/src/plugins/contracts/package-manifest.contract.test.ts
+++ b/src/plugins/contracts/package-manifest.contract.test.ts
@@ -99,11 +99,13 @@ for (const params of packageManifestContractTests) {
   describePackageManifestContract(params);
 }
 
-it("resolves Anthropic's installed Agent SDK at the plugin and root runtime pins", () => {
+it("aligns Anthropic's source SDK pins without a root runtime SDK dependency", () => {
   const dependencyName = "@anthropic-ai/claude-agent-sdk";
   const pluginPackagePath = path.resolve(process.cwd(), "extensions/anthropic/package.json");
   const pluginManifest = JSON.parse(fs.readFileSync(pluginPackagePath, "utf8")) as PackageManifest;
-  const rootManifest = JSON.parse(fs.readFileSync("package.json", "utf8")) as PackageManifest;
+  const rootManifest = JSON.parse(fs.readFileSync("package.json", "utf8")) as PackageManifest & {
+    devDependencies?: Record<string, string>;
+  };
   const sdkEntry = createRequire(pluginPackagePath).resolve(dependencyName);
   // The SDK exports sdk.mjs beside its manifest, but does not export ./package.json.
   const sdkManifest = JSON.parse(
@@ -113,7 +115,8 @@ it("resolves Anthropic's installed Agent SDK at the plugin and root runtime pins
   expect(sdkManifest.name).toBe(dependencyName);
   expect(sdkManifest.version).toBeTypeOf("string");
   expect(sdkManifest.version).toBe(pluginManifest.dependencies?.[dependencyName]);
-  expect(sdkManifest.version).toBe(rootManifest.dependencies?.[dependencyName]);
+  expect(sdkManifest.version).toBe(rootManifest.devDependencies?.[dependencyName]);
+  expect(rootManifest.dependencies?.[dependencyName]).toBeUndefined();
 });
 
 it("bundles LanceDB JavaScript while installing matching native bindings per platform", () => {

--- a/src/plugins/copy-bundled-plugin-metadata.test.ts
+++ b/src/plugins/copy-bundled-plugin-metadata.test.ts
@@ -405,7 +405,7 @@ describe("copyBundledPluginMetadata", () => {
       expectedExists: false,
     },
     {
-      name: "removes externalized optional plugin metadata from the core dist",
+      name: "omits external-only metadata without a publishable source-checkout build",
       pluginId: "whatsapp",
       packageName: "@openclaw/whatsapp",
       packageOpenClaw: {
@@ -439,6 +439,36 @@ describe("copyBundledPluginMetadata", () => {
       );
     },
   );
+
+  it("removes build-excluded bundled plugin metadata", () => {
+    const repoRoot = makeRepoRoot("openclaw-bundled-plugin-excluded-meta-");
+    createPlugin(repoRoot, {
+      id: "selected",
+      packageName: "@openclaw/selected",
+      packageOpenClaw: { extensions: ["./index.ts"] },
+    });
+    createPlugin(repoRoot, {
+      id: "whatsapp",
+      packageName: "@openclaw/whatsapp",
+      packageOpenClaw: {
+        extensions: ["./index.ts"],
+        setupEntry: "./setup-entry.ts",
+      },
+    });
+    const staleDistDir = path.join(repoRoot, "dist", "extensions", "whatsapp");
+    fs.mkdirSync(staleDistDir, { recursive: true });
+    fs.writeFileSync(path.join(staleDistDir, "index.js"), "export default {}\n", "utf8");
+
+    copyBundledPluginMetadata({
+      repoRoot,
+      env: { OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS: "selected" },
+    });
+
+    expect(fs.existsSync(staleDistDir)).toBe(false);
+    expect(readBundledPackageJson(repoRoot, "selected").openclaw?.extensions).toEqual([
+      "./index.js",
+    ]);
+  });
 
   it("preserves isolated source-checkout output for an external plugin", () => {
     const repoRoot = makeRepoRoot("openclaw-external-plugin-local-dist-meta-");

--- a/src/plugins/copy-bundled-plugin-metadata.test.ts
+++ b/src/plugins/copy-bundled-plugin-metadata.test.ts
@@ -269,7 +269,7 @@ describe("copyBundledPluginMetadata", () => {
     expect(fs.existsSync(path.join(repoRoot, "dist", "extensions", "tlon", "bundled-skills"))).toBe(
       false,
     );
-    expect(fs.existsSync(staleNodeModulesDir)).toBe(true);
+    expect(fs.existsSync(staleNodeModulesDir)).toBe(false);
   });
 
   it("retries transient skill copy races from concurrent runtime postbuilds", () => {

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -1,5 +1,6 @@
 // Build All tests cover build all script behavior.
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -28,6 +29,7 @@ import {
 } from "../../scripts/lib/build-artifact-cache.mts";
 import { listBundledPluginBuildEntries } from "../../scripts/lib/bundled-plugin-build-entries.mjs";
 import { TSDOWN_UNIFIED_CONFIG_GROUP } from "../../scripts/lib/tsdown-config-groups.mts";
+import { runNodeMain } from "../../scripts/run-node.mts";
 
 function getBuildAllStep(label: string) {
   const step = BUILD_ALL_STEPS.find((entry) => entry.label === label);
@@ -789,6 +791,99 @@ describe("resolveBuildAllSteps", () => {
       "build-stamp",
       "runtime-postbuild-stamp",
     ]);
+  });
+
+  it.each([undefined, "0", "1"])(
+    "preserves source-run declaration choice %s through the canonical runtime build",
+    async (skipDts) => {
+      const cwd = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-source-rebuild-")),
+      );
+      const childEnv = {
+        OPENCLAW_BUILD_PRIVATE_QA: "1",
+        OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: skipDts,
+      };
+      const spawn = vi.fn((_command: string, _args: string[], _options: SpawnOptions) => {
+        const child = new EventEmitter();
+        queueMicrotask(() => child.emit("exit", 0, null));
+        return child;
+      });
+      const postbuild = vi.fn();
+      try {
+        expect(
+          await runNodeMain({
+            cwd,
+            env: childEnv,
+            args: ["status"],
+            spawn,
+            spawnSync: () => ({ status: 1 }),
+            stderr: { write: () => true },
+            runRuntimePostBuild: postbuild,
+          }),
+        ).toBe(0);
+        expect(spawn.mock.calls.map(([, args]) => args)).toEqual([
+          ["--import", "tsx", "scripts/build-all.mts", "qaRuntime"],
+          ["openclaw.mjs", "status"],
+        ]);
+        const env = spawn.mock.calls[0]![2].env!;
+        const invocations: ReturnType<typeof resolveBuildAllStep>[] = [];
+        const result = await runBuildAllSteps("qaRuntime", {
+          env,
+          logger: { error: vi.fn(), warn: vi.fn() },
+          resolveCacheState: () => ({ cacheable: false, fresh: false, reason: "no-cache" }),
+          runStep(invocation) {
+            invocations.push(invocation);
+            return { status: 0 };
+          },
+        });
+        expect(result.exitCode).toBe(0);
+        const compiler = invocations.find((call) =>
+          call.args.includes("scripts/tsdown-build.mts"),
+        )!;
+        expect(compiler.options.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD).toBe(skipDts ?? "1");
+        expect(
+          invocations.every((call) => call.options.env.OPENCLAW_BUILD_PRIVATE_QA === "1"),
+        ).toBe(true);
+        expect(result.timings.map(({ label }) => label)).toEqual([
+          "plugins:assets:build",
+          "tsdown",
+          "external-plugins:local-dist",
+          "check-cli-bootstrap-imports",
+          "plugins:assets:copy",
+          "runtime-postbuild",
+          "build-stamp",
+          "runtime-postbuild-stamp",
+        ]);
+        expect(postbuild).not.toHaveBeenCalled();
+        expect(fs.existsSync(path.join(cwd, ".artifacts/run-node-build.lock"))).toBe(false);
+      } finally {
+        fs.rmSync(cwd, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each([
+    ["external-plugins:local-dist", "scripts/build-external-plugin-local-dist.mts"],
+    ["runtime-postbuild", "scripts/runtime-postbuild.mjs"],
+  ])("does not stamp qaRuntime after %s fails", async (label, script) => {
+    const invocations: ReturnType<typeof resolveBuildAllStep>[] = [];
+    const result = await runBuildAllSteps("qaRuntime", {
+      env: {},
+      logger: { error: vi.fn(), warn: vi.fn() },
+      resolveCacheState: () => ({ cacheable: false, fresh: false, reason: "no-cache" }),
+      runStep(invocation) {
+        invocations.push(invocation);
+        return { status: invocation.args.includes(script) ? 23 : 0 };
+      },
+    });
+
+    expect(result.exitCode).toBe(23);
+    expect(result.timings.at(-1)).toMatchObject({ label, status: "failed" });
+    expect(invocations.at(-1)?.args).toContain(script);
+    for (const invocation of invocations) {
+      expect(invocation.args).not.toContain("scripts/build-stamp.mts");
+      expect(invocation.args).not.toContain("scripts/runtime-postbuild-stamp.mts");
+    }
   });
 
   it("uses the full runtime artifact surface without declaration work when DTS is disabled", () => {

--- a/test/scripts/build-external-plugin-local-dist.test.ts
+++ b/test/scripts/build-external-plugin-local-dist.test.ts
@@ -133,120 +133,18 @@ describe("external plugin local dist build", () => {
     }
   });
 
-  it.for([false, true])(
-    "retains each plugin's dependency owner and the shared host SDK (relocate=%s)",
-    async (relocate, context) => {
-      // Windows junctions remain absolute; release relocation uses POSIX symlinks.
+  it.for([
+    ["esm", false],
+    ["cjs", false],
+    ["esm", true],
+    ["cjs", true],
+  ] as const)(
+    "retains %s source dependencies across metadata profiles and the shared host SDK (relocate=%s)",
+    async ([runtimeFormat, relocate], context) => {
+      // Windows junctions remain absolute; checkout relocation uses POSIX symlinks.
       if (relocate && process.platform === "win32") {
         context.skip();
       }
-      const repoRoot = fs.realpathSync(tempDirs.make("openclaw-external-plugin-owners-"));
-      fs.writeFileSync(
-        path.join(repoRoot, "package.json"),
-        JSON.stringify({
-          name: "openclaw",
-          version: "1.0.0",
-          type: "module",
-          exports: { "./plugin-sdk/probe": "./probe.js" },
-        }),
-      );
-      fs.writeFileSync(path.join(repoRoot, "probe.js"), "export const shared = {};\n");
-      for (const [pluginId, version] of [
-        ["first", "1.0.0"],
-        ["second", "2.0.0"],
-      ] as const) {
-        const packageDir = path.join(repoRoot, "extensions", pluginId);
-        const dependencyDir = path.join(packageDir, "node_modules", "private-dep");
-        fs.mkdirSync(dependencyDir, { recursive: true });
-        fs.writeFileSync(
-          path.join(packageDir, "package.json"),
-          JSON.stringify({
-            name: `@openclaw/${pluginId}`,
-            version: "1.0.0",
-            type: "module",
-            dependencies: { "private-dep": version },
-            peerDependencies: { openclaw: "1.0.0" },
-            openclaw: {
-              extensions: ["./index.ts"],
-              build: { bundledDist: false },
-              release: { publishToNpm: true },
-            },
-          }),
-        );
-        fs.writeFileSync(
-          path.join(dependencyDir, "package.json"),
-          JSON.stringify({ name: "private-dep", version, type: "module", main: "index.js" }),
-        );
-        fs.writeFileSync(
-          path.join(dependencyDir, "index.js"),
-          `export default ${JSON.stringify(version)};\n`,
-        );
-        fs.symlinkSync(
-          process.platform === "win32" ? repoRoot : "../../..",
-          path.join(packageDir, "node_modules", "openclaw"),
-          process.platform === "win32" ? "junction" : "dir",
-        );
-        fs.writeFileSync(
-          path.join(packageDir, "index.ts"),
-          'export { default as version } from "private-dep";\nexport { shared } from "openclaw/plugin-sdk/probe";\n',
-        );
-        fs.writeFileSync(
-          path.join(packageDir, "openclaw.plugin.json"),
-          JSON.stringify({ id: pluginId, skills: ["./node_modules/private-dep"] }),
-        );
-      }
-      await buildExternalPluginLocalDist({ repoRoot, env: {}, logLevel: "silent" });
-      copyBundledPluginMetadata({ repoRoot, env: {} });
-      // Repeating postbuild must not remove source packages through the output link.
-      copyBundledPluginMetadata({ repoRoot, env: {} });
-      let runtimeRoot = repoRoot;
-      if (relocate) {
-        runtimeRoot = fs.realpathSync(tempDirs.make("openclaw-external-plugin-relocated-"));
-        fs.cpSync(repoRoot, runtimeRoot, { recursive: true, verbatimSymlinks: true });
-        fs.rmSync(repoRoot, { recursive: true });
-      }
-      const entryUrl = (pluginId: string) =>
-        pathToFileURL(path.join(runtimeRoot, "dist", "extensions", pluginId, "index.js")).href;
-      const stagedDir = path.join(runtimeRoot, "staged", "first");
-      fs.cpSync(path.join(runtimeRoot, "dist", "extensions", "first"), stagedDir, {
-        recursive: true,
-      });
-      const output = execFileSync(
-        process.execPath,
-        [
-          "--input-type=module",
-          "-e",
-          `
-      const first = await import(${JSON.stringify(entryUrl("first"))});
-      const second = await import(${JSON.stringify(entryUrl("second"))});
-      const staged = await import(${JSON.stringify(pathToFileURL(path.join(stagedDir, "index.js")).href)});
-      console.log(JSON.stringify({ versions: [first.version, second.version, staged.version], shared: first.shared === second.shared && first.shared === staged.shared }));
-    `,
-        ],
-        { encoding: "utf8" },
-      );
-      expect(JSON.parse(output)).toEqual({ versions: ["1.0.0", "2.0.0", "1.0.0"], shared: true });
-      for (const pluginId of ["first", "second"]) {
-        const runtimeModules = path.join(
-          runtimeRoot,
-          "dist",
-          "extensions",
-          pluginId,
-          "node_modules",
-        );
-        if (process.platform !== "win32") {
-          expect(path.isAbsolute(fs.readlinkSync(runtimeModules))).toBe(false);
-        }
-        expect(fs.realpathSync(runtimeModules)).toBe(
-          path.join(runtimeRoot, "extensions", pluginId, "node_modules"),
-        );
-      }
-    },
-  );
-
-  it.each(["esm", "cjs"])(
-    "retains %s source dependencies across metadata profiles and the shared host SDK",
-    async (runtimeFormat) => {
       const repoRoot = fs.realpathSync(tempDirs.make("openclaw-external-plugin-owners-"));
       const dependency = "@fixture/private-dep";
       const plugins = [
@@ -369,16 +267,23 @@ describe("external plugin local dist build", () => {
           ).toBe(`# Private dependency ${version}\n`);
         }
       }
+      let runtimeRoot = repoRoot;
+      if (relocate) {
+        runtimeRoot = fs.realpathSync(tempDirs.make("openclaw-external-plugin-relocated-"));
+        await fs.promises.cp(repoRoot, runtimeRoot, { recursive: true, verbatimSymlinks: true });
+        fs.rmSync(repoRoot, { recursive: true });
+      }
       const extension = runtimeFormat === "cjs" ? ".cjs" : ".js";
       const entryUrl = (pluginId: string) =>
-        pathToFileURL(path.join(repoRoot, "dist", "extensions", pluginId, `index${extension}`))
+        pathToFileURL(path.join(runtimeRoot, "dist", "extensions", pluginId, `index${extension}`))
           .href;
-      const stagedDir = path.join(repoRoot, "staged", "first");
-      // Match installPackageDir's link-preserving copy contract. Node's native
-      // cpSync walker can traverse Windows junctions instead of preserving them.
-      await fs.promises.cp(path.join(repoRoot, "dist", "extensions", "first"), stagedDir, {
+      const stagedDir = path.join(runtimeRoot, "staged", "first");
+      // Moving only a plugin needs POSIX links rebased to their source owners;
+      // moving the whole checkout above preserves them. Keep Windows junctions
+      // verbatim and use async cp: cpSync can recurse through the host back-link.
+      await fs.promises.cp(path.join(runtimeRoot, "dist", "extensions", "first"), stagedDir, {
         recursive: true,
-        verbatimSymlinks: true,
+        verbatimSymlinks: process.platform === "win32",
       });
       const output = execFileSync(
         process.execPath,
@@ -392,13 +297,29 @@ describe("external plugin local dist build", () => {
       const first = await load(${JSON.stringify(entryUrl("first"))});
       const second = await load(${JSON.stringify(entryUrl("second"))});
       const staged = await load(${JSON.stringify(pathToFileURL(path.join(stagedDir, `index${extension}`)).href)});
-      const host = await import(${JSON.stringify(pathToFileURL(path.join(repoRoot, "dist/plugin-sdk/probe.js")).href)});
+      const host = await import(${JSON.stringify(pathToFileURL(path.join(runtimeRoot, "dist/plugin-sdk/probe.js")).href)});
       console.log(JSON.stringify({ versions: [first.version, second.version, staged.version], shared: first.shared === host.shared && first.shared === second.shared && first.shared === staged.shared }));
     `,
         ],
         { encoding: "utf8" },
       );
       expect(JSON.parse(output)).toEqual({ versions: ["1.0.0", "2.0.0", "1.0.0"], shared: true });
+      for (const [pluginId, version] of plugins) {
+        const modules = path.join(runtimeRoot, "dist", "extensions", pluginId, "node_modules");
+        expect(fs.lstatSync(modules).isSymbolicLink()).toBe(false);
+        expect(fs.lstatSync(path.join(modules, "@fixture")).isSymbolicLink()).toBe(false);
+        for (const [name, owner] of [
+          ["openclaw", runtimeRoot],
+          [dependency, path.join(runtimeRoot, "installed", version, "node_modules", dependency)],
+          [".bin", path.join(runtimeRoot, "extensions", pluginId, "node_modules", ".bin")],
+        ] as const) {
+          const link = path.join(modules, name);
+          if (process.platform !== "win32") {
+            expect(path.isAbsolute(fs.readlinkSync(link))).toBe(false);
+          }
+          expect(fs.realpathSync(link)).toBe(owner);
+        }
+      }
       expect(
         execFileSync(process.execPath, [path.join(stagedDir, "node_modules/.bin/probe.cjs")], {
           encoding: "utf8",

--- a/test/scripts/build-external-plugin-local-dist.test.ts
+++ b/test/scripts/build-external-plugin-local-dist.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -17,6 +17,87 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("external plugin local dist build", () => {
+  it("keeps excluded plugin graphs isolated and their runtime metadata loadable", async () => {
+    const repoRoot = fs.realpathSync(tempDirs.make("openclaw-isolated-plugin-graphs-"));
+    const plugins = [
+      { id: "external-esm", runtimeFormat: "esm", publishToNpm: true },
+      { id: "external-cjs", runtimeFormat: "cjs", publishToNpm: true },
+      { id: "private-plugin", runtimeFormat: "esm", publishToNpm: false },
+    ];
+    fs.writeFileSync(
+      path.join(repoRoot, "package.json"),
+      JSON.stringify({
+        name: "openclaw",
+        version: "1.0.0",
+        type: "module",
+        files: ["dist/**", ...plugins.map(({ id }) => `!dist/extensions/${id}/**`)],
+      }),
+    );
+    for (const { id, runtimeFormat, publishToNpm } of plugins) {
+      const pluginRoot = path.join(repoRoot, "extensions", id);
+      fs.mkdirSync(pluginRoot, { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginRoot, "package.json"),
+        JSON.stringify({
+          name: `@openclaw/${id}`,
+          version: "1.0.0",
+          type: "module",
+          openclaw: {
+            extensions: ["./index.ts"],
+            setupEntry: "./setup-entry.ts",
+            build: { runtimeFormat },
+            release: { publishToNpm },
+          },
+        }),
+      );
+      fs.writeFileSync(path.join(pluginRoot, "openclaw.plugin.json"), JSON.stringify({ id }));
+      fs.writeFileSync(
+        path.join(pluginRoot, "runtime-api.ts"),
+        `export const identity = ${JSON.stringify(id)};`,
+      );
+      for (const entry of ["index.ts", "setup-entry.ts"]) {
+        fs.writeFileSync(
+          path.join(pluginRoot, entry),
+          'export { identity } from "./runtime-api.js";',
+        );
+      }
+    }
+    await expect(
+      buildExternalPluginLocalDist({ repoRoot, env: {}, logLevel: "silent" }),
+    ).resolves.toMatchObject({
+      pluginDirs: plugins.map(({ id }) => id).toSorted(),
+    });
+    copyBundledPluginMetadata({ repoRoot, env: {} });
+    expect(fs.readdirSync(path.join(repoRoot, "dist"))).toEqual(["extensions"]);
+    for (const { id, runtimeFormat } of plugins) {
+      const pluginRoot = path.join(repoRoot, "dist/extensions", id);
+      const metadata = JSON.parse(fs.readFileSync(path.join(pluginRoot, "package.json"), "utf8"));
+      const extension = runtimeFormat === "cjs" ? ".cjs" : ".js";
+      expect(metadata.openclaw.extensions).toEqual([`./index${extension}`]);
+      expect(metadata.openclaw.setupEntry).toBe(`./setup-entry${extension}`);
+      expect(fs.existsSync(path.join(repoRoot, "extensions", id, "dist"))).toBe(false);
+      const probe = spawnSync(
+        process.execPath,
+        [
+          "--input-type=module",
+          "--eval",
+          `
+        import assert from "node:assert/strict";
+        import { readFileSync } from "node:fs";
+        import { pathToFileURL } from "node:url";
+        const root = pathToFileURL(process.cwd() + "/");
+        const pkg = JSON.parse(readFileSync(new URL("package.json", root)));
+        for (const entry of [...pkg.openclaw.extensions, pkg.openclaw.setupEntry]) {
+          assert.equal((await import(new URL(entry, root))).identity, ${JSON.stringify(id)});
+        }
+      `,
+        ],
+        { cwd: pluginRoot, encoding: "utf8" },
+      );
+      expect(probe.status, probe.stdout + probe.stderr).toBe(0);
+    }
+  });
+
   it.for([false, true])(
     "retains each plugin's dependency owner and the shared host SDK (relocate=%s)",
     async (relocate, context) => {
@@ -132,7 +213,6 @@ describe("external plugin local dist build", () => {
     const packageDirs = listExternalPluginLocalDistPackageDirs();
     const excludedPluginIds = collectRootPackageExcludedExtensionDirs();
 
-    expect(packageDirs).toHaveLength(67);
     expect(packageDirs).toEqual(
       expect.arrayContaining([
         "extensions/diffs",
@@ -144,6 +224,10 @@ describe("external plugin local dist build", () => {
         "extensions/sms",
         "extensions/mxc",
         "extensions/whatsapp",
+        "extensions/codex",
+        "extensions/diagnostics-otel",
+        "extensions/msteams",
+        "extensions/visitor-access",
       ]),
     );
     expect(

--- a/test/scripts/build-external-plugin-local-dist.test.ts
+++ b/test/scripts/build-external-plugin-local-dist.test.ts
@@ -374,12 +374,12 @@ describe("external plugin local dist build", () => {
         pathToFileURL(path.join(repoRoot, "dist", "extensions", pluginId, `index${extension}`))
           .href;
       const stagedDir = path.join(repoRoot, "staged", "first");
-      fs.cpSync(path.join(repoRoot, "dist", "extensions", "first"), stagedDir, { recursive: true });
-      expect(
-        execFileSync(process.execPath, [path.join(stagedDir, "node_modules/.bin/probe.cjs")], {
-          encoding: "utf8",
-        }).trim(),
-      ).toBe("1.0.0");
+      // Match installPackageDir's link-preserving copy contract. Node's native
+      // cpSync walker can traverse Windows junctions instead of preserving them.
+      await fs.promises.cp(path.join(repoRoot, "dist", "extensions", "first"), stagedDir, {
+        recursive: true,
+        verbatimSymlinks: true,
+      });
       const output = execFileSync(
         process.execPath,
         [
@@ -399,6 +399,11 @@ describe("external plugin local dist build", () => {
         { encoding: "utf8" },
       );
       expect(JSON.parse(output)).toEqual({ versions: ["1.0.0", "2.0.0", "1.0.0"], shared: true });
+      expect(
+        execFileSync(process.execPath, [path.join(stagedDir, "node_modules/.bin/probe.cjs")], {
+          encoding: "utf8",
+        }).trim(),
+      ).toBe("1.0.0");
     },
   );
 

--- a/test/scripts/build-external-plugin-local-dist.test.ts
+++ b/test/scripts/build-external-plugin-local-dist.test.ts
@@ -244,116 +244,163 @@ describe("external plugin local dist build", () => {
     },
   );
 
-  it("retains source dependencies across metadata profiles and the shared host SDK", async () => {
-    const repoRoot = tempDirs.make("openclaw-external-plugin-owners-");
-    const plugins = [
-      ["first", "1.0.0"],
-      ["second", "2.0.0"],
-    ] as const;
-    fs.writeFileSync(
-      path.join(repoRoot, "package.json"),
-      JSON.stringify({
-        name: "openclaw",
-        version: "1.0.0",
-        type: "module",
-        exports: { "./plugin-sdk/probe": "./probe.js" },
-      }),
-    );
-    fs.writeFileSync(path.join(repoRoot, "probe.js"), "export const shared = {};\n");
-    for (const [pluginId, version] of plugins) {
-      const packageDir = path.join(repoRoot, "extensions", pluginId);
-      const dependencyDir = path.join(packageDir, "node_modules", "private-dep");
-      fs.mkdirSync(dependencyDir, { recursive: true });
+  it.each(["esm", "cjs"])(
+    "retains %s source dependencies across metadata profiles and the shared host SDK",
+    async (runtimeFormat) => {
+      const repoRoot = fs.realpathSync(tempDirs.make("openclaw-external-plugin-owners-"));
+      const dependency = "@fixture/private-dep";
+      const plugins = [
+        ["first", "1.0.0"],
+        ["second", "2.0.0"],
+      ] as const;
       fs.writeFileSync(
-        path.join(packageDir, "package.json"),
+        path.join(repoRoot, "package.json"),
         JSON.stringify({
-          name: `@openclaw/${pluginId}`,
+          name: "openclaw",
           version: "1.0.0",
           type: "module",
-          dependencies: { "private-dep": version },
-          peerDependencies: { openclaw: "1.0.0" },
-          openclaw: {
-            extensions: ["./index.ts"],
-            build: { bundledDist: false },
-            release: { publishToNpm: true },
-          },
+          exports: { "./plugin-sdk/probe": "./dist/plugin-sdk/probe.js" },
         }),
       );
+      fs.mkdirSync(path.join(repoRoot, "dist", "plugin-sdk"), { recursive: true });
       fs.writeFileSync(
-        path.join(dependencyDir, "package.json"),
-        JSON.stringify({ name: "private-dep", version, type: "module", main: "index.js" }),
+        path.join(repoRoot, "dist", "plugin-sdk", "probe.js"),
+        "export const shared = {};\n",
       );
-      fs.writeFileSync(
-        path.join(dependencyDir, "index.js"),
-        `export default ${JSON.stringify(version)};\n`,
-      );
-      fs.writeFileSync(path.join(dependencyDir, "SKILL.md"), `# Private dependency ${version}\n`);
-      fs.symlinkSync(
-        repoRoot,
-        path.join(packageDir, "node_modules", "openclaw"),
-        process.platform === "win32" ? "junction" : "dir",
-      );
-      fs.writeFileSync(
-        path.join(packageDir, "index.ts"),
-        'export { default as version } from "private-dep";\nexport { shared } from "openclaw/plugin-sdk/probe";\n',
-      );
-      fs.writeFileSync(
-        path.join(packageDir, "openclaw.plugin.json"),
-        JSON.stringify({ id: pluginId, skills: ["./node_modules/private-dep"] }),
-      );
-    }
-    await buildExternalPluginLocalDist({ repoRoot, env: {}, logLevel: "silent" });
-    // Old output links belong to the previous profile, even when the new plan is unified.
-    for (const [profile, env, isolated] of [
-      ["isolated", {}, true],
-      ["Docker unified", { [DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV]: "first,second" }, false],
-      ["isolated again", {}, true],
-      ["isolated repeated", {}, true],
-    ] as const) {
-      copyBundledPluginMetadata({ repoRoot, env });
+      const sourceHostLinks = new Map<string, string>();
       for (const [pluginId, version] of plugins) {
-        const sourceModules = path.join(repoRoot, "extensions", pluginId, "node_modules");
-        const outputRoot = path.join(repoRoot, "dist", "extensions", pluginId);
-        expect(
-          fs.readFileSync(path.join(sourceModules, "private-dep", "SKILL.md"), "utf8"),
-          profile,
-        ).toBe(`# Private dependency ${version}\n`);
-        expect(
-          fs
-            .lstatSync(path.join(outputRoot, "node_modules"), { throwIfNoEntry: false })
-            ?.isSymbolicLink() ?? false,
-          profile,
-        ).toBe(isolated);
-        const manifest = JSON.parse(
-          fs.readFileSync(path.join(outputRoot, "openclaw.plugin.json"), "utf8"),
+        const packageDir = path.join(repoRoot, "extensions", pluginId);
+        const modulesDir = path.join(packageDir, "node_modules");
+        const dependencyLink = path.join(modulesDir, dependency);
+        const dependencyDir = path.join(repoRoot, "installed", version, "node_modules", dependency);
+        fs.mkdirSync(dependencyDir, { recursive: true });
+        fs.mkdirSync(path.dirname(dependencyLink), { recursive: true });
+        fs.mkdirSync(path.join(modulesDir, ".bin"));
+        fs.writeFileSync(
+          path.join(modulesDir, ".bin", "probe.cjs"),
+          `console.log(require("../${dependency}").version);\n`,
         );
-        expect(manifest.skills, profile).toEqual(["./bundled-skills/private-dep"]);
-        expect(
-          fs.readFileSync(path.join(outputRoot, manifest.skills[0], "SKILL.md"), "utf8"),
-          profile,
-        ).toBe(`# Private dependency ${version}\n`);
+        fs.symlinkSync(
+          path.relative(path.dirname(dependencyLink), dependencyDir),
+          dependencyLink,
+          "dir",
+        );
+        fs.writeFileSync(
+          path.join(packageDir, "package.json"),
+          JSON.stringify({
+            name: `@openclaw/${pluginId}`,
+            version: "1.0.0",
+            type: "module",
+            dependencies: { [dependency]: version },
+            peerDependencies: { openclaw: "1.0.0" },
+            openclaw: {
+              extensions: ["./index.ts"],
+              build: { bundledDist: false, runtimeFormat },
+              release: { publishToNpm: true },
+            },
+          }),
+        );
+        fs.writeFileSync(
+          path.join(dependencyDir, "package.json"),
+          JSON.stringify({ name: dependency, version, main: "index.cjs" }),
+        );
+        fs.writeFileSync(
+          path.join(dependencyDir, "index.cjs"),
+          `exports.version = ${JSON.stringify(version)};\n`,
+        );
+        fs.writeFileSync(path.join(dependencyDir, "SKILL.md"), `# Private dependency ${version}\n`);
+        fs.symlinkSync(
+          path.relative(modulesDir, repoRoot),
+          path.join(packageDir, "node_modules", "openclaw"),
+          "dir",
+        );
+        sourceHostLinks.set(pluginId, fs.readlinkSync(path.join(modulesDir, "openclaw")));
+        fs.writeFileSync(
+          path.join(packageDir, "index.ts"),
+          `export { version } from "${dependency}";\nexport { shared } from "openclaw/plugin-sdk/probe";\n`,
+        );
+        fs.writeFileSync(
+          path.join(packageDir, "openclaw.plugin.json"),
+          JSON.stringify({ id: pluginId, skills: [`./node_modules/${dependency}`] }),
+        );
       }
-    }
-    const entryUrl = (pluginId: string) =>
-      pathToFileURL(path.join(repoRoot, "dist", "extensions", pluginId, "index.js")).href;
-    const stagedDir = path.join(repoRoot, "staged", "first");
-    fs.cpSync(path.join(repoRoot, "dist", "extensions", "first"), stagedDir, { recursive: true });
-    const output = execFileSync(
-      process.execPath,
-      [
-        "--input-type=module",
-        "-e",
-        `
-      const first = await import(${JSON.stringify(entryUrl("first"))});
-      const second = await import(${JSON.stringify(entryUrl("second"))});
-      const staged = await import(${JSON.stringify(pathToFileURL(path.join(stagedDir, "index.js")).href)});
-      console.log(JSON.stringify({ versions: [first.version, second.version, staged.version], shared: first.shared === second.shared && first.shared === staged.shared }));
+      await buildExternalPluginLocalDist({ repoRoot, env: {}, logLevel: "silent" });
+      // Start with the previous build's directory link, then exercise both profile transitions.
+      for (const [pluginId] of plugins) {
+        fs.symlinkSync(
+          path.join(repoRoot, "extensions", pluginId, "node_modules"),
+          path.join(repoRoot, "dist", "extensions", pluginId, "node_modules"),
+          "junction",
+        );
+      }
+      // Old output links belong to the previous profile, even when the new plan is unified.
+      for (const [profile, env, isolated] of [
+        [
+          "legacy Docker unified",
+          { [DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV]: "first,second" },
+          false,
+        ],
+        ["isolated", {}, true],
+        ["Docker unified", { [DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV]: "first,second" }, false],
+        ["isolated again", {}, true],
+        ["isolated repeated", {}, true],
+      ] as const) {
+        copyBundledPluginMetadata({ repoRoot, env });
+        for (const [pluginId, version] of plugins) {
+          const sourceModules = path.join(repoRoot, "extensions", pluginId, "node_modules");
+          const outputRoot = path.join(repoRoot, "dist", "extensions", pluginId);
+          expect(
+            fs.readFileSync(path.join(sourceModules, dependency, "SKILL.md"), "utf8"),
+            profile,
+          ).toBe(`# Private dependency ${version}\n`);
+          expect(fs.existsSync(path.join(outputRoot, "node_modules", "openclaw")), profile).toBe(
+            isolated,
+          );
+          expect(fs.readlinkSync(path.join(sourceModules, "openclaw")), profile).toBe(
+            sourceHostLinks.get(pluginId),
+          );
+          const manifest = JSON.parse(
+            fs.readFileSync(path.join(outputRoot, "openclaw.plugin.json"), "utf8"),
+          );
+          expect(manifest.skills, profile).toEqual([`./bundled-skills/${dependency}`]);
+          expect(
+            fs.readFileSync(path.join(outputRoot, manifest.skills[0], "SKILL.md"), "utf8"),
+            profile,
+          ).toBe(`# Private dependency ${version}\n`);
+        }
+      }
+      const extension = runtimeFormat === "cjs" ? ".cjs" : ".js";
+      const entryUrl = (pluginId: string) =>
+        pathToFileURL(path.join(repoRoot, "dist", "extensions", pluginId, `index${extension}`))
+          .href;
+      const stagedDir = path.join(repoRoot, "staged", "first");
+      fs.cpSync(path.join(repoRoot, "dist", "extensions", "first"), stagedDir, { recursive: true });
+      expect(
+        execFileSync(process.execPath, [path.join(stagedDir, "node_modules/.bin/probe.cjs")], {
+          encoding: "utf8",
+        }).trim(),
+      ).toBe("1.0.0");
+      const output = execFileSync(
+        process.execPath,
+        [
+          "--input-type=module",
+          "-e",
+          `
+      import { createRequire } from "node:module";
+      import { fileURLToPath } from "node:url";
+      const load = ${runtimeFormat === "cjs" ? "(url) => createRequire(import.meta.url)(fileURLToPath(url))" : "(url) => import(url)"};
+      const first = await load(${JSON.stringify(entryUrl("first"))});
+      const second = await load(${JSON.stringify(entryUrl("second"))});
+      const staged = await load(${JSON.stringify(pathToFileURL(path.join(stagedDir, `index${extension}`)).href)});
+      const host = await import(${JSON.stringify(pathToFileURL(path.join(repoRoot, "dist/plugin-sdk/probe.js")).href)});
+      console.log(JSON.stringify({ versions: [first.version, second.version, staged.version], shared: first.shared === host.shared && first.shared === second.shared && first.shared === staged.shared }));
     `,
-      ],
-      { encoding: "utf8" },
-    );
-    expect(JSON.parse(output)).toEqual({ versions: ["1.0.0", "2.0.0", "1.0.0"], shared: true });
-  });
+        ],
+        { encoding: "utf8" },
+      );
+      expect(JSON.parse(output)).toEqual({ versions: ["1.0.0", "2.0.0", "1.0.0"], shared: true });
+    },
+  );
 
   it("selects every externalized first-party plugin behind a package exclusion", () => {
     const packageDirs = listExternalPluginLocalDistPackageDirs();

--- a/test/scripts/build-external-plugin-local-dist.test.ts
+++ b/test/scripts/build-external-plugin-local-dist.test.ts
@@ -244,6 +244,117 @@ describe("external plugin local dist build", () => {
     },
   );
 
+  it("retains source dependencies across metadata profiles and the shared host SDK", async () => {
+    const repoRoot = tempDirs.make("openclaw-external-plugin-owners-");
+    const plugins = [
+      ["first", "1.0.0"],
+      ["second", "2.0.0"],
+    ] as const;
+    fs.writeFileSync(
+      path.join(repoRoot, "package.json"),
+      JSON.stringify({
+        name: "openclaw",
+        version: "1.0.0",
+        type: "module",
+        exports: { "./plugin-sdk/probe": "./probe.js" },
+      }),
+    );
+    fs.writeFileSync(path.join(repoRoot, "probe.js"), "export const shared = {};\n");
+    for (const [pluginId, version] of plugins) {
+      const packageDir = path.join(repoRoot, "extensions", pluginId);
+      const dependencyDir = path.join(packageDir, "node_modules", "private-dep");
+      fs.mkdirSync(dependencyDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(packageDir, "package.json"),
+        JSON.stringify({
+          name: `@openclaw/${pluginId}`,
+          version: "1.0.0",
+          type: "module",
+          dependencies: { "private-dep": version },
+          peerDependencies: { openclaw: "1.0.0" },
+          openclaw: {
+            extensions: ["./index.ts"],
+            build: { bundledDist: false },
+            release: { publishToNpm: true },
+          },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(dependencyDir, "package.json"),
+        JSON.stringify({ name: "private-dep", version, type: "module", main: "index.js" }),
+      );
+      fs.writeFileSync(
+        path.join(dependencyDir, "index.js"),
+        `export default ${JSON.stringify(version)};\n`,
+      );
+      fs.writeFileSync(path.join(dependencyDir, "SKILL.md"), `# Private dependency ${version}\n`);
+      fs.symlinkSync(
+        repoRoot,
+        path.join(packageDir, "node_modules", "openclaw"),
+        process.platform === "win32" ? "junction" : "dir",
+      );
+      fs.writeFileSync(
+        path.join(packageDir, "index.ts"),
+        'export { default as version } from "private-dep";\nexport { shared } from "openclaw/plugin-sdk/probe";\n',
+      );
+      fs.writeFileSync(
+        path.join(packageDir, "openclaw.plugin.json"),
+        JSON.stringify({ id: pluginId, skills: ["./node_modules/private-dep"] }),
+      );
+    }
+    await buildExternalPluginLocalDist({ repoRoot, env: {}, logLevel: "silent" });
+    // Old output links belong to the previous profile, even when the new plan is unified.
+    for (const [profile, env, isolated] of [
+      ["isolated", {}, true],
+      ["Docker unified", { [DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV]: "first,second" }, false],
+      ["isolated again", {}, true],
+      ["isolated repeated", {}, true],
+    ] as const) {
+      copyBundledPluginMetadata({ repoRoot, env });
+      for (const [pluginId, version] of plugins) {
+        const sourceModules = path.join(repoRoot, "extensions", pluginId, "node_modules");
+        const outputRoot = path.join(repoRoot, "dist", "extensions", pluginId);
+        expect(
+          fs.readFileSync(path.join(sourceModules, "private-dep", "SKILL.md"), "utf8"),
+          profile,
+        ).toBe(`# Private dependency ${version}\n`);
+        expect(
+          fs
+            .lstatSync(path.join(outputRoot, "node_modules"), { throwIfNoEntry: false })
+            ?.isSymbolicLink() ?? false,
+          profile,
+        ).toBe(isolated);
+        const manifest = JSON.parse(
+          fs.readFileSync(path.join(outputRoot, "openclaw.plugin.json"), "utf8"),
+        );
+        expect(manifest.skills, profile).toEqual(["./bundled-skills/private-dep"]);
+        expect(
+          fs.readFileSync(path.join(outputRoot, manifest.skills[0], "SKILL.md"), "utf8"),
+          profile,
+        ).toBe(`# Private dependency ${version}\n`);
+      }
+    }
+    const entryUrl = (pluginId: string) =>
+      pathToFileURL(path.join(repoRoot, "dist", "extensions", pluginId, "index.js")).href;
+    const stagedDir = path.join(repoRoot, "staged", "first");
+    fs.cpSync(path.join(repoRoot, "dist", "extensions", "first"), stagedDir, { recursive: true });
+    const output = execFileSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `
+      const first = await import(${JSON.stringify(entryUrl("first"))});
+      const second = await import(${JSON.stringify(entryUrl("second"))});
+      const staged = await import(${JSON.stringify(pathToFileURL(path.join(stagedDir, "index.js")).href)});
+      console.log(JSON.stringify({ versions: [first.version, second.version, staged.version], shared: first.shared === second.shared && first.shared === staged.shared }));
+    `,
+      ],
+      { encoding: "utf8" },
+    );
+    expect(JSON.parse(output)).toEqual({ versions: ["1.0.0", "2.0.0", "1.0.0"], shared: true });
+  });
+
   it("selects every externalized first-party plugin behind a package exclusion", () => {
     const packageDirs = listExternalPluginLocalDistPackageDirs();
     const excludedPluginIds = collectRootPackageExcludedExtensionDirs();

--- a/test/scripts/build-external-plugin-local-dist.test.ts
+++ b/test/scripts/build-external-plugin-local-dist.test.ts
@@ -10,8 +10,11 @@ import {
 import { copyBundledPluginMetadata } from "../../scripts/copy-bundled-plugin-metadata.mts";
 import {
   collectRootPackageExcludedExtensionDirs,
+  collectSourceCheckoutPluginBuildEntries,
   DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV,
 } from "../../scripts/lib/bundled-plugin-build-entries.mjs";
+import { BUILD_STAMP_FILE } from "../../scripts/lib/local-build-metadata-paths.mts";
+import { resolveBuildRequirement } from "../../scripts/run-node.mts";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -20,9 +23,10 @@ describe("external plugin local dist build", () => {
   it("keeps excluded plugin graphs isolated and their runtime metadata loadable", async () => {
     const repoRoot = fs.realpathSync(tempDirs.make("openclaw-isolated-plugin-graphs-"));
     const plugins = [
-      { id: "external-esm", runtimeFormat: "esm", publishToNpm: true },
-      { id: "external-cjs", runtimeFormat: "cjs", publishToNpm: true },
-      { id: "private-plugin", runtimeFormat: "esm", publishToNpm: false },
+      { id: "external-esm", runtimeFormat: "esm", publishToNpm: true, bundledDist: true },
+      { id: "external-cjs", runtimeFormat: "cjs", publishToNpm: true, bundledDist: true },
+      { id: "external-only", runtimeFormat: "cjs", publishToNpm: true, bundledDist: false },
+      { id: "private-plugin", runtimeFormat: "esm", publishToNpm: false, bundledDist: true },
     ];
     fs.writeFileSync(
       path.join(repoRoot, "package.json"),
@@ -33,7 +37,7 @@ describe("external plugin local dist build", () => {
         files: ["dist/**", ...plugins.map(({ id }) => `!dist/extensions/${id}/**`)],
       }),
     );
-    for (const { id, runtimeFormat, publishToNpm } of plugins) {
+    for (const { id, runtimeFormat, publishToNpm, bundledDist } of plugins) {
       const pluginRoot = path.join(repoRoot, "extensions", id);
       fs.mkdirSync(pluginRoot, { recursive: true });
       fs.writeFileSync(
@@ -45,7 +49,7 @@ describe("external plugin local dist build", () => {
           openclaw: {
             extensions: ["./index.ts"],
             setupEntry: "./setup-entry.ts",
-            build: { runtimeFormat },
+            build: { runtimeFormat, bundledDist },
             release: { publishToNpm },
           },
         }),
@@ -95,6 +99,37 @@ describe("external plugin local dist build", () => {
         { cwd: pluginRoot, encoding: "utf8" },
       );
       expect(probe.status, probe.stdout + probe.stderr).toBe(0);
+    }
+
+    const distRoot = path.join(repoRoot, "dist");
+    const distEntry = path.join(distRoot, "entry.js");
+    const buildStampPath = path.join(distRoot, BUILD_STAMP_FILE);
+    fs.writeFileSync(distEntry, "export {};\n");
+    fs.writeFileSync(buildStampPath, "{}\n");
+    const readiness = {
+      cwd: repoRoot,
+      env: {},
+      fs,
+      distRoot,
+      distEntry,
+      buildStampPath,
+      configFiles: [],
+      sourceRoots: [],
+      spawnSync: () => ({ status: 1 }),
+    };
+    expect(resolveBuildRequirement(readiness)).toEqual({ shouldBuild: false, reason: "clean" });
+    // Neither a bundled CJS entry nor an external-only entry may be certified
+    // by a stale .js file after its selected .cjs output disappears.
+    for (const id of ["external-cjs", "external-only"]) {
+      const output = path.join(distRoot, "extensions", id, "runtime-api.cjs");
+      const contents = fs.readFileSync(output);
+      fs.unlinkSync(output);
+      fs.writeFileSync(output.replace(/\.cjs$/u, ".js"), "export {};\n");
+      expect(resolveBuildRequirement(readiness)).toEqual({
+        shouldBuild: true,
+        reason: "missing_bundled_plugin_dist_entry",
+      });
+      fs.writeFileSync(output, contents);
     }
   });
 
@@ -244,6 +279,131 @@ describe("external plugin local dist build", () => {
         },
       }),
     ).toEqual([]);
+  });
+
+  it("retains released optional outputs and respects private QA and bounded selectors", () => {
+    const env = { OPENCLAW_INCLUDE_OPTIONAL_BUNDLED: "0" };
+    const selected = collectSourceCheckoutPluginBuildEntries({ env });
+    expect(selected.some(({ id }) => id === "qa-lab")).toBe(false);
+    expect(selected.find(({ id }) => id === "msteams")).toMatchObject({
+      isolated: true,
+      runtimeExtension: ".cjs",
+    });
+    const privateQa = collectSourceCheckoutPluginBuildEntries({
+      env: { ...env, OPENCLAW_BUILD_PRIVATE_QA: "1" },
+    });
+    expect(privateQa.find(({ id }) => id === "qa-lab")).toMatchObject({
+      isolated: false,
+      runtimeExtension: ".js",
+    });
+    expect(
+      collectSourceCheckoutPluginBuildEntries({
+        env: { OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS: "telegram" },
+      }).map(({ id }) => id),
+    ).toEqual(["telegram"]);
+  });
+
+  it("agrees on Docker compiler, metadata, and readiness outputs without unselected excluded plugins", () => {
+    const repoRoot = fs.realpathSync(tempDirs.make("openclaw-docker-plugin-format-"));
+    const pluginIds = ["demo", "unselected", "packaged"];
+    fs.writeFileSync(
+      path.join(repoRoot, "package.json"),
+      JSON.stringify({
+        version: "1.0.0",
+        type: "module",
+        files: ["dist/**", "!dist/extensions/demo/**", "!dist/extensions/unselected/**"],
+      }),
+    );
+    for (const id of pluginIds) {
+      const pluginRoot = path.join(repoRoot, "extensions", id);
+      fs.mkdirSync(pluginRoot, { recursive: true });
+      fs.writeFileSync(path.join(pluginRoot, "openclaw.plugin.json"), JSON.stringify({ id }));
+      fs.writeFileSync(
+        path.join(pluginRoot, "package.json"),
+        JSON.stringify({
+          openclaw: {
+            extensions: ["./index.ts"],
+            setupEntry: "./setup-entry.ts",
+            build: { bundledDist: id !== "demo", runtimeFormat: "cjs" },
+            release: { publishToNpm: true },
+          },
+        }),
+      );
+      for (const entry of ["index.ts", "setup-entry.ts"]) {
+        fs.writeFileSync(path.join(pluginRoot, entry), "export {};\n");
+      }
+    }
+    // Evaluate the real compiler config against synthetic plugins. These links
+    // expose existing read-only config inputs; no core graph is compiled.
+    for (const input of [
+      "packages",
+      "src",
+      "node_modules",
+      "extensions/browser",
+      "extensions/anthropic",
+    ]) {
+      fs.symlinkSync(path.resolve(input), path.join(repoRoot, input), "dir");
+    }
+    const env = { [DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV]: "demo" };
+    const compiler = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        path.resolve("scripts/tsx.mjs"),
+        "--input-type=module",
+        "--eval",
+        `
+        import { pathToFileURL } from "node:url";
+        const { default: configs } = await import(pathToFileURL(process.argv[1]).href);
+        const entry = configs.find((config) => config.name === "openclaw-unified").entry;
+        const ids = new Set(JSON.parse(process.argv[2]));
+        console.log(JSON.stringify(Object.keys(entry).filter((key) =>
+          key.startsWith("extensions/") && ids.has(key.split("/")[1])).sort()));
+      `,
+        path.resolve("tsdown.config.ts"),
+        JSON.stringify(pluginIds),
+      ],
+      { cwd: repoRoot, env: { ...process.env, ...env }, encoding: "utf8" },
+    );
+    expect(compiler.status, compiler.stderr).toBe(0);
+    const compilerEntries: string[] = JSON.parse(compiler.stdout);
+    expect(compilerEntries).toEqual([
+      "extensions/demo/index",
+      "extensions/demo/setup-entry",
+      "extensions/packaged/index",
+      "extensions/packaged/setup-entry",
+    ]);
+    const distRoot = path.join(repoRoot, "dist");
+    for (const entry of compilerEntries) {
+      const output = path.join(distRoot, `${entry}.js`);
+      fs.mkdirSync(path.dirname(output), { recursive: true });
+      fs.writeFileSync(output, "export {};\n");
+    }
+    copyBundledPluginMetadata({ repoRoot, env });
+    const builtPackage = JSON.parse(
+      fs.readFileSync(path.join(distRoot, "extensions/demo/package.json"), "utf8"),
+    );
+    expect(builtPackage.openclaw.extensions).toEqual(["./index.js"]);
+    expect(builtPackage.openclaw.setupEntry).toBe("./setup-entry.js");
+    expect(fs.existsSync(path.join(distRoot, "extensions/unselected"))).toBe(false);
+    expect(listExternalPluginLocalDistPackageDirs({ repoRoot, env })).toEqual([]);
+    const distEntry = path.join(distRoot, "entry.js");
+    const buildStampPath = path.join(distRoot, BUILD_STAMP_FILE);
+    fs.writeFileSync(distEntry, "export {};\n");
+    fs.writeFileSync(buildStampPath, "{}\n");
+    expect(
+      resolveBuildRequirement({
+        cwd: repoRoot,
+        env,
+        fs,
+        distRoot,
+        distEntry,
+        buildStampPath,
+        configFiles: [],
+        sourceRoots: [],
+        spawnSync: () => ({ status: 1 }),
+      }),
+    ).toEqual({ shouldBuild: false, reason: "clean" });
   });
 
   it("performs no writes when Docker owns the selected build", async () => {

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   collectChannelConfigDoctorBuildEntries,
+  collectPluginDeclarationSourceEntries,
   collectRootPackageExcludedExtensionDirs,
   DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV,
   listBundledPluginBuildEntries,
@@ -28,6 +29,28 @@ function pickEntries(entries: Record<string, string>, keys: readonly string[]) {
 }
 
 describe("bundled plugin build entries", () => {
+  it("selects typed barrels and manifest exports rather than every runtime sidecar", () => {
+    const sources = [
+      "./index.ts",
+      "./api.ts",
+      "./runtime-api.ts",
+      "./contract-api.ts",
+      "./client.ts",
+      "./types.ts",
+      "./runtime-helper.ts",
+      "./setup-entry.ts",
+    ];
+    expect(
+      collectPluginDeclarationSourceEntries(
+        {
+          exports: { "./client": { types: "./dist/client.d.ts", import: "./dist/client.js" } },
+          types: "./dist/types.d.ts",
+        },
+        sources,
+      ),
+    ).toEqual(["./api.ts", "./runtime-api.ts", "./contract-api.ts", "./client.ts", "./types.ts"]);
+  });
+
   it("retains manifest-owned config repairs independently of runtime package exclusions", () => {
     const cwd = tempDirs.make("openclaw-config-doctor-entries-");
     const pluginDir = path.join(cwd, "extensions", "external-owner");

--- a/test/scripts/check-built-plugin-control-plane-modules.test.ts
+++ b/test/scripts/check-built-plugin-control-plane-modules.test.ts
@@ -12,10 +12,25 @@ import {
 
 const roots: string[] = [];
 
-function makeRoot(): string {
+function makeRoot(extension = ".js"): string {
   const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-control-plane-"));
   roots.push(rootDir);
   fs.writeFileSync(path.join(rootDir, "package.json"), '{"type":"module"}\n');
+  if (extension === ".cjs") {
+    write(rootDir, "extensions/demo/openclaw.plugin.json", '{"id":"demo"}');
+    write(rootDir, "extensions/demo/index.ts", "export {};\n");
+    write(
+      rootDir,
+      "extensions/demo/package.json",
+      JSON.stringify({
+        openclaw: {
+          extensions: ["./index.ts"],
+          build: { bundledDist: false, runtimeFormat: "cjs" },
+          release: { publishToNpm: true },
+        },
+      }),
+    );
+  }
   return rootDir;
 }
 
@@ -33,56 +48,71 @@ afterEach(() => {
 });
 
 describe("built plugin control-plane module loads", () => {
-  it("lists exact contract files and channel legacy setup references", () => {
-    const rootDir = makeRoot();
-    write(rootDir, "dist/extensions/demo/doctor-contract-api.js", "export const ok = true;\n");
-    write(rootDir, "dist/extensions/demo/contract-api.js", "export const ok = true;\n");
+  it.each([".js", ".cjs"])(
+    "lists exact %s contracts and channel legacy setup references",
+    (extension) => {
+      const rootDir = makeRoot(extension);
+      write(
+        rootDir,
+        `dist/extensions/demo/doctor-contract-api${extension}`,
+        "export const ok = true;\n",
+      );
+      write(rootDir, `dist/extensions/demo/contract-api${extension}`, "export const ok = true;\n");
+      write(
+        rootDir,
+        `dist/extensions/demo/provider-contract-api${extension}`,
+        "export const ignored = true;\n",
+      );
+      write(
+        rootDir,
+        `dist/extensions/demo/setup-entry${extension}`,
+        [
+          "const setup = {",
+          `  legacyStateMigrations: { specifier: "./legacy-state-migrations-api${extension}" },`,
+          `  legacySessionSurface: { specifier: "./legacy-session-surface-api${extension}" },`,
+          "};",
+          "export default setup;",
+        ].join("\n"),
+      );
+      write(
+        rootDir,
+        `dist/extensions/demo/legacy-state-migrations-api${extension}`,
+        "export {};\n",
+      );
+      write(rootDir, `dist/extensions/demo/legacy-session-surface-api${extension}`, "export {};\n");
+
+      expect(listBuiltPluginControlPlaneModules({ rootDir })).toEqual([
+        {
+          pluginId: "demo",
+          kind: "contract",
+          relativePath: `dist/extensions/demo/contract-api${extension}`,
+        },
+        {
+          pluginId: "demo",
+          kind: "doctor-contract",
+          relativePath: `dist/extensions/demo/doctor-contract-api${extension}`,
+        },
+        {
+          pluginId: "demo",
+          kind: "channel-legacy-session-surface",
+          relativePath: `dist/extensions/demo/legacy-session-surface-api${extension}`,
+        },
+        {
+          pluginId: "demo",
+          kind: "channel-legacy-state-migrations",
+          relativePath: `dist/extensions/demo/legacy-state-migrations-api${extension}`,
+        },
+      ]);
+    },
+  );
+
+  it.each([".js", ".cjs"])("accepts synchronously requireable %s artifacts", (extension) => {
+    const rootDir = makeRoot(extension);
     write(
       rootDir,
-      "dist/extensions/demo/provider-contract-api.js",
-      "export const ignored = true;\n",
+      `dist/extensions/demo/doctor-contract-api${extension}`,
+      extension === ".cjs" ? "exports.ok = true;\n" : "export const ok = true;\n",
     );
-    write(
-      rootDir,
-      "dist/extensions/demo/setup-entry.js",
-      [
-        "const setup = {",
-        '  legacyStateMigrations: { specifier: "./legacy-state-migrations-api.js" },',
-        '  legacySessionSurface: { specifier: "./legacy-session-surface-api.js" },',
-        "};",
-        "export default setup;",
-      ].join("\n"),
-    );
-    write(rootDir, "dist/extensions/demo/legacy-state-migrations-api.js", "export {};\n");
-    write(rootDir, "dist/extensions/demo/legacy-session-surface-api.js", "export {};\n");
-
-    expect(listBuiltPluginControlPlaneModules({ rootDir })).toEqual([
-      {
-        pluginId: "demo",
-        kind: "contract",
-        relativePath: "dist/extensions/demo/contract-api.js",
-      },
-      {
-        pluginId: "demo",
-        kind: "doctor-contract",
-        relativePath: "dist/extensions/demo/doctor-contract-api.js",
-      },
-      {
-        pluginId: "demo",
-        kind: "channel-legacy-session-surface",
-        relativePath: "dist/extensions/demo/legacy-session-surface-api.js",
-      },
-      {
-        pluginId: "demo",
-        kind: "channel-legacy-state-migrations",
-        relativePath: "dist/extensions/demo/legacy-state-migrations-api.js",
-      },
-    ]);
-  });
-
-  it("accepts synchronously requireable ESM artifacts", () => {
-    const rootDir = makeRoot();
-    write(rootDir, "dist/extensions/demo/doctor-contract-api.js", "export const ok = true;\n");
 
     expect(() => verifyBuiltPluginControlPlaneModules({ rootDir })).not.toThrow();
   });
@@ -112,50 +142,78 @@ describe("built plugin control-plane module loads", () => {
 });
 
 describe("built doctor contract closures", () => {
-  it("follows chunk edges to a forbidden runtime dependency", () => {
-    const rootDir = makeRoot();
-    write(
-      rootDir,
-      "dist/extensions/demo/doctor-contract-api.js",
-      'import { rule } from "../../token-chunk.js";\nexport const rules = [rule];\n',
-    );
-    write(rootDir, "dist/token-chunk.js", 'export { rule } from "./exec-chunk.js";\n');
-    write(rootDir, "dist/exec-chunk.js", 'import "execa";\nexport const rule = 1;\n');
-
-    expect(
-      collectBuiltDoctorContractClosureViolations(listBuiltPluginControlPlaneModules({ rootDir }), {
+  it.each([".js", ".cjs"])(
+    "follows %s chunk edges to a forbidden runtime dependency",
+    (extension) => {
+      const rootDir = makeRoot(extension);
+      write(
         rootDir,
-      }),
-    ).toEqual([
-      {
-        pluginId: "demo",
-        kind: "doctor-contract",
-        relativePath: "dist/extensions/demo/doctor-contract-api.js",
-        dependency: "execa",
-        importerPath: "dist/exec-chunk.js",
-      },
-    ]);
-  });
-
-  it("ignores lazy edges and non-doctor contract surfaces", () => {
-    const rootDir = makeRoot();
-    // A dynamic import is never paid at enumeration time, and the general contract
-    // surface may legitimately spawn commands (matrix probes its SDK packages).
-    write(
-      rootDir,
-      "dist/extensions/demo/doctor-contract-api.js",
-      'export const load = () => import("execa");\n',
-    );
-    write(
-      rootDir,
-      "dist/extensions/demo/contract-api.js",
-      'import "execa";\nexport const a = 1;\n',
-    );
-
-    expect(
-      collectBuiltDoctorContractClosureViolations(listBuiltPluginControlPlaneModules({ rootDir }), {
+        `dist/extensions/demo/doctor-contract-api${extension}`,
+        extension === ".cjs"
+          ? 'module.exports = require("../../token-chunk.cjs");'
+          : 'export * from "../../token-chunk.js";',
+      );
+      write(
         rootDir,
-      }),
-    ).toEqual([]);
-  });
+        `dist/token-chunk${extension}`,
+        extension === ".cjs"
+          ? 'module.exports = require("./exec-chunk.cjs");'
+          : 'export * from "./exec-chunk.js";',
+      );
+      write(
+        rootDir,
+        `dist/exec-chunk${extension}`,
+        extension === ".cjs"
+          ? 'const exec = require("execa"); exports.rule = exec;'
+          : 'import "execa"; export const rule = 1;',
+      );
+
+      expect(
+        collectBuiltDoctorContractClosureViolations(
+          listBuiltPluginControlPlaneModules({ rootDir }),
+          { rootDir },
+        ),
+      ).toEqual([
+        {
+          pluginId: "demo",
+          kind: "doctor-contract",
+          relativePath: `dist/extensions/demo/doctor-contract-api${extension}`,
+          dependency: "execa",
+          importerPath: `dist/exec-chunk${extension}`,
+        },
+      ]);
+    },
+  );
+
+  it.each([".js", ".cjs"])(
+    "ignores lazy %s edges and non-doctor contract surfaces",
+    (extension) => {
+      const rootDir = makeRoot(extension);
+      // A dynamic import is never paid at enumeration time, and the general contract
+      // surface may legitimately spawn commands (matrix probes its SDK packages).
+      write(
+        rootDir,
+        `dist/extensions/demo/doctor-contract-api${extension}`,
+        extension === ".cjs"
+          ? 'exports.load = () => require("execa");'
+          : 'export const load = () => import("execa");',
+      );
+      write(
+        rootDir,
+        `dist/extensions/demo/contract-api${extension}`,
+        extension === ".cjs"
+          ? 'require("execa"); exports.a = 1;'
+          : 'import "execa"; export const a = 1;',
+      );
+
+      expect(
+        collectBuiltDoctorContractClosureViolations(
+          listBuiltPluginControlPlaneModules({ rootDir }),
+          {
+            rootDir,
+          },
+        ),
+      ).toEqual([]);
+    },
+  );
 });

--- a/test/scripts/check-gateway-watch-regression.test.ts
+++ b/test/scripts/check-gateway-watch-regression.test.ts
@@ -93,6 +93,7 @@ describe("check-gateway-watch-regression", () => {
       cpuMs: 0,
       distRuntimeByteGrowth,
       distRuntimeFileGrowth: 0,
+      removedPaths: 0,
       options: {
         cpuFailMs: 8000,
         cpuWarnMs: 1000,
@@ -125,6 +126,38 @@ describe("check-gateway-watch-regression", () => {
     expect(second.text).toHaveLength(8);
     expect(WATCH_LOG_CAPTURE_MAX_CHARS).toBeGreaterThan(1024);
   });
+
+  it.each([
+    { reason: "missing_bundled_plugin_dist_entry", removedPaths: 0 },
+    { reason: null, removedPaths: 2932 },
+    { reason: "dirty_watched_tree", removedPaths: 0 },
+  ])(
+    "rejects prebuilt artifact mutation: $reason / $removedPaths removed",
+    ({ reason, removedPaths }) => {
+      const findings = collectGatewayWatchFindings({
+        cpuMs: 0,
+        distRuntimeByteGrowth: -1024,
+        distRuntimeFileGrowth: 0,
+        removedPaths,
+        options: parseArgs(["--skip-build"]),
+        watchBuildReason: reason,
+        watchTriggeredBuild: reason !== null,
+        watchResult: {
+          idleCpuMs: 0,
+          readyBeforeWindow: true,
+          spawnError: null,
+          timingFileMissing: false,
+        },
+      });
+      expect(findings.failures).toEqual([
+        removedPaths > 0
+          ? "gateway:watch removed 2932 prebuilt artifact paths"
+          : reason === "dirty_watched_tree"
+            ? "gateway:watch invalid local run: dirty watched source tree forced a rebuild during the watch window"
+            : "gateway:watch unexpectedly rebuilt prebuilt artifacts (missing_bundled_plugin_dist_entry)",
+      ]);
+    },
+  );
 
   it("keeps build-regression detection after diagnostic logs truncate", () => {
     const detected = updateWatchBuildDetection(
@@ -195,6 +228,7 @@ describe("check-gateway-watch-regression", () => {
       cpuMs: 0,
       distRuntimeByteGrowth: 0,
       distRuntimeFileGrowth: 0,
+      removedPaths: 0,
       options: {
         cpuFailMs: 8000,
         cpuWarnMs: 1000,
@@ -223,6 +257,7 @@ describe("check-gateway-watch-regression", () => {
       cpuMs: 0,
       distRuntimeByteGrowth: 0,
       distRuntimeFileGrowth: 0,
+      removedPaths: 0,
       options: {
         cpuFailMs: 8000,
         cpuWarnMs: 1000,
@@ -254,6 +289,7 @@ describe("check-gateway-watch-regression", () => {
       cpuMs: 0,
       distRuntimeByteGrowth: 0,
       distRuntimeFileGrowth: 0,
+      removedPaths: 0,
       options: {
         cpuFailMs: 8000,
         cpuWarnMs: 1000,

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -314,7 +314,21 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
         const groups = plan
           .flatMap((job) => job.groups)
           .filter((group) => group.shard_name.startsWith(`${target.shardName}-hosted-`));
-        expect(groups).toHaveLength(3);
+        // Hosted preparation alone exceeds the serial budget, so its consumer
+        // stays alone; hybrid retains its existing balanced three-way split.
+        expect(groups).toHaveLength(runnerBackend === "github" ? 4 : 3);
+        if (runnerBackend === "github") {
+          expect(groups.find((group) => group.pretestBuildMode)?.includePatterns).toEqual([
+            consumer,
+          ]);
+          expect(
+            plan
+              .filter((job) => job.predictedSeconds! > 150)
+              .every(
+                (job) => job.groups.length === 1 && job.groups[0]!.includePatterns?.length === 1,
+              ),
+          ).toBe(true);
+        }
         expect(
           groups
             .filter((group) => group.pretestBuildMode === "runtime")

--- a/test/scripts/claude-agent-sdk-assets.test.ts
+++ b/test/scripts/claude-agent-sdk-assets.test.ts
@@ -1,0 +1,228 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { build } from "tsdown";
+import { afterEach, describe, expect, it } from "vitest";
+import { createClaudeAgentSdkAssetPlugin } from "../../scripts/lib/claude-agent-sdk-assets.mts";
+
+const sdkPackage = "@anthropic-ai/claude-agent-sdk";
+const sdkSourceDir = path.dirname(createRequire(import.meta.url).resolve(sdkPackage));
+const tempDirs: string[] = [];
+
+async function createFixture() {
+  const rootDir = await fs.realpath(
+    await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sdk-assets-")),
+  );
+  tempDirs.push(rootDir);
+  const sdkDir = path.join(rootDir, "node_modules", sdkPackage);
+  await fs.cp(sdkSourceDir, sdkDir, {
+    recursive: true,
+    filter: (source) => path.basename(source) !== "node_modules",
+  });
+  await fs.writeFile(path.join(rootDir, "package.json"), '{"type":"module"}\n');
+  const entries: Record<string, string> = {};
+  for (const prefix of ["", "extensions/anthropic/"]) {
+    for (const kind of ["dynamic", "static"]) {
+      const name = `${prefix}${kind}`;
+      const source = path.join(rootDir, `${name.replaceAll("/", "-")}.mjs`);
+      const specifier = JSON.stringify(sdkPackage);
+      const code =
+        kind === "dynamic"
+          ? `export const loadSdk = () => import(${specifier});
+             export async function* queryExports() {
+               const { query } = await import(${specifier});
+               yield query;
+             }`
+          : `import * as sdk from ${specifier}; export { sdk }; export * from ${specifier};`;
+      await fs.writeFile(source, code);
+      entries[name] = source;
+    }
+  }
+  return { rootDir, sdkDir, entries };
+}
+
+// This child implements only the fixture side of the published SDK stdio contract.
+// The real SDK owns framing, callback routing, and reuse of the same process.
+const fixtureCli = `
+  import assert from "node:assert/strict";
+  import { createInterface } from "node:readline";
+  const send = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
+  let hookId;
+  let turn = 0;
+  for await (const line of createInterface({ input: process.stdin })) {
+    const message = JSON.parse(line);
+    if (message.type === "control_request" && message.request.subtype === "initialize") {
+      hookId = message.request.hooks.PreToolUse[0].hookCallbackIds[0];
+      send({ type: "control_response", response: {
+        subtype: "success", request_id: message.request_id, response: { commands: [], models: [] }
+      }});
+    } else if (message.type === "user") {
+      assert.ok(hookId);
+      turn++;
+      send({ type: "control_request", request_id: "hook", request: {
+        subtype: "hook_callback", callback_id: hookId, tool_use_id: "tool-" + turn,
+        input: { hook_event_name: "PreToolUse", tool_name: "Read", tool_input: { file_path: "fixture.txt" } }
+      }});
+    } else if (message.type === "control_response" && message.response.request_id === "hook") {
+      assert.equal(message.response.response.continue, true);
+      send({ type: "control_request", request_id: "permission", request: {
+        subtype: "can_use_tool", tool_name: "Read", input: { file_path: "fixture.txt" }, tool_use_id: "tool-" + turn
+      }});
+    } else if (message.type === "control_response" && message.response.request_id === "permission") {
+      assert.equal(message.response.response.behavior, "deny");
+      send({ type: "result", subtype: "success", is_error: false,
+        result: "denied-" + turn, session_id: "fixture-session" });
+    } else {
+      throw new Error("Unexpected fixture protocol message: " + message.type);
+    }
+  }
+`;
+
+const runtimeProbe = `
+  import assert from "node:assert/strict";
+  import { spawn } from "node:child_process";
+  import { PassThrough } from "node:stream";
+  const [entry, nestedEntry, staticEntry, nestedStaticEntry, executable] = process.argv.slice(1);
+  const dynamicModules = await Promise.all([entry, nestedEntry].map((file) => import(file)));
+  const sdk = await dynamicModules[0].loadSdk();
+  for (const module of dynamicModules) {
+    assert.equal(await module.loadSdk(), sdk);
+    for await (const query of module.queryExports()) assert.equal(query, sdk.query);
+  }
+  for (const file of [staticEntry, nestedStaticEntry]) {
+    const module = await import(file);
+    assert.equal(module.sdk, sdk);
+    assert.deepEqual(Object.keys(module).filter((name) => name !== "sdk").sort(), Object.keys(sdk).sort());
+    for (const [name, value] of Object.entries(sdk)) assert.equal(module[name], value);
+  }
+  assert.throws(() => sdk.query({ prompt: "fixture" }), /Native CLI binary/);
+  let spawns = 0, permissions = 0, hooks = 0;
+  const prompts = new PassThrough({ objectMode: true });
+  const query = sdk.query({ prompt: prompts, options: {
+    pathToClaudeCodeExecutable: executable,
+    executable: process.execPath,
+    cwd: process.cwd(), env: process.env, settingSources: [],
+    spawnClaudeCodeProcess(options) {
+      spawns++;
+      assert.equal(options.command, process.execPath);
+      assert.equal(options.args[0], executable);
+      assert.ok(options.args.includes("--permission-prompt-tool"));
+      return spawn(options.command, options.args, {
+        cwd: options.cwd, env: options.env, signal: options.signal, stdio: ["pipe", "pipe", "inherit"]
+      });
+    },
+    canUseTool: async (name, input) => {
+      assert.equal(name, "Read");
+      assert.equal(input.file_path, "fixture.txt");
+      permissions++;
+      return { behavior: "deny", message: "Fixture denied the read." };
+    },
+    hooks: { PreToolUse: [{ hooks: [async (input) => {
+      assert.equal(input.hook_event_name, "PreToolUse");
+      hooks++;
+      return { continue: true };
+    }] }] }
+  }});
+  const prompt = () => prompts.write({ type: "user", session_id: "", parent_tool_use_id: null,
+    message: { role: "user", content: "fixture" } });
+  const results = [];
+  prompt();
+  try {
+    for await (const message of query) {
+      if (message.type !== "result") continue;
+      results.push(message.result);
+      if (results.length === 1) prompt();
+      else prompts.end();
+    }
+  } finally { query.close(); prompts.destroy(); }
+  process.stdout.write(JSON.stringify({ results, spawns, permissions, hooks }));
+`;
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("Claude Agent SDK package assets", () => {
+  it("preserves root and nested SDK imports through tsdown without native packages", async () => {
+    const { rootDir, sdkDir, entries } = await createFixture();
+    const sourceManifest = JSON.parse(await fs.readFile(path.join(sdkDir, "package.json"), "utf8"));
+    const outputDir = path.join(rootDir, "artifact");
+    // Use the production build wrapper: its dependency resolver forwards Rolldown
+    // resolutions and can lose forced-relative metadata when it wraps the SDK resolver.
+    await build({
+      config: false,
+      cwd: rootDir,
+      entry: entries,
+      outDir: outputDir,
+      outExtensions: () => ({ js: ".js" }),
+      fixedExtension: false,
+      dts: false,
+      logLevel: "silent",
+      plugins: [createClaudeAgentSdkAssetPlugin(rootDir)],
+    });
+    const assetDir = path.join(outputDir, "extensions/anthropic/agent-sdk");
+    const packagedManifest = JSON.parse(
+      await fs.readFile(path.join(assetDir, "package.json"), "utf8"),
+    );
+    const { optionalDependencies, ...expectedManifest } = sourceManifest;
+    expect(Object.keys(optionalDependencies).length).toBeGreaterThan(0);
+    expect(packagedManifest).toEqual(expectedManifest);
+    for (const file of [...sourceManifest.files, "LICENSE.md", "README.md"]) {
+      expect(await fs.readFile(path.join(assetDir, file))).toEqual(
+        await fs.readFile(path.join(sdkDir, file)),
+      );
+    }
+    // Remove the source dependency tree: bare imports or accidental native fallback must fail.
+    await fs.rm(path.join(rootDir, "node_modules"), { recursive: true });
+    const executable = path.join(rootDir, "installed-claude.mjs");
+    await fs.writeFile(executable, fixtureCli);
+    const output = execFileSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        runtimeProbe,
+        pathToFileURL(path.join(outputDir, "dynamic.js")).href,
+        pathToFileURL(path.join(outputDir, "extensions/anthropic/dynamic.js")).href,
+        pathToFileURL(path.join(outputDir, "static.js")).href,
+        pathToFileURL(path.join(outputDir, "extensions/anthropic/static.js")).href,
+        executable,
+      ],
+      {
+        cwd: rootDir,
+        timeout: 15_000,
+        encoding: "utf8",
+        env: {
+          HOME: rootDir,
+          USERPROFILE: rootDir,
+          CLAUDE_CONFIG_DIR: rootDir,
+          PATH: process.env.PATH,
+          SystemRoot: process.env.SystemRoot,
+          TMPDIR: rootDir,
+          TEMP: rootDir,
+        },
+      },
+    );
+    expect(JSON.parse(output)).toEqual({
+      results: ["denied-1", "denied-2"],
+      spawns: 1,
+      permissions: 2,
+      hooks: 2,
+    });
+  });
+
+  it.each(["optionalDependencies", "dependencies"])(
+    "rejects an unreviewed non-native %s entry rather than silently dropping its runtime",
+    async (field) => {
+      const { rootDir, sdkDir } = await createFixture();
+      const manifestPath = path.join(sdkDir, "package.json");
+      const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+      manifest[field] = { ...manifest[field], "fixture-runtime": "1.0.0" };
+      await fs.writeFile(manifestPath, JSON.stringify(manifest));
+      expect(() => createClaudeAgentSdkAssetPlugin(rootDir)).toThrow("dependency layout changed");
+    },
+  );
+});

--- a/test/scripts/tsdown-config.test.ts
+++ b/test/scripts/tsdown-config.test.ts
@@ -5,7 +5,10 @@ import { createRequire, isBuiltin } from "node:module";
 import path from "node:path";
 import { build } from "tsdown";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { collectRootPackageExcludedExtensionDirs } from "../../scripts/lib/bundled-plugin-build-entries.mjs";
+import {
+  collectRootPackageExcludedExtensionDirs,
+  DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV,
+} from "../../scripts/lib/bundled-plugin-build-entries.mjs";
 import { publicPluginSdkEntrypoints } from "../../scripts/lib/plugin-sdk-entries.mts";
 import {
   TSDOWN_PACKAGE_CONFIG_GROUP,
@@ -13,6 +16,7 @@ import {
   TSDOWN_UNIFIED_DTS_CONFIG_GROUPS,
 } from "../../scripts/lib/tsdown-config-groups.mts";
 import { WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID } from "../../scripts/lib/worker-deploy-build-plugin.mts";
+import { importFreshModule } from "../../src/plugin-sdk/test-helpers/import-fresh.js";
 import buildConfigs from "../../tsdown.config.ts";
 import { copyFsSafePackageFixture } from "./fs-safe-package.test-support.js";
 import { createScriptTestHarness } from "./test-helpers.js";
@@ -76,11 +80,20 @@ if (loaded.length) assert(loaded[0].startsWith(path.dirname(rootDir) + path.sep)
 
 describe("tsdown config", () => {
   it.each([false, true])(
-    "runs the bundled memory store with only production dependencies (verbose=%s)",
+    "runs the Docker-selected memory store with only production dependencies (verbose=%s)",
     async (verbose) => {
       vi.stubEnv("OPENCLAW_BUILD_VERBOSE", verbose ? "1" : "0");
-      const selected = configs.find((config) => config.name === TSDOWN_UNIFIED_CONFIG_GROUP);
       const entryName = "extensions/memory-lancedb/lancedb-store";
+      const defaultConfig = configs.find((config) => config.name === TSDOWN_UNIFIED_CONFIG_GROUP);
+      expect(defaultConfig?.entry).not.toHaveProperty(entryName);
+      vi.stubEnv(DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV, "memory-lancedb");
+      // Selection is captured during config evaluation; keep the default graph untouched.
+      const { default: selectedConfigs } = await importFreshModule<
+        typeof import("../../tsdown.config.ts")
+      >(import.meta.url, `../../tsdown.config.ts?docker-memory-lancedb=${verbose}`);
+      const selected = selectedConfigs.find(
+        (config) => config.name === TSDOWN_UNIFIED_CONFIG_GROUP,
+      );
       const source = (selected?.entry as Record<string, string> | undefined)?.[entryName];
       expect(source).toBeDefined();
       const root = fs.realpathSync(createTempDir("openclaw-tsdown-memory-"));

--- a/test/scripts/tsdown-config.test.ts
+++ b/test/scripts/tsdown-config.test.ts
@@ -5,6 +5,7 @@ import { createRequire, isBuiltin } from "node:module";
 import path from "node:path";
 import { build } from "tsdown";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { collectRootPackageExcludedExtensionDirs } from "../../scripts/lib/bundled-plugin-build-entries.mjs";
 import { publicPluginSdkEntrypoints } from "../../scripts/lib/plugin-sdk-entries.mts";
 import {
   TSDOWN_PACKAGE_CONFIG_GROUP,
@@ -453,7 +454,7 @@ describe("tsdown config", () => {
       );
       expect(selected).toBeDefined();
       const packages = [
-        "@anthropic-ai/claude-agent-sdk",
+        ...(declarations ? ["@anthropic-ai/claude-agent-sdk"] : []),
         "@anthropic-ai/vertex-sdk",
         "@slack/bolt",
         "@slack/web-api",
@@ -579,16 +580,31 @@ describe("tsdown config", () => {
     }
   });
 
-  it("assigns every TypeScript runtime entry to exactly one bounded declaration graph", () => {
-    const unifiedRuntimeConfig = configs.find(
-      (entry) => entry.name === TSDOWN_UNIFIED_CONFIG_GROUP,
+  it("keeps excluded plugins out of the unified graph without dropping host helpers", () => {
+    const runtime = configs.find((entry) => entry.name === TSDOWN_UNIFIED_CONFIG_GROUP);
+    const entries = runtime?.entry as Record<string, string>;
+    const excluded = collectRootPackageExcludedExtensionDirs();
+    expect(
+      Object.keys(entries).filter(
+        (name) => name.startsWith("extensions/") && excluded.has(name.split("/")[1]!),
+      ),
+    ).toEqual([]);
+    expect(entries["plugin-sdk/codex-mcp-projection"]).toBe(
+      "src/plugin-sdk/codex-mcp-projection.ts",
     );
-    const runtimeSources = Object.values(unifiedRuntimeConfig?.entry ?? {}).map((source) => {
-      const sourceString = String(source);
-      return (
-        path.isAbsolute(sourceString) ? path.relative(process.cwd(), sourceString) : sourceString
-      ).replaceAll("\\", "/");
-    });
+    expect(entries["plugin-sdk/codex-session-transcript-runtime"]).toBe(
+      "src/plugin-sdk/codex-session-transcript-runtime.ts",
+    );
+    expect(entries["plugins/public-surface-runtime"]).toBe("src/plugins/public-surface-runtime.ts");
+    expect(Object.values(entries)).toEqual(
+      expect.arrayContaining([
+        "extensions/vault/vault-secret-id.js",
+        "extensions/vault/vault-secret-ref-resolver.js",
+      ]),
+    );
+  });
+
+  it("emits bounded public declarations without private runtime roots", () => {
     const declarationSources = TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.flatMap((name) => {
       const declarationConfig = configs.find((entry) => entry.name === name);
       const dts = declarationConfig?.dts;
@@ -599,19 +615,28 @@ describe("tsdown config", () => {
       return dts.entry;
     });
 
-    expect(runtimeSources).toEqual(
+    expect(declarationSources).toEqual(
       expect.arrayContaining([
-        "extensions/vault/vault-secret-id.js",
-        "extensions/vault/vault-secret-ref-resolver.js",
+        "src/index.ts",
+        ...publicPluginSdkEntrypoints.map((entry) => `src/plugin-sdk/${entry}.ts`),
+        "extensions/anthropic/api.ts",
+        "extensions/anthropic/contract-api.ts",
+        "extensions/memory-core/api.ts",
+        "extensions/memory-core/runtime-api.ts",
       ]),
     );
-    expect(declarationSources.toSorted()).toEqual(
-      runtimeSources.filter((source) => /\.[cm]?tsx?$/u.test(source)).toSorted(),
-    );
+    expect(
+      declarationSources.filter(
+        (source) => source.startsWith("src/") && !source.startsWith("src/plugin-sdk/"),
+      ),
+    ).toEqual(["src/index.ts"]);
+    expect(declarationSources).not.toContain("extensions/anthropic/agent-sdk-user-input.ts");
+    expect(declarationSources).not.toContain("extensions/anthropic/agent-sdk-runtime-helpers.ts");
+    expect(declarationSources.every((source) => /\.[cm]?tsx?$/u.test(source))).toBe(true);
     expect(new Set(declarationSources).size).toBe(declarationSources.length);
   });
 
-  it("keeps public SDK declarations together and isolates private runtime declarations", () => {
+  it("keeps public SDK types canonical without emitting private runtime declarations", () => {
     const [publicDeclarationSources = [], privateDeclarationSources = []] =
       TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.filter((name) =>
         name.startsWith("openclaw-dts-plugin-sdk-"),
@@ -620,11 +645,13 @@ describe("tsdown config", () => {
         return dts && typeof dts === "object" && Array.isArray(dts.entry) ? dts.entry : [];
       });
     const publicSources = publicPluginSdkEntrypoints.map((entry) => `src/plugin-sdk/${entry}.ts`);
-    const publicSourceSet = new Set(publicSources);
-
     expect(publicDeclarationSources.toSorted()).toEqual(publicSources.toSorted());
-    expect(privateDeclarationSources.some((source) => publicSourceSet.has(source))).toBe(false);
-    expect(privateDeclarationSources).toContain("src/plugin-sdk/tts-runtime.ts");
+    expect(privateDeclarationSources).toEqual([]);
+    const runtime = configs.find((entry) => entry.name === TSDOWN_UNIFIED_CONFIG_GROUP);
+    expect(runtime?.entry).toHaveProperty(
+      "plugin-sdk/tts-runtime",
+      "src/plugin-sdk/tts-runtime.ts",
+    );
   });
 
   it("builds self-contained worker deploy executables with every dependency bundled", () => {

--- a/test/scripts/tsdown-declaration-fixture.ts
+++ b/test/scripts/tsdown-declaration-fixture.ts
@@ -172,7 +172,10 @@ export function createFixture(
     // Exercise every real extension partition, even in the small compiler fixture.
     for (const id of ["fixture-a", "fixture-b", "fixture-c", "fixture-d", "fixture-e"]) {
       write(`extensions/${id}/openclaw.plugin.json`, JSON.stringify({ id }));
-      write(`extensions/${id}/package.json`, JSON.stringify({ name: `@openclaw/${id}` }));
+      write(
+        `extensions/${id}/package.json`,
+        JSON.stringify({ name: `@openclaw/${id}`, exports: { ".": "./dist/index.js" } }),
+      );
       write(`extensions/${id}/index.ts`, "export {};\n");
     }
   }

--- a/test/scripts/tsdown-runtime-config.test.ts
+++ b/test/scripts/tsdown-runtime-config.test.ts
@@ -366,7 +366,7 @@ describe("tsdown config", () => {
     expect(externalize("jimp", undefined, false)).toBe(true);
   });
 
-  it("always bundles plugin SDK package-local runtime dependencies", () => {
+  it("bundles SDK-owned helpers while retaining fs-safe package ownership", () => {
     const unifiedGraph = requireUnifiedDistGraph();
     const alwaysBundle = unifiedGraph.deps?.alwaysBundle;
 
@@ -374,6 +374,8 @@ describe("tsdown config", () => {
       throw new Error("expected unified graph alwaysBundle predicate");
     }
 
+    expect(alwaysBundle("@openclaw/fs-safe")).toBe(false);
+    expect(alwaysBundle("@openclaw/fs-safe/path")).toBe(false);
     expect(alwaysBundle("openclaw/plugin-sdk/ssrf-runtime-internal")).toBe(true);
     expect(alwaysBundle("openclaw/plugin-sdk/ssrf-runtime")).toBe(false);
     expect(alwaysBundle("zod")).toBe(true);

--- a/test/scripts/verify-mac-node-worker-fs.test.ts
+++ b/test/scripts/verify-mac-node-worker-fs.test.ts
@@ -37,6 +37,7 @@ describe.skipIf(process.platform !== "darwin")("Mac worker bundled filesystem pr
     for (const bundle of bundles) {
       await bundle[Symbol.asyncDispose]();
     }
+    expect(fs.existsSync(path.join(compiled, "dist/native"))).toBe(false);
     fs.writeFileSync(path.join(compiled, "package.json"), '{"type":"module"}');
   });
 
@@ -169,5 +170,26 @@ registerHooks({
     expect(fs.readFileSync(path.join(home, "native-create-proof"), "utf8")).toBe(
       "bundled worker create proof\n",
     );
+  });
+
+  it("does not recover an omitted platform package from a stale dist native tree", () => {
+    const { packageRoot, home, native, nativePackage } = fixture();
+    const staleNative = path.join(
+      packageRoot,
+      "dist/native",
+      `${process.platform}-${process.arch}`,
+      "fs-safe-native.node",
+    );
+    fs.mkdirSync(path.dirname(staleNative), { recursive: true });
+    fs.copyFileSync(native, staleNative);
+    fs.rmSync(nativePackage.root, { recursive: true });
+    const result = probe(packageRoot, home);
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain("helper-unavailable");
+    expect(result.stderr).toContain(nativePackage.name);
+    expect(fs.readFileSync(path.join(home, "native-write-proof"), "utf8")).toBe(
+      "before replacement\n",
+    );
+    expect(fs.existsSync(path.join(home, "native-create-proof"))).toBe(false);
   });
 });

--- a/test/scripts/vitest-worker-artifacts.test.ts
+++ b/test/scripts/vitest-worker-artifacts.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { setImmediate as nextTurn } from "node:timers/promises";
@@ -29,6 +30,22 @@ import {
 
 const root = process.cwd();
 const it = createWorkerArtifactTest();
+const compilerModuleUrl = pathToFileURL(createRequire(import.meta.url).resolve("tsdown")).href;
+
+function interceptCompilerBuild(directory: string, source: string): string {
+  // Sync require hooks still use the CJS filesystem loader; a resolve-only data URL is not loadable.
+  const wrapper = writeFixture(
+    directory,
+    "tsdown-wrapper.mjs",
+    `import {build as compile} from ${JSON.stringify(compilerModuleUrl)};\n${source}`,
+  );
+  return `import {registerHooks} from 'node:module';
+registerHooks({resolve(specifier,context,nextResolve) {
+  return specifier==='tsdown'
+    ? {url:${JSON.stringify(pathToFileURL(wrapper).href)},format:'module',shortCircuit:true}
+    : nextResolve(specifier,context);
+}});`;
+}
 const compilerModule = "scripts/lib/vitest-worker-run.mts";
 const compilerEntry = "scripts/lib/vitest-worker-compiler.mts";
 const artifactsModule = "scripts/lib/vitest-worker-artifacts.mts";
@@ -132,9 +149,7 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
       expect(fs.existsSync(directory)).toBe(false);
     }));
 
-  it("rejects output altered after the real compiler returns before publishing a manifest", ({
-    workerArtifacts,
-  }) =>
+  it("rejects compiler output altered before publishing a manifest", ({ workerArtifacts }) =>
     workerArtifacts.fixtureLifetime.run(async () => {
       const { node } = workerArtifacts.createFixtureCommands();
       const directory = workerArtifacts.fixtureDirectory();
@@ -142,25 +157,24 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
       const preload = writeFixture(
         directory,
         "compiler-fault.mjs",
-        `
+        interceptCompilerBuild(
+          directory,
+          `
         import fs from 'node:fs';
         import path from 'node:path';
-        import Module from 'node:module';
-        const load=Module._load;
-        Module._load=function(id,...args) {
-          const mod=load.call(this,id,...args);
-          if(id!=='tsdown') return mod;
-          return {...mod,async build(options) {
-            const result=await mod.build(options);
-            fs.appendFileSync(path.join(options.outDir,'infra/runtime-process-entrypoints.js'),'altered after compiler');
-            fs.writeFileSync(${JSON.stringify(altered)},'real compiler returned');
-            return result;
-          }};
-        };
-      `,
+        export async function build(options) {
+          const result = await compile(options);
+          fs.appendFileSync(path.join(options.outDir,'infra/runtime-process-entrypoints.js'),'altered after compile');
+          fs.writeFileSync(${JSON.stringify(altered)},'compiler returned');
+          return result;
+        }
+        `,
+        ),
       );
       const owner = createVitestWorkerRun();
       try {
+        // Inject only into the actual native compiler entry, never the parent's
+        // module cache or a production build flag. node() joins this direct child.
         const result = await node([
           "--import",
           pathToFileURL(preload).href,
@@ -169,7 +183,7 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
         ]);
         expect(result.code).not.toBe(0);
         expect(result.stderr).toContain("Compiled subprocess artifact changed");
-        expect(fs.readFileSync(altered, "utf8")).toBe("real compiler returned");
+        expect(fs.readFileSync(altered, "utf8")).toBe("compiler returned");
         expect(fs.existsSync(path.join(owner.descriptor.directory, "manifest.json"))).toBe(false);
       } finally {
         await owner.dispose();
@@ -188,14 +202,16 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
         const preload = writeFixture(
           directory,
           "compiler-lifetime.mjs",
-          `
+          interceptCompilerBuild(
+            directory,
+            `
       import fs from 'node:fs';
       import path from 'node:path';
       import {spawn} from 'node:child_process';
-      import Module, {syncBuiltinESMExports} from 'node:module';
+      import {syncBuiltinESMExports} from 'node:module';
       const directory=${JSON.stringify(directory)}, mode=${JSON.stringify(mode)};
       const record=(name,value)=>fs.writeFileSync(path.join(directory,name),value);
-      const load=Module._load, write=fs.writeFileSync;
+      const write=fs.writeFileSync;
       const gate=()=>new Promise(resolve=>{
         const poll=setInterval(()=>{
           if(fs.existsSync(path.join(directory,'release'))) {clearInterval(poll);resolve();}
@@ -205,11 +221,8 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
           clearInterval(poll);process.exit(0);
         });
       });
-      Module._load=function(id,...args) {
-        const mod=load.call(this,id,...args);
-        if(id!=='tsdown') return mod;
-        return {...mod,async build(options) {
-          const result=await mod.build(options);
+      export async function build(options) {
+        const result=await compile(options);
         if(mode==='cancel while compiling') {
           record('compiling',String(process.pid));
           await gate();
@@ -231,9 +244,8 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
           await new Promise((resolve,reject)=>{leaf.once('message',resolve);leaf.once('error',reject);});
           leaf.unref();
         }
-          return result;
-        }};
-      };
+        return result;
+      }
       fs.writeFileSync=(filename,...args)=>{
         const result=write(filename,...args);
         if(path.basename(String(filename))==='manifest.json' && mode==='close before ready') {
@@ -243,6 +255,7 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
       };
       syncBuiltinESMExports();
     `,
+          ),
         );
         const driver = writeFixture(
           directory,
@@ -1188,6 +1201,35 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
       const initialDirectory = initial.descriptor.directory;
       try {
         const manifest = await prepareWorkers(initial);
+        expect(fs.existsSync(path.join(initialDirectory, "dist/native"))).toBe(false);
+        expect(Object.keys(manifest.outputs).some((name) => name.endsWith(".node"))).toBe(false);
+        // Observe the installed config before/after a real compiled parent import.
+        // A bundled second fs-safe instance would leave this observer at "auto".
+        const policy = await node(
+          [
+            "--input-type=module",
+            "--eval",
+            `import assert from 'node:assert/strict';
+             import {pathToFileURL} from 'node:url';
+             import {getFsSafeNativeConfig} from '@openclaw/fs-safe/config';
+             assert.equal(getFsSafeNativeConfig().mode,'auto');
+             await import(pathToFileURL(process.argv[1]));
+             assert.equal(getFsSafeNativeConfig().mode,'off');`,
+            path.join(initialDirectory, "dist/infra/sqlite-readonly-location.js"),
+          ],
+          fixture,
+          {
+            PATH: process.env.PATH,
+            SystemRoot: process.env.SystemRoot,
+            WINDIR: process.env.WINDIR,
+            HOME: fixture,
+            USERPROFILE: fixture,
+            TMPDIR: fixture,
+            TMP: fixture,
+            TEMP: fixture,
+          },
+        );
+        expect(policy.code, policy.stderr + policy.stdout).toBe(0);
         for (const filename of Object.keys(manifest.inputs)) {
           const target = path.join(fixture, path.relative(root, filename));
           fs.mkdirSync(path.dirname(target), { recursive: true });

--- a/test/scripts/worker-deploy-build-plugin.test.ts
+++ b/test/scripts/worker-deploy-build-plugin.test.ts
@@ -64,6 +64,16 @@ describe("worker deploy build plugin", () => {
     expect(transformed).not.toContain('requireUndici("undici")');
   });
 
+  it("leaves fs-safe native package resolution to the dependency", () => {
+    const nativePath = path.resolve("node_modules/@openclaw/fs-safe/dist/native.js");
+    const source = fs.readFileSync(nativePath, "utf8");
+    const plugin = createWorkerDeployBuildPlugin();
+
+    const transformed = plugin.transform.call({ error: fail }, source, nativePath);
+
+    expect(transformed).toBeNull();
+  });
+
   it("fails closed when the undici dispatcher bootstrap shape changes", () => {
     const dispatcherPath = path.resolve("src/infra/net/undici-dispatcher-options.ts");
     const source = fs.readFileSync(dispatcherPath, "utf8");

--- a/test/scripts/write-plugin-sdk-entry-dts.test.ts
+++ b/test/scripts/write-plugin-sdk-entry-dts.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   pluginSdkEntrypoints,
-  productionPluginSdkEntrypoints,
+  publicPluginSdkEntrypoints,
 } from "../../scripts/lib/plugin-sdk-entries.mts";
 import {
   createFixture,
@@ -98,8 +98,8 @@ describe("write-plugin-sdk-entry-dts", () => {
 
   it("publishes fresh canonical partitions with stable bytes and public nominal identity", () => {
     const { root, write, writeDeclarations, production, qa } = createFixture();
-    expect(production).toEqual(
-      expect.arrayContaining(productionPluginSdkEntrypoints.map((entry) => `plugin-sdk/${entry}`)),
+    expect(production.toSorted()).toEqual(
+      publicPluginSdkEntrypoints.map((entry) => `plugin-sdk/${entry}`).toSorted(),
     );
     expect(qa).toEqual(
       expect.arrayContaining(pluginSdkEntrypoints.map((entry) => `plugin-sdk/${entry}`)),

--- a/test/scripts/write-unified-entry-dts.test.ts
+++ b/test/scripts/write-unified-entry-dts.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { TSDOWN_NON_SDK_DTS_CONFIG_GROUPS } from "../../scripts/lib/tsdown-config-groups.mts";
@@ -133,6 +134,13 @@ describe("write-unified-entry-dts", () => {
     }
     write("dist/obsolete.d.ts", "obsolete root declaration");
     write("dist/extensions/removed/api.d.ts", "obsolete plugin declaration");
+    write("dist/extensions/anthropic/api.d.ts", "obsolete plugin API declaration");
+    write(
+      "dist/extensions/anthropic/agent-sdk-generated/old.d.ts",
+      "obsolete generated declaration",
+    );
+    const sdkAssetRoot = "dist/extensions/anthropic/agent-sdk";
+    write(`${sdkAssetRoot}/obsolete.d.ts`, "removed upstream SDK declaration");
     write(
       "consumer.ts",
       [
@@ -187,6 +195,29 @@ describe("write-unified-entry-dts", () => {
     }
     expect(fs.existsSync(path.join(root, "dist/obsolete.d.ts"))).toBe(false);
     expect(fs.existsSync(path.join(root, "dist/extensions/removed/api.d.ts"))).toBe(false);
+    expect(fs.existsSync(path.join(root, "dist/extensions/anthropic/api.d.ts"))).toBe(false);
+    expect(
+      fs.existsSync(path.join(root, "dist/extensions/anthropic/agent-sdk-generated/old.d.ts")),
+    ).toBe(false);
+    const sdkSource = path.dirname(
+      createRequire(import.meta.url).resolve("@anthropic-ai/claude-agent-sdk"),
+    );
+    const sourceManifest = JSON.parse(
+      fs.readFileSync(path.join(sdkSource, "package.json"), "utf8"),
+    );
+    const sdkFiles: string[] = [...sourceManifest.files, "LICENSE.md", "README.md"];
+    expect(fs.readdirSync(path.join(root, sdkAssetRoot)).toSorted()).toEqual(
+      [...sdkFiles, "package.json"].toSorted(),
+    );
+    for (const file of sdkFiles) {
+      expect(fs.readFileSync(path.join(root, sdkAssetRoot, file))).toEqual(
+        fs.readFileSync(path.join(sdkSource, file)),
+      );
+    }
+    const { optionalDependencies: _nativeCli, ...packagedManifest } = sourceManifest;
+    expect(
+      JSON.parse(fs.readFileSync(path.join(root, sdkAssetRoot, "package.json"), "utf8")),
+    ).toEqual(packagedManifest);
     for (const [file, bytes] of Object.entries(preserved)) {
       expect(fs.readFileSync(path.join(root, file), "utf8")).toBe(bytes);
     }
@@ -205,7 +236,12 @@ describe("write-unified-entry-dts", () => {
     expect(
       records
         .flatMap((record) => Object.keys(record.outputs))
-        .some((file) => file.includes(".app/") || file.includes("control-ui/")),
+        .some(
+          (file) =>
+            file.includes(".app/") ||
+            file.includes("control-ui/") ||
+            file.startsWith(`${sdkAssetRoot}/`),
+        ),
     ).toBe(false);
     const cached = treeHashes(cache);
     const before = treeHashes(path.join(root, "dist"));
@@ -220,6 +256,7 @@ describe("write-unified-entry-dts", () => {
     for (const [file, bytes] of Object.entries(preserved)) {
       write(file, bytes);
     }
+    write(`${sdkAssetRoot}/obsolete.d.ts`, "removed upstream SDK declaration");
     const repeated = runUnifiedBuild(root);
     expect(repeated.status, repeated.stdout + repeated.stderr).toBe(0);
     expect(

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,9 +7,7 @@ import {
   collectBundledPluginBuildEntries,
   collectChannelConfigDoctorBuildEntries,
   collectPluginDeclarationSourceEntries,
-  collectRootPackageExcludedExtensionDirs,
-  NON_PACKAGED_BUNDLED_PLUGIN_DIRS,
-  parseDockerSelectedPluginBuildIdFilter,
+  collectSourceCheckoutPluginBuildEntries,
 } from "./scripts/lib/bundled-plugin-build-entries.mjs";
 import { createClaudeAgentSdkAssetPlugin } from "./scripts/lib/claude-agent-sdk-assets.mts";
 import {
@@ -564,12 +562,8 @@ function shouldExternalizeTerminalCoreDependency(id: string): boolean {
 
 const coreDistEntries = buildCoreDistEntries();
 const dockerE2eHarnessEntries = buildDockerE2eHarnessEntries();
-const rootPackageExcludedPluginDirs = collectRootPackageExcludedExtensionDirs();
-const dockerSelectedPluginIds = parseDockerSelectedPluginBuildIdFilter();
-const rootBundledPluginBuildEntries = bundledPluginBuildEntries.filter(({ id }) =>
-  NON_PACKAGED_BUNDLED_PLUGIN_DIRS.has(id)
-    ? shouldBuildPrivateQaEntries
-    : !rootPackageExcludedPluginDirs.has(id) || dockerSelectedPluginIds?.has(id),
+const rootBundledPluginBuildEntries = collectSourceCheckoutPluginBuildEntries().filter(
+  ({ isolated }) => !isolated,
 );
 
 function buildUnifiedDistEntries(): Record<string, string> {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -6,8 +6,12 @@ import type { DtsOptions, UserConfig } from "tsdown";
 import {
   collectBundledPluginBuildEntries,
   collectChannelConfigDoctorBuildEntries,
+  collectPluginDeclarationSourceEntries,
+  collectRootPackageExcludedExtensionDirs,
   NON_PACKAGED_BUNDLED_PLUGIN_DIRS,
+  parseDockerSelectedPluginBuildIdFilter,
 } from "./scripts/lib/bundled-plugin-build-entries.mjs";
+import { createClaudeAgentSdkAssetPlugin } from "./scripts/lib/claude-agent-sdk-assets.mts";
 import {
   buildPluginSdkEntrySources,
   pluginSdkEntrypoints,
@@ -289,9 +293,6 @@ function withExternalPackageSubpaths(options: { neverBundle: string[] }) {
 
 const rootDependencyOptions = withExternalPackageSubpaths({
   neverBundle: [
-    // The root runtime loads the SDK as its own package; never inline a transitive
-    // copy and relocate its package identity or package-relative assets into dist.
-    "@anthropic-ai/claude-agent-sdk",
     "@anthropic-ai/vertex-sdk",
     "@discordjs/voice",
     "@larksuiteoapi/node-sdk",
@@ -324,7 +325,9 @@ function shouldNeverBundleDeclarationDependency(id: string): boolean {
   // Arrow's relative module augmentations must stay beside their package modules.
   return (
     shouldNeverBundleDependency(id) ||
-    ["zod", "apache-arrow"].some((name) => id === name || id.startsWith(`${name}/`))
+    ["@anthropic-ai/claude-agent-sdk", "zod", "apache-arrow"].some(
+      (name) => id === name || id.startsWith(`${name}/`),
+    )
   );
 }
 
@@ -561,8 +564,12 @@ function shouldExternalizeTerminalCoreDependency(id: string): boolean {
 
 const coreDistEntries = buildCoreDistEntries();
 const dockerE2eHarnessEntries = buildDockerE2eHarnessEntries();
-const rootBundledPluginBuildEntries = bundledPluginBuildEntries.filter(
-  ({ id }) => shouldBuildPrivateQaEntries || !NON_PACKAGED_BUNDLED_PLUGIN_DIRS.has(id),
+const rootPackageExcludedPluginDirs = collectRootPackageExcludedExtensionDirs();
+const dockerSelectedPluginIds = parseDockerSelectedPluginBuildIdFilter();
+const rootBundledPluginBuildEntries = bundledPluginBuildEntries.filter(({ id }) =>
+  NON_PACKAGED_BUNDLED_PLUGIN_DIRS.has(id)
+    ? shouldBuildPrivateQaEntries
+    : !rootPackageExcludedPluginDirs.has(id) || dockerSelectedPluginIds?.has(id),
 );
 
 function buildUnifiedDistEntries(): Record<string, string> {
@@ -654,12 +661,28 @@ function normalizeDeclarationEntrySource(source: string): string {
 function buildUnifiedDeclarationPartitions(
   entries: Record<string, string>,
 ): Array<{ name: string; sources: string[] }> {
-  const sortedEntries = Object.entries(entries).toSorted(([left], [right]) =>
-    left.localeCompare(right),
+  const publicPluginSdkEntryNames = new Set(
+    publicPluginSdkEntrypoints.map((entry) => `plugin-sdk/${entry}`),
   );
-  const baseEntries = sortedEntries.filter(
-    ([name]) => !name.startsWith("plugin-sdk/") && !name.startsWith("extensions/"),
+  const pluginContracts = listBundledPluginEntrySources(
+    rootBundledPluginBuildEntries.map((plugin) => ({
+      id: plugin.id,
+      sourceEntries: collectPluginDeclarationSourceEntries(
+        plugin.packageJson,
+        plugin.sourceEntries,
+      ),
+    })),
   );
+  // Runtime entrypoints include workers, lazy loaders, and private implementation
+  // sidecars. Only the library root, typed SDK, and plugin contracts own declarations.
+  const sortedEntries = Object.entries(entries)
+    .filter(([name]) =>
+      name.startsWith("plugin-sdk/")
+        ? shouldBuildPrivateQaEntries || publicPluginSdkEntryNames.has(name)
+        : name === "index" || Object.hasOwn(pluginContracts, name),
+    )
+    .toSorted(([left], [right]) => left.localeCompare(right));
+  const baseEntries = sortedEntries.filter(([name]) => name === "index");
   const pluginSdkEntries = sortedEntries.filter(([name]) => name.startsWith("plugin-sdk/"));
   const extensionEntriesById = new Map<string, UnifiedEntry[]>();
   for (const entry of sortedEntries) {
@@ -676,9 +699,8 @@ function buildUnifiedDeclarationPartitions(
     extensionEntriesById.set(extensionId, extensionEntries);
   }
 
-  const publicPluginSdkEntryNames = new Set(
-    publicPluginSdkEntrypoints.map((entry) => `plugin-sdk/${entry}`),
-  );
+  // Keep memory-bounded partitions. Outside private QA the private SDK partition
+  // has no emit roots, so the declaration plugin performs no compiler work for it.
   const pluginSdkPartitions = [
     pluginSdkEntries.filter(([name]) => publicPluginSdkEntryNames.has(name)),
     pluginSdkEntries.filter(([name]) => !publicPluginSdkEntryNames.has(name)),
@@ -774,7 +796,7 @@ const configs = [
       // and bundled hooks in one graph so runtime singletons are emitted once.
       entry: unifiedDistEntries,
       deps: unifiedDeps,
-      plugins: [createStateSchemaInlinePlugin()],
+      plugins: [createClaudeAgentSdkAssetPlugin(), createStateSchemaInlinePlugin()],
     },
     false,
   ),

--- a/ui/src/e2e/chat-submit-responsiveness.e2e.test.ts
+++ b/ui/src/e2e/chat-submit-responsiveness.e2e.test.ts
@@ -120,7 +120,12 @@ suite.define(() => {
         };
         textarea.addEventListener(
           "keydown",
-          () => {
+          function onSubmit(event) {
+            // Meta+Enter emits a modifier keydown first; only submission queues the next input.
+            if (event.key !== "Enter") {
+              return;
+            }
+            textarea.removeEventListener("keydown", onSubmit, true);
             const channel = new MessageChannel();
             channel.port1.addEventListener(
               "message",
@@ -142,13 +147,11 @@ suite.define(() => {
             channel.port1.start();
             channel.port2.postMessage(undefined);
           },
-          { capture: true, once: true },
+          { capture: true },
         );
       });
 
-      // A chord fires the one-shot listener on its modifier before submission.
-      // Arm the next-input task from the actual submit key instead.
-      await composer.press("Enter");
+      await composer.press("Meta+Enter");
       const request = await gateway.waitForRequest("chat.send");
       expect(request.params).toMatchObject({ message: "first prompt" });
       await expect


### PR DESCRIPTION
## What Problem This Solves

Removes redundant npm installation payload without replacing Claude’s official SDK or dropping public plugin capabilities. OpenClaw already selects an installed Claude executable, but its root SDK dependency also installed a second large native executable. The root build additionally emitted chunks for excluded plugins and declarations for private runtime entrypoints.

This is maintainer-requested packaging work. The fs-safe 0.7 platform-package migration originally investigated here is already on main through the [personal skill-libraries change](https://github.com/openclaw/openclaw/pull/134068); the remaining dependency diff only moves the existing SDK 0.3.241 pin from root runtime to development ownership.

## Why This Change Was Made

Keep the official SDK as package-relative build assets: runtime bytes, types, exports, peers, README, and license remain intact; only its reviewed native optional dependencies are omitted from the emitted manifest. The existing installed-executable selection, process spawner, fd-3 authentication transport, permissions, hooks, and session protocol stay unchanged.

Use one selected plugin-output plan for unified compilation, isolated source-checkout builds, metadata, and readiness. Excluded plugins no longer seed root chunks, but remain usable in source checkouts. Isolated CommonJS plugins retain `.cjs`; explicitly selected Docker plugins use the unified `.js` graph. Full launcher rebuilds now invoke the canonical runtime build profile instead of a second incomplete sequence.

Restrict declarations to public root/SDK and genuine plugin contracts while retaining bounded compilation and nominal identities. Declaration publication/cache restoration preserve copied SDK type assets; runtime rebuilds still replace obsolete SDK files. The asset resolver runs before tsdown’s dependency proxy so nested dynamic imports retain their relative paths.

## Reconciliation and platform repairs

Final candidate `15a192fcaa0ba6f9d70d218fff781ede43dade23` is rebased onto pinned main `f03555625c9a16b55c43716c001726738cdc6b87`. Main's per-group declaration cache, writer/staging, literal ordering, cache-hit/mutation tests and `stableTypeOrdering` remain. Copied opaque SDK types remain excluded from generated inventory while all 15 SDK files, stale generated sibling pruning and runtime replacement semantics are retained. No dependency pin, cooldown exception or production CI cap was changed.

The canonical metadata owner removes old output dependency links before cleanup, regardless of the new isolated/unified plan. This prevents an isolated→Docker-selected unified transition from deleting source packages through the old link. Per-package staging replaces the outer node_modules junction with real output-owned node_modules/scope directories and links to canonical source-owned packages, private versions, native payloads and .bin launchers. Windows keeps absolute junctions: its outer junction plus pnpm's relative host link previously misresolved package.json/exports for both ESM and CJS.

Main subsequently added POSIX whole-checkout relocation. The accepted absolute-link producer failed that real import case. The reconciled producer uses relative canonical targets on POSIX and preserves absolute Windows junction behavior. The existing real-builder fixture now combines ESM/CJS, profile transitions, source preservation, shared SDK identity, private versions, staged copying, launcher execution and checkout relocation. Both relocation cases failed before the repair and passed afterward; no assertion or timeout was weakened. Whole-checkout copies preserve relative links; copying only a plugin rebases POSIX links to their existing owners, as main's fixture did. Windows retains asynchronous verbatim copying. Node 22's synchronous copier follows Windows junctions and recursed through the host back-link; the fixture-only correction uses async fs.cp, matching the existing link-preserving installer primitive. No production copy workaround or SDK-specifier rewrite was added.

The planner integration repair subdivides hosted tooling into complete-file batches using the existing 150-second admission budget and existing packer. On the previously failing CI merge tree it reduced 114 jobs to 109 under the unchanged 112 cap, retaining all 554 files / 16 parents and the same five runtime-build jobs; predicted work was not discounted. Main's family separation, worker limits, hybrid policy and timing floors remain. The current planner files exactly match the maintainer-reviewed integration.

The Composer failure was fixture ordering, not lost production draft: Playwright's Meta event consumed a once listener before Enter. The listener now filters Enter and removes itself there, with an exact first-message assertion. The Swift queued-catalog fixture's independent two-second readiness poll failed before its measured 50 ms deadline began. Its opt-in FIFO rendezvous follows the first request's lifetime; the 50 ms deadline, cancellation/join, no unexpected request and single-process checks remain, and timeout/cancellation siblings remain ungated. Neither repair changes production code or adds sleeps, timeout allowances or production test seams.

## Verification

**Exact-head CI passed:** [CI 33597768913](https://github.com/openclaw/openclaw/actions/runs/33597768913), attempt 1, head `15a192fcaa0ba6f9d70d218fff781ede43dade23`: 235 successful jobs and nine skips, including the actual native Swift suite and selected Windows checks. No cancellation or retry was needed on this final run.

**Clean Linux package/install proof passed:** [run 33597815822](https://github.com/openclaw/openclaw/actions/runs/33597815822), configured Blacksmith Testbox, exact head `15a192fcaa0ba6f9d70d218fff781ede43dade23`, Node 24.19.0 / npm 11.17.0. The wrapper completed with exit 0 in 9m14s; the owned lease was stopped and independently confirmed completed. The linked Actions check records cancellation during lease cleanup; that is not a failed proof command. All 96 pre-build tests passed: 34 doctor/archive, 37 declaration/SDK and 25 metadata/build-owner. The full package build, original-order runtime checks, canonical tarball validation and normal npm installation all passed.

The clean Linux command validates the exact configured source head and frozen install; doctor/archive, declaration/SDK and metadata owners; full pnpm build:package; singleton→watch→Discord in original order; canonical packing/import closure; and an isolated normal-lifecycle npm install with optional dependencies. Watch must become ready without rebuilding or changing artifact membership. The real Gateway-to-mock-Discord multipart scenario covers five filename/component cases.

Installed-package checks compare every SDK asset and the emitted manifest with upstream, import the SDK, reject any registry SDK/native-executable subtree, require exactly one fs-safe platform leaf and native-required create/write/read, and run CLI startup, Anthropic runtime inspection and plugin doctor without dependency reprovisioning. SDK 0.3.241 has no ordinary dependencies, eight guarded native optionals, twelve package-relative files entries and three peers. All 14 non-manifest files remained byte-identical; only the reviewed native optionals are omitted from the manifest. Runtime SHA256 remains `5c3ff5871a1fd5884475bc838c868a7a3d4e2b454680f9bd5a4ccf63a5b1284a`, matching the earlier authenticated installed-Claude proof. That authenticated call is earlier supporting evidence, not a new secret-backed run.

Current local verification passed 513 owner tests (408 tooling, 90 launcher/readiness, 15 metadata), the scoped changed gate including scripts/root-test types and typed lint, and a fresh restricted complete-branch Codex P0 autoreview: scoped-clean, no findings. The normal-hook commit was verified byte-for-byte against its source hash manifest. Canonical pnpm build qaRuntime passed: 90 isolated plugins and 53 native control-plane modules.

**Local package gap:** pnpm build:package completed all six declaration compiler invocations but failed its publication fence after 485.89 seconds: an ancestor main-checkout node_modules/@types/events/index.d.ts had a ctime inside compilation. That dependency is outside this worktree. No actor or byte-content change is inferred from ctime, no install was modified and no guard was bypassed. This is a failed local package build, not a pass. Earlier broad macOS gates also hit recorded filesystem stalls and remain incomplete. Clean Linux and exact-head CI are reported separately above. No native Swift tests ran on the operator desktop.

## Auxiliary native scan recovery

Shared OpenClawKit Periphery [33597768830](https://github.com/openclaw/openclaw/actions/runs/33597768830) passed on attempt 1. Both auxiliary scans initially had unassigned zero-step jobs. A second complete observation caught the shared-kit iOS scan acquiring a runner, so it was left running. The separate macOS Periphery [33597768930](https://github.com/openclaw/openclaw/actions/runs/33597768930) still had no active work; only that run was cancelled, confirmed terminal, then retried with `gh run rerun 33597768930 --failed`. The existing workflow selected GitHub `macos-26` on attempt 2 and preserved the successful scope job's original execution. Attempt 2 passed. The default native watcher then reported GREEN with zero pending checks. No scan coverage, source, backend policy or timeout was changed.

## Earlier platform evidence and CI recovery

[Windows native acceptance 33594797136](https://github.com/openclaw/openclaw/actions/runs/33594797136) completed successfully at diagnostic SHA `d370d8351c7dc01007ef04500cca86a567ab03e3`, all four fresh Windows Node 22.23.2 x64 jobs. Baseline actual-owner and real-builder ESM/CJS loads failed; the corrected candidate passed private versions, SDK singleton, transitions, staged copy and bin assertions. Full qaRuntime built 90 isolated plugins, 53 control-plane modules passed twice, and the actual staged codex.cmd reported codex-cli 0.151.0. The diagnostic workflow/probes remain off this PR. This proves native build/loading and the launcher, not a complete Windows release/package-install campaign. The reconciliation preserves the native-tested Windows target/junction behavior; new-head CI is separate above.

The intermediate Windows diagnostic [33594331842](https://github.com/openclaw/openclaw/actions/runs/33594331842) pinpointed fixture-only synchronous junction recursion after metadata transitions. The final marker-free async-copy fixture repair retained every assertion. Earlier [33593349248](https://github.com/openclaw/openclaw/actions/runs/33593349248) did not pass acceptance; these failed attempts were diagnosed, not relabeled or blindly retried.

At earlier head `6096618`, [native macOS job 100120565674](https://github.com/openclaw/openclaw/actions/runs/33588410294/job/100120565674), attempt 2, passed the queued deadline in 0.420s, all 1,911 application tests, 1,571 OpenClawKit tests and named isolation partitions. Its original run was cancelled only after the complete job set showed no executing work and the remaining native jobs had no runner or steps; the documented selected-job retry used the workflow-owned hosted route. The overall 609 run remained red for the diagnosed Windows/planner failures. At preceding head `8065753`, [33582018407](https://github.com/openclaw/openclaw/actions/runs/33582018407) used the same verified zero-step recovery; its real Swift readiness failure led to the fixture repair, not a blind test rerun.

Earlier clean Linux [33588436189](https://github.com/openclaw/openclaw/actions/runs/33588436189) and earlier maintainer cohorts: 321 build-owner, 302 filesystem/archive (one platform skip), 244 planner and 150 package/SDK/compiler tests are bounded prior evidence, not relabeled final-head passes. All earlier leases are stopped. The historical detached-worktree Testbox attempt was invalid because its login shell entered the configured checkout; the final proof explicitly validates the configured root and exact source head.

## Package measurements and caveats

The final candidate installed **440,884,730 regular-file bytes** / **535,457,792 allocated bytes**, with **34,284 files** and **330 package instances**. Its tarball is **56,028,434 compressed bytes**, **175,979,951 unpacked bytes**, and **9,762 entries**; SHA-256 `1bf0112dfb9144bcfa45f8064aa20dd60c4ac6d8dcedb38af9ddf7c5580bdecd`. The normal install selected exactly `@openclaw/fs-safe-linux-x64-gnu`, completed native-required writes, and contained no registry SDK/native executable subtree.

The integrity-verified published 2026.8.1 baseline measured 831,067,017 regular-file bytes, yielding an observed reduction of about 47%. This is **not a same-source A/B attribution**: main advanced, fs-safe 0.7 landed separately, and the original baseline used scripts-disabled measurement flags. Candidate installation uses normal lifecycle behavior. The tarball is a proof artifact, not an npm publication or release.

## Review follow-through

The [ClawSweeper review at this final head](https://github.com/openclaw/openclaw/pull/135478#issuecomment-5499316942) asks for staged host-SDK resolution, real-layout imports and exact-head Windows validation; an earlier review also requested direct SDK-manifest inspection. The missing-host premise is not reproduced on the real postbuild output: the existing [stageBundledPluginRuntime/ensureOpenClawExtensionAlias owner](https://github.com/openclaw/openclaw/blob/15a192fcaa0ba6f9d70d218fff781ede43dade23/scripts/stage-bundled-plugin-runtime.mts#L184) creates dist/extensions/node_modules/openclaw with exported SDK forwarding modules. Both Amazon Bedrock and Mantle emitted index.js and discovery.js import in plain Node without plugin-local host links, and normal CLI runtime inspection reports loaded. This canonical owner was absent from the review's evidence map. No extra host peer or fallback was added. These macOS Node 26 plain-Node probes exercise the real postbuild layout; the selected Windows control-plane checks passed in exact-head CI. The real build/import probes supplement the synthetic per-package ownership fixture; the Windows and SDK-manifest proof are above. No requested coverage was silently skipped.

fs-safe's raw TAR admission/extraction contract remains covered by real malformed archive fixtures. The **Native-required updater activation** follow-up is existing-main work for staged activation, old-updater and service-only environments, not part of this dependency delta. No updater policy is changed. Generated build/package manifests are not runtime SQLite/schema migrations; that persistent-schema tag does not apply.

LOC against pinned main: production/tooling 408 added / 340 deleted (**net +68**), tests/support 1,550 added / 468 deleted (**net +1,082**), docs +2, manifests/lockfiles 4 added / 4 deleted. The production growth establishes the official 87-line SDK asset owner and canonical output/dependency ownership while deleting duplicate launcher/build policy; the additional six lines preserve the required POSIX/Windows link contract.

This is a candidate checkpoint for maintainer verification, **not a merge or approval to skip native landing gates**. Native review artifacts remain stale and must be regenerated by the maintainer. No native prepare/merge, changelog, release, npm publication or advisory operation has run.
