### PR TITLE
fix(skills): keep one profile from exhausting pending ZIP imports

### DIFF
--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -165,6 +165,13 @@ Worker resource delivery also has an 8 MiB aggregate limit; narrow the session
 selection if its complete bundles exceed that limit. Published revisions are
 retained, including revisions still selected by older sessions.
 
+ZIP imports allow up to 16 unfinished uploads per canonical profile and 32
+across the Gateway. Linked or merged identities share the profile limit.
+Completed imports do not count toward either limit, and uploads expire one
+hour after they begin. If a profile merge or upgrade leaves more uploads than
+the limit allows, existing unexpired uploads can still be completed. Finish
+existing uploads or wait for them to expire before starting more.
+
 The Gateway stores library records and revision metadata in
 `state/openclaw.sqlite`, and immutable bundles under
 `skill-library/<skill-id>/revisions/<revision-hash>/` inside its state directory.

--- a/src/skills/library/import.ts
+++ b/src/skills/library/import.ts
@@ -32,11 +32,13 @@ import {
   ensureSkillLibrarySchema,
   requireSkillLibraryEntry,
   requireSkillLibraryProfile,
+  requireSkillLibraryUpload,
   skillLibraryDb,
   type SkillLibraryAuthority,
 } from "./store.js";
 
 const MAX_CHUNK_BYTES = 256 * 1024;
+const MAX_ACTIVE_UPLOADS = 32;
 
 async function publishDirectory(
   authority: SkillLibraryAuthority,
@@ -108,15 +110,25 @@ export async function uploadSkillLibrary(
         kysely.deleteFrom("skill_library_uploads").where("expires_at", "<=", Date.now()),
       );
       // Completed receipts remain replayable without occupying an active upload slot.
-      const activeUploads = kysely
-        .selectFrom("skill_library_uploads")
-        .select("upload_id")
-        .where("published_skill_id", "is", null)
-        .limit(32);
-      if (executeSqliteQuerySync(db, activeUploads).rows.length >= 32) {
+      const activeUploads = executeSqliteQuerySync(
+        db,
+        kysely
+          .selectFrom("skill_library_uploads")
+          .select("owner_profile_id")
+          .where("published_skill_id", "is", null)
+          .limit(MAX_ACTIVE_UPLOADS),
+      ).rows;
+      // One canonical profile may fill only half the pool, including uploads begun before a merge.
+      if (
+        activeUploads.length >= MAX_ACTIVE_UPLOADS ||
+        activeUploads.filter(
+          (upload) => selectResolvedUserProfileById(db, upload.owner_profile_id)?.id === actor,
+        ).length >=
+          MAX_ACTIVE_UPLOADS / 2
+      ) {
         throw new SkillLibraryError(
           "LIMIT",
-          "Too many active imports. Finish an existing import or retry after it expires.",
+          "Active import limit reached for your profile or the Gateway. Finish an existing import or retry after it expires.",
         );
       }
       const uploadId = randomUUID();
@@ -136,28 +148,8 @@ export async function uploadSkillLibrary(
       return { uploadId, offset: 0, maxChunkBytes: MAX_CHUNK_BYTES };
     }, options);
   }
-  const readOwned = () => {
-    const db = openOpenClawStateDatabase(options).db;
-    const actor = requireSkillLibraryProfile(db, authority);
-    const upload = executeSqliteQuerySync(
-      db,
-      skillLibraryDb(db)
-        .selectFrom("skill_library_uploads")
-        .selectAll()
-        .where("upload_id", "=", params.uploadId),
-    ).rows[0];
-    if (
-      !upload ||
-      upload.expires_at <= Date.now() ||
-      selectResolvedUserProfileById(db, upload.owner_profile_id)?.id !== actor
-    ) {
-      throw new SkillLibraryError(
-        "NOT_FOUND",
-        "Upload not found for your profile, or expired. Start a new import.",
-      );
-    }
-    return upload;
-  };
+  const readOwned = () =>
+    requireSkillLibraryUpload(openOpenClawStateDatabase(options).db, params.uploadId, authority);
   if (params.action === "chunk") {
     const bytes = Buffer.from(params.data, "base64");
     if (
@@ -238,9 +230,7 @@ export async function uploadSkillLibrary(
           receipt: await publishDirectory(
             {
               ...authority,
-              assertCurrent: () => {
-                readOwned();
-              },
+              assertCurrent: readOwned,
             },
             upload.slug,
             rootDir,

--- a/src/skills/library/service.test.ts
+++ b/src/skills/library/service.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { SKILL_LIBRARY_MAX_FILE_BYTES } from "../../../packages/gateway-protocol/src/schema/skill-library.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { tableExists } from "../../state/openclaw-state-db-schema-helpers.js";
@@ -508,8 +508,10 @@ describe("library admission and imports", () => {
     }
     expect(revisions[0]).toBe(revisions[1]);
   });
-  it("counts only unfinished imports against the active upload limit", async () => {
-    const { alice, options } = fixture();
+  it("reserves pending import capacity for other profiles without counting completed receipts", async () => {
+    const { alice, actor, options } = fixture();
+    const bob = actor(ensureProfileForEmail("bob@example.test", options).id);
+    const charlie = actor(ensureProfileForEmail("charlie@example.test", options).id);
     const { default: JSZip } = await import("jszip");
     const zip = new JSZip();
     zip.file("SKILL.md", content);
@@ -528,13 +530,20 @@ describe("library admission and imports", () => {
     if (!("entry" in receipt)) {
       throw new Error("Expected completed import receipt");
     }
-    for (let index = 0; index < 31; index++) {
-      await beginZipUpload(alice, bytes, `pending-${index}`, options);
+    for (let index = 0; index < 16; index++) {
+      await beginZipUpload(alice, bytes, `alice-pending-${index}`, options);
     }
-    await expect(beginZipUpload(alice, bytes, "last-active-slot", options)).resolves.toMatchObject({
-      offset: 0,
-    });
-    await expect(beginZipUpload(alice, bytes, "over-active-limit", options)).rejects.toMatchObject({
+    await expect(beginZipUpload(alice, bytes, "over-profile-limit", options)).rejects.toMatchObject(
+      {
+        code: "LIMIT",
+      },
+    );
+    for (let index = 0; index < 16; index++) {
+      await beginZipUpload(bob, bytes, `bob-pending-${index}`, options);
+    }
+    await expect(
+      beginZipUpload(charlie, bytes, "over-global-limit", options),
+    ).rejects.toMatchObject({
       code: "LIMIT",
     });
     await expect(
@@ -543,6 +552,47 @@ describe("library admission and imports", () => {
     expect(listSkillLibrary(alice, {}, options).entries.map((entry) => entry.skillId)).toEqual([
       receipt.entry.skillId,
     ]);
+  });
+
+  it("counts merged upload owners together while preserving completion and expiry", async () => {
+    const { alice, actor, options } = fixture();
+    const bob = actor(ensureProfileForEmail("bob@example.test", options).id);
+    const { default: JSZip } = await import("jszip");
+    const bytes = await new JSZip().file("SKILL.md", content).generateAsync({ type: "nodebuffer" });
+    const begun = await beginZipUpload(bob, bytes, "before-merge", options);
+    for (let index = 0; index < 8; index++) {
+      await beginZipUpload(alice, bytes, `alice-${index}`, options);
+      await beginZipUpload(bob, bytes, `bob-${index}`, options);
+    }
+    linkEmail("bob@example.test", alice.profileId!, options);
+    // Durable upload owners and retained connections may still carry Bob's pre-merge ID.
+    for (const authority of [alice, bob]) {
+      await expect(beginZipUpload(authority, bytes, "after-merge", options)).rejects.toMatchObject({
+        code: "LIMIT",
+      });
+    }
+    await uploadSkillLibrary(
+      alice,
+      { action: "chunk", uploadId: begun.uploadId, offset: 0, data: bytes.toString("base64") },
+      options,
+    );
+    await expect(
+      uploadSkillLibrary(bob, { action: "commit", uploadId: begun.uploadId }, options),
+    ).resolves.toMatchObject({ state: "published", entry: { ownerProfileId: alice.profileId } });
+    await expect(beginZipUpload(alice, bytes, "still-full", options)).rejects.toMatchObject({
+      code: "LIMIT",
+    });
+    const clock = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 3_600_000);
+    try {
+      await expect(beginZipUpload(bob, bytes, "after-expiry", options)).resolves.toMatchObject({
+        offset: 0,
+      });
+      await expect(
+        uploadSkillLibrary(alice, { action: "commit", uploadId: begun.uploadId }, options),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    } finally {
+      clock.mockRestore();
+    }
   });
 
   it("rejects a compressed oversized ZIP member at extraction before publishing a skill", async () => {

--- a/src/skills/library/service.ts
+++ b/src/skills/library/service.ts
@@ -39,6 +39,7 @@ import {
   recordSkillLibraryEvent,
   requireSkillLibraryEntry,
   requireSkillLibraryProfile,
+  requireSkillLibraryUpload,
   resolveSkillLibraryActor,
   selectSkillLibraryRevision,
   selectSkillLibraryRow,
@@ -280,15 +281,12 @@ export async function saveSkillLibrary(
       ({ db }) => {
         const actor = requireSkillLibraryProfile(db, authority);
         if (uploadId) {
-          const upload = executeSqliteQuerySync(
-            db,
-            skillLibraryDb(db)
-              .selectFrom("skill_library_uploads")
-              .selectAll()
-              .where("upload_id", "=", uploadId),
-          ).rows[0];
-          if (!upload || upload.slug !== params.slug || upload.expires_at <= Date.now()) {
-            throw new SkillLibraryError("NOT_FOUND", "Upload expired; start the import again.");
+          const upload = requireSkillLibraryUpload(db, uploadId, authority);
+          if (upload.slug !== params.slug) {
+            throw new SkillLibraryError(
+              "NOT_FOUND",
+              "Upload slug changed; start the import again.",
+            );
           }
           if (upload.published_skill_id) {
             return skillLibraryReceipt(

--- a/src/skills/library/store.ts
+++ b/src/skills/library/store.ts
@@ -125,6 +125,32 @@ export function requireSkillLibraryProfile(
   return actor.profileId;
 }
 
+export function requireSkillLibraryUpload(
+  db: DatabaseSync,
+  uploadId: string,
+  authority: SkillLibraryAuthority,
+) {
+  const actor = requireSkillLibraryProfile(db, authority);
+  const upload = executeSqliteQueryTakeFirstSync(
+    db,
+    skillLibraryDb(db)
+      .selectFrom("skill_library_uploads")
+      .selectAll()
+      .where("upload_id", "=", uploadId),
+  );
+  if (
+    !upload ||
+    upload.expires_at <= Date.now() ||
+    selectResolvedUserProfileById(db, upload.owner_profile_id)?.id !== actor
+  ) {
+    throw new SkillLibraryError(
+      "NOT_FOUND",
+      "Upload not found for your profile, or expired. Start a new import.",
+    );
+  }
+  return upload;
+}
+
 export function selectSkillLibraryRow(
   db: DatabaseSync,
   skillId: string,

--- a/test/e2e/qa-lab/runtime/skill-library-identity-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/skill-library-identity-wire.e2e.test.ts
@@ -1,9 +1,12 @@
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import type {
   SkillsLibraryListResult,
   SkillsLibraryReadResult,
   SkillsLibraryReceipt,
   SkillsLibrarySaveParams,
+  SkillsLibraryUploadParams,
+  SkillsLibraryUploadResult,
 } from "../../../../packages/gateway-protocol/src/schema/skill-library.js";
 import { runQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
 import {
@@ -313,6 +316,55 @@ describe("skill library real Gateway identity boundary", () => {
             }),
             "FORBIDDEN",
           );
+
+          const { default: JSZip } = await import("jszip");
+          const zipContent =
+            "---\nname: upload-proof\ndescription: Synthetic quota boundary proof.\n---\n# Upload proof\n";
+          const zip = new JSZip().file("SKILL.md", zipContent);
+          const bytes = await zip.generateAsync({ type: "nodebuffer" });
+          const sha256 = createHash("sha256").update(bytes).digest("hex");
+          const upload = (client: SkillLibraryWireClient, params: SkillsLibraryUploadParams) =>
+            client.request<SkillsLibraryUploadResult>("skills.library.upload", params);
+          const begin = (client: SkillLibraryWireClient, slug: string) =>
+            upload(client, { action: "begin", slug, sizeBytes: bytes.length, sha256 });
+          for (let index = 0; index < 16; index++) {
+            await expect(begin(alice, `pending-${index}`)).resolves.toMatchObject({
+              uploadId: expect.any(String),
+              offset: 0,
+            });
+          }
+          // The quota follows the person, including their separate administrator connection.
+          for (const client of [alice, aliceAdmin]) {
+            await expectLibraryError(begin(client, "over-profile-limit"), "LIMIT");
+          }
+          const begun = await begin(bob, "upload-proof");
+          if (!("uploadId" in begun)) {
+            throw new Error("Expected Bob's upload ID");
+          }
+          await expect(
+            upload(bob, {
+              action: "chunk",
+              uploadId: begun.uploadId,
+              offset: 0,
+              data: bytes.toString("base64"),
+            }),
+          ).resolves.toMatchObject({ uploadId: begun.uploadId, offset: bytes.length });
+          const published = await upload(bob, { action: "commit", uploadId: begun.uploadId });
+          if (!("entry" in published)) {
+            throw new Error("Expected Bob's publication receipt");
+          }
+          expect(published).toMatchObject({
+            state: "published",
+            entry: { ownerProfileId: bobList.profileId },
+          });
+          expect((await read(bob, published.entry.skillId)).content).toBe(zipContent);
+          await expect(
+            upload(bob, { action: "commit", uploadId: begun.uploadId }),
+          ).resolves.toMatchObject({
+            state: "unchanged",
+            entry: { skillId: published.entry.skillId },
+          });
+          await expectLibraryError(begin(alice, "still-over-profile-limit"), "LIMIT");
         },
         async () => {
           for (const client of clients.reverse()) {


### PR DESCRIPTION
Closes #135587. Follow-up to #134068 and its [post-merge review note](https://github.com/openclaw/openclaw/pull/134068#issuecomment-5500721006).

## What Problem This Solves

Fixes an issue where users importing a personal skill ZIP could be blocked when one other profile occupied all 32 unfinished upload slots.

## Why This Change Was Made

Admission now reserves capacity across owners: at most 16 pending imports per canonical profile, within the unchanged 32-pending Gateway ceiling. Counting, expiry cleanup, and insertion remain in the existing synchronous SQLite transaction. Linked and merged identities share the same allowance.

The cleanup moves upload ownership and expiry validation into the store owner, reused by chunk/commit and final publication. Publication still revalidates after asynchronous work; no parallel store or compatibility path was added.

The documented quota tradeoff and ClawSweeper Rank-up move were [accepted in the maintainer decision](https://github.com/openclaw/openclaw/pull/135593#issuecomment-5501287868); the review found no correctness or security defect.

## User Impact

One profile can no longer newly occupy the whole pending-import pool. Existing unexpired uploads remain finishable even when a merge or upgrade leaves a profile over quota. Completed receipts stay replayable and do not consume pending capacity; the one-hour expiry is unchanged.

This bounds pending admission, not total retained bytes. Multiple profiles can still fill the global pool, and existing over-quota uploads are not evicted. No configuration, protocol, schema, migration, or retention change.

## Evidence

Before: extending the existing SQLite-backed test on main `45be2a2ed06` to begin an import as Bob after Alice filled 32 slots reproduced `LIMIT` at `src/skills/library/import.ts:117` (1 targeted regression failed; 14 unrelated tests filtered out).

After: all 34 focused tests passed across the library service, bundle validation, and Gateway library handler suites. The regression covers 16-per-profile/32-global admission, completed replay at saturation, historical owners after a profile merge, over-quota completion, and expiry recovery.

Codex autoreview: no accepted/actionable P0–P2 findings. Formatting and the normal pre-commit checks passed. Real authenticated Gateway ZIP import proof passed on Linux through a real child Gateway and WebSocket authentication, with synthetic identities and ZIP content: Alice reaches 16, both Alice connections reject the 17th, Bob begins/chunks/commits/reads/replays, and Alice remains capped. No mock handler or injected authority. [Blacksmith run](https://github.com/openclaw/openclaw/actions/runs/33564587048), lease `tbx_01m1fg4mpz6b1g158yk3ssvz73`, wrapper exit 0; scenario 1/1 passed in 2.62 seconds, including clean build/setup 295.37 seconds. The six synced files were byte-identical to PR head `7315701e8bf9600a4141deb36cc2b278bf7d1d84`.

Remote command: `OPENCLAW_BUILD_PRIVATE_QA=1 node scripts/run-node.mjs --help` followed by `OPENCLAW_E2E_VERBOSE=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/e2e/qa-lab/runtime/skill-library-identity-wire.e2e.test.ts`. The task-owned Testbox stopped successfully; the linked lease workflow may show cancellation during normal cleanup. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33565139673) passed for `7315701e8bf9600a4141deb36cc2b278bf7d1d84`.

Production LOC: +55/-41 (net +14), after consolidating the duplicated upload lookup. Remaining growth implements the canonical-owner allowance and shared validation call boundary; tests add +111/-9 (net +102), documentation +7. No generated or lockfile changes.
