### PR TITLE
refactor(scripts): centralize SQLite metric reads

### DIFF
--- a/scripts/bench-sqlite-state.ts
+++ b/scripts/bench-sqlite-state.ts
@@ -16,6 +16,7 @@ import {
   openOpenClawStateDatabase,
 } from "../src/state/openclaw-state-db.js";
 import { parseStrictIntegerOption } from "./lib/dev-tooling-safety.ts";
+import { readSqliteMetricBytes } from "./lib/sqlite-file-metrics.ts";
 import {
   collectSqliteQueryPlanEvidence,
   type SqliteQueryPlanEvidence,
@@ -180,16 +181,8 @@ function nowMs(): number {
   return Number(process.hrtime.bigint()) / 1e6;
 }
 
-function fileSize(pathname: string): number {
-  try {
-    return fs.statSync(pathname).size;
-  } catch {
-    return 0;
-  }
-}
-
 function walSize(pathname: string): number {
-  return fileSize(`${pathname}-wal`);
+  return readSqliteMetricBytes(`${pathname}-wal`);
 }
 
 function stateRowCount(config: ProfileConfig): number {

--- a/scripts/lib/sqlite-file-metrics.ts
+++ b/scripts/lib/sqlite-file-metrics.ts
@@ -1,0 +1,10 @@
+import { statSync } from "node:fs";
+
+export function readSqliteMetricBytes(pathname: string): number {
+  try {
+    return statSync(pathname).size;
+  } catch {
+    // Metric sampling is best-effort; any stat failure counts as zero.
+    return 0;
+  }
+}

--- a/scripts/lib/sqlite-reliability-runner.ts
+++ b/scripts/lib/sqlite-reliability-runner.ts
@@ -18,6 +18,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../src/state/openclaw-state-db.js";
+import { readSqliteMetricBytes } from "./sqlite-file-metrics.ts";
 import { runVacuumInterruptionProof } from "./sqlite-reliability-compaction.js";
 import {
   COMMITTED_WAL_SENTINEL,
@@ -89,14 +90,6 @@ function percentile(values: number[], pct: number): number {
   const sorted = values.toSorted((left, right) => left - right);
   const index = Math.min(sorted.length - 1, Math.ceil((pct / 100) * sorted.length) - 1);
   return Number((sorted[index] ?? 0).toFixed(3));
-}
-
-function fileSize(pathname: string): number {
-  try {
-    return fs.statSync(pathname).size;
-  } catch {
-    return 0;
-  }
 }
 
 function resolveTargetDatabase(options: CliOptions, env: NodeJS.ProcessEnv): TargetDatabase {
@@ -713,7 +706,7 @@ export async function runReliabilityStress(options: CliOptions): Promise<Reliabi
     });
     writer = startWriter(target.path, profile);
     await waitForWriterMessage(writer, "ready");
-    const walBytesBefore = fileSize(`${target.path}-wal`);
+    const walBytesBefore = readSqliteMetricBytes(`${target.path}-wal`);
     let peakWalBytes = walBytesBefore;
     const partial = await waitForWriterMessage(writer, "partial", () => {
       writer?.child.send?.({ kind: "hold-partial" });
@@ -863,7 +856,7 @@ export async function runReliabilityStress(options: CliOptions): Promise<Reliabi
         visibleAfterRestore: false,
       },
       walBytes: {
-        after: fileSize(`${target.path}-wal`),
+        after: readSqliteMetricBytes(`${target.path}-wal`),
         before: walBytesBefore,
         limit: profile.maxWalBytes,
         peak: peakWalBytes,

--- a/scripts/lib/sqlite-reliability-wal-monitor.ts
+++ b/scripts/lib/sqlite-reliability-wal-monitor.ts
@@ -1,14 +1,6 @@
-import fs from "node:fs";
+import { readSqliteMetricBytes } from "./sqlite-file-metrics.ts";
 
 const DEFAULT_POLL_INTERVAL_MS = 25;
-
-function fileSize(pathname: string): number {
-  try {
-    return fs.statSync(pathname).size;
-  } catch {
-    return 0;
-  }
-}
 
 export async function monitorSqliteWalDuring<T>(params: {
   maxWalBytes: number;
@@ -17,10 +9,10 @@ export async function monitorSqliteWalDuring<T>(params: {
   pollIntervalMs?: number;
   walPath: string;
 }): Promise<{ peakWalBytes: number; result: T }> {
-  let peakWalBytes = fileSize(params.walPath);
+  let peakWalBytes = readSqliteMetricBytes(params.walPath);
   let limitExceeded = false;
   const sample = () => {
-    const currentWalBytes = fileSize(params.walPath);
+    const currentWalBytes = readSqliteMetricBytes(params.walPath);
     peakWalBytes = Math.max(peakWalBytes, currentWalBytes);
     if (!limitExceeded && currentWalBytes > params.maxWalBytes) {
       limitExceeded = true;


### PR DESCRIPTION
## What Problem This Solves

Three SQLite tooling paths independently implemented the same best-effort filesystem metric read. Keeping identical catch-all file-size sampling in the state benchmark, reliability runner, and WAL monitor made the metric contract easier to drift.

This is a maintainer-requested refactor from the duplicate-function audit. It does not change product runtime behavior.

## Why This Change Was Made

Private helper `scripts/lib/sqlite-file-metrics.ts` now owns synchronous `statSync(pathname).size` sampling with the existing catch-all `0` fallback. Only these callers migrate:

- `scripts/bench-sqlite-state.ts`
- `scripts/lib/sqlite-reliability-runner.ts`
- `scripts/lib/sqlite-reliability-wal-monitor.ts`

Compaction and index-repair helpers remain local because they intentionally suppress only `ENOENT`. Release-log helpers remain with their release tooling owner.

No SQL, SQLite schema, transaction, persistence, SDK, config, or protocol behavior changes.

Judged tooling LOC: `+18/-30`, net `-12`. Tests: `+0/-0`. The reviewed estimate was net `-9`; the exact formatted diff removes three additional separator lines rather than padding the patch to match the forecast.

## User Impact

No user-visible behavior change. Benchmark and reliability metrics retain synchronous sampling, identical byte values, and the same best-effort zero result for any filesystem stat failure.

## Evidence

- Local focused tests: 14/14 passed:
  - `test/scripts/bench-sqlite-state.test.ts`
  - `test/scripts/bench-sqlite-reliability.test.ts`
- Local import-cycle check: 0 runtime value cycles.
- Local exact changed-file scripts/tooling gate: passed.
- `git diff --check`: passed.
- Blacksmith Testbox exact candidate-tree proof: `tbx_01m1f65zand5q4zh6ywyc0s51d`, exit 0.
  - 14/14 focused tests passed.
  - Import-cycle check passed.
  - Exact changed-file scripts/tooling gate passed.
  - Run: https://github.com/openclaw/openclaw/actions/runs/33548142984
- Autoreview: scoped-clean, overall correct `0.99`.
- Signed commit: `af6823079e15a0e7b580d7e19f170caa39370264`.
- Codex hard gate inspected at sibling Codex commit `5f49aba876922d6f2f55caa153bbb0ed1b46feba`:
  - `codex-rs/cli/src/main.rs:220-245`
  - `codex-rs/cli/src/main.rs:2840-2870`
  - No relevant runtime or protocol dependency.
- Overlap rechecked:
  - https://github.com/openclaw/openclaw/pull/135280 centralizes SQLite reliability state assertions and touches a separate runner helper/import hunk.
  - https://github.com/openclaw/openclaw/pull/122612 stabilizes VACUUM interruption timing and touches a separate compaction constant hunk.

Both overlaps are rebase-sensitive but do not implement or modify this metric helper.
