### PR TITLE
refactor(gateway): share unauthorized upgrade rejection

### DIFF
--- a/src/gateway/desktop/node-stream-broker.ts
+++ b/src/gateway/desktop/node-stream-broker.ts
@@ -8,6 +8,7 @@ import {
   NODE_DESKTOP_ATTACH_PATH,
   NODE_PORTAL_ATTACH_PATH,
 } from "../../shared/node-desktop-stream.js";
+import { rejectUnauthorizedUpgrade } from "../http-upgrade-rejection.js";
 import type { NodeRegistry } from "../node-registry.js";
 import { startWebSocketKeepalive } from "../websocket-keepalive.js";
 
@@ -98,11 +99,6 @@ function parseStreamMetadata(
     registerSecretValueForRedaction(vncPassword);
   }
   return { auth: value.auth, ...(vncPassword ? { vncPassword } : {}) };
-}
-
-function writeUnauthorized(socket: Duplex): void {
-  socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
-  socket.destroy();
 }
 
 function readAttachedStream(
@@ -285,12 +281,12 @@ export function createNodeDesktopStreamBroker(deps: { ttlMs?: number; now?: () =
     }
     const ticket = (resource.searchParams.get("ticket") ?? "").trim();
     if (!TICKET_PATTERN.test(ticket)) {
-      writeUnauthorized(socket);
+      rejectUnauthorizedUpgrade(socket);
       return true;
     }
     const entry = tickets.get(ticket);
     if (!entry || entry.kind !== kind || entry.redeemed || entry.expiresAtMs <= now()) {
-      writeUnauthorized(socket);
+      rejectUnauthorizedUpgrade(socket);
       if (entry && entry.kind === kind && !entry.redeemed) {
         rejectTicket(ticket, new Error(`node ${kind} stream ticket expired`));
       }
@@ -317,7 +313,7 @@ export function createNodeDesktopStreamBroker(deps: { ttlMs?: number; now?: () =
       socket.off("error", onSocketError);
       socket.off("end", onSocketClose);
       socket.off("close", onSocketClose);
-      writeUnauthorized(socket);
+      rejectUnauthorizedUpgrade(socket);
       rejectTicket(ticket, new Error(`node ${kind} stream ticket binding is stale`));
       return true;
     }

--- a/src/gateway/desktop/observe-bridge.ts
+++ b/src/gateway/desktop/observe-bridge.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
+import { rejectUnauthorizedUpgrade } from "../http-upgrade-rejection.js";
 import { startWebSocketKeepalive } from "../websocket-keepalive.js";
 import { connectRfbAttachment, type DesktopRfbAttachment } from "./attachment.js";
 import {
@@ -98,11 +99,6 @@ function consumeDesktopObserverToken(
   return entry.expiresAt > nowMs ? entry : undefined;
 }
 
-function writeUnauthorized(socket: Duplex): void {
-  socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
-  socket.destroy();
-}
-
 function rawDataBuffer(data: RawData): Buffer {
   if (Buffer.isBuffer(data)) {
     return data;
@@ -190,7 +186,7 @@ export function handleDesktopObserveUpgrade(
   const token = resource.searchParams.get("token") ?? "";
   const entry = consumeDesktopObserverToken(token);
   if (!entry) {
-    writeUnauthorized(socket);
+    rejectUnauthorizedUpgrade(socket);
     return true;
   }
   desktopObserverWss.handleUpgrade(req, socket, head, (ws) => {

--- a/src/gateway/http-upgrade-rejection.ts
+++ b/src/gateway/http-upgrade-rejection.ts
@@ -1,0 +1,6 @@
+import type { Duplex } from "node:stream";
+
+export function rejectUnauthorizedUpgrade(socket: Duplex): void {
+  socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+  socket.destroy();
+}

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -11,6 +11,7 @@ import type { PluginHttpRouteRegistration, PluginRegistry } from "../../plugins/
 import { withPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { respondControlUiPluginAuthCookieProbe } from "../control-ui-plugin-auth-cookie.js";
 import { finishFailedGatewayHttpResponse } from "../http-common.js";
+import { rejectUnauthorizedUpgrade } from "../http-upgrade-rejection.js";
 import type { AuthorizedGatewayHttpRequest } from "../http-utils.js";
 import type { GatewayRequestContext, GatewayRequestOptions } from "../server-methods/types.js";
 import {
@@ -80,11 +81,6 @@ function createPluginRouteRuntimeClient(
       scopes: [...scopes],
     },
   };
-}
-
-function writeUpgradeUnauthorized(socket: Duplex) {
-  socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
-  socket.destroy();
 }
 
 type PluginRouteRuntimeDispatchContext = {
@@ -320,7 +316,7 @@ export function createGatewayPluginUpgradeHandler(params: {
     const requiresGatewayAuth = matchedPluginRoutesRequireGatewayAuth(matchedRoutes);
     if (requiresGatewayAuth && dispatchContext?.gatewayAuthSatisfied !== true) {
       log.warn(`plugin http upgrade blocked without gateway auth (${pathContext.canonicalPath})`);
-      writeUpgradeUnauthorized(socket);
+      rejectUnauthorizedUpgrade(socket);
       return true;
     }
     const gatewayRequestAuth = dispatchContext?.gatewayRequestAuth;
@@ -335,7 +331,7 @@ export function createGatewayPluginUpgradeHandler(params: {
         log.warn(
           `plugin http upgrade blocked without ${missingRuntimeContext} (${pathContext.canonicalPath})`,
         );
-        writeUpgradeUnauthorized(socket);
+        rejectUnauthorizedUpgrade(socket);
         return true;
       }
     }


### PR DESCRIPTION
## What Problem This Solves

Three internal Gateway upgrade paths independently encoded the same terminal HTTP 401 response. Keeping the security-sensitive response bytes and write-then-destroy ordering in multiple owners made future drift easier.

## Why This Change Was Made

This adds one dependency-free internal `rejectUnauthorizedUpgrade` leaf and delegates exactly six existing call sites: three node stream ticket rejections, one desktop observer token rejection, and two plugin upgrade authorization rejections. Response bytes, write-before-destroy ordering, route ownership, and all surrounding authorization decisions remain unchanged.

The production delta is `+15/-21` (net `-6`); tests are `+0/-0`. This corrects the review estimate of `+15/-18`: each removed local helper occupied four code lines plus one redundant separator line.

Open PRs https://github.com/openclaw/openclaw/pull/112820 and https://github.com/openclaw/openclaw/pull/119444 still touch `src/gateway/server/plugins-http.ts`, but their current heads and hunks remain disjoint from this change.

## User Impact

No user-visible behavior changes. Unauthorized upgrades still receive the exact same HTTP 401 response before the socket is destroyed.

## Evidence

- `pnpm test src/gateway/desktop/node-stream-broker.test.ts src/gateway/desktop/observe-bridge.test.ts src/gateway/server/plugins-http.test.ts`: 3 files, 47 tests passed. Subsequent main-only rebases had zero changes in the four target blobs.
- No new test was added: the node and observer suites already exercise real sockets, while the plugin suite verifies the rejection through its existing mock `Duplex` boundary.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `git diff --check`: passed.
- `git diff --numstat origin/main...HEAD`: production `+15/-21`, tests `+0/-0`, exactly four files.
- `node --import tsx scripts/check-deadcode-exports.mts`: production, full-tree, and script unused-export scans passed with 0 entries after adding the tracked UI config files omitted by the sparse profile.
- `pnpm check:changed -- <four files>`: formatting, boundary guards, core graph checks, and core production typecheck passed; the core-test shard is blocked by the shared install missing the current `mermaid` dependency.
- `pnpm build`: reached runtime postbuild; blocked by the shared `@openclaw/ai/diagnostics` install lacking the current `hasRetryableConnectionErrorCode` export. The worktree install was intentionally not mutated.
- Autoreview: scoped clean, no accepted/actionable findings, correctness `0.95`.
- Codex gate checked at `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; both sections are unrelated CLI parsing and prompt normalization.
- No Crabbox or live proof was run because this is a byte-for-byte, ordering-preserving internal refactor with existing socket-boundary coverage.
