### PR TITLE
fix(ui): keep sidebar and chat fades off scrollbars

### DIFF
--- a/ui/src/e2e/sidebar-selection-overflow.e2e.test.ts
+++ b/ui/src/e2e/sidebar-selection-overflow.e2e.test.ts
@@ -13,7 +13,7 @@ const suite = createControlUiE2eSuite({
 });
 
 suite.define(() => {
-  it("keeps the active session pill clear of a classic scrollbar", async () => {
+  it("keeps the active session pill and fade clear of a classic scrollbar", async () => {
     const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
     if (captureProof) {
       await fs.mkdir(path.join(suite.artifactDir, "sidebar-selection-overflow"), {
@@ -58,8 +58,11 @@ suite.define(() => {
         }
         const rowRect = row.getBoundingClientRect();
         const sectionRect = section.getBoundingClientRect();
+        const scrollerStyle = getComputedStyle(scroller);
         return {
           inset: sectionRect.right - rowRect.right,
+          maskImage: scrollerStyle.maskImage,
+          maskSize: scrollerStyle.maskSize,
           overflows: scroller.scrollHeight > scroller.clientHeight,
           sectionPaddingEnd: Number.parseFloat(getComputedStyle(section).paddingRight),
         };
@@ -69,6 +72,8 @@ suite.define(() => {
       expect(geometry.inset, JSON.stringify(geometry)).toBeGreaterThanOrEqual(
         geometry.sectionPaddingEnd,
       );
+      expect(geometry.maskImage.match(/linear-gradient/g)).toHaveLength(2);
+      expect(geometry.maskSize.split(", ")).toContain("12px 100%");
 
       if (captureProof) {
         await page.screenshot({

--- a/ui/src/e2e/sidebar-selection-overflow.e2e.test.ts
+++ b/ui/src/e2e/sidebar-selection-overflow.e2e.test.ts
@@ -62,6 +62,7 @@ suite.define(() => {
         return {
           inset: sectionRect.right - rowRect.right,
           maskImage: scrollerStyle.maskImage,
+          maskPosition: scrollerStyle.maskPosition,
           maskSize: scrollerStyle.maskSize,
           overflows: scroller.scrollHeight > scroller.clientHeight,
           sectionPaddingEnd: Number.parseFloat(getComputedStyle(section).paddingRight),
@@ -73,7 +74,14 @@ suite.define(() => {
         geometry.sectionPaddingEnd,
       );
       expect(geometry.maskImage.match(/linear-gradient/g)).toHaveLength(2);
+      expect(geometry.maskPosition.split(", ").at(-1)?.split(" ")[0]).toBe("100%");
       expect(geometry.maskSize.split(", ")).toContain("12px 100%");
+
+      const rtlMaskPosition = await active.evaluate((row) => {
+        document.documentElement.dir = "rtl";
+        return getComputedStyle(row.closest<HTMLElement>(".sidebar-shell__body")!).maskPosition;
+      });
+      expect(rtlMaskPosition.split(", ").at(-1)?.split(" ")[0]).toBe("0%");
 
       if (captureProof) {
         await page.screenshot({

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1938,6 +1938,8 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
 
   it.each([
     [1200, 800, "desktop"],
+    [900, 500, "landscape-900"],
+    [640, 900, "responsive-640"],
     [320, 568, "mobile-320"],
     [375, 812, "mobile-375"],
     [430, 932, "mobile-430"],
@@ -1987,15 +1989,32 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
                 width: bounds.width,
               };
             };
+            const composer = document
+              .querySelector<HTMLElement>(".agent-chat__composer-shell")!
+              .getBoundingClientRect();
+            const thread = document
+              .querySelector<HTMLElement>(".chat-thread")!
+              .getBoundingClientRect();
+            const fade = getComputedStyle(
+              document.querySelector<HTMLElement>(".agent-chat__composer-shell")!,
+              "::before",
+            );
             return {
               composer: rect(".agent-chat__composer-shell"),
               conversation: rect(".chat-main__conversation"),
+              fadeInsetLeft: composer.left + Number.parseFloat(fade.left) - thread.left,
+              fadeInsetRight: thread.right - (composer.right - Number.parseFloat(fade.right)),
+              scrollbarSize: Number.parseFloat(
+                getComputedStyle(document.documentElement).getPropertyValue("--scrollbar-size"),
+              ),
               thread: rect(".chat-thread"),
             };
           });
         expect(await page.locator(".chat-topbar-notices").isVisible()).toBe(false);
         expect(await page.locator(".agent-chat__composer-overlay").isVisible()).toBe(false);
         const before = await geometry();
+        expect(before.fadeInsetLeft).toBeGreaterThanOrEqual(before.scrollbarSize);
+        expect(before.fadeInsetRight).toBeGreaterThanOrEqual(before.scrollbarSize);
         await page.locator(".chat-topbar-notices").evaluate((node) => {
           node.innerHTML =
             '<div class="chat-composer-neighbor-card chat-cloud-disk-space-notice">Disk space low</div>';
@@ -3112,47 +3131,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         expect(thread.width).toBeCloseTo(768, 0);
         expect(Math.abs(assistantLane.left - thread.left)).toBeLessThanOrEqual(1);
         expect(Math.abs(userLane.right - thread.right)).toBeLessThanOrEqual(1);
-      } finally {
-        await closeBrowserPage(page);
-      }
-    },
-  );
-
-  it.each([
-    [393, 852],
-    [640, 900],
-    [900, 500],
-    [1366, 900],
-  ] as const)(
-    "keeps the transcript fade inside its scrollbar gutters at %sx%s",
-    async (width, height) => {
-      const page = await openFixture(width, height, { direct: true });
-      try {
-        const geometry = await page.evaluate(() => {
-          const composer = document.querySelector<HTMLElement>(".agent-chat__composer-shell");
-          const transcript = document.querySelector<HTMLElement>(".chat-thread");
-          if (!composer || !transcript) {
-            throw new Error("Missing transcript fade fixture");
-          }
-          const composerRect = composer.getBoundingClientRect();
-          const transcriptRect = transcript.getBoundingClientRect();
-          const fadeStyle = getComputedStyle(composer, "::before");
-          const rootStyle = getComputedStyle(document.documentElement);
-          return {
-            fadeLeft: composerRect.left + Number.parseFloat(fadeStyle.left),
-            fadeRight: composerRect.right - Number.parseFloat(fadeStyle.right),
-            scrollbarSize: Number.parseFloat(rootStyle.getPropertyValue("--scrollbar-size")),
-            transcriptLeft: transcriptRect.left,
-            transcriptRight: transcriptRect.right,
-          };
-        });
-
-        expect(geometry.fadeLeft - geometry.transcriptLeft).toBeGreaterThanOrEqual(
-          geometry.scrollbarSize,
-        );
-        expect(geometry.transcriptRight - geometry.fadeRight).toBeGreaterThanOrEqual(
-          geometry.scrollbarSize,
-        );
       } finally {
         await closeBrowserPage(page);
       }

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1938,8 +1938,8 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
 
   it.each([
     [1200, 800, "desktop"],
-    [900, 500, "landscape-900"],
-    [640, 900, "responsive-640"],
+    [900, 500, "mobile-landscape-900"],
+    [640, 900, "mobile-responsive-640"],
     [320, 568, "mobile-320"],
     [375, 812, "mobile-375"],
     [430, 932, "mobile-430"],

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -3120,6 +3120,47 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
 
   it.each([
     [393, 852],
+    [640, 900],
+    [900, 500],
+    [1366, 900],
+  ] as const)(
+    "keeps the transcript fade inside its scrollbar gutters at %sx%s",
+    async (width, height) => {
+      const page = await openFixture(width, height, { direct: true });
+      try {
+        const geometry = await page.evaluate(() => {
+          const composer = document.querySelector<HTMLElement>(".agent-chat__composer-shell");
+          const transcript = document.querySelector<HTMLElement>(".chat-thread");
+          if (!composer || !transcript) {
+            throw new Error("Missing transcript fade fixture");
+          }
+          const composerRect = composer.getBoundingClientRect();
+          const transcriptRect = transcript.getBoundingClientRect();
+          const fadeStyle = getComputedStyle(composer, "::before");
+          const rootStyle = getComputedStyle(document.documentElement);
+          return {
+            fadeLeft: composerRect.left + Number.parseFloat(fadeStyle.left),
+            fadeRight: composerRect.right - Number.parseFloat(fadeStyle.right),
+            scrollbarSize: Number.parseFloat(rootStyle.getPropertyValue("--scrollbar-size")),
+            transcriptLeft: transcriptRect.left,
+            transcriptRight: transcriptRect.right,
+          };
+        });
+
+        expect(geometry.fadeLeft - geometry.transcriptLeft).toBeGreaterThanOrEqual(
+          geometry.scrollbarSize,
+        );
+        expect(geometry.transcriptRight - geometry.fadeRight).toBeGreaterThanOrEqual(
+          geometry.scrollbarSize,
+        );
+      } finally {
+        await closeBrowserPage(page);
+      }
+    },
+  );
+
+  it.each([
+    [393, 852],
     [900, 500],
     [1366, 900],
     [1920, 1080],

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2165,10 +2165,9 @@ button.chat-reply-preview--message:disabled {
    covers it. The solid tail sits behind rounded corners, so card silhouettes
    cannot expose unfaded text; its chat-surface color is invisible when there
    is no transcript behind it. */
-.agent-chat__composer-shell::before {
+.chat-main__conversation > .agent-chat__composer-shell::before {
   position: absolute;
-  inset: calc(0px - var(--chat-transcript-fade-height, 20px)) calc(0px - var(--chat-thread-gutter))
-    auto;
+  inset: calc(0px - var(--chat-transcript-fade-height, 20px)) 0 auto;
   height: calc(
     var(--chat-transcript-fade-height, 20px) + var(--chat-transcript-fade-stack-overlap, 20px)
   );
@@ -7261,6 +7260,10 @@ button.chat-pr__diff {
     gap: 6px;
   }
 
+  .chat-main__conversation > .agent-chat__composer-shell::before {
+    inset-inline: calc(var(--chat-thread-gutter) - var(--chat-mobile-edge-inset, 4px));
+  }
+
   .session-suggestions {
     width: calc(100% - 8px);
   }
@@ -7432,12 +7435,6 @@ button.chat-pr__diff {
    the secondary controls share one smaller box so model and effort can remain
    visible instead of collapsing into the model menu. */
 @media (max-width: 560px) {
-  /* The taller mobile fade follows the transcript content bounds, not the
-     scroll viewport bounds, so the edge gutters and scrollbar stay uncovered. */
-  .agent-chat__composer-shell::before {
-    inset-inline: calc(var(--chat-thread-gutter) - 4px);
-  }
-
   .agent-chat__input--mobile-toolbar {
     --chat-composer-min-height: 105px;
     --chat-mobile-row-target-size: 32px;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1330,7 +1330,7 @@ openclaw-settings-save-indicator:empty {
     var(--scrollbar-size) 100% no-repeat;
 }
 
-.sidebar-shell__body:dir(rtl) {
+:root[dir="rtl"] .sidebar-shell__body {
   --sidebar-scrollbar-edge: left;
 }
 

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1321,8 +1321,11 @@ openclaw-settings-save-indicator:empty {
 .sidebar-shell__body--scroll-top,
 .sidebar-shell__body--scroll-middle,
 .sidebar-shell__body--scroll-bottom {
-  -webkit-mask-image: var(--sidebar-body-mask);
-  mask-image: var(--sidebar-body-mask);
+  /* The second layer keeps the native scrollbar out of the content fade. */
+  -webkit-mask: var(--sidebar-body-mask), linear-gradient(black, black) right /
+    var(--scrollbar-size) 100% no-repeat;
+  mask: var(--sidebar-body-mask), linear-gradient(black, black) right / var(--scrollbar-size) 100%
+    no-repeat;
 }
 
 .sidebar-recent-sessions__group {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1321,17 +1321,19 @@ openclaw-settings-save-indicator:empty {
 .sidebar-shell__body--scroll-top,
 .sidebar-shell__body--scroll-middle,
 .sidebar-shell__body--scroll-bottom {
-  --sidebar-scrollbar-edge: right;
+  --sidebar-scroll-edge: right;
 
   /* The second layer keeps the native scrollbar out of the content fade. */
-  -webkit-mask: var(--sidebar-body-mask), linear-gradient(black, black)
-    var(--sidebar-scrollbar-edge) / var(--scrollbar-size) 100% no-repeat;
-  mask: var(--sidebar-body-mask), linear-gradient(black, black) var(--sidebar-scrollbar-edge) /
-    var(--scrollbar-size) 100% no-repeat;
+  -webkit-mask:
+    var(--sidebar-body-mask),
+    linear-gradient(black, black) var(--sidebar-scroll-edge) / var(--scrollbar-size) 100% no-repeat;
+  mask:
+    var(--sidebar-body-mask),
+    linear-gradient(black, black) var(--sidebar-scroll-edge) / var(--scrollbar-size) 100% no-repeat;
 }
 
 :root[dir="rtl"] .sidebar-shell__body {
-  --sidebar-scrollbar-edge: left;
+  --sidebar-scroll-edge: left;
 }
 
 .sidebar-recent-sessions__group {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1321,11 +1321,17 @@ openclaw-settings-save-indicator:empty {
 .sidebar-shell__body--scroll-top,
 .sidebar-shell__body--scroll-middle,
 .sidebar-shell__body--scroll-bottom {
+  --sidebar-scrollbar-edge: right;
+
   /* The second layer keeps the native scrollbar out of the content fade. */
-  -webkit-mask: var(--sidebar-body-mask), linear-gradient(black, black) right /
+  -webkit-mask: var(--sidebar-body-mask), linear-gradient(black, black)
+    var(--sidebar-scrollbar-edge) / var(--scrollbar-size) 100% no-repeat;
+  mask: var(--sidebar-body-mask), linear-gradient(black, black) var(--sidebar-scrollbar-edge) /
     var(--scrollbar-size) 100% no-repeat;
-  mask: var(--sidebar-body-mask), linear-gradient(black, black) right / var(--scrollbar-size) 100%
-    no-repeat;
+}
+
+.sidebar-shell__body:dir(rtl) {
+  --sidebar-scrollbar-edge: left;
 }
 
 .sidebar-recent-sessions__group {


### PR DESCRIPTION
Closes #135562

## What Problem This Solves

Fixes an issue where users with overflowing sidebar sessions or chat history would see the vertical scrollbar fade together with content at the top or bottom edge. The sidebar and chat transcript used distinct fade owners, but both painted across the scrollbar strip.

## Why This Change Was Made

The sidebar keeps its existing state-aware content mask and adds an opaque mask layer over the canonical scrollbar strip. The chat composer fade is constrained to the transcript content lane on desktop, responsive, and landscape-phone layouts, matching the existing scrollbar-safe header fade.

The two paths remain owner-specific: the sidebar mask reflects remaining scroll directions, while the chat fade is the fixed transition above an intentionally underlapping transcript. No scrollbar styling, scroll behavior, gutter geometry, or mock fixture ships in this change.

CSS Masking Level 1 section 7.10, [The Mask Image Rendering Model](https://www.w3.org/TR/css-masking-1/#the-mask-image-rendering-model), explains why masking the sidebar scroller affects its rendered group as a whole. The fix changes that mask composition; it does not rely on `scrollbar-gutter` to exempt the scrollbar.

## User Impact

Sidebar and chat scrollbars remain legible through the fade regions, so users can read the current scroll position without losing the existing overflow cues.

## Evidence

### LTR Before

Both right-side scrollbar thumbs are visible and faded at the content edges.

![LTR Before: right-side sidebar and chat scrollbars are faded at the content edges](https://github.com/user-attachments/assets/aeab88a1-99da-4a9c-bce3-9fff86468f94)

### LTR After

Both right-side scrollbar thumbs remain fully legible through the fade regions.

![LTR After: right-side sidebar and chat scrollbars remain legible](https://github.com/user-attachments/assets/8c701e8f-895e-43c4-95a7-e9dc28d7e492)

### RTL Before

With the document direction reversed, both scrollbar thumbs move to the left edge and are faded there.

![RTL Before: left-side sidebar and chat scrollbars are faded at the content edges](https://github.com/user-attachments/assets/06afd937-b3c7-4c8e-a4a0-7f3b85bf9a3a)

### RTL After

The sidebar mask follows the scrollbar to the left edge, while the symmetric chat gutters keep the transcript scrollbar legible.

![RTL After: left-side sidebar and chat scrollbars remain legible](https://github.com/user-attachments/assets/a2addbbb-1071-4d42-8024-2bd84cc44905)

All screenshots use the same `1101x800` viewport, partially scrolled sidebar and transcript, content, and dark theme. Chromium ran without its default `--hide-scrollbars` argument and with overlay scrollbars disabled so both native scrollbar thumbs are visible in-frame. Each image was inspected before upload; fixture model text was replaced with synthetic text before capture without touching either fade or scrollbar region.

Focused regression coverage included in the commit:

- The classic-scrollbar sidebar E2E requires two mask layers, a `12px` opaque scrollbar layer, and verifies its physical edge in LTR and RTL.
- The existing faithful chat layout matrix now covers desktop, `640px` responsive, landscape phone, and narrow phone layouts; each fade edge must remain at least one canonical scrollbar width inside the transcript scrollport.

Local suites, builds, typechecks, and lint were not run on the mock-only workstation. Exact-head CI is the validation owner for this closeout.

ClawSweeper Rank-up disposition: exact-head lint/UI failures are being resolved before merge. The optional local focused rerun is skipped because this workstation is restricted to mock-only verification; exact-head CI runs the changed browser and sidebar E2E coverage instead.

Consumers checked nominally:

- App sidebar Pages, Online, and Sessions content share `.sidebar-shell__body`; all retain the same state-aware fades and scrollbar placement.
- Normal chat, dashboard chat, split/retained panes, responsive/mobile chat, and the question composer share the direct conversation composer fade and receive the scrollbar-safe bounds.
- The read-only task transcript has no adjacent composer fade and remains unchanged.
- New Session and Custodian reuse the composer shell class outside the chat conversation; the narrowed selector intentionally leaves them unchanged.
- Inbox overflow cues, composer textarea, slash/skill menus, composer queue, session goal, attachment rail, side-panel tabs, markdown tables, task suggestions, code blocks, and collapsed tool disclosures own separate bounded fade geometries and remain unchanged.
