### PR TITLE
perf(cron): reuse collation within name-sorted job lists

### DIFF
--- a/src/cron/service/list-page-sort.ts
+++ b/src/cron/service/list-page-sort.ts
@@ -7,12 +7,16 @@ export function sortCronJobs(
   sortDir: CronSortDir,
 ): CronJob[] {
   const dir = sortDir === "desc" ? -1 : 1;
+  // Explicit options bypass native localeCompare caching; keep collation local to this sort.
+  let compareNames: Intl.Collator["compare"] | undefined;
   return jobs.toSorted((a, b) => {
-    let cmp;
+    let cmp = 0;
     if (sortBy === "name") {
       const aName = typeof a.name === "string" ? a.name : "";
       const bName = typeof b.name === "string" ? b.name : "";
-      cmp = aName.localeCompare(bName, undefined, { sensitivity: "base" });
+      // oxlint-disable-next-line typescript/unbound-method -- Intl.Collator.compare returns a bound function.
+      compareNames ??= new Intl.Collator(undefined, { sensitivity: "base" }).compare;
+      cmp = compareNames(aName, bName);
     } else if (sortBy === "updatedAtMs") {
       cmp = a.updatedAtMs - b.updatedAtMs;
     } else {
@@ -20,14 +24,9 @@ export function sortCronJobs(
       const bNext = b.state.nextRunAtMs;
       if (typeof aNext === "number" && typeof bNext === "number") {
         cmp = aNext - bNext;
-      } else if (typeof aNext === "number") {
-        // Missing run times are not directional sort keys. Keep paused jobs
-        // after runnable jobs so descending pages do not hide scheduled work.
-        return -1;
-      } else if (typeof bNext === "number") {
-        return 1;
-      } else {
-        cmp = 0;
+      } else if (typeof aNext === "number" || typeof bNext === "number") {
+        // Missing run times stay last in either direction so paused jobs cannot hide scheduled work.
+        return typeof aNext === "number" ? -1 : 1;
       }
     }
     if (cmp !== 0) {

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -218,6 +218,8 @@ describe("production lint suppressions", () => {
         "src/cli/test-runtime-capture.ts|typescript/no-unnecessary-type-parameters|1",
         // Cleanup is retained in AggregateError.errors; extraction remains the primary cause.
         "src/commands/backup-restore.ts|preserve-caught-error|1",
+        // Intl.Collator.compare is a getter returning a bound function.
+        "src/cron/service/list-page-sort.ts|typescript/unbound-method|1",
         "src/gateway/test-helpers.server.ts|typescript/no-unnecessary-type-parameters|1",
         "src/hooks/module-loader.ts|typescript/no-unnecessary-type-parameters|1",
         "src/infra/device-pairing-store.ts|typescript/no-unnecessary-type-parameters|1",

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-row-lifecycle.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-row-lifecycle.ts
@@ -109,12 +109,15 @@ describe("AppSidebar catalog row lifecycle", () => {
       await sidebar.updateComplete;
     };
     await setLabel("A long catalog session title");
-    const oldLabel = sidebar.querySelector<HTMLElement>(".hover-marquee");
+    const labelSelector = "[data-catalog-session-key] .sidebar-recent-session__name";
+    const oldLabel = sidebar.querySelector<HTMLElement>(labelSelector);
+    expect(oldLabel?.textContent).toBe("A long catalog session title");
     oldLabel?.classList.add("hover-marquee--scrolling");
     oldLabel?.style.setProperty("--hover-marquee-shift", "-80px");
     await setLabel("Short");
 
-    const updatedLabel = sidebar.querySelector<HTMLElement>(".hover-marquee");
+    const updatedLabel = sidebar.querySelector<HTMLElement>(labelSelector);
+    expect(updatedLabel?.textContent).toBe("Short");
     expect(updatedLabel).not.toBe(oldLabel);
     expect(updatedLabel?.classList.contains("hover-marquee--scrolling")).toBe(false);
     expect(updatedLabel?.style.getPropertyValue("--hover-marquee-shift")).toBe("");


### PR DESCRIPTION
Name-sorted cron lists construct an ICU collator for every comparison because `localeCompare` receives explicit options. The cost grows with the full filtered job list, even when the caller requests one small page.

This change keeps one lazy `Intl.Collator` comparison function within `sortCronJobs`. Empty, single-job and numeric sorts do not construct it. Locale and sensitivity defaults, ascending ID tie-breaks, missing-last numeric ordering, input ownership, filtering and snapshot revisions stay unchanged. The adjacent missing-time branches collapse into one equivalent branch. Production: **+9/−10 lines, net −1**; test and test-support changes total +7/−2, net +5; no new dependency, configuration, schema or persistent cache.

The narrow lint suppression documents a language contract: `Intl.Collator.compare` returns a bound function. Node's [localeCompare implementation](https://github.com/nodejs/node/blob/v26.8.1/deps/v8/src/objects/intl-objects.cc#L1014) shows the explicit-options cache exclusion; the [compare getter](https://github.com/nodejs/node/blob/v26.8.1/deps/v8/src/builtins/builtins-intl.cc#L1106) retains the bound function.

### Measured behavior

One fixed before/candidate/candidate/before sequence on Node 26.8.1, with actual SQLite-backed cron services and authenticated loopback Gateway requests. Each of 12 rows has one first use, eight warmups and 31 measured observations in each host: **1,920 observations**, with full returned values, serialized output, revisions, timings and RSS retained. The clock includes the entire list operation and JSON serialization; Gateway rows also include transport. No output normalization, excluded outliers, workload retuning or timing retries.

| Complete operation | Before median, two orders | Candidate median, two orders | Reduction |
| --- | --- | --- | --- |
| Service, 32 jobs sorted by name | 412 / 444 µs | 220 / 228 µs | 47 / 49% |
| Service, 128 jobs sorted by name | 1.767 / 1.782 ms | 0.504 / 0.522 ms | 71 / 71% |
| Gateway, 50-job Control UI request | 4.151 / 4.040 ms | 3.805 / 3.617 ms | 8 / 10% |
| Gateway, later page of 128 jobs | 5.490 / 5.949 ms | 4.390 / 4.528 ms | 20 / 24% |

All four primary rows exceeded the predeclared 3% improvement requirement in both orders. No control exceeded the predeclared 3% regression limit in both orders. This is a name-sort improvement, with real limits:

- The numeric timestamp control was slower by 1 / 14 µs (+0.22 / +3.06%). The default full RPC control was +3.63 / −0.48%; singleton and other control changes were also directionally mixed.
- First default service reads were +60 / +49 µs. First default RPC reads with previews were +90 / +1,459 µs. The later name-page first read was +291 µs in the forward order. These prevent a universal first-use improvement claim.
- Candidate whole-host peak RSS was +0.54 / +1.13%; post-Gateway sample RSS was often 32–94 MB higher. No memory benefit or GC explanation is claimed.
- The reverse candidate retained a 77 ms full-request sample and its 56 ms server response log. No slow samples were removed.

### Validation

The original paired native proof compares **24 complete output cases**: Unicode and case ties, both directions, unchanged ID ordering, malformed helper-only inputs, all 72 numeric/missing combinations, page isolation, full revisions and off-page mutations, defaults, filtering and invalid RPC parameters. Both variants have complete startup logs, the expected two disabled managed jobs, clean shutdown and verified process/database/coordinator cleanup. Earlier successful proof runs without native logs were retained as incomplete evidence and were not used for timing.

Measurements are pinned to `3a6654c851582b81f15f9c54dc5deacf5e5f945a`. After pulling main `213975df7583433c088dc18e755d5c870156fa9f`, fresh validation covered the newer startup catch-up code:

- **248 existing tests per variant**, across five complete files and two canonical projects: sort guards, nonblocking reads, past-due reads, startup catch-up and Gateway cron validation.
- A fresh native Gateway run on the integrated candidate matched all 24 earlier output byte streams exactly. Full startup logs and disabled managed jobs were inspected; every observed process/group, temporary database, coordinator and listener closed. Its slower startup and 96 ms status response remain compatibility evidence, not a speed comparison.
- Independent source/raw-data review checked all 1,920 observations and 24 paired cases, including slower controls and cleanup. Codex review found no actionable issues.
- Final `pnpm check:changed`: **passed** (224.8 seconds). The first run passed typechecks and guards but flagged the specified bound function as an unbound method; the explanatory suppression passed a separate type-aware lint run. It adds only a comment to the measured executable source.

The fixed timing result SHA-256 is `da1466e6076a569af57168ee450c1e229bbe6981846f9529d073dce97ccfbc95`; independent audit seal is `c9b0f22ff19833ccbd8f42a83546f366056fc481877de4aa1a2ef8184c72536e`. Raw local artifacts are retained; hosted checks provide the independently runnable repository validation.

No changelog or public API/docs changes are needed. Release context: reduce overhead when operators or clients list cron jobs sorted by name.

A separate source-only follow-up records that visibility-scoped pagination should be reproduced under concurrent mutation to check snapshot consistency. It is unconfirmed and predates this comparator change.

CI caught the repository suppression inventory missing the intentional `Intl.Collator.compare` lint exception. Head `24d9a1c` adds one exact allowlist entry and its bound-getter explanation (two test lines); production remains +9/−10, net −1. All four suppression-guard tests, the changed-file checks, and a fresh structured review pass. No runtime code or historical measurements changed. The failed CI result is retained and the updated head runs normal CI.

The second CI run exposed a sidebar test selector made ambiguous by upstream #135523: a new heading now also uses `.hover-marquee`. This PR includes the bounded test repair: select the catalog session label and assert its old and new text while retaining replacement/style checks. The full sidebar suite reproduced one failure out of 323 before the edit and passed all 323 afterward. The refreshed complete PR passed a new structured Codex review and changed-file checks. The current head includes this test-only repair and a rebase onto `a6f0d094`; the cron production owner remains byte-identical to the previously measured candidate. No UI production behavior changed.
