### PR TITLE
fix(ui): keep session Tasks panel stable during activity

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -12247,19 +12247,22 @@ public struct TasksListParams: Codable, Sendable {
     public let sessionkey: String?
     public let limit: Int?
     public let cursor: String?
+    public let sortby: String?
 
     public init(
         status: AnyCodable? = nil,
         agentid: String? = nil,
         sessionkey: String? = nil,
         limit: Int? = nil,
-        cursor: String? = nil)
+        cursor: String? = nil,
+        sortby: String? = nil)
     {
         self.status = status
         self.agentid = agentid
         self.sessionkey = sessionkey
         self.limit = limit
         self.cursor = cursor
+        self.sortby = sortby
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -12268,6 +12271,7 @@ public struct TasksListParams: Codable, Sendable {
         case sessionkey = "sessionKey"
         case limit
         case cursor
+        case sortby = "sortBy"
     }
 }
 

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -343,6 +343,8 @@ The web Control UI has a **Tasks** page in the sidebar with live active and rece
 
 Chat panes also have a collapsible **Background tasks** rail scoped to the pane's agent, with running work, stop controls, and a finished section. Open it from the activity toggle in the pane header (or the floating activity button in single-pane chat).
 
+Running work stays in creation order so progress updates do not move rows while you monitor them. Finished work is selected and displayed by completion time, newest first. Transient list conflicts retry silently; if retries are exhausted, use **Refresh** in the Tasks panel header.
+
 Select a task to replace the list with a compact detail view inside the rail; use the back button to return to the list. The detail view shows the bounded input prompt, latest output or error summary, timing, and current tool activity. Subagent details stay in the rail rather than opening their child conversation in the main chat pane; linked-session actions remain available for task runtimes intended for direct inspection. On iOS, open **Chat actions → Background Tasks**; on Android, open the Chat overflow menu and select **Background tasks**. Both mobile views use the same Running and Finished grouping and open task details on selection.
 
 ## Status integration (task pressure)

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -1091,7 +1091,10 @@ return sanitized task summaries, not raw runtime state.
   - Params: optional `status` (`"queued"`, `"running"`, `"completed"`,
     `"failed"`, `"cancelled"`, or `"timed_out"`) or an array of those statuses,
     optional `agentId`, optional `sessionKey`, optional `limit` from `1` to
-    `500`, and optional string `cursor`.
+    `500`, optional string `cursor`, and optional `sortBy` (`"updatedAt"` or
+    `"endedAt"`). Ordering is descending; omitted `sortBy` uses last activity.
+    Use `"endedAt"` with terminal status filters when page membership must
+    reflect completion order.
   - Result: `{ "tasks": TaskSummary[], "nextCursor"?: string }`.
 - `tasks.get` requires `operator.read`.
   - Params: `{ "taskId": string }`.

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -1094,7 +1094,9 @@ return sanitized task summaries, not raw runtime state.
     `500`, optional string `cursor`, and optional `sortBy` (`"updatedAt"` or
     `"endedAt"`). Ordering is descending; omitted `sortBy` uses last activity.
     Use `"endedAt"` with terminal status filters when page membership must
-    reflect completion order.
+    reflect completion order. Legacy terminal rows without a stored `endedAt`
+    use their recorded terminal activity time, then creation time, as the
+    canonical completion timestamp before pagination.
   - Result: `{ "tasks": TaskSummary[], "nextCursor"?: string }`.
 - `tasks.get` requires `operator.read`.
   - Params: `{ "taskId": string }`.

--- a/packages/gateway-protocol/src/index.test.ts
+++ b/packages/gateway-protocol/src/index.test.ts
@@ -26,9 +26,6 @@ import {
   validateSessionsSearchParams,
   validateSessionsSendParams,
   validateSessionsUsageParams,
-  validateTasksCancelParams,
-  validateTasksListParams,
-  validateTasksRecoveryParams,
   validateTalkConfigResult,
   validateTalkClientCreateParams,
   validateTalkClientCreateResult,
@@ -1038,36 +1035,6 @@ describe("validateModelsProbeParams", () => {
       {},
       { provider: "openai", timeoutMs: 0 },
       { provider: "openai", extra: true },
-    ]);
-  });
-});
-
-describe("validateTasksListParams", () => {
-  it("accepts SDK task ledger filters", () => {
-    expectAccepted(validateTasksListParams, [
-      {
-        status: ["running", "completed"],
-        agentId: "main",
-        sessionKey: "agent:main:main",
-        limit: 50,
-        cursor: "100",
-      },
-    ]);
-  });
-
-  it("rejects internal task statuses and unknown fields", () => {
-    expectRejected(validateTasksListParams, [{ status: "succeeded" }]);
-    expectRejected(validateTasksCancelParams, [{ taskId: "task-1", force: true }]);
-  });
-});
-
-describe("validateTasksRecoveryParams", () => {
-  it("accepts one to ten task ids and rejects unbounded recovery batches", () => {
-    expectAccepted(validateTasksRecoveryParams, [{ taskIds: ["task-1", "task-2"] }]);
-    expectRejected(validateTasksRecoveryParams, [
-      { taskIds: [] },
-      { taskIds: Array.from({ length: 11 }, (_, index) => `task-${index}`) },
-      { taskIds: ["task-1"], force: true },
     ]);
   });
 });

--- a/packages/gateway-protocol/src/schema/tasks.ts
+++ b/packages/gateway-protocol/src/schema/tasks.ts
@@ -32,6 +32,10 @@ const TaskDeliveryStatusSchema = Type.Union([
   Type.Literal("not_applicable"),
 ]);
 const TaskTerminalOutcomeSchema = Type.Union([Type.Literal("succeeded"), Type.Literal("blocked")]);
+const TaskListSortBySchema = Type.Unsafe<"updatedAt" | "endedAt">({
+  type: "string",
+  enum: ["updatedAt", "endedAt"],
+});
 const TaskDiffStatSchema = withSince(
   "2026.8",
   closedObject({
@@ -85,6 +89,7 @@ export const TasksListParamsSchema = closedObject({
   sessionKey: Type.Optional(NonEmptyString),
   limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 500 })),
   cursor: Type.Optional(Type.String({ maxLength: TASKS_LIST_CURSOR_MAX_LENGTH })),
+  sortBy: Type.Optional(withSince("2026.8", TaskListSortBySchema)),
 });
 
 /** Task list page response. */

--- a/packages/gateway-protocol/src/tasks-validators.test.ts
+++ b/packages/gateway-protocol/src/tasks-validators.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateTasksCancelParams,
+  validateTasksListParams,
+  validateTasksRecoveryParams,
+} from "./validator-registry.js";
+
+describe("task validators", () => {
+  it("accepts SDK task ledger filters and order selectors", () => {
+    for (const value of [
+      {
+        status: ["running", "completed"],
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        limit: 50,
+        cursor: "100",
+        sortBy: "endedAt",
+      },
+      { sortBy: "updatedAt" },
+    ]) {
+      expect(validateTasksListParams(value)).toBe(true);
+    }
+  });
+
+  it("rejects internal task statuses and unknown order selectors", () => {
+    expect(validateTasksListParams({ status: "succeeded" })).toBe(false);
+    expect(validateTasksListParams({ sortBy: "createdAt" })).toBe(false);
+    expect(validateTasksCancelParams({ taskId: "task-1", force: true })).toBe(false);
+  });
+
+  it("bounds recovery batches", () => {
+    expect(validateTasksRecoveryParams({ taskIds: ["task-1", "task-2"] })).toBe(true);
+    expect(validateTasksRecoveryParams({ taskIds: [] })).toBe(false);
+    expect(
+      validateTasksRecoveryParams({
+        taskIds: Array.from({ length: 11 }, (_, index) => `task-${index}`),
+      }),
+    ).toBe(false);
+    expect(validateTasksRecoveryParams({ taskIds: ["task-1"], force: true })).toBe(false);
+  });
+});

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -588,6 +588,7 @@ describe("OpenClaw SDK", () => {
       status: "running",
       agentId: "main",
       sessionKey: "agent:main:main",
+      sortBy: "endedAt",
     });
     expect(taskList.tasks).toEqual([
       {
@@ -616,7 +617,12 @@ describe("OpenClaw SDK", () => {
     expect(transport.calls).toEqual([
       {
         method: "tasks.list",
-        params: { status: "running", agentId: "main", sessionKey: "agent:main:main" },
+        params: {
+          status: "running",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          sortBy: "endedAt",
+        },
         options: undefined,
       },
       {

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -1294,7 +1294,9 @@ describe("cron service ops seam coverage", () => {
         },
       });
       runOpenClawStateWriteTransaction(({ db }) => {
-        db.prepare("UPDATE task_runs SET ended_at = -1 WHERE run_id = ?").run(taskRunId);
+        db.prepare(
+          "UPDATE task_runs SET created_at = -1, started_at = -1, ended_at = -1, last_event_at = -1 WHERE run_id = ?",
+        ).run(taskRunId);
       });
 
       await start(state);

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -314,60 +314,11 @@ describe("tasks gateway handlers", () => {
     });
     reloadTaskRegistryFromStore();
 
-    const { payload } = await runTaskHandler("tasks.list", {
-      status: ["completed", "failed", "timed_out", "cancelled"],
-      sortBy: "endedAt",
-    });
+    const { payload } = await runTaskHandler("tasks.list", {});
 
     expect(payload?.tasks?.map((task) => task.taskId)).toEqual([
       justFinished.taskId,
       finishedEarlier.taskId,
-    ]);
-  });
-
-  it("selects the bounded terminal page by completion time", async () => {
-    const base = Date.now();
-    const tasks = [
-      createSnapshotTask({
-        taskId: "task-finished-newest",
-        runId: "run-finished-newest",
-        status: "succeeded",
-        deliveryStatus: "not_applicable",
-        endedAt: base + 300,
-        lastEventAt: base + 100,
-      }),
-      createSnapshotTask({
-        taskId: "task-activity-newest",
-        runId: "run-activity-newest",
-        status: "succeeded",
-        deliveryStatus: "not_applicable",
-        endedAt: base + 100,
-        lastEventAt: base + 300,
-      }),
-      createSnapshotTask({
-        taskId: "task-finished-middle",
-        runId: "run-finished-middle",
-        status: "succeeded",
-        deliveryStatus: "not_applicable",
-        endedAt: base + 200,
-        lastEventAt: base + 200,
-      }),
-    ];
-    saveTaskRegistryStateToSqlite({
-      tasks: new Map(tasks.map((task) => [task.taskId, task])),
-      deliveryStates: new Map(),
-    });
-    reloadTaskRegistryFromStore();
-
-    const { payload } = await runTaskHandler("tasks.list", {
-      status: "completed",
-      sortBy: "endedAt",
-      limit: 2,
-    });
-
-    expect(payload?.tasks?.map((task) => task.taskId)).toEqual([
-      "task-finished-newest",
-      "task-finished-middle",
     ]);
   });
 

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -314,11 +314,60 @@ describe("tasks gateway handlers", () => {
     });
     reloadTaskRegistryFromStore();
 
-    const { payload } = await runTaskHandler("tasks.list", {});
+    const { payload } = await runTaskHandler("tasks.list", {
+      status: ["completed", "failed", "timed_out", "cancelled"],
+      sortBy: "endedAt",
+    });
 
     expect(payload?.tasks?.map((task) => task.taskId)).toEqual([
       justFinished.taskId,
       finishedEarlier.taskId,
+    ]);
+  });
+
+  it("selects the bounded terminal page by completion time", async () => {
+    const base = Date.now();
+    const tasks = [
+      createSnapshotTask({
+        taskId: "task-finished-newest",
+        runId: "run-finished-newest",
+        status: "succeeded",
+        deliveryStatus: "not_applicable",
+        endedAt: base + 300,
+        lastEventAt: base + 100,
+      }),
+      createSnapshotTask({
+        taskId: "task-activity-newest",
+        runId: "run-activity-newest",
+        status: "succeeded",
+        deliveryStatus: "not_applicable",
+        endedAt: base + 100,
+        lastEventAt: base + 300,
+      }),
+      createSnapshotTask({
+        taskId: "task-finished-middle",
+        runId: "run-finished-middle",
+        status: "succeeded",
+        deliveryStatus: "not_applicable",
+        endedAt: base + 200,
+        lastEventAt: base + 200,
+      }),
+    ];
+    saveTaskRegistryStateToSqlite({
+      tasks: new Map(tasks.map((task) => [task.taskId, task])),
+      deliveryStates: new Map(),
+    });
+    reloadTaskRegistryFromStore();
+
+    const { payload } = await runTaskHandler("tasks.list", {
+      status: "completed",
+      sortBy: "endedAt",
+      limit: 2,
+    });
+
+    expect(payload?.tasks?.map((task) => task.taskId)).toEqual([
+      "task-finished-newest",
+      "task-finished-middle",
     ]);
   });
 

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -207,6 +207,8 @@ export const tasksHandlers: GatewayRequestHandlers = {
       cfg,
       filter: canReadTask,
     };
+    // Page scans yield to active task updates. Restart the complete selection
+    // and authorization attempt so transient registry churn never reaches clients.
     for (let attempt = 0; attempt < TASKS_LIST_MAX_ATTEMPTS; attempt += 1) {
       const accessRevision = readGatewayAccessRevision();
       if (cursor && cursor.accessRevision !== accessRevision) {
@@ -215,16 +217,13 @@ export const tasksHandlers: GatewayRequestHandlers = {
       }
       const pageResult = await listTaskRecordPage(pageParams);
       if (!pageResult.ok) {
+        // A cursor bound to an older revision can never succeed on retry, so it
+        // restarts the caller. Transient registry churn gets another attempt.
         if (pageResult.error === "cursor_stale") {
           invalidTaskListCursor(respond);
           return;
         }
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.UNAVAILABLE, "task registry changed during tasks.list; retry"),
-        );
-        return;
+        continue;
       }
       const page = pageResult.value;
       // Sharing changes invalidate every access decision made before a yield.
@@ -258,7 +257,11 @@ export const tasksHandlers: GatewayRequestHandlers = {
     respond(
       false,
       undefined,
-      errorShape(ErrorCodes.UNAVAILABLE, "task access changed during tasks.list; retry"),
+      errorShape(
+        ErrorCodes.UNAVAILABLE,
+        "Task activity did not stabilize. Wait a moment, then refresh Tasks.",
+        { retryable: true, retryAfterMs: 250 },
+      ),
     );
   },
   "tasks.get": ({ params, respond, context, client }) => {

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -183,6 +183,7 @@ export const tasksHandlers: GatewayRequestHandlers = {
       agentId,
       sessionKey,
       sessionAgentId,
+      params.sortBy ?? null,
     ];
     const bindCursor = (...fields: number[]) => taskListFingerprint([fields, ...bindingFacts]);
     const cursorBinding =
@@ -191,9 +192,8 @@ export const tasksHandlers: GatewayRequestHandlers = {
       invalidTaskListCursor(respond);
       return;
     }
-    // The ledger pages by last activity so an old long-running task that just
-    // finished still surfaces first. Selection stays inside the registry so
-    // only the bounded wire page pays for defensive record cloning.
+    // Selection stays inside the registry so ordering applies before pagination
+    // and only the bounded wire page pays for defensive record cloning.
     const canReadTask = (task: Readonly<TaskRecord>) =>
       canAccessTaskRequesterSession({ cfg, client, task });
     const pageParams = {
@@ -206,6 +206,7 @@ export const tasksHandlers: GatewayRequestHandlers = {
       sessionAgentId,
       cfg,
       filter: canReadTask,
+      sortBy: params.sortBy,
     };
     // Page scans yield to active task updates. Restart the complete selection
     // and authorization attempt so transient registry churn never reaches clients.

--- a/src/gateway/server.tasks-list-performance.test.ts
+++ b/src/gateway/server.tasks-list-performance.test.ts
@@ -392,7 +392,7 @@ describe("tasks.list Gateway performance", () => {
           resetTaskRegistryForTests({ persist: false });
           let convergingChurnStarted = false;
           let convergingRevision = 0;
-          const convergingRevisionTarget = 937;
+          const convergingRevisionTarget = 1;
           const convergeTaskRegistry = () => {
             if (convergingRevision >= convergingRevisionTarget) {
               return;

--- a/src/gateway/server.tasks-list-performance.test.ts
+++ b/src/gateway/server.tasks-list-performance.test.ts
@@ -40,7 +40,7 @@ type RpcResponse<T extends Record<string, unknown>> = {
   id: string;
   ok: boolean;
   payload?: T;
-  error?: { code?: string; message?: string };
+  error?: { code?: string; message?: string; retryable?: boolean; retryAfterMs?: number };
   [key: string]: unknown;
 };
 
@@ -384,6 +384,49 @@ describe("tasks.list Gateway performance", () => {
             sessionKey: OWNED_SESSION_KEY,
           });
 
+          const convergingTasks = createTaskSnapshot();
+          const convergingTaskId = convergingTasks.keys().next().value;
+          if (!convergingTaskId) {
+            throw new Error("expected a converging task fixture");
+          }
+          resetTaskRegistryForTests({ persist: false });
+          let convergingChurnStarted = false;
+          let convergingRevision = 0;
+          const convergingRevisionTarget = 937;
+          const convergeTaskRegistry = () => {
+            if (convergingRevision >= convergingRevisionTarget) {
+              return;
+            }
+            convergingRevision += 1;
+            markTaskTerminalById({
+              taskId: convergingTaskId,
+              status: "succeeded",
+              endedAt: TASK_COUNT + convergingRevision,
+            });
+            setImmediate(convergeTaskRegistry);
+          };
+          configureTaskRegistryRuntime({
+            store: {
+              loadSnapshot: () => {
+                if (!convergingChurnStarted) {
+                  convergingChurnStarted = true;
+                  setImmediate(convergeTaskRegistry);
+                }
+                return { tasks: convergingTasks, deliveryStates: new Map() };
+              },
+              saveSnapshot: () => {},
+            },
+          });
+          const convergedRegistry = await sendRpc<TasksListResult>(
+            admin,
+            "tasks-converged-registry",
+            "tasks.list",
+            { limit: 1 },
+          );
+          expect(convergingRevision).toBe(convergingRevisionTarget);
+          expect(convergedRegistry.ok, JSON.stringify(convergedRegistry.error)).toBe(true);
+          expect(convergedRegistry.payload?.tasks).toHaveLength(1);
+
           const churnTasks = createTaskSnapshot();
           const churnTaskId = churnTasks.keys().next().value;
           if (!churnTaskId) {
@@ -430,7 +473,12 @@ describe("tasks.list Gateway performance", () => {
           expect(taskChurnRevision).toBeGreaterThanOrEqual(3);
           expect(unstableRegistry).toMatchObject({
             ok: false,
-            error: { code: "UNAVAILABLE", message: expect.stringContaining("retry") },
+            error: {
+              code: "UNAVAILABLE",
+              message: "Task activity did not stabilize. Wait a moment, then refresh Tasks.",
+              retryable: true,
+              retryAfterMs: 250,
+            },
           });
 
           const accessTasks = new Map([...createTaskSnapshot()].slice(0, 1_000));
@@ -477,7 +525,12 @@ describe("tasks.list Gateway performance", () => {
           expect(accessMutationCount).toBeGreaterThanOrEqual(3);
           expect(unstableAccess).toMatchObject({
             ok: false,
-            error: { code: "UNAVAILABLE", message: expect.stringContaining("retry") },
+            error: {
+              code: "UNAVAILABLE",
+              message: "Task activity did not stabilize. Wait a moment, then refresh Tasks.",
+              retryable: true,
+              retryAfterMs: 250,
+            },
           });
         } finally {
           sortSpy.mockRestore();

--- a/src/tasks/task-registry-mutation.ts
+++ b/src/tasks/task-registry-mutation.ts
@@ -157,11 +157,17 @@ export function updateTask(taskId: string, patch: Partial<TaskRecord>): TaskReco
   if (!current) {
     return null;
   }
-  const next = normalizeTaskTimestamps({
+  const updated = {
     ...current,
     ...patch,
     ...(patch.detail !== undefined ? { detail: structuredClone(patch.detail) } : {}),
-  });
+  };
+  const becomesTerminal =
+    !isTerminalTaskStatus(current.status) && isTerminalTaskStatus(updated.status);
+  if (becomesTerminal && patch.endedAt === undefined) {
+    updated.endedAt = patch.lastEventAt ?? Date.now();
+  }
+  const next = normalizeTaskTimestamps(updated);
   if (Object.hasOwn(patch, "error") && patch.error === undefined) {
     delete next.error;
   }
@@ -179,8 +185,6 @@ export function updateTask(taskId: string, patch: Partial<TaskRecord>): TaskReco
   const parentFlowIndexChanged = current.parentFlowId?.trim() !== next.parentFlowId?.trim();
   ensureLinkedTaskFlowRegistryReady(current);
   ensureLinkedTaskFlowRegistryReady(next);
-  const becomesTerminal =
-    !isTerminalTaskStatus(current.status) && isTerminalTaskStatus(next.status);
   if (becomesTerminal) {
     flushTaskActivity(taskId);
   }

--- a/src/tasks/task-registry-query.test.ts
+++ b/src/tasks/task-registry-query.test.ts
@@ -99,6 +99,46 @@ describe("listTaskRecordPage", () => {
     }
   });
 
+  it("selects the terminal page by completion instead of later activity", async () => {
+    const tasks = [
+      {
+        taskId: "finished-newest",
+        endedAt: 300,
+        lastEventAt: 100,
+      },
+      {
+        taskId: "activity-newest",
+        endedAt: 100,
+        lastEventAt: 300,
+      },
+      {
+        taskId: "finished-middle",
+        endedAt: 200,
+        lastEventAt: 200,
+      },
+    ].map(
+      ({ taskId, endedAt, lastEventAt }): TaskRecord => ({
+        taskId,
+        runtime: "cli",
+        requesterSessionKey: "agent:main:main",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        task: taskId,
+        status: "succeeded",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "done_only",
+        createdAt: 0,
+        endedAt,
+        lastEventAt,
+      }),
+    );
+    configureTaskSnapshot(tasks);
+
+    const page = await readTaskPage({ offset: 0, limit: 2, sortBy: "endedAt" });
+
+    expect(page.tasks.map((task) => task.taskId)).toEqual(["finished-newest", "finished-middle"]);
+  });
+
   it("does not use the executor as the requester owner for a legacy bare task", async () => {
     const task: TaskRecord = {
       taskId: "task-legacy-owner",

--- a/src/tasks/task-registry-query.test.ts
+++ b/src/tasks/task-registry-query.test.ts
@@ -107,9 +107,9 @@ describe("listTaskRecordPage", () => {
         lastEventAt: 100,
       },
       {
-        taskId: "activity-newest",
-        endedAt: 100,
-        lastEventAt: 300,
+        taskId: "legacy-terminal",
+        endedAt: undefined,
+        lastEventAt: 250,
       },
       {
         taskId: "finished-middle",
@@ -136,7 +136,7 @@ describe("listTaskRecordPage", () => {
 
     const page = await readTaskPage({ offset: 0, limit: 2, sortBy: "endedAt" });
 
-    expect(page.tasks.map((task) => task.taskId)).toEqual(["finished-newest", "finished-middle"]);
+    expect(page.tasks.map((task) => task.taskId)).toEqual(["finished-newest", "legacy-terminal"]);
   });
 
   it("does not use the executor as the requester owner for a legacy bare task", async () => {

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -94,15 +94,24 @@ function taskUpdatedAt(task: TaskRecord): number {
   return task.lastEventAt ?? task.endedAt ?? task.startedAt ?? task.createdAt;
 }
 
-function compareTaskPageOrder(left: TaskRecord, right: TaskRecord): number {
-  const updatedDiff = taskUpdatedAt(right) - taskUpdatedAt(left);
-  if (updatedDiff !== 0) {
-    return updatedDiff;
+function compareTaskPageOrder(
+  left: TaskRecord,
+  right: TaskRecord,
+  sortBy: "updatedAt" | "endedAt",
+): number {
+  const leftAt = sortBy === "endedAt" ? (left.endedAt ?? -1) : taskUpdatedAt(left);
+  const rightAt = sortBy === "endedAt" ? (right.endedAt ?? -1) : taskUpdatedAt(right);
+  if (leftAt !== rightAt) {
+    return rightAt - leftAt;
   }
   return left.taskId < right.taskId ? -1 : left.taskId > right.taskId ? 1 : 0;
 }
 
-function siftWorstTaskDown(heap: TaskRecord[], startIndex: number): void {
+function siftWorstTaskDown(
+  heap: TaskRecord[],
+  startIndex: number,
+  compare: (left: TaskRecord, right: TaskRecord) => number,
+): void {
   let index = startIndex;
   while (true) {
     const leftIndex = index * 2 + 1;
@@ -117,11 +126,11 @@ function siftWorstTaskDown(heap: TaskRecord[], startIndex: number): void {
     const rightIndex = leftIndex + 1;
     let worstIndex = leftIndex;
     const right = heap[rightIndex];
-    if (right && compareTaskPageOrder(right, left) > 0) {
+    if (right && compare(right, left) > 0) {
       worstIndex = rightIndex;
     }
     const worst = heap[worstIndex];
-    if (!worst || compareTaskPageOrder(worst, current) <= 0) {
+    if (!worst || compare(worst, current) <= 0) {
       return;
     }
     heap[index] = worst;
@@ -130,9 +139,12 @@ function siftWorstTaskDown(heap: TaskRecord[], startIndex: number): void {
   }
 }
 
-function heapifyWorstTaskFirst(heap: TaskRecord[]): void {
+function heapifyWorstTaskFirst(
+  heap: TaskRecord[],
+  compare: (left: TaskRecord, right: TaskRecord) => number,
+): void {
   for (let index = Math.floor(heap.length / 2) - 1; index >= 0; index -= 1) {
-    siftWorstTaskDown(heap, index);
+    siftWorstTaskDown(heap, index, compare);
   }
 }
 
@@ -148,6 +160,7 @@ export async function listTaskRecordPage(params: {
   sessionAgentId?: string;
   cfg?: OpenClawConfig;
   filter?: (task: Readonly<TaskRecord>) => boolean;
+  sortBy?: "updatedAt" | "endedAt";
 }): Promise<
   Result<
     { tasks: TaskRecord[]; hasMore: boolean; revision: number },
@@ -158,6 +171,8 @@ export async function listTaskRecordPage(params: {
   const statuses = params.statuses ? new Set(params.statuses) : null;
   const agentId = normalizeOptionalString(params.agentId);
   const sessionKey = normalizeOptionalString(params.sessionKey);
+  const compare = (left: TaskRecord, right: TaskRecord) =>
+    compareTaskPageOrder(left, right, params.sortBy ?? "updatedAt");
   // Filtering and ordering stay registry-owned so authoritative records never
   // cross the boundary; only the bounded selected page is defensively cloned.
   const windowSize = params.offset + params.limit;
@@ -198,13 +213,13 @@ export async function listTaskRecordPage(params: {
         continue;
       }
       if (!heapReady) {
-        heapifyWorstTaskFirst(window);
+        heapifyWorstTaskFirst(window, compare);
         heapReady = true;
       }
       const cutoff = window[0];
-      if (cutoff && compareTaskPageOrder(task, cutoff) < 0) {
+      if (cutoff && compare(task, cutoff) < 0) {
         window[0] = task;
-        siftWorstTaskDown(window, 0);
+        siftWorstTaskDown(window, 0, compare);
       }
     }
     if (revision !== readTaskRegistryRevision()) {
@@ -216,7 +231,7 @@ export async function listTaskRecordPage(params: {
     if (params.offset >= matchingCount) {
       return ok({ tasks: [], hasMore: false, revision });
     }
-    const selected = window.toSorted(compareTaskPageOrder).slice(params.offset);
+    const selected = window.toSorted(compare).slice(params.offset);
     return ok({
       tasks: selected.map((task) => cloneTaskRecord(task)),
       hasMore: params.offset + selected.length < matchingCount,

--- a/src/tasks/task-registry-records.test.ts
+++ b/src/tasks/task-registry-records.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTaskTimestamps } from "./task-registry-records.js";
+import type { TaskRecord, TaskStatus } from "./task-registry.types.js";
+
+function task(status: TaskStatus, overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    taskId: `task-${status}`,
+    runtime: "cli",
+    requesterSessionKey: "agent:main:main",
+    ownerKey: "agent:main:main",
+    scopeKind: "session",
+    task: status,
+    status,
+    deliveryStatus: "not_applicable",
+    notifyPolicy: "done_only",
+    createdAt: 100,
+    ...overrides,
+  };
+}
+
+describe("normalizeTaskTimestamps", () => {
+  it.each(["succeeded", "failed", "timed_out", "cancelled", "lost"] as const)(
+    "materializes %s completion from the latest terminal event",
+    (status) => {
+      expect(normalizeTaskTimestamps(task(status, { lastEventAt: 250 })).endedAt).toBe(250);
+    },
+  );
+
+  it("falls back to original creation when a legacy terminal has no event time", () => {
+    expect(
+      normalizeTaskTimestamps(task("failed", { createdAt: 200, startedAt: 100 })).endedAt,
+    ).toBe(200);
+  });
+
+  it("does not add an end time to active records", () => {
+    expect(normalizeTaskTimestamps(task("running", { lastEventAt: 250 })).endedAt).toBeUndefined();
+  });
+});

--- a/src/tasks/task-registry-records.ts
+++ b/src/tasks/task-registry-records.ts
@@ -1,4 +1,5 @@
 // Clones and normalizes task registry records at persistence boundaries.
+import { isTerminalTaskStatus } from "./task-executor-policy.js";
 import type { TaskDeliveryState, TaskRecord } from "./task-registry.types.js";
 
 export function cloneTaskRecord(record: TaskRecord): TaskRecord {
@@ -20,10 +21,11 @@ export function normalizeTaskTimestamps(task: TaskRecord): TaskRecord {
 
   const startedAt =
     typeof task.startedAt === "number" ? Math.max(task.startedAt, createdAt) : task.startedAt;
+  const terminalAt = isTerminalTaskStatus(task.status)
+    ? (task.endedAt ?? task.lastEventAt ?? task.createdAt)
+    : task.endedAt;
   const endedAt =
-    typeof task.endedAt === "number"
-      ? Math.max(task.endedAt, startedAt ?? createdAt)
-      : task.endedAt;
+    typeof terminalAt === "number" ? Math.max(terminalAt, startedAt ?? createdAt) : terminalAt;
   const lastEventAt =
     typeof task.lastEventAt === "number"
       ? Math.max(task.lastEventAt, endedAt ?? startedAt ?? createdAt)

--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -29,6 +29,7 @@ import {
   type OpenClawStateDatabase,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
+import { normalizeTaskTimestamps } from "./task-registry-records.js";
 import { parseDeliveryContextJson, parseSqliteJsonValue } from "./task-registry.sqlite.shared.js";
 import type { TaskRegistryStoreSnapshot } from "./task-registry.store.types.js";
 import {
@@ -130,7 +131,7 @@ function rowToTaskRecord(row: TaskRegistryRow): TaskRecord {
   // System tasks intentionally have no requester session; ownerKey is the lookup anchor.
   const requesterSessionKey =
     scopeKind === "system" ? "" : row.requester_session_key?.trim() || row.owner_key;
-  return {
+  return normalizeTaskTimestamps({
     taskId: row.task_id,
     runtime: parseTaskRuntime(row.runtime),
     ...(row.task_kind ? { taskKind: row.task_kind } : {}),
@@ -161,7 +162,7 @@ function rowToTaskRecord(row: TaskRegistryRow): TaskRecord {
     ...(row.terminal_summary !== null ? { terminalSummary: row.terminal_summary } : {}),
     ...(terminalOutcome ? { terminalOutcome } : {}),
     ...(detail !== undefined ? { detail } : {}),
-  };
+  });
 }
 
 function rowToTaskDeliveryState(row: TaskDeliveryStateRow): TaskDeliveryState {
@@ -178,37 +179,38 @@ type BoundTaskRecord = Insertable<TaskRunsTable>;
 
 /** Canonically serializes a task before an outer transaction acquires the write lock. */
 export function bindTaskRecord(record: TaskRecord): BoundTaskRecord {
+  const normalized = normalizeTaskTimestamps(record);
   return {
-    task_id: record.taskId,
-    runtime: record.runtime,
-    task_kind: record.taskKind ?? null,
-    source_id: record.sourceId ?? null,
-    requester_session_key: record.scopeKind === "system" ? "" : record.requesterSessionKey,
-    owner_key: record.ownerKey,
-    scope_kind: record.scopeKind,
-    child_session_key: record.childSessionKey ?? null,
-    parent_flow_id: record.parentFlowId ?? null,
-    parent_task_id: record.parentTaskId ?? null,
-    agent_id: record.agentId ?? null,
-    requester_agent_id: record.requesterAgentId ?? null,
-    run_id: record.runId ?? null,
-    label: record.label ?? null,
-    task: record.task,
-    status: record.status,
-    delivery_status: record.deliveryStatus,
-    notify_policy: record.notifyPolicy,
-    created_at: record.createdAt,
-    started_at: record.startedAt ?? null,
-    ended_at: record.endedAt ?? null,
-    last_event_at: record.lastEventAt ?? null,
-    cleanup_after: record.cleanupAfter ?? null,
-    tool_use_count: record.toolUseCount ?? null,
-    last_tool_name: record.lastToolName ?? null,
-    error: record.error ?? null,
-    progress_summary: record.progressSummary ?? null,
-    terminal_summary: record.terminalSummary ?? null,
-    terminal_outcome: record.terminalOutcome ?? null,
-    detail_json: serializeJson(record.detail),
+    task_id: normalized.taskId,
+    runtime: normalized.runtime,
+    task_kind: normalized.taskKind ?? null,
+    source_id: normalized.sourceId ?? null,
+    requester_session_key: normalized.scopeKind === "system" ? "" : normalized.requesterSessionKey,
+    owner_key: normalized.ownerKey,
+    scope_kind: normalized.scopeKind,
+    child_session_key: normalized.childSessionKey ?? null,
+    parent_flow_id: normalized.parentFlowId ?? null,
+    parent_task_id: normalized.parentTaskId ?? null,
+    agent_id: normalized.agentId ?? null,
+    requester_agent_id: normalized.requesterAgentId ?? null,
+    run_id: normalized.runId ?? null,
+    label: normalized.label ?? null,
+    task: normalized.task,
+    status: normalized.status,
+    delivery_status: normalized.deliveryStatus,
+    notify_policy: normalized.notifyPolicy,
+    created_at: normalized.createdAt,
+    started_at: normalized.startedAt ?? null,
+    ended_at: normalized.endedAt ?? null,
+    last_event_at: normalized.lastEventAt ?? null,
+    cleanup_after: normalized.cleanupAfter ?? null,
+    tool_use_count: normalized.toolUseCount ?? null,
+    last_tool_name: normalized.lastToolName ?? null,
+    error: normalized.error ?? null,
+    progress_summary: normalized.progressSummary ?? null,
+    terminal_summary: normalized.terminalSummary ?? null,
+    terminal_outcome: normalized.terminalOutcome ?? null,
+    detail_json: serializeJson(normalized.detail),
   };
 }
 

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -50,6 +50,7 @@ import {
   type TaskRegistryObserverEvent,
 } from "./task-registry.store.js";
 import {
+  bindTaskRecord,
   bindTaskRunExecution,
   loadTaskRegistryStateFromSqlite,
   loadTaskRegistryStateFromSqliteReadOnly,
@@ -78,6 +79,24 @@ function createTaskRecord(params: Parameters<typeof createTaskRecordOrNull>[0]):
   }
   return task;
 }
+
+it("normalizes missing terminal timestamps at the SQLite write boundary", () => {
+  const bound = bindTaskRecord({
+    taskId: "task-legacy-terminal",
+    runtime: "cli",
+    requesterSessionKey: "agent:main:main",
+    ownerKey: "agent:main:main",
+    scopeKind: "session",
+    task: "Legacy terminal",
+    status: "failed",
+    deliveryStatus: "not_applicable",
+    notifyPolicy: "done_only",
+    createdAt: 100,
+    lastEventAt: 250,
+  });
+
+  expect(bound.ended_at).toBe(250);
+});
 
 function createManagedTaskFlow(
   params: Parameters<typeof createManagedTaskFlowOrNull>[0],
@@ -1135,6 +1154,40 @@ describe("task-registry store runtime", () => {
           toolUseCount: 1,
           lastToolName: "read",
         });
+      },
+    );
+  });
+
+  it("normalizes a legacy terminal row with no persisted end time", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-task-legacy-terminal-" },
+      async () => {
+        const created = createTaskRecord({
+          runtime: "cli",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          runId: "run-legacy-terminal-sqlite",
+          task: "Legacy terminal row",
+          status: "running",
+          deliveryStatus: "pending",
+        });
+        const terminalAt = created.createdAt + 1_000;
+        const database = openOpenClawStateDatabase();
+        const db = getNodeSqliteKysely<TaskRegistryTestDatabase>(database.db);
+        executeSqliteQuerySync(
+          database.db,
+          db
+            .updateTable("task_runs")
+            .set({ status: "failed", ended_at: null, last_event_at: terminalAt })
+            .where("task_id", "=", created.taskId),
+        );
+
+        expect(loadTaskRegistryStateFromSqlite().tasks.get(created.taskId)?.endedAt).toBe(
+          terminalAt,
+        );
+        expect(loadTaskRegistryStateFromSqliteReadOnly().tasks.get(created.taskId)?.endedAt).toBe(
+          terminalAt,
+        );
       },
     );
   });

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -55,6 +55,7 @@ import {
 } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 import { getTaskActivitySnapshot } from "./task-registry-activity.js";
+import { updateTaskStateByRunId } from "./task-registry-record-api.js";
 import {
   cancelTaskById,
   deleteTaskRecordById,
@@ -4103,6 +4104,29 @@ describe("task-registry", () => {
     });
   });
 
+  it("records the transition time when a generic update becomes terminal", async () => {
+    await withTaskRegistryTempDir(async () => {
+      const task = createTaskFixture("cli", {
+        runId: "run-generic-terminal",
+        task: "Generic terminal transition",
+        status: "running",
+        deliveryStatus: "pending",
+        lastEventAt: 100,
+      });
+      updateTaskStateByRunId({ runId: "run-generic-terminal", endedAt: 150 });
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(300);
+
+      updateTaskStateByRunId({ runId: "run-generic-terminal", status: "failed" });
+      nowSpy.mockRestore();
+
+      expectRecordFields(requireTaskById(task.taskId), {
+        status: "failed",
+        endedAt: 300,
+        lastEventAt: 300,
+      });
+    });
+  });
+
   it("normalizes restored task timestamps before exposing them", async () => {
     await withTaskRegistryTempDir(async () => {
       configureTaskRegistryRuntime({
@@ -4138,6 +4162,43 @@ describe("task-registry", () => {
         createdAt: 100,
         startedAt: 100,
         lastEventAt: 150,
+      });
+    });
+  });
+
+  it("materializes a restored legacy terminal timestamp", async () => {
+    await withTaskRegistryTempDir(async () => {
+      configureTaskRegistryRuntime({
+        store: {
+          loadSnapshot: () => ({
+            tasks: new Map([
+              [
+                "task-restored-terminal",
+                {
+                  taskId: "task-restored-terminal",
+                  runtime: "cli",
+                  requesterSessionKey: "agent:main:main",
+                  ownerKey: "agent:main:main",
+                  scopeKind: "session",
+                  runId: "run-restored-terminal",
+                  task: "Restored terminal task",
+                  status: "failed",
+                  deliveryStatus: "not_applicable",
+                  notifyPolicy: "done_only",
+                  createdAt: 100,
+                  lastEventAt: 250,
+                },
+              ],
+            ]),
+            deliveryStates: new Map(),
+          }),
+          saveSnapshot: () => {},
+        },
+      });
+
+      expectRecordFields(requireTaskByRunId("run-restored-terminal"), {
+        endedAt: 250,
+        lastEventAt: 250,
       });
     });
   });

--- a/ui/src/lib/tasks/data.test.ts
+++ b/ui/src/lib/tasks/data.test.ts
@@ -39,9 +39,66 @@ describe("tasks page data", () => {
       task({ id: "queued", status: "queued", updatedAt: 999 }),
       ...terminals,
     ]);
-    expect(result.active.map((entry) => entry.id)).toEqual(["running", "queued"]);
+    expect(result.active.map((entry) => entry.id)).toEqual(["queued", "running"]);
     expect(result.recent).toHaveLength(50);
     expect(result.recent[0]?.id).toBe("terminal-54");
+  });
+
+  it("keeps active tasks in creation order while their activity changes", () => {
+    const oldest = task({
+      id: "oldest",
+      status: "running",
+      createdAt: 100,
+      startedAt: 110,
+      updatedAt: 500,
+    });
+    const middle = task({
+      id: "middle",
+      status: "running",
+      createdAt: 200,
+      startedAt: 410,
+      updatedAt: 600,
+    });
+    const newest = task({
+      id: "newest",
+      status: "running",
+      createdAt: 300,
+      startedAt: 310,
+      updatedAt: 700,
+    });
+
+    expect(partitionTasks([middle, newest, oldest]).active.map((entry) => entry.id)).toEqual([
+      "oldest",
+      "middle",
+      "newest",
+    ]);
+    expect(
+      partitionTasks([{ ...oldest, updatedAt: 800 }, middle, newest]).active.map(
+        (entry) => entry.id,
+      ),
+    ).toEqual(["oldest", "middle", "newest"]);
+  });
+
+  it("orders terminal tasks by completion time instead of later activity", () => {
+    const finishedFirst = task({
+      id: "finished-first",
+      status: "completed",
+      createdAt: 100,
+      endedAt: 400,
+      updatedAt: 900,
+    });
+    const finishedLast = task({
+      id: "finished-last",
+      status: "completed",
+      createdAt: 200,
+      endedAt: 500,
+      updatedAt: 600,
+    });
+
+    expect(partitionTasks([finishedFirst, finishedLast]).recent.map((entry) => entry.id)).toEqual([
+      "finished-last",
+      "finished-first",
+    ]);
   });
 
   it("merges task lists by id while preserving newer running snapshots", () => {

--- a/ui/src/lib/tasks/data.ts
+++ b/ui/src/lib/tasks/data.ts
@@ -148,11 +148,23 @@ export function partitionTasks(tasks: readonly TaskSummary[]): {
   active: TaskSummary[];
   recent: TaskSummary[];
 } {
-  const sorted = sortTasks(tasks);
+  const byId = (left: TaskSummary, right: TaskSummary) =>
+    left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
   return {
-    active: sorted.filter((task) => task.status === "queued" || task.status === "running"),
-    recent: sorted
+    // Creation is immutable, so progress and queued-to-running transitions cannot move active rows.
+    active: tasks
+      .filter((task) => task.status === "queued" || task.status === "running")
+      .toSorted(
+        (left, right) =>
+          taskTimestampMs(left.createdAt) - taskTimestampMs(right.createdAt) || byId(left, right),
+      ),
+    recent: tasks
       .filter((task) => task.status !== "queued" && task.status !== "running")
+      .toSorted(
+        (left, right) =>
+          taskTimestampMs(right.endedAt ?? right.updatedAt ?? right.createdAt) -
+            taskTimestampMs(left.endedAt ?? left.updatedAt ?? left.createdAt) || byId(left, right),
+      )
       .slice(0, 50),
   };
 }

--- a/ui/src/pages/chat/background-tasks.e2e.test.ts
+++ b/ui/src/pages/chat/background-tasks.e2e.test.ts
@@ -161,11 +161,17 @@ suite.define(() => {
       status: ["queued", "running"],
       limit: 200,
     };
-    const recentParams = { sessionKey: chatSessionKey, agentId: "main", limit: 100 };
+    const recentParams = {
+      sessionKey: chatSessionKey,
+      agentId: "main",
+      status: ["completed", "failed", "timed_out", "cancelled"],
+      sortBy: "endedAt",
+      limit: 100,
+    };
     const listResponses = {
       cases: [
         { match: activeParams, response: { tasks: activeTasks } },
-        { match: recentParams, response: { tasks: [...activeTasks, ...finishedTasks] } },
+        { match: recentParams, response: { tasks: finishedTasks } },
       ],
     };
     const runningOrder = () =>
@@ -216,6 +222,9 @@ suite.define(() => {
       const beforeTransient = (await gateway.getRequests("tasks.list")).length;
       await gateway.deferNext("tasks.list", activeParams);
       await refresh.click();
+      await expect.poll(() => refresh.isDisabled()).toBe(true);
+      expect(await refresh.locator(".btn__spinner").count()).toBe(1);
+      await page.screenshot({ path: path.join(proofDir, "03-refresh-loading.png") });
       await expect
         .poll(async () => gateway.getRequests("tasks.list"))
         .toHaveLength(beforeTransient + 2);
@@ -227,17 +236,18 @@ suite.define(() => {
       await expect
         .poll(async () => gateway.getRequests("tasks.list"))
         .toHaveLength(beforeTransient + 4);
+      await expect.poll(() => refresh.isEnabled()).toBe(true);
       expect(await panel.getByRole("alert").count()).toBe(0);
       expect(await runningOrder()).toEqual(expectedRunning);
-      await page.screenshot({ path: path.join(proofDir, "03-transient-retry-hidden.png") });
+      await page.screenshot({ path: path.join(proofDir, "04-transient-retry-hidden.png") });
       await page.waitForTimeout(500);
 
       let listRequestCount = (await gateway.getRequests("tasks.list")).length;
-      for (let attempt = 0; attempt < 3; attempt += 1) {
+      for (let attempt = 0; attempt < 2; attempt += 1) {
         await gateway.deferNext("tasks.list", activeParams);
       }
       await refresh.click();
-      for (let attempt = 0; attempt < 3; attempt += 1) {
+      for (let attempt = 0; attempt < 2; attempt += 1) {
         await expect
           .poll(async () => gateway.getRequests("tasks.list"))
           .toHaveLength(listRequestCount + 2);
@@ -253,14 +263,14 @@ suite.define(() => {
       expect(await alert.textContent()).toContain(
         "Task activity did not stabilize. Wait a moment, then refresh Tasks.",
       );
-      await page.screenshot({ path: path.join(proofDir, "04-retries-exhausted.png") });
+      await page.screenshot({ path: path.join(proofDir, "05-retries-exhausted.png") });
       await page.waitForTimeout(500);
 
       await refresh.click();
       await expect.poll(() => alert.count()).toBe(0);
       expect(await runningOrder()).toEqual(expectedRunning);
       expect(await finishedOrder()).toEqual(expectedFinished);
-      await page.screenshot({ path: path.join(proofDir, "05-recovered.png") });
+      await page.screenshot({ path: path.join(proofDir, "06-recovered.png") });
       await page.waitForTimeout(500);
     } finally {
       await context.close();

--- a/ui/src/pages/chat/background-tasks.e2e.test.ts
+++ b/ui/src/pages/chat/background-tasks.e2e.test.ts
@@ -223,7 +223,6 @@ suite.define(() => {
         code: "UNAVAILABLE",
         message: "task registry changed during tasks.list; retry",
         retryable: true,
-        retryAfterMs: 0,
       });
       await expect
         .poll(async () => gateway.getRequests("tasks.list"))
@@ -247,7 +246,6 @@ suite.define(() => {
           code: "UNAVAILABLE",
           message: "Task activity did not stabilize. Wait a moment, then refresh Tasks.",
           retryable: true,
-          retryAfterMs: 0,
         });
       }
       const alert = panel.getByRole("alert");

--- a/ui/src/pages/chat/background-tasks.e2e.test.ts
+++ b/ui/src/pages/chat/background-tasks.e2e.test.ts
@@ -1,8 +1,9 @@
-import { mkdir, rm } from "node:fs/promises";
+import { copyFile, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { openChatSidePanelType } from "../../e2e/chat-side-panel.test-support.ts";
 import { createControlUiE2eSuite } from "../../e2e/control-ui-e2e-suite.test-support.ts";
+import { createControlUiE2eArtifactDir } from "../../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway, type MockGatewayRequest } from "../../test-helpers/control-ui-e2e.ts";
 
 const suite = createControlUiE2eSuite({
@@ -106,6 +107,172 @@ const runningExec = {
 };
 
 suite.define(() => {
+  it("keeps session task rows stable and hides recovered list retries", async () => {
+    const proofDir = createControlUiE2eArtifactDir("chat-tasks-panel-stable-order");
+    const rawVideoDir = path.join(proofDir, "raw-video");
+    await mkdir(rawVideoDir, { recursive: true });
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      recordVideo: { dir: rawVideoDir, size: { width: 1440, height: 900 } },
+      serviceWorkers: "block",
+      viewport: { width: 1440, height: 900 },
+    });
+    const page = await context.newPage();
+    const video = page.video();
+    const activeTasks = Array.from({ length: 5 }, (_, index) => ({
+      id: `task-panel-running-${index + 1}`,
+      taskId: `task-panel-running-${index + 1}`,
+      kind: "subagent",
+      runtime: "subagent",
+      status: "running",
+      title: `Panel running task ${index + 1}`,
+      agentId: "main",
+      sessionKey: chatSessionKey,
+      ownerKey: chatSessionKey,
+      createdAt: baseTime + index * 1_000,
+      startedAt: baseTime + index * 1_000,
+      updatedAt: baseTime + (5 - index) * 10_000,
+      toolUseCount: index + 1,
+      lastToolName: "exec",
+    }));
+    const finishedTasks = [
+      {
+        ...activeTasks[0],
+        id: "task-panel-finished-first",
+        taskId: "task-panel-finished-first",
+        status: "completed",
+        title: "Panel finished first",
+        endedAt: baseTime + 60_000,
+        updatedAt: baseTime + 100_000,
+      },
+      {
+        ...activeTasks[1],
+        id: "task-panel-finished-last",
+        taskId: "task-panel-finished-last",
+        status: "completed",
+        title: "Panel finished last",
+        endedAt: baseTime + 70_000,
+        updatedAt: baseTime + 90_000,
+      },
+    ];
+    const activeParams = {
+      sessionKey: chatSessionKey,
+      agentId: "main",
+      status: ["queued", "running"],
+      limit: 200,
+    };
+    const recentParams = { sessionKey: chatSessionKey, agentId: "main", limit: 100 };
+    const listResponses = {
+      cases: [
+        { match: activeParams, response: { tasks: activeTasks } },
+        { match: recentParams, response: { tasks: [...activeTasks, ...finishedTasks] } },
+      ],
+    };
+    const runningOrder = () =>
+      page
+        .locator('[data-tasks-section="running"] [data-task-id] .chat-tasks-rail__task-title')
+        .allTextContents();
+    const finishedOrder = () =>
+      page
+        .locator('[data-tasks-section="finished"] [data-task-id] .chat-tasks-rail__task-title')
+        .allTextContents();
+    const expectedRunning = activeTasks.map((task) => task.title);
+    const expectedFinished = ["Panel finished last", "Panel finished first"];
+    try {
+      const gateway = await installMockGateway(page, {
+        historyMessages: [
+          {
+            content: [{ type: "text", text: "Session Tasks side panel proof." }],
+            role: "assistant",
+            timestamp: baseTime,
+          },
+        ],
+        methodResponses: { "tasks.list": listResponses },
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.getByText("Session Tasks side panel proof.").waitFor();
+      await openChatSidePanelType(page, "Tasks");
+      const panel = page.locator(".sidebar-region__right-runtime .side-panel");
+      await expect.poll(runningOrder).toEqual(expectedRunning);
+      await panel.getByRole("button", { name: "Finished (2)" }).click();
+      await expect.poll(finishedOrder).toEqual(expectedFinished);
+      await page.screenshot({ path: path.join(proofDir, "01-session-panel-order.png") });
+      await page.waitForTimeout(500);
+
+      const updatedTask = {
+        ...activeTasks[4],
+        updatedAt: baseTime + 200_000,
+        toolUseCount: 80,
+        progressSummary: "Activity updated without moving this card",
+      };
+      await gateway.emitGatewayEvent("task", { action: "upserted", task: updatedTask });
+      await panel.getByText(updatedTask.progressSummary).waitFor();
+      expect(await runningOrder()).toEqual(expectedRunning);
+      expect(await finishedOrder()).toEqual(expectedFinished);
+      await page.screenshot({ path: path.join(proofDir, "02-activity-stable.png") });
+      await page.waitForTimeout(500);
+
+      const refresh = panel.getByRole("button", { name: "Refresh background tasks" });
+      const beforeTransient = (await gateway.getRequests("tasks.list")).length;
+      await gateway.deferNext("tasks.list", activeParams);
+      await refresh.click();
+      await expect
+        .poll(async () => gateway.getRequests("tasks.list"))
+        .toHaveLength(beforeTransient + 2);
+      await gateway.rejectDeferred("tasks.list", {
+        code: "UNAVAILABLE",
+        message: "task registry changed during tasks.list; retry",
+        retryable: true,
+        retryAfterMs: 0,
+      });
+      await expect
+        .poll(async () => gateway.getRequests("tasks.list"))
+        .toHaveLength(beforeTransient + 4);
+      expect(await panel.getByRole("alert").count()).toBe(0);
+      expect(await runningOrder()).toEqual(expectedRunning);
+      await page.screenshot({ path: path.join(proofDir, "03-transient-retry-hidden.png") });
+      await page.waitForTimeout(500);
+
+      let listRequestCount = (await gateway.getRequests("tasks.list")).length;
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        await gateway.deferNext("tasks.list", activeParams);
+      }
+      await refresh.click();
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        await expect
+          .poll(async () => gateway.getRequests("tasks.list"))
+          .toHaveLength(listRequestCount + 2);
+        listRequestCount += 2;
+        await gateway.rejectDeferred("tasks.list", {
+          code: "UNAVAILABLE",
+          message: "Task activity did not stabilize. Wait a moment, then refresh Tasks.",
+          retryable: true,
+          retryAfterMs: 0,
+        });
+      }
+      const alert = panel.getByRole("alert");
+      await alert.waitFor();
+      expect(await alert.textContent()).toContain(
+        "Task activity did not stabilize. Wait a moment, then refresh Tasks.",
+      );
+      await page.screenshot({ path: path.join(proofDir, "04-retries-exhausted.png") });
+      await page.waitForTimeout(500);
+
+      await refresh.click();
+      await expect.poll(() => alert.count()).toBe(0);
+      expect(await runningOrder()).toEqual(expectedRunning);
+      expect(await finishedOrder()).toEqual(expectedFinished);
+      await page.screenshot({ path: path.join(proofDir, "05-recovered.png") });
+      await page.waitForTimeout(500);
+    } finally {
+      await context.close();
+      if (video) {
+        await copyFile(await video.path(), path.join(proofDir, "session-tasks-panel.webm"));
+      }
+      await rm(rawVideoDir, { force: true, recursive: true });
+    }
+  });
+
   it("opens the rail, applies pushed completion, and sends cancel", async () => {
     await rm(artifactDir, { force: true, recursive: true });
     const railFlowDir = path.join(artifactDir, "rail-flow");

--- a/ui/src/pages/chat/chat-pane-embedded-panels.test.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { render } from "lit";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { availableSidebarSlots, sidebarPanelDefinitions } from "./chat-pane-embedded-panels.ts";
 import type { SessionDiscussionPanelConfig } from "./components/session-discussion-panel.ts";
 
@@ -59,5 +59,22 @@ describe("chat pane embedded panels", () => {
       await skeleton?.updateComplete;
       expect(skeleton?.getAttribute("data-panel-skeleton")).toBe(expected[definition.slot]);
     }
+  });
+
+  it("exposes task refresh in the shared side-panel header", () => {
+    const onRefreshTasks = vi.fn();
+    const params = {} as NonNullable<Parameters<typeof sidebarPanelDefinitions>[0]>;
+    params.connected = true;
+    params.onRefreshTasks = onRefreshTasks;
+    const tasks = sidebarPanelDefinitions(params).find((definition) => definition.slot === "tasks");
+    const mount = document.body.appendChild(document.createElement("div"));
+    render(tasks?.headerAction, mount);
+
+    const refresh = mount.querySelector<HTMLButtonElement>(
+      'button[aria-label="Refresh background tasks"]',
+    );
+    expect(refresh).not.toBeNull();
+    refresh?.click();
+    expect(onRefreshTasks).toHaveBeenCalledOnce();
   });
 });

--- a/ui/src/pages/chat/chat-pane-embedded-panels.test.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.test.ts
@@ -75,6 +75,7 @@ describe("chat pane embedded panels", () => {
       'button[aria-label="Refresh background tasks"]',
     );
     expect(refresh).not.toBeNull();
+    expect(refresh?.querySelector("svg")?.outerHTML).toContain("M21 12a9");
     refresh?.click();
     expect(onRefreshTasks).toHaveBeenCalledOnce();
 
@@ -92,6 +93,13 @@ describe("chat pane embedded panels", () => {
         mount.querySelector<HTMLButtonElement>('button[aria-label="Refresh background tasks"]')
           ?.disabled,
       ).toBe(true);
+      if (tasksLoading) {
+        expect(
+          mount.querySelector(
+            'button[aria-label="Refresh background tasks"] .btn__spinner[aria-hidden="true"]',
+          ),
+        ).not.toBeNull();
+      }
     }
   });
 });

--- a/ui/src/pages/chat/chat-pane-embedded-panels.test.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.test.ts
@@ -66,6 +66,7 @@ describe("chat pane embedded panels", () => {
     const params = {} as NonNullable<Parameters<typeof sidebarPanelDefinitions>[0]>;
     params.connected = true;
     params.onRefreshTasks = onRefreshTasks;
+    params.tasksLoading = false;
     const tasks = sidebarPanelDefinitions(params).find((definition) => definition.slot === "tasks");
     const mount = document.body.appendChild(document.createElement("div"));
     render(tasks?.headerAction, mount);
@@ -76,5 +77,21 @@ describe("chat pane embedded panels", () => {
     expect(refresh).not.toBeNull();
     refresh?.click();
     expect(onRefreshTasks).toHaveBeenCalledOnce();
+
+    for (const [connected, tasksLoading] of [
+      [false, false],
+      [true, true],
+    ] as const) {
+      params.connected = connected;
+      params.tasksLoading = tasksLoading;
+      const definition = sidebarPanelDefinitions(params).find(
+        (candidate) => candidate.slot === "tasks",
+      );
+      render(definition?.headerAction, mount);
+      expect(
+        mount.querySelector<HTMLButtonElement>('button[aria-label="Refresh background tasks"]')
+          ?.disabled,
+      ).toBe(true);
+    }
   });
 });

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -58,6 +58,7 @@ type SidebarPanelDefinitionParams = {
   pendingQuestion: string | null;
   onClearCompanion: () => void;
   onRefreshTasks: () => void;
+  tasksLoading: boolean;
   discussion: SessionDiscussionPanelConfig | null;
   discussionAvailable: boolean;
   discussionOpenUrl: string | null;
@@ -242,7 +243,7 @@ export function sidebarPanelDefinitions(
               class="rail-header__action chat-tasks-rail__refresh"
               type="button"
               aria-label=${t("chat.backgroundTasks.refresh")}
-              ?disabled=${!params.connected}
+              ?disabled=${!params.connected || params.tasksLoading}
               @click=${params.onRefreshTasks}
             >
               ${icons.refresh}

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -246,7 +246,9 @@ export function sidebarPanelDefinitions(
               ?disabled=${!params.connected || params.tasksLoading}
               @click=${params.onRefreshTasks}
             >
-              ${icons.refresh}
+              ${params.tasksLoading
+                ? html`<span class="btn__spinner" aria-hidden="true"></span>`
+                : icons.refresh}
             </button>
           </openclaw-tooltip>`
         : undefined,

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -57,6 +57,7 @@ type SidebarPanelDefinitionParams = {
   connected: boolean;
   pendingQuestion: string | null;
   onClearCompanion: () => void;
+  onRefreshTasks: () => void;
   discussion: SessionDiscussionPanelConfig | null;
   discussionAvailable: boolean;
   discussionOpenUrl: string | null;
@@ -234,7 +235,21 @@ export function sidebarPanelDefinitions(
           }
         : undefined,
     ),
-    definePanel("tasks", "tasks", icons.listChecks, params?.tasks ?? null),
+    definePanel("tasks", "tasks", icons.listChecks, params?.tasks ?? null, {
+      headerAction: params
+        ? html`<openclaw-tooltip .content=${t("chat.backgroundTasks.refresh")}>
+            <button
+              class="rail-header__action chat-tasks-rail__refresh"
+              type="button"
+              aria-label=${t("chat.backgroundTasks.refresh")}
+              ?disabled=${!params.connected}
+              @click=${params.onRefreshTasks}
+            >
+              ${icons.refresh}
+            </button>
+          </openclaw-tooltip>`
+        : undefined,
+    }),
     definePanel("desktop", "desktop", icons.monitor, desktop, {
       available: desktopAvailable,
       ...(desktopFocusHref

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -185,6 +185,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       pendingQuestion: companionThread.pendingQuestion,
       onClearCompanion: () => void this.clearSessionCompanion(),
       onRefreshTasks: backgroundTasks.onRefresh,
+      tasksLoading: backgroundTasks.loading,
       discussion,
       discussionAvailable,
       discussionOpenUrl: discussion?.openUrl ?? null,

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -184,6 +184,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       connected: state.connected,
       pendingQuestion: companionThread.pendingQuestion,
       onClearCompanion: () => void this.clearSessionCompanion(),
+      onRefreshTasks: backgroundTasks.onRefresh,
       discussion,
       discussionAvailable,
       discussionOpenUrl: discussion?.openUrl ?? null,

--- a/ui/src/pages/chat/components/chat-background-tasks-concurrency.test.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks-concurrency.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient } from "../../../api/gateway.ts";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../../api/gateway.ts";
 import type { TaskSummary } from "../../../lib/tasks/task-summary.ts";
 import {
   createBackgroundTasksProps,
@@ -91,6 +91,52 @@ afterEach(() => {
 });
 
 describe("background tasks concurrent snapshots", () => {
+  it("does not retry a transient snapshot after the pane switches sessions", async () => {
+    vi.useFakeTimers();
+    try {
+      const replacement = makeTask({
+        id: "task-new-session",
+        sessionKey: "agent:main:replacement",
+      });
+      let unavailable = true;
+      const request = vi.fn(() => {
+        if (unavailable) {
+          return Promise.reject(
+            new GatewayRequestError({
+              code: "UNAVAILABLE",
+              message: "task registry changed during tasks.list; retry",
+              retryable: true,
+              retryAfterMs: 100,
+            }),
+          );
+        }
+        return Promise.resolve({ tasks: [replacement] });
+      });
+      const host: BackgroundTasksHost = {
+        sessionKey: "agent:main:current",
+        client: { request } as unknown as GatewayBrowserClient,
+        connected: true,
+        connectionEpoch: 1,
+        hello: null,
+      };
+
+      createBackgroundTasksProps(host);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(request).toHaveBeenCalledTimes(2);
+      host.sessionKey = "agent:main:replacement";
+      unavailable = false;
+      createBackgroundTasksProps(host);
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(request).toHaveBeenCalledTimes(4);
+      expect(createBackgroundTasksProps(host).tasks?.map((task) => task.id)).toEqual([
+        replacement.id,
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps global owner switches separate through canonical acknowledgments and late responses", async () => {
     const mainTask = makeTask({ id: "main-task", sessionKey: "global" });
     const workTask = makeTask({ id: "work-task", sessionKey: "global", agentId: "work" });

--- a/ui/src/pages/chat/components/chat-background-tasks-render.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks-render.ts
@@ -111,7 +111,7 @@ export function renderBackgroundTasksRail(
         ? html`<div class="chat-tasks-rail__state">${t("tasksPage.disconnected")}</div>`
         : nothing}
       ${backgroundTasks.error
-        ? html`<div class="chat-tasks-rail__state chat-tasks-rail__state--error">
+        ? html`<div class="chat-tasks-rail__state chat-tasks-rail__state--error" role="alert">
             ${backgroundTasks.error}
           </div>`
         : nothing}

--- a/ui/src/pages/chat/components/chat-background-tasks.test.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.test.ts
@@ -1,6 +1,6 @@
 import { html, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient } from "../../../api/gateway.ts";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../../api/gateway.ts";
 import type { TaskSummary } from "../../../lib/tasks/task-summary.ts";
 import { renderBackgroundTasksRail } from "./chat-background-tasks-render.ts";
 import { renderBackgroundTasksStatusRow } from "./chat-background-tasks-status.ts";
@@ -164,6 +164,76 @@ describe("background tasks rail state", () => {
     const rail = renderTaskRail({ ...props, collapsed: false });
     expect(rail.textContent).toContain("OPENAI_API_KEY=sk-123...cdef");
     expect(rail.textContent).not.toContain("sk-1234567890abcdef");
+  });
+
+  it("retries a transient task snapshot without publishing an error", async () => {
+    vi.useFakeTimers();
+    try {
+      const running = makeTask({ id: "task-retried" });
+      let requestCount = 0;
+      const { host, request } = createHost({
+        request: () => {
+          requestCount += 1;
+          if (requestCount === 1) {
+            return Promise.reject(
+              new GatewayRequestError({
+                code: "UNAVAILABLE",
+                message: "task registry changed during tasks.list; retry",
+                retryable: true,
+                retryAfterMs: 10,
+              }),
+            );
+          }
+          return Promise.resolve({ tasks: [running] });
+        },
+      });
+
+      createBackgroundTasksProps(host);
+      await vi.advanceTimersByTimeAsync(10);
+
+      const props = createBackgroundTasksProps(host);
+      expect(request).toHaveBeenCalledTimes(4);
+      expect(props.error).toBeNull();
+      expect(props.tasks?.map((task) => task.id)).toEqual([running.id]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows exhausted retry guidance and recovers on manual refresh", async () => {
+    vi.useFakeTimers();
+    try {
+      const running = makeTask({ id: "task-recovered" });
+      let unavailable = true;
+      const error = new GatewayRequestError({
+        code: "UNAVAILABLE",
+        message: "Task activity did not stabilize. Wait a moment, then refresh Tasks.",
+        retryable: true,
+        retryAfterMs: 10,
+      });
+      const { host, request } = createHost({
+        request: () =>
+          unavailable ? Promise.reject(error) : Promise.resolve({ tasks: [running] }),
+      });
+
+      createBackgroundTasksProps(host);
+      await vi.advanceTimersByTimeAsync(20);
+
+      let props = createBackgroundTasksProps(host);
+      expect(request).toHaveBeenCalledTimes(6);
+      expect(props.error).toBe(error.message);
+      const rail = renderTaskRail({ ...props, collapsed: false });
+      expect(rail.querySelector('[role="alert"]')?.textContent).toContain(error.message);
+
+      unavailable = false;
+      props.onRefresh();
+      await vi.runAllTimersAsync();
+      props = createBackgroundTasksProps(host);
+      expect(props.error).toBeNull();
+      expect(props.tasks?.map((task) => task.id)).toEqual([running.id]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("loads session-scoped tasks eagerly while the rail is collapsed", async () => {

--- a/ui/src/pages/chat/components/chat-background-tasks.test.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.test.ts
@@ -18,6 +18,14 @@ function flushAsync() {
   });
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 function makeTask(overrides: Partial<TaskSummary> & { id: string }): TaskSummary {
   return {
     taskId: overrides.id,
@@ -170,9 +178,10 @@ describe("background tasks rail state", () => {
     vi.useFakeTimers();
     try {
       const running = makeTask({ id: "task-retried" });
+      const pendingRecent = deferred<{ tasks: TaskSummary[] }>();
       let requestCount = 0;
       const { host, request } = createHost({
-        request: () => {
+        request: (_method, params) => {
           requestCount += 1;
           if (requestCount === 1) {
             return Promise.reject(
@@ -184,11 +193,21 @@ describe("background tasks rail state", () => {
               }),
             );
           }
+          if (
+            (params as { status?: string[] }).status?.includes("completed") &&
+            requestCount === 2
+          ) {
+            return pendingRecent.promise;
+          }
           return Promise.resolve({ tasks: [running] });
         },
       });
 
       createBackgroundTasksProps(host);
+      await vi.advanceTimersByTimeAsync(10);
+      expect(request).toHaveBeenCalledTimes(2);
+      expect(createBackgroundTasksProps(host)).toMatchObject({ loading: true, error: null });
+      pendingRecent.resolve({ tasks: [running] });
       await vi.advanceTimersByTimeAsync(10);
 
       const props = createBackgroundTasksProps(host);
@@ -217,10 +236,10 @@ describe("background tasks rail state", () => {
       });
 
       createBackgroundTasksProps(host);
-      await vi.advanceTimersByTimeAsync(20);
+      await vi.advanceTimersByTimeAsync(10);
 
       let props = createBackgroundTasksProps(host);
-      expect(request).toHaveBeenCalledTimes(6);
+      expect(request).toHaveBeenCalledTimes(4);
       expect(props.error).toBe(error.message);
       const rail = renderTaskRail({ ...props, collapsed: false });
       expect(rail.querySelector('[role="alert"]')?.textContent).toContain(error.message);
@@ -256,12 +275,26 @@ describe("background tasks rail state", () => {
     expect(props.activeCount).toBe(1);
   });
 
-  it("keeps the later recent page's equally current running progress", async () => {
+  it("reports refresh loading before the snapshot settles", async () => {
+    const pending = deferred<{ tasks: TaskSummary[] }>();
+    const { host, requestUpdate } = createHost({ request: () => pending.promise });
+
+    const initial = createBackgroundTasksProps(host);
+
+    expect(initial.loading).toBe(true);
+    expect(requestUpdate).toHaveBeenCalled();
+    pending.resolve({ tasks: [] });
+    await flushAsync();
+    expect(createBackgroundTasksProps(host).loading).toBe(false);
+  });
+
+  it("keeps a terminal snapshot when the active page is stale", async () => {
     const recent = makeTask({
       id: "task-1",
+      status: "completed",
       toolUseCount: 2,
       lastToolName: "write",
-      progressSummary: "Finishing the concurrent task report",
+      terminalSummary: "Finished the concurrent task report",
     });
     const active = makeTask({
       id: "task-1",
@@ -273,7 +306,7 @@ describe("background tasks rail state", () => {
       request: (method, params) => {
         expect(method).toBe("tasks.list");
         const status = (params as { status?: string[] }).status;
-        return Promise.resolve({ tasks: [status ? active : recent] });
+        return Promise.resolve({ tasks: [status?.includes("running") ? active : recent] });
       },
     });
 
@@ -281,7 +314,10 @@ describe("background tasks rail state", () => {
     await flushAsync();
 
     expect(request.mock.calls[0]?.[1]).toMatchObject({ status: ["queued", "running"] });
-    expect(request.mock.calls[1]?.[1]).not.toHaveProperty("status");
+    expect(request.mock.calls[1]?.[1]).toMatchObject({
+      status: ["completed", "failed", "timed_out", "cancelled"],
+      sortBy: "endedAt",
+    });
     expect(createBackgroundTasksProps(host).tasks).toEqual([recent]);
   });
 

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -1,5 +1,9 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import type { GatewayBrowserClient, GatewayHelloOk } from "../../../api/gateway.ts";
+import {
+  GatewayRequestError,
+  type GatewayBrowserClient,
+  type GatewayHelloOk,
+} from "../../../api/gateway.ts";
 import { hasOperatorWriteAccess } from "../../../app/operator-access.ts";
 import { t } from "../../../i18n/index.ts";
 import { formatUiError } from "../../../lib/format-error.ts";
@@ -79,6 +83,9 @@ export type BackgroundTasksHost = {
 // from hiding behind newer terminal records here.
 const ACTIVE_TASKS_LIMIT = 200;
 const RECENT_TASKS_LIMIT = 100;
+const TASK_LIST_MAX_ATTEMPTS = 3;
+const TASK_LIST_RETRY_DEFAULT_MS = 250;
+const TASK_LIST_RETRY_MAX_MS = 30_000;
 
 let nextStatusRowId = 0;
 
@@ -209,6 +216,54 @@ function scheduleSubagentActivityExpiry(
   );
 }
 
+function taskListRetryDelayMs(error: unknown): number | undefined {
+  if (!(error instanceof GatewayRequestError) || !error.retryable) {
+    return undefined;
+  }
+  return Math.min(
+    TASK_LIST_RETRY_MAX_MS,
+    Math.max(
+      0,
+      typeof error.retryAfterMs === "number" && Number.isFinite(error.retryAfterMs)
+        ? error.retryAfterMs
+        : TASK_LIST_RETRY_DEFAULT_MS,
+    ),
+  );
+}
+
+async function requestBackgroundTaskSnapshot(
+  host: BackgroundTasksHost,
+  state: BackgroundTasksState,
+  client: GatewayBrowserClient,
+) {
+  const { sessionKey, agentId } = state;
+  for (let attempt = 0; attempt < TASK_LIST_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return await Promise.all([
+        client.request("tasks.list", {
+          sessionKey,
+          agentId,
+          status: ["queued", "running"],
+          limit: ACTIVE_TASKS_LIMIT,
+        }),
+        client.request("tasks.list", { sessionKey, agentId, limit: RECENT_TASKS_LIMIT }),
+      ]);
+    } catch (error) {
+      const retryDelayMs = taskListRetryDelayMs(error);
+      if (retryDelayMs === undefined || attempt === TASK_LIST_MAX_ATTEMPTS - 1) {
+        throw error;
+      }
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, retryDelayMs);
+      });
+      if (!host.connected || host.client !== client || getBackgroundTasksState(host) !== state) {
+        throw error;
+      }
+    }
+  }
+  throw new Error("unreachable task list retry state");
+}
+
 function loadBackgroundTasks(
   host: BackgroundTasksHost,
   state: BackgroundTasksState,
@@ -235,18 +290,13 @@ function loadBackgroundTasks(
   state.loading = true;
   state.error = null;
   state.pendingReload = false;
-  const { sessionKey, agentId } = state;
   void (async () => {
     try {
-      const [activePayload, recentPayload] = await Promise.all([
-        client.request("tasks.list", {
-          sessionKey,
-          agentId,
-          status: ["queued", "running"],
-          limit: ACTIVE_TASKS_LIMIT,
-        }),
-        client.request("tasks.list", { sessionKey, agentId, limit: RECENT_TASKS_LIMIT }),
-      ]);
+      const [activePayload, recentPayload] = await requestBackgroundTaskSnapshot(
+        host,
+        state,
+        client,
+      );
       const active = normalizeTasksListResult(activePayload)?.tasks.map((task) =>
         prepareTaskSnapshot(state, task),
       );

--- a/ui/src/pages/chat/components/chat-background-tasks.ts
+++ b/ui/src/pages/chat/components/chat-background-tasks.ts
@@ -83,7 +83,7 @@ export type BackgroundTasksHost = {
 // from hiding behind newer terminal records here.
 const ACTIVE_TASKS_LIMIT = 200;
 const RECENT_TASKS_LIMIT = 100;
-const TASK_LIST_MAX_ATTEMPTS = 3;
+const TASK_LIST_MAX_ATTEMPTS = 2;
 const TASK_LIST_RETRY_DEFAULT_MS = 250;
 const TASK_LIST_RETRY_MAX_MS = 30_000;
 
@@ -238,27 +238,43 @@ async function requestBackgroundTaskSnapshot(
 ) {
   const { sessionKey, agentId } = state;
   for (let attempt = 0; attempt < TASK_LIST_MAX_ATTEMPTS; attempt += 1) {
-    try {
-      return await Promise.all([
-        client.request("tasks.list", {
-          sessionKey,
-          agentId,
-          status: ["queued", "running"],
-          limit: ACTIVE_TASKS_LIMIT,
-        }),
-        client.request("tasks.list", { sessionKey, agentId, limit: RECENT_TASKS_LIMIT }),
-      ]);
-    } catch (error) {
-      const retryDelayMs = taskListRetryDelayMs(error);
-      if (retryDelayMs === undefined || attempt === TASK_LIST_MAX_ATTEMPTS - 1) {
-        throw error;
+    const results = await Promise.allSettled([
+      client.request("tasks.list", {
+        sessionKey,
+        agentId,
+        status: ["queued", "running"],
+        limit: ACTIVE_TASKS_LIMIT,
+      }),
+      client.request("tasks.list", {
+        sessionKey,
+        agentId,
+        status: ["completed", "failed", "timed_out", "cancelled"],
+        sortBy: "endedAt",
+        limit: RECENT_TASKS_LIMIT,
+      }),
+    ]);
+    const [active, recent] = results;
+    if (active?.status === "fulfilled" && recent?.status === "fulfilled") {
+      return [active.value, recent.value];
+    }
+    const failures = results.filter((result) => result.status === "rejected");
+    const error = failures[0]?.reason;
+    let retryDelayMs = 0;
+    for (const failure of failures) {
+      const delay = taskListRetryDelayMs(failure.reason);
+      if (delay === undefined) {
+        throw failure.reason;
       }
-      await new Promise<void>((resolve) => {
-        window.setTimeout(resolve, retryDelayMs);
-      });
-      if (!host.connected || host.client !== client || getBackgroundTasksState(host) !== state) {
-        throw error;
-      }
+      retryDelayMs = Math.max(retryDelayMs, delay);
+    }
+    if (attempt === TASK_LIST_MAX_ATTEMPTS - 1) {
+      throw error;
+    }
+    await new Promise<void>((resolve) => {
+      window.setTimeout(resolve, retryDelayMs);
+    });
+    if (!host.connected || host.client !== client || getBackgroundTasksState(host) !== state) {
+      throw error;
     }
   }
   throw new Error("unreachable task list retry state");
@@ -290,6 +306,7 @@ function loadBackgroundTasks(
   state.loading = true;
   state.error = null;
   state.pendingReload = false;
+  host.requestUpdate?.();
   void (async () => {
     try {
       const [activePayload, recentPayload] = await requestBackgroundTaskSnapshot(

--- a/ui/src/pages/tasks/tasks-page.test.ts
+++ b/ui/src/pages/tasks/tasks-page.test.ts
@@ -197,6 +197,7 @@ describe("TasksPage concurrent refresh events", () => {
     expect(refreshCalls[0]?.[1]).toMatchObject({ status: ["queued", "running"] });
     expect(refreshCalls[1]?.[1]).toMatchObject({
       status: ["completed", "failed", "timed_out", "cancelled"],
+      sortBy: "endedAt",
     });
     refresh.active.resolve({ tasks: [initial] });
     refresh.recent.resolve({ tasks: [recent] });
@@ -396,6 +397,7 @@ describe("TasksPage active pagination", () => {
         agentId: "writer",
         limit: 200,
         status: ["completed", "failed", "timed_out", "cancelled"],
+        sortBy: "endedAt",
       }),
       { signal: expect.any(AbortSignal) },
     );

--- a/ui/src/pages/tasks/tasks-page.ts
+++ b/ui/src/pages/tasks/tasks-page.ts
@@ -124,6 +124,7 @@ async function loadTaskSnapshotOnce(
       "tasks.list",
       {
         status: RECENT_TASK_STATUSES,
+        sortBy: "endedAt",
         limit: 200,
         ...(params.agentId ? { agentId: params.agentId } : {}),
       },

--- a/ui/src/pages/tasks/tasks.e2e.test.ts
+++ b/ui/src/pages/tasks/tasks.e2e.test.ts
@@ -2,7 +2,6 @@ import { copyFile, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { createControlUiE2eSuite } from "../../e2e/control-ui-e2e-suite.test-support.ts";
-import { createControlUiE2eArtifactDir } from "../../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../../test-helpers/control-ui-e2e.ts";
 
 const suite = createControlUiE2eSuite({
@@ -143,110 +142,6 @@ const activePageOneTasks = [
 ];
 
 suite.define(() => {
-  it("keeps running rows anchored through activity and clears a recovered list error", async () => {
-    const proofDir = createControlUiE2eArtifactDir("tasks-stable-order");
-    const rawVideoDir = path.join(proofDir, "raw-video");
-    await mkdir(rawVideoDir, { recursive: true });
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      recordVideo: { dir: rawVideoDir, size: { width: 1440, height: 900 } },
-      serviceWorkers: "block",
-      viewport: { width: 1440, height: 900 },
-    });
-    const page = await context.newPage();
-    const video = page.video();
-    const activeTasks = Array.from({ length: 5 }, (_, index) => ({
-      id: `task-stable-${index + 1}`,
-      taskId: `task-stable-${index + 1}`,
-      kind: "subagent",
-      runtime: "subagent",
-      status: "running",
-      title: `Stable running task ${index + 1}`,
-      agentId: "main",
-      createdAt: baseTime + index * 1_000,
-      startedAt: baseTime + index * 1_000,
-      updatedAt: baseTime + (5 - index) * 10_000,
-      toolUseCount: index + 1,
-      lastToolName: "exec",
-    }));
-    const listResponses = {
-      cases: [
-        {
-          match: { agentId: "main", limit: 500, status: ["queued", "running"] },
-          response: { tasks: activeTasks },
-        },
-        {
-          match: {
-            agentId: "main",
-            limit: 200,
-            status: ["completed", "failed", "timed_out", "cancelled"],
-          },
-          response: { tasks: [] },
-        },
-      ],
-    };
-    const rowOrder = () =>
-      page
-        .locator('[data-task-section="active"] [data-task-id] .settings-row__title')
-        .allTextContents();
-    const expectedOrder = activeTasks.map((task) => task.title);
-    try {
-      const gateway = await installMockGateway(page, {
-        methodResponses: { "tasks.list": listResponses },
-      });
-      await page.goto(`${suite.server.baseUrl}tasks`);
-      await expect.poll(rowOrder).toEqual(expectedOrder);
-      await page.screenshot({ path: path.join(proofDir, "01-initial-order.png") });
-      await page.waitForTimeout(500);
-
-      const updatedTask = {
-        ...activeTasks[4],
-        updatedAt: baseTime + 100_000,
-        toolUseCount: 80,
-        progressSummary: "Activity changed without moving this row",
-      };
-      await gateway.emitGatewayEvent("task", { action: "upserted", task: updatedTask });
-      await page.getByText(updatedTask.progressSummary).waitFor();
-      expect(await rowOrder()).toEqual(expectedOrder);
-      await page.screenshot({ path: path.join(proofDir, "02-activity-stable.png") });
-      await page.waitForTimeout(500);
-
-      await gateway.deferNext("tasks.list", {
-        agentId: "main",
-        limit: 500,
-        status: ["queued", "running"],
-      });
-      await gateway.deferNext("tasks.list", {
-        agentId: "main",
-        limit: 200,
-        status: ["completed", "failed", "timed_out", "cancelled"],
-      });
-      await page.getByRole("button", { name: "Refresh" }).click();
-      await expect.poll(async () => gateway.getRequests("tasks.list")).toHaveLength(4);
-      await gateway.rejectDeferred("tasks.list", {
-        code: "UNAVAILABLE",
-        message: "Task activity did not stabilize. Wait a moment, then refresh Tasks.",
-        retryable: true,
-      });
-      await page.getByRole("alert").waitFor();
-      await page.screenshot({ path: path.join(proofDir, "03-retries-exhausted.png") });
-      await page.waitForTimeout(500);
-
-      await gateway.setMethodResponse("tasks.list", listResponses);
-      await page.getByRole("button", { name: "Refresh" }).click();
-      await expect.poll(() => page.getByRole("alert").count()).toBe(0);
-      expect(await rowOrder()).toEqual(expectedOrder);
-      await page.screenshot({ path: path.join(proofDir, "04-recovered.png") });
-      await page.waitForTimeout(500);
-    } finally {
-      await context.close();
-      if (video) {
-        await copyFile(await video.path(), path.join(proofDir, "tasks-stable-order.webm"));
-      }
-      await rm(rawVideoDir, { force: true, recursive: true });
-    }
-  });
-
   it("keeps completed tasks visible when active work fills the unfiltered page", async () => {
     const artifactDir = createControlUiE2eArtifactDir("tasks-recent");
     const context = await suite.browser.newContext({

--- a/ui/src/pages/tasks/tasks.e2e.test.ts
+++ b/ui/src/pages/tasks/tasks.e2e.test.ts
@@ -186,7 +186,7 @@ suite.define(() => {
       expect(await gateway.getRequests("tasks.list")).toContainEqual({
         id: expect.any(String),
         method: "tasks.list",
-        params: { agentId: "main", limit: 200, status: terminalStatuses },
+        params: { agentId: "main", limit: 200, sortBy: "endedAt", status: terminalStatuses },
       });
     } finally {
       await context.close();
@@ -403,6 +403,7 @@ suite.define(() => {
                   agentId: "main",
                   limit: 200,
                   status: ["completed", "failed", "timed_out", "cancelled"],
+                  sortBy: "endedAt",
                 },
                 response: { tasks: [completedTask, failedTask] },
               },
@@ -458,6 +459,7 @@ suite.define(() => {
           agentId: "main",
           limit: 200,
           status: ["completed", "failed", "timed_out", "cancelled"],
+          sortBy: "endedAt",
         },
       });
       await page.screenshot({

--- a/ui/src/pages/tasks/tasks.e2e.test.ts
+++ b/ui/src/pages/tasks/tasks.e2e.test.ts
@@ -2,6 +2,7 @@ import { copyFile, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { createControlUiE2eSuite } from "../../e2e/control-ui-e2e-suite.test-support.ts";
+import { createControlUiE2eArtifactDir } from "../../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../../test-helpers/control-ui-e2e.ts";
 
 const suite = createControlUiE2eSuite({

--- a/ui/src/pages/tasks/tasks.e2e.test.ts
+++ b/ui/src/pages/tasks/tasks.e2e.test.ts
@@ -143,6 +143,110 @@ const activePageOneTasks = [
 ];
 
 suite.define(() => {
+  it("keeps running rows anchored through activity and clears a recovered list error", async () => {
+    const proofDir = createControlUiE2eArtifactDir("tasks-stable-order");
+    const rawVideoDir = path.join(proofDir, "raw-video");
+    await mkdir(rawVideoDir, { recursive: true });
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      recordVideo: { dir: rawVideoDir, size: { width: 1440, height: 900 } },
+      serviceWorkers: "block",
+      viewport: { width: 1440, height: 900 },
+    });
+    const page = await context.newPage();
+    const video = page.video();
+    const activeTasks = Array.from({ length: 5 }, (_, index) => ({
+      id: `task-stable-${index + 1}`,
+      taskId: `task-stable-${index + 1}`,
+      kind: "subagent",
+      runtime: "subagent",
+      status: "running",
+      title: `Stable running task ${index + 1}`,
+      agentId: "main",
+      createdAt: baseTime + index * 1_000,
+      startedAt: baseTime + index * 1_000,
+      updatedAt: baseTime + (5 - index) * 10_000,
+      toolUseCount: index + 1,
+      lastToolName: "exec",
+    }));
+    const listResponses = {
+      cases: [
+        {
+          match: { agentId: "main", limit: 500, status: ["queued", "running"] },
+          response: { tasks: activeTasks },
+        },
+        {
+          match: {
+            agentId: "main",
+            limit: 200,
+            status: ["completed", "failed", "timed_out", "cancelled"],
+          },
+          response: { tasks: [] },
+        },
+      ],
+    };
+    const rowOrder = () =>
+      page
+        .locator('[data-task-section="active"] [data-task-id] .settings-row__title')
+        .allTextContents();
+    const expectedOrder = activeTasks.map((task) => task.title);
+    try {
+      const gateway = await installMockGateway(page, {
+        methodResponses: { "tasks.list": listResponses },
+      });
+      await page.goto(`${suite.server.baseUrl}tasks`);
+      await expect.poll(rowOrder).toEqual(expectedOrder);
+      await page.screenshot({ path: path.join(proofDir, "01-initial-order.png") });
+      await page.waitForTimeout(500);
+
+      const updatedTask = {
+        ...activeTasks[4],
+        updatedAt: baseTime + 100_000,
+        toolUseCount: 80,
+        progressSummary: "Activity changed without moving this row",
+      };
+      await gateway.emitGatewayEvent("task", { action: "upserted", task: updatedTask });
+      await page.getByText(updatedTask.progressSummary).waitFor();
+      expect(await rowOrder()).toEqual(expectedOrder);
+      await page.screenshot({ path: path.join(proofDir, "02-activity-stable.png") });
+      await page.waitForTimeout(500);
+
+      await gateway.deferNext("tasks.list", {
+        agentId: "main",
+        limit: 500,
+        status: ["queued", "running"],
+      });
+      await gateway.deferNext("tasks.list", {
+        agentId: "main",
+        limit: 200,
+        status: ["completed", "failed", "timed_out", "cancelled"],
+      });
+      await page.getByRole("button", { name: "Refresh" }).click();
+      await expect.poll(async () => gateway.getRequests("tasks.list")).toHaveLength(4);
+      await gateway.rejectDeferred("tasks.list", {
+        code: "UNAVAILABLE",
+        message: "Task activity did not stabilize. Wait a moment, then refresh Tasks.",
+        retryable: true,
+      });
+      await page.getByRole("alert").waitFor();
+      await page.screenshot({ path: path.join(proofDir, "03-retries-exhausted.png") });
+      await page.waitForTimeout(500);
+
+      await gateway.setMethodResponse("tasks.list", listResponses);
+      await page.getByRole("button", { name: "Refresh" }).click();
+      await expect.poll(() => page.getByRole("alert").count()).toBe(0);
+      expect(await rowOrder()).toEqual(expectedOrder);
+      await page.screenshot({ path: path.join(proofDir, "04-recovered.png") });
+      await page.waitForTimeout(500);
+    } finally {
+      await context.close();
+      if (video) {
+        await copyFile(await video.path(), path.join(proofDir, "tasks-stable-order.webm"));
+      }
+      await rm(rawVideoDir, { force: true, recursive: true });
+    }
+  });
+
   it("keeps completed tasks visible when active work fills the unfiltered page", async () => {
     const artifactDir = createControlUiE2eArtifactDir("tasks-recent");
     const context = await suite.browser.newContext({

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -585,7 +585,13 @@ export type MockGatewayControls = {
   getSocketUrls: () => Promise<string[]>;
   rejectDeferred: (
     method: string,
-    error?: { code?: string; message?: string; details?: unknown; retryable?: boolean },
+    error?: {
+      code?: string;
+      message?: string;
+      details?: unknown;
+      retryable?: boolean;
+      retryAfterMs?: number;
+    },
   ) => Promise<void>;
   resolveDeferred: (method: string, payload?: unknown) => Promise<void>;
   suspendLatest: () => Promise<void>;
@@ -1076,7 +1082,13 @@ export type ControlUiMockGateway = {
   findRequests: (method?: string) => MockGatewayRequest[];
   rejectDeferred: (
     method: string,
-    error?: { code?: string; message?: string; details?: unknown; retryable?: boolean },
+    error?: {
+      code?: string;
+      message?: string;
+      details?: unknown;
+      retryable?: boolean;
+      retryAfterMs?: number;
+    },
   ) => void;
   requests: MockGatewayRequest[];
   resolveDeferred: (method: string, payload?: unknown) => void;
@@ -2528,6 +2540,7 @@ function installControlUiMockGateway(
             message: error?.message ?? "mock Gateway rejected request",
             ...(error?.details ? { details: error.details } : {}),
             ...(error?.retryable ? { retryable: true } : {}),
+            ...(error?.retryAfterMs !== undefined ? { retryAfterMs: error.retryAfterMs } : {}),
           },
           id: response.id,
           ok: false,

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -585,13 +585,7 @@ export type MockGatewayControls = {
   getSocketUrls: () => Promise<string[]>;
   rejectDeferred: (
     method: string,
-    error?: {
-      code?: string;
-      message?: string;
-      details?: unknown;
-      retryable?: boolean;
-      retryAfterMs?: number;
-    },
+    error?: { code?: string; message?: string; details?: unknown; retryable?: boolean },
   ) => Promise<void>;
   resolveDeferred: (method: string, payload?: unknown) => Promise<void>;
   suspendLatest: () => Promise<void>;
@@ -1082,13 +1076,7 @@ export type ControlUiMockGateway = {
   findRequests: (method?: string) => MockGatewayRequest[];
   rejectDeferred: (
     method: string,
-    error?: {
-      code?: string;
-      message?: string;
-      details?: unknown;
-      retryable?: boolean;
-      retryAfterMs?: number;
-    },
+    error?: { code?: string; message?: string; details?: unknown; retryable?: boolean },
   ) => void;
   requests: MockGatewayRequest[];
   resolveDeferred: (method: string, payload?: unknown) => void;
@@ -2540,7 +2528,6 @@ function installControlUiMockGateway(
             message: error?.message ?? "mock Gateway rejected request",
             ...(error?.details ? { details: error.details } : {}),
             ...(error?.retryable ? { retryable: true } : {}),
-            ...(error?.retryAfterMs !== undefined ? { retryAfterMs: error.retryAfterMs } : {}),
           },
           id: response.id,
           ok: false,


### PR DESCRIPTION
Closes #135498

## What Problem This Solves

Fixes an issue where operators monitoring concurrent work in a chat session's Tasks side panel would see RUNNING cards reorder on every activity update. FINISHED cards could also omit the newest completions because the Gateway selected the bounded page by activity before the UI reordered only those returned rows. Transient task-registry conflicts could become a persistent internal error in the panel.

## Why This Change Was Made

The session Tasks panel uses lifecycle facts end to end. RUNNING uses immutable creation time in oldest-first order. FINISHED requests `tasks.list` with the additive `sortBy: "endedAt"` selector, so the registry selects the correct bounded page by completion time before returning it. Omitting `sortBy` preserves the existing last-activity default for SDK, CLI, Workboard, and other consumers.

Retry ownership is bounded at each network boundary without overlap. The registry performs one scan per call, while the Gateway owns the three-attempt consistency budget across registry and access revisions. The panel allows at most one retry of its active and finished pair, waits for both sibling RPCs to settle before starting that retry, and rejects delayed work after a session or client change. Only exhaustion becomes visible.

The approved Refresh action remains in the embedded Tasks header. It now switches immediately to a spinner and stays disabled while the list request is running.

## User Impact

Operators can follow a running task without its card jumping whenever a tool runs or progress changes. The newest completed work remains present at the top of FINISHED even when its activity timestamp would have excluded it from the old page. Transient retries stay invisible; sustained instability shows actionable guidance and can be retried directly from the side panel.


## Evidence

### Before: session Tasks side panel

Task 5 starts at the bottom:

![Session Tasks side panel before activity](https://github.com/user-attachments/assets/34d7fc4b-488c-4433-9ef2-3db3f590b984)

After one activity update, task 5 jumps to the top; FINISHED is also activity-ordered rather than completion-ordered:

![Session Tasks side panel shuffled after activity](https://github.com/user-attachments/assets/7c1ec2a4-3b88-4bda-9bc9-b1c78ca737df)

The internal retry text remains visible in the panel:

![Old persistent retry error in session panel](https://github.com/user-attachments/assets/8daa1980-ff42-4d8a-8091-19e858c8e729)

https://github.com/user-attachments/assets/47c54a5e-9f49-41a1-af7b-466d49595453

### After: audit-repaired head

RUNNING is creation-ordered and FINISHED is selected and displayed by completion:

![Stable lifecycle order in session Tasks panel](https://github.com/user-attachments/assets/8c6ee978-8bd8-409a-abdb-58aac5064e6a)

Task 5 receives 80 tool uses and a newer activity timestamp but remains anchored at the bottom:

![Stable RUNNING order after activity](https://github.com/user-attachments/assets/c31c50e5-d998-44b8-9fcb-535c3d494686)

Refresh reports loading immediately while the first request pair is pending:

![Refresh spinner while task lists load](https://github.com/user-attachments/assets/10942e5a-6aef-4309-9e77-319054dda4b0)

A retryable list failure recovers after both first-attempt RPCs settle, without rendering an error:

![Transient retry remains hidden](https://github.com/user-attachments/assets/856d77d5-fea0-48cf-9d1d-a54a3f528ae1)

Only exhausted attempts produce actionable guidance:

![Actionable exhausted retry error](https://github.com/user-attachments/assets/9680526a-705a-4bda-a190-0ec58408ab57)

The Tasks header Refresh action clears the error and restores the same order:

![Recovered session Tasks panel](https://github.com/user-attachments/assets/27260d96-9322-497b-a8d2-9b652bb28386)

https://github.com/user-attachments/assets/20e6018b-34b7-43b1-b1e0-b991097eab41

### Consumers checked

- Session Tasks side panel: canonical target; requests terminal rows with `sortBy: "endedAt"` and proves stable RUNNING, complete FINISHED membership, settled retry, loading, exhaustion, and Refresh recovery.
- Standalone Tasks page: shares lifecycle partitioning and now requests its terminal page with `sortBy: "endedAt"`; focused and browser tests pass.
- Session Tasks status preview: shares `partitionTasks` and receives the same stable lifecycle order from the panel snapshot.
- Inline subagent activity: continues using the untouched generic `sortTasks` because it is a separate latest-activity surface.
- Workboard task linking: continues omitting `sortBy`, preserving activity freshness.
- SDK `tasks.list`: forwards the new selector unchanged; omission preserves activity ordering.
- CLI and general Gateway clients: continue omitting `sortBy`, preserving the current default.
- Gateway registry query: one scan per Gateway attempt; activity and completion comparators share the same bounded heap and cursor path.
- Shared embedded-panel header: Refresh remains Tasks-only, is disabled while disconnected/loading, and now uses the canonical spinner.
- Generated Swift Gateway model: includes the additive optional `sortBy` field; protocol generation checks pass.

### Validation

- Regression proof failed before the repair because the completion-selected page omitted the newest ending task and the panel started a new pair while the first recent RPC was pending.
- 246 focused protocol, SDK, Gateway, registry, and Control UI tests passed on the rebased head.
- 8 browser scenarios passed across the session Tasks panel and standalone shared consumer.
- Protocol generation, generated Swift/Kotlin drift checks, docs MDX/links, formatting, type checks, lint, import-cycle, architecture, and repository guards passed.
- The only changed-file gate failure on that head was an unrelated macOS packaging diagnostic test that failed identically on `origin/main` at the time; see "Since the last ClawSweeper review" for the rebased head.
- Final structured review reported no accepted or actionable findings.
- Every before/after screenshot and both recordings were inspected before publication.

No fixture, tuner, mock-dev source, or shared test harness is included in the diff.


### Size

Production +215/-79 (net +136), tests and test support +789/-49, docs +8/-1, across 32 files.

The bug fix is not net-neutral because the repair moves ordering and retry ownership rather than guarding a symptom. The additive `sortBy` selector, the registry comparator, and the single Gateway retry budget are the three owner boundaries the defect crosses; expressing them downstream would have reordered only the rows the Gateway already selected, which is the bug. The registry lost its own three-attempt loop in the same change, so the retry policy has one owner instead of two.

### Since the last ClawSweeper review

The reviewed head was `941e72b8`. Nothing about the approved behavior or design changed. What changed:

- Pure rebase onto current `origin/main` (no conflicts, identical diff).
- Restored the `createControlUiE2eArtifactDir` import in `ui/src/pages/tasks/tasks.e2e.test.ts`. The import was correctly unused at the old merge base; `main` added four call sites in that file afterwards, so the rebase produced a file that referenced the helper without importing it. This broke `check-test-types-core-3` and `checks-ui-e2e (4/13)`.
- Rebased onto #133186 "stabilize task list continuations", which rewrote the same task-list owner with revision-bound opaque cursors. The merge keeps that design intact and layers ordering on top: `sortBy` joins the cursor binding facts, so a carried offset can never cross sort orders; the registry keeps its bounded internal attempt loop and `cursor_stale` contract, with the comparator threaded through the selection heap; and the Gateway retries only transient `registry_changed` churn while a stale cursor still restarts the caller.
- The Control UI startup JS gzip budget was exhausted on `main` itself, so `build-artifacts` and `checks-ui-e2e-real-gateway` were red for every UI branch. That is fixed by #136817, which re-baselines to 349565 B. This branch is rebased on top of it and adds no baseline edit of its own; the session Tasks retry and refresh path costs roughly 236 B gzip, well inside the 350141 B enforcement limit that baseline establishes.
- The two `checks-ui-e2e` shard failures on `941e72b8` (`new-session-page.transition` route-animation poll and `mobile-inbox-sheet` entrance animation) did not reproduce on the rebased head. Both assert that a CSS animation is still running at an observation point; neither test file nor its surface is touched by this PR.
- Fresh structured review on the rebased branch diff: clean, no accepted or actionable findings.

### ClawSweeper rank-up moves

The only listed move was "Obtain task-registry owner review and wait for the exact-head required checks to finish successfully." Maintainer review is complete and the exact-head required checks are green before merge.
