### PR TITLE
perf(cli): avoid materializing unused process output

### DIFF
--- a/src/agents/cli-output-error.test.ts
+++ b/src/agents/cli-output-error.test.ts
@@ -287,35 +287,38 @@ describe("createCliJsonlStreamingParser errors", () => {
     });
   });
 
-  it("keeps plugin-owned terminal errors ahead of later result summaries", () => {
-    const usageEvents: Array<{ usage: unknown; isTerminal: boolean }> = [];
-    const parser = createCliJsonlStreamingParser({
-      backend: { command: "acme", output: "jsonl" },
-      providerId: "acme-cli",
-      parseJsonlEvent: (line) =>
-        line === "failed"
-          ? { kind: "result", errorText: "provider failed" }
-          : {
-              kind: "result",
-              text: "must not replace the provider error",
-              sessionId: "late-successor",
-              usage: { input: 2, output: 1, total: 3 },
-            },
-      onAssistantDelta: () => {},
-      onUsage: (usage, isTerminal) => usageEvents.push({ usage, isTerminal }),
-    });
+  it.each(["", "preserved answer"])(
+    "keeps plugin-owned terminal errors and text %j ahead of later result summaries",
+    (text) => {
+      const usageEvents: Array<{ usage: unknown; isTerminal: boolean }> = [];
+      const parser = createCliJsonlStreamingParser({
+        backend: { command: "acme", output: "jsonl" },
+        providerId: "acme-cli",
+        parseJsonlEvent: (line) =>
+          line === "failed"
+            ? { kind: "result", text, errorText: "provider failed" }
+            : {
+                kind: "result",
+                text: "must not replace the provider error",
+                sessionId: "late-successor",
+                usage: { input: 2, output: 1, total: 3 },
+              },
+        onAssistantDelta: () => {},
+        onUsage: (usage, isTerminal) => usageEvents.push({ usage, isTerminal }),
+      });
 
-    parser.push("failed\nsummary\n");
-    parser.finish();
+      parser.push("failed\nsummary\n");
+      parser.finish();
 
-    expect(parser.getOutput()).toEqual({
-      text: "",
-      sessionId: "late-successor",
-      usage: { input: 2, output: 1, total: 3 },
-      errorText: "provider failed",
-    });
-    expect(usageEvents).toEqual([{ usage: { input: 2, output: 1, total: 3 }, isTerminal: true }]);
-  });
+      expect(parser.getOutput()).toEqual({
+        text,
+        sessionId: "late-successor",
+        usage: { input: 2, output: 1, total: 3 },
+        errorText: "provider failed",
+      });
+      expect(usageEvents).toEqual([{ usage: { input: 2, output: 1, total: 3 }, isTerminal: true }]);
+    },
+  );
 
   it("preserves plugin-owned session ids emitted after terminal errors", () => {
     const sessionIds: string[] = [];
@@ -388,7 +391,11 @@ describe("createCliJsonlStreamingParser errors", () => {
     });
   });
 
-  it("retains built-in fallback text after a plugin handles other lines", () => {
+  it.each([
+    ["without a result", undefined, "delegated answer"],
+    ["with an empty result", "  ", "delegated answer"],
+    ["with an authoritative result", "final answer", "final answer"],
+  ] as const)("retains mixed plugin text precedence %s", (_label, resultText, expectedText) => {
     const parser = createCliJsonlStreamingParser({
       backend: { command: "acme", output: "jsonl" },
       providerId: "acme-cli",
@@ -398,6 +405,9 @@ describe("createCliJsonlStreamingParser errors", () => {
         }
         if (line === "prefix") {
           return { kind: "text", text: "streamed prefix" };
+        }
+        if (line === "result") {
+          return { kind: "result", text: resultText };
         }
         return null;
       },
@@ -412,13 +422,14 @@ describe("createCliJsonlStreamingParser errors", () => {
           type: "item.completed",
           item: { type: "agent_message", text: "delegated answer" },
         }),
+        ...(resultText === undefined ? [] : ["result"]),
         "",
       ].join("\n"),
     );
     parser.finish();
 
     expect(parser.getOutput()).toEqual({
-      text: "delegated answer",
+      text: expectedText,
       sessionId: "custom-session",
       usage: undefined,
     });

--- a/src/agents/cli-output-events.ts
+++ b/src/agents/cli-output-events.ts
@@ -186,13 +186,12 @@ export function projectCliBackendEvent(params: {
     params.onUsage?.(event.usage, true);
   }
   const existingErrorText = state.output?.errorText;
-  const eventText = event.text?.trim() ?? "";
-  const existingText = state.output?.text.trim() ?? "";
-  const streamedText = state.assistantText.trim();
-  const delegatedText = params.texts.join("\n").trim();
-  const resultText = existingErrorText
-    ? existingText || delegatedText || streamedText
-    : eventText || existingText || delegatedText || streamedText;
+  // Stop at the authoritative winner before composing fallback transcripts.
+  const resultText =
+    (!existingErrorText && event.text?.trim()) ||
+    state.output?.text.trim() ||
+    params.texts.join("\n").trim() ||
+    state.assistantText.trim();
   const errorText = existingErrorText || event.errorText;
   state.output = {
     ...state.output,

--- a/src/agents/cli-runner/execute-process.ts
+++ b/src/agents/cli-runner/execute-process.ts
@@ -75,7 +75,6 @@ export async function executeCliProcess(params: {
   nodeEnv?: Record<string, string>;
   nodeClearEnv?: string[];
   useManagedClaudeLiveSession: boolean;
-  usePluginOwnedExecution: boolean;
   initialGatewayCaptureKey?: string;
   useResume: boolean;
   cliSessionIdToUse?: string;
@@ -333,9 +332,9 @@ export async function executeCliProcess(params: {
     );
   }
 
-  const stdout = stdoutParseBuffer.toString("utf8").trim();
+  let stdout: string | undefined;
+  const readStdout = () => (stdout ??= stdoutParseBuffer.toString("utf8").trim());
   const stdoutDiagnostic = stdoutTail.trim();
-  const stderr = stderrParseBuffer.toString("utf8").trim();
   const stderrDiagnostic = stderrTail.trim();
   const processDiagnostics = {
     backendId: context.backendResolved.id,
@@ -372,7 +371,7 @@ export async function executeCliProcess(params: {
     streamedJsonlOutput ??
     (params.outputMode === "json" && !stdoutParseExceeded
       ? parseCliOutput({
-          raw: stdout,
+          raw: readStdout(),
           backend: params.backend,
           providerId: context.backendResolved.id,
           outputMode: params.outputMode,
@@ -464,9 +463,10 @@ export async function executeCliProcess(params: {
       );
     }
     const retryEmptyFailure = result.reason === "exit" && !params.events.hasObservedCliActivity();
+    const stderr = stderrParseBuffer.toString("utf8").trim();
     throw createCliExitFailoverError({
       context: failoverContext,
-      candidates: [stderr, stdout, stderrDiagnostic, stdoutDiagnostic],
+      candidates: [stderr, readStdout(), stderrDiagnostic, stdoutDiagnostic],
       fallbackMessage: "CLI failed.",
       retryEmptyFailure,
       resumeAtArg: retryEmptyFailure ? resumeAtArg : undefined,
@@ -487,7 +487,7 @@ export async function executeCliProcess(params: {
         `CLI backend ${context.backendResolved.id} does not support manual compaction`,
       );
     }
-    const validation = manualCompaction.validateOutput(stdout);
+    const validation = manualCompaction.validateOutput(readStdout());
     if (!validation.ok) {
       throw createCliFailoverError(validation.reason, "unknown", failoverContext);
     }
@@ -501,7 +501,7 @@ export async function executeCliProcess(params: {
   const parsed =
     parsedStructuredOutput ??
     parseCliOutput({
-      raw: stdout,
+      raw: readStdout(),
       backend: params.backend,
       providerId: context.backendResolved.id,
       outputMode: params.outputMode,

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -525,42 +525,43 @@ describe("executePreparedCliRun supervisor output capture", () => {
     expect(result.sessionId).toBe("resume-jsonl-session");
   });
 
-  it("classifies failed stdout from the retained parse buffer before the diagnostic tail", async () => {
-    // The error classifier needs the retained parse buffer; the human-facing
-    // diagnostic tail may contain only noise once stdout grows large.
-    const errorPrefix = `${JSON.stringify({
-      type: "result",
-      is_error: true,
-      result: "429 rate limit exceeded",
-    })}\n`;
-    const noisyTail = "x".repeat(80 * 1024);
+  it.each(["stdout", "stderr"] as const)(
+    "classifies failed %s from the retained parse buffer before other candidates",
+    async (stream) => {
+      // The error classifier needs the retained parse buffer; the human-facing
+      // diagnostic tail may contain only noise once stdout grows large.
+      const errorPrefix = `${JSON.stringify({
+        type: "result",
+        is_error: true,
+        result: "429 rate limit exceeded",
+      })}\n`;
+      const noisyTail = "x".repeat(80 * 1024);
 
-    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
-      const input = args[0] as SupervisorSpawnInput;
-      input.onStdout?.(errorPrefix);
-      input.onStdout?.(noisyTail);
-      return createManagedRun({
-        reason: "exit",
-        exitCode: 1,
-        exitSignal: null,
-        durationMs: 50,
-        stdout: input.captureOutput === false ? "" : `${errorPrefix}${noisyTail}`,
-        stderr: "",
-        timedOut: false,
-        noOutputTimedOut: false,
+      supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const input = args[0] as SupervisorSpawnInput;
+        const emit = stream === "stderr" ? input.onStderr : input.onStdout;
+        emit?.(errorPrefix);
+        emit?.(noisyTail);
+        if (stream === "stderr") {
+          input.onStdout?.(JSON.stringify({ type: "error", message: "Credit balance is too low" }));
+        }
+        return createManagedRun({
+          reason: "exit",
+          exitCode: 1,
+          exitSignal: null,
+          durationMs: 50,
+          stdout: "",
+          stderr: "",
+          timedOut: false,
+          noOutputTimedOut: false,
+        });
       });
-    });
 
-    try {
-      await executePreparedCliRun(buildPreparedCliRunContext({ output: "text" }));
-    } catch (error) {
-      const classified = error as { reason?: unknown; status?: unknown };
-      expect(classified.reason).toBe("rate_limit");
-      expect(classified.status).toBe(429);
-      return;
-    }
-    throw new Error("Expected CLI run to reject with a rate limit error");
-  });
+      await expect(
+        executePreparedCliRun(buildPreparedCliRunContext({ output: "text" })),
+      ).rejects.toMatchObject({ reason: "rate_limit", status: 429 });
+    },
+  );
 
   it("fails one-shot Claude is_error results even when the process exits successfully", async () => {
     const stdout = `${JSON.stringify({

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -572,7 +572,6 @@ export async function executePreparedCliRun(
         nodeEnv: nodeEnv && Object.keys(nodeEnv).length > 0 ? nodeEnv : undefined,
         nodeClearEnv: nodeClearEnv.length > 0 ? nodeClearEnv : undefined,
         useManagedClaudeLiveSession,
-        usePluginOwnedExecution,
         initialGatewayCaptureKey,
         useResume,
         cliSessionIdToUse,


### PR DESCRIPTION
## What Problem This Solves

CLI-backed turns composed large fallback transcripts and decoded retained stdout/stderr even when an authoritative result, timeout, or failure had already decided the outcome. Repeated result events could repeatedly join a growing transcript that was never used.

## Why This Change Was Made

Short-circuit result selection in its existing order and materialize process output only at its actual consumers. Stdout is memoized within the completed process; stderr is decoded when exit classification needs it. Remove the unused execution flag from the internal process call as well.

The supervisor still owns bounded capture and cancellation. Parse buffers, diagnostic tails, terminal failures, manual compaction, and stderr/stdout error precedence retain their existing contracts. No cache, dependency, configuration, or alternate execution path is introduced.

## User Impact

CLI-backed turns do less transient string work while returning the same answers, errors, diagnostics, and session metadata. Production LOC: +13/-15 (net -2). Tests: +76/-64 (net +12).

## Evidence

The fixed ten-scenario real-child probe reduced direct UTF-8 decoding in the process owner from 7,422,346 to 82,137 bytes. JSONL success fell from 2,097,152 bytes to zero; successful JSON/text skipped 1 MiB of unused stderr. Required raw fallback, manual compaction, and ordered failure diagnostics remain equal. A separate 200-event probe removed all 200 unused 1 MiB transcript joins for authoritative results, retained answers, and sticky errors; the required-fallback control still performs all 200 joins. The allocation-work budget fails before and passes after. These are causal work counts, not a controlled RSS reduction.

A fresh source Gateway loaded a registered synthetic CLI-backend plugin, handled an agent RPC through the actual supervisor and child process, returned the final answer, and persisted matching chat history. The client, Gateway, child, port, and temporary state were cleaned up. This proves the product path with a synthetic backend; it does not claim a vendor-native Codex run.

175 owner/sibling tests passed, including the real inherited-pipe process-settlement test. After integrating the two-line unused-argument cleanup, 99 parser, executor, and cancellation tests passed again. Full changed-file checks (including types, lint, and formatting) and fresh isolated Codex autoreview passed. Existing tests were parameterized to cover conflicting result/error sources rather than adding a separate implementation-shaped suite.

The review inspected the complete parser/process owners, callers, sibling output modes, supervisor boundaries, and upstream Codex `exec_events.rs` and `event_processor_with_jsonl_output.rs` at `e017e93aceafb2fe04bed1c926e448a5fb4f913d`. The stable v2026.8.2 tag contains the eager forms; output precedence is deliberately preserved.
