### PR TITLE
fix(test): preserve retained inputs across nested Vitest cleanup

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -611,6 +611,7 @@ jobs:
             scripts/lib/failed-trailer.mts
             scripts/lib/error-format.mts
             scripts/lib/managed-child-process.mts
+            scripts/lib/vitest-resource-ownership.mts
             scripts/lib/windows-taskkill.mjs
             scripts/lib/release-version.mjs
             .github/actions/setup-pnpm-store-cache/ensure-node.sh

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -367,17 +367,25 @@ The launcher does not split runs or change watch, filter, or report semantics.
 The namespace contains isolated homes, their JIT caches, SDK/shared-home allocation
 roots, and fallback SQLite state; its lifetime spans shared-worker files and module
 resets. On POSIX detached launches, the parent removes
-only that namespace after its child process group has stopped and output pipes
-have closed, including passing and failing runs, child crashes, caught `SIGINT`/`SIGTERM`
+only that namespace after its child process group has stopped, output pipes
+have closed, and nested resource owners have released their pending claims,
+including passing and failing runs, child crashes, caught `SIGINT`/`SIGTERM`
 signals, and watchdog termination where supported. Explicit state, profile output,
 and mirror artifacts outside the namespace remain untouched. Failed or unverified
-group joins retain the namespace and report the exact path for manual recovery.
+group joins or unresolved nested claims retain the namespace and report the exact
+path for manual recovery. Nested namespaces, fixture lifetimes, and managed commands
+register ephemeral filesystem ownership before admitting work. Release requires
+positive completion evidence; caught cleanup failures, module resets, worker exit,
+or an intermediate runner crash cannot release a pending claim or its ancestors.
+Managed commands keep their existing close-based completion contract unless strict
+tree verification is requested; failed finalization never releases ownership.
+Stop all remaining writers before manually removing the reported exact directory.
 Windows and non-detached launches allocate the same isolated native home, but retain
-their namespace with a diagnostic after child exit and pipe closure because
+their namespace and enclosing claims with a diagnostic after child exit because
 descendant completion cannot be verified. Raw external invocations do not gain
-this boundary. Forced parent
-or supervisor death (such as `SIGKILL`) can prevent cleanup; descendants that
-intentionally escape the owned group can recreate removed paths. The wrappers do
+this boundary. Forced parent or supervisor death (such as `SIGKILL`) can prevent
+cleanup; unregistered descendants that intentionally escape the owned group remain
+outside this contract. The wrappers do
 not sweep old directories or infer ownership from names, ages, or PIDs.
 This is home isolation, not a filesystem sandbox: explicit absolute paths,
 `os.userInfo()` account lookup, children with stripped or replaced home variables,

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -381,8 +381,8 @@ Managed commands keep their existing close-based completion contract unless stri
 tree verification is requested; failed finalization never releases ownership.
 Stop all remaining writers before manually removing the reported exact directory.
 Windows and non-detached launches allocate the same isolated native home, but retain
-their namespace and enclosing claims with a diagnostic after child exit because
-descendant completion cannot be verified. Raw external invocations do not gain
+their namespace and enclosing claims with a diagnostic after child exit and pipe
+closure because descendant completion cannot be verified. Raw external invocations do not gain
 this boundary. Forced parent or supervisor death (such as `SIGKILL`) can prevent
 cleanup; unregistered descendants that intentionally escape the owned group remain
 outside this contract. The wrappers do

--- a/scripts/lib/extension-boundary-inputs.mts
+++ b/scripts/lib/extension-boundary-inputs.mts
@@ -32,6 +32,7 @@ const GENERATOR_INPUTS = [
   "scripts/lib/build-artifact-cache.mts",
   "scripts/lib/local-check-runtime.mts",
   "scripts/lib/managed-child-process.mts",
+  "scripts/lib/vitest-resource-ownership.mts",
   "scripts/lib/dist-artifact-ownership.mts",
   "scripts/lib/direct-run.mjs",
   "scripts/lib/repo-root.mjs",

--- a/scripts/lib/managed-child-process.mts
+++ b/scripts/lib/managed-child-process.mts
@@ -1,9 +1,10 @@
 // Runs child commands with process-group signal forwarding and Windows shell normalization.
 import { spawn, spawnSync } from "node:child_process";
 import type { ChildProcess, StdioOptions } from "node:child_process";
-import { constants as osConstants } from "node:os";
+import { constants as osConstants, tmpdir } from "node:os";
 import { Writable } from "node:stream";
 import { buildCmdExeCommandLine, resolveWindowsCmdExePath } from "../windows-cmd-helpers.mjs";
+import { findVitestResourceOwner } from "./vitest-resource-ownership.mts";
 import { resolveWindowsTaskkillPath } from "./windows-taskkill.mjs";
 
 const FORWARDED_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"] satisfies NodeJS.Signals[];
@@ -325,6 +326,14 @@ export async function runManagedCommand({
     platform,
     comSpec,
   });
+  const commandEnv = env ?? process.env;
+  let releaseClaim = findVitestResourceOwner(
+    commandEnv.TMPDIR || commandEnv.TMP || commandEnv.TEMP || tmpdir(),
+  )?.claim();
+  const releaseOwnership = () => {
+    releaseClaim?.();
+    releaseClaim = undefined;
+  };
   // Register before spawn: a child can become ready before spawn returns.
   installSignalHandlers();
   let child: ChildProcess;
@@ -332,6 +341,7 @@ export async function runManagedCommand({
     child = spawn(spawnSpec.command, spawnSpec.args, spawnSpec.options);
   } catch (error) {
     removeSignalHandlersIfIdle();
+    releaseOwnership();
     throw error;
   }
   let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
@@ -356,6 +366,7 @@ export async function runManagedCommand({
       runTaskkill,
       forceKillDelayMs,
       forceKillOnLeaderExit,
+      onTerminated: releaseOwnership,
     });
     cancellation = finalization.then(
       () => outcome,
@@ -424,7 +435,11 @@ export async function runManagedCommand({
     let outcome = await Promise.race([completion, canceled]);
     if (outcome.type === "completed" && requireProcessTreeExit && !cancellation) {
       try {
-        await (finalization ??= finalizeManagedChild(child, undefined, { platform, runTaskkill }));
+        await (finalization ??= finalizeManagedChild(child, undefined, {
+          platform,
+          runTaskkill,
+          onTerminated: releaseOwnership,
+        }));
       } catch (error) {
         outcome = { type: "failed", error };
       }
@@ -432,6 +447,11 @@ export async function runManagedCommand({
     // Cancellation owns the result even when it arrives during normal drainage.
     if (cancellation) {
       outcome = await cancellation;
+    }
+    // Preserve the ordinary API's close-based contract. Cancellation and strict
+    // commands release only at the finalizer's positive termination boundary.
+    if (outcome.type === "completed" && !requireProcessTreeExit && !cancellation) {
+      releaseOwnership();
     }
     if (outcome.type === "failed") {
       throw outcome.error;
@@ -451,6 +471,9 @@ export async function runManagedCommand({
     signal?.removeEventListener("abort", abort);
     managedChildren.delete(forwardSignal);
     removeSignalHandlersIfIdle();
+    if (!child.pid) {
+      releaseOwnership();
+    }
   }
 }
 
@@ -462,11 +485,13 @@ async function finalizeManagedChild(
     runTaskkill,
     forceKillDelayMs = FORCE_KILL_DELAY_MS,
     forceKillOnLeaderExit = false,
+    onTerminated,
   }: {
     platform: NodeJS.Platform;
     runTaskkill: TaskkillRunner;
     forceKillDelayMs?: number;
     forceKillOnLeaderExit?: boolean;
+    onTerminated: () => void;
   },
 ) {
   // Nested wrappers own detached groups. Let them forward the signal before
@@ -497,6 +522,7 @@ async function finalizeManagedChild(
     const exited = child.exitCode !== null || child.signalCode !== null;
     const pipesClosed = [child.stdout, child.stderr].every((pipe) => !pipe || pipe.closed);
     if (groupState === "dead" && exited && pipesClosed) {
+      onTerminated();
       // A missing group at signal time supersedes the earlier racy liveness probe.
       if (!signal && termination?.processTreeState !== "terminated") {
         throw createManagedCommandCleanupError(

--- a/scripts/lib/plugin-clawhub-release.ts
+++ b/scripts/lib/plugin-clawhub-release.ts
@@ -85,6 +85,7 @@ const CLAWHUB_RELEASE_AUTHORITY_PATHS = [
   "scripts/lib/bounded-command.mjs",
   "scripts/lib/bounded-command.mts",
   "scripts/lib/managed-child-process.mts",
+  "scripts/lib/vitest-resource-ownership.mts",
   "scripts/lib/tsx-cli-shim.mjs",
   "scripts/lib/bounded-response.mjs",
   "scripts/lib/plugin-npm-release.ts",

--- a/scripts/lib/vitest-process.mts
+++ b/scripts/lib/vitest-process.mts
@@ -19,6 +19,10 @@ import {
   createVitestProcessCompletion,
   shouldUseDetachedVitestProcessGroup,
 } from "../vitest-process-group.mts";
+import {
+  createVitestResourceOwner,
+  findVitestResourceOwner,
+} from "./vitest-resource-ownership.mts";
 
 /** Own temporary files until the Vitest child, its group, and its pipes have joined. */
 export function spawnOwnedVitestProcess(spec: {
@@ -37,12 +41,25 @@ export function spawnOwnedVitestProcess(spec: {
   const tempDirs = createTempDirTracker();
   const detached = spec.options.detached ?? shouldUseDetachedVitestProcessGroup();
   const verifiedGroup = detached && shouldUseDetachedVitestProcessGroup();
-  const tempRoot = tempDirs.make(
-    "oc-vt-",
-    fs.realpathSync(env.TMPDIR || env.TMP || env.TEMP || tmpdir()),
-  );
+  let tempRoot: string | undefined;
+  let owner: ReturnType<typeof createVitestResourceOwner> | undefined;
+  let parent: { root: string; release: () => void } | undefined;
+  const dispose = () => {
+    owner?.assertReleased();
+    tempDirs.cleanup();
+    parent?.release();
+  };
   let child;
   try {
+    const containingRoot = fs.realpathSync(env.TMPDIR || env.TMP || env.TEMP || tmpdir());
+    // An intermediate runner can die before publishing its own cleanup result.
+    // Its containing owner must already hold the obligation before allocation.
+    const containingOwner = findVitestResourceOwner(containingRoot);
+    if (containingOwner) {
+      parent = { root: containingOwner.root, release: containingOwner.claim() };
+    }
+    tempRoot = tempDirs.make("oc-vt-", containingRoot);
+    owner = createVitestResourceOwner(tempRoot);
     const childEnv: NodeJS.ProcessEnv = { ...env, TMPDIR: tempRoot, TMP: tempRoot, TEMP: tempRoot };
     if (mode !== "tooling" && !(policy.live && policy.allowRealHome)) {
       const nativeHome = path.join(tempRoot, "home");
@@ -69,31 +86,39 @@ export function spawnOwnedVitestProcess(spec: {
     child = spawn(spec.command, spec.args, options);
   } catch (error) {
     tempDirs.cleanup();
+    parent?.release();
     throw error;
   }
-  const completion = createVitestProcessCompletion({ child, detached }).then(
-    (result) => {
+  const completion = (async () => {
+    try {
+      const result = await createVitestProcessCompletion({ child, detached });
       if (verifiedGroup) {
-        tempDirs.cleanup();
+        dispose();
       } else {
+        // Keep the containing claim too: leader exit cannot certify descendants.
         console.error(
           `[vitest] retained temporary namespace ${tempRoot}; descendant completion is unverified on this non-group launch. Stop the remaining writers before removing this exact directory.`,
         );
       }
       return result;
-    },
-    (error: unknown) => {
+    } catch (error) {
+      // A failed parent receipt can follow successful child disposal. Report
+      // the still-owned ancestor, not a child directory already removed.
+      const retainedRoot = tempRoot && tempDirs.dirs.has(tempRoot) ? tempRoot : parent?.root;
       // No PID means spawn failed; otherwise unverified writers still own the files.
       if (!child.pid) {
-        tempDirs.cleanup();
-      } else {
-        throw new Error(
-          `[vitest] retained temporary namespace ${tempRoot}; child/group completion was not verified. Stop the remaining writers before removing this exact directory.`,
-          { cause: error },
+        dispose();
+      } else if (retainedRoot) {
+        throw Object.assign(
+          new Error(
+            `[vitest] retained temporary namespace ${retainedRoot}; child/group or nested resource completion was not verified. Stop the remaining writers before removing this exact directory.`,
+            { cause: error },
+          ),
+          { processTreeState: "indeterminate" },
         );
       }
       throw error;
-    },
-  );
+    }
+  })();
   return { child, completion };
 }

--- a/scripts/lib/vitest-resource-ownership.mts
+++ b/scripts/lib/vitest-resource-ownership.mts
@@ -1,0 +1,98 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Ephemeral Node/Vitest resource handoff, not application persistence. Claims
+// survive worker/module death; only the namespace's process owner deletes them.
+const OWNER_DIRECTORY = ".vitest-resource-owner";
+const ID_PATTERN = /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/;
+
+function readReceipt(file: string): string {
+  const fd = fs.openSync(file, "r");
+  try {
+    const buffer = Buffer.alloc(128);
+    return buffer.subarray(0, fs.readSync(fd, buffer)).toString("utf8");
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function resourceOwner(root: string, identity: string) {
+  const directory = path.join(root, OWNER_DIRECTORY);
+  const ownerFile = path.join(directory, "owner");
+  const claims = path.join(directory, "claims");
+  const verifyOwner = () => {
+    if (readReceipt(ownerFile) !== identity) {
+      throw new Error(`Vitest resource owner changed: ${root}`);
+    }
+  };
+  return {
+    root,
+    claim() {
+      verifyOwner();
+      const id = randomUUID();
+      const claim = path.join(claims, id);
+      // Atomic pending admission, before allocation/spawn. No shared JSON RMW
+      // and no deletion-based release: a missing receipt never means success.
+      fs.mkdirSync(claim);
+      return () => {
+        verifyOwner();
+        fs.writeFileSync(path.join(claim, "released"), `${identity}:${id}`, { flag: "wx" });
+      };
+    },
+    assertReleased() {
+      verifyOwner();
+      // The creator expects this registry. Missing/unreadable metadata is not
+      // an empty set, including after all workers have exited successfully.
+      for (const id of fs.readdirSync(claims)) {
+        const receipt = path.join(claims, id, "released");
+        try {
+          if (ID_PATTERN.test(id) && readReceipt(receipt) === `${identity}:${id}`) {
+            continue;
+          }
+        } catch {
+          // Retain on missing, corrupt, or unreadable completion evidence.
+        }
+        throw new Error(`Unreleased Vitest resource claim: ${path.join(claims, id)}`);
+      }
+    },
+  };
+}
+
+export function createVitestResourceOwner(root: string) {
+  const identity = randomUUID();
+  const directory = path.join(root, OWNER_DIRECTORY);
+  fs.mkdirSync(directory);
+  fs.mkdirSync(path.join(directory, "claims"));
+  fs.writeFileSync(path.join(directory, "owner"), identity, { flag: "wx" });
+  return resourceOwner(root, identity);
+}
+
+/** Discover only explicit containing owners, including canonical TMP symlinks. */
+export function findVitestResourceOwner(root = tmpdir()) {
+  let current = path.resolve(root);
+  while (true) {
+    try {
+      // A command may create its own TMP leaf; find the existing containing
+      // owner without making that directory or changing command admission.
+      current = fs.realpathSync(current);
+      fs.lstatSync(path.join(current, OWNER_DIRECTORY));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+      const parent = path.dirname(current);
+      if (parent === current) {
+        return undefined;
+      }
+      current = parent;
+      continue;
+    }
+    const identity = readReceipt(path.join(current, OWNER_DIRECTORY, "owner"));
+    if (!ID_PATTERN.test(identity)) {
+      throw new Error(`Invalid Vitest resource owner: ${current}`);
+    }
+    return resourceOwner(current, identity);
+  }
+}

--- a/scripts/lib/vitest-worker-compiler.mts
+++ b/scripts/lib/vitest-worker-compiler.mts
@@ -42,6 +42,7 @@ async function compileVitestWorkerArtifacts(directory: string): Promise<void> {
     "scripts/lib/vitest-worker-run.mts",
     "scripts/lib/vitest-worker-compiler.mts",
     "scripts/lib/managed-child-process.mts",
+    "scripts/lib/vitest-resource-ownership.mts",
     "scripts/lib/windows-taskkill.mjs",
     "scripts/windows-cmd-helpers.mjs",
     "scripts/lib/runtime-process-build-entries.mts",

--- a/scripts/pr-lib/wrapper-components.txt
+++ b/scripts/pr-lib/wrapper-components.txt
@@ -25,6 +25,7 @@ scripts/lib/vitest-home-selection.mts
 scripts/lib/vitest-local-scheduling.mts
 scripts/lib/vitest-process-env.mts
 scripts/lib/vitest-process.mts
+scripts/lib/vitest-resource-ownership.mts
 scripts/lib/vitest-shard-metadata.mts
 scripts/lib/vitest-unhandled-errors.mts
 scripts/lib/vitest-worker-artifacts.mts

--- a/scripts/tsdown-build.mts
+++ b/scripts/tsdown-build.mts
@@ -105,6 +105,7 @@ export const TSDOWN_DECLARATION_TOOL_INPUTS = [
   "scripts/lib/build-artifact-cache.mts",
   "scripts/lib/dist-artifact-ownership.mts",
   "scripts/lib/managed-child-process.mts",
+  "scripts/lib/vitest-resource-ownership.mts",
   "scripts/lib/direct-run.mjs",
   "scripts/lib/repo-root.mjs",
   "scripts/lib/local-check-runtime.mts",

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -656,6 +656,7 @@ describe("package-openclaw-for-docker", () => {
       "scripts/lib/bundled-plugin-paths.mjs",
       "scripts/lib/error-format.mts",
       "scripts/lib/managed-child-process.mts",
+      "scripts/lib/vitest-resource-ownership.mts",
       "scripts/lib/npm-json-output.mts",
       "scripts/lib/optional-bundled-clusters.mjs",
       "scripts/lib/output-root-guard.mjs",

--- a/test/helpers/fixture-lifetime.ts
+++ b/test/helpers/fixture-lifetime.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { findVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
 import { makeTempDir } from "./temp-dir.js";
 
 function hasUnjoinedWork(value: unknown): boolean {
@@ -20,10 +21,19 @@ function hasUnjoinedWork(value: unknown): boolean {
 /** Own whole fixture bodies as well as commands that can outlive a failed assertion. */
 export function createFixtureLifetime() {
   const roots = new Set<string>();
+  const claims = new Map<string, () => void>();
   let pendingCleanup: Promise<void> | undefined;
   const work: { completion: Promise<unknown>; cleanup: boolean }[] = [];
 
+  function register(root?: string) {
+    const owner = findVitestResourceOwner(root);
+    if (owner && !claims.has(owner.root)) {
+      claims.set(owner.root, owner.claim());
+    }
+  }
+
   function track<T>(completion: Promise<T>, cleanup = false): Promise<T> {
+    register();
     work.push({ completion, cleanup });
     void completion.catch(() => {});
     return completion;
@@ -32,6 +42,7 @@ export function createFixtureLifetime() {
   function run<T>(body: () => Promise<T>): Promise<T> {
     // Register before the callback's first await, and observe late rejection even
     // when Vitest has already rejected its separate timeout/cancellation promise.
+    register();
     return track(Promise.resolve().then(body));
   }
 
@@ -52,6 +63,9 @@ export function createFixtureLifetime() {
     if (failures.length) {
       const ownedRoots = [...roots];
       roots.clear();
+      // Abandon the local handles, never the pending receipts. Later cleanup,
+      // reuse, or module reset cannot certify an earlier failed drain.
+      claims.clear();
       throw new AggregateError(
         failures,
         `Fixture cleanup unverified; retained ${ownedRoots.join(", ")}`,
@@ -74,15 +88,21 @@ export function createFixtureLifetime() {
     if (errors.length > 1) {
       throw new AggregateError(errors, "Test temporary directory cleanup failed");
     }
+    for (const [root, release] of claims) {
+      release();
+      claims.delete(root);
+    }
   }
 
   return {
     run,
     track,
     verifyCleanup: (body: () => Promise<void>) => {
+      register();
       return track(Promise.resolve().then(body), true);
     },
     createTempDir: (prefix: string, root?: string) => {
+      register(root);
       return makeTempDir(roots, prefix, root);
     },
     cleanup() {

--- a/test/helpers/fixture-lifetime.ts
+++ b/test/helpers/fixture-lifetime.ts
@@ -18,14 +18,14 @@ function hasUnjoinedWork(value: unknown): boolean {
   );
 }
 
-/** Own whole fixture bodies as well as commands that can outlive a failed assertion. */
-export function createFixtureLifetime() {
+/** Own whole fixture bodies; an explicit root scopes deliberate retention without changing env. */
+export function createFixtureLifetime(ownerRoot?: string) {
   const roots = new Set<string>();
   const claims = new Map<string, () => void>();
   let pendingCleanup: Promise<void> | undefined;
   const work: { completion: Promise<unknown>; cleanup: boolean }[] = [];
 
-  function register(root?: string) {
+  function register(root = ownerRoot) {
     const owner = findVitestResourceOwner(root);
     if (owner && !claims.has(owner.root)) {
       claims.set(owner.root, owner.claim());
@@ -101,7 +101,7 @@ export function createFixtureLifetime() {
       register();
       return track(Promise.resolve().then(body), true);
     },
-    createTempDir: (prefix: string, root?: string) => {
+    createTempDir: (prefix: string, root = ownerRoot) => {
       register(root);
       return makeTempDir(roots, prefix, root);
     },

--- a/test/helpers/fixture-lifetime.ts
+++ b/test/helpers/fixture-lifetime.ts
@@ -48,46 +48,55 @@ export function createFixtureLifetime(ownerRoot?: string) {
 
   async function drain() {
     const failures: unknown[] = [];
-    // Bodies can register their final command/cleanup while unwinding. Drain
-    // those too; a rejected command alone does not certify process-group death.
-    while (work.length) {
-      const batch = work.splice(0);
-      const results = await Promise.allSettled(batch.map((item) => item.completion));
-      for (const [index, result] of results.entries()) {
-        const value: unknown = result.status === "rejected" ? result.reason : result.value;
-        if ((batch[index]!.cleanup && result.status === "rejected") || hasUnjoinedWork(value)) {
-          failures.push(value);
+    // Removal yields too: work admitted during it still owns this same claim.
+    // Drain those bodies and roots before publishing any completion receipt.
+    do {
+      // Bodies can register their final command/cleanup while unwinding. Drain
+      // those too; a rejected command alone does not certify process-group death.
+      while (work.length) {
+        const batch = work.splice(0);
+        const results = await Promise.allSettled(batch.map((item) => item.completion));
+        for (const [index, result] of results.entries()) {
+          const value: unknown = result.status === "rejected" ? result.reason : result.value;
+          if ((batch[index]!.cleanup && result.status === "rejected") || hasUnjoinedWork(value)) {
+            failures.push(value);
+          }
         }
       }
-    }
-    if (failures.length) {
-      const ownedRoots = [...roots];
-      roots.clear();
-      // Abandon the local handles, never the pending receipts. Later cleanup,
-      // reuse, or module reset cannot certify an earlier failed drain.
-      claims.clear();
-      throw new AggregateError(
-        failures,
-        `Fixture cleanup unverified; retained ${ownedRoots.join(", ")}`,
+      if (failures.length) {
+        const ownedRoots = [...roots];
+        roots.clear();
+        // Abandon the local handles, never the pending receipts. Later cleanup,
+        // reuse, or module reset cannot certify an earlier failed drain.
+        claims.clear();
+        throw new AggregateError(
+          failures,
+          `Fixture cleanup unverified; retained ${ownedRoots.join(", ")}`,
+        );
+      }
+      // Recursive removal can take seconds on Darwin. Keep sibling command deadlines,
+      // output drainage, and reaping live while releasing these already-joined inputs.
+      const removals = await Promise.allSettled(
+        [...roots].map(async (root) => {
+          await fs.promises.rm(root, {
+            recursive: true,
+            force: true,
+            maxRetries: 5,
+            retryDelay: 20,
+          });
+          roots.delete(root);
+        }),
       );
-    }
-    // Recursive removal can take seconds on Darwin. Keep sibling command deadlines,
-    // output drainage, and reaping live while releasing these already-joined inputs.
-    const removals = await Promise.allSettled(
-      [...roots].map(async (root) => {
-        await fs.promises.rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
-        roots.delete(root);
-      }),
-    );
-    const errors = removals.flatMap((result) =>
-      result.status === "rejected" ? [result.reason] : [],
-    );
-    if (errors.length === 1) {
-      throw errors[0];
-    }
-    if (errors.length > 1) {
-      throw new AggregateError(errors, "Test temporary directory cleanup failed");
-    }
+      const errors = removals.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+      if (errors.length === 1) {
+        throw errors[0];
+      }
+      if (errors.length > 1) {
+        throw new AggregateError(errors, "Test temporary directory cleanup failed");
+      }
+    } while (work.length || roots.size);
     for (const [root, release] of claims) {
       release();
       claims.delete(root);

--- a/test/helpers/run-node-script.test.ts
+++ b/test/helpers/run-node-script.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
+import { createVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
 import { createFixtureLifetime } from "./fixture-lifetime.js";
 import { waitForDead, waitForPidFile } from "./process-wait.js";
 import { runNodeScript } from "./run-node-script.js";
@@ -74,6 +75,11 @@ if(mode==='at limit') {
 it.skipIf(process.platform === "win32")(
   "retains inputs when captured command output leaves cleanup uncertain",
   async ({ signal }) => {
+    const ownerRoot = tempDirs.make("node-script-owner-");
+    const owner = createVitestResourceOwner(ownerRoot);
+    for (const key of ["TMPDIR", "TMP", "TEMP"]) {
+      vi.stubEnv(key, ownerRoot);
+    }
     const fixture = createFixtureLifetime();
     const directory = fixture.createTempDir("openclaw-node-script-uncertain-");
     const script = join(directory, "parent.mjs");
@@ -110,6 +116,7 @@ child.once('message',()=>process.exit(0));
         processTreeState: "indeterminate",
       });
       await expect(fixture.cleanup()).rejects.toThrow("Fixture cleanup unverified");
+      expect(() => owner.assertReleased()).toThrow("Unreleased Vitest resource claim");
       expect(existsSync(directory)).toBe(true);
       writeFileSync(release, "release");
       await waitForDead(await waitForPidFile(pidFile, 2_000), 2_000);
@@ -124,6 +131,7 @@ child.once('message',()=>process.exit(0));
       }
       await fixture.cleanup();
       rmSync(directory, { recursive: true, force: true });
+      vi.unstubAllEnvs();
     }
   },
 );

--- a/test/scripts/dist-artifact-ownership.test.ts
+++ b/test/scripts/dist-artifact-ownership.test.ts
@@ -9,6 +9,7 @@ import {
   TSDOWN_NON_SDK_DTS_CONFIG_GROUPS,
   TSDOWN_PLUGIN_SDK_DTS_CONFIG_GROUPS,
 } from "../../scripts/lib/tsdown-config-groups.mts";
+import { createVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
 import { createFixtureLifetime } from "../helpers/fixture-lifetime.js";
 import { waitForDead } from "../helpers/process-wait.js";
 import { createFixture as createDeclarationFixture } from "./tsdown-declaration-fixture.js";
@@ -134,6 +135,7 @@ async function runWithProcesses(
       root: string,
       script: string,
       args?: string[],
+      resourceOwner?: ReturnType<typeof createVitestResourceOwner>,
     ) => {
       waiting: Promise<void>;
       done: Promise<{ code: unknown; output: string }>;
@@ -228,16 +230,23 @@ async function runWithProcesses(
         socket.on('data', () => socket.end());
       `,
       waitEvent,
-      start: (root, script, args = []) => {
+      start: (root, script, args, resourceOwner) => {
         signal.throwIfAborted();
-        const child = spawn(process.execPath, [script, ...args], {
+        const commandArgs = [script, ...(args ?? [])];
+        const child = spawn(process.execPath, commandArgs, {
           cwd: root,
-          env: { ...process.env, npm_execpath: path.join(root, "pnpm.cjs") },
+          env: {
+            ...process.env,
+            ...(resourceOwner
+              ? { TMPDIR: resourceOwner.root, TMP: resourceOwner.root, TEMP: resourceOwner.root }
+              : {}),
+            npm_execpath: path.join(root, "pnpm.cjs"),
+          },
           stdio: ["ignore", "pipe", "pipe"],
         });
         children.push(child);
         let output = "";
-        diagnostics.push(() => `[fixture ${root}] ${script} ${args.join(" ")}\n${output}`);
+        diagnostics.push(() => `[fixture ${root}] ${commandArgs.join(" ")}\n${output}`);
         let announceWait!: () => void;
         const waiting = new Promise<void>((resolve) => {
           announceWait = resolve;
@@ -554,6 +563,9 @@ describe.skipIf(process.platform === "win32")("dist artifact ownership", () => {
   it("retains ownership when a supervisor exits before its compiler joins", async ({ signal }) => {
     await withProcesses(async ({ checkpoint, waitEvent, start }) => {
       const root = createCheckout();
+      // This fixture deliberately loses the managed owner. Its independent
+      // checkpoint census below still joins the compiler before disposing inputs.
+      const resourceOwner = createVitestResourceOwner(root);
       installCompiler(
         root,
         `require('node:fs').writeFileSync('compiler.pid', String(process.pid)); ${checkpoint("orphan-ready")}`,
@@ -570,7 +582,7 @@ describe.skipIf(process.platform === "win32")("dist artifact ownership", () => {
           `await import(${JSON.stringify(path.join(sourceRoot, "scripts/run-tsgo.mts"))});`,
         ].join("\n"),
       );
-      const supervisor = start(root, owner);
+      const supervisor = start(root, owner, [], resourceOwner);
       const compilerGate = await supervisor.event("orphan-ready");
       const compilerPid = Number(fs.readFileSync(path.join(root, "compiler.pid"), "utf8"));
       (await waitEvent("exit-owner")).write("exit");
@@ -588,6 +600,7 @@ describe.skipIf(process.platform === "win32")("dist artifact ownership", () => {
       expect(fs.existsSync(path.join(root, ".artifacts/dist-artifacts.lock/owner.json"))).toBe(
         true,
       );
+      expect(() => resourceOwner.assertReleased()).toThrow("Unreleased Vitest resource claim");
       compilerGate.write("continue");
       await waitForDead(compilerPid, 2_000);
     }, signal);
@@ -598,6 +611,7 @@ describe.skipIf(process.platform === "win32")("dist artifact ownership", () => {
   }) => {
     await withProcesses(async ({ checkpoint, waitEvent, start }) => {
       const root = createCheckout();
+      const resourceOwner = createVitestResourceOwner(root);
       installCompiler(
         root,
         `require('node:fs').writeFileSync('compiler.json', JSON.stringify({ pid: process.pid, wrapper: process.ppid })); ${checkpoint("nested-compiler-ready")}`,
@@ -617,7 +631,7 @@ describe.skipIf(process.platform === "win32")("dist artifact ownership", () => {
           `bin: process.execPath, args: distArtifactEntryArgs(${JSON.stringify(path.join(sourceRoot, "scripts/run-tsgo.mts"))}, ${JSON.stringify(tsgoArgs)}), requireProcessTreeExit: true }));`,
         ].join("\n"),
       );
-      const supervisor = start(root, owner);
+      const supervisor = start(root, owner, [], resourceOwner);
       const compilerGate = await supervisor.event("nested-compiler-ready");
       const compiler = JSON.parse(fs.readFileSync(path.join(root, "compiler.json"), "utf8"));
       try {
@@ -629,6 +643,7 @@ describe.skipIf(process.platform === "win32")("dist artifact ownership", () => {
           fs.existsSync(path.join(root, declarationPath)),
           "a killed nested wrapper cannot certify compiler completion",
         ).toBe(true);
+        expect(() => resourceOwner.assertReleased()).toThrow("Unreleased Vitest resource claim");
       } finally {
         compilerGate.write("continue");
         await waitForDead(compiler.pid, 2_000);

--- a/test/scripts/docker-all-harness.test-support.ts
+++ b/test/scripts/docker-all-harness.test-support.ts
@@ -22,6 +22,7 @@ export function copyDockerSchedulerHarness(root: string) {
     "docker-e2e-scenarios.mts",
     "local-check-runtime.mts",
     "managed-child-process.mts",
+    "vitest-resource-ownership.mts",
     "official-external-channel-catalog.json",
     "release-version.mjs",
     "sleep.mjs",

--- a/test/scripts/fixture-lifetime.test.ts
+++ b/test/scripts/fixture-lifetime.test.ts
@@ -32,13 +32,18 @@ it("registers fresh fixture work after clean release and module reset", async ()
   vi.resetModules();
   const { createFixtureLifetime: createFreshLifetime } =
     await import("../helpers/fixture-lifetime.js");
-  const fresh = createFreshLifetime();
-  for (const lifetime of [fixture, fresh]) {
+  const nestedOwner = createVitestResourceOwner(tempDirs.make("fixture-explicit-owner-"));
+  const fresh = createFreshLifetime(nestedOwner.root);
+  for (const [lifetime, expectedOwner] of [
+    [fixture, owner],
+    [fresh, nestedOwner],
+  ] as const) {
     const root = lifetime.createTempDir("fixture-fresh-");
-    expect(() => owner.assertReleased()).toThrow("Unreleased Vitest resource claim");
+    expect(path.dirname(root)).toBe(expectedOwner.root);
+    expect(() => expectedOwner.assertReleased()).toThrow("Unreleased Vitest resource claim");
     await lifetime.cleanup();
     expect(fs.existsSync(root)).toBe(false);
-    expect(() => owner.assertReleased()).not.toThrow();
+    expect(() => expectedOwner.assertReleased()).not.toThrow();
   }
 });
 

--- a/test/scripts/fixture-lifetime.test.ts
+++ b/test/scripts/fixture-lifetime.test.ts
@@ -1,14 +1,46 @@
 import { getEventListeners } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
 import { runNodeStep } from "../../scripts/prepare-extension-package-boundary-artifacts.mts";
 import { createFixtureLifetime } from "../helpers/fixture-lifetime.js";
 import { isProcessAlive, waitForDead } from "../helpers/process-wait.js";
 import { createDeferred } from "../helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let owner: ReturnType<typeof createVitestResourceOwner>;
+beforeEach(() => {
+  // The tests deliberately retain claims, then join/dispose their own probes.
+  // Model that namespace separately from the runner executing these assertions.
+  const root = tempDirs.make("fixture-lifetime-owner-");
+  owner = createVitestResourceOwner(root);
+  for (const key of ["TMPDIR", "TMP", "TEMP"]) {
+    vi.stubEnv(key, root);
+  }
+});
+afterEach(() => vi.unstubAllEnvs());
 const fixture = createFixtureLifetime();
 afterEach(() => fixture.cleanup());
+
+it("registers fresh fixture work after clean release and module reset", async () => {
+  const first = fixture.createTempDir("fixture-first-");
+  await fixture.cleanup();
+  expect(fs.existsSync(first)).toBe(false);
+  expect(() => owner.assertReleased()).not.toThrow();
+  vi.resetModules();
+  const { createFixtureLifetime: createFreshLifetime } =
+    await import("../helpers/fixture-lifetime.js");
+  const fresh = createFreshLifetime();
+  for (const lifetime of [fixture, fresh]) {
+    const root = lifetime.createTempDir("fixture-fresh-");
+    expect(() => owner.assertReleased()).toThrow("Unreleased Vitest resource claim");
+    await lifetime.cleanup();
+    expect(fs.existsSync(root)).toBe(false);
+    expect(() => owner.assertReleased()).not.toThrow();
+  }
+});
 
 it("cleans independent roots after a removal failure and retries the retained root", async () => {
   const lifetime = createFixtureLifetime();
@@ -29,6 +61,7 @@ it("cleans independent roots after a removal failure and retries the retained ro
     removal.mockRestore();
     await lifetime.cleanup();
     expect(fs.existsSync(first)).toBe(false);
+    expect(() => owner.assertReleased()).not.toThrow();
   } finally {
     removal.mockRestore();
     for (const root of [first, second]) {
@@ -300,6 +333,11 @@ it.each(["cause", "aggregate", "cleanup"])(
     try {
       await expect(fixture.cleanup()).rejects.toThrow("Fixture cleanup unverified");
       expect(fs.existsSync(root)).toBe(true);
+      await fixture.cleanup();
+      const next = fixture.createTempDir("fixture-lifetime-reused-");
+      await fixture.cleanup();
+      expect(fs.existsSync(next)).toBe(false);
+      expect(() => owner.assertReleased()).toThrow("Unreleased Vitest resource claim");
     } finally {
       // The injected uncertainty has no process behind it; this test owns its disposal.
       fs.rmSync(root, { recursive: true, force: true });

--- a/test/scripts/fixture-lifetime.test.ts
+++ b/test/scripts/fixture-lifetime.test.ts
@@ -75,6 +75,57 @@ it("cleans independent roots after a removal failure and retries the retained ro
   }
 });
 
+it("holds claims for work admitted during asynchronous fixture removal", async () => {
+  const lifetime = createFixtureLifetime();
+  const first = lifetime.createTempDir("fixture-removing-");
+  const removing = createDeferred();
+  const allowRemoval = createDeferred();
+  const removed = createDeferred();
+  const allowWork = createDeferred();
+  const remove = fs.promises.rm;
+  const removal = vi.spyOn(fs.promises, "rm").mockImplementation(async (root, options) => {
+    if (root === first) {
+      removing.resolve();
+      await allowRemoval.promise;
+    }
+    await remove(root, options);
+    if (root === first) {
+      removed.resolve();
+    }
+  });
+  let cleaned = false;
+  const cleanup = lifetime.cleanup().then(() => {
+    cleaned = true;
+  });
+  let work: Promise<void> | undefined;
+  try {
+    await removing.promise;
+    const later = lifetime.createTempDir("fixture-admitted-during-removal-");
+    work = lifetime.run(() => allowWork.promise);
+    allowRemoval.resolve();
+    await removed.promise;
+    // Let the first removal's completion callbacks run while the later body is held.
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(cleaned).toBe(false);
+    expect(() => owner.assertReleased()).toThrow("Unreleased Vitest resource claim");
+    expect(fs.existsSync(later)).toBe(true);
+    allowWork.resolve();
+    await work;
+    await cleanup;
+    expect(fs.existsSync(later)).toBe(false);
+    expect(() => owner.assertReleased()).not.toThrow();
+  } finally {
+    allowRemoval.resolve();
+    allowWork.resolve();
+    await work;
+    await cleanup;
+    removal.mockRestore();
+    await lifetime.cleanup();
+  }
+});
+
 it
   .skipIf(process.platform === "win32")
   .for(["normal", "missing readiness", "held close", "early exit", "cleanup rejection"])(

--- a/test/scripts/lint-status.test.ts
+++ b/test/scripts/lint-status.test.ts
@@ -49,6 +49,7 @@ export function waitForFile(file) {
     "lib/dist-artifact-ownership.mts",
     "lib/failed-trailer.mts",
     "lib/managed-child-process.mts",
+    "lib/vitest-resource-ownership.mts",
     "lib/windows-taskkill.mjs",
     "lib/repo-root.mjs",
   ]) {

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -15,6 +15,7 @@ import {
   terminateManagedChild,
   waitForManagedProcessGroupExit,
 } from "../../scripts/lib/managed-child-process.mts";
+import { createVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
 import {
   runNodeStep,
   runNodeStepsInParallel,
@@ -84,6 +85,25 @@ fs.renameSync(pidPath + ".tmp", pidPath);
 }
 
 describe("managed-child-process", () => {
+  it("registers with the containing owner when the command creates its own TMP leaf", async () => {
+    const root = createTempDir("managed-command-owner-");
+    const owner = createVitestResourceOwner(root);
+    const tmp = path.join(root, "child-tmp");
+    const code = await runManagedCommand({
+      bin: process.execPath,
+      args: ["-e", "require('node:fs').mkdirSync(process.env.TMPDIR)"],
+      env: { ...process.env, TMPDIR: tmp, TMP: tmp, TEMP: tmp },
+      shell: false,
+      stdio: "ignore",
+      onReady() {
+        expect(() => owner.assertReleased()).toThrow("Unreleased Vitest resource claim");
+      },
+    });
+    expect(code).toBe(0);
+    expect(fs.existsSync(tmp)).toBe(true);
+    expect(() => owner.assertReleased()).not.toThrow();
+  });
+
   it.runIf(process.platform === "linux")(
     "accepts exited tooling descendants still awaiting reaping",
     async () => {
@@ -1005,6 +1025,8 @@ setInterval(() => {}, 1_000);
   });
 
   it("fails closed when Windows taskkill cannot verify timeout cleanup", async () => {
+    const root = createTempDir("managed-command-owner-");
+    const owner = createVitestResourceOwner(root);
     const originalSystemRoot = process.env.SystemRoot;
     const originalWindir = process.env.WINDIR;
     let childPid = 0;
@@ -1024,6 +1046,7 @@ setInterval(() => {}, 1_000);
           },
           platform: "win32",
           runTaskkill,
+          env: { ...process.env, TMPDIR: root, TMP: root, TEMP: root },
           shell: false,
           stdio: "ignore",
           timeoutMs: 200,
@@ -1044,6 +1067,7 @@ setInterval(() => {}, 1_000);
         },
       );
       await waitFor(() => !isProcessAlive(childPid));
+      expect(() => owner.assertReleased()).toThrow("Unreleased Vitest resource claim");
     } finally {
       restoreEnvValue("SystemRoot", originalSystemRoot);
       restoreEnvValue("WINDIR", originalWindir);
@@ -1180,6 +1204,10 @@ if (role === "leaf") {
       const dir = fs.mkdtempSync(
         path.join(fs.realpathSync(os.tmpdir()), "openclaw-managed-held-output-"),
       );
+      // This namespace owns the deliberate failed join and manual rescue. Pass
+      // it explicitly so concurrent rows never mutate shared worker environment.
+      const owner = createVitestResourceOwner(dir);
+      const env = { ...process.env, TMPDIR: dir, TMP: dir, TEMP: dir };
       const pidPath = path.join(dir, "escaped.pid");
       const parentPidPath = path.join(dir, "parent.pid");
       const failPath = path.join(dir, "fail");
@@ -1224,6 +1252,7 @@ child.once('message', () => { ${normalExit ? "process.exit(0);" : ""} });
             ? runManagedCommand({
                 bin: process.execPath,
                 args,
+                env,
                 stdio: ["ignore", "pipe", "pipe"],
                 timeoutMs: mode === "timeout" ? 100 : undefined,
                 // This row verifies the full pipe-drain budget, not the default TERM grace.
@@ -1244,9 +1273,10 @@ child.once('message', () => { ${normalExit ? "process.exit(0);" : ""} });
                 },
               })
             : runNodeStepsInParallel([
-                { label: "blocked", args, timeoutMs: 100, abortKillGraceMs: 100 },
+                { label: "blocked", args, env, timeoutMs: 100, abortKillGraceMs: 100 },
                 {
                   label: "primary",
+                  env,
                   args: [
                     "-e",
                     `setInterval(() => { if (require('node:fs').existsSync(${JSON.stringify(failPath)})) process.exit(2); }, 5);`,
@@ -1314,6 +1344,11 @@ child.once('message', () => { ${normalExit ? "process.exit(0);" : ""} });
           await waitForDead(escapedPid, 2_000);
         }
         expectCase(isProcessAlive(escapedPid)).toBe(mode !== "normal drainage");
+        if (mode === "normal drainage") {
+          expectCase(() => owner.assertReleased()).not.toThrow();
+        } else {
+          expectCase(() => owner.assertReleased()).toThrow("Unreleased Vitest resource claim");
+        }
       } finally {
         fs.writeFileSync(failPath, "fail");
         abortController.abort();

--- a/test/scripts/nested-retention.test-support.ts
+++ b/test/scripts/nested-retention.test-support.ts
@@ -204,7 +204,6 @@ export default {
   const abort = () => killGroup(child.pid!);
   signal.addEventListener("abort", abort, { once: true });
   const deadline = setTimeout(abort, 60000);
-  let joined = false;
   let outerClosed = false;
   const taskProcesses = () => {
     let pids: string;
@@ -351,7 +350,6 @@ export default {
           }),
         );
         expect(taskProcesses()).toEqual([]);
-        joined = outerClosed;
         write(
           "cleanup.json",
           JSON.stringify(
@@ -370,9 +368,8 @@ export default {
     clearTimeout(deadline);
     signal.removeEventListener("abort", abort);
     write("output.log", output);
-    // Keep all evidence on failure, and never recursively delete unjoined inputs.
-    if (joined) {
-      fs.rmSync(file("tmp"), { recursive: true, force: true });
-    }
   }
+  // Only a successful scenario and every joined cleanup may dispose the complete
+  // fixture. Any body or cleanup failure retains its evidence and inputs.
+  fs.rmSync(root, { recursive: true, force: true });
 }

--- a/test/scripts/nested-retention.test-support.ts
+++ b/test/scripts/nested-retention.test-support.ts
@@ -1,0 +1,378 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { expect } from "vitest";
+import { spawnOwnedVitestProcess } from "../../scripts/lib/vitest-process.mts";
+import { isProcessAlive, waitForDead, waitForFile } from "../helpers/process-wait.js";
+import { withTestTimeout } from "../helpers/promise.js";
+import { runQaGatewayFixture } from "../helpers/qa-gateway-cleanup.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+
+/** Real escaped writer, inner fixture lifetime, and two non-isolated worker files. */
+export async function proveNestedRetention(
+  root: string,
+  pool: "threads" | "forks",
+  signal: AbortSignal,
+  mode: "failure" | "swallowed" | "crash" = "failure",
+) {
+  const file = (name: string) => path.join(root, name);
+  const source = (name: string) => JSON.stringify(path.join(repoRoot, name));
+  const read = (name: string) => JSON.parse(fs.readFileSync(file(name), "utf8"));
+  const write = (name: string, text: string) => fs.writeFileSync(file(name), text);
+  write(
+    "process.mjs",
+    `import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+const [role, control, input] = process.argv.slice(2);
+const file = name => path.join(control, name);
+const publish = (name, data) => {
+  fs.writeFileSync(file(name + '.tmp'), JSON.stringify(data));
+  fs.renameSync(file(name + '.tmp'), file(name));
+};
+if (role === 'leader') {
+  const child = spawn(process.execPath, [import.meta.filename, 'writer', control, input], {
+    detached: true, stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+  });
+  publish('writer.pid.json', child.pid);
+  child.once('message', () => process.exit(0));
+  child.once('error', () => process.exit(2));
+} else {
+  // A safety deadline is not a readiness signal. The test must stop and join us.
+  const deadline = setTimeout(() => process.exit(3), 90000);
+  const poll = setInterval(() => {
+    if (fs.existsSync(file('stop'))) {
+      clearTimeout(deadline);
+      clearInterval(poll);
+      return;
+    }
+    for (const phase of ['before', 'after']) {
+      if (!fs.existsSync(file(phase + '.request')) || fs.existsSync(file(phase + '.json'))) continue;
+      try {
+        fs.appendFileSync(input, phase + '\\n');
+        publish(phase + '.json', { pid: process.pid, written: phase });
+      } catch (error) {
+        publish(phase + '.json', { pid: process.pid, error: error.code });
+      }
+    }
+  }, 5);
+  process.send('ready');
+  process.disconnect();
+}
+`,
+  );
+  write(
+    "01-retain.test.ts",
+    `import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { afterEach, expect, it } from 'vitest';
+import { threadId } from 'node:worker_threads';
+import { createFixtureLifetime } from ${source("test/helpers/fixture-lifetime.ts")};
+import { runManagedCommand, inspectManagedProcessGroup } from ${source("scripts/lib/managed-child-process.mts")};
+import { waitForFile } from ${source("test/helpers/process-wait.ts")};
+const lifetime = createFixtureLifetime();
+const control = ${JSON.stringify(root)};
+const file = name => path.join(control, name);
+let retained;
+afterEach(async () => {
+  try { await lifetime.cleanup(); }
+  catch (error) {
+    expect(error).toBeInstanceOf(AggregateError);
+    expect(error.errors[0]).toMatchObject({ code: 'EPROCESSGROUP_CLEANUP_FAILED', processTreeState: 'indeterminate' });
+    expect(fs.existsSync(retained.root)).toBe(true);
+    fs.writeFileSync(file('retained.json'), JSON.stringify({ ...retained, cleanup: error.message, cleanupCode: error.errors[0].code, processTreeState: error.errors[0].processTreeState }));
+    ${mode === "swallowed" ? "" : "throw error;"}
+  }
+});
+it('retains inputs after a genuine escaped writer fails strict join', async () => {
+  const root = lifetime.createTempDir('inner-retained-');
+  const input = path.join(root, 'input');
+  fs.writeFileSync(input, 'owned\\n');
+  let child;
+  const command = lifetime.track(runManagedCommand({
+    bin: process.execPath, args: [file('process.mjs'), 'leader', control, input],
+    shell: false, stdio: ['ignore', 'pipe', 'pipe'], requireProcessTreeExit: true,
+    timeoutMs: 15000, timeoutKillGraceMs: 0,
+    onReady(owned) {
+      child = owned;
+      fs.writeFileSync(file('leader.pid.json'), JSON.stringify(child.pid));
+    },
+  }));
+  fs.writeFileSync(file('before.request'), 'write');
+  await waitForFile(file('before.json'), 10000);
+  const before = JSON.parse(fs.readFileSync(file('before.json'), 'utf8'));
+  expect(before.written).toBe('before');
+  retained = { root, input, namespace: os.tmpdir(), workerPid: process.pid, threadId, leaderPid: child.pid, writerPid: before.pid };
+  fs.writeFileSync(file('retained.json'), JSON.stringify(retained));
+  ${mode === "crash" ? "process.kill(process.pid, 'SIGKILL'); await new Promise(() => {});" : ""}
+  await expect(command).rejects.toMatchObject({ code: 'EPROCESSGROUP_CLEANUP_FAILED', processTreeState: 'indeterminate' });
+  expect(child.exitCode).toBe(0);
+  expect(inspectManagedProcessGroup(child, { errorPolicy: 'indeterminate' })).toBe('dead');
+  expect(child.stdout.destroyed).toBe(true);
+}, 25000);
+`,
+  );
+  write(
+    "02-reset.test.ts",
+    `import fs from 'node:fs';
+import { threadId } from 'node:worker_threads';
+import { expect, it, vi } from 'vitest';
+vi.resetModules();
+const { createFixtureLifetime } = await import(${source("test/helpers/fixture-lifetime.ts")});
+it('keeps retained inputs across the next non-isolated file and module reset', async () => {
+  const retained = JSON.parse(fs.readFileSync(${JSON.stringify(file("retained.json"))}, 'utf8'));
+  expect(process.pid).toBe(retained.workerPid);
+  expect(threadId).toBe(retained.threadId);
+  await createFixtureLifetime().cleanup();
+  expect(fs.readFileSync(retained.input, 'utf8')).toBe('owned\\nbefore\\n');
+});
+`,
+  );
+  write(
+    "vitest.config.ts",
+    `import { sharedVitestConfig } from ${source("test/vitest/vitest.shared.config.ts")};
+import { BaseSequencer } from 'vitest/node';
+class Ordered extends BaseSequencer {
+  async sort(files) { return [...files].sort((a, b) => a.moduleId.localeCompare(b.moduleId)); }
+}
+export default {
+  resolve: sharedVitestConfig.resolve, plugins: sharedVitestConfig.plugins,
+  cacheDir: ${JSON.stringify(file("cache"))},
+  test: {
+    include: [${JSON.stringify(mode === "crash" ? "01-retain.test.ts" : "0*.test.ts")}], pool: ${JSON.stringify(pool)}, isolate: false,
+    maxWorkers: 1, fileParallelism: false, sequence: { sequencer: Ordered },
+    runner: ${source("test/non-isolated-runner.ts")},
+    reporters: ['verbose', 'json'], outputFile: ${JSON.stringify(file("report.json"))},
+    testTimeout: 25000, hookTimeout: 10000, teardownTimeout: 5000,
+  },
+};
+`,
+  );
+  const args = [
+    path.join(repoRoot, "scripts/run-vitest.mjs"),
+    "run",
+    "--config",
+    file("vitest.config.ts"),
+    "--root",
+    root,
+    "--configLoader",
+    "native",
+  ];
+  const { child, completion } = spawnOwnedVitestProcess({
+    command: process.execPath,
+    args,
+    options: {
+      cwd: root,
+      env: {
+        PATH: process.env.PATH,
+        HOME: file("home"),
+        USERPROFILE: file("home"),
+        TMPDIR: file("tmp"),
+        TMP: file("tmp"),
+        TEMP: file("tmp"),
+        CI: "1",
+        NODE_DISABLE_COMPILE_CACHE: "1",
+        TSX_DISABLE_CACHE: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  });
+  let output = "";
+  for (const pipe of [child.stdout, child.stderr]) {
+    pipe!.on("data", (chunk) => {
+      output += String(chunk);
+    });
+  }
+  const outcome = completion.then(
+    (result) => ({ result }),
+    (error: unknown) => ({ error: String(error) }),
+  );
+  const closed = new Promise<void>((resolve) => {
+    child.once("close", () => resolve());
+  });
+  const killGroup = (pid: number) => {
+    try {
+      process.kill(-pid, "SIGKILL");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+        throw error;
+      }
+    }
+  };
+  const abort = () => killGroup(child.pid!);
+  signal.addEventListener("abort", abort, { once: true });
+  const deadline = setTimeout(abort, 60000);
+  let joined = false;
+  let outerClosed = false;
+  const taskProcesses = () => {
+    let pids: string;
+    try {
+      // Select the unique fixture first: unrelated host argv can exceed ps's
+      // capture budget and must never enter test diagnostics or cleanup.
+      pids = execFileSync("pgrep", ["-f", root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")], {
+        encoding: "utf8",
+        timeout: 2000,
+      }).trim();
+    } catch (error) {
+      if (error && typeof error === "object" && "status" in error && error.status === 1) {
+        return [];
+      }
+      throw error;
+    }
+    return execFileSync("ps", ["-p", pids.split(/\s+/).join(","), "-o", "pid=,pgid=,command="], {
+      encoding: "utf8",
+      timeout: 2000,
+    })
+      .split("\n")
+      .filter(
+        (line) =>
+          line
+            .trimStart()
+            .replace(/^\d+\s+\d+\s+/, "")
+            .startsWith(process.execPath + " ") &&
+          line.includes(root) &&
+          [
+            file("process.mjs"),
+            "scripts/run-vitest.mjs",
+            "scripts/lib/vitest-worker-bootstrap.mts",
+          ].some((entry) => line.includes(entry)),
+      )
+      .map((line) => {
+        const match = /^\s*(\d+)\s+(\d+)\s/.exec(line);
+        if (!match) {
+          throw new Error("Could not inspect task-owned process");
+        }
+        return { pid: Number(match[1]), group: Number(match[2]) };
+      });
+  };
+  try {
+    await runQaGatewayFixture(
+      async () => {
+        signal.throwIfAborted();
+        const outer = await withTestTimeout(outcome, 65000, "outer completion did not settle");
+        await withTestTimeout(closed, 5000, "outer child did not close");
+        const retained = read("retained.json");
+        const before = read("before.json");
+        write("after.request", "write");
+        await waitForFile(file("after.json"), 5000);
+        const after = read("after.json");
+        const observation = {
+          pool,
+          mode,
+          node: process.version,
+          command: [process.execPath, ...args],
+          outer,
+          outerPid: child.pid,
+          outerAlive: isProcessAlive(child.pid!),
+          workerAlive: isProcessAlive(retained.workerPid),
+          leaderAlive: isProcessAlive(retained.leaderPid),
+          retained,
+          before,
+          after,
+          writerAlive: isProcessAlive(retained.writerPid),
+          rootExists: fs.existsSync(retained.root),
+          namespaceExists: fs.existsSync(retained.namespace),
+          processes: execFileSync(
+            "ps",
+            ["-o", "pid=,ppid=,pgid=,stat=", "-p", String(retained.writerPid)],
+            { encoding: "utf8", timeout: 2000 },
+          ).trim(),
+        };
+        write("observation.json", JSON.stringify(observation, null, 2));
+        if (mode !== "crash") {
+          const report = read("report.json");
+          expect(report.testResults.map((entry: { status: string }) => entry.status)).toEqual([
+            mode === "failure" ? "failed" : "passed",
+            "passed",
+          ]);
+          if (mode === "failure") {
+            expect(report.testResults[0].assertionResults[0].failureMessages.join("\n")).toContain(
+              "Managed command cleanup could not verify child, process group, and output closure",
+            );
+          } else {
+            expect(report.success).toBe(true);
+          }
+        }
+        expect(outer).toHaveProperty(
+          "error",
+          expect.stringContaining("retained temporary namespace"),
+        );
+        expect(output).toContain(`retained temporary namespace ${retained.namespace}`);
+        expect(observation.outerAlive).toBe(false);
+        expect(observation.workerAlive).toBe(false);
+        expect(observation.leaderAlive).toBe(false);
+        expect(observation.writerAlive).toBe(true);
+        expect(after.pid).toBe(before.pid);
+        expect(
+          observation.rootExists,
+          `nested retained root was deleted while writer ${after.pid} remained live; evidence: ${file("observation.json")}`,
+        ).toBe(true);
+        expect(after).toEqual({ pid: before.pid, written: "after" });
+      },
+      async () => {
+        // Include detached nested coordinators; killing only the first wrapper
+        // cannot prevent a late inner launch after a failed readiness wait.
+        if (child.exitCode === null && child.signalCode === null) {
+          abort();
+        }
+        const spawners = taskProcesses();
+        for (const { group } of spawners) {
+          killGroup(group);
+        }
+        for (const { pid } of spawners) {
+          await waitForDead(pid, 5000);
+        }
+        await withTestTimeout(closed, 5000, "outer cleanup did not close");
+        await withTestTimeout(outcome, 5000, "outer cleanup did not settle");
+        outerClosed = true;
+      },
+      async () => {
+        write("stop", "stop");
+        const recorded = ["leader.pid.json", "writer.pid.json"]
+          .filter((name) => fs.existsSync(file(name)))
+          .map((name) => Number(fs.readFileSync(file(name), "utf8")))
+          .filter((pid) => Number.isSafeInteger(pid) && pid > 1);
+        // Close the spawn-to-PID-publication window using the exact task argv.
+        const remaining = taskProcesses();
+        for (const { group } of remaining) {
+          killGroup(group);
+        }
+        const pids = [...new Set([...recorded, ...remaining.map(({ pid }) => pid)])];
+        await runQaGatewayFixture(
+          async () => {},
+          ...pids.map((pid) => async () => {
+            if (!Number.isSafeInteger(pid) || pid <= 1) {
+              throw new Error("Invalid owned fixture PID");
+            }
+            killGroup(pid);
+            await waitForDead(pid, 5000);
+          }),
+        );
+        expect(taskProcesses()).toEqual([]);
+        joined = outerClosed;
+        write(
+          "cleanup.json",
+          JSON.stringify(
+            {
+              outerPid: child.pid,
+              outerClosed,
+              pids: pids.map((pid) => ({ pid, alive: isProcessAlive(pid) })),
+            },
+            null,
+            2,
+          ),
+        );
+      },
+    );
+  } finally {
+    clearTimeout(deadline);
+    signal.removeEventListener("abort", abort);
+    write("output.log", output);
+    // Keep all evidence on failure, and never recursively delete unjoined inputs.
+    if (joined) {
+      fs.rmSync(file("tmp"), { recursive: true, force: true });
+    }
+  }
+}

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -26,6 +26,8 @@ import { delimiter, dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
+import { createFixtureLifetime } from "../helpers/fixture-lifetime.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 import {
   validClawsweeperReviewCommentPages,
@@ -132,8 +134,7 @@ afterAll(() => {
   rmSync(templateRepo, { force: true, recursive: true });
 });
 
-function createRepo(nestedName?: string) {
-  const tempRoot = tempDirs.make("openclaw-pr-operation-lock-");
+function createRepo(nestedName?: string, tempRoot = tempDirs.make("openclaw-pr-operation-lock-")) {
   const dir = nestedName ? join(tempRoot, nestedName) : tempRoot;
   if (nestedName) {
     mkdirSync(dir);
@@ -2633,57 +2634,78 @@ describePosix("scripts/pr per-PR operation lock", () => {
       await cleanupController(repoDir, controller, pidFile);
     }
   }, 15_000);
-  it("retains the lock when a nested managed process group escapes cancellation", async () => {
-    const repoDir = createRepo();
-    const nestedPidFile = join(repoDir, "nested-pgid");
-    const signalRelayedFile = join(repoDir, "nested-signal-relayed");
-    const nestedScript = writeFixtureFile(repoDir, "nested.mjs", [
-      'import fs from "node:fs";',
-      "fs.writeFileSync(process.argv[2], String(process.pid));",
-      'process.on("SIGTERM", () => fs.writeFileSync(process.argv[3], "relayed\\n"));',
-      "setInterval(() => {}, 1000);",
-    ]);
-    const relayScript = writeFixtureFile(repoDir, "relay.mjs", [
-      `import { runManagedCommand } from ${JSON.stringify(managedChildUrl)};`,
-      "process.exitCode = await runManagedCommand({",
-      "  bin: process.execPath,",
-      `  args: [${JSON.stringify(nestedScript)}, ${JSON.stringify(nestedPidFile)}, ${JSON.stringify(signalRelayedFile)}],`,
-      '  stdio: "ignore",',
-      "});",
-    ]);
-    const fixture = writeOperationFixture(repoDir, "nested-operation.sh", [
-      "acquire_pr_operation_lock 42",
-      `node '${relayScript}'`,
-    ]);
-    const controller = spawn(process.execPath, [processGroupRunner, repoDir, fixture], {
-      cwd: repoDir,
-      stdio: "ignore",
-    });
-    let nestedPgid: number | undefined;
-    try {
-      expect(await waitFor(() => existsSync(nestedPidFile) && refExists(repoDir))).toBe(true);
-      nestedPgid = await waitForProcessId(nestedPidFile);
-      const ownerOid = refOid(repoDir);
-      expect(processGroupExists(nestedPgid!)).toBe(true);
-      controller.kill("SIGTERM");
-      expect(await waitFor(() => existsSync(signalRelayedFile))).toBe(true);
-      controller.kill("SIGTERM");
-      await waitForExit(controller, 8000);
-      expect(controller.exitCode).toBe(143);
-      expect(processGroupExists(nestedPgid!)).toBe(true);
-      expect(refOid(repoDir)).toBe(ownerOid);
-      const blocked = probeOperationLock(repoDir);
-      expect(blocked.status).toBe(0);
-      expect(blocked.stdout.trim()).toBe("2");
-      killProcessGroup(nestedPgid!, "SIGKILL");
-      expect(await waitFor(() => !processGroupExists(nestedPgid!))).toBe(true);
-      recoverOperationLock(repoDir, ownerOid);
-    } finally {
-      if (nestedPgid) {
-        await cleanupProcessGroup(nestedPgid);
+  it("retains the lock when a nested managed process group escapes cancellation", async ({
+    onTestFinished,
+  }) => {
+    const lifetime = createFixtureLifetime();
+    onTestFinished(() => lifetime.cleanup());
+    await lifetime.run(async () => {
+      const repoDir = createRepo(undefined, lifetime.createTempDir("pr-escaped-cancellation-"));
+      const resourceOwner = createVitestResourceOwner(repoDir);
+      const nestedPidFile = join(repoDir, "nested-pgid");
+      const signalRelayedFile = join(repoDir, "nested-signal-relayed");
+      const nestedScript = writeFixtureFile(repoDir, "nested.mjs", [
+        'import fs from "node:fs";',
+        "fs.writeFileSync(process.argv[2], String(process.pid));",
+        'process.on("SIGTERM", () => fs.writeFileSync(process.argv[3], "relayed\\n"));',
+        "setInterval(() => {}, 1000);",
+      ]);
+      const relayScript = writeFixtureFile(repoDir, "relay.mjs", [
+        `import { runManagedCommand } from ${JSON.stringify(managedChildUrl)};`,
+        "process.exitCode = await runManagedCommand({",
+        "  bin: process.execPath,",
+        `  args: [${JSON.stringify(nestedScript)}, ${JSON.stringify(nestedPidFile)}, ${JSON.stringify(signalRelayedFile)}],`,
+        '  stdio: "ignore",',
+        "});",
+      ]);
+      const fixture = writeOperationFixture(repoDir, "nested-operation.sh", [
+        "acquire_pr_operation_lock 42",
+        `node '${relayScript}'`,
+      ]);
+      const controller = spawn(process.execPath, [processGroupRunner, repoDir, fixture], {
+        cwd: repoDir,
+        // The test deliberately kills the relay before its managed claim can release.
+        // Only this fixture's independent group census may dispose its retained inputs.
+        env: { ...process.env, TMPDIR: repoDir, TMP: repoDir, TEMP: repoDir },
+        stdio: "ignore",
+      });
+      let nestedPgid: number | undefined;
+      try {
+        expect(await waitFor(() => existsSync(nestedPidFile) && refExists(repoDir))).toBe(true);
+        nestedPgid = await waitForProcessId(nestedPidFile);
+        const ownerOid = refOid(repoDir);
+        expect(processGroupExists(nestedPgid!)).toBe(true);
+        controller.kill("SIGTERM");
+        expect(await waitFor(() => existsSync(signalRelayedFile))).toBe(true);
+        controller.kill("SIGTERM");
+        await waitForExit(controller, 8000);
+        expect(controller.exitCode).toBe(143);
+        expect(processGroupExists(nestedPgid!)).toBe(true);
+        expect(refOid(repoDir)).toBe(ownerOid);
+        const blocked = probeOperationLock(repoDir);
+        expect(blocked.status).toBe(0);
+        expect(blocked.stdout.trim()).toBe("2");
+        expect(() => resourceOwner.assertReleased()).toThrow("Unreleased Vitest resource claim");
+        killProcessGroup(nestedPgid!, "SIGKILL");
+        expect(await waitFor(() => !processGroupExists(nestedPgid!))).toBe(true);
+        recoverOperationLock(repoDir, ownerOid);
+      } finally {
+        await lifetime.verifyCleanup(async () => {
+          try {
+            await cleanupController(repoDir, controller);
+          } finally {
+            // Fence the PID producer before rereading after a failed observation.
+            // A pending claim without a recorded child remains unverified.
+            const recordedPgid = nestedPgid ?? readProcessIdFile(nestedPidFile);
+            if (recordedPgid) {
+              await cleanupProcessGroup(recordedPgid);
+            } else {
+              resourceOwner.assertReleased();
+            }
+          }
+        });
       }
-      await cleanupController(repoDir, controller);
-    }
+    });
   });
   it("has one dispatcher acquisition for composite prepare-run", () => {
     const script = readFileSync(join(repoRoot, "scripts/pr"), "utf8");

--- a/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
+++ b/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
@@ -9,6 +9,7 @@ import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coerci
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { readArtifactRecord } from "../../scripts/lib/build-artifact-cache.mts";
 import { BOUNDARY_PLUGIN_UNITS } from "../../scripts/lib/extension-boundary-inputs.mts";
+import { createVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
 import {
   createPrefixedOutputWriter,
   parseMode,
@@ -310,7 +311,14 @@ describe("prepare-extension-package-boundary-artifacts", () => {
       const signal = AbortSignal.any([contextSignal, controller.signal]);
       const observationFailure = new Error("drain observation failed");
       const originalNow = Date.now;
-      const rootDir = createTempDir("openclaw-boundary-abort-drain-");
+      // Only the injected fixture-write failure owns a separate namespace.
+      // Real step claims and their cleanup failures still belong to the outer fixture.
+      const retainedOwner =
+        mode === "cleanup write failure"
+          ? createVitestResourceOwner(createTempDir("boundary-cleanup-owner-"))
+          : undefined;
+      const driverFixture = retainedOwner ? createFixtureLifetime(retainedOwner.root) : fixture;
+      const rootDir = driverFixture.createTempDir("openclaw-boundary-abort-drain-");
       let descendantPid = 0;
       let command: ReturnType<typeof runNodeStepsInParallel> | undefined;
       let outcome: Promise<unknown> | undefined;
@@ -318,7 +326,7 @@ describe("prepare-extension-package-boundary-artifacts", () => {
       let joined = false;
       let requiredRescue = false;
       let heldAtRescue = false;
-      const driver = fixture.run(async () => {
+      const driver = driverFixture.run(async () => {
         const readyPath = path.join(rootDir, "descendant.ready");
         const drainedPath = path.join(rootDir, "descendant.drained");
         const failPath = path.join(rootDir, "fail");
@@ -410,7 +418,7 @@ describe("prepare-extension-package-boundary-artifacts", () => {
               });
             });
           }
-          await fixture.verifyCleanup(async () => {
+          await driverFixture.verifyCleanup(async () => {
             try {
               fs.writeFileSync(mode === "cleanup write failure" ? rootDir : failPath, "fail");
             } finally {
@@ -434,8 +442,9 @@ describe("prepare-extension-package-boundary-artifacts", () => {
       if (mode === "cleanup write failure") {
         expect(error).toHaveProperty("code", "EISDIR");
         try {
-          await expect(fixture.cleanup()).rejects.toThrow("Fixture cleanup unverified");
+          await expect(driverFixture.cleanup()).rejects.toThrow("Fixture cleanup unverified");
           expect(fs.existsSync(rootDir)).toBe(true);
+          expect(() => retainedOwner!.assertReleased()).toThrow("Unreleased Vitest resource claim");
         } finally {
           // Only the injected filesystem failure is disposable, after the real join.
           fs.rmSync(rootDir, { recursive: true, force: true });

--- a/test/scripts/release-preflight.test.ts
+++ b/test/scripts/release-preflight.test.ts
@@ -135,6 +135,7 @@ function makeIsolatedPreflightFixture(params: Parameters<typeof makeReleaseFixtu
     "scripts/lib/failed-trailer.mts",
     "scripts/lib/local-check-runtime.mts",
     "scripts/lib/managed-child-process.mts",
+    "scripts/lib/vitest-resource-ownership.mts",
     "scripts/lib/release-version.mjs",
     "scripts/lib/tsx-cli-shim.mjs",
     "scripts/lib/windows-taskkill.mjs",

--- a/test/scripts/run-vitest-state-cleanup.test.ts
+++ b/test/scripts/run-vitest-state-cleanup.test.ts
@@ -5,13 +5,34 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, expect, it, vi } from "vitest";
 import type { JsonTestResults } from "vitest/reporters";
 import packageJson from "../../package.json" with { type: "json" };
+import { runManagedCommand } from "../../scripts/lib/managed-child-process.mts";
 import { resolveVitestHomeSelection } from "../../scripts/lib/vitest-home-selection.mts";
 import { spawnOwnedVitestProcess } from "../../scripts/lib/vitest-process.mts";
+import { createVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
+import { createFixtureLifetime } from "../helpers/fixture-lifetime.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+import { proveNestedRetention } from "./nested-retention.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const nestedLifetime = createFixtureLifetime();
+afterEach(() => nestedLifetime.cleanup());
 const repoRoot = path.resolve(import.meta.dirname, "../..");
 const posixIt = process.platform === "win32" ? it.skip : it;
+
+function prepareVitestFixture(root: string, homeName = "home") {
+  const tmp = path.join(root, "tmp");
+  const home = path.join(root, homeName);
+  fs.mkdirSync(tmp);
+  fs.mkdirSync(home);
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify({ private: true, type: "module", packageManager: packageJson.packageManager }),
+  );
+  // Keep pnpm's pinned toolchain record without sharing lockfile writes.
+  fs.copyFileSync(path.join(repoRoot, "pnpm-lock.yaml"), path.join(root, "pnpm-lock.yaml"));
+  fs.symlinkSync(path.join(repoRoot, "node_modules"), path.join(root, "node_modules"), "junction");
+  return { tmp, home };
+}
 
 const intentionalFailure = "intentional failure after SQLite allocation";
 const counterfactualFailure = "counterfactual first-file failure after allocation receipt";
@@ -49,13 +70,15 @@ function expectFixtureResults(
     expect(file.status, file.name).toBe(expectedStatus);
     expect(file.message, file.name).toBe("");
     expect(
-      file.assertionResults.map(({ ancestorTitles, fullName, title, status, failureMessages }) => ({
-        ancestorTitles,
-        fullName,
-        title,
-        status,
-        failureMessages: failureMessages?.map((message) => message.split("\n")[0]),
-      })),
+      file.assertionResults.map(
+        ({ ancestorTitles, fullName, title: caseTitle, status, failureMessages }) => ({
+          ancestorTitles,
+          fullName,
+          title: caseTitle,
+          status,
+          failureMessages: failureMessages?.map((message) => message.split("\n")[0]),
+        }),
+      ),
       file.name,
     ).toEqual([
       {
@@ -141,11 +164,8 @@ posixIt.each([
   "$route cleans its namespace after $pool completion ($homePolicy, failed run: $failRun, paused after acknowledgement: $pauseAfterAck, first-file failure: $failFirstFile)",
   async ({ route, pool, failRun, pauseAfterAck, failFirstFile, homePolicy }) => {
     const root = tempDirs.make("oc-vt-state-");
-    const tmp = path.join(root, "tmp");
     const profileOnly = homePolicy === "profile-only" || homePolicy === "profile-only-parent-shell";
-    const home = path.join(root, profileOnly ? "home-$source" : "home");
-    fs.mkdirSync(tmp);
-    fs.mkdirSync(home);
+    const { tmp, home } = prepareVitestFixture(root, profileOnly ? "home-$source" : "home");
     const realHome = homePolicy === "real-home";
     const hermetic = homePolicy === "hermetic-ambient";
     const profileLoaded = profileOnly || ["staged-live", "real-home"].includes(homePolicy);
@@ -158,18 +178,6 @@ posixIt.each([
     fs.writeFileSync(
       path.join(home, ".profile"),
       'export VITEST_HOME_SOURCE_MARKER=$(cat "$HOME/profile-marker")\n',
-    );
-    fs.writeFileSync(
-      path.join(root, "package.json"),
-      JSON.stringify({ private: true, type: "module", packageManager: packageJson.packageManager }),
-    );
-    // pnpm records the pinned toolchain in its lockfile even for exec. Keep that
-    // dependency record with the installed modules without sharing lockfile writes.
-    fs.copyFileSync(path.join(repoRoot, "pnpm-lock.yaml"), path.join(root, "pnpm-lock.yaml"));
-    fs.symlinkSync(
-      path.join(repoRoot, "node_modules"),
-      path.join(root, "node_modules"),
-      "junction",
     );
 
     // These namespaces belong to callers, not the child invocation. Keep an open
@@ -728,6 +736,7 @@ console.log(JSON.stringify({ namespace: os.tmpdir(), homes: [os.homedir(), homed
 
 it("retains native home after child and pipes close when descendants cannot be verified", async () => {
   const root = tempDirs.make("oc-vt-home-retained-");
+  const parent = createVitestResourceOwner(root);
   const log = vi.spyOn(console, "error").mockImplementation(() => {});
   const { child, completion } = spawnOwnedVitestProcess({
     command: process.execPath,
@@ -750,6 +759,7 @@ it("retains native home after child and pipes close when descendants cannot be v
     expect(observed.home).toBe(path.join(observed.namespace, "home"));
     expect(path.dirname(observed.namespace)).toBe(root);
     expect(fs.existsSync(observed.home)).toBe(true);
+    expect(() => parent.assertReleased()).toThrow("Unreleased Vitest resource claim");
     expect(log).toHaveBeenCalledWith(
       expect.stringContaining(`retained temporary namespace ${observed.namespace}`),
     );
@@ -760,6 +770,25 @@ it("retains native home after child and pipes close when descendants cannot be v
     log.mockRestore();
   }
 });
+
+posixIt.for([
+  { pool: "threads", mode: "failure" },
+  { pool: "forks", mode: "failure" },
+  { pool: "threads", mode: "swallowed" },
+  { pool: "threads", mode: "crash" },
+  { pool: "forks", mode: "crash" },
+] as const)(
+  "preserves nested managed-child retention after outer $pool completion ($mode)",
+  { timeout: 80_000 },
+  async ({ pool, mode }, { signal }) =>
+    nestedLifetime.run(async () => {
+      const evidence = path.join(repoRoot, ".artifacts/nested-retention");
+      fs.mkdirSync(evidence, { recursive: true });
+      const root = fs.mkdtempSync(path.join(evidence, `${pool}-${mode}-`));
+      prepareVitestFixture(root);
+      await proveNestedRetention(root, pool, signal, mode);
+    }),
+);
 
 it("removes only its namespace when spawning fails before acquiring a PID", async () => {
   const root = tempDirs.make("oc-vt-spawn-");
@@ -778,10 +807,97 @@ it("removes only its namespace when spawning fails before acquiring a PID", asyn
   expect(fs.readFileSync(sentinel, "utf8")).toBe("keep");
 });
 
+posixIt.each([
+  "released",
+  "pending",
+  "missing receipt",
+  "corrupt receipt",
+  "unreadable receipt",
+  "missing owner",
+  "missing registry",
+  "missing parent registry",
+])("requires positive nested release evidence: %s", async (mode) => {
+  const root = tempDirs.make("oc-vt-receipt-");
+  const parent = createVitestResourceOwner(root);
+  const receipt = path.join(root, "namespace");
+  const { completion } = spawnOwnedVitestProcess({
+    command: process.execPath,
+    args: [
+      "--input-type=module",
+      "-e",
+      `
+      import fs from 'node:fs';
+      import path from 'node:path';
+      import os from 'node:os';
+      import { findVitestResourceOwner } from ${JSON.stringify(path.join(repoRoot, "scripts/lib/vitest-resource-ownership.mts"))};
+      const root = os.tmpdir(), mode = ${JSON.stringify(mode)};
+      fs.writeFileSync(${JSON.stringify(receipt)}, root);
+      const release = findVitestResourceOwner().claim();
+      const metadata = path.join(root, '.vitest-resource-owner');
+      const claims = path.join(metadata, 'claims');
+      const released = path.join(claims, fs.readdirSync(claims)[0], 'released');
+      if (mode !== 'pending') release();
+      if (mode === 'missing receipt' || mode === 'unreadable receipt') fs.unlinkSync(released);
+      if (mode === 'unreadable receipt') fs.mkdirSync(released);
+      if (mode === 'corrupt receipt') fs.writeFileSync(released, 'not a completion receipt');
+      if (mode === 'missing owner') fs.unlinkSync(path.join(metadata, 'owner'));
+      if (mode === 'missing registry') fs.rmSync(claims, { recursive: true });
+      if (mode === 'missing parent registry') fs.rmSync(path.join(path.dirname(root), '.vitest-resource-owner', 'claims'), { recursive: true });
+    `,
+    ],
+    options: { env: { TMPDIR: root }, stdio: "ignore" },
+  });
+  if (mode === "released") {
+    await expect(completion).resolves.toMatchObject({ code: 0 });
+    expect(() => parent.assertReleased()).not.toThrow();
+  } else {
+    await expect(completion).rejects.toThrow("retained temporary namespace");
+    if (mode === "missing parent registry") {
+      await expect(completion).rejects.toThrow(`retained temporary namespace ${root};`);
+      expect(() => parent.assertReleased()).toThrow(/ENOENT/);
+    } else {
+      expect(() => parent.assertReleased()).toThrow("Unreleased Vitest resource claim");
+    }
+  }
+  const namespace = fs.readFileSync(receipt, "utf8");
+  expect(fs.existsSync(namespace)).toBe(!["released", "missing parent registry"].includes(mode));
+});
+
+posixIt("rejects resource registration before allocating inputs or launching work", async () => {
+  const root = tempDirs.make("oc-vt-admission-");
+  createVitestResourceOwner(root);
+  const claims = path.join(root, ".vitest-resource-owner", "claims");
+  fs.rmdirSync(claims);
+  fs.writeFileSync(claims, "registry unavailable");
+  const launched = path.join(root, "launched");
+  const args = ["-e", `require('node:fs').writeFileSync(${JSON.stringify(launched)}, 'launched')`];
+  const env = { TMPDIR: root, TMP: root, TEMP: root };
+  expect(() =>
+    spawnOwnedVitestProcess({ command: process.execPath, args, options: { env } }),
+  ).toThrow();
+  await expect(runManagedCommand({ bin: process.execPath, args, env })).rejects.toThrow();
+  for (const [key, value] of Object.entries(env)) {
+    vi.stubEnv(key, value);
+  }
+  try {
+    const lifetime = createFixtureLifetime();
+    const body = vi.fn(async () => {});
+    expect(() => lifetime.run(body)).toThrow();
+    expect(() => lifetime.createTempDir("unadmitted-")).toThrow();
+    await Promise.resolve();
+    expect(body).not.toHaveBeenCalled();
+    expect(fs.existsSync(launched)).toBe(false);
+    expect(fs.readdirSync(root)).toEqual([".vitest-resource-owner"]);
+  } finally {
+    vi.unstubAllEnvs();
+  }
+});
+
 posixIt(
   "retains the exact namespace with recovery guidance when group verification fails",
   async () => {
     const root = tempDirs.make("oc-vt-unverified-");
+    createVitestResourceOwner(root);
     const receipt = path.join(root, "namespace");
     const { child, completion } = spawnOwnedVitestProcess({
       command: process.execPath,

--- a/test/scripts/run-vitest-state-cleanup.test.ts
+++ b/test/scripts/run-vitest-state-cleanup.test.ts
@@ -787,6 +787,7 @@ posixIt.for([
       const root = fs.mkdtempSync(path.join(evidence, `${pool}-${mode}-`));
       prepareVitestFixture(root);
       await proveNestedRetention(root, pool, signal, mode);
+      expect(fs.existsSync(root), "successful joined fixture must be removed").toBe(false);
     }),
 );
 

--- a/test/scripts/vitest-worker-artifacts.test.ts
+++ b/test/scripts/vitest-worker-artifacts.test.ts
@@ -255,7 +255,12 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
       import {syncBuiltinESMExports} from 'node:module';
       import {setTimeout as tick} from 'node:timers/promises';
       import {inspectManagedProcessGroup} from ${JSON.stringify(pathToFileURL(path.join(root, "scripts/lib/managed-child-process.mts")).href)};
+      import {createVitestResourceOwner} from ${JSON.stringify(pathToFileURL(path.join(root, "scripts/lib/vitest-resource-ownership.mts")).href)};
       const directory=${JSON.stringify(directory)}, mode=${JSON.stringify(mode)};
+      // Only the deliberately escaped writer has a fixture-owned namespace.
+      // Other compiler failures must still retain the outer runner's claims.
+      const resources=mode==='uncertain output'?createVitestResourceOwner(directory):undefined;
+      if(resources) Object.assign(process.env,{TMPDIR:directory,TMP:directory,TEMP:directory});
       const file=name=>path.join(directory,name);
       fs.writeFileSync(file('input'),'compiler input');
       const spawn=cp.spawn;
@@ -309,6 +314,7 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
             if(mode==='uncertain output') {
               assert.equal(fs.existsSync(generation),true);
               process.kill(leafPid,0);
+              assert.throws(()=>resources.assertReleased(),/Unreleased Vitest resource claim/);
               fs.writeFileSync(file('leaf-release'),'release');
               while(!fs.existsSync(file('leaf-read'))) await tick(5);
               assert.equal(fs.readFileSync(file('leaf-read'),'utf8'),'retained input');
@@ -322,6 +328,11 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
         child.kill('SIGTERM');
         await completion.catch(()=>{});
         await owner.dispose().catch(()=>{});
+        assert.equal(inspectManagedProcessGroup(child,{errorPolicy:'indeterminate'}),'dead');
+        if(compiler) {
+          assert.equal(closed,true);
+          assert.equal(inspectManagedProcessGroup(compiler,{errorPolicy:'indeterminate'}),'dead');
+        }
         if(fs.existsSync(file('leaf-pid'))) {
           leafPid=Number(fs.readFileSync(file('leaf-pid'),'utf8'));
           try {process.kill(leafPid,'SIGKILL');} catch(error) {if(error.code!=='ESRCH') throw error;}
@@ -334,7 +345,15 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
       }
     `,
         );
-        const result = await node([driver]);
+        const command = node([driver]);
+        await workerArtifacts.fixtureLifetime.verifyCleanup(async () => {
+          const result = await command;
+          // Driver death must not turn its private pending claims into disposable inputs.
+          expect(result.stdout.split("\n")).toContain(
+            JSON.stringify({ mode, cleanup: "joined", generationRemoved: true }),
+          );
+        });
+        const result = await command;
         console.log(result.stdout);
         expect(result.code, result.stderr + result.stdout).toBe(0);
       }),


### PR DESCRIPTION
Closes #135630 — retained fixture inputs are deleted while nested writers remain live.

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where developers running managed Vitest tests lose fixture inputs after an inner command reports unverified cleanup. The outer runner could delete the containing namespace even while the nested detached writer was still alive.

## Why This Change Was Made

The outer namespace owner now requires both its existing child/group/pipe join and positive release of pre-registered nested resource claims. One small ephemeral Node/Vitest filesystem handoff connects namespace, fixture-lifetime, and managed-command owners, so swallowed errors, module resets, and intermediate crashes cannot erase unresolved ownership.

This replaces unconditional namespace deletion without weakening process-tree inspection, changing existing grace/drain deadlines, adding operator configuration/environment variables, or changing the non-strict managed-command completion contract. The required rebase preserves main's native-home isolation and asynchronous fixture removal; newly admitted work is drained before that asynchronous removal can release its claim. Standalone script-copy lists and compiler/release/native-wrapper input inventories include the new helper. This is test/tool lifecycle metadata, not application persistence or a SQLite change.

## User Impact

Managed test runs retain inputs at their original paths when nested cleanup is uncertain and fail visibly with the exact directory and manual-recovery guidance. Ordinary successful and assertion-failing runs with verified resource completion still clean up. There is no application-runtime feature change.

## Evidence

Real-process regression on macOS 26.6.2 / Node 24.20.0 / Vitest 4.1.11:

| Scenario | Before repair | After repair |
| --- | --- | --- |
| Non-isolated thread and fork workers, inner failed join, next-file module reset, two containing namespaces | Outer completion deleted retained inputs; still-live writer's next append returned `ENOENT` | Outer completion rejects; unchanged input path retained and next append succeeds |
| Swallowed cleanup error with passing native test report | No durable retention handoff | Pending claims still retain ancestors |
| Thread-process or fork-worker crash before cleanup publication | No pre-registered nested obligation | Pending claims survive the crash and retain inputs |

The initial independent owner/writer selection passed **21 tests**, with **120** process/lifetime siblings passing. After integration with current main, the combined owner/CI selection passed **44 tests**, process-group/managed-command coverage passed **106**, and all **11** fixture-lifetime cases passed. These selections overlap and are not an aggregate test count. Every real writer was stopped and joined after its post-completion append. Native-home controls and ordinary pass/fail flows passed; the compiler uncertain-output case also passed with a positive recovery receipt and verified writer termination inside its unchanged deadline. The new asynchronous-removal admission regression demonstrably failed before the additional repair. The regression harness selects only fixture-specific processes before collecting argv, avoiding whole-host output-buffer failures without larger buffers or deadlines.

Focused owner/writer command:

```bash
node scripts/run-vitest.mjs test/scripts/run-vitest-state-cleanup.test.ts test/scripts/fixture-lifetime.test.ts --testNamePattern 'positive nested release|resource registration|spawning fails|group verification fails|fresh fixture|unverified .* cleanup|removal failure|nested managed-child retention' --reporter=verbose
```

Sibling command:

```bash
node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts test/scripts/fixture-lifetime.test.ts test/helpers/run-node-script.test.ts test/scripts/vitest-process-group.test.ts --reporter=verbose
```

The refreshed ClawSweeper finding about successful regression-fixture leaks is also repaired: the complete generated root is removed only after the scenario and every process cleanup phase succeed. Body or cleanup failures keep the full evidence and inputs. A new assertion failed against the previous helper, then the final owner/writer selection passed **22 tests**, including all five real-writer modes and their root-disposal assertions. The helper no longer keeps a separate inferred `joined` flag or removes only the `tmp` child.

The explicit changed-file formatting/typecheck/lint/guard plan passed, as did `git diff --check`. Fresh independent Autoreview returned scoped-clean at its default P0 threshold before commit. The existing extracted native-wrapper dependency test first reproduced a missing-helper import; adding the helper to the authoritative wrapper bundle fixed it, and that test plus the metadata changed gate passed. Exact-head CI and native prepare/merge results will be recorded in the landing proof comment.

### Scope and remaining proof limits

- Against the pinned integration base: tooling +172/-18 (**net +154**), tests/support +852/-125, docs +16/-8, and one workflow input-file line. Positive tooling growth supplies the missing cross-process ownership handoff; application runtime is unchanged.
- No process-tree checks, existing deadlines, or useful assertions were removed. Deliberate lost-owner fixtures assert retention in explicit fixture-owned namespaces and independently join their writers before disposal.
- The complete native-home/SQLite cross-runner matrix is not claimed as locally verified. A fork/pass flow exceeded its unchanged 120-second deadline in a larger local selection, then passed on exact focused retry in 67 seconds; ordinary threaded pass/fail flows passed. Canceled diagnostic processes were stopped and joined. No deadline was increased.
- Native Linux/Windows and full package/Docker execution are not claimed by the local proof. CI coverage is reported separately rather than relabeled as local proof.
- Unregistered descendants that intentionally escape existing completion contracts are not newly guaranteed. There is no old-directory sweep or automatic PID-based reclamation.
