### PR TITLE
refactor(cli): remove redundant rich-output gates

### DIFF
--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -22,7 +22,7 @@ import {
   getTerminalTableWidth,
   renderTerminalSafeTable,
 } from "../../packages/terminal-core/src/table.js";
-import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
+import { theme } from "../../packages/terminal-core/src/theme.js";
 import { resolveConfiguredAgentId } from "../agents/agent-scope-config.js";
 import { readBestEffortConfig, type OpenClawConfig } from "../config/config.js";
 import { ADMIN_SCOPE, APPROVALS_SCOPE, type OperatorScope } from "../gateway/method-scopes.js";
@@ -891,16 +891,13 @@ function buildEffectivePolicyReport(params: {
 }
 
 function renderEffectivePolicy(params: { report: EffectivePolicyReport }) {
-  const rich = isRich();
-  const heading = (text: string) => (rich ? theme.heading(text) : text);
-  const muted = (text: string) => (rich ? theme.muted(text) : text);
   if (params.report.scopes.length === 0 && !params.report.note) {
     return;
   }
   defaultRuntime.log("");
-  defaultRuntime.log(heading("Effective Policy"));
+  defaultRuntime.log(theme.heading("Effective Policy"));
   if (params.report.scopes.length === 0) {
-    defaultRuntime.log(muted(params.report.note ?? "No effective policy details available."));
+    defaultRuntime.log(theme.muted(params.report.note ?? "No effective policy details available."));
     return;
   }
   const rows = params.report.scopes.map((summary) => ({
@@ -924,7 +921,7 @@ function renderEffectivePolicy(params: { report: EffectivePolicyReport }) {
     }).trimEnd(),
   );
   defaultRuntime.log("");
-  defaultRuntime.log(muted(`Precedence: ${params.report.note}`));
+  defaultRuntime.log(theme.muted(`Precedence: ${params.report.note}`));
 }
 
 function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: string) {
@@ -932,9 +929,6 @@ function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: s
     renderNativeApprovalsSnapshot(snapshot, targetLabel);
     return;
   }
-  const rich = isRich();
-  const heading = (text: string) => (rich ? theme.heading(text) : text);
-  const muted = (text: string) => (rich ? theme.muted(text) : text);
   const tableWidth = getTerminalTableWidth();
 
   const file = snapshot.file ?? { version: 1 };
@@ -963,7 +957,9 @@ function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: s
         Target: targetLabel,
         Agent: agentId,
         Pattern: pattern,
-        LastUsed: lastUsedAt ? formatTimeAgo(Math.max(0, now - lastUsedAt)) : muted("unknown"),
+        LastUsed: lastUsedAt
+          ? formatTimeAgo(Math.max(0, now - lastUsedAt))
+          : theme.muted("unknown"),
       });
     }
   }
@@ -983,7 +979,7 @@ function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: s
     { Field: "Allowlist", Value: String(allowlistRows.length) },
   ];
 
-  defaultRuntime.log(heading("Approvals"));
+  defaultRuntime.log(theme.heading("Approvals"));
   defaultRuntime.log(
     renderTerminalSafeTable({
       width: tableWidth,
@@ -997,12 +993,12 @@ function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: s
 
   if (allowlistRows.length === 0) {
     defaultRuntime.log("");
-    defaultRuntime.log(muted("No allowlist entries."));
+    defaultRuntime.log(theme.muted("No allowlist entries."));
     return;
   }
 
   defaultRuntime.log("");
-  defaultRuntime.log(heading("Allowlist"));
+  defaultRuntime.log(theme.heading("Allowlist"));
   defaultRuntime.log(
     renderTerminalSafeTable({
       width: tableWidth,
@@ -1018,9 +1014,6 @@ function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: s
 }
 
 function renderNativeApprovalsSnapshot(snapshot: NativeExecApprovalsSnapshot, targetLabel: string) {
-  const rich = isRich();
-  const heading = (text: string) => (rich ? theme.heading(text) : text);
-  const muted = (text: string) => (rich ? theme.muted(text) : text);
   const rules = snapshot.enabled ? snapshot.rules : [];
   const summaryRows = [
     { Field: "Target", Value: targetLabel },
@@ -1033,7 +1026,7 @@ function renderNativeApprovalsSnapshot(snapshot: NativeExecApprovalsSnapshot, ta
     },
     { Field: "Rules", Value: String(rules.length) },
   ];
-  defaultRuntime.log(heading("Approvals"));
+  defaultRuntime.log(theme.heading("Approvals"));
   defaultRuntime.log(
     renderTerminalSafeTable({
       width: getTerminalTableWidth(),
@@ -1046,11 +1039,11 @@ function renderNativeApprovalsSnapshot(snapshot: NativeExecApprovalsSnapshot, ta
   );
   if (rules.length === 0) {
     defaultRuntime.log("");
-    defaultRuntime.log(muted("No host-native rules."));
+    defaultRuntime.log(theme.muted("No host-native rules."));
     return;
   }
   defaultRuntime.log("");
-  defaultRuntime.log(heading("Rules"));
+  defaultRuntime.log(theme.heading("Rules"));
   defaultRuntime.log(
     renderTerminalSafeTable({
       width: getTerminalTableWidth(),
@@ -1321,9 +1314,8 @@ export function registerExecApprovalsCli(program: Command) {
           return;
         }
 
-        const muted = (text: string) => (isRich() ? theme.muted(text) : text);
         if (source === "local") {
-          defaultRuntime.log(muted("Showing local approvals."));
+          defaultRuntime.log(theme.muted("Showing local approvals."));
           defaultRuntime.log("");
         }
         const targetLabel = source === "local" ? "local" : nodeId ? `node:${nodeId}` : "gateway";

--- a/src/cli/exec-policy-cli.ts
+++ b/src/cli/exec-policy-cli.ts
@@ -3,7 +3,7 @@ import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
-import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
+import { theme } from "../../packages/terminal-core/src/theme.js";
 import { readConfigFileSnapshot, replaceConfigFile } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { sanitizeExecApprovalDisplayText } from "../infra/exec-approval-text-sanitize.js";
@@ -327,10 +327,7 @@ function buildExecPolicyShowScope(snapshot: ExecPolicyScopeSnapshot): ExecPolicy
 }
 
 function renderExecPolicyShow(payload: ExecPolicyShowPayload): void {
-  const rich = isRich();
-  const heading = (text: string) => (rich ? theme.heading(text) : text);
-  const muted = (text: string) => (rich ? theme.muted(text) : text);
-  defaultRuntime.log(heading("Exec Policy"));
+  defaultRuntime.log(theme.heading("Exec Policy"));
   defaultRuntime.log(
     renderTable({
       width: getTerminalTableWidth(),
@@ -351,7 +348,7 @@ function renderExecPolicyShow(payload: ExecPolicyShowPayload): void {
     }).trimEnd(),
   );
   defaultRuntime.log("");
-  defaultRuntime.log(heading("Effective Policy"));
+  defaultRuntime.log(theme.heading("Effective Policy"));
   defaultRuntime.log(
     renderTable({
       width: getTerminalTableWidth(),
@@ -380,7 +377,7 @@ function renderExecPolicyShow(payload: ExecPolicyShowPayload): void {
     }).trimEnd(),
   );
   defaultRuntime.log("");
-  defaultRuntime.log(muted(payload.effectivePolicy.note));
+  defaultRuntime.log(theme.muted(payload.effectivePolicy.note));
 }
 
 async function applyLocalExecPolicy(policy: ExecPolicyResolved): Promise<ExecPolicyShowPayload> {

--- a/src/cli/security-cli.ts
+++ b/src/cli/security-cli.ts
@@ -5,7 +5,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
-import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
+import { theme } from "../../packages/terminal-core/src/theme.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { GatewayAuthMode } from "../config/types.gateway.js";
 import { defaultRuntime } from "../runtime.js";
@@ -62,14 +62,13 @@ function buildAuditGatewayAuthOverride(params: {
 }
 
 function formatSummary(summary: { critical: number; warn: number; info: number }): string {
-  const rich = isRich();
   const c = summary.critical;
   const w = summary.warn;
   const i = summary.info;
   const parts: string[] = [];
-  parts.push(rich ? theme.error(`${c} critical`) : `${c} critical`);
-  parts.push(rich ? theme.warn(`${w} warn`) : `${w} warn`);
-  parts.push(rich ? theme.muted(`${i} info`) : `${i} info`);
+  parts.push(theme.error(`${c} critical`));
+  parts.push(theme.warn(`${w} warn`));
+  parts.push(theme.muted(`${i} info`));
   return parts.join(" · ");
 }
 
@@ -158,65 +157,65 @@ export function registerSecurityCli(program: Command) {
         return;
       }
 
-      const rich = isRich();
-      const heading = (text: string) => (rich ? theme.heading(text) : text);
-      const muted = (text: string) => (rich ? theme.muted(text) : text);
-
       const lines: string[] = [];
-      lines.push(heading("OpenClaw security audit"));
-      lines.push(muted(`Summary: ${formatSummary(report.summary)}`));
+      lines.push(theme.heading("OpenClaw security audit"));
+      lines.push(theme.muted(`Summary: ${formatSummary(report.summary)}`));
       if ((report.suppressedFindings?.length ?? 0) > 0) {
-        lines.push(muted(`Suppressed: ${report.suppressedFindings?.length ?? 0} configured`));
+        lines.push(theme.muted(`Suppressed: ${report.suppressedFindings?.length ?? 0} configured`));
       }
-      lines.push(muted(`Run deeper: ${formatCliCommand("openclaw security audit --deep")}`));
+      lines.push(theme.muted(`Run deeper: ${formatCliCommand("openclaw security audit --deep")}`));
       for (const diagnostic of secretDiagnostics) {
-        lines.push(muted(`[secrets] ${diagnostic}`));
+        lines.push(theme.muted(`[secrets] ${diagnostic}`));
       }
 
       if (opts.fix) {
-        lines.push(muted(`Fix: ${formatCliCommand("openclaw security audit --fix")}`));
+        lines.push(theme.muted(`Fix: ${formatCliCommand("openclaw security audit --fix")}`));
         if (!fixResult) {
-          lines.push(muted("Fixes: failed to apply (unexpected error)"));
+          lines.push(theme.muted("Fixes: failed to apply (unexpected error)"));
         } else if (
           fixResult.errors.length === 0 &&
           fixResult.changes.length === 0 &&
           fixResult.actions.every((a) => !a.ok)
         ) {
-          lines.push(muted("Fixes: no changes applied"));
+          lines.push(theme.muted("Fixes: no changes applied"));
         } else {
           lines.push("");
-          lines.push(heading("FIX"));
+          lines.push(theme.heading("FIX"));
           for (const change of fixResult.changes) {
-            lines.push(muted(`  ${shortenHomeInString(change)}`));
+            lines.push(theme.muted(`  ${shortenHomeInString(change)}`));
           }
           for (const action of fixResult.actions) {
             if (action.kind === "chmod") {
               const mode = action.mode.toString(8).padStart(3, "0");
               if (action.ok) {
-                lines.push(muted(`  chmod ${mode} ${shortenHomePath(action.path)}`));
+                lines.push(theme.muted(`  chmod ${mode} ${shortenHomePath(action.path)}`));
               } else if (action.skipped) {
                 lines.push(
-                  muted(`  skip chmod ${mode} ${shortenHomePath(action.path)} (${action.skipped})`),
+                  theme.muted(
+                    `  skip chmod ${mode} ${shortenHomePath(action.path)} (${action.skipped})`,
+                  ),
                 );
               } else if (action.error) {
                 lines.push(
-                  muted(`  chmod ${mode} ${shortenHomePath(action.path)} failed: ${action.error}`),
+                  theme.muted(
+                    `  chmod ${mode} ${shortenHomePath(action.path)} failed: ${action.error}`,
+                  ),
                 );
               }
               continue;
             }
             const command = shortenHomeInString(action.command);
             if (action.ok) {
-              lines.push(muted(`  ${command}`));
+              lines.push(theme.muted(`  ${command}`));
             } else if (action.skipped) {
-              lines.push(muted(`  skip ${command} (${action.skipped})`));
+              lines.push(theme.muted(`  skip ${command} (${action.skipped})`));
             } else if (action.error) {
-              lines.push(muted(`  ${command} failed: ${action.error}`));
+              lines.push(theme.muted(`  ${command} failed: ${action.error}`));
             }
           }
           if (fixResult.errors.length > 0) {
             for (const err of fixResult.errors) {
-              lines.push(muted(`  error: ${shortenHomeInString(err)}`));
+              lines.push(theme.muted(`  error: ${shortenHomeInString(err)}`));
             }
           }
         }
@@ -232,23 +231,17 @@ export function registerSecurityCli(program: Command) {
         }
         const label =
           sev === "critical"
-            ? rich
-              ? theme.error("CRITICAL")
-              : "CRITICAL"
+            ? theme.error("CRITICAL")
             : sev === "warn"
-              ? rich
-                ? theme.warn("WARN")
-                : "WARN"
-              : rich
-                ? theme.muted("INFO")
-                : "INFO";
+              ? theme.warn("WARN")
+              : theme.muted("INFO");
         lines.push("");
-        lines.push(heading(label));
+        lines.push(theme.heading(label));
         for (const f of list) {
           lines.push(`${theme.muted(f.checkId)} ${f.title}`);
           lines.push(`  ${f.detail}`);
           if (f.remediation?.trim()) {
-            lines.push(`  ${muted(`Fix: ${f.remediation.trim()}`)}`);
+            lines.push(`  ${theme.muted(`Fix: ${f.remediation.trim()}`)}`);
           }
         }
       };

--- a/src/commands/message-format.ts
+++ b/src/commands/message-format.ts
@@ -1,7 +1,7 @@
 /** Human-readable formatter for `openclaw message` action results. */
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
-import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
+import { theme } from "../../packages/terminal-core/src/theme.js";
 import { getLoadedChannelPlugin } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.public.js";
 import type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
@@ -212,18 +212,12 @@ export function formatMessageCliText(
   result: MessageActionResult,
   opts?: { displayLimit?: number },
 ): string[] {
-  const rich = isRich();
-  const ok = (text: string) => (rich ? theme.success(text) : text);
-  const fail = (text: string) => (rich ? theme.error(text) : text);
-  const muted = (text: string) => (rich ? theme.muted(text) : text);
-  const heading = (text: string) => (rich ? theme.heading(text) : text);
-
   const width = getTerminalTableWidth();
   const displayLimit = opts?.displayLimit;
   const formatOpts: FormatOpts = { width, displayLimit };
 
   if (result.dryRun) {
-    return [muted(`[dry-run] would run ${result.action} via ${result.channel}`)];
+    return [theme.muted(`[dry-run] would run ${result.action} via ${result.channel}`)];
   }
 
   const outcome = resolveMessageActionOutcome(result);
@@ -238,7 +232,7 @@ export function formatMessageCliText(
     const okCount = results.filter((entry) => entry.ok).length;
     const total = results.length;
     const successful = outcome.ok;
-    const headingLine = (successful ? ok : fail)(
+    const headingLine = (successful ? theme.success : theme.error)(
       `${successful ? "✅ Broadcast complete" : "❌ Broadcast failed"} (${okCount}/${total} succeeded, ${total - okCount} failed)`,
     );
     return [
@@ -258,7 +252,7 @@ export function formatMessageCliText(
 
   if (!outcome.ok) {
     const messageId = result.kind === "send" ? result.sendResult?.result?.messageId : undefined;
-    return [fail(`❌ ${outcome.error}${messageId ? ` Message ID: ${messageId}` : ""}`)];
+    return [theme.error(`❌ ${outcome.error}${messageId ? ` Message ID: ${messageId}` : ""}`)];
   }
 
   if (result.kind === "send") {
@@ -266,11 +260,11 @@ export function formatMessageCliText(
       const send = result.sendResult;
       if (send.via === "direct") {
         const directResult = send.result as OutboundDeliveryResult | undefined;
-        return [ok(formatOutboundDeliverySummary(send.channel, directResult))];
+        return [theme.success(formatOutboundDeliverySummary(send.channel, directResult))];
       }
       const gatewayResult = send.result as { messageId?: string } | undefined;
       return [
-        ok(
+        theme.success(
           formatGatewaySummary({
             channel: send.channel,
             messageId: gatewayResult?.messageId ?? null,
@@ -281,7 +275,7 @@ export function formatMessageCliText(
 
     const label = resolveChannelLabel(result.channel);
     const msgId = resolveMessageActionMessageId(result.payload);
-    return [ok(`✅ Sent via ${label}.${msgId ? ` Message ID: ${msgId}` : ""}`)];
+    return [theme.success(`✅ Sent via ${label}.${msgId ? ` Message ID: ${msgId}` : ""}`)];
   }
 
   if (result.kind === "poll") {
@@ -294,19 +288,19 @@ export function formatMessageCliText(
           ? ({ ...poll.result, channel: poll.channel } satisfies OutboundDeliveryResult)
           : undefined;
         const lines = [
-          ok(
+          theme.success(
             formatOutboundDeliverySummary(poll.channel, directResult, {
               action: "Poll sent",
             }),
           ),
         ];
         if (pollId) {
-          lines.push(ok(`Poll id: ${pollId}`));
+          lines.push(theme.success(`Poll id: ${pollId}`));
         }
         return lines;
       }
       const lines = [
-        ok(
+        theme.success(
           formatGatewaySummary({
             action: "Poll sent",
             channel: poll.channel,
@@ -315,14 +309,14 @@ export function formatMessageCliText(
         ),
       ];
       if (pollId) {
-        lines.push(ok(`Poll id: ${pollId}`));
+        lines.push(theme.success(`Poll id: ${pollId}`));
       }
       return lines;
     }
 
     const label = resolveChannelLabel(result.channel);
     const msgId = resolveMessageActionMessageId(result.payload);
-    return [ok(`✅ Poll sent via ${label}.${msgId ? ` Message ID: ${msgId}` : ""}`)];
+    return [theme.success(`✅ Poll sent via ${label}.${msgId ? ` Message ID: ${msgId}` : ""}`)];
   }
 
   // Channel actions share the generic plugin-action payload shape, so format
@@ -334,25 +328,25 @@ export function formatMessageCliText(
     const added = (payload as { added?: unknown }).added;
     const removed = (payload as { removed?: unknown }).removed;
     if (typeof added === "string" && added.trim()) {
-      lines.push(ok(`✅ Reaction added: ${added.trim()}`));
+      lines.push(theme.success(`✅ Reaction added: ${added.trim()}`));
       return lines;
     }
     if (typeof removed === "string" && removed.trim()) {
-      lines.push(ok(`✅ Reaction removed: ${removed.trim()}`));
+      lines.push(theme.success(`✅ Reaction removed: ${removed.trim()}`));
       return lines;
     }
     if (Array.isArray(removed)) {
       const list = normalizeStringEntries(removed).join(", ");
-      lines.push(ok(`✅ Reactions removed${list ? `: ${list}` : ""}`));
+      lines.push(theme.success(`✅ Reactions removed${list ? `: ${list}` : ""}`));
       return lines;
     }
-    lines.push(ok("✅ Reaction updated."));
+    lines.push(theme.success("✅ Reaction updated."));
     return lines;
   }
 
   const reactionsTable = renderReactions(payload, formatOpts);
   if (reactionsTable !== null && result.action === "reactions") {
-    lines.push(heading("Reactions"));
+    lines.push(theme.heading("Reactions"));
     lines.push(reactionsTable);
     return lines;
   }
@@ -365,9 +359,9 @@ export function formatMessageCliText(
         : undefined;
     if (Array.isArray(messages)) {
       const table = renderMessageList(messages, formatOpts, read ? "No messages." : "No pins.");
-      lines.push(heading(read ? "Messages" : "Pinned messages"));
+      lines.push(theme.heading(read ? "Messages" : "Pinned messages"));
       lines.push(table);
-      const hint = renderPaginationHint(payload, muted);
+      const hint = renderPaginationHint(payload, theme.muted);
       if (hint) {
         lines.push(hint);
       }
@@ -379,10 +373,11 @@ export function formatMessageCliText(
     const results = (payload as { results?: unknown }).results;
     const list = extractDiscordSearchResultsMessages(results);
     if (list) {
-      lines.push(heading("Search results"));
+      lines.push(theme.heading("Search results"));
       lines.push(renderMessageList(list, formatOpts, "No results."));
       // Discord's approximate result count cannot prove another page exists.
-      const hint = renderPaginationHint(payload, muted) ?? renderPaginationHint(results, muted);
+      const hint =
+        renderPaginationHint(payload, theme.muted) ?? renderPaginationHint(results, theme.muted);
       if (hint) {
         lines.push(hint);
       }
@@ -391,11 +386,11 @@ export function formatMessageCliText(
   }
 
   // Generic success + compact details table.
-  lines.push(ok(`✅ ${result.action} via ${resolveChannelLabel(result.channel)}.`));
+  lines.push(theme.success(`✅ ${result.action} via ${resolveChannelLabel(result.channel)}.`));
   const summary = renderObjectSummary(payload, formatOpts);
   lines.push("");
   lines.push(summary);
   lines.push("");
-  lines.push(muted("Tip: use --json for full output."));
+  lines.push(theme.muted("Tip: use --json for full output."));
   return lines;
 }

--- a/src/commands/status-all/report-lines.ts
+++ b/src/commands/status-all/report-lines.ts
@@ -3,7 +3,7 @@
 
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getTerminalTableWidth, renderTable } from "../../../packages/terminal-core/src/table.js";
-import { isRich, theme } from "../../../packages/terminal-core/src/theme.js";
+import { theme } from "../../../packages/terminal-core/src/theme.js";
 import type { ProgressReporter } from "../../cli/progress.js";
 import type { BestEffortConfigSnapshot } from "../../config/io.js";
 import { formatStatusConfigDiagnosticEntries } from "../status.format.js";
@@ -64,27 +64,20 @@ export async function buildStatusAllReportLines(params: {
     "lines" | "progress" | "muted" | "ok" | "warn" | "fail" | "connectionDetailsForReport"
   >;
 }) {
-  const rich = isRich();
-  const heading = (text: string) => (rich ? theme.heading(text) : text);
-  const ok = (text: string) => (rich ? theme.success(text) : text);
-  const warn = (text: string) => (rich ? theme.warn(text) : text);
-  const fail = (text: string) => (rich ? theme.error(text) : text);
-  const muted = (text: string) => (rich ? theme.muted(text) : text);
-
   const tableWidth = getTerminalTableWidth();
 
   const lines: string[] = [];
   if (params.configDiagnostics) {
     lines.push(
-      warn("Config diagnostics:"),
+      theme.warn("Config diagnostics:"),
       ...formatStatusConfigDiagnosticEntries(params.configDiagnostics),
       "",
     );
   }
-  lines.push(heading("OpenClaw status --all"));
+  lines.push(theme.heading("OpenClaw status --all"));
   appendStatusReportSections({
     lines,
-    heading,
+    heading: theme.heading,
     width: tableWidth,
     renderTable,
     sections: [
@@ -104,17 +97,17 @@ export async function buildStatusAllReportLines(params: {
         rows: buildStatusChannelsTableRows({
           rows: params.channels.rows,
           channelIssues: params.channelIssues,
-          ok,
-          warn,
-          muted,
+          ok: theme.success,
+          warn: theme.warn,
+          muted: theme.muted,
           accentDim: theme.accentDim,
           formatIssueMessage: (message) => truncateUtf16Safe(message, 90),
         }),
       },
       ...buildStatusChannelDetailSections({
         details: params.channels.details,
-        ok,
-        warn,
+        ok: theme.success,
+        warn: theme.warn,
       }),
       {
         kind: "table",
@@ -122,25 +115,25 @@ export async function buildStatusAllReportLines(params: {
         columns: [...statusAgentsTableColumns],
         rows: buildStatusAgentTableRows({
           agentStatus: params.agentStatus,
-          ok,
-          warn,
+          ok: theme.success,
+          warn: theme.warn,
         }),
       },
     ],
   });
   appendStatusSectionHeading({
     lines,
-    heading,
+    heading: theme.heading,
     title: "Diagnosis (read-only)",
   });
 
   await appendStatusAllDiagnosis({
     lines,
     progress: params.progress,
-    muted,
-    ok,
-    warn,
-    fail,
+    muted: theme.muted,
+    ok: theme.success,
+    warn: theme.warn,
+    fail: theme.error,
     connectionDetailsForReport: params.connectionDetailsForReport,
     ...params.diagnosis,
   });


### PR DESCRIPTION
## What Problem This Solves

Five CLI rendering owners duplicated terminal richness policy with local `isRich()` snapshots and identity wrappers around the shared theme functions. Chalk and `packages/terminal-core/src/theme.ts` already own the level-zero identity contract, so the duplicate gates added drift risk without changing output.

## Why This Change Was Made

Deletes the redundant policy and calls the canonical `theme` functions directly. No helper, API, config, protocol, SDK, or terminal-core surface was added.

Exact scope:

- `src/cli/exec-approvals-cli.ts`: remove local heading/muted wrappers from effective policy, file approvals, native approvals, and local-source output.
- `src/cli/exec-policy-cli.ts`: render show headings and note through `theme` directly.
- `src/cli/security-cli.ts`: render summary, human audit output, fix output, and severity labels through `theme` directly.
- `src/commands/message-format.ts`: use `theme.success`, `theme.error`, `theme.muted`, and `theme.heading` directly, including pagination callbacks.
- `src/commands/status-all/report-lines.ts`: pass canonical theme functions directly to report, table, section, and diagnosis owners.

JSON branches, text and emoji content, tables, terminal sanitization, control flow, and call timing are unchanged.

## User Impact

No user-visible behavior change. Rich terminals keep the same styling; plain and `NO_COLOR` output remains byte-identical.

## Evidence

- Signed head `16b60f05ee7de6dda6cf74d9200242bfbbf41b71`, parent `b49119b44f41b16a4bde85acc5ace2d4969023e6`.
- Judged LOC: production `+88/-118`, net `-30`; tests `0`.
- Focused owner proof: 7 files, 126 tests passed across three Vitest shards (`4 + 89 + 33`), including human output, JSON separation, sanitization, approvals, security, message outcomes, and status report composition.
- Output equivalence: 35 representative cases across each of default, `NO_COLOR=1`, `FORCE_COLOR=0`, `FORCE_COLOR=1`, and `NO_COLOR=1 FORCE_COLOR=1`; all 175 old/new comparisons had identical SHA-256 output. Plain hash: `afde04566d581ca5311350363039c5c53c0f85b9ecee5dc620c5a449e287585c`. Rich hash: `dea2b3b07564f49dcae40ed8fa51d6695c58882c8ddd9fceb46b79a22bf66b24`.
- Local format, focused lint, core typecheck, import-cycle check, and `git diff --check` passed.
- Local changed-file checks passed after materializing sparse-checkout UI config inputs; the initially blocked dead-export lane then reported zero unused exports in all three scans.
- Exact-tree Blacksmith Testbox changed gate passed: lease `tbx_01m1f9ae4ck8reyzy9ak8s9axd`, run https://github.com/openclaw/openclaw/actions/runs/33553435426, command duration 16m38s, exit 0.
- Sol-high autoreview: scoped-clean, correct, confidence 0.98.
- Dependency proof: Chalk 6.0.0 `applyStyle` returns its input unchanged when color level is `<= 0` or the string is empty.
- Codex source gate inspected directly: `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`; no protocol or runtime coupling.
- Direct local launcher proof was attempted with isolated state for human and JSON CLI paths. It was blocked before command execution by an unrelated stale shared-build export mismatch in the linked local install; focused owner tests and the exact-tree Testbox gate are the executable proof.

Live overlap recheck immediately before publication:

- https://github.com/openclaw/openclaw/pull/123867 touches allowlist validation/update logic in `exec-approvals-cli.ts`; render hunks are disjoint.
- https://github.com/openclaw/openclaw/pull/123075 adds approval resolution provenance in `exec-approvals-cli.ts`; render hunks are disjoint.
- https://github.com/openclaw/openclaw/pull/89756 changes exec-policy configuration/migration behavior; the show renderer cleanup is disjoint.
- https://github.com/openclaw/openclaw/pull/83440 is a stale pending-approvals branch that adds another identical rich-output wrapper; when rebased, it should use the direct theme calls established here.
