### PR TITLE
test(browser): consolidate proxy file rejection coverage

### DIFF
--- a/extensions/browser/src/browser/proxy-files.test.ts
+++ b/extensions/browser/src/browser/proxy-files.test.ts
@@ -1,8 +1,8 @@
 // Browser tests cover proxy files plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createTempHomeEnv, type TempHomeEnv } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createTempHomeEnv, type TempHomeEnv } from "../../test-support.js";
 import { BROWSER_PROXY_MAX_FILE_BYTES } from "../browser-proxy-envelope.js";
 import { persistBrowserProxyResultFiles } from "./proxy-files.js";
 
@@ -135,25 +135,6 @@ describe("persistBrowserProxyResultFiles", () => {
     ).rejects.toHaveProperty("code", "ENOENT");
   });
 
-  it("rejects malformed base64 before persisting files", async () => {
-    const error = await persistBrowserProxyResultFiles({ path: "/tmp/malformed.bin" }, [
-      {
-        path: "/tmp/malformed.bin",
-        base64: "aGVsbG8$",
-        mimeType: "application/octet-stream",
-      },
-    ]).then(
-      () => null,
-      (err: unknown) => err,
-    );
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toBe("browser proxy file contains malformed base64 data");
-
-    await expect(
-      fs.stat(path.join(tempHome.home, ".openclaw", "media", "browser")),
-    ).rejects.toHaveProperty("code", "ENOENT");
-  });
-
   it.each([
     { name: "invalid alphabet", base64: "aGVsbG8$" },
     { name: "invalid padding", base64: "aGVsbG8===" },
@@ -161,15 +142,21 @@ describe("persistBrowserProxyResultFiles", () => {
     { name: "impossible unpadded length", base64: "S" },
     { name: "whitespace without encoded data", base64: " \n\t" },
   ])("rejects $name before creating the media directory", async ({ base64 }) => {
-    await expect(
-      persistBrowserProxyResultFiles({ path: "/tmp/malformed-browser-download.bin" }, [
+    const error = await persistBrowserProxyResultFiles(
+      { path: "/tmp/malformed-browser-download.bin" },
+      [
         {
           path: "/tmp/malformed-browser-download.bin",
           base64,
           mimeType: "application/octet-stream",
         },
-      ]),
-    ).rejects.toThrow("browser proxy file contains malformed base64 data");
+      ],
+    ).then(
+      () => undefined,
+      (cause: unknown) => cause,
+    );
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toHaveProperty("message", "browser proxy file contains malformed base64 data");
 
     await expect(
       fs.stat(path.join(tempHome.home, ".openclaw", "media", "browser")),

--- a/extensions/browser/test-support.ts
+++ b/extensions/browser/test-support.ts
@@ -7,6 +7,5 @@ export {
   type CliRuntimeCapture,
 } from "openclaw/plugin-sdk/test-fixtures";
 export { createTempHomeEnv, useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
-export type { TempHomeEnv } from "openclaw/plugin-sdk/test-env";
 export { isLiveTestEnabled } from "openclaw/plugin-sdk/test-live";
 export type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";


### PR DESCRIPTION
The browser proxy suite checked the same invalid-base64 input twice and loaded unrelated browser test-support exports to obtain its temporary-home helper. Keep the existing five-row malformed-input table, assert the actual Error and exact message for every row, and import the same helper directly from the repo-local test-env subpath. Remove the now-unused TempHomeEnv type re-export from browser test support.

The invalid-alphabet row absorbs the duplicate case. Existing no-directory-on-rejection, size bounds, base64 forms, path substitutions and real filesystem persistence assertions remain. Production delta is zero; tests/support +11/-25. The remaining createTempHomeEnv re-export still serves a separate browser E2E consumer.

Validation: 19 baseline cases and all 18 retained cases pass; the candidate ran with shuffle seed 1889. Test identities differ only by the absorbed duplicate. The first static gate exposed the unused type re-export, which is removed in the final change. The expanded checks passed both plugin type graphs, five doctor-contract cases, all three dead-export scans, and the remaining repository guards. Final lint passed after renaming a shadowed callback parameter. Independent Codex review and manual owner/fixture/Vite import review pass. No wall-time ratio is claimed from cold import runs.
