### PR TITLE
fix(codex): stop using stale instructions after prompt-hook changes

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -960,6 +960,19 @@ thread configuration overlaps.
 
 ## Workspace bootstrap files
 
+The full generic developer policy, including a `before_prompt_build.systemPrompt`
+replacement, remains native session configuration for compaction and native-child
+inheritance. Ordinary persistent cold or changed-configuration resumes require an
+uninterrupted managed local stdio process owner and observed native unload before OpenClaw injects the full
+current policy. Merely sending `developerInstructions` on `thread/resume` does not
+refresh the model-visible policy on stock Codex. Explicit `systemPrompt: ""` sends
+a withdrawal, not a fallback to older instructions.
+
+Ordinary incognito turns can reuse unchanged generic policy, but changed or emptied
+policy is rejected without sending another native turn or discarding the live
+conversation. Turn-scoped collaboration instructions remain a separate surface.
+See [Hook boundaries](/plugins/codex-harness-runtime#hook-boundaries) for recovery.
+
 Codex normally handles `AGENTS.md` itself through native project-doc discovery.
 OpenClaw does not write synthetic Codex project-doc files or depend on Codex
 fallback filenames for persona files, because Codex fallbacks only apply when

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -210,6 +210,45 @@ scheduled heartbeat user message when present.
 
 ## Hook boundaries
 
+For ordinary persistent conversations, a `before_prompt_build` result containing
+`systemPrompt` replaces the complete OpenClaw generic developer policy. An explicit
+empty string withdraws that policy. Unchanged, configuration-proven warm threads
+stay warm, with the retained subscription and host authority rechecked after plugin
+policy awaits. A closed or archived thread cannot be reused merely because its
+connection is still open. Cold resumes and changed-policy resumes preserve the native thread and
+history, verify that Codex unloaded the previous configuration, then append a
+complete superseding policy message before admitting the turn. Historical policy
+text can remain in the transcript; the later policy explicitly supersedes it.
+
+If another client lease, subscriber, or failed native unload prevents configuration
+proof, the turn stops before inference. A prewrite ownership refusal keeps the
+healthy shared client and its other conversations available. External WebSocket,
+Unix-socket, and stdio-proxy connections do not prove exclusive native-process
+ownership, so ordinary conversations cannot perform this guarded cold refresh on
+those transports. Use OpenClaw-managed local stdio; for lease contention, stop
+competing native work before reconnecting. Policy refusals and uncertain or
+acknowledged policy-write failures preserve the conversation and stop automatic
+auth-profile, model-fallback, and whole-turn retries.
+
+Supervised external connections retain their existing shared connection-lease
+semantics; existing native-home and tool-catalog restrictions still apply. Those
+lease checks do not establish exclusive ownership
+of the external native process; strengthening that guarantee is a separate
+limitation, not part of ordinary policy refresh. Manual ordinary adoption still
+requires its agent-home and tool-catalog checks as well as native-process proof.
+
+Ordinary incognito conversations retain their live ephemeral history. Stock Codex
+cannot update their generic session configuration or resume them from disk, so a
+changed or explicitly emptied generic policy stops the next turn before inference.
+Restore the previous policy to continue the conversation, or start a
+new incognito conversation for the new policy. Unchanged-policy turns continue;
+this check adds no idle expiry or persistence to incognito history.
+
+Preflight refusals keep the normal external-chat diagnostic privacy and group
+silence policy. Verbose mode can show bounded recovery detail; Control UI retains
+its usual diagnostic rendering. An externally closed ephemeral thread cannot be
+promised recoverable.
+
 | Layer                                 | Owner                    | Purpose                                                             |
 | ------------------------------------- | ------------------------ | ------------------------------------------------------------------- |
 | OpenClaw plugin hooks                 | OpenClaw                 | Product/plugin compatibility across OpenClaw and Codex harnesses.   |
@@ -461,6 +500,12 @@ and can retry on a fresh client. Client closure, request cancellation, or a
 failed compaction turn returns a failed operation. Automatic context-pressure
 compaction is Codex's job; OpenClaw only starts native compaction for manually
 requested triggers.
+
+A standalone cold compact operation does not run prompt-build hooks or establish
+ordinary-turn configuration. It releases its subscription after the operation;
+the next ordinary turn verifies configuration and refreshes generic policy through
+the normal resume path. Warm compaction returns only the configuration ownership
+it actually acquired.
 
 When OpenClaw projects an existing session's continuity into a fresh Codex
 thread, it includes saved compaction and branch summaries, even when no

--- a/extensions/codex/src/app-server/attempt-startup-retry.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup-retry.test.ts
@@ -571,7 +571,7 @@ describe("Codex app-server startup retry", () => {
     }
   });
 
-  it("preserves the shared client and binding after resume overload exhausts", async () => {
+  it("preserves the shared client and binding across contended and overloaded resumes", async () => {
     const fixture = await createStartupFailureFixture("overload");
     const sibling = await startFixtureAttempt(fixture);
     sibling.turnRoute.release();
@@ -587,13 +587,21 @@ describe("Codex app-server startup retry", () => {
       const requestsBeforeResume = await fs.readFile(fixture.requestLogPath, "utf8");
 
       await expect(startFixtureAttempt(fixture)).rejects.toMatchObject({
+        name: "CodexAdoptedThreadActiveError",
+        scope: undefined,
+      });
+      expect(await fs.readFile(fixture.requestLogPath, "utf8")).toBe(requestsBeforeResume);
+      await expect(testCodexAppServerBindingStore.read(identity)).resolves.toEqual(binding);
+      // Only the sole lease can reach native resume; contention must not write first.
+      sibling.releaseSharedClientLease();
+      await expect(startFixtureAttempt(fixture)).rejects.toMatchObject({
         name: "CodexAppServerRpcError",
         code: -32_001,
         method: "thread/resume",
       });
       const requests = await fs.readFile(fixture.requestLogPath, "utf8");
       expect(new Set(requests.slice(requestsBeforeResume.length).trim().split("\n"))).toEqual(
-        new Set(["thread/resume"]),
+        new Set(["thread/read", "thread/resume"]),
       );
       await expect(testCodexAppServerBindingStore.read(identity)).resolves.toEqual(binding);
 

--- a/extensions/codex/src/app-server/attempt-startup.test-support.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test-support.ts
@@ -1,10 +1,18 @@
+import { randomUUID } from "node:crypto";
+import os from "node:os";
+import path from "node:path";
+import type {
+  CodexBundleMcpThreadConfig,
+  EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { expect, vi } from "vitest";
 import type { startCodexAttemptThread } from "./attempt-startup.js";
 import { withEphemeralCodexAuthStore } from "./auth-start-options.js";
 import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { createCodexTestHostCapabilities } from "./host-capability.test-support.js";
 import { resolveCodexAppServerSpawnIdentity } from "./shared-client.js";
-import { createClientHarness } from "./test-support.js";
+import { createClientHarness, createCodexTestModel } from "./test-support.js";
 
 export type AttemptClientHarness = ReturnType<typeof createClientHarness>;
 export const HARNESS_REQUEST_TIMEOUT_MS = 15_000;
@@ -111,3 +119,53 @@ export function createPairedAttemptRuntime() {
     openDuplex,
   };
 }
+
+export type AttemptPaths = {
+  agentDir: string;
+  cwd: string;
+  sessionFile: string;
+  workspaceDir: string;
+};
+
+export function createAttemptPaths(tempRoots: Set<string>): AttemptPaths {
+  const root = path.join(os.tmpdir(), `openclaw-codex-attempt-startup-${randomUUID()}`);
+  tempRoots.add(root);
+  return {
+    agentDir: path.join(root, "agent"),
+    cwd: path.join(root, "workspace"),
+    sessionFile: path.join(root, "session.jsonl"),
+    workspaceDir: path.join(root, "workspace"),
+  };
+}
+
+export function createAttemptParams(paths: AttemptPaths): EmbeddedRunAttemptParams {
+  return {
+    hostCapabilities: createCodexTestHostCapabilities(),
+    prompt: "hello",
+    sessionId: "session-1",
+    sessionKey: "agent:agent-1:session-1",
+    agentDir: paths.agentDir,
+    sessionFile: paths.sessionFile,
+    effectiveCwd: paths.cwd,
+    workspaceDir: paths.workspaceDir,
+    runId: "run-1",
+    provider: "codex",
+    modelId: "gpt-5.4-codex",
+    model: createCodexTestModel("codex"),
+    thinkLevel: "medium",
+    disableTools: true,
+    timeoutMs: 5_000,
+    authStorage: {} as never,
+    authProfileStore: { version: 1, profiles: {} },
+    modelRegistry: {} as never,
+  } as EmbeddedRunAttemptParams;
+}
+
+export const bundleMcpThreadConfig = {
+  configPatch: undefined,
+  diagnostics: [],
+  evaluated: false,
+  fingerprint: undefined,
+  staticServerNames: [],
+  userStaticServerNames: [],
+} satisfies CodexBundleMcpThreadConfig;

--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -1,20 +1,21 @@
 // Codex tests cover attempt startup plugin behavior.
-import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import {
   AgentHarnessPreflightError,
-  type CodexBundleMcpThreadConfig,
   type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startCodexAttemptThread } from "./attempt-startup.js";
 import {
+  bundleMcpThreadConfig,
   answerInitialize,
   answerPreparedApiKeyLogin,
   captureExpectedRuntimeArtifact,
   createPairedAttemptRuntime,
+  createAttemptPaths,
+  createAttemptParams,
+  type AttemptPaths,
   HARNESS_REQUEST_TIMEOUT_MS,
   readHarnessMessages,
   readHarnessRequestMethods,
@@ -31,7 +32,6 @@ import {
   resolveCodexAppServerRuntimeOptions,
   resolveCodexComputerUseConfig,
 } from "./config.js";
-import { createCodexTestHostCapabilities } from "./host-capability.test-support.js";
 import { defaultCodexPluginMetadataCache } from "./plugin-metadata-cache.js";
 import { sandboxExecServerRegistry } from "./sandbox-exec-server-registry.js";
 import { releaseCodexSandboxExecServerEnvironment } from "./sandbox-exec-server.js";
@@ -46,10 +46,13 @@ import {
   createIsolatedCodexAppServerClient,
   getLeasedSharedCodexAppServerClient,
   releaseLeasedSharedCodexAppServerClient,
+  retainSharedCodexAppServerClientIfCurrent,
   type CodexAppServerPreparedAuth,
   type CodexAppServerClientFactory,
 } from "./shared-client.js";
-import { createClientHarness, createCodexTestModel } from "./test-support.js";
+import { createClientHarness } from "./test-support.js";
+import { createCodexLifecycleHarness } from "./thread-lifecycle.test-fixtures.js";
+import { retainCodexAppServerBindingSubscription } from "./thread-ownership.js";
 
 const desktopGeneration = vi.hoisted(() => ({
   current: undefined as { epoch: number; fingerprint: string } | undefined,
@@ -81,61 +84,11 @@ vi.mock("./computer-use.js", async (importOriginal) => {
   };
 });
 
-type AttemptPaths = {
-  agentDir: string;
-  cwd: string;
-  sessionFile: string;
-  workspaceDir: string;
-};
-
 const tempRoots = new Set<string>();
-
-function createAttemptPaths(): AttemptPaths {
-  const root = path.join(os.tmpdir(), `openclaw-codex-attempt-startup-${randomUUID()}`);
-  tempRoots.add(root);
-  return {
-    agentDir: path.join(root, "agent"),
-    cwd: path.join(root, "workspace"),
-    sessionFile: path.join(root, "session.jsonl"),
-    workspaceDir: path.join(root, "workspace"),
-  };
-}
-
-function createAttemptParams(paths: AttemptPaths): EmbeddedRunAttemptParams {
-  return {
-    hostCapabilities: createCodexTestHostCapabilities(),
-    prompt: "hello",
-    sessionId: "session-1",
-    sessionKey: "agent:agent-1:session-1",
-    agentDir: paths.agentDir,
-    sessionFile: paths.sessionFile,
-    effectiveCwd: paths.cwd,
-    workspaceDir: paths.workspaceDir,
-    runId: "run-1",
-    provider: "codex",
-    modelId: "gpt-5.4-codex",
-    model: createCodexTestModel("codex"),
-    thinkLevel: "medium",
-    disableTools: true,
-    timeoutMs: 5_000,
-    authStorage: {} as never,
-    authProfileStore: { version: 1, profiles: {} },
-    modelRegistry: {} as never,
-  } as EmbeddedRunAttemptParams;
-}
 
 const pluginConfig: CodexPluginConfig = {
   appServer: { command: "codex" },
 };
-
-const bundleMcpThreadConfig = {
-  configPatch: undefined,
-  diagnostics: [],
-  evaluated: false,
-  fingerprint: undefined,
-  staticServerNames: [],
-  userStaticServerNames: [],
-} satisfies CodexBundleMcpThreadConfig;
 
 function startThreadWithHarness(
   startupTimeoutMs: number,
@@ -158,7 +111,7 @@ function startThreadWithHarness(
   },
 ) {
   const harness = overrides?.harness ?? createClientHarness();
-  const paths = overrides?.paths ?? createAttemptPaths();
+  const paths = overrides?.paths ?? createAttemptPaths(tempRoots);
   const startSpy = overrides?.skipStartSpy
     ? undefined
     : vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
@@ -213,7 +166,7 @@ async function startIsolatedPairedAttempt(params: {
   runtime: NonNullable<Parameters<typeof startCodexAttemptThread>[0]["runtime"]>;
   paths?: AttemptPaths;
 }) {
-  const paths = params.paths ?? createAttemptPaths();
+  const paths = params.paths ?? createAttemptPaths(tempRoots);
   const sandbox = {
     ...createSandboxContext({}),
     backendId: "node",
@@ -327,7 +280,7 @@ describe("startCodexAttemptThread", () => {
   });
 
   it("rejects an expected artifact mismatch before any native thread request", async () => {
-    const paths = createAttemptPaths();
+    const paths = createAttemptPaths(tempRoots);
     await fs.mkdir(paths.workspaceDir, { recursive: true });
     const command = path.join(paths.workspaceDir, "codex-runtime");
     await fs.writeFile(command, "native-v1");
@@ -349,7 +302,7 @@ describe("startCodexAttemptThread", () => {
   });
 
   it("returns a matching expected artifact with the started thread", async () => {
-    const paths = createAttemptPaths();
+    const paths = createAttemptPaths(tempRoots);
     await fs.mkdir(paths.workspaceDir, { recursive: true });
     const command = path.join(paths.workspaceDir, "codex-runtime");
     await fs.writeFile(command, "native-v1");
@@ -385,7 +338,7 @@ describe("startCodexAttemptThread", () => {
       .spyOn(CodexAppServerClient, "start")
       .mockResolvedValueOnce(first.client)
       .mockResolvedValueOnce(second.client);
-    const paths = createAttemptPaths();
+    const paths = createAttemptPaths(tempRoots);
     let persistedComputerUse = false;
     const { run } = startThreadWithHarness(10_000, new AbortController().signal, {
       harness: first,
@@ -465,7 +418,7 @@ describe("startCodexAttemptThread", () => {
       }
       const { run } = startThreadWithHarness(10_000, new AbortController().signal, {
         harness: first,
-        paths: createAttemptPaths(),
+        paths: createAttemptPaths(tempRoots),
         pluginConfig: {},
         skipStartSpy: true,
         startupPreparedAuth: { kind: "api-key", apiKey: "prepared-platform-key" },
@@ -512,7 +465,7 @@ describe("startCodexAttemptThread", () => {
   it("retires the startup generation when context restart sees a new executable owner", async () => {
     const harness = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
-    const paths = createAttemptPaths();
+    const paths = createAttemptPaths(tempRoots);
     const { run } = startThreadWithHarness(5_000, new AbortController().signal, {
       harness,
       paths,
@@ -532,10 +485,12 @@ describe("startCodexAttemptThread", () => {
       '[plugins."computer-use@openai-bundled"]\nenabled = true\n',
     );
 
-    await expect(result.restartContextEngineCodexThread()).rejects.toThrow(
-      "codex app-server client is closed",
-    );
-    expect(harness.writes).toHaveLength(writesBeforeRestart);
+    const restart = result.restartContextEngineCodexThread();
+    const read = JSON.parse(await harness.waitForWrite(writesBeforeRestart));
+    expect(read.method).toBe("thread/read");
+    harness.send({ id: read.id, result: { thread: threadStartResult("thread-original").thread } });
+    await expect(restart).rejects.toThrow("codex app-server client is closed");
+    expect(harness.writes).toHaveLength(writesBeforeRestart + 1);
 
     result.turnRoute.release();
     result.releaseSharedClientLease();
@@ -550,7 +505,7 @@ describe("startCodexAttemptThread", () => {
       .mockResolvedValueOnce(retained.client)
       .mockResolvedValueOnce(replacement.client);
     const appServer = resolveCodexAppServerRuntimeOptions({ pluginConfig });
-    const paths = createAttemptPaths();
+    const paths = createAttemptPaths(tempRoots);
 
     const retainedLease = getLeasedSharedCodexAppServerClient({
       startOptions: appServer.start,
@@ -586,6 +541,61 @@ describe("startCodexAttemptThread", () => {
     expect(releaseLeasedSharedCodexAppServerClient(replacement.client)).toBe(true);
   });
 
+  it("preserves the healthy shared client and incognito history after a prewrite resume refusal", async () => {
+    const paths = createAttemptPaths(tempRoots);
+    const harness = createCodexLifecycleHarness({
+      respond: async (method, params) => {
+        if (method === "thread/start") {
+          return threadStartResult(
+            (params as { ephemeral?: boolean }).ephemeral ? "incognito" : "ordinary",
+          );
+        }
+        throw new Error(`unexpected method: ${method}`);
+      },
+    });
+    const start = vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
+    const common = { paths, harness, skipStartSpy: true };
+    const ordinary = await startThreadWithHarness(5_000, undefined, common).run;
+    await harness.endTurn(ordinary.thread.threadId);
+    ordinary.turnRoute.release();
+    ordinary.releaseSharedClientLease();
+    const incognito = {
+      ...common,
+      buildAttemptParams: () => ({
+        ...createAttemptParams(paths),
+        sessionId: "incognito-session",
+        sessionKey: "agent:agent-1:dashboard:incognito-refusal",
+      }),
+    };
+    const previous = await startThreadWithHarness(5_000, undefined, incognito).run;
+    await retainCodexAppServerBindingSubscription(harness.client, previous.thread.threadId, {
+      configFingerprint: previous.thread.liveThreadConfigFingerprint,
+      ephemeralPolicy: previous.thread.liveThreadEphemeralPolicy,
+    });
+    previous.turnRoute.release();
+    previous.releaseSharedClientLease();
+
+    const sibling = retainSharedCodexAppServerClientIfCurrent(harness.client);
+    expect(sibling).toBeTypeOf("function");
+    const before = harness.writes.length;
+    await expect(startThreadWithHarness(5_000, undefined, common).run).rejects.toMatchObject({
+      name: "CodexAdoptedThreadActiveError",
+    });
+    expect(harness.writes).toHaveLength(before);
+    const reacquired = retainSharedCodexAppServerClientIfCurrent(harness.client);
+    expect(reacquired).toBeTypeOf("function");
+    reacquired?.();
+    sibling?.();
+    expect(harness.client.getCloseError()).toBeUndefined();
+    const continued = await startThreadWithHarness(5_000, undefined, incognito).run;
+    expect(continued.client).toBe(harness.client);
+    expect(continued.thread.threadId).toBe(previous.thread.threadId);
+    expect(harness.writes).toHaveLength(before);
+    expect(start).toHaveBeenCalledTimes(1);
+    continued.turnRoute.release();
+    continued.releaseSharedClientLease();
+  });
+
   it("clears the shared app-server when startup abandons an in-flight thread request", async () => {
     vi.useFakeTimers();
     const { harness, run } = startThreadWithHarness(500);
@@ -612,7 +622,7 @@ describe("startCodexAttemptThread", () => {
     const retained = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(retained.client);
     const appServer = resolveCodexAppServerRuntimeOptions({ pluginConfig });
-    const paths = createAttemptPaths();
+    const paths = createAttemptPaths(tempRoots);
 
     const retainedLease = getLeasedSharedCodexAppServerClient({
       startOptions: appServer.start,
@@ -676,7 +686,7 @@ describe("startCodexAttemptThread", () => {
     const appServer = resolveCodexAppServerRuntimeOptions({
       pluginConfig: sharedInitializePluginConfig,
     });
-    const paths = createAttemptPaths();
+    const paths = createAttemptPaths(tempRoots);
     const { harness, run, startSpy } = startThreadWithHarness(3_000, new AbortController().signal, {
       pluginConfig: sharedInitializePluginConfig,
       paths,
@@ -713,7 +723,7 @@ describe("startCodexAttemptThread", () => {
   });
 
   it("bounds a real stdio initialize request and cleans up the child", async () => {
-    const paths = createAttemptPaths();
+    const paths = createAttemptPaths(tempRoots);
     const root = path.dirname(paths.agentDir);
     const fixturePath = path.join(root, "stall-initialize.mjs");
     const requestLogPath = path.join(root, "requests.log");
@@ -829,8 +839,8 @@ describe("startCodexAttemptThread", () => {
     const first = createClientHarness();
     const second = createClientHarness();
     const runtime = createPairedAttemptRuntime();
-    const firstPaths = createAttemptPaths();
-    const secondPaths = createAttemptPaths();
+    const firstPaths = createAttemptPaths(tempRoots);
+    const secondPaths = createAttemptPaths(tempRoots);
     const start = vi.spyOn(CodexAppServerClient, "start").mockImplementation(async (options) => {
       const codexHome = options?.env?.CODEX_HOME;
       if (codexHome?.startsWith(`${firstPaths.agentDir}${path.sep}`)) {

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -613,10 +613,7 @@ export async function startCodexAttemptThread(params: {
               } else if (
                 !isCodexAppServerStartSelectionChangedError(startupAttemptError) &&
                 (shouldClearSharedClientAfterStartupRace(startupAttemptError) ||
-                  shouldClearSharedClientAfterStartupFailure({
-                    error: startupAttemptError,
-                    spawnedBy: params.spawnedBy,
-                  }))
+                  shouldClearSharedClientAfterStartupFailure(startupAttemptError, params.spawnedBy))
               ) {
                 if (startupClientForAbandonedRequestCleanup === startupClient) {
                   startupClientForAbandonedRequestCleanup = undefined;
@@ -698,10 +695,7 @@ export async function startCodexAttemptThread(params: {
     } else if (
       !isCodexAppServerStartSelectionChangedError(error) &&
       (shouldClearSharedClientAfterStartupRace(error) ||
-        shouldClearSharedClientAfterStartupFailure({
-          error,
-          spawnedBy: params.spawnedBy,
-        }))
+        shouldClearSharedClientAfterStartupFailure(error, params.spawnedBy))
     ) {
       releaseSharedClientLease?.();
       releaseSharedClientLease = undefined;
@@ -718,12 +712,15 @@ function shouldClearSharedClientAfterStartupRace(error: unknown): boolean {
   return isCodexAppServerStartupError(error) || isCodexAppServerRequestTimeoutError(error);
 }
 
-function shouldClearSharedClientAfterStartupFailure(params: {
-  error: unknown;
-  spawnedBy: EmbeddedRunAttemptParams["spawnedBy"];
-}): boolean {
-  if (isCodexAppServerOverloadError(params.error)) {
-    return false;
-  }
-  return isCodexAppServerBrokenPipeError(params.error) || !params.spawnedBy;
+function shouldClearSharedClientAfterStartupFailure(
+  error: unknown,
+  spawnedBy: EmbeddedRunAttemptParams["spawnedBy"],
+): boolean {
+  // Model-independent preflights preserve healthy conversations. A handoff with
+  // an uncertain native write owns its retirement at the resume boundary.
+  return (
+    !isCodexAppServerOverloadError(error) &&
+    !(error instanceof AgentHarnessPreflightError && error.scope === undefined) &&
+    (isCodexAppServerBrokenPipeError(error) || !spawnedBy)
+  );
 }

--- a/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts
@@ -132,7 +132,10 @@ async function writeCodexAppServerBinding(
   );
 }
 
-function createCodexAuthProfileHarness(params: { startMethod: "thread/start" | "thread/resume" }) {
+function createCodexAuthProfileHarness(params: {
+  startMethod: "thread/start" | "thread/resume";
+  persistedThreads?: string[];
+}) {
   const seenAuthProfileIds: Array<string | undefined> = [];
   const seenAgentDirs: Array<string | undefined> = [];
   const seenClientOptions: CodexAppServerClientOptions[] = [];
@@ -147,6 +150,7 @@ function createCodexAuthProfileHarness(params: { startMethod: "thread/start" | "
       throw new Error(`unexpected method: ${method}`);
     },
     {
+      persistedThreads: params.persistedThreads,
       onStart(authProfileId, agentDir, options) {
         seenAuthProfileIds.push(authProfileId);
         seenAgentDirs.push(agentDir);
@@ -205,7 +209,10 @@ describe("Auth profile runtime contract - Codex app-server adapter", () => {
   });
 
   it("reuses a bound OpenAI Codex auth profile when resume params omit authProfileId", async () => {
-    const harness = createCodexAuthProfileHarness({ startMethod: "thread/resume" });
+    const harness = createCodexAuthProfileHarness({
+      startMethod: "thread/resume",
+      persistedThreads: ["thread-auth-contract"],
+    });
     const sessionFile = path.join(tmpDir, "session.jsonl");
     await writeCodexAppServerBinding(sessionFile, {
       threadId: "thread-auth-contract",
@@ -230,7 +237,10 @@ describe("Auth profile runtime contract - Codex app-server adapter", () => {
   });
 
   it("prefers an explicit runtime auth profile over a stale persisted binding", async () => {
-    const harness = createCodexAuthProfileHarness({ startMethod: "thread/resume" });
+    const harness = createCodexAuthProfileHarness({
+      startMethod: "thread/resume",
+      persistedThreads: ["thread-auth-contract"],
+    });
     const sessionFile = path.join(tmpDir, "session.jsonl");
     await writeCodexAppServerBinding(sessionFile, {
       threadId: "thread-auth-contract",

--- a/extensions/codex/src/app-server/client-runtime.test.ts
+++ b/extensions/codex/src/app-server/client-runtime.test.ts
@@ -47,6 +47,24 @@ describe("Codex app-server client runtime", () => {
     mocks.mergeRateLimitUpdate.mockClear();
   });
 
+  it("retains ephemeral policy and history beyond persistent idle and capacity limits", async () => {
+    vi.useFakeTimers();
+    const { client } = createClientHarness();
+    clients.push(client);
+    ensureCodexAppServerClientRuntime(client, { agentDir: "/tmp/agent" });
+    const release = vi.fn(async (_threadId: string) => undefined);
+    await retainCodexAppServerLiveThread(client, "ephemeral", release, "creation-config", null, "");
+    for (let i = 0; i <= EXPECTED_MAX_IDLE_LIVE_THREADS; i++) {
+      await retainCodexAppServerLiveThread(client, `persistent-${i}`, release);
+    }
+    await vi.advanceTimersByTimeAsync(EXPECTED_LIVE_THREAD_IDLE_TIMEOUT_MS + 1);
+    const ownership = await consumeCodexAppServerLiveThread(client, "ephemeral");
+    expect(ownership).toMatchObject({ configFingerprint: "creation-config", ephemeralPolicy: "" });
+    expect(release.mock.calls.some(([threadId]) => threadId === "ephemeral")).toBe(false);
+    await ownership?.release("ephemeral");
+    expect(hasCodexAppServerLiveThread(client, "ephemeral")).toBe(false);
+  });
+
   it("installs shared handlers once per physical client", async () => {
     const harness = createClientHarness();
     clients.push(harness.client);

--- a/extensions/codex/src/app-server/client-runtime.ts
+++ b/extensions/codex/src/app-server/client-runtime.ts
@@ -28,6 +28,7 @@ type ClientRuntime = {
 
 type RetainedLiveThread = {
   configFingerprint?: string;
+  ephemeralPolicy?: string;
   serviceTier?: CodexServiceTier | null;
   expiresAt: number;
   release: (threadId: string, assertCurrent?: () => void) => Promise<void>;
@@ -42,6 +43,8 @@ type ThreadReleaseTransition = {
 export type CodexAppServerLiveThreadOwnership = {
   assertCurrent: () => void;
   configFingerprint?: string;
+  /** Ephemeral configuration is creation-owned and cannot be refreshed or cold-resumed. */
+  ephemeralPolicy?: string;
   serviceTier?: CodexServiceTier | null;
   release: (threadId: string, assertCurrent?: () => void) => Promise<void>;
 };
@@ -294,7 +297,9 @@ async function releaseRetainedThread(
     ) {
       // A failed unsubscribe leaves the native subscription alive. Restore its
       // exact callback and LRU position; renewing TTL prevents a zero-delay retry spin.
-      retained.expiresAt = Date.now() + CODEX_APP_SERVER_LIVE_THREAD_IDLE_TIMEOUT_MS;
+      if (retained.ephemeralPolicy === undefined) {
+        retained.expiresAt = Date.now() + CODEX_APP_SERVER_LIVE_THREAD_IDLE_TIMEOUT_MS;
+      }
       const newerThreads = [...runtime.retainedThreads.entries()].filter(
         ([candidateThreadId]) => !olderThreadIds.has(candidateThreadId),
       );
@@ -332,14 +337,15 @@ async function evictExcessIdleThreads(
   client: CodexAppServerClient,
   runtime: ClientRuntime,
 ): Promise<void> {
-  let idleThreadIds = [...runtime.retainedThreads.keys()].filter(
-    (threadId) => !runtime.protectedThreads.has(threadId),
-  );
-  while (idleThreadIds.length > CODEX_APP_SERVER_LIVE_THREAD_MAX_IDLE) {
-    await releaseRetainedThread(client, runtime, idleThreadIds[0]!);
-    idleThreadIds = [...runtime.retainedThreads.keys()].filter(
-      (threadId) => !runtime.protectedThreads.has(threadId),
+  const idleThreads = () =>
+    [...runtime.retainedThreads].filter(
+      ([threadId, thread]) =>
+        thread.ephemeralPolicy === undefined && !runtime.protectedThreads.has(threadId),
     );
+  let idleThreadIds = idleThreads();
+  while (idleThreadIds.length > CODEX_APP_SERVER_LIVE_THREAD_MAX_IDLE) {
+    await releaseRetainedThread(client, runtime, idleThreadIds[0]![0]);
+    idleThreadIds = idleThreads();
   }
 }
 
@@ -350,6 +356,7 @@ export async function retainCodexAppServerLiveThread(
   releaseThread?: (threadId: string, assertCurrent?: () => void) => Promise<void>,
   configFingerprint?: string,
   serviceTier?: CodexServiceTier | null,
+  ephemeralPolicy?: string,
 ): Promise<boolean> {
   const runtime = configuredClients.get(client);
   if (!runtime || runtime.closed) {
@@ -374,8 +381,14 @@ export async function retainCodexAppServerLiveThread(
   runtime.retainedThreads.delete(threadId);
   const retained: RetainedLiveThread = {
     configFingerprint,
+    ephemeralPolicy,
     serviceTier,
-    expiresAt: Date.now() + CODEX_APP_SERVER_LIVE_THREAD_IDLE_TIMEOUT_MS,
+    // Ephemeral history has no disk resume source. Preserve its existing client lifetime,
+    // rather than subjecting it to the persistent registry's idle eviction.
+    expiresAt:
+      ephemeralPolicy === undefined
+        ? Date.now() + CODEX_APP_SERVER_LIVE_THREAD_IDLE_TIMEOUT_MS
+        : Number.POSITIVE_INFINITY,
     release:
       (releaseThread ? (physicalThreadReleases.get(releaseThread) ?? releaseThread) : undefined) ??
       (async (releasedThreadId, assertCurrent) => {
@@ -526,6 +539,7 @@ function claimCodexAppServerThreadOwnership(
   return {
     assertCurrent,
     configFingerprint: retained.configFingerprint,
+    ephemeralPolicy: retained.ephemeralPolicy,
     serviceTier: retained.serviceTier,
     release,
   };
@@ -647,7 +661,9 @@ export function protectCodexAppServerLiveThread(
       if (retained) {
         // A detached child is live activity, not parent idleness. Its terminal
         // delivery starts the parent's normal warm-session retention window.
-        retained.expiresAt = Date.now() + CODEX_APP_SERVER_LIVE_THREAD_IDLE_TIMEOUT_MS;
+        if (retained.ephemeralPolicy === undefined) {
+          retained.expiresAt = Date.now() + CODEX_APP_SERVER_LIVE_THREAD_IDLE_TIMEOUT_MS;
+        }
         runtime.retainedThreads.delete(threadId);
         runtime.retainedThreads.set(threadId, retained);
       }

--- a/extensions/codex/src/app-server/launch-args.ts
+++ b/extensions/codex/src/app-server/launch-args.ts
@@ -74,6 +74,16 @@ export function readCodexAppServerConfigOptions(args: readonly string[]) {
   );
 }
 
+/** The stdio proxy forwards to an external server; it does not own that runtime. */
+export function isCodexAppServerProxyLaunch(args: readonly string[]): boolean {
+  const tokens = readCodexArgs(args);
+  const server = tokens.findLastIndex(({ name }) => name === "app-server");
+  return (
+    server >= 0 &&
+    tokens.slice(server + 1).find(({ name }) => !name.startsWith("-"))?.name === "proxy"
+  );
+}
+
 /** Keeps Codex overrides in one CLI scope without rewriting raw TOML or wrapper prefixes. */
 export function normalizeCodexAppServerArgs(
   rawArgs: string[],

--- a/extensions/codex/src/app-server/run-attempt-cleanup.ts
+++ b/extensions/codex/src/app-server/run-attempt-cleanup.ts
@@ -83,18 +83,19 @@ export async function cleanupCodexAttempt(
       (terminalState.turnSucceeded ||
         (state.permissionChangeRestart === "confirmed" && !params.abortSignal?.aborted)) &&
       isIncognitoSessionKey(params.sessionKey);
-    // Native-preserved and supervision threads have separate ownership and can
-    // never enter the ordinary persistent warm-thread cache.
-    const retainedPersistentThread =
-      terminalState.turnSucceeded &&
-      !isIncognitoSessionKey(params.sessionKey) &&
-      params.cleanupBundleMcpOnRunEnd !== true &&
-      resourceState.thread.liveThreadConfigFingerprint !== undefined &&
-      resourceState.thread.clientId ===
-        resolveCodexAppServerClientInstanceId(resourceState.client) &&
-      resourceState.thread.preserveNativeModel !== true &&
-      resourceState.thread.connectionScope !== "supervision" &&
-      !resourceState.thread.ringZeroConfigFingerprint
+    // Incognito uses the same generation owner but retains its creation policy
+    // without idle eviction. Native-preserved and supervised lifetimes stay separate.
+    const retainedOrdinaryThread =
+      ((retainLiveIncognitoThread &&
+        resourceState.thread.liveThreadEphemeralPolicy !== undefined) ||
+        (terminalState.turnSucceeded &&
+          !isIncognitoSessionKey(params.sessionKey) &&
+          params.cleanupBundleMcpOnRunEnd !== true &&
+          resourceState.thread.liveThreadConfigFingerprint !== undefined &&
+          resourceState.thread.preserveNativeModel !== true &&
+          resourceState.thread.connectionScope !== "supervision" &&
+          !resourceState.thread.ringZeroConfigFingerprint)) &&
+      resourceState.thread.clientId === resolveCodexAppServerClientInstanceId(resourceState.client)
         ? (await bindingStore.read(bindingIdentity))?.threadId === resourceState.thread.threadId &&
           (await bindingStore.withLease(bindingIdentity, async () => {
             // Reset/end uses this same generation lease. Never publish an old
@@ -111,15 +112,19 @@ export async function cleanupCodexAttempt(
                 release: resourceState.thread.liveThreadOwnership?.release,
                 configFingerprint: resourceState.thread.liveThreadConfigFingerprint,
                 serviceTier: connection.mutable.pluginAppServer.serviceTier,
+                ephemeralPolicy: resourceState.thread.liveThreadEphemeralPolicy,
               },
             );
           }))
         : false;
+    // Nonordinary incognito lifetimes retain their previous live-only ownership.
+    const retainLiveThread =
+      retainedOrdinaryThread ||
+      (retainLiveIncognitoThread && resourceState.thread.liveThreadEphemeralPolicy === undefined);
     // Codex keeps approvals in its native session; independent conversations
     // must retain their own subscriptions instead of evicting one another.
-    const retainLiveThread = retainLiveIncognitoThread || retainedPersistentThread;
     const bindingReleased =
-      isIncognitoSessionKey(params.sessionKey) && !retainLiveIncognitoThread
+      isIncognitoSessionKey(params.sessionKey) && !retainLiveThread
         ? await bindingStore.mutate(bindingIdentity, {
             kind: "clear",
             threadId: resourceState.thread.threadId,

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -26,7 +26,7 @@ import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-r
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { afterEach, beforeEach, expect, vi } from "vitest";
 import { defaultCodexAppInventoryCache } from "./app-inventory-cache.js";
-import type { CodexAppServerClient } from "./client.js";
+import { CodexAppServerClient } from "./client.js";
 import {
   mockClientRuntimeMethods as createMockClientRuntimeMethods,
   threadStartResult as createThreadStartResult,
@@ -52,6 +52,7 @@ import {
   createCodexTestToolTerminalObserver,
   type CodexTestAppServerClientFactory,
 } from "./test-support.js";
+import { createCodexLifecycleTurnHarness } from "./thread-lifecycle.test-fixtures.js";
 import { CODEX_APP_SERVER_VERSION } from "./version.js";
 import { codexWorkspaceDirCache } from "./workspace-dir-cache.js";
 
@@ -146,7 +147,9 @@ export function setCodexAppServerClientFactoryForTest(
     // Narrow test doubles still need the client lifecycle hook installed by
     // the keyed router, even when the test never simulates transport closure.
     testClient.addCloseHandler ??= () => () => undefined;
-    multiplexCodexTestClientHandlers(client);
+    if (!(client instanceof CodexAppServerClient)) {
+      multiplexCodexTestClientHandlers(client);
+    }
     return client;
   });
 }
@@ -341,36 +344,10 @@ export async function bindProductionHarnessHostCapabilitiesForTest(
   return close;
 }
 
-export function setCodexTestModelSupportsTools(
-  params: EmbeddedRunAttemptParams,
-  supportsTools: boolean,
-): void {
-  params.model = {
-    ...params.model,
-    compat: { ...params.model.compat, supportsTools },
-  } as EmbeddedRunAttemptParams["model"] & { compat: { supportsTools: boolean } };
-}
-
-export function createCodexRuntimePlanFixture(): NonNullable<
-  EmbeddedRunAttemptParams["runtimePlan"]
-> {
-  return {
-    auth: {},
-    observability: {
-      resolvedRef: "codex/gpt-5.4-codex",
-      provider: "codex",
-      modelId: "gpt-5.4-codex",
-      harnessId: "codex",
-    },
-    prompt: {
-      resolveSystemPromptContribution: () => undefined,
-    },
-    tools: {
-      normalize: (tools: unknown[]) => tools,
-      logDiagnostics: () => undefined,
-    },
-  } as unknown as NonNullable<EmbeddedRunAttemptParams["runtimePlan"]>;
-}
+export {
+  setCodexTestModelSupportsTools,
+  createCodexRuntimePlanFixture,
+} from "./thread-lifecycle.test-fixtures.js";
 
 export function assistantMessage(text: string, timestamp: number) {
   return {
@@ -459,6 +436,7 @@ export function createAppServerHarness(
     options?: { signal?: AbortSignal },
   ) => Promise<unknown>,
   options: {
+    persistedThreads?: string[];
     onStart?: (
       authProfileId: string | undefined,
       agentDir: string | undefined,
@@ -466,6 +444,21 @@ export function createAppServerHarness(
     ) => void;
   } = {},
 ) {
+  if (options.persistedThreads) {
+    const harness = createCodexLifecycleTurnHarness({
+      respond: requestImpl,
+      persistedThreads: options.persistedThreads,
+      agentDir: path.join(tempDir, "wire-agent"),
+      wait: appServerHarnessWait,
+    });
+    setCodexAppServerClientFactoryForTest(
+      async (_start, auth, agentDir, _config, clientOptions) => {
+        options.onStart?.(auth, agentDir, clientOptions);
+        return await harness.acquire(clientOptions);
+      },
+    );
+    return harness;
+  }
   const requests: Array<{ method: string; params: unknown }> = [];
   const notificationHandlers = new Set<
     (notification: CodexServerNotification) => Promise<void> | void
@@ -619,6 +612,7 @@ export function createStartedThreadHarness(
     options?: { signal?: AbortSignal },
   ) => Promise<unknown> = async () => undefined,
   options: {
+    persistedThreads?: string[];
     onStart?: (
       authProfileId: string | undefined,
       agentDir: string | undefined,
@@ -650,24 +644,27 @@ export function createStartedThreadHarness(
   }, options);
 }
 
-export function createResumeHarness() {
-  return createAppServerHarness(async (method, params) => {
-    if (method === "configRequirements/read") {
-      return { requirements: null };
-    }
-    if (method === "config/read") {
-      return { config: {}, origins: {} };
-    }
-    if (method === "thread/resume") {
-      // Resume must echo the requested thread; a different id is rejected as
-      // an unsafe subscription.
-      return threadStartResult((params as { threadId?: string })?.threadId ?? "thread-existing");
-    }
-    if (method === "turn/start") {
-      return turnStartResult();
-    }
-    return {};
-  });
+export function createResumeHarness(threadId = "thread-existing") {
+  return createAppServerHarness(
+    async (method, params) => {
+      if (method === "configRequirements/read") {
+        return { requirements: null };
+      }
+      if (method === "config/read") {
+        return { config: {}, origins: {} };
+      }
+      if (method === "thread/resume") {
+        // Resume must echo the requested thread; a different id is rejected as
+        // an unsafe subscription.
+        return threadStartResult((params as { threadId?: string })?.threadId ?? "thread-existing");
+      }
+      if (method === "turn/start") {
+        return turnStartResult();
+      }
+      return {};
+    },
+    { persistedThreads: [threadId] },
+  );
 }
 
 type RuntimeDynamicToolForTest = Parameters<

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -156,8 +156,9 @@ function toolResultMessage(payload: unknown, timestamp: number): AgentMessage {
 
 function createStartedThreadHarness(
   requestImpl?: Parameters<typeof createSharedStartedThreadHarness>[0],
+  options?: Parameters<typeof createSharedStartedThreadHarness>[1],
 ) {
-  const harness = createSharedStartedThreadHarness(requestImpl);
+  const harness = createSharedStartedThreadHarness(requestImpl, options);
   return {
     ...harness,
     async completeTurn(status: "completed" | "failed" = "completed", threadId = "thread-1") {
@@ -731,15 +732,18 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
         contextProjection: { mode: "thread_bootstrap" as const, epoch: "epoch-1" },
       })),
     });
-    const harness = createStartedThreadHarness(async (method) => {
-      if (method === "thread/resume") {
-        return threadStartResult("thread-bootstrapped");
-      }
-      if (method === "thread/start") {
-        return threadStartResult("thread-fresh");
-      }
-      return undefined;
-    });
+    const harness = createStartedThreadHarness(
+      async (method) => {
+        if (method === "thread/resume") {
+          return threadStartResult("thread-bootstrapped");
+        }
+        if (method === "thread/start") {
+          return threadStartResult("thread-fresh");
+        }
+        return undefined;
+      },
+      { persistedThreads: ["thread-bootstrapped"] },
+    );
     const params = createParams(sessionFile, workspaceDir);
     params.agentDir = agentDir;
     params.contextEngine = contextEngine;
@@ -757,7 +761,9 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     await harness.waitForMethod("turn/start");
 
     expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
       "turn/start",
     ]);
     const inputText = getRequestInputText(harness);
@@ -1362,22 +1368,25 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
       }),
     );
     const contextEngine = createContextEngine({ assemble, compact });
-    const harness = createStartedThreadHarness(async (method, requestParams) => {
-      const request = requireRecord(requestParams, `${method} params`);
-      if (method === "thread/resume") {
-        return threadStartResult("thread-old");
-      }
-      if (method === "turn/start" && request.threadId === "thread-old") {
-        throw new Error("Codex ran out of room in the model's context window");
-      }
-      if (method === "thread/start") {
-        return threadStartResult("thread-fresh");
-      }
-      if (method === "turn/start" && request.threadId === "thread-fresh") {
-        return turnStartResult("turn-fresh");
-      }
-      return undefined;
-    });
+    const harness = createStartedThreadHarness(
+      async (method, requestParams) => {
+        const request = requireRecord(requestParams, `${method} params`);
+        if (method === "thread/resume") {
+          return threadStartResult("thread-old");
+        }
+        if (method === "turn/start" && request.threadId === "thread-old") {
+          throw new Error("Codex ran out of room in the model's context window");
+        }
+        if (method === "thread/start") {
+          return threadStartResult("thread-fresh");
+        }
+        if (method === "turn/start" && request.threadId === "thread-fresh") {
+          return turnStartResult("turn-fresh");
+        }
+        return undefined;
+      },
+      { persistedThreads: ["thread-old"] },
+    );
     const params = createParams(sessionFile, workspaceDir);
     params.contextEngine = contextEngine;
     params.contextTokenBudget = 400_000;
@@ -1385,7 +1394,9 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     const run = runCodexAppServerAttempt(params);
     await vi.waitFor(() =>
       expect(harness.requests.map((request) => request.method)).toEqual([
+        "thread/read",
         "thread/resume",
+        "thread/inject_items",
         "turn/start",
         "thread/start",
         "turn/start",
@@ -1447,21 +1458,29 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
         contextProjection: { mode: "thread_bootstrap", epoch: "epoch-before" },
       }),
     });
-    const harness = createStartedThreadHarness(async (method, requestParams) => {
-      const request = requireRecord(requestParams, `${method} params`);
-      if (method === "thread/resume") {
-        return threadStartResult("thread-old");
-      }
-      if (method === "turn/start" && request.threadId === "thread-old") {
-        throw new Error("Codex ran out of room in the model's context window");
-      }
-      if (method === "thread/start") {
-        throw Object.assign(new Error("managed executable selection changed during startup"), {
-          code: "CODEX_APP_SERVER_START_SELECTION_CHANGED",
-        });
-      }
-      return undefined;
-    });
+    const successorStart = vi.fn(() => threadStartResult("thread-fresh"));
+    const harness = createStartedThreadHarness(
+      async (method, requestParams) => {
+        const request = requireRecord(requestParams, `${method} params`);
+        if (method === "thread/resume") {
+          return threadStartResult("thread-old");
+        }
+        if (method === "turn/start" && request.threadId === "thread-old") {
+          // Selection changes after the original turn writes; the successor is rejected locally.
+          harness.client.setThreadSessionRequestGuard(async () => {
+            throw Object.assign(new Error("managed executable selection changed during startup"), {
+              code: "CODEX_APP_SERVER_START_SELECTION_CHANGED",
+            });
+          });
+          throw new Error("Codex ran out of room in the model's context window");
+        }
+        if (method === "thread/start") {
+          return successorStart();
+        }
+        return undefined;
+      },
+      { persistedThreads: ["thread-old"] },
+    );
     const params = createParams(sessionFile, workspaceDir);
     params.contextEngine = contextEngine;
     params.contextTokenBudget = 400_000;
@@ -1476,11 +1495,14 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
       replaySafe: true,
     });
     expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
       "turn/start",
       "thread/start",
       "thread/unsubscribe",
     ]);
+    expect(successorStart).not.toHaveBeenCalled();
     expect(await readCodexAppServerBinding(sessionFile)).toBeUndefined();
   });
 
@@ -1520,24 +1542,27 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
       }),
     );
     const contextEngine = createContextEngine({ assemble, compact });
-    const harness = createStartedThreadHarness(async (method, requestParams) => {
-      const request = requireRecord(requestParams, `${method} params`);
-      if (method === "thread/resume") {
-        return threadStartResult("thread-old");
-      }
-      if (method === "turn/start" && request.threadId === "thread-old") {
-        await writeCodexAppServerBinding(sessionFile, {
-          threadId: "thread-new",
-          cwd: workspaceDir,
-          dynamicToolsFingerprint: "[]",
-        });
-        throw new Error("Codex ran out of room in the model's context window");
-      }
-      if (method === "thread/start") {
-        return threadStartResult("thread-fresh");
-      }
-      return undefined;
-    });
+    const harness = createStartedThreadHarness(
+      async (method, requestParams) => {
+        const request = requireRecord(requestParams, `${method} params`);
+        if (method === "thread/resume") {
+          return threadStartResult("thread-old");
+        }
+        if (method === "turn/start" && request.threadId === "thread-old") {
+          await writeCodexAppServerBinding(sessionFile, {
+            threadId: "thread-new",
+            cwd: workspaceDir,
+            dynamicToolsFingerprint: "[]",
+          });
+          throw new Error("Codex ran out of room in the model's context window");
+        }
+        if (method === "thread/start") {
+          return threadStartResult("thread-fresh");
+        }
+        return undefined;
+      },
+      { persistedThreads: ["thread-old"] },
+    );
     const params = createParams(sessionFile, workspaceDir);
     params.contextEngine = contextEngine;
     params.contextTokenBudget = 400_000;
@@ -1548,7 +1573,9 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
 
     expect(compact).not.toHaveBeenCalled();
     expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
       "turn/start",
       "thread/unsubscribe",
     ]);
@@ -1592,15 +1619,18 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
       }),
     );
     const contextEngine = createContextEngine({ assemble, compact });
-    const harness = createStartedThreadHarness(async (method) => {
-      if (method === "thread/resume") {
-        return threadStartResult("thread-old");
-      }
-      if (method === "turn/start") {
-        return turnStartResult("turn-old");
-      }
-      return undefined;
-    });
+    const harness = createStartedThreadHarness(
+      async (method) => {
+        if (method === "thread/resume") {
+          return threadStartResult("thread-old");
+        }
+        if (method === "turn/start") {
+          return turnStartResult("turn-old");
+        }
+        return undefined;
+      },
+      { persistedThreads: ["thread-old"] },
+    );
     const params = createParams(sessionFile, workspaceDir);
     params.contextEngine = contextEngine;
     params.contextTokenBudget = 400_000;
@@ -1627,7 +1657,9 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     );
     expect(compact).not.toHaveBeenCalled();
     expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
       "turn/start",
       "thread/unsubscribe",
     ]);
@@ -1748,22 +1780,25 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
       }),
     );
     const contextEngine = createContextEngine({ assemble, compact });
-    const harness = createStartedThreadHarness(async (method, requestParams) => {
-      const request = requireRecord(requestParams, `${method} params`);
-      if (method === "thread/resume") {
-        return threadStartResult("thread-old");
-      }
-      if (method === "turn/start" && request.threadId === "thread-old") {
-        throw new Error("Codex ran out of room in the model's context window");
-      }
-      if (method === "thread/start") {
-        return threadStartResult("thread-fresh");
-      }
-      if (method === "turn/start" && request.threadId === "thread-fresh") {
-        return turnStartResult("turn-fresh");
-      }
-      return undefined;
-    });
+    const harness = createStartedThreadHarness(
+      async (method, requestParams) => {
+        const request = requireRecord(requestParams, `${method} params`);
+        if (method === "thread/resume") {
+          return threadStartResult("thread-old");
+        }
+        if (method === "turn/start" && request.threadId === "thread-old") {
+          throw new Error("Codex ran out of room in the model's context window");
+        }
+        if (method === "thread/start") {
+          return threadStartResult("thread-fresh");
+        }
+        if (method === "turn/start" && request.threadId === "thread-fresh") {
+          return turnStartResult("turn-fresh");
+        }
+        return undefined;
+      },
+      { persistedThreads: ["thread-old"] },
+    );
     const params = createParams(sessionFile, workspaceDir);
     params.contextEngine = contextEngine;
     params.contextTokenBudget = 400_000;
@@ -1772,7 +1807,9 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
     await vi.waitFor(
       () =>
         expect(harness.requests.map((request) => request.method)).toEqual([
+          "thread/read",
           "thread/resume",
+          "thread/inject_items",
           "turn/start",
           "thread/start",
           "turn/start",

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -707,7 +707,7 @@ describe("runCodexAppServerAttempt native hook relay", () => {
       const sameExecutionSession = kind === "replacement";
       const sessionFile = path.join(tempDir, "session.jsonl");
       const workspaceDir = path.join(tempDir, "workspace");
-      const firstHarness = createStartedThreadHarness();
+      const firstHarness = createStartedThreadHarness(undefined, { persistedThreads: [] });
       const firstParams = createLoopRelayParams(sessionFile, workspaceDir);
       firstParams.sandboxSessionKey = "agent:main:policy";
       const firstRun = runCodexAppServerAttempt(firstParams, {
@@ -745,8 +745,9 @@ describe("runCodexAppServerAttempt native hook relay", () => {
         }),
       ).resolves.toMatchObject({ exitCode: 0 });
 
+      firstHarness.close();
       const secondHarness = sameExecutionSession
-        ? createResumeHarness()
+        ? createResumeHarness("thread-1")
         : createStartedThreadHarness();
       const secondParams = createLoopRelayParams(
         sameExecutionSession ? sessionFile : path.join(tempDir, "independent-session.jsonl"),
@@ -922,14 +923,17 @@ describe("runCodexAppServerAttempt native hook relay", () => {
       dynamicToolsFingerprint: "[]",
       nativeHookRelayGeneration: "generation-from-failed-resume",
     });
-    const harness = createStartedThreadHarness(async (method) => {
-      if (method === "thread/resume") {
-        // Exact unsubscribe after the structured RPC failure proves the resume
-        // subscription is released before falling back to a fresh thread.
-        throw new CodexAppServerRpcError({ code: -32_000, message: "resume failed" }, method);
-      }
-      return undefined;
-    });
+    const harness = createStartedThreadHarness(
+      async (method) => {
+        if (method === "thread/resume") {
+          // Exact unsubscribe after the structured RPC failure proves the resume
+          // subscription is released before falling back to a fresh thread.
+          throw new CodexAppServerRpcError({ code: -32_000, message: "resume failed" }, method);
+        }
+        return undefined;
+      },
+      { persistedThreads: ["thread-existing"] },
+    );
 
     const run = runCodexAppServerAttempt(createLoopRelayParams(sessionFile, workspaceDir), {
       nativeHookRelay: {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -27,7 +27,7 @@ import {
   appendSessionTranscriptMessageByIdentity,
   readSessionTranscriptEvents,
 } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import WebSocket from "ws";
 import { defaultCodexAppInventoryCache } from "./app-inventory-cache.js";
 import { codexAppInventoryResponse } from "./app-inventory.test-helpers.js";
@@ -127,6 +127,10 @@ import {
   codexDynamicToolsFingerprint,
   startOrResumeThread as startOrResumeThreadImpl,
 } from "./thread-lifecycle.js";
+import {
+  createCodexLifecycleHarness,
+  createLeasedCodexLifecycleHarness,
+} from "./thread-lifecycle.test-fixtures.js";
 
 const agentHarnessRuntimeMocks = vi.hoisted(() => ({
   forceModelToolsUnsupported: false,
@@ -842,22 +846,17 @@ async function runSharedClientRestartTest(closeCount: number) {
   const { sessionFile, workspaceDir } = createRunPaths();
   await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
   const requests: string[][] = [];
-  const clients: CodexAppServerClient[] = [];
-  let starts = 0;
-  const state: {
-    notify: (notification: CodexServerNotification) => Promise<void>;
-  } = { notify: async () => undefined };
-  setCodexAppServerClientFactoryForTest(async () => {
-    const startIndex = starts++;
+  const clients: Array<ReturnType<typeof createCodexLifecycleHarness>> = [];
+  onTestFinished(async () => {
+    await Promise.all(clients.map(({ client }) => client.closeAndWait()));
+  });
+  vi.spyOn(CodexAppServerClient, "start").mockImplementation(async () => {
+    const startIndex = clients.length;
     const methods: string[] = [];
     requests.push(methods);
-    const client = {
-      ...mockClientRuntimeMethods(),
-      request: vi.fn(async (method: string) => {
-        methods.push(method);
-        if (method === "thread/resume" && startIndex < closeCount) {
-          throw new Error("codex app-server client is closed");
-        }
+    const wire = createCodexLifecycleHarness({
+      persistedThreads: ["thread-existing"],
+      respond: async (method) => {
         if (method === "thread/resume") {
           return threadStartResult("thread-existing");
         }
@@ -865,27 +864,51 @@ async function runSharedClientRestartTest(closeCount: number) {
           return turnStartResult();
         }
         return {};
-      }),
-      addNotificationHandler: (handler: typeof state.notify) => {
-        state.notify = handler;
-        return () => undefined;
       },
-      addRequestHandler: () => () => undefined,
-    } as unknown as CodexAppServerClient;
-    clients.push(client);
-    return client;
+    });
+    const nativeRequest = CodexAppServerClient.prototype.request.bind(wire.client);
+    wire.request.mockImplementation((method, params, options) => {
+      if (method !== "initialize") {
+        methods.push(method);
+      }
+      // This retry scenario loses the transport before resume is written.
+      // Post-write loss remains indeterminate and is covered by the handoff owner.
+      if (method === "thread/resume" && startIndex < closeCount) {
+        wire.client.close();
+      }
+      return nativeRequest(method, params, options);
+    });
+    clients.push(wire);
+    return wire.client;
   });
+  setCodexAppServerClientFactoryForTest(
+    async (_start, _auth, _agent, _config, options) =>
+      await sharedClientModule.getLeasedSharedCodexAppServerClient({
+        ...options,
+        startOptions: {
+          transport: "stdio",
+          command: process.execPath,
+          args: ["app-server"],
+          headers: {},
+        },
+        agentDir: path.join(tempDir, "restart-agent"),
+        authProfileId: null,
+        preparedAuth: undefined,
+        authRequirement: undefined,
+        config: {},
+      }),
+  );
   const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
-  await vi.waitFor(() => expect(requests[closeCount]).toContain("turn/start"), fastWait);
-  await state.notify({
+  await Promise.race([
+    run,
+    vi.waitFor(() => expect(requests[closeCount]).toContain("turn/start"), fastWait),
+  ]);
+  clients[closeCount]!.notify({
     method: "turn/completed",
-    params: {
-      threadId: "thread-existing",
-      turnId: "turn-1",
-      turn: { id: "turn-1", status: "completed" },
-    },
+    params: { threadId: "thread-existing", turn: { id: "turn-1", status: "completed" } },
   });
-  return { result: await run, requests, client: clients[closeCount]! };
+  const result = await run;
+  return { result, requests, client: clients[closeCount]!.client };
 }
 
 async function expectRetainedSuccessfulThread(client: CodexAppServerClient, threadId: string) {
@@ -2340,7 +2363,7 @@ describe("runCodexAppServerAttempt", () => {
       codexDynamicToolsFingerprint(normalBridge.specs),
     );
     let startedThreadId: string | undefined;
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/start") {
         startedThreadId = "thread-stable-heartbeat";
         return threadStartResult(startedThreadId);
@@ -2350,6 +2373,11 @@ describe("runCodexAppServerAttempt", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "heartbeat-agent"),
+      respond,
+    });
+    const { client, request } = fixture;
     const turns = [
       { params: createRunParams(), bridge: normalBridge },
       { params: heartbeatParams, bridge: heartbeatBridge },
@@ -2357,17 +2385,26 @@ describe("runCodexAppServerAttempt", () => {
     ];
     for (const turn of turns) {
       await startOrResumeThread({
-        client: { request } as never,
+        client,
         params: turn.params,
         cwd: workspaceDir,
         dynamicTools: turn.bridge.specs,
         appServer: createThreadLifecycleAppServerOptions(),
+        signal: new AbortController().signal,
       });
+      await fixture.endTurn("thread-stable-heartbeat");
     }
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
+      "thread/unsubscribe",
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
+      "thread/unsubscribe",
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
+      "thread/unsubscribe",
     ]);
   });
   it("keeps message in the registered schema when disabled for an internal turn", async () => {
@@ -4030,6 +4067,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(Date.parse(completedBinding?.historyCoveredThrough ?? "")).toBeGreaterThan(
       originalBindingUpdatedAt,
     );
+    firstHarness.close();
     const secondHarness = createResumeHarness();
     const secondParams = createParams(sessionFile, workspaceDir);
     secondParams.prompt = "continue after steering";
@@ -4081,6 +4119,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(firstInputText).toContain("OpenClaw assembled context for this turn:");
     expect(firstInputText).toContain("we were discussing the Sonnet leak screenshots");
     expect(firstInputText).toContain("is the previous message trustworthy?");
+    firstHarness.close();
     const secondHarness = createResumeHarness();
     const secondParams = createParams(sessionFile, workspaceDir);
     secondParams.prompt = "continue from there";
@@ -4326,7 +4365,7 @@ describe("runCodexAppServerAttempt", () => {
     await fs.writeFile(path.join(agentWorkspaceDir, "AGENTS.md"), agentsGuidance);
     await fs.writeFile(path.join(agentWorkspaceDir, "SOUL.md"), soulGuidance);
     await fs.writeFile(path.join(executionDir, "AGENTS.md"), "Execution project instructions");
-    const harness = createStartedThreadHarness();
+    const harness = createStartedThreadHarness(undefined, { persistedThreads: [] });
     const params = createParams(sessionFile, executionDir);
     params.bootstrapWorkspaceDir = agentWorkspaceDir;
     setAgentWorkspaceForTest(params, agentWorkspaceDir);
@@ -4370,13 +4409,14 @@ describe("runCodexAppServerAttempt", () => {
 
     const updatedGuidance = "Updated AGENTS guidance must wait for a new session.";
     await fs.writeFile(path.join(agentWorkspaceDir, "AGENTS.md"), updatedGuidance);
-    const resumeHarness = createResumeHarness();
+    harness.close();
+    const resumeHarness = createResumeHarness("thread-1");
     const resumeParams = createParams(sessionFile, executionDir);
     resumeParams.bootstrapWorkspaceDir = agentWorkspaceDir;
     setAgentWorkspaceForTest(resumeParams, agentWorkspaceDir);
     const resumedRun = runCodexAppServerAttempt(resumeParams);
-    await resumeHarness.waitForMethod("turn/start");
-    await resumeHarness.completeTurn({ threadId: "thread-1", turnId: "turn-2" });
+    await Promise.race([resumedRun, resumeHarness.waitForMethod("turn/start")]);
+    await resumeHarness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await resumedRun;
     const threadResume = resumeHarness.requests.find(
       (request) => request.method === "thread/resume",
@@ -5190,20 +5230,25 @@ describe("runCodexAppServerAttempt", () => {
   it("preserves a healthy binding when the server rejects unsupported image input", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
     await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
-    const harness = createAppServerHarness(async (method) => {
-      if (method === "thread/resume") {
-        return threadStartResult("thread-existing");
-      }
-      if (method === "turn/start") {
-        throw new Error("unsupported image input");
-      }
-      return {};
-    });
+    const harness = createAppServerHarness(
+      async (method) => {
+        if (method === "thread/resume") {
+          return threadStartResult("thread-existing");
+        }
+        if (method === "turn/start") {
+          throw new Error("unsupported image input");
+        }
+        return {};
+      },
+      { persistedThreads: ["thread-existing"] },
+    );
     await expect(runCodexAppServerAttempt(createParams(sessionFile, workspaceDir))).rejects.toThrow(
       "unsupported image input",
     );
     expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
       "turn/start",
       "thread/unsubscribe",
     ]);
@@ -5215,41 +5260,44 @@ describe("runCodexAppServerAttempt", () => {
     await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
     let turnStartCalls = 0;
     const harnessRef: { current?: ReturnType<typeof createAppServerHarness> } = {};
-    const harness = createAppServerHarness(async (method) => {
-      if (method === "thread/resume") {
-        return threadStartResult("thread-existing");
-      }
-      if (method === "turn/start") {
-        turnStartCalls += 1;
-        if (turnStartCalls === 1) {
-          queueMicrotask(() => {
-            void harnessRef.current?.notify({
-              method: "turn/completed",
-              params: {
-                threadId: "thread-existing",
-                turnId: "compact-turn",
-                turn: { id: "compact-turn", status: "completed" },
-              },
-            });
-          });
-          throw new CodexAppServerRpcError(
-            {
-              message: "cannot steer a compact turn",
-              data: {
-                message: "cannot steer a compact turn",
-                codexErrorInfo: {
-                  activeTurnNotSteerable: { turnKind: "compact" },
-                },
-                additionalDetails: null,
-              },
-            },
-            "turn/start",
-          );
+    const harness = createAppServerHarness(
+      async (method) => {
+        if (method === "thread/resume") {
+          return threadStartResult("thread-existing");
         }
-        return turnStartResult("turn-1");
-      }
-      return {};
-    });
+        if (method === "turn/start") {
+          turnStartCalls += 1;
+          if (turnStartCalls === 1) {
+            queueMicrotask(() => {
+              void harnessRef.current?.notify({
+                method: "turn/completed",
+                params: {
+                  threadId: "thread-existing",
+                  turnId: "compact-turn",
+                  turn: { id: "compact-turn", status: "completed" },
+                },
+              });
+            });
+            throw new CodexAppServerRpcError(
+              {
+                message: "cannot steer a compact turn",
+                data: {
+                  message: "cannot steer a compact turn",
+                  codexErrorInfo: {
+                    activeTurnNotSteerable: { turnKind: "compact" },
+                  },
+                  additionalDetails: null,
+                },
+              },
+              "turn/start",
+            );
+          }
+          return turnStartResult("turn-1");
+        }
+        return {};
+      },
+      { persistedThreads: ["thread-existing"] },
+    );
     harnessRef.current = harness;
     const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
     await vi.waitFor(
@@ -5262,7 +5310,9 @@ describe("runCodexAppServerAttempt", () => {
     await harness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
     await run;
     expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
       "turn/start",
       "turn/start",
     ]);
@@ -5272,23 +5322,26 @@ describe("runCodexAppServerAttempt", () => {
   it("waits for the exact active native turn before starting a resumed thread turn", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
     await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
-    const harness = createAppServerHarness(async (method) => {
-      if (method === "thread/resume") {
-        const response = threadStartResult("thread-existing");
-        return {
-          ...response,
-          thread: {
-            ...response.thread,
-            status: { type: "active", activeFlags: [] },
-            turns: [{ id: "compact-turn", status: "inProgress", items: [] }],
-          },
-        };
-      }
-      if (method === "turn/start") {
-        return turnStartResult("turn-1");
-      }
-      return {};
-    });
+    const harness = createAppServerHarness(
+      async (method) => {
+        if (method === "thread/resume") {
+          const response = threadStartResult("thread-existing");
+          return {
+            ...response,
+            thread: {
+              ...response.thread,
+              status: { type: "active", activeFlags: [] },
+              turns: [{ id: "compact-turn", status: "inProgress", items: [] }],
+            },
+          };
+        }
+        if (method === "turn/start") {
+          return turnStartResult("turn-1");
+        }
+        return {};
+      },
+      { persistedThreads: ["thread-existing"] },
+    );
     const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
     await harness.waitForMethod("thread/resume");
     await new Promise((resolve) => {
@@ -5324,7 +5377,9 @@ describe("runCodexAppServerAttempt", () => {
     await harness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
     await run;
     expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
       "turn/start",
     ]);
     await expectRetainedSuccessfulThread(harness.client, "thread-existing");
@@ -5332,32 +5387,37 @@ describe("runCodexAppServerAttempt", () => {
   it("does not retry turn/start for non-compact active turns", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
     await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
-    const harness = createAppServerHarness(async (method) => {
-      if (method === "thread/resume") {
-        return threadStartResult("thread-existing");
-      }
-      if (method === "turn/start") {
-        throw new CodexAppServerRpcError(
-          {
-            message: "cannot steer a review turn",
-            data: {
+    const harness = createAppServerHarness(
+      async (method) => {
+        if (method === "thread/resume") {
+          return threadStartResult("thread-existing");
+        }
+        if (method === "turn/start") {
+          throw new CodexAppServerRpcError(
+            {
               message: "cannot steer a review turn",
-              codexErrorInfo: {
-                activeTurnNotSteerable: { turnKind: "review" },
+              data: {
+                message: "cannot steer a review turn",
+                codexErrorInfo: {
+                  activeTurnNotSteerable: { turnKind: "review" },
+                },
+                additionalDetails: null,
               },
-              additionalDetails: null,
             },
-          },
-          "turn/start",
-        );
-      }
-      return {};
-    });
+            "turn/start",
+          );
+        }
+        return {};
+      },
+      { persistedThreads: ["thread-existing"] },
+    );
     await expect(runCodexAppServerAttempt(createParams(sessionFile, workspaceDir))).rejects.toThrow(
       "cannot steer a review turn",
     );
     expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
       "turn/start",
       "thread/unsubscribe",
     ]);
@@ -6271,19 +6331,22 @@ describe("runCodexAppServerAttempt", () => {
     await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
     const turnIds = ["turn-ada", "turn-grace"] as const;
     let nextTurnIndex = 0;
-    const harness = createAppServerHarness(async (method, params) => {
-      if (method === "thread/resume") {
-        return threadStartResult((params as { threadId?: string }).threadId ?? "thread-existing");
-      }
-      if (method === "turn/start") {
-        const turnId = turnIds[nextTurnIndex++];
-        if (!turnId) {
-          throw new Error("unexpected extra turn/start");
+    const harness = createAppServerHarness(
+      async (method, params) => {
+        if (method === "thread/resume") {
+          return threadStartResult((params as { threadId?: string }).threadId ?? "thread-existing");
         }
-        return turnStartResult(turnId);
-      }
-      return {};
-    });
+        if (method === "turn/start") {
+          const turnId = turnIds[nextTurnIndex++];
+          if (!turnId) {
+            throw new Error("unexpected extra turn/start");
+          }
+          return turnStartResult(turnId);
+        }
+        return {};
+      },
+      { persistedThreads: ["thread-existing"] },
+    );
 
     const runTurn = async (sender: { id: string; name: string }, prompt: string, runId: string) => {
       const expectedTurnStarts =
@@ -6595,7 +6658,10 @@ describe("runCodexAppServerAttempt", () => {
   it("restarts the app-server once when a shared client closes during startup", async () => {
     const { result, requests, client } = await runSharedClientRestartTest(1);
     expect(readAttemptTerminal(result).aborted).toBe(false);
-    expect(requests).toEqual([["thread/resume"], ["thread/resume", "turn/start"]]);
+    expect(requests).toEqual([
+      ["thread/read", "thread/resume"],
+      ["thread/read", "thread/resume", "thread/inject_items", "turn/start"],
+    ]);
     await expectRetainedSuccessfulThread(client, "thread-existing");
   });
 
@@ -6603,9 +6669,9 @@ describe("runCodexAppServerAttempt", () => {
     const { result, requests, client } = await runSharedClientRestartTest(2);
     expect(readAttemptTerminal(result).aborted).toBe(false);
     expect(requests).toEqual([
-      ["thread/resume"],
-      ["thread/resume"],
-      ["thread/resume", "turn/start"],
+      ["thread/read", "thread/resume"],
+      ["thread/read", "thread/resume"],
+      ["thread/read", "thread/resume", "thread/inject_items", "turn/start"],
     ]);
     await expectRetainedSuccessfulThread(client, "thread-existing");
   });
@@ -6666,8 +6732,10 @@ describe("runCodexAppServerAttempt", () => {
   it("retains the prepared execution model across native resume without exposing it in lifecycle events", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
     const runtimeModelId = "test-runtime-model";
-    const freshHarness = createStartedThreadHarness(async (method) =>
-      method === "thread/start" ? { ...threadStartResult(), model: runtimeModelId } : undefined,
+    const freshHarness = createStartedThreadHarness(
+      async (method) =>
+        method === "thread/start" ? { ...threadStartResult(), model: runtimeModelId } : undefined,
+      { persistedThreads: [] },
     );
     const params = createParams(sessionFile, workspaceDir);
     params.modelId = "gpt-5.6-sol";
@@ -6693,14 +6761,16 @@ describe("runCodexAppServerAttempt", () => {
     await expect(readCodexAppServerBinding(sessionFile)).resolves.toMatchObject({
       threadId: "thread-1",
       model: runtimeModelId,
-      clientId: "test-client-1",
+      clientId: freshHarness.client.getInstanceId(),
     });
 
-    const resumedHarness = createStartedThreadHarness(async (method) =>
-      method === "thread/resume" ? { ...threadStartResult(), model: runtimeModelId } : undefined,
+    freshHarness.close();
+    const resumedHarness = createStartedThreadHarness(
+      async (method) =>
+        method === "thread/resume" ? { ...threadStartResult(), model: runtimeModelId } : undefined,
+      { persistedThreads: ["thread-1"] },
     );
-    // A different physical client forces native resume instead of warm thread reuse.
-    vi.spyOn(resumedHarness.client, "getInstanceId").mockReturnValue("test-client-2");
+
     const onResumedAgentEvent = vi.fn();
     const resumedRun = runCodexAppServerAttempt(
       { ...params, runId: "run-2", onAgentEvent: onResumedAgentEvent },
@@ -6719,7 +6789,7 @@ describe("runCodexAppServerAttempt", () => {
     await expect(readCodexAppServerBinding(sessionFile)).resolves.toMatchObject({
       threadId: "thread-1",
       model: runtimeModelId,
-      clientId: "test-client-2",
+      clientId: resumedHarness.client.getInstanceId(),
     });
     for (const onAgentEvent of [onFreshAgentEvent, onResumedAgentEvent]) {
       expect(onAgentEvent).toHaveBeenCalledWith({
@@ -6989,145 +7059,163 @@ describe("runCodexAppServerAttempt", () => {
     expect(turnRequestParams?.approvalsReviewer).toBe("user");
   });
 
-  it("uses a supervised native model for review policy despite an outer Anthropic default", async () => {
-    const { sessionFile, workspaceDir, agentDir } = createRunPaths();
-    const codexHome = path.join(tempDir, "review-codex-home");
-    vi.stubEnv("CODEX_HOME", codexHome);
-    const rolloutPath = path.join(codexHome, "sessions", "thread-existing.jsonl");
-    await fs.mkdir(path.dirname(rolloutPath), { recursive: true });
-    await fs.writeFile(
-      rolloutPath,
-      JSON.stringify({
-        type: "session_meta",
-        payload: { id: "thread-existing", model_provider: "openai", dynamic_tools: [] },
-      }) + "\n",
-    );
-    const pluginConfig = {
-      appServer: {
-        mode: "guardian",
-        command: process.execPath,
-        args: ["app-server"],
-      },
-      supervision: { enabled: true },
-    };
-    await writeExistingBinding(sessionFile, workspaceDir, {
-      connectionScope: "supervision",
-      supervisionSourceThreadId: "thread-existing",
-      model: "gpt-5.5",
-      modelProvider: "openai",
-      preserveNativeModel: true,
-      conversationSourceTransferComplete: true,
-      dynamicToolsFingerprint: codexDynamicToolsFingerprint([]),
-      rolloutPath,
-      appServerRuntimeFingerprint: buildCodexAppServerConnectionFingerprint(
-        resolveCodexSupervisionAppServerRuntimeOptions({ pluginConfig }),
-        agentDir,
-      ),
-    });
-    const nativeResponse = {
-      ...threadStartResult("thread-existing", { cwd: workspaceDir }),
-      model: "gpt-5.5",
-      modelProvider: "openai",
-      approvalsReviewer: "auto_review",
-      serviceTier: "priority",
-    };
-    const turnStarted = createDeferred<void>();
-    const requests: Array<{ method: string; params: unknown }> = [];
-    const harness = createClientHarness({
-      onWrite: (line, send) => {
-        const message: unknown = JSON.parse(line);
-        if (
-          !isJsonObject(message) ||
-          typeof message.method !== "string" ||
-          message.id === undefined
-        ) {
+  it.each(["stdio", "websocket", "unix", "proxy"] as const)(
+    "preserves supervised native model and transport/home guards over %s",
+    async (transport) => {
+      const { sessionFile, workspaceDir, agentDir } = createRunPaths();
+      const codexHome = path.join(tempDir, "review-codex-home");
+      vi.stubEnv("CODEX_HOME", codexHome);
+      const rolloutPath = path.join(codexHome, "sessions", "thread-existing.jsonl");
+      await fs.mkdir(path.dirname(rolloutPath), { recursive: true });
+      await fs.writeFile(
+        rolloutPath,
+        JSON.stringify({
+          type: "session_meta",
+          payload: { id: "thread-existing", model_provider: "openai", dynamic_tools: [] },
+        }) + "\n",
+      );
+      const pluginConfig = {
+        appServer: {
+          mode: "guardian",
+          command: process.execPath,
+          args: transport === "proxy" ? ["app-server", "proxy"] : ["app-server"],
+          transport: transport === "proxy" ? "stdio" : transport,
+          ...(transport === "websocket" ? { url: "ws://127.0.0.1:8123" } : {}),
+          ...(transport === "unix" ? { url: "unix:///tmp/synthetic-codex.sock" } : {}),
+        },
+        supervision: { enabled: true },
+      };
+      await writeExistingBinding(sessionFile, workspaceDir, {
+        connectionScope: "supervision",
+        supervisionSourceThreadId: "thread-existing",
+        model: "gpt-5.5",
+        modelProvider: "openai",
+        preserveNativeModel: true,
+        conversationSourceTransferComplete: true,
+        dynamicToolsFingerprint: codexDynamicToolsFingerprint([]),
+        rolloutPath,
+        appServerRuntimeFingerprint: buildCodexAppServerConnectionFingerprint(
+          resolveCodexSupervisionAppServerRuntimeOptions({ pluginConfig }),
+          agentDir,
+        ),
+      });
+      const nativeResponse = {
+        ...threadStartResult("thread-existing", { cwd: workspaceDir }),
+        model: "gpt-5.5",
+        modelProvider: "openai",
+        approvalsReviewer: "auto_review",
+        serviceTier: "priority",
+      };
+      const turnStarted = createDeferred<void>();
+      const requests: Array<{ method: string; params: unknown }> = [];
+      const harness = createClientHarness({
+        onWrite: (line, send) => {
+          const message: unknown = JSON.parse(line);
+          if (
+            !isJsonObject(message) ||
+            typeof message.method !== "string" ||
+            message.id === undefined
+          ) {
+            return;
+          }
+          requests.push({ method: message.method, params: message.params });
+          let result: unknown = {};
+          if (message.method === "initialize") {
+            result = {
+              userAgent: `codex-cli/${getMockRuntimeIdentity().serverVersion}`,
+              codexHome,
+            };
+          } else if (message.method === "config/read") {
+            result = { config: { model_provider: "openai" }, origins: {} };
+          } else if (message.method === "thread/read") {
+            result = { thread: { ...nativeResponse.thread, path: rolloutPath } };
+          } else if (message.method === "thread/resume") {
+            // Native resume tears down an idle, unsubscribed thread before applying overrides.
+            // A successful response alone cannot prove that its configuration changed.
+            send({
+              method: "thread/status/changed",
+              params: { threadId: "thread-existing", status: { type: "notLoaded" } },
+            });
+            result = nativeResponse;
+          } else if (message.method === "turn/start") {
+            result = turnStartResult();
+            turnStarted.resolve();
+          } else if (message.method === "thread/unsubscribe") {
+            result = { status: "unsubscribed" };
+          }
+          send({ id: message.id, result });
+        },
+      });
+      const start = vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
+      const clientFactory = vi.fn(sharedClientModule.getLeasedSharedCodexAppServerClient);
+      testing.setOpenClawCodingToolsFactoryForTests(() => []);
+      // This test owns review-policy projection, not requester-scoped MCP discovery.
+      agentHarnessRuntimeMocks.forceModelToolsUnsupported = true;
+      agentHarnessRuntimeMocks.skipRequesterScopedMcpMaterialization = true;
+      const params = createParams(sessionFile, workspaceDir);
+      params.agentDir = agentDir;
+      params.provider = "anthropic";
+      params.modelId = "claude-opus-4-6";
+      params.model = createCodexTestModel("anthropic");
+      params.fastMode = true;
+      setCodexTestModelSupportsTools(params, false);
+      params.config = {
+        ...params.config,
+        tools: { ...params.config?.tools, exec: { mode: "auto" } },
+      } as EmbeddedRunAttemptParams["config"];
+      const run = runCodexAppServerAttempt(params, {
+        pluginConfig,
+        clientFactory,
+      });
+      try {
+        if (transport === "websocket" || transport === "unix") {
+          await expect(run).rejects.toThrow(
+            "original verified local binding and selected native connection",
+          );
+          expect(
+            requests.some(({ method }) => method === "thread/resume" || method === "turn/start"),
+          ).toBe(false);
           return;
         }
-        requests.push({ method: message.method, params: message.params });
-        let result: unknown = {};
-        if (message.method === "initialize") {
-          result = { userAgent: `codex-cli/${getMockRuntimeIdentity().serverVersion}`, codexHome };
-        } else if (message.method === "config/read") {
-          result = { config: { model_provider: "openai" }, origins: {} };
-        } else if (message.method === "thread/read") {
-          result = { thread: { ...nativeResponse.thread, path: rolloutPath } };
-        } else if (message.method === "thread/resume") {
-          // Native resume tears down an idle, unsubscribed thread before applying overrides.
-          // A successful response alone cannot prove that its configuration changed.
-          send({
-            method: "thread/status/changed",
-            params: { threadId: "thread-existing", status: { type: "notLoaded" } },
-          });
-          result = nativeResponse;
-        } else if (message.method === "turn/start") {
-          result = turnStartResult();
-          turnStarted.resolve();
-        } else if (message.method === "thread/unsubscribe") {
-          result = { status: "unsubscribed" };
-        }
-        send({ id: message.id, result });
-      },
-    });
-    const start = vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
-    const clientFactory = vi.fn(sharedClientModule.getLeasedSharedCodexAppServerClient);
-    testing.setOpenClawCodingToolsFactoryForTests(() => []);
-    // This test owns review-policy projection, not requester-scoped MCP discovery.
-    agentHarnessRuntimeMocks.forceModelToolsUnsupported = true;
-    agentHarnessRuntimeMocks.skipRequesterScopedMcpMaterialization = true;
-    const params = createParams(sessionFile, workspaceDir);
-    params.agentDir = agentDir;
-    params.provider = "anthropic";
-    params.modelId = "claude-opus-4-6";
-    params.model = createCodexTestModel("anthropic");
-    params.fastMode = true;
-    setCodexTestModelSupportsTools(params, false);
-    params.config = {
-      ...params.config,
-      tools: { ...params.config?.tools, exec: { mode: "auto" } },
-    } as EmbeddedRunAttemptParams["config"];
-    const run = runCodexAppServerAttempt(params, {
-      pluginConfig,
-      clientFactory,
-    });
-    try {
-      await Promise.race([
-        turnStarted.promise,
-        run.then((result) => {
-          throw new Error("Codex attempt ended before turn/start", { cause: result });
+        await Promise.race([
+          turnStarted.promise,
+          run.then((result) => {
+            throw new Error("Codex attempt ended before turn/start", { cause: result });
+          }),
+        ]);
+        harness.send({
+          method: "turn/completed",
+          params: { threadId: "thread-existing", turn: { id: "turn-1", status: "completed" } },
+        });
+        expect(readAttemptTerminal(await run)).toMatchObject({
+          aborted: false,
+          timedOut: false,
+          promptError: null,
+        });
+      } finally {
+        start.mockRestore();
+        await harness.client.closeAndWait();
+      }
+      expect(clientFactory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authProfileId: null,
+          startOptions: expect.objectContaining({ homeScope: "user" }),
         }),
-      ]);
-      harness.send({
-        method: "turn/completed",
-        params: { threadId: "thread-existing", turn: { id: "turn-1", status: "completed" } },
-      });
-      expect(readAttemptTerminal(await run)).toMatchObject({
-        aborted: false,
-        timedOut: false,
-        promptError: null,
-      });
-    } finally {
-      start.mockRestore();
-      await harness.client.closeAndWait();
-    }
-    expect(clientFactory).toHaveBeenCalledWith(
-      expect.objectContaining({
-        authProfileId: null,
-        startOptions: expect.objectContaining({ homeScope: "user" }),
-      }),
-    );
-    const resumeRequest = requests.find((request) => request.method === "thread/resume");
-    const resumeParams = resumeRequest?.params as Record<string, unknown> | undefined;
-    expect(resumeParams).not.toHaveProperty("model");
-    expect(resumeParams).not.toHaveProperty("modelProvider");
-    expect(resumeParams?.approvalsReviewer).toBe("auto_review");
-    expect(resumeParams?.serviceTier).toBe("priority");
-    const turnRequest = requests.find((request) => request.method === "turn/start");
-    const turnParams = turnRequest?.params as Record<string, unknown> | undefined;
-    expect(turnParams).not.toHaveProperty("model");
-    expect(turnParams).not.toHaveProperty("modelProvider");
-    expect(turnParams?.approvalsReviewer).toBe("auto_review");
-    expect(turnParams?.serviceTier).toBe("priority");
-  });
+      );
+      const resumeRequest = requests.find((request) => request.method === "thread/resume");
+      const resumeParams = resumeRequest?.params as Record<string, unknown> | undefined;
+      expect(resumeParams).not.toHaveProperty("model");
+      expect(resumeParams).not.toHaveProperty("modelProvider");
+      expect(resumeParams?.approvalsReviewer).toBe("auto_review");
+      expect(resumeParams?.serviceTier).toBe("priority");
+      const turnRequest = requests.find((request) => request.method === "turn/start");
+      const turnParams = turnRequest?.params as Record<string, unknown> | undefined;
+      expect(turnParams).not.toHaveProperty("model");
+      expect(turnParams).not.toHaveProperty("modelProvider");
+      expect(turnParams?.approvalsReviewer).toBe("auto_review");
+      expect(turnParams?.serviceTier).toBe("priority");
+    },
+  );
 
   it("forwards Codex agent exclusions to requester-scoped MCP materialization", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
@@ -7445,6 +7533,7 @@ describe("runCodexAppServerAttempt", () => {
         throw new Error(`unexpected method: ${method}`);
       },
       {
+        persistedThreads: ["thread-existing"],
         onStart: (authProfileId, agentDir) => {
           seenAuthProfileIds.push(authProfileId);
           seenAgentDirs.push(agentDir);

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -98,16 +98,10 @@ vi.mock("./desktop-generation.js", () => ({
   waitForCodexDesktopGeneration: mocks.waitForCodexDesktopGeneration,
 }));
 
-vi.mock("openclaw/plugin-sdk/agent-harness-runtime", () => ({
-  AgentHarnessPreflightError: class extends Error {
-    readonly scope: string;
-
-    constructor(message: string, options: { scope: string; cause?: unknown }) {
-      super(message, { cause: options.cause });
-      this.name = "AgentHarnessPreflightError";
-      this.scope = options.scope;
-    }
-  },
+vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => ({
+  AgentHarnessPreflightError: (
+    await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness-runtime")>()
+  ).AgentHarnessPreflightError,
   embeddedAgentLog: mocks.embeddedAgentLog,
   formatErrorMessage: (error: unknown) => String(error),
   OPENCLAW_VERSION: "test",
@@ -513,27 +507,123 @@ describe("shared Codex app-server client", () => {
     expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
   });
 
+  it.each([
+    { name: "isolated stdio", transport: "stdio", allowed: true },
+    { name: "isolated websocket", transport: "websocket", allowed: false },
+    { name: "isolated unix", transport: "unix", allowed: false },
+    { name: "shared websocket", transport: "websocket", allowed: false, shared: true },
+    { name: "shared unix", transport: "unix", allowed: false, shared: true },
+    { name: "redirected stdio", transport: "stdio", allowed: false, redirect: true },
+    { name: "stdio proxy", transport: "stdio", allowed: false, args: ["app-server", "proxy"] },
+    {
+      name: "stdio option value",
+      transport: "stdio",
+      allowed: true,
+      args: ["app-server", "--cd", "proxy"],
+    },
+  ] as const)(
+    "captures configuration ownership only for a caller-spawned runtime: $name",
+    async (scenario) => {
+      const harness = createClientHarness();
+      vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
+      if ("redirect" in scenario) {
+        mocks.bridgeCodexAppServerStartOptions.mockImplementationOnce(async ({ startOptions }) => ({
+          ...startOptions,
+          transport: "websocket",
+          url: "ws://127.0.0.1:8123",
+        }));
+      }
+      const acquire = (
+        "shared" in scenario
+          ? getLeasedSharedCodexAppServerClient
+          : createIsolatedCodexAppServerClient
+      )({
+        timeoutMs: 1_000,
+        startOptions: {
+          transport: scenario.transport,
+          command: "codex",
+          args: scenario.args ? [...scenario.args] : ["app-server"],
+          headers: {},
+          ...(scenario.transport === "websocket" ? { url: "ws://127.0.0.1:8123" } : {}),
+          ...(scenario.transport === "unix" ? { url: "unix:///tmp/synthetic-codex.sock" } : {}),
+        },
+      });
+      await sendInitializeResult(harness, "openclaw/0.151.0 (Linux; test)");
+      const client = await acquire;
+      if (!scenario.allowed) {
+        const writes = harness.writes.length;
+        expect(() => captureExclusiveSharedCodexAppServerClient(client, "native-process")).toThrow(
+          "reconnect through managed local stdio",
+        );
+        expect(harness.writes).toHaveLength(writes);
+        expect(client.getCloseError()).toBeUndefined();
+      } else {
+        const assertCurrent = captureExclusiveSharedCodexAppServerClient(client, "native-process");
+        expect(assertCurrent).not.toThrow();
+        client.close();
+        expect(assertCurrent).toThrow(CodexAdoptedThreadActiveError);
+      }
+      if ("shared" in scenario) {
+        releaseLeasedSharedCodexAppServerClient(client);
+      }
+      client.close();
+    },
+  );
+
   it("captures configuration ownership only for a sole registered lease", async () => {
     const harness = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
-    expect(() => captureExclusiveSharedCodexAppServerClient(harness.client)).toThrow(
+    expect(() => captureExclusiveSharedCodexAppServerClient(harness.client, "connection")).toThrow(
       CodexAdoptedThreadActiveError,
     );
     const acquire = getLeasedSharedCodexAppServerClient({ timeoutMs: 1_000 });
     await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
     const client = await acquire;
-    expect(captureExclusiveSharedCodexAppServerClient(client)).not.toThrow();
+    expect(captureExclusiveSharedCodexAppServerClient(client, "native-process")).not.toThrow();
 
     const retained = retainSharedCodexAppServerClientByInstanceId(client.getInstanceId());
-    expect(() => captureExclusiveSharedCodexAppServerClient(client)).toThrow(
+    expect(() => captureExclusiveSharedCodexAppServerClient(client, "native-process")).toThrow(
       CodexAdoptedThreadActiveError,
     );
     retained?.release();
     expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
-    expect(() => captureExclusiveSharedCodexAppServerClient(client)).toThrow(
+    expect(() => captureExclusiveSharedCodexAppServerClient(client, "native-process")).toThrow(
       CodexAdoptedThreadActiveError,
     );
   });
+
+  it.each(["websocket", "unix", "proxy"] as const)(
+    "preserves supervised connection-lease ownership over %s without claiming its native process",
+    async (transport) => {
+      const harness = createClientHarness();
+      vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
+      const acquire = getLeasedSharedCodexAppServerClient({
+        timeoutMs: 1_000,
+        startOptions: {
+          transport: transport === "proxy" ? "stdio" : transport,
+          command: "codex",
+          args: transport === "proxy" ? ["app-server", "proxy"] : ["app-server"],
+          headers: {},
+          ...(transport === "websocket" ? { url: "ws://127.0.0.1:8123" } : {}),
+          ...(transport === "unix" ? { url: "unix:///tmp/synthetic-codex.sock" } : {}),
+        },
+      });
+      await sendInitializeResult(harness, "openclaw/0.151.0 (Linux; test)");
+      const client = await acquire;
+      try {
+        const assertCurrent = captureExclusiveSharedCodexAppServerClient(client, "connection");
+        expect(assertCurrent).not.toThrow();
+        const release = retainSharedCodexAppServerClientIfCurrent(client);
+        expect(assertCurrent).toThrow(CodexAdoptedThreadActiveError);
+        release?.();
+        expect(assertCurrent).toThrow(CodexAdoptedThreadActiveError);
+        expect(captureExclusiveSharedCodexAppServerClient(client, "connection")).not.toThrow();
+      } finally {
+        releaseLeasedSharedCodexAppServerClient(client);
+        client.close();
+      }
+    },
+  );
 
   it.each(["acquire", "retain"] as const)(
     "revokes captured configuration ownership after a completed sibling %s",
@@ -554,7 +644,7 @@ describe("shared Codex app-server client", () => {
       const acquire = getLeasedSharedCodexAppServerClient(options);
       await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
       const client = await acquire;
-      const assertExclusive = captureExclusiveSharedCodexAppServerClient(client);
+      const assertExclusive = captureExclusiveSharedCodexAppServerClient(client, "native-process");
       if (operation === "acquire") {
         expect(await getLeasedSharedCodexAppServerClient(options)).toBe(client);
         expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
@@ -563,7 +653,7 @@ describe("shared Codex app-server client", () => {
       }
 
       expect(assertExclusive).toThrow(CodexAdoptedThreadActiveError);
-      expect(captureExclusiveSharedCodexAppServerClient(client)).not.toThrow();
+      expect(captureExclusiveSharedCodexAppServerClient(client, "native-process")).not.toThrow();
       expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
     },
   );
@@ -574,13 +664,13 @@ describe("shared Codex app-server client", () => {
     const acquire = getLeasedSharedCodexAppServerClient({ timeoutMs: 1_000 });
     await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
     const client = await acquire;
-    const assertExclusive = captureExclusiveSharedCodexAppServerClient(client);
+    const assertExclusive = captureExclusiveSharedCodexAppServerClient(client, "native-process");
     let observedPendingAcquire = false;
     await getSharedCodexAppServerClient({
       timeoutMs: 1_000,
       onStartedClient: () => {
         observedPendingAcquire = true;
-        expect(() => captureExclusiveSharedCodexAppServerClient(client)).toThrow(
+        expect(() => captureExclusiveSharedCodexAppServerClient(client, "native-process")).toThrow(
           CodexAdoptedThreadActiveError,
         );
         expect(assertExclusive).toThrow(CodexAdoptedThreadActiveError);
@@ -589,7 +679,7 @@ describe("shared Codex app-server client", () => {
 
     expect(observedPendingAcquire).toBe(true);
     expect(assertExclusive).toThrow(CodexAdoptedThreadActiveError);
-    expect(captureExclusiveSharedCodexAppServerClient(client)).not.toThrow();
+    expect(captureExclusiveSharedCodexAppServerClient(client, "native-process")).not.toThrow();
     expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
   });
 
@@ -599,11 +689,11 @@ describe("shared Codex app-server client", () => {
     const acquire = getLeasedSharedCodexAppServerClient({ timeoutMs: 1_000 });
     await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
     const client = await acquire;
-    const assertExclusive = captureExclusiveSharedCodexAppServerClient(client);
+    const assertExclusive = captureExclusiveSharedCodexAppServerClient(client, "native-process");
     retireSharedCodexAppServerClientIfCurrent(client);
 
     expect(assertExclusive).toThrow(CodexAdoptedThreadActiveError);
-    expect(() => captureExclusiveSharedCodexAppServerClient(client)).toThrow(
+    expect(() => captureExclusiveSharedCodexAppServerClient(client, "native-process")).toThrow(
       CodexAdoptedThreadActiveError,
     );
     expect(harness.stdinDestroyed).toBe(false);

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -40,6 +40,7 @@ import {
   isCodexDesktopGenerationCurrent,
   waitForCodexDesktopGeneration,
 } from "./desktop-generation.js";
+import { isCodexAppServerProxyLaunch } from "./launch-args.js";
 import {
   isManagedCodexDesktopCommand,
   resolveManagedCodexAppServerStartOptions,
@@ -1374,11 +1375,34 @@ export function retainSharedCodexAppServerClientByInstanceId(
   return undefined;
 }
 
-/** Captures sole physical-client ownership across awaited configuration adoption. */
+/** Captures the required connection or native-process ownership across awaited work. */
 export function captureExclusiveSharedCodexAppServerClient(
   client: CodexAppServerClient,
+  requiredOwnership: "connection" | "native-process",
 ): () => void {
   const state = getSharedCodexAppServerClientState();
+  // Ordinary refresh needs a process, not a connection to an external server.
+  // Supervision/release retain their existing shared connection-lease contract.
+  const start = getCodexAppServerClientStartMetadata().get(client)?.startOptions;
+  if (
+    requiredOwnership === "native-process" &&
+    (start?.transport !== "stdio" || isCodexAppServerProxyLaunch(start.args))
+  ) {
+    throw new AgentHarnessPreflightError(
+      "Codex ordinary configuration refresh requires an OpenClaw-managed local stdio process, not an external socket or app-server proxy. No turn was sent; reconnect through managed local stdio before continuing.",
+    );
+  }
+  if (requiredOwnership === "native-process" && state.isolatedClients.has(client)) {
+    // Worker clients already have a sole per-attempt owner, not a shared-pool lease.
+    // Host/placement authority is checked by the caller across every awaited handoff.
+    const assertIsolated = () => {
+      if (!state.isolatedClients.has(client) || client.getCloseError()) {
+        throw new CodexAdoptedThreadActiveError();
+      }
+    };
+    assertIsolated();
+    return assertIsolated;
+  }
   for (const [key, entry] of state.clients) {
     if (entry.client !== client) {
       continue;

--- a/extensions/codex/src/app-server/thread-lifecycle-adoption.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-adoption.ts
@@ -34,7 +34,7 @@ import { withExclusiveCodexAppServerThread } from "./thread-ownership.js";
 import { assertCodexSupervisionThreadLineage } from "./thread-policy.js";
 
 /** Passive refusal must precede releasing or acquiring any native subscription. */
-export async function assertAdoptedCodexThreadResumeAllowed(
+async function assertAdoptedCodexThreadResumeAllowed(
   params: CodexStartOrResumeThreadParams,
   threadId: string,
   context: Pick<CodexThreadRequestContext, "lifecycleTiming" | "throwIfAborted">,
@@ -199,7 +199,7 @@ async function preparePendingCodexThreadResume(
   }
   // Codex can reuse a concurrently resumed child while ignoring overrides.
   // Only an uninterrupted sole client lease makes the unload receipt conclusive.
-  const assertCurrent = captureExclusiveSharedCodexAppServerClient(params.client);
+  const assertCurrent = captureExclusiveSharedCodexAppServerClient(params.client, "native-process");
   const { thread } = await params.client.request(
     "thread/read",
     { threadId: binding.threadId, includeTurns: false },
@@ -244,24 +244,30 @@ async function preparePendingCodexThreadResume(
   }
 }
 
-/** Known supervision keeps its native home; manual adoption's home restrictions stay separate. */
-export function prepareSupervisedCodexThreadResume(
+/** Observe teardown before release; a successful resume alone can acknowledge ignored overrides. */
+export async function prepareCodexThreadResume(
   params: CodexStartOrResumeThreadParams,
   binding: CodexAppServerThreadBinding,
-  thread: CodexThread,
+  context: Pick<CodexThreadRequestContext, "lifecycleTiming" | "throwIfAborted">,
 ) {
-  assertCodexSupervisionThreadLineage(binding, thread);
   if (isCodexAppServerLiveThreadClaimed(params.client, binding.threadId)) {
     throw new CodexAdoptedThreadActiveError();
   }
-  const assertExclusive = captureExclusiveSharedCodexAppServerClient(params.client);
+  const assertExclusive = captureExclusiveSharedCodexAppServerClient(
+    params.client,
+    binding.connectionScope === "supervision" ? "connection" : "native-process",
+  );
   const assertCurrent = () => {
     params.params.hostCapabilities.assertActive();
     params.signal?.throwIfAborted();
     assertExclusive();
-    assertCodexSupervisionThreadLineage(binding, thread);
   };
   assertCurrent();
+  const thread = await assertAdoptedCodexThreadResumeAllowed(params, binding.threadId, context);
+  assertCurrent();
+  // Known supervision keeps its native home; manual adoption's stricter home and catalog
+  // checks remain in preparePendingCodexThreadResume, before this common handoff.
+  assertCodexSupervisionThreadLineage(binding, thread);
   return { ...observeCodexThreadConfiguration(params, thread, assertCurrent), assertCurrent };
 }
 

--- a/extensions/codex/src/app-server/thread-lifecycle-errors.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-errors.ts
@@ -1,4 +1,7 @@
-import { formatErrorMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  AgentHarnessPreflightError,
+  formatErrorMessage,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 
 export class CodexThreadStartRequestError extends Error {
   constructor(cause: unknown) {
@@ -21,7 +24,7 @@ export class CodexRestrictedToolSurfaceAttestationError extends Error {
   }
 }
 
-export class CodexAdoptedThreadActiveError extends Error {
+export class CodexAdoptedThreadActiveError extends AgentHarnessPreflightError {
   constructor() {
     super("Codex session became active in another runner; wait for it to finish before continuing");
     this.name = "CodexAdoptedThreadActiveError";

--- a/extensions/codex/src/app-server/thread-lifecycle-io.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-io.ts
@@ -97,8 +97,8 @@ export async function resumeExistingCodexThread(
   const assertHandoffCurrent = () => {
     params.params.hostCapabilities.assertActive();
     throwIfAborted();
-    context.assertResumeOwnership?.();
-    context.assertResumeConfiguration?.();
+    context.assertResumeOwnership();
+    context.assertResumeConfiguration();
   };
   const abandonClient =
     params.abandonClient ?? (() => closeCodexStartupClientBestEffort(params.client));
@@ -182,7 +182,7 @@ export async function resumeExistingCodexThread(
     );
     resumeResponseAccepted = true;
     assertCodexThreadAcceptsDirectInput(response.thread);
-    context.assertResumeConfiguration?.();
+    context.assertResumeConfiguration();
     // Current-policy denial must release this subscription and stop, not retry
     // as a fresh thread. A confirmed config change still follows normal rotation.
     const loadedPluginThreadConfig = await context.buildLoadedPluginThreadConfig?.(resumeBinding);
@@ -218,29 +218,21 @@ export async function resumeExistingCodexThread(
           ),
         );
       } catch (error) {
-        context.assertResumeOwnership?.();
+        context.assertResumeOwnership();
         await abandonClient();
         throw new CodexRestrictedToolSurfaceAttestationError(error);
       }
     }
     throwIfAborted();
-    if (
-      resumeBinding.connectionScope === "supervision" &&
-      !resumeBinding.pendingSupervisionBranch
-    ) {
-      if (!context.assertResumeConfiguration) {
-        throw new Error("Codex supervised resume requires verified configuration ownership");
-      }
-      await refreshCodexThreadPolicy({
-        client: params.client,
-        threadId: resumeBinding.threadId,
-        developerInstructions: resumeParams.developerInstructions,
-        timeoutMs: params.appServer.requestTimeoutMs,
-        signal: params.signal,
-        assertCurrent: assertHandoffCurrent,
-      });
-      policyOutcome = "acknowledged";
-    }
+    await refreshCodexThreadPolicy({
+      client: params.client,
+      threadId: resumeBinding.threadId,
+      developerInstructions: resumeParams.developerInstructions,
+      timeoutMs: params.appServer.requestTimeoutMs,
+      signal: params.signal,
+      assertCurrent: assertHandoffCurrent,
+    });
+    policyOutcome = "acknowledged";
     assertHandoffCurrent();
     const resumePatch = {
       // Resume moves native subscription ownership to this physical client.
@@ -371,12 +363,7 @@ export async function resumeExistingCodexThread(
         error instanceof CodexThreadPolicyHandoffError ||
         error instanceof CodexAppServerUnsafeSubscriptionError
           ? error
-          : resumeBinding.connectionScope === "supervision"
-            ? new CodexThreadPolicyHandoffError(policyOutcome, error)
-            : new CodexAppServerUnsafeSubscriptionError(
-                `Codex thread/resume handoff failed: ${error instanceof Error ? error.message : String(error)}`,
-                { cause: error },
-              );
+          : new CodexThreadPolicyHandoffError(policyOutcome, error);
       const subscriptionReleased = await unsubscribeCodexThreadBestEffort(params.client, {
         threadId: resumeBinding.threadId,
         timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
@@ -395,9 +382,15 @@ export async function resumeExistingCodexThread(
           try {
             await abandonClient();
           } catch (cause) {
-            throw new CodexAppServerUnsafeSubscriptionError(
-              "Codex thread/resume client could not be retired",
-              { cause },
+            // A secondary cleanup failure must not erase the native policy-write outcome.
+            throw new CodexThreadPolicyHandoffError(
+              handoffError instanceof CodexThreadPolicyHandoffError
+                ? handoffError.outcome
+                : policyOutcome,
+              new AggregateError(
+                [handoffError, cause],
+                "Codex thread/resume client could not be retired",
+              ),
             );
           }
         }

--- a/extensions/codex/src/app-server/thread-lifecycle-result.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-result.ts
@@ -77,6 +77,9 @@ export function buildStartedCodexThreadBinding(input: {
     pluginAppPolicyContext: input.pluginThreadConfig?.policyContext,
     contextEngine: context.contextEngineBinding,
     environmentSelectionFingerprint: context.environmentSelectionFingerprint,
+    ...(startParams.ephemeral && !context.ringZeroConfigFingerprint
+      ? { liveThreadEphemeralPolicy: startParams.developerInstructions }
+      : {}),
     // Transient starts do not own the persisted binding, so their native
     // subscriptions must be released instead of entering the warm cache.
     ...(!context.preserveExistingBinding

--- a/extensions/codex/src/app-server/thread-lifecycle-run.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-run.ts
@@ -32,9 +32,8 @@ import {
   shouldStartTransientNoToolThread,
 } from "./thread-fingerprints.js";
 import {
-  assertAdoptedCodexThreadResumeAllowed,
   resumePendingCodexThread,
-  prepareSupervisedCodexThreadResume,
+  prepareCodexThreadResume,
   withCodexThreadLifecycleBinding,
 } from "./thread-lifecycle-adoption.js";
 import { CodexThreadBindingConflictError } from "./thread-lifecycle-errors.js";
@@ -630,28 +629,6 @@ export async function startOrResumeThread(
           );
           await clearCurrentBinding("rotating a stale thread binding");
         }
-      } else if (incognito) {
-        if (
-          binding.clientId &&
-          binding.clientId === clientId &&
-          ((await buildLoadedPluginThreadConfig(binding))?.fingerprint ??
-            binding.pluginAppsFingerprint) === binding.pluginAppsFingerprint
-        ) {
-          // Ephemeral threads have no cold-resume source; reuse only the live client that started it.
-          params.buildFinalConfigPatch?.({ action: "resume", binding });
-          throwIfAborted();
-          lifecycleTiming.mark("thread-ready");
-          lifecycleTiming.logSummary({
-            runId: params.params.runId,
-            sessionId: params.params.sessionId,
-            sessionKey: params.params.sessionKey,
-            threadId: binding.threadId,
-            action: "resumed",
-          });
-          return { ...binding, lifecycle: { action: "resumed" } };
-        }
-        await clearCurrentBinding("rotating an unavailable ephemeral thread binding");
-        binding = undefined;
       } else {
         const warmReuse = await tryReuseCodexLiveThread({
           ...requestContext,
@@ -663,31 +640,24 @@ export async function startOrResumeThread(
         if (warmReuse.kind === "ready") {
           return warmReuse.binding;
         }
-        if (warmReuse.kind === "rotate") {
+        if (incognito || warmReuse.kind === "rotate") {
           throwIfAborted();
-          await clearCurrentBinding("rotating a stale plugin app binding");
+          await clearCurrentBinding(
+            incognito
+              ? "rotating an unavailable ephemeral thread binding"
+              : "rotating a stale plugin app binding",
+          );
         } else {
           // Native adoption must be checked before releasing any retained owner;
           // a passive refusal neither acquires nor authorizes dropping a subscription.
-          const adoptedThread =
-            binding.preserveNativeModel === true
-              ? await assertAdoptedCodexThreadResumeAllowed(
-                  params,
-                  binding.threadId,
-                  requestContext,
-                )
-              : undefined;
-          const configuration =
-            adoptedThread && binding.connectionScope === "supervision"
-              ? prepareSupervisedCodexThreadResume(params, binding, adoptedThread)
-              : undefined;
+          const configuration = await prepareCodexThreadResume(params, binding, requestContext);
           try {
             await releaseRetainedThread(
               binding.threadId,
               binding.clientId,
-              configuration?.assertCurrent,
+              configuration.assertCurrent,
             );
-            configuration?.assertCurrent();
+            configuration.assertCurrent();
             const resumed = await resumeExistingCodexThread(params, {
               ...requestContext,
               binding,
@@ -695,14 +665,14 @@ export async function startOrResumeThread(
               prebuiltFinalConfigPatch: warmReuse.prebuiltFinalConfigPatch,
               prebuiltPluginThreadConfig,
               buildLoadedPluginThreadConfig,
-              assertResumeOwnership: configuration?.assertCurrent,
-              assertResumeConfiguration: configuration?.assertConfigured,
+              assertResumeOwnership: configuration.assertCurrent,
+              assertResumeConfiguration: configuration.assertConfigured,
             });
             if (resumed) {
               return resumed;
             }
           } finally {
-            configuration?.dispose();
+            configuration.dispose();
           }
         }
       }

--- a/extensions/codex/src/app-server/thread-lifecycle-types.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-types.ts
@@ -28,6 +28,8 @@ type CodexAppServerThreadLifecycle = {
 export type CodexAppServerThreadLifecycleBinding = CodexAppServerThreadBinding & {
   lifecycle: CodexAppServerThreadLifecycle;
   liveThreadConfigFingerprint?: string;
+  /** Creation-time policy for a live ephemeral thread; never persisted in the binding. */
+  liveThreadEphemeralPolicy?: string;
   /** Process-local claim proof; never write this callback into durable binding state. */
   liveThreadOwnership?: CodexAppServerLiveThreadOwnership;
   clearInheritedServiceTier?: true;
@@ -133,8 +135,8 @@ export type CodexResumeThreadContext = CodexThreadRequestContext & {
     binding: CodexAppServerThreadBinding,
   ) => Promise<CodexPluginThreadConfig | undefined>;
   prebuiltFinalConfigPatch?: CodexThreadFinalConfigPatchResult;
-  assertResumeConfiguration?: () => void;
-  assertResumeOwnership?: () => void;
+  assertResumeConfiguration: () => void;
+  assertResumeOwnership: () => void;
 };
 
 export type CodexStartThreadContext = CodexThreadRequestContext & {

--- a/extensions/codex/src/app-server/thread-lifecycle-warm.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-warm.ts
@@ -1,3 +1,5 @@
+import { AgentHarnessPreflightError } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { isIncognitoSessionKey } from "../incognito-session.js";
 import {
   CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
   closeCodexStartupClientBestEffort,
@@ -33,6 +35,8 @@ import type {
   CodexThreadRequestContext,
   CodexThreadFinalConfigPatchResult,
 } from "./thread-lifecycle-types.js";
+import { retainCodexAppServerBindingSubscription } from "./thread-ownership.js";
+import { CodexIncognitoPolicyChangeError } from "./thread-policy.js";
 import { buildThreadResumeParams } from "./thread-requests.js";
 
 type CodexWarmThreadReuseParams = CodexThreadRequestContext & {
@@ -137,7 +141,7 @@ export async function releaseCodexBoundLiveThread(
     const client = previous?.client ?? options.client;
     const assertPrevious =
       previous && options.assertCurrent
-        ? captureExclusiveSharedCodexAppServerClient(client)
+        ? captureExclusiveSharedCodexAppServerClient(client, "connection")
         : undefined;
     if (isCodexAppServerLiveThreadClaimed(client, options.threadId)) {
       throw new Error(`Codex thread ${options.threadId} is claimed by active work; stop it first.`);
@@ -179,6 +183,26 @@ export async function tryReuseCodexLiveThread(
     throwIfAborted,
     userMcpServersConfigPatch,
   } = options;
+  const incognito = isIncognitoSessionKey(params.params.sessionKey);
+
+  // These native-owned/restricted ephemeral lifetimes do not enter ordinary
+  // configuration ownership. Keep their existing live-only continuation path.
+  if (
+    incognito &&
+    (binding.preserveNativeModel || binding.connectionScope === "supervision" || ringZeroActive)
+  ) {
+    if (
+      binding.clientId === clientId &&
+      binding.clientId &&
+      ((await options.buildLoadedPluginThreadConfig(binding))?.fingerprint ??
+        binding.pluginAppsFingerprint) === binding.pluginAppsFingerprint
+    ) {
+      params.buildFinalConfigPatch?.({ action: "resume", binding });
+      throwIfAborted();
+      return { kind: "ready", binding: { ...binding, lifecycle: { action: "resumed" } } };
+    }
+    return { kind: "rotate" };
+  }
 
   if (
     !binding.clientId ||
@@ -194,18 +218,31 @@ export async function tryReuseCodexLiveThread(
   if (!retainedThread) {
     return { kind: "resume" };
   }
-  const assertCurrentClient = () => {
+  const assertWarmOwner = () => {
     throwIfAborted();
     // Startup attaches router abort after this lifecycle call. A closed client's
     // inventory failure must not be treated as revocation of the durable binding.
     if (!isCodexAppServerClientRuntimeLive(params.client)) {
       throw params.client.getCloseError() ?? new Error("codex app-server client is closed");
     }
+    try {
+      // Notifications can revoke this exact claim while its physical client stays
+      // healthy. Both subscription and host authority must survive policy awaits.
+      retainedThread.assertCurrent();
+      params.params.hostCapabilities.assertActive();
+    } catch (cause) {
+      throw new AgentHarnessPreflightError(
+        "Codex warm thread ownership changed before this turn could run. No turn was sent; reconnect before continuing, or start a new conversation if the original thread was closed.",
+        { cause },
+      );
+    }
   };
   let ownershipTransferred = false;
+  let preserveSubscription = false;
   try {
+    assertWarmOwner();
     const pluginThreadConfig = await options.buildLoadedPluginThreadConfig(binding);
-    assertCurrentClient();
+    assertWarmOwner();
     if (pluginThreadConfig && pluginThreadConfig.fingerprint !== binding.pluginAppsFingerprint) {
       return { kind: "rotate" };
     }
@@ -253,21 +290,29 @@ export async function tryReuseCodexLiveThread(
         disableLoginShell: params.disableLoginShell,
       }),
     );
-    const liveThreadConfigFingerprint = fingerprintCodexThreadConfig(
-      {
-        ...resumeParams,
-        // Keep the actual loaded provider separate from caller-selected
-        // overrides so account or provider changes always invalidate reuse.
-        model: binding.model ?? resumeParams.model ?? null,
-        requestedModel: resumeParams.model ?? null,
-        modelProvider: binding.modelProvider ?? resumeParams.modelProvider ?? null,
-        requestedModelProvider: resumeParams.modelProvider ?? binding.modelProvider ?? null,
-      },
-      resumeAuthProfileId,
-      dynamicToolsFingerprint,
-    );
-    if (retainedThread.configFingerprint !== liveThreadConfigFingerprint) {
-      // Loaded Codex threads ignore overrides; release the claimed subscription before resume.
+    const liveThreadConfigFingerprint = incognito
+      ? retainedThread.configFingerprint
+      : fingerprintCodexThreadConfig(
+          {
+            ...resumeParams,
+            // Keep the actual loaded provider separate from caller-selected
+            // overrides so account or provider changes always invalidate reuse.
+            model: binding.model ?? resumeParams.model ?? null,
+            requestedModel: resumeParams.model ?? null,
+            modelProvider: binding.modelProvider ?? resumeParams.modelProvider ?? null,
+            requestedModelProvider: resumeParams.modelProvider ?? binding.modelProvider ?? null,
+          },
+          resumeAuthProfileId,
+          dynamicToolsFingerprint,
+        );
+    if (incognito && retainedThread.ephemeralPolicy !== resumeParams.developerInstructions) {
+      preserveSubscription = true;
+      throw new CodexIncognitoPolicyChangeError();
+    }
+    if (!incognito && retainedThread.configFingerprint !== liveThreadConfigFingerprint) {
+      // Return the same owner first: cold-resume preparation must observe native teardown
+      // before releasing it, otherwise a loaded resume can silently ignore new policy.
+      preserveSubscription = true;
       return { kind: "resume", prebuiltFinalConfigPatch };
     }
     await attestCodexPluginThreadApps({
@@ -276,35 +321,37 @@ export async function tryReuseCodexLiveThread(
       appIds: pluginThreadConfig?.provisionalAppIds ?? [],
       signal: params.signal,
     });
-    assertCurrentClient();
+    assertWarmOwner();
     const nativeHookRelayGeneration =
       prebuiltFinalConfigPatch.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration;
     const model = startModelSelection.model;
     // Validate ownership even when relay generation is unchanged; reset may
     // have replaced the persisted binding since it was first read. Model and
     // cwd are sticky turn settings, so future turns and /btw need current facts.
-    const committed = await lifecycleTiming.measure("warm-thread-write-binding", () =>
-      params.bindingStore.mutate(
-        bindingIdentity,
-        {
-          kind: "patch",
-          threadId: binding.threadId,
-          // Environment selection is sticky turn/start state, like cwd/model;
-          // recording its new value must not recreate the approval-bearing thread.
-          patch: {
-            cwd: params.cwd,
-            model,
-            nativeHookRelayGeneration,
-            environmentSelectionFingerprint,
+    const committed =
+      incognito ||
+      (await lifecycleTiming.measure("warm-thread-write-binding", () =>
+        params.bindingStore.mutate(
+          bindingIdentity,
+          {
+            kind: "patch",
+            threadId: binding.threadId,
+            // Environment selection is sticky turn/start state, like cwd/model;
+            // recording its new value must not recreate the approval-bearing thread.
+            patch: {
+              cwd: params.cwd,
+              model,
+              nativeHookRelayGeneration,
+              environmentSelectionFingerprint,
+            },
           },
-        },
-        assertCurrentClient,
-      ),
-    );
+          assertWarmOwner,
+        ),
+      ));
     if (!committed) {
       throw new CodexThreadBindingConflictError(binding.threadId, "committing a reused thread");
     }
-    assertCurrentClient();
+    assertWarmOwner();
     lifecycleTiming.mark("thread-ready");
     lifecycleTiming.logSummary({
       runId: params.params.runId,
@@ -318,13 +365,13 @@ export async function tryReuseCodexLiveThread(
       kind: "ready",
       binding: {
         ...binding,
-        cwd: params.cwd,
-        model,
-        nativeHookRelayGeneration,
-        environmentSelectionFingerprint,
+        ...(!incognito
+          ? { cwd: params.cwd, model, nativeHookRelayGeneration, environmentSelectionFingerprint }
+          : {}),
         liveThreadConfigFingerprint,
+        liveThreadEphemeralPolicy: retainedThread.ephemeralPolicy,
         liveThreadOwnership: retainedThread,
-        ...(retainedThread.serviceTier && resumeParams.serviceTier === undefined
+        ...(!incognito && retainedThread.serviceTier && resumeParams.serviceTier === undefined
           ? { clearInheritedServiceTier: true }
           : {}),
         lifecycle: { action: "resumed" },
@@ -332,10 +379,28 @@ export async function tryReuseCodexLiveThread(
     };
   } finally {
     if (!ownershipTransferred) {
+      let failure: { cause: unknown } | undefined;
       try {
-        // Keep the claim's generation fence across policy awaits and binding conflicts.
-        await retainedThread.release(binding.threadId);
-      } catch (error) {
+        if (preserveSubscription) {
+          if (
+            !(await retainCodexAppServerBindingSubscription(
+              params.client,
+              binding.threadId,
+              retainedThread,
+            ))
+          ) {
+            failure = {
+              cause: new Error("Codex live thread ownership could not be returned to its session"),
+            };
+          }
+        } else {
+          // Keep the claim's generation fence across policy awaits and binding conflicts.
+          await retainedThread.release(binding.threadId);
+        }
+      } catch (cause) {
+        failure = { cause };
+      }
+      if (failure) {
         await abandonCodexLiveThreadRelease(
           {
             client: params.client,
@@ -343,7 +408,7 @@ export async function tryReuseCodexLiveThread(
             lifecycleTiming,
             threadId: binding.threadId,
           },
-          error,
+          failure.cause,
         );
       }
     }

--- a/extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts
@@ -10,10 +10,7 @@ import {
   retainCodexAppServerLiveThread,
 } from "./client-runtime.js";
 import { CodexAppServerRpcError } from "./client.js";
-import {
-  createFakeCodexAppServerClient,
-  threadStartResult,
-} from "./codex-app-server.test-fixtures.js";
+import { threadStartResult } from "./codex-app-server.test-fixtures.js";
 import { resolveCodexPluginsPolicy } from "./config.js";
 import {
   appInfo,
@@ -33,6 +30,7 @@ import { createCodexTestModel, useAutoCleanupTempDirTracker } from "./test-suppo
 import { startOrResumeThread as startOrResumeThreadImpl } from "./thread-lifecycle.js";
 import {
   createAppServerOptions,
+  createLeasedCodexLifecycleHarness,
   createParams,
   resetThreadLifecycleTestFixtures,
 } from "./thread-lifecycle.test-fixtures.js";
@@ -73,7 +71,7 @@ describe("Codex app inventory across physical process restart", () => {
   };
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   let tempDir = "";
-  const processes: Array<ReturnType<typeof createFakeCodexAppServerClient>> = [];
+  const processes: Array<{ close: () => void }> = [];
 
   beforeEach(() => {
     tempDir = tempDirs.make("openclaw-cold-app-inventory-");
@@ -128,9 +126,10 @@ describe("Codex app inventory across physical process restart", () => {
       },
     };
 
-    function createProcess() {
+    async function createProcess(persistedThreadId?: string) {
       const processId = `process-${++processSequence}`;
       const loadedThreads = new Map<string, JsonObject>();
+      const subscribedThreads = new Set<string>();
       const threadToolRevocations = new Set<string>();
       const disabledThreadApps = new Set<string>();
       const abort = new AbortController();
@@ -143,127 +142,150 @@ describe("Codex app inventory across physical process restart", () => {
           throw closeError;
         }
       };
-      const fake = createFakeCodexAppServerClient(async (method, raw) => {
-        assertOpen();
-        const requestParams = isJsonObject(raw) ? raw : {};
-        const threadId =
-          typeof requestParams.threadId === "string" ? requestParams.threadId : undefined;
-        calls.push({
-          processId,
-          method,
-          params: requestParams,
-          loaded: Boolean(threadId && loadedThreads.has(threadId)),
-        });
-        if (
-          ["app/installed", "app/read", "mcpServerStatus/list"].includes(method) &&
-          threadId &&
-          !loadedThreads.has(threadId)
-        ) {
-          throw new CodexAppServerRpcError(
-            { code: -32600, message: `thread not found: ${threadId}` },
-            method,
-          );
-        }
-        if (method === "skills/list") {
-          return { data: [], errors: [] };
-        }
-        if (method === "config/read") {
-          return { config: currentConfig, layers: [] };
-        }
-        if (method === "plugin/installed") {
-          return pluginInstalled([pluginSummary(pluginName, { installed: true, enabled: true })]);
-        }
-        if (method === "plugin/read") {
-          return pluginDetail(pluginName, [appSummary(appId)]);
-        }
-        if (method === "app/installed" || method === "app/read") {
-          if (threadId) {
-            await faults.beforeInventory?.();
-          }
-          assertOpen();
-          const effective = threadId ? loadedThreads.get(threadId) : currentConfig;
-          const apps = isJsonObject(effective?.apps) ? effective.apps : {};
-          const app = isJsonObject(apps[appId]) ? apps[appId] : {};
-          const row = {
-            ...appInfo(appId, !accountRevoked),
-            isEnabled: app.enabled === true && !(threadId && disabledThreadApps.has(threadId)),
-          };
-          if (method === "app/installed") {
-            return codexAppInventoryResponse(
-              method,
-              [row],
-              {
-                forceRefresh: requestParams.forceRefresh === true,
-              },
-              { callableByAppId: { [appId]: !accountRevoked && row.isEnabled } },
-            );
-          }
-          return codexAppInventoryResponse(method, [row], {
-            appIds: Array.isArray(requestParams.appIds)
-              ? requestParams.appIds.filter((value): value is string => typeof value === "string")
-              : [],
-            includeTools: requestParams.includeTools === true,
+      const fake = await createLeasedCodexLifecycleHarness({
+        agentDir,
+        persistedThreads: persistedThreadId ? [persistedThreadId] : [],
+        unsubscribe: (threadId) => {
+          calls.push({
+            processId,
+            method: "thread/unsubscribe",
+            params: { threadId },
+            loaded: loadedThreads.has(threadId),
           });
-        }
-        if (method === "mcpServerStatus/list") {
+          if (faults.unsubscribe) {
+            throw faults.unsubscribe;
+          }
+          const wasSubscribed = subscribedThreads.delete(threadId);
           return {
-            data: [
-              {
-                name: "codex_apps",
-                tools:
-                  accountRevoked || (threadId && threadToolRevocations.has(threadId))
-                    ? {}
-                    : { list: { _meta: { connector_id: appId } } },
-              },
-            ],
-            nextCursor: null,
+            status: !loadedThreads.has(threadId)
+              ? "notLoaded"
+              : wasSubscribed
+                ? "unsubscribed"
+                : "notSubscribed",
           };
-        }
-        if (method === "thread/start") {
-          const id = `00000000-0000-4000-8000-${String(++sequence).padStart(12, "0")}`;
-          const config = isJsonObject(requestParams.config) ? requestParams.config : {};
-          durableThreads.set(id, config);
-          loadedThreads.set(id, config);
-          return { ...threadStartResult(id, workspaceDir), model: params.modelId };
-        }
-        if (method === "thread/resume" && threadId) {
-          if (!durableThreads.has(threadId)) {
+        },
+        respond: async (method, raw) => {
+          assertOpen();
+          const requestParams = isJsonObject(raw) ? raw : {};
+          const threadId =
+            typeof requestParams.threadId === "string" ? requestParams.threadId : undefined;
+          calls.push({
+            processId,
+            method,
+            params: requestParams,
+            loaded: Boolean(threadId && loadedThreads.has(threadId)),
+          });
+          if (
+            ["app/installed", "app/read", "mcpServerStatus/list"].includes(method) &&
+            threadId &&
+            !loadedThreads.has(threadId)
+          ) {
             throw new CodexAppServerRpcError(
               { code: -32600, message: `thread not found: ${threadId}` },
               method,
             );
           }
-          // Loaded threads ignore config overrides; cold resume rebuilds effective config.
-          if (!loadedThreads.has(threadId)) {
-            const config = isJsonObject(requestParams.config)
-              ? requestParams.config
-              : durableThreads.get(threadId)!;
-            loadedThreads.set(threadId, config);
-            durableThreads.set(threadId, config);
+          if (method === "skills/list") {
+            return { data: [], errors: [] };
           }
-          return { ...threadStartResult(threadId, workspaceDir), model: params.modelId };
-        }
-        if (method === "thread/unsubscribe" && threadId) {
-          if (faults.unsubscribe) {
-            throw faults.unsubscribe;
+          if (method === "config/read") {
+            return { config: currentConfig, layers: [] };
           }
-          loadedThreads.delete(threadId);
-          return { status: "unsubscribed" };
-        }
-        if (method === "thread/delete" && threadId) {
-          loadedThreads.delete(threadId);
-          durableThreads.delete(threadId);
-          return {};
-        }
-        throw new Error(`unexpected fixture RPC: ${method}`);
+          if (method === "plugin/installed") {
+            return pluginInstalled([pluginSummary(pluginName, { installed: true, enabled: true })]);
+          }
+          if (method === "plugin/read") {
+            return pluginDetail(pluginName, [appSummary(appId)]);
+          }
+          if (method === "app/installed" || method === "app/read") {
+            if (threadId) {
+              await faults.beforeInventory?.();
+            }
+            assertOpen();
+            const effective = threadId ? loadedThreads.get(threadId) : currentConfig;
+            const apps = isJsonObject(effective?.apps) ? effective.apps : {};
+            const app = isJsonObject(apps[appId]) ? apps[appId] : {};
+            const row = {
+              ...appInfo(appId, !accountRevoked),
+              isEnabled: app.enabled === true && !(threadId && disabledThreadApps.has(threadId)),
+            };
+            if (method === "app/installed") {
+              return codexAppInventoryResponse(
+                method,
+                [row],
+                {
+                  forceRefresh: requestParams.forceRefresh === true,
+                },
+                { callableByAppId: { [appId]: !accountRevoked && row.isEnabled } },
+              );
+            }
+            return codexAppInventoryResponse(method, [row], {
+              appIds: Array.isArray(requestParams.appIds)
+                ? requestParams.appIds.filter((value): value is string => typeof value === "string")
+                : [],
+              includeTools: requestParams.includeTools === true,
+            });
+          }
+          if (method === "mcpServerStatus/list") {
+            return {
+              data: [
+                {
+                  name: "codex_apps",
+                  tools:
+                    accountRevoked || (threadId && threadToolRevocations.has(threadId))
+                      ? {}
+                      : { list: { _meta: { connector_id: appId } } },
+                },
+              ],
+              nextCursor: null,
+            };
+          }
+          if (method === "thread/start") {
+            const id = `00000000-0000-4000-8000-${String(++sequence).padStart(12, "0")}`;
+            const config = isJsonObject(requestParams.config) ? requestParams.config : {};
+            durableThreads.set(id, config);
+            loadedThreads.set(id, config);
+            subscribedThreads.add(id);
+            return { ...threadStartResult(id, workspaceDir), model: params.modelId };
+          }
+          if (method === "thread/resume" && threadId) {
+            if (!durableThreads.has(threadId)) {
+              throw new CodexAppServerRpcError(
+                { code: -32600, message: `thread not found: ${threadId}` },
+                method,
+              );
+            }
+            // Loaded threads ignore config overrides; cold resume rebuilds effective config.
+            if (!loadedThreads.has(threadId)) {
+              const config = isJsonObject(requestParams.config)
+                ? requestParams.config
+                : durableThreads.get(threadId)!;
+              loadedThreads.set(threadId, config);
+              durableThreads.set(threadId, config);
+            }
+            subscribedThreads.add(threadId);
+            return { ...threadStartResult(threadId, workspaceDir), model: params.modelId };
+          }
+          if (method === "thread/delete" && threadId) {
+            loadedThreads.delete(threadId);
+            durableThreads.delete(threadId);
+            return {};
+          }
+          throw new Error(`unexpected fixture RPC: ${method}`);
+        },
       });
-      vi.spyOn(fake.client, "getInstanceId").mockReturnValue(processId);
+      const close = (error?: Error) => {
+        closeError = error;
+        loadedThreads.clear();
+        subscribedThreads.clear();
+        fake.client.close();
+      };
       fake.client.addCloseHandler((client) => {
         closeError = client.getCloseError() ?? new Error("codex app-server client is closed");
       });
       ensureCodexAppServerClientRuntime(fake.client, { agentDir });
-      processes.push(fake);
-      const abandonClient = vi.fn(async () => fake.close());
+      processes.push({ close });
+      const abandonClient = vi.fn(async () => close());
       const appCacheKey = "same-account-home-version";
       const inputFingerprint = buildScheduledCodexAppAuthorityInputFingerprint(
         buildCodexPluginThreadConfigInputFingerprint({ pluginConfig, appCacheKey }),
@@ -286,7 +308,9 @@ describe("Codex app inventory across physical process restart", () => {
         });
       return {
         ...fake,
+        close,
         loadedThreads,
+        subscribedThreads,
         threadToolRevocations,
         disabledThreadApps,
         abort,
@@ -337,7 +361,7 @@ describe("Codex app inventory across physical process restart", () => {
 
   async function continuation(scheduled: boolean, lifecycle: string) {
     const f = await fixture(scheduled);
-    const firstProcess = f.createProcess();
+    const firstProcess = await f.createProcess();
     const first = await firstProcess.run();
     expect(first.pluginAppPolicyContext?.apps[appId]).toBeDefined();
     expect(firstProcess.loadedThreads.has(first.threadId)).toBe(true);
@@ -354,13 +378,20 @@ describe("Codex app inventory across physical process restart", () => {
         expect(await releaseCodexAppServerLiveThread(firstProcess.client, first.threadId)).toBe(
           true,
         );
-        expect(firstProcess.loadedThreads.has(first.threadId)).toBe(false);
+        expect(firstProcess.subscribedThreads.has(first.threadId)).toBe(false);
+        expect(firstProcess.loadedThreads.has(first.threadId)).toBe(true);
+        // Native idle eviction is a separate event, not an unsubscribe receipt.
+        firstProcess.loadedThreads.delete(first.threadId);
+        firstProcess.notify({
+          method: "thread/closed",
+          params: { threadId: first.threadId },
+        });
       }
     } else {
       firstProcess.close();
       f.restartStore();
     }
-    const process = lifecycle === "cold" ? f.createProcess() : firstProcess;
+    const process = lifecycle === "cold" ? await f.createProcess(first.threadId) : firstProcess;
     return { ...f, first, process };
   }
 
@@ -377,7 +408,16 @@ describe("Codex app inventory across physical process restart", () => {
       const f = await continuation(scheduled, lifecycle);
       const { first, process } = f;
       const boundary = f.calls.length;
+      const requestBoundary = process.request.mock.calls.length;
       const second = await process.run();
+      expect(
+        process.request.mock.calls
+          .slice(requestBoundary)
+          .map(([method]) => method)
+          .filter((method) => method.startsWith("thread/")),
+      ).toEqual(
+        lifecycle === "warm" ? [] : ["thread/read", "thread/resume", "thread/inject_items"],
+      );
       expect(second.threadId).toBe(first.threadId);
       if (lifecycle === "warm") {
         expect(f.calls.slice(boundary).some((call) => call.method === "thread/resume")).toBe(false);
@@ -489,7 +529,7 @@ describe("Codex app inventory across physical process restart", () => {
     expect(await f.readBinding()).toEqual(
       fault === "abort" ? previousBinding : { ...previousBinding, threadId: replacementId },
     );
-    expect(f.process.loadedThreads.has(f.first.threadId)).toBe(false);
+    expect(f.process.subscribedThreads.has(f.first.threadId)).toBe(false);
     expect(f.calls.slice(boundary).some((call) => call.method === "thread/start")).toBe(false);
   });
 
@@ -502,7 +542,7 @@ describe("Codex app inventory across physical process restart", () => {
       const boundary = f.calls.length;
       await expect(f.process.run()).rejects.toThrow("did not expose admitted apps");
       expect(await f.readBinding()).toEqual(previousBinding);
-      expect(f.process.loadedThreads.has(f.first.threadId)).toBe(false);
+      expect(f.process.subscribedThreads.has(f.first.threadId)).toBe(false);
       expect(f.calls.slice(boundary).some((call) => call.method === "thread/start")).toBe(false);
     },
   );
@@ -533,9 +573,17 @@ describe("Codex app inventory across physical process restart", () => {
       f.process.threadToolRevocations.add(f.first.threadId);
       f.process.faults.unsubscribe = new Error("unsubscribe unavailable");
       const boundary = f.calls.length;
-      await expect(f.process.run()).rejects.toMatchObject({
-        name: "CodexAppServerUnsafeSubscriptionError",
-      });
+      await expect(f.process.run()).rejects.toMatchObject(
+        lifecycle === "cold"
+          ? {
+              name: "CodexThreadPolicyHandoffError",
+              outcome: "not-written",
+              cause: expect.objectContaining({
+                message: expect.stringContaining("Scheduled Codex apps are unavailable"),
+              }),
+            }
+          : { name: "CodexAppServerUnsafeSubscriptionError" },
+      );
       expect(f.process.abandonClient).toHaveBeenCalledOnce();
       expect(await f.readBinding()).toEqual(previousBinding);
       expect(f.calls.slice(boundary).some((call) => call.method === "thread/start")).toBe(false);

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -1,6 +1,7 @@
 // Codex tests cover thread lifecycle.binding plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { AgentHarnessPreflightError } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it, vi } from "vitest";
 import { resumeThread } from "../command-handler-bindings.js";
@@ -8,6 +9,7 @@ import { resolveCodexCommandDeps } from "../command-handler-deps.js";
 import {
   claimCodexAppServerLiveThread,
   ensureCodexAppServerClientRuntime,
+  isCodexAppServerLiveThreadClaimed,
   retainCodexAppServerLiveThread,
 } from "./client-runtime.js";
 import { CodexAppServerClient, CodexAppServerRpcError } from "./client.js";
@@ -21,6 +23,7 @@ import type {
   RpcRequest,
 } from "./protocol.js";
 import {
+  bindProductionHarnessHostCapabilitiesForTest,
   createParams as createRunAttemptParams,
   setupRunAttemptTestHooks,
   tempDir,
@@ -44,7 +47,9 @@ import {
   buildThreadResumeParams,
   startOrResumeThread as startOrResumeThreadImpl,
 } from "./thread-lifecycle.js";
+import { createLeasedCodexLifecycleHarness } from "./thread-lifecycle.test-fixtures.js";
 import { withCodexAppServerThreadMutation } from "./thread-ownership.js";
+import { CodexIncognitoPolicyChangeError } from "./thread-policy.js";
 
 function startOrResumeThread(
   params: Omit<Parameters<typeof startOrResumeThreadImpl>[0], "bindingStore">,
@@ -55,6 +60,7 @@ function startOrResumeThread(
     params.params.sessionKey,
   );
   return startOrResumeThreadImpl({
+    signal: new AbortController().signal,
     ...params,
     bindingStore: testCodexAppServerBindingStore,
   });
@@ -395,6 +401,9 @@ async function createManualResumeFixture(
       }
       return { ...response, thread };
     }
+    if (method === "thread/inject_items") {
+      return {};
+    }
     throw new Error(`unexpected method: ${method}`);
   });
   const wire = options.wireClient ? createClientHarness() : undefined;
@@ -575,6 +584,199 @@ async function createLeasedLifecycleWireClient(
 }
 
 describe("Codex app-server thread lifecycle bindings", () => {
+  it("exposes incognito policy refusal as an unscoped preflight", () => {
+    const error = new CodexIncognitoPolicyChangeError();
+    expect(error).toBeInstanceOf(AgentHarnessPreflightError);
+    expect(error).toMatchObject({ scope: undefined });
+  });
+  it.each([
+    { developerInstructions: "replacement policy", fault: "none" },
+    { developerInstructions: "", fault: "none" },
+    { developerInstructions: "replacement policy", fault: "unload" },
+    { developerInstructions: "replacement policy", fault: "competing resume" },
+    { developerInstructions: "replacement policy", fault: "unknown write" },
+    { developerInstructions: "replacement policy", fault: "retirement failure" },
+    { developerInstructions: "replacement policy", fault: "binding commit" },
+  ])(
+    "refreshes ordinary generic policy before admitting a resumed turn: $developerInstructions / $fault",
+    async ({ developerInstructions, fault }) => {
+      const sessionFile = path.join(tempDir, "ordinary-policy.jsonl");
+      const workspaceDir = path.join(tempDir, "workspace");
+      const threadId = "ordinary-policy";
+      const response = threadStartResult(threadId);
+      const requests: RpcRequest[] = [];
+      const wire = await createLeasedLifecycleWireClient(path.join(tempDir, "agent"), (request) => {
+        requests.push(request);
+        if (request.method === "thread/read") {
+          return {
+            thread: {
+              ...response.thread,
+              status: { type: fault === "unload" ? "idle" : "notLoaded" },
+            },
+          };
+        }
+        if (request.method === "thread/resume") {
+          if (fault === "competing resume") {
+            retainSharedCodexAppServerClientIfCurrent(wire.client)?.();
+          }
+          return response;
+        }
+        if (request.method === "thread/inject_items") {
+          if (fault === "unknown write" || fault === "retirement failure") {
+            throw new CodexAppServerRpcError(
+              { code: -32603, message: "policy flush failed after write" },
+              "thread/inject_items",
+            );
+          }
+          return {};
+        }
+        if (request.method === "thread/unsubscribe") {
+          return { status: "unsubscribed" };
+        }
+        throw new Error(`unexpected method: ${request.method}`);
+      });
+      await writeCodexAppServerBinding(sessionFile, { threadId, cwd: workspaceDir });
+      const before = await readCodexAppServerBinding(sessionFile);
+      if (fault === "binding commit") {
+        vi.spyOn(testCodexAppServerBindingStore, "mutate").mockRejectedValueOnce(
+          new Error("binding commit failed"),
+        );
+      }
+      try {
+        const run = startOrResumeThread({
+          client: wire.client,
+          params: {
+            ...createParams(sessionFile, workspaceDir),
+            agentDir: path.join(tempDir, "agent"),
+          },
+          cwd: workspaceDir,
+          dynamicTools: [],
+          appServer: createThreadLifecycleAppServerOptions(),
+          userMcpServersEnabled: false,
+          developerInstructions,
+          signal: new AbortController().signal,
+          ...(fault === "retirement failure"
+            ? {
+                abandonClient: async () => {
+                  throw new Error("client retirement failed");
+                },
+              }
+            : {}),
+        });
+        if (fault !== "none") {
+          await expect(run).rejects.toBeInstanceOf(AgentHarnessPreflightError);
+          await expect(run).rejects.toMatchObject({
+            name: "CodexThreadPolicyHandoffError",
+            scope: undefined,
+            outcome:
+              fault === "unknown write" || fault === "retirement failure"
+                ? "unknown"
+                : fault === "binding commit"
+                  ? "acknowledged"
+                  : "not-written",
+          });
+          expect(await readCodexAppServerBinding(sessionFile)).toEqual(before);
+          expect(requests.filter(({ method }) => method === "thread/resume")).toHaveLength(1);
+          expect(requests.filter(({ method }) => method === "thread/inject_items")).toHaveLength(
+            fault === "unknown write" ||
+              fault === "retirement failure" ||
+              fault === "binding commit"
+              ? 1
+              : 0,
+          );
+          expect(requests.some(({ method }) => method === "thread/start")).toBe(false);
+          return;
+        }
+        await run;
+        expect(requests.map(({ method }) => method)).toEqual([
+          "thread/read",
+          "thread/resume",
+          "thread/inject_items",
+        ]);
+        const policy = JSON.stringify(requests.at(-1)?.params);
+        expect(policy).toContain(
+          developerInstructions || "earlier OpenClaw generic policy is withdrawn",
+        );
+        expect(policy).toContain("It replaces earlier OpenClaw-supplied generic policy");
+        expect((await readCodexAppServerBinding(sessionFile))?.threadId).toBe(threadId);
+      } finally {
+        releaseLeasedSharedCodexAppServerClient(wire.client);
+        wire.client.close();
+      }
+    },
+  );
+
+  it.each(["initial policy", "replacement policy", ""])(
+    "keeps ordinary warm configuration honest across policy %j",
+    async (developerInstructions) => {
+      const sessionFile = path.join(tempDir, "ordinary-warm-policy.jsonl");
+      const workspaceDir = path.join(tempDir, "workspace");
+      const threadId = "ordinary-warm-policy";
+      const response = threadStartResult(threadId);
+      const methods: string[] = [];
+      const wire = await createLeasedLifecycleWireClient(path.join(tempDir, "agent"), (request) => {
+        methods.push(request.method);
+        if (request.method === "thread/start" || request.method === "thread/resume") {
+          return response;
+        }
+        if (request.method === "thread/read") {
+          return { thread: response.thread };
+        }
+        if (request.method === "thread/unsubscribe") {
+          wire.send({
+            method: "thread/status/changed",
+            params: { threadId, status: { type: "notLoaded" } },
+          });
+          return { status: "unsubscribed" };
+        }
+        if (request.method === "thread/inject_items") {
+          return {};
+        }
+        throw new Error(`unexpected method: ${request.method}`);
+      });
+      const common = {
+        client: wire.client,
+        params: {
+          ...createParams(sessionFile, workspaceDir),
+          agentDir: path.join(tempDir, "agent"),
+        },
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+        userMcpServersEnabled: false,
+        signal: new AbortController().signal,
+      };
+      try {
+        const first = await startOrResumeThread({
+          ...common,
+          developerInstructions: "initial policy",
+        });
+        await retainCodexAppServerLiveThread(
+          wire.client,
+          first.threadId,
+          undefined,
+          first.liveThreadConfigFingerprint,
+        );
+        const second = await startOrResumeThread({ ...common, developerInstructions });
+        expect(second.threadId).toBe(first.threadId);
+        expect(methods).toEqual(
+          developerInstructions === "initial policy"
+            ? ["thread/start"]
+            : [
+                "thread/start",
+                "thread/read",
+                "thread/unsubscribe",
+                "thread/resume",
+                "thread/inject_items",
+              ],
+        );
+      } finally {
+        releaseLeasedSharedCodexAppServerClient(wire.client);
+        wire.client.close();
+      }
+    },
+  );
+
   it("persists the native rollout path across thread start and resume", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
@@ -587,7 +789,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       `rollout-${threadId}.jsonl`,
     );
     const params = createParams(sessionFile, workspaceDir);
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method !== "thread/start" && method !== "thread/resume") {
         throw new Error(`unexpected method: ${method}`);
       }
@@ -597,8 +799,13 @@ describe("Codex app-server thread lifecycle bindings", () => {
         thread: { ...response.thread, path: rolloutPath },
       };
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
     const common = {
-      client: { getInstanceId: () => "native-rollout-client", request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -617,13 +824,20 @@ describe("Codex app-server thread lifecycle bindings", () => {
       rolloutPath,
     });
 
+    await fixture.endTurn("thread-native-rollout");
     const resumed = await startOrResumeThread(common);
     expect(resumed).toMatchObject({
       threadId,
       rolloutPath,
       lifecycle: { action: "resumed" },
     });
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start", "thread/resume"]);
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/start",
+      "thread/unsubscribe",
+      "thread/read",
+      "thread/resume",
+      "thread/inject_items",
+    ]);
     await expect(readCodexAppServerBinding(sessionFile)).resolves.toMatchObject({
       threadId,
       rolloutPath,
@@ -696,18 +910,147 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
   });
 
+  it.each(
+    [false, true].flatMap((incognito) =>
+      ["plugin config", "app attestation"].flatMap((stage) =>
+        ["thread/closed", "thread/archived", "host"].map((revocation) => ({
+          incognito,
+          stage,
+          revocation,
+        })),
+      ),
+    ),
+  )(
+    "refuses revoked warm ownership during $stage ($revocation, incognito: $incognito)",
+    async ({ incognito, stage, revocation }) => {
+      const sessionFile = path.join(tempDir, "warm-revocation.jsonl");
+      const workspaceDir = path.join(tempDir, "warm-revocation-workspace");
+      const params = createParams(sessionFile, workspaceDir);
+      if (incognito) {
+        params.sessionKey = "agent:main:dashboard:incognito-warm-revocation";
+      }
+      const closeHost = await bindProductionHarnessHostCapabilitiesForTest(params);
+      const entered = createDeferred<void>();
+      const proceed = createDeferred<void>();
+      let warming = false;
+      const pause = async (currentStage: string) => {
+        if (warming && stage === currentStage) {
+          entered.resolve();
+          await proceed.promise;
+        }
+      };
+      const fixture = await createLeasedCodexLifecycleHarness({
+        agentDir: path.join(tempDir, "agent"),
+        respond: async (method) => {
+          if (method === "thread/start") {
+            return threadStartResult("warm-revoked");
+          }
+          if (method === "app/installed") {
+            await pause("app attestation");
+            return { apps: [{ id: "fixture-app", enabled: true, callable: true }] };
+          }
+          throw new Error(`unexpected method: ${method}`);
+        },
+      });
+      const { client, request } = fixture;
+      const abandonClient = vi.fn(async () => {});
+      const common = {
+        client,
+        params,
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+        userMcpServersEnabled: false,
+        abandonClient,
+        nativeHookRelayGeneration: "original-relay",
+        pluginThreadConfig: {
+          enabled: true,
+          requiresCurrentPolicyCheck: true,
+          inputFingerprint: "warm-app-input",
+          build: async () => {
+            await pause("plugin config");
+            return {
+              enabled: true,
+              fingerprint: "warm-app-config",
+              inputFingerprint: "warm-app-input",
+              diagnostics: [],
+              configPatch: createPluginAppConfigPatch(),
+              policyContext: createPluginAppPolicyContext(),
+              provisionalAppIds: ["fixture-app"],
+            };
+          },
+        },
+      };
+      const started = await startOrResumeThread(common);
+      await retainCodexAppServerLiveThread(
+        client,
+        started.threadId,
+        undefined,
+        started.liveThreadConfigFingerprint,
+        null,
+        started.liveThreadEphemeralPolicy,
+      );
+      fixture.seed(threadStartResult("sibling"), { loaded: true, subscribed: true });
+      const sibling = await claimCodexAppServerLiveThread(client, "sibling");
+      expect(sibling).toBeDefined();
+      const before = await readCodexAppServerBinding(sessionFile);
+      request.mockClear();
+      warming = true;
+      const pending = startOrResumeThread({
+        ...common,
+        nativeHookRelayGeneration: "stale-refresh",
+      });
+      await entered.promise;
+      expect(isCodexAppServerLiveThreadClaimed(client, started.threadId)).toBe(true);
+      expect(request.mock.calls.some(([method]) => method.startsWith("thread/"))).toBe(false);
+      let successor: typeof sibling;
+      if (revocation === "host") {
+        closeHost();
+      } else {
+        fixture.notify({
+          method: revocation as "thread/closed" | "thread/archived",
+          params: { threadId: started.threadId },
+        });
+        successor = await claimCodexAppServerLiveThread(client, started.threadId);
+        expect(successor).toBeDefined();
+      }
+      proceed.resolve();
+      const error = await pending.catch((cause: unknown) => cause);
+      expect(error).toBeInstanceOf(AgentHarnessPreflightError);
+      expect(error).toMatchObject({
+        name: "AgentHarnessPreflightError",
+        scope: undefined,
+        message: expect.stringContaining("reconnect before continuing"),
+      });
+      await expect(readCodexAppServerBinding(sessionFile)).resolves.toEqual(before);
+      expect(() => sibling!.assertCurrent()).not.toThrow();
+      if (successor) {
+        expect(() => successor.assertCurrent()).not.toThrow();
+      }
+      expect(
+        request.mock.calls
+          .filter(([method]) => method.startsWith("thread/"))
+          .map(([method, requestParams]) => [method, requestParams]),
+      ).toEqual(
+        revocation === "host" ? [["thread/unsubscribe", { threadId: started.threadId }]] : [],
+      );
+      expect(abandonClient).not.toHaveBeenCalled();
+      expect(client.getCloseError()).toBeUndefined();
+    },
+  );
+
   it("cold-resumes a warm thread to clear stale enforcing PreToolUse hooks", async () => {
     const sessionFile = path.join(tempDir, "warm-cleared-hooks-session.jsonl");
     const workspaceDir = path.join(tempDir, "warm-cleared-hooks-workspace");
     const params = createParams(sessionFile, workspaceDir);
-    const fake = createFakeCodexAppServerClient(async (method: string) => {
-      if (method === "thread/start" || method === "thread/resume") {
-        return threadStartResult("thread-warm-cleared-hooks");
-      }
-      if (method === "thread/unsubscribe") {
-        return {};
-      }
-      throw new Error(`unexpected method: ${method}`);
+    const fake = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond: async (method: string) => {
+        if (method === "thread/start" || method === "thread/resume") {
+          return threadStartResult("thread-warm-cleared-hooks");
+        }
+        throw new Error(`unexpected method: ${method}`);
+      },
     });
     const client = fake.client;
     ensureCodexAppServerClientRuntime(client, { agentDir: workspaceDir });
@@ -761,8 +1104,10 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
     expect(fake.request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
+      "thread/read",
       "thread/unsubscribe",
       "thread/resume",
+      "thread/inject_items",
     ]);
     const resumeConfig = fake.request.mock.calls.find(
       ([method]) => method === "thread/resume",
@@ -777,26 +1122,20 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const sessionFile = path.join(tempDir, "warm-image-deny-session.jsonl");
     const workspaceDir = path.join(tempDir, "warm-image-deny-workspace");
     const params = createParams(sessionFile, workspaceDir);
-    const request = vi.fn(async (method: string, _params?: unknown) => {
+    const respond = vi.fn(async (method: string, _params?: unknown) => {
       if (method === "configRequirements/read") {
         return { requirements: null };
       }
       if (method === "thread/start" || method === "thread/resume") {
         return threadStartResult("thread-warm-image-deny");
       }
-      if (method === "thread/unsubscribe") {
-        return {};
-      }
       throw new Error(`unexpected method: ${method}`);
     });
-    const client = {
-      getInstanceId: () => "client-warm-image-deny",
-      request,
-      addNotificationHandler: () => () => undefined,
-      addRequestHandler: () => () => undefined,
-      addCloseHandler: () => () => undefined,
-    } as never;
-    ensureCodexAppServerClientRuntime(client, { agentDir: workspaceDir });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
     const common = {
       client,
       params,
@@ -825,8 +1164,10 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
       "configRequirements/read",
+      "thread/read",
       "thread/unsubscribe",
       "thread/resume",
+      "thread/inject_items",
     ]);
     expect(request.mock.calls.find(([method]) => method === "thread/resume")?.[1]).toMatchObject({
       config: { "features.image_generation": false },
@@ -911,20 +1252,18 @@ describe("Codex app-server thread lifecycle bindings", () => {
       cwd: workspaceDir,
       dynamicToolsFingerprint: "[]",
     });
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/resume") {
         return threadStartResult("thread-reused");
       }
       throw new Error(`unexpected method: ${method}`);
     });
-    const client = {
-      getInstanceId: () => "client-after-restart",
-      request,
-      addNotificationHandler: () => () => undefined,
-      addRequestHandler: () => () => undefined,
-      addCloseHandler: () => () => undefined,
-    } as never;
-    ensureCodexAppServerClientRuntime(client, { agentDir: workspaceDir });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+      persistedThreads: ["thread-reused"],
+    });
+    const { client, request } = fixture;
     const common = {
       client,
       params: createParams(sessionFile, workspaceDir),
@@ -936,10 +1275,10 @@ describe("Codex app-server thread lifecycle bindings", () => {
 
     const resumed = await startOrResumeThread(common);
 
-    expect(resumed.clientId).toBe("client-after-restart");
+    expect(resumed.clientId).toBe(client.getInstanceId());
     await expect(readCodexAppServerBinding(sessionFile)).resolves.toMatchObject({
       threadId: "thread-reused",
-      clientId: "client-after-restart",
+      clientId: client.getInstanceId(),
     });
     await retainCodexAppServerLiveThread(
       client,
@@ -949,9 +1288,13 @@ describe("Codex app-server thread lifecycle bindings", () => {
     );
     await expect(startOrResumeThread(common)).resolves.toMatchObject({
       threadId: "thread-reused",
-      clientId: "client-after-restart",
+      clientId: client.getInstanceId(),
     });
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/read",
+      "thread/resume",
+      "thread/inject_items",
+    ]);
   });
 
   it.each([
@@ -987,6 +1330,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
           "thread/read",
           "thread/unsubscribe",
           "thread/resume",
+          "thread/inject_items",
         ]);
       } finally {
         fixture.close();
@@ -1106,10 +1450,14 @@ describe("Codex app-server thread lifecycle bindings", () => {
       const fixture = await createManualResumeFixture({ cold: true, competingLease });
       const before = await readCodexAppServerBinding(fixture.sessionFile);
       try {
-        await expect(fixture.start()).rejects.toMatchObject(
+        const run = fixture.start();
+        await expect(run).rejects.toBeInstanceOf(AgentHarnessPreflightError);
+        await expect(run).rejects.toMatchObject({ scope: undefined });
+        await expect(run).rejects.toMatchObject(
           competingLease === "resume"
             ? {
-                name: "CodexAppServerUnsafeSubscriptionError",
+                name: "CodexThreadPolicyHandoffError",
+                outcome: "not-written",
                 cause: { name: "CodexAdoptedThreadActiveError" },
               }
             : { name: "CodexAdoptedThreadActiveError" },
@@ -1461,23 +1809,17 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const sessionFile = path.join(tempDir, "warm-config-session.jsonl");
     const workspaceDir = path.join(tempDir, "warm-config-workspace");
     const params = createParams(sessionFile, workspaceDir);
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/start" || method === "thread/resume") {
         return threadStartResult("thread-warm-config");
       }
-      if (method === "thread/unsubscribe") {
-        return { status: "unsubscribed" };
-      }
       throw new Error(`unexpected method: ${method}`);
     });
-    const client = {
-      getInstanceId: () => "client-warm-config",
-      request,
-      addNotificationHandler: () => () => undefined,
-      addRequestHandler: () => () => undefined,
-      addCloseHandler: () => () => undefined,
-    } as never;
-    ensureCodexAppServerClientRuntime(client, { agentDir: workspaceDir });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
     const common = {
       client,
       params,
@@ -1504,8 +1846,10 @@ describe("Codex app-server thread lifecycle bindings", () => {
 
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
+      "thread/read",
       "thread/unsubscribe",
       "thread/resume",
+      "thread/inject_items",
     ]);
     expect(resumed).toMatchObject({
       threadId: "thread-warm-config",
@@ -1519,23 +1863,17 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const workspaceDir = path.join(tempDir, "warm-auth-workspace");
     const params = createParams(sessionFile, workspaceDir);
     params.authProfileId = "openai:before";
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/start" || method === "thread/resume") {
         return threadStartResult("thread-warm-auth");
       }
-      if (method === "thread/unsubscribe") {
-        return { status: "unsubscribed" };
-      }
       throw new Error(`unexpected method: ${method}`);
     });
-    const client = {
-      getInstanceId: () => "client-warm-auth",
-      request,
-      addNotificationHandler: () => () => undefined,
-      addRequestHandler: () => () => undefined,
-      addCloseHandler: () => () => undefined,
-    } as never;
-    ensureCodexAppServerClientRuntime(client, { agentDir: workspaceDir });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
     const common = {
       client,
       params,
@@ -1557,8 +1895,10 @@ describe("Codex app-server thread lifecycle bindings", () => {
 
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
+      "thread/read",
       "thread/unsubscribe",
       "thread/resume",
+      "thread/inject_items",
     ]);
     expect(resumed).toMatchObject({
       authProfileId: "openai:after",
@@ -1572,23 +1912,17 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const sessionFile = path.join(tempDir, "warm-provider-session.jsonl");
     const workspaceDir = path.join(tempDir, "warm-provider-workspace");
     const params = createParams(sessionFile, workspaceDir);
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/start" || method === "thread/resume") {
         return threadStartResult("thread-warm-provider");
       }
-      if (method === "thread/unsubscribe") {
-        return { status: "unsubscribed" };
-      }
       throw new Error(`unexpected method: ${method}`);
     });
-    const client = {
-      getInstanceId: () => "client-warm-provider",
-      request,
-      addNotificationHandler: () => () => undefined,
-      addRequestHandler: () => () => undefined,
-      addCloseHandler: () => () => undefined,
-    } as never;
-    ensureCodexAppServerClientRuntime(client, { agentDir: workspaceDir });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
     const common = {
       client,
       params,
@@ -1610,8 +1944,10 @@ describe("Codex app-server thread lifecycle bindings", () => {
 
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
+      "thread/read",
       "thread/unsubscribe",
       "thread/resume",
+      "thread/inject_items",
     ]);
     expect(request).toHaveBeenCalledWith(
       "thread/resume",
@@ -1721,46 +2057,79 @@ describe("Codex app-server thread lifecycle bindings", () => {
     ]);
   });
 
-  it("reuses one live ephemeral thread across two incognito turns", async () => {
-    const sessionFile = path.join(tempDir, "incognito-session.jsonl");
-    const workspaceDir = path.join(tempDir, "incognito-workspace");
-    const params = createParams(sessionFile, workspaceDir);
-    params.sessionKey = "agent:main:dashboard:incognito-two-turns";
-    const request = vi.fn(async (method: string, _params?: unknown) => {
-      if (method === "thread/start") {
-        return threadStartResult("thread-incognito");
+  it.each([false, true])(
+    "reuses one live ephemeral thread across two incognito turns (restricted: %s)",
+    async (restricted) => {
+      const sessionFile = path.join(tempDir, "incognito-session.jsonl");
+      const workspaceDir = path.join(tempDir, "incognito-workspace");
+      const params = createParams(sessionFile, workspaceDir);
+      params.sessionKey = "agent:main:dashboard:incognito-two-turns";
+      if (restricted) {
+        params.toolsAllow = ["openclaw"];
       }
-      throw new Error(`unexpected method: ${method}`);
-    });
-    const client = {
-      getInstanceId: () => "client-incognito",
-      request,
-    } as never;
-    const common = {
-      client,
-      params,
-      cwd: workspaceDir,
-      dynamicTools: [],
-      appServer: createThreadLifecycleAppServerOptions(),
-      userMcpServersEnabled: false,
-    };
+      const request = vi.fn(async (method: string, _params?: unknown) => {
+        if (method === "config/read") {
+          return { layers: [], config: { mcp_servers: {} } };
+        }
+        if (method === "configRequirements/read") {
+          return { requirements: null };
+        }
+        if (method === "mcpServerStatus/list") {
+          return { data: [], nextCursor: null };
+        }
+        if (method === "thread/start") {
+          return threadStartResult("thread-incognito");
+        }
+        throw new Error(`unexpected method: ${method}`);
+      });
+      const client = {
+        getInstanceId: () => "client-incognito",
+        request,
+        addNotificationHandler: () => () => undefined,
+        addRequestHandler: () => () => undefined,
+        addCloseHandler: () => () => undefined,
+      } as never;
+      ensureCodexAppServerClientRuntime(client, { agentDir: workspaceDir });
+      const common = {
+        client,
+        params,
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+        userMcpServersEnabled: false,
+        ...(restricted ? { nativeCodeModeEnabled: false, hostSystemAgentActive: true } : {}),
+      };
 
-    const first = await startOrResumeThread(common);
-    const second = await startOrResumeThread(common);
+      const first = await startOrResumeThread(common);
+      if (restricted) {
+        expect(first).not.toHaveProperty("liveThreadEphemeralPolicy");
+      } else {
+        await retainCodexAppServerLiveThread(
+          client,
+          first.threadId,
+          undefined,
+          first.liveThreadConfigFingerprint,
+          null,
+          first.liveThreadEphemeralPolicy,
+        );
+      }
+      const second = await startOrResumeThread(common);
 
-    expect(first).toMatchObject({
-      clientId: "client-incognito",
-      threadId: "thread-incognito",
-      lifecycle: { action: "started" },
-    });
-    expect(second).toMatchObject({
-      clientId: "client-incognito",
-      threadId: "thread-incognito",
-      lifecycle: { action: "resumed" },
-    });
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start"]);
-    expect(request.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ ephemeral: true }));
-  });
+      expect(first).toMatchObject({
+        clientId: "client-incognito",
+        threadId: "thread-incognito",
+        lifecycle: { action: "started" },
+      });
+      expect(second).toMatchObject({
+        clientId: "client-incognito",
+        threadId: "thread-incognito",
+        lifecycle: { action: "resumed" },
+      });
+      const threadCalls = request.mock.calls.filter(([method]) => method.startsWith("thread/"));
+      expect(threadCalls.map(([method]) => method)).toEqual(["thread/start"]);
+      expect(threadCalls[0]?.[1]).toEqual(expect.objectContaining({ ephemeral: true }));
+    },
+  );
 
   it("resumes the same restricted OpenClaw thread so turn two retains native memory", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
@@ -1775,7 +2144,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const params = createParams(sessionFile, workspaceDir);
     params.toolsAllow = ["openclaw"];
     let nextThread = 1;
-    const request = vi.fn(async (method: string, _requestParams?: unknown) => {
+    const respond = vi.fn(async (method: string, _requestParams?: unknown) => {
       if (method === "config/read") {
         return {
           layers: [
@@ -1814,8 +2183,13 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
     const common = {
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [createNamedDynamicTool("openclaw")],
@@ -1826,6 +2200,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     };
 
     const first = await startOrResumeThread(common);
+    await fixture.endTurn("thread-ring-zero-1");
     const second = await startOrResumeThread(common);
 
     expect(first.lifecycle.action).toBe("started");
@@ -1835,10 +2210,13 @@ describe("Codex app-server thread lifecycle bindings", () => {
       "configRequirements/read",
       "thread/start",
       "mcpServerStatus/list",
+      "thread/unsubscribe",
       "config/read",
       "configRequirements/read",
+      "thread/read",
       "thread/resume",
       "mcpServerStatus/list",
+      "thread/inject_items",
     ]);
     const startCalls = request.mock.calls.filter(([method]) => method === "thread/start");
     expect(startCalls.map(([, startParams]) => startParams)).toEqual([
@@ -2157,7 +2535,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const params = createParams(sessionFile, workspaceDir);
     params.toolsAllow = ["openclaw"];
     let attestationCount = 0;
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "config/read") {
         return { config: {}, layers: [] };
       }
@@ -2175,7 +2553,11 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
-    const client = { request } as never;
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
     const abandonClient = vi.fn(async () => {});
     const common = {
       client,
@@ -2190,6 +2572,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     };
 
     await startOrResumeThread(common);
+    await fixture.endTurn("thread-ring-zero");
     await expect(startOrResumeThread(common)).rejects.toThrow(
       "Codex restricted-tool-surface MCP attestation failed",
     );
@@ -2200,8 +2583,10 @@ describe("Codex app-server thread lifecycle bindings", () => {
       "configRequirements/read",
       "thread/start",
       "mcpServerStatus/list",
+      "thread/unsubscribe",
       "config/read",
       "configRequirements/read",
+      "thread/read",
       "thread/resume",
       "mcpServerStatus/list",
     ]);
@@ -2634,7 +3019,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
     const params = createParams(sessionFile, workspaceDir);
     params.modelId = requestedModel;
-    const request = vi.fn(async (method: string, requestParams?: unknown) => {
+    const respond = vi.fn(async (method: string, requestParams?: unknown) => {
       if (method === "thread/resume") {
         const response = threadStartResult("thread-existing");
         response.model = (requestParams as { model: string }).model;
@@ -2642,17 +3027,27 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+      persistedThreads: ["thread-existing"],
+    });
+    const { client, request } = fixture;
 
     const binding = await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
       appServer: createThreadLifecycleAppServerOptions(),
     });
 
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
-    expect(request.mock.calls[0]?.[1]).toMatchObject({
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/read",
+      "thread/resume",
+      "thread/inject_items",
+    ]);
+    expect(request.mock.calls.find(([method]) => method === "thread/resume")?.[1]).toMatchObject({
       threadId: "thread-existing",
       model: requestedModel,
     });
@@ -2724,14 +3119,9 @@ describe("Codex app-server thread lifecycle bindings", () => {
     params.provider = "codex";
     params.modelId = "local-model-2";
     const appServer = createThreadLifecycleAppServerOptions();
-    const request = vi.fn(async (method: string, _requestParams?: unknown) => {
+    const respond = vi.fn(async (method: string, _requestParams?: unknown) => {
       if (method === "thread/resume") {
         throw new CodexAppServerRpcError({ code: -32_000, message: "stale thread" }, method);
-      }
-      if (method === "thread/unsubscribe") {
-        // Pre-acceptance rejection has no membership, but the exact cleanup RPC
-        // makes that fact observable before stale-binding recovery continues.
-        return { status: "notSubscribed" };
       }
       if (method === "thread/start") {
         const response = threadStartResult("thread-new");
@@ -2742,9 +3132,15 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+      persistedThreads: ["thread-existing"],
+    });
+    const { client, request } = fixture;
 
     const binding = await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -2755,6 +3151,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       | Record<string, unknown>
       | undefined;
     expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/read",
       "thread/resume",
       "thread/unsubscribe",
       "thread/start",
@@ -2775,22 +3172,28 @@ describe("Codex app-server thread lifecycle bindings", () => {
       modelProvider: "openai",
       dynamicToolsFingerprint: "[]",
     });
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/resume") {
         throw new CodexAppServerRpcError({ code: -32_603, message: "resume failed" }, method);
-      }
-      if (method === "thread/unsubscribe") {
-        throw new Error("unsubscribe rejected");
       }
       if (method === "thread/start") {
         throw new Error("unsafe resume must not start a replacement thread");
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+      persistedThreads: ["thread-existing"],
+      unsubscribe: async () => {
+        throw new Error("unsubscribe rejected");
+      },
+    });
+    const { client, request } = fixture;
 
     await expect(
       startOrResumeThread({
-        client: { request } as never,
+        client,
         params: createParams(sessionFile, workspaceDir),
         cwd: workspaceDir,
         dynamicTools: [],
@@ -2799,6 +3202,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     ).rejects.toMatchObject({ name: "CodexAppServerUnsafeSubscriptionError" });
 
     expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/read",
       "thread/resume",
       "thread/unsubscribe",
     ]);
@@ -2847,7 +3251,8 @@ describe("Codex app-server thread lifecycle bindings", () => {
       });
       const originalBinding = await readCodexAppServerBinding(sessionFile);
       await expect(wire.start(sessionFile, workspaceDir)).rejects.toMatchObject({
-        name: "CodexAppServerUnsafeSubscriptionError",
+        name: "CodexThreadPolicyHandoffError",
+        outcome: "not-written",
       });
 
       await expect(readCodexAppServerBinding(sessionFile)).resolves.toEqual(originalBinding);
@@ -2885,6 +3290,14 @@ describe("Codex app-server thread lifecycle bindings", () => {
       "thread/resume",
     );
     const wire = await createLeasedLifecycleWireClient(agentDir, (request) => {
+      if (request.method === "thread/read") {
+        return {
+          thread: {
+            ...threadStartResult("thread-overloaded").thread,
+            status: { type: "notLoaded" },
+          },
+        };
+      }
       if (request.method === "thread/resume") {
         throw overload;
       }
@@ -2909,7 +3322,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       await expect(readCodexAppServerBinding(sessionFile)).resolves.toEqual(originalBinding);
       expect(
         new Set(wire.writes.map((message) => (JSON.parse(message) as RpcRequest).method)),
-      ).toEqual(new Set(["thread/resume"]));
+      ).toEqual(new Set(["thread/read", "thread/resume"]));
       const retained = retainSharedCodexAppServerClientIfCurrent(wire.client);
       expect(retained).toBeTypeOf("function");
       retained?.();
@@ -2980,7 +3393,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     params.provider = "codex";
     params.modelId = "openai/gpt-oss-20b";
     const appServer = createThreadLifecycleAppServerOptions();
-    const request = vi.fn(async (method: string, _requestParams?: unknown) => {
+    const respond = vi.fn(async (method: string, _requestParams?: unknown) => {
       if (method === "thread/resume") {
         const response = threadStartResult("thread-existing");
         response.model = "openai/gpt-oss-20b";
@@ -2990,17 +3403,29 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+      persistedThreads: ["thread-existing"],
+    });
+    const { client, request } = fixture;
 
     const binding = await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
       appServer,
     });
 
-    const resumeParams = request.mock.calls[0]?.[1] as Record<string, unknown> | undefined;
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
+    const resumeParams = request.mock.calls.find(([method]) => method === "thread/resume")?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/read",
+      "thread/resume",
+      "thread/inject_items",
+    ]);
     expect(resumeParams?.model).toBe("openai/gpt-oss-20b");
     expect(resumeParams?.modelProvider).toBe("lmstudio");
     expect(binding.threadId).toBe("thread-existing");
@@ -3066,7 +3491,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     params.disableTools = false;
     const appServer = createThreadLifecycleAppServerOptions();
     let starts = 0;
-    const request = vi.fn(async (method: string, _params?: unknown) => {
+    const respond = vi.fn(async (method: string, _params?: unknown) => {
       if (method === "thread/start") {
         starts += 1;
         return threadStartResult(`thread-${starts}`);
@@ -3076,9 +3501,14 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
 
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [createDeferredNamedDynamicTool("web_search")],
@@ -3086,8 +3516,9 @@ describe("Codex app-server thread lifecycle bindings", () => {
       appServer,
     });
     params.toolsAllow = ["message"];
+    await fixture.endTurn("thread-1");
     const restrictedBinding = await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [createDeferredNamedDynamicTool("web_search")],
@@ -3096,8 +3527,9 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
     const savedAfterRestriction = await readCodexAppServerBinding(sessionFile);
     params.toolsAllow = undefined;
+    await fixture.endTurn("thread-2");
     const resumedBinding = await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [createDeferredNamedDynamicTool("web_search")],
@@ -3111,13 +3543,21 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(resumedBinding.threadId).toBe("thread-1");
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
+      "thread/unsubscribe",
       "thread/start",
+      "thread/unsubscribe",
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
     ]);
     expect(request.mock.calls[0]?.[1]).toMatchObject({
       config: { web_search: "cached" },
     });
-    expect(request.mock.calls[1]?.[1]).toMatchObject({
+    expect(
+      request.mock.calls.filter(
+        ([method]) => method === "thread/start" || method === "thread/resume",
+      )[1]?.[1],
+    ).toMatchObject({
       config: { web_search: "disabled" },
     });
   });
@@ -3200,7 +3640,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const params = createParams(sessionFile, workspaceDir);
     const appServer = createThreadLifecycleAppServerOptions();
     let starts = 0;
-    const request = vi.fn(async (method: string, requestParams?: unknown) => {
+    const respond = vi.fn(async (method: string, requestParams?: unknown) => {
       if (method === "thread/start") {
         starts += 1;
         return threadStartResult(`thread-${starts}`);
@@ -3210,9 +3650,14 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
 
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -3220,8 +3665,9 @@ describe("Codex app-server thread lifecycle bindings", () => {
       webSearchAllowed: true,
       appServer,
     });
+    await fixture.endTurn("thread-1");
     const transientBinding = await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -3230,8 +3676,9 @@ describe("Codex app-server thread lifecycle bindings", () => {
       appServer,
     });
     const savedAfterUnknownSupport = await readCodexAppServerBinding(sessionFile);
+    await fixture.endTurn("thread-2");
     const resumedBinding = await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -3246,13 +3693,21 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(resumedBinding.threadId).toBe("thread-1");
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
+      "thread/unsubscribe",
       "thread/start",
+      "thread/unsubscribe",
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
     ]);
     expect(request.mock.calls[0]?.[1]).toMatchObject({
       config: { web_search: "cached" },
     });
-    expect(request.mock.calls[1]?.[1]).toMatchObject({
+    expect(
+      request.mock.calls.filter(
+        ([method]) => method === "thread/start" || method === "thread/resume",
+      )[1]?.[1],
+    ).toMatchObject({
       config: { web_search: "disabled" },
     });
   });
@@ -3290,7 +3745,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const params = createParams(sessionFile, workspaceDir);
     const appServer = createThreadLifecycleAppServerOptions();
     let starts = 0;
-    const request = vi.fn(async (method: string, requestParams?: unknown) => {
+    const respond = vi.fn(async (method: string, requestParams?: unknown) => {
       if (method === "thread/start") {
         starts += 1;
         return threadStartResult(`thread-${starts}`);
@@ -3300,9 +3755,14 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
 
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [createDeferredNamedDynamicTool("web_search")],
@@ -3311,8 +3771,9 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
     params.config = { tools: { deny: ["web_search"] } };
     params.toolsAllow = [];
+    await fixture.endTurn("thread-1");
     const restrictedBinding = await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -3320,8 +3781,9 @@ describe("Codex app-server thread lifecycle bindings", () => {
       webSearchAllowed: false,
       appServer,
     });
+    await fixture.endTurn("thread-2");
     const resumedRestrictedBinding = await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -3335,8 +3797,12 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect((await readCodexAppServerBinding(sessionFile))?.threadId).toBe("thread-2");
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
+      "thread/unsubscribe",
       "thread/start",
+      "thread/unsubscribe",
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
     ]);
   });
 
@@ -3346,7 +3812,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const params = createParams(sessionFile, workspaceDir);
     const appServer = createThreadLifecycleAppServerOptions();
     let starts = 0;
-    const request = vi.fn(async (method: string, requestParams?: unknown) => {
+    const respond = vi.fn(async (method: string, requestParams?: unknown) => {
       if (method === "thread/start") {
         starts += 1;
         return threadStartResult(`thread-${starts}`);
@@ -3356,9 +3822,14 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
 
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [createDeferredNamedDynamicTool("web_search")],
@@ -3368,8 +3839,9 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
     params.config = { tools: { deny: ["web_search"] } };
     params.toolsAllow = ["message"];
+    await fixture.endTurn("thread-1");
     const restrictedBinding = await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -3378,8 +3850,9 @@ describe("Codex app-server thread lifecycle bindings", () => {
       webSearchAllowed: false,
       appServer,
     });
+    await fixture.endTurn("thread-2");
     const resumedRestrictedBinding = await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -3394,8 +3867,12 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect((await readCodexAppServerBinding(sessionFile))?.threadId).toBe("thread-2");
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
+      "thread/unsubscribe",
       "thread/start",
+      "thread/unsubscribe",
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
     ]);
   });
 
@@ -3568,7 +4045,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     params.disableTools = false;
     const appServer = createThreadLifecycleAppServerOptions();
     let starts = 0;
-    const request = vi.fn(async (method: string, requestParams?: unknown) => {
+    const respond = vi.fn(async (method: string, requestParams?: unknown) => {
       if (method === "thread/start") {
         starts += 1;
         return threadStartResult(`thread-${starts}`);
@@ -3580,17 +4057,23 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
 
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
       appServer,
     });
     params.disableTools = true;
+    await fixture.endTurn("thread-1");
     const restrictedBinding = await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -3598,8 +4081,9 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
     const savedAfterRestriction = await readCodexAppServerBinding(sessionFile);
     params.disableTools = false;
+    await fixture.endTurn("thread-2");
     const resumedBinding = await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -3611,10 +4095,18 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(resumedBinding.threadId).toBe("thread-1");
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
+      "thread/unsubscribe",
       "thread/start",
+      "thread/unsubscribe",
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
     ]);
-    expect(request.mock.calls[1]?.[1]).toMatchObject({
+    expect(
+      request.mock.calls.filter(
+        ([method]) => method === "thread/start" || method === "thread/resume",
+      )[1]?.[1],
+    ).toMatchObject({
       config: { web_search: "disabled" },
     });
   });
@@ -3660,7 +4152,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(sessionFile, workspaceDir);
     const appServer = createThreadLifecycleAppServerOptions();
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/start") {
         return threadStartResult("thread-existing");
       }
@@ -3669,16 +4161,22 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
 
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [createNamedDynamicTool("wiki_status"), createNamedDynamicTool("diffs")],
       appServer,
     });
+    await fixture.endTurn("thread-existing");
     const binding = await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [createNamedDynamicTool("diffs"), createNamedDynamicTool("wiki_status")],
@@ -3686,7 +4184,13 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
 
     expect(binding.threadId).toBe("thread-existing");
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start", "thread/resume"]);
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/start",
+      "thread/unsubscribe",
+      "thread/read",
+      "thread/resume",
+      "thread/inject_items",
+    ]);
   });
 
   it("starts a fresh Codex thread for legacy context-engine sidecars without metadata", async () => {
@@ -3758,15 +4262,21 @@ describe("Codex app-server thread lifecycle bindings", () => {
     } as never;
     params.contextTokenBudget = 400_000;
     const appServer = createThreadLifecycleAppServerOptions();
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/resume") {
         return threadStartResult("thread-existing");
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+      persistedThreads: ["thread-existing"],
+    });
+    const { client, request } = fixture;
 
     const binding = await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -3775,7 +4285,11 @@ describe("Codex app-server thread lifecycle bindings", () => {
 
     expect(binding.threadId).toBe("thread-existing");
     expect(binding.lifecycle).toEqual({ action: "resumed" });
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/read",
+      "thread/resume",
+      "thread/inject_items",
+    ]);
   });
 
   it("starts a fresh Codex thread when context-engine sidecar metadata is no longer active", async () => {
@@ -3887,7 +4401,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const params = createParams(sessionFile, workspaceDir);
     const appServer = createThreadLifecycleAppServerOptions();
     let nextThread = 1;
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/start") {
         return threadStartResult(`thread-${nextThread++}`);
       }
@@ -3896,24 +4410,31 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
 
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [createDeferredNamedDynamicTool("message")],
       appServer,
     });
     const fingerprint = (await readCodexAppServerBinding(sessionFile))?.dynamicToolsFingerprint;
+    await fixture.endTurn("thread-1");
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
       appServer,
     });
+    await fixture.endTurn("thread-2");
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [createDeferredNamedDynamicTool("message")],
@@ -3926,8 +4447,12 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(binding?.threadId).toBe("thread-1");
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
+      "thread/unsubscribe",
       "thread/start",
+      "thread/unsubscribe",
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
     ]);
   });
 
@@ -3994,24 +4519,21 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
     const params = createParams(sessionFile, workspaceDir);
     const appServer = createThreadLifecycleAppServerOptions();
-    const request = vi.fn(
-      async (
-        method: string,
-        _requestParams?: {
-          config?: unknown;
-          dynamicTools?: unknown[];
-          environments?: unknown[];
-        },
-      ) => {
-        if (method === "thread/start") {
-          return threadStartResult("thread-transient");
-        }
-        if (method === "thread/resume") {
-          return threadStartResult("thread-existing");
-        }
-        throw new Error(`unexpected method: ${method}`);
-      },
-    );
+    const respond = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-transient");
+      }
+      if (method === "thread/resume") {
+        return threadStartResult("thread-existing");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+      persistedThreads: ["thread-existing"],
+    });
+    const { client, request } = fixture;
     const buildDenyAllPluginThreadConfig = vi.fn(async () => ({
       enabled: true,
       configPatch: {
@@ -4038,7 +4560,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     }));
 
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [createNamedDynamicTool("read"), createNamedDynamicTool("apply_patch")],
@@ -4057,8 +4579,9 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(savedAfterDeny?.pluginAppsFingerprint).toBe("plugin-apps-config-1");
     expect(savedAfterDeny?.pluginAppsInputFingerprint).toBe("plugin-apps-input-1");
 
+    await fixture.endTurn("thread-transient");
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -4074,7 +4597,13 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(buildDenyAllPluginThreadConfig).toHaveBeenCalledTimes(1);
     expect(buildEnabledPluginThreadConfig).toHaveBeenCalledTimes(1);
     const requestCalls = request.mock.calls;
-    expect(requestCalls.map(([method]) => method)).toEqual(["thread/start", "thread/resume"]);
+    expect(requestCalls.map(([method]) => method)).toEqual([
+      "thread/start",
+      "thread/unsubscribe",
+      "thread/read",
+      "thread/resume",
+      "thread/inject_items",
+    ]);
     expect(requestCalls[0]?.[1]).toMatchObject({
       dynamicTools: [
         expect.objectContaining({ name: "read" }),
@@ -4082,7 +4611,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       ],
       environments: [],
     });
-    expect(requestCalls[0]?.[1]?.config).toMatchObject({
+    expect((requestCalls[0]?.[1] as { config?: unknown })?.config).toMatchObject({
       apps: {
         _default: {
           enabled: false,
@@ -4109,16 +4638,23 @@ describe("Codex app-server thread lifecycle bindings", () => {
       dynamicToolsFingerprint: "[]",
     });
     const appServer = createThreadLifecycleAppServerOptions();
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/resume") {
-        throw new Error("codex app-server client is closed");
+        fixture.client.close();
+        return await new Promise(() => {});
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+      persistedThreads: ["thread-existing"],
+    });
+    const { client, request } = fixture;
 
     await expect(
       startOrResumeThread({
-        client: { request } as never,
+        client,
         params: createParams(sessionFile, workspaceDir),
         cwd: workspaceDir,
         dynamicTools: [],
@@ -4126,7 +4662,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }),
     ).rejects.toThrow("codex app-server client is closed");
 
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/read", "thread/resume"]);
     const binding = await readCodexAppServerBinding(sessionFile);
     expect(binding?.threadId).toBe("thread-existing");
   });
@@ -4172,7 +4708,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(sessionFile, workspaceDir);
     const appServer = createThreadLifecycleAppServerOptions();
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/start") {
         return threadStartResult("thread-existing");
       }
@@ -4181,6 +4717,11 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
     const config = {
       "features.hooks": true,
       "hooks.PreToolUse": [],
@@ -4191,15 +4732,16 @@ describe("Codex app-server thread lifecycle bindings", () => {
     };
 
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
       appServer,
       config,
     });
+    await fixture.endTurn("thread-existing");
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -4208,9 +4750,17 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
 
     const requestCalls = request.mock.calls as unknown as Array<[string, { config?: unknown }]>;
-    expect(requestCalls.map(([method]) => method)).toEqual(["thread/start", "thread/resume"]);
+    expect(requestCalls.map(([method]) => method)).toEqual([
+      "thread/start",
+      "thread/unsubscribe",
+      "thread/read",
+      "thread/resume",
+      "thread/inject_items",
+    ]);
     expect(requestCalls[0]?.[1].config).toEqual(expectedConfig);
-    expect(requestCalls[1]?.[1].config).toEqual(expectedConfig);
+    expect(requestCalls.find(([method]) => method === "thread/resume")?.[1].config).toEqual(
+      expectedConfig,
+    );
   });
 
   it("merges native hook relay config with plugin app config when starting a thread", async () => {
@@ -4270,12 +4820,17 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(sessionFile, workspaceDir);
     const appServer = createThreadLifecycleAppServerOptions();
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/start" || method === "thread/resume") {
         return threadStartResult("thread-hooks");
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
     const pluginAppPolicyContext = createPluginAppPolicyContext();
     const finalConfigPatch = {
       "features.hooks": true,
@@ -4304,7 +4859,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     };
 
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -4313,8 +4868,9 @@ describe("Codex app-server thread lifecycle bindings", () => {
       finalConfigPatch,
       pluginThreadConfig,
     });
+    await fixture.endTurn("thread-hooks");
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -4328,14 +4884,20 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
 
     const requestCalls = request.mock.calls as unknown as Array<[string, { config?: unknown }]>;
-    expect(requestCalls.map(([method]) => method)).toEqual(["thread/start", "thread/resume"]);
+    expect(requestCalls.map(([method]) => method)).toEqual([
+      "thread/start",
+      "thread/unsubscribe",
+      "thread/read",
+      "thread/resume",
+      "thread/inject_items",
+    ]);
     expect(requestCalls[0]?.[1].config).toMatchObject({
       "features.hooks": true,
       ...DEFAULT_CODEX_RUNTIME_THREAD_CONFIG,
       "hooks.PreToolUse": finalConfigPatch["hooks.PreToolUse"],
       ...createPluginAppConfigPatch(),
     });
-    expect(requestCalls[1]?.[1].config).toMatchObject({
+    expect(requestCalls.find(([method]) => method === "thread/resume")?.[1].config).toMatchObject({
       "features.hooks": true,
       ...DEFAULT_CODEX_RUNTIME_THREAD_CONFIG,
       "hooks.PreToolUse": finalConfigPatch["hooks.PreToolUse"],
@@ -4350,7 +4912,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       ...createThreadLifecycleAppServerOptions(),
       approvalsReviewer: "auto_review" as const,
     };
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "config/read") {
         return { config: {}, origins: {} };
       }
@@ -4359,7 +4921,11 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
-    const client = { request } as never;
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
     const basePolicyContext = createPluginAppPolicyContext();
     const pluginAppPolicyContext = {
       ...basePolicyContext,
@@ -4394,6 +4960,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
         build: buildPluginThreadConfig,
       },
     });
+    await fixture.endTurn("thread-plugins");
     const binding = await startOrResumeThread({
       client,
       params,
@@ -4417,10 +4984,15 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(requestCalls.map(([method]) => method)).toEqual([
       "config/read",
       "thread/start",
+      "thread/unsubscribe",
       "config/read",
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
     ]);
-    const threadRequests = requestCalls.filter(([method]) => method !== "config/read");
+    const threadRequests = requestCalls.filter(
+      ([method]) => method === "thread/start" || method === "thread/resume",
+    );
     expect(threadRequests.map(([, requestParams]) => requestParams.approvalsReviewer)).toEqual([
       "auto_review",
       "auto_review",
@@ -4505,18 +5077,21 @@ describe("Codex app-server thread lifecycle bindings", () => {
       pluginAppPolicyContext: scenario.previousPolicyContext,
     });
     const params = createParams(sessionFile, workspaceDir);
-    const request = vi.fn(async (method: string, _requestParams?: unknown) => {
+    const respond = vi.fn(async (method: string, _requestParams?: unknown) => {
       if (method === "thread/start") {
         return threadStartResult("thread-recovered");
       }
       if (method === "thread/resume") {
         return threadStartResult("thread-existing");
       }
-      if (method === "thread/unsubscribe") {
-        return { status: "unsubscribed" };
-      }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+      persistedThreads: ["thread-existing"],
+    });
+    const { client, request } = fixture;
     const buildPluginThreadConfig = vi.fn(async () => ({
       enabled: true,
       configPatch: scenario.configPatch,
@@ -4527,7 +5102,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     }));
 
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -4542,6 +5117,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
 
     expect(buildPluginThreadConfig).toHaveBeenCalledTimes(1);
     expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/read",
       "thread/resume",
       "thread/unsubscribe",
       "thread/start",
@@ -4574,15 +5150,21 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
     const params = createParams(sessionFile, workspaceDir);
     const appServer = createThreadLifecycleAppServerOptions();
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/resume") {
         return threadStartResult("thread-existing");
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+      persistedThreads: ["thread-existing"],
+    });
+    const { client, request } = fixture;
 
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -4598,8 +5180,12 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
 
     const requestCalls = request.mock.calls as unknown as Array<[string, { config?: unknown }]>;
-    expect(requestCalls.map(([method]) => method)).toEqual(["thread/resume"]);
-    expect(requestCalls[0]?.[1].config).toEqual({
+    expect(requestCalls.map(([method]) => method)).toEqual([
+      "thread/read",
+      "thread/resume",
+      "thread/inject_items",
+    ]);
+    expect(requestCalls.find(([method]) => method === "thread/resume")?.[1].config).toEqual({
       ...DEFAULT_CODEX_RUNTIME_THREAD_CONFIG,
       ...createPluginAppConfigPatch(),
     });
@@ -4626,12 +5212,18 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
     const params = createParams(sessionFile, workspaceDir);
     const appServer = createThreadLifecycleAppServerOptions();
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/resume") {
         return threadStartResult("thread-existing");
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+      persistedThreads: ["thread-existing"],
+    });
+    const { client, request } = fixture;
     const buildPluginThreadConfig = vi.fn(async () => ({
       enabled: true,
       configPatch: {
@@ -4650,7 +5242,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     }));
 
     await startOrResumeThread({
-      client: { request } as never,
+      client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -4664,8 +5256,12 @@ describe("Codex app-server thread lifecycle bindings", () => {
 
     expect(buildPluginThreadConfig).toHaveBeenCalledTimes(1);
     const requestCalls = request.mock.calls as unknown as Array<[string, { config?: unknown }]>;
-    expect(requestCalls.map(([method]) => method)).toEqual(["thread/resume"]);
-    expect(requestCalls[0]?.[1].config).toEqual({
+    expect(requestCalls.map(([method]) => method)).toEqual([
+      "thread/read",
+      "thread/resume",
+      "thread/inject_items",
+    ]);
+    expect(requestCalls.find(([method]) => method === "thread/resume")?.[1].config).toEqual({
       ...DEFAULT_CODEX_RUNTIME_THREAD_CONFIG,
       apps: {
         _default: {
@@ -4787,15 +5383,18 @@ describe("Codex app-server thread lifecycle bindings", () => {
       },
     };
 
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: params.agentDir,
+      persistedThreads: ["thread-existing"],
+      respond: async (method) => {
+        if (method === "thread/resume") {
+          return threadStartResult("thread-existing");
+        }
+        throw new Error(`unexpected method: ${method}`);
+      },
+    });
     const binding = await startOrResumeThread({
-      client: {
-        request: async (method: string) => {
-          if (method === "thread/resume") {
-            return threadStartResult("thread-existing");
-          }
-          throw new Error(`unexpected method: ${method}`);
-        },
-      } as never,
+      client: fixture.client,
       params,
       cwd: workspaceDir,
       dynamicTools: [],

--- a/extensions/codex/src/app-server/thread-lifecycle.test-fixtures.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test-fixtures.ts
@@ -1,9 +1,309 @@
 import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { AuthStorage, ModelRegistry } from "openclaw/plugin-sdk/agent-sessions";
+import { expect, onTestFinished, vi } from "vitest";
+import { CodexAppServerClient, CodexAppServerRpcError } from "./client.js";
+import { threadStartResult as nativeThreadStartResult } from "./codex-app-server.test-fixtures.js";
 import type { CodexAppServerRuntimeOptions } from "./config.js";
+import { isJsonObject, type RpcRequest, type CodexServerNotification } from "./protocol.js";
 import { testCodexAppServerBindingStore } from "./session-binding.test-helpers.js";
-import { createCodexTestModel } from "./test-support.js";
+import {
+  getLeasedSharedCodexAppServerClient,
+  releaseLeasedSharedCodexAppServerClient,
+  type CodexAppServerClientOptions,
+} from "./shared-client.js";
+import { createClientHarness, createCodexTestModel } from "./test-support.js";
 import { startOrResumeThread as startOrResumeThreadImpl } from "./thread-lifecycle.js";
+
+type NativeFixtureThread = {
+  response: Record<string, unknown>;
+  thread: Record<string, unknown>;
+  loaded: boolean;
+  subscribed: boolean;
+  items: unknown[];
+};
+
+/** A synthetic native server, not a client mock: requests still cross the real wire and guards. */
+export function createCodexLifecycleHarness(options: {
+  respond: (method: string, params?: unknown) => unknown;
+  persistedThreads?: string[];
+  unsubscribe?: (threadId: string) => unknown;
+}) {
+  const threads = new Map<string, NativeFixtureThread>();
+  const remember = (response: unknown, loaded: boolean, subscribed: boolean) => {
+    if (
+      !isJsonObject(response) ||
+      !isJsonObject(response.thread) ||
+      typeof response.thread.id !== "string"
+    ) {
+      throw new Error("Native lifecycle fixture requires an explicit thread response");
+    }
+    const entry: NativeFixtureThread = {
+      response,
+      thread: response.thread,
+      loaded,
+      subscribed,
+      items: [],
+    };
+    threads.set(response.thread.id, entry);
+    return entry;
+  };
+  for (const threadId of options.persistedThreads ?? []) {
+    remember(nativeThreadStartResult(threadId), false, false);
+  }
+  const dispatch = async (request: RpcRequest) => {
+    const params = isJsonObject(request.params) ? request.params : {};
+    const threadId = typeof params.threadId === "string" ? params.threadId : "";
+    const current = threads.get(threadId);
+    if (request.method === "initialize") {
+      return { userAgent: "codex-cli/0.151.0" };
+    }
+    if (request.method === "thread/start") {
+      const response = await options.respond(request.method, request.params);
+      remember(response, true, true);
+      return response;
+    }
+    if (request.method === "thread/read") {
+      if (!current) {
+        throw new Error(`Unknown synthetic native thread: ${threadId}`);
+      }
+      return {
+        thread: {
+          ...current.thread,
+          status: current.loaded ? current.thread.status : { type: "notLoaded" },
+        },
+      };
+    }
+    if (request.method === "thread/unsubscribe") {
+      const response = options.unsubscribe
+        ? await options.unsubscribe(threadId)
+        : {
+            status: !current?.loaded
+              ? "notLoaded"
+              : current.subscribed
+                ? "unsubscribed"
+                : "notSubscribed",
+          };
+      if (current && isJsonObject(response) && response.status === "notLoaded") {
+        current.loaded = false;
+        current.subscribed = false;
+      } else if (
+        current &&
+        isJsonObject(response) &&
+        (response.status === "unsubscribed" || response.status === "notSubscribed")
+      ) {
+        current.subscribed = false;
+      }
+      return response;
+    }
+    if (request.method === "thread/resume") {
+      if (!current) {
+        throw new Error(`Unseeded synthetic native resume: ${threadId}`);
+      }
+      // Stock 0.151.0 retains an unsubscribed loaded cache entry. Full resume overrides
+      // trigger teardown only when no subscriber can still observe that session.
+      if (
+        current.loaded &&
+        !current.subscribed &&
+        isJsonObject(current.thread.status) &&
+        current.thread.status.type === "idle" &&
+        current.thread.canAcceptDirectInput !== false &&
+        (params.config !== undefined ||
+          params.developerInstructions !== undefined ||
+          params.baseInstructions !== undefined)
+      ) {
+        current.loaded = false;
+        harness.send({
+          method: "thread/status/changed",
+          params: { threadId, status: { type: "notLoaded" } },
+        });
+      }
+      const response = await options.respond(request.method, request.params);
+      if (current.loaded) {
+        current.subscribed = true;
+        return current.response;
+      }
+      const resumed = remember(response, true, true);
+      resumed.items = current.items;
+      return response;
+    }
+    if (request.method === "thread/inject_items") {
+      if (!current?.loaded || !current.subscribed) {
+        throw new Error(`Synthetic injection requires a loaded subscription: ${threadId}`);
+      }
+      current.items.push(...(Array.isArray(params.items) ? params.items : []));
+      return {};
+    }
+    return await options.respond(request.method, request.params);
+  };
+  const harness = createClientHarness({
+    onWrite: (line, send) => {
+      const request = JSON.parse(line) as RpcRequest;
+      if (request.id === undefined || typeof request.method !== "string") {
+        return;
+      }
+      void dispatch(request).then(
+        (result) => send({ id: request.id, result }),
+        (error: unknown) =>
+          send({
+            id: request.id,
+            error: {
+              code: error instanceof CodexAppServerRpcError ? error.code : -32603,
+              message: error instanceof Error ? error.message : String(error),
+              ...(error instanceof CodexAppServerRpcError ? { data: error.data } : {}),
+            },
+          }),
+      );
+    },
+  });
+  return Object.assign(harness, {
+    request: vi.spyOn(harness.client, "request"),
+    seed: (
+      response: unknown,
+      state: { loaded: boolean; subscribed: boolean } = { loaded: false, subscribed: false },
+    ) => remember(response, state.loaded, state.subscribed),
+    notify: (notification: CodexServerNotification) => {
+      const params = isJsonObject(notification.params) ? notification.params : {};
+      const current =
+        typeof params.threadId === "string" ? threads.get(params.threadId) : undefined;
+      if (current && notification.method === "turn/completed") {
+        current.thread.status = { type: "idle" };
+      }
+      if (current && notification.method === "thread/closed") {
+        current.loaded = false;
+        current.subscribed = false;
+      }
+      harness.send(notification);
+    },
+    endTurn: (threadId: string) => harness.client.request("thread/unsubscribe", { threadId }),
+  });
+}
+
+/** Turn notifications and server requests use the same real client as lifecycle handoffs. */
+export function createCodexLifecycleTurnHarness(
+  params: Parameters<typeof createCodexLifecycleHarness>[0] & {
+    agentDir: string;
+    wait: { interval: number; timeout: number };
+  },
+) {
+  const wire = createCodexLifecycleHarness(params);
+  const { client, request } = wire;
+  const requests: Array<{ method: string; params: unknown }> = [];
+  const nativeRequest = CodexAppServerClient.prototype.request.bind(client);
+  request.mockImplementation((method, requestParams, options) => {
+    if (method !== "initialize") {
+      requests.push({ method, params: requestParams });
+    }
+    return nativeRequest(method, requestParams, options);
+  });
+  vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(client);
+  // Authentication is outside this lifecycle fixture; the caller still observes
+  // its requested selection before acquiring this credential-free physical owner.
+  const acquire = async (options?: CodexAppServerClientOptions) =>
+    await getLeasedSharedCodexAppServerClient({
+      ...options,
+      startOptions: {
+        transport: "stdio",
+        command: process.execPath,
+        args: ["app-server"],
+        headers: {},
+      },
+      agentDir: params.agentDir,
+      authProfileId: null,
+      preparedAuth: undefined,
+      authRequirement: undefined,
+      config: {},
+    });
+  onTestFinished(async () => {
+    await client.closeAndWait();
+  });
+  const pendingNotifications = new Set<Promise<unknown>>();
+  const registerNotification = client.addNotificationHandler.bind(client);
+  vi.spyOn(client, "addNotificationHandler").mockImplementation((handler) =>
+    registerNotification((notification) => {
+      const pending = Promise.resolve(handler(notification));
+      pendingNotifications.add(pending);
+      void pending.then(
+        () => pendingNotifications.delete(pending),
+        () => pendingNotifications.delete(pending),
+      );
+      return pending;
+    }),
+  );
+  const notify = async (notification: CodexServerNotification) => {
+    wire.notify(notification);
+    await Promise.all(pendingNotifications);
+  };
+  const waitForMethod = async (method: string, timeoutMs: number = params.wait.timeout) => {
+    await vi.waitFor(() => expect(requests.map((entry) => entry.method)).toContain(method), {
+      interval: 1,
+      timeout: timeoutMs,
+    });
+  };
+  const handleServerRequest = async (incoming: {
+    id: string | number;
+    method: string;
+    params?: unknown;
+  }) => {
+    wire.send(incoming);
+    let response: { result?: unknown; error?: unknown } | undefined;
+    await vi.waitFor(() => {
+      response = wire.writes
+        .map((line) => JSON.parse(line))
+        .find((entry) => entry.id === incoming.id && !entry.method);
+      expect(response).toBeDefined();
+    }, params.wait);
+    if (response?.error) {
+      throw new Error("Synthetic server request rejected", { cause: response.error });
+    }
+    return response?.result;
+  };
+  return {
+    acquire,
+    client,
+    request,
+    requests,
+    waitForMethod,
+    notify,
+    handleServerRequest,
+    waitForServerRequestHandler: async () => handleServerRequest,
+    completeTurn: async ({ threadId, turnId }: { threadId: string; turnId: string }) => {
+      await notify({
+        method: "turn/completed",
+        params: { threadId, turn: { id: turnId, status: "completed" } },
+      });
+    },
+    close: () => client.close(),
+  };
+}
+
+export async function createLeasedCodexLifecycleHarness(
+  options: Parameters<typeof createCodexLifecycleHarness>[0] & { agentDir: string },
+) {
+  const harness = createCodexLifecycleHarness(options);
+  const start = vi.spyOn(CodexAppServerClient, "start").mockResolvedValueOnce(harness.client);
+  const acquireOptions: CodexAppServerClientOptions = {
+    startOptions: {
+      transport: "stdio",
+      command: process.execPath,
+      args: ["app-server"],
+      headers: {},
+    },
+    agentDir: options.agentDir,
+    authProfileId: null,
+    config: {},
+  };
+  try {
+    await getLeasedSharedCodexAppServerClient(acquireOptions);
+  } finally {
+    start.mockRestore();
+  }
+  harness.request.mockClear();
+  onTestFinished(async () => {
+    releaseLeasedSharedCodexAppServerClient(harness.client);
+    await harness.client.closeAndWait();
+  });
+  return Object.assign(harness, { acquireOptions });
+}
 
 type ThreadLifecycleTestHostCapability = {
   capabilities: EmbeddedRunAttemptParams["hostCapabilities"];
@@ -60,7 +360,11 @@ function createTrackedThreadLifecycleHostCapability(): ThreadLifecycleTestHostCa
 export function startOrResumeThread(
   params: Omit<Parameters<typeof startOrResumeThreadImpl>[0], "bindingStore">,
 ) {
-  return startOrResumeThreadImpl({ ...params, bindingStore: testCodexAppServerBindingStore });
+  return startOrResumeThreadImpl({
+    signal: new AbortController().signal,
+    ...params,
+    bindingStore: testCodexAppServerBindingStore,
+  });
 }
 
 export function threadStartResult(threadId = "thread-1"): Record<string, unknown> {
@@ -155,4 +459,35 @@ export function resetThreadLifecycleTestFixtures(): void {
     host.close();
   }
   activeHostCapabilities.clear();
+}
+
+export function setCodexTestModelSupportsTools(
+  params: EmbeddedRunAttemptParams,
+  supportsTools: boolean,
+): void {
+  params.model = {
+    ...params.model,
+    compat: { ...params.model.compat, supportsTools },
+  } as EmbeddedRunAttemptParams["model"] & { compat: { supportsTools: boolean } };
+}
+
+export function createCodexRuntimePlanFixture(): NonNullable<
+  EmbeddedRunAttemptParams["runtimePlan"]
+> {
+  return {
+    auth: {},
+    observability: {
+      resolvedRef: "codex/gpt-5.4-codex",
+      provider: "codex",
+      modelId: "gpt-5.4-codex",
+      harnessId: "codex",
+    },
+    prompt: {
+      resolveSystemPromptContribution: () => undefined,
+    },
+    tools: {
+      normalize: (tools: unknown[]) => tools,
+      logDiagnostics: () => undefined,
+    },
+  } as unknown as NonNullable<EmbeddedRunAttemptParams["runtimePlan"]>;
 }

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -15,7 +15,6 @@ import {
   retainCodexAppServerLiveThread,
 } from "./client-runtime.js";
 import { CodexAppServerRpcError } from "./client.js";
-import { createFakeCodexAppServerClient } from "./codex-app-server.test-fixtures.js";
 import { createCodexTestHostCapabilities } from "./host-capability.test-support.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
 import type { CodexPluginThreadConfig } from "./plugin-thread-config.js";
@@ -54,6 +53,7 @@ import {
   resolveReasoningEffort,
   startOrResumeThread as startOrResumeThreadImpl,
 } from "./thread-lifecycle.js";
+import { createLeasedCodexLifecycleHarness } from "./thread-lifecycle.test-fixtures.js";
 import { attestCodexRestrictedToolSurfaceMcpServersDisabled } from "./thread-requests.js";
 
 type CodexThreadLifecycleTimingLogger = NonNullable<
@@ -2778,7 +2778,7 @@ describe("Codex plugin binding recovery", () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createThreadLifecycleParams(sessionFile, workspaceDir);
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/start" || method === "thread/resume") {
         return threadStartResult("thread-settled");
       }
@@ -2800,8 +2800,14 @@ describe("Codex plugin binding recovery", () => {
       policyContext: { fingerprint: "plugin-policy-settled", apps: {}, pluginAppIds: {} },
       diagnostics: [],
     }));
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
     const common = {
-      client: { request } as never,
+      client,
+      signal: new AbortController().signal,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -2818,6 +2824,7 @@ describe("Codex plugin binding recovery", () => {
         build,
       },
     });
+    await fixture.endTurn("thread-settled");
     await startOrResumeThread({
       ...common,
       pluginThreadConfig: {
@@ -2830,19 +2837,22 @@ describe("Codex plugin binding recovery", () => {
     });
 
     expect(build).toHaveBeenCalledTimes(1);
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start", "thread/resume"]);
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/start",
+      "thread/unsubscribe",
+      "thread/read",
+      "thread/resume",
+      "thread/inject_items",
+    ]);
   });
 
   it("rebuilds once when a settled negative binding still enables the plugin", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createThreadLifecycleParams(sessionFile, workspaceDir);
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/start" || method === "thread/resume") {
         return threadStartResult("thread-settled-transition");
-      }
-      if (method === "thread/unsubscribe") {
-        return { status: "unsubscribed" };
       }
       throw new Error(`unexpected method: ${method}`);
     });
@@ -2876,8 +2886,14 @@ describe("Codex plugin binding recovery", () => {
         policyContext: { fingerprint: "plugin-policy-settled", apps: {}, pluginAppIds: {} },
         diagnostics: [],
       });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
     const common = {
-      client: { request } as never,
+      client,
+      signal: new AbortController().signal,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -2894,6 +2910,7 @@ describe("Codex plugin binding recovery", () => {
         build,
       },
     });
+    await fixture.endTurn("thread-settled-transition");
     const settledProvider = {
       enabled: true,
       inputFingerprint: "plugin-input-settled",
@@ -2902,15 +2919,21 @@ describe("Codex plugin binding recovery", () => {
       build,
     };
     await startOrResumeThread({ ...common, pluginThreadConfig: settledProvider });
+    await fixture.endTurn("thread-settled-transition");
     await startOrResumeThread({ ...common, pluginThreadConfig: settledProvider });
 
     expect(build).toHaveBeenCalledTimes(2);
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
+      "thread/unsubscribe",
+      "thread/read",
       "thread/resume",
       "thread/unsubscribe",
       "thread/start",
+      "thread/unsubscribe",
+      "thread/read",
       "thread/resume",
+      "thread/inject_items",
     ]);
   });
 
@@ -2922,7 +2945,7 @@ describe("Codex plugin binding recovery", () => {
     let bindingStore = createCodexAppServerBindingStore(stateStore);
     let threadSequence = 0;
     const threadStarts: Array<Record<string, unknown>> = [];
-    const request = vi.fn(async (method: string, requestParams?: unknown) => {
+    const respond = vi.fn(async (method: string, requestParams?: unknown) => {
       if (method === "thread/start") {
         threadSequence += 1;
         threadStarts.push(requestParams as Record<string, unknown>);
@@ -2969,8 +2992,14 @@ describe("Codex plugin binding recovery", () => {
         }),
       };
     };
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client, request } = fixture;
     const common = {
-      client: { request } as never,
+      client,
+      signal: new AbortController().signal,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
@@ -2982,6 +3011,7 @@ describe("Codex plugin binding recovery", () => {
       bindingStore,
       pluginThreadConfig: provider("unrestricted", true),
     });
+    await fixture.endTurn("thread-authority-1");
     const revokedProvider = provider("unrestricted", true);
     revokedProvider.build.mockRejectedValueOnce(new Error("calendar revoked by current policy"));
     await expect(
@@ -2996,11 +3026,13 @@ describe("Codex plugin binding recovery", () => {
       bindingStore,
       pluginThreadConfig: provider("scheduled-cap-1", false),
     });
+    await fixture.endTurn("thread-authority-2");
     await startOrResumeThreadImpl({
       ...common,
       bindingStore,
       pluginThreadConfig: provider("unrestricted", true),
     });
+    await fixture.endTurn("thread-authority-3");
     bindingStore = createCodexAppServerBindingStore(stateStore);
     await startOrResumeThreadImpl({
       ...common,
@@ -3011,12 +3043,18 @@ describe("Codex plugin binding recovery", () => {
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
       "app/installed",
+      "thread/unsubscribe",
+      "thread/read",
       "thread/start",
       "app/installed",
+      "thread/unsubscribe",
       "thread/start",
       "app/installed",
+      "thread/unsubscribe",
+      "thread/read",
       "thread/resume",
       "app/installed",
+      "thread/inject_items",
     ]);
     expect(threadStarts).toHaveLength(3);
     expect(threadStarts[1]?.config).toMatchObject({
@@ -3454,10 +3492,7 @@ describe("Codex app-server adopted thread lifecycle", () => {
     const params = createThreadLifecycleParams(sessionFile, workspaceDir);
     const { identity, threadId } = await seedAdoptedThreadBinding(params, workspaceDir);
     let resumeCount = 0;
-    const request = vi.fn(async (method: string, _requestParams?: unknown) => {
-      if (method === "thread/read") {
-        return { thread: threadStartResult(threadId).thread };
-      }
+    const respond = vi.fn(async (method: string, _requestParams?: unknown) => {
       if (method === "thread/resume") {
         resumeCount += 1;
         return {
@@ -3469,28 +3504,39 @@ describe("Codex app-server adopted thread lifecycle", () => {
       throw new Error(`unexpected method: ${method}`);
     });
 
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+      persistedThreads: [threadId],
+    });
+    const { client, request } = fixture;
     const commonParams = {
-      client: { request } as never,
+      client,
+      signal: new AbortController().signal,
       params,
       cwd: workspaceDir,
       dynamicTools: [],
       appServer: createThreadLifecycleAppServerOptions(),
     };
     const firstBinding = await startOrResumeThread(commonParams);
+    await fixture.endTurn(threadId);
     const secondBinding = await startOrResumeThread(commonParams);
 
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/read",
       "thread/resume",
+      "thread/inject_items",
+      "thread/unsubscribe",
       "thread/read",
       "thread/resume",
+      "thread/inject_items",
     ]);
     expect(request.mock.calls[0]?.[1]).toEqual({ threadId, includeTurns: false });
-    expect(request.mock.calls[2]?.[1]).toEqual({ threadId, includeTurns: false });
+    expect(request.mock.calls[4]?.[1]).toEqual({ threadId, includeTurns: false });
     expect(request.mock.calls[1]?.[1]).not.toHaveProperty("model");
     expect(request.mock.calls[1]?.[1]).not.toHaveProperty("modelProvider");
-    expect(request.mock.calls[3]?.[1]).not.toHaveProperty("model");
-    expect(request.mock.calls[3]?.[1]).not.toHaveProperty("modelProvider");
+    expect(request.mock.calls[5]?.[1]).not.toHaveProperty("model");
+    expect(request.mock.calls[5]?.[1]).not.toHaveProperty("modelProvider");
     expect(firstBinding).toMatchObject({
       model: "native-model-1",
       modelProvider: "lmstudio",
@@ -3520,21 +3566,23 @@ describe("Codex app-server adopted thread lifecycle", () => {
       const workspaceDir = path.join(tempDir, "workspace");
       const params = createThreadLifecycleParams(sessionFile, workspaceDir);
       const { identity, threadId } = await seedAdoptedThreadBinding(params, workspaceDir);
-      const harness = createFakeCodexAppServerClient(async (method: string) => {
-        if (method === "thread/read") {
-          return {
-            thread: {
-              ...threadStartResult(threadId).thread,
-              status: { type: status },
-              canAcceptDirectInput,
-            },
-          };
-        }
-        if (method === "thread/unsubscribe") {
-          return { status: "unsubscribed" };
-        }
-        throw new Error(`unexpected method: ${method}`);
+      const harness = await createLeasedCodexLifecycleHarness({
+        agentDir: path.join(tempDir, "agent"),
+        respond: (method) => {
+          throw new Error(`unexpected method: ${method}`);
+        },
       });
+      harness.seed(
+        {
+          ...threadStartResult(threadId),
+          thread: {
+            ...(threadStartResult(threadId).thread as object),
+            status: { type: status },
+            canAcceptDirectInput,
+          },
+        },
+        { loaded: true, subscribed: true },
+      );
       ensureCodexAppServerClientRuntime(harness.client, { agentDir: workspaceDir });
       await testCodexAppServerBindingStore.mutate(identity, {
         kind: "patch",
@@ -3562,7 +3610,7 @@ describe("Codex app-server adopted thread lifecycle", () => {
         expect(await testCodexAppServerBindingStore.read(identity)).toEqual(before);
         expect(reserveResumeThread).not.toHaveBeenCalled();
       } finally {
-        harness.close();
+        harness.client.close();
       }
     },
   );
@@ -5682,7 +5730,7 @@ describe("Codex app-server thread lifecycle timing", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     let nowMs = 0;
     const log = createTimingLogger(true);
-    const request = vi.fn(async (method: string) => {
+    const respond = vi.fn(async (method: string) => {
       if (method === "thread/start") {
         return threadStartResult("thread-existing");
       }
@@ -5692,8 +5740,14 @@ describe("Codex app-server thread lifecycle timing", () => {
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+    const { client } = fixture;
     const commonParams = {
-      client: { request } as never,
+      client,
+      signal: new AbortController().signal,
       params: createThreadLifecycleParams(sessionFile, workspaceDir),
       cwd: workspaceDir,
       dynamicTools: [],
@@ -5708,6 +5762,7 @@ describe("Codex app-server thread lifecycle timing", () => {
         log: createTimingLogger(false),
       },
     });
+    await fixture.endTurn("thread-existing");
     await startOrResumeThread({
       ...commonParams,
       timing: {

--- a/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
@@ -15,6 +15,7 @@ import {
 } from "./session-binding.test-helpers.js";
 import {
   createAppServerOptions,
+  createLeasedCodexLifecycleHarness,
   createParams,
   resetThreadLifecycleTestFixtures,
   startOrResumeThread,
@@ -195,9 +196,13 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
       }
       throw new Error(`unexpected method: ${method}`);
     });
+    let wire = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond: request,
+    });
     const run = async () =>
       await startOrResumeThread({
-        client: { request } as never,
+        client: wire.client,
         params: createParams(sessionFile, workspaceDir, config),
         cwd: workspaceDir,
         dynamicTools: [],
@@ -205,7 +210,19 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
       });
 
     await run();
+    await wire.client.closeAndWait();
+    wire = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond: request,
+      persistedThreads: ["thread-policy"],
+    });
     await run();
+
+    expect(wire.request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/read",
+      "thread/resume",
+      "thread/inject_items",
+    ]);
 
     for (const method of ["thread/start", "thread/resume"]) {
       const call = request.mock.calls.find(([candidate]) => candidate === method);
@@ -376,9 +393,13 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
         }
         throw new Error(`unexpected method: ${method}`);
       });
+      let wire = await createLeasedCodexLifecycleHarness({
+        agentDir: path.join(tempDir, "agent"),
+        respond: request,
+      });
       const run = () =>
         startOrResumeThread({
-          client: { request } as never,
+          client: wire.client,
           params: createParams(sessionFile, workspaceDir, config),
           cwd: workspaceDir,
           dynamicTools: [],
@@ -419,9 +440,20 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
         hashCodexAppServerBindingFingerprint(legacyFingerprint),
       );
 
+      await wire.client.closeAndWait();
+      wire = await createLeasedCodexLifecycleHarness({
+        agentDir: path.join(tempDir, "agent"),
+        respond: request,
+        persistedThreads: ["thread-beta5"],
+      });
       request.mockClear();
       await run();
       expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
+      expect(wire.request.mock.calls.map(([method]) => method)).toEqual([
+        "thread/read",
+        "thread/resume",
+        "thread/inject_items",
+      ]);
     },
   );
 
@@ -922,24 +954,39 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
       throw new Error(`unexpected method: ${method}`);
     });
 
+    let wire = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond: request,
+    });
     await startOrResumeThread({
-      client: { request } as never,
+      client: wire.client,
       params: createParams(sessionFile, workspaceDir, config),
       cwd: workspaceDir,
       dynamicTools: [],
       appServer: createAppServerOptions(),
     });
 
+    await wire.client.closeAndWait();
+    wire = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond: request,
+      persistedThreads: ["thread-with-user-mcp"],
+    });
     request.mockClear();
 
     await startOrResumeThread({
-      client: { request } as never,
+      client: wire.client,
       params: createParams(sessionFile, workspaceDir, config),
       cwd: workspaceDir,
       dynamicTools: [],
       appServer: createAppServerOptions(),
     });
 
+    expect(wire.request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/read",
+      "thread/resume",
+      "thread/inject_items",
+    ]);
     const resumeCall = request.mock.calls.find(([method]) => method === "thread/resume");
     const resumeParams = resumeCall?.[1] as {
       config?: { mcp_servers?: Record<string, unknown> };

--- a/extensions/codex/src/app-server/thread-ownership.ts
+++ b/extensions/codex/src/app-server/thread-ownership.ts
@@ -67,7 +67,7 @@ export async function withCodexConversationThreadActivity<T>(
   return await nativeThreadOwners.enqueue(`conversation:${bindingId}`, run);
 }
 
-/** Publishes one owned persistent subscription into the shared bounded idle registry. */
+/** Publishes one owned subscription with its persistent or ephemeral retention lifetime. */
 export async function retainCodexAppServerBindingSubscription(
   client: CodexAppServerClient,
   threadId: string,
@@ -93,6 +93,7 @@ export async function retainCodexAppServerBindingSubscription(
       }),
     ownership?.configFingerprint,
     ownership?.serviceTier,
+    ownership?.ephemeralPolicy,
   );
 }
 

--- a/extensions/codex/src/app-server/thread-policy.ts
+++ b/extensions/codex/src/app-server/thread-policy.ts
@@ -1,3 +1,4 @@
+import { AgentHarnessPreflightError } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   isCodexAppServerOverloadError,
   isCodexAppServerPrewriteRequestCancellationError,
@@ -10,8 +11,18 @@ import {
 } from "./request.js";
 import type { CodexAppServerThreadBinding } from "./session-binding.js";
 
+/** A refusal, not a failed native write: the ephemeral conversation must stay alive. */
+export class CodexIncognitoPolicyChangeError extends AgentHarnessPreflightError {
+  constructor() {
+    super(
+      "Codex cannot change generic instructions in a live incognito conversation. No turn was sent and the conversation is preserved. Restore the previous instructions to continue it, or start a new incognito conversation for the changed policy.",
+    );
+    this.name = "CodexIncognitoPolicyChangeError";
+  }
+}
+
 /** Never replay a handoff: native persistence can precede an unsuccessful RPC response. */
-export class CodexThreadPolicyHandoffError extends Error {
+export class CodexThreadPolicyHandoffError extends AgentHarnessPreflightError {
   constructor(
     readonly outcome: "not-written" | "unknown" | "acknowledged",
     cause: unknown,

--- a/src/agents/embedded-agent-runner/run.harness-auth-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run.harness-auth-failover.test.ts
@@ -162,20 +162,32 @@ describe("native harness auth failover", () => {
     );
   });
 
-  it("does not rotate profiles for an unclassified harness failure", async () => {
-    const runEmbeddedAgent = prepareAuthFailoverRun();
-    const failure = new Error("native harness process exited");
-    mockedRunEmbeddedAttempt.mockRejectedValueOnce(failure);
+  it.each(["unclassified", "preflight"])(
+    "does not rotate or mark profiles for a %s harness failure",
+    async (kind) => {
+      const runEmbeddedAgent = prepareAuthFailoverRun();
+      // The integration harness resets modules before loading the runtime.
+      const { AgentHarnessPreflightError } = await import("../harness/errors.js");
+      const failure =
+        kind === "preflight"
+          ? new AgentHarnessPreflightError("handoff refused; reconnect before continuing", {
+              cause: permanentAuthFailure(),
+            })
+          : new Error("native harness process exited");
+      mockedRunEmbeddedAttempt
+        .mockRejectedValueOnce(failure)
+        .mockResolvedValueOnce(makeAttemptResult({ assistantTexts: ["unexpected retry"] }));
 
-    await expect(
-      runEmbeddedAgent({
-        ...createOverflowRunParams(state),
-        provider: "openai",
-        model: "gpt-5.6-luna",
-        runId: "run-native-harness-non-auth-failure",
-      }),
-    ).rejects.toBe(failure);
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledOnce();
-    expect(mockedMarkAuthProfileFailure).not.toHaveBeenCalled();
-  });
+      await expect(
+        runEmbeddedAgent({
+          ...createOverflowRunParams(state),
+          provider: "openai",
+          model: "gpt-5.6-luna",
+          runId: "run-native-harness-non-auth-failure",
+        }),
+      ).rejects.toBe(failure);
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledOnce();
+      expect(mockedMarkAuthProfileFailure).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
 import { attachErrorDiagnostic, formatErrorMessageForDisplay } from "../infra/error-diagnostics.js";
 import { getFailoverErrorCode } from "./failover/error.js";
+import { AgentHarnessPreflightError } from "./harness/errors.js";
 
 // Classification here is message/status table behavior. Provider-attributed
 // structured signals (e.g. moonshot + 429) otherwise cross the plugin-consult
@@ -59,6 +60,27 @@ const OPENAI_SERVER_ERROR_PAYLOAD =
   'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}';
 
 describe("failover-error", () => {
+  it.each([
+    {
+      message: "handoff refused",
+      cause: { status: 401, code: "INVALID_API_KEY", message: "API key has been revoked" },
+    },
+    {
+      message: "handoff refused: 529 OVERLOADED",
+      cause: { status: 529, code: "OVERLOADED", message: "overloaded" },
+    },
+    { message: "503 service unavailable; reconnect before continuing", cause: { status: 503 } },
+  ])(
+    "does not promote a direct preflight into a provider failure: $message",
+    ({ message, cause }) => {
+      const error = new AgentHarnessPreflightError(message, { cause });
+      expect(resolveFailoverReasonFromError(error)).toBeNull();
+      expect(coerceToFailoverError(error)).toBeNull();
+      expect(describeFailoverError(error)).toEqual({ message });
+      expect(resolveModelFallbackError(error)).toEqual({ kind: "coordination", error });
+      expect(error.cause).toBe(cause);
+    },
+  );
   it("finds structured CLI timeout context through aggregate wrappers", () => {
     const timeout = new FailoverError("CLI exceeded timeout", {
       reason: "timeout",

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -512,67 +512,22 @@ describe("failover-error", () => {
     ).toBe("format");
   });
 
-  it("treats HTTP 422 as format error", () => {
-    expect(
-      resolveFailoverReasonFromError({
-        status: 422,
-        message: "check open ai req parameter error",
-      }),
-    ).toBe("format");
+  it.each([
+    ["check open ai req parameter error", "format"],
+    ["insufficient credits", "billing"],
+  ])("classifies HTTP 422 message %s as %s", (message, reason) => {
+    expect(resolveFailoverReasonFromError({ status: 422, message })).toBe(reason);
   });
 
-  it("treats 422 with billing message as billing instead of format", () => {
+  it.each([
+    ["402", "Monthly spend limit reached. Please visit your billing settings.", "rate_limit"],
+    ["HTTP 402", "rate limit exceeded", "rate_limit"],
+    ["HTTP 402", "Your usage limit has been reached. Please upgrade your plan.", "billing"],
+  ])("keeps %s wrappers aligned with status-split payloads: %s", (prefix, message, reason) => {
     expect(
-      resolveFailoverReasonFromError({
-        status: 422,
-        message: "insufficient credits",
-      }),
-    ).toBe("billing");
-  });
-
-  it("keeps raw 402 wrappers aligned with status-split temporary spend limits", () => {
-    const message = "Monthly spend limit reached. Please visit your billing settings.";
-    expect(
-      resolveFailoverReasonFromError({
-        message: `402 Payment Required: ${message}`,
-      }),
-    ).toBe("rate_limit");
-    expect(
-      resolveFailoverReasonFromError({
-        status: 402,
-        message,
-      }),
-    ).toBe("rate_limit");
-  });
-
-  it("keeps explicit 402 rate-limit wrappers aligned with status-split payloads", () => {
-    const message = "rate limit exceeded";
-    expect(
-      resolveFailoverReasonFromError({
-        message: `HTTP 402 Payment Required: ${message}`,
-      }),
-    ).toBe("rate_limit");
-    expect(
-      resolveFailoverReasonFromError({
-        status: 402,
-        message,
-      }),
-    ).toBe("rate_limit");
-  });
-
-  it("keeps plan-upgrade 402 wrappers aligned with status-split billing payloads", () => {
-    const message = "Your usage limit has been reached. Please upgrade your plan.";
-    expect(
-      resolveFailoverReasonFromError({
-        message: `HTTP 402 Payment Required: ${message}`,
-      }),
-    ).toBe("billing");
-    expect(
-      resolveFailoverReasonFromError({
-        status: 402,
-        message,
-      }),
-    ).toBe("billing");
+      resolveFailoverReasonFromError({ message: `${prefix} Payment Required: ${message}` }),
+    ).toBe(reason);
+    expect(resolveFailoverReasonFromError({ status: 402, message })).toBe(reason);
   });
 
   it("infers timeout from common node error codes", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -26,7 +26,10 @@ import {
   type CliTimeoutContext,
 } from "./failover/error.js";
 import type { FailoverClassification, FailoverReason, FailoverSignal } from "./failover/signal.js";
-import { AgentHarnessSessionSupersededError } from "./harness/errors.js";
+import {
+  AgentHarnessSessionSupersededError,
+  isAgentHarnessPreflightError,
+} from "./harness/errors.js";
 
 export {
   FailoverError,
@@ -506,6 +509,11 @@ function resolveFailoverClassificationFromError(
   err: unknown,
   providerHint?: string,
 ): FailoverClassification | null {
+  // A direct preflight owns the refusal; its cause is diagnostic, not a failed
+  // provider attempt that may rotate credentials or replay the turn.
+  if (isAgentHarnessPreflightError(err)) {
+    return null;
+  }
   return resolveFailoverClassificationFromErrorInternal(err, new Set<object>(), 0, providerHint);
 }
 
@@ -590,6 +598,9 @@ export function describeFailoverError(err: unknown): {
   sessionId?: string;
   lane?: string;
 } {
+  if (isAgentHarnessPreflightError(err)) {
+    return { message: err.message };
+  }
   if (isFailoverError(err)) {
     return {
       message: err.message,
@@ -721,6 +732,9 @@ export function resolveModelFallbackError(
   // Keep the wrapper identity before coercion can discard the terminal fact.
   if (findCliMaxTurnsError(err)) {
     return { kind: "terminal", error: err };
+  }
+  if (isAgentHarnessPreflightError(err)) {
+    return { kind: "coordination", error: err };
   }
   const failoverError = coerceToFailoverError(err, context);
   if (failoverError) {

--- a/src/agents/model-fallback.terminal-boundary.test.ts
+++ b/src/agents/model-fallback.terminal-boundary.test.ts
@@ -45,6 +45,17 @@ const fallbackOptions = {
   fallbacksOverride: ["fixture-next/fixture-model"],
 };
 
+it("does not replay an unscoped preflight subclass on another model", async () => {
+  class PolicyRefusal extends AgentHarnessPreflightError {}
+  const error = new PolicyRefusal("handoff refused", {
+    cause: new FailoverError("529 overloaded", { reason: "overloaded", status: 529 }),
+  });
+  const run = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce("unexpected fallback");
+  await expect(runWithModelFallback({ ...fallbackOptions, run })).rejects.toBe(error);
+  expect(run).toHaveBeenCalledOnce();
+  expect(providerHook).not.toHaveBeenCalled();
+});
+
 const wrappers = [
   { name: "direct", wrap: (error: FailoverError): unknown => error },
   { name: "error", wrap: (error: FailoverError): unknown => ({ error }) },

--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -18,6 +18,7 @@ import {
   renderRateLimitOrOverloadedCopy,
   renderRateLimitReplyCopy,
 } from "../../agents/failover/user-copy.js";
+import { isAgentHarnessPreflightError } from "../../agents/harness/errors.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { isAgentRunRestartAbortReason } from "../../agents/run-termination.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -149,6 +150,34 @@ export async function handleAgentExecutionError(params: {
     outcome: "error",
     error: message,
   });
+  // The exhausted preflight is deliberate, even if its diagnostic cause looks
+  // like HTTP/overload. Settle delivery and normal diagnostic policy without replay.
+  if (isAgentHarnessPreflightError(err)) {
+    const externalReply = buildExternalRunFailureReply(
+      { message, error: err },
+      {
+        includeDetails: isVerboseFailureDetailEnabled(turn.resolvedVerboseLevel),
+        isHeartbeat: turn.isHeartbeat,
+      },
+    );
+    const text = resolveExternalRunFailureTextForConversation({
+      text: params.shouldSurfaceToControlUi
+        ? renderControlUiAgentFailureCopy(message)
+        : externalReply.text,
+      visibleReplyDelivered: await turn.resolveVisibleReplyDelivery?.(),
+      sessionCtx: turn.sessionCtx,
+      isGenericRunnerFailure: externalReply.isGenericRunnerFailure,
+      cfg: turn.followupRun.run.config,
+    });
+    takePendingLifecycleTerminal().emit("error", err);
+    turn.replyOperation?.fail("run_failed", err);
+    await params.modelPatch.fail(err);
+    return {
+      kind: "final",
+      payload: markAgentRunFailureReplyPayload({ text }),
+      postCompactionModelFailure,
+    };
+  }
   const failoverFacts = resolveReplyFailoverFacts(err, message);
   const fallbackAttempts = isFailoverError(err) ? err.attempts : undefined;
   const hasFallbackAttempts = Boolean(fallbackAttempts?.length);

--- a/src/auto-reply/reply/agent-runner-execution-conversation-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-conversation-failures.test.ts
@@ -1,16 +1,121 @@
 import { describe, expect, it, vi } from "vitest";
 import { PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE } from "../../agents/failover/user-copy.js";
 import type { TemplateContext } from "../templating.js";
+import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import {
   setupAgentRunnerExecutionTestState,
   getExecuteAgentTurnForTest,
   createMockTypingSignaler,
   createFollowupRun,
+  createMinimalRunAgentTurnParams,
+  GENERIC_RUN_FAILURE_TEXT,
+  NON_DIRECT_FAILURE_SURFACE_CASES,
+  createNonDirectFailureSessionCtx,
 } from "./agent-runner-execution.test-support.js";
 
 const state = setupAgentRunnerExecutionTestState();
 
 describe("executeAgentTurn: conversation failures", () => {
+  it.each(NON_DIRECT_FAILURE_SURFACE_CASES)(
+    "keeps raw runner failure boilerplate out of $label chats",
+    async (testCase) => {
+      state.runEmbeddedAgentMock.mockRejectedValueOnce(
+        new Error("openai/gpt-5.5 ended with an incomplete terminal response"),
+      );
+
+      const executeAgentTurn = await getExecuteAgentTurnForTest();
+      const result = await executeAgentTurn(
+        createMinimalRunAgentTurnParams({
+          sessionCtx: createNonDirectFailureSessionCtx(testCase),
+        }),
+      );
+
+      expect(result.kind).toBe("final");
+      if (result.kind === "final") {
+        expect(result.payload.text).toBe(SILENT_REPLY_TOKEN);
+      }
+    },
+  );
+
+  it.each(["group", "channel"] as const)(
+    "surfaces raw runner failure copy in Discord %s chats when silentReply.group is set to disallow",
+    async (chatType) => {
+      state.runEmbeddedAgentMock.mockRejectedValueOnce(
+        new Error("openai/gpt-5.5 ended with an incomplete terminal response"),
+      );
+
+      const followupRun = createFollowupRun();
+      followupRun.run.config = {
+        agents: {
+          defaults: {
+            silentReply: { group: "disallow" },
+          },
+        },
+      };
+
+      const executeAgentTurn = await getExecuteAgentTurnForTest();
+      const result = await executeAgentTurn(
+        createMinimalRunAgentTurnParams({
+          followupRun,
+          sessionCtx: {
+            Provider: "discord",
+            Surface: "discord",
+            ChatType: chatType,
+            GroupSubject: "agent group",
+            GroupChannel: "#general",
+            MessageSid: "msg",
+          } as unknown as TemplateContext,
+        }),
+      );
+
+      expect(result.kind).toBe("final");
+      if (result.kind === "final") {
+        expect(result.payload.text).not.toBe(SILENT_REPLY_TOKEN);
+        expect(result.payload.text).toBe(GENERIC_RUN_FAILURE_TEXT);
+      }
+    },
+  );
+
+  it("surfaces raw runner failure copy when per-surface silentReply.group is set to disallow", async () => {
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new Error("openai/gpt-5.5 ended with an incomplete terminal response"),
+    );
+
+    const followupRun = createFollowupRun();
+    followupRun.run.config = {
+      agents: {
+        defaults: {
+          silentReply: { group: "allow" },
+        },
+      },
+      surfaces: {
+        discord: {
+          silentReply: { group: "disallow" },
+        },
+      },
+    };
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(
+      createMinimalRunAgentTurnParams({
+        followupRun,
+        sessionCtx: {
+          Provider: "discord",
+          Surface: "discord",
+          ChatType: "group",
+          GroupSubject: "agent group",
+          GroupChannel: "#general",
+          MessageSid: "msg",
+        } as unknown as TemplateContext,
+      }),
+    );
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(GENERIC_RUN_FAILURE_TEXT);
+    }
+  });
+
   it("returns a session reset hint for Bedrock tool mismatch errors on external chat channels", async () => {
     state.runEmbeddedAgentMock.mockRejectedValueOnce(
       new Error(

--- a/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { formatBillingErrorMessage } from "../../agents/embedded-agent-helpers.js";
 import { FailoverError } from "../../agents/failover-error.js";
+import { AgentHarnessPreflightError } from "../../agents/harness/errors.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { ProviderAuthError } from "../../agents/model-auth.js";
 import { getReplyPayloadMetadata } from "../reply-payload.js";
@@ -75,6 +76,122 @@ function createOpenAiServiceUnavailableError() {
 }
 
 describe("executeAgentTurn: provider failures", () => {
+  it.each(
+    [
+      "Handoff refused after 529 OVERLOADED; reconnect before continuing.",
+      "503 service unavailable; reconnect before continuing.",
+    ].flatMap((message) =>
+      [
+        "direct",
+        "verbose",
+        "verbose full",
+        "group",
+        "channel",
+        "verbose group",
+        "verbose channel",
+        "partial",
+        "disallow",
+        "control UI",
+      ].map((surface) => ({ message, surface })),
+    ),
+  )(
+    "settles preflight diagnostics without replay: $surface / $message",
+    async ({ message, surface }) => {
+      const executeAgentTurn = await getExecuteAgentTurnForTest();
+      vi.useFakeTimers();
+      const error = new AgentHarnessPreflightError(
+        `${message} diagnostic-canary ${"x".repeat(1500)}`,
+        {
+          cause: { status: 529, code: "OVERLOADED" },
+        },
+      );
+      const { replyOperation, failMock } = createMockReplyOperation();
+      const onBlockReply = vi.fn();
+      let partialAccepted = false;
+      const resolveVisibleReplyDelivery = vi.fn(async () => {
+        await Promise.resolve();
+        expect(failMock).not.toHaveBeenCalled();
+        return partialAccepted;
+      });
+      const silentGroup = ["group", "channel", "verbose group", "verbose channel"].includes(
+        surface,
+      );
+      const group = silentGroup || surface === "partial" || surface === "disallow";
+      state.isInternalMessageChannelMock.mockReturnValue(surface === "control UI");
+      state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+        await params.onPartialReply?.({ text: "accepted partial" });
+        throw error;
+      });
+      state.runWithModelFallbackMock
+        .mockImplementationOnce(async (params: FallbackRunnerParams) => {
+          if (surface === "partial") {
+            return await params.run("anthropic", "claude", initialFallbackAttemptOptions(params));
+          }
+          throw error;
+        })
+        .mockResolvedValueOnce({
+          result: { payloads: [{ text: "unexpected retry" }], meta: {} },
+          provider: "fixture",
+          model: "fixture",
+          attempts: [],
+        });
+      const followupRun = createFollowupRun();
+      if (surface === "disallow") {
+        followupRun.run.config = { agents: { defaults: { silentReply: { group: "disallow" } } } };
+      }
+      const pending = executeAgentTurn({
+        ...createMinimalRunAgentTurnParams({
+          replyOperation,
+          opts: {
+            onBlockReply,
+            onPartialReply: () => {
+              partialAccepted = true;
+              return true;
+            },
+          },
+          sessionCtx: group
+            ? createNonDirectFailureSessionCtx(
+                NON_DIRECT_FAILURE_SURFACE_CASES[surface.includes("channel") ? 1 : 0],
+              )
+            : createDirectFailureSessionCtx(),
+          followupRun,
+        }),
+        resolvedVerboseLevel:
+          surface === "verbose full"
+            ? "full"
+            : surface.startsWith("verbose") || surface === "partial" || surface === "disallow"
+              ? "on"
+              : "off",
+        resolveVisibleReplyDelivery,
+      });
+      await vi.advanceTimersByTimeAsync(30_000);
+      const result = await pending;
+      expect(state.runWithModelFallbackMock).toHaveBeenCalledOnce();
+      expect(failMock).toHaveBeenCalledWith("run_failed", error);
+      expect(result.kind).toBe("final");
+      if (result.kind === "final") {
+        if (silentGroup) {
+          expect(result.payload.text).toBe(SILENT_REPLY_TOKEN);
+          expect(result.payload.isError).toBeUndefined();
+        } else if (surface === "direct") {
+          expect(result.payload.text).toBe(GENERIC_RUN_FAILURE_TEXT);
+          expect(result.payload.text).not.toContain("diagnostic-canary");
+        } else {
+          expect(result.payload.isError).toBe(true);
+          expect(result.payload.text).toContain("Agent failed before reply:");
+          expect(result.payload.text).toContain("reconnect before continuing");
+          if (surface === "control UI") {
+            expect(result.payload.text).toContain("openclaw logs --follow");
+          } else {
+            expect(result.payload.text!.length).toBeLessThanOrEqual(1020);
+          }
+        }
+      }
+      expect(partialAccepted).toBe(surface === "partial");
+      expect(resolveVisibleReplyDelivery).toHaveBeenCalledOnce();
+      expect(onBlockReply).not.toHaveBeenCalled();
+    },
+  );
   it("reports the terminal provider failure to the dispatch owner", async () => {
     const onAgentRunTerminalOutcome = vi.fn();
     state.runEmbeddedAgentMock.mockRejectedValueOnce(new Error("provider returned HTTP 500"));
@@ -85,24 +202,6 @@ describe("executeAgentTurn: provider failures", () => {
     expect(onAgentRunTerminalOutcome).toHaveBeenCalledOnce();
     expect(onAgentRunTerminalOutcome).toHaveBeenCalledWith("failed");
   });
-
-  it.each(NON_DIRECT_FAILURE_SURFACE_CASES)(
-    "keeps raw runner failure boilerplate out of $label chats",
-    async (testCase) => {
-      state.runEmbeddedAgentMock.mockRejectedValueOnce(
-        new Error("openai/gpt-5.5 ended with an incomplete terminal response"),
-      );
-
-      const result = await executeTestTurn({
-        sessionCtx: createNonDirectFailureSessionCtx(testCase),
-      });
-
-      expect(result.kind).toBe("final");
-      if (result.kind === "final") {
-        expect(result.payload.text).toBe(SILENT_REPLY_TOKEN);
-      }
-    },
-  );
 
   it.each(
     NON_DIRECT_FAILURE_SURFACE_CASES.flatMap((surface) =>
@@ -145,79 +244,6 @@ describe("executeAgentTurn: provider failures", () => {
       expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(failure === "provider" ? 1 : 3);
     },
   );
-
-  it.each(["group", "channel"] as const)(
-    "surfaces raw runner failure copy in Discord %s chats when silentReply.group is set to disallow",
-    async (chatType) => {
-      state.runEmbeddedAgentMock.mockRejectedValueOnce(
-        new Error("openai/gpt-5.5 ended with an incomplete terminal response"),
-      );
-
-      const followupRun = createFollowupRun();
-      followupRun.run.config = {
-        agents: {
-          defaults: {
-            silentReply: { group: "disallow" },
-          },
-        },
-      };
-
-      const result = await executeTestTurn({
-        followupRun,
-        sessionCtx: {
-          Provider: "discord",
-          Surface: "discord",
-          ChatType: chatType,
-          GroupSubject: "agent group",
-          GroupChannel: "#general",
-          MessageSid: "msg",
-        } as unknown as TemplateContext,
-      });
-
-      expect(result.kind).toBe("final");
-      if (result.kind === "final") {
-        expect(result.payload.text).not.toBe(SILENT_REPLY_TOKEN);
-        expect(result.payload.text).toBe(GENERIC_RUN_FAILURE_TEXT);
-      }
-    },
-  );
-
-  it("surfaces raw runner failure copy when per-surface silentReply.group is set to disallow", async () => {
-    state.runEmbeddedAgentMock.mockRejectedValueOnce(
-      new Error("openai/gpt-5.5 ended with an incomplete terminal response"),
-    );
-
-    const followupRun = createFollowupRun();
-    followupRun.run.config = {
-      agents: {
-        defaults: {
-          silentReply: { group: "allow" },
-        },
-      },
-      surfaces: {
-        discord: {
-          silentReply: { group: "disallow" },
-        },
-      },
-    };
-
-    const result = await executeTestTurn({
-      followupRun,
-      sessionCtx: {
-        Provider: "discord",
-        Surface: "discord",
-        ChatType: "group",
-        GroupSubject: "agent group",
-        GroupChannel: "#general",
-        MessageSid: "msg",
-      } as unknown as TemplateContext,
-    });
-
-    expect(result.kind).toBe("final");
-    if (result.kind === "final") {
-      expect(result.payload.text).toBe(GENERIC_RUN_FAILURE_TEXT);
-    }
-  });
 
   it.each(NON_DIRECT_FAILURE_SURFACE_CASES)(
     "keeps default silent behavior in $label chats when silentReply policy is unset",

--- a/src/auto-reply/reply/agent-runner-failure-reply.test.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.test.ts
@@ -9,6 +9,7 @@ import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import {
   buildEmptyInteractiveReplyPayload,
   buildExternalRunFailureReply,
+  buildKnownAgentRunFailureReplyPayload,
   buildPreflightCompactionFailureText,
   resolveExternalRunFailureTextForConversation,
 } from "./agent-runner-failure-reply.js";
@@ -48,19 +49,26 @@ describe("buildEmptyInteractiveReplyPayload", () => {
 });
 
 describe("buildExternalRunFailureReply", () => {
-  it.each(["auth", "overload", "HTTP"])(
+  it.each(["401 unauthorized", "529 overloaded", "503 service unavailable", "402 billing"])(
     "keeps preflight %s diagnostics behind verbose opt-in",
     (failure) => {
-      const message = `${failure === "HTTP" ? "503 service unavailable" : failure}; reconnect before continuing. diagnostic-canary ${"x".repeat(1500)}`;
+      const message = `${failure}; reconnect before continuing. diagnostic-canary ${"x".repeat(1500)}`;
       const input = {
         message,
         error: new AgentHarnessPreflightError(message, {
           cause: new FailoverError("provider diagnostic", {
-            reason: failure === "auth" ? "auth" : "overloaded",
-            status: failure === "auth" ? 401 : 529,
+            reason: failure.startsWith("401") ? "auth" : "overloaded",
+            status: failure.startsWith("401") ? 401 : 529,
           }),
         }),
       };
+      expect(
+        buildKnownAgentRunFailureReplyPayload({
+          err: input.error,
+          sessionCtx: { Provider: "discord", Surface: "discord", ChatType: "group" },
+          resolvedVerboseLevel: "off",
+        }),
+      ).toBeUndefined();
       expect(buildExternalRunFailureReply(input)).toEqual({
         text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
         isGenericRunnerFailure: true,

--- a/src/auto-reply/reply/agent-runner-failure-reply.test.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { FailoverError } from "../../agents/failover-error.js";
-import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "../../agents/failover/user-copy.js";
+import {
+  GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+  HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
+} from "../../agents/failover/user-copy.js";
+import { AgentHarnessPreflightError } from "../../agents/harness/errors.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import {
   buildEmptyInteractiveReplyPayload,
   buildExternalRunFailureReply,
   buildPreflightCompactionFailureText,
+  resolveExternalRunFailureTextForConversation,
 } from "./agent-runner-failure-reply.js";
 
 const EMPTY_INTERACTIVE_REPLY_TEXT =
@@ -43,6 +48,45 @@ describe("buildEmptyInteractiveReplyPayload", () => {
 });
 
 describe("buildExternalRunFailureReply", () => {
+  it.each(["auth", "overload", "HTTP"])(
+    "keeps preflight %s diagnostics behind verbose opt-in",
+    (failure) => {
+      const message = `${failure === "HTTP" ? "503 service unavailable" : failure}; reconnect before continuing. diagnostic-canary ${"x".repeat(1500)}`;
+      const input = {
+        message,
+        error: new AgentHarnessPreflightError(message, {
+          cause: new FailoverError("provider diagnostic", {
+            reason: failure === "auth" ? "auth" : "overloaded",
+            status: failure === "auth" ? 401 : 529,
+          }),
+        }),
+      };
+      expect(buildExternalRunFailureReply(input)).toEqual({
+        text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+        isGenericRunnerFailure: true,
+      });
+      const heartbeat = buildExternalRunFailureReply(input, {
+        isHeartbeat: true,
+        includeDetails: true,
+      });
+      expect(heartbeat.text).toBe(HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT);
+      expect(
+        resolveExternalRunFailureTextForConversation({
+          text: heartbeat.text,
+          isGenericRunnerFailure: heartbeat.isGenericRunnerFailure,
+          sessionCtx: { Provider: "discord", Surface: "discord", ChatType: "group" },
+        }),
+      ).toBe(HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT);
+      const verbose = buildExternalRunFailureReply(input, { includeDetails: true });
+      expect(verbose.isGenericRunnerFailure).toBe(true);
+      expect(verbose.text).toContain("reconnect before continuing");
+      expect(verbose.text).toContain("diagnostic-canary");
+      expect(verbose.text).toBe(
+        `⚠️ Agent failed before reply: ${message.slice(0, 899)}…. Please try again, or use /new to start a fresh session.`,
+      );
+    },
+  );
+
   it("forwards classified provider copy when verbose detail is off", () => {
     const message = "opaque provider response with secret-canary";
     const reply = buildExternalRunFailureReply(

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -32,6 +32,7 @@ import {
   resolveProviderRequestFailureCopy,
   type ReplyFallbackAttempt,
 } from "../../agents/failover/user-copy.js";
+import { isAgentHarnessPreflightError } from "../../agents/harness/errors.js";
 import { isProviderAuthError } from "../../agents/model-auth-runtime-shared.js";
 import { buildProviderAuthRecoveryHint } from "../../agents/provider-auth-recovery-hint.js";
 import { resolveSilentReplyPolicy } from "../../config/silent-reply.js";
@@ -202,7 +203,7 @@ export function buildAuthProfileFailoverFailureText(error: unknown): string | nu
 }
 
 function formatForwardedExternalRunFailureText(message: string): string {
-  const sanitized = renderUserFacingText(message, { errorContext: true })
+  const sanitized = message
     .trim()
     .replace(/^⚠️\s*/u, "")
     .replace(/\s+/gu, " ");
@@ -229,6 +230,20 @@ export function buildExternalRunFailureReply(
   const message = typeof input === "string" ? input : input.message;
   const error = typeof input === "string" ? undefined : input.error;
   const normalizedMessage = collapseRepeatedFailureDetail(message);
+  // Preflight detail is diagnostic, not provider copy or an assurance that it is
+  // safe to disclose. Verbose opt-in and the shared detail cap still apply.
+  if (isAgentHarnessPreflightError(error)) {
+    return {
+      text: options?.isHeartbeat
+        ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT
+        : options?.includeDetails
+          ? formatForwardedExternalRunFailureText(
+              sanitizeUserFacingText(normalizedMessage, { errorContext: true }),
+            )
+          : GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+      isGenericRunnerFailure: !options?.isHeartbeat,
+    };
+  }
   const failoverFacts =
     options?.failoverFacts ??
     resolveReplyFailoverFacts(error ?? normalizedMessage, normalizedMessage);
@@ -325,7 +340,9 @@ export function buildExternalRunFailureReply(
   // explicit opt-in because sanitization does not make raw provider bodies safe.
   return {
     text: options?.includeDetails
-      ? formatForwardedExternalRunFailureText(normalizedMessage)
+      ? formatForwardedExternalRunFailureText(
+          renderUserFacingText(normalizedMessage, { errorContext: true }),
+        )
       : GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
     isGenericRunnerFailure: true,
   };

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -437,6 +437,11 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
   resolvedVerboseLevel: VerboseLevel | undefined;
   cfg?: OpenClawConfig;
 }): ReplyPayload | undefined {
+  // Direct preflight diagnostics are not provider failures; preserve their
+  // identity for the caller's generic settlement and disclosure policy.
+  if (isAgentHarnessPreflightError(params.err)) {
+    return undefined;
+  }
   const message = formatErrorMessage(params.err);
   const failoverFacts = resolveReplyFailoverFacts(params.err, message);
   const fallbackAttempts = readFallbackAttempts(params.err);


### PR DESCRIPTION
Closes #135338 — stale generic instructions after Codex prompt-hook replacement.

## What Problem This Solves

Fixes an issue where users continuing an ordinary Codex conversation could retain stale OpenClaw generic instructions after a `before_prompt_build` hook replaced the system prompt or explicitly returned an empty string. Sending the new configuration on resume alone did not update the next model request's inherited instruction history.

## Why This Change Was Made

The Codex plugin now establishes native configuration ownership before reusing the existing complete-policy injection carrier. Persistent resumes keep the native conversation, establish that the old configuration was unloaded, and append a complete superseding policy or explicit withdrawal; this also keeps configuration correct for compaction and native-child inheritance. Independent native/project/collaboration instructions and user authority remain separate.

The existing exact-generation live-thread owner now also holds ordinary incognito creation policy in memory, without adding idle expiry or persistence. Direct preflight refusals retain their identity through failover and reply presentation, rather than turning diagnostic text into provider auth, billing, or overload facts. Integration preserves main's single transient retry controller and subprocess diagnostic copying; no removed outer retry loop is restored.

## User Impact

Unchanged, configuration-proven warm conversations retain their fast path. Changed or cold persistent resumes refresh the full generic policy, including an explicit empty withdrawal. Old policy text may remain in append-only history, but the later complete policy supersedes it.

The owner explicitly accepted guarded persistent refresh and changed-incognito refusal. When another lease/subscriber or failed unload prevents configuration proof, the turn refuses before inference and preserves the conversation. Ordinary cold refresh requires managed local non-proxy stdio; external sockets/proxies cannot provide this proof. Resolve contention and reconnect through managed local stdio. Supervised external connections keep their existing, narrower connection-lease contract.

A live incognito conversation cannot change its creation-time generic policy on stock Codex. A changed or emptied policy therefore refuses before inference; restore the original policy to continue the same conversation, or start a new incognito conversation for the new policy. This introduces no expiry or new store.

Unknown policy-write outcomes are not automatically replayed or rotated away. Default external diagnostic privacy, verbose detail limits, group silence, accepted-partial settlement, heartbeat visibility, and Control UI formatting remain under their existing owners. There are no new settings, schemas, dependencies, native patches, or operator-state changes.

## Evidence

### Native behavior and dependency contract

Stock `@openai/codex` 0.151.0 was verified against its official npm platform artifact (SHA-256 `98491713ffb196061003ee148636e743997cc31d76144ba7c53462269896891d`). The baseline used production OpenClaw hook/prompt/lifecycle composition, admitted host authority, real native stdio, and a credential-free loopback Responses endpoint—not a mocked resume acknowledgment.

All twelve baseline native turns completed, but the six second-turn replacement/empty-policy assertions failed. The repaired native implementation passed twelve scenarios, including warm/cold replacement and withdrawal, unchanged warm reuse, contention recovery, incognito original-policy same-thread recovery, and `A → B → native warm compaction → unchanged B`. Captures contain 28 native HTTP requests; all 15 clients and both servers closed, with no Authorization headers or auth files. The same twelve scenarios were rerun successfully on exact published head `6a8f0492d3f0bfab5830b72c1102ebe157731d3a` / tree `112f6d7c0fd4aab1c68724161838c4b0a79d2218` on Linux in [Testbox run 33565101656](https://github.com/openclaw/openclaw/actions/runs/33565101656): 28 requests, all 15 clients and both servers closed, no Authorization headers. Linux used frozen-lockfile stock Codex 0.151.0, native SHA-256 `9739cbc928b9c573be83256acd46668f5dd4f119d2d09e05246895ca2aaf0c9a`. The temporary launcher retained identical probe logic and only relocated its source aliases to the isolated Linux checkout. These runs prove model-input composition, not external model inference or model compliance.

Exact stock source personally inspected at `78c290807ce710180111df227df3b7a4fe845452`:

- [Full generic context versus ordinary world-state differences](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/core/src/session/mod.rs#L3675-L3701), with the [subsequent-turn path](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/core/src/session/mod.rs#L4017-L4104).
- [Loaded-thread resume can ignore configuration overrides](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/app-server/src/request_processors/thread_processor.rs#L4133-L4183).
- [Developer-item injection records and flushes history](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/core/src/codex_thread.rs#L626-L662).

### Integrated verification

The source-bound Linux Node 24.19.0 test phase passed **2,457 tests across 60 complete files**, plus a separate 14-test startup-retry run, in [Testbox run 33542677845](https://github.com/openclaw/openclaw/actions/runs/33542677845). The later lint phase of that run correctly failed on the combined test-file size; five existing HTTP 402/422 cases were then table-driven without dropping inputs or assertions. Counts across these overlapping runs must not be summed.

The initial Linux run also exposed an obsolete startup fixture: it expected native resume overload while retaining a competing lease. The existing real-stdio test now proves both the no-write contention refusal and native overload after legitimate lease release, preserving the same client and binding.

Main's [retry-controller consolidation](https://github.com/openclaw/openclaw/pull/134281) remains intact. Two failing known-reply tests demonstrated that its message-based classification could turn preflight diagnostics into provider overload copy; the guarded known-reply entry fixes that without restoring outer retry loops. Main's [protocol declaration-build repair](https://github.com/openclaw/openclaw/pull/135360) was picked up by rebase, rather than patched around here; all 40 task files remained byte-identical during that rebase.

Fresh isolated Codex reviews covered the complete integrated candidate and the final pending delta: scoped-clean at P0/P1, no findings. Reviewers inspected code/evidence; execution results are recorded separately.

The post-consolidation owner suite passed **78 tests**, and full `pnpm build` passed on exact commit `6a8f0492d3f0bfab5830b72c1102ebe157731d3a` / tree `112f6d7c0fd4aab1c68724161838c4b0a79d2218` in [Testbox run 33561972328](https://github.com/openclaw/openclaw/actions/runs/33561972328). Full `pnpm check` stopped at the assertion-baseline comparison because the prepared checkout was shallow and could not resolve the branch fork; its fallback compared unchanged older-base files against newer main. The unchanged exact-head full `pnpm build` and `pnpm check` then **passed** with complete Git history and the verified original fork in [Testbox run 33565101656](https://github.com/openclaw/openclaw/actions/runs/33565101656), provider `blacksmith-testbox`, lease `tbx_01m1fgfg900589ywy3reb8arpb`; no baseline was edited or bypassed. [Exact-head PR CI](https://github.com/openclaw/openclaw/actions/runs/33563517830) also completed successfully. The final exact-head stock-native rerun also passed on that lease. The local attempt stopped before startup because the interrupted dependency install left `openai/index.js` missing; it is not counted as passing proof. Both ClawSweeper Rank-up moves are addressed: exact-head native/Testbox proof above and [explicit compatibility/LOC acceptance](https://github.com/openclaw/openclaw/pull/135577#issuecomment-5501464930).

<details>
<summary>Exact integrated test command (60 complete files)</summary>

```bash
node scripts/run-vitest.mjs \
  src/agents/failover-error.test.ts \
  src/agents/model-fallback.test.ts \
  src/agents/model-fallback.terminal-boundary.test.ts \
  src/agents/model-fallback.probe.test.ts \
  src/agents/model-fallback-observation.test.ts \
  src/agents/harness/lifecycle.test.ts \
  src/agents/harness/prompt-compaction-hook-helpers.test.ts \
  src/agents/embedded-agent-runner/run.harness-auth-failover.test.ts \
  src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts \
  src/agents/embedded-agent-runner/run/failover-policy.test.ts \
  src/agents/embedded-agent-runner/run/retry-budget.test.ts \
  src/agents/embedded-agent-runner/run/retry-limit.test.ts \
  src/agents/embedded-agent-runner/run/assistant-failover.test.ts \
  src/agents/failover/failover-classification.corpus.test.ts \
  src/auto-reply/reply/agent-runner-failure-reply.test.ts \
  src/auto-reply/reply/agent-runner-execution-conversation-failures.test.ts \
  src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts \
  src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts \
  src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts \
  src/auto-reply/reply/agent-runner-execution-context-failures.test.ts \
  extensions/codex/src/app-server/attempt-client-cleanup.test.ts \
  extensions/codex/src/app-server/attempt-startup-retry.test.ts \
  extensions/codex/src/app-server/attempt-startup.test.ts \
  extensions/codex/src/app-server/auth-profile-runtime-contract.test.ts \
  extensions/codex/src/app-server/client-runtime.test.ts \
  extensions/codex/src/app-server/client.test.ts \
  extensions/codex/src/app-server/compact.test.ts \
  extensions/codex/src/app-server/context-compaction-activity.test.ts \
  extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts \
  extensions/codex/src/app-server/run-attempt-connection.test.ts \
  extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts \
  extensions/codex/src/app-server/run-attempt-runtime.authority.test.ts \
  extensions/codex/src/app-server/run-attempt-state.test.ts \
  extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts \
  extensions/codex/src/app-server/run-attempt-tools.test.ts \
  extensions/codex/src/app-server/run-attempt.agent-end-context.test.ts \
  extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts \
  extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts \
  extensions/codex/src/app-server/run-attempt.context-engine.test.ts \
  extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts \
  extensions/codex/src/app-server/run-attempt.hooks.test.ts \
  extensions/codex/src/app-server/run-attempt.media-lifetime.test.ts \
  extensions/codex/src/app-server/run-attempt.native-hook-relay-retention.test.ts \
  extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts \
  extensions/codex/src/app-server/run-attempt.notification-burst.test.ts \
  extensions/codex/src/app-server/run-attempt.reasoning-effort.test.ts \
  extensions/codex/src/app-server/run-attempt.steering-media.test.ts \
  extensions/codex/src/app-server/run-attempt.steering.test.ts \
  extensions/codex/src/app-server/run-attempt.test.ts \
  extensions/codex/src/app-server/run-attempt.turn-watches.test.ts \
  extensions/codex/src/app-server/run-attempt.usage-limits.test.ts \
  extensions/codex/src/app-server/run-attempt.vision-tools.test.ts \
  extensions/codex/src/app-server/shared-client.test.ts \
  extensions/codex/src/app-server/startup-binding.test.ts \
  extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts \
  extensions/codex/src/app-server/thread-lifecycle.binding.test.ts \
  extensions/codex/src/app-server/thread-lifecycle.configured-mcp-ownership.test.ts \
  extensions/codex/src/app-server/thread-lifecycle.test.ts \
  extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts \
  extensions/codex/src/app-server/transport-startup.test.ts
```

The final isolated worktree also runs the post-consolidation owner test and the full repository gates:

```bash
node scripts/run-vitest.mjs src/agents/failover-error.test.ts
```

```bash
pnpm build
```

```bash
pnpm check
```

</details>

### Scope and tradeoffs

Production LOC: **+348/−177, net +171**. Tests/support: **+2661/−1073, net +1588**. Docs: **+58**. Growth implements accepted configuration proof, volatile incognito-policy continuity, exact warm-owner revalidation, and non-retriable/private failure handling. The ordinary bypass and separate incognito reuse branch were removed; existing policy, ownership, SDK-error, and presentation mechanisms remain canonical.

No full-repository test suite, external model inference, live remote-worker run, native-child live spawn, or stronger supervised external-process attestation is claimed. Local Mac verification encountered filesystem/module-loading stalls and an incomplete, explicitly cancelled dependency install; those are not presented as passing checks or a proven OS/package-manager defect. Linux validation uses fresh lockfile-derived dependencies and exact source identities.

Regression introduction is unknown; no last-known-good release has been established. Documentation: https://docs.openclaw.ai/plugins/codex-harness-runtime#hook-boundaries and https://docs.openclaw.ai/plugins/codex-harness-reference.
