### PR TITLE
test(infra): reuse maintenance warning runtime

### DIFF
--- a/src/infra/session-maintenance-warning.test.ts
+++ b/src/infra/session-maintenance-warning.test.ts
@@ -1,6 +1,5 @@
-// Tests session maintenance warning formatting and suppression.
 import { randomUUID } from "node:crypto";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 type DeliveryCall = {
   channel?: string;
@@ -90,9 +89,13 @@ describe("deliverSessionMaintenanceWarning", () => {
   let prevVitest: string | undefined;
   let prevNodeEnv: string | undefined;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
+    // Start under this suite's mocks, then reuse the owner across disjoint session keys.
     vi.resetModules();
     ({ deliverSessionMaintenanceWarning } = await import("./session-maintenance-warning.js"));
+  });
+
+  beforeEach(() => {
     prevVitest = process.env.VITEST;
     prevNodeEnv = process.env.NODE_ENV;
     delete process.env.VITEST;


### PR DESCRIPTION
The session-maintenance warning tests reset and import the same owner before all seven cases. Keep one intentional clean import under the existing hoisted mocks, then reuse it across the suite's separate session keys. Per-case mock state and environment restoration remain unchanged.

The warning cache remains real: UUID and explicit agent keys cannot collide with the LRU case's session:N keys, and its 4096-entry fill removes any preceding entries before the existing eviction assertions. Delivery failure rejects a send after the message runtime has loaded, so it does not poison the cached import. This removes six module resets and repeated owner imports without adding a production reset seam or broader mocks. Production delta is zero; tests +6/-3.

Validation: all seven cases passed before and after. Shuffled seed 11 exercised delivery failure, LRU fill/eviction, fallback, changed-context delivery, test-mode suppression, deduplication, and context forwarding in that order. Case names and all per-case setup, bodies, assertions, and cleanup are unchanged. The full changed-file gate, independent Codex review, and manual cache/message-runtime ownership review passed. No wall-time claim is made from the cold-import runs.
