### PR TITLE
fix: persist settled cron failure-alert outcomes

### DIFF
--- a/src/cron/cron-delivery-outcomes.e2e.test.ts
+++ b/src/cron/cron-delivery-outcomes.e2e.test.ts
@@ -370,15 +370,18 @@ describe.sequential("cron delivery outcomes", () => {
                   'Automation "required completion delivery" delivery failed\nLast error: primary route rejected',
               },
             });
-            expect(await persistedJob(storePath, job.id)).toMatchObject({
-              state: {
-                lastRunStatus: "ok",
-                lastDeliveryStatus: "not-delivered",
-                lastDeliveryError: "primary route rejected",
-                consecutiveErrors: 0,
-                lastFailureNotificationDeliveryStatus: "unknown",
-                lastFailureAlertAtMs: now,
-              },
+            await vi.waitFor(async () => {
+              expect(await persistedJob(storePath, job.id)).toMatchObject({
+                state: {
+                  lastRunStatus: "ok",
+                  lastDeliveryStatus: "not-delivered",
+                  lastDeliveryError: "primary route rejected",
+                  consecutiveErrors: 0,
+                  lastFailureNotificationDelivered: true,
+                  lastFailureNotificationDeliveryStatus: "delivered",
+                  lastFailureAlertAtMs: now,
+                },
+              });
             });
 
             now += 60_000;
@@ -443,8 +446,9 @@ describe.sequential("cron delivery outcomes", () => {
       async (state) => {
         const enqueueSystemEvent = vi.fn();
         const requestHeartbeat = vi.fn();
+        const storePath = state.path("cron", "jobs.json");
         const cron = new CronService({
-          storePath: state.path("cron", "jobs.json"),
+          storePath,
           cronEnabled: true,
           log: createNoopLogger(),
           enqueueSystemEvent,
@@ -495,6 +499,17 @@ describe.sequential("cron delivery outcomes", () => {
             reason: "wake",
             agentId: "work",
             sessionKey,
+          });
+          await vi.waitFor(async () => {
+            expect(await persistedJob(storePath, job.id)).toMatchObject({
+              state: {
+                lastFailureNotificationDelivered: false,
+                lastFailureNotificationDeliveryStatus: "not-delivered",
+                lastFailureNotificationDeliveryError: expect.stringContaining(
+                  "Blocked hostname or private/internal/special-use IP address",
+                ),
+              },
+            });
           });
         } finally {
           cron.stop();
@@ -562,12 +577,16 @@ describe.sequential("cron delivery outcomes", () => {
                   'Automation "skipped run alert" skipped 1 times\nSkip reason: requests-in-flight',
               },
             });
-            expect(await persistedJob(storePath, job.id)).toMatchObject({
-              state: {
-                lastRunStatus: "skipped",
-                consecutiveSkipped: 1,
-                lastFailureAlertAtMs: expect.any(Number),
-              },
+            await vi.waitFor(async () => {
+              expect(await persistedJob(storePath, job.id)).toMatchObject({
+                state: {
+                  lastRunStatus: "skipped",
+                  consecutiveSkipped: 1,
+                  lastFailureAlertAtMs: expect.any(Number),
+                  lastFailureNotificationDelivered: true,
+                  lastFailureNotificationDeliveryStatus: "delivered",
+                },
+              });
             });
             expect(historyEntry(storePath, job.id)).toMatchObject({
               status: "skipped",

--- a/src/cron/service.failure-alert-notifications.test.ts
+++ b/src/cron/service.failure-alert-notifications.test.ts
@@ -116,7 +116,12 @@ describe("CronService failure notification delivery", () => {
     const runner = startHeartbeatRunner({ cfg, readCurrentConfig: () => cfg, runOnce });
     const store = await makeStorePath();
     const resolveOriginDeliveryContext = vi.fn(() => deliveryContext);
-    const sendCronFailureAlert = vi.fn(async () => {
+    const sendCronFailureAlert = vi.fn(async (params) => {
+      await params.onDeliverySettled({
+        delivered: false,
+        status: "not-delivered",
+        error: "failure alert channel unavailable",
+      });
       throw new Error("failure alert channel unavailable");
     });
     const cron = new CronService({

--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -240,32 +240,30 @@ describe("CronService failure alerts", () => {
 
   it.each([
     {
-      name: "suppressed before reaching the recipient",
-      recipientReached: false,
+      name: "was not delivered",
+      outcome: { delivered: false, status: "not-delivered" as const },
       rejects: false,
       fallbackCalls: 1,
     },
     {
-      name: "suppressed after the recipient may have received it",
-      recipientReached: true,
+      name: "has an unknown outcome",
+      outcome: { status: "unknown" as const },
       rejects: false,
       fallbackCalls: 0,
     },
     {
-      name: "failed after reaching the recipient",
-      recipientReached: true,
-      rejects: true,
+      name: "was delivered",
+      outcome: { delivered: true, status: "delivered" as const },
+      rejects: false,
       fallbackCalls: 0,
     },
     {
-      name: "failed before reaching the recipient",
-      recipientReached: false,
-      rejects: true,
-      fallbackCalls: 1,
-    },
-    {
-      name: "rejected before a delivery attempt",
-      recipientReached: undefined,
+      name: "failed after settling as not delivered",
+      outcome: {
+        delivered: false,
+        status: "not-delivered" as const,
+        error: "failure alert delivery failed",
+      },
       rejects: true,
       fallbackCalls: 1,
     },
@@ -274,9 +272,7 @@ describe("CronService failure alerts", () => {
       { failureAlert: { enabled: true, after: 1 } },
       async ({ cron, sendCronFailureAlert, enqueueSystemEvent, addJob }) => {
         sendCronFailureAlert.mockImplementationOnce(async (alert) => {
-          if (testCase.recipientReached !== undefined) {
-            alert.onDeliveryAttempt?.(testCase.recipientReached);
-          }
+          await alert.onDeliverySettled(testCase.outcome);
           if (testCase.rejects) {
             throw new Error("failure alert delivery failed");
           }
@@ -286,14 +282,9 @@ describe("CronService failure alerts", () => {
         await cron.run(job.id, "force");
 
         expect(sendCronFailureAlert).toHaveBeenCalledOnce();
-        expect(enqueueSystemEvent).toHaveBeenCalledTimes(testCase.fallbackCalls);
-
-        const deliveryAttempt = alertCallArg(sendCronFailureAlert).onDeliveryAttempt;
-        expect(typeof deliveryAttempt).toBe("function");
-        if (typeof deliveryAttempt === "function") {
-          deliveryAttempt(false);
-        }
-        expect(enqueueSystemEvent).toHaveBeenCalledTimes(testCase.fallbackCalls);
+        await vi.waitFor(() =>
+          expect(enqueueSystemEvent).toHaveBeenCalledTimes(testCase.fallbackCalls),
+        );
       },
     );
   });

--- a/src/cron/service/failure-alerts.persistence.test.ts
+++ b/src/cron/service/failure-alerts.persistence.test.ts
@@ -482,3 +482,116 @@ describe("cron failure alert persistence", () => {
     });
   });
 });
+
+describe("cron failure alert outcome write-back", () => {
+  const dueAt = Date.parse("2026-08-01T15:00:00.000Z");
+  const endedAt = dueAt + 10;
+
+  async function runFailure(params: { id: string; sendCronFailureAlert: SendCronFailureAlert }) {
+    const store = fixtures.makeStorePath();
+    const job = createAlertJob({ id: params.id, dueAt });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+    const state = createAlertState({
+      storePath: store.storePath,
+      nowMs: () => endedAt,
+      sendCronFailureAlert: params.sendCronFailureAlert,
+    });
+    await finalizeAlertOutcome({
+      state,
+      job,
+      status: "error",
+      error: "provider unavailable",
+      startedAt: dueAt,
+      endedAt,
+    });
+    return { store, state };
+  }
+
+  it("persists a delivered outcome once the send settles", async () => {
+    const { store } = await runFailure({
+      id: "alert-outcome-delivered",
+      sendCronFailureAlert: vi.fn(async (params) => {
+        params.onDeliveryAttempt?.(true);
+      }),
+    });
+
+    await vi.waitFor(async () => {
+      expect((await loadCronStore(store.storePath)).jobs[0]?.state).toMatchObject({
+        lastFailureAlertAtMs: endedAt,
+        lastFailureNotificationDelivered: true,
+        lastFailureNotificationDeliveryStatus: "delivered",
+      });
+    });
+    expect(
+      (await loadCronStore(store.storePath)).jobs[0]?.state.lastFailureNotificationDeliveryError,
+    ).toBeUndefined();
+  });
+
+  it("persists a not-delivered outcome with the error when the send rejects", async () => {
+    const { store } = await runFailure({
+      id: "alert-outcome-rejected",
+      sendCronFailureAlert: vi.fn(async () => {
+        throw new Error("alert channel exploded");
+      }),
+    });
+
+    await vi.waitFor(async () => {
+      expect((await loadCronStore(store.storePath)).jobs[0]?.state).toMatchObject({
+        lastFailureNotificationDelivered: false,
+        lastFailureNotificationDeliveryStatus: "not-delivered",
+        lastFailureNotificationDeliveryError: expect.stringContaining("alert channel exploded"),
+      });
+    });
+  });
+
+  it("persists a not-delivered outcome when no delivery attempt reaches the recipient", async () => {
+    const { store } = await runFailure({
+      id: "alert-outcome-unreached",
+      sendCronFailureAlert: vi.fn(async (params) => {
+        params.onDeliveryAttempt?.(false);
+      }),
+    });
+
+    await vi.waitFor(async () => {
+      expect((await loadCronStore(store.storePath)).jobs[0]?.state).toMatchObject({
+        lastFailureNotificationDelivered: false,
+        lastFailureNotificationDeliveryStatus: "not-delivered",
+        lastFailureNotificationDeliveryError: expect.stringContaining("recipient not reached"),
+      });
+    });
+  });
+
+  it("does not clobber a newer alert cycle that owns the fields", async () => {
+    let resolveSend: (() => void) | undefined;
+    const sendGate = new Promise<void>((resolve) => {
+      resolveSend = resolve;
+    });
+    const sendCronFailureAlert = vi.fn(async (params) => {
+      await sendGate;
+      params.onDeliveryAttempt?.(true);
+    });
+    const { state } = await runFailure({
+      id: "alert-outcome-stale-cycle",
+      sendCronFailureAlert,
+    });
+
+    // A newer alert cycle re-requests the notification before the first send
+    // settles; the stale settle must not overwrite its fields.
+    const live = state.store?.jobs[0];
+    expect(live).toBeDefined();
+    live!.state.lastFailureAlertAtMs = endedAt + 60_000;
+    live!.state.lastFailureNotificationDelivered = undefined;
+    live!.state.lastFailureNotificationDeliveryStatus = "unknown";
+    live!.state.lastFailureNotificationDeliveryError = undefined;
+
+    resolveSend?.();
+    await sendCronFailureAlert.mock.results[0]?.value;
+    await state.op;
+
+    expect(live!.state).toMatchObject({
+      lastFailureAlertAtMs: endedAt + 60_000,
+      lastFailureNotificationDeliveryStatus: "unknown",
+    });
+    expect(live!.state.lastFailureNotificationDelivered).toBeUndefined();
+  });
+});

--- a/src/cron/service/failure-alerts.persistence.test.ts
+++ b/src/cron/service/failure-alerts.persistence.test.ts
@@ -602,6 +602,128 @@ describe("cron failure alert outcome write-back", () => {
     expect(persisted).not.toContain("abcdefghijklmnopqrstuvwxyz123456");
   });
 
+  it("does not overwrite a newer alert cycle committed by a sibling service", async () => {
+    const store = fixtures.makeStorePath();
+    const job = createAlertJob({ id: "alert-outcome-sibling-cycle", dueAt });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    // Service A: the send stays in flight while a sibling commits a newer cycle.
+    let releaseA: (() => void) | undefined;
+    const gateA = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    const sendA = vi.fn(async (params) => {
+      await gateA;
+      params.onDeliveryAttempt?.(true);
+    });
+    const stateA = createAlertState({
+      storePath: store.storePath,
+      nowMs: () => endedAt,
+      sendCronFailureAlert: sendA,
+    });
+    await finalizeAlertOutcome({
+      state: stateA,
+      job,
+      status: "error",
+      error: "provider unavailable",
+      startedAt: dueAt,
+      endedAt,
+    });
+
+    // Service B on the same store: a later failure past the cooldown starts a
+    // newer alert cycle and commits it.
+    const laterAt = endedAt + 600_000;
+    const sendB = vi.fn(async () => undefined);
+    const stateB = createAlertState({
+      storePath: store.storePath,
+      nowMs: () => laterAt,
+      sendCronFailureAlert: sendB,
+    });
+    const jobForB = structuredClone(job);
+    jobForB.state.runningAtMs = laterAt;
+    await finalizeAlertOutcome({
+      state: stateB,
+      job: jobForB,
+      status: "error",
+      error: "provider unavailable again",
+      startedAt: laterAt - 10,
+      endedAt: laterAt,
+    });
+    await vi.waitFor(async () => {
+      expect((await loadCronStore(store.storePath)).jobs[0]?.state.lastFailureAlertAtMs).toBe(
+        laterAt,
+      );
+    });
+
+    // Service A's delayed send settles with a stale snapshot; it must not
+    // overwrite the sibling's newer cycle.
+    releaseA?.();
+    await sendA.mock.results[0]?.value;
+    await Promise.resolve();
+    await stateA.op;
+    await Promise.resolve();
+    await stateA.op;
+
+    const persisted = (await loadCronStore(store.storePath)).jobs[0]?.state;
+    expect(persisted?.lastFailureAlertAtMs).toBe(laterAt);
+    expect(persisted?.lastFailureNotificationDelivered).not.toBe(true);
+  });
+
+  it("restores the live fields when the outcome persist fails", async () => {
+    const store = fixtures.makeStorePath();
+    const job = createAlertJob({ id: "alert-outcome-persist-restore", dueAt });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    let releaseSend: (() => void) | undefined;
+    const sendGate = new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    });
+    const sendCronFailureAlert = vi.fn(async (params) => {
+      await sendGate;
+      params.onDeliveryAttempt?.(true);
+    });
+    const state = createAlertState({
+      storePath: store.storePath,
+      nowMs: () => endedAt,
+      sendCronFailureAlert,
+    });
+    await finalizeAlertOutcome({
+      state,
+      job,
+      status: "error",
+      error: "provider unavailable",
+      startedAt: dueAt,
+      endedAt,
+    });
+
+    // The run itself is durable; from here on every write to this row fails.
+    const database = openOpenClawStateDatabase().db;
+    database.exec(`
+      CREATE TEMP TRIGGER reject_outcome_write
+      BEFORE UPDATE ON cron_jobs
+      WHEN NEW.store_key = '${cronStoreKey(store.storePath)}' AND NEW.job_id = '${job.id}'
+      BEGIN
+        SELECT RAISE(ABORT, 'outcome write failed');
+      END;
+    `);
+    try {
+      releaseSend?.();
+      await sendCronFailureAlert.mock.results[0]?.value;
+      await Promise.resolve();
+      await state.op;
+      await Promise.resolve();
+      await state.op;
+
+      // The live gateway must not report an outcome SQLite refused to commit.
+      const live = state.store?.jobs[0]?.state;
+      expect(live?.lastFailureNotificationDeliveryStatus).toBe("unknown");
+      expect(live?.lastFailureNotificationDelivered).toBeUndefined();
+      expect(live?.lastFailureNotificationDeliveryError).toBeUndefined();
+    } finally {
+      database.exec("DROP TRIGGER IF EXISTS reject_outcome_write;");
+    }
+  });
+
   it("does not clobber a newer alert cycle that owns the fields", async () => {
     let resolveSend: (() => void) | undefined;
     const sendGate = new Promise<void>((resolve) => {

--- a/src/cron/service/failure-alerts.persistence.test.ts
+++ b/src/cron/service/failure-alerts.persistence.test.ts
@@ -5,6 +5,7 @@ import {
   noopLogger,
   setupCronRegressionFixtures,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
 import { markCronJobActive } from "../active-jobs.js";
 import { loadCronStore, saveCronStore } from "../store.js";
@@ -559,6 +560,46 @@ describe("cron failure alert outcome write-back", () => {
         lastFailureNotificationDeliveryError: expect.stringContaining("recipient not reached"),
       });
     });
+  });
+
+  it("keeps the reach fact when the send rejects after a successful delivery attempt", async () => {
+    const { store } = await runFailure({
+      id: "alert-outcome-reach-then-reject",
+      sendCronFailureAlert: vi.fn(async (params) => {
+        params.onDeliveryAttempt?.(true);
+        throw new Error("later delivery work failed");
+      }),
+    });
+
+    await vi.waitFor(async () => {
+      expect((await loadCronStore(store.storePath)).jobs[0]?.state).toMatchObject({
+        lastFailureNotificationDelivered: true,
+        lastFailureNotificationDeliveryStatus: "delivered",
+        lastFailureNotificationDeliveryError: expect.stringContaining("later delivery work failed"),
+      });
+    });
+  });
+
+  it("redacts transport errors before persisting them", async () => {
+    const err = new Error(
+      "webhook rejected: token=abcdefghijklmnopqrstuvwxyz123456 for https://alerts.example.test",
+    );
+    const { store } = await runFailure({
+      id: "alert-outcome-redacted-error",
+      sendCronFailureAlert: vi.fn(async () => {
+        throw err;
+      }),
+    });
+
+    await vi.waitFor(async () => {
+      expect(
+        (await loadCronStore(store.storePath)).jobs[0]?.state.lastFailureNotificationDeliveryStatus,
+      ).toBe("not-delivered");
+    });
+    const persisted = (await loadCronStore(store.storePath)).jobs[0]?.state
+      .lastFailureNotificationDeliveryError;
+    expect(persisted).toBe(formatErrorMessage(err));
+    expect(persisted).not.toContain("abcdefghijklmnopqrstuvwxyz123456");
   });
 
   it("does not clobber a newer alert cycle that owns the fields", async () => {

--- a/src/cron/service/failure-alerts.persistence.test.ts
+++ b/src/cron/service/failure-alerts.persistence.test.ts
@@ -10,7 +10,8 @@ import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
 import { markCronJobActive } from "../active-jobs.js";
 import { loadCronStore, saveCronStore } from "../store.js";
 import { cronStoreKey } from "../store/key.js";
-import type { CronJob, CronRunStatus } from "../types.js";
+import type { CronFailureNotificationDelivery, CronJob, CronRunStatus } from "../types.js";
+import { stop as stopCronService } from "./ops-lifecycle.js";
 import { restoreFinalizedStartupRun } from "./startup-run-repair.js";
 import { createCronServiceState } from "./state.js";
 import { finalizeCompletedCronRunOutcomes } from "./timer-outcome-finalization.js";
@@ -508,86 +509,57 @@ describe("cron failure alert outcome write-back", () => {
     return { store, state };
   }
 
-  it("persists a delivered outcome once the send settles", async () => {
-    const { store } = await runFailure({
-      id: "alert-outcome-delivered",
-      sendCronFailureAlert: vi.fn(async (params) => {
-        params.onDeliveryAttempt?.(true);
-      }),
-    });
-
-    await vi.waitFor(async () => {
-      expect((await loadCronStore(store.storePath)).jobs[0]?.state).toMatchObject({
-        lastFailureAlertAtMs: endedAt,
-        lastFailureNotificationDelivered: true,
-        lastFailureNotificationDeliveryStatus: "delivered",
+  it.each([
+    {
+      name: "delivered",
+      outcome: { delivered: true, status: "delivered" },
+    },
+    {
+      name: "not delivered",
+      outcome: {
+        delivered: false,
+        status: "not-delivered",
+        error: "alert channel exploded",
+      },
+    },
+    {
+      name: "unknown",
+      outcome: { status: "unknown", error: "later delivery work failed" },
+    },
+  ] satisfies Array<{ name: string; outcome: CronFailureNotificationDelivery }>)(
+    "persists a $name outcome once the send settles",
+    async ({ name, outcome }) => {
+      const { store } = await runFailure({
+        id: `alert-outcome-${name.replaceAll(" ", "-")}`,
+        sendCronFailureAlert: vi.fn(async (params) => {
+          await params.onDeliverySettled(outcome);
+        }),
       });
-    });
-    expect(
-      (await loadCronStore(store.storePath)).jobs[0]?.state.lastFailureNotificationDeliveryError,
-    ).toBeUndefined();
-  });
 
-  it("persists a not-delivered outcome with the error when the send rejects", async () => {
-    const { store } = await runFailure({
-      id: "alert-outcome-rejected",
-      sendCronFailureAlert: vi.fn(async () => {
-        throw new Error("alert channel exploded");
-      }),
-    });
-
-    await vi.waitFor(async () => {
-      expect((await loadCronStore(store.storePath)).jobs[0]?.state).toMatchObject({
-        lastFailureNotificationDelivered: false,
-        lastFailureNotificationDeliveryStatus: "not-delivered",
-        lastFailureNotificationDeliveryError: expect.stringContaining("alert channel exploded"),
+      await vi.waitFor(async () => {
+        expect((await loadCronStore(store.storePath)).jobs[0]?.state).toMatchObject({
+          lastFailureAlertAtMs: endedAt,
+          lastFailureNotificationDeliveryStatus: outcome.status,
+        });
       });
-    });
-  });
-
-  it("persists a not-delivered outcome when no delivery attempt reaches the recipient", async () => {
-    const { store } = await runFailure({
-      id: "alert-outcome-unreached",
-      sendCronFailureAlert: vi.fn(async (params) => {
-        params.onDeliveryAttempt?.(false);
-      }),
-    });
-
-    await vi.waitFor(async () => {
-      expect((await loadCronStore(store.storePath)).jobs[0]?.state).toMatchObject({
-        lastFailureNotificationDelivered: false,
-        lastFailureNotificationDeliveryStatus: "not-delivered",
-        lastFailureNotificationDeliveryError: expect.stringContaining("recipient not reached"),
-      });
-    });
-  });
-
-  it("keeps the reach fact when the send rejects after a successful delivery attempt", async () => {
-    const { store } = await runFailure({
-      id: "alert-outcome-reach-then-reject",
-      sendCronFailureAlert: vi.fn(async (params) => {
-        params.onDeliveryAttempt?.(true);
-        throw new Error("later delivery work failed");
-      }),
-    });
-
-    await vi.waitFor(async () => {
-      expect((await loadCronStore(store.storePath)).jobs[0]?.state).toMatchObject({
-        lastFailureNotificationDelivered: true,
-        lastFailureNotificationDeliveryStatus: "delivered",
-        lastFailureNotificationDeliveryError: expect.stringContaining("later delivery work failed"),
-      });
-    });
-  });
+      const persisted = (await loadCronStore(store.storePath)).jobs[0]?.state;
+      expect(persisted?.lastFailureNotificationDelivered).toBe(outcome.delivered);
+      expect(persisted?.lastFailureNotificationDeliveryError).toBe(outcome.error);
+    },
+  );
 
   it("redacts transport errors before persisting them", async () => {
     const err = new Error(
-      "webhook rejected: token=abcdefghijklmnopqrstuvwxyz123456 for https://alerts.example.test",
+      `webhook rejected: token=abcdefghijklmnopqrstuvwxyz123456 ${"x".repeat(2_000)}`,
     );
     const { store } = await runFailure({
       id: "alert-outcome-redacted-error",
-      sendCronFailureAlert: vi.fn(async () => {
-        throw err;
+      sendCronFailureAlert: vi.fn(async (params) => {
+        await params.onDeliverySettled({
+          delivered: false,
+          status: "not-delivered",
+          error: err.message,
+        });
       }),
     });
 
@@ -598,7 +570,8 @@ describe("cron failure alert outcome write-back", () => {
     });
     const persisted = (await loadCronStore(store.storePath)).jobs[0]?.state
       .lastFailureNotificationDeliveryError;
-    expect(persisted).toBe(formatErrorMessage(err));
+    expect(persisted).toHaveLength(1_000);
+    expect(formatErrorMessage(err).length).toBeGreaterThan(1_000);
     expect(persisted).not.toContain("abcdefghijklmnopqrstuvwxyz123456");
   });
 
@@ -614,7 +587,7 @@ describe("cron failure alert outcome write-back", () => {
     });
     const sendA = vi.fn(async (params) => {
       await gateA;
-      params.onDeliveryAttempt?.(true);
+      await params.onDeliverySettled({ delivered: true, status: "delivered" });
     });
     const stateA = createAlertState({
       storePath: store.storePath,
@@ -633,7 +606,13 @@ describe("cron failure alert outcome write-back", () => {
     // Service B on the same store: a later failure past the cooldown starts a
     // newer alert cycle and commits it.
     const laterAt = endedAt + 600_000;
-    const sendB = vi.fn(async () => undefined);
+    const sendB = vi.fn(async (params) => {
+      await params.onDeliverySettled({
+        delivered: false,
+        status: "not-delivered",
+        error: "recipient not reached",
+      });
+    });
     const stateB = createAlertState({
       storePath: store.storePath,
       nowMs: () => laterAt,
@@ -680,7 +659,7 @@ describe("cron failure alert outcome write-back", () => {
     });
     const sendCronFailureAlert = vi.fn(async (params) => {
       await sendGate;
-      params.onDeliveryAttempt?.(true);
+      await params.onDeliverySettled({ delivered: false, status: "not-delivered" });
     });
     const state = createAlertState({
       storePath: store.storePath,
@@ -719,42 +698,77 @@ describe("cron failure alert outcome write-back", () => {
       expect(live?.lastFailureNotificationDeliveryStatus).toBe("unknown");
       expect(live?.lastFailureNotificationDelivered).toBeUndefined();
       expect(live?.lastFailureNotificationDeliveryError).toBeUndefined();
+      const durable = (await loadCronStore(store.storePath)).jobs[0]?.state;
+      expect(durable?.lastFailureNotificationDeliveryStatus).toBe("unknown");
+      expect(durable?.lastFailureNotificationDelivered).toBeUndefined();
+      expect(durable?.lastFailureNotificationDeliveryError).toBeUndefined();
+      expect(state.deps.enqueueSystemEvent).toHaveBeenCalledOnce();
     } finally {
       database.exec("DROP TRIGGER IF EXISTS reject_outcome_write;");
     }
   });
 
-  it("does not clobber a newer alert cycle that owns the fields", async () => {
+  it("does not overwrite a newer run in the same alert cooldown cycle", async () => {
     let resolveSend: (() => void) | undefined;
     const sendGate = new Promise<void>((resolve) => {
       resolveSend = resolve;
     });
     const sendCronFailureAlert = vi.fn(async (params) => {
       await sendGate;
-      params.onDeliveryAttempt?.(true);
+      await params.onDeliverySettled({ delivered: false, status: "not-delivered" });
     });
-    const { state } = await runFailure({
-      id: "alert-outcome-stale-cycle",
+    const { store, state } = await runFailure({
+      id: "alert-outcome-same-cycle-newer-run",
       sendCronFailureAlert,
     });
-
-    // A newer alert cycle re-requests the notification before the first send
-    // settles; the stale settle must not overwrite its fields.
-    const live = state.store?.jobs[0];
-    expect(live).toBeDefined();
-    live!.state.lastFailureAlertAtMs = endedAt + 60_000;
-    live!.state.lastFailureNotificationDelivered = undefined;
-    live!.state.lastFailureNotificationDeliveryStatus = "unknown";
-    live!.state.lastFailureNotificationDeliveryError = undefined;
+    const currentJob = state.store?.jobs[0];
+    if (!currentJob) {
+      throw new Error("expected persisted cron job");
+    }
+    const laterAt = endedAt + 1_000;
+    currentJob.state.runningAtMs = laterAt;
+    await finalizeAlertOutcome({
+      state,
+      job: currentJob,
+      status: "error",
+      error: "provider still unavailable",
+      startedAt: laterAt,
+      endedAt: laterAt + 10,
+    });
+    expect(sendCronFailureAlert).toHaveBeenCalledOnce();
 
     resolveSend?.();
     await sendCronFailureAlert.mock.results[0]?.value;
-    await state.op;
+    const durable = (await loadCronStore(store.storePath)).jobs[0]?.state;
+    expect(durable).toMatchObject({
+      lastRunAtMs: laterAt,
+      lastFailureAlertAtMs: endedAt,
+      lastFailureNotificationDeliveryStatus: "not-requested",
+    });
+    expect(state.deps.enqueueSystemEvent).not.toHaveBeenCalled();
+  });
 
-    expect(live!.state).toMatchObject({
-      lastFailureAlertAtMs: endedAt + 60_000,
+  it("does not write after the service lifecycle retires", async () => {
+    let resolveSend: (() => void) | undefined;
+    const sendGate = new Promise<void>((resolve) => {
+      resolveSend = resolve;
+    });
+    const sendCronFailureAlert = vi.fn(async (params) => {
+      await sendGate;
+      await params.onDeliverySettled({ delivered: false, status: "not-delivered" });
+    });
+    const { store, state } = await runFailure({
+      id: "alert-outcome-retired-lifecycle",
+      sendCronFailureAlert,
+    });
+
+    stopCronService(state);
+    resolveSend?.();
+    await sendCronFailureAlert.mock.results[0]?.value;
+
+    expect((await loadCronStore(store.storePath)).jobs[0]?.state).toMatchObject({
       lastFailureNotificationDeliveryStatus: "unknown",
     });
-    expect(live!.state.lastFailureNotificationDelivered).toBeUndefined();
+    expect(state.deps.enqueueSystemEvent).not.toHaveBeenCalled();
   });
 });

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -250,13 +250,10 @@ function transportFailureAlert(
     pendingFallback = false;
   };
   if (!state.deps.sendCronFailureAlert) {
+    // No transport means no send whose outcome could be recorded: the alert
+    // goes straight to the in-app fallback queue and the intent stays
+    // "unknown", matching the pre-existing contract for transport-less setups.
     fallback();
-    void recordFailureAlertOutcome(state, {
-      jobId,
-      alertAtMs,
-      delivered: false,
-      error: "failure-alert transport unavailable; queued as in-app notification",
-    });
     return;
   }
   void state.deps

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -19,7 +19,9 @@ import type {
   CronJob,
   CronMessageChannel,
 } from "../types.js";
+import { locked } from "./locked.js";
 import type { CronServiceState, DeferredCronNotifications } from "./state.js";
+import { persist } from "./store.js";
 import { enqueueCronNotification } from "./wake.js";
 
 const DEFAULT_FAILURE_ALERT_AFTER = 2;
@@ -192,6 +194,42 @@ export function resolveFailureAlert(
   };
 }
 
+/**
+ * Writes the settled outcome of a failure-alert send back onto the live job so
+ * `cron get`/`cron runs` stop reporting the pre-send "unknown" forever. The job
+ * is re-resolved by id because the transport may hold a snapshot, and the
+ * write-back is skipped when a newer alert cycle owns the fields.
+ */
+async function recordFailureAlertOutcome(
+  state: CronServiceState,
+  params: {
+    jobId: string;
+    alertAtMs: number | undefined;
+    delivered: boolean;
+    error?: string;
+  },
+): Promise<void> {
+  try {
+    await locked(state, async () => {
+      const job = state.store?.jobs.find((entry) => entry.id === params.jobId);
+      if (!job || job.state.lastFailureAlertAtMs !== params.alertAtMs) {
+        return;
+      }
+      job.state.lastFailureNotificationDelivered = params.delivered;
+      job.state.lastFailureNotificationDeliveryStatus = params.delivered
+        ? "delivered"
+        : "not-delivered";
+      job.state.lastFailureNotificationDeliveryError = params.error;
+      await persist(state, { stateOnly: true });
+    });
+  } catch (err) {
+    state.deps.log.warn(
+      { jobId: params.jobId, err: String(err) },
+      "cron: failed to record failure-alert outcome",
+    );
+  }
+}
+
 function transportFailureAlert(
   state: CronServiceState,
   params: {
@@ -201,15 +239,24 @@ function transportFailureAlert(
     route: ResolvedFailureAlert;
   },
 ): void {
+  const jobId = params.job.id;
+  const alertAtMs = params.job.state.lastFailureAlertAtMs;
+  let reachedRecipient = false;
   let pendingFallback = true;
-  const fallback = (reachedRecipient = false) => {
-    if (pendingFallback && !reachedRecipient) {
+  const fallback = (reached = false) => {
+    if (pendingFallback && !reached) {
       enqueueCronNotification(state, params.job, params.payload.text ?? "", "failure-alert");
     }
     pendingFallback = false;
   };
   if (!state.deps.sendCronFailureAlert) {
     fallback();
+    void recordFailureAlertOutcome(state, {
+      jobId,
+      alertAtMs,
+      delivered: false,
+      error: "failure-alert transport unavailable; queued as in-app notification",
+    });
     return;
   }
   void state.deps
@@ -223,14 +270,33 @@ function transportFailureAlert(
       accountId: params.route.accountId,
       threadId: params.route.threadId,
       ...(params.route.alternateRoute ? { inheritSessionThread: false as const } : {}),
-      onDeliveryAttempt: fallback,
+      onDeliveryAttempt: (reached) => {
+        reachedRecipient ||= reached;
+        fallback(reached);
+      },
     })
+    .then(() =>
+      recordFailureAlertOutcome(state, {
+        jobId,
+        alertAtMs,
+        delivered: reachedRecipient,
+        error: reachedRecipient
+          ? undefined
+          : "recipient not reached; queued as in-app notification",
+      }),
+    )
     .catch((err: unknown) => {
       state.deps.log.warn(
         { jobId: params.job.id, err: String(err) },
         "cron: failure alert delivery failed",
       );
       fallback();
+      void recordFailureAlertOutcome(state, {
+        jobId,
+        alertAtMs,
+        delivered: false,
+        error: String(err),
+      });
     });
 }
 

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -22,7 +22,7 @@ import type {
 } from "../types.js";
 import { locked } from "./locked.js";
 import type { CronServiceState, DeferredCronNotifications } from "./state.js";
-import { persist } from "./store.js";
+import { ensureLoaded, persist } from "./store.js";
 import { enqueueCronNotification } from "./wake.js";
 
 const DEFAULT_FAILURE_ALERT_AFTER = 2;
@@ -213,16 +213,36 @@ async function recordFailureAlertOutcome(
 ): Promise<void> {
   try {
     await locked(state, async () => {
+      // A sibling service on the same store partition may have committed a
+      // newer snapshot while this send was in flight; refresh the cached
+      // store before validating so a stale snapshot cannot overwrite a newer
+      // alert cycle. ensureLoaded is a no-op when no sibling committed.
+      await ensureLoaded(state);
       const job = state.store?.jobs.find((entry) => entry.id === params.jobId);
       if (!job || job.state.lastFailureAlertAtMs !== params.alertAtMs) {
         return;
       }
+      const prior = {
+        delivered: job.state.lastFailureNotificationDelivered,
+        status: job.state.lastFailureNotificationDeliveryStatus,
+        error: job.state.lastFailureNotificationDeliveryError,
+      };
       job.state.lastFailureNotificationDelivered = params.delivered;
       job.state.lastFailureNotificationDeliveryStatus = params.delivered
         ? "delivered"
         : "not-delivered";
       job.state.lastFailureNotificationDeliveryError = params.error;
-      await persist(state, { stateOnly: true });
+      try {
+        await persist(state, { stateOnly: true });
+      } catch (persistErr) {
+        // Never let the live gateway report an outcome SQLite refused to
+        // commit; a later unrelated persist would make the stale value
+        // durable.
+        job.state.lastFailureNotificationDelivered = prior.delivered;
+        job.state.lastFailureNotificationDeliveryStatus = prior.status;
+        job.state.lastFailureNotificationDeliveryError = prior.error;
+        throw persistErr;
+      }
     });
   } catch (err) {
     state.deps.log.warn(

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -9,6 +9,7 @@ import type { FailoverReason } from "../../agents/failover/signal.js";
 import { buildCodexLoginRecovery } from "../../auto-reply/codex-login-recovery.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { normalizeAnyChannelId } from "../../channels/registry-normalize.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveTargetPrefixedChannel } from "../../infra/outbound/channel-target-prefix.js";
 import { normalizeTargetForProvider } from "../../infra/outbound/target-normalization.js";
 import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-plan.js";
@@ -196,8 +197,9 @@ export function resolveFailureAlert(
 
 /**
  * Writes the settled outcome of a failure-alert send back onto the live job so
- * `cron get`/`cron runs` stop reporting the pre-send "unknown" forever. The job
- * is re-resolved by id because the transport may hold a snapshot, and the
+ * `cron get` stops reporting the pre-send "unknown" forever. Run-history
+ * entries snapshot these fields at run finalization and are not revised. The
+ * job is re-resolved by id because the transport may hold a snapshot, and the
  * write-back is skipped when a newer alert cycle owns the fields.
  */
 async function recordFailureAlertOutcome(
@@ -288,11 +290,14 @@ function transportFailureAlert(
         "cron: failure alert delivery failed",
       );
       fallback();
+      // A send can report a successful delivery attempt and then reject for
+      // later partial work; the recipient was still reached, so keep the
+      // rejection as diagnostic context instead of overwriting the reach fact.
       void recordFailureAlertOutcome(state, {
         jobId,
         alertAtMs,
-        delivered: false,
-        error: String(err),
+        delivered: reachedRecipient,
+        error: formatErrorMessage(err),
       });
     });
 }

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -21,8 +21,8 @@ import type {
   CronMessageChannel,
 } from "../types.js";
 import { locked } from "./locked.js";
+import { applyCronRuntimeRowsToState, commitCronRuntimeRows } from "./runtime-store.js";
 import type { CronServiceState, DeferredCronNotifications } from "./state.js";
-import { ensureLoaded, persist } from "./store.js";
 import { enqueueCronNotification } from "./wake.js";
 
 const DEFAULT_FAILURE_ALERT_AFTER = 2;
@@ -195,60 +195,63 @@ export function resolveFailureAlert(
   };
 }
 
-/**
- * Writes the settled outcome of a failure-alert send back onto the live job so
- * `cron get` stops reporting the pre-send "unknown" forever. Run-history
- * entries snapshot these fields at run finalization and are not revised. The
- * job is re-resolved by id because the transport may hold a snapshot, and the
- * write-back is skipped when a newer alert cycle owns the fields.
- */
+type FailureAlertCycle = {
+  alertAtMs: number | undefined;
+  jobId: string;
+  lifecycleGeneration: number;
+  runAtMs: number | undefined;
+};
+
+const FAILURE_ALERT_ERROR_MAX_LENGTH = 1_000;
+type FailureAlertRecordResult = "recorded" | "stale" | "persistence-failed";
+
+/** Writes one settled transport fact while the exact alert cycle still owns the row. */
 async function recordFailureAlertOutcome(
   state: CronServiceState,
-  params: {
-    jobId: string;
-    alertAtMs: number | undefined;
-    delivered: boolean;
-    error?: string;
-  },
-): Promise<void> {
+  cycle: FailureAlertCycle,
+  outcome: CronFailureNotificationDelivery,
+): Promise<FailureAlertRecordResult> {
+  let ownsCycle = false;
   try {
-    await locked(state, async () => {
-      // A sibling service on the same store partition may have committed a
-      // newer snapshot while this send was in flight; refresh the cached
-      // store before validating so a stale snapshot cannot overwrite a newer
-      // alert cycle. ensureLoaded is a no-op when no sibling committed.
-      await ensureLoaded(state);
-      const job = state.store?.jobs.find((entry) => entry.id === params.jobId);
-      if (!job || job.state.lastFailureAlertAtMs !== params.alertAtMs) {
-        return;
+    return await locked(state, async () => {
+      if (state.stopped || state.lifecycleGeneration !== cycle.lifecycleGeneration) {
+        return "stale";
       }
-      const prior = {
-        delivered: job.state.lastFailureNotificationDelivered,
-        status: job.state.lastFailureNotificationDeliveryStatus,
-        error: job.state.lastFailureNotificationDeliveryError,
-      };
-      job.state.lastFailureNotificationDelivered = params.delivered;
-      job.state.lastFailureNotificationDeliveryStatus = params.delivered
-        ? "delivered"
-        : "not-delivered";
-      job.state.lastFailureNotificationDeliveryError = params.error;
-      try {
-        await persist(state, { stateOnly: true });
-      } catch (persistErr) {
-        // Never let the live gateway report an outcome SQLite refused to
-        // commit; a later unrelated persist would make the stale value
-        // durable.
-        job.state.lastFailureNotificationDelivered = prior.delivered;
-        job.state.lastFailureNotificationDeliveryStatus = prior.status;
-        job.state.lastFailureNotificationDeliveryError = prior.error;
-        throw persistErr;
+      const committedJob = commitCronRuntimeRows({
+        state,
+        jobIds: [cycle.jobId],
+        operationLabel: "cron.failure-alert-outcome",
+        mutate: ({ jobs }) => {
+          const job = jobs.get(cycle.jobId);
+          if (
+            !job ||
+            job.state.lastRunAtMs !== cycle.runAtMs ||
+            job.state.lastFailureAlertAtMs !== cycle.alertAtMs ||
+            job.state.lastFailureNotificationDeliveryStatus !== "unknown"
+          ) {
+            return { value: undefined };
+          }
+          ownsCycle = true;
+          job.state.lastFailureNotificationDelivered = outcome.delivered;
+          job.state.lastFailureNotificationDeliveryStatus = outcome.status;
+          job.state.lastFailureNotificationDeliveryError = outcome.error
+            ? truncateUtf16Safe(formatErrorMessage(outcome.error), FAILURE_ALERT_ERROR_MAX_LENGTH)
+            : undefined;
+          return { upsertJobIds: [job.id], value: job };
+        },
+      });
+      if (committedJob) {
+        applyCronRuntimeRowsToState(state, [committedJob], [], { publish: false });
+        return "recorded";
       }
+      return "stale";
     });
   } catch (err) {
     state.deps.log.warn(
-      { jobId: params.jobId, err: String(err) },
+      { jobId: cycle.jobId, err: formatErrorMessage(err) },
       "cron: failed to record failure-alert outcome",
     );
+    return ownsCycle ? "persistence-failed" : "stale";
   }
 }
 
@@ -263,19 +266,12 @@ function transportFailureAlert(
 ): void {
   const jobId = params.job.id;
   const alertAtMs = params.job.state.lastFailureAlertAtMs;
-  let reachedRecipient = false;
-  let pendingFallback = true;
-  const fallback = (reached = false) => {
-    if (pendingFallback && !reached) {
-      enqueueCronNotification(state, params.job, params.payload.text ?? "", "failure-alert");
-    }
-    pendingFallback = false;
-  };
+  const lifecycleGeneration = state.lifecycleGeneration;
   if (!state.deps.sendCronFailureAlert) {
     // No transport means no send whose outcome could be recorded: the alert
     // goes straight to the in-app fallback queue and the intent stays
     // "unknown", matching the pre-existing contract for transport-less setups.
-    fallback();
+    enqueueCronNotification(state, params.job, params.payload.text ?? "", "failure-alert");
     return;
   }
   void state.deps
@@ -289,36 +285,22 @@ function transportFailureAlert(
       accountId: params.route.accountId,
       threadId: params.route.threadId,
       ...(params.route.alternateRoute ? { inheritSessionThread: false as const } : {}),
-      onDeliveryAttempt: (reached) => {
-        reachedRecipient ||= reached;
-        fallback(reached);
+      onDeliverySettled: async (outcome) => {
+        const recordResult = await recordFailureAlertOutcome(
+          state,
+          { jobId, alertAtMs, runAtMs: params.runAtMs, lifecycleGeneration },
+          outcome,
+        );
+        if (recordResult !== "stale" && outcome.status === "not-delivered") {
+          enqueueCronNotification(state, params.job, params.payload.text ?? "", "failure-alert");
+        }
       },
     })
-    .then(() =>
-      recordFailureAlertOutcome(state, {
-        jobId,
-        alertAtMs,
-        delivered: reachedRecipient,
-        error: reachedRecipient
-          ? undefined
-          : "recipient not reached; queued as in-app notification",
-      }),
-    )
     .catch((err: unknown) => {
       state.deps.log.warn(
         { jobId: params.job.id, err: String(err) },
         "cron: failure alert delivery failed",
       );
-      fallback();
-      // A send can report a successful delivery attempt and then reject for
-      // later partial work; the recipient was still reached, so keep the
-      // rejection as diagnostic context instead of overwriting the reach fact.
-      void recordFailureAlertOutcome(state, {
-        jobId,
-        alertAtMs,
-        delivered: reachedRecipient,
-        error: formatErrorMessage(err),
-      });
     });
 }
 

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -292,7 +292,8 @@ export type CronServiceDeps = {
     accountId?: string;
     threadId?: string | number;
     inheritSessionThread?: false;
-    onDeliveryAttempt?: (reachedRecipient: boolean) => void;
+    /** Persists the transport-owned terminal fact before Gateway work admission releases. */
+    onDeliverySettled: (outcome: CronFailureNotificationDelivery) => Promise<void>;
   }) => Promise<void>;
   onEvent?: (evt: CronEvent, context?: CronEventContext) => void;
 };

--- a/src/cron/service/timer.timeout-watchdog.test.ts
+++ b/src/cron/service/timer.timeout-watchdog.test.ts
@@ -830,7 +830,7 @@ describe("cron service timer regressions", () => {
         accountId: undefined,
         threadId: undefined,
         inheritSessionThread: false,
-        onDeliveryAttempt: expect.any(Function),
+        onDeliverySettled: expect.any(Function),
       });
     } finally {
       vi.useRealTimers();

--- a/src/gateway/server-cron-notifications.presentation.test.ts
+++ b/src/gateway/server-cron-notifications.presentation.test.ts
@@ -14,12 +14,24 @@ vi.mock("../cron/delivery.js", async (importOriginal) => {
   };
 });
 
-import { sendGatewayCronFailureAlert } from "./server-cron-notifications.js";
+import { sendGatewayCronFailureAlert as sendGatewayCronFailureAlertBase } from "./server-cron-notifications.js";
+
+const sendGatewayCronFailureAlert = (
+  params: Omit<Parameters<typeof sendGatewayCronFailureAlertBase>[0], "onDeliverySettled">,
+) =>
+  sendGatewayCronFailureAlertBase({
+    ...params,
+    onDeliverySettled: async () => {},
+  });
 
 describe("sendGatewayCronFailureAlert presentation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.sendCronAnnouncePayloadStrict.mockResolvedValue(undefined);
+    mocks.sendCronAnnouncePayloadStrict.mockResolvedValue({
+      status: "sent",
+      results: [],
+      receipt: { primaryPlatformMessageId: undefined, platformMessageIds: [], parts: [] },
+    });
   });
 
   it.each([

--- a/src/gateway/server-cron-notifications.presentation.test.ts
+++ b/src/gateway/server-cron-notifications.presentation.test.ts
@@ -30,7 +30,12 @@ describe("sendGatewayCronFailureAlert presentation", () => {
     mocks.sendCronAnnouncePayloadStrict.mockResolvedValue({
       status: "sent",
       results: [],
-      receipt: { primaryPlatformMessageId: undefined, platformMessageIds: [], parts: [] },
+      receipt: {
+        primaryPlatformMessageId: undefined,
+        platformMessageIds: [],
+        parts: [],
+        sentAt: 0,
+      },
     });
   });
 

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -50,7 +50,7 @@ function sentFailureAlert() {
   return {
     status: "sent" as const,
     results: [],
-    receipt: { primaryPlatformMessageId: undefined, platformMessageIds: [], parts: [] },
+    receipt: { primaryPlatformMessageId: undefined, platformMessageIds: [], parts: [], sentAt: 0 },
   };
 }
 

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -35,8 +35,24 @@ vi.mock("../cron/delivery.js", async (importOriginal) => {
 
 import {
   dispatchGatewayCronFinishedNotifications,
-  sendGatewayCronFailureAlert,
+  sendGatewayCronFailureAlert as sendGatewayCronFailureAlertBase,
 } from "./server-cron-notifications.js";
+
+const sendGatewayCronFailureAlert = (
+  params: Omit<Parameters<typeof sendGatewayCronFailureAlertBase>[0], "onDeliverySettled">,
+) =>
+  sendGatewayCronFailureAlertBase({
+    ...params,
+    onDeliverySettled: async () => {},
+  });
+
+function sentFailureAlert() {
+  return {
+    status: "sent" as const,
+    results: [],
+    receipt: { primaryPlatformMessageId: undefined, platformMessageIds: [], parts: [] },
+  };
+}
 
 function waitForFast(assertion: () => void | Promise<void>) {
   return vi.waitFor(assertion, { interval: 1 });
@@ -104,7 +120,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       finalUrl: "https://example.invalid/cron",
       release: vi.fn(async () => {}),
     }));
-    mocks.sendCronAnnouncePayloadStrict.mockResolvedValue(undefined);
+    mocks.sendCronAnnouncePayloadStrict.mockResolvedValue(sentFailureAlert());
   });
 
   afterEach(() => {
@@ -164,6 +180,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     });
     mocks.sendCronAnnouncePayloadStrict.mockImplementationOnce(async () => {
       await failureDelivery.promise;
+      return sentFailureAlert();
     });
     const job = createCompletionWebhookJob();
     const parentAdmission = tryBeginGatewayRootWorkAdmission();
@@ -293,7 +310,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
 
   it("cancels an unread webhook response before releasing its guard", async () => {
     const cleanupOrder: string[] = [];
-    const onDeliveryAttempt = vi.fn();
+    const onDeliverySettled = vi.fn(async () => {});
     const response = new Response(
       new ReadableStream({
         cancel() {
@@ -310,7 +327,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       }),
     });
 
-    await sendGatewayCronFailureAlert({
+    await sendGatewayCronFailureAlertBase({
       deps: {} as CliDeps,
       logger: { warn: vi.fn() },
       resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
@@ -322,11 +339,14 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       channel: "last",
       mode: "webhook",
       to: "https://example.invalid/cron",
-      onDeliveryAttempt,
+      onDeliverySettled,
     });
 
     expect(cleanupOrder).toEqual(["cancel", "release"]);
-    expect(onDeliveryAttempt).toHaveBeenCalledExactlyOnceWith(true);
+    expect(onDeliverySettled).toHaveBeenCalledExactlyOnceWith({
+      delivered: true,
+      status: "delivered",
+    });
   });
 
   it("releases Gateway admission when webhook response cancellation never settles", async () => {
@@ -372,7 +392,6 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
   });
 
   it("preserves the primary topic on scheduler-authorized alerts", async () => {
-    const onDeliveryAttempt = vi.fn();
     const job = createWebhookJob({
       mode: "announce",
       channel: "telegram",
@@ -392,12 +411,11 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       accountId: "bot-a",
       threadId: 42,
       mode: "announce",
-      onDeliveryAttempt,
     });
 
     expect(mocks.sendCronAnnouncePayloadStrict).toHaveBeenCalledWith(
       expect.objectContaining({
-        onDeliveryAttempt,
+        onDeliveryAttempt: expect.any(Function),
         target: expect.objectContaining({
           channel: "telegram",
           to: "-1001234567890",
@@ -593,6 +611,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     const deferred = createVoidDeferred();
     mocks.sendCronAnnouncePayloadStrict.mockImplementationOnce(async () => {
       await deferred.promise;
+      return sentFailureAlert();
     });
     const job = createWebhookJob({ mode: "announce", channel: "discord", to: "channel:ops" });
 
@@ -614,6 +633,32 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     expect(getActiveGatewayRootWorkCount()).toBe(0);
   });
 
+  it("keeps failure-alert admission until settled persistence completes", async () => {
+    const settlement = createVoidDeferred();
+    const onDeliverySettled = vi.fn(async () => {
+      await settlement.promise;
+    });
+    const job = createWebhookJob({ mode: "announce", channel: "discord", to: "channel:ops" });
+
+    const delivery = sendGatewayCronFailureAlertBase({
+      deps: {} as CliDeps,
+      logger: { warn: vi.fn() },
+      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+      job,
+      payload: { text: "cron failed" },
+      channel: "discord",
+      to: "channel:ops",
+      mode: "announce",
+      onDeliverySettled,
+    });
+
+    await waitForFast(() => expect(onDeliverySettled).toHaveBeenCalledOnce());
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+    settlement.resolve();
+    await delivery;
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
   it.each([
     { description: "honors cancellation", honorsCancellation: true, recipientReached: false },
     { description: "ignores cancellation", honorsCancellation: false, recipientReached: false },
@@ -628,7 +673,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       vi.useFakeTimers();
       try {
         let deliverySignal: AbortSignal | undefined;
-        const onDeliveryAttempt = vi.fn();
+        const onDeliverySettled = vi.fn(async () => {});
         mocks.sendCronAnnouncePayloadStrict.mockImplementationOnce(
           ({
             abortSignal,
@@ -658,7 +703,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
         );
         const job = createWebhookJob({ mode: "announce", channel: "discord", to: "channel:ops" });
 
-        const delivery = sendGatewayCronFailureAlert({
+        const delivery = sendGatewayCronFailureAlertBase({
           deps: {} as CliDeps,
           logger: { warn: vi.fn() },
           resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
@@ -667,7 +712,7 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
           channel: "discord",
           to: "channel:ops",
           mode: "announce",
-          onDeliveryAttempt,
+          onDeliverySettled,
         });
         const deliveryOutcome = delivery.then(
           () => undefined,
@@ -681,14 +726,18 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
         await vi.advanceTimersByTimeAsync(9_999);
         expect(getActiveGatewayRootWorkCount()).toBe(1);
         expect(deliverySignal?.aborted).toBe(false);
-        expect(onDeliveryAttempt).toHaveBeenCalledTimes(recipientReached ? 1 : 0);
+        expect(onDeliverySettled).not.toHaveBeenCalled();
 
         await vi.advanceTimersByTimeAsync(1);
         expect(deliverySignal?.aborted).toBe(true);
         await expect(deliveryOutcome).resolves.toEqual(
           expect.objectContaining({ message: "cron: failure alert announcement timed out" }),
         );
-        expect(onDeliveryAttempt).toHaveBeenCalledTimes(recipientReached ? 1 : 0);
+        expect(onDeliverySettled).toHaveBeenCalledExactlyOnceWith({
+          delivered: recipientReached ? undefined : false,
+          status: recipientReached ? "unknown" : "not-delivered",
+          error: "cron: failure alert announcement timed out",
+        });
         expect(getActiveGatewayRootWorkCount()).toBe(0);
         expect(vi.getTimerCount()).toBe(0);
       } finally {

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -14,7 +14,7 @@ import { retryTransientDirectCronDelivery } from "../cron/isolated-agent/deliver
 import { createCronExecutionId } from "../cron/run-id.js";
 import type { CronEvent, CronService } from "../cron/service.js";
 import { resolveCronDeliverySessionKey } from "../cron/session-target.js";
-import type { CronJob } from "../cron/types.js";
+import type { CronFailureNotificationDelivery, CronJob } from "../cron/types.js";
 import { normalizeHttpWebhookUrl } from "../cron/webhook-url.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatZonedTimestamp } from "../infra/format-time/format-datetime.js";
@@ -342,75 +342,111 @@ function dispatchDetachedCronNotification(params: {
 /** Transports a scheduler-authorized cron failure alert. */
 export async function sendGatewayCronFailureAlert(params: CronFailureAlertParams): Promise<void> {
   await runWithGatewayIndependentRootWorkContinuation(async () => {
-    await sendGatewayCronFailureAlertUnderAdmission(params);
+    const settled = await sendGatewayCronFailureAlertUnderAdmission(params);
+    await params.onDeliverySettled(settled.outcome);
+    if (settled.kind === "failed") {
+      throw settled.error;
+    }
   }, "cron:failure-alert");
 }
 
+type FailureAlertTransportResult =
+  | { kind: "settled"; outcome: CronFailureNotificationDelivery }
+  | { kind: "failed"; error: unknown; outcome: CronFailureNotificationDelivery };
+
 async function sendGatewayCronFailureAlertUnderAdmission(
   params: CronFailureAlertParams,
-): Promise<void> {
-  const { agentId, cfg: runtimeConfig } = params.resolveCronAgent(params.job.agentId);
+): Promise<FailureAlertTransportResult> {
+  let mayHaveReachedRecipient = false;
+  const onDeliveryAttempt = (reachedRecipient: boolean) => {
+    mayHaveReachedRecipient ||= reachedRecipient;
+  };
+  try {
+    const { agentId, cfg: runtimeConfig } = params.resolveCronAgent(params.job.agentId);
+    if (params.mode === "webhook") {
+      if (!params.to) {
+        throw new Error("cron failure alert webhook requires a URL");
+      }
+      const webhookUrl = normalizeHttpWebhookUrl(params.to);
+      if (!webhookUrl) {
+        throw new Error("cron failure alert webhook requires a valid http(s) URL");
+      }
+      await postCronWebhookStrict({
+        webhookUrl,
+        webhookToken: normalizeOptionalString(params.webhookToken),
+        ssrfPolicy: params.ssrfPolicy,
+        onDeliveryAccepted: () => onDeliveryAttempt(true),
+        payload: {
+          jobId: params.job.id,
+          jobName: params.job.name,
+          message: params.payload.text ?? "",
+          runAtMs: params.runAtMs,
+        },
+      });
+      return { kind: "settled", outcome: { delivered: true, status: "delivered" } };
+    }
 
-  if (params.mode === "webhook") {
-    if (!params.to) {
-      throw new Error("cron failure alert webhook requires a URL");
-    }
-    const webhookUrl = normalizeHttpWebhookUrl(params.to);
-    if (!webhookUrl) {
-      throw new Error("cron failure alert webhook requires a valid http(s) URL");
-    }
-    await postCronWebhookStrict({
-      webhookUrl,
-      webhookToken: normalizeOptionalString(params.webhookToken),
-      ssrfPolicy: params.ssrfPolicy,
-      onDeliveryAccepted: () => params.onDeliveryAttempt?.(true),
-      payload: {
+    const abortController = new AbortController();
+    const deliveryTimeoutError = new Error("cron: failure alert announcement timed out");
+    // Release Gateway admission on deadline even when a transport ignores abort.
+    const result = await withTimeout(
+      sendCronAnnouncePayloadStrict({
+        deps: params.deps,
+        cfg: runtimeConfig,
+        agentId,
         jobId: params.job.id,
-        jobName: params.job.name,
-        message: params.payload.text ?? "",
-        runAtMs: params.runAtMs,
+        target: {
+          channel: params.channel,
+          to: params.to,
+          accountId: params.accountId,
+          threadId: params.threadId,
+          sessionKey: resolveCronDeliverySessionKey(params.job),
+          inheritSessionThread: params.inheritSessionThread,
+        },
+        payload: {
+          ...params.payload,
+          text: appendCronFailureAlertDetails(
+            params.payload.text ?? "",
+            params.job.id,
+            params.runAtMs,
+            runtimeConfig,
+          ),
+        },
+        abortSignal: abortController.signal,
+        onDeliveryAttempt,
+      }),
+      CRON_WEBHOOK_TIMEOUT_MS,
+      {
+        createError: () => {
+          abortController.abort(deliveryTimeoutError);
+          return deliveryTimeoutError;
+        },
       },
-    });
-    return;
+    );
+    if (result.status === "sent") {
+      return { kind: "settled", outcome: { delivered: true, status: "delivered" } };
+    }
+    const uncertain = result.reason === "adapter_returned_no_identity";
+    return {
+      kind: "settled",
+      outcome: {
+        delivered: uncertain ? undefined : false,
+        status: uncertain ? "unknown" : "not-delivered",
+        error: `cron failure alert ${uncertain ? "outcome is unknown" : "was suppressed"}: ${result.reason}`,
+      },
+    };
+  } catch (err) {
+    const error = formatErrorMessage(err);
+    return {
+      kind: "failed",
+      error: err,
+      outcome: {
+        delivered: mayHaveReachedRecipient ? undefined : false,
+        status: mayHaveReachedRecipient ? "unknown" : "not-delivered",
+        error,
+      },
+    };
   }
-
-  const abortController = new AbortController();
-  const deliveryTimeoutError = new Error("cron: failure alert announcement timed out");
-  // Release Gateway admission on deadline even when a transport ignores abort.
-  await withTimeout(
-    sendCronAnnouncePayloadStrict({
-      deps: params.deps,
-      cfg: runtimeConfig,
-      agentId,
-      jobId: params.job.id,
-      target: {
-        channel: params.channel,
-        to: params.to,
-        accountId: params.accountId,
-        threadId: params.threadId,
-        sessionKey: resolveCronDeliverySessionKey(params.job),
-        inheritSessionThread: params.inheritSessionThread,
-      },
-      payload: {
-        ...params.payload,
-        text: appendCronFailureAlertDetails(
-          params.payload.text ?? "",
-          params.job.id,
-          params.runAtMs,
-          runtimeConfig,
-        ),
-      },
-      abortSignal: abortController.signal,
-      onDeliveryAttempt: params.onDeliveryAttempt,
-    }),
-    CRON_WEBHOOK_TIMEOUT_MS,
-    {
-      createError: () => {
-        abortController.abort(deliveryTimeoutError);
-        return deliveryTimeoutError;
-      },
-    },
-  );
 }
 
 /** Fans out completion webhooks after a cron run finishes. */

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -14,6 +14,7 @@ import type { GuardedFetchOptions } from "../infra/net/fetch-guard.js";
 import { peekSystemEvents } from "../infra/system-events.js";
 import { withPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
+import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
 import { listTaskRegistryRecordsByRuntimeSourceIdFromSqlite } from "../tasks/task-registry.store.sqlite.js";
 import { getGatewayProcessInstanceId } from "./process-instance.js";
 import type { GatewayCronState } from "./server-cron.js";
@@ -2393,6 +2394,99 @@ describe("gateway server cron", () => {
       expect(completionCall.body).not.toHaveProperty("summary");
       expect(completionCall.body).not.toHaveProperty("diagnostics");
       expect(JSON.stringify(completionCall.body)).not.toContain("SECRET_TOKEN");
+    } finally {
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
+    }
+  }, 45_000);
+
+  test("persists settled failure-alert outcomes for cron get and list", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-failure-alert-outcomes-",
+      cronEnabled: false,
+    });
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    const expectOutcome = async (jobId: string, expected: Record<string, unknown>) => {
+      await vi.waitFor(async () => {
+        const getResult = await rpcReq(ws, "cron.get", { id: jobId });
+        expect(getResult.payload).toMatchObject(expected);
+        for (const compact of [false, true]) {
+          const listResult = await rpcReq(ws, "cron.list", {
+            compact,
+            includeDeliveryPreviews: false,
+          });
+          const listed = (
+            listResult.payload as { jobs?: Array<Record<string, unknown>> } | null
+          )?.jobs?.find((job) => job.id === jobId);
+          expect(listed).toMatchObject(expected);
+        }
+      });
+    };
+
+    try {
+      cronIsolatedRun.mockResolvedValueOnce({ status: "error", error: "job failed" });
+      const deliveredJobId = await addWebhookCronJob({
+        ws,
+        name: "delivered failure alert",
+        sessionTarget: "isolated",
+        delivery: { mode: "none" },
+        failureAlert: {
+          after: 1,
+          mode: "webhook",
+          to: "https://example.invalid/delivered-failure-alert",
+        },
+      });
+      await runCronJobAndWaitForFinished(ws, deliveredJobId);
+      await expectOutcome(deliveredJobId, {
+        lastFailureNotificationDelivered: true,
+        lastFailureNotificationDeliveryStatus: "delivered",
+      });
+
+      fetchWithSsrFGuardMock.mockRejectedValueOnce(new Error("alert transport rejected"));
+      cronIsolatedRun.mockResolvedValueOnce({ status: "error", error: "job failed" });
+      const failedJobId = await addWebhookCronJob({
+        ws,
+        name: "failed failure alert",
+        sessionTarget: "isolated",
+        delivery: { mode: "none" },
+        failureAlert: {
+          after: 1,
+          mode: "webhook",
+          to: "https://example.invalid/failed-failure-alert",
+        },
+      });
+      await runCronJobAndWaitForFinished(ws, failedJobId);
+      await expectOutcome(failedJobId, {
+        lastFailureNotificationDelivered: false,
+        lastFailureNotificationDeliveryStatus: "not-delivered",
+        lastFailureNotificationDeliveryError: expect.stringContaining("alert transport rejected"),
+      });
+
+      sendCronAnnouncePayloadStrictMock.mockImplementationOnce(async (params) => {
+        params.onDeliveryAttempt?.(false);
+        return {
+          status: "suppressed",
+          results: [],
+          receipt: { primaryPlatformMessageId: undefined, platformMessageIds: [], parts: [] },
+          reason: "adapter_returned_no_send",
+        };
+      });
+      cronIsolatedRun.mockResolvedValueOnce({ status: "error", error: "job failed" });
+      const unreachedJobId = await addWebhookCronJob({
+        ws,
+        name: "unreached failure alert",
+        sessionTarget: "isolated",
+        delivery: { mode: "none" },
+        failureAlert: { after: 1, mode: "announce", channel: "last" },
+      });
+      await runCronJobAndWaitForFinished(ws, unreachedJobId);
+      await expectOutcome(unreachedJobId, {
+        lastFailureNotificationDelivered: false,
+        lastFailureNotificationDeliveryStatus: "not-delivered",
+        lastFailureNotificationDeliveryError: expect.stringContaining("adapter_returned_no_send"),
+      });
+      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
     } finally {
       await cleanupCronTestRun({ ws, server, prevSkipCron });
     }

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -2468,7 +2468,12 @@ describe("gateway server cron", () => {
         return {
           status: "suppressed",
           results: [],
-          receipt: { primaryPlatformMessageId: undefined, platformMessageIds: [], parts: [] },
+          receipt: {
+            primaryPlatformMessageId: undefined,
+            platformMessageIds: [],
+            parts: [],
+            sentAt: 0,
+          },
           reason: "adapter_returned_no_send",
         };
       });


### PR DESCRIPTION
Related: #131847

## What Problem This Solves

Cron failure alerts wrote `lastFailureNotificationDeliveryStatus: "unknown"` before dispatch. The detached transport never wrote its settled result back. After delivery finished, both `openclaw cron get` and `openclaw cron list` still reported an unknown outcome.

Run-history entries remain immutable. This change fixes the live job state used by `cron get` and `cron list`.

## Why This Change Was Made

- The Gateway transport now returns one closed settled result: `delivered`, `not-delivered`, or `unknown` for a send that may have reached the recipient before failing.
- The Gateway keeps its independent work admission until the cron owner finishes the settled-state callback.
- The cron owner rereads and updates only the target job inside the existing SQLite write transaction.
- The write requires the same service lifecycle generation, run timestamp, alert timestamp, and pending `unknown` state.
- A stale run, newer run in the same cooldown cycle, sibling service update, stopped service, or replaced lifecycle cannot write or enqueue fallback work.
- A failed outcome write leaves memory and SQLite at `unknown`. A current non-delivery still uses the existing in-app fallback.
- Persisted transport errors are redacted and capped at 1,000 UTF-16 code units.

No SQLite schema, schema version, migration, stored shape, or configuration option changed.

## User Impact

After a failure alert settles, `cron get` and full or compact `cron list` show whether it was delivered, not delivered, or uncertain. Operators no longer see `unknown` forever after a confirmed result.

## Evidence

Current-main red at `4fc24e6e0f81121cef0fb4395db29fb87700e7f6`:

```text
expected lastFailureNotificationDeliveryStatus: "delivered"
received lastFailureNotificationDeliveryStatus: "unknown"
```

Exact-head green at `91178a6cc7551434c79ccaffc71d1848ba5761f5`:

```text
gateway server cron > persists settled failure-alert outcomes for cron get and list
Tests 1 passed | 28 skipped
```

The Gateway WebSocket test covers confirmed delivery, confirmed non-delivery, and transport rejection. It checks `cron.get`, full `cron.list`, and compact `cron.list` against task-local state.

Focused validation:

```text
node scripts/run-vitest.mjs src/cron/service/failure-alerts.persistence.test.ts src/cron/service.failure-alert.test.ts src/cron/service.failure-alert-notifications.test.ts
93 passed

node scripts/run-vitest.mjs src/gateway/server-cron-notifications.test.ts src/gateway/server-cron-notifications.presentation.test.ts
35 passed

OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/cron/cron-delivery-outcomes.e2e.test.ts
6 passed
```

The sibling end-to-end cases cover execution failure alerts, required completion-delivery failure alerts, skipped-run alerts, rejected sends, and immutable history snapshots. Owner tests cover same-cycle newer runs, sibling services, persistence failure rollback, lifecycle retirement, error redaction, and error bounds.

Production delta: +107 lines. Test and test-support delta: +470 lines. The production growth adds the closed Gateway settlement contract, exact lifecycle ownership checks, and targeted authoritative-row commit that the fix requires.
