### PR TITLE
fix(pr): preserve ignored files and skip redundant prepare transitions

### DIFF
--- a/scripts/pr-lib/prepare-core.sh
+++ b/scripts/pr-lib/prepare-core.sh
@@ -143,7 +143,7 @@ prepare_init() {
   review_validate_artifacts "$pr" || return 1
   require_ready_review_recommendation || return 1
   mark_pr_operation_side_effects_started
-  enter_worktree "$pr" true || return 1
+  enter_worktree "$pr" false || return 1
 
   require_artifact .local/pr-meta.env
   require_artifact .local/review.md
@@ -166,6 +166,9 @@ prepare_init() {
     echo "Prepare init failed: missing PR_HEAD_SHA in .local/pr-meta.env. Re-run review-init."
     exit 1
   fi
+  # Keep clean-state admission and recoverable detachment without visiting main.
+  # Fetch cannot update pr-$pr while that branch is checked out.
+  checkout_pr_worktree_target "$pr" "$reviewed_head_sha" || return 1
 
   local json
   json=$(pr_meta_json "$pr")

--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -77,6 +77,8 @@ require_no_ignored_transition_paths() {
   local source="$2"
   local target="$3"
   local file
+  # Keep ls-files' literal subtree matching: check-ignore on a directory misses
+  # ignored descendants that restore would delete. Bound argv; skip empty diffs.
   git diff --name-only --no-renames -z "$source" "$target" |
     while IFS= read -r -d '' file; do
       case "$file" in
@@ -85,19 +87,20 @@ require_no_ignored_transition_paths() {
           return 1
           ;;
       esac
-    done || return 1
-
-  # Ask Git about every transition path at once. Per-path ignored-file scans
-  # become prohibitively slow when a PR is far behind main.
-  git diff --name-only --no-renames -z "$source" "$target" |
-    { git check-ignore -z --stdin || [ "$?" -eq 1 ]; } |
+      printf ':(literal)%s\0' "$file"
+      # A file or symlink ancestor would also be replaced; ordinary directories
+      # may contain unrelated ignored data and must not widen the query.
+      while [[ "$file" == */* ]]; do
+        file=${file%/*}
+        if [ -L "$file" ] || { [ -e "$file" ] && [ ! -d "$file" ]; }; then
+          printf ':(literal)%s\0' "$file"
+        fi
+      done
+    done |
+    xargs -0 -r -s 32768 git ls-files --others --ignored --exclude-standard -z -- |
     while IFS= read -r -d '' file; do
-      # check-ignore also reports paths that do not exist. Only an existing
-      # ignored entry can be overwritten by the transition.
-      if [ -e "$file" ] || [ -L "$file" ]; then
-        refuse_review_transition "$pr" "ignored file '$file' would be overwritten by the journaled transition."
-        return 1
-      fi
+      refuse_review_transition "$pr" "ignored file '$file' would be overwritten by the journaled transition."
+      return 1
     done
 }
 

--- a/test/scripts/pr-main-refresh.test-support.ts
+++ b/test/scripts/pr-main-refresh.test-support.ts
@@ -198,6 +198,8 @@ export function createMainRefreshFixture(directory: string) {
     metadata,
     authorPermission: "write",
     failFetch: false,
+    failPrFetch: false,
+    failDetach: false,
     failFetchAt: 0,
     pauseFetchAt: 0,
     failAuth: false,
@@ -259,6 +261,11 @@ function runGit(args, input) {
     instrumentedGit,
     prelude +
       `
+if ((control.failPrFetch && args.includes('fetch') && args.includes('pull/42/head:pr-42')) ||
+    (control.failDetach && args[0] === 'checkout' && args[1] === '--detach')) {
+  console.error('fatal: injected prepare handoff failure');
+  process.exit(73);
+}
 const mainFetch = args.includes('fetch') && args.some(arg =>
   arg === 'main' || arg.startsWith('+refs/heads/main:') || arg === 'refs/heads/main'
 );
@@ -524,8 +531,11 @@ if (process.argv[1]?.endsWith('/watch-pr-ci.mts')) {
     metadata,
     configure(update: Partial<typeof control>) {
       Object.assign(control, update);
-      if (control.hostedCi === "scheduled") delete env.NODE_OPTIONS;
-      else env.NODE_OPTIONS = `--import=${clock}`;
+      if (control.hostedCi === "scheduled") {
+        delete env.NODE_OPTIONS;
+      } else {
+        env.NODE_OPTIONS = `--import=${clock}`;
+      }
       writeFileSync(controlFile, JSON.stringify(control));
     },
     events() {

--- a/test/scripts/pr-main-refresh.test.ts
+++ b/test/scripts/pr-main-refresh.test.ts
@@ -35,6 +35,132 @@ function recoverFixtureLock(f: ReturnType<typeof fixture>, oid: string) {
 }
 
 describePosix("native PR main refresh boundaries", () => {
+  it.each(["detached", "pr-42", "pr-42-prep"])(
+    "prepares directly from the reviewed head (%s) without visiting main",
+    (branch) => {
+      const f = fixture();
+      f.git(f.canonical, "branch", "temp/pr-42", f.sameTreeHead);
+      if (branch !== "detached") {
+        f.git(f.worktree, "checkout", "-B", branch, f.head);
+      }
+      writeFileSync(join(f.canonical, "src/subject.ts"), "unrelated shared-checkout work\n");
+      const sharedDiff = f.git(f.canonical, "diff", "HEAD");
+      const review = readFileSync(join(f.local, "review.md"), "utf8");
+      const result = f.run("prepare-init", "bash", f.worktree);
+      expect(result.status, result.stdout + result.stderr).toBe(0);
+      expect(f.git(f.worktree, "branch", "--show-current")).toBe("pr-42-prep");
+      expect(f.git(f.worktree, "rev-parse", "HEAD")).toBe(f.head);
+      expect(f.git(f.worktree, "status", "--porcelain")).toBe("");
+      expect(f.git(f.canonical, "rev-parse", "temp/pr-42")).toBe(f.sameTreeHead);
+      expect(f.git(f.canonical, "diff", "HEAD")).toBe(sharedDiff);
+      expect(readFileSync(join(f.local, "review.md"), "utf8")).toBe(review);
+      expect(existsSync(join(f.local, "review-transition.json"))).toBe(false);
+      const checkouts = f.events().filter((e) => e.args?.[0] === "checkout");
+      expect(checkouts.length).toBeGreaterThan(0);
+      expect(checkouts.every((e) => e.args?.at(-1) === f.head)).toBe(true);
+      expect(f.events().filter((e) => e.kind === "main-fetch")).toHaveLength(1);
+    },
+  );
+
+  it.each(["staged", "unstaged", "untracked", "unmerged"])(
+    "refuses same-head preparation with %s foreign state",
+    (state) => {
+      const f = fixture();
+      if (state === "unmerged") {
+        expect(() => f.git(f.worktree, "merge", f.movedMain)).toThrow();
+      } else {
+        const path = state === "untracked" ? "foreign.txt" : "src/subject.ts";
+        writeFileSync(join(f.worktree, path), "foreign data\n");
+        if (state === "staged") {
+          f.git(f.worktree, "add", path);
+        }
+      }
+      const before = [
+        f.git(f.worktree, "rev-parse", "HEAD"),
+        f.git(f.worktree, "ls-files", "--stage"),
+        f.git(f.worktree, "status", "--porcelain"),
+        f.git(f.worktree, "diff", "HEAD"),
+      ];
+      const result = f.run("prepare-init");
+      expect(result.status, result.stdout + result.stderr).not.toBe(0);
+      expect(result.stderr).toContain("foreign state blocks a new transition");
+      expect([
+        f.git(f.worktree, "rev-parse", "HEAD"),
+        f.git(f.worktree, "ls-files", "--stage"),
+        f.git(f.worktree, "status", "--porcelain"),
+        f.git(f.worktree, "diff", "HEAD"),
+      ]).toEqual(before);
+      expect(existsSync(join(f.local, "prep-context.env"))).toBe(false);
+      expect(existsSync(join(f.local, "review-transition.json"))).toBe(false);
+      expect(f.git(f.canonical, "rev-parse", "HEAD")).toBe(f.main);
+    },
+  );
+
+  it.each(["detach", "fetch"])("recovers preparation after failed %s handoff", (failure) => {
+    const f = fixture();
+    f.git(f.worktree, "checkout", "-B", "pr-42", f.head);
+    f.configure({ failDetach: failure === "detach", failPrFetch: failure === "fetch" });
+    const failed = f.run("prepare-init");
+    expect(failed.status, failed.stdout + failed.stderr).not.toBe(0);
+    expect(failed.stderr).toContain("injected prepare handoff failure");
+    expect(f.git(f.worktree, "rev-parse", "HEAD")).toBe(f.head);
+    expect(f.git(f.worktree, "status", "--porcelain")).toBe("");
+    expect(existsSync(join(f.local, "prep-context.env"))).toBe(false);
+    const journal = join(f.local, "review-transition.json");
+    expect(existsSync(journal)).toBe(failure === "detach");
+    if (failure === "detach") {
+      expect(JSON.parse(readFileSync(journal, "utf8"))).toEqual({
+        version: 1,
+        pr: 42,
+        source: f.head,
+        target: f.head,
+        mode: "detached",
+        branch: null,
+      });
+    }
+    const owner = f.git(f.canonical, "rev-parse", "refs/openclaw/pr-operation-locks/42");
+    expect(failed.stderr).toContain(`lock-recover 42 ${owner} --confirmed-no-running-tools`);
+    recoverFixtureLock(f, owner);
+    f.configure({ failDetach: false, failPrFetch: false });
+    const result = f.run("prepare-init");
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(f.git(f.worktree, "branch", "--show-current")).toBe("pr-42-prep");
+    expect(f.git(f.worktree, "rev-parse", "HEAD")).toBe(f.head);
+    expect(existsSync(journal)).toBe(false);
+  });
+
+  it("finishes an older main transition before rejecting a stale PR-head review", () => {
+    const f = fixture();
+    const journal = join(f.local, "review-transition.json");
+    writeFileSync(
+      journal,
+      JSON.stringify({
+        version: 1,
+        pr: 42,
+        source: f.head,
+        target: f.main,
+        mode: "detached",
+        branch: null,
+      }),
+    );
+    f.git(
+      f.worktree,
+      "restore",
+      `--source=${f.main}`,
+      "--staged",
+      "--worktree",
+      "--",
+      "src/subject.ts",
+    );
+    const result = f.run("prepare-init");
+    expect(result.status, result.stdout + result.stderr).not.toBe(0);
+    expect(result.stdout).toContain("expected HEAD at PR_HEAD_SHA");
+    expect(f.git(f.worktree, "rev-parse", "HEAD")).toBe(f.main);
+    expect(f.git(f.worktree, "status", "--porcelain")).toBe("");
+    expect(existsSync(journal)).toBe(false);
+    expect(existsSync(join(f.local, "prep-context.env"))).toBe(false);
+  });
+
   it("completes supervised prepare with three fresh checkpoints and exact stamps", () => {
     const f = fixture();
     const result = f.run("prepare-run");
@@ -362,9 +488,11 @@ read -r release < "$OPENCLAW_TEST_FETCH_HOLD"
       const ready = new Promise<string>((resolve, reject) => {
         let data = "";
         reader.on("data", (chunk) => {
-          data += chunk;
+          data += chunk.toString();
           const newline = data.indexOf("\n");
-          if (newline >= 0) resolve(data.slice(0, newline));
+          if (newline >= 0) {
+            resolve(data.slice(0, newline));
+          }
         });
         reader.once("error", reject);
       });
@@ -425,7 +553,9 @@ read -r release < "$OPENCLAW_TEST_FETCH_HOLD"
         f.configure({ pauseFetchAt: 0 });
         const retry = f.run("review-checkout-main");
         const retryOwner = f.git(f.canonical, "for-each-ref", "--format=%(objectname)", lockRef);
-        if (retryOwner) recoverFixtureLock(f, retryOwner);
+        if (retryOwner) {
+          recoverFixtureLock(f, retryOwner);
+        }
         expect(retry.status, retry.stdout + retry.stderr).toBe(0);
         expect(initializedTree).toBe(
           fetchNumber === 1 ? undefined : f.git(f.canonical, "rev-parse", `${f.main}^{tree}`),
@@ -435,8 +565,9 @@ read -r release < "$OPENCLAW_TEST_FETCH_HOLD"
         expect(f.git(f.worktree, "status", "--porcelain")).toBe("");
         expect(f.git(f.canonical, "rev-parse", "HEAD")).toBe(f.head);
       } finally {
-        if (controller.exitCode === null && controller.signalCode === null)
+        if (controller.exitCode === null && controller.signalCode === null) {
           controller.kill("SIGTERM");
+        }
         await exited;
         // Unblock a pending FIFO open/read even if the wrapper exited before the handshake.
         const fd = openSync(readyPath, constants.O_RDWR);
@@ -454,10 +585,12 @@ read -r release < "$OPENCLAW_TEST_FETCH_HOLD"
       expect(f.git(f.canonical, "rev-parse", `${f.head}^{tree}`)).toBe(
         f.git(f.canonical, "rev-parse", `${f.sameTreeHead}^{tree}`),
       );
-      if (boundary === "metadata")
+      if (boundary === "metadata") {
         f.configure({ metadata: { ...f.metadata, headRefOid: f.sameTreeHead } });
-      if (boundary === "branch")
+      }
+      if (boundary === "branch") {
         f.configure({ metadata: { ...f.metadata, headRefName: "renamed" } });
+      }
       if (boundary === "fetched") {
         f.git(f.canonical, "push", "origin", `${f.sameTreeHead}:refs/pull/42/head`);
       }
@@ -468,6 +601,8 @@ read -r release < "$OPENCLAW_TEST_FETCH_HOLD"
       );
       expect(existsSync(join(f.local, "prep-context.env"))).toBe(false);
       expect(existsSync(join(f.local, "prep.env"))).toBe(false);
+      expect(f.git(f.worktree, "rev-parse", "HEAD")).toBe(f.head);
+      expect(f.git(f.worktree, "status", "--porcelain")).toBe("");
       expect(f.events().some((e) => e.kind === "hosted-gate")).toBe(false);
     },
   );
@@ -481,7 +616,9 @@ read -r release < "$OPENCLAW_TEST_FETCH_HOLD"
       // This case owns the nonhosted watcher's post-wait refresh contract.
       writeFileSync(join(f.local, "gates.env"), "GATES_MODE=full\n");
       f.configure({ moveAtCi: true });
-      if (strict) f.env.OPENCLAW_PR_STRICT_DRIFT = "1";
+      if (strict) {
+        f.env.OPENCLAW_PR_STRICT_DRIFT = "1";
+      }
       const before = f.events().length;
       const result = f.run("merge-verify");
       expect(result.status, result.stdout + result.stderr).toBe(strict ? 1 : 0);

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -276,6 +276,7 @@ function createFreshMainTemplate() {
     "seq",
     "sh",
     "sleep",
+    "xargs",
   ]) {
     symlinkSync(
       execFileSync("which", [command], { encoding: "utf8", env: setupEnv }).trim(),
@@ -752,17 +753,26 @@ describePosix("scripts/pr per-PR operation lock", () => {
   it.each([
     ["ls-files --others --exclude-standard -z", "require_no_foreign_untracked"],
     ["diff --name-only --no-renames -z", "require_no_ignored_transition_paths"],
-    ["check-ignore -z --stdin", "require_no_ignored_transition_paths"],
+    ["ls-files --others --ignored --exclude-standard -z", "require_no_ignored_transition_paths"],
     ["diff --cached --name-only --no-renames -z", "validate_review_transition_state"],
   ])("rejects failed %s reads in %s", (query, guard) => {
     const repoDir = createRepo();
     const head = refOid(repoDir, "HEAD");
+    writeFileSync(join(repoDir, "base.txt"), "target\n");
+    execFileSync("git", ["commit", "-qam", "target fixture"], { cwd: repoDir });
+    const target = refOid(repoDir, "HEAD");
+    execFileSync("git", ["checkout", "--detach", head], { cwd: repoDir });
+    const binDir = tempDirs.make("openclaw-pr-query-failure-");
+    const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+    const proxy = writeFixtureFile(binDir, "git", [
+      "#!/usr/bin/env bash",
+      `case "$*" in ${JSON.stringify(query)}*) echo 'fixture query failed' >&2; exit 7 ;; esac`,
+      `exec '${realGit}' "$@"`,
+    ]);
+    chmodSync(proxy, 0o755);
     const result = runLockShell(repoDir, [
-      "git() {",
-      `  case "$*" in ${JSON.stringify(query)}*) echo 'fixture query failed' >&2; return 7 ;; esac`,
-      '  command git "$@"',
-      "}",
-      `${guard} 42 ${head} ${head} || exit $?`,
+      `export PATH='${binDir}':"$PATH"`,
+      `${guard} 42 ${head} ${target} || exit $?`,
     ]);
     expect(result.stderr).toContain("fixture query failed");
     expect(result.status, result.stdout + result.stderr).not.toBe(0);
@@ -1017,7 +1027,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
             expect.soft(git("-C", worktreeDir, "branch", "--show-current")).toBe("temp/pr-42");
             expect.soft(git("-C", worktreeDir, "write-tree")).toBe(canonicalTree);
             expect.soft(git("-C", worktreeDir, "diff", "--exit-code")).toBe("");
-            expect.soft(readdirSync(localDir).sort()).toEqual([...artifactNames].sort());
+            expect.soft(readdirSync(localDir).toSorted()).toEqual(artifactNames.toSorted());
             for (const [name, contents] of priorArtifacts) {
               expect.soft(readFileSync(join(localDir, name), "utf8"), name).toBe(contents);
             }
@@ -2052,20 +2062,33 @@ describePosix("scripts/pr per-PR operation lock", () => {
   it("joins Git read producers before releasing a successful operation lock", async () => {
     const repoDir = createRepo();
     const producerExited = join(repoDir, "worktree-producer-exited");
+    const binDir = tempDirs.make("openclaw-pr-joined-query-");
+    const queryExited = join(binDir, "query-exited");
+    const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+    const proxy = writeFixtureFile(binDir, "git", [
+      "#!/usr/bin/env bash",
+      'if [ "$1" = ls-files ] && [ "${3:-}" = --ignored ]; then',
+      "  exec 1>&-",
+      "  sleep 0.1",
+      `  : > '${queryExited}'`,
+      "  exit 0",
+      "fi",
+      `exec '${realGit}' "$@"`,
+    ]);
+    chmodSync(proxy, 0o755);
     const result = await runSupervisedOperation(repoDir, "joined-worktree-operation.sh", [
+      `export PATH='${binDir}':"$PATH"`,
       "acquire_pr_operation_lock 42",
       "git() {",
-      "  local result=0",
       '  case "$*" in',
       '    "worktree list"*) printf \'worktree %s\\0branch refs/heads/pr-42\\0\\0\' "$PWD" ;;',
-      '    "ls-files --others --exclude-standard -z"|"diff --name-only --no-renames -z "*|"diff --cached --name-only --no-renames -z "*) ;;',
-      '    "check-ignore -z --stdin") result=1 ;;',
+      "    \"diff --name-only --no-renames -z \"*) printf 'base.txt\\0' ;;",
+      '    "ls-files --others --exclude-standard -z"|"diff --cached --name-only --no-renames -z "*) ;;',
       '    *) command git "$@"; return $? ;;',
       "  esac",
       "  exec 1>&-",
       "  sleep 0.1",
       "  : >worktree-producer-exited",
-      '  return "$result"',
       "}",
       'worktree_is_registered "$PWD"',
       "test -f worktree-producer-exited",
@@ -2078,6 +2101,10 @@ describePosix("scripts/pr per-PR operation lock", () => {
       "  rm worktree-producer-exited",
       '  "$guard" 42 "$head" "$head" || exit $?',
       "  test -f worktree-producer-exited",
+      '  if [ "$guard" != require_no_foreign_untracked ]; then',
+      `    test -f '${queryExited}'`,
+      `    rm '${queryExited}'`,
+      "  fi",
       "done",
     ]);
     expect(result.status, result.stdout + "\n" + result.stderr).toBe(0);

--- a/test/scripts/pr-worktree-containment.test.ts
+++ b/test/scripts/pr-worktree-containment.test.ts
@@ -6,6 +6,7 @@ import {
   cpSync,
   mkdirSync,
   readFileSync,
+  readlinkSync,
   realpathSync,
   rmSync,
   symlinkSync,
@@ -223,7 +224,9 @@ describePosix("scripts/pr worktree containment", () => {
     const prepared = new Promise<void>((resolve) => {
       writer.stdout.on("data", (chunk) => {
         writerOutput += chunk;
-        if (writerOutput.includes("prepare: ok\n")) resolve();
+        if (writerOutput.includes("prepare: ok\n")) {
+          resolve();
+        }
       });
     });
     writer.stdin.write(
@@ -270,7 +273,9 @@ describePosix("scripts/pr worktree containment", () => {
             }),
         ),
       );
-      for (const result of results) expect.soft(result.code, result.output).toBe(0);
+      for (const result of results) {
+        expect.soft(result.code, result.output).toBe(0);
+      }
       expect(writer.exitCode).toBeNull();
       expect(readFileSync(fetchHead, "utf8")).toBe(previousFetch);
       expect(git(fixture.root, "rev-parse", "refs/remotes/origin/main")).toBe(fixture.mainSha);
@@ -650,30 +655,114 @@ describePosix("scripts/pr worktree containment", () => {
     });
   }
 
-  it("refuses and preserves an ignored file colliding with the transition target", () => {
-    const fixture = createReviewFixture();
-    const worktree = join(fixture.root, ".worktrees", "pr-42");
-    const result = runShell(fixture, [
-      "review_init 42",
-      "review_checkout_pr 42",
-      "source_sha=$(git rev-parse HEAD)",
-      "target_sha=$(git rev-parse origin/main)",
-      'jq -cn --arg source "$source_sha" --arg target "$target_sha" \'{version:1,pr:42,source:$source,target:$target,mode:"detached",branch:null}\' > .local/review-transition.json',
-      'git restore --source="$target_sha" --staged --worktree -- transition-a.txt',
-      'printf "main-only.txt\\n" >> "$(git rev-parse --git-path info/exclude)"',
-      'printf "foreign ignored\\n" > main-only.txt',
-      "git check-ignore -q main-only.txt",
-      "review_init 42",
-    ]);
+  for (const recovery of [false, true]) {
+    it.each([
+      { name: "file", path: "main-only.txt", directory: false, symlink: false },
+      { name: "dangling symlink", path: "main-only.txt", directory: false, symlink: true },
+      {
+        name: "file ancestor",
+        path: "main-only.txt",
+        directory: false,
+        symlink: false,
+        ancestor: true,
+      },
+      {
+        name: "dangling symlink ancestor",
+        path: "main-only.txt",
+        directory: false,
+        symlink: true,
+        ancestor: true,
+      },
+      {
+        name: "directory symlink ancestor",
+        path: "main-only.txt",
+        directory: false,
+        symlink: true,
+        ancestor: true,
+        directoryTarget: true,
+      },
+      {
+        name: "directory containing ignored data",
+        path: "main-only.txt/private.ignored",
+        directory: true,
+        symlink: false,
+      },
+      {
+        name: "directory containing an ignored dangling symlink",
+        path: "main-only.txt/private.ignored",
+        directory: true,
+        symlink: true,
+      },
+    ])(`preserves an ignored $name before mutation (recovery=${recovery})`, (collision) => {
+      const fixture = createReviewFixture();
+      if ("ancestor" in collision) {
+        git(fixture.root, "checkout", "main");
+        rmSync(join(fixture.root, "main-only.txt"));
+        mkdirSync(join(fixture.root, "main-only.txt", "nested"), { recursive: true });
+        writeFileSync(join(fixture.root, "main-only.txt", "nested", "child.txt"), "target\n");
+        git(fixture.root, "add", "-A");
+        git(fixture.root, "commit", "-m", "directory target fixture");
+        fixture.mainSha = git(fixture.root, "rev-parse", "HEAD");
+        git(fixture.root, "checkout", fixture.siblingBranch);
+      }
+      const linkTarget = "directoryTarget" in collision ? ".local/link-target" : "missing";
+      const worktree = join(fixture.root, ".worktrees", "pr-42");
+      const setup = runShell(fixture, [
+        "review_init 42",
+        "review_checkout_pr 42",
+        ...(recovery
+          ? [
+              `write_review_transition_journal 42 ${fixture.prASha} ${fixture.mainSha} detached ''`,
+              `git restore --source=${fixture.mainSha} --staged --worktree -- transition-a.txt`,
+            ]
+          : []),
+        `printf '%s\\n' '${collision.path}' >> "$(git rev-parse --git-path info/exclude)"`,
+        ...(collision.directory ? ["mkdir main-only.txt"] : []),
+        "mkdir -p .local/link-target",
+        "printf 'unrelated target data\\n' > .local/link-target/private",
+        collision.symlink
+          ? `ln -s '${linkTarget}' '${collision.path}'`
+          : `printf 'foreign ignored\\n' > '${collision.path}'`,
+      ]);
+      expect(setup.status, `${setup.stdout}\n${setup.stderr}`).toBe(0);
+      const before = reviewState(worktree);
+      const result = runShell(fixture, [recovery ? "review_init 42" : "review_checkout_main 42"]);
 
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("ignored file 'main-only.txt' would be overwritten");
-    expect(git(worktree, "rev-parse", "HEAD")).toBe(fixture.prASha);
-    expect(git(worktree, "status", "--short", "--ignored", "--", "main-only.txt")).toBe(
-      "!! main-only.txt",
-    );
-    expect(readFileSync(join(worktree, "main-only.txt"), "utf8")).toBe("foreign ignored\n");
-    expect(existsSync(join(worktree, ".local", "review-transition.json"))).toBe(true);
+      expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+      expect(result.stderr).toContain(`ignored file '${collision.path}' would be overwritten`);
+      expect(reviewState(worktree)).toEqual(before);
+      const preserved = join(worktree, collision.path);
+      expect(collision.symlink ? readlinkSync(preserved) : readFileSync(preserved, "utf8")).toBe(
+        collision.symlink ? linkTarget : "foreign ignored\n",
+      );
+      expect(readFileSync(join(worktree, ".local/link-target/private"), "utf8")).toBe(
+        "unrelated target data\n",
+      );
+      expectCanonicalCheckoutUnchanged(fixture);
+    });
+  }
+
+  it.each([".local", ".local/review-mode.env"])("refuses reserved transition path %s", (path) => {
+    const fixture = createReviewFixture();
+    git(fixture.root, "checkout", "review/pr");
+    if (path !== ".local") {
+      mkdirSync(join(fixture.root, ".local"));
+    }
+    writeFileSync(join(fixture.root, path), "not an owned artifact\n");
+    git(fixture.root, "add", "-f", "--", path);
+    git(fixture.root, "commit", "-m", "reserved namespace fixture");
+    git(fixture.root, "update-ref", "refs/pull/42/head", "HEAD");
+    git(fixture.root, "checkout", fixture.siblingBranch);
+    const setup = runShell(fixture, ["review_checkout_main 42"]);
+    expect(setup.status, setup.stdout + setup.stderr).toBe(0);
+    const worktree = join(fixture.root, ".worktrees", "pr-42");
+    const before = reviewState(worktree);
+    const artifact = readFileSync(join(worktree, ".local", "review-mode.env"), "utf8");
+    const result = runShell(fixture, ["review_checkout_pr 42"]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("reserved .local artifact namespace");
+    expect(reviewState(worktree)).toEqual(before);
+    expect(readFileSync(join(worktree, ".local", "review-mode.env"), "utf8")).toBe(artifact);
     expectCanonicalCheckoutUnchanged(fixture);
   });
 
@@ -682,7 +771,9 @@ describePosix("scripts/pr worktree containment", () => {
     const result = runShell(fixture, [
       "review_init 42",
       "review_checkout_pr 42",
-      'printf "main-only.txt\\n" >> "$(git rev-parse --git-path info/exclude)"',
+      'printf "main-only.txt\\n.local/\\n" >> "$(git rev-parse --git-path info/exclude)"',
+      'printf "preserved artifact\\n" > .local/review-note',
+      "review_checkout_pr 42",
       "git check-ignore -q main-only.txt",
       "test ! -e main-only.txt",
       "review_checkout_main 42",
@@ -695,19 +786,30 @@ describePosix("scripts/pr worktree containment", () => {
     expectCanonicalCheckoutUnchanged(fixture);
   });
 
-  it("checks every transition target for ignored collisions with bounded Git queries", () => {
+  it.each([false, true])("bounds literal transition queries (collision=%s)", (collision) => {
     const fixture = createReviewFixture();
     git(fixture.root, "checkout", "review/pr");
-    for (let index = 0; index < 32; index += 1) {
-      writeFileSync(join(fixture.root, `transition-batch-${index}.txt`), `${index}\n`);
+    for (let index = 0; index < 192; index += 1) {
+      const name = `transition-batch-${index}-${"x".repeat(180)}.txt`;
+      writeFileSync(join(fixture.root, name), `${index}\n`);
     }
-    const literalPath = "transition-[literal]*?.txt";
+    const literalPath = "zz-transition-[literal]*?\n雪\\name.txt";
     writeFileSync(join(fixture.root, literalPath), "literal path\n");
     git(fixture.root, "add", ".");
     git(fixture.root, "commit", "-m", "add transition batch");
     git(fixture.root, "update-ref", "refs/pull/42/head", "HEAD");
     git(fixture.root, "checkout", fixture.siblingBranch);
 
+    const worktree = join(fixture.root, ".worktrees", "pr-42");
+    const setup = runShell(fixture, ["review_checkout_main 42"]);
+    expect(setup.status, setup.stdout + setup.stderr).toBe(0);
+    writeFileSync(git(worktree, "rev-parse", "--git-path", "info/exclude"), "zz-*\n");
+    const lookalike = join(worktree, "zz-transition-literal1\n雪\\name.txt");
+    writeFileSync(lookalike, "unrelated ignored data\n");
+    if (collision) {
+      writeFileSync(join(worktree, literalPath), "foreign ignored\n");
+    }
+    const before = reviewState(worktree);
     const tools = join(fixture.root, "tools");
     const commandLog = join(fixture.root, "git-commands.log");
     mkdirSync(tools);
@@ -718,7 +820,12 @@ describePosix("scripts/pr worktree containment", () => {
       join(tools, "git"),
       [
         "#!/usr/bin/env bash",
-        'printf "%s\\n" "$*" >> "$GIT_COMMAND_LOG"',
+        'printf "%s\\n" "$1" >> "$GIT_COMMAND_LOG"',
+        'if [ "${1:-}" = ls-files ] && [ "${3:-}" = --ignored ]; then',
+        '  printf "ignored-query\\n" >> "$GIT_COMMAND_LOG"',
+        '  bytes=0; for arg in "$@"; do bytes=$((bytes + ${#arg} + 1)); done',
+        '  if [ "$bytes" -gt 32768 ]; then exit 126; fi',
+        "fi",
         'if [[ ( "${1:-}" == "restore" || "${2:-}" == "restore" ) && "$#" -gt 12 ]]; then',
         '  printf "%s\\n" "Argument list too long" >&2',
         "  exit 126",
@@ -732,18 +839,22 @@ describePosix("scripts/pr worktree containment", () => {
       GIT_COMMAND_LOG: commandLog,
       PATH: `${tools}:${process.env.PATH ?? ""}`,
       REAL_GIT: realGit,
+      LC_ALL: "C",
     });
 
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(collision ? 1 : 0);
     const commands = readFileSync(commandLog, "utf8").trim().split("\n");
-    // checkout validates once before journaling and again while recovering it.
-    expect(commands.filter((command) => command.startsWith("check-ignore "))).toHaveLength(2);
-    expect(
-      commands.filter((command) => command.startsWith("ls-files --others --ignored ")),
-    ).toHaveLength(0);
-    expect(readFileSync(join(fixture.root, ".worktrees", "pr-42", literalPath), "utf8")).toBe(
-      "literal path\n",
+    const queries = commands.filter((command) => command === "ignored-query").length;
+    expect(queries).toBeGreaterThan(1);
+    expect(queries).toBeLessThan(16);
+    expect(readFileSync(join(worktree, literalPath), "utf8")).toBe(
+      collision ? "foreign ignored\n" : "literal path\n",
     );
+    expect(readFileSync(lookalike, "utf8")).toBe("unrelated ignored data\n");
+    if (collision) {
+      expect(result.stderr).toContain(`ignored file '${literalPath}' would be overwritten`);
+      expect(reviewState(worktree)).toEqual(before);
+    }
     expectCanonicalCheckoutUnchanged(fixture);
   });
 });


### PR DESCRIPTION
Related: #132180 (native preparation investigation context; the node-execution changes in that PR are not modified here).

## What Problem This Solves

Fixes an issue where maintainers switching or recovering a PR worktree could lose ignored files when a tracked target replaced a directory containing ignored data. It also removes warm `prepare-init`'s unnecessary trip from the reviewed head to main and back, which materializes unrelated changes in a behind-main PR.

Current main already batches with `git check-ignore`, but checking a directory's ignore status is not equivalent to enumerating ignored descendants. A disposable native transition reproduced successful checkout followed by deletion of synthetic ignored operator data.

## Why This Change Was Made

Use the existing Git ownership boundary rather than bypassing it: stream NUL-delimited literal pathspecs into size-bounded `git ls-files --others --ignored --exclude-standard` batches. Include existing blocking file/symlink ancestors, but not ordinary parent directories containing unrelated ignored siblings. Preserve both pre-journal and recovery validation, `.local` refusal, foreground producer joins, query-error propagation, and shared-checkout containment.

Warm preparation uses the existing journaled checkout helper at the exact reviewed SHA in detached mode. This retains strict dirty-state admission and gets HEAD off `pr-N` before fetching into that branch. A bare reset-flag change would lose those safeguards. Journal schema, allowed branch modes, process-lock recovery, wrapper trust selection, cold provisioning, and main freshness checkpoints are unchanged.

Alternatives rejected: keeping `check-ignore` loses descendant collisions; a per-path `ls-files` loop reintroduces subprocess fan-out; enumerating every ignored file needlessly scans unrelated dependency/build trees; an unguarded same-head checkout can preserve foreign modifications.

## User Impact

Maintainer PR transitions preserve ignored files and links rather than overwriting them. Warm preparation keeps the reviewed tree in place instead of materializing main solely to return to the same reviewed head. Old pending main-target journals still recover before exact-head review validation rejects stale review state.

Production/tooling LOC: +19/-13 (net +6). Tests/support: +343/-58 (net +285). The small production growth owns ignored blocking-ancestor protection and recoverable same-head preparation; no new production helper module or configuration surface.

## Evidence

- Before repair, four descendant collision cases failed: ignored regular files and dangling links, each before a new transition and during journal recovery. The baseline native transition deleted synthetic ignored data. The direct-prepare regression also failed because it reset the temp branch to main.
- Final focused native wrapper selection: **104 passed**, four files; 159 unrelated cases intentionally unselected. Coverage includes literal wildcard/newline/Unicode filenames, bounded multi-batch queries, ignored descendants and blocking ancestors, dangling links, missing ignored paths, `.local` namespace refusal, dirty/unmerged state, query failure and child joins, detached/attached reviewed heads, interrupted preparation and cold fetches, exact-head drift, and unchanged shared-checkout contents.
- Changed-scope checks passed: test-root typecheck, script lint, changed-test lint, formatting, and selected repository guards. Shell syntax and `git diff --check` passed. An incomplete local dependency installation was repaired with a frozen task-local install; no source workaround or weakened assertion was used. Nearby test lint cleanup is included.
- Fresh pre-commit independent Codex review passed at the standard P0 priority with no accepted/actionable findings.
- Dependency contracts checked directly in installed Git 2.55.0 and macOS `xargs` documentation, with actual Git subprocesses in disposable repositories.

### Synthetic guard benchmark

Exactly 2,601 changed paths; two guard validations per sample, with setup outside the measured interval and Git Trace2 counting subprocesses:

| Guard | Ignored-file queries | Total Git starts | Wall-time samples (seconds) |
| --- | ---: | ---: | --- |
| Historical per-path guard | 5,202 | 5,204 | 651.3414, 212.8911, 110.5652 |
| Existing `check-ignore` batch, which misses ignored descendants | 2 | 6 | 0.1116, 0.1035, 0.1049 |
| Repaired bounded literal batches, including blocking ancestors | 6 | 8 | 0.2153, 0.2267, 0.3590 |

The repaired native collision check refused before journaling, retained source HEAD, and preserved the ignored contents. These are guard-only synthetic measurements on a variable-load macOS host, **not attribution of the original preparation's aggregate wall time**. The supplied then-main commit already contains batching; this investigation does not establish which wrapper bytes ran during the original incident. No active PR132180 worktree/artifact or dirty canonical checkout was modified.

The descendant regression was verified in the raw-parent patch for batching commit 7e4eeb90d7c89303b1811c267443a4762ca17a35 (parent 7f9a46ea820550717b0436e57397b6e550de829c).

### Commands

```bash
node scripts/run-vitest.mjs test/scripts/pr-worktree-containment.test.ts test/scripts/pr-main-refresh.test.ts test/scripts/pr-operation-lock.test.ts test/scripts/pr-prepare-gates.test.ts -t 'scripts/pr worktree containment|prepares directly|same-head preparation|recovers preparation|finishes an older|completes supervised prepare|keeps nested preparation|rejects changed exact PR identity|rejects failed .* reads|joins Git read producers|preserves native entry phase|prepare review readiness|recovers cold|requires fresh main.*auth.*existing=true'
```

```bash
node scripts/check-changed.mjs -- scripts/pr-lib/worktree.sh scripts/pr-lib/prepare-core.sh test/scripts/pr-main-refresh.test-support.ts test/scripts/pr-main-refresh.test.ts test/scripts/pr-operation-lock.test.ts test/scripts/pr-worktree-containment.test.ts
```

```bash
bash -n scripts/pr-lib/worktree.sh scripts/pr-lib/prepare-core.sh
```

```bash
git diff --check
```

Proof scope: native wrappers and real Git in synthetic local repositories, not product runtime/channel changes. Browser, full product suite, and real PR132180 preparation were deliberately not run. Exact-head hosted CI and native landing evidence will be checked before merge.
