### PR TITLE
fix: quick start hangs after Codex setup probe

### DIFF
--- a/src/system-agent/setup-inference-activate.ts
+++ b/src/system-agent/setup-inference-activate.ts
@@ -661,6 +661,12 @@ async function activateSetupInferenceUnredacted(
     };
   } finally {
     let codexCleanupError: SetupInferenceActivationIndeterminateError | undefined;
+    if (params.surface === "cli" && codexProbePluginGeneration) {
+      // The CLI probe generation has no long-lived host to dispose its harnesses.
+      // Close them before removing their temporary agent home or the process survives setup.
+      const { disposeRegisteredAgentHarnesses } = await import("../agents/harness/registry.js");
+      await withProbePluginGeneration(disposeRegisteredAgentHarnesses);
+    }
     if (pendingCodexInstall && codexInstallOwnership !== "owned") {
       // Reassert after probing: a partial install-index commit may have cleared
       // the early marker even though the matching model route never committed.

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -4813,6 +4813,7 @@ describe("activateSetupInference", () => {
       },
     };
     const stagedRegistry = createEmptyPluginRegistry();
+    const dispose = vi.fn(async () => undefined);
     stagedRegistry.agentHarnesses.push({
       pluginId: "codex",
       source: "test",
@@ -4823,6 +4824,7 @@ describe("activateSetupInference", () => {
         runAttempt: async () => {
           throw new Error("unused");
         },
+        dispose,
       },
     });
     const prepareProbeMetadata = (config: OpenClawConfig, workspaceDir: string) => {
@@ -4904,6 +4906,39 @@ describe("activateSetupInference", () => {
     expect(ownerArtifactRegistry).toBe(stagedRegistry);
     expect(captureSystemAgentOwnerPluginArtifacts).toHaveBeenCalledOnce();
     expect(runEmbeddedAgent).toHaveBeenCalledOnce();
+    expect(dispose).not.toHaveBeenCalled();
+  });
+
+  it("disposes the private Codex probe generation after CLI activation", async () => {
+    const stagedRegistry = createEmptyPluginRegistry();
+    const dispose = vi.fn(async () => undefined);
+    stagedRegistry.agentHarnesses.push({
+      pluginId: "codex",
+      source: "test",
+      harness: {
+        id: "codex",
+        label: "Codex",
+        supports: () => ({ supported: true }),
+        runAttempt: async () => {
+          throw new Error("unused");
+        },
+        dispose,
+      },
+    });
+    mocks.loadAgentRuntimePluginRegistryHandle.mockReturnValueOnce(stagedRegistry);
+    const configHarness = createPreRosterConfigTransformHarness();
+
+    const result = await activateCodexSetup({
+      surface: "cli",
+      workspace: "/tmp/work",
+      deps: {
+        readConfigFileSnapshot: configHarness.readSnapshot as never,
+        transformConfigWithPendingPluginInstalls: configHarness.transform as never,
+      },
+    });
+
+    expect(result).toMatchObject({ ok: true, modelRef: "openai/gpt-5.6-sol" });
+    expect(dispose).toHaveBeenCalledOnce();
   });
 
   it("commits only the refreshed codex record when authored install metadata is stale", async () => {


### PR DESCRIPTION
Related: #134221

## What Problem This Solves

Fixes an issue where users selecting Codex during Quick start could leave the OpenClaw process and its probe `codex app-server` child alive after setup exited.

## Why This Change Was Made

CLI inference activation owns a private plugin generation with no long-lived host to clean it up. The activation now disposes that generation's registered harnesses before removing its temporary agent home. Gateway activation remains unchanged because the Gateway owns and reuses its generation.

## User Impact

Quick start can probe Codex and exit normally without requiring users to find and terminate a leaked background process.

## Evidence

- Before the fix, leaving the Quick start TUI retained an active `MessagePort` and a descendant `codex app-server --listen stdio://` process.
- After scoped CLI disposal, the Quick start process and probe descendants exited while an independently running Gateway remained alive.
- Codex contract check: `../codex/codex-rs/app-server-transport/src/transport/stdio.rs:49-79` drains stdin until EOF and reports connection closure; `../codex/codex-rs/app-server/src/lib.rs:1015-1035` exits the single-client server loop on that closure.
- Production delta: +6 lines. Test delta: +35 lines.

Testing:

```text
node scripts/run-vitest.mjs src/system-agent/setup-inference.test.ts src/commands/onboard-guided.quickstart.test.ts
# 160 passed

pnpm check:changed
# passed

.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
# scoped-clean; no actionable findings
```
