### PR TITLE
fix(workboard): inherit workspace and expose lifecycle tools

### DIFF
--- a/docs/cli/workboard.md
+++ b/docs/cli/workboard.md
@@ -73,6 +73,9 @@ openclaw workboard create "Write Workboard docs" --status ready --agent docs-age
 | `--json`                | Print the created card as machine JSON  |
 
 `create` writes directly to Workboard SQLite state. The card is immediately visible in the Control UI Workboard tab and to Workboard tools.
+If the selected board has a default workspace, a card without an explicit
+workspace adopts that default when it is first dispatched; dispatch validates
+and persists the workspace under the card's recorded authority.
 
 ## `show`
 

--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -206,6 +206,13 @@ OpenClaw subagent sessions still own execution. One dispatch pass:
 Workers get bounded card context plus the claim token needed to heartbeat,
 complete, or block the card through the Workboard tools.
 
+When a card has no explicit workspace, its board's current default workspace is
+validated and copied onto the card at first dispatch. An explicit card
+workspace, including `scratch`, always wins. The copied workspace keeps the
+card's recorded authority ceiling and is intersected with the dispatching
+caller's current access before the worker starts. A legacy card without
+recorded workspace authority adopts the current caller's access at that point.
+
 Workspace paths follow the caller's existing filesystem authority. Gateway
 clients with `operator.write` can use configured agent workspaces;
 `operator.admin` clients can use other host checkouts. Sandboxed agent tools use

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -207,6 +207,26 @@ async function buildDynamicToolsForTest(
 }
 
 describe("Codex app-server dynamic tool build", () => {
+  it("forwards the owner-scoped plugin tool grant into dynamic tool construction", async () => {
+    const workspaceDir = path.join(tempDir, "runtime-plugin-grant-workspace");
+    const params = createParams(path.join(tempDir, "runtime-plugin-grant.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.runtimePluginToolGrant = {
+      pluginId: "workboard",
+      toolNames: ["workboard_heartbeat", "workboard_complete", "workboard_block"],
+    };
+    let grant: unknown;
+    setOpenClawCodingToolsFactoryForTests((options) => {
+      grant = options.runtimePluginToolGrant;
+      return [];
+    });
+
+    await buildDynamicToolsForTest(params, workspaceDir);
+
+    expect(grant).toEqual(params.runtimePluginToolGrant);
+  });
+
   it("forwards the explicit yield acknowledgment without exposing private context", async () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -239,6 +239,12 @@ describe("createCopilotToolBridge", () => {
     await createCopilotToolBridge({
       abortSignal: controller.signal,
       agentDir: "/agent",
+      attemptParams: {
+        runtimePluginToolGrant: {
+          pluginId: "workboard",
+          toolNames: ["workboard_heartbeat", "workboard_complete", "workboard_block"],
+        },
+      },
       computerContextEpoch,
       createOpenClawCodingTools,
       cwd: "/workspace/task",
@@ -259,6 +265,10 @@ describe("createCopilotToolBridge", () => {
         cwd: "/workspace/task",
         modelId: "gpt-4o",
         modelProvider: "github-copilot",
+        runtimePluginToolGrant: {
+          pluginId: "workboard",
+          toolNames: ["workboard_heartbeat", "workboard_complete", "workboard_block"],
+        },
         sessionId: "session-1",
         // sessionKey is the sandboxSessionKey derivation; with no
         // attemptParams the bridge falls back to input.sessionKey.

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -310,6 +310,16 @@ const QA_TELEGRAM_VISIBLE_PARTIAL_FAILURE_MARKER = "TELEGRAM-VISIBLE-PARTIAL-BEF
 const QA_REPEATED_REQUEST_RESPONSE_PAUSE_MS = 80_000;
 const QA_REPEATED_REQUEST_STALLED_RESPONSE_PAUSE_MS = 180_000;
 const QA_REPEATED_REQUEST_STALL_ATTEMPT = 5;
+const QA_WORKBOARD_LIFECYCLE_PILOT_MARKER = "QA-WORKBOARD-LIFECYCLE-PILOT";
+
+function extractQaWorkboardLifecycleClaim(prompt: string) {
+  if (!prompt.includes(QA_WORKBOARD_LIFECYCLE_PILOT_MARKER)) {
+    return null;
+  }
+  const cardId = /^Card id:\s*(\S+)$/mu.exec(prompt)?.[1];
+  const token = /^Claim token:\s*(\S+)$/mu.exec(prompt)?.[1];
+  return cardId && token ? { cardId, token } : null;
+}
 
 function isStreamingToolProgressContinuationText(text: string) {
   const trimmed = text.trim();
@@ -918,6 +928,37 @@ async function buildResponsesPayload(
     return buildFailedResponseEvents();
   }
   const toolJson = parseToolOutputJson(scenarioToolOutput);
+  const workboardClaim = extractQaWorkboardLifecycleClaim(prompt);
+  if (workboardClaim) {
+    if (
+      !hasToolDefinition(toolDeclarationBody, "workboard_heartbeat") ||
+      !hasToolDefinition(toolDeclarationBody, "workboard_complete")
+    ) {
+      return buildAssistantEvents("QA Workboard lifecycle tools unavailable.");
+    }
+    if (!hasCompletedToolOutput) {
+      return buildToolCallEventsWithArgs("workboard_heartbeat", {
+        id: workboardClaim.cardId,
+        token: workboardClaim.token,
+        note: "QA lifecycle pilot heartbeat persisted.",
+      });
+    }
+    if (completedToolName === "workboard_heartbeat") {
+      return buildToolCallEventsWithArgs("workboard_complete", {
+        id: workboardClaim.cardId,
+        token: workboardClaim.token,
+        summary: "QA lifecycle pilot completed through the claimed worker tool.",
+        proof: {
+          status: "passed",
+          label: "Workboard lifecycle pilot",
+          note: "Heartbeat and completion ran through the dispatched worker.",
+        },
+      });
+    }
+    if (completedToolName === "workboard_complete") {
+      return buildAssistantEvents("QA-WORKBOARD-LIFECYCLE-PILOT-DONE");
+    }
+  }
   // The hard-kill fixture shares the first real checkpoint below, but recovery
   // must settle without scheduling the repeated-restart fixture's later waits.
   if (

--- a/extensions/workboard/src/cli.test.ts
+++ b/extensions/workboard/src/cli.test.ts
@@ -2,7 +2,12 @@
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerWorkboardCli } from "./cli.js";
-import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
+import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
+import type {
+  PersistedWorkboardBoard,
+  PersistedWorkboardCard,
+  WorkboardKeyedStore,
+} from "./persistence-types.js";
 import { WorkboardStore } from "./store.js";
 
 const gatewayRuntime = vi.hoisted(() => ({
@@ -101,6 +106,37 @@ describe("registerWorkboardCli", () => {
         }),
       }),
     ]);
+  });
+
+  it("dispatches a CLI-created card in its board's default workspace", async () => {
+    const store = new WorkboardStore(createMemoryStore(), {
+      boards: createMemoryStore<PersistedWorkboardBoard>(),
+    });
+    await store.upsertBoard({ id: "ops", defaultWorkspace: { kind: "scratch" } });
+    const program = createProgram(store);
+    await program.parseAsync(
+      ["workboard", "create", "Inherited workspace", "--board", "ops", "--status", "ready"],
+      { from: "user" },
+    );
+    const run = vi.fn().mockResolvedValue({ runId: "run-inherited" });
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { boardId: "ops", maxStarts: 1 },
+    });
+
+    expect(result.startFailures).toEqual([]);
+    expect(result.started).toHaveLength(1);
+    await expect(store.get(result.started[0]!.cardId)).resolves.toMatchObject({
+      metadata: {
+        automation: {
+          boardId: "ops",
+          workspace: { kind: "scratch" },
+          workspaceAccess: { unrestricted: true },
+        },
+      },
+    });
   });
 
   it("redacts claim tokens from card JSON output", async () => {

--- a/extensions/workboard/src/dispatcher.test.ts
+++ b/extensions/workboard/src/dispatcher.test.ts
@@ -1,7 +1,11 @@
 // Workboard tests cover dispatcher plugin behavior.
 import { describe, expect, it, vi } from "vitest";
 import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
-import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
+import type {
+  PersistedWorkboardBoard,
+  PersistedWorkboardCard,
+  WorkboardKeyedStore,
+} from "./persistence-types.js";
 import { WorkboardStore } from "./store.js";
 
 function createMemoryStore<T = PersistedWorkboardCard>(): WorkboardKeyedStore<T> {
@@ -190,11 +194,14 @@ describe("dispatchAndStartWorkboardCards", () => {
   });
 
   it("does not claim a card whose workspace authority changed after preflight", async () => {
-    const store = new WorkboardStore(createMemoryStore());
+    const store = new WorkboardStore(createMemoryStore(), {
+      boards: createMemoryStore<PersistedWorkboardBoard>(),
+    });
+    await store.upsertBoard({ id: "ops", defaultWorkspace: { kind: "scratch" } });
     const card = await store.create({
       title: "Racing authority update",
       status: "ready",
-      workspace: { kind: "dir", path: "/workspace" },
+      boardId: "ops",
       workspaceAccess: { unrestricted: true },
     });
     const originalClaim = store.claim.bind(store);
@@ -224,6 +231,39 @@ describe("dispatchAndStartWorkboardCards", () => {
     ]);
     expect(run).not.toHaveBeenCalled();
     await expect(store.get(card.id)).resolves.toMatchObject({ status: "ready" });
+    await expect(store.get(card.id)).resolves.toMatchObject({
+      metadata: { automation: { workspace: { kind: "scratch" } } },
+    });
+  });
+
+  it("preserves an explicit card workspace over the board default", async () => {
+    const store = new WorkboardStore(createMemoryStore(), {
+      boards: createMemoryStore<PersistedWorkboardBoard>(),
+    });
+    await store.upsertBoard({
+      id: "ops",
+      defaultWorkspace: { kind: "dir", path: "/board-default" },
+    });
+    const card = await store.create({
+      title: "Explicit scratch worker",
+      status: "ready",
+      boardId: "ops",
+      workspace: { kind: "scratch" },
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-explicit" });
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { boardId: "ops", maxStarts: 1 },
+    });
+
+    expect(result.startFailures).toEqual([]);
+    expect(run.mock.calls[0]?.[0]).not.toHaveProperty("cwd");
+    await expect(store.get(card.id)).resolves.toMatchObject({
+      metadata: { automation: { workspace: { kind: "scratch" } } },
+    });
   });
 
   it("rejects worktree sources outside the dispatcher's workspace boundary", async () => {

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -342,7 +342,8 @@ async function runWorkboardDispatch(
   if (selection.rejection) {
     startFailures.push(selection.rejection);
   }
-  for (const card of selection.cards) {
+  for (const selectedCard of selection.cards) {
+    let card = selectedCard;
     const ownerId = ownerOverride || workboardCardSlotOwner(card, now);
     if (acceptedStarts >= maxStarts || attemptedStarts >= maxAttempts) {
       break;
@@ -357,7 +358,10 @@ async function runWorkboardDispatch(
     let runStarted = false;
     let workspaceMutation: { before: WorkboardCard; after: WorkboardCard } | undefined;
     let preparedLaunch: WorkboardPreparedLaunch | undefined;
-    const requestedWorkspace = card.metadata?.automation?.workspace;
+    const explicitWorkspace = card.metadata?.automation?.workspace;
+    const requestedWorkspace =
+      explicitWorkspace ??
+      (await params.store.getBoardMetadata(cardBoardId(card)))?.defaultWorkspace;
     let workspaceAccess: WorkboardWorkspaceAccess;
     let targetWorkspace: string | undefined;
     let persistWorkspaceAccess: boolean;
@@ -442,6 +446,17 @@ async function runWorkboardDispatch(
       }
     }
     try {
+      if (!explicitWorkspace && requestedWorkspace) {
+        card = await params.store.update(
+          card.id,
+          {
+            workspace: requestedWorkspace,
+            ...(persistWorkspaceAccess ? { workspaceAccess } : {}),
+          },
+          { expectedUpdatedAt: card.updatedAt },
+        );
+        persistWorkspaceAccess = false;
+      }
       const claimed = await params.store.claim(
         card.id,
         { ownerId, ttlSeconds: card.metadata?.automation?.maxRuntimeSeconds },

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -422,6 +422,11 @@ export class WorkboardCoreStore {
     };
   }
 
+  async getBoardMetadata(id: unknown): Promise<WorkboardBoardMetadata | undefined> {
+    const entry = await this.boardStore.lookup(normalizeBoardIdRequired(id));
+    return entry?.version === 1 ? entry.board : undefined;
+  }
+
   async upsertBoard(input: WorkboardBoardInput): Promise<WorkboardBoardMetadata> {
     return await this.enqueueMutation(async () => {
       const id = normalizeBoardIdRequired(input.id);

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -295,6 +295,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
         ...(execution ? { execution } : {}),
         metadata: {
           ...metadata,
+          workerProtocol: { state: "completed", updatedAt: now },
           claim: undefined,
           attempts: closeRunningAttempts(metadata.attempts, now, "succeeded"),
           failureCount: 0,
@@ -357,6 +358,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
           : {}),
       metadata: {
         ...metadata,
+        workerProtocol: { state: "blocked", updatedAt: now, detail: reason },
         claim: undefined,
         attempts: closeRunningAttempts(metadata.attempts, now, "blocked", reason),
         failureCount: (metadata.failureCount ?? 0) + 1,

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -23,6 +23,7 @@ import type {
   PluginHookChannelContext,
   PluginHookToolRequesterContext,
 } from "../plugins/hook-types.js";
+import type { RuntimePluginToolGrant } from "../plugins/runtime/tool-grant.js";
 import { appendRuntimePluginToolGrant } from "../plugins/tool-grant-allowlist.js";
 import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../secrets/runtime-state.js";
@@ -311,6 +312,8 @@ type OpenClawCodingToolsOptions = {
   allowGatewaySubagentBinding?: boolean;
   /** Runtime-scoped explicit allowlist used to materialize matching plugin tools. */
   runtimeToolAllowlist?: string[];
+  /** Host-minted exact plugin tool grant for this run. */
+  runtimePluginToolGrant?: RuntimePluginToolGrant;
   /** Host-prepared proof that this exact session can request Gateway publication. */
   githubPublicationAvailable?: boolean;
   /** True when runtimeToolAllowlist is real parent authority that child sessions inherit. */
@@ -448,6 +451,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
       sandboxToolPolicy: sandbox?.tools,
       runtimeToolAllowlist: options?.runtimeToolAllowlist,
       inheritRuntimeToolAllowlist: options?.inheritRuntimeToolAllowlist,
+      runtimePluginToolGrant: options?.runtimePluginToolGrant,
       inputProvenance: options?.inputProvenance,
       trustedInternalHandoff: options?.trustedInternalHandoff,
       scheduledToolPolicy: options?.scheduledToolPolicy,

--- a/src/agents/cli-runner/mcp-grant-context.test.ts
+++ b/src/agents/cli-runner/mcp-grant-context.test.ts
@@ -58,6 +58,17 @@ describe("buildCliMcpGrantContext source-reply authority", () => {
     expect(buildGrant({ replyToMode: "all" }).replyToMode).toBe("all");
   });
 
+  it("carries the host-minted plugin tool grant into the loopback context", () => {
+    const runtimePluginToolGrant = {
+      pluginId: "workboard",
+      toolNames: ["workboard_heartbeat", "workboard_complete", "workboard_block"],
+    } as const;
+
+    expect(buildGrant({ runtimePluginToolGrant }).runtimePluginToolGrant).toEqual(
+      runtimePluginToolGrant,
+    );
+  });
+
   it.each(["read-only", "guarded", "workspace", "full"] as const)(
     "carries the exact %s session permission into the loopback grant",
     (permissionMode) => {

--- a/src/agents/cli-runner/mcp-grant-context.ts
+++ b/src/agents/cli-runner/mcp-grant-context.ts
@@ -160,6 +160,9 @@ export function buildCliMcpGrantContext(params: {
     // Restricted runs get their allowlist stamped into the grant; the
     // loopback server enforces it on tools/list and tools/call.
     ...(params.toolsAllow ? { toolsAllow: params.toolsAllow } : {}),
+    ...(params.run.runtimePluginToolGrant
+      ? { runtimePluginToolGrant: params.run.runtimePluginToolGrant }
+      : {}),
     ...(params.run.skillWorkshopProposalRevision
       ? { skillWorkshop: { proposalRevision: params.run.skillWorkshopProposalRevision } }
       : {}),

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -1318,6 +1318,7 @@ export async function prepareCliRunContext(
       sandboxToolPolicy: sandboxStatus.sandboxed ? sandboxStatus.toolPolicy : undefined,
       runtimeToolAllowlist: runtimeToolsAllowPolicy,
       inheritRuntimeToolAllowlist: true,
+      runtimePluginToolGrant: params.runtimePluginToolGrant,
       inputProvenance: params.inputProvenance,
       scheduledToolPolicy: params.scheduledToolPolicy,
     });

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -38,6 +38,7 @@ import type {
   CliBackendPromptContext,
 } from "../../plugins/cli-backend.types.js";
 import type { PluginHookChannelContext } from "../../plugins/hook-types.js";
+import type { RuntimePluginToolGrant } from "../../plugins/runtime/tool-grant.js";
 import type { SpawnSecretInput } from "../../process/supervisor/types.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
@@ -263,6 +264,8 @@ export type RunCliAgentParams = {
   approvalReviewerDeviceId?: string;
   /** Runtime tool allow-list. CLI harnesses need a backend-owned exact translation. */
   toolsAllow?: string[];
+  /** Owner-scoped plugin tool grant minted by the host for this run. */
+  runtimePluginToolGrant?: RuntimePluginToolGrant;
   /** Exact Skill Workshop proposal revision bound by the Gateway for this turn. */
   skillWorkshopProposalRevision?: SkillWorkshopProposalRevisionConstraint;
   /** Trusted server-stamped authority for an explicitly capped scheduled run. */

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -2685,7 +2685,7 @@ describe("CLI attempt execution", () => {
     expect(firstRunCliAgentArg().authProfileId).toBeUndefined();
   });
 
-  it("forwards runtime toolsAllow into CLI attempts so the CLI harness can fail closed", async () => {
+  it("forwards runtime tool authority into CLI attempts so the CLI harness can fail closed", async () => {
     const sessionKey = "agent:main:direct:claude-tools-allow";
     const sessionEntry = makeSessionEntry("openclaw-session-cli-tools-allow");
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
@@ -2699,7 +2699,13 @@ describe("CLI attempt execution", () => {
       sessionKey,
       body: "route this",
       runId: "run-cli-tools-allow",
-      opts: { toolsAllow: ["read", "web_search"] },
+      opts: {
+        toolsAllow: ["read", "web_search"],
+        runtimePluginToolGrant: {
+          pluginId: "workboard",
+          toolNames: ["workboard_heartbeat", "workboard_complete", "workboard_block"],
+        },
+      },
       messageChannel: "discord",
       sessionStore,
     });
@@ -2707,6 +2713,10 @@ describe("CLI attempt execution", () => {
     expectMockArgFields(runCliAgentMock, {
       provider: "claude-cli",
       toolsAllow: ["read", "web_search"],
+      runtimePluginToolGrant: {
+        pluginId: "workboard",
+        toolNames: ["workboard_heartbeat", "workboard_complete", "workboard_block"],
+      },
     });
   });
 

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -1020,6 +1020,7 @@ export function runAgentAttempt(params: {
             onExecutionPhase: onRuntimeActivity,
             lane: params.opts.lane,
             extraSystemPrompt: params.opts.extraSystemPrompt,
+            runtimePluginToolGrant: params.opts.runtimePluginToolGrant,
             inputProvenance: params.opts.inputProvenance,
             cronCreatorCallerOrigin: params.opts.cronCreatorAuthorityCapability?.callerOrigin,
             sourceReplyDeliveryMode: params.opts.sourceReplyDeliveryMode,

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch.test.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch.test.ts
@@ -424,6 +424,10 @@ describe("runEmbeddedAgentViaCliBackendIfEligible execution", () => {
     const params = baseRunParams({
       sessionTarget,
       toolsAllow: ["memory_search", "memory_get", "notes_retrieve_context"],
+      runtimePluginToolGrant: {
+        pluginId: "workboard",
+        toolNames: ["workboard_heartbeat", "workboard_complete", "workboard_block"],
+      },
     });
 
     const result = await runEmbeddedAgentViaCliBackendIfEligible(params);
@@ -441,6 +445,10 @@ describe("runEmbeddedAgentViaCliBackendIfEligible execution", () => {
       disableCliLiveSession: true,
       cleanupCliLiveSessionOnRunEnd: true,
       requireExplicitMessageTarget: true,
+      runtimePluginToolGrant: {
+        pluginId: "workboard",
+        toolNames: ["workboard_heartbeat", "workboard_complete", "workboard_block"],
+      },
       cliToolAvailability: {
         native: [],
         openClaw: ["memory_search", "memory_get", "notes_retrieve_context"],

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch.ts
@@ -240,6 +240,7 @@ async function runEmbeddedAgentViaCliBackend(
       lifecycleGeneration: params.lifecycleGeneration,
       lane: params.lane,
       extraSystemPrompt: params.extraSystemPrompt,
+      runtimePluginToolGrant: params.runtimePluginToolGrant,
       messageChannel: params.messageChannel,
       messageProvider: params.messageProvider,
       bootstrapContextMode: params.bootstrapContextMode,

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -293,6 +293,20 @@ describe("embedded run retry dispatch", () => {
     },
   );
 
+  it("preserves an owner-scoped plugin tool grant at harness dispatch", async () => {
+    const input = makeDispatchInput({}, createEmbeddedRunReplayState());
+    const runtimePluginToolGrant = {
+      pluginId: "workboard",
+      toolNames: ["workboard_heartbeat", "workboard_complete", "workboard_block"],
+    };
+    input.params.runtimePluginToolGrant = runtimePluginToolGrant;
+
+    const result = await dispatchEmbeddedRunAttempt(input);
+
+    expect(result.preparedAttempt.runtimePluginToolGrant).toBe(runtimePluginToolGrant);
+    expect(mocks.runAttempt.mock.calls[0]?.[0].runtimePluginToolGrant).toBe(runtimePluginToolGrant);
+  });
+
   it.each([true, false])(
     "settles accepted spawns before a late post-compaction abort (yielded: %s)",
     async (yieldDetected) => {

--- a/src/agents/embedded-agent-runner/run/attempt-tool-run-context.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-run-context.ts
@@ -3,6 +3,7 @@ import {
   freezeDiagnosticTraceContext,
   type DiagnosticTraceContext,
 } from "../../../infra/diagnostic-trace-context.js";
+import type { RuntimePluginToolGrant } from "../../../plugins/runtime/tool-grant.js";
 import { mergeForcedEmbeddedAttemptToolsAllow } from "./attempt-tool-construction-plan.js";
 import type { EmbeddedRunTrigger } from "./params.js";
 
@@ -18,13 +19,17 @@ export function buildEmbeddedAttemptToolRunContext(params: {
   swarmCollector?: boolean;
   swarmOutputSchema?: Record<string, unknown>;
   conversationToolPolicy?: GroupToolPolicyConfig;
+  runtimePluginToolGrant?: RuntimePluginToolGrant;
   trace?: DiagnosticTraceContext;
 }) {
   // Collector output is mandatory result transport, even on a narrowed tool surface.
   const runtimeToolAllowlist = mergeForcedEmbeddedAttemptToolsAllow(params.toolsAllow, {
     forceMessageTool: params.forceMessageTool,
-    forceToolNames:
-      params.swarmCollector && params.swarmOutputSchema ? ["structured_output"] : undefined,
+    // Owner-granted plugin tools must survive the narrowed runtime filter after materialization.
+    forceToolNames: [
+      ...(params.swarmCollector && params.swarmOutputSchema ? ["structured_output"] : []),
+      ...(params.runtimePluginToolGrant?.toolNames ?? []),
+    ],
   });
   return {
     trigger: params.trigger,
@@ -35,6 +40,9 @@ export function buildEmbeddedAttemptToolRunContext(params: {
     ...(runtimeToolAllowlist ? { runtimeToolAllowlist } : {}),
     ...(params.conversationToolPolicy
       ? { conversationToolPolicy: params.conversationToolPolicy }
+      : {}),
+    ...(params.runtimePluginToolGrant
+      ? { runtimePluginToolGrant: params.runtimePluginToolGrant }
       : {}),
     // Freeze trace metadata at the attempt boundary so later mutable diagnostic updates do not
     // rewrite the facts attached to tool calls already in flight.

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -128,11 +128,25 @@ describe("buildEmbeddedAttemptToolRunContext", () => {
       jobId: "job-1",
       memoryFlushWritePath: "memory/log.md",
       toolsAllow: ["memory_search", "memory_get"],
+      runtimePluginToolGrant: {
+        pluginId: "workboard",
+        toolNames: ["workboard_heartbeat", "workboard_complete", "workboard_block"],
+      },
     });
     expect(context.trigger).toBe("manual");
     expect(context.jobId).toBe("job-1");
     expect(context.memoryFlushWritePath).toBe("memory/log.md");
-    expect(context.runtimeToolAllowlist).toEqual(["memory_search", "memory_get"]);
+    expect(context.runtimeToolAllowlist).toEqual([
+      "memory_search",
+      "memory_get",
+      "workboard_heartbeat",
+      "workboard_complete",
+      "workboard_block",
+    ]);
+    expect(context.runtimePluginToolGrant).toEqual({
+      pluginId: "workboard",
+      toolNames: ["workboard_heartbeat", "workboard_complete", "workboard_block"],
+    });
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -494,6 +494,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
     scheduledRuntimeAuthority: params.scheduledRuntimeAuthority,
     scheduledRuntimeAuthorityRecoveryRequired: params.scheduledRuntimeAuthorityRecoveryRequired,
     toolsAllow: params.toolsAllow,
+    runtimePluginToolGrant: params.runtimePluginToolGrant,
     toolExecutionAllow: params.toolExecutionAllow,
     // Authorized prompt enrichment needs the exact prepared turn policy identity.
     toolAuthorityFingerprint: params.toolAuthorityFingerprint,

--- a/src/gateway/mcp-grant-store.ts
+++ b/src/gateway/mcp-grant-store.ts
@@ -16,6 +16,7 @@ import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { CronScheduledToolCallerOrigin } from "../cron/scheduled-tool-policy.js";
 import type { ExecMode } from "../infra/exec-approvals.js";
 import type { PluginHookChannelContext } from "../plugins/hook-types.js";
+import type { RuntimePluginToolGrant } from "../plugins/runtime/tool-grant.js";
 import { resolveGlobalMap } from "../shared/global-singleton.js";
 import type { SkillWorkshopRunOptions } from "../skills/workshop/types.js";
 
@@ -55,6 +56,8 @@ export type McpLoopbackRequestContext = {
    * hard enforcement. Unset keeps the full session-scoped surface.
    */
   toolsAllow?: string[];
+  /** Host-minted exact plugin tool grant; never sourced from MCP request fields. */
+  runtimePluginToolGrant?: RuntimePluginToolGrant;
   skillWorkshop?: SkillWorkshopRunOptions;
   /**
    * Attempt-local authority to start or redirect delegated work, stamped into

--- a/src/gateway/mcp-http.runtime.test.ts
+++ b/src/gateway/mcp-http.runtime.test.ts
@@ -105,6 +105,19 @@ describe("resolveMcpLoopbackScopedTools", () => {
     );
   });
 
+  it("forwards the owner-scoped plugin tool grant into loopback tool construction", () => {
+    const runtimePluginToolGrant = {
+      pluginId: "workboard",
+      toolNames: ["workboard_heartbeat", "workboard_complete", "workboard_block"],
+    } as const;
+
+    resolveMcpLoopbackScopedTools(scopeParams({ runtimePluginToolGrant }));
+
+    expect(resolveGatewayScopedTools).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimePluginToolGrant }),
+    );
+  });
+
   it("exposes explicitly granted coding tools through the mediated loopback surface", () => {
     resolveGatewayScopedTools.mockReturnValue(scopedToolFixture(["read", "exec", "browser"]));
 
@@ -219,6 +232,26 @@ describe("McpLoopbackToolCache", () => {
     // Same allowlist reuses the cached row.
     cache.resolve(scopeParams({ cfg, toolsAllow: ["memory_search"] }));
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not share cache rows across different owner-scoped plugin grants", () => {
+    const cache = new McpLoopbackToolCache();
+    const cfg = {} as OpenClawConfig;
+
+    cache.resolve(
+      scopeParams({
+        cfg,
+        runtimePluginToolGrant: { pluginId: "workboard", toolNames: ["workboard_complete"] },
+      }),
+    );
+    cache.resolve(
+      scopeParams({
+        cfg,
+        runtimePluginToolGrant: { pluginId: "workboard", toolNames: ["workboard_block"] },
+      }),
+    );
+
+    expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
   });
 
   it("does not share cache rows across different runtime policy agents", () => {

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -207,6 +207,7 @@ export class McpLoopbackToolCache {
       // Unset (full scope) must never share a cache row with an empty
       // allowlist (deny-all), so the marker distinguishes presence.
       params.toolsAllow ? `allow:${[...new Set(params.toolsAllow)].toSorted().join(",")}` : "",
+      JSON.stringify(params.runtimePluginToolGrant ?? null),
       JSON.stringify(params.skillWorkshop?.proposalRevision ?? null),
       // A delegation-restricted attempt must never read or seed the cached
       // full-capability list for the same session/run context.

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -1250,6 +1250,10 @@ describe("mcp loopback server", () => {
       sourceReplyDeliveryMode: "message_tool_only",
       sourceReplyOnly: true,
       toolsAllow: ["message"],
+      runtimePluginToolGrant: {
+        pluginId: "workboard",
+        toolNames: ["workboard_heartbeat", "workboard_complete", "workboard_block"],
+      },
       // The delegation gate lives in resolveGatewayScopedTools, so dropping
       // this field at the HTTP mapping silently disables it for CLI backends.
       delegationCapability: "report_only",

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -344,6 +344,7 @@ async function startMcpLoopbackServer(port = 0): Promise<{
           taskSuggestionDeliveryMode: requestContext.taskSuggestionDeliveryMode,
           requireExplicitMessageTarget: requestContext.requireExplicitMessageTarget,
           toolsAllow: requestContext.toolsAllow,
+          runtimePluginToolGrant: requestContext.runtimePluginToolGrant,
           delegationCapability: requestContext.delegationCapability,
           scheduledToolPolicy: requestContext.scheduledToolPolicy,
           senderIsOwner: requestContext.senderIsOwner,

--- a/src/gateway/tool-resolution.exclude.test.ts
+++ b/src/gateway/tool-resolution.exclude.test.ts
@@ -8,6 +8,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isPluginToolAllowed } from "../plugins/tool-grant-allowlist.js";
+import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 
 type CreateOpenClawToolsArg = {
   agentAccountId?: string;
@@ -17,6 +19,7 @@ type CreateOpenClawToolsArg = {
   inheritedToolAllowlist?: string[];
   inheritedToolDenylist?: string[];
   pluginToolDenylist?: string[];
+  pluginToolAllowlist?: string[];
   sandboxed?: boolean;
   requesterAgentIdOverride?: string;
   gatewayCallerAccountId?: string;
@@ -138,6 +141,39 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
     });
 
     expect(readCreateToolsArgs().clientCaps).toEqual(["tool-events", "inline-widgets"]);
+  });
+
+  it("materializes only the owner-scoped tools in a runtime plugin grant", () => {
+    const workboardTools = [
+      "workboard_heartbeat",
+      "workboard_complete",
+      "workboard_block",
+      "workboard_list",
+    ].map((name) => hoisted.makeTool(name));
+    for (const tool of workboardTools) {
+      setPluginToolMeta(tool as never, { pluginId: "workboard", optional: false });
+    }
+    hoisted.createOpenClawToolsMock.mockReturnValueOnce(workboardTools);
+
+    const result = resolveGatewayScopedTools({
+      cfg: { tools: { profile: "coding" } } as OpenClawConfig,
+      sessionKey: "agent:main:subagent:workboard-card",
+      surface: "loopback",
+      runtimePluginToolGrant: {
+        pluginId: "workboard",
+        toolNames: ["workboard_heartbeat", "workboard_complete", "workboard_block"],
+      },
+    });
+
+    expect(result.tools.map((tool) => tool.name)).toEqual([
+      "workboard_heartbeat",
+      "workboard_complete",
+      "workboard_block",
+    ]);
+    const allowlist = new Set(readCreateToolsArgs().pluginToolAllowlist);
+    expect(isPluginToolAllowed(allowlist, "workboard", "workboard_complete")).toBe(true);
+    expect(isPluginToolAllowed(allowlist, "workboard", "workboard_list")).toBe(false);
+    expect(isPluginToolAllowed(allowlist, "other-plugin", "workboard_complete")).toBe(false);
   });
 
   it("passes immutable source-reply authority into message-tool construction", () => {

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -54,6 +54,8 @@ import { resolveEventSessionRoutingPolicy } from "../infra/event-session-routing
 import type { ExecMode } from "../infra/exec-approvals.js";
 import { logWarn } from "../logger.js";
 import type { PluginHookChannelContext } from "../plugins/hook-types.js";
+import type { RuntimePluginToolGrant } from "../plugins/runtime/tool-grant.js";
+import { appendRuntimePluginToolGrant } from "../plugins/tool-grant-allowlist.js";
 import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import {
   DEFAULT_GATEWAY_HTTP_TOOL_DENY,
@@ -113,6 +115,8 @@ export function resolveGatewayScopedTools(params: {
   mediatedToolNames?: Iterable<string>;
   disablePluginTools?: boolean;
   gatewayRequestedTools?: string[];
+  /** Host-minted exact plugin tool grant for this loopback run. */
+  runtimePluginToolGrant?: RuntimePluginToolGrant;
   /** Add the CLI-only, node-forced exec tool before applying the shared policy pipeline. */
   includeNodeExecTool?: boolean;
   execSession?: ExecSessionDefaults;
@@ -182,15 +186,18 @@ export function resolveGatewayScopedTools(params: {
       ? "message_tool_only"
       : undefined);
   const runtimeAlsoAllow = sourceReplyDeliveryMode === "message_tool_only" ? ["message"] : [];
+  const runtimePluginToolNames = params.runtimePluginToolGrant?.toolNames ?? [];
   const profilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(profilePolicy, [
     ...(profileAlsoAllow ?? []),
     ...gatewayRequestedTools,
     ...runtimeAlsoAllow,
+    ...runtimePluginToolNames,
   ]);
   const providerProfilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(providerProfilePolicy, [
     ...(providerProfileAlsoAllow ?? []),
     ...gatewayRequestedTools,
     ...runtimeAlsoAllow,
+    ...runtimePluginToolNames,
   ]);
   const senderId = params.channelContext?.sender?.id;
   // Only immutable Gateway-launched grants can opt into node exec. Match the
@@ -339,20 +346,23 @@ export function resolveGatewayScopedTools(params: {
     clientCaps: params.clientCaps,
     workspaceDir,
     sandboxed: sandboxRuntime.sandboxed,
-    pluginToolAllowlist: collectExplicitAllowlist([
-      profilePolicy,
-      providerProfilePolicy,
-      globalPolicy,
-      globalProviderPolicy,
-      agentPolicy,
-      agentProviderPolicy,
-      groupPolicy,
-      senderPolicy,
-      sandboxPolicy,
-      subagentPolicy,
-      inheritedToolPolicy,
-      gatewayRequestedTools.length > 0 ? { allow: gatewayRequestedTools } : undefined,
-    ]),
+    pluginToolAllowlist: appendRuntimePluginToolGrant(
+      collectExplicitAllowlist([
+        profilePolicy,
+        providerProfilePolicy,
+        globalPolicy,
+        globalProviderPolicy,
+        agentPolicy,
+        agentProviderPolicy,
+        groupPolicy,
+        senderPolicy,
+        sandboxPolicy,
+        subagentPolicy,
+        inheritedToolPolicy,
+        gatewayRequestedTools.length > 0 ? { allow: gatewayRequestedTools } : undefined,
+      ]),
+      params.runtimePluginToolGrant,
+    ),
     pluginToolDenylist: explicitDenylist,
     cronCreatorToolAllowlist,
     inheritedToolAllowlist,

--- a/test/e2e/qa-lab/runtime/managed-worktrees-workboard-lifecycle-product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/managed-worktrees-workboard-lifecycle-product-proof.e2e.test.ts
@@ -24,7 +24,12 @@ type WorkboardCard = {
   id: string;
   runId?: string;
   status?: string;
-  metadata?: { automation?: { workspace?: WorkboardWorkspace } };
+  events?: Array<{ kind?: string }>;
+  metadata?: {
+    automation?: { workspace?: WorkboardWorkspace };
+    proof?: Array<{ label?: string; status?: string }>;
+    workerProtocol?: { state?: string };
+  };
 };
 type WorkboardCreateResult = { card: WorkboardCard };
 type WorkboardCompleteResult = { card: WorkboardCard };
@@ -35,6 +40,15 @@ type WorkboardDispatchResult = {
 };
 type WorktreeListResult = { worktrees: ManagedWorktreeRecord[] };
 type GatewayRunResult = { status?: unknown };
+type TasksListResult = {
+  tasks: Array<{
+    kind?: string;
+    runtime?: string;
+    runId?: string;
+    status?: string;
+    childSessionKey?: string;
+  }>;
+};
 
 let gatewayOwner: ReturnType<typeof createQaLiveLaneGateway> | undefined;
 let harness: Awaited<ReturnType<ReturnType<typeof createQaLiveLaneGateway>["start"]>> | undefined;
@@ -71,13 +85,14 @@ async function initializeRepository(root: string): Promise<string> {
   return await fs.realpath(repo);
 }
 
-async function startHarness() {
+async function startHarness(options: { forcedRuntime?: "codex" } = {}) {
   gatewayOwner = createQaLiveLaneGateway();
   harness = await gatewayOwner.start({
     repoRoot: process.cwd(),
     providerMode: "mock-openai",
     primaryModel: "mock-openai/gpt-5.6-luna",
     alternateModel: "mock-openai/gpt-5.6-luna",
+    ...(options.forcedRuntime ? { forcedRuntime: options.forcedRuntime } : {}),
     transport: {
       requiredPluginIds: [],
       createGatewayConfig: () => ({}),
@@ -105,6 +120,28 @@ function managedWorktreeName(cardId: string): string {
     .replace(/[^a-z0-9-]/g, "-")
     .replace(/-+/g, "-");
   return `wb-${suffix}`.slice(0, 64).replace(/-$/, "");
+}
+
+function collectDeclaredToolNames(value: unknown, names = new Set<string>()): Set<string> {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectDeclaredToolNames(item, names);
+    }
+    return names;
+  }
+  if (!value || typeof value !== "object") {
+    return names;
+  }
+  const record = value as Record<string, unknown>;
+  for (const key of ["name", "tool", "functionName"] as const) {
+    if (typeof record[key] === "string") {
+      names.add(record[key]);
+    }
+  }
+  for (const item of Object.values(record)) {
+    collectDeclaredToolNames(item, names);
+  }
+  return names;
 }
 
 async function createCard(params: {
@@ -202,6 +239,135 @@ async function waitForWorktreeState(params: {
 }
 
 describe("managed worktrees Workboard-owner product proof", () => {
+  it(
+    "runs a board-default card through task, worktree, heartbeat, and completion",
+    { timeout: 180_000 },
+    async () => {
+      const canonicalTmp = await fs.realpath(os.tmpdir());
+      const fixtureRoot = tempDirs.make("openclaw-workboard-lifecycle-pilot-", canonicalTmp);
+      const repo = await initializeRepository(fixtureRoot);
+      const activeHarness = await startHarness({ forcedRuntime: "codex" });
+      const stateDir = path.join(await fs.realpath(activeHarness.gateway.tempRoot), "state");
+      const boardId = "qa-lifecycle-pilot";
+      await activeHarness.gateway.call("workboard.boards.upsert", {
+        id: boardId,
+        defaultWorkspace: { kind: "worktree", path: repo, branch: "main" },
+      });
+      const created = (await activeHarness.gateway.call("workboard.cards.create", {
+        title: "QA-WORKBOARD-LIFECYCLE-PILOT",
+        status: "ready",
+        agentId: "qa",
+        boardId,
+      })) as WorkboardCreateResult;
+      expect(created.card.metadata?.automation?.workspace).toBeUndefined();
+      const name = managedWorktreeName(created.card.id);
+
+      const { materializedPath, started } = await dispatchCardAndWaitForWorktree({
+        boardId,
+        cardId: created.card.id,
+        name,
+        stateDir,
+      });
+      const terminal = (await activeHarness.gateway.call(
+        "agent.wait",
+        { runId: started.runId, timeoutMs: 30_000 },
+        { timeoutMs: 35_000 },
+      )) as GatewayRunResult;
+      expect(terminal.status).toBe("ok");
+
+      const deadline = Date.now() + 30_000;
+      let completedCard: WorkboardCard | undefined;
+      while (Date.now() < deadline) {
+        const cards = (await activeHarness.gateway.call("workboard.cards.list", {
+          boardId,
+        })) as WorkboardListResult;
+        completedCard = cards.cards.find((card) => card.id === created.card.id);
+        if (
+          completedCard?.status === "done" &&
+          completedCard.metadata?.workerProtocol?.state === "completed"
+        ) {
+          break;
+        }
+        await sleep(50);
+      }
+      expect(completedCard).toMatchObject({
+        id: created.card.id,
+        status: "done",
+        metadata: {
+          automation: {
+            workspace: expect.any(Object),
+          },
+          proof: [
+            expect.objectContaining({ label: "Workboard lifecycle pilot", status: "passed" }),
+          ],
+          workerProtocol: { state: "completed" },
+        },
+      });
+      expect(completedCard?.events?.map((event) => event.kind)).toContain("heartbeat");
+
+      const tasks = (await activeHarness.gateway.call("tasks.list", {
+        agentId: "qa",
+        limit: 100,
+      })) as TasksListResult;
+      expect(tasks.tasks).toContainEqual(
+        expect.objectContaining({
+          kind: "subagent",
+          runtime: "subagent",
+          runId: started.runId,
+          status: "completed",
+          childSessionKey: started.sessionKey,
+        }),
+      );
+
+      const requests = (await fetch(`${activeHarness.mock!.baseUrl}/debug/requests`).then(
+        (response) => response.json(),
+      )) as Array<{
+        body?: { tools?: unknown; dynamicTools?: unknown };
+        plannedToolName?: string;
+        prompt?: string;
+        toolOutput?: string;
+      }>;
+      const initialRequest = requests.find(
+        (request) =>
+          request.prompt?.includes("QA-WORKBOARD-LIFECYCLE-PILOT") && !request.toolOutput,
+      );
+      const declaredWorkboardTools = [
+        ...collectDeclaredToolNames([
+          initialRequest?.body?.tools,
+          initialRequest?.body?.dynamicTools,
+        ]),
+      ]
+        .filter((name) => name.startsWith("workboard_"))
+        .toSorted();
+      expect(declaredWorkboardTools).toEqual(
+        ["workboard_heartbeat", "workboard_complete", "workboard_block"].toSorted(),
+      );
+      expect(
+        requests
+          .map((request) => request.plannedToolName)
+          .filter((name): name is string => Boolean(name?.startsWith("workboard_"))),
+      ).toEqual(["workboard_heartbeat", "workboard_complete"]);
+
+      const worktree = (await listWorktrees()).worktrees.find(
+        (record) => record.ownerKind === "workboard" && record.ownerId === created.card.id,
+      );
+      const removed = await waitForWorktreeState({
+        id: worktree?.id ?? "",
+        predicate: (record) => record?.runEndCleanup?.outcome === "removed-lossless",
+        timeoutMs: 30_000,
+      });
+      expect(removed?.removedAt).toEqual(expect.any(Number));
+      await expect(fs.access(materializedPath)).rejects.toMatchObject({ code: "ENOENT" });
+      const finalCards = (await activeHarness.gateway.call("workboard.cards.list", {
+        boardId,
+      })) as WorkboardListResult;
+      expect(
+        finalCards.cards.find((card) => card.id === created.card.id)?.metadata?.automation
+          ?.workspace,
+      ).toEqual({ kind: "worktree", path: repo, branch: "main" });
+    },
+  );
+
   it(
     "nudges a persisted future automation when a linked worker ends",
     { timeout: 120_000 },


### PR DESCRIPTION
## Summary
- resolve board default workspace metadata when a card has no explicit workspace, while preserving explicit card overrides
- revalidate card workspace/agent authority at claim time
- expose only the bounded Workboard heartbeat, completion, and block tools to dispatched claimed workers
- persist terminal worker protocol state and add focused documentation

## What Problem This Solves
Cards without an explicit workspace did not inherit their board's configured default, and dispatched workers did not receive the bounded lifecycle tools needed to report heartbeat and terminal state. The fix keeps workspace selection Workboard-owned while the Gateway mints and filters the exact run-scoped plugin tool grant.

## Evidence
Final-head local Gateway product proof passed on `e53d1650cbdd08c638caa3d2b5cf4bc12494decc` on 2026-09-19. The checkout and remote PR head matched, the tracked tree stayed clean, and the exact-head prebuilt dist was reused without installing dependencies or rebuilding.

```bash
CI=1 OPENCLAW_E2E_USE_PREBUILT_DIST=1 \
  OPENCLAW_E2E_WORKERS=1 \
  OPENCLAW_VITEST_MAX_WORKERS=1 \
  node scripts/run-vitest.mjs \
  test/e2e/qa-lab/runtime/managed-worktrees-workboard-lifecycle-product-proof.e2e.test.ts \
  --reporter=verbose --reporter=json \
  --outputFile=.artifacts/qa-e2e/pr-135522-final-head-e53d1650cbd-rerun-20260919/vitest-result.json
```

```text
PASS board-default card through task, worktree, heartbeat, and completion
PASS persisted future-automation nudge after linked worker end
PASS clean worktree removal and dirty worktree retention

Test Files  1 passed (1)
Tests       3 passed (3)
Duration    46.24s (50.47s wrapper)
```

The proof created the card without `metadata.automation.workspace`, observed the persisted board-default workspace after dispatch, and captured exactly `workboard_heartbeat`, `workboard_complete`, and `workboard_block` in the provider-visible surface. The exercised calls were heartbeat then completion. Persisted state was card `done`, proof `passed`, worker protocol `completed`, heartbeat event present, and linked task `completed`. Clean cleanup recorded `removed-lossless`; the dirty case recorded `retained-dirty` and preserved its untracked file.

Native Vitest JSON SHA-256: `3ccc98838af200386c97c8019da30cfe5bd2e7547429a7fc5e6f6826f31fb99c`.

## Test coverage
- CLI board-workspace inheritance and explicit override preservation
- dispatch authority revalidation
- bounded lifecycle-tool exposure across native/Codex/Copilot paths
- QA-Lab managed-worktree product proof: card → dispatch → native task → managed worktree → heartbeat → completion with persisted status/proof, plus clean removal and dirty retention

## Rollout / upgrade
This is an upstream source fix based on current `main`, after `v2026.8.1`. Existing `2026.8.1` installations will not receive it through configuration alone; deploy or upgrade to an OpenClaw build/release containing this patch. No data migration is required.
