### PR TITLE
refactor(daemon): simplify platform path selection

### DIFF
--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -478,6 +478,24 @@ describe("auditGatewayServiceConfig", () => {
     expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayCommandMissing)).toBe(true);
   });
 
+  it("skips PATH drift checks for semicolon-delimited Windows paths", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "C:\\Users\\test" },
+      platform: "win32",
+      expectedServicePath: "C:\\Program Files\\nodejs;C:\\Windows\\System32",
+      command: {
+        programArguments: ["C:\\Program Files\\nodejs\\node.exe", "gateway"],
+        environment: {
+          PATH: "C:\\Users\\test\\.nvm\\current\\bin;C:\\Windows\\System32",
+        },
+      },
+    });
+
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayPathMissing)).toBe(false);
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayPathMissingDirs)).toBe(false);
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayPathNonMinimal)).toBe(false);
+  });
+
   it("flags gateway service port drift from the expected config port", async () => {
     const audit = await auditGatewayServiceConfig({
       env: { HOME: "/tmp" },

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -451,10 +451,6 @@ export function readEmbeddedGatewayToken(command: GatewayServiceCommand): string
   return normalizeOptionalString(command.environment?.OPENCLAW_GATEWAY_TOKEN);
 }
 
-function getPathModule(platform: NodeJS.Platform) {
-  return platform === "win32" ? path.win32 : path.posix;
-}
-
 function getEquivalentMinimalPathEntries(
   entry: string,
   platform: NodeJS.Platform,
@@ -496,13 +492,13 @@ function auditGatewayServicePath(
   }
 
   const expected = expectedServicePath?.trim()
-    ? normalizeStringEntries(expectedServicePath.split(getPathModule(platform).delimiter))
+    ? normalizeStringEntries(expectedServicePath.split(path.posix.delimiter))
     : getMinimalServicePathPartsFromEnv({
         platform,
         env,
         includeMissingUserBinDefaults: false,
       });
-  const parts = normalizeStringEntries(servicePath.split(getPathModule(platform).delimiter));
+  const parts = normalizeStringEntries(servicePath.split(path.posix.delimiter));
   const normalizedParts = new Set(parts.map((entry) => normalizeServicePathEntry(entry, platform)));
   const normalizedExpected = new Set(
     expected.map((entry) => normalizeServicePathEntry(entry, platform)),

--- a/src/daemon/service-path-policy.ts
+++ b/src/daemon/service-path-policy.ts
@@ -3,12 +3,8 @@ import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
 // Service PATH policy keeps managed services away from user shell package-manager paths.
-function getPathModule(platform: NodeJS.Platform) {
-  return platform === "win32" ? path.win32 : path.posix;
-}
-
 export function normalizeServicePathEntry(entry: string, platform: NodeJS.Platform): string {
-  const pathModule = getPathModule(platform);
+  const pathModule = platform === "win32" ? path.win32 : path.posix;
   const normalized = pathModule.normalize(entry).replaceAll("\\", "/");
   if (platform === "win32") {
     return normalizeLowercaseStringOrEmpty(normalized);


### PR DESCRIPTION
## What Problem This Solves

Daemon PATH code repeated the same platform selector even where the surrounding owner already constrained the valid platform. Treating every copy as a shared abstraction added an unnecessary cross-module API and obscured the narrower contracts.

## Why This Change Was Made

The service audit returns before PATH parsing on Windows, so its two splits now use `path.posix.delimiter` directly. Service PATH policy keeps its single cross-platform selector inline beside normalization. The earlier `src/daemon/paths.ts` export was removed, and runtime path discovery retains its existing private helper because it has several genuine cross-platform callers.

A focused regression test now supplies a semicolon-delimited Windows PATH plus a mismatched expected PATH and proves the audit emits none of `gatewayPathMissing`, `gatewayPathMissingDirs`, or `gatewayPathNonMinimal`. This protects the Windows early-return invariant that makes the POSIX-only parsing explicit and safe.

No public barrel, SDK seam, configuration, default, persistence, or fallback behavior changes.

## User Impact

No user-visible behavior changes. POSIX service PATH auditing and Windows/POSIX service path normalization preserve their previous semantics with less production code and an explicit Windows regression boundary.

Production LOC: `+3/-11` across two files, net `-8`. Tests: `+18/-0`.

## Evidence

- Final signed head: `f20f51d1b013b70fae4587ddc4526b0c91c08f21`.
- `node scripts/run-vitest.mjs run src/daemon/service-audit.test.ts src/daemon/service-env.test.ts src/daemon/schtasks.install.test.ts`
  - Passed on the final head: 3 files, 166 tests.
- `node scripts/check-changed.mjs --dry-run -- src/daemon/service-audit.test.ts`
  - Classified the change as the core-test lane.
- `node scripts/check-changed.mjs -- src/daemon/service-audit.test.ts`
  - Passed conflict-marker, max-lines, assertion-safety, attribution, dependency, formatting, plugin-boundary, wrapper, package-patch, temp-directory, and core graph guards.
  - Its core-test typecheck initially exposed missing package-local links in the isolated worktree; `gwt` restored those links without installing dependencies or changing source.
- `pnpm tsgo:core:test`
  - Passed after the worktree dependency links were restored.
- `pnpm check:coercion-helpers`
- `pnpm check:deprecated-api-usage`
- `node --import tsx scripts/check-deadcode-exports.mts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/daemon/service-audit.test.ts`
  - All passed.
- `git diff --check`
  - Passed.
- Exact Codex autoreview with `gpt-5.6-sol` at high reasoning:
  - Scoped clean, no accepted/actionable findings, correctness `0.99`.
- Independent frozen-head review:
  - Passed exact signed head `f20f51d1b013b70fae4587ddc4526b0c91c08f21` at confidence `0.99`.
  - Independently reproduced all 166 focused tests and confirmed the Windows fixture catches removal of the audit early return.
- Codex gate inspected directly at `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those ranges are unrelated to daemon PATH handling.
- Hosted exact-head CI and native Testbox preparation are required before merge.
