### PR TITLE
fix(ui): hide rewind while agent is working

### DIFF
--- a/ui/src/pages/chat/components/chat-message-confirmation.ts
+++ b/ui/src/pages/chat/components/chat-message-confirmation.ts
@@ -102,7 +102,7 @@ type ConfirmedActionParams = {
   preferenceName: string;
 };
 
-export function renderRewindButton(onRewind: () => void, disabled: boolean) {
+export function renderRewindButton(onRewind: () => void) {
   const label = t("chat.messages.rewind");
   const params: ConfirmedActionParams = {
     action: onRewind,
@@ -112,11 +112,10 @@ export function renderRewindButton(onRewind: () => void, disabled: boolean) {
   };
   return html`
     <span class="chat-confirm-wrap chat-rewind-wrap">
-      <openclaw-tooltip .content=${disabled ? t("chat.messages.rewindUnavailable") : label}>
+      <openclaw-tooltip .content=${label}>
         <button
           class="chat-group-rewind"
           aria-label=${label}
-          ?disabled=${disabled}
           @click=${(event: Event) =>
             openConfirmedActionPopover(event.currentTarget as HTMLElement, params)}
         >

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -395,7 +395,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
     normalizedRole === "user" &&
     Boolean(
       (footerActionDetails?.replyTarget && opts.onReply) ||
-      opts.onRewind ||
+      (opts.onRewind && !opts.rewindDisabled) ||
       footerActionDetails?.markdown,
     );
   const userFooterActions = hasUserFooterActions
@@ -407,9 +407,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
           ${footerActionDetails?.replyTarget && opts.onReply
             ? renderReplyButton(footerActionDetails.replyTarget, opts.onReply)
             : nothing}
-          ${opts.onRewind
-            ? renderRewindButton(opts.onRewind, Boolean(opts.rewindDisabled))
-            : nothing}
+          ${opts.onRewind && !opts.rewindDisabled ? renderRewindButton(opts.onRewind) : nothing}
           ${footerActionDetails?.markdown
             ? renderMessageActionButtons(footerActionDetails, {})
             : nothing}

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1189,7 +1189,7 @@ describe("grouped chat rendering", () => {
     expect(onRewind).toHaveBeenCalledTimes(1);
   });
 
-  it("disables rewind while the agent is working", () => {
+  it("hides rewind while the agent is working", () => {
     const container = document.createElement("div");
     renderMessageGroups(
       container,
@@ -1197,10 +1197,7 @@ describe("grouped chat rendering", () => {
       { onRewind: vi.fn(), rewindDisabled: true },
     );
 
-    const button = container.querySelector<HTMLButtonElement>(".chat-group-rewind");
-    const tooltip = button?.closest("openclaw-tooltip");
-    expect(button?.disabled).toBe(true);
-    expect(tooltip?.content).toBe("Rewind is unavailable while the agent is working");
+    expect(container.querySelector(".chat-group-rewind")).toBeNull();
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

The chat footer rendered the Rewind action while an agent run was active, even though the action was disabled and unusable.

## Why This Change Was Made

Unavailable footer actions should not occupy space or present a dead control. The renderer now omits Rewind whenever `rewindDisabled` is true and simplifies the button helper because it no longer needs a disabled presentation.

## User Impact

While an agent is working, user-message footers keep Reply and message metadata but no longer show the disabled circular Rewind action. Rewind returns normally when the run is no longer active.

## Evidence

### Before

The disabled Rewind action appears beside Reply during an active run.

![Before: disabled Rewind action is visible](https://github.com/user-attachments/assets/4a83faa7-399b-426b-875b-faaf5743e906)

### After

The disabled action is omitted while Reply and message metadata remain.

![After: disabled Rewind action is omitted](https://github.com/user-attachments/assets/82b92a02-115c-4444-a1ad-24919b5ece25)

### Validation

- `pnpm 12.1.0 exec vitest run --config ui/vitest.config.ts ui/src/pages/chat/components/chat-message.test.ts` — 223 tests passed.
- Repository changed-check gate passed, including Control UI typecheck, dead-export scan, and UI lint.
- Both captures came from the isolated Control UI mock surface and were inspected before upload.
- Known tooling gap: two mandatory autoreview attempts reached the isolated reviewer but failed with HTTP 401 before producing any review result. No clean-review result is claimed.

## Worked on by

No credited participants were provided for this turn.
