### PR TITLE
refactor(telegram): share draft plain fallbacks

### DIFF
--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -1299,6 +1299,30 @@ describe("createTelegramDraftStream", () => {
     expect(warn).toHaveBeenCalledWith(
       "telegram stream preview degrade=plain-fallback:rich-entity-invalid: 400: Bad Request: RICH_MESSAGE_URL_INVALID",
     );
+
+    api.raw.editMessageText.mockRejectedValueOnce(
+      new Error("400: Bad Request: RICH_MESSAGE_URL_INVALID"),
+    );
+    stream.update("| Rank | Model |\n| --- | --- |\n| 1 | GPT-5.6 |");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.raw.editMessageText).toHaveBeenCalledTimes(1);
+    expect(api.editMessageText).toHaveBeenCalledTimes(1);
+    const editedPlain = api.editMessageText.mock.calls[0]?.[2] ?? "";
+    expect(editedPlain).toContain("Rank");
+    expect(editedPlain).toContain("GPT-5.6");
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, editedPlain);
+    expect(api.deleteMessage).not.toHaveBeenCalled();
+    expect(stream.messageId()).toBe(17);
+    expect(stream.currentMessageSnapshot?.()).toEqual({
+      text: editedPlain,
+      sourceText: editedPlain,
+      sourceTextMode: "html",
+    });
+    expect(warn).toHaveBeenCalledWith(
+      "telegram stream preview edit degrade=plain-fallback:rich-entity-invalid: 400: Bad Request: RICH_MESSAGE_URL_INVALID",
+    );
   });
 
   it("skips rich entity detection for draft text with provider-prefixed email addresses", async () => {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -276,6 +276,13 @@ export function createTelegramDraftStream(params: {
     page: PlannedTelegramDraftPage,
     sendMessageParams: ReturnType<typeof reserveReplyTargetForSend>,
   ) => {
+    const sendPlainFallback = async (plan: { plainText: string }) => ({
+      message: await params.api.sendMessage(chatId, plan.plainText, {
+        ...sendMessageParams,
+        ...linkPreviewParams,
+      }),
+      snapshot: fallbackSnapshot(plan.plainText),
+    });
     if (page.richMessage) {
       const richMessage = page.richMessage;
       warnTelegramRichBlocksDegradations({
@@ -299,13 +306,7 @@ export function createTelegramDraftStream(params: {
           }),
           snapshot: toDraftSnapshot(page),
         }),
-        sendPlain: async (plan) => ({
-          message: await params.api.sendMessage(chatId, plan.plainText, {
-            ...sendMessageParams,
-            ...linkPreviewParams,
-          }),
-          snapshot: fallbackSnapshot(plan.plainText),
-        }),
+        sendPlain: sendPlainFallback,
       });
     }
     if (page.sourceTextMode !== "html") {
@@ -333,13 +334,7 @@ export function createTelegramDraftStream(params: {
         }),
         snapshot: toDraftSnapshot(page),
       }),
-      sendPlain: async (plan) => ({
-        message: await params.api.sendMessage(chatId, plan.plainText, {
-          ...sendMessageParams,
-          ...linkPreviewParams,
-        }),
-        snapshot: fallbackSnapshot(plan.plainText),
-      }),
+      sendPlain: sendPlainFallback,
     });
   };
   const sendMessageTransportPreview = async (
@@ -356,6 +351,10 @@ export function createTelegramDraftStream(params: {
     if (typeof targetMessageId === "number") {
       streamVisibleSinceMs ??= Date.now();
       let acceptedSnapshot = toDraftSnapshot(page);
+      const editPlainFallback = async (plan: { plainText: string }) => {
+        await editMessageTextWithPreview(targetMessageId, plan.plainText);
+        return fallbackSnapshot(plan.plainText);
+      };
       if (page.richMessage) {
         const richMessage = page.richMessage;
         warnTelegramRichBlocksDegradations({
@@ -376,10 +375,7 @@ export function createTelegramDraftStream(params: {
             });
             return toDraftSnapshot(page);
           },
-          sendPlain: async (plan) => {
-            await editMessageTextWithPreview(targetMessageId, plan.plainText);
-            return fallbackSnapshot(plan.plainText);
-          },
+          sendPlain: editPlainFallback,
         });
       } else if (page.sourceTextMode === "html") {
         acceptedSnapshot = await withTelegramPlainFallback<TelegramDraftMessageSnapshot>({
@@ -393,10 +389,7 @@ export function createTelegramDraftStream(params: {
             });
             return toDraftSnapshot(page);
           },
-          sendPlain: async (plan) => {
-            await editMessageTextWithPreview(targetMessageId, plan.plainText);
-            return fallbackSnapshot(plan.plainText);
-          },
+          sendPlain: editPlainFallback,
         });
       } else {
         await editMessageTextWithPreview(targetMessageId, page.sourceText);


### PR DESCRIPTION
## Summary

- share one operation-local plain fallback callback across rich and HTML draft sends
- share a separate operation-local callback across rich and HTML draft edits
- extend the rich fallback regression through a same-message plain edit

## Root cause and fix

The Telegram draft-stream owner duplicated equivalent plain fallback callbacks in the rich and HTML send/edit branches. That duplication left sibling behavior able to drift independently and the existing rich regression covered only the first send.

`extensions/telegram/src/draft-stream.ts` now has one send callback scoped to each send operation and one distinct edit callback scoped to the current-message edit operation. The refactor removes four inline callback bodies while preserving send parameters, link-preview parameters, target message identity, fallback snapshots, warnings, retry ownership, and lifecycle behavior.

The behavioral regression proves that a rich send rejection falls back to one plain SUT message, then a later rich edit rejection edits that same active message through the legacy plain path, updates the snapshot, emits the edit degradation warning, and performs no delete or second send.

## Scope

- Production: `extensions/telegram/src/draft-stream.ts` +15/-22, net -7
- Tests: `extensions/telegram/src/draft-stream.test.ts` +24/-0
- No SDK, lifecycle, retry, parameter, security, config, or persistence changes

The adjacent oversized-fallback reliability bug remains out of scope and is tracked at https://github.com/openclaw/openclaw/issues/135546.

Overlap checks remain open and do not invalidate this scope:

- https://github.com/openclaw/openclaw/pull/122653
- https://github.com/openclaw/openclaw/pull/100359
- https://github.com/openclaw/openclaw/pull/114087

## Verification

- four Telegram suites: 4 files, 497 tests passed
- focused draft-stream suite: 90 tests passed
- `pnpm check:import-cycles`: 0 runtime value cycles
- changed-files dry-run and real gates: passed
- exact-tree Blacksmith Testbox `tbx_01m1fca0axm0fscpg9kgp0zbty`: 4 files, 497 tests passed; https://github.com/openclaw/openclaw/actions/runs/33558497410
- autoreview: no accepted/actionable findings, correctness 0.98
- Test Server doctor: blocked before credential acquisition because this host has no authenticated `convex` command or broker credential pair; no Telegram action was attempted

The required Codex source contract check was completed at `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`; those CLI parsing and prompt-normalization paths do not affect this Telegram-local refactor.
