### PR TITLE
improve(ui): speed up switching in large session lists

### DIFF
--- a/scripts/control-ui-mock-background-tasks.ts
+++ b/scripts/control-ui-mock-background-tasks.ts
@@ -77,6 +77,7 @@ export function buildBackgroundTasksMock(baseTime: number) {
     finishedTask(5, now),
   ];
   return {
+    sessions: [taskSessionKey, secondTaskSessionKey].map((key) => ({ key })),
     sessionTranscripts: {
       [taskSessionKey]: {
         messages: [

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -3053,6 +3053,7 @@ async function createChatPickerScenario(
     sessionArchiveFiltering: true,
     sessions: [
       ...sessions,
+      ...backgroundTasks.sessions,
       ...archivedSessions,
       ...telegramSessions,
       ...claudeSessions,

--- a/ui/src/components/app-sidebar-row-identity.browser.test.ts
+++ b/ui/src/components/app-sidebar-row-identity.browser.test.ts
@@ -9,28 +9,38 @@ describe.runIf("__vitest_browser__" in globalThis)("sidebar session row DOM iden
     await import("./app-sidebar.ts");
     const { createGatewayHarness, createSessionsHarness, createSessionState, mountSidebar } =
       await import("../test-helpers/app-sidebar.ts");
-    const harness = createSessionsHarness("main", ["agent:main:alpha", "agent:main:beta"]);
-    const { sidebar } = await mountSidebar(
+    const alphaKey = "agent:main:dashboard:11111111-1111-4111-8111-111111111111";
+    const harness = createSessionsHarness("main", [alphaKey, "agent:main:beta"]);
+    Object.assign(harness.sessions.state.result!.sessions[0]!, {
+      displayName: "Release Board",
+      boardFace: "dashboard",
+    });
+    const { provider, sidebar, context } = await mountSidebar(
       createGatewayHarness({ instanceId: "self-instance" } as GatewayBrowserClient).gateway,
       harness.sessions,
     );
+    provider.setContext({ ...context, basePath: "/control" });
+    sidebar.basePath = "/control";
     sidebar.connected = true;
     await sidebar.updateComplete;
 
     const rowFor = (key: string) =>
       sidebar.querySelector<HTMLElement>(`[data-session-tree="${key}"]`);
-    const alphaBefore = rowFor("agent:main:alpha");
+    const alphaBefore = rowFor(alphaKey);
     const betaBefore = rowFor("agent:main:beta");
     expect(alphaBefore).not.toBeNull();
     expect(betaBefore).not.toBeNull();
+    expect(alphaBefore?.querySelector("a")?.getAttribute("href")).toBe(
+      "/control/dashboard/main/release-board-11111111?nav=collapsed",
+    );
 
     // A newly created session sorts first (createdAt desc) and shifts every
     // existing row's position; keyed reuse must move their DOM, not rebuild it.
-    const next = createSessionState("main", [
-      "agent:main:alpha",
-      "agent:main:beta",
-      "agent:main:gamma",
-    ]);
+    const next = createSessionState("main", [alphaKey, "agent:main:beta", "agent:main:gamma"]);
+    Object.assign(next.result!.sessions[0]!, {
+      displayName: "Renamed Board",
+      boardFace: "chat",
+    });
     const gamma = next.result?.sessions.find((row) => row.key === "agent:main:gamma");
     if (gamma) {
       gamma.createdAt = Date.now();
@@ -42,7 +52,13 @@ describe.runIf("__vitest_browser__" in globalThis)("sidebar session row DOM iden
       row.getAttribute("data-session-tree"),
     );
     expect(rowKeys[0]).toBe("agent:main:gamma");
-    expect(rowFor("agent:main:alpha")).toBe(alphaBefore);
+    expect(rowFor(alphaKey)).toBe(alphaBefore);
     expect(rowFor("agent:main:beta")).toBe(betaBefore);
+    expect(alphaBefore?.querySelector("a")?.getAttribute("href")).toBe(
+      "/control/chat/main/renamed-board-11111111?nav=collapsed",
+    );
+    expect(betaBefore?.querySelector("a")?.getAttribute("href")).toBe(
+      "/control/chat/main/beta?nav=collapsed",
+    );
   });
 });

--- a/ui/src/components/app-sidebar-session-narration.test.ts
+++ b/ui/src/components/app-sidebar-session-narration.test.ts
@@ -15,7 +15,6 @@ function runningRow(key: string): SidebarRecentSession {
     key,
     label: "Run",
     updatedAt: Date.now(),
-    href: "#",
     active: false,
     visuallyActive: false,
     hasActiveRun: true,

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -22,10 +22,6 @@ import {
   sessionMatchesVisibleSessionScope,
 } from "../lib/sessions/index.ts";
 import {
-  resolveSessionPreferredFace,
-  sessionNavigationTarget,
-} from "../lib/sessions/route-navigation.ts";
-import {
   areUiSessionKeysEquivalent,
   buildAgentMainSessionKey,
   isAcpSessionKey,
@@ -163,12 +159,6 @@ export function buildSidebarSessionNavigationState(input: {
   resolveAgentStatusNote: (row: GatewaySessionRow) => string | undefined;
 }): SidebarSessionNavigationState {
   const { context } = input;
-  const mainKey = context
-    ? resolveUiConfiguredMainKey({
-        agentsList: context.agents.state.agentsList,
-        hello: context.gateway.snapshot.hello,
-      })
-    : undefined;
   const navigation = resolveSessionNavigation({
     result: input.sessionsResult,
     activeSession: input.activeSession,
@@ -208,15 +198,6 @@ export function buildSidebarSessionNavigationState(input: {
       userLabel: row.label,
       subtitle: resolveSessionWorkSubtitle(row),
       workContext: resolveSessionWorkContext(row),
-      href: sessionNavigationTarget({
-        face: resolveSessionPreferredFace(row),
-        sessionKey: row.key,
-        fallbackAgentId: navigation.selectedAgentId,
-        basePath: context?.basePath ?? "",
-        row,
-        mainKey,
-        preferenceDerivedFace: true,
-      }).href,
       active: row.key === navigation.activeRowKey,
       visuallyActive: input.highlightCurrentSession && row.key === navigation.currentSessionKey,
       // Normalize optional gateway state before collapsing it to the sidebar's required fact.

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -303,6 +303,19 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     return this.getSessionNavigationState().selectedAgentId;
   }
 
+  sidebarSessionHref(session: SidebarRecentSession): string {
+    // Build links only for rendered rows, after full-roster projection and pagination.
+    return sessionNavigationTarget({
+      face: resolveSessionPreferredFace(session),
+      sessionKey: session.key,
+      fallbackAgentId: this.selectedAgentIdForSessions(),
+      basePath: this.context?.basePath ?? "",
+      row: session,
+      mainKey: this.context ? this.sessionMainKey() : undefined,
+      preferenceDerivedFace: true,
+    }).href;
+  }
+
   sidebarSessionStatusFilter(): SidebarSessionStatusFilter {
     return this.sessionsStatusFilter;
   }

--- a/ui/src/components/app-sidebar-session-projection.test.ts
+++ b/ui/src/components/app-sidebar-session-projection.test.ts
@@ -14,7 +14,6 @@ function sessionRow(
   return {
     key,
     label: key,
-    href: `/chat/${key}`,
     active: false,
     visuallyActive: false,
     hasActiveRun: false,

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -111,6 +111,7 @@ export interface SessionListHost {
   isSessionChildrenFullyShown(sessionKey: string): boolean;
   startSessionDrag(session: SidebarRecentSession): void;
   finishSessionDrag(): void;
+  sidebarSessionHref(session: SidebarRecentSession): string;
   handleSessionRowClick(event: MouseEvent, session: SidebarRecentSession): void;
   toggleSessionChildren(session: SidebarRecentSession): void;
   toggleSessionPin(session: SidebarRecentSession): void;
@@ -344,7 +345,7 @@ export function renderRecentSession(params: {
       @mouseleave=${stopHoverMarqueeFromEvent}
     >
       <a
-        href=${withSidebarNavCollapseIntent(session.href)}
+        href=${withSidebarNavCollapseIntent(host.sidebarSessionHref(session))}
         class="sidebar-recent-session__link"
         draggable="false"
         aria-current=${session.visuallyActive ? "page" : nothing}

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -79,7 +79,6 @@ export type SidebarRecentSession = {
   /** Compact repo/branch/node line for work sessions. */
   subtitle?: string;
   workContext?: SessionWorkContext;
-  href: string;
   active: boolean;
   visuallyActive: boolean;
   hasActiveRun: boolean;

--- a/ui/src/e2e/board-fixture.e2e.test.ts
+++ b/ui/src/e2e/board-fixture.e2e.test.ts
@@ -223,38 +223,48 @@ describeStandaloneMockServer("standalone Control UI mock server", () => {
     }
   });
 
-  it("serves background-task transcripts through both chat entry points", async () => {
-    const page = await browser.newPage();
-    try {
-      await page.goto(new URL("/chat", fixtureServer.url).toString());
-      await page.getByRole("textbox", { name: "Message Molty" }).waitFor();
-      const sessionKey = "agent:openclaw-mock:subagent:mock-task-1";
-      const [description] = (await requestPreviewGateway(page, [
-        { method: "sessions.describe", params: { key: sessionKey } },
-      ])) as Array<{ session: { sessionId: string } }>;
-      const replies = await requestPreviewGateway(
-        page,
-        ["chat.history", "chat.startup"].map((method) => ({
-          method,
-          params: { sessionKey },
-        })),
-      );
-      for (const reply of replies) {
-        expect(reply).toMatchObject({
-          sessionId: description!.session.sessionId,
-          messages: [
-            { role: "user", content: [{ text: expect.stringContaining("Map the run-status") }] },
-            {
-              role: "assistant",
-              content: [{ text: expect.stringContaining("Tracing task events") }],
-            },
-          ],
+  it.each([
+    { task: 1, user: "Map the run-status", assistant: "Tracing task events" },
+    { task: 2, user: "Audit the gateway", assistant: "Comparing requester" },
+  ])(
+    "serves background task $task through both chat entry points",
+    async ({ task, user, assistant }) => {
+      const page = await browser.newPage();
+      try {
+        await page.goto(new URL("/chat", fixtureServer.url).toString());
+        await page.getByRole("textbox", { name: "Message Molty" }).waitFor();
+        const sessionKey = `agent:openclaw-mock:subagent:mock-task-${task}`;
+        const [description] = (await requestPreviewGateway(page, [
+          { method: "sessions.describe", params: { key: sessionKey } },
+        ])) as Array<{ session: { sessionId: string } }>;
+        expect(description).toMatchObject({
+          session: { key: sessionKey, sessionId: expect.any(String) },
         });
+        const replies = await requestPreviewGateway(
+          page,
+          ["chat.history", "chat.startup"].map((method) => ({
+            method,
+            params: { sessionKey },
+          })),
+        );
+        for (const reply of replies) {
+          expect(reply).toMatchObject({
+            sessionId: description!.session.sessionId,
+            sessionInfo: description!.session,
+            messages: [
+              { role: "user", content: [{ text: expect.stringContaining(user) }] },
+              {
+                role: "assistant",
+                content: [{ text: expect.stringContaining(assistant) }],
+              },
+            ],
+          });
+        }
+      } finally {
+        await page.close();
       }
-    } finally {
-      await page.close();
-    }
-  });
+    },
+  );
 
   it("keeps the main preview run active when hydrating canonical session metadata", async () => {
     const page = await browser.newPage();

--- a/ui/src/e2e/chat-skill-library.e2e.test.ts
+++ b/ui/src/e2e/chat-skill-library.e2e.test.ts
@@ -180,6 +180,8 @@ suite.define(() => {
       await expect.poll(() => back.evaluate((node) => node.matches(":focus"))).toBe(true);
       await page.keyboard.press("Enter");
       await menu.getByText("Selected for this session", { exact: true }).waitFor();
+      // The new view renders before its frame-bound focus handoff finishes.
+      await expect.poll(() => back.evaluate((node) => node.matches(":focus"))).toBe(true);
       expect(await gateway.getRequests("skills.library.activate")).toHaveLength(0);
       await page.keyboard.press("Home");
       await page.keyboard.press("ArrowDown");

--- a/ui/src/lib/sessions/index-supplemental-reconcile.test.ts
+++ b/ui/src/lib/sessions/index-supplemental-reconcile.test.ts
@@ -35,7 +35,7 @@ function capabilityWithList(result: ReturnType<typeof sessionsResult>) {
 }
 
 describe("supplemental session reconciliation", () => {
-  it("does not notify subscribers when lineage republishes the current row and defaults", async () => {
+  it("publishes an owner change but not unchanged lineage rows and defaults", async () => {
     const canonical = {
       key,
       kind: "direct" as const,
@@ -47,6 +47,12 @@ describe("supplemental session reconciliation", () => {
       await sessions.refresh({ force: true });
       const published = vi.fn();
       sessions.subscribe(published);
+      const result = sessions.state.result;
+      sessions.reconcile(canonical, result?.defaults, { resultAgentId: "main" });
+      expect(sessions.state.result).toBe(result);
+      expect(sessions.state.agentId).toBe("main");
+      expect(published).toHaveBeenCalledOnce();
+      published.mockClear();
       const owner = {
         activeSessionLineageRoot: null,
         activeSessionLineageSelectedRow: null,

--- a/ui/src/lib/sessions/index-supplemental-reconcile.test.ts
+++ b/ui/src/lib/sessions/index-supplemental-reconcile.test.ts
@@ -35,6 +35,41 @@ function capabilityWithList(result: ReturnType<typeof sessionsResult>) {
 }
 
 describe("supplemental session reconciliation", () => {
+  it("does not notify subscribers when lineage republishes the current row and defaults", async () => {
+    const canonical = {
+      key,
+      kind: "direct" as const,
+      sessionId: "session-device",
+      updatedAt: 10,
+    };
+    const sessions = capabilityWithList(sessionsResult([canonical], 10));
+    try {
+      await sessions.refresh({ force: true });
+      const published = vi.fn();
+      sessions.subscribe(published);
+      const owner = {
+        activeSessionLineageRoot: null,
+        activeSessionLineageSelectedRow: null,
+        childSessionRowsByParent: {},
+        context: { sessions },
+        sessionsResult: sessions.state.result,
+      };
+
+      publishActiveSessionLineage(
+        owner,
+        key,
+        { rowsByParent: {}, topmostRow: canonical, lookupFailed: false },
+        sessions.canonicalListRevision,
+      );
+
+      expect(owner.activeSessionLineageSelectedRow).toEqual(canonical);
+      expect(sessions.state.result?.sessions).toEqual([canonical]);
+      expect(published).not.toHaveBeenCalled();
+    } finally {
+      sessions.dispose();
+    }
+  });
+
   it("preserves a matching canonical row when history started before its list", async () => {
     const sessions = capabilityWithList(
       sessionsResult(
@@ -53,6 +88,8 @@ describe("supplemental session reconciliation", () => {
     const sourceCanonicalListRevision = sessions.canonicalListRevision;
 
     await sessions.refresh({ force: true });
+    const published = vi.fn();
+    sessions.subscribe(published);
     sessions.reconcile(
       {
         key,
@@ -73,6 +110,7 @@ describe("supplemental session reconciliation", () => {
       model: "gpt-5.6-luna",
       contextTokens: 128_000,
     });
+    expect(published).toHaveBeenCalledOnce();
     sessions.dispose();
   });
 

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -316,15 +316,17 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     const result = decorateRows(
       reconcileSessionHistory(state.result, row, defaults, historyOptions, preserveCanonicalRow),
     );
-    if (result === state.result) {
+    const agentId = options?.resultAgentId?.trim()
+      ? normalizeAgentId(options.resultAgentId)
+      : state.agentId;
+    // Ownership can change without changing any rows; subscribers need both.
+    if (result === state.result && agentId === state.agentId) {
       return true;
     }
     publish({
       ...state,
       result,
-      agentId: options?.resultAgentId?.trim()
-        ? normalizeAgentId(options.resultAgentId)
-        : state.agentId,
+      agentId,
     });
     return true;
   };

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -585,14 +585,18 @@ export function reconcileSessionHistory(
   const nextDefaults = defaults
     ? preserveRicherThinkingMetadata(defaults, result.defaults)
     : result.defaults;
+  // Lineage and repeated events can supply the current defaults. Preserve
+  // result identity when nothing changes so shared subscribers stay quiet.
+  const resultWithDefaults =
+    nextDefaults === result.defaults ? result : { ...result, defaults: nextDefaults };
   if (preserveMatchingExistingRow && existing) {
-    return defaults ? { ...result, defaults: nextDefaults } : result;
+    return resultWithDefaults;
   }
   if (isOlderSessionSnapshot(session, existing)) {
     return result;
   }
   if (isOutsideResultScope || (!existing && !isPersistedSessionRow(session))) {
-    return defaults ? { ...result, defaults: nextDefaults } : result;
+    return resultWithDefaults;
   }
   const visibleKey = existing?.key ?? session.key;
   const visibleSession = preserveRosterPresentationMetadata(
@@ -603,19 +607,14 @@ export function reconcileSessionHistory(
     existing,
   );
   if (isStaleForActiveSession(visibleSession, existing)) {
-    // Keep result identity when nothing changed so the caller's
-    // result === state.result publish gate can skip a spurious re-render.
-    return defaults ? { ...result, defaults: nextDefaults } : result;
+    return resultWithDefaults;
   }
   if (
     existing &&
     isShallowEqualSessionRow(visibleSession, existing) &&
     sessionMatchesArchivedFilter(visibleSession, archivedFilter)
   ) {
-    // The same event reconciled twice (capability handler + chat page) must
-    // no-op the second pass; a fresh array here defeats every downstream
-    // result === state.result publish gate and re-renders per event.
-    return defaults ? { ...result, defaults: nextDefaults } : result;
+    return resultWithDefaults;
   }
   const sessions = sessionMatchesArchivedFilter(visibleSession, archivedFilter)
     ? [

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-row-lifecycle.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-row-lifecycle.ts
@@ -23,6 +23,7 @@ describe("AppSidebar catalog row lifecycle", () => {
       )!;
       adoptedRow.label = label;
       adoptedRow.displayName = "Captured native title";
+      adoptedRow.boardFace = "dashboard";
       const { sidebar } = await mountSidebar(
         createGateway({} as GatewayBrowserClient),
         sessions.sessions,
@@ -37,6 +38,9 @@ describe("AppSidebar catalog row lifecycle", () => {
       expect(row?.querySelector(".sidebar-recent-session__name")?.textContent).toBe(expected);
       expect(row?.querySelector("[data-session-menu]")?.getAttribute("aria-label")).toContain(
         expected,
+      );
+      expect(row?.querySelector("a")?.getAttribute("href")).toBe(
+        "/dashboard/main/adopted-title?nav=collapsed",
       );
     },
   );

--- a/ui/src/test-helpers/control-ui-e2e.sessions.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.sessions.test.ts
@@ -143,6 +143,27 @@ it.for(["rows", "static list"])(
   },
 );
 
+it("returns a missing descriptor without materializing an unseeded session", async ({
+  connect,
+}) => {
+  const { request } = await connect({
+    defaultAgentId: "ops",
+    sessionKey: notes.key,
+    sessions: [notes],
+  });
+  const missingKey = "agent:ops:main";
+
+  expect((await request("sessions.describe", { key: missingKey })).payload).toEqual({
+    session: null,
+  });
+  expect((await request("sessions.list")).payload.sessions).toEqual([
+    expect.objectContaining(notes),
+  ]);
+  expect((await request("chat.history", { sessionKey: missingKey })).payload).not.toHaveProperty(
+    "sessionInfo",
+  );
+});
+
 it.for(["cases", "sequence"])(
   "does not invent metadata for %s-only rows",
   async (kind, { connect }) => {
@@ -162,7 +183,6 @@ it.for(["cases", "sequence"])(
             : { sequence: [list, { sessions: [] }] },
       },
     });
-    const identity = { key: row.key, sessionId: row.sessionId };
     for (const method of ["chat.startup", "chat.history"]) {
       // A sessionInfo is a complete row replacement at the UI boundary, not a patch.
       expect((await request(method, { sessionKey: row.key })).payload).not.toHaveProperty(
@@ -170,9 +190,8 @@ it.for(["cases", "sequence"])(
       );
     }
     expect((await request("sessions.list")).payload.sessions).toEqual([row]);
-    expect((await request("sessions.describe", { key: row.key })).payload.session).toEqual(
-      identity,
-    );
+    // Wire-only list responses do not declare a canonical stored row for describe.
+    expect((await request("sessions.describe", { key: row.key })).payload.session).toBeNull();
   },
 );
 

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -2008,7 +2008,7 @@ function installControlUiMockGateway(
       case "sessions.describe": {
         const key =
           isRecord(params) && typeof params.key === "string" ? params.key : scenario.sessionKey;
-        return { session: sessions.read(key) };
+        return { session: sessions.sessionInfo(key) ?? null };
       }
       case "chat.metadata":
         return {


### PR DESCRIPTION
Related: #135332 (earlier session-switch sidebar work).

<details>
<summary>Additional instructions</summary>

The branch is in openclaw/openclaw and remains editable by maintainers.

</details>

## What Problem This Solves

Switching between existing chats still takes longer to become interactive when the session sidebar has a large roster. This maintainer-requested follow-up reduces that work while keeping the existing session routes and retained chat panes.

## Why This Change Was Made

Preserve the session result when lineage reconciliation supplies the current defaults and an unchanged row, so shared subscribers do not receive a redundant publication. Build session links through the existing URL owner in the row renderer, after pagination, instead of computing a link for every roster row.

The old projected href field and its full-roster construction path are removed. Pinned, child and adopted catalog rows share the same renderer; configured main/global routes, preferred faces and base paths retain the existing routing contract. Production LOC: +29/-34 (net -5); tests: +138/-45; test support and preview tooling: +3/-1. No new cache, dependency, configuration, protocol or persistence surface.

The benchmark also exposed an incorrect mock: sessions.describe invented a descriptor for an absent session and could turn a 500-row fixture into 501 rows. The mock now returns session:null through its canonical fixture owner, matching the Gateway's missing-entry contract. Regression coverage protects absent and materialized rows. The preview fixture explicitly seeds its two background-task sessions so describe, history and startup agree on their identity.

## User Impact

The measured optimization reduced median click-to-interactive latency by about 13% for retained-session switching with a 500-session roster in the paired frontend benchmark. The 50-session median is effectively unchanged.

| Roster | Median before → after | p95 before → after |
| ---: | ---: | ---: |
| 50 sessions | 34.00 → 34.35 ms | 48.3 → 44.5 ms |
| 500 sessions | 49.65 → 43.25 ms | 66.0 → 58.8 ms |

The 500-session median improved in all three pairs: 51.20 → 43.80 ms, 48.95 → 44.20 ms and 49.90 → 40.35 ms. First-open observations were noisy and are not claimed as an improvement.

## Evidence

- Fresh integrated branch: 896 tests across 14 files passed, including the unchanged restored-global-queue regression, actual lineage-to-capability notifications, retained-pane ownership, row DOM identity, main/global/preferred-face routes, catalog adoption and mock descriptor contracts.
- Sixteen Chromium E2E flows across four files passed: preview fixtures, retained-pane hydration/reconnect, sidebar ordering across run completion and native-session sidebar behavior. The setup builds the production UI for the tested source.
- All four interrupted-scroll variants passed locally, and all eight disclosure-anchor cases passed in the subsequent hosted run. The scrolling implementation and assertions remain unchanged.
- Fresh Codex autoreview (default P0 scope) passed on the complete branch plus CI repairs now committed as f7be8445a845a96cd2058db381718069bc5864da with no accepted/actionable findings.
- The full prescribed changed-file gate passed on 6e8e4be4: core-test/UI/script type checks, formatting, lint, i18n, dependency guards, script erasability and all dead-export scans. The final two-line test-only follow-up passed both skill-library browser cases, formatting and targeted lint; production code is unchanged. [Final-head CI](https://github.com/openclaw/openclaw/actions/runs/33566883904) completed successfully on f7be8445, including the required CI gate.

The first hosted run caught two integration regressions. The no-op publication check now compares both result identity and agent ownership, so setting a list's owner cannot be lost when rows are unchanged. Its regression proves exactly one ownership notification followed by no redundant lineage notification. The preview's missing task-session records are now seeded through the existing fixture owner; unknown describe requests still return null. Both failures were reproduced before repair and then passed locally and in the next hosted run. That run exposed a separate skill-menu test race: returning from Back renders the next view before its scheduled focus handoff. The test now waits for the new Back row to receive focus before sending more keys, preserving all existing native-keyboard and permission assertions without changing production code.

### Measurement scope

Three alternating baseline/candidate pairs, 32 retained switches per run, six warmups: 96 retained samples per build and roster, including every slow outlier. Real Chromium 151, production bundles, 1440×900 viewport, ten initially rendered sidebar rows, and fixed 70/30-message transcripts. A switch completes only when the target transcript is visible, the pane owns an enabled composer and the target route is committed.

The paired measurements and images use pinned baseline c07f0487472cd390a7e895539ae5ed9196002724 and measured candidate 30b0380f73035b05e5723d7585ff38f5f7ff2b36. The optimization was cleanly rebased onto eee230d0b763d30e737aaf0c28c7277aa30adcf9, then received the ownership and fixture repairs described above. The final integrated source received the fresh checks above and the separate final-head retiming below. Both benchmark variants use the same corrected mock Gateway. Host load was shared and variable; this is frontend evidence, not an isolated-host confidence interval or a provider/network latency measurement. Live access to the session-owned dev Gateway was blocked by the environment's browser access restriction, so no real-Gateway timing claim is made.

Separate six-switch CPU profiles mapped every sampled bundle frame to verified source maps (451/451 baseline, 434/434 candidate). Sampled application-containing time fell from 268.5 to 216.3 ms. URL-owner containing time fell from 23.6 to 6.1 ms; sidebar projection containing time fell from 103.0 to 66.6 ms. These owner figures overlap and are not additive or independent latency estimates.

An experimental liveness scan simplification did not produce a repeatable improvement and was removed. Remaining follow-up candidates are system-chrome computed-style work and repeated session-key normalization; neither is changed here.

### Final-head follow-up

A fresh production build of f7be8445a845a96cd2058db381718069bc5864da was compared with the same pinned baseline in two alternating orders (baseline/final, then final/baseline): 64 retained switches per build at 500 sessions, six warmups per run. Median click-to-interactive time was 50.75 → 43.90 ms (13.5% lower), and p95 was 69.6 → 59.9 ms. Both pairs improved: 50.75 → 42.15 ms and 50.70 → 45.65 ms. Visible-transcript timing was effectively flat at 7.90 → 7.95 ms.

These samples are separate from the original 96-sample experiment. The final comparison includes intervening main changes and does not independently isolate attribution to this patch. All runs kept exactly 500 sessions, used trusted browser clicks, included every retained sample, and recorded no page errors, external HTTP requests or native WebSocket connections. The production source and bundles were verified unchanged before and after measurement.

A separate diagnostic on that exact production build asserted that all 350 observed row-link calls used the prepared navigation snapshot and triggered zero full-roster projections. A deliberate outside-render call incremented the projection counter by one, confirming the instrumentation. The lifecycle owner is AppSidebar: it captures navigation in willUpdate, serves that snapshot during synchronous row rendering, and clears it in updated. The ClawSweeper P1 and related repair requests miss this override; the explicit disposition and proof are recorded in [the review response](https://github.com/openclaw/openclaw/pull/135574#issuecomment-5501481088).

### Before / after

Inspected production-browser benchmark captures; their pixels are identical, as expected for this performance refactor.

Before:

![500-session fixture before the refactor](https://github.com/user-attachments/assets/314cbe15-9fd2-4e25-87f8-f5512123af20)

After:

![500-session fixture after the refactor](https://github.com/user-attachments/assets/f4d83b24-0037-4d78-bc11-bd328346dbac)
