### PR TITLE
fix(ui): explain trusted-proxy login failures

### DIFF
--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -505,6 +505,14 @@ Separate, non-trusted-proxy-specific findings also apply whenever Control UI is 
 
 ## Troubleshooting
 
+### Control UI says Proxy authentication required
+
+The Gateway is reachable, but it rejected proxy authentication or forwarded identity. For `AUTH_IDENTITY_HEADER_REQUIRED`, a required proxy header was missing or blank; this is not a network outage.
+
+Open the configured authenticated proxy or SSO dashboard URL and sign in there instead of visiting the Gateway's loopback URL directly. If the error persists, ask the Gateway administrator to verify identity and required-header forwarding on **WebSocket upgrade requests**, and confirm that the signed-in account is permitted.
+
+A Gateway token cannot replace proxy authentication. Do not send identity headers from the browser, broaden `trustedProxies`, or remove `allowUsers` to work around the rejection.
+
 <AccordionGroup>
   <Accordion title="trusted_proxy_untrusted_source">
     The request didn't come from an IP in `gateway.trustedProxies`. Check:
@@ -524,7 +532,7 @@ Separate, non-trusted-proxy-specific findings also apply whenever Control UI is 
 
     Fix:
 
-    - Prefer token/password auth for internal same-host clients that do not go through the proxy, or
+    - Use an explicitly configured local password for internal same-host clients that do not go through the proxy; token fallback is not supported in trusted-proxy mode, or
     - Route through a non-loopback trusted proxy address and keep that IP in `gateway.trustedProxies`, or
     - For a deliberate same-host reverse proxy, set `gateway.auth.trustedProxy.allowLoopback = true`, keep the loopback address in `gateway.trustedProxies`, and make sure the proxy strips or overwrites identity headers.
 
@@ -556,7 +564,7 @@ Separate, non-trusted-proxy-specific findings also apply whenever Control UI is 
 
   </Accordion>
   <Accordion title="trusted_proxy_user_not_allowed">
-    The user is authenticated but not in `allowUsers`. Either add them or remove the allowlist.
+    The user is authenticated but not in `allowUsers`. Sign in with a permitted account or ask the Gateway administrator to review the intended access policy. Do not remove the allowlist as a connectivity workaround.
   </Accordion>
   <Accordion title="trusted_proxy_no_proxies_configured / trusted_proxy_config_missing">
     `gateway.auth.mode` is `"trusted-proxy"` but `gateway.trustedProxies` is empty, or `gateway.auth.trustedProxy` itself is missing. Every request is rejected until both are set.

--- a/docs/web/dashboard.md
+++ b/docs/web/dashboard.md
@@ -87,10 +87,11 @@ Non-goals for v1:
 - Confirm the gateway is reachable: local `openclaw status`; remote, SSH tunnel `ssh -N -L 18789:127.0.0.1:18789 user@gateway-host` then open `http://127.0.0.1:18789/`.
 - For `AUTH_TOKEN_MISMATCH`, clients may do one trusted retry with a cached device token when the gateway returns retry hints; that retry reuses the token's cached approved scopes (explicit `deviceToken`/`scopes` callers keep their requested scope set). If auth still fails after that retry, resolve token drift manually.
 - For `AUTH_SCOPE_MISMATCH`, the device token was recognized but does not carry the requested scopes; re-pair or approve the new scope set instead of rotating the shared gateway token.
+- For **Proxy authentication required** or `AUTH_IDENTITY_HEADER_REQUIRED`, open the configured proxy/SSO dashboard URL and sign in there. Ask the Gateway administrator to check identity-header forwarding on WebSocket upgrades and account access. A Gateway token cannot override trusted-proxy mode; see [Trusted proxy troubleshooting](/gateway/trusted-proxy-auth#control-ui-says-proxy-authentication-required).
 - Outside that retry path, the Control UI prefers a pending bootstrap token so a fresh host-issued handoff can create or upgrade the browser credential. Without a pending bootstrap, explicit shared token/password take precedence over the stored device token.
 - On the async Tailscale Serve path, failed attempts for the same `{scope, ip}` are serialized before the failed-auth limiter records them, so a second concurrent bad retry can already show `retry later`.
 - For token drift repair steps, see [Token drift recovery checklist](/cli/devices#token-drift-recovery-checklist).
-- Retrieve or supply the shared secret from the gateway host:
+- For shared-secret authentication, retrieve or supply the configured secret from the gateway host:
   - Token: run `openclaw gateway auth-token --show` in an interactive terminal on the Gateway host
   - Password: resolve the configured `gateway.auth.password` or `OPENCLAW_GATEWAY_PASSWORD`
   - SecretRef-managed token: run `openclaw gateway auth-token --show`; if resolution fails, repair the external secret provider and rerun it

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -583,6 +583,7 @@ export class OpenClawApp extends OpenClawLightDomElement {
               connected: gatewayConnected,
               lastError: gatewaySnapshot.lastError,
               lastErrorCode: gatewaySnapshot.lastErrorCode,
+              lastErrorAuthReason: gatewaySnapshot.lastErrorAuthReason,
               hasToken: Boolean(this.loginToken.trim()),
               hasPassword: Boolean(this.loginPassword.trim()),
               gatewayUrl: this.loginGatewayUrl,

--- a/ui/src/app/gateway-store.auth.test.ts
+++ b/ui/src/app/gateway-store.auth.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
+import { setAvatarGatewayOrigin } from "../lib/identity-avatar-context.ts";
+import {
+  createGatewayStoreTestStore as createStore,
+  GATEWAY_STORE_TEST_HELLO as HELLO,
+  stubGatewayStoreTestGlobals,
+} from "./gateway-store.test-support.ts";
+
+describe("createApplicationGateway authentication diagnostics", () => {
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    stubGatewayStoreTestGlobals();
+    store = createStore();
+  });
+
+  afterEach(() => {
+    store.gateway.stop();
+    setAvatarGatewayOrigin(null);
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    {
+      name: "missing-token auth detail",
+      outerCode: "INVALID_REQUEST",
+      detailCode: ConnectErrorDetailCodes.AUTH_TOKEN_MISSING,
+      message: "token missing",
+    },
+    {
+      name: "pairing-required detail",
+      outerCode: "NOT_PAIRED",
+      detailCode: ConnectErrorDetailCodes.PAIRING_REQUIRED,
+      message: "device is not approved",
+    },
+  ])("preserves the structured $name in the login snapshot", (fixture) => {
+    const { gateway, current } = store;
+    gateway.start();
+
+    current().opts.onClose?.({
+      code: 4008,
+      reason: "connect failed",
+      error: {
+        code: fixture.outerCode,
+        message: fixture.message,
+        details: { code: fixture.detailCode },
+      },
+      willRetry: false,
+    });
+
+    expect(gateway.snapshot.lastError).toBe(fixture.message);
+    expect(gateway.snapshot.lastErrorCode).toBe(fixture.detailCode);
+  });
+
+  it.each([
+    {
+      name: "missing user",
+      authReason: "trusted_proxy_user_missing",
+      expected: "trusted_proxy_user_missing",
+    },
+    {
+      name: "attribution",
+      authReason: "proxy_attribution_required",
+      expected: "proxy_attribution_required",
+    },
+    { name: "unknown reason", authReason: "trusted_proxy_unknown", expected: null },
+    { name: "oversized reason", authReason: "unrecognized".repeat(1_000), expected: null },
+    {
+      name: "non-string reason",
+      authReason: { reason: "trusted_proxy_user_missing" },
+      expected: null,
+    },
+    { name: "absent reason", authReason: undefined, expected: null },
+  ])("projects only recognized auth reasons: $name", ({ authReason, expected }) => {
+    const { gateway, current } = store;
+    gateway.start();
+    current().opts.onClose?.({
+      code: 1008,
+      reason: "unauthorized",
+      error: {
+        code: "INVALID_REQUEST",
+        message: "unauthorized",
+        details: { code: ConnectErrorDetailCodes.AUTH_UNAUTHORIZED, authReason },
+      },
+      willRetry: false,
+    });
+    expect(gateway.snapshot.lastErrorAuthReason).toBe(expected);
+  });
+
+  it("keeps proxy rejection reasons scoped to the current failed connection", () => {
+    const { gateway, current } = store;
+    gateway.start();
+    const rejection = {
+      code: 1008,
+      reason: "unauthorized",
+      error: {
+        code: "INVALID_REQUEST",
+        message: "unauthorized",
+        details: {
+          code: ConnectErrorDetailCodes.AUTH_UNAUTHORIZED,
+          authReason: "trusted_proxy_user_not_allowed",
+        },
+      },
+      willRetry: false,
+    };
+    current().opts.onClose?.(rejection);
+    expect(gateway.snapshot.lastErrorAuthReason).toBe("trusted_proxy_user_not_allowed");
+
+    const stale = current();
+    gateway.connect();
+    expect(gateway.snapshot.lastErrorAuthReason).toBeNull();
+    stale.opts.onClose?.(rejection);
+    expect(gateway.snapshot.lastErrorAuthReason).toBeNull();
+
+    current().opts.onClose?.(rejection);
+    current().opts.onHello?.(HELLO);
+    expect(gateway.snapshot.lastErrorAuthReason).toBeNull();
+    current().opts.onClose?.(rejection);
+    current().opts.onClose?.({ code: 1006, reason: "socket lost", willRetry: true });
+    expect(gateway.snapshot.lastErrorAuthReason).toBeNull();
+    current().opts.onClose?.(rejection);
+    gateway.stop();
+    expect(gateway.snapshot.lastErrorAuthReason).toBeNull();
+  });
+
+  it("preserves an outer code when a transport failure has no structured detail", () => {
+    const { gateway, current } = store;
+    gateway.start();
+
+    current().opts.onClose?.({
+      code: 1006,
+      reason: "websocket error",
+      error: { code: "UNAVAILABLE", message: "WebSocket connection failed" },
+      willRetry: false,
+    });
+
+    expect(gateway.snapshot.lastError).toBe("WebSocket connection failed");
+    expect(gateway.snapshot.lastErrorCode).toBe("UNAVAILABLE");
+  });
+});

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -136,53 +136,6 @@ describe("createApplicationGateway connection phase", () => {
     expect(gateway.snapshot.phase).toBe("connected");
   });
 
-  it.each([
-    {
-      name: "missing-token auth detail",
-      outerCode: "INVALID_REQUEST",
-      detailCode: ConnectErrorDetailCodes.AUTH_TOKEN_MISSING,
-      message: "token missing",
-    },
-    {
-      name: "pairing-required detail",
-      outerCode: "NOT_PAIRED",
-      detailCode: ConnectErrorDetailCodes.PAIRING_REQUIRED,
-      message: "device is not approved",
-    },
-  ])("preserves the structured $name in the login snapshot", (fixture) => {
-    const { gateway, current } = createStore();
-    gateway.start();
-
-    current().opts.onClose?.({
-      code: 4008,
-      reason: "connect failed",
-      error: {
-        code: fixture.outerCode,
-        message: fixture.message,
-        details: { code: fixture.detailCode },
-      },
-      willRetry: false,
-    });
-
-    expect(gateway.snapshot.lastError).toBe(fixture.message);
-    expect(gateway.snapshot.lastErrorCode).toBe(fixture.detailCode);
-  });
-
-  it("preserves an outer code when a transport failure has no structured detail", () => {
-    const { gateway, current } = createStore();
-    gateway.start();
-
-    current().opts.onClose?.({
-      code: 1006,
-      reason: "websocket error",
-      error: { code: "UNAVAILABLE", message: "WebSocket connection failed" },
-      willRetry: false,
-    });
-
-    expect(gateway.snapshot.lastError).toBe("WebSocket connection failed");
-    expect(gateway.snapshot.lastErrorCode).toBe("UNAVAILABLE");
-  });
-
   it("does not invent an assistant agent id before the gateway advertises one", () => {
     const { gateway, current } = createStore();
 

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -19,6 +19,7 @@ import {
 import { CONTROL_UI_BUILD_INFO, controlUiBuildDiffersFrom } from "../build-info.ts";
 import { t } from "../i18n/index.ts";
 import { bumpCanvasWidgetFrameConnectionGeneration } from "../lib/chat/canvas-widget-frame-generation.ts";
+import { readConnectionAuthReason } from "../lib/connection-hints.ts";
 import { formatUiError, formatUiExternalText } from "../lib/format-error.ts";
 import { setAvatarGatewayOrigin } from "../lib/identity-avatar-context.ts";
 import { resolveSessionKey } from "../lib/sessions/index.ts";
@@ -113,6 +114,7 @@ export function createApplicationGateway(
     sessionKey: settings.sessionKey,
     lastError: null,
     lastErrorCode: null,
+    lastErrorAuthReason: null,
     selfUser: null,
   };
   let client: GatewayBrowserClient | null = null;
@@ -450,6 +452,7 @@ export function createApplicationGateway(
             selfUser: null,
             lastError: null,
             lastErrorCode: null,
+            lastErrorAuthReason: null,
           });
           const targetBuildId = hello.server?.buildId?.trim() || hello.server?.version?.trim();
           if (targetBuildId) {
@@ -500,6 +503,7 @@ export function createApplicationGateway(
           sessionKey,
           lastError: null,
           lastErrorCode: null,
+          lastErrorAuthReason: null,
           selfUser: resolveSelfPresenceUser(
             readPresenceEntries(hello.snapshot) ?? [],
             nextClient.instanceId,
@@ -566,6 +570,7 @@ export function createApplicationGateway(
               ? formatUiError(error.message)
               : `disconnected (${code}): ${formatUiExternalText(reason, t("common.unknown"))}`,
           lastErrorCode: startupPending ? null : lastErrorCode,
+          lastErrorAuthReason: startupPending ? null : readConnectionAuthReason(error?.details),
         });
       },
       onGap: ({ expected, received }) => {
@@ -576,6 +581,7 @@ export function createApplicationGateway(
           ...snapshot,
           lastError: `event gap detected (expected seq ${expected}, got ${received}); reconnecting`,
           lastErrorCode: null,
+          lastErrorAuthReason: null,
         });
         if (isCurrentClient(nextClient)) {
           connect();
@@ -612,6 +618,7 @@ export function createApplicationGateway(
       sessionKey: nextSessionKey,
       lastError: null,
       lastErrorCode: null,
+      lastErrorAuthReason: null,
     });
     if (isCurrentClient(nextClient)) {
       nextClient.start();
@@ -664,6 +671,7 @@ export function createApplicationGateway(
         selfUser: null,
         lastError: null,
         lastErrorCode: null,
+        lastErrorAuthReason: null,
       });
     },
     subscribe: (listener) => {

--- a/ui/src/app/gateway.ts
+++ b/ui/src/app/gateway.ts
@@ -23,6 +23,7 @@ export type ApplicationGatewaySnapshot = {
   sessionKey: string;
   lastError: string | null;
   lastErrorCode: string | null;
+  lastErrorAuthReason?: string | null;
   /** Identity projected from this browser connection's own presence entry. */
   selfUser?: AuthenticatedUser | null;
 };

--- a/ui/src/components/login-gate.test.ts
+++ b/ui/src/components/login-gate.test.ts
@@ -9,18 +9,21 @@ type LoginGateElement = HTMLElement & {
   updateComplete: Promise<boolean>;
 };
 
-async function mountFailure(lastError: string, lastErrorCode: string | null) {
+async function mountFailure(
+  lastError: string,
+  lastErrorCode: string | null,
+  credentials = { token: "", password: "" },
+) {
   const element = document.createElement("openclaw-login-gate") as LoginGateElement;
   element.props = {
     resourceBasePath: "",
     connected: false,
     lastError,
     lastErrorCode,
-    hasToken: false,
-    hasPassword: false,
+    hasToken: Boolean(credentials.token),
+    hasPassword: Boolean(credentials.password),
     gatewayUrl: "ws://127.0.0.1:18789",
-    token: "",
-    password: "",
+    ...credentials,
     showGatewayToken: false,
     showGatewayPassword: false,
     onGatewayUrlChange: vi.fn(),
@@ -43,6 +46,34 @@ afterEach(() => {
 });
 
 describe("login gate failure recovery", () => {
+  it.each([
+    { name: "empty", token: "", password: "" },
+    { name: "populated", token: "test-token", password: "test-password" },
+  ])("explains missing identity headers with $name credentials", async ({ token, password }) => {
+    const element = await mountFailure(
+      "unauthorized",
+      ConnectErrorDetailCodes.AUTH_IDENTITY_HEADER_REQUIRED,
+      { token, password },
+    );
+    const failure = element.querySelector(".login-gate__failure");
+    const steps = failure?.querySelector(".login-gate__failure-steps")?.textContent;
+
+    expect(failure?.getAttribute("data-kind")).toBe("trusted-proxy");
+    expect(steps).toMatch(/(?:open|use|sign in).*?(?:authenticated proxy|SSO).*?URL/iu);
+    expect(steps).toMatch(/configured/iu);
+    expect(failure?.textContent).toMatch(
+      /missing.*?identity[- ]headers?|identity[- ]headers?.*?missing/iu,
+    );
+    expect(steps).toMatch(/forward/iu);
+    expect(steps).toMatch(/WebSocket upgrade/iu);
+    expect(failure?.querySelector(".login-gate__failure-docs")?.getAttribute("href")).toBe(
+      "https://docs.openclaw.ai/gateway/trusted-proxy-auth",
+    );
+    expect(failure?.querySelector(".login-gate__failure-raw")?.textContent).toBe("unauthorized");
+    expect(failure?.querySelectorAll(".login-gate__failure-steps code")).toHaveLength(0);
+    expect(steps).not.toMatch(/generate.*?token|replace.*?(?:token|password)|Gateway is running/iu);
+  });
+
   it.each([
     "Authenticated profile verification is unavailable; retry the request.",
     "GitHub is rate limiting profile verification. Retry shortly; if this continues, ask a gateway administrator to check the GitHub API credential.",

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -20,6 +20,7 @@ import { icons } from "./icons.ts";
 type LoginFailureKind =
   | "auth-required"
   | "auth-failed"
+  | "trusted-proxy"
   | "auth-rate-limited"
   | "profile-unavailable"
   | "pairing-required"
@@ -51,13 +52,8 @@ type LoginFailureFeedback = {
   rawError: string;
 };
 
-type LoginGateProps = {
+type LoginGateProps = LoginFailureFeedbackParams & {
   resourceBasePath: string;
-  connected: boolean;
-  lastError: string | null;
-  lastErrorCode?: string | null;
-  hasToken: boolean;
-  hasPassword: boolean;
   gatewayUrl: string;
   token: string;
   password: string;
@@ -71,13 +67,7 @@ type LoginGateProps = {
   onConnect: () => void;
 };
 
-type LoginFailureFeedbackParams = {
-  connected: boolean;
-  lastError: string | null;
-  lastErrorCode?: string | null;
-  hasToken: boolean;
-  hasPassword: boolean;
-};
+type LoginFailureFeedbackParams = Parameters<typeof resolveAuthHintKind>[0];
 
 function buildFeedback(params: {
   kind: LoginFailureKind;
@@ -253,6 +243,20 @@ function resolveLoginFailureFeedback(
   }
 
   const authHintKind = resolveAuthHintKind(params);
+  if (authHintKind === "trusted-proxy") {
+    return buildFeedback({
+      kind: "trusted-proxy",
+      rawError,
+      titleKey: "login.failure.trustedProxy.title",
+      summaryKey: "login.failure.trustedProxy.summary",
+      stepKeys: [
+        "login.failure.trustedProxy.stepSignIn",
+        "login.failure.trustedProxy.stepHeaders",
+        "login.failure.trustedProxy.stepNoToken",
+      ],
+      docsHref: "https://docs.openclaw.ai/gateway/trusted-proxy-auth",
+    });
+  }
   if (authHintKind === "required") {
     return buildFeedback({
       kind: "auth-required",

--- a/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { captureControlUiE2eFailureDiagnostics } from "../test-helpers/control-ui-e2e.ts";
 import {
   createChatFlowE2eSuite,
   expectRequestCountStable,
@@ -362,11 +363,34 @@ suite.define(() => {
       await keyboardRow.locator(".chat-queue__remove").focus();
       await page.keyboard.press("Enter");
       await keyboardRow.waitFor({ state: "detached", timeout: 10_000 });
-      const programmaticRow = await queueDisposable("programmatic removal");
-      await programmaticRow
-        .locator(".chat-queue__remove")
-        .evaluate((button: HTMLElement) => button.click());
+      // Remove at the first DOM commit, before yielded delivery can resume.
+      // Programmatic activation must keep cancellation exact even at this boundary.
+      const removal = await page.evaluateHandle(() => {
+        let removed = false;
+        const observer = new MutationObserver(() => {
+          const queuedRow = [...document.querySelectorAll(".chat-queue__item")].find(
+            (item) =>
+              item.querySelector(".chat-queue__text")?.textContent === "programmatic removal",
+          );
+          const button = queuedRow?.querySelector<HTMLButtonElement>(".chat-queue__remove");
+          if (button) {
+            observer.disconnect();
+            button.click();
+            removed = true;
+          }
+        });
+        observer.observe(document, { childList: true, subtree: true });
+        return { wasRemoved: () => removed };
+      });
+      await composer.fill("programmatic removal");
+      await composer.press("Enter");
+      await expect.poll(() => removal.evaluate((proof) => proof.wasRemoved())).toBe(true);
+      await removal.dispose();
+      const programmaticRow = page.locator(".chat-queue__item", {
+        hasText: "programmatic removal",
+      });
       await programmaticRow.waitFor({ state: "detached", timeout: 10_000 });
+      await expectRequestCountStable(gateway, "chat.send", 1);
       await page.getByRole("alert").waitFor({ state: "detached", timeout: 10_000 });
       expect(await gateway.getRequests("chat.send")).toHaveLength(1);
       if (artifactDir) {
@@ -431,6 +455,12 @@ suite.define(() => {
       if (artifactDir) {
         await page.screenshot({ path: `${artifactDir}/03-exact-drain.png`, fullPage: true });
       }
+    } catch (error) {
+      await captureControlUiE2eFailureDiagnostics(page, {
+        error: error instanceof Error ? error : new Error(String(error)),
+        label: "queue-edit-reconnect",
+      });
+      throw error;
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/chat-outbox-payloads.e2e.test.ts
+++ b/ui/src/e2e/chat-outbox-payloads.e2e.test.ts
@@ -1,4 +1,3 @@
-import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { assert, expect, it } from "vitest";
@@ -17,7 +16,6 @@ import {
 } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
-const proofDir = path.resolve(".artifacts/control-ui-e2e/outbox-capacity/after");
 const file = {
   name: "mock-original.txt",
   mimeType: "text/plain",
@@ -73,6 +71,33 @@ async function readPayloadBytes(page: Page, key: string): Promise<string[] | nul
   );
 }
 
+async function readComposerDraftContents(page: Page) {
+  return page.evaluate(async () => {
+    const result = <T>(request: IDBRequest<T>) =>
+      new Promise<T>((resolve, reject) => {
+        request.addEventListener("success", () => resolve(request.result), { once: true });
+        request.addEventListener(
+          "error",
+          () => reject(request.error ?? new Error("IndexedDB request failed")),
+          { once: true },
+        );
+      });
+    const database = await result(indexedDB.open("openclaw-control-ui"));
+    try {
+      const drafts = (await result(
+        database.transaction("composerDrafts").objectStore("composerDrafts").getAll(),
+      )) as Array<{ text: string; attachments: unknown[]; goalMode?: unknown }>;
+      return drafts.map((draft) => ({
+        text: draft.text,
+        attachmentCount: draft.attachments.length,
+        goalMode: draft.goalMode ?? null,
+      }));
+    } finally {
+      database.close();
+    }
+  });
+}
+
 async function stage(page: Page, message: string) {
   await composerFor(page).fill(message);
   await paneFor(page).locator(".agent-chat__file-input").setInputFiles(file);
@@ -117,6 +142,11 @@ suite.define(() => {
             reference,
             "Admission must own the complete Blob before seeding the legacy envelope",
           );
+          // Queue admission precedes durable composer clearing. Finish the fixture
+          // before navigation can abort that write and restore an occupied destination.
+          await expect
+            .poll(() => readComposerDraftContents(page))
+            .toEqual([{ text: "", attachmentCount: 0, goalMode: null }]);
           await page.route("**/outbox-legacy-seed", (route) =>
             route.fulfill({ contentType: "text/html", body: "Synthetic v3 metadata seed" }),
           );
@@ -181,6 +211,10 @@ suite.define(() => {
             await notice.getByRole("button", { name: "Restore here for review" }).click();
             const dialog = page.locator("openclaw-modal-dialog");
             await dialog.getByText(`${destination} (main)`, { exact: true }).waitFor();
+            await page.screenshot({
+              path: path.join(suite.artifactDir, "v3-global-destination-confirmation.png"),
+              animations: "disabled",
+            });
             await dialog.getByRole("button", { name: "Restore here for review" }).click();
           }
           await paneFor(page).getByText("Delivery unconfirmed", { exact: true }).waitFor();
@@ -198,10 +232,9 @@ suite.define(() => {
             file.buffer.toString("base64"),
           ]);
           await expectRequestCountStable(gateway, "chat.send", 0);
-          await mkdir(proofDir, { recursive: true });
           await page.screenshot({
             path: path.join(
-              proofDir,
+              suite.artifactDir,
               `v3-${legacySessionKey === "global" ? "recovered" : "named"}-paused.png`,
             ),
             fullPage: true,
@@ -242,7 +275,7 @@ suite.define(() => {
       {
         serviceWorkers: "block",
         viewport: { width: 1280, height: 900 },
-        recordVideo: { dir: path.join(proofDir, "lifecycle-video") },
+        recordVideo: { dir: path.join(suite.artifactDir, "lifecycle-video") },
       },
       async ({ page }) => {
         const gateway = await installMockGateway(page, {
@@ -288,7 +321,7 @@ suite.define(() => {
         await expectRequestCountStable(gateway, "chat.send", 0);
         expect((await readQueue(page))[0]?.sendRunId).toBe(queued.sendRunId);
         await page.screenshot({
-          path: path.join(proofDir, "reload-unconfirmed.png"),
+          path: path.join(suite.artifactDir, "reload-unconfirmed.png"),
           fullPage: true,
           animations: "disabled",
         });
@@ -567,9 +600,8 @@ suite.define(() => {
           expect((await readQueue(duplicate))[0]?.attachmentPayload).toEqual(reference);
           const row = paneFor(duplicate).locator(".chat-queue__item");
           await expect.poll(() => row.count()).toBe(1);
-          await mkdir(proofDir, { recursive: true });
           await duplicate.screenshot({
-            path: path.join(proofDir, "duplicate-before-claim-removal.png"),
+            path: path.join(suite.artifactDir, "duplicate-before-claim-removal.png"),
             fullPage: true,
             animations: "disabled",
           });
@@ -604,7 +636,7 @@ suite.define(() => {
           });
           await page.bringToFront();
           await page.screenshot({
-            path: path.join(proofDir, "source-after-duplicate-removal.png"),
+            path: path.join(suite.artifactDir, "source-after-duplicate-removal.png"),
             fullPage: true,
             animations: "disabled",
           });
@@ -746,17 +778,9 @@ suite.define(() => {
       await row.dblclick();
       await row.locator(".chat-queue__edit-input").fill("Mock Gateway: edited with original bytes");
       await row.locator(".chat-queue__edit-submit").click();
-      try {
-        await expect
-          .poll(async () => (await readQueue(page))[0]?.text)
-          .toBe("Mock Gateway: edited with original bytes");
-      } catch (error) {
-        const bodyText = await page.locator("body").textContent();
-        assert(bodyText !== null, "Expected a body for the failure capture");
-        await writeFile(path.join(proofDir, "upgrade-failure.txt"), bodyText);
-        await page.screenshot({ path: path.join(proofDir, "upgrade-failure.png"), fullPage: true });
-        throw error;
-      }
+      await expect
+        .poll(async () => (await readQueue(page))[0]?.text)
+        .toBe("Mock Gateway: edited with original bytes");
       expect((await readQueue(page))[0]?.attachmentPayload).toBeDefined();
       expect(await composerFor(page).inputValue()).toBe("Mock Gateway: newer independent draft");
       expect(await paneFor(page).locator(".chat-attachment-thumb").count()).toBe(1);
@@ -916,7 +940,7 @@ suite.define(() => {
       await expectRequestCountStable(gateway, "chat.send", 0);
       expect((await readQueue(page))[0]?.id).toBe(original.id);
       await page.screenshot({
-        path: path.join(proofDir, "corrupt-payload-retained.png"),
+        path: path.join(suite.artifactDir, "corrupt-payload-retained.png"),
         animations: "disabled",
         fullPage: true,
       });

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -1000,6 +1000,9 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
   it("confirms gatewayUrl, accepts the allowed origin, and rejects an unlisted origin", async () => {
     const rejected = await createBrowserPage(rejectedUi.baseUrl, proxy.trustedUrl);
     await waitForVisibleFailure(rejected.page, "origin not allowed");
+    const originFailure = rejected.page.locator(".login-gate__failure");
+    expect(await originFailure.getAttribute("data-kind")).toBe("origin-not-allowed");
+    expect(await originFailure.locator(".login-gate__command").count()).toBe(0);
     const rejectedOrigin = new URL(rejectedUi.baseUrl).origin;
     const rejectedEvidence = await waitForConnectionEvidence(
       (entry) =>

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -851,6 +851,16 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
     );
     expect(untrustedEvidence.gatewayResult?.message).toContain("unauthorized");
     expect(untrustedEvidence.gatewayResult?.errorReason).toBe(expectedReason);
+    expect(untrustedEvidence.gatewayResult?.errorCode).toBe(
+      ConnectErrorDetailCodes.AUTH_IDENTITY_HEADER_REQUIRED,
+    );
+    const failure = rejected.page.locator(".login-gate__failure");
+    expect(await failure.getAttribute("data-kind")).toBe("trusted-proxy");
+    expect(await failure.locator(".login-gate__failure-steps").textContent()).toContain("SSO");
+    expect(await failure.locator(".login-gate__failure-steps").textContent()).toContain(
+      "WebSocket upgrade",
+    );
+    expect(await failure.locator(".login-gate__command").count()).toBe(0);
     expect(untrustedEvidence.identityInjected).toBe(false);
     expect(untrustedEvidence.requiredHeaderInjected).toBe(false);
     await captureChromiumScreenshot(rejected.page, "02-untrusted-proxy-rejected.png");

--- a/ui/src/e2e/control-ui-e2e-suite.test-support.ts
+++ b/ui/src/e2e/control-ui-e2e-suite.test-support.ts
@@ -2,6 +2,7 @@ import { chromium, type Browser, type BrowserContext, type Locator, type Page } 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, inject } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
+  captureControlUiE2eFailureDiagnostics,
   controlUiE2eWaitTimeoutMs,
   startControlUiE2eServer,
   type ControlUiE2eServer,
@@ -193,7 +194,15 @@ export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): Cont
       const context = await newBrowserContext(contextOptions);
       try {
         const page = await context.newPage();
-        return await run({ context, page });
+        try {
+          return await run({ context, page });
+        } catch (error) {
+          await captureControlUiE2eFailureDiagnostics(page, {
+            error: error instanceof Error ? error : new Error(String(error)),
+            label: options.name,
+          });
+          throw error;
+        }
       } finally {
         await closeBrowserContext(context);
       }

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -369,6 +369,16 @@ suite.define(() => {
       expectedTitle: "Proxy authentication required",
     },
     {
+      name: "disallowed browser origin",
+      error: {
+        code: "INVALID_REQUEST",
+        message: "origin not allowed",
+        details: { code: ConnectErrorDetailCodes.CONTROL_UI_ORIGIN_NOT_ALLOWED },
+      },
+      expectedKind: "origin-not-allowed",
+      expectedTitle: "Browser origin not allowed",
+    },
+    {
       name: "pairing approval",
       error: {
         code: "NOT_PAIRED",

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -4,7 +4,10 @@ import type { BrowserContext, Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
-import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import {
+  captureControlUiE2eFailureDiagnostics,
+  installMockGateway,
+} from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -427,14 +430,19 @@ suite.define(() => {
       recordVideo: { dir: RECOVERY_ARTIFACT_DIR, size: viewport },
     });
     const page = await context.newPage();
-    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+    const gateway = await installMockGateway(page, {
+      methodResponses: { connect: { __mockError: fixture.error } },
+    });
 
     try {
       await page.goto(suite.server.baseUrl);
       await gateway.waitForRequest("connect");
-      await gateway.rejectDeferred("connect", fixture.error);
 
       await page.locator(".login-gate__failure").waitFor();
+      // Retryable guidance must survive a real reconnect, including time spent capturing proof.
+      if (fixture.error.code === "UNAVAILABLE") {
+        await gateway.waitForRequest("connect", { after: 1 });
+      }
       await page.screenshot({
         path: path.join(RECOVERY_ARTIFACT_DIR, "login-failure.png"),
         fullPage: true,
@@ -445,6 +453,12 @@ suite.define(() => {
       expect(await failure.locator(".login-gate__failure-title").textContent()).toBe(
         fixture.expectedTitle,
       );
+    } catch (error) {
+      await captureControlUiE2eFailureDiagnostics(page, {
+        error: error instanceof Error ? error : new Error(String(error)),
+        label: `login-guidance-${fixture.name}`,
+      });
+      throw error;
     } finally {
       await closeContext(context);
     }

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -346,6 +346,29 @@ suite.define(() => {
       expectedTitle: "Auth required",
     },
     {
+      name: "missing identity header",
+      error: {
+        code: "INVALID_REQUEST",
+        message: "unauthorized",
+        details: { code: ConnectErrorDetailCodes.AUTH_IDENTITY_HEADER_REQUIRED },
+      },
+      expectedKind: "trusted-proxy",
+      expectedTitle: "Proxy authentication required",
+    },
+    {
+      name: "proxy account rejection",
+      error: {
+        code: "INVALID_REQUEST",
+        message: "unauthorized",
+        details: {
+          code: ConnectErrorDetailCodes.AUTH_UNAUTHORIZED,
+          authReason: "trusted_proxy_user_not_allowed",
+        },
+      },
+      expectedKind: "trusted-proxy",
+      expectedTitle: "Proxy authentication required",
+    },
+    {
       name: "pairing approval",
       error: {
         code: "NOT_PAIRED",

--- a/ui/src/e2e/mobile-sidebar-session-menu.e2e.test.ts
+++ b/ui/src/e2e/mobile-sidebar-session-menu.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { captureControlUiE2eFailureDiagnostics } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   captureUiProof,
@@ -85,6 +86,12 @@ suite.define(() => {
       expect(backBox.y).toBeGreaterThanOrEqual(menuBox.y);
       expect(backBox.y + backBox.height).toBeLessThanOrEqual(menuBox.y + menuBox.height);
       await captureUiProof(suite, page, "mobile-sidebar-session-menu-after-group-drilldown.png");
+    } catch (error) {
+      await captureControlUiE2eFailureDiagnostics(page, {
+        error: error instanceof Error ? error : new Error(String(error)),
+        label: "mobile-sidebar-session-menu",
+      });
+      throw error;
     } finally {
       await context.close();
     }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5035,6 +5035,16 @@ export const en: TranslationMap & {
         stepMode:
           "Use one matching auth mode at a time: gateway token for token mode, password for password mode.",
       },
+      trustedProxy: {
+        title: "Proxy authentication required",
+        summary:
+          "The Gateway is reachable, but it rejected the proxy identity or forwarding information.",
+        stepSignIn:
+          "Open the configured authenticated proxy or SSO dashboard URL and sign in there, rather than visiting the Gateway directly.",
+        stepHeaders:
+          "Ask the Gateway administrator to check for missing identity headers and required-header forwarding on WebSocket upgrade requests, and confirm your account is permitted.",
+        stepNoToken: "A Gateway token cannot replace proxy authentication.",
+      },
       rateLimited: {
         title: "Too many failed attempts",
         summary: "The Gateway is temporarily limiting authentication attempts for this client.",

--- a/ui/src/lib/connection-hints.node.test.ts
+++ b/ui/src/lib/connection-hints.node.test.ts
@@ -147,17 +147,93 @@ describe("resolveAuthHintKind", () => {
     ).toBe("failed");
   });
 
-  it("does not treat generic connect failures as auth failures", () => {
+  it.each([
+    ["empty credentials", false, false, "unauthorized"],
+    ["token", true, false, "connect failed"],
+    ["password", false, true, "unauthorized"],
+    ["both credentials", true, true, "connect failed"],
+  ])("uses the identity-header code with %s", (_name, hasToken, hasPassword, lastError) => {
     expect(
       resolveAuthHintKind({
         connected: false,
-        lastError: "disconnected (4008): connect failed",
-        lastErrorCode: ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED,
-        hasToken: true,
+        lastError,
+        lastErrorCode: ConnectErrorDetailCodes.AUTH_IDENTITY_HEADER_REQUIRED,
+        hasToken,
+        hasPassword,
+      }),
+    ).toBe("trusted-proxy");
+  });
+
+  it.each([
+    ["connected clients", true, "unauthorized"],
+    ["missing errors", false, null],
+    ["empty errors", false, ""],
+  ])("ignores the identity-header code for %s", (_name, connected, lastError) => {
+    expect(
+      resolveAuthHintKind({
+        connected,
+        lastError,
+        lastErrorCode: ConnectErrorDetailCodes.AUTH_IDENTITY_HEADER_REQUIRED,
+        hasToken: false,
         hasPassword: false,
       }),
     ).toBeNull();
   });
+
+  it.each([ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED, "UNKNOWN_CONNECT_ERROR"])(
+    "does not infer auth from unauthorized when the structured code is %s",
+    (lastErrorCode) => {
+      expect(
+        resolveAuthHintKind({
+          connected: false,
+          lastError: "unauthorized",
+          lastErrorCode,
+          hasToken: true,
+          hasPassword: false,
+        }),
+      ).toBeNull();
+    },
+  );
+
+  it.each([
+    "trusted_proxy_no_request",
+    "trusted_proxy_untrusted_source",
+    "trusted_proxy_loopback_source",
+    "trusted_proxy_local_interface_check_failed",
+    "trusted_proxy_local_interface_source",
+    "trusted_proxy_user_missing",
+    "trusted_proxy_user_not_allowed",
+    "trusted_proxy_config_missing",
+    "trusted_proxy_no_proxies_configured",
+    "proxy_attribution_required",
+  ])("classifies the structured proxy denial %s without token advice", (lastErrorAuthReason) => {
+    expect(
+      resolveAuthHintKind({
+        connected: false,
+        lastError: "unauthorized",
+        lastErrorCode: ConnectErrorDetailCodes.AUTH_UNAUTHORIZED,
+        lastErrorAuthReason,
+        hasToken: true,
+        hasPassword: true,
+      }),
+    ).toBe("trusted-proxy");
+  });
+
+  it.each([undefined, "unknown", "trusted_proxy_unknown"])(
+    "does not infer proxy authentication from an unrecognized reason %s",
+    (lastErrorAuthReason) => {
+      expect(
+        resolveAuthHintKind({
+          connected: false,
+          lastError: "unauthorized: trusted_proxy_user_missing",
+          lastErrorCode: ConnectErrorDetailCodes.AUTH_UNAUTHORIZED,
+          lastErrorAuthReason,
+          hasToken: false,
+          hasPassword: false,
+        }),
+      ).toBe("failed");
+    },
+  );
 
   it("falls back to unauthorized string matching without structured codes", () => {
     expect(

--- a/ui/src/lib/connection-hints.ts
+++ b/ui/src/lib/connection-hints.ts
@@ -1,3 +1,4 @@
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 // Connection-failure hint classification shared by the login gate.
 import {
@@ -35,7 +36,27 @@ const INSECURE_CONTEXT_CODES = new Set<string>([
   ConnectErrorDetailCodes.DEVICE_IDENTITY_REQUIRED,
 ]);
 
-type AuthHintKind = "required" | "failed";
+const PROXY_AUTH_REASONS = new Set<string>([
+  "trusted_proxy_no_request",
+  "trusted_proxy_untrusted_source",
+  "trusted_proxy_loopback_source",
+  "trusted_proxy_local_interface_check_failed",
+  "trusted_proxy_local_interface_source",
+  "trusted_proxy_user_missing",
+  "trusted_proxy_user_not_allowed",
+  "trusted_proxy_config_missing",
+  "trusted_proxy_no_proxies_configured",
+  "proxy_attribution_required",
+]);
+
+// Generic unauthorized codes need their proxy reason; retain only these fixed
+// producer values rather than arbitrary server details in the application snapshot.
+export function readConnectionAuthReason(details: unknown): string | null {
+  const reason = asNullableRecord(details)?.authReason;
+  return typeof reason === "string" && PROXY_AUTH_REASONS.has(reason) ? reason : null;
+}
+
+type AuthHintKind = "required" | "failed" | "trusted-proxy";
 
 type PairingHint =
   | {
@@ -85,6 +106,7 @@ export function resolveAuthHintKind(params: {
   connected: boolean;
   lastError: string | null;
   lastErrorCode?: string | null;
+  lastErrorAuthReason?: string | null;
   hasToken: boolean;
   hasPassword: boolean;
 }): AuthHintKind | null {
@@ -92,6 +114,14 @@ export function resolveAuthHintKind(params: {
     return null;
   }
   if (params.lastErrorCode) {
+    if (
+      params.lastErrorCode === ConnectErrorDetailCodes.AUTH_IDENTITY_HEADER_REQUIRED ||
+      (params.lastErrorCode === ConnectErrorDetailCodes.AUTH_UNAUTHORIZED &&
+        typeof params.lastErrorAuthReason === "string" &&
+        PROXY_AUTH_REASONS.has(params.lastErrorAuthReason))
+    ) {
+      return "trusted-proxy";
+    }
     if (!AUTH_FAILURE_CODES.has(params.lastErrorCode)) {
       return null;
     }

--- a/ui/src/pages/chat/chat-send-delivery.ts
+++ b/ui/src/pages/chat/chat-send-delivery.ts
@@ -580,7 +580,7 @@ export async function deliverChatQueueItem(
       candidate.queue.some((entry) => entry.id === item.id),
     );
     if (!outbox) {
-      setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
+      // Admission succeeded; removal or another drain can retire the row while we yield.
       return "pending";
     }
     let drainResult: QueuedChatSendResult | undefined;


### PR DESCRIPTION
Closes #135556 (Control UI mislabels trusted-proxy identity rejection).

Related: #133799 (personal GitHub account connections), where this pre-existing diagnostic mismatch was observed. That PR did not introduce it and is not changed by this work.

## What Problem This Solves

Users opening the Control UI without the identity headers required by their trusted proxy saw **Could not connect** and Gateway-running/network advice, even though the Gateway was reachable and correctly rejecting authentication. Other structured proxy denials lost their specific reason and received token-replacement advice instead.

Landing CI also exposed a queue-cancellation race: removing a queued message during the deliberate post-admission input yield could let the resumed delivery task falsely report a reconnect-storage failure.

## Why This Change Was Made

Preserve the Gateway's bounded, recognized proxy-rejection reason through the UI snapshot and classify it in the existing connection-hint owner. The renderer reuses localized feedback/redaction to point users to their configured authenticated proxy/SSO URL and administrator-owned WebSocket identity-header checks.

Gateway authentication enforcement, protocol codes, trust lists, account allowlists, and configuration semantics are unchanged. A pasted Gateway token does not override proxy authentication. Tailscale alternatives and browser-Origin recovery stay separate. Main's redactor move and lazy login renderer are preserved. Duplicate login parameter declarations are consolidated; authentication snapshot tests use a focused sibling suite and the existing harness. Nearby docs no longer imply token fallback or removing an account allowlist.

The queue repair deletes a false error assignment at the delivery owner: once durable admission has succeeded, an absent row may have been intentionally removed or retired by another drain. Real storage-write failures keep their existing diagnostics. The browser regression deterministically removes the row at its first DOM commit, before delivery resumes, without replacing browser APIs or changing timeouts.

## User Impact

Proxy failures now produce **Proxy authentication required**, with actionable sign-in, header-forwarding, and permitted-account guidance. Authentication remains denied until configured ingress requirements are satisfied. Immediately removing a queued message no longer produces a false storage-error alert; the remaining messages retain their order and exact-once delivery behavior.

## Evidence

- Real isolated built Gateway/Chromium before/after: `AUTH_IDENTITY_HEADER_REQUIRED`, raw `unauthorized`, and `data-kind=network` become `data-kind=trusted-proxy` with appropriate guidance. A synthetic pasted token remains rejected. No operator Gateway or live state was used.
- Pre-fix classifier/renderer assertions failed for the intended reason; **123 focused unit tests passed**, covering known/unknown reasons, credentials, snapshot clearing and stale-client isolation.
- **All 20 login E2E cases passed**, including the eight application-handshake categories and actual `CONTROL_UI_ORIGIN_NOT_ALLOWED` → `origin-not-allowed` recovery. Retryable fixtures now remain rejected through a real reconnect rather than defaulting to success during screenshots. Additional login/auth/scroll units passed 69/69 and virtualizer units 38/38. An earlier review's proposed `trusted_proxy_origin_not_allowed` fixture is HTTP-only: `auth.ts:268` skips that policy for the WebSocket surface. Browser admission emits its separate Origin code and the existing renderer already handles it. See the [source-backed review disposition](https://github.com/openclaw/openclaw/pull/135584#issuecomment-5501307426). The real transport Origin case additionally asserts its specific card and absence of token-recovery commands.
- All **four real Gateway auth-transport cases passed** in [integrated auth-fix CI](https://github.com/openclaw/openclaw/actions/runs/33564104592/job/100045537986): trusted acceptance, missing-header rejection with corrected guidance, credential scoping, Origin enforcement and config save. Final-candidate [CI run 33582845877](https://github.com/openclaw/openclaw/actions/runs/33582845877) completed successfully at `87609546f4d746514b500e6cc530750ae3bfdbb9`, with zero pending checks.
- The retained queue regression **failed before** the delivery repair with successful row removal followed by the storage alert and unchanged 10-second wait timeout. **Seven queue-edit/reorder/responsiveness browser tests passed after**; the complete queue-edit file passed **4/4 again on final source**. No extra send occurred, and the remaining queue drained in exact order with unique idempotency keys. Synthetic before/after captures were inspected.
- **22 payload-migration/recovery/queue browser cases passed**, followed by **10/10 on the final payload-test source**. Native IndexedDB contention reproduced a fixture-ordering failure before the test waited for its durable empty composer, then passed with that precondition and unchanged destination/byte/idempotency/no-send assertions. The shared page helper now captures failures before cleanup; captures use existing per-attempt directories. No production storage or recovery changes.
- UI build/budgets, i18n, types and scoped lint/styles passed. Queue changed checks found one shadowed test local after all preceding checks passed; the local was renamed and failed/remaining scoped checks plus final browser proof passed. The entire aggregate was not rerun after the identifier-only correction. Fresh complete-candidate independent review is scoped-clean at P0, with no accepted/actionable findings. Native review artifacts validated; the [land-ready proof](https://github.com/openclaw/openclaw/pull/135584#issuecomment-5501307426) records exact final CI and commands.

### CI and local-environment history

The first CI mobile-sidebar timeout did not reproduce alone, in the exact **119-test/26-file order**, or at 4×/8× browser CPU slowdown. A confirmed diagnostics gap was fixed using the existing capture helper before context closure, preserving the original failure. Controlled rejection verified the capture while the page was open. Fourteen sibling E2Es and thirteen diagnostic-owner tests passed; the mobile shard passed on the next run. No deterministic mobile timing fix is claimed.

The second run failed the queue scenario described above. The original CI alert text was not captured, so retrospective causality is not absolute; the same failing sequence now has deterministic browser proof and an owner-level repair. Both custom-page failure paths retain diagnostic evidence before cleanup.

The third run passed the real auth job, including the new explicit Origin-card assertions, but failed the legacy Blob recovery fixture. That test navigated away after queue admission but before asynchronous IndexedDB composer clearing committed; a reload could restore the old draft, and recovery correctly refused to overwrite the occupied destination. The test now waits for its intended persisted-empty fixture before seeding legacy metadata. A finite native transaction demonstrated fail-before/pass-after; its timing probe is not in final source. The exact destination text remains asserted, and production migration, storage and conflict protection are unchanged. Historical CI interleaving remains inferential because no capture existed; the shared `withPage` lifecycle now preserves future failures.

The fourth run exposed a login-fixture lifetime defect: one rejected deferred connect was followed by the mock's default successful hello, which correctly removed the login card before delayed assertions. The test now supplies the same denial persistently and requires a real second connect for retryable cases. The original fixture fails that barrier; the fixed full login suite passes.

That run also recorded a 112px native-wheel offset instead of zero before transcript text recovery. No scroll repair is claimed. After Mac investigation, **Blacksmith Testbox** `tbx_01m1fxr9sbfr8vb4nvwe1ggfkg` ran the exact failed merge `7eaf7fe743663966fe0e4cceb634b3a1c42411d0` under Node 24.19, Chromium 144, frozen dependencies and the normal two-worker bundled configuration. The original 26-file shard passed **121/121 with tracing and 121/121 in a separate pristine checkout**. No failure interleaving reproduced, no scroll code/assertions changed. [Testbox run and environment proof](https://github.com/openclaw/openclaw/actions/runs/33581830577); wrapper commands exited 0 and the owned lease is stopped/completed. The exact test command in both isolated checkouts was:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner --shard 5/13
```

A frozen-lockfile install repaired missing pinned SDK files without dependency changes. Supplemental macOS real-transport setup still exceeded its existing deadline; hosted CI supplies that full boundary proof. A proposed queue unit probe was interrupted without a result and removed; it is not counted as passing. No timeout, assertion, dependency version, authentication rule or trust restriction was weakened.

Production LOC: **+69/-15 (net +54)**. Growth is bounded diagnostic metadata/category/copy; the queue change removes one executable line and adds an ownership comment. Tests: **+418/-85 (net +333)**, including moved cases, boundary proof and failure capture. Docs: **+12/-3**. No persistent store, schema, migration, configuration or changelog changes.

### Before: trusted-proxy rejection

![Before: a proxy identity rejection is shown as a network failure](https://github.com/user-attachments/assets/0aef632b-9484-44d6-8885-1079d53260d5)

### After: same rejected connection, correct recovery

![After: the same rejected connection gets proxy and SSO recovery guidance](https://github.com/user-attachments/assets/a02a31c8-e709-498d-9df8-6a3819fbea37)

![Before: successful queue removal followed by a false storage error](https://github.com/user-attachments/assets/7487eeee-5b56-423b-aabb-a489a049280e)

![After: identical queued rows without the false storage error](https://github.com/user-attachments/assets/c029b83a-31a2-48c3-a035-2366fbf62ca0)

