### PR TITLE
refactor(cli): share gateway port validator

### DIFF
--- a/src/cli/shared/parse-port.ts
+++ b/src/cli/shared/parse-port.ts
@@ -1,9 +1,15 @@
-// CLI-facing TCP port parser wrapper.
+// CLI-facing TCP port parser and validator wrappers.
 import { parseTcpPort } from "../../infra/tcp-port.js";
-
-/** Re-export the canonical TCP port parser and limit for CLI callers. */
+import { formatPortRangeHint } from "../error-format.js";
 
 /** Parse a TCP port from unknown CLI/config input, returning null for invalid values. */
 export function parsePort(raw: unknown): number | null {
   return parseTcpPort(raw);
+}
+
+export function validateGatewayPortInput(value: unknown): string | undefined {
+  if (parsePort(value) === null) {
+    return formatPortRangeHint();
+  }
+  return undefined;
 }

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -7,8 +7,8 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { note } from "../../packages/terminal-core/src/note.js";
-import { formatPortRangeHint } from "../cli/error-format.js";
 import { parsePort } from "../cli/shared/parse-port.js";
+import { validateGatewayPortInput } from "../cli/shared/parse-port.js";
 import { resolveGatewayPort } from "../config/config.js";
 import type { GatewayTrustedProxyConfig } from "../config/types.gateway.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -35,13 +35,6 @@ import {
 
 type GatewayAuthChoice = "token" | "password" | "trusted-proxy";
 type GatewayTokenInputMode = "plaintext" | "ref";
-
-function validateGatewayPortInput(value: unknown): string | undefined {
-  if (parsePort(value) === null) {
-    return formatPortRangeHint();
-  }
-  return undefined;
-}
 
 /** Prompt for local Gateway network/auth settings and return config plus call token. */
 export async function promptGatewayConfig(

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -10,8 +10,8 @@ import {
 } from "../agents/agent-scope-config.js";
 import { describeCodexNativeWebSearch } from "../agents/codex-native-web-search.shared.js";
 import { formatCliCommand } from "../cli/command-format.js";
-import { formatPortRangeHint } from "../cli/error-format.js";
 import { parsePort } from "../cli/shared/parse-port.js";
+import { validateGatewayPortInput } from "../cli/shared/parse-port.js";
 import { readConfigFileSnapshotForWrite, resolveGatewayPort } from "../config/config.js";
 import { inheritLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { logConfigUpdated } from "../config/logging.js";
@@ -77,13 +77,6 @@ const GATEWAY_HINT_PROBE_TIMEOUT_MS = 300;
 const setupPluginConfigModuleLoader = createLazyImportLoader<SetupPluginConfigModule>(
   () => import("../wizard/setup.plugin-config.js"),
 );
-
-function validateGatewayPortInput(value: unknown): string | undefined {
-  if (parsePort(value) === null) {
-    return formatPortRangeHint();
-  }
-  return undefined;
-}
 
 function loadSetupPluginConfigModule(): Promise<SetupPluginConfigModule> {
   return setupPluginConfigModuleLoader.load();

--- a/src/wizard/setup.gateway-config.ts
+++ b/src/wizard/setup.gateway-config.ts
@@ -2,6 +2,7 @@
 import { validateDottedDecimalIPv4Input } from "@openclaw/net-policy/ipv4";
 import { formatPortRangeHint } from "../cli/error-format.js";
 import { parsePort } from "../cli/shared/parse-port.js";
+import { validateGatewayPortInput } from "../cli/shared/parse-port.js";
 import {
   normalizeGatewayTokenInput,
   randomToken,
@@ -60,13 +61,6 @@ function getLocalizedTailscaleExposureOptions() {
 
 function normalizeWizardTextInput(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
-}
-
-function validateGatewayPortInput(value: unknown): string | undefined {
-  if (parsePort(value) === null) {
-    return formatPortRangeHint();
-  }
-  return undefined;
 }
 
 export async function configureGatewayForSetup(


### PR DESCRIPTION
## What Problem This Solves

Gateway port prompts carried three byte-identical validation callbacks in separate configure and setup flows. That duplicated the same strict parser and range-message policy across adjacent CLI owners, making future drift unnecessarily easy.

## Why This Change Was Made

Moves the existing six-line validator into the internal shared CLI port module and routes all three prompt flows through it. Parsing, prompt text, error text, defaults, fallback behavior, proxy behavior, and public surfaces remain unchanged.

## User Impact

No user-visible behavior changes. Gateway port validation now has one internal implementation instead of three copies.

Production LOC: `+12/-26` across four files, net `-14`. Tests: `0`.

## Evidence

- `pnpm test src/cli/shared/parse-port.test.ts src/commands/configure.gateway.test.ts src/commands/configure.wizard.gateway.test.ts src/wizard/setup.gateway-config.test.ts`
  - Passed: 4 files, 114 tests.
- `pnpm check:import-cycles`
  - Passed: 0 runtime value cycles.
- `node_modules/.bin/oxfmt --check src/cli/shared/parse-port.ts src/commands/configure.gateway.ts src/commands/configure.wizard.ts src/wizard/setup.gateway-config.ts`
  - Passed.
- `git diff --check origin/main...HEAD`
  - Passed.
- Autoreview: scoped clean, no accepted/actionable findings; overall `0.99`.
- `pnpm check:changed -- src/cli/shared/parse-port.ts src/commands/configure.gateway.ts src/commands/configure.wizard.ts src/wizard/setup.gateway-config.ts`
  - Touched-file formatting, core typecheck, and preceding guards passed.
  - The full linked-worktree gate could not complete because an unrelated core-test shard could not resolve the existing `mermaid` dependency from `packages/mermaid-renderer`.
- `pnpm build`
  - Compilation and bundle phases completed.
  - Existing linked-worktree state blocked runtime postbuild: `node_modules/@openclaw/ai` resolved to a stale canonical checkout whose built diagnostics entry lacked the current-main `hasRetryableConnectionErrorCode` export. This branch does not touch that package or any failing plugin contract.

Coverage limitation: `parsePort` acceptance is directly tested. Setup invokes the validator callback and asserts the error-message substring. The configure gateway and configure wizard suites exercise the surrounding flows but do not directly invoke every validation callback, so this does not claim complete callback or exact error-text coverage.

Codex hard gate inspected:

- `../codex/codex-rs/cli/src/main.rs:220-245`
- `../codex/codex-rs/cli/src/main.rs:2840-2870`

Those sections are unrelated CLI/completion and prompt-normalization code.

No Crabbox or live proof was needed for this behavior-neutral internal refactor.
