### PR TITLE
fix: Recent Chats list has cleaner alignment and hover feedback

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -7982,7 +7982,7 @@ button.chat-pr__diff {
 .agent-chat__recents {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
   width: min(100%, 520px);
   margin-top: 12px;
   text-align: left;
@@ -7994,7 +7994,7 @@ button.chat-pr__diff {
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--muted);
-  margin: 0 0 2px 4px;
+  margin: 0 0 2px 12px;
 }
 
 .agent-chat__recent {
@@ -8004,19 +8004,16 @@ button.chat-pr__diff {
   min-height: 40px;
   padding: 8px 12px;
   border-radius: var(--radius-md);
-  border: 1px solid transparent;
+  border: none;
   background: transparent;
   color: var(--text);
   font-size: 13px;
   text-align: left;
-  transition:
-    background 0.15s,
-    border-color 0.15s;
+  transition: background 0.15s;
 }
 
 .agent-chat__recent:hover {
-  background: var(--panel);
-  border-color: var(--border);
+  background: var(--bg-hover);
 }
 
 .agent-chat__recent-name {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Recent Chats heading did not align with the row content, row spacing felt too loose, and hovering a chat produced an outlined treatment instead of a clear background highlight.

## Why This Change Was Made

The heading now shares the rows' 12px content inset, the inter-row gap is reduced from 4px to 2px, and hover feedback uses the existing `--bg-hover` token without a border. The change stays within the existing Recent Chats stylesheet owner and removes three production CSS lines overall.

## User Impact

Recent Chats now reads as one aligned, tighter list, and hovered rows receive a filled highlight without an outline.

## Evidence

Both captures come from the real Control UI in an isolated browser with the first recent-chat row hovered.

**Before**

![Recent Chats before: offset heading, outlined hover, and wider row spacing](https://github.com/user-attachments/assets/493ba935-b559-4edc-82b2-acf20ebb8b45)

**After**

![Recent Chats after: aligned heading, filled hover, and tighter row spacing](https://github.com/user-attachments/assets/85026cac-5f12-44c2-bee8-1986b32c9f52)

Validation:

- `pnpm check:changed` passed, including changed-file formatting, Control UI i18n verification, core-test and UI typechecks, and targeted stylesheet lint.
- `git diff --check` passed.
- The repository Autoreview helper was attempted, but its isolated Codex client returned HTTP 401 before producing a review verdict. No alternate engine or retry was used.

## Worked on by

- None credited for this turn.
