### PR TITLE
test(bedrock): consolidate missing-credential selection coverage

### DIFF
--- a/extensions/amazon-bedrock/memory-embedding-adapter.test.ts
+++ b/extensions/amazon-bedrock/memory-embedding-adapter.test.ts
@@ -1,4 +1,3 @@
-// Amazon Bedrock tests cover memory embedding adapter plugin behavior.
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const hasAwsCredentialsMock = vi.hoisted(() => vi.fn());
@@ -64,17 +63,25 @@ describe("bedrockMemoryEmbeddingProviderAdapter", () => {
     expect(bedrockMemoryEmbeddingProviderAdapter.allowExplicitWhenConfiguredAuto).toBe(true);
   });
 
-  it("throws a missing-api-key sentinel error when AWS credentials are unavailable", async () => {
+  it("reports missing credentials to automatic provider selection", async () => {
     hasAwsCredentialsMock.mockResolvedValue(false);
 
-    await expect(
-      bedrockMemoryEmbeddingProviderAdapter.create(defaultCreateOptions()),
-    ).rejects.toThrow(/No API key found for provider "bedrock"/);
-    await expect(
-      bedrockMemoryEmbeddingProviderAdapter.create(defaultCreateOptions()),
-    ).rejects.toThrow(/AWS credentials are not available/);
+    const error = await bedrockMemoryEmbeddingProviderAdapter.create(defaultCreateOptions()).then(
+      () => undefined,
+      (cause: unknown) => cause,
+    );
 
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toHaveProperty(
+      "message",
+      expect.stringContaining('No API key found for provider "bedrock"'),
+    );
+    expect(error).toHaveProperty(
+      "message",
+      expect.stringContaining("AWS credentials are not available"),
+    );
     expect(createBedrockEmbeddingProviderMock).not.toHaveBeenCalled();
+    expect(bedrockMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection?.(error)).toBe(true);
   });
 
   it("creates the provider when AWS credentials are available", async () => {
@@ -152,19 +159,5 @@ describe("bedrockMemoryEmbeddingProviderAdapter", () => {
       model: "amazon.titan-embed-text-v2:0",
       dimensions: 1024,
     });
-  });
-
-  it("lets the auto-select loop skip bedrock when credentials are unavailable", async () => {
-    hasAwsCredentialsMock.mockResolvedValue(false);
-
-    let thrown: unknown;
-    try {
-      await bedrockMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
-    } catch (err) {
-      thrown = err;
-    }
-
-    expect(thrown).toBeInstanceOf(Error);
-    expect(bedrockMemoryEmbeddingProviderAdapter.shouldContinueAutoSelection?.(thrown)).toBe(true);
   });
 });


### PR DESCRIPTION
The Bedrock embedding adapter suite invoked the same missing-credentials failure three times across two cases. Capture one actual rejection and use it to verify both diagnostic fragments, the Error type, that provider creation never starts, and that automatic provider selection recognizes the same error. Remove the duplicate case and its manual try/catch.

The successful provider construction, canonical regional cache identity, PrivateLink endpoint invalidation, metadata and credential-reset coverage remain. Six baseline cases become five with both missing-credential cases combined; production delta is zero and tests are +16/-23. No AWS request or live credential is needed, and no latency ratio is claimed.

Validation: the six-case baseline passed; all five retained cases passed through the canonical provider runner with shuffle seed 1997. Manual review covered the complete test and adapter, provider factory, automatic-selection classifier, registration owner and relevant history.

The full changed-file gate passed, including plugin test types, all three dead-export scans and lint. Independent Codex review and the manual owner-boundary review found no actionable issue.
