### PR TITLE
feat(telegram,message-tool): multi-media sends grouped into albums

### DIFF
--- a/extensions/telegram/src/channel.message-adapter.test.ts
+++ b/extensions/telegram/src/channel.message-adapter.test.ts
@@ -157,9 +157,7 @@ describe("telegram channel message adapter", () => {
 
     const proveBatch = async () => {
       const startCallCount = sendMessageTelegramMock.mock.calls.length;
-      sendMessageTelegramMock
-        .mockResolvedValueOnce({ messageId: "tg-batch-1", chatId: "12345" })
-        .mockResolvedValueOnce({ messageId: "tg-batch-2", chatId: "12345" });
+      sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-batch-1", chatId: "12345" });
       await adapter.send!.payload!({
         cfg: {} as never,
         to: "12345",
@@ -174,6 +172,7 @@ describe("telegram channel message adapter", () => {
         deps: { sendTelegram: sendMessageTelegramMock },
       });
       const batchCalls = sendMessageTelegramMock.mock.calls.slice(startCallCount);
+      expect(batchCalls).toHaveLength(1);
       expect(batchCalls[0]).toEqual([
         "12345",
         "batch",
@@ -191,28 +190,8 @@ describe("telegram channel message adapter", () => {
           mediaReadFile: undefined,
           forceDocument: false,
           quoteText: undefined,
-          mediaUrl: "https://example.com/a.png",
+          mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
           buttons: undefined,
-        },
-      ]);
-      expect(batchCalls[1]).toEqual([
-        "12345",
-        "",
-        {
-          cfg: {},
-          verbose: false,
-          messageThreadId: undefined,
-          replyToMessageId: undefined,
-          replyToIdSource: undefined,
-          replyToMode: undefined,
-          accountId: undefined,
-          silent: undefined,
-          gatewayClientScopes: undefined,
-          mediaLocalRoots: undefined,
-          mediaReadFile: undefined,
-          forceDocument: false,
-          quoteText: undefined,
-          mediaUrl: "https://example.com/b.png",
         },
       ]);
     };
@@ -255,11 +234,9 @@ describe("telegram channel message adapter", () => {
     });
   });
 
-  it("keeps implicit first replies on the first delivered payload media", async () => {
+  it("keeps implicit first replies on the album payload media", async () => {
     const adapter = requireTelegramMessageAdapter();
-    sendMessageTelegramMock
-      .mockResolvedValueOnce({ messageId: "tg-media-1", chatId: "12345" })
-      .mockResolvedValueOnce({ messageId: "tg-media-2", chatId: "12345" });
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-media-1", chatId: "12345" });
 
     await adapter.send!.payload!({
       cfg: {} as never,
@@ -275,14 +252,12 @@ describe("telegram channel message adapter", () => {
       deps: { sendTelegram: sendMessageTelegramMock },
     });
 
-    const firstOpts = sendMessageTelegramMock.mock.calls[0]?.[2] as
-      | { replyToMessageId?: number }
+    expect(sendMessageTelegramMock).toHaveBeenCalledTimes(1);
+    const options = sendMessageTelegramMock.mock.calls[0]?.[2] as
+      | { replyToMessageId?: number; mediaUrls?: string[] }
       | undefined;
-    const secondOpts = sendMessageTelegramMock.mock.calls[1]?.[2] as
-      | { replyToMessageId?: number }
-      | undefined;
-    expect(firstOpts?.replyToMessageId).toBe(900);
-    expect(secondOpts?.replyToMessageId).toBeUndefined();
+    expect(options?.replyToMessageId).toBe(900);
+    expect(options?.mediaUrls).toEqual(["https://example.com/a.png", "https://example.com/b.png"]);
   });
 
   it("backs declared live preview finalizer capabilities with adapter proofs", async () => {

--- a/extensions/telegram/src/interactive-fallback.ts
+++ b/extensions/telegram/src/interactive-fallback.ts
@@ -22,7 +22,7 @@ import {
 } from "./button-types.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
 
-const TELEGRAM_CONTROL_ONLY_FALLBACK = "Choose an option.";
+export const TELEGRAM_CONTROL_ONLY_FALLBACK = "Choose an option.";
 
 const TELEGRAM_PRESENTATION_CAPABILITIES = {
   supported: true,

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -53,15 +53,6 @@ function lastCallOptions(
   return callOptionsAt(mock, mock.mock.calls.length - 1, expectedTo, expectedText);
 }
 
-function callOptionsFromEnd(
-  mock: MockWithCalls,
-  offsetFromEnd: number,
-  expectedTo: string,
-  expectedText: string,
-): Record<string, unknown> {
-  return callOptionsAt(mock, mock.mock.calls.length - offsetFromEnd, expectedTo, expectedText);
-}
-
 describe("telegramOutbound", () => {
   beforeEach(() => {
     pinMessageTelegramMock.mockReset();
@@ -111,10 +102,8 @@ describe("telegramOutbound", () => {
     expect(result).toEqual({ channel: "telegram", messageId: "tg-media" });
   });
 
-  it("sends payload media in sequence and keeps buttons on the first message only", async () => {
-    sendMessageTelegramMock
-      .mockResolvedValueOnce({ messageId: "tg-1", chatId: "12345" })
-      .mockResolvedValueOnce({ messageId: "tg-2", chatId: "12345" });
+  it("groups payload media into a single album send with buttons", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-1", chatId: "12345" });
     const mediaAccess = { localRoots: ["/tmp/media"], workspaceDir: "/tmp/media" };
 
     const result = await telegramOutbound.sendPayload!({
@@ -144,32 +133,17 @@ describe("telegramOutbound", () => {
       deps: { sendTelegram: sendMessageTelegramMock },
     });
 
-    expect(sendMessageTelegramMock).toHaveBeenCalledTimes(2);
-    const firstOptions = callOptionsAt(sendMessageTelegramMock, 0, "12345", "Approval required");
-    expect(firstOptions.mediaUrl).toBe("chart.png");
-    expect(firstOptions.mediaAccess).toBe(mediaAccess);
-    expect(firstOptions.mediaLocalRoots).toEqual(["/tmp/media"]);
-    expect(firstOptions.quoteText).toBe("quoted");
-    expect(firstOptions.buttons).toEqual([
+    expect(sendMessageTelegramMock).toHaveBeenCalledTimes(1);
+    const options = callOptionsAt(sendMessageTelegramMock, 0, "12345", "Approval required");
+    expect(options.mediaUrl).toBeUndefined();
+    expect(options.mediaUrls).toEqual(["chart.png", "chart-2.png"]);
+    expect(options.mediaAccess).toBe(mediaAccess);
+    expect(options.mediaLocalRoots).toEqual(["/tmp/media"]);
+    expect(options.quoteText).toBe("quoted");
+    expect(options.buttons).toEqual([
       [{ text: "Allow Once", callback_data: "/approve abc allow-once" }],
     ]);
-    expect(firstOptions.promptContextProjectionPlan).toMatchObject({
-      cursor: {
-        source: {
-          transcriptMessageId: "assistant-media",
-        },
-        nextPartIndex: 0,
-        complete: true,
-      },
-      finalPart: false,
-    });
-    const secondOptions = callOptionsAt(sendMessageTelegramMock, 1, "12345", "");
-    expect(secondOptions.mediaUrl).toBe("chart-2.png");
-    expect(secondOptions.mediaAccess).toBe(mediaAccess);
-    expect(secondOptions.mediaLocalRoots).toEqual(["/tmp/media"]);
-    expect(secondOptions.quoteText).toBe("quoted");
-    expect(secondOptions.buttons).toBeUndefined();
-    expect(secondOptions.promptContextProjectionPlan).toMatchObject({
+    expect(options.promptContextProjectionPlan).toMatchObject({
       cursor: {
         source: {
           transcriptMessageId: "assistant-media",
@@ -179,12 +153,9 @@ describe("telegramOutbound", () => {
       },
       finalPart: true,
     });
-    expect((firstOptions.promptContextProjectionPlan as { cursor: unknown }).cursor).toBe(
-      (secondOptions.promptContextProjectionPlan as { cursor: unknown }).cursor,
-    );
     expect(result).toEqual({
       channel: "telegram",
-      messageId: "tg-2",
+      messageId: "tg-1",
       target: { kind: "chat", id: "12345" },
     });
   });
@@ -914,9 +885,7 @@ describe("telegramOutbound", () => {
       expect(options.silent).toBe(true);
     };
     const proveBatch = async () => {
-      sendMessageTelegramMock
-        .mockResolvedValueOnce({ messageId: "tg-batch-1", chatId: "12345" })
-        .mockResolvedValueOnce({ messageId: "tg-batch-2", chatId: "12345" });
+      sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-batch", chatId: "12345" });
       await telegramOutbound.sendPayload!({
         cfg: {} as never,
         to: "12345",
@@ -927,10 +896,10 @@ describe("telegramOutbound", () => {
         },
         deps: { sendTelegram: sendMessageTelegramMock },
       });
-      const firstOptions = callOptionsFromEnd(sendMessageTelegramMock, 2, "12345", "batch");
-      expect(firstOptions.mediaUrl).toBe("https://example.com/a.png");
-      const secondOptions = callOptionsFromEnd(sendMessageTelegramMock, 1, "12345", "");
-      expect(secondOptions.mediaUrl).toBe("https://example.com/b.png");
+      // Multiple media are handed to the send layer as one mediaUrls array so it
+      // can group them into a Telegram album (or fall back per-media).
+      const options = lastCallOptions(sendMessageTelegramMock, "12345", "batch");
+      expect(options.mediaUrls).toEqual(["https://example.com/a.png", "https://example.com/b.png"]);
     };
 
     await verifyDurableFinalCapabilityProofs({

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -504,6 +504,9 @@ export function createTelegramOutboundAdapter(
       }),
     deliveryCapabilities: {
       pin: true,
+      // sendPayload groups 2+ media into one album and reports every accepted
+      // album item in the receipt, so core may route multi-media payloads here.
+      sendPayloadGroupsMedia: true,
       durableFinal: {
         text: true,
         media: true,

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -419,6 +419,20 @@ export async function sendTelegramPayloadMessages(params: {
     return { messageId: String(replyToMessageId), chatId: params.to };
   }
 
+  // Multiple media can be grouped into a single Telegram album; hand the full
+  // media list to the send layer, which decides album eligibility (2-10 photos/
+  // videos) and falls back to per-media sends otherwise. A single album call is
+  // first and final, so implicit reply targets stay on it rather than being
+  // consumed for a per-media sequence.
+  if (mediaUrls.length >= 2 && !payload.videoAsNote) {
+    return await params.send(params.to, text, {
+      ...payloadOpts,
+      ...projectionOptions(true),
+      mediaUrls,
+      buttons,
+    });
+  }
+
   // Telegram allows reply_markup on media; attach buttons only to the first send.
   return await sendPayloadMediaSequenceOrFallback({
     text,

--- a/extensions/telegram/src/send-media-group.ts
+++ b/extensions/telegram/src/send-media-group.ts
@@ -1,16 +1,14 @@
 import { InputFile } from "grammy";
 import type { InlineKeyboardMarkup, InputMediaPhoto, InputMediaVideo, Message } from "grammy/types";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
-import {
-  createChannelPartialDeliveryError,
-  isChannelPartialDeliveryError,
-} from "openclaw/plugin-sdk/channel-inbound";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { ResolvedTelegramAccount } from "./accounts.js";
 import { telegramCaptionDeliveryMetadata } from "./caption.js";
+import { TELEGRAM_CONTROL_ONLY_FALLBACK } from "./interactive-fallback.js";
 import { prepareTelegramOutboundMedia } from "./outbound-media.js";
 import type { TelegramOutboundPromptContextMessage as TelegramMessageLike } from "./outbound-message-context.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
@@ -162,7 +160,13 @@ export async function sendTelegramMediaAlbum(
   const { followUpText } = firstPlan;
   const htmlCaption = firstPlan.htmlCaption;
   const plainCaption = firstPlan.plainCaption;
-  const needsSeparateText = Boolean(followUpText);
+  // Telegram cannot host an inline keyboard on a media-group (album) message:
+  // sendMediaGroup has no reply_markup parameter and a later
+  // editMessageReplyMarkup is rejected ("message is not modified"). When an
+  // inline keyboard is requested, the album is sent captionless and the text is
+  // delivered as a follow-up message that carries the buttons instead.
+  const needsSeparateText = Boolean(followUpText) || Boolean(replyMarkup);
+  const albumCaption = needsSeparateText ? undefined : htmlCaption;
 
   const buildInputs = (
     captionValue: string | undefined,
@@ -194,10 +198,10 @@ export async function sendTelegramMediaAlbum(
   let groupDelivery: { result: Message[]; acceptedParams: Record<string, unknown> };
   let deliveredCaption: string | undefined;
   try {
-    groupDelivery = await sendGroup(buildInputs(htmlCaption, "HTML"));
-    deliveredCaption = plainCaption;
+    groupDelivery = await sendGroup(buildInputs(albumCaption, albumCaption ? "HTML" : undefined));
+    deliveredCaption = albumCaption ? plainCaption : undefined;
   } catch (error) {
-    if (isTelegramHtmlParseError(error) && plainCaption) {
+    if (isTelegramHtmlParseError(error) && albumCaption && plainCaption) {
       logVerbose(
         `telegram sendMediaGroup caption HTML rejected; retrying as plain caption: ${formatErrorMessage(
           error,
@@ -205,7 +209,7 @@ export async function sendTelegramMediaAlbum(
       );
       groupDelivery = await sendGroup(buildInputs(plainCaption, undefined));
       deliveredCaption = plainCaption;
-    } else if (isTelegramEmptyContentError(error) && htmlCaption) {
+    } else if (isTelegramEmptyContentError(error) && albumCaption) {
       groupDelivery = await sendGroup(buildInputs(undefined, undefined));
       deliveredCaption = undefined;
     } else {
@@ -231,22 +235,6 @@ export async function sendTelegramMediaAlbum(
   const mediaUsedReplyTo = resolveAcceptedReplyToMessageId(acceptedMediaParams) !== undefined;
   const primaryMessageId = resolveTelegramMessageIdOrThrow(primary, "media group send");
   const resolvedChatId = String(primary.chat?.id ?? chatId);
-  // Telegram rejects reply_markup on sendMediaGroup, so the inline keyboard is
-  // attached to the accepted primary message afterwards. A failed edit keeps
-  // the delivered album but reports a partial delivery, mirroring the
-  // single-media recovery pattern.
-  let keyboardError: unknown;
-  if (!needsSeparateText && replyMarkup) {
-    try {
-      await api.editMessageReplyMarkup(resolvedChatId, primaryMessageId, {
-        reply_markup: replyMarkup,
-      });
-    } catch (editError) {
-      keyboardError = editError;
-    }
-  }
-  const hasInlineKeyboard =
-    !needsSeparateText && Boolean(replyMarkup) && keyboardError === undefined;
   const albumResults = results.map((message) => ({
     messageId: String(resolveTelegramMessageIdOrThrow(message, "media group send")),
     chatId: resolvedChatId,
@@ -262,7 +250,7 @@ export async function sendTelegramMediaAlbum(
         result: message,
         acceptedParams: groupDelivery.acceptedParams,
         plainText: isPrimary ? (deliveredCaption ?? "") : "",
-        hasInlineKeyboard: isPrimary ? hasInlineKeyboard : false,
+        hasInlineKeyboard: false,
       },
       async () => {
         recordSentMessage(chatId, messageId, cfg, {
@@ -272,10 +260,9 @@ export async function sendTelegramMediaAlbum(
         if (!isPrimary) {
           return;
         }
-        const meta = {
-          ...(deliveredCaption ? { telegramDeliveredText: deliveredCaption } : {}),
-          telegramHasInlineKeyboard: hasInlineKeyboard,
-        };
+        const meta: { telegramDeliveredText?: string } = deliveredCaption
+          ? { telegramDeliveredText: deliveredCaption }
+          : {};
         telegramCaptionDeliveryMetadata.add(meta);
         mediaDeliveryResult = await reportDelivery(
           messageId,
@@ -327,35 +314,37 @@ export async function sendTelegramMediaAlbum(
     direction: "outbound",
   });
 
-  if (keyboardError !== undefined) {
-    // The album was delivered; only the inline keyboard edit failed.
-    throw createChannelPartialDeliveryError(keyboardError, {
-      messageIds: albumResults.map((entry) => entry.messageId),
-      receipt: albumReceipt,
-      visibleReplySent: true,
-    });
-  }
-
-  // If text was too long for a caption, send it as a separate follow-up message.
-  if (needsSeparateText && followUpText) {
+  // When text was too long for a caption, or an inline keyboard was requested
+  // (albums cannot host buttons), deliver the text as a separate follow-up
+  // message; the buttons ride on its final chunk. With no text to accompany the
+  // keyboard, the buttons-only host falls back to the channel's control text.
+  if (needsSeparateText) {
+    const followUpSendText =
+      followUpText ??
+      (replyMarkup ? albumText?.trim() || TELEGRAM_CONTROL_ONLY_FALLBACK : undefined);
+    if (!followUpSendText) {
+      return {
+        messageId: String(primaryMessageId),
+        chatId: resolvedChatId,
+        ...(mediaDeliveryResult?.meta ? { meta: mediaDeliveryResult.meta } : {}),
+        receipt: albumReceipt,
+      };
+    }
     let textResult: TelegramSendResult;
     try {
-      textResult = await sendChunkedText(followUpText, "media group text follow-up send", {
+      textResult = await sendChunkedText(followUpSendText, "media group text follow-up send", {
         replyToAlreadyUsed: singleUseReplyTo && mediaUsedReplyTo,
       });
     } catch (error) {
       if (!isChannelPartialDeliveryError(error) && isTelegramEmptyContentError(error)) {
         await recordDeliveredPromptContext({ message: primary, messageId: primaryMessageId }, true);
-        const finalMediaResult = mediaDeliveryResult ?? {
-          messageId: String(primaryMessageId),
-          chatId: resolvedChatId,
-        };
-        if (!hasInlineKeyboard) {
-          return finalMediaResult;
-        }
-        const meta = { ...finalMediaResult.meta, telegramHasInlineKeyboard: true };
-        telegramCaptionDeliveryMetadata.add(meta);
-        return { ...finalMediaResult, meta };
+        return (
+          mediaDeliveryResult ?? {
+            messageId: String(primaryMessageId),
+            chatId: resolvedChatId,
+            receipt: albumReceipt,
+          }
+        );
       }
       await recordDeliveredPromptContext({ message: primary, messageId: primaryMessageId }, false);
       return sender.fail(error);

--- a/extensions/telegram/src/send-media-group.ts
+++ b/extensions/telegram/src/send-media-group.ts
@@ -399,7 +399,9 @@ export async function sendTelegramMediaAlbum(
     receipt.parts = receipt.parts.map((part, index) => ({
       ...part,
       index,
-      ...(index === 0 ? { kind: "media" } : {}),
+      // Every accepted album message is physical media; only the follow-up text
+      // chunks that come after them are text parts.
+      ...(index < albumResults.length ? { kind: "media" } : {}),
       ...(mediaReplyToId &&
       (index < albumResults.length || (!textResult.receipt && !singleUseReplyTo))
         ? { replyToId: mediaReplyToId }

--- a/extensions/telegram/src/send-media-group.ts
+++ b/extensions/telegram/src/send-media-group.ts
@@ -1,0 +1,355 @@
+import { InputFile } from "grammy";
+import type { InlineKeyboardMarkup, InputMediaPhoto, InputMediaVideo, Message } from "grammy/types";
+import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
+import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
+import type { ResolvedTelegramAccount } from "./accounts.js";
+import { telegramCaptionDeliveryMetadata } from "./caption.js";
+import { prepareTelegramOutboundMedia } from "./outbound-media.js";
+import type { TelegramOutboundPromptContextMessage as TelegramMessageLike } from "./outbound-message-context.js";
+import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
+import { isTelegramEmptyContentError, isTelegramHtmlParseError } from "./rich-plain-fallback.js";
+import {
+  logTelegramOutboundSendOk,
+  resolveAcceptedReplyToMessageId,
+  resolveTelegramMessageIdOrThrow,
+  toAcceptedThreadScopedParams,
+  type TelegramApi,
+  type TelegramThreadScopedParams,
+} from "./send-context.js";
+import type { TelegramSendOpts, TelegramSendResult } from "./send-message-types.js";
+import { createTelegramPreparedSender } from "./send-prepared.js";
+import {
+  buildOutboundMediaLoadOptions,
+  loadWebMedia,
+  type OpenClawConfig,
+} from "./send.runtime.js";
+import { recordSentMessage } from "./sent-message-cache.js";
+
+const MAX_TELEGRAM_MEDIA_GROUP_ITEMS = 10;
+
+type ReportTelegramDelivery = (
+  messageId: string | number,
+  deliveredChatId: string | number,
+  message: TelegramMessageLike,
+  meta?: TelegramSendResult["meta"],
+  kind?: "text" | "media",
+  onPrepared?: (delivery: TelegramSendResult) => void,
+) => Promise<TelegramSendResult>;
+
+type RecordDeliveredPromptContext = (
+  params: Omit<
+    Parameters<typeof recordOutboundMessageForPromptContext>[0],
+    "cfg" | "account" | "botUserId" | "chatId" | "promptContextProjection"
+  >,
+  finalPart: boolean,
+) => Promise<void>;
+
+export type TelegramMediaGroupSendContext = {
+  cfg: OpenClawConfig;
+  account: ResolvedTelegramAccount;
+  ownerAgentId: string;
+  api: TelegramApi;
+  chatId: string;
+  preparedThreadParams: TelegramThreadScopedParams;
+  sender: ReturnType<typeof createTelegramPreparedSender>;
+  singleUseReplyTo: boolean;
+  replyMarkup: InlineKeyboardMarkup | undefined;
+  mediaMaxBytes: number;
+  textMode: "markdown" | "html";
+  tableMode: MarkdownTableMode;
+  reportDelivery: ReportTelegramDelivery;
+  recordDeliveredPromptContext: RecordDeliveredPromptContext;
+  shouldSendTelegramImageAsPhoto: (buffer: Buffer) => Promise<boolean>;
+  sendChunkedText: (
+    rawText: string,
+    context: string,
+    options?: {
+      replyToAlreadyUsed?: boolean;
+      beforeFirstAccepted?: () => Promise<void>;
+    },
+  ) => Promise<TelegramSendResult>;
+  opts: TelegramSendOpts;
+};
+
+/**
+ * Sends multiple photos/videos as a single Telegram album (media group).
+ * Returns undefined when the media group path is not applicable so callers can
+ * fall back to sending each attachment as its own message.
+ */
+export async function sendTelegramMediaAlbum(
+  context: TelegramMediaGroupSendContext,
+  urls: readonly string[],
+  albumText: string,
+): Promise<TelegramSendResult | undefined> {
+  const {
+    cfg,
+    account,
+    ownerAgentId,
+    api,
+    chatId,
+    preparedThreadParams,
+    sender,
+    singleUseReplyTo,
+    replyMarkup,
+    mediaMaxBytes,
+    textMode,
+    tableMode,
+    reportDelivery,
+    recordDeliveredPromptContext,
+    shouldSendTelegramImageAsPhoto,
+    sendChunkedText,
+    opts,
+  } = context;
+  if (
+    urls.length < 2 ||
+    urls.length > MAX_TELEGRAM_MEDIA_GROUP_ITEMS ||
+    opts.asVoice ||
+    opts.asVideoNote ||
+    opts.forceDocument
+  ) {
+    return undefined;
+  }
+  const loadOptions = buildOutboundMediaLoadOptions({
+    maxBytes: mediaMaxBytes,
+    mediaAccess: opts.mediaAccess,
+    mediaLocalRoots: opts.mediaLocalRoots,
+    mediaReadFile: opts.mediaReadFile,
+  });
+  let loaded: Array<Awaited<ReturnType<typeof loadWebMedia>>>;
+  try {
+    loaded = await Promise.all(urls.map((url) => loadWebMedia(url, loadOptions)));
+  } catch (error) {
+    logVerbose(
+      `telegram media group load failed; falling back to separate sends: ${formatErrorMessage(
+        error,
+      )}`,
+    );
+    return undefined;
+  }
+  const plans: Array<{
+    media: Awaited<ReturnType<typeof loadWebMedia>>;
+    plan: ReturnType<typeof prepareTelegramOutboundMedia>;
+  }> = [];
+  for (const media of loaded) {
+    const plan = prepareTelegramOutboundMedia({ media, textMode, tableMode });
+    if (
+      plan.isGif ||
+      plan.isVideoNote ||
+      (plan.deliveryKind !== "image" && plan.deliveryKind !== "video")
+    ) {
+      return undefined;
+    }
+    if (plan.deliveryKind === "image" && !(await shouldSendTelegramImageAsPhoto(media.buffer))) {
+      return undefined;
+    }
+    plans.push({ media, plan });
+  }
+
+  // Only the first media carries the caption; the rest are captionless.
+  const firstPlan = prepareTelegramOutboundMedia({
+    media: loaded[0]!,
+    text: albumText,
+    textMode,
+    tableMode,
+  });
+  const { followUpText } = firstPlan;
+  const htmlCaption = firstPlan.htmlCaption;
+  const plainCaption = firstPlan.plainCaption;
+  const needsSeparateText = Boolean(followUpText);
+
+  const buildInputs = (
+    captionValue: string | undefined,
+    parseMode: "HTML" | undefined,
+  ): Array<InputMediaPhoto | InputMediaVideo> =>
+    plans.map(({ media, plan }, index) => {
+      const mediaRef = new InputFile(media.buffer, plan.fileName);
+      const input: InputMediaPhoto | InputMediaVideo =
+        plan.deliveryKind === "video"
+          ? { type: "video", media: mediaRef }
+          : { type: "photo", media: mediaRef };
+      if (index === 0 && captionValue) {
+        input.caption = captionValue;
+        if (parseMode) {
+          input.parse_mode = parseMode;
+        }
+      }
+      return input;
+    });
+
+  const groupParams: Record<string, unknown> = {
+    ...preparedThreadParams,
+    ...(opts.silent === true ? { disable_notification: true } : {}),
+    ...(!needsSeparateText && replyMarkup ? { reply_markup: replyMarkup } : {}),
+  };
+  const sendGroup = (inputs: Array<InputMediaPhoto | InputMediaVideo>) =>
+    sender.request("sendMediaGroup", groupParams, (effective) =>
+      api.sendMediaGroup(chatId, inputs, effective),
+    );
+  let groupDelivery: { result: Message[]; acceptedParams: Record<string, unknown> };
+  let deliveredCaption: string | undefined;
+  try {
+    groupDelivery = await sendGroup(buildInputs(htmlCaption, "HTML"));
+    deliveredCaption = plainCaption;
+  } catch (error) {
+    if (isTelegramHtmlParseError(error) && plainCaption) {
+      logVerbose(
+        `telegram sendMediaGroup caption HTML rejected; retrying as plain caption: ${formatErrorMessage(
+          error,
+        )}`,
+      );
+      groupDelivery = await sendGroup(buildInputs(plainCaption, undefined));
+      deliveredCaption = plainCaption;
+    } else if (isTelegramEmptyContentError(error) && htmlCaption) {
+      groupDelivery = await sendGroup(buildInputs(undefined, undefined));
+      deliveredCaption = undefined;
+    } else {
+      // Telegram sends are explicitly non-idempotent: a reset or timeout can
+      // occur after the album was accepted. Falling back to per-media sends
+      // here could duplicate user-visible media, so propagate the uncertain
+      // outcome instead of resending every item.
+      opts.promptContextProjectionPlan?.cursor.invalidate();
+      logVerbose(
+        `telegram sendMediaGroup failed; propagating instead of resending: ${formatErrorMessage(
+          error,
+        )}`,
+      );
+      throw error;
+    }
+  }
+  const results = groupDelivery.result;
+  const primary = results[0];
+  if (!primary) {
+    throw new Error("Telegram media group send returned no messages");
+  }
+  const acceptedMediaParams = toAcceptedThreadScopedParams(groupDelivery.acceptedParams);
+  const mediaUsedReplyTo = resolveAcceptedReplyToMessageId(acceptedMediaParams) !== undefined;
+  const primaryMessageId = resolveTelegramMessageIdOrThrow(primary, "media group send");
+  const resolvedChatId = String(primary.chat?.id ?? chatId);
+  const hasInlineKeyboard = !needsSeparateText && Boolean(replyMarkup);
+  const albumResults = results.map((message) => ({
+    messageId: String(resolveTelegramMessageIdOrThrow(message, "media group send")),
+    chatId: resolvedChatId,
+  }));
+  let mediaDeliveryResult: TelegramSendResult | undefined;
+  // Every physical album message stays in delivery custody so a later observer
+  // or follow-up failure reports all delivered ids, not just the primary one.
+  for (const [index, message] of results.entries()) {
+    const isPrimary = index === 0;
+    const messageId = resolveTelegramMessageIdOrThrow(message, "media group send");
+    await sender.accept(
+      {
+        result: message,
+        acceptedParams: groupDelivery.acceptedParams,
+        plainText: isPrimary ? (deliveredCaption ?? "") : "",
+        hasInlineKeyboard: isPrimary ? hasInlineKeyboard : false,
+      },
+      async () => {
+        recordSentMessage(chatId, messageId, cfg, {
+          accountId: account.accountId,
+          agentId: ownerAgentId,
+        });
+        if (!isPrimary) {
+          return;
+        }
+        const meta = {
+          ...(deliveredCaption ? { telegramDeliveredText: deliveredCaption } : {}),
+          telegramHasInlineKeyboard: hasInlineKeyboard,
+        };
+        telegramCaptionDeliveryMetadata.add(meta);
+        mediaDeliveryResult = await reportDelivery(
+          messageId,
+          resolvedChatId,
+          message,
+          meta,
+          "media",
+          (delivery) => {
+            mediaDeliveryResult = delivery;
+          },
+        );
+        if (!needsSeparateText) {
+          await recordDeliveredPromptContext(
+            {
+              message,
+              messageId,
+              ...(deliveredCaption ? { text: deliveredCaption } : {}),
+              ...(acceptedMediaParams?.message_thread_id !== undefined
+                ? { messageThreadId: acceptedMediaParams.message_thread_id }
+                : {}),
+            },
+            true,
+          );
+        }
+      },
+      () => ({
+        ...(mediaDeliveryResult?.receipt ? { receipt: mediaDeliveryResult.receipt } : {}),
+        visibleReplySent: true,
+      }),
+    );
+  }
+  const albumReceipt = createMessageReceiptFromOutboundResults({
+    results: albumResults,
+    kind: "media",
+  });
+  logTelegramOutboundSendOk({
+    accountId: account.accountId,
+    chatId: resolvedChatId,
+    messageId: String(primaryMessageId),
+    operation: "sendMediaGroup",
+    deliveryKind: "media_group",
+    messageThreadId: acceptedMediaParams?.message_thread_id,
+    replyToMessageId: opts.replyToMessageId,
+    silent: opts.silent,
+  });
+  recordChannelActivity({
+    channel: "telegram",
+    accountId: account.accountId,
+    direction: "outbound",
+  });
+
+  // If text was too long for a caption, send it as a separate follow-up message.
+  if (needsSeparateText && followUpText) {
+    let textResult: TelegramSendResult;
+    try {
+      textResult = await sendChunkedText(followUpText, "media group text follow-up send", {
+        replyToAlreadyUsed: singleUseReplyTo && mediaUsedReplyTo,
+      });
+    } catch (error) {
+      if (!isChannelPartialDeliveryError(error) && isTelegramEmptyContentError(error)) {
+        await recordDeliveredPromptContext({ message: primary, messageId: primaryMessageId }, true);
+        const finalMediaResult = mediaDeliveryResult ?? {
+          messageId: String(primaryMessageId),
+          chatId: resolvedChatId,
+        };
+        if (!hasInlineKeyboard) {
+          return finalMediaResult;
+        }
+        const meta = { ...finalMediaResult.meta, telegramHasInlineKeyboard: true };
+        telegramCaptionDeliveryMetadata.add(meta);
+        return { ...finalMediaResult, meta };
+      }
+      await recordDeliveredPromptContext({ message: primary, messageId: primaryMessageId }, false);
+      return sender.fail(error);
+    }
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [...albumResults, textResult],
+      kind: "text",
+    });
+    receipt.parts = receipt.parts.map((part, index) => ({
+      ...part,
+      index,
+      ...(index === 0 ? { kind: "media" } : {}),
+    }));
+    return { ...textResult, chatId: resolvedChatId, receipt };
+  }
+
+  return {
+    messageId: String(primaryMessageId),
+    chatId: resolvedChatId,
+    ...(mediaDeliveryResult?.meta ? { meta: mediaDeliveryResult.meta } : {}),
+    receipt: albumReceipt,
+  };
+}

--- a/extensions/telegram/src/send-media-group.ts
+++ b/extensions/telegram/src/send-media-group.ts
@@ -245,6 +245,28 @@ export async function sendTelegramMediaAlbum(
   // later report/projection failure must not strand accepted siblings outside
   // the partial-delivery id list.
   const custodyStart = sender.parts.length;
+  // The album primary enters prompt context exactly once. Without a text
+  // follow-up it is the final part; with a follow-up (caption overflow or
+  // buttons) it is recorded before the first follow-up chunk is accepted so
+  // the visible album survives even when the caption/controls move to text.
+  let albumPromptContextRecorded = false;
+  const recordAlbumPromptContext = async (finalPart: boolean) => {
+    if (albumPromptContextRecorded) {
+      return;
+    }
+    albumPromptContextRecorded = true;
+    await recordDeliveredPromptContext(
+      {
+        message: primary,
+        messageId: primaryMessageId,
+        ...(deliveredCaption ? { text: deliveredCaption } : {}),
+        ...(acceptedMediaParams?.message_thread_id !== undefined
+          ? { messageThreadId: acceptedMediaParams.message_thread_id }
+          : {}),
+      },
+      finalPart,
+    );
+  };
   const acceptedParts = results.map((message, index) =>
     sender.register({
       result: message,
@@ -279,17 +301,7 @@ export async function sendTelegramMediaAlbum(
         },
       );
       if (!needsSeparateText) {
-        await recordDeliveredPromptContext(
-          {
-            message: accepted.result,
-            messageId,
-            ...(deliveredCaption ? { text: deliveredCaption } : {}),
-            ...(acceptedMediaParams?.message_thread_id !== undefined
-              ? { messageThreadId: acceptedMediaParams.message_thread_id }
-              : {}),
-          },
-          true,
-        );
+        await recordAlbumPromptContext(true);
       }
     }
   } catch (error) {
@@ -338,6 +350,11 @@ export async function sendTelegramMediaAlbum(
     try {
       textResult = await sendChunkedText(followUpSendText, "media group text follow-up send", {
         replyToAlreadyUsed: singleUseReplyTo && mediaUsedReplyTo,
+        // The follow-up text carries the caption/controls, but the already
+        // accepted album is the visible media. Record it before the first
+        // follow-up chunk so a successful caption/button host still leaves the
+        // album in prompt context (mirrors the single-media long-caption path).
+        beforeFirstAccepted: () => recordAlbumPromptContext(false),
       });
     } catch (error) {
       // The follow-up text is the only possible host for an over-length caption
@@ -347,16 +364,13 @@ export async function sendTelegramMediaAlbum(
       // accepted album must be reported as a partial delivery that keeps every
       // album message id and the complete album receipt.
       if (!isChannelPartialDeliveryError(error) && isTelegramEmptyContentError(error)) {
-        await recordDeliveredPromptContext(
-          { message: primary, messageId: primaryMessageId },
-          false,
-        );
+        await recordAlbumPromptContext(false);
         return sender.fail(error, custodyStart, {
           receipt: albumReceipt,
           visibleReplySent: true,
         });
       }
-      await recordDeliveredPromptContext({ message: primary, messageId: primaryMessageId }, false);
+      await recordAlbumPromptContext(false);
       return sender.fail(error);
     }
     const receipt = createMessageReceiptFromOutboundResults({

--- a/extensions/telegram/src/send-media-group.ts
+++ b/extensions/telegram/src/send-media-group.ts
@@ -340,15 +340,21 @@ export async function sendTelegramMediaAlbum(
         replyToAlreadyUsed: singleUseReplyTo && mediaUsedReplyTo,
       });
     } catch (error) {
+      // The follow-up text is the only possible host for an over-length caption
+      // or an inline keyboard: albums cannot carry either. When that text is
+      // rejected as empty content, the requested caption or controls were not
+      // delivered even though Telegram accepted the whole media group, so the
+      // accepted album must be reported as a partial delivery that keeps every
+      // album message id and the complete album receipt.
       if (!isChannelPartialDeliveryError(error) && isTelegramEmptyContentError(error)) {
-        await recordDeliveredPromptContext({ message: primary, messageId: primaryMessageId }, true);
-        return (
-          mediaDeliveryResult ?? {
-            messageId: String(primaryMessageId),
-            chatId: resolvedChatId,
-            receipt: albumReceipt,
-          }
+        await recordDeliveredPromptContext(
+          { message: primary, messageId: primaryMessageId },
+          false,
         );
+        return sender.fail(error, custodyStart, {
+          receipt: albumReceipt,
+          visibleReplySent: true,
+        });
       }
       await recordDeliveredPromptContext({ message: primary, messageId: primaryMessageId }, false);
       return sender.fail(error);

--- a/extensions/telegram/src/send-media-group.ts
+++ b/extensions/telegram/src/send-media-group.ts
@@ -1,7 +1,10 @@
 import { InputFile } from "grammy";
 import type { InlineKeyboardMarkup, InputMediaPhoto, InputMediaVideo, Message } from "grammy/types";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
-import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
 import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -183,7 +186,6 @@ export async function sendTelegramMediaAlbum(
   const groupParams: Record<string, unknown> = {
     ...preparedThreadParams,
     ...(opts.silent === true ? { disable_notification: true } : {}),
-    ...(!needsSeparateText && replyMarkup ? { reply_markup: replyMarkup } : {}),
   };
   const sendGroup = (inputs: Array<InputMediaPhoto | InputMediaVideo>) =>
     sender.request("sendMediaGroup", groupParams, (effective) =>
@@ -229,7 +231,22 @@ export async function sendTelegramMediaAlbum(
   const mediaUsedReplyTo = resolveAcceptedReplyToMessageId(acceptedMediaParams) !== undefined;
   const primaryMessageId = resolveTelegramMessageIdOrThrow(primary, "media group send");
   const resolvedChatId = String(primary.chat?.id ?? chatId);
-  const hasInlineKeyboard = !needsSeparateText && Boolean(replyMarkup);
+  // Telegram rejects reply_markup on sendMediaGroup, so the inline keyboard is
+  // attached to the accepted primary message afterwards. A failed edit keeps
+  // the delivered album but reports a partial delivery, mirroring the
+  // single-media recovery pattern.
+  let keyboardError: unknown;
+  if (!needsSeparateText && replyMarkup) {
+    try {
+      await api.editMessageReplyMarkup(resolvedChatId, primaryMessageId, {
+        reply_markup: replyMarkup,
+      });
+    } catch (editError) {
+      keyboardError = editError;
+    }
+  }
+  const hasInlineKeyboard =
+    !needsSeparateText && Boolean(replyMarkup) && keyboardError === undefined;
   const albumResults = results.map((message) => ({
     messageId: String(resolveTelegramMessageIdOrThrow(message, "media group send")),
     chatId: resolvedChatId,
@@ -309,6 +326,15 @@ export async function sendTelegramMediaAlbum(
     accountId: account.accountId,
     direction: "outbound",
   });
+
+  if (keyboardError !== undefined) {
+    // The album was delivered; only the inline keyboard edit failed.
+    throw createChannelPartialDeliveryError(keyboardError, {
+      messageIds: albumResults.map((entry) => entry.messageId),
+      receipt: albumReceipt,
+      visibleReplySent: true,
+    });
+  }
 
   // If text was too long for a caption, send it as a separate follow-up message.
   if (needsSeparateText && followUpText) {

--- a/extensions/telegram/src/send-media-group.ts
+++ b/extensions/telegram/src/send-media-group.ts
@@ -285,6 +285,15 @@ export async function sendTelegramMediaAlbum(
       hasInlineKeyboard: false,
     }),
   );
+  // The complete album receipt is derived before any fallible observer runs so
+  // a report/projection failure after Telegram accepts the group reports every
+  // accepted sibling (id list AND receipt), not just the primary item's result.
+  const albumReceipt = createMessageReceiptFromOutboundResults({
+    results: albumResults,
+    kind: "media",
+    ...(albumThreadId !== undefined ? { threadId: String(albumThreadId) } : {}),
+    ...(mediaReplyToId ? { replyToId: mediaReplyToId } : {}),
+  });
   try {
     for (const [index, accepted] of acceptedParts.entries()) {
       const isPrimary = index === 0;
@@ -316,16 +325,10 @@ export async function sendTelegramMediaAlbum(
     }
   } catch (error) {
     return sender.fail(error, custodyStart, {
-      ...(mediaDeliveryResult?.receipt ? { receipt: mediaDeliveryResult.receipt } : {}),
+      receipt: albumReceipt,
       visibleReplySent: true,
     });
   }
-  const albumReceipt = createMessageReceiptFromOutboundResults({
-    results: albumResults,
-    kind: "media",
-    ...(albumThreadId !== undefined ? { threadId: String(albumThreadId) } : {}),
-    ...(mediaReplyToId ? { replyToId: mediaReplyToId } : {}),
-  });
   logTelegramOutboundSendOk({
     accountId: account.accountId,
     chatId: resolvedChatId,

--- a/extensions/telegram/src/send-media-group.ts
+++ b/extensions/telegram/src/send-media-group.ts
@@ -232,7 +232,19 @@ export async function sendTelegramMediaAlbum(
     throw new Error("Telegram media group send returned no messages");
   }
   const acceptedMediaParams = toAcceptedThreadScopedParams(groupDelivery.acceptedParams);
-  const mediaUsedReplyTo = resolveAcceptedReplyToMessageId(acceptedMediaParams) !== undefined;
+  const mediaReplyToId = resolveAcceptedReplyToMessageId(acceptedMediaParams)?.toString();
+  const mediaUsedReplyTo = mediaReplyToId !== undefined;
+  // The accepted topic can arrive as message_thread_id (forum/bot-private DMs)
+  // or direct_messages_topic_id (channel Direct Messages topics). Both are the
+  // accepted routing fact a downstream receipt must preserve.
+  const acceptedParams = groupDelivery.acceptedParams as {
+    message_thread_id?: unknown;
+    direct_messages_topic_id?: unknown;
+  };
+  const albumThreadId = [
+    acceptedParams.message_thread_id,
+    acceptedParams.direct_messages_topic_id,
+  ].find((value) => typeof value === "number" && Number.isFinite(value)) as number | undefined;
   const primaryMessageId = resolveTelegramMessageIdOrThrow(primary, "media group send");
   const resolvedChatId = String(primary.chat?.id ?? chatId);
   const albumResults = results.map((message) => ({
@@ -260,9 +272,7 @@ export async function sendTelegramMediaAlbum(
         message: primary,
         messageId: primaryMessageId,
         ...(deliveredCaption ? { text: deliveredCaption } : {}),
-        ...(acceptedMediaParams?.message_thread_id !== undefined
-          ? { messageThreadId: acceptedMediaParams.message_thread_id }
-          : {}),
+        ...(albumThreadId !== undefined ? { messageThreadId: albumThreadId } : {}),
       },
       finalPart,
     );
@@ -313,6 +323,8 @@ export async function sendTelegramMediaAlbum(
   const albumReceipt = createMessageReceiptFromOutboundResults({
     results: albumResults,
     kind: "media",
+    ...(albumThreadId !== undefined ? { threadId: String(albumThreadId) } : {}),
+    ...(mediaReplyToId ? { replyToId: mediaReplyToId } : {}),
   });
   logTelegramOutboundSendOk({
     accountId: account.accountId,
@@ -320,7 +332,7 @@ export async function sendTelegramMediaAlbum(
     messageId: String(primaryMessageId),
     operation: "sendMediaGroup",
     deliveryKind: "media_group",
-    messageThreadId: acceptedMediaParams?.message_thread_id,
+    messageThreadId: albumThreadId,
     replyToMessageId: opts.replyToMessageId,
     silent: opts.silent,
   });
@@ -376,11 +388,22 @@ export async function sendTelegramMediaAlbum(
     const receipt = createMessageReceiptFromOutboundResults({
       results: [...albumResults, textResult],
       kind: "text",
+      ...(albumThreadId !== undefined ? { threadId: String(albumThreadId) } : {}),
     });
+    if (mediaReplyToId) {
+      receipt.replyToId = mediaReplyToId;
+    }
+    // The whole album shared one accepted route: every album part keeps the
+    // topic/reply facts. The follow-up text only inherits the reply when it was
+    // itself sent as a reply (mirrors the single-media long-caption path).
     receipt.parts = receipt.parts.map((part, index) => ({
       ...part,
       index,
       ...(index === 0 ? { kind: "media" } : {}),
+      ...(mediaReplyToId &&
+      (index < albumResults.length || (!textResult.receipt && !singleUseReplyTo))
+        ? { replyToId: mediaReplyToId }
+        : {}),
     }));
     return { ...textResult, chatId: resolvedChatId, receipt };
   }

--- a/extensions/telegram/src/send-media-group.ts
+++ b/extensions/telegram/src/send-media-group.ts
@@ -240,59 +240,63 @@ export async function sendTelegramMediaAlbum(
     chatId: resolvedChatId,
   }));
   let mediaDeliveryResult: TelegramSendResult | undefined;
-  // Every physical album message stays in delivery custody so a later observer
-  // or follow-up failure reports all delivered ids, not just the primary one.
-  for (const [index, message] of results.entries()) {
-    const isPrimary = index === 0;
-    const messageId = resolveTelegramMessageIdOrThrow(message, "media group send");
-    await sender.accept(
-      {
-        result: message,
-        acceptedParams: groupDelivery.acceptedParams,
-        plainText: isPrimary ? (deliveredCaption ?? "") : "",
-        hasInlineKeyboard: false,
-      },
-      async () => {
-        recordSentMessage(chatId, messageId, cfg, {
-          accountId: account.accountId,
-          agentId: ownerAgentId,
-        });
-        if (!isPrimary) {
-          return;
-        }
-        const meta: { telegramDeliveredText?: string } = deliveredCaption
-          ? { telegramDeliveredText: deliveredCaption }
-          : {};
-        telegramCaptionDeliveryMetadata.add(meta);
-        mediaDeliveryResult = await reportDelivery(
-          messageId,
-          resolvedChatId,
-          message,
-          meta,
-          "media",
-          (delivery) => {
-            mediaDeliveryResult = delivery;
+  // Every accepted album message enters delivery custody BEFORE any fallible
+  // observer runs. Telegram has already accepted the whole media group, so a
+  // later report/projection failure must not strand accepted siblings outside
+  // the partial-delivery id list.
+  const custodyStart = sender.parts.length;
+  const acceptedParts = results.map((message, index) =>
+    sender.register({
+      result: message,
+      acceptedParams: groupDelivery.acceptedParams,
+      plainText: index === 0 ? (deliveredCaption ?? "") : "",
+      hasInlineKeyboard: false,
+    }),
+  );
+  try {
+    for (const [index, accepted] of acceptedParts.entries()) {
+      const isPrimary = index === 0;
+      const messageId = accepted.messageId;
+      recordSentMessage(chatId, messageId, cfg, {
+        accountId: account.accountId,
+        agentId: ownerAgentId,
+      });
+      if (!isPrimary) {
+        continue;
+      }
+      const meta: { telegramDeliveredText?: string } = deliveredCaption
+        ? { telegramDeliveredText: deliveredCaption }
+        : {};
+      telegramCaptionDeliveryMetadata.add(meta);
+      mediaDeliveryResult = await reportDelivery(
+        messageId,
+        resolvedChatId,
+        accepted.result,
+        meta,
+        "media",
+        (delivery) => {
+          mediaDeliveryResult = delivery;
+        },
+      );
+      if (!needsSeparateText) {
+        await recordDeliveredPromptContext(
+          {
+            message: accepted.result,
+            messageId,
+            ...(deliveredCaption ? { text: deliveredCaption } : {}),
+            ...(acceptedMediaParams?.message_thread_id !== undefined
+              ? { messageThreadId: acceptedMediaParams.message_thread_id }
+              : {}),
           },
+          true,
         );
-        if (!needsSeparateText) {
-          await recordDeliveredPromptContext(
-            {
-              message,
-              messageId,
-              ...(deliveredCaption ? { text: deliveredCaption } : {}),
-              ...(acceptedMediaParams?.message_thread_id !== undefined
-                ? { messageThreadId: acceptedMediaParams.message_thread_id }
-                : {}),
-            },
-            true,
-          );
-        }
-      },
-      () => ({
-        ...(mediaDeliveryResult?.receipt ? { receipt: mediaDeliveryResult.receipt } : {}),
-        visibleReplySent: true,
-      }),
-    );
+      }
+    }
+  } catch (error) {
+    return sender.fail(error, custodyStart, {
+      ...(mediaDeliveryResult?.receipt ? { receipt: mediaDeliveryResult.receipt } : {}),
+      visibleReplySent: true,
+    });
   }
   const albumReceipt = createMessageReceiptFromOutboundResults({
     results: albumResults,

--- a/extensions/telegram/src/send-message-types.ts
+++ b/extensions/telegram/src/send-message-types.ts
@@ -13,6 +13,8 @@ export type TelegramSendOpts = {
   accountId?: string;
   verbose?: boolean;
   mediaUrl?: string;
+  /** Multiple media URLs/paths sent together. Telegram groups 2-10 photos/videos into a single album message. */
+  mediaUrls?: readonly string[];
   mediaAccess?: OutboundMediaAccess;
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;

--- a/extensions/telegram/src/send-message.ts
+++ b/extensions/telegram/src/send-message.ts
@@ -234,8 +234,18 @@ async function sendMessageTelegramWithContext(
   }
 
   // Sends a single media attachment (photo/document/animation/audio/video/voice)
-  // following the established per-media delivery semantics.
-  const sendSingleMedia = async (singleMediaUrl: string): Promise<TelegramSendResult> => {
+  // following the established per-media delivery semantics. When part of a
+  // multi-media sequence (album fallback), only the first item carries the
+  // caption, inline keyboard, and implicit reply target, and only the last item
+  // finalizes the prompt-context projection — mirroring the media-sequence
+  // policy used by the payload transport.
+  const sendSingleMedia = async (
+    singleMediaUrl: string,
+    sequence?: { isFirst: boolean; isLast: boolean },
+  ): Promise<TelegramSendResult> => {
+    const isFirst = sequence?.isFirst ?? true;
+    const isLast = sequence?.isLast ?? true;
+    const itemText = isFirst ? text : "";
     const media = await loadWebMedia(
       singleMediaUrl,
       buildOutboundMediaLoadOptions({
@@ -248,7 +258,7 @@ async function sendMessageTelegramWithContext(
     );
     const mediaPlan = prepareTelegramOutboundMedia({
       media,
-      text,
+      text: itemText,
       textMode,
       tableMode,
       forceDocument: opts.forceDocument,
@@ -273,11 +283,11 @@ async function sendMessageTelegramWithContext(
     const needsSeparateText = Boolean(followUpText);
     // When splitting, put reply_markup only on the follow-up text (the "main" content),
     // not on the media message.
-    const mediaThreadParams = preparedThreadParams;
+    const mediaThreadParams = isFirst ? preparedThreadParams : buildThreadParams(false);
     const mediaUsedReplyTo = resolveAcceptedReplyToMessageId(mediaThreadParams) !== undefined;
     const baseMediaParams = {
       ...mediaThreadParams,
-      ...(!needsSeparateText && replyMarkup ? { reply_markup: replyMarkup } : {}),
+      ...(!needsSeparateText && isFirst && replyMarkup ? { reply_markup: replyMarkup } : {}),
     };
     const videoDimensions =
       mediaPlan.deliveryKind === "video" && !mediaPlan.isVideoNote
@@ -301,7 +311,7 @@ async function sendMessageTelegramWithContext(
       if (
         mediaSender.label === "voice" &&
         isTelegramVoiceMessagesForbiddenError(error) &&
-        text.trim()
+        itemText.trim()
       ) {
         logVerbose(
           "telegram sendVoice forbidden by recipient privacy settings; falling back to text",
@@ -364,9 +374,9 @@ async function sendMessageTelegramWithContext(
           accountId: account.accountId,
           agentId: ownerAgentId,
         });
-        await reportMediaDelivery(!needsSeparateText && Boolean(replyMarkup));
+        await reportMediaDelivery(!needsSeparateText && isFirst && Boolean(replyMarkup));
         if (!needsSeparateText) {
-          await recordMediaPromptContext(true);
+          await recordMediaPromptContext(isLast);
         }
       },
       () => ({
@@ -503,10 +513,15 @@ async function sendMessageTelegramWithContext(
     }
     // The media group path is not applicable (mixed/non-album media types, count
     // outside 2-10, or the group request failed); fall back to sending each media
-    // attachment as its own message with the established per-media semantics.
+    // attachment as its own message with the established per-media sequencing:
+    // first-item metadata (caption, keyboard, implicit reply) is not repeated.
+    const lastIndex = allMediaUrls.length - 1;
     let lastResult: TelegramSendResult | undefined;
-    for (const entry of allMediaUrls) {
-      lastResult = await sendSingleMedia(entry);
+    for (const [index, entry] of allMediaUrls.entries()) {
+      lastResult = await sendSingleMedia(entry, {
+        isFirst: index === 0,
+        isLast: index === lastIndex,
+      });
     }
     return lastResult!;
   }

--- a/extensions/telegram/src/send-message.ts
+++ b/extensions/telegram/src/send-message.ts
@@ -30,6 +30,7 @@ import {
   type TelegramApiContext,
 } from "./send-context.js";
 import { isTelegramVoiceMessagesForbiddenError } from "./send-error-predicates.js";
+import { sendTelegramMediaAlbum } from "./send-media-group.js";
 import { createTelegramTextSender } from "./send-message-text.js";
 import type { TelegramSendOpts, TelegramSendResult } from "./send-message-types.js";
 import { prepareTelegramOutbound, reportTelegramProviderDelivery } from "./send-outbound.js";
@@ -131,6 +132,10 @@ async function sendMessageTelegramWithContext(
     }
   };
   const mediaUrl = opts.mediaUrl?.trim();
+  const mediaUrls = (opts.mediaUrls ?? [])
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter(Boolean);
+  const allMediaUrls = mediaUrls.length > 0 ? mediaUrls : mediaUrl ? [mediaUrl] : [];
   const mediaMaxBytes =
     opts.maxBytes ??
     (typeof account.config.mediaMaxMb === "number" ? account.config.mediaMaxMb : 100) * 1024 * 1024;
@@ -228,9 +233,11 @@ async function sendMessageTelegramWithContext(
     }
   }
 
-  if (mediaUrl) {
+  // Sends a single media attachment (photo/document/animation/audio/video/voice)
+  // following the established per-media delivery semantics.
+  const sendSingleMedia = async (singleMediaUrl: string): Promise<TelegramSendResult> => {
     const media = await loadWebMedia(
-      mediaUrl,
+      singleMediaUrl,
       buildOutboundMediaLoadOptions({
         maxBytes: mediaMaxBytes,
         mediaAccess: opts.mediaAccess,
@@ -462,6 +469,46 @@ async function sendMessageTelegramWithContext(
           chatId: resolvedChatId,
           ...(mediaDeliveryResult?.receipt ? { receipt: mediaDeliveryResult.receipt } : {}),
         };
+  };
+
+  if (allMediaUrls.length > 0) {
+    if (allMediaUrls.length === 1) {
+      return await sendSingleMedia(allMediaUrls[0]!);
+    }
+    const albumResult = await sendTelegramMediaAlbum(
+      {
+        cfg,
+        account,
+        ownerAgentId,
+        api,
+        chatId,
+        preparedThreadParams,
+        sender,
+        singleUseReplyTo,
+        replyMarkup,
+        mediaMaxBytes,
+        textMode,
+        tableMode,
+        reportDelivery,
+        recordDeliveredPromptContext,
+        shouldSendTelegramImageAsPhoto,
+        sendChunkedText,
+        opts,
+      },
+      allMediaUrls,
+      text,
+    );
+    if (albumResult) {
+      return albumResult;
+    }
+    // The media group path is not applicable (mixed/non-album media types, count
+    // outside 2-10, or the group request failed); fall back to sending each media
+    // attachment as its own message with the established per-media semantics.
+    let lastResult: TelegramSendResult | undefined;
+    for (const entry of allMediaUrls) {
+      lastResult = await sendSingleMedia(entry);
+    }
+    return lastResult!;
   }
 
   if (!text || !text.trim()) {

--- a/extensions/telegram/src/send-prepared.ts
+++ b/extensions/telegram/src/send-prepared.ts
@@ -67,7 +67,8 @@ export type TelegramPreparedSendPart = {
 };
 
 type TextFallback = { index: number; count: number };
-type AcceptedPart = TelegramPreparedSendPart & { messageId: number };
+export type TelegramPreparedAcceptedPart = TelegramPreparedSendPart & { messageId: number };
+type AcceptedPart = TelegramPreparedAcceptedPart;
 type ObservePart = (part: AcceptedPart) => Promise<void>;
 type PartialDeliveryResult = Parameters<typeof mergeTelegramPartialDeliveryError>[1];
 type Tracking = Omit<
@@ -118,6 +119,11 @@ export function createTelegramPreparedSender(config: {
       fail(error, 0, details?.());
     }
   };
+  // Registers provider-accepted parts without running a fallible observer.
+  // Multi-result sends (media groups) register every accepted item first so a
+  // later observer failure cannot strand accepted siblings outside custody.
+  const register = (part: TelegramPreparedSendPart): TelegramPreparedAcceptedPart =>
+    recordAcceptance(part);
   const request = <T>(
     label: string,
     requestParams: Record<string, unknown>,
@@ -317,7 +323,7 @@ export function createTelegramPreparedSender(config: {
       sender: delivery.sender,
     };
   };
-  return { parts, accept, fail, sendText, sendMedia, request };
+  return { parts, accept, register, fail, sendText, sendMedia, request };
 }
 
 export type TelegramPreparedSender = ReturnType<typeof createTelegramPreparedSender>;

--- a/extensions/telegram/src/send-prepared.ts
+++ b/extensions/telegram/src/send-prepared.ts
@@ -317,7 +317,7 @@ export function createTelegramPreparedSender(config: {
       sender: delivery.sender,
     };
   };
-  return { parts, accept, fail, sendText, sendMedia };
+  return { parts, accept, fail, sendText, sendMedia, request };
 }
 
 export type TelegramPreparedSender = ReturnType<typeof createTelegramPreparedSender>;

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -4891,6 +4891,65 @@ describe("sendMessageTelegram media group (album)", () => {
     expect(sendMediaGroup).toHaveBeenCalledTimes(1);
   });
 
+  it("reports an empty album text follow-up as a partial delivery with every album id", async () => {
+    const chatId = "123";
+    const sendMediaGroup = vi.fn().mockResolvedValue([
+      { message_id: 160, chat: { id: chatId } },
+      { message_id: 161, chat: { id: chatId } },
+    ]);
+    const sendMessage = vi.fn().mockRejectedValue(new Error("Bad Request: text must be non-empty"));
+    const api = makeTelegramApiTestMock({ sendMediaGroup, sendMessage });
+
+    loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
+
+    // When the album needs a separate text message to host an inline keyboard,
+    // an empty-content rejection means the controls were never delivered. The
+    // accepted album is a partial delivery, not a success: recovery must keep
+    // every accepted album message id and the complete album receipt.
+    const error = await sendMessageTelegram(chatId, "album caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+      buttons: [[{ text: "Open", url: "https://example.com" }]],
+    }).catch((caught: unknown) => caught);
+
+    expect(isChannelPartialDeliveryError(error)).toBe(true);
+    if (!isChannelPartialDeliveryError(error)) {
+      throw error;
+    }
+    expect([...(error.deliveryResult.messageIds ?? [])].toSorted()).toEqual(["160", "161"]);
+    expect(error.deliveryResult.receipt?.platformMessageIds).toEqual(["160", "161"]);
+    expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an empty over-length caption follow-up as partial delivery with the album receipt", async () => {
+    const chatId = "123";
+    const sendMediaGroup = vi.fn().mockResolvedValue([
+      { message_id: 170, chat: { id: chatId } },
+      { message_id: 171, chat: { id: chatId } },
+    ]);
+    const sendMessage = vi.fn().mockRejectedValue(new Error("Bad Request: text must be non-empty"));
+    const api = makeTelegramApiTestMock({ sendMediaGroup, sendMessage });
+
+    loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
+
+    const error = await sendMessageTelegram(chatId, "x".repeat(1200), {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+    }).catch((caught: unknown) => caught);
+
+    expect(isChannelPartialDeliveryError(error)).toBe(true);
+    if (!isChannelPartialDeliveryError(error)) {
+      throw error;
+    }
+    expect([...(error.deliveryResult.messageIds ?? [])].toSorted()).toEqual(["170", "171"]);
+    expect(error.deliveryResult.receipt?.platformMessageIds).toEqual(["170", "171"]);
+    expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to separate photo sends when a media group item is not album-compatible", async () => {
     const chatId = "123";
     const sendPhoto = vi.fn().mockResolvedValue({ message_id: 200, chat: { id: chatId } });

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -4950,6 +4950,59 @@ describe("sendMessageTelegram media group (album)", () => {
     expect(sendMediaGroup).toHaveBeenCalledTimes(1);
   });
 
+  it("records the accepted album before a successful text follow-up", async () => {
+    const storePath = `/tmp/openclaw-telegram-album-before-followup-${process.pid}-${Date.now()}.json`;
+    const chatId = "123";
+    const sendMediaGroup = vi.fn().mockResolvedValue([
+      { message_id: 180, chat: { id: chatId } },
+      { message_id: 181, chat: { id: chatId } },
+    ]);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 182, chat: { id: chatId } });
+    const api = makeTelegramApiTestMock({ sendMediaGroup, sendMessage });
+    const cursor = createTelegramPromptContextProjectionCursor({
+      transcriptMessageId: "assistant-album-before-followup",
+    });
+
+    loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
+
+    // A successful caption/button follow-up must still record the already
+    // accepted album into prompt context before the first text chunk lands,
+    // mirroring the single-media long-caption path.
+    const res = await sendMessageTelegram(chatId, "album caption", {
+      cfg: { session: { store: storePath } },
+      token: "tok",
+      api,
+      mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+      buttons: [[{ text: "Open", url: "https://example.com" }]],
+      promptContextProjectionPlan: { cursor, finalPart: true },
+    });
+
+    expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(res.messageId).toBe("182");
+    const cache = createTelegramMessageCache({
+      scope: resolveTelegramMessageCacheScope(storePath),
+    });
+    const cachedAlbum = await cache.get({
+      accountId: "default",
+      chatId,
+      messageId: "180",
+    });
+    const cachedText = await cache.get({
+      accountId: "default",
+      chatId,
+      messageId: "182",
+    });
+    expect(cachedAlbum?.promptContextProjectionMarker).toEqual({
+      kind: "valid",
+      projection: { ...cursor.source, partIndex: 0, finalPart: false },
+    });
+    expect(cachedText?.promptContextProjectionMarker).toEqual({
+      kind: "valid",
+      projection: { ...cursor.source, partIndex: 1, finalPart: true },
+    });
+  });
+
   it("falls back to separate photo sends when a media group item is not album-compatible", async () => {
     const chatId = "123";
     const sendPhoto = vi.fn().mockResolvedValue({ message_id: 200, chat: { id: chatId } });

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -4733,6 +4733,147 @@ describe("sendMessageTelegram", () => {
   });
 });
 
+describe("sendMessageTelegram media group (album)", () => {
+  function mockMediaByUrl(url: string) {
+    return {
+      buffer: Buffer.from(url),
+      ...(url.endsWith(".pdf")
+        ? { contentType: "application/pdf", fileName: "doc.pdf" }
+        : {
+            contentType: "image/png",
+            fileName: url.split("/").pop() ?? "media",
+          }),
+    };
+  }
+
+  it("groups 2+ photos into a single sendMediaGroup album with caption on the first", async () => {
+    const chatId = "123";
+    const sendMediaGroup = vi.fn().mockResolvedValue([
+      { message_id: 100, chat: { id: chatId } },
+      { message_id: 101, chat: { id: chatId } },
+    ]);
+    const api = makeTelegramApiTestMock({ sendMediaGroup });
+
+    loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
+
+    const res = await sendMessageTelegram(chatId, "album caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+    });
+
+    const [actualChatId, inputs, params] = requireMockCall(
+      firstMockCall(sendMediaGroup, "sendMediaGroup call"),
+      "sendMediaGroup call",
+    );
+    expect(actualChatId).toBe(chatId);
+    expect(Array.isArray(inputs)).toBe(true);
+    const mediaInputs = inputs as Array<Record<string, unknown>>;
+    expect(mediaInputs.map(({ type }) => type)).toEqual(["photo", "photo"]);
+    expect(mediaInputs[0]?.caption).toBe("album caption");
+    expect(mediaInputs[0]?.parse_mode).toBe("HTML");
+    expect(mediaInputs[1]?.caption).toBeUndefined();
+    expect((mediaInputs[0]?.media as { filename?: string })?.filename).toBe("a.png");
+    expect((mediaInputs[1]?.media as { filename?: string })?.filename).toBe("b.png");
+    expect(params).toEqual({});
+    expect(res.messageId).toBe("100");
+    expect(res.chatId).toBe(chatId);
+  });
+
+  it("falls back to separate photo sends when a media group item is not album-compatible", async () => {
+    const chatId = "123";
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 200, chat: { id: chatId } });
+    const sendDocument = vi.fn().mockResolvedValue({ message_id: 201, chat: { id: chatId } });
+    const api = makeTelegramApiTestMock({ sendPhoto, sendDocument });
+
+    loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
+
+    const res = await sendMessageTelegram(chatId, "caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrls: ["https://example.com/a.png", "https://example.com/doc.pdf"],
+    });
+
+    expect(sendPhoto).toHaveBeenCalledTimes(1);
+    expect(sendDocument).toHaveBeenCalledTimes(1);
+    expect(res.messageId).toBe("201");
+  });
+
+  it("propagates an ambiguous media group failure instead of resending per media", async () => {
+    const chatId = "123";
+    const sendMediaGroup = vi.fn().mockRejectedValue(new Error("500: Internal Server Error"));
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 300, chat: { id: chatId } });
+    const api = makeTelegramApiTestMock({ sendMediaGroup, sendPhoto });
+
+    loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
+
+    await expect(
+      sendMessageTelegram(chatId, "caption", {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api,
+        mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+      }),
+    ).rejects.toThrow(/500: Internal Server Error/);
+
+    // Telegram sends are non-idempotent: an ambiguous post-dispatch failure must
+    // never trigger duplicate per-media sends.
+    expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+    expect(sendPhoto).not.toHaveBeenCalled();
+  });
+
+  it("keeps every album message in delivery custody and receipts", async () => {
+    const chatId = "123";
+    const sendMediaGroup = vi.fn().mockResolvedValue([
+      { message_id: 100, chat: { id: chatId } },
+      { message_id: 101, chat: { id: chatId } },
+      { message_id: 102, chat: { id: chatId } },
+    ]);
+    const api = makeTelegramApiTestMock({ sendMediaGroup });
+
+    loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
+
+    const res = await sendMessageTelegram(chatId, "album caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrls: [
+        "https://example.com/a.png",
+        "https://example.com/b.png",
+        "https://example.com/c.png",
+      ],
+    });
+
+    expect(res.messageId).toBe("100");
+    expect(res.receipt?.primaryPlatformMessageId).toBe("100");
+    expect(res.receipt?.platformMessageIds).toEqual(["100", "101", "102"]);
+    expect(res.receipt?.parts).toHaveLength(3);
+  });
+
+  it("uses the single-media path for a single mediaUrls entry", async () => {
+    const chatId = "123";
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 400, chat: { id: chatId } });
+    const api = makeTelegramApiTestMock({ sendPhoto });
+
+    mockLoadedMedia({ contentType: "image/png", fileName: "a.png" });
+
+    const res = await sendMessageTelegram(chatId, "caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrls: ["https://example.com/a.png"],
+    });
+
+    expectMediaSendCall(firstMockCall(sendPhoto, "send photo call"), "send photo call", chatId, {
+      caption: "caption",
+      parse_mode: "HTML",
+    });
+    expect(res.messageId).toBe("400");
+  });
+});
+
 describe("reactMessageTelegram", () => {
   it.each([
     {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -5114,6 +5114,113 @@ describe("sendMessageTelegram media group (album)", () => {
     expect(res.receipt?.parts).toHaveLength(3);
   });
 
+  it("preserves forum topic routing on an album receipt", async () => {
+    const chatId = "-1001234567890";
+    const sendMediaGroup = vi.fn().mockResolvedValue([
+      { message_id: 900, message_thread_id: 271, chat: { id: chatId, type: "supergroup" } },
+      { message_id: 901, message_thread_id: 271, chat: { id: chatId, type: "supergroup" } },
+    ]);
+    const api = makeTelegramApiTestMock({ sendMediaGroup });
+
+    loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
+
+    const res = await sendMessageTelegram(chatId, "album caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+      messageThreadId: 271,
+    });
+
+    expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+    const groupParams = requireMockCall(
+      firstMockCall(sendMediaGroup, "sendMediaGroup call"),
+      "sendMediaGroup call",
+    )[2] as Record<string, unknown>;
+    expect(groupParams.message_thread_id).toBe(271);
+    expect(res.messageId).toBe("900");
+    expect(res.receipt?.threadId).toBe("271");
+    expect(res.receipt?.parts.map(({ threadId, replyToId }) => ({ threadId, replyToId }))).toEqual([
+      { threadId: "271", replyToId: undefined },
+      { threadId: "271", replyToId: undefined },
+    ]);
+  });
+
+  it("preserves explicit native reply routing on an album receipt", async () => {
+    const chatId = "123";
+    const sendMediaGroup = vi.fn().mockResolvedValue([
+      { message_id: 910, chat: { id: chatId } },
+      { message_id: 911, chat: { id: chatId } },
+    ]);
+    const api = makeTelegramApiTestMock({ sendMediaGroup });
+
+    loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
+
+    const res = await sendMessageTelegram(chatId, "album caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+      replyToMessageId: 500,
+      replyToIdSource: "explicit",
+      replyToMode: "all",
+    });
+
+    expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+    expect(res.messageId).toBe("910");
+    expect(res.receipt?.replyToId).toBe("500");
+    expect(res.receipt?.parts.map((part) => part.replyToId)).toEqual(["500", "500"]);
+  });
+
+  it("preserves topic and reply routing on an album caption follow-up", async () => {
+    const chatId = "-1001234567890";
+    const longText = "A".repeat(1100);
+    const sendMediaGroup = vi.fn().mockResolvedValue([
+      { message_id: 920, message_thread_id: 271, chat: { id: chatId, type: "supergroup" } },
+      { message_id: 921, message_thread_id: 271, chat: { id: chatId, type: "supergroup" } },
+    ]);
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 922,
+      message_thread_id: 271,
+      chat: { id: chatId, type: "supergroup" },
+    });
+    const api = makeTelegramApiTestMock({ sendMediaGroup, sendMessage });
+
+    loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
+
+    // An over-length caption is delivered as a follow-up text message. The
+    // album (one media group send) keeps the accepted topic and implicit reply;
+    // the first-mode reply is single-use, so the follow-up text does not reply.
+    const res = await sendMessageTelegram(chatId, longText, {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+      messageThreadId: 271,
+      replyToMessageId: 500,
+      replyToIdSource: "implicit",
+      replyToMode: "first",
+    });
+
+    expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(res.messageId).toBe("922");
+    expect(res.receipt?.threadId).toBe("271");
+    expect(res.receipt?.replyToId).toBe("500");
+    expect(
+      res.receipt?.parts.map(({ kind, index, threadId, replyToId }) => ({
+        kind,
+        index,
+        threadId,
+        replyToId,
+      })),
+    ).toEqual([
+      { kind: "media", index: 0, threadId: "271", replyToId: "500" },
+      { kind: "text", index: 1, threadId: "271", replyToId: "500" },
+      { kind: "text", index: 2, threadId: "271", replyToId: undefined },
+    ]);
+  });
+
   it("uses the single-media path for a single mediaUrls entry", async () => {
     const chatId = "123";
     const sendPhoto = vi.fn().mockResolvedValue({ message_id: 400, chat: { id: chatId } });

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -4801,6 +4801,46 @@ describe("sendMessageTelegram media group (album)", () => {
     expect(res.messageId).toBe("201");
   });
 
+  it("preserves first-item metadata across album fallback sends", async () => {
+    const chatId = "123";
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 210, chat: { id: chatId } });
+    const sendDocument = vi.fn().mockResolvedValue({ message_id: 211, chat: { id: chatId } });
+    const api = makeTelegramApiTestMock({ sendPhoto, sendDocument });
+
+    loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
+
+    const res = await sendMessageTelegram(chatId, "shared caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrls: [
+        "https://example.com/a.png",
+        "https://example.com/b.pdf",
+        "https://example.com/c.pdf",
+      ],
+      replyToMessageId: 42,
+      buttons: [[{ text: "Open", url: "https://example.com" }]],
+    });
+
+    expect(sendPhoto).toHaveBeenCalledTimes(1);
+    expect(sendDocument).toHaveBeenCalledTimes(2);
+
+    // First physical send carries the one-time metadata...
+    const photoParams = sendPhoto.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(photoParams.caption).toBe("shared caption");
+    expect(photoParams.reply_to_message_id).toBe(42);
+    expect(photoParams.reply_markup).toBeDefined();
+
+    // ...and later sends must not repeat it.
+    for (const call of sendDocument.mock.calls) {
+      const docParams = call[2] as Record<string, unknown>;
+      expect(docParams.caption).toBeUndefined();
+      expect(docParams.reply_to_message_id).toBeUndefined();
+      expect(docParams.reply_markup).toBeUndefined();
+    }
+    expect(res.messageId).toBe("211");
+  });
+
   it("propagates an ambiguous media group failure instead of resending per media", async () => {
     const chatId = "123";
     const sendMediaGroup = vi.fn().mockRejectedValue(new Error("500: Internal Server Error"));

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -4888,6 +4888,11 @@ describe("sendMessageTelegram media group (album)", () => {
     expect(isChannelPartialDeliveryError(error)).toBe(true);
     const deliveryResult = (error as { deliveryResult?: { messageIds?: string[] } }).deliveryResult;
     expect([...(deliveryResult?.messageIds ?? [])].toSorted()).toEqual(["140", "141"]);
+    // The partial delivery must carry the complete album receipt (both accepted
+    // messages), not just the primary item's observer result.
+    const receipt = (error as { deliveryResult?: { receipt?: { platformMessageIds?: string[] } } })
+      .deliveryResult?.receipt;
+    expect(receipt?.platformMessageIds).toEqual(["140", "141"]);
     expect(sendMediaGroup).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -4781,16 +4781,15 @@ describe("sendMessageTelegram media group (album)", () => {
     expect(res.chatId).toBe(chatId);
   });
 
-  it("attaches inline keyboards to the accepted primary album message", async () => {
+  it("hosts album inline buttons on a caption follow-up message", async () => {
     const chatId = "123";
     const sendMediaGroup = vi.fn().mockResolvedValue([
       { message_id: 110, chat: { id: chatId } },
       { message_id: 111, chat: { id: chatId } },
     ]);
-    const editMessageReplyMarkup = vi
-      .fn()
-      .mockResolvedValue({ message_id: 110, chat: { id: chatId } });
-    const api = makeTelegramApiTestMock({ sendMediaGroup, editMessageReplyMarkup });
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 120, chat: { id: chatId } });
+    const editMessageReplyMarkup = vi.fn();
+    const api = makeTelegramApiTestMock({ sendMediaGroup, sendMessage, editMessageReplyMarkup });
 
     loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
 
@@ -4802,46 +4801,68 @@ describe("sendMessageTelegram media group (album)", () => {
       buttons: [[{ text: "Open", url: "https://example.com" }]],
     });
 
-    // sendMediaGroup must not carry reply_markup: Telegram rejects that
-    // parameter for media group sends.
-    const groupParams = requireMockCall(
+    // Telegram albums cannot host an inline keyboard (no reply_markup on
+    // sendMediaGroup, and editMessageReplyMarkup on an album message is
+    // rejected), so the media group is sent captionless without a retrofit;
+    // the caption text and buttons are delivered on a follow-up message.
+    const [groupChatId, inputs, groupParams] = requireMockCall(
       firstMockCall(sendMediaGroup, "sendMediaGroup call"),
       "sendMediaGroup call",
-    )[2] as Record<string, unknown>;
-    expect(groupParams.reply_markup).toBeUndefined();
+    );
+    expect(groupChatId).toBe(chatId);
+    const mediaInputs = inputs as Array<Record<string, unknown>>;
+    expect(mediaInputs.map(({ type }) => type)).toEqual(["photo", "photo"]);
+    expect(mediaInputs[0]?.caption).toBeUndefined();
+    expect(mediaInputs[1]?.caption).toBeUndefined();
+    expect((groupParams as Record<string, unknown>).reply_markup).toBeUndefined();
+    expect(editMessageReplyMarkup).not.toHaveBeenCalled();
 
-    // The keyboard is attached to the accepted primary message instead.
-    expect(editMessageReplyMarkup).toHaveBeenCalledTimes(1);
-    expect(editMessageReplyMarkup.mock.calls[0]?.[0]).toBe(chatId);
-    expect(editMessageReplyMarkup.mock.calls[0]?.[1]).toBe(110);
-    expect(res.messageId).toBe("110");
-    expect(res.meta?.telegramHasInlineKeyboard).toBe(true);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const [textChatId, text, textParams] = sendMessage.mock.calls[0]!;
+    expect(textChatId).toBe(chatId);
+    expect(text).toBe("album caption");
+    expect((textParams as Record<string, unknown>).reply_markup).toEqual({
+      inline_keyboard: [[{ text: "Open", url: "https://example.com" }]],
+    });
+    expect(res.messageId).toBe("120");
   });
 
-  it("reports a partial delivery when the album keyboard edit fails", async () => {
+  it("hosts album buttons on the control text when no caption is set", async () => {
     const chatId = "123";
     const sendMediaGroup = vi.fn().mockResolvedValue([
       { message_id: 130, chat: { id: chatId } },
       { message_id: 131, chat: { id: chatId } },
     ]);
-    const editMessageReplyMarkup = vi.fn().mockRejectedValue(new Error("400: Bad Request"));
-    const api = makeTelegramApiTestMock({ sendMediaGroup, editMessageReplyMarkup });
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 132, chat: { id: chatId } });
+    const api = makeTelegramApiTestMock({ sendMediaGroup, sendMessage });
 
     loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
 
-    const error = await sendMessageTelegram(chatId, "album caption", {
+    const res = await sendMessageTelegram(chatId, "", {
       cfg: TELEGRAM_TEST_CFG,
       token: "tok",
       api,
       mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
       buttons: [[{ text: "Open", url: "https://example.com" }]],
-    }).catch((caught: unknown) => caught);
+    });
 
-    // The album itself was delivered; the failed keyboard edit surfaces as a
-    // partial delivery instead of a resend.
-    expect(isChannelPartialDeliveryError(error)).toBe(true);
     expect(sendMediaGroup).toHaveBeenCalledTimes(1);
-    expect(editMessageReplyMarkup).toHaveBeenCalledTimes(1);
+    const mediaInputs = requireMockCall(
+      firstMockCall(sendMediaGroup, "sendMediaGroup call"),
+      "sendMediaGroup call",
+    )[1] as Array<Record<string, unknown>>;
+    expect(mediaInputs[0]?.caption).toBeUndefined();
+
+    // With no caption the keyboard still needs a text host, so the channel's
+    // buttons-only fallback text is used.
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const [textChatId, text, textParams] = sendMessage.mock.calls[0]!;
+    expect(textChatId).toBe(chatId);
+    expect(text).toBe("Choose an option.");
+    expect((textParams as Record<string, unknown>).reply_markup).toEqual({
+      inline_keyboard: [[{ text: "Open", url: "https://example.com" }]],
+    });
+    expect(res.messageId).toBe("132");
   });
 
   it("falls back to separate photo sends when a media group item is not album-compatible", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -5207,6 +5207,9 @@ describe("sendMessageTelegram media group (album)", () => {
     expect(res.messageId).toBe("922");
     expect(res.receipt?.threadId).toBe("271");
     expect(res.receipt?.replyToId).toBe("500");
+    // Every accepted album message keeps kind media; only the follow-up text
+    // chunk after them is a text part.
+    expect(res.receipt?.parts.map((part) => part.kind)).toEqual(["media", "media", "text"]);
     expect(
       res.receipt?.parts.map(({ kind, index, threadId, replyToId }) => ({
         kind,
@@ -5216,7 +5219,7 @@ describe("sendMessageTelegram media group (album)", () => {
       })),
     ).toEqual([
       { kind: "media", index: 0, threadId: "271", replyToId: "500" },
-      { kind: "text", index: 1, threadId: "271", replyToId: "500" },
+      { kind: "media", index: 1, threadId: "271", replyToId: "500" },
       { kind: "text", index: 2, threadId: "271", replyToId: undefined },
     ]);
   });

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -4865,6 +4865,32 @@ describe("sendMessageTelegram media group (album)", () => {
     expect(res.messageId).toBe("132");
   });
 
+  it("registers every accepted album item before a delivery observer failure", async () => {
+    const chatId = "123";
+    const sendMediaGroup = vi.fn().mockResolvedValue([
+      { message_id: 140, chat: { id: chatId } },
+      { message_id: 141, chat: { id: chatId } },
+    ]);
+    const api = makeTelegramApiTestMock({ sendMediaGroup });
+
+    loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
+
+    const error = await sendMessageTelegram(chatId, "album caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+      // The primary delivery observer fails after Telegram accepted the whole
+      // media group; custody must still cover both accepted album messages.
+      onDeliveryResult: vi.fn().mockRejectedValue(new Error("delivery observer failed")),
+    }).catch((caught: unknown) => caught);
+
+    expect(isChannelPartialDeliveryError(error)).toBe(true);
+    const deliveryResult = (error as { deliveryResult?: { messageIds?: string[] } }).deliveryResult;
+    expect([...(deliveryResult?.messageIds ?? [])].toSorted()).toEqual(["140", "141"]);
+    expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to separate photo sends when a media group item is not album-compatible", async () => {
     const chatId = "123";
     const sendPhoto = vi.fn().mockResolvedValue({ message_id: 200, chat: { id: chatId } });

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -4781,6 +4781,69 @@ describe("sendMessageTelegram media group (album)", () => {
     expect(res.chatId).toBe(chatId);
   });
 
+  it("attaches inline keyboards to the accepted primary album message", async () => {
+    const chatId = "123";
+    const sendMediaGroup = vi.fn().mockResolvedValue([
+      { message_id: 110, chat: { id: chatId } },
+      { message_id: 111, chat: { id: chatId } },
+    ]);
+    const editMessageReplyMarkup = vi
+      .fn()
+      .mockResolvedValue({ message_id: 110, chat: { id: chatId } });
+    const api = makeTelegramApiTestMock({ sendMediaGroup, editMessageReplyMarkup });
+
+    loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
+
+    const res = await sendMessageTelegram(chatId, "album caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+      buttons: [[{ text: "Open", url: "https://example.com" }]],
+    });
+
+    // sendMediaGroup must not carry reply_markup: Telegram rejects that
+    // parameter for media group sends.
+    const groupParams = requireMockCall(
+      firstMockCall(sendMediaGroup, "sendMediaGroup call"),
+      "sendMediaGroup call",
+    )[2] as Record<string, unknown>;
+    expect(groupParams.reply_markup).toBeUndefined();
+
+    // The keyboard is attached to the accepted primary message instead.
+    expect(editMessageReplyMarkup).toHaveBeenCalledTimes(1);
+    expect(editMessageReplyMarkup.mock.calls[0]?.[0]).toBe(chatId);
+    expect(editMessageReplyMarkup.mock.calls[0]?.[1]).toBe(110);
+    expect(res.messageId).toBe("110");
+    expect(res.meta?.telegramHasInlineKeyboard).toBe(true);
+  });
+
+  it("reports a partial delivery when the album keyboard edit fails", async () => {
+    const chatId = "123";
+    const sendMediaGroup = vi.fn().mockResolvedValue([
+      { message_id: 130, chat: { id: chatId } },
+      { message_id: 131, chat: { id: chatId } },
+    ]);
+    const editMessageReplyMarkup = vi.fn().mockRejectedValue(new Error("400: Bad Request"));
+    const api = makeTelegramApiTestMock({ sendMediaGroup, editMessageReplyMarkup });
+
+    loadWebMedia.mockImplementation(async (url: string) => mockMediaByUrl(url));
+
+    const error = await sendMessageTelegram(chatId, "album caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+      buttons: [[{ text: "Open", url: "https://example.com" }]],
+    }).catch((caught: unknown) => caught);
+
+    // The album itself was delivered; the failed keyboard edit surfaces as a
+    // partial delivery instead of a resend.
+    expect(isChannelPartialDeliveryError(error)).toBe(true);
+    expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+    expect(editMessageReplyMarkup).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to separate photo sends when a media group item is not album-compatible", async () => {
     const chatId = "123";
     const sendPhoto = vi.fn().mockResolvedValue({ message_id: 200, chat: { id: chatId } });

--- a/src/agents/tools/message-tool-schema-scoping.ts
+++ b/src/agents/tools/message-tool-schema-scoping.ts
@@ -6,7 +6,7 @@ type SchemaProperties = Record<string, TSchema>;
 type SchemaPropertiesBuilder = () => SchemaProperties;
 
 export const MESSAGE_TOOL_SEND_TEXT_DESCRIPTION =
-  'Text for action="send". A send needs message or another send payload such as media, mediaUrls, attachments, or presentation.';
+  'Text for action="send". A send needs message or another send payload such as media, attachments, or presentation.';
 
 export function buildMessageToolQuerySchemaProperties(): SchemaProperties {
   return { query: Type.Optional(Type.String()) };

--- a/src/agents/tools/message-tool-schema-scoping.ts
+++ b/src/agents/tools/message-tool-schema-scoping.ts
@@ -6,7 +6,7 @@ type SchemaProperties = Record<string, TSchema>;
 type SchemaPropertiesBuilder = () => SchemaProperties;
 
 export const MESSAGE_TOOL_SEND_TEXT_DESCRIPTION =
-  'Text for action="send". A send needs message or another send payload such as media, attachments, or presentation.';
+  'Text for action="send". A send needs message or another send payload such as media, mediaUrls, attachments, or presentation.';
 
 export function buildMessageToolQuerySchemaProperties(): SchemaProperties {
   return { query: Type.Optional(Type.String()) };

--- a/src/agents/tools/message-tool-schema.ts
+++ b/src/agents/tools/message-tool-schema.ts
@@ -143,7 +143,14 @@ function buildSendSchema(options: {
     effect: Type.Optional(Type.String({ description: "Alias for effectId." })),
     media: Type.Optional(
       Type.String({
-        description: "Media URL/path. data: use buffer.",
+        description:
+          "Single media URL/path. For multiple media use mediaUrls (or attachments). data: use buffer.",
+      }),
+    ),
+    mediaUrls: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          "Multiple media URLs/paths; sent together when the channel supports grouped media, otherwise as individual attachments.",
       }),
     ),
     filename: Type.Optional(Type.String()),

--- a/src/agents/tools/message-tool-schema.ts
+++ b/src/agents/tools/message-tool-schema.ts
@@ -143,14 +143,7 @@ function buildSendSchema(options: {
     effect: Type.Optional(Type.String({ description: "Alias for effectId." })),
     media: Type.Optional(
       Type.String({
-        description:
-          "Single media URL/path. For multiple media use mediaUrls (or attachments). data: use buffer.",
-      }),
-    ),
-    mediaUrls: Type.Optional(
-      Type.Array(Type.String(), {
-        description:
-          "Multiple media URLs/paths; sent together when the channel supports grouped media, otherwise as individual attachments.",
+        description: "Single media URL/path. For multiple media use attachments. data: use buffer.",
       }),
     ),
     filename: Type.Optional(Type.String()),
@@ -171,7 +164,8 @@ function buildSendSchema(options: {
           mimeType: Type.Optional(Type.String()),
         }),
         {
-          description: "Attachments; each uses media.",
+          description:
+            "Attachments; each uses media. Multiple attachments deliver together when the channel supports grouped media, otherwise as individual messages.",
         },
       ),
     ),

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -3336,7 +3336,7 @@ describe("message tool path passthrough", () => {
     const attachmentProperties = attachments?.items?.properties ?? {};
 
     expect(properties).toHaveProperty("media");
-    expect(properties).toHaveProperty("mediaUrls");
+    expect(properties).not.toHaveProperty("mediaUrls");
     expect(properties).not.toHaveProperty("mediaUrl");
     expect(properties).not.toHaveProperty("path");
     expect(properties).not.toHaveProperty("filePath");

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -3336,8 +3336,8 @@ describe("message tool path passthrough", () => {
     const attachmentProperties = attachments?.items?.properties ?? {};
 
     expect(properties).toHaveProperty("media");
+    expect(properties).toHaveProperty("mediaUrls");
     expect(properties).not.toHaveProperty("mediaUrl");
-    expect(properties).not.toHaveProperty("mediaUrls");
     expect(properties).not.toHaveProperty("path");
     expect(properties).not.toHaveProperty("filePath");
     expect(properties).not.toHaveProperty("fileUrl");

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -119,6 +119,15 @@ export type ChannelPresentationCapabilities = {
 
 export type ChannelDeliveryCapabilities = {
   pin?: boolean;
+  /**
+   * Whether the channel's sendPayload transport delivers 2+ media items as one
+   * grouped platform message with complete custody of every accepted item
+   * (e.g. Telegram media albums). Channels whose payload helper sends each
+   * attachment separately and returns only the last result must NOT set this:
+   * core routes multi-media payloads through sendPayload only for grouped-
+   * capable channels and keeps per-media fanout for everyone else.
+   */
+  sendPayloadGroupsMedia?: boolean;
   durableFinal?: {
     text?: boolean;
     media?: boolean;

--- a/src/infra/outbound/deliver-channel.ts
+++ b/src/infra/outbound/deliver-channel.ts
@@ -266,6 +266,10 @@ function createPluginHandler(
     durableFinalForPayloadGate?.capabilities?.reconcileUnknownSend !== true ||
     durableFinalForPayloadGate.reconcileUnknownSendKinds === undefined ||
     durableFinalForPayloadGate.reconcileUnknownSendKinds.payload === true;
+  // Only a payload transport that groups media and reports every accepted item
+  // (e.g. Telegram albums) may host core multi-media payloads; sequential
+  // payload helpers (e.g. Zalo) stay on the per-media fanout instead.
+  const groupsMultiMediaInPayload = outbound?.deliveryCapabilities?.sendPayloadGroupsMedia === true;
   if (!messageText && !outbound?.sendText) {
     return null;
   }
@@ -336,6 +340,7 @@ function createPluginHandler(
     // formatted-only adapters and records the fallback as a plain sent text.
     supportsMedia: Boolean(messageMedia ?? sendMedia ?? outbound?.sendFormattedMedia),
     reconcilesDurableSendPayload,
+    groupsMultiMediaInPayload,
     sanitizeText: outbound?.sanitizeText
       ? (payload) =>
           outbound.sanitizeText!({

--- a/src/infra/outbound/deliver-channel.ts
+++ b/src/infra/outbound/deliver-channel.ts
@@ -257,6 +257,15 @@ function createPluginHandler(
       );
     }
   };
+  // Mirrors assertUnknownSendReconciliationKind for "payload": lets core keep
+  // multi-media payloads on the reconciled media path when a required durable
+  // send would reject a payload-kind attempt before platform I/O.
+  const durableFinalForPayloadGate = params.message?.durableFinal;
+  const reconcilesDurableSendPayload =
+    params.requiredUnknownSendReconciliation !== true ||
+    durableFinalForPayloadGate?.capabilities?.reconcileUnknownSend !== true ||
+    durableFinalForPayloadGate.reconcileUnknownSendKinds === undefined ||
+    durableFinalForPayloadGate.reconcileUnknownSendKinds.payload === true;
   if (!messageText && !outbound?.sendText) {
     return null;
   }
@@ -326,6 +335,7 @@ function createPluginHandler(
     // over sendMedia), so leaving it out here silently drops media for
     // formatted-only adapters and records the fallback as a plain sent text.
     supportsMedia: Boolean(messageMedia ?? sendMedia ?? outbound?.sendFormattedMedia),
+    reconcilesDurableSendPayload,
     sanitizeText: outbound?.sanitizeText
       ? (payload) =>
           outbound.sanitizeText!({

--- a/src/infra/outbound/deliver-contracts.ts
+++ b/src/infra/outbound/deliver-contracts.ts
@@ -115,6 +115,13 @@ export type ChannelHandler = {
    * channels that only reconcile text/media kinds.
    */
   reconcilesDurableSendPayload?: boolean;
+  /**
+   * Whether sendPayload delivers 2+ media items as one grouped platform message
+   * with complete custody of every accepted item. Core routes multi-media
+   * payloads through sendPayload only for grouped-capable channels; everything
+   * else stays on the per-media fanout.
+   */
+  groupsMultiMediaInPayload?: boolean;
   sendFormattedText?: (
     text: string,
     overrides?: OutboundMessageSendOverrides,

--- a/src/infra/outbound/deliver-contracts.ts
+++ b/src/infra/outbound/deliver-contracts.ts
@@ -108,6 +108,13 @@ export type ChannelHandler = {
     payload: ReplyPayload,
     overrides?: OutboundMessageSendOverrides,
   ) => Promise<OutboundDeliveryResult>;
+  /**
+   * Whether a required durable send reconciliation accepts "payload" attempts.
+   * Only set when the delivery runs with required unknown-send reconciliation;
+   * core uses it to keep multi-media payloads on the reconciled media path for
+   * channels that only reconcile text/media kinds.
+   */
+  reconcilesDurableSendPayload?: boolean;
   sendFormattedText?: (
     text: string,
     overrides?: OutboundMessageSendOverrides,

--- a/src/infra/outbound/deliver-core.ts
+++ b/src/infra/outbound/deliver-core.ts
@@ -362,9 +362,10 @@ export async function deliverOutboundPayloadsCore(
       const beforeCount = results.length;
       let mirroredPayload = payloadSummary;
       let mediaMessageIds: { first?: string; last?: string } | undefined;
-      // Multi-media payloads route through the channel payload transport when
-      // available so a channel can group them (e.g. Telegram albums); the simple
-      // per-media fanout only handles single-media or payload-less channels.
+      // Multi-media payloads route through the channel payload transport only
+      // when the channel declares a grouped multi-media transport (e.g. Telegram
+      // albums) — a payload helper that sends each attachment separately would
+      // otherwise drop every accepted item except the last from core custody.
       // Durable sends additionally require the channel to reconcile "payload"
       // attempts — channels that only reconcile text/media (e.g. Matrix) stay on
       // the fanout so the payload-kind assertion cannot reject before platform I/O.
@@ -373,6 +374,7 @@ export async function deliverOutboundPayloadsCore(
           sendTextOnlyErrorPayloads: deliveryHandler.sendTextOnlyErrorPayloads,
         }) ||
         (payloadSummary.mediaUrls.length >= 2 &&
+          deliveryHandler.groupsMultiMediaInPayload === true &&
           deliveryHandler.reconcilesDurableSendPayload !== false);
       if (deliveryHandler.sendPayload && routesPayloadTransport) {
         const delivery = await deliveryHandler.sendPayload(

--- a/src/infra/outbound/deliver-core.ts
+++ b/src/infra/outbound/deliver-core.ts
@@ -362,12 +362,14 @@ export async function deliverOutboundPayloadsCore(
       const beforeCount = results.length;
       let mirroredPayload = payloadSummary;
       let mediaMessageIds: { first?: string; last?: string } | undefined;
-      if (
-        deliveryHandler.sendPayload &&
+      // Multi-media payloads route through the channel payload transport when
+      // available so a channel can group them (e.g. Telegram albums); the simple
+      // per-media fanout only handles single-media or payload-less channels.
+      const routesPayloadTransport =
         payloadRequiresDurablePayloadTransport(effectivePayload, {
           sendTextOnlyErrorPayloads: deliveryHandler.sendTextOnlyErrorPayloads,
-        })
-      ) {
+        }) || payloadSummary.mediaUrls.length >= 2;
+      if (deliveryHandler.sendPayload && routesPayloadTransport) {
         const delivery = await deliveryHandler.sendPayload(
           effectivePayload,
           withPreparedTarget(applySendReplyToConsumption(sendOverrides)),

--- a/src/infra/outbound/deliver-core.ts
+++ b/src/infra/outbound/deliver-core.ts
@@ -365,10 +365,15 @@ export async function deliverOutboundPayloadsCore(
       // Multi-media payloads route through the channel payload transport when
       // available so a channel can group them (e.g. Telegram albums); the simple
       // per-media fanout only handles single-media or payload-less channels.
+      // Durable sends additionally require the channel to reconcile "payload"
+      // attempts — channels that only reconcile text/media (e.g. Matrix) stay on
+      // the fanout so the payload-kind assertion cannot reject before platform I/O.
       const routesPayloadTransport =
         payloadRequiresDurablePayloadTransport(effectivePayload, {
           sendTextOnlyErrorPayloads: deliveryHandler.sendTextOnlyErrorPayloads,
-        }) || payloadSummary.mediaUrls.length >= 2;
+        }) ||
+        (payloadSummary.mediaUrls.length >= 2 &&
+          deliveryHandler.reconcilesDurableSendPayload !== false);
       if (deliveryHandler.sendPayload && routesPayloadTransport) {
         const delivery = await deliveryHandler.sendPayload(
           effectivePayload,

--- a/src/infra/outbound/deliver.payload-transport.test.ts
+++ b/src/infra/outbound/deliver.payload-transport.test.ts
@@ -1,0 +1,109 @@
+// Covers payload-transport routing for multi-media outbound payloads: channels
+// that expose sendPayload receive the whole media list (so they can group it,
+// e.g. Telegram albums), while single-media payloads stay on the per-media fanout.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMessageReceiptFromOutboundResults } from "../../channels/message/receipt.js";
+import type { ChannelOutboundAdapter } from "../../channels/plugins/types.public.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { deliverOutboundPayloadsCore } from "./deliver-core.js";
+import { createUnmodifiedPreparedOutboundBatch } from "./prepared-batch.js";
+
+const createResult = (messageId: string) => ({
+  channel: "matrix" as const,
+  messageId,
+  receipt: createMessageReceiptFromOutboundResults({
+    results: [{ channel: "matrix", messageId }],
+  }),
+});
+
+function installOutbound(outbound: ChannelOutboundAdapter) {
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "matrix",
+        source: "test",
+        plugin: createOutboundTestPlugin({ id: "matrix", outbound }),
+      },
+    ]),
+  );
+}
+
+async function deliverPayloads(params: {
+  outbound: ChannelOutboundAdapter;
+  payloads: Parameters<typeof createUnmodifiedPreparedOutboundBatch>[0];
+}) {
+  installOutbound(params.outbound);
+  return await deliverOutboundPayloadsCore({
+    cfg: {},
+    channel: "matrix",
+    to: "room-parent",
+    payloads: [...params.payloads],
+    preparedBatch: createUnmodifiedPreparedOutboundBatch(params.payloads),
+  });
+}
+
+afterEach(() => {
+  setActivePluginRegistry(createEmptyPluginRegistry());
+  vi.restoreAllMocks();
+});
+
+describe("outbound payload-transport routing", () => {
+  it("routes a multi-media payload through sendPayload instead of per-media fanout", async () => {
+    const sendPayload = vi.fn(async (ctx: { payload: { mediaUrls?: string[]; text?: string } }) =>
+      createResult(`album:${ctx.payload.mediaUrls?.length}`),
+    );
+    const sendMedia = vi.fn(async ({ mediaUrl }: { mediaUrl?: string }) =>
+      createResult(`media:${mediaUrl}`),
+    );
+    const outbound = {
+      deliveryMode: "direct",
+      sendText: vi.fn(async ({ text }: { text: string }) => createResult(`text:${text}`)),
+      sendPayload,
+      sendMedia,
+    } satisfies ChannelOutboundAdapter;
+
+    const results = await deliverPayloads({
+      outbound,
+      payloads: [
+        {
+          text: "album caption",
+          mediaUrls: ["https://example.com/one.png", "https://example.com/two.png"],
+        },
+      ],
+    });
+
+    expect(sendPayload).toHaveBeenCalledTimes(1);
+    expect(sendMedia).not.toHaveBeenCalled();
+    expect(sendPayload.mock.calls[0]?.[0].payload.mediaUrls).toEqual([
+      "https://example.com/one.png",
+      "https://example.com/two.png",
+    ]);
+    expect(results.map((result) => result.messageId)).toEqual(["album:2"]);
+  });
+
+  it("keeps single-media payloads on the per-media fanout", async () => {
+    const sendPayload = vi.fn(async () => createResult("payload:single"));
+    const sendMedia = vi.fn(async ({ mediaUrl }: { mediaUrl?: string }) =>
+      createResult(`media:${mediaUrl}`),
+    );
+    const outbound = {
+      deliveryMode: "direct",
+      sendText: vi.fn(async ({ text }: { text: string }) => createResult(`text:${text}`)),
+      sendPayload,
+      sendMedia,
+    } satisfies ChannelOutboundAdapter;
+
+    const results = await deliverPayloads({
+      outbound,
+      payloads: [{ text: "single", mediaUrls: ["https://example.com/one.png"] }],
+    });
+
+    expect(sendPayload).not.toHaveBeenCalled();
+    expect(sendMedia).toHaveBeenCalledTimes(1);
+    expect(results.map((result) => result.messageId)).toEqual([
+      "media:https://example.com/one.png",
+    ]);
+  });
+});

--- a/src/infra/outbound/deliver.payload-transport.test.ts
+++ b/src/infra/outbound/deliver.payload-transport.test.ts
@@ -66,6 +66,9 @@ describe("outbound payload-transport routing", () => {
       sendText: vi.fn(async ({ text }: { text: string }) => createResult(`text:${text}`)),
       sendPayload,
       sendMedia,
+      // Album-capable payload transport: sendPayload groups the media and
+      // reports every accepted item, so core may hand over the whole list.
+      deliveryCapabilities: { sendPayloadGroupsMedia: true },
     } satisfies ChannelOutboundAdapter;
 
     const results = await deliverPayloads({
@@ -85,6 +88,39 @@ describe("outbound payload-transport routing", () => {
       "https://example.com/two.png",
     ]);
     expect(results.map((result) => result.messageId)).toEqual(["album:2"]);
+  });
+
+  it("keeps multi-media on the per-media fanout for a sequential payload sender (Zalo-shaped)", async () => {
+    // Zalo's sendPayload helper sends each attachment separately and returns
+    // only the last result; it does not declare grouped multi-media custody, so
+    // core must fan out per item instead of handing the whole list to sendPayload.
+    const sendPayload = vi.fn(async () => createResult("payload:sequential"));
+    const sendMedia = vi.fn(async ({ mediaUrl }: { mediaUrl?: string }) =>
+      createResult(`media:${mediaUrl}`),
+    );
+    const outbound = {
+      deliveryMode: "direct",
+      sendText: vi.fn(async ({ text }: { text: string }) => createResult(`text:${text}`)),
+      sendPayload,
+      sendMedia,
+    } satisfies ChannelOutboundAdapter;
+
+    const results = await deliverPayloads({
+      outbound,
+      payloads: [
+        {
+          text: "album caption",
+          mediaUrls: ["https://example.com/one.png", "https://example.com/two.png"],
+        },
+      ],
+    });
+
+    expect(sendPayload).not.toHaveBeenCalled();
+    expect(sendMedia).toHaveBeenCalledTimes(2);
+    expect(results.map((result) => result.messageId)).toEqual([
+      "media:https://example.com/one.png",
+      "media:https://example.com/two.png",
+    ]);
   });
 
   it("keeps single-media payloads on the per-media fanout", async () => {
@@ -171,6 +207,7 @@ describe("outbound payload-transport routing", () => {
       sendText: vi.fn(async ({ text }: { text: string }) => createResult(`text:${text}`)),
       sendPayload,
       sendMedia,
+      deliveryCapabilities: { sendPayloadGroupsMedia: true },
     } satisfies ChannelOutboundAdapter;
     const plugin = {
       ...createOutboundTestPlugin({ id: "matrix", outbound }),

--- a/src/infra/outbound/deliver.payload-transport.test.ts
+++ b/src/infra/outbound/deliver.payload-transport.test.ts
@@ -19,12 +19,16 @@ const createResult = (messageId: string) => ({
 });
 
 function installOutbound(outbound: ChannelOutboundAdapter) {
+  installPlugin(createOutboundTestPlugin({ id: "matrix", outbound }));
+}
+
+function installPlugin(plugin: ReturnType<typeof createOutboundTestPlugin>) {
   setActivePluginRegistry(
     createTestRegistry([
       {
         pluginId: "matrix",
         source: "test",
-        plugin: createOutboundTestPlugin({ id: "matrix", outbound }),
+        plugin,
       },
     ]),
   );
@@ -105,5 +109,98 @@ describe("outbound payload-transport routing", () => {
     expect(results.map((result) => result.messageId)).toEqual([
       "media:https://example.com/one.png",
     ]);
+  });
+
+  it("keeps durable multi-media on the reconciled media path without payload reconciliation", async () => {
+    const sendPayload = vi.fn(async () => createResult("payload:durable"));
+    const sendMedia = vi.fn(async ({ mediaUrl }: { mediaUrl?: string }) =>
+      createResult(`media:${mediaUrl}`),
+    );
+    const outbound = {
+      deliveryMode: "direct",
+      sendText: vi.fn(async ({ text }: { text: string }) => createResult(`text:${text}`)),
+      sendPayload,
+      sendMedia,
+    } satisfies ChannelOutboundAdapter;
+    // Matrix-style durable declaration: reconciliation covers text and media
+    // only, so a payload-kind attempt must be unreachable for durable sends.
+    const plugin = {
+      ...createOutboundTestPlugin({ id: "matrix", outbound }),
+      message: {
+        durableFinal: {
+          capabilities: { text: true, media: true, reconcileUnknownSend: true },
+          reconcileUnknownSendKinds: { text: true, media: true },
+          reconcileUnknownSend: async () => ({ status: "not_sent" }),
+        },
+      },
+    };
+
+    installPlugin(plugin);
+    const payloads = [
+      {
+        text: "album caption",
+        mediaUrls: ["https://example.com/one.png", "https://example.com/two.png"],
+      },
+    ];
+    const results = await deliverOutboundPayloadsCore({
+      cfg: {},
+      channel: "matrix",
+      to: "room-parent",
+      payloads: [...payloads],
+      preparedBatch: createUnmodifiedPreparedOutboundBatch(payloads),
+      requiredUnknownSendReconciliation: true,
+    });
+
+    expect(sendPayload).not.toHaveBeenCalled();
+    expect(sendMedia).toHaveBeenCalledTimes(2);
+    expect(results.map((result) => result.messageId)).toEqual([
+      "media:https://example.com/one.png",
+      "media:https://example.com/two.png",
+    ]);
+  });
+
+  it("routes durable multi-media through sendPayload when the channel reconciles payload attempts", async () => {
+    const sendPayload = vi.fn(async (ctx: { payload: { mediaUrls?: string[]; text?: string } }) =>
+      createResult(`album:${ctx.payload.mediaUrls?.length}`),
+    );
+    const sendMedia = vi.fn(async ({ mediaUrl }: { mediaUrl?: string }) =>
+      createResult(`media:${mediaUrl}`),
+    );
+    const outbound = {
+      deliveryMode: "direct",
+      sendText: vi.fn(async ({ text }: { text: string }) => createResult(`text:${text}`)),
+      sendPayload,
+      sendMedia,
+    } satisfies ChannelOutboundAdapter;
+    const plugin = {
+      ...createOutboundTestPlugin({ id: "matrix", outbound }),
+      message: {
+        durableFinal: {
+          capabilities: { text: true, media: true, reconcileUnknownSend: true },
+          reconcileUnknownSendKinds: { text: true, media: true, payload: true },
+          reconcileUnknownSend: async () => ({ status: "not_sent" }),
+        },
+      },
+    };
+
+    installPlugin(plugin);
+    const payloads = [
+      {
+        text: "album caption",
+        mediaUrls: ["https://example.com/one.png", "https://example.com/two.png"],
+      },
+    ];
+    const results = await deliverOutboundPayloadsCore({
+      cfg: {},
+      channel: "matrix",
+      to: "room-parent",
+      payloads: [...payloads],
+      preparedBatch: createUnmodifiedPreparedOutboundBatch(payloads),
+      requiredUnknownSendReconciliation: true,
+    });
+
+    expect(sendPayload).toHaveBeenCalledTimes(1);
+    expect(sendMedia).not.toHaveBeenCalled();
+    expect(results.map((result) => result.messageId)).toEqual(["album:2"]);
   });
 });

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -93,11 +93,18 @@
           "type": "boolean"
         },
         "media": {
-          "description": "Media URL/path. data: use buffer.",
+          "description": "Single media URL/path. For multiple media use mediaUrls (or attachments). data: use buffer.",
           "type": "string"
         },
+        "mediaUrls": {
+          "description": "Multiple media URLs/paths; sent together when the channel supports grouped media, otherwise as individual attachments.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "message": {
-          "description": "Text for action=\"send\". A send needs message or another send payload such as media, attachments, or presentation.",
+          "description": "Text for action=\"send\". A send needs message or another send payload such as media, mediaUrls, attachments, or presentation.",
           "type": "string"
         },
         "mimeType": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -31,7 +31,7 @@
           "type": "boolean"
         },
         "attachments": {
-          "description": "Attachments; each uses media.",
+          "description": "Attachments; each uses media. Multiple attachments deliver together when the channel supports grouped media, otherwise as individual messages.",
           "items": {
             "properties": {
               "media": {
@@ -93,18 +93,11 @@
           "type": "boolean"
         },
         "media": {
-          "description": "Single media URL/path. For multiple media use mediaUrls (or attachments). data: use buffer.",
+          "description": "Single media URL/path. For multiple media use attachments. data: use buffer.",
           "type": "string"
         },
-        "mediaUrls": {
-          "description": "Multiple media URLs/paths; sent together when the channel supports grouped media, otherwise as individual attachments.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "message": {
-          "description": "Text for action=\"send\". A send needs message or another send payload such as media, mediaUrls, attachments, or presentation.",
+          "description": "Text for action=\"send\". A send needs message or another send payload such as media, attachments, or presentation.",
           "type": "string"
         },
         "mimeType": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=d34d752dc536112b64be490513a501650982c65b48000ce5146780e49e9a05ad
-+++ discord-group-codex-message-tool.md	sha256=b5fdd042400d28e793090195c5f14c11446eb8f723bfbb14ebac9ee25835f9e7
+--- telegram-direct-codex-message-tool.md	sha256=4e327fd2e11b3319e42fb2c740f86ce5fe7d0ef7720eebdd6d795640a23c7315
++++ discord-group-codex-message-tool.md	sha256=18acd478d9f9abd48847f304ddd62fd805af313e46fb7bf7e2269b86b6a45311
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -16,44 +16,44 @@
 @@ -30,1 +30,1 @@
 -  "toolSnapshot": "codex-dynamic-tools.telegram-direct.json",
 +  "toolSnapshot": "codex-dynamic-tools.discord-group.json",
-@@ -135,1 +135,1 @@
+@@ -134,1 +134,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-discord-group-codex-message-tool"
-@@ -146,1 +146,1 @@
+@@ -145,1 +145,1 @@
 -      "value": "{\"sender\":{\"id\":\"1000001\",\"name\":\"Pash\",\"username\":\"pash\"}}"
 +      "value": "{\"sender\":{\"id\":\"424242\",\"name\":\"Pash\",\"username\":\"pash\"}}"
-@@ -177,1 +177,1 @@
+@@ -172,1 +172,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-discord-group-codex-message-tool"
-@@ -214,1 +214,1 @@
+@@ -209,1 +209,1 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.discord-group.json",
-@@ -242,2 +242,2 @@
--    "chars": 56379,
--    "roughTokens": 14095
-+    "chars": 56959,
-+    "roughTokens": 14240
-@@ -246,2 +246,2 @@
+@@ -237,2 +237,2 @@
+-    "chars": 56718,
+-    "roughTokens": 14180
++    "chars": 57298,
++    "roughTokens": 14325
+@@ -241,2 +241,2 @@
 -    "chars": 3224,
 -    "roughTokens": 806
 +    "chars": 4333,
 +    "roughTokens": 1084
-@@ -250,2 +250,2 @@
+@@ -245,2 +245,2 @@
 -    "chars": 27170,
 -    "roughTokens": 6793
 +    "chars": 28650,
 +    "roughTokens": 7163
-@@ -254,2 +254,2 @@
--    "chars": 83551,
--    "roughTokens": 20888
-+    "chars": 85611,
-+    "roughTokens": 21403
-@@ -258,2 +258,2 @@
+@@ -249,2 +249,2 @@
+-    "chars": 83890,
+-    "roughTokens": 20973
++    "chars": 85950,
++    "roughTokens": 21488
+@@ -253,2 +253,2 @@
 -    "chars": 863,
 -    "roughTokens": 216
 +    "chars": 1234,
 +    "roughTokens": 309
-@@ -467,4 +467,4 @@
+@@ -462,4 +462,4 @@
 -  "channel": "telegram",
 -  "provider": "telegram",
 -  "surface": "telegram",
@@ -62,21 +62,21 @@
 +  "provider": "discord",
 +  "surface": "discord",
 +  "chat_type": "group"
-@@ -475,1 +475,3 @@
+@@ -470,1 +470,3 @@
 -You are in a Telegram direct conversation. Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation. If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.
 +You are in a Discord group chat. Normal final replies are private and are not automatically sent to this group chat. To post visible output here, use the message tool with action=send; the target defaults to this group chat. Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \n sequences; use real line breaks sparingly. If addressed to someone else, stay silent unless invited or correcting key facts. Discord: wrap bare URLs like <https://example.com> to suppress embeds. When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value. If no visible group response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to this group chat. Be extremely selective: reply only when directly addressed or clearly helpful.
 +
 +Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included). Address the specific sender noted in the message context.
-@@ -531,1 +533,1 @@
+@@ -526,1 +528,1 @@
 -{"chat_id":"user:1000001","message_id":"tg-msg-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
 +{"chat_id":"channel:987654321","message_id":"discord-msg-0001","conversation_label":"OpenClaw/#agent-sandbox","sender":{"id":"424242","name":"Pash","username":"pash"},"group_subject":"OpenClaw maintainers","group_channel":"#agent-sandbox","group_space":"OpenClaw","is_group_chat":true,"was_mentioned":true,"history_count":2}
-@@ -534,1 +536,5 @@
+@@ -529,1 +531,5 @@
 -Can you check whether the nightly build finished and tell me what happened?
 +Chat history since last reply: ⟦openclaw:ctx⟧
 +Peter: I pushed the Discord-side message-tool bridge.
 +Pash: @OpenClaw please verify the Codex happy path too.
 +
 +can you audit whether this prompt path has conflicting silence instructions?
-@@ -539,1 +545,1 @@
+@@ -534,1 +540,1 @@
 -Full JSON: `codex-dynamic-tools.telegram-direct.json`
 +Full tool overrides: `codex-dynamic-tools.discord-group.json` (base: `codex-dynamic-tools.telegram-direct.json`)

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=4e327fd2e11b3319e42fb2c740f86ce5fe7d0ef7720eebdd6d795640a23c7315
-+++ discord-group-codex-message-tool.md	sha256=18acd478d9f9abd48847f304ddd62fd805af313e46fb7bf7e2269b86b6a45311
+--- telegram-direct-codex-message-tool.md	sha256=15ce719dea2c0ca1a3fce25349323b54367b11d56f1c9e5ec079d1b7b517036d
++++ discord-group-codex-message-tool.md	sha256=6f369eed63263db15c53543e48194af287546f8267819fd96981936e3062380c
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -29,10 +29,10 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.discord-group.json",
 @@ -237,2 +237,2 @@
--    "chars": 56718,
--    "roughTokens": 14180
-+    "chars": 57298,
-+    "roughTokens": 14325
+-    "chars": 56535,
+-    "roughTokens": 14134
++    "chars": 57115,
++    "roughTokens": 14279
 @@ -241,2 +241,2 @@
 -    "chars": 3224,
 -    "roughTokens": 806
@@ -44,10 +44,10 @@
 +    "chars": 28650,
 +    "roughTokens": 7163
 @@ -249,2 +249,2 @@
--    "chars": 83890,
--    "roughTokens": 20973
-+    "chars": 85950,
-+    "roughTokens": 21488
+-    "chars": 83707,
+-    "roughTokens": 20927
++    "chars": 85767,
++    "roughTokens": 21442
 @@ -253,2 +253,2 @@
 -    "chars": 863,
 -    "roughTokens": 216

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=15ce719dea2c0ca1a3fce25349323b54367b11d56f1c9e5ec079d1b7b517036d
-+++ discord-group-codex-message-tool.md	sha256=6f369eed63263db15c53543e48194af287546f8267819fd96981936e3062380c
+--- telegram-direct-codex-message-tool.md	sha256=9072ec22ee8f59463517921b6363e5667d06d183aaff39fcc26755384694a9cf
++++ discord-group-codex-message-tool.md	sha256=d205b3500b8449e284a918e7e066ad27f4ad4ae0f4fb5431974ec8b9770d9495
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -16,44 +16,44 @@
 @@ -30,1 +30,1 @@
 -  "toolSnapshot": "codex-dynamic-tools.telegram-direct.json",
 +  "toolSnapshot": "codex-dynamic-tools.discord-group.json",
-@@ -134,1 +134,1 @@
+@@ -135,1 +135,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-discord-group-codex-message-tool"
-@@ -145,1 +145,1 @@
+@@ -146,1 +146,1 @@
 -      "value": "{\"sender\":{\"id\":\"1000001\",\"name\":\"Pash\",\"username\":\"pash\"}}"
 +      "value": "{\"sender\":{\"id\":\"424242\",\"name\":\"Pash\",\"username\":\"pash\"}}"
-@@ -172,1 +172,1 @@
+@@ -177,1 +177,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-discord-group-codex-message-tool"
-@@ -209,1 +209,1 @@
+@@ -214,1 +214,1 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.discord-group.json",
-@@ -237,2 +237,2 @@
+@@ -242,2 +242,2 @@
 -    "chars": 56535,
 -    "roughTokens": 14134
 +    "chars": 57115,
 +    "roughTokens": 14279
-@@ -241,2 +241,2 @@
+@@ -246,2 +246,2 @@
 -    "chars": 3224,
 -    "roughTokens": 806
 +    "chars": 4333,
 +    "roughTokens": 1084
-@@ -245,2 +245,2 @@
+@@ -250,2 +250,2 @@
 -    "chars": 27170,
 -    "roughTokens": 6793
 +    "chars": 28650,
 +    "roughTokens": 7163
-@@ -249,2 +249,2 @@
+@@ -254,2 +254,2 @@
 -    "chars": 83707,
 -    "roughTokens": 20927
 +    "chars": 85767,
 +    "roughTokens": 21442
-@@ -253,2 +253,2 @@
+@@ -258,2 +258,2 @@
 -    "chars": 863,
 -    "roughTokens": 216
 +    "chars": 1234,
 +    "roughTokens": 309
-@@ -462,4 +462,4 @@
+@@ -467,4 +467,4 @@
 -  "channel": "telegram",
 -  "provider": "telegram",
 -  "surface": "telegram",
@@ -62,21 +62,21 @@
 +  "provider": "discord",
 +  "surface": "discord",
 +  "chat_type": "group"
-@@ -470,1 +470,3 @@
+@@ -475,1 +475,3 @@
 -You are in a Telegram direct conversation. Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation. If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.
 +You are in a Discord group chat. Normal final replies are private and are not automatically sent to this group chat. To post visible output here, use the message tool with action=send; the target defaults to this group chat. Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \n sequences; use real line breaks sparingly. If addressed to someone else, stay silent unless invited or correcting key facts. Discord: wrap bare URLs like <https://example.com> to suppress embeds. When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value. If no visible group response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to this group chat. Be extremely selective: reply only when directly addressed or clearly helpful.
 +
 +Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included). Address the specific sender noted in the message context.
-@@ -526,1 +528,1 @@
+@@ -531,1 +533,1 @@
 -{"chat_id":"user:1000001","message_id":"tg-msg-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
 +{"chat_id":"channel:987654321","message_id":"discord-msg-0001","conversation_label":"OpenClaw/#agent-sandbox","sender":{"id":"424242","name":"Pash","username":"pash"},"group_subject":"OpenClaw maintainers","group_channel":"#agent-sandbox","group_space":"OpenClaw","is_group_chat":true,"was_mentioned":true,"history_count":2}
-@@ -529,1 +531,5 @@
+@@ -534,1 +536,5 @@
 -Can you check whether the nightly build finished and tell me what happened?
 +Chat history since last reply: ⟦openclaw:ctx⟧
 +Peter: I pushed the Discord-side message-tool bridge.
 +Pash: @OpenClaw please verify the Codex happy path too.
 +
 +can you audit whether this prompt path has conflicting silence instructions?
-@@ -534,1 +540,1 @@
+@@ -539,1 +545,1 @@
 -Full JSON: `codex-dynamic-tools.telegram-direct.json`
 +Full tool overrides: `codex-dynamic-tools.discord-group.json` (base: `codex-dynamic-tools.telegram-direct.json`)

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 56718,
-    "roughTokens": 14180
+    "chars": 56535,
+    "roughTokens": 14134
   },
   "openClawDeveloperInstructions": {
     "chars": 3224,
@@ -251,8 +251,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6793
   },
   "totalWithDynamicToolsJson": {
-    "chars": 83890,
-    "roughTokens": 20973
+    "chars": 83707,
+    "roughTokens": 20927
   },
   "userInputText": {
     "chars": 863,
@@ -586,7 +586,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "boolean"
         },
         "attachments": {
-          "description": "Attachments; each uses media.",
+          "description": "Attachments; each uses media. Multiple attachments deliver together when the channel supports grouped media, otherwise as individual messages.",
           "items": {
             "properties": {
               "media": {
@@ -648,18 +648,11 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "boolean"
         },
         "media": {
-          "description": "Single media URL/path. For multiple media use mediaUrls (or attachments). data: use buffer.",
+          "description": "Single media URL/path. For multiple media use attachments. data: use buffer.",
           "type": "string"
         },
-        "mediaUrls": {
-          "description": "Multiple media URLs/paths; sent together when the channel supports grouped media, otherwise as individual attachments.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "message": {
-          "description": "Text for action=\"send\". A send needs message or another send payload such as media, mediaUrls, attachments, or presentation.",
+          "description": "Text for action=\"send\". A send needs message or another send payload such as media, attachments, or presentation.",
           "type": "string"
         },
         "mimeType": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 56379,
-    "roughTokens": 14095
+    "chars": 56718,
+    "roughTokens": 14180
   },
   "openClawDeveloperInstructions": {
     "chars": 3224,
@@ -251,8 +251,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6793
   },
   "totalWithDynamicToolsJson": {
-    "chars": 83551,
-    "roughTokens": 20888
+    "chars": 83890,
+    "roughTokens": 20973
   },
   "userInputText": {
     "chars": 863,
@@ -648,11 +648,18 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "boolean"
         },
         "media": {
-          "description": "Media URL/path. data: use buffer.",
+          "description": "Single media URL/path. For multiple media use mediaUrls (or attachments). data: use buffer.",
           "type": "string"
         },
+        "mediaUrls": {
+          "description": "Multiple media URLs/paths; sent together when the channel supports grouped media, otherwise as individual attachments.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "message": {
-          "description": "Text for action=\"send\". A send needs message or another send payload such as media, attachments, or presentation.",
+          "description": "Text for action=\"send\". A send needs message or another send payload such as media, mediaUrls, attachments, or presentation.",
           "type": "string"
         },
         "mimeType": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=4e327fd2e11b3319e42fb2c740f86ce5fe7d0ef7720eebdd6d795640a23c7315
-+++ telegram-heartbeat-codex-tool.md	sha256=b1dc05345b9b6803dc49f4945ab7d613298ecd0e34eb95eb39f49ff5bf3ff789
+--- telegram-direct-codex-message-tool.md	sha256=15ce719dea2c0ca1a3fce25349323b54367b11d56f1c9e5ec079d1b7b517036d
++++ telegram-heartbeat-codex-tool.md	sha256=b2a0f81a7977c848524c7c2e23578571b4dea189a710cf87724fe76da7185437
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -32,20 +32,20 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.heartbeat-turn.json",
 @@ -237,2 +232,2 @@
--    "chars": 56718,
--    "roughTokens": 14180
-+    "chars": 58211,
-+    "roughTokens": 14553
+-    "chars": 56535,
+-    "roughTokens": 14134
++    "chars": 58028,
++    "roughTokens": 14507
 @@ -245,2 +240,2 @@
 -    "chars": 27170,
 -    "roughTokens": 6793
 +    "chars": 27512,
 +    "roughTokens": 6878
 @@ -249,2 +244,2 @@
--    "chars": 83890,
--    "roughTokens": 20973
-+    "chars": 85725,
-+    "roughTokens": 21432
+-    "chars": 83707,
+-    "roughTokens": 20927
++    "chars": 85542,
++    "roughTokens": 21386
 @@ -253,2 +248,2 @@
 -    "chars": 863,
 -    "roughTokens": 216
@@ -62,7 +62,7 @@
 +Full tool overrides: `codex-dynamic-tools.heartbeat-turn.json` (base: `codex-dynamic-tools.telegram-direct.json`)
 @@ -554,0 +550,1 @@
 +  "heartbeat_respond",
-@@ -708,0 +705,39 @@
+@@ -701,0 +698,39 @@
 +  },
 +  {
 +    "description": "Accept heartbeat result for post-turn handling. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only.",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=15ce719dea2c0ca1a3fce25349323b54367b11d56f1c9e5ec079d1b7b517036d
-+++ telegram-heartbeat-codex-tool.md	sha256=b2a0f81a7977c848524c7c2e23578571b4dea189a710cf87724fe76da7185437
+--- telegram-direct-codex-message-tool.md	sha256=9072ec22ee8f59463517921b6363e5667d06d183aaff39fcc26755384694a9cf
++++ telegram-heartbeat-codex-tool.md	sha256=6aa6b7e87e8192de410a16a8f718bda3f996f398b7fe948f4632be173857a155
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -13,56 +13,54 @@
 -  "trigger": "user"
 +  "toolSnapshot": "codex-dynamic-tools.heartbeat-turn.json",
 +  "trigger": "heartbeat"
-@@ -96,0 +97,1 @@
+@@ -97,0 +98,1 @@
 +    "heartbeat_respond",
-@@ -134,1 +135,1 @@
+@@ -135,1 +136,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-telegram-heartbeat-codex-tool"
-@@ -142,6 +142,0 @@
--  "additionalContext": {
+@@ -144,4 +144,0 @@
 -    "openclaw_current_sender": {
 -      "kind": "untrusted",
 -      "value": "{\"sender\":{\"id\":\"1000001\",\"name\":\"Pash\",\"username\":\"pash\"}}"
--    }
--  },
-@@ -172,1 +167,1 @@
+-    },
+@@ -177,1 +174,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-telegram-heartbeat-codex-tool"
-@@ -209,1 +204,1 @@
+@@ -214,1 +211,1 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.heartbeat-turn.json",
-@@ -237,2 +232,2 @@
+@@ -242,2 +239,2 @@
 -    "chars": 56535,
 -    "roughTokens": 14134
 +    "chars": 58028,
 +    "roughTokens": 14507
-@@ -245,2 +240,2 @@
+@@ -250,2 +247,2 @@
 -    "chars": 27170,
 -    "roughTokens": 6793
 +    "chars": 27512,
 +    "roughTokens": 6878
-@@ -249,2 +244,2 @@
+@@ -254,2 +251,2 @@
 -    "chars": 83707,
 -    "roughTokens": 20927
 +    "chars": 85542,
 +    "roughTokens": 21386
-@@ -253,2 +248,2 @@
+@@ -258,2 +255,2 @@
 -    "chars": 863,
 -    "roughTokens": 216
 +    "chars": 1205,
 +    "roughTokens": 302
-@@ -526,1 +521,1 @@
+@@ -531,1 +528,1 @@
 -{"chat_id":"user:1000001","message_id":"tg-msg-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
 +{"chat_id":"user:1000001","message_id":"heartbeat-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
-@@ -529,1 +524,1 @@
+@@ -534,1 +531,1 @@
 -Can you check whether the nightly build finished and tell me what happened?
 +Follow the heartbeat monitor scratch context when provided. Recurring tasks are automations; create or change their schedules with the automations tool, not heartbeat scratch. Do not infer or repeat old tasks from prior chats. Use heartbeat_respond to report the wake outcome. Set notify=false when nothing needs the user's attention. Set notify=true with notificationText only when the user should be interrupted.
-@@ -534,1 +529,1 @@
+@@ -539,1 +536,1 @@
 -Full JSON: `codex-dynamic-tools.telegram-direct.json`
 +Full tool overrides: `codex-dynamic-tools.heartbeat-turn.json` (base: `codex-dynamic-tools.telegram-direct.json`)
-@@ -554,0 +550,1 @@
+@@ -559,0 +557,1 @@
 +  "heartbeat_respond",
-@@ -701,0 +698,39 @@
+@@ -706,0 +705,39 @@
 +  },
 +  {
 +    "description": "Accept heartbeat result for post-turn handling. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only.",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=d34d752dc536112b64be490513a501650982c65b48000ce5146780e49e9a05ad
-+++ telegram-heartbeat-codex-tool.md	sha256=34e5effb10b918859678a8f46e06602c59f14854a05c80732731f8f3d1093c60
+--- telegram-direct-codex-message-tool.md	sha256=4e327fd2e11b3319e42fb2c740f86ce5fe7d0ef7720eebdd6d795640a23c7315
++++ telegram-heartbeat-codex-tool.md	sha256=b1dc05345b9b6803dc49f4945ab7d613298ecd0e34eb95eb39f49ff5bf3ff789
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -13,54 +13,56 @@
 -  "trigger": "user"
 +  "toolSnapshot": "codex-dynamic-tools.heartbeat-turn.json",
 +  "trigger": "heartbeat"
-@@ -97,0 +98,1 @@
+@@ -96,0 +97,1 @@
 +    "heartbeat_respond",
-@@ -135,1 +136,1 @@
+@@ -134,1 +135,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-telegram-heartbeat-codex-tool"
-@@ -144,4 +144,0 @@
+@@ -142,6 +142,0 @@
+-  "additionalContext": {
 -    "openclaw_current_sender": {
 -      "kind": "untrusted",
 -      "value": "{\"sender\":{\"id\":\"1000001\",\"name\":\"Pash\",\"username\":\"pash\"}}"
--    },
-@@ -177,1 +174,1 @@
+-    }
+-  },
+@@ -172,1 +167,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-telegram-heartbeat-codex-tool"
-@@ -214,1 +211,1 @@
+@@ -209,1 +204,1 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.heartbeat-turn.json",
-@@ -242,2 +239,2 @@
--    "chars": 56379,
--    "roughTokens": 14095
-+    "chars": 57872,
-+    "roughTokens": 14468
-@@ -250,2 +247,2 @@
+@@ -237,2 +232,2 @@
+-    "chars": 56718,
+-    "roughTokens": 14180
++    "chars": 58211,
++    "roughTokens": 14553
+@@ -245,2 +240,2 @@
 -    "chars": 27170,
 -    "roughTokens": 6793
 +    "chars": 27512,
 +    "roughTokens": 6878
-@@ -254,2 +251,2 @@
--    "chars": 83551,
--    "roughTokens": 20888
-+    "chars": 85386,
-+    "roughTokens": 21347
-@@ -258,2 +255,2 @@
+@@ -249,2 +244,2 @@
+-    "chars": 83890,
+-    "roughTokens": 20973
++    "chars": 85725,
++    "roughTokens": 21432
+@@ -253,2 +248,2 @@
 -    "chars": 863,
 -    "roughTokens": 216
 +    "chars": 1205,
 +    "roughTokens": 302
-@@ -531,1 +528,1 @@
+@@ -526,1 +521,1 @@
 -{"chat_id":"user:1000001","message_id":"tg-msg-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
 +{"chat_id":"user:1000001","message_id":"heartbeat-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
-@@ -534,1 +531,1 @@
+@@ -529,1 +524,1 @@
 -Can you check whether the nightly build finished and tell me what happened?
 +Follow the heartbeat monitor scratch context when provided. Recurring tasks are automations; create or change their schedules with the automations tool, not heartbeat scratch. Do not infer or repeat old tasks from prior chats. Use heartbeat_respond to report the wake outcome. Set notify=false when nothing needs the user's attention. Set notify=true with notificationText only when the user should be interrupted.
-@@ -539,1 +536,1 @@
+@@ -534,1 +529,1 @@
 -Full JSON: `codex-dynamic-tools.telegram-direct.json`
 +Full tool overrides: `codex-dynamic-tools.heartbeat-turn.json` (base: `codex-dynamic-tools.telegram-direct.json`)
-@@ -559,0 +557,1 @@
+@@ -554,0 +550,1 @@
 +  "heartbeat_respond",
-@@ -706,0 +705,39 @@
+@@ -708,0 +705,39 @@
 +  },
 +  {
 +    "description": "Accept heartbeat result for post-turn handling. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only.",


### PR DESCRIPTION
Closes #135545

## What Problem This Solves

When an agent generates multiple images (for example three avatar candidates) and
decides to send them all, the `message` tool's `media` parameter accepts a single
file. The multi-file `attachments` object-array form is easy for models to miss,
so in practice agents default to sending one image and the user only ever receives
one of the generated images.

On Telegram, even when multiple media were provided, each file was sent as a
separate photo message with no album grouping.

## Why This Change Was Made

- Surface a flat, model-friendly `mediaUrls: string[]` parameter on the message
  tool send schema so agents can reliably request multiple media in one tool call.
- Give the Telegram channel native album support (`sendMediaGroup`): 2-10 photos
  or videos are delivered as a single grouped album message with the caption on
  the first item, and graceful fallback to per-media sends when album constraints
  are not met (mixed/non-photo/video media, >10 items, `forceDocument`,
  voice/video-note, or a media-group API error).

## User Impact

- Agents can send several generated images in a single `message` call.
- Telegram recipients see a tidy media album instead of scattered photos (or a
  single dropped image).

## Evidence

- **Schema**: `src/agents/tools/message-tool-schema.ts` adds `mediaUrls` to the
  send schema; the existing "canonical media params" test was updated
  (`message-tool.test.ts`).
- **Send layer**: `extensions/telegram/src/send-message.ts` adds
  `sendTelegramMediaAlbum` with fallback to the existing per-media path
  (`sendSingleMedia`).
- **Adapter**: `extensions/telegram/src/outbound-adapter.ts` hands multi-media
  payloads to the send layer as one `mediaUrls` array.
- **Tests**:
  - `extensions/telegram/src/send.test.ts`: album grouping, fallback on
    non-album media, fallback on API failure, single-entry path.
  - `extensions/telegram/src/outbound-adapter.test.ts` and
    `channel.message-adapter.test.ts`: album payload path (single call with
    `mediaUrls`).
- **Validation**: `tsgo:core` and `tsgo:extensions` pass; full Telegram extension
  test suite passes (3913 tests, 0 failures); `message-tool.test.ts` (240 tests)
  passes.

## Album + inline keyboard (after-fix, real-machine proof)

**Behavior**: when a multi-media payload also requests inline buttons, the album
is sent as a captionless media group and the caption text is delivered as an
immediately following text message whose final chunk carries the `reply_markup`
(commit `ac0b35001b`). Telegram media-group messages cannot host inline
keyboards (`sendMediaGroup` has no `reply_markup`; a post-send
`editMessageReplyMarkup` on an album message is rejected with 400 "message is
not modified"), so this is the only supported Telegram representation of
"several images + buttons".

**Live trace** (gateway build `2026.8.1-ac0b35001b98`, two independent runs,
before/after):

```
BEFORE (81f73da7cd send-then-edit retrofit):
19:42:41 outbound send ok ... messageId=12647 operation=sendMediaGroup deliveryKind=media_group
19:42:41 [ws] ⇄ res ✗ message.action errorCode=UNAVAILABLE
        OutboundDeliveryError: Call to 'editMessageReplyMarkup' failed!
        (400: Bad Request: message is not modified: ... reply markup are exactly the same ...)

AFTER (ac0b35001b caption follow-up host):
20:53:34 outbound send ok ... messageId=12664 operation=sendMediaGroup deliveryKind=media_group
20:53:34 outbound send ok ... messageId=12667 operation=sendRichMessage deliveryKind=text chunkCount=1
20:53:34 [ws] ⇄ res ✓ message.action 3548ms   → tool result { ok: true, messageId: "12667" }
20:55:05 outbound send ok ... messageId=12671 operation=sendMediaGroup deliveryKind=media_group
20:55:06 outbound send ok ... messageId=12674 operation=sendRichMessage deliveryKind=text chunkCount=1
20:55:06 [ws] ⇄ res ✓ message.action 3567ms   → tool result { ok: true, messageId: "12674" }
```

User confirmed visually that the album shows the grouped photos and the
clickable button row sits on the text message directly below the album; no
`editMessageReplyMarkup`, no partial-delivery error, no UNAVAILABLE.

**Tests**: album+buttons asserts captionless `sendMediaGroup` + follow-up text
with `reply_markup` (no retrofit); no-caption case asserts the buttons-only
host falls back to the control text. Full `extensions/telegram` suite:
**3917 passed**; `tsgo:core`/`tsgo:extensions`/lint clean.

## Full matrix re-run on the exact review head

All four Telegram delivery shapes re-run on gateway build
**`2026.8.1-74b6046234cf`** (commit `74b6046234`, current PR head), each
returning `ok: true`:

| Shape | Gateway trace | messageId (tool result) | Result |
|---|---|---|---|
| Album (3 photos) | `sendMediaGroup` | 12683 | ✅ |
| Album + inline buttons | `sendMediaGroup` (12686) then text follow-up with `reply_markup` (12689) | 12689 | ✅ |
| Three separate photos | `sendPhoto` ×3 | 12691 / 12692 / 12693 | ✅ |
| Single photo + inline buttons | `sendPhoto` (with `reply_markup`) | 12694 | ✅ |

Every `message.action` completed successfully (`res ✓`, no
`editMessageReplyMarkup`, no partial-delivery error, no UNAVAILABLE). The
album+buttons case confirms the caption follow-up host on the current head.

**Round-5 fixes on this head** (both source-verified by the new tests):
- Album custody: every accepted media-group message is registered before any
  fallible observer, so an observer failure reports all album ids
  (`extensions/telegram` suite; new callback-failure case).
- Multi-media routing: only payload transports that declare
  `sendPayloadGroupsMedia` (Telegram) host multi-media payloads; sequential
  senders (Zalo) stay on per-media fanout (new Zalo-shaped regression in
  `deliver.payload-transport.test.ts`).

Test status on this head: `extensions/telegram` 3918 passed (one unrelated
webhook timing flake re-passed in isolation), `extensions/zalo` 473 passed,
`deliver.payload-transport.test.ts` 5 passed; `tsgo:core`/`tsgo:extensions`
and lint clean.

## Rebase onto current main + round-6/7 review fixes

Branch rebased onto current `openclaw/openclaw@main` (was 500+ commits
behind; PR previously reported mergeable=false / dirty). Now
`mergeable: true`. Prompt snapshots regenerated on the rebased head.

**Round-6 fixes** (both P1s from the 15:29 UTC review, all in
`sendTelegramMediaAlbum`'s empty-follow-up recovery):
- An empty-content rejection of the follow-up text (the only legal host for
  an over-length caption or an album's inline keyboard) now reports the
  accepted album as a **partial delivery** (`sender.fail(error,
  custodyStart, { receipt: albumReceipt })`) instead of silently returning
  success.
- Recovery keeps **every album id** in `messageIds` and returns the
  **complete album receipt** (`albumReceipt`), not the collapsed primary
  observer result.

**Round-7 fix** (new P1 from the 17:09 UTC review): the successful
caption/button follow-up path now records the accepted album into prompt
context **before** the first follow-up chunk via `beforeFirstAccepted`
(mirroring the single-media long-caption path), guarded so the empty/generic
follow-up failure branches record it exactly once.

**New regressions** (extensions/telegram/src/send.test.ts):
- empty button-host follow-up -> partial delivery with every album id;
- empty over-length-caption follow-up -> partial delivery + album receipt;
- successful album + buttons records album primary (part 0, non-final) then
  follow-up text (part 1, final) in prompt-context projection.

Test status on head 5ff2256211: send.test.ts 269 passed, album describe 12
passed, `deliver.payload-transport.test.ts` 5 passed,
`prompt:snapshots:check` clean; `tsgo:core`/`tsgo:extensions` and lint
clean.

## Round-9 fix: preserve topic and reply route facts in album receipts

New P1 from the 18:13 UTC review (head `5ff2256211`): `albumReceipt` was built
from bare message/chat ids, so a multi-media album sent into a forum/bot-private
topic or as a native reply returned a receipt without the accepted
`message_thread_id`/`direct_messages_topic_id` or reply target — unlike the
single-media path — and downstream transcript/thread mirroring treated it as a
routing mismatch.

Fixed on head `634fb885563` (`extensions/telegram/src/send-media-group.ts`),
mirroring the single-media long-caption path:
- The album receipt now carries the accepted route facts: `threadId` from the
  accepted topic param (`message_thread_id`, or `direct_messages_topic_id` for
  channel Direct Messages topics) and `replyToId` from the accepted reply.
- Every album message part keeps the shared route; in the caption/button
  follow-up combined receipt the follow-up text only inherits the reply when it
  was itself sent as a reply (first-mode single-use replies are not reused).
- Prompt-context recording and the outbound success log resolve the same thread
  id.

New regressions (extensions/telegram/src/send.test.ts):
- forum topic routing on a media-only album receipt (`threadId` on aggregate
  and every part);
- explicit native reply routing on a media-only album receipt (`replyToId` on
  every album part);
- topic + implicit first-mode reply with an over-length caption follow-up
  (album parts keep thread + reply; the reply-less follow-up text keeps the
  thread only).

Test status on head `634fb885563`: send.test.ts **272 passed** (269 prior +
3 new), album describe 15 passed, `tsgo:extensions` clean, oxlint/oxfmt clean.
## Round-9 exact-head real-machine proof (head 634fb885563)

Four-shape matrix re-run on the deployed gateway at the current review head.
Gateway build **`2026.8.1-634fb885563a`** (`dist/build-info.json` commit
`634fb885563a152ebc00ca784d333c4589a501e1`), Telegram direct chat
(`accountId=default`, chatId redacted). All `message.action` calls returned
`ok: true`.

| Shape | message tool call | Gateway trace | Tool result messageId |
|---|---|---|---|
| Album (3 photos) | 3 `attachments` (picX/picY/picZ) | `sendMediaGroup` → 12703 | 12703 |
| Album + inline buttons | 3 `attachments` + `presentation.buttons` | `sendMediaGroup` → 12706, then `sendRichMessage` text (buttons host) → 12709 | 12709 |
| Three separate photos | 3 × single-`media` sends | `sendPhoto` → 12711 / 12712 / 12713 | 12711 / 12712 / 12713 |
| Single photo + inline buttons | single `media` + `presentation.buttons` | `sendPhoto` → 12714 | 12714 |

Journal excerpt (chatId redacted):

```
03:35:10 [telegram] outbound send ok accountId=default chatId=<redacted> messageId=12703 operation=sendMediaGroup deliveryKind=media_group
03:35:14 [telegram] outbound send ok accountId=default chatId=<redacted> messageId=12706 operation=sendMediaGroup deliveryKind=media_group
03:35:15 [telegram] outbound send ok accountId=default chatId=<redacted> messageId=12709 operation=sendRichMessage deliveryKind=text chunkCount=1
03:35:19 [telegram] outbound send ok accountId=default chatId=<redacted> messageId=12711 operation=sendPhoto deliveryKind=photo
03:35:24 [telegram] outbound send ok accountId=default chatId=<redacted> messageId=12712 operation=sendPhoto deliveryKind=photo
03:35:29 [telegram] outbound send ok accountId=default chatId=<redacted> messageId=12713 operation=sendPhoto deliveryKind=photo
03:35:35 [telegram] outbound send ok accountId=default chatId=<redacted> messageId=12714 operation=sendPhoto deliveryKind=photo
[ws] ⇄ res ✓ message.action … channel=telegram   (all six tool calls)
```

Session transcript confirms each tool result: `{ ok: true, messageId: "12703" }`,
`{ ok: true, messageId: "12709" }`, `12711`, `12712`, `12713`, `12714` —
no partial-delivery error, no `editMessageReplyMarkup` retrofit, no
UNAVAILABLE. The three single-image sends stay on the per-media `sendPhoto`
route (no accidental album), and the single photo + buttons stays on the
single-media keyboard path.

## Round-10: P2 fix + rebase onto 8.2 + native-reply receipt proof

**P2 — Mark every album item as media in combined receipts (fixed, head 9445dc4b671)**
The album-plus-follow-up combined receipt was built with `kind: "text"` and only
index 0 rewritten to `media`, so a two-photo album followed by text reported
`media/text/text`, misclassifying the second accepted photo (the added
topic/reply regression had encoded that defect as expected behavior). Every
accepted album message now stays `kind: "media"`; only the follow-up text parts
keep `text`. Regression now asserts the complete kind sequence
(`media/media/text`).

**Rebase onto 8.2-era main** — branch rebased onto current `openclaw/openclaw@main`
(45 commits incl. the 8.2 release), 16 commits, `mergeable: true` (state
"blocked" only reflects pending review). send.test.ts 272 passed,
`deliver.payload-transport.test.ts` 5 passed, `tsgo:core`/`tsgo:extensions`,
prompt-snapshot check and lint clean.

**Native-reply receipt proof (exact head 9445dc4b671, real Telegram)**
The round-9 proof gap was that the exact-head live trace did not exercise the
new topic/native-reply receipt path. Re-run on gateway build
`2026.8.1-9445dc4b6713` (dist/build-info.json commit 9445dc4b6713), direct
Telegram chat (accountId=default, chatId redacted), an album sent as a **native
reply** to the source message:

```
message tool call: action=send attachments=[repA.png,repB.png,repC.png]
                   caption="相册原生回复receipt验证"
                   replyTo="12726" quoteText="album-reply-quote-2"
04:46:35 [telegram] outbound send ok ... messageId=12728
         operation=sendMediaGroup deliveryKind=media_group replyToMessageId=12726
04:46:35 [ws] ⇄ res ✓ message.action 3446ms channel=telegram
tool result: { ok: true, messageId: "12728", chatId: "104371657",
               receipt: { replyToId: "12726" }, sourceReplyRoute: "current-source" }
```

The accepted native-reply target now reaches the album receipt
(`receipt.replyToId = "12726"`), which is exactly the route fact the round-8/9
reviews found missing; `logTelegramOutboundSendOk` reports
`replyToMessageId=12726` for the same send. No `editMessageReplyMarkup`, no
partial-delivery error, no UNAVAILABLE.

## Round-11: full album receipt on observer failure (head d3eb10c1c79)

The 20:57 UTC review's P1 (late finding on the unchanged head): when the primary
delivery observer fails after Telegram accepts the whole group, the catch passed
only the primary item's observer receipt to `sender.fail` — every album id came
back from the custody ledger but the receipt covered the first photo only.

The complete `albumReceipt` (all accepted album messages + route facts) is now
derived **before** any fallible observer runs and used by the failure branch, so
partial delivery carries every accepted album message in both `messageIds` and
`receipt.platformMessageIds`. The observer-failure regression now asserts
`receipt.platformMessageIds` covers the whole album (["140","141"]).

send.test.ts 272 passed; tsgo:extensions/oxlint/oxfmt clean. The round-10
exact-head native-reply and direct-chat matrix evidence remains valid: the only
source change since then is the failure-path receipt construction and its
regression, with the success-path album send untouched.
