### PR TITLE
refactor(ci): remove contract discovery wrappers

### DIFF
--- a/scripts/lib/channel-contract-test-plan.mts
+++ b/scripts/lib/channel-contract-test-plan.mts
@@ -3,10 +3,6 @@ import { relative } from "node:path";
 import { listTrackedTestFiles } from "./list-test-files.mts";
 import { assignWeightedTestFiles } from "./weighted-test-shards.mts";
 
-function listContractTestFiles(rootDir = "src/channels/plugins/contracts") {
-  return listTrackedTestFiles(rootDir);
-}
-
 const CONTRACT_FILE_WEIGHTS = new Map([
   ["channel-import-guardrails.test.ts", 18],
   ["outbound-payload.contract.test.ts", 18],
@@ -46,7 +42,7 @@ export function createChannelContractTestShards() {
 
   const coreFiles = new Array<string>();
   const registryFiles = new Array<string>();
-  for (const file of listContractTestFiles(rootDir)) {
+  for (const file of listTrackedTestFiles(rootDir)) {
     const name = relative(rootDir, file).replaceAll("\\", "/");
     (name.startsWith("plugins-core.") || name.startsWith("plugin.")
       ? coreFiles

--- a/scripts/lib/plugin-contract-test-plan.mts
+++ b/scripts/lib/plugin-contract-test-plan.mts
@@ -2,10 +2,6 @@
 import { listTrackedTestFiles } from "./list-test-files.mts";
 import { assignWeightedTestFiles } from "./weighted-test-shards.mts";
 
-function listContractTestFiles(rootDir = "src/plugins/contracts") {
-  return listTrackedTestFiles(rootDir);
-}
-
 const CONTRACT_FILE_WEIGHTS = new Map([
   ["plugin-sdk-subpaths.test.ts", 80],
   ["tts.contract.test.ts", 70],
@@ -33,6 +29,7 @@ function resolveContractFileWeight(file: string) {
 
 /** Create balanced plugin contract test shards for CI check planning. */
 export function createPluginContractTestShards() {
+  const rootDir = "src/plugins/contracts";
   const suffixes = ["a", "b"];
   const groups = suffixes.map((suffix) => ({
     checkName: `checks-fast-contracts-plugins-${suffix}`,
@@ -40,7 +37,7 @@ export function createPluginContractTestShards() {
     weight: 0,
   }));
 
-  assignWeightedTestFiles(groups, listContractTestFiles(), resolveContractFileWeight);
+  assignWeightedTestFiles(groups, listTrackedTestFiles(rootDir), resolveContractFileWeight);
 
   return groups
     .map(({ checkName, includePatterns }) => ({


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested duplicate-function cleanup found that the channel and plugin contract-test planners retained private identity wrappers around the canonical tracked-test discovery helper. Those wrappers duplicated no policy and obscured the actual discovery owner.

## Why This Change Was Made

Both planners now call `listTrackedTestFiles` directly. `scripts/lib/list-test-files.mts` remains the sole owner of git-tracked, sorted `.test.ts` discovery and recursive filesystem fallback behavior.

Removed paths:

- `scripts/lib/channel-contract-test-plan.mts` private `listContractTestFiles`
- `scripts/lib/plugin-contract-test-plan.mts` private `listContractTestFiles`

The larger `scripts/lib/ci-node-test-plan.mts` identity pattern is excluded because it has fourteen callers and requires a separate owner audit.

Production LOC: `0`. Tests/test support: `0`. Tooling: `+3/-10`, net `-7`.

## User Impact

No user-visible behavior changes. CI contract-test shard planning keeps the same files, ordering, weights, and shard assignments with less duplicate plumbing.

## Evidence

- Focused shard-plan tests: 2 files, 9 tests passed.
- Changed-file dry run classified only the scripts/tooling lane.
- Local changed gate passed except for an initial sparse-worktree typecheck failure caused by omitted tracked `ui/config/*` files; after materializing the worktree, the failed scripts typecheck and all remaining gate commands passed.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `git diff --check`: passed.
- Blacksmith Testbox exact-tree changed gate passed: provider `blacksmith-testbox`, lease `tbx_01m1f6479acp8znrdrc3msypvy`, Actions run https://github.com/openclaw/openclaw/actions/runs/33548048982, exit 0 in 2m30s; lease stopped cleanly. An earlier sparse-checkout preflight lease `tbx_01m1f63kedp1rpag6eysjv3arn` was also stopped cleanly before any remote command ran.
- Autoreview: `gpt-5.6-sol`, high reasoning, scoped-clean with no accepted/actionable findings.
- Codex hard gate personally inspected in sibling Codex `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; both are unrelated CLI parser/completion paths.
- Targeted live overlap check found no open PR touching either planner. https://github.com/openclaw/openclaw/pull/126405 only adds a plugin contract test discovered by the unchanged helper contract.
