### PR TITLE
refactor(worker): share command success check

### DIFF
--- a/src/gateway/worker-environments/bootstrap.ts
+++ b/src/gateway/worker-environments/bootstrap.ts
@@ -30,6 +30,7 @@ import {
   workerSshOptions,
   workerSshRemoteCommand,
 } from "./ssh.js";
+import { workerCommandSucceeded } from "./worker-command-result.js";
 
 const BOOTSTRAP_ROOT = ".openclaw-worker";
 const BOOTSTRAP_RECEIPT = "bootstrap-receipt.json";
@@ -574,10 +575,6 @@ function commandFailure(phase: string, result: SpawnResult): Error {
   return new Error(`Worker bootstrap ${phase} failed (${status})${output ? `: ${output}` : ""}`);
 }
 
-function isSuccess(result: SpawnResult): boolean {
-  return result.termination === "exit" && result.code === 0;
-}
-
 async function runSshScript(params: {
   prepared: PreparedWorkerSsh;
   runCommand: WorkerBootstrapCommandRunner;
@@ -697,7 +694,7 @@ function parsePreflight(
       "Worker bootstrap requires Node 22.22.3+, 24.15.0+, or 25.9.0+ with WAL-reset-safe SQLite on the leased host; install a supported Node runtime in the provider setup phase and retry",
     );
   }
-  if (!isSuccess(result)) {
+  if (!workerCommandSucceeded(result)) {
     throw commandFailure("preflight", result);
   }
   const output = parseTaggedOutput(result.stdout);
@@ -784,7 +781,7 @@ export async function bootstrapWorker(
             workerSshCommandOptions({ timeoutMs: remainingTimeoutMs, signal: dependencies.signal }),
           ),
       );
-      if (!isSuccess(transfer)) {
+      if (!workerCommandSucceeded(transfer)) {
         throw commandFailure("bundle transfer", transfer);
       }
     }
@@ -817,7 +814,7 @@ export async function bootstrapWorker(
         "Worker npm bootstrap requires npm on the leased host; use bundle install or provide npm in the provider setup phase",
       );
     }
-    if (!isSuccess(install)) {
+    if (!workerCommandSucceeded(install)) {
       throw commandFailure("install", install);
     }
     const output = parseTaggedOutput(install.stdout);

--- a/src/gateway/worker-environments/desktop-tunnel.ts
+++ b/src/gateway/worker-environments/desktop-tunnel.ts
@@ -27,6 +27,7 @@ import {
   workerSshProcessError,
   WORKER_TUNNEL_READY_MARKER,
 } from "./tunnel-ssh-runner.js";
+import { workerCommandSucceeded } from "./worker-command-result.js";
 
 const PASSWORD_READ_TIMEOUT_MS = 20_000;
 const APP_LAUNCH_TIMEOUT_MS = 30_000;
@@ -62,10 +63,6 @@ class WorkerDesktopUnsupportedError extends Error {
     super(`${operation} is not supported on Windows gateway hosts`);
     this.name = "WorkerDesktopUnsupportedError";
   }
-}
-
-function successful(result: Awaited<ReturnType<WorkerSshRunner["run"]>>): boolean {
-  return result.termination === "exit" && result.code === 0;
 }
 
 /** Owns worker-specific desktop SSH acquisition and app launch processes. */
@@ -191,7 +188,7 @@ export function createWorkerDesktopTunnels(deps: {
             ],
             workerSshCommandOptions({ timeoutMs: PASSWORD_READ_TIMEOUT_MS }),
           );
-          if (!successful(result)) {
+          if (!workerCommandSucceeded(result)) {
             throw workerSshProcessError(result.stderr || result.stdout);
           }
           vncPassword = result.stdout.replace(/(?:\r?\n)+$/u, "");
@@ -331,7 +328,7 @@ export function createWorkerDesktopTunnels(deps: {
             signal: abortController.signal,
           }),
         );
-        if (!successful(result)) {
+        if (!workerCommandSucceeded(result)) {
           throw workerSshProcessError(result.stderr || result.stdout);
         }
       } finally {

--- a/src/gateway/worker-environments/node-worker-workspace-fallback.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-fallback.ts
@@ -9,6 +9,7 @@ import type {
   WorkerWorkspaceSyncRequest,
   WorkerWorkspaceSyncResult,
 } from "./tunnel-contract.js";
+import { workerCommandSucceeded } from "./worker-command-result.js";
 import { boundedWorkerError } from "./worker-error.js";
 import {
   resolveWorkerWorkspaceGitAuthor,
@@ -174,10 +175,6 @@ async function inspectEligibleOrigin(localPath: string): Promise<OriginInspectio
   }
 }
 
-function succeeded(result: SpawnResult): boolean {
-  return result.termination === "exit" && result.code === 0;
-}
-
 /** Optional published-origin fast path; HTTPS transfer remains the canonical fallback. */
 export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
   let supportsSeeds = true;
@@ -206,12 +203,12 @@ export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
       timeoutMs: GIT_TIMEOUT_MS,
       transportRetry: "never",
     });
-    if (!succeeded(checkedOut) || checkedOut.workspaceDir !== workspaceDir) {
+    if (!workerCommandSucceeded(checkedOut) || checkedOut.workspaceDir !== workspaceDir) {
       return { kind: "fallback", reason: "checkout-failed" };
     }
     const captured = await capture(checkedOut.workspaceDir, identity.commit);
     const manifestRef = captured.stdout.trim();
-    if (!succeeded(captured) || !MANIFEST_REF_PATTERN.test(manifestRef)) {
+    if (!workerCommandSucceeded(captured) || !MANIFEST_REF_PATTERN.test(manifestRef)) {
       return { kind: "fallback", reason: "manifest-capture-failed" };
     }
     if (manifestRef !== expectedManifestRef) {
@@ -227,10 +224,10 @@ export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
     async captureManifest(dir: string, base: string | null, reference: string) {
       const captured = await capture(dir, base, reference);
       const manifestRef = captured.stdout.trim();
-      if (!succeeded(captured) || !MANIFEST_REF_PATTERN.test(manifestRef)) {
+      if (!workerCommandSucceeded(captured) || !MANIFEST_REF_PATTERN.test(manifestRef)) {
         const detail = boundedWorkerError(
           captured.stderr.trim() ||
-            (!succeeded(captured)
+            (!workerCommandSucceeded(captured)
               ? `${captured.termination} (exit code ${captured.code}, signal ${captured.signal})`
               : "invalid manifest reference"),
         );
@@ -258,13 +255,13 @@ export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
             timeoutMs: GIT_TIMEOUT_MS,
             transportRetry: "never",
           });
-          if (succeeded(applied) && applied.stdout.trim() === "applied") {
+          if (workerCommandSucceeded(applied) && applied.stdout.trim() === "applied") {
             const remote = await exec({
               argv: ["git", ...GIT_NONINTERACTIVE_ARGS, "remote", "get-url", "origin"],
               timeoutMs: GIT_TIMEOUT_MS,
               transportRetry: "never",
             });
-            if (!succeeded(remote) || remote.stdout.trim() !== identity.origin) {
+            if (!workerCommandSucceeded(remote) || remote.stdout.trim() !== identity.origin) {
               throw new Error("Node workspace seed origin mismatch");
             }
             const fetched = await exec({
@@ -279,7 +276,7 @@ export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
               timeoutMs: GIT_TIMEOUT_MS,
               transportRetry: "never",
             });
-            if (!succeeded(fetched)) {
+            if (!workerCommandSucceeded(fetched)) {
               throw workspaceSyncError(fetched);
             }
             outcome = await checkoutAndCapture(
@@ -319,7 +316,7 @@ export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
           timeoutMs: GIT_TIMEOUT_MS,
           transportRetry: "never",
         });
-        if (!succeeded(cloned)) {
+        if (!workerCommandSucceeded(cloned)) {
           return { kind: "fallback", reason: "clone-failed" };
         }
         outcome = await checkoutAndCapture(
@@ -337,7 +334,7 @@ export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
             timeoutMs: 180_000,
             transportRetry: "never",
           });
-          if (!succeeded(stored)) {
+          if (!workerCommandSucceeded(stored)) {
             throw workspaceSyncError(stored);
           }
         } catch (error) {
@@ -373,7 +370,7 @@ export function createNodeWorkerWorkspaceFallback(exec: WorkspaceExec) {
           argv: [...git, `user.${key}`, value],
           transportRetry: "never",
         });
-        if (!succeeded(configured)) {
+        if (!workerCommandSucceeded(configured)) {
           throw workspaceSyncError(configured);
         }
       }

--- a/src/gateway/worker-environments/worker-command-result.ts
+++ b/src/gateway/worker-environments/worker-command-result.ts
@@ -1,0 +1,5 @@
+import type { SpawnResult } from "../../process/exec-result.js";
+
+export function workerCommandSucceeded(result: SpawnResult): boolean {
+  return result.termination === "exit" && result.code === 0;
+}

--- a/src/gateway/worker-environments/workspace-accepted-sync.ts
+++ b/src/gateway/worker-environments/workspace-accepted-sync.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import type { SpawnResult } from "../../process/exec.js";
 import type { WorkerWorkspaceCommand } from "./tunnel-contract.js";
+import { workerCommandSucceeded } from "./worker-command-result.js";
 import {
   AcceptedWorkspacePublicationIndeterminateError,
   isAcceptedWorkspacePublicationIndeterminateError,
@@ -20,7 +21,6 @@ import {
   captureRemoteWorkspaceManifest,
   WORKER_WORKSPACE_RSYNC_DESTINATION,
   workerAcceptedWorkspaceRsyncReceiverPath,
-  workerWorkspaceCommandSucceeded,
   workspaceSyncError,
 } from "./workspace-sync-helpers.js";
 import {
@@ -55,7 +55,7 @@ export async function recoverAcceptedWorkspacePublication(params: {
       randomBytes(16).toString("hex"),
     ],
   });
-  if (!workerWorkspaceCommandSucceeded(recovered)) {
+  if (!workerCommandSucceeded(recovered)) {
     throw workspaceSyncError(recovered);
   }
 }
@@ -94,7 +94,7 @@ function createAcceptedWorkspacePublisher(params: {
       ],
       input: acceptedRaw,
     });
-    if (!workerWorkspaceCommandSucceeded(published)) {
+    if (!workerCommandSucceeded(published)) {
       throw workspaceSyncError(published);
     }
 
@@ -150,7 +150,7 @@ function createAcceptedWorkspacePublisher(params: {
           observationFailure,
         );
       }
-      if (!workerWorkspaceCommandSucceeded(settled)) {
+      if (!workerCommandSucceeded(settled)) {
         throw new AcceptedWorkspacePublicationIndeterminateError(
           operation,
           publicationFailure,
@@ -185,7 +185,7 @@ function createAcceptedWorkspacePublisher(params: {
           observationFailure,
         );
       }
-      if (!workerWorkspaceCommandSucceeded(retried)) {
+      if (!workerCommandSucceeded(retried)) {
         const retryFailure = workspaceSyncError(retried);
         if (!isIndeterminateWorkspaceCommandResult(retried)) {
           throw retryFailure;
@@ -211,7 +211,7 @@ function createAcceptedWorkspacePublisher(params: {
         ],
         input: JSON.stringify([...changed]),
       });
-      if (!workerWorkspaceCommandSucceeded(begun)) {
+      if (!workerCommandSucceeded(begun)) {
         throw workspaceSyncError(begun);
       }
       transactionBegun = true;
@@ -254,7 +254,7 @@ function createAcceptedWorkspacePublisher(params: {
             localSource,
             `${params.scpTarget}:${WORKER_WORKSPACE_RSYNC_DESTINATION}`,
           ]);
-          if (!workerWorkspaceCommandSucceeded(transferred)) {
+          if (!workerCommandSucceeded(transferred)) {
             throw workspaceSyncError(transferred);
           }
         } finally {
@@ -271,7 +271,7 @@ function createAcceptedWorkspacePublisher(params: {
           throw applyFailure;
         }
       }
-      if (applied && !workerWorkspaceCommandSucceeded(applied)) {
+      if (applied && !workerCommandSucceeded(applied)) {
         const applyFailure = workspaceSyncError(applied);
         if (!isIndeterminateWorkspaceCommandResult(applied)) {
           throw applyFailure;
@@ -289,7 +289,7 @@ function createAcceptedWorkspacePublisher(params: {
         await finishIndeterminateCommit(commitFailure);
         return;
       }
-      if (!workerWorkspaceCommandSucceeded(committed)) {
+      if (!workerCommandSucceeded(committed)) {
         const commitFailure = workspaceSyncError(committed);
         if (isIndeterminateWorkspaceCommandResult(committed)) {
           await finishIndeterminateCommit(commitFailure);
@@ -306,7 +306,7 @@ function createAcceptedWorkspacePublisher(params: {
       if (transactionBegun) {
         try {
           const rolledBack = await transactionCommand("rollback");
-          if (!workerWorkspaceCommandSucceeded(rolledBack)) {
+          if (!workerCommandSucceeded(rolledBack)) {
             throw workspaceSyncError(rolledBack);
           }
         } catch (rollbackFailure) {

--- a/src/gateway/worker-environments/workspace-quiescence.ts
+++ b/src/gateway/worker-environments/workspace-quiescence.ts
@@ -1,16 +1,13 @@
 import path from "node:path";
 import type { SpawnResult } from "../../process/exec.js";
 import type { WorkerWorkspaceCommand, WorkerWorkspaceQuiescence } from "./tunnel-contract.js";
+import { workerCommandSucceeded } from "./worker-command-result.js";
 import {
   REMOTE_WORKSPACE_QUIESCE_JS,
   REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS,
   REMOTE_WORKSPACE_RESUME_JS,
 } from "./workspace-quiescence-scripts.js";
-import {
-  waitForQuiescenceRenewal,
-  workerWorkspaceCommandSucceeded,
-  workspaceSyncError,
-} from "./workspace-sync-helpers.js";
+import { waitForQuiescenceRenewal, workspaceSyncError } from "./workspace-sync-helpers.js";
 
 const WORKSPACE_QUIESCENCE_TIMEOUT_MS = 12 * 60_000;
 const WORKSPACE_QUIESCENCE_RENEW_INTERVAL_MS = 4 * 60_000;
@@ -32,7 +29,7 @@ export function createWorkerWorkspaceQuiescence(params: {
     const hostMode = params.sharedHost ? "shared-host" : "dedicated";
     const run = async (argv: string[]) => {
       const result = await params.runWorkspaceCommand({ transportRetry: "never", argv });
-      if (!workerWorkspaceCommandSucceeded(result)) {
+      if (!workerCommandSucceeded(result)) {
         throw workspaceSyncError(result);
       }
       return result;

--- a/src/gateway/worker-environments/workspace-sync-helpers.ts
+++ b/src/gateway/worker-environments/workspace-sync-helpers.ts
@@ -13,6 +13,7 @@ import {
   workerSshRemoteCommand,
 } from "./ssh.js";
 import type { WorkerWorkspaceCommand, WorkerWorkspaceSyncRequest } from "./tunnel-contract.js";
+import { workerCommandSucceeded } from "./worker-command-result.js";
 import {
   parseRemoteWorkspaceManifestEnvelope,
   recordRemoteWorkspaceHashMetrics,
@@ -58,10 +59,6 @@ export function waitForQuiescenceRenewal(
     }, intervalMs);
     signal.addEventListener("abort", onAbort, { once: true });
   });
-}
-
-export function workerWorkspaceCommandSucceeded(result: SpawnResult): boolean {
-  return result.termination === "exit" && result.code === 0;
 }
 
 export function workspaceSyncError(result: SpawnResult): Error {
@@ -193,7 +190,7 @@ async function resolveRemoteWorkspaceBaseManifest(
       baseDigest,
     ],
   });
-  if (!workerWorkspaceCommandSucceeded(resolved)) {
+  if (!workerCommandSucceeded(resolved)) {
     throw workspaceSyncError(resolved);
   }
   if (parseManifestRef(resolved.stdout.trim()) !== expectedRef) {
@@ -242,7 +239,7 @@ export async function captureRemoteWorkspaceManifest(params: {
     .finally(() => {
       params.metrics.remoteManifestWallDurationMs += performance.now() - startedAt;
     });
-  if (!workerWorkspaceCommandSucceeded(captured)) {
+  if (!workerCommandSucceeded(captured)) {
     throw workspaceSyncError(captured);
   }
   let response;
@@ -282,10 +279,10 @@ export async function probeWorkspaceGitMode(params: {
       params.commandOptions,
     ),
   ]);
-  if (!workerWorkspaceCommandSucceeded(gitRootResult)) {
+  if (!workerCommandSucceeded(gitRootResult)) {
     throw workspaceSyncError(gitRootResult);
   }
-  if (workerWorkspaceCommandSucceeded(gitBaseResult)) {
+  if (workerCommandSucceeded(gitBaseResult)) {
     return {
       mode: "git",
       gitRoot: gitRootResult.stdout.trim(),
@@ -305,7 +302,7 @@ export async function resolveWorkerWorkspaceGitAuthor(
   const git = ["git", "-C", request.localPath, "config", "--get"];
   const read = async (key: "name" | "email") => {
     const result = await runTask([...git, `user.${key}`]);
-    return workerWorkspaceCommandSucceeded(result) ? result.stdout.trim() : "";
+    return workerCommandSucceeded(result) ? result.stdout.trim() : "";
   };
   const [name, email] = await Promise.all([read("name"), read("email")]);
   return {

--- a/src/gateway/worker-environments/workspace-sync.ts
+++ b/src/gateway/worker-environments/workspace-sync.ts
@@ -13,6 +13,7 @@ import type {
   WorkerWorkspaceSyncRequest,
   WorkerWorkspaceSyncResult,
 } from "./tunnel-contract.js";
+import { workerCommandSucceeded as success } from "./worker-command-result.js";
 import {
   createAcceptedWorkspacePublisherFactory,
   recoverAcceptedWorkspacePublication,
@@ -57,7 +58,6 @@ import {
   stableWorkerPathComponent,
   validateWorkspaceSyncRequest,
   WORKER_WORKSPACE_RSYNC_DESTINATION,
-  workerWorkspaceCommandSucceeded as success,
   workerWorkspaceRsyncRemoteCommand,
   workerWorkspaceRsyncReceiverEntryPath,
   workerWorkspaceSshArgv,


### PR DESCRIPTION
## What Problem This Solves

Worker environment command results used four duplicated success predicates across related Gateway flows. Keeping the same policy in several places made future drift possible.

## Why This Change Was Made

Adds one dependency-free `workerCommandSucceeded` helper at the worker-environment owner boundary. It preserves the exact existing rule: success requires `termination === "exit"` and `code === 0`.

The migration covers exactly 39 call sites across eight production files. Four local predicates were removed. Special handling for exit code `1`, SSH exit `255`, retries, lifecycle fencing, authority checks, and cleanup remains separate and unchanged.

No barrel, SDK, runtime export, protocol, configuration, persistence, test, documentation, dependency, or changelog surface changed.

## User Impact

No user-visible behavior changes. Normal exit with code zero remains successful; nonzero exits, signals, timeouts, SSH 255 handling, retries, and existing error paths remain unchanged.

## Evidence

- Replayed onto current `main` parent `73a73e5ffca7e0d80c77f4d85229f3dc75c0d243`.
- Signed head: `60fe0af28d02ac907b53bc7c5b33ed2d2ac9ed6a`.
- Tree: `55d3c69cc1a36efc649ff307e6a8784b715eec1a`.
- Stable patch ID: `e61c4a443a6e1c79dc657ebb8e68443a6e30bba6`, identical to the original PR patch.
- Production diff: `+43/-53`, net `-10`; tests: `0`.
- Exact scope: seven modified production files plus new `worker-command-result.ts`.
- Differential matrix: 20 termination/code combinations, zero differences.
- Focused Gateway proof: 125 tests passed; two Windows-only tests skipped on macOS. `provider-bootstrap.test.ts` could not collect because the shared dependency install is missing `mdast-util-from-markdown`.
- Formatting and `git diff --check`: passed.
- `check:import-cycles`: zero runtime value cycles.
- `check:madge-import-cycles`: zero cycles.
- `check:changed`: every guard before core typecheck passed; core typecheck stopped on missing shared markdown and phone dependencies.
- `pnpm build`: stopped during bundled plugin assets because the shared install is missing `@pierre/diffs` and Shiki language packages.
- Test audit: no tests changed; existing worker owner and sibling suites cover the observable policy, so no helper-only implementation test was added.
- Fresh autoreview: scoped clean, no actionable P0-P2 findings, correctness 0.99.
- Overlap recheck: #136961 at `08850bb2687d0099e9a3616c9ac98e2e3b84ece2`, #135838 at `afa4ea62b50d2f0e46998451e20fc9b0502d9339`, #134931 at `0628c2d2a338a921dc352712ce12033312ec9fb3`, and #132180 at `3d2801dd9fc5aeeeed249c86dba7d1742191545d`; all remain open and do not redefine the zero-exit success policy.
- Required sibling Codex inspection covered `codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those CLI surfaces are unrelated.

No CI, ClawSweeper, Testbox, prepare, or merge action has been run for this refreshed head. The PR remains draft pending independent frozen review.
