### PR TITLE
fix(ui): keep session owner filters compact

### DIFF
--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -13,10 +13,15 @@ import {
 } from "./app-sidebar-session-types.ts";
 import { icons } from "./icons.ts";
 import {
+  renderCompactSessionMenuFrame,
+  renderCompactSessionMenuNavigationItem,
+} from "./session-menu-compact.ts";
+import {
   renderSessionOwnerAvatar,
   renderSessionOwnerChip,
   type SessionOwnerOption,
 } from "./session-owner-chip.ts";
+import type { SidebarFilterMenuView } from "./sidebar-menus-controller.ts";
 import {
   consumeDropdownKeyboardDismissal,
   syncDropdownItemRadio,
@@ -69,16 +74,50 @@ function renderSidebarMenuRadioItem(params: {
   `;
 }
 
-function renderSidebarOwnerFilter(
-  owners: readonly SessionOwnerOption[],
-  ownerFilterId: string | null,
-  involvingMe: boolean,
-  selfOwnerId: string | null,
-) {
+function renderSidebarOwnerOptions(params: {
+  owners: readonly SessionOwnerOption[];
+  ownerFilterId: string | null;
+  selfOwnerId: string | null;
+  submenu: boolean;
+}) {
+  return params.owners.map((owner) =>
+    renderSidebarMenuRadioItem({
+      value: `owner:${owner.id}`,
+      checked: params.ownerFilterId === owner.id,
+      label:
+        owner.id === params.selfOwnerId
+          ? t("sessionsView.ownerYou", { name: owner.label ?? owner.id })
+          : (owner.label ?? owner.id),
+      owner,
+      submenu: params.submenu,
+    }),
+  );
+}
+
+function renderSidebarOwnerFilter(params: {
+  owners: readonly SessionOwnerOption[];
+  ownerFilterId: string | null;
+  involvingMe: boolean;
+  selfOwnerId: string | null;
+  compact: boolean;
+}) {
+  const { owners, ownerFilterId, involvingMe } = params;
   if (owners.length === 0 && ownerFilterId === null && !involvingMe) {
     return nothing;
   }
   const selectedOwner = owners.find((owner) => owner.id === ownerFilterId);
+  const selectedName = selectedOwner?.label ?? selectedOwner?.id;
+  const accessibleLabel = selectedName
+    ? t("sessionsView.specificOwnerSelected", { name: selectedName })
+    : t("sessionsView.specificOwnerAvailable", { count: String(owners.length) });
+  const details = selectedOwner
+    ? html`${renderSessionOwnerAvatar(selectedOwner)}
+        <span class="session-menu__shortcut sidebar-session-owner-selection__name"
+          >${selectedName}</span
+        >`
+    : html`<span class="session-menu__shortcut sidebar-session-owner-count"
+        >${owners.length}</span
+      >`;
   return html`
     <div class="session-menu__separator" role="separator"></div>
     <div class="sidebar-session-sort-menu__title">${t("sessionsView.owners")}</div>
@@ -93,42 +132,39 @@ function renderSidebarOwnerFilter(
       label: t("sessionsView.involvingMe"),
     })}
     ${owners.length > 0
-      ? html`<wa-dropdown-item
-          class="sidebar-session-sort-menu__item sidebar-session-owner-submenu"
-        >
-          <span class="session-menu__text">${t("sessionsView.specificOwner")}</span>
-          ${selectedOwner
-            ? html`<span
-                slot="details"
-                class="session-menu__shortcut sidebar-session-owner-selection"
-                aria-hidden="true"
-              >
-                ${renderSessionOwnerAvatar(selectedOwner)}
-                <span class="sidebar-session-owner-selection__name"
-                  >${selectedOwner.label ?? selectedOwner.id}</span
-                >
-              </span>`
-            : html`<span
-                slot="details"
-                class="session-menu__shortcut sidebar-session-owner-count"
-                aria-hidden="true"
-                >${owners.length}</span
-              >`}
-          ${owners.map((owner) =>
-            renderSidebarMenuRadioItem({
-              value: `owner:${owner.id}`,
-              checked: ownerFilterId === owner.id,
-              label:
-                owner.id === selfOwnerId
-                  ? t("sessionsView.ownerYou", { name: owner.label ?? owner.id })
-                  : (owner.label ?? owner.id),
-              owner,
-              submenu: true,
-            }),
-          )}
-        </wa-dropdown-item>`
+      ? params.compact
+        ? renderCompactSessionMenuNavigationItem({
+            view: "specific-owner",
+            label: t("sessionsView.specificOwner"),
+            icon: icons.users,
+            details: html`<span class="sidebar-session-owner-selection">${details}</span>`,
+            accessibleLabel,
+          })
+        : html`<wa-dropdown-item
+            class="sidebar-session-sort-menu__item sidebar-session-owner-submenu"
+            aria-label=${accessibleLabel}
+          >
+            <span class="session-menu__text">${t("sessionsView.specificOwner")}</span>
+            <span
+              slot="details"
+              class="session-menu__shortcut sidebar-session-owner-selection"
+              aria-hidden="true"
+              >${details}</span
+            >
+            ${renderSidebarOwnerOptions({ ...params, submenu: true })}
+          </wa-dropdown-item>`
       : nothing}
   `;
+}
+
+function renderCompactSidebarOwnerFilter(params: {
+  owners: readonly SessionOwnerOption[];
+  ownerFilterId: string | null;
+  selfOwnerId: string | null;
+}) {
+  return renderCompactSessionMenuFrame(
+    html`${renderSidebarOwnerOptions({ ...params, submenu: false })}`,
+  );
 }
 
 export function renderSidebarSessionGroupMenu(params: {
@@ -217,13 +253,16 @@ export function renderSidebarSessionGroupMenu(params: {
 }
 
 export function renderSidebarCatalogViewMenu(params: {
-  position: { x: number; y: number };
+  position: { catalogId: string; x: number; y: number };
   trigger: HTMLElement | null;
   grouping: CatalogProjectGrouping;
   owners: readonly SessionOwnerOption[];
   ownerFilterId: string | null;
   involvingMe: boolean;
   selfOwnerId: string | null;
+  compact: boolean;
+  view: SidebarFilterMenuView;
+  onViewChange: (view: SidebarFilterMenuView) => void;
   onGroupingChange: (grouping: CatalogProjectGrouping) => void;
   onOwnerFilterChange: (ownerId: string | null, involvingMe?: boolean) => void;
   onHide: () => void;
@@ -236,10 +275,10 @@ export function renderSidebarCatalogViewMenu(params: {
     { grouping: "none", label: t("sessionsView.groupByNone") },
   ] as const satisfies ReadonlyArray<{ grouping: CatalogProjectGrouping; label: string }>;
   return keyed(
-    position,
+    `${position.catalogId}:${position.x}:${position.y}`,
     html`
       <wa-dropdown
-        class="sidebar-session-sort-menu sidebar-catalog-view-menu"
+        class=${`sidebar-session-sort-menu sidebar-catalog-view-menu${params.compact ? " session-menu--compact" : ""}`}
         .open=${true}
         placement="bottom-start"
         .distance=${0}
@@ -247,7 +286,11 @@ export function renderSidebarCatalogViewMenu(params: {
         @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
           event.preventDefault();
           const value = event.detail.item.value;
-          if (value?.startsWith("grouping:")) {
+          if (value === "compact:open-specific-owner") {
+            params.onViewChange("specific-owner");
+          } else if (value === "compact:back") {
+            params.onViewChange("root");
+          } else if (value?.startsWith("grouping:")) {
             params.onGroupingChange(value.slice("grouping:".length) as CatalogProjectGrouping);
           } else if (value?.startsWith("owner:")) {
             params.onOwnerFilterChange(value.slice("owner:".length) || null);
@@ -262,24 +305,21 @@ export function renderSidebarCatalogViewMenu(params: {
         @wa-after-hide=${(event: Event) => params.onClose(consumeDropdownKeyboardDismissal(event))}
       >
         ${renderSidebarMenuTrigger(position, t("chat.sidebar.catalogViewOptions"))}
-        <div class="sidebar-session-sort-menu__title">${t("sessionsView.groupBy")}</div>
-        ${groupingOptions.map((option) =>
-          renderSidebarMenuRadioItem({
-            value: `grouping:${option.grouping}`,
-            checked: params.grouping === option.grouping,
-            label: option.label,
-          }),
-        )}
-        ${renderSidebarOwnerFilter(
-          params.owners,
-          params.ownerFilterId,
-          params.involvingMe,
-          params.selfOwnerId,
-        )}
-        <div class="session-menu__separator" role="separator"></div>
-        <wa-dropdown-item class="sidebar-session-sort-menu__item" value="hide-catalog">
-          <span class="session-menu__text">${t("chat.sidebar.hideFromSidebar")}</span>
-        </wa-dropdown-item>
+        ${params.compact && params.view === "specific-owner"
+          ? renderCompactSidebarOwnerFilter(params)
+          : html`<div class="sidebar-session-sort-menu__title">${t("sessionsView.groupBy")}</div>
+              ${groupingOptions.map((option) =>
+                renderSidebarMenuRadioItem({
+                  value: `grouping:${option.grouping}`,
+                  checked: params.grouping === option.grouping,
+                  label: option.label,
+                }),
+              )}
+              ${renderSidebarOwnerFilter(params)}
+              <div class="session-menu__separator" role="separator"></div>
+              <wa-dropdown-item class="sidebar-session-sort-menu__item" value="hide-catalog">
+                <span class="session-menu__text">${t("chat.sidebar.hideFromSidebar")}</span>
+              </wa-dropdown-item>`}
       </wa-dropdown>
     `,
   );
@@ -300,6 +340,9 @@ export function renderSidebarSessionSortMenu(params: {
   ownerFilterId: string | null;
   involvingMe: boolean;
   selfOwnerId: string | null;
+  compact: boolean;
+  view: SidebarFilterMenuView;
+  onViewChange: (view: SidebarFilterMenuView) => void;
   onGroupingChange: (grouping: SidebarSessionsGrouping) => void;
   onSortModeChange: (mode: SidebarSessionSortMode) => void;
   onStatusFilterChange: (statusFilter: SidebarSessionStatusFilter) => void;
@@ -318,10 +361,10 @@ export function renderSidebarSessionSortMenu(params: {
     { grouping: "none", label: t("sessionsView.groupByNone") },
   ] as const satisfies ReadonlyArray<{ grouping: SidebarSessionsGrouping; label: string }>;
   return keyed(
-    position,
+    `${position.x}:${position.y}`,
     html`
       <wa-dropdown
-        class="sidebar-session-sort-menu"
+        class=${`sidebar-session-sort-menu${params.compact ? " session-menu--compact" : ""}`}
         .open=${true}
         placement="bottom-start"
         .distance=${0}
@@ -329,7 +372,11 @@ export function renderSidebarSessionSortMenu(params: {
         @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
           event.preventDefault();
           const value = event.detail.item.value;
-          if (value?.startsWith("grouping:")) {
+          if (value === "compact:open-specific-owner") {
+            params.onViewChange("specific-owner");
+          } else if (value === "compact:back") {
+            params.onViewChange("root");
+          } else if (value?.startsWith("grouping:")) {
             params.onGroupingChange(value.slice("grouping:".length) as SidebarSessionsGrouping);
           } else if (value?.startsWith("sort:")) {
             params.onSortModeChange(value.slice("sort:".length) as SidebarSessionSortMode);
@@ -356,92 +403,89 @@ export function renderSidebarSessionSortMenu(params: {
         @wa-after-hide=${(event: Event) => params.onClose(consumeDropdownKeyboardDismissal(event))}
       >
         ${renderSidebarMenuTrigger(position, t("chat.sidebar.sortSessions"))}
-        <div class="sidebar-session-sort-menu__title">${t("sessionsView.groupBy")}</div>
-        ${groupingOptions
-          .filter((option) => option.grouping !== "person" || params.peopleSortAvailable)
-          .map((option) =>
-            renderSidebarMenuRadioItem({
-              value: `grouping:${option.grouping}`,
-              checked: params.grouping === option.grouping,
-              label: option.label,
-            }),
-          )}
-        <div class="session-menu__separator" role="separator"></div>
-        <div class="sidebar-session-sort-menu__title">${t("chat.sidebar.sortBy")}</div>
-        ${SIDEBAR_SESSION_SORT_OPTIONS.filter(
-          (option) => option.mode !== "people" || params.peopleSortAvailable,
-        ).map((option) =>
-          renderSidebarMenuRadioItem({
-            value: `sort:${option.mode}`,
-            checked: params.sortMode === option.mode,
-            label: t(option.labelKey),
-          }),
-        )}
-        <div class="session-menu__separator" role="separator"></div>
-        <div class="sidebar-session-sort-menu__title">${t("sessionsView.status")}</div>
-        ${SIDEBAR_SESSION_STATUS_OPTIONS.map((statusFilter) =>
-          renderSidebarMenuRadioItem({
-            value: `status:${statusFilter}`,
-            checked: params.statusFilter === statusFilter,
-            label:
-              statusFilter === "active"
-                ? t("common.active")
-                : statusFilter === "archived"
-                  ? t("sessionsView.archived")
-                  : t("sessionsView.all"),
-          }),
-        )}
-        ${renderSidebarOwnerFilter(
-          params.owners,
-          params.ownerFilterId,
-          params.involvingMe,
-          params.selfOwnerId,
-        )}
-        <div class="session-menu__separator" role="separator"></div>
-        <wa-dropdown-item
-          class="sidebar-session-sort-menu__item"
-          type="checkbox"
-          value="show-preview"
-          .checked=${params.showPreview}
-        >
-          <span class="session-menu__text">${t("sessionsView.showSessionPreview")}</span>
-          <span slot="details" class="session-menu__check" aria-hidden="true"
-            >${params.showPreview ? icons.check : nothing}</span
-          >
-        </wa-dropdown-item>
-        <wa-dropdown-item
-          class="sidebar-session-sort-menu__item"
-          type="checkbox"
-          value="show-cron"
-          .checked=${params.showCron}
-        >
-          <span class="session-menu__text">${t("sessionsView.showCronSessions")}</span>
-          <span slot="details" class="session-menu__check" aria-hidden="true"
-            >${params.showCron ? icons.check : nothing}</span
-          >
-        </wa-dropdown-item>
-        <wa-dropdown-item
-          class="sidebar-session-sort-menu__item"
-          type="checkbox"
-          value="show-system"
-          .checked=${params.showSystem}
-        >
-          <span class="session-menu__text">${t("sessionsView.showSystemSessions")}</span>
-          <span slot="details" class="session-menu__check" aria-hidden="true"
-            >${params.showSystem ? icons.check : nothing}</span
-          >
-        </wa-dropdown-item>
-        <wa-dropdown-item
-          class="sidebar-session-sort-menu__item"
-          type="checkbox"
-          value="hide-empty-groups"
-          .checked=${params.hideEmptyGroups}
-        >
-          <span class="session-menu__text">${t("sessionsView.hideEmptyGroups")}</span>
-          <span slot="details" class="session-menu__check" aria-hidden="true"
-            >${params.hideEmptyGroups ? icons.check : nothing}</span
-          >
-        </wa-dropdown-item>
+        ${params.compact && params.view === "specific-owner"
+          ? renderCompactSidebarOwnerFilter(params)
+          : html`<div class="sidebar-session-sort-menu__title">${t("sessionsView.groupBy")}</div>
+              ${groupingOptions
+                .filter((option) => option.grouping !== "person" || params.peopleSortAvailable)
+                .map((option) =>
+                  renderSidebarMenuRadioItem({
+                    value: `grouping:${option.grouping}`,
+                    checked: params.grouping === option.grouping,
+                    label: option.label,
+                  }),
+                )}
+              <div class="session-menu__separator" role="separator"></div>
+              <div class="sidebar-session-sort-menu__title">${t("chat.sidebar.sortBy")}</div>
+              ${SIDEBAR_SESSION_SORT_OPTIONS.filter(
+                (option) => option.mode !== "people" || params.peopleSortAvailable,
+              ).map((option) =>
+                renderSidebarMenuRadioItem({
+                  value: `sort:${option.mode}`,
+                  checked: params.sortMode === option.mode,
+                  label: t(option.labelKey),
+                }),
+              )}
+              <div class="session-menu__separator" role="separator"></div>
+              <div class="sidebar-session-sort-menu__title">${t("sessionsView.status")}</div>
+              ${SIDEBAR_SESSION_STATUS_OPTIONS.map((statusFilter) =>
+                renderSidebarMenuRadioItem({
+                  value: `status:${statusFilter}`,
+                  checked: params.statusFilter === statusFilter,
+                  label:
+                    statusFilter === "active"
+                      ? t("common.active")
+                      : statusFilter === "archived"
+                        ? t("sessionsView.archived")
+                        : t("sessionsView.all"),
+                }),
+              )}
+              ${renderSidebarOwnerFilter(params)}
+              <div class="session-menu__separator" role="separator"></div>
+              <wa-dropdown-item
+                class="sidebar-session-sort-menu__item"
+                type="checkbox"
+                value="show-preview"
+                .checked=${params.showPreview}
+              >
+                <span class="session-menu__text">${t("sessionsView.showSessionPreview")}</span>
+                <span slot="details" class="session-menu__check" aria-hidden="true"
+                  >${params.showPreview ? icons.check : nothing}</span
+                >
+              </wa-dropdown-item>
+              <wa-dropdown-item
+                class="sidebar-session-sort-menu__item"
+                type="checkbox"
+                value="show-cron"
+                .checked=${params.showCron}
+              >
+                <span class="session-menu__text">${t("sessionsView.showCronSessions")}</span>
+                <span slot="details" class="session-menu__check" aria-hidden="true"
+                  >${params.showCron ? icons.check : nothing}</span
+                >
+              </wa-dropdown-item>
+              <wa-dropdown-item
+                class="sidebar-session-sort-menu__item"
+                type="checkbox"
+                value="show-system"
+                .checked=${params.showSystem}
+              >
+                <span class="session-menu__text">${t("sessionsView.showSystemSessions")}</span>
+                <span slot="details" class="session-menu__check" aria-hidden="true"
+                  >${params.showSystem ? icons.check : nothing}</span
+                >
+              </wa-dropdown-item>
+              <wa-dropdown-item
+                class="sidebar-session-sort-menu__item"
+                type="checkbox"
+                value="hide-empty-groups"
+                .checked=${params.hideEmptyGroups}
+              >
+                <span class="session-menu__text">${t("sessionsView.hideEmptyGroups")}</span>
+                <span slot="details" class="session-menu__check" aria-hidden="true"
+                  >${params.hideEmptyGroups ? icons.check : nothing}</span
+                >
+              </wa-dropdown-item>`}
       </wa-dropdown>
     `,
   );

--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -43,9 +43,11 @@ function renderSidebarMenuRadioItem(params: {
   checked: boolean;
   label: string;
   owner?: SessionOwnerOption;
+  submenu?: boolean;
 }) {
   return html`
     <wa-dropdown-item
+      slot=${params.submenu ? "submenu" : nothing}
       class="sidebar-session-sort-menu__item"
       value=${params.value}
       role="menuitemradio"
@@ -85,17 +87,23 @@ function renderSidebarOwnerFilter(
       checked: involvingMe,
       label: t("sessionsView.involvingMe"),
     })}
-    ${owners.map((owner) =>
-      renderSidebarMenuRadioItem({
-        value: `owner:${owner.id}`,
-        checked: ownerFilterId === owner.id,
-        label:
-          owner.id === selfOwnerId
-            ? t("sessionsView.ownerYou", { name: owner.label ?? owner.id })
-            : (owner.label ?? owner.id),
-        owner,
-      }),
-    )}
+    ${owners.length > 0
+      ? html`<wa-dropdown-item class="session-menu__item sidebar-session-sort-menu__item">
+          <span class="session-menu__text">${t("sessionsView.owners")}</span>
+          ${owners.map((owner) =>
+            renderSidebarMenuRadioItem({
+              value: `owner:${owner.id}`,
+              checked: ownerFilterId === owner.id,
+              label:
+                owner.id === selfOwnerId
+                  ? t("sessionsView.ownerYou", { name: owner.label ?? owner.id })
+                  : (owner.label ?? owner.id),
+              owner,
+              submenu: true,
+            }),
+          )}
+        </wa-dropdown-item>`
+      : nothing}
   `;
 }
 

--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -12,7 +12,6 @@ import {
   type SidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
 import { icons } from "./icons.ts";
-import { menuShortcutHint } from "./menu-shortcuts.ts";
 import {
   renderSessionOwnerAvatar,
   renderSessionOwnerChip,
@@ -109,7 +108,12 @@ function renderSidebarOwnerFilter(
                   >${selectedOwner.label ?? selectedOwner.id}</span
                 >
               </span>`
-            : menuShortcutHint(String(owners.length))}
+            : html`<span
+                slot="details"
+                class="session-menu__shortcut sidebar-session-owner-count"
+                aria-hidden="true"
+                >${owners.length}</span
+              >`}
           ${owners.map((owner) =>
             renderSidebarMenuRadioItem({
               value: `owner:${owner.id}`,

--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -112,12 +112,8 @@ function renderSidebarOwnerFilter(params: {
     : t("sessionsView.specificOwnerAvailable", { count: String(owners.length) });
   const details = selectedOwner
     ? html`${renderSessionOwnerAvatar(selectedOwner)}
-        <span class="session-menu__shortcut sidebar-session-owner-selection__name"
-          >${selectedName}</span
-        >`
-    : html`<span class="session-menu__shortcut sidebar-session-owner-count"
-        >${owners.length}</span
-      >`;
+        <span class="sidebar-session-owner-selection__name">${selectedName}</span>`
+    : html`<span class="sidebar-session-owner-count">${owners.length}</span>`;
   return html`
     <div class="session-menu__separator" role="separator"></div>
     <div class="sidebar-session-sort-menu__title">${t("sessionsView.owners")}</div>
@@ -134,10 +130,12 @@ function renderSidebarOwnerFilter(params: {
     ${owners.length > 0
       ? params.compact
         ? renderCompactSessionMenuNavigationItem({
-            view: "specific-owner",
+            value: "compact:open-specific-owner",
             label: t("sessionsView.specificOwner"),
             icon: icons.users,
-            details: html`<span class="sidebar-session-owner-selection">${details}</span>`,
+            details: html`<span class="session-menu__shortcut sidebar-session-owner-selection"
+              >${details}</span
+            >`,
             accessibleLabel,
           })
         : html`<wa-dropdown-item
@@ -165,6 +163,13 @@ function renderCompactSidebarOwnerFilter(params: {
   return renderCompactSessionMenuFrame(
     html`${renderSidebarOwnerOptions({ ...params, submenu: false })}`,
   );
+}
+
+function sidebarFilterMenuViewForValue(value: string | undefined): SidebarFilterMenuView | null {
+  if (value === "compact:open-specific-owner") {
+    return "specific-owner";
+  }
+  return value === "compact:back" ? "root" : null;
 }
 
 export function renderSidebarSessionGroupMenu(params: {
@@ -286,10 +291,9 @@ export function renderSidebarCatalogViewMenu(params: {
         @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
           event.preventDefault();
           const value = event.detail.item.value;
-          if (value === "compact:open-specific-owner") {
-            params.onViewChange("specific-owner");
-          } else if (value === "compact:back") {
-            params.onViewChange("root");
+          const view = sidebarFilterMenuViewForValue(value);
+          if (view) {
+            params.onViewChange(view);
           } else if (value?.startsWith("grouping:")) {
             params.onGroupingChange(value.slice("grouping:".length) as CatalogProjectGrouping);
           } else if (value?.startsWith("owner:")) {
@@ -372,10 +376,9 @@ export function renderSidebarSessionSortMenu(params: {
         @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
           event.preventDefault();
           const value = event.detail.item.value;
-          if (value === "compact:open-specific-owner") {
-            params.onViewChange("specific-owner");
-          } else if (value === "compact:back") {
-            params.onViewChange("root");
+          const view = sidebarFilterMenuViewForValue(value);
+          if (view) {
+            params.onViewChange(view);
           } else if (value?.startsWith("grouping:")) {
             params.onGroupingChange(value.slice("grouping:".length) as SidebarSessionsGrouping);
           } else if (value?.startsWith("sort:")) {

--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -12,6 +12,7 @@ import {
   type SidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
 import { icons } from "./icons.ts";
+import { menuShortcutHint } from "./menu-shortcuts.ts";
 import {
   renderSessionOwnerAvatar,
   renderSessionOwnerChip,
@@ -79,8 +80,6 @@ function renderSidebarOwnerFilter(
     return nothing;
   }
   const selectedOwner = owners.find((owner) => owner.id === ownerFilterId);
-  const previewOwners = selectedOwner ? [selectedOwner] : owners.slice(0, 3);
-  const previewOverflow = selectedOwner ? 0 : owners.length - previewOwners.length;
   return html`
     <div class="session-menu__separator" role="separator"></div>
     <div class="sidebar-session-sort-menu__title">${t("sessionsView.owners")}</div>
@@ -98,13 +97,19 @@ function renderSidebarOwnerFilter(
       ? html`<wa-dropdown-item
           class="sidebar-session-sort-menu__item sidebar-session-owner-submenu"
         >
-          <span class="session-menu__text">${t("sessionsView.owners")}</span>
-          <span slot="details" class="sidebar-session-owner-preview" aria-hidden="true">
-            ${previewOwners.map((owner) => renderSessionOwnerAvatar(owner))}
-            ${previewOverflow > 0
-              ? html`<span class="viewer-avatar viewer-avatar--overflow">+${previewOverflow}</span>`
-              : nothing}
-          </span>
+          <span class="session-menu__text">${t("sessionsView.specificOwner")}</span>
+          ${selectedOwner
+            ? html`<span
+                slot="details"
+                class="session-menu__shortcut sidebar-session-owner-selection"
+                aria-hidden="true"
+              >
+                ${renderSessionOwnerAvatar(selectedOwner)}
+                <span class="sidebar-session-owner-selection__name"
+                  >${selectedOwner.label ?? selectedOwner.id}</span
+                >
+              </span>`
+            : menuShortcutHint(String(owners.length))}
           ${owners.map((owner) =>
             renderSidebarMenuRadioItem({
               value: `owner:${owner.id}`,

--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -12,7 +12,11 @@ import {
   type SidebarSessionStatusFilter,
 } from "./app-sidebar-session-types.ts";
 import { icons } from "./icons.ts";
-import { renderSessionOwnerChip, type SessionOwnerOption } from "./session-owner-chip.ts";
+import {
+  renderSessionOwnerAvatar,
+  renderSessionOwnerChip,
+  type SessionOwnerOption,
+} from "./session-owner-chip.ts";
 import {
   consumeDropdownKeyboardDismissal,
   syncDropdownItemRadio,
@@ -74,6 +78,9 @@ function renderSidebarOwnerFilter(
   if (owners.length === 0 && ownerFilterId === null && !involvingMe) {
     return nothing;
   }
+  const selectedOwner = owners.find((owner) => owner.id === ownerFilterId);
+  const previewOwners = selectedOwner ? [selectedOwner] : owners.slice(0, 3);
+  const previewOverflow = selectedOwner ? 0 : owners.length - previewOwners.length;
   return html`
     <div class="session-menu__separator" role="separator"></div>
     <div class="sidebar-session-sort-menu__title">${t("sessionsView.owners")}</div>
@@ -88,8 +95,16 @@ function renderSidebarOwnerFilter(
       label: t("sessionsView.involvingMe"),
     })}
     ${owners.length > 0
-      ? html`<wa-dropdown-item class="session-menu__item sidebar-session-sort-menu__item">
+      ? html`<wa-dropdown-item
+          class="sidebar-session-sort-menu__item sidebar-session-owner-submenu"
+        >
           <span class="session-menu__text">${t("sessionsView.owners")}</span>
+          <span slot="details" class="sidebar-session-owner-preview" aria-hidden="true">
+            ${previewOwners.map((owner) => renderSessionOwnerAvatar(owner))}
+            ${previewOverflow > 0
+              ? html`<span class="viewer-avatar viewer-avatar--overflow">+${previewOverflow}</span>`
+              : nothing}
+          </span>
           ${owners.map((owner) =>
             renderSidebarMenuRadioItem({
               value: `owner:${owner.id}`,

--- a/ui/src/components/session-menu-actions.ts
+++ b/ui/src/components/session-menu-actions.ts
@@ -310,7 +310,13 @@ export class SessionMenuActions {
     title?: string,
   ) {
     if (this.readState().compact) {
-      return renderCompactSessionMenuNavigationItem({ view, label, icon, disabled, title });
+      return renderCompactSessionMenuNavigationItem({
+        value: `compact:open-${view}`,
+        label,
+        icon,
+        disabled,
+        title,
+      });
     }
     const shortcut = view === "icon" ? "i" : view === "copy" ? "c" : undefined;
     return html`<wa-dropdown-item
@@ -396,7 +402,7 @@ export class SessionMenuActions {
         : state.compact
           ? state.selfOwner || state.ownerOptions.length > 0
             ? renderCompactSessionMenuNavigationItem({
-                view: "assign-owner",
+                value: "compact:open-assign-owner",
                 label: t("sessionsView.assignTo"),
                 icon: icons.users,
                 disabled: this.actionDisabled("assign-owner"),

--- a/ui/src/components/session-menu-compact.ts
+++ b/ui/src/components/session-menu-compact.ts
@@ -24,7 +24,7 @@ export function compactSessionMenuViewForValue(value: string): CompactSessionMen
 }
 
 export function renderCompactSessionMenuNavigationItem(params: {
-  view: Exclude<CompactSessionMenuView, "root"> | "specific-owner";
+  value: string;
   label: string;
   icon: TemplateResult;
   details?: TemplateResult;
@@ -34,8 +34,8 @@ export function renderCompactSessionMenuNavigationItem(params: {
 }) {
   return html`
     <wa-dropdown-item
-      class="session-menu__item"
-      value=${`compact:open-${params.view}`}
+      class=${`session-menu__item${params.details ? " session-menu__item--compact-details" : ""}`}
+      value=${params.value}
       aria-label=${params.accessibleLabel ?? nothing}
       ?disabled=${params.disabled ?? false}
       title=${params.title ?? nothing}
@@ -43,16 +43,13 @@ export function renderCompactSessionMenuNavigationItem(params: {
       <span slot="icon" class="session-menu__icon" aria-hidden="true">${params.icon}</span>
       <span class="session-menu__text">${params.label}</span>
       ${params.details
-        ? html`<span slot="details" class="session-menu__compact-details" aria-hidden="true">
-            ${params.details}
-            <span class="session-menu__icon session-menu__chevron">${icons.chevronRight}</span>
-          </span>`
-        : html`<span
-            slot="details"
-            class="session-menu__icon session-menu__chevron"
-            aria-hidden="true"
-            >${icons.chevronRight}</span
-          >`}
+        ? html`<span class="session-menu__compact-details" aria-hidden="true"
+            >${params.details}</span
+          >`
+        : nothing}
+      <span slot="details" class="session-menu__icon session-menu__chevron" aria-hidden="true"
+        >${icons.chevronRight}</span
+      >
     </wa-dropdown-item>
   `;
 }

--- a/ui/src/components/session-menu-compact.ts
+++ b/ui/src/components/session-menu-compact.ts
@@ -24,9 +24,11 @@ export function compactSessionMenuViewForValue(value: string): CompactSessionMen
 }
 
 export function renderCompactSessionMenuNavigationItem(params: {
-  view: Exclude<CompactSessionMenuView, "root">;
+  view: Exclude<CompactSessionMenuView, "root"> | "specific-owner";
   label: string;
   icon: TemplateResult;
+  details?: TemplateResult;
+  accessibleLabel?: string;
   disabled?: boolean;
   title?: string;
 }) {
@@ -34,14 +36,23 @@ export function renderCompactSessionMenuNavigationItem(params: {
     <wa-dropdown-item
       class="session-menu__item"
       value=${`compact:open-${params.view}`}
+      aria-label=${params.accessibleLabel ?? nothing}
       ?disabled=${params.disabled ?? false}
       title=${params.title ?? nothing}
     >
       <span slot="icon" class="session-menu__icon" aria-hidden="true">${params.icon}</span>
       <span class="session-menu__text">${params.label}</span>
-      <span slot="details" class="session-menu__icon session-menu__chevron" aria-hidden="true"
-        >${icons.chevronRight}</span
-      >
+      ${params.details
+        ? html`<span slot="details" class="session-menu__compact-details" aria-hidden="true">
+            ${params.details}
+            <span class="session-menu__icon session-menu__chevron">${icons.chevronRight}</span>
+          </span>`
+        : html`<span
+            slot="details"
+            class="session-menu__icon session-menu__chevron"
+            aria-hidden="true"
+            >${icons.chevronRight}</span
+          >`}
     </wa-dropdown-item>
   `;
 }

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -51,19 +51,17 @@ type SidebarMenuAgent = {
   identity?: { name?: string; emoji?: string; avatar?: string; avatarUrl?: string };
 };
 
+type MenuPosition = { x: number; y: number };
+type CatalogMenuPosition = MenuPosition & { catalogId: string };
+
 interface SidebarMenusControllerState {
   customizeMenuPosition: { x: number; y: number } | null;
   moreMenuPosition: { x: number; y: number } | null;
   sessionMenu: SidebarSessionMenuState | null;
   sessionMenuWork: SessionMenuWork | null;
   sessionGroupMenu: SidebarSessionGroupMenuState | null;
-  sessionSortMenuPosition: { x: number; y: number; view: SidebarFilterMenuView } | null;
-  catalogViewMenuPosition: {
-    catalogId: string;
-    x: number;
-    y: number;
-    view: SidebarFilterMenuView;
-  } | null;
+  sessionSortMenuPosition: MenuPosition | null;
+  catalogViewMenuPosition: CatalogMenuPosition | null;
   agentMenuPosition: { x: number; top: number } | null;
   agentMenuInteractionState: AgentMenuInteractionState;
   identityMenuPosition: { x: number; bottom: number; width: number } | null;
@@ -166,13 +164,9 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
   sessionMenu: SidebarSessionMenuState | null = null;
   sessionMenuWork: SessionMenuWork | null = null;
   sessionGroupMenu: SidebarSessionGroupMenuState | null = null;
-  sessionSortMenuPosition: { x: number; y: number; view: SidebarFilterMenuView } | null = null;
-  catalogViewMenuPosition: {
-    catalogId: string;
-    x: number;
-    y: number;
-    view: SidebarFilterMenuView;
-  } | null = null;
+  sessionSortMenuPosition: MenuPosition | null = null;
+  catalogViewMenuPosition: CatalogMenuPosition | null = null;
+  filterMenuView: SidebarFilterMenuView = "root";
   agentMenuPosition: { x: number; top: number } | null = null;
   // Anchored by its bottom edge so the footer menu grows upward regardless of height.
   identityMenuPosition: { x: number; bottom: number; width: number } | null = null;
@@ -461,19 +455,11 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
     const rect = trigger.getBoundingClientRect();
     this.dismissTransientMenus();
     this.sessionSortMenuTrigger = trigger;
+    this.filterMenuView = "root";
     this.updateState("sessionSortMenuPosition", {
       x: Math.max(8, Math.min(rect.right, window.innerWidth - menuWidth - 8)),
       y: Math.max(8, Math.min(rect.bottom + 4, window.innerHeight - menuMaxHeight - 8)),
-      view: "root",
     });
-  }
-
-  setSessionSortMenuView(view: SidebarFilterMenuView) {
-    const menu = this.sessionSortMenuPosition;
-    if (menu) {
-      this.updateState("sessionSortMenuPosition", { ...menu, view });
-      this.focusFilterMenuView();
-    }
   }
 
   toggleCatalogViewMenu(catalogId: string, trigger: HTMLElement) {
@@ -491,29 +477,35 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
     const menuMaxHeight = 360;
     this.dismissTransientMenus();
     this.catalogViewMenuTrigger = trigger;
+    this.filterMenuView = "root";
     this.updateState("catalogViewMenuPosition", {
       catalogId,
       x: Math.max(8, Math.min(x, window.innerWidth - menuWidth - 8)),
       y: Math.max(8, Math.min(y, window.innerHeight - menuMaxHeight - 8)),
-      view: "root",
     });
   }
 
-  setCatalogViewMenuView(view: SidebarFilterMenuView) {
-    const menu = this.catalogViewMenuPosition;
-    if (menu) {
-      this.updateState("catalogViewMenuPosition", { ...menu, view });
-      this.focusFilterMenuView();
+  setFilterMenuView(view: SidebarFilterMenuView) {
+    if (!this.sessionSortMenuPosition && !this.catalogViewMenuPosition) {
+      return;
     }
+    this.filterMenuView = view;
+    this.host.requestUpdate();
+    this.focusFilterMenuView();
   }
 
   private focusFilterMenuView() {
     void this.host.updateComplete.then(() => {
-      document
-        .querySelector<HTMLElement>(
-          ".sidebar-session-sort-menu wa-dropdown-item:not([disabled]):not([slot='submenu'])",
-        )
-        ?.focus();
+      const trigger = this.sessionSortMenuTrigger ?? this.catalogViewMenuTrigger;
+      const dropdown = trigger
+        ?.closest("openclaw-app-sidebar")
+        ?.querySelector<HTMLElement>(".sidebar-session-sort-menu");
+      const menu = dropdown?.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+      if (!dropdown || !menu) {
+        return;
+      }
+      menu.scrollTop = 0;
+      dropdown.querySelector<HTMLElement>("wa-dropdown-item:not([disabled])")?.focus();
     });
   }
 

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -57,12 +57,19 @@ interface SidebarMenusControllerState {
   sessionMenu: SidebarSessionMenuState | null;
   sessionMenuWork: SessionMenuWork | null;
   sessionGroupMenu: SidebarSessionGroupMenuState | null;
-  sessionSortMenuPosition: { x: number; y: number } | null;
-  catalogViewMenuPosition: { catalogId: string; x: number; y: number } | null;
+  sessionSortMenuPosition: { x: number; y: number; view: SidebarFilterMenuView } | null;
+  catalogViewMenuPosition: {
+    catalogId: string;
+    x: number;
+    y: number;
+    view: SidebarFilterMenuView;
+  } | null;
   agentMenuPosition: { x: number; top: number } | null;
   agentMenuInteractionState: AgentMenuInteractionState;
   identityMenuPosition: { x: number; bottom: number; width: number } | null;
 }
+
+export type SidebarFilterMenuView = "root" | "specific-owner";
 
 type SidebarMenusRenderer = {
   renderSidebarAgentMenuForController(controller: SidebarMenusController): unknown;
@@ -159,8 +166,13 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
   sessionMenu: SidebarSessionMenuState | null = null;
   sessionMenuWork: SessionMenuWork | null = null;
   sessionGroupMenu: SidebarSessionGroupMenuState | null = null;
-  sessionSortMenuPosition: { x: number; y: number } | null = null;
-  catalogViewMenuPosition: { catalogId: string; x: number; y: number } | null = null;
+  sessionSortMenuPosition: { x: number; y: number; view: SidebarFilterMenuView } | null = null;
+  catalogViewMenuPosition: {
+    catalogId: string;
+    x: number;
+    y: number;
+    view: SidebarFilterMenuView;
+  } | null = null;
   agentMenuPosition: { x: number; top: number } | null = null;
   // Anchored by its bottom edge so the footer menu grows upward regardless of height.
   identityMenuPosition: { x: number; bottom: number; width: number } | null = null;
@@ -452,7 +464,16 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
     this.updateState("sessionSortMenuPosition", {
       x: Math.max(8, Math.min(rect.right, window.innerWidth - menuWidth - 8)),
       y: Math.max(8, Math.min(rect.bottom + 4, window.innerHeight - menuMaxHeight - 8)),
+      view: "root",
     });
+  }
+
+  setSessionSortMenuView(view: SidebarFilterMenuView) {
+    const menu = this.sessionSortMenuPosition;
+    if (menu) {
+      this.updateState("sessionSortMenuPosition", { ...menu, view });
+      this.focusFilterMenuView();
+    }
   }
 
   toggleCatalogViewMenu(catalogId: string, trigger: HTMLElement) {
@@ -474,6 +495,25 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
       catalogId,
       x: Math.max(8, Math.min(x, window.innerWidth - menuWidth - 8)),
       y: Math.max(8, Math.min(y, window.innerHeight - menuMaxHeight - 8)),
+      view: "root",
+    });
+  }
+
+  setCatalogViewMenuView(view: SidebarFilterMenuView) {
+    const menu = this.catalogViewMenuPosition;
+    if (menu) {
+      this.updateState("catalogViewMenuPosition", { ...menu, view });
+      this.focusFilterMenuView();
+    }
+  }
+
+  private focusFilterMenuView() {
+    void this.host.updateComplete.then(() => {
+      document
+        .querySelector<HTMLElement>(
+          ".sidebar-session-sort-menu wa-dropdown-item:not([disabled]):not([slot='submenu'])",
+        )
+        ?.focus();
     });
   }
 

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -472,6 +472,9 @@ export function renderSidebarSessionSortMenuForController(controller: SidebarMen
     ownerFilterId: host.sessionOwnerFilterActive ? host.sessionOwnerFilterId : null,
     involvingMe: host.sessionInvolvingMeFilterActive,
     selfOwnerId: host.sessionDataContext?.gateway.snapshot.selfUser?.id ?? null,
+    compact: isMobileNavLayout(),
+    view: position.view,
+    onViewChange: (view) => controller.setSessionSortMenuView(view),
     onGroupingChange: (grouping) => {
       host.sessionOrganizer.setSessionsGrouping(grouping);
       controller.closeSessionSortMenu({ restoreFocus: true });
@@ -527,6 +530,9 @@ export function renderSidebarCatalogViewMenuForController(controller: SidebarMen
     ownerFilterId: host.sessionOwnerFilterActive ? host.sessionOwnerFilterId : null,
     involvingMe: host.sessionInvolvingMeFilterActive,
     selfOwnerId: host.sessionDataContext?.gateway.snapshot.selfUser?.id ?? null,
+    compact: isMobileNavLayout(),
+    view: position.view,
+    onViewChange: (view) => controller.setCatalogViewMenuView(view),
     onGroupingChange: (grouping) => {
       host.setCatalogProjectGrouping(grouping);
       controller.closeCatalogViewMenu({ restoreFocus: true });

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -473,8 +473,8 @@ export function renderSidebarSessionSortMenuForController(controller: SidebarMen
     involvingMe: host.sessionInvolvingMeFilterActive,
     selfOwnerId: host.sessionDataContext?.gateway.snapshot.selfUser?.id ?? null,
     compact: isMobileNavLayout(),
-    view: position.view,
-    onViewChange: (view) => controller.setSessionSortMenuView(view),
+    view: controller.filterMenuView,
+    onViewChange: (view) => controller.setFilterMenuView(view),
     onGroupingChange: (grouping) => {
       host.sessionOrganizer.setSessionsGrouping(grouping);
       controller.closeSessionSortMenu({ restoreFocus: true });
@@ -531,8 +531,8 @@ export function renderSidebarCatalogViewMenuForController(controller: SidebarMen
     involvingMe: host.sessionInvolvingMeFilterActive,
     selfOwnerId: host.sessionDataContext?.gateway.snapshot.selfUser?.id ?? null,
     compact: isMobileNavLayout(),
-    view: position.view,
-    onViewChange: (view) => controller.setCatalogViewMenuView(view),
+    view: controller.filterMenuView,
+    onViewChange: (view) => controller.setFilterMenuView(view),
     onGroupingChange: (grouping) => {
       host.setCatalogProjectGrouping(grouping);
       controller.closeCatalogViewMenu({ restoreFocus: true });

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -29,6 +29,7 @@ import {
   renderSidebarSessionGroupMenu,
   renderSidebarSessionSortMenu,
 } from "./app-sidebar-session-menu-renderers.ts";
+import "../styles/sidebar-menus.css";
 import { sessionMenuReasons } from "./session-menu-access.ts";
 import type { SessionMenuAction } from "./session-menu.ts";
 import { listAssignableSessionOwners } from "./session-owner-chip.ts";

--- a/ui/src/components/web-awesome.test.ts
+++ b/ui/src/components/web-awesome.test.ts
@@ -46,8 +46,20 @@ async function createSubmenuDropdown(itemLabel = "Specific owner") {
   item.append(owner);
   dropdown.append(trigger, item);
   document.body.append(dropdown);
-  await Promise.all([dropdown.updateComplete, item.updateComplete]);
   dropdown.dispatchEvent(new CustomEvent("wa-show", { bubbles: true, composed: true }));
+  await Promise.all([dropdown.updateComplete, item.updateComplete]);
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+  await item.updateComplete;
+  item.dispatchEvent(
+    new CustomEvent("submenu-opening", {
+      bubbles: true,
+      composed: true,
+      detail: { item },
+    }),
+  );
+  await Promise.resolve();
   return { dropdown, item };
 }
 

--- a/ui/src/components/web-awesome.test.ts
+++ b/ui/src/components/web-awesome.test.ts
@@ -31,6 +31,26 @@ async function createDropdown(label?: string, domRoot: (typeof domRoots)[number]
   return { dropdown, trigger };
 }
 
+async function createSubmenuDropdown(itemLabel = "Specific owner") {
+  const dropdown = document.createElement("wa-dropdown") as DropdownElement;
+  dropdown.setAttribute("aria-label", "Filter & sort");
+  const trigger = document.createElement("button");
+  trigger.slot = "trigger";
+  trigger.textContent = "Filter & sort";
+  const item = document.createElement("wa-dropdown-item") as DropdownElement;
+  item.setAttribute("aria-label", itemLabel);
+  item.textContent = "Specific owner";
+  const owner = document.createElement("wa-dropdown-item");
+  owner.slot = "submenu";
+  owner.textContent = "Ada";
+  item.append(owner);
+  dropdown.append(trigger, item);
+  document.body.append(dropdown);
+  await Promise.all([dropdown.updateComplete, item.updateComplete]);
+  dropdown.dispatchEvent(new CustomEvent("wa-show", { bubbles: true, composed: true }));
+  return { dropdown, item };
+}
+
 afterEach(() => document.body.replaceChildren());
 
 describe("Web Awesome adapters", () => {
@@ -61,6 +81,14 @@ describe("Web Awesome adapters", () => {
 
     expect(dropdown.shadowRoot?.querySelector('[part="menu"]')?.getAttribute("aria-label")).toBe(
       "Actions",
+    );
+  });
+
+  it("labels a submenu from its parent item", async () => {
+    const { item } = await createSubmenuDropdown("Specific owner: Ada");
+
+    expect(item.shadowRoot?.querySelector('[part="submenu"]')?.getAttribute("aria-label")).toBe(
+      "Specific owner: Ada",
     );
   });
 

--- a/ui/src/components/web-awesome.ts
+++ b/ui/src/components/web-awesome.ts
@@ -68,6 +68,27 @@ function labelDropdownMenu(dropdown: HTMLElement) {
   }
 }
 
+function labelDropdownSubmenus(dropdown: HTMLElement) {
+  for (const item of dropdown.querySelectorAll<HTMLElement>("wa-dropdown-item")) {
+    const submenu = item.shadowRoot?.querySelector<HTMLElement>('[part="submenu"]');
+    if (!submenu) {
+      continue;
+    }
+    const labelSlot = item.shadowRoot?.querySelector<HTMLSlotElement>("slot:not([name])");
+    const slottedLabel = labelSlot
+      ?.assignedNodes({ flatten: true })
+      .map((node) => node.textContent)
+      .join(" ")
+      .replace(/\s+/gu, " ")
+      .trim();
+    const label = item.getAttribute("aria-label") ?? slottedLabel;
+    if (label) {
+      submenu.setAttribute("aria-label", label);
+      submenu.removeAttribute("aria-labelledby");
+    }
+  }
+}
+
 const dropdownLabelObservers = new WeakMap<HTMLElement, MutationObserver>();
 
 function startDropdownLabelSync(event: Event) {
@@ -79,11 +100,15 @@ function startDropdownLabelSync(event: Event) {
   // Reopening must restore the menu before Web Awesome moves focus into it.
   dropdown.shadowRoot?.querySelector<HTMLElement>('[part="menu"]')?.removeAttribute("inert");
   labelDropdownMenu(dropdown);
+  labelDropdownSubmenus(dropdown);
   dropdownLabelObservers.get(dropdown)?.disconnect();
   if (typeof MutationObserver === "undefined") {
     return;
   }
-  const observer = new MutationObserver(() => labelDropdownMenu(dropdown));
+  const observer = new MutationObserver(() => {
+    labelDropdownMenu(dropdown);
+    labelDropdownSubmenus(dropdown);
+  });
   // Open menus can survive an in-place locale render. Watch only their light
   // DOM so translated labels stay current without observing the whole app.
   observer.observe(dropdown, {

--- a/ui/src/components/web-awesome.ts
+++ b/ui/src/components/web-awesome.ts
@@ -68,25 +68,40 @@ function labelDropdownMenu(dropdown: HTMLElement) {
   }
 }
 
-function labelDropdownSubmenus(dropdown: HTMLElement) {
-  for (const item of dropdown.querySelectorAll<HTMLElement>("wa-dropdown-item")) {
-    const submenu = item.shadowRoot?.querySelector<HTMLElement>('[part="submenu"]');
-    if (!submenu) {
-      continue;
-    }
-    const labelSlot = item.shadowRoot?.querySelector<HTMLSlotElement>("slot:not([name])");
-    const slottedLabel = labelSlot
-      ?.assignedNodes({ flatten: true })
-      .map((node) => node.textContent)
-      .join(" ")
-      .replace(/\s+/gu, " ")
-      .trim();
-    const label = item.getAttribute("aria-label") ?? slottedLabel;
-    if (label) {
-      submenu.setAttribute("aria-label", label);
-      submenu.removeAttribute("aria-labelledby");
-    }
+function labelDropdownSubmenu(item: HTMLElement) {
+  const submenu = item.shadowRoot?.querySelector<HTMLElement>('[part="submenu"]');
+  if (!submenu) {
+    return;
   }
+  const labelSlot = item.shadowRoot?.querySelector<HTMLSlotElement>("slot:not([name])");
+  const slottedLabel = labelSlot
+    ?.assignedNodes({ flatten: true })
+    .map((node) => node.textContent)
+    .join(" ")
+    .replace(/\s+/gu, " ")
+    .trim();
+  const label = item.getAttribute("aria-label") ?? slottedLabel;
+  if (label) {
+    submenu.setAttribute("aria-label", label);
+    submenu.removeAttribute("aria-labelledby");
+  }
+}
+
+function labelDropdownSubmenus(dropdown: HTMLElement) {
+  dropdown.querySelectorAll<HTMLElement>("wa-dropdown-item").forEach(labelDropdownSubmenu);
+}
+
+function labelOpeningSubmenu(event: CustomEvent<{ item?: unknown }>) {
+  const item = event.detail?.item;
+  if (!(item instanceof HTMLElement) || item.localName !== "wa-dropdown-item") {
+    return;
+  }
+  const updateComplete = "updateComplete" in item ? item.updateComplete : undefined;
+  void Promise.resolve(updateComplete).then(() => {
+    if (item.isConnected) {
+      labelDropdownSubmenu(item);
+    }
+  });
 }
 
 const dropdownLabelObservers = new WeakMap<HTMLElement, MutationObserver>();
@@ -151,6 +166,15 @@ function stopDropdownLabelSync(event: Event) {
 
 if (typeof document !== "undefined") {
   document.addEventListener("wa-show", startDropdownLabelSync);
+  document.addEventListener(
+    "submenu-opening",
+    (event) => {
+      if (event instanceof CustomEvent) {
+        labelOpeningSubmenu(event);
+      }
+    },
+    true,
+  );
   document.addEventListener("wa-hide", disableClosingDropdownMenu);
   document.addEventListener("wa-after-hide", stopDropdownLabelSync);
 }

--- a/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
+++ b/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
@@ -1,0 +1,95 @@
+import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
+import {
+  controlUiSessionUrl,
+  createSessionManagementE2eSuite,
+  installMockGateway,
+  sessionsListResponse,
+} from "./session-management.test-support.ts";
+
+const suite = createSessionManagementE2eSuite();
+
+suite.define(() => {
+  it("navigates the owner filter submenu with arrow, Enter, and Escape keys", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      sessionKey: "agent:main:ada",
+      presenceUsers: [{ self: true, id: "profile-patrick", name: "Patrick" }],
+      historyMessages: [{ role: "assistant", content: [{ type: "text", text: "Ready." }] }],
+      methodResponses: {
+        "sessions.list": {
+          ...sessionsListResponse([
+            sessionRow("agent:main:ada", "Ada research", 2),
+            sessionRow("agent:main:bob", "Bob operations", 1),
+          ]),
+          owners: [
+            { type: "human", id: "profile-ada", label: "Ada" },
+            { type: "human", id: "profile-bob", label: "Bob" },
+          ],
+        },
+      },
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:ada"));
+      const trigger = page.getByRole("button", { name: "Filter & sort" });
+      await trigger.focus();
+      await page.keyboard.press("Enter");
+      const menu = page.locator(".sidebar-session-sort-menu");
+      const ownerSubmenu = menu.getByRole("menuitem", { name: "Owners", exact: true });
+      const focusedTopLevelItem = menu.locator(
+        ':scope > wa-dropdown-item:not([slot="submenu"]):focus',
+      );
+      await expect.poll(() => focusedTopLevelItem.count()).toBe(1);
+      const parentIndex = await ownerSubmenu.evaluate((element) =>
+        [...(element.parentElement?.children ?? [])]
+          .filter(
+            (item) =>
+              item.localName === "wa-dropdown-item" && item.getAttribute("slot") !== "submenu",
+          )
+          .indexOf(element),
+      );
+      expect(parentIndex).toBeGreaterThanOrEqual(0);
+
+      const focusOwnerSubmenu = async () => {
+        await page.keyboard.press("Home");
+        for (let step = 0; step < parentIndex; step += 1) {
+          await page.keyboard.press("ArrowDown");
+        }
+      };
+      await focusOwnerSubmenu();
+      await expect
+        .poll(() => ownerSubmenu.evaluate((element) => element === document.activeElement))
+        .toBe(true);
+
+      await page.keyboard.press("ArrowRight");
+      await expect.poll(() => ownerSubmenu.getAttribute("aria-expanded")).toBe("true");
+      await page.keyboard.press("Escape");
+      await expect.poll(() => ownerSubmenu.getAttribute("aria-expanded")).toBe("false");
+      await expect.poll(() => menu.getAttribute("open")).toBeNull();
+      await expect
+        .poll(() => trigger.evaluate((element) => element === document.activeElement))
+        .toBe(true);
+
+      await page.keyboard.press("Enter");
+      await expect.poll(() => focusedTopLevelItem.count()).toBe(1);
+      await focusOwnerSubmenu();
+      await page.keyboard.press("ArrowRight");
+      await expect.poll(() => ownerSubmenu.getAttribute("aria-expanded")).toBe("true");
+      await page.keyboard.press("ArrowDown");
+      await page.keyboard.press("Enter");
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("sessions.list")).some(
+            (request) =>
+              (request.params as { ownerId?: unknown } | undefined)?.ownerId === "profile-ada",
+          ),
+        )
+        .toBe(true);
+      await expect.poll(() => menu.count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
+++ b/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
@@ -9,6 +9,14 @@ import {
 
 const suite = createSessionManagementE2eSuite();
 
+function largeOwnerList(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    type: "human" as const,
+    id: index === count - 1 ? `profile-${"owner-without-label-".repeat(10)}` : `profile-${index}`,
+    ...(index === count - 1 ? {} : { label: `Owner ${index + 1}` }),
+  }));
+}
+
 suite.define(() => {
   it("navigates the owner filter submenu with arrow, Enter, and Escape keys", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
@@ -39,7 +47,10 @@ suite.define(() => {
       await trigger.focus();
       await page.keyboard.press("Enter");
       const menu = page.locator(".sidebar-session-sort-menu");
-      const ownerSubmenu = menu.getByRole("menuitem", { name: "Specific owner", exact: true });
+      const ownerSubmenu = menu.getByRole("menuitem", {
+        name: "Specific owner: 5 available",
+        exact: true,
+      });
       const allOwnersLabel = menu.locator('[value="owner:"] .session-menu__text');
       const ownersLabel = ownerSubmenu.locator(":scope > .session-menu__text");
       const labelAlignment = await allOwnersLabel.evaluate(
@@ -52,13 +63,15 @@ suite.define(() => {
         await allOwnersLabel.evaluate((label) => getComputedStyle(label).color),
       );
       await expect
-        .poll(() => ownerSubmenu.locator(".session-menu__shortcut").textContent())
+        .poll(() => ownerSubmenu.locator(".sidebar-session-owner-count").textContent())
         .toBe("5");
-      expect(await ownerSubmenu.locator(":scope > .sidebar-session-owner-selection").count()).toBe(
-        0,
-      );
-      const trailingGap = (selector: string) =>
-        ownerSubmenu.evaluate((element, contentSelector) => {
+      expect(
+        await ownerSubmenu
+          .locator(":scope > .sidebar-session-owner-selection .viewer-avatar")
+          .count(),
+      ).toBe(0);
+      const trailingGap = (item: typeof ownerSubmenu, selector: string) =>
+        item.evaluate((element, contentSelector) => {
           const details = element.querySelector<HTMLElement>(":scope > [slot='details']");
           const chevron = element.shadowRoot?.querySelector<HTMLElement>("[part='submenu-icon']");
           const content = element.querySelector<HTMLElement>(contentSelector);
@@ -73,7 +86,9 @@ suite.define(() => {
           }
           return chevron.getBoundingClientRect().left - contentBounds.right;
         }, selector);
-      expect(await trailingGap(".sidebar-session-owner-count")).toBeLessThanOrEqual(8);
+      expect(await trailingGap(ownerSubmenu, ".sidebar-session-owner-count")).toBeLessThanOrEqual(
+        8,
+      );
       const focusedTopLevelItem = menu.locator(
         ':scope > wa-dropdown-item:not([slot="submenu"]):focus',
       );
@@ -101,6 +116,13 @@ suite.define(() => {
 
       await page.keyboard.press("ArrowRight");
       await expect.poll(() => ownerSubmenu.getAttribute("aria-expanded")).toBe("true");
+      await expect
+        .poll(() =>
+          ownerSubmenu.evaluate((element) =>
+            element.shadowRoot?.querySelector('[part="submenu"]')?.getAttribute("aria-label"),
+          ),
+        )
+        .toBe("Specific owner: 5 available");
       await page.keyboard.press("Escape");
       await expect.poll(() => ownerSubmenu.getAttribute("aria-expanded")).toBe("false");
       await expect.poll(() => menu.getAttribute("open")).toBeNull();
@@ -128,13 +150,13 @@ suite.define(() => {
       await expect
         .poll(() =>
           page
-            .getByRole("menuitem", { name: "Specific owner", exact: true })
+            .getByRole("menuitem", { name: "Specific owner: Ada", exact: true })
             .locator(".sidebar-session-owner-selection .viewer-avatar")
             .count(),
         )
         .toBe(1);
       const selectedOwnerSubmenu = page.getByRole("menuitem", {
-        name: "Specific owner",
+        name: "Specific owner: Ada",
         exact: true,
       });
       await expect
@@ -145,7 +167,82 @@ suite.define(() => {
       await expect
         .poll(() => page.locator('[value="owner:"]').getAttribute("aria-checked"))
         .toBe("false");
-      expect(await trailingGap(".sidebar-session-owner-selection__name")).toBeLessThanOrEqual(8);
+      expect(
+        await trailingGap(selectedOwnerSubmenu, ".sidebar-session-owner-selection__name"),
+      ).toBeLessThanOrEqual(8);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it.each([
+    { name: "desktop", ownerCount: 60, viewport: { height: 800, width: 1200 } },
+    { name: "compact", ownerCount: 30, viewport: { height: 650, width: 390 } },
+  ])("contains a large owner roster in the $name menu", async ({ name, ownerCount, viewport }) => {
+    const context = await suite.browser.newContext({ viewport });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      sessionKey: "agent:main:large-roster",
+      methodResponses: {
+        "sessions.list": {
+          ...sessionsListResponse([
+            sessionRow("agent:main:large-roster", "Large owner roster", Date.now()),
+          ]),
+          owners: largeOwnerList(ownerCount),
+        },
+      },
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:large-roster"));
+      if (name === "compact") {
+        await page.getByRole("button", { name: "Expand sidebar" }).click();
+      }
+      await page.getByRole("button", { name: "Filter & sort" }).click();
+      const menu = page.locator(".sidebar-session-sort-menu");
+      const specificOwner = menu.getByRole("menuitem", { name: /Specific owner/ });
+      await specificOwner.waitFor();
+      await expect
+        .poll(() => specificOwner.getAttribute("aria-label"))
+        .toMatch(/^Specific owner: \d+ available$/u);
+
+      if (name === "compact") {
+        expect(await specificOwner.getAttribute("aria-haspopup")).toBeNull();
+        await specificOwner.click();
+        await menu.getByRole("menuitem", { name: "Back", exact: true }).waitFor();
+        expect(await menu.locator('[slot="submenu"]').count()).toBe(0);
+        await menu.getByRole("menuitem", { name: "Back", exact: true }).click();
+        await menu.getByRole("menuitem", { name: /Specific owner/ }).click();
+        await menu.locator('[value^="owner:"]').last().click();
+        await expect.poll(() => menu.count()).toBe(0);
+        return;
+      }
+
+      await specificOwner.hover();
+      const submenuMetrics = await specificOwner.evaluate((element) => {
+        const submenu = element.shadowRoot?.querySelector<HTMLElement>('[part="submenu"]');
+        const lastLabel = element.querySelector<HTMLElement>(
+          'wa-dropdown-item[slot="submenu"]:last-of-type .session-menu__text',
+        );
+        if (!submenu || !lastLabel) {
+          throw new Error("expected a complete owner submenu");
+        }
+        const style = getComputedStyle(submenu);
+        return {
+          clientHeight: submenu.clientHeight,
+          scrollHeight: submenu.scrollHeight,
+          width: submenu.getBoundingClientRect().width,
+          maxHeight: style.maxHeight,
+          maxWidth: style.maxWidth,
+          overflowY: style.overflowY,
+          labelOverflows: lastLabel.scrollWidth > lastLabel.clientWidth,
+        };
+      });
+      expect(submenuMetrics.clientHeight).toBeLessThanOrEqual(viewport.height - 16);
+      expect(submenuMetrics.scrollHeight).toBeGreaterThan(submenuMetrics.clientHeight);
+      expect(submenuMetrics.width).toBeLessThanOrEqual(220);
+      expect(submenuMetrics.overflowY).toBe("auto");
+      expect(submenuMetrics.labelOverflows).toBe(true);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
+++ b/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
@@ -39,7 +39,7 @@ suite.define(() => {
       await trigger.focus();
       await page.keyboard.press("Enter");
       const menu = page.locator(".sidebar-session-sort-menu");
-      const ownerSubmenu = menu.getByRole("menuitem", { name: "Owners", exact: true });
+      const ownerSubmenu = menu.getByRole("menuitem", { name: "Specific owner", exact: true });
       const allOwnersLabel = menu.locator('[value="owner:"] .session-menu__text');
       const ownersLabel = ownerSubmenu.locator(":scope > .session-menu__text");
       const labelAlignment = await allOwnersLabel.evaluate(
@@ -52,11 +52,21 @@ suite.define(() => {
         await allOwnersLabel.evaluate((label) => getComputedStyle(label).color),
       );
       await expect
-        .poll(() => ownerSubmenu.locator(".sidebar-session-owner-preview .viewer-avatar").count())
-        .toBe(4);
-      await expect
-        .poll(() => ownerSubmenu.locator(".viewer-avatar--overflow").textContent())
-        .toBe("+2");
+        .poll(() => ownerSubmenu.locator(".session-menu__shortcut").textContent())
+        .toBe("5");
+      expect(await ownerSubmenu.locator(":scope > .sidebar-session-owner-selection").count()).toBe(
+        0,
+      );
+      const trailingGap = () =>
+        ownerSubmenu.evaluate((element) => {
+          const details = element.querySelector<HTMLElement>(":scope > [slot='details']");
+          const chevron = element.shadowRoot?.querySelector<HTMLElement>("[part='submenu-icon']");
+          if (!details || !chevron) {
+            throw new Error("expected owner trailing content and submenu chevron");
+          }
+          return chevron.getBoundingClientRect().left - details.getBoundingClientRect().right;
+        });
+      expect(await trailingGap()).toBeLessThanOrEqual(9);
       const focusedTopLevelItem = menu.locator(
         ':scope > wa-dropdown-item:not([slot="submenu"]):focus',
       );
@@ -111,11 +121,24 @@ suite.define(() => {
       await expect
         .poll(() =>
           page
-            .getByRole("menuitem", { name: "Owners", exact: true })
-            .locator(".sidebar-session-owner-preview .viewer-avatar")
+            .getByRole("menuitem", { name: "Specific owner", exact: true })
+            .locator(".sidebar-session-owner-selection .viewer-avatar")
             .count(),
         )
         .toBe(1);
+      const selectedOwnerSubmenu = page.getByRole("menuitem", {
+        name: "Specific owner",
+        exact: true,
+      });
+      await expect
+        .poll(() =>
+          selectedOwnerSubmenu.locator(".sidebar-session-owner-selection__name").textContent(),
+        )
+        .toBe("Ada");
+      await expect
+        .poll(() => page.locator('[value="owner:"]').getAttribute("aria-checked"))
+        .toBe("false");
+      expect(await trailingGap()).toBeLessThanOrEqual(9);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
+++ b/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
@@ -57,16 +57,23 @@ suite.define(() => {
       expect(await ownerSubmenu.locator(":scope > .sidebar-session-owner-selection").count()).toBe(
         0,
       );
-      const trailingGap = () =>
-        ownerSubmenu.evaluate((element) => {
+      const trailingGap = (selector: string) =>
+        ownerSubmenu.evaluate((element, contentSelector) => {
           const details = element.querySelector<HTMLElement>(":scope > [slot='details']");
           const chevron = element.shadowRoot?.querySelector<HTMLElement>("[part='submenu-icon']");
-          if (!details || !chevron) {
+          const content = element.querySelector<HTMLElement>(contentSelector);
+          if (!details || !chevron || !content) {
             throw new Error("expected owner trailing content and submenu chevron");
           }
-          return chevron.getBoundingClientRect().left - details.getBoundingClientRect().right;
-        });
-      expect(await trailingGap()).toBeLessThanOrEqual(9);
+          const contentBounds = content.getBoundingClientRect();
+          if (details !== content) {
+            const range = document.createRange();
+            range.selectNodeContents(content);
+            return chevron.getBoundingClientRect().left - range.getBoundingClientRect().right;
+          }
+          return chevron.getBoundingClientRect().left - contentBounds.right;
+        }, selector);
+      expect(await trailingGap(".sidebar-session-owner-count")).toBeLessThanOrEqual(8);
       const focusedTopLevelItem = menu.locator(
         ':scope > wa-dropdown-item:not([slot="submenu"]):focus',
       );
@@ -138,7 +145,7 @@ suite.define(() => {
       await expect
         .poll(() => page.locator('[value="owner:"]').getAttribute("aria-checked"))
         .toBe("false");
-      expect(await trailingGap()).toBeLessThanOrEqual(9);
+      expect(await trailingGap(".sidebar-session-owner-selection__name")).toBeLessThanOrEqual(8);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
+++ b/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
@@ -26,6 +26,8 @@ suite.define(() => {
           owners: [
             { type: "human", id: "profile-ada", label: "Ada" },
             { type: "human", id: "profile-bob", label: "Bob" },
+            { type: "human", id: "profile-carol", label: "Carol" },
+            { type: "human", id: "profile-dave", label: "Dave" },
           ],
         },
       },
@@ -38,6 +40,23 @@ suite.define(() => {
       await page.keyboard.press("Enter");
       const menu = page.locator(".sidebar-session-sort-menu");
       const ownerSubmenu = menu.getByRole("menuitem", { name: "Owners", exact: true });
+      const allOwnersLabel = menu.locator('[value="owner:"] .session-menu__text');
+      const ownersLabel = ownerSubmenu.locator(":scope > .session-menu__text");
+      const labelAlignment = await allOwnersLabel.evaluate(
+        (allOwners, owners) =>
+          Math.abs(allOwners.getBoundingClientRect().left - owners.getBoundingClientRect().left),
+        await ownersLabel.elementHandle(),
+      );
+      expect(labelAlignment).toBeLessThanOrEqual(0.5);
+      expect(await ownersLabel.evaluate((label) => getComputedStyle(label).color)).toBe(
+        await allOwnersLabel.evaluate((label) => getComputedStyle(label).color),
+      );
+      await expect
+        .poll(() => ownerSubmenu.locator(".sidebar-session-owner-preview .viewer-avatar").count())
+        .toBe(4);
+      await expect
+        .poll(() => ownerSubmenu.locator(".viewer-avatar--overflow").textContent())
+        .toBe("+2");
       const focusedTopLevelItem = menu.locator(
         ':scope > wa-dropdown-item:not([slot="submenu"]):focus',
       );
@@ -88,6 +107,15 @@ suite.define(() => {
         )
         .toBe(true);
       await expect.poll(() => menu.count()).toBe(0);
+      await trigger.click();
+      await expect
+        .poll(() =>
+          page
+            .getByRole("menuitem", { name: "Owners", exact: true })
+            .locator(".sidebar-session-owner-preview .viewer-avatar")
+            .count(),
+        )
+        .toBe(1);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
+++ b/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
@@ -208,13 +208,60 @@ suite.define(() => {
 
       if (name === "compact") {
         expect(await specificOwner.getAttribute("aria-haspopup")).toBeNull();
+        await specificOwner.evaluate((element) => {
+          const menuPart = element
+            .closest("wa-dropdown")
+            ?.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+          if (menuPart) {
+            menuPart.scrollTop = menuPart.scrollHeight;
+          }
+        });
         await specificOwner.click();
-        await menu.getByRole("menuitem", { name: "Back", exact: true }).waitFor();
+        const back = menu.getByRole("menuitem", { name: "Back", exact: true });
+        await back.waitFor();
         expect(await menu.locator('[slot="submenu"]').count()).toBe(0);
-        await menu.getByRole("menuitem", { name: "Back", exact: true }).click();
+        await expect
+          .poll(() =>
+            menu.evaluate(
+              (dropdown) =>
+                dropdown.shadowRoot?.querySelector<HTMLElement>('[part="menu"]')?.scrollTop,
+            ),
+          )
+          .toBe(0);
+        await expect.poll(() => menu.locator('[value="owner:profile-0"]').isVisible()).toBe(true);
+        await back.click();
         await menu.getByRole("menuitem", { name: /Specific owner/ }).click();
         await menu.locator('[value^="owner:"]').last().click();
         await expect.poll(() => menu.count()).toBe(0);
+        await page.getByRole("button", { name: "Filter & sort" }).click();
+        const selected = page.getByRole("menuitem", { name: /Specific owner:/ });
+        const selectedGeometry = await selected.evaluate((element) => {
+          const dropdown = element.closest("wa-dropdown");
+          const menuPart = dropdown?.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+          const label = element
+            .querySelector<HTMLElement>(".session-menu__text")
+            ?.getBoundingClientRect();
+          const chevron = element
+            .querySelector<HTMLElement>(".session-menu__chevron")
+            ?.getBoundingClientRect();
+          const selectedName = element.querySelector<HTMLElement>(
+            ".sidebar-session-owner-selection__name",
+          );
+          const menuBounds = menuPart?.getBoundingClientRect();
+          return {
+            menuWidth: menuBounds?.width ?? 0,
+            labelLeft: label?.left ?? 0,
+            chevronRight: chevron?.right ?? 0,
+            menuRight: menuBounds?.right ?? 0,
+            nameOverflows: Boolean(
+              selectedName && selectedName.scrollWidth > selectedName.clientWidth,
+            ),
+          };
+        });
+        expect(selectedGeometry.menuWidth).toBeLessThanOrEqual(220);
+        expect(selectedGeometry.labelLeft).toBeGreaterThan(0);
+        expect(selectedGeometry.chevronRight).toBeLessThanOrEqual(selectedGeometry.menuRight);
+        expect(selectedGeometry.nameOverflows).toBe(true);
         return;
       }
 
@@ -243,6 +290,48 @@ suite.define(() => {
       expect(submenuMetrics.width).toBeLessThanOrEqual(220);
       expect(submenuMetrics.overflowY).toBe("auto");
       expect(submenuMetrics.labelOverflows).toBe(true);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("mirrors compact owner navigation arrows in RTL", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 650, width: 390 } });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      sessionKey: "agent:main:rtl-owners",
+      methodResponses: {
+        "sessions.list": {
+          ...sessionsListResponse([sessionRow("agent:main:rtl-owners", "RTL owners", Date.now())]),
+          owners: largeOwnerList(3),
+        },
+      },
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:rtl-owners"));
+      await page.locator("html").evaluate((element) => {
+        element.setAttribute("dir", "rtl");
+      });
+      await page.getByRole("button", { name: "Expand sidebar" }).click();
+      await page.getByRole("button", { name: "Filter & sort" }).click();
+      const specificOwner = page.getByRole("menuitem", { name: /Specific owner/ });
+      await expect
+        .poll(() =>
+          specificOwner
+            .locator(".session-menu__chevron")
+            .evaluate((element) => getComputedStyle(element).transform),
+        )
+        .toContain("-1");
+      await specificOwner.click();
+      await expect
+        .poll(() =>
+          page
+            .getByRole("menuitem", { name: "Back", exact: true })
+            .locator(":scope > .session-menu__icon")
+            .evaluate((element) => getComputedStyle(element).transform),
+        )
+        .toContain("-1");
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -310,14 +310,16 @@ suite.define(() => {
     await captureUiProof(suite, currentPage, "00-people-controls-from-session-owners.png");
     await expectBrowser(ownerMenu.locator('[value="grouping:person"]')).toBeVisible();
     await expectBrowser(ownerMenu.locator('[value="sort:people"]')).toBeVisible();
-    const ownerRows = ownerMenu.locator('wa-dropdown-item[value^="owner:"]:not([value="owner:"])');
+    const ownerSubmenu = ownerMenu.getByRole("menuitem", { name: "Owners", exact: true });
+    await ownerSubmenu.hover();
+    const ownerRows = ownerSubmenu.locator('[slot="submenu"][value^="owner:"]');
     await expectBrowser(ownerRows).toHaveCount(3);
+    await expectBrowser(ownerRows.first()).toBeVisible();
     await expectBrowser(ownerRows.first()).toHaveAttribute("value", "owner:profile-patrick");
     await expectBrowser(ownerRows.first()).toContainText("Patrick (You)");
     await expectBrowser(ownerRows.locator("openclaw-session-owner-chip img")).toHaveCount(3);
-    const firstOwnerCenterDelta = await avatarLabelCenterDelta(ownerRows.first());
     await captureUiProof(suite, currentPage, "00-people-sort-available.png");
-    expect(firstOwnerCenterDelta).toBeLessThanOrEqual(0.5);
+    expect(await avatarLabelCenterDelta(ownerRows.first())).toBeLessThanOrEqual(0.5);
     await selectMenuValue(ownerMenu, "grouping:person");
     await expectBrowser(
       currentPage.locator('[data-session-section="person:profile:profile-ada"]'),
@@ -365,8 +367,8 @@ suite.define(() => {
         );
     };
     const beforeSelection = (await gateway.getRequests("sessions.list")).length;
-    await peopleMenu.locator('[value="owner:profile-ada"]').waitFor();
-    await selectMenuValue(peopleMenu, "owner:profile-ada");
+    await peopleMenu.getByRole("menuitem", { name: "Owners", exact: true }).hover();
+    await peopleMenu.locator('[slot="submenu"][value="owner:profile-ada"]').click();
     await expectOwnerFilter(beforeSelection);
     await captureSessionOwnerProof(suite, currentPage, "04-owner-filter-selected.png");
 

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -310,7 +310,7 @@ suite.define(() => {
     await captureUiProof(suite, currentPage, "00-people-controls-from-session-owners.png");
     await expectBrowser(ownerMenu.locator('[value="grouping:person"]')).toBeVisible();
     await expectBrowser(ownerMenu.locator('[value="sort:people"]')).toBeVisible();
-    const ownerSubmenu = ownerMenu.getByRole("menuitem", { name: "Specific owner", exact: true });
+    const ownerSubmenu = ownerMenu.getByRole("menuitem", { name: /Specific owner/ });
     await ownerSubmenu.hover();
     const ownerRows = ownerSubmenu.locator('[slot="submenu"][value^="owner:"]');
     await expectBrowser(ownerRows).toHaveCount(3);
@@ -367,7 +367,7 @@ suite.define(() => {
         );
     };
     const beforeSelection = (await gateway.getRequests("sessions.list")).length;
-    await peopleMenu.getByRole("menuitem", { name: "Specific owner", exact: true }).hover();
+    await peopleMenu.getByRole("menuitem", { name: /Specific owner/ }).hover();
     await peopleMenu.locator('[slot="submenu"][value="owner:profile-ada"]').click();
     await expectOwnerFilter(beforeSelection);
     await captureSessionOwnerProof(suite, currentPage, "04-owner-filter-selected.png");

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -310,7 +310,7 @@ suite.define(() => {
     await captureUiProof(suite, currentPage, "00-people-controls-from-session-owners.png");
     await expectBrowser(ownerMenu.locator('[value="grouping:person"]')).toBeVisible();
     await expectBrowser(ownerMenu.locator('[value="sort:people"]')).toBeVisible();
-    const ownerSubmenu = ownerMenu.getByRole("menuitem", { name: "Owners", exact: true });
+    const ownerSubmenu = ownerMenu.getByRole("menuitem", { name: "Specific owner", exact: true });
     await ownerSubmenu.hover();
     const ownerRows = ownerSubmenu.locator('[slot="submenu"][value^="owner:"]');
     await expectBrowser(ownerRows).toHaveCount(3);
@@ -367,7 +367,7 @@ suite.define(() => {
         );
     };
     const beforeSelection = (await gateway.getRequests("sessions.list")).length;
-    await peopleMenu.getByRole("menuitem", { name: "Owners", exact: true }).hover();
+    await peopleMenu.getByRole("menuitem", { name: "Specific owner", exact: true }).hover();
     await peopleMenu.locator('[slot="submenu"][value="owner:profile-ada"]').click();
     await expectOwnerFilter(beforeSelection);
     await captureSessionOwnerProof(suite, currentPage, "04-owner-filter-selected.png");

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -988,6 +988,7 @@ export const en: TranslationMap & {
     owners: "Owners",
     allOwners: "All owners",
     involvingMe: "Involving me",
+    specificOwner: "Specific owner",
     ownerYou: "{name} (You)",
     withParticipant: "with {name}",
     withMoreParticipants: "+{count} more",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -989,6 +989,8 @@ export const en: TranslationMap & {
     allOwners: "All owners",
     involvingMe: "Involving me",
     specificOwner: "Specific owner",
+    specificOwnerAvailable: "Specific owner: {count} available",
+    specificOwnerSelected: "Specific owner: {name}",
     ownerYou: "{name} (You)",
     withParticipant: "with {name}",
     withMoreParticipants: "+{count} more",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2574,33 +2574,6 @@ wa-dropdown.session-menu--compact::part(menu) {
   overflow-y: auto;
 }
 
-.session-menu__compact-details {
-  display: inline-flex;
-  flex: 0 1 auto;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-  max-width: 96px;
-  overflow: hidden;
-}
-
-wa-dropdown-item.session-menu__item--compact-details::part(label) {
-  display: flex;
-  align-items: center;
-  min-width: 0;
-}
-
-wa-dropdown-item.session-menu__item--compact-details {
-  box-sizing: border-box;
-  width: 100%;
-  min-width: 0;
-}
-
-html[dir="rtl"] .session-menu__chevron,
-html[dir="rtl"] .session-menu__back > .session-menu__icon {
-  transform: scaleX(-1);
-}
-
 /* Popover hosts live in the top layer so menus escape in-page stacking
    contexts (e.g. the sidebar resizer above the nav); the host itself must
    stay a zero-size shell around its fixed-position menu. */
@@ -2635,8 +2608,6 @@ wa-dropdown.sidebar-session-sort-menu {
 }
 
 wa-dropdown.sidebar-session-sort-menu::part(menu) {
-  box-sizing: border-box;
-  width: min(220px, calc(100dvw - 16px));
   min-width: 176px;
   max-width: 220px;
   padding: var(--menu-padding);
@@ -2644,13 +2615,6 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   border-radius: var(--menu-radius);
   background: var(--bg-elevated);
   box-shadow: var(--overlay-shadow);
-}
-
-wa-dropdown-item.sidebar-session-owner-submenu::part(submenu) {
-  width: min(220px, calc(100dvw - 16px));
-  max-width: calc(100dvw - 16px);
-  max-height: calc(100dvh - 16px);
-  overflow: auto;
 }
 
 .sidebar-session-sort-menu__title {
@@ -2681,7 +2645,6 @@ wa-dropdown-item.sidebar-session-owner-submenu::part(submenu) {
 
 .row.session-menu__label {
   gap: 8px;
-  min-width: 0;
 }
 
 /* Web Awesome's shadow row adds `margin-inline-end: 0.75em !important` to the
@@ -2700,48 +2663,10 @@ wa-dropdown-item.session-menu__item::part(icon) {
 
 /* Web Awesome insets the submenu chevron 1em at its own font size, landing it
    inside the shortcut column and heavier than the hints. Share their rail. */
-wa-dropdown-item.session-menu__item::part(submenu-icon),
-wa-dropdown-item.sidebar-session-owner-submenu::part(submenu-icon) {
+wa-dropdown-item.session-menu__item::part(submenu-icon) {
   inset-inline-end: 8px;
   color: var(--muted);
   font-size: 10px;
-}
-
-.sidebar-session-owner-submenu {
-  color: var(--text);
-}
-
-.session-menu__shortcut.sidebar-session-owner-count {
-  min-width: 0;
-  margin-inline-end: -2px;
-  text-align: right;
-}
-
-.session-menu__shortcut.sidebar-session-owner-selection {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  min-width: 0;
-  width: auto;
-  max-width: 96px;
-  margin-inline-end: -2px;
-  font-family: inherit;
-}
-
-.sidebar-session-owner-selection .viewer-avatar {
-  flex: 0 0 auto;
-  border-color: var(--bg-elevated);
-}
-
-.sidebar-session-owner-selection__name {
-  display: block;
-  flex: 1 1 auto;
-  max-width: 72px;
-  overflow: hidden;
-  color: var(--muted);
-  font-size: var(--control-ui-text-xs);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .session-menu__item:hover:not(:disabled):not([aria-disabled="true"]),

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2674,19 +2674,27 @@ wa-dropdown-item.sidebar-session-owner-submenu::part(submenu-icon) {
   color: var(--text);
 }
 
-.sidebar-session-owner-preview {
+.session-menu__shortcut.sidebar-session-owner-selection {
   display: inline-flex;
   align-items: center;
-  padding-right: 14px;
+  gap: 4px;
+  min-width: 0;
+  width: auto;
+  font-family: inherit;
 }
 
-.sidebar-session-owner-preview .viewer-avatar {
+.sidebar-session-owner-selection .viewer-avatar {
+  flex: 0 0 auto;
   border-color: var(--bg-elevated);
 }
 
-.sidebar-session-owner-preview openclaw-viewer-avatar:not(:first-child) .viewer-avatar,
-.sidebar-session-owner-preview > .viewer-avatar:not(:first-child) {
-  margin-left: -5px;
+.sidebar-session-owner-selection__name {
+  max-width: 72px;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: var(--control-ui-text-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .session-menu__item:hover:not(:disabled):not([aria-disabled="true"]),

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2663,10 +2663,30 @@ wa-dropdown-item.session-menu__item::part(icon) {
 
 /* Web Awesome insets the submenu chevron 1em at its own font size, landing it
    inside the shortcut column and heavier than the hints. Share their rail. */
-wa-dropdown-item.session-menu__item::part(submenu-icon) {
+wa-dropdown-item.session-menu__item::part(submenu-icon),
+wa-dropdown-item.sidebar-session-owner-submenu::part(submenu-icon) {
   inset-inline-end: 8px;
   color: var(--muted);
   font-size: 10px;
+}
+
+.sidebar-session-owner-submenu {
+  color: var(--text);
+}
+
+.sidebar-session-owner-preview {
+  display: inline-flex;
+  align-items: center;
+  padding-right: 14px;
+}
+
+.sidebar-session-owner-preview .viewer-avatar {
+  border-color: var(--bg-elevated);
+}
+
+.sidebar-session-owner-preview openclaw-viewer-avatar:not(:first-child) .viewer-avatar,
+.sidebar-session-owner-preview > .viewer-avatar:not(:first-child) {
+  margin-left: -5px;
 }
 
 .session-menu__item:hover:not(:disabled):not([aria-disabled="true"]),

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2674,12 +2674,19 @@ wa-dropdown-item.sidebar-session-owner-submenu::part(submenu-icon) {
   color: var(--text);
 }
 
+.session-menu__shortcut.sidebar-session-owner-count {
+  min-width: 0;
+  margin-inline-end: -2px;
+  text-align: right;
+}
+
 .session-menu__shortcut.sidebar-session-owner-selection {
   display: inline-flex;
   align-items: center;
   gap: 4px;
   min-width: 0;
   width: auto;
+  margin-inline-end: -2px;
   font-family: inherit;
 }
 

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2574,6 +2574,12 @@ wa-dropdown.session-menu--compact::part(menu) {
   overflow-y: auto;
 }
 
+.session-menu__compact-details {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
 /* Popover hosts live in the top layer so menus escape in-page stacking
    contexts (e.g. the sidebar resizer above the nav); the host itself must
    stay a zero-size shell around its fixed-position menu. */
@@ -2617,6 +2623,13 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   box-shadow: var(--overlay-shadow);
 }
 
+wa-dropdown-item.sidebar-session-owner-submenu::part(submenu) {
+  width: min(220px, calc(100dvw - 16px));
+  max-width: calc(100dvw - 16px);
+  max-height: calc(100dvh - 16px);
+  overflow: auto;
+}
+
 .sidebar-session-sort-menu__title {
   padding: 4px 8px 2px;
   color: var(--muted);
@@ -2645,6 +2658,7 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
 
 .row.session-menu__label {
   gap: 8px;
+  min-width: 0;
 }
 
 /* Web Awesome's shadow row adds `margin-inline-end: 0.75em !important` to the

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2569,6 +2569,11 @@ wa-dropdown.session-menu::part(menu) {
   display: inline-flex;
 }
 
+html[dir="rtl"] .session-menu__chevron,
+html[dir="rtl"] .session-menu__back > .session-menu__icon {
+  transform: scaleX(-1);
+}
+
 wa-dropdown.session-menu--compact::part(menu) {
   max-height: calc(100dvh - 16px);
   overflow-y: auto;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2576,8 +2576,29 @@ wa-dropdown.session-menu--compact::part(menu) {
 
 .session-menu__compact-details {
   display: inline-flex;
+  flex: 0 1 auto;
   align-items: center;
   gap: 6px;
+  min-width: 0;
+  max-width: 96px;
+  overflow: hidden;
+}
+
+wa-dropdown-item.session-menu__item--compact-details::part(label) {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+wa-dropdown-item.session-menu__item--compact-details {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+}
+
+html[dir="rtl"] .session-menu__chevron,
+html[dir="rtl"] .session-menu__back > .session-menu__icon {
+  transform: scaleX(-1);
 }
 
 /* Popover hosts live in the top layer so menus escape in-page stacking
@@ -2614,6 +2635,8 @@ wa-dropdown.sidebar-session-sort-menu {
 }
 
 wa-dropdown.sidebar-session-sort-menu::part(menu) {
+  box-sizing: border-box;
+  width: min(220px, calc(100dvw - 16px));
   min-width: 176px;
   max-width: 220px;
   padding: var(--menu-padding);
@@ -2700,6 +2723,7 @@ wa-dropdown-item.sidebar-session-owner-submenu::part(submenu-icon) {
   gap: 4px;
   min-width: 0;
   width: auto;
+  max-width: 96px;
   margin-inline-end: -2px;
   font-family: inherit;
 }
@@ -2710,6 +2734,8 @@ wa-dropdown-item.sidebar-session-owner-submenu::part(submenu-icon) {
 }
 
 .sidebar-session-owner-selection__name {
+  display: block;
+  flex: 1 1 auto;
   max-width: 72px;
   overflow: hidden;
   color: var(--muted);

--- a/ui/src/styles/sidebar-menus.css
+++ b/ui/src/styles/sidebar-menus.css
@@ -1,0 +1,85 @@
+.session-menu__compact-details {
+  display: inline-flex;
+  flex: 0 1 auto;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  max-width: 96px;
+  overflow: hidden;
+}
+
+wa-dropdown-item.session-menu__item--compact-details::part(label) {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+wa-dropdown-item.session-menu__item--compact-details {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+}
+
+html[dir="rtl"] .session-menu__chevron,
+html[dir="rtl"] .session-menu__back > .session-menu__icon {
+  transform: scaleX(-1);
+}
+
+wa-dropdown.sidebar-session-sort-menu::part(menu) {
+  box-sizing: border-box;
+  width: min(220px, calc(100dvw - 16px));
+}
+
+wa-dropdown-item.sidebar-session-owner-submenu::part(submenu) {
+  width: min(220px, calc(100dvw - 16px));
+  max-width: calc(100dvw - 16px);
+  max-height: calc(100dvh - 16px);
+  overflow: auto;
+}
+
+.row.session-menu__label {
+  min-width: 0;
+}
+
+wa-dropdown-item.sidebar-session-owner-submenu::part(submenu-icon) {
+  inset-inline-end: 8px;
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.sidebar-session-owner-submenu {
+  color: var(--text);
+}
+
+.session-menu__shortcut.sidebar-session-owner-count {
+  min-width: 0;
+  margin-inline-end: -2px;
+  text-align: right;
+}
+
+.session-menu__shortcut.sidebar-session-owner-selection {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  width: auto;
+  max-width: 96px;
+  margin-inline-end: -2px;
+  font-family: inherit;
+}
+
+.sidebar-session-owner-selection .viewer-avatar {
+  flex: 0 0 auto;
+  border-color: var(--bg-elevated);
+}
+
+.sidebar-session-owner-selection__name {
+  display: block;
+  flex: 1 1 auto;
+  max-width: 72px;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: var(--control-ui-text-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/ui/src/styles/sidebar-menus.css
+++ b/ui/src/styles/sidebar-menus.css
@@ -20,11 +20,6 @@ wa-dropdown-item.session-menu__item--compact-details {
   min-width: 0;
 }
 
-html[dir="rtl"] .session-menu__chevron,
-html[dir="rtl"] .session-menu__back > .session-menu__icon {
-  transform: scaleX(-1);
-}
-
 wa-dropdown.sidebar-session-sort-menu::part(menu) {
   box-sizing: border-box;
   width: min(220px, calc(100dvw - 16px));


### PR DESCRIPTION
Closes #135503

## What Problem This Solves

Fixes an issue where opening the session list's **Filter & sort** popover rendered every individual owner in the primary menu. Larger owner rosters made the popover excessively tall and pushed unrelated controls into a long scroll.

## Why This Change Was Made

**All owners** and **Involving me** remain in the primary Owners section, while individual choices move into a **Specific owner** submenu. Desktop keeps the approved side flyout with bounded width, height, scrolling, and truncation. Compact layouts reuse the existing inline Back navigation. The shared compact owner resets inherited scroll, contains long selected IDs, and mirrors forward/Back affordances in RTL. The shared dropdown adapter names nested menus when their actual opening lifecycle begins.

The final cleanup also removes avoidable duplication: shared position aliases replace repeated shapes, one mutually exclusive filter-menu view replaces two view fields and setters, one parser owns compact Back/open dispatch, and the compact navigation helper accepts an explicit value instead of a sidebar-only view literal. Template reindentation accounts for much of the raw renderer churn and does not add a second behavior path.

## User Impact

The session filter stays compact and usable with large rosters, long identifiers, narrow mobile viewports, RTL locales, pointer input, keyboard input, and assistive technology. The approved row states remain unchanged: an available-owner count beside the chevron, or the selected owner's avatar and name.

## Evidence

### Before

![Session filter with a flat owner list](https://github.com/user-attachments/assets/14ca3760-dbb4-4aba-ab49-3272588c746c)

### Approved row states

![Specific owner count beside the chevron](https://github.com/user-attachments/assets/a356ad87-6478-4ea3-ae20-845d46f4e098)

![Selected owner beside the chevron](https://github.com/user-attachments/assets/c8519b18-e51c-4d7b-a7bb-6923f94e81cf)

### Desktop flyout

![Bounded desktop owner submenu](https://github.com/user-attachments/assets/76c701f5-71f5-4299-a2ec-9f9be1bb8d2f)

### Compact navigation

At 390×650, the owner list opens at scrollTop 0 with its first owner visible; the shared menu width is 220 px.

![Compact inline owner navigation](https://github.com/user-attachments/assets/56721147-c05a-47cb-a955-c74b40e6f088)

### Review notes

- The desktop owner flyout and the compact Back navigation contract were confirmed by the Control UI owner (PR author) before landing.
- The submenu relies on the pinned Web Awesome submenu lifecycle as the intended dependency boundary; Escape handling remains the documented follow-up.

## Validation

- `pnpm check:changed`
- `pnpm test ui/src/components/web-awesome.test.ts ui/src/components/session-menu.test.ts ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts ui/src/e2e/session-ownership.e2e.test.ts`
- 17 owner-flow E2E tests plus shared component coverage passed after rebasing onto current `main`.
- Compact coverage verifies long selected-ID truncation, 220 px menu containment, contained chevron, scrollTop reset, first-owner visibility, Back, and RTL mirroring.
- Nested-menu coverage reproduces root opening before item readiness, then verifies naming at `submenu-opening` after the item update.

Production LOC: +398/-140 (net +258) | Tests: +386/-5 (net +381)

### Follow-up

- **Escape from nested Web Awesome menus:** pressing Escape inside a flyout still dismisses the complete dropdown. Web Awesome owns the private submenu stack; closing only the public item would leave that stack stale. A one-level Escape repair belongs upstream or in an explicitly approved dependency patch rather than a shadow-DOM workaround in this change.

