### PR TITLE
fix(release): generate stable appcasts with macOS Bash

### DIFF
--- a/scripts/make_appcast.sh
+++ b/scripts/make_appcast.sh
@@ -61,15 +61,16 @@ if [[ -z "$VERSION" ]]; then
   fi
 fi
 
-CHANNEL_ARGS=()
+# Bash 3.2 treats an empty array as unset under nounset, so keep a required option.
+APPCAST_ARGS=(--embed-release-notes)
 if [[ "$VERSION" == *-alpha.* || "$VERSION" == *.alpha.* ]]; then
   echo "Alpha releases do not ship via Sparkle: $VERSION" >&2
   exit 1
 fi
 if [[ "$VERSION" == *-beta.* || "$VERSION" == *.beta.* ]]; then
-  CHANNEL_ARGS=(--channel beta)
+  APPCAST_ARGS+=(--channel beta)
 elif [[ "$VERSION" =~ ^[0-9]{4}\.[1-9][0-9]*\.([0-9]+)$ && "${BASH_REMATCH[1]}" -ge 33 ]]; then
-  CHANNEL_ARGS=(--channel extended-stable)
+  APPCAST_ARGS+=(--channel extended-stable)
 fi
 
 TMP_DIR="$(mktemp -d)"
@@ -106,9 +107,8 @@ fi
 "$GENERATE_APPCAST" \
   --ed-key-file "$PRIVATE_KEY_FILE" \
   --download-url-prefix "$DOWNLOAD_URL_PREFIX" \
-  --embed-release-notes \
   --link "$FEED_URL" \
-  "${CHANNEL_ARGS[@]}" \
+  "${APPCAST_ARGS[@]}" \
   "$TMP_DIR"
 
 APPCAST_PATH="$TMP_DIR/appcast.xml" APPCAST_VERSION="$VERSION" node <<'NODE'

--- a/test/scripts/make-appcast.test.ts
+++ b/test/scripts/make-appcast.test.ts
@@ -1,5 +1,16 @@
 // Make Appcast tests cover release appcast script behavior.
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const scriptPath = "scripts/make_appcast.sh";
@@ -22,15 +33,75 @@ describe("make_appcast cleanup", () => {
     expect(setupBlock).toContain('rm -f "$NOTES_HTML"');
   });
 
-  it("adds release-train channels and refuses alpha releases", () => {
-    const script = readFileSync(scriptPath, "utf8");
-
-    expect(script).toContain('if [[ "$VERSION" == *-beta.* || "$VERSION" == *.beta.* ]]; then');
-    expect(script).toContain("CHANNEL_ARGS=(--channel beta)");
-    expect(script).toContain("CHANNEL_ARGS=(--channel extended-stable)");
-    expect(script).toContain('"${BASH_REMATCH[1]}" -ge 33');
-    expect(script).toContain('if [[ "$VERSION" == *-alpha.* || "$VERSION" == *.alpha.* ]]; then');
-    expect(script).toContain('"${CHANNEL_ARGS[@]}"');
+  it.skipIf(process.platform === "win32").each([
+    ["2026.8.2", undefined],
+    ["2026.8.2-beta.1", "beta"],
+    ["2026.8.2.beta.1", "beta"],
+    ["2026.8.33", "extended-stable"],
+    ["2026.8.2-alpha.1", "refused"],
+  ])("generates the correct Sparkle channel for %s with system Bash", (version, channel) => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-appcast-"));
+    try {
+      const scripts = path.join(root, "scripts");
+      mkdirSync(scripts);
+      copyFileSync(scriptPath, path.join(scripts, "make_appcast.sh"));
+      writeFileSync(
+        path.join(scripts, "changelog-to-html.sh"),
+        "#!/bin/sh\necho '<p>Release notes</p>'\n",
+        { mode: 0o755 },
+      );
+      const zip = path.join(root, `OpenClaw-${version}.zip`);
+      writeFileSync(zip, "fixture archive");
+      writeFileSync(path.join(root, "appcast.xml"), "previous feed");
+      const generator = path.join(root, "generate-appcast");
+      writeFileSync(
+        generator,
+        `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+fs.writeFileSync(path.join(__dirname, "arguments.json"), JSON.stringify(args));
+fs.writeFileSync(path.join(args.at(-1), "appcast.xml"), '<rss><channel><item><sparkle:shortVersionString>${version}</sparkle:shortVersionString><enclosure sparkle:edSignature="fixture-signature" /></item></channel></rss>');
+`,
+        { mode: 0o755 },
+      );
+      const result = spawnSync("/bin/bash", [path.join(scripts, "make_appcast.sh"), zip], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          SPARKLE_PRIVATE_KEY_FILE: path.join(root, "unused-fixture-key"),
+          SPARKLE_GENERATE_APPCAST: generator,
+          SPARKLE_RELEASE_VERSION: version,
+          KEEP_SPARKLE_NOTES: "0",
+        },
+      });
+      const argsFile = path.join(root, "arguments.json");
+      if (channel === "refused") {
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain("Alpha releases do not ship via Sparkle");
+        expect(existsSync(argsFile)).toBe(false);
+        expect(readFileSync(path.join(root, "appcast.xml"), "utf8")).toBe("previous feed");
+        return;
+      }
+      expect(result.status, result.stderr).toBe(0);
+      const args = JSON.parse(readFileSync(argsFile, "utf8")) as string[];
+      expect(args).toContain("--embed-release-notes");
+      if (channel) {
+        expect(args.slice(args.indexOf("--channel"), args.indexOf("--channel") + 2)).toEqual([
+          "--channel",
+          channel,
+        ]);
+      } else {
+        expect(args).not.toContain("--channel");
+      }
+      expect(args).not.toContain("");
+      expect(readFileSync(path.join(root, "appcast.xml"), "utf8")).toContain(
+        `<sparkle:shortVersionString>${version}</sparkle:shortVersionString>`,
+      );
+      expect(existsSync(path.join(root, `OpenClaw-${version}.html`))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("prefers the host-architecture Sparkle tool and requires a signed entry", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where generating a stable macOS appcast with the system Bash 3.2 could report an unbound array, exit successfully, and leave the previous feed untouched. This surfaced during 2026.8.2 publication.

## Why This Change Was Made

The generator arguments now always contain the existing required release-notes option, with channel arguments appended for beta and extended-stable releases. This removes the empty-array expansion that Bash 3.2 treats as unset under `nounset`, without changing channel selection or signed-entry validation. Production LOC is unchanged.

## User Impact

Release maintainers can generate stable Sparkle feeds with macOS's system shell. Beta and extended-stable channel behavior remains covered, and alpha publication remains refused.

## Evidence

Reproduced the original failure with `/bin/bash` 3.2.57: exit status 0, `CHANNEL_ARGS[@]: unbound variable`, generator never called, previous feed unchanged. The executable regression failed before the repair and passed afterward. All seven focused `test/scripts/make-appcast.test.ts` tests pass, including stable, both beta spellings, extended-stable, alpha refusal, feed replacement, and temporary release-note cleanup. Bounded P0 autoreview found no actionable findings. Formatter and diff checks pass.

This prepares the script repair while release artifacts upload. Merge is held until publication completes. No app rebuild or signed artifact changes are included.
