### PR TITLE
test(tooling): share immutable pnpm launcher fixtures

### DIFF
--- a/test/scripts/pnpm-runner.test.ts
+++ b/test/scripts/pnpm-runner.test.ts
@@ -1,14 +1,53 @@
-// Pnpm Runner tests cover pnpm runner script behavior.
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { createPnpmRunnerSpawnSpec, resolvePnpmRunner } from "../../scripts/pnpm-runner.mts";
 import { buildCmdExeCommandLine } from "../../scripts/windows-cmd-helpers.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 describe("resolvePnpmRunner", () => {
   const posixIt = process.platform === "win32" ? it.skip : it;
+
+  const tempDirs = useAutoCleanupTempDirTracker(afterAll);
+  let fixturesRoot: string;
+
+  beforeAll(() => {
+    fixturesRoot = tempDirs.make("pnpm-runner-");
+    const writeLauncher = (relativePath: string, source: string | Buffer, mode?: number) => {
+      const file = path.join(fixturesRoot, relativePath);
+      mkdirSync(path.dirname(file), { recursive: true });
+      writeFileSync(file, source);
+      if (mode !== undefined) {
+        chmodSync(file, mode);
+      }
+    };
+    for (const name of ["pnpm-cli.cjs", "pnpm.cjs", "pnpm.mjs"]) {
+      writeLauncher(
+        `env/${name}`,
+        `console.log(JSON.stringify({
+          entrypoint: process.argv[1],
+          npmExecPath: process.env.npm_execpath ?? null,
+          args: process.argv.slice(2),
+        }));\n`,
+      );
+    }
+    writeLauncher("js/pnpm.cjs", "console.log('pnpm');\n");
+    writeLauncher("shebang/pnpm", "#!/usr/bin/env node\nconsole.log('pnpm');\n");
+    const elfHeader = Buffer.from([0x7f, 0x45, 0x4c, 0x46]);
+    for (const name of ["pnpm", "pnpm-native"]) {
+      writeLauncher(`native/${name}`, elfHeader, 0o755);
+    }
+    writeLauncher("not-executable/pnpm", elfHeader, 0o644);
+    writeLauncher("shell/pnpm", '#!/bin/sh\nprintf "%s\\n" "$@"\n', 0o755);
+    writeLauncher("parent/pnpm", "#!/usr/bin/env node\n", 0o755);
+    // PATH absence and precedence need separate directories even though setup is shared.
+    mkdirSync(path.join(fixturesRoot, "child"));
+    for (const name of ["corepack/corepack", "path/pnpm", "path/corepack"]) {
+      writeLauncher(name, "#!/bin/sh\nexit 0\n", 0o755);
+    }
+    writeLauncher("windows/corepack.cmd", "@exit /b 0\r\n");
+  });
 
   afterEach(() => vi.unstubAllEnvs());
 
@@ -18,177 +57,135 @@ describe("resolvePnpmRunner", () => {
     { name: "default process env", env: "default", override: false, entrypoint: "pnpm-cli.cjs" },
     { name: "empty env with override", env: "empty", override: true, entrypoint: "pnpm.mjs" },
   ])("executes with $name at the child boundary", ({ env: envMode, override, entrypoint }) => {
-    const tempDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), "pnpm-runner-env-")));
+    const tempDir = path.join(fixturesRoot, "env");
     const parentPath = path.join(tempDir, "pnpm-cli.cjs");
     const selectedPath = path.join(tempDir, "pnpm.cjs");
     const overridePath = path.join(tempDir, "pnpm.mjs");
-    try {
-      for (const file of [parentPath, selectedPath, overridePath]) {
-        writeFileSync(
-          file,
-          `console.log(JSON.stringify({
-            entrypoint: process.argv[1],
-            npmExecPath: process.env.npm_execpath ?? null,
-            args: process.argv.slice(2),
-          }));\n`,
-        );
-      }
-      const env =
-        envMode === "selected"
-          ? { npm_execpath: selectedPath }
-          : envMode === "empty"
-            ? {}
-            : undefined;
-      const params = {
-        cwd: tempDir,
-        env,
-        npmExecPath: override ? overridePath : undefined,
-        pnpmArgs: ["literal & argument"],
-        stdio: "pipe",
-      };
-      // Windows worker env copies are case-sensitive. Set the default environment
-      // in a real main thread so launcher selection and child inheritance agree.
-      const result = spawnSync(process.execPath, ["--input-type=module", "-"], {
-        encoding: "utf8",
-        input: `
-          import { spawnSync } from "node:child_process";
-          process.env.npm_execpath = ${JSON.stringify(parentPath)};
-          const { createPnpmRunnerSpawnSpec } = await import(${JSON.stringify(new URL("../../scripts/pnpm-runner.mts", import.meta.url).href)});
-          const spec = createPnpmRunnerSpawnSpec(${JSON.stringify(params)});
-          const result = spawnSync(spec.command, spec.args, { ...spec.options, encoding: "utf8" });
-          if (result.error) throw result.error;
-          process.stdout.write(result.stdout);
-          process.stderr.write(result.stderr);
-          process.exitCode = result.status ?? 1;
-        `,
-      });
-      expect(result.status, result.stderr).toBe(0);
-      expect(JSON.parse(result.stdout)).toEqual({
-        entrypoint: path.join(tempDir, entrypoint),
-        npmExecPath:
-          envMode === "selected" ? selectedPath : envMode === "empty" ? null : parentPath,
-        args: ["literal & argument"],
-      });
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
+    const env =
+      envMode === "selected"
+        ? { npm_execpath: selectedPath }
+        : envMode === "empty"
+          ? {}
+          : undefined;
+    const params = {
+      cwd: tempDir,
+      env,
+      npmExecPath: override ? overridePath : undefined,
+      pnpmArgs: ["literal & argument"],
+      stdio: "pipe",
+    };
+    // Windows worker env copies are case-sensitive. Set the default environment
+    // in a real main thread so launcher selection and child inheritance agree.
+    const result = spawnSync(process.execPath, ["--input-type=module", "-"], {
+      encoding: "utf8",
+      input: `
+        import { spawnSync } from "node:child_process";
+        process.env.npm_execpath = ${JSON.stringify(parentPath)};
+        const { createPnpmRunnerSpawnSpec } = await import(${JSON.stringify(new URL("../../scripts/pnpm-runner.mts", import.meta.url).href)});
+        const spec = createPnpmRunnerSpawnSpec(${JSON.stringify(params)});
+        const result = spawnSync(spec.command, spec.args, { ...spec.options, encoding: "utf8" });
+        if (result.error) throw result.error;
+        process.stdout.write(result.stdout);
+        process.stderr.write(result.stderr);
+        process.exitCode = result.status ?? 1;
+      `,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      entrypoint: path.join(tempDir, entrypoint),
+      npmExecPath: envMode === "selected" ? selectedPath : envMode === "empty" ? null : parentPath,
+      args: ["literal & argument"],
+    });
   });
 
   it("uses npm_execpath when it points to a JS pnpm entrypoint", () => {
-    const tempDir = mkdtempSync(path.join(os.tmpdir(), "pnpm-runner-"));
+    const tempDir = path.join(fixturesRoot, "js");
     const npmExecPath = path.join(tempDir, "pnpm.cjs");
-    writeFileSync(npmExecPath, "console.log('pnpm');\n");
 
-    try {
-      expect(
-        resolvePnpmRunner({
-          npmExecPath,
-          nodeExecPath: "/usr/local/bin/node",
-          pnpmArgs: ["exec", "vitest", "run"],
-          platform: "linux",
-        }),
-      ).toEqual({
-        command: "/usr/local/bin/node",
-        args: [npmExecPath, "exec", "vitest", "run"],
-        shell: false,
-      });
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(
+      resolvePnpmRunner({
+        npmExecPath,
+        nodeExecPath: "/usr/local/bin/node",
+        pnpmArgs: ["exec", "vitest", "run"],
+        platform: "linux",
+      }),
+    ).toEqual({
+      command: "/usr/local/bin/node",
+      args: [npmExecPath, "exec", "vitest", "run"],
+      shell: false,
+    });
   });
 
   it("uses npm_execpath when it points to a shebang pnpm script", () => {
-    const tempDir = mkdtempSync(path.join(os.tmpdir(), "pnpm-runner-"));
+    const tempDir = path.join(fixturesRoot, "shebang");
     const npmExecPath = path.join(tempDir, "pnpm");
-    writeFileSync(npmExecPath, "#!/usr/bin/env node\nconsole.log('pnpm');\n");
 
-    try {
-      expect(
-        resolvePnpmRunner({
-          npmExecPath,
-          nodeExecPath: "/usr/local/bin/node",
-          pnpmArgs: ["exec", "vitest", "run"],
-          platform: "linux",
-        }),
-      ).toEqual({
-        command: "/usr/local/bin/node",
-        args: [npmExecPath, "exec", "vitest", "run"],
-        shell: false,
-      });
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(
+      resolvePnpmRunner({
+        npmExecPath,
+        nodeExecPath: "/usr/local/bin/node",
+        pnpmArgs: ["exec", "vitest", "run"],
+        platform: "linux",
+      }),
+    ).toEqual({
+      command: "/usr/local/bin/node",
+      args: [npmExecPath, "exec", "vitest", "run"],
+      shell: false,
+    });
   });
 
   it("prepends node args when launching pnpm through node", () => {
-    const tempDir = mkdtempSync(path.join(os.tmpdir(), "pnpm-runner-"));
+    const tempDir = path.join(fixturesRoot, "js");
     const npmExecPath = path.join(tempDir, "pnpm.cjs");
-    writeFileSync(npmExecPath, "console.log('pnpm');\n");
 
-    try {
-      expect(
-        resolvePnpmRunner({
-          npmExecPath,
-          nodeArgs: ["--no-maglev"],
-          nodeExecPath: "/usr/local/bin/node",
-          pnpmArgs: ["exec", "vitest", "run"],
-          platform: "linux",
-        }),
-      ).toEqual({
-        command: "/usr/local/bin/node",
-        args: ["--no-maglev", npmExecPath, "exec", "vitest", "run"],
-        shell: false,
-      });
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(
+      resolvePnpmRunner({
+        npmExecPath,
+        nodeArgs: ["--no-maglev"],
+        nodeExecPath: "/usr/local/bin/node",
+        pnpmArgs: ["exec", "vitest", "run"],
+        platform: "linux",
+      }),
+    ).toEqual({
+      command: "/usr/local/bin/node",
+      args: ["--no-maglev", npmExecPath, "exec", "vitest", "run"],
+      shell: false,
+    });
   });
 
   it.each(["pnpm", "pnpm-native"])("executes native %s from npm_execpath directly", (basename) => {
-    const tempDir = mkdtempSync(path.join(os.tmpdir(), "pnpm-runner-"));
+    const tempDir = path.join(fixturesRoot, "native");
     const npmExecPath = path.join(tempDir, basename);
-    writeFileSync(npmExecPath, Buffer.from([0x7f, 0x45, 0x4c, 0x46]));
-    chmodSync(npmExecPath, 0o755);
 
-    try {
-      expect(
-        resolvePnpmRunner({
-          npmExecPath,
-          pnpmArgs: ["exec", "vitest", "run"],
-          platform: "linux",
-        }),
-      ).toEqual({
-        command: npmExecPath,
-        args: ["exec", "vitest", "run"],
-        shell: false,
-      });
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(
+      resolvePnpmRunner({
+        npmExecPath,
+        pnpmArgs: ["exec", "vitest", "run"],
+        platform: "linux",
+      }),
+    ).toEqual({
+      command: npmExecPath,
+      args: ["exec", "vitest", "run"],
+      shell: false,
+    });
   });
 
   posixIt("falls back to bare pnpm when native npm_execpath is not executable", () => {
-    const tempDir = mkdtempSync(path.join(os.tmpdir(), "pnpm-runner-"));
+    const tempDir = path.join(fixturesRoot, "not-executable");
     const npmExecPath = path.join(tempDir, "pnpm");
-    writeFileSync(npmExecPath, Buffer.from([0x7f, 0x45, 0x4c, 0x46]));
-    chmodSync(npmExecPath, 0o644);
 
-    try {
-      expect(
-        resolvePnpmRunner({
-          npmExecPath,
-          env: { PATH: "" },
-          pnpmArgs: ["exec", "vitest", "run"],
-          platform: "linux",
-        }),
-      ).toEqual({
-        command: "pnpm",
-        args: ["exec", "vitest", "run"],
-        shell: false,
-      });
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(
+      resolvePnpmRunner({
+        npmExecPath,
+        env: { PATH: "" },
+        pnpmArgs: ["exec", "vitest", "run"],
+        platform: "linux",
+      }),
+    ).toEqual({
+      command: "pnpm",
+      args: ["exec", "vitest", "run"],
+      shell: false,
+    });
   });
 
   it.each(["pnpm.exe", "pnpm-native.exe"])("executes %s directly on Windows", (basename) => {
@@ -210,45 +207,34 @@ describe("resolvePnpmRunner", () => {
   });
 
   posixIt("executes a shell npm_execpath with its own interpreter", () => {
-    const tempDir = mkdtempSync(path.join(os.tmpdir(), "pnpm-runner-shell-"));
+    const tempDir = path.join(fixturesRoot, "shell");
     const npmExecPath = path.join(tempDir, "pnpm");
-    writeFileSync(npmExecPath, '#!/bin/sh\nprintf "%s\\n" "$@"\n');
-    chmodSync(npmExecPath, 0o755);
-    try {
-      const spec = createPnpmRunnerSpawnSpec({
-        npmExecPath,
-        pnpmArgs: ["literal & argument"],
-        stdio: "pipe",
-      });
-      const result = spawnSync(spec.command, spec.args, { ...spec.options, encoding: "utf8" });
-      expect(result.status, result.stderr).toBe(0);
-      expect(result.stdout).toBe("literal & argument\n");
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
+    const spec = createPnpmRunnerSpawnSpec({
+      npmExecPath,
+      pnpmArgs: ["literal & argument"],
+      stdio: "pipe",
+    });
+    const result = spawnSync(spec.command, spec.args, { ...spec.options, encoding: "utf8" });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe("literal & argument\n");
   });
 
   it("uses pnpm.cjs through node for Windows-style paths", () => {
-    const tempDir = mkdtempSync(path.join(os.tmpdir(), "pnpm-runner-"));
+    const tempDir = path.join(fixturesRoot, "js");
     const npmExecPath = path.join(tempDir, "pnpm.cjs");
-    writeFileSync(npmExecPath, "console.log('pnpm');\n");
 
-    try {
-      expect(
-        resolvePnpmRunner({
-          npmExecPath,
-          nodeExecPath: "C:\\Program Files\\nodejs\\node.exe",
-          pnpmArgs: ["exec", "vitest", "run"],
-          platform: "win32",
-        }),
-      ).toEqual({
-        command: "C:\\Program Files\\nodejs\\node.exe",
-        args: [npmExecPath, "exec", "vitest", "run"],
-        shell: false,
-      });
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(
+      resolvePnpmRunner({
+        npmExecPath,
+        nodeExecPath: "C:\\Program Files\\nodejs\\node.exe",
+        pnpmArgs: ["exec", "vitest", "run"],
+        platform: "win32",
+      }),
+    ).toEqual({
+      command: "C:\\Program Files\\nodejs\\node.exe",
+      args: [npmExecPath, "exec", "vitest", "run"],
+      shell: false,
+    });
   });
 
   it("falls back to pnpm.cmd on Windows for a missing legacy pnpm 10 JS entrypoint", () => {
@@ -307,100 +293,75 @@ describe("resolvePnpmRunner", () => {
   });
 
   posixIt("does not resolve parent npm_execpath or PATH for an explicit empty env", () => {
-    const tempDir = mkdtempSync(path.join(os.tmpdir(), "pnpm-runner-empty-env-"));
+    const tempDir = path.join(fixturesRoot, "parent");
     const npmExecPath = path.join(tempDir, "pnpm");
-    try {
-      writeFileSync(npmExecPath, "#!/usr/bin/env node\n");
-      chmodSync(npmExecPath, 0o755);
-      vi.stubEnv("npm_execpath", npmExecPath);
-      vi.stubEnv("PATH", tempDir);
-      expect(
-        resolvePnpmRunner({
-          env: {},
-          pnpmArgs: ["exec", "vitest", "run"],
-          platform: "linux",
-        }),
-      ).toEqual({
-        command: "pnpm",
-        args: ["exec", "vitest", "run"],
-        shell: false,
-      });
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
+    vi.stubEnv("npm_execpath", npmExecPath);
+    vi.stubEnv("PATH", tempDir);
+    expect(
+      resolvePnpmRunner({
+        env: {},
+        pnpmArgs: ["exec", "vitest", "run"],
+        platform: "linux",
+      }),
+    ).toEqual({
+      command: "pnpm",
+      args: ["exec", "vitest", "run"],
+      shell: false,
+    });
   });
 
   posixIt("resolves relative PATH entries from the child working directory", () => {
-    const childDir = mkdtempSync(path.join(os.tmpdir(), "pnpm-runner-child-"));
+    const childDir = path.join(fixturesRoot, "child");
 
-    try {
-      expect(
-        resolvePnpmRunner({
-          cwd: childDir,
-          npmExecPath: "",
-          env: { PATH: "node_modules/.bin" },
-          pnpmArgs: ["exec", "vitest", "run"],
-          platform: "linux",
-        }),
-      ).toEqual({
-        command: "pnpm",
-        args: ["exec", "vitest", "run"],
-        shell: false,
-      });
-    } finally {
-      rmSync(childDir, { recursive: true, force: true });
-    }
+    expect(
+      resolvePnpmRunner({
+        cwd: childDir,
+        npmExecPath: "",
+        env: { PATH: "node_modules/.bin" },
+        pnpmArgs: ["exec", "vitest", "run"],
+        platform: "linux",
+      }),
+    ).toEqual({
+      command: "pnpm",
+      args: ["exec", "vitest", "run"],
+      shell: false,
+    });
   });
 
   posixIt("uses Corepack when pnpm is not directly available on PATH", () => {
-    const tempDir = mkdtempSync(path.join(os.tmpdir(), "pnpm-runner-corepack-"));
+    const tempDir = path.join(fixturesRoot, "corepack");
     const corepackPath = path.join(tempDir, "corepack");
-    writeFileSync(corepackPath, "#!/bin/sh\nexit 0\n");
-    chmodSync(corepackPath, 0o755);
 
-    try {
-      expect(
-        resolvePnpmRunner({
-          npmExecPath: "",
-          env: { PATH: tempDir },
-          pnpmArgs: ["exec", "tsdown"],
-          platform: "darwin",
-        }),
-      ).toEqual({
-        command: corepackPath,
-        args: ["pnpm", "exec", "tsdown"],
-        shell: false,
-      });
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(
+      resolvePnpmRunner({
+        npmExecPath: "",
+        env: { PATH: tempDir },
+        pnpmArgs: ["exec", "tsdown"],
+        platform: "darwin",
+      }),
+    ).toEqual({
+      command: corepackPath,
+      args: ["pnpm", "exec", "tsdown"],
+      shell: false,
+    });
   });
 
   posixIt("prefers a direct pnpm executable over Corepack", () => {
-    const tempDir = mkdtempSync(path.join(os.tmpdir(), "pnpm-runner-path-"));
+    const tempDir = path.join(fixturesRoot, "path");
     const pnpmPath = path.join(tempDir, "pnpm");
-    const corepackPath = path.join(tempDir, "corepack");
-    writeFileSync(pnpmPath, "#!/bin/sh\nexit 0\n");
-    writeFileSync(corepackPath, "#!/bin/sh\nexit 0\n");
-    chmodSync(pnpmPath, 0o755);
-    chmodSync(corepackPath, 0o755);
 
-    try {
-      expect(
-        resolvePnpmRunner({
-          npmExecPath: "",
-          env: { PATH: tempDir },
-          pnpmArgs: ["exec", "tsdown"],
-          platform: "darwin",
-        }),
-      ).toEqual({
-        command: pnpmPath,
-        args: ["exec", "tsdown"],
-        shell: false,
-      });
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(
+      resolvePnpmRunner({
+        npmExecPath: "",
+        env: { PATH: tempDir },
+        pnpmArgs: ["exec", "tsdown"],
+        platform: "darwin",
+      }),
+    ).toEqual({
+      command: pnpmPath,
+      args: ["exec", "tsdown"],
+      shell: false,
+    });
   });
 
   it("wraps pnpm.cmd via cmd.exe on Windows when npm_execpath is unavailable", () => {
@@ -441,33 +402,28 @@ describe("resolvePnpmRunner", () => {
   });
 
   it("uses Corepack on Windows when no pnpm shim is available", () => {
-    const tempDir = mkdtempSync(path.join(os.tmpdir(), "pnpm-runner-corepack-"));
+    const tempDir = path.join(fixturesRoot, "windows");
     const corepackPath = path.join(tempDir, "corepack.cmd");
-    writeFileSync(corepackPath, "@exit /b 0\r\n");
 
-    try {
-      expect(
-        resolvePnpmRunner({
-          comSpec: "C:\\Windows\\System32\\cmd.exe",
-          npmExecPath: "",
-          env: { Path: tempDir, PATHEXT: ".CMD;.EXE" },
-          pnpmArgs: ["exec", "vitest", "run"],
-          platform: "win32",
-        }),
-      ).toEqual({
-        command: "C:\\Windows\\System32\\cmd.exe",
-        args: [
-          "/d",
-          "/s",
-          "/c",
-          buildCmdExeCommandLine(corepackPath, ["pnpm", "exec", "vitest", "run"]),
-        ],
-        shell: false,
-        windowsVerbatimArguments: true,
-      });
-    } finally {
-      rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(
+      resolvePnpmRunner({
+        comSpec: "C:\\Windows\\System32\\cmd.exe",
+        npmExecPath: "",
+        env: { Path: tempDir, PATHEXT: ".CMD;.EXE" },
+        pnpmArgs: ["exec", "vitest", "run"],
+        platform: "win32",
+      }),
+    ).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: [
+        "/d",
+        "/s",
+        "/c",
+        buildCmdExeCommandLine(corepackPath, ["pnpm", "exec", "vitest", "run"]),
+      ],
+      shell: false,
+      windowsVerbatimArguments: true,
+    });
   });
 
   it("escapes caret arguments for Windows cmd.exe", () => {


### PR DESCRIPTION
## What Problem This Solves

The pnpm launcher tests repeatedly write identical scripts and rebuild temporary directories while testing launcher resolution and child-process environment handling.

## Why This Change Was Made

Give the suite one canonical temporary root containing immutable launcher fixtures. Keep separate directories for missing PATH entries, Corepack-only lookup, executable precedence, shell interpreters, and executable/non-executable native files. The existing temporary-directory tracker owns cleanup after the suite, and environment restoration remains per case.

All real main-thread, nested Node, and shell executions stay in their original cases. Their assertions and platform-specific coverage are retained.

## User Impact

No launcher behavior changes. On POSIX, 17 temporary-root lifetimes become one, reporter writes drop from 12 to three, and three identical JavaScript launcher writes become one. Removing repeated setup and cleanup also removes 44 net test lines.

## Evidence

- Baseline and after: 52/52 cases pass across pnpm-runner and its Playwright installer caller.
- All 26 exact launcher case identities retained; shuffled owner run, seed 1093: 26/26 pass.
- Observed owner suite time: 754 ms before, 466 ms after. These are single-run observations, not a stable benchmark.
- Full changed-file gate passed: root-test typecheck, targeted lint/formatting, script lint, and architecture/API guards.
- Diff-scoped Codex review (P0 scope): clean; manual launcher contents, permissions, environment, and fixture-lifecycle review complete.
- Production LOC: zero. Test LOC: +250/-294, mostly unindenting cases after removing their duplicate cleanup blocks.
- Local execution was on macOS; native Windows coverage remains in the existing CI selection.
