### PR TITLE
fix(signal): compute command authorization for plugin command syntax

### DIFF
--- a/extensions/msteams/src/monitor-handler/message-handler.conversation-authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.conversation-authz.test.ts
@@ -226,6 +226,40 @@ describe("msteams group conversation allowlist authorization", () => {
     expect(runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 
+  it("computes command authorization for plugin command text from an admitted sender", async () => {
+    runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher.mockClear();
+    const { deps } = createDeps({
+      channels: {
+        msteams: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["group-member-aad"],
+          requireMention: false,
+        },
+      },
+    } as OpenClawConfig);
+
+    await createMSTeamsMessageHandler(deps)(
+      createMessageActivity({
+        id: "plugin-command-message",
+        text: "/plugin-tool run",
+        from: {
+          id: "group-member-bot-framework-id",
+          aadObjectId: "group-member-aad",
+          name: "Group Member",
+        },
+        conversation: {
+          id: "19:group@thread.tacv2",
+          conversationType: "groupChat",
+        },
+      }),
+    );
+
+    expect(runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    const dispatched = runtimeApiMockState.dispatchReplyWithBufferedBlockDispatcher.mock
+      .calls[0]?.[0] as { ctx?: { CommandAuthorized?: boolean } } | undefined;
+    expect(dispatched?.ctx?.CommandAuthorized).toBe(true);
+  });
+
   const rejectedCases: ConversationCase[] = [
     {
       label: "another group conversation",

--- a/extensions/signal/src/monitor/access-policy.test.ts
+++ b/extensions/signal/src/monitor/access-policy.test.ts
@@ -279,6 +279,25 @@ describe("resolveSignalAccessState", () => {
     expect(access.commandAccess.shouldBlockControlCommand).toBe(false);
   });
 
+  it("authorizes plugin command syntax without the control-command drop", async () => {
+    const access = await resolveSignalAccessState({
+      accountId: "default",
+      dmPolicy: "allowlist",
+      groupPolicy: "allowlist",
+      allowFrom: [],
+      groupAllowFrom: [SIGNAL_SENDER.e164],
+      sender: SIGNAL_SENDER,
+      groupId: SIGNAL_GROUP_ID,
+      isGroup: true,
+      shouldComputeCommandAuthorized: true,
+    });
+
+    expect(access.senderAccess.decision).toBe("allow");
+    expect(access.commandAccess.requested).toBe(true);
+    expect(access.commandAccess.authorized).toBe(true);
+    expect(access.commandAccess.shouldBlockControlCommand).toBe(false);
+  });
+
   it("authorizes group control commands through a sender UUID alias", async () => {
     const access = await resolveSignalAccessState({
       accountId: "default",

--- a/extensions/signal/src/monitor/access-policy.ts
+++ b/extensions/signal/src/monitor/access-policy.ts
@@ -121,14 +121,19 @@ export async function resolveSignalAccessState(params: {
   isGroup?: boolean;
   cfg?: Pick<OpenClawConfig, "accessGroups" | "commands">;
   hasControlCommand?: boolean;
+  /** Broad command-shaped probe (plugin command syntax included) that requests command authorization. */
+  shouldComputeCommandAuthorized?: boolean;
   readStoreAllowFrom?: () => Promise<string[]>;
   contextBinding?: ChannelIngressContextBinding;
 }) {
   const isGroup = params.isGroup ?? params.groupId != null;
+  // Authorization must be requested for every command-shaped message (plugin syntax included);
+  // the narrow control-command fact alone drives the control-lane drop and mention bypass.
   const command =
-    params.hasControlCommand === true
+    params.shouldComputeCommandAuthorized || params.hasControlCommand === true
       ? {
           allowTextCommands: true,
+          hasControlCommand: params.hasControlCommand === true,
           directGroupAllowFrom: "effective" as const,
         }
       : undefined;

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -1302,6 +1302,32 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(requireCapturedContext().CommandAuthorized).toBe(true);
   });
 
+  it("authorizes plugin command syntax for allowlisted direct senders", async () => {
+    const handler = createTestHandler({
+      cfg: createDirectConfig({
+        signal: { dmPolicy: "allowlist", allowFrom: ["+15550002222"] },
+      }),
+    });
+
+    await receiveDirectMessage(handler, {
+      dataMessage: { message: "/plugin-tool run", attachments: [] },
+    });
+
+    expect(requireCapturedContext().CommandAuthorized).toBe(true);
+  });
+
+  it("authorizes plugin command syntax for group allowlist senders", async () => {
+    const handler = createTestHandler({
+      cfg: createGroupAllowlistConfig({ signal: { groupAllowFrom: ["g1"] } }),
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["g1"],
+    });
+
+    await receiveGroupMessage(handler, "/plugin-tool run");
+
+    expect(requireCapturedContext().CommandAuthorized).toBe(true);
+  });
+
   it("allows reaction-only group events when groupAllowFrom matches the reaction group id", async () => {
     const handler = createTestHandler({
       cfg: createGroupAllowlistConfig({ signal: { groupAllowFrom: ["g1"] } }),

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -45,7 +45,10 @@ import {
   resolveChannelGroupPolicy,
   resolveChannelGroupRequireMention,
 } from "openclaw/plugin-sdk/channel-policy";
-import { isControlCommandMessage } from "openclaw/plugin-sdk/command-detection";
+import {
+  isControlCommandMessage,
+  shouldComputeCommandAuthorized,
+} from "openclaw/plugin-sdk/command-detection";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   createInternalHookEvent,
@@ -1011,6 +1014,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const groupId = dataMessage?.groupInfo?.groupId ?? reaction?.groupInfo?.groupId ?? undefined;
     const isGroup = Boolean(groupId);
     const hasControlCommandInMessage = isControlCommandMessage(messageText, deps.cfg);
+    const shouldComputeCommandAuth = shouldComputeCommandAuthorized(messageText, deps.cfg);
 
     const senderDisplay = formatSignalSenderDisplay(sender);
     const resolveChannelIngress = async (contextBinding?: ChannelIngressContextBinding) =>
@@ -1025,6 +1029,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         isGroup,
         cfg: deps.cfg,
         hasControlCommand: hasControlCommandInMessage,
+        shouldComputeCommandAuthorized: shouldComputeCommandAuth,
         contextBinding,
       });
     const accessDecision = await resolveChannelIngress();


### PR DESCRIPTION
## What Problem This Solves

Closes #135502.

Signal ingress requested the shared command-authorization gate only when the narrow control-command detector (`isControlCommandMessage`) matched. Registered plugin commands (`api.registerCommand({ name: "swarm-delivery", ... })`) never match that detector, so for an admitted sender invoking a plugin command the gate is never requested and `commandAccess` reports unrequested authority (`authorized: false`). With default `requireAuth`, core then rejects the command before the plugin handler runs; with `requireAuth: false`, the handler observes `isAuthorizedSender !== true`.

Signal also emits that false value into the inbound context (`access.commands.authorized`), so plugin commands and plain chat are indistinguishable at the dispatch boundary.

### Why Microsoft Teams is unaffected

The issue's source reading extends the defect to Microsoft Teams (`isControlCommandMessage` at `access.ts:255-265` + the `commandAccess.requested ? ... : undefined` emission at `access.ts:419`). That inference does not hold against current `main`: `resolveMSTeamsSenderAccess` passes the `command` preset **unconditionally** (`extensions/msteams/src/monitor-handler/access.ts:219-224`), so `commandAccess.requested` is always true there and authorization is computed for every admitted message — plugin syntax included. The narrow `isControlCommand` flag on Teams only feeds the exact control-lane drop (`shouldBlockControlCommand`) and the group mention bypass, which is the correct contract. This PR adds a committed Teams regression test asserting `CommandAuthorized: true` for plugin command text from an allowlisted sender, so the sibling difference is a recorded fact rather than prose.

## Why This Change Was Made

The bug lives at the producer: `resolveSignalAccessState` conflated two distinct facts into one boolean — "does this message need command authorization metadata?" and "is this an exact control command?". The shared ingress kernel already models them separately (`ChannelIngressPolicyInput["command"]`: object presence requests the gate; `hasControlCommand` drives `shouldBlockControlCommand`), and Google Chat's ingress already splits them (`extensions/googlechat/src/monitor-access.ts:217-238`). This change gives Signal the same shape:

- `shouldComputeCommandAuthorized` (broad probe: control commands, inline `/x` `!x` tokens, spaced plugin syntax) requests the gate, so plugin commands get a computed authority result.
- `hasControlCommand` (narrow) is passed through as the kernel's control-command fact, so the unauthorized control-command drop and the group mention bypass are unchanged.
- Plugin-looking syntax is not promoted into the control lane: `resolveSignalControlLaneKey` still requires the built-in active-run control text matcher, and `resolveInboundMentionDecision` still receives the narrow fact.

No kernel or core changes: the detection ownership stays with the channel ingress where it already lived.

## User Impact

- Registered plugin commands invoked from Signal DMs and groups by admitted senders now carry a computed `CommandAuthorized`/`isAuthorizedSender` instead of a forced `false`; default-`requireAuth` plugin commands stop being rejected at the Signal ingress boundary.
- Unauthorized control commands in groups are still dropped; group mention requirements and the mention bypass are unchanged; non-command chat still reports unrequested authority exactly as before.
- Requesting the gate never blocks a message by itself — the only drop (`shouldBlockControlCommand`) still requires the narrow control-command fact.

## Evidence

Regression tests (committed, CI-selected):

- `extensions/signal/src/monitor/event-handler.inbound-context.test.ts` — drives the real Signal event handler through the real shared ingress kernel to the dispatch context: plugin command text from an allowlisted DM sender and from a group-allowlist sender dispatches with `CommandAuthorized: true`.
- `extensions/signal/src/monitor/access-policy.test.ts` — unit contract: the broad probe alone requests the gate (`requested: true`, `authorized: true`) while `shouldBlockControlCommand` stays `false`.
- `extensions/msteams/src/monitor-handler/message-handler.conversation-authz.test.ts` — Teams unaffected-proof: plugin command text from an allowlisted sender dispatches with `CommandAuthorized: true`.

Pre-fix failure (both new Signal boundary tests, captured by stashing the two production files before the fix):

```
 × ... > authorizes plugin command syntax for allowlisted direct senders
   → expected false to be true // Object.is equality
 × ... > authorizes plugin command syntax for group allowlist senders
   → expected false to be true // Object.is equality
 Test Files  1 failed (1)
      Tests  2 failed | 50 skipped (52)
```

Post-fix:

```
extensions/signal/src/monitor/ + extensions/msteams/src/monitor-handler/
 Test Files  19 passed (19)
      Tests  255 passed (255)
```

Commands: `node scripts/run-vitest.mjs extensions/signal/src/monitor/ extensions/msteams/src/monitor-handler/`; typecheck `pnpm tsgo:extensions` + `pnpm tsgo:extensions:test`; lint `node_modules/.bin/oxlint -c .oxlintrc.json --type-aware <touched files>`; format `oxfmt --check`.

Proof shape note: the changed path (event handler → `resolveSignalAccessState` → shared ingress kernel → dispatch context) runs real production functions in the committed tests; only the transport/dispatch boundary is a fixture. Live Signal proof was not run: this environment has no signal-cli installation or Signal account.

LOC: production `+10 / -2` (net +8; `access-policy.ts` +5/-1, `event-handler.ts` +5/-1), tests `+79`. The growth is the two-fact boundary split described above — the prior single boolean could not express "request authorization" and "control-lane classification" independently, and no existing structure absorbed the distinction without duplicating detection across both surfaces.

Follow-up noted (not in scope): `message-handler.test-support.ts` injects a `shouldComputeCommandAuthorized` test double that no Teams production path calls today; removing the dead seam deserves its own small change.
