### PR TITLE
perf: resolve web fetch providers once in their owner

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3795,7 +3795,7 @@ src/utils/usage-format.ts	1
 src/version.ts	5
 src/video-generation/capability-overlays.ts	1
 src/video-generation/runtime.ts	1
-src/web-fetch/runtime.ts	6
+src/web-fetch/runtime.ts	3
 src/web-search/runtime-execution.ts	1
 src/web-search/runtime.ts	3
 src/web/provider-runtime-shared.ts	1

--- a/src/web-fetch/runtime.test.ts
+++ b/src/web-fetch/runtime.test.ts
@@ -58,13 +58,16 @@ function createFirecrawlProvider(
   });
 }
 
-function createThirdPartyFetchProvider(): PluginWebFetchProviderEntry {
+function createThirdPartyFetchProvider(
+  overrides: Partial<WebFetchTestProviderParams> = {},
+): PluginWebFetchProviderEntry {
   return createWebFetchTestProvider({
     pluginId: "third-party-fetch",
     id: "thirdparty",
     credentialPath: "plugins.entries.third-party-fetch.config.webFetch.apiKey",
     autoDetectOrder: 0,
     getConfiguredCredentialValue: () => "runtime-key",
+    ...overrides,
   });
 }
 
@@ -142,6 +145,11 @@ describe("web fetch runtime", () => {
   });
 
   it("prefers the runtime-selected provider when metadata is available", async () => {
+    const unrelated = createThirdPartyFetchProvider({
+      getConfiguredCredentialValue: () => {
+        throw new Error("selected provider resolution probed unrelated credentials");
+      },
+    });
     const provider = createFirecrawlProvider({
       createTool: ({ runtimeMetadata }) => ({
         description: "firecrawl",
@@ -152,8 +160,8 @@ describe("web fetch runtime", () => {
         }),
       }),
     });
-    resolvePluginWebFetchProvidersMock.mockReturnValue([provider]);
-    resolveRuntimeWebFetchProvidersMock.mockReturnValue([provider]);
+    resolvePluginWebFetchProvidersMock.mockReturnValue([unrelated, provider]);
+    resolveRuntimeWebFetchProvidersMock.mockReturnValue([unrelated, provider]);
 
     const runtimeWebFetch: RuntimeWebFetchMetadata = {
       providerSource: "auto-detect",

--- a/src/web-fetch/runtime.ts
+++ b/src/web-fetch/runtime.ts
@@ -20,7 +20,6 @@ import {
   providerRequiresCredential,
   readWebProviderEnvValue,
   resolveWebProviderConfig,
-  resolveWebProviderDefinition,
 } from "../web/provider-runtime-shared.js";
 
 // Runtime provider selection for the web_fetch tool. It resolves config,
@@ -131,31 +130,18 @@ export function listWebFetchProviders(params?: {
   });
 }
 
-/** Resolves the configured or auto-detected web_fetch provider id. */
-function resolveWebFetchProviderId(params: {
+/** Auto-detects a web_fetch provider after explicit selections have been resolved. */
+function resolveAutoWebFetchProviderId(params: {
   fetch?: WebFetchConfig;
   config?: OpenClawConfig;
-  providers?: PluginWebFetchProviderEntry[];
+  providers: PluginWebFetchProviderEntry[];
 }): string {
-  const providers = sortWebFetchProvidersForAutoDetect(
-    params.providers ??
-      resolvePluginWebFetchProviders({
-        config: params.config,
-      }),
-  );
   const raw =
     params.fetch && "provider" in params.fetch
       ? normalizeLowercaseStringOrEmpty(params.fetch.provider)
       : "";
 
-  if (raw) {
-    const explicit = providers.find((provider) => provider.id === raw);
-    if (explicit) {
-      return explicit.id;
-    }
-  }
-
-  for (const provider of providers) {
+  for (const provider of params.providers) {
     if (!providerRequiresCredential(provider)) {
       if (!hasAutoDetectCredential(provider, params.config, params.fetch)) {
         continue;
@@ -262,43 +248,29 @@ function resolveWebFetchProvidersForOptions(
 export function resolveWebFetchDefinition(
   options?: ResolveWebFetchDefinitionParams,
 ): WebFetchDefinitionResolution {
-  const fetch = resolveWebProviderConfig(options?.config, "fetch") as
-    | NonNullable<WebFetchConfig>
-    | undefined;
+  const fetch = resolveFetchConfig(options?.config);
   if (!resolveWebFetchEnabled({ fetch, sandboxed: options?.sandboxed })) {
     return null;
   }
   const runtimeWebFetch =
     options?.runtimeWebFetch ?? getActiveRuntimeWebToolsMetadataFromState()?.fetch;
   const providers = resolveWebFetchProvidersForOptions(options);
-  return resolveWebProviderDefinition({
+  if (providers.length === 0) {
+    return null;
+  }
+  const providerId =
+    options?.providerId ??
+    resolveConfiguredWebFetchProviderId({ fetch, providers }) ??
+    runtimeWebFetch?.selectedProvider ??
+    resolveAutoWebFetchProviderId({ config: options?.config, fetch, providers });
+  const provider = providers.find((entry) => entry.id === providerId);
+  if (!provider) {
+    return null;
+  }
+  const definition = provider.createTool({
     config: options?.config,
-    toolConfig: fetch as Record<string, unknown> | undefined,
+    fetchConfig: fetch as Record<string, unknown> | undefined,
     runtimeMetadata: runtimeWebFetch,
-    sandboxed: options?.sandboxed,
-    providerId:
-      options?.providerId ??
-      resolveConfiguredWebFetchProviderId({
-        fetch,
-        providers,
-      }),
-    providers,
-    resolveEnabled: ({ toolConfig, sandboxed }) =>
-      resolveWebFetchEnabled({
-        fetch: toolConfig as WebFetchConfig | undefined,
-        sandboxed,
-      }),
-    resolveAutoProviderId: ({ config, toolConfig, providers: providersLocal }) =>
-      resolveWebFetchProviderId({
-        config,
-        fetch: toolConfig as WebFetchConfig | undefined,
-        providers: providersLocal,
-      }),
-    createTool: ({ provider, config, toolConfig, runtimeMetadata }) =>
-      provider.createTool({
-        config,
-        fetchConfig: toolConfig,
-        runtimeMetadata,
-      }),
   });
+  return definition ? { provider, definition } : null;
 }

--- a/src/web/provider-runtime-shared.test.ts
+++ b/src/web/provider-runtime-shared.test.ts
@@ -1,10 +1,9 @@
-// Web provider runtime tests cover shared config, credential, and definition resolution.
+// Web provider runtime tests cover shared config and credential resolution.
 import { describe, expect, it } from "vitest";
 import {
   hasWebProviderEntryCredential,
   readWebProviderEnvValue,
   resolveWebProviderConfig,
-  resolveWebProviderDefinition,
 } from "./provider-runtime-shared.js";
 
 describe("resolveWebProviderConfig", () => {
@@ -147,34 +146,5 @@ describe("hasWebProviderEntryCredential", () => {
         resolveProviderAuthValue: (providerId) => providerId === "custom-auth",
       }),
     ).toBe(true);
-  });
-});
-
-describe("resolveWebProviderDefinition", () => {
-  it("falls back to auto-detect when runtime metadata has no selected provider", () => {
-    const resolved = resolveWebProviderDefinition({
-      config: {},
-      toolConfig: { enabled: true },
-      runtimeMetadata: {},
-      providers: [
-        {
-          id: "custom",
-        },
-      ],
-      resolveEnabled: () => true,
-      resolveAutoProviderId: () => "custom",
-      createTool: ({ provider }) => ({
-        name: provider.id,
-      }),
-    });
-
-    expect(resolved).toEqual({
-      provider: {
-        id: "custom",
-      },
-      definition: {
-        name: "custom",
-      },
-    });
   });
 });

--- a/src/web/provider-runtime-shared.ts
+++ b/src/web/provider-runtime-shared.ts
@@ -1,4 +1,4 @@
-// Shared web provider config, credential, and definition resolution.
+// Shared web provider config and credential resolution.
 import {
   coerceSecretRef,
   isLegacySecretRefEnvMarker,
@@ -12,11 +12,6 @@ type WebProviderConfigSource = {
       fetch?: unknown;
     };
   };
-};
-
-type RuntimeWebProviderMetadata = {
-  providerConfigured?: string;
-  selectedProvider?: string;
 };
 
 type ProviderWithCredential = {
@@ -166,80 +161,4 @@ export function hasWebProviderEntryCredential<
         })
       : undefined,
   );
-}
-
-export function resolveWebProviderDefinition<
-  TProvider extends { id: string },
-  TConfigSource extends WebProviderConfigSource,
-  TConfig extends Record<string, unknown> | undefined,
-  TRuntimeMetadata extends RuntimeWebProviderMetadata,
-  TDefinition,
->(params: {
-  config: TConfigSource | undefined;
-  toolConfig: TConfig;
-  runtimeMetadata: TRuntimeMetadata | undefined;
-  sandboxed?: boolean;
-  providerId?: string;
-  providers: TProvider[];
-  resolveEnabled: (params: { toolConfig: TConfig; sandboxed?: boolean }) => boolean;
-  resolveAutoProviderId: (params: {
-    config: TConfigSource | undefined;
-    toolConfig: TConfig;
-    providers: TProvider[];
-  }) => string;
-  resolveFallbackProviderId?: (params: {
-    config: TConfigSource | undefined;
-    toolConfig: TConfig;
-    providers: TProvider[];
-    providerId: string;
-  }) => string | undefined;
-  createTool: (params: {
-    provider: TProvider;
-    config: TConfigSource | undefined;
-    toolConfig: TConfig;
-    runtimeMetadata: TRuntimeMetadata | undefined;
-  }) => TDefinition | null;
-}): { provider: TProvider; definition: TDefinition } | null {
-  if (!params.resolveEnabled({ toolConfig: params.toolConfig, sandboxed: params.sandboxed })) {
-    return null;
-  }
-  const providers = params.providers.filter(Boolean);
-  if (providers.length === 0) {
-    return null;
-  }
-  const autoProviderId = params.resolveAutoProviderId({
-    config: params.config,
-    toolConfig: params.toolConfig,
-    providers,
-  });
-  const providerId =
-    params.providerId ?? params.runtimeMetadata?.selectedProvider ?? autoProviderId;
-  if (!providerId) {
-    return null;
-  }
-  const provider =
-    providers.find((entry) => entry.id === providerId) ??
-    providers.find(
-      (entry) =>
-        entry.id ===
-        params.resolveFallbackProviderId?.({
-          config: params.config,
-          toolConfig: params.toolConfig,
-          providers,
-          providerId,
-        }),
-    );
-  if (!provider) {
-    return null;
-  }
-  const definition = params.createTool({
-    provider,
-    config: params.config,
-    toolConfig: params.toolConfig,
-    runtimeMetadata: params.runtimeMetadata,
-  });
-  if (!definition) {
-    return null;
-  }
-  return { provider, definition };
 }


### PR DESCRIPTION
## What Problem This Solves

Web fetch performed credential discovery for unrelated providers even after a provider had already been selected. Besides doing discarded work, an unrelated credential callback could prevent the selected provider from running.

Production LOC: +21/-130 (net -109) | Tests: +12/-34 (net -22).

## Why This Change Was Made

Resolve the provider and construct its tool in the web-fetch owner. Explicit selection, valid configured selection and prepared runtime metadata take precedence; credential auto-detection runs only when needed. Delete the former shared definition adapter, its unused fallback hook and its helper-only test. Web search already owns its separate multi-provider execution flow and retains the shared credential/config helpers.

The provider inventory is prepared and sorted once. Empty and unknown explicit selections, invalid configured IDs, keyless providers, sandbox filtering, cache invalidation and construction context retain their existing behavior. No configuration, SDK, dependency, protocol or persistence surface changes.

## User Impact

Selected web-fetch providers avoid unrelated credential lookups and repeated sorting. The same provider returns the same bounded result. This reduces repeated work and removes an unnecessary abstraction; it is not a claim of lower network latency or measured whole-Gateway RSS.

## Evidence

The strengthened runtime regression fails on baseline when an unrelated credential getter throws, then passes with the selected provider's real tool result after the change. All 81 focused repository tests pass across fetch selection, shared credentials, fetch cache/cancellation and the search sibling. Production/test type checking, typed lint, formatting, a full build, independent full-owner review and isolated Codex autoreview pass.

The final complete-owner differential preserves provider choice and exact construction context in 15 cases. In a deliberately amplified 32-provider, 10,000-resolution workload, runtime-selected credential callbacks fall from 320,000 to zero and repeated sorting from 10,000 to zero; automatic selection retains its credential checks. These are owner-operation counts, not product timing or memory measurements.

A built development Gateway ran real OpenAI turns and web tools in separate isolated sessions. With Readability disabled through the existing task configuration, the actual Firecrawl fallback returned HTTP 200 for example.com, with `externalContent.provider` and extractor both `firecrawl`. The ordinary path returned HTTP 200 with the `readability` extractor and no provider marker. Both runs verified the page title/body, one successful nested web fetch followed by one local read in the same Code Mode call, matching durable call/result IDs, the final reply and Gateway exit 0. The first direct-path proof assertion incorrectly expected the page title to repeat in the body; correcting that artifact-only assertion to check the separate title field and body produced a clean repeat. Runtime behavior was already correct.

Related: #103113 tracks recovery from stale automatic-provider metadata. This change preserves current missing-provider behavior; that separate recovery policy remains with the existing PR.
