### PR TITLE
test(tooling): reuse packed artifact identity fixture

### DIFF
--- a/test/scripts/repo-e2e-artifacts.test.ts
+++ b/test/scripts/repo-e2e-artifacts.test.ts
@@ -1,12 +1,12 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { transferRepoE2eArtifacts } from "../../scripts/repo-e2e-artifacts.mts";
 import { resolveBuildRequirement } from "../../scripts/run-node.mts";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const tempDirs = useAutoCleanupTempDirTracker(afterAll);
 
 function fixture() {
   const root = fs.realpathSync(tempDirs.make("repo-e2e-artifacts-"));
@@ -115,22 +115,45 @@ describe("repo E2E artifact transfer", () => {
     },
   );
 
-  it.each(["targetSha", "profile", "node", "platform", "arch", "privateQa"])(
-    "rejects mismatched %s before extraction",
-    (field) => {
-      const { root, artifact } = fixture();
-      transferRepoE2eArtifacts("pack", artifact, "full", root);
-      const manifest = path.join(artifact, "repo-e2e-build.json");
-      const recorded = JSON.parse(fs.readFileSync(manifest, "utf8"));
-      recorded.identity[field] = "mismatched";
-      fs.writeFileSync(manifest, JSON.stringify(recorded));
-      fs.rmSync(path.join(root, "dist"), { recursive: true });
-      expect(() => transferRepoE2eArtifacts("restore", artifact, "full", root)).toThrow(
-        "artifact identity differs",
-      );
-      expect(fs.existsSync(path.join(root, "dist"))).toBe(false);
-    },
-  );
+  describe.sequential("identity validation", () => {
+    let root: string;
+    let artifact: string;
+    let manifest: string;
+    let originalManifest: string;
+
+    beforeAll(() => {
+      vi.stubEnv("OPENCLAW_BUILD_PRIVATE_QA", "1");
+      try {
+        ({ root, artifact } = fixture());
+        transferRepoE2eArtifacts("pack", artifact, "full", root);
+        manifest = path.join(artifact, "repo-e2e-build.json");
+        originalManifest = fs.readFileSync(manifest, "utf8");
+        fs.rmSync(path.join(root, "dist"), { recursive: true });
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
+    it.each(["targetSha", "profile", "node", "platform", "arch", "privateQa"])(
+      "rejects mismatched %s before extraction",
+      (field) => {
+        // Each probe changes one field of the pristine identity while reusing the real archive.
+        const recorded = JSON.parse(originalManifest);
+        recorded.identity[field] = "mismatched";
+        fs.writeFileSync(manifest, JSON.stringify(recorded));
+        try {
+          expect(fs.existsSync(path.join(root, "dist"))).toBe(false);
+          expect(() => transferRepoE2eArtifacts("restore", artifact, "full", root)).toThrow(
+            "artifact identity differs",
+          );
+          expect(fs.existsSync(path.join(root, "dist"))).toBe(false);
+        } finally {
+          fs.writeFileSync(manifest, originalManifest);
+          fs.rmSync(path.join(root, "dist"), { recursive: true, force: true });
+        }
+      },
+    );
+  });
 
   it("rejects corrupt archives before extraction", () => {
     const { root, artifact } = fixture();


### PR DESCRIPTION
## What Problem This Solves

The repository E2E artifact tests repeatedly initialize Git repositories and create identical tar archives for six identity-rejection cases, even though rejection happens before extraction.

## Why This Change Was Made

Give those six cases one suite-owned packed fixture and run the group sequentially. Each probe starts from pristine manifest bytes, changes exactly one identity field, and restores the manifest and absent-output state in `finally`. Successful restores and corrupt-archive checks retain their own fixtures; the suite owns final directory cleanup.

## User Impact

No runtime or release behavior changes. Four fixture/archive preparations replace nine, avoiding 25 Git and five tar setup subprocesses while retaining all nine scenarios and their real filesystem/process boundaries.

## Evidence

- Before: 9/9 passing; measured suite time 3.28 seconds.
- After: 9/9 passing; 2.17 seconds. Shuffled order (seed 813): 9/9 passing, 1.70 seconds. These are single-run observations, not a stable benchmark.
- All nine leaf case identities retained. The six rejection cases now share an explicit identity-validation group.
- Full changed-file gate passed: root-test typecheck, targeted test lint/formatting, script lint, architecture and API guards.
- Diff-scoped Codex review (P0 scope): clean; manual fixture, environment, and failure-oracle review completed.
- Production LOC: zero. Test LOC: +41/-18; the added lifecycle code preserves independent rejection probes while removing repeated setup.
