### PR TITLE
fix(channels): preserve selected agent during plugin discovery

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2309,7 +2309,7 @@ src/cli/capability-cli/video.ts	7
 src/cli/capability-cli/web.ts	6
 src/cli/channel-auth.ts	4
 src/cli/channel-options.ts	1
-src/cli/channels-cli.ts	7
+src/cli/channels-cli.ts	5
 src/cli/claws-cli.gateway-readiness.ts	1
 src/cli/claws-cli.runtime.ts	2
 src/cli/command-config-resolution.ts	2

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -50,7 +50,7 @@ does not create account routing bindings; guided setup asks about routing separa
 ## Status / capabilities / resolve / logs
 
 - `channels status`: `--channel <name>`, `--probe`, `--timeout <ms>` (default `10000`), `--json`
-- `channels capabilities`: `--channel <name>`, `--account <id>` (requires `--channel`), `--target <dest>` (requires `--channel`), `--timeout <ms>` (default `10000`, capped at `30000`), `--json`
+- `channels capabilities`: `--channel <name>`, `--agent <id>`, `--account <id>` (requires `--channel`), `--target <dest>` (requires `--channel`), `--timeout <ms>` (default `10000`, capped at `30000`), `--json`
 - `channels resolve <entries...>`: `--channel <name>`, `--account <id>`, `--agent <id>`, `--kind <auto|user|group|channel>` (default `auto`), `--json`
 - `channels logs`: `--channel <name|all>` (default `all`), `--lines <n>` (default `200`), `--json`
 

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -40,6 +40,13 @@ In an explicit multi-agent setup, workspace-scoped channel plugins come from
 returns the shared bundled, managed, and global inventory with a diagnostic;
 it does not guess one agent workspace.
 
+For `add`, `login`, `logout`, `remove`, and `resolve`, or `capabilities --channel`,
+use `--agent <id>` to select the workspace used for channel plugin discovery.
+The option works before or after the subcommand; a subcommand value takes precedence.
+Without it, discovery uses the configured System Agent or the existing sole/legacy owner.
+An explicit fleet with no such owner requires `--agent`. Selecting a workspace
+does not create account routing bindings; guided setup asks about routing separately.
+
 ## Status / capabilities / resolve / logs
 
 - `channels status`: `--channel <name>`, `--probe`, `--timeout <ms>` (default `10000`), `--json`
@@ -118,7 +125,7 @@ See [CLI automation](/start/wizard-cli-automation) for additional non-interactiv
 `channels remove` only operates on installed/configured channel plugins. Use `channels add` first for installable catalog channels. Without `--delete` it asks to disable the account and keeps its config; `--delete` removes the config entries without prompting.
 For runtime-backed channel plugins, `channels remove` also asks the running Gateway to stop the selected account before it updates config, so disabling or deleting an account does not leave the old listener active until restart.
 
-The shared control envelope contains only `--channel`, `--account`, and the optional account display `--name`. Each modern channel plugin owns its credential, transport, and provider-specific semantics. Once a channel is selected by positional id or `--channel <id>`, the CLI builds only that channel's options from bundled or installed plugin package metadata without loading channel runtime code.
+The shared control envelope contains `--agent`, `--channel`, `--account`, and the optional account display `--name`. Each modern channel plugin owns its credential, transport, and provider-specific semantics. Once a channel is selected by positional id or `--channel <id>`, the CLI builds only that channel's options from bundled or installed plugin package metadata without loading channel runtime code.
 
 Common-looking flags such as `--token`, `--url`, or `--use-env` are still channel-owned when a modern contract handles them. When a selected third-party plugin still uses the legacy shared setup adapter, core registers the released compatibility flag set for that channel only, alongside its legacy `cliAddOptions`. Unrelated legacy fields do not leak into other channels, and a modern selected channel rejects compatibility flags it did not declare.
 
@@ -176,7 +183,7 @@ openclaw channels login --channel whatsapp
 openclaw channels logout --channel whatsapp
 ```
 
-- `channels login` supports `--account <id>` and `--verbose`; `channels logout` supports `--account <id>`.
+- `channels login` supports `--agent <id>`, `--account <id>`, and `--verbose`; `channels logout` supports `--agent <id>` and `--account <id>`.
 - `channels login` and `logout` can infer the channel when only one configured channel supports that action; with several, pass `--channel`.
 - `channels logout` prefers the live Gateway path when reachable, so logout stops any active listener before clearing channel auth state. If a local Gateway is not reachable, it falls back to local auth cleanup; with `gateway.mode: "remote"` the gateway error fails the command instead.
 - Logout reports whether the plugin cleared saved auth. If the plugin reports that the account is not logged out, the CLI warns that other credentials may still be active; this is not a claim that provider-side tokens were revoked.

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -252,16 +252,24 @@ export function resolveAmbientOwnerAgentId(
   return tryResolveAmbientOwnerAgentId(cfg, requestedAgentId) ?? resolveSoleAgentId(cfg, context);
 }
 
-/** Resolves a CLI operation owner while preserving legacy default markers outside explicit fleets. */
+/** Returns a CLI operation owner while preserving legacy defaults outside explicit fleets. */
+export function tryResolveAgentOperationAgentId(
+  cfg: OpenClawConfig,
+  requestedAgentId?: string,
+): string | undefined {
+  if (requestedAgentId !== undefined || cfg.agents?.ownership === "explicit") {
+    return tryResolveAmbientOwnerAgentId(cfg, requestedAgentId);
+  }
+  return tryResolveLegacyCompatibilityAgentId(cfg);
+}
+
+/** Resolves a CLI operation owner, requiring selection when no owner is configured. */
 export function resolveAgentOperationAgentId(
   cfg: OpenClawConfig,
   requestedAgentId?: string,
   context?: AgentSelectionContext,
 ): string {
-  if (requestedAgentId !== undefined || cfg.agents?.ownership === "explicit") {
-    return resolveAmbientOwnerAgentId(cfg, requestedAgentId, context);
-  }
-  return tryResolveLegacyCompatibilityAgentId(cfg) ?? resolveDefaultAgentId(cfg, context);
+  return tryResolveAgentOperationAgentId(cfg, requestedAgentId) ?? resolveSoleAgentId(cfg, context);
 }
 
 /**

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -31,7 +31,7 @@ import { isRecord, resolveConfigDir, resolveUserPath } from "../../utils.js";
 import { buildManifestChannelMeta } from "./channel-meta.js";
 import type { ChannelMeta } from "./types.public.js";
 
-export type ChannelUiMetaEntry = {
+type ChannelUiMetaEntry = {
   id: string;
   label: string;
   detailLabel: string;
@@ -47,7 +47,7 @@ export type ChannelUiCatalog = {
   byId: Record<string, ChannelUiMetaEntry>;
 };
 
-export type ChannelPluginCatalogInstall = PluginPackageInstall &
+type ChannelPluginCatalogInstall = PluginPackageInstall &
   ({ clawhubSpec: string } | { npmSpec: string });
 
 export type ChannelPluginCatalogEntry = {

--- a/src/cli/channel-auth.owner.integration.test.ts
+++ b/src/cli/channel-auth.owner.integration.test.ts
@@ -1,0 +1,211 @@
+// Exercise Commander, auth dispatch, and actual owner resolution with local I/O seams.
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPluginCatalogEntry } from "../channels/plugins/catalog.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { registerChannelsCli } from "./channels-cli.js";
+
+const fixture = vi.hoisted(() => ({
+  config: {} as OpenClawConfig,
+  registered: true,
+  login: vi.fn(),
+  logout: vi.fn(async () => ({ cleared: false })),
+  catalog: vi.fn<(...args: unknown[]) => ChannelPluginCatalogEntry[]>(() => []),
+  loadScoped: vi.fn(),
+  runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+}));
+
+vi.mock("../config/config.js", () => ({ getRuntimeConfig: () => fixture.config }));
+vi.mock("../commands/config-validation.js", () => ({
+  requireValidConfigFileSnapshot: async () => ({ sourceConfig: fixture.config, hash: "fixture" }),
+}));
+vi.mock("../config/plugin-auto-enable.js", () => ({
+  applyPluginAutoEnable: ({ config }: { config: OpenClawConfig }) => ({ config, changes: [] }),
+}));
+vi.mock("../channels/plugins/catalog.js", () => ({
+  listRawChannelPluginCatalogEntries: fixture.catalog,
+  getChannelPluginCatalogEntry: () => undefined,
+}));
+vi.mock("../channels/plugins/index.js", () => ({
+  normalizeChannelId: (id: string) => id,
+  getLoadedChannelPlugin: () => (fixture.registered ? plugin : undefined),
+  listChannelPlugins: () => [plugin],
+}));
+vi.mock("../commands/channel-setup/plugin-install.js", () => ({
+  loadChannelSetupPluginRegistrySnapshotForChannel: fixture.loadScoped,
+  ensureChannelSetupPluginInstalled: vi.fn(),
+}));
+vi.mock("../gateway/call.js", () => ({
+  callGateway: async () => {
+    throw new Error("isolated fixture has no Gateway");
+  },
+}));
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: fixture.runtime,
+  ExitError: class extends Error {},
+}));
+
+const plugin = {
+  id: "fixture-chat",
+  auth: { login: fixture.login },
+  gateway: { logoutAccount: fixture.logout },
+  config: {
+    listAccountIds: () => ["work"],
+    resolveAccount: () => ({ accountId: "work" }),
+  },
+};
+
+async function runAuth(mode: string, parent: string[] = [], leaf: string[] = []) {
+  const args = ["channels", ...parent, mode, ...leaf, "--channel", plugin.id, "--account", "work"];
+  const program = new Command()
+    .name("openclaw")
+    .enablePositionalOptions()
+    .exitOverride()
+    .configureOutput({ writeErr: () => undefined });
+  await registerChannelsCli(program, ["node", "openclaw", ...args]);
+  await program.parseAsync(args, { from: "user" });
+}
+
+describe.each(["login", "logout"])("channels %s owner", (mode) => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fixture.registered = true;
+    fixture.config = {
+      agents: {
+        ownership: "explicit",
+        entries: {
+          research: { workspace: "/tmp/research-workspace" },
+          ops: { workspace: "/tmp/ops-workspace" },
+        },
+      },
+    };
+    fixture.catalog.mockReturnValue([
+      {
+        id: plugin.id,
+        pluginId: plugin.id,
+        origin: "bundled",
+        meta: {
+          id: plugin.id,
+          label: "Fixture",
+          selectionLabel: "Fixture",
+          docsPath: "",
+          blurb: "",
+        },
+        install: { npmSpec: "fixture-chat" },
+      },
+    ]);
+    fixture.loadScoped.mockReturnValue({ channels: [{ plugin }], channelSetups: [] });
+  });
+
+  it.each([
+    { name: "parent", parent: ["--agent", "ops"], leaf: [], owner: "ops" },
+    { name: "leaf", parent: [], leaf: ["--agent", "ops"], owner: "ops" },
+    {
+      name: "leaf overrides parent",
+      parent: ["--agent", "research"],
+      leaf: ["--agent", "ops"],
+      owner: "ops",
+    },
+    { name: "System Agent", parent: [], leaf: [], owner: "research" },
+    { name: "trimmed explicit", parent: ["--agent", " ops "], leaf: [], owner: "ops" },
+    { name: "explicit before System Agent", parent: ["--agent", "ops"], leaf: [], owner: "ops" },
+  ])("retains the $name owner through plugin discovery", async ({ parent, leaf, owner, name }) => {
+    if (name === "System Agent") {
+      fixture.config.agents!.defaults = { systemAgent: { agentId: "research" } };
+    } else if (name === "explicit before System Agent") {
+      fixture.config.agents!.defaults = { systemAgent: { agentId: "???" } };
+    }
+    fixture.registered = false;
+
+    await runAuth(mode, parent, leaf);
+
+    expect(fixture.runtime.error).not.toHaveBeenCalled();
+    expect(fixture.loadScoped).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: `/tmp/${owner}-workspace` }),
+    );
+    expect(mode === "login" ? fixture.login : fixture.logout).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: "work" }),
+    );
+  });
+
+  it("does not require discovery to reload an already registered plugin", async () => {
+    await runAuth(mode, ["--agent", "ops"]);
+
+    expect(fixture.runtime.error).not.toHaveBeenCalled();
+    expect(fixture.catalog).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: "/tmp/ops-workspace" }),
+    );
+    expect(fixture.loadScoped).not.toHaveBeenCalled();
+    expect(mode === "login" ? fixture.login : fixture.logout).toHaveBeenCalled();
+  });
+
+  it("keeps an ownerless fleet from reaching either auth action", async () => {
+    await runAuth(mode);
+
+    expect(fixture.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("no explicit owner"),
+    );
+    expect(fixture.runtime.exit).toHaveBeenCalledWith(1);
+    expect(fixture.catalog).not.toHaveBeenCalled();
+    expect(fixture.login).not.toHaveBeenCalled();
+    expect(fixture.logout).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { agent: "missing", error: 'Unknown agent id "missing"' },
+    { agent: " ", error: "--agent must not be blank" },
+  ])("rejects invalid explicit agent '$agent' before discovery", async ({ agent, error }) => {
+    fixture.config.agents!.defaults = { systemAgent: { agentId: "research" } };
+
+    await runAuth(mode, ["--agent", agent]);
+
+    expect(fixture.runtime.error).toHaveBeenCalledWith(expect.stringContaining(error));
+    expect(fixture.catalog).not.toHaveBeenCalled();
+    expect(fixture.login).not.toHaveBeenCalled();
+    expect(fixture.logout).not.toHaveBeenCalled();
+  });
+
+  it("rejects a stale configured System Agent before discovery", async () => {
+    fixture.config.agents!.defaults = { systemAgent: { agentId: "missing" } };
+
+    await runAuth(mode);
+
+    expect(fixture.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown agent id "missing"'),
+    );
+    expect(fixture.catalog).not.toHaveBeenCalled();
+  });
+
+  it.each(["???", "OPS"])(
+    "rejects explicit owner %s instead of normalizing it into another agent",
+    async (agent) => {
+      fixture.config.agents!.entries = {
+        main: { workspace: "/tmp/main-workspace" },
+        ops: { workspace: "/tmp/ops-workspace" },
+      };
+      await runAuth(mode, ["--agent", agent]);
+
+      expect(fixture.runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining(`Unknown agent id "${agent}"`),
+      );
+      expect(fixture.runtime.exit).toHaveBeenCalledWith(1);
+      expect(fixture.catalog).not.toHaveBeenCalled();
+      expect(fixture.login).not.toHaveBeenCalled();
+      expect(fixture.logout).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps the legacy owner when the configured System Agent is unused", async () => {
+    fixture.config.agents!.ownership = undefined;
+    fixture.config.agents!.entries!.research!.default = true;
+    fixture.config.agents!.defaults = { systemAgent: { agentId: "???" } };
+
+    await runAuth(mode);
+
+    expect(fixture.runtime.error).not.toHaveBeenCalled();
+    expect(fixture.catalog).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: "/tmp/research-workspace" }),
+    );
+    expect(mode === "login" ? fixture.login : fixture.logout).toHaveBeenCalled();
+  });
+});

--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -7,7 +7,6 @@ import { runChannelLogin, runChannelLogout } from "./channel-auth.js";
 
 const mocks = vi.hoisted(() => ({
   resolveAgentWorkspaceDir: vi.fn(),
-  resolveDefaultAgentId: vi.fn(),
   getChannelPluginCatalogEntry: vi.fn(),
   listChannelPluginCatalogEntries: vi.fn(),
   resolveChannelDefaultAccountId: vi.fn(),
@@ -31,7 +30,6 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../agents/agent-scope.js", () => ({
   resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
-  resolveDefaultAgentId: mocks.resolveDefaultAgentId,
 }));
 
 vi.mock("../channels/plugins/catalog.js", () => ({
@@ -193,7 +191,6 @@ describe("channel-auth", () => {
     );
     mocks.callGateway.mockResolvedValue({ cleared: true, loggedOut: true });
     mocks.listChannelPlugins.mockReturnValue([plugin]);
-    mocks.resolveDefaultAgentId.mockReturnValue("main");
     mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/workspace");
     mocks.resolveChannelDefaultAccountId.mockReturnValue("default-account");
     mocks.createClackPrompter.mockReturnValue({} as object);

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -24,6 +24,7 @@ import { formatCliCommand } from "./command-format.js";
 import { formatUnsupportedChannelActionMessage } from "./error-format.js";
 
 type ChannelAuthOptions = {
+  agent?: string;
   channel?: string;
   account?: string;
   verbose?: boolean;
@@ -116,6 +117,7 @@ async function resolveChannelPluginForMode(
   const resolved = await resolveInstallableChannelPlugin({
     cfg,
     runtime,
+    agentId: opts.agent,
     rawChannel: channelInput,
     ...(normalizedChannelId ? { channelId: normalizedChannelId } : {}),
     allowInstall: true,

--- a/src/cli/channels-cli-add-args.ts
+++ b/src/cli/channels-cli-add-args.ts
@@ -1,4 +1,5 @@
 import { Option, type Command } from "commander";
+import { getCommandArgsWithRootOptions } from "../infra/cli-root-options.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeWindowsArgv } from "./windows-argv.js";
 
@@ -13,8 +14,10 @@ export type ChannelSetupCliOption = {
 };
 
 const CHANNEL_ADD_SHARED_BOOLEAN_OPTIONS = new Set(["--help", "-h"]);
-const CHANNEL_ADD_SHARED_VALUE_OPTIONS = new Set(["--channel", "--account", "--name"]);
-const CHANNEL_ADD_SHARED_VALUE_OPTION_PREFIXES = ["--channel=", "--account=", "--name="];
+const CHANNEL_ADD_SHARED_VALUE_OPTIONS = new Set(["--agent", "--channel", "--account", "--name"]);
+const CHANNEL_ADD_SHARED_VALUE_OPTION_PREFIXES = [...CHANNEL_ADD_SHARED_VALUE_OPTIONS].map(
+  (flag) => `${flag}=`,
+);
 
 const channelSetupCliOptionsLoader = createLazyImportLoader<ChannelSetupCliOptionsModule>(
   () => import("../channels/plugins/cli-add-options.js"),
@@ -59,13 +62,14 @@ export async function resolveChannelsAddChannelFromArgv(
   argv: string[],
 ): Promise<string | undefined> {
   const normalizedArgv = normalizeWindowsArgv(argv);
-  const addIndex = normalizedArgv.findIndex(
-    (arg, index) => arg === "add" && normalizedArgv[index - 1] === "channels",
-  );
-  if (addIndex === -1) {
+  const args = getCommandArgsWithRootOptions(normalizedArgv, {
+    commandPath: ["channels", "add"],
+    valueFlags: ["--agent"],
+    mode: "command-path",
+  });
+  if (!args) {
     return undefined;
   }
-  const args = normalizedArgv.slice(addIndex + 1);
   let explicitChannel: string | undefined;
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];

--- a/src/cli/channels-cli.test.ts
+++ b/src/cli/channels-cli.test.ts
@@ -21,6 +21,12 @@ const channelsLogsCommandMock = vi.hoisted(() =>
   vi.fn(async (_options: { channel?: string }, _runtime: unknown) => undefined),
 );
 const channelsResolveCommandMock = vi.hoisted(() => vi.fn(async () => undefined));
+const channelsCapabilitiesCommandMock = vi.hoisted(() => vi.fn(async () => undefined));
+const channelsRemoveCommandMock = vi.hoisted(() => vi.fn(async () => undefined));
+const channelAuthMocks = vi.hoisted(() => ({
+  runChannelLogin: vi.fn(async () => undefined),
+  runChannelLogout: vi.fn(async () => undefined),
+}));
 const runtimeMock = vi.hoisted(() => ({
   log: vi.fn(),
   error: vi.fn(),
@@ -39,7 +45,11 @@ vi.mock("../commands/channels.js", () => ({
   channelsAddCommand: channelsAddCommandMock,
   channelsLogsCommand: channelsLogsCommandMock,
   channelsResolveCommand: channelsResolveCommandMock,
+  channelsCapabilitiesCommand: channelsCapabilitiesCommandMock,
+  channelsRemoveCommand: channelsRemoveCommandMock,
 }));
+
+vi.mock("./channel-auth.js", () => channelAuthMocks);
 
 vi.mock("../runtime.js", () => ({
   defaultRuntime: runtimeMock,
@@ -124,18 +134,35 @@ describe("registerChannelsCli", () => {
     },
   );
 
-  it.each([
-    ["parent", ["channels", "--agent", "ops", "resolve", "room"]],
-    ["leaf", ["channels", "resolve", "--agent", "ops", "room"]],
-  ])("forwards the %s --agent option to channel resolution", async (_label, args) => {
+  it.each(
+    ["add", "capabilities", "login", "logout", "remove", "resolve"].flatMap((leaf) =>
+      ["parent", "leaf", "both"].map((position) => ({ leaf, position })),
+    ),
+  )("forwards the $position --agent option to channels $leaf", async ({ leaf, position }) => {
+    const parentArgs =
+      position === "leaf" ? [] : ["--agent", position === "both" ? "research" : "ops"];
+    const leafArgs = position === "parent" ? [] : ["--agent", "ops"];
+    const args = ["channels", ...parentArgs, leaf, ...leafArgs, "--channel", "telegram"];
+    if (leaf === "resolve") {
+      args.push("room");
+    }
     const program = new Command().name("openclaw").enablePositionalOptions().exitOverride();
 
     await registerChannelsCli(program, ["node", "openclaw", ...args]);
     await program.parseAsync(args, { from: "user" });
 
-    expect(channelsResolveCommandMock).toHaveBeenCalledWith(
-      expect.objectContaining({ agent: "ops", entries: ["room"] }),
+    const command = {
+      add: channelsAddCommandMock,
+      capabilities: channelsCapabilitiesCommandMock,
+      login: channelAuthMocks.runChannelLogin,
+      logout: channelAuthMocks.runChannelLogout,
+      remove: channelsRemoveCommandMock,
+      resolve: channelsResolveCommandMock,
+    }[leaf];
+    expect(command).toHaveBeenCalledWith(
+      expect.objectContaining({ agent: "ops" }),
       runtimeMock,
+      ...(leaf === "add" ? [{ hasFlags: false }] : leaf === "remove" ? [{ hasFlags: true }] : []),
     );
   });
 
@@ -427,6 +454,7 @@ describe("registerChannelsCli", () => {
 
       expect(getChannelAddOptionFlags(program)).toEqual([
         "--channel <name>",
+        "--agent <id>",
         "--account <id>",
         "--name <name>",
       ]);
@@ -629,6 +657,27 @@ describe("registerChannelsCli", () => {
       { hasFlags: true },
     );
   });
+
+  it.each([{ parentArgs: ["--agent", "add"] }, { parentArgs: ["--agent=add"] }])(
+    "registers setup flags after parent owner options $parentArgs",
+    async ({ parentArgs }) => {
+      await runChannelsAddCli([
+        "channels",
+        ...parentArgs,
+        "add",
+        "--channel",
+        "telegram",
+        "--token",
+        "fixture-token",
+      ]);
+
+      expect(channelsAddCommandMock).toHaveBeenCalledWith(
+        expect.objectContaining({ agent: "add", channel: "telegram", token: "fixture-token" }),
+        runtimeMock,
+        { hasFlags: true },
+      );
+    },
+  );
 
   it("prefers modern contract options when a channel also publishes cliAddOptions", async () => {
     listBundledPackageChannelMetadataMock.mockReturnValue([

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -24,7 +24,7 @@ import { normalizeWindowsArgv } from "./windows-argv.js";
 
 type ChannelsCommandsModule = typeof import("../commands/channels.js");
 const optionNamesRemove = ["channel", "account", "delete"] as const;
-const CHANNEL_ADD_SELECTION_OPTION_NAMES = new Set(["channel"]);
+const CHANNEL_ADD_SELECTION_OPTION_NAMES = new Set(["agent", "channel"]);
 
 type RegisterChannelsCliOptions = {
   includeSetupOptions?: boolean;
@@ -78,6 +78,15 @@ function runChannelsCommandWithDanger(action: () => Promise<void>, label: string
 
 function getOptionNames(command: Command): string[] {
   return command.options.map((option) => option.attributeName());
+}
+
+function resolveAgentOption(command: Command): string | undefined {
+  const source = command.getOptionValueSource("agent");
+  const value =
+    source && source !== "default"
+      ? command.getOptionValue("agent")
+      : inheritOptionFromParent<string>(command, "agent");
+  return typeof value === "string" ? value : undefined;
 }
 
 function addChannelSetupOption(
@@ -205,15 +214,19 @@ export async function registerChannelsCli(
   channels
     .command("capabilities")
     .description("Show provider capabilities (intents/scopes + supported features)")
+    .option("--agent <id>", "Agent owner for channel discovery")
     .option("--channel <name>", `Channel (${formatCliChannelOptions(["all"])})`)
     .option("--account <id>", "Account id (only with --channel)")
     .option("--target <dest>", "Channel target for permission audit (Discord channel:<id>)")
     .option("--timeout <ms>", "Timeout in ms", "10000")
     .option("--json", "Output JSON", false)
-    .action(async (opts) => {
+    .action(async (opts, command) => {
       await runChannelsCommand(async () => {
         const { channelsCapabilitiesCommand } = await loadChannelsCommands();
-        await channelsCapabilitiesCommand(opts, defaultRuntime);
+        await channelsCapabilitiesCommand(
+          { ...opts, agent: resolveAgentOption(command) },
+          defaultRuntime,
+        );
       });
     });
 
@@ -233,16 +246,9 @@ export async function registerChannelsCli(
     .action(async (entries, opts, command) => {
       await runChannelsCommand(async () => {
         const { channelsResolveCommand } = await loadChannelsCommands();
-        const agentSource = command.getOptionValueSource("agent");
-        const agent =
-          agentSource && agentSource !== "default"
-            ? typeof opts.agent === "string"
-              ? opts.agent
-              : undefined
-            : inheritOptionFromParent<string>(command, "agent");
         await channelsResolveCommand(
           {
-            agent,
+            agent: resolveAgentOption(command),
             channel: opts.channel as string | undefined,
             account: opts.account as string | undefined,
             kind: opts.kind as "auto" | "user" | "group" | "channel",
@@ -320,6 +326,7 @@ export async function registerChannelsCli(
         ])}\n`,
     )
     .option("--channel <name>", `Channel (${channelNames})`)
+    .option("--agent <id>", "Agent owner for channel setup")
     .option("--account <id>", "Account id (default when omitted)")
     .option("--name <name>", "Display name for this account");
 
@@ -343,11 +350,14 @@ export async function registerChannelsCli(
         getOptionNames(command).filter((name) => !CHANNEL_ADD_SELECTION_OPTION_NAMES.has(name)),
       );
       await channelsAddCommand(
-        resolveChannelsAddOptions(
-          channelArg,
-          opts,
-          channelSetupOptionMode === "modern" ? command : undefined,
-        ),
+        {
+          ...resolveChannelsAddOptions(
+            channelArg,
+            opts,
+            channelSetupOptionMode === "modern" ? command : undefined,
+          ),
+          agent: resolveAgentOption(command),
+        },
         defaultRuntime,
         {
           hasFlags,
@@ -359,6 +369,7 @@ export async function registerChannelsCli(
   channels
     .command("remove")
     .description("Disable or delete a channel account")
+    .option("--agent <id>", "Agent owner for channel discovery")
     .option("--channel <name>", `Channel (${channelNames})`)
     .option("--account <id>", "Account id (default when omitted)")
     .option("--delete", "Delete config entries (no prompt)", false)
@@ -366,45 +377,44 @@ export async function registerChannelsCli(
       await runChannelsCommand(async () => {
         const { channelsRemoveCommand } = await loadChannelsCommands();
         const hasFlags = hasExplicitOptions(command, optionNamesRemove);
-        await channelsRemoveCommand(opts, defaultRuntime, { hasFlags });
+        await channelsRemoveCommand(
+          { ...opts, agent: resolveAgentOption(command) },
+          defaultRuntime,
+          { hasFlags },
+        );
       });
     });
 
-  channels
-    .command("login")
-    .description("Link a channel account (if supported)")
-    .option("--channel <channel>", "Channel alias (auto when only one is configured)")
-    .option("--account <id>", "Account id (accountId)")
-    .option("--verbose", "Verbose connection logs", false)
-    .action(async (opts) => {
-      await runChannelsCommandWithDanger(async () => {
-        await runChannelLogin(
-          {
-            channel: opts.channel as string | undefined,
-            account: opts.account as string | undefined,
-            verbose: Boolean(opts.verbose),
-          },
-          defaultRuntime,
-        );
-      }, "Channel login failed");
+  for (const mode of ["login", "logout"] as const) {
+    const auth = channels
+      .command(mode)
+      .description(
+        mode === "login"
+          ? "Link a channel account (if supported)"
+          : "Log out of a channel session (if supported)",
+      )
+      .option("--agent <id>", "Agent owner for channel discovery")
+      .option("--channel <channel>", "Channel alias (auto when only one is configured)")
+      .option("--account <id>", "Account id (accountId)");
+    if (mode === "login") {
+      auth.option("--verbose", "Verbose connection logs", false);
+    }
+    auth.action(async (opts, command) => {
+      await runChannelsCommandWithDanger(
+        () =>
+          (mode === "login" ? runChannelLogin : runChannelLogout)(
+            {
+              agent: resolveAgentOption(command),
+              channel: opts.channel as string | undefined,
+              account: opts.account as string | undefined,
+              ...(mode === "login" ? { verbose: Boolean(opts.verbose) } : {}),
+            },
+            defaultRuntime,
+          ),
+        `Channel ${mode} failed`,
+      );
     });
-
-  channels
-    .command("logout")
-    .description("Log out of a channel session (if supported)")
-    .option("--channel <channel>", "Channel alias (auto when only one is configured)")
-    .option("--account <id>", "Account id (accountId)")
-    .action(async (opts) => {
-      await runChannelsCommandWithDanger(async () => {
-        await runChannelLogout(
-          {
-            channel: opts.channel as string | undefined,
-            account: opts.account as string | undefined,
-          },
-          defaultRuntime,
-        );
-      }, "Channel logout failed");
-    });
+  }
 
   applyParentDefaultHelpAction(channels);
 }

--- a/src/cli/parent-command-path.ts
+++ b/src/cli/parent-command-path.ts
@@ -65,6 +65,7 @@ export function resolveParentAwareCommandPath(argv: readonly string[]): string[]
   return (
     resolveParentCommandPath(argv, "agent", AGENT_PARENT_BOOLEAN_FLAGS, AGENT_PARENT_VALUE_FLAGS) ??
     resolveModelsParentCommandPath(argv) ??
+    resolveParentCommandPath(argv, "channels", [], ["--agent"]) ??
     resolveParentCommandPath(argv, "update", UPDATE_PARENT_BOOLEAN_FLAGS, UPDATE_PARENT_VALUE_FLAGS)
   );
 }

--- a/src/commands/channel-setup/channel-plugin-resolution.test.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.test.ts
@@ -1,12 +1,12 @@
 // Channel plugin resolution tests cover trusted catalog lookup, install prompts, and setup plugin snapshots.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSelectionRequiredError } from "../../agents/agent-scope-config.js";
 import type { ChannelPluginCatalogEntry } from "../../channels/plugins/catalog.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import { createPluginRuntimeStore } from "../../plugin-sdk/runtime-store.js";
 
 const mocks = vi.hoisted(() => ({
   resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
-  resolveDefaultAgentId: vi.fn(() => "default"),
   listChannelPluginCatalogEntries: vi.fn(),
   getChannelPluginCatalogEntry: vi.fn(),
   getChannelPlugin: vi.fn(),
@@ -18,7 +18,6 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
-  resolveDefaultAgentId: mocks.resolveDefaultAgentId,
 }));
 
 vi.mock("../../channels/plugins/catalog.js", () => ({
@@ -82,7 +81,6 @@ describe("resolveInstallableChannelPlugin", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/workspace");
-    mocks.resolveDefaultAgentId.mockReturnValue("default");
     mocks.getChannelPlugin.mockReturnValue(undefined);
     mocks.getLoadedChannelPlugin.mockReturnValue(undefined);
     mocks.getChannelPluginCatalogEntry.mockReturnValue(undefined);
@@ -98,9 +96,6 @@ describe("resolveInstallableChannelPlugin", () => {
       directory: { self: vi.fn() },
     } as ChannelPlugin;
     mocks.getLoadedChannelPlugin.mockReturnValue(registeredPlugin);
-    mocks.resolveDefaultAgentId.mockImplementation(() => {
-      throw new Error("agent selection required");
-    });
 
     const result = await resolveInstallableChannelPlugin({
       cfg: {
@@ -122,7 +117,7 @@ describe("resolveInstallableChannelPlugin", () => {
       pluginInstalled: false,
       supportsRequestedCapability: true,
     });
-    expect(mocks.resolveDefaultAgentId).not.toHaveBeenCalled();
+    expect(mocks.resolveAgentWorkspaceDir).not.toHaveBeenCalled();
     expect(mocks.getLoadedChannelPlugin).toHaveBeenCalledWith("telegram");
     expect(mocks.getChannelPlugin).not.toHaveBeenCalled();
     expect(mocks.listChannelPluginCatalogEntries).not.toHaveBeenCalled();
@@ -131,9 +126,6 @@ describe("resolveInstallableChannelPlugin", () => {
 
   it("requires a workspace owner before falling back to an unloaded bundled plugin", async () => {
     mocks.getChannelPlugin.mockReturnValue(createPlugin("telegram"));
-    mocks.resolveDefaultAgentId.mockImplementation(() => {
-      throw new Error("agent selection required");
-    });
 
     await expect(
       resolveInstallableChannelPlugin({
@@ -147,18 +139,14 @@ describe("resolveInstallableChannelPlugin", () => {
         allowInstall: false,
         preferRegisteredPlugin: true,
       }),
-    ).rejects.toThrow("agent selection required");
+    ).rejects.toThrow(AgentSelectionRequiredError);
 
     expect(mocks.getLoadedChannelPlugin).toHaveBeenCalledWith("telegram");
     expect(mocks.getChannelPlugin).not.toHaveBeenCalled();
-    expect(mocks.resolveDefaultAgentId).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveAgentWorkspaceDir).not.toHaveBeenCalled();
   });
 
   it("still requires a workspace owner before resolving an unregistered plugin", async () => {
-    mocks.resolveDefaultAgentId.mockImplementation(() => {
-      throw new Error("agent selection required");
-    });
-
     await expect(
       resolveInstallableChannelPlugin({
         cfg: {
@@ -171,11 +159,11 @@ describe("resolveInstallableChannelPlugin", () => {
         allowInstall: false,
         preferRegisteredPlugin: true,
       }),
-    ).rejects.toThrow("agent selection required");
+    ).rejects.toThrow(AgentSelectionRequiredError);
 
     expect(mocks.getLoadedChannelPlugin).toHaveBeenCalledWith("workspace-channel");
     expect(mocks.getChannelPlugin).not.toHaveBeenCalled();
-    expect(mocks.resolveDefaultAgentId).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveAgentWorkspaceDir).not.toHaveBeenCalled();
     expect(mocks.listChannelPluginCatalogEntries).not.toHaveBeenCalled();
   });
 
@@ -228,7 +216,6 @@ describe("resolveInstallableChannelPlugin", () => {
     expect(snapshotRequest?.pluginId).toBe("telegram");
     expect(snapshotRequest?.workspaceDir).toBe("/tmp/workspace");
     expect(mocks.resolveAgentWorkspaceDir).toHaveBeenCalledWith(config, "ops");
-    expect(mocks.resolveDefaultAgentId).not.toHaveBeenCalled();
   });
 
   it("keeps trusted workspace channel plugins eligible for setup resolution", async () => {
@@ -395,5 +382,9 @@ describe("resolveInstallableChannelPlugin", () => {
     };
     expect(installRequest?.entry).toBe(catalogEntry);
     expect(result.pluginInstalled).toBe(true);
+    expect(mocks.resolveAgentWorkspaceDir).toHaveBeenCalledTimes(1);
+    expect(mocks.loadChannelSetupPluginRegistrySnapshotForChannel).toHaveBeenLastCalledWith(
+      expect.objectContaining({ workspaceDir: "/tmp/workspace" }),
+    );
   });
 });

--- a/src/commands/channel-setup/channel-plugin-resolution.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.ts
@@ -1,6 +1,5 @@
 // Resolves or installs channel plugins needed by setup/onboarding flows.
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import {
   listRawChannelPluginCatalogEntries,
   type ChannelPluginCatalogEntry,
@@ -12,6 +11,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
+import { resolveChannelSetupOwner } from "./owner.js";
 import {
   ensureChannelSetupPluginInstalled,
   loadChannelSetupPluginRegistrySnapshotForChannel,
@@ -35,10 +35,6 @@ type ResolveInstallableChannelPluginResult = {
   pluginInstalled: boolean;
   supportsRequestedCapability?: boolean;
 };
-
-function resolveWorkspaceDir(cfg: OpenClawConfig, agentId?: string) {
-  return resolveAgentWorkspaceDir(cfg, agentId ?? resolveDefaultAgentId(cfg));
-}
 
 function resolveResolvedChannelId(params: {
   rawChannel?: string | null;
@@ -140,7 +136,8 @@ export async function resolveInstallableChannelPlugin(params: {
     };
   }
 
-  const workspaceDir = resolveWorkspaceDir(nextCfg, params.agentId);
+  // Installation may replace config, but discovery must retain this operation's workspace.
+  const { workspaceDir } = resolveChannelSetupOwner(nextCfg, params.agentId);
   const catalogEntry =
     (params.rawChannel
       ? resolveCatalogChannelEntry(params.rawChannel, nextCfg, workspaceDir)
@@ -220,7 +217,7 @@ export async function resolveInstallableChannelPlugin(params: {
             channelId,
             supports,
             pluginId: installedPluginId,
-            workspaceDir: resolveWorkspaceDir(nextCfg, params.agentId),
+            workspaceDir,
           })
         : undefined;
       return {

--- a/src/commands/channel-setup/owner.ts
+++ b/src/commands/channel-setup/owner.ts
@@ -1,0 +1,24 @@
+import {
+  resolveAgentOperationAgentId,
+  resolveConfiguredAgentId,
+} from "../../agents/agent-scope-config.js";
+import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+/** Validate the selected operation owner before using its workspace for discovery. */
+export function resolveChannelSetupOwner(cfg: OpenClawConfig, requestedAgentId?: string) {
+  const requested = requestedAgentId?.trim();
+  if (requestedAgentId !== undefined && !requested) {
+    throw new Error("--agent must not be blank");
+  }
+  // Explicit CLI IDs must match the roster rather than normalize into a different agent.
+  const agentId = resolveConfiguredAgentId(
+    cfg,
+    requested ??
+      resolveAgentOperationAgentId(cfg, undefined, {
+        surface: "channel plugin discovery",
+        hint: "Pass --agent <id> to channels commands or set agents.defaults.systemAgent.agentId.",
+      }),
+  );
+  return { agentId, workspaceDir: resolveAgentWorkspaceDir(cfg, agentId) };
+}

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { getBundledChannelSetupPlugin } from "../channels/plugins/bundled.js";
 import type { ChannelPluginCatalogEntry } from "../channels/plugins/catalog.js";
 import { defineChannelSetupContract } from "../channels/plugins/setup-contract.js";
+import type { SetupChannelsOptions } from "../channels/plugins/setup-wizard-types.js";
 import type { ChannelSetupInput } from "../channels/plugins/types.core.js";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -21,7 +22,11 @@ import {
   createExternalChatCatalogEntry,
   createExternalChatSetupPlugin,
 } from "./channels.plugin-install.test-helpers.js";
-import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
+import {
+  baseConfigSnapshot,
+  createTestConfigSnapshot,
+  createTestRuntime,
+} from "./test-runtime-config-helpers.js";
 
 let channelsAddCommand: typeof import("./channels/add.js").channelsAddCommand;
 let runChannelsSetupWizard: typeof import("./channels/add-wizard.js").runChannelsSetupWizard;
@@ -532,6 +537,73 @@ describe("channelsAddCommand", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
+
+  it.each([false, true])("retains the selected workspace when hasFlags=%s", async (hasFlags) => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "research" } },
+        entries: {
+          research: { workspace: "/tmp/research-workspace" },
+          ops: { workspace: "/tmp/ops-workspace" },
+        },
+      },
+    };
+    configMocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(cfg));
+
+    await channelsAddCommand(
+      { channel: "lifecycle-chat", agent: "ops", ...(hasFlags ? { token: "fixture-token" } : {}) },
+      runtime,
+      { hasFlags },
+    );
+
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(catalogMocks.listChannelPluginCatalogEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: "/tmp/ops-workspace" }),
+    );
+    if (!hasFlags) {
+      expect(setupOptions().workspaceDir).toBe("/tmp/ops-workspace");
+    }
+  });
+
+  it.each([undefined, "research"])(
+    "keeps workspace selection separate from the routing prompt with ambient owner %s",
+    async (systemAgentId) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          ownership: "explicit",
+          entries: { research: {}, ops: { workspace: "/tmp/ops-workspace" } },
+          ...(systemAgentId ? { defaults: { systemAgent: { agentId: systemAgentId } } } : {}),
+        },
+      };
+      configMocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(cfg));
+      channelWizardMocks.setupChannels.mockImplementationOnce(async (...args: unknown[]) => {
+        const options = args[3] as SetupChannelsOptions;
+        options.onSelection?.(["lifecycle-chat"]);
+        options.onAccountId?.("lifecycle-chat", "work");
+        return cfg;
+      });
+      channelWizardMocks.prompter.select.mockImplementationOnce(async () => {
+        expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+        return "research";
+      });
+
+      await channelsAddCommand({ channel: "lifecycle-chat", agent: "ops" }, runtime, {
+        hasFlags: false,
+      });
+
+      expect(setupOptions().workspaceDir).toBe("/tmp/ops-workspace");
+      expect(channelWizardMocks.prompter.select).toHaveBeenCalledWith(
+        expect.objectContaining({ initialValue: systemAgentId }),
+      );
+      expect(writtenConfig().bindings).toEqual([
+        {
+          agentId: "research",
+          match: { channel: "lifecycle-chat", accountId: "work" },
+        },
+      ]);
+    },
+  );
 
   it("fails fast before guided setup when no interactive terminal is available", async () => {
     terminalMocks.isTerminalInteractive.mockReturnValue(false);
@@ -1093,9 +1165,13 @@ describe("channelsAddCommand", () => {
     );
     configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
 
-    await channelsAddCommand({ channel: "typed-chat", token: "secret", port: "8080" }, runtime, {
-      hasFlags: true,
-    });
+    await channelsAddCommand(
+      { channel: "typed-chat", agent: "main", token: "secret", port: "8080" },
+      runtime,
+      {
+        hasFlags: true,
+      },
+    );
 
     expect(writtenChannel("typed-chat")).toEqual({ token: "secret", port: 8080 });
     expect(applyAccountConfig).toHaveBeenCalledWith({

--- a/src/commands/channels.remove.test.ts
+++ b/src/commands/channels.remove.test.ts
@@ -110,6 +110,13 @@ describe("channelsRemoveCommand", () => {
   it("asks users to add an external channel plugin before removing its account", async () => {
     configMocks.readConfigFileSnapshot.mockResolvedValue(
       createTestConfigSnapshot({
+        agents: {
+          ownership: "explicit",
+          entries: {
+            research: { workspace: "/tmp/research-workspace" },
+            ops: { workspace: "/tmp/ops-workspace" },
+          },
+        },
         channels: {
           "external-chat": {
             enabled: true,
@@ -124,6 +131,7 @@ describe("channelsRemoveCommand", () => {
     await channelsRemoveCommand(
       {
         channel: "external-chat",
+        agent: "ops",
         account: "default",
         delete: true,
       },
@@ -133,6 +141,9 @@ describe("channelsRemoveCommand", () => {
 
     expect(ensureChannelSetupPluginInstalled).not.toHaveBeenCalled();
     expect(loadChannelSetupPluginRegistrySnapshotForChannel).toHaveBeenCalledTimes(1);
+    expect(loadChannelSetupPluginRegistrySnapshotForChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: "/tmp/ops-workspace" }),
+    );
     expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
     expect(runtime.error).toHaveBeenCalledWith(
       'Channel plugin "external-chat" is not installed. Run openclaw channels add --channel external-chat first.',

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -2,8 +2,10 @@
 // prompter) and the gateway `wizard.start {flow:"channels"}` RPC (session
 // prompter driving the Control UI / native clients).
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
-import { resolveAgentOperationAgentId } from "../../agents/agent-scope-config.js";
-import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
+import {
+  resolveConfiguredAgentId,
+  tryResolveAgentOperationAgentId,
+} from "../../agents/agent-scope-config.js";
 import { getLoadedChannelPlugin } from "../../channels/plugins/index.js";
 import type { ChannelSetupPlugin } from "../../channels/plugins/setup-wizard-types.js";
 import { formatUnknownChannelMessage } from "../../cli/error-format.js";
@@ -14,6 +16,7 @@ import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import { applyAgentBindings, describeBinding } from "../agents.bindings.js";
+import { resolveChannelSetupOwner } from "../channel-setup/owner.js";
 import type { ChannelChoice } from "../onboard-types.js";
 import { applyAccountName } from "./add-mutators.js";
 
@@ -36,6 +39,7 @@ function unresolvedInitialWizardChannelTarget(channel: string): InitialWizardCha
 export async function resolveInitialWizardChannelTarget(
   raw: string | undefined,
   cfg: OpenClawConfig,
+  workspaceDir?: string,
 ): Promise<InitialWizardChannelTarget> {
   if (raw === undefined) {
     return { kind: "omitted" };
@@ -51,7 +55,7 @@ export async function resolveInitialWizardChannelTarget(
   const resolved = resolveChannelSetupEntries({
     cfg,
     installedPlugins: listActiveChannelSetupPlugins(),
-    workspaceDir: resolveAgentWorkspaceDir(cfg, resolveAgentOperationAgentId(cfg)),
+    workspaceDir: workspaceDir ?? resolveChannelSetupOwner(cfg).workspaceDir,
   });
   const matchedEntry =
     resolved.entries.find(
@@ -69,6 +73,7 @@ export async function resolveInitialWizardChannelTarget(
 
 type ChannelsAddWizardFlowParams = {
   cfg: OpenClawConfig;
+  workspaceDir?: string;
   baseHash?: string;
   runtime: RuntimeEnv;
   prompter: WizardPrompter;
@@ -102,6 +107,7 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
   const resolvedPlugins = new Map<ChannelChoice, ChannelSetupPlugin>();
   await prompter.intro("Channel setup");
   let nextConfig = await onboardChannels.setupChannels(cfg, runtime, prompter, {
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
     ...(params.initialChannel ? { initialSelection: [params.initialChannel] } : {}),
     ...(params.initialChannel ? { finishAfterInitialSelection: true } : {}),
     allowDisable: false,
@@ -212,7 +218,9 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
               initialValue: true,
             });
     if (bindNow) {
-      const defaultAgentId = resolveAgentOperationAgentId(nextConfig);
+      const owner = tryResolveAgentOperationAgentId(nextConfig);
+      const defaultAgentId =
+        owner === undefined ? undefined : resolveConfiguredAgentId(nextConfig, owner);
       for (const target of bindTargets) {
         const targetAgentId = await prompter.select({
           message: `Send ${target.channel}/${target.accountId} messages to agent`,

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -1,8 +1,6 @@
 import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
 // Implements guided and non-interactive `openclaw channels add` account setup.
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
-import { resolveAgentOperationAgentId } from "../../agents/agent-scope-config.js";
-import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import {
   applyPreparedChannelAccountConfiguration,
   type ChannelAccountMutationPlugin,
@@ -27,6 +25,7 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { WizardCancelledError } from "../../wizard/prompts.js";
 import { normalizeExternalChannelSetupConfig } from "../channel-setup/config-compatibility.js";
+import { resolveChannelSetupOwner } from "../channel-setup/owner.js";
 import { channelLabel } from "./runtime-label.js";
 import { requireValidConfigFileSnapshot, shouldUseWizard } from "./shared.js";
 
@@ -49,29 +48,29 @@ function loadOnboardChannels(): Promise<OnboardChannelsModule> {
 }
 
 export type ChannelsAddOptions = {
+  agent?: string;
   channel?: string;
   account?: string;
 } & Record<string, unknown>;
 
-const CHANNEL_ADD_CONTROL_OPTION_KEYS = new Set(["channel", "account"]);
+const CHANNEL_ADD_CONTROL_OPTION_KEYS = new Set(["agent", "channel", "account"]);
 
-async function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | null) {
+async function resolveCatalogChannelEntry(
+  raw: string,
+  cfg: OpenClawConfig,
+  resolveWorkspaceDir: () => string,
+) {
   const trimmed = normalizeOptionalLowercaseString(raw);
   if (!trimmed) {
     return undefined;
   }
-  const entries = cfg
-    ? await import("../channel-setup/trusted-catalog.js").then(
-        ({ listTrustedChannelPluginCatalogEntries }) =>
-          listTrustedChannelPluginCatalogEntries({
-            cfg,
-            workspaceDir: resolveAgentWorkspaceDir(cfg, resolveAgentOperationAgentId(cfg)),
-          }),
-      )
-    : await import("../../channels/plugins/catalog.js").then(
-        ({ listRawChannelPluginCatalogEntries }) =>
-          listRawChannelPluginCatalogEntries({ excludeWorkspace: true }),
-      );
+  const entries = await import("../channel-setup/trusted-catalog.js").then(
+    ({ listTrustedChannelPluginCatalogEntries }) =>
+      listTrustedChannelPluginCatalogEntries({
+        cfg,
+        workspaceDir: resolveWorkspaceDir(),
+      }),
+  );
   return entries.find((entry) => {
     if (normalizeOptionalLowercaseString(entry.id) === trimmed) {
       return true;
@@ -158,7 +157,9 @@ async function channelsAddCommandImpl(
   if (useWizard) {
     const { resolveInitialWizardChannelTarget, runChannelsAddWizardFlow } =
       await import("./add-wizard.js");
-    const target = await resolveInitialWizardChannelTarget(opts.channel, cfg);
+    const workspaceDir =
+      opts.agent === undefined ? undefined : resolveChannelSetupOwner(cfg, opts.agent).workspaceDir;
+    const target = await resolveInitialWizardChannelTarget(opts.channel, cfg, workspaceDir);
     if (target.kind === "unresolved") {
       runtime.error(target.message);
       runtime.exit(1);
@@ -176,6 +177,7 @@ async function channelsAddCommandImpl(
       ...(baseHash !== undefined ? { baseHash } : {}),
       runtime,
       prompter: createClackPrompter(),
+      ...(workspaceDir ? { workspaceDir } : {}),
       ...(target.kind === "resolved" ? { initialChannel: target.channel } : {}),
       ...(params?.beforePersistentEffect
         ? { beforePersistentEffect: params.beforePersistentEffect }
@@ -186,9 +188,10 @@ async function channelsAddCommandImpl(
 
   const rawChannel = opts.channel ?? "";
   let channel = normalizeChannelId(rawChannel);
-  let catalogEntry = await resolveCatalogChannelEntry(rawChannel, nextConfig);
+  let preparedWorkspaceDir: string | undefined;
   const resolveWorkspaceDir = () =>
-    resolveAgentWorkspaceDir(nextConfig, resolveAgentOperationAgentId(nextConfig));
+    (preparedWorkspaceDir ??= resolveChannelSetupOwner(cfg, opts.agent).workspaceDir);
+  let catalogEntry = await resolveCatalogChannelEntry(rawChannel, nextConfig, resolveWorkspaceDir);
   // May load a scoped plugin when the channel is not already registered.
   const loadScopedPlugin = async (
     channelId: ChannelId,

--- a/src/commands/channels/capabilities.test.ts
+++ b/src/commands/channels/capabilities.test.ts
@@ -453,7 +453,7 @@ describe("channelsCapabilitiesCommand", () => {
     ]);
   });
 
-  it("installs an explicit optional channel before rendering capabilities", async () => {
+  it("installs an explicit optional channel in the selected owner before rendering capabilities", async () => {
     const tokenRef = {
       source: "env",
       provider: "default",
@@ -508,11 +508,11 @@ describe("channelsCapabilitiesCommand", () => {
       };
     });
 
-    await channelsCapabilitiesCommand({ channel: "slack" }, runtime);
+    await channelsCapabilitiesCommand({ channel: "slack", agent: "ops" }, runtime);
 
     expect(mocks.resolveInstallableChannelPlugin).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ rawChannel: "slack", allowInstall: true }),
+      expect.objectContaining({ rawChannel: "slack", agentId: "ops", allowInstall: true }),
     );
     expect(mocks.resolveInstallableChannelPlugin.mock.calls[0]?.[0].cfg).toEqual(sourceConfig);
 

--- a/src/commands/channels/capabilities.ts
+++ b/src/commands/channels/capabilities.ts
@@ -32,6 +32,7 @@ import { persistChannelPluginConfig } from "./plugin-config-persistence.js";
 import { formatChannelAccountLabel } from "./shared.js";
 
 export type ChannelsCapabilitiesOptions = {
+  agent?: string;
   channel?: string;
   account?: string;
   target?: string;
@@ -343,6 +344,7 @@ export async function channelsCapabilitiesCommand(
           const resolved = await resolveInstallableChannelPlugin({
             cfg: configSnapshot.sourceConfig,
             runtime,
+            agentId: opts.agent,
             rawChannel,
             allowInstall: true,
           });

--- a/src/commands/channels/remove.ts
+++ b/src/commands/channels/remove.ts
@@ -24,6 +24,7 @@ import { channelLabel } from "./runtime-label.js";
 import { type ChatChannel, requireValidConfigFileSnapshot, shouldUseWizard } from "./shared.js";
 
 export type ChannelsRemoveOptions = {
+  agent?: string;
   channel?: string;
   account?: string;
   delete?: boolean;
@@ -158,6 +159,7 @@ export async function channelsRemoveCommand(
         return await resolveInstallableChannelPlugin({
           cfg,
           runtime,
+          agentId: opts.agent,
           rawChannel: lookupChannel,
           allowInstall: false,
         });

--- a/src/infra/cli-root-options.ts
+++ b/src/infra/cli-root-options.ts
@@ -106,6 +106,22 @@ export function getCommandPositionalsWithRootOptions(
   argv: readonly string[],
   options: CommandPositionalsParseOptions,
 ): string[] | null {
+  return parseCommandArgsWithRootOptions(argv, options, false);
+}
+
+/** Preserve the leaf's raw arguments after consuming its root and parent options. */
+export function getCommandArgsWithRootOptions(
+  argv: readonly string[],
+  options: Omit<CommandPositionalsParseOptions, "maxPositionals">,
+): string[] | null {
+  return parseCommandArgsWithRootOptions(argv, options, true);
+}
+
+function parseCommandArgsWithRootOptions(
+  argv: readonly string[],
+  options: CommandPositionalsParseOptions,
+  returnTail: boolean,
+): string[] | null {
   const args = argv.slice(2);
   const booleanFlags = new Set(options.booleanFlags ?? []);
   const valueFlags = new Set(options.valueFlags ?? []);
@@ -149,6 +165,9 @@ export function getCommandPositionalsWithRootOptions(
         return null;
       }
       commandIndex += 1;
+      if (returnTail && commandIndex === options.commandPath.length) {
+        return args.slice(index + 1);
+      }
       continue;
     }
     positionals.push(arg);


### PR DESCRIPTION
Related: #134421. Companion to #135447.

## What Problem This Solves

Fixes an issue where users linking or logging out of channel accounts would receive “no explicit owner” in multi-agent setups even after passing a selector, such as `openclaw channels --agent ops login --channel <name>`, or configuring a System Agent. The same lost selection affected channel add, specific-channel capabilities, and remove. Thanks @abacha for the original report.

## Why This Change Was Made

The CLI now carries the existing selector through each applicable command and validates the owner before preparing its discovery workspace. That workspace stays attached to the operation through plugin installation and reload; guided add reuses the existing workspace option while keeping account routing a separate user choice.

## User Impact

`--agent <id>` works before or after add, capabilities, login, logout, remove, and resolve, with an explicit subcommand value taking precedence. Omitted selection retains the existing System Agent, sole-agent, and legacy-owner policy. Ambiguous operations still request an owner, invalid explicit IDs fail before auth, and `--agent` neither leaks into plugin setup input nor turns guided add into noninteractive setup. List/status and default/all capabilities keep their global semantics.

## Evidence

- The real Commander/auth/discovery regression failed before the repair. Follow-up regressions also proved that explicit `???` and `OPS` must not normalize into another configured agent; both verbs now reject them while all valid-owner controls pass.
- 251 focused tests pass across CLI parsing, auth, add, remove, resolve, capabilities, discovery lifecycle, shared root-option parsing, and operation-owner policy. After the mechanical main refresh, 96 tests pass across real Gateway state-directory proof, state-directory policy, CLI parsing and auth-owner integration.
- `pnpm build qaRuntime` passes. The baseline built CLI failed all six login/logout parent, subcommand, and System Agent cases. The final build passes all 15 expected outcomes: six successful auth calls, two ownerless failures, four invalid-selector failures, and add/capabilities/remove. These runs use a local synthetic channel plugin, temporary config/state, and an isolated loopback transport, without contacting a live account; cleanup completed.
- All planned changed-surface checks passed across the preserved prefix and final lint/guard reruns. The aggregate run initially exited 1 because the fresh worktree lacked Matrix/WhatsApp declaration artifacts; canonical `--mode=all` preparation resolved the exact extension-lint failure without source changes. The original aggregate exit is preserved. Two unused internal catalog type exports are now local; their type shapes and emitted JavaScript remain unchanged.
- Production +174/-94 = +80; tests +370/-35 = +335. Growth supplies missing selector admission/propagation and shared argument parsing. Duplicated auth registration and post-install owner rediscovery were removed; the existing wizard workspace option is reused. The assertion baseline only decreases from 7 to 5 for removed casts.
- Independent source review covered the full owner, parser, setup, and sibling paths, including Commander's option-source behavior, with no unresolved findings.
- Fresh managed Codex review of the complete 22-file candidate, including the capabilities option-summary correction requested by [ClawSweeper](https://github.com/openclaw/openclaw/pull/135505#issuecomment-5499531106), returned scoped-clean at P0. The subsequent main refresh preserved both patches unchanged. Current head: `352fa4168a9ed19d5681222c5b3bf9e7113dc3da`; [hosted CI 33561204540](https://github.com/openclaw/openclaw/actions/runs/33561204540) passed on that exact head (204 successful jobs, 16 skipped).
- The prior CI failure was in the unchanged state-directory Gateway test. This branch now includes the upstream test repair from #135495, which separates authenticated-hello proof from the production offline-probe timeout. The refreshed real-Gateway case passes; no production timeout or fallback was changed.

Focused regression command:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  src/infra/cli-root-options.test.ts \
  src/agents/agent-scope-config.test.ts \
  src/cli/channel-auth.owner.integration.test.ts \
  src/cli/channel-auth.test.ts \
  src/cli/channels-cli.test.ts \
  src/commands/channel-setup/channel-plugin-resolution.test.ts \
  src/commands/channels.add.test.ts \
  src/commands/channels.remove.test.ts \
  src/commands/channels.resolve.test.ts \
  src/commands/channels/capabilities.test.ts
```

Named follow-up: “Explicit ambient target validation: unrepresentable IDs alias main.” Configured System Agent, heartbeat, and Talk targets share that shipped schema/normalization behavior; this repair preserves it for a coordinated producer-level follow-up. Explicit CLI IDs retain the existing `channels resolve` direct-membership contract.

Tooling follow-up: standalone full plugin lint should prepare the peer-plugin declarations required by its existing package-boundary paths.
