### PR TITLE
refactor(plugins): share disabled install config preparation

### DIFF
--- a/src/plugins/bundled-install.ts
+++ b/src/plugins/bundled-install.ts
@@ -1,9 +1,9 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { BundledPluginSource } from "./bundled-sources.js";
 import {
   persistPluginInstall,
+  prepareConfigForDisabledInstall,
   type ConfigSnapshotForInstallPersist,
 } from "./install-persistence.js";
 import { validateJsonSchemaValue } from "./schema-validator.js";
@@ -41,25 +41,6 @@ function resolveBundledPluginConfigEnablement(params: {
     : { mode: "invalid", error: result.errors[0]?.text ?? "invalid plugin config" };
 }
 
-function prepareConfigForDisabledBundledInstall(
-  config: OpenClawConfig,
-  pluginId: string,
-): OpenClawConfig {
-  const entry = config.plugins?.entries?.[pluginId];
-  const policy = isRecord(entry) ? { ...entry } : {};
-  delete policy.config;
-  return {
-    ...config,
-    plugins: {
-      ...config.plugins,
-      entries: {
-        ...config.plugins?.entries,
-        [pluginId]: { ...policy, enabled: false },
-      },
-    },
-  };
-}
-
 export async function installBundledPluginSource(params: {
   snapshot: ConfigSnapshotForInstallPersist;
   rawSpec: string;
@@ -82,7 +63,7 @@ export async function installBundledPluginSource(params: {
   const shouldEnable = configEnablement.mode === "ready";
   const configBase = shouldEnable
     ? params.snapshot.config
-    : prepareConfigForDisabledBundledInstall(params.snapshot.config, params.bundledSource.pluginId);
+    : prepareConfigForDisabledInstall(params.snapshot.config, params.bundledSource.pluginId);
   const configWarning = shouldEnable
     ? undefined
     : `Installed bundled plugin "${params.bundledSource.pluginId}" without enabling it because it requires configuration first. Configure it, then run \`openclaw plugins enable ${params.bundledSource.pluginId}\`.`;

--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -427,7 +427,10 @@ function resolveReplacedManagedInstallRemoval(params: {
   return plan.directoryRemoval;
 }
 
-function prepareConfigForDisabledInstall(config: OpenClawConfig, pluginId: string): OpenClawConfig {
+export function prepareConfigForDisabledInstall(
+  config: OpenClawConfig,
+  pluginId: string,
+): OpenClawConfig {
   const entry = config.plugins?.entries?.[pluginId];
   const policy = isRecord(entry) ? { ...entry } : {};
   delete policy.config;


### PR DESCRIPTION
## What Problem This Solves

The bundled-plugin install path duplicated the persistence owner's disabled-install config preparation. Keeping two copies of this policy made future drift possible around which entry fields are preserved, which field is removed, and when `enabled: false` is applied.

## Why This Change Was Made

`src/plugins/install-persistence.ts` now exports its existing `prepareConfigForDisabledInstall` owner helper. `src/plugins/bundled-install.ts` imports that helper directly and removes `prepareConfigForDisabledBundledInstall`, leaving one canonical config-preparation path.

The bundled enablement validator remains separate from manifest-schema validation. No validator, schema, config, doctor, database, protocol, API, barrel, SDK, or compatibility behavior changes.

## User Impact

No user-visible behavior change. Disabled plugin installs continue to:

- use canonical `isRecord` handling and shallow own-enumerable copying, dropping custom prototypes;
- remove only the entry's `config`;
- apply `enabled: false` last;
- preserve unrelated entry policy, sibling plugin entries, plugin-level settings, and top-level config;
- keep bundled enablement validation and manifest-schema validation distinct and fail-closed.

## Evidence

Root cause/owner:

- Owner: `src/plugins/install-persistence.ts`
- Canonical fix: export and reuse the existing persistence helper.
- Removed path: `prepareConfigForDisabledBundledInstall` from `src/plugins/bundled-install.ts`.

Validation:

- `pnpm test src/plugins/install-persistence.enablement.test.ts` - 9 passed.
- `pnpm test src/plugins/install-persistence.warning-sink.test.ts` - 4 passed.
- `pnpm test src/cli/plugins-cli.install.test.ts` - 208 passed.
- `node_modules/.bin/oxfmt --write --threads=1 src/plugins/install-persistence.ts src/plugins/bundled-install.ts`
- `node_modules/.bin/oxfmt --check src/plugins/install-persistence.ts src/plugins/bundled-install.ts`
- `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 pnpm check:changed -- src/plugins/install-persistence.ts src/plugins/bundled-install.ts` - passed. This uses the gate's documented sparse-worktree override because the `gwt` core profile omits UI inputs required by the dead-export scanner; no dependency install or reconciliation was performed.
- `pnpm check:import-cycles` - 0 runtime value cycles.
- `git diff --check` - passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.6-sol --thinking high --codex-bin /opt/homebrew/Caskroom/codex/0.149.0/bin/codex --base origin/main` - scoped-clean, no accepted/actionable findings.

LOC:

- Production: +6/-22, net -16.
- Tests: +0/-0.
- No changelog entry: deterministic refactor with no user-visible behavior change.

Sibling flow coverage:

- Persistence enablement coverage verifies required-config installs preserve entry policy and disable correctly.
- Warning-sink coverage verifies the missing-config result and operator guidance.
- CLI install coverage exercises bundled missing, invalid, and explicit valid config flows, including sibling/plugin-level config preservation.

Overlap recheck against live GitHub state:

- https://github.com/openclaw/openclaw/pull/129324 touches only nesting-parser preflight hunks in `install-persistence.ts`.
- https://github.com/openclaw/openclaw/pull/125414 touches only install transaction plumbing in `install-persistence.ts`.
- https://github.com/openclaw/openclaw/pull/134943 touches only a pre-persistent-effect hook in `install-persistence.ts`.
- No open competing PR was found for either disabled-install helper or this deduplication.
- Current base is `4561ff89c9fa0de546185b4a41a471eeebf15502`; both target blobs were unchanged from the audited base before rebase.

No Crabbox or live proof was run. This change only extracts deterministic in-memory object preparation without changing validation or persistence behavior, and the existing real CLI install flow covers the bundled path.

Codex hard gate personally inspected in the sibling Codex checkout:

- `codex-rs/cli/src/main.rs:220-245`
- `codex-rs/cli/src/main.rs:2840-2870`
