### PR TITLE
refactor(media): centralize guarded POST requests

### DIFF
--- a/src/media-understanding/shared.test.ts
+++ b/src/media-understanding/shared.test.ts
@@ -38,6 +38,7 @@ import {
   fetchWithTimeoutGuarded,
   pollProviderOperationJson,
   postJsonRequest,
+  postMultipartRequest,
   postTranscriptionRequest,
   resolveProviderHttpRequestConfig,
   resolveProviderHttpRequestConfigWithOriginTrust,
@@ -686,6 +687,16 @@ describe("resolveProviderHttpRequestConfig", () => {
 });
 
 describe("fetchWithTimeoutGuarded", () => {
+  it.each([postTranscriptionRequest, postJsonRequest, postMultipartRequest])(
+    "rejects aborted POSTs",
+    async (request) => {
+      const signal = AbortSignal.abort("request cancelled");
+      const args = { url: "x", headers: new Headers(), body: "x", fetchFn: fetch, signal };
+      await expect(request(args)).rejects.toBe(signal.reason);
+      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("applies a default timeout when callers omit one", async () => {
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response(null, { status: 200 }),

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -651,39 +651,28 @@ type GuardedPostRequestParams<TBody> = GuardedProviderRequestParams &
   };
 
 export async function postTranscriptionRequest(params: GuardedPostRequestParams<BodyInit>) {
-  return await postGuardedRequest({
-    url: params.url,
-    init: {
-      method: "POST",
-      headers: params.headers,
-      body: params.body,
-      ...(params.signal ? { signal: params.signal } : {}),
-    },
-    timeoutMs: params.timeoutMs,
-    fetchFn: params.fetchFn,
-    guardedOptions: resolveGuardedRequestOptions(params),
-    retryStage: params.retryStage,
-    retry: params.retry,
-  });
+  return await postGuardedRequest(params, params.body);
 }
 
-async function postGuardedRequest(params: {
-  url: string;
-  init: RequestInit;
-  timeoutMs?: number;
-  fetchFn: typeof fetch;
-  guardedOptions?: GuardedProviderRequestOptions;
-  retryStage?: ProviderOperationRetryStage;
-  retry?: TransientProviderRetryConfig;
-}) {
+async function postGuardedRequest<TBody>(
+  params: GuardedPostRequestParams<TBody>,
+  requestBody: BodyInit | undefined,
+) {
+  const init: RequestInit = {
+    method: "POST",
+    headers: params.headers,
+    body: requestBody,
+    ...(params.signal ? { signal: params.signal } : {}),
+  };
+  const guardedOptions = resolveGuardedRequestOptions(params);
   const operation = async () => {
-    params.init.signal?.throwIfAborted();
+    init.signal?.throwIfAborted();
     const result = await fetchWithTimeoutGuarded(
       params.url,
-      params.init,
+      init,
       params.timeoutMs,
       params.fetchFn,
-      params.guardedOptions,
+      guardedOptions,
     );
     if (params.retryStage && isTransientProviderHttpStatus(result.response.status)) {
       try {
@@ -703,43 +692,17 @@ async function postGuardedRequest(params: {
     provider: "provider-http",
     stage: params.retryStage,
     retry: params.retry,
-    signal: params.init.signal ?? undefined,
+    signal: init.signal ?? undefined,
     operation,
   });
 }
 
 export async function postJsonRequest(params: GuardedPostRequestParams<unknown>) {
-  return await postGuardedRequest({
-    url: params.url,
-    init: {
-      method: "POST",
-      headers: params.headers,
-      body: JSON.stringify(params.body),
-      ...(params.signal ? { signal: params.signal } : {}),
-    },
-    timeoutMs: params.timeoutMs,
-    fetchFn: params.fetchFn,
-    guardedOptions: resolveGuardedRequestOptions(params),
-    retryStage: params.retryStage,
-    retry: params.retry,
-  });
+  return await postGuardedRequest(params, JSON.stringify(params.body));
 }
 
 export async function postMultipartRequest(params: GuardedPostRequestParams<BodyInit>) {
-  return await postGuardedRequest({
-    url: params.url,
-    init: {
-      method: "POST",
-      headers: params.headers,
-      body: params.body,
-      ...(params.signal ? { signal: params.signal } : {}),
-    },
-    timeoutMs: params.timeoutMs,
-    fetchFn: params.fetchFn,
-    guardedOptions: resolveGuardedRequestOptions(params),
-    retryStage: params.retryStage,
-    retry: params.retry,
-  });
+  return await postGuardedRequest(params, params.body);
 }
 
 export function requireTranscriptionText(


### PR DESCRIPTION
## What Problem This Solves

The shared media HTTP owner maintained the same guarded POST request construction in three public wrappers. Transcription, JSON, and multipart requests could drift in abort propagation, guarded network policy, or retry behavior when one copy changed without the others.

## Why This Change Was Made

`src/media-understanding/shared.ts` now constructs the POST `RequestInit` and resolves guarded options once in the private `postGuardedRequest` owner. `postTranscriptionRequest`, `postJsonRequest`, and `postMultipartRequest` remain distinct async exports with `return await`, preserving their public identities and existing Plugin SDK surface.

Headers, raw bodies, `FormData`, and signals retain their caller-owned identities. JSON serialization still occurs once before retries. Pre-abort checks, timeout handling, SSRF and dispatcher options, transient-status retry decisions, error parsing, and response-release ordering are unchanged.

## User Impact

No user-visible behavior change. Provider POST requests now share one canonical guarded transport path without changing security policy, retries, or public APIs.

## Evidence

- Signed head `bf10a5f3e15ed311b201e03cfb8e78ecbe1b2a1b`; parent `0730b41693592e7dbce141d0dc8dda6ad33eddb3`.
- Production LOC: `+18/-55`, net `-37`. Tests: `+11/-0`.
- Test-audit authoring gate: the added table protects observable pre-abort behavior across all three public exports; it catches a dropped signal or accidental fetch during consolidation; existing coverage did not exercise multipart or all wrappers at this boundary; no production test seam was added.
- Focused matrix passed: 5 Vitest shards, 137 tests across shared media HTTP, Deepgram, ElevenLabs, OpenAI-compatible image generation, OpenAI video generation, PixVerse, and Plugin SDK subpath contracts.
- `pnpm plugin-sdk:surface:check` passed with 345 SDK entrypoints and no forbidden package-exported subpaths.
- `pnpm check:import-cycles` passed with 0 runtime value cycles.
- Targeted formatting, Oxlint, core production types, and `git diff --check` passed. The local linked install could not resolve the unrelated UI `mermaid` dependency during core-test typechecking; the hydrated exact-tree Testbox gate below passed that full stage.
- Exact-tree Blacksmith Testbox changed gate passed in 19m24s: lease `tbx_01m1faspjf5cbmxkvr0rygybnf`, run https://github.com/openclaw/openclaw/actions/runs/33555966680.
- Sol-high autoreview was scoped-clean at 0.99 on the exact two-file patch.
- Codex contract gate inspected directly: `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`; no protocol or runtime coupling exists.
- Open overlap rechecked immediately before publication: https://github.com/openclaw/openclaw/pull/132559 changes only the timeout-error export near `src/media-understanding/shared.ts:147`; this POST consolidation is hunk-disjoint.
