### PR TITLE
fix(auth): map claude-cli 410 session-expired to the re-auth hint

### DIFF
--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -252,6 +252,38 @@ describe("oauth refresh failure hints", () => {
     });
   });
 
+  it("classifies structured claude-cli 410 session-expired failures as a provider refresh failure", () => {
+    const error = new FailoverError(
+      "Failed to authenticate: OAuth session expired and could not be refreshed",
+      {
+        reason: "session_expired",
+        provider: "claude-cli",
+        model: "claude-sonnet-4-20250514",
+        status: 410,
+      },
+    );
+
+    expect(classifyOAuthRefreshFailureError(error)).toEqual({
+      provider: "claude-cli",
+      reason: "revoked",
+    });
+  });
+
+  it("classifies the claude-cli OAuth session-expired message without structured metadata", () => {
+    const message =
+      "Provider claude-cli failed: Failed to authenticate: OAuth session expired and could not be refreshed";
+    expect(classifyOAuthRefreshFailure(message)).toEqual({
+      provider: "claude-cli",
+      reason: "revoked",
+    });
+  });
+
+  it("does not classify a non-claude OAuth session-expired message as a Claude refresh failure", () => {
+    const otherProviderMessage =
+      "Provider openai failed: Failed to authenticate: OAuth session expired and could not be refreshed";
+    expect(classifyOAuthRefreshFailure(otherProviderMessage)).toBeNull();
+  });
+
   it("does not classify a 401 auth failure without claude-cli prefix as a refresh failure", () => {
     // A generic 401 from another provider should NOT be treated as an OAuth
     // refresh failure — it lacks the "claude-cli" provider prefix.

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -136,9 +136,17 @@ const SAFE_PROVIDER_ID_RE = /^[a-z0-9][a-z0-9._-]*$/;
 // unrelated provider 401 failures.
 const CLAUDE_CLI_AUTH_FAILURE_RE =
   /\bclaude-cli\b.+?\b(failed to authenticate|401\s+invalid authentication credentials)\b/is;
+// 410 session_expired structured failure surfaces "OAuth session expired" without
+// the 401 "Invalid authentication credentials" phrase; recognize it so the same
+// re-authentication hint family is emitted when structured metadata is incomplete.
+const CLAUDE_CLI_SESSION_EXPIRED_RE = /\bclaude-cli\b.+?\boauth session expired\b/is;
 
 function isClaudeCliExpiredOAuthMessage(message: string): boolean {
   return CLAUDE_CLI_AUTH_FAILURE_RE.test(message);
+}
+
+function isClaudeCliSessionExpiredMessage(message: string): boolean {
+  return CLAUDE_CLI_SESSION_EXPIRED_RE.test(message);
 }
 
 function readStructuredClaudeCliAuthFailure(err: unknown): StructuredClaudeCliAuthFailure | null {
@@ -149,8 +157,8 @@ function readStructuredClaudeCliAuthFailure(err: unknown): StructuredClaudeCliAu
   if (
     candidate.name !== "FailoverError" ||
     candidate.provider !== "claude-cli" ||
-    candidate.reason !== "auth" ||
-    candidate.status !== 401
+    (candidate.reason !== "auth" && candidate.reason !== "session_expired") ||
+    (candidate.status !== 401 && candidate.status !== 410)
   ) {
     return null;
   }
@@ -173,7 +181,8 @@ function classifyStructuredClaudeCliOAuthFailureReason(
   }
   const hasExpiredTokenSignal =
     lower.includes("failed to authenticate") ||
-    lower.includes("invalid authentication credentials");
+    lower.includes("invalid authentication credentials") ||
+    lower.includes("oauth session expired");
   return hasExpiredTokenSignal ? "revoked" : null;
 }
 
@@ -183,12 +192,13 @@ function isOAuthRefreshFailureMessage(message: string): boolean {
     lower.includes("oauth token refresh failed") ||
     lower.includes("access token could not be refreshed") ||
     lower.includes("authentication session could not be refreshed automatically") ||
-    isClaudeCliExpiredOAuthMessage(message)
+    isClaudeCliExpiredOAuthMessage(message) ||
+    isClaudeCliSessionExpiredMessage(message)
   );
 }
 
 function extractOAuthRefreshFailureProvider(message: string): string | null {
-  if (isClaudeCliExpiredOAuthMessage(message)) {
+  if (isClaudeCliExpiredOAuthMessage(message) || isClaudeCliSessionExpiredMessage(message)) {
     // The message was produced by the claude-cli subprocess; the provider is
     // statically known — no need to parse it from the error text.
     return "claude-cli";
@@ -256,6 +266,11 @@ export function classifyOAuthRefreshFailureReason(
     // when its stored OAuth token has expired.  Map this to "revoked" so the
     // caller surfaces the targeted re-auth hint rather than the generic login
     // failure copy.
+    return "revoked";
+  }
+  if (isClaudeCliSessionExpiredMessage(message)) {
+    // 410 session_expired: the native Claude login expired and could not be
+    // refreshed. Same targeted re-auth family as the 401 path.
     return "revoked";
   }
   return null;

--- a/src/auto-reply/reply/agent-runner-failure-reply.test.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.test.ts
@@ -89,6 +89,23 @@ describe("buildExternalRunFailureReply", () => {
     );
     expect(reply.isGenericRunnerFailure).toBe(false);
   });
+
+  it("surfaces a Claude CLI re-auth hint for a structured 410 session-expired failure", () => {
+    const message = "Failed to authenticate: OAuth session expired and could not be refreshed";
+    const reply = buildExternalRunFailureReply({
+      message,
+      error: new FailoverError(message, {
+        reason: "session_expired",
+        provider: "claude-cli",
+        model: "claude-sonnet-4-20250514",
+        status: 410,
+      }),
+    });
+
+    expect(reply.text).toContain("Model login expired on the gateway");
+    expect(reply.text).toContain("claude auth login");
+    expect(reply.isGenericRunnerFailure).toBe(false);
+  });
 });
 
 describe("buildPreflightCompactionFailureText", () => {


### PR DESCRIPTION
Closes #135519

## What Problem This Solves

A canonical Anthropic model routed through `agentRuntime.id=claude-cli` that hit a structured `reason=session_expired` / `status=410` failure (native Claude login genuinely expired, "OAuth session expired and could not be refreshed") was reduced to the generic Control UI "Something went wrong" instead of an actionable re-authentication hint. The existing #97669 fix only covered the `reason=auth` / `status=401` shape.

## Why This Change Was Made

`readStructuredClaudeCliAuthFailure` only accepted `reason: "auth"` and `status: 401`, so the 410 `session_expired` shape was never classified. This PR:

- accepts `reason: "session_expired"` alongside `"auth"` and `status: 410` alongside `401` in the structured classifier;
- recognizes the "OAuth session expired" phrase in the reason classifier (mapping to `revoked`), so the same re-auth family is emitted;
- adds a defensive message-level classifier for "OAuth session expired" that is **scoped to `claude-cli`** (the prefix-bound pattern), so a non-Claude provider emitting the same phrase keeps its own recovery path.

The existing `buildExternalRunFailureReply` path then renders "Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli` …" instead of the generic copy. Unrelated provider 410/401 failures keep their existing classification because the classifier still requires the `claude-cli` provider identity or the Claude-specific phrase.

## User Impact

Operators see an actionable `claude auth login` hint when the native Claude CLI login expires, matching the recovery that actually repairs the route, instead of a generic retry message that cannot fix the expired login. Non-Claude providers are unaffected.

## Evidence

Exact head: `106170d0f40d55df9a4546b1452405bbc919a3b4`

- `src/agents/auth-profiles/oauth-refresh-failure.test.ts` — "classifies structured claude-cli 410 session-expired failures", "classifies the claude-cli OAuth session-expired message without structured metadata", and a new negative "does not classify a non-claude OAuth session-expired message as a Claude refresh failure". 21 passed.
- `src/auto-reply/reply/agent-runner-failure-reply.test.ts` — "surfaces a Claude CLI re-auth hint for a structured 410 session-expired failure" asserting the hint contains `claude auth login`. 28 passed across both files.
- Production typecheck passes; `check:changed` is green except the pre-existing unrelated `ui/src/components/markdown-mermaid.runtime.ts` missing-`mermaid` declaration in the reused dependency tree.

## AI Assistance

AI-assisted implementation. I manually verified the 401-vs-410 classifier split, the Claude-scoped message matching, the downstream re-auth hint rendering, the focused regressions including the non-Claude negative, and the changed-file gates.