### PR TITLE
refactor(qa-lab): share polling transport health checks

### DIFF
--- a/extensions/qa-lab/src/live-transports/discord/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/discord/adapter.runtime.ts
@@ -5,6 +5,7 @@ import {
   acquireQaCredentialLease,
   startQaCredentialLeaseHeartbeat,
 } from "../shared/credential-lease.runtime.js";
+import { assertPollingTransportHealthy } from "../shared/live-transport-health.js";
 import { discordQaScenarioSupport } from "./discord-live.runtime.js";
 import { createDiscordQaScenarioEnvironment } from "./scenario-environment.js";
 
@@ -112,12 +113,7 @@ export async function createDiscordQaTransportAdapter(
     accountId,
     requiredPluginIds: ["discord"],
     supportedActions: [],
-    assertTransportHealthy() {
-      if (pollingError) {
-        throw pollingError;
-      }
-      heartbeat.throwIfFailed();
-    },
+    assertTransportHealthy: () => assertPollingTransportHealthy(pollingError, heartbeat),
     async sendInbound(input) {
       const text = input.text.replaceAll("@openclaw", `<@${runtimeEnv.sutApplicationId}>`);
       const sent = await discordQaScenarioSupport.testing.sendChannelMessage(

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-health.test.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-health.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { assertPollingTransportHealthy } from "./live-transport-health.js";
+
+describe("polling transport health", () => {
+  it("throws the polling failure before checking the lease heartbeat", () => {
+    const pollingError = new Error("polling failed");
+    const throwIfFailed = vi.fn(() => {
+      throw new Error("heartbeat failed");
+    });
+
+    try {
+      assertPollingTransportHealthy(pollingError, { throwIfFailed });
+      throw new Error("expected transport health failure");
+    } catch (error) {
+      expect(error).toBe(pollingError);
+    }
+    expect(throwIfFailed).not.toHaveBeenCalled();
+  });
+
+  it("preserves the lease heartbeat failure when polling is healthy", () => {
+    const heartbeatError = new Error("heartbeat failed");
+
+    try {
+      assertPollingTransportHealthy(undefined, {
+        throwIfFailed() {
+          throw heartbeatError;
+        },
+      });
+      throw new Error("expected transport health failure");
+    } catch (error) {
+      expect(error).toBe(heartbeatError);
+    }
+  });
+});

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-health.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-health.ts
@@ -1,0 +1,9 @@
+export function assertPollingTransportHealthy(
+  pollingError: Error | undefined,
+  leaseHeartbeat: { throwIfFailed(): void },
+): void {
+  if (pollingError) {
+    throw pollingError;
+  }
+  leaseHeartbeat.throwIfFailed();
+}

--- a/extensions/qa-lab/src/live-transports/slack/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/adapter.runtime.ts
@@ -14,6 +14,7 @@ import {
   acquireQaCredentialLease,
   startQaCredentialLeaseHeartbeat,
 } from "../shared/credential-lease.runtime.js";
+import { assertPollingTransportHealthy } from "../shared/live-transport-health.js";
 import { createSlackQaScenarioEnvironment } from "./scenario-environment.js";
 import { getSlackQaMessageWriteCursor, readSlackQaMessageWrites } from "./slack-live.capture.js";
 import {
@@ -265,12 +266,7 @@ export async function createSlackQaTransportAdapter(
     accountId,
     requiredPluginIds: ["slack"],
     supportedActions: [],
-    assertTransportHealthy() {
-      if (pollingError) {
-        throw pollingError;
-      }
-      heartbeat.throwIfFailed();
-    },
+    assertTransportHealthy: () => assertPollingTransportHealthy(pollingError, heartbeat),
     async sendInbound(input) {
       heartbeat.throwIfFailed();
       logicalConversationId = input.conversation.id;

--- a/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.ts
@@ -11,6 +11,7 @@ import {
   acquireQaCredentialLease,
   startQaCredentialLeaseHeartbeat,
 } from "../shared/credential-lease.runtime.js";
+import { assertPollingTransportHealthy } from "../shared/live-transport-health.js";
 import { createWhatsAppQaScenarioEnvironment } from "./scenario-environment.js";
 import {
   buildWhatsAppQaConfig,
@@ -138,12 +139,7 @@ export async function createWhatsAppQaTransportAdapter(
     accountId,
     requiredPluginIds: ["whatsapp"],
     supportedActions: [],
-    assertTransportHealthy() {
-      if (pollingError) {
-        throw pollingError;
-      }
-      heartbeat.throwIfFailed();
-    },
+    assertTransportHealthy: () => assertPollingTransportHealthy(pollingError, heartbeat),
     async sendInbound(input) {
       heartbeat.throwIfFailed();
       logicalConversationId = input.conversation.id;


### PR DESCRIPTION
## What Problem This Solves

QA Lab's Discord, Slack, and WhatsApp polling transports duplicated the same ordered health check. That duplication made polling-error precedence and lease-heartbeat error identity easier to drift independently.

## Why This Change Was Made

The private QA Lab live-transport runtime now owns one canonical polling transport health assertion. Discord, Slack, and WhatsApp call it without changing error identity or precedence: an existing polling error is thrown first, otherwise the lease heartbeat is checked.

Matrix remains polling-only. Telegram remains userbot-first. Buzz retains its heartbeat and relay-specific ordering. Credential leases, registries, SDK surfaces, manifests, dependencies, locks, protocol, and configuration are unchanged.

## User Impact

No user-visible behavior changes. This is a private QA Lab refactor that removes three duplicate health-check implementations while preserving byte-equivalent thrown error objects and ordering.

## Evidence

- Root cause: three polling transport adapters independently implemented the same polling-error-first, heartbeat-second invariant.
- Owner: `extensions/qa-lab/src/live-transports/shared/`.
- Canonical fix: `assertPollingTransportHealthy`.
- Removed duplicates: Discord, Slack, and WhatsApp adapter-local implementations.
- Production LOC: +15/-18, net -3. Test LOC: +34/-0.
- Focused helper and adapter tests: 4 files, 20 tests passed.
- Full QA Lab extension suite on Testbox: 225 files, 3193 tests passed.
- `pnpm check:changed` on Testbox: passed.
- `pnpm test:changed` on Testbox: passed all 3 Vitest shards in 651.30s, including the focused extension shard at 4 files and 20 tests.
- `pnpm check:import-cycles` on Testbox: 0 runtime value cycles.
- `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build qaRuntime` on Testbox: passed in 48.7s.
- Delegated Testbox run: `tbx_01m1fcx2xzcb5d40gz8qsk7as4`, exit 0 in 25m40.832s. The backing Blacksmith run is https://github.com/openclaw/openclaw/actions/runs/33559519465.
- Formatter, `git diff --check`, and changed dry-run classification: passed.
- Structured review: two passes, zero actionable findings.
- No live channel run: this is behavior-neutral private QA infrastructure with exact error identity and precedence covered directly. Testbox was used only because the shared worktree's symlinked local install predates the current workspace package export required by the full suite.
- Codex contract check: `openai/codex` `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870` were inspected; neither surface couples to this private transport assertion.
- Overlap check: https://github.com/openclaw/openclaw/pull/119256 touches the WhatsApp adapter for an unrelated `repoRoot` argument. https://github.com/openclaw/openclaw/pull/124467 touches QA transport typing only. Neither overlaps the health invariant.
- Stop conditions rechecked against `origin/main` at `0ac185506ca7f4d2049e58d340279de808526850`: the assertion contract, polling-error producers, heartbeat contract, and net-negative production scope are unchanged.

No changelog entry: pure private refactor.
