### PR TITLE
perf(security): avoid unnecessary Unicode marker folding

### DIFF
--- a/src/security/external-content.ts
+++ b/src/security/external-content.ts
@@ -153,8 +153,8 @@ const LLM_SPECIAL_TOKEN_PATTERN = new RegExp(
 
 const FULLWIDTH_ASCII_OFFSET = 0xfee0;
 
-// Map of Unicode angle bracket homoglyphs to their ASCII equivalents.
-const ANGLE_BRACKET_MAP: Record<number, string> = {
+// Finite character folds used only to locate spoofed external-content markers.
+const MARKER_CHAR_FOLDS: Record<number, string> = {
   0xff1c: "<", // fullwidth <
   0xff1e: ">", // fullwidth >
   0x2329: "<", // left-pointing angle bracket
@@ -183,43 +183,37 @@ const ANGLE_BRACKET_MAP: Record<number, string> = {
   0x276f: ">", // heavy right-pointing angle quotation mark ornament
   0x02c2: "<", // modifier letter left arrowhead
   0x02c3: ">", // modifier letter right arrowhead
+  0x200b: "", // zero width space
+  0x200c: "", // zero width non-joiner
+  0x200d: "", // zero width joiner
+  0x2060: "", // word joiner
+  0xfeff: "", // zero width no-break space
+  0x00ad: "", // soft hyphen
 };
 
-function foldMarkerChar(char: string): string {
-  const code = char.charCodeAt(0);
-  if (code >= 0xff21 && code <= 0xff3a) {
-    return String.fromCharCode(code - FULLWIDTH_ASCII_OFFSET);
+for (const start of [0xff21, 0xff41]) {
+  for (let code = start; code < start + 26; code += 1) {
+    MARKER_CHAR_FOLDS[code] = String.fromCharCode(code - FULLWIDTH_ASCII_OFFSET);
   }
-  if (code >= 0xff41 && code <= 0xff5a) {
-    return String.fromCharCode(code - FULLWIDTH_ASCII_OFFSET);
-  }
-  const bracket = ANGLE_BRACKET_MAP[code];
-  if (bracket) {
-    return bracket;
-  }
-  return char;
 }
 
-function isMarkerIgnorableChar(char: string): boolean {
-  const code = char.charCodeAt(0);
-  return (
-    code === 0x200b ||
-    code === 0x200c ||
-    code === 0x200d ||
-    code === 0x2060 ||
-    code === 0xfeff ||
-    code === 0x00ad
-  );
-}
+// Derive detection from the folds so new substitutions cannot bypass offset mapping.
+// Every key is a non-ASCII BMP code unit, not RegExp character-class syntax.
+const MARKER_FOLD_PATTERN = new RegExp(
+  `[${Object.keys(MARKER_CHAR_FOLDS)
+    .map((code) => String.fromCharCode(Number(code)))
+    .join("")}]`,
+  "u",
+);
 
 type FoldedMarkerMatch = {
   folded: string;
-  // ASCII folding is identity; all other retained code units need only their source start.
+  // Without folds, offsets are identity; changed text needs each retained source start.
   originalStartByFoldedIndex?: number[];
 };
 
 function foldMarkerTextWithIndexMap(input: string): FoldedMarkerMatch {
-  if (!/[\u0080-\u{10FFFF}]/u.test(input)) {
+  if (!MARKER_FOLD_PATTERN.test(input)) {
     return { folded: input };
   }
   let folded = "";
@@ -227,10 +221,11 @@ function foldMarkerTextWithIndexMap(input: string): FoldedMarkerMatch {
 
   for (let index = 0; index < input.length; index += 1) {
     const char = input.charAt(index);
-    if (isMarkerIgnorableChar(char)) {
+    const code = input.charCodeAt(index);
+    const foldedChar = code < 0x80 ? char : (MARKER_CHAR_FOLDS[code] ?? char);
+    if (foldedChar === "") {
       continue;
     }
-    const foldedChar = foldMarkerChar(char);
     folded += foldedChar;
     originalStartByFoldedIndex.push(index);
   }


### PR DESCRIPTION
External-content wrapping currently builds a folded copy and UTF-16 offset map for almost any non-ASCII text, even when none of its characters can alter an untrusted-content marker. Accented prose, CJK text and ordinary emoji therefore pay for a scan and allocations that leave the text unchanged.

This change puts the existing bracket, fullwidth-letter and ignorable-character substitutions in one finite table. A detector derived from that table skips mapping when offsets are already identical. When mapping is needed, ASCII characters bypass the table lookup. The marker grammar, clipping rules, metadata sanitization, special-token handling and security warnings stay unchanged. The two separate character helpers are removed. Formatted production delta is +24/−29, net −5; there are no test, dependency, configuration, SDK or storage changes.

The fixed before/candidate/candidate/before experiment retained all 768 observations and 30,016 full returned values. Representative complete-operation medians were:

| Workload | Before | After | Reduction across both run orders |
| --- | ---: | ---: | ---: |
| Accented article wrapping | 344–384 µs | 11.1–11.4 µs | 96.8–97.0% |
| CJK article wrapping | 391–392 µs | 29.9–31.0 µs | 92.1–92.4% |
| Large mixed article wrapping | 3.79–3.94 ms | 199–202 µs | 94.7–94.9% |
| Folded/ignored forged marker | 367–371 µs | 219–231 µs | 37.8–40.2% |
| Emoji article with joiners | 340–354 µs | 205–219 µs | 38.2–39.9% |
| Two-million-unit wrapper input | 79.7–80.6 ms | 2.22–2.24 ms | 97.2% |

The unchanged numerical gate passed, with no adverse measured medians. The small ASCII control's first 256-call blocks were slower by 14.82%/1.93% (about 0.606/0.074 µs per call); those results are retained. An earlier implementation without the ASCII bypass failed the control gate and remains a recorded failure. This is a fresh complete experiment with the same inputs, counts and thresholds, not a selective retry. The clocks include the complete public wrapping/truncation/search-normalization operation and result collection; they do not establish faster provider requests, network/spill throughput or Gateway startup.

Correctness proof pairs all 85 complete cases and 12 full row arrays, including every finite fold, long-S behavior, clipped markers, surrogates, metadata and special tokens. Separate native HTTP proofs exercise real inline and spilled `web_fetch` responses, retaining the entire spill and checking resource cleanup. Both source variants pass the same 166 existing tests across six whole suites in four native configurations. Independent agents verified every raw output, all timing observations, the emitted owners and the canonical suite reports. The measurements were frozen at `c07f048`; integration on newer `342cb21` again passed all 166 tests. The final formatting change only wraps a method chain across lines. Structured Codex review is clean.

The exact `37c3ca7` build passed, as did `pnpm check:changed`. A fresh isolated Gateway completed four real OpenAI turns, two sequential web fetches (Markdown and text, HTTP 200), and four health/status RPCs. An independent audit checked all delivered replies against the closed SQLite transcript, both complete spills, the actual Gateway CPU profile, all 12,487 build entries, and resource cleanup. This is live compatibility evidence, not a paired latency claim. The fixed numerical experiment above remains the performance evidence. The final structured Codex review found no actionable defects. Release-note context is captured here; the repository changelog is release-owned.

The branch was refreshed to `848d865` on current main after CI hit the already-repaired CLI state-directory integration test (#135495). The changed Unicode owner is byte-for-byte identical to `37c3ca7`; a fresh structured review remains clean. The live/build evidence above retains its original head, and the refreshed head runs normal CI before landing.
