### PR TITLE
fix(workspace): treat Windows NTFS EPERM on bootstrap files as already present

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -199,6 +199,36 @@ describe("ensureAgentWorkspace", () => {
     expect(readWorkspaceStateSnapshot(tempDir).attestation).toBeDefined();
   });
 
+  it("treats Windows NTFS EPERM on an existing bootstrap file as already present", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const agentsPath = path.join(tempDir, DEFAULT_AGENTS_FILENAME);
+    const existingContent = "existing custom agents instructions\n";
+    await fs.writeFile(agentsPath, existingContent, "utf8");
+
+    const realWriteFile = fs.writeFile.bind(fs);
+    const writeSpy = vi
+      .spyOn(fs, "writeFile")
+      .mockImplementation(async (filePath, content, options) => {
+        const flag = (options as { flag?: string } | undefined)?.flag;
+        if (flag === "wx" && filePath === agentsPath) {
+          const error = new Error(
+            "EPERM: operation not permitted, open 'AGENTS.md'",
+          ) as NodeJS.ErrnoException;
+          error.code = "EPERM";
+          throw error;
+        }
+        return await realWriteFile(filePath, content, options);
+      });
+
+    try {
+      await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+    } finally {
+      writeSpy.mockRestore();
+    }
+
+    await expect(fs.readFile(agentsPath, "utf8")).resolves.toBe(existingContent);
+  });
+
   it("does not overwrite a foreign root workspace-state.json file", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     const foreignStatePath = path.join(tempDir, "workspace-state.json");

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -323,10 +323,22 @@ async function writeFileIfMissing(filePath: string, content: string): Promise<bo
     return true;
   } catch (err) {
     const anyErr = err as { code?: string };
-    if (anyErr.code !== "EEXIST") {
-      throw err;
+    if (anyErr.code === "EEXIST") {
+      return false;
     }
-    return false;
+    // Windows NTFS reports EPERM (and AV-held files may surface EACCES)
+    // instead of EEXIST when the `wx` flag collides with an existing bootstrap
+    // file. Treat those as "already exists" only when the path actually
+    // exists; a real permission error on a missing path must still fail.
+    if (anyErr.code === "EPERM" || anyErr.code === "EACCES") {
+      try {
+        await fs.access(filePath);
+        return false;
+      } catch {
+        // Path does not exist; fall through to rethrow the original error.
+      }
+    }
+    throw err;
   }
 }
 


### PR DESCRIPTION
Closes #135230

## What Problem This Solves

On Windows, workspace bootstrap could fail with `EPERM: operation not permitted, open 'AGENTS.md'` and surface as a send failure in the UI. Root cause: `writeFileIfMissing` uses the `wx` (fail-if-exists) flag and only treated `EEXIST` as "already present", but Windows NTFS (especially behind a directory junction or with a momentarily held handle) reports `EPERM` instead of `EEXIST` when the bootstrap file already exists.

## Why This Change Was Made

`writeFileIfMissing` now treats `EPERM`/`EACCES` as "already present" **only when the target path actually exists**, then returns `false` and skips the write. A real permission error on a missing path still rethrows, so a genuine access problem is never silently swallowed. `EEXIST` handling is unchanged.

## User Impact

Windows users on NTFS (with or without a directory junction) can bootstrap a workspace whose `AGENTS.md` already exists or is momentarily held, without the gateway crashing the send path. Real permission errors still fail loudly.

## Evidence

Exact head: `21c08e15eecb1babab747ec9c904055877756897`.

- `src/agents/workspace.test.ts` — new focused regression "treats Windows NTFS EPERM on an existing bootstrap file as already present" that mocks `fs.writeFile` to throw `EPERM` on the `wx` write, asserts bootstrap completes without throwing, and asserts the existing `AGENTS.md` content is preserved. 62 passed.
- Production typecheck passes; `check:changed` is green except the pre-existing unrelated `ui/vite.config.ts` missing-`pako` declaration in the reused dependency tree.

## AI Assistance

AI-assisted implementation. I manually verified the `wx` flag semantics, the guarded `EPERM`/`EACCES` fallback that only treats existing paths as present, the focused regression, and the changed-file gates.
