### PR TITLE
test(media): scope QR temporary files to their test

### DIFF
--- a/src/media/qr-image.test.ts
+++ b/src/media/qr-image.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 
 const { MOCK_PNG_BASE64, MOCK_PNG_BUFFER, toBuffer } = vi.hoisted(() => {
   const MOCK_PNG_BUFFERLocal = Buffer.from("fakepng");
@@ -26,15 +27,9 @@ beforeAll(async () => {
 });
 
 describe("renderQrPngBase64", () => {
-  const tmpRoot = path.join(os.tmpdir(), "openclaw-qr-image-tests");
-
   beforeEach(() => {
     toBuffer.mockClear();
     toBuffer.mockResolvedValue(MOCK_PNG_BUFFER);
-  });
-
-  afterEach(async () => {
-    await fs.rm(tmpRoot, { recursive: true, force: true });
   });
 
   it("delegates PNG rendering to qrcode", async () => {
@@ -81,8 +76,8 @@ describe("renderQrPngBase64", () => {
     );
   });
 
-  it("writes QR PNGs to a scoped temp file", async () => {
-    await fs.mkdir(tmpRoot, { recursive: true });
+  it("writes QR PNGs to a scoped temp file", async ({ onTestFinished }) => {
+    const tmpRoot = useAutoCleanupTempDirTracker(onTestFinished).make("openclaw-qr-image-");
 
     const result = await writeQrPngTempFile("openclaw", {
       tmpRoot,
@@ -102,7 +97,7 @@ describe("renderQrPngBase64", () => {
   ])("rejects pathful QR temp %s values", async (name, opts) => {
     await expect(
       writeQrPngTempFile("openclaw", {
-        tmpRoot,
+        tmpRoot: os.tmpdir(),
         dirPrefix: opts.dirPrefix,
         fileName: opts.fileName,
       }),


### PR DESCRIPTION
The QR image suite removes a shared system-temp directory after all 13 cases, although only one case writes a file. Give that case a unique parent registered with the existing test-finish cleanup tracker, and remove the other 12 recursive cleanup attempts. Validation-only cases keep exercising the real path guard without owning filesystem state.

All rendering options, validation rows, data-URL checks, filename/media-root assertions and exact file readback remain. The renderer boundary retains its existing fake PNG bytes; the real terminal-rendering siblings remain covered. Production delta is zero; tests +5/-10.

Validation: all 18 existing cases passed before and after, with identical names; the candidate ran shuffled with seed 1777 through the normal test router. The full changed-file gate, including messaging test types, three dead-export scans and lint, passed. Independent Codex review and manual fixture/owner/dependency review found no actionable issue. No wall-time or observed collision-frequency claim is made.

Named follow-up: QR workspace descriptor ownership. The production writer currently returns paths without its fs-safe workspace cleanup owner, and device-pair removes the directory directly. An isolated fs-safe 0.7.0 reproduction on macOS observed retained parent descriptors after raw removal and release through workspace.cleanup(). This test-only change does not repair that production lifetime boundary; preserving delivery outcomes and the public helper contract needs a separate change. Local tests use the existing fs-safe 0.5.6 install; the locked 0.7.0 source was inspected and hosted locked-dependency CI is required before landing.
