### PR TITLE
refactor(logging): share diagnostic filename timestamp

### DIFF
--- a/src/logging/diagnostic-stability-bundle.ts
+++ b/src/logging/diagnostic-stability-bundle.ts
@@ -18,6 +18,7 @@ import {
   type DiagnosticStabilitySnapshot,
 } from "./diagnostic-stability.js";
 import { redactSensitiveText } from "./redact.js";
+import { formatDiagnosticFilenameTimestamp } from "./timestamps.js";
 
 export const DIAGNOSTIC_STABILITY_BUNDLE_VERSION = 1;
 const DEFAULT_DIAGNOSTIC_STABILITY_BUNDLE_LIMIT = MAX_DIAGNOSTIC_STABILITY_LIMIT;
@@ -155,10 +156,6 @@ function normalizeReason(reason: string): string {
   return SAFE_REASON_CODE.test(reason) ? reason : "unknown";
 }
 
-function formatBundleTimestamp(now: Date): string {
-  return now.toISOString().replace(/[:.]/g, "-");
-}
-
 function readErrorCode(error: unknown): string | undefined {
   if (!error || typeof error !== "object" || !("code" in error)) {
     return undefined;
@@ -225,7 +222,7 @@ function resolveDiagnosticStabilityBundleDir(
 function buildBundlePath(dir: string, now: Date, reason: string): string {
   return path.join(
     dir,
-    `${BUNDLE_PREFIX}${formatBundleTimestamp(now)}-${process.pid}-${normalizeReason(reason)}${BUNDLE_SUFFIX}`,
+    `${BUNDLE_PREFIX}${formatDiagnosticFilenameTimestamp(now)}-${process.pid}-${normalizeReason(reason)}${BUNDLE_SUFFIX}`,
   );
 }
 

--- a/src/logging/diagnostic-support-export.ts
+++ b/src/logging/diagnostic-support-export.ts
@@ -38,6 +38,7 @@ import {
   type SupportRedactionContext,
 } from "./diagnostic-support-redaction.js";
 import { readConfiguredLogTail, type LogTailPayload } from "./log-tail.js";
+import { formatDiagnosticFilenameTimestamp } from "./timestamps.js";
 
 const DIAGNOSTIC_SUPPORT_EXPORT_VERSION = 1;
 
@@ -182,10 +183,6 @@ type CollectedSupportSnapshot = {
   summary: SupportSnapshotStatus;
   file?: DiagnosticSupportExportFile;
 };
-
-function formatExportTimestamp(now: Date): string {
-  return now.toISOString().replace(/[:.]/g, "-");
-}
 
 function normalizePositiveInteger(value: unknown, fallback: number): number {
   const parsed = typeof value === "number" ? value : Number(value);
@@ -636,7 +633,7 @@ function defaultOutputPath(options: { now: Date; stateDir: string }): string {
     options.stateDir,
     "logs",
     "support",
-    `${SUPPORT_EXPORT_PREFIX}${formatExportTimestamp(options.now)}-${process.pid}${SUPPORT_EXPORT_SUFFIX}`,
+    `${SUPPORT_EXPORT_PREFIX}${formatDiagnosticFilenameTimestamp(options.now)}-${process.pid}${SUPPORT_EXPORT_SUFFIX}`,
   );
 }
 
@@ -659,7 +656,7 @@ function resolveOutputPath(options: {
     if (fs.statSync(resolved).isDirectory()) {
       return path.join(
         resolved,
-        `${SUPPORT_EXPORT_PREFIX}${formatExportTimestamp(options.now)}-${process.pid}${SUPPORT_EXPORT_SUFFIX}`,
+        `${SUPPORT_EXPORT_PREFIX}${formatDiagnosticFilenameTimestamp(options.now)}-${process.pid}${SUPPORT_EXPORT_SUFFIX}`,
       );
     }
   } catch {

--- a/src/logging/timestamps.test.ts
+++ b/src/logging/timestamps.test.ts
@@ -1,6 +1,14 @@
 // Timestamp tests cover timestamp formatting and timezone fallback behavior.
 import { describe, expect, it } from "vitest";
-import { formatTimestamp } from "./timestamps.js";
+import { formatDiagnosticFilenameTimestamp, formatTimestamp } from "./timestamps.js";
+
+describe("formatDiagnosticFilenameTimestamp", () => {
+  it("formats an ISO timestamp for filenames", () => {
+    expect(formatDiagnosticFilenameTimestamp(new Date("2024-01-15T14:30:45.123Z"))).toBe(
+      "2024-01-15T14-30-45-123Z",
+    );
+  });
+});
 
 describe("formatTimestamp", () => {
   const testDate = new Date("2024-01-15T14:30:45.123Z");

--- a/src/logging/timestamps.ts
+++ b/src/logging/timestamps.ts
@@ -1,4 +1,4 @@
-// Timestamp helpers validate time zones and format log timestamps.
+// Timestamp helpers validate time zones and format log and diagnostic timestamps.
 const validTimeZoneCache = new Map<string, boolean>();
 const timestampFormatterCache = new Map<string, Intl.DateTimeFormat>();
 let hostTimeZone: string | undefined;
@@ -35,6 +35,10 @@ function resolveEffectiveTimeZone(timeZone?: string): string {
 
 function formatOffset(offsetRaw: string): string {
   return offsetRaw === "GMT" ? "+00:00" : offsetRaw.slice(3);
+}
+
+export function formatDiagnosticFilenameTimestamp(date: Date): string {
+  return date.toISOString().replace(/[:.]/g, "-");
 }
 
 function getTimestampParts(date: Date, timeZone?: string) {


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested duplication cleanup: the two core diagnostic file writers independently implemented the same filename-safe ISO timestamp conversion. Keeping those byte semantics duplicated made it easier for stability bundles and support exports to drift.

## Why This Change Was Made

`src/logging/timestamps.ts` now owns the internal `formatDiagnosticFilenameTimestamp(date)` contract. The stability bundle and support export writers use that canonical helper, and their local `formatBundleTimestamp` and `formatExportTimestamp` copies are removed.

The helper remains core-internal. Plugin copies stay local; no package or Plugin SDK seam was added. `timestampMsToIsoFileStamp` remains separate because it preserves different separator and invalid-input behavior.

## User Impact

No user-visible behavior changes. Diagnostic stability bundles and support export ZIPs keep the exact same filenames while the shared byte contract has one core owner.

## Evidence

- Frozen source identity: signed head `328b0400e0e3497a5f44e398c274337a87067d91`, parent `9eb32506fbe46fd91d49b9f34af5dadc9d6004b3`, tree `006ab111d6ec9e2547f932994b42a0ff182ba348`, patch ID `1cf7e2c8835cf04d7741fc332dddf085843d165b`.
- Surface: exactly four files. Production `+10/-12` (net `-2`); tests `+9/-1` (net `+8`).
- Focused tests: 31/31 passed across `src/logging/timestamps.test.ts`, `src/logging/diagnostic-stability-bundle.test.ts`, and `src/logging/diagnostic-support-export.test.ts`.
- Differential proof: 500,024 comparisons over 250,012 deterministic dates, including Date limits and epoch zero, produced zero mismatches. Invalid dates preserved native `RangeError`; receiver binding and property-access order were identical.
- Real filesystem proof: default and directory support-export paths retained exact UTC/millisecond/PID filenames; stability retention remained bounded; same-millisecond writes retained overwrite behavior; invalid dates failed before creating a new file.
- Repository gates: `pnpm check:changed` passed for `core, coreTests`, including full core production/test type shards, format, lint, dead exports, import cycles, boundaries, database/storage guards, and related ratchets. Direct `oxfmt`, `oxlint`, `git diff --check`, import-cycle, and dead-export checks also passed.
- Full build compiled plugin assets, packages, and unified output, then stopped in an unrelated Discord declaration build with TS2883 in `extensions/discord/src/send.emojis-stickers.ts`. Exact-head CI must supply the global build proof.
- Test audit: the exact-byte assertion protects the observable filename contract without adding a test-only seam or duplicative coverage.
- Deslop: no behavior-neutral cleanup remained; no code was changed during execution.
- Autoreview: exact commit-mode `gpt-5.6-sol` with high reasoning returned scoped-clean, no findings, correctness `0.99`.
- Current main `32bb94ee8467b615fd6a67c5d16da09a4c138744` merges cleanly. Its only relevant protected-file drift removes the unrelated `resetDiagnosticStabilityBundleForTest` helper after owned fatal-hook cleanup; neither path constructor nor timestamp owner changed.
- Overlap pins remain unchanged: https://github.com/openclaw/openclaw/pull/84836 at `00058145c8f73592390abb844e8cc7bf982df1b0` touches later stability event handling; https://github.com/openclaw/openclaw/pull/133910 at `b962a6fbdfbab09729d785a0e8847d25cc099f23` has no exact-file overlap. The open-PR exact-file scan found no additional overlap.
- Dedicated live/Testbox behavior proof is not applicable because this is byte-identical internal code movement with real filesystem proof and no environment-sensitive behavior. Native prepare remains required before landing.
- Codex hard gate checked directly at `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`; those CLI declaration and prompt-normalization paths are unrelated.
