### PR TITLE
ci: scope declaration caches to generator inputs

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -105,6 +105,12 @@ provenance metadata. Private QA shards select their private runtime entries. The
 `build-artifacts` job owns Control UI and SDK declaration validation; release
 package builds still generate the full declarations.
 
+Declaration caches hash the selected writer's transitive generator imports,
+package and plugin metadata, explicit schema and build metadata inputs, and
+the compiler's recorded source files. Editing an unrelated CI script does not
+rebuild declarations. Resolution topology still participates in the cache key,
+and an unresolved generator import stops the build instead of trusting a cache.
+
 Local `pnpm build:ci-artifacts` uses the same memory admission as full and package
 builds. The orchestrator passes the resolved heap budget to every child process,
 including the SDK declaration writer, so local builds do not depend on CI's

--- a/scripts/lib/state-schema-inline-plugin.mts
+++ b/scripts/lib/state-schema-inline-plugin.mts
@@ -16,6 +16,10 @@ const STATE_SCHEMA_MODULES = [
   },
 ] as const;
 
+export const STATE_SCHEMA_GENERATOR_INPUTS = STATE_SCHEMA_MODULES.map(
+  ({ schemaPath }) => schemaPath,
+);
+
 /** Inline canonical schema bytes so bundled consumers need no SQL asset. */
 export function createStateSchemaInlinePlugin(rootDir = process.cwd()) {
   const schemasByModulePath = new Map(

--- a/scripts/lib/tsdown-declaration-generator-inputs.mts
+++ b/scripts/lib/tsdown-declaration-generator-inputs.mts
@@ -1,0 +1,179 @@
+import fs from "node:fs";
+import { builtinModules } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { collectModuleReferencesFromSource } from "./guard-inventory-utils.mjs";
+import { STATE_SCHEMA_GENERATOR_INPUTS } from "./state-schema-inline-plugin.mts";
+import { resolveDeclarationInputCaptureModule } from "./tsdown-declaration-inputs.mts";
+import { resolveTsxImport } from "./tsx-cli-shim.mjs";
+import { resolveWorkerDeployGeneratorInputs } from "./worker-deploy-build-plugin.mts";
+
+const sourceFilePattern = /\.(?:[cm]?[jt]sx?)$/u;
+const builtins = new Set([...builtinModules, ...builtinModules.map((name) => `node:${name}`)]);
+const portablePath = (root: string, file: string) => {
+  const relative = path.relative(root, file);
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+    ? relative.split(path.sep).join("/")
+    : file;
+};
+
+function dynamicEdgeExpressions(sourceFile: ts.SourceFile) {
+  const expressions: string[] = [];
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      node.arguments[0] !== undefined &&
+      ((node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+        !ts.isStringLiteralLike(node.arguments[0])) ||
+        (ts.isIdentifier(node.expression) &&
+          node.expression.text === "require" &&
+          !ts.isStringLiteralLike(node.arguments[0])))
+    ) {
+      expressions.push(node.arguments[0].getText(sourceFile));
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return expressions;
+}
+
+/** Resolve the complete executable and non-module input graph for one declaration writer. */
+export function resolveTsdownDeclarationGeneratorInputs(rootDir: string, generatorEntry: string) {
+  const root = fs.realpathSync(rootDir);
+  const dynamicOwners = new Map<string, { expressions: string[]; targets: string[] }>([
+    [
+      "scripts/lib/dist-artifact-ownership.mts",
+      { expressions: ["script"], targets: [generatorEntry] },
+    ],
+    [
+      "scripts/lib/tsdown-declaration-inputs.mts",
+      {
+        expressions: ["pathToFileURL(resolveDeclarationInputCaptureModule()).href"],
+        targets: [resolveDeclarationInputCaptureModule()],
+      },
+    ],
+    [
+      "scripts/lib/tsdown-declaration-writer.mts",
+      {
+        expressions: ['pathToFileURL(path.join(root, "tsdown.config.ts")).href'],
+        targets: ["tsdown.config.ts"],
+      },
+    ],
+    [
+      "scripts/lib/tsx-cli-shim.mjs",
+      {
+        expressions: ["resolveTsxImport(SHIM_CHECKOUT_ROOT)"],
+        targets: [fileURLToPath(resolveTsxImport(root))],
+      },
+    ],
+  ]);
+  const observedDynamicOwners = new Set<string>();
+  const config = ts.readConfigFile(path.join(root, "tsconfig.json"), (file) =>
+    ts.sys.readFile(file),
+  );
+  if (config.error) {
+    throw new Error(ts.flattenDiagnosticMessageText(config.error.messageText, "\n"));
+  }
+  const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, root);
+  if (parsed.errors.length) {
+    throw new Error(
+      parsed.errors
+        .map((error) => ts.flattenDiagnosticMessageText(error.messageText, "\n"))
+        .join("\n"),
+    );
+  }
+  const compilerOptions = parsed.options;
+  const files = new Map<string, string>();
+
+  const visit = (input: string) => {
+    const requested = input.startsWith("file:") ? fileURLToPath(input) : input;
+    const absolute = fs.realpathSync(path.resolve(root, requested));
+    const id = portablePath(root, absolute);
+    if (files.has(id)) {
+      return;
+    }
+    files.set(id, absolute);
+    if (
+      id === absolute ||
+      id.split("/").includes("node_modules") ||
+      !sourceFilePattern.test(absolute)
+    ) {
+      return;
+    }
+    const source = fs.readFileSync(absolute, "utf8");
+    const sourceFile = ts.createSourceFile(absolute, source, ts.ScriptTarget.Latest, true);
+    const expressions = dynamicEdgeExpressions(sourceFile);
+    const owner = dynamicOwners.get(id);
+    if (
+      JSON.stringify(expressions) !== JSON.stringify(owner?.expressions ?? []) ||
+      (expressions.length > 0 && !owner?.targets.length)
+    ) {
+      throw new Error(`Unresolved dynamic module edges in ${id}: ${JSON.stringify(expressions)}`);
+    }
+    if (owner) {
+      observedDynamicOwners.add(id);
+      owner.targets.forEach(visit);
+    }
+    for (const reference of collectModuleReferencesFromSource(source, {
+      fileName: absolute,
+      ts,
+    })) {
+      if (reference.kind === "import-meta-url") {
+        const target = path.resolve(path.dirname(absolute), reference.specifier);
+        if (fs.statSync(target).isDirectory()) {
+          if (portablePath(root, fs.realpathSync(target)) !== "") {
+            throw new Error(`Unowned import.meta directory in ${id}:${reference.line}`);
+          }
+        } else {
+          visit(target);
+        }
+        continue;
+      }
+      if (builtins.has(reference.specifier)) {
+        continue;
+      }
+      const exact = reference.specifier.startsWith(".")
+        ? path.resolve(path.dirname(absolute), reference.specifier)
+        : undefined;
+      const resolved =
+        exact && fs.existsSync(exact) && fs.statSync(exact).isFile()
+          ? exact
+          : ts.resolveModuleName(reference.specifier, absolute, compilerOptions, ts.sys)
+              .resolvedModule?.resolvedFileName;
+      if (!resolved) {
+        throw new Error(
+          `Unresolved ${reference.kind} in ${id}:${reference.line}: ${reference.specifier}`,
+        );
+      }
+      const canonical = fs.realpathSync(resolved);
+      const relative = path.relative(root, canonical);
+      if (
+        !relative.startsWith(`..${path.sep}`) &&
+        !path.isAbsolute(relative) &&
+        !relative.split(path.sep).includes("node_modules")
+      ) {
+        visit(canonical);
+      }
+      // The lockfile and installed topology own resolved package imports. Exact
+      // computed package targets above remain byte inputs in this same closure.
+    }
+  };
+
+  [generatorEntry, "scripts/tsx.mjs", "tsdown.config.ts"].forEach(visit);
+  for (const owner of dynamicOwners.keys()) {
+    if (!observedDynamicOwners.has(owner)) {
+      throw new Error(`Dynamic module owner is outside the generator closure: ${owner}`);
+    }
+  }
+  return [
+    "package.json",
+    "pnpm-lock.yaml",
+    "tsconfig.json",
+    ...[...files.entries()]
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([, file]) => file),
+    ...STATE_SCHEMA_GENERATOR_INPUTS,
+    ...resolveWorkerDeployGeneratorInputs(root),
+  ];
+}

--- a/scripts/lib/tsdown-declaration-inputs.mts
+++ b/scripts/lib/tsdown-declaration-inputs.mts
@@ -11,6 +11,12 @@ const stagePrefix = (root: string) =>
 const receiptPath = (output: string, name: string) =>
   path.join(output, "..", "compiler-inputs", `${name}.json`);
 
+export function resolveDeclarationInputCaptureModule() {
+  const require = createRequire(import.meta.url);
+  const fromTsdown = createRequire(require.resolve("tsdown"));
+  return fromTsdown.resolve("rolldown-plugin-dts/tsc-context");
+}
+
 export function createDeclarationStage(root: string) {
   return fs.mkdtempSync(stagePrefix(root));
 }
@@ -40,10 +46,8 @@ export function createDeclarationInputCapture(name: string) {
       return;
     }
     const request: { roots: string[] } = JSON.parse(fs.readFileSync(file, "utf8"));
-    const require = createRequire(import.meta.url);
-    const fromTsdown = createRequire(require.resolve("tsdown"));
     const { globalContext }: { globalContext: { programs: ts.Program[] } } = await import(
-      pathToFileURL(fromTsdown.resolve("rolldown-plugin-dts/tsc-context")).href
+      pathToFileURL(resolveDeclarationInputCaptureModule()).href
     );
     const roots = new Set(
       globalContext.programs.flatMap((program) =>

--- a/scripts/lib/tsdown-declaration-writer.mts
+++ b/scripts/lib/tsdown-declaration-writer.mts
@@ -5,7 +5,6 @@ import { pathToFileURL } from "node:url";
 import {
   prepareTsdownBuildExecution,
   TSDOWN_DECLARATION_EXTENSIONS,
-  TSDOWN_DECLARATION_TOOL_INPUTS,
   TSDOWN_UNIFIED_CACHE_ENV,
 } from "../tsdown-build.mts";
 import {
@@ -17,6 +16,7 @@ import {
 import { CompilerInputSnapshot } from "./compiler-input-snapshot.mts";
 import { publishStagedDeclarations } from "./declaration-stage.mts";
 import { withDistArtifactOwnership } from "./dist-artifact-ownership.mts";
+import { resolveTsdownDeclarationGeneratorInputs } from "./tsdown-declaration-generator-inputs.mts";
 import {
   createDeclarationStage,
   readDeclarationInputs,
@@ -27,6 +27,7 @@ export async function writeTsdownDeclarations(
   groups: readonly string[],
   label: string,
   previousOutputs: (root: string) => string[],
+  generatorEntry: string,
 ) {
   const root = process.cwd();
   let staging: string | undefined;
@@ -107,18 +108,7 @@ export async function writeTsdownDeclarations(
       if (!plan) {
         throw new Error("Insufficient memory for declaration build");
       }
-      const generatorInputs = [
-        ...TSDOWN_DECLARATION_TOOL_INPUTS,
-        "tsdown.config.ts",
-        "scripts/write-plugin-sdk-entry-dts.ts",
-        "scripts/write-unified-entry-dts.ts",
-        "scripts/lib/tsdown-declaration-writer.mts",
-        "scripts/lib/declaration-stage.mts",
-        "scripts/lib/compiler-input-snapshot.mts",
-        "scripts/lib/tsdown-declaration-inputs.mts",
-        "src/infra/runtime-process-entrypoints.ts",
-        "extensions/memory-core/src/memory/manager-search-knn-entrypoint.ts",
-      ];
+      const generatorInputs = resolveTsdownDeclarationGeneratorInputs(root, generatorEntry);
       const step: BuildCacheStep = {
         label,
         cache: {
@@ -133,11 +123,8 @@ export async function writeTsdownDeclarations(
         new CompilerInputSnapshot(root, {
           toolchainFiles: resolveTsdownCompilerFiles(),
           generatorInputs,
-          // Config evaluation reads generator modules and package/plugin metadata.
-          // Keep those bytes conservative; only ordinary compiler sources narrow.
-          isGeneratorInput: (file) =>
-            file.startsWith("scripts/") ||
-            /(?:^|\/)(?:package|openclaw\.plugin)\.json$/u.test(file),
+          // Config evaluation reads package/plugin metadata selected from topology.
+          isGeneratorInput: (file) => /(?:^|\/)(?:package|openclaw\.plugin)\.json$/u.test(file),
         });
       const before = snapshot();
       const liveDist = path.join(root, "dist");

--- a/scripts/lib/tsx-cli-shim.mjs
+++ b/scripts/lib/tsx-cli-shim.mjs
@@ -27,7 +27,7 @@ function resolvePrimaryRoot(checkoutRoot) {
   return path.basename(resolved) === ".git" ? path.dirname(resolved) : null;
 }
 
-function resolveTsxImport(checkoutRoot) {
+export function resolveTsxImport(checkoutRoot) {
   const modulesDir =
     process.env.PNPM_CONFIG_MODULES_DIR?.trim() || process.env.npm_config_modules_dir?.trim();
   const hydratedTsxRoot = modulesDir

--- a/scripts/lib/windows-cmd-helpers-runtime.mts
+++ b/scripts/lib/windows-cmd-helpers-runtime.mts
@@ -1,8 +1,7 @@
 // Typed bridge to the plain-Node Windows command helpers.
 import { isRecord } from "./record-shared.mjs";
 
-const runtimeSpecifier = "../windows-cmd-helpers.mjs";
-const runtime: unknown = await import(runtimeSpecifier);
+const runtime: unknown = await import("../windows-cmd-helpers.mjs");
 
 function runtimeFunction(name: string): (...args: unknown[]) => unknown {
   if (!isRecord(runtime) || !(name in runtime)) {

--- a/scripts/lib/worker-deploy-build-plugin.mts
+++ b/scripts/lib/worker-deploy-build-plugin.mts
@@ -22,6 +22,14 @@ const UNDICI_REQUIRE_BOOTSTRAP = [
 ] as const;
 const WORKER_UNDICI_IMPORT = 'import * as bundledUndici from "undici";';
 
+export function resolveWorkerDeployGeneratorInputs(rootDir = process.cwd()) {
+  const playwrightRoot = fs.realpathSync(path.resolve(rootDir, "node_modules/playwright-core"));
+  return [
+    path.join(playwrightRoot, "package.json"),
+    path.join(playwrightRoot, "browsers.json"),
+  ] as const;
+}
+
 /** Composes bundled-plugin runtime and removes dependency package reads from the worker build. */
 export function createWorkerDeployBuildPlugin(rootDir = process.cwd()) {
   const playwrightRoot = fs.realpathSync(path.resolve(rootDir, "node_modules/playwright-core"));
@@ -35,12 +43,12 @@ export function createWorkerDeployBuildPlugin(rootDir = process.cwd()) {
   const undiciDispatcherOptionsPath = fs.realpathSync(
     path.resolve("src/infra/net/undici-dispatcher-options.ts"),
   );
-  const packageJson = JSON.parse(
-    fs.readFileSync(path.join(playwrightRoot, "package.json"), "utf8"),
-  ) as { name: string; version: string };
-  const browsersJson = JSON.parse(
-    fs.readFileSync(path.join(playwrightRoot, "browsers.json"), "utf8"),
-  ) as unknown;
+  const [packageJsonPath, browsersJsonPath] = resolveWorkerDeployGeneratorInputs(rootDir);
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+    name: string;
+    version: string;
+  };
+  const browsersJson = JSON.parse(fs.readFileSync(browsersJsonPath, "utf8")) as unknown;
   const replacement = `    packageRoot = __dirname;
     packageJSON = ${JSON.stringify({ name: packageJson.name, version: packageJson.version })};
     binPath = packageRoot;`;

--- a/scripts/write-plugin-sdk-entry-dts.ts
+++ b/scripts/write-plugin-sdk-entry-dts.ts
@@ -5,11 +5,15 @@ import { TSDOWN_PLUGIN_SDK_DTS_CONFIG_GROUPS } from "./lib/tsdown-config-groups.
 import { writeTsdownDeclarations } from "./lib/tsdown-declaration-writer.mts";
 import { TSDOWN_DECLARATION_EXTENSIONS } from "./tsdown-build.mts";
 
-await writeTsdownDeclarations(TSDOWN_PLUGIN_SDK_DTS_CONFIG_GROUPS, "tsdown-plugin-sdk", (root) =>
-  // This subset owns flat SDK entries, never other groups' shared root chunks.
-  listCacheFiles(
-    root,
-    [{ path: "dist/plugin-sdk", extensions: TSDOWN_DECLARATION_EXTENSIONS, recursive: false }],
-    fs,
-  ),
+await writeTsdownDeclarations(
+  TSDOWN_PLUGIN_SDK_DTS_CONFIG_GROUPS,
+  "tsdown-plugin-sdk",
+  (root) =>
+    // This subset owns flat SDK entries, never other groups' shared root chunks.
+    listCacheFiles(
+      root,
+      [{ path: "dist/plugin-sdk", extensions: TSDOWN_DECLARATION_EXTENSIONS, recursive: false }],
+      fs,
+    ),
+  "scripts/write-plugin-sdk-entry-dts.ts",
 );

--- a/scripts/write-unified-entry-dts.ts
+++ b/scripts/write-unified-entry-dts.ts
@@ -2,6 +2,9 @@ import { TSDOWN_NON_SDK_DTS_CONFIG_GROUPS } from "./lib/tsdown-config-groups.mts
 import { writeTsdownDeclarations } from "./lib/tsdown-declaration-writer.mts";
 import { listReplaceableTsdownDeclarationOutputs } from "./tsdown-build.mts";
 
-await writeTsdownDeclarations(TSDOWN_NON_SDK_DTS_CONFIG_GROUPS, "tsdown-unified", (root) =>
-  listReplaceableTsdownDeclarationOutputs({ cwd: root, roots: ["dist"] }),
+await writeTsdownDeclarations(
+  TSDOWN_NON_SDK_DTS_CONFIG_GROUPS,
+  "tsdown-unified",
+  (root) => listReplaceableTsdownDeclarationOutputs({ cwd: root, roots: ["dist"] }),
+  "scripts/write-unified-entry-dts.ts",
 );

--- a/test/scripts/dist-artifact-ownership.test.ts
+++ b/test/scripts/dist-artifact-ownership.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../scripts/lib/tsdown-config-groups.mts";
 import { createFixtureLifetime } from "../helpers/fixture-lifetime.js";
 import { waitForDead } from "../helpers/process-wait.js";
+import { createFixture as createDeclarationFixture } from "./tsdown-declaration-fixture.js";
 
 const fixture = createFixtureLifetime();
 afterEach(() => fixture.cleanup());
@@ -292,29 +293,40 @@ describe.skipIf(process.platform === "win32")("dist artifact ownership", () => {
     "retains nested $script cleanup metadata (staging cleanup failure=$failStagingCleanup)",
     async ({ script, failStagingCleanup }, { signal }) => {
       await withProcesses(async ({ start }) => {
-        const root = createCheckout();
-        installScripts(root, [script, "run-tsgo.mts", "tsdown-build.mts", "pnpm-runner.mts"]);
-        write(root, "tsconfig.json", '{"extends":"./tsconfig.plugin-sdk.dts.json"}');
-        fs.mkdirSync(path.join(root, "packages"), { recursive: true });
-        fs.symlinkSync(
-          path.join(sourceRoot, "packages/normalization-core"),
-          path.join(root, "packages/normalization-core"),
-        );
+        const groups =
+          script === "write-plugin-sdk-entry-dts.ts"
+            ? TSDOWN_PLUGIN_SDK_DTS_CONFIG_GROUPS
+            : script === "write-unified-entry-dts.ts"
+              ? TSDOWN_NON_SDK_DTS_CONFIG_GROUPS
+              : undefined;
+        // Declaration writers need their real generator graph; this lifetime still
+        // owns the root so timed-out children are joined before inputs are removed.
+        const root = groups
+          ? createDeclarationFixture(
+              groups,
+              path.join(fs.realpathSync(fixture.createTempDir("openclaw-dist-owner-")), "Project"),
+            ).root
+          : createCheckout();
+        if (!groups) {
+          installScripts(root, [script, "run-tsgo.mts", "tsdown-build.mts", "pnpm-runner.mts"]);
+          write(root, "tsconfig.json", '{"extends":"./tsconfig.plugin-sdk.dts.json"}');
+          fs.mkdirSync(path.join(root, "packages"), { recursive: true });
+          fs.symlinkSync(
+            path.join(sourceRoot, "packages/normalization-core"),
+            path.join(root, "packages/normalization-core"),
+          );
+        }
+        const moduleRoot = groups ? root : sourceRoot;
         const scriptUrl = pathToFileURL(path.join(root, "scripts", script)).href;
         const moduleUrl = (name: string) =>
-          pathToFileURL(path.join(sourceRoot, "scripts/lib", name)).href;
-        write(
-          root,
-          "tsdown.config.ts",
-          `export default ${JSON.stringify([...TSDOWN_PLUGIN_SDK_DTS_CONFIG_GROUPS, ...TSDOWN_NON_SDK_DTS_CONFIG_GROUPS])}.map(name => ({ name, dts: { entry: ['fixture.ts'] }, entry: { 'plugin-sdk/fixture': 'fixture.ts' } }));`,
-        );
+          pathToFileURL(path.join(moduleRoot, "scripts/lib", name)).href;
         const failure = `throw new AggregateError([new Error('child failed', { cause: Object.assign(new Error('cleanup unverified'), { processTreeState: 'indeterminate' }) })], 'fixture failure');`;
         const replacements = {
           [scriptUrl]: {
             "./lib/extension-boundary-inputs.mts": `export * from ${JSON.stringify(moduleUrl("extension-boundary-inputs.mts"))}; export class BoundaryInputSnapshot { constructor() { ${failure} } }`,
           },
           [moduleUrl("tsdown-declaration-writer.mts")]: {
-            "../tsdown-build.mts": `export * from ${JSON.stringify(pathToFileURL(path.join(sourceRoot, "scripts/tsdown-build.mts")).href)}; export const prepareTsdownBuildExecution = () => ({});`,
+            "../tsdown-build.mts": `export * from ${JSON.stringify(pathToFileURL(path.join(moduleRoot, "scripts/tsdown-build.mts")).href)}; export const prepareTsdownBuildExecution = () => ({});`,
             "./declaration-stage.mts": `export async function publishStagedDeclarations() { ${failure} }`,
           },
         };

--- a/test/scripts/tsdown-declaration-fixture.ts
+++ b/test/scripts/tsdown-declaration-fixture.ts
@@ -13,7 +13,6 @@ import { createScriptTestHarness } from "./test-helpers.js";
 const { createTempDir } = createScriptTestHarness();
 const sourceRoot = process.cwd();
 export const loader = pathToFileURL(path.resolve("scripts/tsx.mjs")).href;
-const writer = path.resolve("scripts/write-plugin-sdk-entry-dts.ts");
 export const declarationInputs = [
   { file: "src/contract.d.ts", name: "SourceOnly" },
   { file: "root.d.mts", name: "RootOnly" },
@@ -124,8 +123,11 @@ export function createFixture(groups: readonly string[] = TSDOWN_PLUGIN_SDK_DTS_
   fs.mkdirSync(path.join(root, "extensions"));
   fs.mkdirSync(path.join(root, "scripts/lib"));
   for (const script of [
+    "build-all.mts",
     "tsdown-build.mts",
     "pnpm-runner.mts",
+    "windows-cmd-helpers.mjs",
+    "write-plugin-sdk-entry-dts.ts",
     "write-unified-entry-dts.ts",
     "tsx.mjs",
   ]) {
@@ -134,20 +136,10 @@ export function createFixture(groups: readonly string[] = TSDOWN_PLUGIN_SDK_DTS_
       fs.copyFileSync(source, path.join(root, "scripts", script));
     }
   }
-  for (const entry of fs.readdirSync(path.join(sourceRoot, "scripts/lib"), {
-    withFileTypes: true,
-  })) {
-    const source = path.join(sourceRoot, "scripts/lib", entry.name);
-    const target = path.join(root, "scripts/lib", entry.name);
-    if (
-      entry.name === "runtime-process-build-entries.mts" ||
-      entry.name === "runtime-process-core-build-entries.mts"
-    ) {
-      fs.copyFileSync(source, target);
-    } else {
-      fs.symlinkSync(source, target, entry.isDirectory() ? "junction" : "file");
-    }
-  }
+  // Generator imports must resolve inside the same tree whose bytes are cached.
+  fs.cpSync(path.join(sourceRoot, "scripts/lib"), path.join(root, "scripts/lib"), {
+    recursive: true,
+  });
   // These owners derive runtime inputs from import.meta.url; keep that graph inside the fixture.
   const runtimeEntryOwners = new Set([
     "src/infra/runtime-process-entrypoints.ts",
@@ -278,7 +270,12 @@ export function createFixture(groups: readonly string[] = TSDOWN_PLUGIN_SDK_DTS_
 }
 
 export function runWriter(root: string, privateQa = false, env: NodeJS.ProcessEnv = {}) {
-  return runFixture(root, ["--import", loader, writer], privateQa, env);
+  return runFixture(
+    root,
+    ["--import", loader, path.join(root, "scripts/write-plugin-sdk-entry-dts.ts")],
+    privateQa,
+    env,
+  );
 }
 
 export function runUnifiedBuild(root: string) {
@@ -288,8 +285,8 @@ export function runUnifiedBuild(root: string) {
     "--input-type=module",
     "--eval",
     `
-import { resolveBuildAllSteps, runBuildAllSteps } from ${JSON.stringify(pathToFileURL(path.join(sourceRoot, "scripts/build-all.mts")).href)};
-import { withDistArtifactOwnership } from ${JSON.stringify(pathToFileURL(path.join(sourceRoot, "scripts/lib/dist-artifact-ownership.mts")).href)};
+import { resolveBuildAllSteps, runBuildAllSteps } from ${JSON.stringify(pathToFileURL(path.join(root, "scripts/build-all.mts")).href)};
+import { withDistArtifactOwnership } from ${JSON.stringify(pathToFileURL(path.join(root, "scripts/lib/dist-artifact-ownership.mts")).href)};
 await withDistArtifactOwnership(process.cwd(), async () => {
   const steps = resolveBuildAllSteps("full").filter(step =>
     ["tsdown-unified", "write-unified-entry-dts"].includes(step.label));
@@ -303,7 +300,7 @@ await withDistArtifactOwnership(process.cwd(), async () => {
 export function runUnifiedWriter(root: string, env: NodeJS.ProcessEnv = {}) {
   return runFixture(
     root,
-    ["--import", loader, path.join(sourceRoot, "scripts/write-unified-entry-dts.ts")],
+    ["--import", loader, path.join(root, "scripts/write-unified-entry-dts.ts")],
     false,
     env,
   );

--- a/test/scripts/tsdown-declaration-fixture.ts
+++ b/test/scripts/tsdown-declaration-fixture.ts
@@ -100,8 +100,10 @@ process.stdout.write(JSON.stringify({ inputs, selected, declarations }));
   };
 }
 
-export function createFixture(groups: readonly string[] = TSDOWN_PLUGIN_SDK_DTS_CONFIG_GROUPS) {
-  const root = path.join(fs.realpathSync(createTempDir("openclaw-sdk-declarations-")), "Project");
+export function createFixture(
+  groups: readonly string[] = TSDOWN_PLUGIN_SDK_DTS_CONFIG_GROUPS,
+  root = path.join(fs.realpathSync(createTempDir("openclaw-sdk-declarations-")), "Project"),
+) {
   fs.mkdirSync(root, { recursive: true });
   fs.mkdirSync(path.join(root, ".artifacts"));
   fs.symlinkSync(path.resolve("node_modules"), path.join(root, "node_modules"), "junction");

--- a/test/scripts/write-unified-entry-dts.test.ts
+++ b/test/scripts/write-unified-entry-dts.test.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { readArtifactRecord } from "../../scripts/lib/build-artifact-cache.mts";
 import { TSDOWN_NON_SDK_DTS_CONFIG_GROUPS } from "../../scripts/lib/tsdown-config-groups.mts";
+import { resolveTsdownDeclarationGeneratorInputs } from "../../scripts/lib/tsdown-declaration-generator-inputs.mts";
 import {
   createFixture,
   declarationInputs,
@@ -14,6 +15,95 @@ import {
 } from "./tsdown-declaration-fixture.js";
 
 describe("write-unified-entry-dts", () => {
+  it("owns the executable generator closure without unrelated CI planning code", () => {
+    const root = process.cwd();
+    const closure = resolveTsdownDeclarationGeneratorInputs(
+      root,
+      "scripts/write-unified-entry-dts.ts",
+    ).map((file) => path.relative(root, file).split(path.sep).join("/"));
+
+    expect(closure).toEqual(
+      expect.arrayContaining([
+        "scripts/lib/tsdown-declaration-generator-inputs.mts",
+        "scripts/lib/plugin-sdk-entrypoints.json",
+        "scripts/lib/record-shared.mjs",
+        "packages/normalization-core/src/mountinfo-path.ts",
+        "extensions/memory-core/src/memory/manager-search-knn-entrypoint.ts",
+        "src/state/openclaw-state-schema.sql",
+        "src/state/openclaw-agent-schema.sql",
+      ]),
+    );
+    expect(closure).not.toContain("scripts/lib/ci-node-test-plan.mts");
+  });
+
+  it.each([
+    ["unowned dynamic", "\nvoid import(generatorTarget);\n", "Unresolved dynamic module edges"],
+    ["unresolved static", '\nimport "./missing-generator-owner.mts";\n', "Unresolved import"],
+  ])("rejects an %s edge in the real generator graph", (_name, injected, message) => {
+    const readFileSync = fs.readFileSync.bind(fs);
+    const read = vi.spyOn(fs, "readFileSync").mockImplementation((file, options) => {
+      const contents = readFileSync(file, options);
+      return typeof contents === "string" && String(file).endsWith("numeric-options.mjs")
+        ? `${contents}${injected}`
+        : contents;
+    });
+    try {
+      expect(() =>
+        resolveTsdownDeclarationGeneratorInputs(
+          process.cwd(),
+          "scripts/write-unified-entry-dts.ts",
+        ),
+      ).toThrow(message);
+    } finally {
+      read.mockRestore();
+    }
+  });
+
+  it("rejects a same-count computed import retarget", () => {
+    const readFileSync = fs.readFileSync.bind(fs);
+    const read = vi.spyOn(fs, "readFileSync").mockImplementation((file, options) => {
+      const contents = readFileSync(file, options);
+      return typeof contents === "string" && String(file).endsWith("tsx-cli-shim.mjs")
+        ? contents.replace(
+            "resolveTsxImport(SHIM_CHECKOUT_ROOT)",
+            "resolveTsxImport(process.cwd())",
+          )
+        : contents;
+    });
+    try {
+      expect(() =>
+        resolveTsdownDeclarationGeneratorInputs(
+          process.cwd(),
+          "scripts/write-unified-entry-dts.ts",
+        ),
+      ).toThrow("Unresolved dynamic module edges");
+    } finally {
+      read.mockRestore();
+    }
+  });
+
+  it("leaves physical and external installed dependencies to lockfile topology", () => {
+    const root = process.cwd();
+    const list = () =>
+      resolveTsdownDeclarationGeneratorInputs(root, "scripts/write-unified-entry-dts.ts").map(
+        (file) => path.relative(root, file).split(path.sep).join("/"),
+      );
+    expect(list().some((file) => file.endsWith("/typescript/lib/typescript.d.ts"))).toBe(false);
+
+    const realpathSync = fs.realpathSync.bind(fs);
+    const realpath = vi.spyOn(fs, "realpathSync").mockImplementation((file, options) => {
+      const name = String(file).replaceAll("\\", "/");
+      return name.endsWith("/node_modules/typescript/lib/typescript.d.ts")
+        ? path.join(root, "node_modules/typescript/lib/typescript.d.ts")
+        : realpathSync(file, options as never);
+    });
+    try {
+      expect(list().some((file) => file.endsWith("/typescript/lib/typescript.d.ts"))).toBe(false);
+    } finally {
+      realpath.mockRestore();
+    }
+  });
+
   it("reuses six complete unified groups after unrelated byte edits while rebuilding runtime", () => {
     const { root, write, production, declarations } = createFixture(
       TSDOWN_NON_SDK_DTS_CONFIG_GROUPS,
@@ -113,6 +203,10 @@ describe("write-unified-entry-dts", () => {
     write("test/unrelated.test.ts", "export const test = 2;\n");
     write("ui/unrelated.ts", "export const view = 2;\n");
     write(".github/workflows/unrelated.yml", "name: unrelated after\n");
+    fs.appendFileSync(
+      path.join(root, "scripts/lib/ci-node-test-plan.mts"),
+      "\n// Unrelated CI planning edit.\n",
+    );
     fs.rmSync(path.join(root, "dist"), { recursive: true });
     for (const [file, bytes] of Object.entries(preserved)) {
       write(file, bytes);


### PR DESCRIPTION
## What Problem This Solves

An unrelated CI planner edit invalidates every declaration cache because the declaration writer hashes every file under `scripts/` as generator code. In [run 33543755885](https://github.com/openclaw/openclaw/actions/runs/33543755885/job/99976571762), Docker restored the protected build archive but still spent 305.6 seconds rebuilding all six unified and both SDK declaration groups. The Docker job took 530 seconds.

## Why This Change Was Made

The declaration writer now uses the transitive executable inputs of its selected entry, the TypeScript loader, and the canonical build configuration. The resolver reuses the existing TypeScript module-reference parser, follows repository and workspace imports, and retains package/plugin metadata, compiler receipts, dependency topology, schema SQL, and Playwright build metadata. Existing runtime resolvers also supply the exact computed loader and compiler targets. Unknown computed imports and unresolved imports fail the build.

This replaces the blanket `scripts/**` byte dependency and the partial hand-maintained generator list. The fixed Windows helper import becomes literal. Non-module input paths remain declared by the schema and worker build plugins that read them. Installed dependencies retain the existing lockfile/topology trust contract; they are immutable within a setup-completed CI job.

## User Impact

CI-only script edits can reuse valid declarations while the runtime build still runs. Declaration contents, compiler validation, staging/publication ownership, memory admission, and protected cache publication remain unchanged. There is no new dependency or product configuration.

## Evidence

- The existing real-compiler regression fails on the previous writer: after an unrelated planner edit, seven compiler invocations run instead of the one runtime invocation. With the fix, the runtime rebuilds and all six declaration groups restore with identical output and cache hashes.
- Both complete declaration owner suites pass: 21 cases, including SDK partition selection, moved-cache reuse, nominal type identity, invalid configuration, input mutation, failed compiler receipts, and preservation of the previously published generation.
- Five focused resolver cases cover real graph membership, unknown computed imports, unresolved static imports, a same-count computed-import retarget, and both physical and externally linked installed dependencies.
- Fixtures now execute their copied writer and build owner from the same temporary repository. This preserves actual module identity and input ownership instead of importing generator code from outside the tree being cached.
- Changed-file checks and a fresh scoped Codex review pass. After refreshing onto current main, the patch has only a context change around the worker plugin; all five resolver cases pass again against that current generator graph.
- [The first native run](https://github.com/openclaw/openclaw/actions/runs/33560098168) passed its build and declaration suites but exposed four existing ownership fixtures that lacked the now-required generator graph. They now reuse the canonical declaration fixture with a caller-owned temporary root, retaining the real nested module identity and joined cleanup. The four cases fail before this repair; all nineteen ownership cases and both existing default-factory declaration checks pass afterward. The selected changed-file gate and a fresh scoped Codex review pass. This repair changes test setup only and preserves every cleanup assertion.

- [Current-head native CI run 33562366246, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33562366246/attempts/2) passed on `f3049db00a7b617c3dfa709fe3d7057d35169914`. The first attempt reached 124 successful jobs and 15 skips, then three remaining jobs waited 20 minutes without a runner or executed step. Retrying the unfinished jobs through the existing hosted fallback completed validation; no source changed during recovery.
- Fresh full-diff Codex review on that head found no actionable P0 issue (scoped clean, confidence 0.98). The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/135559#issuecomment-5501284586) reports no correctness or security finding. Its rank-up request is satisfied: the full exact-head CI run has 128 successful jobs, 15 intentional skips, and a successful aggregate gate.
- The final maintainer inspection closes the review environment’s remaining evidence gaps. The declaration owner, snapshot, staging, compiler capture, entry scripts, canonical `tsdown.config.ts`, and worker plugin on current main `19620d1877a5e6b4a0bcd371224cd981b7dc83cd` are unchanged from the inspected base. Installed TypeScript resolution code and the actual loader/compiler resolvers were inspected directly and exercised by the real compiler fixtures. The worker-plugin edit only extracts paths for existing package and browser metadata reads; it changes no durable schema or serialized state.

Retained local proof commands:

```sh
node scripts/run-vitest.mjs test/scripts/dist-artifact-ownership.test.ts -t 'retains nested'
node scripts/run-vitest.mjs test/scripts/dist-artifact-ownership.test.ts test/scripts/write-plugin-sdk-entry-dts.test.ts test/scripts/write-unified-entry-dts.test.ts -t 'dist artifact ownership|preserves repository input metadata|records successful empty partitions'
node scripts/check-changed.mjs -- test/scripts/dist-artifact-ownership.test.ts test/scripts/tsdown-declaration-fixture.ts
```

Native protected publication followed by an ordinary consumer hit is still required to measure the full CI improvement. The earlier outer archive hit was not an inner declaration-cache hit, and this PR does not claim that the five-minute target has been reached.

Judged LOC: product runtime unchanged; build tooling +227/-39, tests +122/-16, test support +20/-21, docs +6/-0. The new resolver is necessary to retain the complete executable input boundary while removing unrelated script bytes; it reuses the existing parser and replaces the partial input list instead of adding a second cache path.
