### PR TITLE
fix(pr): distinguish quota failures from authentication errors

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -109,6 +109,7 @@ const repositoryScriptEntries = [
   "scripts/pr-lib/ci-dispatch.mjs!",
   // merge.sh invokes this native review-authority parser by path.
   "scripts/pr-lib/clawsweeper-review-gate.mjs!",
+  "scripts/pr-lib/gh-api-preflight.mjs!",
   "scripts/pr-lib/review-artifacts.mjs!",
   "scripts/pr-lib/process-group-runner.mjs!",
   "scripts/pre-commit/filter-staged-files.mjs!",

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -139,6 +139,24 @@ Authoritative REST reads request revalidation with `Cache-Control: max-age=0`
 and supply concrete repository paths. Writer identity comes from the authenticated
 GraphQL viewer, not a relay's REST caller profile.
 
+Before entering a PR worktree, `scripts/pr` checks that viewer with one request.
+Rate-limit failures stop the operation before fetch or merge side effects and
+report only safe metadata from that same response: HTTP status, quota resource,
+remaining quota, limit, UTC reset time, and retry delay when available.
+Respect `retry-after` before retrying manually; wait for the primary reset only
+when that budget is exhausted. A future primary reset is not the unblock time for
+a secondary throttle with quota remaining. Without a usable retry delay or an
+exhausted budget's reset, wait at least 60 seconds. A zero remaining balance alone
+does not attribute an HTTP 200 failure to rate limiting: malformed or missing
+viewer data and unrelated errors still fail, with exhaustion reported separately.
+An unknown reset is reported as unknown; a separate pooled REST quota is not
+evidence about the failed viewer request. Refreshing credentials does not restore
+quota. Only missing or rejected authentication suggests manually configuring or
+refreshing the intended active credential; forbidden, server, transport, and
+malformed responses remain blocking failures without login advice. The preflight
+does not retry, switch accounts, or change GitHub CLI routing, and it does not
+print raw response bodies, headers, or CLI errors.
+
 The default `rollup` mode waits for the attached CI workflow to succeed and
 for the remaining rollup checks to finish without failures. Supersession stays
 within workflow identity; `Auto response` is excluded from the wait.

--- a/scripts/pr-lib/gh-api-preflight.mjs
+++ b/scripts/pr-lib/gh-api-preflight.mjs
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+
+const exitCode = Number(process.argv[2]);
+const response = readFileSync(0, "utf8");
+const boundary = /\r?\n\r?\n/.exec(response);
+const lines = boundary ? response.slice(0, boundary.index).split(/\r?\n/) : [];
+const status = /^HTTP\/\d+(?:\.\d+)? ([1-5]\d{2})(?: .*)?$/.exec(lines.shift() ?? "")?.[1];
+const headers = new Map();
+if (status) {
+  for (const line of lines) {
+    const colon = line.indexOf(":");
+    if (colon > 0) {
+      headers.set(line.slice(0, colon).toLowerCase(), line.slice(colon + 1).trim());
+    }
+  }
+}
+let body;
+try {
+  body = boundary ? JSON.parse(response.slice(boundary.index + boundary[0].length)) : null;
+} catch {
+  // Malformed output is not evidence of rejected credentials.
+}
+
+const login = body?.data?.viewer?.login;
+if (
+  exitCode === 0 &&
+  status === "200" &&
+  typeof login === "string" &&
+  login.trim().length > 0 &&
+  (body.errors === undefined || (Array.isArray(body.errors) && body.errors.length === 0))
+) {
+  process.exit(0);
+}
+
+// Only numeric headers and known resource names may escape this response.
+/** @param {string} name */
+function numericHeader(name) {
+  const value = headers.get(name);
+  return /^\d{1,15}$/.test(value ?? "") ? Number(value) : undefined;
+}
+const remaining = numericHeader("x-ratelimit-remaining");
+const limit = numericHeader("x-ratelimit-limit");
+const reset = numericHeader("x-ratelimit-reset");
+const retryAfter = numericHeader("retry-after");
+const resource = headers.get("x-ratelimit-resource") === "graphql" ? "graphql" : "unknown";
+const rateLimited =
+  Array.isArray(body?.errors) && body.errors.some((error) => error?.type === "RATE_LIMITED");
+const throttleMessage =
+  typeof body?.message === "string" &&
+  /\b(?:secondary rate limit|abuse detection|API rate limit exceeded)\b/i.test(body.message);
+const details = `HTTP ${status ?? "unknown"}; exit=${exitCode}`;
+const resetUtc =
+  reset !== undefined && reset <= 253402300799
+    ? new Date(reset * 1000).toISOString().replace(".000Z", "Z")
+    : "unknown";
+const quota = `resource=${resource}; remaining=${remaining ?? "unknown"}; limit=${limit ?? "unknown"}; reset=${resetUtc}`;
+
+// A depleted balance does not explain a malformed/partial HTTP 200 response.
+if (
+  ["200", "403", "429"].includes(status) &&
+  (status === "429" ||
+    (status === "403" && (remaining === 0 || retryAfter !== undefined)) ||
+    rateLimited ||
+    throttleMessage)
+) {
+  console.error(
+    `GitHub API preflight rate limited (${details}; ${quota}${retryAfter === undefined ? "" : `; retry-after=${retryAfter}s`}).`,
+  );
+  const waits = [];
+  if (retryAfter !== undefined) {
+    waits.push(`at least ${retryAfter} seconds`);
+  }
+  // Primary reset is a retry constraint only when that budget is exhausted,
+  // not the unblock time for a secondary throttle with quota remaining.
+  if (remaining === 0 && resetUtc !== "unknown") {
+    waits.push(`until ${resetUtc} (UTC)`);
+  }
+  if (waits.length === 0) {
+    waits.push("at least 60 seconds");
+  }
+  console.error(
+    `Wait ${waits.join(" and ")}${resetUtc === "unknown" ? "; reset time is unknown" : ""}, then retry manually.`,
+  );
+} else if (status === "401" || (exitCode === 4 && !status)) {
+  // gh v2.98.0 returns 4 for its pre-request missing-auth check; 403 is not that contract.
+  console.error(`GitHub API preflight authentication unavailable (${details}).`);
+  console.error("Configure or refresh the intended active credential manually, then retry.");
+} else {
+  console.error(`GitHub API preflight failed (${details}); authentication was not verified.`);
+  if (remaining === 0) {
+    console.error(`Observed exhausted primary quota (${quota}); failure cause remains unverified.`);
+  }
+  console.error("Check connectivity, GitHub service status, and access policy before retrying.");
+}
+process.exitCode = 1;

--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -26,18 +26,11 @@ repo_root() {
 }
 
 ensure_gh_api_auth() {
-  # gh auth status fetches token scopes through REST and misreports quota
-  # failures as invalid credentials. GraphQL verifies the active local token
-  # without sending maintainers through a login that cannot restore quota.
-  if gh_plain api graphql -f 'query=query { viewer { login } }' --jq .data.viewer.login >/dev/null 2>&1; then
-    return 0
-  fi
-
-  cat >&2 <<'EOF'
-GitHub CLI auth is not usable for non-interactive API calls.
-Run `gh auth login -h github.com` (or refresh the current token) and retry.
-EOF
-  return 1
+  # Diagnose only this viewer request's budget. A pooled REST probe can describe
+  # a different credential; raw response/error text must never reach diagnostics.
+  local response exit_code=0
+  response=$(gh_plain api graphql -f 'query=query { viewer { login } }' --include 2>/dev/null) || exit_code=$?
+  printf '%s' "$response" | node "$(dirname "${BASH_SOURCE[0]}")/gh-api-preflight.mjs" "$exit_code"
 }
 
 ensure_full_pr_worktree_checkout() {

--- a/test/scripts/pr-crabbox-merge-bypass.test.ts
+++ b/test/scripts/pr-crabbox-merge-bypass.test.ts
@@ -366,7 +366,8 @@ else if (endpoint === "graphql" && args.some(arg => arg.includes("repository(own
 } else if (endpoint === "user") out(args[args.indexOf("--jq")+1] === ".login" ? "relay-reader" : {login:"relay-reader"});
 else if (endpoint === "graphql" && args.includes("query=query { viewer { login } }")) {
   const json = JSON.stringify({data:{viewer:value.actor}});
-  out(cp.execFileSync("jq", ["-r", args[args.indexOf("--jq") + 1]], {input:json,encoding:"utf8"}).trim());
+  if (args.includes("--include")) out("HTTP/2.0 200 OK\\n\\n" + json);
+  else out(cp.execFileSync("jq", ["-r", args[args.indexOf("--jq") + 1]], {input:json,encoding:"utf8"}).trim());
 } else {
   if (!endpoint) fail("unexpected command");
   const mutable = endpoint.startsWith("orgs/") ||

--- a/test/scripts/pr-main-refresh.test-support.ts
+++ b/test/scripts/pr-main-refresh.test-support.ts
@@ -203,6 +203,7 @@ export function createMainRefreshFixture(directory: string) {
     failFetchAt: 0,
     pauseFetchAt: 0,
     failAuth: false,
+    viewerRateLimited: false,
     moveAfterFirstFetch: false,
     moveAtGate: false,
     moveAtChecks: false,
@@ -385,6 +386,11 @@ if (args[0] === 'pr' && args[1] === 'view') {
   if (endpoint === 'graphql') {
     if (control.failAuth) process.exit(1);
     if (args.some(arg => arg.includes('viewer { login }'))) {
+      if (control.viewerRateLimited) {
+        if (args.includes('--include')) process.stdout.write('HTTP/2.0 200 OK\\nX-RateLimit-Resource: graphql\\r\\nX-RateLimit-Remaining: 0\\r\\n\\r\\n');
+        console.log(JSON.stringify({ errors: [{ type: 'RATE_LIMITED', message: 'Synthetic quota failure' }] }));
+        process.exit(1);
+      }
       value = { data: { viewer: { login: 'fixture' } } };
     } else if (args.some(arg => arg.includes('ref(qualifiedName:'))) {
       value = { data: { repository: {
@@ -475,6 +481,7 @@ if (args[0] === 'pr' && args[1] === 'view') {
   throw new Error('Unexpected GitHub command ' + args.join(' '));
 }
 const jqIndex = args.indexOf('--jq');
+if (args.includes('--include')) process.stdout.write('HTTP/2.0 200 OK\\n\\n');
 if (jqIndex >= 0) {
   const result = spawnSync('jq', ['-r', args[jqIndex + 1]], {
     input: JSON.stringify(value),

--- a/test/scripts/pr-main-refresh.test.ts
+++ b/test/scripts/pr-main-refresh.test.ts
@@ -668,8 +668,28 @@ read -r release < "$OPENCLAW_TEST_FETCH_HOLD"
       "/bin/bash",
     );
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("GitHub CLI auth is not usable");
+    expect(result.stderr).toContain("GitHub API preflight failed");
     expect(f.events().some((e) => e.kind === "main-fetch")).toBe(false);
+  });
+
+  it("stops native merge on viewer quota failure before fetch or dispatch and releases its lock", () => {
+    const f = fixture();
+    f.configure({ viewerRateLimited: true });
+    const result = f.run("merge-run");
+    expect(result.status, result.stdout + result.stderr).toBe(1);
+    expect(result.stderr).toContain("GitHub API preflight rate limited");
+    expect(f.events().some((e) => e.kind === "main-fetch")).toBe(false);
+    const ghCalls = f.events().filter((e) => e.kind === "gh");
+    expect(ghCalls.at(-1)?.args).toEqual([
+      "api",
+      "graphql",
+      "-f",
+      "query=query { viewer { login } }",
+      "--include",
+    ]);
+    expect(ghCalls.some((e) => e.args?.includes("merge"))).toBe(false);
+    expect(f.git(f.origin, "rev-parse", "refs/heads/main")).toBe(f.main);
+    expect(f.git(f.canonical, "for-each-ref", "--format=%(refname)", "refs/openclaw")).toBe("");
   });
 
   for (const bash of ["bash", ...(process.platform === "darwin" ? ["/bin/bash"] : [])]) {

--- a/test/scripts/pr-merge-outcome.test.ts
+++ b/test/scripts/pr-merge-outcome.test.ts
@@ -262,7 +262,7 @@ const advanceMain=()=>{
 };
 if(args[0]==="repo") out(args.includes("--jq")?s.repo.nameWithOwner:s.repo);
 else if(args[0]==="api"&&args.includes("user")) out("relay-reader");
-else if(args.includes("graphql")&&args.includes("query=query { viewer { login } }")) out(s.operator);
+else if(args.includes("graphql")&&args.includes("query=query { viewer { login } }")) out(args.includes("--include") ? "HTTP/2.0 200 OK\\n\\n" + JSON.stringify({data:{viewer:{login:s.operator}}}) : s.operator);
 else if(args[0]==="pr"&&args[1]==="checks") {
   if(s.duringChecks?.head) s.pr.headRefOid=s.duringChecks.head;
   if(s.duringChecks?.artifact) fs.appendFileSync(process.env.FIXTURE_REPO+"/.worktrees/pr-123/.local/"+s.duringChecks.artifact,"\\n# changed during checks\\n");

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -907,12 +907,12 @@ describePosix("scripts/pr per-PR operation lock", () => {
         "set -euo pipefail",
         'case "$*" in',
         '  "auth token") printf "token:1\\n" >> "$OPENCLAW_TEST_GH_EVENTS"; exit 1 ;;',
-        '  "api graphql -f query=query { viewer { login } } --jq .data.viewer.login")',
+        '  "api graphql -f query=query { viewer { login } } --include")',
         '    if [ "$OPENCLAW_TEST_AUTH_FAILURE" = 1 ]; then',
         '      printf "viewer:1\\n" >> "$OPENCLAW_TEST_GH_EVENTS"; exit 1',
         "    fi",
         '    printf "viewer:0\\n" >> "$OPENCLAW_TEST_GH_EVENTS"',
-        '    printf "fixture-user\\n" ;;',
+        '    printf \'HTTP/2.0 200 OK\\n\\n{"data":{"viewer":{"login":"fixture-user"}}}\\n\' ;;',
         '  "pr view 42 --json headRefOid")',
         '    cat "$OPENCLAW_TEST_PR_METADATA"; printf "head:0\\n" >> "$OPENCLAW_TEST_GH_EVENTS" ;;',
         '  "pr view 42 --json number,title,state,isDraft,author,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,url,body,labels,assignees,changedFiles,additions,deletions,statusCheckRollup,files")',
@@ -1019,7 +1019,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
                 : ["token:1", "viewer:1"],
             );
           expect.soft(controller.exitCode, output).toBe(1);
-          expect.soft(output).toContain("GitHub CLI auth is not usable");
+          expect.soft(output).toContain("GitHub API preflight failed");
           expect.soft(events.filter(Boolean), output).toEqual([]);
           expect.soft(git("rev-parse", "refs/heads/pr-42")).toBe(cachedMain);
           expect.soft(existsSync(worktreeDir)).toBe(existing);
@@ -1072,7 +1072,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
             expect.soft(output).not.toContain("Missing test target file:");
             if (failure === "auth") {
               expect.soft(fetches, output).toEqual([]);
-              expect.soft(output).toContain("GitHub CLI auth is not usable");
+              expect.soft(output).toContain("GitHub API preflight failed");
             } else {
               expect.soft(fetches, output).toEqual(["fetch:main:128"]);
               expect.soft(output).toContain("couldn't find remote ref refs/heads/main");
@@ -1737,7 +1737,9 @@ describePosix("scripts/pr per-PR operation lock", () => {
         "fetch_count=0",
         "gh_plain() {",
         `  printf 'auth\\n' >> '${traceFile}'`,
-        `  return ${failure === "auth" ? code : 0}`,
+        failure === "auth"
+          ? `  return ${code}`
+          : '  printf \'HTTP/2.0 200 OK\\n\\n{"data":{"viewer":{"login":"fixture-user"}}}\\n\'',
         "}",
         "git() {",
         `  printf 'git %s\\n' "$*" >> '${traceFile}'`,
@@ -1858,6 +1860,8 @@ describePosix("scripts/pr per-PR operation lock", () => {
         '  "api graphql --hostname "*)',
         '    state=OPEN; if grep -q "^merged$" "$OPENCLAW_TEST_LIFECYCLE"; then state=MERGED; fi',
         `    jq -cn --arg state "$state" --arg head '${preparedHead}' '{data:{repository:{id:"fixture-repo",url:"https://github.com/fixture/repo",nameWithOwner:"fixture/repo",ref:{target:{oid:$head}},pullRequest:{id:"fixture-pr",number:42,url:"https://github.com/fixture/repo/pull/42",state:$state,headRefOid:$head,baseRefName:"main",isDraft:false,mergeCommit:(if $state=="MERGED" then {oid:$head} else null end),autoMergeRequest:null,isInMergeQueue:false,isMergeQueueEnabled:false,mergeable:"MERGEABLE",mergeStateStatus:"CLEAN"}}}}' ;;`,
+        '  "api graphql -f query=query { viewer { login } } --include")',
+        '    printf \'HTTP/2.0 200 OK\\n\\n{"data":{"viewer":{"login":"fixture-user"}}}\\n\' ;;',
         '  "api graphql "*) printf "fixture-user\\n" ;;',
         '  "pr merge 42 "*)',
         '    git rev-parse refs/openclaw/pr-operation-locks/42 > "$OPENCLAW_TEST_OWNER"',

--- a/test/scripts/pr-worktree-containment.test.ts
+++ b/test/scripts/pr-worktree-containment.test.ts
@@ -146,7 +146,7 @@ function runShell(fixture: Fixture, commands: string[], env?: NodeJS.ProcessEnv)
         'source "$3"',
         'fixture_root="$4"',
         'script_parent_dir="$fixture_root"',
-        "gh_plain() { :; }",
+        `gh_plain() { printf 'HTTP/2.0 200 OK\\n\\n{"data":{"viewer":{"login":"fixture-user"}}}\\n'; }`,
         "mark_pr_operation_side_effects_started() { :; }",
         'pr_meta_json() { local head; head=$(git rev-parse refs/pull/42/head); jq -cn --arg head "$head" \'{number:42,title:"fixture",url:"https://example.invalid/42",state:"OPEN",isDraft:false,author:{login:"fixture"},baseRefName:"main",headRefName:"review/pr",headRefOid:$head,headRepository:{nameWithOwner:"fixture/repo",url:""},headRepositoryOwner:{login:"fixture"},additions:1,deletions:0,changedFiles:3}\'; }',
         ...commands,
@@ -179,7 +179,7 @@ function traceEntryCommands(failure: string, code = 73) {
     ...["git", "cd", "pwd", "mkdir", "rm", "mv", "trash"].map(
       (name) => `${name}() { trace_command ${name} "$@" || return $?; command ${name} "$@"; }`,
     ),
-    'gh_plain() { trace_command gh_plain "$@"; }',
+    `gh_plain() { trace_command gh_plain "$@" || return $?; printf 'HTTP/2.0 200 OK\\n\\n{"data":{"viewer":{"login":"fixture-user"}}}\\n'; }`,
   ];
 }
 
@@ -249,7 +249,7 @@ describePosix("scripts/pr worktree containment", () => {
                 "bash",
                 [
                   "-c",
-                  'set -euo pipefail\nsource "$1"\nsource "$2"\nsource "$3"\nscript_parent_dir="$4"\ngh_plain() { :; }\nmark_pr_operation_side_effects_started() { :; }\nreview_checkout_main "$5"',
+                  `set -euo pipefail\nsource "$1"\nsource "$2"\nsource "$3"\nscript_parent_dir="$4"\ngh_plain() { printf 'HTTP/2.0 200 OK\\n\\n{"data":{"viewer":{"login":"fixture-user"}}}\\n'; }\nmark_pr_operation_side_effects_started() { :; }\nreview_checkout_main "$5"`,
                   "pr-concurrency",
                   commonScript,
                   worktreeScript,
@@ -321,7 +321,7 @@ describePosix("scripts/pr worktree containment", () => {
       expectEntryStopped(fixture, result);
       expect(reviewState(worktree)).toEqual(before);
       if (failure.includes("gh_plain")) {
-        expect(result.stderr).toContain("GitHub CLI auth is not usable");
+        expect(result.stderr).toContain("GitHub API preflight failed");
       }
     });
   }

--- a/test/scripts/pr-worktree-evidence.test.ts
+++ b/test/scripts/pr-worktree-evidence.test.ts
@@ -68,14 +68,18 @@ function fixture() {
     captureName = "merge-output.log",
   ) => {
     const dir = join(repo, ".worktrees", `pr-${pr}`);
-    if (registered) git(["worktree", "add", "-q", "-b", `temp/pr-${pr}`, dir]);
-    else git(["branch", `temp/pr-${pr}`]);
+    if (registered) {
+      git(["worktree", "add", "-q", "-b", `temp/pr-${pr}`, dir]);
+    } else {
+      git(["branch", `temp/pr-${pr}`]);
+    }
     git(["branch", `pr-${pr}`]);
     git(["branch", `pr-${pr}-prep`]);
     mkdirSync(join(dir, ".local"), { recursive: true });
     writeFileSync(join(dir, ".local", "prep.env"), "synthetic metadata\n");
-    if (capture === "symlink") symlinkSync("missing-capture", join(dir, ".local", captureName));
-    else if (capture) {
+    if (capture === "symlink") {
+      symlinkSync("missing-capture", join(dir, ".local", captureName));
+    } else if (capture) {
       writeFileSync(
         join(dir, ".local", captureName),
         capture === "empty" ? "" : "Synthetic response\n",
@@ -105,8 +109,8 @@ gh() {
   fi
 }
 gh_plain() {
-  if [ "$*" = 'api graphql -f query=query { viewer { login } } --jq .data.viewer.login' ]; then
-    printf 'fixture-user\\n'
+  if [ "$*" = 'api graphql -f query=query { viewer { login } } --include' ]; then
+    printf 'HTTP/2.0 200 OK\\n\\n{"data":{"viewer":{"login":"fixture-user"}}}\\n'
   else
     echo "Unexpected direct GitHub call: $*" >&2; exit 97
   fi
@@ -253,7 +257,9 @@ describePosix("native worktree cleanup preserves merge evidence", () => {
         "echo unexpected-entry-completed",
       ]);
       expect.soft(existsSync(join(dir, ".local/merge-output.log")), result.output).toBe(true);
-      if (existsSync(join(dir, ".local/merge-output.log"))) expect(evidence(dir)).toEqual(before);
+      if (existsSync(join(dir, ".local/merge-output.log"))) {
+        expect(evidence(dir)).toEqual(before);
+      }
       expect.soft(f.worktrees()).toBe(registrations);
       expect(f.branches()).toBe(branches);
       expect(result.status, result.output).not.toBe(0);
@@ -270,8 +276,9 @@ describePosix("native worktree cleanup preserves merge evidence", () => {
       const f = fixture();
       const dir = f.add(910001, "populated");
       const ref = f.record(910001);
-      if (fault === "corrupt")
+      if (fault === "corrupt") {
         f.git(["update-ref", ref, f.git(["hash-object", "-w", "--stdin"], "bad")]);
+      }
       if (fault === "symbolic") {
         f.git(["update-ref", "refs/fixture/retained", f.git(["rev-parse", ref])]);
         f.git(["symbolic-ref", ref, "refs/fixture/retained"]);

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -769,7 +769,7 @@ exit 99
       join(fixture.bin, "gh"),
       `#!/bin/sh
 if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
-  printf 'fixture-user\\n'
+  printf 'HTTP/2.0 200 OK\\n\\n{"data":{"viewer":{"login":"fixture-user"}}}\\n'
   exit 0
 fi
 echo "Unexpected gh call: $*" >&2
@@ -1123,36 +1123,269 @@ exit 99
     );
   });
 
-  it("verifies local GitHub auth through GraphQL when REST quota is unavailable", () => {
-    const dir = tempDirs.make("openclaw-pr-auth-");
-    const gh = join(dir, "gh");
-    writeFileSync(
-      gh,
-      `#!/bin/sh
-if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
-  printf 'monalisa\\n'
-  exit 0
-fi
-exit 1
-`,
-    );
-    chmodSync(gh, 0o755);
+  const viewer = { data: { viewer: { login: "fixture-user" } } };
+  const quota = {
+    "X-RateLimit-Resource": "graphql",
+    "X-RateLimit-Limit": "5000",
+    "X-RateLimit-Remaining": "0",
+    "X-RateLimit-Reset": "1893456000",
+  };
+  const rateError = { errors: [{ type: "RATE_LIMITED", message: "synthetic-private-detail" }] };
+  const preflightCases: {
+    name: string;
+    status?: number;
+    code: number;
+    body?: unknown;
+    rawBody?: string;
+    headers?: Record<string, string>;
+    diagnostic?: string;
+    details?: string[];
+    absent?: string[];
+  }[] = [
+    {
+      name: "primary GraphQL quota exhaustion",
+      status: 200,
+      code: 1,
+      body: rateError,
+      headers: quota,
+      diagnostic: "rate limited",
+      details: ["resource=graphql; remaining=0; limit=5000", "reset=2030-01-01T00:00:00Z", "Wait"],
+    },
+    {
+      name: "primary HTTP 403 exhaustion",
+      status: 403,
+      code: 1,
+      body: { message: "API rate limit exceeded for synthetic-private-detail" },
+      headers: quota,
+      diagnostic: "rate limited",
+      details: ["remaining=0", "Wait"],
+    },
+    {
+      name: "HTTP 429 throttle",
+      status: 429,
+      code: 1,
+      body: {},
+      diagnostic: "rate limited",
+      details: ["reset=unknown", "reset time is unknown", "Wait"],
+    },
+    ...[200, 403].map((status) => ({
+      name: `secondary HTTP ${status} throttle`,
+      status,
+      code: 1,
+      body: { message: "You have exceeded a secondary rate limit. synthetic-private-detail" },
+      headers: { ...quota, "Retry-After": "60", "X-RateLimit-Remaining": "50" },
+      diagnostic: "rate limited",
+      details: [
+        "remaining=50",
+        "reset=2030-01-01T00:00:00Z",
+        "retry-after=60s",
+        "Wait at least 60 seconds",
+      ],
+      absent: ["until 2030-01-01T00:00:00Z"],
+    })),
+    {
+      name: "secondary throttle without retry header",
+      status: 403,
+      code: 1,
+      body: { message: "You have exceeded a secondary rate limit." },
+      diagnostic: "rate limited",
+      details: ["reset=unknown", "Wait"],
+    },
+    {
+      name: "invalid quota metadata",
+      status: 200,
+      code: 1,
+      body: rateError,
+      headers: {
+        "X-RateLimit-Resource": "synthetic-private-detail",
+        "X-RateLimit-Remaining": "no",
+        "X-RateLimit-Limit": "5000synthetic-private-detail",
+        "X-RateLimit-Reset": "999999999999999",
+        "Retry-After": "synthetic-private-detail",
+      },
+      diagnostic: "rate limited",
+      details: ["resource=unknown; remaining=unknown; limit=unknown; reset=unknown"],
+    },
+    {
+      name: "rejected authentication",
+      status: 401,
+      code: 1,
+      body: { message: "Bad credentials synthetic-private-detail" },
+      diagnostic: "authentication unavailable",
+    },
+    { name: "missing authentication", code: 4, diagnostic: "authentication unavailable" },
+    ...[403, 500, 503].map((status) => ({
+      name: `HTTP ${status} failure`,
+      status,
+      code: 1,
+      body: { message: "synthetic-private-detail" },
+      diagnostic: "failed",
+    })),
+    { name: "transport failure", code: 1, diagnostic: "failed" },
+    {
+      name: "unknown GraphQL error",
+      status: 200,
+      code: 1,
+      body: { errors: [{ type: "SYNTHETIC_UNKNOWN", message: "synthetic-private-detail" }] },
+      headers: quota,
+      diagnostic: "failed",
+      details: [
+        "Observed exhausted primary quota",
+        "remaining=0",
+        "failure cause remains unverified",
+      ],
+    },
+    {
+      name: "malformed body",
+      status: 200,
+      code: 1,
+      rawBody: "{synthetic-private-detail",
+      headers: quota,
+      diagnostic: "failed",
+      details: [
+        "Observed exhausted primary quota",
+        "remaining=0",
+        "failure cause remains unverified",
+      ],
+    },
+    {
+      name: "successful process without viewer",
+      status: 200,
+      code: 0,
+      body: { data: { viewer: null } },
+      headers: quota,
+      diagnostic: "failed",
+      details: [
+        "Observed exhausted primary quota",
+        "remaining=0",
+        "failure cause remains unverified",
+      ],
+    },
+    {
+      name: "empty viewer",
+      status: 200,
+      code: 0,
+      body: { data: { viewer: { login: "  " } } },
+      diagnostic: "failed",
+    },
+    {
+      name: "wrong viewer type",
+      status: 200,
+      code: 0,
+      body: { data: { viewer: { login: 42 } } },
+      diagnostic: "failed",
+    },
+    {
+      name: "partial viewer with errors",
+      status: 200,
+      code: 0,
+      body: { ...viewer, errors: [{ type: "FORBIDDEN" }] },
+      diagnostic: "failed",
+    },
+    {
+      name: "viewer with failed process",
+      status: 200,
+      code: 1,
+      body: viewer,
+      diagnostic: "failed",
+    },
+    { name: "missing HTTP framing", code: 0, body: viewer, diagnostic: "failed" },
+    { name: "valid viewer", status: 200, code: 0, body: viewer },
+    { name: "successful last quota request", status: 200, code: 0, body: viewer, headers: quota },
+  ];
 
+  it.each([
+    ...preflightCases.map((scenario) => ({ ...scenario, route: "default" })),
+    { ...preflightCases[0]!, route: "override" },
+  ])("GitHub API preflight: $name ($route)", ({ route, ...scenario }) => {
+    const dir = tempDirs.make("openclaw-pr-auth-");
+    const env = isolatedWrapperEnv(dir);
+    const bin = join(dir, "bin");
+    mkdirSync(bin);
+    const pathGh = join(bin, "gh");
+    const gh = route === "default" ? pathGh : join(dir, "selected-gh");
+    const calls = join(dir, "calls.jsonl");
+    const headers =
+      scenario.status === undefined
+        ? ""
+        : `HTTP/2.0 ${scenario.status} Synthetic\nContent-Type: application/json\r\n` +
+          Object.entries(scenario.headers ?? {})
+            .map(([name, value]) => `${name}: ${value}\r\n`)
+            .join("") +
+          "X-Request-Id: synthetic-private-detail\r\n\r\n";
+    const body =
+      scenario.rawBody ?? (scenario.body === undefined ? "" : JSON.stringify(scenario.body));
+    const fakeGh = `#!${process.execPath}
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(calls)}, JSON.stringify(args) + "\\n");
+if (args.includes("--include")) process.stdout.write(${JSON.stringify(headers)});
+process.stdout.write(${JSON.stringify(body)});
+console.error("gh: synthetic-private-detail");
+process.exit(${scenario.code});
+`;
+    writeFileSync(
+      pathGh,
+      route === "default" ? fakeGh : "#!/bin/sh\necho UNEXPECTED_ROUTE >&2\nexit 99\n",
+      { mode: 0o755 },
+    );
+    if (route === "override") {
+      writeFileSync(gh, fakeGh, { mode: 0o755 });
+    }
     const result = spawnSync(
       "bash",
       [
         "-c",
-        "source scripts/lib/plain-gh.sh; source scripts/pr-lib/worktree.sh; ensure_gh_api_auth",
+        [
+          "set -euo pipefail",
+          "source scripts/lib/plain-gh.sh",
+          'source "$PWD/scripts/pr-lib/worktree.sh"',
+          'repo_root() { printf "%s\\n" "$HOME"; }',
+          "mark_pr_operation_side_effects_started() { echo UNEXPECTED_SIDE_EFFECT; return 99; }",
+          scenario.diagnostic ? "enter_worktree 42 false || exit 1" : "ensure_gh_api_auth",
+        ].join("\n"),
       ],
       {
         cwd: process.cwd(),
-        env: { ...isolatedWrapperEnv(dir), OPENCLAW_GH_BIN: gh, GH_TOKEN: "synthetic-token" },
         encoding: "utf8",
+        env: {
+          ...env,
+          OPENCLAW_GH_BIN: route === "override" ? gh : "",
+          GH_TOKEN: "synthetic-token",
+        },
       },
     );
-
-    expect(result.status).toBe(0);
-    expect(result.stderr).toBe("");
+    expect(result.status, result.stderr).toBe(scenario.diagnostic ? 1 : 0);
+    expect(result.stdout).not.toContain("UNEXPECTED");
+    expect(result.stdout + result.stderr).not.toMatch(/synthetic-private-detail|UNEXPECTED_ROUTE/);
+    if (scenario.diagnostic) {
+      expect(result.stderr).toContain(`GitHub API preflight ${scenario.diagnostic}`);
+      for (const detail of scenario.details ?? []) {
+        expect(result.stderr).toContain(detail);
+      }
+      for (const detail of scenario.absent ?? []) {
+        expect(result.stderr).not.toContain(detail);
+      }
+      if (scenario.diagnostic === "failed") {
+        expect(result.stderr).not.toContain("preflight rate limited");
+      }
+      if (scenario.diagnostic === "authentication unavailable") {
+        expect(result.stderr).toContain(
+          "Configure or refresh the intended active credential manually",
+        );
+      } else {
+        expect(result.stderr).not.toMatch(/login|refresh|invalid credentials/i);
+      }
+    } else {
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toBe("");
+    }
+    expect(
+      readFileSync(calls, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+    ).toEqual([["api", "graphql", "-f", "query=query { viewer { login } }", "--include"]]);
   });
 
   it.each(["default", "override"])(


### PR DESCRIPTION
Related: #135123 (root-test lint repair; this is a separate maintainer-tooling follow-up).

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch and remains takeover-ready.

</details>

## What Problem This Solves

Fixes an issue where maintainers landing a PR through `scripts/pr` were told to log in or refresh credentials when the viewer GraphQL preflight had actually exhausted its request quota. Reauthentication cannot restore that quota, so the diagnostic sent operators toward the wrong recovery action.

## Why This Change Was Made

The preflight now classifies the status, body, and quota headers from its single viewer request rather than discarding the evidence or consulting a potentially different pooled REST budget. It emits only safe metadata, distinguishes throttling from missing/rejected authentication and unverified failures, and preserves the fail-closed boundary before fetch or merge side effects.

A native Node parser replaces the unconditional login diagnostic. Removing the jq projection gives one response shape instead of projected success versus raw error bodies. The helper stays inside the wrapper's existing trusted directory and is registered as an executable root. No retry, alternate account/binary, new dependency, configuration option, or review/CI bypass is added.

## User Impact

Maintainers get quota/reset/retry guidance for rate limits, credential guidance only for missing or rejected authentication, and an explicit unverified outcome for other failures. Secondary throttling does not force a wait for an unrelated hourly reset; a successful request consuming the last quota point still succeeds. Unknown resets remain unknown, and raw response bodies, identities, headers, CLI errors, and credentials are not printed.

The operator guidance is documented with the [CI workflow](https://docs.openclaw.ai/ci#watching-pull-request-ci). Touched tests also receive required mechanical lint cleanup without changing their assertions or deadlines.

## Evidence

### Refreshed candidate

Rebased the actual test conflicts onto captured main `3a60bd396949e4daca80237dbba71ca11b10e934` and published **`5369ad6ac3ab3946ca99742363207209f2c1cbfa`**, replacing reviewed head `9c3e4f0cba5f3b8079b3eda36771ccaa03c09ecb` with an exact old-head lease.

The outcome tests retain main's replacement-head recovery, mutations during checks, recovery-record validation, and completed-receipt coverage; only the viewer response framing changes versus main. The wrapper tests retain the complete exact-diagnostic/redaction/single-request table and selected-binary case, adapted to main's temporary-directory tracker and synthetic Git identities. The obsolete success-only test is removed. Auth parser, owner function, and diagnostic docs are byte-identical to the reviewed patch, modulo unrelated main evolution. Recovery production behavior is unchanged.

**Fresh proof: 108 targeted tests passed.** Commands below use the canonical runner, one worker, and a task-owned cache:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.cache/vitest/pr-auth-refresh-135657 node scripts/run-vitest.mjs test/scripts/pr-wrappers.test.ts test/scripts/pr-main-refresh.test.ts -t 'GitHub API preflight|stops native merge on viewer quota'
```

25 passed: exact CLI boundary, redaction, selected-binary routing, and native quota refusal before fetch/dispatch.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.cache/vitest/pr-auth-refresh-135657 node scripts/run-vitest.mjs test/scripts/pr-operation-lock.test.ts test/scripts/pr-merge-outcome.test.ts test/scripts/pr-wrappers.test.ts -t 'preserves native entry phase ownership|requires fresh main before replacing PR artifacts|confirms .* through fresh reads and preserves completion after later revert|submits verified attribution with pinned head|operator recovery preserves evidence|replacement recovery refuses stale or unapproved evidence|fails closed on recovery-|with forward main during final receipt observation|initializes stamped review artifacts|resolves review writer identity'
```

83 passed: phase ownership, fresh-main guards, attribution/completion, newer recovery/receipt cases, and wrapper artifact/identity routes.

```bash
node scripts/check-changed.mjs --staged --base 3a60bd396949e4daca80237dbba71ca11b10e934
bash -n scripts/pr-lib/worktree.sh
node --check scripts/pr-lib/gh-api-preflight.mjs
git diff --cached --check
```

All passed before rebase continuation; the resulting commit tree was verified identical to the tested/reviewed staged tree. Fresh protected Codex autoreview of the complete resolved uncommitted patch was scoped-clean at the P0-only threshold. The fresh live viewer probe through the unchanged route exited 0 with empty stdout/stderr; no response or credentials were persisted. Live quota exhaustion was not induced.

The preserved pre-fix reproduction was rerun against captured main and failed on the intended quota-diagnostic assertion: one viewer request, no worktree side effects, and the old incorrect login advice. An initial boundary run was stopped during a persistent filesystem rename wait before test execution; its log/sample were retained, and the same proof passed with the fresh cache. Assertions and deadlines were not weakened. No full broad suite is claimed.

Production/tooling: **+101/-12 (net +89)**; tests/support: **+310/-38 (net +272)**; docs: **+18**. Production growth still buys same-response parsing, strict success validation, safe metadata projection, and UTC/delay guidance; there is no new production behavior in this refresh.

The prior 74-test proof, [old-head green CI](https://github.com/openclaw/openclaw/actions/runs/33571442416), and native preparation remain historical evidence for `9c3e4f0cba5f3b8079b3eda36771ccaa03c09ecb`, not proof for the refreshed head.

The separate [queued-input UI repair, PR #135790](https://github.com/openclaw/openclaw/pull/135790), landed as [952b9b9505010f75c7d9fff97e0c4153646352b8](https://github.com/openclaw/openclaw/commit/952b9b9505010f75c7d9fff97e0c4153646352b8); [issue #135785](https://github.com/openclaw/openclaw/issues/135785) is closed.

**Exact-head CI green** for `5369ad6ac3ab3946ca99742363207209f2c1cbfa`: [CI run 33585351577, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33585351577) completed successfully; the required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33585351577/job/100109557004) is SUCCESS. Native exact-head review artifacts validate in the existing standalone namespace. This refresh stops before prepare/merge for lead inspection; no merge, auto-merge, queue request, or bypass is authorized or attempted. No post-merge main-CI success is claimed.

Direct dependency proof: [GitHub CLI v2.98.0 response handling](https://github.com/cli/cli/blob/a255baf71d13fe5947a4eb7ad521ffd412d64cee/pkg/cmd/api/api.go#L473-L560), its upstream tests and missing-auth exit mapping, and [GitHub GraphQL rate limits](https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api). Full upstream-source citations are preserved in the [maintainer proof comment](https://github.com/openclaw/openclaw/pull/135657#issuecomment-5502196790).
