### PR TITLE
perf: avoid transient executable-header buffers

### DIFF
--- a/src/infra/system-run-mutable-file-policy.ts
+++ b/src/infra/system-run-mutable-file-policy.ts
@@ -105,32 +105,21 @@ export function resolvesToExistingFileSync(rawOperand: string, cwd: string | und
   }
 }
 
+// ELF, Mach-O, and fat executable headers, including both Mach-O byte orders.
+const BINARY_EXECUTABLE_MAGICS = new Set([
+  0x7f454c46, 0xfeedface, 0xcefaedfe, 0xfeedfacf, 0xcffaedfe, 0xcafebabe, 0xbebafeca, 0xcafebabf,
+  0xbfbafeca,
+]);
+
 function isKnownBinaryExecutableHeader(buffer: Buffer): boolean {
-  if (buffer.length >= 4 && buffer.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46]))) {
+  if (buffer.length >= 4 && BINARY_EXECUTABLE_MAGICS.has(buffer.readUInt32BE(0))) {
     return true;
   }
-  if (
-    buffer.length >= 4 &&
-    (buffer.subarray(0, 4).equals(Buffer.from([0xfe, 0xed, 0xfa, 0xce])) ||
-      buffer.subarray(0, 4).equals(Buffer.from([0xce, 0xfa, 0xed, 0xfe])) ||
-      buffer.subarray(0, 4).equals(Buffer.from([0xfe, 0xed, 0xfa, 0xcf])) ||
-      buffer.subarray(0, 4).equals(Buffer.from([0xcf, 0xfa, 0xed, 0xfe])) ||
-      buffer.subarray(0, 4).equals(Buffer.from([0xca, 0xfe, 0xba, 0xbe])) ||
-      buffer.subarray(0, 4).equals(Buffer.from([0xbe, 0xba, 0xfe, 0xca])) ||
-      buffer.subarray(0, 4).equals(Buffer.from([0xca, 0xfe, 0xba, 0xbf])) ||
-      buffer.subarray(0, 4).equals(Buffer.from([0xbf, 0xba, 0xfe, 0xca])))
-  ) {
-    return true;
-  }
-  if (buffer.length < 0x40 || !buffer.subarray(0, 2).equals(Buffer.from([0x4d, 0x5a]))) {
+  if (buffer.length < 0x40 || buffer.readUInt16BE(0) !== 0x4d5a) {
     return false;
   }
   const peOffset = buffer.readUInt32LE(0x3c);
-  return (
-    peOffset >= 0 &&
-    peOffset <= buffer.length - 4 &&
-    buffer.subarray(peOffset, peOffset + 4).equals(Buffer.from([0x50, 0x45, 0x00, 0x00]))
-  );
+  return peOffset <= buffer.length - 4 && buffer.readUInt32BE(peOffset) === 0x50450000;
 }
 
 export function isLikelyScriptLikePathSync(targetPath: string): boolean {
@@ -156,7 +145,7 @@ export function isLikelyScriptLikePathSync(targetPath: string): boolean {
   } catch {
     return true;
   }
-  if (header.length === 0 || header.subarray(0, 2).equals(Buffer.from("#!"))) {
+  if (header.length === 0 || (header[0] === 0x23 && header[1] === 0x21)) {
     return true;
   }
   return !isKnownBinaryExecutableHeader(header);


### PR DESCRIPTION
## What Problem This Solves

Node command preparation repeatedly allocated small comparison buffers while recognizing native executable headers. Every inspection recreated the same signatures before deciding whether a file needed script binding.

## Why This Change Was Made

Keep the fixed signatures as numbers and inspect the existing bounded read buffer directly. The classifier remains the single owner of this decision. All nine ELF/Mach-O/fat signatures, DOS/PE checks, shebang recognition, short reads, and the 1024-byte read window retain their meaning.

Filesystem ownership, symlink handling, mutable-file binding, approval consumption, and execution-time revalidation retain their existing boundaries. No public policy, configuration, dependency, or persistence change is introduced.

## User Impact

Command preparation creates fewer temporary objects with the same native/script classification and approval behavior. Production LOC: +10/-21 (net -11); test code unchanged.

## Evidence

An actual-filesystem probe ran 30,000 classifications across six formats. Comparison `Buffer.from` calls fell from 205,000 to zero, eliminating 750,000 requested comparison-buffer bytes; subarray views fell from 235,000 to 30,000. Required 1024-byte read buffers stayed unchanged. These are causal allocation-work counts, not retained-heap or RSS measurements.

Both versions matched on 141 filesystem cases, including all signatures, truncation, maximum unsigned PE offsets, read-window edges, symlinks, missing paths, and directories. A separate one-byte-at-a-time read probe matched on 137 files and 15,681 reads. The same 141 canonical tests passed before and after:

```sh
node scripts/run-vitest.mjs src/node-host/invoke-system-run-plan.test.ts src/infra/system-run-approval-binding.test.ts src/node-host/invoke-system-run.test.ts src/infra/boundary-file-read.test.ts
```

Separately built baseline and candidate each passed 39 assertions through a real foreground Gateway, headless node, and signed public clients on macOS. The flow covered an immutable native executable, denial without approval, allow-once execution, replay denial, unchanged approved script execution, and rejection after script bytes changed while approval was pending. The changed script's marker stayed absent. V8 coverage from the actual node process confirmed classifier execution. All four Gateway/node processes exited, their ports closed, and temporary state was removed.

The complete classification, file-read, preparation, approval-binding, Gateway sanitization, and execution owners were inspected, along with Node's actual integer-read implementation and existing approval documentation. Full changed-file checks and fresh isolated Codex autoreview passed. No native Codex runtime or live-provider behavior is claimed by this change.
