### PR TITLE
perf(browser): prepare profile defaults in one map

### DIFF
--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -865,17 +865,36 @@ describe("browser config", () => {
     expect(getBrowserProfileCapabilities(work).usesChromeMcp).toBe(false);
   });
 
-  it("resolves a configured custom default profile", () => {
-    const resolved = resolveBrowserConfig({
-      defaultProfile: "custom",
-      profiles: {
+  it.each(
+    [[], ["openclaw"], ["user"], ["chrome"], ["openclaw", "user", "chrome"]].map(
+      (configuredDefaults) => ({ configuredDefaults }),
+    ),
+  )(
+    "resolves a custom default while preserving configured profiles $configuredDefaults",
+    ({ configuredDefaults }) => {
+      const profiles = Object.freeze({
         custom: { cdpPort: 19999 },
-      },
-    });
+        ...Object.fromEntries(configuredDefaults.map((name) => [name, { cdpPort: 20000 }])),
+      });
+      const resolved = resolveBrowserConfig({
+        defaultProfile: "custom",
+        profiles,
+      });
 
-    const profile = resolveProfile(resolved, resolved.defaultProfile);
-    expect(resolved.defaultProfile).toBe("custom");
-    expect(profile?.name).toBe("custom");
-    expect(profile?.cdpPort).toBe(19999);
-  });
+      const profile = resolveProfile(resolved, resolved.defaultProfile);
+      expect(resolved.defaultProfile).toBe("custom");
+      expect(profile?.name).toBe("custom");
+      expect(profile?.cdpPort).toBe(19999);
+      expect(Object.keys(resolved.profiles)).toEqual([
+        "custom",
+        ...configuredDefaults,
+        ...["openclaw", "user", "chrome"].filter((name) => !configuredDefaults.includes(name)),
+      ]);
+      for (const [name, configured] of Object.entries(profiles)) {
+        expect(resolved.profiles[name]).toBe(configured);
+      }
+      delete resolved.profiles.custom;
+      expect(resolveRequiredProfile({ profiles }, "custom").cdpPort).toBe(19999);
+    },
+  );
 });

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -260,12 +260,13 @@ function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | 
   return resolved ?? (hasExplicitPrivateSetting ? { dangerouslyAllowPrivateNetwork: false } : {});
 }
 
-function ensureDefaultProfile(
+function ensureDefaultProfiles(
   profiles: Record<string, BrowserProfileConfig> | undefined,
   legacyCdpPort?: number,
   derivedDefaultCdpPort?: number,
   legacyCdpUrl?: string,
 ): Record<string, BrowserProfileConfig> {
+  // Built-in defaults share this private map; configured profiles stay caller-owned.
   const result = { ...profiles };
   if (!result[DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME]) {
     result[DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME] = {
@@ -273,34 +274,17 @@ function ensureDefaultProfile(
       ...(legacyCdpUrl ? { cdpUrl: legacyCdpUrl } : {}),
     };
   }
-  return result;
-}
-
-function ensureDefaultUserBrowserProfile(
-  profiles: Record<string, BrowserProfileConfig>,
-): Record<string, BrowserProfileConfig> {
-  const result = { ...profiles };
-  if (result.user) {
-    return result;
+  if (!result.user) {
+    result.user = {
+      driver: "existing-session",
+      attachOnly: true,
+    };
   }
-  result.user = {
-    driver: "existing-session",
-    attachOnly: true,
-  };
-  return result;
-}
-
-/** Built-in profile for the Chrome extension relay (user's signed-in browser). */
-function ensureDefaultChromeExtensionProfile(
-  profiles: Record<string, BrowserProfileConfig>,
-): Record<string, BrowserProfileConfig> {
-  const result = { ...profiles };
-  if (result.chrome) {
-    return result;
+  if (!result.chrome) {
+    result.chrome = {
+      driver: "extension",
+    };
   }
-  result.chrome = {
-    driver: "extension",
-  };
   return result;
 }
 
@@ -426,10 +410,11 @@ export function resolveBrowserConfig(
   const legacyCdpPort = rawCdpUrl ? cdpInfo.port : undefined;
   const isWsUrl = cdpInfo.parsed.protocol === "ws:" || cdpInfo.parsed.protocol === "wss:";
   const legacyCdpUrl = rawCdpUrl && isWsUrl ? cdpInfo.normalized : undefined;
-  let profiles = ensureDefaultChromeExtensionProfile(
-    ensureDefaultUserBrowserProfile(
-      ensureDefaultProfile(cfg?.profiles, legacyCdpPort, cdpPortRangeStart, legacyCdpUrl),
-    ),
+  let profiles = ensureDefaultProfiles(
+    cfg?.profiles,
+    legacyCdpPort,
+    cdpPortRangeStart,
+    legacyCdpUrl,
   );
   const cdpProtocol = cdpInfo.parsed.protocol === "https:" ? "https" : "http";
 


### PR DESCRIPTION
## What Problem This Solves

Browser profile preparation copied the whole configured profile map three times to add its built-in defaults. Each private intermediate map was immediately copied by the next helper, adding allocation work whenever the canonical browser configuration was prepared.

## Why This Change Was Made

Combine the three private default helpers into one preparer that copies the map once and adds the same managed, existing-session, and extension profiles in the same order. Configured entries keep their identity and precedence. The separate legacy-CDP helper still owns its necessary nested-profile copy.

## User Impact

Browser behavior, profile order, custom defaults, ports, authentication, sandbox policy, refresh handling, and lifecycle ownership remain the same. Production LOC is +16/-31 (net -15); tests are +30/-11 (net +19).

## Evidence

For 200 preparations with 64 configured profiles, observed private map copies fall from 600 to 200 and copied property slots from 39,000 to 12,800. All eight combinations of built-in overrides retain byte-identical output. Frozen inputs, configured-entry identity, returned-map mutation isolation, legacy endpoints, invalid URLs, and port-exhaustion behavior pass before and after. The work-budget probe fails on baseline and passes on the candidate. These are allocation-work counts, not a controlled RSS or latency result.

381 tests passed across configuration, hot reload, Gateway profile routing, timeout handling, and browser-tool paths; one Windows-only test was skipped on macOS. The full changed-file gate passed after Git integration. Independent Codex review found no actionable findings at the requested threshold.

A real local Gateway loaded the exact changed Browser plugin source and completed authenticated status, managed open, snapshot, reference click, changed snapshot, and close against Chromium 151.0.7922.34. The fixture label changed from “Ready route proof” to “Saved route proof.” V8 coverage records seven calls to the new preparer. The browser kept `noSandbox:false`; both owned processes exited, all three ports were rebound, and temporary state was removed.

An initial mixed-source attempt was excluded after attribution caught the compiled plugin. Cold source-loading attempts exceeded the harness client window; the successful run used a separate passive warm-up while retaining the product's route/action limits. No startup improvement is claimed. Live remote-node, extension-pairing, and container paths were not exercised; their existing forwarding and lifecycle tests passed.
