### PR TITLE
test(tooling): share immutable GitHub CLI fixture commands

### DIFF
--- a/test/scripts/plain-gh.test.ts
+++ b/test/scripts/plain-gh.test.ts
@@ -10,7 +10,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   execGhApiRead,
   execGhJson,
@@ -23,6 +23,7 @@ import {
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const commandDirs = useAutoCleanupTempDirTracker(afterAll);
 const shellHelper = path.resolve("scripts/lib/plain-gh.sh");
 const tokenNames = [
   "GH_TOKEN",
@@ -31,9 +32,14 @@ const tokenNames = [
   "GITHUB_ENTERPRISE_TOKEN",
 ] as const;
 const engines = ["shell", "Node"] as const;
+let commands: ReturnType<typeof makeCommandFixture>;
 
-function makeFixture() {
-  const root = tempDirs.make("plain-gh-");
+beforeAll(() => {
+  commands = makeCommandFixture();
+});
+
+function makeCommandFixture() {
+  const root = commandDirs.make("plain-gh-commands-");
   const home = path.join(root, "home");
   const protectedBin = path.join(home, "bin");
   const secondBin = path.join(root, "second");
@@ -42,8 +48,6 @@ function makeFixture() {
     mkdirSync(dir, { recursive: true });
   }
   symlinkSync("/usr/bin/env", path.join(toolsBin, "env"));
-  const calls = path.join(root, "calls.jsonl");
-  writeFileSync(calls, "");
   for (const [dir, route] of [
     [protectedBin, "protected"],
     [secondBin, "second"],
@@ -76,6 +80,15 @@ if (argv[0] === "auth" && argv[1] === "token") {
     );
     chmodSync(gh, 0o755);
   }
+  return { home, protectedBin, secondBin, toolsBin };
+}
+
+function makeFixture() {
+  const root = tempDirs.make("plain-gh-");
+  // Share executable files only; environments and outputs stay private to each test.
+  const { home, protectedBin, secondBin, toolsBin } = commands;
+  const calls = path.join(root, "calls.jsonl");
+  writeFileSync(calls, "");
   const env: NodeJS.ProcessEnv = {
     HOME: home,
     PATH: [protectedBin, secondBin, toolsBin].join(path.delimiter),


### PR DESCRIPTION
The plain-gh tests recreate identical command trees for 32 cases. Build the two immutable fake executables and env symlink once, using the existing temporary-directory tracker for suite cleanup. Each case still owns its environment, call log, negative executable fixture, and binary output.

This removes 31 repeated command trees: executable writes and chmods fall from 64 to 2 each, symlinks from 32 to 1, and command-directory creation calls from 96 to 3. All real subprocess calls, protected PATH refusal, credential routing, output limits, binary output, and streaming assertions remain unchanged. Production delta is zero; tests +18/-5.

Validation: all 33 cases passed before and after, with identical case names and byte-identical test bodies. The candidate passed shuffled seed 1553; the complete changed-file gate and independent Codex/manual lifecycle reviews passed. The suite remains dominated by subprocess execution; no wall-time speedup is claimed from these single runs.

Follow-up verification: exact-head CI run33571262573 completed successfully. The reviewed main50f7f06 retains the original fixture implementation. Direct inspection of installed Vitest4.1.11 confirms suite afterAll runs in finally even when suite setup or a case fails; this resolves the review worker’s unavailable dependency/main evidence.
