### PR TITLE
fix(test): prevent concurrent macOS fixtures from starving child cleanup

### DIFF
--- a/test/helpers/fixture-lifetime.ts
+++ b/test/helpers/fixture-lifetime.ts
@@ -1,4 +1,5 @@
-import { cleanupTempDirs, makeTempDir } from "./temp-dir.js";
+import fs from "node:fs";
+import { makeTempDir } from "./temp-dir.js";
 
 function hasUnjoinedWork(value: unknown): boolean {
   if (!value || typeof value !== "object") {
@@ -56,7 +57,23 @@ export function createFixtureLifetime() {
         `Fixture cleanup unverified; retained ${ownedRoots.join(", ")}`,
       );
     }
-    cleanupTempDirs(roots);
+    // Recursive removal can take seconds on Darwin. Keep sibling command deadlines,
+    // output drainage, and reaping live while releasing these already-joined inputs.
+    const removals = await Promise.allSettled(
+      [...roots].map(async (root) => {
+        await fs.promises.rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+        roots.delete(root);
+      }),
+    );
+    const errors = removals.flatMap((result) =>
+      result.status === "rejected" ? [result.reason] : [],
+    );
+    if (errors.length === 1) {
+      throw errors[0];
+    }
+    if (errors.length > 1) {
+      throw new AggregateError(errors, "Test temporary directory cleanup failed");
+    }
   }
 
   return {

--- a/test/helpers/mac-native.ts
+++ b/test/helpers/mac-native.ts
@@ -1,6 +1,7 @@
-import { spawnSync } from "node:child_process";
-import { mkdirSync, readFileSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { runMacFixtureTool } from "../scripts/mac-native-fixtures.test-support.js";
+import type { MacScriptFixture } from "../scripts/mac-script-fixture.test-support.js";
 
 // SDK mach-o/{loader,fat}.h layouts; classification uses the host's real tools.
 export function machoFixture(bits = 64, little = true, fat = false, fileType = 2): Buffer {
@@ -35,75 +36,83 @@ export function machoFixture(bits = 64, little = true, fat = false, fileType = 2
   return result;
 }
 
-function runNativeFixtureTool(command: string, args: string[], input?: string) {
-  const result = spawnSync(command, args, { encoding: "utf8", input });
-  if (result.status !== 0) {
-    throw new Error(`Could not create native fixture with ${command}: ${result.stderr}`);
-  }
-}
-
-function writeNativeObject(filename: string, arch: string) {
-  runNativeFixtureTool(
+async function writeNativeObject(filename: string, arch: string, mac: MacScriptFixture) {
+  const source = `${filename}.c`;
+  await writeFile(source, "int native_fixture(void) { return 0; }\n");
+  await runMacFixtureTool(
     "/usr/bin/xcrun",
-    ["clang", "-arch", arch, "-x", "c", "-c", "-", "-o", filename],
-    "int native_fixture(void) { return 0; }\n",
+    ["clang", "-arch", arch, "-x", "c", "-c", source, "-o", filename],
+    path.dirname(filename),
+    mac,
   );
 }
 
-export function nativeObjectFixture(root: string, format: "thin" | "fat32" | "fat64"): Buffer {
-  mkdirSync(root);
-  const inputs = (format === "thin" ? ["arm64"] : ["arm64", "x86_64"]).map((arch) => {
+export async function nativeObjectFixture(
+  root: string,
+  format: "thin" | "fat32" | "fat64",
+  mac: MacScriptFixture,
+): Promise<Buffer> {
+  await mkdir(root);
+  const inputs = [];
+  for (const arch of format === "thin" ? ["arm64"] : ["arm64", "x86_64"]) {
     const filename = path.join(root, `${arch}.o`);
-    writeNativeObject(filename, arch);
-    return filename;
-  });
+    await writeNativeObject(filename, arch, mac);
+    inputs.push(filename);
+  }
   if (format === "thin") {
-    return readFileSync(path.join(root, "arm64.o"));
+    return readFile(path.join(root, "arm64.o"));
   }
   const filename = path.join(root, "object");
-  runNativeFixtureTool("/usr/bin/lipo", [
-    "-create",
-    ...(format === "fat64" ? ["-fat64"] : []),
-    ...inputs,
-    "-output",
-    filename,
-  ]);
-  return readFileSync(filename);
+  await runMacFixtureTool(
+    "/usr/bin/lipo",
+    ["-create", ...(format === "fat64" ? ["-fat64"] : []), ...inputs, "-output", filename],
+    root,
+    mac,
+  );
+  return readFile(filename);
 }
 
-export function writeFat64Fixture(filename: string): Buffer {
-  runNativeFixtureTool("/usr/bin/lipo", [
-    "-create",
-    "-fat64",
-    "/usr/bin/true",
-    "-output",
-    filename,
-  ]);
-  return readFileSync(filename);
+export async function writeFat64Fixture(filename: string, mac: MacScriptFixture): Promise<Buffer> {
+  await runMacFixtureTool(
+    "/usr/bin/lipo",
+    ["-create", "-fat64", "/usr/bin/true", "-output", filename],
+    path.dirname(filename),
+    mac,
+  );
+  return readFile(filename);
 }
 
-export function universalArchiveFixture(root: string, fat64: boolean, mixed: boolean): Buffer {
-  mkdirSync(root);
+export async function universalArchiveFixture(
+  root: string,
+  fat64: boolean,
+  mixed: boolean,
+  mac: MacScriptFixture,
+): Promise<Buffer> {
+  await mkdir(root);
   const inputs: string[] = [];
   for (const arch of ["arm64", "x86_64"]) {
     const object = path.join(root, `${arch}.o`);
     if (mixed && arch === "x86_64") {
-      runNativeFixtureTool("/usr/bin/lipo", ["-thin", arch, "/usr/bin/true", "-output", object]);
+      await runMacFixtureTool(
+        "/usr/bin/lipo",
+        ["-thin", arch, "/usr/bin/true", "-output", object],
+        root,
+        mac,
+      );
       inputs.push(object);
       continue;
     }
-    writeNativeObject(object, arch);
+    await writeNativeObject(object, arch, mac);
     const archive = path.join(root, `${arch}.a`);
-    runNativeFixtureTool("/usr/bin/ar", ["rcs", archive, object]);
+    await runMacFixtureTool("/usr/bin/ar", ["rcs", archive, object], root, mac);
     inputs.push(archive);
   }
   const filename = path.join(root, "universal");
-  runNativeFixtureTool("/usr/bin/lipo", [
-    "-create",
-    ...(fat64 ? ["-fat64"] : []),
-    ...inputs,
-    "-output",
-    filename,
-  ]);
-  return readFileSync(filename);
+  await runMacFixtureTool(
+    "/usr/bin/lipo",
+    ["-create", ...(fat64 ? ["-fat64"] : []), ...inputs, "-output", filename],
+    root,
+    mac,
+  );
+  return readFile(filename);
 }

--- a/test/helpers/mac-signing.ts
+++ b/test/helpers/mac-signing.ts
@@ -1,4 +1,5 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { chmod, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { MacScriptFixture } from "../scripts/mac-script-fixture.test-support.js";
 import { machoFixture } from "./mac-native.js";
@@ -12,9 +13,9 @@ for arg in "$@"; do
 done
 `;
 
-export function installFakeCodesign(binDir: string) {
+export async function installFakeCodesign(binDir: string) {
   const fakeCodesign = path.join(binDir, "codesign");
-  writeFileSync(
+  await writeFile(
     fakeCodesign,
     `#!/usr/bin/env bash
 set -euo pipefail
@@ -57,12 +58,12 @@ else
 fi
 `,
   );
-  chmodSync(fakeCodesign, 0o755);
+  await chmod(fakeCodesign, 0o755);
 }
 
-export function installTransientFakeCodesign(binDir: string) {
+export async function installTransientFakeCodesign(binDir: string) {
   const fakeCodesign = path.join(binDir, "codesign");
-  writeFileSync(
+  await writeFile(
     fakeCodesign,
     `#!/usr/bin/env bash
 set -euo pipefail
@@ -91,12 +92,12 @@ if [ "$count" -le "$CODESIGN_TRANSIENT_FAILURES" ]; then
 fi
 `,
   );
-  chmodSync(fakeCodesign, 0o755);
+  await chmod(fakeCodesign, 0o755);
 }
 
-export function installElevationFakeCodesign(binDir: string) {
+export async function installElevationFakeCodesign(binDir: string) {
   const fakeCodesign = path.join(binDir, "codesign");
-  writeFileSync(
+  await writeFile(
     fakeCodesign,
     `#!/usr/bin/env bash
 set -euo pipefail
@@ -124,7 +125,7 @@ done
 exit 0
 `,
   );
-  chmodSync(fakeCodesign, 0o755);
+  await chmod(fakeCodesign, 0o755);
 }
 
 type SigningEvent = {
@@ -135,7 +136,11 @@ type SigningEvent = {
 };
 type FileEvent = { args: string[]; magics: string[] };
 
-export function makeSigningFixture(mac: MacScriptFixture, root: string, appName = "Odd ' app.app") {
+export async function makeSigningFixture(
+  mac: MacScriptFixture,
+  root: string,
+  appName = "Odd ' app.app",
+) {
   const app = path.join(root, appName);
   const worker = path.join(app, "Contents/Resources/node-worker/arm64");
   const bin = path.join(root, "bin");
@@ -147,11 +152,11 @@ export function makeSigningFixture(mac: MacScriptFixture, root: string, appName 
   const sealed = path.join(capture, "sealed");
   const swaps = path.join(capture, "swaps.jsonl");
   for (const dir of [worker, bin, capture]) {
-    mkdirSync(dir, { recursive: true });
+    await mkdir(dir, { recursive: true });
   }
-  writeFileSync(options, "{}");
+  await writeFile(options, "{}");
   const fake = path.join(bin, "codesign");
-  writeFileSync(
+  await writeFile(
     fake,
     `#!${process.execPath}
 const fs = require('node:fs');
@@ -196,9 +201,9 @@ if (args.includes('--sign') && target === ${JSON.stringify(app)}) {
 })().catch(error => { console.error(error); process.exit(74); });
 `,
   );
-  chmodSync(fake, 0o755);
+  await chmod(fake, 0o755);
   const boundary = path.join(root, "boundary.py");
-  writeFileSync(
+  await writeFile(
     boundary,
     `import json, os, runpy, subprocess, sys
 config = json.load(open(${JSON.stringify(options)}))
@@ -282,7 +287,7 @@ runpy.run_path(sys.argv[0], run_name='__main__')
   );
   const bashEnv = path.join(root, "bash-env");
   const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
-  writeFileSync(
+  await writeFile(
     bashEnv,
     `function /usr/bin/file() { command /usr/bin/python3 ${quote(boundary)} file "$@"; }
 function /usr/bin/python3() {
@@ -294,7 +299,7 @@ function /usr/bin/python3() {
 `,
   );
   const driver = path.join(root, "swap-driver.py");
-  writeFileSync(
+  await writeFile(
     driver,
     `import json, os, select, socket, subprocess, sys, tempfile
 config = json.load(open(${JSON.stringify(options)}))
@@ -332,14 +337,14 @@ with tempfile.TemporaryDirectory(prefix='oc-sign-swap-', dir='/tmp') as control:
   return {
     app,
     worker,
-    put(relative: string, data: Buffer | string = machoFixture()) {
+    async put(relative: string, data: Buffer | string = machoFixture()) {
       const filename = path.join(app, relative);
-      mkdirSync(path.dirname(filename), { recursive: true });
-      writeFileSync(filename, data);
+      await mkdir(path.dirname(filename), { recursive: true });
+      await writeFile(filename, data);
       return filename;
     },
-    run(config: Record<string, unknown> = {}, elevation = false, target = app) {
-      writeFileSync(options, JSON.stringify(config));
+    async run(config: Record<string, unknown> = {}, elevation = false, target = app) {
+      await writeFile(options, JSON.stringify(config));
       const command = config.swapStage === "before-sign" ? "/usr/bin/python3" : "/bin/bash";
       const args = ["scripts/codesign-mac-app.sh", target];
       return mac.run(command, config.swapStage === "before-sign" ? [driver, ...args] : args, {
@@ -355,8 +360,8 @@ with tempfile.TemporaryDirectory(prefix='oc-sign-swap-', dir='/tmp') as control:
         },
       });
     },
-    scan(config: Record<string, unknown> = {}) {
-      writeFileSync(options, JSON.stringify(config));
+    async scan(config: Record<string, unknown> = {}) {
+      await writeFile(options, JSON.stringify(config));
       return mac.run(
         "/usr/bin/python3",
         [boundary, "scan", "scripts/lib/mac-native-inventory.py", app],

--- a/test/scripts/codesign-mac-app.test.ts
+++ b/test/scripts/codesign-mac-app.test.ts
@@ -1,13 +1,6 @@
 // Codesign Mac App tests cover codesign mac app script behavior.
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
-import { link } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
+import { chmod, link, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, type TestContext } from "vitest";
@@ -23,7 +16,6 @@ import {
   installElevationFakeCodesign,
   makeSigningFixture,
 } from "../helpers/mac-signing.js";
-import { cleanupTempDirs } from "../helpers/temp-dir.js";
 import { createMacScriptTest, type MacScriptFixture } from "./mac-script-fixture.test-support.js";
 
 const it = createMacScriptTest();
@@ -41,12 +33,12 @@ async function runCodesignWithoutAllocation(
   const binDir = path.join(tempRoot, "bin");
   const allocation = path.join(tempRoot, "allocation-attempted");
   const allocator = path.join(binDir, "mktemp");
-  mkdirSync(binDir);
-  writeFileSync(
+  await mkdir(binDir);
+  await writeFile(
     allocator,
     `#!${process.execPath}\nrequire('node:fs').writeFileSync(${JSON.stringify(allocation)}, 'called');\nprocess.exit(91);\n`,
   );
-  chmodSync(allocator, 0o755);
+  await chmod(allocator, 0o755);
   const result = await mac.run("bash", [scriptPath, ...args], {
     cwd: process.cwd(),
     encoding: "utf8",
@@ -108,7 +100,7 @@ describe("codesign-mac-app temp file hygiene", () => {
     mac.lifetime.run(async () => {
       const tempRoot = mac.createTempDir("openclaw-codesign-extra-");
       const app = path.join(tempRoot, "Fake.app");
-      mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
+      await mkdir(path.join(app, "Contents", "MacOS"), { recursive: true });
       const result = await runCodesignWithoutAllocation(mac, expect, [app, "extra"], tempRoot);
 
       expect(result.status).toBe(1);
@@ -122,12 +114,12 @@ describe("codesign-mac-app temp file hygiene", () => {
       const binDir = path.join(tempRoot, "bin");
       const captureDir = path.join(app, "Contents", "test-capture");
       const logPath = path.join(captureDir, "codesign.log");
-      mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
-      mkdirSync(binDir);
-      mkdirSync(captureDir);
-      writeFileSync(path.join(app, "Contents", "MacOS", "openclaw-mlx-tts"), "#!/bin/sh\n");
-      writeFileSync(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
-      installFakeCodesign(binDir);
+      await mkdir(path.join(app, "Contents", "MacOS"), { recursive: true });
+      await mkdir(binDir);
+      await mkdir(captureDir);
+      await writeFile(path.join(app, "Contents", "MacOS", "openclaw-mlx-tts"), "#!/bin/sh\n");
+      await writeFile(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
+      await installFakeCodesign(binDir);
 
       const result = await mac.run("bash", [scriptPath, app], {
         cwd: process.cwd(),
@@ -224,17 +216,17 @@ describe("codesign-mac-app temp file hygiene", () => {
         const app = path.join(tempRoot, "Fake.app");
         const binDir = path.join(tempRoot, "bin");
         const resources = path.join(app, "Contents", "Resources");
-        mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
-        mkdirSync(resources, { recursive: true });
-        mkdirSync(binDir);
-        writeFileSync(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
+        await mkdir(path.join(app, "Contents", "MacOS"), { recursive: true });
+        await mkdir(resources, { recursive: true });
+        await mkdir(binDir);
+        await writeFile(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
         const cuaDriver = path.join(resources, "cua-driver");
         if (kind === "file") {
-          writeFileSync(cuaDriver, "driver\n");
+          await writeFile(cuaDriver, "driver\n");
         } else {
-          symlinkSync("/missing/cua-driver", cuaDriver);
+          await symlink("/missing/cua-driver", cuaDriver);
         }
-        installElevationFakeCodesign(binDir);
+        await installElevationFakeCodesign(binDir);
 
         const result = await mac.run("bash", [scriptPath, app], {
           cwd: process.cwd(),
@@ -260,10 +252,10 @@ describe("codesign-mac-app temp file hygiene", () => {
         const tempRoot = mac.createTempDir("openclaw-codesign-elevation-metadata-");
         const app = path.join(tempRoot, "Fake.app");
         const binDir = path.join(tempRoot, "bin");
-        mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
-        mkdirSync(binDir);
-        writeFileSync(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
-        installElevationFakeCodesign(binDir);
+        await mkdir(path.join(app, "Contents", "MacOS"), { recursive: true });
+        await mkdir(binDir);
+        await writeFile(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
+        await installElevationFakeCodesign(binDir);
 
         const result = await mac.run("bash", [scriptPath, app], {
           cwd: process.cwd(),
@@ -292,10 +284,10 @@ describe("codesign-mac-app temp file hygiene", () => {
         const tempRoot = mac.createTempDir("openclaw-codesign-elevation-no-authority-");
         const app = path.join(tempRoot, "Fake.app");
         const binDir = path.join(tempRoot, "bin");
-        mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
-        mkdirSync(binDir);
-        writeFileSync(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
-        installElevationFakeCodesign(binDir);
+        await mkdir(path.join(app, "Contents", "MacOS"), { recursive: true });
+        await mkdir(binDir);
+        await writeFile(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
+        await installElevationFakeCodesign(binDir);
 
         const result = await mac.run("bash", [scriptPath, app], {
           cwd: process.cwd(),
@@ -320,10 +312,10 @@ describe("codesign-mac-app temp file hygiene", () => {
       const tempRoot = mac.createTempDir("openclaw-codesign-elevation-failed-metadata-");
       const app = path.join(tempRoot, "Fake.app");
       const binDir = path.join(tempRoot, "bin");
-      mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
-      mkdirSync(binDir);
-      writeFileSync(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
-      installElevationFakeCodesign(binDir);
+      await mkdir(path.join(app, "Contents", "MacOS"), { recursive: true });
+      await mkdir(binDir);
+      await writeFile(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
+      await installElevationFakeCodesign(binDir);
 
       const result = await mac.run("bash", [scriptPath, app], {
         cwd: process.cwd(),
@@ -351,11 +343,11 @@ describe("codesign-mac-app temp file hygiene", () => {
       const app = path.join(tempRoot, "Fake.app");
       const binDir = path.join(tempRoot, "bin");
       const countFile = path.join(app, "Contents", "codesign-count");
-      mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
-      mkdirSync(binDir);
-      writeFileSync(path.join(app, "Contents", "MacOS", "openclaw-mlx-tts"), "#!/bin/sh\n");
-      writeFileSync(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
-      installTransientFakeCodesign(binDir);
+      await mkdir(path.join(app, "Contents", "MacOS"), { recursive: true });
+      await mkdir(binDir);
+      await writeFile(path.join(app, "Contents", "MacOS", "openclaw-mlx-tts"), "#!/bin/sh\n");
+      await writeFile(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
+      await installTransientFakeCodesign(binDir);
 
       const result = await mac.run("bash", [scriptPath, app], {
         cwd: process.cwd(),
@@ -387,15 +379,15 @@ describe("codesign-mac-app temp file hygiene", () => {
         const app = path.join(tempRoot, "Fake.app");
         const binDir = path.join(tempRoot, "bin");
         const countFile = path.join(app, "Contents", "codesign-count");
-        mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
-        mkdirSync(binDir);
+        await mkdir(path.join(app, "Contents", "MacOS"), { recursive: true });
+        await mkdir(binDir);
         if (target === "helper") {
-          writeFileSync(path.join(app, "Contents", "MacOS", "openclaw-mlx-tts"), "#!/bin/sh\n");
+          await writeFile(path.join(app, "Contents", "MacOS", "openclaw-mlx-tts"), "#!/bin/sh\n");
         }
-        installTransientFakeCodesign(binDir);
+        await installTransientFakeCodesign(binDir);
         // Keep identity lookup and attribute cleanup inert even if signing setup changes.
         for (const command of ["security", "xattr"]) {
-          writeFileSync(path.join(binDir, command), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+          await writeFile(path.join(binDir, command), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
         }
 
         const result = await mac.run("bash", [scriptPath, app], {
@@ -432,7 +424,7 @@ describe("codesign-mac-app temp file hygiene", () => {
         } finally {
           // Clean a regression's task-created leak, never an unexpected system path.
           if (path.basename(directory).startsWith("openclaw-entitlements.")) {
-            cleanupTempDirs([directory]);
+            await rm(directory, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
           }
         }
       }),
@@ -480,13 +472,13 @@ describe("codesign-mac-app temp file hygiene", () => {
         const binDir = path.join(tempRoot, "bin");
         const captureDir = path.join(app, "Contents", "test-capture");
         const argsLog = path.join(captureDir, "codesign-args.log");
-        mkdirSync(path.join(app, "Contents", "MacOS"), { recursive: true });
-        mkdirSync(binDir);
-        mkdirSync(captureDir);
-        writeFileSync(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
-        installFakeCodesign(binDir);
+        await mkdir(path.join(app, "Contents", "MacOS"), { recursive: true });
+        await mkdir(binDir);
+        await mkdir(captureDir);
+        await writeFile(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
+        await installFakeCodesign(binDir);
         const fakeSecurity = path.join(binDir, "security");
-        writeFileSync(
+        await writeFile(
           fakeSecurity,
           `#!/usr/bin/env bash
 printf '%s\\n' \\
@@ -494,7 +486,7 @@ printf '%s\\n' \\
   '  2) 11AA22BB33CC44DD55EE66FF77008899AABBCCDD "Apple Development: Example Developer (ABCDE12345)"'
 `,
         );
-        chmodSync(fakeSecurity, 0o755);
+        await chmod(fakeSecurity, 0o755);
 
         const result = await mac.run("bash", [scriptPath, app], {
           cwd: process.cwd(),
@@ -531,7 +523,7 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
     "limits worker JIT entitlements to known JS runtime executables on $arch",
     ({ arch, sdkArch, cpuType }, { mac, expect }) =>
       mac.lifetime.run(async () => {
-        const fixture = makeSigningFixture(mac, mac.createTempDir("openclaw-inventory-jit-"));
+        const fixture = await makeSigningFixture(mac, mac.createTempDir("openclaw-inventory-jit-"));
         const modules = "lib/node_modules/openclaw/node_modules";
         const sdkRuntime = `node_modules/@anthropic-ai/claude-agent-sdk-darwin-${sdkArch}/claude`;
         const expected = new Map<string, boolean>();
@@ -551,7 +543,10 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
         ] as const) {
           const bytes = machoFixture(64, true, false, fileType);
           bytes.writeUInt32LE(cpuType, 4);
-          const filename = fixture.put(`Contents/Resources/node-worker/${arch}/${relative}`, bytes);
+          const filename = await fixture.put(
+            `Contents/Resources/node-worker/${arch}/${relative}`,
+            bytes,
+          );
           expected.set(filename, jit);
         }
         const result = await fixture.run();
@@ -595,7 +590,10 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
     "selects every canonical native format with header-appropriate entitlements (elevation: %s)",
     (elevation, { mac, expect }) =>
       mac.lifetime.run(async () => {
-        const fixture = makeSigningFixture(mac, mac.createTempDir("openclaw-inventory-formats-"));
+        const fixture = await makeSigningFixture(
+          mac,
+          mac.createTempDir("openclaw-inventory-formats-"),
+        );
         const expected = new Map<string, boolean>();
         const candidates: string[] = [];
         for (const bits of [32, 64]) {
@@ -606,7 +604,7 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
                 continue;
               }
               for (const type of [2, 6]) {
-                const filename = fixture.put(
+                const filename = await fixture.put(
                   `${workerPath}formats/${bits}-${little}-${fat}-${type} executable\n\t'\\/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude`,
                   machoFixture(bits, little, fat, type),
                 );
@@ -622,13 +620,13 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
           ["truncated", Buffer.from("cffa", "hex")],
           ["fat-false-positive", Buffer.from("cafebabe", "hex")],
         ] as const) {
-          fixture.put(workerPath + name, bytes);
+          await fixture.put(workerPath + name, bytes);
         }
-        symlinkSync(
+        await symlink(
           expectDefined(candidates[0], "native fixture"),
           path.join(fixture.worker, "native-link"),
         );
-        symlinkSync("missing", path.join(fixture.worker, "dangling"));
+        await symlink("missing", path.join(fixture.worker, "dangling"));
         const result = await fixture.run({}, elevation);
         expect(result.status, result.stderr).toBe(0);
         const events = fixture.events();
@@ -667,12 +665,12 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
     "examines but rejects byte-swapped fat%d containers",
     (bits, { mac, expect }) =>
       mac.lifetime.run(async () => {
-        const fixture = makeSigningFixture(
+        const fixture = await makeSigningFixture(
           mac,
           mac.createTempDir("openclaw-inventory-swapped-fat-"),
         );
         const bytes = machoFixture(bits, true, true);
-        fixture.put(workerPath + "invalid-fat.node", bytes);
+        await fixture.put(workerPath + "invalid-fat.node", bytes);
         const result = await fixture.run();
         expect(result.status, result.stdout).not.toBe(0);
         expect(result.stderr).toMatch(/native header/i);
@@ -687,19 +685,19 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
     "classifies real fat64 code and rejects mixed slice types (mixed: %s)",
     (mixed, { mac, expect }) =>
       mac.lifetime.run(async () => {
-        const fixture = makeSigningFixture(
+        const fixture = await makeSigningFixture(
           mac,
           mac.createTempDir("openclaw-inventory-real-fat64-"),
         );
-        const native = fixture.put(workerPath + "bin/node");
-        const bytes = writeFat64Fixture(native);
+        const native = await fixture.put(workerPath + "bin/node");
+        const bytes = await writeFat64Fixture(native, mac);
         expect(bytes.readUInt32BE(0)).toBe(0xcafebabf);
         expect(bytes.readUInt32BE(4)).toBeGreaterThanOrEqual(2);
         if (mixed) {
           const offset = Number(bytes.readBigUInt64BE(48));
           expect(bytes.readUInt32LE(offset)).toBe(0xfeedfacf);
           bytes.writeUInt32LE(6, offset + 12); // One MH_DYLIB slice must not inherit MH_EXECUTE JIT rights.
-          writeFileSync(native, bytes);
+          await writeFile(native, bytes);
         }
         expect((await mac.run("/usr/bin/lipo", ["-archs", native])).status).toBe(0);
         const result = await fixture.run();
@@ -723,12 +721,12 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
     expect,
   }) =>
     mac.lifetime.run(async () => {
-      const fixture = makeSigningFixture(mac, mac.createTempDir("openclaw-macho-filetypes-"));
+      const fixture = await makeSigningFixture(mac, mac.createTempDir("openclaw-macho-filetypes-"));
       const resources = new Map<string, Buffer>();
       const candidates: string[] = [];
       for (const fileType of [1, 2, 4, 5, 6, 7, 8, 9, 10, 11]) {
         const bytes = machoFixture(64, true, false, fileType);
-        const filename = fixture.put(
+        const filename = await fixture.put(
           `${workerPath}type-${fileType}/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude`,
           bytes,
         );
@@ -757,10 +755,10 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
     (format, { mac, expect }) =>
       mac.lifetime.run(async () => {
         const root = mac.createTempDir("openclaw-real-object-");
-        const fixture = makeSigningFixture(mac, root);
-        const node = fixture.put(workerPath + "bin/node");
-        const bytes = nativeObjectFixture(path.join(root, "object-inputs"), format);
-        const object = fixture.put(workerPath + "opaque-object", bytes);
+        const fixture = await makeSigningFixture(mac, root);
+        const node = await fixture.put(workerPath + "bin/node");
+        const bytes = await nativeObjectFixture(path.join(root, "object-inputs"), format, mac);
+        const object = await fixture.put(workerPath + "opaque-object", bytes);
         const result = await fixture.run();
         expect(result.status, result.stderr).toBe(0);
         expect(readFileSync(object)).toEqual(bytes);
@@ -779,10 +777,11 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
     ({ fat64, imageSlice }, { mac, expect }) =>
       mac.lifetime.run(async () => {
         const root = mac.createTempDir("openclaw-mixed-object-");
-        const fixture = makeSigningFixture(mac, root);
-        const bytes = nativeObjectFixture(
+        const fixture = await makeSigningFixture(mac, root);
+        const bytes = await nativeObjectFixture(
           path.join(root, "object-inputs"),
           fat64 ? "fat64" : "fat32",
+          mac,
         );
         const record = 8 + imageSlice * (fat64 ? 32 : 20);
         const offset = fat64
@@ -790,7 +789,7 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
           : bytes.readUInt32BE(record + 8);
         expect(bytes.readUInt32LE(offset)).toBe(0xfeedfacf);
         bytes.writeUInt32LE(6, offset + 12);
-        fixture.put(workerPath + "mixed", bytes);
+        await fixture.put(workerPath + "mixed", bytes);
         const result = await fixture.run();
         expect(result.status, result.stdout).not.toBe(0);
         expect(result.stderr).toMatch(/Mixed.*resource/);
@@ -807,12 +806,13 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
     ({ fat64, content }, { mac, expect }) =>
       mac.lifetime.run(async () => {
         const root = mac.createTempDir("openclaw-inventory-archive-");
-        const fixture = makeSigningFixture(mac, root);
-        const node = fixture.put(workerPath + "node");
-        const bytes = universalArchiveFixture(
+        const fixture = await makeSigningFixture(mac, root);
+        const node = await fixture.put(workerPath + "node");
+        const bytes = await universalArchiveFixture(
           path.join(root, "archive-inputs"),
           fat64,
           content !== "archive",
+          mac,
         );
         if (content === "invalid") {
           for (let index = 0; index < bytes.readUInt32BE(4); index++) {
@@ -825,7 +825,7 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
             }
           }
         }
-        const archive = fixture.put(workerPath + "opaque-resource", bytes);
+        const archive = await fixture.put(workerPath + "opaque-resource", bytes);
         const result = await fixture.run();
         expect(readFileSync(archive)).toEqual(bytes);
         if (content !== "archive") {
@@ -851,15 +851,15 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
     expect,
   }) =>
     mac.lifetime.run(async () => {
-      const fixture = makeSigningFixture(mac, mac.createTempDir("openclaw-inventory-scale-"));
+      const fixture = await makeSigningFixture(mac, mac.createTempDir("openclaw-inventory-scale-"));
       for (let i = 0; i < 24; i++) {
-        fixture.put(`${workerPath}native-${i}`, machoFixture(64, true, false, i % 2 ? 6 : 2));
+        await fixture.put(`${workerPath}native-${i}`, machoFixture(64, true, false, i % 2 ? 6 : 2));
       }
       const dataSource = path.join(path.dirname(fixture.app), "non-code-payload");
-      writeFileSync(dataSource, "export {};\n");
+      await writeFile(dataSource, "export {};\n");
       for (let start = 24; start < 1_024; start += 256) {
         const directory = path.join(fixture.worker, "data", String(start));
-        mkdirSync(directory, { recursive: true });
+        await mkdir(directory, { recursive: true });
         await Promise.all(
           Array.from({ length: Math.min(256, 1_024 - start) }, (_, index) =>
             link(dataSource, path.join(directory, `${start + index}.js`)),
@@ -867,11 +867,11 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
         );
       }
       const outside = path.join(path.dirname(fixture.app), "external");
-      mkdirSync(outside);
-      writeFileSync(path.join(outside, "native"), machoFixture());
-      symlinkSync(outside, path.join(fixture.worker, "directory-link"));
-      symlinkSync(path.join(outside, "native"), path.join(fixture.worker, "file-link"));
-      symlinkSync("missing", path.join(fixture.worker, "dangling"));
+      await mkdir(outside);
+      await writeFile(path.join(outside, "native"), machoFixture());
+      await symlink(outside, path.join(fixture.worker, "directory-link"));
+      await symlink(path.join(outside, "native"), path.join(fixture.worker, "file-link"));
+      await symlink("missing", path.join(fixture.worker, "dangling"));
       const result = await fixture.scan({ maxFileCalls: 8 });
       expect(result.status, result.stderr).toBe(0);
       expect(fixture.classifications().length).toBeLessThanOrEqual(2);
@@ -890,10 +890,10 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
     (suffix, { mac, expect }) =>
       mac.lifetime.run(async () => {
         const root = mac.createTempDir("openclaw-inventory-root-link-");
-        const fixture = makeSigningFixture(mac, root);
-        fixture.put(workerPath + "node");
+        const fixture = await makeSigningFixture(mac, root);
+        await fixture.put(workerPath + "node");
         const alias = path.join(root, "Alias.app");
-        symlinkSync(fixture.app, alias);
+        await symlink(fixture.app, alias);
         const result = await fixture.run({}, false, alias + suffix);
         expect(result.status).toBe(1);
         expect(result.stderr).toContain("must not be a symlink");
@@ -910,15 +910,15 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
   ])("rejects directory swaps without mutating external files (%s)", (swapStage, { mac, expect }) =>
     mac.lifetime.run(async () => {
       const root = mac.createTempDir("openclaw-inventory-swap-");
-      const fixture = makeSigningFixture(mac, root);
+      const fixture = await makeSigningFixture(mac, root);
       const swapDirectory = path.join(fixture.worker, "package");
       const externalDirectory = path.join(root, "external");
       const name = "native ' payload\n.node";
       const external = path.join(externalDirectory, name);
-      mkdirSync(swapDirectory);
-      mkdirSync(externalDirectory);
+      await mkdir(swapDirectory);
+      await mkdir(externalDirectory);
       const original = machoFixture();
-      writeFileSync(external, original);
+      await writeFile(external, original);
       const attribute = "org.openclaw.signing-fixture";
       expect(
         (await mac.run("/usr/bin/xattr", ["-w", attribute, "untouched", external])).status,
@@ -926,7 +926,7 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
       // The first schedule discovers a file that never existed in the bundle.
       // Later schedules redirect a previously discovered name at the next boundary.
       if (swapStage !== "before-directory-open") {
-        fixture.put(`${workerPath}package/${name}`);
+        await fixture.put(`${workerPath}package/${name}`);
       }
       const result = await fixture.run({
         swapStage,
@@ -965,16 +965,16 @@ describe.runIf(process.platform === "darwin")("Mac native inventory", () => {
   }) =>
     mac.lifetime.run(async () => {
       const root = mac.createTempDir("openclaw-inventory-descriptors-");
-      const fixture = makeSigningFixture(mac, root);
-      const native = fixture.put(workerPath + "node");
+      const fixture = await makeSigningFixture(mac, root);
+      const native = await fixture.put(workerPath + "node");
       const signed = await fixture.run({ writeTarget: native });
       expect(signed.status, signed.stderr).toBe(0);
       expect(readFileSync(native).subarray(-19).toString()).toBe("\nfixture-signature\n");
 
       const external = path.join(root, "external");
-      writeFileSync(external, "untouched");
+      await writeFile(external, "untouched");
       const scratch = path.join(root, "mutation-tmp");
-      mkdirSync(scratch);
+      await mkdir(scratch);
       const result = await mac.run(
         "/usr/bin/python3",
         [
@@ -1006,9 +1006,9 @@ with open(sys.argv[1], 'ab', buffering=0) as stream:
   }) =>
     mac.lifetime.run(async () => {
       const root = mac.createTempDir("openclaw-inventory-hardlink-");
-      const fixture = makeSigningFixture(mac, root);
+      const fixture = await makeSigningFixture(mac, root);
       const external = path.join(root, "external");
-      writeFileSync(external, machoFixture());
+      await writeFile(external, machoFixture());
       const attribute = "org.openclaw.signing-fixture";
       expect(
         (await mac.run("/usr/bin/xattr", ["-w", attribute, "untouched", external])).status,
@@ -1029,18 +1029,18 @@ with open(sys.argv[1], 'ab', buffering=0) as stream:
   }) =>
     mac.lifetime.run(async () => {
       const root = mac.createTempDir("openclaw-inventory-fifo-");
-      const fixture = makeSigningFixture(mac, root);
+      const fixture = await makeSigningFixture(mac, root);
       expect((await mac.run("/usr/bin/mkfifo", [path.join(fixture.worker, "fifo")])).status).toBe(
         0,
       );
       // Observe the cleanup boundary without letting a regression hang real xattr on the FIFO.
       const invoked = path.join(fixture.app, "xattr-invoked");
       const xattr = path.join(root, "bin", "xattr");
-      writeFileSync(
+      await writeFile(
         xattr,
         `#!${process.execPath}\nrequire('node:fs').writeFileSync(${JSON.stringify(invoked)}, 'called');\n`,
       );
-      chmodSync(xattr, 0o755);
+      await chmod(xattr, 0o755);
       const result = await fixture.run();
       expect(result.status, result.stderr).toBe(1);
       expect(result.stderr).toContain("special files");
@@ -1052,11 +1052,14 @@ with open(sys.argv[1], 'ab', buffering=0) as stream:
     "seals each bundle owner once after nested code with suffix %j",
     (suffix, { mac, expect }) =>
       mac.lifetime.run(async () => {
-        const fixture = makeSigningFixture(mac, mac.createTempDir("openclaw-inventory-order-"));
-        const helper = fixture.put("Contents/MacOS/openclaw-mlx-tts");
-        const cua = fixture.put("Contents/Resources/cua-driver");
-        const worker = fixture.put(workerPath + "node");
-        fixture.put("Contents/MacOS/OpenClaw");
+        const fixture = await makeSigningFixture(
+          mac,
+          mac.createTempDir("openclaw-inventory-order-"),
+        );
+        const helper = await fixture.put("Contents/MacOS/openclaw-mlx-tts");
+        const cua = await fixture.put("Contents/Resources/cua-driver");
+        const worker = await fixture.put(workerPath + "node");
+        await fixture.put("Contents/MacOS/OpenClaw");
         const sparkle = "Contents/Frameworks/Sparkle.framework";
         for (const member of [
           "Sparkle",
@@ -1065,16 +1068,16 @@ with open(sys.argv[1], 'ab', buffering=0) as stream:
           "XPCServices/Downloader.xpc/Contents/MacOS/Downloader",
           "XPCServices/Installer.xpc/Contents/MacOS/Installer",
         ]) {
-          fixture.put(
+          await fixture.put(
             `${sparkle}/Versions/B/${member}`,
             member === "Autoupdate" ? machoFixture(64, false, true) : machoFixture(),
           );
         }
-        const extra = fixture.put(
+        const extra = await fixture.put(
           `${sparkle}/Versions/B/Extras/extra.node`,
           machoFixture(64, true, false, 6),
         );
-        const nested = fixture.put(
+        const nested = await fixture.put(
           "Contents/Frameworks/Outer.framework/Versions/A/Inner.framework/inner.dylib",
           machoFixture(64, true, false, 6),
         );
@@ -1132,8 +1135,8 @@ with open(sys.argv[1], 'ab', buffering=0) as stream:
     "entitlementFailure",
   ])("fails closed on %s at the signing/audit boundary", (failure, { mac, expect }) =>
     mac.lifetime.run(async () => {
-      const fixture = makeSigningFixture(mac, mac.createTempDir("openclaw-inventory-gates-"));
-      const native = fixture.put(workerPath + "node");
+      const fixture = await makeSigningFixture(mac, mac.createTempDir("openclaw-inventory-gates-"));
+      const native = await fixture.put(workerPath + "node");
       const config =
         failure === "formatSkipTeam"
           ? { format: native, skipTeam: true }
@@ -1162,12 +1165,12 @@ with open(sys.argv[1], 'ab', buffering=0) as stream:
     "uses signature metadata rather than filename text (%s)",
     (failure, { mac, expect }) =>
       mac.lifetime.run(async () => {
-        const fixture = makeSigningFixture(
+        const fixture = await makeSigningFixture(
           mac,
           mac.createTempDir("openclaw-metadata-"),
           "Injected\nFormat=Mach-O thin (arm64)\nCodeDirectory v=20400\nTeamIdentifier=FWJYW4S8P8\nAuthority=Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)\n.app",
         );
-        const native = fixture.put(workerPath + "node");
+        const native = await fixture.put(workerPath + "node");
         const configs: Record<string, Record<string, unknown>> = {
           valid: {},
           team: { mismatch: native },
@@ -1205,9 +1208,12 @@ with open(sys.argv[1], 'ab', buffering=0) as stream:
           "unterminated",
           "error-record",
         ]) {
-          const fixture = makeSigningFixture(mac, mac.createTempDir("openclaw-inventory-failure-"));
-          const native = fixture.put(workerPath + "node");
-          fixture.put(workerPath + "addon", machoFixture(64, true, false, 6));
+          const fixture = await makeSigningFixture(
+            mac,
+            mac.createTempDir("openclaw-inventory-failure-"),
+          );
+          const native = await fixture.put(workerPath + "node");
+          await fixture.put(workerPath + "addon", machoFixture(64, true, false, 6));
           const result = await fixture.run({ fault, phase, partialPath: native });
           expect(result.status, `${phase}/${fault}: ${result.stdout}`).not.toBe(0);
           expect(result.stdout).not.toContain("Codesign complete");
@@ -1222,8 +1228,11 @@ with open(sys.argv[1], 'ab', buffering=0) as stream:
     "audits native files created while signing the app (%s)",
     (gate, { mac, expect }) =>
       mac.lifetime.run(async () => {
-        const fixture = makeSigningFixture(mac, mac.createTempDir("openclaw-inventory-fresh-"));
-        fixture.put(workerPath + "node");
+        const fixture = await makeSigningFixture(
+          mac,
+          mac.createTempDir("openclaw-inventory-fresh-"),
+        );
+        await fixture.put(workerPath + "node");
         const generated = path.join(fixture.worker, "generated-after-sign.node");
         const result = await fixture.run(
           {

--- a/test/scripts/fixture-lifetime.test.ts
+++ b/test/scripts/fixture-lifetime.test.ts
@@ -16,7 +16,7 @@ it("cleans independent roots after a removal failure and retries the retained ro
   const second = lifetime.createTempDir("fixture-lifetime-independent-");
   const failure = Object.assign(new Error("fixture directory busy"), { code: "EBUSY" });
   const remove = fs.rmSync;
-  const removal = vi.spyOn(fs, "rmSync").mockImplementation((root, options) => {
+  const removal = vi.spyOn(fs.promises, "rm").mockImplementation(async (root, options) => {
     if (root === first) {
       throw failure;
     }

--- a/test/scripts/mac-elevation-artifact.test-support.ts
+++ b/test/scripts/mac-elevation-artifact.test-support.ts
@@ -1,15 +1,6 @@
-import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { chmod, mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect } from "vitest";
 import {
@@ -39,15 +30,15 @@ function digest(contents: string | Buffer) {
   return createHash("sha256").update(contents).digest("hex");
 }
 
-export function write(file: string, contents: string | Buffer, mode = 0o644) {
-  mkdirSync(path.dirname(file), { recursive: true });
-  writeFileSync(file, contents);
-  chmodSync(file, mode);
+export async function write(file: string, contents: string | Buffer, mode = 0o644) {
+  await mkdir(path.dirname(file), { recursive: true });
+  await writeFile(file, contents);
+  await chmod(file, mode);
 }
 
-export function artifactFixture(mac: MacScriptFixture) {
+export async function artifactFixture(mac: MacScriptFixture) {
   const root = mac.createTempDir("openclaw-elevation-native-");
-  const binaries = compiledMacNativeFixtures(root);
+  const binaries = await compiledMacNativeFixtures(root, mac);
   const home = path.join(root, "home [portable]");
   const payload = path.join(root, "payload [archive]");
   const app = path.join(payload, "OpenClaw.app");
@@ -58,12 +49,12 @@ export function artifactFixture(mac: MacScriptFixture) {
   const calls = path.join(home, "policy-calls");
   const fileCalls = path.join(home, "file-calls");
   const forbidden = path.join(home, "forbidden-calls");
-  mkdirSync(bin, { recursive: true });
-  write(installer, readFileSync("scripts/mac-elevation-host.sh"), 0o555);
-  write(calls, "");
-  write(fileCalls, "");
+  await mkdir(bin, { recursive: true });
+  await write(installer, readFileSync("scripts/mac-elevation-host.sh"), 0o555);
+  await write(calls, "");
+  await write(fileCalls, "");
   const fileCallCount = () => readFileSync(fileCalls, "utf8").split("\n").filter(Boolean).length;
-  write(
+  await write(
     app + "/Contents/Info.plist",
     `<?xml version="1.0"?><plist version="1.0"><dict>
 <key>CFBundleIdentifier</key><string>ai.openclaw.mac</string>
@@ -75,31 +66,39 @@ export function artifactFixture(mac: MacScriptFixture) {
 <key>OpenClawWorkerBuildID</key><string>${buildInfo.buildId}</string>
 </dict></plist>`,
   );
-  write(app + "/Contents/MacOS/OpenClaw", binaries.universal, 0o755);
-  write(app + "/Contents/MacOS/openclaw-mlx-tts", binaries.universal, 0o755);
-  write(app + "/Contents/Frameworks/shared [fixture].dylib", binaries.universalLibrary, 0o755);
+  await write(app + "/Contents/MacOS/OpenClaw", binaries.universal, 0o755);
+  await write(app + "/Contents/MacOS/openclaw-mlx-tts", binaries.universal, 0o755);
+  await write(
+    app + "/Contents/Frameworks/shared [fixture].dylib",
+    binaries.universalLibrary,
+    0o755,
+  );
   for (const arch of ["arm64", "x86_64"] as const) {
     const worker = path.join(app, workerRoot, arch);
-    write(path.join(worker, "bin/node"), binaries[arch], 0o755);
-    write(path.join(worker, workerDist, "entry.js"), "// inert package entry\n");
-    write(path.join(worker, workerDist, "build-info.json"), JSON.stringify(buildInfo));
-    write(path.join(worker, addon), binaries[arch === "arm64" ? "armLibrary" : "intelLibrary"]);
-    write(path.join(worker, library), binaries.universalLibrary);
-    write(
+    await write(path.join(worker, "bin/node"), binaries[arch], 0o755);
+    await write(path.join(worker, workerDist, "entry.js"), "// inert package entry\n");
+    await write(path.join(worker, workerDist, "build-info.json"), JSON.stringify(buildInfo));
+    await write(
+      path.join(worker, addon),
+      binaries[arch === "arm64" ? "armLibrary" : "intelLibrary"],
+    );
+    await write(path.join(worker, library), binaries.universalLibrary);
+    await write(
       path.join(worker, "lib/native.a"),
       binaries[arch === "arm64" ? "armArchive" : "intelArchive"],
     );
-    symlinkSync("../lib/node_modules/openclaw/dist/entry.js", path.join(worker, "bin/openclaw"));
-    symlinkSync("native [fixture]", path.join(worker, "lib/node_modules/native-alias"));
+    await symlink("../lib/node_modules/openclaw/dist/entry.js", path.join(worker, "bin/openclaw"));
+    await symlink("native [fixture]", path.join(worker, "lib/node_modules/native-alias"));
   }
-  const jq = spawnSync("/bin/sh", ["-c", "command -v jq"], {
+  const jq = await mac.run("/bin/sh", ["-c", "command -v jq"], {
     encoding: "utf8",
     env: { PATH: process.env.PATH },
   });
+  expect(jq.error, jq.stderr).toBeUndefined();
   expect(jq.status, jq.stderr).toBe(0);
-  symlinkSync(jq.stdout.trim(), path.join(bin, "jq"));
+  await symlink(jq.stdout.trim(), path.join(bin, "jq"));
   const bashEnv = path.join(home, "intercepts.bash");
-  write(
+  await write(
     bashEnv,
     `
 record() { printf '%s\\n' "$*" >>"$TEST_CALLS"; }
@@ -219,7 +218,7 @@ plutil() {
     "curl",
     "ssh",
   ]) {
-    write(
+    await write(
       path.join(bin, tool),
       '#!/bin/sh\nprintf "%s\\n" "forbidden PATH fallthrough" >>"$TEST_FORBIDDEN"\nexit 97\n',
       0o755,
@@ -269,21 +268,27 @@ plutil() {
     teamIdentifier: "FWJYW4S8P8",
     cdhashes: { arm64: "FIXTUREARM64", x86_64: "FIXTUREX8664" },
     architectures: {
-      main: runMacFixtureTool("/usr/bin/lipo", ["-archs", app + "/Contents/MacOS/OpenClaw"], root),
-      helper: runMacFixtureTool(
+      main: await runMacFixtureTool(
+        "/usr/bin/lipo",
+        ["-archs", app + "/Contents/MacOS/OpenClaw"],
+        root,
+        mac,
+      ),
+      helper: await runMacFixtureTool(
         "/usr/bin/lipo",
         ["-archs", app + "/Contents/MacOS/openclaw-mlx-tts"],
         root,
+        mac,
       ),
     },
     entitlementsSha256: { main: digest(entitlements), helper: digest(entitlements) },
     notarizationId: "12345678-1234-1234-1234-123456789abc",
   };
-  const verify = (fault = "") => {
-    rmSync(archive, { force: true });
-    runMacFixtureTool("/usr/bin/ditto", ["-c", "-k", payload, archive], root);
+  const verify = async (fault = "") => {
+    await rm(archive, { force: true });
+    await runMacFixtureTool("/usr/bin/ditto", ["-c", "-k", payload, archive], root, mac);
     receipt.archiveSha256 = digest(readFileSync(archive));
-    write(receiptPath, JSON.stringify(receipt));
+    await write(receiptPath, JSON.stringify(receipt));
     return run(
       [
         installer,
@@ -298,11 +303,11 @@ plutil() {
       fault,
     );
   };
-  const verifyProgram = (program: string, fault: string) => {
+  const verifyProgram = async (program: string, fault: string) => {
     const script = readFileSync(installer, "utf8");
     // Retain actual owners and cleanup, but exclude every operational entrypoint.
-    chmodSync(installer, 0o755);
-    write(
+    await chmod(installer, 0o755);
+    await write(
       installer,
       `${script.slice(0, script.lastIndexOf("\nrefresh_runtime_paths\n"))}
 prepare_authenticated_artifact_inputs "$ARTIFACT_RECEIPT" "$ARCHIVE" "\${BASH_SOURCE[0]}"
@@ -320,7 +325,7 @@ ${program}`,
     calls,
     fileCallCount,
     at: (relative: string) => path.join(app, relative),
-    verifyCode() {
+    async verifyCode() {
       // Measure discovery independently of ZIP extraction and receipt verification;
       // full portable-artifact cases below still exercise those boundaries.
       const script = readFileSync(installer, "utf8");
@@ -331,7 +336,7 @@ ${program}`,
       const fail = script.slice(script.indexOf("fail() {"), script.indexOf("\nusage() {"));
       const verifier = path.join(home, "verify-code.bash");
       // System Bash reads BASH_ENV for a script file, but not for -c here.
-      write(
+      await write(
         verifier,
         `set -euo pipefail\n${fail}\n${helpers}\nverify_elevation_code "$1"\nprintf 'Elevation code verified\\n'`,
       );
@@ -359,7 +364,7 @@ printf 'Staged copy verified: %s\\n' "$STAGED_INSTALL_APP_PATH"
         fault,
       );
     },
-    recoveryPlan(fault: string) {
+    async recoveryPlan(fault: string) {
       const script = readFileSync(installer, "utf8");
       const functions = (
         [
@@ -372,7 +377,7 @@ printf 'Staged copy verified: %s\\n' "$STAGED_INSTALL_APP_PATH"
       const planner = path.join(home, "recovery-plan.bash");
       // Keep the real recovery conditional, but exit before receipt/transaction work.
       // The existing BASH_ENV still intercepts policy and denies live tools.
-      write(
+      await write(
         planner,
         `set -euo pipefail
 ${functions.join("\n")}

--- a/test/scripts/mac-elevation-artifact.test.ts
+++ b/test/scripts/mac-elevation-artifact.test.ts
@@ -1,13 +1,5 @@
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  renameSync,
-  rmSync,
-  statSync,
-  symlinkSync,
-} from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { mkdir, rename, rm, symlink } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect } from "vitest";
 import {
@@ -83,7 +75,7 @@ describe.skipIf(process.platform !== "darwin")(
       mac,
     }) =>
       mac.lifetime.run(async () => {
-        const harness = artifactFixture(mac);
+        const harness = await artifactFixture(mac);
         const result = await harness.verify();
         expect(result.status, result.stderr).toBe(0);
         expect(result.stdout).toContain(
@@ -113,16 +105,16 @@ describe.skipIf(process.platform !== "darwin")(
       "rejects an archive with an invalid app root (%s) before authenticating a helper",
       async (kind, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
+          const harness = await artifactFixture(mac);
           if (kind === "extra-entry") {
-            write(path.join(path.dirname(harness.app), "unexpected"), "not app content\n");
+            await write(path.join(path.dirname(harness.app), "unexpected"), "not app content\n");
           } else {
             const reference = path.join(harness.home, "reference.app");
-            renameSync(harness.app, reference);
+            await rename(harness.app, reference);
             if (kind === "symlink") {
-              symlinkSync(reference, harness.app);
+              await symlink(reference, harness.app);
             } else {
-              write(harness.app, "not an app directory\n");
+              await write(harness.app, "not an app directory\n");
             }
           }
           const result = await harness.verify();
@@ -139,12 +131,12 @@ describe.skipIf(process.platform !== "darwin")(
       mac,
     }) =>
       mac.lifetime.run(async () => {
-        const harness = artifactFixture(mac);
+        const harness = await artifactFixture(mac);
         for (const arch of ["arm64", "x86_64"]) {
           const node = harness.at(`${workerRoot}/${arch}/bin/node`);
-          renameSync(node, `${node}-real\n`);
-          write(`${node}-real\n`, harness.binaries.universal, 0o755);
-          symlinkSync("node-real\n", node);
+          await rename(node, `${node}-real\n`);
+          await write(`${node}-real\n`, harness.binaries.universal, 0o755);
+          await symlink("node-real\n", node);
         }
         const result = await harness.verify();
         expect(result.status, result.stderr).toBe(0);
@@ -155,10 +147,10 @@ describe.skipIf(process.platform !== "darwin")(
       mac,
     }) =>
       mac.lifetime.run(async () => {
-        const harness = artifactFixture(mac);
+        const harness = await artifactFixture(mac);
         for (const arch of ["arm64", "x86_64"]) {
           for (let index = 0; index < 40; index++) {
-            write(
+            await write(
               harness.at(`${workerRoot}/${arch}/nested/win32/resource [*]?\n${index}.js`),
               `// harmless platform resource ${index}\n`,
             );
@@ -187,15 +179,16 @@ describe.skipIf(process.platform !== "darwin")(
       "rejects wrong fat64 slices in %s code",
       async ([_name, relative, arch, mode, archive], { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
+          const harness = await artifactFixture(mac);
           const bytes = archive
-            ? macFatContainerFixture(
+            ? await macFatContainerFixture(
                 harness.home,
                 [harness.binaries[arch === "arm64" ? "armArchive" : "intelArchive"]],
                 true,
+                mac,
               )
-            : singleSliceMacFat64(harness.home, arch);
-          write(harness.at(relative), bytes, mode);
+            : await singleSliceMacFat64(harness.home, arch, mac);
+          await write(harness.at(relative), bytes, mode);
           const result = await harness.verify();
           expect(result.status, result.stderr).toBe(1);
           expect(result.stderr).toContain(
@@ -212,8 +205,8 @@ describe.skipIf(process.platform !== "darwin")(
       `${workerRoot}/arm64/${addon}`,
     ])("rejects malformed fat64 code at %s", async (relative, { mac }) =>
       mac.lifetime.run(async () => {
-        const harness = artifactFixture(mac);
-        write(harness.at(relative), Buffer.from("cafebabf", "hex"), 0o755);
+        const harness = await artifactFixture(mac);
+        await write(harness.at(relative), Buffer.from("cafebabf", "hex"), 0o755);
         const result = await harness.verify();
         expect(result.status, result.stderr).toBe(1);
         expect(result.stderr).toContain("could not inspect elevation code slices:");
@@ -228,7 +221,7 @@ describe.skipIf(process.platform !== "darwin")(
       ]),
     )("rejects %s signatures despite successful app policy verification", async (fault, { mac }) =>
       mac.lifetime.run(async () => {
-        const harness = artifactFixture(mac);
+        const harness = await artifactFixture(mac);
         const result = await harness.verify(fault);
         expect(result.status, result.stderr).toBe(1);
         expect(result.stderr).toContain("elevation code lacks native signature format:");
@@ -244,15 +237,16 @@ describe.skipIf(process.platform !== "darwin")(
       "rejects generic raw-fat64 signatures at %s",
       async ([relative, libraryImage], { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
+          const harness = await artifactFixture(mac);
           const bytes = libraryImage
-            ? macFatContainerFixture(
+            ? await macFatContainerFixture(
                 harness.home,
                 [harness.binaries.armLibrary, harness.binaries.intelLibrary],
                 true,
+                mac,
               )
             : harness.binaries.fat64;
-          write(harness.at(relative), bytes, libraryImage ? 0o644 : 0o755);
+          await write(harness.at(relative), bytes, libraryImage ? 0o644 : 0o755);
           const result = await harness.verify();
           expect(result.status, result.stderr).toBe(1);
           expect(result.stderr).toContain("elevation code lacks native signature format:");
@@ -270,23 +264,27 @@ describe.skipIf(process.platform !== "darwin")(
       "rejects mixed $resource/native containers (fat64=$fat64, archiveFirst=$archiveFirst)",
       async ({ resource, fat64, archiveFirst }, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
+          const harness = await artifactFixture(mac);
           const armResource =
             resource === "archive"
               ? harness.binaries.armArchive
-              : macObjectFixture(harness.home, "arm64");
+              : await macObjectFixture(harness.home, "arm64", mac);
           const intelResource =
             resource === "archive"
               ? harness.binaries.intelArchive
-              : macObjectFixture(harness.home, "x86_64");
-          const mixed = macFatContainerFixture(
+              : await macObjectFixture(harness.home, "x86_64", mac);
+          const mixed = await macFatContainerFixture(
             harness.home,
             archiveFirst
               ? [harness.binaries.armLibrary, intelResource]
               : [armResource, harness.binaries.intelLibrary],
             fat64,
+            mac,
           );
-          write(harness.at(`${workerRoot}/arm64/${addon}`), withMachResourceKind(mixed, resource));
+          await write(
+            harness.at(`${workerRoot}/arm64/${addon}`),
+            withMachResourceKind(mixed, resource),
+          );
           const result = await harness.verify();
           expect(result.status, result.stderr).toBe(1);
           expect(result.stderr).toContain(
@@ -299,12 +297,12 @@ describe.skipIf(process.platform !== "darwin")(
       mac,
     }) =>
       mac.lifetime.run(async () => {
-        const harness = artifactFixture(mac);
+        const harness = await artifactFixture(mac);
         const bytes = Buffer.from(harness.binaries.universalArchive);
         expect(bytes.readUInt32BE(0)).toBe(0xcafebabe);
         expect(bytes.readUInt32BE(8)).toBe(0x01000007); // x86_64 comes first in lipo output.
         bytes.fill(0, bytes.readUInt32BE(16), bytes.readUInt32BE(16) + 8);
-        write(harness.at(`${workerRoot}/arm64/${addon}`), bytes);
+        await write(harness.at(`${workerRoot}/arm64/${addon}`), bytes);
         const result = await harness.verify();
         expect(result.status, result.stderr).toBe(1);
         expect(result.stderr).toContain("invalid elevation code slice:");
@@ -320,20 +318,20 @@ describe.skipIf(process.platform !== "darwin")(
       "rejects $resource resources posing as Node ($format)",
       async ({ resource, format }, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
+          const harness = await artifactFixture(mac);
           const arm =
             resource === "archive"
               ? harness.binaries.armArchive
-              : macObjectFixture(harness.home, "arm64");
+              : await macObjectFixture(harness.home, "arm64", mac);
           const intel =
             resource === "archive"
               ? harness.binaries.intelArchive
-              : macObjectFixture(harness.home, "x86_64");
+              : await macObjectFixture(harness.home, "x86_64", mac);
           const bytes =
             format !== "thin"
-              ? macFatContainerFixture(harness.home, [arm, intel], format === "fat64")
+              ? await macFatContainerFixture(harness.home, [arm, intel], format === "fat64", mac)
               : arm;
-          write(
+          await write(
             harness.at(`${workerRoot}/arm64/bin/node`),
             withMachResourceKind(bytes, resource),
             0o755,
@@ -355,18 +353,19 @@ describe.skipIf(process.platform !== "darwin")(
       "accepts $format $resource resources without changing bytes or modes",
       async ({ resource, format }, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
+          const harness = await artifactFixture(mac);
           const objects = {
-            arm64: macObjectFixture(harness.home, "arm64"),
-            x86_64: macObjectFixture(harness.home, "x86_64"),
+            arm64: await macObjectFixture(harness.home, "arm64", mac),
+            x86_64: await macObjectFixture(harness.home, "x86_64", mac),
           };
           const universal =
             format === "thin"
               ? undefined
-              : macFatContainerFixture(
+              : await macFatContainerFixture(
                   harness.home,
                   [objects.arm64, objects.x86_64],
                   format === "fat64",
+                  mac,
                 );
           const preserved = [];
           for (const arch of ["arm64", "x86_64"] as const) {
@@ -375,7 +374,7 @@ describe.skipIf(process.platform !== "darwin")(
                 `${workerRoot}/${arch}/lib/object-resource [*]\n${mode}.dylib`,
               );
               const bytes = withMachResourceKind(universal ?? objects[arch], resource);
-              write(target, bytes, mode);
+              await write(target, bytes, mode);
               preserved.push({ target, bytes, mode });
             }
           }
@@ -409,15 +408,19 @@ describe.skipIf(process.platform !== "darwin")(
       "rejects wrong-architecture $format object resources in $arch",
       async ({ arch, format }, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
-          const wrong = macObjectFixture(harness.home, arch === "arm64" ? "x86_64" : "arm64");
+          const harness = await artifactFixture(mac);
+          const wrong = await macObjectFixture(
+            harness.home,
+            arch === "arm64" ? "x86_64" : "arm64",
+            mac,
+          );
           const bytes =
             format === "thin"
               ? wrong
-              : macFatContainerFixture(harness.home, [wrong], format === "fat64");
+              : await macFatContainerFixture(harness.home, [wrong], format === "fat64", mac);
           // lipo -info repeats the path: injected architecture text is still a filename.
           const relative = `${workerRoot}/${arch}/lib/object-resource are: arm64 x86_64\nNon-fat file: injected is architecture: ${arch}`;
-          write(harness.at(relative), bytes);
+          await write(harness.at(relative), bytes);
           const result = await harness.verify();
           expect(result.status, result.stderr).toBe(1);
           expect(result.stderr).toContain(`elevation worker Mach-O lacks ${arch}:`);
@@ -431,7 +434,7 @@ describe.skipIf(process.platform !== "darwin")(
       ),
     )("rejects $kind GNU thin archives in $arch", async ({ arch, kind }, { mac }) =>
       mac.lifetime.run(async () => {
-        const harness = artifactFixture(mac);
+        const harness = await artifactFixture(mac);
         const header = [
           "missing.o/".padEnd(16),
           "0".padEnd(12),
@@ -442,10 +445,10 @@ describe.skipIf(process.platform !== "darwin")(
           "`\n",
         ].join("");
         const target = harness.at(`${workerRoot}/${arch}/lib/opaque [*].resource`);
-        write(target, `!<thin>\n${kind === "empty" ? "" : header}`);
-        expect(runMacFixtureTool("/usr/bin/file", ["-b", target], harness.home)).toContain(
-          "thin archive with",
-        );
+        await write(target, `!<thin>\n${kind === "empty" ? "" : header}`);
+        expect(
+          await runMacFixtureTool("/usr/bin/file", ["-b", target], harness.home, mac),
+        ).toContain("thin archive with");
         const result = await harness.verify();
         expect(result.status, result.stderr).toBe(1);
         expect(result.stderr).toContain("elevation worker contains unsupported thin archive:");
@@ -457,15 +460,16 @@ describe.skipIf(process.platform !== "darwin")(
       mac,
     }) =>
       mac.lifetime.run(async () => {
-        const harness = artifactFixture(mac);
-        write(path.join(harness.home, "ordinary.txt"), "ordinary resource\n");
+        const harness = await artifactFixture(mac);
+        await write(path.join(harness.home, "ordinary.txt"), "ordinary resource\n");
         const tar = path.join(harness.home, "ordinary.tar");
-        runMacFixtureTool(
+        await runMacFixtureTool(
           "/usr/bin/tar",
           ["--format", "ustar", "-cf", tar, "-C", harness.home, "ordinary.txt"],
           harness.home,
+          mac,
         );
-        expect(runMacFixtureTool("/usr/bin/file", ["-b", tar], harness.home)).toBe(
+        expect(await runMacFixtureTool("/usr/bin/file", ["-b", tar], harness.home, mac)).toBe(
           "POSIX tar archive",
         );
         const targets = [
@@ -476,7 +480,7 @@ describe.skipIf(process.platform !== "darwin")(
           ]),
         ];
         for (const relative of targets) {
-          write(
+          await write(
             harness.at(relative),
             harness.binaries.universal,
             relative.endsWith(addon) ? 0o644 : 0o755,
@@ -484,25 +488,26 @@ describe.skipIf(process.platform !== "darwin")(
         }
         // Shared slice enforcement retains find -perm -111 semantics, not just -x.
         for (const mode of [0o644, 0o700, 0o750]) {
-          write(
+          await write(
             harness.at(`Contents/Frameworks/thin-${mode}.dylib`),
             harness.binaries.armLibrary,
             mode,
           );
         }
-        const archive64 = macFatContainerFixture(
+        const archive64 = await macFatContainerFixture(
           harness.home,
           [harness.binaries.armArchive, harness.binaries.intelArchive],
           true,
+          mac,
         );
         for (const arch of ["arm64", "x86_64"]) {
-          write(harness.at(`${workerRoot}/${arch}/ordinary.resource`), readFileSync(tar));
-          write(
+          await write(harness.at(`${workerRoot}/${arch}/ordinary.resource`), readFileSync(tar));
+          await write(
             harness.at(`${workerRoot}/${arch}/lib/universal.a`),
             harness.binaries.universalArchive,
           );
-          write(harness.at(`${workerRoot}/${arch}/lib/archive64 [*]`), archive64);
-          write(
+          await write(harness.at(`${workerRoot}/${arch}/lib/archive64 [*]`), archive64);
+          await write(
             harness.at(`${workerRoot}/${arch}/Example.class`),
             Buffer.from("cafebabe0000003400010001000000000000000000000000", "hex"),
           );
@@ -554,19 +559,23 @@ describe.skipIf(process.platform !== "darwin")(
       "rejects case-aliased worker structure $relative ($fault)",
       async ({ relative, alias, fault }, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
+          const harness = await artifactFixture(mac);
           for (const arch of ["arm64", "x86_64"]) {
-            write(harness.at(`${workerRoot}/${arch}/bin/node`), harness.binaries.universal, 0o755);
+            await write(
+              harness.at(`${workerRoot}/${arch}/bin/node`),
+              harness.binaries.universal,
+              0o755,
+            );
           }
           const target = harness.at(`${workerRoot}/arm64/${addon}`);
           if (fault === "wrong-slice") {
-            write(target, harness.binaries.intelLibrary);
+            await write(target, harness.binaries.intelLibrary);
           } else {
             const outside = path.join(harness.home, "outside-addon");
-            renameSync(target, outside);
-            symlinkSync(outside, target);
+            await rename(target, outside);
+            await symlink(outside, target);
           }
-          renameSync(harness.at(relative), harness.at(alias));
+          await rename(harness.at(relative), harness.at(alias));
           expect(readdirSync(path.dirname(harness.at(alias)))).toContain(path.basename(alias));
           const result = await harness.verify();
           expect(result.status, result.stderr).toBe(1);
@@ -580,8 +589,8 @@ describe.skipIf(process.platform !== "darwin")(
       ["x86_64 worker", `${workerRoot}/x86_64`],
     ] as const)("rejects missing %s", async ([_name, relative], { mac }) =>
       mac.lifetime.run(async () => {
-        const harness = artifactFixture(mac);
-        rmSync(harness.at(relative), { recursive: true });
+        const harness = await artifactFixture(mac);
+        await rm(harness.at(relative), { recursive: true });
         const result = await harness.verify();
         expect(result.status, result.stderr).toBe(1);
         expect(result.stderr).toContain("elevation worker directory missing or symlinked:");
@@ -592,7 +601,7 @@ describe.skipIf(process.platform !== "darwin")(
       "rejects wrong slices throughout the %s worker",
       async (arch, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
+          const harness = await artifactFixture(mac);
           const wrongArch = arch === "arm64" ? "x86_64" : "arm64";
           const cases = [
             ["bin/node", harness.binaries[wrongArch], 0o755],
@@ -608,15 +617,15 @@ describe.skipIf(process.platform !== "darwin")(
           for (const [relative, contents, mode] of cases) {
             const target = harness.at(`${workerRoot}/${arch}/${relative}`);
             const original = existsSync(target) ? readFileSync(target) : undefined;
-            write(target, contents, mode);
+            await write(target, contents, mode);
             const result = await harness.verify();
             expect(result.status, `${relative}: ${result.stderr}`).toBe(1);
             expect(result.stderr).toContain(`elevation worker Mach-O lacks ${arch}:`);
             expect(result.stderr).toContain(relative);
             if (original) {
-              write(target, original, mode);
+              await write(target, original, mode);
             } else {
-              rmSync(target);
+              await rm(target);
             }
           }
         }),
@@ -626,8 +635,8 @@ describe.skipIf(process.platform !== "darwin")(
       "rejects an incomplete worker missing %s",
       async (relative, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
-          rmSync(harness.at(`${workerRoot}/x86_64/${relative}`));
+          const harness = await artifactFixture(mac);
+          await rm(harness.at(`${workerRoot}/x86_64/${relative}`));
           const result = await harness.verify();
           expect(result.status, result.stderr).toBe(1);
           // The npm-style entrypoint link must also remain valid when its target disappears.
@@ -641,8 +650,8 @@ describe.skipIf(process.platform !== "darwin")(
       "rejects mismatched worker %s",
       async (key, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
-          write(
+          const harness = await artifactFixture(mac);
+          await write(
             harness.at(`${workerRoot}/x86_64/${workerDist}/build-info.json`),
             JSON.stringify({ ...buildInfo, [key]: "wrong" }),
           );
@@ -657,17 +666,18 @@ describe.skipIf(process.platform !== "darwin")(
       mac,
     }) =>
       mac.lifetime.run(async () => {
-        const harness = artifactFixture(mac);
+        const harness = await artifactFixture(mac);
         const node = harness.at(`${workerRoot}/arm64/bin/node`);
-        write(node, "#!/bin/sh\nexit 97\n", 0o755);
+        await write(node, "#!/bin/sh\nexit 97\n", 0o755);
         const nonNative = await harness.verify();
         expect(nonNative.status, nonNative.stderr).toBe(1);
         expect(nonNative.stderr).toContain("elevation worker Node must be Mach-O:");
-        write(node, harness.binaries.arm64, 0o755);
-        runMacFixtureTool(
+        await write(node, harness.binaries.arm64, 0o755);
+        await runMacFixtureTool(
           "/usr/bin/plutil",
           ["-remove", "OpenClawWorkerBuildID", harness.at("Contents/Info.plist")],
           harness.home,
+          mac,
         );
         const missingIdentity = await harness.verify("plist-error-stdout");
         expect(missingIdentity.status, missingIdentity.stderr).toBe(1);
@@ -678,14 +688,14 @@ describe.skipIf(process.platform !== "darwin")(
       "rejects an unexpected worker architecture %s",
       async (kind, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
+          const harness = await artifactFixture(mac);
           const extra = harness.at(`${workerRoot}/unexpected [arch]`);
           if (kind === "directory") {
-            mkdirSync(extra);
+            await mkdir(extra);
           } else if (kind === "symlink") {
-            symlinkSync("arm64", extra);
+            await symlink("arm64", extra);
           } else {
-            write(extra, "unexpected");
+            await write(extra, "unexpected");
           }
           const result = await harness.verify();
           expect(result.status, result.stderr).toBe(1);
@@ -708,11 +718,11 @@ describe.skipIf(process.platform !== "darwin")(
       "rejects an escaping root, intermediate, or terminal link at %s",
       async (relative, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
+          const harness = await artifactFixture(mac);
           const target = harness.at(relative);
           const outside = path.join(harness.home, "outside-worker");
-          renameSync(target, outside);
-          symlinkSync(outside, target);
+          await rename(target, outside);
+          await symlink(outside, target);
           const result = await harness.verify();
           expect(result.status, result.stderr).toBe(1);
           expect(result.stderr).toMatch(
@@ -729,21 +739,21 @@ describe.skipIf(process.platform !== "darwin")(
       "cross-worker",
     ])("rejects %s worker links", async (kind, { mac }) =>
       mac.lifetime.run(async () => {
-        const harness = artifactFixture(mac);
+        const harness = await artifactFixture(mac);
         const worker = harness.at(`${workerRoot}/arm64`);
         if (kind === "directory-cycle") {
-          symlinkSync(".", path.join(worker, "loop"));
+          await symlink(".", path.join(worker, "loop"));
         } else if (kind === "indirect-directory-cycle") {
-          mkdirSync(path.join(worker, "a"));
-          mkdirSync(path.join(worker, "b"));
-          symlinkSync("../b", path.join(worker, "a/to-b"));
-          symlinkSync("../a", path.join(worker, "b/to-a"));
+          await mkdir(path.join(worker, "a"));
+          await mkdir(path.join(worker, "b"));
+          await symlink("../b", path.join(worker, "a/to-b"));
+          await symlink("../a", path.join(worker, "b/to-a"));
         } else if (kind === "cross-worker") {
-          symlinkSync("../x86_64", path.join(worker, "other-worker"));
+          await symlink("../x86_64", path.join(worker, "other-worker"));
         } else {
           const node = path.join(worker, "bin/node");
-          rmSync(node);
-          symlinkSync(kind === "dangling" ? "missing" : "node", node);
+          await rm(node);
+          await symlink(kind === "dangling" ? "missing" : "node", node);
         }
         const result = await harness.verify();
         expect(result.status, result.stderr).toBe(1);
@@ -763,8 +773,8 @@ describe.skipIf(process.platform !== "darwin")(
       "Contents/Frameworks/shared [fixture].dylib",
     ])("rejects thin shared code at %s", async (relative, { mac }) =>
       mac.lifetime.run(async () => {
-        const harness = artifactFixture(mac);
-        write(
+        const harness = await artifactFixture(mac);
+        await write(
           harness.at(relative),
           relative.endsWith(".dylib") ? harness.binaries.armLibrary : harness.binaries.x86_64,
           0o755,
@@ -839,8 +849,8 @@ describe.skipIf(process.platform !== "darwin")(
       "preserves the %s policy gate with observable mocks",
       async ([fault, code, diagnostic, command], { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
-          mkdirSync(harness.at(`${workerRoot}/arm64/fixture.xpc`));
+          const harness = await artifactFixture(mac);
+          await mkdir(harness.at(`${workerRoot}/arm64/fixture.xpc`));
           const result = await harness.verify(fault);
           expect(result.status, result.stderr).toBe(code);
           expect(result.stderr).toContain(diagnostic);
@@ -865,7 +875,7 @@ describe.skipIf(process.platform !== "darwin")(
       ["lipo", "could not inspect elevation code slices:"],
     ])("fails closed when %s cannot scan the artifact", async ([fault, diagnostic], { mac }) =>
       mac.lifetime.run(async () => {
-        const harness = artifactFixture(mac);
+        const harness = await artifactFixture(mac);
         const result = await harness.verify(fault);
         expect(result.status, result.stderr).toBe(1);
         expect(result.stderr).toContain(diagnostic);
@@ -877,12 +887,12 @@ describe.skipIf(process.platform !== "darwin")(
       "preserves CUA omission for a driver %s",
       async (kind, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
+          const harness = await artifactFixture(mac);
           const driver = harness.at("Contents/Resources/cua-driver");
           if (kind === "file") {
-            write(driver, "inert driver");
+            await write(driver, "inert driver");
           } else {
-            symlinkSync("missing-driver", driver);
+            await symlink("missing-driver", driver);
           }
           const result = await harness.verify();
           expect(result.status, result.stderr).toBe(1);
@@ -893,8 +903,8 @@ describe.skipIf(process.platform !== "darwin")(
       "rejects noncanonical build metadata %s",
       async (metadata, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
-          write(harness.at(`${workerRoot}/arm64/${workerDist}/build-info.json`), metadata);
+          const harness = await artifactFixture(mac);
+          await write(harness.at(`${workerRoot}/arm64/${workerDist}/build-info.json`), metadata);
           const result = await harness.verify();
           expect(result.status, result.stderr).toBe(1);
           expect(result.stderr).toContain("elevation worker build metadata does not match app:");
@@ -905,7 +915,7 @@ describe.skipIf(process.platform !== "darwin")(
       "fully verifies a new destination-stage copy with %s policy",
       async (fault, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
+          const harness = await artifactFixture(mac);
           const result = await harness.verifyStagedCopy(fault);
           expect(result.status, result.stderr).toBe(
             fault === "healthy" ? 0 : fault === "signature" ? 1 : 23,
@@ -939,7 +949,7 @@ describe.skipIf(process.platform !== "darwin")(
       ["teamIdentifier", "TeamIdentifier"],
     ] as const)("binds receipt %s to the fully audited app", async ([key, diagnostic], { mac }) =>
       mac.lifetime.run(async () => {
-        const harness = artifactFixture(mac);
+        const harness = await artifactFixture(mac);
         harness.receipt[key] = "wrong";
         const result = await harness.verify();
         expect(result.status, result.stderr).toBe(1);
@@ -957,7 +967,7 @@ describe.skipIf(process.platform !== "darwin")(
       "binds receipt $field for $target to the fully audited app",
       async ({ field, target }, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
+          const harness = await artifactFixture(mac);
           harness.receipt[field][target] = "wrong";
           const result = await harness.verify();
           expect(result.status, result.stderr).toBe(1);
@@ -972,7 +982,7 @@ describe.skipIf(process.platform !== "darwin")(
       "propagates %s failure through conditional receipt verification",
       async (fault, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
+          const harness = await artifactFixture(mac);
           const result = await harness.verifyReceiptConditionally(fault);
           expect(result.status, result.stderr).toBe(23);
           expect(result.stderr).toContain(`mock rejection: ${fault}`);
@@ -989,7 +999,7 @@ describe.skipIf(process.platform !== "darwin")(
       "classifies recovery planning after %s policy result",
       async ([fault, state, command], { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
+          const harness = await artifactFixture(mac);
           const result = await harness.recoveryPlan(fault);
           expect(result.status, result.stderr).toBe(0);
           expect(result.stdout).toBe(`Recovery planning state: ${state}\n`);
@@ -1003,8 +1013,8 @@ describe.skipIf(process.platform !== "darwin")(
       "rejects foreign %s worker assets even without executable bits",
       async (format, { mac }) =>
         mac.lifetime.run(async () => {
-          const harness = artifactFixture(mac);
-          write(harness.at(`${workerRoot}/arm64/${addon}`), harness.binaries[format]);
+          const harness = await artifactFixture(mac);
+          await write(harness.at(`${workerRoot}/arm64/${addon}`), harness.binaries[format]);
           const result = await harness.verify();
           expect(result.status, result.stderr).toBe(1);
           expect(result.stderr).toContain("elevation worker contains non-Mach-O native code:");

--- a/test/scripts/mac-elevation-artifact.test.ts
+++ b/test/scripts/mac-elevation-artifact.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { mkdir, rename, rm, symlink } from "node:fs/promises";
 import path from "node:path";
-import { describe, expect } from "vitest";
+import { describe, expect, vi } from "vitest";
 import {
   addon,
   artifactFixture,
@@ -14,6 +14,7 @@ import {
   write,
 } from "./mac-elevation-artifact.test-support.js";
 import {
+  compiledMacNativeFixtures,
   macFatContainerFixture,
   macObjectFixture,
   runMacFixtureTool,
@@ -71,6 +72,36 @@ function withMachResourceKind(
 describe.skipIf(process.platform !== "darwin")(
   "portable elevation native artifact verification",
   () => {
+    // The following archive case owns a new lifetime and must prepare successfully
+    // after this failed flight; keep the failure probe ahead of the concurrent cases.
+    it("rejects all borrowers of a failed native preparation", ({ mac }) =>
+      mac.lifetime.run(async () => {
+        const root = mac.createTempDir("openclaw-native-preparation-failure-");
+        const tool = vi.spyOn(mac, "run").mockResolvedValueOnce({
+          status: 1,
+          signal: null,
+          error: undefined,
+          stdout: "",
+          stderr: "injected native preparation failure",
+        });
+        try {
+          const results = await Promise.allSettled([
+            compiledMacNativeFixtures(root, mac),
+            macObjectFixture(root, "arm64", mac),
+          ]);
+          const rejected = {
+            status: "rejected",
+            reason: expect.objectContaining({
+              message: expect.stringContaining("injected native preparation failure"),
+            }),
+          };
+          expect(results).toEqual([rejected, rejected]);
+          expect(tool).toHaveBeenCalledTimes(1);
+        } finally {
+          tool.mockRestore();
+        }
+      }));
+
     it.concurrent("accepts a real archive with a complete native worker pair outside the checkout", async ({
       mac,
     }) =>

--- a/test/scripts/mac-native-fixtures.test-support.ts
+++ b/test/scripts/mac-native-fixtures.test-support.ts
@@ -101,9 +101,19 @@ export async function compiledMacNativeFixtures(
 }
 
 function prepareMacNativeFixtures(root: string, mac: MacScriptFixture) {
-  // The first case owns and joins preparation; borrowers receive only complete
-  // in-memory bytes. Cancellation rejects all borrowers instead of publishing partial state.
-  return (nativeFixtures ??= mac.lifetime.run(() => compileMacNativeFixtures(root, mac)));
+  if (nativeFixtures) {
+    return nativeFixtures;
+  }
+  // The first case owns preparation; only complete in-memory bytes are shared.
+  // A failed flight rejects its borrowers, but must not poison later case lifetimes.
+  const preparation = mac.lifetime.run(() => compileMacNativeFixtures(root, mac));
+  nativeFixtures = preparation;
+  void preparation.catch(() => {
+    if (nativeFixtures === preparation) {
+      nativeFixtures = undefined;
+    }
+  });
+  return preparation;
 }
 
 async function compileMacNativeFixtures(

--- a/test/scripts/mac-native-fixtures.test-support.ts
+++ b/test/scripts/mac-native-fixtures.test-support.ts
@@ -1,17 +1,23 @@
-import { spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect } from "vitest";
+import type { MacScriptFixture } from "./mac-script-fixture.test-support.js";
 
 const systemPath = "/usr/bin:/bin:/usr/sbin:/sbin";
 
-export function runMacFixtureTool(command: string, args: string[], root: string) {
-  const result = spawnSync(command, args, {
+export async function runMacFixtureTool(
+  command: string,
+  args: string[],
+  root: string,
+  mac: MacScriptFixture,
+) {
+  const result = await mac.run(command, args, {
     encoding: "utf8",
     cwd: root,
     env: { HOME: root, TMPDIR: root, PATH: systemPath },
   });
-  expect(result.status, `${command}: ${result.error ?? result.stderr}`).toBe(0);
+  expect(result.error, `${command}: ${result.stderr}`).toBeUndefined();
+  expect(result.status, `${command}: ${result.stderr}`).toBe(0);
   return result.stdout.trim();
 }
 
@@ -31,50 +37,81 @@ type NativeFixtures = Record<
   | "intelArchive",
   Buffer
 >;
-let nativeFixtures: NativeFixtures | undefined;
-const nativeObjects = new Map<"arm64" | "x86_64", Buffer>();
+type PreparedNativeFixtures = {
+  binaries: NativeFixtures;
+  objects: Record<"arm64" | "x86_64", Buffer>;
+};
+let nativeFixtures: Promise<PreparedNativeFixtures> | undefined;
 
-export function macObjectFixture(root: string, arch: "arm64" | "x86_64") {
-  compiledMacNativeFixtures(root);
-  const object = nativeObjects.get(arch);
-  if (!object) {
-    throw new Error(`Missing compiled ${arch} object fixture`);
-  }
-  return object;
+export async function macObjectFixture(
+  root: string,
+  arch: "arm64" | "x86_64",
+  mac: MacScriptFixture,
+) {
+  return (await prepareMacNativeFixtures(root, mac)).objects[arch];
 }
 
-export function macFatContainerFixture(root: string, slices: readonly Buffer[], fat64 = false) {
-  const inputs = slices.map((bytes, index) => {
+export async function macFatContainerFixture(
+  root: string,
+  slices: readonly Buffer[],
+  fat64: boolean,
+  mac: MacScriptFixture,
+) {
+  const inputs = [];
+  for (const [index, bytes] of slices.entries()) {
     const file = path.join(root, `fat-container-input-${index}`);
-    writeFileSync(file, bytes);
-    return file;
-  });
+    await writeFile(file, bytes);
+    inputs.push(file);
+  }
   const output = path.join(root, "fat-container");
-  runMacFixtureTool(
+  await runMacFixtureTool(
     "/usr/bin/lipo",
     ["-create", ...(fat64 ? ["-fat64"] : []), ...inputs, "-output", output],
     root,
+    mac,
   );
-  return readFileSync(output);
+  return readFile(output);
 }
 
-export function singleSliceMacFat64(root: string, arch: "arm64" | "x86_64"): Buffer {
+export async function singleSliceMacFat64(
+  root: string,
+  arch: "arm64" | "x86_64",
+  mac: MacScriptFixture,
+) {
   const input = path.join(root, `fat64-input-${arch}`);
   const output = path.join(root, `fat64-single-${arch}`);
-  writeFileSync(input, compiledMacNativeFixtures(root)[arch]);
-  runMacFixtureTool("/usr/bin/lipo", ["-create", "-fat64", input, "-output", output], root);
-  expect(runMacFixtureTool("/usr/bin/lipo", ["-archs", output], root)).toBe(arch);
-  const bytes = readFileSync(output);
+  await writeFile(input, (await compiledMacNativeFixtures(root, mac))[arch]);
+  await runMacFixtureTool(
+    "/usr/bin/lipo",
+    ["-create", "-fat64", input, "-output", output],
+    root,
+    mac,
+  );
+  expect(await runMacFixtureTool("/usr/bin/lipo", ["-archs", output], root, mac)).toBe(arch);
+  const bytes = await readFile(output);
   expect(bytes.subarray(0, 4).toString("hex")).toBe("cafebabf");
   return bytes;
 }
 
-export function compiledMacNativeFixtures(root: string): NativeFixtures {
-  if (nativeFixtures) {
-    return nativeFixtures;
-  }
+export async function compiledMacNativeFixtures(
+  root: string,
+  mac: MacScriptFixture,
+): Promise<NativeFixtures> {
+  return (await prepareMacNativeFixtures(root, mac)).binaries;
+}
+
+function prepareMacNativeFixtures(root: string, mac: MacScriptFixture) {
+  // The first case owns and joins preparation; borrowers receive only complete
+  // in-memory bytes. Cancellation rejects all borrowers instead of publishing partial state.
+  return (nativeFixtures ??= mac.lifetime.run(() => compileMacNativeFixtures(root, mac)));
+}
+
+async function compileMacNativeFixtures(
+  root: string,
+  mac: MacScriptFixture,
+): Promise<PreparedNativeFixtures> {
   const source = path.join(root, "inert.c");
-  writeFileSync(source, "int main(void) { return 0; }\n");
+  await writeFile(source, "int main(void) { return 0; }\n");
   const files = {
     arm64: path.join(root, "arm64"),
     x86_64: path.join(root, "x86_64"),
@@ -88,13 +125,15 @@ export function compiledMacNativeFixtures(root: string): NativeFixtures {
     elf: path.join(root, "elf"),
     armArchive: path.join(root, "arm.a"),
     intelArchive: path.join(root, "intel.a"),
+    armObject: path.join(root, "arm64.o"),
+    intelObject: path.join(root, "x86_64.o"),
   };
   for (const arch of ["arm64", "x86_64"] as const) {
     for (const dynamic of [false, true]) {
       const output = dynamic
         ? files[arch === "arm64" ? "armLibrary" : "intelLibrary"]
         : files[arch];
-      runMacFixtureTool(
+      await runMacFixtureTool(
         "/usr/bin/xcrun",
         [
           "clang",
@@ -108,48 +147,59 @@ export function compiledMacNativeFixtures(root: string): NativeFixtures {
           output,
         ],
         root,
+        mac,
       );
-      expect(runMacFixtureTool("/usr/bin/lipo", ["-archs", output], root)).toBe(arch);
+      expect(await runMacFixtureTool("/usr/bin/lipo", ["-archs", output], root, mac)).toBe(arch);
     }
-    const object = path.join(root, `${arch}.o`);
+    const object = files[arch === "arm64" ? "armObject" : "intelObject"];
     const archive = files[arch === "arm64" ? "armArchive" : "intelArchive"];
-    runMacFixtureTool("/usr/bin/xcrun", ["clang", "-arch", arch, "-c", source, "-o", object], root);
-    nativeObjects.set(arch, readFileSync(object));
-    runMacFixtureTool("/usr/bin/ar", ["rcs", archive, object], root);
-    expect(runMacFixtureTool("/usr/bin/lipo", ["-archs", archive], root)).toBe(arch);
+    await runMacFixtureTool(
+      "/usr/bin/xcrun",
+      ["clang", "-arch", arch, "-c", source, "-o", object],
+      root,
+      mac,
+    );
+    await runMacFixtureTool("/usr/bin/ar", ["rcs", archive, object], root, mac);
+    expect(await runMacFixtureTool("/usr/bin/lipo", ["-archs", archive], root, mac)).toBe(arch);
   }
-  runMacFixtureTool(
+  await runMacFixtureTool(
     "/usr/bin/lipo",
     ["-create", files.arm64, files.x86_64, "-output", files.universal],
     root,
+    mac,
   );
-  runMacFixtureTool(
+  await runMacFixtureTool(
     "/usr/bin/lipo",
     ["-create", files.armLibrary, files.intelLibrary, "-output", files.universalLibrary],
     root,
+    mac,
   );
-  runMacFixtureTool(
+  await runMacFixtureTool(
     "/usr/bin/xcrun",
     ["clang", "-target", "x86_64-unknown-linux-gnu", "-c", source, "-o", files.elf],
     root,
+    mac,
   );
-  expect(runMacFixtureTool("/usr/bin/file", ["-b", files.elf], root)).toContain("ELF");
-  runMacFixtureTool(
+  expect(await runMacFixtureTool("/usr/bin/file", ["-b", files.elf], root, mac)).toContain("ELF");
+  await runMacFixtureTool(
     "/usr/bin/lipo",
     ["-create", "-fat64", files.arm64, files.x86_64, "-output", files.fat64],
     root,
+    mac,
   );
-  runMacFixtureTool(
+  await runMacFixtureTool(
     "/usr/bin/lipo",
     ["-create", files.armArchive, files.intelArchive, "-output", files.universalArchive],
     root,
+    mac,
   );
-  runMacFixtureTool(
+  await runMacFixtureTool(
     "/usr/bin/xcrun",
     ["clang", "-target", "x86_64-pc-windows-msvc", "-c", source, "-o", files.coff],
     root,
+    mac,
   );
-  expect(runMacFixtureTool("/usr/bin/file", ["-b", files.coff], root)).toContain("COFF");
+  expect(await runMacFixtureTool("/usr/bin/file", ["-b", files.coff], root, mac)).toContain("COFF");
   // Minimal inert PE32+ image: DOS header, NT/optional headers, one .text section.
   const pe = Buffer.alloc(1024);
   pe.write("MZ");
@@ -174,24 +224,25 @@ export function compiledMacNativeFixtures(root: string): NativeFixtures {
   pe.writeUInt32LE(512, 412);
   pe.writeUInt32LE(0x60000020, 428);
   pe[512] = 0xc3;
-  writeFileSync(path.join(root, "windows.exe"), pe);
-  expect(
-    runMacFixtureTool("/usr/bin/file", ["-b", path.join(root, "windows.exe")], root),
-  ).toContain("PE32+");
-  nativeFixtures = {
-    arm64: readFileSync(files.arm64),
-    x86_64: readFileSync(files.x86_64),
-    universal: readFileSync(files.universal),
-    fat64: readFileSync(files.fat64),
-    universalArchive: readFileSync(files.universalArchive),
-    coff: readFileSync(files.coff),
-    pe,
-    armLibrary: readFileSync(files.armLibrary),
-    intelLibrary: readFileSync(files.intelLibrary),
-    universalLibrary: readFileSync(files.universalLibrary),
-    elf: readFileSync(files.elf),
-    armArchive: readFileSync(files.armArchive),
-    intelArchive: readFileSync(files.intelArchive),
+  const peFile = path.join(root, "windows.exe");
+  await writeFile(peFile, pe);
+  expect(await runMacFixtureTool("/usr/bin/file", ["-b", peFile], root, mac)).toContain("PE32+");
+  return {
+    binaries: {
+      arm64: await readFile(files.arm64),
+      x86_64: await readFile(files.x86_64),
+      universal: await readFile(files.universal),
+      fat64: await readFile(files.fat64),
+      universalArchive: await readFile(files.universalArchive),
+      coff: await readFile(files.coff),
+      pe,
+      armLibrary: await readFile(files.armLibrary),
+      intelLibrary: await readFile(files.intelLibrary),
+      universalLibrary: await readFile(files.universalLibrary),
+      elf: await readFile(files.elf),
+      armArchive: await readFile(files.armArchive),
+      intelArchive: await readFile(files.intelArchive),
+    },
+    objects: { arm64: await readFile(files.armObject), x86_64: await readFile(files.intelObject) },
   };
-  return nativeFixtures;
 }

--- a/test/scripts/mac-native-fixtures.test.ts
+++ b/test/scripts/mac-native-fixtures.test.ts
@@ -1,0 +1,43 @@
+import { once } from "node:events";
+import { createServer } from "node:net";
+import { expect } from "vitest";
+import { runMacFixtureTool } from "./mac-native-fixtures.test-support.js";
+import { createMacScriptTest } from "./mac-script-fixture.test-support.js";
+
+const it = createMacScriptTest();
+
+it("services parent events while an owned native fixture tool waits for release", ({ mac }) =>
+  mac.lifetime.run(async () => {
+    const root = mac.createTempDir("mac-native-handshake-");
+    const server = createServer((socket) => socket.end("released"));
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing fixture listener address");
+      }
+      const output = await runMacFixtureTool(
+        process.execPath,
+        [
+          "--eval",
+          `
+const socket = require("node:net").connect(${address.port}, "127.0.0.1");
+const deadline = setTimeout(() => {
+  console.error("parent could not service fixture handshake");
+  process.exit(73);
+}, 1500);
+socket.on("data", (data) => process.stdout.write(data));
+socket.on("end", () => clearTimeout(deadline));
+`,
+        ],
+        root,
+        mac,
+      );
+      expect(output).toBe("released");
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  }));

--- a/test/scripts/mac-node-worker-materialization.test-support.ts
+++ b/test/scripts/mac-node-worker-materialization.test-support.ts
@@ -1,44 +1,28 @@
-import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
-  chmodSync,
-  cpSync,
   existsSync,
-  linkSync,
   lstatSync,
-  mkdirSync,
   readFileSync,
   readdirSync,
   readlinkSync,
   realpathSync,
-  renameSync,
   statSync,
-  symlinkSync,
-  writeFileSync,
 } from "node:fs";
+import { chmod, cp, link, mkdir, rename, symlink } from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
-import { artifactFixture } from "./mac-elevation-artifact.test-support.js";
+import { describe, expect } from "vitest";
+import { artifactFixture, write } from "./mac-elevation-artifact.test-support.js";
 import {
   compiledMacNativeFixtures,
   macFatContainerFixture,
   macObjectFixture,
   runMacFixtureTool,
 } from "./mac-native-fixtures.test-support.js";
-import { createMacScriptTest } from "./mac-script-fixture.test-support.js";
-
-const temps = useAutoCleanupTempDirTracker(afterEach);
+import { createMacScriptTest, type MacScriptFixture } from "./mac-script-fixture.test-support.js";
 const systemPath = "/usr/bin:/bin:/usr/sbin:/sbin";
 const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
 const materializer = "scripts/materialize-mac-node-worker.py";
 const inventory = "scripts/lib/mac-native-inventory.py";
-
-function write(file: string, contents: string | Buffer, mode = 0o644) {
-  mkdirSync(path.dirname(file), { recursive: true });
-  writeFileSync(file, contents);
-  chmodSync(file, mode);
-}
 
 function snapshot(root: string) {
   const records: { path: string; mode: number; kind: string; content?: string }[] = [];
@@ -65,18 +49,18 @@ function snapshot(root: string) {
   return records;
 }
 
-function materializationFixture(complete = false) {
-  const root = realpathSync(temps.make("openclaw-worker-native-copy-"));
+async function materializationFixture(mac: MacScriptFixture, complete = false) {
+  const root = realpathSync(mac.createTempDir("openclaw-worker-native-copy-"));
   const source = path.join(root, "canonical");
   const parent = path.join(root, "stage");
   const destination = path.join(parent, "derived");
-  mkdirSync(source);
-  mkdirSync(parent);
-  const binaries = compiledMacNativeFixtures(root);
+  await mkdir(source);
+  await mkdir(parent);
+  const binaries = await compiledMacNativeFixtures(root, mac);
   for (const [name, bytes] of Object.entries(
     complete ? binaries : { arm64: binaries.arm64, elf: binaries.elf },
   )) {
-    write(path.join(source, `images/${name}`), bytes);
+    await write(path.join(source, `images/${name}`), bytes);
   }
   for (const filename of [
     "nested/win32/README.md",
@@ -85,29 +69,36 @@ function materializationFixture(complete = false) {
     "opposite-linux/name.node",
     "space [*]?\nresource.js",
   ]) {
-    write(path.join(source, filename), "// nonbinary resource remains byte-identical\n", 0o640);
+    await write(
+      path.join(source, filename),
+      "// nonbinary resource remains byte-identical\n",
+      0o640,
+    );
   }
-  write(path.join(source, "engine.wasm"), Buffer.from("0061736d01000000", "hex"));
+  await write(path.join(source, "engine.wasm"), Buffer.from("0061736d01000000", "hex"));
   // Java and fat Mach-O share CAFEBABE. Classifier-owned non-native resources survive.
-  write(
+  await write(
     path.join(source, "Example.class"),
     Buffer.from("cafebabe0000003400010001000000000000000000000000", "hex"),
   );
   for (let i = 0; i < (complete ? 70 : 2); i++) {
-    write(path.join(source, `scripts/${i} [*]\n.js`), `// resource ${i}\n`);
+    await write(path.join(source, `scripts/${i} [*]\n.js`), `// resource ${i}\n`);
   }
-  mkdirSync(path.join(source, "empty"));
-  chmodSync(path.join(source, "empty"), 0o550);
-  symlinkSync("../nested/win32/build.mjs", path.join(source, "scripts/npm-style"));
-  symlinkSync("nested/win32", path.join(source, "directory-alias"));
+  await mkdir(path.join(source, "empty"));
+  await chmod(path.join(source, "empty"), 0o550);
+  await symlink("../nested/win32/build.mjs", path.join(source, "scripts/npm-style"));
+  await symlink("nested/win32", path.join(source, "directory-alias"));
   return {
     root,
     source,
     parent,
     destination,
     binaries,
-    run(arch = "arm64", options: { source?: string; destination?: string; prelude?: string } = {}) {
-      return spawnSync(
+    async run(
+      arch = "arm64",
+      options: { source?: string; destination?: string; prelude?: string } = {},
+    ) {
+      return await mac.run(
         "/usr/bin/python3",
         [
           "-B",
@@ -132,25 +123,25 @@ function materializationFixture(complete = false) {
   };
 }
 
-function stagingFixture() {
-  const root = realpathSync(temps.make("openclaw-worker-materialization-"));
-  const binaries = compiledMacNativeFixtures(root);
+async function stagingFixture(mac: MacScriptFixture) {
+  const root = realpathSync(mac.createTempDir("openclaw-worker-materialization-"));
+  const binaries = await compiledMacNativeFixtures(root, mac);
   const scripts = path.join(root, "scripts");
   const destination = path.join(root, "published");
   const calls = path.join(root, "verification-calls");
   const tmp = path.join(root, "tmp");
-  mkdirSync(scripts);
-  mkdirSync(tmp);
-  cpSync("scripts/stage-mac-node-worker.sh", path.join(scripts, "stage-mac-node-worker.sh"));
-  cpSync(materializer, path.join(scripts, path.basename(materializer)));
-  write(path.join(scripts, "lib/mac-native-inventory.py"), readFileSync(inventory));
-  write(path.join(root, "canonical.tgz"), "inert package mock");
-  write(path.join(root, "dist/build-info.json"), '{"buildId":"unchanged-build"}');
-  write(
+  await mkdir(scripts);
+  await mkdir(tmp);
+  await cp("scripts/stage-mac-node-worker.sh", path.join(scripts, "stage-mac-node-worker.sh"));
+  await cp(materializer, path.join(scripts, path.basename(materializer)));
+  await write(path.join(scripts, "lib/mac-native-inventory.py"), readFileSync(inventory));
+  await write(path.join(root, "canonical.tgz"), "inert package mock");
+  await write(path.join(root, "dist/build-info.json"), '{"buildId":"unchanged-build"}');
+  await write(
     path.join(scripts, "package-openclaw-for-docker.mjs"),
     `import assert from 'node:assert/strict';\nassert(process.argv.includes('--pnpm-pack'), 'worker package must use the repository-pinned packer');\nconsole.log(${JSON.stringify(path.join(root, "canonical.tgz"))});\n`,
   );
-  write(
+  await write(
     path.join(scripts, "verify-mac-node-worker.mjs"),
     `
 import assert from 'node:assert/strict';
@@ -162,12 +153,16 @@ if (process.argv[2].includes('/x86_64/') && fs.existsSync(${JSON.stringify(path.
   );
   for (const arch of ["arm64", "x86_64"] as const) {
     const canonical = path.join(root, "canonical", arch);
-    write(path.join(canonical, "matching.node"), binaries[arch]);
-    write(path.join(canonical, "foreign.node"), binaries.elf);
-    write(path.join(canonical, "nested/win32/build.mjs"), "// preserve Windows source\n", 0o755);
-    cpSync(path.join(root, "dist/build-info.json"), path.join(canonical, "build-info.json"));
+    await write(path.join(canonical, "matching.node"), binaries[arch]);
+    await write(path.join(canonical, "foreign.node"), binaries.elf);
+    await write(
+      path.join(canonical, "nested/win32/build.mjs"),
+      "// preserve Windows source\n",
+      0o755,
+    );
+    await cp(path.join(root, "dist/build-info.json"), path.join(canonical, "build-info.json"));
     // The fixture Node is an explicit execution mock; no native payload is launched.
-    write(
+    await write(
       path.join(canonical, "bin/node"),
       `#!/bin/bash
 set -euo pipefail
@@ -179,7 +174,7 @@ exec ${quote(process.execPath)} "$@"
       0o755,
     );
   }
-  write(
+  await write(
     path.join(scripts, "install-cli.sh"),
     `
 node_dir() { printf '%s' "$PREFIX/node"; }
@@ -198,8 +193,8 @@ install_openclaw() { :; }
     destination,
     calls,
     tmp,
-    run(variant: string, tempRoot = tmp) {
-      return spawnSync(
+    async run(variant: string, tempRoot = tmp) {
+      return await mac.run(
         "/bin/bash",
         [path.join(scripts, "stage-mac-node-worker.sh"), destination, "arm64", "x86_64"],
         {
@@ -219,222 +214,242 @@ install_openclaw() { :; }
 export function registerMacWorkerMaterializationTests() {
   describe.skipIf(process.platform !== "darwin")("elevation worker materialization", () => {
     const it = createMacScriptTest();
-    it("provisions beside the destination when system temp is unavailable", () => {
-      for (const variant of ["standard", "elevation-host"]) {
-        const fixture = stagingFixture();
-        const before = snapshot(path.join(fixture.root, "canonical"));
-        const result = fixture.run(variant, path.join(fixture.tmp, "unavailable"));
-        expect(result.status, result.stderr).toBe(0);
-        expect(snapshot(path.join(fixture.root, "canonical"))).toEqual(before);
-        const calls = readFileSync(fixture.calls, "utf8").trim().split("\n");
-        expect(calls).toHaveLength(2);
-        for (const [index, call] of calls.entries()) {
-          const arch = index === 0 ? "arm64" : "x86_64";
-          const [node, runtime, expected] = call.split("|");
-          expect(node).toBe(`${runtime}/bin/node`);
-          expect(runtime).toContain(`/${arch}/${variant === "standard" ? "runtime" : "elevation"}`);
-          expect(expected).toBe(path.join(fixture.root, "dist/build-info.json"));
-          const scratch = path.resolve(runtime!, "../..");
-          expect(path.dirname(scratch)).toBe(path.dirname(fixture.destination));
-          expect(existsSync(scratch)).toBe(false);
-          expect(snapshot(path.join(fixture.destination, arch))).toEqual(
-            snapshot(path.join(fixture.root, "canonical", arch)).filter(
-              (entry) => variant === "standard" || entry.path !== "foreign.node",
-            ),
-          );
+    it("provisions beside the destination when system temp is unavailable", ({ mac }) =>
+      mac.lifetime.run(async () => {
+        for (const variant of ["standard", "elevation-host"]) {
+          const fixture = await stagingFixture(mac);
+          const before = snapshot(path.join(fixture.root, "canonical"));
+          const result = await fixture.run(variant, path.join(fixture.tmp, "unavailable"));
+          expect(result.status, result.stderr).toBe(0);
+          expect(snapshot(path.join(fixture.root, "canonical"))).toEqual(before);
+          const calls = readFileSync(fixture.calls, "utf8").trim().split("\n");
+          expect(calls).toHaveLength(2);
+          for (const [index, call] of calls.entries()) {
+            const arch = index === 0 ? "arm64" : "x86_64";
+            const [node, runtime, expected] = call.split("|");
+            expect(node).toBe(`${runtime}/bin/node`);
+            expect(runtime).toContain(
+              `/${arch}/${variant === "standard" ? "runtime" : "elevation"}`,
+            );
+            expect(expected).toBe(path.join(fixture.root, "dist/build-info.json"));
+            const scratch = path.resolve(runtime!, "../..");
+            expect(path.dirname(scratch)).toBe(path.dirname(fixture.destination));
+            expect(existsSync(scratch)).toBe(false);
+            expect(snapshot(path.join(fixture.destination, arch))).toEqual(
+              snapshot(path.join(fixture.root, "canonical", arch)).filter(
+                (entry) => variant === "standard" || entry.path !== "foreign.node",
+              ),
+            );
+          }
+          expect(readdirSync(fixture.tmp)).toEqual([]);
         }
-        expect(readdirSync(fixture.tmp)).toEqual([]);
-      }
-    });
+      }));
 
-    it.each(
+    it.for(
       ["standard", "elevation-host"].flatMap((variant) =>
         ["verification", "occupied", "occupied-link"].map((failure) => ({ variant, failure })),
       ),
     )(
       "publishes neither architecture on second $variant $failure failure",
-      ({ variant, failure }) => {
-        const fixture = stagingFixture();
-        if (failure === "verification") {
-          write(path.join(fixture.root, "reject-verification"), "");
-        } else if (failure === "occupied") {
-          write(path.join(fixture.destination, "x86_64/sentinel"), "owner");
-        } else {
-          mkdirSync(fixture.destination);
-          symlinkSync("missing", path.join(fixture.destination, "x86_64"));
-        }
-        const before = existsSync(fixture.destination) ? snapshot(fixture.destination) : [];
-        const result = fixture.run(variant);
-        expect(result.status, result.stderr).toBe(failure === "verification" ? 42 : 1);
-        const calls = readFileSync(fixture.calls, "utf8").trim().split("\n");
-        expect(calls).toHaveLength(2);
-        for (const call of calls) {
-          expect(existsSync(path.resolve(call.split("|")[1]!, "../.."))).toBe(false);
-        }
-        expect(existsSync(path.join(fixture.destination, "arm64"))).toBe(false);
-        expect(existsSync(fixture.destination) ? snapshot(fixture.destination) : []).toEqual(
-          before,
-        );
-        expect(readdirSync(fixture.tmp)).toEqual([]);
-      },
-    );
-
-    it.each(["arm64", "x86_64"])(
-      "retains every resource and eligible native image for %s without changing canonical input",
-      (arch) => {
-        const fixture = materializationFixture(true);
-        for (const fat64 of [false, true]) {
-          const bytes = macFatContainerFixture(
-            fixture.root,
-            [macObjectFixture(fixture.root, "arm64"), macObjectFixture(fixture.root, "x86_64")],
-            fat64,
-          );
-          expect(
-            runMacFixtureTool(
-              "/usr/bin/lipo",
-              ["-archs", path.join(fixture.root, "fat-container")],
-              fixture.root,
-            )
-              .split(" ")
-              .toSorted(),
-          ).toEqual(["arm64", "x86_64"]);
-          expect(bytes.readUInt32BE(0)).toBe(fat64 ? 0xcafebabf : 0xcafebabe);
-          expect(bytes.readUInt32BE(4)).toBe(2);
-          // Synthetic classification controls, never memory dumps or executed.
-          // lipo -create ignores MH_CORE inputs; change only the completed slices' types.
-          for (let index = 0; index < 2; index++) {
-            const record = 8 + index * (fat64 ? 32 : 20);
-            const offset = fat64
-              ? Number(bytes.readBigUInt64BE(record + 8))
-              : bytes.readUInt32BE(record + 8);
-            expect(bytes.readUInt32LE(offset)).toBe(0xfeedfacf);
-            expect(bytes.readUInt32LE(offset + 12)).toBe(1);
-            bytes.writeUInt32LE(4, offset + 12);
+      ({ variant, failure }, { mac }) =>
+        mac.lifetime.run(async () => {
+          const fixture = await stagingFixture(mac);
+          if (failure === "verification") {
+            await write(path.join(fixture.root, "reject-verification"), "");
+          } else if (failure === "occupied") {
+            await write(path.join(fixture.destination, "x86_64/sentinel"), "owner");
+          } else {
+            await mkdir(fixture.destination);
+            await symlink("missing", path.join(fixture.destination, "x86_64"));
           }
-          write(path.join(fixture.source, `synthetic-core-fat${fat64 ? 64 : 32}`), bytes);
-        }
-        const oddNative = "images/odd [*]?\narm64";
-        renameSync(path.join(fixture.source, "images/arm64"), path.join(fixture.source, oddNative));
-        for (const [name, contents, mode] of [
-          ["database.js", "db.connect();\n", 0o644],
-          ["unicode.js", "db.label = 'café';\n", 0o644],
-          ["query.txt", "(Query expression)\n", 0o644],
-          ["setuid.txt", "small inert resource\n", 0o4755],
-        ] as const) {
-          const resource = path.join(fixture.source, "scripts", name);
-          write(resource, contents, mode);
-          expect(statSync(resource).mode & 0o7777).toBe(mode);
-        }
-        // Establish the source filesystem's actual name equivalence; never guess
-        // which Unicode spelling readdir returns or fold component text in the test.
-        for (const [name, literal, alias] of [
-          ["Library/addon.node", "library/ADDON.NODE", "0-case-alias"],
-          ["Café.txt", "Cafe\u0301.txt", "0-unicode-alias"],
-        ] as const) {
-          write(path.join(fixture.source, name), "retained lookup resource\n", 0o640);
-          expect(statSync(path.join(fixture.source, literal)).ino).toBe(
-            statSync(path.join(fixture.source, name)).ino,
+          const before = existsSync(fixture.destination) ? snapshot(fixture.destination) : [];
+          const result = await fixture.run(variant);
+          expect(result.status, result.stderr).toBe(failure === "verification" ? 42 : 1);
+          const calls = readFileSync(fixture.calls, "utf8").trim().split("\n");
+          expect(calls).toHaveLength(2);
+          for (const call of calls) {
+            expect(existsSync(path.resolve(call.split("|")[1]!, "../.."))).toBe(false);
+          }
+          expect(existsSync(path.join(fixture.destination, "arm64"))).toBe(false);
+          expect(existsSync(fixture.destination) ? snapshot(fixture.destination) : []).toEqual(
+            before,
           );
-          symlinkSync(literal, path.join(fixture.source, alias));
-        }
-        linkSync(
-          path.join(fixture.source, "Library/addon.node"),
-          path.join(fixture.source, "Library/second.node"),
-        );
-        symlinkSync("library/SECOND.NODE", path.join(fixture.source, "0-hardlink-alias"));
-        symlinkSync("library/", path.join(fixture.source, "0-directory"));
-        symlinkSync("0-DIRECTORY/../engine.wasm", path.join(fixture.source, "0-parent-alias"));
-        chmodSync(fixture.source, 0o750);
-        const before = snapshot(fixture.source);
-        const result = fixture.run(arch);
-        expect(result.status, result.stderr).toBe(0);
-        const omitted = new Set(
-          [
-            "coff",
-            "pe",
-            "elf",
-            ...(arch === "arm64"
-              ? ["x86_64", "intelLibrary", "intelArchive"]
-              : ["arm64", "armLibrary", "armArchive"]),
-          ].map((name) => (name === "arm64" ? oddNative : `images/${name}`)),
-        );
-        expect(snapshot(fixture.destination)).toEqual(
-          before.filter((entry) => !omitted.has(entry.path)),
-        );
-        expect(snapshot(fixture.source)).toEqual(before);
-        for (const alias of [
-          "0-case-alias",
-          "0-unicode-alias",
-          "0-hardlink-alias",
-          "0-parent-alias",
-        ]) {
-          expect(readFileSync(path.join(fixture.destination, alias))).toEqual(
-            readFileSync(path.join(fixture.source, alias)),
-          );
-          expect(readlinkSync(path.join(fixture.destination, alias))).toBe(
-            readlinkSync(path.join(fixture.source, alias)),
-          );
-        }
-        const outputSecond = statSync(path.join(fixture.destination, "Library/second.node"));
-        expect(outputSecond.ino).not.toBe(
-          statSync(path.join(fixture.destination, "Library/addon.node")).ino,
-        );
-        expect(statSync(path.join(fixture.destination, "0-hardlink-alias")).ino).toBe(
-          outputSecond.ino,
-        );
-        expect(result.stderr).toContain("omitted 6 native images");
-        for (const name of omitted) {
-          expect(result.stderr).toContain(JSON.stringify(name));
-        }
-        expect(
-          runMacFixtureTool(
-            "/usr/bin/lipo",
-            ["-archs", path.join(fixture.destination, "images/fat64")],
-            fixture.root,
-          ),
-        ).toContain(arch);
-      },
+          expect(readdirSync(fixture.tmp)).toEqual([]);
+        }),
     );
 
-    it.each([
+    it.for(["arm64", "x86_64"])(
+      "retains every resource and eligible native image for %s without changing canonical input",
+      (arch, { mac }) =>
+        mac.lifetime.run(async () => {
+          const fixture = await materializationFixture(mac, true);
+          for (const fat64 of [false, true]) {
+            const bytes = await macFatContainerFixture(
+              fixture.root,
+              [
+                await macObjectFixture(fixture.root, "arm64", mac),
+                await macObjectFixture(fixture.root, "x86_64", mac),
+              ],
+              fat64,
+              mac,
+            );
+            expect(
+              (
+                await runMacFixtureTool(
+                  "/usr/bin/lipo",
+                  ["-archs", path.join(fixture.root, "fat-container")],
+                  fixture.root,
+                  mac,
+                )
+              )
+                .split(" ")
+                .toSorted(),
+            ).toEqual(["arm64", "x86_64"]);
+            expect(bytes.readUInt32BE(0)).toBe(fat64 ? 0xcafebabf : 0xcafebabe);
+            expect(bytes.readUInt32BE(4)).toBe(2);
+            // Synthetic classification controls, never memory dumps or executed.
+            // lipo -create ignores MH_CORE inputs; change only the completed slices' types.
+            for (let index = 0; index < 2; index++) {
+              const record = 8 + index * (fat64 ? 32 : 20);
+              const offset = fat64
+                ? Number(bytes.readBigUInt64BE(record + 8))
+                : bytes.readUInt32BE(record + 8);
+              expect(bytes.readUInt32LE(offset)).toBe(0xfeedfacf);
+              expect(bytes.readUInt32LE(offset + 12)).toBe(1);
+              bytes.writeUInt32LE(4, offset + 12);
+            }
+            await write(path.join(fixture.source, `synthetic-core-fat${fat64 ? 64 : 32}`), bytes);
+          }
+          const oddNative = "images/odd [*]?\narm64";
+          await rename(
+            path.join(fixture.source, "images/arm64"),
+            path.join(fixture.source, oddNative),
+          );
+          for (const [name, contents, mode] of [
+            ["database.js", "db.connect();\n", 0o644],
+            ["unicode.js", "db.label = 'café';\n", 0o644],
+            ["query.txt", "(Query expression)\n", 0o644],
+            ["setuid.txt", "small inert resource\n", 0o4755],
+          ] as const) {
+            const resource = path.join(fixture.source, "scripts", name);
+            await write(resource, contents, mode);
+            expect(statSync(resource).mode & 0o7777).toBe(mode);
+          }
+          // Establish the source filesystem's actual name equivalence; never guess
+          // which Unicode spelling readdir returns or fold component text in the test.
+          for (const [name, literal, alias] of [
+            ["Library/addon.node", "library/ADDON.NODE", "0-case-alias"],
+            ["Café.txt", "Cafe\u0301.txt", "0-unicode-alias"],
+          ] as const) {
+            await write(path.join(fixture.source, name), "retained lookup resource\n", 0o640);
+            expect(statSync(path.join(fixture.source, literal)).ino).toBe(
+              statSync(path.join(fixture.source, name)).ino,
+            );
+            await symlink(literal, path.join(fixture.source, alias));
+          }
+          await link(
+            path.join(fixture.source, "Library/addon.node"),
+            path.join(fixture.source, "Library/second.node"),
+          );
+          await symlink("library/SECOND.NODE", path.join(fixture.source, "0-hardlink-alias"));
+          await symlink("library/", path.join(fixture.source, "0-directory"));
+          await symlink("0-DIRECTORY/../engine.wasm", path.join(fixture.source, "0-parent-alias"));
+          await chmod(fixture.source, 0o750);
+          const before = snapshot(fixture.source);
+          const result = await fixture.run(arch);
+          expect(result.status, result.stderr).toBe(0);
+          const omitted = new Set(
+            [
+              "coff",
+              "pe",
+              "elf",
+              ...(arch === "arm64"
+                ? ["x86_64", "intelLibrary", "intelArchive"]
+                : ["arm64", "armLibrary", "armArchive"]),
+            ].map((name) => (name === "arm64" ? oddNative : `images/${name}`)),
+          );
+          expect(snapshot(fixture.destination)).toEqual(
+            before.filter((entry) => !omitted.has(entry.path)),
+          );
+          expect(snapshot(fixture.source)).toEqual(before);
+          for (const alias of [
+            "0-case-alias",
+            "0-unicode-alias",
+            "0-hardlink-alias",
+            "0-parent-alias",
+          ]) {
+            expect(readFileSync(path.join(fixture.destination, alias))).toEqual(
+              readFileSync(path.join(fixture.source, alias)),
+            );
+            expect(readlinkSync(path.join(fixture.destination, alias))).toBe(
+              readlinkSync(path.join(fixture.source, alias)),
+            );
+          }
+          const outputSecond = statSync(path.join(fixture.destination, "Library/second.node"));
+          expect(outputSecond.ino).not.toBe(
+            statSync(path.join(fixture.destination, "Library/addon.node")).ino,
+          );
+          expect(statSync(path.join(fixture.destination, "0-hardlink-alias")).ino).toBe(
+            outputSecond.ino,
+          );
+          expect(result.stderr).toContain("omitted 6 native images");
+          for (const name of omitted) {
+            expect(result.stderr).toContain(JSON.stringify(name));
+          }
+          expect(
+            await runMacFixtureTool(
+              "/usr/bin/lipo",
+              ["-archs", path.join(fixture.destination, "images/fat64")],
+              fixture.root,
+              mac,
+            ),
+          ).toContain(arch);
+        }),
+    );
+
+    it.for([
       "occupied",
       "occupied-link",
       "inside-source",
       "outside-parent",
       "source-link",
       "parent-alias",
-    ])("rejects unsafe construction roots (%s) without touching input or occupants", (kind) => {
-      const fixture = materializationFixture();
-      let source = fixture.source;
-      let destination = fixture.destination;
-      if (kind === "occupied") {
-        write(path.join(destination, "sentinel"), "owner");
-      }
-      if (kind === "occupied-link") {
-        symlinkSync(source, destination);
-      }
-      if (kind === "inside-source") {
-        destination = path.join(source, "new-output");
-      }
-      if (kind === "outside-parent") {
-        destination = path.join(fixture.root, "new-output");
-      }
-      if (kind === "source-link") {
-        source = path.join(fixture.root, "source-alias");
-        symlinkSync(fixture.source, source);
-      }
-      if (kind === "parent-alias") {
-        symlinkSync(fixture.source, path.join(fixture.parent, "alias"));
-        destination = path.join(fixture.parent, "alias", "new-output");
-      }
-      const before = snapshot(fixture.root);
-      const result = fixture.run("arm64", { source, destination });
-      expect(result.status, result.stderr).not.toBe(0);
-      expect(result.stderr).toMatch(/File exists|disjoint|Not a directory/);
-      expect(snapshot(fixture.root)).toEqual(before);
-    });
+    ])(
+      "rejects unsafe construction roots (%s) without touching input or occupants",
+      (kind, { mac }) =>
+        mac.lifetime.run(async () => {
+          const fixture = await materializationFixture(mac);
+          let source = fixture.source;
+          let destination = fixture.destination;
+          if (kind === "occupied") {
+            await write(path.join(destination, "sentinel"), "owner");
+          }
+          if (kind === "occupied-link") {
+            await symlink(source, destination);
+          }
+          if (kind === "inside-source") {
+            destination = path.join(source, "new-output");
+          }
+          if (kind === "outside-parent") {
+            destination = path.join(fixture.root, "new-output");
+          }
+          if (kind === "source-link") {
+            source = path.join(fixture.root, "source-alias");
+            await symlink(fixture.source, source);
+          }
+          if (kind === "parent-alias") {
+            await symlink(fixture.source, path.join(fixture.parent, "alias"));
+            destination = path.join(fixture.parent, "alias", "new-output");
+          }
+          const before = snapshot(fixture.root);
+          const result = await fixture.run("arm64", { source, destination });
+          expect(result.status, result.stderr).not.toBe(0);
+          expect(result.stderr).toMatch(/File exists|disjoint|Not a directory/);
+          expect(snapshot(fixture.root)).toEqual(before);
+        }),
+    );
 
-    it.each([
+    it.for([
       "absolute",
       "escape",
       "dangling",
@@ -445,36 +460,38 @@ export function registerMacWorkerMaterializationTests() {
       "link-cycle",
       "directory-cycle",
       "indirect-cycle",
-    ])("rejects unprovable source links (%s) and leaves no partial output", (kind) => {
-      const fixture = materializationFixture();
-      const targets: Record<string, string> = {
-        absolute: path.join(fixture.source, "engine.wasm"),
-        escape: "../inert.c",
-        omitted: "images/elf",
-        "case-omitted": "IMAGES/ELF",
-        "case-cycle": "LINK",
-        "case-file-slash": "IMAGES/ARM64/",
-        "directory-cycle": ".",
-        "link-cycle": "link",
-      };
-      const target = targets[kind] ?? "missing";
-      if (kind === "indirect-cycle") {
-        mkdirSync(path.join(fixture.source, "a"));
-        mkdirSync(path.join(fixture.source, "b"));
-        symlinkSync("../b", path.join(fixture.source, "a/to-b"));
-        symlinkSync("../a", path.join(fixture.source, "b/to-a"));
-      } else {
-        symlinkSync(target, path.join(fixture.source, "link"));
-      }
-      const before = snapshot(fixture.source);
-      const result = fixture.run();
-      expect(result.status, result.stderr).not.toBe(0);
-      expect(result.stderr).toMatch(/symlink|Cyclic|ELOOP|ENOENT|No such file/);
-      expect(snapshot(fixture.source)).toEqual(before);
-      expect(existsSync(fixture.destination)).toBe(false);
-    });
+    ])("rejects unprovable source links (%s) and leaves no partial output", (kind, { mac }) =>
+      mac.lifetime.run(async () => {
+        const fixture = await materializationFixture(mac);
+        const targets: Record<string, string> = {
+          absolute: path.join(fixture.source, "engine.wasm"),
+          escape: "../inert.c",
+          omitted: "images/elf",
+          "case-omitted": "IMAGES/ELF",
+          "case-cycle": "LINK",
+          "case-file-slash": "IMAGES/ARM64/",
+          "directory-cycle": ".",
+          "link-cycle": "link",
+        };
+        const target = targets[kind] ?? "missing";
+        if (kind === "indirect-cycle") {
+          await mkdir(path.join(fixture.source, "a"));
+          await mkdir(path.join(fixture.source, "b"));
+          await symlink("../b", path.join(fixture.source, "a/to-b"));
+          await symlink("../a", path.join(fixture.source, "b/to-a"));
+        } else {
+          await symlink(target, path.join(fixture.source, "link"));
+        }
+        const before = snapshot(fixture.source);
+        const result = await fixture.run();
+        expect(result.status, result.stderr).not.toBe(0);
+        expect(result.stderr).toMatch(/symlink|Cyclic|ELOOP|ENOENT|No such file/);
+        expect(snapshot(fixture.source)).toEqual(before);
+        expect(existsSync(fixture.destination)).toBe(false);
+      }),
+    );
 
-    it.each([
+    it.for([
       ["feedface", 18, false],
       ["cefaedfe", 7, false],
       ["feedfacf", 0x1000012, false],
@@ -483,89 +500,98 @@ export function registerMacWorkerMaterializationTests() {
       ["cafebabf", 0, true],
       ["bebafeca", 0, false],
       ["bfbafeca", 0, false],
-    ] as const)("classifies Mach magic %s with real Darwin tools", (magic, cpu, retained) => {
-      const fixture = materializationFixture();
-      let bytes: Buffer;
-      if (cpu) {
-        const wide = magic === "feedfacf" || magic === "cffaedfe";
-        bytes = Buffer.alloc(wide ? 32 : 28);
-        Buffer.from(magic, "hex").copy(bytes);
-        const little = magic === "cefaedfe" || magic === "cffaedfe";
-        const fields = [cpu, cpu === 7 ? 3 : 0, 1, 0, 0, 0];
-        fields.forEach((value, index) =>
-          little
-            ? bytes.writeUInt32LE(value, 4 + index * 4)
-            : bytes.writeUInt32BE(value, 4 + index * 4),
-        );
-      } else {
-        bytes = Buffer.from(
-          magic === "cafebabf" || magic === "bfbafeca"
-            ? fixture.binaries.fat64
-            : fixture.binaries.universal,
-        );
-        if (magic === "bebafeca" || magic === "bfbafeca") {
-          // Apple's fat.h requires big-endian on disk; swapped containers fail closed.
-          const stride = magic === "bfbafeca" ? 32 : 20;
-          bytes.subarray(0, 8).swap32();
-          for (let index = 0; index < 2; index++) {
-            const start = 8 + index * stride;
-            bytes.subarray(start, start + (stride === 20 ? 20 : 8)).swap32();
-            if (stride === 32) {
-              bytes.subarray(start + 8, start + 24).swap64();
-              bytes.subarray(start + 24, start + 32).swap32();
+    ] as const)(
+      "classifies Mach magic %s with real Darwin tools",
+      ([magic, cpu, retained], { mac }) =>
+        mac.lifetime.run(async () => {
+          const fixture = await materializationFixture(mac);
+          let bytes: Buffer;
+          if (cpu) {
+            const wide = magic === "feedfacf" || magic === "cffaedfe";
+            bytes = Buffer.alloc(wide ? 32 : 28);
+            Buffer.from(magic, "hex").copy(bytes);
+            const little = magic === "cefaedfe" || magic === "cffaedfe";
+            const fields = [cpu, cpu === 7 ? 3 : 0, 1, 0, 0, 0];
+            fields.forEach((value, index) =>
+              little
+                ? bytes.writeUInt32LE(value, 4 + index * 4)
+                : bytes.writeUInt32BE(value, 4 + index * 4),
+            );
+          } else {
+            bytes = Buffer.from(
+              magic === "cafebabf" || magic === "bfbafeca"
+                ? fixture.binaries.fat64
+                : fixture.binaries.universal,
+            );
+            if (magic === "bebafeca" || magic === "bfbafeca") {
+              // Apple's fat.h requires big-endian on disk; swapped containers fail closed.
+              const stride = magic === "bfbafeca" ? 32 : 20;
+              bytes.subarray(0, 8).swap32();
+              for (let index = 0; index < 2; index++) {
+                const start = 8 + index * stride;
+                bytes.subarray(start, start + (stride === 20 ? 20 : 8)).swap32();
+                if (stride === 32) {
+                  bytes.subarray(start + 8, start + 24).swap64();
+                  bytes.subarray(start + 24, start + 32).swap32();
+                }
+              }
             }
           }
-        }
-      }
-      write(path.join(fixture.source, "magic"), bytes);
-      const before = snapshot(fixture.source);
-      const authority = spawnSync("/usr/bin/lipo", ["-archs", path.join(fixture.source, "magic")], {
-        encoding: "utf8",
-        env: { HOME: fixture.root, TMPDIR: fixture.root, PATH: systemPath },
-      });
-      const result = fixture.run();
-      // Newer Apple lipo also rejects big-endian thin headers. Its failure must
-      // stop construction, never turn an unclassified native image into a resource.
-      const unsupported = authority.status !== 0;
-      if (unsupported) {
-        expect(result.status, result.stderr).not.toBe(0);
-        expect(existsSync(fixture.destination)).toBe(false);
-      } else {
-        expect(result.status, result.stderr).toBe(0);
-        expect(existsSync(path.join(fixture.destination, "magic"))).toBe(retained);
-        if (retained) {
-          expect(readFileSync(path.join(fixture.destination, "magic"))).toEqual(bytes);
-        }
-      }
-      expect(snapshot(fixture.source)).toEqual(before);
-    });
-
-    it.each(["mach", "fat64", "elf", "pe", "coff", "archive"])(
-      "fails closed on malformed %s native candidates",
-      (kind) => {
-        const fixture = materializationFixture();
-        const bytes =
-          kind === "mach"
-            ? Buffer.from("cffaedfe", "hex")
-            : kind === "fat64"
-              ? Buffer.from("cafebabf", "hex")
-              : kind === "elf"
-                ? fixture.binaries.elf.subarray(0, 7)
-                : kind === "coff"
-                  ? fixture.binaries.coff.subarray(0, 3)
-                  : kind === "pe"
-                    ? fixture.binaries.pe.subarray(0, 16)
-                    : Buffer.from("!<arch>\nmalformed");
-        write(path.join(fixture.source, "broken"), bytes);
-        const before = snapshot(fixture.source);
-        const result = fixture.run();
-        expect(result.status, result.stderr).not.toBe(0);
-        expect(existsSync(fixture.destination)).toBe(false);
-        expect(snapshot(fixture.source)).toEqual(before);
-      },
+          await write(path.join(fixture.source, "magic"), bytes);
+          const before = snapshot(fixture.source);
+          const authority = await mac.run(
+            "/usr/bin/lipo",
+            ["-archs", path.join(fixture.source, "magic")],
+            {
+              encoding: "utf8",
+              env: { HOME: fixture.root, TMPDIR: fixture.root, PATH: systemPath },
+            },
+          );
+          const result = await fixture.run();
+          // Newer Apple lipo also rejects big-endian thin headers. Its failure must
+          // stop construction, never turn an unclassified native image into a resource.
+          const unsupported = authority.status !== 0;
+          if (unsupported) {
+            expect(result.status, result.stderr).not.toBe(0);
+            expect(existsSync(fixture.destination)).toBe(false);
+          } else {
+            expect(result.status, result.stderr).toBe(0);
+            expect(existsSync(path.join(fixture.destination, "magic"))).toBe(retained);
+            if (retained) {
+              expect(readFileSync(path.join(fixture.destination, "magic"))).toEqual(bytes);
+            }
+          }
+          expect(snapshot(fixture.source)).toEqual(before);
+        }),
     );
 
-    it.each([
+    it.for(["mach", "fat64", "elf", "pe", "coff", "archive"])(
+      "fails closed on malformed %s native candidates",
+      (kind, { mac }) =>
+        mac.lifetime.run(async () => {
+          const fixture = await materializationFixture(mac);
+          const bytes =
+            kind === "mach"
+              ? Buffer.from("cffaedfe", "hex")
+              : kind === "fat64"
+                ? Buffer.from("cafebabf", "hex")
+                : kind === "elf"
+                  ? fixture.binaries.elf.subarray(0, 7)
+                  : kind === "coff"
+                    ? fixture.binaries.coff.subarray(0, 3)
+                    : kind === "pe"
+                      ? fixture.binaries.pe.subarray(0, 16)
+                      : Buffer.from("!<arch>\nmalformed");
+          await write(path.join(fixture.source, "broken"), bytes);
+          const before = snapshot(fixture.source);
+          const result = await fixture.run();
+          expect(result.status, result.stderr).not.toBe(0);
+          expect(existsSync(fixture.destination)).toBe(false);
+          expect(snapshot(fixture.source)).toEqual(before);
+        }),
+    );
+
+    it.for([
       "file-exit",
       "file-framing",
       "file-empty",
@@ -585,11 +611,12 @@ export function registerMacWorkerMaterializationTests() {
       "copy",
       "close",
       "output-link",
-    ])("fails closed on %s errors without publishing partial output", (failure) => {
-      const fixture = materializationFixture();
-      const before = snapshot(fixture.source);
-      const result = fixture.run("arm64", {
-        prelude: `
+    ])("fails closed on %s errors without publishing partial output", (failure, { mac }) =>
+      mac.lifetime.run(async () => {
+        const fixture = await materializationFixture(mac);
+        const before = snapshot(fixture.source);
+        const result = await fixture.run("arm64", {
+          prelude: `
 import os, shutil, subprocess
 failure = ${JSON.stringify(failure)}
 original_run, original_scan, original_copy, original_fdopen = subprocess.run, os.scandir, shutil.copyfileobj, os.fdopen
@@ -646,35 +673,37 @@ import atexit
 def verify_closed():
     assert all(stream.closed for stream in opened), "leaked source stream"
 `,
-      });
-      expect(result.status, result.stderr).not.toBe(0);
-      expect(result.stderr).toMatch(
-        /injected|Incomplete worker|Invalid worker|Uncertain worker|Unclassified worker|equivalent output target/,
-      );
-      expect(result.stderr).not.toContain("leaked source stream");
-      expect(existsSync(fixture.destination)).toBe(false);
-      expect(snapshot(fixture.source)).toEqual(before);
-    });
+        });
+        expect(result.status, result.stderr).not.toBe(0);
+        expect(result.stderr).toMatch(
+          /injected|Incomplete worker|Invalid worker|Uncertain worker|Unclassified worker|equivalent output target/,
+        );
+        expect(result.stderr).not.toContain("leaked source stream");
+        expect(existsSync(fixture.destination)).toBe(false);
+        expect(snapshot(fixture.source)).toEqual(before);
+      }),
+    );
 
-    it.each(["before-open", "before-scan", "after-classification", "symlink-aba"])(
+    it.for(["before-open", "before-scan", "after-classification", "symlink-aba"])(
       "rejects source substitution %s without reading outside bytes or publishing",
-      (schedule) => {
-        const fixture = materializationFixture();
-        const inside = path.join(fixture.source, "images");
-        const outside = path.join(fixture.root, "outside");
-        const outsideBytes = Buffer.concat([
-          fixture.binaries.arm64,
-          Buffer.from("outside sentinel"),
-        ]);
-        write(path.join(outside, "arm64"), outsideBytes);
-        if (schedule === "symlink-aba") {
-          write(path.join(fixture.source, "a.txt"), "original resource");
-          write(path.join(fixture.source, "b.txt"), "substituted resource");
-          symlinkSync("a.txt", path.join(fixture.source, "alias"));
-        }
-        const before = snapshot(fixture.source);
-        const result = fixture.run("arm64", {
-          prelude: `
+      (schedule, { mac }) =>
+        mac.lifetime.run(async () => {
+          const fixture = await materializationFixture(mac);
+          const inside = path.join(fixture.source, "images");
+          const outside = path.join(fixture.root, "outside");
+          const outsideBytes = Buffer.concat([
+            fixture.binaries.arm64,
+            Buffer.from("outside sentinel"),
+          ]);
+          await write(path.join(outside, "arm64"), outsideBytes);
+          if (schedule === "symlink-aba") {
+            await write(path.join(fixture.source, "a.txt"), "original resource");
+            await write(path.join(fixture.source, "b.txt"), "substituted resource");
+            await symlink("a.txt", path.join(fixture.source, "alias"));
+          }
+          const before = snapshot(fixture.source);
+          const result = await fixture.run("arm64", {
+            prelude: `
 import os, shutil, subprocess, json
 inside, outside = ${JSON.stringify(inside)}, ${JSON.stringify(outside)}
 schedule = ${JSON.stringify(schedule)}
@@ -733,41 +762,44 @@ def evidence():
     with open(${JSON.stringify(path.join(fixture.root, "race.json"))}, "w") as output:
         json.dump({"changed": changed, "copied": copied, "outsideOpened": outside_opened, "initialFds": initial_fds, "finalFds": len(os.listdir("/dev/fd")) - 1}, output)
 `,
-        });
-        const evidence = JSON.parse(readFileSync(path.join(fixture.root, "race.json"), "utf8")) as {
-          changed: boolean;
-          copied: string[];
-          outsideOpened: boolean[];
-          initialFds: number;
-          finalFds: number;
-        };
-        expect(evidence.changed).toBe(true);
-        expect(evidence.finalFds).toBe(evidence.initialFds);
-        expect(evidence.outsideOpened).toEqual([]);
-        expect(result.status, result.stderr).not.toBe(0);
-        expect(result.stderr).toMatch(/Inventory|directory|symbolic link/i);
-        expect(existsSync(fixture.destination)).toBe(false);
-        expect(evidence.copied).toEqual(
-          schedule === "before-open" || schedule === "symlink-aba"
-            ? []
-            : [fixture.binaries.arm64.toString("hex")],
-        );
-        expect(readFileSync(path.join(outside, "arm64"))).toEqual(outsideBytes);
-        if (schedule === "symlink-aba") {
-          expect(snapshot(fixture.source)).toEqual(before);
-          expect(readlinkSync(path.join(fixture.source, "alias"))).toBe("a.txt");
-        }
-      },
+          });
+          const evidence = JSON.parse(
+            readFileSync(path.join(fixture.root, "race.json"), "utf8"),
+          ) as {
+            changed: boolean;
+            copied: string[];
+            outsideOpened: boolean[];
+            initialFds: number;
+            finalFds: number;
+          };
+          expect(evidence.changed).toBe(true);
+          expect(evidence.finalFds).toBe(evidence.initialFds);
+          expect(evidence.outsideOpened).toEqual([]);
+          expect(result.status, result.stderr).not.toBe(0);
+          expect(result.stderr).toMatch(/Inventory|directory|symbolic link/i);
+          expect(existsSync(fixture.destination)).toBe(false);
+          expect(evidence.copied).toEqual(
+            schedule === "before-open" || schedule === "symlink-aba"
+              ? []
+              : [fixture.binaries.arm64.toString("hex")],
+          );
+          expect(readFileSync(path.join(outside, "arm64"))).toEqual(outsideBytes);
+          if (schedule === "symlink-aba") {
+            expect(snapshot(fixture.source)).toEqual(before);
+            expect(readlinkSync(path.join(fixture.source, "alias"))).toBe("a.txt");
+          }
+        }),
     );
 
-    it("rejects in-place source mutation restored after lipo before native omission", () => {
-      const fixture = materializationFixture();
-      const target = path.join(fixture.source, "images/arm64");
-      const replacement = path.join(fixture.root, "replacement");
-      write(replacement, fixture.binaries.x86_64);
-      const before = snapshot(fixture.source);
-      const result = fixture.run("arm64", {
-        prelude: `
+    it("rejects in-place source mutation restored after lipo before native omission", ({ mac }) =>
+      mac.lifetime.run(async () => {
+        const fixture = await materializationFixture(mac);
+        const target = path.join(fixture.source, "images/arm64");
+        const replacement = path.join(fixture.root, "replacement");
+        await write(replacement, fixture.binaries.x86_64);
+        const before = snapshot(fixture.source);
+        const result = await fixture.run("arm64", {
+          prelude: `
 import atexit, json, os, subprocess
 target = ${JSON.stringify(target)}
 with open(target, "rb") as stream: original = stream.read()
@@ -799,40 +831,43 @@ def evidence():
                    "sameMtime": current.st_mtime_ns == original_info.st_mtime_ns,
                    "initialFds": initial_fds, "finalFds": len(os.listdir("/dev/fd")) - 1}, output)
 `,
-      });
-      const evidence = JSON.parse(
-        readFileSync(path.join(fixture.root, "omission.json"), "utf8"),
-      ) as {
-        schedule: string[];
-        sameInode: boolean;
-        changedCtime: boolean;
-        sameMtime: boolean;
-        initialFds: number;
-        finalFds: number;
-      };
-      expect(evidence.schedule).toEqual([
-        "replaced after file classification",
-        "lipo observed x86_64",
-        "restored before omission",
-      ]);
-      expect(evidence.sameInode).toBe(true);
-      expect(evidence.changedCtime).toBe(true);
-      expect(evidence.sameMtime).toBe(true);
-      expect(evidence.finalFds).toBe(evidence.initialFds);
-      expect(snapshot(fixture.source)).toEqual(before);
-      expect(result.status, result.stderr).not.toBe(0);
-      expect(existsSync(fixture.destination)).toBe(false);
-    });
+        });
+        const evidence = JSON.parse(
+          readFileSync(path.join(fixture.root, "omission.json"), "utf8"),
+        ) as {
+          schedule: string[];
+          sameInode: boolean;
+          changedCtime: boolean;
+          sameMtime: boolean;
+          initialFds: number;
+          finalFds: number;
+        };
+        expect(evidence.schedule).toEqual([
+          "replaced after file classification",
+          "lipo observed x86_64",
+          "restored before omission",
+        ]);
+        expect(evidence.sameInode).toBe(true);
+        expect(evidence.changedCtime).toBe(true);
+        expect(evidence.sameMtime).toBe(true);
+        expect(evidence.finalFds).toBe(evidence.initialFds);
+        expect(snapshot(fixture.source)).toEqual(before);
+        expect(result.status, result.stderr).not.toBe(0);
+        expect(existsSync(fixture.destination)).toBe(false);
+      }));
 
-    it("bounds native batches and rewinds retained handles after real classifier reads", () => {
-      const fixture = materializationFixture();
-      for (let index = 0; index < 130; index++) {
-        write(path.join(fixture.source, `native-${index}`), fixture.binaries.arm64);
-        write(path.join(fixture.source, `resource-${index}.js`), "// ordinary resource\n");
-      }
-      const before = snapshot(fixture.source);
-      const result = fixture.run("arm64", {
-        prelude: `
+    it("bounds native batches and rewinds retained handles after real classifier reads", ({
+      mac,
+    }) =>
+      mac.lifetime.run(async () => {
+        const fixture = await materializationFixture(mac);
+        for (let index = 0; index < 130; index++) {
+          await write(path.join(fixture.source, `native-${index}`), fixture.binaries.arm64);
+          await write(path.join(fixture.source, `resource-${index}.js`), "// ordinary resource\n");
+        }
+        const before = snapshot(fixture.source);
+        const result = await fixture.run("arm64", {
+          prelude: `
 import os, subprocess, json, atexit
 original_run = subprocess.run
 batches = []
@@ -849,45 +884,54 @@ def evidence():
     with open(${JSON.stringify(path.join(fixture.root, "batches.json"))}, "w") as output:
         json.dump({"batches": batches, "initial": initial_fds, "final": len(os.listdir("/dev/fd")) - 1}, output)
 `,
-      });
-      expect(result.status, result.stderr).toBe(0);
-      expect(snapshot(fixture.destination)).toEqual(
-        before.filter((entry) => entry.path !== "images/elf"),
-      );
-      expect(snapshot(fixture.source)).toEqual(before);
-      const evidence = JSON.parse(
-        readFileSync(path.join(fixture.root, "batches.json"), "utf8"),
-      ) as { batches: number[]; initial: number; final: number };
-      expect(evidence.batches.length).toBeLessThanOrEqual(3);
-      expect(Math.max(...evidence.batches)).toBeLessThanOrEqual(64);
-      expect(evidence.batches.reduce((sum, size) => sum + size, 0)).toBe(133);
-      expect(evidence.final).toBe(evidence.initial);
-    });
+        });
+        expect(result.status, result.stderr).toBe(0);
+        expect(snapshot(fixture.destination)).toEqual(
+          before.filter((entry) => entry.path !== "images/elf"),
+        );
+        expect(snapshot(fixture.source)).toEqual(before);
+        const evidence = JSON.parse(
+          readFileSync(path.join(fixture.root, "batches.json"), "utf8"),
+        ) as { batches: number[]; initial: number; final: number };
+        expect(evidence.batches.length).toBeLessThanOrEqual(3);
+        expect(Math.max(...evidence.batches)).toBeLessThanOrEqual(64);
+        expect(evidence.batches.reduce((sum, size) => sum + size, 0)).toBe(133);
+        expect(evidence.final).toBe(evidence.initial);
+      }));
 
-    it("rejects special input files without blocking or publishing", () => {
-      const fixture = materializationFixture();
-      runMacFixtureTool("/usr/bin/mkfifo", [path.join(fixture.source, "fifo")], fixture.root);
-      const result = fixture.run();
-      expect(result.status, result.stderr).not.toBe(0);
-      expect(result.stderr).toContain("Unsupported worker filesystem entry");
-      expect(existsSync(fixture.destination)).toBe(false);
-    });
+    it("rejects special input files without blocking or publishing", ({ mac }) =>
+      mac.lifetime.run(async () => {
+        const fixture = await materializationFixture(mac);
+        await runMacFixtureTool(
+          "/usr/bin/mkfifo",
+          [path.join(fixture.source, "fifo")],
+          fixture.root,
+          mac,
+        );
+        const result = await fixture.run();
+        expect(result.status, result.stderr).not.toBe(0);
+        expect(result.stderr).toContain("Unsupported worker filesystem entry");
+        expect(existsSync(fixture.destination)).toBe(false);
+      }));
 
     it("feeds freshly derived worker pairs to the real portable consumer", async ({ mac }) =>
       mac.lifetime.run(async () => {
-        const harness = artifactFixture(mac);
+        const harness = await artifactFixture(mac);
         for (const arch of ["arm64", "x86_64"] as const) {
           const worker = harness.at(`Contents/Resources/node-worker/${arch}`);
           const canonical = path.join(harness.home, `canonical-${arch}`);
-          renameSync(worker, canonical);
-          write(path.join(canonical, "nested/win32/README.md"), "Windows source is retained\n");
-          write(path.join(canonical, "nested/win32/foreign.node"), harness.binaries.pe);
-          write(
+          await rename(worker, canonical);
+          await write(
+            path.join(canonical, "nested/win32/README.md"),
+            "Windows source is retained\n",
+          );
+          await write(path.join(canonical, "nested/win32/foreign.node"), harness.binaries.pe);
+          await write(
             path.join(canonical, "opposite-mac.node"),
             harness.binaries[arch === "arm64" ? "x86_64" : "arm64"],
           );
           const before = snapshot(canonical);
-          const result = spawnSync(
+          const result = await mac.run(
             "/usr/bin/python3",
             ["-B", materializer, canonical, worker, path.dirname(worker), arch],
             {

--- a/test/scripts/mac-node-worker.test.ts
+++ b/test/scripts/mac-node-worker.test.ts
@@ -9,9 +9,10 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it as baseIt } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 import { registerMacWorkerMaterializationTests } from "./mac-node-worker-materialization.test-support.js";
+import { createMacScriptTest } from "./mac-script-fixture.test-support.js";
 
 registerMacWorkerMaterializationTests();
 
@@ -19,7 +20,7 @@ const temps = useAutoCleanupTempDirTracker(afterEach);
 const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
 
 describe("Mac app worker publication", () => {
-  it.each(["sign", "worker", "seal", "stage", "success"])(
+  baseIt.each(["sign", "worker", "seal", "stage", "success"])(
     "publishes only a verified replacement (%s)",
     (failure) => {
       const root = temps.make("openclaw-worker-publication-");
@@ -81,23 +82,25 @@ describe("Mac app worker publication", () => {
     },
   );
 
-  it("provisions packages without invoking the service owner or changing operator state", () => {
-    const root = temps.make("openclaw-worker-provision-");
-    const home = path.join(root, "home");
-    const prefix = path.join(root, "private");
-    const sentinel = path.join(root, "operator", ".openclaw", "state", "sentinel");
-    mkdirSync(path.dirname(sentinel), { recursive: true });
-    mkdirSync(home);
-    writeFileSync(sentinel, "operator-owned");
-    const nodeDir = path.join(prefix, "tools", "node-v24.19.0");
-    mkdirSync(path.join(nodeDir, "bin"), { recursive: true });
-    // Only npm/network is replaced. The real install_openclaw implementation
-    // must remain a provision-only seam even when a loaded Gateway is reported.
-    symlinkSync(process.execPath, path.join(nodeDir, "bin", "node"));
-    const npm = path.join(nodeDir, "bin", "npm");
-    writeFileSync(
-      npm,
-      `#!/bin/bash
+  baseIt(
+    "provisions packages without invoking the service owner or changing operator state",
+    () => {
+      const root = temps.make("openclaw-worker-provision-");
+      const home = path.join(root, "home");
+      const prefix = path.join(root, "private");
+      const sentinel = path.join(root, "operator", ".openclaw", "state", "sentinel");
+      mkdirSync(path.dirname(sentinel), { recursive: true });
+      mkdirSync(home);
+      writeFileSync(sentinel, "operator-owned");
+      const nodeDir = path.join(prefix, "tools", "node-v24.19.0");
+      mkdirSync(path.join(nodeDir, "bin"), { recursive: true });
+      // Only npm/network is replaced. The real install_openclaw implementation
+      // must remain a provision-only seam even when a loaded Gateway is reported.
+      symlinkSync(process.execPath, path.join(nodeDir, "bin", "node"));
+      const npm = path.join(nodeDir, "bin", "npm");
+      writeFileSync(
+        npm,
+        `#!/bin/bash
 case "$1" in
   --version) echo 11.15.0 ;;
   config) echo null ;;
@@ -108,14 +111,14 @@ case "$1" in
   *) exit 4 ;;
 esac
 `,
-    );
-    chmodSync(npm, 0o755);
-    const calls = path.join(root, "service-calls");
-    const result = spawnSync(
-      "/bin/bash",
-      [
-        "-c",
-        `
+      );
+      chmodSync(npm, 0o755);
+      const calls = path.join(root, "service-calls");
+      const result = spawnSync(
+        "/bin/bash",
+        [
+          "-c",
+          `
       set -euo pipefail
       source scripts/install-cli.sh
       PREFIX=${quote(prefix)}
@@ -125,23 +128,25 @@ esac
       install_openclaw
       test -f "$(node_dir)/lib/node_modules/openclaw/dist/entry.js"
     `,
-      ],
-      {
-        encoding: "utf8",
-        env: {
-          HOME: home,
-          PATH: `${path.join(nodeDir, "bin")}:/usr/bin:/bin`,
-          OPENCLAW_INSTALL_CLI_SH_NO_RUN: "1",
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            HOME: home,
+            PATH: `${path.join(nodeDir, "bin")}:/usr/bin:/bin`,
+            OPENCLAW_INSTALL_CLI_SH_NO_RUN: "1",
+          },
         },
-      },
-    );
-    expect(result.status, result.stderr).toBe(0);
-    expect(existsSync(calls)).toBe(false);
-    expect(readFileSync(sentinel, "utf8")).toBe("operator-owned");
-  });
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(existsSync(calls)).toBe(false);
+      expect(readFileSync(sentinel, "utf8")).toBe("operator-owned");
+    },
+  );
 });
 
 describe.runIf(process.platform === "darwin")("Mac worker portability inventory", () => {
+  const it = createMacScriptTest();
   it("audits supported thin and fat formats through real otool", async () => {
     const { auditMacWorkerPortability } =
       await import("../../scripts/lib/mac-worker-portability.mjs");
@@ -164,36 +169,37 @@ describe.runIf(process.platform === "darwin")("Mac worker portability inventory"
     expect(auditMacWorkerPortability(root, node)).toBe(7);
   });
 
-  it.each([
-    "Java",
-    "fat32 archive",
-    "fat64 archive",
-    "thin object",
-    "fat32 object",
-    "fat64 object",
-  ])("preserves %s resources without treating them as loadable images", async (kind) => {
-    const { auditMacWorkerPortability } =
-      await import("../../scripts/lib/mac-worker-portability.mjs");
-    const { machoFixture, nativeObjectFixture, universalArchiveFixture } =
-      await import("../helpers/mac-native.js");
-    const parent = temps.make("openclaw-portability-resource-");
-    const root = path.join(parent, "runtime");
-    mkdirSync(root);
-    const node = path.join(root, "node");
-    writeFileSync(node, machoFixture());
-    const filename = path.join(root, "opaque-resource");
-    const format = kind.startsWith("fat32") ? "fat32" : kind.startsWith("fat64") ? "fat64" : "thin";
-    const inputs = path.join(parent, "resource-inputs");
-    const bytes =
-      kind === "Java"
-        ? Buffer.from("cafebabe0000003d0001", "hex")
-        : kind.endsWith("archive")
-          ? universalArchiveFixture(inputs, format === "fat64", false)
-          : nativeObjectFixture(inputs, format);
-    writeFileSync(filename, bytes);
-    expect(auditMacWorkerPortability(root, node)).toBe(1);
-    expect(readFileSync(filename)).toEqual(bytes);
-  });
+  it.for(["Java", "fat32 archive", "fat64 archive", "thin object", "fat32 object", "fat64 object"])(
+    "preserves %s resources without treating them as loadable images",
+    (kind, { mac }) =>
+      mac.lifetime.run(async () => {
+        const { auditMacWorkerPortability } =
+          await import("../../scripts/lib/mac-worker-portability.mjs");
+        const { machoFixture, nativeObjectFixture, universalArchiveFixture } =
+          await import("../helpers/mac-native.js");
+        const parent = mac.createTempDir("openclaw-portability-resource-");
+        const root = path.join(parent, "runtime");
+        mkdirSync(root);
+        const node = path.join(root, "node");
+        writeFileSync(node, machoFixture());
+        const filename = path.join(root, "opaque-resource");
+        const format = kind.startsWith("fat32")
+          ? "fat32"
+          : kind.startsWith("fat64")
+            ? "fat64"
+            : "thin";
+        const inputs = path.join(parent, "resource-inputs");
+        const bytes =
+          kind === "Java"
+            ? Buffer.from("cafebabe0000003d0001", "hex")
+            : kind.endsWith("archive")
+              ? await universalArchiveFixture(inputs, format === "fat64", false, mac)
+              : await nativeObjectFixture(inputs, format, mac);
+        writeFileSync(filename, bytes);
+        expect(auditMacWorkerPortability(root, node)).toBe(1);
+        expect(readFileSync(filename)).toEqual(bytes);
+      }),
+  );
 
   it.each([false, true])(
     "binds captured symlink targets before publication (replacement: %s)",

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2162,6 +2162,7 @@ describe("scripts/test-projects changed-target routing", () => {
           "test/scripts/android-version.test.ts",
           "test/scripts/ci-git-prerequisites.test.ts",
           "test/scripts/ios-release-plan.test.ts",
+          "test/scripts/mac-native-fixtures.test.ts",
         ],
         watchMode: false,
       },


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where maintainers validating macOS app changes could see nondeterministic packaging-test timeouts and process-group cleanup failures when native fixture cases ran concurrently. These failures occurred before the artifact assertions and reproduced on the unchanged test owners at [the reported base](https://github.com/openclaw/openclaw/commit/494f86248e70c46d28d3f1e0e3273450458f9c26).

## Why This Change Was Made

Native preparation and recursive fixture deletion were synchronous on the same thread that supervised asynchronous verification commands. This change puts native preparation on the existing managed-command path and awaits filesystem preparation/deletion, retaining one complete single-flight compiled-fixture result and the existing whole-body lifetime owner. Signing, artifact, materialization, and portability callers use that ownership consistently.

The three-case concurrency limit, 20-second verifier deadlines, assertions, native tool execution, and fail-closed process-group checks are unchanged. No production packaging or verifier code changes.

## User Impact

No runtime or public API change. Developers retain concurrent, real-native-tool packaging coverage without the fixture thread starving child output, exit observation, deadlines, or cleanup.

Production LOC: **+0/-0**. Tests: **+420/-320**; test support: **+810/-669**. The test/support growth carries awaited ownership, complete prepared-state publication, and the regression proof; much of the diff is call-site migration and callback formatting.

## Evidence

### Root-cause reproduction and matched-runtime replay

Ran the complete 12-row resource acceptance table in original order on the reported base, retaining three concurrent cases and all deadlines. Buffered event-loop/command traces were paired with an independent macOS kqueue/libproc exit observer. Both before/after runs used Node 26.8.1 and Vitest 4.1.11; the fixed replay used the existing artifact-file split with the same table and assertions.

| Observation | Before | Fixed fixture owners |
| --- | ---: | ---: |
| Resource cases | 11 failed / 1 passed | 12 passed |
| Maximum concurrent cases | 3 | 3 |
| Maximum event-loop delay | 35,030.83 ms | 60.49 ms |
| Maximum Node exit-observation lag | 32.44 s | 5.44 ms |
| Timeout results | 9 | 0 |
| Cleanup failures | 2 | 0 |

The baseline also included a genuine native execution overrun with a promptly serviced deadline. This patch does not accept late success or reinterpret every historical timeout as delayed observation. The fixed table completed within the unchanged deadlines. Timings are observations on a loaded host, not an idle-host performance guarantee. Instrumentation remains local-only.

### Regression and sibling proof

- New parent/child socket-handshake regression fails on the original synchronous helper with child exit 73 (`parent could not service fixture handshake`) and passes with the managed asynchronous helper.
- Handshake plus existing fixture-lifetime regressions: **10 passed**.
- Full artifact suite before the failed-flight follow-up: **173 passed**, including the resource table and policy rejection paths. The added failure probe brings the final suite to 174 cases.
- Full worker materialization/portability file: **112 passed** after correcting a migration-time fixture-registration mistake.
- macOS Node coverage: part 1 passed **152** tests; part 2's other seven files passed, with the complete worker-file rerun supplying passing coverage for its corrected cases; part 3 passed **354** tests across seven shards.
- Final root test typecheck, changed-file type-aware lint, script lint, formatting, and `git diff --check` passed. The original aggregate changed-check run caught the fixture-registration mistake; its failed log is retained rather than relabeled as a successful command.

The [initial CI run's routing job](https://github.com/openclaw/openclaw/actions/runs/33549774831/job/99996347275) exposed a stale strict expectation: the new handshake regression correctly joins the isolated-fast partition, whose expected file list still contained only the previous three tests. The follow-up adds that fourth file without changing classification or weakening the assertion. Routing, isolated-config, and handshake validation then passed **416 tests**.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/test-projects.test.ts test/vitest-unit-fast-config.test.ts test/scripts/mac-native-fixtures.test.ts --reporter=verbose
```

### Review follow-up: failed-flight ownership

[ClawSweeper's late finding](https://github.com/openclaw/openclaw/pull/135501#issuecomment-5499387899) identified a rejected single-flight promise being retained for later fixture users. [The follow-up repair](https://github.com/openclaw/openclaw/commit/a1cb24815d34b624a25ef9e55750e84233b1a1c3) clears only the current failed flight. Successful preparation stays cached, current borrowers still receive the original rejection, and a later independent fixture can own fresh preparation. There is no automatic retry of the failed operation.

The regression injects one failed native tool result for simultaneous binary/object borrowers, immediately followed by the existing real-artifact case in a new fixture lifetime. Before the repair, the failure probe passed and that real-artifact case failed immediately on the cached injected error. After the repair, **both cases passed**, including real compilation and archive verification. Existing artifact cases remain concurrent.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/mac-elevation-artifact.test.ts -t 'rejects all borrowers of a failed native preparation|accepts a real archive' --reporter=verbose
```

Validation caveat: the local follow-up initially encountered missing installed Matrix/Slack declarations; a frozen-lockfile install restored them. Root types and script lint then passed. The broader native run subsequently hit unchanged command/test deadlines, including a signing case before the new cache probe ran. That owned run was stopped and its failing log retained; it is not counted as a passing aggregate. The cache-fix head subsequently passed **531 tests** in [native macOS CI](https://github.com/openclaw/openclaw/actions/runs/33569966289/job/100061724972), including the failed-flight probe immediately followed by successful real-archive preparation.

### Final landing refresh

The remaining failure in that CI run was a sidebar test selecting the catalog heading instead of the session label. Its tested merge used main `fd78d6a9bfcdfe9b287c954a490a5772ab542c3a`; [the canonical correction](https://github.com/openclaw/openclaw/commit/013fe714f23a87facde9b3877051e501247ecbd3) landed immediately afterward. This PR was rebased onto main containing that correction rather than adding a duplicate UI patch. `git range-diff` verified all three fixture commits remain patch-identical.

On refreshed head `8af94868e45637abfe0fd1564b18110b57a6abb9`, **767 tests passed across six files**, covering the complete sidebar/marquee suites, routing and isolated configuration, the handshake regression, and fixture lifetime. The previously failing sidebar and strict routing assertions passed unchanged except for the canonical main-side selector repair. A fresh full-PR Codex autoreview was scoped-clean at its default P0 threshold; no accepted/actionable findings. The final exact-head [CI run](https://github.com/openclaw/openclaw/actions/runs/33573717363) is **green**, including all three macOS shards and the corrected UI/routing gates. The final [macOS part 2 job](https://github.com/openclaw/openclaw/actions/runs/33573717363/job/100073255692) passed **551 tests**, including the ordered failed-flight/recovery pair. This completes the latest ClawSweeper review's sole rank-up move: green exact-head routing and macOS coverage.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts ui/src/lib/hover-marquee.test.ts test/scripts/test-projects.test.ts test/vitest-unit-fast-config.test.ts test/scripts/mac-native-fixtures.test.ts test/scripts/fixture-lifetime.test.ts --reporter=verbose
```

Representative commands:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/mac-native-fixtures.test.ts test/scripts/fixture-lifetime.test.ts --reporter=verbose
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/mac-elevation-artifact.test.ts -t "accepts '(thin|fat32|fat64)' '(object|synthetic-core|synthetic-dylib-stub|synthetic-dsym)' resources without changing bytes or modes$" --reporter=verbose
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/mac-node-worker.test.ts --reporter=verbose
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test:macos:ci:3
```

```bash
pnpm tsgo:test:root
```

This is test-only work: no app launch, signing, live Keychain/service operation, or UI capture was needed. A separate pre-existing follow-up tracks the outer Vitest namespace not consuming inner fixture-retention state; this change preserves the inner fail-closed behavior rather than masking that separate ownership gap.


