### PR TITLE
refactor(qa-lab): reuse approval result formatter

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-approval.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-approval.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { normalizeUniqueStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { formatApprovalResultValue } from "../../shared/live-approval-result.js";
 import type { MatrixQaObservedEvent } from "../substrate/events.js";
 import {
   MATRIX_QA_DRIVER_DM_ROOM_KEY,
@@ -326,16 +327,6 @@ function assertApprovalDecisionResult(params: {
       `approval decision was ${formatApprovalResultValue(result?.decision)} instead of ${params.decision}`,
     );
   }
-}
-
-function formatApprovalResultValue(value: unknown) {
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  if (value == null) {
-    return "<missing>";
-  }
-  return JSON.stringify(value) ?? "<unserializable>";
 }
 
 async function requestExecApproval(params: {


### PR DESCRIPTION
## What Problem This Solves

QA Lab's Matrix approval scenario retained a private copy of the approval-result formatter after the formatter gained a shared owner. Keeping both copies leaves behavior-preserving migrations incomplete and allows their output semantics to drift.

## Why This Change Was Made

Matrix now imports the existing shared `formatApprovalResultValue` helper and removes its byte-identical private copy. The adjacent Matrix approval helpers remain untouched because their ID validation and error ordering intentionally differ from the shared helpers.

History confirms the incomplete migration: `f76a3a3bbec` introduced the shared approval-result helpers, while the later Matrix QA Lab migration in `ad345524736` carried the duplicate formatter forward.

Exact delta:

- Production: 1 file, +1/-10, net -9
- Tests: 0
- No wrappers, aliases, new exports, public API, SDK, config, protocol, or behavior changes

## User Impact

No user-visible behavior changes. Matrix approval QA failures retain the same primitive, missing-value, JSON, and unserializable formatting.

## Evidence

- `pnpm test:extension qa-lab`: passed in clean Testbox, 224 files / 3,191 tests
- `pnpm check:changed`: passed in Testbox
- `pnpm test:changed`: its shallow Testbox baseline selected unrelated main changes; one unrelated Git-transfer test file failed seven exact mode assertions because the runner used umask `0002` (`0664`/`0775` instead of `0644`/`0755`). The exact failed file reran with umask `0022` and passed 12 tests with 1 skipped.
- `pnpm check:import-cycles`: passed locally and in Testbox, 0 runtime value cycles
- `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build qaRuntime`: passed in Testbox
- Formatter, `git diff --check`, and changed dry-run classification passed; the final dry run selects only `extensions` and `extensionTests`
- Exact two-pass Codex autoreview: 0 actionable findings, overall correctness 0.96
- Testbox runs: https://github.com/openclaw/openclaw/actions/runs/33562598911 and https://github.com/openclaw/openclaw/actions/runs/33566816059

No new test was added: a formatter test would pass before and after this import-only consolidation and would only restate the byte-identical implementation. Existing QA Lab extension coverage exercises the approval scenarios.

Local runtime gates were concretely infeasible because the shared `node_modules` checkout had a stale `@openclaw/ai/diagnostics` export contract, so clean Testbox proof was used. No Testbox live Matrix run was added: this is a behavior-neutral private helper consolidation, and the current QA campaign already has bounded Crabbox coverage.

Overlap check:

- https://github.com/openclaw/openclaw/pull/135570 remains hunk-disjoint
- https://github.com/openclaw/openclaw/pull/120887 still has the reviewed head; both relevant files matched `main`

Codex hard gate: personally inspected `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`. Those CLI dispatch/completion paths are unrelated to this QA-only formatter consolidation.
