### PR TITLE
refactor(migrate): consolidate selection handling

### DIFF
--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -671,6 +671,46 @@ describe("migrateApplyCommand", () => {
     expect(mocks.provider.apply).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    { label: "skills", command: migrateDefaultCommand, acceptSkills: false },
+    { label: "plugins after skills (default)", command: migrateDefaultCommand, acceptSkills: true },
+    { label: "plugins after skills (apply)", command: migrateApplyCommand, acceptSkills: true },
+  ])(
+    "stops before confirmation and apply when cancelling $label",
+    async ({ command, acceptSkills }) => {
+      Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+      const skillPlan = codexSkillPlan();
+      const items = [...skillPlan.items, ...codexPluginPlan().items];
+      const planned = codexSkillPlan({
+        items,
+        summary: { ...skillPlan.summary, total: items.length, planned: items.length },
+      });
+      const original = structuredClone(planned);
+      mocks.provider.plan.mockResolvedValue(planned);
+      if (acceptSkills) {
+        mocks.multiselect.mockResolvedValueOnce(["skill:alpha"]);
+      }
+      mocks.multiselect.mockResolvedValueOnce(mocks.cancelSymbol);
+
+      const result = await command(runtime, { provider: "codex" });
+
+      expect(result).toBe(planned);
+      expect(planned).toStrictEqual(original);
+      expect(mocks.clackCancel).toHaveBeenCalledWith("Migration cancelled.");
+      expect(runtime.log).toHaveBeenCalledWith("Migration cancelled.");
+      expect(mocks.multiselect).toHaveBeenCalledTimes(acceptSkills ? 2 : 1);
+      expect(String(multiselectPrompt().message)).toContain("Select Codex skills");
+      if (acceptSkills) {
+        expect(String(multiselectPrompt(1).message)).toContain("Select native Codex plugins");
+        expect(runtime.log).toHaveBeenCalledWith("Selected 1 of 2 Codex skills for migration.");
+      }
+      expect(mocks.clackConfirm).not.toHaveBeenCalled();
+      expect(mocks.promptYesNo).not.toHaveBeenCalled();
+      expect(mocks.backupCreateCommand).not.toHaveBeenCalled();
+      expect(mocks.provider.apply).not.toHaveBeenCalled();
+    },
+  );
+
   it("prompts for Codex skills before interactive default apply", async () => {
     Object.defineProperty(process.stdin, "isTTY", {
       configurable: true,

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -30,17 +30,13 @@ import {
   formatMigrationPluginSelectionLabel,
   formatMigrationSkillSelectionHint,
   formatMigrationSkillSelectionLabel,
-  getDefaultMigrationPluginSelectionValues,
-  getDefaultMigrationSkillSelectionValues,
-  getMigrationPluginSelectionValue,
-  getMigrationSkillSelectionValue,
+  getDefaultMigrationSelectionValues,
   getSelectableMigrationPluginItems,
   getSelectableMigrationSkillItems,
   MIGRATION_SELECTION_ACCEPT,
   MIGRATION_SELECTION_TOGGLE_ALL_OFF,
   MIGRATION_SELECTION_TOGGLE_ALL_ON,
-  resolveInteractiveMigrationPluginSelection,
-  resolveInteractiveMigrationSkillSelection,
+  resolveInteractiveMigrationSelection,
 } from "./migrate/selection.js";
 import { promptMigrationSkillSelectionValues } from "./migrate/skill-selection-prompt.js";
 import type {
@@ -160,37 +156,51 @@ function assertVerifyPluginAppsProvider(providerId: string, opts: MigrateCommonO
   }
 }
 
-async function promptCodexMigrationSkillSelection(
+async function promptCodexMigrationSelection(
   runtime: RuntimeEnv,
   plan: MigrationPlan,
   opts: MigrateCommonOptions & { yes?: boolean },
+  kind: "skills" | "plugins",
 ): Promise<MigrationPlan | null> {
   if (
     plan.providerId !== "codex" ||
     opts.yes ||
     opts.json ||
-    opts.skills !== undefined ||
+    opts[kind] !== undefined ||
     !process.stdin.isTTY
   ) {
     return plan;
   }
-  const skillItems = getSelectableMigrationSkillItems(plan);
-  if (skillItems.length === 0) {
+  const skillSelection = kind === "skills";
+  const items = skillSelection
+    ? getSelectableMigrationSkillItems(plan)
+    : getSelectableMigrationPluginItems(plan);
+  if (items.length === 0) {
     return plan;
   }
   const selected = await promptMigrationSkillSelectionValues({
-    message: stylePromptMessage("Select Codex skills to migrate into this agent"),
+    message: stylePromptMessage(
+      skillSelection
+        ? "Select Codex skills to migrate into this agent"
+        : "Select native Codex plugins to activate in this agent",
+    ),
     options: [
       {
         value: MIGRATION_SELECTION_ACCEPT,
         label: "Accept recommended",
-        hint: "Migrate every recommended skill",
+        hint: skillSelection
+          ? "Migrate every recommended skill"
+          : "Migrate every recommended plugin",
       },
-      ...skillItems.map((item) => {
-        const hint = formatMigrationSkillSelectionHint(item);
+      ...items.map((item) => {
+        const hint = skillSelection
+          ? formatMigrationSkillSelectionHint(item)
+          : formatMigrationPluginSelectionHint(item);
         return {
-          value: getMigrationSkillSelectionValue(item),
-          label: formatMigrationSkillSelectionLabel(item),
+          value: item.id,
+          label: skillSelection
+            ? formatMigrationSkillSelectionLabel(item)
+            : formatMigrationPluginSelectionLabel(item),
           hint: hint === undefined ? undefined : stylePromptHint(hint),
         };
       }),
@@ -203,8 +213,8 @@ async function promptCodexMigrationSkillSelection(
         label: "Toggle all off",
       },
     ],
-    initialValues: getDefaultMigrationSkillSelectionValues(skillItems),
-    selectableValues: skillItems.map(getMigrationSkillSelectionValue),
+    initialValues: getDefaultMigrationSelectionValues(items),
+    selectableValues: items.map((item) => item.id),
     cursorAt: MIGRATION_SELECTION_ACCEPT,
   });
   if (isCancel(selected)) {
@@ -212,71 +222,14 @@ async function promptCodexMigrationSkillSelection(
     runtime.log("Migration cancelled.");
     return null;
   }
-  const selection = resolveInteractiveMigrationSkillSelection(skillItems, selected ?? []);
-  const selectedPlan = applyMigrationSelectedSkillItemIds(plan, selection.selectedItemIds);
-  runtime.log(
-    `Selected ${selection.selectedItemIds.size} of ${skillItems.length} Codex skills for migration.`,
-  );
-  return selectedPlan;
-}
-
-async function promptCodexMigrationPluginSelection(
-  runtime: RuntimeEnv,
-  plan: MigrationPlan,
-  opts: MigrateCommonOptions & { yes?: boolean },
-): Promise<MigrationPlan | null> {
-  if (
-    plan.providerId !== "codex" ||
-    opts.yes ||
-    opts.json ||
-    opts.plugins !== undefined ||
-    !process.stdin.isTTY
-  ) {
-    return plan;
-  }
-  const pluginItems = getSelectableMigrationPluginItems(plan);
-  if (pluginItems.length === 0) {
-    return plan;
-  }
-  const selected = await promptMigrationSkillSelectionValues({
-    message: stylePromptMessage("Select native Codex plugins to activate in this agent"),
-    options: [
-      {
-        value: MIGRATION_SELECTION_ACCEPT,
-        label: "Accept recommended",
-        hint: "Migrate every recommended plugin",
-      },
-      ...pluginItems.map((item) => {
-        const hint = formatMigrationPluginSelectionHint(item);
-        return {
-          value: getMigrationPluginSelectionValue(item),
-          label: formatMigrationPluginSelectionLabel(item),
-          hint: hint === undefined ? undefined : stylePromptHint(hint),
-        };
-      }),
-      {
-        value: MIGRATION_SELECTION_TOGGLE_ALL_ON,
-        label: "Toggle all on",
-      },
-      {
-        value: MIGRATION_SELECTION_TOGGLE_ALL_OFF,
-        label: "Toggle all off",
-      },
-    ],
-    initialValues: getDefaultMigrationPluginSelectionValues(pluginItems),
-    selectableValues: pluginItems.map(getMigrationPluginSelectionValue),
-    cursorAt: MIGRATION_SELECTION_ACCEPT,
-  });
-  if (isCancel(selected)) {
-    cancel(stylePromptTitle("Migration cancelled.") ?? "Migration cancelled.");
-    runtime.log("Migration cancelled.");
-    return null;
-  }
-  const selection = resolveInteractiveMigrationPluginSelection(pluginItems, selected ?? []);
-  const selectedPlan = applyMigrationSelectedPluginItemIds(plan, selection.selectedItemIds);
-  runtime.log(
-    `Selected ${selection.selectedItemIds.size} of ${pluginItems.length} native Codex plugins for activation.`,
-  );
+  const selection = resolveInteractiveMigrationSelection(items, selected ?? []);
+  const selectedPlan = skillSelection
+    ? applyMigrationSelectedSkillItemIds(plan, selection.selectedItemIds)
+    : applyMigrationSelectedPluginItemIds(plan, selection.selectedItemIds);
+  const purpose = skillSelection
+    ? "Codex skills for migration"
+    : "native Codex plugins for activation";
+  runtime.log(`Selected ${selection.selectedItemIds.size} of ${items.length} ${purpose}.`);
   return selectedPlan;
 }
 
@@ -285,11 +238,11 @@ async function promptCodexMigrationSelections(
   plan: MigrationPlan,
   opts: MigrateCommonOptions & { yes?: boolean },
 ): Promise<MigrationPlan | null> {
-  const skillSelectedPlan = await promptCodexMigrationSkillSelection(runtime, plan, opts);
+  const skillSelectedPlan = await promptCodexMigrationSelection(runtime, plan, opts, "skills");
   if (!skillSelectedPlan) {
     return null;
   }
-  return await promptCodexMigrationPluginSelection(runtime, skillSelectedPlan, opts);
+  return await promptCodexMigrationSelection(runtime, skillSelectedPlan, opts, "plugins");
 }
 
 function hasSelectedCodexMigrationWork(plan: MigrationPlan): boolean {

--- a/src/commands/migrate/selection.test.ts
+++ b/src/commands/migrate/selection.test.ts
@@ -11,16 +11,14 @@ import {
   applyMigrationSelectedSkillItemIds,
   applyMigrationSkillSelection,
   formatMigrationPluginSelectionHint,
-  getDefaultMigrationPluginSelectionValues,
+  getDefaultMigrationSelectionValues,
   getSelectableMigrationPluginItems,
-  getDefaultMigrationSkillSelectionValues,
   MIGRATION_SELECTION_TOGGLE_ALL_OFF,
   MIGRATION_SELECTION_TOGGLE_ALL_ON,
   reconcileInteractiveMigrationEnterValues,
   reconcileInteractiveMigrationShortcutValues,
   reconcileInteractiveMigrationSkillToggleValues,
-  resolveInteractiveMigrationPluginSelection,
-  resolveInteractiveMigrationSkillSelection,
+  resolveInteractiveMigrationSelection,
 } from "./selection.js";
 
 const MIGRATION_NOT_SELECTED_REASON = "not selected for migration";
@@ -280,7 +278,7 @@ describe("applyMigrationSkillSelection", () => {
 
   it("defaults interactive selection to planned skills only", () => {
     expect(
-      getDefaultMigrationSkillSelectionValues([
+      getDefaultMigrationSelectionValues([
         skillItem({ id: "skill:alpha", name: "alpha" }),
         skillItem({
           id: "skill:beta",
@@ -304,13 +302,13 @@ describe("applyMigrationSkillSelection", () => {
     ];
 
     expect(
-      resolveInteractiveMigrationSkillSelection(items, [
+      resolveInteractiveMigrationSelection(items, [
         MIGRATION_SELECTION_TOGGLE_ALL_ON,
         MIGRATION_SELECTION_TOGGLE_ALL_OFF,
       ]),
     ).toEqual({ action: "select", selectedItemIds: new Set() });
     expect(
-      resolveInteractiveMigrationSkillSelection(items, [MIGRATION_SELECTION_TOGGLE_ALL_ON]),
+      resolveInteractiveMigrationSelection(items, [MIGRATION_SELECTION_TOGGLE_ALL_ON]),
     ).toEqual({
       action: "select",
       selectedItemIds: new Set(["skill:alpha", "skill:beta"]),
@@ -425,29 +423,78 @@ describe("applyMigrationSkillSelection", () => {
 });
 
 describe("applyMigrationPluginSelection", () => {
-  it("keeps selected plugins and skips unselected plugin install items", () => {
-    const selected = applyMigrationPluginSelection(
-      plan([
+  it.each([
+    { value: undefined },
+    { value: null },
+    { value: [] },
+    { value: {} },
+    { value: { config: [] } },
+    { value: { config: { codexPlugins: [] } } },
+    { value: { config: { codexPlugins: { plugins: [] } } } },
+  ])("leaves unrelated config shapes unchanged: %j", ({ value }) => {
+    const item: MigrationItem = {
+      id: "config:other",
+      kind: "config",
+      action: "merge",
+      status: "planned",
+      details: { value },
+    };
+
+    const selected = applyMigrationSelectedPluginItemIds(plan([item]), new Set());
+
+    expect(selected.items[0]).toBe(item);
+  });
+
+  it.each([
+    { kind: "config", action: "create" },
+    { kind: "archive", action: "merge" },
+  ])("does not filter plugin-shaped data outside config merges: %j", (identity) => {
+    const item = { ...codexPluginConfigItem(["gmail"]), ...identity };
+    const selected = applyMigrationSelectedPluginItemIds(plan([item]), new Set());
+
+    expect(selected.items[0]).toBe(item);
+    expectSummaryFields(selected.summary, { planned: 1, skipped: 0 });
+  });
+
+  it.each([
+    { skipConfig: false, planned: 2, skipped: 1 },
+    { skipConfig: true, planned: 1, skipped: 2 },
+  ])(
+    "keeps selected plugins and skips unselected plugin install items (config skipped: $skipConfig)",
+    ({ skipConfig, planned, skipped }) => {
+      const initial = plan([
         pluginItem({ id: "plugin:google-calendar", name: "google-calendar" }),
         pluginItem({ id: "plugin:gmail", name: "gmail" }),
         codexPluginConfigItem(["google-calendar", "gmail"]),
-      ]),
-      ["google-calendar"],
-    );
+      ]);
+      const selected = applyMigrationPluginSelection(
+        skipConfig
+          ? applyMigrationItemSelection(initial, ["plugin:google-calendar", "plugin:gmail"])
+          : initial,
+        ["google-calendar"],
+      );
 
-    expectSummaryFields(selected.summary, { planned: 2, skipped: 1, conflicts: 0 });
-    expectItemStatus(selected.items, "plugin:google-calendar", "planned");
-    expectItemStatus(selected.items, "plugin:gmail", "skipped", MIGRATION_NOT_SELECTED_REASON);
-    const configItem = requireItem(selected.items, "config:codex-plugins");
-    expect(configItem.status).toBe("planned");
-    const plugins = requireCodexPluginConfigPlugins(configItem);
-    expect(requireRecord(plugins["google-calendar"], "google calendar plugin config")).toEqual({
-      enabled: true,
-      marketplaceName: "openai-curated",
-      pluginName: "google-calendar",
-    });
-    expect(Object.keys(plugins)).toEqual(["google-calendar"]);
-  });
+      expectSummaryFields(selected.summary, { planned, skipped, conflicts: 0 });
+      expectItemStatus(selected.items, "plugin:google-calendar", "planned");
+      expectItemStatus(selected.items, "plugin:gmail", "skipped", MIGRATION_NOT_SELECTED_REASON);
+      const configItem = requireItem(selected.items, "config:codex-plugins");
+      expect(configItem.status).toBe(skipConfig ? "skipped" : "planned");
+      expect(configItem.reason).toBe(skipConfig ? MIGRATION_NOT_SELECTED_REASON : undefined);
+      expect(configItem.details).toMatchObject({
+        value: {
+          enabled: true,
+          config: { codexPlugins: { enabled: true, allow_destructive_actions: true } },
+        },
+      });
+      const plugins = requireCodexPluginConfigPlugins(configItem);
+      expect(requireRecord(plugins["google-calendar"], "google calendar plugin config")).toEqual({
+        enabled: true,
+        marketplaceName: "openai-curated",
+        pluginName: "google-calendar",
+      });
+      expect(Object.keys(plugins)).toEqual(["google-calendar"]);
+    },
+  );
 
   it("skips the Codex plugin config item when no plugin remains selected", () => {
     const selected = applyMigrationPluginSelection(
@@ -491,7 +538,7 @@ describe("applyMigrationPluginSelection", () => {
 
   it("defaults interactive plugin selection to planned plugins", () => {
     expect(
-      getDefaultMigrationPluginSelectionValues([
+      getDefaultMigrationSelectionValues([
         pluginItem({ id: "plugin:google-calendar", name: "google-calendar" }),
         pluginItem({
           id: "plugin:gmail",
@@ -530,18 +577,18 @@ describe("applyMigrationPluginSelection", () => {
     ];
 
     expect(
-      resolveInteractiveMigrationPluginSelection(items, [
+      resolveInteractiveMigrationSelection(items, [
         MIGRATION_SELECTION_TOGGLE_ALL_ON,
         MIGRATION_SELECTION_TOGGLE_ALL_OFF,
       ]),
     ).toEqual({ action: "select", selectedItemIds: new Set() });
     expect(
-      resolveInteractiveMigrationPluginSelection(items, [MIGRATION_SELECTION_TOGGLE_ALL_ON]),
+      resolveInteractiveMigrationSelection(items, [MIGRATION_SELECTION_TOGGLE_ALL_ON]),
     ).toEqual({
       action: "select",
       selectedItemIds: new Set(["plugin:google-calendar", "plugin:gmail"]),
     });
-    expect(resolveInteractiveMigrationPluginSelection(items, ["plugin:gmail"])).toEqual({
+    expect(resolveInteractiveMigrationSelection(items, ["plugin:gmail"])).toEqual({
       action: "select",
       selectedItemIds: new Set(["plugin:gmail"]),
     });

--- a/src/commands/migrate/selection.ts
+++ b/src/commands/migrate/selection.ts
@@ -15,10 +15,6 @@ export const MIGRATION_SELECTION_TOGGLE_ALL_ON = "__openclaw_migrate_toggle_all_
 export const MIGRATION_SELECTION_TOGGLE_ALL_OFF = "__openclaw_migrate_toggle_all_off__";
 
 type InteractiveMigrationSelection = { action: "select"; selectedItemIds: Set<string> };
-/** Interactive skill selection result consumed by the apply flow. */
-type InteractiveMigrationSkillSelection = InteractiveMigrationSelection;
-/** Interactive plugin selection result consumed by the apply flow. */
-type InteractiveMigrationPluginSelection = InteractiveMigrationSelection;
 
 function normalizeSelectionRef(value: string): string {
   return value.trim().toLowerCase();
@@ -148,34 +144,6 @@ function resolveSelectedMigrationItemIds(params: {
   return selectedIds;
 }
 
-function resolveSelectedSkillItemIds(
-  items: readonly MigrationItem[],
-  selectedRefs: readonly string[],
-): Set<string> {
-  return resolveSelectedMigrationItemIds({
-    items,
-    selectedRefs,
-    refsForItem: migrationSkillRefs,
-    formatSelectionLabel: formatMigrationSkillSelectionLabel,
-    kindLabel: "skill",
-    availableLabel: "skills",
-  });
-}
-
-function resolveSelectedPluginItemIds(
-  items: readonly MigrationItem[],
-  selectedRefs: readonly string[],
-): Set<string> {
-  return resolveSelectedMigrationItemIds({
-    items,
-    selectedRefs,
-    refsForItem: migrationPluginRefs,
-    formatSelectionLabel: formatMigrationPluginSelectionLabel,
-    kindLabel: "plugin",
-    availableLabel: "plugins",
-  });
-}
-
 /** Returns skill copy items that can still be selected or deselected. */
 export function getSelectableMigrationSkillItems(plan: MigrationPlan): MigrationItem[] {
   return plan.items.filter(
@@ -201,31 +169,14 @@ export function getSelectableMigrationPluginItems(plan: MigrationPlan): Migratio
   );
 }
 
-/** Returns the stable checkbox value for a skill migration item. */
-export function getMigrationSkillSelectionValue(item: MigrationItem): string {
-  return item.id;
-}
-
-/** Returns the stable checkbox value for a plugin migration item. */
-export function getMigrationPluginSelectionValue(item: MigrationItem): string {
-  return item.id;
-}
-
 /** Formats the visible label for a plugin migration checkbox. */
 export function formatMigrationPluginSelectionLabel(item: MigrationItem): string {
   return readMigrationPluginName(item) ?? item.id.replace(/^plugin:/u, "");
 }
 
-/** Defaults skill selection to planned items only. */
-export function getDefaultMigrationSkillSelectionValues(items: readonly MigrationItem[]): string[] {
-  return items.filter((item) => item.status === "planned").map(getMigrationSkillSelectionValue);
-}
-
-/** Defaults plugin selection to planned items only. */
-export function getDefaultMigrationPluginSelectionValues(
-  items: readonly MigrationItem[],
-): string[] {
-  return items.filter((item) => item.status === "planned").map(getMigrationPluginSelectionValue);
+/** Defaults migration checkboxes to planned item ids in plan order. */
+export function getDefaultMigrationSelectionValues(items: readonly MigrationItem[]): string[] {
+  return items.filter((item) => item.status === "planned").map((item) => item.id);
 }
 
 /** Formats the visible label for a skill migration checkbox. */
@@ -311,7 +262,14 @@ export function applyMigrationSkillSelection(
     return plan;
   }
   const selectable = getSelectableMigrationSkillItems(plan);
-  const selectedIds = resolveSelectedSkillItemIds(selectable, selectedSkillRefs);
+  const selectedIds = resolveSelectedMigrationItemIds({
+    items: selectable,
+    selectedRefs: selectedSkillRefs,
+    refsForItem: migrationSkillRefs,
+    formatSelectionLabel: formatMigrationSkillSelectionLabel,
+    kindLabel: "skill",
+    availableLabel: "skills",
+  });
   return applyMigrationSelectedSkillItemIds(plan, selectedIds);
 }
 
@@ -324,7 +282,14 @@ export function applyMigrationPluginSelection(
     return plan;
   }
   const selectable = getSelectableMigrationPluginItems(plan);
-  const selectedIds = resolveSelectedPluginItemIds(selectable, selectedPluginRefs);
+  const selectedIds = resolveSelectedMigrationItemIds({
+    items: selectable,
+    selectedRefs: selectedPluginRefs,
+    refsForItem: migrationPluginRefs,
+    formatSelectionLabel: formatMigrationPluginSelectionLabel,
+    kindLabel: "plugin",
+    availableLabel: "plugins",
+  });
   return applyMigrationSelectedPluginItemIds(plan, selectedIds);
 }
 
@@ -342,8 +307,9 @@ export function applyMigrationSelectedPluginItemIds(
       .filter((value): value is string => value !== undefined),
   );
   const items = plan.items.map((item) => {
-    if (isCodexPluginConfigItem(item)) {
-      return applyCodexPluginConfigSelection(item, selectedConfigKeys);
+    const selectedConfigItem = applyCodexPluginConfigSelection(item, selectedConfigKeys);
+    if (selectedConfigItem) {
+      return selectedConfigItem;
     }
     if (!selectableIds.has(item.id) || selectedItemIds.has(item.id)) {
       return item;
@@ -357,40 +323,25 @@ export function applyMigrationSelectedPluginItemIds(
   };
 }
 
-function isCodexPluginConfigItem(item: MigrationItem): boolean {
-  if (item.kind !== "config" || item.action !== "merge") {
-    return false;
-  }
-  const value = item.details?.value;
-  if (!isRecord(value)) {
-    return false;
-  }
-  const config = value.config;
-  if (!isRecord(config)) {
-    return false;
-  }
-  const codexPlugins = config.codexPlugins;
-  if (!isRecord(codexPlugins)) {
-    return false;
-  }
-  return isRecord(codexPlugins.plugins);
-}
-
 function applyCodexPluginConfigSelection(
   item: MigrationItem,
   selectedConfigKeys: ReadonlySet<string>,
-): MigrationItem {
+): MigrationItem | undefined {
+  // Nonmatching config shapes still pass through ordinary item-id selection.
+  if (item.kind !== "config" || item.action !== "merge") {
+    return undefined;
+  }
   const value = item.details?.value;
   if (!isRecord(value)) {
-    return item;
+    return undefined;
   }
   const config = value.config;
   if (!isRecord(config)) {
-    return item;
+    return undefined;
   }
   const codexPlugins = config.codexPlugins;
   if (!isRecord(codexPlugins) || !isRecord(codexPlugins.plugins)) {
-    return item;
+    return undefined;
   }
   const plugins = Object.fromEntries(
     Object.entries(codexPlugins.plugins).filter(([configKey]) => selectedConfigKeys.has(configKey)),
@@ -416,12 +367,12 @@ function applyCodexPluginConfigSelection(
   };
 }
 
-function resolveInteractiveMigrationSelection(
+/** Resolves checkbox values into migration item ids for either selector. */
+export function resolveInteractiveMigrationSelection(
   items: readonly MigrationItem[],
   selectedValues: readonly string[],
-  getSelectionValue: (item: MigrationItem) => string,
 ): InteractiveMigrationSelection {
-  const selectableIds = new Set(items.map(getSelectionValue));
+  const selectableIds = new Set(items.map((item) => item.id));
   const selectedItemIds = new Set(selectedValues.filter((value) => selectableIds.has(value)));
   if (selectedItemIds.size > 0) {
     return { action: "select", selectedItemIds };
@@ -462,30 +413,6 @@ function resolveMigrationSelectionBulkToggleValues(
     return [MIGRATION_SELECTION_TOGGLE_ALL_OFF];
   }
   return undefined;
-}
-
-/** Resolves checkbox values into selected skill migration item ids. */
-export function resolveInteractiveMigrationSkillSelection(
-  items: readonly MigrationItem[],
-  selectedValues: readonly string[],
-): InteractiveMigrationSkillSelection {
-  return resolveInteractiveMigrationSelection(
-    items,
-    selectedValues,
-    getMigrationSkillSelectionValue,
-  );
-}
-
-/** Resolves checkbox values into selected plugin migration item ids. */
-export function resolveInteractiveMigrationPluginSelection(
-  items: readonly MigrationItem[],
-  selectedValues: readonly string[],
-): InteractiveMigrationPluginSelection {
-  return resolveInteractiveMigrationSelection(
-    items,
-    selectedValues,
-    getMigrationPluginSelectionValue,
-  );
 }
 
 /** Reconciles all/none checkbox toggles for the skill-selection prompt. */


### PR DESCRIPTION
## What Problem This Solves

The migration selector has separate skill and plugin copies of the same checkbox/default flow, plus an aggregate plugin-config predicate that repeats validation in its transformer. This is a maintainer-requested cleanup of that duplication, not a claimed fix for a newly reproduced user-facing migration defect.

## Why This Change Was Made

Use one prompt adapter and the existing shared item-id selection owner for both kinds. Keep skill and plugin eligibility, reference matching, labels, hints, and their selection-specific plan updates separate. Fold aggregate plugin-config recognition into its existing transformer so nonmatching shapes continue through ordinary item selection.

The change removes identity/default/resolver facades and duplicate prompt orchestration: production **−120 lines** (+71/−191), tests **+87 lines**, across four files.

## User Impact

No intended CLI, selection order, defaults, visible wording, cancellation, skip-reason, or configuration-shape change. Skills are still offered before plugins; explicit selectors and `--yes` keep their existing paths. No persistence/schema, auth, provider policy, dependency, or public SDK change is included.

## Evidence

- The original five-suite baseline passed 71 cases. The same owner plus characterization controls passed 84 cases before implementation; the candidate passed the same 84 case identities and within-suite order. Controls cover cancellation after accepting skills, unrelated config shapes, and already-skipped aggregate config with preserved sibling fields.
- Four fresh real Commander/Clack PTY scenarios passed with an isolated fixture provider: cancellation at plugins through default and apply, declining final confirmation, and `--yes` with exact skill/plugin selectors and no input. This proves the core selection/dispatch boundary, **not** native Codex discovery, installation, credentials, backup contents, or a real Codex migration.
- The ordinary configured changed gate passed all 29 required checks, followed by the normal full 16-stage build. Source, dependency, generated-output, and known-process closure were qualified separately. These are prepublication source-tree results, not future exact-head PR CI.
- Precommit Codex review and a separate review of saved commit `ec2f1e4bf148538996599f67f5fe53012d6e3f24` each completed two normal evidence passes with no findings at the requested P0 threshold. Both review closeouts verified source integrity and known-process/owned-temporary-directory cleanup. These are scoped advisory reviews, not all-priority verdicts or hosted CI.
- Earlier failed evidence is retained: one changed-gate run stopped on formatting; the final delta was only the formatter-required two-line ternary wrap. An earlier PTY fixture omitted canonical Commander positional-option setup; the corrected four-case run was fresh, with no partial-result transfer. The earlier fixture and its two coordinator files remain retained; no whole-host cleanup claim is made.

Named follow-ups outside this cleanup: align the existing CLI registration test harness with canonical positional parsing and assert forwarded flags; refresh stale selection wording in `docs/cli/migrate.md`; investigate the separately recorded media-core browser-externalization build warning without suppressing it.

<details>
<summary>Additional instructions</summary>

Please leave **Allow edits from maintainers** enabled so maintainers can help finish the PR if needed.

</details>
