### PR TITLE
test(file-transfer): reuse directory archive runtime

### DIFF
--- a/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
@@ -4,21 +4,46 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import * as tar from "tar";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { DIR_FETCH_HARD_MAX_BYTES, FILE_TRANSFER_SUBDIR } from "./descriptors.js";
 
+const appendFileTransferAudit = vi.fn(async () => undefined);
+const saveMediaBuffer = vi.fn<() => Promise<{ path: string }>>();
+const invokeNodeToolPayload = vi.fn<typeof import("./node-tool-invoke.js").invokeNodeToolPayload>();
+let createDirFetchTool: typeof import("./dir-fetch-tool.js").createDirFetchTool;
 let tmpRoot: string;
+
+beforeAll(async () => {
+  // Keep the real archive runtime stable; only the node payload and saved path vary per case.
+  vi.resetModules();
+  vi.doMock("openclaw/plugin-sdk/media-store", () => ({ saveMediaBuffer }));
+  vi.doMock("../shared/audit.js", () => ({ appendFileTransferAudit }));
+  vi.doMock("./node-tool-invoke.js", () => ({
+    readRequiredNodePath: (params: Record<string, unknown>) => ({
+      node: String(params.node),
+      requestedPath: String(params.path),
+    }),
+    invokeNodeToolPayload,
+  }));
+  ({ createDirFetchTool } = await import("./dir-fetch-tool.js"));
+});
 
 beforeEach(async () => {
   tmpRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "dir-fetch-tool-test-")));
 });
 
 afterEach(async () => {
+  appendFileTransferAudit.mockReset();
+  saveMediaBuffer.mockReset();
+  invokeNodeToolPayload.mockReset();
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+afterAll(() => {
   vi.doUnmock("openclaw/plugin-sdk/media-store");
   vi.doUnmock("../shared/audit.js");
   vi.doUnmock("./node-tool-invoke.js");
   vi.resetModules();
-  await fs.rm(tmpRoot, { recursive: true, force: true });
 });
 
 async function createTarBuffer(params: {
@@ -35,47 +60,30 @@ async function createTarBuffer(params: {
   return Buffer.concat(chunks);
 }
 
-async function importTool(tarBuffer: Buffer) {
+function prepareArchive(tarBuffer: Buffer) {
   const archivePath = path.join(tmpRoot, `archive-${randomUUID()}.tar.gz`);
-  const appendFileTransferAudit = vi.fn(async () => undefined);
-  const saveMediaBuffer = vi.fn(async () => {
+  saveMediaBuffer.mockImplementation(async () => {
     await fs.writeFile(archivePath, tarBuffer);
     return { path: archivePath };
   });
-  vi.resetModules();
-  vi.doMock("openclaw/plugin-sdk/media-store", () => ({
-    saveMediaBuffer,
+  invokeNodeToolPayload.mockImplementation(async () => ({
+    nodeId: "node-1",
+    nodeDisplayName: "Node One",
+    payload: {
+      ok: true,
+      path: "/tmp/project",
+      tarBase64: tarBuffer.toString("base64"),
+      tarBytes: tarBuffer.byteLength,
+      sha256: crypto.createHash("sha256").update(tarBuffer).digest("hex"),
+      fileCount: 3,
+    },
+    startedAt: Date.now(),
   }));
-  vi.doMock("../shared/audit.js", () => ({ appendFileTransferAudit }));
-  vi.doMock("./node-tool-invoke.js", () => ({
-    readRequiredNodePath: (params: Record<string, unknown>) => ({
-      node: String(params.node),
-      requestedPath: String(params.path),
-    }),
-    invokeNodeToolPayload: vi.fn(async () => ({
-      nodeId: "node-1",
-      nodeDisplayName: "Node One",
-      payload: {
-        ok: true,
-        path: "/tmp/project",
-        tarBase64: tarBuffer.toString("base64"),
-        tarBytes: tarBuffer.byteLength,
-        sha256: crypto.createHash("sha256").update(tarBuffer).digest("hex"),
-        fileCount: 3,
-      },
-      startedAt: Date.now(),
-    })),
-  }));
-  return {
-    archivePath,
-    appendFileTransferAudit,
-    saveMediaBuffer,
-    module: await import("./dir-fetch-tool.js"),
-  };
+  return archivePath;
 }
 
-async function executeDirFetch(module: typeof import("./dir-fetch-tool.js")) {
-  return await module.createDirFetchTool().execute("tool-call-1", {
+async function executeDirFetch() {
+  return await createDirFetchTool().execute("tool-call-1", {
     node: "node-1",
     path: "/tmp/project",
   });
@@ -94,9 +102,9 @@ describe("dir.fetch archive extraction", () => {
         await fs.writeFile(path.join(sourceDir, ".hidden", "note.txt"), "hidden member");
       },
     });
-    const { appendFileTransferAudit, module, saveMediaBuffer } = await importTool(tarBuffer);
+    prepareArchive(tarBuffer);
 
-    const result = await executeDirFetch(module);
+    const result = await executeDirFetch();
 
     expect(result).toMatchObject({
       content: [{ type: "text", text: expect.stringContaining("Fetched 4 files") }],
@@ -156,11 +164,11 @@ describe("dir.fetch archive extraction", () => {
           await fs.symlink("../auth/token", path.join(sourceDir, "data", "token-link"));
         },
       });
-      const { appendFileTransferAudit, archivePath, module } = await importTool(tarBuffer);
+      const archivePath = prepareArchive(tarBuffer);
 
       // A symlink entry used to hang extraction instead of rejecting; the test
       // timeout bounds settling, so a hang regression fails without a wall-clock race.
-      await expect(executeDirFetch(module)).rejects.toThrow(/dir\.fetch UNSAFE_ARCHIVE:.*link/iu);
+      await expect(executeDirFetch()).rejects.toThrow(/dir\.fetch UNSAFE_ARCHIVE:.*link/iu);
       await expect(fs.access(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
       expect(appendFileTransferAudit).toHaveBeenLastCalledWith(
         expect.objectContaining({ decision: "error", errorCode: "UNSAFE_ARCHIVE" }),
@@ -177,9 +185,9 @@ describe("dir.fetch archive extraction", () => {
           await fs.writeFile(path.join(sourceDir, "dir\\note.txt"), "canonical content");
         },
       });
-      const { module } = await importTool(tarBuffer);
+      prepareArchive(tarBuffer);
 
-      const result = await executeDirFetch(module);
+      const result = await executeDirFetch();
       const files = (result.details as { files: Array<{ relPath: string; localPath: string }> })
         .files;
       expect(files).toMatchObject([{ relPath: path.join("dir", "note.txt") }]);
@@ -194,9 +202,9 @@ describe("dir.fetch archive extraction", () => {
         await fs.writeFile(path.join(sourceDir, "large.bin"), Buffer.alloc(16 * 1024 * 1024 + 1));
       },
     });
-    const { appendFileTransferAudit, module } = await importTool(tarBuffer);
+    prepareArchive(tarBuffer);
 
-    await expect(executeDirFetch(module)).rejects.toThrow(
+    await expect(executeDirFetch()).rejects.toThrow(
       /dir\.fetch UNCOMPRESSED_TOO_LARGE: archive entry extracted size exceeds limit/iu,
     );
     expect(appendFileTransferAudit).toHaveBeenLastCalledWith(


### PR DESCRIPTION
The directory-fetch tests rebuilt the same real archive runtime for each archive case. Load that runtime once under three stable mocks, then reset only each case's payload, saved path, and audit calls. Every case still creates its own tool and temporary directory; the suite removes its mocks and module cache at teardown.

This keeps all four archive scenarios and their assertions, including real tar extraction, symlink rejection, path normalization, oversized entry rejection, and audit/cleanup behavior. It removes three owner imports, six module resets, and nine mock registrations on the POSIX run. Production is unchanged; tests +52/-44.

Validation: all 41 owner and sibling cases passed in one shuffled worker (seed 1469), including node-host directory fetch, directory listing, and file fetch. The changed-file type, architecture, dead-export, formatting, and lint checks passed. Independent Codex review and manual lifecycle/dependency review found no actionable issue.

The local checkout has fs-safe 0.5.6 while the lockfile pins 0.7.0. The pinned package's archive ownership and admission source was inspected separately; exact-head hosted tests with locked dependencies are required before landing. No local dependency reconciliation was performed.
