### PR TITLE
perf(agents): remove redundant finalize-hook message copy

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
@@ -217,6 +217,7 @@ describe("prepareEmbeddedAttemptStream", () => {
           resolveHook = resolve;
         }),
     );
+    const messages = [{ role: "user", content: "Question" }];
     const prepared = prepareEmbeddedAttemptStream({
       attempt: {
         runId: "run-finalize-id",
@@ -228,7 +229,7 @@ describe("prepareEmbeddedAttemptStream", () => {
       activeSession: {
         agent: { hasQueuedMessages: () => false },
         isStreaming: false,
-        messages: [],
+        messages,
         pendingMessageCount: 0,
       } as never,
       hookRunner: { hasHooks: (name: string) => name === "before_agent_finalize" } as never,
@@ -275,6 +276,11 @@ describe("prepareEmbeddedAttemptStream", () => {
     });
 
     await vi.waitFor(() => expect(mocks.runBeforeFinalizeHook).toHaveBeenCalledOnce());
+    const hookMessages = mocks.runBeforeFinalizeHook.mock.calls[0]?.[0].event.messages;
+    expect(hookMessages).not.toBe(messages);
+    expect(hookMessages[0]).toBe(messages[0]);
+    messages.push({ role: "user", content: "Later message" });
+    expect(hookMessages).toHaveLength(1);
     expect(prepared.queueHandle.isStopped?.()).toBe(true);
     await expect(prepared.queueHandle.queueMessage("too late")).rejects.toThrow(
       "active session is finalizing",
@@ -282,6 +288,7 @@ describe("prepareEmbeddedAttemptStream", () => {
 
     resolveHook?.({ action: "revise", reason: "Tighten the answer" });
     await expect(decision).resolves.toEqual({ suppressTerminalDelivery: true });
+    expect(hookMessages).toHaveLength(1);
     expect(prepared.getBeforeAgentFinalizeRevisionEntryId()).toBe("canonical-entry-id");
     expect(prepared.queueHandle.isStopped?.()).toBe(true);
   });

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -185,7 +185,7 @@ export function prepareEmbeddedAttemptStream(input: {
           return;
         }
         const hookMessages = projectNestedToolActivityForHooks(
-          input.activeSession.messages.slice(),
+          input.activeSession.messages,
           input.nestedToolActivities,
         );
         const reportedModelRef = resolveReportedModelRef({


### PR DESCRIPTION
## What Problem This Solves

Each embedded turn reaching the before-finalize hook copied the session message list immediately before its canonical projector created another detached list. Long transcripts paid for an intermediate array that was discarded.

## Why This Change Was Made

Pass the live message list directly to the synchronous projection owner. That owner always returns a fresh array, including when no nested activity exists, before the hook can await. It preserves ordinary message identity and the existing shallow nested-activity projection. The old projector could return its input; its replacement made the caller's extra slice obsolete.

History assembly and settlement snapshots protect different awaited boundaries and remain in place. The existing agent-end sibling already uses this same projection ownership.

## User Impact

One unnecessary array is removed per eligible finalize callback, with the same hook messages, permissions, finalize/revise behavior, and terminal delivery. Production LOC: +1/-1 (net 0). Existing test: +8/-1 (net +7).

## Evidence

Eight before/after cases cover 0, 1, 1,024, and 32,768 ordinary messages with zero or two nested activities. The production callback performs one input slice before and zero after; all eight projected payload hashes match. Both directions of array mutation isolation, ordinary-message identity, shallow activity details, and retained awaited payloads remain correct. The zero-slice work assertion fails against the baseline. This counts the removed intermediate array and its logical entries; it is not a payload-copy or RSS claim because V8 can share array backing storage.

A real source Gateway loaded an explicitly permitted hook plugin and ran the embedded agent, QuickJS Code Mode, and normal hook runner against a local synthetic OpenAI Responses server. No-tool, nested-tool, rejected-output/recovery, and follow-up turns passed. The run and final chat event stayed pending while the hook awaited its release; stored chat history and the agent-end sibling excluded hook-local array changes. Client, Gateway, temporary state, and the logger were joined and cleaned up. This was synthetic-provider product proof, not native Codex or a live vendor call.

44 owner, delivery, full-entry finalize, lifecycle-helper, and hook-runner tests passed on each revision. The existing delayed-hook test now explicitly checks fresh-array ownership and retention across a source append. Full changed-file checks, type-aware lint, formatting, and fresh isolated Codex autoreview passed after integration. The changed files remain identical on current main to the reviewed baseline apart from this patch.
