### PR TITLE
fix(linux): restore first-run Gateway choices without the CLI

### DIFF
--- a/.github/workflows/linux-app.yml
+++ b/.github/workflows/linux-app.yml
@@ -36,18 +36,25 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
+            at-spi2-core \
             build-essential \
             curl \
+            dbus-x11 \
             file \
+            gir1.2-atspi-2.0 \
             gstreamer1.0-libav \
             gstreamer1.0-plugins-bad \
             gstreamer1.0-plugins-good \
+            libatk-adaptor \
             libayatana-appindicator3-dev \
             librsvg2-dev \
             libssl-dev \
             libwebkit2gtk-4.1-dev \
             libxdo-dev \
-            wget
+            python3-gi \
+            wget \
+            xauth \
+            xvfb
 
       - name: Install Rust
         run: rustup toolchain install stable --profile minimal --component rustfmt
@@ -86,6 +93,23 @@ jobs:
         # pubkey makes the bundler hard-require it. Skip updater artifacts here;
         # linux-app-release.yml builds the signed updater bundles.
         run: pnpm dlx @tauri-apps/cli@2.11.4 build --bundles deb,appimage --config '{"bundle":{"createUpdaterArtifacts":false}}'
+
+      - name: Test native first-run setup without a CLI
+        id: first-run
+        run: |
+          xvfb-run -a -s '-screen 0 1280x1024x24' dbus-run-session -- \
+            /usr/bin/python3 apps/linux/tests/first_run.py \
+            apps/linux/src-tauri/target/release/openclaw-desktop \
+            2>&1 | tee "${RUNNER_TEMP}/linux-first-run.log"
+
+      - name: Upload first-run failure log
+        if: failure() && steps.first-run.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: linux-first-run-failure
+          retention-days: 14
+          if-no-files-found: error
+          path: ${{ runner.temp }}/linux-first-run.log
 
       - name: Upload bundles
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/linux-app.yml
+++ b/.github/workflows/linux-app.yml
@@ -96,6 +96,7 @@ jobs:
 
       - name: Test native first-run setup without a CLI
         id: first-run
+        shell: bash
         run: |
           xvfb-run -a -s '-screen 0 1280x1024x24' dbus-run-session -- \
             /usr/bin/python3 apps/linux/tests/first_run.py \

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -456,18 +456,25 @@ impl DesktopState {
                 return self.connect_remote_locked(app, remote);
             }
         }
-        let cli = match self.resolve_cli() {
+        let cli = self.resolve_cli();
+        if !explicit_local && !remote_gateway::has_configured_gateway()? {
+            // First-run setup belongs to the pending bootstrap reply. Navigating
+            // here replaces its WebView and loses the local/remote choice.
+            let snapshot = match cli {
+                Ok(_) => GatewaySnapshot::unconfigured(),
+                Err(CliError::Missing) => GatewaySnapshot::missing_cli(),
+                Err(error) => return Err(error.to_string()),
+            };
+            self.update_tray(&snapshot);
+            return Ok(snapshot);
+        }
+        let cli = match cli {
             Ok(cli) => cli,
             Err(CliError::Missing) => {
                 return self.show_missing_cli(app, explicit_local, None);
             }
             Err(error) => return Err(error.to_string()),
         };
-        if !explicit_local && !remote_gateway::has_configured_gateway()? {
-            let snapshot = GatewaySnapshot::unconfigured();
-            self.update_tray(&snapshot);
-            return Ok(snapshot);
-        }
         if explicit_local {
             self.inner
                 .remote_tunnel

--- a/apps/linux/tests/first_run.py
+++ b/apps/linux/tests/first_run.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Exercise the real CI development binary, without installing or connecting.
+
+Run as a non-root user with python3-gi, gir1.2-atspi-2.0, at-spi2-core,
+libatk-adaptor, xvfb, xauth and dbus-x11 installed:
+  xvfb-run -a dbus-run-session -- python3 apps/linux/tests/first_run.py BINARY
+
+Use the unbundled 0.1.0 development build: local setup on a release build
+intentionally starts installation instead of showing the channel chooser.
+"""
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def exercise(app, Atspi, GLib):
+    last_headings = set()
+
+    def nodes():
+        desktop = Atspi.get_desktop(0)
+        for index in range(desktop.get_child_count()):
+            owner = desktop.get_child_at_index(index)
+            if owner is None or owner.get_process_id() != app.pid:
+                continue
+            pending = [owner]
+            visited = 0
+            while pending:
+                node = pending.pop()
+                # A child can disappear while WebKit builds or replaces its tree.
+                if node is None:
+                    continue
+                visited += 1
+                if visited > 500:
+                    raise RuntimeError("First-run accessibility tree exceeded 500 nodes")
+                yield node
+                pending.extend(
+                    node.get_child_at_index(child)
+                    for child in range(node.get_child_count())
+                )
+
+    def wait(label, role=None, *, prefix=False, predicate=None):
+        deadline = time.monotonic() + 30
+        last_error = None
+        while time.monotonic() < deadline:
+            if app.poll() is not None:
+                raise RuntimeError(f"Native app exited with {app.returncode} waiting for {label!r}")
+            try:
+                last_headings.clear()
+                for node in nodes():
+                    name = node.get_name()
+                    actual_role = node.get_role_name()
+                    if actual_role == "heading":
+                        last_headings.add(name)
+                    if role is None:
+                        text = node.get_text_iface()
+                        matches = text is not None and text.get_text(0, -1) == label
+                    else:
+                        matches = actual_role == role and (
+                            name.startswith(label) if prefix else name == label
+                        )
+                    # Application-root state queries can block in GTK; only
+                    # inspect visibility on the semantic control being asserted.
+                    if (
+                        matches
+                        and node.get_state_set().contains(Atspi.StateType.VISIBLE)
+                        and (predicate is None or predicate(node))
+                    ):
+                        print(f"Observed {label}", flush=True)
+                        return node
+            except GLib.Error as error:
+                # WebKit can replace accessible objects during a screen transition.
+                last_error = error
+            time.sleep(0.1)
+        raise RuntimeError(
+            f"Timed out waiting for {label!r}; headings={sorted(last_headings)!r}; "
+            f"accessibility error={last_error}"
+        )
+
+    def click(label, role="push button", *, prefix=False):
+        node = wait(label, role, prefix=prefix)
+        action = node.get_action_iface()
+        if action is None or action.get_n_actions() == 0 or not action.do_action(0):
+            raise RuntimeError(f"Could not activate {label!r} through AT-SPI")
+
+    def empty_entry(label):
+        node = wait(label, "entry")
+        if node.get_text_iface().get_text(0, -1):
+            raise RuntimeError(f"Expected an empty {label!r}; refusing a remote connection")
+
+    wait("Welcome to OpenClaw", "heading")
+    click("Get started")
+    wait("Where should your assistant live?", "heading")
+    click("On another computer", "toggle button", prefix=True)
+    wait("Gateway URL", "toggle button")
+    wait("SSH tunnel", "toggle button")
+    empty_entry("Gateway URL")
+    click("Connect to Gateway")
+    wait("Enter a Gateway URL to continue.")
+    click("SSH tunnel", "toggle button")
+    empty_entry("SSH target")
+    wait("Gateway port", "entry")
+    click("Connect to Gateway")
+    wait("Enter an SSH target to continue.")
+    click("Back")
+    wait("Welcome to OpenClaw", "heading")
+    click("Get started")
+    click("On this computer", "toggle button", prefix=True)
+    click("Continue")
+    # Keeping missingCli (not unconfigured) is what preserves local installation.
+    wait("Choose a release channel", "heading")
+    wait("RELEASE CHANNEL", "combo box")
+    wait(
+        "Development",
+        "menu item",
+        predicate=lambda node: node.get_state_set().contains(Atspi.StateType.SELECTED),
+    )
+    wait("Install OpenClaw", "push button")
+    print("PASS: native first-run remote choices and local development channel", flush=True)
+
+
+def interrupted(signum, _frame):
+    raise RuntimeError(f"Native first-run smoke interrupted by signal {signum}")
+
+
+def drive(binary):
+    try:
+        import gi
+
+        gi.require_version("Atspi", "2.0")
+        from gi.repository import Atspi, GLib
+    except (ImportError, ValueError) as error:
+        raise RuntimeError(f"Install python3-gi and gir1.2-atspi-2.0: {error}") from error
+
+    Atspi.set_timeout(1000, 1000)
+    desktop = Atspi.get_desktop(0)
+    if desktop is None or desktop.get_child_count():
+        raise RuntimeError("AT-SPI needs an empty private accessibility session")
+    with Path("app.log").open("wb") as log:
+        app = subprocess.Popen(
+            [str(binary)],
+            stdin=subprocess.DEVNULL,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+        )
+        try:
+            exercise(app, Atspi, GLib)
+        finally:
+            if app.poll() is None:
+                app.terminate()
+            try:
+                app.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                app.kill()
+                app.wait(timeout=5)
+            Atspi.exit()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("binary", type=Path)
+    parser.add_argument("--driver", action="store_true", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    if sys.platform != "linux" or os.geteuid() == 0:
+        parser.error("Run on Linux as a non-root user; do not disable the WebKit sandbox")
+    for key in ("DISPLAY", "DBUS_SESSION_BUS_ADDRESS"):
+        if not os.environ.get(key):
+            parser.error("Run inside xvfb-run and a private dbus-run-session")
+    binary = args.binary.resolve(strict=True)
+    if not os.access(binary, os.X_OK):
+        parser.error("The native app binary must be executable")
+    if shutil.which("openclaw", path="/usr/bin:/bin"):
+        parser.error("The minimal system PATH must not contain an OpenClaw CLI")
+
+    if args.driver:
+        drive(binary)
+        return
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        signal.signal(sig, interrupted)
+    with tempfile.TemporaryDirectory(prefix="openclaw-first-run-") as directory:
+        root = Path(directory)
+        # Allowlisting drops CLI/config overrides, credentials and existing desktop state.
+        env = {
+            key: os.environ[key]
+            for key in ("DISPLAY", "DBUS_SESSION_BUS_ADDRESS", "XAUTHORITY")
+            if key in os.environ
+        }
+        env.update(
+            HOME=str(root),
+            PATH="/usr/bin:/bin",
+            LANG="C.UTF-8",
+            LC_ALL="C.UTF-8",
+            GDK_BACKEND="x11",
+            XDG_SESSION_TYPE="x11",
+            GTK_MODULES="atk-bridge",
+            NO_AT_BRIDGE="0",
+        )
+        for variable, relative in (
+            ("XDG_CONFIG_HOME", ".config"),
+            ("XDG_CACHE_HOME", ".cache"),
+            ("XDG_DATA_HOME", ".local/share"),
+            ("XDG_STATE_HOME", ".local/state"),
+            ("XDG_RUNTIME_DIR", "runtime"),
+            ("TMPDIR", "tmp"),
+        ):
+            path = root / relative
+            path.mkdir(mode=0o700, parents=True)
+            env[variable] = str(path)
+        # Native AT-SPI calls can block Python signal handlers. Keep the deadline
+        # and cleanup outside that process, with its app in the same owned group.
+        worker = subprocess.Popen(
+            [sys.executable, str(Path(__file__).resolve()), "--driver", str(binary)],
+            cwd=root,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        passed = False
+        try:
+            try:
+                code = worker.wait(timeout=120)
+            except subprocess.TimeoutExpired as error:
+                raise RuntimeError("Native first-run driver exceeded 120 seconds") from error
+            if code:
+                raise RuntimeError(f"Native first-run driver exited with {code}")
+            passed = True
+        finally:
+            try:
+                try:
+                    os.killpg(worker.pid, signal.SIGTERM)
+                    worker.wait(timeout=5)
+                except (ProcessLookupError, subprocess.TimeoutExpired):
+                    pass
+                finally:
+                    try:
+                        os.killpg(worker.pid, signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+                    worker.wait(timeout=5)
+            finally:
+                if not passed and (root / "app.log").is_file():
+                    with (root / "app.log").open("rb") as log:
+                        log.seek(0, os.SEEK_END)
+                        log.seek(max(0, log.tell() - 8000))
+                        print("Native app output (isolated environment):", file=sys.stderr)
+                        print(log.read().decode(errors="replace"), file=sys.stderr)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/apps/linux/tests/first_run.py
+++ b/apps/linux/tests/first_run.py
@@ -55,7 +55,9 @@ def exercise(app, Atspi, GLib):
                 last_headings.clear()
                 for node in nodes():
                     name = node.get_name()
-                    actual_role = node.get_role_name()
+                    # WebKitGTK 2.50.4 emits shifted numeric AT-SPI roles. Ask it
+                    # for the role name instead; the child locale is C.UTF-8.
+                    actual_role = node.get_localized_role_name()
                     if actual_role == "heading":
                         last_headings.add(name)
                     if role is None:
@@ -74,6 +76,7 @@ def exercise(app, Atspi, GLib):
                     ):
                         print(f"Observed {label}", flush=True)
                         return node
+                last_error = None
             except GLib.Error as error:
                 # WebKit can replace accessible objects during a screen transition.
                 last_error = error


### PR DESCRIPTION
Closes #135565

<details>
<summary>Additional instructions</summary>

The head branch is in openclaw/openclaw, so maintainers can edit it directly.

</details>

## What Problem This Solves

Fixes an issue where users launching the Linux desktop companion for the first time would see only the CLI installer when no CLI or Gateway configuration existed. The Welcome screen and manual remote Gateway choice were unreachable, although a remote connection does not require a local CLI.

## Why This Change Was Made

First-run presentation belongs to the pending bootstrap reply. Missing-CLI recovery was navigating the WebView before that reply completed, replacing the document that would have displayed Welcome. Unselected first-run now returns its existing `missingCli` or `unconfigured` result without navigating. Keeping those phases distinct preserves build-aware local installation; saved remote, configured-local, explicit-local, and watchdog recovery retain their current ownership and navigation guards.

A native accessibility test runs the real built app in Linux CI, with a fresh HOME, private D-Bus session, and no CLI. It covers Welcome, both remote transports and empty-input feedback, and the local Development channel chooser. It never clicks Install or connects to an operator Gateway. A mocked bootstrap test would miss the native navigation that caused this regression.

## User Impact

Fresh installs can choose **On another computer** without installing a local CLI first. Choosing **On this computer** still follows the existing stable/development installation behavior. No configuration, persistence, protocol, or runtime dependency changes are introduced. This restores the documented [Linux first-run flow](https://docs.openclaw.ai/platforms/linux#first-run-setup).

## Evidence

Native before/after captures use the same isolated Linux environment and an unbundled development build, with no saved account or Gateway data:

| Before: installer-only | After: Welcome | After: local or remote |
| --- | --- | --- |
| ![Before: first-run incorrectly requires the CLI](https://github.com/user-attachments/assets/b6b0da01-df63-445f-903d-da85a3cfca1b) | ![After: Welcome is reachable without a CLI](https://github.com/user-attachments/assets/404d739e-459b-42e4-bf1f-3a2f5c74376e) | ![After: both Gateway choices are available](https://github.com/user-attachments/assets/02fc184c-ba34-41a0-91a1-a1d5bb7bfa89) |

The final frozen native test in [a31b35a2](https://github.com/openclaw/openclaw/commit/a31b35a2c88dae7319ef4a80cb5964ac49dc3ac0) **fails before** on `67d149a5` (expected Welcome; actual heading: “OpenClaw needs the CLI”) and **passes after** against the fixed Tauri release-profile/custom-protocol binary. All 55 app/build source inputs remain byte-identical to the compiled [222d6f46](https://github.com/openclaw/openclaw/commit/222d6f462fe3720095f9c7670077a15e95f1f8ca); those inputs and the final test script were independently verified against the final commit. This proof used Debian 12 arm64, Rust 1.97.1, GTK 3.24.38, and WebKitGTK 2.50.6. The same final test also passes all 23 observations against the first hosted run’s extracted CI DEB on Ubuntu 22.04/x64 with matching WebKitGTK 2.50.4 and AT-SPI 2.44.0. That additional local run used x64 emulation and the DEB payload, not a system package installation or the unbundled hosted executable.

CI runs the unbundled executable produced by the Tauri release-profile build (app version `0.1.0`). The workflow uses explicit Bash with `pipefail` so its log pipe cannot hide failures:

```sh
xvfb-run -a -s '-screen 0 1280x1024x24' dbus-run-session -- \
  /usr/bin/python3 apps/linux/tests/first_run.py \
  apps/linux/src-tauri/target/release/openclaw-desktop
```

The first [Linux App attempt](https://github.com/openclaw/openclaw/actions/runs/33570729635) had a false-green native step: the implicit shell let `tee` hide a failing test. This is repaired, with the original broken application proven to return exit 1 through the strict pipeline. Investigation of the actual CI artifact also found an upstream WebKitGTK 2.50.4 AT-SPI enum defect: a real `h1` was reported numerically as `document frame`, even though the screen rendered correctly. The final test queries the documented server role-name API under its existing C locale; it still requires the exact heading, visibility, controls, actions, and selected channel. Comparing the official [2.50.4](https://webkitgtk.org/releases/webkitgtk-2.50.4.tar.xz) and [2.50.5](https://webkitgtk.org/releases/webkitgtk-2.50.5.tar.xz) source archives verifies the enum fix, and the live artifact reports `heading` through this API. No role remapping, relaxed assertion, longer timeout, OS dependency change, or sandbox override was added. Old transient accessibility errors are cleared after a complete successful scan. [Fresh exact-head Linux App](https://github.com/openclaw/openclaw/actions/runs/33573303949) now passes all 23 native observations with explicit `pipefail`, the final PASS, and no failure output. The earlier green badge is not counted as native proof. The failure-only log upload was correctly skipped on this passing run; no deliberately failing hosted run was injected solely to exercise that upload.

The harness also passed a forced-stall containment check: stopping its native driver triggers the unchanged 120-second parent deadline, removes the temporary HOME, and leaves no active owned descendants. Initial harness-only accessibility polling/cleanup failures were repaired before this red/green proof; they are not counted as application regressions.

- Linux arm64: 133 Rust unit tests, 10 integration tests, the explicitly enabled private D-Bus sleep-cycle test, and a locked native build passed.
- macOS arm64: all 133 Rust tests and formatting passed. Existing dashboard recovery and Quick Chat frontend coverage: 22 tests passed.
- Manual native flow: Welcome → Gateway choices → direct/SSH controls and empty-input validation; unsafe public plaintext URL rejected through real Rust IPC; returning to local setup selects Development. Configured-local/no-CLI still shows CLI recovery. A saved remote configuration still takes precedence over CLI discovery; a deliberately closed loopback endpoint proves selection only, not connectivity.
- Workflow checks (`actionlint`, `zizmor`, CI ownership/interpolation guards), changed-file checks, and independent Codex review passed. The initial local workflow-check failure was Python 3.9 rejecting the pinned pre-commit version; using isolated Python 3.12 resolved it without changing repository pins.

Validation limits: no actual CLI or system-package installation, successful authenticated Gateway connection, signed update, stable-release package launch, Wayland session, or macOS GUI launch is claimed. [Exact-head main CI](https://github.com/openclaw/openclaw/actions/runs/33573396844) also passed: 127 successful jobs and 17 skipped. All 151 active PR checks passed; 39 were skipped, with none pending or failing.

<details>
<summary>Root cause, provenance, and scope</summary>

The reply-bearing `bootstrap` command queues `Connect`; `DesktopState::connect_selected` previously sent a missing CLI directly to `show_missing_cli`, which navigates to `?mode=missingCli`. The replacement document cannot receive the original reply. The original native run showed the installer-only screen and Tauri's missing-callback-after-reload diagnostic. The canonical fix separates unselected first-run from local recovery at `connect_selected`, not with a frontend retry or a second startup path.

Raw-parent comparison of commit [3bd3b273](https://github.com/openclaw/openclaw/commit/3bd3b2730c2371eb9ebac242cf58441f3e0ae41b) against `5b605da389460fd035d9a2031064ed949303b14f` verifies the navigation was introduced in [#131974](https://github.com/openclaw/openclaw/pull/131974), authored and merged by @vyctorbrzezowski on 2026-08-28; Git records GitHub as committer. This is patch-based provenance, not an inference from the merger. The affected Rust and frontend files are byte-identical between the baseline and stable `v2026.8.2`.

Production delta: `main.rs` +13/-6, net +7 including two explanatory comment lines. The five net source lines preserve the distinct CLI-missing phase while keeping configured/explicit recovery in its existing owner; collapsing both outcomes to `unconfigured` breaks the local channel chooser. Native test/support: +264/-0. CI wiring: +26/-1. No generated files or lockfiles changed.

Named follow-up outside this bootstrap repair: generic Open Dashboard callers currently enqueue explicit-local connection actions. Preserving an already selected remote dashboard through those tray/Quick Chat/deep-link actions needs a separate owner-level repair; simply swapping the queue variant would discard reply-only outcomes or replace an existing remote WebView. This change does not claim to fix that separate path.

</details>
