### PR TITLE
docs: add Cursor verify-openclaw skill

### DIFF
--- a/.cursor/skills/verify-openclaw/SKILL.md
+++ b/.cursor/skills/verify-openclaw/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: verify-openclaw
+description: Verify OpenClaw with CONTRIBUTING.md commands before a PR.
+---
+
+# Verify OpenClaw
+
+Follow CONTRIBUTING.md. Use the workspace installer at repo root.
+
+Runtime: Node 24.15+ for source checkouts when possible (also 22.22.3+ and 25.9+; Node 23 unsupported). docs/install/node.md recommends Node 26.
+
+Contributor bar from CONTRIBUTING.md:
+
+    pnpm install
+    pnpm build && pnpm check && pnpm test
+
+pnpm verify runs check then test and does not replace build.
+Targeted lanes: check:changed, test:fast, test:extension, test:contracts, docs:list, format:docs:check.
+
+Do not submit refactor-only PRs, test or CI-only for known main failures, CHANGELOG.md, security CODEOWNERS paths without an owner, or public vuln disclosure.
+
+PR title: type: user-facing description (feat, fix, improve, refactor, docs, chore). One problem. American English. Fill the PR template. Keep Allow edits from maintainers enabled.


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Cursor agents contributing to this fork have no repo-local verify skill, so they guess commands instead of following CONTRIBUTING.md.

## Why This Change Was Made

Add `.cursor/skills/verify-openclaw/SKILL.md` that points at the CONTRIBUTING contributor bar, Node floors, targeted lanes, and PR title rules. Origin has no `.cursor` tree. Optional docs-only file.

## User Impact

No user-visible product change. Contributors using Cursor get the CONTRIBUTING bar without guessing.
