### PR TITLE
test(plugins): align artifact fixtures with build policy

### DIFF
--- a/src/plugins/copy-bundled-plugin-metadata.test.ts
+++ b/src/plugins/copy-bundled-plugin-metadata.test.ts
@@ -401,6 +401,7 @@ describe("copyBundledPluginMetadata", () => {
       packageName: "@openclaw/acpx-plugin",
       packageOpenClaw: { extensions: ["./index.ts"] },
       env: excludeOptionalEnv,
+      seedStaleDist: true,
       expectedExists: false,
     },
     {
@@ -409,42 +410,35 @@ describe("copyBundledPluginMetadata", () => {
       packageName: "@openclaw/whatsapp",
       packageOpenClaw: {
         extensions: ["./index.ts"],
+        build: { bundledDist: false },
         install: { npmSpec: "@openclaw/whatsapp" },
       },
       env: {},
+      seedStaleDist: false,
       expectedExists: false,
     },
-  ] as const)("$name", ({ pluginId, packageName, packageOpenClaw, env, expectedExists }) => {
-    const repoRoot = makeRepoRoot(`openclaw-bundled-plugin-${pluginId}-`);
-    createPlugin(repoRoot, {
-      id: pluginId,
-      packageName,
-      packageOpenClaw,
-    });
+  ] as const)(
+    "$name",
+    ({ pluginId, packageName, packageOpenClaw, env, seedStaleDist, expectedExists }) => {
+      const repoRoot = makeRepoRoot(`openclaw-bundled-plugin-${pluginId}-`);
+      createPlugin(repoRoot, {
+        id: pluginId,
+        packageName,
+        packageOpenClaw,
+      });
+      if (seedStaleDist) {
+        const staleDistDir = path.join(repoRoot, "dist", "extensions", pluginId);
+        fs.mkdirSync(staleDistDir, { recursive: true });
+        fs.writeFileSync(path.join(staleDistDir, "index.js"), "export default {};\n", "utf8");
+      }
 
-    copyBundledPluginMetadataWithEnv({ repoRoot, env });
+      copyBundledPluginMetadataWithEnv({ repoRoot, env });
 
-    expect(fs.existsSync(path.join(repoRoot, "dist", "extensions", pluginId))).toBe(expectedExists);
-  });
-
-  it("removes build-excluded bundled plugin metadata", () => {
-    const repoRoot = makeRepoRoot("openclaw-bundled-plugin-excluded-meta-");
-    createPlugin(repoRoot, {
-      id: "whatsapp",
-      packageName: "@openclaw/whatsapp",
-      packageOpenClaw: {
-        extensions: ["./index.ts"],
-        setupEntry: "./setup-entry.ts",
-      },
-    });
-    const staleDistDir = path.join(repoRoot, "dist", "extensions", "whatsapp");
-    fs.mkdirSync(staleDistDir, { recursive: true });
-    fs.writeFileSync(path.join(staleDistDir, "index.js"), "export default {}\n", "utf8");
-
-    copyBundledPluginMetadata({ repoRoot });
-
-    expect(fs.existsSync(staleDistDir)).toBe(false);
-  });
+      expect(fs.existsSync(path.join(repoRoot, "dist", "extensions", pluginId))).toBe(
+        expectedExists,
+      );
+    },
+  );
 
   it("preserves isolated source-checkout output for an external plugin", () => {
     const repoRoot = makeRepoRoot("openclaw-external-plugin-local-dist-meta-");

--- a/src/plugins/public-surface-loader.test.ts
+++ b/src/plugins/public-surface-loader.test.ts
@@ -236,11 +236,9 @@ describe("bundled plugin public surface loader", () => {
       `
         import assert from "node:assert/strict";
         import fs from "node:fs";
-        import { createRequire } from "node:module";
         import { loadBundledPluginPublicArtifactModuleSync, loadPluginPublicArtifactModuleSync } from ${moduleUrl("src/plugins/public-surface-loader.ts")};
         import { loadFacadeModuleAtLocationSync } from ${moduleUrl("src/plugin-sdk/facade-loader.ts")};
         import { clearPluginMetadataLifecycleCaches } from ${moduleUrl("src/plugins/plugin-metadata-lifecycle.ts")};
-        assert.equal(typeof createRequire(import.meta.url).extensions[".ts"], "function");
         const load = () => loadBundledPluginPublicArtifactModuleSync({ dirName: "demo", artifactBasename: "secret-contract-api.js" });
         const first = load();
         assert.equal(first.marker, "original");


### PR DESCRIPTION
## Summary

- align bundled-plugin metadata fixtures with the current externalization policy
- retain stale-output cleanup coverage in the canonical table-driven case
- remove a `require.extensions` implementation assertion while preserving loader behavior coverage

## Root cause

Full Release Validation for exact main SHA `1fa579a1c2d5f0edb01b84edaa2974136b745b9e` exposed three stale test assertions:

- the WhatsApp fixture did not model its manifest-owned `build.bundledDist: false` exclusion
- a standalone metadata test contradicted the intentional preservation of external local dist output
- the public-surface loader test asserted a `require.extensions[".ts"]` hook that is intentionally absent under the current `tsx/esm` preload

Production behavior was correct. This patch updates tests at their owning boundaries without changing runtime code.

## Test audit

- the retained metadata cases protect observable artifact inclusion/removal behavior
- the removed standalone case duplicated the table-driven owner boundary with contradictory fixture policy
- the loader subprocess still proves import-only dependency loading, cache identity, lifecycle invalidation, and shared CJS identity
- no test-only production seam is added

Production LOC: `0`

Test LOC: `+23/-31`

## Validation

- `OPENCLAW_VITEST_MAX_WORKERS=1 npx --yes node@24.19.0 --import ./scripts/tsx.mjs scripts/run-vitest.mjs test/scripts/bundled-plugin-build-entries.test.ts src/plugins/copy-bundled-plugin-metadata.test.ts src/plugins/public-surface-loader.test.ts src/plugins/plugin-module-loader-cache.test.ts` (`92` passed)
- `pnpm check:changed -- src/plugins/copy-bundled-plugin-metadata.test.ts src/plugins/public-surface-loader.test.ts`
  - all changed-file gates passed
  - sparse-worktree type graph skip documented
  - deadcode export scan rerun after expanding tracked `ui/config`: all three Knip scans passed with zero entries
- `git diff --check`
- autoreview: `scoped-clean`

## Failure evidence

- Full Release Validation: https://github.com/openclaw/openclaw/actions/runs/33568086210
- exact-SHA normal CI: https://github.com/openclaw/openclaw/actions/runs/33568123157
- plugin prerelease: https://github.com/openclaw/openclaw/actions/runs/33568124010
