### PR TITLE
refactor(discord): share terminal approval rendering

### DIFF
--- a/extensions/discord/src/approval-handler.runtime.ts
+++ b/extensions/discord/src/approval-handler.runtime.ts
@@ -3,7 +3,9 @@ import { ButtonStyle } from "discord-api-types/v10";
 import type {
   ApprovalViewModel,
   ChannelApprovalCapabilityHandlerContext,
+  ExpiredApprovalView,
   PendingApprovalView,
+  ResolvedApprovalView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { createChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
 import type { ExecApprovalActionDescriptor } from "openclaw/plugin-sdk/approval-reply-runtime";
@@ -329,6 +331,23 @@ function createApprovalContainer(params: {
   });
 }
 
+function buildDiscordTerminalApprovalResult(
+  params: ChannelApprovalCapabilityHandlerContext & {
+    view: ResolvedApprovalView | ExpiredApprovalView;
+  },
+) {
+  const resolvedContext = resolveHandlerContext(params);
+  if (!resolvedContext) {
+    return { kind: "delete" } as const;
+  }
+  const container = createApprovalContainer({
+    view: params.view,
+    cfg: params.cfg,
+    accountId: resolvedContext.accountId,
+  });
+  return { kind: "update", payload: container } as const;
+}
+
 async function updateMessage(params: {
   cfg: OpenClawConfig;
   accountId: string;
@@ -431,30 +450,8 @@ export const discordApprovalNativeRuntime = createChannelApprovalNativeRuntimeAd
         body: stripUndefinedFields(serializePayload(buildExecApprovalPayload(container))),
       };
     },
-    buildResolvedResult: ({ cfg, accountId, context, view }) => {
-      const resolvedContext = resolveHandlerContext({ cfg, accountId, context });
-      if (!resolvedContext) {
-        return { kind: "delete" } as const;
-      }
-      const container = createApprovalContainer({
-        view,
-        cfg,
-        accountId: resolvedContext.accountId,
-      });
-      return { kind: "update", payload: container } as const;
-    },
-    buildExpiredResult: ({ cfg, accountId, context, view }) => {
-      const resolvedContext = resolveHandlerContext({ cfg, accountId, context });
-      if (!resolvedContext) {
-        return { kind: "delete" } as const;
-      }
-      const container = createApprovalContainer({
-        view,
-        cfg,
-        accountId: resolvedContext.accountId,
-      });
-      return { kind: "update", payload: container } as const;
-    },
+    buildResolvedResult: buildDiscordTerminalApprovalResult,
+    buildExpiredResult: buildDiscordTerminalApprovalResult,
   },
   transport: {
     prepareTarget: async ({ cfg, accountId, context, plannedTarget }) => {


### PR DESCRIPTION
## What Problem This Solves

Discord's native approval presentation duplicated the same terminal rendering callback for resolved and expired approvals. The copies owned identical context validation, deletion fallback, container creation, and final update behavior, creating drift risk inside a lifecycle-sensitive channel path.

## Why This Change Was Made

The Discord plugin now owns one private `buildDiscordTerminalApprovalResult` callback and assigns it directly to both required presentation fields.

The callback accepts the explicit `ResolvedApprovalView | ExpiredApprovalView` union. This intentionally excludes pending and future phases from silently entering terminal rendering. Both contract fields remain distinct, and the core and lazy runtime adapters still construct separate async forwarding wrappers, so shared callback identity is not observable.

Missing context still returns `delete`; every invocation still creates a fresh container from the exact `cfg`, `accountId`, `context`, and phase-specific `view`. Approval ownership, lifecycle generation, transport cleanup, interaction authority, channel encoding, and security policy are unchanged. No SDK, core, config, protocol, persistence, test, documentation, or changelog surface changed.

## User Impact

No user-visible behavior changes. Resolved and expired Discord approvals retain the same rendering and cleanup behavior with one canonical plugin-private implementation.

## Evidence

- Signed head: `bc7a5785d964bed5609bb8ad98fa21f83a159e60`
- Parent: `eb0d8830e7dc795e1bb927b5800b61a67470c8ae`
- Production LOC: `+21/-24`, net `-3`; tests: `0`. The two added type-only imports enforce the explicit terminal-view union.
- Focused local proof: 45 tests passed across:
  - `extensions/discord/src/approval-handler.runtime.test.ts`
  - `extensions/discord/src/approval-native.test.ts`
  - `src/infra/approval-handler-runtime.test.ts`
- Targeted formatting, lint, extension production/test types, import cycles, dead exports, plugin boundaries, and changed-file checks passed.
- Exact-tree Blacksmith Testbox changed gate passed on lease `tbx_01m1fbs6869k54qrm5y8jrc2a7`, run https://github.com/openclaw/openclaw/actions/runs/33557638590.
- Sol-high autoreview completed with no accepted/actionable findings, confidence `0.98`.
- The acting executor inspected `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`; those CLI parsing/completion paths impose no approval runtime contract.
- Current-main preservation: the target file did not change between the verified parent and the latest fetched `origin/main`.
- Live Discord proof was not run because this is a behavior-neutral private callback dedupe with existing resolved/expired channel coverage.

Open overlaps were rechecked immediately before publication and remain separate:

- https://github.com/openclaw/openclaw/pull/123075 changes pending action lifecycle binding.
- https://github.com/openclaw/openclaw/pull/98577 changes terminal cancellation presentation.
- https://github.com/openclaw/openclaw/pull/82240 changes plugin approval long-description rendering.
