### PR TITLE
refactor(xai): centralize base URL resolution

### DIFF
--- a/extensions/xai/base-url.test.ts
+++ b/extensions/xai/base-url.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveXaiBaseUrl } from "./base-url.js";
+import { XAI_BASE_URL } from "./model-definitions.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("resolveXaiBaseUrl", () => {
+  it("uses the canonical default without explicit or environment input", () => {
+    vi.stubEnv("XAI_BASE_URL", undefined);
+
+    expect(resolveXaiBaseUrl()).toBe(XAI_BASE_URL);
+  });
+
+  it("trims the environment URL", () => {
+    vi.stubEnv("XAI_BASE_URL", "  https://env.example/v1  ");
+
+    expect(resolveXaiBaseUrl()).toBe("https://env.example/v1");
+  });
+
+  it("trims and prefers the explicit URL", () => {
+    vi.stubEnv("XAI_BASE_URL", "https://env.example/v1");
+
+    expect(resolveXaiBaseUrl("  https://config.example/v1  ")).toBe("https://config.example/v1");
+  });
+
+  it("uses the canonical default when blank explicit input suppresses the environment", () => {
+    vi.stubEnv("XAI_BASE_URL", "https://env.example/v1");
+
+    expect(resolveXaiBaseUrl(" \t ")).toBe(XAI_BASE_URL);
+  });
+});

--- a/extensions/xai/base-url.ts
+++ b/extensions/xai/base-url.ts
@@ -1,0 +1,7 @@
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { XAI_BASE_URL } from "./model-definitions.js";
+
+export function resolveXaiBaseUrl(value?: string): string {
+  // Select explicit input before trimming so blank input suppresses the environment override.
+  return normalizeOptionalString(value ?? process.env.XAI_BASE_URL) ?? XAI_BASE_URL;
+}

--- a/extensions/xai/realtime-transcription-provider.ts
+++ b/extensions/xai/realtime-transcription-provider.ts
@@ -9,12 +9,12 @@ import {
   type RealtimeTranscriptionWebSocketTransport,
 } from "openclaw/plugin-sdk/realtime-transcription";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveXaiBaseUrl } from "./base-url.js";
 import {
   createXaiRealtimeTranscriptionProviderMetadata,
   normalizeXaiRealtimeTranscriptionProviderConfig,
   type XaiRealtimeTranscriptionEncoding,
 } from "./capability-provider-metadata.js";
-import { XAI_BASE_URL } from "./model-definitions.js";
 import { xaiUserAgentHeaderFor } from "./src/xai-user-agent.js";
 
 type XaiRealtimeTranscriptionSessionConfig = RealtimeTranscriptionSessionCreateRequest & {
@@ -48,12 +48,8 @@ const XAI_REALTIME_STT_MAX_RECONNECT_ATTEMPTS = 5;
 const XAI_REALTIME_STT_RECONNECT_DELAY_MS = 1000;
 const XAI_REALTIME_STT_MAX_QUEUED_BYTES = 2 * 1024 * 1024;
 
-function normalizeXaiRealtimeBaseUrl(value?: string): string {
-  return normalizeOptionalString(value ?? process.env.XAI_BASE_URL) ?? XAI_BASE_URL;
-}
-
 function toXaiRealtimeWsUrl(config: XaiRealtimeTranscriptionSessionConfig): string {
-  const url = new URL(normalizeXaiRealtimeBaseUrl(config.baseUrl));
+  const url = new URL(resolveXaiBaseUrl(config.baseUrl));
   url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
   url.pathname = `${url.pathname.replace(/\/+$/, "")}/stt`;
   url.searchParams.set("sample_rate", String(config.sampleRate));
@@ -182,7 +178,7 @@ export function buildXaiRealtimeTranscriptionProvider(): RealtimeTranscriptionPr
         ...req,
         apiKey: seedApiKey ?? "",
         resolveApiKey: () => resolveXaiRealtimeApiKey(config.apiKey, req.cfg),
-        baseUrl: normalizeXaiRealtimeBaseUrl(config.baseUrl),
+        baseUrl: resolveXaiBaseUrl(config.baseUrl),
         sampleRate: config.sampleRate ?? XAI_REALTIME_STT_DEFAULT_SAMPLE_RATE,
         encoding: config.encoding ?? XAI_REALTIME_STT_DEFAULT_ENCODING,
         interimResults: config.interimResults ?? true,

--- a/extensions/xai/realtime-voice-config.ts
+++ b/extensions/xai/realtime-voice-config.ts
@@ -16,7 +16,6 @@ import {
   normalizeOptionalString,
   parseBooleanValue,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { XAI_BASE_URL } from "./model-definitions.js";
 
 type XaiRealtimeVoice = "eve" | "ara" | "rex" | "sal" | "leo";
 type XaiRealtimeReasoningEffort = "high" | "none";
@@ -150,10 +149,6 @@ function readNestedXaiConfig(rawConfig: RealtimeVoiceProviderConfig) {
   return readXaiObjectRecord(providers?.xai ?? raw?.xai ?? raw) ?? {};
 }
 
-export function normalizeXaiRealtimeBaseUrl(value?: string): string {
-  return normalizeOptionalString(value ?? process.env.XAI_BASE_URL) ?? XAI_BASE_URL;
-}
-
 function normalizeXaiRealtimeVoice(value: unknown): string | undefined {
   const normalized = normalizeOptionalString(value);
   if (!normalized) {
@@ -222,7 +217,7 @@ export function toXaiRealtimeWsUrl(
   model: string,
   conversationId?: string,
 ): string {
-  const url = new URL(normalizeXaiRealtimeBaseUrl(baseUrl));
+  const url = new URL(baseUrl);
   url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
   url.pathname = `${url.pathname.replace(/\/+$/, "")}/realtime`;
   url.searchParams.set("model", model);

--- a/extensions/xai/realtime-voice-provider.ts
+++ b/extensions/xai/realtime-voice-provider.ts
@@ -1,14 +1,12 @@
 import type { RealtimeVoiceProviderPlugin } from "openclaw/plugin-sdk/realtime-voice";
+import { resolveXaiBaseUrl } from "./base-url.js";
 import {
   assertXaiRealtimeVoiceRequestSupported,
   createXaiRealtimeVoiceProviderMetadata,
 } from "./capability-provider-metadata.js";
 import { resolveXaiRealtimeApiKey } from "./realtime-voice-auth.runtime.js";
 import { XaiRealtimeVoiceBridge } from "./realtime-voice-bridge.js";
-import {
-  normalizeXaiRealtimeBaseUrl,
-  normalizeXaiRealtimeProviderConfig,
-} from "./realtime-voice-config.js";
+import { normalizeXaiRealtimeProviderConfig } from "./realtime-voice-config.js";
 
 export function buildXaiRealtimeVoiceProvider(): RealtimeVoiceProviderPlugin {
   return {
@@ -19,7 +17,7 @@ export function buildXaiRealtimeVoiceProvider(): RealtimeVoiceProviderPlugin {
       return new XaiRealtimeVoiceBridge({
         ...req,
         apiKey: config.apiKey,
-        baseUrl: normalizeXaiRealtimeBaseUrl(config.baseUrl),
+        baseUrl: resolveXaiBaseUrl(config.baseUrl),
         model: config.model,
         voice: config.voice,
         vadThreshold: config.vadThreshold,

--- a/extensions/xai/stt.ts
+++ b/extensions/xai/stt.ts
@@ -12,12 +12,9 @@ import {
   resolveProviderHttpRequestConfig,
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveXaiBaseUrl } from "./base-url.js";
 import { createXaiMediaUnderstandingProviderMetadata } from "./capability-provider-metadata.js";
 import { XAI_BASE_URL } from "./model-definitions.js";
-
-function resolveXaiSttBaseUrl(value?: string): string {
-  return normalizeOptionalString(value ?? process.env.XAI_BASE_URL) ?? XAI_BASE_URL;
-}
 
 async function transcribeXaiAudio(
   params: AudioTranscriptionRequest,
@@ -25,7 +22,7 @@ async function transcribeXaiAudio(
   const fetchFn = params.fetchFn ?? fetch;
   const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
     resolveProviderHttpRequestConfig({
-      baseUrl: resolveXaiSttBaseUrl(params.baseUrl),
+      baseUrl: resolveXaiBaseUrl(params.baseUrl),
       defaultBaseUrl: XAI_BASE_URL,
       headers: params.headers,
       request: params.request,


### PR DESCRIPTION
## What Problem This Solves

Three xAI speech paths independently owned the same base-URL precedence and normalization logic. That duplicated provider policy across batch STT, realtime transcription, and realtime voice, making later fixes likely to drift between capabilities.

## Why This Change Was Made

The xAI plugin now owns the behavior in one private `resolveXaiBaseUrl` helper. It selects explicit input before trimming, so a blank explicit value intentionally suppresses `XAI_BASE_URL` and falls back to the canonical xAI endpoint; nonblank explicit and environment values remain trimmed.

Removed duplicate paths:

- realtime transcription's local base-URL resolver
- realtime voice config's exported base-URL resolver
- batch STT's local base-URL resolver

The helper is imported directly by production callers and is not exported through the plugin API or Plugin SDK. Endpoint construction, HTTP policy, WebSocket protocol conversion, manifests, config surfaces, and the canonical `XAI_BASE_URL` constant are unchanged.

Production LOC: `+16/-23`, net `-7`. Tests: `+33`.

## User Impact

No user-visible behavior changes. xAI STT and realtime voice/transcription now share one plugin-private config/environment/default precedence contract.

## Evidence

- Focused local boundary proof: 5 test files, 123 tests passed, including local HTTP STT and real local WebSocket transcription/voice flows.
- Full local xAI extension lane: 31 test files, 518 tests passed.
- Changed-file guards, extension production/test typechecks, Oxlint, formatting, dead-export checks, coercion/deprecation guards, and import-cycle checks passed.
- Blacksmith Testbox `tbx_01m1f79jqmfvvdjynwgecp2vth`: exact candidate tree; xAI extension lane 518/518 passed; import cycles 0; full build passed. Run: https://github.com/openclaw/openclaw/actions/runs/33550031279
- Local linked-worktree build was not used as the final build signal because its shared root `node_modules` resolved stale `@openclaw/ai` artifacts. The isolated exact-tree Testbox build passed.
- Sol/high autoreview against `origin/main`: scoped clean, correctness `0.97`.
- Codex hard gate inspected directly at `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those CLI/completion paths are unrelated.
- No paid or live xAI request was made. Local HTTP/WebSocket boundary tests cover the unchanged request routing and precedence behavior.
