### PR TITLE
refactor(openai): centralize reasoning output mode

### DIFF
--- a/extensions/openai/openai-chatgpt-provider.ts
+++ b/extensions/openai/openai-chatgpt-provider.ts
@@ -644,7 +644,6 @@ export function buildOpenAICodexProviderHooks(): Pick<
       return OPENAI_CHATGPT_MODERN_MODEL_IDS.some((modelId) => modelId === id);
     },
     ...buildOpenAIResponsesProviderHooks(),
-    resolveReasoningOutputMode: () => "native",
     normalizeResolvedModel: (ctx) => {
       if (!isOpenAIOrLegacyCodexProvider(ctx.provider)) {
         return undefined;

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -1066,7 +1066,6 @@ export function buildOpenAIProvider(): ProviderPlugin {
     matchesContextOverflowError: ({ errorMessage }) =>
       /content_filter.*(?:prompt|input).*(?:too long|exceed)/i.test(errorMessage),
     classifyFailoverReason: ({ code }) => classifyOpenAiFailoverCode(code),
-    resolveReasoningOutputMode: () => "native",
     resolveThinkingProfile: ({ provider, modelId, agentRuntime, api, compat }) =>
       normalizeProviderId(provider) === PROVIDER_ID
         ? resolveUnifiedOpenAIThinkingProfile(modelId, agentRuntime, compat, api)

--- a/extensions/openai/shared.ts
+++ b/extensions/openai/shared.ts
@@ -69,7 +69,11 @@ function defaultOpenAIResponsesExtraParams(
 
 type OpenAIResponsesProviderHooks = Pick<
   ProviderPlugin,
-  "buildReplayPolicy" | "prepareExtraParams" | "wrapStreamFn" | "resolveTransportTurnState"
+  | "buildReplayPolicy"
+  | "prepareExtraParams"
+  | "resolveReasoningOutputMode"
+  | "wrapStreamFn"
+  | "resolveTransportTurnState"
 >;
 
 const resolveOpenAIResponsesTransportTurnState: NonNullable<
@@ -94,6 +98,7 @@ export function buildOpenAIResponsesProviderHooks(options?: {
   return {
     buildReplayPolicy: buildOpenAIReplayPolicy,
     prepareExtraParams: (ctx) => defaultOpenAIResponsesExtraParams(ctx.extraParams, options),
+    resolveReasoningOutputMode: () => "native",
     wrapStreamFn: wrapOpenAIResponsesProviderStreamFn,
     resolveTransportTurnState: resolveOpenAIResponsesTransportTurnState,
   };


### PR DESCRIPTION
## Summary

Centralize OpenAI Responses reasoning-output mode in the plugin-private shared hook builder.

## Root cause and owner

The native reasoning-output mode was duplicated in both provider descriptors instead of being owned by the shared OpenAI Responses hook builder that supplies their common private hooks.

The canonical owner is `extensions/openai/shared.ts`. `OpenAIResponsesProviderHooks` now explicitly includes `resolveReasoningOutputMode`, and `buildOpenAIResponsesProviderHooks` returns the native-mode callback.

## Spread-order proof

- `extensions/openai/openai-chatgpt-provider.ts` spreads the shared hooks into the descriptor. Removing its later duplicate leaves the shared native-mode callback intact.
- `extensions/openai/openai-provider.ts` spreads `responsesHooks` into the descriptor. Its only later hook override is `prepareExtraParams`, so the shared reasoning-output callback survives unchanged.

## Scope

Excluded intentionally: SDK surface, other providers, replay families, request/response or transport behavior, tests, docs, and changelog.

Judged LOC: production net 0, tests 0. Raw diff: +6/-3.

## Validation

- Focused plan suite: 147 tests passed.
- `pnpm test:extension openai`: 901 passed, 1 skipped.
- Changed-file gate: dry run and actual run passed.
- `pnpm check:import-cycles`: 0 cycles.
- Exact-tree Blacksmith Testbox/Crabbox proof on tree `405a36f26b92489aadca53e28a8b01e1b1338cb7`: OpenAI extension suite, import-cycle check, and full `pnpm build` passed.
  - Lease: `tbx_01m1f87b0xs5ng1831r7hzvgqg`
  - Run: https://github.com/openclaw/openclaw/actions/runs/33551605765
- Mandated autoreview: scoped-clean, patch correctness 0.99, no findings.

## Contract checks

- Personally inspected Codex `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; both spans are unrelated CLI/completion handling and impose no provider-hook constraint.
- No paid or live provider call was made because this consolidation does not change external request, response, or transport behavior.
