### PR TITLE
refactor(config): unify audit append path

### DIFF
--- a/src/config/io.audit.test.ts
+++ b/src/config/io.audit.test.ts
@@ -225,7 +225,7 @@ describe("config io audit helpers", () => {
     const home = await suiteRootTracker.make("append");
     const record = createRenameAuditRecord(home);
 
-    await appendConfigAuditRecord({
+    const appendPromise = appendConfigAuditRecord({
       env: {} as NodeJS.ProcessEnv,
       homedir: () => home,
       record,
@@ -240,6 +240,7 @@ describe("config io audit helpers", () => {
     expect(written.event).toBe("config.write");
     expect(written.result).toBe("rename");
     expect(written.nextHash).toBe("next-hash");
+    await expect(appendPromise).resolves.toBeUndefined();
   });
 
   it("reads a bounded newest-first audit window for Doctor provenance", async () => {

--- a/src/config/io.audit.ts
+++ b/src/config/io.audit.ts
@@ -687,16 +687,7 @@ export function sanitizeConfigAuditRecord(record: ConfigAuditRecord): ConfigAudi
 }
 
 export async function appendConfigAuditRecord(params: ConfigAuditAppendParams): Promise<void> {
-  try {
-    const record = sanitizeConfigAuditRecord(resolveConfigAuditAppendRecord(params));
-    openConfigAuditStore(resolveConfigAuditStoreEnv(params)).register(
-      configAuditEntryKey(record),
-      record,
-      Date.parse(record.ts),
-    );
-  } catch {
-    // best-effort
-  }
+  appendConfigAuditRecordSync(params);
 }
 
 export function appendConfigAuditRecordSync(params: ConfigAuditAppendParams): void {


### PR DESCRIPTION
## What Problem This Solves

Config audit appends had two byte-equivalent implementations for the async and synchronous entry points. Since both now write through the same synchronous SQLite store, keeping two copies created drift risk around sanitization, key generation, registration, and best-effort error handling.

## Why This Change Was Made

The synchronous append function is the canonical owner. The async API retains its existing `Promise<void>` signature and delegates directly to `appendConfigAuditRecordSync(params)`.

This preserves the same-turn timing contract: async function bodies execute synchronously until they return, so sanitization, UUID generation, serialization, registration, pruning, transaction commit, and permission hardening still complete before the promise is returned. The existing SQLite append test now reads and validates the persisted row before awaiting that promise, then verifies the promise resolves to `undefined`.

The async and sync implementations were originally distinct file-backed paths. Commit `9d97e10efe08` moved both onto the same synchronous SQLite owner, leaving the duplicate append body behind.

## User Impact

No user-visible behavior change. Config audit persistence now has one canonical append implementation while preserving both public call shapes and their existing ordering.

No SQLite schema, table, row shape, transaction, retention, locking, recovery, configuration, or persistence semantics changed.

## Evidence

- Signed head: `669fc0ceec529df0d572d97cbffe4fdacc6393b4`
- Parent: `75bcd267f5e72086fa5361e263b0f6cb1248adc6`
- Production LOC: `+1/-10` (net `-9`)
- Tests: `+2/-1` (net `+1`)
- Focused Vitest: 4 files, 436 tests passed
  - `src/config/io.audit.test.ts`
  - `src/config/io.observe-recovery.test.ts`
  - `src/config/io.write-config.test.ts`
  - `src/gateway/config-reload.test.ts`
- Targeted `oxfmt`, type-aware `oxlint`, `git diff --check`, core typecheck, import-cycle guard, native-state schema guard, database-first guard, media-download helper guard, runtime-sidecar guard, webhook/auth guards: passed
- Changed-file dry run: `core, coreTests`
- Changed-file gate: all reached gates passed; its dead-export step initially lacked sparse-checkout UI config, then passed all three scans after adding that checkout-only path
- Full core-test type shard was not rerun to completion because the shared install lacks the existing `mermaid@11.17.1` dependency and this worktree intentionally performed no install. The focused runtime suites and targeted type-aware lint passed.
- Sol-high autoreview: scoped clean, 0.99
- Rebase preserved the patch byte-for-byte by stable patch ID
- Current-main target comparison: no changes in either touched file
- Open PR overlap search: no matching active PR
- Codex source inspected: `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; unrelated CLI parsing/completion paths
