### PR TITLE
refactor(gateway): share exact admin scope membership

### DIFF
--- a/src/gateway/agent-turn/agent-handler-helpers.ts
+++ b/src/gateway/agent-turn/agent-handler-helpers.ts
@@ -24,7 +24,7 @@ import {
 } from "../../sessions/agent-harness-session-key.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
 import { setSafeTimeout } from "../../utils/timer-delay.js";
-import { ADMIN_SCOPE } from "../method-scopes.js";
+import { hasOperatorAdminScope } from "../operator-scopes.js";
 import type { GatewayRequestHandlerOptions } from "../server-methods/types.js";
 import {
   emitGatewaySessionEndPluginHook,
@@ -51,11 +51,6 @@ export type RestoredCronContinuation = {
     requireExplicitMessageTarget?: boolean;
   };
 };
-
-export function clientHasAdminScope(client: GatewayRequestHandlerOptions["client"]): boolean {
-  const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
-  return scopes.includes(ADMIN_SCOPE);
-}
 
 export function respondDeletedAgentSession(params: {
   cfg: OpenClawConfig;
@@ -139,7 +134,9 @@ export function respondUnavailableAgentSessionForKey(params: {
 export function resolveAllowModelOverrideFromClient(
   client: GatewayRequestHandlerOptions["client"],
 ): boolean {
-  return clientHasAdminScope(client) || client?.internal?.allowModelOverride === true;
+  return (
+    hasOperatorAdminScope(client?.connect?.scopes) || client?.internal?.allowModelOverride === true
+  );
 }
 
 export function resolveCanUseInternalRuntimeHandoff(

--- a/src/gateway/agent-turn/agent-run-user-turn.ts
+++ b/src/gateway/agent-turn/agent-run-user-turn.ts
@@ -27,13 +27,13 @@ import {
   type ChatImageContent,
   type OffloadedRef,
 } from "../chat-attachments.js";
+import { hasOperatorAdminScope } from "../operator-scopes.js";
 import type { AgentRunRequest } from "../server-methods/agent-request-types.js";
 import { resolveSessionRuntimeCwd } from "../server-methods/agent-session-reset.js";
 import { gatewayClientSenderFields } from "../server-methods/gateway-client-identity.js";
 import { loadSessionEntry } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
 import {
-  clientHasAdminScope,
   shouldSuppressAgentPromptPersistence,
   type RestoredCronContinuation,
 } from "./agent-handler-helpers.js";
@@ -129,7 +129,7 @@ export async function prepareAgentRunUserTurn(params: {
 
     const senderIsOwner = params.restoredCronContinuation
       ? true
-      : clientHasAdminScope(params.client);
+      : hasOperatorAdminScope(params.client?.connect?.scopes);
     const suppressPromptPersistence =
       params.requestedPromptPersistenceSuppression ||
       shouldSuppressAgentPromptPersistence({

--- a/src/gateway/operator-scopes.test.ts
+++ b/src/gateway/operator-scopes.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { hasOperatorAdminScope } from "./operator-scopes.js";
+
+describe("hasOperatorAdminScope", () => {
+  it.each([
+    [["operator.admin"], true],
+    [["operator.read", "operator.admin", "operator.write"], true],
+    [["operator.write"], false],
+    [[" operator.admin "], false],
+    [["OPERATOR.ADMIN"], false],
+    ["operator.admin", false],
+    [{ 0: "operator.admin" }, false],
+    [new Set(["operator.admin"]), false],
+    [null, false],
+    [undefined, false],
+  ] as const)("checks exact raw array membership for %j", (scopes, expected) => {
+    expect(hasOperatorAdminScope(scopes)).toBe(expected);
+  });
+});

--- a/src/gateway/operator-scopes.ts
+++ b/src/gateway/operator-scopes.ts
@@ -9,6 +9,11 @@ export const PAIRING_SCOPE = "operator.pairing" as const;
 export const TALK_SCOPE = "operator.talk" as const;
 export const TALK_SECRETS_SCOPE = "operator.talk.secrets" as const;
 
+/** Exact raw membership only; no normalization or implied scopes. */
+export function hasOperatorAdminScope(scopes: unknown): boolean {
+  return Array.isArray(scopes) && scopes.includes(ADMIN_SCOPE);
+}
+
 /** Operator privileges advertised by gateway auth and checked by method policy. */
 export type OperatorScope =
   | typeof ADMIN_SCOPE

--- a/src/gateway/server-methods/agent-reset-phase.ts
+++ b/src/gateway/server-methods/agent-reset-phase.ts
@@ -12,8 +12,8 @@ import { assertAgentRunLifecycleGenerationCurrent } from "../../infra/agent-even
 import { assertPreparedSkillLibrarySelection } from "../../skills/library/selection.js";
 import { AGENT_SESSION_RESET_COMMAND_RE } from "../agent-command-policy.js";
 import { setGatewayDedupeEntries } from "../agent-turn/agent-dedupe.js";
-import { clientHasAdminScope } from "../agent-turn/agent-handler-helpers.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
+import { hasOperatorAdminScope } from "../operator-scopes.js";
 import { prepareSkillLibrarySessionCreation } from "../skill-library-session.js";
 import { formatForLog } from "../ws-log.js";
 import type { AgentRunRequest } from "./agent-request-types.js";
@@ -81,7 +81,7 @@ export async function runAgentResetPhase(params: {
     return { ...base, stop: true, accepted: true };
   }
   const postResetMessage = normalizeOptionalString(resetCommandMatch[2]) ?? "";
-  if (!clientHasAdminScope(params.client)) {
+  if (!hasOperatorAdminScope(params.client?.connect?.scopes)) {
     params.respond(
       false,
       undefined,

--- a/src/gateway/server-methods/chat-origin-routing.ts
+++ b/src/gateway/server-methods/chat-origin-routing.ts
@@ -21,7 +21,6 @@ import {
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import { sanitizeChatSendMessageInput } from "../chat-input-sanitize.js";
-import { ADMIN_SCOPE } from "../method-scopes.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
@@ -314,9 +313,4 @@ export function isAcpBridgeClient(client: GatewayRequestHandlerOptions["client"]
     info?.displayName === "ACP" &&
     info?.version === "acp"
   );
-}
-
-export function hasGatewayAdminScope(client: GatewayRequestHandlerOptions["client"]): boolean {
-  const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
-  return scopes.includes(ADMIN_SCOPE);
 }

--- a/src/gateway/server-methods/chat-send-request.ts
+++ b/src/gateway/server-methods/chat-send-request.ts
@@ -25,9 +25,9 @@ import { isBrowserCopilotClient, isOperatorUiClient } from "../../utils/message-
 import { isChatStopCommandText } from "../chat-abort.js";
 import type { ChatAttachment } from "../chat-attachments.js";
 import { sanitizeChatSendMessageInput } from "../chat-input-sanitize.js";
+import { hasOperatorAdminScope } from "../operator-scopes.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
 import {
-  hasGatewayAdminScope,
   normalizeExplicitChatSendOrigin,
   normalizeOptionalChatSystemReceipt,
   type ChatSendExplicitOrigin,
@@ -132,7 +132,7 @@ export function normalizeChatSendRequest(params: {
       suppressCommandInterpretation ||
       explicitOriginResult.value) &&
     !params.trustedSystemInput &&
-    !hasGatewayAdminScope(params.client)
+    !hasOperatorAdminScope(params.client?.connect?.scopes)
   ) {
     return {
       ok: false,
@@ -195,7 +195,10 @@ export function normalizeChatSendRequest(params: {
           operationId: p.idempotencyKey,
           issuedAtMs: p.intent.issuedAtMs,
           objective: p.message,
-          requestFingerprint: fingerprintSessionGoalRequest([p, hasGatewayAdminScope(client)]),
+          requestFingerprint: fingerprintSessionGoalRequest([
+            p,
+            hasOperatorAdminScope(client?.connect?.scopes),
+          ]),
         }
       : undefined);
   const commandInterpretationSuppressed =

--- a/src/gateway/server-methods/chat-send-session.ts
+++ b/src/gateway/server-methods/chat-send-session.ts
@@ -16,6 +16,7 @@ import { resolveMissingAgentHarnessSessionError } from "../../sessions/agent-har
 import { assertPreparedSkillLibrarySelection } from "../../skills/library/selection.js";
 import { isBrowserOperatorUiClient } from "../../utils/message-channel.js";
 import { authorizeGatewaySessionCreation, resolveCreatorSandbox } from "../operator-role-policy.js";
+import { hasOperatorAdminScope } from "../operator-scopes.js";
 import { pendingChatSendDedupeKey } from "../server-shared.js";
 import {
   loadSessionEntry,
@@ -24,7 +25,6 @@ import {
 } from "../session-utils.js";
 import { prepareSkillLibrarySessionCreation } from "../skill-library-session.js";
 import {
-  hasGatewayAdminScope,
   resolveChatSendActiveScopeKey,
   resolveRequestedChatAgentId,
   validateChatSelectedAgent,
@@ -239,7 +239,7 @@ export function prepareChatSendSession(params: {
       request.systemProvenanceReceipt === undefined &&
       !request.suppressCommandInterpretation,
     message: rawMessage,
-    senderIsOwner: hasGatewayAdminScope(client),
+    senderIsOwner: hasOperatorAdminScope(client?.connect?.scopes),
   });
 
   return {

--- a/src/gateway/server-methods/chat-user-turn-recorder.ts
+++ b/src/gateway/server-methods/chat-user-turn-recorder.ts
@@ -6,9 +6,9 @@ import {
   type UserTurnInput,
   type UserTurnTranscriptRecorder,
 } from "../../sessions/user-turn-transcript.js";
+import { hasOperatorAdminScope } from "../operator-scopes.js";
 import { loadSessionEntry } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
-import { hasGatewayAdminScope } from "./chat-origin-routing.js";
 import { buildRestartSafeChatTranscriptState } from "./chat-restart-recovery.js";
 import type { AdmittedChatSend } from "./chat-send-admission.js";
 import {
@@ -52,7 +52,7 @@ export function createGatewayChatUserTurnController(params: {
     idempotencyKey: buildRunUserTurnIdempotencyKey(session.clientRunId),
     ...(request.p.replyToId ? { replyToId: request.p.replyToId } : {}),
     ...(sender ? { sender } : {}),
-    ...(hasGatewayAdminScope(params.client) ? { senderIsOwner: true } : {}),
+    ...(hasOperatorAdminScope(params.client?.connect?.scopes) ? { senderIsOwner: true } : {}),
     ...(request.systemInputProvenance ? { provenance: request.systemInputProvenance } : {}),
   };
   const replyContextFieldsPromise = request.p.replyToId

--- a/src/gateway/server-methods/conversations.ts
+++ b/src/gateway/server-methods/conversations.ts
@@ -16,7 +16,7 @@ import {
 import { runGatewayConversationList } from "../conversation-list.js";
 import { runGatewayConversationSend } from "../conversation-send.js";
 import { runGatewayConversationTurn } from "../conversation-turn.js";
-import { ADMIN_SCOPE } from "../operator-scopes.js";
+import { hasOperatorAdminScope } from "../operator-scopes.js";
 import { resolveGatewayPluginConfig } from "../runtime-plugin-config.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { formatForLog } from "../ws-log.js";
@@ -44,7 +44,7 @@ type ConversationHandlerDeps = {
 function isAuthenticatedOwner(client: GatewayClient | null): boolean {
   // These RPCs require operator.admin. Derive owner status from the admitted
   // socket anyway so no future schema field can self-assert channel authority.
-  return client?.connect?.scopes?.includes(ADMIN_SCOPE) === true;
+  return hasOperatorAdminScope(client?.connect?.scopes);
 }
 
 function validateConversationSourceSession(params: {

--- a/src/gateway/server-methods/cron-creator-authority-admission.ts
+++ b/src/gateway/server-methods/cron-creator-authority-admission.ts
@@ -1,5 +1,5 @@
 import type { InputProvenance } from "../../sessions/input-provenance.js";
-import { clientHasAdminScope } from "../agent-turn/agent-handler-helpers.js";
+import { hasOperatorAdminScope } from "../operator-scopes.js";
 import type { AgentRunRequest } from "./agent-request-types.js";
 import type { GatewayClient } from "./shared-types.js";
 
@@ -24,7 +24,7 @@ function resolveDirectLocalOperatorAuthority(
   const runId = params.runId.trim();
   const isDirectLocalOperator =
     runId.length > 0 &&
-    clientHasAdminScope(params.client ?? null) &&
+    hasOperatorAdminScope(params.client?.connect?.scopes) &&
     internal?.isLocalClient === true &&
     Boolean(params.resolvedSessionKey?.trim()) &&
     !params.spawnedBy?.trim() &&

--- a/src/gateway/server-methods/nodes-policy.ts
+++ b/src/gateway/server-methods/nodes-policy.ts
@@ -12,10 +12,6 @@ export const nodeInvokePolicy = {
     const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
     return scopes.includes(ADMIN_SCOPE) || scopes.includes(PAIRING_SCOPE);
   },
-  clientHasOperatorAdminScope(client: GatewayClient | null): boolean {
-    const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
-    return scopes.includes(ADMIN_SCOPE);
-  },
   rejectClaudeAgentRun(command: string, respond: RespondFn): boolean {
     if (command !== NODE_AGENT_CLI_CLAUDE_RUN_COMMAND) {
       return false;

--- a/src/gateway/server-methods/nodes.invoke.ts
+++ b/src/gateway/server-methods/nodes.invoke.ts
@@ -23,7 +23,7 @@ import {
   NODE_WAKE_RECONNECT_WAIT_MS,
   releaseNodeWakeLifecycle,
 } from "../node-wake-state.js";
-import { ADMIN_SCOPE } from "../operator-scopes.js";
+import { ADMIN_SCOPE, hasOperatorAdminScope } from "../operator-scopes.js";
 import { buildNodeCommandRejectionHint } from "./node-command-rejection-hint.js";
 import { nodeInvokePolicy } from "./nodes-policy.js";
 import { handleNodeInvokeProgress } from "./nodes.handlers.invoke-progress.js";
@@ -115,10 +115,7 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    if (
-      isAdminOnlyNodeInvokeCommand(command) &&
-      !nodeInvokePolicy.clientHasOperatorAdminScope(client)
-    ) {
+    if (isAdminOnlyNodeInvokeCommand(command) && !hasOperatorAdminScope(client?.connect?.scopes)) {
       respond(
         false,
         undefined,

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -20,7 +20,7 @@ import { controlRealtimeVoiceAgentRun } from "../../talk/agent-run-control.js";
 import { ensureClientVoiceAgentSessionEntry } from "../../talk/client-voice-session.js";
 import { resolveConfiguredRealtimeVoiceProvider } from "../../talk/provider-resolver.js";
 import { resolveSandboxedSessionCreation } from "../operator-role-policy.js";
-import { ADMIN_SCOPE } from "../operator-scopes.js";
+import { ADMIN_SCOPE, hasOperatorAdminScope } from "../operator-scopes.js";
 import { SessionMutationAuthorizationChangedError } from "../session-sharing.js";
 import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
 import { resolveTalkAgentConsultAuthority } from "../talk-client-gateway-control.js";
@@ -87,7 +87,7 @@ function canCloseManagedRoomSession(
 function canCreateUnscopedManagedRoomSession(
   client: { connect?: { scopes?: string[] } } | null,
 ): boolean {
-  return client?.connect?.scopes?.includes(ADMIN_SCOPE) === true;
+  return hasOperatorAdminScope(client?.connect?.scopes);
 }
 
 function managedRoomOwnershipError(action: string) {

--- a/src/gateway/server-methods/talk-shared.ts
+++ b/src/gateway/server-methods/talk-shared.ts
@@ -30,7 +30,7 @@ import {
   resolveSupportedVoiceModelRefs,
   type VoiceModelProvider,
 } from "../../tts/voice-models.js";
-import { ADMIN_SCOPE } from "../operator-scopes.js";
+import { hasOperatorAdminScope } from "../operator-scopes.js";
 
 /** Resolve the Talk session mode, defaulting managed-room transports to stt-tts. */
 export function normalizeTalkSessionMode(params: { mode?: string; transport?: string }): TalkMode {
@@ -75,8 +75,7 @@ export async function resolveTalkRealtimeProviderInstructions(params: {
 }
 
 export function canUseTalkDirectTools(client: { connect?: { scopes?: string[] } } | null): boolean {
-  const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
-  return scopes.includes(ADMIN_SCOPE);
+  return hasOperatorAdminScope(client?.connect?.scopes);
 }
 
 export function broadcastTalkRoomEvents(

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -39,7 +39,11 @@ import type {
 } from "../plugins/runtime/types.js";
 import type { PluginLogger, PluginOrigin } from "../plugins/types.js";
 import { ADMIN_SCOPE, authorizeOperatorScopesForRequiredScope } from "./method-scopes.js";
-import { normalizeOperatorScopeList, type OperatorScope } from "./operator-scopes.js";
+import {
+  hasOperatorAdminScope,
+  normalizeOperatorScopeList,
+  type OperatorScope,
+} from "./operator-scopes.js";
 import type { GatewayNodeInvokeStream } from "./server-methods/shared-types.js";
 import type {
   GatewayContextResolver,
@@ -176,13 +180,10 @@ function authorizeFallbackModelOverride(params: {
 
 // ── Internal gateway dispatch for plugin runtime ────────────────────
 
-function hasAdminScope(client: GatewayRequestOptions["client"] | undefined): boolean {
-  const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
-  return scopes.includes(ADMIN_SCOPE);
-}
-
 function canClientUseModelOverride(client: GatewayRequestOptions["client"]): boolean {
-  return hasAdminScope(client) || client?.internal?.allowModelOverride === true;
+  return (
+    hasOperatorAdminScope(client?.connect?.scopes) || client?.internal?.allowModelOverride === true
+  );
 }
 
 function canTrustedOfficialPluginRequestScopes(params: {
@@ -380,7 +381,7 @@ export function createGatewaySubagentRuntime(
       const pluginOwnedCleanupOptions = pluginId
         ? {
             pluginRuntimeOwnerId: pluginId,
-            ...(!hasAdminScope(scope?.client)
+            ...(!hasOperatorAdminScope(scope?.client?.connect?.scopes)
               ? {
                   forceSyntheticClient: true,
                   syntheticScopes: [ADMIN_SCOPE],

--- a/src/gateway/session-sharing-policy.ts
+++ b/src/gateway/session-sharing-policy.ts
@@ -14,6 +14,7 @@ import {
   resolveGatewayOperatorRoleActor,
   resolveOperatorRolePolicy,
 } from "./operator-role-policy.js";
+import { hasOperatorAdminScope } from "./operator-scopes.js";
 import {
   authenticatedProfileUnavailableError,
   gatewayClientSessionCreator,
@@ -48,7 +49,7 @@ export function resolveSessionVisibility(
 export function isGatewayAdmin(client: Pick<GatewayClient, "connect"> | null): boolean {
   // Internal/plugin-runtime runs reach authorization with a client that has no
   // connect handshake; treat a connect-less client as a non-admin, never a crash.
-  return client?.connect?.scopes?.includes("operator.admin") === true;
+  return hasOperatorAdminScope(client?.connect?.scopes);
 }
 
 export function allowedSessionVisibilities(cfg: OpenClawConfig): SessionVisibility[] {

--- a/src/gateway/talk-client-gateway-control.ts
+++ b/src/gateway/talk-client-gateway-control.ts
@@ -44,7 +44,7 @@ import {
 } from "../talk/realtime-session-harness.js";
 import type { TalkEvent } from "../talk/talk-events.js";
 import { registerChatAbortController } from "./chat-abort.js";
-import { ADMIN_SCOPE, WRITE_SCOPE } from "./operator-scopes.js";
+import { hasOperatorAdminScope, WRITE_SCOPE } from "./operator-scopes.js";
 import type { GatewayRequestContext } from "./server-methods/shared-types.js";
 import { resolveOwnedActiveTalkRunTarget } from "./server-methods/talk-client-run-ownership.js";
 import { formatError } from "./server-utils.js";
@@ -81,7 +81,7 @@ export type TalkAgentConsultAuthority = {
 export function resolveTalkAgentConsultAuthority(
   scopes: readonly string[] | undefined,
 ): TalkAgentConsultAuthority {
-  const senderIsOwner = scopes?.includes(ADMIN_SCOPE) === true;
+  const senderIsOwner = hasOperatorAdminScope(scopes);
   if (senderIsOwner || scopes?.includes(WRITE_SCOPE) === true) {
     return { senderIsOwner };
   }


### PR DESCRIPTION
## What Problem This Solves

Gateway admin-scope checks were duplicated across several internal owners, making exact membership semantics easier to drift during future security-sensitive changes.

## Why This Change Was Made

`operator-scopes.ts` now owns one exact raw-membership predicate: the input must be an array containing the literal `operator.admin`. Malformed, absent, string, object, set, whitespace-padded, and case-variant inputs deny; there is no coercion, normalization, role implication, fallback, or implication from write, pairing, Talk, or approval scopes.

Semantic policy wrappers remain intact: `canUseTalkDirectTools`, `canCreateUnscopedManagedRoomSession`, `isGatewayAdmin`, and `isAuthenticatedOwner`. Generic aliases were removed: `hasAdminScope`, `clientHasAdminScope`, `hasGatewayAdminScope`, and `clientHasOperatorAdminScope`. The Talk write-scope composite and node pairing composite remain unchanged.

This deliberately excludes method authorization implication, connection normalization and role ceilings, device auth, trusted-null session mutation bypasses, HTTP ceilings, and direct checks with distinct semantics. There is no protocol, public SDK, client type, config, persistence, or schema change.

## User Impact

No user-visible behavior changes. This is an internal exact-membership refactor that reduces policy drift while preserving every existing Gateway authorization boundary.

## Evidence

- Focused Gateway suite: 9 files passed, 378 tests passed. The requested `session-sharing-policy.test.ts` does not exist on current main, so the owning `session-sharing.test.ts` suite was run.
- New hostile-input table covers exact admin, mixed scopes, write-only, whitespace, case, string, object, set, null, and undefined.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `oxfmt --check` on all 18 changed files: passed.
- `git diff --check`: passed.
- Exact autoreview command: scoped clean, no accepted/actionable findings, correctness 0.98.
- `pnpm check:changed`: selected checks began successfully but the test typecheck cannot complete because the shared unreconciled `node_modules` lacks current main's `mermaid` dependency. Worktree policy for this task explicitly forbids install/reconcile. Core production typecheck and the earlier selected checks passed before that dependency error.
- Production LOC: +46/-53, net -7. Test LOC: +19/-0. Total: +65/-53 across 18 files.
- No changelog: no user-visible behavior.
- No live or Crabbox proof: this changes only an internal exact-membership predicate and was covered through the owning Gateway suites.

Current-main and overlap check:

- Rebasing finished on current `origin/main` at `abf21a675ca56fd79cee4afa97af643180c2a1c6`; intervening main commits changed none of the reviewed files.
- https://github.com/openclaw/openclaw/pull/102168 remains open at `f2baec20182796e033d0d620c9f0902e48478608`.
- https://github.com/openclaw/openclaw/pull/120140 remains open at `9f3bb9374a200931b76947a8411f66f1a6c12c6a`; its possible third `server-plugins.ts` use is not on current main and was not added here.
- No competing extraction was found. https://github.com/openclaw/openclaw/pull/132622 was the only text-search hit and touches unrelated Feishu/message-action files.

Codex hard-gate inspection: `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870` were personally checked; these CLI/completion paths do not alter this Gateway-local membership contract.
