### PR TITLE
fix(update): hand agent-launched updates to managed helper

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -320,8 +320,11 @@ LaunchAgent Gateway, the CLI hands the update to the same managed-service helper
 before stopping the Gateway. It prints the helper log path and follow-up commands
 for update status and Gateway health, then exits; this acknowledges the handoff,
 not a completed update. The helper owns stop, update, restart, and recovery outside
-the Gateway process tree. Plain terminal updates remain synchronous, and
-`--no-restart` does not authorize stopping the agent's Gateway.
+the Gateway process tree. Keep stdout connected to the agent: stopping the service
+can terminate the surrounding exec shell (SIGTERM or exit 143), including commands
+chained after the update. After a handoff result, use the printed follow-up commands
+for the final outcome. Plain terminal updates remain synchronous, and `--no-restart`
+does not authorize stopping the agent's Gateway.
 
 The Gateway core auto-updater requires a managed service restart path. It hands
 the CLI update to a detached helper before the Gateway exits. A foreground

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -315,6 +315,14 @@ aligned:
 
 ### Restart handoff
 
+When an agent runs `openclaw update` inside a systemd user service or macOS
+LaunchAgent Gateway, the CLI hands the update to the same managed-service helper
+before stopping the Gateway. It prints the helper log path and follow-up commands
+for update status and Gateway health, then exits; this acknowledges the handoff,
+not a completed update. The helper owns stop, update, restart, and recovery outside
+the Gateway process tree. Plain terminal updates remain synchronous, and
+`--no-restart` does not authorize stopping the agent's Gateway.
+
 The Gateway core auto-updater requires a managed service restart path. It hands
 the CLI update to a detached helper before the Gateway exits. A foreground
 Gateway keeps update hints but leaves installation and activation to the

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -5690,7 +5690,7 @@ describe("update-cli", () => {
 
       await withEnvAsync(env, () =>
         invokeUpdateCli({ yes: true, json: true, acceptCapabilities: true, ...options }),
-      ).catch((error) => {
+      ).catch((error: unknown) => {
         throw new Error(`${getErrorOutput()}\n${JSON.stringify(lastWriteJsonCall())}`, {
           cause: error,
         });

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -5619,45 +5619,60 @@ describe("update-cli", () => {
     expect(packageInstallCommandCall()).toBeUndefined();
   });
 
-  it.each(
-    (
-      [
-        { platform: "linux", env: { INVOCATION_ID: "gateway-invocation" }, supervisor: "systemd" },
-        { platform: "linux", env: { JOURNAL_STREAM: "8:123" }, supervisor: "systemd" },
-        {
-          platform: "linux",
-          env: { OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service" },
-          supervisor: "systemd",
-        },
-        { platform: "linux", env: {}, supervisor: "systemd", ancestor: true },
-        {
-          platform: "linux",
-          env: { INVOCATION_ID: "gateway-invocation" },
-          supervisor: "systemd",
-          options: { tag: "./candidate.tgz" },
-          tag: "./candidate.tgz",
-        },
-        {
-          platform: "linux",
-          env: { INVOCATION_ID: "gateway-invocation" },
-          supervisor: "systemd",
-          options: { channel: "extended-stable" },
-          tag: undefined,
-        },
-        {
-          platform: "darwin",
-          env: { OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway" },
-          supervisor: "launchd",
-        },
-      ] as const
-    ).map((testCase) => ({ options: {}, tag: "9999.0.0", ancestor: false, ...testCase })),
-  )(
-    "hands agent-initiated updates to $supervisor before stopping the gateway ($env)",
-    async ({ platform, env, supervisor, options, tag, ancestor }) => {
+  it.each<{
+    platform: "linux" | "darwin";
+    env: NodeJS.ProcessEnv;
+    supervisor: "systemd" | "launchd";
+    options?: Parameters<typeof updateCommand>[0];
+    ancestor?: boolean;
+    git?: boolean;
+  }>([
+    { platform: "linux", env: { INVOCATION_ID: "gateway-invocation" }, supervisor: "systemd" },
+    { platform: "linux", env: { JOURNAL_STREAM: "8:123" }, supervisor: "systemd" },
+    {
+      platform: "linux",
+      env: { OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service" },
+      supervisor: "systemd",
+    },
+    { platform: "linux", env: {}, supervisor: "systemd", ancestor: true },
+    {
+      platform: "linux",
+      env: { INVOCATION_ID: "gateway-invocation" },
+      supervisor: "systemd",
+      options: { tag: "./candidate.tgz" },
+    },
+    {
+      platform: "linux",
+      env: { INVOCATION_ID: "gateway-invocation" },
+      supervisor: "systemd",
+      options: { channel: "extended-stable" },
+    },
+    {
+      platform: "darwin",
+      env: { OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway" },
+      supervisor: "launchd",
+    },
+    { platform: "linux", env: {}, supervisor: "systemd", ancestor: true, git: true },
+  ])(
+    "hands agent-initiated updates to $supervisor before stopping the gateway ($env, git=$git)",
+    async ({ platform, env, supervisor, options = {}, ancestor = false, git = false }) => {
       vi.spyOn(process, "platform", "get").mockReturnValue(platform);
-      const { pkgRoot: root, entryPath } = await setupInstalledPackageRoot(
-        createCaseDir("openclaw-update-handoff"),
-      );
+      const caseDir = createCaseDir("openclaw-update-handoff");
+      const sha = "a".repeat(40);
+      const { pkgRoot: root, entryPath } = git
+        ? {
+            pkgRoot: caseDir,
+            entryPath: await writeOpenClawPackageFixture(caseDir, "1.0.0", {
+              git: true,
+              builtSha: sha,
+              entrySource: "export {};\n",
+            }),
+          }
+        : await setupInstalledPackageRoot(caseDir);
+      if (git) {
+        vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+        vi.mocked(runCommandWithTimeout).mockResolvedValue(commandResult({ stdout: sha }));
+      }
       mockFileBackedPathExists();
       mockRunningManagedGateway([process.execPath, entryPath, "gateway", "run"]);
       if (ancestor) {
@@ -5675,7 +5690,11 @@ describe("update-cli", () => {
 
       await withEnvAsync(env, () =>
         invokeUpdateCli({ yes: true, json: true, acceptCapabilities: true, ...options }),
-      );
+      ).catch((error) => {
+        throw new Error(`${getErrorOutput()}\n${JSON.stringify(lastWriteJsonCall())}`, {
+          cause: error,
+        });
+      });
 
       expect(managedUpdateHandoff.start, getErrorOutput() || getLogOutput()).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -5683,7 +5702,8 @@ describe("update-cli", () => {
           supervisor,
           parentPid: gatewayFixturePid,
           invocationCwd: process.cwd(),
-          tag,
+          tag:
+            git || options.channel === "extended-stable" ? undefined : (options.tag ?? "9999.0.0"),
           acceptCapabilities: true,
         }),
       );
@@ -5692,7 +5712,7 @@ describe("update-cli", () => {
         handoffId: "test-handoff",
         installRoot: root,
       });
-      expectNoSideEffects(serviceStop, serviceRestart, runRestartScript);
+      expectNoSideEffects(serviceStop, serviceRestart, runRestartScript, runGatewayUpdate);
       expect(packageInstallCommandCall()).toBeUndefined();
       expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
       expect(lastWriteJsonCall()).toMatchObject({
@@ -5708,51 +5728,53 @@ describe("update-cli", () => {
     },
   );
 
-  it.each(["preparation", "final ancestry recheck"])(
-    "reports a Git service refusal during %s without an unsafe recovery verdict",
-    async (phase) => {
-      const root = createCaseDir("openclaw-git-ancestry-refusal");
-      const sha = "a".repeat(40);
-      await writeOpenClawPackageFixture(root, "1.0.0", {
-        git: true,
-        builtSha: sha,
-        entrySource: "export {};\n",
+  it("reports a Git service refusal at the final ancestry recheck without an unsafe recovery verdict", async () => {
+    const root = createCaseDir("openclaw-git-ancestry-refusal");
+    const sha = "a".repeat(40);
+    await writeOpenClawPackageFixture(root, "1.0.0", {
+      git: true,
+      builtSha: sha,
+      entrySource: "export {};\n",
+    });
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    vi.mocked(runCommandWithTimeout).mockResolvedValue(commandResult({ stdout: sha }));
+    mockRunningManagedGateway(["node", path.join(root, "dist", "index.js"), "gateway"]);
+    const preparations = mockGitUpdateAfterMutation(makeOkUpdateResult({ mode: "git", root }));
+    mockGetSelfAndAncestorPidsSync.mockReturnValue(new Set<number>([process.pid]));
+    const runningRuntime = { status: "running", pid: gatewayFixturePid, state: "running" };
+    // Inspection and preparation see an external caller; the final runtime
+    // reread discovers the Gateway is now an ancestor before native shutdown.
+    serviceReadRuntime
+      .mockResolvedValueOnce(runningRuntime)
+      .mockResolvedValueOnce(runningRuntime)
+      .mockImplementation(async () => {
+        mockGetSelfAndAncestorPidsSync.mockReturnValue(
+          new Set<number>([process.pid, gatewayFixturePid]),
+        );
+        return runningRuntime;
       });
-      vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
-      vi.mocked(runCommandWithTimeout).mockResolvedValue(commandResult({ stdout: sha }));
-      mockRunningManagedGateway(["node", path.join(root, "dist", "index.js"), "gateway"]);
-      const preparations = mockGitUpdateAfterMutation(makeOkUpdateResult({ mode: "git", root }));
-      mockGetSelfAndAncestorPidsSync.mockReturnValue(
-        new Set<number>([process.pid, gatewayFixturePid]),
-      );
-      if (phase === "final ancestry recheck") {
-        mockGetSelfAndAncestorPidsSync.mockReturnValueOnce(new Set<number>([process.pid]));
-      }
 
-      await expect(invokeUpdateCli({ yes: true, json: true })).rejects.toEqual(new ExitError(1));
+    await expect(invokeUpdateCli({ yes: true, json: true })).rejects.toEqual(new ExitError(1));
 
-      expect(runUpdateFailureTriage).toHaveBeenCalledOnce();
-      expect(vi.mocked(runUpdateFailureTriage).mock.calls[0]?.[0].failure).toMatchObject({
-        result: {
-          status: "error",
-          reason: "managed-service-preflight",
-          recovery: { serviceRestartSafe: true },
-          steps: [
-            expect.objectContaining({
-              stderrTail: expect.stringContaining(
-                `Gateway PID ${gatewayFixturePid} is an ancestor`,
-              ),
-            }),
-          ],
-        },
-      });
-      expect(preparations).toEqual([]);
-      expectNoSideEffects(serviceStop, serviceStart, serviceRestart);
-      expect(freshRestartCalls()).toHaveLength(0);
-      expect(getErrorOutput()).not.toContain("Update recovery is unverified");
-      expect(defaultRuntime.exit).not.toHaveBeenCalled();
-    },
-  );
+    expect(runUpdateFailureTriage).toHaveBeenCalledOnce();
+    expect(vi.mocked(runUpdateFailureTriage).mock.calls[0]?.[0].failure).toMatchObject({
+      result: {
+        status: "error",
+        reason: "managed-service-preflight",
+        recovery: { serviceRestartSafe: true },
+        steps: [
+          expect.objectContaining({
+            stderrTail: expect.stringContaining(`Gateway PID ${gatewayFixturePid} is an ancestor`),
+          }),
+        ],
+      },
+    });
+    expect(preparations).toEqual([]);
+    expectNoSideEffects(serviceStop, serviceStart, serviceRestart);
+    expect(freshRestartCalls()).toHaveLength(0);
+    expect(getErrorOutput()).not.toContain("Update recovery is unverified");
+    expect(defaultRuntime.exit).not.toHaveBeenCalled();
+  });
 
   it("refuses package updates from inherited gateway runtime pid when process ancestry is truncated", async () => {
     await mockPackageInstallAtCaseDir();

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../daemon/constants.js";
 import { mockSystemAccountHome } from "../daemon/service.test-helpers.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { SUPERVISOR_HINT_ENV_VARS } from "../infra/supervisor-markers.js";
 import { isBetaTag } from "../infra/update-channels.js";
 import { applyDevUpdateTargetEnv } from "../infra/update-dev-target.js";
 import {
@@ -62,6 +63,11 @@ const suspendScheduledTaskAutoStartForUpdate = vi.fn();
 const resumeScheduledTaskAutoStartAfterUpdate = vi.fn();
 const prepareRestartScript = vi.fn();
 const runRestartScript = vi.fn();
+const managedUpdateHandoff = vi.hoisted(() => ({
+  start: vi.fn(),
+  transfer: vi.fn(),
+  cancel: vi.fn(),
+}));
 const mockedRunDaemonInstall = vi.fn();
 const serviceReadCommand = vi.fn();
 const serviceReadRuntime = vi.fn();
@@ -115,6 +121,8 @@ const execFile = vi.fn((...args: unknown[]) => {
 const spawn = vi.fn();
 const { defaultRuntime: runtimeCapture, resetRuntimeCapture } = createCliRuntimeCapture();
 const serviceEnvSnapshot = captureEnv([
+  ...SUPERVISOR_HINT_ENV_VARS,
+  "OPENCLAW_UPDATE_RUN_HANDOFF",
   "OPENCLAW_SERVICE_MARKER",
   "OPENCLAW_SERVICE_KIND",
   GATEWAY_SERVICE_RUNTIME_PID_ENV,
@@ -128,6 +136,12 @@ vi.mock("@clack/prompts", () => ({
   isCancel,
   spinner,
   note: vi.fn(),
+}));
+
+vi.mock("../infra/update-managed-service-handoff.js", () => ({
+  startManagedServiceUpdateHandoff: managedUpdateHandoff.start,
+  transferManagedServiceUpdateHandoff: managedUpdateHandoff.transfer,
+  cancelManagedServiceUpdateHandoff: managedUpdateHandoff.cancel,
 }));
 
 // Fresh diagnostic processes have owner coverage; interactive cases retain the
@@ -1692,7 +1706,11 @@ describe("update-cli", () => {
     delete process.env.OPENCLAW_SERVICE_MARKER;
     delete process.env.OPENCLAW_SERVICE_KIND;
     delete process.env[GATEWAY_SERVICE_RUNTIME_PID_ENV];
-    for (const key of GATEWAY_SERVICE_SELECTOR_ENV_KEYS) {
+    for (const key of [
+      ...GATEWAY_SERVICE_SELECTOR_ENV_KEYS,
+      ...SUPERVISOR_HINT_ENV_VARS,
+      "OPENCLAW_UPDATE_RUN_HANDOFF",
+    ]) {
       delete process.env[key];
     }
     restartHealthTestControl.snapshot = undefined;
@@ -2045,6 +2063,7 @@ describe("update-cli", () => {
       expect(freshRestartCalls().length).toBe(restart ? 1 : 0);
       expect(serviceStart).not.toHaveBeenCalled();
       expectNoSideEffects(
+        managedUpdateHandoff.start,
         runDaemonInstall,
         runDaemonRestart,
         prepareRestartScript,
@@ -5599,6 +5618,95 @@ describe("update-cli", () => {
     expect(serviceStop).not.toHaveBeenCalled();
     expect(packageInstallCommandCall()).toBeUndefined();
   });
+
+  it.each(
+    (
+      [
+        { platform: "linux", env: { INVOCATION_ID: "gateway-invocation" }, supervisor: "systemd" },
+        { platform: "linux", env: { JOURNAL_STREAM: "8:123" }, supervisor: "systemd" },
+        {
+          platform: "linux",
+          env: { OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service" },
+          supervisor: "systemd",
+        },
+        { platform: "linux", env: {}, supervisor: "systemd", ancestor: true },
+        {
+          platform: "linux",
+          env: { INVOCATION_ID: "gateway-invocation" },
+          supervisor: "systemd",
+          options: { tag: "./candidate.tgz" },
+          tag: "./candidate.tgz",
+        },
+        {
+          platform: "linux",
+          env: { INVOCATION_ID: "gateway-invocation" },
+          supervisor: "systemd",
+          options: { channel: "extended-stable" },
+          tag: undefined,
+        },
+        {
+          platform: "darwin",
+          env: { OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway" },
+          supervisor: "launchd",
+        },
+      ] as const
+    ).map((testCase) => ({ options: {}, tag: "9999.0.0", ancestor: false, ...testCase })),
+  )(
+    "hands agent-initiated updates to $supervisor before stopping the gateway ($env)",
+    async ({ platform, env, supervisor, options, tag, ancestor }) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue(platform);
+      const { pkgRoot: root, entryPath } = await setupInstalledPackageRoot(
+        createCaseDir("openclaw-update-handoff"),
+      );
+      mockFileBackedPathExists();
+      mockRunningManagedGateway([process.execPath, entryPath, "gateway", "run"]);
+      if (ancestor) {
+        mockGetSelfAndAncestorPidsSync.mockReturnValue(new Set([process.pid, gatewayFixturePid]));
+      }
+      managedUpdateHandoff.start.mockResolvedValue({
+        status: "started",
+        handoffId: "test-handoff",
+        installRoot: root,
+        logPath: "/tmp/update-handoff/handoff.log",
+        command: "openclaw update --yes",
+        pid: 12345,
+      });
+      managedUpdateHandoff.transfer.mockResolvedValue(true);
+
+      await withEnvAsync(env, () =>
+        invokeUpdateCli({ yes: true, json: true, acceptCapabilities: true, ...options }),
+      );
+
+      expect(managedUpdateHandoff.start, getErrorOutput() || getLogOutput()).toHaveBeenCalledWith(
+        expect.objectContaining({
+          root,
+          supervisor,
+          parentPid: gatewayFixturePid,
+          invocationCwd: process.cwd(),
+          tag,
+          acceptCapabilities: true,
+        }),
+      );
+      expect(managedUpdateHandoff.transfer).toHaveBeenCalledWith({
+        kind: "managed-update-handoff",
+        handoffId: "test-handoff",
+        installRoot: root,
+      });
+      expectNoSideEffects(serviceStop, serviceRestart, runRestartScript);
+      expect(packageInstallCommandCall()).toBeUndefined();
+      expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+      expect(lastWriteJsonCall()).toMatchObject({
+        status: "skipped",
+        reason: "managed-service-handoff-started",
+        steps: [
+          expect.objectContaining({
+            stdoutTail: expect.stringContaining("/tmp/update-handoff/handoff.log"),
+          }),
+        ],
+      });
+      expect(JSON.stringify(lastWriteJsonCall())).toContain("gateway status --deep");
+    },
+  );
 
   it.each(["preparation", "final ancestry recheck"])(
     "reports a Git service refusal during %s without an unsafe recovery verdict",

--- a/src/cli/update-cli/update-command-execution.ts
+++ b/src/cli/update-cli/update-command-execution.ts
@@ -18,11 +18,13 @@ import {
   hasSchemaRefusal,
 } from "./schema-preflight.js";
 import {
+  normalizeTag,
   resolveGitInstallDir,
   UpdatePreMutationError,
   type UpdateCommandOptions,
 } from "./shared.js";
 import { createBeforeGitMutation, updateGitInstall } from "./update-command-git.js";
+import { handoffUpdateFromGateway } from "./update-command-handoff.js";
 import {
   captureOwnedManagedUpdateContext,
   type OwnedManagedUpdateContext,
@@ -113,6 +115,27 @@ export async function executeMutableUpdate(params: {
           jsonMode: Boolean(params.opts.json),
           timeoutMs: params.updateStepTimeoutMs,
           phase,
+          handoffFromGateway: (state) =>
+            handoffUpdateFromGateway({
+              state,
+              root: mutationRoot,
+              opts: params.opts,
+              // Pin the inspected package. Extended-stable resolves its protected
+              // selector again because its public CLI contract forbids --tag.
+              tag:
+                params.updateInstallKind === "package" && params.channel !== "extended-stable"
+                  ? (normalizeTag(params.packageInstallSpec) ?? undefined)
+                  : undefined,
+              mode:
+                params.updateInstallKind === "git"
+                  ? "git"
+                  : (params.packageInstallTarget?.manager ?? "unknown"),
+              timeoutMs: params.updateStepTimeoutMs,
+              devTarget: params.devTarget,
+              nodeRunner: params.packageUpdateNodeRunner,
+              invocationCwd: params.invocationCwd,
+              stopProgress: params.stop,
+            }),
         });
         if (preManagedServiceStop.windowsTaskAutoStartRecovery) {
           params.recoveryState.windowsTaskAutoStartRecovery =

--- a/src/cli/update-cli/update-command-handoff.ts
+++ b/src/cli/update-cli/update-command-handoff.ts
@@ -1,0 +1,173 @@
+import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
+import { GATEWAY_SERVICE_RUNTIME_PID_ENV, isGatewayServiceEnv } from "../../daemon/constants.js";
+import { resolveGatewayInstallEntrypoint } from "../../daemon/gateway-entrypoint.js";
+import {
+  resolveManagedGatewayServiceCommand,
+  type GatewayServiceState,
+} from "../../daemon/service-types.js";
+import { resolveInstallationTarget } from "../../infra/installation-target-context.js";
+import { writeRestartSentinel } from "../../infra/restart-sentinel.js";
+import { getSelfAndAncestorPidsSync } from "../../infra/restart-stale-pids.js";
+import { resolveGatewayRestartDeferralTimeoutMs } from "../../infra/restart.js";
+import { detectRespawnSupervisor } from "../../infra/supervisor-markers.js";
+import { normalizeUpdateChannel } from "../../infra/update-channels.js";
+import { CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON } from "../../infra/update-control-plane-sentinel.js";
+import type { DevUpdateTarget } from "../../infra/update-dev-target.js";
+import {
+  cancelManagedServiceUpdateHandoff,
+  startManagedServiceUpdateHandoff,
+  transferManagedServiceUpdateHandoff,
+} from "../../infra/update-managed-service-handoff.js";
+import { buildUpdateRestartSentinelPayload } from "../../infra/update-restart-sentinel-payload.js";
+import type { UpdateRunResult } from "../../infra/update-runner.js";
+import { defaultRuntime } from "../../runtime.js";
+import { formatInstallationTargetCommand } from "../installation-target-format.js";
+import { resolveNodeRunner, UpdatePreMutationError, type UpdateCommandOptions } from "./shared.js";
+import { resolveOwnedManagedUpdateEnv } from "./update-command-service-env.js";
+
+function parsePositivePid(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value > 0 ? Math.floor(value) : null;
+  }
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return /^\d+$/u.test(trimmed) ? (parseStrictPositiveInteger(trimmed) ?? null) : null;
+}
+
+export function gatewayAncestryBlockMessage(pid: unknown): string | undefined {
+  const gatewayPid = parsePositivePid(pid);
+  if (gatewayPid === null) {
+    return undefined;
+  }
+  const inherited =
+    isGatewayServiceEnv(process.env) &&
+    parsePositivePid(process.env[GATEWAY_SERVICE_RUNTIME_PID_ENV]) === gatewayPid;
+  if (!inherited && !getSelfAndAncestorPidsSync().has(gatewayPid)) {
+    return undefined;
+  }
+  return `This command is running inside the gateway process tree.
+Gateway PID ${gatewayPid} is an ancestor of this process, so this command cannot safely stop or restart the gateway that owns it.
+Run this command from a shell outside the gateway service, or stop the gateway service first and retry.`;
+}
+
+export async function handoffUpdateFromGateway(params: {
+  state: GatewayServiceState;
+  root: string;
+  mode: UpdateRunResult["mode"];
+  opts: UpdateCommandOptions;
+  tag?: string;
+  timeoutMs: number;
+  devTarget?: DevUpdateTarget;
+  nodeRunner?: string;
+  invocationCwd?: string;
+  stopProgress: () => void;
+}): Promise<boolean> {
+  if (
+    process.env.OPENCLAW_UPDATE_RUN_HANDOFF === "1" ||
+    (process.platform !== "linux" && process.platform !== "darwin")
+  ) {
+    return false;
+  }
+  const parentPid = parsePositivePid(params.state.runtime?.pid);
+  const supervisor =
+    detectRespawnSupervisor(process.env, process.platform, {
+      includeLinuxOpenClawGatewayServiceMarker: true,
+    }) ??
+    (gatewayAncestryBlockMessage(parentPid)
+      ? process.platform === "linux"
+        ? "systemd"
+        : "launchd"
+      : null);
+  if (!parentPid || !supervisor) {
+    return false;
+  }
+  params.stopProgress();
+  const env = resolveOwnedManagedUpdateEnv({
+    serviceEnv: params.state.env,
+    serviceDefinitionEnv: resolveManagedGatewayServiceCommand(params.state.command)?.environment,
+    invocationCwd: params.invocationCwd,
+  });
+  const argv1 = await resolveGatewayInstallEntrypoint(params.root);
+  if (!argv1) {
+    throw new UpdatePreMutationError(
+      "managed-service-handoff-failed",
+      "Cannot locate the installed updater; run `openclaw doctor` before retrying.",
+    );
+  }
+  const started = await startManagedServiceUpdateHandoff({
+    root: params.root,
+    invocationCwd: params.invocationCwd,
+    parentPid,
+    supervisor,
+    env,
+    execPath: params.nodeRunner ?? resolveNodeRunner(),
+    argv1,
+    timeoutMs: params.timeoutMs,
+    restartDrainTimeoutMs: resolveGatewayRestartDeferralTimeoutMs(),
+    channel: normalizeUpdateChannel(params.opts.channel) ?? undefined,
+    tag: params.tag,
+    devTarget: params.devTarget,
+    acceptCapabilities: params.opts.acceptCapabilities,
+    meta: {},
+  });
+  if (started.status === "joined") {
+    throw new UpdatePreMutationError(
+      "managed-service-handoff-already-running",
+      "Another managed update is already running. Inspect `openclaw status --all` before retrying.",
+    );
+  }
+  const identity = {
+    kind: "managed-update-handoff" as const,
+    handoffId: started.handoffId,
+    installRoot: started.installRoot,
+  };
+  const target = resolveInstallationTarget(env);
+  const statusCommand = formatInstallationTargetCommand(["openclaw", "status", "--all"], target, {
+    env,
+  });
+  const healthCommand = formatInstallationTargetCommand(
+    ["openclaw", "gateway", "status", "--deep"],
+    target,
+    { env },
+  );
+  const guidance = `Update continues outside the Gateway process. Log: ${started.logPath}\nFollow up: ${statusCommand}; ${healthCommand}.`;
+  const result: UpdateRunResult = {
+    status: "skipped",
+    mode: params.mode,
+    root: started.installRoot,
+    reason: CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON,
+    steps: [
+      {
+        name: "managed-service update handoff",
+        command: started.command,
+        cwd: started.installRoot,
+        durationMs: 0,
+        exitCode: null,
+        stdoutTail: guidance,
+      },
+    ],
+    durationMs: 0,
+  };
+  try {
+    await writeRestartSentinel(
+      buildUpdateRestartSentinelPayload({
+        result,
+        meta: { handoffId: started.handoffId, root: started.installRoot },
+      }),
+      env,
+    );
+    if (!(await transferManagedServiceUpdateHandoff(identity))) {
+      throw new Error(
+        `Managed update ownership transfer failed. Inspect ${started.logPath} and run ${healthCommand} before retrying.`,
+      );
+    }
+  } catch (error) {
+    await cancelManagedServiceUpdateHandoff(identity);
+    throw error;
+  }
+  if (params.opts.json) {
+    defaultRuntime.writeJson(result);
+  } else {
+    defaultRuntime.log(guidance);
+  }
+  return true;
+}

--- a/src/cli/update-cli/update-command-service-maintenance.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.ts
@@ -1,16 +1,11 @@
 // Managed service identity, shutdown, and recovery shared by update and Doctor.
 import { Writable } from "node:stream";
-import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { createConfigIO } from "../../config/io.js";
 import { resolveGatewayPort } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import {
-  GATEWAY_SERVICE_RUNTIME_PID_ENV,
-  isGatewayServiceEnv,
-  resolveGatewayProfileSuffix,
-} from "../../daemon/constants.js";
+import { isGatewayServiceEnv, resolveGatewayProfileSuffix } from "../../daemon/constants.js";
 import { resolveLaunchAgentLabel } from "../../daemon/launchd-label.js";
 import { resolveTaskName } from "../../daemon/schtasks-layout.js";
 import {
@@ -30,7 +25,6 @@ import {
 import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
 import { resolveSystemdServiceName } from "../../daemon/systemd-service-files.js";
 import { sha256Hex } from "../../infra/crypto-digest.js";
-import { getSelfAndAncestorPidsSync } from "../../infra/restart-stale-pids.js";
 import { parseTcpPortFromArgs } from "../../infra/tcp-port.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -44,6 +38,7 @@ import {
   waitForSignalExitBarriers,
 } from "../signal-exit-barrier.js";
 import { UpdatePreMutationError } from "./shared.js";
+import { gatewayAncestryBlockMessage } from "./update-command-handoff.js";
 import { runUpdatedInstallGatewayCommand } from "./update-command-service-command.js";
 import {
   assertGatewayServiceManagementAllowedForUpdate,
@@ -245,30 +240,6 @@ export class UpdateCommandAbort extends Error {
   }
 }
 
-function parsePositivePid(value: unknown): number | null {
-  if (typeof value === "number") {
-    return Number.isFinite(value) && value > 0 ? Math.floor(value) : null;
-  }
-  const trimmed = typeof value === "string" ? value.trim() : "";
-  return /^\d+$/u.test(trimmed) ? (parseStrictPositiveInteger(trimmed) ?? null) : null;
-}
-
-function gatewayAncestryBlockMessage(pid: unknown): string | undefined {
-  const gatewayPid = parsePositivePid(pid);
-  if (gatewayPid === null) {
-    return undefined;
-  }
-  const inherited =
-    isGatewayServiceEnv(process.env) &&
-    parsePositivePid(process.env[GATEWAY_SERVICE_RUNTIME_PID_ENV]) === gatewayPid;
-  if (!inherited && !getSelfAndAncestorPidsSync().has(gatewayPid)) {
-    return undefined;
-  }
-  return `This command is running inside the gateway process tree.
-Gateway PID ${gatewayPid} is an ancestor of this process, so this command cannot safely stop or restart the gateway that owns it.
-Run this command from a shell outside the gateway service, or stop the gateway service first and retry.`;
-}
-
 function serviceControlStdoutForMode(jsonMode: boolean): NodeJS.WritableStream {
   return jsonMode ? JSON_MODE_SERVICE_STDOUT : process.stdout;
 }
@@ -418,6 +389,7 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
   shouldRestart: boolean;
   jsonMode: boolean;
   phase?: "inspect" | "prepare";
+  handoffFromGateway?: (state: GatewayServiceState) => Promise<boolean>;
   expectedService?: Pick<PreManagedServiceStop, "serviceEnv" | "serviceUpdateVerdict">;
   timeoutMs?: number;
 }): Promise<PreManagedServiceStop> {
@@ -493,6 +465,16 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
       serviceMutationSkipMessage:
         "Gateway service management skipped: the service belongs to a different OpenClaw installation and was left untouched.",
     };
+  }
+  // Transfer before either inspection-only Git planning or native shutdown can
+  // return control to an updater still owned by this service.
+  if (
+    serviceUpdateVerdict.kind === "owned" &&
+    params.shouldRestart &&
+    serviceState.running &&
+    (await params.handoffFromGateway?.(serviceState))
+  ) {
+    throw new UpdateCommandAbort();
   }
   if (serviceUpdateVerdict.kind === "absent" || params.phase === "inspect") {
     return inspected;

--- a/src/infra/update-managed-service-handoff-command.test.ts
+++ b/src/infra/update-managed-service-handoff-command.test.ts
@@ -72,6 +72,7 @@ afterEach(async () => {
 async function startHandoffAndReadCommand(params: {
   channel: "beta" | "extended-stable";
   tag?: string;
+  acceptCapabilities?: boolean;
   devTarget?: DevUpdateTarget;
   env?: NodeJS.ProcessEnv;
   restartDelayMs?: number;
@@ -90,6 +91,7 @@ async function startHandoffAndReadCommand(params: {
     ...(params.restartDelayMs === undefined ? {} : { restartDelayMs: params.restartDelayMs }),
     channel: params.channel,
     ...(params.tag ? { tag: params.tag } : {}),
+    ...(params.acceptCapabilities ? { acceptCapabilities: true } : {}),
     parentPid: process.pid,
     execPath: "/usr/local/bin/node",
     argv1: "/opt/openclaw/openclaw.mjs",
@@ -166,6 +168,7 @@ describe("managed service update handoff command", () => {
     const result = await startHandoffAndReadCommand({
       channel: "beta",
       tag: "2.0.0-beta.1",
+      acceptCapabilities: true,
     });
 
     expect(result.commandArgv).toEqual([
@@ -174,6 +177,7 @@ describe("managed service update handoff command", () => {
       "update",
       "--yes",
       "--json",
+      "--accept-capabilities",
       "--channel",
       "beta",
       "--tag",
@@ -181,6 +185,9 @@ describe("managed service update handoff command", () => {
     ]);
     expect(result.command).toContain("--tag 2.0.0-beta.1");
     expect(result.command).toContain("--channel beta");
+    expect(result.command).toContain("--accept-capabilities");
+    expect(result.command).toContain("--yes");
+    expect(result.command).not.toContain("--json");
   });
 
   it("merges a tracked target into the child environment without replacing caller fields", async () => {

--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -137,7 +137,10 @@ function readRestartSentinelPayload(env: NodeJS.ProcessEnv, key = "current"): un
 
 async function runManagedServiceManagerBoundary(
   kind: "systemd" | "launchd",
-  options?: ManagedServiceManagerBoundaryOptions,
+  options?: ManagedServiceManagerBoundaryOptions & {
+    controlDisconnect?: "transferred" | "unarmed" | "dead-parent";
+    relativeInput?: boolean;
+  },
 ): Promise<ManagedServiceManagerBoundaryResult> {
   const { spawn } =
     await vi.importActual<typeof import("node:child_process")>("node:child_process");
@@ -184,6 +187,11 @@ async function runManagedServiceManagerBoundary(
     }
   `,
   );
+  const invocationCwd = options?.relativeInput ? path.join(root, "invoking-directory") : undefined;
+  if (invocationCwd) {
+    await fs.mkdir(invocationCwd);
+    await fs.writeFile(path.join(invocationCwd, "update-input.txt"), "selected target");
+  }
   const parent = spawn(process.execPath, ["-e", "process.stdin.resume()"], {
     stdio: ["pipe", "ignore", "ignore"],
   });
@@ -217,6 +225,7 @@ async function runManagedServiceManagerBoundary(
       root,
       restartDrainTimeoutMs: 300_000,
       parentPid,
+      invocationCwd,
       execPath: process.execPath,
       argv1: process.argv[1],
       handoffId: `${kind}-boundary`,
@@ -244,6 +253,23 @@ async function runManagedServiceManagerBoundary(
       stateDatabasePath,
       options,
     });
+    let updaterScript = createManagedServiceUpdaterFixtureScript({
+      kind,
+      root,
+      statePath,
+      updaterPath,
+      logPath: String(generated.logPath),
+      stateDatabasePath,
+      consumeNotification,
+      options,
+    });
+    if (invocationCwd) {
+      // Consuming a relative input then removing cwd forces recovery and triage
+      // to launch from the durable helper directory, not the vanished caller cwd.
+      updaterScript =
+        `const inputFs=require("node:fs");if(inputFs.readFileSync("update-input.txt","utf8")!=="selected target")process.exit(42);inputFs.rmSync(process.cwd(),{recursive:true});` +
+        updaterScript;
+    }
     await fs.writeFile(
       paramsPath,
       JSON.stringify({
@@ -264,20 +290,7 @@ async function runManagedServiceManagerBoundary(
         ...(options?.recoveryHang || options?.triageHang ? { recoveryTimeoutMs: 1000 } : {}),
         recovery: { serviceRestartSafe: true, version: "1.0.0" },
         recoveryModulePath,
-        commandArgv: [
-          process.execPath,
-          "-e",
-          createManagedServiceUpdaterFixtureScript({
-            kind,
-            root,
-            statePath,
-            updaterPath,
-            logPath: String(generated.logPath),
-            stateDatabasePath,
-            consumeNotification,
-            options,
-          }),
-        ],
+        commandArgv: [process.execPath, "-e", updaterScript],
       }),
     );
     if (options?.recoverySentinel) {
@@ -351,7 +364,29 @@ async function runManagedServiceManagerBoundary(
       startIdentity: expect.any(String),
     });
     await expect(pathExists(commandsPath)).resolves.toBe(false);
-    if (options?.parentExitTimeoutMs !== undefined) {
+    if (options?.controlDisconnect) {
+      if (options.controlDisconnect !== "unarmed") {
+        const transferred = waitForHandoffResponse(runningHelper.stdout, "transferred");
+        runningHelper.stdin?.write("transfer\n");
+        await transferred;
+        await expect(pathExists(commandsPath)).resolves.toBe(false);
+      }
+      if (options.controlDisconnect === "dead-parent") {
+        parent.stdin?.end();
+        await vi.waitFor(() => expect(parent.exitCode).toBe(0));
+      }
+      runningHelper.stdin?.end();
+      if (options.controlDisconnect === "transferred") {
+        await vi.waitFor(async () => {
+          expect(JSON.parse(await fs.readFile(statePath, "utf8"))).toMatchObject({ parked: true });
+        });
+        parent.stdin?.end();
+      }
+      expect(await completion, stderr).toBe(options.helperExitCode ?? 0);
+      await expect(pathExists(updaterPath)).resolves.toBe(
+        options.controlDisconnect === "transferred",
+      );
+    } else if (options?.parentExitTimeoutMs !== undefined) {
       const timeout = options.parentExitTimeoutMs + (options.launchdTeardown ? 8_000 : 3_000);
       let timer: ReturnType<typeof setTimeout> | undefined;
       try {
@@ -436,9 +471,15 @@ async function runManagedServiceManagerBoundary(
         }
       : null;
     return {
-      commands: (await fs.readFile(commandsPath, "utf8")).trim().split("\n"),
+      commands: (await fs.readFile(commandsPath, "utf8").catch(() => ""))
+        .trim()
+        .split("\n")
+        .filter(Boolean),
       parentSignal: parent.signalCode,
-      state: JSON.parse(await fs.readFile(statePath, "utf8")) as Record<string, unknown>,
+      state: JSON.parse(await fs.readFile(statePath, "utf8").catch(() => "{}")) as Record<
+        string,
+        unknown
+      >,
       sentinel: readRestartSentinelPayload({ OPENCLAW_STATE_DIR: root }),
       log: await fs.readFile(String(generated.logPath), "utf8"),
       savedFailure,
@@ -461,6 +502,56 @@ async function runManagedServiceManagerBoundary(
 
 describe("managed service update handoff", () => {
   const itUnix = it.runIf(process.platform !== "win32");
+
+  itUnix.each(
+    (["systemd", "launchd"] as const).flatMap((kind) =>
+      [false, true].map((recover) => ({ kind, recover })),
+    ),
+  )(
+    "transfers $kind update ownership before CLI disconnect and preserves relative inputs (recovery=$recover)",
+    async ({ kind, recover }) => {
+      const { commands, state, sensitiveFilesRemoved } = await runManagedServiceManagerBoundary(
+        kind,
+        {
+          controlDisconnect: "transferred",
+          relativeInput: true,
+          updaterExitCode: recover ? 7 : 0,
+          helperExitCode: recover ? 7 : 0,
+          updaterResult: {
+            status: recover ? "error" : "ok",
+            mode: "npm",
+            ...(recover ? { recovery: { serviceRestartSafe: true, version: "1.0.0" } } : {}),
+          },
+        },
+      );
+      expect(commands.some((command) => /\b(stop|bootout)\b/.test(command))).toBe(true);
+      expect(state).toMatchObject({ parked: true });
+      if (recover) {
+        expect(state).toMatchObject({
+          restored: true,
+          healthProbeCount: 1,
+          triageCalls: 1,
+          triageObservedRestored: true,
+          triageObservedRecovery: true,
+        });
+      }
+      expect(sensitiveFilesRemoved).toBe(true);
+    },
+  );
+
+  itUnix.each(["unarmed", "dead-parent"] as const)(
+    "does not stop or update the service after %s control disconnect",
+    async (controlDisconnect) => {
+      const { commands, sentinel } = await runManagedServiceManagerBoundary("systemd", {
+        controlDisconnect,
+        updaterExitCode: 0,
+      });
+      expect(commands).toEqual([]);
+      expect(sentinel).toMatchObject({
+        payload: { status: "skipped", stats: { reason: "managed-service-handoff-cancelled" } },
+      });
+    },
+  );
 
   it("rejects failed helper spawns and removes the sensitive handoff directory", async () => {
     const child = createSpawnMock();

--- a/src/infra/update-managed-service-handoff-single-flight.test.ts
+++ b/src/infra/update-managed-service-handoff-single-flight.test.ts
@@ -248,6 +248,7 @@ describe("managed service update handoff single-flight", () => {
         cancelManagedServiceUpdateHandoff,
         claimManagedServiceUpdateHandoff,
         startManagedServiceUpdateHandoff,
+        transferManagedServiceUpdateHandoff,
       } = await import("./update-managed-service-handoff.js");
       const started = await startManagedServiceUpdateHandoff({
         root,
@@ -263,6 +264,7 @@ describe("managed service update handoff single-flight", () => {
       }
       const identity = { kind: "managed-update-handoff" as const, ...started };
       expect(claimManagedServiceUpdateHandoff(identity)).toBe(true);
+      await expect(transferManagedServiceUpdateHandoff(identity)).resolves.toBe(true);
       if (failure === "dead") {
         vi.spyOn(processIdentity, "isPidAlive").mockReturnValue(false);
       } else {

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -3,6 +3,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
+import { Socket } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
@@ -980,7 +981,7 @@ function killOwnedCommand(child) {
 }
 
 /** @param {"update" | "recovery" | "diagnostic"} phase */
-async function runOwnedUpdateCommand(phase, commandArgv, timeoutMs) {
+async function runOwnedUpdateCommand(phase, commandArgv, timeoutMs, cwd = params.cwd) {
   const outputFd = fs.openSync(params.logPath, "a", 0o600);
   let timeout;
   const updaterChunks = [];
@@ -988,7 +989,7 @@ async function runOwnedUpdateCommand(phase, commandArgv, timeoutMs) {
   let outputOverflow = false;
   try {
     const child = spawn(process.execPath, ["-e", ${JSON.stringify(HANDOFF_COMMAND_RUNNER_SCRIPT)}, JSON.stringify(commandArgv)], {
-      cwd: params.cwd,
+      cwd,
       env: process.env,
       detached: true,
       stdio: ["pipe", "pipe", outputFd],
@@ -1135,12 +1136,14 @@ async function collectUpdateFailureTriage() {
       }
       wake?.();
     });
-    process.stdin.once("close", () => {
+    const onDisconnect = () => {
       disconnected = true;
       wake?.();
-    });
+    };
+    process.stdin.once("end", onDisconnect).once("close", onDisconnect);
     const reply = (line) => fs.writeSync(1, line + "\n");
     let parked = false;
+    let transferred = false;
     while (isPidAlive(params.parentPid)) {
       if (!ownsManagedUpdateLease()) throw new Error("managed update lease no longer owns the helper");
       if (readProcessStartIdentity(params.parentPid) !== params.parentStartIdentity) {
@@ -1159,8 +1162,20 @@ async function collectUpdateFailureTriage() {
           try { process.kill(params.parentPid, "SIGKILL"); } catch {}
         }
       }
+      // A child CLI must finish reporting before its Gateway's stop kills it.
+      // Only an acknowledged transfer lets EOF commit; ordinary EOF cancels.
+      if (transferred && disconnected && !parked) {
+        appendLog("initiating CLI disconnected; parking the managed gateway service");
+        await parkGatewayService();
+        parked = true;
+        outcome = Date.now() < params.parentExitDeadlineAt ? "update" : "restore";
+      }
       const command = commands.shift();
-      if (command === "park") {
+      if (command === "transfer" && !parked && !transferred) {
+        transferred = true;
+        appendLog("managed update ownership transferred; waiting for initiating CLI exit");
+        reply("transferred");
+      } else if (command === "park") {
         try {
           if (!parked) await parkGatewayService();
           parked = true;
@@ -1252,7 +1267,8 @@ async function collectUpdateFailureTriage() {
     }
 
     appendLog("starting managed update command: " + params.commandLabel);
-    const exit = await runOwnedUpdateCommand("update", params.commandArgv);
+    // Update inputs retain shell-relative paths; recovery keeps the durable helper cwd.
+    const exit = await runOwnedUpdateCommand("update", params.commandArgv, undefined, params.invocationCwd);
     const { updaterOutput, outputOverflow } = exit;
     // Only this invocation's direct child result carries the producer decision.
     // Success may change install roots; only recovery requires the original root.
@@ -1324,6 +1340,7 @@ type ManagedServiceUpdateHandoffParams = {
   restartDelayMs?: number;
   channel?: UpdateChannel;
   tag?: string;
+  acceptCapabilities?: boolean;
   meta: UpdateRestartSentinelMeta;
   handoffId?: string;
   supervisor?: RespawnSupervisor | null;
@@ -1332,6 +1349,7 @@ type ManagedServiceUpdateHandoffParams = {
   execPath?: string;
   argv1?: string;
   parentPid?: number;
+  invocationCwd?: string;
 };
 
 type ManagedServiceUpdateHandoffResult = {
@@ -1359,10 +1377,14 @@ function resolveUpdateCliArgv(params: {
   timeoutMs?: number;
   channel?: UpdateChannel;
   tag?: string;
+  acceptCapabilities?: boolean;
   execPath?: string;
   argv1?: string;
 }): string[] {
   const updateArgs = ["update", "--yes", "--json"];
+  if (params.acceptCapabilities) {
+    updateArgs.push("--accept-capabilities");
+  }
   if (params.channel) {
     updateArgs.push("--channel", params.channel);
   }
@@ -1392,7 +1414,12 @@ function resolveManagedServiceCliArgv(
 }
 
 export function formatManagedServiceUpdateCommand(
-  params?: { timeoutMs?: number; channel?: UpdateChannel; tag?: string },
+  params?: {
+    timeoutMs?: number;
+    channel?: UpdateChannel;
+    tag?: string;
+    acceptCapabilities?: boolean;
+  },
   env: NodeJS.ProcessEnv = process.env,
 ): string {
   return formatCliCommand(
@@ -1522,14 +1549,17 @@ async function spawnManagedServiceUpdateHandoff(
   );
   const logPath = path.join(dir, "handoff.log");
   const commandArgv = resolveUpdateCliArgv({
-    timeoutMs: params.timeoutMs,
-    channel: params.channel,
-    tag: params.tag,
+    ...params,
     execPath: params.execPath ?? process.execPath,
     argv1: params.argv1 ?? process.argv[1],
   });
   const commandLabel = formatManagedServiceUpdateCommand(
-    { timeoutMs: params.timeoutMs, channel: params.channel, tag: params.tag },
+    {
+      timeoutMs: params.timeoutMs,
+      channel: params.channel,
+      tag: params.tag,
+      acceptCapabilities: params.acceptCapabilities,
+    },
     params.env,
   );
   const metaFile: ControlPlaneUpdateSentinelMetaFile = {
@@ -1572,6 +1602,7 @@ async function spawnManagedServiceUpdateHandoff(
     parentExitTimeoutMs,
     parentExitDeadlineAt: Date.now() + parentExitTimeoutMs,
     cwd: dir,
+    invocationCwd: params.invocationCwd,
     commandArgv,
     recoveryCommandArgv: resolveManagedServiceCliArgv(
       { execPath: params.execPath ?? process.execPath, argv1: params.argv1 ?? process.argv[1] },
@@ -1877,6 +1908,28 @@ export async function commitManagedServiceUpdateHandoff(
       outcome === "update" ? "commit" : "restore-commit",
     )) === "committed"
   );
+}
+
+export async function transferManagedServiceUpdateHandoff(
+  identity: NonNullable<GatewayRestartIntent["successorOwner"]>,
+): Promise<boolean> {
+  const child = activeManagedServiceUpdateHandoffs.get(
+    resolveUpdateInstallRoot(identity.installRoot),
+  )?.launcher;
+  if (
+    !(child?.stdin instanceof Socket) ||
+    !(child.stdout instanceof Socket) ||
+    !claimManagedServiceUpdateHandoff(identity) ||
+    (await sendManagedServiceUpdateHandoffCommand(identity, "transfer")) !== "transferred" ||
+    !claimManagedServiceUpdateHandoff(identity)
+  ) {
+    return false;
+  }
+  // Node's spawn pipe streams are net.Socket instances. Unref keeps the control
+  // channel open until CLI exit, so its result is printed before service stop.
+  child.stdin.unref();
+  child.stdout.unref();
+  return true;
 }
 
 export async function cancelManagedServiceUpdateHandoff(


### PR DESCRIPTION
## What Problem This Solves

Fixes #135655.

An agent-launched `openclaw update` can inherit the managed Gateway's process tree and systemd cgroup. Stopping a `KillMode=control-group` unit then kills the updater before package replacement and recovery. Current ancestry refusals protect some entry paths but leave the agent unable to complete the update.

Reports: https://x.com/MisterLeeHODL/status/2094867377653473789 and https://x.com/allinmaxi/status/2094883854767042831.

## Why This Change Was Made

The CLI now transfers an owned, running supervised Gateway update to the existing managed-service handoff before either Git mutation or native shutdown. The shared helper acknowledges transfer while the CLI is alive, waits for the CLI's control pipe to close after reporting its result, and then owns the existing stop/update/restart/recovery sequence. Unarmed disconnects still cancel; the existing lease and exact native process-generation checks remain authoritative.

The adapter preserves the inspected package target, explicit channel selection, capability consent, installation selectors, and invocation directory. Recovery and triage retain the durable helper directory even if package replacement removes the invoking directory. Extended-stable retains its protected selector and repeats the normal child preflight because its public CLI contract forbids combining that channel with `--tag`.

Changing `KillMode` to `process` is rejected: it would undo the control-group hygiene associated with #50186. Documenting “do not update from the agent” is also rejected: a supported action needs a working continuation, not a dead end. There is no second handoff implementation. The ordinary terminal restart helper remains live and is not removed.

Production LOC: +273/-42 (net +231); tests: +287/-57 (net +230); docs: +11. The growth implements the previously missing CLI-to-helper ownership transfer and observable result; the existing Gateway-initiated park/commit handshake cannot safely be executed by a child that its own service stop will kill. Existing ancestry logic is moved, not duplicated. No unrelated consolidation is used to offset this growth.

## User Impact

Agent-initiated Linux user-systemd and macOS LaunchAgent updates return an explicit handoff result, the helper log path, and installation-specific status/health commands. That result means the update was accepted, not that it finished. Plain terminal updates remain synchronous, and `--no-restart` still does not authorize stopping the agent's Gateway. No configuration option, environment variable, storage schema, protocol version, or service kill policy is added or changed. `invocationCwd` travels only in the existing ephemeral helper-parameter artifact; the SQLite lease and restart-sentinel representations are unchanged.

## Evidence

- Root-cause source: `src/cli/update-cli/update-command-service-maintenance.ts`, `src/cli/update-cli/update-command-execution.ts`, `src/infra/update-managed-service-handoff.ts`, and `src/daemon/systemd-unit.ts`.
- Added CLI coverage for systemd markers, launchd markers, real ancestry detection, exact package targets, relative inputs, extended-stable selection, and unchanged terminal behavior.
- Extended executable-helper coverage for transfer-before-disconnect, unarmed/dead-parent cancellation, relative input resolution, and recovery after the invocation directory disappears. Existing scope-launch coverage checks `systemd-run --user --scope`.
- Before-fix proof against `0edbcd8efac0599b2ed58f44cd9c84ed7b1027cc`: the Git ancestry handoff regression fails with `Number of calls: 0`; the package ancestry case returns `managed-service-preflight` and instructs the caller to use an outside shell. Marker-only cases reached the old in-process package path, but their later fixture verification failures are not counted as regression proof. The generated-helper transfer reproduction also failed before the patch with `managed handoff helper exited before transferred`.
- Linux candidate proof at `da7979d620dd7ec7b942753f4abe6eb1a7984e28`: `pnpm test src/cli/update-cli.test.ts src/infra/update-managed-service-handoff-lifecycle.test.ts src/infra/update-managed-service-handoff-command.test.ts src/infra/update-managed-service-handoff-single-flight.test.ts` passed all 510 tests (357 CLI + 153 helper); the later commit adds only an erased `unknown` test annotation. Local focused rerun passed nine cases.
- Native macOS LaunchAgent proof also passed through the real Gateway agent/exec flow: helper PID `77910` survived Gateway PID `76311` exiting and was reparented to PID 1; package update/swap/Doctor exited 0; Gateway PID `86051` returned active, enabled, and ready; the final update sentinel was `ok`. The same correlated model tool result contained the handoff guidance. The corrected observer completed with `NATIVE_LAUNCHAGENT_PROOF_PASSED`, exit 0. Earlier synthetic launchd/pipe checks remain supplemental; an initial observer-path error and premature interpretation of the parked interval were corrected without production changes.
- Uncommitted and branch autoreview passed with `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority` (default P0 threshold); the final `1820fbc040b9` branch pass also exited 0.
- `node scripts/check-changed.mjs -- <changed files>` passed production/test typechecks and all structural/dead-code guards, then caught a missing `unknown` annotation in test diagnostics. After correcting it, the exact eight-file `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ...` rerun passed.
- Native user-systemd proof passed through a real Gateway agent turn with the existing scripted mock provider. The exec child was inside the Gateway service cgroup; the updater ran in `openclaw-update-492b1fb7-79ce-4590-8b1a-6199b99531a1.scope`; Gateway PID changed from `38947` to `40102`, both invocation identities differed, `KillMode=control-group` remained unchanged, package update/swap/Doctor steps exited 0, and the final update sentinel was `ok` after readiness. The same correlated model `function_call_output` contained `managed-service-handoff-started`, its helper log, and installation-specific follow-up commands. Four production hashes match the final branch.
- The native run used an unpublished same-version package replacement, not registry publication. Native fixture setup first exposed non-canonical/permissive directories and an intentionally unavailable HTTP exec surface; the successful proof uses private canonical profile paths and the real agent exec flow. No production guards were bypassed.
- Observed caveat, now documented: service stop can terminate the surrounding shell with exit 143 even though the agent receives the accepted handoff JSON and the out-of-band update succeeds. Redirecting CLI output and reading it only in a later shell command can lose that feedback when the service kills the remaining shell; keep stdout connected and observe the final update using the printed commands.
- CI caught obsolete Git refusal assertions and two test-only lint issues; those are corrected. Run `33577649374` subsequently reported a help-process exit timeout outside the update execution graph; the exact failing test passed in isolation on the same Linux candidate. Exact-head `1820fbc040b95091a983154881486e48c906afb0` CI is green: https://github.com/openclaw/openclaw/actions/runs/33578741714 (`watch-pr-ci.mjs` ended `GREEN`, exit 0).
