### PR TITLE
refactor(acpx): share command part quoting

### DIFF
--- a/extensions/acpx/src/command-line.ts
+++ b/extensions/acpx/src/command-line.ts
@@ -7,6 +7,11 @@ export function quoteCommandPart(value: string): string {
   return JSON.stringify(value);
 }
 
+/** Preserve OpenClaw's persisted ACPX command identity when appending one argument. */
+export function quoteAcpxCommandPart(value: string): string {
+  return /^[A-Za-z0-9_./:=@+-]+$/.test(value) ? value : `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 /** Split a command string into argv-like parts using simple quote/backslash rules. */
 export function splitCommandParts(value: string): string[] {
   const parts: string[] = [];

--- a/extensions/acpx/src/process-lease.test.ts
+++ b/extensions/acpx/src/process-lease.test.ts
@@ -9,6 +9,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createAcpxProcessLeaseStore,
+  hashAcpxProcessCommand,
   openAcpxProcessLeaseStateStore,
   OPENCLAW_ACPX_LEASE_ID_ARG,
   OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
@@ -117,18 +118,25 @@ describe("withAcpxLeaseEnvironment", () => {
   it("quotes portable lease wrapper args", () => {
     const command = withAcpxLeaseEnvironment({
       command: "node C:/openclaw/acpx/codex-acp-wrapper.mjs",
-      leaseId: "lease test",
-      gatewayInstanceId: "gateway-test",
+      leaseId: "lease owner's",
+      gatewayInstanceId: "gateway test",
     });
 
     expect(command).toBe(
       [
         "node C:/openclaw/acpx/codex-acp-wrapper.mjs",
         OPENCLAW_ACPX_LEASE_ID_ARG,
-        "'lease test'",
+        "'lease owner'\\''s'",
         OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
-        "gateway-test",
+        "'gateway test'",
       ].join(" "),
+    );
+    expect(readAcpxProcessLeaseIdentity(command)).toEqual({
+      leaseId: "lease owner's",
+      gatewayInstanceId: "gateway test",
+    });
+    expect(hashAcpxProcessCommand(command)).toBe(
+      "6f32cded06e0918f184947aa85b4f20e173d1d3a69a4cb14e786902db142af94",
     );
   });
 });

--- a/extensions/acpx/src/process-lease.ts
+++ b/extensions/acpx/src/process-lease.ts
@@ -7,7 +7,7 @@ import type {
   OpenKeyedStoreOptions,
   PluginStateKeyedStore,
 } from "openclaw/plugin-sdk/plugin-state-runtime";
-import { splitCommandParts } from "./command-line.js";
+import { quoteAcpxCommandPart, splitCommandParts } from "./command-line.js";
 import { ACPX_PROCESS_LEASE_MAX_ENTRIES, ACPX_PROCESS_LEASE_NAMESPACE } from "./state.js";
 
 /** CLI argument carrying the ACPX process lease id. */
@@ -185,10 +185,6 @@ export function hashAcpxProcessCommand(command: string): string {
   return createHash("sha256").update(command).digest("hex");
 }
 
-function quoteEnvValue(value: string): string {
-  return /^[A-Za-z0-9_./:=@+-]+$/.test(value) ? value : `'${value.replace(/'/g, "'\\''")}'`;
-}
-
 function appendAcpxLeaseArgs(params: {
   command: string;
   leaseId: string;
@@ -197,9 +193,9 @@ function appendAcpxLeaseArgs(params: {
   return [
     params.command,
     OPENCLAW_ACPX_LEASE_ID_ARG,
-    quoteEnvValue(params.leaseId),
+    quoteAcpxCommandPart(params.leaseId),
     OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
-    quoteEnvValue(params.gatewayInstanceId),
+    quoteAcpxCommandPart(params.gatewayInstanceId),
   ].join(" ");
 }
 

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1326,9 +1326,9 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       `npx @agentclientprotocol/codex-acp@1.6.2 ${OPENCLAW_CODEX_CONFIG_ARG} '{"model":"gpt-5.4","model_reasoning_effort":"medium"}'`,
     );
     expect(testing.isCodexAcpCommand("openclaw acp")).toBe(false);
-    expect(testing.normalizeAgentCommand(["node", "/tmp/codex acp/index.js", "--label", ""])).toBe(
-      "node '/tmp/codex acp/index.js' --label ''",
-    );
+    expect(
+      testing.normalizeAgentCommand(["node", "/tmp/codex acp/index.js", "--label", "owner's", ""]),
+    ).toBe("node '/tmp/codex acp/index.js' --label 'owner'\\''s' ''");
   });
 
   it("passes gpt-5.5 Codex ACP startup through instead of blocking it", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -29,7 +29,7 @@ import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtim
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { AcpRuntimeError, type AcpRuntime, type AcpRuntimeErrorCode } from "../runtime-api.js";
 import { CODEX_ACP_PACKAGE, OPENCLAW_CODEX_CONFIG_ARG } from "./codex-adapter.js";
-import { splitCommandParts } from "./command-line.js";
+import { quoteAcpxCommandPart, splitCommandParts } from "./command-line.js";
 import {
   ACPX_PROBE_LEASE_SESSION_KEY,
   createAcpxProcessLeaseId,
@@ -695,16 +695,9 @@ async function ensureDelegateSessionWithModelFallback(
   }
 }
 
-function quoteShellArg(value: string): string {
-  if (/^[A-Za-z0-9_./:=@+-]+$/.test(value)) {
-    return value;
-  }
-  return `'${value.replace(/'/g, "'\\''")}'`;
-}
-
 function normalizeAgentCommand(command: string | string[]): string | undefined {
   const normalized = Array.isArray(command)
-    ? command.map((part) => quoteShellArg(part)).join(" ")
+    ? command.map((part) => quoteAcpxCommandPart(part)).join(" ")
     : command;
   return normalized.trim() || undefined;
 }
@@ -717,7 +710,7 @@ function appendCodexAcpConfigOverrides(command: string, override: CodexAcpModelO
   if (Object.keys(config).length === 0) {
     return command;
   }
-  return `${command} ${OPENCLAW_CODEX_CONFIG_ARG} ${quoteShellArg(JSON.stringify(config))}`;
+  return `${command} ${OPENCLAW_CODEX_CONFIG_ARG} ${quoteAcpxCommandPart(JSON.stringify(config))}`;
 }
 
 function createModelScopedAgentRegistry(params: {


### PR DESCRIPTION
## What Problem This Solves

ACPX command serialization duplicated the same private quoting policy in runtime registry normalization and process-lease argument insertion. Those commands are persisted and hashed, so independent copies created avoidable drift risk for session reuse and lease identity.

## Why This Change Was Made

The ACPX plugin now owns one private-to-plugin `quoteAcpxCommandPart` codec in its existing command-line module. Runtime registry normalization and process-lease argument insertion both reuse it, while the duplicate `quoteShellArg` and `quoteEnvValue` paths are removed.

The change does not alter `config.ts` command quoting, the existing JSON display/config serializer, SDK or public exports, manifests, dependencies, lockfiles, runtime behavior, or persistence shapes.

## User Impact

No user-visible behavior changes. Existing ACPX command bytes, process-lease identities, and command hashes remain exact.

## Evidence

- Focused consumer-boundary suites: 113 tests passed.
- Full ACPX plugin suite: 275 tests passed across 24 files.
- Exact compatibility proof: all 1,112,064 Unicode scalar values plus 100,000 deterministic generated strings matched both removed implementations with zero differences.
- Lease boundary proof preserves the exact command hash `6f32cded06e0918f184947aa85b4f20e173d1d3a69a4cb14e786902db142af94` and round-trips apostrophe/space-bearing identities.
- Clean Testbox build passed on the exact five-file tree: `tbx_01m1fcpdhbe2znz60ptcjd05tx`, run `33559170833`.
- Import-cycle check: 0 runtime value cycles.
- Plugin SDK surface check passed: 149 public subpaths verified, 0 forbidden package exports.
- Changed-file dry run selected `extensions` and `extensionTests`. All selected production/test typechecks, formatting, lint, boundary, dependency, coercion, deprecated-API, dead-code, database-first, media, sidecar, and architecture checks passed. The linked worktree initially omitted tracked `ui/config` files from its sparse profile; the failed test-typecheck surface passed after materializing those tracked files.
- Exact autoreview: scoped clean, overall confidence `0.92`.
- Judged LOC: production `+11/-17` (net `-6`); tests `+15/-7` (net `+8`).
- Overlap: #132116 remains open and changes `runtime.ts` around `stableLaunchCommand`, not this helper/import hunk. It does not change `normalizeAgentCommand`, `appendCodexAcpConfigOverrides`, registry return shapes, or ACPX `0.13.1`.
- Live ACP execution was not run because this is an exact byte-preserving internal deduplication with no package wiring, runtime policy, or environment behavior change.
