### PR TITLE
feat(ui): adopt Carapace for plugin settings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2565,6 +2565,9 @@ importers:
       '@novnc/novnc':
         specifier: 1.7.0
         version: 1.7.0
+      '@openclaw/carapace':
+        specifier: github:openclaw/carapace#6c38d2a9b558104957d581033bce5a127632d60e
+        version: https://codeload.github.com/openclaw/carapace/tar.gz/6c38d2a9b558104957d581033bce5a127632d60e
       '@openclaw/gateway-client':
         specifier: workspace:*
         version: link:../packages/gateway-client
@@ -4115,6 +4118,11 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@openclaw/carapace@https://codeload.github.com/openclaw/carapace/tar.gz/6c38d2a9b558104957d581033bce5a127632d60e':
+    resolution: {gitHosted: true, integrity: sha512-1qdvbQKqudDLZXuHr54kyh7Dz5Z3/GgeeDW1TSKkENT9yfBeWuP90c9orsfwXiVChvVch1bOnYzr93xibWkJQA==, tarball: https://codeload.github.com/openclaw/carapace/tar.gz/6c38d2a9b558104957d581033bce5a127632d60e}
+    version: 0.6.2
+    engines: {bun: '>=1.3.0'}
 
   '@openclaw/crabline@0.1.17':
     resolution: {integrity: sha512-tMjpIhzJvCulDA6mYL8nOA6XExWXZoBOrD4XgL3gsNdEDAWY4FCaHYyNCXwKPU2QSs78FU0xZ3NIQRr9ErHRpQ==}
@@ -11403,6 +11411,8 @@ snapshots:
 
   '@openai/codex@0.151.0-win32-x64':
     optional: true
+
+  '@openclaw/carapace@https://codeload.github.com/openclaw/carapace/tar.gz/6c38d2a9b558104957d581033bce5a127632d60e': {}
 
   '@openclaw/crabline@0.1.17':
     dependencies:

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -2526,6 +2526,11 @@ async function createChatPickerScenario(
       "plugins.list": buildPluginCatalogMock(),
       "plugins.inspect": buildPluginInspectMock(),
       "plugins.setEnabled": buildPluginSetEnabledMock(),
+      "skills.status": {
+        workspaceDir: "/Users/demo/Projects/openclaw",
+        managedSkillsDir: "/Users/demo/.openclaw/skills",
+        skills: [],
+      },
       "channels.status": buildChannelsStatusMock(baseTime),
       "channels.pairing.list": buildChannelsPairingMock(baseTime),
       "channels.pairing.approve": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,6 +23,7 @@
     "@noble/ed25519": "3.1.0",
     "@noble/hashes": "2.3.0",
     "@novnc/novnc": "1.7.0",
+    "@openclaw/carapace": "github:openclaw/carapace#6c38d2a9b558104957d581033bce5a127632d60e",
     "@openclaw/gateway-client": "workspace:*",
     "@openclaw/gateway-protocol": "workspace:*",
     "@openclaw/libterminal": "0.3.2",

--- a/ui/src/app/vite-config.node.test.ts
+++ b/ui/src/app/vite-config.node.test.ts
@@ -418,9 +418,25 @@ describe("Control UI Vite config", () => {
     const aliases = resolveExternalPackageAliasesForVite(resolvePackage);
 
     expect(resolvePackage.mock.calls).toEqual([
+      ["@openclaw/carapace/tokens.css"],
+      ["@openclaw/carapace/components.css"],
+      ["@openclaw/carapace/candidate/controls.css"],
+      ["@openclaw/carapace/candidate/feedback.css"],
+      ["@openclaw/carapace/candidate/data.css"],
+      ["@openclaw/carapace/candidate/application.css"],
       ["@openclaw/libterminal/package.json"],
       ["@openclaw/uirouter/package.json"],
     ]);
+    expect(aliases.find((alias) => alias.find === "@openclaw/carapace/tokens.css")).toEqual({
+      find: "@openclaw/carapace/tokens.css",
+      replacement: "/parent/node_modules/@openclaw/carapace/tokens.css",
+    });
+    expect(
+      aliases.find((alias) => alias.find === "@openclaw/carapace/candidate/application.css"),
+    ).toEqual({
+      find: "@openclaw/carapace/candidate/application.css",
+      replacement: "/parent/node_modules/@openclaw/carapace/candidate/application.css",
+    });
     expect(aliases.find((alias) => alias.find === "@openclaw/libterminal/browser")).toEqual({
       find: "@openclaw/libterminal/browser",
       replacement: path.join("/parent/node_modules/@openclaw/libterminal", "dist/browser.js"),

--- a/ui/src/components/hub-tabs.ts
+++ b/ui/src/components/hub-tabs.ts
@@ -19,6 +19,8 @@ type HubTabsProps<T extends string> = {
   ariaLabel: string;
   panelId: string;
   className?: string;
+  /** Opts this strip into Carapace's segmented-control presentation. */
+  carapace?: boolean;
   variant?: "primary" | "sub";
   onSelect: (tab: T) => void;
   onActivate?: (element: HTMLElement) => void;
@@ -64,7 +66,7 @@ function reclaimFocus(hubId: string, tab: string, element: Element | undefined) 
 
 export function renderHubTabs<T extends string>(props: HubTabsProps<T>): TemplateResult {
   const variant = props.variant ?? "primary";
-  const className = `hub-tabs hub-tabs--${variant} ${props.id}-hub-tabs${props.className ? ` ${props.className}` : ""}`;
+  const className = `hub-tabs hub-tabs--${variant} ${props.id}-hub-tabs${props.carapace ? " oc-segmented" : ""}${props.className ? ` ${props.className}` : ""}`;
   const fallbackFocusValue =
     props.active === null ? props.tabs.find((tab) => !tab.disabled)?.value : null;
   return html`
@@ -83,7 +85,7 @@ export function renderHubTabs<T extends string>(props: HubTabsProps<T>): Templat
             id=${`${props.id}-tab-${tab.value}`}
             panel=${tab.value}
             aria-controls=${props.panelId}
-            class="hub-tab"
+            class="hub-tab ${props.carapace ? "oc-segmented-item" : ""}"
             ?active=${selected}
             ?disabled=${tab.disabled}
             .tabIndex=${selected || tab.value === fallbackFocusValue ? 0 : -1}

--- a/ui/src/components/mcp-server-form.ts
+++ b/ui/src/components/mcp-server-form.ts
@@ -13,6 +13,7 @@ export function renderMcpServerForm(props: {
   disabled?: boolean;
   blockedReason?: string | null;
   autofocus?: boolean;
+  carapace?: boolean;
   onSubmit: (form: McpServerForm) => void;
   onCancel: () => void;
 }): TemplateResult {
@@ -36,7 +37,7 @@ export function renderMcpServerForm(props: {
         <span>${t("mcpServers.nameLabel")}</span>
         <input
           name="mcp-name"
-          class="settings-input"
+          class="settings-input ${props.carapace ? "oc-input" : ""}"
           type="text"
           required
           placeholder="context7"
@@ -50,7 +51,7 @@ export function renderMcpServerForm(props: {
         <span>${t("mcpServers.transportLabel")}</span>
         <select
           name="mcp-transport"
-          class="settings-select"
+          class="settings-select ${props.carapace ? "oc-select" : ""}"
           title=${props.blockedReason ?? ""}
           ?disabled=${disabled}
         >
@@ -63,7 +64,7 @@ export function renderMcpServerForm(props: {
         <span>${t("mcpServers.targetLabel")}</span>
         <input
           name="mcp-target"
-          class="settings-input"
+          class="settings-input ${props.carapace ? "oc-input" : ""}"
           type="text"
           required
           placeholder="https://mcp.example.com/mcp  ·  npx some-mcp-server"
@@ -75,13 +76,18 @@ export function renderMcpServerForm(props: {
       <div class="mcp-server-form__actions">
         <button
           type="submit"
-          class="btn btn--sm"
+          class="btn btn--sm ${props.carapace ? "oc-action oc-action-primary" : ""}"
           title=${props.blockedReason ?? ""}
           ?disabled=${disabled}
         >
           ${props.busy ? t("mcpServers.adding") : t("mcpServers.add")}
         </button>
-        <button type="button" class="btn btn--sm" ?disabled=${props.busy} @click=${props.onCancel}>
+        <button
+          type="button"
+          class="btn btn--sm ${props.carapace ? "oc-action oc-action-secondary" : ""}"
+          ?disabled=${props.busy}
+          @click=${props.onCancel}
+        >
           ${t("common.cancel")}
         </button>
       </div>

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -20,6 +20,8 @@ type SettingsRowProps = {
   title: unknown;
   description?: unknown;
   control?: SettingsRowControl;
+  /** Opts this row into the shared Carapace settings contract. */
+  carapace?: boolean;
   /** Full-width control below the text (textareas, segmented sets that wrap). */
   stacked?: boolean;
   /** Full-width control below the text through the narrow-layout breakpoint. */
@@ -35,6 +37,8 @@ export type SettingsSectionProps = {
   count?: number;
   /** Marks the group surface as a danger zone. */
   danger?: boolean;
+  /** Opts this section into the shared Carapace settings contract. */
+  carapace?: boolean;
 };
 
 type SettingsHelpTriggerProps = {
@@ -53,9 +57,15 @@ export type SettingsPageHeaderProps = {
 
 export function renderSettingsPage(
   children: unknown,
-  options: { wide?: boolean } = {},
+  options: { wide?: boolean; carapace?: boolean } = {},
 ): TemplateResult {
-  const className = options.wide ? "settings-page settings-page--wide" : "settings-page";
+  const className = [
+    "settings-page",
+    options.wide ? "settings-page--wide" : "",
+    options.carapace ? "oc-app-surface" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
   return html`<div class=${className}>${children}</div>`;
 }
 
@@ -115,10 +125,16 @@ export function renderSettingsSection(props: SettingsSectionProps, rows: unknown
   const copy =
     props.title || props.description
       ? html`
-          <div class="settings-section__copy">
+          <div
+            class="settings-section__copy ${props.carapace ? "oc-settings-section-heading" : ""}"
+          >
             ${props.title
               ? html`
-                  <h2 class="settings-section__heading">
+                  <h2
+                    class="settings-section__heading ${props.carapace
+                      ? "oc-settings-section-title"
+                      : ""}"
+                  >
                     ${props.title}${props.count !== undefined
                       ? html` <span class="settings-count">${props.count}</span>`
                       : nothing}
@@ -132,7 +148,9 @@ export function renderSettingsSection(props: SettingsSectionProps, rows: unknown
   const header =
     copy || props.actions
       ? html`
-          <div class="settings-section__header">
+          <div
+            class="settings-section__header ${props.carapace ? "oc-settings-section-header" : ""}"
+          >
             ${copy}
             ${props.actions
               ? html`<div class="settings-section__actions">${props.actions}</div>`
@@ -140,9 +158,15 @@ export function renderSettingsSection(props: SettingsSectionProps, rows: unknown
           </div>
         `
       : nothing;
-  const groupClass = props.danger ? "settings-group settings-group--danger" : "settings-group";
+  const groupClass = [
+    "settings-group",
+    props.danger ? "settings-group--danger" : "",
+    props.carapace ? "oc-settings-group" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
   return html`
-    <section class="settings-section">
+    <section class="settings-section ${props.carapace ? "oc-settings-section" : ""}">
       ${header}
       <div class=${groupClass}>${rows}</div>
     </section>
@@ -150,27 +174,48 @@ export function renderSettingsSection(props: SettingsSectionProps, rows: unknown
 }
 
 /** A bare group surface without a section heading (rare; prefer sections). */
-export function renderSettingsGroup(rows: unknown, options: { danger?: boolean } = {}) {
-  const groupClass = options.danger ? "settings-group settings-group--danger" : "settings-group";
+export function renderSettingsGroup(
+  rows: unknown,
+  options: { danger?: boolean; carapace?: boolean } = {},
+) {
+  const groupClass = [
+    "settings-group",
+    options.danger ? "settings-group--danger" : "",
+    options.carapace ? "oc-settings-group" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
   return html`<div class=${groupClass}>${rows}</div>`;
 }
 
 export function renderSettingsRow(props: SettingsRowProps): TemplateResult {
-  const className = props.stacked
-    ? "settings-row settings-row--stacked"
-    : props.stackedOnNarrow
-      ? "settings-row settings-row--stacked-on-narrow"
-      : "settings-row";
+  const className = [
+    "settings-row",
+    props.stacked ? "settings-row--stacked" : "",
+    props.stackedOnNarrow ? "settings-row--stacked-on-narrow" : "",
+    props.carapace ? `oc-settings-row${props.stacked ? " oc-settings-row-stacked" : ""}` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
   return html`
     <div class=${className}>
-      <div class="settings-row__text">
-        <span class="settings-row__title">${props.title}</span>
+      <div class="settings-row__text ${props.carapace ? "oc-settings-row-content" : ""}">
+        <span class="settings-row__title ${props.carapace ? "oc-settings-row-title" : ""}"
+          >${props.title}</span
+        >
         ${props.description
-          ? html`<span class="settings-row__desc">${props.description}</span>`
+          ? html`<span
+              class="settings-row__desc ${props.carapace ? "oc-settings-row-description" : ""}"
+              >${props.description}</span
+            >`
           : nothing}
       </div>
       ${props.control !== undefined && props.control !== nothing
-        ? html`<div class="settings-row__control">${props.control}</div>`
+        ? html`<div
+            class="settings-row__control ${props.carapace ? "oc-settings-row-control" : ""}"
+          >
+            ${props.control}
+          </div>`
         : nothing}
     </div>
   `;
@@ -302,10 +347,11 @@ export function renderSettingsSegmented<T extends string>(props: {
   disabled?: boolean;
   ariaLabel?: string;
   className?: string;
+  carapace?: boolean;
 }): TemplateResult {
   return html`
     <wa-radio-group
-      class="settings-segmented ${props.className ?? ""}"
+      class="settings-segmented ${props.carapace ? "oc-segmented" : ""} ${props.className ?? ""}"
       size="s"
       orientation="horizontal"
       .value=${live(props.value)}
@@ -327,9 +373,9 @@ export function renderSettingsSegmented<T extends string>(props: {
       ${props.options.map(
         (option) => html`
           <wa-radio
-            class="settings-segmented__btn ${option.value === props.value
-              ? "settings-segmented__btn--active"
-              : ""}"
+            class="settings-segmented__btn ${props.carapace
+              ? "oc-segmented-item"
+              : ""} ${option.value === props.value ? "settings-segmented__btn--active" : ""}"
             appearance="button"
             value=${option.value}
             .checked=${live(option.value === props.value)}
@@ -354,12 +400,27 @@ export function renderSettingsStatus(props: {
   kind: SettingsStatusKind;
   label: unknown;
   dot?: boolean;
+  carapace?: boolean;
 }): TemplateResult {
   const modifier = props.kind === "muted" ? "" : ` settings-status--${props.kind}`;
+  const carapaceKind =
+    props.kind === "ok"
+      ? "oc-status-success"
+      : props.kind === "warn"
+        ? "oc-status-warning"
+        : props.kind === "danger"
+          ? "oc-status-error"
+          : props.kind === "accent"
+            ? "oc-status-info"
+            : "";
   return html`
-    <span class="settings-status${modifier}">
-      ${props.dot === false ? nothing : html`<span class="settings-status__dot"></span>`}
-      ${props.label}
+    <span class="settings-status${modifier} ${props.carapace ? `oc-status ${carapaceKind}` : ""}">
+      ${props.dot === false
+        ? nothing
+        : html`<span
+            class="settings-status__dot ${props.carapace ? "oc-status-indicator" : ""}"
+          ></span>`}
+      <span class=${props.carapace ? "oc-status-label" : ""}>${props.label}</span>
     </span>
   `;
 }
@@ -372,13 +433,20 @@ export function renderSettingsValue(value: unknown, options: { mono?: boolean } 
   return html`<span class=${className}>${value}</span>`;
 }
 
-export function renderSettingsEmpty(message: unknown): TemplateResult {
-  return html`<div class="settings-empty">${message}</div>`;
+export function renderSettingsEmpty(
+  message: unknown,
+  options: { carapace?: boolean } = {},
+): TemplateResult {
+  return options.carapace
+    ? html`<div class="settings-empty oc-empty">
+        <div class="oc-empty-content"><p class="oc-empty-description">${message}</p></div>
+      </div>`
+    : html`<div class="settings-empty">${message}</div>`;
 }
 
 /** Shape-matched placeholder for settings rows whose content has not loaded yet. */
 export function renderSettingsLoadingSkeleton(
-  options: { label?: unknown; rows?: number } = {},
+  options: { label?: unknown; rows?: number; carapace?: boolean } = {},
 ): TemplateResult {
   const rowCount = Math.max(1, options.rows ?? 3);
   return html`
@@ -392,10 +460,22 @@ export function renderSettingsLoadingSkeleton(
         ${Array.from(
           { length: rowCount },
           (_, index) => html`
-            <div class="settings-row settings-loading-skeleton__row">
-              <div class="settings-row__text">
-                <span class="skeleton settings-loading-skeleton__title"></span>
-                <span class="skeleton settings-loading-skeleton__description"></span>
+            <div
+              class="settings-row settings-loading-skeleton__row ${options.carapace
+                ? "oc-settings-row"
+                : ""}"
+            >
+              <div class="settings-row__text ${options.carapace ? "oc-settings-row-content" : ""}">
+                <span
+                  class="skeleton settings-loading-skeleton__title ${options.carapace
+                    ? "oc-skeleton-line oc-skeleton-line-short"
+                    : ""}"
+                ></span>
+                <span
+                  class="skeleton settings-loading-skeleton__description ${options.carapace
+                    ? "oc-skeleton-line"
+                    : ""}"
+                ></span>
               </div>
               <div class="settings-row__control">
                 <span

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -414,7 +414,7 @@ export function renderSettingsStatus(props: {
             ? "oc-status-info"
             : "";
   return html`
-    <span class="settings-status${modifier} ${props.carapace ? `oc-status ${carapaceKind}` : ""}">
+    <span class="settings-status${modifier}${props.carapace ? ` oc-status ${carapaceKind}` : ""}">
       ${props.dot === false
         ? nothing
         : html`<span

--- a/ui/src/e2e/plugins-toolbar-alignment.e2e.test.ts
+++ b/ui/src/e2e/plugins-toolbar-alignment.e2e.test.ts
@@ -1,0 +1,50 @@
+import { expect, it } from "vitest";
+import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI Plugins toolbar alignment",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
+suite.define(() => {
+  it("keeps the Installed toolbar controls on one shared control height", async () => {
+    await suite.withPage({ viewport: { height: 768, width: 1366 } }, async ({ page }) => {
+      await installMockGateway(page, {
+        featureMethods: ["config.get", "plugins.list"],
+        methodResponses: {
+          "config.get": {
+            config: {},
+            sourceConfig: {},
+            hash: "plugins-toolbar-config",
+            issues: [],
+            raw: "{}",
+            valid: true,
+          },
+          "plugins.list": {
+            plugins: [],
+            diagnostics: [],
+            mutationAllowed: true,
+          },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}settings/plugins`);
+      await waitForControlUiRoute(page, { pathname: "/settings/plugins", routeId: "plugins" });
+      const search = await page.locator("#plugins-global-search").boundingBox();
+      const filters = await page.locator(".plugins-toolbar > .settings-segmented").boundingBox();
+      const refresh = await page.locator(".plugins-toolbar > .plugins-refresh").boundingBox();
+
+      if (!search || !filters || !refresh) {
+        throw new Error("Installed plugin toolbar controls did not render");
+      }
+      for (const control of [filters, refresh]) {
+        expect(control.height).toBeCloseTo(search.height, 0);
+        expect(control.y).toBeCloseTo(search.y, 0);
+        expect(control.y + control.height).toBeCloseTo(search.y + search.height, 0);
+      }
+      expect(search.height).toBeCloseTo(32, 0);
+    });
+  });
+});

--- a/ui/src/pages/plugins/consent-dialog.ts
+++ b/ui/src/pages/plugins/consent-dialog.ts
@@ -137,7 +137,7 @@ function renderCapabilityRows(surface: Partial<PluginDeclaredSurface>, widened =
 export function renderPluginDeclaredCapabilities(declared: PluginDeclaredSurface): TemplateResult {
   const rows = renderCapabilityRows(declared);
   return html`
-    <section class="plugins-consent__section">
+    <section class="plugins-consent__section oc-section">
       <h3>${t("pluginConsent.declaredTitle")}</h3>
       <p class="plugins-consent__description">${t("pluginConsent.declaredDescription")}</p>
       ${rows.length > 0
@@ -166,7 +166,7 @@ function renderWidenedCapabilities(details: CapabilityConsentErrorDetails) {
     return nothing;
   }
   return html`
-    <section class="plugins-consent__section">
+    <section class="plugins-consent__section oc-section">
       <h3>${t("pluginConsent.widenedTitle")}</h3>
       <p class="plugins-consent__description">
         ${t("pluginConsent.widenedDescription")}
@@ -217,7 +217,7 @@ function modelOverrideSummary(
 export function renderPluginGrants(grants: PluginOperatorGrants, origin?: string): TemplateResult {
   const conversation = grants.hooks.allowConversationAccess;
   return html`
-    <section class="plugins-consent__section">
+    <section class="plugins-consent__section oc-section">
       <h3>${t("pluginConsent.grantsTitle")}</h3>
       <p class="plugins-consent__description">${t("pluginConsent.grantsDescription")}</p>
       <div class="plugins-consent__rows">
@@ -338,7 +338,7 @@ function renderTrust(trust: PluginsInspectResult["trust"]) {
     trust.disposition === "clean" ? "ok" : trust.disposition === "blocked" ? "danger" : "warn";
   return html`
     <section class="plugins-consent__trust">
-      ${renderSettingsStatus({ kind, label })}
+      ${renderSettingsStatus({ kind, label, carapace: true })}
       ${trust.reasons?.length
         ? html`<ul>
             ${trust.reasons.map((reason) => html`<li>${reason}</li>`)}
@@ -381,7 +381,7 @@ export function renderPluginConsentDialog(props: PluginConsentDialogProps): Temp
   const confirm = html`
     <button
       type="button"
-      class="btn primary"
+      class="btn primary oc-action oc-action-primary"
       ?disabled=${confirmUnavailable && !props.mutationBlockedReason}
       aria-disabled=${!props.canMutate ? "true" : nothing}
       @click=${() => {
@@ -400,7 +400,7 @@ export function renderPluginConsentDialog(props: PluginConsentDialogProps): Temp
       style="--openclaw-modal-width: min(560px, calc(100vw - 32px));"
       @modal-cancel=${props.onCancel}
     >
-      <section class="plugins-consent" data-plugin-consent=${consent.intent.kind}>
+      <section class="plugins-consent oc-card" data-plugin-consent=${consent.intent.kind}>
         <header class="plugins-consent__header">
           ${renderArtTile(slug, name, props.iconUrl)}
           <div>
@@ -416,7 +416,11 @@ export function renderPluginConsentDialog(props: PluginConsentDialogProps): Temp
           : props.error
             ? html`<div class="plugins-consent__error" role="alert">
                 <span>${props.error}</span>
-                <button type="button" class="btn btn--sm" @click=${props.onRetry}>
+                <button
+                  type="button"
+                  class="btn btn--sm oc-action oc-action-secondary"
+                  @click=${props.onRetry}
+                >
                   ${t("pluginsPage.tryAgain")}
                 </button>
               </div>`
@@ -429,7 +433,7 @@ export function renderPluginConsentDialog(props: PluginConsentDialogProps): Temp
                 `
               : html`<p class="plugins-consent__description">${t("pluginConsent.fallback")}</p>`}
         <footer class="plugins-consent__actions">
-          <button type="button" class="btn" @click=${props.onCancel}>
+          <button type="button" class="btn oc-action oc-action-secondary" @click=${props.onCancel}>
             ${t("pluginsPage.cancel")}
           </button>
           ${renderReasonedDisabledControl(props.mutationBlockedReason, confirm)}

--- a/ui/src/pages/plugins/view.ts
+++ b/ui/src/pages/plugins/view.ts
@@ -1346,12 +1346,6 @@ export function renderPlugins(props: PluginsViewProps) {
         </button>
       </div>
 
-      ${props.mutationBlockedReason
-        ? html`<div class="plugins-readonly oc-banner oc-banner-warning" role="note">
-            <span aria-hidden="true">${icons.alertTriangle}</span>
-            <span>${props.mutationBlockedReason}</span>
-          </div>`
-        : nothing}
       ${props.error
         ? html`<div class="plugins-page-error oc-banner oc-banner-error" role="alert">
             <span>${props.error}</span>

--- a/ui/src/pages/plugins/view.ts
+++ b/ui/src/pages/plugins/view.ts
@@ -1318,7 +1318,7 @@ export function renderPlugins(props: PluginsViewProps) {
           : "content";
   return renderSettingsPage(
     html`
-      <div class="plugins-toolbar">
+      <div class="plugins-toolbar plugins-toolbar--plugin-catalog">
         <input
           id="plugins-global-search"
           class="settings-input plugins-toolbar__search oc-input"

--- a/ui/src/pages/plugins/view.ts
+++ b/ui/src/pages/plugins/view.ts
@@ -346,7 +346,7 @@ function stateLabel(plugin: PluginCatalogItem): string {
 
 function stateStatus(plugin: PluginCatalogItem) {
   const kind = plugin.state === "enabled" ? "ok" : plugin.state === "error" ? "danger" : "muted";
-  return renderSettingsStatus({ kind, label: stateLabel(plugin) });
+  return renderSettingsStatus({ kind, label: stateLabel(plugin), carapace: true });
 }
 
 /** Rows pair the status with an Enable/Disable button that already implies the
@@ -371,7 +371,7 @@ function renderMetaLine(parts: ReadonlyArray<TemplateResult | string | typeof no
   if (visible.length === 0) {
     return nothing;
   }
-  return html`<span class="settings-row__desc plugins-meta">
+  return html`<span class="settings-row__desc oc-settings-row-description plugins-meta">
     ${visible.map(
       (part, index) =>
         html`${index > 0 ? html`<span aria-hidden="true"> · </span>` : nothing}${part}`,
@@ -403,7 +403,7 @@ function renderRowMessage(
         : t("pluginsPage.policyReviewBodyKnown", { count: String(findings.length) });
     return html`
       <div
-        class="plugins-row-message plugins-row-message--warning plugins-policy-review"
+        class="plugins-row-message plugins-row-message--warning plugins-policy-review oc-banner oc-banner-warning"
         role="alert"
       >
         <div class="plugins-policy-review__header">
@@ -477,7 +477,7 @@ function renderRowMessage(
         <div class="plugins-policy-review__actions">
           <button
             type="button"
-            class="btn btn--sm"
+            class="btn btn--sm oc-action oc-action-secondary"
             ?disabled=${busy}
             @click=${() => props.onDismissMessage(messageKey)}
           >
@@ -485,7 +485,7 @@ function renderRowMessage(
           </button>
           ${renderMutationButton(props, {
             busy,
-            className: "btn btn--sm danger",
+            className: "btn btn--sm danger oc-action oc-action-secondary",
             label: busy ? t("pluginsPage.installing") : t("pluginsPage.installAnyway"),
             onClick: () =>
               requestInstall(
@@ -503,7 +503,15 @@ function renderRowMessage(
   }
   const role = resolvedMessage.kind === "error" ? "alert" : "status";
   return html`
-    <div class="plugins-row-message plugins-row-message--${resolvedMessage.kind}" role=${role}>
+    <div
+      class="plugins-row-message plugins-row-message--${resolvedMessage.kind} oc-banner ${resolvedMessage.kind ===
+      "error"
+        ? "oc-banner-error"
+        : resolvedMessage.kind === "warning"
+          ? "oc-banner-warning"
+          : "oc-banner-success"}"
+      role=${role}
+    >
       <span>${resolvedMessage.text}</span>
     </div>
   `;
@@ -587,7 +595,7 @@ function renderRemoveButton(
   const label = t("pluginsPage.removeNamed", { name });
   return renderMutationButton(props, {
     busy,
-    className: "btn btn--sm btn--icon plugins-remove",
+    className: "btn btn--sm btn--icon plugins-remove oc-action oc-action-icon oc-action-ghost",
     label: icons.trash,
     onClick: onRemove,
     ariaLabel: label,
@@ -609,7 +617,7 @@ function renderInstallButton(
   }
   return renderMutationButton(props, {
     busy,
-    className: "btn btn--sm plugins-install",
+    className: "btn btn--sm plugins-install oc-action oc-action-primary",
     label: busy ? t("pluginsPage.installing") : t("pluginsPage.install"),
     onClick: () => props.onInstall(request, installIdentity),
     ariaLabel: t("pluginsPage.installNamed", { name }),
@@ -667,6 +675,7 @@ function renderInstalledFilter(props: PluginsViewProps) {
       label: html`${filterLabel(filter)} <span class="settings-count">${counts[filter]}</span>`,
     })),
     onChange: (value) => props.onFilterChange(value),
+    carapace: true,
   });
 }
 
@@ -676,7 +685,7 @@ function renderPluginHeading(params: {
   onShowDetails?: () => void;
 }): TemplateResult {
   return html`
-    <h3 class="settings-row__title">
+    <h3 class="settings-row__title oc-settings-row-title">
       ${params.onShowDetails
         ? html`
             <button
@@ -708,7 +717,7 @@ function renderPluginRow(
   const busy = props.busy[key] || installOperationBusy(props, installIdentity);
   return html`
     <article
-      class="settings-row plugins-item plugins-item--clickable"
+      class="settings-row plugins-item plugins-item--clickable oc-settings-row"
       data-plugin-id=${plugin.id}
       data-plugin-source=${plugin.origin ?? "unknown"}
       data-plugin-status=${plugin.state}
@@ -722,7 +731,7 @@ function renderPluginRow(
       ${renderArtTile(plugin.id, plugin.name, props.iconUrls[plugin.id], () =>
         props.onIconError(plugin.id),
       )}
-      <div class="settings-row__text">
+      <div class="settings-row__text oc-settings-row-content">
         ${renderPluginHeading({
           name: plugin.name,
           content: html`
@@ -735,7 +744,7 @@ function renderPluginRow(
           `,
           onShowDetails: () => props.onShowDetails(plugin.id),
         })}
-        <span class="settings-row__desc">
+        <span class="settings-row__desc oc-settings-row-description">
           ${plugin.description || t("pluginsPage.optionalCapability")}
         </span>
         ${renderMetaLine([
@@ -745,12 +754,15 @@ function renderPluginRow(
             : nothing,
         ])}
       </div>
-      <div class="settings-row__control">
+      <div class="settings-row__control oc-settings-row-control">
         ${plugin.installed ? rowStateStatus(plugin) : nothing}
         ${renderCatalogActions(plugin, props, busy, key)}
       </div>
       ${plugin.error
-        ? html`<div class="plugins-row-message plugins-row-message--error" role="alert">
+        ? html`<div
+            class="plugins-row-message plugins-row-message--error oc-banner oc-banner-error"
+            role="alert"
+          >
             ${formatUiExternalText(plugin.error)}
           </div>`
         : nothing}
@@ -771,9 +783,9 @@ function renderMcpSection(props: PluginsViewProps) {
     return nothing;
   }
   const body = !servers
-    ? renderSettingsLoadingSkeleton({ label: t("pluginsPage.loading"), rows: 2 })
+    ? renderSettingsLoadingSkeleton({ label: t("pluginsPage.loading"), rows: 2, carapace: true })
     : servers.length === 0
-      ? renderSettingsEmpty(t("pluginsPage.mcpEmpty"))
+      ? renderSettingsEmpty(t("pluginsPage.mcpEmpty"), { carapace: true })
       : repeat(
           servers,
           (server) => server.name,
@@ -790,11 +802,12 @@ function renderMcpSection(props: PluginsViewProps) {
         >
         ${renderMutationButton(props, {
           busy: props.mcpBusy,
-          className: "btn btn--sm",
+          className: "btn btn--sm oc-action oc-action-secondary",
           label: html`<span aria-hidden="true">${icons.plus}</span> ${t("mcpServers.add")}`,
           onClick: () => props.onMcpFormToggle(!props.mcpFormOpen),
         })}
       `,
+      carapace: true,
     },
     html`
       ${props.mcpFormOpen
@@ -802,6 +815,7 @@ function renderMcpSection(props: PluginsViewProps) {
             busy: props.mcpBusy,
             disabled: !props.canMutate,
             blockedReason: props.mutationBlockedReason,
+            carapace: true,
             onSubmit: props.onMcpAdd,
             onCancel: () => props.onMcpFormToggle(false),
           })
@@ -822,11 +836,11 @@ function renderMcpSection(props: PluginsViewProps) {
 
 function renderMcpRow(server: McpServerSummary, props: PluginsViewProps): TemplateResult {
   return html`
-    <article class="settings-row plugins-item" data-mcp-name=${server.name}>
+    <article class="settings-row plugins-item oc-settings-row" data-mcp-name=${server.name}>
       ${renderArtTile(server.name, server.name)}
-      <div class="settings-row__text">
-        <h3 class="settings-row__title">${server.name}</h3>
-        <span class="settings-row__desc plugins-meta__mono">
+      <div class="settings-row__text oc-settings-row-content">
+        <h3 class="settings-row__title oc-settings-row-title">${server.name}</h3>
+        <span class="settings-row__desc oc-settings-row-description plugins-meta__mono">
           ${server.target || t("mcpServers.missingTransport")}
         </span>
         ${renderMetaLine([
@@ -835,7 +849,7 @@ function renderMcpRow(server: McpServerSummary, props: PluginsViewProps): Templa
           server.auth === "oauth" ? t("pluginsPage.oauth") : nothing,
         ])}
       </div>
-      <div class="settings-row__control">
+      <div class="settings-row__control oc-settings-row-control">
         ${renderToggleButton(props, props.mcpBusy, {
           enabled: server.enabled,
           onToggle: (enabled) => props.onMcpToggle(server.name, enabled),
@@ -861,7 +875,7 @@ function renderInstalled(props: PluginsViewProps) {
         )
       : groups.map((group) =>
           renderSettingsSection(
-            { title: group.label, count: group.plugins.length },
+            { title: group.label, count: group.plugins.length, carapace: true },
             repeat(
               group.plugins,
               (plugin) => plugin.id,
@@ -892,34 +906,40 @@ function renderConnectorRow(
     );
   return html`
     <article
-      class="settings-row plugins-item"
+      class="settings-row plugins-item oc-settings-row"
       data-connector-id=${connector.id}
       aria-busy=${busy ? "true" : "false"}
     >
       ${renderArtTile(connector.id, connector.name)}
-      <div class="settings-row__text">
-        <h3 class="settings-row__title">${connector.name}</h3>
-        <span class="settings-row__desc">${t(connector.descriptionKey)}</span>
+      <div class="settings-row__text oc-settings-row-content">
+        <h3 class="settings-row__title oc-settings-row-title">${connector.name}</h3>
+        <span class="settings-row__desc oc-settings-row-description"
+          >${t(connector.descriptionKey)}</span
+        >
         ${renderMetaLine(
           isMcp
             ? [t("pluginsPage.mcp"), t("pluginsPage.connectorMcpNote")]
             : [t("pluginsPage.connectorClawHubNote")],
         )}
       </div>
-      <div class="settings-row__control">
+      <div class="settings-row__control oc-settings-row-control">
         ${isMcp
           ? installed
-            ? renderSettingsStatus({ kind: "ok", label: t("pluginsPage.connectorAdded") })
+            ? renderSettingsStatus({
+                kind: "ok",
+                label: t("pluginsPage.connectorAdded"),
+                carapace: true,
+              })
             : renderMutationButton(props, {
                 busy,
-                className: "btn btn--sm",
+                className: "btn btn--sm oc-action oc-action-secondary",
                 label: busy ? t("mcpServers.adding") : t("pluginsPage.connectorAdd"),
                 onClick: () => props.onAddConnector(connector),
               })
           : html`
               <button
                 type="button"
-                class="btn btn--sm"
+                class="btn btn--sm oc-action oc-action-secondary"
                 @click=${() =>
                   connector.action.kind === "clawhub" &&
                   props.onSearchClawHub(connector.action.query)}
@@ -938,7 +958,7 @@ function renderShelf(label: string, rows: readonly TemplateResult[]) {
   if (rows.length === 0) {
     return nothing;
   }
-  return renderSettingsSection({ title: label, count: rows.length }, rows);
+  return renderSettingsSection({ title: label, count: rows.length, carapace: true }, rows);
 }
 
 function findInstalledSearchPlugin(
@@ -964,7 +984,9 @@ function renderClawHubResult(item: PluginSearchResult, props: PluginsViewProps):
   const artSlug = pkg.runtimeId ?? pkg.name;
   return html`
     <article
-      class="settings-row plugins-item ${installed ? "plugins-item--clickable" : ""}"
+      class="settings-row plugins-item oc-settings-row ${installed
+        ? "plugins-item--clickable"
+        : ""}"
       data-package-name=${pkg.name}
       data-plugin-source="clawhub"
       data-plugin-status=${installed?.state ?? "not-installed"}
@@ -976,7 +998,7 @@ function renderClawHubResult(item: PluginSearchResult, props: PluginsViewProps):
       }}
     >
       ${renderArtTile(artSlug, pkg.displayName)}
-      <div class="settings-row__text">
+      <div class="settings-row__text oc-settings-row-content">
         ${renderPluginHeading({
           name: pkg.displayName,
           content: html`
@@ -987,7 +1009,9 @@ function renderClawHubResult(item: PluginSearchResult, props: PluginsViewProps):
           `,
           onShowDetails: installed ? () => props.onShowDetails(installed.id) : undefined,
         })}
-        <span class="settings-row__desc">${pkg.summary || pkg.name}</span>
+        <span class="settings-row__desc oc-settings-row-description"
+          >${pkg.summary || pkg.name}</span
+        >
         ${renderMetaLine([
           pkg.isOfficial ? t("pluginsPage.official") : nothing,
           pkg.verificationTier ? pluginVerificationLabel(pkg.verificationTier) : nothing,
@@ -1002,7 +1026,7 @@ function renderClawHubResult(item: PluginSearchResult, props: PluginsViewProps):
             : t("pluginsPage.codePlugin"),
         ])}
       </div>
-      <div class="settings-row__control">
+      <div class="settings-row__control oc-settings-row-control">
         ${installed
           ? html`${rowStateStatus(installed)}${renderCatalogActions(installed, props, busy, key)}`
           : renderInstallButton(props, busy, pkg.displayName, installRequest, installIdentity)}
@@ -1020,15 +1044,20 @@ function renderClawHubGroup(props: PluginsViewProps) {
   }
   let body: TemplateResult;
   if (props.searchLoading || (!props.searchResults && !props.searchError)) {
-    body = html`<div class="plugins-search-state" role="status">
+    body = html`<div class="plugins-search-state oc-loader" role="status">
       ${t("pluginsPage.searching")}
     </div>`;
   } else if (props.searchError) {
-    body = html`<div class="plugins-search-state plugins-search-state--error" role="alert">
+    body = html`<div
+      class="plugins-search-state plugins-search-state--error oc-banner oc-banner-error"
+      role="alert"
+    >
       ${props.searchError}
     </div>`;
   } else if (props.searchResults && props.searchResults.length === 0) {
-    body = html`${renderSettingsEmpty(t("pluginsPage.noClawHubResultsBody", { query }))}`;
+    body = html`${renderSettingsEmpty(t("pluginsPage.noClawHubResultsBody", { query }), {
+      carapace: true,
+    })}`;
   } else {
     body = html`
       ${repeat(
@@ -1053,6 +1082,7 @@ function renderClawHubGroup(props: PluginsViewProps) {
           <span class="plugins-group__link-icon" aria-hidden="true">${icons.externalLink}</span>
         </a>
       `,
+      carapace: true,
     },
     body,
   );
@@ -1099,6 +1129,7 @@ function renderConnectorSection(
       title: t("pluginsPage.connectorsGroup"),
       count: connectors.length,
       description: t("pluginsPage.connectorsHint"),
+      carapace: true,
     },
     groups.map(
       (entry) => html`
@@ -1131,10 +1162,10 @@ function renderDetailOverlay(props: PluginsViewProps) {
       style="--openclaw-modal-width: min(580px, calc(100vw - 32px));"
       @modal-cancel=${() => props.onShowDetails(null)}
     >
-      <section class="plugins-detail" data-detail-plugin-id=${plugin.id}>
+      <section class="plugins-detail oc-card" data-detail-plugin-id=${plugin.id}>
         <button
           type="button"
-          class="btn btn--sm btn--icon plugins-detail__close"
+          class="btn btn--sm btn--icon plugins-detail__close oc-action oc-action-icon oc-action-ghost"
           aria-label=${t("pluginsPage.detailClose")}
           @click=${() => props.onShowDetails(null)}
         >
@@ -1163,7 +1194,7 @@ function renderDetailOverlay(props: PluginsViewProps) {
               ? renderToggleButton(props, busy, {
                   enabled: plugin.enabled,
                   onToggle: (enabled) => props.onSetEnabled(plugin.id, enabled, key),
-                  className: `btn ${plugin.enabled ? "" : "primary"}`,
+                  className: `btn oc-action ${plugin.enabled ? "oc-action-secondary" : "primary oc-action-primary"}`,
                 })
               : plugin.install
                 ? renderInstallButton(
@@ -1177,7 +1208,7 @@ function renderDetailOverlay(props: PluginsViewProps) {
             ${plugin.removable
               ? renderMutationButton(props, {
                   busy,
-                  className: "btn plugins-detail__remove",
+                  className: "btn plugins-detail__remove oc-action oc-action-secondary",
                   label: html`<span aria-hidden="true">${icons.trash}</span> ${t(
                       "pluginsPage.remove",
                     )}`,
@@ -1186,7 +1217,10 @@ function renderDetailOverlay(props: PluginsViewProps) {
               : nothing}
           </div>
           ${plugin.error
-            ? html`<div class="plugins-row-message plugins-row-message--error" role="alert">
+            ? html`<div
+                class="plugins-row-message plugins-row-message--error oc-banner oc-banner-error"
+                role="alert"
+              >
                 ${formatUiExternalText(plugin.error)}
               </div>`
             : nothing}
@@ -1217,7 +1251,7 @@ function renderDetailOverlay(props: PluginsViewProps) {
                       <span>${props.detailInspectionError}</span>
                       <button
                         type="button"
-                        class="btn btn--sm"
+                        class="btn btn--sm oc-action oc-action-secondary"
                         @click=${() => props.onShowDetails(plugin.id)}
                       >
                         ${t("pluginsPage.tryAgain")}
@@ -1244,7 +1278,7 @@ function renderDetailOverlay(props: PluginsViewProps) {
 
 function renderEmpty(title: string, body: string, mood?: "sleepy" | "curious") {
   return html`
-    <div class="plugins-empty">
+    <div class="plugins-empty oc-empty">
       <!-- Sleepy marks truly empty inventory; curious marks a filter/search miss. -->
       ${mood
         ? html`<openclaw-mascot
@@ -1253,8 +1287,10 @@ function renderEmpty(title: string, body: string, mood?: "sleepy" | "curious") {
             .size=${84}
           ></openclaw-mascot>`
         : html`<span class="plugins-empty__icon" aria-hidden="true">${icons.puzzle}</span>`}
-      <h2>${title}</h2>
-      <p>${body}</p>
+      <div class="oc-empty-content">
+        <h2 class="oc-empty-title">${title}</h2>
+        <p class="oc-empty-description">${body}</p>
+      </div>
     </div>
   `;
 }
@@ -1285,7 +1321,7 @@ export function renderPlugins(props: PluginsViewProps) {
       <div class="plugins-toolbar">
         <input
           id="plugins-global-search"
-          class="settings-input plugins-toolbar__search"
+          class="settings-input plugins-toolbar__search oc-input"
           name="plugins-search"
           type="search"
           autocomplete="off"
@@ -1300,7 +1336,7 @@ export function renderPlugins(props: PluginsViewProps) {
           : nothing}
         <button
           type="button"
-          class="btn btn--sm btn--icon plugins-refresh"
+          class="btn btn--sm btn--icon plugins-refresh oc-action oc-action-icon oc-action-ghost"
           aria-label=${t("pluginsPage.refresh")}
           title=${t("pluginsPage.refresh")}
           ?disabled=${props.loading || !props.connected}
@@ -1310,10 +1346,20 @@ export function renderPlugins(props: PluginsViewProps) {
         </button>
       </div>
 
+      ${props.mutationBlockedReason
+        ? html`<div class="plugins-readonly oc-banner oc-banner-warning" role="note">
+            <span aria-hidden="true">${icons.alertTriangle}</span>
+            <span>${props.mutationBlockedReason}</span>
+          </div>`
+        : nothing}
       ${props.error
-        ? html`<div class="plugins-page-error" role="alert">
+        ? html`<div class="plugins-page-error oc-banner oc-banner-error" role="alert">
             <span>${props.error}</span>
-            <button type="button" class="btn btn--sm" @click=${props.onRefresh}>
+            <button
+              type="button"
+              class="btn btn--sm oc-action oc-action-secondary"
+              @click=${props.onRefresh}
+            >
               ${t("pluginsPage.tryAgain")}
             </button>
           </div>`
@@ -1336,7 +1382,10 @@ export function renderPlugins(props: PluginsViewProps) {
         aria-labelledby=${`plugins-tab-${props.activeTab}`}
       >
         ${panelState === "loading"
-          ? renderSettingsGroup(renderSettingsLoadingSkeleton({ label: t("pluginsPage.loading") }))
+          ? renderSettingsGroup(
+              renderSettingsLoadingSkeleton({ label: t("pluginsPage.loading"), carapace: true }),
+              { carapace: true },
+            )
           : panelState === "error"
             ? nothing
             : panelState === "offline"
@@ -1366,7 +1415,7 @@ export function renderPlugins(props: PluginsViewProps) {
           })
         : nothing}
     `,
-    { wide: true },
+    { wide: true, carapace: true },
   );
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/skill-workshop/empty-states.ts
+++ b/ui/src/pages/skill-workshop/empty-states.ts
@@ -11,13 +11,13 @@ type SkillWorkshopEmptyIcon = "search" | "clock" | "check" | "x" | "shield" | "r
 export function renderBoardEmptyDetail(query: string, statusFilter: SkillWorkshopStatusFilter) {
   const empty = resolveBoardEmptyState(query, statusFilter);
   return html`
-    <div class="sw-detail sw-detail--empty">
-      <div class="sw-filter-empty">
+    <div class="sw-detail sw-detail--empty oc-empty">
+      <div class="sw-filter-empty oc-empty-content">
         <div class="sw-filter-empty__icon" aria-hidden="true">
           ${renderEmptyStateIcon(empty.icon)}
         </div>
-        <p class="sw-empty__title">${empty.title}</p>
-        <p class="sw-empty__sub">${empty.body}</p>
+        <p class="sw-empty__title oc-empty-title">${empty.title}</p>
+        <p class="sw-empty__sub oc-empty-description">${empty.body}</p>
       </div>
     </div>
   `;
@@ -104,7 +104,10 @@ export function renderWorkshopEmptyState(params: {
 }) {
   return html`
     <div class="sw-empty-state">
-      <section class="sw-empty-state__panel" aria-label=${t("skillWorkshop.empty.noProposalsAria")}>
+      <section
+        class="sw-empty-state__panel oc-card"
+        aria-label=${t("skillWorkshop.empty.noProposalsAria")}
+      >
         <div class="sw-empty-state__glyph" aria-hidden="true">
           <span></span>
           <span></span>

--- a/ui/src/pages/skill-workshop/header-controls.ts
+++ b/ui/src/pages/skill-workshop/header-controls.ts
@@ -96,6 +96,7 @@ export function renderSkillWorkshopHeaderControls(
         ariaLabel: t("skillWorkshop.header.view"),
         panelId: "skill-workshop-mode-panel",
         variant: "sub",
+        carapace: true,
         onSelect: (mode) => setSkillWorkshopMode(state, mode, requestUpdate),
       })}
     </div>

--- a/ui/src/pages/skill-workshop/history-scan.ts
+++ b/ui/src/pages/skill-workshop/history-scan.ts
@@ -194,7 +194,7 @@ export function renderSkillWorkshopHistoryScan(params: {
   const result = params.state.result;
   const coverage = result ? formatCoverage(result) : null;
   return html`
-    <section class="sw-history ${result?.hasScanned ? "is-compact" : ""}">
+    <section class="sw-history oc-card ${result?.hasScanned ? "is-compact" : ""}">
       <div class="sw-history__signal" aria-hidden="true">
         <span></span><span></span><span></span><span></span>
       </div>
@@ -230,7 +230,7 @@ export function renderSkillWorkshopHistoryScan(params: {
       </div>
       <div class="sw-history__action">
         <button
-          class="sw-btn sw-btn--primary"
+          class="sw-btn sw-btn--primary oc-action oc-action-primary"
           ?disabled=${!params.canScan || params.state.running || params.state.loading}
           @click=${params.onScan}
         >

--- a/ui/src/pages/skill-workshop/proposal-list.ts
+++ b/ui/src/pages/skill-workshop/proposal-list.ts
@@ -19,6 +19,7 @@ export function renderSkillWorkshopProposalList(
     <aside class="sw-queue">
       <div class="sw-queue__search">
         <input
+          class="oc-input"
           placeholder=${t("skillWorkshop.queue.search")}
           .value=${props.query}
           @input=${(event: Event) =>
@@ -68,7 +69,9 @@ function renderProposalRow(
       : "skillWorkshop.applied.revisions";
   return html`
     <button
-      class="sw-row ${latest.isNew ? "is-new" : "is-seen"} ${isSelected ? "is-selected" : ""}"
+      class="sw-row ${latest.isNew ? "is-new" : "is-seen"} ${isSelected
+        ? "is-selected"
+        : ""} oc-card-interactive"
       @click=${() => props.onSelect(latest.key)}
     >
       <span class="sw-row__dot"></span>

--- a/ui/src/pages/skill-workshop/self-learning.ts
+++ b/ui/src/pages/skill-workshop/self-learning.ts
@@ -113,7 +113,9 @@ export function renderSelfLearningPitch(
       <p>${t("skillWorkshop.selfLearning.pitchBody")}</p>
       <button
         type="button"
-        class="sw-btn sw-btn--primary ${selfLearning.busy ? "is-busy" : ""}"
+        class="sw-btn sw-btn--primary oc-action oc-action-primary ${selfLearning.busy
+          ? "is-busy"
+          : ""}"
         ?disabled=${selfLearning.busy || !selfLearning.canUpdate}
         @click=${() => onToggle(true)}
       >
@@ -129,5 +131,7 @@ export function renderSelfLearningError(selfLearning: SkillWorkshopSelfLearning 
   if (!selfLearning?.error) {
     return nothing;
   }
-  return html`<div class="sw-error" role="status"><span>${selfLearning.error}</span></div>`;
+  return html`<div class="sw-error oc-banner oc-banner-error" role="status">
+    <span>${selfLearning.error}</span>
+  </div>`;
 }

--- a/ui/src/pages/skill-workshop/view.ts
+++ b/ui/src/pages/skill-workshop/view.ts
@@ -106,11 +106,15 @@ export function renderSkillWorkshop(props: SkillWorkshopProps) {
         );
 
   return html`
-    <section class="skill-workshop sw-mode-${props.mode}">
+    <section class="skill-workshop sw-mode-${props.mode} oc-app-surface">
       ${props.error
-        ? html`<div class="sw-error" role="status">
+        ? html`<div class="sw-error oc-banner oc-banner-error" role="status">
             <span>${props.error}</span>
-            <button type="button" class="btn btn--sm" @click=${props.onRetry}>
+            <button
+              type="button"
+              class="btn btn--sm oc-action oc-action-secondary"
+              @click=${props.onRetry}
+            >
               ${t("pluginsPage.tryAgain")}
             </button>
           </div>`
@@ -159,7 +163,7 @@ function renderRevisionDialog(props: SkillWorkshopProps, proposal: SkillWorkshop
       style="--openclaw-modal-width: 560px"
       @modal-cancel=${cancelDisabled ? undefined : props.onRevisionCancel}
     >
-      <section class="sw-revision-dialog ${busy ? "sw-revision-dialog--sending" : ""}">
+      <section class="sw-revision-dialog oc-card ${busy ? "sw-revision-dialog--sending" : ""}">
         <div class="sw-revision-dialog__head">
           <div>
             <div class="sw-revision-dialog__eyebrow">
@@ -170,7 +174,7 @@ function renderRevisionDialog(props: SkillWorkshopProps, proposal: SkillWorkshop
           <openclaw-tooltip content=${t("skillWorkshop.actions.close")}>
             <button
               type="button"
-              class="sw-revision-dialog__close"
+              class="sw-revision-dialog__close oc-action oc-action-icon oc-action-ghost"
               aria-label=${t("skillWorkshop.actions.close")}
               ?disabled=${cancelDisabled}
               @click=${props.onRevisionCancel}
@@ -181,7 +185,7 @@ function renderRevisionDialog(props: SkillWorkshopProps, proposal: SkillWorkshop
         </div>
         <p class="sw-revision-dialog__copy">${t("skillWorkshop.revision.description")}</p>
         <textarea
-          class="sw-revision-dialog__input"
+          class="sw-revision-dialog__input oc-textarea"
           autofocus
           placeholder=${t("skillWorkshop.revision.placeholder")}
           .value=${props.revisionDraft}
@@ -202,7 +206,7 @@ function renderRevisionDialog(props: SkillWorkshopProps, proposal: SkillWorkshop
         <div class="sw-revision-dialog__actions">
           <button
             type="button"
-            class="sw-btn sw-btn--ghost"
+            class="sw-btn sw-btn--ghost oc-action oc-action-ghost"
             ?disabled=${cancelDisabled}
             @click=${props.onRevisionCancel}
           >
@@ -210,7 +214,7 @@ function renderRevisionDialog(props: SkillWorkshopProps, proposal: SkillWorkshop
           </button>
           <button
             type="button"
-            class="sw-btn sw-btn--primary ${busy ? "is-busy" : ""}"
+            class="sw-btn sw-btn--primary oc-action oc-action-primary ${busy ? "is-busy" : ""}"
             ?disabled=${!canSubmit}
             @click=${() => props.onRevisionSubmit(proposal.key)}
           >
@@ -231,7 +235,10 @@ function renderBoard(
 ) {
   return html`
     ${renderLifecycleTabs(props)}
-    <div class="sw-triage" style=${styleMap({ "--sw-queue-width": `${props.queueWidth}px` })}>
+    <div
+      class="sw-triage oc-card"
+      style=${styleMap({ "--sw-queue-width": `${props.queueWidth}px` })}
+    >
       ${renderSkillWorkshopProposalList(
         props,
         groups,
@@ -270,13 +277,13 @@ function renderQueueResizer(props: SkillWorkshopProps) {
 
 function renderLifecycleTabs(props: SkillWorkshopProps) {
   return html`
-    <div class="sw-lifecycle-tabs">
+    <div class="sw-lifecycle-tabs oc-segmented">
       ${STATUS_TABS.map((status) => {
         const isActive = props.statusFilter === status;
         const count = props.counts[status] ?? 0;
         return html`
           <button
-            class="sw-lifecycle-tab ${isActive ? "is-active" : ""}"
+            class="sw-lifecycle-tab oc-segmented-item ${isActive ? "is-active" : ""}"
             @click=${() => props.onStatusFilterChange(status)}
           >
             ${t(STATUS_LABEL[status])} <span class="settings-count">${count}</span>
@@ -295,7 +302,7 @@ function renderBodyModeButton(
   const active = props.appliedDiffMode === mode;
   return html`
     <button
-      class="sw-body-mode__button ${active ? "is-active" : ""}"
+      class="sw-body-mode__button oc-segmented-item ${active ? "is-active" : ""}"
       aria-pressed=${active ? "true" : "false"}
       @click=${() => props.onAppliedDiffModeChange(mode)}
     >
@@ -306,7 +313,11 @@ function renderBodyModeButton(
 
 function renderBodyModeToggle(props: SkillWorkshopProps) {
   return html`
-    <div class="sw-body-mode" role="group" aria-label=${t("skillWorkshop.diff.viewLabel")}>
+    <div
+      class="sw-body-mode oc-segmented"
+      role="group"
+      aria-label=${t("skillWorkshop.diff.viewLabel")}
+    >
       ${renderBodyModeButton(props, "changes", t("skillWorkshop.diff.changes"))}
       ${renderBodyModeButton(props, "full", t("skillWorkshop.diff.fullBody"))}
     </div>
@@ -387,7 +398,7 @@ function renderDetail(
       </div>
 
       <div class="sw-detail__body">
-        <div class="sw-body-card">
+        <div class="sw-body-card oc-card">
           <div class="sw-body-card__head">
             <h1>${proposal.slug}</h1>
             ${previousRevision ? renderBodyModeToggle(props) : nothing}
@@ -435,7 +446,7 @@ function renderDetail(
 
 function renderActionNotice(notice: SkillWorkshopActionNotice) {
   return html`
-    <div class="sw-action-toast" role="status" aria-live="polite">
+    <div class="sw-action-toast oc-banner" role="status" aria-live="polite">
       <span>${notice.label}</span>
       <strong>${notice.slug}</strong>
       <span>·</span>
@@ -456,7 +467,7 @@ function renderPendingActions(props: SkillWorkshopProps, proposal: SkillWorkshop
   return html`
     <div class="sw-action-bar" aria-busy=${busy ? "true" : "false"}>
       <button
-        class="sw-btn ${busy === "evaluate" ? "is-busy" : ""}"
+        class="sw-btn oc-action oc-action-secondary ${busy === "evaluate" ? "is-busy" : ""}"
         ?disabled=${disabled || !props.access.canEvaluate}
         @click=${() => props.onEvaluate(proposal.key)}
       >
@@ -465,14 +476,16 @@ function renderPendingActions(props: SkillWorkshopProps, proposal: SkillWorkshop
           : t("skillWorkshop.actions.evaluate")}
       </button>
       <button
-        class="sw-btn sw-btn--primary ${busy === "apply" ? "is-busy" : ""}"
+        class="sw-btn sw-btn--primary oc-action oc-action-primary ${busy === "apply"
+          ? "is-busy"
+          : ""}"
         ?disabled=${disabled || !props.access.canApply}
         @click=${() => props.onApply(proposalDecision(proposal))}
       >
         ${busy === "apply" ? t("skillWorkshop.actions.applying") : t("skillWorkshop.actions.apply")}
       </button>
       <button
-        class="sw-btn ${busy === "revise" ? "is-busy" : ""}"
+        class="sw-btn oc-action oc-action-secondary ${busy === "revise" ? "is-busy" : ""}"
         ?disabled=${disabled || !props.access.canRevise}
         @click=${() => props.onRevise(proposal.key)}
       >
@@ -481,7 +494,9 @@ function renderPendingActions(props: SkillWorkshopProps, proposal: SkillWorkshop
           : t("skillWorkshop.actions.revise")}
       </button>
       <button
-        class="sw-btn sw-btn--ghost sw-btn--danger ${busy === "reject" ? "is-busy" : ""}"
+        class="sw-btn sw-btn--ghost sw-btn--danger oc-action oc-action-ghost ${busy === "reject"
+          ? "is-busy"
+          : ""}"
         ?disabled=${disabled || !props.access.canReject}
         @click=${() => props.onReject(proposalDecision(proposal))}
       >
@@ -504,7 +519,7 @@ function renderToday(
 ) {
   if (!hero) {
     return html`
-      <div class="sw-today sw-today--empty">
+      <div class="sw-today sw-today--empty oc-empty">
         <p class="sw-empty__title">${t("skillWorkshop.today.emptyTitle")}</p>
         <p class="sw-empty__sub">${t("skillWorkshop.today.emptyBody")}</p>
       </div>
@@ -568,7 +583,7 @@ function renderToday(
           : nothing}
       </div>
 
-      <article class="sw-today__hero">
+      <article class="sw-today__hero oc-card">
         <div class="sw-today__label">
           <span class="sw-today__ping"></span>
           ${heroLabel} · ${ageLabel}
@@ -607,7 +622,8 @@ function renderToday(
           ? html`
               <div class="sw-today__actions" aria-busy=${busy ? "true" : "false"}>
                 <button
-                  class="sw-today__big sw-today__big--evaluate ${busy === "evaluate"
+                  class="sw-today__big sw-today__big--evaluate oc-action oc-action-secondary ${busy ===
+                  "evaluate"
                     ? "is-busy"
                     : ""}"
                   ?disabled=${disabled || !props.access.canEvaluate}
@@ -619,7 +635,10 @@ function renderToday(
                   <span class="sw-today__big-sub">${t("skillWorkshop.today.runChecks")}</span>
                 </button>
                 <button
-                  class="sw-today__big sw-today__big--primary ${busy === "apply" ? "is-busy" : ""}"
+                  class="sw-today__big sw-today__big--primary oc-action oc-action-primary ${busy ===
+                  "apply"
+                    ? "is-busy"
+                    : ""}"
                   ?disabled=${disabled || !props.access.canApply}
                   @click=${() => props.onApply(proposalDecision(hero))}
                 >
@@ -629,7 +648,10 @@ function renderToday(
                   <span class="sw-today__big-sub">${t("skillWorkshop.today.addToSkills")}</span>
                 </button>
                 <button
-                  class="sw-today__big sw-today__big--tweak ${busy === "revise" ? "is-busy" : ""}"
+                  class="sw-today__big sw-today__big--tweak oc-action oc-action-secondary ${busy ===
+                  "revise"
+                    ? "is-busy"
+                    : ""}"
                   ?disabled=${disabled || !props.access.canRevise}
                   @click=${() => props.onRevise(hero.key)}
                 >
@@ -639,7 +661,10 @@ function renderToday(
                   <span class="sw-today__big-sub">${t("skillWorkshop.today.askAgent")}</span>
                 </button>
                 <button
-                  class="sw-today__big sw-today__big--skip ${busy === "reject" ? "is-busy" : ""}"
+                  class="sw-today__big sw-today__big--skip oc-action oc-action-ghost ${busy ===
+                  "reject"
+                    ? "is-busy"
+                    : ""}"
                   ?disabled=${disabled || !props.access.canReject}
                   @click=${() => props.onReject(proposalDecision(hero))}
                 >
@@ -726,7 +751,7 @@ function renderToday(
 function renderEvaluation(evaluation: SkillWorkshopEvaluation, today = false) {
   const completedAt = Date.parse(evaluation.completedAt);
   return html`
-    <section class="sw-evaluation ${today ? "sw-evaluation--today" : ""}">
+    <section class="sw-evaluation oc-section ${today ? "sw-evaluation--today" : ""}">
       <header class="sw-evaluation__head">
         <h3>${t("skillWorkshop.evaluation.title")}</h3>
         <div class="sw-evaluation__meta">
@@ -757,18 +782,18 @@ function renderEvaluationOutcome(outcome: SkillWorkshopEvaluationOutcome) {
     ? `${outcome.pluginId} ${outcome.pluginVersion}`
     : outcome.pluginId;
   return html`
-    <section class="sw-evaluation__outcome">
+    <section class="sw-evaluation__outcome oc-card">
       <div class="sw-evaluation__outcome-head">
         <div class="sw-evaluation__identity">
           <strong>${outcome.evaluatorId}</strong>
           <span>${pluginLabel}</span>
         </div>
         <div class="sw-evaluation__badges">
-          <span class="sw-evaluation__badge is-${outcome.status}">
+          <span class="sw-evaluation__badge oc-badge is-${outcome.status}">
             ${t(`skillWorkshop.evaluation.status.${outcome.status}`)}
           </span>
           ${result?.decision
-            ? html`<span class="sw-evaluation__badge is-${result.decision}">
+            ? html`<span class="sw-evaluation__badge oc-badge is-${result.decision}">
                 ${t(`skillWorkshop.evaluation.decision.${result.decision}`)}
               </span>`
             : nothing}

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -146,11 +146,19 @@ function skillStatusClass(skill: SkillStatusEntry): string {
 /** Dot+text availability status for a skill row. */
 function skillAvailabilityStatus(skill: SkillStatusEntry): TemplateResult {
   if (skill.disabled) {
-    return renderSettingsStatus({ kind: "muted", label: t("skillsPage.tabs.disabled") });
+    return renderSettingsStatus({
+      kind: "muted",
+      label: t("skillsPage.tabs.disabled"),
+      carapace: true,
+    });
   }
   return isSkillAvailable(skill)
-    ? renderSettingsStatus({ kind: "ok", label: t("skillsPage.tabs.ready") })
-    : renderSettingsStatus({ kind: "warn", label: t("skillsPage.tabs.needsSetup") });
+    ? renderSettingsStatus({ kind: "ok", label: t("skillsPage.tabs.ready"), carapace: true })
+    : renderSettingsStatus({
+        kind: "warn",
+        label: t("skillsPage.tabs.needsSetup"),
+        carapace: true,
+      });
 }
 
 function verdictForSkill(skill: SkillStatusEntry, verdicts: SkillsProps["clawhubVerdicts"]) {
@@ -275,7 +283,9 @@ export function renderSkills(props: SkillsProps) {
           ? nothing
           : renderSkillsToolbar(props, statusCounts, filtered.length)}
         ${props.error
-          ? html`<div class="callout danger" role="alert">${props.error}</div>`
+          ? html`<div class="callout danger oc-banner oc-banner-error" role="alert">
+              ${props.error}
+            </div>`
           : nothing}
         ${renderClawHubSection(props)}
         ${props.showInventory === false
@@ -285,10 +295,11 @@ export function renderSkills(props: SkillsProps) {
                 !props.connected && !props.report
                   ? t("skillsPage.disconnected")
                   : t("skillsPage.empty"),
+                { carapace: true },
               )
             : groups.map((group) => renderSkillGroup(group, props))}
       `,
-      { wide: true },
+      { wide: true, carapace: true },
     )}
     ${detailSkill ? renderSkillDetail(detailSkill, props) : nothing}
     ${props.clawhubDetailRef ? renderClawHubDetailDialog(props) : nothing}
@@ -299,14 +310,14 @@ export function renderSkills(props: SkillsProps) {
  * shell so each group keeps the pre-migration expand/collapse interaction. */
 function renderSkillGroup(group: SkillGroup, props: SkillsProps) {
   return html`
-    <details class="settings-section skills-group" open>
-      <summary class="settings-section__header skills-group__summary">
-        <h2 class="settings-section__heading">
+    <details class="settings-section skills-group oc-settings-section" open>
+      <summary class="settings-section__header skills-group__summary oc-settings-section-header">
+        <h2 class="settings-section__heading oc-settings-section-title">
           ${group.label} <span class="settings-count">${group.skills.length}</span>
         </h2>
         <span class="skills-group__chevron" aria-hidden="true">${icons.chevronDown}</span>
       </summary>
-      <div class="settings-group">
+      <div class="settings-group oc-settings-group">
         ${repeat(
           group.skills,
           (skill) => skill.skillKey,
@@ -339,6 +350,7 @@ function renderSkillsToolbar(
             <span class="settings-count">${statusCounts[tab.id]}</span>`,
         })),
         onChange: (value) => props.onStatusFilterChange(value),
+        carapace: true,
       })}
       ${agents.length > 1
         ? html`
@@ -369,7 +381,7 @@ function renderSkillsToolbar(
       <label class="plugins-field skills-toolbar__search">
         <span>${t("common.search")}</span>
         <input
-          class="settings-input"
+          class="settings-input oc-input"
           .value=${props.filter}
           @input=${(e: Event) => props.onFilterChange((e.target as HTMLInputElement).value)}
           placeholder=${t("skillsPage.filterPlaceholder")}
@@ -382,7 +394,7 @@ function renderSkillsToolbar(
       </span>
       <button
         type="button"
-        class="btn"
+        class="btn oc-action oc-action-secondary"
         ?disabled=${skillControlsLocked(props) || !props.connected}
         @click=${props.onRefresh}
       >
@@ -397,11 +409,12 @@ function renderClawHubSection(props: SkillsProps) {
     {
       title: t("skillsPage.clawHub"),
       description: t("skillsPage.clawHubSubtitle"),
+      carapace: true,
     },
     html`
-      <div class="settings-row">
+      <div class="settings-row oc-settings-row oc-settings-row-stacked">
         <input
-          class="settings-input plugins-row-input"
+          class="settings-input plugins-row-input oc-input"
           .value=${props.clawhubQuery}
           @input=${(e: Event) => props.onClawHubQueryChange((e.target as HTMLInputElement).value)}
           placeholder=${t("skillsPage.searchClawHub")}
@@ -413,13 +426,18 @@ function renderClawHubSection(props: SkillsProps) {
           : nothing}
       </div>
       ${props.clawhubSearchError
-        ? html`<div class="callout danger plugins-group-message">${props.clawhubSearchError}</div>`
+        ? html`<div class="callout danger plugins-group-message oc-banner oc-banner-error">
+            ${props.clawhubSearchError}
+          </div>`
         : nothing}
       ${props.clawhubInstallMessage
         ? html`<div
             class="callout ${props.clawhubInstallMessage.kind === "error"
               ? "danger"
-              : "success"} plugins-group-message"
+              : "success"} plugins-group-message oc-banner ${props.clawhubInstallMessage.kind ===
+            "error"
+              ? "oc-banner-error"
+              : "oc-banner-success"}"
           >
             <div
               style="max-width: 100%; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word;"
@@ -439,7 +457,7 @@ function renderClawHubResults(props: SkillsProps) {
     return nothing;
   }
   if (results.length === 0) {
-    return renderSettingsEmpty(t("skillsPage.noClawHubResults"));
+    return renderSettingsEmpty(t("skillsPage.noClawHubResults"), { carapace: true });
   }
   return html`
     ${results.map((r) => {
@@ -457,28 +475,36 @@ function renderClawHubResults(props: SkillsProps) {
           ? html`<img class="clawhub-skill-icon" src=${iconUrl} alt="" loading="lazy" />`
           : nothing}
         <span class="clawhub-skill-result__copy">
-          <span class="settings-row__title">${r.displayName}</span>
-          <span class="settings-row__desc">
+          <span class="settings-row__title oc-settings-row-title">${r.displayName}</span>
+          <span class="settings-row__desc oc-settings-row-description">
             ${r.summary ? `${clampText(r.summary, 100)} · ${ref}` : ref}${trustSuffix}
           </span>
         </span>
       `;
       return html`
-        <div class="settings-row plugins-item ${detailRef ? "plugins-item--clickable" : ""}">
+        <div
+          class="settings-row plugins-item oc-settings-row ${detailRef
+            ? "plugins-item--clickable"
+            : ""}"
+        >
           ${detailRef
             ? html`<button
                 type="button"
-                class="settings-row__text plugins-item__detail-button clawhub-skill-result__button"
+                class="settings-row__text plugins-item__detail-button clawhub-skill-result__button oc-settings-row-content"
                 aria-label=${t("skillsPage.openDetails", { name: detailRef })}
                 @click=${() => props.onClawHubDetailOpen(detailRef)}
               >
                 ${rowCopy}
               </button>`
-            : html`<div class="settings-row__text clawhub-skill-result__button">${rowCopy}</div>`}
-          <div class="settings-row__control">
+            : html`<div
+                class="settings-row__text clawhub-skill-result__button oc-settings-row-content"
+              >
+                ${rowCopy}
+              </div>`}
+          <div class="settings-row__control oc-settings-row-control">
             ${r.version ? renderSettingsValue(`v${r.version}`) : nothing}
             <button
-              class="btn btn--sm"
+              class="btn btn--sm oc-action oc-action-secondary"
               ?disabled=${installed || skillInstallLocked(props)}
               @click=${() => {
                 if (!installed) {
@@ -512,7 +538,8 @@ function renderClawHubDetailDialog(props: SkillsProps) {
       @modal-cancel=${props.onClawHubDetailClose}
     >
       <div
-        class="md-preview-dialog__panel ${props.clawhubDetailError && !props.clawhubDetailLoading
+        class="md-preview-dialog__panel oc-card ${props.clawhubDetailError &&
+        !props.clawhubDetailLoading
           ? "md-preview-dialog__panel--message-only"
           : ""}"
       >
@@ -531,7 +558,10 @@ function renderClawHubDetailDialog(props: SkillsProps) {
               ${detail?.skill?.displayName ?? props.clawhubDetailRef}
             </div>
           </div>
-          <button class="btn btn--sm" @click=${props.onClawHubDetailClose}>
+          <button
+            class="btn btn--sm oc-action oc-action-ghost"
+            @click=${props.onClawHubDetailClose}
+          >
             ${t("skillsPage.close")}
           </button>
         </div>
@@ -539,7 +569,9 @@ function renderClawHubDetailDialog(props: SkillsProps) {
           ${props.clawhubDetailLoading
             ? html`<div class="muted">${t("common.loading")}</div>`
             : props.clawhubDetailError
-              ? html`<div class="callout danger">${props.clawhubDetailError}</div>`
+              ? html`<div class="callout danger oc-banner oc-banner-error">
+                  ${props.clawhubDetailError}
+                </div>`
               : detail?.skill
                 ? html`
                     <div style="font-size: 14px; line-height: 1.5;">
@@ -571,7 +603,7 @@ function renderClawHubDetailDialog(props: SkillsProps) {
                         </div>`
                       : nothing}
                     <button
-                      class="btn primary"
+                      class="btn primary oc-action oc-action-primary"
                       ?disabled=${skillInstallLocked(props)}
                       @click=${() => {
                         if (props.clawhubDetailRef) {
@@ -598,24 +630,33 @@ function renderSkill(skill: SkillStatusEntry, props: SkillsProps) {
   const verdict = verdictForSkill(skill, props.clawhubVerdicts);
 
   return html`
-    <div class="settings-row plugins-item plugins-item--clickable">
+    <div class="settings-row plugins-item plugins-item--clickable oc-settings-row">
       <button
         type="button"
-        class="settings-row__text plugins-item__detail-button"
+        class="settings-row__text plugins-item__detail-button oc-settings-row-content"
         aria-label=${t("skillsPage.openDetails", { name: skill.name })}
         @click=${() => props.onDetailOpen(skill.skillKey)}
       >
-        <span class="settings-row__title">
+        <span class="settings-row__title oc-settings-row-title">
           ${skill.emoji ? html`<span>${skill.emoji}</span> ` : nothing}${skill.name}
         </span>
-        <span class="settings-row__desc">${clampText(skill.description, 140)}</span>
+        <span class="settings-row__desc oc-settings-row-description"
+          >${clampText(skill.description, 140)}</span
+        >
       </button>
-      <div class="settings-row__control">
+      <div class="settings-row__control oc-settings-row-control">
         ${skillAvailabilityStatus(skill)}
         ${skill.clawhub?.status === "linked"
-          ? renderSettingsStatus(verdictStatus(verdict, props.clawhubVerdictsLoading))
+          ? renderSettingsStatus({
+              ...verdictStatus(verdict, props.clawhubVerdictsLoading),
+              carapace: true,
+            })
           : skill.clawhub?.status === "invalid"
-            ? renderSettingsStatus({ kind: "warn", label: t("skillsPage.invalidLink") })
+            ? renderSettingsStatus({
+                kind: "warn",
+                label: t("skillsPage.invalidLink"),
+                carapace: true,
+              })
             : nothing}
         ${renderSettingsToggle({
           checked: !skill.disabled,
@@ -652,7 +693,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
       style="--openclaw-modal-width: min(1040px, calc(100vw - 32px));"
       @modal-cancel=${props.onDetailClose}
     >
-      <div class="md-preview-dialog__panel">
+      <div class="md-preview-dialog__panel oc-card">
         <div class="md-preview-dialog__header">
           <div
             class="md-preview-dialog__title"
@@ -662,7 +703,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
             ${skill.emoji ? html`<span style="font-size: 18px;">${skill.emoji}</span>` : nothing}
             <span>${skill.name}</span>
           </div>
-          <button class="btn btn--sm" @click=${props.onDetailClose}>
+          <button class="btn btn--sm oc-action oc-action-ghost" @click=${props.onDetailClose}>
             ${t("skillsPage.close")}
           </button>
         </div>
@@ -688,6 +729,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
                   ariaLabel: skill.name,
                   panelId: "skill-detail-panel",
                   variant: "sub",
+                  carapace: true,
                   onSelect: props.onDetailTabChange,
                 })}
               `
@@ -706,7 +748,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
           ${missing.length > 0
             ? html`
                 <div
-                  class="callout"
+                  class="callout oc-banner oc-banner-warning"
                   style="border-color: var(--warn-subtle); background: var(--warn-subtle); color: var(--warn);"
                 >
                   <div style="font-weight: 600; margin-bottom: 4px;">
@@ -736,7 +778,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
             </span>
             ${installOption
               ? html`<button
-                  class="btn"
+                  class="btn oc-action oc-action-secondary"
                   ?disabled=${installLocked}
                   @click=${() =>
                     installOption && props.onInstall(skill.skillKey, skill.name, installOption.id)}
@@ -747,7 +789,11 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
           </div>
 
           ${message
-            ? html`<div class="callout ${message.kind === "error" ? "danger" : "success"}">
+            ? html`<div
+                class="callout ${message.kind === "error"
+                  ? "danger oc-banner-error"
+                  : "success oc-banner-success"} oc-banner"
+              >
                 ${formatUiExternalText(message.message)}
               </div>`
             : nothing}
@@ -762,6 +808,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
                       ></span
                     >
                     <input
+                      class="oc-input"
                       type="password"
                       required
                       ?disabled=${updateLocked}
@@ -782,7 +829,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
                       : nothing;
                   })()}
                   <button
-                    class="btn primary"
+                    class="btn primary oc-action oc-action-primary"
                     ?disabled=${updateLocked || !editValue.trim()}
                     @click=${() => props.onSaveKey(skill.skillKey)}
                   >
@@ -826,7 +873,7 @@ function renderInstalledClawHubOverview(
     return nothing;
   }
   if (link.status === "invalid") {
-    return html`<div class="callout danger">
+    return html`<div class="callout danger oc-banner oc-banner-error">
       <div style="font-weight: 600; margin-bottom: 4px;">${t("skillsPage.invalidLink")}</div>
       <div>${formatUiExternalText(link.reason)}</div>
     </div>`;
@@ -839,7 +886,7 @@ function renderInstalledClawHubOverview(
   const installedRef = `${link.ownerHandle ? `@${link.ownerHandle}/` : ""}${link.slug}@${link.installedVersion}`;
   return html`
     <div
-      class="callout"
+      class="callout oc-banner"
       style="display: grid; gap: 8px; border-color: var(--border); background: var(--panel-strong);"
     >
       <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
@@ -874,7 +921,7 @@ function renderInstalledSkillCard(skill: SkillStatusEntry, props: SkillsProps) {
   if (content === undefined) {
     const error = props.skillCardErrors[skill.skillKey];
     if (error) {
-      return html`<div class="callout danger">${error}</div>`;
+      return html`<div class="callout danger oc-banner oc-banner-error">${error}</div>`;
     }
     return html`<div class="muted" style="font-size: 13px;">
       ${props.skillCardLoadingKey === skill.skillKey

--- a/ui/src/styles/carapace-control-ui.css
+++ b/ui/src/styles/carapace-control-ui.css
@@ -1,0 +1,240 @@
+/* Control UI owns theme selection; Carapace owns the semantic component roles.
+ * Keeping this bridge pointed at the resolved Control UI tokens makes every
+ * shipped theme family, mode, and imported custom theme work without a
+ * Carapace-side copy of the product theme catalog. */
+:root {
+  --oc-bg-page: var(--bg);
+  --oc-bg-surface: var(--card);
+  --oc-bg-elevated: var(--bg-elevated);
+  --oc-bg-recessed: var(--bg-accent);
+  --oc-bg-contrast: var(--text-strong);
+
+  --oc-accent-primary: var(--accent);
+  --oc-accent-primary-hover: var(--accent-hover);
+  --oc-accent-primary-deep: var(--primary-hover);
+  --oc-accent-secondary: var(--accent-2);
+  --oc-accent-secondary-deep: var(--accent-2-muted);
+
+  --oc-text-primary: var(--text-strong);
+  --oc-text-secondary: var(--text);
+  --oc-text-muted: var(--muted);
+  --oc-text-inactive: color-mix(in srgb, var(--muted) 62%, transparent);
+  --oc-text-inverse: var(--accent-foreground);
+  --oc-text-link: var(--link);
+  --oc-text-on-accent: var(--primary-foreground);
+
+  --oc-border-subtle: var(--border);
+  --oc-border-strong: var(--border-strong);
+  --oc-border-accent: color-mix(in srgb, var(--accent) 42%, transparent);
+
+  --oc-surface-card: var(--card);
+  --oc-surface-card-strong: var(--popover);
+  --oc-surface-overlay: var(--popover);
+  --oc-surface-modal-backdrop: color-mix(in srgb, var(--bg) 66%, transparent);
+  --oc-surface-interactive: var(--bg-elevated);
+  --oc-surface-interactive-hover: var(--bg-hover);
+  --oc-control-bg: var(--input);
+  --oc-control-bg-hover: var(--bg-hover);
+  --oc-surface-accent-soft: var(--accent-subtle);
+  --oc-surface-secondary-soft: var(--accent-2-subtle);
+  --oc-chart-line: var(--grid-line);
+  --oc-selection-bg: var(--selection-bg);
+  --oc-focus-ring: var(--ring);
+
+  --oc-status-success-bg: var(--ok-subtle);
+  --oc-status-success-fg: var(--ok);
+  --oc-status-warning-bg: var(--warn-subtle);
+  --oc-status-warning-fg: var(--warn);
+  --oc-status-error-bg: var(--danger-subtle);
+  --oc-status-error-fg: var(--danger);
+  --oc-status-info-bg: var(--info-subtle);
+  --oc-status-info-fg: var(--info);
+
+  --oc-input-bg: color-mix(in srgb, var(--bg) 80%, var(--bg-elevated) 20%);
+  --oc-input-border: var(--input);
+  --oc-input-placeholder: var(--muted);
+  --oc-input-focus-border: var(--ring);
+  --oc-input-focus-ring: var(--focus);
+
+  --oc-font-body: var(--font-body);
+  --oc-font-display: var(--font-display);
+  --oc-font-mono: var(--mono);
+  --oc-font-size-xs: var(--control-ui-text-xs);
+  --oc-font-size-sm: var(--control-ui-text-sm);
+  --oc-font-size-base: var(--control-ui-text-md);
+  --oc-font-size-md: var(--control-ui-text-md);
+  --oc-font-size-lg: var(--control-ui-text-lg);
+
+  --oc-space-1: var(--space-1);
+  --oc-space-2: var(--space-2);
+  --oc-space-3: var(--space-3);
+  --oc-space-4: var(--space-4);
+  --oc-space-5: var(--space-5);
+  --oc-space-6: var(--space-6);
+  --oc-space-7: var(--space-7);
+  --oc-space-8: var(--space-8);
+
+  --oc-radius-sm: var(--radius-sm);
+  --oc-radius-md: var(--radius-md);
+  --oc-radius-lg: var(--radius-lg);
+  --oc-radius-xl: var(--radius-xl);
+  --oc-radius-full: var(--radius-full);
+  --oc-radius-surface: var(--radius-lg);
+  --oc-radius-control: var(--radius-md);
+  --oc-radius-inset: var(--radius-sm);
+  --oc-radius-round: var(--radius-full);
+
+  --oc-shadow-sm: var(--shadow-sm);
+  --oc-shadow-md: var(--shadow-md);
+  --oc-shadow-lg: var(--shadow-lg);
+  --oc-layer-popover: var(--z-dropdown);
+  --oc-layer-notification: var(--z-toast);
+  --oc-duration-fast: var(--duration-fast);
+  --oc-duration-ui: var(--duration-normal);
+  --oc-ease-out: var(--ease-out);
+  --oc-control-min-height: var(--settings-control-height, 2.75rem);
+}
+
+/* Carapace's settings primitives assume a two-child grid row. Control UI's
+ * established settings row also supports a leading artwork slot, so the
+ * adapter retains that flex contract while sourcing its visual values from
+ * Carapace semantic tokens. */
+.settings-page.oc-app-surface {
+  background: transparent;
+}
+
+.settings-section.oc-settings-section {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--oc-space-3);
+}
+
+.settings-section__header.oc-settings-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--oc-space-3);
+  padding: 0;
+}
+
+.settings-section__copy.oc-settings-section-heading {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--oc-space-1);
+}
+
+.settings-section__heading.oc-settings-section-title {
+  color: var(--oc-text-muted);
+  font-family: var(--oc-font-body);
+  font-size: var(--oc-font-size-xs);
+  font-weight: 600;
+  line-height: 1.4;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.settings-group.oc-settings-group {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--oc-border-subtle) 85%, transparent);
+  border-radius: var(--oc-radius-surface);
+  background: var(--oc-bg-surface);
+  box-shadow: none;
+}
+
+.settings-row.oc-settings-row {
+  display: flex;
+  min-width: 0;
+  min-height: 3rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--oc-space-4);
+  padding: calc(var(--oc-space-3) - 2px) var(--oc-space-4);
+}
+
+.settings-row__text.oc-settings-row-content {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.settings-row__title.oc-settings-row-title {
+  color: var(--oc-text-primary);
+  font-size: var(--oc-font-size-base);
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.settings-row__desc.oc-settings-row-description {
+  color: var(--oc-text-muted);
+  font-size: var(--oc-font-size-sm);
+  line-height: 1.45;
+}
+
+.settings-row__control.oc-settings-row-control {
+  display: flex;
+  width: auto;
+  min-width: 0;
+  max-width: 60%;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--oc-space-2);
+}
+
+.settings-row--stacked.oc-settings-row,
+.settings-row--stacked-on-narrow.oc-settings-row {
+  align-items: stretch;
+  flex-direction: column;
+  gap: var(--oc-space-2);
+}
+
+.settings-row--stacked.oc-settings-row .oc-settings-row-control,
+.settings-row--stacked-on-narrow.oc-settings-row .oc-settings-row-control {
+  width: 100%;
+  max-width: none;
+  justify-content: flex-start;
+}
+
+.settings-page.oc-app-surface .btn.oc-action {
+  min-height: 0;
+  gap: 6px;
+  padding: 8px 14px;
+  border-color: var(--oc-border-subtle);
+  border-radius: var(--oc-radius-control);
+  background: var(--oc-bg-elevated);
+  color: var(--oc-text-primary);
+  font-size: var(--oc-font-size-sm);
+  font-weight: 500;
+  line-height: normal;
+}
+
+.settings-page.oc-app-surface .btn.btn--sm.oc-action {
+  padding: 6px 10px;
+  font-size: var(--oc-font-size-xs);
+}
+
+.settings-page.oc-app-surface .btn.oc-action:hover:not(:disabled) {
+  border-color: var(--oc-border-strong);
+  background: var(--oc-surface-interactive-hover);
+  color: var(--oc-text-primary);
+}
+
+.settings-page.oc-app-surface .btn.oc-action-icon {
+  width: 30px;
+  height: 30px;
+  padding: 7px;
+}
+
+/* The Control UI radio carries selection as a class while Carapace's generic
+ * item waits for aria-selected/is-active. Keep the shared helper's state
+ * contract and apply Carapace's interactive surface at that adapter seam. */
+.settings-segmented__btn.oc-segmented-item.settings-segmented__btn--active {
+  background: var(--oc-surface-interactive);
+}

--- a/ui/src/styles/carapace-control-ui.css
+++ b/ui/src/styles/carapace-control-ui.css
@@ -232,6 +232,28 @@
   padding: 7px;
 }
 
+/* Preserve Control UI's compact control height when Carapace's segmented
+ * surface and item insets are composed around Web Awesome radio buttons. */
+.settings-page.oc-app-surface .plugins-toolbar--plugin-catalog > .btn.oc-action-icon {
+  width: var(--settings-control-height);
+  min-width: var(--settings-control-height);
+  height: var(--settings-control-height);
+}
+
+.settings-page.oc-app-surface .plugins-toolbar--plugin-catalog > .settings-segmented.oc-segmented {
+  height: var(--settings-control-height);
+  padding: calc(var(--oc-space-1) / 2);
+}
+
+.settings-page.oc-app-surface
+  .plugins-toolbar--plugin-catalog
+  > .settings-segmented.oc-segmented
+  > .settings-segmented__btn.oc-segmented-item {
+  height: calc(var(--settings-control-height) - var(--oc-space-1) - 2px);
+  min-height: calc(var(--settings-control-height) - var(--oc-space-1) - 2px);
+  padding-block: 0;
+}
+
 /* The Control UI radio carries selection as a class while Carapace's generic
  * item waits for aria-selected/is-active. Keep the shared helper's state
  * contract and apply Carapace's interactive surface at that adapter seam. */

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -1,3 +1,11 @@
+@import "@openclaw/carapace/tokens.css";
+@import "@openclaw/carapace/components.css";
+@import "@openclaw/carapace/candidate/controls.css";
+@import "@openclaw/carapace/candidate/feedback.css";
+@import "@openclaw/carapace/candidate/data.css";
+@import "@openclaw/carapace/candidate/application.css";
+@import "./carapace-control-ui.css";
+
 /* Plugins hub page-specifics layered on the settings design language
  * (styles/settings.css): art tiles, row messages, the detail overlay, and the
  * MCP inline form. Structural layout comes from .settings-page/.settings-row. */
@@ -14,7 +22,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: var(--space-5);
+  gap: var(--oc-space-5);
   max-height: none;
 }
 

--- a/ui/src/styles/skill-workshop.css
+++ b/ui/src/styles/skill-workshop.css
@@ -15,18 +15,28 @@
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
-  box-sizing: border-box;
   width: 100%;
   max-width: 1120px;
+  box-sizing: border-box;
   height: 100%;
   margin-inline: auto;
   min-height: 0;
   overflow: hidden;
+  padding-inline: var(--space-4);
   padding-bottom: 16px;
 }
 
 .content--skill-workshop .content-header {
+  width: 100%;
   flex-shrink: 0;
+  padding-inline: 0;
+  transform: none;
+}
+
+@media (min-width: 769px) {
+  .content--skill-workshop {
+    transform: translateX(var(--space-3));
+  }
 }
 
 .sw-hub-panel {

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -336,7 +336,19 @@ export function resolveExternalPackageAliasesForVite(
 ): ControlUiViteAlias[] {
   const packageRoot = (specifier: string) =>
     path.dirname(resolvePackage(`${specifier}/package.json`));
+  const carapaceStyles = [
+    "tokens.css",
+    "components.css",
+    "candidate/controls.css",
+    "candidate/feedback.css",
+    "candidate/data.css",
+    "candidate/application.css",
+  ].map((entry) => {
+    const specifier = `@openclaw/carapace/${entry}`;
+    return { find: specifier, replacement: resolvePackage(specifier) };
+  });
   return [
+    ...carapaceStyles,
     {
       find: "@openclaw/libterminal/browser",
       replacement: path.join(packageRoot("@openclaw/libterminal"), "dist/browser.js"),


### PR DESCRIPTION
## What Problem This Solves

The Plugins settings hub and its Installed, Discover, Skills, and Workshop surfaces still used bespoke Control UI styling, so the page could not share Carapace component contracts or design tokens and drifted visually from the target interface.

## Why This Change Was Made

Pins Carapace to a reviewed commit and imports its token and component CSS through explicit Vite aliases. A Control UI bridge maps every existing OpenClaw theme into Carapace semantic tokens, while opt-in component classes apply Carapace controls, status, feedback, data, and application patterns only within the Plugins hub. Carapace itself is unchanged.

## User Impact

Operators get a visually consistent Plugins experience across Installed, Discover, Skills, Workshop, dialogs, forms, loading states, and empty/error states. Existing OpenClaw themes, routing, permissions, and plugin behavior remain intact.

## Evidence

- Live-tested the exact PR head at http://127.0.0.1:61123/settings/plugins.
- Navigated Installed, Discover, Skills, and Workshop with zero browser console errors.
- Verified the Installed toolbar search, segmented filter, and refresh controls all render at 32px high.
- Focused Playwright alignment regression: 1 test passed.
- UI regression suites: 26 tests passed.
- TypeScript UI check and Control UI production build passed.
- Stylelint, oxfmt, and changed-file checks passed.
- Two independent review passes found no remaining actionable toolbar-alignment findings.

## Before / After

| Before — current main | After — Carapace, aligned toolbar |
| --- | --- |
| ![Plugins settings before Carapace](https://github.com/user-attachments/assets/3608fbe7-7680-405e-8573-a7cccc3d0025) | ![Plugins settings after Carapace with aligned toolbar controls](https://gist.githubusercontent.com/Patrick-Erichsen/f7d983c68b0cb2ec56305518a16baef4/raw/3349f904b67b22ca1a6255667abe428a97b3e87f/after-toolbar-aligned.svg) |

References OCF-61