### PR TITLE
refactor(plugins): simplify discovery, setup, and update reporting

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2430,7 +2430,6 @@ src/commands/backup-restore.ts	1
 src/commands/backup-schedule.ts	2
 src/commands/backup-shared.ts	1
 src/commands/backup-verify.ts	2
-src/commands/channel-setup/channel-plugin-resolution.ts	1
 src/commands/channel-setup/config-compatibility.ts	2
 src/commands/channel-setup/discovery.ts	11
 src/commands/channel-test-registry.ts	2

--- a/src/cli/channels-cli-add-args.ts
+++ b/src/cli/channels-cli-add-args.ts
@@ -1,9 +1,8 @@
 import { Option, type Command } from "commander";
 import { getCommandArgsWithRootOptions } from "../infra/cli-root-options.js";
-import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import { createLazyPromise } from "../shared/lazy-promise.js";
 import { normalizeWindowsArgv } from "./windows-argv.js";
 
-type ChannelSetupCliOptionsModule = typeof import("../channels/plugins/cli-add-options.js");
 type ChannelSetupFlagArity = "boolean" | "value" | "conflict";
 
 export type ChannelSetupCliOption = {
@@ -19,13 +18,9 @@ const CHANNEL_ADD_SHARED_VALUE_OPTION_PREFIXES = [...CHANNEL_ADD_SHARED_VALUE_OP
   (flag) => `${flag}=`,
 );
 
-const channelSetupCliOptionsLoader = createLazyImportLoader<ChannelSetupCliOptionsModule>(
+export const loadChannelSetupCliOptions = createLazyPromise(
   () => import("../channels/plugins/cli-add-options.js"),
 );
-
-export function loadChannelSetupCliOptions(): Promise<ChannelSetupCliOptionsModule> {
-  return channelSetupCliOptionsLoader.load();
-}
 
 export function getChannelSetupOptionSwitches(flags: string): string[] {
   const option = new Option(flags);

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -5,7 +5,7 @@ import { theme } from "../../packages/terminal-core/src/theme.js";
 import { danger } from "../globals.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { defaultRuntime } from "../runtime.js";
-import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import { createLazyPromise } from "../shared/lazy-promise.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
 import { runChannelLogin, runChannelLogout } from "./channel-auth.js";
 import { formatCliChannelOptions } from "./channel-options.js";
@@ -22,7 +22,6 @@ import { formatHelpExamples } from "./help-format.js";
 import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
 import { normalizeWindowsArgv } from "./windows-argv.js";
 
-type ChannelsCommandsModule = typeof import("../commands/channels.js");
 const optionNamesRemove = ["channel", "account", "delete"] as const;
 const CHANNEL_ADD_SELECTION_OPTION_NAMES = new Set(["agent", "channel"]);
 
@@ -58,12 +57,7 @@ const LEGACY_CHANNEL_SETUP_OPTIONS: readonly ChannelSetupCliOption[] = [
   },
 ];
 
-const channelsCommandsLoader = createLazyImportLoader<ChannelsCommandsModule>(
-  () => import("../commands/channels.js"),
-);
-function loadChannelsCommands(): Promise<ChannelsCommandsModule> {
-  return channelsCommandsLoader.load();
-}
+const loadChannelsCommands = createLazyPromise(() => import("../commands/channels.js"));
 
 function runChannelsCommand(action: () => Promise<void>) {
   return runCommandWithRuntime(defaultRuntime, action);

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -8,6 +8,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { Command } from "commander";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../packages/gateway-protocol/src/capability-consent-error-details.js";
+import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { writePackageDistInventory } from "../../scripts/lib/package-dist-inventory.ts";
 import { LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH } from "../../scripts/lib/package-lifecycle-marker.mjs";
 import { createDeferred } from "../../test/helpers/promise.js";
@@ -362,22 +363,6 @@ vi.mock("../plugins/installed-plugin-index-store-write.js", async (importOrigina
 });
 
 vi.mock("../commands/doctor/shared/post-core-plugin-convergence.js", () => ({
-  convergenceWarningsToOutcomes: (convergence: {
-    warnings: Array<{ pluginId?: string; message: string }>;
-    errored: boolean;
-  }) => ({
-    warnings: convergence.warnings,
-    outcomes: convergence.warnings
-      .filter((warning): warning is { pluginId: string; message: string } =>
-        Boolean(warning.pluginId),
-      )
-      .map((warning) => ({
-        pluginId: warning.pluginId,
-        status: "error",
-        message: warning.message,
-      })),
-    errored: convergence.errored,
-  }),
   runPostCorePluginConvergence: vi.fn(async (params: { baselineInstallRecords?: unknown }) => ({
     changes: [],
     warnings: [],
@@ -3456,6 +3441,82 @@ describe("update-cli", () => {
       env: { OPENCLAW_UPDATE_IN_PROGRESS: "0" },
     });
   });
+
+  it.each([false, true].flatMap((json) => [false, true].map((errored) => ({ json, errored }))))(
+    "preserves convergence diagnostic output (json=$json, errored=$errored)",
+    async ({ json, errored }) => {
+      const repairWarning = {
+        reason: "Package lookup deferred.",
+        message: "Package lookup deferred.",
+        guidance: ["Retry plugin repair."],
+      };
+      const smokeWarning = {
+        pluginId: "reporting-fixture",
+        reason: "missing-main-entry: entry missing",
+        message: 'Plugin "reporting-fixture" failed payload verification.',
+        guidance: ["Inspect the plugin entry."],
+      };
+      const notice = {
+        reason: "Retained plugin remains available.",
+        message: "Retained plugin remains available.",
+        guidance: [],
+      };
+      const warnings = errored ? [repairWarning, smokeWarning] : [repairWarning];
+      runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
+        ...postCoreConvergenceResult({ warnings, errored }),
+        notices: [notice],
+      });
+      const { updatePluginsAfterCoreUpdate } =
+        await import("./update-cli/update-command-plugins.js");
+
+      const result = await updatePluginsAfterCoreUpdate({
+        root: process.cwd(),
+        channel: "stable",
+        configSnapshot: baseSnapshot,
+        timeoutMs: 60_000,
+        json,
+      });
+
+      expect(result).toEqual({
+        status: errored ? "error" : "warning",
+        changed: false,
+        warnings: [...warnings, notice],
+        sync: {
+          changed: false,
+          switchedToBundled: [],
+          switchedToNpm: [],
+          warnings: [],
+          errors: [],
+        },
+        npm: {
+          changed: false,
+          outcomes: errored
+            ? [{ pluginId: "reporting-fixture", status: "error", message: smokeWarning.message }]
+            : [],
+        },
+        integrityDrifts: [],
+      });
+      const logs = vi
+        .mocked(defaultRuntime.log)
+        .mock.calls.map(([value]) => stripAnsi(String(value)));
+      expect(logs).toEqual(
+        json
+          ? []
+          : [
+              "",
+              "Updating plugins...",
+              repairWarning.message,
+              "  Retry plugin repair.",
+              ...(errored ? [smokeWarning.message, "  Inspect the plugin entry."] : []),
+              notice.message,
+              errored
+                ? "npm plugins: 0 updated, 0 unchanged, 1 failed."
+                : "No plugin updates needed.",
+              ...(errored ? [smokeWarning.message] : []),
+            ],
+      );
+    },
+  );
 
   it("keeps fresh doctor output off stdout during json post-core resume", async () => {
     vi.mocked(runExec).mockImplementation(async (_file, args) => ({

--- a/src/cli/update-cli/update-command-plugins.ts
+++ b/src/cli/update-cli/update-command-plugins.ts
@@ -2,10 +2,7 @@
 import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../../packages/gateway-protocol/src/capability-consent-error-details.js";
 import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
-import {
-  convergenceWarningsToOutcomes,
-  runPostCorePluginConvergence,
-} from "../../commands/doctor/shared/post-core-plugin-convergence.js";
+import { runPostCorePluginConvergence } from "../../commands/doctor/shared/post-core-plugin-convergence.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
@@ -41,15 +38,6 @@ const POST_UPDATE_PLUGIN_REPAIR_GUIDANCE =
 
 type PostUpdatePluginWarning = NonNullable<PostCorePluginUpdateResult["warnings"]>[number];
 
-function isClawHubTrustNotice(message: string): boolean {
-  return stripAnsi(message).includes("ClawHub Security Audit");
-}
-
-function isNonBlockingClawHubTrustNotice(message: string): boolean {
-  const audit = stripAnsi(message);
-  return audit.includes("ClawHub Security Audit") && audit.includes("Outcome: Review");
-}
-
 function formatPluginUpdateWarning(message: string): string {
   return message.includes("╭─") ? message : theme.warn(message);
 }
@@ -84,34 +72,6 @@ function createPostUpdatePluginWarning(params: {
       ? `Plugin "${params.pluginId}" could not be processed after the core update: ${reason} ${guidance.join(" ")}`
       : `Plugin post-update processing could not complete after the core update: ${reason} ${guidance.join(" ")}`,
     guidance,
-  };
-}
-
-function createGuidedPostUpdatePluginOutcome(
-  outcome: PluginUpdateOutcome,
-  options: { includeWarningInReason?: boolean } = {},
-): {
-  outcome: PluginUpdateOutcome;
-  warning?: PostUpdatePluginWarning;
-} {
-  if (outcome.status !== "error" && !isActionableSkippedPostUpdateOutcome(outcome)) {
-    return { outcome };
-  }
-  const includeWarningInReason = options.includeWarningInReason ?? true;
-  const warningReason =
-    outcome.warning && includeWarningInReason
-      ? `${outcome.warning}\n${outcome.message}`
-      : outcome.message;
-  const warning = createPostUpdatePluginWarning({
-    ...(outcome.pluginId && outcome.pluginId !== "unknown" ? { pluginId: outcome.pluginId } : {}),
-    reason: warningReason,
-  });
-  return {
-    outcome: {
-      ...outcome,
-      message: warning.message,
-    },
-    warning,
   };
 }
 
@@ -164,19 +124,6 @@ export async function updatePluginsAfterCoreUpdate(params: {
 
   const clawHubTrustNotices = new Set<string>();
   const loggedPluginWarnings = new Set<string>();
-  const hasLoggedPluginWarning = (message: string): boolean =>
-    loggedPluginWarnings.has(stripAnsi(message));
-  const recordLoggedPluginWarning = (message: string): void => {
-    loggedPluginWarnings.add(stripAnsi(message));
-  };
-  const recordClawHubTrustNotice = (message: string): void => {
-    const shouldRecord = params.json
-      ? isClawHubTrustNotice(message)
-      : isNonBlockingClawHubTrustNotice(message);
-    if (shouldRecord) {
-      clawHubTrustNotices.add(stripAnsi(message));
-    }
-  };
   const pluginLogger = {
     ...(params.json ? { terminalLinks: false } : {}),
     info: (msg: string) => {
@@ -185,8 +132,14 @@ export async function updatePluginsAfterCoreUpdate(params: {
       }
     },
     warn: (msg: string) => {
-      recordLoggedPluginWarning(msg);
-      recordClawHubTrustNotice(msg);
+      const plain = stripAnsi(msg);
+      loggedPluginWarnings.add(plain);
+      if (
+        plain.includes("ClawHub Security Audit") &&
+        (params.json || plain.includes("Outcome: Review"))
+      ) {
+        clawHubTrustNotices.add(plain);
+      }
       if (!params.json) {
         runtime.log(formatPluginUpdateWarning(msg));
       }
@@ -221,14 +174,35 @@ export async function updatePluginsAfterCoreUpdate(params: {
   });
   const integrityDrifts: PostCorePluginUpdateResult["integrityDrifts"] = [];
   const pluginUpdateOutcomes: PluginUpdateOutcome[] = [];
-  const collectPluginOutcome = (rawOutcome: PluginUpdateOutcome) => {
-    const includeWarningInReason =
-      params.json || !rawOutcome.warning || !hasLoggedPluginWarning(rawOutcome.warning);
-    const guided = createGuidedPostUpdatePluginOutcome(rawOutcome, { includeWarningInReason });
-    pluginUpdateOutcomes.push(guided.outcome);
-    if (guided.warning) {
-      warnings.push(guided.warning);
+  const collectPluginOutcome = (outcome: PluginUpdateOutcome) => {
+    if (outcome.status !== "error" && !isActionableSkippedPostUpdateOutcome(outcome)) {
+      pluginUpdateOutcomes.push(outcome);
+      return;
     }
+    const includeWarningInReason =
+      params.json || !outcome.warning || !loggedPluginWarnings.has(stripAnsi(outcome.warning));
+    const warning = createPostUpdatePluginWarning({
+      ...(outcome.pluginId && outcome.pluginId !== "unknown" ? { pluginId: outcome.pluginId } : {}),
+      reason:
+        outcome.warning && includeWarningInReason
+          ? `${outcome.warning}\n${outcome.message}`
+          : outcome.message,
+    });
+    pluginUpdateOutcomes.push({ ...outcome, message: warning.message });
+    warnings.push(warning);
+  };
+  const collectMissingPayloadOutcome = (entry: MissingPluginInstallPayload) => {
+    const warning = createPostUpdatePluginWarning({
+      pluginId: entry.pluginId,
+      reason: `Plugin install payload missing after update: ${formatMissingPluginPayloadReason(entry)}.`,
+    });
+    warnings.push(warning);
+    pluginUpdateOutcomes.push({
+      pluginId: entry.pluginId,
+      status: "error",
+      message: warning.message,
+    });
+    return warning;
   };
 
   const onPluginIntegrityDrift = async (drift: PluginUpdateIntegrityDriftParams) => {
@@ -274,18 +248,8 @@ export async function updatePluginsAfterCoreUpdate(params: {
   }
   let pluginConfig = cohort.config;
   let pluginsChanged = cohort.changed || params.configChanged === true;
-  const npmPluginsChanged = cohort.npmChanged;
   for (const entry of cohort.missingPayloads) {
-    const warning = createPostUpdatePluginWarning({
-      pluginId: entry.pluginId,
-      reason: `Plugin install payload missing after update: ${formatMissingPluginPayloadReason(entry)}.`,
-    });
-    warnings.push(warning);
-    pluginUpdateOutcomes.push({
-      pluginId: entry.pluginId,
-      status: "error",
-      message: warning.message,
-    });
+    const warning = collectMissingPayloadOutcome(entry);
     if (!params.json) {
       runtime.log(theme.warn(warning.message));
     }
@@ -295,22 +259,11 @@ export async function updatePluginsAfterCoreUpdate(params: {
     collectPluginOutcome(rawOutcome);
   }
 
-  pluginUpdateOutcomes.push(
-    ...cohort.remainingMissingPayloads
-      .filter((entry) => !cohort.repairedMissingPayloadIds.has(entry.pluginId))
-      .map((entry): PluginUpdateOutcome => {
-        const warning = createPostUpdatePluginWarning({
-          pluginId: entry.pluginId,
-          reason: `Plugin install payload missing after update: ${formatMissingPluginPayloadReason(entry)}.`,
-        });
-        warnings.push(warning);
-        return {
-          pluginId: entry.pluginId,
-          status: "error",
-          message: warning.message,
-        };
-      }),
-  );
+  for (const entry of cohort.remainingMissingPayloads) {
+    if (!cohort.repairedMissingPayloadIds.has(entry.pluginId)) {
+      collectMissingPayloadOutcome(entry);
+    }
+  }
 
   // Convergence checks activation before restart. Seed it from the current
   // sync/npm records so repair cannot overwrite them with an older disk snapshot.
@@ -327,8 +280,13 @@ export async function updatePluginsAfterCoreUpdate(params: {
       runtime.log(theme.muted(change));
     }
   }
-  const convergenceFolded = convergenceWarningsToOutcomes(convergence);
-  for (const warning of convergenceFolded.warnings) {
+  const convergenceOutcomes = convergence.warnings.flatMap((warning): PluginUpdateOutcome[] =>
+    warning.pluginId
+      ? [{ pluginId: warning.pluginId, status: "error", message: warning.message }]
+      : [],
+  );
+  const convergenceErrored = convergence.errored;
+  for (const warning of [...convergence.warnings, ...(convergence.notices ?? [])]) {
     warnings.push(warning);
     if (!params.json) {
       runtime.log(theme.warn(warning.message));
@@ -337,8 +295,7 @@ export async function updatePluginsAfterCoreUpdate(params: {
       }
     }
   }
-  pluginUpdateOutcomes.push(...convergenceFolded.outcomes);
-  const convergenceErrored = convergenceFolded.errored;
+  pluginUpdateOutcomes.push(...convergenceOutcomes);
   // Repair already persisted this authoritative map; the commit below must not
   // restore the pre-convergence records and discard successful repairs.
   pluginConfig = withPluginInstallRecords(pluginConfig, convergence.installRecords);
@@ -407,7 +364,7 @@ export async function updatePluginsAfterCoreUpdate(params: {
       errors: cohort.sync.summary.errors.map((error) => error.message),
     },
     npm: {
-      changed: npmPluginsChanged,
+      changed: cohort.npmChanged,
       outcomes: pluginUpdateOutcomes,
     },
     integrityDrifts,
@@ -437,7 +394,7 @@ export async function updatePluginsAfterCoreUpdate(params: {
     );
   }
   for (const warning of cohort.sync.summary.warnings) {
-    if (!hasLoggedPluginWarning(warning)) {
+    if (!loggedPluginWarnings.has(stripAnsi(warning))) {
       runtime.log(formatPluginUpdateWarning(warning));
     }
   }

--- a/src/commands/channel-setup/channel-plugin-resolution.test.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.test.ts
@@ -387,4 +387,56 @@ describe("resolveInstallableChannelPlugin", () => {
       expect.objectContaining({ workspaceDir: "/tmp/workspace" }),
     );
   });
+
+  it.each([true, false])(
+    "preserves the installation result and workspace when installed=%s",
+    async (installed) => {
+      const cfg = { plugins: { enabled: true } };
+      const entry = createCatalogEntry({ id: "demo", pluginId: "demo", origin: "bundled" });
+      const plugin = createPlugin("demo");
+      const pluginId = installed ? "installed-demo" : "demo";
+      const nextCfg = installed ? { plugins: { allow: [pluginId] } } : cfg;
+      mocks.listChannelPluginCatalogEntries.mockReturnValue([entry]);
+      mocks.loadChannelSetupPluginRegistrySnapshotForChannel.mockImplementation(
+        ({ cfg: loadedCfg }) => ({
+          channels: installed && loadedCfg === nextCfg ? [{ plugin }] : [],
+          channelSetups: [],
+        }),
+      );
+      mocks.ensureChannelSetupPluginInstalled.mockResolvedValueOnce({
+        cfg: nextCfg,
+        installed,
+        pluginId,
+        status: installed ? "installed" : "skipped",
+      });
+
+      const result = await resolveInstallableChannelPlugin({
+        cfg,
+        runtime: {} as never,
+        rawChannel: "demo",
+      });
+
+      expect(result).toEqual({
+        cfg: nextCfg,
+        channelId: "demo",
+        plugin: installed ? plugin : undefined,
+        catalogEntry: { ...entry, pluginId },
+        configChanged: installed,
+        pluginInstalled: installed,
+        supportsRequestedCapability: installed ? true : undefined,
+      });
+      expect(mocks.resolveAgentWorkspaceDir).toHaveBeenCalledTimes(1);
+      expect(mocks.ensureChannelSetupPluginInstalled).toHaveBeenCalledWith(
+        expect.objectContaining({ cfg, entry, workspaceDir: "/tmp/workspace" }),
+      );
+      expect(mocks.loadChannelSetupPluginRegistrySnapshotForChannel).toHaveBeenCalledTimes(
+        installed ? 2 : 1,
+      );
+      if (installed) {
+        expect(mocks.loadChannelSetupPluginRegistrySnapshotForChannel).toHaveBeenLastCalledWith(
+          expect.objectContaining({ cfg: nextCfg, pluginId, workspaceDir: "/tmp/workspace" }),
+        );
+      }
+    },
+  );
 });

--- a/src/commands/channel-setup/channel-plugin-resolution.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.ts
@@ -1,9 +1,6 @@
 // Resolves or installs channel plugins needed by setup/onboarding flows.
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
-import {
-  listRawChannelPluginCatalogEntries,
-  type ChannelPluginCatalogEntry,
-} from "../../channels/plugins/catalog.js";
+import type { ChannelPluginCatalogEntry } from "../../channels/plugins/catalog.js";
 import { getLoadedChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
@@ -21,11 +18,6 @@ import {
   listTrustedChannelPluginCatalogEntries,
 } from "./trusted-catalog.js";
 
-type ChannelPluginSnapshot = {
-  channels: Array<{ plugin: ChannelPlugin }>;
-  channelSetups: Array<{ plugin: ChannelPlugin }>;
-};
-
 type ResolveInstallableChannelPluginResult = {
   cfg: OpenClawConfig;
   channelId?: ChannelId;
@@ -36,35 +28,12 @@ type ResolveInstallableChannelPluginResult = {
   supportsRequestedCapability?: boolean;
 };
 
-function resolveResolvedChannelId(params: {
-  rawChannel?: string | null;
-  catalogEntry?: ChannelPluginCatalogEntry;
-}): ChannelId | undefined {
-  const normalized = normalizeChannelId(params.rawChannel);
-  if (normalized) {
-    return normalized;
-  }
-  if (!params.catalogEntry) {
-    return undefined;
-  }
-  return normalizeChannelId(params.catalogEntry.id) ?? (params.catalogEntry.id as ChannelId);
-}
-
-function resolveCatalogChannelEntry(
-  raw: string,
-  cfg: OpenClawConfig | null,
-  workspaceDir?: string,
-) {
+function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig, workspaceDir?: string) {
   const trimmed = normalizeOptionalLowercaseString(raw);
   if (!trimmed) {
     return undefined;
   }
-  const entries = cfg
-    ? listTrustedChannelPluginCatalogEntries({
-        cfg,
-        workspaceDir,
-      })
-    : listRawChannelPluginCatalogEntries({ excludeWorkspace: true });
+  const entries = listTrustedChannelPluginCatalogEntries({ cfg, workspaceDir });
   return entries.find((entry) => {
     if (normalizeOptionalLowercaseString(entry.id) === trimmed) {
       return true;
@@ -73,37 +42,6 @@ function resolveCatalogChannelEntry(
       (alias) => normalizeOptionalLowercaseString(alias) === trimmed,
     );
   });
-}
-
-function findScopedChannelPlugin(
-  snapshot: ChannelPluginSnapshot,
-  channelId: ChannelId,
-  supports: (plugin: ChannelPlugin) => boolean,
-): ChannelPlugin | undefined {
-  const runtimePlugin = snapshot.channels.find((entry) => entry.plugin.id === channelId)?.plugin;
-  if (runtimePlugin) {
-    return runtimePlugin;
-  }
-  const setupPlugin = snapshot.channelSetups.find((entry) => entry.plugin.id === channelId)?.plugin;
-  return setupPlugin && supports(setupPlugin) ? setupPlugin : undefined;
-}
-
-function loadScopedChannelPlugin(params: {
-  cfg: OpenClawConfig;
-  runtime: RuntimeEnv;
-  channelId: ChannelId;
-  supports: (plugin: ChannelPlugin) => boolean;
-  pluginId?: string;
-  workspaceDir?: string;
-}): ChannelPlugin | undefined {
-  const snapshot = loadChannelSetupPluginRegistrySnapshotForChannel({
-    cfg: params.cfg,
-    runtime: params.runtime,
-    channel: params.channelId,
-    ...(params.pluginId ? { pluginId: params.pluginId } : {}),
-    workspaceDir: params.workspaceDir,
-  });
-  return findScopedChannelPlugin(snapshot, params.channelId, params.supports);
 }
 
 /** Resolve an existing channel plugin, scoped setup plugin, or installable catalog entry. */
@@ -138,7 +76,7 @@ export async function resolveInstallableChannelPlugin(params: {
 
   // Installation may replace config, but discovery must retain this operation's workspace.
   const { workspaceDir } = resolveChannelSetupOwner(nextCfg, params.agentId);
-  const catalogEntry =
+  let catalogEntry =
     (params.rawChannel
       ? resolveCatalogChannelEntry(params.rawChannel, nextCfg, workspaceDir)
       : undefined) ??
@@ -150,10 +88,7 @@ export async function resolveInstallableChannelPlugin(params: {
       : undefined);
   const channelId =
     directChannelId ??
-    resolveResolvedChannelId({
-      rawChannel: params.rawChannel,
-      catalogEntry,
-    });
+    (catalogEntry ? (normalizeChannelId(catalogEntry.id) ?? catalogEntry.id) : undefined);
   if (!channelId) {
     return {
       cfg: nextCfg,
@@ -165,42 +100,31 @@ export async function resolveInstallableChannelPlugin(params: {
 
   // Bundled plugin metadata is not runtime-bound; load it through the scoped registry
   // before returning a plugin that callers can execute.
-  const existing = getLoadedChannelPlugin(channelId);
-  if (existing) {
-    return {
-      cfg: nextCfg,
-      channelId,
-      plugin: existing,
-      catalogEntry,
-      configChanged: false,
-      pluginInstalled: false,
-      supportsRequestedCapability: supports(existing),
-    };
-  }
-
-  const resolvedPluginId = catalogEntry?.pluginId;
-  if (catalogEntry) {
-    const scoped = loadScopedChannelPlugin({
-      cfg: nextCfg,
-      runtime: params.runtime,
-      channelId,
-      supports,
-      pluginId: resolvedPluginId,
-      workspaceDir,
-    });
-    if (scoped) {
-      return {
+  let plugin = getLoadedChannelPlugin(channelId);
+  let pluginInstalled = false;
+  if (!plugin && catalogEntry) {
+    const loadPlugin = (pluginId?: string): ChannelPlugin | undefined => {
+      const snapshot = loadChannelSetupPluginRegistrySnapshotForChannel({
         cfg: nextCfg,
-        channelId,
-        plugin: scoped,
-        catalogEntry,
-        configChanged: false,
-        pluginInstalled: false,
-        supportsRequestedCapability: supports(scoped),
-      };
-    }
+        runtime: params.runtime,
+        channel: channelId,
+        ...(pluginId ? { pluginId } : {}),
+        workspaceDir,
+      });
+      const runtimePlugin = snapshot.channels.find(
+        (entry) => entry.plugin.id === channelId,
+      )?.plugin;
+      if (runtimePlugin) {
+        return runtimePlugin;
+      }
+      const setupPlugin = snapshot.channelSetups.find(
+        (entry) => entry.plugin.id === channelId,
+      )?.plugin;
+      return setupPlugin && supports(setupPlugin) ? setupPlugin : undefined;
+    };
+    plugin = loadPlugin(catalogEntry.pluginId);
 
-    if (params.allowInstall !== false) {
+    if (!plugin && params.allowInstall !== false) {
       const installResult = await ensureChannelSetupPluginInstalled({
         cfg: nextCfg,
         entry: catalogEntry,
@@ -209,38 +133,24 @@ export async function resolveInstallableChannelPlugin(params: {
         workspaceDir,
       });
       nextCfg = installResult.cfg;
-      const installedPluginId = installResult.pluginId ?? resolvedPluginId;
-      const installedPlugin = installResult.installed
-        ? loadScopedChannelPlugin({
-            cfg: nextCfg,
-            runtime: params.runtime,
-            channelId,
-            supports,
-            pluginId: installedPluginId,
-            workspaceDir,
-          })
-        : undefined;
-      return {
-        cfg: nextCfg,
-        channelId,
-        plugin: installedPlugin ?? existing,
-        catalogEntry:
-          installedPluginId && catalogEntry.pluginId !== installedPluginId
-            ? { ...catalogEntry, pluginId: installedPluginId }
-            : catalogEntry,
-        configChanged: nextCfg !== params.cfg,
-        pluginInstalled: installResult.installed,
-        supportsRequestedCapability: installedPlugin ? supports(installedPlugin) : undefined,
-      };
+      const installedPluginId = installResult.pluginId ?? catalogEntry.pluginId;
+      pluginInstalled = installResult.installed;
+      if (pluginInstalled) {
+        plugin = loadPlugin(installedPluginId);
+      }
+      if (installedPluginId && catalogEntry.pluginId !== installedPluginId) {
+        catalogEntry = { ...catalogEntry, pluginId: installedPluginId };
+      }
     }
   }
 
   return {
     cfg: nextCfg,
     channelId,
-    plugin: existing,
+    plugin,
     catalogEntry,
-    configChanged: false,
-    pluginInstalled: false,
+    configChanged: nextCfg !== params.cfg,
+    pluginInstalled,
+    supportsRequestedCapability: plugin ? supports(plugin) : undefined,
   };
 }

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -20,12 +20,6 @@ import { resolveChannelSetupOwner } from "../channel-setup/owner.js";
 import type { ChannelChoice } from "../onboard-types.js";
 import { applyAccountName } from "./add-mutators.js";
 
-type OnboardChannelsModule = typeof import("../onboard-channels.js");
-
-async function loadOnboardChannels(): Promise<OnboardChannelsModule> {
-  return await import("../onboard-channels.js");
-}
-
 type InitialWizardChannelTarget =
   | { kind: "omitted" }
   | { kind: "resolved"; channel: ChannelChoice }
@@ -94,7 +88,7 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
   const { cfg, baseHash, runtime, prompter } = params;
   const [{ buildAgentSummaries }, onboardChannels] = await Promise.all([
     import("../agents.config.js"),
-    loadOnboardChannels(),
+    import("../onboard-channels.js"),
   ]);
   const channelSetup = onboardChannels.createChannelSetupTransaction({
     runtime,

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -21,7 +21,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { commitConfigWithPendingPluginInstalls } from "../../plugins/install-record-commit.js";
 import { refreshPluginRegistryAfterConfigMutation } from "../../plugins/registry-refresh.js";
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
-import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { createLazyPromise } from "../../shared/lazy-promise.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { WizardCancelledError } from "../../wizard/prompts.js";
 import { normalizeExternalChannelSetupConfig } from "../channel-setup/config-compatibility.js";
@@ -29,23 +29,10 @@ import { resolveChannelSetupOwner } from "../channel-setup/owner.js";
 import { channelLabel } from "./runtime-label.js";
 import { requireValidConfigFileSnapshot, shouldUseWizard } from "./shared.js";
 
-type ChannelSetupPluginInstallModule = typeof import("../channel-setup/plugin-install.js");
-type OnboardChannelsModule = typeof import("../onboard-channels.js");
-
-const channelSetupPluginInstallLoader = createLazyImportLoader<ChannelSetupPluginInstallModule>(
+const loadChannelSetupPluginInstall = createLazyPromise(
   () => import("../channel-setup/plugin-install.js"),
 );
-const onboardChannelsLoader = createLazyImportLoader<OnboardChannelsModule>(
-  () => import("../onboard-channels.js"),
-);
-
-function loadChannelSetupPluginInstall(): Promise<ChannelSetupPluginInstallModule> {
-  return channelSetupPluginInstallLoader.load();
-}
-
-function loadOnboardChannels(): Promise<OnboardChannelsModule> {
-  return onboardChannelsLoader.load();
-}
+const loadOnboardChannels = createLazyPromise(() => import("../onboard-channels.js"));
 
 export type ChannelsAddOptions = {
   agent?: string;

--- a/src/commands/doctor/shared/post-core-plugin-convergence.test.ts
+++ b/src/commands/doctor/shared/post-core-plugin-convergence.test.ts
@@ -45,10 +45,7 @@ import {
   runActivePluginPayloadSmokeCheck,
 } from "../../../plugins/active-payload-verification.js";
 import { VERSION } from "../../../version.js";
-import {
-  convergenceWarningsToOutcomes,
-  runPostCorePluginConvergence,
-} from "./post-core-plugin-convergence.js";
+import { runPostCorePluginConvergence } from "./post-core-plugin-convergence.js";
 
 describe("runPostCorePluginConvergence", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -550,11 +547,6 @@ describe("runPostCorePluginConvergence", () => {
         guidance: [],
       },
     ]);
-    expect(convergenceWarningsToOutcomes(result)).toStrictEqual({
-      warnings: result.notices,
-      outcomes: [],
-      errored: false,
-    });
   });
 
   it("flags errored=true when smoke check finds a missing main entry", async () => {
@@ -633,7 +625,7 @@ describe("runPostCorePluginConvergence", () => {
     ]);
   });
 
-  it("uses ownership guidance and a coherent update outcome for unreadable package.json", async () => {
+  it("uses ownership guidance for unreadable package.json", async () => {
     mocks.repairMissingConfiguredPluginInstalls.mockResolvedValue({
       changes: [],
       warnings: [],
@@ -673,11 +665,7 @@ describe("runPostCorePluginConvergence", () => {
         guidance,
       },
     ]);
-    expect(convergenceWarningsToOutcomes(result)).toStrictEqual({
-      warnings: result.warnings,
-      outcomes: [{ pluginId: "brave", status: "error", message }],
-      errored: true,
-    });
+    expect(result.errored).toBe(true);
   });
 
   it("does not duplicate a package-scoped repair error owned by a smoke failure", async () => {
@@ -853,46 +841,6 @@ describe("runPostCorePluginConvergence", () => {
         OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
       },
     });
-  });
-});
-
-describe("convergenceWarningsToOutcomes", () => {
-  it("emits per-plugin error outcomes for warnings that name a pluginId", () => {
-    const folded = convergenceWarningsToOutcomes({
-      changes: [],
-      warnings: [
-        {
-          pluginId: "brave",
-          reason: "missing-main-entry: …",
-          message: 'Plugin "brave" failed payload smoke check.',
-          guidance: ["Run `openclaw update repair`."],
-        },
-        {
-          reason: "Failed install",
-          message: "Failed install for some plugin.",
-          guidance: ["Run `openclaw update repair`."],
-        },
-      ],
-      errored: true,
-      smokeFailures: [],
-      installRecords: {},
-    });
-    expect(folded.errored).toBe(true);
-    expect(folded.outcomes).toEqual([
-      { pluginId: "brave", status: "error", message: 'Plugin "brave" failed payload smoke check.' },
-    ]);
-    expect(folded.warnings).toHaveLength(2);
-  });
-
-  it("returns errored=false and no outcomes for a clean convergence", () => {
-    const folded = convergenceWarningsToOutcomes({
-      changes: ["Repaired."],
-      warnings: [],
-      errored: false,
-      smokeFailures: [],
-      installRecords: {},
-    });
-    expect(folded).toEqual({ warnings: [], outcomes: [], errored: false });
   });
 });
 

--- a/src/commands/doctor/shared/post-core-plugin-convergence.ts
+++ b/src/commands/doctor/shared/post-core-plugin-convergence.ts
@@ -277,31 +277,3 @@ export async function runPostCorePluginConvergence(params: {
     installRecords: records,
   };
 }
-
-/**
- * Pure helper used by `updatePluginsAfterCoreUpdate` to fold a convergence
- * result into the existing `PluginUpdateOutcome[]` / warning shape that the
- * post-core update result carries.
- *
- * Returns:
- *  - `outcomes` to append to `pluginUpdateOutcomes`. Only convergence
- *    warnings that name a `pluginId` produce per-plugin error outcomes; the
- *    rest are surfaced via `warnings`.
- *  - `errored` boolean that callers translate into `status: "error"`.
- *    Pending activation consent and smoke failures remain errors on the
- *    explicit update path; ordinary repair warnings are nonblocking.
- */
-export function convergenceWarningsToOutcomes(convergence: PostCoreConvergenceResult): {
-  warnings: PostCoreConvergenceWarning[];
-  outcomes: Array<{ pluginId: string; status: "error"; message: string }>;
-  errored: boolean;
-} {
-  const outcomes = convergence.warnings
-    .filter((w): w is PostCoreConvergenceWarning & { pluginId: string } => Boolean(w.pluginId))
-    .map((w) => ({ pluginId: w.pluginId, status: "error" as const, message: w.message }));
-  return {
-    warnings: [...convergence.warnings, ...(convergence.notices ?? [])],
-    outcomes,
-    errored: convergence.errored,
-  };
-}

--- a/src/plugins/provider-self-hosted-discovery.ts
+++ b/src/plugins/provider-self-hosted-discovery.ts
@@ -162,39 +162,29 @@ function resolveRuntimePropsUrl(params: { serverBaseUrl: string; modelId?: strin
 }
 
 /** Guarded model-row discovery for OpenAI-compatible self-hosted servers. */
-async function discoverOpenAICompatibleModelRows(params: {
-  inferenceBaseUrl: string;
-  serverBaseUrl?: string;
-  apiKey?: string;
-  headers?: Record<string, string>;
-  label: string;
-  healthPath?: string;
-  modelsPathOrder?: "inference" | "server-first";
-  routerModelProps?: boolean;
-  discoverRuntimeContext?: boolean;
-  timeoutMs?: number;
-  propsTimeoutMs?: number;
-  signal?: AbortSignal;
-}): Promise<OpenAICompatibleModelDiscoveryResult> {
-  const inferenceBaseUrl = params.inferenceBaseUrl.trim().replace(/\/+$/, "");
+async function discoverOpenAICompatibleModelRows(
+  params: OpenAICompatibleLocalModelsParams,
+): Promise<OpenAICompatibleModelDiscoveryResult> {
+  const inferenceBaseUrl = params.baseUrl.trim().replace(/\/+$/, "");
   const inferredServerBaseUrl = inferenceBaseUrl.replace(/\/v1$/u, "");
   const serverBaseUrl = (params.serverBaseUrl ?? inferredServerBaseUrl).replace(/\/+$/, "");
-  const origin = new URL(serverBaseUrl).origin;
   const timeoutMs = params.timeoutMs ?? 5_000;
+  const request = {
+    ...params,
+    origin: new URL(serverBaseUrl).origin,
+    timeoutMs,
+    acceptJson: params.modelsPathOrder === "server-first",
+    readBody: true,
+  };
   let health: "ready" | "loading" | "unknown" = "unknown";
 
   if (params.healthPath) {
     const path = params.healthPath;
     const healthResult = await fetchSelfHostedDiscoveryJson({
+      ...request,
       url: `${serverBaseUrl}${path}`,
-      origin,
-      apiKey: params.apiKey,
-      headers: params.headers,
       acceptJson: true,
-      timeoutMs,
-      signal: params.signal,
       readBody: false,
-      label: params.label,
     });
     if (healthResult.kind === "unreachable") {
       return healthResult;
@@ -222,15 +212,8 @@ async function discoverOpenAICompatibleModelRows(params: {
     | undefined;
   for (const candidate of modelCandidates) {
     const result = await fetchSelfHostedDiscoveryJson({
+      ...request,
       url: candidate.url,
-      origin,
-      apiKey: params.apiKey,
-      headers: params.headers,
-      acceptJson: params.modelsPathOrder === "server-first",
-      timeoutMs,
-      signal: params.signal,
-      readBody: true,
-      label: params.label,
     });
     if (result.kind === "unreachable") {
       return result;
@@ -258,56 +241,45 @@ async function discoverOpenAICompatibleModelRows(params: {
   if (!modelList || modelList.kind !== "success") {
     return modelList ?? { kind: "unreachable", error: new Error("missing model response") };
   }
-  const { models } = modelList;
-  const rows: OpenAICompatibleModelDiscoveryRow[] = models.map((model) => ({ model }));
+  const rows: OpenAICompatibleModelDiscoveryRow[] = modelList.models.map((model) => ({ model }));
   if (params.discoverRuntimeContext !== false) {
     const routerMode =
       params.routerModelProps &&
-      models.some((model) => asOptionalRecord(model.status) !== undefined);
-    const queryByModel = routerMode || (!params.routerModelProps && models.length > 1);
-    const probeIndexes = models
-      .map((model, index) => (shouldProbeRuntimeProps(model) ? index : -1))
-      .filter((index) => index >= 0)
+      rows.some(({ model }) => asOptionalRecord(model.status) !== undefined);
+    const queryByModel = routerMode || (!params.routerModelProps && rows.length > 1);
+    const probeRows = rows
+      .filter(({ model }) => shouldProbeRuntimeProps(model))
       .slice(0, SELF_HOSTED_RUNTIME_CONTEXT_MAX_MODELS);
     const deadline = Date.now() + timeoutMs;
-    const { results } = await runTasksWithConcurrency({
+    await runTasksWithConcurrency({
       limit: SELF_HOSTED_RUNTIME_CONTEXT_CONCURRENCY,
       errorMode: "stop",
       throwOnError: true,
-      tasks: probeIndexes.map((index) => async () => {
+      tasks: probeRows.map((row) => async () => {
         const remainingMs = deadline - Date.now();
         if (remainingMs <= 0) {
-          return undefined;
+          return;
         }
-        const model = models[index];
-        const modelId = normalizeOptionalString(model?.id);
-        if (!model || !modelId) {
-          return undefined;
+        const modelId = normalizeOptionalString(row.model.id);
+        if (!modelId) {
+          return;
         }
         const result = await fetchSelfHostedDiscoveryJson({
+          ...request,
           url: resolveRuntimePropsUrl({
             serverBaseUrl,
             modelId: queryByModel ? modelId : undefined,
           }),
-          origin,
-          apiKey: params.apiKey,
-          headers: params.headers,
-          acceptJson: params.modelsPathOrder === "server-first",
           timeoutMs: Math.min(params.propsTimeoutMs ?? timeoutMs, remainingMs),
-          signal: params.signal,
-          readBody: true,
           label: `${params.label} /props`,
         });
         const props =
           result.kind === "response" && result.ok ? asOptionalRecord(result.body) : undefined;
-        return props ? ([index, props] as const) : undefined;
+        if (props) {
+          row.props = props;
+        }
       }),
     });
-    for (const result of results) {
-      if (result) {
-        rows[result[0]] = { model: models[result[0]]!, props: result[1] };
-      }
-    }
   }
 
   return { kind: "success", health, rows, fetchedAt: Date.now() };
@@ -348,19 +320,10 @@ export async function discoverOpenAICompatibleLocalModels(
   }
 
   const result = await discoverOpenAICompatibleModelRows({
-    inferenceBaseUrl: params.baseUrl,
-    serverBaseUrl: params.serverBaseUrl,
-    apiKey: params.apiKey,
-    headers: params.headers,
-    label: params.label,
-    healthPath: params.healthPath,
-    modelsPathOrder: params.modelsPathOrder,
-    routerModelProps: params.routerModelProps,
+    ...params,
     discoverRuntimeContext:
       params.contextWindow === undefined && params.discoverRuntimeContext !== false,
-    timeoutMs: params.timeoutMs,
     propsTimeoutMs: params.propsTimeoutMs ?? 2_500,
-    signal: params.signal,
   });
   if (params.rawResult) {
     return result;


### PR DESCRIPTION
Related: #134421, #135361. Follow-up to #135445, #135460, and #135505.

## What Problem This Solves

The recent release-feedback fixes left duplicated result construction and forwarding in channel setup, self-hosted model discovery, and post-update plugin reporting. This maintainer-requested refactor removes those parallel representations so the existing owners carry their results through one flow.

## Why This Change Was Made

- Channel resolution shares its scoped load/install/reload result path and uses the existing lazy-promise helper directly. The registered-directory fast path, runtime-versus-setup capability rules, and selected workspace survive unchanged when installation replaces the config or plugin ID.
- Discovery reuses its parameter contract and gives each bounded props task its own model row, removing index/result-tuple reconciliation while preserving catalog order, probe limits, deadlines, authentication, and cleanup.
- The update CLI owns its warning/outcome projection directly. Shared Doctor convergence no longer exports a CLI-only adapter; missing-payload reporting and trust-warning normalization each have one owner. Repair and pending-consent state remain in their existing owners.

Production: **+130 / -358 = -228 lines** across eight files. Tests: **+132 / -71 = +61 lines**. One obsolete assertion-baseline entry is removed. No API, configuration, database, dependency, or protocol changes.

The update changes only rearrange reporting: cohort selection, capability consent, install-record writes, and recovery/retirement behavior stay in their existing owners. The shared Doctor change only removes its CLI projection; it changes no stored representation or migration.

## User Impact

Behavior is preserved: channel operations retain the selected agent, discovery keeps its existing fallback and authorization behavior, and update output retains warning/notice order and consent-failure status. Tests now exercise the update CLI collector instead of copying the deleted projection into a mock.

## Evidence

- Channel/CLI owner, trusted-catalog, directory, and lazy-promise coverage: **303 passing tests** across 13 suites; the final installation-contract fixture also passes all 11 cases after its cleanup. The 251 common pre-refactor cases passed before editing.
- Discovery: **60 existing tests pass unchanged before and after**, including five real loopback HTTP cases.
- Update: **192 passing tests**, including 56 CLI cases and 136 convergence/retirement/repair cases. Four new result/output cases passed against the original implementation before the refactor.
- Independent source reviews found no actionable findings. Managed Codex autoreview reports no P0 findings for the complete patch.
- The complete local changed-check gate passed, including production/test type checks, lint, unused-export scans, and runtime import-cycle checks.
- Full build passed, including SDK declarations, CLI bootstrap/export guards, and Control UI artifact checks.
- **15 compiled CLI scenarios passed** against this commit: nine successful login/logout, add, capabilities, and remove operations plus six expected owner-selection rejections. The real CLI loaded a fixture plugin with temporary home/config/state and a loopback Gateway stub; cleanup passed. The proof covers channel resolution, command handling, and owner-selection errors.
- [Checks for this PR](https://github.com/openclaw/openclaw/pull/135598/checks) are green on `5bc9a77c2e092cb691f20a0e8f6ebed3e3146008`: 225 passed, 51 intentionally skipped, none pending or failing.
- [ClawSweeper review](https://github.com/openclaw/openclaw/pull/135598#issuecomment-5501331269) found no actionable regression. Its sole Rank-up move was to wait for the normal exact-head CI checks; those checks are green.
