### PR TITLE
fix(gateway): avoid stale Control UI 304 responses

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -989,6 +989,8 @@ pnpm ui:build
 
 For bundled builds, the Gateway retains manifest-verified assets so already-open tabs can fetch older asset URLs after an update. The cache keeps at most three generations and 96 MiB total, preferring the current generation; older generations can be pruned sooner to meet the byte budget. Background startup preparation reuses verified inventories through publication and pruning instead of rereading unchanged retained assets at each step. Newly published assets are verified before reuse, including a concurrent publisher's winning copy. Configured `gateway.controlUi.root` builds do not use this cache.
 
+Non-index static assets use `Last-Modified` for conditional `GET` and `HEAD` requests. `If-None-Match` takes precedence over `If-Modified-Since`: `*` matches an existing asset, while other values receive the normal `200` response because static assets do not emit ETags. Date-only revalidation still returns `304` for unchanged assets. If no available content encoding is acceptable, the Gateway returns `406` before evaluating either condition.
+
 Optional absolute base (fixed asset URLs):
 
 ```bash

--- a/src/gateway/control-ui-conditional.http.test.ts
+++ b/src/gateway/control-ui-conditional.http.test.ts
@@ -1,0 +1,172 @@
+import fs from "node:fs/promises";
+import { createServer, request, type IncomingMessage, type Server } from "node:http";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { handleControlUiHttpRequest } from "./control-ui.js";
+
+const assetBody = Buffer.from('console.log("conditional fixture");\n');
+const modifiedAt = new Date("2024-01-01T00:00:00.000Z");
+const lastModified = modifiedAt.toUTCString();
+const laterModifiedSince = new Date("2024-01-02T00:00:00.000Z").toUTCString();
+const earlierModifiedSince = new Date("2023-12-31T00:00:00.000Z").toUTCString();
+const conditionalCases: {
+  name: string;
+  headers: Record<string, string>;
+  status: 200 | 304;
+}[] = [
+  { name: "unconditional request", headers: {}, status: 200 },
+  {
+    name: "equal If-Modified-Since",
+    headers: { "If-Modified-Since": lastModified },
+    status: 304,
+  },
+  {
+    name: "later If-Modified-Since",
+    headers: { "If-Modified-Since": laterModifiedSince },
+    status: 304,
+  },
+  {
+    name: "older If-Modified-Since",
+    headers: { "If-Modified-Since": earlierModifiedSince },
+    status: 200,
+  },
+  { name: "stale If-None-Match alone", headers: { "If-None-Match": '"stale"' }, status: 200 },
+  {
+    name: "stale If-None-Match overrides equal If-Modified-Since",
+    headers: { "If-None-Match": '"stale"', "If-Modified-Since": lastModified },
+    status: 200,
+  },
+  {
+    name: "weak stale If-None-Match overrides later If-Modified-Since",
+    headers: { "If-None-Match": 'W/"stale"', "If-Modified-Since": laterModifiedSince },
+    status: 200,
+  },
+  {
+    name: "empty If-None-Match overrides later If-Modified-Since",
+    headers: { "If-None-Match": "", "If-Modified-Since": laterModifiedSince },
+    status: 200,
+  },
+  { name: "wildcard If-None-Match alone", headers: { "If-None-Match": "*" }, status: 304 },
+  {
+    name: "wildcard If-None-Match overrides equal If-Modified-Since",
+    headers: { "If-None-Match": "*", "If-Modified-Since": lastModified },
+    status: 304,
+  },
+  {
+    name: "wildcard If-None-Match overrides older If-Modified-Since",
+    headers: { "If-None-Match": "*", "If-Modified-Since": earlierModifiedSince },
+    status: 304,
+  },
+  {
+    name: "matching date releases the negotiated representation",
+    headers: { "Accept-Encoding": "gzip", "If-Modified-Since": lastModified },
+    status: 304,
+  },
+];
+
+function requestAsset(
+  url: string,
+  method: "GET" | "HEAD",
+  headers: Record<string, string>,
+): Promise<{ response: IncomingMessage; body: Buffer }> {
+  // Node HTTP preserves an explicitly empty If-None-Match on the wire.
+  return new Promise((resolve, reject) => {
+    const req = request(url, { method, headers, agent: false }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk: Buffer) => chunks.push(chunk));
+      response.on("error", reject);
+      response.on("end", () => resolve({ response, body: Buffer.concat(chunks) }));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe.each([
+  { kind: "bundled", basePath: "", cacheControl: "public, max-age=31536000, immutable" },
+  { kind: "resolved", basePath: "/dashboard", cacheControl: "no-cache" },
+] as const)("$kind static asset conditional HTTP requests", ({ kind, basePath, cacheControl }) => {
+  const tempDirs = createTempDirTracker();
+  let server: Server | undefined;
+  let assetUrl: string;
+
+  beforeAll(async () => {
+    const root = tempDirs.make("openclaw-ui-conditional-");
+    const assetPath = path.join(root, "assets", "app-fixture.js");
+    await fs.mkdir(path.dirname(assetPath));
+    await fs.writeFile(assetPath, assetBody);
+    await fs.writeFile(`${assetPath}.gz`, gzipSync(assetBody));
+    await fs.utimes(assetPath, modifiedAt, modifiedAt);
+    server = createServer((req, res) => {
+      void handleControlUiHttpRequest(req, res, {
+        basePath,
+        config: {},
+        root: { kind, path: root, realPath: root },
+      }).catch((error: unknown) => {
+        res.statusCode = 500;
+        res.end(error instanceof Error ? error.message : String(error));
+      });
+    });
+    const listeningServer = server;
+    await new Promise<void>((resolve, reject) => {
+      listeningServer.once("error", reject);
+      listeningServer.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected a TCP listener for the static asset fixture");
+    }
+    assetUrl = `http://127.0.0.1:${address.port}${basePath}/assets/app-fixture.js`;
+  });
+
+  afterAll(async () => {
+    try {
+      const listeningServer = server;
+      if (listeningServer?.listening) {
+        await new Promise<void>((resolve, reject) => {
+          listeningServer.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    } finally {
+      tempDirs.cleanup();
+    }
+  });
+
+  describe.each(["GET", "HEAD"] as const)("%s", (method) => {
+    it.each(conditionalCases)("$name", async ({ headers, status }) => {
+      const { response, body } = await requestAsset(assetUrl, method, headers);
+
+      expect(response.statusCode).toBe(status);
+      expect(response.headers["last-modified"]).toBe(lastModified);
+      expect(response.headers["cache-control"]).toBe(cacheControl);
+      expect(response.headers.vary).toBe("Accept-Encoding");
+      expect(response.headers.etag).toBeUndefined();
+      expect(response.headers["content-length"]).toBe(
+        status === 304 ? undefined : String(assetBody.length),
+      );
+      expect(body).toEqual(status === 200 && method === "GET" ? assetBody : Buffer.alloc(0));
+    });
+
+    it.each<Record<string, string>>([
+      { "If-Modified-Since": laterModifiedSince },
+      { "If-None-Match": "*" },
+      { "If-None-Match": "*", "If-Modified-Since": laterModifiedSince },
+      { "If-None-Match": '"stale"', "If-Modified-Since": laterModifiedSince },
+    ])("rejects unacceptable encodings before evaluating %j", async (condition) => {
+      const { response, body } = await requestAsset(assetUrl, method, {
+        ...condition,
+        "Accept-Encoding": "identity;q=0, *;q=0",
+      });
+
+      expect(response.statusCode).toBe(406);
+      expect(response.headers["cache-control"]).toBe("no-store");
+      expect(response.headers.vary).toBe("Accept-Encoding");
+      expect(response.headers["last-modified"]).toBeUndefined();
+      expect(response.headers.etag).toBeUndefined();
+      expect(response.headers["content-length"]).toBe(String(Buffer.byteLength("Not Acceptable")));
+      expect(body.toString()).toBe(method === "GET" ? "Not Acceptable" : "");
+    });
+  });
+});

--- a/src/gateway/control-ui-static.ts
+++ b/src/gateway/control-ui-static.ts
@@ -226,14 +226,15 @@ function setControlUiFileHeaders(
   setControlUiEncodingHeaders(res, extension, options?.encoding ?? "identity");
 }
 
-/**
- * `no-cache` responses without a validator force a full re-download on every
- * revisit; fonts and theme CSS are the heavy unhashed assets that hit this.
- * HTTP-dates carry whole-second precision, so compare on floored seconds.
- */
+/** Revalidate no-cache static assets without generating entity tags. */
 export function isControlUiFileUnmodified(req: IncomingMessage, lastModifiedMs: number): boolean {
   if (req.method !== "GET" && req.method !== "HEAD") {
     return false;
+  }
+  // Entity-tag conditions supersede dates; only "*" matches these ETag-free files.
+  const ifNoneMatch = req.headers?.["if-none-match"];
+  if (ifNoneMatch !== undefined) {
+    return ifNoneMatch.trim() === "*";
   }
   const header = req.headers?.["if-modified-since"];
   const since = typeof header === "string" ? Date.parse(header) : Number.NaN;

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -1026,15 +1026,9 @@ export async function handleControlUiHttpRequest(
     }
   }
   if (safeFile && path.basename(safeFile.path) !== "index.html") {
-    // Filesystem clocks may lead this host; validators cannot postdate message
-    // origination or a future date would 304 later replacements (mirrors
-    // resolveByteResponse in http-byte-range.ts).
+    // Future filesystem clocks must not make later replacements look unmodified;
+    // clamp to response origination as in resolveByteResponse.
     const lastModifiedMs = Math.floor(Math.min(safeFile.mtimeMs, Date.now()) / 1_000) * 1_000;
-    if (isControlUiFileUnmodified(req, lastModifiedMs)) {
-      fs.closeSync(safeFile.fd);
-      respondControlUiNotModified(res, { immutable: immutableAsset, lastModifiedMs });
-      return true;
-    }
     const representation = resolveOpenedControlUiRepresentation({
       req,
       sourceFile: safeFile,
@@ -1044,6 +1038,12 @@ export async function handleControlUiHttpRequest(
     });
     if (!representation) {
       respondControlUiNotAcceptable(res);
+      return true;
+    }
+    // Negotiation failures precede preconditions; release the selected representation on 304.
+    if (isControlUiFileUnmodified(req, lastModifiedMs)) {
+      fs.closeSync(representation.bodyFile.fd);
+      respondControlUiNotModified(res, { immutable: immutableAsset, lastModifiedMs });
       return true;
     }
     if (req.method === "HEAD") {


### PR DESCRIPTION
Closes #135606 — Control UI returns 304 for nonmatching cache validators.

<details>
<summary>Additional instructions</summary>

**Allow edits from maintainers** is enabled through this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where clients revalidating Control UI static assets would receive a bodyless `304 Not Modified` when they sent a stale/nonmatching `If-None-Match` together with a current or later `If-Modified-Since`. The client should receive the current asset rather than reuse its cached copy.

This affects fonts, plain CSS, and fingerprinted assets, for both bundled and configured roots and for GET/HEAD. The complete outer Gateway HTTP path does not resolve the competing validators before the static owner.

## Why This Change Was Made

The static conditional owner now evaluates `If-None-Match` presence first, including empty values; only the wildcard `*` can match an existing file because static assets deliberately do not emit ETags. The caller selects an acceptable representation before evaluating preconditions, so normal `406` negotiation failures cannot become `304`, and a not-modified response closes the selected descriptor rather than a source descriptor already released during sidecar selection.

Last-Modified capture, future-clock clamping, date-only revalidation, cache metadata, compression, retained assets, and GET/HEAD behavior remain intact. No ETags, config options, schema, dependencies, protocol-version changes, or parallel serving flow were added.

**Production LOC:** +14/-13, net +1. **Tests:** +172/-0. **Docs:** +2/-0. The one net production line implements the missing entity-tag/wildcard contract; representation selection and descriptor ownership reuse the existing path. The final PR remains four files; a redundant test-only CI correction was dropped after the canonical repair landed on main.

Contract: [RFC 9110 §13.1.3](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.3), [wildcard matching §13.1.2](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.1.2), and [normal checks before preconditions §13.2.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-13.2.1).

## User Impact

Conditional clients receive current Control UI asset bytes when their entity-tag condition does not match. Date-only requests still avoid retransferring unchanged assets. Wildcard existence checks and unacceptable encoding requests retain the correct HTTP outcomes without requiring an operator configuration change.

This changes HTTP status/header behavior, not rendered layout. Documentation is updated in the [Control UI guide](https://docs.openclaw.ai/web/control-ui).

## Evidence

The baseline was frozen main `9101e7cc9de17bb661e2eb694090cc6a07c1752a`. The affected runtime source and outer caller remained unchanged on inspected main `80ae248de1c050d2508f378245b2f1add18f47ed`. Current head `708a93d043e421bc746f4cedcfcdacf3d0e42147` is one HTTP-repair commit over that base. All four HTTP/doc blobs match the original reviewed publication `97340010e5d82f1472e41855f5b38671797b7fe6` byte-for-byte. The full production HTTP probe was rerun after the latest rebase and again passed 180/180 cases.

### Before and after

| Proof | Unchanged main | Repaired candidate |
| --- | --- | --- |
| Real-handler TCP regression | 32 failed, 32 passed | 64 passed |
| Full production Gateway HTTP probe | 96 failed, 84 passed | 180 passed |
| Owner and sibling Vitest suites | Regression captured separately | 5 files, 311 passed |

The full HTTP probe used actual `createGatewayHttpServer` loopback listeners on ephemeral ports and synthetic files, covering font/plain CSS/fingerprinted CSS, bundled/default and configured/prefixed roots, GET/HEAD, stale/weak/empty entity tags, wildcard controls, date-only controls, negotiation failures, cache metadata, lengths, and bodies. The 96 baseline failures comprise 36 original competing-header failures, 24 wildcard existence failures, and 36 negotiation-order failures.

```json
{"transport":"loopback TCP via createGatewayHttpServer","cases":180,"passed":180,"failed":0,"syntheticFilesOnly":true,"operatorGatewayChanged":false}
```

The checked-in regression uses the real `handleControlUiHttpRequest` over Node HTTP, not a mocked conditional response. It includes a gzip-selected 304 control to catch closing the wrong descriptor. A broader initial Vitest fixture was stopped during unrelated cold compilation, then narrowed to this actual owning handler; the full outer pipeline remains covered by the separate production HTTP probe. No screenshots or video are offered as proof of wire-level validator semantics.

### Local validation

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/control-ui-conditional.http.test.ts src/gateway/control-ui-static.test.ts src/gateway/control-ui.http.test.ts src/gateway/http-byte-range.test.ts src/gateway/control-ui-response-metadata.http.test.ts
```

5 files, 311 tests passed.

```bash
node scripts/check-changed.mjs -- src/gateway/control-ui-static.ts src/gateway/control-ui.ts src/gateway/control-ui-conditional.http.test.ts docs/web/control-ui.md
```

Passed all selected formatting, production/test typecheck, lint, dead-export, import-cycle and guard lanes. `git diff --check` passed.

Fresh independent Codex autoreview covered the complete HTTP repair and the temporary CI correction below, with no actionable P0–P2 findings. The final rebase retains the exact reviewed four-file HTTP/doc patch and removes only the redundant test delta already on main. Exact-head hosted CI is required before native prepare/merge.

### CI blocker resolved before landing

The [first exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33568556676) failed in [the sidebar lifecycle test shard](https://github.com/openclaw/openclaw/actions/runs/33568556676/job/100057417184), not in the HTTP regressions. Its sidebar-wide `.hover-marquee` selector now finds the unchanged catalog header, while the fixture renames a session. The failure reproduced in isolation before editing.

A local correction freshly resolved the catalog session label before and after the rename, asserted both expected labels, and retained all node-replacement, scrolling-class, and shift-reset assertions. Production already handles the keyed session label correctly; no UI production code change was needed.

```bash
node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts ui/src/lib/hover-marquee.test.ts
```

Two files, **330 tests passed** after the local correction. Focused formatting/lint, the UI typecheck, and `git diff --check` also passed.

An equivalent canonical test fix then landed on main in [the cron optimization PR, including the sidebar CI cleanup](https://github.com/openclaw/openclaw/pull/135597), commit `013fe714f23a87facde9b3877051e501247ecbd3`. Its raw parent diff and merged state were verified. This branch was rebased onto main and the redundant local test commit was dropped; the entire sidebar helper now matches main. The original failed test passed again against that canonical fix. The new head must complete required CI; no failed check is being bypassed.

### Provenance and scope

Raw parent comparison confirms the deficient static Last-Modified path was added in [the font-serving/revalidation change](https://github.com/openclaw/openclaw/pull/131471), commit `e2dd590a3ec27d9b6a1c278d547129db73be8a2c`, parent `d4c1acb59c3c54be7c2eeb7eaa89248e4023dbde`. Stable tag `v2026.8.1` contains that code. Gitcrawl and live GitHub searches found no overlapping static precedence repair; the open mutable-media validator work concerns a different owner/contract.

A named follow-up tracks existing acceptance of non-HTTP ISO dates and duplicate If-Modified-Since fields. Those date-parser cases omit If-None-Match and are independent of this repair; the intended follow-up is to reuse the media owner's strict date/headersDistinct contract, not add another parser.
