### PR TITLE
fix(ui): keep group titles on one marquee line

### DIFF
--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -291,7 +291,7 @@ export function renderAppSidebarOnline(host: AppSidebarRenderHost) {
                 >${collapsed ? icons.chevronRight : icons.chevronDown}</span
               >
             </span>
-            <span class="sidebar-recent-sessions__label-text">${label}</span>
+            <span class="sidebar-recent-sessions__label-text hover-marquee">${label}</span>
             ${collapsed
               ? html`<span class="sidebar-online__facepile">
                   <openclaw-viewer-facepile

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -279,7 +279,9 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
                   >${collapsed ? icons.chevronRight : icons.chevronDown}</span
                 >
               </span>
-              <span class="sidebar-recent-sessions__label-text">${catalog.label}</span>
+              <span class="sidebar-recent-sessions__label-text hover-marquee"
+                >${catalog.label}</span
+              >
               ${renderCatalogHeaderStatus(hasActiveRun, hasUnread)}
               ${hasError || (collapsed && rows.length > 0)
                 ? html`<span

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -174,7 +174,7 @@ function renderSessionSection(params: {
                       aria-hidden="true"
                     ></openclaw-viewer-avatar>`
                   : nothing}
-                <span class="sidebar-recent-sessions__label-text">${label}</span>
+                <span class="sidebar-recent-sessions__label-text hover-marquee">${label}</span>
                 ${collapsed && totalRowCount > 0
                   ? html`<span class="sidebar-session-group-count">${totalRowCount}</span>`
                   : nothing}

--- a/ui/src/components/app-sidebar-session-section-header.ts
+++ b/ui/src/components/app-sidebar-session-section-header.ts
@@ -1,4 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
+import { startHoverMarqueeFromEvent, stopHoverMarqueeFromEvent } from "../lib/hover-marquee.ts";
 import { writeSidebarSectionDragData } from "../lib/sessions/drag.ts";
 
 export function renderSidebarSessionSectionHeader(params: {
@@ -51,6 +52,8 @@ export function renderSidebarSessionSectionHeader(params: {
         (event.currentTarget as HTMLElement).removeAttribute("data-section-drag-blocked");
         params.onFinishDrag();
       }}
+      @mouseenter=${startHoverMarqueeFromEvent}
+      @mouseleave=${stopHoverMarqueeFromEvent}
       @contextmenu=${params.onContextMenu ?? nothing}
     >
       <span class="sidebar-session-group-drag-handle" aria-hidden="true"></span>

--- a/ui/src/e2e/session-management.groups.e2e.test.ts
+++ b/ui/src/e2e/session-management.groups.e2e.test.ts
@@ -22,6 +22,69 @@ import {
 const suite = createSessionManagementE2eSuite();
 
 suite.define(() => {
+  it("keeps long group titles on one line and reveals them on hover", async () => {
+    const groupName = "OpenClaw Bugfixes / Miscellaneous Product Work and Release Coordination";
+    const context = await suite.browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 720, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      featureMethods: [...defaultControlUiFeatureMethods, "sessions.groups.list"],
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:group-title", "Group title behavior", Date.now(), {
+            category: groupName,
+          }),
+        ]),
+      },
+      sessionGroups: [groupName],
+      sessionKey: "agent:main:group-title",
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:group-title"));
+      const group = page.locator(`[data-session-section="category:${groupName}"]`);
+      const header = group.locator(":scope > .sidebar-recent-sessions__head");
+      const label = header.locator(".sidebar-recent-sessions__label-text");
+      await group.waitFor({ state: "visible", timeout: 10_000 });
+      await captureUiProof(suite, page, "sidebar-group-title-resting.png");
+
+      const resting = await label.evaluate((element) => {
+        const style = getComputedStyle(element);
+        return {
+          clientWidth: element.clientWidth,
+          height: element.getBoundingClientRect().height,
+          lineHeight: Number.parseFloat(style.lineHeight),
+          scrollWidth: element.scrollWidth,
+          textOverflow: style.textOverflow,
+          whiteSpace: style.whiteSpace,
+        };
+      });
+      expect(resting.whiteSpace).toBe("nowrap");
+      expect(resting.textOverflow).toBe("ellipsis");
+      expect(resting.height).toBeLessThanOrEqual(resting.lineHeight + 1);
+      expect(resting.scrollWidth).toBeGreaterThan(resting.clientWidth);
+
+      await label.hover();
+      await expect
+        .poll(() => label.getAttribute("class"), { timeout: 3_000 })
+        .toContain("hover-marquee--scrolling");
+      await expect
+        .poll(() =>
+          label.evaluate((element) =>
+            Number.parseFloat(getComputedStyle(element).getPropertyValue("text-indent")),
+          ),
+        )
+        .toBeLessThan(-1);
+      await captureUiProof(suite, page, "sidebar-group-title-hovered.png");
+    } finally {
+      await context.close();
+    }
+  });
+
   it("recovers an empty group catalog after a transient load failure", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",

--- a/ui/src/lib/hover-marquee.test.ts
+++ b/ui/src/lib/hover-marquee.test.ts
@@ -89,7 +89,7 @@ describe("hover marquee", () => {
     }).not.toThrow();
   });
 
-  it("remeasures an active marquee when its available width changes", () => {
+  it("remeasures any active marquee host when its available width changes", () => {
     let resizeCallback: ResizeObserverCallback | undefined;
     class TestResizeObserver implements ResizeObserver {
       constructor(callback: ResizeObserverCallback) {
@@ -108,7 +108,6 @@ describe("hover marquee", () => {
     vi.stubGlobal("ResizeObserver", TestResizeObserver);
     let labelWidth = 180;
     const row = document.createElement("div");
-    row.className = "session-row-host";
     Object.defineProperty(row, "matches", {
       value: (selector: string) => selector === ":hover",
     });

--- a/ui/src/lib/hover-marquee.ts
+++ b/ui/src/lib/hover-marquee.ts
@@ -7,6 +7,7 @@ const MARQUEE_SPEED_PX_PER_SEC = 80;
 const MARQUEE_MIN_DURATION_MS = 300;
 const MARQUEE_HOVER_DELAY_MS = 500;
 const pendingMarquees = new WeakMap<HTMLElement, number>();
+const marqueeHosts = new WeakMap<HTMLElement, HTMLElement>();
 let marqueeResizeObserver: ResizeObserver | undefined;
 
 function isMarqueeHostActive(host: HTMLElement): boolean {
@@ -38,9 +39,10 @@ function observeMarquee(label: HTMLElement): void {
           continue;
         }
         const resizedLabel = entry.target;
-        const host = resizedLabel.closest<HTMLElement>(".session-row-host");
-        if (!host || !isMarqueeHostActive(host)) {
+        const host = marqueeHosts.get(resizedLabel);
+        if (!host?.isConnected || !isMarqueeHostActive(host)) {
           marqueeResizeObserver?.unobserve(resizedLabel);
+          marqueeHosts.delete(resizedLabel);
           continue;
         }
         clearPendingMarquee(resizedLabel);
@@ -57,6 +59,7 @@ function startHoverMarquee(host: HTMLElement): void {
   if (!label) {
     return;
   }
+  marqueeHosts.set(label, host);
   observeMarquee(label);
   if (label.classList.contains("hover-marquee--scrolling")) {
     return;
@@ -102,6 +105,7 @@ function stopHoverMarquee(host: HTMLElement): void {
   clearPendingMarquee(label);
   label.classList.remove("hover-marquee--scrolling");
   marqueeResizeObserver?.unobserve(label);
+  marqueeHosts.delete(label);
 }
 
 export function startHoverMarqueeFromEvent(event: Event): void {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1575,6 +1575,11 @@ openclaw-settings-save-indicator:empty {
   color: var(--muted);
 }
 
+.sidebar-session-group-toggle > .sidebar-recent-sessions__label-text {
+  min-width: 0;
+  flex: 1 1 0;
+}
+
 /* Flex, not grid: WebKit does not re-run a grid flex-item's intrinsic sizing
    when rows stream in or grow a second subtitle line after first layout, so a
    grid list keeps a stale height and the next section paints over its rows. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where long session group titles could wrap onto multiple rows and did not reveal their clipped text with the hover behavior used by session rows.

## Why This Change Was Made

Session group labels now share the existing `hover-marquee` behavior and remain a single flex-constrained line. The marquee helper now tracks its actual host rather than assuming every label belongs to a session row, so resize handling works for both row and group-header hosts.

## User Impact

Long group titles stay compact in the sidebar. Resting titles truncate with an ellipsis, then slide horizontally on hover to reveal the remaining text.

## Evidence

| Before hover | After hover |
| --- | --- |
| One-line title rests with an ellipsis. | The same title slides to reveal its clipped tail. |
| ![Before hover: long group title rests on one ellipsized row](https://files.catbox.moe/av3uy8.png) | ![After hover: long group title has slid horizontally](https://files.catbox.moe/izv8sm.png) |

- `OPENCLAW_CAPTURE_UI_PROOF=1 corepack pnpm@12.1.0 test:ui:e2e -- ui/src/e2e/session-management.groups.e2e.test.ts` — 12/12 passed.
- `node scripts/run-vitest.mjs ui/src/lib/hover-marquee.test.ts --reporter=dot` — 7/7 passed.
- `pnpm check:changed` — passed before the interrupted publish step, including UI/core typechecks, lint, stylelint, formatting, and repository ratchets.
- Final exact-head formatting, stylelint, and `git diff --check` — passed.
- The repository autoreview helper was attempted twice but exited before producing JSON; no automated-review verdict is claimed.

Release note: Long session group titles now stay on one row and scroll horizontally on hover.

## Worked on by

_No additional credited participants._
