### PR TITLE
test(infra): reuse commit-resolution setup

### DIFF
--- a/src/infra/git-commit.test.ts
+++ b/src/infra/git-commit.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import { gitCommitPrefixesMatch } from "./git-commit.js";
 
@@ -48,8 +48,6 @@ async function makeFakeGitRepo(
   const gitdir = options.gitdir ?? path.join(root, ".git");
   if (options.gitdir) {
     await fs.writeFile(path.join(root, ".git"), `gitdir: ${options.gitdir}\n`, "utf-8");
-  } else {
-    await fs.mkdir(gitdir, { recursive: true });
   }
   await fs.mkdir(gitdir, { recursive: true });
   await fs.writeFile(path.join(gitdir, "HEAD"), options.head, "utf-8");
@@ -99,7 +97,8 @@ describe("git commit resolution", () => {
   let resolveCommitHash: (typeof import("./git-commit.js"))["resolveCommitHash"];
   let resolveLoadedCommitHash: (typeof import("./git-commit.js"))["resolveLoadedCommitHash"];
 
-  beforeEach(async () => {
+  // Unique fixture paths isolate cache entries without reloading the owner for each case.
+  beforeAll(async () => {
     vi.restoreAllMocks();
     vi.doUnmock("node:fs");
     vi.doUnmock("node:module");
@@ -109,8 +108,6 @@ describe("git commit resolution", () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
-    vi.doUnmock("node:fs");
-    vi.doUnmock("node:module");
     await tempDirs.cleanup();
   });
 


### PR DESCRIPTION
## What Problem This Solves

The commit-resolution tests repeatedly rebuild the same module graph while exercising independent temporary repositories, adding setup time to the infra test lane.

## Why This Change Was Made

Load the resolver once after the suite's deliberate clean import. Each case already owns a unique search directory, so the production cache remains isolated without a reset before every case. Keep per-case spy restoration and filesystem cleanup, and remove a duplicate directory creation in the repository fixture.

## User Impact

No runtime behavior changes. The suite avoids 23 module resets while retaining all 33 existing cases, including positive/negative caching, LRU eviction, bounded short reads, worktree refs, package containment, and loaded-build identity.

## Evidence

- Before: 33/33 passing; measured test time 757 ms.
- After: 39/39 passing across commit-resolution and Git-root tests; same 33 commit-resolution case identities; measured suite time 414 ms.
- Shuffled order (seed 731): 33/33 passing, 378 ms. These single-run timings are observations, not a stable benchmark.
- Full changed-file gate passed: focused infra typecheck/lint, formatting, architecture/API guards, and production/full-tree/script dead-export scans.
- Diff-scoped Codex review (P0 scope): clean; manual cache and fixture-lifecycle review completed.
- Production LOC: zero. Test LOC: +3/-6.

The broader attempt also exposed an unchanged version-output suite cold-import timeout in a separate shard before this test ran. Its pending callback then contaminated the next JSON capture. That failure is recorded for a separate focused repair; this PR does not change that path.


## Review follow-through

The completed ClawSweeper review found no code findings. Its remaining verification concern is resolved by the maintainer runs already recorded above: all 33 owner cases, six Git-root sibling cases, and all 33 shuffled owner cases (seed 731) pass. [Exact-head CI is green](https://github.com/openclaw/openclaw/actions/runs/33560423982). The suite-level import, unique fixture paths, and per-case cleanup remain as reviewed. No code change or repeat review is needed for the review worker's missing dependency/network access.
