### PR TITLE
docs: move v2026.8.1 beta note to footnote

### DIFF
--- a/docs/releases/2026.8.1.md
+++ b/docs/releases/2026.8.1.md
@@ -16,12 +16,6 @@ keywords:
 
 For the story behind this release, read [OpenClaw 2.0, Accidentally](https://openclaw.ai/blog/openclaw-2-accidentally).
 
-<Warning>
-**Mistaken beta publication**
-
-The package published as `2026.9.1-beta.1` was incorrectly versioned and is actually `2026.8.1-beta.4`. It should not be interpreted as newer than stable `2026.8.1`; stable users should install or update to `2026.8.1`.
-</Warning>
-
 This update touches every part of OpenClaw, including installation, messaging, memory, skills, models, automations, the browser and native apps, plugins, security, and many smaller fixes.
 
 The sections below describe the user-facing result, with the complete PR and commit record available inside each subsection when someone wants to dig into it.
@@ -20264,3 +20258,5 @@ This completes the record for all 17,675 analyzed PRs and commits in v2026.8.1. 
 </Accordion>
 
 </AccordionGroup>
+
+_Version note: The package published as `2026.9.1-beta.1` was incorrectly versioned and corresponds to `2026.8.1-beta.4`; it is not newer than stable `2026.8.1`._


### PR DESCRIPTION
## What Problem This Solves

The prominent mistaken-beta warning at the top of the v2026.8.1 release notes interrupts the release overview and gives a historical versioning correction more visual weight than the release itself.

## Why This Change Was Made

This removes the warning from the introduction and preserves the same clarification as a quiet version note at the true end of the page. The correction remains available to readers and agents without dominating the human-readable release notes.

## User Impact

Readers now reach the v2026.8.1 release story immediately. Anyone who needs the beta-version clarification can still find it at the bottom of the page.

## Evidence

- `pnpm docs:list`
- `node scripts/check-docs-mdx.mjs docs/releases/2026.8.1.md`
- `pnpm check:docs` (739 formatted docs, 737 linted docs, 752 MDX files, 7,203 internal links, and 1,212 validated config examples)
- `pnpm check:changed` (`docs-only` lane)
- `git diff --check origin/main...HEAD`
- Exact diff: one docs file, 2 insertions and 6 deletions
