### PR TITLE
fix: session group rename briefly shows duplicate groups

### DIFF
--- a/ui/src/e2e/session-management.group-rename-atomic.e2e.test.ts
+++ b/ui/src/e2e/session-management.group-rename-atomic.e2e.test.ts
@@ -1,0 +1,84 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
+import {
+  activateSelfRemovingControl,
+  captureUiProof,
+  captureUiProofEnabled,
+  controlUiSessionUrl,
+  createSessionManagementE2eSuite,
+  installMockGateway,
+  sessionsListResponse,
+  submitInputDialog,
+} from "./session-management.test-support.ts";
+
+const suite = createSessionManagementE2eSuite();
+
+suite.define(() => {
+  it("renames a populated group as one visible transition", async () => {
+    const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      recordVideo: captureUiProofEnabled
+        ? { dir: suite.artifactDir, size: { height: 900, width: 1280 } }
+        : undefined,
+    });
+    const page = await context.newPage();
+    const proofVideo = page.video();
+    const gateway = await installMockGateway(page, {
+      featureMethods: [
+        "chat.metadata",
+        "chat.startup",
+        "sessions.groups.list",
+        "sessions.groups.rename",
+      ],
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:paper", "Paper", baseTime, { category: "Research" }),
+        ]),
+      },
+      sessionGroups: ["Research"],
+      sessionKey: "agent:main:paper",
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:paper"));
+      const research = page.locator('[data-session-section="category:Research"]');
+      await research.waitFor({ state: "visible", timeout: 10_000 });
+      await expect.poll(() => research.locator(".sidebar-recent-session").count()).toBe(1);
+
+      const listRequestsBeforeRename = (await gateway.getRequests("sessions.list")).length;
+      await gateway.deferNext("sessions.list");
+      await research.locator(".sidebar-recent-sessions__head").hover();
+      await research.getByRole("button", { name: "Group options for Research" }).click();
+      await activateSelfRemovingControl(page.getByRole("menuitem", { name: "Rename group…" }));
+      await submitInputDialog(page, "Projects");
+      await gateway.waitForRequest("sessions.groups.rename");
+      await gateway.waitForRequest("sessions.list", { after: listRequestsBeforeRename });
+
+      if (captureUiProofEnabled) {
+        await captureUiProof(suite, page, "group-rename-pending-refresh.png");
+        await page.waitForTimeout(1_500);
+      }
+      expect(
+        await page
+          .locator('[data-session-section^="category:"]')
+          .evaluateAll((elements) =>
+            elements.map((element) => element.getAttribute("data-session-section")),
+          ),
+      ).toEqual(["category:Projects"]);
+      const projects = page.locator('[data-session-section="category:Projects"]');
+      await expect.poll(() => projects.locator(".sidebar-recent-session").count()).toBe(1);
+
+      await gateway.resolveDeferred("sessions.list");
+      await expect.poll(() => projects.locator(".sidebar-recent-session").count()).toBe(1);
+    } finally {
+      await context.close();
+      if (captureUiProofEnabled && proofVideo) {
+        await proofVideo.saveAs(path.join(suite.artifactDir, "group-rename-atomic.webm"));
+      }
+    }
+  });
+});

--- a/ui/src/lib/sessions/session-group-catalog.ts
+++ b/ui/src/lib/sessions/session-group-catalog.ts
@@ -26,6 +26,21 @@ type SessionGroupCatalogHost = {
   retryDelayMs: (error: unknown) => number | null;
 };
 
+function renameSessionGroupMembers(state: SessionState, from: string, to: string): SessionState {
+  if (!state.result) {
+    return state;
+  }
+  let changed = false;
+  const sessions = state.result.sessions.map((row) => {
+    if (row.category !== from) {
+      return row;
+    }
+    changed = true;
+    return { ...row, category: to };
+  });
+  return changed ? { ...state, result: { ...state.result, sessions } } : state;
+}
+
 const LEGACY_GROUPS_STORAGE_KEY = "openclaw:sessions:custom-groups";
 const GROUPS_LIST_METHOD = "sessions.groups.list";
 const GROUPS_DEFAULTS_METHOD = "sessions.groups.defaults";
@@ -88,8 +103,8 @@ export function createSessionGroupCatalog(host: SessionGroupCatalogHost) {
     groupSettings: readonly SessionGroupSettings[],
     sectionOrder: readonly string[],
     status: SessionGroupDefaultsStatus,
+    state: SessionState = host.readState(),
   ) => {
-    const state = host.readState();
     const groups = groupSettings.map((group) => group.name);
     const groupsUnchanged =
       groups.length === state.groups.length &&
@@ -255,11 +270,13 @@ export function createSessionGroupCatalog(host: SessionGroupCatalogHost) {
   const publishPathFreeMutation = (
     groupSettings: readonly SessionGroupSettings[],
     sectionOrder: readonly string[],
+    transformState?: (state: SessionState) => SessionState,
   ) => {
     // Catalog mutations do not carry authoritative defaults. Retire any older
     // defaults read and keep group routes blocked until a fresh read completes.
     invalidate();
-    publishCatalog(groupSettings, sectionOrder, "loading");
+    const state = host.readState();
+    publishCatalog(groupSettings, sectionOrder, "loading", transformState?.(state) ?? state);
     void load();
   };
 
@@ -309,8 +326,11 @@ export function createSessionGroupCatalog(host: SessionGroupCatalogHost) {
       publishPathFreeMutation(
         mergeSessionGroupDefaults(readSessionCustomGroups(result), { defaults: renamedDefaults }),
         readSidebarSectionOrder(result),
+        // The catalog and the rows that populate it are one visible snapshot.
+        // The canonical refresh below verifies this local projection afterward.
+        (state) => renameSessionGroupMembers(state, from, to),
       );
-      // Mutation response commits before a background member-row reconciliation.
+      // The Gateway response confirms the rename before this canonical reconciliation.
       void host.refreshRows();
       return "completed";
     } catch (error) {

--- a/ui/src/lib/sessions/session-group-rename.test.ts
+++ b/ui/src/lib/sessions/session-group-rename.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+import { expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionsListResult } from "../../api/types.ts";
+import { createSessionCapability } from "./index.ts";
+import { createGatewayHarness, sessionsResult } from "./session-capability.test-support.ts";
+
+it("publishes renamed group members atomically while the canonical refresh is pending", async () => {
+  const refreshed = createDeferred<SessionsListResult>();
+  let groupListCalls = 0;
+  let listCalls = 0;
+  const request = vi.fn(async (method: string) => {
+    if (method === "sessions.groups.list") {
+      groupListCalls += 1;
+      return { groups: [{ name: groupListCalls === 1 ? "Alpha" : "Beta" }] };
+    }
+    if (method === "sessions.groups.rename") {
+      return { groups: [{ name: "Beta" }] };
+    }
+    if (method === "sessions.list") {
+      listCalls += 1;
+      return listCalls === 1
+        ? sessionsResult(
+            [
+              {
+                key: "agent:main:grouped",
+                kind: "direct",
+                sessionId: "grouped-session",
+                updatedAt: 1,
+                category: "Alpha",
+              },
+            ],
+            1,
+          )
+        : await refreshed.promise;
+    }
+    throw new Error(`Unexpected request: ${method}`);
+  });
+  const client = { request } as unknown as GatewayBrowserClient;
+  const { gateway } = createGatewayHarness(client, [
+    "sessions.groups.list",
+    "sessions.groups.rename",
+  ]);
+  const sessions = createSessionCapability(gateway);
+
+  await sessions.refresh({ force: true });
+  await sessions.groupsLoad();
+  await expect(sessions.groupsRename("Alpha", "Beta")).resolves.toBe("completed");
+
+  expect(sessions.state.groups).toEqual(["Beta"]);
+  expect(sessions.state.result?.sessions).toEqual([
+    expect.objectContaining({ key: "agent:main:grouped", category: "Beta" }),
+  ]);
+
+  refreshed.resolve(
+    sessionsResult(
+      [
+        {
+          key: "agent:main:grouped",
+          kind: "direct",
+          sessionId: "grouped-session",
+          updatedAt: 1,
+          category: "Beta",
+        },
+      ],
+      2,
+    ),
+  );
+  sessions.dispose();
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where renaming a populated session group briefly created an empty group with the new name while the existing sessions remained under the old name.

## Why This Change Was Made

The rename mutation published the group catalog before the subsequent `sessions.list` refresh published the renamed member rows. The confirmed rename now projects the new category onto locally known member rows in the same state publication; the background canonical refresh remains as reconciliation.

## User Impact

Renaming a session group is now one visible transition: the original group disappears and its sessions immediately appear under the new name, without a transient duplicate or empty group.

## Evidence

The browser regression deliberately holds the post-rename canonical `sessions.list` refresh so it captures the exact race window.

| Before: split catalog/member state | After: atomic rename |
| --- | --- |
| [![Before: empty Projects and populated Research](https://cdn.jsdelivr.net/gh/Patrick-Erichsen/openclaw@9984479b80fc1303f28f0e3c6fb203c5fe17a585/pr-proof/session-group-rename/before.png)](https://cdn.jsdelivr.net/gh/Patrick-Erichsen/openclaw@9984479b80fc1303f28f0e3c6fb203c5fe17a585/pr-proof/session-group-rename/before.mp4) | [![After: populated Projects only](https://cdn.jsdelivr.net/gh/Patrick-Erichsen/openclaw@9984479b80fc1303f28f0e3c6fb203c5fe17a585/pr-proof/session-group-rename/after.png)](https://cdn.jsdelivr.net/gh/Patrick-Erichsen/openclaw@9984479b80fc1303f28f0e3c6fb203c5fe17a585/pr-proof/session-group-rename/after.mp4) |
| [Watch before recording](https://cdn.jsdelivr.net/gh/Patrick-Erichsen/openclaw@9984479b80fc1303f28f0e3c6fb203c5fe17a585/pr-proof/session-group-rename/before.mp4) | [Watch after recording](https://cdn.jsdelivr.net/gh/Patrick-Erichsen/openclaw@9984479b80fc1303f28f0e3c6fb203c5fe17a585/pr-proof/session-group-rename/after.mp4) |

Validation on current `origin/main`:

- `pnpm exec vitest run ui/src/lib/sessions/session-group-rename.test.ts` — 1 passed
- `OPENCLAW_CAPTURE_UI_PROOF=1 pnpm test:ui:e2e ui/src/e2e/session-management.group-rename-atomic.e2e.test.ts` — 1 passed
- `pnpm check:changed` — passed

## Worked on by

No additional credited participants.
