### PR TITLE
fix(channels): compute plugin-command authorization on Signal and MS Teams

### DIFF
--- a/extensions/msteams/src/monitor-handler/access.ts
+++ b/extensions/msteams/src/monitor-handler/access.ts
@@ -258,10 +258,16 @@ export async function admitMSTeamsMessage(params: {
   });
   const isControlCommand =
     allowTextCommands && core.channel.commands.isControlCommandMessage(params.text, params.cfg);
+  const shouldComputeAuth =
+    allowTextCommands &&
+    core.channel.commands.shouldComputeCommandAuthorized(params.text, params.cfg);
+  const convType = normalizeOptionalLowercaseString(params.activity.conversation?.conversationType);
+  const messageIsDirectMessage =
+    convType === "personal" || (!convType && !params.activity.conversation?.isGroup);
   const access = await resolveMSTeamsSenderAccess({
     cfg: params.cfg,
     activity: params.activity,
-    hasControlCommand: isControlCommand,
+    hasControlCommand: messageIsDirectMessage ? shouldComputeAuth : isControlCommand,
   });
   const {
     dmPolicy,

--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -734,6 +734,32 @@ describe("msteams monitor handler authz", () => {
     expect(ctxPayload.CommandAuthorized).toBe(false);
   });
 
+  it("uses the broad authorization probe for direct-message plugin commands", async () => {
+    resetThreadMocks();
+    const isControlCommandMessage = vi.fn(() => false);
+    const shouldComputeCommandAuthorized = vi.fn(() => true);
+    const { deps } = createDeps(
+      {
+        channels: {
+          msteams: {
+            dmPolicy: "open",
+            allowFrom: ["attacker-aad"],
+          },
+        },
+      } as OpenClawConfig,
+      { isControlCommandMessage, shouldComputeCommandAuthorized },
+    );
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler(createAttackerPersonalActivity("msg-plugin"));
+
+    expect(shouldComputeCommandAuthorized).toHaveBeenCalledWith("hello", deps.cfg);
+    expect(isControlCommandMessage).toHaveBeenCalledWith("hello", deps.cfg);
+    const dispatched = firstSettledDispatch();
+    const ctxPayload = recordFromMockCall(dispatched?.ctxPayload);
+    expect(ctxPayload.CommandAuthorized).toBe(true);
+  });
+
   it("marks skipped channel message system events as non-owner without duplicating body text", async () => {
     resetThreadMocks();
     const { deps, enqueueSystemEvent } = createDeps({

--- a/extensions/signal/src/monitor/event-handler.mention-gating.test.ts
+++ b/extensions/signal/src/monitor/event-handler.mention-gating.test.ts
@@ -221,6 +221,13 @@ describe("signal mention gating", () => {
     expect(getCapturedCtx().WasMentioned).toBe(false);
   });
 
+  it("does not drop group text with inline command tokens when requireMention is off", async () => {
+    const handler = createMentionHandler({ requireMention: false });
+
+    await handler(makeGroupEvent({ message: "hello /status" }));
+    expect(getCapturedCtx().Body).toContain("hello /status");
+  });
+
   it("allows explicitly configured Signal groups by group id without a mention", async () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -45,7 +45,10 @@ import {
   resolveChannelGroupPolicy,
   resolveChannelGroupRequireMention,
 } from "openclaw/plugin-sdk/channel-policy";
-import { isControlCommandMessage } from "openclaw/plugin-sdk/command-detection";
+import {
+  isControlCommandMessage,
+  shouldComputeCommandAuthorized,
+} from "openclaw/plugin-sdk/command-detection";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   createInternalHookEvent,
@@ -1011,6 +1014,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const groupId = dataMessage?.groupInfo?.groupId ?? reaction?.groupInfo?.groupId ?? undefined;
     const isGroup = Boolean(groupId);
     const hasControlCommandInMessage = isControlCommandMessage(messageText, deps.cfg);
+    const shouldComputeCommandAuthorization = shouldComputeCommandAuthorized(messageText, deps.cfg);
 
     const senderDisplay = formatSignalSenderDisplay(sender);
     const resolveChannelIngress = async (contextBinding?: ChannelIngressContextBinding) =>
@@ -1024,7 +1028,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         groupId,
         isGroup,
         cfg: deps.cfg,
-        hasControlCommand: hasControlCommandInMessage,
+        hasControlCommand: isGroup ? hasControlCommandInMessage : shouldComputeCommandAuthorization,
         contextBinding,
       });
     const accessDecision = await resolveChannelIngress();


### PR DESCRIPTION
Closes #135502

## What Problem This Solves

On Signal and Microsoft Teams, an otherwise-admitted sender invoking a registered plugin command could reach the handler with `CommandAuthorized`/`isAuthorizedSender` false (or be rejected by the default `requireAuth` boundary) because these channels decided whether to compute command authorization with the narrow `isControlCommandMessage` detector, which only recognizes built-in control commands and abort triggers — not arbitrary plugin commands registered through `api.registerCommand(...)`.

## Why This Change Was Made

`isControlCommandMessage` (exact control-lane/drop) and `shouldComputeCommandAuthorized` (broad probe that also matches inline `/x`/`!x` tokens and registered plugin commands) are separate helpers. Other ingresses (Google Chat, Zalo, ZaloUser, Feishu) already use the broad probe at the authorization boundary. This PR does the same for Signal and MS Teams while keeping the narrow detector for exact control-lane/drop behavior:

- Signal: direct-message admission now uses `shouldComputeCommandAuthorized`, while group admission keeps `isControlCommandMessage` (matching Google Chat's group-vs-DM split), so inline command-looking group text is not dropped and still reaches mention gating.
- MS Teams: direct-message admission now uses `shouldComputeCommandAuthorized`, while group/channel admission keeps `isControlCommandMessage`.

## User Impact

Plugin commands registered on Signal/MS Teams now receive the same computed command-authority result as on other channels — the default `requireAuth` boundary rejects unauthorized senders before the handler runs, and `requireAuth: false` handlers observe the correct `isAuthorizedSender` value. Group/channel text that merely contains inline command tokens is still dispatched normally.

## Evidence

Exact head: `5744943bb5e050d0697a05c6c58b9c5e6020dd21`

- `extensions/msteams/src/monitor-handler/message-handler.authz.test.ts` — "uses the broad authorization probe for direct-message plugin commands" asserts `shouldComputeCommandAuthorized` is consulted and `CommandAuthorized` is true for an admitted DM sender; existing "does not drop inline command-looking group text" still passes (group keeps the narrow probe). 23 passed.
- `extensions/signal/src/monitor/event-handler.mention-gating.test.ts` — new "does not drop group text with inline command tokens when requireMention is off" proves group inline text is still dispatched. Signal monitor suite 138 passed.
- Production typecheck passes; `check:changed` is green except the pre-existing unrelated `ui/vite.config.ts` missing-`pako` declaration in the reused dependency tree.

## AI Assistance

AI-assisted implementation. I manually verified the narrow-vs-broad probe split, the group-vs-DM boundary on both channels, the Signal mention-gate regression, the focused regressions, and the changed-file gates.