### PR TITLE
refactor(auth): reuse failure state reset

### DIFF
--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -34,6 +34,7 @@ import {
   isActiveUnusableWindow,
   isAuthCooldownBypassedForProvider,
   isModelScopedCooldownReason,
+  resetAuthProfileFailureState,
   resolveProfileUnusableUntil,
 } from "./usage-state.js";
 
@@ -841,29 +842,6 @@ export function resolveInlineProviderApiKeyUnusableUntil(
   return resolveProfileUnusableUntil(stats);
 }
 
-function resetUsageStats(
-  existing: ProfileUsageStats | undefined,
-  overrides?: Partial<ProfileUsageStats>,
-): ProfileUsageStats {
-  return {
-    ...existing,
-    errorCount: 0,
-    blockedUntil: undefined,
-    blockedReason: undefined,
-    blockedSource: undefined,
-    blockedModel: undefined,
-    blockedScope: undefined,
-    cooldownUntil: undefined,
-    cooldownReason: undefined,
-    cooldownClassification: undefined,
-    cooldownModel: undefined,
-    disabledUntil: undefined,
-    disabledReason: undefined,
-    failureCounts: undefined,
-    ...overrides,
-  };
-}
-
 function updateUsageStatsEntry(
   store: AuthProfileStore,
   profileId: string,
@@ -1305,7 +1283,9 @@ export async function clearAuthProfileCooldown(params: {
         return false;
       }
 
-      updateUsageStatsEntry(freshStore, profileId, (existing) => resetUsageStats(existing));
+      updateUsageStatsEntry(freshStore, profileId, (existing) =>
+        resetAuthProfileFailureState(existing ?? {}),
+      );
       return true;
     },
   });


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested duplication cleanup: manual auth-profile failure clearing carried a private copy of the canonical failure-state reset. Keeping both implementations made future reset-field changes vulnerable to drift.

## Why This Change Was Made

`src/agents/auth-profiles/usage-state.ts` remains the existing owner of reusable auth-profile failure-state normalization. The manual clear path now calls `resetAuthProfileFailureState(existing ?? {})`, and the duplicate `resetUsageStats` path is deleted.

The canonical helper was not widened or otherwise changed. Overrides, reset fields, preserved usage history, undefined-stat behavior, locking, owner persistence, profile replacement, successful-use reset, rotation, and provider bypass semantics remain unchanged. There are no configuration, schema, SDK, dependency, transaction, locking, persistence, or recovery changes.

## User Impact

No user-visible behavior changes. Auth-profile cooldown clearing continues to reset the same failure fields while preserving unrelated usage history.

## Evidence

- Diff: one production file, `+4/-24` (net `-20`); tests `+0/-0`.
- Patch ID: `5dcb228b7f9d40cdb38c4aaff1560fb735ca67ac`.
- Focused owner-boundary tests passed before and after the final refresh: 5 files, 187 tests.
  - `src/agents/auth-profiles/usage.test.ts`
  - `src/agents/auth-profiles/usage.inherited-owner.test.ts`
  - `src/agents/auth-profiles/upsert-with-lock.sqlite.test.ts`
  - `src/agents/auth-profiles/profiles.test.ts`
  - `src/agents/auth-profiles/order.test.ts`
- The five test blobs and their runner configuration are byte-identical to the reviewed parent. The earlier 186-test planning count was stale; the live suite consistently reports 187.
- A 100,000-case differential compared the removed implementation with the canonical helper across ordinary and malformed values, overrides, throwing proxies, property descriptors, getter/trap order, and fresh-input mutation checks: zero mismatches.
- `node scripts/check-changed.mjs --dry-run -- src/agents/auth-profiles/usage.ts` passed classification.
- `node scripts/check-changed.mjs -- src/agents/auth-profiles/usage.ts` passed conflict, ratchet, attribution, registry, wildcard export, duplicate coverage, dependency pin, formatting, plugin boundary, wrapper shadowing, package patch, and core graph-boundary checks. It then stopped in core typechecking because the linked shared install lacks `markdown-it-cjk-friendly`, `mdast-util-from-markdown`, `mdast-util-gfm-table`, `micromark-extension-gfm-table`, and `libphonenumber-js/min`.
- `pnpm check:test-types` reached the same missing-dependency blocker after the task-local sparse profile was expanded for its tracked UI config inputs.
- `pnpm check:import-cycles` passed with zero runtime value cycles.
- `pnpm check:madge-import-cycles` passed with zero cycles.
- `git diff --check` passed.
- `pnpm build` was not run against an incomplete dependency tree. Available idle ordinary checkouts had different lockfiles, so dependencies were not installed, reconciled, or borrowed in the worktree.
- No new test was added: existing owner-boundary tests already pin complete manual clearing, preserved history, missing-entry behavior, inherited-owner persistence, login replacement, successful-use reset, and profile ordering.
- No CI or Crabbox/Testbox run was dispatched in this executor phase.

Overlap heads were rechecked immediately before push and remained open and unchanged:

- #107671 `ece4917e7b8e5e15b0724757a1efd3d930ce12ef`
- #113183 `538f2ae85d3439091fba430c50fb20dabbd7a250`
- #125573 `5fe0eb140a7e63d8c9abe4cd4760dc13ea8433d5`
- #125906 `8637dad9e5282b188f6cfd666ae696431d73ee5c`

The acting executor directly inspected the required Codex source at `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`. Those sections cover unrelated CLI subcommand, prompt normalization, completion generation, and test-import behavior; this refactor does not affect Codex protocol or runtime contracts.
