### PR TITLE
fix(test): empty named-file runs incorrectly pass by default

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -163,6 +163,17 @@ verify lease cleanup; never stop the operator's Gateway.
 2. `pnpm test <path-or-filter>` for one file, directory, or explicit target.
 3. `pnpm test` only when you intentionally need the full local Vitest suite.
 
+When a one-shot routed run targets only explicit test-file paths, each selected
+Vitest invocation must discover at least one test file. Excluding every selected
+file fails even when the lane normally permits empty runs. To allow that outcome
+intentionally, use `pnpm test <test-file-path> -- --passWithNoTests`. Use
+`--passWithNoTests=false` to require nonempty discovery explicitly. Broader
+selectors and source-derived selections retain their lane defaults.
+
+An explicit `--config` run through `scripts/run-vitest.mjs` keeps its stricter
+named-file policy and does not permit empty named-file runs. Plugin
+`--allow-no-tests` and `--allow-empty-after-exclude` controls are unchanged.
+
 Codex and other linked/sparse worktrees can run local tests and checks. When the
 dependency install is ready, use the normal commands above. If pnpm would
 reconcile a shared install, use the direct Node harnesses to bypass that

--- a/scripts/lib/vitest-report-owner.mts
+++ b/scripts/lib/vitest-report-owner.mts
@@ -56,7 +56,10 @@ function caseInventory(reports: JsonTestResults[]) {
     .toSorted();
 }
 
-function nativeHelpRequested(args: string[], parseCLI: typeof import("vitest/node").parseCLI) {
+export function nativeHelpRequested(
+  args: string[],
+  parseCLI: typeof import("vitest/node").parseCLI,
+) {
   const controls: string[] = [];
   for (const [index, original] of args.entries()) {
     if (original === "--") {

--- a/scripts/test-projects-run.mts
+++ b/scripts/test-projects-run.mts
@@ -12,7 +12,10 @@ import {
   prepareE2eVitestRuntime,
   prepareVitestRuntime,
 } from "./lib/vitest-build-prerequisites.mts";
-import { isVitestWorkerMetadataRequest } from "./lib/vitest-cli-mode.mts";
+import {
+  hasNonRunVitestSubcommand,
+  isVitestWorkerMetadataRequest,
+} from "./lib/vitest-cli-mode.mts";
 import type { exitVitestBySignal } from "./lib/vitest-cli.mts";
 import { resolveVitestHomeSelection } from "./lib/vitest-home-selection.mts";
 import {
@@ -20,7 +23,11 @@ import {
   resolveLocalFullSuiteProfile,
   resolveLocalVitestEnv,
 } from "./lib/vitest-local-scheduling.mts";
-import { createVitestReportOwner, type VitestReportOwner } from "./lib/vitest-report-owner.mts";
+import {
+  createVitestReportOwner,
+  nativeHelpRequested,
+  type VitestReportOwner,
+} from "./lib/vitest-report-owner.mts";
 import {
   createShardTimingSample,
   readShardTimings,
@@ -44,6 +51,7 @@ import {
   findUnmatchedExplicitTestTargets,
   formatFailedShardDigest,
   formatNoChangedTestTargetLines,
+  isTestFileTarget,
   listFullExtensionVitestProjectConfigs,
   orderFullSuiteSpecsForParallelRun,
   parseTestProjectsArgs,
@@ -295,7 +303,7 @@ export async function runTestProjects(exitBySignal: typeof exitVitestBySignal) {
     return;
   }
   const baseEnv = resolveLocalVitestEnv(process.env);
-  const { targetArgs } = parseTestProjectsArgs(args, process.cwd());
+  const { targetArgs, forwardedArgs } = parseTestProjectsArgs(args, process.cwd());
   const unmatchedExplicitTargets = findUnmatchedExplicitTestTargets(args, process.cwd());
   if (unmatchedExplicitTargets.length > 0) {
     for (const unmatched of unmatchedExplicitTargets) {
@@ -351,6 +359,40 @@ export async function runTestProjects(exitBySignal: typeof exitVitestBySignal) {
     printNoChangedTestTargets(args, process.cwd(), baseEnv);
     printTestSummary("skipped", 0, performance.now() - suiteStartedAt);
     return;
+  }
+
+  if (
+    targetArgs.length &&
+    !runSpecs.some((spec) => spec.watchMode) &&
+    !hasNonRunVitestSubcommand(forwardedArgs)
+  ) {
+    // Native parsing stays in the execution owner. Original filters distinguish
+    // explicit files from broad selections that also lower to literal include files.
+    const { parseCLI } = await import("vitest/node");
+    try {
+      if (!nativeHelpRequested(forwardedArgs, parseCLI)) {
+        const { filter, options } = parseCLI(["vitest", "run", ...forwardedArgs]);
+        if (
+          filter.length > 0 &&
+          filter.every(
+            (file) =>
+              isTestFileTarget(file) && /[/\\]/u.test(file) && !/[*?[\]{}]|[@+!]\(/u.test(file),
+          ) &&
+          !options.watch &&
+          options.run !== false &&
+          !options.listTags &&
+          !options.clearCache &&
+          !options.mergeReports &&
+          !Object.hasOwn(options, "passWithNoTests")
+        ) {
+          for (const spec of runSpecs) {
+            spec.pnpmArgs.push("--passWithNoTests=false");
+          }
+        }
+      }
+    } catch {
+      // Invalid native input belongs to the real child; do not add another scalar.
+    }
   }
 
   runSpecs.forEach((spec, index) => {

--- a/test/scripts/test-projects-build-admission.test.ts
+++ b/test/scripts/test-projects-build-admission.test.ts
@@ -346,6 +346,17 @@ async function start(args: string[]) {
   await import(entryUrl);
 }
 
+function createPreparationGate<T>(prepare: typeof commands.prepare) {
+  const started = createDeferred();
+  const result = createDeferred<T>();
+  prepare.mockImplementation(() => {
+    started.resolve();
+    return result.promise;
+  });
+  // Import completion does not imply admission; observe the preparation owner.
+  return { ...result, started: started.promise };
+}
+
 describe("test-projects build admission", () => {
   const toolingConfig = "test/vitest/vitest.tooling.config.ts";
   const ordinaryTooling = "test/scripts/run-vitest-state-cleanup.test.ts";
@@ -437,15 +448,21 @@ describe("test-projects build admission", () => {
     "holds every reader until preparation completes (parallel=%s)",
     async (parallel) => {
       vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", parallel ? "2" : "");
-      const preparation = createDeferred<number>();
+      const preparation = createPreparationGate<number>(commands.prepare);
       const readers = createDeferred<{ code: number; signal: null }>();
-      commands.prepare.mockReturnValue(preparation.promise);
-      commands.reader.mockImplementation(() => ({
-        completion: readers.promise,
-        getForwardedSignal: () => undefined,
-      }));
+      const readersStarted = createDeferred();
+      commands.reader.mockImplementation(() => {
+        if (commands.reader.mock.calls.length === (parallel ? 2 : 1)) {
+          readersStarted.resolve();
+        }
+        return {
+          completion: readers.promise,
+          getForwardedSignal: () => undefined,
+        };
+      });
       await start(targets);
       try {
+        await Promise.race([preparation.started, terminal.promise]);
         expect(commands.reader).not.toHaveBeenCalled();
         expect(commands.prepare).toHaveBeenCalledExactlyOnceWith(
           expect.objectContaining({
@@ -454,7 +471,8 @@ describe("test-projects build admission", () => {
           }),
         );
         preparation.resolve(0);
-        await vi.waitFor(() => expect(commands.reader).toHaveBeenCalledTimes(parallel ? 2 : 1));
+        await Promise.race([readersStarted.promise, terminal.promise]);
+        expect(commands.reader).toHaveBeenCalledTimes(parallel ? 2 : 1);
       } finally {
         preparation.resolve(0);
         readers.resolve({ code: 0, signal: null });
@@ -496,22 +514,25 @@ describe("test-projects build admission", () => {
       if (mode === "prebuilt") {
         vi.stubEnv("OPENCLAW_E2E_USE_PREBUILT_DIST", "1");
       }
-      const preparation = createDeferred<NodeJS.ProcessEnv>();
-      commands.prepareE2e.mockReturnValue(preparation.promise);
+      const preparation = createPreparationGate<NodeJS.ProcessEnv>(commands.prepareE2e);
       if (mode === "prebuilt") {
         preparation.resolve({});
       }
       await start([nativeHostTarget]);
-      if (mode !== "prebuilt") {
-        expect(commands.reader).not.toHaveBeenCalled();
-        expect(commands.prepareE2e).toHaveBeenCalledOnce();
+      try {
+        await Promise.race([preparation.started, terminal.promise]);
+        if (mode !== "prebuilt") {
+          expect(commands.reader).not.toHaveBeenCalled();
+          expect(commands.prepareE2e).toHaveBeenCalledOnce();
+        }
+      } finally {
         if (mode === "failed build") {
           preparation.reject(new Error("build failed"));
         } else {
           preparation.resolve({ OPENCLAW_E2E_USE_PREBUILT_DIST: "1" });
         }
+        await terminal.promise;
       }
-      await terminal.promise;
       expect(commands.prepare).not.toHaveBeenCalled();
       expect(commands.prepareE2e).toHaveBeenCalledOnce();
       expect(commands.reader).toHaveBeenCalledTimes(mode === "failed build" ? 0 : 1);
@@ -549,10 +570,10 @@ describe("test-projects build admission", () => {
 
   it("coalesces mixed E2E and private QA preparation before marking only E2E prebuilt", async () => {
     vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "2");
-    const preparation = createDeferred<NodeJS.ProcessEnv>();
-    commands.prepareE2e.mockReturnValue(preparation.promise);
+    const preparation = createPreparationGate<NodeJS.ProcessEnv>(commands.prepareE2e);
     await start([...targets, e2eTarget]);
     try {
+      await Promise.race([preparation.started, terminal.promise]);
       expect(commands.prepareE2e).toHaveBeenCalledOnce();
       expect(commands.prepare).not.toHaveBeenCalled();
       expect(commands.reader).not.toHaveBeenCalled();
@@ -606,17 +627,14 @@ describe("plugin batch build admission", () => {
         await import("../../scripts/lib/extension-test-plan.mts");
       const { runExtensionBatchPlan } = await import("../../scripts/test-extension-batch.mts");
       const batch = resolveExtensionBatchPlan({ extensionIds: ["qa-lab", "matrix", "firecrawl"] });
-      const preparation = createDeferred<number>();
-      commands.prepare.mockReturnValue(preparation.promise);
+      const preparation = createPreparationGate<number>(commands.prepare);
       const reader = vi.fn().mockResolvedValue(0);
       const running = runExtensionBatchPlan(batch, {
         env: { OPENCLAW_EXTENSION_BATCH_PARALLEL: parallel },
         runGroup: reader,
       });
       try {
-        await new Promise<void>((resolve) => {
-          setImmediate(resolve);
-        });
+        await Promise.race([preparation.started, running]);
         expect(reader).not.toHaveBeenCalled();
         expect(commands.prepare).toHaveBeenCalledExactlyOnceWith(
           expect.objectContaining({

--- a/test/scripts/test-projects-empty-native.test.ts
+++ b/test/scripts/test-projects-empty-native.test.ts
@@ -1,0 +1,210 @@
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { JsonTestResults } from "vitest/node";
+import { runManagedCommand } from "../../scripts/lib/managed-child-process.mts";
+import { createBoundedChildOutput } from "../helpers/bounded-child-output.js";
+import { createFixtureLifetime } from "../helpers/fixture-lifetime.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const target = "test/scripts/empty-policy.synthetic.test.ts";
+const sibling = "test/scripts/empty-policy-sibling.synthetic.test.ts";
+const source = "test/scripts/empty-policy.synthetic.ts";
+const isolated = "test/scripts/control-ui-i18n.test.ts";
+const config = "test/vitest/vitest.tooling.config.ts";
+
+describe("project runner native empty-file policy", () => {
+  it.for([
+    { name: "delegated default", code: 1 },
+    { name: "package test entry default", code: 1, entry: "projects" },
+    { name: "several exact files", code: 1, selectors: [target, sibling] },
+    {
+      name: "exact files across lanes",
+      code: 1,
+      selectors: [target, isolated],
+      parallel: true,
+      emptyInvocations: 2,
+    },
+    { name: "explicit true", code: 0, flags: ["--passWithNoTests=true"] },
+    { name: "bare opt-in", code: 0, flags: ["--passWithNoTests"] },
+    { name: "explicit false", code: 1, flags: ["--passWithNoTests=false"] },
+    { name: "native negation", code: 1, flags: ["--no-passWithNoTests"] },
+    { name: "native dashed spelling", code: 0, flags: ["--pass-with-no-tests=true"] },
+    {
+      name: "invalid duplicate scalar",
+      code: 1,
+      flags: ["--passWithNoTests", "--passWithNoTests"],
+      invalid: true,
+    },
+    { name: "direct configured default", code: 1, flags: ["--config", config] },
+    { name: "directory selection", code: 0, selectors: ["test/scripts"] },
+    { name: "glob selection", code: 0, selectors: ["test/scripts/*.test.ts"] },
+    { name: "mixed basename and exact selection", code: 0, selectors: ["empty-policy", target] },
+    {
+      name: "config selection",
+      code: 0,
+      selectors: ["test/vitest/vitest.tooling-docker.config.ts"],
+      entry: "projects",
+    },
+    { name: "source-derived selection", code: 0, selectors: [source] },
+    { name: "native help", code: 0, flags: ["--help=true"], help: true },
+    { name: "non-excluded control", code: 0, excluded: false, tests: 1 },
+    { name: "one surviving named file", code: 0, selectors: [target, sibling], tests: 1 },
+    {
+      name: "skipped case is still a discovered file",
+      code: 0,
+      excluded: false,
+      tests: 1,
+      skipped: true,
+    },
+  ])("$name", { timeout: 60_000 }, async (scenario, { signal, onTestFinished }) => {
+    const lifetime = createFixtureLifetime();
+    onTestFinished(() => lifetime.cleanup());
+    await lifetime.run(async () => {
+      // An unjoined child still owns its files: keep them outside the enclosing
+      // Vitest process's disposable namespace, just like withShimFixture.
+      const parent = process.platform === "win32" ? tmpdir() : path.dirname(tmpdir());
+      const root = fs.realpathSync(lifetime.createTempDir("oc-default-empty-", parent));
+      const stdout = createBoundedChildOutput();
+      const stderr = createBoundedChildOutput();
+      // Copy the real configs so their repoRoot is isolated; link their unchanged
+      // setup, runner and source dependencies from the source checkout.
+      fs.mkdirSync(path.join(root, "test/scripts"), { recursive: true });
+      for (const name of ["vitest", "tsconfig"]) {
+        fs.cpSync(path.join(repoRoot, "test", name), path.join(root, "test", name), {
+          recursive: true,
+        });
+      }
+      for (const name of ["scripts", "src", "packages", "node_modules"]) {
+        fs.symlinkSync(path.join(repoRoot, name), path.join(root, name), "junction");
+      }
+      for (const name of ["package.json", "tsconfig.json"]) {
+        fs.copyFileSync(path.join(repoRoot, name), path.join(root, name));
+      }
+      for (const entry of fs.readdirSync(path.join(repoRoot, "test"), { withFileTypes: true })) {
+        if (entry.isFile() && !entry.name.endsWith(".test.ts")) {
+          fs.symlinkSync(
+            path.join(repoRoot, "test", entry.name),
+            path.join(root, "test", entry.name),
+            "file",
+          );
+        }
+      }
+      const env: NodeJS.ProcessEnv = {
+        PATH: process.env.PATH,
+        SystemRoot: process.env.SystemRoot,
+        HOME: path.join(root, "home"),
+        USERPROFILE: path.join(root, "home"),
+        OPENCLAW_HOME: path.join(root, "home"),
+        OPENCLAW_STATE_DIR: path.join(root, "state"),
+        OPENCLAW_CONFIG_PATH: path.join(root, "state/openclaw.json"),
+        TMPDIR: path.join(root, "tmp"),
+        TMP: path.join(root, "tmp"),
+        TEMP: path.join(root, "tmp"),
+        XDG_CACHE_HOME: path.join(root, "cache"),
+        XDG_CONFIG_HOME: path.join(root, "config"),
+        TSX_TSCONFIG_PATH: path.join(repoRoot, "tsconfig.json"),
+        TSX_DISABLE_CACHE: "1",
+        NODE_DISABLE_COMPILE_CACHE: "1",
+        COREPACK_ENABLE_NETWORK: "0",
+        GIT_OPTIONAL_LOCKS: "0",
+        CI: "1",
+        NO_COLOR: "1",
+        FORCE_COLOR: "0",
+        OPENCLAW_TEST_PROJECTS_TIMINGS: "0",
+        OPENCLAW_VITEST_MAX_WORKERS: "1",
+        OPENCLAW_VITEST_FS_MODULE_CACHE_PATH: path.join(root, "module-cache"),
+        OPENCLAW_VITEST_NO_OUTPUT_RETRY: "0",
+        ...(scenario.parallel ? { OPENCLAW_TEST_PROJECTS_PARALLEL: "2" } : {}),
+      };
+      for (const name of ["home", "state", "tmp", "cache", "config"]) {
+        fs.mkdirSync(path.join(root, name));
+      }
+      fs.writeFileSync(env.OPENCLAW_CONFIG_PATH!, "{}");
+      const runFixtureCommand = (bin: string, commandArgs: string[]) =>
+        lifetime.track(
+          runManagedCommand({
+            bin,
+            args: commandArgs,
+            cwd: root,
+            env,
+            signal,
+            stdio: ["ignore", "pipe", "pipe"],
+            timeoutMs: 45_000,
+            timeoutKillGraceMs: 10_000,
+            requireProcessTreeExit: process.platform !== "win32",
+            onReady(child) {
+              child.stdout?.on("data", stdout.append);
+              child.stderr?.on("data", stderr.append);
+            },
+          }),
+        );
+      // Discovery must not inherit an enclosing checkout's ignored temp directory.
+      expect(await runFixtureCommand("git", ["init", "--quiet"]), stderr.text()).toBe(0);
+      const marker = path.join(root, "executed");
+      fs.writeFileSync(path.join(root, source), "export const value = 1;\n");
+      for (const file of [target, sibling, ...(scenario.parallel ? [isolated] : [])]) {
+        fs.writeFileSync(
+          path.join(root, file),
+          `import fs from "node:fs";
+import { it } from "vitest";
+import "./empty-policy.synthetic.ts";
+it${scenario.skipped ? ".skip" : ""}("records execution", () => fs.appendFileSync(${JSON.stringify(marker)}, "executed\\n"));
+`,
+        );
+      }
+      const output = path.join(root, "native.json");
+      const args = [
+        ...(scenario.entry === "projects"
+          ? ["--import", "tsx", path.join(repoRoot, "scripts/test-projects.mts")]
+          : [path.join(repoRoot, "scripts/run-vitest.mjs")]),
+        ...(scenario.selectors ?? [target]),
+        ...(scenario.emptyInvocations
+          ? ["--reporter=verbose"]
+          : ["--reporter=json", `--outputFile=${output}`]),
+        "--exclude=src/scripts/**",
+        ...(scenario.excluded === false
+          ? []
+          : [
+              `--exclude=${target}`,
+              ...(scenario.tests ? [] : [`--exclude=${sibling}`]),
+              ...(scenario.parallel ? [`--exclude=${isolated}`] : []),
+            ]),
+        ...(scenario.flags ?? []),
+      ];
+      const code = await runFixtureCommand(process.execPath, args);
+      const report = fs.existsSync(output)
+        ? (JSON.parse(fs.readFileSync(output, "utf8")) as JsonTestResults)
+        : undefined;
+      const evidence = JSON.stringify({
+        args,
+        code,
+        stdout: stdout.text(),
+        stderr: stderr.text(),
+        report,
+      });
+      expect(code, evidence).toBe(scenario.code);
+      expect(stderr.text(), evidence).not.toContain("Unhandled Errors");
+      if (scenario.emptyInvocations) {
+        expect(
+          stderr.text().match(/No test files found, exiting with code 1/gu),
+          evidence,
+        ).toHaveLength(scenario.emptyInvocations);
+      } else if (scenario.help) {
+        expect(stdout.text().match(/Usage:/gu), evidence).toHaveLength(1);
+        expect(report).toBeUndefined();
+      } else if (scenario.invalid) {
+        expect(stderr.text()).toContain("Expected a single value for option");
+        expect(report).toBeUndefined();
+      } else {
+        expect(report, evidence).toMatchObject({
+          success: scenario.code === 0,
+          numTotalTests: scenario.tests ?? 0,
+        });
+        expect(report?.testResults).toHaveLength(scenario.tests ? 1 : 0);
+      }
+      expect(fs.existsSync(marker), evidence).toBe(Boolean(scenario.tests && !scenario.skipped));
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/135352 (explicit-file tests can pass empty without an allow-empty choice).

Related, not superseded: https://github.com/openclaw/openclaw/pull/133449 (explicit boolean argument and cleanup repair).

<details>
<summary>Additional instructions</summary>

This same-repository branch remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where contributors naming test files would receive a passing result when exclusions removed every selected file and they had not opted into an empty run. It affects routed `pnpm test <file>` and project-entry runs.

This is the longstanding absent-option default gap, not a newly introduced scalar-parser regression or removal of an operator's explicit allow-empty choice.

## Why This Change Was Made

The project execution owner applies the approved default while original native CLI filters still distinguish explicit test files from broader selections lowered into include metadata. Vitest remains authoritative for parsing, invalid-input diagnostics, and discovery outcomes; shared lane defaults and the direct wrapper's stronger contract stay unchanged.

The boundary regressions use real commands/configs, isolated Git discovery and state, and the existing fixture-lifetime owner. Admission checks now synchronize on preparation itself rather than assuming an entrypoint import has reached that asynchronous boundary.

## User Impact

A finite routed request containing only explicit test-file paths fails when a selected native invocation discovers zero files unless the caller supplies the existing allow-empty policy. Explicit true/bare opt-ins still permit emptiness; false, negation, native spelling and invalid inputs retain their native behavior. Skipped cases remain distinct from undiscovered files.

Directory/glob/basename/source-derived/mixed/config selections, changed-only no-work runs, metadata/watch paths, plugin allow-empty controls, and the direct configured wrapper's stricter policy are preserved. No options, environment variables, application-runtime or persistence surfaces are added. The enablement path is documented in the [testing reference](https://docs.openclaw.ai/reference/test#routine-local-order).

## Evidence

Final rebased head: `3bc45d53393692a0d088afc201182fed83b5a8bc`; pinned main snapshot: `9e4febb30627109552bd099df5f6ba36fbcd5e37`; source tree: `629a255179af6070ebaffb021f40472c24205281`. Exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/33575596159) is complete and green; native prepare and squash merge completed. Landed commit: [`c7277fb99e6960ac7e61d8b31eda38fc18d16399`](https://github.com/openclaw/openclaw/commit/c7277fb99e6960ac7e61d8b31eda38fc18d16399); issue #135352 is closed as completed.

Fresh final-tree proof used [the prepared Blacksmith CI-parity environment](https://github.com/openclaw/openclaw/actions/runs/33574505352), Node 24.19.0, pnpm 12.1.0, patched Vitest 4.1.11, TypeScript 6.0.3 and fs-safe 0.7.0. The frozen install succeeded. Commands used synthetic HOME/state/tmp directories and the actual repository wrappers and native reports, with source bindings checked before and after. No forced runtime/cache path, dependency override, weaker assertion or increased deadline was used.

- Real operator-facing CLI: excluding the named file with no policy exits **1** and records zero tests; adding `--passWithNoTests` exits **0** and records zero tests.
- Full native matrix: **20/20 passed**. Its nonempty control, exact multi-file/multi-lane requests, explicit/invalid native policy, direct configured behavior, broad selectors, help and skipped-but-discovered cases all retain their contracts.
- Full admission suite: **77/77 passed**, including upstream selective-exclusion coverage and actual preparation/reader synchronization with finally joins.
- Routing, direct wrapper, plugin, native report, home-selection/lifecycle, pattern and CI planner siblings: **1,016/1,016 passed**, no skipped or failed cases. This includes the newly integrated upstream home-selection checks and deliberately paused-worker teardown.
- Five-path changed gate and `pnpm docs:list`: **passed**. Formatting, both typechecks, lint and selected guards completed on this exact tree.
- Fresh canonical Codex autoreview: **scoped-clean at P0**, two complete passes, no findings. Empty-workspace/restricted review isolation, complete bundle bounds and TruffleHog scans were preserved.

Representative executed commands (reporter/output arguments and synthetic state are recorded in the retained receipts):

```bash
node scripts/run-vitest.mjs test/scripts/test-projects-empty-native.test.ts --exclude=test/scripts/test-projects-empty-native.test.ts
node scripts/run-vitest.mjs test/scripts/test-projects-empty-native.test.ts --exclude=test/scripts/test-projects-empty-native.test.ts --passWithNoTests
node scripts/run-vitest.mjs test/scripts/test-projects-empty-native.test.ts
node scripts/run-vitest.mjs test/scripts/test-projects-build-admission.test.ts
node scripts/run-vitest.mjs test/scripts/test-projects.test.ts test/scripts/test-projects-routing.test.ts test/scripts/run-vitest.test.ts test/scripts/run-vitest-bounded.test.ts test/scripts/run-vitest-state-cleanup.test.ts test/scripts/vitest-report-owner.test.ts test/scripts/test-extension.test.ts test/vitest/vitest.pattern-file.test.ts test/scripts/ci-node-test-plan.test.ts
node scripts/check-changed.mjs --timed -- docs/reference/test.md scripts/lib/vitest-report-owner.mts scripts/test-projects-run.mts test/scripts/test-projects-empty-native.test.ts test/scripts/test-projects-build-admission.test.ts
pnpm docs:list
```

Prior pre-fix reproduction returned exit 0 for the absent option and failed the regression's expected-exit-1 assertion. A full `pnpm build` passed in 3003.714 seconds **before the first rebase**; it is historical evidence, not a fresh full build. Final focused proof exercises current dependencies/build admission, and exact-head hosted CI covers the integrated upstream tree. The interrupted local frozen-install attempt remains a documented filesystem stall, not successful proof; no manual node_modules repair was performed. Earlier interrupted runs and lost pre-reboot sibling receipts are not counted in the fresh totals above.

Production/tooling LOC: **+49/-4 (net +45)**; application runtime: **0**. Tests: **+248/-20 (net +228)**; docs: **+11**. The growth implements the approved original-selector/default boundary where original arguments and concrete native invocations coexist. An unconditional pre-delegation guard would erase explicit opt-in and miss the direct project entry; changing lane defaults would alter broader selectors. The patch reuses native parsing/help classification, adds no parser/option/runtime fallback/test-only production seam, and replaces import-completion timing assumptions with preparation events.

## Canonical CI integration and known history

The prior exact-head [CI run 33569890494](https://github.com/openclaw/openclaw/actions/runs/33569890494) remains **failed**, not relabeled:

- [compact-large-18](https://github.com/openclaw/openclaw/actions/runs/33569890494/job/100061500337) selected a section-header marquee instead of the catalog-session label.
- [compact-small-55](https://github.com/openclaw/openclaw/actions/runs/33569890494/job/100061500059) mixed real timing measurements into its synthetic fixture and exceeded the valid 112-job cap.

Both canonical repairs are integrated from [merged PR #135585](https://github.com/openclaw/openclaw/pull/135585), squash [`d650e7a2a7b0234a65dd1853998c79d88e2dcfea`](https://github.com/openclaw/openclaw/commit/d650e7a2a7b0234a65dd1853998c79d88e2dcfea). [PR #135636](https://github.com/openclaw/openclaw/pull/135636) is closed/superseded. No duplicate fixture edits, cap changes, unrelated merges or gate bypasses were added. This necessary rebase preserves exactly the five-file repair; every added/deleted patch line matches the previous published candidate. Upstream home-selection ownership remains intact and is freshly tested.

## Maintainer decision and ClawSweeper follow-through

The narrower strict routed default was explicitly approved before implementation and reaffirmed for this landing. Automation intentionally permitting an empty named-file run uses the existing `--passWithNoTests` opt-in. Broader selection, direct configured and plugin contracts remain unchanged.

[ClawSweeper’s completed review](https://github.com/openclaw/openclaw/pull/135609#issuecomment-5501478257) has no scoped correctness finding. Its rank-up requests are addressed by the explicit compatibility acceptance, canonical rebase/exact-head CI gate, and personal inspection of the actual patched Vitest `parseCLI`/scalar validation/discovery-completion contracts. fs-safe 0.7.0 native loader and lock/deadline/release ownership were also inspected. Fresh native command/report proof verifies those assumptions. No redundant re-review request or fabricated completion marker was used.

Only issue #135352 is a closure target. The scalar issue #133432, PR #133449 and their active work remain separate and untouched. No release, npm, changelog or advisory action is part of this PR.

Native [land-ready proof](https://github.com/openclaw/openclaw/pull/135609#issuecomment-5502583688) and [confirmed merge receipt](https://github.com/openclaw/openclaw/pull/135609#issuecomment-5502610796) record the completed flow.
