### PR TITLE
refactor(config): centralize session root resolution

### DIFF
--- a/src/config/sessions/targets.ts
+++ b/src/config/sessions/targets.ts
@@ -216,6 +216,27 @@ function isValidatedRecoveryCandidateSessionsDir(params: {
   }
 }
 
+function createRealAgentsRootResolver(): (agentsRoot: string) => string | undefined {
+  // Freeze successes and skippable failures for one discovery pass; each caller gets a fresh cache.
+  const realAgentsRoots = new Map<string, string | undefined>();
+  return (agentsRoot) => {
+    if (realAgentsRoots.has(agentsRoot)) {
+      return realAgentsRoots.get(agentsRoot);
+    }
+    try {
+      const realAgentsRoot = fsSync.realpathSync.native(agentsRoot);
+      realAgentsRoots.set(agentsRoot, realAgentsRoot);
+      return realAgentsRoot;
+    } catch (err) {
+      if (shouldSkipDiscoveryError(err)) {
+        realAgentsRoots.set(agentsRoot, undefined);
+        return undefined;
+      }
+      throw err;
+    }
+  };
+}
+
 function resolveSessionStoreDiscoveryState(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv,
@@ -428,23 +449,7 @@ export function resolveAllAgentSessionStoreCandidateTargetsSync(
 ): SessionStoreTarget[] {
   const env = params.env ?? process.env;
   const { configuredTargets, agentsRoots } = resolveSessionStoreDiscoveryState(cfg, env);
-  const realAgentsRoots = new Map<string, string | undefined>();
-  const getRealAgentsRoot = (agentsRoot: string): string | undefined => {
-    if (realAgentsRoots.has(agentsRoot)) {
-      return realAgentsRoots.get(agentsRoot);
-    }
-    try {
-      const realAgentsRoot = fsSync.realpathSync.native(agentsRoot);
-      realAgentsRoots.set(agentsRoot, realAgentsRoot);
-      return realAgentsRoot;
-    } catch (err) {
-      if (shouldSkipDiscoveryError(err)) {
-        realAgentsRoots.set(agentsRoot, undefined);
-        return undefined;
-      }
-      throw err;
-    }
-  };
+  const getRealAgentsRoot = createRealAgentsRootResolver();
   const validatedConfiguredTargets = configuredTargets.flatMap((target) => {
     const agentsRoot = resolveAgentsDirFromSessionStorePath(target.storePath);
     if (!agentsRoot) {
@@ -518,23 +523,7 @@ function resolveAgentSessionStoreTargets(
     resolveSessionStorePathCore(undefined, { agentId: requested, env }),
   ]);
   const targets: SessionStoreTarget[] = [];
-  const realAgentsRoots = new Map<string, string | undefined>();
-  const getRealAgentsRoot = (agentsRoot: string): string | undefined => {
-    if (realAgentsRoots.has(agentsRoot)) {
-      return realAgentsRoots.get(agentsRoot);
-    }
-    try {
-      const realAgentsRoot = fsSync.realpathSync.native(agentsRoot);
-      realAgentsRoots.set(agentsRoot, realAgentsRoot);
-      return realAgentsRoot;
-    } catch (err) {
-      if (shouldSkipDiscoveryError(err)) {
-        realAgentsRoots.set(agentsRoot, undefined);
-        return undefined;
-      }
-      throw err;
-    }
-  };
+  const getRealAgentsRoot = createRealAgentsRootResolver();
 
   for (const storePath of storePaths) {
     const agentsRoot = resolveAgentsDirFromSessionStorePath(storePath);


### PR DESCRIPTION
## What Problem This Solves

Session-store discovery had two identical per-call realpath resolver closures. Both cached successful resolutions and skippable failures for one discovery pass, but duplicated the same containment-support policy in separate target-resolution paths.

## Why This Change Was Made

`src/config/sessions/targets.ts` now owns one private `createRealAgentsRootResolver()` factory. Each caller receives a fresh cache. It preserves exact-string keys, cached `undefined` via `Map.has()`, successful native realpaths, negative caching for the six `shouldSkipDiscoveryError` codes, and propagation of every other error.

Only the duplicate closures in recovery-candidate discovery and per-agent target resolution were removed. The distinct success-only retrying resolver in `resolveAllAgentSessionStoreTargetsSync` remains separate because missing roots must be retried there. Validation and containment policy remain owned by `src/config/sessions/targets-path-validation.ts`.

## User Impact

No user-visible behavior changes. Session target discovery keeps the same containment, retry, and error behavior with one canonical implementation for the duplicated policy.

## Evidence

- Signed head: `fd607b4065f6e33580c38071c4f6bf1fda60989f`
- Parent: `b49119b44f41b16a4bde85acc5ace2d4969023e6`
- Tree: `e6061b0f1858fed69032909133adb6f16885e4d1`
- Stable patch ID: `e08cc55b6913a77da4f407494df01dab38fcc3f7`
- Production LOC: `+23/-34`, net `-11`; tests `0`
- A 21-scenario parent/head differential harness produced identical syscall order and output hash `abcb99e8767bafd12c3c2ed3339c1bcf69260f9120995c2a5f2e16f9805f5632`. Coverage included existing, missing, inaccessible, and symlinked roots; all six skippable errors; unexpected `EIO`; repeated calls; independent per-pass caches; the success-only retry path; containment; and exact-string cache keys.
- Existing discovery tests cover unreadable roots, symlink containment, recovery candidates, and exported caller behavior. No implementation-coupled test seam was added for the private factory.
- Current-main review found only unrelated hunks in `src/config/sessions/targets.ts`; the resolver invariant is unchanged and the synthetic merge is clean.
- `git diff --check` passed.
- Autoreview and exact-head CI are being refreshed for this ready-for-review transition.
- Codex hard gate inspected directly at `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`; those CLI sections do not affect this refactor.

The earlier Testbox run https://github.com/openclaw/openclaw/actions/runs/33553459751 is not exact-head evidence: it checked parent `b49119b44f41b16a4bde85acc5ace2d4969023e6` and was cancelled. No Testbox claim is made for this head yet.

## Overlap

Live overlap pins were rechecked:

- https://github.com/openclaw/openclaw/pull/97103 at `add96cdb4c807a6d3e5c6b60ffc352b5292733ca`
- https://github.com/openclaw/openclaw/pull/126605 at `897352dcac639b059493c38dffd3a675d28925e6`
- https://github.com/openclaw/openclaw/pull/133910 at `b962a6fbdfbab09729d785a0e8847d25cc099f23`

They touch separate hunks and do not change the duplicated resolver policy, the private helper location, or the distinct retrying resolver.
