### PR TITLE
fix(ui): restore keyboard navigation after switching submenus

### DIFF
--- a/patches/@awesome.me__webawesome@3.12.0.patch
+++ b/patches/@awesome.me__webawesome@3.12.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/chunks/chunk.JZGJWX35.js b/dist/chunks/chunk.JZGJWX35.js
-index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..88a02b047b464273e155d7f4c831efc18384bb39 100644
+index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..66e09365025b0e593e38d8410c8019d660081e16 100644
 --- a/dist/chunks/chunk.JZGJWX35.js
 +++ b/dist/chunks/chunk.JZGJWX35.js
 @@ -29,6 +29,7 @@ var WaDropdownItem = class extends WebAwesomeElement {
@@ -10,7 +10,19 @@ index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..88a02b047b464273e155d7f4c831efc1
      this.active = false;
      this.variant = "default";
      this.size = "m";
-@@ -67,7 +68,6 @@ var WaDropdownItem = class extends WebAwesomeElement {
+@@ -40,7 +41,10 @@ var WaDropdownItem = class extends WebAwesomeElement {
+     this.submenuOpen = false;
+     this.hasSubmenu = false;
+     this.handleSlotChange = () => {
+-      this.hasSubmenu = this.hasSlotController.test("submenu");
++      const hasSubmenu = this.hasSlotController.test("submenu");
++      // Retire the branch before losing the old submenu state and popup.
++      if (!hasSubmenu) void this.closeSubmenu();
++      this.hasSubmenu = hasSubmenu;
+       this.updateHasSubmenuState();
+       if (this.hasSubmenu) {
+         this.setAttribute("aria-haspopup", "menu");
+@@ -67,7 +71,6 @@ var WaDropdownItem = class extends WebAwesomeElement {
      /** Handles pointer enter to open the submenu on hover */
      this.handlePointerEnter = (event) => {
        if (event.pointerType === "mouse" && this.hasSubmenu && !this.disabled) {
@@ -18,7 +30,7 @@ index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..88a02b047b464273e155d7f4c831efc1
          this.submenuOpen = true;
        }
      };
-@@ -84,7 +84,15 @@ var WaDropdownItem = class extends WebAwesomeElement {
+@@ -84,7 +87,15 @@ var WaDropdownItem = class extends WebAwesomeElement {
    }
    disconnectedCallback() {
      super.disconnectedCallback();
@@ -35,7 +47,7 @@ index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..88a02b047b464273e155d7f4c831efc1
      this.removeEventListener?.("click", this.handleHostClick);
      this.removeEventListener?.("pointerenter", this.handlePointerEnter);
      this.shadowRoot?.removeEventListener?.("click", this.handleClick, { capture: true });
-@@ -127,11 +135,8 @@ var WaDropdownItem = class extends WebAwesomeElement {
+@@ -127,11 +138,8 @@ var WaDropdownItem = class extends WebAwesomeElement {
      }
      if (changedProperties.has("submenuOpen")) {
        this.customStates.set("submenu-open", this.submenuOpen);
@@ -49,7 +61,7 @@ index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..88a02b047b464273e155d7f4c831efc1
      }
    }
    /** Update the has-submenu custom state */
-@@ -140,22 +145,49 @@ var WaDropdownItem = class extends WebAwesomeElement {
+@@ -140,22 +148,51 @@ var WaDropdownItem = class extends WebAwesomeElement {
    }
    /** Opens the submenu. */
    async openSubmenu() {
@@ -70,6 +82,7 @@ index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..88a02b047b464273e155d7f4c831efc1
 +  /** Reconciles property and public-method requests through one submenu lifecycle. */
 +  async updateSubmenuVisibility(previousAnimation) {
 +    const submenu = this.submenuElement;
++    if (!this.submenuOpen) this.dispatchEvent(new Event("submenu-closing"));
 +    if (!this.hasSubmenu || !submenu || !this.isConnected) {
 +      await previousAnimation;
 +      return;
@@ -82,6 +95,7 @@ index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..88a02b047b464273e155d7f4c831efc1
 +    submenu.classList.remove("show", "hide");
 +    if (open) {
 +      this.notifyParentOfOpening();
++      if (!isCurrent()) return;
 +      submenu.showPopover?.();
 +      submenu.hidden = false;
 +      submenu.setAttribute("data-visible", "");
@@ -113,7 +127,19 @@ index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..88a02b047b464273e155d7f4c831efc1
    }
    /** Notifies the parent dropdown that this item is opening its submenu */
    notifyParentOfOpening() {
-@@ -177,18 +209,11 @@ var WaDropdownItem = class extends WebAwesomeElement {
+@@ -165,30 +202,15 @@ var WaDropdownItem = class extends WebAwesomeElement {
+       detail: { item: this }
+     });
+     this.dispatchEvent(event);
+-    const parent = this.parentElement;
+-    if (parent) {
+-      const siblings = [...parent.children].filter(
+-        (el) => el !== this && el.localName === "wa-dropdown-item" && el.getAttribute("slot") === this.getAttribute("slot") && el.submenuOpen
+-      );
+-      siblings.forEach((sibling) => {
+-        sibling.submenuOpen = false;
+-      });
+-    }
    }
    /** Closes the submenu. */
    async closeSubmenu() {
@@ -131,16 +157,49 @@ index 593bac0b7708fc0e908f9f8de650e45f8b3610ec..88a02b047b464273e155d7f4c831efc1
 -        submenu.hidePopover?.();
 -      }
 -    }
++    this.dispatchEvent(new Event("submenu-closing"));
 +    await this.updateComplete;
 +    return this.submenuAnimation;
    }
    /** Determines whether the item navigates when selected. Items with submenus never navigate. */
    isLink() {
+@@ -218,8 +240,9 @@ var WaDropdownItem = class extends WebAwesomeElement {
+   }
+   /** Gets all dropdown items in the submenu. */
+   getSubmenuItems() {
+-    return [...this.children].filter(
+-      (el) => el.localName === "wa-dropdown-item" && el.getAttribute("slot") === "submenu" && !el.hasAttribute("disabled")
++    const slot = this.submenuElement?.querySelector('slot[name="submenu"]');
++    return (slot?.assignedElements({ flatten: true }) ?? []).filter(
++      (el) => el.localName === "wa-dropdown-item" && !el.disabled
+     );
+   }
+   render() {
+@@ -278,7 +301,7 @@ var WaDropdownItem = class extends WebAwesomeElement {
+             >
+               <slot name="submenu"></slot>
+             </div>
+-          ` : ""}
++          ` : html`<slot name="submenu" hidden></slot>`}
+     `;
+   }
+ };
 diff --git a/dist/chunks/chunk.KZJTFPDQ.js b/dist/chunks/chunk.KZJTFPDQ.js
-index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..ece47ac72d6dff3538e5325fecaa2b66aa8de557 100644
+index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..7c076a5462bf77d2e3dc1f73335eaddbbb6054b9 100644
 --- a/dist/chunks/chunk.KZJTFPDQ.js
 +++ b/dist/chunks/chunk.KZJTFPDQ.js
-@@ -68,7 +68,7 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -58,17 +58,16 @@ var openDropdowns = /* @__PURE__ */ new Set();
+ var WaDropdown = class extends WebAwesomeElement {
+   constructor() {
+     super(...arguments);
+-    this.submenuCleanups = /* @__PURE__ */ new Map();
+     this.localize = new LocalizeController(this);
+     this.userTypedQuery = "";
+-    this.openSubmenuStack = [];
++    this.activeSubmenus = [];
+     this.open = false;
+     this.size = "m";
+     this.placement = "bottom-start";
      this.distance = 0;
      this.skidding = 0;
      /** Handles key down events when the menu is open */
@@ -149,7 +208,7 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..ece47ac72d6dff3538e5325fecaa2b66
        const isRtl = this.localize.dir() === "rtl";
        if (event.key === "Escape" && this.open && isTopDismissible(this)) {
          const trigger = this.getTrigger();
-@@ -78,22 +78,11 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -78,22 +77,11 @@ var WaDropdown = class extends WebAwesomeElement {
          trigger?.focus({ preventScroll: true });
          return;
        }
@@ -171,12 +230,12 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..ece47ac72d6dff3538e5325fecaa2b66
 -        activeItemIndex = activeItem ? items.indexOf(activeItem) : -1;
 -      }
 +      const items = currentSubmenuItem ? this.getSubmenuItems(currentSubmenuItem) : this.getItems();
-+      const activeItem = items.find((item) => item.active || item === focusedItem);
++      const activeItem = items.find((item) => item === focusedItem) ?? items.find((item) => item.active);
 +      const activeItemIndex = activeItem ? items.indexOf(activeItem) : -1;
        let itemToSelect;
        if (event.key === "ArrowUp") {
          event.preventDefault();
-@@ -113,38 +102,24 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -113,39 +101,23 @@ var WaDropdown = class extends WebAwesomeElement {
            itemToSelect = items[0];
          }
        }
@@ -201,9 +260,9 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..ece47ac72d6dff3538e5325fecaa2b66
 +      if (event.key === (isRtl ? "ArrowRight" : "ArrowLeft") && currentSubmenuItem) {
          event.preventDefault();
          event.stopPropagation();
-         const removedItem = this.removeFromSubmenuStack();
-         if (removedItem) {
-           removedItem.submenuOpen = false;
+-        const removedItem = this.removeFromSubmenuStack();
+-        if (removedItem) {
+-          removedItem.submenuOpen = false;
 -          setTimeout(() => {
 -            removedItem.focus({ preventScroll: true });
 -            removedItem.active = true;
@@ -214,14 +273,17 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..ece47ac72d6dff3538e5325fecaa2b66
 -              }
 -            });
 -          }, 0);
-+          // Returning focus belongs to this keypress, not a timer that can outlive a reopen.
-+          removedItem.focus({ preventScroll: true });
-+          const parentItems = removedItem.slot === "submenu" ? this.getSubmenuItems(removedItem.parentElement) : this.getItems();
-+          parentItems.forEach((item) => item.active = item === removedItem);
-         }
+-        }
++        // Closing retires ownership synchronously; only this keypress restores focus.
++        void currentSubmenuItem.closeSubmenu();
++        currentSubmenuItem.focus({ preventScroll: true });
++        const parent = this.getCurrentSubmenuItem();
++        const parentItems = parent ? this.getSubmenuItems(parent, true) : this.getItems(true);
++        parentItems.forEach((item) => item.active = item === currentSubmenuItem);
          return;
        }
-@@ -154,7 +129,7 @@ var WaDropdown = class extends WebAwesomeElement {
+       if (event.key === "Home" || event.key === "End") {
+@@ -154,7 +126,7 @@ var WaDropdown = class extends WebAwesomeElement {
          itemToSelect = event.key === "Home" ? items[0] : items[items.length - 1];
        }
        if (event.key === "Tab") {
@@ -230,7 +292,7 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..ece47ac72d6dff3538e5325fecaa2b66
        }
        if (event.key.length === 1 && !(event.metaKey || event.ctrlKey || event.altKey) && !(event.key === " " && this.userTypedQuery === "")) {
          clearTimeout(this.userTypedTimeout);
-@@ -180,19 +155,11 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -180,19 +152,11 @@ var WaDropdown = class extends WebAwesomeElement {
          itemToSelect.scrollIntoView({ block: "nearest" });
          return;
        }
@@ -251,7 +313,26 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..ece47ac72d6dff3538e5325fecaa2b66
          } else {
            this.makeSelection(activeItem, event);
          }
-@@ -241,15 +208,22 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -213,7 +177,8 @@ var WaDropdown = class extends WebAwesomeElement {
+     };
+     /** Handle global mouse movement for safe triangle logic */
+     this.handleGlobalMouseMove = (event) => {
+-      const currentSubmenuItem = this.getCurrentSubmenuItem();
++      const branch = this.activeSubmenus.at(-1);
++      const currentSubmenuItem = branch?.item;
+       if (!currentSubmenuItem?.submenuOpen || !currentSubmenuItem.submenuElement) return;
+       const submenuRect = currentSubmenuItem.submenuElement.getBoundingClientRect();
+       const isRtl = this.localize.dir() === "rtl";
+@@ -231,7 +196,7 @@ var WaDropdown = class extends WebAwesomeElement {
+       );
+       if (!isOverItem && !isOverSubmenu) {
+         setTimeout(() => {
+-          if (!submenuItemHovered && !submenuElementHovered) {
++          if (this.activeSubmenus.includes(branch) && !currentSubmenuItem.matches(":hover") && !currentSubmenuItem.submenuElement.matches(":hover")) {
+             currentSubmenuItem.submenuOpen = false;
+           }
+         }, 100);
+@@ -241,15 +206,20 @@ var WaDropdown = class extends WebAwesomeElement {
    handleSizeChange() {
      warnDeprecatedSize(this.localName, this.size);
    }
@@ -269,15 +350,15 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..ece47ac72d6dff3538e5325fecaa2b66
 +    openDropdowns.delete(this);
      clearInterval(this.userTypedTimeout);
      this.closeAllSubmenus();
-     this.submenuCleanups.forEach((cleanup) => cleanup());
-     this.submenuCleanups.clear();
+-    this.submenuCleanups.forEach((cleanup) => cleanup());
+-    this.submenuCleanups.clear();
 -    document.removeEventListener("mousemove", this.handleGlobalMouseMove);
 -    document.removeEventListener("keydown", this.handleDocumentKeyDown);
 -    document.removeEventListener("pointerdown", this.handleDocumentPointerDown);
      unregisterDismissible(this);
    }
    firstUpdated(changedProperties) {
-@@ -266,12 +240,7 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -266,12 +236,7 @@ var WaDropdown = class extends WebAwesomeElement {
          return;
        }
        this.customStates.set("open", this.open);
@@ -291,16 +372,62 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..ece47ac72d6dff3538e5325fecaa2b66
      }
      if (changedProperties.has("size")) {
        this.syncItemSizes();
-@@ -315,7 +284,7 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -300,104 +265,73 @@ var WaDropdown = class extends WebAwesomeElement {
+     );
+     items.forEach((item) => item.size = this.size);
    }
-   /** Gets the current active submenu item */
+-  /** Handles the submenu navigation stack */
+-  addToSubmenuStack(item) {
+-    const index = this.openSubmenuStack.indexOf(item);
+-    if (index !== -1) {
+-      this.openSubmenuStack = this.openSubmenuStack.slice(0, index + 1);
+-    } else {
+-      this.openSubmenuStack.push(item);
+-    }
+-  }
+-  /** Removes the last item from the submenu stack */
+-  removeFromSubmenuStack() {
+-    return this.openSubmenuStack.pop();
+-  }
+-  /** Gets the current active submenu item */
++  /** Gets the current active submenu item. */
    getCurrentSubmenuItem() {
 -    return this.openSubmenuStack.length > 0 ? this.openSubmenuStack[this.openSubmenuStack.length - 1] : void 0;
-+    return this.openSubmenuStack[this.openSubmenuStack.length - 1];
++    return this.activeSubmenus.at(-1)?.item;
    }
-   /** Closes all submenus in the dropdown. */
-   closeAllSubmenus() {
-@@ -347,57 +316,57 @@ var WaDropdown = class extends WebAwesomeElement {
+-  /** Closes all submenus in the dropdown. */
+-  closeAllSubmenus() {
+-    const items = this.getItems(true);
+-    items.forEach((item) => {
+-      item.submenuOpen = false;
+-    });
+-    this.openSubmenuStack = [];
+-  }
+-  /** Closes sibling submenus at the same level as the specified item. */
+-  closeSiblingSubmenus(item) {
+-    const parentDropdownItem = item.closest('wa-dropdown-item:not([slot="submenu"])');
+-    let siblingItems;
+-    if (parentDropdownItem) {
+-      siblingItems = this.getSubmenuItems(parentDropdownItem, true);
+-    } else {
+-      siblingItems = this.getItems(true);
+-    }
+-    siblingItems.forEach((siblingItem) => {
+-      if (siblingItem !== item && siblingItem.submenuOpen) {
+-        siblingItem.submenuOpen = false;
+-      }
+-    });
+-    if (!this.openSubmenuStack.includes(item)) {
+-      this.openSubmenuStack.push(item);
++  /** Retires an ancestor branch before its hide animations can complete. */
++  closeAllSubmenus(from = 0) {
++    // Remove ownership first: item close notifications may reenter this owner.
++    for (const { item, cleanup } of this.activeSubmenus.splice(from).reverse()) {
++      cleanup();
++      void item.closeSubmenu();
+     }
+   }
+   /** Get the slotted trigger button, a <wa-button> or <button> element */
    getTrigger() {
      return this.querySelector('[slot="trigger"]');
    }
@@ -360,17 +487,6 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..ece47ac72d6dff3538e5325fecaa2b66
 -    if (items.length > 0) {
 -      items.forEach((item, index) => item.active = index === 0);
 -      items[0].focus({ preventScroll: true });
--    }
--    this.dispatchEvent(new WaAfterShowEvent());
--  }
--  /** Hides the dropdown menu. This should only be called from within updated(). */
--  async hideMenu() {
--    if (!this.popup || !this.menu) return;
--    const hideEvent = new WaHideEvent({ source: this });
--    this.dispatchEvent(hideEvent);
--    if (hideEvent.defaultPrevented) {
--      this.open = true;
--      return;
 +    // Join canceled animation cleanup before reusing its class. Show and hide share
 +    // one CSS animation name, so overlapping helpers cannot own separate animations.
 +    this.menu.classList.remove("show", "hide");
@@ -390,6 +506,17 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..ece47ac72d6dff3538e5325fecaa2b66
 +      this.popup.active = false;
 +      this.dispatchEvent(new WaAfterHideEvent());
      }
+-    this.dispatchEvent(new WaAfterShowEvent());
+-  }
+-  /** Hides the dropdown menu. This should only be called from within updated(). */
+-  async hideMenu() {
+-    if (!this.popup || !this.menu) return;
+-    const hideEvent = new WaHideEvent({ source: this });
+-    this.dispatchEvent(hideEvent);
+-    if (hideEvent.defaultPrevented) {
+-      this.open = true;
+-      return;
+-    }
 -    this.open = false;
 -    openDropdowns.delete(this);
 -    unregisterDismissible(this);
@@ -404,6 +531,123 @@ index 11de1ac9d650dc1e2db6922f8fb6cd217bc13a4d..ece47ac72d6dff3538e5325fecaa2b66
    }
    /** Handles clicks on the menu. */
    handleMenuClick(event) {
+@@ -405,8 +339,6 @@ var WaDropdown = class extends WebAwesomeElement {
+     if (!item || item.disabled) return;
+     if (item.hasSubmenu) {
+       if (!item.submenuOpen) {
+-        this.closeSiblingSubmenus(item);
+-        this.addToSubmenuStack(item);
+         item.submenuOpen = true;
+       }
+       event.stopPropagation();
+@@ -433,60 +365,57 @@ var WaDropdown = class extends WebAwesomeElement {
+   handleTriggerClick() {
+     this.open = !this.open;
+   }
+-  /** Handles submenu opening events */
++  /** Keeps one composed ancestor branch, including forwarded submenu slots. */
+   handleSubmenuOpening(event) {
+-    const openingItem = event.detail.item;
+-    this.closeSiblingSubmenus(openingItem);
+-    this.addToSubmenuStack(openingItem);
+-    this.setupSubmenuPosition(openingItem);
+-    this.processSubmenuItems(openingItem);
++    event.stopPropagation();
++    const path = event.composedPath();
++    const branch = path.slice(0, path.indexOf(this)).filter((el) => el instanceof HTMLElement && el.localName === "wa-dropdown-item").reverse();
++    // A child requested during ancestor teardown cannot own an orphan popover.
++    if (branch.some((item) => !item.submenuOpen)) {
++      void event.detail.item.closeSubmenu();
++      return;
++    }
++    let shared = 0;
++    while (shared < branch.length && this.activeSubmenus[shared]?.item === branch[shared]) shared++;
++    // Repeated ancestor notifications must not discard its still-open descendants.
++    if (shared === branch.length) return;
++    this.closeAllSubmenus(shared);
++    for (const item of branch.slice(shared)) {
++      this.activeSubmenus.push({ item, cleanup: this.setupSubmenuPosition(item) });
++    }
+   }
+-  /** Sets up submenu positioning with autoUpdate */
++  /** Binds positioning and close notifications to this exact open lifetime. */
+   setupSubmenuPosition(item) {
+-    if (!item.submenuElement) return;
+-    this.cleanupSubmenuPosition(item);
++    const controller = new AbortController();
++    const { signal } = controller;
+     const cleanup = autoUpdate(item, item.submenuElement, () => {
+-      this.positionSubmenu(item);
++      this.positionSubmenu(item, () => !signal.aborted);
+       this.updateSafeTriangleCoordinates(item);
+     });
+-    this.submenuCleanups.set(item, cleanup);
++    // Listen on the item itself: a disconnected item's event cannot bubble here.
++    item.addEventListener("submenu-closing", () => {
++      const index = this.activeSubmenus.findIndex((entry) => entry.item === item);
++      if (index !== -1) this.closeAllSubmenus(index);
++    }, { signal });
+     const submenuSlot = item.submenuElement.querySelector('slot[name="submenu"]');
+-    if (submenuSlot) {
+-      submenuSlot.removeEventListener("slotchange", WaDropdown.handleSubmenuSlotChange);
+-      submenuSlot.addEventListener("slotchange", WaDropdown.handleSubmenuSlotChange);
+-      WaDropdown.handleSubmenuSlotChange({ target: submenuSlot });
+-    }
+-  }
+-  static handleSubmenuSlotChange(event) {
+-    const slot = event.target;
+-    if (!slot) return;
+-    const items = slot.assignedElements().filter((el) => el.localName === "wa-dropdown-item");
+-    if (items.length === 0) return;
+-    const hasSubmenuItems = items.some((item) => item.hasSubmenu);
+-    const hasCheckboxItems = items.some((item) => item.type === "checkbox");
+-    items.forEach((item) => {
+-      item.submenuAdjacent = hasSubmenuItems;
+-      item.checkboxAdjacent = hasCheckboxItems;
+-    });
++    submenuSlot?.addEventListener("slotchange", () => this.processSubmenuItems(item), { signal });
++    this.processSubmenuItems(item);
++    return () => {
++      controller.abort();
++      cleanup();
++    };
+   }
+   processSubmenuItems(item) {
+-    if (!item.submenuElement) return;
+-    const submenuItems = this.getSubmenuItems(item, true);
+-    const hasSubmenuItems = submenuItems.some((subItem) => subItem.hasSubmenu);
+-    submenuItems.forEach((subItem) => {
+-      subItem.submenuAdjacent = hasSubmenuItems;
++    const items = this.getSubmenuItems(item, true);
++    const hasSubmenu = items.some((child) => child.hasSubmenu);
++    const hasCheckbox = items.some((child) => child.type === "checkbox");
++    items.forEach((child) => {
++      child.submenuAdjacent = hasSubmenu;
++      child.checkboxAdjacent = hasCheckbox;
+     });
+   }
+-  /** Cleans up submenu positioning */
+-  cleanupSubmenuPosition(item) {
+-    const cleanup = this.submenuCleanups.get(item);
+-    if (cleanup) {
+-      cleanup();
+-      this.submenuCleanups.delete(item);
+-    }
+-  }
+   /** Positions a submenu relative to its parent item */
+-  positionSubmenu(item) {
++  positionSubmenu(item, isCurrent) {
+     if (!item.submenuElement) return;
+     const isRtl = this.localize.dir() === "rtl";
+     const placement = isRtl ? "left-start" : "right-start";
+@@ -506,6 +435,7 @@ var WaDropdown = class extends WebAwesomeElement {
+         })
+       ]
+     }).then(({ x, y, placement: placement2 }) => {
++      if (!isCurrent()) return;
+       item.submenuElement.setAttribute("data-placement", placement2);
+       Object.assign(item.submenuElement.style, {
+         left: `${x}px`,
 diff --git a/dist/chunks/chunk.L6CIKOFQ.js b/dist/chunks/chunk.L6CIKOFQ.js
 index 20d309f89017ef7d1857f3b1c88216a88354fefd..ea0b8ee34255009d9d9e86605dbdc05969ea3840 100644
 --- a/dist/chunks/chunk.L6CIKOFQ.js
@@ -455,19 +699,25 @@ index 20d309f89017ef7d1857f3b1c88216a88354fefd..ea0b8ee34255009d9d9e86605dbdc059
  function parseDuration(duration) {
    duration = duration.toString().toLowerCase();
 diff --git a/dist/components/dropdown/dropdown.d.ts b/dist/components/dropdown/dropdown.d.ts
-index 561ccfa258274c2c41cb728c0bfef26381c9f30c..7a7daf1c941e51f5104ad6342f4f4f49d3fd522d 100644
+index 561ccfa258274c2c41cb728c0bfef26381c9f30c..7da1ccc5e1a55eeef5df886f612449832dc01157 100644
 --- a/dist/components/dropdown/dropdown.d.ts
 +++ b/dist/components/dropdown/dropdown.d.ts
-@@ -34,6 +34,8 @@ export default class WaDropdown extends WebAwesomeElement {
+@@ -29,11 +29,12 @@ import '../popup/popup.js';
+  */
+ export default class WaDropdown extends WebAwesomeElement {
+     static css: import("lit").CSSResult[];
+-    private submenuCleanups;
+     private readonly localize;
      private userTypedQuery;
      private userTypedTimeout;
-     private openSubmenuStack;
+-    private openSubmenuStack;
++    private activeSubmenus;
 +    private menuTransition?;
 +    private menuAnimation?;
      defaultSlot: HTMLSlotElement;
      private menu;
      private popup;
-@@ -51,6 +53,7 @@ export default class WaDropdown extends WebAwesomeElement {
+@@ -51,6 +52,7 @@ export default class WaDropdown extends WebAwesomeElement {
      distance: number;
      /** The offset of the dropdown menu along its trigger. */
      skidding: number;
@@ -475,8 +725,22 @@ index 561ccfa258274c2c41cb728c0bfef26381c9f30c..7a7daf1c941e51f5104ad6342f4f4f49
      disconnectedCallback(): void;
      firstUpdated(changedProperties: PropertyValues<typeof this>): void;
      updated(changedProperties: PropertyValues<typeof this>): Promise<void>;
-@@ -72,10 +75,8 @@ export default class WaDropdown extends WebAwesomeElement {
-     private closeSiblingSubmenus;
+@@ -60,22 +62,14 @@ export default class WaDropdown extends WebAwesomeElement {
+     private getSubmenuItems;
+     /** Syncs item sizes with the dropdown's size property. */
+     private syncItemSizes;
+-    /** Handles the submenu navigation stack */
+-    private addToSubmenuStack;
+-    /** Removes the last item from the submenu stack */
+-    private removeFromSubmenuStack;
+-    /** Gets the current active submenu item */
++    /** Gets the current active submenu item. */
+     private getCurrentSubmenuItem;
+-    /** Closes all submenus in the dropdown. */
++    /** Retires an ancestor branch before its hide animations can complete. */
+     private closeAllSubmenus;
+-    /** Closes sibling submenus at the same level as the specified item. */
+-    private closeSiblingSubmenus;
      /** Get the slotted trigger button, a <wa-button> or <button> element */
      private getTrigger;
 -    /** Shows the dropdown menu. This should only be called from within updated(). */
@@ -488,6 +752,17 @@ index 561ccfa258274c2c41cb728c0bfef26381c9f30c..7a7daf1c941e51f5104ad6342f4f4f49
      /** Handles key down events when the menu is open */
      private handleDocumentKeyDown;
      /** Handles pointer down events when the dropdown is open. */
+@@ -90,10 +84,7 @@ export default class WaDropdown extends WebAwesomeElement {
+     private handleSubmenuOpening;
+     /** Sets up submenu positioning with autoUpdate */
+     private setupSubmenuPosition;
+-    private static handleSubmenuSlotChange;
+     private processSubmenuItems;
+-    /** Cleans up submenu positioning */
+-    private cleanupSubmenuPosition;
+     /** Positions a submenu relative to its parent item */
+     private positionSubmenu;
+     /** Updates the safe triangle coordinates for a submenu */
 diff --git a/dist/components/dropdown-item/dropdown-item.d.ts b/dist/components/dropdown-item/dropdown-item.d.ts
 index 1e458bc4c742d94cd58d688acde8a45f9c681763..477eac752d3d2c0a81ee3a59a80c09b81d972888 100644
 --- a/dist/components/dropdown-item/dropdown-item.d.ts
@@ -526,10 +801,21 @@ index bedb1923179f2a73be2eaf24e8c1a3c35718683d..04dc1c15097ad58de31a8670e2c870d3
  /** Parses a CSS duration and returns the number of milliseconds. */
  export declare function parseDuration(duration: number | string): number;
 diff --git a/dist-cdn/chunks/chunk.63RYV7SI.js b/dist-cdn/chunks/chunk.63RYV7SI.js
-index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..75fb3bc5a3e2870e855a1679cd4e2474ee90b404 100644
+index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..93d65f3128c2a4acb30c51ac3899b8d809f7ab33 100644
 --- a/dist-cdn/chunks/chunk.63RYV7SI.js
 +++ b/dist-cdn/chunks/chunk.63RYV7SI.js
-@@ -78,7 +78,7 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -68,17 +68,16 @@ var openDropdowns = /* @__PURE__ */ new Set();
+ var WaDropdown = class extends WebAwesomeElement {
+   constructor() {
+     super(...arguments);
+-    this.submenuCleanups = /* @__PURE__ */ new Map();
+     this.localize = new LocalizeController(this);
+     this.userTypedQuery = "";
+-    this.openSubmenuStack = [];
++    this.activeSubmenus = [];
+     this.open = false;
+     this.size = "m";
+     this.placement = "bottom-start";
      this.distance = 0;
      this.skidding = 0;
      /** Handles key down events when the menu is open */
@@ -538,7 +824,7 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..75fb3bc5a3e2870e855a1679cd4e2474
        const isRtl = this.localize.dir() === "rtl";
        if (event.key === "Escape" && this.open && isTopDismissible(this)) {
          const trigger = this.getTrigger();
-@@ -88,22 +88,11 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -88,22 +87,11 @@ var WaDropdown = class extends WebAwesomeElement {
          trigger?.focus({ preventScroll: true });
          return;
        }
@@ -560,12 +846,12 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..75fb3bc5a3e2870e855a1679cd4e2474
 -        activeItemIndex = activeItem ? items.indexOf(activeItem) : -1;
 -      }
 +      const items = currentSubmenuItem ? this.getSubmenuItems(currentSubmenuItem) : this.getItems();
-+      const activeItem = items.find((item) => item.active || item === focusedItem);
++      const activeItem = items.find((item) => item === focusedItem) ?? items.find((item) => item.active);
 +      const activeItemIndex = activeItem ? items.indexOf(activeItem) : -1;
        let itemToSelect;
        if (event.key === "ArrowUp") {
          event.preventDefault();
-@@ -123,38 +112,24 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -123,39 +111,23 @@ var WaDropdown = class extends WebAwesomeElement {
            itemToSelect = items[0];
          }
        }
@@ -590,9 +876,9 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..75fb3bc5a3e2870e855a1679cd4e2474
 +      if (event.key === (isRtl ? "ArrowRight" : "ArrowLeft") && currentSubmenuItem) {
          event.preventDefault();
          event.stopPropagation();
-         const removedItem = this.removeFromSubmenuStack();
-         if (removedItem) {
-           removedItem.submenuOpen = false;
+-        const removedItem = this.removeFromSubmenuStack();
+-        if (removedItem) {
+-          removedItem.submenuOpen = false;
 -          setTimeout(() => {
 -            removedItem.focus({ preventScroll: true });
 -            removedItem.active = true;
@@ -603,14 +889,17 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..75fb3bc5a3e2870e855a1679cd4e2474
 -              }
 -            });
 -          }, 0);
-+          // Returning focus belongs to this keypress, not a timer that can outlive a reopen.
-+          removedItem.focus({ preventScroll: true });
-+          const parentItems = removedItem.slot === "submenu" ? this.getSubmenuItems(removedItem.parentElement) : this.getItems();
-+          parentItems.forEach((item) => item.active = item === removedItem);
-         }
+-        }
++        // Closing retires ownership synchronously; only this keypress restores focus.
++        void currentSubmenuItem.closeSubmenu();
++        currentSubmenuItem.focus({ preventScroll: true });
++        const parent = this.getCurrentSubmenuItem();
++        const parentItems = parent ? this.getSubmenuItems(parent, true) : this.getItems(true);
++        parentItems.forEach((item) => item.active = item === currentSubmenuItem);
          return;
        }
-@@ -164,7 +139,7 @@ var WaDropdown = class extends WebAwesomeElement {
+       if (event.key === "Home" || event.key === "End") {
+@@ -164,7 +136,7 @@ var WaDropdown = class extends WebAwesomeElement {
          itemToSelect = event.key === "Home" ? items[0] : items[items.length - 1];
        }
        if (event.key === "Tab") {
@@ -619,7 +908,7 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..75fb3bc5a3e2870e855a1679cd4e2474
        }
        if (event.key.length === 1 && !(event.metaKey || event.ctrlKey || event.altKey) && !(event.key === " " && this.userTypedQuery === "")) {
          clearTimeout(this.userTypedTimeout);
-@@ -190,19 +165,11 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -190,19 +162,11 @@ var WaDropdown = class extends WebAwesomeElement {
          itemToSelect.scrollIntoView({ block: "nearest" });
          return;
        }
@@ -640,7 +929,26 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..75fb3bc5a3e2870e855a1679cd4e2474
          } else {
            this.makeSelection(activeItem, event);
          }
-@@ -251,15 +218,22 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -223,7 +187,8 @@ var WaDropdown = class extends WebAwesomeElement {
+     };
+     /** Handle global mouse movement for safe triangle logic */
+     this.handleGlobalMouseMove = (event) => {
+-      const currentSubmenuItem = this.getCurrentSubmenuItem();
++      const branch = this.activeSubmenus.at(-1);
++      const currentSubmenuItem = branch?.item;
+       if (!currentSubmenuItem?.submenuOpen || !currentSubmenuItem.submenuElement) return;
+       const submenuRect = currentSubmenuItem.submenuElement.getBoundingClientRect();
+       const isRtl = this.localize.dir() === "rtl";
+@@ -241,7 +206,7 @@ var WaDropdown = class extends WebAwesomeElement {
+       );
+       if (!isOverItem && !isOverSubmenu) {
+         setTimeout(() => {
+-          if (!submenuItemHovered && !submenuElementHovered) {
++          if (this.activeSubmenus.includes(branch) && !currentSubmenuItem.matches(":hover") && !currentSubmenuItem.submenuElement.matches(":hover")) {
+             currentSubmenuItem.submenuOpen = false;
+           }
+         }, 100);
+@@ -251,15 +216,20 @@ var WaDropdown = class extends WebAwesomeElement {
    handleSizeChange() {
      warnDeprecatedSize(this.localName, this.size);
    }
@@ -658,15 +966,15 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..75fb3bc5a3e2870e855a1679cd4e2474
 +    openDropdowns.delete(this);
      clearInterval(this.userTypedTimeout);
      this.closeAllSubmenus();
-     this.submenuCleanups.forEach((cleanup) => cleanup());
-     this.submenuCleanups.clear();
+-    this.submenuCleanups.forEach((cleanup) => cleanup());
+-    this.submenuCleanups.clear();
 -    document.removeEventListener("mousemove", this.handleGlobalMouseMove);
 -    document.removeEventListener("keydown", this.handleDocumentKeyDown);
 -    document.removeEventListener("pointerdown", this.handleDocumentPointerDown);
      unregisterDismissible(this);
    }
    firstUpdated(changedProperties) {
-@@ -276,12 +250,7 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -276,12 +246,7 @@ var WaDropdown = class extends WebAwesomeElement {
          return;
        }
        this.customStates.set("open", this.open);
@@ -680,16 +988,62 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..75fb3bc5a3e2870e855a1679cd4e2474
      }
      if (changedProperties.has("size")) {
        this.syncItemSizes();
-@@ -325,7 +294,7 @@ var WaDropdown = class extends WebAwesomeElement {
+@@ -310,104 +275,73 @@ var WaDropdown = class extends WebAwesomeElement {
+     );
+     items.forEach((item) => item.size = this.size);
    }
-   /** Gets the current active submenu item */
+-  /** Handles the submenu navigation stack */
+-  addToSubmenuStack(item) {
+-    const index = this.openSubmenuStack.indexOf(item);
+-    if (index !== -1) {
+-      this.openSubmenuStack = this.openSubmenuStack.slice(0, index + 1);
+-    } else {
+-      this.openSubmenuStack.push(item);
+-    }
+-  }
+-  /** Removes the last item from the submenu stack */
+-  removeFromSubmenuStack() {
+-    return this.openSubmenuStack.pop();
+-  }
+-  /** Gets the current active submenu item */
++  /** Gets the current active submenu item. */
    getCurrentSubmenuItem() {
 -    return this.openSubmenuStack.length > 0 ? this.openSubmenuStack[this.openSubmenuStack.length - 1] : void 0;
-+    return this.openSubmenuStack[this.openSubmenuStack.length - 1];
++    return this.activeSubmenus.at(-1)?.item;
    }
-   /** Closes all submenus in the dropdown. */
-   closeAllSubmenus() {
-@@ -357,57 +326,57 @@ var WaDropdown = class extends WebAwesomeElement {
+-  /** Closes all submenus in the dropdown. */
+-  closeAllSubmenus() {
+-    const items = this.getItems(true);
+-    items.forEach((item) => {
+-      item.submenuOpen = false;
+-    });
+-    this.openSubmenuStack = [];
+-  }
+-  /** Closes sibling submenus at the same level as the specified item. */
+-  closeSiblingSubmenus(item) {
+-    const parentDropdownItem = item.closest('wa-dropdown-item:not([slot="submenu"])');
+-    let siblingItems;
+-    if (parentDropdownItem) {
+-      siblingItems = this.getSubmenuItems(parentDropdownItem, true);
+-    } else {
+-      siblingItems = this.getItems(true);
+-    }
+-    siblingItems.forEach((siblingItem) => {
+-      if (siblingItem !== item && siblingItem.submenuOpen) {
+-        siblingItem.submenuOpen = false;
+-      }
+-    });
+-    if (!this.openSubmenuStack.includes(item)) {
+-      this.openSubmenuStack.push(item);
++  /** Retires an ancestor branch before its hide animations can complete. */
++  closeAllSubmenus(from = 0) {
++    // Remove ownership first: item close notifications may reenter this owner.
++    for (const { item, cleanup } of this.activeSubmenus.splice(from).reverse()) {
++      cleanup();
++      void item.closeSubmenu();
+     }
+   }
+   /** Get the slotted trigger button, a <wa-button> or <button> element */
    getTrigger() {
      return this.querySelector('[slot="trigger"]');
    }
@@ -749,17 +1103,6 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..75fb3bc5a3e2870e855a1679cd4e2474
 -    if (items.length > 0) {
 -      items.forEach((item, index) => item.active = index === 0);
 -      items[0].focus({ preventScroll: true });
--    }
--    this.dispatchEvent(new WaAfterShowEvent());
--  }
--  /** Hides the dropdown menu. This should only be called from within updated(). */
--  async hideMenu() {
--    if (!this.popup || !this.menu) return;
--    const hideEvent = new WaHideEvent({ source: this });
--    this.dispatchEvent(hideEvent);
--    if (hideEvent.defaultPrevented) {
--      this.open = true;
--      return;
 +    // Join canceled animation cleanup before reusing its class. Show and hide share
 +    // one CSS animation name, so overlapping helpers cannot own separate animations.
 +    this.menu.classList.remove("show", "hide");
@@ -779,6 +1122,17 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..75fb3bc5a3e2870e855a1679cd4e2474
 +      this.popup.active = false;
 +      this.dispatchEvent(new WaAfterHideEvent());
      }
+-    this.dispatchEvent(new WaAfterShowEvent());
+-  }
+-  /** Hides the dropdown menu. This should only be called from within updated(). */
+-  async hideMenu() {
+-    if (!this.popup || !this.menu) return;
+-    const hideEvent = new WaHideEvent({ source: this });
+-    this.dispatchEvent(hideEvent);
+-    if (hideEvent.defaultPrevented) {
+-      this.open = true;
+-      return;
+-    }
 -    this.open = false;
 -    openDropdowns.delete(this);
 -    unregisterDismissible(this);
@@ -793,6 +1147,123 @@ index 886b0e05a9d51bbe6636d1e394d49ef4edfb84fc..75fb3bc5a3e2870e855a1679cd4e2474
    }
    /** Handles clicks on the menu. */
    handleMenuClick(event) {
+@@ -415,8 +349,6 @@ var WaDropdown = class extends WebAwesomeElement {
+     if (!item || item.disabled) return;
+     if (item.hasSubmenu) {
+       if (!item.submenuOpen) {
+-        this.closeSiblingSubmenus(item);
+-        this.addToSubmenuStack(item);
+         item.submenuOpen = true;
+       }
+       event.stopPropagation();
+@@ -443,60 +375,57 @@ var WaDropdown = class extends WebAwesomeElement {
+   handleTriggerClick() {
+     this.open = !this.open;
+   }
+-  /** Handles submenu opening events */
++  /** Keeps one composed ancestor branch, including forwarded submenu slots. */
+   handleSubmenuOpening(event) {
+-    const openingItem = event.detail.item;
+-    this.closeSiblingSubmenus(openingItem);
+-    this.addToSubmenuStack(openingItem);
+-    this.setupSubmenuPosition(openingItem);
+-    this.processSubmenuItems(openingItem);
++    event.stopPropagation();
++    const path = event.composedPath();
++    const branch = path.slice(0, path.indexOf(this)).filter((el) => el instanceof HTMLElement && el.localName === "wa-dropdown-item").reverse();
++    // A child requested during ancestor teardown cannot own an orphan popover.
++    if (branch.some((item) => !item.submenuOpen)) {
++      void event.detail.item.closeSubmenu();
++      return;
++    }
++    let shared = 0;
++    while (shared < branch.length && this.activeSubmenus[shared]?.item === branch[shared]) shared++;
++    // Repeated ancestor notifications must not discard its still-open descendants.
++    if (shared === branch.length) return;
++    this.closeAllSubmenus(shared);
++    for (const item of branch.slice(shared)) {
++      this.activeSubmenus.push({ item, cleanup: this.setupSubmenuPosition(item) });
++    }
+   }
+-  /** Sets up submenu positioning with autoUpdate */
++  /** Binds positioning and close notifications to this exact open lifetime. */
+   setupSubmenuPosition(item) {
+-    if (!item.submenuElement) return;
+-    this.cleanupSubmenuPosition(item);
++    const controller = new AbortController();
++    const { signal } = controller;
+     const cleanup = autoUpdate(item, item.submenuElement, () => {
+-      this.positionSubmenu(item);
++      this.positionSubmenu(item, () => !signal.aborted);
+       this.updateSafeTriangleCoordinates(item);
+     });
+-    this.submenuCleanups.set(item, cleanup);
++    // Listen on the item itself: a disconnected item's event cannot bubble here.
++    item.addEventListener("submenu-closing", () => {
++      const index = this.activeSubmenus.findIndex((entry) => entry.item === item);
++      if (index !== -1) this.closeAllSubmenus(index);
++    }, { signal });
+     const submenuSlot = item.submenuElement.querySelector('slot[name="submenu"]');
+-    if (submenuSlot) {
+-      submenuSlot.removeEventListener("slotchange", WaDropdown.handleSubmenuSlotChange);
+-      submenuSlot.addEventListener("slotchange", WaDropdown.handleSubmenuSlotChange);
+-      WaDropdown.handleSubmenuSlotChange({ target: submenuSlot });
+-    }
+-  }
+-  static handleSubmenuSlotChange(event) {
+-    const slot = event.target;
+-    if (!slot) return;
+-    const items = slot.assignedElements().filter((el) => el.localName === "wa-dropdown-item");
+-    if (items.length === 0) return;
+-    const hasSubmenuItems = items.some((item) => item.hasSubmenu);
+-    const hasCheckboxItems = items.some((item) => item.type === "checkbox");
+-    items.forEach((item) => {
+-      item.submenuAdjacent = hasSubmenuItems;
+-      item.checkboxAdjacent = hasCheckboxItems;
+-    });
++    submenuSlot?.addEventListener("slotchange", () => this.processSubmenuItems(item), { signal });
++    this.processSubmenuItems(item);
++    return () => {
++      controller.abort();
++      cleanup();
++    };
+   }
+   processSubmenuItems(item) {
+-    if (!item.submenuElement) return;
+-    const submenuItems = this.getSubmenuItems(item, true);
+-    const hasSubmenuItems = submenuItems.some((subItem) => subItem.hasSubmenu);
+-    submenuItems.forEach((subItem) => {
+-      subItem.submenuAdjacent = hasSubmenuItems;
++    const items = this.getSubmenuItems(item, true);
++    const hasSubmenu = items.some((child) => child.hasSubmenu);
++    const hasCheckbox = items.some((child) => child.type === "checkbox");
++    items.forEach((child) => {
++      child.submenuAdjacent = hasSubmenu;
++      child.checkboxAdjacent = hasCheckbox;
+     });
+   }
+-  /** Cleans up submenu positioning */
+-  cleanupSubmenuPosition(item) {
+-    const cleanup = this.submenuCleanups.get(item);
+-    if (cleanup) {
+-      cleanup();
+-      this.submenuCleanups.delete(item);
+-    }
+-  }
+   /** Positions a submenu relative to its parent item */
+-  positionSubmenu(item) {
++  positionSubmenu(item, isCurrent) {
+     if (!item.submenuElement) return;
+     const isRtl = this.localize.dir() === "rtl";
+     const placement = isRtl ? "left-start" : "right-start";
+@@ -516,6 +445,7 @@ var WaDropdown = class extends WebAwesomeElement {
+         })
+       ]
+     }).then(({ x: x2, y, placement: placement2 }) => {
++      if (!isCurrent()) return;
+       item.submenuElement.setAttribute("data-placement", placement2);
+       Object.assign(item.submenuElement.style, {
+         left: `${x2}px`,
 diff --git a/dist-cdn/chunks/chunk.L6CIKOFQ.js b/dist-cdn/chunks/chunk.L6CIKOFQ.js
 index 20d309f89017ef7d1857f3b1c88216a88354fefd..ea0b8ee34255009d9d9e86605dbdc05969ea3840 100644
 --- a/dist-cdn/chunks/chunk.L6CIKOFQ.js
@@ -844,7 +1315,7 @@ index 20d309f89017ef7d1857f3b1c88216a88354fefd..ea0b8ee34255009d9d9e86605dbdc059
  function parseDuration(duration) {
    duration = duration.toString().toLowerCase();
 diff --git a/dist-cdn/chunks/chunk.W2C46OQX.js b/dist-cdn/chunks/chunk.W2C46OQX.js
-index da164574ce537b386894e751d6e9727cc9249d08..fb180692bc81c4b0efb8c8fd86f6fc121a7e3acd 100644
+index da164574ce537b386894e751d6e9727cc9249d08..4625393889d6d1b92bddc212b8ba407843f70136 100644
 --- a/dist-cdn/chunks/chunk.W2C46OQX.js
 +++ b/dist-cdn/chunks/chunk.W2C46OQX.js
 @@ -36,6 +36,7 @@ var WaDropdownItem = class extends WebAwesomeElement {
@@ -855,7 +1326,19 @@ index da164574ce537b386894e751d6e9727cc9249d08..fb180692bc81c4b0efb8c8fd86f6fc12
      this.active = false;
      this.variant = "default";
      this.size = "m";
-@@ -74,7 +75,6 @@ var WaDropdownItem = class extends WebAwesomeElement {
+@@ -47,7 +48,10 @@ var WaDropdownItem = class extends WebAwesomeElement {
+     this.submenuOpen = false;
+     this.hasSubmenu = false;
+     this.handleSlotChange = () => {
+-      this.hasSubmenu = this.hasSlotController.test("submenu");
++      const hasSubmenu = this.hasSlotController.test("submenu");
++      // Retire the branch before losing the old submenu state and popup.
++      if (!hasSubmenu) void this.closeSubmenu();
++      this.hasSubmenu = hasSubmenu;
+       this.updateHasSubmenuState();
+       if (this.hasSubmenu) {
+         this.setAttribute("aria-haspopup", "menu");
+@@ -74,7 +78,6 @@ var WaDropdownItem = class extends WebAwesomeElement {
      /** Handles pointer enter to open the submenu on hover */
      this.handlePointerEnter = (event) => {
        if (event.pointerType === "mouse" && this.hasSubmenu && !this.disabled) {
@@ -863,7 +1346,7 @@ index da164574ce537b386894e751d6e9727cc9249d08..fb180692bc81c4b0efb8c8fd86f6fc12
          this.submenuOpen = true;
        }
      };
-@@ -91,7 +91,15 @@ var WaDropdownItem = class extends WebAwesomeElement {
+@@ -91,7 +94,15 @@ var WaDropdownItem = class extends WebAwesomeElement {
    }
    disconnectedCallback() {
      super.disconnectedCallback();
@@ -880,7 +1363,7 @@ index da164574ce537b386894e751d6e9727cc9249d08..fb180692bc81c4b0efb8c8fd86f6fc12
      this.removeEventListener?.("click", this.handleHostClick);
      this.removeEventListener?.("pointerenter", this.handlePointerEnter);
      this.shadowRoot?.removeEventListener?.("click", this.handleClick, { capture: true });
-@@ -134,11 +142,8 @@ var WaDropdownItem = class extends WebAwesomeElement {
+@@ -134,11 +145,8 @@ var WaDropdownItem = class extends WebAwesomeElement {
      }
      if (changedProperties.has("submenuOpen")) {
        this.customStates.set("submenu-open", this.submenuOpen);
@@ -894,7 +1377,7 @@ index da164574ce537b386894e751d6e9727cc9249d08..fb180692bc81c4b0efb8c8fd86f6fc12
      }
    }
    /** Update the has-submenu custom state */
-@@ -147,22 +152,49 @@ var WaDropdownItem = class extends WebAwesomeElement {
+@@ -147,22 +155,51 @@ var WaDropdownItem = class extends WebAwesomeElement {
    }
    /** Opens the submenu. */
    async openSubmenu() {
@@ -915,6 +1398,7 @@ index da164574ce537b386894e751d6e9727cc9249d08..fb180692bc81c4b0efb8c8fd86f6fc12
 +  /** Reconciles property and public-method requests through one submenu lifecycle. */
 +  async updateSubmenuVisibility(previousAnimation) {
 +    const submenu = this.submenuElement;
++    if (!this.submenuOpen) this.dispatchEvent(new Event("submenu-closing"));
 +    if (!this.hasSubmenu || !submenu || !this.isConnected) {
 +      await previousAnimation;
 +      return;
@@ -927,6 +1411,7 @@ index da164574ce537b386894e751d6e9727cc9249d08..fb180692bc81c4b0efb8c8fd86f6fc12
 +    submenu.classList.remove("show", "hide");
 +    if (open) {
 +      this.notifyParentOfOpening();
++      if (!isCurrent()) return;
 +      submenu.showPopover?.();
 +      submenu.hidden = false;
 +      submenu.setAttribute("data-visible", "");
@@ -958,7 +1443,19 @@ index da164574ce537b386894e751d6e9727cc9249d08..fb180692bc81c4b0efb8c8fd86f6fc12
    }
    /** Notifies the parent dropdown that this item is opening its submenu */
    notifyParentOfOpening() {
-@@ -184,18 +216,11 @@ var WaDropdownItem = class extends WebAwesomeElement {
+@@ -172,30 +209,15 @@ var WaDropdownItem = class extends WebAwesomeElement {
+       detail: { item: this }
+     });
+     this.dispatchEvent(event);
+-    const parent = this.parentElement;
+-    if (parent) {
+-      const siblings = [...parent.children].filter(
+-        (el) => el !== this && el.localName === "wa-dropdown-item" && el.getAttribute("slot") === this.getAttribute("slot") && el.submenuOpen
+-      );
+-      siblings.forEach((sibling) => {
+-        sibling.submenuOpen = false;
+-      });
+-    }
    }
    /** Closes the submenu. */
    async closeSubmenu() {
@@ -976,25 +1473,53 @@ index da164574ce537b386894e751d6e9727cc9249d08..fb180692bc81c4b0efb8c8fd86f6fc12
 -        submenu.hidePopover?.();
 -      }
 -    }
++    this.dispatchEvent(new Event("submenu-closing"));
 +    await this.updateComplete;
 +    return this.submenuAnimation;
    }
    /** Determines whether the item navigates when selected. Items with submenus never navigate. */
    isLink() {
+@@ -225,8 +247,9 @@ var WaDropdownItem = class extends WebAwesomeElement {
+   }
+   /** Gets all dropdown items in the submenu. */
+   getSubmenuItems() {
+-    return [...this.children].filter(
+-      (el) => el.localName === "wa-dropdown-item" && el.getAttribute("slot") === "submenu" && !el.hasAttribute("disabled")
++    const slot = this.submenuElement?.querySelector('slot[name="submenu"]');
++    return (slot?.assignedElements({ flatten: true }) ?? []).filter(
++      (el) => el.localName === "wa-dropdown-item" && !el.disabled
+     );
+   }
+   render() {
+@@ -285,7 +308,7 @@ var WaDropdownItem = class extends WebAwesomeElement {
+             >
+               <slot name="submenu"></slot>
+             </div>
+-          ` : ""}
++          ` : html`<slot name="submenu" hidden></slot>`}
+     `;
+   }
+ };
 diff --git a/dist-cdn/components/dropdown/dropdown.d.ts b/dist-cdn/components/dropdown/dropdown.d.ts
-index 561ccfa258274c2c41cb728c0bfef26381c9f30c..7a7daf1c941e51f5104ad6342f4f4f49d3fd522d 100644
+index 561ccfa258274c2c41cb728c0bfef26381c9f30c..7da1ccc5e1a55eeef5df886f612449832dc01157 100644
 --- a/dist-cdn/components/dropdown/dropdown.d.ts
 +++ b/dist-cdn/components/dropdown/dropdown.d.ts
-@@ -34,6 +34,8 @@ export default class WaDropdown extends WebAwesomeElement {
+@@ -29,11 +29,12 @@ import '../popup/popup.js';
+  */
+ export default class WaDropdown extends WebAwesomeElement {
+     static css: import("lit").CSSResult[];
+-    private submenuCleanups;
+     private readonly localize;
      private userTypedQuery;
      private userTypedTimeout;
-     private openSubmenuStack;
+-    private openSubmenuStack;
++    private activeSubmenus;
 +    private menuTransition?;
 +    private menuAnimation?;
      defaultSlot: HTMLSlotElement;
      private menu;
      private popup;
-@@ -51,6 +53,7 @@ export default class WaDropdown extends WebAwesomeElement {
+@@ -51,6 +52,7 @@ export default class WaDropdown extends WebAwesomeElement {
      distance: number;
      /** The offset of the dropdown menu along its trigger. */
      skidding: number;
@@ -1002,8 +1527,22 @@ index 561ccfa258274c2c41cb728c0bfef26381c9f30c..7a7daf1c941e51f5104ad6342f4f4f49
      disconnectedCallback(): void;
      firstUpdated(changedProperties: PropertyValues<typeof this>): void;
      updated(changedProperties: PropertyValues<typeof this>): Promise<void>;
-@@ -72,10 +75,8 @@ export default class WaDropdown extends WebAwesomeElement {
-     private closeSiblingSubmenus;
+@@ -60,22 +62,14 @@ export default class WaDropdown extends WebAwesomeElement {
+     private getSubmenuItems;
+     /** Syncs item sizes with the dropdown's size property. */
+     private syncItemSizes;
+-    /** Handles the submenu navigation stack */
+-    private addToSubmenuStack;
+-    /** Removes the last item from the submenu stack */
+-    private removeFromSubmenuStack;
+-    /** Gets the current active submenu item */
++    /** Gets the current active submenu item. */
+     private getCurrentSubmenuItem;
+-    /** Closes all submenus in the dropdown. */
++    /** Retires an ancestor branch before its hide animations can complete. */
+     private closeAllSubmenus;
+-    /** Closes sibling submenus at the same level as the specified item. */
+-    private closeSiblingSubmenus;
      /** Get the slotted trigger button, a <wa-button> or <button> element */
      private getTrigger;
 -    /** Shows the dropdown menu. This should only be called from within updated(). */
@@ -1015,6 +1554,17 @@ index 561ccfa258274c2c41cb728c0bfef26381c9f30c..7a7daf1c941e51f5104ad6342f4f4f49
      /** Handles key down events when the menu is open */
      private handleDocumentKeyDown;
      /** Handles pointer down events when the dropdown is open. */
+@@ -90,10 +84,7 @@ export default class WaDropdown extends WebAwesomeElement {
+     private handleSubmenuOpening;
+     /** Sets up submenu positioning with autoUpdate */
+     private setupSubmenuPosition;
+-    private static handleSubmenuSlotChange;
+     private processSubmenuItems;
+-    /** Cleans up submenu positioning */
+-    private cleanupSubmenuPosition;
+     /** Positions a submenu relative to its parent item */
+     private positionSubmenu;
+     /** Updates the safe triangle coordinates for a submenu */
 diff --git a/dist-cdn/components/dropdown-item/dropdown-item.d.ts b/dist-cdn/components/dropdown-item/dropdown-item.d.ts
 index 1e458bc4c742d94cd58d688acde8a45f9c681763..477eac752d3d2c0a81ee3a59a80c09b81d972888 100644
 --- a/dist-cdn/components/dropdown-item/dropdown-item.d.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,7 +147,7 @@ overrides:
 packageExtensionsChecksum: sha256-zZ8fyodhMTumshonC7kktCqTPsiHL3UAyS9vltFAlMo=
 
 patchedDependencies:
-  '@awesome.me/webawesome@3.12.0': bc34fe9e2ae30000725c1a8361518c2fd62712eb65d6e23db44abd9a9d5131ff
+  '@awesome.me/webawesome@3.12.0': 56965f5288ab449b79b5cf0920c37325444105bfc76f146d339c954804671fee
   '@vitest/runner@4.1.11': 55258cdf55f944f5e9bfbc52251b3696225ca2993e2d9f56b90b88f764193d93
   matrix-js-sdk@42.2.0: 9e97147d99b86977d6665a676cdf853434ef61eee7cfb176bb66c9c48da599b4
   vitest@4.1.11: c21477c229514823498ab3a08311070cec46b1811e866bc1b3f6ff3f5720da2e
@@ -2525,7 +2525,7 @@ importers:
     dependencies:
       '@awesome.me/webawesome':
         specifier: 3.12.0
-        version: 3.12.0(patch_hash=bc34fe9e2ae30000725c1a8361518c2fd62712eb65d6e23db44abd9a9d5131ff)(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)
+        version: 3.12.0(patch_hash=56965f5288ab449b79b5cf0920c37325444105bfc76f146d339c954804671fee)(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)
       '@codemirror/commands':
         specifier: 6.11.0
         version: 6.11.0
@@ -9786,7 +9786,7 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
-  '@awesome.me/webawesome@3.12.0(patch_hash=bc34fe9e2ae30000725c1a8361518c2fd62712eb65d6e23db44abd9a9d5131ff)(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)':
+  '@awesome.me/webawesome@3.12.0(patch_hash=56965f5288ab449b79b5cf0920c37325444105bfc76f146d339c954804671fee)(@floating-ui/utils@0.2.12)(@types/node@26.2.0)(@types/react@19.2.18)':
     dependencies:
       '@ctrl/tinycolor': 4.1.0
       '@floating-ui/dom': 1.8.0

--- a/ui/src/components/web-awesome-dropdown-owner.browser.test.ts
+++ b/ui/src/components/web-awesome-dropdown-owner.browser.test.ts
@@ -1,0 +1,404 @@
+import { afterEach, describe, expect, it } from "vitest";
+import "@awesome.me/webawesome/dist/styles/themes/default.css";
+import "./web-awesome.ts";
+
+type Item = HTMLElementTagNameMap["wa-dropdown-item"];
+
+function item(label: string, ...children: Item[]) {
+  const element = document.createElement("wa-dropdown-item");
+  element.append(label);
+  for (const child of children) {
+    child.slot = "submenu";
+    element.append(child);
+  }
+  return element;
+}
+
+async function fixture(shadow = false) {
+  const leaf = item("Deep action");
+  const inner = item("Inner", leaf);
+  const middle = item("Middle", inner);
+  const alternateLeaf = item("Alternate action");
+  const alternate = item("Alternate", alternateLeaf);
+  const parent = item("More", middle, alternate);
+  const otherLeaf = item("Other action");
+  const other = item("Other", otherLeaf);
+  const first = item("Web search");
+  const disabled = item("Unavailable");
+  disabled.disabled = true;
+  const dropdown = document.createElement("wa-dropdown");
+  const trigger = document.createElement("button");
+  trigger.slot = "trigger";
+  trigger.textContent = "Actions";
+  dropdown.append(trigger, first, disabled, parent, other);
+  const outside = document.createElement("button");
+  outside.textContent = "Outside";
+  const host = document.createElement("div");
+  const root = shadow ? host.attachShadow({ mode: "open" }) : host;
+  root.append(dropdown, outside);
+  document.body.append(host);
+  const items = [
+    first,
+    disabled,
+    parent,
+    middle,
+    inner,
+    leaf,
+    alternate,
+    alternateLeaf,
+    other,
+    otherLeaf,
+  ];
+  await dropdown.updateComplete;
+  await Promise.all(items.map((entry) => entry.updateComplete));
+  dropdown.open = true;
+  await expect.poll(() => root.querySelector("wa-dropdown")?.open).toBe(true);
+  await expect.poll(() => focused()).toBe(first);
+  return {
+    host,
+    root,
+    dropdown,
+    trigger,
+    outside,
+    first,
+    disabled,
+    parent,
+    middle,
+    inner,
+    leaf,
+    alternate,
+    alternateLeaf,
+    other,
+    otherLeaf,
+  };
+}
+
+function focused(): Element | null {
+  let active = document.activeElement;
+  while (active?.shadowRoot?.activeElement) {
+    active = active.shadowRoot.activeElement;
+  }
+  return active;
+}
+
+async function hidden(...items: Item[]) {
+  await expect
+    .poll(() =>
+      items.every(
+        (entry) =>
+          !entry.submenuOpen &&
+          entry.submenuElement.hidden &&
+          !entry.submenuElement.matches(":popover-open"),
+      ),
+    )
+    .toBe(true);
+}
+
+async function back(key: string, trigger: Item) {
+  const { userEvent } = await import("vitest/browser");
+  await userEvent.keyboard(`{${key}}`);
+  expect(focused()).toBe(trigger);
+  expect(trigger.active).toBe(true);
+}
+
+afterEach(() => document.body.replaceChildren());
+
+describe.runIf("__vitest_browser__" in globalThis)("Web Awesome submenu owner", () => {
+  it.each(["ltr", "rtl"] as const)(
+    "returns to root after sibling replacement (%s)",
+    async (dir) => {
+      const { userEvent } = await import("vitest/browser");
+      const f = await fixture();
+      f.dropdown.dir = dir;
+      await f.parent.openSubmenu();
+      await f.other.openSubmenu();
+      await hidden(f.parent);
+      expect(focused()).toBe(f.otherLeaf);
+      if (dir === "rtl") {
+        // Placement flips at the left viewport edge; backward navigation stays RTL.
+        await expect
+          .poll(() => f.other.submenuElement.getAttribute("data-placement"))
+          .toMatch(/^right/);
+      }
+      await back(dir === "rtl" ? "ArrowRight" : "ArrowLeft", f.other);
+      await userEvent.keyboard("{ArrowDown}");
+      expect(focused()).toBe(f.first);
+      await userEvent.keyboard("{ArrowDown}");
+      expect(focused()).toBe(f.parent);
+      await userEvent.keyboard("{End}");
+      expect(focused()).toBe(f.other);
+      await userEvent.keyboard("{Home}");
+      expect(focused()).toBe(f.first);
+      await userEvent.keyboard("o");
+      expect(focused()).toBe(f.other);
+    },
+  );
+
+  it("preserves three ancestors, then retires only the replaced nested branch", async () => {
+    const f = await fixture();
+    await f.parent.openSubmenu();
+    await f.middle.openSubmenu();
+    await f.inner.openSubmenu();
+    expect([f.parent.submenuOpen, f.middle.submenuOpen, f.inner.submenuOpen]).toEqual([
+      true,
+      true,
+      true,
+    ]);
+    f.inner.disabled = true;
+    await f.alternate.openSubmenu();
+    expect(f.parent.submenuOpen).toBe(true);
+    await hidden(f.middle, f.inner);
+    expect(focused()).toBe(f.alternateLeaf);
+    await back("ArrowLeft", f.alternate);
+    await back("ArrowLeft", f.parent);
+  });
+
+  it("keeps the open child branch when an ancestor is opened repeatedly", async () => {
+    const f = await fixture();
+    await f.parent.openSubmenu();
+    await f.middle.openSubmenu();
+    await f.parent.openSubmenu();
+    // A batched property reversal notifies again without actually closing the ancestor.
+    f.parent.submenuOpen = false;
+    f.parent.submenuOpen = true;
+    await f.parent.updateComplete;
+    await f.parent.openSubmenu();
+    expect(f.middle.submenuOpen).toBe(true);
+    await back("ArrowLeft", f.middle);
+    await back("ArrowLeft", f.parent);
+  });
+
+  it.each(["method", "property", "hover"] as const)(
+    "retires a standalone %s close before navigation",
+    async (reason) => {
+      const { page, userEvent } = await import("vitest/browser");
+      const f = await fixture();
+      await f.other.openSubmenu();
+      if (reason === "method") {
+        await f.other.closeSubmenu();
+      } else if (reason === "property") {
+        f.other.submenuOpen = false;
+      } else {
+        await page.elementLocator(f.outside).hover();
+      }
+      f.outside.focus();
+      await hidden(f.other);
+      expect(focused()).toBe(f.outside);
+      f.other.focus();
+      await userEvent.keyboard("{ArrowDown}");
+      expect(focused()).toBe(f.first);
+    },
+  );
+
+  it.each(["ancestor", "root", "disconnect"] as const)(
+    "closes disabled descendants on %s retirement and remount",
+    async (reason) => {
+      const { userEvent } = await import("vitest/browser");
+      const f = await fixture();
+      await f.parent.openSubmenu();
+      await f.middle.openSubmenu();
+      f.middle.disabled = true;
+      if (reason === "ancestor") {
+        f.parent.submenuOpen = false;
+      } else if (reason === "root") {
+        f.dropdown.open = false;
+      } else {
+        f.parent.remove();
+      }
+      f.outside.focus();
+      await hidden(f.parent, f.middle);
+      expect(focused()).toBe(f.outside);
+      if (reason === "disconnect") {
+        f.other.before(f.parent);
+      }
+      if (reason === "root") {
+        await expect
+          .poll(() => f.dropdown.shadowRoot?.querySelector("wa-popup")?.active)
+          .toBe(false);
+        f.dropdown.open = true;
+        await expect.poll(() => focused()).toBe(f.first);
+      }
+      f.middle.disabled = false;
+      await f.parent.openSubmenu();
+      expect(focused()).toBe(f.middle);
+      await back("ArrowLeft", f.parent);
+      await userEvent.keyboard("{ArrowDown}");
+      expect(focused()).toBe(f.other);
+    },
+  );
+
+  it("retires direct item disconnection before another submenu opens", async () => {
+    const { userEvent } = await import("vitest/browser");
+    const f = await fixture();
+    await f.other.openSubmenu();
+    f.other.remove();
+    await hidden(f.other);
+    f.parent.focus();
+    await userEvent.keyboard("{ArrowDown}");
+    expect(focused()).toBe(f.first);
+    f.dropdown.append(f.other);
+    await f.other.openSubmenu();
+    await back("ArrowLeft", f.other);
+    await userEvent.keyboard("{ArrowDown}");
+    expect(focused()).toBe(f.first);
+  });
+
+  it("navigates sibling submenus through forwarded slots inside a shadow caller", async () => {
+    const { userEvent } = await import("vitest/browser");
+    const f = await fixture(true);
+    // A slot in the caller's shadow tree forwards light-DOM children to the submenu.
+    const forward = document.createElement("slot");
+    forward.name = "forwarded";
+    forward.slot = "submenu";
+    f.parent.replaceChildren("More", forward);
+    f.middle.slot = "forwarded";
+    f.alternate.slot = "forwarded";
+    f.host.append(f.middle, f.alternate);
+    await f.parent.updateComplete;
+    await f.parent.openSubmenu();
+    expect(focused()).toBe(f.middle);
+    await userEvent.keyboard("{ArrowRight}");
+    expect(focused()).toBe(f.inner);
+    await f.alternate.openSubmenu();
+    await hidden(f.middle);
+    await back("ArrowLeft", f.alternate);
+    await userEvent.keyboard("{Home}");
+    expect(focused()).toBe(f.middle);
+    await back("ArrowLeft", f.parent);
+    await userEvent.keyboard("{ArrowDown}");
+    expect(focused()).toBe(f.other);
+  });
+
+  it("keeps the new sibling focused when replacement interrupts an opening animation", async () => {
+    const f = await fixture();
+    let replaced = false;
+    f.parent.submenuElement.addEventListener(
+      "animationstart",
+      () => {
+        expect(
+          f.parent.submenuElement
+            .getAnimations()
+            .some((animation) => animation.playState === "running"),
+        ).toBe(true);
+        replaced = true;
+        void f.other.openSubmenu();
+      },
+      { once: true },
+    );
+    await f.parent.openSubmenu();
+    await expect.poll(() => replaced).toBe(true);
+    await hidden(f.parent);
+    await expect.poll(() => focused()).toBe(f.otherLeaf);
+    await back("ArrowLeft", f.other);
+  });
+
+  it("does not let an interrupted close retire a reopened child branch", async () => {
+    const f = await fixture();
+    await f.parent.openSubmenu();
+    await f.middle.openSubmenu();
+    let reopened: Promise<unknown> | undefined;
+    f.parent.submenuElement.addEventListener(
+      "animationstart",
+      () => {
+        reopened = f.parent.openSubmenu().then(() => f.middle.openSubmenu());
+      },
+      { once: true },
+    );
+    await f.parent.closeSubmenu();
+    await expect.poll(() => reopened !== undefined).toBe(true);
+    await reopened;
+    expect(f.parent.submenuElement.matches(":popover-open")).toBe(true);
+    expect(f.middle.submenuElement.matches(":popover-open")).toBe(true);
+    expect(focused()).toBe(f.inner);
+    await back("ArrowLeft", f.middle);
+    await back("ArrowLeft", f.parent);
+  });
+
+  it.each(["mouse", "touch", "pen"] as const)(
+    "replaces siblings through %s input without hover opening on touch or pen",
+    async (pointerType) => {
+      const { page } = await import("vitest/browser");
+      const f = await fixture();
+      await f.parent.openSubmenu();
+      if (pointerType === "mouse") {
+        await page.elementLocator(f.other).hover();
+      } else {
+        f.other.dispatchEvent(new PointerEvent("pointerenter", { pointerType }));
+        await f.other.updateComplete;
+        expect(f.other.submenuOpen).toBe(false);
+        f.other.click();
+      }
+      await hidden(f.parent);
+      await expect.poll(() => focused()).toBe(f.otherLeaf);
+      await back("ArrowLeft", f.other);
+    },
+  );
+
+  it("rejects a pending child opening beneath a closing ancestor", async () => {
+    const f = await fixture();
+    await f.parent.openSubmenu();
+    f.parent.submenuOpen = false;
+    f.middle.submenuOpen = true;
+    await hidden(f.parent, f.middle);
+    await f.other.openSubmenu();
+    expect(focused()).toBe(f.otherLeaf);
+    await back("ArrowLeft", f.other);
+  });
+
+  it("returns to the surviving level before a property hide animation finishes", async () => {
+    const f = await fixture();
+    await f.other.openSubmenu();
+    let navigation: { running: boolean; focused: Element | null } | undefined;
+    f.other.submenuElement.addEventListener(
+      "animationstart",
+      () => {
+        const running = f.other.submenuElement
+          .getAnimations()
+          .some((animation) => animation.playState === "running");
+        f.other.focus();
+        f.other.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, composed: true }),
+        );
+        navigation = { running, focused: focused() };
+      },
+      { once: true },
+    );
+    f.other.submenuOpen = false;
+    await hidden(f.other);
+    expect(navigation).toEqual({ running: true, focused: f.first });
+  });
+
+  it.each(["removal", "slot reassignment"] as const)(
+    "retires an emptied submenu after last-child %s and supports restoration",
+    async (change) => {
+      const { userEvent } = await import("vitest/browser");
+      const f = await fixture();
+      await f.other.openSubmenu();
+      const retiredSubmenu = f.other.submenuElement;
+      if (change === "removal") {
+        f.otherLeaf.remove();
+      } else {
+        f.otherLeaf.slot = "details";
+      }
+      await expect.poll(() => f.other.hasSubmenu).toBe(false);
+      await expect.poll(() => retiredSubmenu.isConnected).toBe(false);
+      f.other.focus();
+      await userEvent.keyboard("{ArrowDown}");
+      expect(focused()).toBe(f.first);
+      expect(f.other.submenuOpen).toBe(false);
+      expect(retiredSubmenu.matches(":popover-open")).toBe(false);
+
+      f.otherLeaf.slot = "submenu";
+      if (change === "removal") {
+        f.other.append(f.otherLeaf);
+      }
+      await expect.poll(() => f.other.submenuElement?.isConnected).toBe(true);
+      await f.other.openSubmenu();
+      expect(focused()).toBe(f.otherLeaf);
+      expect(f.other.submenuElement.matches(":popover-open")).toBe(true);
+      await back("ArrowLeft", f.other);
+      await userEvent.keyboard("{ArrowDown}");
+      expect(focused()).toBe(f.first);
+    },
+  );
+});


### PR DESCRIPTION
Closes #135613

Related: https://github.com/openclaw/openclaw/pull/135006 — the earlier hide/reopen dismissal and animation repair remains intact. This fixes a separately reproduced, pre-existing submenu ownership defect.

## What Problem This Solves

Fixes an issue where users switching between sibling submenus in Control UI action menus could no longer navigate the visible parent menu with the keyboard. In the actual sidebar session menu, Move to group → Copy → ArrowLeft → ArrowDown left focus on Copy instead of moving to Open in. A minimal menu with B as its final item also failed to wrap back to the first root item.

The same stale ownership affected public/property/hover closure, deeper nesting, and removing or reassigning the final child of an open submenu. The primary sibling sequence also reproduces on pristine Web Awesome 3.12.0 (`03bc24f7e2409fcaaff1bec8b66c9b96949061d6`), so it was not introduced by the earlier OpenClaw animation repair.

## Why This Change Was Made

Web Awesome's dropdown now owns one active composed ancestor branch and the positioning/listener cleanup for each open lifetime, rather than combining opening history with separate item-level sibling policy. Closing or replacing a branch retires its navigation ownership before awaited animation completion; slot loss enters that same lifecycle before discarding the old submenu state.

The repair removes duplicate sibling scans, ad hoc push/pop producers, a separate cleanup map, and redundant submenu preparation. It preserves real ancestors, reason-specific focus, forwarded slots, RTL behavior, disabled-item handling, and the earlier generation-fenced animation work. The existing exact-version 3.12.0 patch is extended with explicit maintainer approval; there is no version bump, new dependency override, config/protocol/schema change, or UI framework migration.

## User Impact

Keyboard navigation resumes at the correct visible menu level after submenu switches and closure. Nested branches close without leaving orphaned state, and dynamically emptied submenus no longer trap navigation. No operator configuration change is needed.

Logical production runtime: **+70/-111 (net -41 lines)** in the normal distribution; the CDN mirror repeats the same change (net -82 shipped runtime lines). Private dropdown declarations shrink by 10 lines per distribution. Tests: **+404 lines, 21 owner cases**. The larger raw patch-file diff consists of patch context and existing hunks, not production growth. The lockfile changes only three patch-hash references; dependency versions and the rest of the graph are unchanged.

## Evidence

- **56/56** installed Chromium tests passed: all 21 owner cases plus 35 existing dropdown-lifecycle/menu-surface cases.
- Against the immutable pre-fix installed baseline, the exact latest owner test has **15 intended failures / 6 existing-behavior passes**, with no skips or unhandled assertions. The new cases include sibling switching, deep ancestors, disabled descendants, method/property/hover close, direct disconnection/remount, forwarded slots, interrupted animations, and last-child removal/slot reassignment with restoration.
- Real source-mode Control UI with the canonical synthetic Gateway: Move to group → Copy → ArrowLeft → ArrowDown now focuses Open in. End/ArrowDown root wrapping, Home, and Escape also passed with no page errors. This is actual browser/application interaction using synthetic data, not a live provider or operator Gateway.
- Native lock update and frozen installation passed; all **2,280 package-owned installed files** match the verified candidate. pnpm-managed nested dependencies were separately checked against their declared, exactly locked versions. Existing animation-repair files remain unchanged.
- Production Control UI build, targeted formatting/type/lint checks, dependency-patch guard, CDN JavaScript syntax, and diff checks passed. Fresh independent Codex review returned scoped-clean at the configured P0 threshold.

Core browser command:

```bash
node scripts/run-vitest.mjs run --config ui/vitest.config.ts --project browser ui/src/components/web-awesome-dropdown-owner.browser.test.ts ui/src/components/web-awesome-dropdown.browser.test.ts ui/src/components/menu-surface.browser.test.ts
```

Production UI build:

```bash
pnpm ui:build
```

The local proof is Chromium on macOS, not a full Safari/assistive-technology matrix. CDN owner bytes and syntax were checked; no separate CDN browser run is claimed. Exact-head hosted CI and native landing-gate results will be recorded before merge.

### Before/after visual proof

Real application screenshots and a short video were captured and inspected in full, using only synthetic fixture data. The screenshots are attached below; the video and complete state trace are retained locally. The repaired package and owner test are byte-identical after rebase.

**Before:** after both submenus finish hiding, ArrowDown leaves focus on Copy.

![Before: focus remains on Copy](https://github.com/user-attachments/assets/52df36f8-20c4-4e7a-9a39-c6f1dd8b6ea7)

**After:** the same interaction resumes parent-menu navigation and focuses Open in.

![After: focus advances to Open in](https://github.com/user-attachments/assets/d12baf1a-a951-48e1-8fd0-5a0173d67200)

Initial attachment attempts were rate-limited and the approved artifact fallback was unavailable. The standard GitHub upload succeeded after cooldown; no authentication or service configuration was changed. [Proof comment](https://github.com/openclaw/openclaw/pull/135629#issuecomment-5502151665).

