### PR TITLE
test(cli): await version diagnostic completion

### DIFF
--- a/src/entry.version-fast-path.test.ts
+++ b/src/entry.version-fast-path.test.ts
@@ -1,5 +1,6 @@
 // Tests version fast-path output before the full entrypoint loads.
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../test/helpers/promise.js";
 import { tryHandleRootVersionFastPath } from "./entry.version-fast-path.js";
 
 vi.mock("./cli/argv.js", () => ({
@@ -13,15 +14,15 @@ vi.mock("./cli/container-target.js", () => ({
     argv.includes("--container") ? "demo" : (env.OPENCLAW_CONTAINER ?? null),
 }));
 
-async function flushVersionFastPath() {
-  await Promise.resolve();
-  await Promise.resolve();
-}
-
 describe("entry root version fast path", () => {
   it("prints version output and skips host handling when container-targeted", async () => {
     const output = vi.fn();
-    const exit = vi.fn();
+    const taggedExit = createDeferred();
+    const plainExit = createDeferred();
+    const exit = vi
+      .fn()
+      .mockImplementationOnce(() => taggedExit.resolve())
+      .mockImplementationOnce(() => plainExit.resolve());
     const resolveVersion = vi.fn<
       () => Promise<{
         VERSION: string;
@@ -39,7 +40,7 @@ describe("entry root version fast path", () => {
         resolveVersion,
       }),
     ).toBe(true);
-    await flushVersionFastPath();
+    await taggedExit.promise;
     expect(output).toHaveBeenCalledWith("OpenClaw 9.9.9-test (abc1234)");
     expect(exit).toHaveBeenCalledWith(0);
 
@@ -57,7 +58,7 @@ describe("entry root version fast path", () => {
         resolveVersion,
       }),
     ).toBe(true);
-    await flushVersionFastPath();
+    await plainExit.promise;
     expect(output).toHaveBeenCalledWith("OpenClaw 9.9.9-test");
     expect(exit).toHaveBeenCalledWith(0);
 
@@ -84,72 +85,80 @@ describe("entry root version fast path", () => {
     ).toBe(false);
   });
 
-  it("calls exit(1) via injected exit hook when resolveVersion rejects", async () => {
-    const exit = vi.fn();
-    const output = vi.fn();
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
-    const resolveVersion = vi
-      .fn<() => Promise<never>>()
-      .mockRejectedValue(new Error("version resolution failed"));
+  describe("default error diagnostics", () => {
+    let logging: typeof import("./logging.js");
 
-    try {
-      expect(
-        tryHandleRootVersionFastPath(["node", "openclaw", "--version"], {
+    beforeAll(async () => {
+      // Cold diagnostics can compile worker artifacts; prepare them before behavior deadlines.
+      [logging] = await Promise.all([
+        import("./logging.js"),
+        import("./cli/dotenv.js"),
+        import("./logging/json-console-line.js"),
+      ]);
+    });
+
+    it("calls exit(1) via injected exit hook when resolveVersion rejects", async () => {
+      const completed = createDeferred();
+      const exit = vi.fn(() => completed.resolve());
+      const output = vi.fn();
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+      const resolveVersion = vi
+        .fn<() => Promise<never>>()
+        .mockRejectedValue(new Error("version resolution failed"));
+
+      try {
+        const handled = tryHandleRootVersionFastPath(["node", "openclaw", "--version"], {
           output,
           exit,
           resolveVersion,
-        }),
-      ).toBe(true);
-      await flushVersionFastPath();
-      expect(resolveVersion).toHaveBeenCalledTimes(1);
-      await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1), { timeout: 10_000 });
-      expect(output).not.toHaveBeenCalled();
-      expect(exit).toHaveBeenCalledTimes(1);
-      expect(stderrSpy.mock.calls.map(([value]) => String(value)).join("\n")).toContain(
-        "version resolution failed",
-      );
-    } finally {
-      stderrSpy.mockRestore();
-    }
-  });
+        });
+        await withTestTimeout(completed.promise, 10_000, "version failure did not exit");
+        expect(handled).toBe(true);
+        expect(resolveVersion).toHaveBeenCalledTimes(1);
+        expect(exit).toHaveBeenCalledWith(1);
+        expect(output).not.toHaveBeenCalled();
+        expect(exit).toHaveBeenCalledTimes(1);
+        expect(stderrSpy.mock.calls.map(([value]) => String(value)).join("\n")).toContain(
+          "version resolution failed",
+        );
+      } finally {
+        stderrSpy.mockRestore();
+      }
+    });
 
-  it("structures version-resolution failures for JSON console output", async () => {
-    const logging = await import("./logging.js");
-    const exit = vi.fn();
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
-    const resolveVersion = vi
-      .fn<() => Promise<never>>()
-      .mockRejectedValue(new Error("version resolution failed"));
-    logging.setLoggerOverride({ level: "silent", consoleLevel: "info", consoleStyle: "json" });
+    it("structures version-resolution failures for JSON console output", async () => {
+      const completed = createDeferred();
+      const exit = vi.fn(() => completed.resolve());
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+      const resolveVersion = vi
+        .fn<() => Promise<never>>()
+        .mockRejectedValue(new Error("version resolution failed"));
+      logging.setLoggerOverride({ level: "silent", consoleLevel: "info", consoleStyle: "json" });
 
-    try {
-      expect(
-        tryHandleRootVersionFastPath(["node", "openclaw", "--version"], {
+      try {
+        const handled = tryHandleRootVersionFastPath(["node", "openclaw", "--version"], {
           exit,
           resolveVersion,
-        }),
-      ).toBe(true);
-      await flushVersionFastPath();
-
-      await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1), { timeout: 10_000 });
-      const line = stderrSpy.mock.calls.map(([value]) => String(value)).join("");
-      expect(JSON.parse(line)).toMatchObject({
-        level: "error",
-        message: expect.stringContaining("version resolution failed"),
-      });
-    } finally {
-      logging.resetLogger();
-      stderrSpy.mockRestore();
-    }
+        });
+        await withTestTimeout(completed.promise, 10_000, "JSON version failure did not exit");
+        expect(handled).toBe(true);
+        expect(exit).toHaveBeenCalledWith(1);
+        const line = stderrSpy.mock.calls.map(([value]) => String(value)).join("");
+        expect(JSON.parse(line)).toMatchObject({
+          level: "error",
+          message: expect.stringContaining("version resolution failed"),
+        });
+      } finally {
+        logging.resetLogger();
+        stderrSpy.mockRestore();
+      }
+    });
   });
 
   it("calls injected onError when provided and resolveVersion rejects", async () => {
     const exit = vi.fn();
-    const onError = vi.fn();
+    const completed = createDeferred();
+    const onError = vi.fn(() => completed.resolve());
     const resolveVersion = vi
       .fn<() => Promise<never>>()
       .mockRejectedValue(new Error("version resolution failed"));
@@ -161,7 +170,7 @@ describe("entry root version fast path", () => {
         resolveVersion,
       }),
     ).toBe(true);
-    await flushVersionFastPath();
+    await completed.promise;
     expect(resolveVersion).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledTimes(1);
     expect(exit).not.toHaveBeenCalled();


### PR DESCRIPTION
## What Problem This Solves

The version fast-path error tests start their 10-second assertion deadlines while the real diagnostic imports can trigger worker compilation. A standalone cold run failed both error cases; worker preparation alone took 15.5 seconds. An earlier run also showed the unfinished handler contaminating the next test's JSON capture after its timeout.

## Why This Change Was Made

Give the two default-error cases their own group and prepare the actual dotenv and diagnostic formatting modules in its setup. Focused success and injected-error cases keep their lightweight setup. Observe each invocation's injected exit or error callback with a fresh deferred completion, replacing fixed microtask flushing and polling. The error cases await completion before assertions and retain their existing 10-second bounds; stderr capture and logging overrides remain owned until that completion.

The real default error handler, dotenv loading, JSON formatting, and all four test scenarios remain. The stderr spies now use their typed boolean return directly.

## User Impact

No CLI behavior changes. This removes false cold-import timeouts and the known late-handler capture overlap. Worker compilation remains part of suite setup; this change does not claim to make that compilation faster.

## Evidence

- Original standalone cold run: 2 passed, 2 failed at the existing 10-second error deadlines.
- Changed standalone cold run: 4/4 passed, including real worker preparation lasting 12.7 seconds.
- Final shuffled version, entry, root-help, and package-entrypoint suites: 43/43 passed (seed 1229). The focused success case also passes in 3 ms without worker preparation.
- All four version leaf case names and the complete-capture JSON parse retained. Error timeouts, suite routing, production behavior, and dependency mocks are unchanged.
- Changed-file checks: core-test typecheck, formatting, architecture/API guards, and all three dead-export scans passed. The final targeted lint passed after correcting an unreadable tuple destructuring.
- Diff-scoped Codex review (P0 scope): clean; manual callback/capture lifetime and real formatter review completed.
- Production LOC: zero. Test LOC: +74/-65.
