### PR TITLE
test(ui): target catalog label in marquee lifecycle test

### DIFF
--- a/ui/src/test-helpers/app-sidebar-cases/catalog-row-lifecycle.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-row-lifecycle.ts
@@ -113,12 +113,15 @@ describe("AppSidebar catalog row lifecycle", () => {
       await sidebar.updateComplete;
     };
     await setLabel("A long catalog session title");
-    const oldLabel = sidebar.querySelector<HTMLElement>(".hover-marquee");
+    const row = sidebar.querySelector<HTMLElement>("[data-catalog-session-key]");
+    const oldLabel = row?.querySelector<HTMLElement>(".hover-marquee");
+    expect(oldLabel?.textContent).toBe("A long catalog session title");
     oldLabel?.classList.add("hover-marquee--scrolling");
     oldLabel?.style.setProperty("--hover-marquee-shift", "-80px");
     await setLabel("Short");
 
-    const updatedLabel = sidebar.querySelector<HTMLElement>(".hover-marquee");
+    const updatedLabel = row?.querySelector<HTMLElement>(".hover-marquee");
+    expect(updatedLabel?.textContent).toBe("Short");
     expect(updatedLabel).not.toBe(oldLabel);
     expect(updatedLabel?.classList.contains("hover-marquee--scrolling")).toBe(false);
     expect(updatedLabel?.style.getPropertyValue("--hover-marquee-shift")).toBe("");


### PR DESCRIPTION
The catalog-label lifecycle test started selecting the section header after #135523 added marquee styling to group titles. Renaming a session correctly keeps that header node, so the test failed its label-replacement assertion and blocked unrelated CI.

Scope both reads to the fixture's catalog row and assert the long and renamed label text. Keep the existing DOM replacement, scrolling-class removal, and shift-style removal assertions. The real Lit renderer and its keyed label subtree are unchanged. Production delta is zero; test delta is +5/-2.

Validation: reproduced the original identity failure on current main, then passed all 330 sidebar and marquee tests with the correction. Independent Codex review, manual renderer/dependency/history review, formatting, lint, i18n, architecture guards, and all three dead-export scans passed. Broad local core/UI typechecks stop at an unrelated missing Mermaid dependency in this checkout; exact-head hosted typechecks are required before landing.
