### PR TITLE
refactor(sqlite): share required number coercion

### DIFF
--- a/src/acp/event-ledger.ts
+++ b/src/acp/event-ledger.ts
@@ -1,6 +1,7 @@
 /** Persistent SQLite-backed ACP event ledger for session rehydration. */
 import type { DatabaseSync } from "node:sqlite";
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
 import {
   openOpenClawStateDatabase,
   type OpenClawStateDatabaseOptions,
@@ -23,10 +24,7 @@ export { createInMemoryAcpEventLedger } from "./event-ledger.memory.js";
 export type { AcpEventLedger, AcpEventLedgerReplay } from "./event-ledger.types.js";
 
 function normalizeSqliteInteger(value: number | bigint | null): number {
-  if (typeof value === "bigint") {
-    return Number(value);
-  }
-  return typeof value === "number" ? value : 0;
+  return value === null ? 0 : sqliteNumber(value);
 }
 
 type AcpReplaySessionRow = {

--- a/src/agents/subagents/spawn/acp-parent-stream-store.sqlite.ts
+++ b/src/agents/subagents/spawn/acp-parent-stream-store.sqlite.ts
@@ -4,6 +4,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../../../infra/kysely-sync.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../../../infra/sqlite-number.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../../state/openclaw-agent-db.generated.js";
 import {
   runOpenClawAgentWriteTransaction,
@@ -16,10 +17,6 @@ export type AcpParentStreamEvent = Record<string, unknown>;
 
 function getAcpParentStreamKysely(database: import("node:sqlite").DatabaseSync) {
   return getNodeSqliteKysely<AcpParentStreamDatabase>(database);
-}
-
-function normalizeSqliteNumber(value: number | bigint): number {
-  return typeof value === "bigint" ? Number(value) : value;
 }
 
 /** Records one ordered batch in the same synchronous commit section as sequence allocation. */
@@ -58,9 +55,7 @@ export function recordAcpParentStreamEvents(
         .where("run_id", "=", options.runId),
     );
     const firstSeq =
-      row?.max_seq === null || row?.max_seq === undefined
-        ? 0
-        : normalizeSqliteNumber(row.max_seq) + 1;
+      row?.max_seq === null || row?.max_seq === undefined ? 0 : sqliteNumber(row.max_seq) + 1;
     executeSqliteQuerySync(
       database.db,
       db.insertInto("acp_parent_stream_events").values(

--- a/src/claws/cron.ts
+++ b/src/claws/cron.ts
@@ -4,6 +4,7 @@ import { normalizeCronJobCreate } from "../cron/normalize.js";
 import { createTrustedCronScheduledToolPolicy } from "../cron/scheduled-tool-policy.js";
 import { applyDefaultCronToolsAllow } from "../cron/tools-allow.js";
 import type { CronJob } from "../cron/types.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -68,8 +69,8 @@ function rowToRef(row: CronRefRow): PersistedClawCronRef {
     status: row.status,
     job: JSON.parse(row.job_json) as ClawCronJob,
     ...(row.error ? { error: row.error } : {}),
-    createdAtMs: Number(row.created_at_ms),
-    updatedAtMs: Number(row.updated_at_ms),
+    createdAtMs: sqliteNumber(row.created_at_ms),
+    updatedAtMs: sqliteNumber(row.updated_at_ms),
   };
 }
 

--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -24,6 +24,7 @@ import { moveToTrash } from "../commands/cleanup-utils.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { root as fsSafeRoot, FsSafeError } from "../infra/fs-safe.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { unregisterOpenClawAgentDatabases } from "../state/openclaw-agent-db-registry.js";
 import type { OpenClawStateDatabase } from "../state/openclaw-state-db-contract.js";
@@ -75,8 +76,8 @@ function rowToWorkspaceFile(row: WorkspaceFileRow): PersistedClawWorkspaceFile {
     sourcePath: row.source_path,
     contentDigest: row.content_digest,
     status: row.status,
-    createdAtMs: Number(row.created_at_ms),
-    updatedAtMs: Number(row.updated_at_ms),
+    createdAtMs: sqliteNumber(row.created_at_ms),
+    updatedAtMs: sqliteNumber(row.updated_at_ms),
   };
 }
 

--- a/src/claws/mcp.ts
+++ b/src/claws/mcp.ts
@@ -4,6 +4,7 @@ import { setConfiguredMcpServer } from "../agents/mcp-config-mutation.js";
 import { withClawMcpLifecycleLease } from "../agents/mcp-lifecycle-lease.js";
 import { canonicalizeConfiguredMcpServer } from "../config/mcp-config-normalize.js";
 import { listConfiguredMcpServers } from "../config/mcp-config.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -66,11 +67,11 @@ function rowToRef(row: McpRefRow): PersistedClawMcpServerRef {
     configDigest: row.config_digest,
     relationship: row.relationship,
     origin: row.origin,
-    independentOwner: Number(row.independent_owner) === 1,
+    independentOwner: sqliteNumber(row.independent_owner) === 1,
     status: row.status,
     ...(row.error ? { error: row.error } : {}),
-    createdAtMs: Number(row.created_at_ms),
-    updatedAtMs: Number(row.updated_at_ms),
+    createdAtMs: sqliteNumber(row.created_at_ms),
+    updatedAtMs: sqliteNumber(row.updated_at_ms),
   };
 }
 

--- a/src/claws/package-extension-provenance.ts
+++ b/src/claws/package-extension-provenance.ts
@@ -1,3 +1,4 @@
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
 import type { ClawAppliedExtension, ClawPackage } from "./types.js";
 
 export const CLAW_PACKAGE_REF_SCHEMA_VERSION = "openclaw.clawPackageRef.v1" as const;
@@ -128,9 +129,9 @@ export function rowToPackageRef(row: PackageRefRow): PersistedClawPackageRef {
     status: row.package_status,
     relationship: row.relationship,
     origin: row.origin,
-    independentOwner: Number(row.independent_owner) === 1,
+    independentOwner: sqliteNumber(row.independent_owner) === 1,
     ...(extension ? { extension } : {}),
-    installedAtMs: Number(row.installed_at_ms),
-    updatedAtMs: Number(row.updated_at_ms),
+    installedAtMs: sqliteNumber(row.installed_at_ms),
+    updatedAtMs: sqliteNumber(row.updated_at_ms),
   };
 }

--- a/src/claws/provenance.ts
+++ b/src/claws/provenance.ts
@@ -2,6 +2,7 @@
 
 import type { DatabaseSync } from "node:sqlite";
 import { stableStringify } from "@openclaw/normalization-core";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -90,9 +91,9 @@ function rowToRecord(row: ClawInstallRow): PersistedClawInstall {
       manifestPath: row.manifest_path,
       integrityKind: row.integrity_kind,
       integrity: row.integrity,
-      byteLength: Number(row.source_byte_length),
+      byteLength: sqliteNumber(row.source_byte_length),
     },
-    manifestSchemaVersion: Number(
+    manifestSchemaVersion: sqliteNumber(
       row.manifest_schema_version,
     ) as ClawAddPlan["manifestSchemaVersion"],
     planIntegrity: row.plan_integrity,
@@ -102,8 +103,8 @@ function rowToRecord(row: ClawInstallRow): PersistedClawInstall {
     agentOwnedPaths: JSON.parse(row.agent_owned_paths_json) as string[],
     ...clawBootstrapProvenanceFromRow(row),
     status: row.status,
-    addedAtMs: Number(row.added_at_ms),
-    updatedAtMs: Number(row.updated_at_ms),
+    addedAtMs: sqliteNumber(row.added_at_ms),
+    updatedAtMs: sqliteNumber(row.updated_at_ms),
   };
 }
 

--- a/src/claws/workspace.ts
+++ b/src/claws/workspace.ts
@@ -4,6 +4,7 @@ import { realpath } from "node:fs/promises";
 import { resolve, sep } from "node:path";
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
 import { root as fsSafeRoot, FsSafeError, type Root } from "../infra/fs-safe.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -63,8 +64,8 @@ function rowToWorkspaceFile(row: WorkspaceFileRow): PersistedClawWorkspaceFile {
     sourcePath: row.source_path,
     contentDigest: row.content_digest,
     status: row.status,
-    createdAtMs: Number(row.created_at_ms),
-    updatedAtMs: Number(row.updated_at_ms),
+    createdAtMs: sqliteNumber(row.created_at_ms),
+    updatedAtMs: sqliteNumber(row.updated_at_ms),
   };
 }
 
@@ -190,8 +191,8 @@ function readWorkspaceFile(
       sourcePath: row.source_path,
       contentDigest: row.content_digest,
       status: row.status,
-      createdAtMs: Number(row.created_at_ms),
-      updatedAtMs: Number(row.updated_at_ms),
+      createdAtMs: sqliteNumber(row.created_at_ms),
+      updatedAtMs: sqliteNumber(row.updated_at_ms),
     };
   }, options);
 }

--- a/src/config/sessions/session-accessor.sqlite-delete-snapshot.ts
+++ b/src/config/sessions/session-accessor.sqlite-delete-snapshot.ts
@@ -1,4 +1,5 @@
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../../infra/sqlite-number.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import type { SessionStateDeleteSnapshot } from "./session-accessor.sqlite-delete-snapshot.types.js";
 
@@ -25,10 +26,6 @@ type SessionStateDeleteSnapshotDatabase = Pick<
   | "transcript_events"
   | "transcript_rewrite_watermarks"
 >;
-
-function normalizeOptionalSqliteNumber(value: number | bigint | null | undefined): number | null {
-  return value === null || value === undefined ? null : Number(value);
-}
 
 /** Captures the owner window and canonical child state writable outside the lifecycle queue. */
 export function readSessionStateDeleteSnapshot(
@@ -76,7 +73,7 @@ export function readSessionStateDeleteSnapshot(
       .where("session_id", "=", sessionId),
   );
   return {
-    acpParentStreamEventCount: normalizeOptionalSqliteNumber(acpParentStream?.event_count) ?? 0,
+    acpParentStreamEventCount: sqliteNumber(acpParentStream?.event_count ?? 0),
     generation: rewriteWatermark?.generation ?? null,
     lastSeq: lastEvent?.seq ?? null,
     sessionKey: window?.session_key ?? null,

--- a/src/config/sessions/session-accessor.sqlite-delta.ts
+++ b/src/config/sessions/session-accessor.sqlite-delta.ts
@@ -3,6 +3,7 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
 } from "../../infra/kysely-sync.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../../infra/sqlite-number.js";
 import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type {
@@ -10,7 +11,6 @@ import type {
   SessionTranscriptRawDeltaResult,
   SessionTranscriptReadScope,
 } from "./session-accessor.sqlite-contract.js";
-import { coerceSqliteNumber } from "./session-accessor.sqlite-normalize.js";
 import {
   getSessionKysely,
   resolveSqliteTranscriptReadScope,
@@ -194,7 +194,7 @@ function readRawDeltaInTransaction(
       .limit(1),
   );
   const maxSeq = Math.min(
-    frontier ? coerceSqliteNumber(frontier.seq) : -1,
+    frontier ? sqliteNumber(frontier.seq) : -1,
     beforeEventSeq === undefined ? Number.POSITIVE_INFINITY : beforeEventSeq - 1,
   );
   if (cursor.lastSeq > maxSeq) {
@@ -221,8 +221,8 @@ function readRawDeltaInTransaction(
       .orderBy("seq", "asc")
       .limit(maxEvents + 1),
   ).rows.map((row) => ({
-    seq: coerceSqliteNumber(row.seq),
-    serializedBytes: coerceSqliteNumber(row.serialized_bytes),
+    seq: sqliteNumber(row.seq),
+    serializedBytes: sqliteNumber(row.serialized_bytes),
   }));
 
   let serializedBytes = 0;
@@ -250,7 +250,7 @@ function readRawDeltaInTransaction(
             .orderBy("seq", "asc"),
         ).rows.map((row) => ({
           event: JSON.parse(row.event_json),
-          seq: coerceSqliteNumber(row.seq),
+          seq: sqliteNumber(row.seq),
         }));
   const nextCursor = encodeRawTranscriptCursor({ ...cursor, lastSeq });
   const requiredBytes =

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -4,6 +4,7 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
 } from "../../infra/kysely-sync.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../../infra/sqlite-number.js";
 import type { ChannelRouteRef } from "../../plugin-sdk/channel-route.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import {
@@ -45,10 +46,7 @@ import {
 import { listTranscriptInstancesFromDatabase } from "./session-accessor.sqlite-history.js";
 import { emitCommittedSessionIdentityDiff } from "./session-accessor.sqlite-identity.js";
 import { kickSessionEntryMaintenanceAfterWrite } from "./session-accessor.sqlite-maintenance-kick.js";
-import {
-  createFallbackSessionEntry,
-  coerceSqliteNumber,
-} from "./session-accessor.sqlite-normalize.js";
+import { createFallbackSessionEntry } from "./session-accessor.sqlite-normalize.js";
 import {
   cloneSessionEntry,
   getSessionKysely,
@@ -274,7 +272,7 @@ export function countSessionEntryRowsReadOnly(scope: SessionEntryListScope = {})
         .selectFrom("session_nodes")
         .select((expression) => expression.fn.countAll<number | bigint>().as("count")),
     );
-    return row ? coerceSqliteNumber(row.count) : 0;
+    return row ? sqliteNumber(row.count) : 0;
   }, toDatabaseOptions(resolved));
   return result.found ? result.value : 0;
 }
@@ -389,7 +387,7 @@ export function readSessionUpdatedAtCore(scope: SessionAccessScope): number | un
   const resolved = resolveSqliteScope(scope);
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
   const row = readSessionEntryRow(database, resolved.sessionKey)?.row;
-  return row ? coerceSqliteNumber(row.updated_at) : undefined;
+  return row ? sqliteNumber(row.updated_at) : undefined;
 }
 
 /** Applies a partial entry update to the additive SQLite session store. */

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
@@ -4,6 +4,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   iterateSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../../infra/sqlite-number.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import {
   isIncognitoOpenClawAgentDatabase,
@@ -37,7 +38,6 @@ import type {
   ProjectedLifecycleMutation,
   SessionEntryRemovalPlan,
 } from "./session-accessor.sqlite-lifecycle-types.js";
-import { coerceSqliteNumber } from "./session-accessor.sqlite-normalize.js";
 import { collectSessionStateIdsForEntry } from "./session-accessor.sqlite-references.js";
 import { cloneSessionEntry, getSessionKysely } from "./session-accessor.sqlite-scope.js";
 import {
@@ -123,7 +123,7 @@ function readSessionTranscriptUpdatedAt(
   if (row?.updated_at === null || row?.updated_at === undefined) {
     return undefined;
   }
-  return coerceSqliteNumber(row.updated_at);
+  return sqliteNumber(row.updated_at);
 }
 
 function sqliteTranscriptStateIsReclaimable(params: {
@@ -637,7 +637,7 @@ export function planSessionLifecycleArtifactCleanup(
       !sqliteTranscriptStateIsReclaimable({
         database,
         // Admission updates the node even when a run has no event yet or reuses old events.
-        sessionUpdatedAt: coerceSqliteNumber(row.updated_at),
+        sessionUpdatedAt: sqliteNumber(row.updated_at),
         sessionId: row.current_session_id,
         nowMs: params.nowMs,
         orphanTranscriptMinAgeMs: params.orphanTranscriptMinAgeMs,

--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -2,6 +2,7 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import { sql } from "kysely";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import { runWithSqliteBusyTimeout } from "../../infra/sqlite-busy-timeout.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../../infra/sqlite-number.js";
 import { getChildLogger } from "../../logging/logger.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import {
@@ -316,7 +317,7 @@ async function readSessionTranscriptJsonlBytes(
       );
     }
     for (const row of opened.value) {
-      bytesBySessionId.set(row.session_id, Number(row.jsonl_bytes));
+      bytesBySessionId.set(row.session_id, sqliteNumber(row.jsonl_bytes));
     }
   }
   return bytesBySessionId;

--- a/src/config/sessions/session-accessor.sqlite-normalize.ts
+++ b/src/config/sessions/session-accessor.sqlite-normalize.ts
@@ -20,7 +20,3 @@ export function normalizeSessionRowChatType(value: unknown): "direct" | "group" 
   }
   return null;
 }
-
-export function coerceSqliteNumber(value: number | bigint): number {
-  return typeof value === "bigint" ? Number(value) : value;
-}

--- a/src/config/sessions/session-accessor.sqlite-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-read.ts
@@ -5,6 +5,7 @@ import {
   iterateSqliteQuerySync,
   prepareSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../../infra/sqlite-number.js";
 import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
 import { extractAssistantPhaseText } from "../../shared/chat-message-content.js";
 import { isTranscriptOnlyOpenClawAssistantModel } from "../../shared/transcript-only-openclaw-assistant.js";
@@ -24,7 +25,6 @@ import type {
 } from "./session-accessor.sqlite-contract.js";
 import { readSessionStateDeleteSnapshot } from "./session-accessor.sqlite-delete-snapshot.js";
 import type { SessionStateDeleteSnapshot } from "./session-accessor.sqlite-delete-snapshot.types.js";
-import { coerceSqliteNumber } from "./session-accessor.sqlite-normalize.js";
 import {
   getSessionKysely,
   resolveSqliteTranscriptReadScope,
@@ -178,7 +178,7 @@ export function loadTranscriptEventRowsAfterSeqSync(
   }
   return executeSqliteQuerySync(database.db, query.orderBy("seq", "asc")).rows.map((row) => ({
     event: JSON.parse(row.event_json) as TranscriptEvent,
-    seq: coerceSqliteNumber(row.seq),
+    seq: sqliteNumber(row.seq),
   }));
 }
 
@@ -201,7 +201,7 @@ export function readTranscriptEventAtSeqSync(
   return row
     ? {
         event: JSON.parse(row.event_json) as TranscriptEvent,
-        seq: coerceSqliteNumber(row.seq),
+        seq: sqliteNumber(row.seq),
       }
     : undefined;
 }
@@ -257,7 +257,7 @@ export function readTranscriptEventRows(
   ).rows;
   return rows.map((row) => ({
     eventJson: row.event_json,
-    seq: coerceSqliteNumber(row.seq),
+    seq: sqliteNumber(row.seq),
   }));
 }
 
@@ -276,9 +276,9 @@ export function readTranscriptStorageRows(
       .orderBy("seq", "asc"),
   ).rows;
   return rows.map((row) => ({
-    createdAt: coerceSqliteNumber(row.created_at),
+    createdAt: sqliteNumber(row.created_at),
     eventJson: row.event_json,
-    seq: coerceSqliteNumber(row.seq),
+    seq: sqliteNumber(row.seq),
   }));
 }
 

--- a/src/config/sessions/session-accessor.sqlite-transcript-parent.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-parent.ts
@@ -3,6 +3,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   iterateSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../../infra/sqlite-number.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type { TranscriptMessageAppendOptions } from "./session-accessor.sqlite-contract.js";
 import { readTranscriptIdentityByEventId } from "./session-accessor.sqlite-read.js";
@@ -35,7 +36,7 @@ export function resolveTranscriptMessageAppendParent<TMessage>(
       .select((expression) => expression.fn.countAll<number | bigint>().as("count"))
       .where("session_id", "=", sessionId),
   );
-  const maxAncestors = Number(countRow?.count ?? 0);
+  const maxAncestors = sqliteNumber(countRow?.count ?? 0);
   let ancestorId: string | null = tailId;
   for (let depth = 0; depth <= maxAncestors; depth += 1) {
     if (ancestorId === options.parentId) {

--- a/src/config/sessions/session-accessor.sqlite-transcript-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-state.ts
@@ -4,9 +4,9 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
 } from "../../infra/kysely-sync.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../../infra/sqlite-number.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { publishSessionEntryCacheInvalidation } from "./session-accessor.sqlite-entry-cache.js";
-import { coerceSqliteNumber } from "./session-accessor.sqlite-normalize.js";
 import { getSessionKysely, type ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
 import { parseSessionEntryJson } from "./session-accessor.sqlite-status.js";
 import {
@@ -212,7 +212,7 @@ export function readNextTranscriptSeq(database: OpenClawAgentDatabase, sessionId
       .where("session_id", "=", sessionId),
   );
   const maxSeq =
-    row?.max_seq === null || row?.max_seq === undefined ? -1 : coerceSqliteNumber(row.max_seq);
+    row?.max_seq === null || row?.max_seq === undefined ? -1 : sqliteNumber(row.max_seq);
   return maxSeq + 1;
 }
 

--- a/src/infra/delivery-queue-sqlite-bound.ts
+++ b/src/infra/delivery-queue-sqlite-bound.ts
@@ -9,6 +9,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "./sqlite-number.js";
 
 type QueueStatus = "pending" | "failed" | "completed";
 export type DeliveryQueueReadMode = "pending" | "unfinished" | "all";
@@ -178,13 +179,13 @@ export function inflateDeliveryQueueRow(
   return {
     ...parsed,
     id: row.id,
-    enqueuedAt: Number(row.enqueued_at),
-    retryCount: Number(row.retry_count),
-    ...(row.last_attempt_at == null ? {} : { lastAttemptAt: Number(row.last_attempt_at) }),
+    enqueuedAt: sqliteNumber(row.enqueued_at),
+    retryCount: sqliteNumber(row.retry_count),
+    ...(row.last_attempt_at == null ? {} : { lastAttemptAt: sqliteNumber(row.last_attempt_at) }),
     ...(row.last_error == null ? {} : { lastError: row.last_error }),
     ...(row.platform_send_started_at == null
       ? {}
-      : { platformSendStartedAt: Number(row.platform_send_started_at) }),
+      : { platformSendStartedAt: sqliteNumber(row.platform_send_started_at) }),
     ...(row.recovery_state == null ? {} : { recoveryState: row.recovery_state }),
   };
 }

--- a/src/infra/sqlite-audit-record-store.ts
+++ b/src/infra/sqlite-audit-record-store.ts
@@ -12,6 +12,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "./sqlite-number.js";
 
 type DiagnosticEventsTable = OpenClawStateKyselyDatabase["diagnostic_events"];
 type AuditRecordDatabase = Pick<OpenClawStateKyselyDatabase, "diagnostic_events">;
@@ -54,7 +55,7 @@ function countAuditRecords(database: DatabaseSync, scope: string): number {
       .select((eb) => eb.fn.countAll<number | bigint>().as("count"))
       .where("scope", "=", scope),
   );
-  return typeof row?.count === "bigint" ? Number(row.count) : (row?.count ?? 0);
+  return typeof row?.count === "bigint" ? sqliteNumber(row.count) : (row?.count ?? 0);
 }
 
 function nextAuditSequence(params: {

--- a/src/infra/sqlite-number.test.ts
+++ b/src/infra/sqlite-number.test.ts
@@ -1,7 +1,31 @@
 // Tests for SQLite number normalization.
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
-import { normalizeSqliteNumber } from "./sqlite-number.js";
+import { coerceRequiredSqliteNumber, normalizeSqliteNumber } from "./sqlite-number.js";
+
+describe("coerceRequiredSqliteNumber", () => {
+  it.each([
+    ["number", 5, 5],
+    ["negative zero", -0, -0],
+    ["NaN", Number.NaN, Number.NaN],
+    ["positive infinity", Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY],
+    ["negative infinity", Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY],
+    ["zero bigint", BigInt(0), 0],
+    ["safe bigint", BigInt(Number.MAX_SAFE_INTEGER), Number.MAX_SAFE_INTEGER],
+    [
+      "unsafe positive bigint",
+      BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1),
+      Number(BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1)),
+    ],
+    [
+      "unsafe negative bigint",
+      BigInt(-Number.MAX_SAFE_INTEGER) - BigInt(1),
+      Number(BigInt(-Number.MAX_SAFE_INTEGER) - BigInt(1)),
+    ],
+  ] as const)("preserves the required %s conversion contract", (_name, value, expected) => {
+    expect(Object.is(coerceRequiredSqliteNumber(value), expected)).toBe(true);
+  });
+});
 
 describe("normalizeSqliteNumber", () => {
   it("returns number value unchanged", () => {

--- a/src/infra/sqlite-number.ts
+++ b/src/infra/sqlite-number.ts
@@ -1,5 +1,9 @@
 const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
 
+export function coerceRequiredSqliteNumber(value: number | bigint): number {
+  return typeof value === "bigint" ? Number(value) : value;
+}
+
 /** Converts a SQLite number or safely representable bigint column into a JavaScript number. */
 export function normalizeSqliteNumber(value: number | bigint | null): number | undefined {
   if (typeof value === "bigint") {

--- a/src/infra/state-migrations.cron-run-logs.ts
+++ b/src/infra/state-migrations.cron-run-logs.ts
@@ -6,7 +6,7 @@ import {
   cronRunStatusToTaskStatus,
   parseCronRunLogEntryObject,
 } from "../cron/task-run-detail.js";
-import { normalizeSqliteNumber } from "./sqlite-number.js";
+import { coerceRequiredSqliteNumber, normalizeSqliteNumber } from "./sqlite-number.js";
 
 type CronRunLogEntry = import("../cron/run-log-types.js").CronRunLogEntry;
 type CronDeliveryStatus = import("../cron/types.js").CronDeliveryStatus;
@@ -104,7 +104,9 @@ function hasMirroredIdentity(
 }
 
 function integerToBoolean(value: number | bigint | null | undefined): boolean | undefined {
-  return value === null || value === undefined ? undefined : Number(value) !== 0;
+  return value === null || value === undefined
+    ? undefined
+    : coerceRequiredSqliteNumber(value) !== 0;
 }
 
 /** Legacy rows trust write-time errorReason and diagnostic redaction without recomputation. */

--- a/src/infra/state-migrations.debug-proxy.ts
+++ b/src/infra/state-migrations.debug-proxy.ts
@@ -7,6 +7,7 @@ import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js"
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { sha256Hex } from "./crypto-digest.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "./sqlite-number.js";
 
 const DEBUG_PROXY_SQLITE_SIDECAR_SUFFIXES = ["", "-shm", "-wal", "-journal"] as const;
 
@@ -144,7 +145,7 @@ function assertTableColumns(db: DatabaseSync, table: string, expected: readonly 
 }
 
 function normalizeSqliteInteger(value: number | bigint | null): number | null {
-  return typeof value === "bigint" ? Number(value) : value;
+  return value === null ? null : sqliteNumber(value);
 }
 
 function readLegacyDebugProxyCapture(params: { sourcePath: string; blobDir: string }): {

--- a/src/infra/state-migrations.task-sidecar-rows.ts
+++ b/src/infra/state-migrations.task-sidecar-rows.ts
@@ -2,14 +2,12 @@
 import type { DatabaseSync, SQLInputValue } from "node:sqlite";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "./sqlite-number.js";
 
 export type SqliteBindRow = Record<string, SQLInputValue>;
 
 export function normalizeLegacySqliteInteger(value: number | bigint | null): number | null {
-  if (typeof value === "bigint") {
-    return Number(value);
-  }
-  return value;
+  return value === null ? null : sqliteNumber(value);
 }
 
 export function listSqliteColumns(db: DatabaseSync, table: string): Set<string> {

--- a/src/plugin-state/plugin-blob-store.sqlite.ts
+++ b/src/plugin-state/plugin-blob-store.sqlite.ts
@@ -7,6 +7,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
@@ -277,7 +278,7 @@ function deleteExpiredNamespace(
 }
 
 function totalBytes(rows: readonly { size_bytes: number | bigint }[]): number {
-  return rows.reduce((total, row) => total + Number(row.size_bytes), 0);
+  return rows.reduce((total, row) => total + sqliteNumber(row.size_bytes), 0);
 }
 
 function limitError(message: string, env?: NodeJS.ProcessEnv): PluginBlobStoreError {
@@ -303,7 +304,7 @@ function assertProjectedLimits(params: {
   const pluginRows = selectStoredDescriptors(params.db, {
     pluginId: params.write.pluginId,
   });
-  const previousBytes = params.existing ? Number(params.existing.size_bytes) : 0;
+  const previousBytes = params.existing ? sqliteNumber(params.existing.size_bytes) : 0;
   const rowDelta = params.existing ? 0 : 1;
   if (namespaceRows.length + rowDelta > params.write.maxEntries) {
     throw limitError("Plugin blob namespace reached its stored row limit.", params.write.env);
@@ -354,7 +355,7 @@ function deleteOldestUntilWithinLimits(params: {
     }
     namespaceKeysToDelete.push(row.entry_key);
     namespaceCount -= 1;
-    namespaceBytes -= Number(row.size_bytes);
+    namespaceBytes -= sqliteNumber(row.size_bytes);
   }
   if (
     namespaceCount > params.write.maxEntries ||
@@ -394,7 +395,7 @@ function deleteOldestUntilWithinLimits(params: {
     }
     pluginKeysToDelete.push(row.entry_key);
     pluginCount -= 1;
-    pluginBytes -= Number(row.size_bytes);
+    pluginBytes -= sqliteNumber(row.size_bytes);
   }
   if (
     pluginCount > MAX_PLUGIN_BLOB_ENTRIES_PER_PLUGIN ||

--- a/src/plugin-state/plugin-blob-store.ts
+++ b/src/plugin-state/plugin-blob-store.ts
@@ -1,5 +1,5 @@
 // Public facade for plugin-scoped SQLite blob storage.
-import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
+import { coerceRequiredSqliteNumber, normalizeSqliteNumber } from "../infra/sqlite-number.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import {
@@ -180,7 +180,7 @@ function storedInfoToEntryInfo<TMetadata>(
   return {
     key: row.entry_key,
     metadata: parseMetadata(row.metadata_json, operation, env) as TMetadata,
-    sizeBytes: Number(row.size_bytes),
+    sizeBytes: coerceRequiredSqliteNumber(row.size_bytes),
     createdAt: normalizeSqliteNumber(row.created_at) ?? 0,
     ...(expiresAt != null ? { expiresAt } : {}),
   };

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -10,7 +10,7 @@ import {
 } from "../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { isTerminalSqliteIntegrityError } from "../infra/sqlite-integrity.js";
-import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
+import { coerceRequiredSqliteNumber, normalizeSqliteNumber } from "../infra/sqlite-number.js";
 import {
   isSqliteCorruptionError,
   runSqliteImmediateTransactionSync,
@@ -53,10 +53,6 @@ export type PluginDoctorRawStateEntry = Omit<PluginStateEntry<unknown>, "value" 
   valueJson: string;
   value?: unknown;
   expiresAt: number | null;
-};
-
-type CountRow = {
-  count: number | bigint;
 };
 
 type PluginStateDatabase = {
@@ -341,7 +337,7 @@ function countLivePluginStateNamespaceEntries(
       .where("namespace", "=", params.namespace)
       .where((eb) => eb.or([eb("expires_at", "is", null), eb("expires_at", ">", params.now)])),
   );
-  return countRow(row);
+  return coerceRequiredSqliteNumber(row?.count ?? 0);
 }
 
 function allocatePluginStateNamespaceCreatedAt(
@@ -376,7 +372,7 @@ function countLivePluginStateEntries(
       .where("plugin_id", "=", params.pluginId)
       .where((eb) => eb.or([eb("expires_at", "is", null), eb("expires_at", ">", params.now)])),
   );
-  return countRow(row);
+  return coerceRequiredSqliteNumber(row?.count ?? 0);
 }
 
 function deleteOldestPluginStateNamespaceEntries(
@@ -493,11 +489,6 @@ function withPluginStateDatabaseReadOnly<T>(
   }
 }
 
-function countRow(row: CountRow | undefined): number {
-  const raw = row?.count ?? 0;
-  return typeof raw === "bigint" ? Number(raw) : raw;
-}
-
 function envOptions(env?: NodeJS.ProcessEnv): OpenClawStateDatabaseOptions {
   return env ? { env } : {};
 }
@@ -542,8 +533,8 @@ function readPluginStateRetention(
       .where((eb) => eb.or([eb("expires_at", "is", null), eb("expires_at", ">", params.now)])),
   );
   return {
-    namespaceCount: Number(row?.namespace_count ?? 0),
-    pluginCount: Number(row?.plugin_count ?? 0),
+    namespaceCount: coerceRequiredSqliteNumber(row?.namespace_count ?? 0),
+    pluginCount: coerceRequiredSqliteNumber(row?.plugin_count ?? 0),
     nextExpiry: normalizeSqliteNumber(row?.next_expiry ?? null) ?? Infinity,
     now: params.now,
     sweepPending: true,

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -6,6 +6,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
@@ -102,8 +103,8 @@ function rowToTrustState(
   return {
     mode: "signed",
     signedBy: row.trust_key_id,
-    signatureCount: Number(row.trust_signature_count),
-    threshold: Number(row.trust_threshold),
+    signatureCount: sqliteNumber(row.trust_signature_count),
+    threshold: sqliteNumber(row.trust_threshold),
     verifiedAt: row.trust_verified_at,
   };
 }
@@ -206,7 +207,7 @@ function rowToSnapshot(
   }
   const metadata: HostedOfficialExternalPluginCatalogMetadata = {
     url: row.feed_url,
-    status: Number(row.status),
+    status: sqliteNumber(row.status),
     checksum: row.checksum,
     ...(row.etag ? { etag: row.etag } : {}),
     ...(row.last_modified ? { lastModified: row.last_modified } : {}),

--- a/src/state/openclaw-state-db-legacy-backfills.ts
+++ b/src/state/openclaw-state-db-legacy-backfills.ts
@@ -5,6 +5,7 @@ import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeAgentRunTerminalReplySnapshot } from "../agents/agent-run-terminal-reply.js";
 import { selectDeliverableSessionsReply } from "../agents/tools/sessions-send-tokens.js";
 import { buildApprovalResolutionRef } from "../infra/approval-resolution-ref.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
 import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
 import { compactLegacyDeliveryQueueFailures } from "./openclaw-state-db-delivery-queue-backfill.js";
 import * as operatorApprovalMigration from "./openclaw-state-db-operator-approval-migration.js";
@@ -401,7 +402,7 @@ export function backfillCronRunLogEntryJson(db: DatabaseSync): void {
   );
   for (const row of rows) {
     update.run(
-      JSON.stringify({ ts: Number(row.ts), jobId: row.job_id, action: "finished" }),
+      JSON.stringify({ ts: sqliteNumber(row.ts), jobId: row.job_id, action: "finished" }),
       row.store_key,
       row.job_id,
       row.seq,
@@ -488,7 +489,7 @@ export function backfillCronJobsFromJobJson(db: DatabaseSync): void {
       job.enabled === false ? 0 : 1,
       textField(job, "agentId"),
       payloadKind,
-      numberField(job, "updatedAtMs") ?? (Number(row.updated_at) || 0),
+      numberField(job, "updatedAtMs") ?? (sqliteNumber(row.updated_at) || 0),
       row.store_key,
       row.job_id,
     );

--- a/src/trajectory/runtime-store.sqlite.ts
+++ b/src/trajectory/runtime-store.sqlite.ts
@@ -7,6 +7,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
+import { coerceRequiredSqliteNumber as sqliteNumber } from "../infra/sqlite-number.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
@@ -226,9 +227,9 @@ function readSqliteTrajectoryRuntimeRuns(database: OpenClawAgentDatabase): Traje
       .groupBy(["session_id", "run_id"]),
   ).rows;
   return rows.map((row) => ({
-    newestCreatedAt: normalizeSqliteNumber(row.newest_created_at),
+    newestCreatedAt: sqliteNumber(row.newest_created_at),
     runId: row.run_id,
-    runtimeBytes: normalizeSqliteNumber(row.runtime_bytes),
+    runtimeBytes: sqliteNumber(row.runtime_bytes),
     sessionId: row.session_id,
   }));
 }
@@ -311,7 +312,7 @@ function readNextTrajectorySeq(database: OpenClawAgentDatabase, sessionId: strin
   if (row?.max_seq === null || row?.max_seq === undefined) {
     return 0;
   }
-  return normalizeSqliteNumber(row.max_seq) + 1;
+  return sqliteNumber(row.max_seq) + 1;
 }
 
 function trimSqliteTrajectoryRuntimeWindow(
@@ -363,8 +364,4 @@ function trajectoryJsonlRowBytes(eventJson: string): number {
 
 function readTrajectoryEventTimestamp(event: TrajectoryEvent): number | undefined {
   return parseDateStringTimestampMs(event.ts);
-}
-
-function normalizeSqliteNumber(value: number | bigint): number {
-  return typeof value === "bigint" ? Number(value) : value;
 }


### PR DESCRIPTION
## What Problem This Solves

Required SQLite numeric projections used repeated unchecked `number | bigint` coercion across session, ACP, trajectory, Claw lifecycle, plugin state, delivery queue, catalog snapshot, migration, and audit owners. Keeping that contract duplicated made it easy to confuse it with the separate safe nullable normalization policy.

## Why This Change Was Made

`src/infra/sqlite-number.ts` now owns two explicit private internal contracts:

- `coerceRequiredSqliteNumber(value: number | bigint): number` preserves the exact required-value ternary semantics.
- `normalizeSqliteNumber` remains the nullable safe normalizer and still rejects unsafe bigint values.

The expanded refactor removes local required-value copies and routes the approved typed SQLite projections through the canonical helper. The frozen-review repair additionally changes exactly two remaining projections in `readPluginStateRetention()`: `namespace_count` and `plugin_count`. Both now use the already-imported `coerceRequiredSqliteNumber`; no import, test seam, file, caller, null/default, or getter behavior changed.

Semantic exclusions remain unchanged: mutation result metadata, PRAGMA values, nullable/default normalizers, and external plugin implementations are untouched. `src/infra/sqlite-audit-record-store.ts` keeps its outer ternary and two getter reads, replacing only the inner `Number(row.count)`.

No SQL, schema, generated type, query, transaction, lifecycle, config, SDK, migration output, or persistence semantics changed. This is not a material SQLite store change.

## User Impact

No user-visible behavior change. Internal SQLite projection code now has one required-number coercion owner while retaining the distinct safe nullable contract.

Production LOC is `+96/-106`, net `-10`; tests are `+25/-1`, net `+24`. Scope remains exactly 29 production files plus `src/infra/sqlite-number.test.ts`. The frozen-review repair itself is `+2/-2` in `src/plugin-state/plugin-state-store.sqlite.ts`.

## Evidence

- Exact parent: `35f324956f0c4de1432a9ef48a7b6c5c4b4fcd94`.
- Signed commit: `1334d1e455f3007441aa9754009b72beb6275675`; tree: `1282210ad025503f0831ba98254671b5abab9aee`.
- Aggregate stable patch ID: `be7db6b38359331af931c06fbc4c7494a6dcb396`.
- Frozen-review repair patch ID: `95343fbb904307b5fb0fa73afb6f207e6d630ae5`.
- Updated target-file stable patch ID: `bf9c263c7549b3efdd0e9836dd2310fc8a995dc6`.
- Helper suite: exactly 20 tests passed.
- Focused and broader owner suites: 23 files / 389 tests passed across plugin-state retention/ownership, ACP, audit, trajectory, delivery queue, Claw lifecycle, session conformance/transcript/maintenance, legacy backfills, and official plugin catalog.
- Differential proof: 200,014 values / 400,033 comparisons / 0 mismatches across both repaired projections, including null/default, getter-read, thrown-error, bigint, non-finite number, and negative-zero behavior.
- Exhaustive targeted search found no direct `Number(row...)` conversion attached to a `countAll<number | bigint>` projection; all such target projections use the required coercer, except the intentionally preserved audit outer ternary.
- Passed: `pnpm check:coercion-helpers`, `pnpm lint:kysely`, `pnpm check:import-cycles`, `pnpm check:madge-import-cycles`, and `git diff --check`.
- Changed-path dry run selected only `core, coreTests`.
- Actual changed-path gate passed every check through the core typecheck stage, including formatting, dependency pins, plugin boundaries, package patches, and the core tsgo graph boundary.
- Environment gaps: core/test typechecks remain blocked by absent `markdown-it-cjk-friendly`, `mdast-util-from-markdown`, `mdast-util-gfm-table`, `micromark-extension-gfm-table`, and `libphonenumber-js/min`. The plugin-state E2E setup/build remains blocked by absent `@pierre/diffs` and Shiki language packages. No dependency installation or reconciliation was performed.
- Current-main guard at `ac5f47e2785e006f8d05c34c6769d342c763c121`: no repaired path, helper, generated SQLite projection, Node/Kysely contract, changed-routing/Vitest/build gate, or plugin-state lifecycle behavior changed.
- All 16 overlap PRs remained open at their approved heads before publication: #111250, #112641, #117040, #119023, #119741, #119753, #124749, #124899, #124953, #125002, #125336, #125815, #125906, #128053, #130877, and #132041.
- Codex hard gate inspected directly at `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those ranges are unrelated CLI/completion plumbing.
- Testbox/CI: N/A for this executor repair; neither was started.
