### PR TITLE
refactor(diagnostics): share metric rounding

### DIFF
--- a/src/gateway/server/event-loop-health.ts
+++ b/src/gateway/server/event-loop-health.ts
@@ -1,5 +1,6 @@
 // Event-loop health monitor samples delay, utilization, and CPU pressure for gateway readiness snapshots.
 import { monitorEventLoopDelay, performance } from "node:perf_hooks";
+import { roundDiagnosticMetric } from "../../infra/diagnostic-metrics.js";
 
 const EVENT_LOOP_MONITOR_RESOLUTION_MS = 20;
 const EVENT_LOOP_DELAY_WARN_MS = 1_000;
@@ -50,16 +51,8 @@ type GatewayEventLoopHealthMetrics = Pick<
   "intervalMs" | "delayP99Ms" | "delayMaxMs" | "utilization" | "cpuCoreRatio"
 >;
 
-function roundMetric(value: number, digits = 3): number {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-  const factor = 10 ** digits;
-  return Math.round(value * factor) / factor;
-}
-
 function nanosecondsToMilliseconds(value: number): number {
-  return roundMetric(value / 1_000_000, 1);
+  return roundDiagnosticMetric(value / 1_000_000, 1);
 }
 
 function classifyGatewayEventLoopHealthReasons(
@@ -138,11 +131,12 @@ export function createGatewayEventLoopHealthMonitor(
 
     const cpuUsage = readCpuUsage(lastCpuUsage);
     const currentEventLoopUtilization = readEventLoopUtilization();
-    const utilization = roundMetric(
+    const utilization = roundDiagnosticMetric(
       readEventLoopUtilization(currentEventLoopUtilization, lastEventLoopUtilization).utilization,
+      3,
     );
-    const cpuTotalMs = roundMetric((cpuUsage.user + cpuUsage.system) / 1_000, 1);
-    const cpuCoreRatio = roundMetric(cpuTotalMs / intervalMs);
+    const cpuTotalMs = roundDiagnosticMetric((cpuUsage.user + cpuUsage.system) / 1_000, 1);
+    const cpuCoreRatio = roundDiagnosticMetric(cpuTotalMs / intervalMs, 3);
     const reasons = classifyGatewayEventLoopHealthReasons({
       intervalMs,
       delayP99Ms,

--- a/src/infra/diagnostic-metrics.ts
+++ b/src/infra/diagnostic-metrics.ts
@@ -1,0 +1,7 @@
+export function roundDiagnosticMetric(value: number, digits: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}

--- a/src/logging/diagnostic-phase.ts
+++ b/src/logging/diagnostic-phase.ts
@@ -6,6 +6,7 @@ import {
   type DiagnosticPhaseDetails,
   type DiagnosticPhaseSnapshot,
 } from "../infra/diagnostic-events.js";
+import { roundDiagnosticMetric } from "../infra/diagnostic-metrics.js";
 
 // Tracks nested diagnostic phases for recent-phase snapshots and optional event emission.
 const RECENT_PHASE_CAPACITY = 40;
@@ -20,14 +21,6 @@ type ActiveDiagnosticPhase = {
 
 let activePhaseStack: ActiveDiagnosticPhase[] = [];
 let recentPhases: DiagnosticPhaseSnapshot[] = [];
-
-function roundMetric(value: number, digits = 1): number {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-  const factor = 10 ** digits;
-  return Math.round(value * factor) / factor;
-}
 
 function pushRecentPhase(snapshot: DiagnosticPhaseSnapshot): void {
   recentPhases.push(snapshot);
@@ -96,11 +89,11 @@ export async function withDiagnosticPhase<T>(
   } finally {
     // Remove by identity so nested or overlapping phases do not corrupt the active stack.
     const endedAt = Date.now();
-    const durationMs = roundMetric(performance.now() - active.startedWallMs, 1);
+    const durationMs = roundDiagnosticMetric(performance.now() - active.startedWallMs, 1);
     const cpu = process.cpuUsage(active.cpuStarted);
-    const cpuUserMs = roundMetric(cpu.user / 1_000, 1);
-    const cpuSystemMs = roundMetric(cpu.system / 1_000, 1);
-    const cpuTotalMs = roundMetric(cpuUserMs + cpuSystemMs, 1);
+    const cpuUserMs = roundDiagnosticMetric(cpu.user / 1_000, 1);
+    const cpuSystemMs = roundDiagnosticMetric(cpu.system / 1_000, 1);
+    const cpuTotalMs = roundDiagnosticMetric(cpuUserMs + cpuSystemMs, 1);
     activePhaseStack = activePhaseStack.filter((entry) => entry !== active);
     recordDiagnosticPhase({
       name,
@@ -110,7 +103,7 @@ export async function withDiagnosticPhase<T>(
       cpuUserMs,
       cpuSystemMs,
       cpuTotalMs,
-      cpuCoreRatio: roundMetric(cpuTotalMs / Math.max(1, durationMs), 3),
+      cpuCoreRatio: roundDiagnosticMetric(cpuTotalMs / Math.max(1, durationMs), 3),
       details: active.details,
     });
   }

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -10,6 +10,7 @@ import {
   type DiagnosticPhaseSnapshot,
   type DiagnosticLivenessWarningReason,
 } from "../infra/diagnostic-events.js";
+import { roundDiagnosticMetric } from "../infra/diagnostic-metrics.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { emitDiagnosticMemorySample, resetDiagnosticMemoryForTest } from "./diagnostic-memory.js";
 import {
@@ -250,14 +251,6 @@ function hasOpenDiagnosticWork(snapshot: DiagnosticWorkSnapshot): boolean {
 function hasRecentDiagnosticActivity(now: number): boolean {
   const lastActivityAt = getLastDiagnosticActivityAt();
   return lastActivityAt > 0 && now - lastActivityAt <= RECENT_DIAGNOSTIC_ACTIVITY_MS;
-}
-
-function roundDiagnosticMetric(value: number, digits = 3): number {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-  const factor = 10 ** digits;
-  return Math.round(value * factor) / factor;
 }
 
 function nanosecondsToMilliseconds(value: number): number {


### PR DESCRIPTION
## What Problem This Solves

Diagnostic timing, CPU, utilization, and ratio metrics carried three identical rounding implementations across logging and Gateway health owners. Keeping the same numeric contract in multiple places made future diagnostic output drift unnecessarily easy.

## Why This Change Was Made

Adds one dependency-free internal diagnostic metric rounding helper and routes all 15 existing call sites through it. The helper retains the exact non-finite-to-zero and `Math.round` arithmetic, requires callers to state precision, and adds no SDK, barrel, config, protocol, persistence, or fallback surface.

Precision remains explicit:

- milliseconds and CPU values: 1 digit
- ratios and utilization: 3 digits

The three local implementations are removed. Production LOC is `+20/-33` across four files, net `-13`; tests are `+0/-0`.

## User Impact

No user-visible behavior changes. Diagnostic numeric output, schemas, logs, and Gateway readiness behavior remain unchanged, with one internal owner for rounding policy.

## Evidence

- Focused integration suites: 3 files, 104 tests passed.
- `pnpm check:import-cycles`: passed with 0 runtime value cycles.
- `git diff --check`: passed.
- Exact call-site count: 15.
- Autoreview: scoped clean, no actionable findings, correctness `0.99`.
- `pnpm check:changed -- <four files>` passed policy, formatting, core typecheck, and core test typecheck lanes. Its broad dead-export scan initially could not load sparse-omitted `ui/config`; after adding that tracked path to the worktree sparse profile, the isolated dead-export scan passed all three Knip lanes with 0 entries.
- `pnpm build` completed compilation and packaging, then failed in unrelated runtime postbuild checks because the shared linked `@openclaw/ai/diagnostics` package does not yet export current main's `hasRetryableConnectionErrorCode`. Current source exports it; the linked package reports the export absent.
- Overlap recheck: #115993, #134755, #129388, #112447, and #132459 remain open with unchanged heads. The first three retain reviewed import-region overlap; the latter two remain hunk-disjoint.
- Codex gate inspected directly: `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those ranges concern unrelated CLI parsing and prompt normalization.
- No Crabbox or live proof was run because this is a behavior-neutral internal refactor with existing integration coverage.
