### PR TITLE
refactor(state): share schema version guard

### DIFF
--- a/src/agents/harness/native-hook-relay-client-store.ts
+++ b/src/agents/harness/native-hook-relay-client-store.ts
@@ -1,19 +1,12 @@
 import path from "node:path";
-import type { DatabaseSync } from "node:sqlite";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
-import {
-  createNewerSqliteSchemaVersionError,
-  readSqliteUserVersion,
-} from "../../infra/sqlite-user-version.js";
-import {
-  OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
-  OPENCLAW_STATE_SCHEMA_VERSION,
-} from "../../state/openclaw-state-db-contract.js";
+import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "../../state/openclaw-state-db-contract.js";
+import { assertSupportedStateSchemaVersion } from "../../state/openclaw-state-db-schema-version.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import {
@@ -22,18 +15,6 @@ import {
 } from "./native-hook-relay-bridge-record.js";
 
 type NativeHookRelayBridgeDatabase = Pick<OpenClawStateKyselyDatabase, "native_hook_relay_bridges">;
-
-function assertSupportedSchemaVersion(db: DatabaseSync, pathname: string): void {
-  const userVersion = readSqliteUserVersion(db);
-  if (userVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
-    throw createNewerSqliteSchemaVersionError(
-      "OpenClaw state database",
-      pathname,
-      userVersion,
-      OPENCLAW_STATE_SCHEMA_VERSION,
-    );
-  }
-}
 
 /** Read one native relay locator without loading the shared-state writer lifecycle. */
 export function readNativeHookRelayClientBridgeRecord(params: {
@@ -44,7 +25,7 @@ export function readNativeHookRelayClientBridgeRecord(params: {
   const db = openNodeSqliteDatabase(pathname, { readOnly: true });
   try {
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
-    assertSupportedSchemaVersion(db, pathname);
+    assertSupportedStateSchemaVersion(db, pathname);
     const query = getNodeSqliteKysely<NativeHookRelayBridgeDatabase>(db)
       .selectFrom("native_hook_relay_bridges")
       .selectAll()

--- a/src/cli/native-hook-relay-cli.import-boundary.test.ts
+++ b/src/cli/native-hook-relay-cli.import-boundary.test.ts
@@ -35,6 +35,7 @@ describe("native hook relay CLI import boundary", () => {
       "src/agents/harness/native-hook-relay-bridge-record.ts",
       "src/agents/harness/native-hook-relay-constants.ts",
       "src/agents/harness/native-hook-relay-response-codec.ts",
+      "src/state/openclaw-state-db-schema-version.ts",
     ]
       .map(readSource)
       .join("\n");
@@ -46,6 +47,7 @@ describe("native hook relay CLI import boundary", () => {
       "native-hook-relay-state.js",
       "native-hook-relay-store.js",
       "openclaw-state-db.js",
+      "openclaw-state-db-maintenance.js",
       "gateway/call.js",
     ]) {
       expect(clientGraph).not.toContain(forbiddenImport);

--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -10,10 +10,8 @@ import { isSqliteCorruptionError } from "../infra/sqlite-transaction.js";
 import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
 import { readOpenClawDatabaseQuarantine } from "./openclaw-quarantine-store.js";
 import type { OpenClawStateDatabase } from "./openclaw-state-db-contract.js";
-import {
-  assertSupportedSchemaVersion,
-  createOpenClawDatabaseVerificationError,
-} from "./openclaw-state-db-maintenance.js";
+import { createOpenClawDatabaseVerificationError } from "./openclaw-state-db-maintenance.js";
+import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 
 const cachedDatabases = new Map<string, OpenClawStateDatabase>();
 const cachedDataVersionStatements = new WeakMap<
@@ -155,7 +153,7 @@ function getOpenClawStateDatabaseRuntimeFailure(pathname: string): Error | undef
     }
     // data_version is the cheap external-commit trigger. Re-read user_version
     // only when another connection changed the file.
-    assertSupportedSchemaVersion(cached.db, resolvedPath);
+    assertSupportedStateSchemaVersion(cached.db, resolvedPath);
     cachedDataVersions.set(cached.db, dataVersion);
     return undefined;
   } catch (error) {

--- a/src/state/openclaw-state-db-fast-path.ts
+++ b/src/state/openclaw-state-db-fast-path.ts
@@ -10,11 +10,9 @@ import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import { hasLegacyCronRunLogs } from "../infra/state-migrations.cron-run-logs.js";
 import { VERSION } from "../version.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
-import {
-  assertOpenClawStateDatabaseForMaintenance,
-  assertSupportedSchemaVersion,
-} from "./openclaw-state-db-maintenance.js";
+import { assertOpenClawStateDatabaseForMaintenance } from "./openclaw-state-db-maintenance.js";
 import { assertCanonicalStateSchemaShape } from "./openclaw-state-db-schema-repair.js";
+import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 import {
   getOpenClawStateRuntimeSchema,
   isOpenClawStateStartupRepairableSchemaIssue,
@@ -35,7 +33,7 @@ export function isOpenClawStateSchemaFastPathEligible(
   pathname: string,
 ): boolean {
   return runSqliteDeferredTransactionSync(database, () => {
-    assertSupportedSchemaVersion(database, pathname);
+    assertSupportedStateSchemaVersion(database, pathname);
     if (readSqliteUserVersion(database) !== OPENCLAW_STATE_SCHEMA_VERSION) {
       return false;
     }

--- a/src/state/openclaw-state-db-maintenance.ts
+++ b/src/state/openclaw-state-db-maintenance.ts
@@ -5,10 +5,7 @@ import {
   assertSqliteSchemaTablesPresent,
   type SqliteTableContractReader,
 } from "../infra/sqlite-schema-contract.js";
-import {
-  createNewerSqliteSchemaVersionError,
-  readSqliteUserVersion,
-} from "../infra/sqlite-user-version.js";
+import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import {
   OPENCLAW_DATABASE_SCHEMA_DOCS_URL,
   LAZY_ADDITIVE_STATE_TABLES,
@@ -16,6 +13,7 @@ import {
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db-contract.js";
 import { tableExists, tableHasColumn } from "./openclaw-state-db-schema-helpers.js";
+import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 import { OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY } from "./openclaw-state-schema-compatibility.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
@@ -76,18 +74,6 @@ export function createOpenClawDatabaseVerificationError(
   return error;
 }
 
-export function assertSupportedSchemaVersion(db: DatabaseSync, pathname: string): void {
-  const userVersion = readSqliteUserVersion(db);
-  if (userVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
-    throw createNewerSqliteSchemaVersionError(
-      "OpenClaw state database",
-      pathname,
-      userVersion,
-      OPENCLAW_STATE_SCHEMA_VERSION,
-    );
-  }
-}
-
 /** Require canonical shared-state ownership without requiring the latest schema. */
 export function assertOpenClawStateDatabaseOwner(
   database: DatabaseSync,
@@ -115,15 +101,7 @@ export function assertOpenClawStateDatabaseForMaintenance(
   options: { pathname: string },
   readTable?: SqliteTableContractReader,
 ): void {
-  const userVersion = readSqliteUserVersion(database);
-  if (userVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
-    throw createNewerSqliteSchemaVersionError(
-      "OpenClaw state database",
-      options.pathname,
-      userVersion,
-      OPENCLAW_STATE_SCHEMA_VERSION,
-    );
-  }
+  const userVersion = assertSupportedStateSchemaVersion(database, options.pathname);
   if (userVersion !== OPENCLAW_STATE_SCHEMA_VERSION) {
     throw new Error(
       `OpenClaw state database ${options.pathname} uses schema version ${userVersion}; run openclaw doctor --fix before compacting it.`,

--- a/src/state/openclaw-state-db-open.ts
+++ b/src/state/openclaw-state-db-open.ts
@@ -21,8 +21,8 @@ import {
   OPENCLAW_STATE_SCHEMA_VERSION,
   type OpenClawStateDatabase,
 } from "./openclaw-state-db-contract.js";
-import { assertSupportedSchemaVersion } from "./openclaw-state-db-maintenance.js";
 import { ensureOpenClawStatePermissions } from "./openclaw-state-db-permissions.js";
+import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 
 const stateDbLog = createSubsystemLogger("state/db");
 
@@ -69,7 +69,7 @@ export function openUnpublishedStateDatabase(params: {
     () => {
       let maintenance: SqliteWalMaintenance | undefined;
       try {
-        assertSupportedSchemaVersion(db, params.pathname);
+        assertSupportedStateSchemaVersion(db, params.pathname);
         assertStateDatabaseIntegrityBeforeMutation(db, params.pathname);
         configureSqlitePreSchemaPragmas(db, { busyTimeoutMs });
         maintenance = configureSqliteConnectionPragmas(db, {

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -7,16 +7,12 @@ import {
   prepareSqliteReadOnlyLocationSync,
   prepareSqliteReadOnlyLocationSyncInProcess,
 } from "../infra/sqlite-readonly-location.js";
-import {
-  createNewerSqliteSchemaVersionError,
-  readSqliteUserVersion,
-} from "../infra/sqlite-user-version.js";
 import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
 import {
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
-  OPENCLAW_STATE_SCHEMA_VERSION,
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db-contract.js";
+import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
 type OpenClawStateReadOnlyDatabase = {
@@ -42,18 +38,6 @@ function existingPathOrUndefined(pathname: string): string | undefined {
   }
 }
 
-function assertSupportedSchemaVersion(db: DatabaseSync, pathname: string): void {
-  const userVersion = readSqliteUserVersion(db);
-  if (userVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
-    throw createNewerSqliteSchemaVersionError(
-      "OpenClaw state database",
-      pathname,
-      userVersion,
-      OPENCLAW_STATE_SCHEMA_VERSION,
-    );
-  }
-}
-
 function withOpenClawStateDatabaseReadOnlyIfOpen<T>(
   operation: (database: OpenClawStateReadOnlyDatabase) => T,
   options: OpenClawStateDatabaseOptions,
@@ -70,7 +54,7 @@ function withOpenClawStateDatabaseReadOnlyIfOpen<T>(
     // is checked on the next physical open so hot reads do not poll metadata.
     // A newer build can migrate this file while the handle stays open, so the
     // forward-compatibility gate still runs before any reused read.
-    assertSupportedSchemaVersion(opened.db, pathname);
+    assertSupportedStateSchemaVersion(opened.db, pathname);
     return { reused: true, value: operation(opened) };
   } catch (error) {
     openClawStateDatabaseCache.evictOpenClawStateDatabaseAfterCorruption(opened, error);
@@ -92,7 +76,7 @@ function withFreshOpenClawStateDatabaseReadOnly<T>(
   const db = openNodeSqliteDatabase(location, { readOnly: true });
   try {
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
-    assertSupportedSchemaVersion(db, pathname);
+    assertSupportedStateSchemaVersion(db, pathname);
     return operation({ db, path: pathname });
   } finally {
     clearNodeSqliteKyselyCacheForDatabase(db);

--- a/src/state/openclaw-state-db-schema-version.ts
+++ b/src/state/openclaw-state-db-schema-version.ts
@@ -1,0 +1,19 @@
+import type { DatabaseSync } from "node:sqlite";
+import {
+  createNewerSqliteSchemaVersionError,
+  readSqliteUserVersion,
+} from "../infra/sqlite-user-version.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
+
+export function assertSupportedStateSchemaVersion(db: DatabaseSync, pathname: string): number {
+  const userVersion = readSqliteUserVersion(db);
+  if (userVersion > OPENCLAW_STATE_SCHEMA_VERSION) {
+    throw createNewerSqliteSchemaVersionError(
+      "OpenClaw state database",
+      pathname,
+      userVersion,
+      OPENCLAW_STATE_SCHEMA_VERSION,
+    );
+  }
+  return userVersion;
+}

--- a/src/state/openclaw-state-db-startup-checkpoint.ts
+++ b/src/state/openclaw-state-db-startup-checkpoint.ts
@@ -9,13 +9,11 @@ import {
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db-contract.js";
-import {
-  assertSupportedSchemaVersion,
-  resolveDatabasePath,
-} from "./openclaw-state-db-maintenance.js";
+import { resolveDatabasePath } from "./openclaw-state-db-maintenance.js";
 import { ensureOpenClawStatePermissions } from "./openclaw-state-db-permissions.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
 import { ensureColumn } from "./openclaw-state-db-schema-helpers.js";
+import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 import {
   assertOpenClawStateWriteAllowed,
   runWithOpenClawStateWriteAccess,
@@ -81,7 +79,7 @@ function ensureStartupMigrationCheckpointSchema(
     db,
     () => {
       assertOpenClawStateWriteAllowed({ database: db, databasePath: pathname, env });
-      assertSupportedSchemaVersion(db, pathname);
+      assertSupportedStateSchemaVersion(db, pathname);
       db.exec(`
         CREATE TABLE IF NOT EXISTS schema_meta (
           meta_key TEXT NOT NULL PRIMARY KEY,

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -61,7 +61,6 @@ import {
 } from "./openclaw-state-db-fast-path.js";
 import {
   assertOpenClawStateDatabaseForMaintenance,
-  assertSupportedSchemaVersion,
   markCurrentStateSchemaVersion,
   migrateConversationBindingTargets,
   migrateCronCreatorNamespaces,
@@ -88,6 +87,7 @@ import {
 } from "./openclaw-state-db-schema-repair.js";
 import { migrateSingletonStateFoldInV12 } from "./openclaw-state-db-schema-v12-foldin.js";
 import { migrateJsonCanonicalWideRowsV13 } from "./openclaw-state-db-schema-v13-widerow.js";
+import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 import * as sessionWatchMigration from "./openclaw-state-db-session-watch-migration.js";
 import {
   initializeNativeOpenClawStateConnection,
@@ -160,7 +160,7 @@ function repairStateSchema(
   let ownershipRefused = false;
   try {
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
-    assertSupportedSchemaVersion(db, pathname);
+    assertSupportedStateSchemaVersion(db, pathname);
     db.exec("PRAGMA foreign_keys = OFF;");
     const changes = runSqliteImmediateTransactionSync(
       db,
@@ -324,7 +324,7 @@ function needsOpenClawStateDatabaseSchemaRepair(pathname: string): boolean {
   let database: DatabaseSync | undefined;
   try {
     database = openNodeSqliteDatabase(pathname, { readOnly: true });
-    assertSupportedSchemaVersion(database, pathname);
+    assertSupportedStateSchemaVersion(database, pathname);
     const needsRepair =
       readSqliteUserVersion(database) !== OPENCLAW_STATE_SCHEMA_VERSION ||
       detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(database, pathname).length > 0;
@@ -390,7 +390,7 @@ function ensureSchema(
         () => {
           // Recheck ownership after BEGIN IMMEDIATE to exclude a concurrent external claim.
           assertOpenClawStateWriteAllowed({ database: db, databasePath: pathname, env });
-          assertSupportedSchemaVersion(db, pathname);
+          assertSupportedStateSchemaVersion(db, pathname);
           // Native bootstrap admission is advisory until this transaction owns the
           // write. Never migrate state initialized or occupied by a concurrent owner.
           if (initializeNativeOnly && !isUninitializedNativeStartupDatabase(db)) {
@@ -528,7 +528,7 @@ export async function openExistingOpenClawStateDatabaseReadOnly(
   }
   try {
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
-    assertSupportedSchemaVersion(db, pathname);
+    assertSupportedStateSchemaVersion(db, pathname);
     assertSqliteIntegrity(db, pathname);
     if (readSqliteUserVersion(db) === OPENCLAW_STATE_SCHEMA_VERSION) {
       assertOpenClawStateDatabaseForMaintenance(db, { pathname });


### PR DESCRIPTION
## What Problem This Solves

The state database's newer-schema refusal was duplicated across several open paths. That duplication could drift, and the native hook relay's cold import graph must not pull in writable maintenance lifecycle code.

## Why This Change Was Made

This adds one dependency-light internal schema-version guard and routes the 12 reviewed call sites through it. The helper reads `user_version` once, preserves the exact fail-closed error contract, and returns the value so the maintenance composite keeps its single PRAGMA read.

Three duplicate definitions and the maintenance inline repeat are removed. Intentional later version rereads are unchanged. There are no schema, migration, version, SQL, config, docs, barrel, SDK, or public API changes, and this is not a material store change.

## User Impact

No user-visible behavior changes. A state database created by newer OpenClaw code still fails closed with the existing error, while the native hook relay cold graph remains isolated from state database maintenance.

## Evidence

- Exact reviewed surface: 10 files, 12 production calls, one guard definition.
- Call distribution: state DB 4, readonly 2, maintenance 1, and one each in open, cache, fast path, startup checkpoint, and relay storage.
- LOC: production `+44/-88` (net `-44`); test `+2/-0`.
- Real SQLite differential fixtures at `user_version` 0, 14, 15, and 16 matched before/after acceptance, return value, error constructor/name/message/cause, and one `PRAGMA user_version` read. Database bytes, size, mtime, and sidecar state were unchanged; only the allowed stack helper name could differ.
- Focused state runtime-fence, read-only, preflight, maintenance, startup-checkpoint, relay, CLI, and import-boundary suites: 384 passed, 1 existing skip.
- Passed under Node 24.19: `pnpm lint:kysely`, `pnpm tsgo`, `pnpm check:test-types`, `pnpm build`, native state schema-version guard v15, `pnpm check:import-cycles`, `pnpm check:madge-import-cycles`, changed-file formatting/lint/guard lanes, and `git diff --check`.
- The sparse checkout initially omitted tracked inputs for test types and the native schema guard. Only the reported paths were added; the failed and downstream lanes then passed without installing or changing dependencies.
- Test-audit: the existing cold-graph test now reads the new leaf and independently forbids importing `openclaw-state-db-maintenance.js`, the credible regression introduced by this extraction.
- Replayed with `-S` from reviewed parent `5ecfe38102ce72e723b743b0f2b2a2ef45d479d5`; signed head `434c776a7391d32e4e7cfbd20de04ad8a8ed89cf` has the source's exact ten blobs, aggregate patch ID `ccee5d6d9bc5ae6609c4e09c78c573f2bd601cfc`, and all ten reviewed per-file patch IDs.
- Final live guard used main `111ffb9e51aa16d2d1fdcb38515fdad3c58222a9`: the reviewed parent remained an ancestor and the ten changed files plus `src/infra/sqlite-user-version.ts` and `src/state/openclaw-state-db-contract.ts` were unchanged.
- Rechecked direct overlap heads unchanged, open, and unmerged: #119585 `633ab2bcf2e7b3bf147a338d40e60ccb9d79b061`, #120987 `49d7080af9b319c6b61d4e5d24e8f89bd2c4214f`, #131582 `89b177a4aa82b43ff595753a7cefd3a85787ea12`, #135542 `fd8d64ce6ec7684a023e7fdb5239ea2143858ac0`, and #135372 `ab017334a47a5ebd15b95be55b4a7c81aa94464a`.
- Codex hard gate inspected directly at `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those CLI/completion and prompt-normalization paths are unrelated to this state database refactor.
- No CI, Testbox, prepare, merge, Crabbox, or live run was started. This is behavior-neutral internal code motion with no schema or operator-visible change; the real-SQLite differential and focused suites exercise the contract.
