### PR TITLE
refactor(msteams): share display-name matching

### DIFF
--- a/extensions/msteams/src/resolve-allowlist.ts
+++ b/extensions/msteams/src/resolve-allowlist.ts
@@ -52,14 +52,10 @@ function uniqueItemsById<T extends { id?: string }>(items: T[]): T[] {
   return [...byId.values()];
 }
 
-function findExactTeams(items: GraphGroup[], query: string): GraphGroup[] {
-  const normalized = normalizeExactMatch(query);
-  return uniqueItemsById(
-    items.filter((item) => normalizeExactMatch(item.displayName) === normalized),
-  );
-}
-
-function findExactChannels(items: GraphChannel[], query: string): GraphChannel[] {
+function findExactByDisplayName<T extends { id?: string; displayName?: string }>(
+  items: T[],
+  query: string,
+): T[] {
   const normalized = normalizeExactMatch(query);
   return uniqueItemsById(
     items.filter((item) => normalizeExactMatch(item.displayName) === normalized),
@@ -365,7 +361,7 @@ export async function resolveMSTeamsChannelAllowlist(params: {
         if (result.truncated) {
           return { input, resolved: false, note: "team lookup incomplete" };
         }
-        const exactTeams = findExactTeams(result.items, team);
+        const exactTeams = findExactByDisplayName(result.items, team);
         const [exactTeam] = exactTeams;
         if (!exactTeam) {
           return { input, resolved: false, note: "team not found" };
@@ -400,7 +396,7 @@ export async function resolveMSTeamsChannelAllowlist(params: {
       } catch {
         return { input, resolved: false, note: "channel lookup failed" };
       }
-      const generalChannels = findExactChannels(teamChannels, "general");
+      const generalChannels = findExactByDisplayName(teamChannels, "general");
       if (params.teamIdMode !== "graph" && generalChannels.length !== 1) {
         return {
           input,
@@ -424,7 +420,9 @@ export async function resolveMSTeamsChannelAllowlist(params: {
         };
       }
       const channelById = teamChannels.find((item) => item.id === channel);
-      const exactChannels = channelById ? [channelById] : findExactChannels(teamChannels, channel);
+      const exactChannels = channelById
+        ? [channelById]
+        : findExactByDisplayName(teamChannels, channel);
       if (exactChannels.length === 0) {
         return { input, resolved: false, note: "channel not found" };
       }


### PR DESCRIPTION
## What Problem This Solves

Microsoft Teams allowlist resolution had separate private functions for exact team-name and channel-name matching even though both Graph result types expose the same selected `id` and `displayName` fields. The duplicate implementations owned identical normalization and ID-deduplication policy, creating avoidable drift risk in an authorization-sensitive resolver.

## Why This Change Was Made

`extensions/msteams/src/resolve-allowlist.ts` now owns one private generic `findExactByDisplayName` matcher after `uniqueItemsById`. It preserves the existing lowercase normalization and first-item-per-trimmed-ID behavior, then serves only the three existing team/channel display-name call sites:

- team result matching;
- General channel matching;
- requested channel matching after the existing ID-first lookup.

User matching remains separate because `findExactUsers` intentionally checks `displayName`, `mail`, and `userPrincipalName`.

## User Impact

No user-visible behavior changes. Graph token acquisition, API call order, pagination completeness, ID-first channel matching, ambiguity handling, diagnostics, and fail-closed behavior are unchanged. No SDK, core, config, test, documentation, or changelog surface changed.

## Evidence

- Signed head: `46ec62eb5b37578d1a02b0290b6dab0838f03421`; parent: `0730b41693592e7dbce141d0dc8dda6ad33eddb3`.
- Production LOC: `+9/-11`, net `-2`; tests: `0`.
- Graph source types define both `GraphGroup` and `GraphChannel` with optional `id` and `displayName`; the owning list requests select exactly `id,displayName`.
- Five reviewed Microsoft Teams suites passed: 5 files, 136 tests.
- The changed-file gate passed, including 5 additional doctor-contract tests, extension production/test type checks, extension lint, format, dependency and boundary guards, dead-export scan, and runtime import-cycle checks.
- Explicit `pnpm check:import-cycles` passed with 0 runtime value cycles.
- Sol-high autoreview against `origin/main` returned scoped-clean with 0.99 confidence.
- Codex contract gate inspected `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`; those CLI parsing/completion paths are unrelated.
- https://github.com/openclaw/openclaw/pull/115432 modifies Microsoft Teams ingress identity normalization in the same file, but its live matcher and three call-site hunks are disjoint.
- https://github.com/openclaw/openclaw/pull/55828 is a conflicting older rewrite of the pre-current Microsoft Teams resolver architecture; it does not invalidate this current-main private matcher consolidation.
- Testbox and live Microsoft Graph proof were not run because this private, behavior-neutral refactor changes no request, response, credential, or network behavior.
