### PR TITLE
refactor(discord): share DM owner normalization

### DIFF
--- a/extensions/discord/src/monitor/agent-components.dispatch.ts
+++ b/extensions/discord/src/monitor/agent-components.dispatch.ts
@@ -25,7 +25,7 @@ import {
 } from "./agent-components-helpers.js";
 import { readSessionUpdatedAt, resolveStorePath } from "./agent-components.deps.runtime.js";
 import {
-  normalizeDiscordAllowList,
+  normalizeDiscordDmOwnerEntry,
   resolveDiscordChannelConfigWithFallback,
   resolveDiscordGuildEntry,
 } from "./allow-list.js";
@@ -145,11 +145,7 @@ export async function dispatchDiscordComponentEvent(params: {
     ? resolvePinnedMainDmOwnerFromAllowlist({
         dmScope: ctx.cfg.session?.dmScope,
         allowFrom: channelConfig?.users ?? guildInfo?.users,
-        normalizeEntry: (entry: string) => {
-          const normalized = normalizeDiscordAllowList([entry], ["discord:", "user:", "pk:"]);
-          const candidate = normalized?.ids.values().next().value;
-          return typeof candidate === "string" && /^\d+$/.test(candidate) ? candidate : undefined;
-        },
+        normalizeEntry: normalizeDiscordDmOwnerEntry,
       })
     : null;
   const commandAuthorized = await resolveComponentCommandAuthorized({

--- a/extensions/discord/src/monitor/allow-list.test.ts
+++ b/extensions/discord/src/monitor/allow-list.test.ts
@@ -1,6 +1,32 @@
 // Discord tests cover allow list plugin behavior.
 import { describe, expect, it } from "vitest";
-import { normalizeDiscordDisplaySlug, normalizeDiscordSlug } from "./allow-list.js";
+import {
+  normalizeDiscordDisplaySlug,
+  normalizeDiscordDmOwnerEntry,
+  normalizeDiscordSlug,
+} from "./allow-list.js";
+
+describe("discord DM owner normalization", () => {
+  it.each([
+    ["123", "123"],
+    [" 123 ", "123"],
+    ["<@123>", "123"],
+    ["<@!123>", "123"],
+    ["discord:123", "123"],
+    ["user:123", "123"],
+    ["pk:123", "123"],
+    ["*", undefined],
+    ["alice", undefined],
+    ["", undefined],
+    ["   ", undefined],
+    ["discord:alice", undefined],
+    ["user:", undefined],
+    ["pk:abc", undefined],
+    ["discord:123:user:456", undefined],
+  ])("normalizes %j to %j", (entry, expected) => {
+    expect(normalizeDiscordDmOwnerEntry(entry)).toBe(expected);
+  });
+});
 
 describe("discord slug normalization", () => {
   it("keeps config slugs ASCII-only", () => {

--- a/extensions/discord/src/monitor/allow-list.ts
+++ b/extensions/discord/src/monitor/allow-list.ts
@@ -91,6 +91,12 @@ export function normalizeDiscordAllowList(raw: string[] | undefined, prefixes: s
   return { allowAll, ids, names } satisfies DiscordAllowList;
 }
 
+export function normalizeDiscordDmOwnerEntry(entry: string): string | undefined {
+  const normalized = normalizeDiscordAllowList([entry], ["discord:", "user:", "pk:"]);
+  const candidate = normalized?.ids.values().next().value;
+  return typeof candidate === "string" && /^\d+$/.test(candidate) ? candidate : undefined;
+}
+
 export function normalizeDiscordSlug(value: string) {
   return normalizeLowercaseStringOrEmpty(value)
     .replace(/^#/, "")

--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -24,7 +24,7 @@ import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/sess
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveDiscordConversationIdentity } from "../conversation-identity.js";
 import { ChannelType } from "../internal/discord.js";
-import { normalizeDiscordAllowList, normalizeDiscordSlug } from "./allow-list.js";
+import { normalizeDiscordDmOwnerEntry, normalizeDiscordSlug } from "./allow-list.js";
 import { resolveTimestampMs } from "./format.js";
 import {
   buildDiscordInboundAccessContext,
@@ -48,12 +48,6 @@ import {
   DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS,
   DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS,
 } from "./timeouts.js";
-
-function normalizeDiscordDmOwnerEntry(entry: string): string | undefined {
-  const normalized = normalizeDiscordAllowList([entry], ["discord:", "user:", "pk:"]);
-  const candidate = normalized?.ids.values().next().value;
-  return typeof candidate === "string" && /^\d+$/.test(candidate) ? candidate : undefined;
-}
 
 function isContextAborted(abortSignal?: AbortSignal): boolean {
   return Boolean(abortSignal?.aborted);


### PR DESCRIPTION
## What Problem This Solves

Discord DM main-route owner normalization had two private copies, one for normal messages and one for component dispatch. Keeping the same routing rule in two places made future drift possible.

## Why This Change Was Made

The Discord allow-list module now owns one private-module `normalizeDiscordDmOwnerEntry` helper. Both callers use it, and both duplicate implementations are removed.

The canonical helper preserves the existing contract exactly:

- normalize one entry with `discord:`, `user:`, and `pk:` prefixes
- use only the first normalized ID
- return only an all-numeric ID
- accept trimmed numeric IDs, `<@123>`, `<@!123>`, and numeric prefixed forms
- reject wildcard, names, empty values, and nonnumeric prefixed values

Route pinning remains independent from command/voice authorization; this does not reuse `DISCORD_OWNER_ALLOWLIST_PREFIXES`. The real-DM `allowFrom: channelConfig?.users ?? guildInfo?.users` source selection is unchanged and out of scope.

## User Impact

No user-visible behavior change. This removes duplicate private routing logic while preserving its security-relevant normalization boundary.

## Evidence

Root cause and owner:

- Duplicate owner-entry normalization existed in the normal-message and component-dispatch paths.
- `extensions/discord/src/monitor/allow-list.ts` is the canonical owner.
- Both duplicates were deleted; no SDK, API, config, auth, routing guard, command-owner normalization, seam, or barrel changed.

Focused tests:

- `node scripts/run-vitest.mjs extensions/discord/src/monitor/allow-list.test.ts` - 17 passed
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.process.session-routing.test.ts` - 12 passed
- `node scripts/run-vitest.mjs extensions/discord/src/monitor/monitor.test.ts` - 28 passed

Gates:

- changed-file `oxfmt` check and `git diff --check` passed
- `node scripts/check-changed.mjs --dry-run -- <changed files>` selected the expected extension and extension-test lanes
- selected changed gates passed, including extension production/test typechecks, oxlint, dead-code export checks, coercion/deprecation/persistence guards, and import cycles (`0` runtime value cycles)
- the sparse worktree initially omitted tracked `ui/config/`; after adding it to the sparse set, the failed extension-test typecheck and all remaining selected gates passed
- mandated autoreview: scoped-clean, no accepted/actionable findings, patch correctness `0.99`

Full extension lane:

- `pnpm test:extension discord` was attempted under local Node.js `v26.7.0`, which is outside this repository's supported engine range. The suite produced no assertion failure but terminated late with Vitest `Worker exited unexpectedly`. A supported Node runtime was not installed locally; targeted and changed-scope proof above is green.

LOC:

- production: `+9/-13` (net `-4`)
- tests: `+27/-1` (net `+26`)

Sibling and overlap coverage:

- Normal-message session routing and component dispatch are both covered.
- Pre-edit live overlap check: https://github.com/openclaw/openclaw/pull/107698 had no target files; https://github.com/openclaw/openclaw/pull/122238 only had hunk-disjoint queued-message context changes.
- An exhaustive open-PR target-file scan found no competing PR. The final `origin/main` refresh did not change any target file.

Live proof:

- Crabbox/live Discord proof is not relevant for this private behavior-preserving extraction: it changes no external Discord contract, and an authenticated channel run cannot distinguish the shared helper from the duplicated implementation. No live behavior claim is made.

Codex hard gate inspected:

- `../codex/codex-rs/cli/src/main.rs:220-245`
- `../codex/codex-rs/cli/src/main.rs:2840-2870`

Those CLI command/config-normalization surfaces do not alter this private Discord normalization extraction.
