### PR TITLE
perf: let context memory own tool-set snapshots

### DIFF
--- a/src/agents/harness/context-engine-lifecycle.test.ts
+++ b/src/agents/harness/context-engine-lifecycle.test.ts
@@ -20,6 +20,7 @@ import {
   clearMemoryPluginState,
   registerMemoryPromptPreparation,
   registerTestMemoryPromptBuilder,
+  type MemoryPromptSectionParams,
 } from "../../plugins/memory-state.test-fixtures.js";
 import { compactContextEngineWithSafetyTimeout } from "../embedded-agent-runner/compaction-safety-timeout.js";
 import { OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE } from "../internal-runtime-context.js";
@@ -132,52 +133,64 @@ describe("harness context engine lifecycle", () => {
     }
   });
 
-  it("scopes async memory preparation to non-legacy assembly with sandbox context", async () => {
-    const prepare = vi.fn(async ({ sandboxed }) => [
-      "## Prepared Memory",
-      `sandboxed=${sandboxed}`,
-      "",
-    ]);
-    registerTestMemoryPromptBuilder(() => ["## Memory Recall", ""]);
-    registerMemoryPromptPreparation("memory-wiki", prepare);
-    const availableTools = new Set(["wiki_search"]);
-    const assemble = vi.fn(async (params: Parameters<ContextEngine["assemble"]>[0]) => ({
-      messages: params.messages,
-      estimatedTokens: 0,
-      systemPromptAddition: buildMemorySystemPromptAddition({
-        availableTools: params.availableTools ?? new Set(),
-        citationsMode: params.citationsMode,
-      }),
-    }));
-
-    try {
-      const result = await assembleHarnessContextEngine({
-        contextEngine: createContextEngine({ assemble }),
-        sessionId: sessionParams.sessionId,
-        sessionKey: "global",
-        agentId: "support",
-        messages: [textMessage("user", "visible ask", 1)],
-        availableTools,
-        citationsMode: "on",
-        sandboxed: true,
-        modelId: "gpt-test",
+  it.each([false, true])(
+    "isolates prepared memory tools across non-legacy turns with sandboxed=%s",
+    async (sandboxed) => {
+      const prepare = vi.fn(async (params: MemoryPromptSectionParams) => {
+        const tools = [...params.availableTools].join(",");
+        params.availableTools.add("preparer-only");
+        await Promise.resolve();
+        return ["## Prepared Memory", `sandboxed=${params.sandboxed}; tools=${tools}`, ""];
       });
-
-      expect(result?.systemPromptAddition).toBe(
-        "## Memory Recall\n\n## Prepared Memory\nsandboxed=true",
-      );
-      expect(prepare).toHaveBeenCalledWith(
-        expect.objectContaining({
-          agentId: "support",
-          agentSessionKey: "global",
-          sandboxed: true,
+      registerTestMemoryPromptBuilder(({ availableTools }) => {
+        availableTools.add("builder-only");
+        return ["## Memory Recall", ""];
+      });
+      registerMemoryPromptPreparation("memory-wiki", prepare);
+      const assemble = vi.fn(async (params: Parameters<ContextEngine["assemble"]>[0]) => ({
+        messages: params.messages,
+        estimatedTokens: 0,
+        systemPromptAddition: buildMemorySystemPromptAddition({
+          availableTools: params.availableTools ?? new Set(),
+          citationsMode: params.citationsMode,
         }),
-      );
-      expect(buildMemorySystemPromptAddition({ availableTools })).toBe("## Memory Recall");
-    } finally {
-      clearMemoryPluginState();
-    }
-  });
+      }));
+
+      try {
+        for (const toolNames of [undefined, [], ["wiki_search"], ["memory_search"]]) {
+          const availableTools = toolNames ? new Set(toolNames) : undefined;
+          const result = await assembleHarnessContextEngine({
+            contextEngine: createContextEngine({ assemble }),
+            sessionId: sessionParams.sessionId,
+            sessionKey: "global",
+            agentId: "support",
+            messages: [textMessage("user", "visible ask", 1)],
+            availableTools,
+            citationsMode: "on",
+            sandboxed,
+            modelId: "gpt-test",
+          });
+
+          expect(result?.systemPromptAddition).toBe(
+            `## Memory Recall\n\n## Prepared Memory\nsandboxed=${sandboxed}; tools=${(toolNames ?? []).join(",")}`,
+          );
+          expect([...(availableTools ?? [])]).toEqual(toolNames ?? []);
+          expect(prepare).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              agentId: "support",
+              agentSessionKey: "global",
+              sandboxed,
+            }),
+          );
+        }
+        expect(buildMemorySystemPromptAddition({ availableTools: new Set() })).toBe(
+          "## Memory Recall",
+        );
+      } finally {
+        clearMemoryPluginState();
+      }
+    },
+  );
 
   it("keeps hidden runtime-context custom messages out of assemble hooks", async () => {
     const visibleUser = textMessage("user", "visible ask", 1);

--- a/src/agents/harness/context-engine-lifecycle.ts
+++ b/src/agents/harness/context-engine-lifecycle.ts
@@ -212,7 +212,7 @@ export async function assembleHarnessContextEngine(params: {
         ? await assemble()
         : await runWithPreparedMemoryPromptSection(
             {
-              availableTools: new Set(params.availableTools),
+              availableTools: params.availableTools ?? new Set(),
               citationsMode: params.citationsMode,
               agentId: params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey),
               agentSessionKey: params.sessionKey,


### PR DESCRIPTION
## What Problem This Solves

Each context-engine preparation copied its available-tool set immediately before context memory copied that temporary set again. Long tool catalogs amplified the transient allocation without providing another ownership boundary.

## Why This Change Was Made

Pass the available set directly to context memory, which synchronously takes its existing private snapshot. Keep the empty-set path for omitted input and retain the separate snapshots passed to context engines and preparation callbacks. The legacy path is unchanged.

## User Impact

Context preparation allocates one fewer temporary set per supplied tool catalog, with the same tool availability, mutation isolation, and turn lifecycle. Production LOC is unchanged (+1/-1); tests are +57/-44 (net +13).

## Evidence

For 200 preparations with 64 available tools, intermediate sets fell from 200 to zero and copied intermediate entries from 12,800 to zero. The 4,096-tool stress fixture removed 819,200 intermediate entries. Required memory/engine/callback snapshots remained present; omitted-input behavior remained equal. These are owner allocation-work counts, not process RSS measurements.

160 tests passed across the harness, memory, preparation, and delegate owners. Existing cases now exercise caller, engine, and callback mutations, omitted input, legacy behavior, deferred preparation, and abort paths through the canonical boundary.

A fresh source Gateway ran two nonlegacy turns with a registered context-engine plugin, synthetic sandbox tool provider, and mock OpenAI HTTP endpoint. Model requests exposed `proof_alpha` then `proof_beta` as expected, mutations stayed isolated, both turns committed without quarantine, and chat history matched. The Gateway, clients, HTTP service, ports, and private state were cleaned up. This is actual Gateway behavior with controlled provider/tool fixtures; it does not claim vendor-native or OS-sandbox execution.

The complete harness, context-memory, delegate, embedded-history, and native prompt callers were inspected. Upstream Codex dynamic-tool protocol and application-server types were also read directly. Full changed-file checks and fresh isolated Codex autoreview passed. No configuration, SDK, schema, or persistence contract changes.
