### PR TITLE
fix(ui): simplify session context menu grouping

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -2033,7 +2033,6 @@ async function createChatPickerScenario(
       "openclaw.chat",
       "openclaw.chat.history",
       "progressCard.get",
-      "sessions.assignOwner",
       "sessions.delete",
       "sessions.diff",
       "sessions.files.set",

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -2103,6 +2103,7 @@ async function createChatPickerScenario(
         id: selfProfile.id,
         name: selfProfile.displayName ?? undefined,
         email: selfProfile.emails[0],
+        avatarUrl: `/api/users/${selfProfile.id}/avatar`,
       },
       {
         id: "presence-colin",

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -2033,6 +2033,7 @@ async function createChatPickerScenario(
       "openclaw.chat",
       "openclaw.chat.history",
       "progressCard.get",
+      "sessions.assignOwner",
       "sessions.delete",
       "sessions.diff",
       "sessions.files.set",

--- a/ui/src/components/session-icon-picker.ts
+++ b/ui/src/components/session-icon-picker.ts
@@ -178,6 +178,7 @@ export function renderSessionAppearancePicker(props: SessionIconPickerProps) {
       onSelect: props.onSelectColor,
     })}
     ${renderSessionIconGrid({ ...props, inline: true })}
+    <div class="session-menu__separator" role="separator"></div>
     <button
       type="button"
       class="session-menu__icon-remove"

--- a/ui/src/components/session-menu-actions.ts
+++ b/ui/src/components/session-menu-actions.ts
@@ -6,7 +6,6 @@ import { icons } from "./icons.ts";
 import { menuShortcutHint } from "./menu-shortcuts.ts";
 import { renderSessionAppearancePicker } from "./session-icon-picker.ts";
 import {
-  compactSessionOwnerOptions,
   renderCompactSessionMenuNavigationItem,
   renderCompactSessionMenuView,
   type CompactSessionMenuView,
@@ -394,7 +393,7 @@ export class SessionMenuActions {
       ${batch
         ? nothing
         : state.compact
-          ? compactSessionOwnerOptions(state.ownerOptions, state.selfOwner).length > 0
+          ? state.selfOwner || state.ownerOptions.length > 0
             ? renderCompactSessionMenuNavigationItem({
                 view: "assign-owner",
                 label: t("sessionsView.assignTo"),
@@ -481,7 +480,8 @@ export class SessionMenuActions {
     const state = this.readState();
     return renderCompactSessionMenuView({
       view,
-      ownerOptions: compactSessionOwnerOptions(state.ownerOptions, state.selfOwner),
+      ownerOptions: state.ownerOptions,
+      selfOwner: state.selfOwner,
       currentOwnerId: state.currentOwnerId,
       assignOwnerDisabled: this.actionDisabled("assign-owner"),
       assignOwnerDisabledReason: state.actionDisabledReasons["assign-owner"],

--- a/ui/src/components/session-menu-compact.ts
+++ b/ui/src/components/session-menu-compact.ts
@@ -25,16 +25,6 @@ export function compactSessionMenuViewForValue(value: string): CompactSessionMen
   return COMPACT_SESSION_MENU_VIEW_BY_VALUE[value] ?? null;
 }
 
-export function compactSessionOwnerOptions(
-  ownerOptions: readonly SessionOwnerOption[],
-  selfOwner: SessionOwnerOption | null,
-): readonly SessionOwnerOption[] {
-  if (!selfOwner || ownerOptions.some((owner) => owner.id === selfOwner.id)) {
-    return ownerOptions;
-  }
-  return [selfOwner, ...ownerOptions];
-}
-
 export function renderCompactSessionMenuNavigationItem(params: {
   view: Exclude<CompactSessionMenuView, "root">;
   label: string;
@@ -72,6 +62,7 @@ export function renderCompactSessionMenuFrame(body: TemplateResult | readonly Te
 export function renderCompactSessionMenuView(params: {
   view: CompactSessionMenuView;
   ownerOptions: readonly SessionOwnerOption[];
+  selfOwner: SessionOwnerOption | null;
   currentOwnerId: string | null;
   assignOwnerDisabled: boolean;
   assignOwnerDisabledReason?: string;
@@ -92,6 +83,7 @@ export function renderCompactSessionMenuView(params: {
           ? renderSessionOwnerAssignmentOptions(
               {
                 ownerOptions: params.ownerOptions,
+                selfOwner: params.selfOwner,
                 currentOwnerId: params.currentOwnerId,
                 disabled: params.assignOwnerDisabled,
                 disabledReason: params.assignOwnerDisabledReason,

--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -158,13 +158,13 @@ describe("session menu", () => {
     expect(menuItemLabels(menu).filter((label) => label.startsWith("Assign to"))).toEqual([
       "Assign to…",
     ]);
-    expect(menuItemLabels(submenu)).toEqual(["Me", "Ada", "Research"]);
+    expect(menuItemLabels(submenu)).toEqual(["Me", "Research"]);
     expect(selected.getAttribute("role")).toBe("menuitemradio");
     expect(selected.getAttribute("aria-checked")).toBe("true");
     expect(selected.disabled).toBe(true);
     expect(selected.querySelector("[slot='details']")).not.toBeNull();
 
-    for (const label of ["Me", "Ada"]) {
+    for (const label of ["Me", "Research"]) {
       const value = menuItem(menu, label).getAttribute("value");
       menu.querySelector("wa-dropdown")?.dispatchEvent(
         new CustomEvent("wa-select", {
@@ -176,7 +176,7 @@ describe("session menu", () => {
     }
     expect(onAction.mock.calls).toEqual([
       [{ kind: "assign-owner", owner: { type: "human", id: "profile-ada" } }],
-      [{ kind: "assign-owner", owner: { type: "human", id: "profile-ada" } }],
+      [{ kind: "assign-owner", owner: { type: "agent", id: "research:one" } }],
     ]);
     expect(onClose).toHaveBeenCalledTimes(2);
     const closeOrder = onClose.mock.invocationCallOrder[0];
@@ -292,7 +292,7 @@ describe("session menu", () => {
     await menu.updateComplete;
     selectMenuValue(menu, "compact:open-assign-owner");
     await menu.updateComplete;
-    expect(menuItemLabels(menu)).toEqual(["Back", "Me", "Ada", "Research owner"]);
+    expect(menuItemLabels(menu)).toEqual(["Back", "Me", "Research owner"]);
 
     selectMenuValue(menu, "compact:back");
     await menu.updateComplete;

--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -158,13 +158,13 @@ describe("session menu", () => {
     expect(menuItemLabels(menu).filter((label) => label.startsWith("Assign to"))).toEqual([
       "Assign to…",
     ]);
-    expect(menuItemLabels(submenu)).toEqual(["Assign to me", "Ada", "Research"]);
+    expect(menuItemLabels(submenu)).toEqual(["Me", "Ada", "Research"]);
     expect(selected.getAttribute("role")).toBe("menuitemradio");
     expect(selected.getAttribute("aria-checked")).toBe("true");
     expect(selected.disabled).toBe(true);
     expect(selected.querySelector("[slot='details']")).not.toBeNull();
 
-    for (const label of ["Assign to me", "Ada"]) {
+    for (const label of ["Me", "Ada"]) {
       const value = menuItem(menu, label).getAttribute("value");
       menu.querySelector("wa-dropdown")?.dispatchEvent(
         new CustomEvent("wa-select", {
@@ -292,7 +292,7 @@ describe("session menu", () => {
     await menu.updateComplete;
     selectMenuValue(menu, "compact:open-assign-owner");
     await menu.updateComplete;
-    expect(menuItemLabels(menu)).toEqual(["Back", "Assign to me", "Ada", "Research owner"]);
+    expect(menuItemLabels(menu)).toEqual(["Back", "Me", "Ada", "Research owner"]);
 
     selectMenuValue(menu, "compact:back");
     await menu.updateComplete;

--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -142,7 +142,7 @@ function selectMenuValue(menu: SessionMenuElement, value: string) {
 }
 
 describe("session menu", () => {
-  it("dispatches the same canonical owner from the self shortcut and submenu", async () => {
+  it("puts the self shortcut first in the owner submenu and dispatches canonical owners", async () => {
     const onAction = vi.fn<(action: SessionMenuAction) => void>();
     const onClose = vi.fn();
     const selfOwner = { type: "human", id: "profile-ada", label: "Ada" } as const;
@@ -154,6 +154,11 @@ describe("session menu", () => {
       onClose,
     });
     const selected = menuItem(menu, "Research");
+    const submenu = menuItem(menu, "Assign to…");
+    expect(menuItemLabels(menu).filter((label) => label.startsWith("Assign to"))).toEqual([
+      "Assign to…",
+    ]);
+    expect(menuItemLabels(submenu)).toEqual(["Assign to me", "Ada", "Research"]);
     expect(selected.getAttribute("role")).toBe("menuitemradio");
     expect(selected.getAttribute("aria-checked")).toBe("true");
     expect(selected.disabled).toBe(true);
@@ -287,7 +292,7 @@ describe("session menu", () => {
     await menu.updateComplete;
     selectMenuValue(menu, "compact:open-assign-owner");
     await menu.updateComplete;
-    expect(menuItemLabels(menu)).toEqual(["Back", "Ada", "Research owner"]);
+    expect(menuItemLabels(menu)).toEqual(["Back", "Assign to me", "Ada", "Research owner"]);
 
     selectMenuValue(menu, "compact:back");
     await menu.updateComplete;
@@ -626,6 +631,7 @@ describe("session menu", () => {
     choices[1]?.click();
     expect(onAction).toHaveBeenCalledWith({ kind: "set-icon", icon: "🚀" });
     const remove = submenu.querySelector<HTMLButtonElement>(".session-menu__icon-remove");
+    expect(remove?.previousElementSibling?.getAttribute("role")).toBe("separator");
     expect(remove?.textContent?.trim()).toBe("Reset to default");
     remove?.click();
     expect(onAction).toHaveBeenCalledWith({ kind: "reset-appearance" });

--- a/ui/src/components/session-owner-menu.ts
+++ b/ui/src/components/session-owner-menu.ts
@@ -30,6 +30,9 @@ export function renderSessionOwnerAssignmentOptions(
 ) {
   const title = params.disabledReason ?? nothing;
   const selfChecked = params.selfOwner?.id === params.currentOwnerId;
+  const ownerOptions = params.ownerOptions.filter(
+    (owner) => owner.type !== params.selfOwner?.type || owner.id !== params.selfOwner.id,
+  );
   return html`
     ${params.selfOwner
       ? html`<wa-dropdown-item
@@ -51,7 +54,7 @@ export function renderSessionOwnerAssignmentOptions(
             : nothing}
         </wa-dropdown-item>`
       : nothing}
-    ${params.ownerOptions.map((owner) => {
+    ${ownerOptions.map((owner) => {
       const checked = owner.id === params.currentOwnerId;
       return html`
         <wa-dropdown-item

--- a/ui/src/components/session-owner-menu.ts
+++ b/ui/src/components/session-owner-menu.ts
@@ -9,6 +9,7 @@ type SessionOwnerAssignment = Pick<SessionOwnerOption, "type" | "id">;
 
 type SessionOwnerMenuParams = {
   ownerOptions: readonly SessionOwnerOption[];
+  selfOwner: SessionOwnerOption | null;
   currentOwnerId: string | null;
   disabled: boolean;
   disabledReason?: string;
@@ -28,61 +29,63 @@ export function renderSessionOwnerAssignmentOptions(
   inline = false,
 ) {
   const title = params.disabledReason ?? nothing;
-  return params.ownerOptions.map((owner) => {
-    const checked = owner.id === params.currentOwnerId;
-    return html`
-      <wa-dropdown-item
-        slot=${inline ? nothing : "submenu"}
-        class="session-menu__item"
-        value=${`assign-owner:${owner.type}:${encodeURIComponent(owner.id)}`}
-        role="menuitemradio"
-        aria-checked=${String(checked)}
-        ${ref((element) => syncDropdownItemRadio(element, checked))}
-        ?disabled=${params.disabled || checked}
-        title=${title}
-      >
-        <span slot="icon" class="session-menu__icon" aria-hidden="true"
-          >${renderSessionOwnerAvatar(owner)}</span
-        >
-        <span class="session-menu__text">${owner.label ?? owner.id}</span>
-        ${checked
-          ? html`<span slot="details" class="session-menu__check" aria-hidden="true"
-              >${icons.check}</span
-            >`
-          : nothing}
-      </wa-dropdown-item>
-    `;
-  });
-}
-
-export function renderSessionOwnerAssignmentMenu(
-  params: SessionOwnerMenuParams & {
-    selfOwner: SessionOwnerOption | null;
-  },
-) {
-  const title = params.disabledReason ?? nothing;
+  const selfChecked = params.selfOwner?.id === params.currentOwnerId;
   return html`
     ${params.selfOwner
       ? html`<wa-dropdown-item
+          slot=${inline ? nothing : "submenu"}
           class="session-menu__item"
           value=${`assign-owner:${params.selfOwner.type}:${encodeURIComponent(params.selfOwner.id)}`}
-          ?disabled=${params.disabled || params.currentOwnerId === params.selfOwner.id}
+          role="menuitemradio"
+          aria-checked=${String(selfChecked)}
+          ${ref((element) => syncDropdownItemRadio(element, selfChecked))}
+          ?disabled=${params.disabled || selfChecked}
           title=${title}
         >
           <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.users}</span>
           <span class="session-menu__text">${t("sessionsView.assignToMe")}</span>
+          ${selfChecked
+            ? html`<span slot="details" class="session-menu__check" aria-hidden="true"
+                >${icons.check}</span
+              >`
+            : nothing}
         </wa-dropdown-item>`
       : nothing}
-    ${params.ownerOptions.length > 0
-      ? html`<wa-dropdown-item
+    ${params.ownerOptions.map((owner) => {
+      const checked = owner.id === params.currentOwnerId;
+      return html`
+        <wa-dropdown-item
+          slot=${inline ? nothing : "submenu"}
           class="session-menu__item"
-          ?disabled=${params.disabled}
+          value=${`assign-owner:${owner.type}:${encodeURIComponent(owner.id)}`}
+          role="menuitemradio"
+          aria-checked=${String(checked)}
+          ${ref((element) => syncDropdownItemRadio(element, checked))}
+          ?disabled=${params.disabled || checked}
           title=${title}
         >
-          <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.users}</span>
-          <span class="session-menu__text">${t("sessionsView.assignTo")}</span>
-          ${renderSessionOwnerAssignmentOptions(params)}
-        </wa-dropdown-item>`
-      : nothing}
+          <span slot="icon" class="session-menu__icon" aria-hidden="true"
+            >${renderSessionOwnerAvatar(owner)}</span
+          >
+          <span class="session-menu__text">${owner.label ?? owner.id}</span>
+          ${checked
+            ? html`<span slot="details" class="session-menu__check" aria-hidden="true"
+                >${icons.check}</span
+              >`
+            : nothing}
+        </wa-dropdown-item>
+      `;
+    })}
   `;
+}
+
+export function renderSessionOwnerAssignmentMenu(params: SessionOwnerMenuParams) {
+  const title = params.disabledReason ?? nothing;
+  return params.selfOwner || params.ownerOptions.length > 0
+    ? html`<wa-dropdown-item class="session-menu__item" ?disabled=${params.disabled} title=${title}>
+        <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.users}</span>
+        <span class="session-menu__text">${t("sessionsView.assignTo")}</span>
+        ${renderSessionOwnerAssignmentOptions(params)}
+      </wa-dropdown-item>`
+    : nothing;
 }

--- a/ui/src/e2e/chat-continue-in-terminal.e2e.test.ts
+++ b/ui/src/e2e/chat-continue-in-terminal.e2e.test.ts
@@ -50,7 +50,6 @@ const sharedManagementActions = [
   "Pin session",
   "Mark as unread",
   "Rename…",
-  "Assign to me",
   "Assign to…",
   "Icon & color",
   "Fork conversation",
@@ -60,9 +59,7 @@ const sharedManagementActions = [
   "Archive session",
   "Delete…",
 ] as const;
-const compactManagementActions = sharedManagementActions.filter(
-  (label) => label !== "Assign to me",
-);
+const compactManagementActions = sharedManagementActions;
 
 suite.define(() => {
   it("shows, copies, and retires a credential-free exact continuation command", async () => {

--- a/ui/src/e2e/session-color.e2e.test.ts
+++ b/ui/src/e2e/session-color.e2e.test.ts
@@ -70,6 +70,18 @@ suite.define(() => {
           await openSessionMenuSubmenu(page, "Icon & color");
         }
         const picker = page.locator(".session-menu__appearance:visible");
+        await expect
+          .poll(() =>
+            picker.evaluate((element) => {
+              const iconPicker = element.querySelector(".session-menu__icon-picker");
+              const iconsLabel = element.querySelectorAll(".session-menu__icon-section-label")[2];
+              return [
+                iconPicker ? getComputedStyle(iconPicker).marginTop : null,
+                iconsLabel ? getComputedStyle(iconsLabel).marginTop : null,
+              ];
+            }),
+          )
+          .toEqual(["4px", "4px"]);
         const focused = () =>
           page.evaluate(
             () =>

--- a/ui/src/e2e/session-color.e2e.test.ts
+++ b/ui/src/e2e/session-color.e2e.test.ts
@@ -97,6 +97,13 @@ suite.define(() => {
         const reset = picker.getByRole("button", { name: "Reset to default", exact: true });
         await expect
           .poll(() =>
+            reset.evaluate(
+              (element) => element.previousElementSibling?.getAttribute("role") ?? null,
+            ),
+          )
+          .toBe("separator");
+        await expect
+          .poll(() =>
             reset.evaluateAll((elements) =>
               elements.some((element) => element === document.activeElement),
             ),

--- a/ui/src/e2e/session-owner-assignment.e2e.test.ts
+++ b/ui/src/e2e/session-owner-assignment.e2e.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 import { readThemedPopupPaint } from "./popup-theme.test-support.ts";
+import { openSessionMenuSubmenu } from "./session-management.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI session owner assignment mocked Gateway E2E",
@@ -30,6 +31,7 @@ function sessionsListResponse() {
     owners: [
       { type: "human" as const, id: "profile-ada", label: "Ada" },
       { type: "human" as const, id: "profile-bob", label: "Bob" },
+      { type: "human" as const, id: "profile-carol", label: "Carol" },
     ],
     defaults: { contextTokens: null, model: null, modelProvider: null },
     path: "",
@@ -72,12 +74,14 @@ async function installOwnerGateway(page: Page) {
 
 async function expectAssignmentRequest(
   gateway: Awaited<ReturnType<typeof installOwnerGateway>>,
+  ownerId = "profile-ada",
+  after?: number,
 ): Promise<void> {
-  const request = await gateway.waitForRequest("sessions.assignOwner");
+  const request = await gateway.waitForRequest("sessions.assignOwner", { after });
   expect(request.params).toEqual({
     agentId: "main",
     key: sessionKey,
-    owner: { type: "human", id: "profile-ada" },
+    owner: { type: "human", id: ownerId },
   });
 }
 
@@ -93,12 +97,87 @@ async function captureProof(page: Page, surface: string): Promise<void> {
 }
 
 async function chooseAssignToMe(page: Page): Promise<void> {
-  const action = page.locator('wa-dropdown-item[value="assign-owner:human:profile-ada"]:visible');
+  await page.getByRole("menuitem", { name: "Assign to…", exact: true }).hover();
+  const action = page.getByRole("menuitemradio", { name: "Assign to me", exact: true });
   await action.waitFor({ state: "visible" });
   await action.click();
 }
 
 suite.define(() => {
+  it("assigns named and self owners through one keyboard-accessible submenu", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installOwnerGateway(page);
+        const row = page.locator(`[data-session-key="${sessionKey}"]`);
+        await row.hover();
+        const trigger = row.getByRole("button", {
+          name: "Open session menu: Owner outcome",
+          exact: true,
+        });
+        await trigger.click();
+
+        const menu = page.locator("openclaw-session-menu");
+        const rootAssignmentLabels = await menu
+          .locator(":scope > wa-dropdown > wa-dropdown-item > .session-menu__text")
+          .allTextContents();
+        expect(rootAssignmentLabels.filter((label) => label.startsWith("Assign to"))).toEqual([
+          "Assign to…",
+        ]);
+        const assignTo = menu.getByRole("menuitem", {
+          name: "Assign to…",
+          exact: true,
+        });
+        await assignTo.hover();
+        const ownerItems = assignTo.locator(
+          ':scope > wa-dropdown-item[slot="submenu"] > .session-menu__text',
+        );
+        await expectBrowser(ownerItems).toHaveText([
+          "Assign to me",
+          "OpenClaw",
+          "Ada",
+          "Bob",
+          "Carol",
+        ]);
+        await captureProof(page, "assignment-submenu");
+
+        await assignTo.getByRole("menuitemradio", { name: "Carol", exact: true }).click();
+        await expectAssignmentRequest(gateway, "profile-carol");
+        await gateway.resolveDeferred("sessions.assignOwner", {
+          ok: true,
+          key: sessionKey,
+          owner: { actor: { type: "human", id: "profile-carol", label: "Carol" } },
+        });
+
+        await gateway.deferNext("sessions.assignOwner");
+        await row.hover();
+        await trigger.press("Enter");
+        await openSessionMenuSubmenu(page, "Assign to…");
+        const keyboardAssignTo = page.getByRole("menuitem", {
+          name: "Assign to…",
+          exact: true,
+        });
+        await expectBrowser(
+          page.getByRole("menuitemradio", { name: "Assign to me", exact: true }),
+        ).toBeFocused();
+        await page.keyboard.press("Escape");
+        await expectBrowser(trigger).toHaveAttribute("aria-expanded", "false");
+        await trigger.press("Enter");
+        await openSessionMenuSubmenu(page, "Assign to…");
+        await expectBrowser(keyboardAssignTo).toHaveAttribute("aria-expanded", "true");
+        await expectBrowser(
+          page.getByRole("menuitemradio", { name: "Assign to me", exact: true }),
+        ).toBeFocused();
+        await page.keyboard.press("Enter");
+        await expectAssignmentRequest(gateway, "profile-ada", 1);
+      },
+    );
+  });
+
   it("themes the assignee submenu with the active palette", async () => {
     await suite.withPage(
       {
@@ -127,9 +206,7 @@ suite.define(() => {
           .click();
         const assignTo = page.getByRole("menuitem", { name: "Assign to…", exact: true });
         await assignTo.hover();
-        await assignTo
-          .locator('wa-dropdown-item[slot="submenu"][value="assign-owner:human:profile-ada"]')
-          .waitFor();
+        await assignTo.getByRole("menuitemradio", { name: "Assign to me", exact: true }).waitFor();
 
         const paint = await readThemedPopupPaint(assignTo, "submenu");
         await captureProof(page, "assignee-submenu");

--- a/ui/src/e2e/session-owner-assignment.e2e.test.ts
+++ b/ui/src/e2e/session-owner-assignment.e2e.test.ts
@@ -166,6 +166,27 @@ suite.define(() => {
           ':scope > wa-dropdown-item[slot="submenu"] > .session-menu__text',
         );
         await expectBrowser(ownerItems).toHaveText(["Me", "OpenClaw", "Bob", "Carol"]);
+        const avatarSizes = await assignTo
+          .locator(':scope > wa-dropdown-item[slot="submenu"] .viewer-avatar')
+          .evaluateAll((avatars) =>
+            avatars.map((avatar) => {
+              const bounds = avatar.getBoundingClientRect();
+              const style = getComputedStyle(avatar);
+              return {
+                height: bounds.height,
+                width: bounds.width,
+                cssHeight: style.height,
+                cssWidth: style.width,
+              };
+            }),
+          );
+        expect(avatarSizes.length).toBeGreaterThan(0);
+        expect(
+          avatarSizes.every(
+            ({ width, height, cssWidth, cssHeight }) =>
+              Math.abs(width - height) < 0.01 && cssWidth === "14px" && cssHeight === "14px",
+          ),
+        ).toBe(true);
         await captureProof(page, "assignment-submenu");
 
         await assignTo.getByRole("menuitemradio", { name: "Carol", exact: true }).click();

--- a/ui/src/e2e/session-owner-assignment.e2e.test.ts
+++ b/ui/src/e2e/session-owner-assignment.e2e.test.ts
@@ -104,6 +104,35 @@ async function chooseMe(page: Page): Promise<void> {
 }
 
 suite.define(() => {
+  it("marks exactly one target when the session is assigned to self", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        await installOwnerGateway(page);
+        const row = page.locator('[data-session-key="agent:main:ada-research"]');
+        await row.hover();
+        await row
+          .getByRole("button", { name: "Open session menu: Ada research", exact: true })
+          .click();
+        const assignTo = page.getByRole("menuitem", { name: "Assign to…", exact: true });
+        await assignTo.hover();
+
+        const checked = assignTo.locator(
+          ':scope > wa-dropdown-item[slot="submenu"][aria-checked="true"]',
+        );
+        await expectBrowser(checked).toHaveCount(1);
+        await expectBrowser(checked.locator(":scope > .session-menu__text")).toHaveText("Me");
+        await expectBrowser(
+          assignTo.locator(':scope > wa-dropdown-item[slot="submenu"] > .session-menu__text'),
+        ).toHaveText(["Me", "OpenClaw", "Bob", "Carol"]);
+      },
+    );
+  });
+
   it("assigns named and self owners through one keyboard-accessible submenu", async () => {
     await suite.withPage(
       {
@@ -136,7 +165,7 @@ suite.define(() => {
         const ownerItems = assignTo.locator(
           ':scope > wa-dropdown-item[slot="submenu"] > .session-menu__text',
         );
-        await expectBrowser(ownerItems).toHaveText(["Me", "OpenClaw", "Ada", "Bob", "Carol"]);
+        await expectBrowser(ownerItems).toHaveText(["Me", "OpenClaw", "Bob", "Carol"]);
         await captureProof(page, "assignment-submenu");
 
         await assignTo.getByRole("menuitemradio", { name: "Carol", exact: true }).click();

--- a/ui/src/e2e/session-owner-assignment.e2e.test.ts
+++ b/ui/src/e2e/session-owner-assignment.e2e.test.ts
@@ -96,9 +96,9 @@ async function captureProof(page: Page, surface: string): Promise<void> {
   });
 }
 
-async function chooseAssignToMe(page: Page): Promise<void> {
+async function chooseMe(page: Page): Promise<void> {
   await page.getByRole("menuitem", { name: "Assign to…", exact: true }).hover();
-  const action = page.getByRole("menuitemradio", { name: "Assign to me", exact: true });
+  const action = page.getByRole("menuitemradio", { name: "Me", exact: true });
   await action.waitFor({ state: "visible" });
   await action.click();
 }
@@ -136,13 +136,7 @@ suite.define(() => {
         const ownerItems = assignTo.locator(
           ':scope > wa-dropdown-item[slot="submenu"] > .session-menu__text',
         );
-        await expectBrowser(ownerItems).toHaveText([
-          "Assign to me",
-          "OpenClaw",
-          "Ada",
-          "Bob",
-          "Carol",
-        ]);
+        await expectBrowser(ownerItems).toHaveText(["Me", "OpenClaw", "Ada", "Bob", "Carol"]);
         await captureProof(page, "assignment-submenu");
 
         await assignTo.getByRole("menuitemradio", { name: "Carol", exact: true }).click();
@@ -162,7 +156,7 @@ suite.define(() => {
           exact: true,
         });
         await expectBrowser(
-          page.getByRole("menuitemradio", { name: "Assign to me", exact: true }),
+          page.getByRole("menuitemradio", { name: "Me", exact: true }),
         ).toBeFocused();
         await page.keyboard.press("Escape");
         await expectBrowser(trigger).toHaveAttribute("aria-expanded", "false");
@@ -170,7 +164,7 @@ suite.define(() => {
         await openSessionMenuSubmenu(page, "Assign to…");
         await expectBrowser(keyboardAssignTo).toHaveAttribute("aria-expanded", "true");
         await expectBrowser(
-          page.getByRole("menuitemradio", { name: "Assign to me", exact: true }),
+          page.getByRole("menuitemradio", { name: "Me", exact: true }),
         ).toBeFocused();
         await page.keyboard.press("Enter");
         await expectAssignmentRequest(gateway, "profile-ada", 1);
@@ -206,7 +200,7 @@ suite.define(() => {
           .click();
         const assignTo = page.getByRole("menuitem", { name: "Assign to…", exact: true });
         await assignTo.hover();
-        await assignTo.getByRole("menuitemradio", { name: "Assign to me", exact: true }).waitFor();
+        await assignTo.getByRole("menuitemradio", { name: "Me", exact: true }).waitFor();
 
         const paint = await readThemedPopupPaint(assignTo, "submenu");
         await captureProof(page, "assignee-submenu");
@@ -228,7 +222,7 @@ suite.define(() => {
         const activePane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--active");
         const menuTrigger = activePane.getByRole("button", { name: "Actions for Owner outcome" });
         await menuTrigger.press("Enter");
-        await chooseAssignToMe(page);
+        await chooseMe(page);
         await expectAssignmentRequest(gateway);
 
         const message = "Owner assignment rejected for visible outcome proof.";
@@ -262,7 +256,7 @@ suite.define(() => {
         await row
           .getByRole("button", { name: "Open session menu: Owner outcome", exact: true })
           .click();
-        await chooseAssignToMe(page);
+        await chooseMe(page);
         await expectAssignmentRequest(gateway);
 
         const message = "Sidebar owner assignment rejected for visible outcome proof.";

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -985,7 +985,7 @@ export const en: TranslationMap & {
     ownerYou: "{name} (You)",
     withParticipant: "with {name}",
     withMoreParticipants: "+{count} more",
-    assignToMe: "Assign to me",
+    assignToMe: "Me",
     assignTo: "Assign to…",
     filterControls: "Session filters",
     filters: "Filters",

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -473,7 +473,7 @@ describe("chat header session menu", () => {
     ).toEqual(["Assign to…"]);
     expect(
       Array.from(submenu.querySelectorAll("wa-dropdown-item[slot='submenu']")).map(itemLabel),
-    ).toEqual(["Me", "Ada", "Research"]);
+    ).toEqual(["Me", "Research"]);
     const selected = item(menu, "Research");
     expect(selected.getAttribute("role")).toBe("menuitemradio");
     expect(selected.getAttribute("aria-checked")).toBe("true");
@@ -619,7 +619,7 @@ describe("chat header session menu", () => {
       Array.from(
         menu.querySelectorAll<MenuItemElement>(":scope > wa-dropdown > wa-dropdown-item"),
       ).map(itemLabel),
-    ).toEqual(["Back", "Me", "Ada", "Research"]);
+    ).toEqual(["Back", "Me", "Research"]);
     select(menu, "assign-owner:human:profile-ada");
     expect(onAction).toHaveBeenCalledWith({
       kind: "assign-owner",

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -473,14 +473,14 @@ describe("chat header session menu", () => {
     ).toEqual(["Assign to…"]);
     expect(
       Array.from(submenu.querySelectorAll("wa-dropdown-item[slot='submenu']")).map(itemLabel),
-    ).toEqual(["Assign to me", "Ada", "Research"]);
+    ).toEqual(["Me", "Ada", "Research"]);
     const selected = item(menu, "Research");
     expect(selected.getAttribute("role")).toBe("menuitemradio");
     expect(selected.getAttribute("aria-checked")).toBe("true");
     expect(selected.disabled).toBe(true);
     expect(selected.querySelector("[slot='details']")).not.toBeNull();
 
-    select(menu, item(menu, "Assign to me").getAttribute("value") ?? "");
+    select(menu, item(menu, "Me").getAttribute("value") ?? "");
     select(menu, "assign-owner:agent:research%3Aone");
     expect(onAction.mock.calls).toEqual([
       [{ kind: "assign-owner", owner: { type: "human", id: "profile-ada" } }],
@@ -619,7 +619,7 @@ describe("chat header session menu", () => {
       Array.from(
         menu.querySelectorAll<MenuItemElement>(":scope > wa-dropdown > wa-dropdown-item"),
       ).map(itemLabel),
-    ).toEqual(["Back", "Assign to me", "Ada", "Research"]);
+    ).toEqual(["Back", "Me", "Ada", "Research"]);
     select(menu, "assign-owner:human:profile-ada");
     expect(onAction).toHaveBeenCalledWith({
       kind: "assign-owner",

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -454,7 +454,7 @@ describe("chat header session menu", () => {
     expect(splitRight).toHaveBeenCalledOnce();
   });
 
-  it("offers direct and submenu owner assignment", async () => {
+  it("offers self and named owner assignment in one submenu", async () => {
     const onAction = vi.fn<(action: HeaderMenuAction) => void>();
     const ada = { type: "human", id: "profile-ada", label: "Ada" } as const;
     const research = { type: "agent", id: "research:one", label: "Research" } as const;
@@ -465,11 +465,15 @@ describe("chat header session menu", () => {
       onAction,
     });
 
-    expect(item(menu, "Assign to me").disabled).toBe(false);
     const submenu = item(menu, "Assign to…");
     expect(
+      Array.from(menu.querySelectorAll<MenuItemElement>(":scope > wa-dropdown > wa-dropdown-item"))
+        .map(itemLabel)
+        .filter((label) => label.startsWith("Assign to")),
+    ).toEqual(["Assign to…"]);
+    expect(
       Array.from(submenu.querySelectorAll("wa-dropdown-item[slot='submenu']")).map(itemLabel),
-    ).toEqual(["Ada", "Research"]);
+    ).toEqual(["Assign to me", "Ada", "Research"]);
     const selected = item(menu, "Research");
     expect(selected.getAttribute("role")).toBe("menuitemradio");
     expect(selected.getAttribute("aria-checked")).toBe("true");
@@ -615,7 +619,7 @@ describe("chat header session menu", () => {
       Array.from(
         menu.querySelectorAll<MenuItemElement>(":scope > wa-dropdown > wa-dropdown-item"),
       ).map(itemLabel),
-    ).toEqual(["Back", "Ada", "Research"]);
+    ).toEqual(["Back", "Assign to me", "Ada", "Research"]);
     select(menu, "assign-owner:human:profile-ada");
     expect(onAction).toHaveBeenCalledWith({
       kind: "assign-owner",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2692,6 +2692,11 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   color: var(--muted);
 }
 
+.session-menu__icon .viewer-avatar {
+  width: 14px;
+  height: 14px;
+}
+
 .session-menu__icon svg,
 .session-menu__check svg {
   width: 14px;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2808,6 +2808,11 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   padding: 2px;
 }
 
+.session-menu__colors + .session-menu__icon-picker,
+.session-menu__icon-grid + .session-menu__icon-section-label {
+  margin-top: var(--space-1);
+}
+
 .session-menu__icon-options {
   display: flex;
   flex-direction: column;

--- a/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
@@ -211,7 +211,7 @@ describe("AppSidebar session mutation feedback", () => {
       Array.from(
         assignmentMenu?.querySelectorAll<HTMLElement>('wa-dropdown-item[slot="submenu"]') ?? [],
       ).map((item) => item.querySelector(".session-menu__text")?.textContent?.trim()),
-    ).toEqual(["Me", "Ada", "Bob"]);
+    ).toEqual(["Me", "Bob"]);
     menu.querySelector("wa-dropdown")?.dispatchEvent(
       new CustomEvent("wa-select", {
         bubbles: true,

--- a/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
@@ -197,8 +197,21 @@ describe("AppSidebar session mutation feedback", () => {
     await sidebar.updateComplete;
 
     const menu = await openSessionMenu(sidebar, row.key);
-    expect(menu.textContent).toContain("Assign to me");
-    expect(menu.textContent).toContain("Assign to…");
+    expect(
+      Array.from(menu.querySelectorAll<HTMLElement>(":scope > wa-dropdown > wa-dropdown-item"))
+        .map((item) => item.querySelector(".session-menu__text")?.textContent?.trim())
+        .filter((label) => label?.startsWith("Assign to")),
+    ).toEqual(["Assign to…"]);
+    const assignmentMenu = Array.from(
+      menu.querySelectorAll<HTMLElement>(":scope > wa-dropdown > wa-dropdown-item"),
+    ).find(
+      (item) => item.querySelector(".session-menu__text")?.textContent?.trim() === "Assign to…",
+    );
+    expect(
+      Array.from(
+        assignmentMenu?.querySelectorAll<HTMLElement>('wa-dropdown-item[slot="submenu"]') ?? [],
+      ).map((item) => item.querySelector(".session-menu__text")?.textContent?.trim()),
+    ).toEqual(["Assign to me", "Ada", "Bob"]);
     menu.querySelector("wa-dropdown")?.dispatchEvent(
       new CustomEvent("wa-select", {
         bubbles: true,
@@ -222,7 +235,7 @@ describe("AppSidebar session mutation feedback", () => {
 
     const selfMenu = await openSessionMenu(sidebar, row.key);
     const selfItem = selfMenu.querySelector<HTMLElement>(
-      ':scope > wa-dropdown > wa-dropdown-item[value="assign-owner:human:profile-ada"]',
+      ':scope > wa-dropdown > wa-dropdown-item wa-dropdown-item[slot="submenu"][value="assign-owner:human:profile-ada"]',
     );
     selfMenu.querySelector("wa-dropdown")?.dispatchEvent(
       new CustomEvent("wa-select", {

--- a/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
@@ -211,7 +211,7 @@ describe("AppSidebar session mutation feedback", () => {
       Array.from(
         assignmentMenu?.querySelectorAll<HTMLElement>('wa-dropdown-item[slot="submenu"]') ?? [],
       ).map((item) => item.querySelector(".session-menu__text")?.textContent?.trim()),
-    ).toEqual(["Assign to me", "Ada", "Bob"]);
+    ).toEqual(["Me", "Ada", "Bob"]);
     menu.querySelector("wa-dropdown")?.dispatchEvent(
       new CustomEvent("wa-select", {
         bubbles: true,


### PR DESCRIPTION
Closes #135506

## What Problem This Solves

Fixes an issue where session context menus exposed adjacent "Assign to me" and "Assign to…" actions for one ownership workflow. The "Icon & color" submenu also grouped "Reset to default" directly with the icon grid and left the Color, Emoji, and Icons sections visually crowded.

When a session was already assigned to the current user, the consolidated submenu could render both "Me" and that user's name as selected targets for the same owner. Owner avatars in this submenu also inherited an 18px height inside a 14px icon rail, compressing them horizontally into ovals.

## Why This Change Was Made

Session ownership now uses one existing submenu, with "Me" as its first target followed by the available owner names. The matching self entry is removed from the remaining owner list by its canonical type and ID, so one owner has one target and one selected state. Assignment dispatch is unchanged.

The existing owner avatar component and menu icon structure remain in place. Menu-hosted viewer avatars now use the icon rail's 14x14 square, matching the circular geometry used by the same avatar component in sidebar and owner-list surfaces. This geometry issue was pre-existing on `main`; the shared submenu structure already placed an 18px avatar inside the 14px rail before this PR.

The appearance picker uses the standard menu separator before its reset action and the existing smallest spacing token between Color, Emoji, and Icons. Desktop and compact menus continue through the same canonical assignment and appearance paths.

There was no existing self-assignment letter shortcut to preserve. Standard submenu arrow, Enter, and Escape navigation remains intact.

Production LOC: +65/-56 (net +9). The additions are the canonical self-target filter, approved token-based spacing, and menu-local square avatar constraint; assignment consolidation otherwise removes duplicate rendering. Tests: +185/-25. Tooling fixture: +1/-0.

## User Impact

Session context menus are shorter and present ownership as one coherent list of targets. Users can assign a session to themselves through "Me" or choose another owner by mouse or keyboard. A self-owned session shows exactly one selected target, and people avatars remain circular. The appearance submenu has clearer, restrained grouping between its sections and reset action.

## Evidence

The full-surface captures use the same mocked session surface, 1440x900 viewport, light theme, browser, and menu path. Avatar close-ups use that same state at 2x device scale.

### Assignment Actions

Before consolidation: two adjacent root actions.

![Session menu with separate Assign to me and Assign to entries](https://github.com/user-attachments/assets/895d3ce6-cfe0-456c-9c91-a2d67dfb0ff9)

Before self-target repair: a self-owned session marks both "Me" and the user's name.

![Self-owned session with duplicate selected assignment targets](https://github.com/user-attachments/assets/d5f1d38c-54fd-4826-ada4-e4cc991356b1)

After: one submenu, "Me" first and selected exactly once, with the duplicate self name removed.

![Single Assign to submenu with one selected Me target](https://github.com/user-attachments/assets/f3db7aad-55c2-4cd0-899e-d397a7dedadd)

### Avatar Geometry

Before: the 18px-tall avatar is compressed by the 14px menu icon rail, producing an oval.

![Assignment submenu with vertically stretched owner avatars](https://github.com/user-attachments/assets/2b9506fd-5232-42fd-b4fc-66f8f32d3818)

After: each menu avatar resolves to a 14x14 square and remains circular.

![Assignment submenu with circular owner avatars](https://github.com/user-attachments/assets/f9fae6ba-a1af-4516-9217-6909aa61c632)

### Appearance Grouping

Before: no extra section spacing, and "Reset to default" touches the icon grid.

![Icon and color submenu before spacing and reset grouping](https://github.com/user-attachments/assets/f2b0f0e9-4076-44e8-83ad-a158bfb42fd1)

After: subtle token-based spacing separates Color, Emoji, and Icons, and the standard separator groups the reset action.

![Icon and color submenu with section spacing and reset separator](https://github.com/user-attachments/assets/c95dd649-b448-49d6-b9eb-1048b9f2f5ad)

### Shared Consumers Checked

- Sidebar session menu: owner list, self owner, current owner, access gating, assignment dispatch, and circular submenu avatars remain connected; component integration and browser coverage passed.
- Chat header session menu: shared owner state, canonical self filtering, ordering, dispatch, and circular submenu avatars remain connected; component coverage passed.
- Compact session menu: the same canonical owner options, avatar geometry, and appearance picker remain available through drill-down navigation; compact ordering and appearance browser coverage passed.
- Sessions page row menu: the shared appearance picker and reset dispatch remain connected. Its existing host does not supply owner options, so no assignment surface was added there; shared picker coverage passed.

### Rebased Main CI Repair

- Rebased `main` exposed an existing mock inconsistency: the avatar-origin E2E required a synthetic self-avatar request, while the mock presence producer supplied no avatar URL.
- The self-presence fixture now records its relative preview avatar URL directly; the strict E2E passed and continues to reject external or operator-Gateway requests.

### Validation

- The self-owner regression failed before the repair with two selected items, then passed with exactly one selected "Me" item.
- Focused component coverage: 387 passed.
- Focused assignment browser coverage: 5 passed; full focused browser coverage before the final geometry-only fix: 11 passed.
- Browser geometry proof verifies every named owner avatar has equal physical width and height with a 14x14 CSS box.
- Changed formatting, type, lint, and repository guards passed.
- English locale baseline verification passed with no generated output change.
- Browser coverage verifies one root assignment action, canonical self filtering, "Me" ordering, named and self assignment, arrow/Enter/Escape navigation, circular avatars, 4px token-based section spacing, and the reset separator.
