### PR TITLE
test: avoid leaked concurrent node configuration workers

### DIFF
--- a/scripts/lib/vitest-worker-artifacts.mts
+++ b/scripts/lib/vitest-worker-artifacts.mts
@@ -14,6 +14,7 @@ export const vitestWorkerDeclarationEntries = {
     "src/agents/command/cli-compaction-runtime.test-support.ts",
   "gateway/session-title-retention.test-support":
     "src/gateway/session-title-retention.test-support.ts",
+  "node-host/config-runtime.test-support": "src/node-host/config-runtime.test-support.ts",
   "skills/library/persistence-runtime.test-support":
     "src/skills/library/persistence-runtime.test-support.ts",
   "tui/tui-pty-runtime-test-support": "src/tui/tui-pty-runtime-test-support.ts",

--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { cliCompactionBackendEntrypoints } from "../../src/agents/command/cli-compaction-runtime.test-support.ts";
 import { sessionTitleRetentionEntrypoints } from "../../src/gateway/session-title-retention.test-support.ts";
+import { nodeHostConfigRuntimeEntrypoint } from "../../src/node-host/config-runtime.test-support.ts";
 import { persistenceRuntimeEntrypoint } from "../../src/skills/library/persistence-runtime.test-support.ts";
 import { tuiPtyRuntimeEntrypoints } from "../../src/tui/tui-pty-runtime-test-support.ts";
 import { runtimeProcessBuildEntries } from "./runtime-process-build-entries.mts";
@@ -13,6 +14,7 @@ export const vitestWorkerBuildEntries = {
       ...cliCompactionBackendEntrypoints,
       ...Object.values(tuiPtyRuntimeEntrypoints),
       ...Object.values(sessionTitleRetentionEntrypoints),
+      nodeHostConfigRuntimeEntrypoint,
       persistenceRuntimeEntrypoint,
     ].map((entry) => [
       entry.distWorkerPath.replace(/\.js$/u, ""),

--- a/src/node-host/config-runtime.test-support.ts
+++ b/src/node-host/config-runtime.test-support.ts
@@ -1,0 +1,6 @@
+// The invocation compiles this worker before the concurrent configure readiness deadline.
+export const nodeHostConfigRuntimeEntrypoint = {
+  currentModuleUrl: import.meta.url,
+  sourceWorkerName: "config-worker.test-support",
+  distWorkerPath: "node-host/config-worker.test-support.js",
+} as const;

--- a/src/node-host/config-worker.test-support.ts
+++ b/src/node-host/config-worker.test-support.ts
@@ -1,0 +1,18 @@
+import { once } from "node:events";
+import { configureNodeHost } from "./config.js";
+
+const [candidateNodeId, nowMs] = process.argv.slice(2);
+const start = once(process, "message");
+process.send!("ready");
+await start;
+
+const config = await configureNodeHost({
+  candidateNodeId,
+  fallbackDisplayName: "node",
+  gateway: {},
+  nowMs: Number(nowMs),
+});
+await new Promise<void>((resolve, reject) => {
+  process.send!(config, (error) => (error ? reject(error) : resolve()));
+});
+process.disconnect!();

--- a/src/node-host/config.test.ts
+++ b/src/node-host/config.test.ts
@@ -1,14 +1,19 @@
-import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { runManagedCommand } from "../../scripts/lib/managed-child-process.mts";
+import { createBoundedChildOutput } from "../../test/helpers/bounded-child-output.js";
+import { createFixtureLifetime } from "../../test/helpers/fixture-lifetime.js";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
+import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import {
   readConfigMachineState,
   readConfigMachineStateWithMetadata,
   writeConfigMachineState,
 } from "../state/config-machine-state.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { nodeHostConfigRuntimeEntrypoint } from "./config-runtime.test-support.js";
 import {
   configureNodeHost,
   loadNodeHostConfig,
@@ -17,97 +22,69 @@ import {
 } from "./config.js";
 
 const fixtureDigest = ["fixture", "digest"].join("-");
+const fixture = createFixtureLifetime();
 
 async function runConcurrentImplicitConfigures(
   stateDir: string,
+  signal: AbortSignal,
 ): Promise<[NodeHostConfig, NodeHostConfig]> {
-  const startPath = path.join(stateDir, "configure-start");
-  const moduleUrl = new URL("./config.ts", import.meta.url).href;
-  const workerSource = `
-    import fs from "node:fs";
-    const { configureNodeHost } = await import(process.env.OPENCLAW_NODE_HOST_CONFIG_MODULE);
-    fs.writeFileSync(process.env.OPENCLAW_NODE_HOST_READY_PATH, "ready");
-    const deadline = Date.now() + 15_000;
-    while (!fs.existsSync(process.env.OPENCLAW_NODE_HOST_START_PATH)) {
-      if (Date.now() >= deadline) {
-        throw new Error("timed out waiting for concurrent node-host configure start");
-      }
-      await new Promise((resolve) => setTimeout(resolve, 2));
-    }
-    const config = await configureNodeHost({
-      candidateNodeId: process.env.OPENCLAW_NODE_HOST_CANDIDATE,
-      fallbackDisplayName: "node",
-      gateway: {},
-      env: { ...process.env, OPENCLAW_STATE_DIR: process.env.OPENCLAW_NODE_HOST_STATE_DIR },
-      nowMs: Number(process.env.OPENCLAW_NODE_HOST_NOW_MS),
-    });
-    console.log(JSON.stringify(config));
-  `;
+  const workerUrl = resolveRuntimeWorkerUrl(nodeHostConfigRuntimeEntrypoint);
+  const cancellation = new AbortController();
+  const childSignal = AbortSignal.any([signal, cancellation.signal]);
   const workers = ["candidate-a", "candidate-b"].map((candidate, index) => {
-    const readyPath = path.join(stateDir, `configure-ready-${index}`);
-    const child = spawn(
-      process.execPath,
-      ["--import", "tsx", "--input-type=module", "-e", workerSource],
-      {
-        env: {
-          ...process.env,
-          OPENCLAW_NODE_HOST_CANDIDATE: candidate,
-          OPENCLAW_NODE_HOST_CONFIG_MODULE: moduleUrl,
-          OPENCLAW_NODE_HOST_NOW_MS: String(index + 1),
-          OPENCLAW_NODE_HOST_READY_PATH: readyPath,
-          OPENCLAW_NODE_HOST_START_PATH: startPath,
-          OPENCLAW_NODE_HOST_STATE_DIR: stateDir,
+    const ready = createDeferred<ChildProcess>();
+    const stderr = createBoundedChildOutput();
+    let config: NodeHostConfig | undefined;
+    const outcome = fixture.track(
+      runManagedCommand({
+        bin: process.execPath,
+        args: [...resolveRuntimeWorkerArgv(workerUrl), candidate, String(index + 1)],
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+        shell: false,
+        stdio: ["ignore", "ignore", "pipe", "ipc"],
+        signal: childSignal,
+        requireProcessTreeExit: process.platform !== "win32",
+        onReady(child) {
+          child.stderr!.on("data", stderr.append);
+          child.on("message", (message: "ready" | NodeHostConfig) => {
+            if (message === "ready") {
+              ready.resolve(child);
+            } else {
+              config = message;
+            }
+          });
         },
-        stdio: ["ignore", "pipe", "pipe"],
-      },
-    );
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk) => (stdout += String(chunk)));
-    child.stderr.on("data", (chunk) => (stderr += String(chunk)));
-    const outcome = new Promise<NodeHostConfig>((resolve, reject) => {
-      child.once("error", reject);
-      child.once("close", (code, signal) => {
+      }).then((code) => {
         if (code !== 0) {
-          reject(new Error(`configure worker failed (${String(code ?? signal)}): ${stderr}`));
-          return;
+          throw new Error(`configure worker failed (${code}): ${stderr.text()}`);
         }
-        const resultLine = stdout.trim().split("\n").at(-1);
-        if (!resultLine) {
-          reject(new Error("configure worker produced no result"));
-          return;
+        if (!config) {
+          throw new Error("configure worker produced no result");
         }
-        resolve(JSON.parse(resultLine) as NodeHostConfig);
-      });
-    });
-    return { child, outcome, readyPath };
+        return config;
+      }),
+    );
+    return {
+      ready: Promise.race([
+        ready.promise,
+        outcome.then(() => {
+          throw new Error("configure worker exited before the start barrier");
+        }),
+      ]),
+      outcome,
+    };
   });
 
   try {
-    const deadline = Date.now() + 15_000;
-    while (true) {
-      const ready = await Promise.all(
-        workers.map(async ({ readyPath }) =>
-          fs.access(readyPath).then(
-            () => true,
-            () => false,
-          ),
-        ),
-      );
-      if (ready.every(Boolean)) {
-        break;
-      }
-      if (workers.some(({ child }) => child.exitCode !== null || child.signalCode !== null)) {
-        break;
-      }
-      if (Date.now() >= deadline) {
-        throw new Error("timed out waiting for concurrent configure workers");
-      }
-      await new Promise((resolve) => {
-        setTimeout(resolve, 2);
-      });
+    // Both real processes must finish imports before either can choose its implicit id.
+    const children = await withTestTimeout(
+      Promise.all(workers.map(({ ready }) => ready)),
+      15_000,
+      "timed out waiting for concurrent configure workers",
+    );
+    for (const child of children) {
+      child.send("start");
     }
-    await fs.writeFile(startPath, "start");
     const outcomes = await Promise.all(workers.map(({ outcome }) => outcome));
     const first = outcomes[0];
     const second = outcomes[1];
@@ -116,24 +93,19 @@ async function runConcurrentImplicitConfigures(
     }
     return [first, second];
   } finally {
-    for (const { child } of workers) {
-      if (child.exitCode === null && child.signalCode === null) {
-        child.kill();
-      }
-    }
+    cancellation.abort();
+    await Promise.allSettled(workers.map(({ outcome }) => outcome));
   }
 }
 
 describe("node-host SQLite config", () => {
-  const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
-    afterEach(() => {
-      closeOpenClawStateDatabaseForTest();
-      cleanup();
-    });
+  afterEach(async () => {
+    closeOpenClawStateDatabaseForTest();
+    await fixture.cleanup();
   });
 
   function makeTestEnv(): { env: NodeJS.ProcessEnv; stateDir: string } {
-    const stateDir = tempDirs.make("openclaw-node-host-config-");
+    const stateDir = fixture.createTempDir("openclaw-node-host-config-");
     return { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir }, stateDir };
   }
 
@@ -219,9 +191,11 @@ describe("node-host SQLite config", () => {
     await expect(loadNodeHostConfig(env)).resolves.toMatchObject({ installedAppsSharing: true });
   });
 
-  it("keeps the first committed implicit node id across processes", async () => {
+  it("keeps the first committed implicit node id across processes", async ({ signal }) => {
     const { env, stateDir } = makeTestEnv();
-    const [first, second] = await runConcurrentImplicitConfigures(stateDir);
+    const [first, second] = await fixture.run(() =>
+      runConcurrentImplicitConfigures(stateDir, signal),
+    );
 
     expect(["candidate-a", "candidate-b"]).toContain(first.nodeId);
     expect(second.nodeId).toBe(first.nodeId);


### PR DESCRIPTION
## What Problem This Solves

The concurrent node-configuration test could finish after a readiness failure while its child processes and rejected promises were still running. CI recorded the readiness timeout followed by late SIGTERM rejections attributed to the next test. Each child also loaded TypeScript independently while the parent polled readiness files every two milliseconds.

## Why This Change Was Made

Move the existing two-process fixture onto the invocation-owned compiled-worker registry, IPC readiness barrier, managed process runner, and fixture lifetime. Both children must finish imports before either starts configuration. Every exit path cancels and joins both workers before temporary state is removed.

The test still uses two independent processes with distinct candidate IDs against the same fresh database. The 15-second readiness deadline, 30-second test deadline, and all configuration assertions remain. Standalone source-mode execution continues through the existing worker resolver.

## User Impact

No product behavior changes. The test stops leaking child failures across cases and avoids duplicate source-loader work and filesystem readiness polling. Production LOC: 0. Test and test-support/tooling LOC: +94/-93 (net +1).

## Evidence

The actual CI failures are in [the terminal-lifecycle run](https://github.com/openclaw/openclaw/actions/runs/33562947449) and [the context-map run](https://github.com/openclaw/openclaw/actions/runs/33563374067). Their logs identify the same readiness timeout and late child rejections. The original natural CI startup stall was not reproduced locally; this change repairs the proven cleanup defect and removes duplicated startup work rather than claiming a reproduced scheduler cause.

Controlled probes invoke the actual registered behavior test. For a real child exiting with code 23, baseline returned with only one of two children closed and an unhandled rejection; the candidate returned with both closed and no escaped rejection. A second probe preserves the real 15-second readiness timeout: baseline returned with neither child closed and two late rejections, while the candidate joined both. All deliberately failing baseline children were subsequently joined by probe cleanup.

Normal before/after process traces preserve the two-worker start barrier. The baseline launched two source-preloaded inline workers and performed 914 observed readiness polls; the candidate launched the same compiled JavaScript worker twice with no source preload and no file polling. These are work counts, not a controlled latency or RSS benchmark.

All eight original tests passed in compiled and standalone source modes. After Git integration, the eight configuration tests and five runtime-worker resolver tests passed again, including compilation of the private worker graph. Full changed-file checks passed on the integrated patch. Independent Codex review found no actionable findings at the requested threshold. A combined verification also passed the 335 sidebar, marquee, and idle-import tests with the independent row-selector repair. That repair has since landed on main in #135597; this PR contains only the node-worker change. [Hosted CI on this exact PR head](https://github.com/openclaw/openclaw/actions/runs/33570319849) passed.
