### PR TITLE
test(ai): reuse immutable oversized stream chunks

### DIFF
--- a/packages/ai/src/providers/mistral.bounded-stream.test.ts
+++ b/packages/ai/src/providers/mistral.bounded-stream.test.ts
@@ -44,12 +44,14 @@ describe("Mistral bounded-stream-read real wire proof (loopback http.createServe
   it("caps an oversized body streamed chunked over real wire", async () => {
     const fetcher = createBoundedMistralFetcher(MAX);
     const CHUNK = 1024 * 1024;
+    // Pending writes may retain this buffer, so keep its bytes unchanged.
+    const chunk = Buffer.alloc(CHUNK);
     const server = http.createServer((req, res) => {
       res.writeHead(200, { "content-type": "application/octet-stream" });
       let sent = 0;
       const tick = setInterval(() => {
         if (sent < 18) {
-          res.write(Buffer.alloc(CHUNK));
+          res.write(chunk);
           sent++;
         } else {
           clearInterval(tick);
@@ -66,7 +68,6 @@ describe("Mistral bounded-stream-read real wire proof (loopback http.createServe
     const port = (server.address() as AddressInfo).port;
 
     let captured: Error | undefined;
-    let totalGot = 0;
     try {
       const response = await fetcher(`http://127.0.0.1:${port}/`);
       // Wire framing merges TCP packets, so the reported size at throw time
@@ -74,8 +75,7 @@ describe("Mistral bounded-stream-read real wire proof (loopback http.createServe
       // bounds prove (a) cap fired (got > MAX) and (b) we did not buffer
       // beyond the server's full 18 MiB (got < TOTAL).
       try {
-        const result = await readAllChunks(response.body);
-        totalGot = result.total;
+        await readAllChunks(response.body);
       } catch (err) {
         captured = err as Error;
       }
@@ -97,10 +97,6 @@ describe("Mistral bounded-stream-read real wire proof (loopback http.createServe
           resolve();
         });
       });
-      if (totalGot > 0) {
-        // Use the value to satisfy strict unused rules without affecting asserts.
-        expect(totalGot).toBeGreaterThan(0);
-      }
     }
   });
 
@@ -144,11 +140,13 @@ describe("Mistral bounded-stream-read real wire proof (loopback http.createServe
 describe("Mistral bounded-stream-read direct (synthetic ReadableStream)", () => {
   it("caps an oversized synthetic ReadableStream at 16 MiB", async () => {
     const CHUNK = 1024 * 1024;
+    // Default streams keep chunk references; this reader only inspects byteLength.
+    const chunk = new Uint8Array(CHUNK);
     let sent = 0;
     const synthetic = new ReadableStream<Uint8Array>({
       pull(controller) {
         if (sent < 18) {
-          controller.enqueue(new Uint8Array(CHUNK));
+          controller.enqueue(chunk);
           sent++;
         } else {
           controller.close();


### PR DESCRIPTION
The oversized Mistral stream fixtures repeatedly allocate identical 1 MiB chunks. Reuse one immutable chunk in each fixture: Node HTTP writes and the default WHATWG stream retain references, and these consumers only read the bytes or byte length.

Keep the real HTTP producer, 1 ms wire cadence, 18 MiB source, 16 MiB limit, cancellation, and cleanup unchanged. Remove the unused successful-read counter and its conditional assertion, which only asserted the condition that guarded it after the overflow oracle had already failed. All 23 provider cases remain. Production delta is zero; tests +7/-9.

Validation: all 25 provider and byte-guard cases passed before and after, with identical case names; the candidate used shuffled seed 1667. The real wire overflow reported 16,842,744 bytes against the 16,777,216-byte cap, below the 18,874,368-byte source; normal wire output remained exactly 65 bytes. Full changed-file checks, independent Codex review, and manual installed Node/SDK ownership review passed.

This removes repeated source-buffer allocation and zeroing. It does not claim a peak-memory or stable wall-time improvement.
