### PR TITLE
refactor(state): share state directory database options

### DIFF
--- a/src/gateway/managed-image-record-store.ts
+++ b/src/gateway/managed-image-record-store.ts
@@ -8,8 +8,8 @@ import {
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
+  openClawStateDatabaseOptionsForStateDir as stateDbOptions,
   runOpenClawStateWriteTransaction,
-  type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
 
 export const MANAGED_OUTGOING_ORIGINALS_SUBDIR = "outgoing/originals";
@@ -53,12 +53,6 @@ type ManagedImageRecordEntry = {
   record: ManagedImageRecord;
   cleanupPending: boolean;
 };
-
-function stateDatabaseOptions(stateDir?: string): OpenClawStateDatabaseOptions {
-  return stateDir
-    ? { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } }
-    : { env: process.env };
-}
 
 export function managedImageRecordToRow(record: ManagedImageRecord): ManagedImageRecordInsert {
   return {
@@ -118,7 +112,7 @@ export function readManagedImageRecord(
   attachmentId: string,
   stateDir?: string,
 ): ManagedImageRecord | null {
-  const database = openOpenClawStateDatabase(stateDatabaseOptions(stateDir));
+  const database = openOpenClawStateDatabase(stateDbOptions(stateDir));
   const row = executeSqliteQueryTakeFirstSync(
     database.db,
     getNodeSqliteKysely<ManagedImageRecordDatabase>(database.db)
@@ -134,7 +128,7 @@ export function listManagedImageRecordEntries(params: {
   stateDir?: string;
   sessionKey?: string;
 }): ManagedImageRecordEntry[] {
-  const database = openOpenClawStateDatabase(stateDatabaseOptions(params.stateDir));
+  const database = openOpenClawStateDatabase(stateDbOptions(params.stateDir));
   const stateDb = getNodeSqliteKysely<ManagedImageRecordDatabase>(database.db);
   let query = stateDb.selectFrom("managed_outgoing_image_records").selectAll();
   if (params.sessionKey) {
@@ -157,7 +151,7 @@ export function insertManagedImageRecord(record: ManagedImageRecord, stateDir?: 
         .insertInto("managed_outgoing_image_records")
         .values(managedImageRecordToRow(record)),
     );
-  }, stateDatabaseOptions(stateDir));
+  }, stateDbOptions(stateDir));
 }
 
 /** Promote a transient record atomically so concurrent message commits cannot lose state. */
@@ -208,7 +202,7 @@ export function attachManagedImageRecordToMessage(params: {
         .where("attachment_id", "=", params.attachmentId),
     );
     return true;
-  }, stateDatabaseOptions(params.stateDir));
+  }, stateDbOptions(params.stateDir));
 }
 
 /** Claim only the exact row cleanup planned against; concurrent updates win. */
@@ -240,7 +234,7 @@ export function claimManagedImageRecordCleanupIfCurrent(
         .where("attachment_id", "=", planned.attachmentId),
     );
     return true;
-  }, stateDatabaseOptions(stateDir));
+  }, stateDbOptions(stateDir));
 }
 
 /** Delete a durably claimed row only after its attachment file is gone. */
@@ -271,5 +265,5 @@ export function deleteClaimedManagedImageRecord(
         .where("attachment_id", "=", planned.attachmentId),
     );
     return true;
-  }, stateDatabaseOptions(stateDir));
+  }, stateDbOptions(stateDir));
 }

--- a/src/infra/delivery-queue-sqlite-claim.ts
+++ b/src/infra/delivery-queue-sqlite-claim.ts
@@ -1,4 +1,7 @@
-import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import {
+  openOpenClawStateDatabase,
+  openClawStateDatabaseOptionsForStateDir as stateDbOptions,
+} from "../state/openclaw-state-db.js";
 import {
   loadDeliveryQueueEntry,
   upsertDeliveryQueueEntry,
@@ -41,9 +44,7 @@ export function transitionOwnedDeliveryQueueEntry(
   },
   transition: (entry: DeliveryQueueEntryState) => void,
 ): boolean {
-  const database = openOpenClawStateDatabase({
-    env: params.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } : process.env,
-  });
+  const database = openOpenClawStateDatabase(stateDbOptions(params.stateDir));
   return runSqliteImmediateTransactionSync(
     database.db,
     () => {
@@ -76,9 +77,7 @@ function transitionDeliveryQueueEntryPlatformSend(
 ): boolean {
   // State-database opens reuse the canonical path-owned connection, so both
   // existing queue primitives execute inside this same IMMEDIATE transaction.
-  const database = openOpenClawStateDatabase({
-    env: params.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } : process.env,
-  });
+  const database = openOpenClawStateDatabase(stateDbOptions(params.stateDir));
   return runSqliteImmediateTransactionSync(
     database.db,
     () => {
@@ -154,9 +153,7 @@ export function renewDeliveryQueueEntryPlatformSendLease(
     claimId: string;
   },
 ): number | undefined {
-  const database = openOpenClawStateDatabase({
-    env: params.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: params.stateDir } : process.env,
-  });
+  const database = openOpenClawStateDatabase(stateDbOptions(params.stateDir));
   return runSqliteImmediateTransactionSync(
     database.db,
     () => {

--- a/src/infra/delivery-queue-sqlite-namespace.ts
+++ b/src/infra/delivery-queue-sqlite-namespace.ts
@@ -1,6 +1,9 @@
 // Owns atomic delivery-queue ownership changes across namespace versions.
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
-import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import {
+  openOpenClawStateDatabase,
+  openClawStateDatabaseOptionsForStateDir as stateDbOptions,
+} from "../state/openclaw-state-db.js";
 import {
   completeDeliveryQueueEntry,
   deleteDeliveryQueueEntry,
@@ -19,9 +22,7 @@ type DeliveryQueueDatabase = Pick<OpenClawStateKyselyDatabase, "delivery_queue_e
 type QueueStatus = "pending" | "failed" | "completed";
 
 function openStateDatabase(stateDir?: string) {
-  return openOpenClawStateDatabase({
-    env: stateDir ? { ...process.env, OPENCLAW_STATE_DIR: stateDir } : process.env,
-  });
+  return openOpenClawStateDatabase(stateDbOptions(stateDir));
 }
 
 /** Atomically publishes one staged owner only when retired namespaces do not own its id. */

--- a/src/infra/delivery-queue-sqlite.ts
+++ b/src/infra/delivery-queue-sqlite.ts
@@ -2,6 +2,7 @@
 import { safeParseJsonRecord } from "@openclaw/normalization-core";
 import {
   openOpenClawStateDatabase,
+  openClawStateDatabaseOptionsForStateDir as stateDbOptions,
   type OpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import {
@@ -48,9 +49,7 @@ type TerminalizePendingDeliveryQueueEntryResult =
   | { status: "not_pending" };
 
 function openStateDatabase(stateDir?: string) {
-  return openOpenClawStateDatabase({
-    env: stateDir ? { ...process.env, OPENCLAW_STATE_DIR: stateDir } : process.env,
-  });
+  return openOpenClawStateDatabase(stateDbOptions(stateDir));
 }
 
 function enoent(queueName: string, id: string): Error & { code: string } {

--- a/src/infra/push-apns-store.ts
+++ b/src/infra/push-apns-store.ts
@@ -8,8 +8,8 @@ import { z } from "zod";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
+  openClawStateDatabaseOptionsForStateDir as stateDbOptions,
   runOpenClawStateWriteTransaction,
-  type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
 import { loadPairedDevicePairingStoreRecordFromDatabase } from "./device-pairing-store.js";
 import { resolveNodePairingGeneration } from "./device-pairing.js";
@@ -99,12 +99,6 @@ const MAX_APNS_TOKEN_HEX_LENGTH = 512;
 const MAX_RELAY_IDENTIFIER_LENGTH = 256;
 const MAX_SEND_GRANT_LENGTH = 1024;
 const APNS_REGISTRATION_LOOKUP_CHUNK_SIZE = 500;
-
-function apnsStateDatabaseOptions(stateDir?: string): OpenClawStateDatabaseOptions {
-  return stateDir
-    ? { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } }
-    : { env: process.env };
-}
 
 export function normalizeApnsNodeId(value: string): string {
   return value.trim();
@@ -524,7 +518,7 @@ export async function registerApnsRegistration(
       stateDb.deleteFrom("apns_registration_tombstones").where("node_id", "=", nodeId),
     );
     return next;
-  }, apnsStateDatabaseOptions(params.baseDir));
+  }, stateDbOptions(params.baseDir));
 }
 
 /** Loads one normalized APNs registration by node id. */
@@ -536,7 +530,7 @@ export async function loadApnsRegistration(
   if (!normalizedNodeId) {
     return null;
   }
-  const database = openOpenClawStateDatabase(apnsStateDatabaseOptions(baseDir));
+  const database = openOpenClawStateDatabase(stateDbOptions(baseDir));
   const row = executeSqliteQueryTakeFirstSync(
     database.db,
     getNodeSqliteKysely<ApnsRegistrationDatabase>(database.db)
@@ -566,7 +560,7 @@ export async function loadApnsRegistrations(
   if (uniqueNodeIds.length === 0) {
     return [];
   }
-  const database = openOpenClawStateDatabase(apnsStateDatabaseOptions(baseDir));
+  const database = openOpenClawStateDatabase(stateDbOptions(baseDir));
   const registrations = new Map<string, ApnsRegistration>();
   const stateDb = getNodeSqliteKysely<ApnsRegistrationDatabase>(database.db);
   for (
@@ -644,5 +638,5 @@ export async function clearApnsRegistrationIfCurrent(params: {
       stateDb.deleteFrom("apns_registrations").where("node_id", "=", normalizedNodeId),
     );
     return true;
-  }, apnsStateDatabaseOptions(params.baseDir));
+  }, stateDbOptions(params.baseDir));
 }

--- a/src/infra/push-web-store.ts
+++ b/src/infra/push-web-store.ts
@@ -7,8 +7,8 @@ import { ensureColumn } from "../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
+  openClawStateDatabaseOptionsForStateDir as stateDbOptions,
   runOpenClawStateWriteTransaction,
-  type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
 import { sha256HexPrefixCore } from "./crypto-digest.js";
 import {
@@ -81,12 +81,6 @@ CREATE INDEX IF NOT EXISTS idx_web_push_approval_deliveries_subscription
   ON web_push_approval_deliveries(subscription_id, approval_id);
 `;
 
-function webPushStateDatabaseOptions(stateDir?: string): OpenClawStateDatabaseOptions {
-  return stateDir
-    ? { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } }
-    : { env: process.env };
-}
-
 /** Adds downgrade-safe binding columns before the first Web Push store operation. */
 export function ensureWebPushSubscriptionBindingColumns(db: DatabaseSync): void {
   ensureColumn(db, "web_push_subscriptions", "device_id TEXT");
@@ -95,7 +89,7 @@ export function ensureWebPushSubscriptionBindingColumns(db: DatabaseSync): void 
 }
 
 function ensureWebPushSubscriptionBindingSchema(stateDir?: string): void {
-  const options = webPushStateDatabaseOptions(stateDir);
+  const options = stateDbOptions(stateDir);
   const database = openOpenClawStateDatabase(options);
   if (ensuredWebPushBindingDatabases.has(database.db)) {
     return;
@@ -115,7 +109,7 @@ function ensureWebPushApprovalDeliveryTable(db: DatabaseSync): void {
 }
 
 function ensureWebPushApprovalDeliverySchema(stateDir?: string): void {
-  const options = webPushStateDatabaseOptions(stateDir);
+  const options = stateDbOptions(stateDir);
   const database = openOpenClawStateDatabase(options);
   if (ensuredWebPushApprovalDeliveryDatabases.has(database.db)) {
     return;
@@ -206,7 +200,7 @@ export function findBoundWebPushSubscriptionByEndpoint(params: {
   stateDir?: string;
 }): BoundWebPushSubscription | null {
   ensureWebPushSubscriptionBindingSchema(params.stateDir);
-  const database = openOpenClawStateDatabase(webPushStateDatabaseOptions(params.stateDir));
+  const database = openOpenClawStateDatabase(stateDbOptions(params.stateDir));
   const row = executeSqliteQueryTakeFirstSync(
     database.db,
     getNodeSqliteKysely<WebPushDatabase>(database.db)
@@ -226,7 +220,7 @@ export function setWebPushSubscriptionPreferences(params: {
   stateDir?: string;
 }): boolean {
   ensureWebPushSubscriptionBindingSchema(params.stateDir);
-  const options = webPushStateDatabaseOptions(params.stateDir);
+  const options = stateDbOptions(params.stateDir);
   return runOpenClawStateWriteTransaction(({ db }) => {
     const result = executeSqliteQuerySync(
       db,
@@ -265,7 +259,7 @@ export function webPushSubscriptionsEqual(
 
 export function listWebPushSubscriptions(stateDir?: string): WebPushSubscription[] {
   ensureWebPushSubscriptionBindingSchema(stateDir);
-  const database = openOpenClawStateDatabase(webPushStateDatabaseOptions(stateDir));
+  const database = openOpenClawStateDatabase(stateDbOptions(stateDir));
   const stateDb = getNodeSqliteKysely<WebPushDatabase>(database.db);
   return executeSqliteQuerySync(
     database.db,
@@ -280,7 +274,7 @@ export function listWebPushSubscriptions(stateDir?: string): WebPushSubscription
 /** Lists only subscriptions reconciled by an authenticated browser device. */
 export function listBoundWebPushSubscriptions(stateDir?: string): BoundWebPushSubscription[] {
   ensureWebPushSubscriptionBindingSchema(stateDir);
-  const database = openOpenClawStateDatabase(webPushStateDatabaseOptions(stateDir));
+  const database = openOpenClawStateDatabase(stateDbOptions(stateDir));
   const rows = executeSqliteQuerySync(
     database.db,
     getNodeSqliteKysely<WebPushDatabase>(database.db)
@@ -314,7 +308,7 @@ export function prepareWebPushApprovalDeliveries(params: {
     return false;
   }
   ensureWebPushApprovalDeliverySchema(params.stateDir);
-  const options = webPushStateDatabaseOptions(params.stateDir);
+  const options = stateDbOptions(params.stateDir);
   return runOpenClawStateWriteTransaction(({ db }) => {
     const stateDb = getNodeSqliteKysely<WebPushDatabase>(db);
     const approval = executeSqliteQueryTakeFirstSync(
@@ -403,7 +397,7 @@ export function listWebPushApprovalDeliveryTargets(params: {
       const subscription = boundWebPushSubscriptionFromRow(row);
       return subscription ? [subscription] : [];
     });
-  }, webPushStateDatabaseOptions(params.stateDir));
+  }, stateDbOptions(params.stateDir));
 }
 
 /** Remove only targets whose terminal replacement was accepted. */
@@ -425,7 +419,7 @@ export function deleteWebPushApprovalDeliveryTargets(params: {
         .where("approval_id", "=", params.approvalId)
         .where("subscription_id", "in", subscriptionIds),
     );
-  }, webPushStateDatabaseOptions(params.stateDir));
+  }, stateDbOptions(params.stateDir));
 }
 
 /** Page through a stable snapshot of terminal approvals that still need replacement. */
@@ -439,7 +433,7 @@ export function listTerminalWebPushApprovalDeliveryIds(params: {
   throughApprovalId: string | null;
 } {
   ensureWebPushApprovalDeliverySchema(params.stateDir);
-  const database = openOpenClawStateDatabase(webPushStateDatabaseOptions(params.stateDir));
+  const database = openOpenClawStateDatabase(stateDbOptions(params.stateDir));
   const stateDb = getNodeSqliteKysely<WebPushDatabase>(database.db);
   const terminalApprovalQuery = () =>
     stateDb
@@ -564,7 +558,7 @@ export function upsertWebPushSubscription(params: {
         ),
     );
     return subscription;
-  }, webPushStateDatabaseOptions(params.stateDir));
+  }, stateDbOptions(params.stateDir));
 }
 
 export function deleteBoundWebPushSubscription(params: {
@@ -590,7 +584,7 @@ export function deleteBoundWebPushSubscription(params: {
         ),
     );
     return Number(result.numAffectedRows ?? 0) > 0;
-  }, webPushStateDatabaseOptions(params.stateDir));
+  }, stateDbOptions(params.stateDir));
 }
 
 /** Delete an expired send target only if no newer registration replaced it in flight. */
@@ -614,15 +608,12 @@ export function deleteWebPushSubscriptionIfCurrent(params: {
         .where("updated_at_ms", "=", subscription.updatedAtMs),
     );
     return Number(result.numAffectedRows ?? 0) > 0;
-  }, webPushStateDatabaseOptions(params.stateDir));
+  }, stateDbOptions(params.stateDir));
 }
 
 export function readPersistedVapidKeyPair(stateDir?: string): VapidKeyPair | null {
   return (
-    readConfigMachineState<VapidKeyPair>(
-      WEB_PUSH_VAPID_STATE_KEY,
-      webPushStateDatabaseOptions(stateDir),
-    ) ?? null
+    readConfigMachineState<VapidKeyPair>(WEB_PUSH_VAPID_STATE_KEY, stateDbOptions(stateDir)) ?? null
   );
 }
 
@@ -635,6 +626,6 @@ export function insertVapidKeyPairIfAbsent(params: {
   return updateConfigMachineState<VapidKeyPair>(
     WEB_PUSH_VAPID_STATE_KEY,
     (current) => current ?? params.candidate,
-    webPushStateDatabaseOptions(params.stateDir),
+    stateDbOptions(params.stateDir),
   );
 }

--- a/src/state/openclaw-state-db-options.test.ts
+++ b/src/state/openclaw-state-db-options.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { openClawStateDatabaseOptionsForStateDir } from "./openclaw-state-db.js";
+
+const AMBIENT_KEY = "OPENCLAW_STATE_DB_OPTIONS_TEST_VALUE";
+let envSnapshot: ReturnType<typeof captureEnv>;
+
+beforeEach(() => {
+  envSnapshot = captureEnv(["OPENCLAW_STATE_DIR", AMBIENT_KEY]);
+});
+
+afterEach(() => {
+  envSnapshot.restore();
+});
+
+describe("openClawStateDatabaseOptionsForStateDir", () => {
+  it.each([
+    { label: "undefined", stateDir: undefined },
+    { label: "empty", stateDir: "" },
+  ])("reuses process.env for $label state directories", ({ stateDir }) => {
+    expect(openClawStateDatabaseOptionsForStateDir(stateDir).env).toBe(process.env);
+  });
+
+  it("overrides a non-empty state directory without mutating process.env", () => {
+    setTestEnvValue("OPENCLAW_STATE_DIR", "ambient-state");
+
+    const options = openClawStateDatabaseOptionsForStateDir("explicit-state");
+
+    expect(options.env).not.toBe(process.env);
+    expect(options.env?.OPENCLAW_STATE_DIR).toBe("explicit-state");
+    expect(process.env.OPENCLAW_STATE_DIR).toBe("ambient-state");
+  });
+
+  it("snapshots ambient values for each non-empty state directory call", () => {
+    setTestEnvValue(AMBIENT_KEY, "first");
+    const first = openClawStateDatabaseOptionsForStateDir("first-state");
+    setTestEnvValue(AMBIENT_KEY, "second");
+    const second = openClawStateDatabaseOptionsForStateDir("second-state");
+
+    expect(first.env).not.toBe(second.env);
+    expect(first.env?.[AMBIENT_KEY]).toBe("first");
+    expect(second.env?.[AMBIENT_KEY]).toBe("second");
+    expect(first.env?.OPENCLAW_STATE_DIR).toBe("first-state");
+    expect(second.env?.OPENCLAW_STATE_DIR).toBe("second-state");
+  });
+});

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -120,6 +120,11 @@ export {
 export { ensureOpenClawStatePermissions } from "./openclaw-state-db-permissions.js";
 export { detectOpenClawStateDatabaseSchemaMigrations } from "./openclaw-state-db-schema-repair.js";
 
+// oxfmt-ignore
+export function openClawStateDatabaseOptionsForStateDir(stateDir?: string): OpenClawStateDatabaseOptions {
+  return stateDir ? { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } } : { env: process.env };
+}
+
 /** Reconfirm an advisory worker failure on the live owner connection. */
 export function confirmOpenClawStateDatabaseIntegrity(
   pathname: string,

--- a/src/tui/tui-last-session.ts
+++ b/src/tui/tui-last-session.ts
@@ -10,19 +10,16 @@ import {
 } from "../state/config-machine-state.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
-import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import {
+  openClawStateDatabaseOptionsForStateDir as stateDbOptions,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
 import type { TuiSessionList } from "./tui-backend.js";
 import type { SessionScope } from "./tui-types.js";
 
 type TuiLastSessionDatabase = Pick<OpenClawStateKyselyDatabase, "config_machine_state">;
 
 const TUI_LAST_SESSION_STATE_KEY_PREFIX = "tui.lastSession.";
-
-function stateDatabaseOptions(stateDir?: string) {
-  return stateDir
-    ? { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } }
-    : { env: process.env };
-}
 
 /** Builds a stable private-store key for the current TUI connection, agent, and session scope. */
 export function buildTuiLastSessionScopeKey(params: {
@@ -66,7 +63,7 @@ export async function readTuiLastSessionKey(params: {
 }): Promise<string | null> {
   const sessionKey = readConfigMachineStateWithMetadata<string>(
     `${TUI_LAST_SESSION_STATE_KEY_PREFIX}${params.scopeKey}`,
-    stateDatabaseOptions(params.stateDir),
+    stateDbOptions(params.stateDir),
   );
   const rememberedKey = sessionKey?.value.trim() ?? "";
   return rememberedKey && !isHeartbeatSessionKey(rememberedKey) ? rememberedKey : null;
@@ -85,7 +82,7 @@ export async function writeTuiLastSessionKey(params: {
   writeConfigMachineState(
     `${TUI_LAST_SESSION_STATE_KEY_PREFIX}${params.scopeKey}`,
     sessionKey,
-    stateDatabaseOptions(params.stateDir),
+    stateDbOptions(params.stateDir),
   );
 }
 
@@ -126,7 +123,7 @@ export function clearTuiLastSessionPointers(params: {
   if (params.sessionKeys.size === 0) {
     return 0;
   }
-  const options = stateDatabaseOptions(params.stateDir);
+  const options = stateDbOptions(params.stateDir);
   const matchingKeys = withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
     const rows = executeSqliteQuerySync(
       db,


### PR DESCRIPTION
## What Problem This Solves

State-directory database options were constructed independently across push, managed-image, TUI, and delivery-queue owners. Those copies could drift on empty-string handling, `process.env` identity, or environment snapshot behavior.

## Why This Change Was Made

The state database owner now exports one internal helper:

```ts
return stateDir
  ? { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } }
  : { env: process.env };
```

The change removes four private helpers and migrates the contract-identical APNs, Web Push, managed-image record, TUI last-session, and delivery-queue opens to that canonical path.

Boundaries retained:

- Falsy values, including `""`, preserve `process.env` identity.
- Truthy values create a fresh ambient-environment snapshot and override only `OPENCLAW_STATE_DIR`.
- `process.env` is never mutated.
- Event Web Push, device pairing/read-only, voice wake/routing, managed-image attachments, generic read-only, explicit database, and explicit path option builders remain unchanged.
- No plugin SDK/barrel, schema, migration, cache, config, protocol, API, permission, or persistence semantics changed.
- No changelog entry: this is an internal deterministic refactor.

## User Impact

No user-visible behavior changes. State-database callers now share one owner-defined option contract instead of maintaining duplicate implementations.

## Evidence

Focused behavior and owner tests:

- `node scripts/run-vitest.mjs src/state/openclaw-state-db-options.test.ts src/infra/push-apns.store.test.ts src/infra/push-web.test.ts src/gateway/managed-image-record-store.test.ts src/tui/tui-last-session.test.ts`
  - 56 tests passed.
- `node scripts/run-vitest.mjs src/infra/delivery-queue-sqlite.test.ts src/infra/delivery-queue-sqlite-claim.test.ts src/infra/outbound/delivery-queue-namespaces.test.ts`
  - 44 tests passed.
- The new test calls the real helper without implementation mocking and proves undefined/empty identity, truthy override isolation, no mutation, and per-call ambient snapshots.

Repository gates:

- `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 pnpm check:changed` passed.
  - The override is the gate's documented sparse-checkout deadcode escape hatch.
  - Core production typecheck, changed lint, native state schema v15, database-first storage, runtime sidecar, webhook/pairing, and import-cycle guards passed.
  - Core-test TSGo shards used the gate's repository-owned sparse-input skip. A full materialized attempt reached the shared checkout's missing `mermaid` dependency; no install or worktree reconcile was performed.
- `pnpm check:import-cycles` passed with zero runtime value cycles.
- Changed-file formatting and `git diff --check` passed.
- Build was not selected by `check:changed`.
- Exact local autoreview with Codex `gpt-5.6-sol` at high reasoning reported no accepted/actionable findings and correctness `0.99`.

LOC:

- Production: `+54/-76`, net `-22`.
- Tests: `+46/-0`.
- Total: `+100/-76` across nine files.

Sibling and overlap review:

- Delivery queue coverage includes the canonical store, claim transitions, and namespace ownership paths.
- https://github.com/openclaw/openclaw/pull/135542 and https://github.com/openclaw/openclaw/pull/135372 change state-database repair/backup behavior but do not move the options owner.
- https://github.com/openclaw/openclaw/pull/111464 changes state-database lease/close handling but does not move the options owner.
- https://github.com/openclaw/openclaw/pull/117266 touches a separate managed-image cleanup-claim hunk.
- https://github.com/openclaw/openclaw/pull/114636 and https://github.com/openclaw/openclaw/pull/111487 do not overlap this change.
- The branch was repeatedly rebased through current `origin/main`; intervening main commits did not modify any target file.

Codex contract gate:

- Personally inspected `../codex/codex-rs/cli/src/main.rs:220-245`.
- Personally inspected `../codex/codex-rs/cli/src/main.rs:2840-2870`.
- This refactor does not alter a Codex protocol or runtime interaction.

No Crabbox or live proof was run: the change is an internal deterministic options deduplication with no external API, channel-visible behavior, schema, or persistence change.
