### PR TITLE
fix(ui): group accent color with theme

### DIFF
--- a/ui/src/e2e/appearance-control-layout.e2e.test.ts
+++ b/ui/src/e2e/appearance-control-layout.e2e.test.ts
@@ -38,6 +38,16 @@ suite.define(() => {
         await page.goto(`${suite.server.baseUrl}settings/appearance`);
         await waitForControlUiSettingsTakeover(page);
 
+        const appearanceHeadings = await page
+          .locator(
+            ".settings-page > .settings-section > .settings-section__header > .settings-section__heading",
+          )
+          .allTextContents();
+        const themeIndex = appearanceHeadings.findIndex((heading) => heading.trim() === "Theme");
+        expect(
+          appearanceHeadings.slice(themeIndex, themeIndex + 3).map((heading) => heading.trim()),
+        ).toEqual(["Theme", "Accent color", "Typography"]);
+
         const accent = page.locator("#settings-appearance-accent");
         const customPicker = accent.locator("[data-accent-custom]");
         const customSwatch = accent.locator(".settings-accent-swatch--custom");

--- a/ui/src/pages/config/view-appearance.ts
+++ b/ui/src/pages/config/view-appearance.ts
@@ -437,8 +437,6 @@ export function renderAppearanceSection(
         </div>
       </section>
 
-      ${renderTypography(props, themeOptions.find((option) => option.id === props.theme)!.label)}
-
       <section id=${APPEARANCE_SETTINGS_TARGET_IDS.accent} class="settings-section">
         <div class="settings-section__header">
           <h2 class="settings-section__heading">${t("configView.appearance.accent")}</h2>
@@ -513,6 +511,8 @@ export function renderAppearanceSection(
           <span class="settings-accent-status__scope">${accentProvenance}</span>
         </p>
       </section>
+
+      ${renderTypography(props, themeOptions.find((option) => option.id === props.theme)!.label)}
 
       <section id=${APPEARANCE_SETTINGS_TARGET_IDS.textSize} class="settings-section">
         <div class="settings-section__header">


### PR DESCRIPTION
Closes #135535

## What Problem This Solves

Fixes an issue where users scanning Settings > Appearance find Accent color separated from Theme by Typography, even though Theme and Accent color are related visual identity choices.

## Why This Change Was Made

Moves the existing Accent color section directly below Theme and before Typography. All labels, controls, anchor IDs, and settings behavior remain unchanged; a focused browser test protects the contiguous section order.

## User Impact

Theme and Accent color now appear together, making the Appearance page easier to scan without changing how any setting works.

## Evidence

Both full-page captures use the same conditions: `/settings/appearance`, 1440 x 1000 viewport, dark color scheme, `en-US` locale, reduced motion, and the same page data.

### Before

Theme, Typography, Accent color:

![Appearance settings before: Typography separates Theme and Accent color](https://github.com/user-attachments/assets/683be26f-97e9-41bf-98ce-7a096d3ffcbe)

### After

Theme, Accent color, Typography:

![Appearance settings after: Accent color appears directly below Theme](https://github.com/user-attachments/assets/7d62d25b-4dee-4806-a869-bedbb466d77c)

### Consumers Checked

- `renderAppearance` in `ui/src/pages/config/view.ts`: still renders the same Appearance template; only its internal section order changes.
- `appearanceTheme` and `appearanceAccent` in `ui/src/pages/config/settings-targets.ts`: retain their existing search destinations and hashes.
- `APPEARANCE_SETTINGS_TARGET_IDS.theme` and `.accent` in `ui/src/pages/config/route-data.ts`: retain the existing anchor IDs.
- `scrollToPendingRouteTarget` in `ui/src/pages/config/config-page.ts`: continues resolving those unchanged IDs for deep links.
- `appearance-control-layout.e2e.test.ts`: verifies the three sections are contiguous in the requested order while retaining Accent focus and Theme responsive-layout coverage.

Focused browser coverage and changed-scope checks pass.

Production LOC: +2/-2 (net 0). Tests: +10/-0.
