### PR TITLE
fix: keep state-dir Gateway CI proof reliable under load

### DIFF
--- a/src/cli/state-dir-gateway-check.server.test.ts
+++ b/src/cli/state-dir-gateway-check.server.test.ts
@@ -3,9 +3,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { callGateway } from "../gateway/call.js";
+import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
 import { getFreePort } from "../test-utils/ports.js";
-import { checkCliGatewayStateDir } from "./state-dir-gateway-check.js";
+import { compareCliGatewayStateDirs, type GatewayHello } from "./state-dir-gateway-check.js";
 
 describe("state-dir guard with a real token Gateway", () => {
   const token = "state-dir-test-token";
@@ -14,11 +16,6 @@ describe("state-dir guard with a real token Gateway", () => {
   let port: number;
   let gatewayStateDir: string;
   let cliStateDir: string;
-
-  const setCliStateDir = (stateDir: string) => {
-    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
-    vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
-  };
 
   beforeAll(async () => {
     root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-state-dir-server-"));
@@ -69,14 +66,9 @@ describe("state-dir guard with a real token Gateway", () => {
         reject(new Error(`Gateway fixture exited early: ${code}\n${childStderr}`));
       });
     });
-    vi.stubEnv("HOME", path.join(root, "cli-home"));
-    setCliStateDir(cliStateDir);
-    vi.stubEnv("OPENCLAW_GATEWAY_PORT", String(port));
-    vi.stubEnv("OPENCLAW_SYSTEMD_UNIT", `openclaw-state-dir-server-${process.pid}`);
   }, 120_000);
 
   afterAll(async () => {
-    vi.unstubAllEnvs();
     const exited = new Promise<void>((resolve) => {
       child.once("exit", () => {
         resolve();
@@ -87,37 +79,53 @@ describe("state-dir guard with a real token Gateway", () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
-  it("allows matching authenticated hello paths", async () => {
-    setCliStateDir(gatewayStateDir);
-    await expect(
-      checkCliGatewayStateDir({
-        command: "openclaw channels add",
-        config: { gateway: { mode: "local", port, auth: { mode: "token", token } } },
-      }),
-    ).resolves.toEqual({ kind: "allow" });
-    setCliStateDir(cliStateDir);
-  });
-
-  it("refuses mismatched authenticated hello paths", async () => {
-    const outcome = await checkCliGatewayStateDir({
-      command: "openclaw channels add",
+  it("compares paths from an authenticated Gateway hello", async () => {
+    let hello: GatewayHello | undefined;
+    await callGateway({
       config: { gateway: { mode: "local", port, auth: { mode: "token", token } } },
+      method: "status",
+      params: { includeChannelSummary: false },
+      scopes: [ADMIN_SCOPE],
+      sharedStateMode: "read-only",
+      // This bounds the live integration proof without changing the guard's 3s offline policy.
+      timeoutMs: 60_000,
+      onHelloOk: (value) => {
+        hello = value;
+      },
     });
 
-    expect(outcome).toMatchObject({ kind: "refuse" });
-    if (outcome.kind !== "refuse") {
+    if (!hello?.snapshot.stateDir) {
+      throw new Error("expected authenticated hello state paths");
+    }
+    expect(hello.snapshot).toMatchObject({
+      stateDir: gatewayStateDir,
+      configPath: path.join(gatewayStateDir, "openclaw.json"),
+    });
+    const gatewayPaths = {
+      gatewayStateDir: hello.snapshot.stateDir,
+      gatewayConfigPath: hello.snapshot.configPath,
+      source: "live Gateway" as const,
+      mode: "refuse" as const,
+      command: "openclaw channels add",
+    };
+    expect(
+      compareCliGatewayStateDirs({
+        cliStateDir: gatewayStateDir,
+        cliConfigPath: path.join(gatewayStateDir, "openclaw.json"),
+        ...gatewayPaths,
+      }),
+    ).toEqual({ kind: "allow" });
+
+    const mismatch = compareCliGatewayStateDirs({
+      cliStateDir,
+      cliConfigPath: path.join(cliStateDir, "openclaw.json"),
+      ...gatewayPaths,
+    });
+    expect(mismatch).toMatchObject({ kind: "refuse" });
+    if (mismatch.kind !== "refuse") {
       throw new Error("expected authenticated path mismatch refusal");
     }
-    expect(outcome.message).toContain(gatewayStateDir);
-    expect(outcome.message).toContain("live Gateway");
-  });
-
-  it("warns when a tokenless CLI can prove only the Gateway protocol", async () => {
-    await expect(
-      checkCliGatewayStateDir({
-        command: "openclaw channels add",
-        config: { gateway: { mode: "local", port, auth: { mode: "token" } } },
-      }),
-    ).resolves.toMatchObject({ kind: "warn" });
-  });
+    expect(mismatch.message).toContain(gatewayStateDir);
+    expect(mismatch.message).toContain("live Gateway");
+  }, 120_000);
 });

--- a/src/cli/state-dir-gateway-check.test.ts
+++ b/src/cli/state-dir-gateway-check.test.ts
@@ -116,6 +116,27 @@ describe("state-dir-gateway-check", () => {
     expect(mocks.probeGateway).not.toHaveBeenCalled();
   });
 
+  it("refuses paths from an authenticated hello without service fallback", async () => {
+    const gatewayStateDir = path.join(root, "gateway");
+    const gatewayConfigPath = path.join(gatewayStateDir, "openclaw.json");
+    await fs.mkdir(gatewayStateDir);
+    mocks.callGateway.mockImplementation(
+      async (options: {
+        onHelloOk?: (hello: { snapshot: { stateDir?: string; configPath?: string } }) => void;
+      }) => {
+        options.onHelloOk?.({
+          snapshot: { stateDir: gatewayStateDir, configPath: gatewayConfigPath },
+        });
+        return {};
+      },
+    );
+
+    await expect(
+      checkCliGatewayStateDir({ command: "openclaw channels add", config: {} }),
+    ).resolves.toMatchObject({ kind: "refuse" });
+    expect(mocks.readGatewayServiceState).not.toHaveBeenCalled();
+  });
+
   it("warns only when a credential-blocked protocol probe reaches an unowned Gateway", async () => {
     mocks.callGateway.mockRejectedValue(
       new GatewayCredentialsRequiredError({ method: "status", configPath: cliConfigPath }),


### PR DESCRIPTION
Related: #134403

## What Problem This Solves

Fixes an issue where the state-directory Gateway integration proof could fail under CI load even though the intended production behavior was correct. A real authenticated Gateway hello can take longer than the guard's intentional 3-second offline-allow window, so the old test could observe `allow` and falsely expect `refuse`.

## Why This Change Was Made

The test now separates the two contracts it was conflating:

- one bounded real-Gateway call proves an authenticated hello publishes `stateDir` and `configPath`;
- the state-directory comparison owner proves matching and mismatched outcomes from that same captured snapshot;
- a focused unit case proves the successful `onHelloOk` path refuses without falling back to installed-service inspection.

The live test reuses one Gateway process and one authenticated hello. Its request deadline is 60 seconds and its Vitest deadline is 120 seconds, both owned only by the test. The production 3-second offline-allow policy is unchanged.

Rejected alternatives were increasing the production timeout, retrying the owner call, weakening the expected refusal, or keeping redundant live tokenless coverage. Those approaches would change or mask the production contract; the existing deterministic credential-error/protocol-probe test already owns the tokenless fallback.

## User Impact

No shipped runtime behavior changes. Contributors and maintainers get a deterministic state-directory Gateway proof that remains meaningful under loaded CI runners instead of racing the production offline timeout.

Root cause and owner: `src/cli/state-dir-gateway-check.server.test.ts` timed a real authenticated hello through the production `checkCliGatewayStateDir` guard, while `src/cli/state-dir-gateway-check.ts` intentionally treats an ordinary transport timeout as offline and allows the command. The repair stays in the test owner; no production seam was added.

Scope: test-only, 2 files, +69/-40. Production LOC: 0. No API, config, protocol, dependency, retry, production timeout, SQLite, or persistence change. No exact active duplicate was found; #134403 introduced the original test and is linked only as provenance.

Exact head: `7a3996a1945a7289fab940d1e95d4edfb80e31e5`.

## Evidence

Authoritative failing-before evidence:

- [OpenClaw CI job `checks-node-compact-small-50`](https://github.com/openclaw/openclaw/actions/runs/33539651708/job/99962699368): `refuses mismatched authenticated hello paths` expected `{ kind: "refuse" }` but received `{ kind: "allow" }`. The matching and mismatched authenticated cases took about 3.26s and 3.33s, straddling the 3-second offline-allow deadline.

Corroborating pre-rebase local run on trusted main `01ea77ec3dae416a3c43cced10e7ae45e4147983`:

- 2 failed / 9 passed; matching passed in 3.291s, mismatch returned `allow` in 3.385s, and tokenless returned `allow` in 3.245s.

Post-fix evidence on the exact head:

- focused author run: 2 files / 10 tests passed; real authenticated hello case 23.979s;
- independent exact-head run under Node 24 with an isolated Vitest cache: 2 files / 10 tests passed; real hello case 24.516s; clean process and temporary-directory cleanup;
- `pnpm check:changed`: exit 0, including formatting, typecheck, dead-export scans, and changed-file lint;
- diff-scoped cleanup: clean;
- final branch autoreview: no actionable P0-P2 findings;
- independent exact-head verification: accepted.

Test-audit judgment: the real call proves the external Gateway hello boundary once; the pure comparison reuses its captured evidence for both outcomes; deterministic unit coverage protects callback wiring and fallback ownership. This avoids redundant live cases while preserving the observable invariant.