### PR TITLE
refactor(skills): reuse full catalog rendering

### DIFF
--- a/src/skills/loading/skill-prompt-limits.ts
+++ b/src/skills/loading/skill-prompt-limits.ts
@@ -41,7 +41,7 @@ function buildRenderedSkillsPrompt(params: {
   includeLimitNote?: boolean;
 }): string {
   // resolveCodeModeSkills in src/agents/code-mode-skills.ts parses this exact format; update both together.
-  // The production-renderer parity test in src/agents/code-mode.test.ts enforces this coupling.
+  // The production-renderer parity test in src/agents/code-mode.skills.test.ts enforces this coupling.
   const truncated = params.skills.length < params.total;
   const limitNote =
     params.includeLimitNote === false
@@ -109,8 +109,6 @@ export function prepareSkillsForPrompt(params: SkillsPromptParams): {
     return undefined;
   };
 
-  const fitsFull = (skills: Skill[], includeLimitNote = true): boolean =>
-    renderWithinLimit(skills, { kind: "full" }, includeLimitNote) !== undefined;
   const fitsCompact = (
     skills: Skill[],
     descriptionMaxChars: number,
@@ -119,9 +117,10 @@ export function prepareSkillsForPrompt(params: SkillsPromptParams): {
     renderWithinLimit(skills, { kind: "compact", descriptionMaxChars }, includeLimitNote) !==
     undefined;
 
-  if (fitsFull(skillsForPrompt)) {
+  const fullPrompt = renderWithinLimit(skillsForPrompt, { kind: "full" });
+  if (fullPrompt !== undefined) {
     return {
-      prompt: renderWithinLimit(skillsForPrompt, { kind: "full" }) ?? "",
+      prompt: fullPrompt,
       skills: skillsForPrompt,
     };
   }


### PR DESCRIPTION
## What Problem This Solves

Building a skills catalog that already fits its prompt budget renders the same full catalog twice. This adds avoidable work to workspace snapshots, embedded sessions and the public Plugin SDK formatter.

## Why This Change Was Made

Keep the string returned by the shared budget owner instead of discarding it as a boolean and rendering again. The explicit `undefined` check preserves valid empty strings. Ordering, visibility, character/count limits, remote-note removal, compact fallback and selected skill resources remain unchanged. The obsolete `fitsFull` wrapper is removed, and the nearby parity-test reference is corrected.

Production LOC: +4/−5, net −1. Tests: unchanged. No cache, dependency, configuration, persistence, protocol or SDK contract is added.

## User Impact

The actual public SDK formatter took about 15 µs instead of 26 µs for the measured 24-skill fixture with 20 visible entries. This is a narrow formatter improvement, not a claim that every snapshot, Gateway startup or provider turn is faster.

## Evidence

The fixed before/candidate/candidate/before experiment retained all 768 complete returns: 48 first calls, 192 warmups and 528 measured calls across 12 predeclared workloads. Results from both run orders:

| Complete operation | Forward, before → candidate | Reverse, before → candidate |
| --- | --- | --- |
| Public SDK formatter | 26.000 → 14.791 µs (−43.11%) | 26.334 → 15.042 µs (−42.88%) |
| 24-skill snapshot | 273.250 → 262.333 µs (−4.00%) | 311.416 → 260.333 µs (−16.40%) |
| 8-skill snapshot | 141.541 → 137.625 µs (−2.77%) | 143.833 → 164.250 µs (+14.19%) |

**The original numerical gate failed.** It required both ordinary snapshot sizes to improve at least 3% in both orders. This PR is an explicit engineering acceptance of the narrower SDK gain and simple deletion; the failed gate is not relabelled or retuned. H11 was originally a control. All 11 forward and 8 of 11 reverse candidate formatter samples beat every corresponding baseline sample. Both formatter first calls improved, but snapshot first calls include +35.55%/+7.60% for 24 skills. Compact truncation has smaller consistent regressions (+0.64%/+2.35%). All six adverse median comparisons and seven adverse first comparisons are retained; their cause is not assumed to be noise.

Correctness proof pairs 28 complete native cases per variant, covering full/compact/truncated/empty catalogs, budgets, remote notes, hidden skills, Code Mode parsing, session snapshot reuse and actual materialized resource bytes/cleanup. Both variants pass the same 69 existing tests in six whole suites through four native configurations. An independent agent decoded every proof and timing return, checked exact fixture/input equality, recomputed every vector and gate, and audited canonical test reports and cleanup receipts. Measured source is `759e127`; the integrated source is byte-identical to the measured candidate. A separate full source review and managed Codex review found no actionable defects in their stated scopes.

`pnpm check:changed` passed. The committed `c1af603` sourcePerformance build passed in 29 seconds, and exact-head CI passed. A fresh isolated Gateway completed four real OpenAI turns (READY, arithmetic, recall and web), one complete 384-byte synthetic skill read, and two successful web fetches using both extraction modes. All seven provider requests returned HTTP 200. The persisted 641-character catalog, input-derived prompt reports, complete transcript and actual tool results agree. An independent audit verified the complete evidence, unchanged distribution and physical process/port/credential cleanup. Full web outputs and both native CPU profiles are retained privately. This establishes compatibility and changed-path reachability, not paired latency or memory improvement. Startup diagnostics reported CPU degradation, and the cached health response retained its pre-turn session count; fresh status and closed SQLite independently establish the completed session. No provider request-body capture or remote-channel proof is claimed.

Named follow-up: existing `docs/tools/skills.md` compact-catalog prose mentions a version field that the current formatter omits. This PR leaves that independent documentation discrepancy unchanged. Related bounded-catalog owner: #125346.
